### PR TITLE
fix(feed): pop the adult-content prompt through the sheet's own context

### DIFF
--- a/mobile/lib/screens/feed/pooled_age_restricted_retry.dart
+++ b/mobile/lib/screens/feed/pooled_age_restricted_retry.dart
@@ -12,6 +12,7 @@ import 'package:openvine/blocs/video_playback_status/video_playback_status_state
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/models/viewer_auth_result.dart';
 import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/router/navigator_keys.dart';
 import 'package:openvine/screens/content_filters_screen.dart';
 import 'package:openvine/utils/blossom_blob_hash.dart';
 import 'package:openvine/utils/pause_aware_modals.dart';
@@ -235,11 +236,12 @@ Future<void> _promptAdultContentHidden(BuildContext context) async {
   final openFilters = await context.showVideoPausingVineBottomSheet<bool>(
     scrollable: false,
     showHeaderDivider: false,
-    // The sheet outlives the feed item that opened it — the pooled feed
-    // disposes items that scroll out of the pool — so resolving anything
-    // through the caller's context on tap crashed on a defunct element
-    // (#7291). Everything inside the sheet reads from the sheet's own
-    // subtree, which stays mounted for as long as the sheet is up.
+    // The sheet outlives the error overlay that opened it: the overlay is a
+    // conditional child of the feed item, and any non-append-only feed emit
+    // clears the error state behind the open sheet, unmounting it. Resolving
+    // anything through the caller's context on tap then hit a defunct element
+    // and both buttons went inert (#7291). Everything inside the sheet reads
+    // from the sheet's own subtree, which stays mounted while the sheet is up.
     body: Builder(
       builder: (sheetContext) => VineBottomSheetPrompt(
         sticker: DivineStickerName.trafficCone,
@@ -252,8 +254,17 @@ Future<void> _promptAdultContentHidden(BuildContext context) async {
       ),
     ),
   );
-  if (openFilters != true || !context.mounted) return;
-  await context.pushWithVideoPause<void>(ContentFiltersScreen.path);
+  if (openFilters != true) return;
+
+  // Popping the sheet is not enough on its own: the same unmount that made the
+  // buttons inert also leaves the caller's context defunct, so pushing from it
+  // is skipped and the CTA closes the sheet without opening what it names
+  // (#7350). The root navigator outlives every feed item, and go_router wraps
+  // it in an InheritedGoRouter, so a push resolves from there — the same
+  // durable-context route upload_failure_sheet already takes.
+  final target = context.mounted ? context : NavigatorKeys.root.currentContext;
+  if (target == null || !target.mounted) return;
+  await target.pushWithVideoPause<void>(ContentFiltersScreen.path);
 }
 
 /// Surfaces the connectivity-specific message when a remote signer didn't

--- a/mobile/lib/screens/feed/pooled_age_restricted_retry.dart
+++ b/mobile/lib/screens/feed/pooled_age_restricted_retry.dart
@@ -235,16 +235,21 @@ Future<void> _promptAdultContentHidden(BuildContext context) async {
   final openFilters = await context.showVideoPausingVineBottomSheet<bool>(
     scrollable: false,
     showHeaderDivider: false,
-    body: VineBottomSheetPrompt(
-      sticker: DivineStickerName.trafficCone,
-      title: context.l10n.videoErrorAdultContentHiddenTitle,
-      subtitle: context.l10n.videoErrorAdultContentHiddenBody,
-      primaryButtonText: context.l10n.videoErrorAdultContentHiddenAction,
-      onPrimaryPressed: () =>
-          Navigator.of(context, rootNavigator: true).pop(true),
-      secondaryButtonText: context.l10n.commonNotNow,
-      onSecondaryPressed: () =>
-          Navigator.of(context, rootNavigator: true).pop(false),
+    // The sheet outlives the feed item that opened it — the pooled feed
+    // disposes items that scroll out of the pool — so resolving anything
+    // through the caller's context on tap crashed on a defunct element
+    // (#7291). Everything inside the sheet reads from the sheet's own
+    // subtree, which stays mounted for as long as the sheet is up.
+    body: Builder(
+      builder: (sheetContext) => VineBottomSheetPrompt(
+        sticker: DivineStickerName.trafficCone,
+        title: sheetContext.l10n.videoErrorAdultContentHiddenTitle,
+        subtitle: sheetContext.l10n.videoErrorAdultContentHiddenBody,
+        primaryButtonText: sheetContext.l10n.videoErrorAdultContentHiddenAction,
+        onPrimaryPressed: () => Navigator.of(sheetContext).pop(true),
+        secondaryButtonText: sheetContext.l10n.commonNotNow,
+        onSecondaryPressed: () => Navigator.of(sheetContext).pop(false),
+      ),
     ),
   );
   if (openFilters != true || !context.mounted) return;

--- a/mobile/test/screens/feed/pooled_age_restricted_retry_test.dart
+++ b/mobile/test/screens/feed/pooled_age_restricted_retry_test.dart
@@ -593,6 +593,7 @@ void main() {
         final mediaAuthInterceptor = _MockMediaAuthInterceptor();
         final playbackStatusCubit = VideoPlaybackStatusCubit();
         final hostVisible = ValueNotifier(true);
+        late ProviderContainer container;
         addTearDown(playbackStatusCubit.close);
         addTearDown(hostVisible.dispose);
 
@@ -611,6 +612,7 @@ void main() {
             mediaAuthInterceptor: mediaAuthInterceptor,
             playbackStatusCubit: playbackStatusCubit,
             ageVerificationService: _ageService(verified: true),
+            onContainerReady: (value) => container = value,
             hostVisible: hostVisible,
             retryPlayback: (_) => _retryRecovered,
           ),
@@ -630,6 +632,13 @@ void main() {
 
         expect(tester.takeException(), isNull);
         expect(find.text(_adultContentHiddenTitle), findsNothing);
+        // A pop that runs while the host is gone still has to release the
+        // overlay flag, or the feed stays paused for the rest of the session
+        // (#6239).
+        expect(
+          container.read(overlayVisibilityProvider).hasVisibleOverlay,
+          isFalse,
+        );
       },
     );
 
@@ -640,6 +649,7 @@ void main() {
         final mediaAuthInterceptor = _MockMediaAuthInterceptor();
         final playbackStatusCubit = VideoPlaybackStatusCubit();
         final hostVisible = ValueNotifier(true);
+        late ProviderContainer container;
         addTearDown(playbackStatusCubit.close);
         addTearDown(hostVisible.dispose);
 
@@ -658,6 +668,7 @@ void main() {
             mediaAuthInterceptor: mediaAuthInterceptor,
             playbackStatusCubit: playbackStatusCubit,
             ageVerificationService: _ageService(verified: true),
+            onContainerReady: (value) => container = value,
             hostVisible: hostVisible,
             retryPlayback: (_) => _retryRecovered,
           ),
@@ -677,6 +688,12 @@ void main() {
         expect(tester.takeException(), isNull);
         expect(find.text(_adultContentHiddenTitle), findsNothing);
         expect(find.text(_contentFiltersRouteMarker), findsNothing);
+        // Both flags have to be back down: the sheet closed, and the skipped
+        // push must not have latched the page flag on its way out (#6239).
+        expect(
+          container.read(overlayVisibilityProvider).hasVisibleOverlay,
+          isFalse,
+        );
       },
     );
 

--- a/mobile/test/screens/feed/pooled_age_restricted_retry_test.dart
+++ b/mobile/test/screens/feed/pooled_age_restricted_retry_test.dart
@@ -3,6 +3,7 @@
 
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -586,6 +587,100 @@ void main() {
     );
 
     testWidgets(
+      'dismisses the blocked-by-preference sheet after the host feed item is '
+      'disposed',
+      (tester) async {
+        final mediaAuthInterceptor = _MockMediaAuthInterceptor();
+        final playbackStatusCubit = VideoPlaybackStatusCubit();
+        final hostVisible = ValueNotifier(true);
+        addTearDown(playbackStatusCubit.close);
+        addTearDown(hostVisible.dispose);
+
+        when(
+          () => mediaAuthInterceptor.handleUnauthorizedMedia(
+            context: any(named: 'context'),
+            sha256Hash: _sha256,
+            url: _videoUrl,
+            serverUrl: 'https://media.divine.video',
+            category: 'video',
+          ),
+        ).thenAnswer((_) async => const ViewerAuthBlockedByPreference());
+
+        await tester.pumpWidget(
+          _RetryHarness(
+            mediaAuthInterceptor: mediaAuthInterceptor,
+            playbackStatusCubit: playbackStatusCubit,
+            ageVerificationService: _ageService(verified: true),
+            hostVisible: hostVisible,
+            retryPlayback: (_) => _retryRecovered,
+          ),
+        );
+
+        await tester.tap(find.text('Verify'));
+        await tester.pumpAndSettle();
+        expect(find.text(_adultContentHiddenTitle), findsOneWidget);
+
+        // The feed item that opened the sheet scrolls out of the pool and is
+        // disposed while the sheet is still up (#7291).
+        hostVisible.value = false;
+        await tester.pump();
+
+        await tester.tap(find.text(_notNowText));
+        await tester.pumpAndSettle();
+
+        expect(tester.takeException(), isNull);
+        expect(find.text(_adultContentHiddenTitle), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'closes the sheet without navigating when the host feed item is disposed '
+      'before Open Content Filters',
+      (tester) async {
+        final mediaAuthInterceptor = _MockMediaAuthInterceptor();
+        final playbackStatusCubit = VideoPlaybackStatusCubit();
+        final hostVisible = ValueNotifier(true);
+        addTearDown(playbackStatusCubit.close);
+        addTearDown(hostVisible.dispose);
+
+        when(
+          () => mediaAuthInterceptor.handleUnauthorizedMedia(
+            context: any(named: 'context'),
+            sha256Hash: _sha256,
+            url: _videoUrl,
+            serverUrl: 'https://media.divine.video',
+            category: 'video',
+          ),
+        ).thenAnswer((_) async => const ViewerAuthBlockedByPreference());
+
+        await tester.pumpWidget(
+          _RetryHarness(
+            mediaAuthInterceptor: mediaAuthInterceptor,
+            playbackStatusCubit: playbackStatusCubit,
+            ageVerificationService: _ageService(verified: true),
+            hostVisible: hostVisible,
+            retryPlayback: (_) => _retryRecovered,
+          ),
+        );
+
+        await tester.tap(find.text('Verify'));
+        await tester.pumpAndSettle();
+
+        hostVisible.value = false;
+        await tester.pump();
+
+        await tester.tap(find.text(_adultContentHiddenAction));
+        await tester.pumpAndSettle();
+
+        // The sheet still closes; the follow-up push is skipped because the
+        // caller's context is gone, and neither step may throw.
+        expect(tester.takeException(), isNull);
+        expect(find.text(_adultContentHiddenTitle), findsNothing);
+        expect(find.text(_contentFiltersRouteMarker), findsNothing);
+      },
+    );
+
+    testWidgets(
       'surfaces the connectivity message when the remote signer is unreachable',
       (tester) async {
         final mediaAuthInterceptor = _MockMediaAuthInterceptor();
@@ -799,6 +894,7 @@ class _RetryHarness extends StatefulWidget {
     this.video,
     this.ageVerificationService,
     this.onContainerReady,
+    this.hostVisible,
   });
 
   final MediaAuthInterceptor mediaAuthInterceptor;
@@ -807,6 +903,10 @@ class _RetryHarness extends StatefulWidget {
   final VideoEvent? video;
   final AgeVerificationService? ageVerificationService;
   final ValueChanged<ProviderContainer>? onContainerReady;
+
+  /// Drives whether the widget that calls the retry is in the tree, so a test
+  /// can dispose the caller's context the way the pooled feed does.
+  final ValueListenable<bool>? hostVisible;
 
   @override
   State<_RetryHarness> createState() => _RetryHarnessState();
@@ -820,18 +920,24 @@ class _RetryHarnessState extends State<_RetryHarness> {
       GoRoute(
         path: '/',
         builder: (_, _) => Scaffold(
-          body: Consumer(
-            builder: (context, ref, _) {
-              return TextButton(
-                onPressed: () => retryAgeRestrictedPooledVideo(
-                  context: context,
-                  ref: ref,
-                  video: widget.video ?? _video,
-                  index: 0,
-                  resolveSha256: _resolveSha256,
-                  retryPlayback: widget.retryPlayback,
-                ),
-                child: const Text('Verify'),
+          body: ValueListenableBuilder<bool>(
+            valueListenable: widget.hostVisible ?? _hostAlwaysVisible,
+            builder: (_, hostVisible, _) {
+              if (!hostVisible) return const SizedBox.shrink();
+              return Consumer(
+                builder: (context, ref, _) {
+                  return TextButton(
+                    onPressed: () => retryAgeRestrictedPooledVideo(
+                      context: context,
+                      ref: ref,
+                      video: widget.video ?? _video,
+                      index: 0,
+                      resolveSha256: _resolveSha256,
+                      retryPlayback: widget.retryPlayback,
+                    ),
+                    child: const Text('Verify'),
+                  );
+                },
               );
             },
           ),
@@ -926,6 +1032,9 @@ class _AutoRetryHarness extends StatelessWidget {
     );
   }
 }
+
+/// Default for harnesses that never remove the retry caller from the tree.
+final ValueNotifier<bool> _hostAlwaysVisible = ValueNotifier(true);
 
 final _video = VideoEvent(
   id: _videoId,

--- a/mobile/test/screens/feed/pooled_age_restricted_retry_test.dart
+++ b/mobile/test/screens/feed/pooled_age_restricted_retry_test.dart
@@ -643,8 +643,8 @@ void main() {
     );
 
     testWidgets(
-      'closes the sheet without navigating when the host feed item is disposed '
-      'before Open Content Filters',
+      'records the current outcome: Open Content Filters does nothing once '
+      'the host feed item is disposed',
       (tester) async {
         final mediaAuthInterceptor = _MockMediaAuthInterceptor();
         final playbackStatusCubit = VideoPlaybackStatusCubit();
@@ -683,13 +683,19 @@ void main() {
         await tester.tap(find.text(_adultContentHiddenAction));
         await tester.pumpAndSettle();
 
-        // The sheet still closes; the follow-up push is skipped because the
-        // caller's context is gone, and neither step may throw.
+        // This records what the app does today; it is not a claim that the
+        // no-op is the right product behaviour. The CTA pops the sheet, then
+        // the follow-up push is skipped because the caller's context is
+        // defunct by then, so the viewer taps and nothing visible happens.
+        // Making the CTA survive host disposal is a separate change; whoever
+        // does it should flip the marker expectation below and treat that as
+        // expected, not as a regression.
         expect(tester.takeException(), isNull);
         expect(find.text(_adultContentHiddenTitle), findsNothing);
         expect(find.text(_contentFiltersRouteMarker), findsNothing);
-        // Both flags have to be back down: the sheet closed, and the skipped
-        // push must not have latched the page flag on its way out (#6239).
+        // Regardless of that, both flags have to be back down: the sheet
+        // closed, and the skipped push must not have latched the page flag
+        // on its way out (#6239).
         expect(
           container.read(overlayVisibilityProvider).hasVisibleOverlay,
           isFalse,

--- a/mobile/test/screens/feed/pooled_age_restricted_retry_test.dart
+++ b/mobile/test/screens/feed/pooled_age_restricted_retry_test.dart
@@ -938,7 +938,10 @@ class _RetryHarnessState extends State<_RetryHarness> {
         path: '/',
         builder: (_, _) => Scaffold(
           body: ValueListenableBuilder<bool>(
-            valueListenable: widget.hostVisible ?? _hostAlwaysVisible,
+            // A const listenable that never fires, for the harnesses that keep
+            // the retry caller mounted for the whole test.
+            valueListenable:
+                widget.hostVisible ?? const AlwaysStoppedAnimation<bool>(true),
             builder: (_, hostVisible, _) {
               if (!hostVisible) return const SizedBox.shrink();
               return Consumer(
@@ -1049,9 +1052,6 @@ class _AutoRetryHarness extends StatelessWidget {
     );
   }
 }
-
-/// Default for harnesses that never remove the retry caller from the tree.
-final ValueNotifier<bool> _hostAlwaysVisible = ValueNotifier(true);
 
 final _video = VideoEvent(
   id: _videoId,

--- a/mobile/test/screens/feed/pooled_age_restricted_retry_test.dart
+++ b/mobile/test/screens/feed/pooled_age_restricted_retry_test.dart
@@ -687,7 +687,7 @@ void main() {
         // no-op is the right product behaviour. The CTA pops the sheet, then
         // the follow-up push is skipped because the caller's context is
         // defunct by then, so the viewer taps and nothing visible happens.
-        // Making the CTA survive host disposal is a separate change; whoever
+        // Making the CTA survive host disposal is tracked as #7350; whoever
         // does it should flip the marker expectation below and treat that as
         // expected, not as a regression.
         expect(tester.takeException(), isNull);

--- a/mobile/test/screens/feed/pooled_age_restricted_retry_test.dart
+++ b/mobile/test/screens/feed/pooled_age_restricted_retry_test.dart
@@ -623,8 +623,8 @@ void main() {
         await tester.pumpAndSettle();
         expect(find.text(_adultContentHiddenTitle), findsOneWidget);
 
-        // The feed item that opened the sheet scrolls out of the pool and is
-        // disposed while the sheet is still up (#7291).
+        // A non-append-only feed emit clears the error state behind the open
+        // sheet, unmounting the overlay that opened it (#7291).
         hostVisible.value = false;
         await tester.pump();
 

--- a/mobile/test/screens/feed/pooled_age_restricted_retry_test.dart
+++ b/mobile/test/screens/feed/pooled_age_restricted_retry_test.dart
@@ -19,6 +19,7 @@ import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/viewer_auth_result.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/overlay_visibility_provider.dart';
+import 'package:openvine/router/navigator_keys.dart';
 import 'package:openvine/screens/content_filters_screen.dart';
 import 'package:openvine/screens/feed/pooled_age_restricted_retry.dart';
 import 'package:openvine/services/age_verification_service.dart';
@@ -643,8 +644,7 @@ void main() {
     );
 
     testWidgets(
-      'records the current outcome: Open Content Filters does nothing once '
-      'the host feed item is disposed',
+      'opens Content Filters even after the host feed item is disposed',
       (tester) async {
         final mediaAuthInterceptor = _MockMediaAuthInterceptor();
         final playbackStatusCubit = VideoPlaybackStatusCubit();
@@ -683,23 +683,20 @@ void main() {
         await tester.tap(find.text(_adultContentHiddenAction));
         await tester.pumpAndSettle();
 
-        // This records what the app does today; it is not a claim that the
-        // no-op is the right product behaviour. The CTA pops the sheet, then
-        // the follow-up push is skipped because the caller's context is
-        // defunct by then, so the viewer taps and nothing visible happens.
-        // Making the CTA survive host disposal is tracked as #7350; whoever
-        // does it should flip the marker expectation below and treat that as
-        // expected, not as a regression.
+        // The button has to do what it says even when the overlay that opened
+        // the sheet is gone, or the viewer is left with a CTA that only closes
+        // the sheet (#7350). The push falls back to the root navigator here,
+        // since the caller's context is defunct.
         expect(tester.takeException(), isNull);
         expect(find.text(_adultContentHiddenTitle), findsNothing);
-        expect(find.text(_contentFiltersRouteMarker), findsNothing);
-        // Regardless of that, both flags have to be back down: the sheet
-        // closed, and the skipped push must not have latched the page flag
-        // on its way out (#6239).
+        expect(find.text(_contentFiltersRouteMarker), findsOneWidget);
+        // The sheet flag has to come back down on the way through, or the feed
+        // stays paused for the rest of the session (#6239).
         expect(
-          container.read(overlayVisibilityProvider).hasVisibleOverlay,
+          container.read(overlayVisibilityProvider).isBottomSheetOpen,
           isFalse,
         );
+        expect(container.read(overlayVisibilityProvider).isPageOpen, isTrue);
       },
     );
 
@@ -939,6 +936,9 @@ class _RetryHarnessState extends State<_RetryHarness> {
   // A real router, so the sheet's "Open Content Filters" push is exercised
   // rather than stubbed out.
   late final GoRouter _router = GoRouter(
+    // Mirrors app_router.dart, so the CTA's fallback to the root navigator's
+    // context resolves here the way it does in the app.
+    navigatorKey: NavigatorKeys.root,
     routes: [
       GoRoute(
         path: '/',


### PR DESCRIPTION
## Description

The adult-content prompt in `pooled_age_restricted_retry.dart` built its `VineBottomSheetPrompt` eagerly and closed over `_promptAdultContentHidden`'s own `BuildContext` argument — the error overlay's context, not the sheet's. That overlay is a conditional child of the feed item (`infinite_video_feed.dart:1866`, gated on `_errors`), and `didUpdateWidget` tears down every controller and clears `_errors` on any non-append-only feed emit: a refresh, a feed-mode switch, the `VideoFeedBlocklistChanged` at `video_feed_page.dart:322`. The sheet sits on the root navigator and outlives that, so both of its buttons were left resolving `Navigator.of` against a defunct element and threw `Null check operator used on a null value` from `StatefulElement.state`, matching the reported frame at line 247 (`onSecondaryPressed`) exactly. Append-only pagination keeps the common prefix and is safe.

`GestureRecognizer.invokeCallback` catches that error, so the app keeps running — the user-visible symptom is that both buttons go inert while the sheet stays dismissible. It shows up as FATAL in Crashlytics only because `crash_reporting_service.dart:50` routes `FlutterError.onError` to `recordFlutterFatalError`. 53 events / 14 users in 7 days.

The fix wraps the prompt in a `Builder` and resolves everything inside the sheet from the sheet's own subtree context, which stays mounted for as long as the sheet is up. The CTA's follow-up push, which hit the same defunct context one step later, now falls back to the root navigator's context.

Three non-obvious choices:

- **The l10n lookups moved to `sheetContext` too, not just the navigator calls.** A `Builder` body can rebuild after it is first shown (media query, theme, sheet layout), and `context.l10n` is an inherited-widget lookup — leaving those on the caller's context would have swapped one defunct-element failure for another on the next rebuild.
- **`rootNavigator: true` is dropped.** From inside the sheet's subtree the nearest `Navigator` *is* the navigator hosting the sheet route, and `showVideoPausingVineBottomSheet` already pushes with `useRootNavigator: true`, so this resolves to the same navigator today while popping exactly the sheet if that ever changes. This is also what `VineBottomSheet` does internally for its own dismiss paths (`Navigator.of(modalContext).pop()`).
- **The CTA falls back to `NavigatorKeys.root.currentContext` instead of capturing the router up front.** Fixing only the pop would have left "Open Content Filters" closing the sheet and opening nothing, because the guard short-circuits on the same defunct context. The root navigator outlives every feed item and go_router wraps it in an `InheritedGoRouter` (`router.dart:316`), so `pushWithVideoPause` resolves from it — the same durable-context route `upload_failure_sheet` already takes (`main.dart:3032` → `upload_failure_sheet.dart:70`). A live caller's context is still preferred when it is mounted, so the common path is unchanged and no state has to be captured before the await.

**Related Issues:** Closes #7291, closes #7350

## Out of Scope

#6526 tracks the same unguarded-modal-pop shape at other call sites and asks whether a shared helper should own it. Not touched here — this one is confirmed in production and is fixed on its own rather than waiting on that decision.

## Verification

- `dart format` on both changed files — no changes.
- `flutter analyze lib test integration_test` — no issues found.
- `flutter test` over `pooled_age_restricted_retry_test.dart`, `pause_aware_modals_test.dart`, `upload_failure_listener_test.dart` and `video_publish_provider_test.dart` — 58/58 passed. The last two are included because they wire the same `NavigatorKeys.root` global that this test harness now uses.
- Each new regression test was confirmed to fail against the pre-fix code — the pop tests with the production error verbatim (`Actual: _TypeError:<Null check operator used on a null value>`), the CTA test on the missing route — and to pass after it.
- Manual verification on a real Samsung Galaxy: the sheet opens, "Open Content Filters" lands on the filter screen, "Not now" closes without leaving the feed paused.

The two new tests dispose the widget that opened the sheet while the sheet is still up, then tap each button. The harness gained a `hostVisible` listenable to model the overlay being unmounted, and its router now wires `navigatorKey: NavigatorKeys.root` the way `app_router.dart:128` does, so the fallback resolves in the test the way it does in the app. "Not now" must close the sheet and stay on the feed. "Open Content Filters" must close the sheet and land on the Content Filters route rather than doing nothing.

Both tests also pin the overlay flags, whatever the buttons do: a pop that runs through a defunct context must still release `isBottomSheetOpen`, or the feed stays paused for the rest of the session (#6239).

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
