### PR TITLE
fix(c2pa): classify signer credential failures

### DIFF
--- a/mobile/lib/services/c2pa_signing_service.dart
+++ b/mobile/lib/services/c2pa_signing_service.dart
@@ -502,11 +502,8 @@ class C2paSigningService {
 
   /// Creates a signer for C2PA operations.
   ///
-  /// TODO(#3730): Replace with proper key management:
-  /// - Use HardwareSigner for Secure Enclave (iOS) / StrongBox (Android)x
-  /// - Generate per-user keys during onboarding
-  /// - Store certificates securely
-  /// - Support user-provided certificates via enrollment API
+  /// Always a [RemoteSigner]: #2161 deleted the local `HardwareSigner`
+  /// branch in favour of the authenticated ProofSign server.
   Future<C2paSigner> _createSigner() async {
     var args = '?platform=';
     if (!kIsWeb && defaultTargetPlatform == TargetPlatform.android) {

--- a/mobile/lib/services/c2pa_signing_service.dart
+++ b/mobile/lib/services/c2pa_signing_service.dart
@@ -33,6 +33,10 @@ enum C2paSigningFailureReason {
   tls,
   network,
 
+  /// The remote signer returned a signature or credential the C2PA library
+  /// could not validate.
+  signingCredential,
+
   /// This build opted out of C2PA signing; nothing was attempted.
   disabled,
   other,
@@ -180,7 +184,11 @@ class C2paSigningService {
           category: LogCategory.video,
         );
       }
-      Log.info('prepared C2PA manifest json: ${manifestResult.manifestJson}');
+      Log.info(
+        'Prepared C2PA manifest for $filename',
+        name: 'C2paSigningService',
+        category: LogCategory.video,
+      );
 
       // Create signer for RemoteSigning against proofsign
       final signer = await _createSigner();
@@ -215,10 +223,10 @@ class C2paSigningService {
         );
       }
 
-      // Log.debug("replacing original video $videoPath with signed file $signedFile");
-      inputFile.renameSync('${inputFile.path}.old');
-      // Log.debug("original file renamed: ${iFileNew.path} ");
-      final sFileNew = signedFile.renameSync(inputFile.path);
+      final sFileNew = _replaceOriginalWithSigned(
+        inputFile: inputFile,
+        signedFile: signedFile,
+      );
       Log.debug('signed file renamed: ${sFileNew.path} ');
 
       final signedSize = await sFileNew.length();
@@ -387,6 +395,26 @@ class C2paSigningService {
     }
   }
 
+  static File _replaceOriginalWithSigned({
+    required File inputFile,
+    required File signedFile,
+  }) {
+    final backupPath =
+        '${inputFile.path}.c2pa-replace-${DateTime.now().microsecondsSinceEpoch}.old';
+    final backupFile = inputFile.renameSync(backupPath);
+
+    try {
+      final replacement = signedFile.renameSync(inputFile.path);
+      backupFile.deleteSync();
+      return replacement;
+    } catch (_) {
+      if (!inputFile.existsSync() && backupFile.existsSync()) {
+        backupFile.renameSync(inputFile.path);
+      }
+      rethrow;
+    }
+  }
+
   @visibleForTesting
   static C2paSigningFailureReason classifyFailureReason(Object error) {
     if (error is TimeoutException) {
@@ -398,6 +426,16 @@ class C2paSigningService {
         '$code $message $details'.toLowerCase(),
       _ => error.toString().toLowerCase(),
     };
+
+    if (_containsAny(message, const [
+      'cose signature invalid',
+      'signature invalid',
+      'invalid signature',
+      'signature verification',
+      'credential',
+    ])) {
+      return C2paSigningFailureReason.signingCredential;
+    }
 
     if (_containsAny(message, const [
       'tls',
@@ -484,7 +522,7 @@ class C2paSigningService {
 
   /// Creates a signer for C2PA operations.
   ///
-  /// TODO: Replace with proper key management:
+  /// TODO(#3730): Replace with proper key management:
   /// - Use HardwareSigner for Secure Enclave (iOS) / StrongBox (Android)x
   /// - Generate per-user keys during onboarding
   /// - Store certificates securely

--- a/mobile/lib/services/c2pa_signing_service.dart
+++ b/mobile/lib/services/c2pa_signing_service.dart
@@ -223,15 +223,16 @@ class C2paSigningService {
         );
       }
 
-      final sFileNew = _replaceOriginalWithSigned(
-        inputFile: inputFile,
-        signedFile: signedFile,
+      final sFileNew = signedFile.renameSync(inputFile.path);
+      Log.debug(
+        'Signed file renamed: ${sFileNew.path}',
+        name: 'C2paSigningService',
+        category: LogCategory.video,
       );
-      Log.debug('signed file renamed: ${sFileNew.path} ');
 
       final signedSize = await sFileNew.length();
       Log.info(
-        'C2PA signing complete: $sFileNew (${signedSize ~/ 1024} KB)',
+        'C2PA signing complete: ${sFileNew.path} (${signedSize ~/ 1024} KB)',
         name: 'C2paSigningService',
         category: LogCategory.video,
       );
@@ -395,26 +396,6 @@ class C2paSigningService {
     }
   }
 
-  static File _replaceOriginalWithSigned({
-    required File inputFile,
-    required File signedFile,
-  }) {
-    final backupPath =
-        '${inputFile.path}.c2pa-replace-${DateTime.now().microsecondsSinceEpoch}.old';
-    final backupFile = inputFile.renameSync(backupPath);
-
-    try {
-      final replacement = signedFile.renameSync(inputFile.path);
-      backupFile.deleteSync();
-      return replacement;
-    } catch (_) {
-      if (!inputFile.existsSync() && backupFile.existsSync()) {
-        backupFile.renameSync(inputFile.path);
-      }
-      rethrow;
-    }
-  }
-
   @visibleForTesting
   static C2paSigningFailureReason classifyFailureReason(Object error) {
     if (error is TimeoutException) {
@@ -428,7 +409,6 @@ class C2paSigningService {
     };
 
     if (_containsAny(message, const [
-      'cose signature invalid',
       'signature invalid',
       'invalid signature',
       'signature verification',

--- a/mobile/test/services/c2pa_signing_service_test.dart
+++ b/mobile/test/services/c2pa_signing_service_test.dart
@@ -180,28 +180,28 @@ void main() {
     });
 
     group('signVideo', () {
-      test('replaces the original file in place and removes the replacement '
-          'backup when signing succeeds', () async {
-        final video = writeFile('video.mp4', const [0, 1, 2, 3]);
-        final service = C2paSigningService(
-          c2pa: _WritingC2pa(const [7, 8, 9, 10, 11]),
-        );
+      test(
+        'replaces the original in place and leaves nothing else behind',
+        () async {
+          final video = writeFile('video.mp4', const [0, 1, 2, 3]);
+          final service = C2paSigningService(
+            c2pa: _WritingC2pa(const [7, 8, 9, 10, 11]),
+          );
 
-        final result = await service.signVideo(videoPath: video.path);
+          final result = await service.signVideo(videoPath: video.path);
 
-        expect(result.success, isTrue);
-        expect(result.signedFilePath, video.path);
-        expect(video.readAsBytesSync(), equals([7, 8, 9, 10, 11]));
-        expect(
-          tempDir.listSync().whereType<File>().map(
-            (file) => file.uri.pathSegments.last,
-          ),
-          allOf(
-            isNot(contains('video.mp4.old')),
-            isNot(contains(startsWith('video.mp4.c2pa-replace-'))),
-          ),
-        );
-      });
+          expect(result.success, isTrue);
+          expect(result.signedFilePath, video.path);
+          expect(video.readAsBytesSync(), equals([7, 8, 9, 10, 11]));
+          // No `.old` original, no orphaned `c2pa_signed_*` temp file.
+          expect(
+            tempDir.listSync().whereType<File>().map(
+              (file) => file.uri.pathSegments.last,
+            ),
+            equals(['video.mp4']),
+          );
+        },
+      );
     });
 
     group('resignDerived', () {

--- a/mobile/test/services/c2pa_signing_service_test.dart
+++ b/mobile/test/services/c2pa_signing_service_test.dart
@@ -94,6 +94,17 @@ void main() {
         expect(reason, C2paSigningFailureReason.network);
       });
 
+      test('classifies COSE signature failures as signing credentials', () {
+        final reason = C2paSigningService.classifyFailureReason(
+          PlatformException(
+            code: 'ERROR',
+            message: 'Signature: internal error (COSE signature invalid)',
+          ),
+        );
+
+        expect(reason, C2paSigningFailureReason.signingCredential);
+      });
+
       test('returns typed failure reason when remote signing throws', () async {
         final video = writeFile('video.mp4', const [0, 1, 2, 3]);
         final failingService = C2paSigningService(
@@ -155,9 +166,7 @@ void main() {
           final orphans = tempDir
               .listSync()
               .whereType<File>()
-              .where(
-                (f) => f.uri.pathSegments.last.startsWith('c2pa_signed_'),
-              )
+              .where((f) => f.uri.pathSegments.last.startsWith('c2pa_signed_'))
               .toList();
           expect(
             orphans,
@@ -170,94 +179,113 @@ void main() {
       );
     });
 
+    group('signVideo', () {
+      test('replaces the original file in place and removes the replacement '
+          'backup when signing succeeds', () async {
+        final video = writeFile('video.mp4', const [0, 1, 2, 3]);
+        final service = C2paSigningService(
+          c2pa: _WritingC2pa(const [7, 8, 9, 10, 11]),
+        );
+
+        final result = await service.signVideo(videoPath: video.path);
+
+        expect(result.success, isTrue);
+        expect(result.signedFilePath, video.path);
+        expect(video.readAsBytesSync(), equals([7, 8, 9, 10, 11]));
+        expect(
+          tempDir.listSync().whereType<File>().map(
+            (file) => file.uri.pathSegments.last,
+          ),
+          allOf(
+            isNot(contains('video.mp4.old')),
+            isNot(contains(startsWith('video.mp4.c2pa-replace-'))),
+          ),
+        );
+      });
+    });
+
     group('resignDerived', () {
-      test(
-        'skips re-signing and leaves the file untouched when the source '
-        'carries no manifest',
-        () async {
-          when(
-            () => mockC2pa.readManifestFromFile(any()),
-          ).thenAnswer((_) async => const ManifestStoreInfo());
+      test('skips re-signing and leaves the file untouched when the source '
+          'carries no manifest', () async {
+        when(
+          () => mockC2pa.readManifestFromFile(any()),
+        ).thenAnswer((_) async => const ManifestStoreInfo());
 
-          final output = writeFile('out.mp4', const [1, 2, 3]);
-          final source = writeFile('src.mp4', const [4, 5, 6]);
+        final output = writeFile('out.mp4', const [1, 2, 3]);
+        final source = writeFile('src.mp4', const [4, 5, 6]);
 
-          final result = await service.resignDerived(
-            outputPath: output.path,
-            sourcePath: source.path,
-            action: C2paEditActions.edited,
-          );
+        final result = await service.resignDerived(
+          outputPath: output.path,
+          sourcePath: source.path,
+          action: C2paEditActions.edited,
+        );
 
-          expect(result.success, isFalse);
-          verifyNever(() => mockC2pa.createBuilder(any()));
-          expect(output.readAsBytesSync(), equals([1, 2, 3]));
-        },
-      );
+        expect(result.success, isFalse);
+        verifyNever(() => mockC2pa.createBuilder(any()));
+        expect(output.readAsBytesSync(), equals([1, 2, 3]));
+      });
 
-      test(
-        'carries the source manifest forward: parentOf ingredient, edit '
-        'action, and writes the signed bytes back in place',
-        () async {
-          when(() => mockC2pa.readManifestFromFile(any())).thenAnswer(
-            (_) async => const ManifestStoreInfo(activeManifest: 'urn:c2pa:x'),
-          );
+      test('carries the source manifest forward: parentOf ingredient, edit '
+          'action, and writes the signed bytes back in place', () async {
+        when(() => mockC2pa.readManifestFromFile(any())).thenAnswer(
+          (_) async => const ManifestStoreInfo(activeManifest: 'urn:c2pa:x'),
+        );
 
-          final builder = _MockManifestBuilder();
-          when(
-            () => mockC2pa.createBuilder(any()),
-          ).thenAnswer((_) async => builder);
-          when(
-            () => builder.addIngredient(
-              data: any(named: 'data'),
-              mimeType: any(named: 'mimeType'),
-              config: any(named: 'config'),
-            ),
-          ).thenAnswer((_) async {});
-          final signedBytes = Uint8List.fromList(const [9, 9, 9, 9, 9]);
-          when(
-            () => builder.sign(
-              sourceData: any(named: 'sourceData'),
-              mimeType: any(named: 'mimeType'),
-              signer: any(named: 'signer'),
-            ),
-          ).thenAnswer(
-            (_) async =>
-                BuilderSignResult(signedData: signedBytes, manifestSize: 5),
-          );
+        final builder = _MockManifestBuilder();
+        when(
+          () => mockC2pa.createBuilder(any()),
+        ).thenAnswer((_) async => builder);
+        when(
+          () => builder.addIngredient(
+            data: any(named: 'data'),
+            mimeType: any(named: 'mimeType'),
+            config: any(named: 'config'),
+          ),
+        ).thenAnswer((_) async {});
+        final signedBytes = Uint8List.fromList(const [9, 9, 9, 9, 9]);
+        when(
+          () => builder.sign(
+            sourceData: any(named: 'sourceData'),
+            mimeType: any(named: 'mimeType'),
+            signer: any(named: 'signer'),
+          ),
+        ).thenAnswer(
+          (_) async =>
+              BuilderSignResult(signedData: signedBytes, manifestSize: 5),
+        );
 
-          final output = writeFile('out.mp4', const [1, 2, 3]);
-          final source = writeFile('src.mp4', const [4, 5, 6]);
+        final output = writeFile('out.mp4', const [1, 2, 3]);
+        final source = writeFile('src.mp4', const [4, 5, 6]);
 
-          final result = await service.resignDerived(
-            outputPath: output.path,
-            sourcePath: source.path,
-            action: C2paEditActions.edited,
-          );
+        final result = await service.resignDerived(
+          outputPath: output.path,
+          sourcePath: source.path,
+          action: C2paEditActions.edited,
+        );
 
-          expect(result.success, isTrue);
+        expect(result.success, isTrue);
 
-          final ingredientConfig =
-              verify(
-                    () => builder.addIngredient(
-                      data: any(named: 'data'),
-                      mimeType: any(named: 'mimeType'),
-                      config: captureAny(named: 'config'),
-                    ),
-                  ).captured.single
-                  as IngredientConfig;
-          expect(ingredientConfig.relationship, Relationship.parentOf);
+        final ingredientConfig =
+            verify(
+                  () => builder.addIngredient(
+                    data: any(named: 'data'),
+                    mimeType: any(named: 'mimeType'),
+                    config: captureAny(named: 'config'),
+                  ),
+                ).captured.single
+                as IngredientConfig;
+        expect(ingredientConfig.relationship, Relationship.parentOf);
 
-          final recordedAction =
-              verify(() => builder.addAction(captureAny())).captured.single
-                  as ActionConfig;
-          // Literal token: pins the protocol surface, not just the constant.
-          expect(recordedAction.action, 'c2pa.edited');
+        final recordedAction =
+            verify(() => builder.addAction(captureAny())).captured.single
+                as ActionConfig;
+        // Literal token: pins the protocol surface, not just the constant.
+        expect(recordedAction.action, 'c2pa.edited');
 
-          verify(() => builder.setIntent(ManifestIntent.edit)).called(1);
-          verify(builder.dispose).called(1);
-          expect(output.readAsBytesSync(), equals(signedBytes));
-        },
-      );
+        verify(() => builder.setIntent(ManifestIntent.edit)).called(1);
+        verify(builder.dispose).called(1);
+        expect(output.readAsBytesSync(), equals(signedBytes));
+      });
 
       test(
         'returns failure without signing when the output does not exist',
@@ -322,5 +350,21 @@ class _SlowWritingC2pa extends C2pa {
   }) async {
     await Future<void>.delayed(delay);
     File(destPath).writeAsBytesSync(const [7, 7, 7]);
+  }
+}
+
+class _WritingC2pa extends C2pa {
+  _WritingC2pa(this.bytes);
+
+  final List<int> bytes;
+
+  @override
+  Future<void> signFile({
+    required String sourcePath,
+    required String destPath,
+    required String manifestJson,
+    required C2paSigner signer,
+  }) async {
+    File(destPath).writeAsBytesSync(bytes);
   }
 }


### PR DESCRIPTION
Closes #7476

## Summary
- add a signingCredential C2PA failure reason for COSE/signature validation failures
- cover the successful signVideo replacement path, including cleanup of the temporary replacement backup
- reduce successful signing path cleanup debt by avoiding leaked .old video copies and removing noisy manifest logging

Refs #7386

## Notes
- This narrows the mobile-side fix to classification, regression coverage, and local successful-path cleanup. Restoring live C2PA signing still requires the proofsign-server signer fix described in the issue.

## Verification
- cd mobile && flutter test test/services/c2pa_signing_service_test.dart
- cd mobile && flutter analyze lib/services/c2pa_signing_service.dart test/services/c2pa_signing_service_test.dart
- git diff --check
- pre-push hook: analyzer + test/services/c2pa_signing_service_test.dart
