### PR TITLE
ci(preview): skip web preview build and deploy on draft PRs

### DIFF
--- a/.github/workflows/mobile_pr_preview_build.yml
+++ b/.github/workflows/mobile_pr_preview_build.yml
@@ -1,4 +1,4 @@
-# ABOUTME: Builds a Flutter web preview artifact for every divine-mobile pull request
+# ABOUTME: Builds a Flutter web preview artifact for every ready-for-review divine-mobile pull request
 # ABOUTME: Uploads a deployable artifact that a trusted workflow later pushes to Cloudflare Pages with Wrangler
 
 name: Mobile PR Preview Build
@@ -17,6 +17,9 @@ concurrency:
 jobs:
   build-preview:
     name: Build Flutter Web Preview
+    # Draft PRs get no preview. The ready_for_review trigger above builds the
+    # first preview the moment the PR leaves draft.
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-24.04
     permissions:
       contents: read

--- a/.github/workflows/mobile_pr_preview_deploy.yml
+++ b/.github/workflows/mobile_pr_preview_deploy.yml
@@ -69,17 +69,20 @@ jobs:
               pull_number: prNumber,
             });
 
-            const deployable = pr.state === 'open' && pr.head.sha === artifactSha;
+            const deployable =
+              pr.state === 'open' && !pr.draft && pr.head.sha === artifactSha;
 
             core.setOutput('deployable', deployable ? 'true' : 'false');
             core.setOutput('current_sha', pr.head.sha);
             core.setOutput('pr_state', pr.state);
+            core.setOutput('is_draft', pr.draft ? 'true' : 'false');
 
       - name: Skip stale preview artifact
         if: ${{ steps.freshness.outputs.deployable != 'true' }}
         run: |
           echo "Skipping stale preview artifact."
           echo "PR state: ${{ steps.freshness.outputs.pr_state }}"
+          echo "PR draft: ${{ steps.freshness.outputs.is_draft }}"
           echo "Artifact SHA: ${{ steps.metadata.outputs.head_sha }}"
           echo "Current PR SHA: ${{ steps.freshness.outputs.current_sha }}"
 


### PR DESCRIPTION
Closes #7374

## Description

Draft PRs received a Cloudflare Pages deploy and a `## Mobile PR Preview` comment on every push. That is noise while the work is still in progress, and it spends a full Flutter web release build per commit on a link nobody is meant to open yet.

Two gates:

- **`mobile_pr_preview_build.yml`** — the build job is now gated on `!github.event.pull_request.draft`. The trigger list already contains `ready_for_review`, so the first preview is produced the moment the PR leaves draft. With no artifact uploaded, the `workflow_run`-driven deploy never starts, so no deploy and no comment.
- **`mobile_pr_preview_deploy.yml`** — the freshness step already fetches the PR via the API, so it now also checks `!pr.draft`. This covers the race where a PR is converted back to draft while its build is still in flight; without it the deploy would still post a link afterwards. `is_draft` is echoed in the skip log so a skipped deploy is self-explaining.

Gating the build (rather than only the comment step) is deliberate: the expensive part is the Flutter web release build, and skipping it is what actually saves CI time. Gating only the deploy would keep paying for the build on every draft push.

**Related Issue:** 

## Out of Scope

A preview comment that was already posted stays visible if the PR is converted to draft afterwards — it is only collapsed as outdated on the next successful deploy. Retiring it eagerly would need a separate `converted_to_draft` trigger, which is not included here.

## Verification

- Workflows-only change; no Dart or app code touched, so no device verification applies.
- All PR checks green (Analyze, Format, Generated Files, Tests shards 0–3, Mobile CI, VGV Tag Gate, mergeability, semantic-pull-request).
- `git push` pre-push hooks green (merge-conflict check, package coverage floor, backend-host defaults).
- Note: this PR cannot exercise the changed workflow itself — `Mobile PR Preview Build` has a `paths: mobile/**` filter and this diff only touches `.github/`, so the workflow does not trigger here either way. The gate is verified on the next PR that touches `mobile/**`: no preview comment while it is a draft, and exactly one comment once it is marked ready for review.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [x] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore