### PR TITLE
fix(editor): keep playback gated during clip reload

### DIFF
--- a/mobile/lib/screens/video_metadata/video_metadata_preview_screen.dart
+++ b/mobile/lib/screens/video_metadata/video_metadata_preview_screen.dart
@@ -20,6 +20,7 @@ import 'package:openvine/widgets/video_feed_item/video_feed_item.dart';
 import 'package:openvine/widgets/video_metadata/metadata_hero_corners.dart';
 import 'package:openvine/widgets/video_metadata/modes/capture/video_metadata_capture_bottom_bar.dart';
 import 'package:openvine/widgets/video_metadata/modes/capture/video_metadata_capture_preview_thumbnail.dart';
+import 'package:unified_logger/unified_logger.dart';
 
 /// Full-screen preview of the recorded video with metadata overlay.
 ///
@@ -90,15 +91,41 @@ class _VideoMetadataPreviewScreenState
     final video = widget.clip.video;
     if (video == null) return;
 
-    _controller = DivineVideoPlayerController(useTexture: true);
-    if (mounted) await _controller!.initialize();
-    if (mounted) {
-      await _controller!.setSource(VideoClip.file(await video.safeFilePath()));
+    final controller = DivineVideoPlayerController(useTexture: true);
+    try {
+      await controller.initialize();
+      if (!mounted) {
+        await controller.dispose();
+        return;
+      }
+      await controller.setSource(VideoClip.file(await video.safeFilePath()));
+      if (!mounted) {
+        await controller.dispose();
+        return;
+      }
+      await controller.setLooping(looping: true);
+      if (!mounted) {
+        await controller.dispose();
+        return;
+      }
+      await controller.play();
+      if (!mounted) {
+        await controller.dispose();
+        return;
+      }
+      _controller = controller;
+      // Rebuild so DivineVideoPlayer receives the now-initialized controller.
+      setState(() {});
+    } catch (e, stackTrace) {
+      Log.error(
+        'Metadata preview player failed to load',
+        name: 'VideoMetadataPreviewScreen',
+        category: LogCategory.video,
+        error: e,
+        stackTrace: stackTrace,
+      );
+      unawaited(controller.dispose());
     }
-    if (mounted) await _controller!.setLooping(looping: true);
-    if (mounted) await _controller!.play();
-    // Rebuild so DivineVideoPlayer receives the now-initialized controller.
-    if (mounted) setState(() {});
   }
 
   @override

--- a/mobile/lib/widgets/video_clip/video_clip_preview.dart
+++ b/mobile/lib/widgets/video_clip/video_clip_preview.dart
@@ -74,16 +74,43 @@ class _VideoClipPreviewSheetState extends ConsumerState<VideoClipPreview> {
       return;
     }
 
-    if (mounted) _controller = DivineVideoPlayerController(useTexture: true);
-    if (mounted) await _controller!.initialize();
-    if (mounted) await _controller!.setSource(VideoClip.file(file.path));
-    if (mounted) await _controller!.setLooping(looping: true);
-    if (mounted) await _controller!.play();
-
-    if (!mounted) return;
+    final controller = DivineVideoPlayerController(useTexture: true);
+    try {
+      await controller.initialize();
+      if (!mounted) {
+        await controller.dispose();
+        return;
+      }
+      await controller.setSource(VideoClip.file(file.path));
+      if (!mounted) {
+        await controller.dispose();
+        return;
+      }
+      await controller.setLooping(looping: true);
+      if (!mounted) {
+        await controller.dispose();
+        return;
+      }
+      await controller.play();
+      if (!mounted) {
+        await controller.dispose();
+        return;
+      }
+    } catch (e, stackTrace) {
+      Log.error(
+        'Clip preview player failed to load',
+        name: 'VideoClipPreview',
+        category: LogCategory.video,
+        error: e,
+        stackTrace: stackTrace,
+      );
+      unawaited(controller.dispose());
+      return;
+    }
 
     // Rebuild once video dimensions become available.
