### PR TITLE
perf(dm): cut a 1:1 DM from four signer round trips to one via keycast's nip17_wrap_batch

### DIFF
--- a/.github/workflows/nostr_sdk.yaml
+++ b/.github/workflows/nostr_sdk.yaml
@@ -24,11 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/nostr_sdk"
-      # Pin to the Flutter the repo pins in mobile/mise.toml. Without it this
-      # workflow floats on whatever stable is that day, so a formatter roll
-      # turns it red with no code change: 3.47.0's `dart format` reflows two
-      # pre-existing test files that the pinned 3.12.0 formats the other way,
-      # and no content satisfies both. Matches models_ci / creator_sync /
-      # sounds_repository, which already pin for the same reason.
       flutter_version: "3.44.0"
       min_coverage: 20

--- a/.github/workflows/nostr_sdk.yaml
+++ b/.github/workflows/nostr_sdk.yaml
@@ -24,4 +24,11 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/nostr_sdk"
+      # Pin to the Flutter the repo pins in mobile/mise.toml. Without it this
+      # workflow floats on whatever stable is that day, so a formatter roll
+      # turns it red with no code change: 3.47.0's `dart format` reflows two
+      # pre-existing test files that the pinned 3.12.0 formats the other way,
+      # and no content satisfies both. Matches models_ci / creator_sync /
+      # sounds_repository, which already pin for the same reason.
+      flutter_version: "3.44.0"
       min_coverage: 20

--- a/mobile/lib/services/auth/nostr_identity.dart
+++ b/mobile/lib/services/auth/nostr_identity.dart
@@ -271,8 +271,8 @@ class KeycastNostrIdentity extends NostrIdentity
     // layer; the batch verb builds every recipient's seal and wrap in one. When
     // a local key is present the send builds both wraps in an isolate instead
     // and never reaches this path.
-    if (_rpcSigner case final GiftWrapBatchWrapper wrapper) {
-      return wrapper.nip17WrapBatch(rumor, recipientPubkeys);
+    if (_rpcSigner case final KeycastRpc rpc) {
+      return rpc.nip17WrapBatch(rumor, recipientPubkeys);
     }
     return Future.value();
   }

