### PR TITLE
fix(text): sanitize malformed UTF-16 in remote content at the model boundary

### DIFF
--- a/mobile/lib/services/video_clip_import_service.dart
+++ b/mobile/lib/services/video_clip_import_service.dart
@@ -11,6 +11,7 @@ import 'package:openvine/services/clip_library_service.dart';
 import 'package:openvine/services/subtitle_service.dart';
 import 'package:path/path.dart' as p;
 import 'package:pro_video_editor/pro_video_editor.dart';
+import 'package:text_sanitizer/text_sanitizer.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 typedef VideoClipDownloader =
@@ -233,8 +234,15 @@ class VideoClipImportService {
   /// renderer — i.e. it makes us the source of the malformed text rather than
   /// the relay. Grapheme-cluster truncation also keeps combining marks
   /// attached to their base character.
+  ///
+  /// The incoming value is sanitized as well, because `_subtitleTitle` feeds
+  /// this from `VideoEvent.textTrackContent` — the one source here that no
+  /// model-level display boundary covers, since `SubtitleService.parseVtt`
+  /// carries a relay-served cue through verbatim.
   static String? _normalizedTitle(String? value) {
-    final trimmed = value?.replaceAll(RegExp(r'\s+'), ' ').trim();
+    final trimmed = sanitizeUtf16OrNull(
+      value,
+    )?.replaceAll(RegExp(r'\s+'), ' ').trim();
     if (trimmed == null || trimmed.isEmpty) return null;
     final graphemes = trimmed.characters;
     if (graphemes.length <= 80) return trimmed;

--- a/mobile/lib/services/video_clip_import_service.dart
+++ b/mobile/lib/services/video_clip_import_service.dart
@@ -3,6 +3,7 @@
 
 import 'dart:io';
 
+import 'package:characters/characters.dart';
 import 'package:models/models.dart' as models;
 import 'package:openvine/extensions/video_event_extensions.dart';
 import 'package:openvine/models/divine_video_clip.dart';
@@ -223,11 +224,21 @@ class VideoClipImportService {
     return null;
   }
 
+  /// Caps an imported clip title, counting grapheme clusters rather than
+  /// UTF-16 code units.
+  ///
+  /// Cutting by code unit splits a surrogate pair whenever the limit lands
+  /// mid-emoji, leaving a lone surrogate that later throws
+  /// `Invalid argument(s): string is not well-formed UTF-16` out of the text
+  /// renderer — i.e. it makes us the source of the malformed text rather than
+  /// the relay. Grapheme-cluster truncation also keeps combining marks
+  /// attached to their base character.
   static String? _normalizedTitle(String? value) {
     final trimmed = value?.replaceAll(RegExp(r'\s+'), ' ').trim();
     if (trimmed == null || trimmed.isEmpty) return null;
-    if (trimmed.length <= 80) return trimmed;
-    return '${trimmed.substring(0, 77).trimRight()}...';
+    final graphemes = trimmed.characters;
+    if (graphemes.length <= 80) return trimmed;
+    return '${graphemes.take(77).toString().trimRight()}...';
   }
 
   static String _fallbackTitle(DateTime time) {

--- a/mobile/packages/models/lib/src/user_profile.dart
+++ b/mobile/packages/models/lib/src/user_profile.dart
@@ -19,22 +19,58 @@ import 'package:unique_names_generator/unique_names_generator.dart';
 /// Model representing a Nostr user profile from kind 0 events
 @immutable
 class UserProfile {
-  const UserProfile({
+  /// Normalizes every kind-0 string field to well-formed UTF-16.
+  ///
+  /// This is the display boundary for profile text: all four factories below
+  /// funnel through here, so a lone surrogate in remote kind-0 JSON is
+  /// replaced with U+FFFD once, at the point the profile becomes a typed
+  /// model, instead of at each of the ~40 widgets that render these fields.
+  /// Flutter's paragraph builder throws `Invalid argument(s): string is not
+  /// well-formed UTF-16` on a lone surrogate, and the throw is not confined
+  /// to `Text` — `TextPainter.layout` used for measurement (as the profile
+  /// bio's expand/collapse does), `Semantics` labels, tooltips and
+  /// `EditableText` all reach the same native call, so no single widget can
+  /// be the chokepoint. The URL and identifier fields are covered too: a lone
+  /// surrogate is invalid in all of them, and they render like any other text.
+  ///
+  /// These values *are* republished. `ProfileRepository.saveProfileEvent`
+  /// seeds the new kind-0 content from [rawData] but then overwrites
+  /// `display_name`, `about`, `website`, `picture` and `banner` from the
+  /// typed model the editor was seeded with — so [rawData] does not shield
+  /// them. That is safe: `Utf8Encoder` substitutes U+FFFD for an unpaired
+  /// surrogate anyway, so the bytes on the wire are the same either way.
+  ///
+  /// Only well-formedness is enforced here, not the combining-character cap
+  /// that [sanitizeForDisplay] applies. Capping diacritics is *not* wire-safe
+  /// — it would silently rewrite a user's own bio on that republish path — so
+  /// Zalgo capping stays on the display getters.
+  ///
+  /// [pubkey] and [eventId] are hex identifiers and are left untouched, as is
+  /// [rawData] itself.
+  UserProfile({
     required this.pubkey,
     required this.rawData,
     required this.createdAt,
     required this.eventId,
-    this.name,
-    this.displayName,
-    this.about,
-    this.picture,
-    this.banner,
-    this.website,
-    this.nip05,
-    this.lud16,
-    this.lud06,
+    String? name,
+    String? displayName,
+    String? about,
+    String? picture,
+    String? banner,
+    String? website,
+    String? nip05,
+    String? lud16,
+    String? lud06,
     this.rawTags = const [],
-  });
+  }) : name = sanitizeUtf16OrNull(name),
+       displayName = sanitizeUtf16OrNull(displayName),
+       about = sanitizeUtf16OrNull(about),
+       picture = sanitizeUtf16OrNull(picture),
+       banner = sanitizeUtf16OrNull(banner),
+       website = sanitizeUtf16OrNull(website),
+       nip05 = sanitizeUtf16OrNull(nip05),
+       lud16 = sanitizeUtf16OrNull(lud16),
+       lud06 = sanitizeUtf16OrNull(lud06);
 
   /// Create UserProfile from a Nostr kind 0 event
   factory UserProfile.fromNostrEvent(Event event) {

--- a/mobile/packages/models/lib/src/user_profile.dart
+++ b/mobile/packages/models/lib/src/user_profile.dart
@@ -37,13 +37,18 @@ class UserProfile {
   /// seeds the new kind-0 content from [rawData] but then overwrites
   /// `display_name`, `about`, `website`, `picture` and `banner` from the
   /// typed model the editor was seeded with — so [rawData] does not shield
-  /// them. That is safe: `Utf8Encoder` substitutes U+FFFD for an unpaired
-  /// surrogate anyway, so the bytes on the wire are the same either way.
+  /// them, and any save that carries the typed value through rewrites what
+  /// is stored. That is the point rather than a cost: `jsonEncode` escapes an
+  /// unpaired surrogate as the six literal characters `\ud83d` instead of
+  /// substituting for it, so the value we publish today re-poisons every
+  /// client that parses it back, and NIP-01 has no conformant representation
+  /// for it either. Sanitizing first stops us being a propagation vector.
   ///
   /// Only well-formedness is enforced here, not the combining-character cap
-  /// that [sanitizeForDisplay] applies. Capping diacritics is *not* wire-safe
-  /// — it would silently rewrite a user's own bio on that republish path — so
-  /// Zalgo capping stays on the display getters.
+  /// that [sanitizeForDisplay] applies. An unpaired surrogate is invalid
+  /// input being repaired; stacked diacritics are valid text a user may have
+  /// typed, and capping those on the republish path would silently rewrite
+  /// their own bio — so Zalgo capping stays on the display getters.
   ///
   /// [pubkey] and [eventId] are hex identifiers and are left untouched, as is
   /// [rawData] itself.

--- a/mobile/packages/models/lib/src/video_event.dart
+++ b/mobile/packages/models/lib/src/video_event.dart
@@ -162,10 +162,13 @@ class VideoEvent {
   ///
   /// [content] and [altText] are round-tripped back to relays on the
   /// metadata-edit and subtitle-republish paths, so sanitizing them does
-  /// rewrite what gets re-signed. That is safe: `Utf8Encoder` substitutes
-  /// U+FFFD for an unpaired surrogate anyway, so the wire bytes are identical
-  /// either way. The combining-character cap is *not* wire-safe and stays on
-  /// the display getters for that reason.
+  /// rewrite what gets re-signed. That is deliberate: `Event._getId` runs
+  /// `json.encode` before `utf8.encode`, and that escapes an unpaired
+  /// surrogate as the six literal characters `\ud83d` rather than
+  /// substituting for it, so what we re-sign today re-poisons every client
+  /// that parses it back. The combining-character cap is a different case —
+  /// it would rewrite valid text a user typed — and stays on the display
+  /// getters for that reason.
   ///
   /// Identifier, URL, and tag fields are left untouched — they are either hex
   /// (`id`, `pubkey`, `sha256`) or structural.

--- a/mobile/packages/models/lib/src/video_event.dart
+++ b/mobile/packages/models/lib/src/video_event.dart
@@ -148,14 +148,35 @@ bool _nullableBoolMapEquals(
 class VideoEvent {
   // approved, flagged, etc.
 
-  const VideoEvent({
+  /// Normalizes the free-text fields to well-formed UTF-16.
+  ///
+  /// Same display boundary as the `UserProfile` constructor: note content and
+  /// titles arrive as remote relay text, and a lone surrogate anywhere in
+  /// them throws `Invalid argument(s): string is not well-formed UTF-16` out
+  /// of the native paragraph builder. The [displayContent] / [displayTitle]
+  /// getters below still apply the combining-character cap for rendering,
+  /// but they cannot be the crash boundary on their own because callers
+  /// legitimately read the raw fields too — `VideoPerformance.fromVideo`
+  /// renders `title` straight from the model, and measurement passes never
+  /// reach a display getter at all.
+  ///
+  /// [content] and [altText] are round-tripped back to relays on the
+  /// metadata-edit and subtitle-republish paths, so sanitizing them does
+  /// rewrite what gets re-signed. That is safe: `Utf8Encoder` substitutes
+  /// U+FFFD for an unpaired surrogate anyway, so the wire bytes are identical
+  /// either way. The combining-character cap is *not* wire-safe and stays on
+  /// the display getters for that reason.
+  ///
+  /// Identifier, URL, and tag fields are left untouched — they are either hex
+  /// (`id`, `pubkey`, `sha256`) or structural.
+  VideoEvent({
     required this.id,
     required this.pubkey,
     required this.createdAt,
-    required this.content,
+    required String content,
     required this.timestamp,
     this.eventCreatedAt,
-    this.title,
+    String? title,
     this.videoUrl,
     this.thumbnailUrl,
     this.duration,
@@ -170,7 +191,7 @@ class VideoEvent {
     this.vineId,
     this.addressableDTag,
     this.group,
-    this.altText,
+    String? altText,
     this.blurhash,
     this.isRepost = false,
     this.reposterId,
@@ -189,7 +210,7 @@ class VideoEvent {
     this.nostrLikeCount,
     this.nostrCommentCount,
     this.nostrRepostCount,
-    this.authorName,
+    String? authorName,
     this.authorAvatar,
     this.collaboratorPubkeys = const [],
     this.inspiredByVideo,
@@ -205,7 +226,10 @@ class VideoEvent {
     this.proofSummary,
     this.eventKind,
     this.sourceRelay,
-  });
+  }) : content = sanitizeUtf16(content),
+       title = sanitizeUtf16OrNull(title),
+       altText = sanitizeUtf16OrNull(altText),
+       authorName = sanitizeUtf16OrNull(authorName);
 
   /// Reconstructs a [VideoEvent] from a map produced by [toJson].
   ///

--- a/mobile/packages/models/test/src/user_profile_test.dart
+++ b/mobile/packages/models/test/src/user_profile_test.dart
@@ -58,6 +58,113 @@ void main() {
       });
     });
 
+    group('UTF-16 well-formedness at the display boundary (#7295)', () {
+      // The bio is the field that had no sanitized display getter, so it
+      // reached `TextPainter.layout` raw from the profile header's
+      // expand/collapse measurement pass and threw
+      // "string is not well-formed UTF-16" out of the paragraph builder.
+      test('replaces lone surrogates in every free-text field', () {
+        final lone = String.fromCharCode(0xDE00);
+        final profile = UserProfile(
+          pubkey: testPubkey,
+          rawData: const {},
+          createdAt: testCreatedAt,
+          eventId: testEventId,
+          name: 'n$lone',
+          displayName: 'd$lone',
+          about: 'a$lone',
+          picture: 'p$lone',
+          banner: 'b$lone',
+          website: 'w$lone',
+          nip05: 'i$lone',
+          lud16: 'l$lone',
+          lud06: 'u$lone',
+        );
+
+        expect(profile.name, equals('n�'));
+        expect(profile.displayName, equals('d�'));
+        expect(profile.about, equals('a�'));
+        expect(profile.picture, equals('p�'));
+        expect(profile.banner, equals('b�'));
+        expect(profile.website, equals('w�'));
+        expect(profile.nip05, equals('i�'));
+        expect(profile.lud16, equals('l�'));
+        expect(profile.lud06, equals('u�'));
+      });
+
+      test('sanitizes a lone surrogate arriving via fromNostrEvent', () {
+        final event = Event(
+          testPubkey,
+          EventKind.metadata,
+          [],
+          jsonEncode({
+            'about': 'truncated emoji${String.fromCharCode(0xD83D)}',
+            'display_name': 'Bad${String.fromCharCode(0xD83D)}Name',
+          }),
+          createdAt: 1704067200,
+        )..id = testEventId;
+
+        final profile = UserProfile.fromNostrEvent(event);
+
+        expect(profile.about, equals('truncated emoji�'));
+        expect(profile.displayName, equals('Bad�Name'));
+      });
+
+      test('sanitizes a lone surrogate arriving via fromJson', () {
+        final profile = UserProfile.fromJson({
+          'pubkey': testPubkey,
+          'event_id': testEventId,
+          'created_at': testCreatedAt.millisecondsSinceEpoch,
+          'about': 'json${String.fromCharCode(0xDC00)}bio',
+        });
+
+        expect(profile.about, equals('json�bio'));
+      });
+
+      test('keeps copyWith output well-formed', () {
+        final profile = UserProfile(
+          pubkey: testPubkey,
+          rawData: const {},
+          createdAt: testCreatedAt,
+          eventId: testEventId,
+        ).copyWith(about: 'copy${String.fromCharCode(0xD83D)}bio');
+
+        expect(profile.about, equals('copy�bio'));
+      });
+
+      // Only well-formedness is enforced here. Capping combining marks at
+      // construction would rewrite the user's own bio when the profile editor
+      // seeds from this model and republishes, so Zalgo stays display-only.
+      test('preserves valid emoji and stacked diacritics verbatim', () {
+        const bio = 'hi \u{1F600} o\u0300\u0301\u0302\u0303 done';
+        final profile = UserProfile(
+          pubkey: testPubkey,
+          rawData: const {},
+          createdAt: testCreatedAt,
+          eventId: testEventId,
+          about: bio,
+        );
+
+        expect(profile.about, equals(bio));
+      });
+
+      // rawData carries the original kind-0 bytes for republishing and must
+      // not be rewritten by the display-side normalization.
+      test('leaves rawData untouched', () {
+        final malformed = 'raw${String.fromCharCode(0xD83D)}';
+        final profile = UserProfile(
+          pubkey: testPubkey,
+          rawData: {'about': malformed},
+          createdAt: testCreatedAt,
+          eventId: testEventId,
+          about: malformed,
+        );
+
+        expect(profile.rawData['about'], equals(malformed));
+        expect(profile.about, equals('raw�'));
+      });
+    });
+
     group('fromNostrEvent', () {
       test('parses valid kind 0 event', () {
         final event = Event(

--- a/mobile/packages/models/test/src/video_event_display_test.dart
+++ b/mobile/packages/models/test/src/video_event_display_test.dart
@@ -1,5 +1,5 @@
 // ABOUTME: Tests for VideoEvent.displayTitle and displayContent zalgo-safe
-// ABOUTME: getters that protect UI from combining-character overflow.
+// ABOUTME: getters, and for the constructor's UTF-16 well-formedness boundary.
 
 import 'package:models/models.dart';
 import 'package:test/test.dart';
@@ -9,6 +9,7 @@ void main() {
     String? title,
     String content = '',
     String? authorName,
+    String? altText,
     int createdAt = 1735689600,
     String? publishedAt,
     Map<String, String> rawTags = const {},
@@ -23,6 +24,7 @@ void main() {
     ),
     title: title,
     authorName: authorName,
+    altText: altText,
     publishedAt: publishedAt,
     rawTags: rawTags,
   );
@@ -159,6 +161,48 @@ void main() {
       final video = build(createdAt: 1777489813);
 
       expect(video.hasUnknownOriginalDate, isFalse);
+    });
+  });
+
+  group('UTF-16 well-formedness at the display boundary (#7295)', () {
+    // The display* getters cannot be the only crash boundary: callers read
+    // the raw fields too — `VideoPerformance.fromVideo` renders `title`
+    // straight from the model, and `altText` reaches the paragraph builder
+    // through `Semantics.label` rather than a `Text` widget. A lone surrogate
+    // throws "string is not well-formed UTF-16" from any of them, so the
+    // constructor normalizes once, for every reader.
+    test('replaces a lone surrogate in raw content', () {
+      final video = build(content: 'note${String.fromCharCode(0xD83D)}body');
+
+      expect(video.content, equals('note�body'));
+    });
+
+    test('replaces a lone surrogate in raw title', () {
+      final video = build(title: 'clip${String.fromCharCode(0xDE00)}title');
+
+      expect(video.title, equals('clip�title'));
+    });
+
+    test('replaces a lone surrogate in raw authorName', () {
+      final video = build(authorName: 'by${String.fromCharCode(0xD83D)}me');
+
+      expect(video.authorName, equals('by�me'));
+    });
+
+    test('replaces a lone surrogate in raw altText', () {
+      final video = build(altText: 'a${String.fromCharCode(0xDE00)}dog');
+
+      expect(video.altText, equals('a�dog'));
+    });
+
+    // Zalgo capping stays on the display getters so the raw field keeps the
+    // author's original marks for anything that republishes it.
+    test('preserves emoji and stacked diacritics in raw fields', () {
+      const caption = 'hi \u{1F600} o\u0300\u0301\u0302\u0303 done';
+      final video = build(content: caption);
+
+      expect(video.content, equals(caption));
+      expect(video.displayContent, equals('hi \u{1F600} o\u0300\u0301 done'));
     });
   });
 }

--- a/mobile/packages/text_sanitizer/lib/src/text_sanitizer.dart
+++ b/mobile/packages/text_sanitizer/lib/src/text_sanitizer.dart
@@ -41,6 +41,14 @@ String sanitizeUtf16(String text) {
   return result?.toString() ?? text;
 }
 
+/// Null-tolerant [sanitizeUtf16] for optional fields.
+///
+/// Returns `null` unchanged; otherwise delegates to [sanitizeUtf16]. Intended
+/// for model constructors that normalize a batch of nullable remote-sourced
+/// text fields in one initializer list.
+String? sanitizeUtf16OrNull(String? text) =>
+    text == null ? null : sanitizeUtf16(text);
+
 /// Normalizes malformed UTF-16 and caps combining diacritical characters per
 /// grapheme cluster to prevent Zalgo text from overflowing layout bounds.
 ///

--- a/mobile/packages/text_sanitizer/test/src/text_sanitizer_test.dart
+++ b/mobile/packages/text_sanitizer/test/src/text_sanitizer_test.dart
@@ -123,6 +123,18 @@ void main() {
     });
   });
 
+  group(sanitizeUtf16OrNull, () {
+    test('returns null for null input', () {
+      expect(sanitizeUtf16OrNull(null), isNull);
+    });
+
+    test('delegates to sanitizeUtf16 for non-null input', () {
+      final input = String.fromCharCodes([0x61, 0xD83D]);
+
+      expect(sanitizeUtf16OrNull(input), equals('a�'));
+    });
+  });
+
   group(sanitizeForDisplay, () {
     test('replaces lone surrogates and caps combining chars', () {
       // lone high surrogate, then o + 4 combining chars

--- a/mobile/test/services/video_clip_import_service_test.dart
+++ b/mobile/test/services/video_clip_import_service_test.dart
@@ -257,6 +257,24 @@ First useful caption
     );
   });
 
+  // Regression for #7295: truncating by UTF-16 code unit split the emoji at
+  // the 77-unit boundary and left a lone high surrogate, which then threw
+  // "string is not well-formed UTF-16" out of the paragraph builder when the
+  // clip title was rendered. Truncation now counts grapheme clusters, so the
+  // emoji is either kept whole or dropped whole.
+  test('truncates long library titles without splitting an emoji', () {
+    final title = VideoClipImportService.defaultLibraryTitleFor(
+      _video(
+        title: '${'a' * 76}\u{1F600} trailing text past the eighty limit',
+        content: 'fallback description',
+      ),
+    );
+
+    // The old code-unit cut produced 'a' * 76 + a lone high surrogate, which
+    // this expectation rejects.
+    expect(title, equals('${'a' * 76}\u{1F600}...'));
+  });
+
   test('imports an own (non-classic) video as a saved library clip', () async {
     final service = buildService();
 

--- a/mobile/test/services/video_clip_import_service_test.dart
+++ b/mobile/test/services/video_clip_import_service_test.dart
@@ -275,6 +275,31 @@ First useful caption
     expect(title, equals('${'a' * 76}\u{1F600}...'));
   });
 
+  // Regression for #7295: `textTrackContent` is the only title source here
+  // that no model display boundary covers — `SubtitleService.parseVtt` hands
+  // a relay-served cue through verbatim — so a cue under the length cap
+  // carried its lone surrogate straight into `libraryTitle`, which renders as
+  // a plain `Text`.
+  test('sanitizes a lone surrogate carried in a subtitle cue', () {
+    final loneSurrogate = String.fromCharCode(0xD83D);
+
+    final title = VideoClipImportService.defaultLibraryTitleFor(
+      _video(
+        title: '',
+        content: '',
+        textTrackContent:
+            '''
+WEBVTT
+
+00:00.000 --> 00:02.000
+cue text $loneSurrogate here
+''',
+      ),
+    );
+
+    expect(title, equals('cue text \uFFFD here'));
+  });
+
   test('imports an own (non-classic) video as a saved library clip', () async {
     final service = buildService();
 


### PR DESCRIPTION
## Description

Remote text carrying an unpaired UTF-16 surrogate reached `dart:ui`'s paragraph builder and crashed the app — FATAL, `SIGNAL_REPETITIVE`, ~11 crashes per affected user.

The exact crash point is `profile_header_media.dart`: `_AboutText` builds a `TextSpan` from the **raw** bio and calls `TextPainter.layout()` to decide whether to show "Show more". That measurement pass runs on every build, *before* either output branch — and the two branches below it (`LinkifiedText` / `SelectableLinkifiedText`) are the ones that sanitize. So the guarded widgets were never reached.

**Why the boundary is the model constructor and not a widget.** A widget chokepoint cannot work for this crash: it arrived through a bare `TextPainter`, and `Semantics` labels, tooltips and `EditableText` reach the same native call without going through a `Text` widget at all. Per-field display getters were already the approach in this codebase, and they are exactly what leaked — `UserProfile.about` never got one. So the sanitizer moved one layer down, into the single generative constructor that every `UserProfile` and `VideoEvent` factory funnels through. Zero call-site changes, and it covers fields added later by default.

Coverage was traced end to end rather than assumed: the four `UserProfile` factories, `copyWith`, the Hive adapter's `read`, the Drift DAO's `_rowToUserProfile`, and `ProfileSearchResult.toUserProfile()` all route through it. No bypass. A useful side effect is that already-poisoned Drift/Hive rows are healed on read, so no cache-key bump is needed.

**Only well-formedness is enforced at construction, not the Zalgo cap.** These values *are* republished — `ProfileRepository.saveProfileEvent` seeds new kind-0 content from `rawData` but then overwrites `display_name`/`about`/`website`/`picture`/`banner` from the typed model, and `video_metadata_update_service` / `video_event_publisher` re-sign `altText` and `content`. That republish now goes out sanitized, and that is the point rather than a cost: `jsonEncode` escapes an unpaired surrogate as the six literal characters `\ud83d` instead of substituting for it, and `Event._getId` runs `json.encode` before `utf8.encode`, so the value we publish today re-poisons every client that parses it back. NIP-01 has no conformant representation for it either. Capping combining marks is a different case — it would rewrite valid text a user typed — so that stays on the display getters.

**We were also a source of the malformed input, not just a victim.** `VideoClipImportService._normalizedTitle` cut with `trimmed.substring(0, 77)` — a code-unit cut on remote-derived title/description text. Any emoji straddling unit 77 was split, leaving a lone high surrogate that we then rendered. It now truncates by grapheme cluster, matching the already-correct pattern in `clip_category.dart`. Note this changes the cap's unit: `<= 80` now counts graphemes rather than code units, so an emoji-heavy title can be longer in code units than before. There is no storage constraint on `libraryTitle`, and "80 user-perceived characters" is the more defensible guarantee.

`_normalizedTitle` also sanitizes its input now, not just its output. `_subtitleTitle` feeds it from `VideoEvent.textTrackContent`, which is the one title source here that no model boundary covers — `SubtitleService.parseVtt` carries a relay-served cue through verbatim — so a cue under the length cap took its lone surrogate straight into `libraryTitle`, which renders as a plain `Text`.

Checked and cleared as *not* producing lone surrogates: `nostr_key_utils.maskKey` and the bech32/hex slicers are ASCII-only and are ID truncation, which the repo rules keep intact; `notification_repository` already has `_surrogateSafeCut`.

**Related Issue:** Closes #7295

## Out of Scope

Remaining unguarded remote strings found while sweeping, all pre-existing and none on the reported crash path — tracked in #7359 rather than widening this diff: `AudioEvent` (title / creatorName / licenseName), `CuratedList` and `UserList` name + description, NIP-58 badge displayName + description, `ClassicViner.authorName`, notification `listTitle`, and raw hashtag chips.

`AudioEvent` was deliberately left `const` — it has 10+ `const AudioEvent(` call sites across tests, and that blast radius is disproportionate for a vector this issue did not name.

## Verification

- `flutter analyze lib test integration_test` — clean.
- `flutter test` in `packages/models` — 913 passing; in `packages/text_sanitizer` — 25 passing.
- `flutter test test/services/video_clip_import_service_test.dart` — passing.
- Full app suite via `mise run test` — green, re-run after rebasing onto current `main`.
- `dart format` — no drift.
- Both clip-import regression tests can fail: under the old `substring(0, 77)` the produced title was `'a' * 76 + <lone high surrogate>`, which the expectation rejects, and the subtitle-cue test was run with the `_normalizedTitle` sanitize reverted — it fails there and passes with it.
- `flutter test` cannot catch this class of bug end to end: the headless `flutter_tester` does not throw on an unpaired surrogate, only the real engine does. That is why the assertions are model-layer, and why the remaining surfaces are filed as #7359 instead of left in this description.
- `sanitizeUtf16` re-read line by line for the higher call volume: the `i++` inside the pair branch plus the loop update advances by exactly 2, the lazy `StringBuffer` seed `text.substring(0, i)` is always well-formed at that point, and clean input returns the identical instance.
- Hot-path cost checked rather than assumed: no `VideoEvent.copyWith` occurs in any feed widget `build` — the real call sites are data-layer merges that already copy ~50 fields, so four short O(n) scans are noise.
- Dropping `const` from the two constructors breaks nothing: there were zero `const UserProfile(` / `const VideoEvent(` *invocation* sites in the repo. Both types compare by id / (pubkey, eventId), not identity, so map and set behaviour is unchanged.



## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

