### PR TITLE
fix(observability): stop reporting expected DNS failures to Crashlytics

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -132,6 +132,7 @@ import 'package:openvine/startup/database_bootstrap_failure_app.dart';
 import 'package:openvine/startup/database_corruption_gate.dart';
 import 'package:openvine/startup/startup_splash_release_controller.dart';
 import 'package:openvine/utils/app_uptime.dart';
+import 'package:openvine/utils/expected_network_error.dart';
 import 'package:openvine/utils/log_message_batcher.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:openvine/utils/platform_support.dart';
@@ -1650,22 +1651,46 @@ Future<void> _initializeZendeskSupport() async {
   );
 }
 
+/// Sink [handleUncaughtZoneError] files a report to.
+typedef ZoneErrorRecorder =
+    Future<void> Function(Object error, StackTrace stack, {String? reason});
+
+/// Files a report for an error that escaped every `try`/`catch` in the app
+/// zone.
+///
+/// Expected network/IO failures are dropped instead of reported, for the
+/// reason spelled out on [isExpectedNetworkFailure]: a relay handshake that
+/// fails because the device has no DNS is a state, not a defect, and the
+/// relay's own reconnect path already handles it. Left ungated it dominated
+/// the iOS non-fatal dashboard (#7290).
+///
+/// [recordError] defaults to the app-wide crash reporter; it is injectable so
+/// tests can observe what does and does not get filed.
+@visibleForTesting
+Future<void> handleUncaughtZoneError(
+  Object error,
+  StackTrace stack, {
+  ZoneErrorRecorder? recordError,
+}) async {
+  if (isExpectedNetworkFailure(error)) {
+    Log.warning(
+      'Expected network failure (not reported): $error',
+      name: 'Main',
+    );
+    return;
+  }
+
+  // CrashReportingService.recordError self-guards (no-ops if uninitialized)
+  // and logs its own failure internally, so no outer catch is needed here.
+  final record = recordError ?? CrashReportingService.instance.recordError;
+  await record(error, stack, reason: 'runZonedGuarded');
+}
+
 void main() {
   // Capture any uncaught Dart errors (foreground or background zones)
-  runZonedGuarded(
-    () async {
-      await _startOpenVineApp();
-    },
-    (error, stack) async {
-      // CrashReportingService.recordError self-guards (no-ops if uninitialized)
-      // and logs its own failure internally, so no outer catch is needed here.
-      await CrashReportingService.instance.recordError(
-        error,
-        stack,
-        reason: 'runZonedGuarded',
-      );
-    },
-  );
+  runZonedGuarded(() async {
+    await _startOpenVineApp();
+  }, handleUncaughtZoneError);
 }
 
 class DivineApp extends ConsumerStatefulWidget {

--- a/mobile/lib/utils/expected_network_error.dart
+++ b/mobile/lib/utils/expected_network_error.dart
@@ -4,7 +4,16 @@ import 'dart:io'
 
 import 'package:web_socket_channel/web_socket_channel.dart';
 
-/// Whether [error] is an expected network or IO failure.
+/// Prefix `dart:io` gives every DNS resolution failure.
+///
+/// `dart:io` builds this text itself rather than taking it from the OS:
+/// `_NativeSocket.lookup` and `_NativeSocket._resolveHost` both interpolate
+/// `"Failed host lookup: '$host'"`. Everything the platform contributes lands
+/// in the separate `osError` field, so the prefix does not vary by OS or
+/// locale the way an `errno` or a strerror string does.
+const _hostLookupFailure = 'Failed host lookup:';
+
+/// Whether [error] is an expected network failure that should not be reported.
 ///
 /// Being offline, sitting behind a captive portal, or running on a network
 /// without working DNS is a normal state rather than a defect, which is why
@@ -14,15 +23,32 @@ import 'package:web_socket_channel/web_socket_channel.dart';
 /// connection retry, the relay state machine, and the UI's own offline
 /// handling all still see the failure.
 ///
-/// [WebSocketChannelException] counts because it is how the relay transport
-/// surfaces a failed handshake: `AdapterWebSocketChannel` wraps every connect
-/// error in it, so a check for [io.SocketException] alone would miss every
-/// relay connection failure. Note the wrapper is wider than the socket error
-/// it usually carries — a TLS or malformed-URI failure arrives as the same
-/// type and is dropped with it, while a connect `TimeoutException` is the one
-/// error the wrapper passes through untouched and so is still reported.
+/// Both types it inspects are wider than the failure they usually carry, so
+/// neither is trusted on type alone:
+///
+/// * A SocketException counts only when its message is a DNS resolution
+///   failure. Every other socket error stays reportable — notably the
+///   `Bad file descriptor` raised by a leaked or double-closed descriptor,
+///   which is the one signal that would show such a leak.
+/// * A WebSocketChannelException is unwrapped instead, because
+///   `AdapterWebSocketChannel` wraps *every* connect error in it. Recursing on
+///   `inner` keeps a TLS HandshakeException and the ArgumentError from a
+///   malformed relay URI reportable; silencing those would mean never
+///   connecting to that relay and never hearing why. A wrapper with no `inner`
+///   carries nothing to classify and stays expected.
+///
+/// A connect `TimeoutException` is the one error the wrapper passes through
+/// untouched, so it reaches neither branch and is still reported.
 ///
 /// On web the `dart:io` half resolves to a stub whose `SocketException` is
 /// never instantiated, so the first check is simply always false there.
-bool isExpectedNetworkFailure(Object error) =>
-    error is io.SocketException || error is WebSocketChannelException;
+bool isExpectedNetworkFailure(Object error) {
+  if (error is io.SocketException) {
+    return error.message.startsWith(_hostLookupFailure);
+  }
+  if (error is WebSocketChannelException) {
+    final inner = error.inner;
+    return inner == null || isExpectedNetworkFailure(inner);
+  }
+  return false;
+}

--- a/mobile/lib/utils/expected_network_error.dart
+++ b/mobile/lib/utils/expected_network_error.dart
@@ -1,0 +1,25 @@
+import 'dart:io'
+    if (dart.library.html) 'package:openvine/utils/platform_io_web.dart'
+    as io;
+
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+/// Whether [error] is an expected network or IO failure.
+///
+/// Being offline, sitting behind a captive portal, or running on a network
+/// without working DNS is a normal state rather than a defect, which is why
+/// the decision matrix in `.claude/rules/error_handling.md` puts "Network /
+/// IO (timeout, dropped connection, DNS)" in the not-reportable row. Crash
+/// reporters call this to drop such errors; nothing else changes, so the
+/// connection retry, the relay state machine, and the UI's own offline
+/// handling all still see the failure.
+///
+/// [WebSocketChannelException] counts because it is how the relay transport
+/// surfaces a failed handshake: it wraps the underlying [io.SocketException]
+/// instead of letting it through, so a type check for the socket error alone
+/// would miss every relay connection failure.
+///
+/// On web the `dart:io` half resolves to a stub whose `SocketException` is
+/// never instantiated, so the first check is simply always false there.
+bool isExpectedNetworkFailure(Object error) =>
+    error is io.SocketException || error is WebSocketChannelException;

--- a/mobile/lib/utils/expected_network_error.dart
+++ b/mobile/lib/utils/expected_network_error.dart
@@ -1,5 +1,5 @@
 import 'dart:io'
-    if (dart.library.html) 'package:openvine/utils/platform_io_web.dart'
+    if (dart.library.js_interop) 'package:openvine/utils/platform_io_web.dart'
     as io;
 
 import 'package:web_socket_channel/web_socket_channel.dart';

--- a/mobile/lib/utils/expected_network_error.dart
+++ b/mobile/lib/utils/expected_network_error.dart
@@ -15,9 +15,12 @@ import 'package:web_socket_channel/web_socket_channel.dart';
 /// handling all still see the failure.
 ///
 /// [WebSocketChannelException] counts because it is how the relay transport
-/// surfaces a failed handshake: it wraps the underlying [io.SocketException]
-/// instead of letting it through, so a type check for the socket error alone
-/// would miss every relay connection failure.
+/// surfaces a failed handshake: `AdapterWebSocketChannel` wraps every connect
+/// error in it, so a check for [io.SocketException] alone would miss every
+/// relay connection failure. Note the wrapper is wider than the socket error
+/// it usually carries — a TLS or malformed-URI failure arrives as the same
+/// type and is dropped with it, while a connect `TimeoutException` is the one
+/// error the wrapper passes through untouched and so is still reported.
 ///
 /// On web the `dart:io` half resolves to a stub whose `SocketException` is
 /// never instantiated, so the first check is simply always false there.

--- a/mobile/lib/utils/platform_io_web.dart
+++ b/mobile/lib/utils/platform_io_web.dart
@@ -134,6 +134,19 @@ class PathNotFoundException extends FileSystemException {
   PathNotFoundException(super.message, [super.path, super.osError]);
 }
 
+// SocketException stub for web platform. Web has no dart:io sockets, so this
+// is never thrown or instantiated — it exists so `is SocketException` checks
+// compile for web and correctly evaluate to false.
+class SocketException implements Exception {
+  SocketException(this.message, {this.osError});
+
+  final String message;
+  final OSError? osError;
+
+  @override
+  String toString() => 'SocketException: $message';
+}
+
 // Process stub for web platform
 class Process {
   static Future<ProcessResult> run(

--- a/mobile/lib/utils/recoverable_flutter_error.dart
+++ b/mobile/lib/utils/recoverable_flutter_error.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:media_cache/media_cache.dart';
+import 'package:openvine/utils/expected_network_error.dart';
 
 const _recoverableMediaLoadReason = 'Recoverable media load failure';
 const _recoverableHeroFlightReason = 'Recoverable hero flight layout failure';
+const _expectedNetworkFailureReason = 'Expected network failure';
 const _recoverableMediaHosts = <String>{
   'media.divine.video',
   'cdn.divine.video',
@@ -18,12 +20,11 @@ typedef RecoverableFlutterError = ({
 
   /// Whether the error is still worth a non-fatal Crashlytics report.
   ///
-  /// `false` where the error carries nothing actionable. The decision
-  /// matrix in `.claude/rules/error_handling.md` puts IO failures outside
-  /// Crashlytics, but only the download-without-file branch is silenced so
-  /// far (#7298) — the other recoverable IO signatures still report, and
-  /// widening that is a separate call. The error is logged and presented
-  /// either way.
+  /// `false` where the error carries nothing actionable. The currently
+  /// silenced branches are the download-without-file media-cache failure
+  /// (#7298) and expected DNS failures (#7290). Other recoverable IO
+  /// signatures still report, and widening that is a separate call. The error
+  /// is logged and presented either way.
   bool report,
 });
 
@@ -61,6 +62,13 @@ RecoverableFlutterError? classifyRecoverableFlutterError(
           context.contains('image codec') ||
           context.contains('image resource'));
 
+  if (isExpectedNetworkFailure(details.exception)) {
+    return (reason: _expectedNetworkFailureReason, report: false);
+  }
+
+  // DNS failures are handled above by the typed expected-network predicate.
+  // This string fallback stays intentionally reportable so non-DNS media-host
+  // socket failures, including descriptor-lifecycle bugs, keep their signal.
   final isMediaHostLookup =
       error.contains('SocketException') && hasRecoverableMediaHost;
 

--- a/mobile/test/main_uncaught_zone_error_test.dart
+++ b/mobile/test/main_uncaught_zone_error_test.dart
@@ -40,6 +40,25 @@ void main() {
       expect(filed, isEmpty);
     });
 
+    test('reports a socket failure the app inflicted on itself', () async {
+      // Narrowed in review: only a DNS failure is dropped here, so a leaked
+      // or double-closed descriptor still reaches Crashlytics (#7310).
+      const error = SocketException(
+        'OS Error: Bad file descriptor',
+        osError: OSError('Bad file descriptor', 9),
+      );
+
+      await app.handleUncaughtZoneError(
+        error,
+        StackTrace.current,
+        recordError: recorder(),
+      );
+
+      expect(filed, hasLength(1));
+      expect(filed.single.error, same(error));
+      expect(filed.single.reason, 'runZonedGuarded');
+    });
+
     test('still reports an unexpected error', () async {
       final error = StateError('No public key available');
 

--- a/mobile/test/main_uncaught_zone_error_test.dart
+++ b/mobile/test/main_uncaught_zone_error_test.dart
@@ -1,0 +1,57 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/main.dart' as app;
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+void main() {
+  group('handleUncaughtZoneError', () {
+    late List<({Object error, String? reason})> filed;
+
+    setUp(() => filed = []);
+
+    Future<void> Function(Object, StackTrace, {String? reason}) recorder() {
+      return (error, stack, {reason}) async {
+        filed.add((error: error, reason: reason));
+      };
+    }
+
+    test('does not report a relay handshake that failed on DNS', () async {
+      // The zone guard is where this lands: nothing catches the failed
+      // handshake, so it escapes as an uncaught async error (#7290).
+      await app.handleUncaughtZoneError(
+        WebSocketChannelException.from(
+          const SocketException("Failed host lookup: 'relay.divine.video'"),
+        ),
+        StackTrace.current,
+        recordError: recorder(),
+      );
+
+      expect(filed, isEmpty);
+    });
+
+    test('does not report a bare socket failure', () async {
+      await app.handleUncaughtZoneError(
+        const SocketException("Failed host lookup: 'media.divine.video'"),
+        StackTrace.current,
+        recordError: recorder(),
+      );
+
+      expect(filed, isEmpty);
+    });
+
+    test('still reports an unexpected error', () async {
+      final error = StateError('No public key available');
+
+      await app.handleUncaughtZoneError(
+        error,
+        StackTrace.current,
+        recordError: recorder(),
+      );
+
+      expect(filed, hasLength(1));
+      expect(filed.single.error, same(error));
+      expect(filed.single.reason, 'runZonedGuarded');
+    });
+  });
+}

--- a/mobile/test/utils/expected_network_error_test.dart
+++ b/mobile/test/utils/expected_network_error_test.dart
@@ -7,80 +7,167 @@ import 'package:web_socket_channel/web_socket_channel.dart';
 
 void main() {
   group('isExpectedNetworkFailure', () {
-    test('treats a media host lookup failure as expected', () {
-      // The signature behind the `dart:_http - _HttpClient.getUrl` and
-      // `video_thumbnail_widget.dart - _resolveImageStream` non-fatals.
-      const error = SocketException(
-        "Failed host lookup: 'media.divine.video' "
-        '(OS Error: nodename nor servname provided, or not known, errno = 8)',
-      );
+    group('SocketException', () {
+      test('treats a media host lookup failure as expected', () {
+        // The signature behind the `dart:_http - _HttpClient.getUrl` and
+        // `video_thumbnail_widget.dart - _resolveImageStream` non-fatals.
+        const error = SocketException(
+          "Failed host lookup: 'media.divine.video'",
+          osError: OSError(
+            'nodename nor servname provided, or not known',
+            8,
+          ),
+        );
 
-      expect(isExpectedNetworkFailure(error), isTrue);
+        expect(isExpectedNetworkFailure(error), isTrue);
+      });
+
+      test('reports a self-inflicted socket error', () {
+        // EBADF means the app read a descriptor it had already closed, or ran
+        // out of descriptors — a lifecycle bug, not a flaky network. #7310
+        // tracks a live socket leak in `WebSocketConnectionManager`, so this
+        // must keep reaching Crashlytics or the leak loses its only signal.
+        const error = SocketException(
+          'OS Error: Bad file descriptor',
+          osError: OSError('Bad file descriptor', 9),
+        );
+
+        expect(isExpectedNetworkFailure(error), isFalse);
+      });
+
+      test('reports a refused connection', () {
+        // DNS resolved; the peer answered. That is not the offline state the
+        // predicate exists to drop.
+        const error = SocketException(
+          'Connection refused',
+          osError: OSError('Connection refused', 61),
+          port: 443,
+        );
+
+        expect(isExpectedNetworkFailure(error), isFalse);
+      });
     });
 
-    test('treats even a self-inflicted socket error as expected', () {
-      // The classification is by type with no message allowlist, so an EBADF
-      // — reading a descriptor the app already closed, which is a lifecycle
-      // bug rather than a flaky network — is dropped alongside the offline
-      // cases. Pinned deliberately: it is the known cost of the type check.
-      const error = SocketException(
-        'Bad file descriptor (OS Error: Bad file descriptor, errno = 9)',
-      );
+    group('WebSocketChannelException', () {
+      test('treats a handshake that failed on DNS as expected', () {
+        // The relay transport wraps the socket error rather than rethrowing
+        // it, so a bare `SocketException` check misses every relay DNS
+        // failure.
+        final error = WebSocketChannelException.from(
+          const SocketException("Failed host lookup: 'relay.divine.video'"),
+        );
 
-      expect(isExpectedNetworkFailure(error), isTrue);
+        expect(isExpectedNetworkFailure(error), isTrue);
+      });
+
+      test('reports a TLS handshake failure', () {
+        // `IOWebSocket.connect` only converts `WebSocketException`, so a bad
+        // or expired relay certificate arrives inside the wrapper untouched.
+        // Dropping it would leave the app silently unable to reach that relay.
+        final error = WebSocketChannelException.from(
+          const HandshakeException('Handshake error in client'),
+        );
+
+        expect(isExpectedNetworkFailure(error), isFalse);
+      });
+
+      test('reports a malformed relay URI', () {
+        // `IOWebSocket.connect` rejects a non-ws scheme with `ArgumentError`,
+        // which the adapter wraps like any other connect failure. It is a
+        // config defect that no amount of retrying fixes.
+        final error = WebSocketChannelException.from(
+          ArgumentError.value(
+            Uri.parse('https://relay.divine.video'),
+            'url',
+            'only ws: and wss: schemes are supported',
+          ),
+        );
+
+        expect(isExpectedNetworkFailure(error), isFalse);
+      });
+
+      test('reports a malformed relay URI that failed to parse', () {
+        final error = WebSocketChannelException.from(
+          const FormatException('Invalid port', 'wss://relay.divine.video:xx'),
+        );
+
+        expect(isExpectedNetworkFailure(error), isFalse);
+      });
+
+      test('reports a rejected websocket upgrade', () {
+        // A non-101 response reaches the wrapper as a `WebSocketException`,
+        // not a socket error, so unwrapping keeps it reportable. A relay that
+        // answers every handshake with 502 is broken, not offline.
+        final error = WebSocketChannelException.from(
+          const WebSocketException(
+            "Connection to 'https://relay.divine.video' was not upgraded to "
+            'websocket',
+            502,
+          ),
+        );
+
+        expect(isExpectedNetworkFailure(error), isFalse);
+      });
+
+      test('treats a wrapper with nothing inside as expected', () {
+        // The message-only constructor carries no inner error to classify.
+        // With nothing to inspect, the wrapper keeps its old meaning: the
+        // transport could not connect.
+        final error = WebSocketChannelException(
+          'WebSocket connection failed.',
+        );
+
+        expect(error.inner, isNull);
+        expect(isExpectedNetworkFailure(error), isTrue);
+      });
+
+      test('reports a wrapped self-inflicted socket error', () {
+        // A leaked descriptor is no less a defect for having crossed the
+        // relay transport, so wrapping must not change the verdict.
+        final error = WebSocketChannelException.from(
+          const SocketException(
+            'OS Error: Bad file descriptor',
+            osError: OSError('Bad file descriptor', 9),
+          ),
+        );
+
+        expect(isExpectedNetworkFailure(error), isFalse);
+      });
     });
 
-    test('treats a failed relay handshake as expected', () {
-      // The relay transport wraps the socket error rather than rethrowing it,
-      // so a `SocketException` check alone misses every relay DNS failure.
-      final error = WebSocketChannelException.from(
-        const SocketException("Failed host lookup: 'relay.divine.video'"),
-      );
+    group('unrelated errors', () {
+      test('does not treat a programming-invariant violation as expected', () {
+        expect(
+          isExpectedNetworkFailure(StateError('No public key available')),
+          isFalse,
+        );
+      });
 
-      expect(isExpectedNetworkFailure(error), isTrue);
-    });
-
-    test('treats a rejected websocket upgrade as expected', () {
-      // A handshake the server answers with a non-101 status is still a
-      // transport failure, and the caller already retries.
-      final error = WebSocketChannelException(
-        "Connection to 'https://relay.divine.video' was not upgraded to "
-        'websocket, HTTP status code: 502',
-      );
-
-      expect(isExpectedNetworkFailure(error), isTrue);
-    });
-
-    test('does not treat a programming-invariant violation as expected', () {
-      expect(
-        isExpectedNetworkFailure(StateError('No public key available')),
-        isFalse,
-      );
-    });
-
-    test('does not treat a media decode failure as expected', () {
-      // A broken image is recoverable but not a network failure — it keeps
-      // its existing non-fatal report.
-      expect(
-        isExpectedNetworkFailure(
-          const MediaCacheImageLoadException('https://media.divine.video/x'),
-        ),
-        isFalse,
-      );
-    });
-
-    test(
-      'does not treat an error that merely mentions sockets as expected',
-      () {
-        // The classification is by type, so prose about a socket in an
-        // unrelated failure must not silence it.
+      test('does not treat a media decode failure as expected', () {
+        // A broken image is recoverable but not a network failure — it keeps
+        // its existing non-fatal report.
         expect(
           isExpectedNetworkFailure(
-            Exception('SocketException while parsing the relay config'),
+            const MediaCacheImageLoadException('https://media.divine.video/x'),
           ),
           isFalse,
         );
-      },
-    );
+      });
+
+      test(
+        'does not treat an error that merely mentions a host lookup as '
+        'expected',
+        () {
+          // The message check is scoped to `SocketException`, so prose about a
+          // lookup in an unrelated failure must not silence it.
+          expect(
+            isExpectedNetworkFailure(
+              Exception("Failed host lookup: 'relay.divine.video' in config"),
+            ),
+            isFalse,
+          );
+        },
+      );
+    });
   });
 }

--- a/mobile/test/utils/expected_network_error_test.dart
+++ b/mobile/test/utils/expected_network_error_test.dart
@@ -1,0 +1,82 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:media_cache/media_cache.dart';
+import 'package:openvine/utils/expected_network_error.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+void main() {
+  group('isExpectedNetworkFailure', () {
+    test('treats a media host lookup failure as expected', () {
+      // The signature behind the `dart:_http - _HttpClient.getUrl` and
+      // `video_thumbnail_widget.dart - _resolveImageStream` non-fatals.
+      const error = SocketException(
+        "Failed host lookup: 'media.divine.video' "
+        '(OS Error: nodename nor servname provided, or not known, errno = 8)',
+      );
+
+      expect(isExpectedNetworkFailure(error), isTrue);
+    });
+
+    test('treats a dropped socket as expected', () {
+      const error = SocketException(
+        'Bad file descriptor (OS Error: Bad file descriptor, errno = 9)',
+      );
+
+      expect(isExpectedNetworkFailure(error), isTrue);
+    });
+
+    test('treats a failed relay handshake as expected', () {
+      // The relay transport wraps the socket error rather than rethrowing it,
+      // so a `SocketException` check alone misses every relay DNS failure.
+      final error = WebSocketChannelException.from(
+        const SocketException("Failed host lookup: 'relay.divine.video'"),
+      );
+
+      expect(isExpectedNetworkFailure(error), isTrue);
+    });
+
+    test('treats a rejected websocket upgrade as expected', () {
+      // A handshake the server answers with a non-101 status is still a
+      // transport failure, and the caller already retries.
+      final error = WebSocketChannelException(
+        "Connection to 'https://relay.divine.video' was not upgraded to "
+        'websocket, HTTP status code: 502',
+      );
+
+      expect(isExpectedNetworkFailure(error), isTrue);
+    });
+
+    test('does not treat a programming-invariant violation as expected', () {
+      expect(
+        isExpectedNetworkFailure(StateError('No public key available')),
+        isFalse,
+      );
+    });
+
+    test('does not treat a media decode failure as expected', () {
+      // A broken image is recoverable but not a network failure — it keeps
+      // its existing non-fatal report.
+      expect(
+        isExpectedNetworkFailure(
+          const MediaCacheImageLoadException('https://media.divine.video/x'),
+        ),
+        isFalse,
+      );
+    });
+
+    test(
+      'does not treat an error that merely mentions sockets as expected',
+      () {
+        // The classification is by type, so prose about a socket in an
+        // unrelated failure must not silence it.
+        expect(
+          isExpectedNetworkFailure(
+            Exception('SocketException while parsing the relay config'),
+          ),
+          isFalse,
+        );
+      },
+    );
+  });
+}

--- a/mobile/test/utils/expected_network_error_test.dart
+++ b/mobile/test/utils/expected_network_error_test.dart
@@ -18,7 +18,11 @@ void main() {
       expect(isExpectedNetworkFailure(error), isTrue);
     });
 
-    test('treats a dropped socket as expected', () {
+    test('treats even a self-inflicted socket error as expected', () {
+      // The classification is by type with no message allowlist, so an EBADF
+      // — reading a descriptor the app already closed, which is a lifecycle
+      // bug rather than a flaky network — is dropped alongside the offline
+      // cases. Pinned deliberately: it is the known cost of the type check.
       const error = SocketException(
         'Bad file descriptor (OS Error: Bad file descriptor, errno = 9)',
       );

--- a/mobile/test/utils/recoverable_flutter_error_test.dart
+++ b/mobile/test/utils/recoverable_flutter_error_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:media_cache/media_cache.dart';
 import 'package:openvine/utils/recoverable_flutter_error.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
 
 void main() {
   group('classifyRecoverableFlutterError', () {
@@ -17,10 +18,10 @@ void main() {
         library: 'package:flutter/src/painting/_network_image_io.dart',
       );
 
-      expect(
-        classifyRecoverableFlutterError(details),
-        (reason: 'Recoverable media load failure', report: true),
-      );
+      expect(classifyRecoverableFlutterError(details), (
+        reason: 'Recoverable media load failure',
+        report: true,
+      ));
     });
 
     // A raw NetworkImage that fails with a non-404 HTTP status (401, 403, 500,
@@ -40,23 +41,52 @@ void main() {
           library: 'image resource service',
         );
 
-        expect(
-          classifyRecoverableFlutterError(details),
-          (reason: 'Recoverable media load failure', report: true),
-        );
+        expect(classifyRecoverableFlutterError(details), (
+          reason: 'Recoverable media load failure',
+          report: true,
+        ));
       });
     }
 
-    test('classifies Divine media host lookup failures as recoverable', () {
+    test('classifies Divine media host lookup failures as unreported', () {
       const details = FlutterErrorDetails(
         exception: SocketException("Failed host lookup: 'media.divine.video'"),
         library: 'dart:_http',
       );
 
-      expect(
-        classifyRecoverableFlutterError(details),
-        (reason: 'Recoverable media load failure', report: true),
+      expect(classifyRecoverableFlutterError(details), (
+        reason: 'Expected network failure',
+        report: false,
+      ));
+    });
+
+    test('classifies wrapped relay host lookup failures as unreported', () {
+      final details = FlutterErrorDetails(
+        exception: WebSocketChannelException.from(
+          const SocketException("Failed host lookup: 'relay.divine.video'"),
+        ),
+        library: 'dart:async',
       );
+
+      expect(classifyRecoverableFlutterError(details), (
+        reason: 'Expected network failure',
+        report: false,
+      ));
+    });
+
+    test('still reports non-DNS Divine media socket failures', () {
+      final details = FlutterErrorDetails(
+        exception: Exception(
+          'SocketException: OS Error: Bad file descriptor, '
+          'address = media.divine.video',
+        ),
+        library: 'dart:_http',
+      );
+
+      expect(classifyRecoverableFlutterError(details), (
+        reason: 'Recoverable media load failure',
+        report: true,
+      ));
     });
 
     test('classifies invalid image data failures as recoverable', () {
@@ -65,10 +95,10 @@ void main() {
         library: 'dart:ui',
       );
 
-      expect(
-        classifyRecoverableFlutterError(details),
-        (reason: 'Recoverable media load failure', report: true),
-      );
+      expect(classifyRecoverableFlutterError(details), (
+        reason: 'Recoverable media load failure',
+        report: true,
+      ));
     });
 
     test('classifies interrupted Divine media downloads as recoverable', () {
@@ -80,10 +110,10 @@ void main() {
         library: 'dart:_http',
       );
 
-      expect(
-        classifyRecoverableFlutterError(details),
-        (reason: 'Recoverable media load failure', report: true),
-      );
+      expect(classifyRecoverableFlutterError(details), (
+        reason: 'Recoverable media load failure',
+        report: true,
+      ));
     });
 
     test('classifies dart:_http missing-host URI failures as recoverable', () {
@@ -92,10 +122,10 @@ void main() {
         library: 'dart:_http',
       );
 
-      expect(
-        classifyRecoverableFlutterError(details),
-        (reason: 'Recoverable media load failure', report: true),
-      );
+      expect(classifyRecoverableFlutterError(details), (
+        reason: 'Recoverable media load failure',
+        report: true,
+      ));
     });
 
     test('classifies MediaCacheImageProvider download-without-file failures as '
@@ -106,11 +136,9 @@ void main() {
       // falls back to a placeholder instead of a fatal crash (#5782 follow
       // up: the download-without-file branch was still reported as fatal).
       //
-      // report is false because a dead URL is a plain IO failure, which
-      // `.claude/rules/error_handling.md` puts outside Crashlytics (#7298).
-      // This is the only silenced branch: every other recoverable-media
-      // signature above asserts the full record with report: true, so
-      // widening the silence turns those tests red.
+      // report is false because a dead URL is a plain IO failure with no
+      // actionable signal beyond the URL that the negative cache already acts
+      // on (#7298).
       const details = FlutterErrorDetails(
         exception: MediaCacheImageLoadException(
           'https://web.archive.org/web/20150907190604/'
@@ -119,10 +147,10 @@ void main() {
         library: 'package:media_cache/src/media_cache_image_provider.dart',
       );
 
-      expect(
-        classifyRecoverableFlutterError(details),
-        (reason: 'Recoverable media load failure', report: false),
-      );
+      expect(classifyRecoverableFlutterError(details), (
+        reason: 'Recoverable media load failure',
+        report: false,
+      ));
     });
 
     test('classifies hero flight layout failures as recoverable', () {
@@ -156,10 +184,10 @@ void main() {
         ),
       );
 
-      expect(
-        classifyRecoverableFlutterError(details),
-        (reason: 'Recoverable hero flight layout failure', report: true),
-      );
+      expect(classifyRecoverableFlutterError(details), (
+        reason: 'Recoverable hero flight layout failure',
+        report: true,
+      ));
     });
 
     test('classifies hero placeholder measurement failures as recoverable', () {
@@ -186,10 +214,10 @@ void main() {
         ),
       );
 
-      expect(
-        classifyRecoverableFlutterError(details),
-        (reason: 'Recoverable hero flight layout failure', report: true),
-      );
+      expect(classifyRecoverableFlutterError(details), (
+        reason: 'Recoverable hero flight layout failure',
+        report: true,
+      ));
     });
 
     test(


### PR DESCRIPTION
## Description

Expected DNS failures were filed to Crashlytics as non-fatals. The three issues named in #7290 total 472 events / ~180 users in 7 days — the largest single source of noise on the iOS dashboard. Sitting behind a captive portal or on a network without working DNS is a state, not a defect.

This is **observability-only**. Nothing a user can see changes: `FlutterError.presentError` still runs for every error it ran for before, the relay connection retry is untouched, the media widgets still fall back to their placeholders, and no UI state or status enum moves. The only difference is which errors reach Crashlytics.

The governing rule is the decision matrix in `.claude/rules/error_handling.md`, row **"Network / IO (timeout, dropped connection, DNS) → Reportable? NO — Expected on flaky networks. Surface via UI status enum."** The same file warns that "anything that reaches the generic `catch (e, stackTrace)` block is being implicitly classified as reportable", and prescribes adding a specific handler above it — which is what this PR does at both of `main.dart`'s reporting call sites.

### What changed

- New `mobile/lib/utils/expected_network_error.dart` with `isExpectedNetworkFailure(Object error)`. It accepts a `SocketException` **only when the failure is DNS resolution**, and it **unwraps** a `WebSocketChannelException` and recurses on its `inner` rather than trusting the wrapper type.
- `classifyRecoverableFlutterError` now gates `FlutterError.onError` DNS failures through the existing recoverable-error path with `report: false`: log, `presentError`, return — no `recordError`. This is the branch that produced both "Recoverable media load failure" issues. Returning a non-null classifier result also keeps the error away from `previousOnError`, where it would have been filed as **fatal**.
- The `runZonedGuarded` handler is extracted into a top-level `handleUncaughtZoneError` with an injectable recorder, and gates on the same predicate. Extracting it is what makes "this never reaches the reporter" testable at all. The `runZonedGuarded` body itself is unchanged, so the guard catches exactly what it caught before.
- `platform_io_web.dart` gains a `SocketException` stub so the check compiles for web, where it is correctly always false (nothing is ever an instance of it). The predicate's conditional import keys on `dart.library.js_interop`, matching `lib/platform_io.dart` and the six other conditional imports under `lib/`. `main.dart`'s own two still key on the older `dart.library.html`, which is false under dart2wasm and would resolve the shim back to `dart:io`; those are pre-existing and left alone.

### Why the predicate is narrow

An earlier revision accepted **any** `SocketException` and **any** `WebSocketChannelException`. Both types turned out to be much wider than the failure they usually carry, and gating on type alone silenced real defects:

- `AdapterWebSocketChannel` wraps *every* connect error into a `WebSocketChannelException`. `IOWebSocket.connect` only converts `WebSocketException`, so a TLS `HandshakeException` from a bad or expired relay certificate, and the `ArgumentError` from a malformed relay URI, both arrive inside the wrapper untouched. Under the type check they were dropped — meaning the app would silently never connect to that relay and never say why. Unwrapping keeps them reportable.
- A bare `SocketException` also covers `EBADF` / "bad file descriptor" and descriptor exhaustion. `blossom_upload_service.dart` already treats "bad file descriptor" as a genuine retry-worthy condition, the CHANGELOG records a previously-fixed "Too many open files" leak, and #7310 documents a *live* socket leak in `WebSocketConnectionManager._handleDisconnect`. The type check would have blinded us to exactly that defect's signal.

The DNS discriminator is the message prefix, and it is used deliberately rather than for lack of a structured field. `dart:io` constructs that message itself — `_NativeSocket.lookup` and `_NativeSocket._resolveHost` in `dart-sdk/lib/_internal/vm/bin/socket_patch.dart` (lines 590 and 1173) both interpolate `"Failed host lookup: '$host'"` — so it does not vary by platform or locale. Everything the OS contributes goes to the separate `osError` field, which `toString()` appends in parentheses and never prefixes.

There is no portable structured alternative. `osError.errorCode` on the lookup path is the raw `getaddrinfo` return value (verified: `8` on macOS, matching `EAI_NONAME` in both the macOS SDK and Android NDK `netdb.h`, but `-2` under glibc), and several `EAI_*` codes mean "no DNS". Worse, that same `errorCode` field carries POSIX `errno` values on the socket paths, with no field saying which namespace applies — `8` is `EAI_NONAME` after a lookup but `ENOEXEC` after a socket call. The message is what tells you how to read the number, so it is the more reliable discriminator, not the weaker one. `address`/`port` are both null here but are equally null for `SocketException.closed()` and other unrelated failures, so they do not discriminate either.

### Root cause per call site

**`dart:_http - _HttpClient.getUrl` and `video_thumbnail_widget.dart - _resolveImageStream`** (161 events) — both are the *same* call site. `classifyRecoverableFlutterError` already downgrades them from fatal, and now returns `report: false` for the typed DNS signature so `main.dart` logs and presents the error without filing it. Returning `null` would send these back through `previousOnError` and make them *fatal* again, so the classifier branch is deliberately non-null.

**`main.dart - main.<fn>`** (311 events) — worth reading carefully, because the issue title is misleading. That Crashlytics issue is a **grouping bucket** keyed on the blame frame (the zone handler), not one failure: the reported stack contains only `FirebaseCrashlytics.recordError → CrashReportingService.recordError → main.<fn>`, so the async origin is not in the report at all, and its variants hold several different errors — `WebSocketChannelException: SocketException: Failed host lookup: 'relay.divine.video'`, `HttpException: Content size below specified contentLength`, `ClientException: Request aborted by 'abortTrigger'`, and `SocketException: Bad file descriptor, address = media.divine.video`. Note the last of those is now deliberately **still reported**, per the narrowing above.

I audited every WebSocket creation site before touching anything: `WebSocketConnectionManager._doConnect`, `RelayIsolateWorker.handleWS`, and the two `relay_base_io` factories are the only ones in production code, and each already awaits `ready` or listens to the stream with an `onError`. #2790 fixed exactly that leak in April. I verified the current behaviour with a throwaway harness against an unresolvable host: `WebSocketConnectionManager.connect()` and `RelayBase.connect()` both return `false` with **zero** errors escaping to the zone, and the unhandled `WebSocketChannelException` only appears when nothing awaits `ready` at all — which no production path does any more.

So there is no remaining unhandled boundary to catch this at, and inventing one would be a speculative fix. What is left is that the zone handler reports *everything* unconditionally, while `FlutterError.onError` uses the recoverable-error classifier. Gating both on the documented matrix makes them consistent and is what the issue's own implementation note asks for. This is a classification gate on what gets *reported*, not a widening of what the zone guard *catches* — the guard's scope is byte-for-byte the same.

**Related Issue:** Closes #7290

## Out of Scope

- The same bucket still contains `HttpException: Content size below specified contentLength` and `ClientException: Request aborted by 'abortTrigger'`. Both are the same not-reportable matrix row and would be silenced by widening the predicate by two types, but #7290 scopes the change to `SocketException` / `WebSocketChannelException`, so they are deliberately left alone rather than expanded into here. Worth a follow-up once this lands and the dashboard shows what remains.
- `classifyRecoverableFlutterError`'s other branches (image HTTP status failures, invalid image data, hero flight layout) keep their current non-fatal reports — they are not network failures. Its `isMediaHostLookup` branch matches on the error *string*, so it stays live and useful after the typed DNS check: a non-DNS `SocketException` from a media host — including the `Bad file descriptor, address = media.divine.video` variant — still gets filed by the classifier as a **non-fatal**, rather than reaching `previousOnError` as a fatal.
- A relay connect `TimeoutException` is the one error `AdapterWebSocketChannel` does *not* wrap into a `WebSocketChannelException`, so it still reaches Crashlytics even though the matrix row names timeouts. Left alone rather than widening the predicate again.
- The half-open socket that `WebSocketConnectionManager._handleDisconnect` drops without closing is tracked separately as #7310 and is not touched here. Keeping `EBADF` reportable is what preserves its signal.
- `PlatformDispatcher.instance.onError` in `CrashReportingService` remains the one ungated fatal reporting entry point. In-zone async errors are handled by `runZonedGuarded`, so reachability is limited to root-zone/platform/engine paths; that needs a separate reachability audit rather than being folded into this DNS-only PR.

## Verification

Run from `mobile/`:

- `mise exec -- dart format lib test integration_test` — 3166 files checked, 0 changed.
- `flutter analyze lib test integration_test` — `No issues found!`
- `flutter test test/utils/recoverable_flutter_error_test.dart test/utils/expected_network_error_test.dart test/main_uncaught_zone_error_test.dart` — 35 passed. Coverage pins each narrowing decision: FlutterError DNS returns `report: false`; non-DNS media socket failures still report; zone-handler DNS is dropped; `EBADF`, refused connection, wrapped TLS `HandshakeException`, wrapped `ArgumentError`/`FormatException`, wrapped non-101 upgrade and wrapped `EBADF` all reported; a wrapper with no `inner` still dropped.
- Mutation check that the new assertions can actually fail — reverting the predicate to the old type-only form turns 8 red; dropping the `inner == null` clause turns 1 red; removing the recursion turns 5 red.
- `flutter build web --release` — verifies the `SocketException` web stub and the conditional import still compile for web. Green.
- Throwaway repro harness (not committed) against an unresolvable host, used to confirm the zone-escape mechanism, to rule out a leaking WebSocket boundary, and to capture the real `SocketException` shape (`message`, `osError.errorCode`, `address`, `port`) that the DNS discriminator is built on.
- Manual verification on a real Samsung Galaxy: pending (owner).

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
