### PR TITLE
fix(bloc): stop add/emit after close in work that outlives the bloc

### DIFF
--- a/mobile/lib/blocs/apps_directory/apps_directory_cubit.dart
+++ b/mobile/lib/blocs/apps_directory/apps_directory_cubit.dart
@@ -21,10 +21,12 @@ class AppsDirectoryCubit extends Cubit<AppsDirectoryState> {
     emit(state.copyWith(status: AppsDirectoryStatus.loading));
     try {
       final apps = await _directoryService.fetchApprovedApps();
-      emit(state.copyWith(status: AppsDirectoryStatus.loaded, apps: apps));
+      _emitIfOpen(
+        state.copyWith(status: AppsDirectoryStatus.loaded, apps: apps),
+      );
     } catch (error, stackTrace) {
       addError(error, stackTrace);
-      emit(state.copyWith(status: AppsDirectoryStatus.error));
+      _emitIfOpen(state.copyWith(status: AppsDirectoryStatus.error));
     }
   }
 
@@ -32,10 +34,19 @@ class AppsDirectoryCubit extends Cubit<AppsDirectoryState> {
   Future<void> refreshApps() async {
     try {
       final apps = await _directoryService.fetchApprovedApps();
-      emit(state.copyWith(status: AppsDirectoryStatus.loaded, apps: apps));
+      _emitIfOpen(
+        state.copyWith(status: AppsDirectoryStatus.loaded, apps: apps),
+      );
     } catch (error, stackTrace) {
       addError(error, stackTrace);
-      emit(state.copyWith(status: AppsDirectoryStatus.error));
+      _emitIfOpen(state.copyWith(status: AppsDirectoryStatus.error));
     }
+  }
+
+  /// The directory fetch cannot be cancelled, so it can resolve after the
+  /// screen is gone and the cubit closed.
+  void _emitIfOpen(AppsDirectoryState nextState) {
+    if (isClosed) return;
+    emit(nextState);
   }
 }

--- a/mobile/lib/blocs/badges/badges_cubit.dart
+++ b/mobile/lib/blocs/badges/badges_cubit.dart
@@ -65,6 +65,9 @@ class BadgesCubit extends Cubit<BadgesState> {
   Future<void> _loadDashboard() async {
     try {
       final dashboard = await _repository.loadDashboard();
+      // The dashboard load cannot be cancelled, so it can resolve after the
+      // badges screen was popped and this cubit closed.
+      if (isClosed) return;
       emit(
         state.copyWith(
           status: BadgesStatus.loaded,
@@ -82,6 +85,7 @@ class BadgesCubit extends Cubit<BadgesState> {
       );
     } catch (error, stackTrace) {
       addError(error, stackTrace);
+      if (isClosed) return;
       emit(
         state.copyWith(
           status: BadgesStatus.error,
@@ -104,6 +108,9 @@ class BadgesCubit extends Cubit<BadgesState> {
     try {
       await action();
       final dashboard = await _repository.loadDashboard();
+      // Publishing plus the reload cannot be cancelled, so they can resolve
+      // after the badges screen was popped and this cubit closed.
+      if (isClosed) return;
       emit(
         state.copyWith(
           status: BadgesStatus.loaded,
@@ -116,6 +123,7 @@ class BadgesCubit extends Cubit<BadgesState> {
       );
     } catch (error, stackTrace) {
       addError(error, stackTrace);
+      if (isClosed) return;
       emit(
         state.copyWith(
           actionStatus: BadgeActionStatus.error,

--- a/mobile/lib/blocs/my_following/my_following_bloc.dart
+++ b/mobile/lib/blocs/my_following/my_following_bloc.dart
@@ -238,10 +238,10 @@ class MyFollowingBloc extends Bloc<MyFollowingEvent, MyFollowingState> {
       state.rawFollowingPubkeys.isNotEmpty;
 
   void _ensureFollowingSubscription() {
-    // `close()` lets already-dispatched events finish, so this can run once the
-    // bloc is closed. Subscribing then would outlive [close] entirely, and the
-    // stream replays synchronously on listen, so the callback would fire
-    // straight into a closed event controller.
+    // `close()` lets already-dispatched events finish, so this can run once
+    // the bloc is closed. A subscription created then is never cancelled —
+    // [close] has already run past its cancel — so it would outlive the bloc
+    // and keep the repository stream alive.
     if (isClosed) return;
     _followingSubscription ??= _followRepository.followingStream.listen((
       pubkeys,
@@ -263,12 +263,13 @@ class MyFollowingBloc extends Bloc<MyFollowingEvent, MyFollowingState> {
   @override
   Future<void> close() async {
     // `super.close()` first: it flips [isClosed] synchronously and only then
-    // drains the events still in flight. Cancelling first opened a window
-    // ahead of that flip instead — awaiting a null subscription still yields
-    // a microtask, and an already queued `MyFollowingListLoadRequested` ran
-    // in it with [isClosed] still false, subscribed, and was orphaned by the
-    // cancel that had already happened. Deliveries during the drain are
-    // dropped by the [isClosed] guard in [_ensureFollowingSubscription].
+    // drains the events still in flight. What used to open a window was the
+    // *await* ahead of that flip — `await null` on a null subscription still
+    // yields a microtask, and an already queued
+    // `MyFollowingListLoadRequested` ran in it with [isClosed] still false,
+    // subscribed, and was orphaned by the cancel that had already happened.
+    // Deliveries during the drain are dropped by the [isClosed] guard in
+    // [_ensureFollowingSubscription]'s listener.
     await super.close();
     await _followingSubscription?.cancel();
     _followingSubscription = null;

--- a/mobile/lib/blocs/my_following/my_following_bloc.dart
+++ b/mobile/lib/blocs/my_following/my_following_bloc.dart
@@ -262,16 +262,15 @@ class MyFollowingBloc extends Bloc<MyFollowingEvent, MyFollowingState> {
 
   @override
   Future<void> close() async {
-    // `super.close()` first: it flips [isClosed] synchronously and only then
-    // drains the events still in flight. What used to open a window was the
-    // *await* ahead of that flip — `await null` on a null subscription still
-    // yields a microtask, and an already queued
-    // `MyFollowingListLoadRequested` ran in it with [isClosed] still false,
-    // subscribed, and was orphaned by the cancel that had already happened.
-    // Deliveries during the drain are dropped by the [isClosed] guard in
-    // [_ensureFollowingSubscription]'s listener.
-    await super.close();
-    await _followingSubscription?.cancel();
+    // Cancel first, but do not await ahead of `super.close()`: `await null`
+    // on a not-yet-created subscription still yields a microtask, and an
+    // already queued `MyFollowingListLoadRequested` ran in it with [isClosed]
+    // still false, subscribed, and was orphaned by the cancel that had
+    // already happened. Capturing the future keeps the cancel guaranteed even
+    // if `super.close()` throws.
+    final cancelled = _followingSubscription?.cancel();
     _followingSubscription = null;
+    await super.close();
+    await cancelled;
   }
 }

--- a/mobile/lib/blocs/my_following/my_following_bloc.dart
+++ b/mobile/lib/blocs/my_following/my_following_bloc.dart
@@ -238,9 +238,17 @@ class MyFollowingBloc extends Bloc<MyFollowingEvent, MyFollowingState> {
       state.rawFollowingPubkeys.isNotEmpty;
 
   void _ensureFollowingSubscription() {
-    _followingSubscription ??= _followRepository.followingStream.listen(
-      (pubkeys) => add(_MyFollowingRepositoryUpdated(pubkeys)),
-    );
+    // `close()` lets already-dispatched events finish, so this can run once the
+    // bloc is closed. Subscribing then would outlive [close] entirely, and the
+    // stream replays synchronously on listen, so the callback would fire
+    // straight into a closed event controller.
+    if (isClosed) return;
+    _followingSubscription ??= _followRepository.followingStream.listen((
+      pubkeys,
+    ) {
+      if (isClosed) return;
+      add(_MyFollowingRepositoryUpdated(pubkeys));
+    });
   }
 
   bool _samePubkeys(List<String> a, List<String> b) {
@@ -254,7 +262,15 @@ class MyFollowingBloc extends Bloc<MyFollowingEvent, MyFollowingState> {
 
   @override
   Future<void> close() async {
+    // `super.close()` first: it flips [isClosed] synchronously and only then
+    // drains the events still in flight. Cancelling first opened a window
+    // ahead of that flip instead — awaiting a null subscription still yields
+    // a microtask, and an already queued `MyFollowingListLoadRequested` ran
+    // in it with [isClosed] still false, subscribed, and was orphaned by the
+    // cancel that had already happened. Deliveries during the drain are
+    // dropped by the [isClosed] guard in [_ensureFollowingSubscription].
+    await super.close();
     await _followingSubscription?.cancel();
-    return super.close();
+    _followingSubscription = null;
   }
 }

--- a/mobile/lib/blocs/profile_liked_videos/profile_liked_videos_bloc.dart
+++ b/mobile/lib/blocs/profile_liked_videos/profile_liked_videos_bloc.dart
@@ -535,6 +535,10 @@ class ProfileLikedVideosBloc
           name: 'ProfileLikedVideosBloc',
           category: LogCategory.video,
         );
+        // `close()` drains the events still in flight, so this callback can
+        // run after the event controller is already closed. There is nothing
+        // left to reconcile for at that point.
+        if (isClosed) return state;
         add(ProfileLikedVideosReconcileRequested(newIds));
         return state;
       },
@@ -879,10 +883,14 @@ class ProfileLikedVideosBloc
   }
 
   @override
-  Future<void> close() {
-    _removedVideoIdsSubscription.cancel();
-    _blocklistSubscription.cancel();
-    return super.close();
+  Future<void> close() async {
+    // `super.close()` first: it flips [isClosed] synchronously and only then
+    // drains the events still in flight, so the drained handlers see a closed
+    // bloc and skip dispatching. Cancelling first delays that flip and lets
+    // those handlers dispatch follow-up events into a bloc that is going away.
+    await super.close();
+    await _removedVideoIdsSubscription.cancel();
+    await _blocklistSubscription.cancel();
   }
 }
 

--- a/mobile/lib/blocs/profile_liked_videos/profile_liked_videos_bloc.dart
+++ b/mobile/lib/blocs/profile_liked_videos/profile_liked_videos_bloc.dart
@@ -530,15 +530,16 @@ class ProfileLikedVideosBloc
           return state;
         }
 
+        // `close()` closes the event controller before it cancels this
+        // emitter, so a delivery in that window would dispatch into a closed
+        // bloc. There is nothing left to reconcile for at that point.
+        if (isClosed) return state;
+
         Log.info(
           'ProfileLikedVideosBloc: Liked IDs changed, reconciling list',
           name: 'ProfileLikedVideosBloc',
           category: LogCategory.video,
         );
-        // `close()` drains the events still in flight, so this callback can
-        // run after the event controller is already closed. There is nothing
-        // left to reconcile for at that point.
-        if (isClosed) return state;
         add(ProfileLikedVideosReconcileRequested(newIds));
         return state;
       },
@@ -883,14 +884,10 @@ class ProfileLikedVideosBloc
   }
 
   @override
-  Future<void> close() async {
-    // `super.close()` first: it flips [isClosed] synchronously and only then
-    // drains the events still in flight, so the drained handlers see a closed
-    // bloc and skip dispatching. Cancelling first delays that flip and lets
-    // those handlers dispatch follow-up events into a bloc that is going away.
-    await super.close();
-    await _removedVideoIdsSubscription.cancel();
-    await _blocklistSubscription.cancel();
+  Future<void> close() {
+    _removedVideoIdsSubscription.cancel();
+    _blocklistSubscription.cancel();
+    return super.close();
   }
 }
 

--- a/mobile/lib/blocs/safety_settings/safety_settings_cubit.dart
+++ b/mobile/lib/blocs/safety_settings/safety_settings_cubit.dart
@@ -67,6 +67,10 @@ class SafetySettingsCubit extends Cubit<SafetySettingsState> {
     emit(state.copyWith(status: SafetySettingsStatus.loading));
     await _ageVerificationService.initialize();
     await _moderationLabelService.ensureLoaded();
+    // Leaving the screen mid-load closes the cubit while these awaits are
+    // still pending. Bailing here also stops the subscription below from
+    // being created after [close] already ran past its cancel.
+    if (isClosed) return;
     emit(
       state.copyWith(
         status: SafetySettingsStatus.ready,
@@ -111,7 +115,7 @@ class SafetySettingsCubit extends Cubit<SafetySettingsState> {
       }
     } catch (e, stackTrace) {
       addError(e, stackTrace);
-      emit(state.copyWith(isAgeVerified: previous));
+      _emitIfOpen(state.copyWith(isAgeVerified: previous));
     }
   }
 
@@ -126,7 +130,7 @@ class SafetySettingsCubit extends Cubit<SafetySettingsState> {
       await _divineHostFilterService.setShowDivineHostedOnly(value);
     } catch (e, stackTrace) {
       addError(e, stackTrace);
-      emit(state.copyWith(showDivineHostedOnly: previous));
+      _emitIfOpen(state.copyWith(showDivineHostedOnly: previous));
     }
   }
 
@@ -156,7 +160,7 @@ class SafetySettingsCubit extends Cubit<SafetySettingsState> {
       );
     } catch (e, stackTrace) {
       addError(e, stackTrace);
-      emit(state.copyWith(isPeopleIFollowEnabled: previous));
+      _emitIfOpen(state.copyWith(isPeopleIFollowEnabled: previous));
     }
   }
 
@@ -170,7 +174,7 @@ class SafetySettingsCubit extends Cubit<SafetySettingsState> {
     if (trimmed.isEmpty) return;
     final hexPubkey = npubToHexOrNull(trimmed) ?? trimmed;
     await _moderationLabelService.addLabeler(hexPubkey);
-    emit(
+    _emitIfOpen(
       state.copyWith(customLabelers: _moderationLabelService.customLabelers),
     );
   }
@@ -178,7 +182,7 @@ class SafetySettingsCubit extends Cubit<SafetySettingsState> {
   /// Unsubscribe from a custom labeler.
   Future<void> removeLabeler(String pubkey) async {
     await _moderationLabelService.removeLabeler(pubkey);
-    emit(
+    _emitIfOpen(
       state.copyWith(customLabelers: _moderationLabelService.customLabelers),
     );
   }
@@ -190,11 +194,18 @@ class SafetySettingsCubit extends Cubit<SafetySettingsState> {
   /// frame as the mutation.
   Future<void> unblockUser(String pubkey) async {
     await _contentBlocklistRepository.unblockUser(pubkey);
-    emit(
+    _emitIfOpen(
       state.copyWith(
         blockedUsers: _contentBlocklistRepository.runtimeBlockedUsers,
       ),
     );
+  }
+
+  /// Every mutation here awaits a service call that cannot be cancelled, so
+  /// leaving the screen mid-flight resolves it against a closed cubit.
+  void _emitIfOpen(SafetySettingsState nextState) {
+    if (isClosed) return;
+    emit(nextState);
   }
 
   @override

--- a/mobile/lib/blocs/safety_settings/safety_settings_cubit.dart
+++ b/mobile/lib/blocs/safety_settings/safety_settings_cubit.dart
@@ -210,7 +210,14 @@ class SafetySettingsCubit extends Cubit<SafetySettingsState> {
 
   @override
   Future<void> close() async {
-    await _blocklistSub?.cancel();
-    return super.close();
+    // Do not await the cancel ahead of `super.close()`: that await yields a
+    // microtask in which a [load] parked on `ensureLoaded` resumes, sees
+    // [isClosed] as false, and subscribes past the cancel — leaking the
+    // cubit and its subscription. Capturing the future keeps the cancel
+    // guaranteed even if `super.close()` throws.
+    final cancelled = _blocklistSub?.cancel();
+    _blocklistSub = null;
+    await super.close();
+    await cancelled;
   }
 }

--- a/mobile/lib/blocs/sandbox_route/sandbox_route_cubit.dart
+++ b/mobile/lib/blocs/sandbox_route/sandbox_route_cubit.dart
@@ -40,6 +40,9 @@ class SandboxRouteCubit extends Cubit<SandboxRouteState> {
     if (state is SandboxRouteResolved) return;
     try {
       final apps = await _directoryService.fetchApprovedApps();
+      // The fetch cannot be cancelled, so it can resolve after the route was
+      // popped and this cubit closed.
+      if (isClosed) return;
       for (final app in apps) {
         if (app.id == _appId || app.slug == _appId) {
           emit(SandboxRouteResolved(app));
@@ -49,6 +52,7 @@ class SandboxRouteCubit extends Cubit<SandboxRouteState> {
       emit(const SandboxRouteNotFound());
     } catch (error, stackTrace) {
       addError(error, stackTrace);
+      if (isClosed) return;
       emit(const SandboxRouteNotFound());
     }
   }

--- a/mobile/lib/blocs/settings_account/settings_account_cubit.dart
+++ b/mobile/lib/blocs/settings_account/settings_account_cubit.dart
@@ -34,6 +34,9 @@ class SettingsAccountCubit extends Cubit<SettingsAccountState> {
     try {
       final accounts = await _authService.getKnownAccounts();
       final draftCount = await _draftStorageService.getDraftCount();
+      // Neither read can be cancelled, so both can resolve after the account
+      // sheet was dismissed and this cubit closed.
+      if (isClosed) return;
       emit(
         state.copyWith(
           status: SettingsAccountStatus.loaded,
@@ -44,6 +47,7 @@ class SettingsAccountCubit extends Cubit<SettingsAccountState> {
       );
     } catch (e, stackTrace) {
       addError(e, stackTrace);
+      if (isClosed) return;
       emit(state.copyWith(status: SettingsAccountStatus.failure));
     }
   }

--- a/mobile/lib/screens/profile_setup/widgets/profile_header_preview.dart
+++ b/mobile/lib/screens/profile_setup/widgets/profile_header_preview.dart
@@ -244,7 +244,10 @@ class _BannerEditButton extends ConsumerWidget {
       bytes: selection.bytes,
     );
 
-    if (cropped == null) return;
+    // Picking and cropping are full screens the user can sit in for minutes,
+    // and neither can be cancelled from here — by the time they return, the
+    // profile editor may already be torn down.
+    if (cropped == null || editorBloc.isClosed) return;
 
     editorBloc.add(
       ProfileBannerUploadRequested(

--- a/mobile/test/blocs/apps_directory/apps_directory_cubit_test.dart
+++ b/mobile/test/blocs/apps_directory/apps_directory_cubit_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -83,6 +85,41 @@ void main() {
       ],
       errors: () => [isA<Exception>()],
     );
+
+    group('closed mid-flight', () {
+      test(
+        'loadApps drops the result instead of emitting after close',
+        () async {
+          final fetch = Completer<List<NostrAppDirectoryEntry>>();
+          when(mockService.fetchApprovedApps).thenAnswer((_) => fetch.future);
+
+          final cubit = AppsDirectoryCubit(directoryService: mockService);
+          final loading = cubit.loadApps();
+          await cubit.close();
+          fetch.complete([_fixture()]);
+
+          await expectLater(loading, completes);
+          expect(cubit.state.status, AppsDirectoryStatus.loading);
+          expect(cubit.state.apps, isEmpty);
+        },
+      );
+
+      test(
+        'refreshApps drops a failure instead of emitting after close',
+        () async {
+          final fetch = Completer<List<NostrAppDirectoryEntry>>();
+          when(mockService.fetchApprovedApps).thenAnswer((_) => fetch.future);
+
+          final cubit = AppsDirectoryCubit(directoryService: mockService);
+          final refreshing = cubit.refreshApps();
+          await cubit.close();
+          fetch.completeError(Exception('network error'));
+
+          await expectLater(refreshing, completes);
+          expect(cubit.state.status, AppsDirectoryStatus.initial);
+        },
+      );
+    });
   });
 }
 

--- a/mobile/test/blocs/badges/badges_cubit_test.dart
+++ b/mobile/test/blocs/badges/badges_cubit_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:badge_repository/badge_repository.dart';
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -290,6 +292,64 @@ void main() {
         ),
       ],
     );
+
+    group('closed mid-flight', () {
+      test(
+        'load drops the dashboard instead of emitting after close',
+        () async {
+          final dashboardLoad = Completer<BadgeDashboardData>();
+          when(
+            repository.loadDashboard,
+          ).thenAnswer((_) => dashboardLoad.future);
+
+          final cubit = BadgesCubit(repository: repository);
+          final loading = cubit.load();
+          await cubit.close();
+          dashboardLoad.complete(dashboard);
+
+          await expectLater(loading, completes);
+          expect(cubit.state.status, BadgesStatus.loading);
+          expect(cubit.state.awarded, isEmpty);
+        },
+      );
+
+      test(
+        'acceptAward drops the reload instead of emitting after close',
+        () async {
+          final dashboardLoad = Completer<BadgeDashboardData>();
+          when(() => repository.acceptAward(any())).thenAnswer((_) async {});
+          when(
+            repository.loadDashboard,
+          ).thenAnswer((_) => dashboardLoad.future);
+
+          final cubit = BadgesCubit(repository: repository);
+          final accepting = cubit.acceptAward(awardedBadge);
+          await cubit.close();
+          dashboardLoad.complete(dashboard);
+
+          await expectLater(accepting, completes);
+          expect(cubit.state.actionStatus, BadgeActionStatus.accepting);
+        },
+      );
+
+      test(
+        'acceptAward drops a failure instead of emitting after close',
+        () async {
+          final publish = Completer<void>();
+          when(
+            () => repository.acceptAward(any()),
+          ).thenAnswer((_) => publish.future);
+
+          final cubit = BadgesCubit(repository: repository);
+          final accepting = cubit.acceptAward(awardedBadge);
+          await cubit.close();
+          publish.completeError(Exception('relay rejected'));
+
+          await expectLater(accepting, completes);
+          expect(cubit.state.actionStatus, BadgeActionStatus.accepting);
+        },
+      );
+    });
   });
 }
 

--- a/mobile/test/blocs/my_following/my_following_bloc_test.dart
+++ b/mobile/test/blocs/my_following/my_following_bloc_test.dart
@@ -92,11 +92,9 @@ void main() {
         // handler runs after the event controller is already closed.
         await bloc.close();
 
-        // Subscribing here would outlive close() entirely, and its first
-        // delivery would dispatch into a closed event controller.
+        // A subscription created here is never cancelled — `close()` already
+        // ran past its cancel — so it would outlive the bloc.
         expect(followingStream.hasListener, isFalse);
-        expect(() => followingStream.add(const []), returnsNormally);
-        await Future<void>.delayed(Duration.zero);
       });
 
       test('drops a repository emission that lands while closing', () async {

--- a/mobile/test/blocs/my_following/my_following_bloc_test.dart
+++ b/mobile/test/blocs/my_following/my_following_bloc_test.dart
@@ -97,17 +97,18 @@ void main() {
         expect(followingStream.hasListener, isFalse);
       });
 
-      test('drops a repository emission that lands while closing', () async {
+      test('cancels the subscription even when close is not awaited', () async {
         final bloc = createBloc();
         bloc.add(const MyFollowingListLoadRequested());
         await Future<void>.delayed(Duration.zero);
         expect(followingStream.hasListener, isTrue);
 
+        // The cancel is issued before `super.close()`, so the listener is
+        // already gone by the time close() yields — nothing can be delivered
+        // into the drain.
         final closing = bloc.close();
-        followingStream.add([validPubkey('late')]);
-        await closing;
-
         expect(followingStream.hasListener, isFalse);
+        await closing;
       });
     });
 

--- a/mobile/test/blocs/my_following/my_following_bloc_test.dart
+++ b/mobile/test/blocs/my_following/my_following_bloc_test.dart
@@ -68,6 +68,51 @@ void main() {
       bloc.close();
     });
 
+    group('closed mid-dispatch', () {
+      late StreamController<List<String>> followingStream;
+
+      setUp(() {
+        followingStream = StreamController<List<String>>.broadcast();
+        when(
+          () => mockFollowRepository.followingStream,
+        ).thenAnswer((_) => followingStream.stream);
+        when(() => mockFollowRepository.watchMyFollowingCached()).thenAnswer(
+          (_) => const Stream<CacheResult<FollowingSnapshot>>.empty(),
+        );
+      });
+
+      tearDown(() async {
+        await followingStream.close();
+      });
+
+      test('does not subscribe when the load drains during close', () async {
+        final bloc = createBloc();
+        bloc.add(const MyFollowingListLoadRequested());
+        // No await in between: `close()` drains the queued load, so the
+        // handler runs after the event controller is already closed.
+        await bloc.close();
+
+        // Subscribing here would outlive close() entirely, and its first
+        // delivery would dispatch into a closed event controller.
+        expect(followingStream.hasListener, isFalse);
+        expect(() => followingStream.add(const []), returnsNormally);
+        await Future<void>.delayed(Duration.zero);
+      });
+
+      test('drops a repository emission that lands while closing', () async {
+        final bloc = createBloc();
+        bloc.add(const MyFollowingListLoadRequested());
+        await Future<void>.delayed(Duration.zero);
+        expect(followingStream.hasListener, isTrue);
+
+        final closing = bloc.close();
+        followingStream.add([validPubkey('late')]);
+        await closing;
+
+        expect(followingStream.hasListener, isFalse);
+      });
+    });
+
     group('MyFollowingListLoadRequested', () {
       blocTest<MyFollowingBloc, MyFollowingState>(
         'emits success with pubkeys from stream',

--- a/mobile/test/blocs/profile_liked_videos/profile_liked_videos_bloc_test.dart
+++ b/mobile/test/blocs/profile_liked_videos/profile_liked_videos_bloc_test.dart
@@ -1184,9 +1184,11 @@ void main() {
       blocTest<ProfileLikedVideosBloc, ProfileLikedVideosState>(
         'drops a synchronous liked-ids replay when closed mid-dispatch',
         setUp: () {
-          // The repository stream replays synchronously on listen (rxdart's
-          // startWith does this), so `emit.forEach`'s callback runs inside the
-          // handler itself — which `close()` still drains.
+          // The real stream is a BehaviorSubject replay, so a late listener
+          // is answered with the last value straight away. Delivering that
+          // synchronously here pins the callback inside the window between
+          // `close()` closing the event controller and cancelling this
+          // emitter — which is where production crashed.
           when(() => mockLikesRepository.watchLikedEventIds()).thenAnswer(
             (_) => Stream<List<String>>.multi(
               (controller) => controller.addSync(const ['event2', 'event1']),

--- a/mobile/test/blocs/profile_liked_videos/profile_liked_videos_bloc_test.dart
+++ b/mobile/test/blocs/profile_liked_videos/profile_liked_videos_bloc_test.dart
@@ -1180,6 +1180,33 @@ void main() {
         // After closing, stream events should not cause errors
         expect(() => likedIdsController.add(['event1']), returnsNormally);
       });
+
+      blocTest<ProfileLikedVideosBloc, ProfileLikedVideosState>(
+        'drops a synchronous liked-ids replay when closed mid-dispatch',
+        setUp: () {
+          // The repository stream replays synchronously on listen (rxdart's
+          // startWith does this), so `emit.forEach`'s callback runs inside the
+          // handler itself — which `close()` still drains.
+          when(() => mockLikesRepository.watchLikedEventIds()).thenAnswer(
+            (_) => Stream<List<String>>.multi(
+              (controller) => controller.addSync(const ['event2', 'event1']),
+            ),
+          );
+        },
+        build: createBloc,
+        seed: () => ProfileLikedVideosState(
+          status: ProfileLikedVideosStatus.success,
+          likedEventIds: const ['event1'],
+          videos: [createTestVideo('event1')],
+        ),
+        act: (bloc) async {
+          bloc.add(const ProfileLikedVideosSubscriptionRequested());
+          // No await in between: the handler is still queued, so `close()`
+          // drains it and the reconcile dispatch lands on a closed bloc.
+          await bloc.close();
+        },
+        errors: () => <Object>[],
+      );
     });
 
     group('Other user profile (targetUserPubkey)', () {

--- a/mobile/test/blocs/safety_settings/safety_settings_cubit_test.dart
+++ b/mobile/test/blocs/safety_settings/safety_settings_cubit_test.dart
@@ -439,5 +439,60 @@ void main() {
         ),
       ],
     );
+
+    group('closed mid-flight', () {
+      test('setPeopleIFollowEnabled drops a rollback after close', () async {
+        final toggle = Completer<void>();
+        when(
+          () => moderationLabelService.setFollowingModerationEnabled(
+            any(),
+            followedPubkeys: any(named: 'followedPubkeys'),
+          ),
+        ).thenAnswer((_) => toggle.future);
+
+        final cubit = buildCubit();
+        final toggling = cubit.setPeopleIFollowEnabled(true);
+        await cubit.close();
+        toggle.completeError(Exception('relay fan-out failed'));
+
+        await expectLater(toggling, completes);
+        // The optimistic emit landed before close; the rollback is dropped.
+        expect(cubit.state.isPeopleIFollowEnabled, isTrue);
+      });
+
+      test('unblockUser drops its refresh after close', () async {
+        final unblock = Completer<void>();
+        when(
+          () => blocklistRepository.unblockUser(any()),
+        ).thenAnswer((_) => unblock.future);
+
+        final cubit = buildCubit();
+        final unblocking = cubit.unblockUser('blocked_pubkey');
+        await cubit.close();
+        unblock.complete();
+
+        await expectLater(unblocking, completes);
+      });
+
+      test(
+        'load does not subscribe to the blocklist stream after close',
+        () async {
+          final ensureLoaded = Completer<void>();
+          when(
+            () => moderationLabelService.ensureLoaded(),
+          ).thenAnswer((_) => ensureLoaded.future);
+
+          final cubit = buildCubit();
+          final loading = cubit.load();
+          await cubit.close();
+          ensureLoaded.complete();
+
+          await expectLater(loading, completes);
+          // A subscription created here would outlive close() entirely, since
+          // close() already ran past its cancel.
+          expect(blocklistStream.hasListener, isFalse);
+        },
+      );
+    });
   });
 }

--- a/mobile/test/blocs/safety_settings/safety_settings_cubit_test.dart
+++ b/mobile/test/blocs/safety_settings/safety_settings_cubit_test.dart
@@ -493,6 +493,28 @@ void main() {
           expect(blocklistStream.hasListener, isFalse);
         },
       );
+
+      test('load does not subscribe when it resumes inside close', () async {
+        final ensureLoaded = Completer<void>();
+        when(
+          () => moderationLabelService.ensureLoaded(),
+        ).thenAnswer((_) => ensureLoaded.future);
+
+        final cubit = buildCubit();
+        final loading = cubit.load();
+
+        // The service resolves on the same turn the user leaves the screen,
+        // so load()'s resume is queued ahead of close()'s continuation.
+        // Awaiting the cancel before super.close() yielded a microtask there,
+        // and load() ran in it with isClosed still false — subscribing past
+        // the cancel and leaking both the cubit and the subscription.
+        ensureLoaded.complete();
+        final closing = cubit.close();
+        await closing;
+
+        await expectLater(loading, completes);
+        expect(blocklistStream.hasListener, isFalse);
+      });
     });
   });
 }

--- a/mobile/test/blocs/sandbox_route/sandbox_route_cubit_test.dart
+++ b/mobile/test/blocs/sandbox_route/sandbox_route_cubit_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -128,6 +130,43 @@ void main() {
         verifyNever(mockService.fetchApprovedApps);
       },
     );
+
+    group('closed mid-flight', () {
+      test(
+        'load drops a resolved app instead of emitting after close',
+        () async {
+          final fetch = Completer<List<NostrAppDirectoryEntry>>();
+          when(mockService.fetchApprovedApps).thenAnswer((_) => fetch.future);
+
+          final cubit = SandboxRouteCubit(
+            appId: 'primal-app',
+            directoryService: mockService,
+          );
+          final loading = cubit.load();
+          await cubit.close();
+          fetch.complete([_fixture()]);
+
+          await expectLater(loading, completes);
+          expect(cubit.state, isA<SandboxRouteLoading>());
+        },
+      );
+
+      test('load drops a failure instead of emitting after close', () async {
+        final fetch = Completer<List<NostrAppDirectoryEntry>>();
+        when(mockService.fetchApprovedApps).thenAnswer((_) => fetch.future);
+
+        final cubit = SandboxRouteCubit(
+          appId: 'primal-app',
+          directoryService: mockService,
+        );
+        final loading = cubit.load();
+        await cubit.close();
+        fetch.completeError(Exception('network error'));
+
+        await expectLater(loading, completes);
+        expect(cubit.state, isA<SandboxRouteLoading>());
+      });
+    });
   });
 }
 

--- a/mobile/test/blocs/settings_account/settings_account_cubit_test.dart
+++ b/mobile/test/blocs/settings_account/settings_account_cubit_test.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Unit tests for SettingsAccountCubit
 // ABOUTME: Covers load, addNewAccount, and state helpers
 
+import 'dart:async';
+
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -210,6 +212,45 @@ void main() {
         expect(copied.accounts, equals(testAccounts));
         expect(copied.draftCount, equals(5));
         expect(copied.currentPubkey, equals('pubkey1'));
+      });
+    });
+
+    group('closed mid-flight', () {
+      SettingsAccountCubit createCubit() => SettingsAccountCubit(
+        authService: mockAuthService,
+        draftStorageService: mockDraftStorageService,
+        featureFlagService: mockFeatureFlagService,
+      );
+
+      test('load drops the accounts instead of emitting after close', () async {
+        final accountsRead = Completer<List<KnownAccount>>();
+        when(
+          () => mockAuthService.getKnownAccounts(),
+        ).thenAnswer((_) => accountsRead.future);
+
+        final cubit = createCubit();
+        final loading = cubit.load();
+        await cubit.close();
+        accountsRead.complete(testAccounts);
+
+        await expectLater(loading, completes);
+        expect(cubit.state.status, SettingsAccountStatus.loading);
+        expect(cubit.state.accounts, isEmpty);
+      });
+
+      test('load drops a failure instead of emitting after close', () async {
+        final accountsRead = Completer<List<KnownAccount>>();
+        when(
+          () => mockAuthService.getKnownAccounts(),
+        ).thenAnswer((_) => accountsRead.future);
+
+        final cubit = createCubit();
+        final loading = cubit.load();
+        await cubit.close();
+        accountsRead.completeError(Exception('keystore unavailable'));
+
+        await expectLater(loading, completes);
+        expect(cubit.state.status, SettingsAccountStatus.loading);
       });
     });
   });

--- a/mobile/test/screens/profile_setup/profile_header_preview_test.dart
+++ b/mobile/test/screens/profile_setup/profile_header_preview_test.dart
@@ -63,6 +63,7 @@ void main() {
       when(() => mockAuthService.currentPublicKeyHex).thenReturn(testPubkeyHex);
       bloc = _MockProfileEditorBloc();
       when(() => bloc.state).thenReturn(const ProfileEditorState());
+      when(() => bloc.isClosed).thenReturn(false);
       nameController = TextEditingController();
       tempDir = await Directory.systemTemp.createTemp('header_preview_test');
     });
@@ -150,6 +151,22 @@ void main() {
       expect(launcher.callCount, 0);
       verifyNever(() => bloc.add(any()));
       expect(find.text(l10n.profileSetupImageSelectionFailed), findsOneWidget);
+    });
+
+    testWidgets('drops the upload when the editor closed during the crop', (
+      tester,
+    ) async {
+      // Picking and cropping are full screens; leaving the profile editor
+      // while they are open closes the bloc before the crop returns.
+      stubPickedFile([9, 9, 9]);
+      final launcher = _FakeCropLauncher(Uint8List.fromList([1, 2, 3, 4]));
+      await pump(tester, launcher.launch);
+      when(() => bloc.isClosed).thenReturn(true);
+
+      await pickBannerFromGallery(tester);
+
+      expect(launcher.callCount, 1);
+      verifyNever(() => bloc.add(any()));
     });
   });
 }


### PR DESCRIPTION
## Description

Two Crashlytics issues report use of a closed bloc: `Bad state: Cannot add new events after calling close` and `Bad state: Cannot emit new states after calling close`. Both are **aggregates**, not single call sites — 8 and 12 variants respectively, grouped by the shared bloc-internal blame frame. Pulling every variant's sample event gave 7 distinct app frames for `add` and 11 distinct cubits for `emit`; **nine of those were already fixed on `main`**, eight were not. This addresses the eight.

**Root cause.** `Bloc` overrides `isClosed` as `_eventController.isClosed || super.isClosed`, and `close()` documents that it "will finish processing the pending events". So `close()` flips `isClosed` immediately and *then* drains the queue — those handlers run to completion against a closed event controller, and any `add()` they make throws. For cubits the shape is simpler: an uncancellable awaited future resolving after close.

**Teardown fix — `MyFollowingBloc` and `SafetySettingsCubit`.** Awaiting the cancel before `super.close()` was itself the defect, and not for the obvious reason: `await _followingSubscription?.cancel()` on a *null* subscription is `await null`, which still yields a microtask. An already queued handler runs in that window with `isClosed` still `false`, subscribes, and is then orphaned by the cancel that already ran.

Both now use one conventional shape — issue the cancel, do not await it ahead of `super.close()`, await the captured future after:

```dart
final cancelled = _subscription?.cancel();
_subscription = null;
await super.close();
await cancelled;
```

This keeps the ordering reviewers expect, closes the microtask window, and issues the cancel before `super.close()` can yield or fail.

`SafetySettingsCubit` had the identical window and was not in the original diff's teardown scope: a `load()` parked on `ensureLoaded` resumed inside the cancel await, saw `isClosed` as false, and subscribed past the cancel — leaking the cubit and its subscription. It never crashed, because the listener's own guard stopped the emit, which is why it produced no Crashlytics signature. Its regression test has to queue `load()`'s resume *ahead* of `close()`'s continuation; completing the service after `close()` lets `super.close()` win the microtask race and the leak does not reproduce.

An earlier revision of this PR used a non-idiomatic `super.close()`-first ordering instead, and applied it to `ProfileLikedVideosBloc` too. Both are gone. The first self-check appeared to validate that ordering for both blocs — but the experiment patched awaited cancels into `ProfileLikedVideosBloc`, which `main` never had, so it tested a shape that only existed in the patch. `main` cancels there without awaiting, so `isClosed` already flipped in the same synchronous block and there was no window to close. The load-bearing fix in that bloc is the `isClosed` guard in the `emit.forEach` callback: removing it, with `main`'s `close()` restored, reproduces `Bad state: Cannot add new events after calling close`.

**Guards** — the remaining sites are genuinely uncancellable in-flight futures, where the issue's own guidance says a guard is the right shape: `settings_account`, `apps_directory`, `sandbox_route`, `badges`, `safety_settings`, and `profile_header_preview._pickBannerImage` (the crop is a full screen the user can leave).

**Related Issue:** Closes #7293

**Follow-up prevention work:** #7370 tracks the shared guard/sweep/static-check work that is intentionally out of scope for this targeted Crashlytics fix.

## Out of Scope

- **Two `emit` sample events are mis-bucketed.** Events `5dc218f3…` and `78616ea7…` carry `flutter_error_exception` keys that contradict the issue title — `withResource() may not be called on a closed Pool` and `Null check operator used on a null value`. Crashlytics grouped them by the shared `BlocBase.emit` blame frame. Separate bugs; not addressed here.
- The nine sites already fixed on `main` are untouched, and I deliberately did not sweep the repo for the same pattern beyond what the traces named. The recurrence-prevention sweep is tracked in #7370.
- The `isClosed` guards inside the two stream listeners are no longer pinned by a test that requires delivery after `close()` has already issued the subscription cancel. With the cancel issued before `super.close()`, the subscription is already detached during the drain for the current broadcast-stream tests. They are kept as defence — `cancel()` detaches synchronously for a broadcast controller, but that is not guaranteed for every stream implementation — and #7370 tracks the broader guard-pattern cleanup.

## Verification

17 tests added across the affected bloc/cubit/widget paths. The tests cover the uncancellable-future cases, queued bloc work that drains during `close()`, and teardown ordering for `MyFollowingBloc` and `SafetySettingsCubit`.

Self-review checked the failure mode against `origin/main` and the intermediate teardown revisions. The key can-it-fail coverage is:

- `ProfileLikedVideosBloc` → `drops a synchronous liked-ids replay when closed mid-dispatch`: fails without the `isClosed` guard in the `emit.forEach` callback because the reconcile dispatch lands on a closed bloc.
- `MyFollowingBloc` → `does not subscribe when the load drains during close`: fails against the old awaited-cancel-before-`super.close()` ordering because the queued load can subscribe after close already ran past its cancel.
- `SafetySettingsCubit` → `load does not subscribe when it resumes inside close`: fails against the old awaited-cancel-before-`super.close()` ordering because `load()` can resume in that microtask and create an orphaned subscription.
- `MyFollowingBloc` → `cancels the subscription even when close is not awaited`: already passes on `main` because the subscription cancel is issued synchronously, but fails against the reverted bad teardown ordering and pins the intended close contract.

Self-review also deleted a tautological assertion (a broadcast controller's `add` cannot throw synchronously, so it asserted nothing) and corrected two comments claiming the repository stream replays synchronously on listen — measured, it arrives in a microtask, and the real reason for the guard is the orphaned subscription.

- `flutter test test/blocs/` — 3284/3284
- the 20 test files referencing the changed classes — 497/497
- `flutter test` on the 8 screen/widget files — 124/124
- the three teardown test files × 10 with `--test-randomize-ordering-seed random` — 10/10 (99 tests each run)
- `flutter analyze lib test` — `No issues found!`
- `dart format --set-exit-if-changed` on all 16 changed files — clean

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
