### PR TITLE
fix(providers): abandon in-flight list provider work after disposal

### DIFF
--- a/mobile/lib/providers/list_providers.dart
+++ b/mobile/lib/providers/list_providers.dart
@@ -4,6 +4,7 @@
 import 'dart:async';
 
 import 'package:models/models.dart' hide LogCategory;
+import 'package:nostr_client/nostr_client.dart' show NostrClient;
 import 'package:nostr_sdk/filter.dart';
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
 import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
@@ -13,6 +14,8 @@ import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/providers/repository_providers.dart';
 import 'package:openvine/providers/video_events_providers.dart';
 import 'package:openvine/providers/video_providers.dart';
+import 'package:openvine/services/video_event_service.dart'
+    show VideoEventService;
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:unified_logger/unified_logger.dart';
 
@@ -157,15 +160,55 @@ Future<List<String>> curatedListVideos(Ref ref, String listId) async {
   return service?.getOrderedVideoIds(listId) ?? [];
 }
 
+/// Provider reads that stop once the owning provider is torn down.
+///
+/// An `async*` provider body does not start until the returned stream is
+/// listened to, and it keeps running for a moment after Riverpod tears the
+/// provider down — so any `Ref` touched across one of its `await`s can land on
+/// a dead `Ref` and throw "Cannot use the Ref … after it has been disposed"
+/// (#6274, #7294). Bundling the reads here keeps the `async*` helpers below
+/// free of `Ref` entirely.
+///
+/// The flag cannot be replaced by `ref.mounted`: `invalidateSelf` runs
+/// `onDispose` immediately but only *schedules* the rebuild, so `ref.mounted`
+/// still reports `true` while the old body is running against a `Ref` that is
+/// already being torn down. Pull-to-refresh takes exactly that path, and the
+/// two disposal tests in `list_providers_test.dart` fail against `ref.mounted`.
+///
+/// A `null` return means the body abandons its work rather than fetching on
+/// behalf of something nobody is listening to any more.
+class _LiveDeps {
+  _LiveDeps(this._ref) {
+    _ref.onDispose(() => _torndown = true);
+  }
+
+  final Ref _ref;
+  bool _torndown = false;
+
+  VideoEventService? get videoEventService =>
+      _torndown ? null : _ref.read(videoEventServiceProvider);
+
+  NostrClient? get nostrClient =>
+      _torndown ? null : _ref.read(nostrServiceProvider);
+}
+
 /// Provider for videos from all members of a user list
+///
+/// The body is a plain function so every `Ref` read happens synchronously
+/// during `build` — see [_LiveDeps] for why an `async*` body cannot
+/// touch `Ref`.
 @riverpod
-Stream<List<VideoEvent>> userListMemberVideos(
-  Ref ref,
-  List<String> pubkeys,
-) async* {
+Stream<List<VideoEvent>> userListMemberVideos(Ref ref, List<String> pubkeys) {
   // Watch discovery videos and filter to only those from list members
   final allVideosAsync = ref.watch(videoEventsProvider);
 
+  return _userListMemberVideos(allVideosAsync, pubkeys);
+}
+
+Stream<List<VideoEvent>> _userListMemberVideos(
+  AsyncValue<List<VideoEvent>> allVideosAsync,
+  List<String> pubkeys,
+) async* {
   await for (final _ in Stream.value(null)) {
     if (allVideosAsync.hasValue) {
       final allVideos = allVideosAsync.value!;
@@ -247,8 +290,14 @@ Future<CuratedList?> publicCuratedList(
 
 /// Provider that fetches actual VideoEvent objects for a curated list
 /// Streams videos as they are fetched from cache or relays
+///
+/// `Ref` is either read synchronously in `build` or guarded by [_LiveDeps] —
+/// this provider is the one that matters most, because
+/// `curated_list_feed_screen` calls
+/// `ref.invalidate(curatedListVideoEventsProvider(listId))` on pull-to-refresh,
+/// which disposes the previous build while it is still awaiting relays.
 @riverpod
-Stream<List<VideoEvent>> curatedListVideoEvents(Ref ref, String listId) async* {
+Stream<List<VideoEvent>> curatedListVideoEvents(Ref ref, String listId) {
   // Re-run (and therefore re-filter) when the blocklist changes. Broad changes
   // (account switch / identity adoption, relay-synced blocked-by-others,
   // mute-list recovery) bump this version but emit no granular removed-id
@@ -256,6 +305,20 @@ Stream<List<VideoEvent>> curatedListVideoEvents(Ref ref, String listId) async* {
   // blocked author without a manual refresh (#5104).
   ref.watch(blocklistVersionProvider);
 
+  return _curatedListVideoEvents(
+    listId: listId,
+    // Watched (not awaited) here so the dependency is registered during build;
+    // the future itself is awaited inside the helper below.
+    videoIdsFuture: ref.watch(curatedListVideosProvider(listId).future),
+    live: _LiveDeps(ref),
+  );
+}
+
+Stream<List<VideoEvent>> _curatedListVideoEvents({
+  required String listId,
+  required Future<List<String>> videoIdsFuture,
+  required _LiveDeps live,
+}) async* {
   Log.info(
     '📋 Fetching videos for curated list: $listId',
     name: 'CuratedListVideoEvents',
@@ -263,7 +326,7 @@ Stream<List<VideoEvent>> curatedListVideoEvents(Ref ref, String listId) async* {
   );
 
   // Get the video IDs from the curated list
-  final videoIds = await ref.watch(curatedListVideosProvider(listId).future);
+  final videoIds = await videoIdsFuture;
 
   if (videoIds.isEmpty) {
     Log.info(
@@ -303,8 +366,12 @@ Stream<List<VideoEvent>> curatedListVideoEvents(Ref ref, String listId) async* {
     category: LogCategory.video,
   );
 
-  // First check cache via video event service
-  final videoEventService = ref.read(videoEventServiceProvider);
+  // First check cache via video event service. Null means the provider was
+  // disposed while awaiting the list — abandon the fetch instead of reading a
+  // dead Ref (#7294).
+  final videoEventService = live.videoEventService;
+  if (videoEventService == null) return;
+
   final foundVideos = <VideoEvent>[];
   final missingIds = <String>[];
   final missingCoords = <String>[];
@@ -388,8 +455,6 @@ Stream<List<VideoEvent>> curatedListVideoEvents(Ref ref, String listId) async* {
       category: LogCategory.video,
     );
 
-    final nostrService = ref.read(nostrServiceProvider);
-
     // Build filters for missing videos
     final filters = <Filter>[];
 
@@ -411,8 +476,12 @@ Stream<List<VideoEvent>> curatedListVideoEvents(Ref ref, String listId) async* {
       }
     }
 
+    // Null once the provider is disposed — see the cache lookup above.
+    final nostrClient = live.nostrClient;
+    if (nostrClient == null) return;
+
     if (filters.isNotEmpty) {
-      final eventStream = nostrService.subscribe(filters);
+      final eventStream = nostrClient.subscribe(filters);
       final seenIds = foundVideos.map((v) => v.id.toLowerCase()).toSet();
 
       await for (final event in eventStream) {
@@ -462,15 +531,22 @@ Stream<List<VideoEvent>> curatedListVideoEvents(Ref ref, String listId) async* {
 
 /// Provider that fetches VideoEvent objects directly from a list of video IDs
 /// Use this for discovered lists that aren't in local storage
+///
+/// The body is a plain function, and the reads it needs after an `await` go
+/// through [_LiveDeps] — see there for why an `async*` body cannot touch `Ref`.
 @riverpod
-Stream<List<VideoEvent>> videoEventsByIds(
-  Ref ref,
-  List<String> videoIds,
-) async* {
+Stream<List<VideoEvent>> videoEventsByIds(Ref ref, List<String> videoIds) {
   // Re-run (and therefore re-filter) when the blocklist changes — broad changes
   // bump this version but emit no granular removed-id signal (#5104).
   ref.watch(blocklistVersionProvider);
 
+  return _videoEventsByIds(videoIds: videoIds, live: _LiveDeps(ref));
+}
+
+Stream<List<VideoEvent>> _videoEventsByIds({
+  required List<String> videoIds,
+  required _LiveDeps live,
+}) async* {
   Log.info(
     '📋 Fetching ${videoIds.length} videos by IDs',
     name: 'VideoEventsByIds',
@@ -504,8 +580,12 @@ Stream<List<VideoEvent>> videoEventsByIds(
     category: LogCategory.video,
   );
 
-  // First check cache via video event service
-  final videoEventService = ref.read(videoEventServiceProvider);
+  // First check cache via video event service. Null means the provider was
+  // disposed while this body was suspended — abandon the fetch instead of
+  // reading a dead Ref (#7294).
+  final videoEventService = live.videoEventService;
+  if (videoEventService == null) return;
+
   final foundVideos = <VideoEvent>[];
   final missingIds = <String>[];
   final missingCoords = <String>[];
@@ -598,8 +678,6 @@ Stream<List<VideoEvent>> videoEventsByIds(
       category: LogCategory.video,
     );
 
-    final nostrService = ref.read(nostrServiceProvider);
-
     // Build filters for missing videos
     final filters = <Filter>[];
 
@@ -621,8 +699,12 @@ Stream<List<VideoEvent>> videoEventsByIds(
       }
     }
 
+    // Null once the provider is disposed — see the cache lookup above.
+    final nostrClient = live.nostrClient;
+    if (nostrClient == null) return;
+
     if (filters.isNotEmpty) {
-      final eventStream = nostrService.subscribe(filters);
+      final eventStream = nostrClient.subscribe(filters);
       final seenIds = foundVideos.map((v) => v.id.toLowerCase()).toSet();
 
       await for (final event in eventStream) {

--- a/mobile/lib/providers/list_providers.g.dart
+++ b/mobile/lib/providers/list_providers.g.dart
@@ -315,11 +315,19 @@ final class CuratedListVideosFamily extends $Family
 }
 
 /// Provider for videos from all members of a user list
+///
+/// The body is a plain function so every `Ref` read happens synchronously
+/// during `build` — see [_LiveDeps] for why an `async*` body cannot
+/// touch `Ref`.
 
 @ProviderFor(userListMemberVideos)
 final userListMemberVideosProvider = UserListMemberVideosFamily._();
 
 /// Provider for videos from all members of a user list
+///
+/// The body is a plain function so every `Ref` read happens synchronously
+/// during `build` — see [_LiveDeps] for why an `async*` body cannot
+/// touch `Ref`.
 
 final class UserListMemberVideosProvider
     extends
@@ -330,6 +338,10 @@ final class UserListMemberVideosProvider
         >
     with $FutureModifier<List<VideoEvent>>, $StreamProvider<List<VideoEvent>> {
   /// Provider for videos from all members of a user list
+  ///
+  /// The body is a plain function so every `Ref` read happens synchronously
+  /// during `build` — see [_LiveDeps] for why an `async*` body cannot
+  /// touch `Ref`.
   UserListMemberVideosProvider._({
     required UserListMemberVideosFamily super.from,
     required List<String> super.argument,
@@ -375,9 +387,13 @@ final class UserListMemberVideosProvider
 }
 
 String _$userListMemberVideosHash() =>
-    r'005a02b0974013a6cc82aec093a1e17cf5cc4020';
+    r'acb78c2d384c7425a9ecc45210b60fb0f764ed31';
 
 /// Provider for videos from all members of a user list
+///
+/// The body is a plain function so every `Ref` read happens synchronously
+/// during `build` — see [_LiveDeps] for why an `async*` body cannot
+/// touch `Ref`.
 
 final class UserListMemberVideosFamily extends $Family
     with $FunctionalFamilyOverride<Stream<List<VideoEvent>>, List<String>> {
@@ -391,6 +407,10 @@ final class UserListMemberVideosFamily extends $Family
       );
 
   /// Provider for videos from all members of a user list
+  ///
+  /// The body is a plain function so every `Ref` read happens synchronously
+  /// during `build` — see [_LiveDeps] for why an `async*` body cannot
+  /// touch `Ref`.
 
   UserListMemberVideosProvider call(List<String> pubkeys) =>
       UserListMemberVideosProvider._(argument: pubkeys, from: this);
@@ -626,12 +646,24 @@ final class PublicCuratedListFamily extends $Family
 
 /// Provider that fetches actual VideoEvent objects for a curated list
 /// Streams videos as they are fetched from cache or relays
+///
+/// `Ref` is either read synchronously in `build` or guarded by [_LiveDeps] —
+/// this provider is the one that matters most, because
+/// `curated_list_feed_screen` calls
+/// `ref.invalidate(curatedListVideoEventsProvider(listId))` on pull-to-refresh,
+/// which disposes the previous build while it is still awaiting relays.
 
 @ProviderFor(curatedListVideoEvents)
 final curatedListVideoEventsProvider = CuratedListVideoEventsFamily._();
 
 /// Provider that fetches actual VideoEvent objects for a curated list
 /// Streams videos as they are fetched from cache or relays
+///
+/// `Ref` is either read synchronously in `build` or guarded by [_LiveDeps] —
+/// this provider is the one that matters most, because
+/// `curated_list_feed_screen` calls
+/// `ref.invalidate(curatedListVideoEventsProvider(listId))` on pull-to-refresh,
+/// which disposes the previous build while it is still awaiting relays.
 
 final class CuratedListVideoEventsProvider
     extends
@@ -643,6 +675,12 @@ final class CuratedListVideoEventsProvider
     with $FutureModifier<List<VideoEvent>>, $StreamProvider<List<VideoEvent>> {
   /// Provider that fetches actual VideoEvent objects for a curated list
   /// Streams videos as they are fetched from cache or relays
+  ///
+  /// `Ref` is either read synchronously in `build` or guarded by [_LiveDeps] —
+  /// this provider is the one that matters most, because
+  /// `curated_list_feed_screen` calls
+  /// `ref.invalidate(curatedListVideoEventsProvider(listId))` on pull-to-refresh,
+  /// which disposes the previous build while it is still awaiting relays.
   CuratedListVideoEventsProvider._({
     required CuratedListVideoEventsFamily super.from,
     required String super.argument,
@@ -689,10 +727,16 @@ final class CuratedListVideoEventsProvider
 }
 
 String _$curatedListVideoEventsHash() =>
-    r'c75af13b98f9f2859e06bb938119bc8187bd9e90';
+    r'9f195da0426a9a6a75e2dfd097b6b9ec1410010b';
 
 /// Provider that fetches actual VideoEvent objects for a curated list
 /// Streams videos as they are fetched from cache or relays
+///
+/// `Ref` is either read synchronously in `build` or guarded by [_LiveDeps] —
+/// this provider is the one that matters most, because
+/// `curated_list_feed_screen` calls
+/// `ref.invalidate(curatedListVideoEventsProvider(listId))` on pull-to-refresh,
+/// which disposes the previous build while it is still awaiting relays.
 
 final class CuratedListVideoEventsFamily extends $Family
     with $FunctionalFamilyOverride<Stream<List<VideoEvent>>, String> {
@@ -707,6 +751,12 @@ final class CuratedListVideoEventsFamily extends $Family
 
   /// Provider that fetches actual VideoEvent objects for a curated list
   /// Streams videos as they are fetched from cache or relays
+  ///
+  /// `Ref` is either read synchronously in `build` or guarded by [_LiveDeps] —
+  /// this provider is the one that matters most, because
+  /// `curated_list_feed_screen` calls
+  /// `ref.invalidate(curatedListVideoEventsProvider(listId))` on pull-to-refresh,
+  /// which disposes the previous build while it is still awaiting relays.
 
   CuratedListVideoEventsProvider call(String listId) =>
       CuratedListVideoEventsProvider._(argument: listId, from: this);
@@ -717,12 +767,18 @@ final class CuratedListVideoEventsFamily extends $Family
 
 /// Provider that fetches VideoEvent objects directly from a list of video IDs
 /// Use this for discovered lists that aren't in local storage
+///
+/// The body is a plain function, and the reads it needs after an `await` go
+/// through [_LiveDeps] — see there for why an `async*` body cannot touch `Ref`.
 
 @ProviderFor(videoEventsByIds)
 final videoEventsByIdsProvider = VideoEventsByIdsFamily._();
 
 /// Provider that fetches VideoEvent objects directly from a list of video IDs
 /// Use this for discovered lists that aren't in local storage
+///
+/// The body is a plain function, and the reads it needs after an `await` go
+/// through [_LiveDeps] — see there for why an `async*` body cannot touch `Ref`.
 
 final class VideoEventsByIdsProvider
     extends
@@ -734,6 +790,9 @@ final class VideoEventsByIdsProvider
     with $FutureModifier<List<VideoEvent>>, $StreamProvider<List<VideoEvent>> {
   /// Provider that fetches VideoEvent objects directly from a list of video IDs
   /// Use this for discovered lists that aren't in local storage
+  ///
+  /// The body is a plain function, and the reads it needs after an `await` go
+  /// through [_LiveDeps] — see there for why an `async*` body cannot touch `Ref`.
   VideoEventsByIdsProvider._({
     required VideoEventsByIdsFamily super.from,
     required List<String> super.argument,
@@ -778,10 +837,13 @@ final class VideoEventsByIdsProvider
   }
 }
 
-String _$videoEventsByIdsHash() => r'e6a653a18021cfbf8221af6045f7f20a93841622';
+String _$videoEventsByIdsHash() => r'71472b817b86016d74247fcb6288e252abf97cbf';
 
 /// Provider that fetches VideoEvent objects directly from a list of video IDs
 /// Use this for discovered lists that aren't in local storage
+///
+/// The body is a plain function, and the reads it needs after an `await` go
+/// through [_LiveDeps] — see there for why an `async*` body cannot touch `Ref`.
 
 final class VideoEventsByIdsFamily extends $Family
     with $FunctionalFamilyOverride<Stream<List<VideoEvent>>, List<String>> {
@@ -796,6 +858,9 @@ final class VideoEventsByIdsFamily extends $Family
 
   /// Provider that fetches VideoEvent objects directly from a list of video IDs
   /// Use this for discovered lists that aren't in local storage
+  ///
+  /// The body is a plain function, and the reads it needs after an `await` go
+  /// through [_LiveDeps] — see there for why an `async*` body cannot touch `Ref`.
 
   VideoEventsByIdsProvider call(List<String> videoIds) =>
       VideoEventsByIdsProvider._(argument: videoIds, from: this);

--- a/mobile/test/providers/list_providers_test.dart
+++ b/mobile/test/providers/list_providers_test.dart
@@ -3,6 +3,7 @@
 
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -496,6 +497,83 @@ void main() {
     });
   });
 
+  // Regression: an `async*` provider body does not start until the returned
+  // stream is listened to, so a provider that is invalidated (pull-to-refresh)
+  // or unmounted (screen dismissed) first would reach its `ref.watch` /
+  // `ref.read` on an already-disposed Ref and throw
+  // "Cannot use the Ref … after it has been disposed" (#6274, #7294).
+  group('Ref lifecycle on immediate disposal (#7294)', () {
+    _MockVideoEventService buildVideoEventService() {
+      final video = _video(id: _allowedVideoId, pubkey: _ownerA);
+      final videoEventService = _MockVideoEventService();
+      when(() => videoEventService.discoveryVideos).thenReturn(const []);
+      when(() => videoEventService.homeFeedVideos).thenReturn(const []);
+      when(() => videoEventService.profileVideos).thenReturn(const []);
+      when(
+        () => videoEventService.getVideoById(_allowedVideoId),
+      ).thenReturn(video);
+      when(() => videoEventService.shouldHideVideo(video)).thenReturn(false);
+      return videoEventService;
+    }
+
+    test(
+      '$videoEventsByIdsProvider abandons its fetch without touching Ref',
+      () async {
+        final videoEventService = buildVideoEventService();
+        final container = ProviderContainer(
+          overrides: [
+            videoEventServiceProvider.overrideWithValue(videoEventService),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        final provider = videoEventsByIdsProvider([_allowedVideoId]);
+
+        final uncaughtErrors = await _captureUncaughtErrors(() async {
+          final subscription = container.listen(provider, (_, _) {});
+          container.invalidate(provider);
+          subscription.close();
+          await Future<void>.delayed(Duration.zero);
+        });
+
+        expect(uncaughtErrors, isEmpty);
+        // The work is abandoned, not merely silent: nothing reads the cache
+        // on behalf of a provider that no longer exists.
+        verifyNever(() => videoEventService.getVideoById(any()));
+      },
+    );
+
+    test(
+      '$curatedListVideoEventsProvider abandons its fetch without touching Ref',
+      () async {
+        const listId = 'curated-list-disposed';
+        final videoEventService = buildVideoEventService();
+        final container = ProviderContainer(
+          overrides: [
+            videoEventServiceProvider.overrideWithValue(videoEventService),
+            curatedListVideosProvider(
+              listId,
+            ).overrideWith((ref) => [_allowedVideoId]),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        final provider = curatedListVideoEventsProvider(listId);
+
+        final uncaughtErrors = await _captureUncaughtErrors(() async {
+          final subscription = container.listen(provider, (_, _) {});
+          container.invalidate(provider);
+          subscription.close();
+          await Future<void>.delayed(Duration.zero);
+          await Future<void>.delayed(Duration.zero);
+        });
+
+        expect(uncaughtErrors, isEmpty);
+        verifyNever(() => videoEventService.getVideoById(any()));
+      },
+    );
+  });
+
   group(publicCuratedListProvider, () {
     test(
       'fetches once and does not re-run when the lists state re-emits',
@@ -566,4 +644,30 @@ class _StubCuratedListsState extends CuratedListsState {
   Future<List<CuratedList>> build() async => [];
 
   void reEmit() => state = const AsyncValue.data(<CuratedList>[]);
+}
+
+/// Collects everything that escapes [body] as an unhandled error — both
+/// zone-level async errors and `FlutterError.onError` reports.
+///
+/// A disposed-Ref access surfaces this way rather than as a thrown exception
+/// at the call site, so an `expect(..., isEmpty)` on the result is what makes
+/// the lifecycle regression above visible.
+Future<List<Object>> _captureUncaughtErrors(
+  Future<void> Function() body,
+) async {
+  final errors = <Object>[];
+  final previousFlutterError = FlutterError.onError;
+  FlutterError.onError = (details) {
+    errors.add(details.exception);
+  };
+
+  try {
+    await runZonedGuarded(body, (error, _) {
+      errors.add(error);
+    });
+  } finally {
+    FlutterError.onError = previousFlutterError;
+  }
+
+  return errors;
 }


### PR DESCRIPTION
## Description

**Read this first: the crash named in #7294 is already fixed, and this PR does not fix it.** `commentsProvider` no longer exists anywhere in the repo — comments moved to BLoC long ago. Pulling the actual Crashlytics group rather than trusting the issue title shows three variants: the `CommentsNotifier` one last fired on 1.0.3 in July, and every live event resolves to `userProfileReactiveProvider` at `user_profile_providers.dart:47`. That one was fixed by #6405, which converted the `async*` body into a plain function capturing its deps synchronously in `build`. That fix is intact at HEAD, nothing in the repo undid it, and the group's `lastSeenVersion` is 1.0.17 — zero events on 1.0.18, 1.0.19, or any build after the fix shipped. The "regressed on 11 Mar 2026" signal is a Crashlytics-level `SIGNAL_REGRESSED` on a group first seen in 0.0.1, four months before #6274; it is not an in-repo regression.

So the reported crash is draining as users leave build 813. What this PR does instead is close the sibling audit that #6274 explicitly deferred — the providers with the same unsafe shape that are still live at HEAD and would keep this exact Crashlytics signature alive.

The shape: an `async*` provider body does not start until its returned stream is listened to, and it keeps running briefly after Riverpod tears the provider down. Any `Ref` touched at its first statement or across one of its `await`s can therefore land on a dead `Ref`.

Three providers are converted, all with live consumers:

- `curatedListVideoEvents` — the one that matters. `curated_list_feed_screen` calls `ref.invalidate(curatedListVideoEventsProvider(listId))` on pull-to-refresh, disposing a build that is mid-`await` on relays, after which the body did `ref.read(videoEventServiceProvider)` and `ref.read(nostrServiceProvider)`.
- `videoEventsByIds` — same shape, reached from discovered lists.
- `userListMemberVideos` — `ref.watch` as its first statement, hoisted into the synchronous `build`.

Two mechanisms, matching the two situations. Unconditional deps are hoisted into `build` and the body delegates to a private `Ref`-free `async*` helper — the shape #6405 established. Deps needed only *after* an await go through a small `_LiveDeps` wrapper whose getters return `null` once the provider is torn down, so the body abandons its work instead of fetching on behalf of something nobody is listening to.

**Why `_LiveDeps` is not just a reimplementation of `ref.mounted`.** That was the first thing tried, since `ref.mounted` is Riverpod's own recommendation and this repo already uses it at 42 sites. Both regression tests went red against it. `invalidateSelf` runs `onDispose` immediately but only *schedules* the rebuild, so `ref.mounted` still reports `true` while the old body runs against a `Ref` that is already being torn down — and pull-to-refresh takes exactly that path. The `onDispose`-driven flag is load-bearing, and the class comment says so.

**Related Issue:** Closes #7294

## Out of Scope

An earlier draft of this change also hardened `relayStatisticsStream`, `publicListsContainingVideo`, and `nip05VerificationStream`. All three were reverted:

- `nip05VerificationStream` and `publicListsContainingVideo` have **zero consumers** anywhere in the repo. Restructuring dead code adds diff surface and risk for no defect closure.
- The `nip05VerificationStream` version was worse than that: hoisting its `StreamController` and `addListener` out of the `pending` branch meant that on the common non-pending path *nothing ever listened*, so a single-subscription controller buffered every global `notifyListeners()` without bound, once per live provider instance.
- `relayStatisticsStream` registered its listener during `build` while the body's first `yield` still ran a microtask later, inverting emission order so a stale snapshot replayed over a fresh one. Both benefits its comment claimed turned out not to hold.

Deleting the two dead providers outright is probably the right follow-up, but it is a separate call from fixing a crash class.

Also out of scope: `pageContextProvider` has the same first-statement `ref.watch` in an `async*` body, but it is a plain non-codegen `StreamProvider` that is only torn down with its scope, and it sits on the router hot path.

## Verification

- `flutter analyze lib test integration_test` — clean.
- `flutter test test/providers/list_providers_test.dart` — passing, plus the screen tests that consume these providers: `curated_list_feed_screen_test`, `curated_list_by_author_screen_test`, `user_list_people_screen_test`.
- Full app suite via `mise run test` — green, re-run after rebasing onto current `main`.
- `dart format` — no drift; `build_runner` re-run and the `.g.dart` deltas are provider-hash and doc-comment propagation only.
- Both new tests proved able to fail: stashing the source change reddens `videoEventsByIdsProvider abandons its fetch without touching Ref` and `curatedListVideoEventsProvider abandons its fetch without touching Ref`. A third test for `userListMemberVideos` was written and then deleted — it passed with and without the fix, so under `.claude/rules/testing.md` it was guarding nothing. The hoist for that provider is kept; it is the same defect class, just not reproducible in that harness.
- `verifyNever(getVideoById)` is not vacuous: `_allowedVideoId` is full 64-char hex, so the happy path genuinely reaches that call, pinned by the pre-existing test in the same file.

**Not yet verified on device.** This has not been run on a real Samsung Galaxy yet — that is why the PR is a draft.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
