### PR TITLE
fix(avatar): match the SVG guard to the parser it protects

### DIFF
--- a/mobile/lib/repositories/avatar_svg_repository.dart
+++ b/mobile/lib/repositories/avatar_svg_repository.dart
@@ -8,6 +8,7 @@ import 'dart:typed_data';
 import 'package:http/http.dart' as http;
 import 'package:unified_logger/unified_logger.dart';
 import 'package:xml/xml.dart';
+import 'package:xml/xml_events.dart';
 
 abstract class AvatarSvgRepository {
   /// Loads and validates a remote avatar SVG.
@@ -109,7 +110,7 @@ class HttpAvatarSvgRepository implements AvatarSvgRepository {
       return null;
     }
 
-    if (!_isWellFormedSvg(bytes)) {
+    if (!_parsesAsSvg(bytes)) {
       _logRejected(uri, contentType, 'malformed-svg');
       return null;
     }
@@ -176,10 +177,35 @@ class HttpAvatarSvgRepository implements AvatarSvgRepository {
   bool _isAsciiWhitespace(int byte) =>
       byte == 0x09 || byte == 0x0A || byte == 0x0D || byte == 0x20;
 
-  bool _isWellFormedSvg(Uint8List bytes) {
-    final source = utf8.decode(bytes, allowMalformed: false);
-    final document = XmlDocument.parse(source);
-    return document.rootElement.name.local.toLowerCase() == 'svg';
+  /// Whether [bytes] survive the exact XML pass `flutter_svg` performs, with
+  /// `svg` as the root element.
+  ///
+  /// This mirrors the consumer deliberately: `SvgBytesLoader.provideSvg`
+  /// decodes with `allowMalformed: true`, and `SvgParser` tokenizes with
+  /// `parseEvents` and no nesting or document validation. A stricter check
+  /// rejects avatars flutter_svg renders fine; a laxer one lets a parse
+  /// failure reach flutter_svg, where the call site can no longer catch it —
+  /// `Cache.putIfAbsent` hangs a success-only `then` on the decode future and
+  /// drops the derived future, so the failure also surfaces as an unhandled
+  /// zone error and a Crashlytics non-fatal, even though `errorBuilder`
+  /// already renders the placeholder (#7296).
+  ///
+  /// [parseEvents] is lazy, so the events have to be drained here. Stopping at
+  /// the root element would report malformed markup further down the document
+  /// as valid and hand the failure back to flutter_svg.
+  bool _parsesAsSvg(Uint8List bytes) {
+    final source = utf8.decode(bytes, allowMalformed: true);
+    String? rootName;
+    try {
+      for (final event in parseEvents(source)) {
+        if (rootName == null && event is XmlStartElementEvent) {
+          rootName = event.localName;
+        }
+      }
+    } on XmlException {
+      return false;
+    }
+    return rootName?.toLowerCase() == 'svg';
   }
 
   _AvatarSvgCacheEntry? _readCache(String url) {

--- a/mobile/lib/repositories/avatar_svg_repository.dart
+++ b/mobile/lib/repositories/avatar_svg_repository.dart
@@ -193,13 +193,25 @@ class HttpAvatarSvgRepository implements AvatarSvgRepository {
   /// [parseEvents] is lazy, so the events have to be drained here. Stopping at
   /// the root element would report malformed markup further down the document
   /// as valid and hand the failure back to flutter_svg.
+  ///
+  /// The open-element stack mirrors `SvgParser.endElement`, which reads
+  /// `_parentDrawables.last` with no empty check: an end element outside the
+  /// root throws `StateError: No element` there. Popping only on a name match
+  /// is what makes this the consumer's rule rather than a nesting check —
+  /// `<svg><g></g></g></svg>` keeps a non-empty stack and stays accepted,
+  /// because flutter_svg does not pop on a mismatch either.
   bool _parsesAsSvg(Uint8List bytes) {
     final source = utf8.decode(bytes, allowMalformed: true);
+    final openElements = <String>[];
     String? rootName;
     try {
       for (final event in parseEvents(source)) {
-        if (rootName == null && event is XmlStartElementEvent) {
-          rootName = event.localName;
+        if (event is XmlStartElementEvent) {
+          rootName ??= event.localName;
+          if (!event.isSelfClosing) openElements.add(event.name);
+        } else if (event is XmlEndElementEvent) {
+          if (openElements.isEmpty) return false;
+          if (openElements.last == event.name) openElements.removeLast();
         }
       }
     } on XmlException {

--- a/mobile/lib/repositories/avatar_svg_repository.dart
+++ b/mobile/lib/repositories/avatar_svg_repository.dart
@@ -209,6 +209,11 @@ class HttpAvatarSvgRepository implements AvatarSvgRepository {
   /// working, since its own end tag must not be mistaken for the root's.
   /// Unbalanced markup *inside* the root stays accepted: it trips only a debug
   /// `assert` in the compiler and renders in release.
+  ///
+  /// The rule is one-directional, though: `endElement` pops only on a name
+  /// match, so an `</svg>` arriving while a group is open never empties
+  /// `_parentDrawables`. `<svg><g><rect/></svg></g>` renders there and is
+  /// rejected here — the price of not coupling to the push set.
   bool _parsesAsSvg(Uint8List bytes) {
     final source = utf8.decode(bytes, allowMalformed: true);
     String? rootName;

--- a/mobile/lib/repositories/avatar_svg_repository.dart
+++ b/mobile/lib/repositories/avatar_svg_repository.dart
@@ -194,31 +194,46 @@ class HttpAvatarSvgRepository implements AvatarSvgRepository {
   /// the root element would report malformed markup further down the document
   /// as valid and hand the failure back to flutter_svg.
   ///
-  /// The open-element stack mirrors `SvgParser.endElement`, which reads
-  /// `_parentDrawables.last` with no empty check: an end element outside the
-  /// root throws `StateError: No element` there. Popping only on a name match
-  /// is what makes this the consumer's rule rather than a nesting check —
-  /// `<svg><g></g></g></svg>` keeps a non-empty stack and stays accepted,
-  /// because flutter_svg does not pop on a mismatch either.
+  /// Beyond tokenizing, this enforces one document-level rule: no end element
+  /// may sit outside the root. `SvgParser.endElement` reads
+  /// `_parentDrawables.last` with no empty check, so such an element throws
+  /// `StateError: No element` there.
+  ///
+  /// The rule is expressed over the document rather than over flutter_svg's
+  /// own stack on purpose. Mirroring that stack would mean mirroring its push
+  /// rule too — only `addGroup` pushes, so a `rect` left open desynchronises
+  /// the two — and the push set is `vector_graphics_compiler` internals that a
+  /// version bump can move underneath us.
+  ///
+  /// Tracking the root by `svg` nesting depth is what keeps a nested `<svg>`
+  /// working, since its own end tag must not be mistaken for the root's.
+  /// Unbalanced markup *inside* the root stays accepted: it trips only a debug
+  /// `assert` in the compiler and renders in release.
   bool _parsesAsSvg(Uint8List bytes) {
     final source = utf8.decode(bytes, allowMalformed: true);
-    final openElements = <String>[];
     String? rootName;
+    var svgDepth = 0;
+    var rootClosed = false;
     try {
       for (final event in parseEvents(source)) {
         if (event is XmlStartElementEvent) {
           rootName ??= event.localName;
-          if (!event.isSelfClosing) openElements.add(event.name);
+          if (_isSvgTag(event.localName) && !event.isSelfClosing) svgDepth++;
         } else if (event is XmlEndElementEvent) {
-          if (openElements.isEmpty) return false;
-          if (openElements.last == event.name) openElements.removeLast();
+          if (rootName == null || rootClosed) return false;
+          if (_isSvgTag(event.localName)) {
+            svgDepth--;
+            if (svgDepth <= 0) rootClosed = true;
+          }
         }
       }
     } on XmlException {
       return false;
     }
-    return rootName?.toLowerCase() == 'svg';
+    return rootName != null && _isSvgTag(rootName);
   }
+
+  bool _isSvgTag(String localName) => localName.toLowerCase() == 'svg';
 
   _AvatarSvgCacheEntry? _readCache(String url) {
     final cached = _cache.remove(url);

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -2762,7 +2762,7 @@ packages:
     source: hosted
     version: "1.1.0"
   xml:
-    dependency: "direct dev"
+    dependency: "direct main"
     description:
       name: xml
       sha256: "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025"

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -195,6 +195,9 @@ dependencies:
   share_plus: ^12.0.0 # Cross-platform sharing
   google_fonts: ^6.3.2 # For using Google Fonts including Pacifico
   flutter_svg: ^2.0.10+1 # For custom SVG icons
+  # Pre-flights remote SVG avatars through the same tokenizer flutter_svg uses
+  # before handing bytes to SvgPicture (see AvatarSvgRepository, #7296).
+  xml: ^6.5.0
   skeletonizer: ^2.1.2 # Skeleton loading animations with shimmer effect
 
   # Blurhash Service - Blurhash generation and decoding for image placeholders
@@ -387,7 +390,6 @@ dev_dependencies:
   fake_async: ^1.3.3
   mocktail: ^1.0.3
   bloc_test: ^10.0.0
-  xml: ^6.5.0
 
   # Code generation
   build_runner: ^2.15.0

--- a/mobile/test/repositories/avatar_svg_repository_test.dart
+++ b/mobile/test/repositories/avatar_svg_repository_test.dart
@@ -180,6 +180,23 @@ void main() {
     await expectLater(repository.load(url), completion(unbalanced));
   });
 
+  test('rejects mismatched nesting whose root end tag comes first', () {
+    // Deliberately stricter than the consumer: `endElement` pops only on a
+    // name match, so `</svg>` with a `<g>` still open never empties
+    // `_parentDrawables` and this renders. Accepting it back would take
+    // mirroring the compiler's push set, which is what the document rule
+    // exists to avoid.
+    final repository = repositoryFor(
+      http.Response(
+        '$svgOpenTag<g><rect/></svg></g>',
+        200,
+        headers: {'content-type': 'image/svg+xml'},
+      ),
+    );
+
+    expect(repository.load(url), completion(isNull));
+  });
+
   test('rejects well-formed XML whose root element is not svg', () {
     final repository = repositoryFor(
       http.Response(

--- a/mobile/test/repositories/avatar_svg_repository_test.dart
+++ b/mobile/test/repositories/avatar_svg_repository_test.dart
@@ -76,6 +76,72 @@ void main() {
     expect(repository.load(url), completion(isNull));
   });
 
+  test('rejects markup that only breaks after the root element', () {
+    // Crashlytics b97ccc46 shape: a well-formed <svg> root on line 1 and an
+    // unterminated tag deep into line 2. A validator that stops once it has
+    // seen the root element accepts this and hands the parse failure to
+    // flutter_svg, where it escapes as an unhandled zone error (#7296).
+    final repository = repositoryFor(
+      http.Response(
+        '<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10">\n'
+        '<path d="M0 0 L1 1" ${'a' * 140} <circle r="1"/>\n'
+        '</svg>',
+        200,
+        headers: {'content-type': 'image/svg+xml'},
+      ),
+    );
+
+    expect(repository.load(url), completion(isNull));
+  });
+
+  test('rejects well-formed XML whose root element is not svg', () {
+    final repository = repositoryFor(
+      http.Response(
+        '<html><body>not an svg</body></html>',
+        200,
+        headers: {'content-type': 'image/svg+xml'},
+      ),
+    );
+
+    expect(repository.load(url), completion(isNull));
+  });
+
+  test('accepts SVG payloads carrying non-UTF-8 bytes', () async {
+    // flutter_svg decodes with `allowMalformed: true`, so a stray Latin-1 byte
+    // renders fine. Rejecting it here would blank an avatar that works.
+    final latin1InText = Uint8List.fromList([
+      ...utf8.encode('<svg xmlns="http://www.w3.org/2000/svg"><text>caf'),
+      0xE9,
+      ...utf8.encode('</text></svg>'),
+    ]);
+    final repository = repositoryFor(
+      http.Response.bytes(
+        latin1InText,
+        200,
+        headers: {'content-type': 'image/svg+xml'},
+      ),
+    );
+
+    await expectLater(repository.load(url), completion(latin1InText));
+  });
+
+  test('accepts mismatched nesting that flutter_svg tolerates', () async {
+    // `SvgParser` calls `parseEvents` without nesting validation, so sloppy
+    // generator output still renders. Only tokenizer failures may be rejected.
+    final mismatched = Uint8List.fromList(
+      utf8.encode('<svg xmlns="http://www.w3.org/2000/svg"><g><rect/></svg>'),
+    );
+    final repository = repositoryFor(
+      http.Response.bytes(
+        mismatched,
+        200,
+        headers: {'content-type': 'image/svg+xml'},
+      ),
+    );
+
+    await expectLater(repository.load(url), completion(mismatched));
+  });
+
   test('rejects non-200 responses', () {
     final repository = repositoryFor(
       http.Response(

--- a/mobile/test/repositories/avatar_svg_repository_test.dart
+++ b/mobile/test/repositories/avatar_svg_repository_test.dart
@@ -128,6 +128,40 @@ void main() {
     expect(repository.load(url), completion(isNull));
   });
 
+  test('rejects an end element after the root with a shape left open', () {
+    // A `rect` is a shape, not a group, so flutter_svg never pushes it onto
+    // `_parentDrawables`. Any guard that mirrors that stack instead of the
+    // document desynchronises here and lets the payload through.
+    final repository = repositoryFor(
+      http.Response(
+        '$svgOpenTag<rect width="4" height="4"></svg></rect>',
+        200,
+        headers: {'content-type': 'image/svg+xml'},
+      ),
+    );
+
+    expect(repository.load(url), completion(isNull));
+  });
+
+  test('accepts a nested svg element', () async {
+    // `SvgParser` supports a nested `<svg>` and pushes its own group for it,
+    // so the inner end tag must not be read as the root closing.
+    final nested = Uint8List.fromList(
+      utf8.encode(
+        '$svgOpenTag$svgOpenTag<rect width="4" height="4"/></svg></svg>',
+      ),
+    );
+    final repository = repositoryFor(
+      http.Response.bytes(
+        nested,
+        200,
+        headers: {'content-type': 'image/svg+xml'},
+      ),
+    );
+
+    await expectLater(repository.load(url), completion(nested));
+  });
+
   test('accepts an unbalanced end element inside the root', () async {
     // Only trips a debug `assert` in `vector_graphics_compiler`, and
     // flutter_svg never pops on a name mismatch, so the drawable stack cannot

--- a/mobile/test/repositories/avatar_svg_repository_test.dart
+++ b/mobile/test/repositories/avatar_svg_repository_test.dart
@@ -9,6 +9,11 @@ import 'package:openvine/repositories/avatar_svg_repository.dart';
 
 void main() {
   const url = 'https://divine.video/avatar.svg';
+  // flutter_svg needs a viewport on the root element. Fixtures that assert
+  // "flutter_svg renders this" have to carry one, or they fail for an
+  // unrelated reason and the comparison stops meaning anything.
+  const svgOpenTag =
+      '<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10">';
   final validSvgBytes = Uint8List.fromList(
     utf8.encode(
       '<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1" />',
@@ -110,7 +115,7 @@ void main() {
     // flutter_svg decodes with `allowMalformed: true`, so a stray Latin-1 byte
     // renders fine. Rejecting it here would blank an avatar that works.
     final latin1InText = Uint8List.fromList([
-      ...utf8.encode('<svg xmlns="http://www.w3.org/2000/svg"><text>caf'),
+      ...utf8.encode('$svgOpenTag<text>caf'),
       0xE9,
       ...utf8.encode('</text></svg>'),
     ]);
@@ -129,7 +134,7 @@ void main() {
     // `SvgParser` calls `parseEvents` without nesting validation, so sloppy
     // generator output still renders. Only tokenizer failures may be rejected.
     final mismatched = Uint8List.fromList(
-      utf8.encode('<svg xmlns="http://www.w3.org/2000/svg"><g><rect/></svg>'),
+      utf8.encode('$svgOpenTag<g><rect/></svg>'),
     );
     final repository = repositoryFor(
       http.Response.bytes(

--- a/mobile/test/repositories/avatar_svg_repository_test.dart
+++ b/mobile/test/repositories/avatar_svg_repository_test.dart
@@ -99,6 +99,53 @@ void main() {
     expect(repository.load(url), completion(isNull));
   });
 
+  test('rejects an end element sitting after the root element', () {
+    // `SvgParser.endElement` reads `_parentDrawables.last` with no empty
+    // check, so an end element outside the root throws `StateError: No
+    // element` and escapes as the same orphaned future as a tokenizer
+    // failure. Tokenizing alone does not catch this — only the document
+    // structure does.
+    final repository = repositoryFor(
+      http.Response(
+        '$svgOpenTag<rect width="10" height="10"/></svg></foo>',
+        200,
+        headers: {'content-type': 'image/svg+xml'},
+      ),
+    );
+
+    expect(repository.load(url), completion(isNull));
+  });
+
+  test('rejects an end element sitting before the root element', () {
+    final repository = repositoryFor(
+      http.Response(
+        '</foo>$svgOpenTag<rect width="10" height="10"/></svg>',
+        200,
+        headers: {'content-type': 'image/svg+xml'},
+      ),
+    );
+
+    expect(repository.load(url), completion(isNull));
+  });
+
+  test('accepts an unbalanced end element inside the root', () async {
+    // Only trips a debug `assert` in `vector_graphics_compiler`, and
+    // flutter_svg never pops on a name mismatch, so the drawable stack cannot
+    // underflow here. Rejecting it would blank an avatar that renders.
+    final unbalanced = Uint8List.fromList(
+      utf8.encode('$svgOpenTag<g></g></g></svg>'),
+    );
+    final repository = repositoryFor(
+      http.Response.bytes(
+        unbalanced,
+        200,
+        headers: {'content-type': 'image/svg+xml'},
+      ),
+    );
+
+    await expectLater(repository.load(url), completion(unbalanced));
+  });
+
   test('rejects well-formed XML whose root element is not svg', () {
     final repository = repositoryFor(
       http.Response(


### PR DESCRIPTION
## Description

This started as #7296 (`XmlParserException` from malformed remote XML). That issue turned out to be a re-file of #6118 — same Crashlytics issue `b97ccc46` — which was already fixed before this PR, shipping in 1.0.19+. (The guard entered `main` in `8acb64a90c`, the squash commit for #6766, on 2026-08-07; #6706 is the PR that wrote it, but its own merge commit is not an ancestor of `main` — that squash carried the files along.) The residual events all come from pre-fix installs: the 20 most recent (2026-08-10 → 2026-08-13) are 18× 1.0.17 (813) and 2× 1.0.16 (804), none from 1.0.19/1.0.20. **#7296 is closed as a duplicate and this PR is not a crash fix.**

What verifying that turned up is the opposite defect. `AvatarSvgRepository` validated with `XmlDocument.parse` and a strict UTF-8 decode, but flutter_svg decodes with `allowMalformed: true` and tokenizes with `parseEvents` and no nesting or document validation. `XmlDocument.parse` is `parseEvents` plus both validations, i.e. a strict superset — so the guard never let a tokenizer failure through, but it **did** blank avatars that render fine:

| input | old guard | flutter_svg |
|---|---|---|
| Latin-1 byte in a `<text>` node | `FormatException` → avatar blanked | renders |
| `<svg><g><rect/></svg>` (mismatched nesting) | `XmlTagException` → avatar blanked | renders |

The guard now performs exactly flutter_svg's XML pass, which is also what keeps this class of bug from re-opening: a validator that disagrees with its consumer is wrong in one direction or the other.

"Exactly flutter_svg's XML pass" is more than the tokenizer, and the first revision of this PR got that wrong. `XmlDocument.parse` also enforced document structure, and dropping it let end elements outside the root through — `<svg…></svg></foo>`, `</foo><svg…></svg>`, `<svg…></svg>\n  </g>`. `SvgParser.endElement` reads `_parentDrawables.last` with no empty check, so all three reach flutter_svg as `StateError: No element`, i.e. the same orphaned-future path this PR exists to close, under a different signature. Caught in review by @realmeylisdev.

Two models were tried for that rule before the shipped one. Mirroring `endElement`'s own stack — push on a non-self-closing start, pop on a name match, reject on an empty stack — looks exact but only copies the *pop* rule. Only `addGroup` pushes `_parentDrawables`; `startElement` routes everything else into `addShape`, which pushes nothing. So an open `rect` sits on our stack and never on theirs, `</svg>` stops matching our top, and `<svg…><rect…></svg></rect>` passes while flutter_svg throws. Also caught in review by @realmeylisdev. A naive depth counter fails the same payload *and* additionally rejects `<svg><g></g></g></svg>`.

The guard therefore states the rule over the document instead: track the root by `svg` nesting depth, and reject any end element that appears before the root opens or after it closes. That is exactly `endElement`'s throw condition without copying the push set, which lives in `vector_graphics_compiler` internals a version bump can move. Nesting depth rather than the first `</svg>` is what keeps a nested `<svg>` — explicitly supported, pushes its own group at `parser.dart:80` — from reading as the root closing. Unbalanced markup *inside* the root stays accepted; see Out of Scope.

`parseEvents` is lazy, so the events are drained here — and this is a real trap, not a hypothetical: undrained, `parseEvents` returns OK for every malformed input above. Stopping at the root element would report markup that breaks further down as valid and hand the failure back to flutter_svg, where the call site can no longer catch it. flutter_svg's `Cache.putIfAbsent` hangs a success-only `.then` on the decode future and drops the derived future (and `vector_graphics._loadPicture` does the same with `whenComplete`), so such a failure surfaces as an unhandled zone error and a Crashlytics non-fatal even though `errorBuilder` already renders the placeholder correctly.

Two smaller things in the same area: rejection now returns `false` instead of throwing, so the `malformed-svg` log line actually fires — previously the throw was swallowed by a generic catch upstream. And `xml` was declared under `dev_dependencies` while `lib/` imported it.

**Related Issue:** Relates to #7296 (closed as duplicate of #6118)

## Out of Scope

- **This does not close the whole leak surface.** The guard covers flutter_svg's XML pass — the tokenizer plus the document-level structure `endElement` depends on. A well-formed `<svg>` can still throw later inside `SvgParser` (e.g. `StateError('Invalid SVG data')`), producing the same orphaned future under a different Crashlytics signature. Closing that fully would mean running `encodeSvg` twice or vendoring flutter_svg internals; both judged worse than the noise.
- **Unbalanced markup *inside* the root is accepted deliberately**, e.g. `<svg><g></g></g></svg>`. It trips `assert(depth >= 0)` in `vector_graphics_compiler`'s `_readSubtree` in debug, but asserts are stripped in release and the drawable stack never underflows, so it renders where users are. Rejecting it would blank an avatar that works — the exact false-negative class this PR removes.
- **A second top-level element is rejected**, e.g. `<svg…></svg><foo></foo>`, which flutter_svg renders because the unknown subtree is discarded before `endElement` sees it. This is the one shape where the document rule is stricter than the consumer. Not a regression — `XmlDocument.parse` rejected multi-root documents too — and narrowing it would mean re-introducing knowledge of which elements the compiler discards.
- No flutter_svg bump. Neither 2.2.4 nor 2.3.0 would help: `lib/src/cache.dart` is byte-identical across 2.2.3, 2.2.4 and 2.3.0 (md5 `27e508023821ad3aadd30156d20a229c`), and the `vector_graphics` orphan would remain regardless.
- No suppression filter in `CrashReportingService` — that would hide genuine XML bugs.
- The offending URL could not be named: Crashlytics carries no custom key for it. The identical `2:175` position across all users points at a single document, most likely an HTML error page served from a `.svg` path.
- The root-element check accepts `<SVG>` and `<s:svg>`, which flutter_svg then rejects with `StateError: Invalid SVG data` — it keys its element parsers by the qualified, case-sensitive name. Pre-existing (the old guard also lowercased the local name), so tightening it is a behaviour change left out of this PR.
- ~140 KB of 20 000 nested `<g>` elements sits under the 256 KiB cap, passes the guard in 14 ms, and raises `StackOverflowError` in `vector_graphics_compiler`'s recursive visitor. Also pre-existing — the old guard accepted it too.

## Verification

9 tests added. Can-it-fail verified by mutating the implementation rather than by inspection, and each mutation kills a distinct set:

| mutation | tests that fail |
|---|---|
| old `XmlDocument.parse` body | both `accepts` tests |
| `break` after the root element | `rejects markup that only breaks after the root element`, plus the pre-existing `rejects malformed SVG before flutter_svg sees it` |
| drop the root check (`return rootName != null`) | `rejects well-formed XML whose root element is not svg` |
| drop the `rootClosed` rule | `rejects an end element sitting after the root element`, `rejects an end element after the root with a shape left open` |
| close the root on the first `</svg>` instead of at depth 0 | `accepts a nested svg element` |

The last two rows are the review fix, and the final one is why the root is tracked by nesting depth rather than by its first end tag.

The guard/consumer matrix was re-run against real `vg.encodeSvg` with flutter_svg's own flags after the change. The two middle columns are the models that were tried and rejected:

| payload | tokenizer only | `endElement` stack | naive counter | this guard | flutter_svg |
|---|---|---|---|---|---|
| `<svg…><rect…></svg></rect>` | accept | **accept** | **accept** | reject | `StateError` |
| `<svg…><rect…><circle r="1"></svg></rect></circle>` | accept | **accept** | **accept** | reject | `StateError` |
| `<svg…></svg></foo>` | accept | reject | reject | reject | `StateError` |
| `</foo><svg…></svg>` | accept | reject | reject | reject | `StateError` |
| `<svg…></svg>\n  </g>` | accept | reject | reject | reject | `StateError` |
| `<svg…><g><rect/></g></svg></g>` | accept | reject | reject | reject | `StateError` |
| `<s:svg…></s:svg></foo>` | accept | reject | reject | reject | `StateError` |
| `<svg…><svg…><rect/></svg></svg>` | accept | accept | accept | accept | renders |
| `<svg…><g></g></g></svg>` | accept | accept | **reject** | accept | debug `assert` only |
| `<svg…><g><rect/></svg>` | accept | accept | accept | accept | renders |
| unclosed root, comment/DOCTYPE preamble, trailing comment | accept | accept | accept | accept | renders |
| `<html><body></body></html>` | reject | reject | reject | reject | `StateError` |

Self-review also caught that both `accepts` fixtures lacked `width`/`height`, so flutter_svg would have thrown `StateError: SVG did not specify dimensions` on those exact bytes — the tests passed, but their "flutter_svg renders this" premise, which is the whole justification for relaxing the guard, was unproven. Both fixtures now carry a viewport, checked against the real `vg.encodeSvg` with flutter_svg's own flags.

Equivalence to flutter_svg's XML pass was confirmed by execution, not inspection: a probe ran each fixture through the old guard, the new guard, and real `vg.encodeSvg`, and the verdicts matched on every one — including comment/DOCTYPE/XML-declaration/BOM preambles, a billion-laughs payload (no entity expansion, 0 ms), and 256 KB of attributes (14 ms). `vector_graphics_compiler` pins `xml >=6.3.0 <=6.6.1`, so pub resolves a single `xml` and the guard runs the parser's own tokenizer.

- `flutter test` on `avatar_svg_repository_test` + `user_avatar_svg_test` + `avatar_svg_cubit_test` + `comprehensive_user_avatar_test` + `avatar_failure_cache_test` — 77/77
- `check_dependency_provenance.sh` — no new entries; `pubspec.lock` churn is exactly the one `direct dev` → `direct main` line, no version drift
- `flutter analyze lib test` — `No issues found!`
- `dart format --set-exit-if-changed` — clean
- All 443 bundled SVG assets parsed with both `parseEvents` and `XmlDocument.parse` — 0 failures, ruling out a corrupt bundled asset. Re-run against the document guard after the review fix — 0 rejections, so the added structure check costs no real asset.
- Not verified on a real device. The review's device run on a physical iPhone (iOS 26.6) covers the three payloads end to end: guard hands back the bytes, `SvgPicture.memory` hits `errorBuilder` with `Bad state: No element`, nothing paints.


## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)



