### PR TITLE
fix(video): avoid stale derivative source after publish

### DIFF
--- a/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
+++ b/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
@@ -1236,9 +1236,10 @@ internal class DivineVideoPlayerInstance(
             PlaybackException.ERROR_CODE_IO_NO_PERMISSION -> "http_client_error"
             PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_FAILED -> "network_error"
             PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_TIMEOUT -> "timeout"
-            in 2000..2999 -> "decoder_error"
+            in 2000..2999 -> "io_error"
             in 3000..3999 -> "parse_error"
             in 4000..4999 -> "decoder_error"
+            in 5000..5999 -> "decoder_error"
             in 6000..6999 -> "decoder_error"
             else -> "unknown"
         }

--- a/mobile/packages/divine_video_player/android/src/test/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstanceTest.kt
+++ b/mobile/packages/divine_video_player/android/src/test/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstanceTest.kt
@@ -497,6 +497,13 @@ class DivineVideoPlayerInstanceTest {
         ).also { unmockkStatic(SystemClock::class) }
     }
 
+    private fun playbackError(message: String, errorCode: Int): PlaybackException {
+        mockkStatic(SystemClock::class)
+        every { SystemClock.elapsedRealtime() } returns 0L
+        return PlaybackException(message, null, errorCode)
+            .also { unmockkStatic(SystemClock::class) }
+    }
+
     private fun httpStatusError(status: Int): PlaybackException {
         mockkStatic(SystemClock::class)
         mockkStatic(Uri::class)
@@ -520,6 +527,70 @@ class DivineVideoPlayerInstanceTest {
             unmockkStatic(Uri::class)
             unmockkStatic(SystemClock::class)
         }
+    }
+
+    @Test
+    fun `onPlayerError maps residual IO failures to io_error`() {
+        val listener = capturePlayerListener()
+        val result = mockk<MethodChannel.Result>(relaxed = true)
+        instance.onMethodCall(setClipsCall(), result)
+
+        listener.onPlayerError(playbackError("IO unspecified", 2000))
+
+        verify(exactly = 1) {
+            result.error("PLAYER_ERROR", "IO unspecified", mapOf("errorCode" to "io_error"))
+        }
+        verify(exactly = 0) { result.success(any()) }
+    }
+
+    @Test
+    fun `onPlayerError maps residual cleartext IO failures to io_error`() {
+        val listener = capturePlayerListener()
+        val result = mockk<MethodChannel.Result>(relaxed = true)
+        instance.onMethodCall(setClipsCall(), result)
+
+        listener.onPlayerError(playbackError("Cleartext not permitted", 2007))
+
+        verify(exactly = 1) {
+            result.error(
+                "PLAYER_ERROR",
+                "Cleartext not permitted",
+                mapOf("errorCode" to "io_error"),
+            )
+        }
+        verify(exactly = 0) { result.success(any()) }
+    }
+
+    @Test
+    fun `onPlayerError maps residual read-position IO failures to io_error`() {
+        val listener = capturePlayerListener()
+        val result = mockk<MethodChannel.Result>(relaxed = true)
+        instance.onMethodCall(setClipsCall(), result)
+
+        listener.onPlayerError(playbackError("Read position out of range", 2008))
+
+        verify(exactly = 1) {
+            result.error(
+                "PLAYER_ERROR",
+                "Read position out of range",
+                mapOf("errorCode" to "io_error"),
+            )
+        }
+        verify(exactly = 0) { result.success(any()) }
+    }
+
+    @Test
+    fun `onPlayerError maps renderer failures to decoder_error`() {
+        val listener = capturePlayerListener()
+        val result = mockk<MethodChannel.Result>(relaxed = true)
+        instance.onMethodCall(setClipsCall(), result)
+
+        listener.onPlayerError(playbackError("Renderer failed", 5000))
+
+        verify(exactly = 1) {
+            result.error("PLAYER_ERROR", "Renderer failed", mapOf("errorCode" to "decoder_error"))
+        }
+        verify(exactly = 0) { result.success(any()) }
     }
 
     @Test

--- a/mobile/packages/divine_video_player/lib/src/player_error_code.dart
+++ b/mobile/packages/divine_video_player/lib/src/player_error_code.dart
@@ -45,6 +45,12 @@ enum NativePlayerErrorCode {
   /// iOS: `NSURLErrorTimedOut`.
   timeout,
 
+  /// The platform reported an I/O failure that is not a concrete HTTP,
+  /// network, timeout, or auth condition.
+  ///
+  /// Android: residual `ERROR_CODE_IO_*` values in the 2xxx range.
+  ioError,
+
   /// The media container or segment could not be parsed.
   ///
   /// Android: `ERROR_CODE_PARSING_*` (3xxx range).
@@ -75,6 +81,7 @@ enum NativePlayerErrorCode {
     authRequired => false,
     httpClientError => true,
     httpServerError => true,
+    ioError => true,
     parseError => true,
     networkError => false,
     timeout => false,
@@ -92,6 +99,7 @@ enum NativePlayerErrorCode {
     mediaProcessing => true,
     networkError => true,
     timeout => true,
+    ioError => false,
     authRequired => false,
     httpServerError => false,
     httpClientError => false,
@@ -108,6 +116,7 @@ enum NativePlayerErrorCode {
     'http_server_error' => httpServerError,
     'network_error' => networkError,
     'timeout' => timeout,
+    'io_error' => ioError,
     'parse_error' => parseError,
     'decoder_error' => decoderError,
     _ => unknown,

--- a/mobile/packages/divine_video_player/test/src/video_player_state_test.dart
+++ b/mobile/packages/divine_video_player/test/src/video_player_state_test.dart
@@ -20,6 +20,10 @@ void main() {
         expect(NativePlayerErrorCode.httpServerError.shouldFailover, isTrue);
       });
 
+      test('returns true for ioError', () {
+        expect(NativePlayerErrorCode.ioError.shouldFailover, isTrue);
+      });
+
       test('returns true for parseError', () {
         expect(NativePlayerErrorCode.parseError.shouldFailover, isTrue);
       });
@@ -52,6 +56,10 @@ void main() {
 
       test('returns true for timeout', () {
         expect(NativePlayerErrorCode.timeout.isTransient, isTrue);
+      });
+
+      test('returns false for ioError', () {
+        expect(NativePlayerErrorCode.ioError.isTransient, isFalse);
       });
 
       test('returns false for authRequired', () {
@@ -119,6 +127,13 @@ void main() {
         expect(
           NativePlayerErrorCode.fromString('timeout'),
           equals(NativePlayerErrorCode.timeout),
+        );
+      });
+
+      test('parses io_error', () {
+        expect(
+          NativePlayerErrorCode.fromString('io_error'),
+          equals(NativePlayerErrorCode.ioError),
         );
       });
 

--- a/mobile/packages/infinite_video_feed/lib/src/services/derivative_failure_cache.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/services/derivative_failure_cache.dart
@@ -1,0 +1,56 @@
+import 'package:infinite_video_feed/src/utils/canonical_divine_url.dart';
+
+/// How long a failed Divine derivative should be demoted behind fallbacks.
+const derivativeFailureCacheTtl = Duration(seconds: 90);
+
+/// Provides the current wall-clock time for [DerivativeFailureCache].
+typedef DerivativeFailureClock = DateTime Function();
+
+/// Remembers recent failures for derived Divine media URLs by blob hash.
+///
+/// This is intentionally small and in-memory. It only needs to survive
+/// controller recycling inside the feed window so a freshly published video
+/// does not keep selecting a derivative that just failed.
+class DerivativeFailureCache {
+  /// Creates an in-memory cache with an optional [ttl] and testable [clock].
+  DerivativeFailureCache({
+    Duration ttl = derivativeFailureCacheTtl,
+    DerivativeFailureClock? clock,
+  }) : _ttl = ttl,
+       _clock = clock ?? DateTime.now;
+
+  final Duration _ttl;
+  final DerivativeFailureClock _clock;
+  final _failedAtByHash = <String, DateTime>{};
+
+  /// Records a recent failure if [source] is a Divine derivative URL.
+  void recordFailureForSource(String source) {
+    final hash = derivativeHashForSource(source);
+    if (hash == null) return;
+    _failedAtByHash[hash] = _clock();
+  }
+
+  /// Returns whether [hash] has a live failure entry.
+  bool hasFreshFailureForHash(String hash) {
+    final failedAt = _failedAtByHash[hash];
+    if (failedAt == null) return false;
+    if (_clock().difference(failedAt) <= _ttl) return true;
+
+    _failedAtByHash.remove(hash);
+    return false;
+  }
+}
+
+/// Returns the blob hash for derivative URLs, excluding raw and HLS sources.
+String? derivativeHashForSource(String source) {
+  final hash = extractCanonicalDivineBlobHash(source);
+  if (hash == null) return null;
+
+  final rawUrl = canonicalDivineBlobRawUrl(hash);
+  final hlsUrl = canonicalDivineBlobHlsUrl(hash);
+  if (source == rawUrl || source == hlsUrl || source.contains('/hls/')) {
+    return null;
+  }
+
+  return hash;
+}

--- a/mobile/packages/infinite_video_feed/lib/src/utils/playback_sources.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/utils/playback_sources.dart
@@ -1,6 +1,7 @@
 import 'package:divine_video_player/divine_video_player.dart';
 import 'package:flutter/services.dart';
 import 'package:infinite_video_feed/src/models/video_error_type.dart';
+import 'package:infinite_video_feed/src/services/derivative_failure_cache.dart';
 import 'package:infinite_video_feed/src/utils/canonical_divine_url.dart';
 import 'package:models/models.dart';
 
@@ -37,6 +38,7 @@ import 'package:models/models.dart';
 List<String> resolvePlaybackSources(
   VideoEvent video, {
   String? Function(VideoEvent video)? urlResolver,
+  DerivativeFailureCache? derivativeFailureCache,
 }) {
   final resolvedSource = urlResolver?.call(video) ?? video.videoUrl;
   final originalUrl = video.videoUrl;
@@ -61,9 +63,20 @@ List<String> resolvePlaybackSources(
     // startup" behavior. The bare blob currently fails for range-requesting
     // players until divine-blossom#198 is fixed, so HLS remains behind it as
     // the final recovery source.
-    return isRawBlob
-        ? orderedUniqueSources([resolvedSource, hlsUrl, originalUrl])
-        : orderedUniqueSources([resolvedSource, rawUrl, hlsUrl, originalUrl]);
+    if (isRawBlob) {
+      return orderedUniqueSources([resolvedSource, hlsUrl, originalUrl]);
+    }
+
+    if (derivativeFailureCache?.hasFreshFailureForHash(hash) ?? false) {
+      return orderedUniqueSources([
+        hlsUrl,
+        rawUrl,
+        resolvedSource,
+        originalUrl,
+      ]);
+    }
+
+    return orderedUniqueSources([resolvedSource, rawUrl, hlsUrl, originalUrl]);
   }
 
   return orderedUniqueSources([resolvedSource, originalUrl]);

--- a/mobile/packages/infinite_video_feed/lib/src/utils/source_loader.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/utils/source_loader.dart
@@ -47,6 +47,7 @@ Future<(String, int)> setSourceWithFallbacks({
   bool Function()? isLoadCurrent,
   Duration? maxPlaybackDuration,
   SourceLoadDelay delay = Future<void>.delayed,
+  void Function(String source)? onFailoverSourceFailure,
 }) async {
   Object? lastError;
   StackTrace? lastStackTrace;
@@ -130,6 +131,9 @@ Future<(String, int)> setSourceWithFallbacks({
       }
       final nextAttempt = attemptIndex + 1;
       if (nextAttempt < sources.length) {
+        if (_shouldRecordFailoverSourceFailure(error)) {
+          onFailoverSourceFailure?.call(source);
+        }
         log(
           'Source failed index $index: '
           'failedSource=$source '
@@ -154,4 +158,11 @@ Future<(String, int)> setSourceWithFallbacks({
   }
 
   throw StateError('No playback sources resolved for index $index');
+}
+
+bool _shouldRecordFailoverSourceFailure(Object error) {
+  if (isMediaProcessingError(error)) return true;
+
+  final nativeErrorCode = nativePlayerErrorCodeFromError(error);
+  return nativeErrorCode?.shouldFailover ?? false;
 }

--- a/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
@@ -1371,16 +1371,28 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
   // Source failover depends on runtime native playback errors and source
   // switching on an initialized controller, which package tests cannot
   // simulate without the platform player backend.
-  Future<void> _retryWithNextSource(int index) async {
+  /// Advances [index] to its next playback source.
+  ///
+  /// Set [recordSourceFailure] only when the failover is caused by a typed
+  /// source-level failure. Slow loads and stalls are transient network
+  /// conditions, so they must not demote an otherwise healthy derivative —
+  /// this mirrors the gate `setSourceWithFallbacks` applies before calling
+  /// `onFailoverSourceFailure`.
+  Future<void> _retryWithNextSource(
+    int index, {
+    bool recordSourceFailure = false,
+  }) async {
     if (!_sources.hasSources(index)) {
       _log('No sources to retry for index $index');
       _onVideoStalled(index);
       return;
     }
 
-    final failedSource = _sources.activeSourceFor(index);
-    if (failedSource != null) {
-      _derivativeFailures.recordFailureForSource(failedSource);
+    if (recordSourceFailure) {
+      final failedSource = _sources.activeSourceFor(index);
+      if (failedSource != null) {
+        _derivativeFailures.recordFailureForSource(failedSource);
+      }
     }
 
     final nextSource = _sources.advance(index);
@@ -1745,7 +1757,12 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
               _sources.hasSources(index) &&
               _sources.canAdvance(index);
           if (shouldFailover) {
-            unawaited(_retryWithNextSource(index));
+            unawaited(
+              _retryWithNextSource(
+                index,
+                recordSourceFailure: errorCode?.shouldFailover ?? false,
+              ),
+            );
             return;
           }
 

--- a/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
@@ -8,6 +8,7 @@ import 'package:flutter/widgets.dart';
 import 'package:infinite_video_feed/src/models/builders.dart';
 import 'package:infinite_video_feed/src/models/video_error_type.dart';
 import 'package:infinite_video_feed/src/services/controller_subscriptions.dart';
+import 'package:infinite_video_feed/src/services/derivative_failure_cache.dart';
 import 'package:infinite_video_feed/src/services/disk_prefetcher.dart';
 import 'package:infinite_video_feed/src/services/load_watchdog.dart';
 import 'package:infinite_video_feed/src/services/playback_source_registry.dart';
@@ -59,6 +60,7 @@ class InfiniteVideoFeed extends StatefulWidget {
     this.nearEndThreshold = 10,
     this.onVideoLoopCompleted,
     this.onVideoStalled,
+    this.derivativeFailureCache,
     this.slowLoadThreshold = const Duration(seconds: 8),
     this.preloadGracePeriod = const Duration(seconds: 3),
     this.isActive = true,
@@ -135,6 +137,13 @@ class InfiniteVideoFeed extends StatefulWidget {
   ///
   /// Must be initialized before passing it in.
   final MediaCacheManager cache;
+
+  /// Cache of recently failed Divine derivative sources.
+  ///
+  /// When `null`, the feed creates an in-memory cache for its own controller
+  /// window. Tests and owning widgets may inject one to preserve demotion state
+  /// across feed rebuilds.
+  final DerivativeFailureCache? derivativeFailureCache;
 
   /// The initial video index to display.
   final int initialIndex;
@@ -397,6 +406,7 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
   // ─── Services ───────────────────────────────────────────────────────────
 
   late final PlaybackSourceRegistry _sources;
+  late final DerivativeFailureCache _derivativeFailures;
   late final DiskPrefetcher _prefetcher;
   late final LoadWatchdog _watchdog;
   late final StalePlaybackDetector _staleDetector;
@@ -519,6 +529,8 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
       ..addListener(_syncPagePosition);
 
     _sources = PlaybackSourceRegistry();
+    _derivativeFailures =
+        widget.derivativeFailureCache ?? DerivativeFailureCache();
     _prefetcher = DiskPrefetcher(cache: widget.cache, log: _log);
     // coverage:ignore-start
     // Callback wiring only; exercised transitively by watchdog/detector tests
@@ -997,6 +1009,7 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
       resolveUrls: (video) => resolvePlaybackSources(
         video,
         urlResolver: widget.urlResolver,
+        derivativeFailureCache: _derivativeFailures,
         // Exclude HLS manifests: prefetch writes static files to disk,
         // but HLS playback needs re-streaming the manifest + segments.
       ).where((url) => !isHlsManifest(url)).toList(),
@@ -1139,6 +1152,7 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
       final playbackSources = resolvePlaybackSources(
         video,
         urlResolver: widget.urlResolver,
+        derivativeFailureCache: _derivativeFailures,
       );
       // Hash-bound auth applies to every resolved source for this index, so
       // the optimized/HLS/raw variants all authenticate, not just the bare URL.
@@ -1192,12 +1206,14 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
             httpHeadersForSource: httpHeadersForSource,
             isLoadCurrent: ownsInit,
             maxPlaybackDuration: widget.maxPlaybackDuration,
+            onFailoverSourceFailure: _derivativeFailures.recordFailureForSource,
           );
           if (!guardInitOwnership('setSourceWithFallbacks(cache)')) return;
           _sources.register(index, playbackSources, openedSourceIdx);
           _log(
             'Network fallback source selected index $index (${video.id}): '
-            'openedSource=$openedSource',
+            'openedSource=$openedSource '
+            'attempt=$openedSourceIdx',
           );
         }
       } else {
@@ -1213,12 +1229,14 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
           httpHeadersForSource: httpHeadersForSource,
           isLoadCurrent: ownsInit,
           maxPlaybackDuration: widget.maxPlaybackDuration,
+          onFailoverSourceFailure: _derivativeFailures.recordFailureForSource,
         );
         if (!guardInitOwnership('setSourceWithFallbacks(network)')) return;
         _sources.register(index, playbackSources, openedSourceIdx);
         _log(
           'Source selected index $index (${video.id}): '
-          'openedSource=$openedSource',
+          'openedSource=$openedSource '
+          'attempt=$openedSourceIdx',
         );
       }
 
@@ -1358,6 +1376,11 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
       _log('No sources to retry for index $index');
       _onVideoStalled(index);
       return;
+    }
+
+    final failedSource = _sources.activeSourceFor(index);
+    if (failedSource != null) {
+      _derivativeFailures.recordFailureForSource(failedSource);
     }
 
     final nextSource = _sources.advance(index);
@@ -1716,7 +1739,9 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
           // Fall back to attempting failover for unknown errors so we
           // don't give up prematurely on unclassified failures.
           final shouldFailover =
-              (errorCode == null || errorCode.shouldFailover) &&
+              (errorCode == null ||
+                  errorCode == NativePlayerErrorCode.unknown ||
+                  errorCode.shouldFailover) &&
               _sources.hasSources(index) &&
               _sources.canAdvance(index);
           if (shouldFailover) {

--- a/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
@@ -60,7 +60,6 @@ class InfiniteVideoFeed extends StatefulWidget {
     this.nearEndThreshold = 10,
     this.onVideoLoopCompleted,
     this.onVideoStalled,
-    this.derivativeFailureCache,
     this.slowLoadThreshold = const Duration(seconds: 8),
     this.preloadGracePeriod = const Duration(seconds: 3),
     this.isActive = true,
@@ -137,13 +136,6 @@ class InfiniteVideoFeed extends StatefulWidget {
   ///
   /// Must be initialized before passing it in.
   final MediaCacheManager cache;
-
-  /// Cache of recently failed Divine derivative sources.
-  ///
-  /// When `null`, the feed creates an in-memory cache for its own controller
-  /// window. Tests and owning widgets may inject one to preserve demotion state
-  /// across feed rebuilds.
-  final DerivativeFailureCache? derivativeFailureCache;
 
   /// The initial video index to display.
   final int initialIndex;
@@ -529,8 +521,7 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
       ..addListener(_syncPagePosition);
 
     _sources = PlaybackSourceRegistry();
-    _derivativeFailures =
-        widget.derivativeFailureCache ?? DerivativeFailureCache();
+    _derivativeFailures = DerivativeFailureCache();
     _prefetcher = DiskPrefetcher(cache: widget.cache, log: _log);
     // coverage:ignore-start
     // Callback wiring only; exercised transitively by watchdog/detector tests

--- a/mobile/packages/infinite_video_feed/test/src/services/derivative_failure_cache_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/services/derivative_failure_cache_test.dart
@@ -1,0 +1,53 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:infinite_video_feed/src/services/derivative_failure_cache.dart';
+
+const _hash =
+    'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2';
+const _variantUrl = 'https://media.divine.video/$_hash/720p.mp4';
+const _rawUrl = 'https://media.divine.video/$_hash';
+const _hlsUrl = 'https://media.divine.video/$_hash/hls/master.m3u8';
+
+void main() {
+  group(DerivativeFailureCache, () {
+    late DateTime now;
+    late DerivativeFailureCache cache;
+
+    setUp(() {
+      now = DateTime(2026, 8, 14, 12);
+      cache = DerivativeFailureCache(clock: () => now);
+    });
+
+    test('records failures for derivative sources by hash', () {
+      cache.recordFailureForSource(_variantUrl);
+
+      expect(cache.hasFreshFailureForHash(_hash), isTrue);
+    });
+
+    test('ignores raw and HLS sources', () {
+      cache
+        ..recordFailureForSource(_rawUrl)
+        ..recordFailureForSource(_hlsUrl);
+
+      expect(cache.hasFreshFailureForHash(_hash), isFalse);
+    });
+
+    test('expires failures after the TTL', () {
+      cache.recordFailureForSource(_variantUrl);
+
+      now = now.add(derivativeFailureCacheTtl);
+      expect(cache.hasFreshFailureForHash(_hash), isTrue);
+
+      now = now.add(const Duration(milliseconds: 1));
+      expect(cache.hasFreshFailureForHash(_hash), isFalse);
+    });
+  });
+
+  group('derivativeHashForSource', () {
+    test('returns a hash only for derivative sources', () {
+      expect(derivativeHashForSource(_variantUrl), equals(_hash));
+      expect(derivativeHashForSource(_rawUrl), isNull);
+      expect(derivativeHashForSource(_hlsUrl), isNull);
+      expect(derivativeHashForSource('https://example.com/video.mp4'), isNull);
+    });
+  });
+}

--- a/mobile/packages/infinite_video_feed/test/src/utils/playback_sources_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/utils/playback_sources_test.dart
@@ -2,6 +2,7 @@ import 'package:divine_video_player/divine_video_player.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:infinite_video_feed/src/models/video_error_type.dart';
+import 'package:infinite_video_feed/src/services/derivative_failure_cache.dart';
 import 'package:infinite_video_feed/src/utils/playback_sources.dart';
 import 'package:models/models.dart';
 
@@ -102,6 +103,33 @@ void main() {
           );
         },
       );
+
+      test('leads with HLS while the derivative has a fresh failure', () {
+        final video = _makeVideo(videoUrl: variantUrl);
+        final cache = DerivativeFailureCache()
+          ..recordFailureForSource(variantUrl);
+
+        expect(
+          resolvePlaybackSources(video, derivativeFailureCache: cache),
+          equals([_hlsUrl, _rawUrl, variantUrl]),
+        );
+      });
+
+      test('restores derivative-first ordering after failure TTL expires', () {
+        var now = DateTime(2026, 8, 14, 12);
+        final cache = DerivativeFailureCache(clock: () => now)
+          ..recordFailureForSource(variantUrl);
+        final video = _makeVideo(videoUrl: variantUrl);
+
+        now = now.add(
+          derivativeFailureCacheTtl + const Duration(milliseconds: 1),
+        );
+
+        expect(
+          resolvePlaybackSources(video, derivativeFailureCache: cache),
+          equals([variantUrl, _rawUrl, _hlsUrl]),
+        );
+      });
     });
 
     group('with resolver returning null', () {

--- a/mobile/packages/infinite_video_feed/test/src/utils/source_loader_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/utils/source_loader_test.dart
@@ -152,11 +152,80 @@ void main() {
         equals(['processingUrl', 'rawUrl']),
       );
       expect(delays, isEmpty);
-      expect(
-        logs.where((line) => line.contains('Source processing')),
-        isEmpty,
-      );
+      expect(logs.where((line) => line.contains('Source processing')), isEmpty);
       expect(logs.any((line) => line.contains('retrySource=rawUrl')), isTrue);
+    });
+
+    test('records media-processing source failure before failover', () async {
+      final controller = _RecordingControllerWithFailures(
+        (_) {},
+        failures: [Exception('CoreMediaErrorDomain error -12667 - HTTP 202')],
+      );
+      addTearDown(controller.dispose);
+      final recordedFailures = <String>[];
+
+      await setSourceWithFallbacks(
+        index: 2,
+        controller: controller,
+        sources: ['processingUrl', 'rawUrl'],
+        log: logs.add,
+        onFailoverSourceFailure: recordedFailures.add,
+      );
+
+      expect(recordedFailures, equals(['processingUrl']));
+    });
+
+    test(
+      'records typed failover-class source failure before failover',
+      () async {
+        final controller = _RecordingControllerWithFailures(
+          (_) {},
+          failures: [
+            PlatformException(
+              code: 'PLAYER_ERROR',
+              message: 'ERROR_CODE_IO_UNSPECIFIED',
+              details: const <String, Object?>{'errorCode': 'io_error'},
+            ),
+          ],
+        );
+        addTearDown(controller.dispose);
+        final recordedFailures = <String>[];
+
+        await setSourceWithFallbacks(
+          index: 2,
+          controller: controller,
+          sources: ['derivedMp4', 'hlsUrl'],
+          log: logs.add,
+          onFailoverSourceFailure: recordedFailures.add,
+        );
+
+        expect(recordedFailures, equals(['derivedMp4']));
+      },
+    );
+
+    test('does not record transient timeout failure before failover', () async {
+      final controller = _RecordingControllerWithFailures(
+        (_) {},
+        failures: [
+          PlatformException(
+            code: 'PLAYER_ERROR',
+            message: 'timeout',
+            details: const <String, Object?>{'errorCode': 'timeout'},
+          ),
+        ],
+      );
+      addTearDown(controller.dispose);
+      final recordedFailures = <String>[];
+
+      await setSourceWithFallbacks(
+        index: 2,
+        controller: controller,
+        sources: ['derivedMp4', 'hlsUrl'],
+        log: logs.add,
+        onFailoverSourceFailure: recordedFailures.add,
+      );
+
+      expect(recordedFailures, isEmpty);
     });
 
     test('uses source headers when retrying after HTTP 202', () async {
@@ -217,10 +286,7 @@ void main() {
           logs.where((line) => line.contains('Source processing')),
           hasLength(5),
         );
-        expect(
-          logs.any((line) => line.contains('All sources failed')),
-          isTrue,
-        );
+        expect(logs.any((line) => line.contains('All sources failed')), isTrue);
       },
     );
 


### PR DESCRIPTION
## Description

Fixes post-publish playback recovery by mapping residual Android Media3 IO failures to a failover-capable `io_error` and remembering recently failed Divine derivative URLs by blob hash. While a derivative failure is fresh, playback resolves HLS/raw fallbacks before retrying the derivative, so recycled feed controllers do not keep preferring a known-bad `/720p.mp4` source.

**Related Issue:** Closes #7385

## Out of Scope

Server-side derivative readiness behavior in divine-blossom remains out of scope for this mobile hardening PR.

## Verification

- `flutter test packages/divine_video_player/test/src/video_player_state_test.dart packages/infinite_video_feed/test/src/services/derivative_failure_cache_test.dart packages/infinite_video_feed/test/src/utils/playback_sources_test.dart packages/infinite_video_feed/test/src/utils/source_loader_test.dart`
- `flutter analyze packages/divine_video_player packages/infinite_video_feed`
- Pre-push hook: analysis and changed-file tests passed
- Android unit test command was attempted, but local Gradle could not start before project configuration: system Gradle 9.6.1 is incompatible with the project AGP, and Gradle 8.14 fails locally loading `libnative-platform.dylib` on macOS aarch64.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore