### PR TITLE
fix(recorder): defer overlay visibility lifecycle writes

### DIFF
--- a/mobile/lib/providers/overlay_visibility_provider.dart
+++ b/mobile/lib/providers/overlay_visibility_provider.dart
@@ -49,6 +49,9 @@ class OverlayVisibility extends _$OverlayVisibility {
   @override
   OverlayVisibilityState build() => const OverlayVisibilityState();
 
+  /// Whether this notifier can still accept writes.
+  bool get isMounted => ref.mounted;
+
   /// Set page overlay state (full-screen overlays like settings).
   /// When a page is open, all video players will be released.
   void setPageOpen(bool isOpen) {

--- a/mobile/lib/providers/overlay_visibility_provider.dart
+++ b/mobile/lib/providers/overlay_visibility_provider.dart
@@ -50,12 +50,13 @@ class OverlayVisibility extends _$OverlayVisibility {
   bool _pageOpenWithoutOwner = false;
 
   @override
-  OverlayVisibilityState build() => OverlayVisibilityState(
-    isPageOpen: _pageOpenWithoutOwner || _pageOpenOwners.isNotEmpty,
-  );
+  OverlayVisibilityState build() =>
+      OverlayVisibilityState(isPageOpen: _isPageOpen);
 
   /// Whether this notifier can still accept writes.
   bool get isMounted => ref.mounted;
+
+  bool get _isPageOpen => _pageOpenWithoutOwner || _pageOpenOwners.isNotEmpty;
 
   /// Sets page visibility for callers without an independent owner token.
   /// Owner-held pages remain open when this is set to false.
@@ -82,7 +83,7 @@ class OverlayVisibility extends _$OverlayVisibility {
   }
 
   void _updatePageOpen() {
-    final isOpen = _pageOpenWithoutOwner || _pageOpenOwners.isNotEmpty;
+    final isOpen = _isPageOpen;
     if (state.isPageOpen != isOpen) {
       Log.info(
         'Page ${isOpen ? 'opened' : 'closed'}',

--- a/mobile/lib/providers/overlay_visibility_provider.dart
+++ b/mobile/lib/providers/overlay_visibility_provider.dart
@@ -50,25 +50,34 @@ class OverlayVisibility extends _$OverlayVisibility {
   bool _pageOpenWithoutOwner = false;
 
   @override
-  OverlayVisibilityState build() => const OverlayVisibilityState();
+  OverlayVisibilityState build() => OverlayVisibilityState(
+    isPageOpen: _pageOpenWithoutOwner || _pageOpenOwners.isNotEmpty,
+  );
 
   /// Whether this notifier can still accept writes.
   bool get isMounted => ref.mounted;
 
-  /// Set page overlay state (full-screen overlays like settings).
-  /// When a page is open, all video players will be released.
+  /// Sets page visibility for callers without an independent owner token.
+  /// Owner-held pages remain open when this is set to false.
   void setPageOpen(bool isOpen) {
     _pageOpenWithoutOwner = isOpen;
     _updatePageOpen();
   }
 
-  /// Set page overlay state for one independently mounted owner.
+  /// Sets page visibility for one independently mounted owner.
   void setPageOpenForOwner(Object owner, {required bool isOpen}) {
     if (isOpen) {
       _pageOpenOwners.add(owner);
     } else {
       _pageOpenOwners.remove(owner);
     }
+    _updatePageOpen();
+  }
+
+  /// Clears every page-open source after navigation proves none remain.
+  void clearPageOpen() {
+    _pageOpenWithoutOwner = false;
+    _pageOpenOwners.clear();
     _updatePageOpen();
   }
 

--- a/mobile/lib/providers/overlay_visibility_provider.dart
+++ b/mobile/lib/providers/overlay_visibility_provider.dart
@@ -46,6 +46,9 @@ class OverlayVisibilityState {
 /// Notifier for managing overlay visibility state
 @Riverpod(keepAlive: true)
 class OverlayVisibility extends _$OverlayVisibility {
+  final Set<Object> _pageOpenOwners = {};
+  bool _pageOpenWithoutOwner = false;
+
   @override
   OverlayVisibilityState build() => const OverlayVisibilityState();
 
@@ -55,6 +58,22 @@ class OverlayVisibility extends _$OverlayVisibility {
   /// Set page overlay state (full-screen overlays like settings).
   /// When a page is open, all video players will be released.
   void setPageOpen(bool isOpen) {
+    _pageOpenWithoutOwner = isOpen;
+    _updatePageOpen();
+  }
+
+  /// Set page overlay state for one independently mounted owner.
+  void setPageOpenForOwner(Object owner, {required bool isOpen}) {
+    if (isOpen) {
+      _pageOpenOwners.add(owner);
+    } else {
+      _pageOpenOwners.remove(owner);
+    }
+    _updatePageOpen();
+  }
+
+  void _updatePageOpen() {
+    final isOpen = _pageOpenWithoutOwner || _pageOpenOwners.isNotEmpty;
     if (state.isPageOpen != isOpen) {
       Log.info(
         'Page ${isOpen ? 'opened' : 'closed'}',

--- a/mobile/lib/providers/overlay_visibility_provider.g.dart
+++ b/mobile/lib/providers/overlay_visibility_provider.g.dart
@@ -44,7 +44,7 @@ final class OverlayVisibilityProvider
   }
 }
 
-String _$overlayVisibilityHash() => r'479007988c14948580057673c6a504a2a9bf2422';
+String _$overlayVisibilityHash() => r'60738a3a994db770034f567afa5d2a71016ec2b2';
 
 /// Notifier for managing overlay visibility state
 

--- a/mobile/lib/providers/overlay_visibility_provider.g.dart
+++ b/mobile/lib/providers/overlay_visibility_provider.g.dart
@@ -44,7 +44,7 @@ final class OverlayVisibilityProvider
   }
 }
 
-String _$overlayVisibilityHash() => r'048f5f587812f76e7771a95c5aa58c86574517f0';
+String _$overlayVisibilityHash() => r'ea10b79382c58b122d7d69058aa2db2f9e837c08';
 
 /// Notifier for managing overlay visibility state
 

--- a/mobile/lib/providers/overlay_visibility_provider.g.dart
+++ b/mobile/lib/providers/overlay_visibility_provider.g.dart
@@ -44,7 +44,7 @@ final class OverlayVisibilityProvider
   }
 }
 
-String _$overlayVisibilityHash() => r'1f29f1983f487775163e3084d245ae44c79e4bd6';
+String _$overlayVisibilityHash() => r'479007988c14948580057673c6a504a2a9bf2422';
 
 /// Notifier for managing overlay visibility state
 

--- a/mobile/lib/providers/overlay_visibility_provider.g.dart
+++ b/mobile/lib/providers/overlay_visibility_provider.g.dart
@@ -44,7 +44,7 @@ final class OverlayVisibilityProvider
   }
 }
 
-String _$overlayVisibilityHash() => r'60738a3a994db770034f567afa5d2a71016ec2b2';
+String _$overlayVisibilityHash() => r'048f5f587812f76e7771a95c5aa58c86574517f0';
 
 /// Notifier for managing overlay visibility state
 

--- a/mobile/lib/providers/shell_obscured_provider.dart
+++ b/mobile/lib/providers/shell_obscured_provider.dart
@@ -18,11 +18,13 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 /// without a pop event (e.g. sign-out → /welcome → back to home) cannot keep
 /// the feed paused.
 ///
-/// AppShell also clears `overlayVisibilityProvider.isPageOpen` when this flag
-/// becomes `false`. A page overlay is backed by a route above the shell, so an
-/// uncovered shell proves the page overlay should no longer block autoplay,
-/// even if go_router removed the route with `go()` and never completed the
-/// original `pushWithVideoPause` future.
+/// AppShell also reconciles `overlayVisibilityProvider.isPageOpen` when this
+/// flag becomes `false`. A fresh shell mount clears only stale unowned page
+/// state because it can still sit below a live page owner. `didPopNext` clears
+/// every page owner because popping the route directly above the shell proves
+/// no page overlay should continue blocking autoplay, even if go_router removed
+/// the route with `go()` and never completed the original `pushWithVideoPause`
+/// future.
 ///
 /// The home feed reads this to know it is offstage behind a pushed screen.
 /// GoRouter's `routeInformationProvider` collapses to the shell location

--- a/mobile/lib/router/app_shell.dart
+++ b/mobile/lib/router/app_shell.dart
@@ -103,19 +103,29 @@ class _AppShellState extends ConsumerState<AppShell> with RouteAware {
     super.dispose();
   }
 
-  void _setShellObscured({required bool obscured}) {
+  void _setShellObscured({
+    required bool obscured,
+    bool clearPageOwners = false,
+  }) {
     // RouteAware callbacks can fire mid-frame; defer the provider write so it
     // never lands during this shell's own build.
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
       ref.read(shellObscuredProvider.notifier).setObscured(obscured: obscured);
       if (!obscured) {
-        // Every page overlay is backed by a route above the shell, so an
-        // uncovered shell proves none is open. Not redundant with
-        // `pushWithVideoPause`'s own clear, which a `go()`-style back skips
-        // entirely — see its doc comment. Without this the home feed could stay
-        // permanently unable to autoplay on scroll (#6239).
-        ref.read(overlayVisibilityProvider.notifier).clearPageOpen();
+        final overlayVisibility = ref.read(
+          overlayVisibilityProvider.notifier,
+        );
+        if (clearPageOwners) {
+          // Popping the route directly above the shell proves no page owner
+          // remains. Force-clear because a `go()`-style back can skip the
+          // pushed route's own completion callback (#6239).
+          overlayVisibility.clearPageOpen();
+        } else {
+          // A freshly mounted shell can still sit below a live page owner.
+          // Clear only stale unowned state until a pop proves the stack empty.
+          overlayVisibility.setPageOpen(false);
+        }
       }
     });
   }
@@ -131,7 +141,8 @@ class _AppShellState extends ConsumerState<AppShell> with RouteAware {
   void didPushNext() => _setShellObscured(obscured: true);
 
   @override
-  void didPopNext() => _setShellObscured(obscured: false);
+  void didPopNext() =>
+      _setShellObscured(obscured: false, clearPageOwners: true);
 
   String _titleFor(BuildContext context, WidgetRef ref, RouteContext? ctx) {
     final l10n = context.l10n;

--- a/mobile/lib/router/app_shell.dart
+++ b/mobile/lib/router/app_shell.dart
@@ -115,7 +115,7 @@ class _AppShellState extends ConsumerState<AppShell> with RouteAware {
         // `pushWithVideoPause`'s own clear, which a `go()`-style back skips
         // entirely — see its doc comment. Without this the home feed could stay
         // permanently unable to autoplay on scroll (#6239).
-        ref.read(overlayVisibilityProvider.notifier).setPageOpen(false);
+        ref.read(overlayVisibilityProvider.notifier).clearPageOpen();
       }
     });
   }

--- a/mobile/lib/screens/video_recorder_screen.dart
+++ b/mobile/lib/screens/video_recorder_screen.dart
@@ -180,13 +180,11 @@ class VideoRecorderView extends ConsumerStatefulWidget {
 
 class _VideoRecorderViewState extends ConsumerState<VideoRecorderView>
     with WidgetsBindingObserver, CodecHeavySurfaceGuard {
-  static int _overlayVisibilityOwnerGeneration = 0;
-
   ProviderSubscription<AudioEvent?>? _soundSubscription;
   OverlayVisibility? _overlayVisibilityNotifier;
   late final CreationAnalyticsTracker _creationAnalyticsTracker;
   VideoRecorderMode? _lastRecorderMode;
-  int? _overlayVisibilityOwnerToken;
+  final Object _overlayVisibilityOwner = Object();
   bool _overlayVisibilityPageOpenAsserted = false;
 
   @override
@@ -268,9 +266,11 @@ class _VideoRecorderViewState extends ConsumerState<VideoRecorderView>
   void _pauseBackgroundPlayback() {
     if (_overlayVisibilityPageOpenAsserted) return;
     _overlayVisibilityNotifier = ref.read(overlayVisibilityProvider.notifier);
-    _overlayVisibilityOwnerToken = ++_overlayVisibilityOwnerGeneration;
     _overlayVisibilityPageOpenAsserted = true;
-    _overlayVisibilityNotifier!.setPageOpen(true);
+    _overlayVisibilityNotifier!.setPageOpenForOwner(
+      _overlayVisibilityOwner,
+      isOpen: true,
+    );
     Log.info(
       '⏸️ Paused background playback for camera',
       name: 'VideoRecorderScreen',
@@ -280,19 +280,15 @@ class _VideoRecorderViewState extends ConsumerState<VideoRecorderView>
 
   void _releaseBackgroundPlaybackAfterDispose() {
     final notifier = _overlayVisibilityNotifier;
-    final token = _overlayVisibilityOwnerToken;
-    if (!_overlayVisibilityPageOpenAsserted ||
-        notifier == null ||
-        token == null) {
+    if (!_overlayVisibilityPageOpenAsserted || notifier == null) {
       return;
     }
     _overlayVisibilityPageOpenAsserted = false;
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (_overlayVisibilityOwnerGeneration != token) return;
       if (!notifier.isMounted) return;
-      notifier.setPageOpen(false);
+      notifier.setPageOpenForOwner(_overlayVisibilityOwner, isOpen: false);
       Log.info(
-        '▶️ Resumed background playback after camera close',
+        '▶️ Released camera background playback hold',
         name: 'VideoRecorderScreen',
         category: .video,
       );

--- a/mobile/lib/screens/video_recorder_screen.dart
+++ b/mobile/lib/screens/video_recorder_screen.dart
@@ -180,10 +180,14 @@ class VideoRecorderView extends ConsumerStatefulWidget {
 
 class _VideoRecorderViewState extends ConsumerState<VideoRecorderView>
     with WidgetsBindingObserver, CodecHeavySurfaceGuard {
+  static int _overlayVisibilityOwnerGeneration = 0;
+
   ProviderSubscription<AudioEvent?>? _soundSubscription;
   OverlayVisibility? _overlayVisibilityNotifier;
   late final CreationAnalyticsTracker _creationAnalyticsTracker;
   VideoRecorderMode? _lastRecorderMode;
+  int? _overlayVisibilityOwnerToken;
+  bool _overlayVisibilityPageOpenAsserted = false;
 
   @override
   void initState() {
@@ -213,9 +217,9 @@ class _VideoRecorderViewState extends ConsumerState<VideoRecorderView>
     );
 
     WidgetsBinding.instance.addObserver(this);
-    _pauseBackgroundPlayback();
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       if (!mounted) return;
+      _pauseBackgroundPlayback();
       _initializeCamera();
       await _maybeShowWhySixSeconds();
       if (!mounted) return;
@@ -262,21 +266,37 @@ class _VideoRecorderViewState extends ConsumerState<VideoRecorderView>
 
   /// Force all background video playback to pause while camera is open.
   void _pauseBackgroundPlayback() {
-    try {
-      _overlayVisibilityNotifier = ref.read(overlayVisibilityProvider.notifier);
-      _overlayVisibilityNotifier!.setPageOpen(true);
-      Log.info(
-        '⏸️ Paused background playback for camera',
-        name: 'VideoRecorderScreen',
-        category: .video,
-      );
-    } catch (e) {
-      Log.warning(
-        '📹 Failed to pause background playback: $e',
-        name: 'VideoRecorderScreen',
-        category: .video,
-      );
+    if (_overlayVisibilityPageOpenAsserted) return;
+    _overlayVisibilityNotifier = ref.read(overlayVisibilityProvider.notifier);
+    _overlayVisibilityOwnerToken = ++_overlayVisibilityOwnerGeneration;
+    _overlayVisibilityPageOpenAsserted = true;
+    _overlayVisibilityNotifier!.setPageOpen(true);
+    Log.info(
+      '⏸️ Paused background playback for camera',
+      name: 'VideoRecorderScreen',
+      category: .video,
+    );
+  }
+
+  void _releaseBackgroundPlaybackAfterDispose() {
+    final notifier = _overlayVisibilityNotifier;
+    final token = _overlayVisibilityOwnerToken;
+    if (!_overlayVisibilityPageOpenAsserted ||
+        notifier == null ||
+        token == null) {
+      return;
     }
+    _overlayVisibilityPageOpenAsserted = false;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (_overlayVisibilityOwnerGeneration != token) return;
+      if (!notifier.isMounted) return;
+      notifier.setPageOpen(false);
+      Log.info(
+        '▶️ Resumed background playback after camera close',
+        name: 'VideoRecorderScreen',
+        category: .video,
+      );
+    });
   }
 
   /// Listens to sound selection changes and extracts waveform data.
@@ -342,15 +362,7 @@ class _VideoRecorderViewState extends ConsumerState<VideoRecorderView>
     if (!widget.fromEditor) {
       unawaited(_creationAnalyticsTracker.creationAbandoned());
     }
-    try {
-      _overlayVisibilityNotifier?.setPageOpen(false);
-    } catch (e) {
-      Log.warning(
-        '📹 Failed to clear overlay visibility on dispose: $e',
-        name: 'VideoRecorderScreen',
-        category: .video,
-      );
-    }
+    _releaseBackgroundPlaybackAfterDispose();
     _soundSubscription?.close();
 
     WidgetsBinding.instance.removeObserver(this);

--- a/mobile/test/providers/overlay_visibility_provider_test.dart
+++ b/mobile/test/providers/overlay_visibility_provider_test.dart
@@ -104,6 +104,18 @@ void main() {
       expect(container.read(overlayVisibilityProvider).isPageOpen, isFalse);
     });
 
+    test('clearPageOpen resets explicit and owner-held page overlays', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final notifier = container.read(overlayVisibilityProvider.notifier);
+
+      notifier.setPageOpen(true);
+      notifier.setPageOpenForOwner(Object(), isOpen: true);
+      notifier.clearPageOpen();
+
+      expect(container.read(overlayVisibilityProvider).isPageOpen, isFalse);
+    });
+
     test('isMounted returns false after container disposal', () {
       final container = ProviderContainer();
       final notifier = container.read(overlayVisibilityProvider.notifier);

--- a/mobile/test/providers/overlay_visibility_provider_test.dart
+++ b/mobile/test/providers/overlay_visibility_provider_test.dart
@@ -69,6 +69,41 @@ void main() {
       expect(container.read(overlayVisibilityProvider).isPageOpen, isTrue);
     });
 
+    test('page stays open until every independent owner releases it', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final notifier = container.read(overlayVisibilityProvider.notifier);
+      final firstOwner = Object();
+      final secondOwner = Object();
+
+      notifier.setPageOpenForOwner(firstOwner, isOpen: true);
+      notifier.setPageOpenForOwner(secondOwner, isOpen: true);
+      notifier.setPageOpenForOwner(firstOwner, isOpen: false);
+
+      expect(container.read(overlayVisibilityProvider).isPageOpen, isTrue);
+
+      notifier.setPageOpenForOwner(secondOwner, isOpen: false);
+
+      expect(container.read(overlayVisibilityProvider).isPageOpen, isFalse);
+    });
+
+    test('owner release preserves an explicitly opened page overlay', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final notifier = container.read(overlayVisibilityProvider.notifier);
+      final owner = Object();
+
+      notifier.setPageOpen(true);
+      notifier.setPageOpenForOwner(owner, isOpen: true);
+      notifier.setPageOpenForOwner(owner, isOpen: false);
+
+      expect(container.read(overlayVisibilityProvider).isPageOpen, isTrue);
+
+      notifier.setPageOpen(false);
+
+      expect(container.read(overlayVisibilityProvider).isPageOpen, isFalse);
+    });
+
     test('isMounted returns false after container disposal', () {
       final container = ProviderContainer();
       final notifier = container.read(overlayVisibilityProvider.notifier);

--- a/mobile/test/providers/overlay_visibility_provider_test.dart
+++ b/mobile/test/providers/overlay_visibility_provider_test.dart
@@ -69,6 +69,17 @@ void main() {
       expect(container.read(overlayVisibilityProvider).isPageOpen, isTrue);
     });
 
+    test('isMounted returns false after container disposal', () {
+      final container = ProviderContainer();
+      final notifier = container.read(overlayVisibilityProvider.notifier);
+
+      expect(notifier.isMounted, isTrue);
+
+      container.dispose();
+
+      expect(notifier.isMounted, isFalse);
+    });
+
     test('setBottomSheetOpen updates state', () {
       final container = ProviderContainer();
       addTearDown(container.dispose);

--- a/mobile/test/providers/overlay_visibility_provider_test.dart
+++ b/mobile/test/providers/overlay_visibility_provider_test.dart
@@ -104,6 +104,22 @@ void main() {
       expect(container.read(overlayVisibilityProvider).isPageOpen, isFalse);
     });
 
+    test('explicit close preserves an owner-held page overlay', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final notifier = container.read(overlayVisibilityProvider.notifier);
+      final owner = Object();
+
+      notifier.setPageOpenForOwner(owner, isOpen: true);
+      notifier.setPageOpen(false);
+
+      expect(container.read(overlayVisibilityProvider).isPageOpen, isTrue);
+
+      notifier.setPageOpenForOwner(owner, isOpen: false);
+
+      expect(container.read(overlayVisibilityProvider).isPageOpen, isFalse);
+    });
+
     test('clearPageOpen resets explicit and owner-held page overlays', () {
       final container = ProviderContainer();
       addTearDown(container.dispose);

--- a/mobile/test/providers/overlay_visibility_provider_test.dart
+++ b/mobile/test/providers/overlay_visibility_provider_test.dart
@@ -120,6 +120,28 @@ void main() {
       expect(container.read(overlayVisibilityProvider).isPageOpen, isFalse);
     });
 
+    test(
+      'provider rebuild preserves explicit and owner-held page overlays',
+      () {
+        final container = ProviderContainer();
+        addTearDown(container.dispose);
+        final notifier = container.read(overlayVisibilityProvider.notifier);
+        final owner = Object();
+
+        notifier.setPageOpen(true);
+        notifier.setPageOpenForOwner(owner, isOpen: true);
+        container.invalidate(overlayVisibilityProvider);
+
+        expect(container.read(overlayVisibilityProvider).isPageOpen, isTrue);
+
+        notifier.setPageOpen(false);
+        expect(container.read(overlayVisibilityProvider).isPageOpen, isTrue);
+
+        notifier.setPageOpenForOwner(owner, isOpen: false);
+        expect(container.read(overlayVisibilityProvider).isPageOpen, isFalse);
+      },
+    );
+
     test('clearPageOpen resets explicit and owner-held page overlays', () {
       final container = ProviderContainer();
       addTearDown(container.dispose);

--- a/mobile/test/router/app_shell_obscured_test.dart
+++ b/mobile/test/router/app_shell_obscured_test.dart
@@ -286,6 +286,12 @@ void main() {
       expect(container.read(shellObscuredProvider), isTrue);
       expect(container.read(overlayVisibilityProvider).isPageOpen, isTrue);
 
+      // Model a recorder hold whose ordinary release was skipped. Uncovering
+      // the shell is the final recovery path and must clear every owner.
+      container
+          .read(overlayVisibilityProvider.notifier)
+          .setPageOpenForOwner(Object(), isOpen: true);
+
       // A go()-style back removes the pushed route declaratively, so
       // pushWithVideoPause's future never completes. AppShell must still notice
       // that the shell is uncovered and clear the stranded page flag.

--- a/mobile/test/router/app_shell_obscured_test.dart
+++ b/mobile/test/router/app_shell_obscured_test.dart
@@ -183,6 +183,12 @@ void main() {
       container
           .read(shellObscuredProvider.notifier)
           .setObscured(obscured: true);
+      final overlayVisibility = container.read(
+        overlayVisibilityProvider.notifier,
+      );
+      final liveOwner = Object();
+      overlayVisibility.setPageOpen(true);
+      overlayVisibility.setPageOpenForOwner(liveOwner, isOpen: true);
       expect(container.read(shellObscuredProvider), isTrue);
 
       await tester.pumpWidget(
@@ -195,9 +201,15 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      // didPush fires once as the fresh shell subscribes, clearing the flag so
-      // the home feed can resume.
+      // didPush fires once as the fresh shell subscribes, clearing the stale
+      // obscured flag without dropping a live page owner.
       expect(container.read(shellObscuredProvider), isFalse);
+      expect(container.read(overlayVisibilityProvider).isPageOpen, isTrue);
+
+      // Fresh-shell recovery clears stale unowned state without destroying a
+      // live route owner's hold.
+      overlayVisibility.setPageOpenForOwner(liveOwner, isOpen: false);
+      expect(container.read(overlayVisibilityProvider).isPageOpen, isFalse);
     },
   );
 

--- a/mobile/test/screens/video_recorder_screen_test.dart
+++ b/mobile/test/screens/video_recorder_screen_test.dart
@@ -647,6 +647,14 @@ void main() {
           routeContainer.read(overlayVisibilityProvider).isPageOpen,
           isTrue,
         );
+
+        Navigator.of(tester.element(find.byType(VideoRecorderView))).pop();
+        await tester.pumpAndSettle();
+
+        expect(
+          routeContainer.read(overlayVisibilityProvider).isPageOpen,
+          isFalse,
+        );
       });
 
       testWidgets('clears video publish state when standalone route pops', (

--- a/mobile/test/screens/video_recorder_screen_test.dart
+++ b/mobile/test/screens/video_recorder_screen_test.dart
@@ -536,6 +536,12 @@ void main() {
           ],
         );
         addTearDown(routeContainer.dispose);
+        final pageOpenChanges = <bool>[];
+        final subscription = routeContainer.listen(
+          overlayVisibilityProvider,
+          (_, next) => pageOpenChanges.add(next.isPageOpen),
+        );
+        addTearDown(subscription.close);
 
         await tester.pumpWidget(
           buildNavigatorTestWidget(
@@ -553,6 +559,7 @@ void main() {
           routeContainer.read(overlayVisibilityProvider).isPageOpen,
           isTrue,
         );
+        expect(pageOpenChanges, equals([true]));
 
         Navigator.of(tester.element(find.byType(VideoRecorderView))).pop();
         await tester.pumpAndSettle();
@@ -562,6 +569,7 @@ void main() {
           routeContainer.read(overlayVisibilityProvider).isPageOpen,
           isFalse,
         );
+        expect(pageOpenChanges, equals([true, false]));
       });
 
       testWidgets('clears video publish state when standalone route pops', (

--- a/mobile/test/screens/video_recorder_screen_test.dart
+++ b/mobile/test/screens/video_recorder_screen_test.dart
@@ -101,6 +101,7 @@ List<Override> _stubStorageOverrides() {
 Widget buildTestWidget({
   ProviderContainer? container,
   List<Override> overrides = const [],
+  Key? recorderKey,
 }) {
   final child = MultiBlocProvider(
     providers: [
@@ -109,10 +110,10 @@ Widget buildTestWidget({
         create: (_) => MockCameraPermissionBloc(),
       ),
     ],
-    child: const MaterialApp(
+    child: MaterialApp(
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
-      home: VideoRecorderView(),
+      home: VideoRecorderView(key: recorderKey),
     ),
   );
 
@@ -358,10 +359,18 @@ void main() {
 
       testWidgets('sets page overlay while mounted and clears it after '
           'dispose', (tester) async {
+        final pageOpenChanges = <bool>[];
+        final subscription = container.listen(
+          overlayVisibilityProvider,
+          (_, next) => pageOpenChanges.add(next.isPageOpen),
+        );
+        addTearDown(subscription.close);
+
         await tester.pumpWidget(buildTestWidget(container: container));
         await tester.pump();
 
         expect(container.read(overlayVisibilityProvider).isPageOpen, isTrue);
+        expect(pageOpenChanges, equals([true]));
 
         await tester.pumpWidget(
           const MaterialApp(
@@ -373,31 +382,39 @@ void main() {
         await tester.pump();
 
         expect(container.read(overlayVisibilityProvider).isPageOpen, isFalse);
+        expect(pageOpenChanges, equals([true, false]));
       });
 
-      testWidgets('keeps page overlay open after immediate recorder reopen', (
+      testWidgets('keeps page overlay open during same-frame recorder swap', (
         tester,
       ) async {
-        await tester.pumpWidget(buildTestWidget(container: container));
+        await tester.pumpWidget(
+          buildTestWidget(
+            container: container,
+            recorderKey: const ValueKey('first'),
+          ),
+        );
         await tester.pump();
 
         expect(container.read(overlayVisibilityProvider).isPageOpen, isTrue);
 
+        final pageOpenChanges = <bool>[];
+        final subscription = container.listen(
+          overlayVisibilityProvider,
+          (_, next) => pageOpenChanges.add(next.isPageOpen),
+        );
+        addTearDown(subscription.close);
+
         await tester.pumpWidget(
-          UncontrolledProviderScope(
+          buildTestWidget(
             container: container,
-            child: const MaterialApp(
-              localizationsDelegates: AppLocalizations.localizationsDelegates,
-              supportedLocales: AppLocalizations.supportedLocales,
-              home: Scaffold(body: Text('Other screen')),
-            ),
+            recorderKey: const ValueKey('second'),
           ),
         );
-        await tester.pumpWidget(buildTestWidget(container: container));
-        await tester.pump();
 
         expect(find.byType(VideoRecorderView), findsOneWidget);
         expect(container.read(overlayVisibilityProvider).isPageOpen, isTrue);
+        expect(pageOpenChanges, isNot(contains(false)));
       });
     });
 

--- a/mobile/test/screens/video_recorder_screen_test.dart
+++ b/mobile/test/screens/video_recorder_screen_test.dart
@@ -412,7 +412,7 @@ void main() {
           ),
         );
 
-        expect(find.byType(VideoRecorderView), findsOneWidget);
+        expect(find.byKey(const ValueKey('second')), findsOneWidget);
         expect(container.read(overlayVisibilityProvider).isPageOpen, isTrue);
         expect(pageOpenChanges, isNot(contains(false)));
       });

--- a/mobile/test/screens/video_recorder_screen_test.dart
+++ b/mobile/test/screens/video_recorder_screen_test.dart
@@ -19,6 +19,7 @@ import 'package:openvine/models/video_editor/video_editor_provider_state.dart';
 import 'package:openvine/models/video_publish/video_publish_provider_state.dart';
 import 'package:openvine/models/video_recorder/video_recorder_mode.dart';
 import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/overlay_visibility_provider.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
 import 'package:openvine/providers/video_publish_provider.dart';
@@ -56,9 +57,8 @@ class _FakeVideoPublishNotifier extends VideoPublishNotifier {
 
 class _NonAutosaveVideoEditorNotifier extends VideoEditorNotifier {
   @override
-  VideoEditorProviderState build() => VideoEditorProviderState(
-    isAutosavedDraft: false,
-  );
+  VideoEditorProviderState build() =>
+      VideoEditorProviderState(isAutosavedDraft: false);
 }
 
 class _AutosaveVideoEditorNotifier extends VideoEditorNotifier {
@@ -98,26 +98,35 @@ List<Override> _stubStorageOverrides() {
 }
 
 /// Helper to build VideoRecorderView with required providers and the mock bloc.
-Widget buildTestWidget({List<Override> overrides = const []}) {
+Widget buildTestWidget({
+  ProviderContainer? container,
+  List<Override> overrides = const [],
+}) {
+  final child = MultiBlocProvider(
+    providers: [
+      BlocProvider<VideoRecorderBloc>.value(value: recorderBloc),
+      BlocProvider<CameraPermissionBloc>(
+        create: (_) => MockCameraPermissionBloc(),
+      ),
+    ],
+    child: const MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: VideoRecorderView(),
+    ),
+  );
+
+  if (container != null) {
+    return UncontrolledProviderScope(container: container, child: child);
+  }
+
   return ProviderScope(
     overrides: [
       sharedPreferencesProvider.overrideWithValue(testPrefs),
       ..._stubStorageOverrides(),
       ...overrides,
     ],
-    child: MultiBlocProvider(
-      providers: [
-        BlocProvider<VideoRecorderBloc>.value(value: recorderBloc),
-        BlocProvider<CameraPermissionBloc>(
-          create: (_) => MockCameraPermissionBloc(),
-        ),
-      ],
-      child: const MaterialApp(
-        localizationsDelegates: AppLocalizations.localizationsDelegates,
-        supportedLocales: AppLocalizations.supportedLocales,
-        home: VideoRecorderView(),
-      ),
-    ),
+    child: child,
   );
 }
 
@@ -128,42 +137,46 @@ Widget buildTestWidgetWithOverrides(List<Override> overrides) =>
 Widget buildNavigatorTestWidget({
   required bool fromEditor,
   required List<Override> overrides,
+  ProviderContainer? container,
 }) {
-  return ProviderScope(
-    overrides: [
-      ..._stubStorageOverrides(),
-      ...overrides,
-    ],
-    child: MaterialApp(
-      localizationsDelegates: AppLocalizations.localizationsDelegates,
-      supportedLocales: AppLocalizations.supportedLocales,
-      home: Builder(
-        builder: (context) => Scaffold(
-          body: Center(
-            child: ElevatedButton(
-              onPressed: () {
-                Navigator.of(context).push<void>(
-                  MaterialPageRoute<void>(
-                    builder: (_) => MultiBlocProvider(
-                      providers: [
-                        BlocProvider<VideoRecorderBloc>.value(
-                          value: recorderBloc,
-                        ),
-                        BlocProvider<CameraPermissionBloc>(
-                          create: (_) => MockCameraPermissionBloc(),
-                        ),
-                      ],
-                      child: VideoRecorderView(fromEditor: fromEditor),
-                    ),
+  final child = MaterialApp(
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    home: Builder(
+      builder: (context) => Scaffold(
+        body: Center(
+          child: ElevatedButton(
+            onPressed: () {
+              Navigator.of(context).push<void>(
+                MaterialPageRoute<void>(
+                  builder: (_) => MultiBlocProvider(
+                    providers: [
+                      BlocProvider<VideoRecorderBloc>.value(
+                        value: recorderBloc,
+                      ),
+                      BlocProvider<CameraPermissionBloc>(
+                        create: (_) => MockCameraPermissionBloc(),
+                      ),
+                    ],
+                    child: VideoRecorderView(fromEditor: fromEditor),
                   ),
-                );
-              },
-              child: const Text('Open recorder'),
-            ),
+                ),
+              );
+            },
+            child: const Text('Open recorder'),
           ),
         ),
       ),
     ),
+  );
+
+  if (container != null) {
+    return UncontrolledProviderScope(container: container, child: child);
+  }
+
+  return ProviderScope(
+    overrides: [..._stubStorageOverrides(), ...overrides],
+    child: child,
   );
 }
 
@@ -181,9 +194,7 @@ void main() {
 
     setUp(() async {
       recorderBloc = _MockVideoRecorderBloc();
-      when(
-        () => recorderBloc.state,
-      ).thenReturn(
+      when(() => recorderBloc.state).thenReturn(
         const VideoRecorderBlocState(
           isCameraInitialized: true,
           canRecord: true,
@@ -193,7 +204,10 @@ void main() {
       SharedPreferences.setMockInitialValues({});
       testPrefs = await SharedPreferences.getInstance();
       container = ProviderContainer(
-        overrides: [sharedPreferencesProvider.overrideWithValue(testPrefs)],
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(testPrefs),
+          ..._stubStorageOverrides(),
+        ],
       );
     });
 
@@ -341,6 +355,50 @@ void main() {
         // Should have disposed without errors
         expect(find.byType(VideoRecorderView), findsNothing);
       });
+
+      testWidgets('sets page overlay while mounted and clears it after '
+          'dispose', (tester) async {
+        await tester.pumpWidget(buildTestWidget(container: container));
+        await tester.pump();
+
+        expect(container.read(overlayVisibilityProvider).isPageOpen, isTrue);
+
+        await tester.pumpWidget(
+          const MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(body: Text('Other screen')),
+          ),
+        );
+        await tester.pump();
+
+        expect(container.read(overlayVisibilityProvider).isPageOpen, isFalse);
+      });
+
+      testWidgets('keeps page overlay open after immediate recorder reopen', (
+        tester,
+      ) async {
+        await tester.pumpWidget(buildTestWidget(container: container));
+        await tester.pump();
+
+        expect(container.read(overlayVisibilityProvider).isPageOpen, isTrue);
+
+        await tester.pumpWidget(
+          UncontrolledProviderScope(
+            container: container,
+            child: const MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: Scaffold(body: Text('Other screen')),
+            ),
+          ),
+        );
+        await tester.pumpWidget(buildTestWidget(container: container));
+        await tester.pump();
+
+        expect(find.byType(VideoRecorderView), findsOneWidget);
+        expect(container.read(overlayVisibilityProvider).isPageOpen, isTrue);
+      });
     });
 
     group('Screen Layout', () {
@@ -449,12 +507,50 @@ void main() {
         expect(find.text('Home'), findsOneWidget);
       });
 
+      testWidgets('raw Navigator recorder route clears page overlay on pop', (
+        tester,
+      ) async {
+        SharedPreferences.setMockInitialValues({'why_six_seconds_shown': true});
+        final prefs = await SharedPreferences.getInstance();
+        final routeContainer = ProviderContainer(
+          overrides: [
+            sharedPreferencesProvider.overrideWithValue(prefs),
+            ..._stubStorageOverrides(),
+          ],
+        );
+        addTearDown(routeContainer.dispose);
+
+        await tester.pumpWidget(
+          buildNavigatorTestWidget(
+            fromEditor: true,
+            overrides: const [],
+            container: routeContainer,
+          ),
+        );
+
+        await tester.tap(find.text('Open recorder'));
+        await tester.pumpAndSettle();
+
+        expect(find.byType(VideoRecorderView), findsOneWidget);
+        expect(
+          routeContainer.read(overlayVisibilityProvider).isPageOpen,
+          isTrue,
+        );
+
+        Navigator.of(tester.element(find.byType(VideoRecorderView))).pop();
+        await tester.pumpAndSettle();
+        await tester.pump();
+
+        expect(
+          routeContainer.read(overlayVisibilityProvider).isPageOpen,
+          isFalse,
+        );
+      });
+
       testWidgets('clears video publish state when standalone route pops', (
         tester,
       ) async {
-        SharedPreferences.setMockInitialValues({
-          'why_six_seconds_shown': true,
-        });
+        SharedPreferences.setMockInitialValues({'why_six_seconds_shown': true});
         final prefs = await SharedPreferences.getInstance();
         final fakeVideoPublishNotifier = _FakeVideoPublishNotifier();
 
@@ -466,9 +562,7 @@ void main() {
               videoEditorProvider.overrideWith(
                 _NonAutosaveVideoEditorNotifier.new,
               ),
-              videoPublishProvider.overrideWith(
-                () => fakeVideoPublishNotifier,
-              ),
+              videoPublishProvider.overrideWith(() => fakeVideoPublishNotifier),
             ],
           ),
         );
@@ -488,9 +582,7 @@ void main() {
       testWidgets('does not clear video publish state when editor route pops', (
         tester,
       ) async {
-        SharedPreferences.setMockInitialValues({
-          'why_six_seconds_shown': true,
-        });
+        SharedPreferences.setMockInitialValues({'why_six_seconds_shown': true});
         final prefs = await SharedPreferences.getInstance();
         final fakeVideoPublishNotifier = _FakeVideoPublishNotifier();
 
@@ -502,9 +594,7 @@ void main() {
               videoEditorProvider.overrideWith(
                 _NonAutosaveVideoEditorNotifier.new,
               ),
-              videoPublishProvider.overrideWith(
-                () => fakeVideoPublishNotifier,
-              ),
+              videoPublishProvider.overrideWith(() => fakeVideoPublishNotifier),
             ],
           ),
         );
@@ -524,9 +614,7 @@ void main() {
       testWidgets('discards the autosaved session when the route pops', (
         tester,
       ) async {
-        SharedPreferences.setMockInitialValues({
-          'why_six_seconds_shown': true,
-        });
+        SharedPreferences.setMockInitialValues({'why_six_seconds_shown': true});
         final prefs = await SharedPreferences.getInstance();
         final fakeVideoPublishNotifier = _FakeVideoPublishNotifier();
 
@@ -538,9 +626,7 @@ void main() {
               videoEditorProvider.overrideWith(
                 _AutosaveVideoEditorNotifier.new,
               ),
-              videoPublishProvider.overrideWith(
-                () => fakeVideoPublishNotifier,
-              ),
+              videoPublishProvider.overrideWith(() => fakeVideoPublishNotifier),
             ],
           ),
         );
@@ -759,9 +845,7 @@ void main() {
         final prefs = await SharedPreferences.getInstance();
 
         final mockDraftStorage = _MockDraftStorageService();
-        when(
-          mockDraftStorage.getAutosaveDraft,
-        ).thenAnswer((_) async => null);
+        when(mockDraftStorage.getAutosaveDraft).thenAnswer((_) async => null);
 
         final mockClipLibrary = _MockClipLibraryService();
         when(mockClipLibrary.getAllClips).thenAnswer((_) async => []);

--- a/mobile/test/screens/video_recorder_screen_test.dart
+++ b/mobile/test/screens/video_recorder_screen_test.dart
@@ -6,6 +6,7 @@ import 'dart:core';
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -360,9 +361,13 @@ void main() {
       testWidgets('sets page overlay while mounted and clears it after '
           'dispose', (tester) async {
         final pageOpenChanges = <bool>[];
+        final notificationPhases = <SchedulerPhase>[];
         final subscription = container.listen(
           overlayVisibilityProvider,
-          (_, next) => pageOpenChanges.add(next.isPageOpen),
+          (_, next) {
+            pageOpenChanges.add(next.isPageOpen);
+            notificationPhases.add(SchedulerBinding.instance.schedulerPhase);
+          },
         );
         addTearDown(subscription.close);
 
@@ -371,6 +376,7 @@ void main() {
 
         expect(container.read(overlayVisibilityProvider).isPageOpen, isTrue);
         expect(pageOpenChanges, equals([true]));
+        expect(notificationPhases, equals([SchedulerPhase.postFrameCallbacks]));
 
         await tester.pumpWidget(
           const MaterialApp(
@@ -383,6 +389,10 @@ void main() {
 
         expect(container.read(overlayVisibilityProvider).isPageOpen, isFalse);
         expect(pageOpenChanges, equals([true, false]));
+        expect(
+          notificationPhases,
+          everyElement(SchedulerPhase.postFrameCallbacks),
+        );
       });
 
       testWidgets('keeps page overlay open during same-frame recorder swap', (
@@ -415,6 +425,14 @@ void main() {
         expect(find.byKey(const ValueKey('second')), findsOneWidget);
         expect(container.read(overlayVisibilityProvider).isPageOpen, isTrue);
         expect(pageOpenChanges, isNot(contains(false)));
+
+        await tester.pumpWidget(
+          const MaterialApp(home: Scaffold(body: Text('Other screen'))),
+        );
+        await tester.pump();
+
+        expect(container.read(overlayVisibilityProvider).isPageOpen, isFalse);
+        expect(pageOpenChanges, equals([false]));
       });
     });
 
@@ -570,6 +588,65 @@ void main() {
           isFalse,
         );
         expect(pageOpenChanges, equals([true, false]));
+      });
+
+      testWidgets('closing a nested recorder keeps the underlying owner open', (
+        tester,
+      ) async {
+        SharedPreferences.setMockInitialValues({'why_six_seconds_shown': true});
+        final prefs = await SharedPreferences.getInstance();
+        final routeContainer = ProviderContainer(
+          overrides: [
+            sharedPreferencesProvider.overrideWithValue(prefs),
+            ..._stubStorageOverrides(),
+          ],
+        );
+        addTearDown(routeContainer.dispose);
+
+        await tester.pumpWidget(
+          buildNavigatorTestWidget(
+            fromEditor: false,
+            overrides: const [],
+            container: routeContainer,
+          ),
+        );
+        await tester.tap(find.text('Open recorder'));
+        await tester.pumpAndSettle();
+
+        final firstRecorder = find.byType(VideoRecorderView);
+        Navigator.of(tester.element(firstRecorder)).push<void>(
+          MaterialPageRoute<void>(
+            builder: (_) => MultiBlocProvider(
+              providers: [
+                BlocProvider<VideoRecorderBloc>.value(value: recorderBloc),
+                BlocProvider<CameraPermissionBloc>(
+                  create: (_) => MockCameraPermissionBloc(),
+                ),
+              ],
+              child: const VideoRecorderView(
+                key: ValueKey('nested-recorder'),
+                fromEditor: true,
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(
+          routeContainer.read(overlayVisibilityProvider).isPageOpen,
+          isTrue,
+        );
+
+        Navigator.of(
+          tester.element(find.byKey(const ValueKey('nested-recorder'))),
+        ).pop();
+        await tester.pumpAndSettle();
+
+        expect(find.byType(VideoRecorderView), findsOneWidget);
+        expect(
+          routeContainer.read(overlayVisibilityProvider).isPageOpen,
+          isTrue,
+        );
       });
 
       testWidgets('clears video publish state when standalone route pops', (


### PR DESCRIPTION
## Summary
- move recorder overlay visibility open writes out of initState into the existing post-frame startup path
- track page-overlay ownership per recorder so nested and same-frame recorder lifecycles cannot clear one another
- preserve AppShell's stranded-overlay recovery without clearing live owners when a fresh shell mounts
- add lifecycle coverage for mount/unmount, same-frame replacement, nested recorders, raw Navigator push/pop, and shell recovery
- follow-up: #7489 tracks migrating the remaining pause-aware page overlay helpers to owner tokens

Closes #7390

## Verification
- flutter test test/providers/overlay_visibility_provider_test.dart test/router/app_shell_obscured_test.dart test/screens/video_recorder_screen_test.dart
- flutter analyze lib test integration_test
- pre-push hook: analyzer, generated-file verification, and all changed-file tests
