### PR TITLE
fix(ci): pin package CI to the repo's Flutter toolchain

### DIFF
--- a/.github/workflows/analytics.yaml
+++ b/.github/workflows/analytics.yaml
@@ -24,4 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/analytics"
+      flutter_version: "3.44.0"
       min_coverage: 73

--- a/.github/workflows/app_update_repository.yaml
+++ b/.github/workflows/app_update_repository.yaml
@@ -24,4 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/app_update_repository"
+      flutter_version: "3.44.0"
       min_coverage: 89

--- a/.github/workflows/app_version_client.yaml
+++ b/.github/workflows/app_version_client.yaml
@@ -24,4 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/app_version_client"
+      flutter_version: "3.44.0"
       min_coverage: 76

--- a/.github/workflows/background_uploader.yaml
+++ b/.github/workflows/background_uploader.yaml
@@ -24,4 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/background_uploader"
+      flutter_version: "3.44.0"
       min_coverage: 69

--- a/.github/workflows/badge_repository.yaml
+++ b/.github/workflows/badge_repository.yaml
@@ -24,3 +24,4 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/badge_repository"
+      flutter_version: "3.44.0"

--- a/.github/workflows/blossom_upload_service.yaml
+++ b/.github/workflows/blossom_upload_service.yaml
@@ -24,4 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/blossom_upload_service"
+      flutter_version: "3.44.0"
       min_coverage: 100

--- a/.github/workflows/blurhash_service.yaml
+++ b/.github/workflows/blurhash_service.yaml
@@ -24,3 +24,4 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/blurhash_service"
+      flutter_version: "3.44.0"

--- a/.github/workflows/cache_sync.yml
+++ b/.github/workflows/cache_sync.yml
@@ -24,4 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/cache_sync"
+      flutter_version: "3.44.0"
       coverage_excludes: "**/*.g.dart"

--- a/.github/workflows/caption_generator.yaml
+++ b/.github/workflows/caption_generator.yaml
@@ -24,6 +24,7 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/caption_generator"
+      flutter_version: "3.44.0"
 
   # The Dart workflow above never compiles the native Kotlin, so a compile
   # error would pass green until the package is wired into an app build.

--- a/.github/workflows/categories_repository.yaml
+++ b/.github/workflows/categories_repository.yaml
@@ -24,3 +24,4 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/categories_repository"
+      flutter_version: "3.44.0"

--- a/.github/workflows/collaborator_repository.yaml
+++ b/.github/workflows/collaborator_repository.yaml
@@ -24,4 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/collaborator_repository"
+      flutter_version: "3.44.0"
       min_coverage: 96

--- a/.github/workflows/comments_repository.yaml
+++ b/.github/workflows/comments_repository.yaml
@@ -24,4 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/comments_repository"
+      flutter_version: "3.44.0"
       min_coverage: 80

--- a/.github/workflows/content_blocklist_repository.yaml
+++ b/.github/workflows/content_blocklist_repository.yaml
@@ -24,3 +24,4 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/content_blocklist_repository"
+      flutter_version: "3.44.0"

--- a/.github/workflows/content_policy.yaml
+++ b/.github/workflows/content_policy.yaml
@@ -24,3 +24,4 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/content_policy"
+      flutter_version: "3.44.0"

--- a/.github/workflows/count_formatter.yaml
+++ b/.github/workflows/count_formatter.yaml
@@ -24,3 +24,4 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/count_formatter"
+      flutter_version: "3.44.0"

--- a/.github/workflows/curated_list_repository.yaml
+++ b/.github/workflows/curated_list_repository.yaml
@@ -24,3 +24,4 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/curated_list_repository"
+      flutter_version: "3.44.0"

--- a/.github/workflows/curation_repository.yaml
+++ b/.github/workflows/curation_repository.yaml
@@ -24,3 +24,4 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/curation_repository"
+      flutter_version: "3.44.0"

--- a/.github/workflows/db_client.yaml
+++ b/.github/workflows/db_client.yaml
@@ -24,4 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/db_client"
+      flutter_version: "3.44.0"
       min_coverage: 40

--- a/.github/workflows/divine_blurhash.yaml
+++ b/.github/workflows/divine_blurhash.yaml
@@ -24,3 +24,4 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/divine_blurhash"
+      flutter_version: "3.44.0"

--- a/.github/workflows/divine_camera.yaml
+++ b/.github/workflows/divine_camera.yaml
@@ -24,6 +24,7 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/divine_camera"
+      flutter_version: "3.44.0"
 
   android-unit-tests:
     name: Android Unit Tests

--- a/.github/workflows/divine_quick_actions.yaml
+++ b/.github/workflows/divine_quick_actions.yaml
@@ -24,4 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/divine_quick_actions"
+      flutter_version: "3.44.0"
       min_coverage: 76

--- a/.github/workflows/divine_ui.yml
+++ b/.github/workflows/divine_ui.yml
@@ -24,3 +24,4 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/divine_ui"
+      flutter_version: "3.44.0"

--- a/.github/workflows/divine_video_player.yaml
+++ b/.github/workflows/divine_video_player.yaml
@@ -24,6 +24,7 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/divine_video_player"
+      flutter_version: "3.44.0"
 
   android-unit-tests:
     name: Android Unit Tests

--- a/.github/workflows/dm_repository.yaml
+++ b/.github/workflows/dm_repository.yaml
@@ -24,4 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/dm_repository"
+      flutter_version: "3.44.0"
       min_coverage: 93

--- a/.github/workflows/feed_repository.yaml
+++ b/.github/workflows/feed_repository.yaml
@@ -24,4 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/feed_repository"
+      flutter_version: "3.44.0"
       min_coverage: 64

--- a/.github/workflows/feed_tuning_repository.yaml
+++ b/.github/workflows/feed_tuning_repository.yaml
@@ -24,3 +24,4 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/feed_tuning_repository"
+      flutter_version: "3.44.0"

--- a/.github/workflows/follow_repository.yaml
+++ b/.github/workflows/follow_repository.yaml
@@ -24,3 +24,4 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/follow_repository"
+      flutter_version: "3.44.0"

--- a/.github/workflows/funnelcake_api_client.yaml
+++ b/.github/workflows/funnelcake_api_client.yaml
@@ -24,4 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/funnelcake_api_client"
+      flutter_version: "3.44.0"
       min_coverage: 44

--- a/.github/workflows/hashtag_repository.yaml
+++ b/.github/workflows/hashtag_repository.yaml
@@ -24,4 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/hashtag_repository"
+      flutter_version: "3.44.0"
       min_coverage: 30

--- a/.github/workflows/iap_repository.yaml
+++ b/.github/workflows/iap_repository.yaml
@@ -24,4 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/iap_repository"
+      flutter_version: "3.44.0"
       min_coverage: 90

--- a/.github/workflows/image_metadata_stripper.yaml
+++ b/.github/workflows/image_metadata_stripper.yaml
@@ -24,3 +24,4 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/image_metadata_stripper"
+      flutter_version: "3.44.0"

--- a/.github/workflows/infinite_video_feed.yaml
+++ b/.github/workflows/infinite_video_feed.yaml
@@ -24,3 +24,4 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/infinite_video_feed"
+      flutter_version: "3.44.0"

--- a/.github/workflows/invite_api_client.yaml
+++ b/.github/workflows/invite_api_client.yaml
@@ -24,4 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/invite_api_client"
+      flutter_version: "3.44.0"
       min_coverage: 89

--- a/.github/workflows/keycast_flutter.yaml
+++ b/.github/workflows/keycast_flutter.yaml
@@ -24,4 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/keycast_flutter"
+      flutter_version: "3.44.0"
       min_coverage: 44

--- a/.github/workflows/likes_repository.yaml
+++ b/.github/workflows/likes_repository.yaml
@@ -24,4 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/likes_repository"
+      flutter_version: "3.44.0"
       min_coverage: 62

--- a/.github/workflows/media_cache.yml
+++ b/.github/workflows/media_cache.yml
@@ -24,4 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/media_cache"
+      flutter_version: "3.44.0"
       min_coverage: 98

--- a/.github/workflows/nostr_app_bridge_repository.yaml
+++ b/.github/workflows/nostr_app_bridge_repository.yaml
@@ -24,4 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/nostr_app_bridge_repository"
+      flutter_version: "3.44.0"
       min_coverage: 78

--- a/.github/workflows/nostr_client.yaml
+++ b/.github/workflows/nostr_client.yaml
@@ -24,4 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/nostr_client"
+      flutter_version: "3.44.0"
       min_coverage: 82

--- a/.github/workflows/nostr_key_manager.yml
+++ b/.github/workflows/nostr_key_manager.yml
@@ -24,4 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/nostr_key_manager"
+      flutter_version: "3.44.0"
       min_coverage: 52

--- a/.github/workflows/nostr_sdk.yaml
+++ b/.github/workflows/nostr_sdk.yaml
@@ -24,4 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/nostr_sdk"
+      flutter_version: "3.44.0"
       min_coverage: 20

--- a/.github/workflows/notification_repository.yaml
+++ b/.github/workflows/notification_repository.yaml
@@ -24,4 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/notification_repository"
+      flutter_version: "3.44.0"
       min_coverage: 94

--- a/.github/workflows/people_lists_repository.yaml
+++ b/.github/workflows/people_lists_repository.yaml
@@ -24,4 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/people_lists_repository"
+      flutter_version: "3.44.0"
       min_coverage: 95

--- a/.github/workflows/permissions_service.yaml
+++ b/.github/workflows/permissions_service.yaml
@@ -24,4 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/permissions_service"
+      flutter_version: "3.44.0"
       min_coverage: 22

--- a/.github/workflows/profile_repository.yaml
+++ b/.github/workflows/profile_repository.yaml
@@ -24,3 +24,4 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/profile_repository"
+      flutter_version: "3.44.0"

--- a/.github/workflows/reposts_repository.yaml
+++ b/.github/workflows/reposts_repository.yaml
@@ -24,3 +24,4 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/reposts_repository"
+      flutter_version: "3.44.0"

--- a/.github/workflows/sound_service.yaml
+++ b/.github/workflows/sound_service.yaml
@@ -24,3 +24,4 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/sound_service"
+      flutter_version: "3.44.0"

--- a/.github/workflows/text_sanitizer.yaml
+++ b/.github/workflows/text_sanitizer.yaml
@@ -24,3 +24,4 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/text_sanitizer"
+      flutter_version: "3.44.0"

--- a/.github/workflows/time_formatter.yaml
+++ b/.github/workflows/time_formatter.yaml
@@ -24,4 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/time_formatter"
+      flutter_version: "3.44.0"
       min_coverage: 100

--- a/.github/workflows/tv_static_effect.yaml
+++ b/.github/workflows/tv_static_effect.yaml
@@ -24,3 +24,4 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/tv_static_effect"
+      flutter_version: "3.44.0"

--- a/.github/workflows/unified_logger.yaml
+++ b/.github/workflows/unified_logger.yaml
@@ -24,4 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/unified_logger"
+      flutter_version: "3.44.0"
       min_coverage: 40

--- a/.github/workflows/verifier_client.yaml
+++ b/.github/workflows/verifier_client.yaml
@@ -24,4 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/verifier_client"
+      flutter_version: "3.44.0"
       min_coverage: 76

--- a/.github/workflows/video_event_cache.yaml
+++ b/.github/workflows/video_event_cache.yaml
@@ -24,4 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/video_event_cache"
+      flutter_version: "3.44.0"
       min_coverage: 0

--- a/.github/workflows/videos_repository.yaml
+++ b/.github/workflows/videos_repository.yaml
@@ -24,3 +24,4 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/videos_repository"
+      flutter_version: "3.44.0"


### PR DESCRIPTION
## Description

The 53 package workflows that call the VeryGood reusable `flutter_package.yml` passed no `flutter_version`. That input defaults to `flutter_channel: "stable"`, so package CI ran on whatever stable was that day, while the rest of the repo pins `3.44.0` in `mobile/mise.toml` (used by the pre-push hook and Mobile CI). Package CI was the only thing in the repo on a floating toolchain.

Stable moved `3.44.9` to `3.47.0` on 2026-08-13 and the two formatters stopped agreeing. 3.47 reformats two `nostr_sdk` test files that are clean at 3.44, so any PR touching that package fails its workflow on a diff nobody wrote. #7282 hit this three times.

Reformatting is not an escape: the pinned pre-commit hook reformats the files straight back, so no file content satisfies both gates. Pinning makes a Flutter bump an explicit, reviewable change that reformats everything once, rather than one that lands by itself and retroactively redefines what passes.

This adds `flutter_version: "3.44.0"` after `working_directory` in every caller that lacked it, matching the convention already used by `creator_sync.yaml`, `models_ci.yaml`, and `sounds_repository.yaml`.

**Related Issue:** Closes #7285

## Out of Scope

The issue's third acceptance criterion asks whether a pinned format check should also cover `mobile/packages/` on every PR. Recording the decision rather than building it here: **not in this PR.** Today `Mobile CI`'s Format job pins 3.44.0 but only formats `mobile/{lib,test,integration_test,tools}`, so package formatting is still guarded only when a path filter happens to fire. Extending it is a real behavior change — it would newly gate every PR on 56 packages' formatting — and deserves its own change rather than riding along with a mechanical pin.

Bumping Flutter is likewise a separate, deliberate PR now, which is the point of the pin.

## Verification

- All 56 `flutter_package.yml` callers now pass `flutter_version: "3.44.0"`; verified the value matches `mobile/mise.toml`.
- Structural check that the new key sits directly after `working_directory` at matching indentation inside each `with:` block: 56 correct, 0 problems.
- Swept for other floating toolchain sources: no `subosito/flutter-action` step lacks `flutter-version`, and the only other VeryGood reusable workflow in use is `semantic_pull_request.yml`, which involves no Flutter.
- Every touched workflow lists its own file in its `paths:` filter, so all 53 run on this PR. Green `Nostr SDK CI` here is the direct check against the failure in #7282.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] ✅ Build configuration change
