### PR TITLE
ci(packages): pin package workflows to the repo Flutter toolchain

### DIFF
--- a/.github/workflows/analytics.yaml
+++ b/.github/workflows/analytics.yaml
@@ -24,4 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/analytics"
+      flutter_version: "3.44.0"
       min_coverage: 73

--- a/.github/workflows/app_update_repository.yaml
+++ b/.github/workflows/app_update_repository.yaml
@@ -24,4 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/app_update_repository"
+      flutter_version: "3.44.0"
       min_coverage: 89

--- a/.github/workflows/app_version_client.yaml
+++ b/.github/workflows/app_version_client.yaml
@@ -24,4 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/app_version_client"
+      flutter_version: "3.44.0"
       min_coverage: 76

--- a/.github/workflows/background_uploader.yaml
+++ b/.github/workflows/background_uploader.yaml
@@ -24,4 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/background_uploader"
+      flutter_version: "3.44.0"
       min_coverage: 69

--- a/.github/workflows/badge_repository.yaml
+++ b/.github/workflows/badge_repository.yaml
@@ -24,3 +24,4 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/badge_repository"
+      flutter_version: "3.44.0"

--- a/.github/workflows/blossom_upload_service.yaml
+++ b/.github/workflows/blossom_upload_service.yaml
@@ -24,4 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/blossom_upload_service"
+      flutter_version: "3.44.0"
       min_coverage: 100

--- a/.github/workflows/blurhash_service.yaml
+++ b/.github/workflows/blurhash_service.yaml
@@ -24,3 +24,4 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/blurhash_service"
+      flutter_version: "3.44.0"

--- a/.github/workflows/cache_sync.yml
+++ b/.github/workflows/cache_sync.yml
@@ -24,4 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/cache_sync"
+      flutter_version: "3.44.0"
       coverage_excludes: "**/*.g.dart"

--- a/.github/workflows/caption_generator.yaml
+++ b/.github/workflows/caption_generator.yaml
@@ -24,6 +24,7 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/caption_generator"
+      flutter_version: "3.44.0"
 
   # The Dart workflow above never compiles the native Kotlin, so a compile
   # error would pass green until the package is wired into an app build.

--- a/.github/workflows/categories_repository.yaml
+++ b/.github/workflows/categories_repository.yaml
@@ -24,3 +24,4 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/categories_repository"
+      flutter_version: "3.44.0"

--- a/.github/workflows/collaborator_repository.yaml
+++ b/.github/workflows/collaborator_repository.yaml
@@ -24,4 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/collaborator_repository"
+      flutter_version: "3.44.0"
       min_coverage: 96

--- a/.github/workflows/comments_repository.yaml
+++ b/.github/workflows/comments_repository.yaml
@@ -24,4 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/comments_repository"
+      flutter_version: "3.44.0"
       min_coverage: 80

--- a/.github/workflows/content_blocklist_repository.yaml
+++ b/.github/workflows/content_blocklist_repository.yaml
@@ -24,3 +24,4 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/content_blocklist_repository"
+      flutter_version: "3.44.0"

--- a/.github/workflows/content_policy.yaml
+++ b/.github/workflows/content_policy.yaml
@@ -24,3 +24,4 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/content_policy"
+      flutter_version: "3.44.0"

--- a/.github/workflows/count_formatter.yaml
+++ b/.github/workflows/count_formatter.yaml
@@ -24,3 +24,4 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/count_formatter"
+      flutter_version: "3.44.0"

--- a/.github/workflows/curated_list_repository.yaml
+++ b/.github/workflows/curated_list_repository.yaml
@@ -24,3 +24,4 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/curated_list_repository"
+      flutter_version: "3.44.0"

--- a/.github/workflows/curation_repository.yaml
+++ b/.github/workflows/curation_repository.yaml
@@ -24,3 +24,4 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/curation_repository"
+      flutter_version: "3.44.0"

--- a/.github/workflows/db_client.yaml
+++ b/.github/workflows/db_client.yaml
@@ -24,4 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/db_client"
+      flutter_version: "3.44.0"
       min_coverage: 40

--- a/.github/workflows/divine_blurhash.yaml
+++ b/.github/workflows/divine_blurhash.yaml
@@ -24,3 +24,4 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/divine_blurhash"
+      flutter_version: "3.44.0"

--- a/.github/workflows/divine_camera.yaml
+++ b/.github/workflows/divine_camera.yaml
@@ -24,6 +24,7 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/divine_camera"
+      flutter_version: "3.44.0"
 
   android-unit-tests:
     name: Android Unit Tests

--- a/.github/workflows/divine_quick_actions.yaml
+++ b/.github/workflows/divine_quick_actions.yaml
@@ -24,4 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/divine_quick_actions"
+      flutter_version: "3.44.0"
       min_coverage: 76

--- a/.github/workflows/divine_ui.yml
+++ b/.github/workflows/divine_ui.yml
@@ -24,3 +24,4 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/divine_ui"
+      flutter_version: "3.44.0"

--- a/.github/workflows/divine_video_player.yaml
+++ b/.github/workflows/divine_video_player.yaml
@@ -24,6 +24,7 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/divine_video_player"
+      flutter_version: "3.44.0"
 
   android-unit-tests:
     name: Android Unit Tests

--- a/.github/workflows/dm_repository.yaml
+++ b/.github/workflows/dm_repository.yaml
@@ -24,4 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/dm_repository"
+      flutter_version: "3.44.0"
       min_coverage: 93

--- a/.github/workflows/feed_repository.yaml
+++ b/.github/workflows/feed_repository.yaml
@@ -24,4 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/feed_repository"
+      flutter_version: "3.44.0"
       min_coverage: 64

--- a/.github/workflows/feed_tuning_repository.yaml
+++ b/.github/workflows/feed_tuning_repository.yaml
@@ -24,3 +24,4 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/feed_tuning_repository"
+      flutter_version: "3.44.0"

--- a/.github/workflows/follow_repository.yaml
+++ b/.github/workflows/follow_repository.yaml
@@ -24,3 +24,4 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/follow_repository"
+      flutter_version: "3.44.0"

--- a/.github/workflows/funnelcake_api_client.yaml
+++ b/.github/workflows/funnelcake_api_client.yaml
@@ -24,4 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/funnelcake_api_client"
+      flutter_version: "3.44.0"
       min_coverage: 44

--- a/.github/workflows/hashtag_repository.yaml
+++ b/.github/workflows/hashtag_repository.yaml
@@ -24,4 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/hashtag_repository"
+      flutter_version: "3.44.0"
       min_coverage: 30

--- a/.github/workflows/iap_repository.yaml
+++ b/.github/workflows/iap_repository.yaml
@@ -24,4 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/iap_repository"
+      flutter_version: "3.44.0"
       min_coverage: 90

--- a/.github/workflows/image_metadata_stripper.yaml
+++ b/.github/workflows/image_metadata_stripper.yaml
@@ -24,3 +24,4 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/image_metadata_stripper"
+      flutter_version: "3.44.0"

--- a/.github/workflows/infinite_video_feed.yaml
+++ b/.github/workflows/infinite_video_feed.yaml
@@ -24,3 +24,4 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/infinite_video_feed"
+      flutter_version: "3.44.0"

--- a/.github/workflows/invite_api_client.yaml
+++ b/.github/workflows/invite_api_client.yaml
@@ -24,4 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/invite_api_client"
+      flutter_version: "3.44.0"
       min_coverage: 89

--- a/.github/workflows/keycast_flutter.yaml
+++ b/.github/workflows/keycast_flutter.yaml
@@ -24,4 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/keycast_flutter"
+      flutter_version: "3.44.0"
       min_coverage: 44

--- a/.github/workflows/likes_repository.yaml
+++ b/.github/workflows/likes_repository.yaml
@@ -24,4 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/likes_repository"
+      flutter_version: "3.44.0"
       min_coverage: 62

--- a/.github/workflows/media_cache.yml
+++ b/.github/workflows/media_cache.yml
@@ -24,4 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/media_cache"
+      flutter_version: "3.44.0"
       min_coverage: 98

--- a/.github/workflows/nostr_app_bridge_repository.yaml
+++ b/.github/workflows/nostr_app_bridge_repository.yaml
@@ -24,4 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/nostr_app_bridge_repository"
+      flutter_version: "3.44.0"
       min_coverage: 78

--- a/.github/workflows/nostr_client.yaml
+++ b/.github/workflows/nostr_client.yaml
@@ -24,4 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/nostr_client"
+      flutter_version: "3.44.0"
       min_coverage: 82

--- a/.github/workflows/nostr_key_manager.yml
+++ b/.github/workflows/nostr_key_manager.yml
@@ -24,4 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/nostr_key_manager"
+      flutter_version: "3.44.0"
       min_coverage: 52

--- a/.github/workflows/nostr_sdk.yaml
+++ b/.github/workflows/nostr_sdk.yaml
@@ -24,4 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/nostr_sdk"
+      flutter_version: "3.44.0"
       min_coverage: 20

--- a/.github/workflows/notification_repository.yaml
+++ b/.github/workflows/notification_repository.yaml
@@ -24,4 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/notification_repository"
+      flutter_version: "3.44.0"
       min_coverage: 94

--- a/.github/workflows/people_lists_repository.yaml
+++ b/.github/workflows/people_lists_repository.yaml
@@ -24,4 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/people_lists_repository"
+      flutter_version: "3.44.0"
       min_coverage: 95

--- a/.github/workflows/permissions_service.yaml
+++ b/.github/workflows/permissions_service.yaml
@@ -24,4 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/permissions_service"
+      flutter_version: "3.44.0"
       min_coverage: 22

--- a/.github/workflows/profile_repository.yaml
+++ b/.github/workflows/profile_repository.yaml
@@ -24,3 +24,4 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/profile_repository"
+      flutter_version: "3.44.0"

