### PR TITLE
fix(firebase): make Android initialization idempotent

### DIFF
--- a/docs/CRASH_REPORTING_SETUP.md
+++ b/docs/CRASH_REPORTING_SETUP.md
@@ -15,7 +15,7 @@ reporting. The active Firebase project is **`openvine-co`** (bundle id
 |----------|-----------------|---------------|--------|
 | iOS | `openvine-co` — `firebase_options.dart`, `ios/Runner/GoogleService-Info.plist` | ✅ dSYMs via Codemagic | Production |
 | macOS | `openvine-co` — `macos/Runner/GoogleService-Info.plist` | — | Production (reuses the iOS appId — see note below) |
-| Android | `openvine-co` — `android/app/google-services.json` | ⚠️ R8 mapping upload wired via Gradle; native-symbol upload configured but unverified | `firebase_options.dart` Android options are still being reconciled in #3343 |
+| Android | `openvine-co` — `firebase_options.dart`, `android/app/google-services.json` | ⚠️ R8 mapping upload wired via Gradle; native-symbol upload configured but unverified | Production |
 | Web / Windows / Linux | none | — | Not supported; init is gated off |
 
 `isFirebaseSupported` (`mobile/lib/utils/platform_support.dart`) is a
@@ -27,13 +27,11 @@ currently initialized only when startup passes both `isFirebaseSupported` and
 > as iOS (`1:972941478875:ios:…`). Confirm this is intentional during the
 > #3343 config reconciliation; a distinct macOS app may warrant its own appId.
 
-> **Android note:** `google-services.json` already points at `openvine-co`, but
-> `DefaultFirebaseOptions.android` is still a placeholder, so
-> `Firebase.initializeApp` does not yet initialise Android against the real
-> project. The Crashlytics Gradle plugin is already applied and release builds
-> now enable R8, so an obfuscation mapping file is produced and uploaded;
-> native-symbol upload is configured but not yet verified end-to-end.
-> Reconciling the Android options is tracked in #3343.
+> **Android note:** `google-services.json` and
+> `DefaultFirebaseOptions.android` both point at `openvine-co`. The Crashlytics
+> Gradle plugin is already applied and release builds now enable R8, so an
+> obfuscation mapping file is produced and uploaded; native-symbol upload is
+> configured but not yet verified end-to-end.
 
 ## Configuration files
 
@@ -77,8 +75,7 @@ Release builds upload Crashlytics debug symbols automatically. See
 Without this, iOS crash stacks arrive in Crashlytics unsymbolicated.
 
 > **Android note:** Crashlytics upload wiring is present in Gradle and release
-> builds generate an R8 mapping file for symbolication. Android Firebase options
-> still need reconciliation under #3343.
+> builds generate an R8 mapping file for symbolication.
 
 ## Custom keys on every report
 

--- a/docs/CRASH_REPORTING_SETUP.md
+++ b/docs/CRASH_REPORTING_SETUP.md
@@ -24,8 +24,8 @@ currently initialized only when startup passes both `isFirebaseSupported` and
 `!kIsWeb`, so web remains intentionally gated off in app startup.
 
 > **macOS note:** `firebase_options.dart` currently gives macOS the same appId
-> as iOS (`1:972941478875:ios:…`). Confirm this is intentional during the
-> #3343 config reconciliation; a distinct macOS app may warrant its own appId.
+> as iOS (`1:972941478875:ios:…`). Confirm this is intentional; a distinct
+> macOS app may warrant its own appId.
 
 > **Android note:** `google-services.json` and
 > `DefaultFirebaseOptions.android` both point at `openvine-co`. The Crashlytics

--- a/mobile/firebase.json
+++ b/mobile/firebase.json
@@ -1,1 +1,39 @@
-{"flutter":{"platforms":{"ios":{"default":{"projectId":"openvine-co","appId":"1:972941478875:ios:f61272b3cf485df244b5fe","uploadDebugSymbols":true,"fileOutput":"ios/Runner/GoogleService-Info.plist"}},"macos":{"default":{"projectId":"openvine-co","appId":"1:972941478875:ios:f61272b3cf485df244b5fe","uploadDebugSymbols":true,"fileOutput":"macos/Runner/GoogleService-Info.plist"}},"dart":{"lib/firebase_options.dart":{"projectId":"openvine-co","configurations":{"ios":"1:972941478875:ios:f61272b3cf485df244b5fe","macos":"1:972941478875:ios:f61272b3cf485df244b5fe"}}}}}}
+{
+  "flutter": {
+    "platforms": {
+      "android": {
+        "default": {
+          "projectId": "openvine-co",
+          "appId": "1:972941478875:android:c716006682f92d9444b5fe",
+          "fileOutput": "android/app/google-services.json"
+        }
+      },
+      "ios": {
+        "default": {
+          "projectId": "openvine-co",
+          "appId": "1:972941478875:ios:f61272b3cf485df244b5fe",
+          "uploadDebugSymbols": true,
+          "fileOutput": "ios/Runner/GoogleService-Info.plist"
+        }
+      },
+      "macos": {
+        "default": {
+          "projectId": "openvine-co",
+          "appId": "1:972941478875:ios:f61272b3cf485df244b5fe",
+          "uploadDebugSymbols": true,
+          "fileOutput": "macos/Runner/GoogleService-Info.plist"
+        }
+      },
+      "dart": {
+        "lib/firebase_options.dart": {
+          "projectId": "openvine-co",
+          "configurations": {
+            "android": "1:972941478875:android:c716006682f92d9444b5fe",
+            "ios": "1:972941478875:ios:f61272b3cf485df244b5fe",
+            "macos": "1:972941478875:ios:f61272b3cf485df244b5fe"
+          }
+        }
+      }
+    }
+  }
+}

--- a/mobile/lib/firebase_options.dart
+++ b/mobile/lib/firebase_options.dart
@@ -51,11 +51,11 @@ class DefaultFirebaseOptions {
   );
 
   static const FirebaseOptions android = FirebaseOptions(
-    apiKey: 'placeholder-api-key',
-    appId: '1:placeholder:android:placeholder',
-    messagingSenderId: 'placeholder-sender-id',
-    projectId: 'openvine-placeholder',
-    storageBucket: 'openvine-placeholder.appspot.com',
+    apiKey: 'AIzaSyBUMlaHAMKqeS62WG7w4PeqBPRLMDIZCdo',
+    appId: '1:972941478875:android:c716006682f92d9444b5fe',
+    messagingSenderId: '972941478875',
+    projectId: 'openvine-co',
+    storageBucket: 'openvine-co.firebasestorage.app',
   );
 
   static const FirebaseOptions ios = FirebaseOptions(

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -169,10 +169,37 @@ bool shouldRenderLocalPushNotification(RemoteMessage message) {
   return body is String && body.isNotEmpty;
 }
 
+typedef BackgroundFirebaseInitializer = Future<void> Function();
+typedef BackgroundLocalPushRenderer =
+    Future<void> Function({
+      required int id,
+      required String? title,
+      required String body,
+      required Map<String, dynamic> data,
+    });
+
 /// Top-level background message handler required by Firebase.
 @pragma('vm:entry-point')
 Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
-  await ensureDefaultFirebaseInitialized();
+  await handleFirebaseMessagingBackgroundMessage(message);
+}
+
+@visibleForTesting
+Future<void> handleFirebaseMessagingBackgroundMessage(
+  RemoteMessage message, {
+  BackgroundFirebaseInitializer initializeFirebase =
+      ensureDefaultFirebaseInitialized,
+  BackgroundLocalPushRenderer renderLocalPush = _renderBackgroundLocalPush,
+}) async {
+  try {
+    await initializeFirebase();
+  } catch (error) {
+    Log.warning(
+      'Firebase init failed in background push handler; attempting local '
+      'notification render: $error',
+      name: 'PushNotifications',
+    );
+  }
 
   // The OS already presents iOS alert pushes (aps.alert); only render a local
   // notification for data-only messages so we don't double-render (#4731).
@@ -182,6 +209,20 @@ Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
   final title = data['title'] as String? ?? 'diVine';
   final body = data['body'] as String? ?? '';
 
+  await renderLocalPush(
+    id: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+    title: title,
+    body: body,
+    data: data,
+  );
+}
+
+Future<void> _renderBackgroundLocalPush({
+  required int id,
+  required String? title,
+  required String body,
+  required Map<String, dynamic> data,
+}) async {
   final plugin = FlutterLocalNotificationsPlugin();
   const androidInit = AndroidInitializationSettings('@mipmap/ic_launcher');
   const darwinInit = DarwinInitializationSettings();
@@ -205,7 +246,7 @@ Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
   );
 
   await plugin.show(
-    id: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+    id: id,
     title: title,
     body: body,
     notificationDetails: details,

--- a/mobile/lib/services/firebase_initialization.dart
+++ b/mobile/lib/services/firebase_initialization.dart
@@ -11,8 +11,9 @@ typedef FirebaseInitializer =
 /// Ensures the default Firebase app exists exactly once.
 ///
 /// Android can auto-create the default app before Dart startup via the
-/// google-services plugin. Calling [Firebase.initializeApp] again in that state
-/// throws `[core/duplicate-app]`, which disables downstream Firebase services.
+/// google-services plugin. The pre-check covers repeat Dart calls after
+/// Firebase core has loaded its app list; the duplicate-app catch covers native
+/// auto-init discovered during the first Dart initialize call.
 Future<void> ensureDefaultFirebaseInitialized({
   FirebaseOptions? options,
   FirebaseAppsProvider? appsProvider,
@@ -20,7 +21,12 @@ Future<void> ensureDefaultFirebaseInitialized({
 }) async {
   if ((appsProvider ?? () => Firebase.apps)().isNotEmpty) return;
 
-  await (initializeApp ?? Firebase.initializeApp)(
-    options: options ?? DefaultFirebaseOptions.currentPlatform,
-  );
+  try {
+    await (initializeApp ?? Firebase.initializeApp)(
+      options: options ?? DefaultFirebaseOptions.currentPlatform,
+    );
+  } on FirebaseException catch (error) {
+    if (error.code == 'duplicate-app') return;
+    rethrow;
+  }
 }

--- a/mobile/test/firebase_options_android_config_test.dart
+++ b/mobile/test/firebase_options_android_config_test.dart
@@ -1,0 +1,30 @@
+// ABOUTME: Pins Dart Android Firebase options to the tracked native config.
+// ABOUTME: Prevents google-services.json and firebase_options.dart drift.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/firebase_options.dart';
+
+void main() {
+  test('DefaultFirebaseOptions.android matches google-services.json', () {
+    final config =
+        jsonDecode(File('android/app/google-services.json').readAsStringSync())
+            as Map<String, dynamic>;
+    final projectInfo = config['project_info'] as Map<String, dynamic>;
+    final clients = config['client'] as List<dynamic>;
+    final client = clients.single as Map<String, dynamic>;
+    final clientInfo = client['client_info'] as Map<String, dynamic>;
+    final apiKeys = client['api_key'] as List<dynamic>;
+    final apiKey = apiKeys.single as Map<String, dynamic>;
+
+    const options = DefaultFirebaseOptions.android;
+
+    expect(options.apiKey, apiKey['current_key']);
+    expect(options.appId, clientInfo['mobilesdk_app_id']);
+    expect(options.messagingSenderId, projectInfo['project_number']);
+    expect(options.projectId, projectInfo['project_id']);
+    expect(options.storageBucket, projectInfo['storage_bucket']);
+  });
+}

--- a/mobile/test/main_push_duplicate_render_test.dart
+++ b/mobile/test/main_push_duplicate_render_test.dart
@@ -74,4 +74,34 @@ void main() {
       expect(app.shouldRenderLocalPushNotification(message), isFalse);
     });
   });
+
+  group('handleFirebaseMessagingBackgroundMessage', () {
+    test('still renders a data-only local notification when Firebase init '
+        'fails', () async {
+      const message = RemoteMessage(
+        data: {'title': 'New like', 'body': 'alice liked your video'},
+      );
+      final rendered =
+          <({String? title, String body, Map<String, dynamic> data})>[];
+
+      await app.handleFirebaseMessagingBackgroundMessage(
+        message,
+        initializeFirebase: () async => throw StateError('init failed'),
+        renderLocalPush:
+            ({
+              required int id,
+              required String? title,
+              required String body,
+              required Map<String, dynamic> data,
+            }) async {
+              rendered.add((title: title, body: body, data: data));
+            },
+      );
+
+      expect(rendered, hasLength(1));
+      expect(rendered.single.title, 'New like');
+      expect(rendered.single.body, 'alice liked your video');
+      expect(rendered.single.data, message.data);
+    });
+  });
 }

