### PR TITLE
fix(library): keep sub-second precision in the trash row duration

### DIFF
--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -3057,6 +3057,7 @@
             }
         }
     },
+    "libraryClipDuration": "{seconds} ሰከ",
     "libraryAddClips": "አክል",
     "libraryRecordVideo": "ቪዲዮ ይቅረጹ",
     "videoClipSemanticLabel": "የቪዲዮ ክሊፕ፣ {duration} ሰከንድ",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -2609,6 +2609,7 @@
             }
         }
     },
+    "libraryClipDuration": "{seconds} ث",
     "libraryTabClips": "مقاطع",
     "libraryTabDrafts": "مسودات",
     "libraryWebUnavailableDescription": "تُحفظ المسودات والمقاطع على جهازك. افتح Divine على هاتفك لإدارتها.",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -2818,6 +2818,7 @@
             }
         }
     },
+    "libraryClipDuration": "{seconds} сек",
     "libraryAddClips": "Добави",
     "libraryRecordVideo": "Запишете видео",
     "videoClipSemanticLabel": "Видео клип, {duration} секунди",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -2617,6 +2617,7 @@
             }
         }
     },
+    "libraryClipDuration": "{seconds} Sek",
     "libraryTabClips": "Clips",
     "libraryTabDrafts": "Entwürfe",
     "libraryWebUnavailableDescription": "Entwürfe und Clips werden auf deinem Gerät gespeichert. Öffne Divine auf dem Smartphone, um sie zu verwalten.",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -4206,6 +4206,15 @@
       }
     }
   },
+  "libraryClipDuration": "{seconds}s",
+  "@libraryClipDuration": {
+    "description": "Compact clip duration shown in the library trash row. {seconds} is already formatted with two decimal places, e.g. '5.73'.",
+    "placeholders": {
+      "seconds": {
+        "type": "String"
+      }
+    }
+  },
   "libraryAddClips": "Add",
   "libraryRecordVideo": "Record a Video",
   "videoClipSemanticLabel": "Video clip, {duration} seconds",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -2625,6 +2625,7 @@
             }
         }
     },
+    "libraryClipDuration": "{seconds} s",
     "libraryTabClips": "Clips",
     "libraryTabDrafts": "Borradores",
     "libraryWebUnavailableDescription": "Los borradores y clips se guardan en tu dispositivo; abre Divine en el teléfono para gestionarlos.",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -1715,6 +1715,7 @@
     "libraryDeleteClipMessage": "Sigurado ka bang gusto mong burahin ang clip na ito?",
     "libraryClipSelectionTitle": "Mga Clip",
     "librarySecondsRemaining": "{seconds}s ang natitira",
+    "libraryClipDuration": "{seconds}s",
     "libraryAddClips": "Idagdag",
     "libraryRecordVideo": "Mag-record ng Video",
     "videoClipSemanticLabel": "Video clip, {duration} segundo",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -2617,6 +2617,7 @@
             }
         }
     },
+    "libraryClipDuration": "{seconds} s",
     "libraryTabClips": "Clips",
     "libraryTabDrafts": "Brouillons",
     "libraryWebUnavailableDescription": "Les brouillons et clips sont enregistrés sur ton appareil : ouvre Divine sur ton téléphone pour les gérer.",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -2616,6 +2616,7 @@
             }
         }
     },
+    "libraryClipDuration": "{seconds} dtk",
     "libraryTabClips": "Klip",
     "libraryTabDrafts": "Draf",
     "libraryWebUnavailableDescription": "Draf dan klip disimpan di perangkatmu — buka Divine di ponsel untuk mengelolanya.",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -2617,6 +2617,7 @@
             }
         }
     },
+    "libraryClipDuration": "{seconds} s",
     "libraryTabClips": "Clip",
     "libraryTabDrafts": "Bozze",
     "libraryWebUnavailableDescription": "Bozze e clip sono salvate sul dispositivo: apri Divine sul telefono per gestirle.",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -2609,6 +2609,7 @@
             }
         }
     },
+    "libraryClipDuration": "{seconds}秒",
     "libraryTabClips": "クリップ",
     "libraryTabDrafts": "下書き",
     "libraryWebUnavailableDescription": "下書きとクリップは端末に保存されます。管理するにはスマートフォンでDivineを開いてください。",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -1947,6 +1947,7 @@
             }
         }
     },
+    "libraryClipDuration": "{seconds}초",
     "libraryTabClips": "클립",
     "libraryTabDrafts": "임시 저장",
     "libraryWebUnavailableDescription": "임시 저장과 클립은 기기에 저장됩니다. 관리하려면 휴대폰에서 Divine을 열어 주세요.",

--- a/mobile/lib/l10n/app_ms.arb
+++ b/mobile/lib/l10n/app_ms.arb
@@ -3867,6 +3867,7 @@
       }
     }
   },
+  "libraryClipDuration": "{seconds}s",
   "libraryAddClips": "Tambah",
   "libraryRecordVideo": "Rakam Video",
   "videoClipSemanticLabel": "Klip video, {duration} saat",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -2617,6 +2617,7 @@
             }
         }
     },
+    "libraryClipDuration": "{seconds}s",
     "libraryTabClips": "Clips",
     "libraryTabDrafts": "Concepten",
     "libraryWebUnavailableDescription": "Concepten en clips worden op je apparaat opgeslagen. Open Divine op je telefoon om ze te beheren.",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -2617,6 +2617,7 @@
             }
         }
     },
+    "libraryClipDuration": "{seconds} s",
     "libraryTabClips": "Klify",
     "libraryTabDrafts": "Wersje robocze",
     "libraryWebUnavailableDescription": "Wersje robocze i klipy są na urządzeniu — otwórz Divine w telefonie, żeby nimi zarządzać.",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -2617,6 +2617,7 @@
             }
         }
     },
+    "libraryClipDuration": "{seconds} s",
     "libraryTabClips": "Clipes",
     "libraryTabDrafts": "Rascunhos",
     "libraryWebUnavailableDescription": "Rascunhos e clipes ficam no seu dispositivo — abra o Divine no celular para gerenciá-los.",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -2617,6 +2617,7 @@
             }
         }
     },
+    "libraryClipDuration": "{seconds} s",
     "libraryTabClips": "Clipuri",
     "libraryTabDrafts": "Ciorne",
     "libraryWebUnavailableDescription": "Ciornele și clipurile sunt pe dispozitivul tău — deschide Divine pe telefon ca să le gestionezi.",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -2617,6 +2617,7 @@
             }
         }
     },
+    "libraryClipDuration": "{seconds} s",
     "libraryTabClips": "Klipp",
     "libraryTabDrafts": "Utkast",
     "libraryWebUnavailableDescription": "Utkast och klipp sparas på enheten — öppna Divine i mobilen för att hantera dem.",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -2616,6 +2616,7 @@
             }
         }
     },
+    "libraryClipDuration": "{seconds} sn",
     "libraryTabClips": "Klipler",
     "libraryTabDrafts": "Taslaklar",
     "libraryWebUnavailableDescription": "Taslaklar ve klipler cihazında saklanır; yönetmek için Divine’ı telefonda aç.",

--- a/mobile/lib/l10n/app_ur.arb
+++ b/mobile/lib/l10n/app_ur.arb
@@ -3867,6 +3867,7 @@
       }
     }
   },
+  "libraryClipDuration": "{seconds}s",
   "libraryAddClips": "شامل کریں",
   "libraryRecordVideo": "ویڈیو ریکارڈ کریں",
   "videoClipSemanticLabel": "ویڈیو کلپ، {duration} سیکنڈ",

--- a/mobile/lib/l10n/app_vi.arb
+++ b/mobile/lib/l10n/app_vi.arb
@@ -3867,6 +3867,7 @@
       }
     }
   },
+  "libraryClipDuration": "{seconds} giây",
   "libraryAddClips": "Thêm",
   "libraryRecordVideo": "Quay video",
   "videoClipSemanticLabel": "Clip video, {duration} giây",

--- a/mobile/lib/l10n/app_zh.arb
+++ b/mobile/lib/l10n/app_zh.arb
@@ -3867,6 +3867,7 @@
       }
     }
   },
+  "libraryClipDuration": "{seconds} 秒",
   "libraryAddClips": "添加",
   "libraryRecordVideo": "录制视频",
   "videoClipSemanticLabel": "视频片段，{duration} 秒",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -11597,6 +11597,12 @@ abstract class AppLocalizations {
   /// **'{seconds}s remaining'**
   String librarySecondsRemaining(String seconds);
 
+  /// Compact clip duration shown in the library trash row. {seconds} is already formatted with two decimal places, e.g. '5.73'.
+  ///
+  /// In en, this message translates to:
+  /// **'{seconds}s'**
+  String libraryClipDuration(String seconds);
+
   /// No description provided for @libraryAddClips.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -6521,6 +6521,11 @@ class AppLocalizationsAm extends AppLocalizations {
   }
 
   @override
+  String libraryClipDuration(String seconds) {
+    return '$seconds ሰከ';
+  }
+
+  @override
   String get libraryAddClips => 'አክል';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -6613,6 +6613,11 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
+  String libraryClipDuration(String seconds) {
+    return '$seconds ث';
+  }
+
+  @override
   String get libraryAddClips => 'إضافة';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -6725,6 +6725,11 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
+  String libraryClipDuration(String seconds) {
+    return '$seconds сек';
+  }
+
+  @override
   String get libraryAddClips => 'Добави';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -6747,6 +6747,11 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String libraryClipDuration(String seconds) {
+    return '$seconds Sek';
+  }
+
+  @override
   String get libraryAddClips => 'Hinzufügen';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -6654,6 +6654,11 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String libraryClipDuration(String seconds) {
+    return '${seconds}s';
+  }
+
+  @override
   String get libraryAddClips => 'Add';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -6722,6 +6722,11 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String libraryClipDuration(String seconds) {
+    return '$seconds s';
+  }
+
+  @override
   String get libraryAddClips => 'Añadir';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -6746,6 +6746,11 @@ class AppLocalizationsFil extends AppLocalizations {
   }
 
   @override
+  String libraryClipDuration(String seconds) {
+    return '${seconds}s';
+  }
+
+  @override
   String get libraryAddClips => 'Idagdag';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -6750,6 +6750,11 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String libraryClipDuration(String seconds) {
+    return '$seconds s';
+  }
+
+  @override
   String get libraryAddClips => 'Ajouter';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -6626,6 +6626,11 @@ class AppLocalizationsId extends AppLocalizations {
   }
 
   @override
+  String libraryClipDuration(String seconds) {
+    return '$seconds dtk';
+  }
+
+  @override
   String get libraryAddClips => 'Tambah';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -6726,6 +6726,11 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String libraryClipDuration(String seconds) {
+    return '$seconds s';
+  }
+
+  @override
   String get libraryAddClips => 'Aggiungi';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -6361,6 +6361,11 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
+  String libraryClipDuration(String seconds) {
+    return '$seconds秒';
+  }
+
+  @override
   String get libraryAddClips => '追加';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -6390,6 +6390,11 @@ class AppLocalizationsKo extends AppLocalizations {
   }
 
   @override
+  String libraryClipDuration(String seconds) {
+    return '$seconds초';
+  }
+
+  @override
   String get libraryAddClips => '추가';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -6709,6 +6709,11 @@ class AppLocalizationsMs extends AppLocalizations {
   }
 
   @override
+  String libraryClipDuration(String seconds) {
+    return '${seconds}s';
+  }
+
+  @override
   String get libraryAddClips => 'Tambah';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -6696,6 +6696,11 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
+  String libraryClipDuration(String seconds) {
+    return '${seconds}s';
+  }
+
+  @override
   String get libraryAddClips => 'Toevoegen';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -6827,6 +6827,11 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
+  String libraryClipDuration(String seconds) {
+    return '$seconds s';
+  }
+
+  @override
   String get libraryAddClips => 'Dodaj';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -6707,6 +6707,11 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String libraryClipDuration(String seconds) {
+    return '$seconds s';
+  }
+
+  @override
   String get libraryAddClips => 'Adicionar';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -6823,6 +6823,11 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
+  String libraryClipDuration(String seconds) {
+    return '$seconds s';
+  }
+
+  @override
   String get libraryAddClips => 'Adaugă';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -6655,6 +6655,11 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
+  String libraryClipDuration(String seconds) {
+    return '$seconds s';
+  }
+
+  @override
   String get libraryAddClips => 'Lägg till';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -6626,6 +6626,11 @@ class AppLocalizationsTr extends AppLocalizations {
   }
 
   @override
+  String libraryClipDuration(String seconds) {
+    return '$seconds sn';
+  }
+
+  @override
   String get libraryAddClips => 'Ekle';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -6668,6 +6668,11 @@ class AppLocalizationsUr extends AppLocalizations {
   }
 
   @override
+  String libraryClipDuration(String seconds) {
+    return '${seconds}s';
+  }
+
+  @override
   String get libraryAddClips => 'شامل کریں';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -6666,6 +6666,11 @@ class AppLocalizationsVi extends AppLocalizations {
   }
 
   @override
+  String libraryClipDuration(String seconds) {
+    return '$seconds giây';
+  }
+
+  @override
   String get libraryAddClips => 'Thêm';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -6346,6 +6346,11 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
+  String libraryClipDuration(String seconds) {
+    return '$seconds 秒';
+  }
+
+  @override
   String get libraryAddClips => '添加';
 
   @override

--- a/mobile/lib/widgets/library/trashed_clips_list.dart
+++ b/mobile/lib/widgets/library/trashed_clips_list.dart
@@ -8,6 +8,7 @@ import 'package:openvine/blocs/clips_library/clips_library_bloc.dart';
 import 'package:openvine/constants/clip_library_constants.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/utils/video_editor_utils.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/library/empty_library_state.dart';
 import 'package:openvine/widgets/video_clip/video_clip_thumbnail_card.dart';
@@ -89,7 +90,7 @@ class _TrashedClipTile extends StatelessWidget {
           ),
         ),
         title: Text(
-          '${clip.durationInSeconds.toStringAsFixed(2)}s',
+          context.l10n.libraryClipDuration(clip.duration.toFormattedSeconds()),
           style: VineTheme.titleSmallFont(
             color: context.vineColors.primaryText,
           ),

--- a/mobile/lib/widgets/library/trashed_clips_list.dart
+++ b/mobile/lib/widgets/library/trashed_clips_list.dart
@@ -89,7 +89,7 @@ class _TrashedClipTile extends StatelessWidget {
           ),
         ),
         title: Text(
-          '${clip.duration.inSeconds}s',
+          '${clip.durationInSeconds.toStringAsFixed(2)}s',
           style: VineTheme.titleSmallFont(
             color: context.vineColors.primaryText,
           ),

--- a/mobile/test/widgets/library/trashed_clips_list_test.dart
+++ b/mobile/test/widgets/library/trashed_clips_list_test.dart
@@ -70,7 +70,7 @@ void main() {
       await tester.pump();
 
       expect(find.text(en.libraryTrashAutoDeletes(2)), findsOneWidget);
-      expect(find.text('5.00s'), findsOneWidget);
+      expect(find.text(en.libraryClipDuration('5.00')), findsOneWidget);
       expect(find.text('5.00'), findsNothing);
 
       await tester.tap(find.bySemanticsLabel(en.libraryTrashRestoreLabel));
@@ -100,7 +100,8 @@ void main() {
       );
       await tester.pump();
 
-      expect(find.text('0.40s'), findsOneWidget);
+      expect(find.text(en.libraryClipDuration('0.40')), findsOneWidget);
+      expect(find.text('0.40'), findsNothing);
       expect(find.text('0s'), findsNothing);
     });
 

--- a/mobile/test/widgets/library/trashed_clips_list_test.dart
+++ b/mobile/test/widgets/library/trashed_clips_list_test.dart
@@ -70,7 +70,7 @@ void main() {
       await tester.pump();
 
       expect(find.text(en.libraryTrashAutoDeletes(2)), findsOneWidget);
-      expect(find.text('5s'), findsOneWidget);
+      expect(find.text('5.00s'), findsOneWidget);
       expect(find.text('5.00'), findsNothing);
 
       await tester.tap(find.bySemanticsLabel(en.libraryTrashRestoreLabel));
@@ -79,6 +79,29 @@ void main() {
       verify(
         () => mockBloc.add(const ClipsLibraryRestoreClips({'trashed-clip'})),
       ).called(1);
+    });
+
+    testWidgets('keeps the fractional duration of a sub-second clip', (
+      tester,
+    ) async {
+      final subSecondClip = trashedClip.copyWith(
+        id: 'sub-second-clip',
+        duration: const Duration(milliseconds: 400),
+      );
+
+      await tester.pumpWidget(
+        buildWidget(
+          ClipsLibraryState(
+            status: ClipsLibraryStatus.trashLoaded,
+            filter: const ClipLibraryTrashFilter(),
+            trashedClips: [subSecondClip],
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text('0.40s'), findsOneWidget);
+      expect(find.text('0s'), findsNothing);
     });
 
     testWidgets('confirms before hard-deleting a clip', (tester) async {


### PR DESCRIPTION
## Description

The trash bin row shows a truncated duration and no exact value anywhere.

#7226 set `showDurationBadge: false` on the row's `VideoClipThumbnailCard`, on the rationale that the title already shows the duration. That holds only for whole-second clips: the title was `'${clip.duration.inSeconds}s'`, and `inSeconds` truncates. A 400 ms clip rendered as **"0s"**, with the badge that previously showed `0.40` hidden.

Clip durations are millisecond-precision (`DivineVideoClip.durationInSeconds => duration.inMilliseconds / 1000.0`) and the grid badge deliberately renders two decimals, so truncating in the trash row is inconsistent with how the same value is shown one screen over.

This renders the title from the existing `Duration.toFormattedSeconds()` helper and wraps the compact suffix in a localized `libraryClipDuration` key. The row now shows "0.40s" in English rather than "0s". The badge stays hidden, so #7226's layout intent is preserved.

Found by an automated review pass over #7226; that PR merged before the finding was raised, so this lands against `main` instead.

**Related Issue:** Relates to #7226

## Out of Scope

- No change to the grid badge or to `VideoClipThumbnailCard`.

## Verification

Run from `mobile/` with the mise-pinned Flutter 3.44.0.

- `flutter gen-l10n` → regenerated localization outputs.
- `flutter test test/l10n/arb_consistency_test.dart test/widgets/library/trashed_clips_list_test.dart` → pass.
- `flutter analyze lib test` → No issues found.
- Pre-push hook analyze + changed-file widget test → pass.
- GitHub checks for `33fc727` → all pass.

The trash row test now asserts the localized `0.40s` title is shown, the old `0s` title is absent, and the bare `0.40` badge text remains hidden.

**Not verified:** no golden test covers this row, so the visual result is reasoned from the widget tree rather than observed. The row is a `ListTile` title and the existing narrow-row overflow test passes.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
