### PR TITLE
feat(startup): log build provenance

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -56,6 +56,7 @@ import 'package:openvine/l10n/current_app_l10n.dart';
 import 'package:openvine/l10n/email_verification_error_l10n.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/l10n/resolve_app_ui_locale.dart';
+import 'package:openvine/models/environment_config.dart';
 import 'package:openvine/notifications/routing/notification_tap_target.dart';
 import 'package:openvine/notifications/view/notifications_page.dart';
 import 'package:openvine/observability/divine_bloc_observer.dart';
@@ -1429,22 +1430,21 @@ Future<void> _startOpenVineApp() async {
   // See #3758.
   final buildTag = '${packageInfo.version}+${packageInfo.buildNumber}';
   unawaited(CrashReportingService.instance.setCustomKey('build_tag', buildTag));
-  final shorebirdUpdater = ShorebirdUpdater();
-  unawaited(
-    _recordBuildProvenance(
-      BuildProvenanceService(
+
+  // Provenance is diagnostic, so it waits for the first frame. Constructing a
+  // ShorebirdUpdater probes the Rust updater over FFI on the calling thread,
+  // which upstream flags as a hang risk while the auto-update thread holds the
+  // config lock — not something to run before runApp.
+  final environment = container.read(currentEnvironmentProvider).environment;
+  WidgetsBinding.instance.addPostFrameCallback((_) {
+    unawaited(
+      _recordBuildProvenance(
         packageInfo: packageInfo,
         installSource: installSource,
-        environment: container.read(currentEnvironmentProvider).environment,
-        platform: _startupPlatformName(),
-        shorebirdAvailable: shorebirdUpdater.isAvailable,
-        buildMode: BuildMode.current,
-        readPatchNumber: shorebirdUpdater.isAvailable
-            ? () async => (await shorebirdUpdater.readCurrentPatch())?.number
-            : null,
+        environment: environment,
       ),
-    ),
-  );
+    );
+  });
 
   runApp(
     ContainerSwapHost(
@@ -1458,11 +1458,23 @@ Future<void> _startOpenVineApp() async {
   );
 }
 
-Future<void> _recordBuildProvenance(
-  BuildProvenanceService provenanceService,
-) async {
+Future<void> _recordBuildProvenance({
+  required PackageInfo packageInfo,
+  required InstallSource installSource,
+  required AppEnvironment environment,
+}) async {
   try {
-    final provenance = await provenanceService.resolve();
+    final shorebirdUpdater = ShorebirdUpdater();
+    final provenance = await BuildProvenanceService(
+      packageInfo: packageInfo,
+      installSource: installSource,
+      environment: environment,
+      platform: _startupPlatformName(),
+      shorebirdAvailable: shorebirdUpdater.isAvailable,
+      buildMode: BuildMode.current,
+      readPatchNumber: () async =>
+          (await shorebirdUpdater.readCurrentPatch())?.number,
+    ).resolve();
     Log.info(provenance.summary, name: 'Main', category: LogCategory.system);
     CrashReportingService.instance.log(provenance.summary);
     unawaited(

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -1479,6 +1479,18 @@ Future<void> _recordBuildProvenance({
     CrashReportingService.instance.log(provenance.summary);
     unawaited(
       CrashReportingService.instance.setCustomKey(
+        'environment',
+        provenance.environment.name,
+      ),
+    );
+    unawaited(
+      CrashReportingService.instance.setCustomKey(
+        'build_mode',
+        provenance.buildMode.name,
+      ),
+    );
+    unawaited(
+      CrashReportingService.instance.setCustomKey(
         'install_source',
         provenance.installSource.name,
       ),

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -96,6 +96,7 @@ import 'package:openvine/screens/video_recorder_screen.dart';
 import 'package:openvine/services/app_engagement_store.dart';
 import 'package:openvine/services/back_button_handler.dart';
 import 'package:openvine/services/bandwidth_tracker_service.dart';
+import 'package:openvine/services/build_provenance_service.dart';
 import 'package:openvine/services/c2pa_signing_service.dart';
 import 'package:openvine/services/collaborator_invite_service.dart';
 import 'package:openvine/services/corrupted_video_repair_service.dart';
@@ -146,6 +147,7 @@ import 'package:permissions_service/permissions_service.dart';
 import 'package:pro_image_editor/pro_image_editor.dart'
     show LayerRasterizerHost;
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:shorebird_code_push/shorebird_code_push.dart';
 import 'package:unified_logger/unified_logger.dart';
 import 'package:window_manager/window_manager.dart';
 
@@ -1425,10 +1427,22 @@ Future<void> _startOpenVineApp() async {
   // Tag every crash report with the running build so per-error triage doesn't
   // have to cross-reference the release dashboard. Set once, not per-error.
   // See #3758.
+  final buildTag = '${packageInfo.version}+${packageInfo.buildNumber}';
+  unawaited(CrashReportingService.instance.setCustomKey('build_tag', buildTag));
+  final shorebirdUpdater = ShorebirdUpdater();
   unawaited(
-    CrashReportingService.instance.setCustomKey(
-      'build_tag',
-      '${packageInfo.version}+${packageInfo.buildNumber}',
+    _recordBuildProvenance(
+      BuildProvenanceService(
+        packageInfo: packageInfo,
+        installSource: installSource,
+        environment: container.read(currentEnvironmentProvider).environment,
+        platform: _startupPlatformName(),
+        shorebirdAvailable: shorebirdUpdater.isAvailable,
+        buildMode: BuildMode.current,
+        readPatchNumber: shorebirdUpdater.isAvailable
+            ? () async => (await shorebirdUpdater.readCurrentPatch())?.number
+            : null,
+      ),
     ),
   );
 
@@ -1442,6 +1456,59 @@ Future<void> _startOpenVineApp() async {
       ),
     ),
   );
+}
+
+Future<void> _recordBuildProvenance(
+  BuildProvenanceService provenanceService,
+) async {
+  try {
+    final provenance = await provenanceService.resolve();
+    Log.info(provenance.summary, name: 'Main', category: LogCategory.system);
+    CrashReportingService.instance.log(provenance.summary);
+    unawaited(
+      CrashReportingService.instance.setCustomKey(
+        'install_source',
+        provenance.installSource.name,
+      ),
+    );
+    unawaited(
+      CrashReportingService.instance.setCustomKey(
+        'shorebird_available',
+        provenance.shorebirdAvailable,
+      ),
+    );
+    unawaited(
+      CrashReportingService.instance.setCustomKey(
+        'shorebird_patch',
+        provenance.patchLabel,
+      ),
+    );
+  } catch (error, stack) {
+    Log.warning(
+      'Build provenance logging failed: $error',
+      name: 'Main',
+      category: LogCategory.system,
+    );
+    unawaited(
+      CrashReportingService.instance.recordError(
+        error,
+        stack,
+        reason: 'Build provenance logging failed',
+      ),
+    );
+  }
+}
+
+String _startupPlatformName() {
+  if (kIsWeb) return 'web';
+  return switch (defaultTargetPlatform) {
+    TargetPlatform.android => 'android',
+    TargetPlatform.iOS => 'ios',
+    TargetPlatform.macOS => 'macos',
+    TargetPlatform.windows => 'windows',
+    TargetPlatform.linux => 'linux',
+    TargetPlatform.fuchsia => 'fuchsia',
+  };
 }
 
 /// Initialize core identity services after the first frame.

--- a/mobile/lib/services/build_provenance_service.dart
+++ b/mobile/lib/services/build_provenance_service.dart
@@ -1,0 +1,123 @@
+// ABOUTME: Formats startup build provenance for release QA and crash triage.
+// ABOUTME: Keeps Shorebird patch inspection best-effort and non-fatal.
+
+import 'package:app_update_repository/app_update_repository.dart';
+import 'package:flutter/foundation.dart';
+import 'package:openvine/models/environment_config.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+
+typedef ShorebirdPatchReader = Future<int?> Function();
+
+enum BuildMode {
+  debug,
+  profile,
+  release;
+
+  static BuildMode get current {
+    if (kDebugMode) return BuildMode.debug;
+    if (kProfileMode) return BuildMode.profile;
+    return BuildMode.release;
+  }
+}
+
+enum ShorebirdPatchStatus { unavailable, none, installed, unknown }
+
+@immutable
+class BuildProvenance {
+  const BuildProvenance({
+    required this.version,
+    required this.buildNumber,
+    required this.buildMode,
+    required this.environment,
+    required this.platform,
+    required this.installSource,
+    required this.shorebirdAvailable,
+    required this.patchStatus,
+    this.patchNumber,
+  });
+
+  final String version;
+  final String buildNumber;
+  final BuildMode buildMode;
+  final AppEnvironment environment;
+  final String platform;
+  final InstallSource installSource;
+  final bool shorebirdAvailable;
+  final ShorebirdPatchStatus patchStatus;
+  final int? patchNumber;
+
+  String get buildTag => '$version+$buildNumber';
+
+  String get shorebirdStatus =>
+      shorebirdAvailable ? 'available' : 'unavailable';
+
+  String get patchLabel {
+    return switch (patchStatus) {
+      ShorebirdPatchStatus.unavailable => 'unavailable',
+      ShorebirdPatchStatus.none => 'none',
+      ShorebirdPatchStatus.installed => '${patchNumber ?? 'unknown'}',
+      ShorebirdPatchStatus.unknown => 'unknown',
+    };
+  }
+
+  String get summary =>
+      '[BUILD] $buildTag · ${buildMode.name} · env=${environment.name} · '
+      '$platform · install=${installSource.name} · '
+      'shorebird=$shorebirdStatus · patch=$patchLabel';
+}
+
+class BuildProvenanceService {
+  const BuildProvenanceService({
+    required this.packageInfo,
+    required this.installSource,
+    required this.environment,
+    required this.platform,
+    required this.shorebirdAvailable,
+    this.buildMode = BuildMode.release,
+    this.readPatchNumber,
+  });
+
+  final PackageInfo packageInfo;
+  final InstallSource installSource;
+  final AppEnvironment environment;
+  final String platform;
+  final bool shorebirdAvailable;
+  final BuildMode buildMode;
+  final ShorebirdPatchReader? readPatchNumber;
+
+  Future<BuildProvenance> resolve() async {
+    if (!shorebirdAvailable || readPatchNumber == null) {
+      return _provenance(patchStatus: ShorebirdPatchStatus.unavailable);
+    }
+
+    try {
+      final patchNumber = await readPatchNumber!();
+      if (patchNumber == null) {
+        return _provenance(patchStatus: ShorebirdPatchStatus.none);
+      }
+      return _provenance(
+        patchStatus: ShorebirdPatchStatus.installed,
+        patchNumber: patchNumber,
+      );
+    } catch (_) {
+      return _provenance(patchStatus: ShorebirdPatchStatus.unknown);
+    }
+  }
+
+  BuildProvenance _provenance({
+    required ShorebirdPatchStatus patchStatus,
+    int? patchNumber,
+  }) {
+    return BuildProvenance(
+      version: packageInfo.version,
+      buildNumber: packageInfo.buildNumber,
+      buildMode: buildMode,
+      environment: environment,
+      platform: platform,
+      installSource: installSource,
+      shorebirdAvailable: shorebirdAvailable,
+      patchStatus: patchStatus,
+      patchNumber: patchNumber,
+    );
+  }
+}

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -2196,6 +2196,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
+  shorebird_code_push:
+    dependency: "direct main"
+    description:
+      name: shorebird_code_push
+      sha256: "32df9946782c6ca95d7065c7f2156df74675e931b816d0dc391a3d8f8917930f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.7"
   skeletonizer:
     dependency: "direct main"
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -329,6 +329,7 @@ dependencies:
   flutter_native_splash: ^2.4.7
   flutter_local_notifications: ^21.0.0
   package_info_plus: ^9.0.0
+  shorebird_code_push: ^2.0.7
   # Triggers the OS-native review card (SKStoreReviewController on iOS,
   # Google Play in-app review on Android). Used by AppReviewCoordinator to
   # ask engaged, store-installed creators to rate the app — no custom dialog.

--- a/mobile/test/services/build_provenance_service_test.dart
+++ b/mobile/test/services/build_provenance_service_test.dart
@@ -1,0 +1,122 @@
+import 'package:app_update_repository/app_update_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/models/environment_config.dart';
+import 'package:openvine/services/build_provenance_service.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+
+void main() {
+  group('BuildProvenanceService', () {
+    test('formats a release build with installed Shorebird patch', () async {
+      final provenance = await _service(
+        buildMode: BuildMode.release,
+        installSource: InstallSource.playStore,
+        shorebirdAvailable: true,
+        readPatchNumber: () async => 3,
+      ).resolve();
+
+      expect(
+        provenance.summary,
+        '[BUILD] 1.0.20+837 · release · env=production · android · '
+        'install=playStore · shorebird=available · patch=3',
+      );
+      expect(provenance.buildTag, '1.0.20+837');
+      expect(provenance.patchLabel, '3');
+    });
+
+    test('formats each build mode', () async {
+      for (final buildMode in BuildMode.values) {
+        final provenance = await _service(buildMode: buildMode).resolve();
+
+        expect(provenance.summary, contains(' · ${buildMode.name} · '));
+      }
+    });
+
+    test('formats each install source', () async {
+      for (final installSource in InstallSource.values) {
+        final provenance = await _service(
+          installSource: installSource,
+        ).resolve();
+
+        expect(provenance.summary, contains('install=${installSource.name}'));
+      }
+    });
+
+    test('reports available Shorebird with no installed patch', () async {
+      final provenance = await _service(
+        shorebirdAvailable: true,
+        readPatchNumber: () async => null,
+      ).resolve();
+
+      expect(provenance.summary, contains('shorebird=available · patch=none'));
+      expect(provenance.patchStatus, ShorebirdPatchStatus.none);
+    });
+
+    test('reports unavailable Shorebird without reading patch state', () async {
+      var didReadPatch = false;
+
+      final provenance = await _service(
+        readPatchNumber: () async {
+          didReadPatch = true;
+          return 7;
+        },
+      ).resolve();
+
+      expect(didReadPatch, isFalse);
+      expect(
+        provenance.summary,
+        contains('shorebird=unavailable · patch=unavailable'),
+      );
+      expect(provenance.patchStatus, ShorebirdPatchStatus.unavailable);
+    });
+
+    test('degrades patch read failures to unknown', () async {
+      final provenance = await _service(
+        shorebirdAvailable: true,
+        readPatchNumber: () async => throw StateError('ffi unavailable'),
+      ).resolve();
+
+      expect(
+        provenance.summary,
+        contains('shorebird=available · patch=unknown'),
+      );
+      expect(provenance.patchStatus, ShorebirdPatchStatus.unknown);
+    });
+
+    test('does not expose identifier-shaped values in summary', () async {
+      final provenance = await _service(
+        shorebirdAvailable: true,
+        readPatchNumber: () async => 12,
+      ).resolve();
+
+      expect(provenance.summary, isNot(contains('app_id')));
+      expect(provenance.summary, isNot(contains('pubkey')));
+      expect(provenance.summary, isNot(contains('npub')));
+      expect(
+        provenance.summary,
+        isNot(matches(RegExp('[0-9a-fA-F]{32,}'))),
+      );
+    });
+  });
+}
+
+BuildProvenanceService _service({
+  BuildMode buildMode = BuildMode.debug,
+  InstallSource installSource = InstallSource.sideload,
+  bool shorebirdAvailable = false,
+  ShorebirdPatchReader? readPatchNumber,
+}) {
+  return BuildProvenanceService(
+    packageInfo: PackageInfo(
+      appName: 'Divine',
+      packageName: 'com.divinevideo.app',
+      version: '1.0.20',
+      buildNumber: '837',
+    ),
+    installSource: installSource,
+    environment: AppEnvironment.production,
+    platform: 'android',
+    shorebirdAvailable: shorebirdAvailable,
+    buildMode: buildMode,
+    readPatchNumber: readPatchNumber,
+  );
+}


### PR DESCRIPTION
## Summary
- add startup build provenance formatting for version/build, mode, environment, platform, install source, and Shorebird patch state
- wire a best-effort Shorebird patch read into startup logs and Crashlytics keys without checking for updates
- add shorebird_code_push and focused service coverage

Closes #7392

## Verification
- cd mobile && flutter test test/services/build_provenance_service_test.dart
- cd mobile && flutter analyze lib test integration_test
- cd mobile && flutter test test/main_app_shell_repository_sync_test.dart test/main_background_launch_downloads_test.dart test/main_deep_link_nav_action_test.dart test/main_notification_tap_routing_test.dart test/main_push_duplicate_render_test.dart test/main_uncaught_zone_error_test.dart test/main_video_cache_startup_test.dart test/main_video_deep_link_nav_action_test.dart test/services/build_provenance_service_test.dart
- UPDATE_BASELINE=1 bash mobile/scripts/check_untested_services_floor.sh
- bash mobile/scripts/check_dependency_provenance.sh