--- a/mobile/test/services/firebase_initialization_test.dart
+++ b/mobile/test/services/firebase_initialization_test.dart
@@ -32,7 +32,43 @@ void main() {
       expect(initializeAppCalls, 1);
     });
 
-    test('reuses an existing default Firebase app', () async {
+    test('swallows duplicate-app from native default app auto-init', () async {
+      var initializeAppCalls = 0;
+
+      await ensureDefaultFirebaseInitialized(
+        options: _firebaseOptions,
+        appsProvider: () => const [],
+        initializeApp: ({FirebaseOptions? options}) async {
+          initializeAppCalls++;
+          throw FirebaseException(
+            plugin: 'firebase_core',
+            code: 'duplicate-app',
+            message: 'A Firebase App named "[DEFAULT]" already exists',
+          );
+        },
+      );
+
+      expect(initializeAppCalls, 1);
+    });
+
+    test('rethrows non-duplicate Firebase initialization failures', () async {
+      final error = FirebaseException(
+        plugin: 'firebase_core',
+        code: 'invalid-configuration',
+        message: 'Broken Firebase config',
+      );
+
+      await expectLater(
+        ensureDefaultFirebaseInitialized(
+          options: _firebaseOptions,
+          appsProvider: () => const [],
+          initializeApp: ({FirebaseOptions? options}) async => throw error,
+        ),
+        throwsA(same(error)),
+      );
+    });
+
+    test('uses Firebase.apps fast path after core is initialized', () async {
       var initializeAppCalls = 0;
 
       await ensureDefaultFirebaseInitialized(


### PR DESCRIPTION
## Description

Fixes Android Firebase startup by aligning Dart Android options with the tracked native `google-services.json`, making default-app initialization tolerate native auto-init, and keeping background data-only push rendering alive if Firebase init fails. Adds regression coverage for duplicate-app handling, config drift, and the background push path.

**Related Issue:** Closes #7388

## Out of Scope

Web and Windows Firebase placeholder options remain unchanged; Android is the scoped release-blocking fix. Real-device Pixel launch/background-push verification could not be run because no Android device was connected.

## Verification

- `flutter test test/services/firebase_initialization_test.dart test/firebase_options_android_config_test.dart test/main_push_duplicate_render_test.dart`
- `flutter analyze lib test integration_test`
- `git diff --check`
- Pre-push hook: analyzer and changed-file tests passed
- `flutter devices` showed no connected Android device

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [x] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore