### PR TITLE
test(safety): drop the stale kind-30000 assertion from the block e2e

### DIFF
--- a/mobile/integration_test/e2e/block_leaves_kind3_follow_test.dart
+++ b/mobile/integration_test/e2e/block_leaves_kind3_follow_test.dart
@@ -264,8 +264,13 @@ void main() {
       // reconciler is what covers it now.
       await stack.blocks.blockUser(targetPubkey, ourPubkey: authorPubkey);
 
+      // Blocking authors the standard NIP-51 kind 10000 mute list only. The
+      // non-standard kind 30000 (d=block) list this used to dual-write was
+      // retired by #5462; the one-time empty replacement that retirement
+      // publishes is gated on a non-empty legacy list read back from the
+      // relay, and this fixture serves nothing back, so no kind 30000 is
+      // published on this path at all.
       await relay.awaitPublished(10000);
-      await relay.awaitPublished(30000);
       expect(stack.blocks.isBlocked(targetPubkey), isTrue);
 
       // The republish the reconciler triggers.


### PR DESCRIPTION
## Description

`block_leaves_kind3_follow_test.dart` asserted that blocking publishes a **kind 30000** event. `a2a3585069` ("retire the legacy kind 30000 block list", #7283) removed exactly that write, so the assertion can no longer be satisfied and the test fails:

```
Bad state: relay never received 1 event(s) of kind 30000; saw kinds [3, 3, 10000]
  block_leaves_kind3_follow_test.dart:131  awaitPublished
  block_leaves_kind3_follow_test.dart:268
```

`[3, 3, 10000]` is the intended post-retirement behavior: the kind 3 follow list, the reconciler's republish of it, and the NIP-51 kind 10000 mute list.

**Why the assertion is removed rather than reworked.** The retirement does still publish one empty kind 30000 per account, but `_retireLegacyBlockList` (`content_blocklist_repository.dart`) gates that on reading a non-empty legacy list back from the relay and returns early when the read is `null` (cold miss) or empty. `FakeRelay` serves nothing back — the test says so itself at the assertion just below — so that path cannot fire in this fixture. There is no kind 30000 left here to observe. The retirement's own behavior is covered by unit tests in `content_blocklist_repository_test.dart`, which #7283 extended.

The kind 10000 assertion above it and the #6903 follow-list assertions below are untouched, so what this test exists to prove is unchanged. Line 268 was the only kind-30000 reference in the entire `integration_test/` tree.

**Related Issue:** Relates to #5462

## Why this was not caught by #7283

`Mobile Integration Tests (Services)` is `pull_request`-only — it has **no `push:` trigger**, so it never runs on `main` — and its `paths:` filter covers `mobile/integration_test/e2e/**`, `mobile/integration_test/helpers/**`, `relay_discovery_service.dart`, and the `nostr_sdk` / `nostr_client` / `dm_repository` / `db_client` packages. #7283 changed `content_blocklist_repository` and a profile router, matching none of them; its check list has 16 checks with this workflow absent.

The workflow runs the **whole** `e2e/` suite whenever any trigger path changes, so the failure surfaced on #7348 — an unrelated `dm_repository` change — which is how it was found. Until this lands, every PR touching those four packages or the e2e helpers inherits the red check.

Worth considering separately (not changed here): the combination of no `push:` trigger and a `paths:` filter narrower than the suite the job actually runs means this class of break is invisible until an unrelated PR trips it.

## Out of Scope

- The workflow's trigger configuration itself. Widening `paths:` or adding a `push:` trigger on `main` would prevent a recurrence, but that is a CI-policy change with its own cost and belongs in its own PR.
- Any change to the retirement logic in `content_blocklist_repository.dart`. The behavior is correct; only the stale assertion is wrong.

## Verification

- `dart format --set-exit-if-changed` on the changed file — clean.
- `flutter analyze` on the changed file — no issues.
- `grep -rn "30000" mobile/integration_test/` — only the explanatory comment remains, no assertions.

Not run locally: the e2e suite needs an integration-test device (CI uses `-d linux`); this machine offers only a wirelessly attached iPhone, so driving it here would prove less than CI does. This PR touches `mobile/integration_test/e2e/**`, which is a trigger path, so its own `Integration Tests (services)` run executes the exact test — that run is the verification, and I have not called this fixed until it is green.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
