### PR TITLE
fix(feed): repair a silent relay while the feed load is still waiting

### DIFF
--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -189,6 +189,9 @@ class RelayPool {
   /// Dropped when the subscription is unsubscribed.
   final Map<String, DateTime> _subscriptionSentAt = {};
 
+  /// Armed silence probes, keyed by subscription id.
+  final Map<String, Timer> _subscriptionSilenceProbes = {};
+
   /// One-shot queries at least one relay has already answered.
   ///
   /// Sticky for the query's lifetime rather than a property of the call that
@@ -229,6 +232,7 @@ class RelayPool {
     this.signatureVerificationPolicy = SignatureVerificationPolicy.all,
     this.silentRepairCooldown = const Duration(seconds: 60),
     this.minSubscriptionAgeBeforeRepair = const Duration(seconds: 10),
+    this.subscriptionSilenceProbe = const Duration(seconds: 8),
     this.tempRelayIdleTimeout = const Duration(seconds: 120),
     this.tempRelaySweepInterval = const Duration(seconds: 60),
   });
@@ -280,6 +284,30 @@ class RelayPool {
   /// deadline, so a caller that actually waited still gets the repair.
   /// Injectable so tests need no wall-clock wait.
   Duration minSubscriptionAgeBeforeRepair;
+
+  /// How long after a subscription's REQ fan-out the pool checks whether any
+  /// relay has answered, and repairs the ones that have not.
+  ///
+  /// Until #7301 the same check only ran from [unsubscribe], which meant a
+  /// relay that swallowed the REQ was found *after* the caller had already
+  /// given up. Nothing else could catch it inside that window either: the REQ
+  /// is sent with `skipReconnect`, so a dropped socket queues it silently; a
+  /// half-open socket accepts it into a dead connection and answers nothing;
+  /// and the idle heartbeat needs 90s of silence. A feed load that started on
+  /// a bad socket was therefore guaranteed to burn its caller's full deadline
+  /// and show an empty screen, which is what made Android — where radio
+  /// transitions produce those sockets far more often — time out ~8x more than
+  /// iOS on the same code.
+  ///
+  /// The default sits far above a healthy relay's round-trip (a few hundred ms)
+  /// and well below the app's 30s feed deadline, so a repair still leaves the
+  /// re-issued REQ most of the window to be answered. Injectable so tests need
+  /// no wall-clock wait.
+  ///
+  /// [minSubscriptionAgeBeforeRepair] has no counterpart here: teardown cancels
+  /// the probe, so a feed the user left inside the relay's round-trip time is
+  /// never judged at all rather than being judged and then excused.
+  Duration subscriptionSilenceProbe;
 
   /// Controls whether [_dispatchTypedFrame] performs expensive Schnorr
   /// verification. The event id is always recomputed first; policy skips only
@@ -522,6 +550,12 @@ class RelayPool {
     }
     _tempRelaySweepTimer?.cancel();
     _tempRelaySweepTimer = null;
+    // Nothing left to repair, and a probe outliving the pool would fire into
+    // an empty relay set on every armed subscription.
+    for (final probe in _subscriptionSilenceProbes.values) {
+      probe.cancel();
+    }
+    _subscriptionSilenceProbes.clear();
   }
 
   /// Drops the pool-side state keyed by [url] so a relay that comes back is
@@ -1101,6 +1135,65 @@ class RelayPool {
     _repairSilentRelays(silent, sentAt);
   }
 
