### PR TITLE
fix(media-cache): stop reporting recoverable image-cache IO failures

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -1169,19 +1169,21 @@ Future<void> _startOpenVineApp() async {
       return;
     }
 
-    final recoverableReason = classifyRecoverableFlutterError(details);
-    if (recoverableReason != null) {
+    final recoverable = classifyRecoverableFlutterError(details);
+    if (recoverable != null) {
       Log.warning(
-        '$recoverableReason (non-fatal): ${details.exception}',
+        '${recoverable.reason} (non-fatal): ${details.exception}',
         name: 'Main',
       );
-      unawaited(
-        CrashReportingService.instance.recordError(
-          details.exception,
-          details.stack,
-          reason: recoverableReason,
-        ),
-      );
+      if (recoverable.report) {
+        unawaited(
+          CrashReportingService.instance.recordError(
+            details.exception,
+            details.stack,
+            reason: recoverable.reason,
+          ),
+        );
+      }
       FlutterError.presentError(details);
       return;
     }

--- a/mobile/lib/utils/recoverable_flutter_error.dart
+++ b/mobile/lib/utils/recoverable_flutter_error.dart
@@ -11,8 +11,22 @@ const _recoverableMediaHosts = <String>{
   'cdn.vine.co',
 };
 
-/// Returns a non-fatal reporting reason when a Flutter error is one the app
-/// recovers from on its own, or `null` when it must stay fatal.
+/// How the app should treat a Flutter error it recovers from on its own.
+typedef RecoverableFlutterError = ({
+  /// The Crashlytics reason describing the recovery.
+  String reason,
+
+  /// Whether the error is still worth a non-fatal Crashlytics report.
+  ///
+  /// `false` for expected IO conditions: per the decision matrix in
+  /// `.claude/rules/error_handling.md`, network and IO failures are not
+  /// reportable, so recording them only drowns real bugs in the dashboard.
+  /// The error is still logged and still presented.
+  bool report,
+});
+
+/// Returns how to handle a Flutter error the app recovers from on its own, or
+/// `null` when it must stay fatal.
 ///
 /// The signature checks below match against Flutter/Dart SDK internals:
 /// library paths, context descriptions (for example `_network_image_io` and
@@ -23,7 +37,9 @@ const _recoverableMediaHosts = <String>{
 /// `StackTrace.toString()`: building with `--obfuscate` *or*
 /// `--split-debug-info` (which implies `--dwarf-stack-traces`) strips them and
 /// silently sends those errors back to the fatal path.
-String? classifyRecoverableFlutterError(FlutterErrorDetails details) {
+RecoverableFlutterError? classifyRecoverableFlutterError(
+  FlutterErrorDetails details,
+) {
   final error = details.exception.toString();
   final library = details.library ?? '';
   final context = details.context?.toDescription() ?? '';
@@ -64,16 +80,22 @@ String? classifyRecoverableFlutterError(FlutterErrorDetails details) {
   // the widget falls back to a placeholder. It is host-agnostic because dead
   // Vine avatars are commonly proxied through web.archive.org, which is not a
   // recoverable-media host.
-  final isMediaCacheLoadFailure =
-      details.exception is MediaCacheImageLoadException;
+  //
+  // Reported as a plain IO failure and therefore never sent to Crashlytics
+  // (#7298): the exception carries no information beyond "this URL is dead",
+  // which the avatar/thumbnail negative caches already act on. It accounted
+  // for 13 events across 10 users in a week with nothing actionable in any
+  // of them.
+  if (details.exception is MediaCacheImageLoadException) {
+    return (reason: _recoverableMediaLoadReason, report: false);
+  }
 
   if (isImageHttpFailure ||
       isMediaHostLookup ||
       isInterruptedMediaDownload ||
       isMissingHttpHost ||
-      isInvalidImageData ||
-      isMediaCacheLoadFailure) {
-    return _recoverableMediaLoadReason;
+      isInvalidImageData) {
+    return (reason: _recoverableMediaLoadReason, report: true);
   }
 
   // A hero flight measures its destination hero in a post-frame callback, and
@@ -88,7 +110,7 @@ String? classifyRecoverableFlutterError(FlutterErrorDetails details) {
       (details.stack?.toString().contains('HeroController') ?? false);
 
   if (isHeroFlightLayoutFailure) {
-    return _recoverableHeroFlightReason;
+    return (reason: _recoverableHeroFlightReason, report: true);
   }
 
   return null;

--- a/mobile/lib/utils/recoverable_flutter_error.dart
+++ b/mobile/lib/utils/recoverable_flutter_error.dart
@@ -18,10 +18,12 @@ typedef RecoverableFlutterError = ({
 
   /// Whether the error is still worth a non-fatal Crashlytics report.
   ///
-  /// `false` for expected IO conditions: per the decision matrix in
-  /// `.claude/rules/error_handling.md`, network and IO failures are not
-  /// reportable, so recording them only drowns real bugs in the dashboard.
-  /// The error is still logged and still presented.
+  /// `false` where the error carries nothing actionable. The decision
+  /// matrix in `.claude/rules/error_handling.md` puts IO failures outside
+  /// Crashlytics, but only the download-without-file branch is silenced so
+  /// far (#7298) — the other recoverable IO signatures still report, and
+  /// widening that is a separate call. The error is logged and presented
+  /// either way.
   bool report,
 });
 

--- a/mobile/packages/media_cache/lib/src/cancellable_downloader.dart
+++ b/mobile/packages/media_cache/lib/src/cancellable_downloader.dart
@@ -150,11 +150,13 @@ class _HttpDownload implements CancellableDownload {
 
   final _completer = Completer<CancellableDownloadResult>();
   final _abortCompleter = Completer<void>();
-  // ignore: cancel_subscriptions, owned across cancel/stream lifecycle methods.
+
+  /// Owned across the cancel / write-failure / stream lifecycle methods.
   StreamSubscription<List<int>>? _subscription;
   IOSink? _sink;
   bool _isCancelled = false;
   bool _isDone = false;
+  bool _hasWriteFailure = false;
 
   @override
   Future<CancellableDownloadResult> get result => _completer.future;
@@ -219,7 +221,17 @@ class _HttpDownload implements CancellableDownload {
       if (!parent.existsSync()) {
         await parent.create(recursive: true);
       }
-      _sink = _file.openWrite();
+      final sink = _file.openWrite();
+      _sink = sink;
+      // `openWrite()` opens the file lazily and nothing observes that open
+      // until the first write, so a failure — an over-long cache filename
+      // (ENAMETOOLONG), a purged or read-only directory — escapes to the
+      // enclosing zone and is reported as a crash. Watch `done` and then
+      // engage the sink immediately, which hands the pending open a listener
+      // before the first response chunk can arrive. The zero-length write
+      // leaves the file itself untouched.
+      unawaited(sink.done.then<void>((_) {}, onError: _failWithWriteError));
+      sink.add(const <int>[]);
       _subscription = response.stream.listen(
         (chunk) {
           if (_isCancelled) return;
@@ -247,12 +259,17 @@ class _HttpDownload implements CancellableDownload {
           // into this window and delete a successfully written file.
           _isDone = true;
           try {
-            await _sink?.flush();
+            // `close()` flushes the buffered writes and returns `done`, so a
+            // failed open or write surfaces here. `flush()` must not be used:
+            // once the sink has already reported its failure, it never
+            // completes and would strand this download forever.
             await _sink?.close();
-          } on Object catch (_) {
-            // Best-effort.
+          } on Object catch (error) {
+            await _failWithWriteError(error);
+            return;
           }
           _sink = null;
+          if (_hasWriteFailure) return;
           // coverage:ignore-start
           if (_isCancelled) {
             await _safeDelete();
@@ -290,6 +307,29 @@ class _HttpDownload implements CancellableDownload {
       await _cleanupPartial();
       _safeComplete(const CancellableDownloadResult(file: null));
     }
+  }
+
+  /// Settles this download as a failure after the target file could not be
+  /// opened or written, discarding any partial bytes. Idempotent, and safe to
+  /// call from both the sink's `done` handler and the response stream's
+  /// `onDone` handler.
+  Future<void> _failWithWriteError(Object error) async {
+    final alreadyFailed = _hasWriteFailure;
+    _hasWriteFailure = true;
+    // Drop the sink before anything else can await it: a sink that has
+    // already reported its failure never completes `flush()`.
+    _sink = null;
+    if (!alreadyFailed && !_isCancelled) {
+      Log.warning(
+        'CancellableDownload: write failed for $_url: $error',
+        name: 'MediaCache',
+        category: LogCategory.video,
+      );
+    }
+    await _subscription?.cancel();
+    _subscription = null;
+    await _safeDelete();
+    _safeComplete(const CancellableDownloadResult(file: null));
   }
 
   Future<void> _cleanupPartial() async {

--- a/mobile/packages/media_cache/lib/src/cancellable_downloader.dart
+++ b/mobile/packages/media_cache/lib/src/cancellable_downloader.dart
@@ -238,7 +238,9 @@ class _HttpDownload implements CancellableDownload {
           try {
             _sink?.add(chunk);
           } on Object catch (_) {
-            // Sink errors surface in onError.
+            // Only guards the StateError from adding to a sink a
+            // concurrent cancel already closed. A failed write surfaces
+            // on the sink's `done` future instead.
           }
         },
         onError: (Object error) async {

--- a/mobile/packages/media_cache/test/src/cancellable_downloader_test.dart
+++ b/mobile/packages/media_cache/test/src/cancellable_downloader_test.dart
@@ -103,6 +103,81 @@ void main() {
       expect(download.isCancelled, isFalse);
     });
 
+    // Crashlytics 8ddf179042f3ca20d8b4c90ae75f8f77 (#7298): image cache keys
+    // are full URLs, and a web.archive.org-proxied Vine avatar produces a
+    // filename past the 255-byte NAME_MAX of APFS and ext4. `File.openWrite()`
+    // opens lazily, so the resulting ENAMETOOLONG surfaces only on the sink's
+    // `done` future. Nothing observed it, so it reached Crashlytics through
+    // runZonedGuarded, and the download settled wrongly on top of that:
+    // whichever of the two orderings below occurred, the caller was misled.
+    group('when the target file cannot be opened', () {
+      late File target;
+
+      setUp(() {
+        target = File('${tempDir.path}/${'a' * 300}.jpg');
+      });
+
+      test('completes with null when the response ends before the sink '
+          'reports its failure', () async {
+        final client = _CallbackClient(
+          (_) async => http.StreamedResponse(
+            Stream<List<int>>.fromIterable([utf8.encode('payload')]),
+            200,
+          ),
+        );
+        final downloader = HttpCancellableDownloader(client);
+
+        final zoneErrors = <Object>[];
+        File? resolved;
+        await runZonedGuarded(() async {
+          resolved = await downloader
+              .download(
+                url: 'https://example.com/avatar.jpg',
+                targetFile: target,
+              )
+              .file;
+          // Let any straggling sink error land inside the guarded zone.
+          await pumpEventQueue();
+        }, (error, _) => zoneErrors.add(error));
+
+        expect(resolved, isNull);
+        expect(zoneErrors, isEmpty);
+        expect(target.existsSync(), isFalse);
+      });
+
+      test('completes with null when the sink reports its failure before the '
+          'response ends', () async {
+        // The production ordering: bytes arrive over the network, so the open
+        // error lands long before the last chunk. `flush()` on a sink that has
+        // already reported its failure never completes, which stranded this
+        // download — and every caller joined to its cache key — forever.
+        final body = StreamController<List<int>>();
+        addTearDown(body.close);
+        final client = _CallbackClient(
+          (_) async => http.StreamedResponse(body.stream, 200),
+        );
+        final downloader = HttpCancellableDownloader(client);
+
+        final zoneErrors = <Object>[];
+        File? resolved;
+        await runZonedGuarded(() async {
+          final download = downloader.download(
+            url: 'https://example.com/avatar.jpg',
+            targetFile: target,
+          );
+          await pumpEventQueue();
+          body.add(utf8.encode('payload'));
+          await pumpEventQueue();
+          resolved = await download.file;
+          await pumpEventQueue();
+        }, (error, _) => zoneErrors.add(error));
+
+        expect(resolved, isNull);
+        expect(zoneErrors, isEmpty);
+        expect(target.existsSync(), isFalse);
+      });
+    });
+
     test('close releases the underlying client', () async {
       final client = _CallbackClient(
         (_) async => http.StreamedResponse(const Stream.empty(), 200),

--- a/mobile/test/utils/recoverable_flutter_error_test.dart
+++ b/mobile/test/utils/recoverable_flutter_error_test.dart
@@ -108,6 +108,9 @@ void main() {
       //
       // report is false because a dead URL is a plain IO failure, which
       // `.claude/rules/error_handling.md` puts outside Crashlytics (#7298).
+      // This is the only silenced branch: every other recoverable-media
+      // signature above asserts the full record with report: true, so
+      // widening the silence turns those tests red.
       const details = FlutterErrorDetails(
         exception: MediaCacheImageLoadException(
           'https://web.archive.org/web/20150907190604/'
@@ -120,19 +123,6 @@ void main() {
         classifyRecoverableFlutterError(details),
         (reason: 'Recoverable media load failure', report: false),
       );
-    });
-
-    test('keeps reporting recoverable media failures that are not '
-        '$MediaCacheImageLoadException', () {
-      // Only the media-cache download-without-file branch is silenced; the
-      // remaining recoverable-media signatures still carry a non-fatal
-      // report, so silencing one class cannot silently widen to the rest.
-      const details = FlutterErrorDetails(
-        exception: SocketException("Failed host lookup: 'cdn.divine.video'"),
-        library: 'dart:_http',
-      );
-
-      expect(classifyRecoverableFlutterError(details)?.report, isTrue);
     });
 
     test('classifies hero flight layout failures as recoverable', () {

--- a/mobile/test/utils/recoverable_flutter_error_test.dart
+++ b/mobile/test/utils/recoverable_flutter_error_test.dart
@@ -19,7 +19,7 @@ void main() {
 
       expect(
         classifyRecoverableFlutterError(details),
-        'Recoverable media load failure',
+        (reason: 'Recoverable media load failure', report: true),
       );
     });
 
@@ -42,7 +42,7 @@ void main() {
 
         expect(
           classifyRecoverableFlutterError(details),
-          'Recoverable media load failure',
+          (reason: 'Recoverable media load failure', report: true),
         );
       });
     }
@@ -55,7 +55,7 @@ void main() {
 
       expect(
         classifyRecoverableFlutterError(details),
-        'Recoverable media load failure',
+        (reason: 'Recoverable media load failure', report: true),
       );
     });
 
@@ -67,7 +67,7 @@ void main() {
 
       expect(
         classifyRecoverableFlutterError(details),
-        'Recoverable media load failure',
+        (reason: 'Recoverable media load failure', report: true),
       );
     });
 
@@ -82,7 +82,7 @@ void main() {
 
       expect(
         classifyRecoverableFlutterError(details),
-        'Recoverable media load failure',
+        (reason: 'Recoverable media load failure', report: true),
       );
     });
 
@@ -94,17 +94,20 @@ void main() {
 
       expect(
         classifyRecoverableFlutterError(details),
-        'Recoverable media load failure',
+        (reason: 'Recoverable media load failure', report: true),
       );
     });
 
     test('classifies MediaCacheImageProvider download-without-file failures as '
-        'recoverable regardless of host', () {
+        'recoverable and unreported regardless of host', () {
       // Dead legacy Vine avatars are commonly served through
       // web.archive.org, which is not in the recoverable-media host set —
       // the exception type alone must classify it, so the broken avatar
       // falls back to a placeholder instead of a fatal crash (#5782 follow
       // up: the download-without-file branch was still reported as fatal).
+      //
+      // report is false because a dead URL is a plain IO failure, which
+      // `.claude/rules/error_handling.md` puts outside Crashlytics (#7298).
       const details = FlutterErrorDetails(
         exception: MediaCacheImageLoadException(
           'https://web.archive.org/web/20150907190604/'
@@ -115,8 +118,21 @@ void main() {
 
       expect(
         classifyRecoverableFlutterError(details),
-        'Recoverable media load failure',
+        (reason: 'Recoverable media load failure', report: false),
       );
+    });
+
+    test('keeps reporting recoverable media failures that are not '
+        '$MediaCacheImageLoadException', () {
+      // Only the media-cache download-without-file branch is silenced; the
+      // remaining recoverable-media signatures still carry a non-fatal
+      // report, so silencing one class cannot silently widen to the rest.
+      const details = FlutterErrorDetails(
+        exception: SocketException("Failed host lookup: 'cdn.divine.video'"),
+        library: 'dart:_http',
+      );
+
+      expect(classifyRecoverableFlutterError(details)?.report, isTrue);
     });
 
     test('classifies hero flight layout failures as recoverable', () {
@@ -152,7 +168,7 @@ void main() {
 
       expect(
         classifyRecoverableFlutterError(details),
-        'Recoverable hero flight layout failure',
+        (reason: 'Recoverable hero flight layout failure', report: true),
       );
     });
 
@@ -182,7 +198,7 @@ void main() {
 
       expect(
         classifyRecoverableFlutterError(details),
-        'Recoverable hero flight layout failure',
+        (reason: 'Recoverable hero flight layout failure', report: true),
       );
     });
 


### PR DESCRIPTION
## Description

Two image-cache Crashlytics issues (30 events / 26 users in 7 days) were both expected IO conditions, which `.claude/rules/error_handling.md` puts outside Crashlytics. Reading the actual events showed the reported cause was not what the issue assumed, and that one of them was hiding a hang.

**`dart:io - _FileStreamConsumer.addStream.<fn>` (17 events / 16 users)** — not an OS-purged cache directory. Every sample carries `OS Error: File name too long, errno = 63` and the reason `runZonedGuarded`. Image cache keys are full URLs, and a `web.archive.org`-proxied Vine avatar sanitizes to a filename past the 255-byte `NAME_MAX` of APFS and ext4. `File.openWrite()` opens lazily and nothing observed that open until the first response chunk, so the `ENAMETOOLONG` escaped to the zone and was reported as a crash.

The download then settled wrongly on top of it, in one of two ways depending on which landed first:

- Open error first (the production ordering — bytes arrive over the network well after the open resolves): `onDone` called `_sink.flush()`, and a sink that has already reported its failure never completes `flush()`. The download never settled, so `_pendingCacheOperations[key]` and `_inFlightRelativePaths` leaked, the image provider awaited a future that never completed, and every later caller for that key joined the same stranded operation.
- Response end first: `flush()` and `close()` both threw into a swallow-everything catch, and `onDone` then reported success with a `File` that was never created.

`_HttpDownload` now watches the sink's `done` future and engages the sink immediately so the pending open has a listener before the first chunk, and `onDone` uses `close()` (which flushes and returns `done`) instead of `flush()`, treating its error as a write failure. Either ordering now settles as `file: null` and deletes any partial bytes.

**`MediaCacheImageProvider._loadAsync` (13 events / 10 users)** — `MediaCacheImageLoadException`, reason `Error thrown Recoverable media load failure`. `classifyRecoverableFlutterError` already downgraded it from fatal to non-fatal, but `main.dart` still called `recordError` with that reason, so "recoverable" only ever meant "non-fatal", never "not worth reporting". The classifier now returns a `(reason, report)` record, and this branch is the one that returns `report: false` — the exception carries nothing beyond "this URL is dead", which the avatar and thumbnail negative caches already act on. It is still logged and still presented; only the Crashlytics write is dropped.

Both fixes compose: after the downloader change, an unopenable target now settles as a failed download, which the provider turns into a `MediaCacheImageLoadException` — silenced by the second change rather than trading one Crashlytics issue for another.

### Does the cache directory recover after an OS purge?

Yes, on both write paths, so a purge was never the cause here. `_HttpDownload._start` recreates `_file.parent` before opening (`cancellable_downloader.dart`), which covers the cancellable path `MediaCacheImageProvider` uses; `flutter_cache_manager`'s `IOFileSystem.createFile` re-runs `createDirectory` when the directory has vanished, which covers the legacy `cacheFile`/`downloadFile` path; and `_persistAliasMap` recreates the base directory before writing. `MediaCacheManager._resolveBaseCacheDir` does memoize `_baseCacheDir` and will not recreate a purged directory on its own, but nothing writes through that path without one of the three creates above running first.

### Not fixed here: the over-long filename itself

`MediaCacheManager._relativePathFor` caps nothing — it sanitizes the whole cache key and appends `_<micros>_<seq><ext>`, so any URL over roughly 230 characters produces an unwritable filename. Those avatars can never be cached and are re-downloaded on every scroll, and after this PR they fail cleanly instead of hanging. Truncating the key prefix (the `_<micros>_<seq><ext>` suffix that `_managedCacheFilePattern` matches is preserved either way) would make them start loading, which is a user-visible behaviour change beyond a reporting fix, so it rides in #7311 rather than here.

Worth knowing when reading this PR: the two fixes compose into total silence for that condition. The downloader now settles cleanly, the provider turns that into a `MediaCacheImageLoadException`, and the classifier drops it — so nothing in Crashlytics will report the un-cacheable-URL problem after this lands. That is the intended outcome of a reporting fix, but it does mean #7311 is the only remaining signal.

**Related Issue:** Closes #7298

## Out of Scope

- The over-long cache filename described above — a separate behaviour change, tracked in #7311.
- The other `Recoverable media load failure` signatures (HTTP non-200 image loads, `SocketException` on a Divine media host, interrupted downloads, missing-host URIs, invalid image data) still report. They are arguably also "not reportable" per the same matrix row, but this issue names two specific Crashlytics issues and widening the silence is a separate call. Every one of those signatures asserts the full `(reason, report: true)` record in `recoverable_flutter_error_test.dart`, so widening the silence cannot happen unnoticed.

## Verification

- `dart format` on the five changed files — no reflow.
- `flutter analyze lib test integration_test` from `mobile/` — no issues.
- `flutter test --coverage` in `mobile/packages/media_cache` — 210 tests pass, 98.20% line coverage (the package's own workflow gates at 98).
- `flutter test test/utils/recoverable_flutter_error_test.dart` from `mobile/` — 16 tests pass.
- `flutter test test/widgets/avatar_failure_cache_test.dart test/widgets/user_avatar_svg_test.dart test/widgets/video_thumbnail_widget_test.dart` — 50 tests pass (the app-layer consumers of `MediaCacheImageLoadException`).
- Both new downloader tests were confirmed red against the unpatched `cancellable_downloader.dart`: the response-end-first ordering returns a non-existent `File` instead of `null`, and the sink-error-first ordering times out after 30s — the hang, reproduced.
- Mutation-checked the fix itself against the new tests. Removing the `done` listener, removing the zero-length `add()` that engages the sink, or removing both each turns the sink-error-first test red (timeout, plus a non-empty `zoneErrors` when only the listener goes). Restoring `flush()` ahead of `close()` stays green: with the `done` listener in place `_failWithWriteError` nulls `_sink` in a microtask before the response stream's `onDone` event can run, so a failed sink is never flushed. `close()` is still the right call — it flushes anyway, so `flush()` was always redundant — but the listener, not the `flush()` removal, is what settles the hang.
- Read the pinned Flutter 3.44.0 `dart:io` sources rather than trusting the description: `_StreamSinkImpl._controller` calls `_target.addStream` synchronously, which is what attaches an error handler to `_FileStreamConsumer`'s pending open, and `RandomAccessFile.writeFrom` short-circuits when `end == start`, so the zero-length write leaves the file untouched. On open failure with `_isBound == false` the SDK completes `done` with the error and leaves `_controllerCompleter` uncompleted forever, which is exactly the `flush()` hang.
- Manual verification on a real Samsung Galaxy: pending (owner).

### CI: `Media Cache CI / build` is red for a reason outside this diff

It fails on 6 `unawaited_return_in_try_block` analyzer warnings in `lib/src/media_cache_image_provider.dart` and `lib/src/safe_cache_info_repository.dart`. Both files are byte-identical to `origin/main` on this branch (`git diff origin/main...HEAD` lists neither), and `flutter analyze` at the repo's pinned toolchain is clean.

This is #7285: the package workflows pass no `flutter_version`, so they resolve the latest stable — `stable-3.47.0` in this run — while the repo pins `3.44.0` in `mobile/mise.toml`. The diagnostic does not exist in 3.44.0. `main` is green only because `Media Cache CI` is path-filtered and last ran on 2026-07-20, before the stable bump.

**#7307 unblocks this** — it adds `flutter_version: "3.44.0"` to `.github/workflows/media_cache.yml`. Not patched in here, since it is that PR's fix to land. Every other check on this PR is green.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

