### PR TITLE
refactor(nostr): retire the legacy kind 30000 block list

### DIFF
--- a/docs/MODERATION_COMPLETE_ARCHITECTURE.md
+++ b/docs/MODERATION_COMPLETE_ARCHITECTURE.md
@@ -48,7 +48,7 @@ Divine uses a **three-tier moderation architecture**:
 **Consumes Labels (kind 1985):**
 - `ModerationLabelService` - Subscribes to trusted labelers
 - `ReportAggregationService` - Aggregates reports from friends
-- `ContentBlocklistRepository` - Tracks own blocks (kind 30000 `d=block`), own mutes (kind 10000), and mutual block/mute; exposes an immutable `ContentPolicyState` snapshot
+- `ContentBlocklistRepository` - Tracks own blocks and own mutes (both kind 10000, the only list it authors) plus mutual block/mute; exposes an immutable `ContentPolicyState` snapshot. Other authors' legacy kind 30000 `d=block` lists are still read so a block from a client that has not upgraded still registers
 - `ContentPolicyEngine` (`mobile/packages/content_policy`) - Applies ordered rules (SelfReference, PubkeyMute, PubkeyBlock, MutualMute) against that snapshot to make filtering decisions
 
 **User Experience:**
@@ -184,7 +184,7 @@ Divine uses a **three-tier moderation architecture**:
 
 1. **ModerationLabelService** - Subscribes to Faro's kind 1985 labels
 2. **ReportAggregationService** - Aggregates community kind 1984 reports
-3. **ContentBlocklistRepository** - Own blocks (kind 30000 `d=block`), own mutes (kind 10000), and mutual block/mute; exposes `ContentPolicyState`
+3. **ContentBlocklistRepository** - Own blocks and own mutes (both kind 10000) plus mutual block/mute; exposes `ContentPolicyState`. Reads other authors' legacy kind 30000 `d=block` lists but no longer publishes that kind (#5462)
 4. **ContentPolicyEngine** - Pure-Dart ordered rules (SelfReference, PubkeyMute, PubkeyBlock, MutualMute) gating every feed/search/profile/comment/notification ingress seam
 5. **ContentReportingService** - Creates kind 1984 reports → Faro
 
@@ -292,7 +292,7 @@ final defaultModerators = [
 | Report Creation | ✅ | ContentReportingService creates kind 1984 |
 | Label Subscription | ✅ | ModerationLabelService subscribes to kind 1985 |
 | Report Aggregation | ✅ | ReportAggregationService aggregates kind 1984 |
-| Mute Lists | ✅ | ContentBlocklistRepository tracks kind 10000 / kind 30000; ContentPolicyEngine applies the rules |
+| Mute Lists | ✅ | ContentBlocklistRepository authors kind 10000 and reads others' legacy kind 30000; ContentPolicyEngine applies the rules |
 | Feed Coordinator | ✅ | ContentPolicyEngine gates every ingress seam directly (no separate coordinator) |
 | Moderator Registry | 🔨 | ModeratorRegistryService - manage Faro subs |
 | UI Components | 🔨 | Content warnings, moderator browse |

--- a/mobile/lib/router/widgets/other_profile_screen_router.dart
+++ b/mobile/lib/router/widgets/other_profile_screen_router.dart
@@ -44,10 +44,13 @@ class OtherProfileScreenRouter extends ConsumerWidget {
       return const BrandedLoadingScaffold();
     }
 
-    // If this user has blocked us, show unavailable
+    // If this user has blocked or muted us, show unavailable. Blocks now
+    // travel on the kind 10000 mute list (#5462), so gating on the legacy
+    // kind 30000 signal alone would miss every block published since.
     if (targetHex != null) {
       final blocklistRepository = ref.watch(contentBlocklistRepositoryProvider);
-      if (blocklistRepository.hasBlockedUs(targetHex)) {
+      if (blocklistRepository.hasMutedUs(targetHex) ||
+          blocklistRepository.hasBlockedUs(targetHex)) {
         return UserNotAvailableScreen(
           onBack: context.pop,
           userIdHex: targetHex,

--- a/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
+++ b/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
@@ -33,6 +33,11 @@ const _activePubkeyPrefsKey = 'blocklist_active_pubkey';
 /// list has completed for an account. Scoped per account as `base.pubkey`.
 const _blockListMigratedPrefsKeyBase = 'block_list_migrated_to_mute_list';
 
+/// SharedPreferences key prefix recording that an account's legacy kind 30000
+/// (d=block) list has been replaced with an empty one, so this app never has
+/// to touch that kind again. Scoped per account as `base.pubkey`.
+const _blockListRetiredPrefsKeyBase = 'block_list_retired';
+
 class _MuteListPublishShape {
   const _MuteListPublishShape({required this.tags, required this.content});
 
@@ -50,8 +55,13 @@ class _MuteListPublishShape {
 /// Blocks are persisted to SharedPreferences for survival across restarts,
 /// and published to Nostr as the standard NIP-51 kind 10000 mute list so
 /// they interoperate with other clients (Amethyst, Damus, etc.) and the
-/// Divine backend (#4037). A legacy kind 30000 (d=block) event is also
-/// kept in sync for backward compatibility with older Divine clients.
+/// Divine backend (#4037). Kind 10000 is the only list this app authors for
+/// blocks; the non-standard kind 30000 (d=block) list it used to dual-write
+/// is retired once per account by [_retireLegacyBlockList] (#5462).
+///
+/// Kind 30000 is still *read* for other authors, because clients that have
+/// not upgraded yet keep publishing their blocks there and [hasBlockedUs]
+/// drives blockee-side gating.
 class ContentBlocklistRepository {
   /// Creates a [ContentBlocklistRepository].
   ///
@@ -716,72 +726,136 @@ class ContentBlocklistRepository {
     return _MuteListPublishShape(tags: tags, content: source?.content ?? '');
   }
 
-  /// Publish our legacy block list to Nostr as kind 30000 with d=block.
+  /// Read the pubkeys on our own legacy kind 30000 (d=block) list.
   ///
-  /// Retained for backward compatibility with older Divine clients that
-  /// still read kind 30000. New interop goes through the standard kind
-  /// 10000 mute list ([_publishMuteListToNostr]).
-  // TODO(codex): Remove legacy kind 30000 publishing after kind 10000 rollout.
-  // Tracking issue: #5462.
-  Future<void> _publishBlockListToNostr() async {
-    final signer = _signer;
-    final nostrClient = _nostrClient;
-
-    if (signer == null || nostrClient == null) {
-      Log.debug(
-        'Cannot publish block list - Nostr services not yet injected',
-        name: 'ContentBlocklistRepository',
-        category: LogCategory.system,
+  /// Returns `null` when no such list was seen at all, which is not the same
+  /// as an empty one: a cold relay miss must not be read as "this account has
+  /// nothing left to migrate or retire".
+  ///
+  /// The `d=block` check happens here rather than in the filter because not
+  /// all relays support `#d` filtering, and kind 30000 is shared with
+  /// unrelated people lists (divine-space publishes `d=top8` follow sets on
+  /// it) that must never be ingested as blocks.
+  Future<Set<String>?> _readOwnLegacyBlockPubkeys(
+    NostrClient nostrClient,
+    String ourPubkey,
+  ) async {
+    final events = await nostrClient.queryEvents([
+      Filter(authors: [ourPubkey], kinds: const [30000]),
+    ]);
+    Set<String>? blocked;
+    for (final event in events) {
+      if (event.pubkey != ourPubkey) continue;
+      final hasBlockDTag = event.tags.any(
+        (tag) => tag.length >= 2 && tag[0] == 'd' && tag[1] == 'block',
       );
-      return;
+      if (!hasBlockDTag) continue;
+      blocked ??= <String>{};
+      for (final tag in event.tags) {
+        if (tag.length >= 2 && tag[0] == 'p' && tag[1] != ourPubkey) {
+          blocked.add(tag[1]);
+        }
+      }
     }
+    return blocked;
+  }
 
-    if (!signer.isAuthenticated) {
-      Log.warning(
-        'Cannot publish block list - user not authenticated',
-        name: 'ContentBlocklistRepository',
-        category: LogCategory.system,
-      );
-      return;
-    }
+  /// Retire this account's legacy kind 30000 (d=block) list (#5462).
+  ///
+  /// Blocks are authored on the standard kind 10000 mute list only. Leaving
+  /// the legacy list populated but frozen would be worse than removing it:
+  /// clients that still read it (divine-web, pre-1.0.16 Divine) would keep
+  /// enforcing a block this app can no longer lift. So the list is replaced
+  /// once with an empty one and never written again.
+  ///
+  /// The empty replacement is published rather than an NIP-09 deletion:
+  /// tombstoning a replaceable event by id resurrects the version before it.
+  ///
+  /// Nothing is erased before it reaches the mute list — the legacy entries
+  /// are re-read immediately before the replacement and folded into the mute
+  /// list first if the one-time migration has not already carried them over.
+  /// The per-account flag is set only after a relay accepts the empty
+  /// replacement, so any failure retries on the next launch.
+  Future<void> _retireLegacyBlockList(
+    NostrClient nostrClient,
+    BlockListSigner signer,
+    String ourPubkey,
+  ) async {
+    final prefs = _prefs;
+    if (prefs == null) return;
+    final retiredKey = '$_blockListRetiredPrefsKeyBase.$ourPubkey';
+    if (prefs.getBool(retiredKey) ?? false) return;
+    if (!signer.isAuthenticated) return;
+
+    await _migrateLegacyBlockListToMuteList(nostrClient, signer, ourPubkey);
 
     try {
-      final tags = <List<String>>[
-        ['d', 'block'],
-        ['title', 'Block List'],
-      ];
+      final legacyBlocks = await _readOwnLegacyBlockPubkeys(
+        nostrClient,
+        ourPubkey,
+      );
+      // No legacy list was seen. Either this account never had one or the
+      // relays did not answer; both mean there is nothing to replace, and
+      // publishing an empty list anyway would author the very kind this
+      // change retires.
+      if (legacyBlocks == null) return;
+      if (legacyBlocks.isEmpty) {
+        await prefs.setBool(retiredKey, true);
+        return;
+      }
 
-      for (final pubkey in _runtimeBlocklist) {
-        tags.add(['p', pubkey]);
+      final unmigrated = legacyBlocks.difference(_runtimeBlocklist);
+
+      if (unmigrated.isNotEmpty) {
+        // The migration was skipped or raced this read. Carry the stragglers
+        // over before the legacy copy stops existing.
+        _runtimeBlocklist.addAll(unmigrated);
+        await _saveBlockedUsers();
+        if (!await _publishMuteListToNostr()) {
+          Log.warning(
+            'Legacy block-list retirement deferred: could not carry '
+            '${unmigrated.length} block(s) onto the mute list',
+            name: 'ContentBlocklistRepository',
+            category: LogCategory.system,
+          );
+          return;
+        }
+        for (final pubkey in unmigrated) {
+          _emitChange(BlocklistChange(pubkey: pubkey, op: BlocklistOp.blocked));
+        }
+        _notifyChanged();
       }
 
       final event = await signer.createAndSignEvent(
         kind: 30000,
-        content: 'Block list',
-        tags: tags,
+        content: '',
+        tags: const [
+          ['d', 'block'],
+        ],
       );
+      if (event == null) return;
 
-      if (event != null) {
-        final sentEvent = await nostrClient.publishEvent(event);
-
-        if (sentEvent is PublishSuccess) {
-          Log.info(
-            'Published block list to Nostr with '
-            '${_runtimeBlocklist.length} entries',
-            name: 'ContentBlocklistRepository',
-            category: LogCategory.system,
-          );
-        } else {
-          Log.warning(
-            'Failed to publish block list event to relays',
-            name: 'ContentBlocklistRepository',
-            category: LogCategory.system,
-          );
-        }
+      final sentEvent = await nostrClient.publishEvent(event);
+      if (sentEvent is! PublishSuccess) {
+        Log.warning(
+          'Failed to publish the empty legacy block list; retrying next '
+          'launch',
+          name: 'ContentBlocklistRepository',
+          category: LogCategory.system,
+        );
+        return;
       }
+
+      await prefs.setBool(retiredKey, true);
+
+      Log.info(
+        'Retired the legacy kind 30000 block list',
+        name: 'ContentBlocklistRepository',
+        category: LogCategory.system,
+      );
     } on Object catch (e) {
       Log.error(
-        'Error publishing block list to Nostr: $e',
+        'Failed to retire the legacy block list: $e',
         name: 'ContentBlocklistRepository',
         category: LogCategory.system,
       );
@@ -860,8 +934,7 @@ class ContentBlocklistRepository {
   /// Add a public key to the runtime blocklist
   ///
   /// Persists to SharedPreferences and publishes the user's kind 10000 mute
-  /// list (plus the legacy kind 30000 block list for older Divine clients).
-  /// Awaits the local write so the block survives an immediate app kill.
+  /// list. Awaits the local write so the block survives an immediate app kill.
   /// If [ourPubkey] is provided, it will be used to prevent self-blocking.
   /// Otherwise falls back to [_ourPubkey] set during
   /// [syncMuteListsInBackground].
@@ -872,9 +945,9 @@ class ContentBlocklistRepository {
   /// Add public keys to the runtime blocklist in one persisted write.
   ///
   /// Persists to SharedPreferences and publishes the user's kind 10000 mute
-  /// list once (plus one legacy kind 30000 block-list publish) no matter how
-  /// many new pubkeys are added. Emits one [BlocklistChange] per newly-blocked
-  /// pubkey because downstream feed cleanup reacts per author.
+  /// list once no matter how many new pubkeys are added. Emits one
+  /// [BlocklistChange] per newly-blocked pubkey because downstream feed
+  /// cleanup reacts per author.
   Future<void> blockUsers(Iterable<String> pubkeys, {String? ourPubkey}) async {
     final selfPubkey = ourPubkey ?? _ourPubkey;
     var skippedSelf = false;
@@ -911,7 +984,6 @@ class ContentBlocklistRepository {
       }
       _notifyChanged();
       await _publishMuteListToNostr();
-      await _publishBlockListToNostr();
 
       Log.debug(
         'Added ${newlyBlocked.length} users to blocklist',
@@ -931,7 +1003,7 @@ class ContentBlocklistRepository {
   /// Remove a public key from the runtime blocklist
   ///
   /// Persists to SharedPreferences and republishes the updated kind 10000
-  /// mute list (plus the legacy kind 30000 block list) to Nostr.
+  /// mute list to Nostr.
   /// Awaits the local write so the change survives an immediate app kill.
   /// Note: Cannot remove users from internal blocklist.
   Future<void> unblockUser(String pubkey) async {
@@ -941,7 +1013,6 @@ class ContentBlocklistRepository {
       _emitChange(BlocklistChange(pubkey: pubkey, op: BlocklistOp.unblocked));
       _notifyChanged();
       await _publishMuteListToNostr();
-      await _publishBlockListToNostr();
 
       Log.info(
         'Removed user from blocklist: $pubkey',
@@ -1048,8 +1119,8 @@ class ContentBlocklistRepository {
   ///    when other users mute us (mutual mute).
   /// 2. Our own kind 10000 event — mutes the user authored from other
   ///    Nostr clients (this app has no mute action), and relay-based
-  ///    restoration after reinstall, mirroring the kind 30000 block
-  ///    restore in [syncBlockListsInBackground].
+  ///    restoration after reinstall. Since #5462 this is the only list
+  ///    that carries our own entries back from relays.
   Future<void> syncMuteListsInBackground(
     NostrClient nostrService,
     String ourPubkey,
@@ -1120,16 +1191,17 @@ class ContentBlocklistRepository {
     }
   }
 
-  /// Start background sync of block lists (kind 30000, d=block).
+  /// Start background sync of other users' block lists (kind 30000, d=block).
   ///
-  /// Subscribes to two filter sets in a single subscription:
-  /// 1. Kind 30000 events where our pubkey is in 'p' tags — detects when
-  ///    other users block us.
-  /// 2. All of our own kind 30000 events — restores our block list from
-  ///    the relay so blocks survive app reinstalls (SharedPreferences is
-  ///    wiped on uninstall, but the relay keeps the event). The `d=block`
-  ///    check is done in [_handleBlockListEvent] instead of in the filter
-  ///    because not all relays support `#d` tag filtering.
+  /// Subscribes to kind 30000 events where our pubkey is in 'p' tags, which
+  /// detects when other users block us. Clients that have not upgraded to
+  /// kind 10000 blocks yet still publish here, so this read stays.
+  ///
+  /// Our *own* kind 30000 list is deliberately not subscribed to. It is no
+  /// longer authored (#5462) and [_retireLegacyBlockList] empties it, so a
+  /// superseded copy re-served by a relay could only resurrect blocks the
+  /// user has since lifted. Our blocks now round-trip through the kind 10000
+  /// mute list handled by [syncMuteListsInBackground].
   ///
   /// Using `subscribe` (persistent stream) instead of `queryEvents`
   /// (one-shot) ensures events arrive even if relays connect after this
@@ -1174,31 +1246,22 @@ class ContentBlocklistRepository {
     );
 
     try {
-      // Filter 1: Others' block lists that include our pubkey
+      // Others' block lists that include our pubkey.
       final othersFilter = Filter(kinds: const [30000])..p = [ourPubkey];
 
-      // Filter 2: Our own block list (for relay-based restoration)
-      // Omit the d-tag constraint here — not all relays support #d
-      // filtering, and _handleBlockListEvent already checks for d=block.
-      final ownFilter = Filter(authors: [ourPubkey], kinds: const [30000]);
-
-      nostrService
-          .subscribe([othersFilter, ownFilter])
-          .listen(_handleBlockListEvent);
+      nostrService.subscribe([othersFilter]).listen(_handleBlockListEvent);
 
       _blockListSyncStarted = true;
       _blockListSyncClient = nostrService;
 
-      // One-time migration (#4037): fold any legacy kind 30000 block list
-      // into the standard kind 10000 mute list so pre-existing blocks
-      // finally interoperate with other clients. Fire-and-forget so it
-      // never blocks startup; guarded by a per-account persisted flag.
-      unawaited(
-        _migrateLegacyBlockListToMuteList(nostrService, signer, ourPubkey),
-      );
+      // One-time cutover (#4037, #5462): fold any legacy kind 30000 block
+      // list into the standard kind 10000 mute list, then replace the legacy
+      // list with an empty one. Fire-and-forget so it never blocks startup;
+      // guarded by per-account persisted flags.
+      unawaited(_retireLegacyBlockList(nostrService, signer, ourPubkey));
 
       Log.info(
-        'Block list subscription created (includes own block list restore)',
+        'Block list subscription created (blocked-by detection)',
         name: 'ContentBlocklistRepository',
         category: LogCategory.system,
       );
@@ -1238,22 +1301,9 @@ class ContentBlocklistRepository {
 
     try {
       // 1. Read the legacy kind 30000 d=block list from cache + relays.
-      final relayBlocks = <String>{};
-      final blockEvents = await nostrClient.queryEvents([
-        Filter(authors: [ourPubkey], kinds: const [30000]),
-      ]);
-      for (final event in blockEvents) {
-        if (event.pubkey != ourPubkey) continue;
-        final hasBlockDTag = event.tags.any(
-          (tag) => tag.length >= 2 && tag[0] == 'd' && tag[1] == 'block',
-        );
-        if (!hasBlockDTag) continue;
-        for (final tag in event.tags) {
-          if (tag.length >= 2 && tag[0] == 'p' && tag[1] != ourPubkey) {
-            relayBlocks.add(tag[1]);
-          }
-        }
-      }
+      final relayBlocks =
+          await _readOwnLegacyBlockPubkeys(nostrClient, ourPubkey) ??
+          const <String>{};
 
       // Nothing to migrate. Leave the flag unset because an empty one-shot
       // query can also mean a cold relay miss; retrying on a later launch is
@@ -1415,9 +1465,8 @@ class ContentBlocklistRepository {
   /// Replace our muted-authors set from our latest kind 10000 event.
   ///
   /// Kind 10000 is replaceable, so the newest own event is the complete
-  /// list and replaces [_mutedPubkeys] wholesale — unlike
-  /// [_handleOwnBlockListEvent], which merges to protect locally-authored
-  /// blocks that may not have reached relays.
+  /// list and replaces [_mutedPubkeys] wholesale, guarded by `created_at`
+  /// so a superseded copy re-served by a relay cannot win.
   ///
   /// Our own in-app blocks ([_runtimeBlocklist]) are excluded: this app now
   /// publishes them onto the same kind 10000 list, so an entry that we
@@ -1496,12 +1545,17 @@ class ContentBlocklistRepository {
 
   /// Handle incoming kind 30000 block list events (d=block).
   ///
-  /// Routes to the appropriate handler based on whether the event is
-  /// authored by us (relay restoration) or by another user (blocked-by).
+  /// Only other authors' lists are interpreted, to answer [hasBlockedUs].
+  /// Our own legacy list stopped being a source of truth for our blocks in
+  /// #5462: it is no longer authored, [_retireLegacyBlockList] empties it,
+  /// and merging a superseded copy back in used to resurrect blocks the user
+  /// had already lifted (#7027).
   void _handleBlockListEvent(Event event) {
     if (event.kind != 30000) return;
+    if (event.pubkey == _ourPubkey) return;
 
-    // Only process events with d=block tag
+    // Only process events with d=block tag. Kind 30000 is shared with
+    // unrelated people lists (e.g. divine-space's d=top8 follow set).
     final hasBlockDTag = event.tags.any(
       (tag) =>
           tag.isNotEmpty &&
@@ -1511,45 +1565,7 @@ class ContentBlocklistRepository {
     );
     if (!hasBlockDTag) return;
 
-    if (event.pubkey == _ourPubkey) {
-      _handleOwnBlockListEvent(event);
-    } else {
-      _handleOthersBlockListEvent(event);
-    }
-  }
-
-  /// Restore our block list from a relay-stored event we authored.
-  ///
-  /// Extracts blocked pubkeys from 'p' tags and merges them into the
-  /// runtime blocklist. This ensures blocks survive app reinstalls where
-  /// SharedPreferences data is lost but the relay still holds our event.
-  void _handleOwnBlockListEvent(Event event) {
-    final relayPubkeys = <String>{};
-    for (final tag in event.tags) {
-      if (tag.isNotEmpty &&
-          tag[0] == 'p' &&
-          tag.length >= 2 &&
-          tag[1] != _ourPubkey) {
-        relayPubkeys.add(tag[1]);
-      }
-    }
-
-    final added = relayPubkeys.difference(_runtimeBlocklist);
-    if (added.isEmpty) return;
-
-    _runtimeBlocklist.addAll(added);
-    unawaited(_saveBlockedUsers());
-    for (final pubkey in added) {
-      _emitChange(BlocklistChange(pubkey: pubkey, op: BlocklistOp.blocked));
-    }
-    _notifyChanged();
-
-    Log.info(
-      'Restored ${added.length} blocks from relay '
-      '(total: ${_runtimeBlocklist.length})',
-      name: 'ContentBlocklistRepository',
-      category: LogCategory.system,
-    );
+    _handleOthersBlockListEvent(event);
   }
 
   /// Handle another user's block list event.

--- a/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
+++ b/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
@@ -726,6 +726,15 @@ class ContentBlocklistRepository {
     return _MuteListPublishShape(tags: tags, content: source?.content ?? '');
   }
 
+  /// Whether [pubkey] is still the session identity.
+  ///
+  /// The startup migration and retirement run fire-and-forget across several
+  /// awaits while mutating instance state and publishing through `_signer`.
+  /// An account switch mid-sequence would otherwise splice one account's
+  /// blocks into the next account's mute list, or erase the incoming
+  /// account's legacy list before it has been migrated.
+  bool _isStillActiveAccount(String pubkey) => _ourPubkey == pubkey;
+
   /// Read the pubkeys on our own legacy kind 30000 (d=block) list.
   ///
   /// Returns `null` when no such list was seen at all, which is not the same
@@ -771,11 +780,20 @@ class ContentBlocklistRepository {
   /// The empty replacement is published rather than an NIP-09 deletion:
   /// tombstoning a replaceable event by id resurrects the version before it.
   ///
-  /// Nothing is erased before it reaches the mute list — the legacy entries
-  /// are re-read immediately before the replacement and folded into the mute
-  /// list first if the one-time migration has not already carried them over.
-  /// The per-account flag is set only after a relay accepts the empty
-  /// replacement, so any failure retries on the next launch.
+  /// Nothing is erased before it reaches the mute list. The gate is the
+  /// migration's own per-account flag, which is set only once a relay
+  /// accepted the merged mute list — in-memory membership is not evidence
+  /// the entries ever left the device, and treating it as such would erase
+  /// blocks whose migrate publish had failed.
+  ///
+  /// A legacy pubkey missing from the runtime blocklist is likewise *not*
+  /// treated as a straggler to carry back over. After a confirmed migration
+  /// it means the user deliberately unblocked them, and re-publishing it
+  /// would resurrect a lifted block — the exact failure #7027 describes.
+  ///
+  /// The retired flag is set once a relay accepts the empty replacement, or
+  /// immediately when the legacy list is already empty and there is nothing
+  /// to replace. Any failure retries on the next launch.
   Future<void> _retireLegacyBlockList(
     NostrClient nostrClient,
     BlockListSigner signer,
@@ -788,12 +806,15 @@ class ContentBlocklistRepository {
     if (!signer.isAuthenticated) return;
 
     await _migrateLegacyBlockListToMuteList(nostrClient, signer, ourPubkey);
+    if (!_isStillActiveAccount(ourPubkey)) return;
 
     try {
       final legacyBlocks = await _readOwnLegacyBlockPubkeys(
         nostrClient,
         ourPubkey,
       );
+      if (!_isStillActiveAccount(ourPubkey)) return;
+
       // No legacy list was seen. Either this account never had one or the
       // relays did not answer; both mean there is nothing to replace, and
       // publishing an empty list anyway would author the very kind this
@@ -804,26 +825,17 @@ class ContentBlocklistRepository {
         return;
       }
 
-      final unmigrated = legacyBlocks.difference(_runtimeBlocklist);
-
-      if (unmigrated.isNotEmpty) {
-        // The migration was skipped or raced this read. Carry the stragglers
-        // over before the legacy copy stops existing.
-        _runtimeBlocklist.addAll(unmigrated);
-        await _saveBlockedUsers();
-        if (!await _publishMuteListToNostr()) {
-          Log.warning(
-            'Legacy block-list retirement deferred: could not carry '
-            '${unmigrated.length} block(s) onto the mute list',
-            name: 'ContentBlocklistRepository',
-            category: LogCategory.system,
-          );
-          return;
-        }
-        for (final pubkey in unmigrated) {
-          _emitChange(BlocklistChange(pubkey: pubkey, op: BlocklistOp.blocked));
-        }
-        _notifyChanged();
+      // The list still carries entries, so erasing it is only safe once the
+      // migration has been confirmed accepted by a relay.
+      if (!(prefs.getBool('$_blockListMigratedPrefsKeyBase.$ourPubkey') ??
+          false)) {
+        Log.warning(
+          'Legacy block-list retirement deferred: migration onto the mute '
+          'list is not yet confirmed',
+          name: 'ContentBlocklistRepository',
+          category: LogCategory.system,
+        );
+        return;
       }
 
       final event = await signer.createAndSignEvent(
@@ -834,6 +846,7 @@ class ContentBlocklistRepository {
         ],
       );
       if (event == null) return;
+      if (!_isStillActiveAccount(ourPubkey)) return;
 
       final sentEvent = await nostrClient.publishEvent(event);
       if (sentEvent is! PublishSuccess) {
@@ -1312,6 +1325,8 @@ class ContentBlocklistRepository {
         return;
       }
 
+      if (!_isStillActiveAccount(ourPubkey)) return;
+
       // 2. Read the existing kind 10000 mute list (newest replaceable wins)
       //    so the merge never drops mutes authored on other clients.
       final muteEvents = await nostrClient.queryEvents([
@@ -1326,6 +1341,8 @@ class ContentBlocklistRepository {
         }
       }
 
+      if (!_isStillActiveAccount(ourPubkey)) return;
+
       // 3. Fold both lists into our in-memory state without removing
       //    anything. Legacy entries are our blocks; the rest of the relay's
       //    mute list is preserved as mutes (our own blocks are kept out of
@@ -1339,6 +1356,7 @@ class ContentBlocklistRepository {
       final newlyMuted = _mutedPubkeys.difference(mutedBeforeMerge);
       await _saveBlockedUsers();
       await _saveMutedUsers();
+      if (!_isStillActiveAccount(ourPubkey)) return;
 
       // 4. Republish the unified kind 10000 mute list. Only record the
       //    migration as done once the relay accepts it, so a failure retries.

--- a/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
+++ b/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
@@ -1473,7 +1473,7 @@ void main() {
     });
 
     test(
-      'syncBlockListsInBackground subscribes with two filters',
+      'syncBlockListsInBackground subscribes only to others block lists',
       () async {
         const ourPubkey = 'test_our_pubkey_hex';
         service = ContentBlocklistRepository();
@@ -1501,18 +1501,14 @@ void main() {
         ).called(1);
 
         expect(capturedFilters, isNotNull);
-        expect(capturedFilters!.length, equals(2));
+        // Only others' block lists containing our pubkey. Our own legacy
+        // list stopped being a source of truth for our blocks (#5462).
+        expect(capturedFilters!.length, equals(1));
 
-        // Filter 1: others' block lists containing our pubkey
         final othersFilter = capturedFilters![0] as Filter;
         expect(othersFilter.kinds, contains(30000));
         expect(othersFilter.p, contains(ourPubkey));
-
-        // Filter 2: our own block list for relay restoration
-        // No #d constraint — handler checks d=block, avoids relay compat issues
-        final ownFilter = capturedFilters![1] as Filter;
-        expect(ownFilter.kinds, contains(30000));
-        expect(ownFilter.authors, contains(ourPubkey));
+        expect(othersFilter.authors, isNull);
       },
     );
 
@@ -1694,7 +1690,7 @@ void main() {
     );
   });
 
-  group('ContentBlocklistRepository - Relay Block List Restoration', () {
+  group('ContentBlocklistRepository - legacy own block list is inert', () {
     late ContentBlocklistRepository service;
     late _MockNostrClient mockNostrService;
     late _MockBlockListSigner mockSigner;
@@ -1728,6 +1724,7 @@ void main() {
       mockSigner = _MockBlockListSigner();
       controller = StreamController<Event>();
 
+      when(() => mockSigner.isAuthenticated).thenReturn(false);
       when(
         () => mockNostrService.subscribe(
           any(),
@@ -1740,7 +1737,7 @@ void main() {
     });
 
     test(
-      'restores blocks from own relay event when local blocklist is empty',
+      'own relay event does not restore blocks',
       () async {
         var changeCount = 0;
         service = ContentBlocklistRepository(onChanged: () => changeCount++);
@@ -1754,91 +1751,39 @@ void main() {
         controller.add(makeOwnBlockListEvent([blockedPubkey1, blockedPubkey2]));
         await Future<void>.delayed(const Duration(milliseconds: 50));
 
-        expect(service.isBlocked(blockedPubkey1), isTrue);
-        expect(service.isBlocked(blockedPubkey2), isTrue);
-        expect(service.totalBlockedCount, equals(2));
-        expect(changeCount, equals(1));
-      },
-    );
-
-    test(
-      'merges relay blocks with existing local blocks without duplicates',
-      () async {
-        var changeCount = 0;
-        service = ContentBlocklistRepository(onChanged: () => changeCount++);
-
-        // Pre-block one user locally
-        await service.blockUser(blockedPubkey1, ourPubkey: ourPubkey);
-        expect(service.totalBlockedCount, equals(1));
-        changeCount = 0;
-
-        await service.syncBlockListsInBackground(
-          mockNostrService,
-          mockSigner,
-          ourPubkey,
-        );
-
-        // Relay has both the already-local one and a new one
-        controller.add(
-          makeOwnBlockListEvent([blockedPubkey1, blockedPubkey2]),
-        );
-        await Future<void>.delayed(const Duration(milliseconds: 50));
-
-        expect(service.isBlocked(blockedPubkey1), isTrue);
-        expect(service.isBlocked(blockedPubkey2), isTrue);
-        expect(service.totalBlockedCount, equals(2));
-        expect(changeCount, equals(1));
-      },
-    );
-
-    test(
-      'does not notify when relay blocks already present locally',
-      () async {
-        var changeCount = 0;
-        service = ContentBlocklistRepository(onChanged: () => changeCount++);
-
-        await service.blockUser(blockedPubkey1, ourPubkey: ourPubkey);
-        await service.blockUser(blockedPubkey2, ourPubkey: ourPubkey);
-        changeCount = 0;
-
-        await service.syncBlockListsInBackground(
-          mockNostrService,
-          mockSigner,
-          ourPubkey,
-        );
-
-        controller.add(
-          makeOwnBlockListEvent([blockedPubkey1, blockedPubkey2]),
-        );
-        await Future<void>.delayed(const Duration(milliseconds: 50));
-
+        expect(service.isBlocked(blockedPubkey1), isFalse);
+        expect(service.isBlocked(blockedPubkey2), isFalse);
+        expect(service.totalBlockedCount, equals(0));
         expect(changeCount, equals(0));
-        expect(service.totalBlockedCount, equals(2));
       },
     );
 
     test(
-      'skips own pubkey in relay event p-tags',
+      'a superseded own list cannot resurrect a lifted block (#7027)',
       () async {
         service = ContentBlocklistRepository();
 
+        await service.blockUser(blockedPubkey1, ourPubkey: ourPubkey);
         await service.syncBlockListsInBackground(
           mockNostrService,
           mockSigner,
           ourPubkey,
         );
+        await service.unblockUser(blockedPubkey1);
+        expect(service.isBlocked(blockedPubkey1), isFalse);
 
-        controller.add(makeOwnBlockListEvent([ourPubkey, blockedPubkey1]));
+        // The relay re-serves the superseded copy that still carries the
+        // block. Merging it back in is what made unblock fail to stick.
+        controller.add(makeOwnBlockListEvent([blockedPubkey1]));
         await Future<void>.delayed(const Duration(milliseconds: 50));
 
-        expect(service.isBlocked(blockedPubkey1), isTrue);
-        expect(service.isBlocked(ourPubkey), isFalse);
-        expect(service.totalBlockedCount, equals(1));
+        expect(service.isBlocked(blockedPubkey1), isFalse);
+        expect(service.totalBlockedCount, equals(0));
       },
     );
 
     test(
-      'still detects others blocking us alongside own event restoration',
+      'still detects others blocking us',
       () async {
         var changeCount = 0;
         service = ContentBlocklistRepository(onChanged: () => changeCount++);
@@ -1848,13 +1793,6 @@ void main() {
           mockSigner,
           ourPubkey,
         );
-
-        // Our own block list arrives (restoration)
-        controller.add(makeOwnBlockListEvent([blockedPubkey1]));
-        await Future<void>.delayed(const Duration(milliseconds: 50));
-
-        expect(service.isBlocked(blockedPubkey1), isTrue);
-        expect(changeCount, equals(1));
 
         // Another user blocks us
         final othersEvent =
@@ -1875,7 +1813,7 @@ void main() {
         await Future<void>.delayed(const Duration(milliseconds: 50));
 
         expect(service.hasBlockedUs(blockedPubkey2), isTrue);
-        expect(changeCount, equals(2));
+        expect(changeCount, equals(1));
       },
     );
   });
@@ -2451,21 +2389,16 @@ void main() {
       expect(muteTags, contains(equals(['p', 'pubkey1'])));
       expect(muteTags, isNot(contains(equals(['d', 'block']))));
 
-      // The legacy kind 30000 block list is still kept in sync for older
-      // Divine clients.
-      final blockTags =
-          verify(
-                () => mockSigner.createAndSignEvent(
-                  kind: 30000,
-                  content: 'Block list',
-                  tags: captureAny(named: 'tags'),
-                ),
-              ).captured.last
-              as List<List<String>>;
-      expect(blockTags, contains(equals(['d', 'block'])));
-      expect(blockTags, contains(equals(['p', 'pubkey1'])));
+      // The legacy kind 30000 block list is no longer authored (#5462).
+      verifyNever(
+        () => mockSigner.createAndSignEvent(
+          kind: 30000,
+          content: any(named: 'content'),
+          tags: any(named: 'tags'),
+        ),
+      );
 
-      verify(() => mockClient.publishEvent(any())).called(2);
+      verify(() => mockClient.publishEvent(any())).called(1);
     });
 
     test('blockUsers publishes each Nostr list once for a batch', () async {
@@ -2525,19 +2458,15 @@ void main() {
       );
       expect(muteTags, isNot(contains(equals(['p', ourPubkey]))));
 
-      final blockTags =
-          verify(
-                () => mockSigner.createAndSignEvent(
-                  kind: 30000,
-                  content: 'Block list',
-                  tags: captureAny(named: 'tags'),
-                ),
-              ).captured.single
-              as List<List<String>>;
-      expect(blockTags, contains(equals(['d', 'block'])));
-      expect(blockTags, isNot(contains(equals(['p', ourPubkey]))));
+      verifyNever(
+        () => mockSigner.createAndSignEvent(
+          kind: 30000,
+          content: any(named: 'content'),
+          tags: any(named: 'tags'),
+        ),
+      );
 
-      verify(() => mockClient.publishEvent(any())).called(2);
+      verify(() => mockClient.publishEvent(any())).called(1);
     });
 
     test('unblocking republishes the kind 10000 mute list without the '
@@ -2827,6 +2756,7 @@ void main() {
     const muteC =
         '00000000000000000000000000000000000000000000000000000000000000cc';
     const flagKey = 'block_list_migrated_to_mute_list.$ourPubkey';
+    const retiredKey = 'block_list_retired.$ourPubkey';
 
     late _MockNostrClient mockClient;
     late _MockBlockListSigner mockSigner;
@@ -2888,6 +2818,29 @@ void main() {
         () => mockClient.subscribe(any()),
       ).thenAnswer((_) => const Stream.empty());
       when(() => mockSigner.isAuthenticated).thenReturn(true);
+      when(
+        () => mockSigner.createAndSignEvent(
+          kind: any(named: 'kind'),
+          content: any(named: 'content'),
+          tags: any(named: 'tags'),
+        ),
+      ).thenAnswer(
+        (invocation) async =>
+            Event(
+                ourPubkey,
+                invocation.namedArguments[#kind] as int,
+                invocation.namedArguments[#tags] as List<List<String>>,
+                invocation.namedArguments[#content] as String,
+                createdAt: 3000,
+              )
+              ..id = 'signed-event'
+              ..sig = 'signature',
+      );
+      when(() => mockClient.publishEvent(any())).thenAnswer(
+        (invocation) async => PublishSuccess(
+          event: invocation.positionalArguments.first as Event,
+        ),
+      );
     });
 
     test(
@@ -2990,8 +2943,11 @@ void main() {
       },
     );
 
-    test('does not run again once the migration flag is set', () async {
-      SharedPreferences.setMockInitialValues(<String, Object>{flagKey: true});
+    test('does not run again once both flags are set', () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        flagKey: true,
+        retiredKey: true,
+      });
       prefs = await SharedPreferences.getInstance();
 
       final service = ContentBlocklistRepository(prefs: prefs);
@@ -3006,6 +2962,197 @@ void main() {
 
       service.dispose();
     });
+
+    test(
+      'retires the legacy list for an account that already migrated',
+      () async {
+        SharedPreferences.setMockInitialValues(<String, Object>{
+          flagKey: true,
+          'blocklist_active_pubkey': ourPubkey,
+          'blocked_users_list.$ourPubkey': jsonEncode([blockA]),
+        });
+        prefs = await SharedPreferences.getInstance();
+
+        when(() => mockClient.queryEvents(any())).thenAnswer((
+          invocation,
+        ) async {
+          final filters = invocation.positionalArguments[0] as List<Filter>;
+          final kinds = filters.first.kinds ?? const <int>[];
+          if (kinds.contains(30000)) {
+            return [
+              ownBlockEvent([blockA]),
+            ];
+          }
+          return <Event>[];
+        });
+
+        final service = ContentBlocklistRepository(prefs: prefs);
+        await service.syncBlockListsInBackground(
+          mockClient,
+          mockSigner,
+          ourPubkey,
+        );
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        // The already-carried-over entry needs no republish of the mute list.
+        verifyNever(
+          () => mockSigner.createAndSignEvent(
+            kind: 10000,
+            content: any(named: 'content'),
+            tags: any(named: 'tags'),
+          ),
+        );
+
+        final retirementTags =
+            verify(
+                  () => mockSigner.createAndSignEvent(
+                    kind: 30000,
+                    content: '',
+                    tags: captureAny(named: 'tags'),
+                  ),
+                ).captured.single
+                as List<List<String>>;
+        expect(
+          retirementTags,
+          equals([
+            ['d', 'block'],
+          ]),
+        );
+        expect(prefs.getBool(retiredKey), isTrue);
+
+        service.dispose();
+      },
+    );
+
+    test(
+      'records retirement without republishing an already-empty legacy list',
+      () async {
+        SharedPreferences.setMockInitialValues(<String, Object>{flagKey: true});
+        prefs = await SharedPreferences.getInstance();
+
+        // Another device already emptied it; the replacement still exists.
+        when(() => mockClient.queryEvents(any())).thenAnswer((
+          invocation,
+        ) async {
+          final filters = invocation.positionalArguments[0] as List<Filter>;
+          final kinds = filters.first.kinds ?? const <int>[];
+          if (kinds.contains(30000)) {
+            return [ownBlockEvent(const [])];
+          }
+          return <Event>[];
+        });
+
+        final service = ContentBlocklistRepository(prefs: prefs);
+        await service.syncBlockListsInBackground(
+          mockClient,
+          mockSigner,
+          ourPubkey,
+        );
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        verifyNever(
+          () => mockSigner.createAndSignEvent(
+            kind: any(named: 'kind'),
+            content: any(named: 'content'),
+            tags: any(named: 'tags'),
+          ),
+        );
+        expect(prefs.getBool(retiredKey), isTrue);
+
+        service.dispose();
+      },
+    );
+
+    test(
+      'carries an unmigrated legacy block over before emptying the list',
+      () async {
+        SharedPreferences.setMockInitialValues(<String, Object>{
+          flagKey: true,
+        });
+        prefs = await SharedPreferences.getInstance();
+
+        when(() => mockClient.queryEvents(any())).thenAnswer((
+          invocation,
+        ) async {
+          final filters = invocation.positionalArguments[0] as List<Filter>;
+          final kinds = filters.first.kinds ?? const <int>[];
+          if (kinds.contains(30000)) {
+            return [
+              ownBlockEvent([blockA]),
+            ];
+          }
+          return <Event>[];
+        });
+
+        final service = ContentBlocklistRepository(prefs: prefs);
+        await service.syncBlockListsInBackground(
+          mockClient,
+          mockSigner,
+          ourPubkey,
+        );
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        final muteTags =
+            verify(
+                  () => mockSigner.createAndSignEvent(
+                    kind: 10000,
+                    content: any(named: 'content'),
+                    tags: captureAny(named: 'tags'),
+                  ),
+                ).captured.last
+                as List<List<String>>;
+        expect(muteTags, contains(equals(['p', blockA])));
+        expect(service.isBlocked(blockA), isTrue);
+        expect(prefs.getBool(retiredKey), isTrue);
+
+        service.dispose();
+      },
+    );
+
+    test(
+      'does not empty the legacy list when the carry-over publish fails',
+      () async {
+        SharedPreferences.setMockInitialValues(<String, Object>{
+          flagKey: true,
+        });
+        prefs = await SharedPreferences.getInstance();
+
+        when(() => mockClient.queryEvents(any())).thenAnswer((
+          invocation,
+        ) async {
+          final filters = invocation.positionalArguments[0] as List<Filter>;
+          final kinds = filters.first.kinds ?? const <int>[];
+          if (kinds.contains(30000)) {
+            return [
+              ownBlockEvent([blockA]),
+            ];
+          }
+          return <Event>[];
+        });
+        when(
+          () => mockClient.publishEvent(any()),
+        ).thenAnswer((_) async => const PublishFailed());
+
+        final service = ContentBlocklistRepository(prefs: prefs);
+        await service.syncBlockListsInBackground(
+          mockClient,
+          mockSigner,
+          ourPubkey,
+        );
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        verifyNever(
+          () => mockSigner.createAndSignEvent(
+            kind: 30000,
+            content: any(named: 'content'),
+            tags: any(named: 'tags'),
+          ),
+        );
+        expect(prefs.getBool(retiredKey), isNull);
+
+        service.dispose();
+      },
+    );
 
     test('keeps the flag unset when the republish is rejected', () async {
       when(() => mockClient.queryEvents(any())).thenAnswer((invocation) async {
@@ -3853,8 +4000,8 @@ void main() {
       expect(service.hasBlockedUs(blockerPubkey), isTrue);
       expect(service.hasBlockedUs(otherBlockerPubkey), isTrue);
 
-      // The discovery subscription passes two filters; the by-author watch
-      // is the single-filter one.
+      // The discovery subscription filters on #p; the by-author watch is the
+      // one that filters on authors.
       final watchRequests =
           verify(
                 () => mockNostrService.subscribe(
@@ -3863,7 +4010,9 @@ void main() {
                 ),
               ).captured
               .cast<List<Filter>>()
-              .where((filters) => filters.length == 1)
+              .where(
+                (filters) => filters.every((filter) => filter.authors != null),
+              )
               .toList();
 
       expect(

--- a/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
+++ b/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
@@ -3064,59 +3064,12 @@ void main() {
     );
 
     test(
-      'carries an unmigrated legacy block over before emptying the list',
+      'does not empty the legacy list when the migration publish failed',
       () async {
-        SharedPreferences.setMockInitialValues(<String, Object>{
-          flagKey: true,
-        });
-        prefs = await SharedPreferences.getInstance();
-
-        when(() => mockClient.queryEvents(any())).thenAnswer((
-          invocation,
-        ) async {
-          final filters = invocation.positionalArguments[0] as List<Filter>;
-          final kinds = filters.first.kinds ?? const <int>[];
-          if (kinds.contains(30000)) {
-            return [
-              ownBlockEvent([blockA]),
-            ];
-          }
-          return <Event>[];
-        });
-
-        final service = ContentBlocklistRepository(prefs: prefs);
-        await service.syncBlockListsInBackground(
-          mockClient,
-          mockSigner,
-          ourPubkey,
-        );
-        await Future<void>.delayed(const Duration(milliseconds: 50));
-
-        final muteTags =
-            verify(
-                  () => mockSigner.createAndSignEvent(
-                    kind: 10000,
-                    content: any(named: 'content'),
-                    tags: captureAny(named: 'tags'),
-                  ),
-                ).captured.last
-                as List<List<String>>;
-        expect(muteTags, contains(equals(['p', blockA])));
-        expect(service.isBlocked(blockA), isTrue);
-        expect(prefs.getBool(retiredKey), isTrue);
-
-        service.dispose();
-      },
-    );
-
-    test(
-      'does not empty the legacy list when the carry-over publish fails',
-      () async {
-        SharedPreferences.setMockInitialValues(<String, Object>{
-          flagKey: true,
-        });
-        prefs = await SharedPreferences.getInstance();
-
+        // The migration adds the legacy blocks to the in-memory set before
+        // its publish guard and never rolls back, so runtime membership is
+        // not evidence they reached a relay. Erasing on that signal would
+        // leave the blocks on neither list.
         when(() => mockClient.queryEvents(any())).thenAnswer((
           invocation,
         ) async {
@@ -3148,11 +3101,156 @@ void main() {
             tags: any(named: 'tags'),
           ),
         );
+        expect(prefs.getBool(flagKey), isNull);
         expect(prefs.getBool(retiredKey), isNull);
 
         service.dispose();
       },
     );
+
+    test(
+      'leaves the retired flag unset when the empty replacement is rejected',
+      () async {
+        SharedPreferences.setMockInitialValues(<String, Object>{
+          flagKey: true,
+          'blocklist_active_pubkey': ourPubkey,
+          'blocked_users_list.$ourPubkey': jsonEncode([blockA]),
+        });
+        prefs = await SharedPreferences.getInstance();
+
+        when(() => mockClient.queryEvents(any())).thenAnswer((
+          invocation,
+        ) async {
+          final filters = invocation.positionalArguments[0] as List<Filter>;
+          final kinds = filters.first.kinds ?? const <int>[];
+          if (kinds.contains(30000)) {
+            return [
+              ownBlockEvent([blockA]),
+            ];
+          }
+          return <Event>[];
+        });
+        when(
+          () => mockClient.publishEvent(any()),
+        ).thenAnswer((_) async => const PublishFailed());
+
+        final service = ContentBlocklistRepository(prefs: prefs);
+        await service.syncBlockListsInBackground(
+          mockClient,
+          mockSigner,
+          ourPubkey,
+        );
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        verify(
+          () => mockSigner.createAndSignEvent(
+            kind: 30000,
+            content: '',
+            tags: any(named: 'tags'),
+          ),
+        ).called(1);
+        expect(prefs.getBool(retiredKey), isNull);
+
+        service.dispose();
+      },
+    );
+
+    test(
+      'does not re-block a legacy entry the user unblocked after migrating',
+      () async {
+        // Migration confirmed on an earlier launch, its empty-30000 publish
+        // did not land, and the user has since unblocked blockA. The legacy
+        // list still names A; treating that as a straggler would resurrect
+        // a deliberately lifted block (#7027).
+        SharedPreferences.setMockInitialValues(<String, Object>{
+          flagKey: true,
+          'blocklist_active_pubkey': ourPubkey,
+          'blocked_users_list.$ourPubkey': jsonEncode([blockB]),
+        });
+        prefs = await SharedPreferences.getInstance();
+
+        when(() => mockClient.queryEvents(any())).thenAnswer((
+          invocation,
+        ) async {
+          final filters = invocation.positionalArguments[0] as List<Filter>;
+          final kinds = filters.first.kinds ?? const <int>[];
+          if (kinds.contains(30000)) {
+            return [
+              ownBlockEvent([blockA, blockB]),
+            ];
+          }
+          return <Event>[];
+        });
+
+        final service = ContentBlocklistRepository(prefs: prefs);
+        await service.syncBlockListsInBackground(
+          mockClient,
+          mockSigner,
+          ourPubkey,
+        );
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        expect(service.isBlocked(blockA), isFalse);
+        expect(service.isBlocked(blockB), isTrue);
+        verifyNever(
+          () => mockSigner.createAndSignEvent(
+            kind: 10000,
+            content: any(named: 'content'),
+            tags: any(named: 'tags'),
+          ),
+        );
+        expect(prefs.getBool(retiredKey), isTrue);
+
+        service.dispose();
+      },
+    );
+
+    test('abandons retirement when the account switches mid-flight', () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        flagKey: true,
+        'blocklist_active_pubkey': ourPubkey,
+        'blocked_users_list.$ourPubkey': jsonEncode([blockA]),
+      });
+      prefs = await SharedPreferences.getInstance();
+
+      const otherPubkey =
+          '0000000000000000000000000000000000000000000000000000000000000009';
+      final service = ContentBlocklistRepository(prefs: prefs);
+
+      when(() => mockClient.queryEvents(any())).thenAnswer((
+        invocation,
+      ) async {
+        final filters = invocation.positionalArguments[0] as List<Filter>;
+        final kinds = filters.first.kinds ?? const <int>[];
+        if (kinds.contains(30000)) {
+          // The switch lands while the legacy read is in flight.
+          await service.syncMuteListsInBackground(mockClient, otherPubkey);
+          return [
+            ownBlockEvent([blockA]),
+          ];
+        }
+        return <Event>[];
+      });
+
+      await service.syncBlockListsInBackground(
+        mockClient,
+        mockSigner,
+        ourPubkey,
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      // Nothing is published on the incoming account's behalf.
+      verifyNever(
+        () => mockSigner.createAndSignEvent(
+          kind: 30000,
+          content: any(named: 'content'),
+          tags: any(named: 'tags'),
+        ),
+      );
+      expect(prefs.getBool(retiredKey), isNull);
+
+      service.dispose();
+    });
 
     test('keeps the flag unset when the republish is rejected', () async {
       when(() => mockClient.queryEvents(any())).thenAnswer((invocation) async {

--- a/mobile/test/router/widgets/other_profile_screen_router_test.dart
+++ b/mobile/test/router/widgets/other_profile_screen_router_test.dart
@@ -1,0 +1,85 @@
+// ABOUTME: Tests the blockee-side gate on OtherProfileScreenRouter — a block
+// ABOUTME: now arrives as a kind 10000 mute, so hasMutedUs must gate too.
+
+import 'package:content_blocklist_repository/content_blocklist_repository.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/providers/moderation_providers.dart';
+import 'package:openvine/providers/nostr_client_provider.dart';
+import 'package:openvine/router/widgets/other_profile_screen_router.dart';
+import 'package:openvine/screens/user_not_available_screen.dart';
+
+class _MockContentBlocklistRepository extends Mock
+    implements ContentBlocklistRepository {}
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+void main() {
+  // npub1424242… decodes to a hex pubkey distinct from the viewer's.
+  const targetNpub =
+      'npub1424242424242424242424242424242424242424242424242424qamrcaj';
+  const viewerHex =
+      '0000000000000000000000000000000000000000000000000000000000000001';
+
+  late _MockContentBlocklistRepository blocklist;
+  late _MockNostrClient nostrClient;
+
+  setUp(() {
+    blocklist = _MockContentBlocklistRepository();
+    nostrClient = _MockNostrClient();
+    when(() => nostrClient.publicKey).thenReturn(viewerHex);
+    when(() => blocklist.hasMutedUs(any())).thenReturn(false);
+    when(() => blocklist.hasBlockedUs(any())).thenReturn(false);
+  });
+
+  Future<void> pumpRouter(WidgetTester tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          contentBlocklistRepositoryProvider.overrideWithValue(blocklist),
+          nostrServiceProvider.overrideWithValue(nostrClient),
+        ],
+        child: const MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: OtherProfileScreenRouter(npub: targetNpub),
+        ),
+      ),
+    );
+    await tester.pump();
+  }
+
+  group(OtherProfileScreenRouter, () {
+    testWidgets('hides the profile when the target muted us', (tester) async {
+      when(() => blocklist.hasMutedUs(any())).thenReturn(true);
+
+      await pumpRouter(tester);
+
+      expect(find.byType(UserNotAvailableScreen), findsOneWidget);
+    });
+
+    testWidgets('hides the profile when the target blocked us', (tester) async {
+      when(() => blocklist.hasBlockedUs(any())).thenReturn(true);
+
+      await pumpRouter(tester);
+
+      expect(find.byType(UserNotAvailableScreen), findsOneWidget);
+    });
+
+    testWidgets('renders the profile when neither signal is set', (
+      tester,
+    ) async {
+      await pumpRouter(tester);
+
+      expect(find.byType(UserNotAvailableScreen), findsNothing);
+      // OtherProfileScreen needs the full app provider graph, which this
+      // test deliberately does not wire — the assertion above is about
+      // which branch the router chose, so its build error is discarded.
+      tester.takeException();
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Closes #5462.

Blocks have been dual-written to the non-standard **kind 30000 `d=block`** list and the standard **NIP-51 kind 10000** mute list since #5435 (shipped in 1.0.16, 2026-07-11). Kind 10000 is now the only list this app authors for blocks.

Removing the dual-write on its own would have shipped regressions, so this PR also lands the three changes that make it safe. Each is a separate commit.

## Changes

### 1. `fix(profile)` — gate the unavailable screen on mutes as well as blocks

`other_profile_screen_router.dart` checked `hasBlockedUs` (kind 30000) only. Since a block now travels as a `p` tag on the blocker's kind 10000 list, the blockee sees it via `hasMutedUs`. Without this, a block published after the cutover would stop hiding the blocker's profile from the person they blocked. The sibling gate in `profile_screen_router.dart` already accepted both signals.

### 2. `refactor(nostr)` — retire the legacy kind 30000 block list

- **Stop authoring kind 30000.** `_publishBlockListToNostr` and both call sites in `blockUsers` / `unblockUser` are gone.
- **Replace the legacy list once, don't just abandon it.** A frozen populated list is worse than none: divine-web reads it as the viewer's own blocks (`useFeedBlocklist`), and pre-1.0.16 clients read it for blocked-by gating — so an unblock would never reach either. `_retireLegacyBlockList` publishes an empty replacement once per account, guarded by a new `block_list_retired.<pubkey>` flag set after a relay accepts the replacement, or immediately when the legacy list is already empty and there is nothing to replace. An empty replacement rather than an NIP-09 deletion, because tombstoning a replaceable event by id resurrects the version before it.
- **Never erase before migrating.** The erase is gated on the migration's own per-account flag, which is written only once a relay accepted the merged mute list. In-memory blocklist membership is deliberately *not* used as that signal: the migration adds to memory before its publish guard and never rolls back, so trusting it would erase blocks whose migrate publish had failed — and, after a confirmed migration, would re-block a pubkey the user had since deliberately unblocked. `_readOwnLegacyBlockPubkeys` returns `null` for "no list seen" so a cold relay miss can't be read as "nothing to keep".
- **Account switches abandon the sequence.** Migration and retirement run fire-and-forget at startup across several awaits; both now bail if the session identity changes, so one account's blocks can never be published onto the next account's mute list.
- **Stop treating our own kind 30000 as a source of truth.** `_handleOwnBlockListEvent` merged our own `p` tags back into the runtime blocklist with no removal branch and no `created_at` guard, so a superseded copy re-served by a relay re-added every historical block. With the list frozen that would have turned the intermittent #7027 into a permanent, client-unfixable one. The own-list filter and handler are removed.

Other authors' kind 30000 lists are still read — clients that have not upgraded publish their blocks there and `hasBlockedUs` depends on it.

### 3. `docs(moderation)` — describe kind 10000 as the only authored list

## Deliberately not in this PR

- **The one-time migration stays.** `_migrateLegacyBlockListToMuteList` is what carries pre-1.0.16 blocks onto the mute list when those users eventually update; removing it now would strand them. #5462 conditions its removal on a safe window that has not elapsed.
- **Blocks are not restored from kind 10000 into the block bucket.** After a reinstall that follows retirement, a user's entries come back from their own kind 10000 list as *mutes*: feeds stay filtered, but Safety Settings (which reads `runtimeBlockedUsers`) won't list them. Promoting own kind-10000 `p` tags to blocks would have closed that gap, but `blockedPubkeysForAccount` feeds kind-3 follow-list stripping (#6903 / #7262) — so externally-authored mutes would silently unfollow people. Filed separately rather than mutating the follow graph as a side effect of a refactor.

## Cross-repo readiness

- **funnelcake**: #494, #495, #496 all closed. #496 retired the kind 30000 contract to "legacy" and added the missing kind-10000 query-shape integration tests. The backend keys mute filtering off kind 10000 and does not require kind 30000.
- **divine-web**: authors kind 10000; its feed blocklist unions own-10000 and own-30000, so dropping mobile's write does not change web feed filtering. The empty replacement also clears stale entries it would otherwise keep enforcing.

## Testing

- `flutter test` in `mobile/packages/content_blocklist_repository`: **124 passing, 100% line coverage** (the package has no `min_coverage` override, so the VGV workflow gates at 100%).
- New/changed coverage: only-others subscription shape; own kind-30000 event no longer restores blocks; a superseded own list cannot resurrect a lifted block (#7027 guard); retirement for an already-migrated account; no erase when the migration publish failed; no re-block of an entry unblocked after migrating; retired flag stays unset when the empty replacement is rejected; retirement abandoned on an account switch mid-flight; no publish at all when no legacy list exists; already-empty legacy list records retirement without republishing.
- Router gate: three widget cases (muted-only, blocked-only, neither) in `test/router/widgets/other_profile_screen_router_test.dart`. Verified red by deleting the `hasMutedUs` clause.
- `flutter analyze lib test integration_test` — clean.
- App-side: `test/providers/`, `test/blocs/safety_settings/`, `test/blocs/dm/conversation_actions/`, `test/router/` — 1090 passing.

## Manual test plan

- [ ] Block a user; confirm one kind 10000 publish and no kind 30000 publish.
- [ ] Unblock; confirm the republished kind 10000 omits them and the block does not come back after an app restart.
- [ ] On an account with a pre-existing kind 30000 list: confirm the entries land on kind 10000 and the kind 30000 is replaced with an empty one exactly once.
- [ ] As the blockee, confirm the blocker's profile shows the unavailable screen.
