### PR TITLE
fix(dm): authenticate the read-marker author before applying read cursors

### DIFF
--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -5415,7 +5415,14 @@ class DmRepository {
     // GiftWrapUtil on every unwrap path, so anything else is forged — the
     // conversation id below is derived from participant pubkeys alone, which
     // are public. Fail closed when the local pubkey is unknown. #7343.
-    if (_userPubkey.isEmpty || rumor.pubkey != _userPubkey) return;
+    if (_userPubkey.isEmpty || rumor.pubkey != _userPubkey) {
+      Log.debug(
+        'Ignoring DM read marker ${rumor.id}: author mismatch '
+        '(event=${rumor.pubkey}, user=$_userPubkey)',
+        category: LogCategory.system,
+      );
+      return;
+    }
     final Object? decoded;
     try {
       decoded = jsonDecode(rumor.content);

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -5425,22 +5425,28 @@ class DmRepository {
     if (decoded is! Map) return;
     final read = decoded['read'];
     if (read is! Map) return;
+    // The cursor only ever moves forward, so an out-of-range value can never be
+    // undone: one marker published by a device with a corrupt clock would pin
+    // every conversation read for good. Clamp to the local clock, the same way
+    // an incoming rumor's own created_at is clamped for ordering. #7343.
+    final nowSec = DateTime.now().millisecondsSinceEpoch ~/ 1000;
     for (final entry in read.entries) {
       final tupleKey = entry.key;
       final ts = entry.value;
       if (tupleKey is! String || ts is! int) continue;
+      final cursor = ts > nowSec ? nowSec : ts;
       final pubkeys = tupleKey.split(',');
       if (pubkeys.length < 2) continue;
       final conversationId = computeConversationId(pubkeys);
       final applied = await _conversationsDao.applyReadCursor(
         conversationId,
-        ts,
+        cursor,
         ownerPubkey: _ownerPubkey,
       );
       if (!applied) {
         final existing = _pendingReadCursors[conversationId];
-        if (existing == null || ts > existing) {
-          _pendingReadCursors[conversationId] = ts;
+        if (existing == null || cursor > existing) {
+          _pendingReadCursors[conversationId] = cursor;
         }
       }
     }

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -5409,6 +5409,13 @@ class DmRepository {
   /// applied when the drain completes.
   Future<void> _reconcileReadMarker(Event rumor) async {
     if (!_hasReadMarkerDTag(rumor)) return;
+    // The marker is a self-authored control message: the sender gift-wraps it
+    // to their own pubkey, so the only legitimate author is the local user.
+    // `rumor.pubkey` is the seal signer, authenticated by the Schnorr check in
+    // GiftWrapUtil on every unwrap path, so anything else is forged — the
+    // conversation id below is derived from participant pubkeys alone, which
+    // are public. Fail closed when the local pubkey is unknown. #7343.
+    if (_userPubkey.isEmpty || rumor.pubkey != _userPubkey) return;
     final Object? decoded;
     try {
       decoded = jsonDecode(rumor.content);

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -7213,6 +7213,119 @@ void main() {
       );
     });
 
+    // The tests above inject a `rumorDecryptor`, so they never run the real
+    // unwrap — they assume `rumor.pubkey` is the authenticated seal signer.
+    // These run the production decryptor over real NIP-59 crypto so that
+    // assumption is executed rather than asserted. Real secp256k1 keys are
+    // needed: the `_validPubkey*` fixtures are arbitrary hex, not keypairs,
+    // so they cannot produce a seal whose signature verifies. #7343.
+    group('read-state marker forgery, real NIP-59 crypto (#7343)', () {
+      const victimPrivate =
+          '5c0c523f52a5b6fad39ed2403092df8cebc36318b39383bca6c00808626fab3a';
+      const attackerPrivate =
+          '9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60';
+      final victimPublic = getPublicKey(victimPrivate);
+      final tupleKey = (<String>[
+        victimPublic,
+        _validPubkeyB,
+      ]..sort()).join(',');
+      final conversationId = DmRepository.computeConversationId([
+        victimPublic,
+        _validPubkeyB,
+      ]);
+
+      Map<String, dynamic> markerRumorJson(String authorPubkey) => {
+        'pubkey': authorPubkey,
+        'created_at': 1700000300,
+        'kind': EventKind.appSpecificData,
+        'tags': [
+          ['d', 'divine/dm-read/v1'],
+        ],
+        'content': jsonEncode({
+          'v': 1,
+          'read': {tupleKey: 1700000300},
+        }),
+      };
+
+      /// Seals a read marker authored by [authorPrivate] to the victim as a
+      /// genuine kind-1059 wrap and pushes it through the live subscription.
+      /// No `rumorDecryptor` is injected, so `GiftWrapUtil.getRumorEvent` runs
+      /// and the seal's id and Schnorr signature are really verified.
+      Future<void> deliverRealWrapFrom(
+        String authorPrivate,
+        _InMemoryProcessedGiftWrapsDao ledger,
+      ) async {
+        final built = await buildGiftWrapFromHex(
+          senderPrivateKeyHex: authorPrivate,
+          rumorJson: markerRumorJson(getPublicKey(authorPrivate)),
+          receiverPublicKey: victimPublic,
+        );
+        expect(built, isNotNull, reason: 'the gift-wrap build must succeed');
+        final wrap = built!;
+
+        when(
+          () => mockDirectMessagesDao.hasGiftWrap(any()),
+        ).thenAnswer((_) async => false);
+        final controller = StreamController<Event>();
+        when(
+          () => mockNostrClient.subscribe(
+            any(),
+            subscriptionId: any(named: 'subscriptionId'),
+          ),
+        ).thenAnswer((_) => controller.stream);
+
+        final repository = createRepository(
+          userPubkey: victimPublic,
+          signer: LocalNostrSigner(victimPrivate),
+          processedGiftWrapsDao: ledger,
+        );
+        await repository.startListening();
+        controller.add(wrap);
+
+        // The wrap reaching the ledger is the signal that the read-marker
+        // branch ran to completion. Waiting on it rather than on a fixed sleep
+        // keeps both assertions independent of how long real Schnorr and
+        // NIP-44 work happens to take on the runner.
+        final deadline = DateTime.now().add(const Duration(seconds: 10));
+        while (!ledger.recorded.contains(wrap.id)) {
+          if (DateTime.now().isAfter(deadline)) {
+            fail('the wrap was never processed: ${wrap.id}');
+          }
+          await Future<void>.delayed(const Duration(milliseconds: 20));
+        }
+      }
+
+      test('a wrap sealed by the local user advances the cursor', () async {
+        await deliverRealWrapFrom(
+          victimPrivate,
+          _InMemoryProcessedGiftWrapsDao(),
+        );
+
+        verify(
+          () => mockConversationsDao.applyReadCursor(
+            conversationId,
+            1700000300,
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        ).called(1);
+      });
+
+      test('a wrap sealed by another key never advances a cursor', () async {
+        await deliverRealWrapFrom(
+          attackerPrivate,
+          _InMemoryProcessedGiftWrapsDao(),
+        );
+
+        verifyNever(
+          () => mockConversationsDao.applyReadCursor(
+            any(),
+            any(),
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        );
+      });
+    });
+
     // -----------------------------------------------------------------
     // removeConversation / removeConversations / markConversationsAsRead
     // / countMessagesInConversation

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -7092,6 +7092,96 @@ void main() {
           expect(ledger.recorded, isNot(contains(_giftWrapEventId)));
         },
       );
+
+      // Delivers [rumor] as the decrypted payload of a single incoming gift
+      // wrap on the live subscription, and returns the processed-wrap ledger
+      // that wrap was offered to.
+      Future<_InMemoryProcessedGiftWrapsDao> deliverMarkerRumor(
+        Event rumor,
+      ) async {
+        final ledger = _InMemoryProcessedGiftWrapsDao();
+        when(
+          () => mockDirectMessagesDao.hasGiftWrap(_giftWrapEventId),
+        ).thenAnswer((_) async => false);
+        final controller = StreamController<Event>();
+        when(
+          () => mockNostrClient.subscribe(
+            any(),
+            subscriptionId: any(named: 'subscriptionId'),
+          ),
+        ).thenAnswer((_) => controller.stream);
+
+        final repository = createRepository(
+          processedGiftWrapsDao: ledger,
+          rumorDecryptor: (_, _) async => rumor,
+        );
+        await repository.startListening();
+        controller.add(
+          Event.fromJson({
+            'id': _giftWrapEventId,
+            'pubkey':
+                'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+                'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            'created_at': 1700000000,
+            'kind': EventKind.giftWrap,
+            'tags': [
+              ['p', _validPubkeyA],
+            ],
+            'content': 'encrypted',
+            'sig': '',
+          }),
+        );
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+        return ledger;
+      }
+
+      Event readMarkerFrom(String authorPubkey) => Event.fromJson({
+        'id': _rumorEventId,
+        'pubkey': authorPubkey,
+        'created_at': 1700000300,
+        'kind': EventKind.appSpecificData,
+        'tags': [
+          ['d', 'divine/dm-read/v1'],
+        ],
+        'content': jsonEncode({
+          'v': 1,
+          'read': {tupleKey: 1700000300},
+        }),
+        'sig': '',
+      });
+
+      test(
+        'a read marker authored by another pubkey never advances a cursor',
+        () async {
+          // The marker is self-authored by construction — the sender gift-wraps
+          // it to their own pubkey — and `rumor.pubkey` is the seal signer,
+          // authenticated on every unwrap path. So a marker carrying anyone
+          // else's key is forged, including one from the conversation's own
+          // counterparty, who legitimately knows both participant pubkeys and
+          // can therefore name the conversation. #7343.
+          await deliverMarkerRumor(readMarkerFrom(_validPubkeyB));
+
+          verifyNever(
+            () => mockConversationsDao.applyReadCursor(
+              any(),
+              any(),
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          );
+        },
+      );
+
+      test(
+        'a rejected read marker is still ledgered so it is not re-decrypted '
+        'on every launch',
+        () async {
+          final ledger = await deliverMarkerRumor(
+            readMarkerFrom(_validPubkeyB),
+          );
+
+          expect(ledger.recorded, contains(_giftWrapEventId));
+        },
+      );
     });
 
     // -----------------------------------------------------------------

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -7135,20 +7135,21 @@ void main() {
         return ledger;
       }
 
-      Event readMarkerFrom(String authorPubkey) => Event.fromJson({
-        'id': _rumorEventId,
-        'pubkey': authorPubkey,
-        'created_at': 1700000300,
-        'kind': EventKind.appSpecificData,
-        'tags': [
-          ['d', 'divine/dm-read/v1'],
-        ],
-        'content': jsonEncode({
-          'v': 1,
-          'read': {tupleKey: 1700000300},
-        }),
-        'sig': '',
-      });
+      Event readMarkerFrom(String authorPubkey, {int cursor = 1700000300}) =>
+          Event.fromJson({
+            'id': _rumorEventId,
+            'pubkey': authorPubkey,
+            'created_at': 1700000300,
+            'kind': EventKind.appSpecificData,
+            'tags': [
+              ['d', 'divine/dm-read/v1'],
+            ],
+            'content': jsonEncode({
+              'v': 1,
+              'read': {tupleKey: cursor},
+            }),
+            'sig': '',
+          });
 
       test(
         'a read marker authored by another pubkey never advances a cursor',
@@ -7180,6 +7181,34 @@ void main() {
           );
 
           expect(ledger.recorded, contains(_giftWrapEventId));
+        },
+      );
+
+      test(
+        'a self-authored marker cannot ratchet a cursor past the local clock',
+        () async {
+          // applyReadCursor only ever moves a cursor forward, so a corrupt
+          // clock on one of the user's own devices would otherwise pin every
+          // conversation read forever, with no way back. Mirrors the
+          // persistedCreatedAt clamp applied to every incoming rumor. #7343.
+          const farFuture = 4102444800; // 2100-01-01T00:00:00Z
+
+          await deliverMarkerRumor(
+            readMarkerFrom(_validPubkeyA, cursor: farFuture),
+          );
+
+          final applied =
+              verify(
+                    () => mockConversationsDao.applyReadCursor(
+                      conversationId,
+                      captureAny(),
+                      ownerPubkey: any(named: 'ownerPubkey'),
+                    ),
+                  ).captured.single
+                  as int;
+          final nowSec = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+          expect(applied, isNot(farFuture));
+          expect(applied, lessThanOrEqualTo(nowSec));
         },
       );
     });


### PR DESCRIPTION
## Description

Divine's cross-device DM read cursor is a kind-30078 control message that is only ever legitimately **self-authored** — the sender gift-wraps it to their own pubkey via `publishSelfApplicationMarker`. The receive path never checked that.

`_persistDecryptedGiftWrap` dispatched on kind plus `d`-tag alone, and `_reconcileReadMarker` re-checked only the `d` tag before walking attacker-supplied JSON and calling `applyReadCursor` for each entry. `rumor.pubkey` was never consulted. Because `computeConversationId` is a plain sha256 over the sorted participant pubkeys, and those pubkeys are public, any Nostr user could gift-wrap a read marker to a victim and write read cursors for any conversation they could name.

The write is a monotonic ratchet — `applyReadCursor` takes `MAX(existing, incoming)` and never lowers — and every incoming message is stored with `isRead: isSentByMe`, i.e. false. So one marker fired after each message kept the victim's DM badge dark: messages arrived already looking read. There is no sender allowlist and no blocklist check on this path, so blocking the sender did not stop it, and the subscription filter carries no `authors` constraint. The victim's own device re-published the injected value to their other devices, and the cold-start history drain re-applied it after a reinstall.

**Two commits, each independently revertible:**

1. **`fix(dm): reject read markers not authored by the local user`** — the authorization check. `rumor.pubkey` is the seal signer, authenticated by the Schnorr verification in `GiftWrapUtil` on every unwrap path (live subscription, decryption worker, and the server batch, which attributes to the keycast-verified `slot.sender`), so comparing it against `_userPubkey` is sufficient. An empty `_userPubkey` fails closed. This is the same gate the sibling handlers on the same dispatch already apply — wrapped reaction deletions compare `row.reactorPubkey`, NIP-04 deletions compare `row.senderPubkey`; the read-marker branch was the only one that did not.

   The check sits **inside** `_reconcileReadMarker` rather than at the dispatch site, so a rejected wrap is still recorded in the processed-wrap ledger and is not re-decrypted on every launch. That is safe because the ledger is owner-scoped (`ownerPubkey: _userPubkey`): a marker rejected while a different identity is loaded is recorded under that identity, never the real owner's, so nothing is lost on an account switch. A test pins this placement.

2. **`fix(dm): clamp the read cursor to the local clock`** — defence in depth. The marker's timestamps were only type-checked (`ts is! int`), never bounded, so an out-of-range value was permanent. With the author check in place this is no longer attacker-reachable; it now guards against one of the user's *own* devices publishing with a corrupt clock. Clamping rather than dropping preserves the honest intent ("read up to my now"), and mirrors the `persistedCreatedAt` clamp every incoming rumor already gets. The value stashed in `_pendingReadCursors` is clamped too — otherwise an unbounded cursor would simply re-enter through the post-drain flush in `_restoreReadStateAfterDrain`.

**Related Issue:** Closes #7343

No visual change — no UI, routing, or public API surface is touched. The user-visible behavior change is that a forged marker can no longer silently clear an unread badge.

## Out of Scope

- **Recovery of cursors already poisoned in the field.** `applyReadCursor` never lowers a cursor, so neither commit repairs a device that already applied a forged value. No such device has been observed; if any are found, recovery needs a one-off migration, which is a separate decision.
- **Ledgering behavior is deliberately unchanged.** A rejected marker is still recorded as processed. See commit 1 above for why that is safe; the alternative (skip the ledger) would re-decrypt every forgery on every launch.

## Verification

- `flutter test` in `mobile/packages/dm_repository` — **594 passed**, including the pre-existing self-authored acceptance test (`an incoming kind-30078 read marker advances cursors and is not rendered as a message`), which confirms the legitimate path is unaffected.
- `flutter test --coverage` in the package — **93.94%**, above the `min_coverage: 93` gate in `.github/workflows/dm_repository.yaml`.
- `flutter analyze` on both changed files — no issues.
- `dart format --set-exit-if-changed` on both changed files — clean.
- Full pre-push hook suite passed on push.

Both new tests were written first and watched fail:

- *a read marker authored by another pubkey never advances a cursor* — failed before the fix with `Unexpected calls: applyReadCursor(56ff…, 1700000300, {ownerPubkey: a1b2…})`, i.e. the exploit itself: a non-participant writing a cursor into the victim's conversation. The test uses the conversation's own counterparty as the forger, the strongest case, since they legitimately know both participant pubkeys.
- *a self-authored marker cannot ratchet a cursor past the local clock* — failed before the clamp with the year-2100 value landing unbounded.

The third test (*a rejected read marker is still ledgered*) is a characterization test for behavior deliberately kept. It was verified to have teeth by temporarily moving the author check to the dispatch site, which turned it red (`Expected: contains 'f678…'  Actual: Set:[]`); the mutation was then reverted.

**The forgery is now executed, not just described.** The three tests above inject a `rumorDecryptor`, so they never run the production unwrap — which left the premise of the whole fix (that `rumor.pubkey` is the authenticated seal signer) established by reading `gift_wrap_util.dart` rather than by running it. #7343 recorded the same gap: no forged marker had ever been constructed.

The `read-state marker forgery, real NIP-59 crypto` group closes it. Both tests build genuine kind-1059 wraps with `buildGiftWrapFromHex` and omit `rumorDecryptor`, so `GiftWrapUtil.getRumorEvent` runs and the seal's id and Schnorr signature are really verified. This needs real secp256k1 keys — the `_validPubkey*` fixtures are arbitrary hex, not keypairs, so no seal built from them would verify.

With the author check commented out, the attacker case fails with the vulnerability itself:

```
Unexpected calls: applyReadCursor(
  38932cc643a6ded8cddeaffbc84ec67bcebb9bbd1acb0220738c25aad4293c09,
  1700000300,
  {ownerPubkey: 87d3561f19b74adbe8bf840682992466068830a9d8c36b4a0c99d36f826cb6cb})
```

`87d3561f…` is the victim's own pubkey: a wrap sealed by a different key wrote the victim's cursor. The self-authored test is the control that keeps that negative honest — it passes in both states, so the attacker test cannot be green merely because the wrap failed to decrypt. Neither test sleeps; both wait for the wrap to reach the processed-wrap ledger, so real crypto timing cannot flake them.

Still not done: nothing was published to a live relay, and no forged marker was sent to a real account or device. The demonstration is in-process.

### Adjacent paths checked

Four questions a reviewer would reasonably ask, already run down so they do not have to be re-derived:

- **Can the author check reject a legitimate marker?** No. This was the main regression risk, since a mismatch in the *form* of the two pubkeys would silently break cross-device read sync. Both production wiring sites compute `publicKey` once and pass that same value to `userPubkey:` and to `NIP17MessageService`'s `senderPublicKey:` (`repository_providers.dart:593-603` and `:683-695`), so no case or format divergence is reachable. The self-authored real-crypto test above now proves it by execution rather than by reading.
- **Is the clamp complete, or can an unbounded cursor still get in?** Complete. The only other writer of a read cursor is the drain's last-sent floor, which reads `MAX(created_at)` from `direct_messages` — and inserts store the already-clamped `persistedCreatedAt` (`dm_repository.dart:1913`, `:1950`, `:1982`), so that source is bounded by the same clamp one layer up.
- **Can a marker write another account's read state?** No, on two independent grounds: `applyReadCursor` carries an owner predicate (`conversations_dao.dart:299`), and `_pendingReadCursors` is explicitly cleared on account switch (`:717`) while being deliberately retained on `stopListening` (`:1549`, same user may resume).
- **Does the issue's quoted SQL match the code?** Not exactly — worth flagging for anyone reading #7343 later. The issue quotes `applyReadCursor` as `... WHERE id = ?`, omitting the `AND (owner_pubkey = ? OR owner_pubkey IS NULL)` clause the real query carries. That does not weaken the finding (the attacker names a conversation the victim legitimately owns, so owner scoping was never the obstacle), but it does mean the abridged form should not be read as evidence that the write is unscoped.

Two things noted and deliberately **not** changed here: `_reconcileReadMarker` does not validate the payload's `v` version field, and it does not re-check `_userPubkey` across its `await`s the way `_restoreReadStateAfterDrain` does. Both were traced; the worst case on the second is applying the user's own cursor to their own conversation, so neither is a defect worth widening this PR for.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
