### PR TITLE
fix(relay): close the WebSocket sink on idle-timeout disconnect

### DIFF
--- a/mobile/packages/nostr_sdk/lib/relay/web_socket_connection_manager.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/web_socket_connection_manager.dart
@@ -275,9 +275,9 @@ class WebSocketConnectionManager {
     // Must close the sink, not just drop the reference: the idle heartbeat
     // and checkHealth() tear down a *live* socket, and cancelling the stream
     // subscription alone leaves the underlying connection open forever.
-    // Fire-and-forget because every caller is a stream or timer callback with
-    // nowhere to await into; _closeChannel detaches _channel before its first
-    // await, so a reconnect racing this close keeps its fresh channel.
+    // Fire-and-forget because every caller is synchronous; _closeChannel
+    // detaches _channel before its first await, so a reconnect racing this
+    // close keeps its fresh channel.
     unawaited(_closeChannel());
 
     _setState(ConnectionState.disconnected);

--- a/mobile/packages/nostr_sdk/lib/relay/web_socket_connection_manager.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/web_socket_connection_manager.dart
@@ -271,9 +271,14 @@ class WebSocketConnectionManager {
 
   void _handleDisconnect() {
     _stopHeartbeat();
-    _channelSubscription?.cancel();
-    _channelSubscription = null;
-    _channel = null;
+
+    // Must close the sink, not just drop the reference: the idle heartbeat
+    // and checkHealth() tear down a *live* socket, and cancelling the stream
+    // subscription alone leaves the underlying connection open forever.
+    // Fire-and-forget because every caller is a stream or timer callback with
+    // nowhere to await into; _closeChannel detaches _channel before its first
+    // await, so a reconnect racing this close keeps its fresh channel.
+    unawaited(_closeChannel());
 
     _setState(ConnectionState.disconnected);
     // No automatic reconnection - reconnect happens on-demand when sending
@@ -295,13 +300,17 @@ class WebSocketConnectionManager {
     _channelSubscription?.cancel();
     _channelSubscription = null;
 
-    if (_channel != null) {
-      try {
-        await _channel!.sink.close();
-      } catch (e) {
-        log('Error closing channel: $e');
-      }
-      _channel = null;
+    // Detach before the first await so callers that do not await this future
+    // cannot have a later _doConnect's channel nulled out when the close
+    // finally completes.
+    final channel = _channel;
+    _channel = null;
+    if (channel == null) return;
+
+    try {
+      await channel.sink.close();
+    } catch (e) {
+      log('Error closing channel: $e');
     }
   }
 

--- a/mobile/packages/nostr_sdk/test/unit/web_socket_connection_manager_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/web_socket_connection_manager_test.dart
@@ -307,6 +307,95 @@ void main() {
       });
     });
 
+    // The idle heartbeat and checkHealth() tear down a *live* socket, unlike
+    // the stream-error/stream-done paths where the transport is already gone.
+    // Dropping the channel reference without closing the sink strands an open
+    // connection the manager no longer has a handle to.
+    group('idle disconnect', () {
+      test('closes the channel sink when the heartbeat forces a '
+          'disconnect', () async {
+        final factory = MockWebSocketChannelFactory();
+        final idleManager = WebSocketConnectionManager(
+          url: 'wss://test.relay.com',
+          channelFactory: factory,
+          logger: logMessages.add,
+          config: const WebSocketConfig(
+            heartbeatInterval: Duration(milliseconds: 20),
+            idleTimeout: Duration(milliseconds: 10),
+          ),
+        );
+        addTearDown(idleManager.dispose);
+
+        await idleManager.connect();
+        final idleChannel = factory.lastChannel!;
+        expect(idleChannel.isClosed, isFalse);
+
+        await Future<void>.delayed(const Duration(milliseconds: 120));
+
+        expect(idleManager.state, equals(ConnectionState.disconnected));
+        expect(idleChannel.isClosed, isTrue);
+      });
+
+      test('closes the channel sink when checkHealth finds a stale '
+          'connection', () async {
+        final factory = MockWebSocketChannelFactory();
+        final staleManager = WebSocketConnectionManager(
+          url: 'wss://test.relay.com',
+          channelFactory: factory,
+          logger: logMessages.add,
+          config: const WebSocketConfig(
+            // No heartbeat timer: checkHealth is the only disconnect trigger.
+            heartbeatInterval: Duration.zero,
+            idleTimeout: Duration(milliseconds: 10),
+          ),
+        );
+        addTearDown(staleManager.dispose);
+
+        await staleManager.connect();
+        final staleChannel = factory.lastChannel!;
+        await Future<void>.delayed(const Duration(milliseconds: 30));
+
+        expect(staleManager.checkHealth(), isFalse);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(staleManager.state, equals(ConnectionState.disconnected));
+        expect(staleChannel.isClosed, isTrue);
+      });
+
+      test('reconnects onto a usable fresh channel after an idle '
+          'disconnect', () async {
+        final factory = MockWebSocketChannelFactory();
+        final staleManager = WebSocketConnectionManager(
+          url: 'wss://test.relay.com',
+          channelFactory: factory,
+          logger: logMessages.add,
+          config: const WebSocketConfig(
+            baseReconnectDelay: Duration(milliseconds: 10),
+            heartbeatInterval: Duration.zero,
+            idleTimeout: Duration(milliseconds: 10),
+          ),
+        );
+        addTearDown(staleManager.dispose);
+
+        await staleManager.connect();
+        final staleChannel = factory.lastChannel!;
+        await Future<void>.delayed(const Duration(milliseconds: 30));
+        staleManager.checkHealth();
+
+        final sent = await staleManager.send('["REQ","sub1",{}]');
+
+        // Exactly one live socket per cycle: the idle one is closed and the
+        // fresh one still works.
+        expect(sent, isTrue);
+        expect(staleChannel.isClosed, isTrue);
+        expect(factory.createdChannels, hasLength(2));
+        final freshChannel = factory.lastChannel!;
+        expect(freshChannel, isNot(same(staleChannel)));
+        expect(freshChannel.isClosed, isFalse);
+        expect(freshChannel.sentMessages, contains('["REQ","sub1",{}]'));
+      });
+    });
+
     group('messaging', () {
       test('receives messages', () async {
         await manager.connect();

--- a/mobile/packages/nostr_sdk/test/unit/web_socket_connection_manager_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/web_socket_connection_manager_test.dart
@@ -15,6 +15,9 @@ class MockWebSocketSink implements WebSocketSink {
   String? closeReason;
   final Completer<void> _doneCompleter = Completer<void>();
 
+  /// When set, [close] does not finish until this completer completes.
+  Completer<void>? closeGate;
+
   @override
   void add(dynamic data) {
     if (closed) throw StateError('Sink is closed');
@@ -35,6 +38,8 @@ class MockWebSocketSink implements WebSocketSink {
   Future close([int? closeCode, String? closeReason]) async {
     this.closeCode = closeCode;
     this.closeReason = closeReason;
+    final gate = closeGate;
+    if (gate != null) await gate.future;
     closed = true;
     if (!_doneCompleter.isCompleted) {
       _doneCompleter.complete();
@@ -97,6 +102,16 @@ class MockWebSocketChannel implements WebSocketChannel {
   void simulateClose() {
     _closeCode = 1000;
     _streamController.close();
+  }
+
+  /// Holds [sink]'s close in flight until the returned completer completes.
+  ///
+  /// A real close is a network round trip that can outlive a reconnect; the
+  /// mock otherwise finishes it synchronously, which hides ordering bugs.
+  Completer<void> blockClose() {
+    final gate = Completer<void>();
+    _sink.closeGate = gate;
+    return gate;
   }
 
   List<dynamic> get sentMessages => _sink.messages;
@@ -393,6 +408,41 @@ void main() {
         expect(freshChannel, isNot(same(staleChannel)));
         expect(freshChannel.isClosed, isFalse);
         expect(freshChannel.sentMessages, contains('["REQ","sub1",{}]'));
+      });
+
+      test('keeps the reconnected channel when a slow close lands '
+          'late', () async {
+        final factory = MockWebSocketChannelFactory();
+        final staleManager = WebSocketConnectionManager(
+          url: 'wss://test.relay.com',
+          channelFactory: factory,
+          logger: logMessages.add,
+          config: const WebSocketConfig(
+            baseReconnectDelay: Duration(milliseconds: 10),
+            heartbeatInterval: Duration.zero,
+            idleTimeout: Duration(milliseconds: 10),
+          ),
+        );
+        addTearDown(staleManager.dispose);
+
+        await staleManager.connect();
+        final staleChannel = factory.lastChannel!;
+        final closeGate = staleChannel.blockClose();
+        await Future<void>.delayed(const Duration(milliseconds: 30));
+        staleManager.checkHealth();
+
+        expect(await staleManager.send('["REQ","sub1",{}]'), isTrue);
+        final freshChannel = factory.lastChannel!;
+
+        closeGate.complete();
+        await Future<void>.delayed(Duration.zero);
+
+        // The late close must not detach the channel it never owned, or the
+        // manager reports connected while every send drops on the floor.
+        expect(staleChannel.isClosed, isTrue);
+        expect(staleManager.isConnected, isTrue);
+        expect(await staleManager.send('["REQ","sub2",{}]'), isTrue);
+        expect(freshChannel.sentMessages, contains('["REQ","sub2",{}]'));
       });
     });
 


### PR DESCRIPTION
## Description

`_handleDisconnect` tore down a connection by cancelling the stream subscription and nulling `_channel`, but never closed the sink. Two of its callers fire on a **healthy** socket — the idle heartbeat and `checkHealth()` — so the TCP/TLS connection stayed fully open while the manager reported `disconnected` and dropped its only handle to it. Each idle cycle stranded one more live socket: an OS file descriptor plus the object graph behind it.

Cancelling a subscription on `channel.stream` deliberately does not propagate to the transport. `GuaranteeChannel` keeps an intermediate controller specifically so it can keep observing `done` after the user cancels, and `AdapterWebSocketChannel` closes the real socket only from that inner listener's `onDone` — which is reached only by closing the sink.

`_handleDisconnect` now routes through `_closeChannel`, the sibling teardown that already closes the sink, rather than duplicating the close logic.

**Why `_closeChannel` had to change too:** it nulled `_channel` *after* `await sink.close()`. Fire-and-forgetting that from `_handleDisconnect` would leave `_channel` non-null across the await, so a reconnect racing the close would assign a fresh channel and the late continuation would null **that** one out — stranding the new socket and making `_doSend` return false forever. Strictly worse than the bug being fixed. It now detaches before its first `await`, which also keeps `_handleDisconnect` synchronous for its timer and stream callers.

Closing an already-closed channel is safe — `AdapterWebSocketChannel` swallows `WebSocketConnectionClosed` in its own close path — so the callers that run on an already-dead socket (`_onStreamError`, `_onStreamDone`, `_doSend`'s catch) are unaffected.

**Related Issue:** Closes #7310

## Out of Scope

- **No `CLOSE` is sent for still-open `REQ` subscriptions on this path.** Verified from code: `_releaseQuery` takes the `discardQuery` branch when not connected, and live subscriptions are kept and re-issued as fresh `REQ` on reconnect. Whether the relay keeps streaming matches into the stranded socket, and whether it eventually reaps the connection itself, remain **unverified** — the relay source lives in a separate repo and ships as a prebuilt image, and I did not measure against a real relay.
- `RelayPool.unsubscribe` calls `checkAndCompleteSubscription` with no connected-state guard, unlike `_releaseQuery`, so its `CLOSE` can drive a reconnect or be queued and replayed on a fresh socket where the subscription id is meaningless. Filed as #7358.

## Verification

The idle-disconnect path had no test at all, which is why this went unnoticed. Four added to `web_socket_connection_manager_test.dart`, each confirmed to fail against the unfixed code and pass with it.

The fourth came out of self-review: reverting only the `_closeChannel` detach-before-await hunk, keeping `unawaited(_closeChannel())`, still left all 30 tests green — the mock sink resolved its close in the next microtask, well inside the reconnect backoff, so the race could never occur in the suite. An opt-in `blockClose()` gate now holds a sink close in flight across a reconnect; against the old ordering that test fails on the reconnected send returning false, the `_doSend` failure mode described above.

- `flutter test test/unit/web_socket_connection_manager_test.dart` — 31/31
- `flutter test` (full `nostr_sdk` suite) — 517/517
- same file × 15 with `--test-randomize-ordering-seed random` — 15/15 (10 unloaded, 5 under 36-process CPU saturation)
- `flutter analyze lib test` — clean, package and app layer
- `dart format --set-exit-if-changed` — clean


## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)


