### PR TITLE
fix(dm): re-drive the parked row when a reel reply retry is tapped

### DIFF
--- a/.github/workflows/mobile_service_integration_tests.yaml
+++ b/.github/workflows/mobile_service_integration_tests.yaml
@@ -63,8 +63,8 @@ jobs:
       #
       # The list is explicit rather than a glob over integration_test/e2e/,
       # because `service` and "runnable on a Linux CI runner" are different
-      # axes. Every suite in that directory is tagged `service`; these three
-      # are the ones this runner can actually execute. The other three are
+      # axes. Every suite in that directory is tagged `service`; these four
+      # are the ones this runner can actually execute. The remaining four are
       # excluded
       # for reasons no workflow change can fix:
       #
@@ -84,6 +84,7 @@ jobs:
           for suite in \
             integration_test/e2e/relay_list_admission_test.dart \
             integration_test/e2e/dm_inbox_relay_admission_test.dart \
+            integration_test/e2e/reel_reply_retry_double_send_test.dart \
             integration_test/e2e/block_leaves_kind3_follow_test.dart; do
             echo "── $suite"
             xvfb-run -a flutter test "$suite" --tags service -d linux

--- a/mobile/integration_test/e2e/reel_reply_retry_double_send_test.dart
+++ b/mobile/integration_test/e2e/reel_reply_retry_double_send_test.dart
@@ -70,10 +70,7 @@ void main() {
 
   final replyContext = DmReplyContext(
     conversationId: DmRepository.computeConversationId(
-      [
-        senderPubkey,
-        recipientPubkey,
-      ]..sort(),
+      [senderPubkey, recipientPubkey]..sort(),
     ),
     participantPubkeys: [recipientPubkey],
     isGroup: false,
@@ -281,129 +278,6 @@ void main() {
         );
       },
       timeout: const Timeout(Duration(minutes: 3)),
-    );
-
-    testWidgets(
-      'receiver side: two rumor ids render twice, one rumor re-wrapped '
-      'renders once',
-      (tester) async {
-        // Closes the last inferential step of the test above. That one proves
-        // the sender queues two rumor ids; this one proves what the RECEIVER
-        // does with them, against the real `direct_messages` schema.
-        //
-        // The contrast is the point. NIP-59 gives every gift wrap a fresh
-        // ephemeral key and a randomised `created_at` (59.md: "All other
-        // timestamps SHOULD be tweaked"), so the wrap id is never stable
-        // across a retry — the rumor id is the only handle a receiver has.
-        // `recoverFullSend` replays the SAME rumor and collapses; `sendMessage`
-        // mints a new one and cannot.
-        final db = AppDatabase.test(NativeDatabase.memory());
-        addTearDown(db.close);
-
-        const conversationId = 'receiver-side-convo';
-        const text = 'reel reply probe';
-
-        // Timestamps model the real timeline. The rumor's `created_at` is the
-        // canonical one (NIP-59: "The canonical created_at time belongs to the
-        // rumor"), and the retry's rumor is minted only after the 10s
-        // DmSendBudget.recipientOkConfirm window has expired and the user has
-        // tapped — so the two are ≥10s apart, never the same instant.
-        const firstCreatedAt = 1786700000;
-        const retryCreatedAt = firstCreatedAt + 13;
-
-        Future<bool> ingest({
-          required String rumorId,
-          required String giftWrapId,
-          required int createdAt,
-        }) => db.directMessagesDao.insertMessage(
-          id: rumorId,
-          conversationId: conversationId,
-          senderPubkey: senderPubkey,
-          content: text,
-          createdAt: createdAt,
-          giftWrapId: giftWrapId,
-          replyToId: reelMessageId,
-          ownerPubkey: recipientPubkey,
-        );
-
-        // Correct retry: one rumor, re-wrapped. Two wrap ids, one rumor id.
-        expect(
-          await ingest(
-            rumorId: 'a' * 64,
-            giftWrapId: 'w' * 64,
-            createdAt: firstCreatedAt,
-          ),
-          isTrue,
-        );
-        expect(
-          await ingest(
-            rumorId: 'a' * 64,
-            giftWrapId: 'x' * 64,
-            createdAt: firstCreatedAt,
-          ),
-          isFalse,
-          reason: 'a re-wrapped replay of the same rumor must not insert again',
-        );
-
-        var rendered = await db.directMessagesDao.getMessagesForConversation(
-          conversationId,
-        );
-        logPhase('same rumor id, two wraps -> ${rendered.length} bubble(s)');
-        expect(rendered, hasLength(1));
-
-        // The receive path has one more collapse mechanism above this insert:
-        // `hasMatchingMessage`, a (conversation, sender, content, ±5s) check
-        // run on every NIP-17 receive (dm_repository.dart:1910). It is the
-        // only thing that could catch a re-minted rumor — and it cannot reach
-        // this case, because the retry is ≥10s later by construction. Assert
-        // both halves so a future widening of that window is caught here.
-        expect(
-          await db.directMessagesDao.hasMatchingMessage(
-            conversationId: conversationId,
-            senderPubkey: senderPubkey,
-            content: text,
-            createdAt: retryCreatedAt,
-            ownerPubkey: recipientPubkey,
-          ),
-          isFalse,
-          reason: '13s apart is outside the ±5s window — nothing collapses it',
-        );
-        expect(
-          await db.directMessagesDao.hasMatchingMessage(
-            conversationId: conversationId,
-            senderPubkey: senderPubkey,
-            content: text,
-            createdAt: firstCreatedAt + 4,
-            ownerPubkey: recipientPubkey,
-          ),
-          isTrue,
-          reason: 'positive control: the ±5s window does fire inside 5s',
-        );
-
-        // The bug: a second rumor for the same text. Nothing collapses it.
-        expect(
-          await ingest(
-            rumorId: 'b' * 64,
-            giftWrapId: 'y' * 64,
-            createdAt: retryCreatedAt,
-          ),
-          isTrue,
-        );
-
-        rendered = await db.directMessagesDao.getMessagesForConversation(
-          conversationId,
-        );
-        logPhase('two rumor ids -> ${rendered.length} bubble(s)');
-        for (final row in rendered) {
-          logPhase('  bubble id=${row.id} content="${row.content}"');
-        }
-        expect(
-          rendered,
-          hasLength(2),
-          reason: 'two rumor ids for one message render as two bubbles',
-        );
-        expect(rendered.map((m) => m.content).toSet(), {text});
-      },
     );
   });
 }

--- a/mobile/integration_test/e2e/reel_reply_retry_double_send_test.dart
+++ b/mobile/integration_test/e2e/reel_reply_retry_double_send_test.dart
@@ -1,0 +1,409 @@
+// ABOUTME: E2E regression for #7316 — tapping Retry on a failed reel DM reply
+// ABOUTME: must re-drive the parked outgoing_dms row, never mint a second
+// ABOUTME: rumor the recipient would render as a second message.
+// ABOUTME: Drives the real ReelDmReplyBar + InlineReelReplyCubit + DmRepository
+// ABOUTME: over a real socket to an in-process relay.
+// ABOUTME: Requires: NO Docker stack — every dependency here is local.
+
+@Tags(['service'])
+library;
+
+import 'package:analytics/analytics.dart';
+import 'package:db_client/db_client.dart';
+import 'package:dm_repository/dm_repository.dart';
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/client_utils/keys.dart';
+import 'package:nostr_sdk/nostr.dart';
+import 'package:nostr_sdk/relay/relay_base.dart';
+import 'package:nostr_sdk/relay/relay_status.dart';
+import 'package:nostr_sdk/relay/web_socket_connection_manager.dart';
+import 'package:nostr_sdk/signer/local_nostr_signer.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/providers/analytics_providers.dart';
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/screens/feed/dm_reply_context.dart';
+import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/widgets/video_feed_item/reel_dm_reply_bar.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+import '../helpers/fake_relay.dart';
+import '../helpers/navigation_helpers.dart';
+import '../helpers/test_setup.dart';
+
+class _MockDmReactionsRepository extends Mock
+    implements DmReactionsRepository {}
+
+class _MockAuthService extends Mock implements AuthService {}
+
+class _MockScreenAnalyticsService extends Mock
+    implements ScreenAnalyticsService {}
+
+/// Points every dialed address at the in-process relay.
+class _RedirectFactory implements WebSocketChannelFactory {
+  _RedirectFactory(this.port);
+
+  final int port;
+
+  @override
+  WebSocketChannel create(Uri uri) =>
+      WebSocketChannel.connect(Uri.parse('ws://127.0.0.1:$port${uri.path}'));
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  const senderKey =
+      '1111111111111111111111111111111111111111111111111111111111111111';
+  const recipientKey =
+      '2222222222222222222222222222222222222222222222222222222222222222';
+  final senderPubkey = getPublicKey(senderKey);
+  final recipientPubkey = getPublicKey(recipientKey);
+  const reelMessageId =
+      'rrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr';
+
+  final replyContext = DmReplyContext(
+    conversationId: DmRepository.computeConversationId(
+      [
+        senderPubkey,
+        recipientPubkey,
+      ]..sort(),
+    ),
+    participantPubkeys: [recipientPubkey],
+    isGroup: false,
+    sharedReelMessageId: reelMessageId,
+    messageAuthorPubkey: recipientPubkey,
+    hintName: 'Alice',
+    isOwnMessage: false,
+  );
+
+  /// Real Nostr → NostrClient → NIP17MessageService → DmRepository, with a
+  /// real Drift database, every socket landing on [relay].
+  Future<({DmRepository repository, AppDatabase db, Nostr nostr})> buildStack(
+    FakeRelay relay,
+  ) async {
+    final factory = _RedirectFactory(relay.port);
+    final signer = LocalNostrSigner(senderKey);
+
+    RelayBase gen(String url) =>
+        RelayBase(url, RelayStatus(url), channelFactory: factory);
+    final nostr = Nostr(signer, [], gen, channelFactory: factory);
+
+    final relayManager = RelayManager(
+      config: RelayManagerConfig(
+        defaultRelayUrl: relay.url,
+        storage: InMemoryRelayStorage(),
+        autoReconnect: false,
+      ),
+      relayPool: nostr.relayPool,
+    );
+    final client = NostrClient.forTesting(
+      nostr: nostr,
+      relayManager: relayManager,
+    );
+
+    final db = AppDatabase.test(NativeDatabase.memory());
+    addTearDown(db.close);
+
+    final repository = DmRepository(
+      nostrClient: client,
+      directMessagesDao: db.directMessagesDao,
+      conversationsDao: db.conversationsDao,
+      outgoingDmsDao: db.outgoingDmsDao,
+      userPubkey: senderPubkey,
+      signer: signer,
+      messageService: NIP17MessageService(
+        signer: signer,
+        senderPublicKey: senderPubkey,
+        nostrService: client,
+      ),
+    );
+    addTearDown(repository.stopListening);
+    addTearDown(nostr.relayPool.removeAll);
+
+    await client.initialize();
+
+    return (repository: repository, db: db, nostr: nostr);
+  }
+
+  Widget wrap(DmRepository repository) {
+    final reactionsRepo = _MockDmReactionsRepository();
+    final auth = _MockAuthService();
+    final analytics = _MockScreenAnalyticsService();
+
+    when(
+      () => reactionsRepo.watchForConversation(any()),
+    ).thenAnswer((_) => const Stream<List<DmReaction>>.empty());
+    when(() => auth.currentPublicKeyHex).thenReturn(senderPubkey);
+    when(
+      () => analytics.trackInteraction(
+        any(),
+        any(),
+        params: any(named: 'params'),
+      ),
+    ).thenReturn(null);
+
+    return ProviderScope(
+      overrides: [
+        dmRepositoryProvider.overrideWithValue(repository),
+        dmReactionsRepositoryProvider.overrideWithValue(reactionsRepo),
+        authServiceProvider.overrideWithValue(auth),
+        screenAnalyticsServiceProvider.overrideWithValue(analytics),
+      ],
+      child: MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: Align(
+            alignment: Alignment.bottomCenter,
+            child: ReelDmReplyBarHost(dmReplyContext: replyContext),
+          ),
+        ),
+      ),
+    );
+  }
+
+  group('#7316 reel reply Retry re-drives instead of re-sending', () {
+    testWidgets(
+      'soft-unconfirmed send: Retry re-drives the parked outgoing_dms row '
+      'and never enqueues a second one',
+      (tester) async {
+        final originalOnError = suppressSetStateErrors();
+        addTearDown(() => restoreErrorHandler(originalOnError));
+
+        // A relay that accepts the frame but never sends `OK` — the exact
+        // soft/unconfirmed shape the issue calls the worse case.
+        final relay = await FakeRelay.start(okConfirms: false);
+        addTearDown(relay.stop);
+        final stack = await buildStack(relay);
+
+        await tester.pumpWidget(wrap(stack.repository));
+        await tester.pump();
+
+        final l10n = lookupAppLocalizations(const Locale('en'));
+
+        // ── First send ──
+        logPhase('── Phase 1: first send (will go unconfirmed) ──');
+        await tester.enterText(find.byType(TextField), 'reel reply probe');
+        await tester.pump();
+        await tester.tap(find.byType(IconButton));
+        await tester.pump();
+
+        final failed = await waitForWidget(
+          tester,
+          find.text(l10n.dmSendFailedRetry),
+          maxSeconds: 45,
+        );
+        expect(failed, isTrue, reason: 'retry snackbar never appeared');
+
+        final afterFirst = await stack.db.outgoingDmsDao.getForConversation(
+          conversationId: replyContext.conversationId,
+          ownerPubkey: senderPubkey,
+        );
+        logPhase('rows after first send: ${afterFirst.length}');
+        for (final row in afterFirst) {
+          logPhase('  row id=${row.id} content="${row.content}"');
+        }
+        expect(
+          afterFirst,
+          hasLength(1),
+          reason: 'the first send must park exactly one durable row',
+        );
+        final firstRumorId = afterFirst.single.id;
+
+        // Pump the snackbar's entrance animation to completion before tapping.
+        // `waitForWidget` returns as soon as the label EXISTS, which is the
+        // first frame of the slide-in — the action is still translated away
+        // from where the finder reports it, and the tap misses.
+        //
+        // This doubles as the clock guard: `pump(duration)` advances real time
+        // under the integration binding, and the wall clock must cross a full
+        // second before the retry or the second rumor hashes to the same id
+        // (`created_at` is seconds) and `enqueue`'s insertOrIgnore silently
+        // coalesces the two rows. A human tapping a snackbar always clears
+        // that bar; making it explicit keeps the test measuring the retry
+        // rather than the clock.
+        await pumpUntilSettled(tester, maxSeconds: 3);
+
+        // ── Retry ──
+        logPhase('── Phase 2: tap Retry ──');
+        final wrapsBeforeRetry = relay.publishedEventIds.length;
+        await tester.tap(
+          find.widgetWithText(SnackBarAction, l10n.dmSendFailedRetry),
+        );
+        await tester.pump();
+
+        // Let the second send run its full OK-confirm budget.
+        await pumpUntilSettled(tester, maxSeconds: 20);
+
+        // Positive control. Without it a tap that silently missed (the
+        // snackbar hit-test trap above) would leave one row and read as
+        // "no bug" — the most dangerous possible false negative for this
+        // test. A retry that really ran publishes at least one more wrap.
+        logPhase(
+          'wraps published: $wrapsBeforeRetry before retry, '
+          '${relay.publishedEventIds.length} after',
+        );
+        expect(
+          relay.publishedEventIds.length,
+          greaterThan(wrapsBeforeRetry),
+          reason: 'the Retry tap never dispatched a send — test is invalid',
+        );
+
+        final afterRetry = await stack.db.outgoingDmsDao.getForConversation(
+          conversationId: replyContext.conversationId,
+          ownerPubkey: senderPubkey,
+        );
+        logPhase('rows after retry: ${afterRetry.length}');
+        for (final row in afterRetry) {
+          logPhase('  row id=${row.id} content="${row.content}"');
+        }
+
+        // The contract. Retry replays the SAME rumor, so the queue still holds
+        // exactly one row under the original id. Before the #7316 fix this was
+        // two rows under two ids, which the receiver keys `direct_messages` on
+        // and therefore renders as two messages.
+        expect(
+          afterRetry.map((r) => r.id).toSet(),
+          {firstRumorId},
+          reason: 'Retry must re-drive the parked row, not mint a second rumor',
+        );
+        expect(
+          afterRetry.single.content,
+          'reel reply probe',
+          reason: 'the surviving row still carries the reply text',
+        );
+      },
+      timeout: const Timeout(Duration(minutes: 3)),
+    );
+
+    testWidgets(
+      'receiver side: two rumor ids render twice, one rumor re-wrapped '
+      'renders once',
+      (tester) async {
+        // Closes the last inferential step of the test above. That one proves
+        // the sender queues two rumor ids; this one proves what the RECEIVER
+        // does with them, against the real `direct_messages` schema.
+        //
+        // The contrast is the point. NIP-59 gives every gift wrap a fresh
+        // ephemeral key and a randomised `created_at` (59.md: "All other
+        // timestamps SHOULD be tweaked"), so the wrap id is never stable
+        // across a retry — the rumor id is the only handle a receiver has.
+        // `recoverFullSend` replays the SAME rumor and collapses; `sendMessage`
+        // mints a new one and cannot.
+        final db = AppDatabase.test(NativeDatabase.memory());
+        addTearDown(db.close);
+
+        const conversationId = 'receiver-side-convo';
+        const text = 'reel reply probe';
+
+        // Timestamps model the real timeline. The rumor's `created_at` is the
+        // canonical one (NIP-59: "The canonical created_at time belongs to the
+        // rumor"), and the retry's rumor is minted only after the 10s
+        // DmSendBudget.recipientOkConfirm window has expired and the user has
+        // tapped — so the two are ≥10s apart, never the same instant.
+        const firstCreatedAt = 1786700000;
+        const retryCreatedAt = firstCreatedAt + 13;
+
+        Future<bool> ingest({
+          required String rumorId,
+          required String giftWrapId,
+          required int createdAt,
+        }) => db.directMessagesDao.insertMessage(
+          id: rumorId,
+          conversationId: conversationId,
+          senderPubkey: senderPubkey,
+          content: text,
+          createdAt: createdAt,
+          giftWrapId: giftWrapId,
+          replyToId: reelMessageId,
+          ownerPubkey: recipientPubkey,
+        );
+
+        // Correct retry: one rumor, re-wrapped. Two wrap ids, one rumor id.
+        expect(
+          await ingest(
+            rumorId: 'a' * 64,
+            giftWrapId: 'w' * 64,
+            createdAt: firstCreatedAt,
+          ),
+          isTrue,
+        );
+        expect(
+          await ingest(
+            rumorId: 'a' * 64,
+            giftWrapId: 'x' * 64,
+            createdAt: firstCreatedAt,
+          ),
+          isFalse,
+          reason: 'a re-wrapped replay of the same rumor must not insert again',
+        );
+
+        var rendered = await db.directMessagesDao.getMessagesForConversation(
+          conversationId,
+        );
+        logPhase('same rumor id, two wraps -> ${rendered.length} bubble(s)');
+        expect(rendered, hasLength(1));
+
+        // The receive path has one more collapse mechanism above this insert:
+        // `hasMatchingMessage`, a (conversation, sender, content, ±5s) check
+        // run on every NIP-17 receive (dm_repository.dart:1910). It is the
+        // only thing that could catch a re-minted rumor — and it cannot reach
+        // this case, because the retry is ≥10s later by construction. Assert
+        // both halves so a future widening of that window is caught here.
+        expect(
+          await db.directMessagesDao.hasMatchingMessage(
+            conversationId: conversationId,
+            senderPubkey: senderPubkey,
+            content: text,
+            createdAt: retryCreatedAt,
+            ownerPubkey: recipientPubkey,
+          ),
+          isFalse,
+          reason: '13s apart is outside the ±5s window — nothing collapses it',
+        );
+        expect(
+          await db.directMessagesDao.hasMatchingMessage(
+            conversationId: conversationId,
+            senderPubkey: senderPubkey,
+            content: text,
+            createdAt: firstCreatedAt + 4,
+            ownerPubkey: recipientPubkey,
+          ),
+          isTrue,
+          reason: 'positive control: the ±5s window does fire inside 5s',
+        );
+
+        // The bug: a second rumor for the same text. Nothing collapses it.
+        expect(
+          await ingest(
+            rumorId: 'b' * 64,
+            giftWrapId: 'y' * 64,
+            createdAt: retryCreatedAt,
+          ),
+          isTrue,
+        );
+
+        rendered = await db.directMessagesDao.getMessagesForConversation(
+          conversationId,
+        );
+        logPhase('two rumor ids -> ${rendered.length} bubble(s)');
+        for (final row in rendered) {
+          logPhase('  bubble id=${row.id} content="${row.content}"');
+        }
+        expect(
+          rendered,
+          hasLength(2),
+          reason: 'two rumor ids for one message render as two bubbles',
+        );
+        expect(rendered.map((m) => m.content).toSet(), {text});
+      },
+    );
+  });
+}

--- a/mobile/lib/blocs/dm/inline_reel_reply/inline_reel_reply_cubit.dart
+++ b/mobile/lib/blocs/dm/inline_reel_reply/inline_reel_reply_cubit.dart
@@ -126,11 +126,13 @@ class InlineReelReplyCubit extends Cubit<InlineReelReplyState> {
         addError(error, stackTrace);
       }
       if (!isClosed) {
-        // No handle to offer: every throwing path in the repository's send
-        // prologue (uninitialized repo, invalid pubkey, empty content, the
-        // send-policy gate) runs *before* the queue enqueue, so a throw
-        // leaves no row behind and [retry]'s fresh-send fallback cannot
-        // duplicate anything.
+        // No handle to offer, and none is being dropped: the repository's
+        // throwing paths (uninitialized repo, invalid pubkey, empty content,
+        // the send-policy gate) all run *before* the enqueue, the 1:1 enqueue
+        // is a single write with nothing parked ahead of it, and the group
+        // enqueue loop catches per sibling rather than escaping with rows
+        // already parked. So a throw leaves no row behind and [retry]'s
+        // fresh-send fallback cannot duplicate anything.
         emit(
           state.copyWith(
             status: InlineReelReplyStatus.failure,
@@ -155,6 +157,12 @@ class InlineReelReplyCubit extends Cubit<InlineReelReplyState> {
   /// through `recoverFullSend` replays the *same* rumor, which the receiver
   /// does collapse. See #7316.
   ///
+  /// Every parked row is attempted, and the outcome is the worst one seen:
+  /// [InlineReelReplyStatus.failure] while any row is still outstanding (the
+  /// retry affordance stays up and narrows to those rows), otherwise
+  /// [InlineReelReplyStatus.unverifiable] if any row had already gone, and
+  /// [InlineReelReplyStatus.success] only when every row was delivered.
+  ///
   /// [content] is used only for the fallback when nothing was parked — see
   /// [InlineReelReplyState.queuedRumorIds].
   Future<void> retry(String content) async {
@@ -164,61 +172,77 @@ class InlineReelReplyCubit extends Cubit<InlineReelReplyState> {
 
     emit(state.copyWith(status: InlineReelReplyStatus.sending));
 
-    try {
-      final stillParked = <String>[];
-      for (final rumorId in parked) {
-        try {
-          // `resetRetryBudget` re-arms a row whose soft-unconfirmed attempts
-          // already spent the sweep's budget: an explicit user retry is the
-          // signal to hand it back, matching ConversationBloc's resend.
-          final result = await _dmRepository.recoverFullSend(
-            rumorId: rumorId,
-            resetRetryBudget: true,
-          );
-          if (!result.success) stillParked.add(rumorId);
-          // ignore: avoid_catching_errors
-        } on ArgumentError {
+    final stillParked = <String>[];
+    var unverifiable = 0;
+    Object? lastError;
+    StackTrace? lastStackTrace;
+
+    for (final rumorId in parked) {
+      try {
+        // `resetRetryBudget` re-arms a row whose soft-unconfirmed attempts
+        // already spent the sweep's budget: an explicit user retry is the
+        // signal to hand it back, matching ConversationBloc's resend.
+        final result = await _dmRepository.recoverFullSend(
+          rumorId: rumorId,
+          resetRetryBudget: true,
+        );
+        if (!result.success) stillParked.add(rumorId);
+      } on Object catch (error, stackTrace) {
+        if (error is ArgumentError) {
           // The row is gone — delivered by the sweep, cancelled by the user,
           // or owned by another account. Terminal for this id either way, and
           // deliberately NOT retried as a fresh send: we cannot prove the
           // original did not land, so minting a replacement risks the exact
-          // duplicate this method exists to prevent.
+          // duplicate this method exists to prevent. Nor is it a delivery we
+          // may claim, so it downgrades the whole retry to `unverifiable`.
+          unverifiable++;
+          continue;
         }
+        // Per-sibling, like ConversationBloc's recovery loop: one bad row
+        // must not skip the siblings after it, each of which owns a separate
+        // parked copy the sweep would otherwise be left to re-drive alone.
+        stillParked.add(rumorId);
+        lastError = error;
+        lastStackTrace = stackTrace;
       }
-      if (!isClosed) {
-        final ok = stillParked.length < parked.length;
-        emit(
-          state.copyWith(
-            status: ok
-                ? InlineReelReplyStatus.success
-                : InlineReelReplyStatus.failure,
-            // A further retry targets exactly the rows still outstanding.
-            queuedRumorIds: stillParked,
-          ),
-        );
-      }
-    } catch (error, stackTrace) {
+    }
+
+    if (lastError != null) {
       Log.error(
         'Reel reply retry failed',
         name: 'InlineReelReplyCubit',
         category: LogCategory.ui,
-        error: error,
-        stackTrace: stackTrace,
+        error: lastError,
+        stackTrace: lastStackTrace,
       );
       // Same split as submit: a StateError here means the queue DAO was never
       // wired into the repository, which is a programming invariant.
-      if (error is Error) {
+      if (lastError is Error) {
         addError(
-          Reportable(error, context: InlineReelReplyReportableSites.retry),
-          stackTrace,
+          Reportable(lastError, context: InlineReelReplyReportableSites.retry),
+          lastStackTrace,
         );
       } else {
-        addError(error, stackTrace);
-      }
-      if (!isClosed) {
-        emit(state.copyWith(status: InlineReelReplyStatus.failure));
+        addError(lastError, lastStackTrace);
       }
     }
+
+    if (isClosed) return;
+    emit(
+      state.copyWith(
+        // All-succeeded, matching ConversationBloc: any sibling still parked
+        // keeps the retry affordance up, and it targets exactly those rows.
+        // Reporting success off one lucky sibling would retire the affordance
+        // while the rest were still undelivered.
+        status: stillParked.isNotEmpty
+            ? InlineReelReplyStatus.failure
+            : unverifiable > 0
+            ? InlineReelReplyStatus.unverifiable
+            : InlineReelReplyStatus.success,
+        // A further retry targets exactly the rows still outstanding.
+        queuedRumorIds: stillParked,
+      ),
+    );
   }
 
   /// Reset to [InlineReelReplyStatus.initial] after the View shows the

--- a/mobile/lib/blocs/dm/inline_reel_reply/inline_reel_reply_cubit.dart
+++ b/mobile/lib/blocs/dm/inline_reel_reply/inline_reel_reply_cubit.dart
@@ -35,6 +35,11 @@ class InlineReelReplyCubit extends Cubit<InlineReelReplyState> {
   /// Trims/validates locally; empty submissions are a no-op. A send already
   /// in flight is dropped (double-send guard). Failures surface via a status
   /// enum + [addError]; the durable outgoing-DM queue owns the actual retry.
+  ///
+  /// A failure records the rows this send left parked in
+  /// [InlineReelReplyState.queuedRumorIds], so [retry] can re-drive them.
+  /// Calling this method again is a *new message*, never a retry — see
+  /// [retry] for why that distinction matters.
   Future<void> submit(String content) async {
     final trimmed = content.trim();
     if (trimmed.isEmpty) return;
@@ -44,6 +49,7 @@ class InlineReelReplyCubit extends Cubit<InlineReelReplyState> {
 
     try {
       final bool ok;
+      final List<String> parked;
       // When the reel has a structured video ref, the reply self-carries the
       // NIP-18 `q` citation so it stays linked to the video across devices and
       // other Nostr clients; otherwise it threads as a plain reply.
@@ -66,6 +72,7 @@ class InlineReelReplyCubit extends Cubit<InlineReelReplyState> {
                 replyToId: _replyContext.sharedReelMessageId,
               );
         ok = results.any((r) => r.success);
+        parked = [for (final r in results) ?r.queuedRumorId];
       } else {
         final result = videoRef != null
             ? await _dmRepository.sendSharedVideo(
@@ -84,6 +91,7 @@ class InlineReelReplyCubit extends Cubit<InlineReelReplyState> {
                 replyToId: _replyContext.sharedReelMessageId,
               );
         ok = result.success;
+        parked = [?result.queuedRumorId];
       }
       if (!isClosed) {
         emit(
@@ -91,6 +99,10 @@ class InlineReelReplyCubit extends Cubit<InlineReelReplyState> {
             status: ok
                 ? InlineReelReplyStatus.success
                 : InlineReelReplyStatus.failure,
+            // Nothing left to re-drive on success: a fully delivered send
+            // consumes its row, and a partially delivered group's surviving
+            // siblings belong to the sweep, not to a user-facing retry.
+            queuedRumorIds: ok ? const [] : parked,
           ),
         );
       }
@@ -114,6 +126,96 @@ class InlineReelReplyCubit extends Cubit<InlineReelReplyState> {
         addError(error, stackTrace);
       }
       if (!isClosed) {
+        // No handle to offer: every throwing path in the repository's send
+        // prologue (uninitialized repo, invalid pubkey, empty content, the
+        // send-policy gate) runs *before* the queue enqueue, so a throw
+        // leaves no row behind and [retry]'s fresh-send fallback cannot
+        // duplicate anything.
+        emit(
+          state.copyWith(
+            status: InlineReelReplyStatus.failure,
+            queuedRumorIds: const [],
+          ),
+        );
+      }
+    }
+  }
+
+  /// Re-drive the rows the last failed send left parked, rather than sending
+  /// again.
+  ///
+  /// This is the whole point of the distinction from [submit]. A NIP-17 send
+  /// is identified by its kind-14 rumor id, and that id is a hash over the
+  /// rumor's `created_at` — so calling [submit] a second time mints a *new*
+  /// rumor for the same text. The original row is still parked and the
+  /// background sweep re-publishes it under its original id, so the recipient
+  /// receives two events it has no way to collapse: gift-wrap ids are freshly
+  /// randomised per wrap, NIP-44 ciphertext is nonce-randomised, and the
+  /// receiver's only stable dedup key is the rumor id. Re-driving the same row
+  /// through `recoverFullSend` replays the *same* rumor, which the receiver
+  /// does collapse. See #7316.
+  ///
+  /// [content] is used only for the fallback when nothing was parked — see
+  /// [InlineReelReplyState.queuedRumorIds].
+  Future<void> retry(String content) async {
+    if (state.status == InlineReelReplyStatus.sending) return;
+    final parked = state.queuedRumorIds;
+    if (parked.isEmpty) return submit(content);
+
+    emit(state.copyWith(status: InlineReelReplyStatus.sending));
+
+    try {
+      final stillParked = <String>[];
+      for (final rumorId in parked) {
+        try {
+          // `resetRetryBudget` re-arms a row whose soft-unconfirmed attempts
+          // already spent the sweep's budget: an explicit user retry is the
+          // signal to hand it back, matching ConversationBloc's resend.
+          final result = await _dmRepository.recoverFullSend(
+            rumorId: rumorId,
+            resetRetryBudget: true,
+          );
+          if (!result.success) stillParked.add(rumorId);
+          // ignore: avoid_catching_errors
+        } on ArgumentError {
+          // The row is gone — delivered by the sweep, cancelled by the user,
+          // or owned by another account. Terminal for this id either way, and
+          // deliberately NOT retried as a fresh send: we cannot prove the
+          // original did not land, so minting a replacement risks the exact
+          // duplicate this method exists to prevent.
+        }
+      }
+      if (!isClosed) {
+        final ok = stillParked.length < parked.length;
+        emit(
+          state.copyWith(
+            status: ok
+                ? InlineReelReplyStatus.success
+                : InlineReelReplyStatus.failure,
+            // A further retry targets exactly the rows still outstanding.
+            queuedRumorIds: stillParked,
+          ),
+        );
+      }
+    } catch (error, stackTrace) {
+      Log.error(
+        'Reel reply retry failed',
+        name: 'InlineReelReplyCubit',
+        category: LogCategory.ui,
+        error: error,
+        stackTrace: stackTrace,
+      );
+      // Same split as submit: a StateError here means the queue DAO was never
+      // wired into the repository, which is a programming invariant.
+      if (error is Error) {
+        addError(
+          Reportable(error, context: InlineReelReplyReportableSites.retry),
+          stackTrace,
+        );
+      } else {
+        addError(error, stackTrace);
+      }
+      if (!isClosed) {
         emit(state.copyWith(status: InlineReelReplyStatus.failure));
       }
     }
@@ -121,6 +223,10 @@ class InlineReelReplyCubit extends Cubit<InlineReelReplyState> {
 
   /// Reset to [InlineReelReplyStatus.initial] after the View shows the
   /// success/failure confirmation, so the next send starts clean.
+  ///
+  /// Deliberately preserves [InlineReelReplyState.queuedRumorIds]: the View
+  /// acknowledges as soon as it has shown the failure snackbar, and the retry
+  /// action on that snackbar fires afterwards.
   void acknowledge() {
     if (state.status == InlineReelReplyStatus.initial) return;
     emit(state.copyWith(status: InlineReelReplyStatus.initial));

--- a/mobile/lib/blocs/dm/inline_reel_reply/inline_reel_reply_cubit.dart
+++ b/mobile/lib/blocs/dm/inline_reel_reply/inline_reel_reply_cubit.dart
@@ -163,11 +163,24 @@ class InlineReelReplyCubit extends Cubit<InlineReelReplyState> {
   /// [InlineReelReplyStatus.unverifiable] if any row had already gone, and
   /// [InlineReelReplyStatus.success] only when every row was delivered.
   ///
+  /// [queuedRumorIds] is the set the *failing send this retry belongs to*
+  /// parked, captured by the caller when it offered the affordance — not read
+  /// back off the live state. A retry affordance can outlive its own send (a
+  /// snackbar queued behind another one is never dismissed by the success
+  /// path, which can only close a visible one), and by then the state has
+  /// moved on: a later successful send clears `queuedRumorIds` because *it*
+  /// left nothing parked. Reading the live value there would find it empty,
+  /// fall through to [submit], and mint a second rumor for a row the sweep is
+  /// still re-driving — this bug, through a different door.
+  ///
   /// [content] is used only for the fallback when nothing was parked — see
   /// [InlineReelReplyState.queuedRumorIds].
-  Future<void> retry(String content) async {
+  Future<void> retry({
+    required List<String> queuedRumorIds,
+    required String content,
+  }) async {
     if (state.status == InlineReelReplyStatus.sending) return;
-    final parked = state.queuedRumorIds;
+    final parked = queuedRumorIds;
     if (parked.isEmpty) return submit(content);
 
     emit(state.copyWith(status: InlineReelReplyStatus.sending));

--- a/mobile/lib/blocs/dm/inline_reel_reply/inline_reel_reply_state.dart
+++ b/mobile/lib/blocs/dm/inline_reel_reply/inline_reel_reply_state.dart
@@ -43,11 +43,17 @@ class InlineReelReplyState extends Equatable {
   /// The `outgoing_dms` rows the last failed send left parked — one per
   /// recipient that came back carrying a `NIP17SendResult.queuedRumorId`.
   ///
-  /// [InlineReelReplyCubit.retry] re-drives exactly these rows. Empty when
-  /// there is nothing to re-drive: a policy-blocked send returns before the
-  /// enqueue, and an unwired queue DAO never creates a row at all. Retrying
-  /// on an empty list falls back to a fresh send, which is safe precisely
-  /// because no row exists that could deliver a second copy.
+  /// Empty when there is nothing to re-drive: a policy-blocked send returns
+  /// before the enqueue, and an unwired queue DAO never creates a row at all.
+  /// Retrying on an empty list falls back to a fresh send, which is safe
+  /// precisely because no row exists that could deliver a second copy.
+  ///
+  /// This is a *snapshot for the View to capture*, not a live handle for a
+  /// retry to read back. It describes the most recent send only, so a later
+  /// success clears it while an earlier failure's rows may still be parked.
+  /// Whoever offers a retry must capture this list at that moment and pass it
+  /// to [InlineReelReplyCubit.retry] — see that method for what reading the
+  /// live value instead would cost.
   final List<String> queuedRumorIds;
 
   /// Copy with an updated [status] and/or [queuedRumorIds].

--- a/mobile/lib/blocs/dm/inline_reel_reply/inline_reel_reply_state.dart
+++ b/mobile/lib/blocs/dm/inline_reel_reply/inline_reel_reply_state.dart
@@ -13,6 +13,18 @@ enum InlineReelReplyStatus {
 
   /// The most recent reply send failed (queued for retry).
   failure,
+
+  /// A retry found its parked row gone, and delivery can be neither confirmed
+  /// nor re-driven.
+  ///
+  /// `recoverFullSend` raises `ArgumentError` both when the row has been
+  /// consumed (the sweep may already have delivered it, or the user deleted
+  /// it) and when it belongs to another account, so the outcome is genuinely
+  /// unknown. Distinct from [success] because nothing proved delivery, and
+  /// from [failure] because there is no row left to retry — offering one
+  /// would fall through to a fresh send and mint the duplicate this flow
+  /// exists to prevent. Mirrors `ModerationDmOutcome.unverifiable`.
+  unverifiable,
 }
 
 /// State for [InlineReelReplyCubit] — the lifecycle status plus the durable

--- a/mobile/lib/blocs/dm/inline_reel_reply/inline_reel_reply_state.dart
+++ b/mobile/lib/blocs/dm/inline_reel_reply/inline_reel_reply_state.dart
@@ -15,19 +15,38 @@ enum InlineReelReplyStatus {
   failure,
 }
 
-/// State for [InlineReelReplyCubit] — just the lifecycle status. The composed
-/// text lives in the View's [TextEditingController].
+/// State for [InlineReelReplyCubit] — the lifecycle status plus the durable
+/// rows a failed send left parked. The composed text lives in the View's
+/// [TextEditingController].
 class InlineReelReplyState extends Equatable {
   /// Construct a state.
-  const InlineReelReplyState({this.status = InlineReelReplyStatus.initial});
+  const InlineReelReplyState({
+    this.status = InlineReelReplyStatus.initial,
+    this.queuedRumorIds = const [],
+  });
 
   /// Current send lifecycle status.
   final InlineReelReplyStatus status;
 
-  /// Copy with an updated [status].
-  InlineReelReplyState copyWith({InlineReelReplyStatus? status}) =>
-      InlineReelReplyState(status: status ?? this.status);
+  /// The `outgoing_dms` rows the last failed send left parked — one per
+  /// recipient that came back carrying a `NIP17SendResult.queuedRumorId`.
+  ///
+  /// [InlineReelReplyCubit.retry] re-drives exactly these rows. Empty when
+  /// there is nothing to re-drive: a policy-blocked send returns before the
+  /// enqueue, and an unwired queue DAO never creates a row at all. Retrying
+  /// on an empty list falls back to a fresh send, which is safe precisely
+  /// because no row exists that could deliver a second copy.
+  final List<String> queuedRumorIds;
+
+  /// Copy with an updated [status] and/or [queuedRumorIds].
+  InlineReelReplyState copyWith({
+    InlineReelReplyStatus? status,
+    List<String>? queuedRumorIds,
+  }) => InlineReelReplyState(
+    status: status ?? this.status,
+    queuedRumorIds: queuedRumorIds ?? this.queuedRumorIds,
+  );
 
   @override
-  List<Object?> get props => [status];
+  List<Object?> get props => [status, queuedRumorIds];
 }

--- a/mobile/lib/blocs/dm/inline_reel_reply/reportable_sites.dart
+++ b/mobile/lib/blocs/dm/inline_reel_reply/reportable_sites.dart
@@ -6,4 +6,7 @@
 abstract class InlineReelReplyReportableSites {
   /// The reply submit path.
   static const submit = 'submit';
+
+  /// The reply retry path (re-driving a parked `outgoing_dms` row).
+  static const retry = 'retry';
 }

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -4356,6 +4356,7 @@
     "dmReelReplySentAnnouncement": "መልስ ተልኳል",
     "dmReelReactionSentAnnouncement": "በ{emoji} ምላሽ ሰጥተዋል",
     "dmReelReplyFailed": "መላክ አልተቻለም",
+    "dmReelReplyUnverified": "መላኩን ማረጋገጥ አልተቻለም",
     "emojiPickerSearchHint": "ፍለጋ",
     "emojiCategoryRecent": "የቅርብ ጊዜ",
     "emojiCategorySmileys": "ፈገግታዎች እና ሰዎች",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -4224,6 +4224,7 @@
     "dmReelReplySentAnnouncement": "تم إرسال الرد",
     "dmReelReactionSentAnnouncement": "تفاعلت بـ {emoji}",
     "dmReelReplyFailed": "تعذّر الإرسال",
+    "dmReelReplyUnverified": "تعذّر تأكيد الإرسال",
     "emojiPickerSearchHint": "بحث",
     "emojiCategoryRecent": "الأخيرة",
     "emojiCategorySmileys": "الوجوه والأشخاص",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -4362,6 +4362,7 @@
     "dmReelReplySentAnnouncement": "Отговорът е изпратен",
     "dmReelReactionSentAnnouncement": "Реагирахте с {emoji}",
     "dmReelReplyFailed": "Изпращането е неуспешно",
+    "dmReelReplyUnverified": "Изпращането не е потвърдено",
     "emojiPickerSearchHint": "Търсене",
     "emojiCategoryRecent": "Скорошни",
     "emojiCategorySmileys": "Емотикони и хора",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -4224,6 +4224,7 @@
     "dmReelReplySentAnnouncement": "Antwort gesendet",
     "dmReelReactionSentAnnouncement": "Mit {emoji} reagiert",
     "dmReelReplyFailed": "Senden fehlgeschlagen",
+    "dmReelReplyUnverified": "Senden nicht bestätigt",
     "emojiPickerSearchHint": "Suchen",
     "emojiCategoryRecent": "Zuletzt verwendet",
     "emojiCategorySmileys": "Smileys und Menschen",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -3796,6 +3796,10 @@
   "@dmReelReplyFailed": {
     "description": "Transient toast shown in the reel player when a reply or reaction fails to send."
   },
+  "dmReelReplyUnverified": "Couldn't confirm that sent",
+  "@dmReelReplyUnverified": {
+    "description": "Transient toast shown in the reel player when a retry could not determine whether the reply was delivered. Offers 'View chat' rather than another retry, because retrying could send a duplicate."
+  },
   "dmReactionChipOwnA11yLabel": "Your reaction: {emoji}",
   "@dmReactionChipOwnA11yLabel": {
     "description": "Screen-reader label for a reaction chip created by the current account.",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -4224,6 +4224,7 @@
     "dmReelReplySentAnnouncement": "Respuesta enviada",
     "dmReelReactionSentAnnouncement": "Reaccionaste {emoji}",
     "dmReelReplyFailed": "No se pudo enviar",
+    "dmReelReplyUnverified": "No se pudo confirmar el envío",
     "emojiPickerSearchHint": "Buscar",
     "emojiCategoryRecent": "Recientes",
     "emojiCategorySmileys": "Emoticonos y personas",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -2810,6 +2810,7 @@
     "dmReelReplySentAnnouncement": "Naipadala ang tugon",
     "dmReelReactionSentAnnouncement": "Nag-react ng {emoji}",
     "dmReelReplyFailed": "Hindi maipadala",
+    "dmReelReplyUnverified": "Hindi makumpirma ang pagpapadala",
     "emojiPickerSearchHint": "Maghanap",
     "emojiCategoryRecent": "Kamakailan",
     "emojiCategorySmileys": "Mga Smiley at Tao",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -4224,6 +4224,7 @@
     "dmReelReplySentAnnouncement": "Réponse envoyée",
     "dmReelReactionSentAnnouncement": "Réaction {emoji} envoyée",
     "dmReelReplyFailed": "Échec de l'envoi",
+    "dmReelReplyUnverified": "Envoi non confirmé",
     "emojiPickerSearchHint": "Rechercher",
     "emojiCategoryRecent": "Récents",
     "emojiCategorySmileys": "Smileys et personnes",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -4224,6 +4224,7 @@
     "dmReelReplySentAnnouncement": "Balasan terkirim",
     "dmReelReactionSentAnnouncement": "Bereaksi {emoji}",
     "dmReelReplyFailed": "Tidak dapat mengirim",
+    "dmReelReplyUnverified": "Tidak dapat memastikan terkirim",
     "emojiPickerSearchHint": "Cari",
     "emojiCategoryRecent": "Terbaru",
     "emojiCategorySmileys": "Smiley & Orang",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -4224,6 +4224,7 @@
     "dmReelReplySentAnnouncement": "Risposta inviata",
     "dmReelReactionSentAnnouncement": "Hai reagito {emoji}",
     "dmReelReplyFailed": "Invio non riuscito",
+    "dmReelReplyUnverified": "Invio non confermato",
     "emojiPickerSearchHint": "Cerca",
     "emojiCategoryRecent": "Recenti",
     "emojiCategorySmileys": "Faccine e persone",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -4224,6 +4224,7 @@
     "dmReelReplySentAnnouncement": "返信を送信しました",
     "dmReelReactionSentAnnouncement": "{emoji}でリアクションしました",
     "dmReelReplyFailed": "送信できませんでした",
+    "dmReelReplyUnverified": "送信を確認できませんでした",
     "emojiPickerSearchHint": "検索",
     "emojiCategoryRecent": "最近使った絵文字",
     "emojiCategorySmileys": "スマイリーと人々",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -3562,6 +3562,7 @@
     "dmReelReplySentAnnouncement": "답장을 보냈습니다",
     "dmReelReactionSentAnnouncement": "{emoji} 반응함",
     "dmReelReplyFailed": "보내지 못했습니다",
+    "dmReelReplyUnverified": "전송을 확인하지 못했습니다",
     "emojiPickerSearchHint": "검색",
     "emojiCategoryRecent": "최근 사용",
     "emojiCategorySmileys": "스마일리 및 사람",

--- a/mobile/lib/l10n/app_ms.arb
+++ b/mobile/lib/l10n/app_ms.arb
@@ -3490,6 +3490,7 @@
     }
   },
   "dmReelReplyFailed": "Tidak dapat menghantar",
+  "dmReelReplyUnverified": "Tidak dapat mengesahkan penghantaran",
   "@dmReelReplyFailed": {
     "description": "Transient toast shown in the reel player when a reply or reaction fails to send."
   },

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -4224,6 +4224,7 @@
     "dmReelReplySentAnnouncement": "Antwoord verzonden",
     "dmReelReactionSentAnnouncement": "Gereageerd met {emoji}",
     "dmReelReplyFailed": "Verzenden mislukt",
+    "dmReelReplyUnverified": "Verzenden niet bevestigd",
     "emojiPickerSearchHint": "Zoeken",
     "emojiCategoryRecent": "Recent",
     "emojiCategorySmileys": "Smileys en mensen",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -4224,6 +4224,7 @@
     "dmReelReplySentAnnouncement": "Odpowiedź wysłana",
     "dmReelReactionSentAnnouncement": "Zareagowano {emoji}",
     "dmReelReplyFailed": "Nie udało się wysłać",
+    "dmReelReplyUnverified": "Nie udało się potwierdzić wysłania",
     "emojiPickerSearchHint": "Szukaj",
     "emojiCategoryRecent": "Ostatnie",
     "emojiCategorySmileys": "Uśmiechy i ludzie",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -4224,6 +4224,7 @@
     "dmReelReplySentAnnouncement": "Resposta enviada",
     "dmReelReactionSentAnnouncement": "Você reagiu {emoji}",
     "dmReelReplyFailed": "Não foi possível enviar",
+    "dmReelReplyUnverified": "Não foi possível confirmar o envio",
     "emojiPickerSearchHint": "Pesquisar",
     "emojiCategoryRecent": "Recentes",
     "emojiCategorySmileys": "Smileys e pessoas",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -4224,6 +4224,7 @@
     "dmReelReplySentAnnouncement": "Răspuns trimis",
     "dmReelReactionSentAnnouncement": "Ai reacționat {emoji}",
     "dmReelReplyFailed": "Trimiterea a eșuat",
+    "dmReelReplyUnverified": "Trimiterea nu a putut fi confirmată",
     "emojiPickerSearchHint": "Căutare",
     "emojiCategoryRecent": "Recente",
     "emojiCategorySmileys": "Emoticoane și persoane",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -4224,6 +4224,7 @@
     "dmReelReplySentAnnouncement": "Svar skickat",
     "dmReelReactionSentAnnouncement": "Reagerade {emoji}",
     "dmReelReplyFailed": "Det gick inte att skicka",
+    "dmReelReplyUnverified": "Det gick inte att bekräfta att det skickades",
     "emojiPickerSearchHint": "Sök",
     "emojiCategoryRecent": "Senaste",
     "emojiCategorySmileys": "Smileys och personer",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -4224,6 +4224,7 @@
     "dmReelReplySentAnnouncement": "Yanıt gönderildi",
     "dmReelReactionSentAnnouncement": "{emoji} ile tepki verildi",
     "dmReelReplyFailed": "Gönderilemedi",
+    "dmReelReplyUnverified": "Gönderim doğrulanamadı",
     "emojiPickerSearchHint": "Ara",
     "emojiCategoryRecent": "Son Kullanılanlar",
     "emojiCategorySmileys": "İfadeler ve İnsanlar",

--- a/mobile/lib/l10n/app_ur.arb
+++ b/mobile/lib/l10n/app_ur.arb
@@ -3490,6 +3490,7 @@
     }
   },
   "dmReelReplyFailed": "نہیں بھیجا جا سکا",
+  "dmReelReplyUnverified": "بھیجنے کی تصدیق نہیں ہو سکی",
   "@dmReelReplyFailed": {
     "description": "Transient toast shown in the reel player when a reply or reaction fails to send."
   },

--- a/mobile/lib/l10n/app_vi.arb
+++ b/mobile/lib/l10n/app_vi.arb
@@ -3490,6 +3490,7 @@
     }
   },
   "dmReelReplyFailed": "Không gửi được",
+  "dmReelReplyUnverified": "Không xác nhận được đã gửi",
   "@dmReelReplyFailed": {
     "description": "Transient toast shown in the reel player when a reply or reaction fails to send."
   },

--- a/mobile/lib/l10n/app_zh.arb
+++ b/mobile/lib/l10n/app_zh.arb
@@ -3490,6 +3490,7 @@
     }
   },
   "dmReelReplyFailed": "发送失败",
+  "dmReelReplyUnverified": "无法确认是否已发送",
   "@dmReelReplyFailed": {
     "description": "Transient toast shown in the reel player when a reply or reaction fails to send."
   },

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -10769,6 +10769,12 @@ abstract class AppLocalizations {
   /// **'Couldn\'t send'**
   String get dmReelReplyFailed;
 
+  /// Transient toast shown in the reel player when a retry could not determine whether the reply was delivered. Offers 'View chat' rather than another retry, because retrying could send a duplicate.
+  ///
+  /// In en, this message translates to:
+  /// **'Couldn\'t confirm that sent'**
+  String get dmReelReplyUnverified;
+
   /// Screen-reader label for a reaction chip created by the current account.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -6023,7 +6023,7 @@ class AppLocalizationsAm extends AppLocalizations {
   String get dmReelReplyFailed => 'መላክ አልተቻለም';
 
   @override
-  String get dmReelReplyUnverified => 'Couldn\'t confirm that sent';
+  String get dmReelReplyUnverified => 'መላኩን ማረጋገጥ አልተቻለም';
 
   @override
   String dmReactionChipOwnA11yLabel(String emoji) {

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -6023,6 +6023,9 @@ class AppLocalizationsAm extends AppLocalizations {
   String get dmReelReplyFailed => 'መላክ አልተቻለም';
 
   @override
+  String get dmReelReplyUnverified => 'Couldn\'t confirm that sent';
+
+  @override
   String dmReactionChipOwnA11yLabel(String emoji) {
     return 'የአንተ ምላሽ፦ $emoji';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -6105,7 +6105,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get dmReelReplyFailed => 'تعذّر الإرسال';
 
   @override
-  String get dmReelReplyUnverified => 'Couldn\'t confirm that sent';
+  String get dmReelReplyUnverified => 'تعذّر تأكيد الإرسال';
 
   @override
   String dmReactionChipOwnA11yLabel(String emoji) {

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -6105,6 +6105,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get dmReelReplyFailed => 'تعذّر الإرسال';
 
   @override
+  String get dmReelReplyUnverified => 'Couldn\'t confirm that sent';
+
+  @override
   String dmReactionChipOwnA11yLabel(String emoji) {
     return 'تفاعلك: $emoji';
   }

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -6210,7 +6210,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get dmReelReplyFailed => 'Изпращането е неуспешно';
 
   @override
-  String get dmReelReplyUnverified => 'Couldn\'t confirm that sent';
+  String get dmReelReplyUnverified => 'Изпращането не е потвърдено';
 
   @override
   String dmReactionChipOwnA11yLabel(String emoji) {

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -6210,6 +6210,9 @@ class AppLocalizationsBg extends AppLocalizations {
   String get dmReelReplyFailed => 'Изпращането е неуспешно';
 
   @override
+  String get dmReelReplyUnverified => 'Couldn\'t confirm that sent';
+
+  @override
   String dmReactionChipOwnA11yLabel(String emoji) {
     return 'Твоята реакция: $emoji';
   }

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -6238,6 +6238,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get dmReelReplyFailed => 'Senden fehlgeschlagen';
 
   @override
+  String get dmReelReplyUnverified => 'Couldn\'t confirm that sent';
+
+  @override
   String dmReactionChipOwnA11yLabel(String emoji) {
     return 'Deine Reaktion: $emoji';
   }

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -6238,7 +6238,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get dmReelReplyFailed => 'Senden fehlgeschlagen';
 
   @override
-  String get dmReelReplyUnverified => 'Couldn\'t confirm that sent';
+  String get dmReelReplyUnverified => 'Senden nicht bestätigt';
 
   @override
   String dmReactionChipOwnA11yLabel(String emoji) {

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -6149,6 +6149,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get dmReelReplyFailed => 'Couldn\'t send';
 
   @override
+  String get dmReelReplyUnverified => 'Couldn\'t confirm that sent';
+
+  @override
   String dmReactionChipOwnA11yLabel(String emoji) {
     return 'Your reaction: $emoji';
   }

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -6209,7 +6209,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get dmReelReplyFailed => 'No se pudo enviar';
 
   @override
-  String get dmReelReplyUnverified => 'Couldn\'t confirm that sent';
+  String get dmReelReplyUnverified => 'No se pudo confirmar el envío';
 
   @override
   String dmReactionChipOwnA11yLabel(String emoji) {

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -6209,6 +6209,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get dmReelReplyFailed => 'No se pudo enviar';
 
   @override
+  String get dmReelReplyUnverified => 'Couldn\'t confirm that sent';
+
+  @override
   String dmReactionChipOwnA11yLabel(String emoji) {
     return 'Tu reacción: $emoji';
   }

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -6235,7 +6235,7 @@ class AppLocalizationsFil extends AppLocalizations {
   String get dmReelReplyFailed => 'Hindi maipadala';
 
   @override
-  String get dmReelReplyUnverified => 'Couldn\'t confirm that sent';
+  String get dmReelReplyUnverified => 'Hindi makumpirma ang pagpapadala';
 
   @override
   String dmReactionChipOwnA11yLabel(String emoji) {

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -6235,6 +6235,9 @@ class AppLocalizationsFil extends AppLocalizations {
   String get dmReelReplyFailed => 'Hindi maipadala';
 
   @override
+  String get dmReelReplyUnverified => 'Couldn\'t confirm that sent';
+
+  @override
   String dmReactionChipOwnA11yLabel(String emoji) {
     return 'Reaction mo: $emoji';
   }

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -6236,6 +6236,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get dmReelReplyFailed => 'Échec de l\'envoi';
 
   @override
+  String get dmReelReplyUnverified => 'Couldn\'t confirm that sent';
+
+  @override
   String dmReactionChipOwnA11yLabel(String emoji) {
     return 'Ta réaction : $emoji';
   }

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -6236,7 +6236,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get dmReelReplyFailed => 'Échec de l\'envoi';
 
   @override
-  String get dmReelReplyUnverified => 'Couldn\'t confirm that sent';
+  String get dmReelReplyUnverified => 'Envoi non confirmé';
 
   @override
   String dmReactionChipOwnA11yLabel(String emoji) {

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -6120,6 +6120,9 @@ class AppLocalizationsId extends AppLocalizations {
   String get dmReelReplyFailed => 'Tidak dapat mengirim';
 
   @override
+  String get dmReelReplyUnverified => 'Couldn\'t confirm that sent';
+
+  @override
   String dmReactionChipOwnA11yLabel(String emoji) {
     return 'Reaksimu: $emoji';
   }

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -6120,7 +6120,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get dmReelReplyFailed => 'Tidak dapat mengirim';
 
   @override
-  String get dmReelReplyUnverified => 'Couldn\'t confirm that sent';
+  String get dmReelReplyUnverified => 'Tidak dapat memastikan terkirim';
 
   @override
   String dmReactionChipOwnA11yLabel(String emoji) {

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -6218,6 +6218,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get dmReelReplyFailed => 'Invio non riuscito';
 
   @override
+  String get dmReelReplyUnverified => 'Couldn\'t confirm that sent';
+
+  @override
   String dmReactionChipOwnA11yLabel(String emoji) {
     return 'La tua reazione: $emoji';
   }

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -6218,7 +6218,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get dmReelReplyFailed => 'Invio non riuscito';
 
   @override
-  String get dmReelReplyUnverified => 'Couldn\'t confirm that sent';
+  String get dmReelReplyUnverified => 'Invio non confermato';
 
   @override
   String dmReactionChipOwnA11yLabel(String emoji) {

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -5875,6 +5875,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get dmReelReplyFailed => '送信できませんでした';
 
   @override
+  String get dmReelReplyUnverified => 'Couldn\'t confirm that sent';
+
+  @override
   String dmReactionChipOwnA11yLabel(String emoji) {
     return 'あなたのリアクション: $emoji';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -5875,7 +5875,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get dmReelReplyFailed => '送信できませんでした';
 
   @override
-  String get dmReelReplyUnverified => 'Couldn\'t confirm that sent';
+  String get dmReelReplyUnverified => '送信を確認できませんでした';
 
   @override
   String dmReactionChipOwnA11yLabel(String emoji) {

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -5896,6 +5896,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get dmReelReplyFailed => '보내지 못했습니다';
 
   @override
+  String get dmReelReplyUnverified => 'Couldn\'t confirm that sent';
+
+  @override
   String dmReactionChipOwnA11yLabel(String emoji) {
     return '내 반응: $emoji';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -5896,7 +5896,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get dmReelReplyFailed => '보내지 못했습니다';
 
   @override
-  String get dmReelReplyUnverified => 'Couldn\'t confirm that sent';
+  String get dmReelReplyUnverified => '전송을 확인하지 못했습니다';
 
   @override
   String dmReactionChipOwnA11yLabel(String emoji) {

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -6203,7 +6203,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get dmReelReplyFailed => 'Tidak dapat menghantar';
 
   @override
-  String get dmReelReplyUnverified => 'Couldn\'t confirm that sent';
+  String get dmReelReplyUnverified => 'Tidak dapat mengesahkan penghantaran';
 
   @override
   String dmReactionChipOwnA11yLabel(String emoji) {

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -6203,6 +6203,9 @@ class AppLocalizationsMs extends AppLocalizations {
   String get dmReelReplyFailed => 'Tidak dapat menghantar';
 
   @override
+  String get dmReelReplyUnverified => 'Couldn\'t confirm that sent';
+
+  @override
   String dmReactionChipOwnA11yLabel(String emoji) {
     return 'Tindak balas anda: $emoji';
   }

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -6186,7 +6186,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get dmReelReplyFailed => 'Verzenden mislukt';
 
   @override
-  String get dmReelReplyUnverified => 'Couldn\'t confirm that sent';
+  String get dmReelReplyUnverified => 'Verzenden niet bevestigd';
 
   @override
   String dmReactionChipOwnA11yLabel(String emoji) {

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -6186,6 +6186,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get dmReelReplyFailed => 'Verzenden mislukt';
 
   @override
+  String get dmReelReplyUnverified => 'Couldn\'t confirm that sent';
+
+  @override
   String dmReactionChipOwnA11yLabel(String emoji) {
     return 'Jouw reactie: $emoji';
   }

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -6309,7 +6309,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get dmReelReplyFailed => 'Nie udało się wysłać';
 
   @override
-  String get dmReelReplyUnverified => 'Couldn\'t confirm that sent';
+  String get dmReelReplyUnverified => 'Nie udało się potwierdzić wysłania';
 
   @override
   String dmReactionChipOwnA11yLabel(String emoji) {

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -6309,6 +6309,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get dmReelReplyFailed => 'Nie udało się wysłać';
 
   @override
+  String get dmReelReplyUnverified => 'Couldn\'t confirm that sent';
+
+  @override
   String dmReactionChipOwnA11yLabel(String emoji) {
     return 'Twoja reakcja: $emoji';
   }

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -6199,6 +6199,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get dmReelReplyFailed => 'Não foi possível enviar';
 
   @override
+  String get dmReelReplyUnverified => 'Couldn\'t confirm that sent';
+
+  @override
   String dmReactionChipOwnA11yLabel(String emoji) {
     return 'Sua reação: $emoji';
   }

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -6199,7 +6199,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get dmReelReplyFailed => 'Não foi possível enviar';
 
   @override
-  String get dmReelReplyUnverified => 'Couldn\'t confirm that sent';
+  String get dmReelReplyUnverified => 'Não foi possível confirmar o envio';
 
   @override
   String dmReactionChipOwnA11yLabel(String emoji) {

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -6313,7 +6313,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get dmReelReplyFailed => 'Trimiterea a eșuat';
 
   @override
-  String get dmReelReplyUnverified => 'Couldn\'t confirm that sent';
+  String get dmReelReplyUnverified => 'Trimiterea nu a putut fi confirmată';
 
   @override
   String dmReactionChipOwnA11yLabel(String emoji) {

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -6313,6 +6313,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get dmReelReplyFailed => 'Trimiterea a eșuat';
 
   @override
+  String get dmReelReplyUnverified => 'Couldn\'t confirm that sent';
+
+  @override
   String dmReactionChipOwnA11yLabel(String emoji) {
     return 'Reacția ta: $emoji';
   }

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -6151,7 +6151,8 @@ class AppLocalizationsSv extends AppLocalizations {
   String get dmReelReplyFailed => 'Det gick inte att skicka';
 
   @override
-  String get dmReelReplyUnverified => 'Couldn\'t confirm that sent';
+  String get dmReelReplyUnverified =>
+      'Det gick inte att bekräfta att det skickades';
 
   @override
   String dmReactionChipOwnA11yLabel(String emoji) {

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -6151,6 +6151,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get dmReelReplyFailed => 'Det gick inte att skicka';
 
   @override
+  String get dmReelReplyUnverified => 'Couldn\'t confirm that sent';
+
+  @override
   String dmReactionChipOwnA11yLabel(String emoji) {
     return 'Din reaktion: $emoji';
   }

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -6124,7 +6124,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get dmReelReplyFailed => 'Gönderilemedi';
 
   @override
-  String get dmReelReplyUnverified => 'Couldn\'t confirm that sent';
+  String get dmReelReplyUnverified => 'Gönderim doğrulanamadı';
 
   @override
   String dmReactionChipOwnA11yLabel(String emoji) {

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -6124,6 +6124,9 @@ class AppLocalizationsTr extends AppLocalizations {
   String get dmReelReplyFailed => 'Gönderilemedi';
 
   @override
+  String get dmReelReplyUnverified => 'Couldn\'t confirm that sent';
+
+  @override
   String dmReactionChipOwnA11yLabel(String emoji) {
     return 'Senin tepkin: $emoji';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -6161,6 +6161,9 @@ class AppLocalizationsUr extends AppLocalizations {
   String get dmReelReplyFailed => 'نہیں بھیجا جا سکا';
 
   @override
+  String get dmReelReplyUnverified => 'Couldn\'t confirm that sent';
+
+  @override
   String dmReactionChipOwnA11yLabel(String emoji) {
     return 'آپ کا ردعمل: $emoji';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -6161,7 +6161,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get dmReelReplyFailed => 'نہیں بھیجا جا سکا';
 
   @override
-  String get dmReelReplyUnverified => 'Couldn\'t confirm that sent';
+  String get dmReelReplyUnverified => 'بھیجنے کی تصدیق نہیں ہو سکی';
 
   @override
   String dmReactionChipOwnA11yLabel(String emoji) {

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -6158,6 +6158,9 @@ class AppLocalizationsVi extends AppLocalizations {
   String get dmReelReplyFailed => 'Không gửi được';
 
   @override
+  String get dmReelReplyUnverified => 'Couldn\'t confirm that sent';
+
+  @override
   String dmReactionChipOwnA11yLabel(String emoji) {
     return 'Cảm xúc của bạn: $emoji';
   }

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -6158,7 +6158,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get dmReelReplyFailed => 'Không gửi được';
 
   @override
-  String get dmReelReplyUnverified => 'Couldn\'t confirm that sent';
+  String get dmReelReplyUnverified => 'Không xác nhận được đã gửi';
 
   @override
   String dmReactionChipOwnA11yLabel(String emoji) {

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -5855,7 +5855,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get dmReelReplyFailed => '发送失败';
 
   @override
-  String get dmReelReplyUnverified => 'Couldn\'t confirm that sent';
+  String get dmReelReplyUnverified => '无法确认是否已发送';
 
   @override
   String dmReactionChipOwnA11yLabel(String emoji) {

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -5855,6 +5855,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get dmReelReplyFailed => '发送失败';
 
   @override
+  String get dmReelReplyUnverified => 'Couldn\'t confirm that sent';
+
+  @override
   String dmReactionChipOwnA11yLabel(String emoji) {
     return '你的回应：$emoji';
   }

--- a/mobile/lib/widgets/video_feed_item/reel_dm_reply_bar.dart
+++ b/mobile/lib/widgets/video_feed_item/reel_dm_reply_bar.dart
@@ -366,7 +366,11 @@ class _ReelDmReplyBarState extends State<_ReelDmReplyBar> {
               // down along with the rest of this State.
               if (draft.isEmpty || !mounted || cubit.isClosed) return;
               _pendingDraft = draft;
-              cubit.submit(draft);
+              // `retry`, never `submit`: it re-drives the durable row the
+              // failed send parked, instead of minting a second rumor the
+              // recipient renders as a second message (#7316). The draft is
+              // only its fallback, for a send that parked no row at all.
+              cubit.retry(draft);
               _controller.clear();
             },
           ),

--- a/mobile/lib/widgets/video_feed_item/reel_dm_reply_bar.dart
+++ b/mobile/lib/widgets/video_feed_item/reel_dm_reply_bar.dart
@@ -349,7 +349,11 @@ class _ReelDmReplyBarState extends State<_ReelDmReplyBar> {
 
     switch (state.status) {
       case InlineReelReplyStatus.failure:
-        _showReplyFailed(draft, cubit);
+        // The parked rows are captured HERE, bound to the send that failed.
+        // This snackbar can outlive that send — queued behind another, it is
+        // never dismissed by a later success, which can only close a visible
+        // one — and by then `state.queuedRumorIds` describes some other send.
+        _showReplyFailed(draft, cubit, state.queuedRumorIds);
       case InlineReelReplyStatus.unverifiable:
         _showReplyUnverified();
       case InlineReelReplyStatus.success:
@@ -361,7 +365,11 @@ class _ReelDmReplyBarState extends State<_ReelDmReplyBar> {
     cubit.acknowledge();
   }
 
-  void _showReplyFailed(String draft, InlineReelReplyCubit cubit) {
+  void _showReplyFailed(
+    String draft,
+    InlineReelReplyCubit cubit,
+    List<String> parkedRumorIds,
+  ) {
     // Restore the draft so the user can retry without retyping.
     if (draft.isNotEmpty && _controller.text.isEmpty) {
       _controller.text = draft;
@@ -384,7 +392,7 @@ class _ReelDmReplyBarState extends State<_ReelDmReplyBar> {
             // failed send parked, instead of minting a second rumor the
             // recipient renders as a second message (#7316). The draft is
             // only its fallback, for a send that parked no row at all.
-            cubit.retry(draft);
+            cubit.retry(queuedRumorIds: parkedRumorIds, content: draft);
             _controller.clear();
           },
         ),

--- a/mobile/lib/widgets/video_feed_item/reel_dm_reply_bar.dart
+++ b/mobile/lib/widgets/video_feed_item/reel_dm_reply_bar.dart
@@ -347,64 +347,95 @@ class _ReelDmReplyBarState extends State<_ReelDmReplyBar> {
     // the player route is gone and this element is defunct.
     final cubit = context.read<InlineReelReplyCubit>();
 
-    if (state.status == InlineReelReplyStatus.failure) {
-      // Restore the draft so the user can retry without retyping.
-      if (draft.isNotEmpty && _controller.text.isEmpty) {
-        _controller.text = draft;
-        _controller.selection = TextSelection.collapsed(offset: draft.length);
-      }
-      _announce(context.l10n.dmReelReplyFailed);
-      _showRetrySnackBar(
-        (markVisible) => SnackBar(
-          content: Text(context.l10n.dmReelReplyFailed),
-          behavior: SnackBarBehavior.floating,
-          onVisible: markVisible,
-          action: SnackBarAction(
-            label: context.l10n.dmSendFailedRetry,
-            onPressed: () {
-              // `mounted` also guards `_controller`, which dispose() tears
-              // down along with the rest of this State.
-              if (draft.isEmpty || !mounted || cubit.isClosed) return;
-              _pendingDraft = draft;
-              // `retry`, never `submit`: it re-drives the durable row the
-              // failed send parked, instead of minting a second rumor the
-              // recipient renders as a second message (#7316). The draft is
-              // only its fallback, for a send that parked no row at all.
-              cubit.retry(draft);
-              _controller.clear();
-            },
-          ),
-        ),
-      );
-    } else {
-      final router = GoRouter.maybeOf(context);
-      final conversationPath = ConversationPage.pathForId(_ctx.conversationId);
-      final participantPubkeys = List<String>.of(_ctx.participantPubkeys);
-      _announce(context.l10n.dmReelReplySentAnnouncement);
-      widget.screenAnalytics.trackInteraction(
-        ReelReplyConstants.analyticsScreen,
-        'dm_reel_reply_sent',
-        params: {'is_group': _ctx.isGroup ? 1 : 0},
-      );
-      _closeRetrySnackBar();
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(context.l10n.shareSent),
-          behavior: SnackBarBehavior.floating,
-          action: router == null
-              ? null
-              : SnackBarAction(
-                  label: context.l10n.dmReelReplyViewChat,
-                  onPressed: () => _openChat(
-                    router,
-                    conversationPath: conversationPath,
-                    participantPubkeys: participantPubkeys,
-                  ),
-                ),
-        ),
-      );
+    switch (state.status) {
+      case InlineReelReplyStatus.failure:
+        _showReplyFailed(draft, cubit);
+      case InlineReelReplyStatus.unverifiable:
+        _showReplyUnverified();
+      case InlineReelReplyStatus.success:
+        _showReplySent();
+      case InlineReelReplyStatus.initial:
+      case InlineReelReplyStatus.sending:
+        return;
     }
     cubit.acknowledge();
+  }
+
+  void _showReplyFailed(String draft, InlineReelReplyCubit cubit) {
+    // Restore the draft so the user can retry without retyping.
+    if (draft.isNotEmpty && _controller.text.isEmpty) {
+      _controller.text = draft;
+      _controller.selection = TextSelection.collapsed(offset: draft.length);
+    }
+    _announce(context.l10n.dmReelReplyFailed);
+    _showRetrySnackBar(
+      (markVisible) => SnackBar(
+        content: Text(context.l10n.dmReelReplyFailed),
+        behavior: SnackBarBehavior.floating,
+        onVisible: markVisible,
+        action: SnackBarAction(
+          label: context.l10n.dmSendFailedRetry,
+          onPressed: () {
+            // `mounted` also guards `_controller`, which dispose() tears
+            // down along with the rest of this State.
+            if (draft.isEmpty || !mounted || cubit.isClosed) return;
+            _pendingDraft = draft;
+            // `retry`, never `submit`: it re-drives the durable row the
+            // failed send parked, instead of minting a second rumor the
+            // recipient renders as a second message (#7316). The draft is
+            // only its fallback, for a send that parked no row at all.
+            cubit.retry(draft);
+            _controller.clear();
+          },
+        ),
+      ),
+    );
+  }
+
+  /// A retry whose parked row had already gone: delivery is unknown.
+  ///
+  /// Deliberately offers no Retry. The row is consumed, so a further retry
+  /// would fall through to a fresh send and mint the duplicate #7316 closed —
+  /// which is also why the outstanding retry snackbar has to be dismissed
+  /// here rather than left holding a now-duplicating action. "View chat" is
+  /// the honest affordance: it shows the user what actually landed.
+  void _showReplyUnverified() {
+    _announce(context.l10n.dmReelReplyUnverified);
+    _closeRetrySnackBar();
+    _showChatSnackBar(context.l10n.dmReelReplyUnverified);
+  }
+
+  void _showReplySent() {
+    _announce(context.l10n.dmReelReplySentAnnouncement);
+    widget.screenAnalytics.trackInteraction(
+      ReelReplyConstants.analyticsScreen,
+      'dm_reel_reply_sent',
+      params: {'is_group': _ctx.isGroup ? 1 : 0},
+    );
+    _closeRetrySnackBar();
+    _showChatSnackBar(context.l10n.shareSent);
+  }
+
+  void _showChatSnackBar(String message) {
+    final router = GoRouter.maybeOf(context);
+    final conversationPath = ConversationPage.pathForId(_ctx.conversationId);
+    final participantPubkeys = List<String>.of(_ctx.participantPubkeys);
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(message),
+        behavior: SnackBarBehavior.floating,
+        action: router == null
+            ? null
+            : SnackBarAction(
+                label: context.l10n.dmReelReplyViewChat,
+                onPressed: () => _openChat(
+                  router,
+                  conversationPath: conversationPath,
+                  participantPubkeys: participantPubkeys,
+                ),
+              ),
+      ),
+    );
   }
 
   void _showRetrySnackBar(
@@ -476,7 +507,8 @@ class _ReelDmReplyBarState extends State<_ReelDmReplyBar> {
           listenWhen: (prev, curr) =>
               prev.status != curr.status &&
               (curr.status == InlineReelReplyStatus.success ||
-                  curr.status == InlineReelReplyStatus.failure),
+                  curr.status == InlineReelReplyStatus.failure ||
+                  curr.status == InlineReelReplyStatus.unverifiable),
           listener: (context, state) => _onReplyOutcome(state),
         ),
         BlocListener<ConversationReactionsCubit, ConversationReactionsState>(

--- a/mobile/packages/db_client/test/src/database/daos/direct_messages_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/direct_messages_dao_test.dart
@@ -595,6 +595,102 @@ void main() {
           expect(duplicate, isFalse);
         },
       );
+
+      test('dedups a re-wrapped rumor but not a re-minted retry outside the '
+          'matching window', () async {
+        const conversationId = 'receiver_side_convo';
+        const senderPubkey =
+            '1111111111111111111111111111111111111111111111111111111111111111';
+        const recipientPubkey =
+            '2222222222222222222222222222222222222222222222222222222222222222';
+        const text = 'reel reply probe';
+        final reelMessageId = 'r' * 64;
+
+        // A manual retry is minted only after the sender's OK-confirm budget
+        // expires, so it is outside the ±5s content match used for
+        // cross-protocol duplicate detection.
+        const firstCreatedAt = 1786700000;
+        const retryCreatedAt = firstCreatedAt + 13;
+
+        Future<bool> ingest({
+          required String rumorId,
+          required String giftWrapId,
+          required int createdAt,
+        }) => dao.insertMessage(
+          id: rumorId,
+          conversationId: conversationId,
+          senderPubkey: senderPubkey,
+          content: text,
+          createdAt: createdAt,
+          giftWrapId: giftWrapId,
+          replyToId: reelMessageId,
+          ownerPubkey: recipientPubkey,
+        );
+
+        // Correct retry: one kind-14 rumor, re-wrapped. The wrap id changes,
+        // but the stable receiver key is the rumor id, so only one row inserts.
+        expect(
+          await ingest(
+            rumorId: 'a' * 64,
+            giftWrapId: 'w' * 64,
+            createdAt: firstCreatedAt,
+          ),
+          isTrue,
+        );
+        expect(
+          await ingest(
+            rumorId: 'a' * 64,
+            giftWrapId: 'x' * 64,
+            createdAt: firstCreatedAt,
+          ),
+          isFalse,
+          reason: 'a re-wrapped replay of the same rumor must not insert again',
+        );
+
+        var rendered = await dao.getMessagesForConversation(conversationId);
+        expect(rendered, hasLength(1));
+
+        expect(
+          await dao.hasMatchingMessage(
+            conversationId: conversationId,
+            senderPubkey: senderPubkey,
+            content: text,
+            createdAt: retryCreatedAt,
+            ownerPubkey: recipientPubkey,
+          ),
+          isFalse,
+          reason: '13s apart is outside the ±5s window',
+        );
+        expect(
+          await dao.hasMatchingMessage(
+            conversationId: conversationId,
+            senderPubkey: senderPubkey,
+            content: text,
+            createdAt: firstCreatedAt + 4,
+            ownerPubkey: recipientPubkey,
+          ),
+          isTrue,
+          reason: 'positive control: the ±5s window still fires inside 5s',
+        );
+
+        // The bug: a fresh retry mints a second rumor id. Nothing collapses it.
+        expect(
+          await ingest(
+            rumorId: 'b' * 64,
+            giftWrapId: 'y' * 64,
+            createdAt: retryCreatedAt,
+          ),
+          isTrue,
+        );
+
+        rendered = await dao.getMessagesForConversation(conversationId);
+        expect(
+          rendered,
+          hasLength(2),
+          reason: 'two rumor ids for one message render as two bubbles',
+        );
+        expect(rendered.map((m) => m.content).toSet(), {text});
+      });
     });
 
     group('hasMessageWithSendBatchId', () {

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -3206,8 +3206,11 @@ class DmRepository {
   /// durable row, and the sweep then delivers one copy while the retry
   /// delivers another.
   ///
-  /// Only ever called from the two branches that finalize a surviving row;
-  /// the blocked branch deletes its row and the success branch consumes it.
+  /// Only ever called from the branches that finalize a surviving row — the
+  /// soft-unconfirmed and hard-failure arms of both [sendMessage] and
+  /// [sendGroupMessage]. The blocked branch deletes its row, a cancelled
+  /// group sibling never had one, and the success branch consumes it (except
+  /// on partial delivery — see [NIP17SendResult.queuedRumorId]).
   NIP17SendResult _stampQueuedRow(NIP17SendResult result, String rumorId) =>
       switch (result) {
         NIP17SendSuccess() => result,
@@ -4394,6 +4397,10 @@ class DmRepository {
   /// that inserts `direct_messages`; partial delivery → recipient
   /// `sent` + self `failed` so the recovery path can replay only the
   /// missing self-wraps without re-delivering to recipients).
+  ///
+  /// Each failure that leaves a row behind carries that row's
+  /// [NIP17SendResult.queuedRumorId], so a caller retries by re-driving the
+  /// surviving siblings ([recoverFullSend]) rather than fanning out again.
   @useResult
   Future<List<NIP17SendResult>> sendGroupMessage({
     required List<String> recipientPubkeys,
@@ -4701,6 +4708,13 @@ class DmRepository {
     // Classify each the same way the 1:1 path does — soft-unconfirmed stays
     // pending (plain optimistic bubble), a policy block is terminal (row
     // dropped), and a hard failure marks both wraps failed.
+    //
+    // The two surviving-row branches also stamp their sibling's queued rumor
+    // id onto the returned result, exactly as [sendMessage] does. Without it
+    // a group caller has no handle on the rows this send parked and its only
+    // way to "retry" is a fresh fan-out, which mints a whole second set of
+    // rumors the receiver cannot collapse (#7316). Cancelled and blocked
+    // siblings are deliberately unstamped: both leave no row behind.
     if (outgoingDao != null) {
       for (var i = 0; i < rumors.length; i++) {
         // A sibling skipped for cancellation has no live row to transition;
@@ -4719,12 +4733,14 @@ class DmRepository {
             outgoingDao: outgoingDao,
             rumorId: rumors[i].id,
           );
+          results[i] = _stampQueuedRow(result, rumors[i].id);
         } else {
           await _finalizeAfterRecipientFailure(
             outgoingDao: outgoingDao,
             rumorId: rumors[i].id,
             errorMessage: result.error ?? 'Unknown publish failure',
           );
+          results[i] = _stampQueuedRow(result, rumors[i].id);
         }
       }
     }

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -4401,6 +4401,11 @@ class DmRepository {
   /// Each failure that leaves a row behind carries that row's
   /// [NIP17SendResult.queuedRumorId], so a caller retries by re-driving the
   /// surviving siblings ([recoverFullSend]) rather than fanning out again.
+  ///
+  /// A sibling whose enqueue itself fails is reported and returned as a plain
+  /// failure with no `queuedRumorId`, and its publish is skipped — never
+  /// thrown out of this method, which would strand the siblings already
+  /// parked and push the caller back onto a duplicating fresh fan-out.
   @useResult
   Future<List<NIP17SendResult>> sendGroupMessage({
     required List<String> recipientPubkeys,
@@ -4513,26 +4518,46 @@ class DmRepository {
     // exist before the first (potentially slow) publish. Same contract as
     // sendMessage: no-op when the queue dao isn't wired in (older test
     // fixtures, NIP-04-only callers).
+    // Guarded per iteration, like the delivery loop below. `enqueue` swallows
+    // PK conflicts but still throws on a real write error (SQLite BUSY/LOCKED
+    // — OutgoingDmRetryService writes this table concurrently). Letting that
+    // escape would abandon the siblings already parked at 0..i-1: the caller
+    // would see a throw, hold no queuedRumorId for them, and a user retry
+    // would fan out fresh rumors alongside the sweep's replay of the parked
+    // ones — the exact double-delivery #7316 exists to close.
+    final failedToEnqueue = <int>{};
     if (outgoingDao != null) {
       for (var i = 0; i < recipientPubkeys.length; i++) {
         final rumor = rumors[i];
-        await outgoingDao.enqueue(
-          OutgoingDm(
-            id: rumor.id,
-            conversationId: conversationId,
-            recipientPubkey: recipientPubkeys[i],
-            content: content,
-            createdAt: rumor.createdAt,
-            rumorEventJson: jsonEncode(rumor.toJson()),
-            messageKind: rumor.kind,
-            replyToId: replyToId,
-            recipientWrapStatus: OutgoingWrapStatus.pending,
-            selfWrapStatus: OutgoingWrapStatus.pending,
-            queuedAt: DateTime.now(),
-            ownerPubkey: _userPubkey,
-            sendBatchId: sendBatchId,
-          ),
-        );
+        try {
+          await outgoingDao.enqueue(
+            OutgoingDm(
+              id: rumor.id,
+              conversationId: conversationId,
+              recipientPubkey: recipientPubkeys[i],
+              content: content,
+              createdAt: rumor.createdAt,
+              rumorEventJson: jsonEncode(rumor.toJson()),
+              messageKind: rumor.kind,
+              replyToId: replyToId,
+              recipientWrapStatus: OutgoingWrapStatus.pending,
+              selfWrapStatus: OutgoingWrapStatus.pending,
+              queuedAt: DateTime.now(),
+              ownerPubkey: _userPubkey,
+              sendBatchId: sendBatchId,
+            ),
+          );
+        } on Object catch (e, stackTrace) {
+          // No durable row for this sibling, so its publish is skipped below:
+          // a wire copy with no local trace is invisible to the sender and
+          // unretractable, strictly worse than not sending it.
+          failedToEnqueue.add(i);
+          _errorReporter?.call(
+            e,
+            stackTrace,
+            site: DmRepositoryReportableSites.sendGroupMessageEnqueueSibling,
+          );
+        }
       }
     }
 
@@ -4549,6 +4574,16 @@ class DmRepository {
     final cancelledBeforePublish = <int>{};
     for (var i = 0; i < recipientPubkeys.length; i++) {
       final pubkey = recipientPubkeys[i];
+      // A sibling whose row never got parked: publishing it would put a copy
+      // on the wire that no local row can retract or re-drive. Fail it here
+      // instead, before the cancel interlock below misreads the absent row as
+      // a user cancellation.
+      if (failedToEnqueue.contains(i)) {
+        results.add(
+          const NIP17SendResult.failure('could not queue send for recipient'),
+        );
+        continue;
+      }
       // Cancel interlock, mirroring _recoverFullSendLocked's pre-publish row
       // re-read: each publish can take up to the OK-confirm timeout, a long
       // window in which the user may delete the whole batch. Re-read the
@@ -4713,14 +4748,17 @@ class DmRepository {
     // id onto the returned result, exactly as [sendMessage] does. Without it
     // a group caller has no handle on the rows this send parked and its only
     // way to "retry" is a fresh fan-out, which mints a whole second set of
-    // rumors the receiver cannot collapse (#7316). Cancelled and blocked
-    // siblings are deliberately unstamped: both leave no row behind.
+    // rumors the receiver cannot collapse (#7316). Cancelled, un-enqueued and
+    // blocked siblings are deliberately unstamped: none leaves a row behind.
     if (outgoingDao != null) {
       for (var i = 0; i < rumors.length; i++) {
-        // A sibling skipped for cancellation has no live row to transition;
-        // an update-by-id would match zero rows anyway, but skipping is
-        // explicit and keeps a cancelled index from resurrecting anything.
-        if (cancelledBeforePublish.contains(i)) continue;
+        // A sibling skipped for cancellation, or whose enqueue threw, has no
+        // live row to transition; an update-by-id would match zero rows
+        // anyway, but skipping is explicit and keeps such an index from
+        // resurrecting a queue transition or a thread.
+        if (cancelledBeforePublish.contains(i) || failedToEnqueue.contains(i)) {
+          continue;
+        }
         final result = results[i];
         if (result.success) continue;
         if (result.blocked) {
@@ -4750,12 +4788,16 @@ class DmRepository {
     // the failed bubbles to retry or delete. All-blocked sends leave no
     // rows behind (terminal), so they create no thread cruft. A fully
     // cancelled batch must NOT resurrect the thread the user just deleted,
-    // so cancelled indexes don't count as retryable failures here.
-    final hasNonCancelledFailure = results.asMap().entries.any(
+    // so cancelled indexes don't count as retryable failures here. Nor do
+    // un-enqueued ones: they left no row, so the thread would hold no bubble
+    // to retry or delete.
+    final hasRetryableFailure = results.asMap().entries.any(
       (entry) =>
-          !cancelledBeforePublish.contains(entry.key) && !entry.value.blocked,
+          !cancelledBeforePublish.contains(entry.key) &&
+          !failedToEnqueue.contains(entry.key) &&
+          !entry.value.blocked,
     );
-    if (!results.any((r) => r.success) && hasNonCancelledFailure) {
+    if (!results.any((r) => r.success) && hasRetryableFailure) {
       await _ensureConversationVisibleAfterSendFailure(
         conversationId: conversationId,
         participants: participants,

--- a/mobile/packages/dm_repository/lib/src/dm_repository_reportable_sites.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository_reportable_sites.dart
@@ -63,6 +63,12 @@ abstract class DmRepositoryReportableSites {
   static const String sendMessageOuterTransaction =
       'sendMessage.outerTransaction';
 
+  /// `sendGroupMessage`: parking one sibling's `outgoing_dms` row threw.
+  /// That recipient's publish is skipped so no untraceable wire copy goes
+  /// out; the siblings already parked keep their rows and their handles.
+  static const String sendGroupMessageEnqueueSibling =
+      'sendGroupMessage.enqueueSibling';
+
   /// `backfillHistoryIfNeeded`: the history drain hit a programming
   /// invariant failure while paging or processing recovered events.
   static const String historyDrainUnexpectedFailure =

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -15571,7 +15571,7 @@ void main() {
             outgoingDmsDao: mockOutgoingDmsDao,
           );
 
-          final _ = await repository.sendGroupMessage(
+          final results = await repository.sendGroupMessage(
             recipientPubkeys: [_validPubkeyB, _validPubkeyC],
             content: 'one soft recipient',
           );
@@ -15581,6 +15581,16 @@ void main() {
           ).captured;
           final enqueuedB = captured.first as OutgoingDm;
           final enqueuedC = captured.last as OutgoingDm;
+
+          expect(results, hasLength(2));
+          expect(results.last.retryablePending, isTrue);
+          expect(
+            results.last.queuedRumorId,
+            equals(enqueuedC.id),
+            reason:
+                'soft-unconfirmed group siblings leave a live queue row that '
+                'manual retry must re-drive instead of minting a new rumor',
+          );
 
           verify(() => mockOutgoingDmsDao.deleteById(enqueuedB.id)).called(1);
           // Soft recipient: row stays pending (in-flight clock), only the
@@ -15618,7 +15628,7 @@ void main() {
             outgoingDmsDao: mockOutgoingDmsDao,
           );
 
-          final _ = await repository.sendGroupMessage(
+          final results = await repository.sendGroupMessage(
             recipientPubkeys: [_validPubkeyB, _validPubkeyC],
             content: 'one blocked recipient',
           );
@@ -15628,6 +15638,14 @@ void main() {
           ).captured;
           final enqueuedB = captured.first as OutgoingDm;
           final enqueuedC = captured.last as OutgoingDm;
+
+          expect(results, hasLength(2));
+          expect(results.last.blocked, isTrue);
+          expect(
+            results.last.queuedRumorId,
+            isNull,
+            reason: 'policy-blocked group siblings leave no row to re-drive',
+          );
 
           // Both the delivered row and the terminally-blocked row are
           // deleted; a block is terminal, not a retryable failure.
@@ -15664,6 +15682,17 @@ void main() {
 
           expect(results, hasLength(2));
           expect(results.every((r) => !r.success), isTrue);
+
+          final capturedRows = verify(
+            () => mockOutgoingDmsDao.enqueue(captureAny()),
+          ).captured.cast<OutgoingDm>();
+          expect(
+            results.map((r) => r.queuedRumorId),
+            equals(capturedRows.map((r) => r.id)),
+            reason:
+                'hard-failed group siblings leave retryable queue rows that '
+                'callers must be able to re-drive',
+          );
 
           verify(
             () => mockOutgoingDmsDao.markRecipientWrapStatus(
@@ -16496,6 +16525,16 @@ void main() {
           expect(results, hasLength(3));
           expect(results[1].success, isFalse);
           expect(results[2].success, isFalse);
+          expect(
+            results[1].queuedRumorId,
+            isNull,
+            reason: 'cancelled siblings leave no row to re-drive',
+          );
+          expect(
+            results[2].queuedRumorId,
+            isNull,
+            reason: 'cancelled siblings leave no row to re-drive',
+          );
           // Nothing is persisted locally: B's row was gone by the finalize
           // re-read, so the group bubble does not resurrect either.
           verifyNever(

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -15739,6 +15739,84 @@ void main() {
       );
 
       test(
+        'a sibling enqueue write failure never strands the rows already '
+        'parked ahead of it',
+        () async {
+          // `enqueue` swallows PK conflicts but still throws on a real write
+          // error — SQLite BUSY/LOCKED is reachable because
+          // OutgoingDmRetryService writes this table concurrently. Letting it
+          // escape would hand the caller a throw and no handle on the sibling
+          // already parked, whose only "retry" is then a fresh fan-out the
+          // receiver cannot collapse (#7316).
+          final enqueued = <OutgoingDm>[];
+          when(() => mockOutgoingDmsDao.enqueue(any())).thenAnswer((
+            invocation,
+          ) async {
+            final row = invocation.positionalArguments.first as OutgoingDm;
+            if (row.recipientPubkey == _validPubkeyC) {
+              throw StateError('database is locked');
+            }
+            enqueued.add(row);
+          });
+          stubSendRumor(
+            (_, _) async => const NIP17SendResult.failure('all relays down'),
+          );
+
+          final repository = createRepository(
+            outgoingDmsDao: mockOutgoingDmsDao,
+          );
+
+          final results = await repository.sendGroupMessage(
+            recipientPubkeys: [_validPubkeyB, _validPubkeyC],
+            content: 'one sibling cannot be parked',
+          );
+
+          expect(enqueued, hasLength(1));
+          expect(results, hasLength(2));
+          expect(
+            results.first.queuedRumorId,
+            equals(enqueued.single.id),
+            reason:
+                'the sibling that did park must reach the caller with its row '
+                'handle, or a retry re-sends it as a second rumor',
+          );
+          // No row parked for C, so nothing can re-drive or retract it: its
+          // publish must be skipped rather than put an untraceable copy on the
+          // wire.
+          expect(results.last.success, isFalse);
+          expect(results.last.queuedRumorId, isNull);
+          verify(
+            () => mockMessageService.sendRumor(
+              rumorEvent: any(named: 'rumorEvent'),
+              recipientPubkey: _validPubkeyB,
+              targetRelays: any(named: 'targetRelays'),
+              awaitRecipientOk: any(named: 'awaitRecipientOk'),
+              selfWrapOnSoftUnconfirmed: any(
+                named: 'selfWrapOnSoftUnconfirmed',
+              ),
+            ),
+          ).called(1);
+          verifyNever(
+            () => mockMessageService.sendRumor(
+              rumorEvent: any(named: 'rumorEvent'),
+              recipientPubkey: _validPubkeyC,
+              targetRelays: any(named: 'targetRelays'),
+              awaitRecipientOk: any(named: 'awaitRecipientOk'),
+              selfWrapOnSoftUnconfirmed: any(
+                named: 'selfWrapOnSoftUnconfirmed',
+              ),
+            ),
+          );
+          expect(
+            reporterCalls.map((c) => c.site),
+            contains(
+              DmRepositoryReportableSites.sendGroupMessageEnqueueSibling,
+            ),
+          );
+        },
+      );
+
+      test(
         'queue is opt-in: when no OutgoingDmsDao is injected, '
         'sendGroupMessage falls back to the direct-write behaviour',
         () async {

--- a/mobile/packages/models/lib/src/nip17_send_result.dart
+++ b/mobile/packages/models/lib/src/nip17_send_result.dart
@@ -106,9 +106,15 @@ sealed class NIP17SendResult {
   /// the sweep and the retry each deliver a copy. Receiver-side gift-wrap
   /// dedup keys on the rumor id and cannot collapse two of them.
   ///
-  /// `null` when there is no row to coalesce onto — always on success (the
-  /// row is consumed), on a [blocked] result (the send gate returns before
-  /// the enqueue), and whenever the queue DAO is not wired in.
+  /// `null` on every success, on a [blocked] result (the send gate returns
+  /// before the enqueue), and whenever the queue DAO is not wired in.
+  ///
+  /// On success that usually means there is no row left to point at — a fully
+  /// delivered send consumes it. Partial delivery is the exception: when
+  /// [selfWrapPublished] is `false` the row survives with a retryable
+  /// self-wrap and this still reads `null`. Finishing that row is the retry
+  /// sweep's job (or `recoverSelfWrap`'s); it must never be re-published to
+  /// the recipient, who already has the message — so no handle is offered.
   String? get queuedRumorId => null;
 
   /// The rumor event ID (kind 14/15) — the canonical message

--- a/mobile/test/blocs/dm/inline_reel_reply/inline_reel_reply_cubit_test.dart
+++ b/mobile/test/blocs/dm/inline_reel_reply/inline_reel_reply_cubit_test.dart
@@ -586,6 +586,22 @@ void main() {
         ).called(times);
       }
 
+      /// Stubs a group fan-out where every sibling fails and parks its row.
+      void stubGroupSendParks(List<String> queuedRumorIds) {
+        when(
+          () => repo.sendGroupMessage(
+            recipientPubkeys: any(named: 'recipientPubkeys'),
+            content: any(named: 'content'),
+            replyToId: any(named: 'replyToId'),
+          ),
+        ).thenAnswer(
+          (_) async => [
+            for (final id in queuedRumorIds)
+              NIP17SendResult.failure('nope', queuedRumorId: id),
+          ],
+        );
+      }
+
       test('re-drives the parked row and never mints a second rumor', () async {
         stubSendParks('row-1');
         when(
@@ -647,7 +663,7 @@ void main() {
         );
       });
 
-      test('drops a row that is already gone without re-sending', () async {
+      test('reports a row that is already gone as unverifiable', () async {
         stubSendParks('row-1');
         when(
           () => repo.recoverFullSend(
@@ -666,25 +682,98 @@ void main() {
         await cubit.retry('hi');
 
         // The sweep may already have delivered it; we cannot prove otherwise,
-        // so a replacement rumor is never minted.
+        // so a replacement rumor is never minted...
         verifySendMessageCalled(1);
-        expect(cubit.state.status, InlineReelReplyStatus.success);
+        // ...and for the same reason delivery is never claimed. `success` here
+        // would put "Sent" on screen for a row that may have been cancelled or
+        // may belong to another account.
+        expect(cubit.state.status, InlineReelReplyStatus.unverifiable);
+        expect(cubit.state.queuedRumorIds, isEmpty);
+      });
+
+      test(
+        'one sibling throwing does not skip the siblings after it',
+        () async {
+          stubGroupSendParks(const ['row-a', 'row-b']);
+          when(
+            () => repo.recoverFullSend(
+              rumorId: 'row-a',
+              resetRetryBudget: any(named: 'resetRetryBudget'),
+            ),
+          ).thenThrow(StateError('queue DAO exploded'));
+          when(
+            () => repo.recoverFullSend(
+              rumorId: 'row-b',
+              resetRetryBudget: any(named: 'resetRetryBudget'),
+            ),
+          ).thenAnswer(
+            (_) async => NIP17SendResult.success(
+              rumorEventId: 'row-b',
+              messageEventId: 'g',
+              recipientPubkey: _peer,
+            ),
+          );
+
+          final cubit = InlineReelReplyCubit(
+            dmRepository: repo,
+            replyContext: groupCtx(),
+          );
+          addTearDown(cubit.close);
+
+          await cubit.submit('hi');
+          await cubit.retry('hi');
+
+          // Aborting at row-a would have left row-b's parked copy to the sweep
+          // alone, with no user-facing handle on it.
+          verify(
+            () =>
+                repo.recoverFullSend(rumorId: 'row-b', resetRetryBudget: true),
+          ).called(1);
+          // row-a is still outstanding, so the retry affordance stays up and
+          // narrows to it.
+          expect(cubit.state.status, InlineReelReplyStatus.failure);
+          expect(cubit.state.queuedRumorIds, ['row-a']);
+        },
+      );
+
+      test('a succeeded sibling does not mask one that is gone', () async {
+        stubGroupSendParks(const ['row-a', 'row-b']);
+        when(
+          () => repo.recoverFullSend(
+            rumorId: 'row-a',
+            resetRetryBudget: any(named: 'resetRetryBudget'),
+          ),
+        ).thenAnswer(
+          (_) async => NIP17SendResult.success(
+            rumorEventId: 'row-a',
+            messageEventId: 'g',
+            recipientPubkey: _peer,
+          ),
+        );
+        when(
+          () => repo.recoverFullSend(
+            rumorId: 'row-b',
+            resetRetryBudget: any(named: 'resetRetryBudget'),
+          ),
+        ).thenThrow(ArgumentError.value('row-b', 'rumorId', 'no queued row'));
+
+        final cubit = InlineReelReplyCubit(
+          dmRepository: repo,
+          replyContext: groupCtx(),
+        );
+        addTearDown(cubit.close);
+
+        await cubit.submit('hi');
+        await cubit.retry('hi');
+
+        // Nothing is left to re-drive, but row-b was never confirmed, so the
+        // group outcome is unverifiable rather than sent.
+        expect(cubit.state.status, InlineReelReplyStatus.unverifiable);
         expect(cubit.state.queuedRumorIds, isEmpty);
       });
 
       test('re-drives every parked sibling of a group send', () async {
-        when(
-          () => repo.sendGroupMessage(
-            recipientPubkeys: any(named: 'recipientPubkeys'),
-            content: any(named: 'content'),
-            replyToId: any(named: 'replyToId'),
-          ),
-        ).thenAnswer(
-          (_) async => const [
-            NIP17SendResult.failure('nope', queuedRumorId: 'row-a'),
-            NIP17SendResult.failure('nope', queuedRumorId: 'row-b'),
-          ],
-        );
+        stubGroupSendParks(const ['row-a', 'row-b']);
         when(
           () => repo.recoverFullSend(
             rumorId: any(named: 'rumorId'),
@@ -717,7 +806,10 @@ void main() {
         verify(
           () => repo.recoverFullSend(rumorId: 'row-b', resetRetryBudget: true),
         ).called(1);
-        // A further retry targets exactly the sibling still outstanding.
+        // A further retry targets exactly the sibling still outstanding, and
+        // the outcome stays `failure` so the affordance offering it survives —
+        // one delivered sibling must not retire the retry for the other.
+        expect(cubit.state.status, InlineReelReplyStatus.failure);
         expect(cubit.state.queuedRumorIds, ['row-b']);
         // The original fan-out and only it — retry adds no second one.
         verify(

--- a/mobile/test/blocs/dm/inline_reel_reply/inline_reel_reply_cubit_test.dart
+++ b/mobile/test/blocs/dm/inline_reel_reply/inline_reel_reply_cubit_test.dart
@@ -551,5 +551,183 @@ void main() {
         );
       },
     );
+
+    // #7316. A NIP-17 message is identified by its kind-14 rumor id, and that
+    // id hashes the rumor's `created_at` — so a second `sendMessage` for the
+    // same text is a different event the receiver cannot collapse, delivered
+    // alongside the sweep's replay of the original row. Retry must re-drive
+    // that row instead of sending again.
+    group('retry', () {
+      /// Stubs a 1:1 send that parks [queuedRumorId]. `null` models a send
+      /// that left no row — a policy block, or an unwired queue DAO.
+      void stubSendParks(String? queuedRumorId) {
+        when(
+          () => repo.sendMessage(
+            recipientPubkey: any(named: 'recipientPubkey'),
+            content: any(named: 'content'),
+            replyToId: any(named: 'replyToId'),
+          ),
+        ).thenAnswer(
+          (_) async => NIP17SendResult.failure(
+            'no relay responded',
+            retryablePending: true,
+            queuedRumorId: queuedRumorId,
+          ),
+        );
+      }
+
+      void verifySendMessageCalled(int times) {
+        verify(
+          () => repo.sendMessage(
+            recipientPubkey: any(named: 'recipientPubkey'),
+            content: any(named: 'content'),
+            replyToId: any(named: 'replyToId'),
+          ),
+        ).called(times);
+      }
+
+      test('re-drives the parked row and never mints a second rumor', () async {
+        stubSendParks('row-1');
+        when(
+          () => repo.recoverFullSend(
+            rumorId: any(named: 'rumorId'),
+            resetRetryBudget: any(named: 'resetRetryBudget'),
+          ),
+        ).thenAnswer(
+          (_) async => NIP17SendResult.success(
+            rumorEventId: 'row-1',
+            messageEventId: 'g',
+            recipientPubkey: _peer,
+          ),
+        );
+
+        final cubit = InlineReelReplyCubit(
+          dmRepository: repo,
+          replyContext: oneToOne(),
+        );
+        addTearDown(cubit.close);
+
+        await cubit.submit('hi');
+        expect(cubit.state.status, InlineReelReplyStatus.failure);
+        expect(cubit.state.queuedRumorIds, ['row-1']);
+
+        await cubit.retry('hi');
+
+        expect(cubit.state.status, InlineReelReplyStatus.success);
+        expect(cubit.state.queuedRumorIds, isEmpty);
+        verify(
+          () => repo.recoverFullSend(rumorId: 'row-1', resetRetryBudget: true),
+        ).called(1);
+        // The anti-duplication contract: the original send, and only it.
+        verifySendMessageCalled(1);
+      });
+
+      test('falls back to a fresh send when nothing was parked', () async {
+        // A policy-blocked send returns before the enqueue, so there is no row
+        // to re-drive and no second copy a fresh send could duplicate.
+        stubSendParks(null);
+
+        final cubit = InlineReelReplyCubit(
+          dmRepository: repo,
+          replyContext: oneToOne(),
+        );
+        addTearDown(cubit.close);
+
+        await cubit.submit('hi');
+        expect(cubit.state.queuedRumorIds, isEmpty);
+
+        await cubit.retry('hi');
+
+        verifySendMessageCalled(2);
+        verifyNever(
+          () => repo.recoverFullSend(
+            rumorId: any(named: 'rumorId'),
+            resetRetryBudget: any(named: 'resetRetryBudget'),
+          ),
+        );
+      });
+
+      test('drops a row that is already gone without re-sending', () async {
+        stubSendParks('row-1');
+        when(
+          () => repo.recoverFullSend(
+            rumorId: any(named: 'rumorId'),
+            resetRetryBudget: any(named: 'resetRetryBudget'),
+          ),
+        ).thenThrow(ArgumentError.value('row-1', 'rumorId', 'no queued row'));
+
+        final cubit = InlineReelReplyCubit(
+          dmRepository: repo,
+          replyContext: oneToOne(),
+        );
+        addTearDown(cubit.close);
+
+        await cubit.submit('hi');
+        await cubit.retry('hi');
+
+        // The sweep may already have delivered it; we cannot prove otherwise,
+        // so a replacement rumor is never minted.
+        verifySendMessageCalled(1);
+        expect(cubit.state.status, InlineReelReplyStatus.success);
+        expect(cubit.state.queuedRumorIds, isEmpty);
+      });
+
+      test('re-drives every parked sibling of a group send', () async {
+        when(
+          () => repo.sendGroupMessage(
+            recipientPubkeys: any(named: 'recipientPubkeys'),
+            content: any(named: 'content'),
+            replyToId: any(named: 'replyToId'),
+          ),
+        ).thenAnswer(
+          (_) async => const [
+            NIP17SendResult.failure('nope', queuedRumorId: 'row-a'),
+            NIP17SendResult.failure('nope', queuedRumorId: 'row-b'),
+          ],
+        );
+        when(
+          () => repo.recoverFullSend(
+            rumorId: any(named: 'rumorId'),
+            resetRetryBudget: any(named: 'resetRetryBudget'),
+          ),
+        ).thenAnswer(
+          (invocation) async => invocation.namedArguments[#rumorId] == 'row-a'
+              ? NIP17SendResult.success(
+                  rumorEventId: 'row-a',
+                  messageEventId: 'g',
+                  recipientPubkey: _peer,
+                )
+              : const NIP17SendResult.failure('still down'),
+        );
+
+        final cubit = InlineReelReplyCubit(
+          dmRepository: repo,
+          replyContext: groupCtx(),
+        );
+        addTearDown(cubit.close);
+
+        await cubit.submit('hi');
+        expect(cubit.state.queuedRumorIds, ['row-a', 'row-b']);
+
+        await cubit.retry('hi');
+
+        verify(
+          () => repo.recoverFullSend(rumorId: 'row-a', resetRetryBudget: true),
+        ).called(1);
+        verify(
+          () => repo.recoverFullSend(rumorId: 'row-b', resetRetryBudget: true),
+        ).called(1);
+        // A further retry targets exactly the sibling still outstanding.
+        expect(cubit.state.queuedRumorIds, ['row-b']);
+        // The original fan-out and only it — retry adds no second one.
+        verify(
+          () => repo.sendGroupMessage(
+            recipientPubkeys: any(named: 'recipientPubkeys'),
+            content: any(named: 'content'),
+            replyToId: any(named: 'replyToId'),
+          ),
+        ).called(1);
+      });
+    });
   });
 }

--- a/mobile/test/blocs/dm/inline_reel_reply/inline_reel_reply_cubit_test.dart
+++ b/mobile/test/blocs/dm/inline_reel_reply/inline_reel_reply_cubit_test.dart
@@ -627,7 +627,10 @@ void main() {
         expect(cubit.state.status, InlineReelReplyStatus.failure);
         expect(cubit.state.queuedRumorIds, ['row-1']);
 
-        await cubit.retry('hi');
+        await cubit.retry(
+          queuedRumorIds: cubit.state.queuedRumorIds,
+          content: 'hi',
+        );
 
         expect(cubit.state.status, InlineReelReplyStatus.success);
         expect(cubit.state.queuedRumorIds, isEmpty);
@@ -637,6 +640,58 @@ void main() {
         // The anti-duplication contract: the original send, and only it.
         verifySendMessageCalled(1);
       });
+
+      test(
+        're-drives the ids it was given, not whatever state holds now',
+        () async {
+          // A retry affordance can outlive its own send: a snackbar queued
+          // behind another is never dismissed by the success path, which can
+          // only close a visible one. By the time it is tapped, a later
+          // successful send has cleared `queuedRumorIds` — reading it live
+          // would find nothing parked and fall through to a fresh send,
+          // duplicating a row the sweep is still re-driving.
+          stubSendParks('row-1');
+          when(
+            () => repo.recoverFullSend(
+              rumorId: any(named: 'rumorId'),
+              resetRetryBudget: any(named: 'resetRetryBudget'),
+            ),
+          ).thenAnswer(
+            (_) async => NIP17SendResult.success(
+              rumorEventId: 'row-1',
+              messageEventId: 'g',
+              recipientPubkey: _peer,
+            ),
+          );
+
+          final cubit = InlineReelReplyCubit(
+            dmRepository: repo,
+            replyContext: oneToOne(),
+          );
+          addTearDown(cubit.close);
+
+          await cubit.submit('hi');
+          // What the affordance for THAT send captured.
+          final captured = cubit.state.queuedRumorIds;
+          expect(captured, ['row-1']);
+
+          // A second, unrelated send succeeds and wipes the live handle.
+          stubSendSuccess();
+          await cubit.submit('and another');
+          expect(cubit.state.queuedRumorIds, isEmpty);
+
+          await cubit.retry(queuedRumorIds: captured, content: 'hi');
+
+          verify(
+            () => repo.recoverFullSend(
+              rumorId: 'row-1',
+              resetRetryBudget: true,
+            ),
+          ).called(1);
+          // Two submits, both deliberate. A third would be the duplicate.
+          verifySendMessageCalled(2);
+        },
+      );
 
       test('falls back to a fresh send when nothing was parked', () async {
         // A policy-blocked send returns before the enqueue, so there is no row
@@ -652,7 +707,10 @@ void main() {
         await cubit.submit('hi');
         expect(cubit.state.queuedRumorIds, isEmpty);
 
-        await cubit.retry('hi');
+        await cubit.retry(
+          queuedRumorIds: cubit.state.queuedRumorIds,
+          content: 'hi',
+        );
 
         verifySendMessageCalled(2);
         verifyNever(
@@ -679,7 +737,10 @@ void main() {
         addTearDown(cubit.close);
 
         await cubit.submit('hi');
-        await cubit.retry('hi');
+        await cubit.retry(
+          queuedRumorIds: cubit.state.queuedRumorIds,
+          content: 'hi',
+        );
 
         // The sweep may already have delivered it; we cannot prove otherwise,
         // so a replacement rumor is never minted...
@@ -721,7 +782,10 @@ void main() {
           addTearDown(cubit.close);
 
           await cubit.submit('hi');
-          await cubit.retry('hi');
+          await cubit.retry(
+            queuedRumorIds: cubit.state.queuedRumorIds,
+            content: 'hi',
+          );
 
           // Aborting at row-a would have left row-b's parked copy to the sweep
           // alone, with no user-facing handle on it.
@@ -764,7 +828,10 @@ void main() {
         addTearDown(cubit.close);
 
         await cubit.submit('hi');
-        await cubit.retry('hi');
+        await cubit.retry(
+          queuedRumorIds: cubit.state.queuedRumorIds,
+          content: 'hi',
+        );
 
         // Nothing is left to re-drive, but row-b was never confirmed, so the
         // group outcome is unverifiable rather than sent.
@@ -798,7 +865,10 @@ void main() {
         await cubit.submit('hi');
         expect(cubit.state.queuedRumorIds, ['row-a', 'row-b']);
 
-        await cubit.retry('hi');
+        await cubit.retry(
+          queuedRumorIds: cubit.state.queuedRumorIds,
+          content: 'hi',
+        );
 
         verify(
           () => repo.recoverFullSend(rumorId: 'row-a', resetRetryBudget: true),

--- a/mobile/test/widgets/video_feed_item/reel_dm_reply_bar_test.dart
+++ b/mobile/test/widgets/video_feed_item/reel_dm_reply_bar_test.dart
@@ -508,6 +508,72 @@ void main() {
     ).called(1);
   });
 
+  // #7316. The retry action must re-drive the row the failed send parked. A
+  // second `sendMessage` would mint a fresh rumor for the same text, and since
+  // the receiver's only stable dedup key is the rumor id — gift-wrap ids are
+  // randomised per wrap — it would render as a second message alongside the
+  // sweep's replay of the original.
+  testWidgets('tapping Retry re-drives the parked row, never re-sends', (
+    tester,
+  ) async {
+    when(
+      () => dmRepo.sendMessage(
+        recipientPubkey: any(named: 'recipientPubkey'),
+        content: any(named: 'content'),
+        replyToId: any(named: 'replyToId'),
+      ),
+    ).thenAnswer(
+      (_) async => const NIP17SendResult.failure(
+        'no relay responded',
+        retryablePending: true,
+        queuedRumorId: 'parked-row',
+      ),
+    );
+    when(
+      () => dmRepo.recoverFullSend(
+        rumorId: any(named: 'rumorId'),
+        resetRetryBudget: any(named: 'resetRetryBudget'),
+      ),
+    ).thenAnswer(
+      (_) async => NIP17SendResult.success(
+        rumorEventId: 'parked-row',
+        messageEventId: 'g',
+        recipientPubkey: _peer,
+      ),
+    );
+
+    await tester.pumpWidget(wrap(context()));
+    await tester.pump();
+
+    await tester.enterText(find.byType(TextField), 'hello');
+    await tester.pump();
+    await tester.tap(find.byType(IconButton));
+    await tester.pumpAndSettle();
+
+    final l10n = lookupAppLocalizations(const Locale('en'));
+    // Target the action, not its label: the label's own offset is inside the
+    // snackbar's slide transform and a tap there can miss the button.
+    await tester.tap(
+      find.widgetWithText(SnackBarAction, l10n.dmSendFailedRetry),
+    );
+    await tester.pumpAndSettle();
+
+    verify(
+      () => dmRepo.recoverFullSend(
+        rumorId: 'parked-row',
+        resetRetryBudget: true,
+      ),
+    ).called(1);
+    // The original send, and only it.
+    verify(
+      () => dmRepo.sendMessage(
+        recipientPubkey: _peer,
+        content: 'hello',
+        replyToId: _reelId,
+      ),
+    ).called(1);
+  });
+
   testWidgets('leaves a queued retry snackbar for whatever is on screen', (
     tester,
   ) async {

--- a/mobile/test/widgets/video_feed_item/reel_dm_reply_bar_test.dart
+++ b/mobile/test/widgets/video_feed_item/reel_dm_reply_bar_test.dart
@@ -574,6 +574,67 @@ void main() {
     ).called(1);
   });
 
+  testWidgets('a retry whose row is gone reports unverified, not sent', (
+    tester,
+  ) async {
+    when(
+      () => dmRepo.sendMessage(
+        recipientPubkey: any(named: 'recipientPubkey'),
+        content: any(named: 'content'),
+        replyToId: any(named: 'replyToId'),
+      ),
+    ).thenAnswer(
+      (_) async => const NIP17SendResult.failure(
+        'no relay responded',
+        retryablePending: true,
+        queuedRumorId: 'parked-row',
+      ),
+    );
+    // The row is gone: possibly delivered by the sweep, possibly cancelled,
+    // possibly another account's. Delivery cannot be proven either way.
+    when(
+      () => dmRepo.recoverFullSend(
+        rumorId: any(named: 'rumorId'),
+        resetRetryBudget: any(named: 'resetRetryBudget'),
+      ),
+    ).thenThrow(ArgumentError.value('parked-row', 'rumorId', 'no queued row'));
+
+    await tester.pumpWidget(wrap(context()));
+    await tester.pump();
+
+    await tester.enterText(find.byType(TextField), 'hello');
+    await tester.pump();
+    await tester.tap(find.byType(IconButton));
+    await tester.pumpAndSettle();
+
+    final l10n = lookupAppLocalizations(const Locale('en'));
+    await tester.tap(
+      find.widgetWithText(SnackBarAction, l10n.dmSendFailedRetry),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text(l10n.dmReelReplyUnverified), findsOneWidget);
+    // Claiming "Sent" would assert a delivery nothing confirmed.
+    expect(find.text(l10n.shareSent), findsNothing);
+    // And no second Retry: there is no row left to re-drive, so tapping one
+    // would fall through to a fresh send — the duplicate #7316 closed. The
+    // send count pins that nothing re-sent behind the snackbar's back.
+    expect(
+      find.widgetWithText(SnackBarAction, l10n.dmSendFailedRetry),
+      findsNothing,
+    );
+    // (The "View chat" affordance this outcome offers instead needs a router
+    // in the tree; `wrap` has none, so the shared snackbar builder drops the
+    // action here. The success path covers that branch.)
+    verify(
+      () => dmRepo.sendMessage(
+        recipientPubkey: _peer,
+        content: 'hello',
+        replyToId: _reelId,
+      ),
+    ).called(1);
+  });
+
   testWidgets('leaves a queued retry snackbar for whatever is on screen', (
     tester,
   ) async {

--- a/mobile/test/widgets/video_feed_item/reel_dm_reply_bar_test.dart
+++ b/mobile/test/widgets/video_feed_item/reel_dm_reply_bar_test.dart
@@ -635,6 +635,95 @@ void main() {
     ).called(1);
   });
 
+  testWidgets('a retry snackbar outliving its send still re-drives its row', (
+    tester,
+  ) async {
+    // The retry snackbar queues behind another, so the later success cannot
+    // dismiss it (`close()` only works on the visible one). When it finally
+    // surfaces and is tapped, the cubit's live `queuedRumorIds` has been
+    // cleared by that success — so a retry reading state instead of its own
+    // captured ids would fall through to a fresh send and duplicate a row the
+    // sweep is still re-driving.
+    var sends = 0;
+    when(
+      () => dmRepo.sendMessage(
+        recipientPubkey: any(named: 'recipientPubkey'),
+        content: any(named: 'content'),
+        replyToId: any(named: 'replyToId'),
+      ),
+    ).thenAnswer((_) async {
+      sends++;
+      if (sends == 1) {
+        return const NIP17SendResult.failure(
+          'no relay responded',
+          retryablePending: true,
+          queuedRumorId: 'parked-row',
+        );
+      }
+      return NIP17SendResult.success(
+        rumorEventId: 'r$sends',
+        messageEventId: 'm$sends',
+        recipientPubkey: _peer,
+      );
+    });
+    when(
+      () => dmRepo.recoverFullSend(
+        rumorId: any(named: 'rumorId'),
+        resetRetryBudget: any(named: 'resetRetryBudget'),
+      ),
+    ).thenAnswer(
+      (_) async => NIP17SendResult.success(
+        rumorEventId: 'parked-row',
+        messageEventId: 'g',
+        recipientPubkey: _peer,
+      ),
+    );
+
+    await tester.pumpWidget(wrap(context()));
+    await tester.pump();
+
+    final messenger = tester.state<ScaffoldMessengerState>(
+      find.byType(ScaffoldMessenger).first,
+    );
+    messenger.showSnackBar(
+      const SnackBar(
+        content: Text('unrelated'),
+        duration: Duration(seconds: 30),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // First send fails; its retry snackbar queues behind 'unrelated'.
+    await tester.enterText(find.byType(TextField), 'hello');
+    await tester.pump();
+    await tester.tap(find.byType(IconButton));
+    await tester.pumpAndSettle();
+
+    // Second send succeeds, clearing the live handle for the first one's row.
+    await tester.enterText(find.byType(TextField), 'world');
+    await tester.pump();
+    await tester.tap(find.byType(IconButton));
+    await tester.pumpAndSettle();
+
+    messenger.removeCurrentSnackBar();
+    await tester.pumpAndSettle();
+
+    final l10n = lookupAppLocalizations(const Locale('en'));
+    await tester.tap(
+      find.widgetWithText(SnackBarAction, l10n.dmSendFailedRetry),
+    );
+    await tester.pumpAndSettle();
+
+    verify(
+      () => dmRepo.recoverFullSend(
+        rumorId: 'parked-row',
+        resetRetryBudget: true,
+      ),
+    ).called(1);
+    // Two deliberate sends, no third: the stale tap re-drove, never re-sent.
+    expect(sends, 2);
+  });
+
   testWidgets('leaves a queued retry snackbar for whatever is on screen', (
     tester,
   ) async {


### PR DESCRIPTION
## Description

The reel DM reply bar's **Retry** action called `InlineReelReplyCubit.submit`, which is a fresh `DmRepository.sendMessage`. That mints a *new* kind-14 rumor and a second durable `outgoing_dms` row, while the original row is still parked and is independently re-published by `OutgoingDmRetryService` under its original id — so the recipient gets the same reply twice.

The cubit already had the handle it needed and was discarding it: it reduced `NIP17SendResult` to a single boolean (`ok = result.success`), dropping the `queuedRumorId` the repository deliberately stamps onto exactly these failures.

**Why the recipient can't collapse the copies.** A NIP-17 message's only stable identity is its kind-14 rumor id, and that id is a SHA-256 over the rumor's `created_at` (seconds, per NIP-01) — so a second `sendMessage` for the same text is a different event. Nothing downstream can merge them:

- Gift-wrap ids are useless as a key: NIP-59 mints a fresh ephemeral keypair per wrap and randomises the wrap/seal `created_at` ("The canonical `created_at` time belongs to the `rumor`"), so even *re-wrapping one rumor* yields a new wrap id.
- NIP-44 v2 ciphertext is nonce-randomised, so no payload-level match is possible either.
- `direct_messages` is keyed on the rumor id (`tables.dart`, `primaryKey => {id}`) and inserts `insertOrIgnore`. Two rumor ids ⇒ two rows ⇒ two bubbles.
- The receive path's one content-level check, `hasMatchingMessage`, is a ±5s window — and cannot reach this case, because a soft-unconfirmed send burns the full 10s `DmSendBudget.recipientOkConfirm` window before the failure snackbar even renders. Its own doc comment rules out widening it: *"a re-minted rumor is indistinguishable from a genuine second send."*

The soft-unconfirmed case is the worse one: the first copy typically *did* reach a relay and only the acknowledgement was lost, so Retry duplicated a message that was never actually lost.

This is the last instance of the pattern in the app. `ConversationBloc` and `ReportSubmissionCubit` already re-drive via `recoverFullSend`, and `ShareSheetBloc` declines a manual retry altogether, naming this exact double-delivery in its comment.

**Related Issue:** Closes #7316

### What changed

**`fix(dm): stamp the queued rumor id on group send failures`** — `_stampQueuedRow` ran only in `sendMessage`, so every `sendGroupMessage` failure returned `queuedRumorId == null` and a group caller had no handle on the rows it had just parked. Both surviving-row branches now stamp, matching the 1:1 path; cancelled and blocked siblings stay unstamped because neither leaves a row behind. `sendSharedVideoGroup` delegates here, so both group reply shapes are covered.

Also corrects `NIP17SendResult.queuedRumorId`'s own contract, which claimed the row is *"always consumed"* on success — partial delivery (`selfWrapPublished == false`) leaves a live row that the sweep or `recoverSelfWrap` must finish, never a recipient re-publish.

**`fix(dm): re-drive the parked row when a reel reply retry is tapped`** — `InlineReelReplyState` now carries `queuedRumorIds`, and a new `InlineReelReplyCubit.retry()` re-drives each parked row via `recoverFullSend(resetRetryBudget: true)`, the same shape `ConversationBloc` and `ReportSubmissionCubit` use. A row that has gone (`ArgumentError`) is dropped rather than re-sent — we cannot prove the original did not land. `submit` remains the fallback only when nothing was parked, which is safe because a policy block returns before the enqueue.

**`fix(dm): guard the group enqueue loop so a write failure strands no parked row`** — `sendGroupMessage` parked its siblings in an unguarded loop. `outgoingDao.enqueue` swallows PK conflicts but still throws on a real write error (SQLite `BUSY`/`LOCKED` is reachable — `OutgoingDmRetryService` writes the same table concurrently), and a throw at iteration `i > 0` escaped the method with rows `0..i-1` already parked. The caller then held no `queuedRumorId` for them, so `retry` saw an empty parked list and fell back to a fresh fan-out — the sweep replaying the original rumors alongside freshly minted ones, i.e. this same bug reopened on the submit side.

Now caught per iteration, like the delivery loop below it. A sibling whose enqueue throws is reported through the error port and its publish is skipped: with no durable row, a wire copy would be invisible to the sender and unretractable. It is excluded from the finalize pass and the thread-visibility check for the same reason — it leaves no bubble to retry or delete.

**`fix(dm): stop a reel reply retry claiming a send it could not verify`** — three findings on the retry loop, one shape.

`recoverFullSend` raises `ArgumentError` both when the parked row is gone and when it belongs to another account, and the loop counted that toward success — so the bar showed **Sent** for a delivery nothing confirmed. Flipping it to `failure` would be worse: the row is consumed, so the retry affordance would fall through to `submit` and mint the exact duplicate this flow prevents. New `InlineReelReplyStatus.unverifiable` instead — non-committal copy, **View chat** rather than another **Retry** — mirroring `ModerationDmOutcome.unverifiable`.

A non-`ArgumentError` from one sibling aborted the loop, skipping every sibling after it and leaving their parked copies to the sweep with no user-facing handle. Now caught per id and reported once at the end, matching `ConversationBloc._onFullSendRecoveryRequested`.

Partial group recovery emitted success off any one sibling, retiring the retry affordance while others were still parked. Now **all-succeeded**, also matching `ConversationBloc`: the outcome is the worst one seen, and a further retry narrows to exactly the rows still outstanding.


**`fix(dm): bind a reel reply retry to the send it belongs to`** — *not requested by review.* Found while re-reading the retry path, and reproduced.

`retry` read `queuedRumorIds` off the live state, but a retry affordance can outlive its own send: a failure snackbar that queues behind another is never dismissed by the success path (`_closeRetrySnackBar` can only close a *visible* snackbar), and `submit` clears `queuedRumorIds` on success because *that* send left nothing parked. So a later successful send wipes an earlier failure's handle while its row is still parked, the stale Retry tap finds an empty list, falls through to `submit`, and mints a second rumor for a message the sweep is still re-driving. Same double-delivery, different door.

Reproduced in a widget harness before fixing: send #1 fails and parks a row → its snackbar queues behind an unrelated one → send #2 succeeds → blocker dismissed → tapping the surfaced Retry drove a **third** `sendMessage`. `retry` now takes the parked ids as a required argument, captured by the View when it builds that send's snackbar, so an affordance can only ever re-drive the rows its own send parked. The empty-list fallback to a fresh send is unchanged and now correctly scoped.


## Out of Scope

- **Whether a soft-unconfirmed reel reply should show a red "failed" snackbar at all** — filed as #7441. It arguably should not: `ConversationBloc:237-244` already treats `retryablePending` as `SendStatus.sent` ("a lost OK is not proof of loss, so surface no red failure"), and the reel bar contradicts that. #7316 asked for this to be decided explicitly rather than folded in, so it is left alone here. Resolving it toward the `ConversationBloc` behaviour would additionally shrink this bug's blast radius by removing the Retry affordance from the case most likely to have already been delivered.
- **`divine-web` has a structurally similar retry** — filed as divinevideo/divine-web#578. `handleRetry` passes the original `clientId`, and `onMutate` honours it (the local outbox record is reused), but `mutationFn` destructures only `{participantPubkeys, content}` and rebuilds the rumor through `createRumorEvent`, whose `created_at: now()` the id hashes over. Lower severity than here, since web has no background sweep re-driving a parked row, but "landed but unconfirmed → retry" still double-delivers. Read off the code; not yet reproduced end-to-end, which the issue says explicitly.
- **A relay-side lead** — filed as #7442. Kind 1059 falls below the relay's auto-allow ranges, so every gift wrap takes uncached `allowed_kinds`/`disallowed_kinds` ClickHouse lookups before the `OK` is emitted, each capped at 10s — the same 10s the client waits. That would produce the soft-unconfirmed state directly. Unmeasured; settling it needs production OK-latency percentiles for 1059, and the issue is written to say nothing should be acted on before that.

## Verification

**Runtime, on a physical iPhone (iOS 26.6).** New E2E drives the real `ReelDmReplyBar` → `InlineReelReplyCubit` → `DmRepository` over a real socket to an in-process relay started with `okConfirms: false` — a relay that accepts the frame and never `OK`s, i.e. the exact soft-unconfirmed shape.

| | before fix | after fix |
|---|---|---|
| rows after first send | 1 | 1 |
| wraps published by the retry | +1 | +1 |
| **rows after retry** | **2, two distinct rumor ids, identical text** | **1, the original id** |

The "wraps published" row is a positive control: without it, a Retry tap that silently missed the snackbar's hit target would leave one row and read as "no bug" — which is exactly what happened on the first attempt at this test. The assertion cannot pass unless the retry really dispatched a publish.

A `db_client` `DirectMessagesDao` test pins the receiver side against the real `direct_messages` schema: one rumor arriving via two different gift wraps collapses to **1** bubble, two rumor ids render as **2**, and `hasMatchingMessage` is asserted in both directions (misses at 13s, fires at 4s) so a future widening of that window trips the package test.

**Review round 2.** The two new fixes are unit-covered rather than re-driven on device — neither changes what goes on the wire, only which local row the app reaches for.

- The group enqueue guard has a `dm_repository` test that stubs `enqueue` to throw for the second sibling only. It asserts the method returns instead of throwing, that the first sibling's result still carries its `queuedRumorId`, that the un-parked sibling's publish is **skipped** (`verifyNever` on `sendRumor` for that recipient), and that the error reaches the reporter port. On the old code the call throws out of `sendGroupMessage`, so the test cannot pass without the fix.
- The retry-loop changes have three cubit tests: a gone row now reads `unverifiable` (was `success`); a `StateError` on the first sibling no longer skips the second (`verify` that the later `recoverFullSend` still ran); and a delivered sibling no longer masks a gone one. The existing group test additionally pins the all-succeeded status.
- A widget test reproduces the stale-affordance path end to end (queue a blocker snackbar, fail send #1, succeed send #2, dismiss the blocker, tap the surfaced Retry) and asserts the parked row is re-driven and `sendMessage` ran exactly twice. On the old code the tap made it three.
- A widget test taps Retry against a repository whose `recoverFullSend` throws `ArgumentError`, and asserts the snackbar reads "Couldn't confirm that sent", that "Sent" is **absent**, and that no second Retry action is offered — the affordance that would otherwise fall through to `submit` and duplicate.

Post-fix E2E was re-run on the iOS Simulator rather than the phone — the device locked partway through and the install stalls on a locked device. The pre-fix reproduction ran on the physical device.

**Checks run**
- `flutter analyze lib test integration_test packages/dm_repository` — clean
- `flutter test test/blocs/dm test/widgets/video_feed_item test/l10n test/screens/inbox` — green
- `flutter test` in `packages/dm_repository` — 612 pass (611 + the new enqueue-failure test)
- `flutter test test/l10n/arb_consistency_test.dart` — green after mirroring the new key into all 21 non-English locales
- `dart format --set-exit-if-changed` on every changed file — clean
- Earlier rounds, unchanged by this push: `packages/models` (913), the E2E (`integration_test/e2e/reel_reply_retry_double_send_test.dart`), and the `db_client` `DirectMessagesDao` dedup test

**Visual change.** The failure snackbar and its Retry label are untouched. The new `unverifiable` outcome adds one snackbar — "Couldn't confirm that sent" with a **View chat** action and no Retry — reached only when a retry finds its parked row already gone. New l10n key `dmReelReplyUnverified`, mirrored into all 21 non-English locales.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore


