### PR TITLE
test(media-cache): pin the post-open write-failure orderings

### DIFF
--- a/mobile/packages/media_cache/test/src/cancellable_downloader_test.dart
+++ b/mobile/packages/media_cache/test/src/cancellable_downloader_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:collection';
 import 'dart:convert';
 import 'dart:io';
 
@@ -25,6 +26,23 @@ class _CallbackClient extends http.BaseClient {
     closed = true;
     super.close();
   }
+}
+
+/// A chunk whose element reads throw, so `RandomAccessFile.writeFrom` fails
+/// for it the way a full disk or an IO error would after a successful open.
+class _UnwritableChunk extends ListBase<int> {
+  @override
+  int get length => 32;
+
+  @override
+  set length(int value) => throw UnsupportedError('fixed length');
+
+  @override
+  int operator [](int index) => throw const FileSystemException('write failed');
+
+  @override
+  void operator []=(int index, int value) =>
+      throw UnsupportedError('fixed length');
 }
 
 class _ResultOnlyDownload extends CancellableDownload {
@@ -169,6 +187,83 @@ void main() {
           body.add(utf8.encode('payload'));
           await pumpEventQueue();
           resolved = await download.file;
+          await pumpEventQueue();
+        }, (error, _) => zoneErrors.add(error));
+
+        expect(resolved, isNull);
+        expect(zoneErrors, isEmpty);
+        expect(target.existsSync(), isFalse);
+      });
+    });
+
+    // The open succeeding does not make the sink safe: a write can still fail
+    // (ENOSPC, EIO) after any number of good chunks, and it surfaces on the
+    // same `done` future as a failed open. Both orderings below settle through
+    // `_failWithWriteError`, so they regress together with the group above.
+    group('when a write fails after the file opened', () {
+      late File target;
+
+      setUp(() {
+        target = File('${tempDir.path}/video.mp4');
+      });
+
+      test('completes with null when the write fails mid-stream', () async {
+        // Without the sink's `done` listener this hung forever: nothing
+        // observed the write error, the response stream stayed live, and the
+        // partial file was left behind for the caller to decode.
+        final body = StreamController<List<int>>();
+        addTearDown(body.close);
+        final client = _CallbackClient(
+          (_) async => http.StreamedResponse(body.stream, 200),
+        );
+        final downloader = HttpCancellableDownloader(client);
+
+        final zoneErrors = <Object>[];
+        File? resolved;
+        await runZonedGuarded(() async {
+          final download = downloader.download(
+            url: 'https://example.com/video.mp4',
+            targetFile: target,
+          );
+          await pumpEventQueue();
+          body.add(utf8.encode('good bytes '));
+          await pumpEventQueue();
+          body.add(_UnwritableChunk());
+          await pumpEventQueue();
+          body.add(utf8.encode('bytes that must be discarded'));
+          resolved = await download.file;
+          await pumpEventQueue();
+        }, (error, _) => zoneErrors.add(error));
+
+        expect(resolved, isNull);
+        expect(zoneErrors, isEmpty);
+        expect(target.existsSync(), isFalse);
+      });
+
+      test('completes with null when the last chunk fails to write', () async {
+        // The response ends in the same turn the write fails, so `onDone`
+        // races `done`. Previously `close()` reported success and handed back
+        // a File holding only the bytes written before the failure.
+        final client = _CallbackClient(
+          (_) async => http.StreamedResponse(
+            Stream<List<int>>.fromIterable([
+              utf8.encode('good bytes '),
+              _UnwritableChunk(),
+            ]),
+            200,
+          ),
+        );
+        final downloader = HttpCancellableDownloader(client);
+
+        final zoneErrors = <Object>[];
+        File? resolved;
+        await runZonedGuarded(() async {
+          resolved = await downloader
+              .download(
+                url: 'https://example.com/video.mp4',
+                targetFile: target,
+              )
+              .file;
           await pumpEventQueue();
         }, (error, _) => zoneErrors.add(error));
 


### PR DESCRIPTION
## Description

#7305 fixed the case where `File.openWrite()`'s **open** fails (an over-long cache filename), and shipped tests for both orderings of that. A write can also fail *after* a successful open — a full disk, an IO error — and it surfaces on the same `IOSink.done` future, so the same `_failWithWriteError` path already repairs it. That behaviour had no test, so it can regress silently.

Both tests are red against the pre-#7305 downloader, in two different ways:

- **mid-stream** (`TimeoutException` after 30s): nothing observed the write error while the response stream stayed live, so the download never settled. That is the same hang #7305 describes for the open failure, reached by a different route, and it also left the partial file on disk and leaked an error to the enclosing zone.
- **last chunk** (`Expected: null / Actual: _File:<…/video.mp4>`): `onDone` raced `done`, `close()` reported success, and the caller got a non-null `File` over only the bytes written before the failure — a truncated image that then gets cached and decoded.

`_UnwritableChunk` is a `ListBase<int>` whose element reads throw, which makes `RandomAccessFile.writeFrom` fail for that chunk without touching the filesystem or stubbing `dart:io`.

No production code changes.

**Related Issue:** Relates to #7298

## Out of Scope

- The over-long cache filename itself, still tracked in #7311.
- The remaining `Recoverable media load failure` signatures that still report to Crashlytics — #7305 scoped the silence to the download-without-file branch on purpose.

## Verification

- `dart format` on the changed file — no reflow.
- `flutter analyze` in `mobile/packages/media_cache` — no issues.
- `flutter test --coverage` in `mobile/packages/media_cache` — 215 tests pass, 98.20% line coverage (the package gates at 98).
- Both new tests confirmed red against the pre-#7305 `cancellable_downloader.dart`: mid-stream times out at 30s, last-chunk returns a non-null `File`.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