+  /// [_repairRelaysThatNeverServedSubscription], run *while* the subscription
+  /// is still live instead of at its teardown.
+  ///
+  /// Teardown-time repair only helps the next load; the one the user is
+  /// watching has already failed by then. Probing at
+  /// [subscriptionSilenceProbe] applies the same evidence — this relay was
+  /// sent the REQ and has sent nothing back since — early enough that the
+  /// re-issued REQ can still land inside the caller's deadline.
+  ///
+  /// Two shapes of "sent nothing back" are repaired, because from the caller's
+  /// side they are the same failure:
+  ///
+  /// - **Connected but silent**: the half-open zombie [_repairSilentRelays]
+  ///   already handles. Its own filters apply here unchanged, so a relay that
+  ///   streamed events or EOSE'd is left alone and [silentRepairCooldown]
+  ///   still rate-limits per relay.
+  /// - **Not connected**: the REQ was queued rather than written, because
+  ///   [relayDoSubscribe] sends with `skipReconnect`. Nothing periodic
+  ///   reconnects relays, so without this the frame sits in `pendingMessages`
+  ///   until some unrelated event happens to reconnect the socket.
+  void _probeSubscriptionSilence(String subId) {
+    _subscriptionSilenceProbes.remove(subId);
+    if (!_subscriptions.containsKey(subId)) return;
+    final sentAt = _subscriptionSentAt[subId];
+    if (sentAt == null) return;
+
+    final silent = <String>[];
+    final dropped = <Relay>[];
+    for (final relay in [
+      ..._relaysSnapshot(),
+      ..._tempRelaysSnapshot(),
+      ..._cacheRelaysSnapshot(),
+    ]) {
+      if (!relay.hasSubscriptionById(subId)) continue;
+      if (relay.relayStatus.connected == ClientConnected.connected) {
+        silent.add(relay.url);
+      } else {
+        dropped.add(relay);
+      }
+    }
+
+    if (silent.isNotEmpty) _repairSilentRelays(silent, sentAt);
+    for (final relay in dropped) {
+      log(
+        '📡 ${relay.url} was sent subscription $subId while disconnected and '
+        'has not reconnected; connecting so the queued REQ is written',
+      );
+      unawaited(_reconnectDroppedRelay(relay));
+    }
+  }
+
+  Future<void> _reconnectDroppedRelay(Relay relay) async {
+    try {
+      await relay.connect();
+    } catch (e) {
+      log('dropped-relay reconnect failed for ${relay.url}: $e');
+    }
+  }
+
   /// Releases the one-shot queries [relay] is parked on once it can no longer
   /// answer them.
   ///
@@ -1644,6 +1737,12 @@ class RelayPool {
       }
     }
 
+    _subscriptionSilenceProbes[subscription.id]?.cancel();
+    _subscriptionSilenceProbes[subscription.id] = Timer(
+      subscriptionSilenceProbe,
+      () => _probeSubscriptionSilence(subscription.id),
+    );
+
     return subscription.id;
   }
 
@@ -1703,6 +1802,7 @@ class RelayPool {
   }
 
   void unsubscribe(String id) {
+    _subscriptionSilenceProbes.remove(id)?.cancel();
     final subscription = _subscriptions.remove(id);
     // Clean up EOSE tracking for this subscription
     _subscriptionEoseRelays.remove(id);

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -1154,7 +1154,10 @@ class RelayPool {
   /// - **Not connected**: the REQ was queued rather than written, because
   ///   [relayDoSubscribe] sends with `skipReconnect`. Nothing periodic
   ///   reconnects relays, so without this the frame sits in `pendingMessages`
-  ///   until some unrelated event happens to reconnect the socket.
+  ///   until some unrelated event happens to reconnect the socket. This branch
+  ///   is not gated by [silentRepairCooldown]; it is bounded instead by the
+  ///   probe being one-shot per subscription and by [Relay.connect] no-opping a
+  ///   relay that is already connected or connecting.
   void _probeSubscriptionSilence(String subId) {
     _subscriptionSilenceProbes.remove(subId);
     if (!_subscriptions.containsKey(subId)) return;

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -1194,6 +1194,14 @@ class RelayPool {
     }
   }
 
+  /// Subscription ids that still have a silence probe armed. Tests assert on
+  /// this to prove [unsubscribe] disarms the probe, rather than leaning on the
+  /// [_probeSubscriptionSilence] no-op guard — which would leave a dropped
+  /// `.cancel()` invisible behind a leaked one-shot timer.
+  @visibleForTesting
+  List<String> get armedSilenceProbeSubscriptionIds =>
+      _subscriptionSilenceProbes.keys.toList(growable: false);
+
   /// Releases the one-shot queries [relay] is parked on once it can no longer
   /// answer them.
   ///

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_subscription_silence_probe_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_subscription_silence_probe_test.dart
@@ -165,5 +165,64 @@ void main() {
             'exits from churning healthy connections',
       );
     });
