### PR TITLE
fix(profile): present the session-expired sheet once instead of stacking it

### DIFF
--- a/mobile/lib/widgets/profile/profile_header_widget.dart
+++ b/mobile/lib/widgets/profile/profile_header_widget.dart
@@ -281,21 +281,14 @@ class _ProfileHeaderWidgetState extends ConsumerState<ProfileHeaderWidget> {
       widget.userIdHex,
     );
 
-    // Show session expired bottom sheet for non-anonymous users, but only
-    // after the background RPC upgrade has definitively resolved. Showing the
-    // sheet while the silent refresh is still in flight would send the user
-    // to the login screen even when the refresh ultimately succeeds.
-    if (widget.isOwnProfile &&
+    // This is the condition, not the trigger. It stays true while the session
+    // is expired, so _SessionExpiredPromptTrigger owns the edge (#7308).
+    final shouldPromptForExpiredSession =
+        widget.isOwnProfile &&
         !isAnonymous &&
         hasExpiredSession &&
         !isRpcUpgradeInProgress &&
-        !isDivineLoginBannerHidden) {
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (context.mounted) {
-          _showSessionExpiredSheet(context, ref, widget.userIdHex);
-        }
-      });
-    }
+        !isDivineLoginBannerHidden;
 
     // Compute pending profile actions for the avatar badge
     final pendingActions = ProfileActionType.pending(
@@ -320,6 +313,14 @@ class _ProfileHeaderWidgetState extends ConsumerState<ProfileHeaderWidget> {
       child: Column(
         mainAxisSize: .min,
         children: [
+          // Zero-sized. Owns *when* the session-expired sheet is presented,
+          // so the header's build stays free of route side effects.
+          _SessionExpiredPromptTrigger(
+            shouldPrompt: shouldPromptForExpiredSession,
+            onPrompt: () =>
+                _showSessionExpiredSheet(context, ref, widget.userIdHex),
+          ),
+
           // Navigation buttons — always visible immediately.
           //
           // These are not reliably over media: a profile with no banner image
@@ -479,7 +480,9 @@ class _ProfileHeaderWidgetState extends ConsumerState<ProfileHeaderWidget> {
     return blocProfile;
   }
 
-  void _showSessionExpiredSheet(
+  /// Completes when the sheet is closed, so the caller can tell whether one is
+  /// still on screen.
+  Future<void> _showSessionExpiredSheet(
     BuildContext context,
     WidgetRef ref,
     String userIdHex,
@@ -496,7 +499,7 @@ class _ProfileHeaderWidgetState extends ConsumerState<ProfileHeaderWidget> {
     final publishBloc = context.read<BackgroundPublishBloc>();
     final navigator = Navigator.of(context);
 
-    VineBottomSheetPrompt.show(
+    return VineBottomSheetPrompt.show<void>(
       context: context,
       sticker: DivineStickerName.skeletonKey,
       title: l10n.profileSessionExpired,
@@ -538,6 +541,74 @@ class _ProfileHeaderWidgetState extends ConsumerState<ProfileHeaderWidget> {
       body: ProfileActionsSheetContent(actions: actions),
     );
   }
+}
+
+/// Presents the session-expired prompt from condition edges without stacking.
+///
+/// The prompt is a route, and its condition stays true for as long as the
+/// session is expired. Owning the trigger here reduces that repeated signal to
+/// an edge: [initState] covers a header that mounts already expired, and
+/// [didUpdateWidget] ignores rebuilds that merely re-report true (#7308).
+///
+/// The edge alone is not enough to rule out stacking, because one term of the
+/// condition flickers without the session changing: `isRpcUpgradeInProgress`
+/// goes true then false on every app resume while the session is expired
+/// (`AuthService._refreshOAuthTokenOnResume`). That is a real `false -> true`
+/// edge arriving while the first sheet is still on screen, so a presentation
+/// that has not been closed yet also suppresses the next one.
+class _SessionExpiredPromptTrigger extends StatefulWidget {
+  const _SessionExpiredPromptTrigger({
+    required this.shouldPrompt,
+    required this.onPrompt,
+  });
+
+  /// Whether the expired-session prompt currently applies.
+  final bool shouldPrompt;
+
+  /// Presents the prompt. Called from a post-frame callback; the returned
+  /// future completes when the sheet is closed.
+  final Future<void> Function() onPrompt;
+
+  @override
+  State<_SessionExpiredPromptTrigger> createState() =>
+      _SessionExpiredPromptTriggerState();
+}
+
+class _SessionExpiredPromptTriggerState
+    extends State<_SessionExpiredPromptTrigger> {
+  bool _isPresenting = false;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.shouldPrompt) _schedulePrompt();
+  }
+
+  @override
+  void didUpdateWidget(_SessionExpiredPromptTrigger oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.shouldPrompt && !oldWidget.shouldPrompt) _schedulePrompt();
+  }
+
+  /// Deferred to the next frame because pushing a route is not allowed while
+  /// the tree that asked for it is still building.
+  void _schedulePrompt() {
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      // Re-checked at the end of the frame: the condition can resolve between
+      // arming and firing — a silent refresh succeeding clears the expiry —
+      // and there is no point prompting for a session that is live again.
+      if (!mounted || _isPresenting || !widget.shouldPrompt) return;
+      _isPresenting = true;
+      try {
+        await widget.onPrompt();
+      } finally {
+        if (mounted) _isPresenting = false;
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) => const SizedBox.shrink();
 }
 
 /// Centered tip/support pill below the bio.

--- a/mobile/test/widgets/profile/profile_header_widget_test.dart
+++ b/mobile/test/widgets/profile/profile_header_widget_test.dart
@@ -2134,6 +2134,118 @@ void main() {
       );
 
       testWidgets(
+        'presents the session expired sheet once while the session stays '
+        'expired',
+        (tester) async {
+          // Regression for #7308: the sheet was scheduled from build(), and
+          // the condition stays true for as long as the session is expired,
+          // so every qualifying rebuild pushed another identical sheet route
+          // and the user had to dismiss the same prompt repeatedly.
+          final testProfile = createTestProfile(displayName: 'Test User');
+          SharedPreferences.setMockInitialValues({});
+          final prefs = await SharedPreferences.getInstance();
+
+          await tester.pumpWidget(
+            buildTestWidget(
+              userIdHex: testUserHex,
+              isOwnProfile: true,
+              profile: testProfile,
+              hasExpiredSession: true,
+              sharedPreferences: prefs,
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          expect(find.byType(VineBottomSheetPrompt), findsOneWidget);
+
+          // Rebuild the header with the session still expired. That is the
+          // same expiry, not a new one, so no second sheet may be pushed.
+          await tester.pumpWidget(
+            buildTestWidget(
+              userIdHex: testUserHex,
+              isOwnProfile: true,
+              profile: testProfile,
+              hasExpiredSession: true,
+              sharedPreferences: prefs,
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          expect(find.byType(VineBottomSheetPrompt), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        'does not stack a second sheet when the RPC upgrade flag flickers',
+        (tester) async {
+          // Regression for #7308: `isRpcUpgradeInProgress` goes true then
+          // false on every app resume while the session is expired, so the
+          // condition genuinely transitions false -> true again while the
+          // first sheet is still on screen. Edge detection alone would push a
+          // second sheet on top of it.
+          final testProfile = createTestProfile(displayName: 'Test User');
+          SharedPreferences.setMockInitialValues({});
+          final prefs = await SharedPreferences.getInstance();
+
+          Widget build({required bool isRpcUpgradeInProgress}) =>
+              buildTestWidget(
+                userIdHex: testUserHex,
+                isOwnProfile: true,
+                profile: testProfile,
+                hasExpiredSession: true,
+                isRpcUpgradeInProgress: isRpcUpgradeInProgress,
+                sharedPreferences: prefs,
+              );
+
+          await tester.pumpWidget(build(isRpcUpgradeInProgress: false));
+          await tester.pumpAndSettle();
+          expect(find.byType(VineBottomSheetPrompt), findsOneWidget);
+
+          // App resumes: the background RPC upgrade starts, then fails.
+          await tester.pumpWidget(build(isRpcUpgradeInProgress: true));
+          await tester.pumpAndSettle();
+          await tester.pumpWidget(build(isRpcUpgradeInProgress: false));
+          await tester.pumpAndSettle();
+
+          expect(find.byType(VineBottomSheetPrompt), findsOneWidget);
+        },
+      );
+
+      testWidgets('presents the session expired sheet when it expires while '
+          'the profile is open', (tester) async {
+        // Covers the didUpdateWidget arm: the header mounted on a live
+        // session, so initState did not present.
+        final testProfile = createTestProfile(displayName: 'Test User');
+        SharedPreferences.setMockInitialValues({});
+        final prefs = await SharedPreferences.getInstance();
+
+        await tester.pumpWidget(
+          buildTestWidget(
+            userIdHex: testUserHex,
+            isOwnProfile: true,
+            profile: testProfile,
+            sharedPreferences: prefs,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.byType(VineBottomSheetPrompt), findsNothing);
+
+        await tester.pumpWidget(
+          buildTestWidget(
+            userIdHex: testUserHex,
+            isOwnProfile: true,
+            profile: testProfile,
+            hasExpiredSession: true,
+            sharedPreferences: prefs,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.byType(VineBottomSheetPrompt), findsOneWidget);
+      });
+
+      testWidgets(
         'does not show session expired sheet when dismissed within 30 days',
         (tester) async {
           final testProfile = createTestProfile(displayName: 'Test User');
@@ -2534,10 +2646,7 @@ void main() {
         await tester.pumpAndSettle();
 
         final l10n = lookupAppLocalizations(const Locale('en'));
-        final openSheets = tester
-            .widgetList(find.byType(VineBottomSheetPrompt))
-            .length;
-        expect(openSheets, greaterThan(0));
+        expect(find.byType(VineBottomSheetPrompt), findsOneWidget);
 
         await tester.tap(find.text(l10n.profileMaybeLaterLabel).last);
         await tester.pumpAndSettle();
@@ -2547,10 +2656,7 @@ void main() {
           prefs.getInt('$_dismissedDivineLoginBannerPrefix$testUserHex'),
           isNotNull,
         );
-        expect(
-          find.byType(VineBottomSheetPrompt),
-          findsNWidgets(openSheets - 1),
-        );
+        expect(find.byType(VineBottomSheetPrompt), findsNothing);
       });
 
       testWidgets('dismisses via "Maybe later" after the header unmounts', (
@@ -2593,12 +2699,7 @@ void main() {
         );
         await tester.pumpAndSettle();
         expect(find.byType(ProfileHeaderWidget), findsNothing);
-        // The header re-shows the sheet on every qualifying build, so more
-        // than one can be stacked. Count them and assert the tapped one goes.
-        final openSheets = tester
-            .widgetList(find.byType(VineBottomSheetPrompt))
-            .length;
-        expect(openSheets, greaterThan(0));
+        expect(find.byType(VineBottomSheetPrompt), findsOneWidget);
 
         await tester.tap(find.text(l10n.profileMaybeLaterLabel).last);
         await tester.pumpAndSettle();
@@ -2608,10 +2709,7 @@ void main() {
           prefs.getInt('$_dismissedDivineLoginBannerPrefix$testUserHex'),
           isNotNull,
         );
-        expect(
-          find.byType(VineBottomSheetPrompt),
-          findsNWidgets(openSheets - 1),
-        );
+        expect(find.byType(VineBottomSheetPrompt), findsNothing);
       });
 
       testWidgets('signs in from the sheet after the header unmounts', (
@@ -2659,19 +2757,13 @@ void main() {
         );
         await tester.pumpAndSettle();
         expect(find.byType(ProfileHeaderWidget), findsNothing);
-        final openSheets = tester
-            .widgetList(find.byType(VineBottomSheetPrompt))
-            .length;
-        expect(openSheets, greaterThan(0));
+        expect(find.byType(VineBottomSheetPrompt), findsOneWidget);
 
         await tester.tap(find.text(l10n.profileSignInButton).last);
         await tester.pumpAndSettle();
 
         expect(tester.takeException(), isNull);
-        expect(
-          find.byType(VineBottomSheetPrompt),
-          findsNWidgets(openSheets - 1),
-        );
+        expect(find.byType(VineBottomSheetPrompt), findsNothing);
         expect(authService.tryRefreshCallCount, 1);
         verifyNever(() => mockGoRouter.go(any()));
       });


### PR DESCRIPTION
## Description

`ProfileHeaderWidget` presented the session-expired sheet off a condition, not an edge. `isOwnProfile && !isAnonymous && hasExpiredSession && !isRpcUpgradeInProgress && !isDivineLoginBannerHidden` stays true for as long as the session is expired, and it was evaluated in `build()` with an unconditional `addPostFrameCallback` that pushed a route. The `context.mounted` check guarded against a dead context, not against duplicate presentation, so every qualifying rebuild pushed another identical `ModalBottomSheetRoute` and the prompts stacked.

Condition and trigger are now split. `build()` computes `shouldPromptForExpiredSession`, a pure derivation of values it already watches, and hands it to a zero-sized `_SessionExpiredPromptTrigger` rendered as the first child of the header's `Column`. That widget presents in `initState` when the header mounts already expired and in `didUpdateWidget` only on a `false -> true` transition. A rebuild that merely re-reports `true` does not push another route.

The edge is paired with an `_isPresenting` guard. One term of the condition, `isRpcUpgradeInProgress`, can flicker false -> true -> false while the expired-session sheet is still open, so the trigger also suppresses a new presentation until the current sheet closes. The post-frame callback re-checks `shouldPrompt`, so a silent refresh that succeeds between scheduling and firing does not prompt for a session that is live again.

The conflict with #7304 is resolved on top of current `main`: `_showSessionExpiredSheet` still resolves the route dependencies before showing the sheet, so the sheet actions keep working after the header unmounts, and it now returns the route future so the trigger can know when a sheet is still on screen.

**Related Issue:** Closes #7308

## Out of Scope

- Persisting an "already prompted" marker across profile-route unmounts. Navigating away and back can present again, but still as one sheet, not a stack.

## Verification

- `dart format lib/widgets/profile/profile_header_widget.dart test/widgets/profile/profile_header_widget_test.dart` — no changes.
- `mise exec -- dart format lib test integration_test` — no changes.
- `flutter analyze lib test integration_test` — no issues.
- `flutter test test/widgets/profile/profile_header_widget_test.dart` — 85 tests passed.
- Pre-push hook — merge-conflict check, analyze, and changed-file widget test passed.
- GitHub checks on `f733e657227ac39e1bb122f554fe8883bc24f37e` — all checks green.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