--- a/.github/workflows/reposts_repository.yaml
+++ b/.github/workflows/reposts_repository.yaml
@@ -24,3 +24,4 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/reposts_repository"
+      flutter_version: "3.44.0"

--- a/.github/workflows/sound_service.yaml
+++ b/.github/workflows/sound_service.yaml
@@ -24,3 +24,4 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/sound_service"
+      flutter_version: "3.44.0"

--- a/.github/workflows/text_sanitizer.yaml
+++ b/.github/workflows/text_sanitizer.yaml
@@ -24,3 +24,4 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/text_sanitizer"
+      flutter_version: "3.44.0"

--- a/.github/workflows/time_formatter.yaml
+++ b/.github/workflows/time_formatter.yaml
@@ -24,4 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/time_formatter"
+      flutter_version: "3.44.0"
       min_coverage: 100

--- a/.github/workflows/tv_static_effect.yaml
+++ b/.github/workflows/tv_static_effect.yaml
@@ -24,3 +24,4 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/tv_static_effect"
+      flutter_version: "3.44.0"

--- a/.github/workflows/unified_logger.yaml
+++ b/.github/workflows/unified_logger.yaml
@@ -24,4 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/unified_logger"
+      flutter_version: "3.44.0"
       min_coverage: 40

--- a/.github/workflows/verifier_client.yaml
+++ b/.github/workflows/verifier_client.yaml
@@ -24,4 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/verifier_client"
+      flutter_version: "3.44.0"
       min_coverage: 76

--- a/.github/workflows/video_event_cache.yaml
+++ b/.github/workflows/video_event_cache.yaml
@@ -24,4 +24,5 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/video_event_cache"
+      flutter_version: "3.44.0"
       min_coverage: 0

--- a/.github/workflows/videos_repository.yaml
+++ b/.github/workflows/videos_repository.yaml
@@ -24,3 +24,4 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/videos_repository"
+      flutter_version: "3.44.0"


### PR DESCRIPTION
## Problem

53 of the 56 workflows calling the VeryGood `flutter_package.yml@v1` passed no `flutter_version`, so that input defaulted to `flutter_channel: stable` — whatever Flutter stable happened to be that day. The repo itself pins **3.44.0 / Dart 3.12** in `mobile/mise.toml`, used by `Mobile CI`, the pre-commit hook, and every local run.

Stable rolled **3.44.9 → 3.47.0** on 2026-08-13, and the two toolchains now disagree about `dart format` output.

## Why this is unpassable, not just noisy

Dart 3.13 hugs a trailing function-literal argument — `test('…', () async { … })` on one line — where 3.12 splits it. Neither formatter accepts the other's output, so **no file content satisfies both gates**: formatting for 3.13 makes the pinned-3.12 pre-commit hook reject the commit, and `--no-verify` is not an option.

A contributor who hits this has no correct action available. Three PRs ate it on `nostr_sdk` in a single day — #7279, #7282, #7288 — all on the same two test files none of them touched:

```
Formatted test/integration/temp_relay_lifetime_test.dart
Formatted test/unit/nostr_connect_session_test.dart
Formatted 177 files (2 changed)
```

## Why nothing caught it

- `Mobile CI`'s Format job pins 3.44.0 but formats only `mobile/{lib,test,integration_test,tools}` — never `packages/`.
- Package workflows are path-filtered, so `main` stays green until someone touches a package. It is green because none has run since the bump, not because it would pass.

Package formatting was guarded exclusively by a floating toolchain, so every Flutter release could retroactively redefine what passes.

## Change

One line per workflow, matching the three that already did this (`creator_sync`, `models_ci`, `sounds_repository`):

```yaml
    with:
      working_directory: "mobile/packages/<pkg>"
      flutter_version: "3.44.0"
```

**Not requested, flagged for visibility:** `divine_ui.yml` and `nostr_key_manager.yml` also gain a trailing newline they were missing — `awk` normalized it. One byte each, no semantic change.

## Verification

- All 56 callers parse as valid YAML and resolve `flutter_version: "3.44.0"`.
- Diff is exactly +1 line per file; every added line is byte-identical.
- **This PR self-validates.** All 56 workflows list their own filename in `paths:`, so changing them triggers every package workflow here. If pinning breaks any package, this PR shows it rather than the next one to touch that package.

## Tradeoff, stated deliberately

The float did surface real problems — Dart 3.13's `unawaited_return_in_try_block` is how #7193 was found, including a genuine bug where `invite_api_client` closed a signer in `finally` before the returned future completed.

That argument holds for the **analyzer** and not the **formatter**. An analyzer diagnostic is actionable; the formatter divergence is unfixable by construction. Pinning keeps CI deterministic and matching local work; the useful half is better recovered on purpose — a scheduled job running analyze against latest stable that opens an issue — rather than by ambushing whichever PR touches a package next, weeks after the roll. Worth a follow-up issue; deliberately not built here to keep this reviewable.

Closes #7285
Closes #7286