### PR TITLE
fix(profile): keep the session-expired sheet working after the header unmounts

### DIFF
--- a/mobile/lib/widgets/profile/profile_header_widget.dart
+++ b/mobile/lib/widgets/profile/profile_header_widget.dart
@@ -515,8 +515,14 @@ class _ProfileHeaderWidgetState extends ConsumerState<ProfileHeaderWidget> {
       },
       secondaryButtonText: l10n.profileMaybeLaterLabel,
       onSecondaryPressed: () async {
-        await dismissDivineLoginBanner(prefs, userIdHex);
+        // Close first, persist after: the sheet stays tappable for as long as
+        // the write is in flight, and this is a sheet users are known to tap
+        // repeatedly (#7297), so a second tap would pop the screen underneath.
+        // Awaiting first buys nothing — `setInt` updates the in-memory
+        // SharedPreferences cache synchronously, so the dismissal is already
+        // visible to `isDivineLoginBannerDismissed` before the pop.
         navigator.pop();
+        await dismissDivineLoginBanner(prefs, userIdHex);
       },
     );
   }

--- a/mobile/lib/widgets/profile/profile_header_widget.dart
+++ b/mobile/lib/widgets/profile/profile_header_widget.dart
@@ -11,6 +11,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:models/models.dart';
+import 'package:openvine/blocs/background_publish/background_publish_bloc.dart';
 import 'package:openvine/blocs/my_profile/my_profile_bloc.dart';
 import 'package:openvine/blocs/other_profile/other_profile_bloc.dart';
 import 'package:openvine/constants/semantic_ids.dart';
@@ -484,6 +485,17 @@ class _ProfileHeaderWidgetState extends ConsumerState<ProfileHeaderWidget> {
     String userIdHex,
   ) {
     final l10n = context.l10n;
+    // The sheet is a route of its own, so it outlives this widget: the
+    // profile content unmounts as soon as the shell route's URL leaves the
+    // profile, while the sheet stays on screen and stays tappable. Resolve
+    // every dependency here, where the header is still mounted — reading
+    // `ref` or looking up an ancestor from a button callback throws once the
+    // header is gone (#7297).
+    final authService = ref.read(authServiceProvider);
+    final prefs = ref.read(sharedPreferencesProvider);
+    final publishBloc = context.read<BackgroundPublishBloc>();
+    final navigator = Navigator.of(context);
+
     VineBottomSheetPrompt.show(
       context: context,
       sticker: DivineStickerName.skeletonKey,
@@ -491,22 +503,20 @@ class _ProfileHeaderWidgetState extends ConsumerState<ProfileHeaderWidget> {
       subtitle: l10n.profileSignInToRestore,
       primaryButtonText: l10n.profileSignInButton,
       onPrimaryPressed: () async {
-        Navigator.of(context).pop();
-        final authService = ref.read(authServiceProvider);
+        navigator.pop();
         final refreshed = await authService.tryRefreshExpiredSession();
         if (!context.mounted) return;
         if (refreshed) return;
 
         _deferredLoginOptionsNavigator.goAfterUploadsComplete(
           context: context,
-          publishBloc: context.read(),
+          publishBloc: publishBloc,
         );
       },
       secondaryButtonText: l10n.profileMaybeLaterLabel,
       onSecondaryPressed: () async {
-        final prefs = ref.read(sharedPreferencesProvider);
         await dismissDivineLoginBanner(prefs, userIdHex);
-        if (context.mounted) Navigator.of(context).pop();
+        navigator.pop();
       },
     );
   }

--- a/mobile/test/widgets/profile/profile_header_widget_test.dart
+++ b/mobile/test/widgets/profile/profile_header_widget_test.dart
@@ -166,6 +166,10 @@ class MockAuthService extends Mock implements AuthService {
   final bool isRpcUpgradeInProgressValue;
   final bool tryRefreshResult;
 
+  /// Number of times [tryRefreshExpiredSession] was called. The override below
+  /// bypasses `noSuchMethod`, so mocktail's `verify` cannot see these calls.
+  int tryRefreshCallCount = 0;
+
   @override
   bool get isAnonymous => isAnonymousValue;
 
@@ -186,7 +190,10 @@ class MockAuthService extends Mock implements AuthService {
   bool get isRpcUpgradeInProgress => isRpcUpgradeInProgressValue;
 
   @override
-  Future<bool> tryRefreshExpiredSession() async => tryRefreshResult;
+  Future<bool> tryRefreshExpiredSession() async {
+    tryRefreshCallCount++;
+    return tryRefreshResult;
+  }
 }
 
 const String testUserHex = syntheticTestPubkey;
@@ -334,13 +341,18 @@ void main() {
       ThemeData? theme,
       bool disableAnimations = false,
       bool renderHeader = true,
+      MockAuthService? authService,
     }) {
-      final authService = MockAuthService(
-        isAnonymousValue: isAnonymous,
-        hasExpiredOAuthSessionValue: hasExpiredSession,
-        isRpcUpgradeInProgressValue: isRpcUpgradeInProgress,
-        tryRefreshResult: tryRefreshResult,
-      );
+      // Pass authService when the test needs the same instance across pumps —
+      // e.g. to read tryRefreshCallCount after the header has been unmounted.
+      final effectiveAuthService =
+          authService ??
+          MockAuthService(
+            isAnonymousValue: isAnonymous,
+            hasExpiredOAuthSessionValue: hasExpiredSession,
+            isRpcUpgradeInProgressValue: isRpcUpgradeInProgress,
+            tryRefreshResult: tryRefreshResult,
+          );
 
       final mockPublishBloc = _MockBackgroundPublishBloc();
       final publishState =
@@ -434,7 +446,7 @@ void main() {
                 ? Stream.value(profileStats)
                 : const Stream<ProfileStats?>.empty(),
           ),
-          authServiceProvider.overrideWithValue(authService),
+          authServiceProvider.overrideWithValue(effectiveAuthService),
           badgeRepositoryProvider.overrideWithValue(badgeRepository),
           currentAuthStateProvider.overrideWith(
             (ref) => AuthState.authenticated,
@@ -2615,6 +2627,7 @@ void main() {
         final prefs = await SharedPreferences.getInstance();
         final mockGoRouter = MockGoRouter();
         when(() => mockGoRouter.go(any())).thenReturn(null);
+        final authService = MockAuthService(hasExpiredOAuthSessionValue: true);
 
         await tester.pumpWidget(
           buildTestWidget(
@@ -2624,6 +2637,7 @@ void main() {
             hasExpiredSession: true,
             sharedPreferences: prefs,
             goRouter: mockGoRouter,
+            authService: authService,
           ),
         );
         await tester.pumpAndSettle();
@@ -2639,6 +2653,7 @@ void main() {
             hasExpiredSession: true,
             sharedPreferences: prefs,
             goRouter: mockGoRouter,
+            authService: authService,
             renderHeader: false,
           ),
         );
@@ -2657,6 +2672,7 @@ void main() {
           find.byType(VineBottomSheetPrompt),
           findsNWidgets(openSheets - 1),
         );
+        expect(authService.tryRefreshCallCount, 1);
         verifyNever(() => mockGoRouter.go(any()));
       });
     });

--- a/mobile/test/widgets/profile/profile_header_widget_test.dart
+++ b/mobile/test/widgets/profile/profile_header_widget_test.dart
@@ -2501,6 +2501,46 @@ void main() {
         },
       );
 
+      testWidgets('"Maybe later" closes the sheet and persists the dismissal', (
+        tester,
+      ) async {
+        // The ordinary, still-mounted path. Nothing asserted the outcome of
+        // this tap before #7297 reworked the callback.
+        final testProfile = createTestProfile(displayName: 'Test User');
+        SharedPreferences.setMockInitialValues({});
+        final prefs = await SharedPreferences.getInstance();
+
+        await tester.pumpWidget(
+          buildTestWidget(
+            userIdHex: testUserHex,
+            isOwnProfile: true,
+            profile: testProfile,
+            hasExpiredSession: true,
+            sharedPreferences: prefs,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        final openSheets = tester
+            .widgetList(find.byType(VineBottomSheetPrompt))
+            .length;
+        expect(openSheets, greaterThan(0));
+
+        await tester.tap(find.text(l10n.profileMaybeLaterLabel).last);
+        await tester.pumpAndSettle();
+
+        expect(tester.takeException(), isNull);
+        expect(
+          prefs.getInt('$_dismissedDivineLoginBannerPrefix$testUserHex'),
+          isNotNull,
+        );
+        expect(
+          find.byType(VineBottomSheetPrompt),
+          findsNWidgets(openSheets - 1),
+        );
+      });
+
       testWidgets('dismisses via "Maybe later" after the header unmounts', (
         tester,
       ) async {

--- a/mobile/test/widgets/profile/profile_header_widget_test.dart
+++ b/mobile/test/widgets/profile/profile_header_widget_test.dart
@@ -333,6 +333,7 @@ void main() {
       bool monetizationLinksEnabled = false,
       ThemeData? theme,
       bool disableAnimations = false,
+      bool renderHeader = true,
     }) {
       final authService = MockAuthService(
         isAnonymousValue: isAnonymous,
@@ -355,15 +356,19 @@ void main() {
         () => badgeRepository.loadAcceptedBadgesForProfile(any()),
       ).thenAnswer((_) async => acceptedProfileBadges);
 
-      Widget header = ProfileHeaderWidget(
-        userIdHex: userIdHex,
-        isOwnProfile: isOwnProfile,
-        videoCount: videoCount,
-        profile: suppliedProfile,
-        profileStats: profileStats,
-        displayNameHint: displayNameHint,
-        avatarUrlHint: avatarUrlHint,
-      );
+      // renderHeader: false keeps the surrounding tree (and any route already
+      // pushed on the navigator) intact while the header itself unmounts.
+      Widget header = renderHeader
+          ? ProfileHeaderWidget(
+              userIdHex: userIdHex,
+              isOwnProfile: isOwnProfile,
+              videoCount: videoCount,
+              profile: suppliedProfile,
+              profileStats: profileStats,
+              displayNameHint: displayNameHint,
+              avatarUrlHint: avatarUrlHint,
+            )
+          : const SizedBox.shrink();
 
       if (isOwnProfile) {
         if (provideMyProfileBloc) {
@@ -2495,6 +2500,125 @@ void main() {
           ).called(1);
         },
       );
+
+      testWidgets('dismisses via "Maybe later" after the header unmounts', (
+        tester,
+      ) async {
+        // Regression for #7297: the sheet is a route, so it stays on screen
+        // and tappable after the header unmounts (the profile shell route
+        // collapses its content as soon as the URL moves on). The buttons
+        // resolved `ref` at tap time, so the tap threw `Using "ref" when a
+        // widget is about to or has been unmounted is unsafe` and the
+        // dismissal was silently dropped.
+        final testProfile = createTestProfile(displayName: 'Test User');
+        SharedPreferences.setMockInitialValues({});
+        final prefs = await SharedPreferences.getInstance();
+
+        await tester.pumpWidget(
+          buildTestWidget(
+            userIdHex: testUserHex,
+            isOwnProfile: true,
+            profile: testProfile,
+            hasExpiredSession: true,
+            sharedPreferences: prefs,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        expect(find.text(l10n.profileSessionExpired), findsWidgets);
+
+        // Unmount the header, leaving the sheet route standing.
+        await tester.pumpWidget(
+          buildTestWidget(
+            userIdHex: testUserHex,
+            isOwnProfile: true,
+            profile: testProfile,
+            hasExpiredSession: true,
+            sharedPreferences: prefs,
+            renderHeader: false,
+          ),
+        );
+        await tester.pumpAndSettle();
+        expect(find.byType(ProfileHeaderWidget), findsNothing);
+        // The header re-shows the sheet on every qualifying build, so more
+        // than one can be stacked. Count them and assert the tapped one goes.
+        final openSheets = tester
+            .widgetList(find.byType(VineBottomSheetPrompt))
+            .length;
+        expect(openSheets, greaterThan(0));
+
+        await tester.tap(find.text(l10n.profileMaybeLaterLabel).last);
+        await tester.pumpAndSettle();
+
+        expect(tester.takeException(), isNull);
+        expect(
+          prefs.getInt('$_dismissedDivineLoginBannerPrefix$testUserHex'),
+          isNotNull,
+        );
+        expect(
+          find.byType(VineBottomSheetPrompt),
+          findsNWidgets(openSheets - 1),
+        );
+      });
+
+      testWidgets('signs in from the sheet after the header unmounts', (
+        tester,
+      ) async {
+        // Regression for #7297, primary action: the tap ran
+        // `Navigator.of(context)` on the unmounted header's context. The sheet
+        // must close and the refresh must run; navigation to login-options is
+        // deliberately abandoned, because the deferred navigator is disposed
+        // with the header and the user has already moved on to another screen.
+        final testProfile = createTestProfile(displayName: 'Test User');
+        SharedPreferences.setMockInitialValues({});
+        final prefs = await SharedPreferences.getInstance();
+        final mockGoRouter = MockGoRouter();
+        when(() => mockGoRouter.go(any())).thenReturn(null);
+
+        await tester.pumpWidget(
+          buildTestWidget(
+            userIdHex: testUserHex,
+            isOwnProfile: true,
+            profile: testProfile,
+            hasExpiredSession: true,
+            sharedPreferences: prefs,
+            goRouter: mockGoRouter,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        expect(find.text(l10n.profileSessionExpired), findsWidgets);
+
+        await tester.pumpWidget(
+          buildTestWidget(
+            userIdHex: testUserHex,
+            isOwnProfile: true,
+            profile: testProfile,
+            hasExpiredSession: true,
+            sharedPreferences: prefs,
+            goRouter: mockGoRouter,
+            renderHeader: false,
+          ),
+        );
+        await tester.pumpAndSettle();
+        expect(find.byType(ProfileHeaderWidget), findsNothing);
+        final openSheets = tester
+            .widgetList(find.byType(VineBottomSheetPrompt))
+            .length;
+        expect(openSheets, greaterThan(0));
+
+        await tester.tap(find.text(l10n.profileSignInButton).last);
+        await tester.pumpAndSettle();
+
+        expect(tester.takeException(), isNull);
+        expect(
+          find.byType(VineBottomSheetPrompt),
+          findsNWidgets(openSheets - 1),
+        );
+        verifyNever(() => mockGoRouter.go(any()));
+      });
     });
 
     group('MyProfile state fallbacks (own profile)', () {


### PR DESCRIPTION
## Description

The session-expired sheet is a route, so it outlives the `ProfileHeaderWidget` that opened it. Its button callbacks resolved their dependencies at *tap* time — `ref.read(...)`, `Navigator.of(context)`, `context.read()` — so once the header had unmounted the very first statement of a callback threw and the tap did nothing at all.

The Crashlytics stack is fully synchronous from `_InkResponseState.handleTap` — no async gap — and the blamed line in the 1.0.17+813 build (`profile_header_widget.dart:484`, commit `0ad2b3e`) is `final prefs = ref.read(sharedPreferencesProvider);`, the first line of `onSecondaryPressed`. So the crashing button is **"Maybe later"**, not "Sign in", and the `await` in the "Sign in" path is not involved: the widget was already gone when the button was tapped. The issue's hypothesis (dependency read *after* an await) does not match the trace, so the fix is aimed at the real shape of the bug — the sheet outliving its opener. The sample event backs this up: 3 events within 2 seconds and breadcrumbs showing the user on `pooled_video_feed`, i.e. someone tapping a stranded sheet repeatedly while nothing happened.

The header can unmount with the sheet still on screen because the profile lives in a shell route whose content collapses as soon as the URL leaves the profile; the sheet is pushed on that navigator with `useRootNavigator: false` and simply stays.

Fix: resolve `authService`, `prefs`, the `BackgroundPublishBloc` and the `NavigatorState` once in `_showSessionExpiredSheet`, where the header is guaranteed mounted, and let the callbacks close over plain values. Beyond silencing the exception this restores the intended behaviour — "Maybe later" now actually persists the dismissal and closes the sheet instead of silently dropping both.

Capturing the `NavigatorState` is safe by construction: `VineBottomSheet.show` pushes with `useRootNavigator: false`, i.e. onto the very navigator `Navigator.of(context)` resolves to here, and a navigator cannot be disposed while it is still showing the sheet the user is tapping.

"Maybe later" also pops **before** persisting rather than after. The old order left the sheet tappable for the whole `SharedPreferences` round trip, and this is precisely a sheet users are observed to tap repeatedly, so a second tap would have popped the screen underneath. Awaiting first bought nothing — `setInt` updates the in-memory cache synchronously, so the dismissal is visible to `isDivineLoginBannerDismissed` before the pop either way.

The `context.mounted` guard in the "Sign in" path stays: when the header is gone, `DeferredLoginOptionsNavigator` has already been disposed with the state, so the deferred navigation is deliberately abandoned rather than yanking the user off whatever screen they moved on to. That is the issue's stated expectation ("completes or is abandoned without an exception").

**Related Issue:** Closes #7297

## Out of Scope

- The header re-shows the sheet from a post-frame callback on **every** qualifying build, so identical sheets can stack (visible in the tests — two `VineBottomSheetPrompt`s after one settle). Pre-existing, unrelated to the crash, not touched here; tracked in #7308. The tests count the open sheets rather than assuming one, so they stay valid once that is fixed.
- `DeferredLoginOptionsNavigator.goAfterUploadsComplete` still takes a `BuildContext`; the same latent pattern exists in `settings_screen.dart`. Changing its signature to take a `GoRouter` would spread this fix across three files for no user-visible gain, so it stays as is.

## Verification

- `flutter analyze lib test integration_test` — no issues
- `flutter test test/widgets/profile/profile_header_widget_test.dart` — 82 passed
- `flutter test test/widgets/profile test/screens/profile_setup` — 389 passed
- Both new regression tests were confirmed to fail with the fix reverted: "Maybe later" with the exact reported `Bad state: Using "ref" when a widget is about to or has been unmounted is unsafe`, "Sign in" with `Null check operator used on a null value` thrown from `Navigator.of` reading the state of the unmounted header element.
- The new still-mounted "Maybe later" test was confirmed to fail when the `navigator.pop()` is dropped.
- Manual verification on a real Samsung Galaxy: pending (owner).

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
