### PR TITLE
fix(uploads): resolve publish-snackbar ancestors nullably

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -3052,7 +3052,14 @@ class _UploadFailureListenerState extends State<UploadFailureListener> {
 /// Uses [NavigatorKeys.root] to resolve both localization and
 /// [ScaffoldMessenger] from inside the app tree. The listener itself is mounted
 /// above [MaterialApp], so its own [BuildContext] does not have localization or
-/// scaffold ancestors in production.
+/// scaffold ancestors in production — reading l10n from it is what threw the
+/// null check in #7289 before the root context was adopted.
+///
+/// Both ancestors are resolved nullably: `mounted` only says the element still
+/// exists, not that it can still reach its inherited ancestors — a deactivated
+/// element reports `mounted` while every ancestor lookup returns null. Failing
+/// closed here hands the count back to the caller's buffer/replay path instead
+/// of throwing out of the bloc listener.
 bool _showPublishSuccessSnackbar(
   int count, {
   required ProviderContainer container,
@@ -3060,8 +3067,10 @@ bool _showPublishSuccessSnackbar(
 }) {
   final navContext = NavigatorKeys.root.currentContext;
   if (navContext == null || !navContext.mounted) return false;
-  final l10n = navContext.l10n;
-  ScaffoldMessenger.of(navContext).showSnackBar(
+  final l10n = Localizations.of<AppLocalizations>(navContext, AppLocalizations);
+  final messenger = ScaffoldMessenger.maybeOf(navContext);
+  if (l10n == null || messenger == null) return false;
+  messenger.showSnackBar(
     SnackBar(
       content: Text(
         l10n.uploadPublishedCountMessage(count),

--- a/mobile/lib/providers/video_publish_provider.dart
+++ b/mobile/lib/providers/video_publish_provider.dart
@@ -737,15 +737,23 @@ class VideoPublishNotifier extends Notifier<VideoPublishProviderState> {
     );
   }
 
+  /// Warns that some collaborator invites did not go out, offering a retry.
+  ///
+  /// Resolves l10n nullably for the same reason as the publish-success
+  /// snackbar in `main.dart`: a deactivated root element still reports
+  /// `mounted` while every ancestor lookup returns null (#7289).
   void _showCollaboratorInviteWarning({
     required List<CollaboratorInviteWarning> warnings,
   }) {
     final targetContext = NavigatorKeys.root.currentContext;
     if (targetContext == null || !targetContext.mounted) return;
-    final l10n = targetContext.l10n;
 
+    final l10n = Localizations.of<AppLocalizations>(
+      targetContext,
+      AppLocalizations,
+    );
     final messenger = ScaffoldMessenger.maybeOf(targetContext);
-    if (messenger == null) return;
+    if (l10n == null || messenger == null) return;
 
     messenger.showSnackBar(
       SnackBar(
@@ -773,7 +781,11 @@ class VideoPublishNotifier extends Notifier<VideoPublishProviderState> {
   }) async {
     final targetContext = NavigatorKeys.root.currentContext;
     if (targetContext == null || !targetContext.mounted) return;
-    final l10n = targetContext.l10n;
+    final l10n = Localizations.of<AppLocalizations>(
+      targetContext,
+      AppLocalizations,
+    );
+    if (l10n == null) return;
     final repository = ref.read(collaboratorInviteRecoveryRepositoryProvider);
     if (repository == null) {
       messenger.showSnackBar(

--- a/mobile/test/widgets/upload_failure_listener_test.dart
+++ b/mobile/test/widgets/upload_failure_listener_test.dart
@@ -132,6 +132,11 @@ Widget _buildHarness({
 /// for a deactivated root navigator, which resolves the same way only in
 /// release builds — under asserts an ancestor lookup on a deactivated element
 /// throws instead of returning null.
+///
+/// Both ancestors are dropped together on purpose. `MaterialApp` nests
+/// `Localizations` *above* `ScaffoldMessenger`, so a root context that
+/// resolves the messenger but not l10n cannot occur; either the tree is
+/// healthy or a deactivated element nulls out both lookups at once.
 Widget _buildHarnessWithoutAppAncestors({
   required _MockBackgroundPublishBloc publishBloc,
   required _MockAuthService authService,
@@ -445,8 +450,8 @@ void main() {
     );
 
     testWidgets(
-      'buffers the success when the root context has no localization '
-      'ancestor, then replays it once the ancestors appear',
+      'buffers the success when the root context resolves neither app '
+      'ancestor, then replays it once they appear',
       (tester) async {
         stubPublishBloc(const BackgroundPublishState());
         when(() => authService.isAuthenticated).thenReturn(true);

--- a/mobile/test/widgets/upload_failure_listener_test.dart
+++ b/mobile/test/widgets/upload_failure_listener_test.dart
@@ -128,9 +128,10 @@ Widget _buildHarness({
 /// [Localizations] nor [ScaffoldMessenger].
 ///
 /// This is the shape #7289 crashed on: reading l10n off a context that is
-/// mounted but has no localization ancestor throws a null check. It is also
-/// what a deactivated root navigator looks like — `mounted` stays true while
-/// every inherited lookup returns null.
+/// mounted but has no localization ancestor throws a null check. It stands in
+/// for a deactivated root navigator, which resolves the same way only in
+/// release builds — under asserts an ancestor lookup on a deactivated element
+/// throws instead of returning null.
 Widget _buildHarnessWithoutAppAncestors({
   required _MockBackgroundPublishBloc publishBloc,
   required _MockAuthService authService,
@@ -444,7 +445,8 @@ void main() {
     );
 
     testWidgets(
-      'does not throw when the root context has no localization ancestor',
+      'buffers the success when the root context has no localization '
+      'ancestor, then replays it once the ancestors appear',
       (tester) async {
         stubPublishBloc(const BackgroundPublishState());
         when(() => authService.isAuthenticated).thenReturn(true);
@@ -463,6 +465,27 @@ void main() {
         final l10n = lookupAppLocalizations(const Locale('en'));
         expect(tester.takeException(), isNull);
         expect(find.text(l10n.uploadPublishedCountMessage(1)), findsNothing);
+
+        // Failing closed must hand the count back, not swallow it: once the
+        // ancestors resolve, the buffered success replays on the next state.
+        // The key is detached first so the root navigator is rebuilt under
+        // [MaterialApp] rather than reparented with its ancestor-less route.
+        await tester.pumpWidget(
+          _buildHarness(
+            publishBloc: publishBloc,
+            authService: authService,
+            wireRootNavigatorKey: false,
+          ),
+        );
+        await tester.pumpWidget(
+          _buildHarness(publishBloc: publishBloc, authService: authService),
+        );
+        publishStream.add(const BackgroundPublishState());
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 50));
+
+        expect(tester.takeException(), isNull);
+        expect(find.text(l10n.uploadPublishedCountMessage(1)), findsOneWidget);
       },
     );
 

--- a/mobile/test/widgets/upload_failure_listener_test.dart
+++ b/mobile/test/widgets/upload_failure_listener_test.dart
@@ -123,6 +123,37 @@ Widget _buildHarness({
   );
 }
 
+/// Builds a harness whose [NavigatorKeys.root] navigator sits *outside*
+/// [MaterialApp], so the root context is mounted but resolves neither
+/// [Localizations] nor [ScaffoldMessenger].
+///
+/// This is the shape #7289 crashed on: reading l10n off a context that is
+/// mounted but has no localization ancestor throws a null check. It is also
+/// what a deactivated root navigator looks like — `mounted` stays true while
+/// every inherited lookup returns null.
+Widget _buildHarnessWithoutAppAncestors({
+  required _MockBackgroundPublishBloc publishBloc,
+  required _MockAuthService authService,
+}) {
+  return ProviderScope(
+    overrides: [authServiceProvider.overrideWithValue(authService)],
+    child: BlocProvider<BackgroundPublishBloc>.value(
+      value: publishBloc,
+      child: app.UploadFailureListener(
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: Navigator(
+            key: NavigatorKeys.root,
+            onGenerateRoute: (_) => PageRouteBuilder<void>(
+              pageBuilder: (_, _, _) => const SizedBox.shrink(),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
 /// Creates a [BackgroundUpload] with result == null (in-progress).
 BackgroundUpload _inProgress(String id) =>
     BackgroundUpload(draft: _FakeDraft(id), result: null, progress: 0.5);
@@ -403,6 +434,29 @@ void main() {
         );
 
         publishStream.add(_succeededState('draft-no-root'));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 50));
+
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        expect(tester.takeException(), isNull);
+        expect(find.text(l10n.uploadPublishedCountMessage(1)), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'does not throw when the root context has no localization ancestor',
+      (tester) async {
+        stubPublishBloc(const BackgroundPublishState());
+        when(() => authService.isAuthenticated).thenReturn(true);
+
+        await tester.pumpWidget(
+          _buildHarnessWithoutAppAncestors(
+            publishBloc: publishBloc,
+            authService: authService,
+          ),
+        );
+
+        publishStream.add(_succeededState('draft-no-l10n'));
         await tester.pump();
         await tester.pump(const Duration(milliseconds: 50));
 


### PR DESCRIPTION
## Description

`_showPublishSuccessSnackbar` guarded only on `navContext.mounted` before reading `navContext.l10n` and `ScaffoldMessenger.of(navContext)`. `mounted` says the element still exists — it does not say the element can still reach its inherited ancestors. A deactivated element reports `mounted == true` while `Element._inheritedElements` is already null, and then *every* ancestor lookup returns null: `Localizations` first, `ScaffoldMessenger` one line later. Both were unguarded, so an unresolvable context threw a null check straight out of the bloc listener instead of dropping the snackbar.

One qualifier on that mechanism, since the test harness depends on it: the null-returning behaviour is what a **release** binary does, which is where the Crashlytics reports come from. Under asserts, `framework.dart:5046` catches the deactivated-element lookup first and throws `Looking up a deactivated widget's ancestor is unsafe` instead of returning null. The test therefore reproduces the crash through a context that is mounted and simply has no `Localizations` ancestor — same failure at the same line, reachable in a debug binary.

Both lookups are now nullable and the helper fails closed, returning `false` so the count lands in the caller's existing `_pendingSuccessCount` buffer and replays on a later state emission. `navContext.vineColors` is deliberately left alone — that getter falls back to `VineTheme.darkColors` and never throws.

The two sibling call sites in `mobile/lib/providers/video_publish_provider.dart` are folded in rather than deferred, since it is the same fix: `_showCollaboratorInviteWarning` and `_retryCollaboratorInvites` both read `.l10n` off the root context before any guard could stop them, so both threw the same way. `_showAudioReuseDegradedWarning` and `_showPublishError` were already safe — the first by ordering, the second because it never touches l10n.

### On the crash reported in the issue

The 431 sampled events are **not** from the root-navigator lookup, and the issue's open question rests on a false premise. Evidence:

- Crashlytics version split: 1460 of 1462 events are **1.0.17 (813)**, plus one each on 1.0.17 (815) and 1.0.18 (818). **Zero** events on every 1.0.19 / 1.0.20 build (819–839).
- 1.0.19 is the first shipped build containing #6403 ("fix(l10n): use root context for publish snackbar"). Before that commit the helper took the `BlocListener`'s own context and read `context.l10n` from it. `97aca8af34` is an ancestor of the 1.0.19 bump `b792cb32cf77` and not of the 1.0.18 bump `b5c53289614f`, so 1.0.18 cannot carry the root-context change.
- `UploadFailureListener` is mounted **above** `MaterialApp.router` in `main.dart`, therefore above `Localizations`. That lookup returned null deterministically — no race, and nothing background-specific; `processState: BACKGROUND` merely reflects when background publishes finish.
- The stack offsets confirm which source shipped: the report has callsite 2927 → l10n read 2982, i.e. +55. Every layout before #6403 is +55 (the immediate pre-#6403 parent is 2956 → 3011) and every one after is +58. The absolute pair is tighter still — 2927 / 2982 matches exactly one layout in the whole history, introduced by `ca7d88df0c` (2026-07-26), and every commit carrying it declares `version: 1.0.17+506`. That pins the crashing binary to 1.0.17 rather than just "pre-#6403".

So the reported crash is already fixed in shipped builds. This PR is the hardening the issue asks for regardless, plus a regression test that pins the contract.

**Related Issue:** Closes #7289

## Verification

- New widget test `buffers the success when the root context resolves neither app ancestor, then replays it once they appear` mounts the `NavigatorKeys.root` navigator outside `MaterialApp`, reproducing the exact crash shape. Two negative controls were run against it: reverting the fix in place makes it fail with the original `Null check operator used on a null value` at `app_localizations.dart:91`, and flipping the helper's fail-closed `return false` to `true` makes it fail on the replay assertion. The second control is why the test asserts the replay rather than stopping at "no exception thrown" — without it, silently swallowing the success count would have gone unnoticed.
- The harness drops both ancestors together on purpose. `WidgetsApp` wraps `Localizations` around the result of `widget.builder`, which is where `MaterialApp` inserts `ScaffoldMessenger`, so `Localizations` sits strictly above the messenger. A root context that resolves the messenger but not l10n is therefore unreachable: either the tree is healthy, or a deactivated element nulls out both lookups at once. Pinning the two guards separately would mean modelling a tree that cannot occur, so the test name says what it models instead.
- The two `video_publish_provider.dart` call sites ship without a bespoke regression test. They are only reachable through a full `publishVideo` run carrying invite warnings, which is a heavy fixture for a reorder whose contract is already pinned on the success path.
- `flutter test test/widgets/upload_failure_listener_test.dart test/providers/video_publish_provider_test.dart test/blocs/background_publish_bloc/background_publish_bloc_test.dart` — 74 passed.
- `flutter analyze lib test integration_test` — no issues.
- `dart format` — clean.
- Not yet verified on a real device; the path only fires when a background publish completes.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
