### PR TITLE
fix(profile): drop NIP-05 host exceptions from the profile checkmark

### DIFF
--- a/mobile/lib/widgets/special_profile_checkmark.dart
+++ b/mobile/lib/widgets/special_profile_checkmark.dart
@@ -1,4 +1,4 @@
-// ABOUTME: Hosts explicit exceptions for profile checkmark display.
+// ABOUTME: Pubkey allowlist that drives profile checkmark display.
 // ABOUTME: Keeps special-case badges separate from generic NIP-05 validation.
 
 import 'package:divine_ui/divine_ui.dart';

--- a/mobile/lib/widgets/special_profile_checkmark.dart
+++ b/mobile/lib/widgets/special_profile_checkmark.dart
@@ -6,40 +6,19 @@ import 'package:flutter/material.dart';
 import 'package:models/models.dart';
 import 'package:openvine/l10n/l10n.dart';
 
-const _specialProfileHosts = {
-  'kirstenswasey.divine.video',
-  'rabble.divine.video',
-};
-
+/// Accounts that carry the Divine profile checkmark, identified by pubkey.
+///
+/// Pubkey-only on purpose. Matching a NIP-05 host instead ties the checkmark
+/// to a name the server can reassign, so it would follow the handle to
+/// whoever claims it next rather than staying with the account it was
+/// granted to.
 const _specialProfilePubkeys = {
   'aa50001ef150418f30f62f827399d5c26a5ade52ab45ca4849f99b1726bb47b4',
 };
 
 bool shouldShowSpecialProfileCheckmark(UserProfile? profile) {
   if (profile == null) return false;
-  return _specialProfilePubkeys.contains(profile.pubkey.toLowerCase()) ||
-      _matchesSpecialProfile(profile.nip05) ||
-      _matchesSpecialProfile(profile.displayNip05);
-}
-
-bool _matchesSpecialProfile(String? identifier) {
-  final host = _hostFromProfileIdentifier(identifier);
-  return _specialProfileHosts.contains(host);
-}
-
-String? _hostFromProfileIdentifier(String? identifier) {
-  if (identifier == null) return null;
-  final value = identifier.trim().toLowerCase();
-  if (value.isEmpty) return null;
-
-  final uri = Uri.tryParse(value);
-  if ((uri?.hasScheme ?? false) && uri!.host.isNotEmpty) {
-    return uri.host;
-  }
-
-  final atIndex = value.indexOf('@');
-  final hostLikeValue = atIndex == -1 ? value : value.substring(atIndex + 1);
-  return hostLikeValue.split('/').first;
+  return _specialProfilePubkeys.contains(profile.pubkey.toLowerCase());
 }
 
 class SpecialProfileCheckmark extends StatelessWidget {

--- a/mobile/lib/widgets/special_profile_checkmark.dart
+++ b/mobile/lib/widgets/special_profile_checkmark.dart
@@ -16,6 +16,9 @@ const _specialProfilePubkeys = {
   'aa50001ef150418f30f62f827399d5c26a5ade52ab45ca4849f99b1726bb47b4',
 };
 
+@visibleForTesting
+const Set<String> specialProfilePubkeys = _specialProfilePubkeys;
+
 bool shouldShowSpecialProfileCheckmark(UserProfile? profile) {
   if (profile == null) return false;
   return _specialProfilePubkeys.contains(profile.pubkey.toLowerCase());

--- a/mobile/test/widgets/profile/profile_header_widget_test.dart
+++ b/mobile/test/widgets/profile/profile_header_widget_test.dart
@@ -41,6 +41,7 @@ import 'package:openvine/widgets/profile/profile_action_buttons_widget.dart';
 import 'package:openvine/widgets/profile/profile_header_widget.dart';
 import 'package:openvine/widgets/profile/profile_stats_row_widget.dart';
 import 'package:openvine/widgets/profile/profile_website_row.dart';
+import 'package:openvine/widgets/special_profile_checkmark.dart';
 import 'package:openvine/widgets/user_avatar.dart';
 import 'package:openvine/widgets/user_profile_tile.dart';
 import 'package:openvine/widgets/vine_cached_image.dart';
@@ -197,11 +198,6 @@ class MockAuthService extends Mock implements AuthService {
 }
 
 const String testUserHex = syntheticTestPubkey;
-
-/// Pubkey on the profile-checkmark allowlist in
-/// `lib/widgets/special_profile_checkmark.dart`.
-const specialProfilePubkey =
-    'aa50001ef150418f30f62f827399d5c26a5ade52ab45ca4849f99b1726bb47b4';
 const issuerUserHex =
     '4f071cf08328c9d9dbb21f5d9d1e51fe2ecf4e7de5a4e59ecdf356f6a6f49f22';
 const recipientUserHex =
@@ -605,11 +601,11 @@ void main() {
 
       await tester.pumpWidget(
         buildTestWidget(
-          userIdHex: specialProfilePubkey,
+          userIdHex: specialProfilePubkeys.first,
           isOwnProfile: false,
           suppliedProfile: createTestProfile(
             displayName: 'Checked User',
-            pubkey: specialProfilePubkey,
+            pubkey: specialProfilePubkeys.first,
           ),
         ),
       );

--- a/mobile/test/widgets/profile/profile_header_widget_test.dart
+++ b/mobile/test/widgets/profile/profile_header_widget_test.dart
@@ -197,6 +197,11 @@ class MockAuthService extends Mock implements AuthService {
 }
 
 const String testUserHex = syntheticTestPubkey;
+
+/// Pubkey on the profile-checkmark allowlist in
+/// `lib/widgets/special_profile_checkmark.dart`.
+const specialProfilePubkey =
+    'aa50001ef150418f30f62f827399d5c26a5ade52ab45ca4849f99b1726bb47b4';
 const issuerUserHex =
     '4f071cf08328c9d9dbb21f5d9d1e51fe2ecf4e7de5a4e59ecdf356f6a6f49f22';
 const recipientUserHex =
@@ -277,9 +282,10 @@ void main() {
       Map<String, dynamic> rawData = const {},
       DateTime? createdAt,
       String eventId = 'test-event',
+      String pubkey = testUserHex,
     }) {
       return UserProfile(
-        pubkey: testUserHex,
+        pubkey: pubkey,
         rawData: {
           'display_name': ?displayName,
           'name': ?name,
@@ -599,11 +605,11 @@ void main() {
 
       await tester.pumpWidget(
         buildTestWidget(
-          userIdHex: testUserHex,
+          userIdHex: specialProfilePubkey,
           isOwnProfile: false,
           suppliedProfile: createTestProfile(
             displayName: 'Checked User',
-            nip05: 'rabble.divine.video',
+            pubkey: specialProfilePubkey,
           ),
         ),
       );

--- a/mobile/test/widgets/user_name_nip05_test.dart
+++ b/mobile/test/widgets/user_name_nip05_test.dart
@@ -59,34 +59,14 @@ void main() {
     expect(_specialCheckmark(), findsNothing);
   });
 
-  testWidgets('shows a checkmark for Kirsten Swasey special profile', (
+  testWidgets('does not show a checkmark for a divine.video NIP-05', (
     tester,
   ) async {
-    await tester.pumpWidget(
-      buildSubject(nip05: '_@kirstenswasey.divine.video'),
-    );
-    await tester.pump();
-
-    expect(find.text('Alice'), findsOneWidget);
-    expect(_specialCheckmark(), findsOneWidget);
-  });
-
-  testWidgets('matches the Kirsten Swasey profile URL host', (tester) async {
-    await tester.pumpWidget(
-      buildSubject(nip05: 'http://kirstenswasey.divine.video'),
-    );
-    await tester.pump();
-
-    expect(find.text('Alice'), findsOneWidget);
-    expect(_specialCheckmark(), findsOneWidget);
-  });
-
-  testWidgets('shows a checkmark for Rabble special profile', (tester) async {
     await tester.pumpWidget(buildSubject(nip05: '_@rabble.divine.video'));
     await tester.pump();
 
     expect(find.text('Alice'), findsOneWidget);
-    expect(_specialCheckmark(), findsOneWidget);
+    expect(_specialCheckmark(), findsNothing);
   });
 
   testWidgets('shows a checkmark for special profile pubkey', (tester) async {

--- a/mobile/test/widgets/user_name_nip05_test.dart
+++ b/mobile/test/widgets/user_name_nip05_test.dart
@@ -16,6 +16,11 @@ Finder _specialCheckmark() => find.byWidgetPredicate(
   (w) => w is DivineIcon && w.icon == DivineIconName.check,
 );
 
+/// Pubkey on the profile-checkmark allowlist in
+/// `lib/widgets/special_profile_checkmark.dart`.
+const _specialProfilePubkey =
+    'aa50001ef150418f30f62f827399d5c26a5ade52ab45ca4849f99b1726bb47b4';
+
 void main() {
   const defaultPubkey =
       'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789';
@@ -70,12 +75,7 @@ void main() {
   });
 
   testWidgets('shows a checkmark for special profile pubkey', (tester) async {
-    await tester.pumpWidget(
-      buildSubject(
-        pubkey:
-            'aa50001ef150418f30f62f827399d5c26a5ade52ab45ca4849f99b1726bb47b4',
-      ),
-    );
+    await tester.pumpWidget(buildSubject(pubkey: _specialProfilePubkey));
     await tester.pump();
 
     expect(find.text('Alice'), findsOneWidget);

--- a/mobile/test/widgets/user_name_nip05_test.dart
+++ b/mobile/test/widgets/user_name_nip05_test.dart
@@ -10,16 +10,12 @@ import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/nip05_verification_provider.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/services/nip05_verification_service.dart';
+import 'package:openvine/widgets/special_profile_checkmark.dart';
 import 'package:openvine/widgets/user_name.dart';
 
 Finder _specialCheckmark() => find.byWidgetPredicate(
   (w) => w is DivineIcon && w.icon == DivineIconName.check,
 );
-
-/// Pubkey on the profile-checkmark allowlist in
-/// `lib/widgets/special_profile_checkmark.dart`.
-const _specialProfilePubkey =
-    'aa50001ef150418f30f62f827399d5c26a5ade52ab45ca4849f99b1726bb47b4';
 
 void main() {
   const defaultPubkey =
@@ -75,7 +71,7 @@ void main() {
   });
 
   testWidgets('shows a checkmark for special profile pubkey', (tester) async {
-    await tester.pumpWidget(buildSubject(pubkey: _specialProfilePubkey));
+    await tester.pumpWidget(buildSubject(pubkey: specialProfilePubkeys.first));
     await tester.pump();
 
     expect(find.text('Alice'), findsOneWidget);

--- a/mobile/test/widgets/video_feed_item/video_overlay_actions_description_test.dart
+++ b/mobile/test/widgets/video_feed_item/video_overlay_actions_description_test.dart
@@ -26,6 +26,11 @@ Finder _specialCheckmark() => find.byWidgetPredicate(
   (w) => w is DivineIcon && w.icon == DivineIconName.check,
 );
 
+/// Pubkey on the profile-checkmark allowlist in
+/// `lib/widgets/special_profile_checkmark.dart`.
+const _specialProfilePubkey =
+    'aa50001ef150418f30f62f827399d5c26a5ade52ab45ca4849f99b1726bb47b4';
+
 class _MockVideoInteractionsBloc extends Mock
     implements VideoInteractionsBloc {}
 
@@ -184,10 +189,12 @@ void main() {
   });
 
   testWidgets(
-    'author line shows checkmark for Kirsten Swasey special profile',
+    'author line shows checkmark for a special profile pubkey',
     (
       tester,
     ) async {
+      testVideo = testVideo.copyWith(pubkey: _specialProfilePubkey);
+
       await tester.pumpWidget(
         testProviderScope(
           additionalOverrides: [
@@ -196,7 +203,7 @@ void main() {
               yield UserProfile(
                 pubkey: pubkey,
                 name: 'Alice',
-                nip05: '_@kirstenswasey.divine.video',
+                nip05: 'alice@example.com',
                 rawData: const {},
                 createdAt: DateTime(2026),
                 eventId: 'kind0_event_id',

--- a/mobile/test/widgets/video_feed_item/video_overlay_actions_description_test.dart
+++ b/mobile/test/widgets/video_feed_item/video_overlay_actions_description_test.dart
@@ -14,6 +14,7 @@ import 'package:openvine/providers/nip05_verification_provider.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/services/nip05_verification_service.dart';
 import 'package:openvine/utils/string_utils.dart';
+import 'package:openvine/widgets/special_profile_checkmark.dart';
 import 'package:openvine/widgets/video_feed_item/video_feed_item.dart';
 import 'package:reposts_repository/reposts_repository.dart';
 
@@ -25,11 +26,6 @@ AppLocalizations _l10n(WidgetTester tester) =>
 Finder _specialCheckmark() => find.byWidgetPredicate(
   (w) => w is DivineIcon && w.icon == DivineIconName.check,
 );
-
-/// Pubkey on the profile-checkmark allowlist in
-/// `lib/widgets/special_profile_checkmark.dart`.
-const _specialProfilePubkey =
-    'aa50001ef150418f30f62f827399d5c26a5ade52ab45ca4849f99b1726bb47b4';
 
 class _MockVideoInteractionsBloc extends Mock
     implements VideoInteractionsBloc {}
@@ -188,54 +184,51 @@ void main() {
     expect(_specialCheckmark(), findsNothing);
   });
 
-  testWidgets(
-    'author line shows checkmark for a special profile pubkey',
-    (
-      tester,
-    ) async {
-      testVideo = testVideo.copyWith(pubkey: _specialProfilePubkey);
+  testWidgets('author line shows checkmark for a special profile pubkey', (
+    tester,
+  ) async {
+    testVideo = testVideo.copyWith(pubkey: specialProfilePubkeys.first);
 
-      await tester.pumpWidget(
-        testProviderScope(
-          additionalOverrides: [
-            repostsRepositoryProvider.overrideWithValue(mockRepostsRepository),
-            userProfileReactiveProvider.overrideWith((ref, pubkey) async* {
-              yield UserProfile(
-                pubkey: pubkey,
-                name: 'Alice',
-                nip05: 'alice@example.com',
-                rawData: const {},
-                createdAt: DateTime(2026),
-                eventId: 'kind0_event_id',
-              );
-            }),
-            nip05VerificationProvider.overrideWith(
-              (ref, pubkey) async => Nip05VerificationStatus.verified,
-            ),
-          ],
-          child: MaterialApp(
-            localizationsDelegates: AppLocalizations.localizationsDelegates,
-            supportedLocales: AppLocalizations.supportedLocales,
-            home: Scaffold(
-              body: BlocProvider<VideoInteractionsBloc>.value(
-                value: mockInteractionsBloc,
-                child: VideoOverlayActions(
-                  video: testVideo,
-                  isVisible: true,
-                  isActive: true,
-                ),
+    await tester.pumpWidget(
+      testProviderScope(
+        additionalOverrides: [
+          repostsRepositoryProvider.overrideWithValue(mockRepostsRepository),
+          userProfileReactiveProvider.overrideWith((ref, pubkey) async* {
+            yield UserProfile(
+              pubkey: pubkey,
+              name: 'Alice',
+              nip05: 'alice@example.com',
+              rawData: const {},
+              createdAt: DateTime(2026),
+              eventId: 'kind0_event_id',
+            );
+          }),
+          nip05VerificationProvider.overrideWith(
+            (ref, pubkey) async => Nip05VerificationStatus.verified,
+          ),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: BlocProvider<VideoInteractionsBloc>.value(
+              value: mockInteractionsBloc,
+              child: VideoOverlayActions(
+                video: testVideo,
+                isVisible: true,
+                isActive: true,
               ),
             ),
           ),
         ),
-      );
+      ),
+    );
 
-      await tester.pumpAndSettle();
+    await tester.pumpAndSettle();
 
-      expect(find.text('Alice'), findsOneWidget);
-      expect(_specialCheckmark(), findsOneWidget);
-    },
-  );
+    expect(find.text('Alice'), findsOneWidget);
+    expect(_specialCheckmark(), findsOneWidget);
+  });
 
   testWidgets(
     'does not render a dedicated captions button in the action rail',


### PR DESCRIPTION
Closes #7372

## Description

The profile checkmark matched two hardcoded `*.divine.video` NIP-05 hosts (`kirstenswasey.divine.video`, `rabble.divine.video`) in addition to the pubkey allowlist. This removes the host matching. **It is a temporary removal, until we ship a verification mechanism people can actually understand and act on.**

### Why it is coming out now

The mark renders directly next to the NIP-05 identifier line, so it reads as "this NIP-05 is verified" — but only these two accounts ever had it, while everyone else with a perfectly valid, verified `*.divine.video` NIP-05 got nothing.

That has confused users repeatedly. People keep asking how they can get verified too, and there is no answer to give them: there is no application, no published criteria, and no backend behind the list. It is a `const` in the app binary, so the only way onto it is a PR plus a release. One of the two marked accounts also said in Discord that they do not understand why they have it. A verification signal its own recipients cannot explain is not doing the job it was added for.

#3445 already removed the generic NIP-05 checkmark for the same reason; the two host exceptions kept the misleading signal alive for two accounts.

### Why the host rule is also the wrong anchor

The host is a name `divine-name-server` hands out and can reassign. A host rule therefore follows the handle to whoever claims it next, rather than staying with the account the mark was granted to.

### What changed

The host set is gone and matching runs against the pubkey allowlist only. The host-parsing helpers (`_matchesSpecialProfile`, `_hostFromProfileIdentifier`) had no other callers and are removed with it.

User-visible effect: the two accounts behind those handles lose the checkmark. No other surface changes — NIP-05 identifier text, NIP-39 verified account links, NIP-58 badges and OG Viner status are all separate and untouched.

**Related Issue:** #6154

## Out of Scope

- **The real fix.** Tracked in #6154, which is already parked on a product decision: what "verified" authoritatively means and what should drive the mark — published criteria, a self-serve flow, or a backend-owned `verified` flag. This PR does not attempt that; it only stops showing a signal we cannot explain to the people asking about it. One tension to settle there: #6154 reports users who completed a verification flow were *told* they would get a checkmark, and its short-term option (a) was to add their pubkeys to the allowlist — the opposite direction from this PR. Removing an unexplainable mark and honouring a promise already made are both defensible; that call belongs in #6154, not here.
- The remaining pubkey entry (`aa50001e…bb47b4`, `npub14fgqq8h32pqc7v8k97p88xw4cf494hjj4dzu5jzflxd3wf4mg76qqd783l`) stays. Same open question applies to it, but you pointed at the host list, so that is what this PR touches.

## Verification

- `dart format` on the four changed files — no reflow
- `flutter analyze lib/widgets/special_profile_checkmark.dart test/widgets/user_name_nip05_test.dart test/widgets/video_feed_item/video_overlay_actions_description_test.dart test/widgets/profile/profile_header_widget_test.dart` — no issues
- `flutter test test/widgets/user_name_nip05_test.dart test/widgets/special_profile_checkmark_test.dart test/widgets/video_feed_item/video_overlay_actions_description_test.dart` — 11 passed
- `flutter test test/widgets/profile/profile_header_widget_test.dart` — 82 passed
- Test coverage rewired rather than deleted: the two feed/header tests that reached the checkmark through a host now reach it through the allowlisted pubkey, and `user_name_nip05_test.dart` gains a regression test that a `*.divine.video` NIP-05 renders no checkmark — so re-adding a host rule fails the suite.
- Two follow-up commits on top of the removal, both no-ops at runtime: the file-header `ABOUTME` still described the file as hosting NIP-05 host exceptions, and `user_name_nip05_test.dart` still carried the allowlisted pubkey as a bare literal while the two rewired tests got a named constant pointing back at the lib allowlist. Both aligned.
- Full CI green on the pushed head — analyze, format, generated files, all four test shards.
- Not yet verified on a real Samsung Galaxy.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] 🧹 Code refactor
