### PR TITLE
test(bookmarks): pin the mid-decrypt window the racing-sync test missed

### DIFF
--- a/mobile/test/services/bookmark_service_test.dart
+++ b/mobile/test/services/bookmark_service_test.dart
@@ -1199,12 +1199,25 @@ void main() {
             () => settled = true,
           );
           var everReadUnsaved = false;
-          for (var i = 0; i < 1000 && !settled; i++) {
+          var sampledToCompletion = false;
+          for (var i = 0; i < 1000; i++) {
+            if (settled) {
+              sampledToCompletion = true;
+              break;
+            }
             everReadUnsaved |= !service.isVideoBookmarkedGlobally(privateVideo);
             await Future<void>.value();
           }
           await racing;
 
+          expect(
+            sampledToCompletion,
+            isTrue,
+            reason:
+                'the loop has to outlast the sync, or the assertion below '
+                'passes without ever having sampled the window - which is the '
+                'inert shape this test replaced',
+          );
           expect(
             everReadUnsaved,
             isFalse,

--- a/mobile/test/services/bookmark_service_test.dart
+++ b/mobile/test/services/bookmark_service_test.dart
@@ -1175,7 +1175,7 @@ void main() {
       });
 
       test(
-        'a sync racing the toggle cannot duplicate a private item',
+        'a racing sync never blanks the private items it is re-reading',
         () async {
           stubRelay(
             events: [
@@ -1188,21 +1188,30 @@ void main() {
             ],
           );
           final service = createService();
+          await service.syncGlobalBookmarks();
 
-          // The display read and the toggle share one service instance and
-          // neither is serialized, so both reach the decrypt await together.
-          final racingSync = service.syncGlobalBookmarks();
-          final toggle = service.toggleVideoInGlobalBookmarks(privateVideo);
-          await racingSync;
-          final result = await toggle;
+          // Syncs are not serialized (#7163), so a second one re-reads the
+          // list while the share sheet is still asking whether this video is
+          // saved. Sample that question across the whole re-read rather than
+          // at one instant, since the window is only as wide as the decrypt.
+          var settled = false;
+          final racing = service.syncGlobalBookmarks().whenComplete(
+            () => settled = true,
+          );
+          var everReadUnsaved = false;
+          for (var i = 0; i < 1000 && !settled; i++) {
+            everReadUnsaved |= !service.isVideoBookmarkedGlobally(privateVideo);
+            await Future<void>.value();
+          }
+          await racing;
 
-          expect(result.succeeded, isTrue);
           expect(
-            signedContent,
-            isEmpty,
+            everReadUnsaved,
+            isFalse,
             reason:
-                'a private item adopted twice survives List.remove, so the '
-                'relay keeps the bookmark the user was told was removed',
+                'clearing the private items before the decrypt await makes a '
+                'saved video read as unsaved mid-sync, and a save taken in '
+                'that window publishes it as a public tag (#7136)',
           );
         },
       );


### PR DESCRIPTION
## Description

`main` carries a regression test for the private-bookmark race that cannot fail — and, as review established, so does every other test in that file.

#7222 correctly fixed `_adoptGlobalBookmarksFromEvent` so the decrypt read completes before any mutation, closing the window where two unserialized syncs could interleave. The test guarding that fix — `'a sync racing the toggle cannot duplicate a private item'` — asserts that the re-encrypted `signedContent` ends up empty.

It cannot observe the bug. Removal builds `privateCandidate` from `_privateTags` (`bookmark_service.dart:613`), and `_privateTags` is *assigned* wholesale on each adopt (`:845`), never appended to. So even when two interleaved adopts duplicate `_privateBookmarks` into `[X, X]`, `_privateTags` still holds one copy and `removeWhere` still empties it. The published content is correct with the bug present. The test's stated reason is stale in a second way too: it cites `List.remove` dropping one of a duplicate pair, but the code now uses `removeWhere`.

**Measured, not inferred.** The bug was reintroduced on top of current `main` — moving `_privateBookmarks.clear()` back above the `await _readPrivateItems(content)` — and both tests run against it:

| Test | With bug reintroduced |
|---|---|
| `main`'s current `'…cannot duplicate a private item'` | **passes** (inert) |
| **all 56 tests in `bookmark_service_test.dart`** | **all pass** (@realmeylisdev, in review) |
| this PR's replacement | **fails** |

The middle row is the important one and it is broader than this PR originally claimed. I verified only the one named test was inert; @realmeylisdev re-ran the mutation across the whole file and found nothing in it catches the regression. The gap is file-wide, not a single stale test.

The replacement targets what the interleaving actually breaks: the window between `clear()` and the post-await `addAll`, during which a privately-bookmarked video reports `isVideoBookmarkedGlobally == false`. Since syncs are not serialized (#7163), a concurrent reader — the share sheet deciding whether to offer Save or Saved — can land in that window, read "not saved", and a save taken there republishes the item as a **public** tag. That is the #7136 disclosure this work exists to close, reached through a different door.

The test samples that question at microtask granularity across a racing sync. Event-loop granularity was tried first and missed the window entirely (passed 3/3 against the bug), which is worth knowing if this is ever retuned.

### Review fix: the sample loop could go quiet (`1fc146a`, @realmeylisdev)

The first version of this test reproduced the very defect it was written to remove. Its loop was `for (var i = 0; i < 1000 && !settled; i++)` — the iteration bound doubled as the exit condition, so a sync that outran the budget ended the loop early, left `everReadUnsaved` false, and passed vacuously. @realmeylisdev proved it by starving the loop to a single iteration with the bug present: **it passed.**

`1fc146a` separates the two concerns — the loop now records *why* it stopped and asserts it outlasted the sync, so exhausting the budget fails loudly instead of silently reporting success. Without that, this PR would have replaced one inert test with another.

Test-only change. No production code is touched.

**Related Issue:** Relates to #7222, #7136, #7163

## Out of Scope

- Serializing `syncGlobalBookmarks` (#7163). This PR pins the guarantee the current fix provides; it does not add serialization.
- Broader coverage for the rest of `bookmark_service_test.dart`. The file-wide gap @realmeylisdev found is real, but this PR fixes the one window it set out to pin rather than growing to audit all 56 tests.

## Verification

Run from `mobile/` with the mise-pinned Flutter 3.44.0.

- `flutter test test/services/bookmark_service_test.dart` → 56/56 pass.
- `flutter analyze lib test` → No issues found.
- `dart format --set-exit-if-changed` → clean.
- Red/green proof as tabled above, run against a locally-reverted `bookmark_service.dart`; the revert was discarded and the worktree confirmed clean before commit.
- Starvation proof for `1fc146a` run by @realmeylisdev, not by me.

**Not verified / known limits:**

- This is a timing-shaped test. I ran it on one machine only. @realmeylisdev reports the shards were green on `1fc146a`, which is a second data point against CI's merged-isolate `very_good test --optimization` bundle, but neither of us has stressed it under contention.
- I did not audit every caller that reads `_privateBookmarks` during that window. The share sheet is the exposed reader I traced and confirmed; treat it as the case established, not necessarily the only one.
- The file-wide inertness figure is @realmeylisdev's measurement, reproduced from his review rather than re-run by me.

## Type of Change

- [x] ✅ Build configuration change → *(test coverage; closest applicable box)*
