### PR TITLE
fix(app-update): present the update dialog through the root navigator

### DIFF
--- a/mobile/lib/app_update/view/update_dialog.dart
+++ b/mobile/lib/app_update/view/update_dialog.dart
@@ -30,10 +30,11 @@ class _UpdateDialogListenerState extends State<UpdateDialogListener> {
   ///
   /// The wait exists because `GeoBlockingGate` renders a spinner *in place of*
   /// `MaterialApp` while its check is in flight, and `GeoBlockingService` caps
-  /// that check at 10s. Past this budget the gate has resolved without
-  /// producing an app — a geo-blocked user has no navigator to present into
-  /// and never will get one — so waiting further can only re-arm itself for
-  /// the rest of the session.
+  /// that check at 10s. The budget only bites when frames keep arriving while
+  /// no navigator ever appears: a geo-blocked user shown a static screen in
+  /// place of `MaterialApp` produces no frames, so the retry idles on its own
+  /// rather than re-arming. The 30s bound (3x the 10s check) caps that busy
+  /// case, so it can only ever drop a prompt that had no app to appear in.
   static const _navigatorWaitBudget = Duration(seconds: 30);
 
   ({AppUpdateBloc bloc, AppUpdateState state})? _pending;

--- a/mobile/lib/app_update/view/update_dialog.dart
+++ b/mobile/lib/app_update/view/update_dialog.dart
@@ -26,6 +26,20 @@ class UpdateDialogListener extends StatefulWidget {
 }
 
 class _UpdateDialogListenerState extends State<UpdateDialogListener> {
+  /// How long a prompt waits for the root [Navigator] before it is dropped.
+  ///
+  /// The wait exists because `GeoBlockingGate` renders a spinner *in place of*
+  /// `MaterialApp` while its check is in flight, and `GeoBlockingService` caps
+  /// that check at 10s. Past this budget the gate has resolved without
+  /// producing an app — a geo-blocked user has no navigator to present into
+  /// and never will get one — so waiting further can only re-arm itself for
+  /// the rest of the session.
+  static const _navigatorWaitBudget = Duration(seconds: 30);
+
+  ({AppUpdateBloc bloc, AppUpdateState state})? _pending;
+  Duration? _waitingSince;
+  bool _retryArmed = false;
+
   @override
   Widget build(BuildContext context) {
     return BlocListener<AppUpdateBloc, AppUpdateState>(
@@ -45,16 +59,12 @@ class _UpdateDialogListenerState extends State<UpdateDialogListener> {
 
     final navigatorContext = NavigatorKeys.root.currentContext;
     if (navigatorContext == null || !navigatorContext.mounted) {
-      // The update check can resolve before the router's Navigator is in the
-      // tree: GeoBlockingGate renders a spinner in place of MaterialApp while
-      // its own check is in flight. Retry on the next frame so the prompt is
-      // deferred rather than dropped. This does not request a frame of its
-      // own, so the chain stops on its own if the app stops rendering.
-      WidgetsBinding.instance.addPostFrameCallback(
-        (_) => _present(bloc, state),
-      );
+      _deferUntilNavigator(bloc, state);
       return;
     }
+
+    _pending = null;
+    _waitingSince = null;
 
     showDialog<void>(
       context: navigatorContext,
@@ -68,6 +78,42 @@ class _UpdateDialogListenerState extends State<UpdateDialogListener> {
         ),
       ),
     );
+  }
+
+  /// Re-attempts the prompt on later frames until a [Navigator] exists or
+  /// [_navigatorWaitBudget] elapses.
+  ///
+  /// The update check can resolve before the router's Navigator is in the
+  /// tree: `GeoBlockingGate` renders a spinner in place of `MaterialApp` while
+  /// its own check is in flight. `listenWhen` gates on a single urgency
+  /// transition, so a prompt dropped there is dropped for the whole session —
+  /// hence deferring rather than skipping.
+  ///
+  /// Only one retry is ever in flight, and a second transition arriving
+  /// mid-wait supersedes the pending one rather than stacking a second dialog
+  /// on top of the first.
+  void _deferUntilNavigator(AppUpdateBloc bloc, AppUpdateState state) {
+    _pending = (bloc: bloc, state: state);
+    if (_retryArmed) return;
+    _retryArmed = true;
+    WidgetsBinding.instance.addPostFrameCallback(_retryPending);
+  }
+
+  void _retryPending(Duration timeStamp) {
+    _retryArmed = false;
+    final pending = _pending;
+    if (pending == null) return;
+
+    // addPostFrameCallback never requests a frame of its own, so the budget is
+    // measured against the frames the app actually produced.
+    _waitingSince ??= timeStamp;
+    if (timeStamp - _waitingSince! > _navigatorWaitBudget) {
+      _pending = null;
+      _waitingSince = null;
+      return;
+    }
+
+    _present(pending.bloc, pending.state);
   }
 }
 

--- a/mobile/lib/app_update/view/update_dialog.dart
+++ b/mobile/lib/app_update/view/update_dialog.dart
@@ -3,18 +3,29 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:openvine/app_update/app_update.dart';
+import 'package:openvine/router/navigator_keys.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 /// Shows a dialog when the update urgency is moderate or urgent.
 ///
 /// Place this as a [BlocListener] in the widget tree.
-class UpdateDialogListener extends StatelessWidget {
+///
+/// This listener is mounted above [MaterialApp], so its own [BuildContext] has
+/// no [Navigator] ancestor and cannot present a dialog. The dialog is resolved
+/// through [NavigatorKeys.root] instead, the same way `main.dart` resolves the
+/// publish snackbar.
+class UpdateDialogListener extends StatefulWidget {
   /// Creates an [UpdateDialogListener].
   const UpdateDialogListener({required this.child, super.key});
 
   /// The child widget.
   final Widget child;
 
+  @override
+  State<UpdateDialogListener> createState() => _UpdateDialogListenerState();
+}
+
+class _UpdateDialogListenerState extends State<UpdateDialogListener> {
   @override
   Widget build(BuildContext context) {
     return BlocListener<AppUpdateBloc, AppUpdateState>(
@@ -23,21 +34,39 @@ class UpdateDialogListener extends StatelessWidget {
           (curr.urgency == UpdateUrgency.moderate ||
               curr.urgency == UpdateUrgency.urgent) &&
           prev.urgency != curr.urgency,
-      listener: (context, state) {
-        showDialog<void>(
-          context: context,
-          builder: (_) => BlocProvider.value(
-            value: context.read<AppUpdateBloc>(),
-            child: _UpdateDialog(
-              urgency: state.urgency,
-              latestVersion: state.latestVersion ?? '',
-              downloadUrl: state.downloadUrl ?? '',
-              highlights: state.releaseHighlights,
-            ),
-          ),
-        );
-      },
-      child: child,
+      listener: (context, state) =>
+          _present(context.read<AppUpdateBloc>(), state),
+      child: widget.child,
+    );
+  }
+
+  void _present(AppUpdateBloc bloc, AppUpdateState state) {
+    if (!mounted) return;
+
+    final navigatorContext = NavigatorKeys.root.currentContext;
+    if (navigatorContext == null || !navigatorContext.mounted) {
+      // The update check can resolve before the router's Navigator is in the
+      // tree: GeoBlockingGate renders a spinner in place of MaterialApp while
+      // its own check is in flight. Retry on the next frame so the prompt is
+      // deferred rather than dropped. This does not request a frame of its
+      // own, so the chain stops on its own if the app stops rendering.
+      WidgetsBinding.instance.addPostFrameCallback(
+        (_) => _present(bloc, state),
+      );
+      return;
+    }
+
+    showDialog<void>(
+      context: navigatorContext,
+      builder: (_) => BlocProvider.value(
+        value: bloc,
+        child: _UpdateDialog(
+          urgency: state.urgency,
+          latestVersion: state.latestVersion ?? '',
+          downloadUrl: state.downloadUrl ?? '',
+          highlights: state.releaseHighlights,
+        ),
+      ),
     );
   }
 }

--- a/mobile/test/app_update/view/update_dialog_test.dart
+++ b/mobile/test/app_update/view/update_dialog_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:app_update_repository/app_update_repository.dart';
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter/material.dart';
@@ -6,6 +8,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/app_update/app_update.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/router/navigator_keys.dart';
 
 class _MockAppUpdateBloc extends MockBloc<AppUpdateEvent, AppUpdateState>
     implements AppUpdateBloc {}
@@ -18,15 +21,27 @@ void main() {
       bloc = _MockAppUpdateBloc();
     });
 
-    Widget buildSubject() {
-      return MaterialApp(
-        localizationsDelegates: AppLocalizations.localizationsDelegates,
-        supportedLocales: AppLocalizations.supportedLocales,
-        home: BlocProvider<AppUpdateBloc>.value(
-          value: bloc,
-          child: const UpdateDialogListener(
-            child: Scaffold(body: Text('Home')),
-          ),
+    /// Mirrors production topology: the listener sits *above* [MaterialApp],
+    /// so its own [BuildContext] has no [Navigator] ancestor. The app is keyed
+    /// to [NavigatorKeys.root] so the listener can resolve one the same way
+    /// production does.
+    ///
+    /// When [withApp] is false the listener has no [MaterialApp] below it at
+    /// all — the shape GeoBlockingGate produces while its check is in flight,
+    /// where no [Navigator] exists yet.
+    Widget buildSubject({bool withApp = true}) {
+      return BlocProvider<AppUpdateBloc>.value(
+        value: bloc,
+        child: UpdateDialogListener(
+          child: withApp
+              ? MaterialApp(
+                  navigatorKey: NavigatorKeys.root,
+                  localizationsDelegates:
+                      AppLocalizations.localizationsDelegates,
+                  supportedLocales: AppLocalizations.supportedLocales,
+                  home: const Scaffold(body: Text('Home')),
+                )
+              : const SizedBox.shrink(),
         ),
       );
     }
@@ -97,6 +112,37 @@ void main() {
       await tester.tap(find.text(UpdateCopy.notNow));
 
       verify(() => bloc.add(const AppUpdateDismissed())).called(1);
+    });
+
+    testWidgets('defers the dialog until a Navigator exists', (tester) async {
+      final states = StreamController<AppUpdateState>();
+      addTearDown(states.close);
+      whenListen(
+        bloc,
+        states.stream,
+        initialState: const AppUpdateState(status: AppUpdateStatus.resolved),
+      );
+
+      // No MaterialApp below the listener yet, so no Navigator anywhere.
+      await tester.pumpWidget(buildSubject(withApp: false));
+
+      states.add(
+        const AppUpdateState(
+          status: AppUpdateStatus.resolved,
+          urgency: UpdateUrgency.moderate,
+          latestVersion: '1.0.8',
+          downloadUrl: DownloadUrls.github,
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text(UpdateCopy.moderateTitle), findsNothing);
+
+      // The gate opens and the app — with it, the root Navigator — mounts.
+      await tester.pumpWidget(buildSubject());
+      await tester.pumpAndSettle();
+
+      expect(find.text(UpdateCopy.moderateTitle), findsOneWidget);
     });
   });
 }

--- a/mobile/test/app_update/view/update_dialog_test.dart
+++ b/mobile/test/app_update/view/update_dialog_test.dart
@@ -28,7 +28,10 @@ void main() {
     ///
     /// When [withApp] is false the listener has no [MaterialApp] below it at
     /// all — the shape GeoBlockingGate produces while its check is in flight,
-    /// where no [Navigator] exists yet.
+    /// where no [Navigator] exists yet. That stand-in is a spinner rather than
+    /// an inert box on purpose: the gate's own spinner animates, so the app
+    /// keeps producing frames throughout the wait, which is what drives the
+    /// listener's deferred retry.
     Widget buildSubject({bool withApp = true}) {
       return BlocProvider<AppUpdateBloc>.value(
         value: bloc,
@@ -41,7 +44,10 @@ void main() {
                   supportedLocales: AppLocalizations.supportedLocales,
                   home: const Scaffold(body: Text('Home')),
                 )
-              : const SizedBox.shrink(),
+              : const Directionality(
+                  textDirection: TextDirection.ltr,
+                  child: Center(child: CircularProgressIndicator()),
+                ),
         ),
       );
     }
@@ -143,6 +149,38 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text(UpdateCopy.moderateTitle), findsOneWidget);
+    });
+
+    testWidgets('stops waiting when no Navigator ever arrives', (tester) async {
+      final states = StreamController<AppUpdateState>();
+      addTearDown(states.close);
+      whenListen(
+        bloc,
+        states.stream,
+        initialState: const AppUpdateState(status: AppUpdateStatus.resolved),
+      );
+
+      await tester.pumpWidget(buildSubject(withApp: false));
+
+      states.add(
+        const AppUpdateState(
+          status: AppUpdateStatus.resolved,
+          urgency: UpdateUrgency.moderate,
+          latestVersion: '1.0.8',
+          downloadUrl: DownloadUrls.github,
+        ),
+      );
+      await tester.pump();
+
+      // A geo-blocked user is served GeoBlockedScreen and never gets a
+      // MaterialApp, so the retry has to give up rather than re-arm itself on
+      // every frame for the rest of the session.
+      await tester.pump(const Duration(seconds: 31));
+
+      await tester.pumpWidget(buildSubject());
+      await tester.pumpAndSettle();
+
+      expect(find.text(UpdateCopy.moderateTitle), findsNothing);
     });
   });
 }