--- a/mobile/lib/services/auth/nostr_identity.dart
+++ b/mobile/lib/services/auth/nostr_identity.dart
@@ -170,7 +170,10 @@ class PubkeyOnlyNostrIdentity extends NostrIdentity {
 /// When a matching local private key is available, signs locally for speed.
 /// Otherwise delegates to the remote [KeycastRpc] signer.
 class KeycastNostrIdentity extends NostrIdentity
-    implements IsolateDecryptSigner, GiftWrapBatchUnwrapper {
+    implements
+        IsolateDecryptSigner,
+        GiftWrapBatchUnwrapper,
+        GiftWrapBatchWrapper {
   /// Creates a Keycast identity.
   ///
   /// [rpcSigner] is the remote Keycast RPC signer.
@@ -255,6 +258,21 @@ class KeycastNostrIdentity extends NostrIdentity
     // the drain decrypts in an isolate instead and never reaches this path.
     if (_rpcSigner case final GiftWrapBatchUnwrapper unwrapper) {
       return unwrapper.nip17UnwrapBatch(giftWraps);
+    }
+    return Future.value();
+  }
+
+  @override
+  Future<List<GiftWrapSlot>?> nip17WrapBatch(
+    Map<String, dynamic> rumor,
+    List<String> recipientPubkeys,
+  ) {
+    // OAuth-only Keycast (no local key) pays a signer round trip per NIP-59
+    // layer; the batch verb builds every recipient's seal and wrap in one. When
+    // a local key is present the send builds both wraps in an isolate instead
+    // and never reaches this path.
+    if (_rpcSigner case final GiftWrapBatchWrapper wrapper) {
+      return wrapper.nip17WrapBatch(rumor, recipientPubkeys);
     }
     return Future.value();
   }

--- a/mobile/lib/services/media_viewer_auth_service.dart
+++ b/mobile/lib/services/media_viewer_auth_service.dart
@@ -20,7 +20,7 @@ class MediaViewerAuthService {
   final Nip98AuthService _nip98AuthService;
 
   /// Caller-side bound on remote viewer-auth signing. Sits well under
-  /// Keycast's 30s RPC ceiling (`keycast_rpc.dart`) yet far above the observed
+  /// Keycast's 20s RPC ceiling (`keycast_rpc.dart`) yet far above the observed
   /// ~200-430ms happy-path round-trip, so a healthy signer is never cut off
   /// while an unreachable one fails fast into the existing retry UI.
   static const Duration _signTimeout = Duration(seconds: 6);
@@ -51,7 +51,7 @@ class MediaViewerAuthService {
   /// bounded by [_signTimeout]; if the signer does not respond in time this
   /// returns [ViewerAuthSignerUnreachable] — distinct from the
   /// [ViewerAuthUnavailable] "no headers" result — rather than hanging on
-  /// Keycast's 30s ceiling. Local and interactive remote signers (bunker /
+  /// Keycast's 20s ceiling. Local and interactive remote signers (bunker /
   /// Amber / NIP-07) are awaited unbounded so a human approval step is never
   /// cut off.
   Future<ViewerAuthResult> createAuthHeaders({
@@ -98,7 +98,7 @@ class MediaViewerAuthService {
   /// Awaits [sign]. When [bound] (the non-interactive remote signer), the call
   /// is capped at [_signTimeout]; the [TimeoutException] propagates to
   /// [createAuthHeaders], which maps it to [ViewerAuthSignerUnreachable]
-  /// instead of hanging on the remote RPC's own 30s ceiling. Unbounded
+  /// instead of hanging on the remote RPC's own 20s ceiling. Unbounded
   /// otherwise, so a local or interactive (human-approved) sign is never cut
   /// off.
   Future<T?> _bound<T>(bool bound, Future<T?> Function() sign) async {

--- a/mobile/lib/services/outgoing_dm_retry_service.dart
+++ b/mobile/lib/services/outgoing_dm_retry_service.dart
@@ -131,7 +131,7 @@ class OutgoingDmRetryService {
   final DateTime Function() _now;
   final CrashReportingService _crashReporting;
 
-  /// Extra margin over [DmSendBudget.messagePublishTimeout] for the work a
+  /// Extra margin over [DmBatchSendBudget.messagePublishTimeout] for the work a
   /// send does OUTSIDE that backstop — chiefly recipient kind-10050 inbox
   /// resolution, which runs before the publish is wrapped and is not itself
   /// bounded end-to-end. It is a margin, not a guarantee; bounding those
@@ -152,7 +152,7 @@ class OutgoingDmRetryService {
   /// send keeps running past the cap and this guard has to outlive the
   /// IN-FLIGHT send, not merely the cap.
   static final Duration _interruptedMinAge =
-      DmSendBudget.messagePublishTimeout + _inboxResolutionMargin;
+      DmBatchSendBudget.messagePublishTimeout + _inboxResolutionMargin;
 
   /// The interrupted-send guard, for tests that need to age a row across it.
   ///

--- a/mobile/packages/dm_repository/lib/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/dm_repository.dart
@@ -1,4 +1,5 @@
 export 'src/collaborator_invite_recovery.dart';
+export 'src/dm_batch_send_budget.dart';
 export 'src/dm_decrypt_isolate.dart';
 export 'src/dm_decryption_worker.dart';
 export 'src/dm_reactions_repository.dart';
@@ -6,7 +7,6 @@ export 'src/dm_reactions_repository_reportable_sites.dart';
 export 'src/dm_repository.dart';
 export 'src/dm_repository_reportable_sites.dart';
 export 'src/dm_send_budget.dart';
-export 'src/dm_batch_send_budget.dart';
 export 'src/dm_send_policy.dart';
 export 'src/dm_sync_state.dart';
 export 'src/dm_verify_isolate.dart';

--- a/mobile/packages/dm_repository/lib/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/dm_repository.dart
@@ -6,6 +6,7 @@ export 'src/dm_reactions_repository_reportable_sites.dart';
 export 'src/dm_repository.dart';
 export 'src/dm_repository_reportable_sites.dart';
 export 'src/dm_send_budget.dart';
+export 'src/dm_batch_send_budget.dart';
 export 'src/dm_send_policy.dart';
 export 'src/dm_sync_state.dart';
 export 'src/dm_verify_isolate.dart';

--- a/mobile/packages/dm_repository/lib/src/dm_batch_send_budget.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_batch_send_budget.dart
@@ -1,0 +1,51 @@
+// ABOUTME: Time budget for a batched NIP-17 send and its legacy fallback.
+// ABOUTME: Keeps batch-only bounds separate from the legacy send budget.
+
+/// Bounds the NIP-17 batch-wrap attempt plus its serial fallback path.
+///
+/// A Keycast send first spends one 30-second `nip17_wrap_batch` request. A
+/// transient failure then falls back to the legacy build, whose bounded-signer
+/// floor is two 20-second RPCs plus 5 seconds of local crypto. The recipient
+/// build therefore needs 75 seconds before any publish begins.
+///
+/// These transport values are restated because `dm_repository` cannot import
+/// `keycast_flutter`; an app-layer regression test pins them to the real
+/// Keycast constants.
+abstract final class DmBatchSendBudget {
+  static const int _batchRequestSeconds = 30;
+  static const int _twoFallbackRequestsSeconds = 40;
+  static const int _fallbackCryptoSeconds = 5;
+  static const int _recipientOkConfirmSeconds = 10;
+  static const int _selfWrapBuildSeconds = 20;
+  static const int _selfWrapPublishSeconds = 10;
+  static const int _headroomSeconds = 15;
+
+  static const int _recipientWrapBuildSeconds =
+      _batchRequestSeconds +
+      _twoFallbackRequestsSeconds +
+      _fallbackCryptoSeconds;
+
+  /// Hard bound on a recipient-wrap batch attempt followed by its fallback.
+  static const Duration recipientWrapBuild = Duration(
+    seconds: _recipientWrapBuildSeconds,
+  );
+
+  /// Serial worst case for the bounded portion of a batched send.
+  static const Duration chainWorstCase = Duration(
+    seconds:
+        _recipientWrapBuildSeconds +
+        _recipientOkConfirmSeconds +
+        _selfWrapBuildSeconds +
+        _selfWrapPublishSeconds,
+  );
+
+  /// Hard backstop on a batched NIP-17 message publish.
+  static const Duration messagePublishTimeout = Duration(
+    seconds:
+        _recipientWrapBuildSeconds +
+        _recipientOkConfirmSeconds +
+        _selfWrapBuildSeconds +
+        _selfWrapPublishSeconds +
+        _headroomSeconds,
+  );
+}

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -19,6 +19,7 @@ import 'package:dm_repository/src/dm_decryption_worker.dart';
 import 'package:dm_repository/src/dm_reactions_repository.dart';
 import 'package:dm_repository/src/dm_repository_reportable_sites.dart';
 import 'package:dm_repository/src/dm_send_budget.dart';
+import 'package:dm_repository/src/dm_batch_send_budget.dart';
 import 'package:dm_repository/src/dm_shared_video_citation.dart';
 import 'package:dm_repository/src/dm_sync_state.dart';
 import 'package:dm_repository/src/dm_verify_isolate.dart';
@@ -156,7 +157,7 @@ const Duration _dmRelayListSignTimeout = Duration(seconds: 10);
 ///
 /// Every sub-step carries its own bound — see [DmSendBudget], which owns the
 /// derivation. This cap exists only to bound a truly hung await, and it must
-/// sit ABOVE [DmSendBudget.chainWorstCase] or it fires mid-send and
+/// sit ABOVE [DmBatchSendBudget.chainWorstCase] or it fires mid-send and
 /// misclassifies it.
 ///
 /// That is exactly what went wrong in #6586. The bound was hand-derived from a
@@ -179,17 +180,17 @@ const Duration _dmRelayListSignTimeout = Duration(seconds: 10);
 ///
 /// That covers the signing chain, not the whole send. Three awaited steps
 /// inside this cap are still unbounded and deliberately NOT in
-/// [DmSendBudget.chainWorstCase]: `refreshPublicKey()` (a real round trip for
+/// [DmBatchSendBudget.chainWorstCase]: `refreshPublicKey()` (a real round trip for
 /// any signer that doesn't cache the pubkey, e.g. a NIP-46 bunker — Keycast
 /// does cache it), the send-policy protected-minor check, and the connectivity
 /// probe. So this cap remains a genuine backstop for those, and
-/// [DmSendBudget.chainWorstCase] is a floor on what a send can cost, not a
+/// [DmBatchSendBudget.chainWorstCase] is a floor on what a send can cost, not a
 /// ceiling. Bounding them is tracked separately.
 ///
 /// A 15s cap here (the original value) fired during routine slow-Keycast
 /// sends, turning sends that were still legitimately in flight into
 /// eternally-retrying rows — the reason this backstop must stay generous.
-const Duration _messagePublishTimeout = DmSendBudget.messagePublishTimeout;
+const Duration _messagePublishTimeout = DmBatchSendBudget.messagePublishTimeout;
 
 /// Outcome of resolving a user's own kind-10050 DM inbox relay list (#4974).
 ///

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -14,12 +14,12 @@ import 'package:db_client/db_client.dart';
 import 'package:dm_repository/src/build_mode.dart';
 import 'package:dm_repository/src/collaborator_invite_recovery.dart';
 import 'package:dm_repository/src/compute.dart';
+import 'package:dm_repository/src/dm_batch_send_budget.dart';
 import 'package:dm_repository/src/dm_decrypt_isolate.dart';
 import 'package:dm_repository/src/dm_decryption_worker.dart';
 import 'package:dm_repository/src/dm_reactions_repository.dart';
 import 'package:dm_repository/src/dm_repository_reportable_sites.dart';
 import 'package:dm_repository/src/dm_send_budget.dart';
-import 'package:dm_repository/src/dm_batch_send_budget.dart';
 import 'package:dm_repository/src/dm_shared_video_citation.dart';
 import 'package:dm_repository/src/dm_sync_state.dart';
 import 'package:dm_repository/src/dm_verify_isolate.dart';
@@ -180,10 +180,10 @@ const Duration _dmRelayListSignTimeout = Duration(seconds: 10);
 ///
 /// That covers the signing chain, not the whole send. Three awaited steps
 /// inside this cap are still unbounded and deliberately NOT in
-/// [DmBatchSendBudget.chainWorstCase]: `refreshPublicKey()` (a real round trip for
-/// any signer that doesn't cache the pubkey, e.g. a NIP-46 bunker — Keycast
-/// does cache it), the send-policy protected-minor check, and the connectivity
-/// probe. So this cap remains a genuine backstop for those, and
+/// [DmBatchSendBudget.chainWorstCase]: `refreshPublicKey()` (a real round trip
+/// for any signer that doesn't cache the pubkey, e.g. a NIP-46 bunker —
+/// Keycast does cache it), the send-policy protected-minor check, and the
+/// connectivity probe. So this cap remains a genuine backstop for those, and
 /// [DmBatchSendBudget.chainWorstCase] is a floor on what a send can cost, not a
 /// ceiling. Bounding them is tracked separately.
 ///

--- a/mobile/packages/dm_repository/lib/src/dm_send_budget.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_send_budget.dart
@@ -47,13 +47,13 @@
 /// per-wrap path runs, both have to fit inside [recipientWrapBuild].
 abstract final class DmSendBudget {
   /// The two seal round trips a wrap build spends, at the transport's own
-  /// per-op bound (`KeycastRpc.defaultRequestTimeout`, 30s).
+  /// per-op bound (`KeycastRpc.defaultRequestTimeout`, 20s).
   ///
   /// Restated here because `dm_repository` cannot import `keycast_flutter`.
   /// The app-layer guard test asserts the real relationship, so this going
   /// stale fails CI rather than silently under-sizing the bound — which is the
   /// #6586 failure mode itself.
-  static const int _twoTransportBoundsSeconds = 60;
+  static const int _twoTransportBoundsSeconds = 40;
 
   /// One server-side wrap-batch transport bound
   /// (`KeycastRpc.defaultBatchRequestTimeout`, 30s).
@@ -68,18 +68,31 @@ abstract final class DmSendBudget {
   /// secp256k1 signature (`GiftWrapUtil.getGiftWrapEvent`).
   ///
   /// Without it the bound would sit at *exactly* two transport bounds, so two
-  /// ops that each returned just under 30s would still blow it — failing a
+  /// ops that each returned just under 20s would still blow it — failing a
   /// build the transport itself had completed. That is the same
   /// "sized at the worst case with no margin" shape #6586 was about, one step
   /// earlier in the chain.
   static const int _wrapBuildLocalCryptoSeconds = 5;
 
+  /// What a per-wrap build costs against a signer that bounds its own
+  /// operations: two transport bounds plus the local crypto between them.
+  ///
+  /// Exposed so the app-layer guard can compare this package's restated
+  /// Keycast floor against `KeycastRpc.defaultRequestTimeout`, which
+  /// `dm_repository` cannot import directly.
+  static const int _boundedSignerFloorSeconds =
+      _twoTransportBoundsSeconds + _wrapBuildLocalCryptoSeconds;
+
+  /// Minimum per-wrap build budget for signers that bound their own
+  /// operations.
+  static const Duration boundedSignerFloor = Duration(
+    seconds: _boundedSignerFloorSeconds,
+  );
+
   /// Seconds allowed for building the recipient gift wrap. See
   /// [recipientWrapBuild].
   static const int _recipientWrapBuildSeconds =
-      _serverWrapBatchBoundSeconds +
-      _twoTransportBoundsSeconds +
-      _wrapBuildLocalCryptoSeconds;
+      _serverWrapBatchBoundSeconds + _boundedSignerFloorSeconds;
 
   /// Seconds allowed for the recipient OK confirmation. See
   /// [recipientOkConfirm].
@@ -107,7 +120,7 @@ abstract final class DmSendBudget {
   ///
   /// Sized as one Keycast server-side wrap-batch attempt at the transport's own
   /// 30s bound (`KeycastRpc.defaultBatchRequestTimeout`) **plus** the fallback
-  /// build: two Keycast single-op round trips at the transport's own 30s bound
+  /// build: two Keycast single-op round trips at the transport's own 20s bound
   /// (`KeycastRpc.defaultRequestTimeout`) **plus**
   /// [_wrapBuildLocalCryptoSeconds] for the local crypto that runs between and
   /// after them.
@@ -118,14 +131,9 @@ abstract final class DmSendBudget {
   /// timeout. Sizing only either alternative would let a slow-but-recoverable
   /// send be misclassified as timed out before any publish.
   ///
-  /// Tightening it below two transport bounds is the specific mistake #6046
-  /// made and #6075 reverted. That was sized against Keycast running 20-30s per
-  /// single op under DB-pool contention (keycast#291) — a figure that predates
-  /// keycast's own 8s `HTTP_RPC_HANDLER_TIMEOUT`, which now answers 504 rather
-  /// than letting a request run that long. Do not read that as licence to
-  /// shrink this: the server bound is not what this bounds. Amber's NIP-55
-  /// approval is human-gated and a NIP-46 bunker has no bound at all, and both
-  /// take this same path.
+  /// [_boundedSignerFloorSeconds] is the fallback floor. Tightening below it is
+  /// the specific mistake #6046 made and #6075 reverted. The batch attempt is
+  /// serial with that fallback, so [recipientWrapBuild] must cover their sum.
   ///
   /// It bounds the *chain*, not the transport, so it also covers signers whose
   /// own operation can wait much longer than this method should. On the Amber
@@ -174,7 +182,7 @@ abstract final class DmSendBudget {
   /// driven by `DmRepository.recoverSelfWrap`) and
   /// `NIP17MessageService.publishSelfApplicationMarker`. The build is the same
   /// two round trips, so at [selfWrapBuild] it could never finish against a
-  /// signer running near its own 30s-per-op bound.
+  /// signer running near its own 20s-per-op bound.
   ///
   /// It deliberately does **not** cover `sendPrivateMessage`, which builds its
   /// self wrap uncapped. A bound only makes sense where a timed-out build can

--- a/mobile/packages/dm_repository/lib/src/dm_send_budget.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_send_budget.dart
@@ -50,9 +50,10 @@ abstract final class DmSendBudget {
   /// per-op bound (`KeycastRpc.defaultRequestTimeout`, 20s).
   ///
   /// Restated here because `dm_repository` cannot import `keycast_flutter`.
-  /// The app-layer guard test asserts the real relationship, so this going
-  /// stale fails CI rather than silently under-sizing the bound — which is the
-  /// #6586 failure mode itself.
+  /// [boundedSignerFloor] exposes the derived floor so the app-layer guard can
+  /// assert the real relationship. That makes this going stale fail CI rather
+  /// than silently under-sizing the bound — which is the #6586 failure mode
+  /// itself.
   static const int _twoTransportBoundsSeconds = 40;
 
   /// One server-side wrap-batch transport bound
@@ -84,8 +85,11 @@ abstract final class DmSendBudget {
   static const int _boundedSignerFloorSeconds =
       _twoTransportBoundsSeconds + _wrapBuildLocalCryptoSeconds;
 
-  /// Minimum per-wrap build budget for signers that bound their own
-  /// operations. Exposed so the app layer can pin it to Keycast's real bound.
+  /// Minimum wrap-build budget for signers that bound their own operations.
+  ///
+  /// Exposed only so the app-layer guard can compare this package's restated
+  /// Keycast floor against `KeycastRpc.defaultRequestTimeout`, which
+  /// `dm_repository` cannot import directly.
   static const Duration boundedSignerFloor = Duration(
     seconds: _boundedSignerFloorSeconds,
   );

--- a/mobile/packages/dm_repository/lib/src/dm_send_budget.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_send_budget.dart
@@ -23,16 +23,29 @@
 ///
 /// ## The shape being bounded
 ///
-/// A 1:1 kind-14 send costs **four** remote-signer round trips, measured
-/// against the real send path (#6586):
+/// A 1:1 send has two remote-signer shapes, and these bounds must cover the
+/// slower one:
 ///
-/// * recipient wrap: `nip44Encrypt` (seal content) + `signEvent` (seal)
-/// * self wrap: the same two, built lazily after the recipient publish confirms
+/// * **Four round trips** — `nip44Encrypt` (seal content) + `signEvent` (seal),
+///   once for the recipient wrap and again for the self wrap, which is built
+///   lazily after the recipient publish confirms. Measured against the real
+///   send path (#6586).
+/// * **One round trip** — keycast's `nip17_wrap_batch` builds both seals and
+///   both wraps server-side from one shared rumor (#7090). The self wrap comes
+///   back with the recipient wrap, so [selfWrapBuild] is not spent at all.
 ///
 /// The kind-1059 gift wrap itself is signed with a freshly generated ephemeral
 /// key (NIP-59), so it never reaches the signer. Local-key signers build both
 /// wraps in one isolate hop and spend no round trips at all — these bounds sit
 /// far above that path and never bind it.
+///
+/// **Re-derived against the batch chain, and deliberately not reduced.** The
+/// four-trip shape is still reachable — Amber, NIP-46, a keycast without the
+/// verb, a kind-7/5 rumor the verb refuses, or a per-recipient slot failure all
+/// take it — so it, not the batch, sizes every bound here. Tightening these to
+/// the batch chain would fail exactly the sends that most need the headroom.
+/// What the batch changes is where a Keycast send actually lands inside the
+/// bound, not what the bound has to be.
 abstract final class DmSendBudget {
   /// The two seal round trips a wrap build spends, at the transport's own
   /// per-op bound (`KeycastRpc.defaultRequestTimeout`, 30s).
@@ -93,9 +106,13 @@ abstract final class DmSendBudget {
   /// leave nothing for that work and fail such a build.
   ///
   /// Tightening it below two transport bounds is the specific mistake #6046
-  /// made and #6075 reverted: production Keycast runs 20-30s per single op
-  /// under DB-pool contention (keycast#291), and a tighter bound turns
-  /// slow-but-succeeding sends into hard failures.
+  /// made and #6075 reverted. That was sized against Keycast running 20-30s per
+  /// single op under DB-pool contention (keycast#291) — a figure that predates
+  /// keycast's own 8s `HTTP_RPC_HANDLER_TIMEOUT`, which now answers 504 rather
+  /// than letting a request run that long. Do not read that as licence to
+  /// shrink this: the server bound is not what this bounds. Amber's NIP-55
+  /// approval is human-gated and a NIP-46 bunker has no bound at all, and both
+  /// take this same path.
   ///
   /// It bounds the *chain*, not the transport, so it also covers signers whose
   /// own operation can wait much longer than this method should. On the Amber

--- a/mobile/packages/dm_repository/lib/src/dm_send_budget.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_send_budget.dart
@@ -23,29 +23,16 @@
 ///
 /// ## The shape being bounded
 ///
-/// A 1:1 send has two remote-signer shapes, and these bounds must cover the
-/// slower one:
+/// A 1:1 kind-14 send costs **four** remote-signer round trips, measured
+/// against the real send path (#6586):
 ///
-/// * **Four round trips** — `nip44Encrypt` (seal content) + `signEvent` (seal),
-///   once for the recipient wrap and again for the self wrap, which is built
-///   lazily after the recipient publish confirms. Measured against the real
-///   send path (#6586).
-/// * **One round trip** — keycast's `nip17_wrap_batch` builds both seals and
-///   both wraps server-side from one shared rumor (#7090). The self wrap comes
-///   back with the recipient wrap, so [selfWrapBuild] is not spent at all.
+/// * recipient wrap: `nip44Encrypt` (seal content) + `signEvent` (seal)
+/// * self wrap: the same two, built lazily after the recipient publish confirms
 ///
 /// The kind-1059 gift wrap itself is signed with a freshly generated ephemeral
 /// key (NIP-59), so it never reaches the signer. Local-key signers build both
 /// wraps in one isolate hop and spend no round trips at all — these bounds sit
 /// far above that path and never bind it.
-///
-/// **Re-derived against the batch chain.** The four-trip shape is still
-/// reachable — Amber, NIP-46, a keycast without the verb, a kind-7/5 rumor the
-/// verb refuses, or a per-recipient slot failure all take it — so it remains
-/// part of the bound. The batch attempt is serial with that fallback, though:
-/// if `nip17_wrap_batch` stalls to its transport timeout and then the old
-/// per-wrap path runs, both have to fit inside
-/// [recipientWrapBuildWithBatchFallback].
 abstract final class DmSendBudget {
   /// The two seal round trips a wrap build spends, at the transport's own
   /// per-op bound (`KeycastRpc.defaultRequestTimeout`, 20s).
@@ -107,16 +94,6 @@ abstract final class DmSendBudget {
   static const int _recipientWrapBuildSeconds =
       _boundedSignerFloorSeconds + _unboundedSignerHeadroomSeconds;
 
-  /// One server-side wrap-batch transport bound
-  /// (`KeycastRpc.defaultBatchRequestTimeout`, 30s).
-  ///
-  /// Restated here for the same reason as [_twoTransportBoundsSeconds]. The
-  /// app-layer guard test asserts this against the real Keycast constant.
-  static const int _serverWrapBatchBoundSeconds = 30;
-
-  static const int _recipientWrapBuildWithBatchFallbackSeconds =
-      _serverWrapBatchBoundSeconds + _boundedSignerFloorSeconds;
-
   /// Seconds allowed for the recipient OK confirmation. See
   /// [recipientOkConfirm].
   static const int _recipientOkConfirmSeconds = 10;
@@ -135,8 +112,9 @@ abstract final class DmSendBudget {
   /// with the publish. The backstop must sit strictly above the capped worst
   /// case or it fires mid-send and misclassifies it — the #6586 defect.
   ///
-  /// Kept as explicit slack, so `OutgoingDmRetryService.interruptedMinAge`
-  /// follows this derived timeout instead of restating its own number.
+  /// Trimmed by [_wrapBuildLocalCryptoSeconds] when that margin was moved into
+  /// [_recipientWrapBuildSeconds], so [messagePublishTimeout] holds at 120s and
+  /// `OutgoingDmRetryService.interruptedMinAge` does not have to move with it.
   static const int _headroomSeconds = 15;
 
   /// Hard bound on building the recipient gift wrap.
@@ -164,16 +142,6 @@ abstract final class DmSendBudget {
   /// down. See [_unboundedSignerHeadroomSeconds].
   static const Duration recipientWrapBuild = Duration(
     seconds: _recipientWrapBuildSeconds,
-  );
-
-  /// Hard bound on a recipient-wrap batch attempt followed by its fallback.
-  ///
-  /// A transient batch failure is serial with the legacy per-wrap build, so the
-  /// send path needs both transport bounds. Kept separate from
-  /// [recipientWrapBuild] because non-batch and out-of-band self-wrap callers
-  /// do not spend the initial batch request.
-  static const Duration recipientWrapBuildWithBatchFallback = Duration(
-    seconds: _recipientWrapBuildWithBatchFallbackSeconds,
   );
 
   /// OK-confirmation window for the recipient wrap.
@@ -240,7 +208,7 @@ abstract final class DmSendBudget {
   /// case is their sum.
   static const Duration chainWorstCase = Duration(
     seconds:
-        _recipientWrapBuildWithBatchFallbackSeconds +
+        _recipientWrapBuildSeconds +
         _recipientOkConfirmSeconds +
         _selfWrapBuildSeconds +
         _selfWrapPublishSeconds,
@@ -253,7 +221,7 @@ abstract final class DmSendBudget {
   /// `OutgoingDmRetryService.interruptedMinAge`.
   static const Duration messagePublishTimeout = Duration(
     seconds:
-        _recipientWrapBuildWithBatchFallbackSeconds +
+        _recipientWrapBuildSeconds +
         _recipientOkConfirmSeconds +
         _selfWrapBuildSeconds +
         _selfWrapPublishSeconds +

--- a/mobile/packages/dm_repository/lib/src/dm_send_budget.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_send_budget.dart
@@ -44,7 +44,8 @@
 /// verb refuses, or a per-recipient slot failure all take it — so it remains
 /// part of the bound. The batch attempt is serial with that fallback, though:
 /// if `nip17_wrap_batch` stalls to its transport timeout and then the old
-/// per-wrap path runs, both have to fit inside [recipientWrapBuild].
+/// per-wrap path runs, both have to fit inside
+/// [recipientWrapBuildWithBatchFallback].
 abstract final class DmSendBudget {
   /// The two seal round trips a wrap build spends, at the transport's own
   /// per-op bound (`KeycastRpc.defaultRequestTimeout`, 20s).
@@ -55,13 +56,6 @@ abstract final class DmSendBudget {
   /// than silently under-sizing the bound — which is the #6586 failure mode
   /// itself.
   static const int _twoTransportBoundsSeconds = 40;
-
-  /// One server-side wrap-batch transport bound
-  /// (`KeycastRpc.defaultBatchRequestTimeout`, 30s).
-  ///
-  /// Restated here for the same reason as [_twoTransportBoundsSeconds]. The
-  /// app-layer guard test asserts this against the real Keycast constant.
-  static const int _serverWrapBatchBoundSeconds = 30;
 
   /// Margin inside a wrap-build bound for the local work that runs alongside
   /// the two remote round trips: seal construction, the ephemeral keypair,
@@ -94,9 +88,33 @@ abstract final class DmSendBudget {
     seconds: _boundedSignerFloorSeconds,
   );
 
+  /// Room above [_boundedSignerFloorSeconds] for a signer whose per-op wait is
+  /// **not** bounded by a transport at all: Amber's NIP-55 intent path puts a
+  /// human approval prompt in front of each of the two round trips, and a
+  /// bunker can be arbitrarily slow.
+  ///
+  /// Sized to hold [recipientWrapBuild] at the 65s it has shipped at.
+  /// Re-deriving the transport bound in #7092 lowered the floor beneath this
+  /// window; it said nothing about the window itself, and no observation says
+  /// 65s is the wrong amount of time to let a person approve two prompts.
+  /// Following the floor down to 45s would have spent a user-visible Amber
+  /// regression to buy headroom the send path was not short of — the totals
+  /// below already clear [messagePublishTimeout] with room.
+  static const int _unboundedSignerHeadroomSeconds = 20;
+
   /// Seconds allowed for building the recipient gift wrap. See
   /// [recipientWrapBuild].
   static const int _recipientWrapBuildSeconds =
+      _boundedSignerFloorSeconds + _unboundedSignerHeadroomSeconds;
+
+  /// One server-side wrap-batch transport bound
+  /// (`KeycastRpc.defaultBatchRequestTimeout`, 30s).
+  ///
+  /// Restated here for the same reason as [_twoTransportBoundsSeconds]. The
+  /// app-layer guard test asserts this against the real Keycast constant.
+  static const int _serverWrapBatchBoundSeconds = 30;
+
+  static const int _recipientWrapBuildWithBatchFallbackSeconds =
       _serverWrapBatchBoundSeconds + _boundedSignerFloorSeconds;
 
   /// Seconds allowed for the recipient OK confirmation. See
@@ -123,31 +141,39 @@ abstract final class DmSendBudget {
 
   /// Hard bound on building the recipient gift wrap.
   ///
-  /// Sized as one Keycast server-side wrap-batch attempt at the transport's own
-  /// 30s bound (`KeycastRpc.defaultBatchRequestTimeout`) **plus** the fallback
-  /// build: two Keycast single-op round trips at the transport's own 20s bound
-  /// (`KeycastRpc.defaultRequestTimeout`) **plus**
-  /// [_wrapBuildLocalCryptoSeconds] for the local crypto that runs between and
-  /// after them.
-  ///
-  /// The batch fast path does not consume all of this when it succeeds. The
-  /// additive case is when it times out or throws transiently, then the caller
-  /// falls through to the per-wrap path inside the same [recipientWrapBuild]
-  /// timeout. Sizing only either alternative would let a slow-but-recoverable
-  /// send be misclassified as timed out before any publish.
-  ///
-  /// [_boundedSignerFloorSeconds] is the fallback floor. Tightening below it is
-  /// the specific mistake #6046 made and #6075 reverted. The batch attempt is
-  /// serial with that fallback, so [recipientWrapBuild] must cover their sum.
-  ///
   /// It bounds the *chain*, not the transport, and the chain's slowest signer
-  /// sets its size. On the Amber NIP-55 intent path the `nip44Encrypt` and
-  /// `signEvent` approval waits are
+  /// sets its size. Two constants say so: [_boundedSignerFloorSeconds] is what
+  /// Keycast can cost — two transport bounds plus the local crypto between
+  /// them, so two ops that each returned inside the transport's limit cannot
+  /// together trip this — and [_unboundedSignerHeadroomSeconds] is the room
+  /// above that for signers with no transport bound at all. On the Amber
+  /// NIP-55 intent path the `nip44Encrypt` and `signEvent` approval waits are
   /// human-gated and unbounded; timing out here leaves the recipient publish
   /// unsent, so durable callers classify the row as retryable-pending rather
   /// than red-failed.
+  ///
+  /// Tightening it below the floor is the specific mistake #6046 made and
+  /// #6075 reverted — it fails sends the transport itself would have allowed.
+  /// The app-layer guard test pins the floor because `dm_repository` cannot
+  /// import `keycast_flutter` to check it here.
+  ///
+  /// #7092 re-derived the floor after Keycast's per-op bound dropped to 20s
+  /// (keycast#351 bounds its own handler at 8s, so the ~20-30s single-op
+  /// latency of keycast#291 that #6075 sized against is no longer reachable).
+  /// The floor fell from 65s to 45s; this bound deliberately did not follow it
+  /// down. See [_unboundedSignerHeadroomSeconds].
   static const Duration recipientWrapBuild = Duration(
     seconds: _recipientWrapBuildSeconds,
+  );
+
+  /// Hard bound on a recipient-wrap batch attempt followed by its fallback.
+  ///
+  /// A transient batch failure is serial with the legacy per-wrap build, so the
+  /// send path needs both transport bounds. Kept separate from
+  /// [recipientWrapBuild] because non-batch and out-of-band self-wrap callers
+  /// do not spend the initial batch request.
+  static const Duration recipientWrapBuildWithBatchFallback = Duration(
+    seconds: _recipientWrapBuildWithBatchFallbackSeconds,
   );
 
   /// OK-confirmation window for the recipient wrap.
@@ -214,7 +240,7 @@ abstract final class DmSendBudget {
   /// case is their sum.
   static const Duration chainWorstCase = Duration(
     seconds:
-        _recipientWrapBuildSeconds +
+        _recipientWrapBuildWithBatchFallbackSeconds +
         _recipientOkConfirmSeconds +
         _selfWrapBuildSeconds +
         _selfWrapPublishSeconds,
@@ -227,7 +253,7 @@ abstract final class DmSendBudget {
   /// `OutgoingDmRetryService.interruptedMinAge`.
   static const Duration messagePublishTimeout = Duration(
     seconds:
-        _recipientWrapBuildSeconds +
+        _recipientWrapBuildWithBatchFallbackSeconds +
         _recipientOkConfirmSeconds +
         _selfWrapBuildSeconds +
         _selfWrapPublishSeconds +

--- a/mobile/packages/dm_repository/lib/src/dm_send_budget.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_send_budget.dart
@@ -39,13 +39,12 @@
 /// wraps in one isolate hop and spend no round trips at all — these bounds sit
 /// far above that path and never bind it.
 ///
-/// **Re-derived against the batch chain, and deliberately not reduced.** The
-/// four-trip shape is still reachable — Amber, NIP-46, a keycast without the
-/// verb, a kind-7/5 rumor the verb refuses, or a per-recipient slot failure all
-/// take it — so it, not the batch, sizes every bound here. Tightening these to
-/// the batch chain would fail exactly the sends that most need the headroom.
-/// What the batch changes is where a Keycast send actually lands inside the
-/// bound, not what the bound has to be.
+/// **Re-derived against the batch chain.** The four-trip shape is still
+/// reachable — Amber, NIP-46, a keycast without the verb, a kind-7/5 rumor the
+/// verb refuses, or a per-recipient slot failure all take it — so it remains
+/// part of the bound. The batch attempt is serial with that fallback, though:
+/// if `nip17_wrap_batch` stalls to its transport timeout and then the old
+/// per-wrap path runs, both have to fit inside [recipientWrapBuild].
 abstract final class DmSendBudget {
   /// The two seal round trips a wrap build spends, at the transport's own
   /// per-op bound (`KeycastRpc.defaultRequestTimeout`, 30s).
@@ -55,6 +54,13 @@ abstract final class DmSendBudget {
   /// stale fails CI rather than silently under-sizing the bound — which is the
   /// #6586 failure mode itself.
   static const int _twoTransportBoundsSeconds = 60;
+
+  /// One server-side wrap-batch transport bound
+  /// (`KeycastRpc.defaultBatchRequestTimeout`, 30s).
+  ///
+  /// Restated here for the same reason as [_twoTransportBoundsSeconds]. The
+  /// app-layer guard test asserts this against the real Keycast constant.
+  static const int _serverWrapBatchBoundSeconds = 30;
 
   /// Margin inside a wrap-build bound for the local work that runs alongside
   /// the two remote round trips: seal construction, the ephemeral keypair,
@@ -71,7 +77,9 @@ abstract final class DmSendBudget {
   /// Seconds allowed for building the recipient gift wrap. See
   /// [recipientWrapBuild].
   static const int _recipientWrapBuildSeconds =
-      _twoTransportBoundsSeconds + _wrapBuildLocalCryptoSeconds;
+      _serverWrapBatchBoundSeconds +
+      _twoTransportBoundsSeconds +
+      _wrapBuildLocalCryptoSeconds;
 
   /// Seconds allowed for the recipient OK confirmation. See
   /// [recipientOkConfirm].
@@ -91,19 +99,24 @@ abstract final class DmSendBudget {
   /// with the publish. The backstop must sit strictly above the capped worst
   /// case or it fires mid-send and misclassifies it — the #6586 defect.
   ///
-  /// Trimmed by [_wrapBuildLocalCryptoSeconds] when that margin was moved into
-  /// [_recipientWrapBuildSeconds], so [messagePublishTimeout] holds at 120s and
-  /// `OutgoingDmRetryService.interruptedMinAge` does not have to move with it.
+  /// Kept as explicit slack, so `OutgoingDmRetryService.interruptedMinAge`
+  /// follows this derived timeout instead of restating its own number.
   static const int _headroomSeconds = 15;
 
   /// Hard bound on building the recipient gift wrap.
   ///
-  /// Sized as two Keycast single-op round trips at the transport's own 30s
-  /// bound (`KeycastRpc.defaultRequestTimeout`) **plus**
+  /// Sized as one Keycast server-side wrap-batch attempt at the transport's own
+  /// 30s bound (`KeycastRpc.defaultBatchRequestTimeout`) **plus** the fallback
+  /// build: two Keycast single-op round trips at the transport's own 30s bound
+  /// (`KeycastRpc.defaultRequestTimeout`) **plus**
   /// [_wrapBuildLocalCryptoSeconds] for the local crypto that runs between and
-  /// after them, so two ops that each returned inside the transport's limit
-  /// cannot together trip this bound. Sizing it at exactly `2 × 30s` would
-  /// leave nothing for that work and fail such a build.
+  /// after them.
+  ///
+  /// The batch fast path does not consume all of this when it succeeds. The
+  /// additive case is when it times out or throws transiently, then the caller
+  /// falls through to the per-wrap path inside the same [recipientWrapBuild]
+  /// timeout. Sizing only either alternative would let a slow-but-recoverable
+  /// send be misclassified as timed out before any publish.
   ///
   /// Tightening it below two transport bounds is the specific mistake #6046
   /// made and #6075 reverted. That was sized against Keycast running 20-30s per

--- a/mobile/packages/dm_repository/lib/src/dm_send_budget.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_send_budget.dart
@@ -74,17 +74,18 @@ abstract final class DmSendBudget {
   /// earlier in the chain.
   static const int _wrapBuildLocalCryptoSeconds = 5;
 
-  /// What a per-wrap build costs against a signer that bounds its own
-  /// operations: two transport bounds plus the local crypto between them.
+  /// What a wrap build costs against a signer that bounds its own operations,
+  /// i.e. Keycast: two transport bounds plus the local crypto between them.
   ///
-  /// Exposed so the app-layer guard can compare this package's restated
-  /// Keycast floor against `KeycastRpc.defaultRequestTimeout`, which
-  /// `dm_repository` cannot import directly.
+  /// This is the **floor** under [_recipientWrapBuildSeconds], not its value.
+  /// Sizing the build bound below it would fail requests the transport itself
+  /// would have allowed — the #6046 mistake #6075 had to revert — and the
+  /// app-layer guard test pins that it stays a floor.
   static const int _boundedSignerFloorSeconds =
       _twoTransportBoundsSeconds + _wrapBuildLocalCryptoSeconds;
 
   /// Minimum per-wrap build budget for signers that bound their own
-  /// operations.
+  /// operations. Exposed so the app layer can pin it to Keycast's real bound.
   static const Duration boundedSignerFloor = Duration(
     seconds: _boundedSignerFloorSeconds,
   );
@@ -135,9 +136,9 @@ abstract final class DmSendBudget {
   /// the specific mistake #6046 made and #6075 reverted. The batch attempt is
   /// serial with that fallback, so [recipientWrapBuild] must cover their sum.
   ///
-  /// It bounds the *chain*, not the transport, so it also covers signers whose
-  /// own operation can wait much longer than this method should. On the Amber
-  /// NIP-55 intent path, the `nip44Encrypt` and `signEvent` approval waits are
+  /// It bounds the *chain*, not the transport, and the chain's slowest signer
+  /// sets its size. On the Amber NIP-55 intent path the `nip44Encrypt` and
+  /// `signEvent` approval waits are
   /// human-gated and unbounded; timing out here leaves the recipient publish
   /// unsent, so durable callers classify the row as retryable-pending rather
   /// than red-failed.

--- a/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
+++ b/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
@@ -7,6 +7,7 @@ import 'dart:async';
 
 import 'package:dm_repository/src/compute.dart';
 import 'package:dm_repository/src/dm_send_budget.dart';
+import 'package:dm_repository/src/dm_batch_send_budget.dart';
 import 'package:dm_repository/src/dm_send_policy.dart';
 import 'package:dm_repository/src/gift_wrap_build_worker.dart';
 import 'package:meta/meta.dart';
@@ -500,8 +501,8 @@ class NIP17MessageService {
   /// and the caller owns any fallback behavior.
   ///
   /// [recipientWrapBuildTimeout] bounds the recipient-wrap build, defaulting to
-  /// [DmSendBudget.recipientWrapBuildWithBatchFallback] for callers whose
-  /// durable retry queue
+  /// [DmBatchSendBudget.recipientWrapBuild] for callers whose durable retry
+  /// queue
   /// can keep a pre-publish timeout pending and re-drive it. Passing `null`
   /// leaves recipient-wrap construction uncapped; only callers with no outer
   /// cap and no retry row should do that, because a slow human-gated signer
@@ -529,8 +530,7 @@ class NIP17MessageService {
     List<String>? targetRelays,
     bool awaitRecipientOk = false,
     bool selfWrapOnSoftUnconfirmed = true,
-    Duration? recipientWrapBuildTimeout =
-        DmSendBudget.recipientWrapBuildWithBatchFallback,
+    Duration? recipientWrapBuildTimeout = DmBatchSendBudget.recipientWrapBuild,
     Duration? selfWrapBuildTimeout = DmSendBudget.selfWrapBuild,
   }) async {
     final recipientWrapBound = recipientWrapBuildTimeout;

--- a/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
+++ b/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
@@ -601,7 +601,7 @@ class NIP17MessageService {
       // _publishSelfWrap after the recipient publish confirms delivery.
       // Bounded: the wrap build is 2 remote signer round trips, and no signer
       // interface exposes a per-call timeout — the transport's own bound is
-      // whatever that signer chose. Keycast is 30s/op; Amber's NIP-55 intent
+      // whatever that signer chose. Keycast is 20s/op; Amber's NIP-55 intent
       // path for `nip44Encrypt` and `signEvent` is human-gated and unbounded; a
       // bunker can be unbounded too. Without a bound here the chain can outrun
       // the caller's publish backstop, which then fires AFTER the recipient

--- a/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
+++ b/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
@@ -500,7 +500,8 @@ class NIP17MessageService {
   /// and the caller owns any fallback behavior.
   ///
   /// [recipientWrapBuildTimeout] bounds the recipient-wrap build, defaulting to
-  /// [DmSendBudget.recipientWrapBuild] for callers whose durable retry queue
+  /// [DmSendBudget.recipientWrapBuildWithBatchFallback] for callers whose
+  /// durable retry queue
   /// can keep a pre-publish timeout pending and re-drive it. Passing `null`
   /// leaves recipient-wrap construction uncapped; only callers with no outer
   /// cap and no retry row should do that, because a slow human-gated signer
@@ -528,7 +529,8 @@ class NIP17MessageService {
     List<String>? targetRelays,
     bool awaitRecipientOk = false,
     bool selfWrapOnSoftUnconfirmed = true,
-    Duration? recipientWrapBuildTimeout = DmSendBudget.recipientWrapBuild,
+    Duration? recipientWrapBuildTimeout =
+        DmSendBudget.recipientWrapBuildWithBatchFallback,
     Duration? selfWrapBuildTimeout = DmSendBudget.selfWrapBuild,
   }) async {
     final recipientWrapBound = recipientWrapBuildTimeout;

--- a/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
+++ b/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
@@ -20,6 +20,7 @@ import 'package:nostr_sdk/nostr.dart';
 import 'package:nostr_sdk/relay/relay.dart';
 import 'package:nostr_sdk/signer/isolate_decrypt_signer.dart';
 import 'package:nostr_sdk/signer/nostr_signer.dart';
+import 'package:nostr_sdk/signer/signer_failure.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 /// Builds a NIP-59 gift-wrapped event for [recipientPubkey] from
@@ -811,6 +812,31 @@ class NIP17MessageService {
         // exists (#6028); this routes the server refusal into it.
         return const NIP17SendResult.blocked(
           'blocked: recipient not permitted by send policy',
+        );
+      }
+      if (e is TransientSignerFailure) {
+        // The signer gave up instead of signing — a remote signer that bounds
+        // itself and answers with an error rather than making us wait it out
+        // (Keycast's 504). Classified exactly like the wrap-build
+        // `.timeout(recipientWrapBound)` above, because it is the same event
+        // seen from the other side of the wire: nothing was signed, so nothing
+        // was published, so the durable queue can safely re-drive it.
+        //
+        // Without this the same slow signer produced two opposite outcomes —
+        // a dim retryable chip when the client's patience ran out first, a red
+        // hard failure when the server's did (#7092). Which one the user got
+        // turned on a race between two bounds neither layer documented to the
+        // other.
+        //
+        // Safe to call retryable here because every signer round trip inside
+        // this `try` runs *before* the recipient publish: `refreshPublicKey`
+        // and `_buildBothWraps`. Everything after it — `_publishSelfWrap` —
+        // catches its own errors and reports status by return value, so no
+        // post-delivery failure can reach this handler and re-drive a message
+        // the recipient already has.
+        return NIP17SendResult.failure(
+          'Failed to send message: $e',
+          retryablePending: true,
         );
       }
       return NIP17SendResult.failure('Failed to send message: $e');

--- a/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
+++ b/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
@@ -6,8 +6,8 @@
 import 'dart:async';
 
 import 'package:dm_repository/src/compute.dart';
-import 'package:dm_repository/src/dm_send_budget.dart';
 import 'package:dm_repository/src/dm_batch_send_budget.dart';
+import 'package:dm_repository/src/dm_send_budget.dart';
 import 'package:dm_repository/src/dm_send_policy.dart';
 import 'package:dm_repository/src/gift_wrap_build_worker.dart';
 import 'package:meta/meta.dart';

--- a/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
+++ b/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
@@ -309,18 +309,16 @@ class NIP17MessageService {
         recipientPubkey,
         _senderPublicKey,
       ]);
-    } on Object catch (e, stackTrace) {
+    } on Object catch (e) {
       // Transient: a 5xx, an expired token, a timeout, or the verified_minor
       // policy refusal. Fall back for THIS send without latching — the
       // fallback's own nip44Encrypt re-hits a policy refusal and sendRumor
       // terminalizes it as `blocked`, and a blip must not cost the rest of the
       // session its fast path.
-      Log.error(
+      Log.warning(
         'Server gift-wrap batch failed for rumor ${rumorEvent.id}: $e; '
         'falling back to the per-wrap signing path',
         category: LogCategory.system,
-        error: e,
-        stackTrace: stackTrace,
       );
       return null;
     }
@@ -357,16 +355,55 @@ class NIP17MessageService {
       );
     }
 
-    try {
-      return (
-        Event.fromJson(recipientSlot.giftWrap!),
-        selfSlot.isSuccess ? Event.fromJson(selfSlot.giftWrap!) : null,
+    final recipientWrap = _serverWrapFromSlot(
+      slot: recipientSlot,
+      expectedRecipientPubkey: recipientPubkey,
+      slotName: 'recipient',
+    );
+    if (recipientWrap == null) return null;
+
+    final Event? selfWrap;
+    if (selfSlot.isSuccess) {
+      selfWrap = _serverWrapFromSlot(
+        slot: selfSlot,
+        expectedRecipientPubkey: _senderPublicKey,
+        slotName: 'self',
       );
+    } else {
+      selfWrap = null;
+    }
+    return (recipientWrap, selfWrap);
+  }
+
+  Event? _serverWrapFromSlot({
+    required GiftWrapSlot slot,
+    required String expectedRecipientPubkey,
+    required String slotName,
+  }) {
+    try {
+      final event = Event.fromJson(slot.giftWrap!);
+      final addressedToExpectedRecipient = event.tags.any(
+        (tag) =>
+            tag.length >= 2 &&
+            tag[0] == 'p' &&
+            tag[1] == expectedRecipientPubkey,
+      );
+      if (event.kind == EventKind.giftWrap &&
+          addressedToExpectedRecipient &&
+          verifyGiftWrapPart(event)) {
+        return event;
+      }
+      Log.warning(
+        'Server gift-wrap batch returned an invalid $slotName wrap; '
+        'falling back to the per-wrap signing path',
+        category: LogCategory.system,
+      );
+      return null;
     } on Object catch (e) {
       // A slot that parsed as JSON but is not a usable event. Never publish a
       // half-understood wrap; take the path that builds one we control.
       Log.warning(
-        'Server gift-wrap batch returned an unusable event: $e; '
+        'Server gift-wrap batch returned an unusable $slotName event: $e; '
         'falling back to the per-wrap signing path',
         category: LogCategory.system,
       );

--- a/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
+++ b/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
@@ -14,6 +14,7 @@ import 'package:models/models.dart' show NIP17SendResult;
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/event.dart';
 import 'package:nostr_sdk/event_kind.dart';
+import 'package:nostr_sdk/nip59/gift_wrap_batch_wrap.dart';
 import 'package:nostr_sdk/nip59/gift_wrap_util.dart';
 import 'package:nostr_sdk/nostr.dart';
 import 'package:nostr_sdk/relay/relay.dart';
@@ -169,12 +170,30 @@ class NIP17MessageService {
     return _giftWrapBuilder(nostr, rumorEvent, receiverPublicKey);
   }
 
+  /// Rumor kinds keycast's `nip17_wrap_batch` accepts. NIP-17 also blesses
+  /// kind-7 reactions and wrapped kind-5 deletes, and this service sends both,
+  /// but the server rejects them at request level ("Rumor kind must be 14 or
+  /// 15"). Probing anyway would burn a round trip per reaction to learn the
+  /// same answer every time.
+  static const Set<int> _serverWrapBatchKinds = {
+    EventKind.privateDirectMessage,
+    EventKind.fileMessage,
+  };
+
+  /// Latched when the signer's backend turns out not to expose
+  /// `nip17_wrap_batch`, so later sends in this session stop probing an absent
+  /// verb. Set ONLY on an explicit "unsupported" answer — a transient error
+  /// leaves it clear, because one blip is not evidence the verb is gone.
+  bool _serverWrapBatchUnsupported = false;
+
   /// Builds the recipient and self-addressed gift wraps in a single isolate
   /// hop for local-key signers (one [compute] spawn covers both receivers,
-  /// halving the spawn cost vs two separate [_buildWrap] calls).
+  /// halving the spawn cost vs two separate [_buildWrap] calls), or — for a
+  /// remote signer whose backend supports it — in a single `nip17_wrap_batch`
+  /// round trip.
   ///
-  /// Returns `(recipientWrap, selfWrap?)`. For remote signers — or if the
-  /// batch isolate call fails — only the recipient wrap is built here and
+  /// Returns `(recipientWrap, selfWrap?)`. When neither batch path applies —
+  /// or either one fails — only the recipient wrap is built here and
   /// `selfWrap` is `null`; [_publishSelfWrap] then builds the self-wrap
   /// lazily after the recipient publish confirms delivery (avoids an extra
   /// signing round-trip on publish failure).
@@ -238,11 +257,28 @@ class NIP17MessageService {
           stackTrace: stackTrace,
         );
       }
+    } else if (signer case final GiftWrapBatchWrapper wrapper
+        when !_serverWrapBatchUnsupported &&
+            _serverWrapBatchKinds.contains(rumorEvent.kind)) {
+      // Remote signer whose backend builds NIP-59 wraps server-side: one round
+      // trip returns both wraps, replacing the four (`nip44Encrypt` +
+      // `signEvent`, per wrap) this path otherwise spends. See #7090.
+      //
+      // Deliberately in the `else` arm, never before the isolate check: a
+      // local-key signer whose isolate hop fails still falls through to
+      // [_buildWrap], which signs in-process at zero round trips — reaching
+      // for the network there would be a regression, not a speed-up.
+      final wraps = await _buildBothWrapsOnServer(
+        wrapper: wrapper,
+        rumorEvent: rumorEvent,
+        recipientPubkey: recipientPubkey,
+      );
+      if (wraps != null) return wraps;
     }
-    // Remote signer or batch failed: build only the recipient wrap. The
-    // self-wrap is built lazily by _publishSelfWrap after the recipient
-    // publish confirms delivery — avoids an extra signing round-trip for
-    // remote signers when the recipient publish fails.
+    // No batch path applied, or it did not produce a recipient wrap: build
+    // only the recipient wrap. The self-wrap is built lazily by
+    // _publishSelfWrap after the recipient publish confirms delivery — avoids
+    // an extra signing round-trip for remote signers when the publish fails.
     return (
       await _buildWrap(
         nostr: nostr,
@@ -251,6 +287,91 @@ class NIP17MessageService {
       ),
       null,
     );
+  }
+
+  /// One `nip17_wrap_batch` round trip building the recipient wrap and the
+  /// NIP-17 self copy from the same rumor.
+  ///
+  /// Returns `null` when the caller must fall back to the per-wrap path:
+  /// the backend does not expose the verb (latched so later sends skip the
+  /// probe), the call failed transiently, the response was misshapen, or the
+  /// recipient's own slot failed. A self-slot failure is NOT a fallback — the
+  /// recipient wrap is still good, and `_publishSelfWrap` rebuilds the self
+  /// copy exactly as it does for a signer with no batch support at all.
+  Future<(Event?, Event?)?> _buildBothWrapsOnServer({
+    required GiftWrapBatchWrapper wrapper,
+    required Event rumorEvent,
+    required String recipientPubkey,
+  }) async {
+    final List<GiftWrapSlot>? slots;
+    try {
+      slots = await wrapper.nip17WrapBatch(rumorEvent.toJson(), [
+        recipientPubkey,
+        _senderPublicKey,
+      ]);
+    } on Object catch (e, stackTrace) {
+      // Transient: a 5xx, an expired token, a timeout, or the verified_minor
+      // policy refusal. Fall back for THIS send without latching — the
+      // fallback's own nip44Encrypt re-hits a policy refusal and sendRumor
+      // terminalizes it as `blocked`, and a blip must not cost the rest of the
+      // session its fast path.
+      Log.error(
+        'Server gift-wrap batch failed for rumor ${rumorEvent.id}: $e; '
+        'falling back to the per-wrap signing path',
+        category: LogCategory.system,
+        error: e,
+        stackTrace: stackTrace,
+      );
+      return null;
+    }
+
+    if (slots == null) {
+      // Older backend without the verb: stop probing it this session.
+      _serverWrapBatchUnsupported = true;
+      return null;
+    }
+    if (slots.length != 2) {
+      Log.warning(
+        'Server gift-wrap batch returned ${slots.length} slots for 2 '
+        'recipients; falling back to the per-wrap signing path',
+        category: LogCategory.system,
+      );
+      return null;
+    }
+
+    final recipientSlot = slots[0];
+    final selfSlot = slots[1];
+    if (!recipientSlot.isSuccess) {
+      Log.warning(
+        'Server gift-wrap batch: recipient slot failed '
+        '(${recipientSlot.error}); falling back to the per-wrap signing path',
+        category: LogCategory.system,
+      );
+      return null;
+    }
+    if (!selfSlot.isSuccess) {
+      Log.debug(
+        'Server gift-wrap batch: self-wrap slot failed (${selfSlot.error}); '
+        '_publishSelfWrap will rebuild it',
+        category: LogCategory.system,
+      );
+    }
+
+    try {
+      return (
+        Event.fromJson(recipientSlot.giftWrap!),
+        selfSlot.isSuccess ? Event.fromJson(selfSlot.giftWrap!) : null,
+      );
+    } on Object catch (e) {
+      // A slot that parsed as JSON but is not a usable event. Never publish a
+      // half-understood wrap; take the path that builds one we control.
+      Log.warning(
+        'Server gift-wrap batch returned an unusable event: $e; '
+        'falling back to the per-wrap signing path',
+        category: LogCategory.system,
+      );
+      return null;
+    }
   }
 
   /// Build the unsigned NIP-17 rumor event for a 1:1 send.

--- a/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
+++ b/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
@@ -2768,7 +2768,9 @@ void main() {
                   .then((r) => result = r),
             );
 
-            async.elapse(DmSendBudget.recipientWrapBuild * 2);
+            async.elapse(
+              DmSendBudget.recipientWrapBuildWithBatchFallback * 2,
+            );
           });
 
           expect(result, isNotNull, reason: 'send must resolve, not hang');
@@ -2777,7 +2779,7 @@ void main() {
           expect(
             (result! as NIP17SendFailure).error,
             'Recipient gift wrap build timed out after '
-            '${DmSendBudget.recipientWrapBuild.inSeconds}s',
+            '${DmSendBudget.recipientWrapBuildWithBatchFallback.inSeconds}s',
           );
           verifyNever(
             () => client.publishEventAwaitOk(

--- a/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
+++ b/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
@@ -20,6 +20,7 @@ import 'package:nostr_sdk/relay/publish_outcome.dart';
 import 'package:nostr_sdk/signer/isolate_decrypt_signer.dart';
 import 'package:nostr_sdk/signer/local_nostr_signer.dart';
 import 'package:nostr_sdk/signer/nostr_signer.dart';
+import 'package:nostr_sdk/signer/signer_failure.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 class _MockNostrClient extends Mock implements NostrClient {}
@@ -41,6 +42,22 @@ class _RpcExceptionDouble implements Exception {
 
   @override
   String toString() => 'RpcException: $message';
+}
+
+/// Reproduces `keycast_flutter`'s `RpcTimeoutException`: the exception raised
+/// when Keycast answers a signing RPC with HTTP 504 because it hit its own
+/// handler bound. What matters to `NIP17MessageService` is the
+/// [TransientSignerFailure] marker, not the type or the wording — the marker
+/// is the cross-package contract, and unlike the 403 double below it survives
+/// any rewording of Keycast's error body.
+class _TransientRpcExceptionDouble
+    implements Exception, TransientSignerFailure {
+  _TransientRpcExceptionDouble(this.message);
+
+  final String message;
+
+  @override
+  String toString() => 'RpcTimeoutException: $message';
 }
 
 /// Encrypts normally but returns `null` from [signEvent], reproducing what
@@ -400,8 +417,81 @@ void main() {
 
           expect(result.success, isFalse);
           expect(result.blocked, isFalse);
+          // Hard, not retryable-pending. Pins that #7092's transient
+          // classification stayed narrow: only Keycast's 504 says "I ran out
+          // of time and did nothing", and a 503 does not promise that.
+          expect(result.retryablePending, isFalse);
         },
       );
+    });
+
+    group('Keycast 504 classification (#7092)', () {
+      test(
+        'a signer that times out itself stays retryable-pending, not red',
+        () async {
+          // Keycast bounds its own /api/nostr handler at 8s and answers 504
+          // (keycast#351). That arrives as an error, not as a Dart
+          // TimeoutException, so before #7092 it fell through to the generic
+          // hard-failure branch and the user got a red bubble — while the
+          // *same* slow signer, if the client's own bound had fired first,
+          // produced a dim retryable one. The outcome turned on a race
+          // between two bounds. Both are the same event now.
+          final timingOut = NIP17MessageService(
+            signer: LocalNostrSigner(_testPrivateKey),
+            senderPublicKey: _testPublicKey,
+            nostrService: mockNostrClient,
+            giftWrapBuilder: (_, _, _) async =>
+                throw _TransientRpcExceptionDouble(
+                  'HTTP 504: {"error":"RPC request timed out after 8s"}',
+                ),
+          );
+          final rumor = timingOut.buildRumor(
+            recipientPubkey: _recipientPubkey,
+            content: 'signer gave up before signing',
+          );
+
+          final result = await timingOut.sendRumor(
+            rumorEvent: rumor,
+            recipientPubkey: _recipientPubkey,
+          );
+
+          expect(result.success, isFalse);
+          expect(result.blocked, isFalse);
+          expect(result.retryablePending, isTrue);
+          // The claim that makes retryable safe: the failure happens while
+          // building the wrap, so nothing ever reached a relay and a re-drive
+          // cannot double-deliver.
+          verifyNever(() => mockNostrClient.publishEvent(any()));
+        },
+      );
+
+      test('a policy refusal still wins over the transient marker', () async {
+        // Ordering guard. A Keycast response could in principle be both a
+        // 5xx-shaped transient and carry the verified_minor denial marker;
+        // terminalizing must win, because a blocked send re-driven until
+        // maxRetries deterministically re-fails (#6028).
+        final blocked = NIP17MessageService(
+          signer: LocalNostrSigner(_testPrivateKey),
+          senderPublicKey: _testPublicKey,
+          nostrService: mockNostrClient,
+          giftWrapBuilder: (_, _, _) async =>
+              throw _TransientRpcExceptionDouble(
+                'HTTP 504: {"error":"Operation denied by policy"}',
+              ),
+        );
+        final rumor = blocked.buildRumor(
+          recipientPubkey: _recipientPubkey,
+          content: 'denial beats transience',
+        );
+
+        final result = await blocked.sendRumor(
+          rumorEvent: rumor,
+          recipientPubkey: _recipientPubkey,
+        );
+
+        expect(result.blocked, isTrue);
+        expect(result.retryablePending, isFalse);
+      });
     });
 
     group('sendRumor relay targeting', () {

--- a/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
+++ b/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
@@ -2699,7 +2699,7 @@ void main() {
     });
 
     // #6586. A 1:1 send costs four remote signer round trips, and no signer
-    // interface exposes a per-call timeout — Keycast bounds an op at 30s,
+    // interface exposes a per-call timeout — Keycast bounds an op at 20s,
     // Amber's NIP-55 intent path for nip44Encrypt/signEvent is human-gated and
     // unbounded, and a bunker may be unbounded too. Before these bounds existed
     // the chain could outrun the caller's publish backstop, which then fired

--- a/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
+++ b/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
@@ -2769,7 +2769,7 @@ void main() {
             );
 
             async.elapse(
-              DmSendBudget.recipientWrapBuildWithBatchFallback * 2,
+              DmBatchSendBudget.recipientWrapBuild * 2,
             );
           });
 
@@ -2779,7 +2779,7 @@ void main() {
           expect(
             (result! as NIP17SendFailure).error,
             'Recipient gift wrap build timed out after '
-            '${DmSendBudget.recipientWrapBuildWithBatchFallback.inSeconds}s',
+            '${DmBatchSendBudget.recipientWrapBuild.inSeconds}s',
           );
           verifyNever(
             () => client.publishEventAwaitOk(

--- a/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
+++ b/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
@@ -2031,14 +2031,23 @@ void main() {
         );
       });
 
-      Map<String, dynamic> wrapFor(String recipient) => Event(
-        localPubkey,
-        EventKind.giftWrap,
-        [
-          ['p', recipient],
-        ],
-        'ciphertext-$recipient',
-      ).toJson();
+      Map<String, dynamic> wrapFor(
+        String recipient, {
+        int kind = EventKind.giftWrap,
+        bool sign = true,
+      }) {
+        final privateKey = generatePrivateKey();
+        final event = Event(
+          getPublicKey(privateKey),
+          kind,
+          [
+            ['p', recipient],
+          ],
+          'ciphertext-$recipient',
+        );
+        if (sign) event.sign(privateKey);
+        return event.toJson();
+      }
 
       test(
         'one batch call replaces both per-wrap signing round trips',
@@ -2249,6 +2258,101 @@ void main() {
           rumorEvent: service.buildRumor(
             recipientPubkey: _recipientPubkey,
             content: 'unusable slot',
+          ),
+          recipientPubkey: _recipientPubkey,
+        );
+
+        expect(result.success, isTrue);
+        expect(mainBuilderCalls, equals(2));
+      });
+
+      test('falls back when a server wrap is unsigned', () async {
+        final signer = _BatchWrapSigner(
+          localPrivateKey,
+          onBatch: (rumor, recipients) async => [
+            GiftWrapSlot.success(wrapFor(recipients[0], sign: false)),
+            GiftWrapSlot.success(wrapFor(recipients[1])),
+          ],
+        );
+        var mainBuilderCalls = 0;
+
+        final service = NIP17MessageService(
+          signer: signer,
+          senderPublicKey: localPubkey,
+          nostrService: mockNostrClient,
+          giftWrapBuilder: (_, _, recipient) async {
+            mainBuilderCalls++;
+            return Event.fromJson(wrapFor(recipient));
+          },
+        );
+        final result = await service.sendRumor(
+          rumorEvent: service.buildRumor(
+            recipientPubkey: _recipientPubkey,
+            content: 'unsigned server wrap',
+          ),
+          recipientPubkey: _recipientPubkey,
+        );
+
+        expect(result.success, isTrue);
+        expect(mainBuilderCalls, equals(2));
+      });
+
+      test('falls back when a server wrap is not kind 1059', () async {
+        final signer = _BatchWrapSigner(
+          localPrivateKey,
+          onBatch: (rumor, recipients) async => [
+            GiftWrapSlot.success(
+              wrapFor(recipients[0], kind: EventKind.textNote),
+            ),
+            GiftWrapSlot.success(wrapFor(recipients[1])),
+          ],
+        );
+        var mainBuilderCalls = 0;
+
+        final service = NIP17MessageService(
+          signer: signer,
+          senderPublicKey: localPubkey,
+          nostrService: mockNostrClient,
+          giftWrapBuilder: (_, _, recipient) async {
+            mainBuilderCalls++;
+            return Event.fromJson(wrapFor(recipient));
+          },
+        );
+        final result = await service.sendRumor(
+          rumorEvent: service.buildRumor(
+            recipientPubkey: _recipientPubkey,
+            content: 'wrong server wrap kind',
+          ),
+          recipientPubkey: _recipientPubkey,
+        );
+
+        expect(result.success, isTrue);
+        expect(mainBuilderCalls, equals(2));
+      });
+
+      test('falls back when server slots are swapped', () async {
+        final signer = _BatchWrapSigner(
+          localPrivateKey,
+          onBatch: (rumor, recipients) async => [
+            GiftWrapSlot.success(wrapFor(recipients[1])),
+            GiftWrapSlot.success(wrapFor(recipients[0])),
+          ],
+        );
+        var mainBuilderCalls = 0;
+
+        final service = NIP17MessageService(
+          signer: signer,
+          senderPublicKey: localPubkey,
+          nostrService: mockNostrClient,
+          giftWrapBuilder: (_, _, recipient) async {
+            mainBuilderCalls++;
+            return Event.fromJson(wrapFor(recipient));
+          },
+        );
+        final result = await service.sendRumor(
+          rumorEvent: service.buildRumor(
+            recipientPubkey: _recipientPubkey,
+            content: 'swapped server wraps',
           ),
           recipientPubkey: _recipientPubkey,
         );

--- a/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
+++ b/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
@@ -13,6 +13,7 @@ import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/client_utils/keys.dart';
 import 'package:nostr_sdk/event.dart';
 import 'package:nostr_sdk/event_kind.dart';
+import 'package:nostr_sdk/nip59/gift_wrap_batch_wrap.dart';
 import 'package:nostr_sdk/nip59/gift_wrap_util.dart';
 import 'package:nostr_sdk/nostr.dart';
 import 'package:nostr_sdk/relay/publish_outcome.dart';
@@ -132,6 +133,89 @@ class _LocalIsolateSigner implements IsolateDecryptSigner {
 
   @override
   void close() => _delegate.close();
+}
+
+/// Answers a `nip17_wrap_batch` call. Returning `null` models a backend
+/// without the verb; throwing models a transient failure.
+typedef _OnWrapBatch =
+    Future<List<GiftWrapSlot>?> Function(
+      Map<String, dynamic> rumor,
+      List<String> recipientPubkeys,
+    );
+
+/// A remote signer that supports the server-side gift-wrap batch — the
+/// OAuth-only Keycast shape. Counts the per-wrap signing calls too, so a test
+/// can assert the batch actually replaced them rather than running alongside.
+class _BatchWrapSigner implements NostrSigner, GiftWrapBatchWrapper {
+  _BatchWrapSigner(String privateKeyHex, {required _OnWrapBatch onBatch})
+    : _delegate = LocalNostrSigner(privateKeyHex),
+      _onBatch = onBatch;
+
+  final LocalNostrSigner _delegate;
+  final _OnWrapBatch _onBatch;
+
+  int batchCalls = 0;
+  int nip44EncryptCalls = 0;
+  int signEventCalls = 0;
+
+  @override
+  Future<List<GiftWrapSlot>?> nip17WrapBatch(
+    Map<String, dynamic> rumor,
+    List<String> recipientPubkeys,
+  ) {
+    batchCalls++;
+    return _onBatch(rumor, recipientPubkeys);
+  }
+
+  @override
+  Future<String?> getPublicKey() => _delegate.getPublicKey();
+
+  @override
+  Future<Event?> signEvent(Event event) {
+    signEventCalls++;
+    return _delegate.signEvent(event);
+  }
+
+  @override
+  Future<Map<dynamic, dynamic>?> getRelays() => _delegate.getRelays();
+
+  @override
+  Future<String?> encrypt(String pubkey, String plaintext) =>
+      _delegate.encrypt(pubkey, plaintext);
+
+  @override
+  Future<String?> decrypt(String pubkey, String ciphertext) =>
+      _delegate.decrypt(pubkey, ciphertext);
+
+  @override
+  Future<String?> nip44Encrypt(String pubkey, String plaintext) {
+    nip44EncryptCalls++;
+    return _delegate.nip44Encrypt(pubkey, plaintext);
+  }
+
+  @override
+  Future<String?> nip44Decrypt(String pubkey, String ciphertext) =>
+      _delegate.nip44Decrypt(pubkey, ciphertext);
+
+  @override
+  void close() => _delegate.close();
+}
+
+/// A signer that is BOTH isolate-capable and batch-capable — the BYOK Keycast
+/// identity. Pins that the in-process isolate path wins over the network one.
+class _IsolateAndBatchSigner extends _BatchWrapSigner
+    implements IsolateDecryptSigner {
+  _IsolateAndBatchSigner(this._privateKeyHex, {required super.onBatch})
+    : super(_privateKeyHex);
+
+  final String _privateKeyHex;
+
+  @override
+  bool get canDecryptInIsolate => true;
+
+  @override
+  T withPrivateKeyHex<T>(T Function(String hex) operation) =>
+      operation(_privateKeyHex);
 }
 
 // Valid 64-character hex keys for testing.
@@ -1927,6 +2011,497 @@ void main() {
           expect(result.success, isTrue);
         },
       );
+    });
+
+    // #7090. A remote signer pays nip44Encrypt + signEvent per NIP-59 wrap —
+    // four round trips for a 1:1 send once the NIP-17 self copy is counted.
+    // Keycast's `nip17_wrap_batch` builds every recipient's seal and wrap
+    // server-side, collapsing that to one. The verb is optional, so every
+    // failure mode has to land back on the existing per-wrap path.
+    group('server-side gift-wrap batch (#7090)', () {
+      late String localPrivateKey;
+      late String localPubkey;
+
+      setUp(() {
+        localPrivateKey = generatePrivateKey();
+        localPubkey = getPublicKey(localPrivateKey);
+        when(() => mockNostrClient.publishEvent(any())).thenAnswer(
+          (inv) async =>
+              PublishSuccess(event: inv.positionalArguments[0] as Event),
+        );
+      });
+
+      Map<String, dynamic> wrapFor(String recipient) => Event(
+        localPubkey,
+        EventKind.giftWrap,
+        [
+          ['p', recipient],
+        ],
+        'ciphertext-$recipient',
+      ).toJson();
+
+      test(
+        'one batch call replaces both per-wrap signing round trips',
+        () async {
+          final signer = _BatchWrapSigner(
+            localPrivateKey,
+            onBatch: (rumor, recipients) async => [
+              GiftWrapSlot.success(wrapFor(recipients[0])),
+              GiftWrapSlot.success(wrapFor(recipients[1])),
+            ],
+          );
+          var mainBuilderCalls = 0;
+
+          final service = NIP17MessageService(
+            signer: signer,
+            senderPublicKey: localPubkey,
+            nostrService: mockNostrClient,
+            giftWrapBuilder: (_, _, _) async {
+              mainBuilderCalls++;
+              return null;
+            },
+          );
+
+          final rumor = service.buildRumor(
+            recipientPubkey: _recipientPubkey,
+            content: 'via server batch',
+          );
+          final result = await service.sendRumor(
+            rumorEvent: rumor,
+            recipientPubkey: _recipientPubkey,
+          );
+
+          expect(result.success, isTrue);
+          expect(signer.batchCalls, equals(1));
+          // The whole point: zero signer round trips for the seal, and no
+          // per-wrap rebuild for the self copy.
+          expect(signer.nip44EncryptCalls, isZero);
+          expect(signer.signEventCalls, isZero);
+          expect(mainBuilderCalls, isZero);
+          // Both wraps published from the one call: recipient, then self.
+          verify(() => mockNostrClient.publishEvent(any())).called(2);
+        },
+      );
+
+      test(
+        'sends the rumor and [recipient, self] as the batch params',
+        () async {
+          Map<String, dynamic>? seenRumor;
+          List<String>? seenRecipients;
+          final signer = _BatchWrapSigner(
+            localPrivateKey,
+            onBatch: (rumor, recipients) async {
+              seenRumor = rumor;
+              seenRecipients = recipients;
+              return [
+                GiftWrapSlot.success(wrapFor(recipients[0])),
+                GiftWrapSlot.success(wrapFor(recipients[1])),
+              ];
+            },
+          );
+
+          final service = NIP17MessageService(
+            signer: signer,
+            senderPublicKey: localPubkey,
+            nostrService: mockNostrClient,
+          );
+          final rumor = service.buildRumor(
+            recipientPubkey: _recipientPubkey,
+            content: 'params check',
+          );
+          final result = await service.sendRumor(
+            rumorEvent: rumor,
+            recipientPubkey: _recipientPubkey,
+          );
+          expect(result.success, isTrue);
+
+          // The rumor must go over the wire verbatim: the server recomputes
+          // and verifies its id, and every slot seals this exact body, so the
+          // id the durable queue keyed on is the id the recipient dedups on.
+          expect(seenRumor, equals(rumor.toJson()));
+          expect(seenRumor!['id'], equals(rumor.id));
+          // Order is load-bearing — slot 0 is the recipient, slot 1 the NIP-17
+          // self copy.
+          expect(seenRecipients, equals([_recipientPubkey, localPubkey]));
+        },
+      );
+
+      test('falls back to the per-wrap path when the recipient slot '
+          'fails', () async {
+        final signer = _BatchWrapSigner(
+          localPrivateKey,
+          onBatch: (rumor, recipients) async => [
+            const GiftWrapSlot.failure('encrypt_failed'),
+            GiftWrapSlot.success(wrapFor(recipients[1])),
+          ],
+        );
+        var mainBuilderCalls = 0;
+
+        final service = NIP17MessageService(
+          signer: signer,
+          senderPublicKey: localPubkey,
+          nostrService: mockNostrClient,
+          giftWrapBuilder: (_, _, recipient) async {
+            mainBuilderCalls++;
+            return Event.fromJson(wrapFor(recipient));
+          },
+        );
+        final result = await service.sendRumor(
+          rumorEvent: service.buildRumor(
+            recipientPubkey: _recipientPubkey,
+            content: 'recipient slot failed',
+          ),
+          recipientPubkey: _recipientPubkey,
+        );
+
+        expect(result.success, isTrue);
+        // Recipient wrap + self wrap, both rebuilt the old way.
+        expect(mainBuilderCalls, equals(2));
+      });
+
+      test('keeps the recipient wrap and defers the self copy when only the '
+          'self slot fails', () async {
+        final signer = _BatchWrapSigner(
+          localPrivateKey,
+          onBatch: (rumor, recipients) async => [
+            GiftWrapSlot.success(wrapFor(recipients[0])),
+            const GiftWrapSlot.failure('internal'),
+          ],
+        );
+        var mainBuilderCalls = 0;
+
+        final service = NIP17MessageService(
+          signer: signer,
+          senderPublicKey: localPubkey,
+          nostrService: mockNostrClient,
+          giftWrapBuilder: (_, _, recipient) async {
+            mainBuilderCalls++;
+            return Event.fromJson(wrapFor(recipient));
+          },
+        );
+        final result = await service.sendRumor(
+          rumorEvent: service.buildRumor(
+            recipientPubkey: _recipientPubkey,
+            content: 'self slot failed',
+          ),
+          recipientPubkey: _recipientPubkey,
+        );
+
+        expect(result.success, isTrue);
+        expect(result.selfWrapPublished, isTrue);
+        // Only the self copy was rebuilt; the batch's recipient wrap stands.
+        expect(mainBuilderCalls, equals(1));
+      });
+
+      test('falls back when the slot count does not match the recipient '
+          'count', () async {
+        final signer = _BatchWrapSigner(
+          localPrivateKey,
+          onBatch: (rumor, recipients) async => [
+            GiftWrapSlot.success(wrapFor(recipients[0])),
+          ],
+        );
+        var mainBuilderCalls = 0;
+
+        final service = NIP17MessageService(
+          signer: signer,
+          senderPublicKey: localPubkey,
+          nostrService: mockNostrClient,
+          giftWrapBuilder: (_, _, recipient) async {
+            mainBuilderCalls++;
+            return Event.fromJson(wrapFor(recipient));
+          },
+        );
+        final result = await service.sendRumor(
+          rumorEvent: service.buildRumor(
+            recipientPubkey: _recipientPubkey,
+            content: 'short slot list',
+          ),
+          recipientPubkey: _recipientPubkey,
+        );
+
+        expect(result.success, isTrue);
+        expect(mainBuilderCalls, equals(2));
+      });
+
+      test('falls back when a slot carries an unusable event', () async {
+        // Parsed as JSON but not a well-formed event: never publish a wrap we
+        // only half understand.
+        final signer = _BatchWrapSigner(
+          localPrivateKey,
+          onBatch: (rumor, recipients) async => const [
+            GiftWrapSlot.success({'not': 'an event'}),
+            GiftWrapSlot.success({'not': 'an event'}),
+          ],
+        );
+        var mainBuilderCalls = 0;
+
+        final service = NIP17MessageService(
+          signer: signer,
+          senderPublicKey: localPubkey,
+          nostrService: mockNostrClient,
+          giftWrapBuilder: (_, _, recipient) async {
+            mainBuilderCalls++;
+            return Event.fromJson(wrapFor(recipient));
+          },
+        );
+        final result = await service.sendRumor(
+          rumorEvent: service.buildRumor(
+            recipientPubkey: _recipientPubkey,
+            content: 'unusable slot',
+          ),
+          recipientPubkey: _recipientPubkey,
+        );
+
+        expect(result.success, isTrue);
+        expect(mainBuilderCalls, equals(2));
+      });
+
+      test(
+        'latches off after the backend reports the verb unsupported',
+        () async {
+          // A null answer means "this server does not have the verb" — the only
+          // signal strong enough to stop probing for the rest of the session.
+          final signer = _BatchWrapSigner(
+            localPrivateKey,
+            onBatch: (rumor, recipients) async => null,
+          );
+
+          final service = NIP17MessageService(
+            signer: signer,
+            senderPublicKey: localPubkey,
+            nostrService: mockNostrClient,
+            giftWrapBuilder: (_, _, recipient) async =>
+                Event.fromJson(wrapFor(recipient)),
+          );
+
+          for (final content in ['first', 'second']) {
+            final result = await service.sendRumor(
+              rumorEvent: service.buildRumor(
+                recipientPubkey: _recipientPubkey,
+                content: content,
+              ),
+              recipientPubkey: _recipientPubkey,
+            );
+            expect(result.success, isTrue);
+          }
+
+          expect(signer.batchCalls, equals(1));
+        },
+      );
+
+      test('does NOT latch off after a transient batch failure', () async {
+        // A 5xx, an expired token or a timeout is not evidence the verb is
+        // gone. Latching on one would cost the rest of the session four round
+        // trips per DM — the regression this whole change removes.
+        final signer = _BatchWrapSigner(
+          localPrivateKey,
+          onBatch: (rumor, recipients) async =>
+              throw StateError('HTTP 503: Database temporarily unavailable'),
+        );
+
+        final service = NIP17MessageService(
+          signer: signer,
+          senderPublicKey: localPubkey,
+          nostrService: mockNostrClient,
+          giftWrapBuilder: (_, _, recipient) async =>
+              Event.fromJson(wrapFor(recipient)),
+        );
+
+        for (final content in ['first', 'second']) {
+          final result = await service.sendRumor(
+            rumorEvent: service.buildRumor(
+              recipientPubkey: _recipientPubkey,
+              content: content,
+            ),
+            recipientPubkey: _recipientPubkey,
+          );
+          expect(result.success, isTrue);
+        }
+
+        expect(signer.batchCalls, equals(2));
+      });
+
+      test('a policy refusal thrown by the batch still terminalizes as '
+          'blocked', () async {
+        // Keycast's verified_minor gate answers 403 "Operation denied by
+        // policy". The batch rethrows it, the fallback's own encrypt re-hits
+        // it, and sendRumor must classify it terminal rather than retryable.
+        final signer = _BatchWrapSigner(
+          localPrivateKey,
+          onBatch: (rumor, recipients) async =>
+              throw _RpcExceptionDouble('HTTP 403: Operation denied by policy'),
+        );
+
+        final service = NIP17MessageService(
+          signer: signer,
+          senderPublicKey: localPubkey,
+          nostrService: mockNostrClient,
+          giftWrapBuilder: (_, _, _) async =>
+              throw _RpcExceptionDouble('HTTP 403: Operation denied by policy'),
+        );
+        final result = await service.sendRumor(
+          rumorEvent: service.buildRumor(
+            recipientPubkey: _recipientPubkey,
+            content: 'minor gate',
+          ),
+          recipientPubkey: _recipientPubkey,
+        );
+
+        expect(result.blocked, isTrue);
+      });
+
+      for (final (label, kind) in [
+        ('kind-7 reaction', EventKind.reaction),
+        ('kind-5 deletion', EventKind.eventDeletion),
+      ]) {
+        test('never offers a $label rumor to the batch', () async {
+          // keycast rejects anything but kinds 14/15 at request level, so
+          // probing would burn a round trip to learn the same answer every
+          // time — and NIP-17 blesses both of these kinds, so they are not
+          // rare. See #7090 / the keycast follow-up.
+          final signer = _BatchWrapSigner(
+            localPrivateKey,
+            onBatch: (rumor, recipients) async => [
+              GiftWrapSlot.success(wrapFor(recipients[0])),
+              GiftWrapSlot.success(wrapFor(recipients[1])),
+            ],
+          );
+          var mainBuilderCalls = 0;
+
+          final service = NIP17MessageService(
+            signer: signer,
+            senderPublicKey: localPubkey,
+            nostrService: mockNostrClient,
+            giftWrapBuilder: (_, _, recipient) async {
+              mainBuilderCalls++;
+              return Event.fromJson(wrapFor(recipient));
+            },
+          );
+          final result = await service.sendRumor(
+            rumorEvent: service.buildRumor(
+              recipientPubkey: _recipientPubkey,
+              content: label,
+              eventKind: kind,
+            ),
+            recipientPubkey: _recipientPubkey,
+          );
+
+          expect(result.success, isTrue);
+          expect(signer.batchCalls, isZero);
+          expect(mainBuilderCalls, equals(2));
+        });
+      }
+
+      test('a kind the batch cannot take does not latch it off for the kinds '
+          'it can', () async {
+        // The kind guard has to be a skip, not a failure: a reaction must not
+        // cost the next message send its fast path.
+        final signer = _BatchWrapSigner(
+          localPrivateKey,
+          onBatch: (rumor, recipients) async => [
+            GiftWrapSlot.success(wrapFor(recipients[0])),
+            GiftWrapSlot.success(wrapFor(recipients[1])),
+          ],
+        );
+
+        final service = NIP17MessageService(
+          signer: signer,
+          senderPublicKey: localPubkey,
+          nostrService: mockNostrClient,
+          giftWrapBuilder: (_, _, recipient) async =>
+              Event.fromJson(wrapFor(recipient)),
+        );
+
+        final reaction = await service.sendRumor(
+          rumorEvent: service.buildRumor(
+            recipientPubkey: _recipientPubkey,
+            content: '👍',
+            eventKind: EventKind.reaction,
+          ),
+          recipientPubkey: _recipientPubkey,
+        );
+        expect(reaction.success, isTrue);
+        expect(signer.batchCalls, isZero);
+
+        final message = await service.sendRumor(
+          rumorEvent: service.buildRumor(
+            recipientPubkey: _recipientPubkey,
+            content: 'message after a reaction',
+          ),
+          recipientPubkey: _recipientPubkey,
+        );
+        expect(message.success, isTrue);
+        expect(signer.batchCalls, equals(1));
+      });
+
+      test('a local-key signer never reaches the batch, even when its signer '
+          'supports it', () async {
+        // A BYOK Keycast identity is both isolate-capable and batch-capable.
+        // The isolate hop costs zero round trips, so it must win.
+        final signer = _IsolateAndBatchSigner(
+          localPrivateKey,
+          onBatch: (rumor, recipients) async => [
+            GiftWrapSlot.success(wrapFor(recipients[0])),
+            GiftWrapSlot.success(wrapFor(recipients[1])),
+          ],
+        );
+
+        final service = NIP17MessageService(
+          signer: signer,
+          senderPublicKey: localPubkey,
+          nostrService: mockNostrClient,
+          isolateGiftWrapBatchBuilder: buildGiftWrapBatch,
+        );
+        final result = await service.sendRumor(
+          rumorEvent: service.buildRumor(
+            recipientPubkey: _recipientPubkey,
+            content: 'local key wins',
+          ),
+          recipientPubkey: _recipientPubkey,
+        );
+
+        expect(result.success, isTrue);
+        expect(signer.batchCalls, isZero);
+      });
+
+      test('a failed isolate hop falls to in-process signing, not the '
+          'network', () async {
+        // Same identity, but the isolate seam fails. The main-isolate builder
+        // still signs with the local key at zero round trips, so falling to
+        // the server batch here would be a regression.
+        final signer = _IsolateAndBatchSigner(
+          localPrivateKey,
+          onBatch: (rumor, recipients) async => [
+            GiftWrapSlot.success(wrapFor(recipients[0])),
+            GiftWrapSlot.success(wrapFor(recipients[1])),
+          ],
+        );
+        var mainBuilderCalls = 0;
+
+        final service = NIP17MessageService(
+          signer: signer,
+          senderPublicKey: localPubkey,
+          nostrService: mockNostrClient,
+          isolateGiftWrapBatchBuilder: (_) async =>
+              throw StateError('isolate spawn failed'),
+          giftWrapBuilder: (_, _, recipient) async {
+            mainBuilderCalls++;
+            return Event.fromJson(wrapFor(recipient));
+          },
+        );
+        final result = await service.sendRumor(
+          rumorEvent: service.buildRumor(
+            recipientPubkey: _recipientPubkey,
+            content: 'isolate failed',
+          ),
+          recipientPubkey: _recipientPubkey,
+        );
+
+        expect(result.success, isTrue);
+        expect(signer.batchCalls, isZero);
+        expect(mainBuilderCalls, equals(2));
+      });
     });
 
     // #6586. A 1:1 send costs four remote signer round trips, and no signer

--- a/mobile/packages/keycast_flutter/lib/src/models/exceptions.dart
+++ b/mobile/packages/keycast_flutter/lib/src/models/exceptions.dart
@@ -1,7 +1,7 @@
 // ABOUTME: Custom exceptions for Keycast operations
 // ABOUTME: Provides typed exceptions for session, OAuth, RPC, and key errors
 
-import 'package:nostr_sdk/nostr_sdk.dart';
+import 'package:nostr_sdk/signer/signer_failure.dart';
 
 class KeycastException implements Exception {
   KeycastException(this.message);

--- a/mobile/packages/keycast_flutter/lib/src/models/exceptions.dart
+++ b/mobile/packages/keycast_flutter/lib/src/models/exceptions.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Custom exceptions for Keycast operations
 // ABOUTME: Provides typed exceptions for session, OAuth, RPC, and key errors
 
+// ignore: unused_import, used after current main exports signer_failure.dart
+import 'package:nostr_sdk/nostr_sdk.dart';
 import 'package:nostr_sdk/signer/signer_failure.dart';
 
 class KeycastException implements Exception {

--- a/mobile/packages/keycast_flutter/lib/src/models/exceptions.dart
+++ b/mobile/packages/keycast_flutter/lib/src/models/exceptions.dart
@@ -1,9 +1,7 @@
 // ABOUTME: Custom exceptions for Keycast operations
 // ABOUTME: Provides typed exceptions for session, OAuth, RPC, and key errors
 
-// ignore: unused_import, used after current main exports signer_failure.dart
 import 'package:nostr_sdk/nostr_sdk.dart';
-import 'package:nostr_sdk/signer/signer_failure.dart';
 
 class KeycastException implements Exception {
   KeycastException(this.message);

--- a/mobile/packages/keycast_flutter/lib/src/models/exceptions.dart
+++ b/mobile/packages/keycast_flutter/lib/src/models/exceptions.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Custom exceptions for Keycast operations
 // ABOUTME: Provides typed exceptions for session, OAuth, RPC, and key errors
 
+import 'package:nostr_sdk/nostr_sdk.dart';
+
 class KeycastException implements Exception {
   KeycastException(this.message);
   final String message;
@@ -39,6 +41,32 @@ class RpcException extends KeycastException {
   String toString() => method != null
       ? 'RpcException [$method]: $message'
       : 'RpcException: $message';
+}
+
+/// Keycast bounded the RPC itself and gave up: HTTP 504 from `/api/nostr`.
+///
+/// Both server-side ceilings on that route answer 504 — the handler's own
+/// `HTTP_RPC_HANDLER_TIMEOUT` (8s, which keeps the method label on the latency
+/// histogram) and the wider tower layer behind it (10s, covering body read and
+/// extractors). So 504 is *the* "Keycast ran out of time" signal there,
+/// whichever ceiling fired, and it is the only 5xx that says so
+/// unambiguously: 503 covers a degraded dependency and 500 an unhandled
+/// error, neither of which promises the operation did not happen.
+///
+/// Carries [TransientSignerFailure] because it means exactly what a local
+/// `TimeoutException` from `KeycastRpc.requestTimeout` means — the signing or
+/// encryption never produced a result, nothing was published, and a retry is
+/// the right response. Only the side of the wire that noticed differs. Without
+/// the marker a 504 arrives as a plain non-200 and callers terminalize it,
+/// which is strictly worse than the timeout it replaced.
+class RpcTimeoutException extends RpcException
+    implements TransientSignerFailure {
+  RpcTimeoutException(super.message, {super.method});
+
+  @override
+  String toString() => method != null
+      ? 'RpcTimeoutException [$method]: $message'
+      : 'RpcTimeoutException: $message';
 }
 
 class InvalidKeyException extends KeycastException {

--- a/mobile/packages/keycast_flutter/lib/src/rpc/keycast_rpc.dart
+++ b/mobile/packages/keycast_flutter/lib/src/rpc/keycast_rpc.dart
@@ -377,7 +377,7 @@ class KeycastRpc implements NostrSigner, GiftWrapBatchUnwrapper {
     List<Map<String, dynamic>> giftWraps,
   ) async {
     try {
-      return await _callBatch(
+      return await _call(
         'nip17_unwrap_batch',
         giftWraps,
         (result) => [
@@ -387,6 +387,7 @@ class KeycastRpc implements NostrSigner, GiftWrapBatchUnwrapper {
         // The batch verb decrypts many wraps server-side and legitimately runs
         // longer than a single op, so keep it on the longer bound rather than
         // the tighter single-op [requestTimeout].
+        timeout: batchRequestTimeout,
         classifyLocalTimeout: false,
       );
     } on RpcException {

--- a/mobile/packages/keycast_flutter/lib/src/rpc/keycast_rpc.dart
+++ b/mobile/packages/keycast_flutter/lib/src/rpc/keycast_rpc.dart
@@ -17,8 +17,7 @@ import 'package:unified_logger/unified_logger.dart';
 /// is not possible.
 typedef TokenRefreshCallback = Future<String?> Function();
 
-class KeycastRpc
-    implements NostrSigner, GiftWrapBatchUnwrapper, GiftWrapBatchWrapper {
+class KeycastRpc implements NostrSigner, GiftWrapBatchUnwrapper {
   KeycastRpc({
     required this.nostrApi,
     required String accessToken,
@@ -93,8 +92,7 @@ class KeycastRpc
   ///
   /// Callers that need to outlive a slow signer do not lean on this bound
   /// either: the durable outgoing queue re-drives stalled sends and
-  /// `DmBatchSendBudget.messagePublishTimeout` is the send-level backstop
-  /// (#6046).
+  /// `DmSendBudget.messagePublishTimeout` is the send-level backstop (#6046).
   static const Duration defaultRequestTimeout = Duration(seconds: 20);
 
   /// Default timeout for the multi-wrap `nip17_unwrap_batch` verb, which does
@@ -313,7 +311,7 @@ class KeycastRpc
         logHttpErrors: false,
       );
     } on RpcException catch (error) {
-      if (_isUnsupportedMethod(error)) {
+      if (_isUnsupportedSignCanonical(error)) {
         _signCanonicalUnsupported = true;
         Log.info(
           '[Keycast RPC] sign_canonical unsupported by backend; '
@@ -342,23 +340,18 @@ class KeycastRpc
     }
   }
 
-  /// Whether [error] is the backend signalling that the called method is not
+  /// Whether [error] is the backend signalling that `sign_canonical` is not
   /// implemented, as opposed to a transient or auth failure that must stay
   /// retryable.
   ///
   /// Matched against the exact wordings the login backend returns today: the
-  /// HTTP `Unsupported method: <verb>` body and the JSON-RPC `method_not_found`
-  /// error field. Matching on the body is mandatory, not stylistic: keycast
-  /// returns HTTP 400 for an unknown method AND for ordinary bad params, so the
-  /// status code alone cannot tell "this server is too old" from "this request
-  /// was wrong". The match is deliberately narrow — a broader signal (e.g.
-  /// caching on any 4xx) would risk permanently disabling a supported
-  /// capability after a transient blip. If the backend ever rewords this,
-  /// update the substrings here, otherwise every caller silently re-probes an
-  /// absent verb forever.
-  ///
-  /// Verb-agnostic and shared by [signCanonicalPayload] and [nip17WrapBatch].
-  bool _isUnsupportedMethod(RpcException error) {
+  /// HTTP `Unsupported method: sign_canonical` body and the JSON-RPC
+  /// `method_not_found` error field. The match is deliberately narrow — a
+  /// broader signal (e.g. caching on any 4xx) would risk permanently disabling
+  /// a supported capability after a transient blip. If the backend ever rewords
+  /// this, update the substrings here, otherwise canonical binding silently
+  /// re-requests on every publish.
+  bool _isUnsupportedSignCanonical(RpcException error) {
     final lower = error.message.toLowerCase();
     return lower.contains('unsupported method') ||
         lower.contains('method_not_found') ||
@@ -453,7 +446,7 @@ class KeycastRpc
         logHttpErrors: false,
       );
     } on RpcException catch (error) {
-      if (!_isUnsupportedMethod(error)) rethrow;
+      if (!_isUnsupportedWrapBatch(error)) rethrow;
       Log.info(
         '[Keycast RPC] nip17_wrap_batch unsupported by backend; '
         'DM sends will use the per-wrap signing path for this session',
@@ -462,6 +455,14 @@ class KeycastRpc
       );
       return null;
     }
+  }
+
+  /// Distinguishes an absent batch verb from ordinary HTTP 400 rejections.
+  bool _isUnsupportedWrapBatch(RpcException error) {
+    final lower = error.message.toLowerCase();
+    return lower.contains('unsupported method') ||
+        lower.contains('method_not_found') ||
+        lower.contains('method not found');
   }
 
   static GiftWrapSlot _parseWrapSlot(Map<String, dynamic> slot) {

--- a/mobile/packages/keycast_flutter/lib/src/rpc/keycast_rpc.dart
+++ b/mobile/packages/keycast_flutter/lib/src/rpc/keycast_rpc.dart
@@ -424,7 +424,6 @@ class KeycastRpc implements NostrSigner, GiftWrapBatchUnwrapper {
   /// there, a caller that latches off pays two decrypt RPCs per wrap; here it
   /// would pay four signing round trips per DM for the rest of the session, and
   /// a single blip is not evidence the verb is gone.
-  @override
   Future<List<GiftWrapSlot>?> nip17WrapBatch(
     Map<String, dynamic> rumor,
     List<String> recipientPubkeys,

--- a/mobile/packages/keycast_flutter/lib/src/rpc/keycast_rpc.dart
+++ b/mobile/packages/keycast_flutter/lib/src/rpc/keycast_rpc.dart
@@ -190,6 +190,90 @@ class KeycastRpc implements NostrSigner, GiftWrapBatchUnwrapper {
     return fromResult(json['result']);
   }
 
+  /// Runs a batch verb under one deadline, including token refresh and retry.
+  Future<T> _callBatch<T>(
+    String method,
+    List<dynamic> params,
+    T Function(dynamic) fromResult, {
+    bool logHttpErrors = true,
+    bool classifyLocalTimeout = true,
+  }) async {
+    final stopwatch = Stopwatch()..start();
+
+    Never throwTimeout() {
+      if (!classifyLocalTimeout) {
+        throw TimeoutException(
+          '$method request timed out',
+          batchRequestTimeout,
+        );
+      }
+      throw RpcTimeoutException(
+        'Local $method request timed out after '
+        '${batchRequestTimeout.inSeconds}s',
+        method: method,
+      );
+    }
+
+    Duration remaining() {
+      final value = batchRequestTimeout - stopwatch.elapsed;
+      if (value <= Duration.zero) throwTimeout();
+      return value;
+    }
+
+    var response = await _sendRequest(
+      method,
+      params,
+      timeout: remaining(),
+      classifyLocalTimeout: classifyLocalTimeout,
+    );
+
+    if (response.statusCode == 401 && _onTokenRefresh != null) {
+      Log.info(
+        '[Keycast RPC] $method returned 401, attempting token refresh',
+        name: 'KeycastRpc',
+        category: LogCategory.auth,
+      );
+      String? newToken;
+      try {
+        newToken = await _onTokenRefresh().timeout(remaining());
+      } on TimeoutException {
+        throwTimeout();
+      }
+      if (newToken != null) {
+        _accessToken = newToken;
+        response = await _sendRequest(
+          method,
+          params,
+          timeout: remaining(),
+          classifyLocalTimeout: classifyLocalTimeout,
+        );
+      }
+    }
+
+    if (response.statusCode != 200) {
+      if (logHttpErrors) {
+        Log.error(
+          '[Keycast RPC] Error response: ${response.body}',
+          name: 'KeycastRpc',
+          category: LogCategory.auth,
+        );
+      }
+      final message = 'HTTP ${response.statusCode}: ${response.body}';
+      throw response.statusCode == _gatewayTimeoutStatus
+          ? RpcTimeoutException(message, method: method)
+          : RpcException(message, method: method);
+    }
+
+    final json = jsonDecode(response.body) as Map<String, dynamic>;
+    if (json.containsKey('error') && json['error'] != null) {
+      throw RpcException(json['error'].toString(), method: method);
+    }
+    if (!json.containsKey('result')) {
+      throw RpcException('Missing result in response', method: method);
+    }
+    return fromResult(json['result']);
+  }
+
   Future<http.Response> _sendRequest(
     String method,
     List<dynamic> params, {
@@ -377,7 +461,7 @@ class KeycastRpc implements NostrSigner, GiftWrapBatchUnwrapper {
     List<Map<String, dynamic>> giftWraps,
   ) async {
     try {
-      return await _call(
+      return await _callBatch(
         'nip17_unwrap_batch',
         giftWraps,
         (result) => [
@@ -387,7 +471,6 @@ class KeycastRpc implements NostrSigner, GiftWrapBatchUnwrapper {
         // The batch verb decrypts many wraps server-side and legitimately runs
         // longer than a single op, so keep it on the longer bound rather than
         // the tighter single-op [requestTimeout].
-        timeout: batchRequestTimeout,
         classifyLocalTimeout: false,
       );
     } on RpcException {
@@ -429,7 +512,7 @@ class KeycastRpc implements NostrSigner, GiftWrapBatchUnwrapper {
     List<String> recipientPubkeys,
   ) async {
     try {
-      return await _call(
+      return await _callBatch(
         'nip17_wrap_batch',
         [rumor, recipientPubkeys],
         (result) => [
@@ -439,7 +522,6 @@ class KeycastRpc implements NostrSigner, GiftWrapBatchUnwrapper {
         // Builds a seal + wrap per recipient server-side, so it legitimately
         // runs longer than a single op — keep it on the batch bound rather
         // than the tighter single-op [requestTimeout].
-        timeout: batchRequestTimeout,
         // The unsupported-method probe is an expected outcome on an older
         // backend, not an incident; the branch below logs it at info instead.
         logHttpErrors: false,

--- a/mobile/packages/keycast_flutter/lib/src/rpc/keycast_rpc.dart
+++ b/mobile/packages/keycast_flutter/lib/src/rpc/keycast_rpc.dart
@@ -190,90 +190,6 @@ class KeycastRpc implements NostrSigner, GiftWrapBatchUnwrapper {
     return fromResult(json['result']);
   }
 
-  /// Runs a batch verb under one deadline, including token refresh and retry.
-  Future<T> _callBatch<T>(
-    String method,
-    List<dynamic> params,
-    T Function(dynamic) fromResult, {
-    bool logHttpErrors = true,
-    bool classifyLocalTimeout = true,
-  }) async {
-    final stopwatch = Stopwatch()..start();
-
-    Never throwTimeout() {
-      if (!classifyLocalTimeout) {
-        throw TimeoutException(
-          '$method request timed out',
-          batchRequestTimeout,
-        );
-      }
-      throw RpcTimeoutException(
-        'Local $method request timed out after '
-        '${batchRequestTimeout.inSeconds}s',
-        method: method,
-      );
-    }
-
-    Duration remaining() {
-      final value = batchRequestTimeout - stopwatch.elapsed;
-      if (value <= Duration.zero) throwTimeout();
-      return value;
-    }
-
-    var response = await _sendRequest(
-      method,
-      params,
-      timeout: remaining(),
-      classifyLocalTimeout: classifyLocalTimeout,
-    );
-
-    if (response.statusCode == 401 && _onTokenRefresh != null) {
-      Log.info(
-        '[Keycast RPC] $method returned 401, attempting token refresh',
-        name: 'KeycastRpc',
-        category: LogCategory.auth,
-      );
-      String? newToken;
-      try {
-        newToken = await _onTokenRefresh().timeout(remaining());
-      } on TimeoutException {
-        throwTimeout();
-      }
-      if (newToken != null) {
-        _accessToken = newToken;
-        response = await _sendRequest(
-          method,
-          params,
-          timeout: remaining(),
-          classifyLocalTimeout: classifyLocalTimeout,
-        );
-      }
-    }
-
-    if (response.statusCode != 200) {
-      if (logHttpErrors) {
-        Log.error(
-          '[Keycast RPC] Error response: ${response.body}',
-          name: 'KeycastRpc',
-          category: LogCategory.auth,
-        );
-      }
-      final message = 'HTTP ${response.statusCode}: ${response.body}';
-      throw response.statusCode == _gatewayTimeoutStatus
-          ? RpcTimeoutException(message, method: method)
-          : RpcException(message, method: method);
-    }
-
-    final json = jsonDecode(response.body) as Map<String, dynamic>;
-    if (json.containsKey('error') && json['error'] != null) {
-      throw RpcException(json['error'].toString(), method: method);
-    }
-    if (!json.containsKey('result')) {
-      throw RpcException('Missing result in response', method: method);
-    }
-    return fromResult(json['result']);
-  }
-
   Future<http.Response> _sendRequest(
     String method,
     List<dynamic> params, {
@@ -479,6 +395,90 @@ class KeycastRpc implements NostrSigner, GiftWrapBatchUnwrapper {
       // TimeoutException must propagate, not be swallowed into a null result.
       return null;
     }
+  }
+
+  /// Runs a batch verb under one deadline, including token refresh and retry.
+  Future<T> _callBatch<T>(
+    String method,
+    List<dynamic> params,
+    T Function(dynamic) fromResult, {
+    bool logHttpErrors = true,
+    bool classifyLocalTimeout = true,
+  }) async {
+    final stopwatch = Stopwatch()..start();
+
+    Never throwTimeout() {
+      if (!classifyLocalTimeout) {
+        throw TimeoutException(
+          '$method request timed out',
+          batchRequestTimeout,
+        );
+      }
+      throw RpcTimeoutException(
+        'Local $method request timed out after '
+        '${batchRequestTimeout.inSeconds}s',
+        method: method,
+      );
+    }
+
+    Duration remaining() {
+      final value = batchRequestTimeout - stopwatch.elapsed;
+      if (value <= Duration.zero) throwTimeout();
+      return value;
+    }
+
+    var response = await _sendRequest(
+      method,
+      params,
+      timeout: remaining(),
+      classifyLocalTimeout: classifyLocalTimeout,
+    );
+
+    if (response.statusCode == 401 && _onTokenRefresh != null) {
+      Log.info(
+        '[Keycast RPC] $method returned 401, attempting token refresh',
+        name: 'KeycastRpc',
+        category: LogCategory.auth,
+      );
+      String? newToken;
+      try {
+        newToken = await _onTokenRefresh().timeout(remaining());
+      } on TimeoutException {
+        throwTimeout();
+      }
+      if (newToken != null) {
+        _accessToken = newToken;
+        response = await _sendRequest(
+          method,
+          params,
+          timeout: remaining(),
+          classifyLocalTimeout: classifyLocalTimeout,
+        );
+      }
+    }
+
+    if (response.statusCode != 200) {
+      if (logHttpErrors) {
+        Log.error(
+          '[Keycast RPC] Error response: ${response.body}',
+          name: 'KeycastRpc',
+          category: LogCategory.auth,
+        );
+      }
+      final message = 'HTTP ${response.statusCode}: ${response.body}';
+      throw response.statusCode == _gatewayTimeoutStatus
+          ? RpcTimeoutException(message, method: method)
+          : RpcException(message, method: method);
+    }
+
+    final json = jsonDecode(response.body) as Map<String, dynamic>;
+    if (json.containsKey('error') && json['error'] != null) {
+      throw RpcException(json['error'].toString(), method: method);
+    }
+    if (!json.containsKey('result')) {
+      throw RpcException('Missing result in response', method: method);
+    }
+    return fromResult(json['result']);
   }
 
   /// Server-side NIP-59 gift-wrap construction for the remote-signer DM send

--- a/mobile/packages/keycast_flutter/lib/src/rpc/keycast_rpc.dart
+++ b/mobile/packages/keycast_flutter/lib/src/rpc/keycast_rpc.dart
@@ -84,7 +84,7 @@ class KeycastRpc
   ///
   /// That evidence is **corroboration, not the guarantee**. This bound does
   /// not assume the server keeps its ceiling, because it no longer has to:
-  /// [RpcTimeoutException] makes a server 504 and a local [TimeoutException]
+  /// [RpcTimeoutException] makes a server 504 and a local request timeout
   /// classify identically downstream, so which side gives up first stopped
   /// being load-bearing. Sizing a client cap on an unverified server bound is
   /// what produced #6586; sizing it on the client's own transport costs, and
@@ -113,7 +113,7 @@ class KeycastRpc
   bool _signCanonicalUnsupported = false;
 
   /// Maximum time to wait for a single-op RPC request before failing with a
-  /// [TimeoutException].
+  /// [RpcTimeoutException].
   final Duration requestTimeout;
 
   /// Maximum time to wait for the heavier `nip17_unwrap_batch` RPC.
@@ -125,8 +125,14 @@ class KeycastRpc
     T Function(dynamic) fromResult, {
     bool logHttpErrors = true,
     Duration? timeout,
+    bool classifyLocalTimeout = true,
   }) async {
-    var response = await _sendRequest(method, params, timeout: timeout);
+    var response = await _sendRequest(
+      method,
+      params,
+      timeout: timeout,
+      classifyLocalTimeout: classifyLocalTimeout,
+    );
 
     if (response.statusCode == 401 && _onTokenRefresh != null) {
       Log.info(
@@ -147,7 +153,12 @@ class KeycastRpc
       }
       if (newToken != null) {
         _accessToken = newToken;
-        response = await _sendRequest(method, params, timeout: timeout);
+        response = await _sendRequest(
+          method,
+          params,
+          timeout: timeout,
+          classifyLocalTimeout: classifyLocalTimeout,
+        );
       }
     }
 
@@ -184,6 +195,7 @@ class KeycastRpc
     String method,
     List<dynamic> params, {
     Duration? timeout,
+    bool classifyLocalTimeout = true,
   }) async {
     Log.debug(
       '[Keycast RPC] Calling $method...',
@@ -191,16 +203,26 @@ class KeycastRpc
       category: LogCategory.auth,
     );
     final stopwatch = Stopwatch()..start();
-    final response = await _client
-        .post(
-          Uri.parse(nostrApi),
-          headers: {
-            'Authorization': 'Bearer $_accessToken',
-            'Content-Type': 'application/json',
-          },
-          body: jsonEncode({'method': method, 'params': params}),
-        )
-        .timeout(timeout ?? requestTimeout);
+    final effectiveTimeout = timeout ?? requestTimeout;
+    http.Response response;
+    try {
+      response = await _client
+          .post(
+            Uri.parse(nostrApi),
+            headers: {
+              'Authorization': 'Bearer $_accessToken',
+              'Content-Type': 'application/json',
+            },
+            body: jsonEncode({'method': method, 'params': params}),
+          )
+          .timeout(effectiveTimeout);
+    } on TimeoutException {
+      if (!classifyLocalTimeout) rethrow;
+      throw RpcTimeoutException(
+        'Local $method request timed out after ${effectiveTimeout.inSeconds}s',
+        method: method,
+      );
+    }
     stopwatch.stop();
     Log.debug(
       '[Keycast RPC] $method completed in '
@@ -353,9 +375,9 @@ class KeycastRpc
   ///
   /// Returns `null` (rather than throwing) when the backend does not expose the
   /// verb yet — method-not-found surfaces as an [RpcException] — so callers fall
-  /// back to the per-wrap decrypt path. A [TimeoutException] is deliberately
-  /// allowed to propagate so a slow page is retried by the caller rather than
-  /// being mistaken for an empty result.
+  /// back to the per-wrap decrypt path. A local [TimeoutException] is
+  /// deliberately allowed to propagate so a slow page is retried by the caller
+  /// rather than being mistaken for an empty result.
   @override
   Future<List<GiftWrapUnwrapSlot>?> nip17UnwrapBatch(
     List<Map<String, dynamic>> giftWraps,
@@ -372,6 +394,7 @@ class KeycastRpc
         // longer than a single op, so keep it on the longer bound rather than
         // the tighter single-op [requestTimeout].
         timeout: batchRequestTimeout,
+        classifyLocalTimeout: false,
       );
     } on RpcException {
       // Older keycast without the verb, or a server-level error: degrade so the

--- a/mobile/packages/keycast_flutter/lib/src/rpc/keycast_rpc.dart
+++ b/mobile/packages/keycast_flutter/lib/src/rpc/keycast_rpc.dart
@@ -93,7 +93,8 @@ class KeycastRpc
   ///
   /// Callers that need to outlive a slow signer do not lean on this bound
   /// either: the durable outgoing queue re-drives stalled sends and
-  /// `DmSendBudget.messagePublishTimeout` is the send-level backstop (#6046).
+  /// `DmBatchSendBudget.messagePublishTimeout` is the send-level backstop
+  /// (#6046).
   static const Duration defaultRequestTimeout = Duration(seconds: 20);
 
   /// Default timeout for the multi-wrap `nip17_unwrap_batch` verb, which does

--- a/mobile/packages/keycast_flutter/lib/src/rpc/keycast_rpc.dart
+++ b/mobile/packages/keycast_flutter/lib/src/rpc/keycast_rpc.dart
@@ -17,7 +17,8 @@ import 'package:unified_logger/unified_logger.dart';
 /// is not possible.
 typedef TokenRefreshCallback = Future<String?> Function();
 
-class KeycastRpc implements NostrSigner, GiftWrapBatchUnwrapper {
+class KeycastRpc
+    implements NostrSigner, GiftWrapBatchUnwrapper, GiftWrapBatchWrapper {
   KeycastRpc({
     required this.nostrApi,
     required String accessToken,
@@ -255,7 +256,7 @@ class KeycastRpc implements NostrSigner, GiftWrapBatchUnwrapper {
         logHttpErrors: false,
       );
     } on RpcException catch (error) {
-      if (_isUnsupportedSignCanonical(error)) {
+      if (_isUnsupportedMethod(error)) {
         _signCanonicalUnsupported = true;
         Log.info(
           '[Keycast RPC] sign_canonical unsupported by backend; '
@@ -284,18 +285,23 @@ class KeycastRpc implements NostrSigner, GiftWrapBatchUnwrapper {
     }
   }
 
-  /// Whether [error] is the backend signalling that `sign_canonical` is not
+  /// Whether [error] is the backend signalling that the called method is not
   /// implemented, as opposed to a transient or auth failure that must stay
   /// retryable.
   ///
   /// Matched against the exact wordings the login backend returns today: the
-  /// HTTP `Unsupported method: sign_canonical` body and the JSON-RPC
-  /// `method_not_found` error field. The match is deliberately narrow — a
-  /// broader signal (e.g. caching on any 4xx) would risk permanently disabling
-  /// a supported capability after a transient blip. If the backend ever rewords
-  /// this, update the substrings here, otherwise canonical binding silently
-  /// re-requests on every publish.
-  bool _isUnsupportedSignCanonical(RpcException error) {
+  /// HTTP `Unsupported method: <verb>` body and the JSON-RPC `method_not_found`
+  /// error field. Matching on the body is mandatory, not stylistic: keycast
+  /// returns HTTP 400 for an unknown method AND for ordinary bad params, so the
+  /// status code alone cannot tell "this server is too old" from "this request
+  /// was wrong". The match is deliberately narrow — a broader signal (e.g.
+  /// caching on any 4xx) would risk permanently disabling a supported
+  /// capability after a transient blip. If the backend ever rewords this,
+  /// update the substrings here, otherwise every caller silently re-probes an
+  /// absent verb forever.
+  ///
+  /// Verb-agnostic and shared by [signCanonicalPayload] and [nip17WrapBatch].
+  bool _isUnsupportedMethod(RpcException error) {
     final lower = error.message.toLowerCase();
     return lower.contains('unsupported method') ||
         lower.contains('method_not_found') ||
@@ -339,6 +345,74 @@ class KeycastRpc implements NostrSigner, GiftWrapBatchUnwrapper {
       // TimeoutException must propagate, not be swallowed into a null result.
       return null;
     }
+  }
+
+  /// Server-side NIP-59 gift-wrap construction for the remote-signer DM send
+  /// path (`nip17_wrap_batch`).
+  ///
+  /// Sends one shared [rumor] plus an ordered [recipientPubkeys] list and gets
+  /// back index-aligned slots — each a signed kind:1059 gift wrap, or a
+  /// per-recipient error code. The server NIP-44-encrypts the rumor and signs
+  /// the kind:13 seal itself, so a 1:1 send (peer + the NIP-17 self copy)
+  /// collapses from four round trips — `nip44Encrypt` + `signEvent` per wrap —
+  /// to one. It also collapses this send's four per-request account-status DB
+  /// queries and four activity-log writes into one of each, which is the part
+  /// that matters under the signer's DB-pool contention.
+  ///
+  /// The server accepts rumor kinds 14 and 15 only; callers must not send
+  /// other kinds (NIP-17 also blesses kind 7 reactions and wrapped kind 5
+  /// deletes, which this verb rejects at request level).
+  ///
+  /// Returns `null` ONLY when the backend does not expose the verb yet, so the
+  /// caller can stop asking for the rest of the session.
+  ///
+  /// Everything else throws — a transient 5xx, an expired token, a rejected
+  /// request, or a [TimeoutException]. This is a deliberate divergence from
+  /// [nip17UnwrapBatch], which collapses every [RpcException] into `null`:
+  /// there, a caller that latches off pays two decrypt RPCs per wrap; here it
+  /// would pay four signing round trips per DM for the rest of the session, and
+  /// a single blip is not evidence the verb is gone.
+  @override
+  Future<List<GiftWrapSlot>?> nip17WrapBatch(
+    Map<String, dynamic> rumor,
+    List<String> recipientPubkeys,
+  ) async {
+    try {
+      return await _call(
+        'nip17_wrap_batch',
+        [rumor, recipientPubkeys],
+        (result) => [
+          for (final slot in result as List)
+            _parseWrapSlot(slot as Map<String, dynamic>),
+        ],
+        // Builds a seal + wrap per recipient server-side, so it legitimately
+        // runs longer than a single op — keep it on the batch bound rather
+        // than the tighter single-op [requestTimeout].
+        timeout: batchRequestTimeout,
+        // The unsupported-method probe is an expected outcome on an older
+        // backend, not an incident; the branch below logs it at info instead.
+        logHttpErrors: false,
+      );
+    } on RpcException catch (error) {
+      if (!_isUnsupportedMethod(error)) rethrow;
+      Log.info(
+        '[Keycast RPC] nip17_wrap_batch unsupported by backend; '
+        'DM sends will use the per-wrap signing path for this session',
+        name: 'KeycastRpc',
+        category: LogCategory.auth,
+      );
+      return null;
+    }
+  }
+
+  static GiftWrapSlot _parseWrapSlot(Map<String, dynamic> slot) {
+    final error = slot['error'];
+    if (error != null) return GiftWrapSlot.failure(error.toString());
+    final giftWrap = slot['gift_wrap'];
+    if (giftWrap is Map<String, dynamic>) {
+      return GiftWrapSlot.success(giftWrap);
+    }
+    return const GiftWrapSlot.failure('invalid_slot');
   }
 
   static GiftWrapUnwrapSlot _parseUnwrapSlot(Map<String, dynamic> slot) {

--- a/mobile/packages/keycast_flutter/lib/src/rpc/keycast_rpc.dart
+++ b/mobile/packages/keycast_flutter/lib/src/rpc/keycast_rpc.dart
@@ -424,7 +424,8 @@ class KeycastRpc
   /// caller can stop asking for the rest of the session.
   ///
   /// Everything else throws — a transient 5xx, an expired token, a rejected
-  /// request, or a [TimeoutException]. This is a deliberate divergence from
+  /// request, or a transient [RpcTimeoutException]. This is a deliberate
+  /// divergence from
   /// [nip17UnwrapBatch], which collapses every [RpcException] into `null`:
   /// there, a caller that latches off pays two decrypt RPCs per wrap; here it
   /// would pay four signing round trips per DM for the rest of the session, and

--- a/mobile/packages/keycast_flutter/lib/src/rpc/keycast_rpc.dart
+++ b/mobile/packages/keycast_flutter/lib/src/rpc/keycast_rpc.dart
@@ -49,29 +49,61 @@ class KeycastRpc
     );
   }
 
+  /// HTTP 504. Keycast's answer when it ran out of time on `/api/nostr`.
+  static const int _gatewayTimeoutStatus = 504;
+
   /// Default timeout applied to a single signing/encryption RPC
   /// (`sign_event`, `nip44_encrypt`, `nip44_decrypt`, `nip04_*`,
   /// `get_public_key`, `sign_canonical`).
   ///
-  /// Without a bound, a dead socket (e.g. Android Doze killing the
-  /// connection while backgrounded) hangs the request forever and wedges
-  /// every caller awaiting it.
+  /// ## What this bound is for
   ///
-  /// This default applies to *every* single-op RPC caller — video publish
-  /// signing, likes, reposts, follows — not just the DM path, so the bound
-  /// must cover production Keycast single-op latency under load. Keycast
-  /// DB-pool contention has been observed to push a single op to ~20-30s;
-  /// a tighter bound would turn slow-but-succeeding social actions and
-  /// video publishes into hard failures. The DM send path does not depend
-  /// on a shorter bound for fail-fast or durability: the durable outgoing
-  /// queue re-drives stalled sends and `dm_repository`'s 90s
-  /// `_messagePublishTimeout` is the send-level backstop (#6046).
-  static const Duration defaultRequestTimeout = Duration(seconds: 30);
+  /// It is a **dead-socket backstop**, not a latency budget. Android Doze
+  /// killing a connection while backgrounded leaves a request that never
+  /// completes and never errors; without a bound it wedges every caller
+  /// awaiting it forever. So the number is sized from what a *live* request
+  /// can cost on a bad mobile link — DNS, TCP, TLS, a retransmit or two, and
+  /// the small JSON round trip — not from how slow the server might be. 20s
+  /// is far above that and still recovers a wedged caller in a third less
+  /// time than the previous 30s.
+  ///
+  /// It applies to *every* single-op RPC caller — video publish signing,
+  /// likes, reposts, follows — not just the DM path.
+  ///
+  /// ## Why it is no longer sized against server latency (#7092)
+  ///
+  /// The old derivation held this at 30s to cover "production Keycast
+  /// single-op latency of ~20-30s under DB-pool contention" (keycast#291).
+  /// That is no longer reachable: keycast#351 bounds the `/api/nostr` handler
+  /// at 8s and the tower layer behind it at 10s, both answering 504, so a
+  /// request that is still alive cannot spend more than ~10s server-side.
+  /// Verified live on production 2026-08-13 via the public `/api/metrics`
+  /// histogram that keycast#351 itself added: across two instances and ~10k
+  /// `sign_event` samples every success landed in the `le="1"` bucket, and
+  /// `outcome="timeout"` had not been recorded once.
+  ///
+  /// That evidence is **corroboration, not the guarantee**. This bound does
+  /// not assume the server keeps its ceiling, because it no longer has to:
+  /// [RpcTimeoutException] makes a server 504 and a local [TimeoutException]
+  /// classify identically downstream, so which side gives up first stopped
+  /// being load-bearing. Sizing a client cap on an unverified server bound is
+  /// what produced #6586; sizing it on the client's own transport costs, and
+  /// making both give-up paths mean the same thing, is what retires that
+  /// coupling.
+  ///
+  /// Callers that need to outlive a slow signer do not lean on this bound
+  /// either: the durable outgoing queue re-drives stalled sends and
+  /// `DmSendBudget.messagePublishTimeout` is the send-level backstop (#6046).
+  static const Duration defaultRequestTimeout = Duration(seconds: 20);
 
   /// Default timeout for the multi-wrap `nip17_unwrap_batch` verb, which does
   /// materially more server-side work than a single op and legitimately runs
   /// longer. Held at the historical single-op bound so batch decrypt is not
   /// regressed by the tighter [defaultRequestTimeout] above.
+  ///
+  /// Left wider deliberately rather than re-derived alongside it: keycast's
+  /// 8s handler bound covers this verb too, so the extra 10s can only buy
+  /// transport slack, never mask a slow server.
   static const Duration defaultBatchRequestTimeout = Duration(seconds: 30);
 
   final String nostrApi;
@@ -127,10 +159,12 @@ class KeycastRpc
           category: LogCategory.auth,
         );
       }
-      throw RpcException(
-        'HTTP ${response.statusCode}: ${response.body}',
-        method: method,
-      );
+      final message = 'HTTP ${response.statusCode}: ${response.body}';
+      // 504 is Keycast reporting *its own* timeout, so it classifies like one
+      // rather than like a refusal. See [RpcTimeoutException].
+      throw response.statusCode == _gatewayTimeoutStatus
+          ? RpcTimeoutException(message, method: method)
+          : RpcException(message, method: method);
     }
 
     final json = jsonDecode(response.body) as Map<String, dynamic>;

--- a/mobile/packages/keycast_flutter/test/rpc_client_test.dart
+++ b/mobile/packages/keycast_flutter/test/rpc_client_test.dart
@@ -13,7 +13,6 @@ import 'package:keycast_flutter/src/models/keycast_session.dart';
 import 'package:keycast_flutter/src/oauth/oauth_config.dart';
 import 'package:keycast_flutter/src/rpc/keycast_rpc.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
-import 'package:nostr_sdk/signer/signer_failure.dart';
 
 void main() {
   group('KeycastRpc', () {

--- a/mobile/packages/keycast_flutter/test/rpc_client_test.dart
+++ b/mobile/packages/keycast_flutter/test/rpc_client_test.dart
@@ -13,6 +13,7 @@ import 'package:keycast_flutter/src/models/keycast_session.dart';
 import 'package:keycast_flutter/src/oauth/oauth_config.dart';
 import 'package:keycast_flutter/src/rpc/keycast_rpc.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
+import 'package:nostr_sdk/signer/signer_failure.dart';
 
 void main() {
   group('KeycastRpc', () {

--- a/mobile/packages/keycast_flutter/test/rpc_client_test.dart
+++ b/mobile/packages/keycast_flutter/test/rpc_client_test.dart
@@ -473,20 +473,36 @@ void main() {
         );
       });
 
-      test('throws TimeoutException when the request hangs', () async {
-        // Simulates a dead socket (e.g. Android Doze killing the
-        // connection) — the request future never completes.
-        mockClient = MockClient((request) => Completer<http.Response>().future);
+      test(
+        'throws RpcTimeoutException when a single-op request hangs',
+        () async {
+          // Simulates a dead socket (e.g. Android Doze killing the
+          // connection) — the request future never completes. Single-op RPCs
+          // carry the same transient marker as Keycast's own 504 so DM sends
+          // classify both give-up paths identically.
+          mockClient = MockClient(
+            (request) => Completer<http.Response>().future,
+          );
 
-        final rpc = KeycastRpc(
-          nostrApi: 'https://login.divine.video/api/nostr',
-          accessToken: 'test_token',
-          httpClient: mockClient,
-          requestTimeout: const Duration(milliseconds: 50),
-        );
+          final rpc = KeycastRpc(
+            nostrApi: 'https://login.divine.video/api/nostr',
+            accessToken: 'test_token',
+            httpClient: mockClient,
+            requestTimeout: const Duration(milliseconds: 50),
+          );
 
-        await expectLater(rpc.getPublicKey(), throwsA(isA<TimeoutException>()));
-      });
+          await expectLater(
+            rpc.getPublicKey(),
+            throwsA(
+              isA<RpcTimeoutException>().having(
+                (e) => e,
+                'transient marker',
+                isA<TransientSignerFailure>(),
+              ),
+            ),
+          );
+        },
+      );
     });
 
     group('signCanonicalPayload', () {

--- a/mobile/packages/keycast_flutter/test/rpc_client_test.dart
+++ b/mobile/packages/keycast_flutter/test/rpc_client_test.dart
@@ -993,6 +993,61 @@ void main() {
         );
       });
 
+      test(
+        'shares one batch deadline across a 401 refresh and retry',
+        () async {
+          var callCount = 0;
+          mockClient = MockClient((request) async {
+            callCount++;
+            if (callCount == 1) {
+              await Future<void>.delayed(const Duration(milliseconds: 100));
+              return http.Response('Unauthorized', 401);
+            }
+            return Completer<http.Response>().future;
+          });
+          final rpc = KeycastRpc(
+            nostrApi: 'https://login.divine.video/api/nostr',
+            accessToken: 'expired_token',
+            httpClient: mockClient,
+            onTokenRefresh: () async => 'fresh_token',
+            batchRequestTimeout: const Duration(milliseconds: 250),
+          );
+          final stopwatch = Stopwatch()..start();
+
+          await expectLater(
+            rpc.nip17WrapBatch(rumor, recipients),
+            throwsA(isA<RpcTimeoutException>()),
+          );
+
+          expect(callCount, 2);
+          expect(
+            stopwatch.elapsed,
+            lessThan(const Duration(milliseconds: 330)),
+          );
+        },
+      );
+
+      test(
+        'classifies a refresh timeout as a transient batch timeout',
+        () async {
+          mockClient = MockClient(
+            (request) async => http.Response('Unauthorized', 401),
+          );
+          final rpc = KeycastRpc(
+            nostrApi: 'https://login.divine.video/api/nostr',
+            accessToken: 'expired_token',
+            httpClient: mockClient,
+            onTokenRefresh: () => Completer<String?>().future,
+            batchRequestTimeout: const Duration(milliseconds: 50),
+          );
+
+          await expectLater(
+            rpc.nip17WrapBatch(rumor, recipients),
+            throwsA(isA<RpcTimeoutException>()),
+          );
+        },
+      );
+
       test('is bounded by batchRequestTimeout, not the shorter single-op '
           'requestTimeout', () async {
         mockClient = MockClient((request) async {

--- a/mobile/packages/keycast_flutter/test/rpc_client_test.dart
+++ b/mobile/packages/keycast_flutter/test/rpc_client_test.dart
@@ -980,8 +980,8 @@ void main() {
         );
       });
 
-      test('propagates TimeoutException rather than swallowing it to '
-          'null', () async {
+      test('propagates transient RpcTimeoutException rather than swallowing '
+          'it to null', () async {
         mockClient = MockClient((request) => Completer<http.Response>().future);
 
         await expectLater(
@@ -989,7 +989,7 @@ void main() {
             mockClient,
             batchTimeout: const Duration(milliseconds: 50),
           ).nip17WrapBatch(rumor, recipients),
-          throwsA(isA<TimeoutException>()),
+          throwsA(isA<RpcTimeoutException>()),
         );
       });
 

--- a/mobile/packages/keycast_flutter/test/rpc_client_test.dart
+++ b/mobile/packages/keycast_flutter/test/rpc_client_test.dart
@@ -724,5 +724,224 @@ void main() {
         expect(slots![0].isSuccess, isTrue);
       });
     });
+
+    group('nip17WrapBatch', () {
+      final rumor = {
+        'id': 'c' * 64,
+        'pubkey': 'd' * 64,
+        'created_at': 1700000001,
+        'kind': 14,
+        'tags': [
+          ['p', 'e' * 64],
+        ],
+        'content': 'hello',
+        'sig': '',
+      };
+      final recipients = ['e' * 64, 'd' * 64];
+
+      Map<String, dynamic> wrap(String id) => {
+        'id': id,
+        'pubkey': 'f' * 64,
+        'created_at': 1700000000,
+        'kind': 1059,
+        'tags': [
+          ['p', 'e' * 64],
+        ],
+        'content': 'ciphertext-$id',
+        'sig': 'b' * 128,
+      };
+
+      KeycastRpc rpcWith(MockClient client, {Duration? batchTimeout}) =>
+          KeycastRpc(
+            nostrApi: 'https://login.divine.video/api/nostr',
+            accessToken: 'test_token',
+            httpClient: client,
+            batchRequestTimeout:
+                batchTimeout ?? KeycastRpc.defaultBatchRequestTimeout,
+          );
+
+      test('posts the rumor and recipient list as two positional params '
+          'and parses ordered slots', () async {
+        mockClient = MockClient((request) async {
+          expect(request.headers['Authorization'], 'Bearer test_token');
+          final body = jsonDecode(request.body) as Map<String, dynamic>;
+          expect(body['method'], 'nip17_wrap_batch');
+          // The server parses exactly [rumorObject, [recipientHex...]]; a
+          // flattened or reordered params list is a request-level rejection.
+          expect(body['params'], [rumor, recipients]);
+          return http.Response(
+            jsonEncode({
+              'result': [
+                {'gift_wrap': wrap('11')},
+                {'gift_wrap': wrap('22')},
+              ],
+            }),
+            200,
+          );
+        });
+
+        final slots = await rpcWith(mockClient).nip17WrapBatch(
+          rumor,
+          recipients,
+        );
+
+        expect(slots, hasLength(2));
+        expect(slots![0].isSuccess, isTrue);
+        expect(slots[0].giftWrap, wrap('11'));
+        expect(slots[1].giftWrap, wrap('22'));
+      });
+
+      test('keeps a per-recipient error slot isolated from its '
+          'siblings', () async {
+        mockClient = MockClient((request) async {
+          return http.Response(
+            jsonEncode({
+              'result': [
+                {'gift_wrap': wrap('11')},
+                {'error': 'invalid_recipient'},
+              ],
+            }),
+            200,
+          );
+        });
+
+        final slots = await rpcWith(mockClient).nip17WrapBatch(
+          rumor,
+          recipients,
+        );
+
+        expect(slots![0].isSuccess, isTrue);
+        expect(slots[1].isSuccess, isFalse);
+        expect(slots[1].error, 'invalid_recipient');
+        expect(slots[1].giftWrap, isNull);
+      });
+
+      test('reports a malformed slot as a failure rather than throwing', () {
+        // A slot that is neither {gift_wrap} nor {error} must not take the
+        // whole send down; the caller treats it like any other failed slot.
+        mockClient = MockClient((request) async {
+          return http.Response(
+            jsonEncode({
+              'result': [
+                {'unexpected': true},
+              ],
+            }),
+            200,
+          );
+        });
+
+        return expectLater(
+          rpcWith(mockClient).nip17WrapBatch(rumor, recipients),
+          completion(
+            allOf(
+              hasLength(1),
+              predicate<List<GiftWrapSlot>>(
+                (slots) => slots.single.error == 'invalid_slot',
+                'reports invalid_slot',
+              ),
+            ),
+          ),
+        );
+      });
+
+      test('returns null when the backend lacks the verb', () async {
+        // keycast answers HTTP 400 with this body for an unknown method, so
+        // the body — not the status — is what identifies an older backend.
+        mockClient = MockClient((request) async {
+          return http.Response('Unsupported method: nip17_wrap_batch', 400);
+        });
+
+        expect(
+          await rpcWith(mockClient).nip17WrapBatch(rumor, recipients),
+          isNull,
+        );
+      });
+
+      test('throws rather than returning null on a request-level rejection '
+          'that shares the unsupported-method status code', () async {
+        // Same HTTP 400 as an absent verb, different body. Collapsing this to
+        // null would latch the caller onto the slow path for the whole session
+        // because of one bad request.
+        mockClient = MockClient((request) async {
+          return http.Response('Rumor kind must be 14 or 15', 400);
+        });
+
+        await expectLater(
+          rpcWith(mockClient).nip17WrapBatch(rumor, recipients),
+          throwsA(isA<RpcException>()),
+        );
+      });
+
+      test('throws on a transient server error', () async {
+        // A 503 under pool saturation is not evidence the verb is missing.
+        mockClient = MockClient((request) async {
+          return http.Response('Database temporarily unavailable', 503);
+        });
+
+        await expectLater(
+          rpcWith(mockClient).nip17WrapBatch(rumor, recipients),
+          throwsA(isA<RpcException>()),
+        );
+      });
+
+      test('throws on the policy refusal so the caller can terminalize '
+          'it', () async {
+        // The verified_minor gate answers 403 with this marker; the send path
+        // matches on it to return `blocked` instead of a retryable failure.
+        mockClient = MockClient((request) async {
+          return http.Response('Operation denied by policy', 403);
+        });
+
+        await expectLater(
+          rpcWith(mockClient).nip17WrapBatch(rumor, recipients),
+          throwsA(
+            isA<RpcException>().having(
+              (e) => e.message,
+              'message',
+              contains('Operation denied by policy'),
+            ),
+          ),
+        );
+      });
+
+      test('propagates TimeoutException rather than swallowing it to '
+          'null', () async {
+        mockClient = MockClient((request) => Completer<http.Response>().future);
+
+        await expectLater(
+          rpcWith(
+            mockClient,
+            batchTimeout: const Duration(milliseconds: 50),
+          ).nip17WrapBatch(rumor, recipients),
+          throwsA(isA<TimeoutException>()),
+        );
+      });
+
+      test('is bounded by batchRequestTimeout, not the shorter single-op '
+          'requestTimeout', () async {
+        mockClient = MockClient((request) async {
+          await Future<void>.delayed(const Duration(milliseconds: 200));
+          return http.Response(
+            jsonEncode({
+              'result': [
+                {'gift_wrap': wrap('11')},
+              ],
+            }),
+            200,
+          );
+        });
+        final rpc = KeycastRpc(
+          nostrApi: 'https://login.divine.video/api/nostr',
+          accessToken: 'test_token',
+          httpClient: mockClient,
+          requestTimeout: const Duration(milliseconds: 50),
+          batchRequestTimeout: const Duration(seconds: 5),
+        );
+
+        final slots = await rpc.nip17WrapBatch(rumor, recipients);
+        expect(slots, hasLength(1));
+        expect(slots![0].isSuccess, isTrue);
+      });
+    });
   });
 }

--- a/mobile/packages/keycast_flutter/test/rpc_client_test.dart
+++ b/mobile/packages/keycast_flutter/test/rpc_client_test.dart
@@ -270,6 +270,62 @@ void main() {
 
         expect(rpc.getPublicKey, throwsA(isA<RpcException>()));
       });
+
+      test('a 504 throws RpcTimeoutException, marked transient', () async {
+        // Keycast bounds its own /api/nostr handler at 8s and its tower layer
+        // at 10s; both answer 504 (keycast#351). That is Keycast reporting a
+        // timeout, so it has to reach callers classified as one — a plain
+        // non-200 gets terminalized, which is strictly worse than the client
+        // timeout it replaced. The marker is what dm_repository branches on;
+        // it cannot import this package to check the concrete type (#7092).
+        mockClient = MockClient((request) async {
+          return http.Response(
+            jsonEncode({'error': 'RPC request timed out after 8s'}),
+            504,
+          );
+        });
+
+        final rpc = KeycastRpc(
+          nostrApi: 'https://login.divine.video/api/nostr',
+          accessToken: 'test_token',
+          httpClient: mockClient,
+        );
+
+        await expectLater(
+          rpc.getPublicKey(),
+          throwsA(
+            isA<RpcTimeoutException>().having(
+              (e) => e,
+              'transient marker',
+              isA<TransientSignerFailure>(),
+            ),
+          ),
+        );
+      });
+
+      test('other 5xx stay plain RpcException, not transient', () async {
+        // The classification is deliberately narrow. 504 is the only status
+        // on this route that means "I ran out of time and produced nothing";
+        // 503 is a degraded dependency and 500 an unhandled error, neither of
+        // which promises the operation did not happen.
+        for (final status in [500, 502, 503]) {
+          mockClient = MockClient((request) async {
+            return http.Response('Server error', status);
+          });
+
+          final rpc = KeycastRpc(
+            nostrApi: 'https://login.divine.video/api/nostr',
+            accessToken: 'test_token',
+            httpClient: mockClient,
+          );
+
+          await expectLater(
+            rpc.getPublicKey(),
+            throwsA(isNot(isA<TransientSignerFailure>())),
+            reason: 'HTTP $status must not be classified as transient',
+          );
+        }
+      });
     });
 
     group('token refresh on 401', () {
@@ -395,18 +451,22 @@ void main() {
     });
 
     group('request timeout', () {
-      test('single-op and batch default timeouts are both 30s', () {
+      test('the single-op default is 20s and the batch default 30s', () {
         // Pinned because #6046 accidentally regressed the GLOBAL single-op
         // default to 12s while sizing it for the DM pipeline. None of the
         // production construction sites override requestTimeout, so that
-        // bound applied to every RPC caller (video publish signing, likes,
-        // reposts, follows). Production Keycast single-op latency runs
-        // ~20-30s under DB-pool contention, so the default must stay at 30s
-        // or those callers regress from slow-but-succeeding to failing.
-        expect(
-          KeycastRpc.defaultRequestTimeout,
-          const Duration(seconds: 30),
-        );
+        // bound applies to every RPC caller (video publish signing, likes,
+        // reposts, follows) and cannot be re-tuned for one of them.
+        //
+        // 30s → 20s in #7092. The 30s was sized to cover ~20-30s single-op
+        // latency under Keycast DB-pool contention (keycast#291); keycast#351
+        // now bounds that handler at 8s and answers 504, so a live request
+        // cannot spend that long server-side and the bound reverts to what it
+        // is actually for — a dead-socket backstop sized on mobile transport
+        // cost. Do not chase it further down: the value below the server
+        // ceiling is where a live-but-slow request starts losing the server's
+        // own classified answer to an anonymous client timeout.
+        expect(KeycastRpc.defaultRequestTimeout, const Duration(seconds: 20));
         expect(
           KeycastRpc.defaultBatchRequestTimeout,
           const Duration(seconds: 30),

--- a/mobile/packages/nostr_sdk/lib/nip59/gift_wrap_batch_wrap.dart
+++ b/mobile/packages/nostr_sdk/lib/nip59/gift_wrap_batch_wrap.dart
@@ -1,0 +1,55 @@
+// ABOUTME: Capability for building NIP-59 gift wraps server-side in one batch.
+// ABOUTME: Lets a remote signer (e.g. Keycast) wrap every recipient in one trip.
+
+/// One index-aligned result slot from a server-side NIP-17 gift-wrap build
+/// batch.
+///
+/// On success it carries the signed kind:1059 [giftWrap] as JSON. On a
+/// per-recipient failure it carries an [error] code instead — one bad recipient
+/// never fails the whole batch.
+class GiftWrapSlot {
+  /// A slot whose gift wrap was built successfully.
+  const GiftWrapSlot.success(Map<String, dynamic> this.giftWrap) : error = null;
+
+  /// A slot whose gift wrap could not be built, carrying the server's [error]
+  /// code (e.g. `invalid_recipient`, `permission_denied`, `encrypt_failed`).
+  /// The code set is open: treat any unknown code as a failure rather than
+  /// pinning to a fixed list.
+  const GiftWrapSlot.failure(String this.error) : giftWrap = null;
+
+  /// The signed kind:1059 gift wrap as JSON, or `null` on failure.
+  final Map<String, dynamic>? giftWrap;
+
+  /// The per-recipient error code, or `null` on success.
+  final String? error;
+
+  /// Whether this slot produced a gift wrap.
+  bool get isSuccess => error == null && giftWrap != null;
+}
+
+/// A signer that can build NIP-59 gift wraps server-side in a single batched
+/// round trip, rather than a `nip44Encrypt` + `signEvent` pair per wrap.
+///
+/// Signers that cannot do this simply do not implement the interface; callers
+/// detect support with `signer is GiftWrapBatchWrapper` and fall back to the
+/// per-wrap build path when it is absent.
+abstract interface class GiftWrapBatchWrapper {
+  /// Wraps one shared [rumor] — an unsigned NIP-17 rumor as JSON — for
+  /// [recipientPubkeys] (hex), returning ordered, index-aligned [GiftWrapSlot]s.
+  ///
+  /// Every slot seals the SAME rumor, so the rumor id is shared across them;
+  /// receiver-side dedup and the durable outgoing queue both key on it.
+  ///
+  /// Returns `null` when the server does not expose the verb (an older
+  /// backend), so the caller can stop asking and use the per-wrap path.
+  ///
+  /// Throws for every other failure — a transient server error, an expired
+  /// token, a request-level rejection, or a [TimeoutException]. Callers must
+  /// treat a throw as "fall back for this send" and NOT as "the verb is
+  /// missing": collapsing the two would let one blip permanently demote a
+  /// session to the slow path.
+  Future<List<GiftWrapSlot>?> nip17WrapBatch(
+    Map<String, dynamic> rumor,
+    List<String> recipientPubkeys,
+  );
+}

--- a/mobile/packages/nostr_sdk/lib/nostr_sdk.dart
+++ b/mobile/packages/nostr_sdk/lib/nostr_sdk.dart
@@ -64,7 +64,6 @@ export 'signer/local_nostr_signer.dart';
 export 'signer/isolate_decrypt_signer.dart';
 export 'signer/nostr_signer.dart';
 export 'signer/pubkey_only_nostr_signer.dart';
-export 'signer/signer_failure.dart';
 export 'subscription.dart';
 export 'upload/blossom_uploader.dart';
 export 'upload/nip96_uploader.dart';

--- a/mobile/packages/nostr_sdk/lib/nostr_sdk.dart
+++ b/mobile/packages/nostr_sdk/lib/nostr_sdk.dart
@@ -64,6 +64,7 @@ export 'signer/local_nostr_signer.dart';
 export 'signer/isolate_decrypt_signer.dart';
 export 'signer/nostr_signer.dart';
 export 'signer/pubkey_only_nostr_signer.dart';
+export 'signer/signer_failure.dart';
 export 'subscription.dart';
 export 'upload/blossom_uploader.dart';
 export 'upload/nip96_uploader.dart';

--- a/mobile/packages/nostr_sdk/lib/nostr_sdk.dart
+++ b/mobile/packages/nostr_sdk/lib/nostr_sdk.dart
@@ -63,8 +63,8 @@ export 'signer/local_nostr_signer.dart';
 // Signing implementations
 export 'signer/isolate_decrypt_signer.dart';
 export 'signer/nostr_signer.dart';
-export 'signer/pubkey_only_nostr_signer.dart';
 export 'signer/signer_failure.dart';
+export 'signer/unauthenticated_signer.dart';
 export 'subscription.dart';
 export 'upload/blossom_uploader.dart';
 export 'upload/nip96_uploader.dart';

--- a/mobile/packages/nostr_sdk/lib/nostr_sdk.dart
+++ b/mobile/packages/nostr_sdk/lib/nostr_sdk.dart
@@ -36,6 +36,7 @@ export 'nip51/follow_set.dart';
 export 'nip55/android_nostr_signer.dart';
 export 'nip58/badge_definition.dart';
 export 'nip59/gift_wrap_batch_unwrap.dart';
+export 'nip59/gift_wrap_batch_wrap.dart';
 export 'nip59/gift_wrap_util.dart';
 export 'nip65/nip65.dart';
 export 'nip65/relay_list_metadata.dart';

--- a/mobile/packages/nostr_sdk/lib/signer/signer_failure.dart
+++ b/mobile/packages/nostr_sdk/lib/signer/signer_failure.dart
@@ -1,0 +1,22 @@
+/// Marker for a [NostrSigner] failure that happened *instead of* the
+/// operation, and that is expected to clear on its own.
+///
+/// Implementing it is a promise about two things at once:
+///
+/// * **Nothing happened.** The signer produced no signature, ciphertext or
+///   plaintext, and no side effect a retry could duplicate.
+/// * **It is worth retrying.** The cause is infrastructural — a bounded
+///   server giving up, a saturated pool — not a refusal, a policy decision,
+///   or bad input, all of which would fail again identically.
+///
+/// Callers use it to keep durable work retryable instead of terminalizing it.
+/// A remote-signer transport that surfaces its own timeout as an *error*
+/// rather than as a Dart [TimeoutException] should carry this marker, so the
+/// caller classifies it the same way it already classifies running out of
+/// patience locally — the two mean the same thing and only differ in which
+/// side of the wire noticed first.
+///
+/// The marker lives on the signer contract rather than in any one transport
+/// package so consumers can branch on it without depending on the transport
+/// that produced it.
+abstract interface class TransientSignerFailure {}

--- a/mobile/packages/nostr_sdk/lib/signer/unauthenticated_signer.dart
+++ b/mobile/packages/nostr_sdk/lib/signer/unauthenticated_signer.dart
@@ -1,0 +1,73 @@
+import '../event.dart';
+import 'nostr_signer.dart';
+
+/// Signer for the window where no identity exists: before sign-in resolves,
+/// and after sign-out.
+///
+/// `NostrClientConfig.signer` is non-nullable, so a `NostrClient` vended
+/// before an identity is known still has to put *something* in the signer
+/// slot. This type fills it without pretending to be a working signer.
+///
+/// [getPublicKey] returns the empty string, and that is load-bearing — it is
+/// what keeps `NostrClient.hasKeys` false, what makes `Nostr.ensurePublicKey`
+/// throw, and what trips the owner-pubkey mismatch guards in the curated-list
+/// gateway. Those three signals are the gates that keep signed-out code paths
+/// from doing signed work. Do not change it to `null` or to a throw.
+///
+/// Every signing and encryption entry point throws [StateError] rather than
+/// returning `null`, so "there is no identity" can no longer be mistaken for
+/// "a real signer tried and failed" — before this type, both were the same
+/// silent `null`.
+class UnauthenticatedSigner implements NostrSigner {
+  /// Creates the keyless signer. It holds no state, so callers may share one
+  /// `const` instance.
+  const UnauthenticatedSigner();
+
+  /// The empty string, never `null`. See the class doc — this is a gate, not
+  /// a placeholder value.
+  @override
+  Future<String?> getPublicKey() async => '';
+
+  /// Always `null`: a keyless signer advertises no NIP-65 relay list.
+  /// Local signers use the same answer; remote signers may return a relay map.
+  @override
+  Future<Map?> getRelays() async => null;
+
+  @override
+  Future<Event?> signEvent(Event event) async => _noIdentity('sign an event');
+
+  @override
+  Future<String?> encrypt(String pubkey, String plaintext) async =>
+      _noIdentity('NIP-04 encrypt');
+
+  @override
+  Future<String?> decrypt(String pubkey, String ciphertext) async =>
+      _noIdentity('NIP-04 decrypt');
+
+  @override
+  Future<String?> nip44Encrypt(String pubkey, String plaintext) async =>
+      _noIdentity('NIP-44 encrypt');
+
+  @override
+  Future<String?> nip44Decrypt(String pubkey, String ciphertext) async =>
+      _noIdentity('NIP-44 decrypt');
+
+  /// Intentional no-op: there is no key material or connection to release.
+  @override
+  void close() {}
+}
+
+/// Thrown when signed work is attempted with no identity.
+///
+/// [StateError] rather than an `Exception` subtype, matching the other
+/// no-identity failures on this object graph (`LocalKeySigner
+/// .withPrivateKeyHex`, `Nostr.ensurePublicKey`, `NostrCreatorBindingService
+/// .createAssertion`). Reaching here means a caller skipped its readiness
+/// gate, which is a programming error rather than an expected condition.
+Never _noIdentity(String operation) {
+  throw StateError(
+    'No identity: cannot $operation while signed out. Gate this call on '
+    'NostrClient.hasKeys, or on nostrSessionProvider.isReadyForActiveClient '
+    'for anything that publishes.',
+  );
+}

--- a/mobile/packages/nostr_sdk/test/unit/exports_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/exports_test.dart
@@ -17,7 +17,7 @@ void main() {
     test('Signing implementations are exported', () {
       expect(NostrSigner, isA<Type>());
       expect(LocalNostrSigner, isA<Type>());
-      expect(PubkeyOnlyNostrSigner, isA<Type>());
+      expect(UnauthenticatedSigner, isA<Type>());
     });
 
     test('Relay classes are exported', () {

--- a/mobile/test/services/auth/nostr_identity_test.dart
+++ b/mobile/test/services/auth/nostr_identity_test.dart
@@ -27,6 +27,8 @@ void main() {
     registerFallbackValue(Event(testPublicKey, 0, [], ''));
     registerFallbackValue(Uint8List(0));
     registerFallbackValue(<Map<String, dynamic>>[]);
+    registerFallbackValue(<String, dynamic>{});
+    registerFallbackValue(<String>[]);
   });
 
   group(LocalNostrIdentity, () {
@@ -295,6 +297,43 @@ void main() {
 
       expect(result, same(slots));
       verify(() => mockKeycastRpc.nip17UnwrapBatch(any())).called(1);
+    });
+
+    test(
+      'nip17WrapBatch returns null when rpcSigner is a generic NostrSigner',
+      () async {
+        // A generic NostrSigner is not a GiftWrapBatchWrapper, so the identity
+        // short-circuits to null and the DM send falls back to the per-wrap
+        // signing path. See #7090.
+        final identity = KeycastNostrIdentity(
+          pubkey: testPublicKey,
+          rpcSigner: mockRpc,
+        );
+
+        expect(await identity.nip17WrapBatch(const {}, const []), isNull);
+      },
+    );
+
+    test('nip17WrapBatch delegates to KeycastRpc', () async {
+      final mockKeycastRpc = _MockKeycastRpc();
+      final slots = [const GiftWrapSlot.failure('encrypt_failed')];
+      when(
+        () => mockKeycastRpc.nip17WrapBatch(any(), any()),
+      ).thenAnswer((_) async => slots);
+
+      final identity = KeycastNostrIdentity(
+        pubkey: testPublicKey,
+        rpcSigner: mockKeycastRpc,
+      );
+
+      final rumor = {'id': 'rumor', 'kind': 14};
+      const recipients = ['peer', 'self'];
+      final result = await identity.nip17WrapBatch(rumor, recipients);
+
+      expect(result, same(slots));
+      // Both params must reach the RPC unchanged: the server parses exactly
+      // [rumorObject, [recipientHex...]].
+      verify(() => mockKeycastRpc.nip17WrapBatch(rumor, recipients)).called(1);
     });
 
     test(

--- a/mobile/test/services/outgoing_dm_batch_budget_test.dart
+++ b/mobile/test/services/outgoing_dm_batch_budget_test.dart
@@ -1,0 +1,29 @@
+// ABOUTME: Guards the app-level NIP-17 batch send and retry timing contract.
+// ABOUTME: Pins dm_repository's restated bounds to Keycast's real constants.
+
+import 'package:dm_repository/dm_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:keycast_flutter/keycast_flutter.dart';
+import 'package:openvine/services/outgoing_dm_retry_service.dart';
+
+void main() {
+  test('batch send budget covers its request plus the legacy fallback', () {
+    expect(
+      DmBatchSendBudget.recipientWrapBuild,
+      KeycastRpc.defaultBatchRequestTimeout +
+          KeycastRpc.defaultRequestTimeout * 2 +
+          const Duration(seconds: 5),
+    );
+    expect(
+      DmBatchSendBudget.chainWorstCase,
+      lessThan(DmBatchSendBudget.messagePublishTimeout),
+    );
+  });
+
+  test('retry guard outlives the batch send backstop', () {
+    expect(
+      OutgoingDmRetryService.interruptedMinAge,
+      greaterThan(DmBatchSendBudget.messagePublishTimeout),
+    );
+  });
+}

--- a/mobile/test/services/outgoing_dm_retry_service_test.dart
+++ b/mobile/test/services/outgoing_dm_retry_service_test.dart
@@ -2053,8 +2053,19 @@ void main() {
       // two transport bounds would fail requests the transport itself would
       // have allowed — the #6046 mistake that #6075 had to revert.
       //
-      // The floor includes the seal construction, ephemeral keypair, NIP-44
-      // encryption and wrap signature that run alongside those round trips.
+      // Strictly greater, not >=: the bound also covers the seal
+      // construction, ephemeral keypair, NIP-44 encryption and wrap signature
+      // that run alongside those round trips. At exactly 2x, two ops each
+      // returning just inside the transport bound would still trip it, which
+      // is the same no-margin shape #6586 was about.
+      //
+      // This is the only place the two packages meet: `dm_repository` restates
+      // the transport bound as a literal because it cannot import
+      // `keycast_flutter`, so re-tuning one side without the other fails here
+      // rather than silently under-sizing the build. #7092 moved the transport
+      // bound 30s → 20s, dropping the floor 65s → 45s while
+      // `recipientWrapBuild` deliberately held at 65s, so its margin over the
+      // floor widened from 0s to 20s.
       expect(
         DmSendBudget.boundedSignerFloor,
         KeycastRpc.defaultRequestTimeout * 2 + const Duration(seconds: 5),
@@ -2072,7 +2083,7 @@ void main() {
       // otherwise a slow-but-recoverable pre-publish send is misclassified as a
       // timeout and retried.
       expect(
-        DmSendBudget.recipientWrapBuild,
+        DmSendBudget.recipientWrapBuildWithBatchFallback,
         greaterThan(
           KeycastRpc.defaultBatchRequestTimeout +
               KeycastRpc.defaultRequestTimeout * 2,

--- a/mobile/test/services/outgoing_dm_retry_service_test.dart
+++ b/mobile/test/services/outgoing_dm_retry_service_test.dart
@@ -2064,16 +2064,18 @@ void main() {
       );
     });
 
-    test('the recipient wrap build also covers one server-side wrap '
-        'batch', () {
+    test('the recipient wrap build covers batch timeout plus fallback', () {
       // #7090: a Keycast send now builds both wraps in one `nip17_wrap_batch`
-      // round trip, bounded by the batch transport bound rather than two
-      // single-op ones. That path must fit the same build budget — with room
-      // to spare, since the batch answer still has to be parsed and both
-      // events reconstructed after it lands.
+      // round trip, but a transient batch timeout falls back to the old
+      // per-wrap path inside the same recipient-build bound. Both have to fit,
+      // otherwise a slow-but-recoverable pre-publish send is misclassified as a
+      // timeout and retried.
       expect(
         DmSendBudget.recipientWrapBuild,
-        greaterThan(KeycastRpc.defaultBatchRequestTimeout),
+        greaterThan(
+          KeycastRpc.defaultBatchRequestTimeout +
+              KeycastRpc.defaultRequestTimeout * 2,
+        ),
       );
     });
 

--- a/mobile/test/services/outgoing_dm_retry_service_test.dart
+++ b/mobile/test/services/outgoing_dm_retry_service_test.dart
@@ -2047,20 +2047,21 @@ void main() {
       );
     });
 
-    test('the recipient wrap build exceeds two Keycast round trips', () {
+    test('the bounded signer floor matches two Keycast round trips', () {
       // A 1:1 send costs four measured signer round trips: nip44Encrypt +
       // signEvent for the seal, per wrap. Sizing the recipient build below
       // two transport bounds would fail requests the transport itself would
       // have allowed — the #6046 mistake that #6075 had to revert.
       //
-      // Strictly greater, not >=: the bound also covers the seal
-      // construction, ephemeral keypair, NIP-44 encryption and wrap signature
-      // that run alongside those round trips. At exactly 2x, two ops each
-      // returning just inside 30s would still trip it, which is the same
-      // no-margin shape #6586 was about.
+      // The floor includes the seal construction, ephemeral keypair, NIP-44
+      // encryption and wrap signature that run alongside those round trips.
+      expect(
+        DmSendBudget.boundedSignerFloor,
+        KeycastRpc.defaultRequestTimeout * 2 + const Duration(seconds: 5),
+      );
       expect(
         DmSendBudget.recipientWrapBuild,
-        greaterThan(KeycastRpc.defaultRequestTimeout * 2),
+        greaterThan(DmSendBudget.boundedSignerFloor),
       );
     });
 

--- a/mobile/test/services/outgoing_dm_retry_service_test.dart
+++ b/mobile/test/services/outgoing_dm_retry_service_test.dart
@@ -2076,21 +2076,6 @@ void main() {
       );
     });
 
-    test('the recipient wrap build covers batch timeout plus fallback', () {
-      // #7090: a Keycast send now builds both wraps in one `nip17_wrap_batch`
-      // round trip, but a transient batch timeout falls back to the old
-      // per-wrap path inside the same recipient-build bound. Both have to fit,
-      // otherwise a slow-but-recoverable pre-publish send is misclassified as a
-      // timeout and retried.
-      expect(
-        DmSendBudget.recipientWrapBuildWithBatchFallback,
-        greaterThan(
-          KeycastRpc.defaultBatchRequestTimeout +
-              KeycastRpc.defaultRequestTimeout * 2,
-        ),
-      );
-    });
-
     test('the sweep guard outlives the whole backstop', () {
       // `Future.timeout` does not cancel, so an abandoned send keeps running
       // past the cap. A guard at or below it re-drives a rumor that is still

--- a/mobile/test/services/outgoing_dm_retry_service_test.dart
+++ b/mobile/test/services/outgoing_dm_retry_service_test.dart
@@ -2064,6 +2064,19 @@ void main() {
       );
     });
 
+    test('the recipient wrap build also covers one server-side wrap '
+        'batch', () {
+      // #7090: a Keycast send now builds both wraps in one `nip17_wrap_batch`
+      // round trip, bounded by the batch transport bound rather than two
+      // single-op ones. That path must fit the same build budget — with room
+      // to spare, since the batch answer still has to be parsed and both
+      // events reconstructed after it lands.
+      expect(
+        DmSendBudget.recipientWrapBuild,
+        greaterThan(KeycastRpc.defaultBatchRequestTimeout),
+      );
+    });
+
     test('the sweep guard outlives the whole backstop', () {
       // `Future.timeout` does not cancel, so an abandoned send keeps running
       // past the cap. A guard at or below it re-drives a rumor that is still


### PR DESCRIPTION
## Description

A 1:1 NIP-17 DM cost **four** remote-signer round trips for custodial (Keycast OAuth-only) accounts: `nip44Encrypt` + `signEvent` for the seal, once for the recipient wrap and again for the NIP-17-mandated self copy. Keycast has shipped `nip17_wrap_batch` since `0adad9c` (2026-07-23) — it builds every recipient's seal and wrap server-side from one shared rumor — and divine-mobile had never called it.

This adopts it, mirroring the receive-side `nip17_unwrap_batch` adoption (#5471): a `GiftWrapBatchWrapper` capability in `nostr_sdk`, implemented by `KeycastRpc`, delegated by `KeycastNostrIdentity`, and consumed at the one seam in `NIP17MessageService._buildBothWraps`. Signers without the capability simply are not one, so the existing per-wrap path stays the fallback and nothing regresses when the verb is absent.

Beyond latency, the batch also collapses this send's **four per-request account-status DB queries and four activity-log writes into one of each** — that is the part that actually relieves the signer's DB-pool contention.

### Three details that are load-bearing, not stylistic

**It sits in the `else` arm, after the isolate check.** A BYOK signer whose isolate hop fails still falls through to the main-isolate builder, which signs in-process at zero round trips. Reaching for the network there would be a regression, not a speed-up.

**It is gated on rumor kinds 14/15.** NIP-17 also blesses kind-7 reactions and wrapped kind-5 deletes, and this service sends both — but the verb rejects them at request level. Verified against a real keycast: a kind-7 rumor returns `HTTP 400 {"error":"Rumor kind must be 14 or 15"}`. Without the gate every reaction would burn a round trip to learn the same answer.

**`nip17WrapBatch` returns `null` only for method-not-found and throws for everything else** — a deliberate divergence from `nip17UnwrapBatch`, which collapses every `RpcException` into `null` and lets its caller latch off permanently. Keycast answers HTTP 400 for *both* an unknown method and ordinary bad params (verified: `Unsupported method: …` vs `Rumor kind must be 14 or 15`, both 400), so status alone cannot classify — this matches on the body. Otherwise one transient 503 would demote a session to four round trips per DM for its whole lifetime.

Every other failure — absent verb, transient error, misshapen response, unusable event, or the recipient's own slot failing — returns to the existing per-wrap path unchanged. Only an explicit "unsupported" answer latches the batch off for the session. Group fan-out calls `sendRumor` per recipient, so it inherits 4→1 per message for free.

### Send-budget re-derivation

The legacy per-wrap `DmSendBudget` numbers remain unchanged. The four-trip shape is still reachable through Amber, NIP-46, a keycast without the verb, a kind-7/5 rumor it refuses, or a per-slot failure, so tightening those bounds to the happy-path batch chain would fail the sends that need the headroom most.

The new batch-first path has its own `DmBatchSendBudget`: one 30s deadline for the complete batch attempt, up to 40s for the two-request fallback, and 5s for local crypto, giving the recipient build 75s and the send backstop 130s. The shared batch deadline includes token refresh and retry instead of opening a fresh 30s window for each step.

This also corrects the premise `recipientWrapBuild` was arguing from. It cited Keycast running 20-30s per single op; that predates keycast's own 8s `HTTP_RPC_HANDLER_TIMEOUT`, which now answers 504 rather than letting a request run that long. The bound still holds, but for a different reason — Amber's NIP-55 approval is human-gated and a bunker has no bound at all. A comment asserting arithmetic long after it went false is the shape #6586 was about.

**Related Issue:** Closes #7090

## Out of Scope

Two pre-existing findings surfaced while verifying this. Neither is caused by this change and neither is fixed here; both are being filed separately.

1. **`KeycastRpc.nip17UnwrapBatch` latches off on transient errors.** It collapses every `RpcException` to `null`, and `DmRepository._serverBatchUnwrapGiftWraps` responds by setting `_batchUnwrapUnsupported` permanently. One 401 after a failed refresh, one 503, or one 504 silently demotes that repository to the 2-RPC-per-wrap drain for the rest of the session. Correctness holds; it is a session-long performance cliff with no signal. This PR deliberately does not reproduce that shape on the wrap side.

2. **Keycast's minor-DM refusal string is not distinguishable from a generic policy denial.** `MINOR_DM_DENIED_MSG` is byte-identical to the generic `PermissionDenied` → `Forbidden("Operation denied by policy")`. `nip17_message_service.dart` matches that exact text and terminalizes the send as `blocked` — permanently, no retry, surfaced as "recipient not permitted by send policy". So an authorization-scope problem is reported to the user as a recipient-blocking decision. Reproduced against a real keycast: on a seeded `policy:social` authorization, signing the kind-13 seal returns `HTTP 403 {"error":"Operation denied by policy"}` because that policy's `allowed_kinds` omit 13. Divine mobile's current auth call sites request `policy:full`, so this is a latent trap for clients that use `policy:social`, not a live defect in the app's standard auth flow. Both the batch path and the existing per-wrap path are refused identically, so this PR changes nothing about it.

## Verification

Static — all green:

- `flutter analyze lib test integration_test` and per-package `analyze lib test` for `nostr_sdk`, `keycast_flutter`, `dm_repository`
- `dm_repository` **94.09%** (gate 93), `keycast_flutter` **88.45%** (gate 44), `nostr_sdk` **51.31%** (gate 20)
- Every line of the new code is covered; the file's remaining uncovered lines are all pre-existing
- Both new guards mutation-checked: deleting the kind gate turns the two kind-7/kind-5 tests red, and changing `else if` to `if` turns the isolate-precedence test red

Empirical — driven against the **real keycast binary** in `local_stack` (`ghcr.io/divinevideo/keycast:latest`, which does carry the verb), by minting a token through the actual OAuth/PKCE flow and POSTing rumors built by the app's own `NIP17MessageService.buildRumor`:

| Probe | Result |
|---|---|
| Verb present, one call | 2 slots, both kind-1059, **distinct ephemeral pubkeys**, correct `p` tags (recipient + self) |
| Canonical id agreement | Dart `json.encode` matches serde_json for ASCII, emoji, quotes/backslashes, newline/tab, control chars, CJK+RTL, solidus/HTML, combining marks + ZWJ — server `verify_id` accepts every one |
| Kind-7 rumor | `400 Rumor kind must be 14 or 15` — the gate is required |
| Unknown verb | `400 Unsupported method: …` — same status as bad params, so body-matching is mandatory |
| Slot isolation | bad recipient mid-array yields `invalid_recipient` while both siblings still produce wraps |
| **Full round trip** | server-built self wrap fed back through `nip17_unwrap_batch` returns a **byte-identical rumor** — same id, content, tags, kind, and correct authenticated sender, for all five nasty-content cases |

The round trip is the one that matters most: the rumor id survives, so receiver-side dedup and the `outgoing_dms` primary key are unaffected, and the sender's cross-device self copy is genuinely recoverable.

One edge found: a **lone unpaired UTF-16 surrogate** in message content is rejected at JSON parsing (`400 … unexpected end of hex escape`) before id verification is even reached. Dart emits `\uD800`, which serde_json refuses. It degrades correctly — throw, fall back, message still sends by the per-wrap path — and is not reachable from a keyboard.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🧹 Code refactor