+
+    test(
+      'cycles only the silent relay, sparing a sibling that answered',
+      () async {
+        final signer = LocalNostrSigner(
+          '5ee1c8000ab28edd64d74a7d951ac2dd559814887b1b9e1ac7c5f89e96125c12',
+        );
+        nostr = Nostr(signer, [], (url) => RelayBase(url, RelayStatus(url)));
+        await nostr.refreshPublicKey();
+
+        const answeredUrl = 'wss://answered.divine.video';
+        const silentUrl = 'wss://silent.divine.video';
+        final answeredFactory = FakeWebSocketChannelFactory();
+        final silentFactory = FakeWebSocketChannelFactory();
+        await nostr.relayPool.add(
+          RelayBase(
+            answeredUrl,
+            RelayStatus(answeredUrl),
+            channelFactory: answeredFactory,
+          ),
+        );
+        await nostr.relayPool.add(
+          RelayBase(
+            silentUrl,
+            RelayStatus(silentUrl),
+            channelFactory: silentFactory,
+          ),
+        );
+        nostr.relayPool.subscriptionSilenceProbe = probe;
+
+        final subId = subscribeToFeed();
+        await Future<void>.delayed(Duration.zero);
+        expect(
+          _reqFrames(answeredFactory.createdChannels.single),
+          hasLength(1),
+        );
+        expect(_reqFrames(silentFactory.createdChannels.single), hasLength(1));
+
+        // Only the first relay answers; the second stays a silent zombie.
+        answeredFactory.createdChannels.single.simulateMessage(
+          jsonEncode(['EOSE', subId]),
+        );
+
+        await Future<void>.delayed(afterProbe);
+
+        expect(
+          silentFactory.createdChannels,
+          hasLength(2),
+          reason: 'the silent relay is the one the probe must cycle',
+        );
+        expect(
+          answeredFactory.createdChannels,
+          hasLength(1),
+          reason:
+              "a relay that EOSE'd is healthy and must not be cycled, even "
+              'while a sibling on the same load is being repaired',
+        );
+      },
+    );
   });
 }

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_subscription_silence_probe_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_subscription_silence_probe_test.dart
@@ -1,0 +1,156 @@
+// ABOUTME: Regression tests for the in-flight silence probe that repairs a
+// ABOUTME: relay which never answered a live subscription's REQ (#7301).
+
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nostr_sdk/nostr_sdk.dart';
+
+import '../support/fake_web_socket.dart';
+
+List<List<dynamic>> _reqFrames(FakeWebSocketChannel channel) => channel
+    .sentMessages
+    .map((m) => jsonDecode(m as String) as List<dynamic>)
+    .where((m) => m.first == 'REQ')
+    .toList();
+
+void main() {
+  group('RelayPool in-flight subscription silence probe', () {
+    const relayUrl = 'wss://relay.divine.video';
+    const probe = Duration(milliseconds: 20);
+    // Comfortably past [probe] plus the reconnect's own async hops.
+    const afterProbe = Duration(milliseconds: 80);
+
+    late Nostr nostr;
+    late FakeWebSocketChannelFactory factory;
+
+    Future<void> setUpPool({Object? initialConnectError}) async {
+      final signer = LocalNostrSigner(
+        '5ee1c8000ab28edd64d74a7d951ac2dd559814887b1b9e1ac7c5f89e96125c12',
+      );
+      nostr = Nostr(signer, [], (url) => RelayBase(url, RelayStatus(url)));
+      await nostr.refreshPublicKey();
+      factory = FakeWebSocketChannelFactory(readyError: initialConnectError);
+      await nostr.relayPool.add(
+        RelayBase(relayUrl, RelayStatus(relayUrl), channelFactory: factory),
+      );
+      nostr.relayPool.subscriptionSilenceProbe = probe;
+    }
+
+    String subscribeToFeed() => nostr.subscribe([
+      {
+        'kinds': [34236],
+      },
+    ], (_) {});
+
+    test('a relay that swallowed the REQ is force-reconnected while the '
+        'subscription is still live', () async {
+      await setUpPool();
+      final zombieChannel = factory.createdChannels.single;
+
+      final subId = subscribeToFeed();
+      await Future<void>.delayed(Duration.zero);
+      expect(_reqFrames(zombieChannel), hasLength(1));
+
+      // No unsubscribe: the caller is still waiting on this feed load.
+      await Future<void>.delayed(afterProbe);
+
+      expect(
+        factory.createdChannels,
+        hasLength(2),
+        reason:
+            'the socket must be cycled inside the load window, not at the '
+            'teardown that follows the caller giving up',
+      );
+      expect(
+        _reqFrames(factory.createdChannels.last).map((frame) => frame[1]),
+        [subId],
+        reason: 'the re-issued REQ is what lets the load still succeed',
+      );
+    });
+
+    test('a relay that answered the subscription is left alone', () async {
+      await setUpPool();
+      final channel = factory.createdChannels.single;
+
+      final subId = subscribeToFeed();
+      await Future<void>.delayed(Duration.zero);
+      channel.simulateMessage(jsonEncode(['EOSE', subId]));
+
+      await Future<void>.delayed(afterProbe);
+
+      expect(
+        factory.createdChannels,
+        hasLength(1),
+        reason: 'an EOSE-ing relay is healthy and must not be cycled',
+      );
+    });
+
+    test('a relay that stays inbound-active is left alone — silence '
+        'discriminates zombie from slow', () async {
+      await setUpPool();
+      final channel = factory.createdChannels.single;
+
+      subscribeToFeed();
+      await Future<void>.delayed(Duration.zero);
+      // Nothing for our REQ, but the connection is demonstrably alive.
+      channel.simulateMessage(jsonEncode(['NOTICE', 'busy']));
+
+      await Future<void>.delayed(afterProbe);
+
+      expect(
+        factory.createdChannels,
+        hasLength(1),
+        reason: 'an inbound-active connection must not be cycled',
+      );
+    });
+
+    test('a relay that was disconnected when the REQ was queued is '
+        'reconnected so the frame is written', () async {
+      // The REQ is sent with `skipReconnect`, so a subscription issued while
+      // the socket is down only ever reaches `pendingMessages`.
+      await setUpPool(initialConnectError: Exception('connect failed'));
+      expect(factory.createdChannels, hasLength(1));
+      expect(_reqFrames(factory.createdChannels.single), isEmpty);
+
+      final subId = subscribeToFeed();
+      await Future<void>.delayed(Duration.zero);
+      expect(
+        _reqFrames(factory.createdChannels.single),
+        isEmpty,
+        reason: 'nothing can be written to a socket that never opened',
+      );
+
+      // The network came back; nothing periodic would have noticed.
+      factory.readyError = null;
+      await Future<void>.delayed(afterProbe);
+
+      expect(factory.createdChannels, hasLength(2));
+      expect(
+        _reqFrames(factory.createdChannels.last).map((frame) => frame[1]),
+        [subId],
+        reason: 'the queued REQ must be written on the reconnected socket',
+      );
+    });
+
+    test('a subscription torn down before the probe fires never charges the '
+        'socket', () async {
+      await setUpPool();
+
+      final subId = subscribeToFeed();
+      await Future<void>.delayed(Duration.zero);
+
+      // The user left the screen inside the relay's round-trip time.
+      nostr.unsubscribe(subId);
+      await Future<void>.delayed(afterProbe);
+
+      expect(
+        factory.createdChannels,
+        hasLength(1),
+        reason:
+            'teardown cancels the probe, which is what keeps navigation-speed '
+            'exits from churning healthy connections',
+      );
+    });
+  });
+}

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_subscription_silence_probe_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_subscription_silence_probe_test.dart
@@ -139,9 +139,22 @@ void main() {
 
       final subId = subscribeToFeed();
       await Future<void>.delayed(Duration.zero);
+      expect(
+        nostr.relayPool.armedSilenceProbeSubscriptionIds,
+        [subId],
+        reason: 'the probe is armed while the load is live',
+      );
 
       // The user left the screen inside the relay's round-trip time.
       nostr.unsubscribe(subId);
+      expect(
+        nostr.relayPool.armedSilenceProbeSubscriptionIds,
+        isEmpty,
+        reason:
+            'teardown disarms the probe; without this a torn-down load leaks '
+            'a live timer that a same-id re-subscribe could let cycle a '
+            'healthy connection',
+      );
       await Future<void>.delayed(afterProbe);
 
       expect(


### PR DESCRIPTION
## Description

A feed load's only backstop is the 30s timer in `VideoEventService`, and inside that window nothing could detect or repair a relay that never answered the REQ:

- `relayDoSubscribe` sends with `skipReconnect: true`, so a disconnected socket queues the frame and returns `false` — a value `subscribe()` never inspects.
- A half-open socket accepts the REQ into a dead TCP connection and answers nothing.
- `WebSocketConfig.idleTimeout` is 90s, so the idle heartbeat cannot fire in time.
- `RelayManager.retryDisconnectedRelays` is event-driven, not periodic.
- `_repairRelaysThatNeverServedSubscription` runs only from `unsubscribe`, i.e. after the deadline has already expired.

So a load that started on a bad socket was **guaranteed** to burn the full 30s and show an empty screen. The repair machinery already existed; it just ran one step too late to help the load the user was actually watching.

Android produces those sockets far more often, which is why the same platform-neutral Dart code costs it ~8x more — 4.4% of loads against 0.5% on iOS, concentrated on LTE (8.2%) versus Wi-Fi (3.7%), worst on Viettel/VN at 12.7%.

This PR arms a one-shot silence probe per subscription that runs the same repair **while the load is still live**. Two shapes of "sent nothing back" are handled, because from the caller's side they are the same failure: connected-but-silent relays go through `_repairSilentRelays` unchanged, and disconnected relays get a `connect()` so the queued REQ is finally written. Either path re-issues the REQ via `Relay.onConnected` with most of the caller's window left.

### Why these choices

**Why 8s.** Calibrated against 1.0.19 release traces rather than picked: 5.3% of Android loads that *were* answered took longer than 8s. Those get their REQ re-issued rather than lost, and a fresh socket answers a stored query well inside the remaining ~22s — so the trade is a small risk of restarting a slow-but-working load against removing a guaranteed 30s dead wait. This is the main thing worth watching on device.

**Why no age floor.** `minSubscriptionAgeBeforeRepair` exists so a navigation-speed teardown does not force-cycle a healthy relay. The probe needs no counterpart: teardown cancels it, so a feed the user left inside the relay's round-trip time is never judged at all rather than being judged and then excused.

**Why churn is bounded.** For the connected branch, `_repairSilentRelays`' own filters apply unchanged — a relay that streamed events or EOSE'd stamped its activity clock and is skipped, `silentRepairCooldown` caps repairs at one per relay per 60s, and `_silentRelayRepairsInFlight` collapses concurrent repairs of the same URL. The 60s cooldown also means the existing teardown-time repair cannot double-cycle a relay this probe already handled. Those three gate only that branch; the disconnected branch is bounded instead by the probe being one-shot per subscription and by `Relay.connect` no-opping a relay that is already connected or connecting.

**Why an auth-required relay is not cycled mid-handshake.** A reconnect resets `relayStatus.authed`, so cycling an auth relay costs it a full NIP-42 round trip including the signer. It cannot happen to a relay that is still talking to us: every inbound frame stamps the activity clock in `WebSocketConnectionManager._onMessage`, and both an `AUTH` challenge and a `CLOSED … auth-required` are inbound frames, so `isSilentSince(sentAt)` excludes the relay. What is left is a relay that answers an unauthed REQ with pure silence while a handshake that started *before* the REQ is still out at the signer. That handshake is by then more than 8s old, and `authHandshakeWindow` is 3s — the pool already treats it as not going to settle (`_canStillSettleQuery`), so cycling matches the existing policy, and the cost lands on a relay that had returned nothing at all.

### Two corrections to the issue's data

The issue states every `timeout` sample sits at 30,003–30,043 ms. It does not — the bucket ranges from 47 ms to 572 s. Splitting by whether a duration is physically possible for a 30s timer:

| | <29.9s (impossible) | 29.9–30.2s (real) | >30.2s (impossible) |
|---|---|---|---|
| Android | 26 | **91** | 5 |
| iOS | 7 | **9** | 3 |

So the real rates are Android 4.4% and iOS 0.52% — an ~8x gap rather than 5x — and roughly a quarter of Android's bucket is exactly the name-keyed-trace mis-attribution the issue suspected. #7132 and #7268 already fix that, but neither is released.

The issue also asks for the split to be re-checked against 1.0.20 before committing to a fix. That is not possible: 1.0.20 has zero rows in `firebase_performance`, and #7126, #7132 and #7268 all landed after the 1.0.19 tag.

**Related Issue:** Relates to #7301 — this is the `timeout` half only, so it deliberately does not close the issue.

## Out of Scope

`eose_empty` (the other ~5.9%). The issue is explicit that it is a correct fast path with the wrong UI treatment, that the fix is copy plus a retry affordance rather than a networking change, and that the two should not be fixed together.

## Verification

- New: `packages/nostr_sdk/test/unit/relay_pool_subscription_silence_probe_test.dart` — 6 tests covering the zombie repair, the disconnected re-send, per-relay discrimination (cycle the silent relay, spare a sibling that EOSE'd in the same pass), and the three cases that must **not** cycle a socket (EOSE'd, inbound-active, and torn down before the probe — which also asserts teardown disarms the probe rather than relying on the no-op guard). Confirmed the behavioural tests go red when the probe is removed.
- `flutter test` in `packages/nostr_sdk` — 519 passed at head `a2c0a4c` (includes the existing zombie/query/settle suites, which pin the repair filters this reuses).
- `flutter test` in `packages/nostr_client` — 338 passed.
- `flutter test test/services/feed_load_trace_test.dart test/services/video_event_service_*.dart` — passed.
- `flutter analyze` and `dart format` — clean.
- Device verification on a real Samsung Galaxy: **done** — feed loading exercised on device, no regression seen.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