### PR DESCRIPTION
## Description

`UpdateDialogListener` called `showDialog(context: context, ...)` with its own `BuildContext`. In `main.dart` that listener is mounted **above** `MaterialApp.router` (`MultiBlocProvider` → `EmailVerificationCubit` listener → `UpdateDialogListener` → `UploadFailureListener` → `GeoBlockingGate` → … → `buildApp()`), so its context has no `Navigator` ancestor and `Navigator.of` dereferences null. This is structural, not a race: the prompt threw every single time it fired, which is why 34 users hit it in 7 days and nobody ever saw an update dialog.

The fix resolves the navigator through `NavigatorKeys.root.currentContext` — the house pattern `main.dart` already uses for the publish snackbar and the upload-failure sheets — and passes that context to `showDialog`.

Three non-obvious choices worth calling out:

- **The listener is now a `StatefulWidget`, and a missing navigator defers instead of returning.** A plain "skip when null" guard would swallow the prompt in a window that genuinely exists: `GeoBlockingGate` renders a bare spinner *in place of* `MaterialApp` while its own network check is in flight, so during a cold start there is a stretch with no `Navigator` anywhere in the tree. `AppUpdateBloc`'s check is kicked off at the same first build, and `listenWhen` gates on `prev.urgency != curr.urgency` — a single transition, so a dropped prompt is dropped for the whole session. `_present` therefore re-attempts on a later frame via `addPostFrameCallback`, guarded by `State.mounted`.

- **That wait is bounded at 30s, and single-flight.** `addPostFrameCallback` requests no frame of its own, but that does not make the retry idle here: the gate's spinner animates, so throughout exactly the window the deferral covers the app renders continuously and the retry re-arms on every frame (measured: 32 retries across 31 frames). Left unbounded it would never terminate for a user who never gets a `MaterialApp` at all — a geo-blocked one is served `GeoBlockedScreen` instead — and would keep re-arming for the rest of the session. 30s is three times the 10s cap `GeoBlockingService` puts on its own check, so the budget can only drop a prompt that had no app to appear in. Single-flight because two qualifying transitions arriving mid-wait otherwise armed two independent chains and presented two stacked dialogs; the later prompt now supersedes the pending one instead. The current bloc resolves once per session, so that second case is not reachable today — the guard is there so the mechanism does not depend on it.

- **The bloc is captured before presenting, not read inside the dialog builder.** The builder previously closed over the listener's context; with the presentation potentially deferred by a frame, reading a captured `BuildContext` later is exactly the trap being fixed. `context.read<AppUpdateBloc>()` now happens eagerly in the listener callback and the instance is passed down. The captured bloc cannot outlive its provider here: the listener is a descendant of the same `MultiBlocProvider` subtree, so it unmounts before that bloc can close, and `_present` returns early once unmounted.

This dialog draws its copy from `UpdateCopy` constants rather than `context.l10n`, so it does not touch the root-context localization lookup that #7289 covers.

**Test topology was the reason this shipped.** The existing tests mounted `UpdateDialogListener` as `MaterialApp.home` — inside the Navigator, the one shape production never has. The harness now mirrors production: the listener wraps a `MaterialApp` keyed to `NavigatorKeys.root`, matching how `test/widgets/upload_failure_listener_test.dart` already sets up the same class of listener. The pre-navigator stand-in is a spinner rather than an inert box, because an inert box produces no frames and the deferred retry then never advances — with `SizedBox.shrink()` the deferral tests passed without exercising the retry path at all.

All five tests fail on `origin/main`, with `No MaterialLocalizations found`: `showDialog` asserts on localizations before it reaches `Navigator.of`, so in a debug widget test that assert fires first. The `Null check operator used on a null value` seen in Crashlytics is the same root cause in release, where the assert is compiled out and `Navigator.of`'s `navigator!` is reached.

**Related Issue:** Closes #7292

## Out of Scope

- #7289 (`context.l10n` on the root navigator context in `main.dart`) — separate crash, separate call site, untouched here.
- `UpdateCopy`'s hardcoded English strings are pre-existing l10n debt and are not part of this fix.
- The dialog's raw `TextStyle` / Material button usage is pre-existing design-system debt; no ceiling key grew.

## Verification

- `dart format lib/app_update/view/update_dialog.dart test/app_update/view/update_dialog_test.dart` — clean, 0 changed.
- `flutter analyze lib test integration_test` — No issues found.
- `flutter test test/app_update test/widgets/upload_failure_listener_test.dart test/providers/video_publish_provider_test.dart` — 50 passed. The latter two are included because they share the `NavigatorKeys.root` global key; no cross-test interference.
- Reverted `update_dialog.dart` to its `origin/main` state and re-ran the suite to confirm the regression tests fail without the fix: all 5 red, then green again with the fix restored.
- Reverted only the retry bound and re-ran: `stops waiting when no Navigator ever arrives` red, the other four green.
- `bash scripts/check_raw_dialog_ceiling.sh` — OK, no key grew (the file still has exactly one `showDialog`).
- Manual verification on a real Samsung Galaxy: pending (owner).

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
