### PR TITLE
docs(library): name the real reason both icon buttons measure 48px

### DIFF
--- a/mobile/test/widgets/library/library_toolbar_test.dart
+++ b/mobile/test/widgets/library/library_toolbar_test.dart
@@ -465,9 +465,10 @@ void main() {
         tester,
       ) async {
         // Every icon action is estimated as one 48px tap target, whatever its
-        // type: a destructive button pads by the border width a secondary one
-        // paints instead, so both land on the same outer bounds. If that stops
-        // holding, the estimate goes under and the row overflows.
+        // type: at `small` DivineIconButton centres its pill in an explicit
+        // 48px box, so the bordered secondary and the borderless destructive
+        // land on the same outer bounds however wide their pills draw. If
+        // that stops holding, the estimate goes under and the row overflows.
         await tester.pumpWidget(
           buildWidget(
             isLibrarySelectionMode: true,


### PR DESCRIPTION
## Description

`main` currently contradicts itself about why `_iconButtonWidth = 48.0` is safe.

The doc comment on the constant in `library_toolbar.dart` was corrected during #7172 (commit 526fca3c55) to describe the real invariant. The comment on the test that *pins* that constant was not brought along, so it still carries the old, incorrect reasoning:

> a destructive button pads by the border width a secondary one paints instead, so both land on the same outer bounds

That mechanism does not apply at the size the toolbar uses. In `divine_icon_button.dart:421-423` the compensating padding is `_hasBorder || size == DivineIconButtonSize.small ? 0 : _borderWidth`, so at `small` it is 0 for **both** `secondary` (bordered) and `error` (borderless). What actually fixes the outer bounds is the unconditional `SizedBox.square(dimension: DivineIcon.scaleSize(context, 48))` at `:400-404`. The old rationale is only true for `DivineIconButtonSize.base`.

The risk is a future reader concluding the estimate stays safe because border compensation exists, when the real dependency is the fixed 48px tap-target box — and so checking the wrong thing if that box ever becomes conditional.

Comment only. No code changes; `48.0` is correct and untouched.

**Related Issue:** Relates to #7172

## Out of Scope

- The lib-side doc comment is already correct as of 526fca3c55. Not re-edited.

## Verification

Run from `mobile/` with the mise-pinned Flutter 3.44.0.

- `flutter analyze lib test` → No issues found.
- `flutter test test/widgets/library/library_toolbar_test.dart` → 37/37 pass.
- `dart format --set-exit-if-changed` → clean.

The replacement wording was written after reading `divine_icon_button.dart` directly and confirming `_hasBorder` is true only for `DivineIconButtonType.secondary` (`:313`), and that `library_toolbar.dart:403/411` maps destructive → `.error` and non-destructive → `.secondary`.

**Not verified:** I did not measure rendered pill widths at runtime to confirm the two types visually coincide — the claim rests on reading the `SizedBox.square` constraint, and the existing width test already passes either way. This is a docs change, so nothing here alters behavior.

## Type of Change

- [x] 📝 Documentation
