### PR TITLE
fix(providers): remove DM cleanup Riverpod cycle

### DIFF
--- a/mobile/lib/providers/social_providers.dart
+++ b/mobile/lib/providers/social_providers.dart
@@ -82,6 +82,20 @@ final pendingUploadOwnerCleanupProvider = Provider<PendingUploadOwnerCleanup>((
       ref.read(uploadManagerProvider).deleteAllForOwner(ownerPubkey);
 });
 
+/// Stops the live DM gift-wrap subscription during account cleanup.
+///
+/// The indirection is load-bearing: reading [dmRepositoryProvider] from
+/// [userDataCleanupServiceProvider]'s own callback closes the loop
+/// userDataCleanup → dmRepository → nostrService → authService →
+/// userDataCleanup, which Riverpod's debug cycle guard rejects. See #7389.
+final dmListeningStopProvider = Provider<Future<void> Function()>((ref) {
+  return () async {
+    // Cleanup must not construct a repository just to stop it.
+    if (!ref.exists(dmRepositoryProvider)) return;
+    await ref.read(dmRepositoryProvider).stopListening();
+  };
+});
+
 /// Connectivity trigger for the message retry sweep: fires on EVERY
 /// connectivity transition, including `→ none`. [OutgoingDmRetryService] runs
 /// its own offline probe per pass: an online pass re-drives retryable rows,
@@ -659,6 +673,8 @@ UserDataCleanupService userDataCleanupService(Ref ref) {
   // Wire database cleanup callback so signOut() clears DM and notification data.
   // Stop DM listening FIRST to prevent in-flight event handlers from writing
   // to tables that are being cleared (H3 race condition fix).
+  // Escaping cleanup reads must go through port providers; direct reads of
+  // auth-dependent providers from this callback can recreate #7389.
   //
   // When [deleteUserData] is true (destructive sign-out or identity change),
   // also deletes per-user DAO rows scoped by [userPubkey].
@@ -683,7 +699,7 @@ UserDataCleanupService userDataCleanupService(Ref ref) {
 
         await safeCleanup(
           'dmRepository',
-          () => ref.read(dmRepositoryProvider).stopListening(),
+          () => ref.read(dmListeningStopProvider)(),
         );
         try {
           await ref.read(openVineImageCacheClearProvider)();

--- a/mobile/lib/providers/social_providers.g.dart
+++ b/mobile/lib/providers/social_providers.g.dart
@@ -626,7 +626,7 @@ final class UserDataCleanupServiceProvider
 }
 
 String _$userDataCleanupServiceHash() =>
-    r'88d3fbc4b5f453357c72dd0d65e6fa09a82960d6';
+    r'f8d54465168cf0f76d409aa2b59cdb1a6e9ce08b';
 
 /// Hashtag service depends on Video event service and cache service
 

--- a/mobile/test/providers/social_providers_cleanup_test.dart
+++ b/mobile/test/providers/social_providers_cleanup_test.dart
@@ -196,6 +196,86 @@ void main() {
       );
     });
 
+    test(
+      'database cleanup stops existing dm listener through cycle-safe port',
+      () async {
+        final fakeAuthProvider = Provider<Object>((ref) {
+          ref.watch(userDataCleanupServiceProvider);
+          return Object();
+        });
+        final cycleContainer = ProviderContainer(
+          overrides: [
+            databaseProvider.overrideWithValue(db),
+            sharedPreferencesProvider.overrideWithValue(prefs),
+            openVineImageCacheClearProvider.overrideWithValue(() async {}),
+            uploadManagerProvider.overrideWithValue(uploadManager),
+            dmRepositoryProvider.overrideWith((ref) {
+              ref.watch(fakeAuthProvider);
+              return dmRepository;
+            }),
+          ],
+        );
+        addTearDown(cycleContainer.dispose);
+
+        final cleanupSubscription = cycleContainer.listen(
+          userDataCleanupServiceProvider,
+          (_, _) {},
+        );
+        addTearDown(cleanupSubscription.close);
+        cycleContainer.read(dmRepositoryProvider);
+
+        final service = cleanupSubscription.read();
+        expect(service.onDatabaseCleanup, isNotNull);
+        await service.onDatabaseCleanup!(
+          userPubkey: _pubkeyA,
+          deleteUserData: true,
+        );
+
+        verify(() => dmRepository.stopListening()).called(1);
+      },
+    );
+
+    test(
+      'database cleanup does not build dm repository just to stop it',
+      () async {
+        var dmRepositoryBuilt = false;
+        final fakeAuthProvider = Provider<Object>((ref) {
+          ref.watch(userDataCleanupServiceProvider);
+          return Object();
+        });
+        final cycleContainer = ProviderContainer(
+          overrides: [
+            databaseProvider.overrideWithValue(db),
+            sharedPreferencesProvider.overrideWithValue(prefs),
+            openVineImageCacheClearProvider.overrideWithValue(() async {}),
+            uploadManagerProvider.overrideWithValue(uploadManager),
+            dmRepositoryProvider.overrideWith((ref) {
+              dmRepositoryBuilt = true;
+              ref.watch(fakeAuthProvider);
+              return dmRepository;
+            }),
+          ],
+        );
+        addTearDown(cycleContainer.dispose);
+
+        final cleanupSubscription = cycleContainer.listen(
+          userDataCleanupServiceProvider,
+          (_, _) {},
+        );
+        addTearDown(cleanupSubscription.close);
+
+        final service = cleanupSubscription.read();
+        expect(service.onDatabaseCleanup, isNotNull);
+        await service.onDatabaseCleanup!(
+          userPubkey: _pubkeyA,
+          deleteUserData: true,
+        );
+
+        expect(dmRepositoryBuilt, isFalse);
+        verifyNever(() => dmRepository.stopListening());
+      },
+    );
+
     Future<void> seedDmReaction({
       required String id,
       required String ownerPubkey,


### PR DESCRIPTION
## Summary
- add a DM cleanup port provider so account cleanup stops an existing DM listener without reading dmRepositoryProvider from userDataCleanupServiceProvider's ref
- skip constructing DmRepository when cleanup runs before the repository exists
- avoid the release-mode side effect where sign-out could construct DmRepository, open a departing account's gift-wrap subscription, and self-publish DM relay metadata while cleanup is trying to stop listening
- add regression coverage for the Riverpod cycle shape and the absent-repository cleanup path

Closes #7389

## Technical Details: Breaking Riverpod Circular Dependencies

This PR demonstrates a pattern for breaking Riverpod circular dependencies in cleanup scenarios. The cycle here is:
```
userDataCleanup → dmRepository → nostrService → authService → userDataCleanup
```

**Solution: Port Provider with `ref.exists()` Check**

The `dmListeningStopProvider` is a lightweight intermediary that only reads `dmRepositoryProvider` if it's already initialized (via `ref.exists()`), preventing both the circular dependency and unnecessary construction:

```dart
@riverpod
Future<void Function()> dmListeningStop(Ref ref) async {
  return () {
    if (ref.exists(dmRepositoryProvider)) {
      ref.read(dmRepositoryProvider).stopListening();
    }
  };
}
```

This pattern is useful in any cleanup/shutdown scenario where a cleanup provider needs to call a method on a resource provider that may not yet be constructed.

**Why This Matters in Release Mode**

In debug mode, Riverpod's `CircularDependencyError` guard catches the cycle immediately. In release mode, the debug guard is disabled, but without the port pattern, the old code would silently:
1. Construct dmRepository during cleanup (when it may not yet exist)
2. Call `startListening()` on a departing account's gift-wrap subscription
3. Self-publish DM relay metadata to all user relays
4. Create a resource leak that interferes with the cleanup itself

The port pattern ensures both correct behavior and clean shutdown in both modes.

## Verification
- red check: with the direct dmRepositoryProvider read temporarily restored, social_providers_cleanup_test failed because stopListening was not called and the repository was built just to stop it
- flutter analyze lib test
- flutter test test/providers/social_providers_cleanup_test.dart test/services/user_data_cleanup_service_test.dart
- pre-push hook: analyzer, generated files, and test/providers/social_providers_cleanup_test.dart