### PR TITLE
fix(media-cache): cap cache filenames so long image URLs stay cacheable

### DIFF
--- a/mobile/packages/media_cache/lib/src/media_cache_manager.dart
+++ b/mobile/packages/media_cache/lib/src/media_cache_manager.dart
@@ -955,10 +955,11 @@ class MediaCacheManager extends CacheManager {
   /// cache key plus a monotonic counter and timestamp so concurrent
   /// downloads of the same key cannot collide on disk.
   ///
-  /// The result always fits within `NAME_MAX`: the key contributes at most
-  /// [_maxSanitizedKeyLength] characters and the extension at most 10, so
-  /// even a 20-digit timestamp and a 19-digit counter leave the name well
-  /// short of 255 bytes.
+  /// The result always fits within `NAME_MAX`: the sanitizer emits nothing
+  /// outside `[A-Za-z0-9._-]`, so the key's [_maxSanitizedKeyLength]
+  /// characters are [_maxSanitizedKeyLength] bytes, and the extension adds at
+  /// most 11. Even at the 19-digit ceiling for both the timestamp and the
+  /// counter the name stops at 211 bytes, short of 255.
   String _relativePathFor(String key, String url) {
     final safeKey = _sanitizedKeyFor(key);
     final ext = _extensionFor(url);

--- a/mobile/packages/media_cache/lib/src/media_cache_manager.dart
+++ b/mobile/packages/media_cache/lib/src/media_cache_manager.dart
@@ -1002,7 +1002,8 @@ class MediaCacheManager extends CacheManager {
     } on Object catch (_) {
       // Fall through to default.
     }
-    return _config.defaultExtension;
+    final fallback = _config.defaultExtension;
+    return _usableExtensionPattern.hasMatch(fallback) ? fallback : '.bin';
   }
 
   /// Runs a throttled [enforceCacheLimits] pass once enough downloads have

--- a/mobile/packages/media_cache/lib/src/media_cache_manager.dart
+++ b/mobile/packages/media_cache/lib/src/media_cache_manager.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:clock/clock.dart';
+import 'package:crypto/crypto.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 import 'package:http/io_client.dart';
@@ -33,6 +34,29 @@ final RegExp _webHelperCacheFilePattern = RegExp(
   '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}'
   r'-[0-9a-fA-F]{12}\.[A-Za-z0-9]+$',
 );
+
+/// Longest sanitized cache key kept as the readable head of a cache
+/// filename. `NAME_MAX` — the byte limit for a single path component — is
+/// 255 on APFS, ext4 and f2fs, and `File.openWrite` fails with
+/// `ENAMETOOLONG` past it. Proxied image URLs routinely run past 230
+/// characters, and the image cache keys on the raw URL, so the sanitized key
+/// has to be capped rather than trusted. The cap leaves room for the
+/// `_<microseconds>_<seq><ext>` suffix under every value those three parts
+/// can take.
+const int _maxSanitizedKeyLength = 160;
+
+/// Hex characters of the key digest appended when a sanitized key is
+/// shortened, so two keys sharing a long prefix still land on distinct
+/// filenames.
+const int _keyDigestLength = 16;
+
+/// Matches an extension [MediaCacheManager] will carry over from a URL.
+/// Percent-encoded origin URLs embedded in image-proxy paths decode to
+/// segments whose "extension" is an arbitrarily long tail (`.png?v=2`), which
+/// neither describes a container nor matches [_managedCacheFilePattern].
+/// Anything outside this shape falls back to
+/// [MediaCacheConfig.defaultExtension].
+final RegExp _usableExtensionPattern = RegExp(r'^\.[A-Za-z0-9]{1,10}$');
 
 /// Untracked files younger than this are never reclaimed. Covers the window
 /// where a download settled after the sweep's snapshots were taken (its store
@@ -931,15 +955,41 @@ class MediaCacheManager extends CacheManager {
   /// cache key plus a monotonic counter and timestamp so concurrent
   /// downloads of the same key cannot collide on disk.
   ///
-  /// Non-filesystem-safe characters (slashes, colons, `?`, Unicode, etc.) in
-  /// [key] are replaced with `_` so the path never creates unintended
-  /// sub-directories or fails on `File.openWrite`.
+  /// The result always fits within `NAME_MAX`: the key contributes at most
+  /// [_maxSanitizedKeyLength] characters and the extension at most 10, so
+  /// even a 20-digit timestamp and a 19-digit counter leave the name well
+  /// short of 255 bytes.
   String _relativePathFor(String key, String url) {
-    final safeKey = key.replaceAll(RegExp('[^A-Za-z0-9._-]'), '_');
+    final safeKey = _sanitizedKeyFor(key);
     final ext = _extensionFor(url);
     final seq = ++_downloadSeq;
     final ts = DateTime.now().microsecondsSinceEpoch;
     return '${safeKey}_${ts}_$seq$ext';
+  }
+
+  /// Renders [key] as the readable head of a cache filename.
+  ///
+  /// Non-filesystem-safe characters (slashes, colons, `?`, Unicode, etc.) are
+  /// replaced with `_` so the path never creates unintended sub-directories.
+  /// A key past [_maxSanitizedKeyLength] — every image cached under a long
+  /// proxied URL — keeps as much of its head as fits and ends in a digest of
+  /// the full key, so distinct keys cannot be shortened onto the same name.
+  ///
+  /// Only the filename changes: cache lookups resolve through the stored
+  /// `CacheObject.relativePath`, never by recomputing this from the key, so
+  /// entries written before the cap stay reachable.
+  String _sanitizedKeyFor(String key) {
+    final safeKey = key.replaceAll(RegExp('[^A-Za-z0-9._-]'), '_');
+    if (safeKey.length <= _maxSanitizedKeyLength) return safeKey;
+    final digest = sha256
+        .convert(utf8.encode(key))
+        .toString()
+        .substring(0, _keyDigestLength);
+    final head = safeKey.substring(
+      0,
+      _maxSanitizedKeyLength - _keyDigestLength - 1,
+    );
+    return '${head}_$digest';
   }
 
   String _extensionFor(String url) {
@@ -947,7 +997,7 @@ class MediaCacheManager extends CacheManager {
       final uri = Uri.parse(url);
       final last = uri.pathSegments.isEmpty ? '' : uri.pathSegments.last;
       final ext = path.extension(last);
-      if (ext.isNotEmpty) return ext;
+      if (_usableExtensionPattern.hasMatch(ext)) return ext;
     } on Object catch (_) {
       // Fall through to default.
     }

--- a/mobile/packages/media_cache/pubspec.yaml
+++ b/mobile/packages/media_cache/pubspec.yaml
@@ -11,6 +11,7 @@ environment:
 dependencies:
   clock: ^1.1.2
   cronet_http: ^1.8.0
+  crypto: ^3.0.7
   cupertino_http: ^3.0.2
   file: ^7.0.0
   flutter:

--- a/mobile/packages/media_cache/test/src/media_cache_manager_mocked_test.dart
+++ b/mobile/packages/media_cache/test/src/media_cache_manager_mocked_test.dart
@@ -32,6 +32,18 @@ Future<File?> _cancelAndWait(CancellableCacheOperation operation) async {
   return operation.file;
 }
 
+// Drains the microtask + event queue until the manager's deferred
+// [_resolveBaseCacheDir] -> [_downloader.download] step has run and
+// [downloader.downloads] contains the expected number of entries.
+Future<void> pumpDownloads(
+  FakeCancellableDownloader downloader, {
+  int expected = 1,
+}) async {
+  for (var i = 0; i < 50 && downloader.downloads.length < expected; i++) {
+    await Future<void>.delayed(const Duration(milliseconds: 1));
+  }
+}
+
 void main() {
   setUpTestEnvironment();
 
@@ -552,15 +564,6 @@ void main() {
     });
 
     group('preCacheFiles with mocks', () {
-      Future<void> pumpDownloads(
-        FakeCancellableDownloader downloader, {
-        int expected = 1,
-      }) async {
-        for (var i = 0; i < 50 && downloader.downloads.length < expected; i++) {
-          await Future<void>.delayed(const Duration(milliseconds: 1));
-        }
-      }
-
       test('skips already cached files', () async {
         final mockFile = MockFile();
         final mockFileInfo = MockFileInfo();
@@ -722,18 +725,6 @@ void main() {
     });
 
     group('cacheFileCancellable', () {
-      // Drains the microtask + event queue until the manager's deferred
-      // [_resolveBaseCacheDir] -> [_downloader.download] step has run and
-      // [downloader.downloads] contains the expected number of entries.
-      Future<void> pumpDownloads(
-        FakeCancellableDownloader downloader, {
-        int expected = 1,
-      }) async {
-        for (var i = 0; i < 50 && downloader.downloads.length < expected; i++) {
-          await Future<void>.delayed(const Duration(milliseconds: 1));
-        }
-      }
-
       test(
         'returns completed operation when file is already in manifest',
         () async {
@@ -1178,6 +1169,51 @@ void main() {
         },
       );
 
+      test(
+        'restores a legacy long relativePath from the cache store',
+        () async {
+          final timestamp = DateTime.now().millisecondsSinceEpoch;
+          final cacheKey = 'legacy_relative_path_$timestamp';
+          final cacheDir = Directory('$testTempPath/$cacheKey')
+            ..createSync(recursive: true);
+          final legacyUrl = 'https://cdn.example.com/image/${'a' * 180}.jpg';
+          final legacyName =
+              '${legacyUrl.replaceAll(RegExp('[^A-Za-z0-9._-]'), '_')}'
+              '_1234567890123456_9.jpg';
+          expect(legacyName.length, greaterThan(160));
+          expect(utf8.encode(legacyName).length, lessThanOrEqualTo(255));
+          final cachedFile = await createTestFile(cacheDir, legacyName);
+
+          final repo = MockCacheInfoRepository();
+          final cacheObject = CacheObject(
+            legacyUrl,
+            key: legacyUrl,
+            relativePath: legacyName,
+            validTill: DateTime.now().add(const Duration(days: 7)),
+            id: 1,
+          );
+          when(repo.open).thenAnswer((_) async => true);
+          when(repo.getAllObjects).thenAnswer((_) async => [cacheObject]);
+
+          cacheManager = TestableMediaCacheManager(
+            config: MediaCacheConfig(
+              cacheKey: cacheKey,
+              enableSyncManifest: true,
+            ),
+            repoOverride: repo,
+            tempDirectoryProvider: () async => Directory(testTempPath),
+          );
+
+          await cacheManager.initialize();
+
+          final restored = cacheManager.getCachedFileSync(legacyUrl);
+          expect(restored, isNotNull);
+          expect(restored!.path, cachedFile.path);
+
+          if (cacheDir.existsSync()) cacheDir.deleteSync(recursive: true);
+        },
+      );
+
       test('initialize ignores corrupt aliases.json gracefully', () async {
         final timestamp = DateTime.now().millisecondsSinceEpoch;
         final cacheKey = 'alias_corrupt_$timestamp';
@@ -1391,6 +1427,37 @@ void main() {
 
           await pumpDownloads(downloader);
           expect(downloader.downloads.single.targetFile.path, endsWith('.bin'));
+
+          downloader.downloads.single.completeNull();
+          await op.file;
+        },
+      );
+
+      test(
+        'falls back to .bin when configured default extension is unusable',
+        () async {
+          final timestamp = DateTime.now().millisecondsSinceEpoch;
+          final downloader = FakeCancellableDownloader();
+
+          cacheManager = TestableMediaCacheManager(
+            config: MediaCacheConfig(
+              cacheKey: 'dirty_default_ext_$timestamp',
+              enableSyncManifest: true,
+              defaultExtension: '.${'x' * 300}',
+            ),
+            downloaderOverride: downloader,
+          );
+
+          final op = cacheManager.cacheFileCancellable(
+            'https://example.com/no-extension',
+            key: 'dirty_default_ext_key',
+          );
+
+          await pumpDownloads(downloader);
+          final fileName =
+              downloader.downloads.single.targetFile.uri.pathSegments.last;
+          expect(fileName, endsWith('.bin'));
+          expect(utf8.encode(fileName).length, lessThanOrEqualTo(255));
 
           downloader.downloads.single.completeNull();
           await op.file;
@@ -1803,9 +1870,7 @@ void main() {
           downloaderOverride: downloader,
         );
         final op = cacheManager.cacheFileCancellable(url, key: url);
-        for (var i = 0; i < 50 && downloader.downloads.isEmpty; i++) {
-          await Future<void>.delayed(const Duration(milliseconds: 1));
-        }
+        await pumpDownloads(downloader);
         final download = downloader.downloads.single..completeNull();
         await op.file;
         return download.targetFile.uri.pathSegments.last;
@@ -1817,6 +1882,17 @@ void main() {
         final name = await fileNameFor(
           proxiedUrl(248),
           cacheKey: 'long_url_$timestamp',
+        );
+
+        expect(utf8.encode(name).length, lessThanOrEqualTo(nameMax));
+      });
+
+      test('stays within NAME_MAX for a long multibyte URL key', () async {
+        final timestamp = DateTime.now().millisecondsSinceEpoch;
+
+        final name = await fileNameFor(
+          'https://cdn.example.com/avatars/${'動画' * 120}.jpg',
+          cacheKey: 'unicode_url_$timestamp',
         );
 
         expect(utf8.encode(name).length, lessThanOrEqualTo(nameMax));
@@ -1843,7 +1919,6 @@ void main() {
           '$shared?variant=one',
           cacheKey: 'distinct_a_$timestamp',
         );
-        cacheManager.resetForTesting();
         final second = await fileNameFor(
           '$shared?variant=two',
           cacheKey: 'distinct_b_$timestamp',

--- a/mobile/packages/media_cache/test/src/media_cache_manager_mocked_test.dart
+++ b/mobile/packages/media_cache/test/src/media_cache_manager_mocked_test.dart
@@ -1366,6 +1366,37 @@ void main() {
         await op.file;
       });
 
+      test(
+        'falls back to default extension for a non-extension tail',
+        () async {
+          final timestamp = DateTime.now().millisecondsSinceEpoch;
+          final downloader = FakeCancellableDownloader();
+
+          cacheManager = TestableMediaCacheManager(
+            config: MediaCacheConfig(
+              cacheKey: 'dirty_ext_$timestamp',
+              enableSyncManifest: true,
+            ),
+            downloaderOverride: downloader,
+          );
+
+          // The last path segment decodes to `https://bucket/x.png?v=2`, whose
+          // "extension" is `.png?v=2` — not a container, and not something
+          // reclamation's `_<micros>_<seq>.<alnum>` matcher recognizes.
+          final op = cacheManager.cacheFileCancellable(
+            'https://cdn.example.com/image/fetch/w_100/'
+            'https%3A%2F%2Fbucket.example.com%2Fx.png%3Fv%3D2',
+            key: 'dirty_ext_key',
+          );
+
+          await pumpDownloads(downloader);
+          expect(downloader.downloads.single.targetFile.path, endsWith('.bin'));
+
+          downloader.downloads.single.completeNull();
+          await op.file;
+        },
+      );
+
       test('close cancels active operations and closes downloader', () async {
         final timestamp = DateTime.now().millisecondsSinceEpoch;
         final downloader = FakeCancellableDownloader();
@@ -1738,6 +1769,107 @@ void main() {
           if (cacheDir.existsSync()) cacheDir.deleteSync(recursive: true);
         },
       );
+    });
+
+    group('cacheFileCancellable filename length', () {
+      // `NAME_MAX` — the byte limit for a single path component — is 255 on
+      // APFS, ext4 and f2fs. A longer filename fails `File.openWrite` with
+      // `ENAMETOOLONG`, so the download is never cached and the image never
+      // renders (#7311).
+      const nameMax = 255;
+
+      /// The `_<micros>_<seq><ext>` tail reclamation matches on to decide
+      /// which untracked files it may delete.
+      final managedSuffix = RegExp(r'_\d+_\d+\.[A-Za-z0-9]+$');
+
+      /// A proxy URL of [length] characters, in the shape that produced the
+      /// production failures: a percent-encoded origin URL inside the
+      /// proxy's own path.
+      String proxiedUrl(int length) {
+        const prefix =
+            'https://cdn.example.com/image/fetch/w_1080,h_1080,c_fill/'
+            'https%3A%2F%2Fbucket.example.com%2Fpublic%2Fimages%2F';
+        const suffix = '_1080x1080.png';
+        return prefix + 'a' * (length - prefix.length - suffix.length) + suffix;
+      }
+
+      /// Runs one download for [url] keyed on the URL — the way
+      /// `MediaCacheImageProvider` calls in — and returns the filename the
+      /// manager asked the downloader to write.
+      Future<String> fileNameFor(String url, {required String cacheKey}) async {
+        final downloader = FakeCancellableDownloader();
+        cacheManager = TestableMediaCacheManager(
+          config: MediaCacheConfig.image(cacheKey: cacheKey),
+          downloaderOverride: downloader,
+        );
+        final op = cacheManager.cacheFileCancellable(url, key: url);
+        for (var i = 0; i < 50 && downloader.downloads.isEmpty; i++) {
+          await Future<void>.delayed(const Duration(milliseconds: 1));
+        }
+        final download = downloader.downloads.single..completeNull();
+        await op.file;
+        return download.targetFile.uri.pathSegments.last;
+      }
+
+      test('stays within NAME_MAX for a URL that used to overflow', () async {
+        final timestamp = DateTime.now().millisecondsSinceEpoch;
+
+        final name = await fileNameFor(
+          proxiedUrl(248),
+          cacheKey: 'long_url_$timestamp',
+        );
+
+        expect(utf8.encode(name).length, lessThanOrEqualTo(nameMax));
+      });
+
+      test('keeps the file reclaimable after shortening the key', () async {
+        final timestamp = DateTime.now().millisecondsSinceEpoch;
+
+        final name = await fileNameFor(
+          proxiedUrl(600),
+          cacheKey: 'reclaimable_$timestamp',
+        );
+
+        expect(utf8.encode(name).length, lessThanOrEqualTo(nameMax));
+        expect(name, matches(managedSuffix));
+      });
+
+      test('gives two keys sharing a long prefix distinct names', () async {
+        final timestamp = DateTime.now().millisecondsSinceEpoch;
+        // Differ only in the tail — exactly what shortening drops.
+        final shared = proxiedUrl(400);
+
+        final first = await fileNameFor(
+          '$shared?variant=one',
+          cacheKey: 'distinct_a_$timestamp',
+        );
+        cacheManager.resetForTesting();
+        final second = await fileNameFor(
+          '$shared?variant=two',
+          cacheKey: 'distinct_b_$timestamp',
+        );
+
+        // Compare the key-derived head only: the `_<micros>_<seq>` tail
+        // makes every filename unique on its own and would mask a collision.
+        expect(
+          first.replaceAll(managedSuffix, ''),
+          isNot(second.replaceAll(managedSuffix, '')),
+        );
+      });
+
+      test('embeds a key that already fits verbatim', () async {
+        final timestamp = DateTime.now().millisecondsSinceEpoch;
+
+        final name = await fileNameFor(
+          'https://cdn.example.com/avatars/abc123.jpg',
+          cacheKey: 'short_url_$timestamp',
+        );
+
+        expect(
+          name,
+          startsWith('https___cdn.example.com_avatars_abc123.jpg_'),
+        );
+      });
     });
   });
 }


### PR DESCRIPTION
## Description

`MediaCacheManager._relativePathFor` applied no length cap. The image cache keys every entry on the raw image URL, so a proxied avatar or thumbnail URL past ~232 characters sanitized to a filename over the 255-byte `NAME_MAX` of APFS and ext4, `File.openWrite()` failed with `ENAMETOOLONG`, and no cache entry was ever written. Those images fell back to a placeholder forever and re-issued an HTTPS request every time the URL scrolled back into view. Two URL families in production hit it: a Wayback-proxied legacy avatar (231 chars, intermittent — it depends on the session download counter) and a CDN image-proxy URL embedding a percent-encoded origin (248 chars, unconditional).

**Cap the sanitized key at 160 characters.** A longer key keeps its readable head and ends in a 16-hex `sha256` digest of the full key.

Characters are bytes here, which is what makes the cap a real bound rather than an approximate one: the sanitizer replaces everything outside `[A-Za-z0-9._-]` with `_`, so its output is ASCII by construction — verified by feeding it CJK, accented Latin, and astral-plane input including surrogate pairs, and confirming `chars == utf8Bytes` in every case. Worst case is therefore **211 bytes**, not the ~190 first estimated: 160 for the key, `_`, a 19-digit int64 timestamp, `_`, a 19-digit int64 counter, and an 11-character extension. That is the ceiling under values those parts cannot actually reach simultaneously; it clears `NAME_MAX` by 44 bytes regardless.

Truncation alone would have been enough for the filesystem — `_<micros>_<seq>` already makes each written file unique, and `_downloadSeq` is a monotonic per-instance counter, so a filename collision was never reachable in the first place. The digest is **not** load-bearing for correctness. What it buys is diagnosability: the distinguishing part of both affected URL families sits in the *tail*, which is exactly what truncation drops, so without the digest two entries from the same proxy would present as identical readable heads in the cache directory.

**Only the filename changes, deliberately.** Hashing the URL into the cache *key* would have been the smaller diff, but `getFileFromCache` and manifest restore both resolve through the stored `CacheObject.relativePath` rather than recomputing it from the key. Leaving the key alone means every entry cached before this change stays reachable; changing it would have invalidated the whole image cache once, on every install. Confirmed rather than assumed: `_relativePathFor` has exactly one call site, and every read path bottoms out in `CacheObject.relativePath` — manifest restore directly, and `getFileFromCache` via `CacheStore.getFile` → `fileSystem.createFile(cacheObject.relativePath)` in `flutter_cache_manager` 3.4.2. Nothing recomputes a path from a key.

**Bound the URL-derived extension too.** `_extensionFor` returned whatever followed the last dot of the last path segment. A percent-encoded origin URL inside an image-proxy path decodes to a segment like `https://bucket/x.png?v=2`, whose "extension" is `.png?v=2` — unbounded in length, so it can breach `NAME_MAX` on its own, and outside the `_<micros>_<seq>.<alnum>` shape `_managedCacheFilePattern` matches on, so reclamation could never delete those files either. Anything that does not look like a real extension now falls back to a validated configured `defaultExtension`, or `.bin` if the configured fallback is unusable. This is marginally wider than the reported bug; it is what makes the "fits for *any* URL" invariant actually hold, and it is verified, not hypothetical — the decode is reproduced in a test.

**Related Issue:** Closes #7311

## Out of Scope

- `openvine_video_cache` needed no change: `DiskPrefetcher` keys on a 64-hex event id.
- The legacy non-cancellable `cacheFile` / `downloadFile` path needed no change: `flutter_cache_manager`'s WebHelper names files `<uuid-v1><ext>`.
- Sanitizing an extension that is short but contains odd characters. The length bound and the shape check cover the reachable cases; a broader rewrite of `_extensionFor` is not warranted by this bug.
- **Reclaiming the `…_<micros>_<seq>.png?v=2` files already on disk — filed as #7366.** This cap changes the filename a re-download writes, which moves the store row and leaves the pre-cap file untracked; `_managedCacheFilePattern` cannot match it either, because `?` and `=` follow the dot. Untracked *and* unmatched means neither `_reclaimOrphanedFiles` nor `_evictToByteBudget` can ever delete it. The leak is pre-existing, but shipping this fix is what makes it permanent. It is deliberately not fixed here: the remedy is widening a deletion pattern whose own doc says the conservatism is intentional — it shares the cache directory with bundled seed media and `aliases.json` — and that belongs in a change whose tests are about what must *not* be deleted.

## Verification

- `flutter analyze lib test` in `mobile/packages/media_cache` — clean.
- `flutter test --coverage` in `mobile/packages/media_cache` — 223 pass, 2 skipped, 98.22% line coverage (CI gate is 98).
- App-side suites that consume the image cache: `test/widgets/vine_cached_image_test.dart`, `test/services/storage_management_service_test.dart` — green.
- Original regression tests were run against the unfixed code first: the 248-character URL produced a 271-byte filename, the 600-character one 623 bytes, and the `.png?v=2` decode carried its query into the filename. The prefix-collision test guards the digest specifically — plain truncation fails it. Takeover follow-up added tests for multibyte keys, validated default-extension fallback, and legacy `relativePath` restore.
- `dart format` clean on both changed files.
- Not yet verified on a real device — the deterministic cache filename behavior is covered by package tests; a Samsung Galaxy smoke check can still confirm the avatar-rendering symptom end to end.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore



