### PR TITLE
fix(blossom): demote ProofMode header budget log

### DIFF
--- a/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
+++ b/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
@@ -2946,8 +2946,9 @@ class BlossomUploadService {
   /// X-ProofMode-PublicKey, X-ProofMode-Attestation and X-ProofMode-C2PA
   /// headers from the provided ProofManifest JSON.
   ///
-  /// Headers are attached best-effort within [maxProofModeHeaderBytes]. See
-  /// that constant for why an oversized proof is dropped instead of sent.
+  /// Headers are attached best-effort within [maxProofModeHeaderBytes]. Large
+  /// Android attestations can exceed that budget, so bulk proof fields are
+  /// omitted while canonical proof metadata stays in the video event.
   void _addProofModeHeaders(
     Map<String, dynamic> headers,
     String proofManifestJson,
@@ -2994,10 +2995,10 @@ class BlossomUploadService {
         return;
       }
 
-      Log.warning(
-        'ProofMode headers over the $maxProofModeHeaderBytes byte budget; '
-        'sent $usedBytes bytes and dropped ${dropped.join(', ')}. '
-        'The full manifest still ships in the video event proofmode tag.',
+      Log.info(
+        'ProofMode headers trimmed to the $maxProofModeHeaderBytes byte '
+        'budget; sent $usedBytes bytes and omitted ${dropped.join(', ')}. '
+        'The full manifest is canonical in the video event proofmode tag.',
         name: 'BlossomUploadService',
         category: LogCategory.video,
       );

--- a/mobile/packages/blossom_upload_service/test/src/blossom_upload_proofmode_test.dart
+++ b/mobile/packages/blossom_upload_service/test/src/blossom_upload_proofmode_test.dart
@@ -11,6 +11,7 @@ import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:unified_logger/unified_logger.dart';
 
 class _MockAuthProvider extends Mock implements BlossomAuthProvider {}
 
@@ -60,12 +61,17 @@ void main() {
 
     setUp(() async {
       SharedPreferences.setMockInitialValues({});
+      await LogCaptureService().clearAllLogs();
       mockAuthProvider = _MockAuthProvider();
       mockDio = _MockDio();
       service = BlossomUploadService(
         authProvider: mockAuthProvider,
         dio: mockDio,
       );
+    });
+
+    tearDown(() async {
+      await LogCaptureService().clearAllLogs();
     });
 
     Options? capturedOptions;
@@ -486,6 +492,57 @@ void main() {
               base64.decode(headers['X-ProofMode-PublicKey'] as String),
             ),
             equals(realWorldPublicKey),
+          );
+        },
+      );
+
+      test(
+        'logs over-budget ProofMode header trimming at info severity',
+        () async {
+          arrangeUploadMocks();
+          final mockFile = createMockFile();
+
+          final manifest = jsonEncode({
+            'videoHash': 'abc123',
+            'pgpSignature': 'S' * 821,
+            'publicKey': 'K' * 2048,
+            'deviceAttestation': 'A' * 53826,
+            'c2pa_manifest_id': 'urn:c2pa:7ae319b2-8641-4eea-8203-a1faf72e31e4',
+          });
+
+          await service.uploadVideo(
+            description: 'test',
+            videoFile: mockFile,
+            nostrPubkey: _testPubkey,
+            title: 'test',
+            hashtags: const [],
+            proofManifestJson: manifest,
+          );
+
+          final trimLogs = LogCaptureService().getRecentLogs().where(
+            (log) =>
+                log.name == 'BlossomUploadService' &&
+                log.message.startsWith('ProofMode headers trimmed'),
+          );
+
+          expect(trimLogs, hasLength(1));
+          expect(trimLogs.single.level, LogLevel.info);
+          expect(
+            trimLogs.single.message,
+            contains('omitted X-ProofMode-Attestation'),
+          );
+          expect(trimLogs.single.message, contains('X-ProofMode-Manifest'));
+
+          final warnings = LogCaptureService().getRecentLogs(
+            minLevel: LogLevel.warning,
+          );
+          expect(
+            warnings.where(
+              (log) =>
+                  log.name == 'BlossomUploadService' &&
+                  log.message.contains('ProofMode headers'),
+            ),
+            isEmpty,
           );
         },
       );


### PR DESCRIPTION
## Summary
- demote expected over-budget ProofMode header trimming from warning to info
- reword the log/comment to describe omitted bulk headers as expected budget accounting
- add a regression test that the over-budget path emits an info log and no ProofMode warning

## Issue
Fixes #7391.

Backend ingest note: the upload headers remain best-effort only. Canonical ProofMode metadata stays in the video event proofmode tag, and the full manifest remains available there even when bulk upload headers are omitted.

## Verification
- cd mobile/packages/blossom_upload_service && flutter test test/src/blossom_upload_proofmode_test.dart
- cd mobile/packages/blossom_upload_service && flutter analyze
- cd mobile/packages/blossom_upload_service && flutter test --coverage
- LCOV sanity check: 963/963 hit lines, 100.00% coverage
- pre-push hook: analysis and changed-file test passed