-    _stateSubscription = _controller!.stateStream.listen((state) {
+    _controller = controller;
+    _stateSubscription = controller.stateStream.listen((state) {
       if (mounted && state.videoWidth > 0 && !_hasDimensions) {
         _hasDimensions = true;
         setState(() {});

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
@@ -33,7 +33,6 @@ import 'package:openvine/models/video_editor/transition_geometry.dart';
 import 'package:openvine/providers/clip_manager_provider.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
 import 'package:openvine/screens/video_metadata/video_metadata_screen.dart';
-import 'package:openvine/services/crash_reporting_service.dart';
 import 'package:openvine/services/haptic_service.dart';
 import 'package:openvine/services/video_editor/clip_speed_render_service.dart';
 import 'package:openvine/services/video_editor/stop_motion_audio_preview.dart';
@@ -199,11 +198,8 @@ class VideoEditorCanvas extends StatelessWidget {
   /// failures can mark the player unavailable instead of leaving a broken
   /// native player reported as ready.
   ///
-  /// Swallowing costs the unhandled-async-error path to Crashlytics that #3410
-  /// relied on, and `Log.error` has no Crashlytics sink — so `PLAYER_ERROR` is
-  /// reported explicitly. A decoder that dies mid-edit is a real defect worth a
-  /// non-fatal; `COMPOSITION_ERROR` (stale draft clip) and `NOT_READY` (slow
-  /// OEM decoder) are expected domain failures and stay log-only.
+  /// `PLAYER_ERROR` is left log-only here because this helper lives in the UI
+  /// layer; reportability decisions belong to BLoC/Cubit or service code.
   @visibleForTesting
   static Future<bool> guardClipLoad(Future<void> Function() load) async {
     try {
@@ -222,18 +218,15 @@ class VideoEditorCanvas extends StatelessWidget {
         error: e,
         stackTrace: s,
       );
-      if (e.code == _playerErrorCode) {
-        unawaited(
-          CrashReportingService.instance.recordError(
-            e,
-            s,
-            reason: 'VideoEditorCanvas.guardClipLoad',
-          ),
-        );
-      }
       return false;
     }
   }
+
+  @visibleForTesting
+  static bool shouldPublishClipLoad({
+    required int generation,
+    required int currentGeneration,
+  }) => generation == currentGeneration;
 
   /// Decides how to reconcile the clip [snapshot] read from the editor's
   /// current undo/redo history entry with the app clip state.
@@ -897,7 +890,12 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
   /// Publishes the outcome of the clip load that claimed [generation], unless a
   /// newer load has superseded it.
   void _endClipLoad(int generation, {required bool isReady}) {
-    if (generation != _clipLoadGeneration) return;
+    if (!VideoEditorCanvas.shouldPublishClipLoad(
+      generation: generation,
+      currentGeneration: _clipLoadGeneration,
+    )) {
+      return;
+    }
     _setPlayerReady(isReady);
   }
 
@@ -1372,11 +1370,9 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
     _pendingSeekTarget = currentPosition;
     final generation = _beginClipLoad();
     unawaited(
-      _setClipsSafely(_videoPlayer, [
+      _setClipsForGeneration(generation, _videoPlayer, [
         ..._buildPlayerClips(clips),
-      ], startPosition: _timelineToPlayer(currentPosition)).then(
-        (loaded) => _endClipLoad(generation, isReady: loaded),
-      ),
+      ], startPosition: _timelineToPlayer(currentPosition)),
     );
     _ensureSeamsRendered(clips);
     _ensureSpeedClipsRendered(clips);
@@ -1455,6 +1451,26 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
     );
   }
 
+  Future<bool> _setClipsForGeneration(
+    int generation,
+    DivineVideoPlayerController? player,
+    List<VideoClip> clips, {
+    Duration? startPosition,
+  }) async {
+    try {
+      final loaded = await _setClipsSafely(
+        player,
+        clips,
+        startPosition: startPosition,
+      );
+      _endClipLoad(generation, isReady: loaded);
+      return loaded;
+    } catch (_) {
+      _endClipLoad(generation, isReady: false);
+      rethrow;
+    }
+  }
+
   /// Initializes (or reinitializes) the native video player with [clipPaths].
   Future<void> _initializePlayer(
     List<String> clipPaths, {
@@ -1482,15 +1498,21 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
 
     await player.initialize();
     if (!mounted || !identical(_videoPlayer, player)) return;
-    final loaded = await _setClipsSafely(
-      player,
-      [
-        ..._buildPlayerClips(clips),
-      ],
-      startPosition: startPosition != null && startPosition > Duration.zero
-          ? _timelineToPlayer(startPosition)
-          : null,
-    );
+    late final bool loaded;
+    try {
+      loaded = await _setClipsSafely(
+        player,
+        [
+          ..._buildPlayerClips(clips),
+        ],
+        startPosition: startPosition != null && startPosition > Duration.zero
+            ? _timelineToPlayer(startPosition)
+            : null,
+      );
+    } catch (_) {
+      _endClipLoad(generation, isReady: false);
+      rethrow;
+    }
     if (!mounted || !identical(_videoPlayer, player)) return;
     // Composition failed to build (stale/corrupt draft clip): leave the canvas
     // on its thumbnail fallback rather than marking a broken player ready.
@@ -2087,10 +2109,13 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
         _pendingSeekTarget = currentPosition;
         final generation = _beginClipLoad();
         unawaited(
-          _setClipsSafely(_videoPlayer, [
-            ..._buildPlayerClips(clips),
-          ], startPosition: _timelineToPlayer(currentPosition)).then(
-            (loaded) => _endClipLoad(generation, isReady: loaded),
+          _setClipsForGeneration(
+            generation,
+            _videoPlayer,
+            [
+              ..._buildPlayerClips(clips),
+            ],
+            startPosition: _timelineToPlayer(currentPosition),
           ),
         );
         _ensureSeamsRendered(clips);
@@ -2118,10 +2143,13 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
         _pendingSeekTarget = currentPosition;
         final generation = _beginClipLoad();
         unawaited(
-          _setClipsSafely(_videoPlayer, [
-            ..._buildPlayerClips(clips),
-          ], startPosition: _timelineToPlayer(currentPosition)).then(
-            (loaded) => _endClipLoad(generation, isReady: loaded),
+          _setClipsForGeneration(
+            generation,
+            _videoPlayer,
+            [
+              ..._buildPlayerClips(clips),
+            ],
+            startPosition: _timelineToPlayer(currentPosition),
           ),
         );
         _ensureSeamsRendered(clips);
@@ -2377,10 +2405,14 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
             final ownerEpoch = _seekEpoch;
 
             try {
-              final loaded = await _setClipsSafely(_videoPlayer, [
-                ..._buildPlayerClips(state.clips),
-              ], startPosition: _timelineToPlayer(currentPosition));
-              _endClipLoad(generation, isReady: loaded);
+              final loaded = await _setClipsForGeneration(
+                generation,
+                _videoPlayer,
+                [
+                  ..._buildPlayerClips(state.clips),
+                ],
+                startPosition: _timelineToPlayer(currentPosition),
+              );
               if (!loaded) return;
 
               if (!mounted) return;
@@ -2434,10 +2466,14 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
             final ownerEpoch = _seekEpoch;
 
             try {
-              final loaded = await _setClipsSafely(_videoPlayer, [
-                ..._buildPlayerClips(state.clips),
-              ], startPosition: _timelineToPlayer(startPosition));
-              _endClipLoad(generation, isReady: loaded);
+              final loaded = await _setClipsForGeneration(
+                generation,
+                _videoPlayer,
+                [
+                  ..._buildPlayerClips(state.clips),
+                ],
+                startPosition: _timelineToPlayer(startPosition),
+              );
               if (!loaded) return;
               if (mounted) {
                 VideoEditorCanvas.syncPositionAfterTrimRelease(

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
@@ -197,6 +197,7 @@ class VideoEditorCanvas extends StatelessWidget {
   /// `NOT_READY` and `PLAYER_ERROR` are also swallowed so trim-triggered reload
   /// failures can mark the player unavailable instead of leaving a broken
   /// native player reported as ready.
+
   @visibleForTesting
   static Future<bool> guardClipLoad(Future<void> Function() load) async {
     try {
@@ -397,6 +398,10 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
   ValueNotifier<Duration>? _playTimeNotifier;
 
   final _isPlayerReadyNotifier = ValueNotifier<bool>(false);
+
+  /// Claimed by [_beginClipLoad] so a superseded `setClips` cannot publish its
+  /// stale readiness in [_endClipLoad].
+  int _clipLoadGeneration = 0;
   DivineVideoPlayerController? _videoPlayer;
   StreamSubscription<DivineVideoPlayerState>? _videoPlayerSubscription;
 
@@ -862,6 +867,25 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
     );
   }
 
+  /// Marks the player unusable and claims the clip-load generation this reload
+  /// owns.
+  ///
+  /// The native side answers a superseded `setClips` with `CANCELLED`, which
+  /// [DivineVideoPlayerController.setClips] resolves as success — so without a
+  /// generation the *older* load reports ready while the newer one is still
+  /// buffering, re-opening the exact window this gating closes.
+  int _beginClipLoad() {
+    _setPlayerReady(false);
+    return ++_clipLoadGeneration;
+  }
+
+  /// Publishes the outcome of the clip load that claimed [generation], unless a
+  /// newer load has superseded it.
+  void _endClipLoad(int generation, {required bool isReady}) {
+    if (generation != _clipLoadGeneration) return;
+    _setPlayerReady(isReady);
+  }
+
   bool _canUseVideoPlayerForUserAction(String action) {
     if (!_isPlayerReadyNotifier.value) {
       Log.debug(
@@ -1316,10 +1340,10 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
 
     if (clipPaths.isEmpty) {
       _videoPlayer?.pause();
-      _isPlayerReadyNotifier.value = false;
-      context.read<VideoEditorMainBloc>()
-        ..add(const VideoEditorPlaybackChanged(isPlaying: false))
-        ..add(const VideoEditorPlayerReady(isReady: false));
+      _beginClipLoad();
+      context.read<VideoEditorMainBloc>().add(
+        const VideoEditorPlaybackChanged(isPlaying: false),
+      );
       return;
     }
 
@@ -1331,10 +1355,13 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
     // Pin so a reset report from loading the (seam-aware) composition doesn't
     // snap the playhead back while paused.
     _pendingSeekTarget = currentPosition;
+    final generation = _beginClipLoad();
     unawaited(
       _setClipsSafely(_videoPlayer, [
         ..._buildPlayerClips(clips),
-      ], startPosition: _timelineToPlayer(currentPosition)),
+      ], startPosition: _timelineToPlayer(currentPosition)).then(
+        (loaded) => _endClipLoad(generation, isReady: loaded),
+      ),
     );
     _ensureSeamsRendered(clips);
     _ensureSpeedClipsRendered(clips);
@@ -1421,7 +1448,7 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
     // Dispose old player if it exists.
     await _videoPlayerSubscription?.cancel();
     await _videoPlayer?.dispose();
-    _setPlayerReady(false);
+    final generation = _beginClipLoad();
 
     final clips = ref.read(clipManagerProvider).clips;
 
@@ -1453,7 +1480,7 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
     // Composition failed to build (stale/corrupt draft clip): leave the canvas
     // on its thumbnail fallback rather than marking a broken player ready.
     if (!loaded) {
-      _setPlayerReady(false);
+      _endClipLoad(generation, isReady: false);
       return;
     }
 
@@ -1463,7 +1490,7 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
     await player.setLooping(looping: true);
     if (!mounted || !identical(_videoPlayer, player)) return;
 
-    _setPlayerReady(true);
+    _endClipLoad(generation, isReady: true);
 
     // Setup state stream listener
     _videoPlayerSubscription = player.stateStream.listen(_onPlayerStateChanged);
@@ -1498,8 +1525,10 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
     // notifier/ticker); only touch them while still mounted.
     if (mounted) {
       _setPlayheadTickerActive(false);
-      _isPlayerReadyNotifier.value = false;
     }
+    // Also invalidates any in-flight load, so a `setClips` that resolves after
+    // the release cannot re-enable the play button for a disposed player.
+    _beginClipLoad();
     await player.dispose();
   }
 
@@ -2041,12 +2070,12 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
         // Pin so a reset report from loading the seam-aware composition
         // doesn't snap the playhead back while paused.
         _pendingSeekTarget = currentPosition;
-        _setPlayerReady(false);
+        final generation = _beginClipLoad();
         unawaited(
           _setClipsSafely(_videoPlayer, [
             ..._buildPlayerClips(clips),
           ], startPosition: _timelineToPlayer(currentPosition)).then(
-            _setPlayerReady,
+            (loaded) => _endClipLoad(generation, isReady: loaded),
           ),
         );
         _ensureSeamsRendered(clips);
@@ -2072,12 +2101,12 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
         // Pin so a reset report from loading the seam-aware composition
         // doesn't snap the playhead back while paused.
         _pendingSeekTarget = currentPosition;
-        _setPlayerReady(false);
+        final generation = _beginClipLoad();
         unawaited(
           _setClipsSafely(_videoPlayer, [
             ..._buildPlayerClips(clips),
           ], startPosition: _timelineToPlayer(currentPosition)).then(
-            _setPlayerReady,
+            (loaded) => _endClipLoad(generation, isReady: loaded),
           ),
         );
         _ensureSeamsRendered(clips);
@@ -2328,7 +2357,7 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
 
             _seekEpoch++;
             _pendingSeekPosition = null;
-            _setPlayerReady(false);
+            final generation = _beginClipLoad();
             _isSeeking = true;
             final ownerEpoch = _seekEpoch;
 
@@ -2336,13 +2365,10 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
               final loaded = await _setClipsSafely(_videoPlayer, [
                 ..._buildPlayerClips(state.clips),
               ], startPosition: _timelineToPlayer(currentPosition));
-              if (!loaded) {
-                _setPlayerReady(false);
-                return;
-              }
+              _endClipLoad(generation, isReady: loaded);
+              if (!loaded) return;
 
               if (!mounted) return;
-              _setPlayerReady(true);
               _lastReportedPosition = currentPosition;
               _pendingSeekTarget = currentPosition;
               _setLayerPlayTime(currentPosition);
@@ -2386,7 +2412,7 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
             // Composition swap back — invalidate in-flight single-clip seeks.
             _seekEpoch++;
             _pendingSeekPosition = null;
-            _setPlayerReady(false);
+            final generation = _beginClipLoad();
             // Claim _isSeeking under the new epoch; try/finally ensures
             // release even if setClips throws.
             _isSeeking = true;
@@ -2396,11 +2422,8 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
               final loaded = await _setClipsSafely(_videoPlayer, [
                 ..._buildPlayerClips(state.clips),
               ], startPosition: _timelineToPlayer(startPosition));
-              if (!loaded) {
-                _setPlayerReady(false);
-                return;
-              }
-              _setPlayerReady(true);
+              _endClipLoad(generation, isReady: loaded);
+              if (!loaded) return;
               if (mounted) {
                 VideoEditorCanvas.syncPositionAfterTrimRelease(
                   mainBloc: bloc,

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
@@ -33,6 +33,7 @@ import 'package:openvine/models/video_editor/transition_geometry.dart';
 import 'package:openvine/providers/clip_manager_provider.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
 import 'package:openvine/screens/video_metadata/video_metadata_screen.dart';
+import 'package:openvine/services/crash_reporting_service.dart';
 import 'package:openvine/services/haptic_service.dart';
 import 'package:openvine/services/video_editor/clip_speed_render_service.dart';
 import 'package:openvine/services/video_editor/stop_motion_audio_preview.dart';
@@ -197,7 +198,12 @@ class VideoEditorCanvas extends StatelessWidget {
   /// `NOT_READY` and `PLAYER_ERROR` are also swallowed so trim-triggered reload
   /// failures can mark the player unavailable instead of leaving a broken
   /// native player reported as ready.
-
+  ///
+  /// Swallowing costs the unhandled-async-error path to Crashlytics that #3410
+  /// relied on, and `Log.error` has no Crashlytics sink — so `PLAYER_ERROR` is
+  /// reported explicitly. A decoder that dies mid-edit is a real defect worth a
+  /// non-fatal; `COMPOSITION_ERROR` (stale draft clip) and `NOT_READY` (slow
+  /// OEM decoder) are expected domain failures and stay log-only.
   @visibleForTesting
   static Future<bool> guardClipLoad(Future<void> Function() load) async {
     try {
@@ -216,6 +222,15 @@ class VideoEditorCanvas extends StatelessWidget {
         error: e,
         stackTrace: s,
       );
+      if (e.code == _playerErrorCode) {
+        unawaited(
+          CrashReportingService.instance.recordError(
+            e,
+            s,
+            reason: 'VideoEditorCanvas.guardClipLoad',
+          ),
+        );
+      }
       return false;
     }
   }

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
@@ -179,6 +179,8 @@ class VideoEditorCanvas extends StatelessWidget {
   }
 
   static const _compositionErrorCode = 'COMPOSITION_ERROR';
+  static const _notReadyErrorCode = 'NOT_READY';
+  static const _playerErrorCode = 'PLAYER_ERROR';
 
   /// Runs a `setClips` [load], swallowing the native unbuildable-composition
   /// rejection.
@@ -192,19 +194,22 @@ class VideoEditorCanvas extends StatelessWidget {
   /// letting the rejection escape as an unhandled async error and surface as a
   /// Crashlytics non-fatal (#3410).
   ///
-  /// Only `COMPOSITION_ERROR` is swallowed; any other error (e.g. a
-  /// `PLAYER_ERROR`, `INVALID_ARGS`, or a `StateError` from a broken invariant)
-  /// is rethrown so it still reaches Crashlytics rather than being silently
-  /// hidden.
+  /// `NOT_READY` and `PLAYER_ERROR` are also swallowed so trim-triggered reload
+  /// failures can mark the player unavailable instead of leaving a broken
+  /// native player reported as ready.
   @visibleForTesting
   static Future<bool> guardClipLoad(Future<void> Function() load) async {
     try {
       await load();
       return true;
     } on PlatformException catch (e, s) {
-      if (e.code != _compositionErrorCode) rethrow;
+      if (e.code != _compositionErrorCode &&
+          e.code != _notReadyErrorCode &&
+          e.code != _playerErrorCode) {
+        rethrow;
+      }
       Log.error(
-        'setClips failed with $_compositionErrorCode: $e',
+        'setClips failed with ${e.code}: $e',
         name: 'VideoEditorCanvas',
         category: LogCategory.video,
         error: e,
@@ -849,13 +854,41 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
       .whereType<String>()
       .toList();
 
+  void _setPlayerReady(bool isReady) {
+    if (!mounted) return;
+    _isPlayerReadyNotifier.value = isReady;
+    context.read<VideoEditorMainBloc>().add(
+      VideoEditorPlayerReady(isReady: isReady),
+    );
+  }
+
+  bool _canUseVideoPlayerForUserAction(String action) {
+    if (!_isPlayerReadyNotifier.value) {
+      Log.debug(
+        'Ignoring $action: player is not ready',
+        name: 'VideoEditorCanvas',
+        category: LogCategory.video,
+      );
+      return false;
+    }
+    if (!_isPlayerInitialized) {
+      Log.debug(
+        'Ignoring $action: player is not initialized',
+        name: 'VideoEditorCanvas',
+        category: LogCategory.video,
+      );
+      return false;
+    }
+    return true;
+  }
+
   /// Handles playback restart requests from BLoC.
   void _onPlaybackRestartRequested() {
     if (_isStopMotionComposition) {
       _playStopMotion(from: Duration.zero);
       return;
     }
-    if (!_isPlayerReadyNotifier.value || !_isPlayerInitialized) return;
+    if (!_canUseVideoPlayerForUserAction('playback restart')) return;
 
     // Stop the interpolator on the user action so it can't advance the play
     // time from the stale anchor before the next native report re-anchors it;
@@ -876,7 +909,7 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
       _toggleStopMotionPlayback();
       return;
     }
-    if (!_isPlayerReadyNotifier.value || !_isPlayerInitialized) return;
+    if (!_canUseVideoPlayerForUserAction('playback toggle')) return;
 
     final isPlaying = _videoPlayer?.state.isPlaying ?? false;
     if (isPlaying) {
@@ -905,7 +938,7 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
       }
       return;
     }
-    if (!_isPlayerReadyNotifier.value || !_isPlayerInitialized) return;
+    if (!_canUseVideoPlayerForUserAction('external pause change')) return;
 
     if (isPaused) {
       // Stop the interpolator on pause so it doesn't keep advancing the play
@@ -1388,7 +1421,7 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
     // Dispose old player if it exists.
     await _videoPlayerSubscription?.cancel();
     await _videoPlayer?.dispose();
-    if (mounted) _isPlayerReadyNotifier.value = false;
+    _setPlayerReady(false);
 
     final clips = ref.read(clipManagerProvider).clips;
 
@@ -1419,7 +1452,10 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
     if (!mounted || !identical(_videoPlayer, player)) return;
     // Composition failed to build (stale/corrupt draft clip): leave the canvas
     // on its thumbnail fallback rather than marking a broken player ready.
-    if (!loaded) return;
+    if (!loaded) {
+      _setPlayerReady(false);
+      return;
+    }
 
     if (clips.isEmpty) return;
     _ensureSeamsRendered(clips);
@@ -1427,10 +1463,7 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
     await player.setLooping(looping: true);
     if (!mounted || !identical(_videoPlayer, player)) return;
 
-    _isPlayerReadyNotifier.value = true;
-
-    // Notify BLoC that player is ready
-    context.read<VideoEditorMainBloc>().add(const VideoEditorPlayerReady());
+    _setPlayerReady(true);
 
     // Setup state stream listener
     _videoPlayerSubscription = player.stateStream.listen(_onPlayerStateChanged);
@@ -2008,10 +2041,13 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
         // Pin so a reset report from loading the seam-aware composition
         // doesn't snap the playhead back while paused.
         _pendingSeekTarget = currentPosition;
+        _setPlayerReady(false);
         unawaited(
           _setClipsSafely(_videoPlayer, [
             ..._buildPlayerClips(clips),
-          ], startPosition: _timelineToPlayer(currentPosition)),
+          ], startPosition: _timelineToPlayer(currentPosition)).then(
+            _setPlayerReady,
+          ),
         );
         _ensureSeamsRendered(clips);
         _ensureSpeedClipsRendered(clips);
@@ -2036,10 +2072,13 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
         // Pin so a reset report from loading the seam-aware composition
         // doesn't snap the playhead back while paused.
         _pendingSeekTarget = currentPosition;
+        _setPlayerReady(false);
         unawaited(
           _setClipsSafely(_videoPlayer, [
             ..._buildPlayerClips(clips),
-          ], startPosition: _timelineToPlayer(currentPosition)),
+          ], startPosition: _timelineToPlayer(currentPosition)).then(
+            _setPlayerReady,
+          ),
         );
         _ensureSeamsRendered(clips);
         _ensureSpeedClipsRendered(clips);
@@ -2289,6 +2328,7 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
 
             _seekEpoch++;
             _pendingSeekPosition = null;
+            _setPlayerReady(false);
             _isSeeking = true;
             final ownerEpoch = _seekEpoch;
 
@@ -2296,9 +2336,13 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
               final loaded = await _setClipsSafely(_videoPlayer, [
                 ..._buildPlayerClips(state.clips),
               ], startPosition: _timelineToPlayer(currentPosition));
-              if (!loaded) return;
+              if (!loaded) {
+                _setPlayerReady(false);
+                return;
+              }
 
               if (!mounted) return;
+              _setPlayerReady(true);
               _lastReportedPosition = currentPosition;
               _pendingSeekTarget = currentPosition;
               _setLayerPlayTime(currentPosition);
@@ -2342,6 +2386,7 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
             // Composition swap back — invalidate in-flight single-clip seeks.
             _seekEpoch++;
             _pendingSeekPosition = null;
+            _setPlayerReady(false);
             // Claim _isSeeking under the new epoch; try/finally ensures
             // release even if setClips throws.
             _isSeeking = true;
@@ -2351,7 +2396,11 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
               final loaded = await _setClipsSafely(_videoPlayer, [
                 ..._buildPlayerClips(state.clips),
               ], startPosition: _timelineToPlayer(startPosition));
-              if (!loaded) return;
+              if (!loaded) {
+                _setPlayerReady(false);
+                return;
+              }
+              _setPlayerReady(true);
               if (mounted) {
                 VideoEditorCanvas.syncPositionAfterTrimRelease(
                   mainBloc: bloc,

--- a/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_header.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_header.dart
@@ -6,6 +6,7 @@ import 'package:openvine/blocs/video_editor/main_editor/video_editor_main_bloc.d
 import 'package:openvine/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart';
 import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/models/stop_motion/stop_motion_frame_ops.dart';
 import 'package:openvine/models/video_editor/transition_geometry.dart';
 import 'package:openvine/widgets/video_editor/main_editor/video_editor_scope.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/video_editor_volume_mute_toggle.dart';
@@ -76,6 +77,15 @@ class _PlayPauseButton extends StatelessWidget {
     final isPlayerReady = context.select(
       (VideoEditorMainBloc b) => b.state.isPlayerReady,
     );
+    // A frames-only stop-motion composition has no mp4, so the canvas never
+    // creates a native player and `isPlayerReady` stays false forever. Its
+    // playback runs off the canvas's own ticker, which the toggle handler
+    // branches to before any readiness check — so the button must not wait on
+    // a player that will never exist.
+    final isStopMotion = context.select(
+      (ClipEditorBloc b) => isStopMotionComposition(b.state.clips),
+    );
+    final canTogglePlayback = isPlayerReady || isStopMotion;
 
     return DivineIconButton(
       icon: isPlaying ? .pauseFill : .playFill,
@@ -84,7 +94,7 @@ class _PlayPauseButton extends StatelessWidget {
       semanticLabel: isPlaying
           ? context.l10n.videoEditorPauseSemanticLabel
           : context.l10n.videoEditorPlaySemanticLabel,
-      onPressed: isPlayerReady
+      onPressed: canTogglePlayback
           ? () => context.read<VideoEditorMainBloc>().add(
               const VideoEditorPlaybackToggleRequested(),
             )

--- a/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_header.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_header.dart
@@ -73,6 +73,9 @@ class _PlayPauseButton extends StatelessWidget {
     final isPlaying = context.select(
       (VideoEditorMainBloc b) => b.state.isPlaying,
     );
+    final isPlayerReady = context.select(
+      (VideoEditorMainBloc b) => b.state.isPlayerReady,
+    );
 
     return DivineIconButton(
       icon: isPlaying ? .pauseFill : .playFill,
@@ -81,9 +84,11 @@ class _PlayPauseButton extends StatelessWidget {
       semanticLabel: isPlaying
           ? context.l10n.videoEditorPauseSemanticLabel
           : context.l10n.videoEditorPlaySemanticLabel,
-      onPressed: () => context.read<VideoEditorMainBloc>().add(
-        const VideoEditorPlaybackToggleRequested(),
-      ),
+      onPressed: isPlayerReady
+          ? () => context.read<VideoEditorMainBloc>().add(
+              const VideoEditorPlaybackToggleRequested(),
+            )
+          : null,
     );
   }
 }

--- a/mobile/lib/widgets/video_metadata/modes/classic/video_metadata_classic_preview_thumbnail.dart
+++ b/mobile/lib/widgets/video_metadata/modes/classic/video_metadata_classic_preview_thumbnail.dart
@@ -8,6 +8,7 @@ import 'package:openvine/providers/clip_manager_provider.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
 import 'package:openvine/widgets/video_clip/clip_thumbnail_image.dart';
 import 'package:openvine/widgets/video_editor/video_editor_processing_overlay.dart';
+import 'package:unified_logger/unified_logger.dart';
 
 class VideoMetadataClassicPreviewThumbnail extends ConsumerStatefulWidget {
   const VideoMetadataClassicPreviewThumbnail({super.key});
@@ -78,10 +79,34 @@ class _VideoMetadataClassicPreviewThumbnailState
     if (_controller != null) return;
 
     final controller = DivineVideoPlayerController(useTexture: true);
-    await controller.initialize();
-    if (mounted) await controller.setSource(VideoClip.file(filePath));
-    if (mounted) await controller.setLooping(looping: true);
-    if (mounted) await controller.play();
+    try {
+      await controller.initialize();
+      if (!mounted) {
+        await controller.dispose();
+        return;
+      }
+      await controller.setSource(VideoClip.file(filePath));
+      if (!mounted) {
+        await controller.dispose();
+        return;
+      }
+      await controller.setLooping(looping: true);
+      if (!mounted) {
+        await controller.dispose();
+        return;
+      }
+      await controller.play();
+    } catch (e, stackTrace) {
+      Log.error(
+        'Classic metadata preview player failed to load',
+        name: 'VideoMetadataClassicPreviewThumbnail',
+        category: LogCategory.video,
+        error: e,
+        stackTrace: stackTrace,
+      );
+      unawaited(controller.dispose());
+      return;
+    }
     if (!mounted) return;
 
     setState(() {

--- a/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
+++ b/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
@@ -252,7 +252,11 @@ internal class DivineVideoPlayerInstance(
                 name = "DivineVideoPlayer.Freeze",
             )
         }
-        pendingSetClipsResult?.success(null)
+        pendingSetClipsResult?.error(
+            "NOT_READY",
+            "setClips timed out before player reached STATE_READY",
+            null,
+        )
         pendingSetClipsResult = null
     }
 

--- a/mobile/packages/divine_video_player/android/src/test/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstanceTest.kt
+++ b/mobile/packages/divine_video_player/android/src/test/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstanceTest.kt
@@ -447,6 +447,29 @@ class DivineVideoPlayerInstanceTest {
     }
 
     @Test
+    fun `setClips timeout completes pending result with NOT_READY error`() {
+        capturePlayerListener()
+        val result = mockk<MethodChannel.Result>(relaxed = true)
+        val scheduled = slot<Runnable>()
+        every {
+            mockHandler.postDelayed(capture(scheduled), 10_000L)
+        } returns true
+
+        instance.onMethodCall(setClipsCall(), result)
+
+        scheduled.captured.run()
+
+        verify(exactly = 1) {
+            result.error(
+                "NOT_READY",
+                "setClips timed out before player reached STATE_READY",
+                null,
+            )
+        }
+        verify(exactly = 0) { result.success(any()) }
+    }
+
+    @Test
     fun `onPlayerError completes pending setClips result with error`() {
         val listener = capturePlayerListener()
         val result = mockk<MethodChannel.Result>(relaxed = true)

--- a/mobile/packages/infinite_video_feed/test/src/utils/source_loader_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/utils/source_loader_test.dart
@@ -127,6 +127,36 @@ void main() {
       expect(logs.first, contains('badUrl'));
     });
 
+    test('fails over when Android reports NOT_READY for a source', () async {
+      final clips = <VideoClip>[];
+      final controller = _RecordingControllerWithFailures(
+        clips.add,
+        failures: [
+          PlatformException(
+            code: 'NOT_READY',
+            message: 'setClips timed out before player reached STATE_READY',
+          ),
+        ],
+      );
+      addTearDown(controller.dispose);
+
+      final result = await setSourceWithFallbacks(
+        index: 1,
+        controller: controller,
+        sources: ['slowOptimizedUrl', 'rawUrl'],
+        log: logs.add,
+      );
+
+      expect(result, equals(('rawUrl', 1)));
+      expect(
+        clips.map((clip) => clip.uri),
+        equals(['slowOptimizedUrl', 'rawUrl']),
+      );
+      expect(logs, hasLength(1));
+      expect(logs.single, contains('failedSource=slowOptimizedUrl'));
+      expect(logs.single, contains('retrySource=rawUrl'));
+    });
+
     test('advances immediately on HTTP 202 when a fallback remains', () async {
       final clips = <VideoClip>[];
       final controller = _RecordingControllerWithFailures(

--- a/mobile/test/widgets/video_editor/main_editor/video_editor_canvas_test.dart
+++ b/mobile/test/widgets/video_editor/main_editor/video_editor_canvas_test.dart
@@ -358,6 +358,30 @@ void main() {
       },
     );
 
+    test('returns false for a NOT_READY timeout from the native player', () {
+      expect(
+        VideoEditorCanvas.guardClipLoad(
+          () async => throw PlatformException(
+            code: 'NOT_READY',
+            message: 'setClips timed out before player reached STATE_READY',
+          ),
+        ),
+        completion(isFalse),
+      );
+    });
+
+    test('returns false for a PLAYER_ERROR from the native player', () {
+      expect(
+        VideoEditorCanvas.guardClipLoad(
+          () async => throw PlatformException(
+            code: 'PLAYER_ERROR',
+            message: 'Decoder failed while loading clips.',
+          ),
+        ),
+        completion(isFalse),
+      );
+    });
+
     test('rethrows a non-platform error so genuine bugs still surface', () {
       // A programming-invariant violation (StateError/ArgumentError) is not a
       // composition rejection — it must propagate so it reaches Crashlytics
@@ -370,19 +394,19 @@ void main() {
       );
     });
 
-    test('rethrows non-composition platform errors', () {
+    test('rethrows unexpected platform errors', () {
       expect(
         VideoEditorCanvas.guardClipLoad(
           () async => throw PlatformException(
-            code: 'PLAYER_ERROR',
-            message: 'Decoder failed while loading clips.',
+            code: 'INVALID_ARGS',
+            message: 'clips list required',
           ),
         ),
         throwsA(
           isA<PlatformException>().having(
             (error) => error.code,
             'code',
-            'PLAYER_ERROR',
+            'INVALID_ARGS',
           ),
         ),
       );

--- a/mobile/test/widgets/video_editor/main_editor/video_editor_canvas_test.dart
+++ b/mobile/test/widgets/video_editor/main_editor/video_editor_canvas_test.dart
@@ -413,6 +413,28 @@ void main() {
     });
   });
 
+  group('VideoEditorCanvas.shouldPublishClipLoad', () {
+    test('publishes the active clip load generation', () {
+      expect(
+        VideoEditorCanvas.shouldPublishClipLoad(
+          generation: 3,
+          currentGeneration: 3,
+        ),
+        isTrue,
+      );
+    });
+
+    test('rejects a superseded clip load generation', () {
+      expect(
+        VideoEditorCanvas.shouldPublishClipLoad(
+          generation: 3,
+          currentGeneration: 4,
+        ),
+        isFalse,
+      );
+    });
+  });
+
   group('VideoEditorCanvas.resolveClipSnapshotSync', () {
     late Directory tempDir;
 

--- a/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_header_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_header_test.dart
@@ -12,6 +12,7 @@ import 'package:openvine/blocs/video_editor/main_editor/video_editor_main_bloc.d
 import 'package:openvine/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/stop_motion_clip_frame.dart';
 import 'package:openvine/widgets/video_editor/main_editor/video_editor_scope.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/video_editor_timeline_header.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
@@ -190,6 +191,42 @@ void main() {
         final playButton = buttonBySemanticLabel(tester, 'Play');
 
         expect(playButton.onPressed, isNull);
+      });
+
+      // A frames-only composition never creates a native player, so
+      // isPlayerReady stays false for its whole lifetime — gating the button
+      // on it alone would make stop-motion preview permanently unplayable.
+      testWidgets('keeps play button enabled for a stop-motion composition', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          buildWidget(
+            mainState: const VideoEditorMainState(),
+            clipState: ClipEditorState(clips: [_stopMotionClip()]),
+          ),
+        );
+
+        final playButton = buttonBySemanticLabel(tester, 'Play');
+
+        expect(playButton.onPressed, isNotNull);
+      });
+
+      testWidgets('dispatches toggle event for a stop-motion composition', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          buildWidget(
+            mainState: const VideoEditorMainState(),
+            clipState: ClipEditorState(clips: [_stopMotionClip()]),
+          ),
+        );
+
+        await tester.tap(find.bySemanticsLabel('Play'));
+        await tester.pump();
+
+        verify(
+          () => mockMainBloc.add(const VideoEditorPlaybackToggleRequested()),
+        ).called(1);
       });
     });
 
@@ -411,6 +448,28 @@ DivineIconButton buttonBySemanticLabel(WidgetTester tester, String label) {
     matching: find.byType(DivineIconButton),
   );
   return tester.widget<DivineIconButton>(finder.first);
+}
+
+/// A frames-only clip: `isStopMotion` requires a null [EditorVideo] plus
+/// frames, which is exactly the shape that never gets a native player.
+DivineVideoClip _stopMotionClip() {
+  return DivineVideoClip(
+    id: 'stop-motion-1',
+    stopMotionFrames: const [
+      StopMotionClipFrame(
+        path: '/d/a.jpg',
+        duration: Duration(milliseconds: 83),
+      ),
+      StopMotionClipFrame(
+        path: '/d/b.jpg',
+        duration: Duration(milliseconds: 83),
+      ),
+    ],
+    duration: const Duration(milliseconds: 166),
+    recordedAt: DateTime(2025),
+    originalAspectRatio: 9 / 16,
+    targetAspectRatio: .vertical,
+  );
 }
 
 DivineVideoClip _createTestClip({required String id, int seconds = 2}) {

--- a/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_header_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_header_test.dart
@@ -166,7 +166,11 @@ void main() {
       });
 
       testWidgets('dispatches toggle event on tap', (tester) async {
-        await tester.pumpWidget(buildWidget());
+        await tester.pumpWidget(
+          buildWidget(
+            mainState: const VideoEditorMainState(isPlayerReady: true),
+          ),
+        );
 
         await tester.tap(find.bySemanticsLabel('Play'));
         await tester.pump();
@@ -174,6 +178,18 @@ void main() {
         verify(
           () => mockMainBloc.add(const VideoEditorPlaybackToggleRequested()),
         ).called(1);
+      });
+
+      testWidgets('disables play button while the player is not ready', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          buildWidget(mainState: const VideoEditorMainState()),
+        );
+
+        final playButton = buttonBySemanticLabel(tester, 'Play');
+
+        expect(playButton.onPressed, isNull);
       });
     });
 


### PR DESCRIPTION
## Summary
- return NOT_READY instead of success when Android setClips times out before STATE_READY
- mark editor player readiness false during trim/speed/reload swaps and true only after setClips succeeds
- disable the timeline play button while the player is not ready, while keeping frames-only stop-motion playback enabled
- soft-degrade metadata/clip preview player initialization when setSource now reports NOT_READY
- document and pin feed source failover when Android reports NOT_READY for a source
- keep PLAYER_ERROR handling log-only in the UI helper instead of reporting directly to Crashlytics from a widget

Fixes #7384

## Verification
- cd mobile && flutter analyze lib/screens/video_metadata/video_metadata_preview_screen.dart lib/widgets/video_clip/video_clip_preview.dart lib/widgets/video_editor/main_editor/video_editor_canvas.dart lib/widgets/video_metadata/modes/classic/video_metadata_classic_preview_thumbnail.dart test/widgets/video_editor/main_editor/video_editor_canvas_test.dart packages/infinite_video_feed/test/src/utils/source_loader_test.dart
- cd mobile && flutter test test/widgets/video_editor/main_editor/video_editor_canvas_test.dart test/widgets/video_editor/timeline_editor/video_editor_timeline_header_test.dart
- cd mobile/packages/infinite_video_feed && flutter test test/src/utils/source_loader_test.dart
- pre-push hook: analyzer and changed-file Flutter tests passed
- GitHub checks: all green on 97bcf49ad

## Notes
- Android NOT_READY now intentionally behaves as a failed source load for the feed fallback path. That means a slow optimized source can advance to the next available source instead of resolving success after the 10s native timeout.
- PLAYER_ERROR is swallowed by VideoEditorCanvas.guardClipLoad so the editor can stay gated on thumbnail fallback, but this UI-layer helper does not call Crashlytics directly; any future explicit reporting should go through the repo's BLoC/service reportability path.