### PR TITLE
chore(post-publish): drop the never-configured Remote Config kill switch

### DIFF
--- a/docs/ANALYTICS_OBSERVABILITY.md
+++ b/docs/ANALYTICS_OBSERVABILITY.md
@@ -124,12 +124,9 @@ than treating a missing value as instant.
 The existing profile destination and published-video confirmation remain the
 payoff. A deterministic 50/50 assignment from the authenticated hex pubkey
 adds a create-again action to that confirmation for the `create_again`
-variant. The control variant is unchanged.
+variant. The control variant is unchanged. Assignment is local in the app;
+there is no remote kill switch or Firebase Admin setup for this experiment.
 
-- Remote Config key: `post_publish_create_again_enabled`
-- In-app default: `true`
-- Kill switch: publish the key as `false`; real-time Remote Config updates are
-  activated while the app is running
 - Baseline second-post rate: 44.1%
 
 Events:
@@ -155,9 +152,6 @@ does not make them queryable as dimensions retroactively.
    `mode`.
 2. Create a user-scoped custom dimension named `invite_code` for user property
    `invite_code`.
-3. Create and publish the Remote Config boolean
-   `post_publish_create_again_enabled = true`. Set it to `false` for an
-   immediate kill switch.
 
 The GA4 reporting identity setting does not gate the BigQuery `user_id` field;
 use BigQuery as the campaign source of truth.

--- a/mobile/lib/features/post_publish/post_publish_experiment.dart
+++ b/mobile/lib/features/post_publish/post_publish_experiment.dart
@@ -1,16 +1,11 @@
 // ABOUTME: Deterministically assigns the post-publish create-again experiment.
-// ABOUTME: Uses Firebase Remote Config as a live kill switch.
+// ABOUTME: Assignment is local: sha256 over the pubkey, no remote input.
 
-import 'dart:async';
 import 'dart:convert';
 
 import 'package:analytics/analytics.dart';
 import 'package:crypto/crypto.dart';
-import 'package:firebase_remote_config/firebase_remote_config.dart';
 import 'package:unified_logger/unified_logger.dart';
-
-const postPublishCreateAgainRemoteConfigKey =
-    'post_publish_create_again_enabled';
 
 enum PostPublishVariant {
   control('control'),
@@ -21,86 +16,6 @@ enum PostPublishVariant {
   final String analyticsName;
 }
 
-abstract interface class PostPublishFlagClient {
-  Future<void> initialize();
-  bool get createAgainEnabled;
-  void dispose();
-}
-
-class FirebasePostPublishFlagClient implements PostPublishFlagClient {
-  FirebasePostPublishFlagClient({this.defaultEnabled = true});
-
-  final bool defaultEnabled;
-  FirebaseRemoteConfig? _remoteConfig;
-  StreamSubscription<RemoteConfigUpdate>? _updates;
-  Future<void>? _initialization;
-  bool _defaultsReady = false;
-
-  @override
-  bool get createAgainEnabled {
-    if (!_defaultsReady) return defaultEnabled;
-    try {
-      return _remoteConfig?.getBool(postPublishCreateAgainRemoteConfigKey) ??
-          defaultEnabled;
-    } catch (_) {
-      return defaultEnabled;
-    }
-  }
-
-  @override
-  Future<void> initialize() => _initialization ??= _initialize();
-
-  Future<void> _initialize() async {
-    try {
-      final remoteConfig = FirebaseRemoteConfig.instance;
-      _remoteConfig = remoteConfig;
-      await remoteConfig.setConfigSettings(
-        RemoteConfigSettings(
-          fetchTimeout: const Duration(seconds: 10),
-          minimumFetchInterval: const Duration(hours: 1),
-        ),
-      );
-      await remoteConfig.setDefaults({
-        postPublishCreateAgainRemoteConfigKey: defaultEnabled,
-      });
-      _defaultsReady = true;
-
-      try {
-        await remoteConfig.fetchAndActivate();
-      } catch (error) {
-        Log.warning(
-          'Post-publish Remote Config fetch failed: $error',
-          name: 'FirebasePostPublishFlagClient',
-          category: LogCategory.system,
-        );
-      }
-
-      _updates = remoteConfig.onConfigUpdated.listen((_) async {
-        try {
-          await remoteConfig.activate();
-        } catch (error) {
-          Log.warning(
-            'Post-publish Remote Config activation failed: $error',
-            name: 'FirebasePostPublishFlagClient',
-            category: LogCategory.system,
-          );
-        }
-      });
-    } catch (error) {
-      Log.warning(
-        'Post-publish Remote Config unavailable: $error',
-        name: 'FirebasePostPublishFlagClient',
-        category: LogCategory.system,
-      );
-    }
-  }
-
-  @override
-  void dispose() {
-    unawaited(_updates?.cancel());
-  }
-}
-
 class PostPublishCreateAgainOffer {
   const PostPublishCreateAgainOffer({required this.publishedAt});
 
@@ -109,14 +24,11 @@ class PostPublishCreateAgainOffer {
 
 class PostPublishExperiment {
   PostPublishExperiment({
-    required PostPublishFlagClient flags,
     required AnalyticsEventSink analytics,
     DateTime Function()? now,
-  }) : _flags = flags,
-       _analytics = analytics,
+  }) : _analytics = analytics,
        _now = now ?? DateTime.now;
 
-  final PostPublishFlagClient _flags;
   final AnalyticsEventSink _analytics;
   final DateTime Function() _now;
 
@@ -129,12 +41,8 @@ class PostPublishExperiment {
 
   static const _maxPendingVariants = 32;
 
-  Future<void> initialize() => _flags.initialize();
-
   PostPublishVariant variantForUser(String? pubkeyHex) {
-    if (!_flags.createAgainEnabled || pubkeyHex == null) {
-      return PostPublishVariant.control;
-    }
+    if (pubkeyHex == null) return PostPublishVariant.control;
     // Lowercased so a signer that returns uppercase hex cannot move the same
     // account between buckets.
     final assignmentByte = sha256

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -1929,7 +1929,6 @@ class _DivineAppState extends ConsumerState<DivineApp>
   }
 
   void _initializeDeferredStartup() {
-    unawaited(ref.read(postPublishExperimentProvider).initialize());
     unawaited(
       widget.startupCoordinator.initializeRemaining().catchError((
         Object error,

--- a/mobile/lib/providers/post_publish_providers.dart
+++ b/mobile/lib/providers/post_publish_providers.dart
@@ -1,18 +1,11 @@
-// ABOUTME: Riverpod wiring for the remotely controlled post-publish experiment.
+// ABOUTME: Riverpod wiring for the post-publish create-again experiment.
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/features/post_publish/post_publish_experiment.dart';
 import 'package:openvine/providers/analytics_providers.dart';
 
-final postPublishFlagClientProvider = Provider<PostPublishFlagClient>((ref) {
-  final client = FirebasePostPublishFlagClient();
-  ref.onDispose(client.dispose);
-  return client;
-});
-
 final postPublishExperimentProvider = Provider<PostPublishExperiment>((ref) {
   return PostPublishExperiment(
-    flags: ref.watch(postPublishFlagClientProvider),
     analytics: ref.watch(analyticsEventSinkProvider),
   );
 });

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -761,30 +761,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.1.8+2"
-  firebase_remote_config:
-    dependency: "direct main"
-    description:
-      name: firebase_remote_config
-      sha256: "6d7be334b726537b3aa3a3ef1db9782951cd93c2b996eebc33f64a9f140e0409"
-      url: "https://pub.dev"
-    source: hosted
-    version: "6.1.4"
-  firebase_remote_config_platform_interface:
-    dependency: transitive
-    description:
-      name: firebase_remote_config_platform_interface
-      sha256: f895915923bebb9e8b36a6387fac31a9dd36fbb63fa2ee1ea2cbe309634eecdf
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.7"
-  firebase_remote_config_web:
-    dependency: transitive
-    description:
-      name: firebase_remote_config_web
-      sha256: a4de6b86e5eb0416a46948dcb1fa9fce6a71d41f80fa107f6e202ae579ec81b2
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.10.3"
   fixnum:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -313,8 +313,6 @@ dependencies:
   window_manager: ^0.5.1
   firebase_core: ^4.4.0
   firebase_crashlytics: ^5.0.7
-  # Pinned to the Firebase Core 4.4-compatible FlutterFire release family.
-  firebase_remote_config: 6.1.4
   go_router: ^16.2.4
   # Runtime splash-screen control via FlutterNativeSplash.preserve/remove.
   # Used ONLY for the runtime API — do NOT add a flutter_native_splash:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -313,6 +313,8 @@ dependencies:
   window_manager: ^0.5.1
   firebase_core: ^4.4.0
   firebase_crashlytics: ^5.0.7
+  firebase_performance: ^0.11.1+4
+  firebase_messaging: ^16.1.1
   go_router: ^16.2.4
   # Runtime splash-screen control via FlutterNativeSplash.preserve/remove.
   # Used ONLY for the runtime API — do NOT add a flutter_native_splash:
@@ -337,8 +339,6 @@ dependencies:
   # 3.x bundles the selected native SQLite implementation through hooks, and
   # extra Flutter-specific native SQLite providers can make plain SQLite win.
   sqlite3: ^3.3.3
-  firebase_performance: ^0.11.1+4
-  firebase_messaging: ^16.1.1
   audio_session: ^0.2.2
   pro_video_editor: ^2.11.2
   pro_image_editor: ^13.3.1

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -313,8 +313,8 @@ dependencies:
   window_manager: ^0.5.1
   firebase_core: ^4.4.0
   firebase_crashlytics: ^5.0.7
-  firebase_performance: ^0.11.1+4
   firebase_messaging: ^16.1.1
+  firebase_performance: ^0.11.1+4
   go_router: ^16.2.4
   # Runtime splash-screen control via FlutterNativeSplash.preserve/remove.
   # Used ONLY for the runtime API — do NOT add a flutter_native_splash:

--- a/mobile/test/features/post_publish/post_publish_experiment_test.dart
+++ b/mobile/test/features/post_publish/post_publish_experiment_test.dart
@@ -37,9 +37,7 @@ void main() {
       'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
 
   test('assigns the same user deterministically across calls', () {
-    final experiment = PostPublishExperiment(
-      analytics: _RecordingSink(),
-    );
+    final experiment = PostPublishExperiment(analytics: _RecordingSink());
 
     expect(
       experiment.variantForUser(controlPubkey),
@@ -56,9 +54,7 @@ void main() {
   });
 
   test('assigns the same bucket regardless of hex casing', () {
-    final experiment = PostPublishExperiment(
-      analytics: _RecordingSink(),
-    );
+    final experiment = PostPublishExperiment(analytics: _RecordingSink());
 
     expect(
       experiment.variantForUser(treatmentPubkey.toUpperCase()),
@@ -66,13 +62,16 @@ void main() {
     );
   });
 
+  test('assigns control when no pubkey is available', () {
+    final experiment = PostPublishExperiment(analytics: _RecordingSink());
+
+    expect(experiment.variantForUser(null), PostPublishVariant.control);
+  });
+
   test('records destination, variant, and seconds to create again', () async {
     final sink = _RecordingSink();
     var now = DateTime.utc(2026, 8, 8, 12);
-    final experiment = PostPublishExperiment(
-      analytics: sink,
-      now: () => now,
-    );
+    final experiment = PostPublishExperiment(analytics: sink, now: () => now);
 
     await experiment.screenShown(
       publishId: 'publish-1',
@@ -96,9 +95,7 @@ void main() {
   });
 
   test('bounds pending assignments that never resolve', () async {
-    final experiment = PostPublishExperiment(
-      analytics: _RecordingSink(),
-    );
+    final experiment = PostPublishExperiment(analytics: _RecordingSink());
 
     await experiment.screenShown(
       publishId: 'stranded',
@@ -119,9 +116,7 @@ void main() {
   });
 
   test('drops treatment state when a publish fails', () async {
-    final experiment = PostPublishExperiment(
-      analytics: _RecordingSink(),
-    );
+    final experiment = PostPublishExperiment(analytics: _RecordingSink());
 
     await experiment.screenShown(
       publishId: 'publish-failed',

--- a/mobile/test/features/post_publish/post_publish_experiment_test.dart
+++ b/mobile/test/features/post_publish/post_publish_experiment_test.dart
@@ -4,19 +4,6 @@ import 'package:analytics/analytics.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/features/post_publish/post_publish_experiment.dart';
 
-class _FakeFlags implements PostPublishFlagClient {
-  _FakeFlags(this.createAgainEnabled);
-
-  @override
-  bool createAgainEnabled;
-
-  @override
-  void dispose() {}
-
-  @override
-  Future<void> initialize() async {}
-}
-
 class _RecordingSink implements AnalyticsEventSink {
   final events = <({String name, Map<String, Object> parameters})>[];
 
@@ -51,7 +38,6 @@ void main() {
 
   test('assigns the same user deterministically across calls', () {
     final experiment = PostPublishExperiment(
-      flags: _FakeFlags(true),
       analytics: _RecordingSink(),
     );
 
@@ -71,7 +57,6 @@ void main() {
 
   test('assigns the same bucket regardless of hex casing', () {
     final experiment = PostPublishExperiment(
-      flags: _FakeFlags(true),
       analytics: _RecordingSink(),
     );
 
@@ -81,23 +66,10 @@ void main() {
     );
   });
 
-  test('remote flag forces every user into control', () {
-    final experiment = PostPublishExperiment(
-      flags: _FakeFlags(false),
-      analytics: _RecordingSink(),
-    );
-
-    expect(
-      experiment.variantForUser(treatmentPubkey),
-      PostPublishVariant.control,
-    );
-  });
-
   test('records destination, variant, and seconds to create again', () async {
     final sink = _RecordingSink();
     var now = DateTime.utc(2026, 8, 8, 12);
     final experiment = PostPublishExperiment(
-      flags: _FakeFlags(true),
       analytics: sink,
       now: () => now,
     );
@@ -125,7 +97,6 @@ void main() {
 
   test('bounds pending assignments that never resolve', () async {
     final experiment = PostPublishExperiment(
-      flags: _FakeFlags(true),
       analytics: _RecordingSink(),
     );
 
@@ -149,7 +120,6 @@ void main() {
 
   test('drops treatment state when a publish fails', () async {
     final experiment = PostPublishExperiment(
-      flags: _FakeFlags(true),
       analytics: _RecordingSink(),
     );
 

--- a/mobile/test/widgets/upload_failure_listener_test.dart
+++ b/mobile/test/widgets/upload_failure_listener_test.dart
@@ -46,17 +46,6 @@ class _FakeDraft extends Fake implements DivineVideoDraft {
 
 class _MockGoRouter extends Mock implements GoRouter {}
 
-class _EnabledFlags implements PostPublishFlagClient {
-  @override
-  bool get createAgainEnabled => true;
-
-  @override
-  void dispose() {}
-
-  @override
-  Future<void> initialize() async {}
-}
-
 class _NoOpAnalytics implements AnalyticsEventSink {
   @override
   Future<void> logEvent({
@@ -208,7 +197,6 @@ void main() {
       stubPublishBloc(const BackgroundPublishState());
       when(() => authService.isAuthenticated).thenReturn(true);
       final experiment = PostPublishExperiment(
-        flags: _EnabledFlags(),
         analytics: _NoOpAnalytics(),
       );
       await experiment.screenShown(
@@ -242,7 +230,6 @@ void main() {
       final router = _MockGoRouter();
       when(() => router.push<void>(any())).thenAnswer((_) async {});
       final experiment = PostPublishExperiment(
-        flags: _EnabledFlags(),
         analytics: _NoOpAnalytics(),
       );
       await experiment.screenShown(


### PR DESCRIPTION
Closes #7362

## Description

Removes `firebase_remote_config` and the `PostPublishFlagClient` abstraction that existed only to host it.

**It was never configured.** The Remote Config template on `openvine-co` — the only Firebase project in the org, and the one both `google-services.json` and `firebase_options.dart` point at — is empty, and its version history has zero entries:

```
$ firebase remoteconfig:get --project openvine-co -o rc.json && cat rc.json
{}

$ firebase remoteconfig:versions:list --project openvine-co
(no entries)
```

Nobody ever published a template, so `post_publish_create_again_enabled` never existed as a parameter. In practice that meant every launch fetched an empty template, `getBool(...)` always fell through to the local default `true`, and the `onConfigUpdated` listener could never fire. The kill switch was never armed and could not have been used without someone first creating the parameter in the console.

**Keeping it was not free.** Two concrete costs:

- **iOS build fragility.** This plugin already broke the Codemagic iOS build once by pinning the shared `flutterfire` Swift package at a different `firebase_core` minimum than its siblings (#7016). GitHub CI runs no SPM iOS build, so that class of failure goes green on the PR and only surfaces after merge.
- **It starts costing money in two weeks.** [Remote Config becomes metered on 2026-09-01](https://firebase.google.com/docs/remote-config/pricing): the first 100k fetch requests/day are free, then $0.06 per 10k up to 10M/day, and $0.01 per 10k above 10M/day.

### What that would cost us

`minimumFetchInterval` was set to one hour, so billable volume tracks *sessions*, not installs: a device fetches at most once per hour it is opened, capped at 24/day. Monthly figures below are 30 days:

| Fetches per user per day | 1M DAU | 10M DAU | 100M DAU |
|---|---|---|---|
| 1 — one session, or all sessions inside one hour | $162 | $1,782 | $4,482 |
| 3 — plausible for short-video usage | $522 | $2,382 | $10,482 |
| 8 | $1,422 | $3,882 | $25,482 |
| 24 — ceiling, the one-hour interval cannot exceed this | $2,202 | $8,682 | $73,482 |

Two things worth reading off that table. The cheap tier caps the damage at small scale but not at large scale: past 10M requests/day everything bills at a flat $0.000001, so at 10M DAU tripling the fetch rate only moves the bill from $1,782 to $2,382, while at 100M DAU the same tripling costs an extra $6k/month and the ceiling row reaches $73k. And the numbers are a **floor**: they count the single startup `fetchAndActivate()` only. The `onConfigUpdated` realtime listener holds its own connection and triggers additional fetches, which this model does not include.

None of this is existential. The point is that it is a recurring, install-base-linear bill for a parameter that does not exist in the console, and the meter starts in about two weeks.

**Behaviour is unchanged.** Variant assignment was always local — sha256 over the lowercased pubkey, 50/50 — and never depended on the remote value. Since the flag resolved to `true` on every device, dropping the guard reproduces current production behaviour exactly. The guard is deleted rather than hardcoded to `true` so no dead abstraction is left behind.

## Out of Scope

- **The experiment itself still runs at 50/50.** This PR only removes the remote plumbing; it deliberately does not conclude the A/B test. Deciding whether the create-again offer ships to everyone or gets deleted is a product call that needs the `post_publish_screen_shown` / `post_publish_create_again_tapped` numbers, and it should be its own PR.
- `docs/MIGRATION_AND_ROLLBACK_GUIDE.md` and `docs/PROOFMODE_ATTESTATION_IMPLEMENTATION_PLAN.md` contain `FirebaseRemoteConfig` code samples. Both are historical documents describing architecture that was never built this way (there was never a `FeatureFlags` class reading Remote Config — the post-publish client was the only consumer in the repo). Rewriting them is a separate docs cleanup.

## Verification

- `flutter analyze lib test integration_test` — no issues
- `flutter test test/features/post_publish/post_publish_experiment_test.dart test/widgets/upload_failure_listener_test.dart` — 16 passed
- `flutter test test/providers` — 682 passed, 18 skipped
- `flutter test test/main_*_test.dart` (all 7) — 55 passed
- `dart format` clean; `pubspec.lock` regenerated via `flutter pub get`
- Grepped for remaining references across Dart, Podfile, gradle, plist and `google-services.json` — none left
- The `openvine-co` Remote Config template was re-checked live against the Firebase API and still returns `{}`
- Tested on a real device (Samsung Galaxy): published a video and confirmed the post-publish screen still assigns and renders the create-again offer

## Type of Change

- [x] 🗑️ Chore
- [x] ✅ Build configuration change

