### PR TITLE
fix(video): stop preferring dead stream media

### DIFF
--- a/mobile/lib/services/video_event_publisher.dart
+++ b/mobile/lib/services/video_event_publisher.dart
@@ -1047,13 +1047,14 @@ class VideoEventPublisher {
     void Function()? onEventSigned,
     void Function()? onAudioReuseDegraded,
   }) async {
-    // Validate that at least one video URL is a proper HTTP/HTTPS URL
-    // This prevents local file paths from being published to Nostr
+    // Validate that at least one video URL is publishable.
+    // This prevents local file paths and known dead media hosts from being
+    // published to Nostr.
     final hasValidVideoUrl =
-        _isHttpUrl(upload.streamingMp4Url) ||
-        _isHttpUrl(upload.fallbackUrl) ||
-        _isHttpUrl(upload.streamingHlsUrl) ||
-        _isHttpUrl(upload.cdnUrl);
+        _isPublishableMediaUrl(upload.streamingMp4Url) ||
+        _isPublishableMediaUrl(upload.fallbackUrl) ||
+        _isPublishableMediaUrl(upload.streamingHlsUrl) ||
+        _isPublishableMediaUrl(upload.cdnUrl);
     if (!hasValidVideoUrl) {
       Log.error(
         '❌ Cannot publish - no valid HTTP video URLs found. '
@@ -1109,77 +1110,57 @@ class VideoEventPublisher {
       // Build imeta tag components
       final imetaComponents = <String>[];
 
-      // Add all video URLs from Blossom upload stored in PendingUpload
-      // Priority order (based on _scoreVideoUrl in video_event.dart):
-      // 1. streamingMp4Url (BunnyStream MP4 - scores 110) - ONLY if valid
-      // 2. fallbackUrl (R2 MP4 - scores 100)
-      // 3. streamingHlsUrl (HLS - scores 90)
-
       final urlsAdded = <String>[];
 
-      // Validate BunnyStream MP4 URL - must have quality suffix (e.g., play_360p.mp4)
-      // Invalid: .../play.mp4 (returns 404)
-      // Valid: .../play_360p.mp4, .../play_480p.mp4, etc.
-      if (_isHttpUrl(upload.streamingMp4Url)) {
-        final isValidBunnyMp4 =
-            !upload.streamingMp4Url!.contains('stream.divine.video') ||
-            upload.streamingMp4Url!.contains(
-              RegExp(r'play_\d+p\.mp4'),
-            ); // Non-BunnyStream URLs are assumed valid
-
-        if (isValidBunnyMp4) {
-          imetaComponents.add('url ${upload.streamingMp4Url}');
-          urlsAdded.add('MP4(streaming): ${upload.streamingMp4Url}');
-        } else {
-          Log.warning(
-            '⚠️ Skipping invalid BunnyStream MP4 URL (missing quality suffix): ${upload.streamingMp4Url}',
+      void addPublishableUrl({
+        required String? url,
+        required String fieldName,
+        required String label,
+      }) {
+        if (url == null || url.isEmpty) return;
+        if (!_isHttpUrl(url)) {
+          Log.error(
+            '⚠️ Skipping non-HTTP $fieldName (possible local path): $url',
             name: 'VideoEventPublisher',
             category: LogCategory.video,
           );
+          return;
         }
-      } else if (upload.streamingMp4Url != null &&
-          upload.streamingMp4Url!.isNotEmpty) {
-        Log.error(
-          '⚠️ Skipping non-HTTP streamingMp4Url (possible local path): ${upload.streamingMp4Url}',
-          name: 'VideoEventPublisher',
-          category: LogCategory.video,
-        );
+        if (VideoUrlResolver.isKnownDeadMediaUrl(url)) {
+          Log.warning(
+            '⚠️ Skipping known dead media URL in $fieldName: $url',
+            name: 'VideoEventPublisher',
+            category: LogCategory.video,
+          );
+          return;
+        }
+
+        imetaComponents.add('url $url');
+        urlsAdded.add('$label: $url');
       }
 
-      if (_isHttpUrl(upload.fallbackUrl)) {
-        imetaComponents.add('url ${upload.fallbackUrl}');
-        urlsAdded.add('MP4(R2 fallback): ${upload.fallbackUrl}');
-      } else if (upload.fallbackUrl != null && upload.fallbackUrl!.isNotEmpty) {
-        Log.error(
-          '⚠️ Skipping non-HTTP fallbackUrl (possible local path): ${upload.fallbackUrl}',
-          name: 'VideoEventPublisher',
-          category: LogCategory.video,
-        );
-      }
-
-      if (_isHttpUrl(upload.streamingHlsUrl)) {
-        imetaComponents.add('url ${upload.streamingHlsUrl}');
-        urlsAdded.add('HLS: ${upload.streamingHlsUrl}');
-      } else if (upload.streamingHlsUrl != null &&
-          upload.streamingHlsUrl!.isNotEmpty) {
-        Log.error(
-          '⚠️ Skipping non-HTTP streamingHlsUrl (possible local path): ${upload.streamingHlsUrl}',
-          name: 'VideoEventPublisher',
-          category: LogCategory.video,
-        );
-      }
+      addPublishableUrl(
+        url: upload.streamingMp4Url,
+        fieldName: 'streamingMp4Url',
+        label: 'MP4(streaming)',
+      );
+      addPublishableUrl(
+        url: upload.fallbackUrl,
+        fieldName: 'fallbackUrl',
+        label: 'MP4(R2 fallback)',
+      );
+      addPublishableUrl(
+        url: upload.streamingHlsUrl,
+        fieldName: 'streamingHlsUrl',
+        label: 'HLS',
+      );
 
       // Fallback to legacy cdnUrl if no Blossom-specific URLs
-      if (urlsAdded.isEmpty && _isHttpUrl(upload.cdnUrl)) {
-        imetaComponents.add('url ${upload.cdnUrl}');
-        urlsAdded.add('Legacy CDN: ${upload.cdnUrl}');
-      } else if (urlsAdded.isEmpty &&
-          upload.cdnUrl != null &&
-          upload.cdnUrl!.isNotEmpty) {
-        Log.error(
-          '⚠️ Skipping non-HTTP cdnUrl (possible local path): ${upload.cdnUrl}',
-          name: 'VideoEventPublisher',
-          category: LogCategory.video,
+      if (urlsAdded.isEmpty) {
+        addPublishableUrl(
+          url: upload.cdnUrl,
+          fieldName: 'cdnUrl',
+          label: 'Legacy CDN',
         );
       }
 
@@ -2167,6 +2148,10 @@ class VideoEventPublisher {
   static bool _isHttpUrl(String? url) {
     if (url == null || url.isEmpty) return false;
     return url.startsWith('http://') || url.startsWith('https://');
+  }
+
+  static bool _isPublishableMediaUrl(String? url) {
+    return _isHttpUrl(url) && !VideoUrlResolver.isKnownDeadMediaUrl(url!);
   }
 
   /// Returns [proof] carrying the device attestation this publish should

--- a/mobile/lib/utils/external_link_launcher.dart
+++ b/mobile/lib/utils/external_link_launcher.dart
@@ -17,7 +17,6 @@ const _trustedDomains = {
   'media.divine.video',
   'relay.divine.video',
   'cdn.divine.video',
-  'stream.divine.video',
 };
 
 bool isTrustedExternalLinkHost(String host) {

--- a/mobile/lib/widgets/video_thumbnail_widget.dart
+++ b/mobile/lib/widgets/video_thumbnail_widget.dart
@@ -63,7 +63,9 @@ class _VideoThumbnailWidgetState extends State<VideoThumbnailWidget> {
 
   void _loadThumbnail() {
     final url = widget.video.thumbnailUrl;
-    if (url != null && url.isNotEmpty) {
+    if (url != null &&
+        url.isNotEmpty &&
+        !VideoUrlResolver.isKnownDeadMediaUrl(url)) {
       _thumbnailUrl = url;
     } else {
       _thumbnailUrl = null;

--- a/mobile/packages/models/lib/src/video_event.dart
+++ b/mobile/packages/models/lib/src/video_event.dart
@@ -12,6 +12,14 @@ import 'package:models/src/video_url_resolver.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
 import 'package:text_sanitizer/text_sanitizer.dart';
 
+String? _usableThumbnailUrl(Object? value) {
+  final url = value?.toString();
+  if (url == null || url.isEmpty) return null;
+  if (!VideoUrlResolver.isValidVideoUrl(url)) return null;
+  if (VideoUrlResolver.isKnownDeadMediaUrl(url)) return null;
+  return url;
+}
+
 /// Compact backend-computed ProofMode verification result for feed/list rows.
 @immutable
 class ProofVerificationSummary {
@@ -274,7 +282,7 @@ class VideoEvent {
           : DateTime.fromMillisecondsSinceEpoch(createdAt * 1000, isUtc: true),
       title: json['title'] as String?,
       videoUrl: json['videoUrl'] as String?,
-      thumbnailUrl: json['thumbnailUrl'] as String?,
+      thumbnailUrl: _usableThumbnailUrl(json['thumbnailUrl']),
       duration: optInt(json['duration']),
       dimensions: json['dimensions'] as String?,
       mimeType: json['mimeType'] as String?,
@@ -458,16 +466,15 @@ class VideoEvent {
               case 'dim':
                 dimensions ??= value;
               case 'thumb':
-                // Thumbnail URL
-                if (value.isNotEmpty &&
-                    VideoUrlResolver.isValidVideoUrl(value)) {
-                  thumbnailUrl ??= value;
+                final thumbnail = _usableThumbnailUrl(value);
+                if (thumbnail != null) {
+                  thumbnailUrl ??= thumbnail;
                 }
               case 'image':
                 // NIP-92 uses 'image' for thumbnail in imeta
-                if (value.isNotEmpty &&
-                    VideoUrlResolver.isValidVideoUrl(value)) {
-                  thumbnailUrl ??= value;
+                final thumbnail = _usableThumbnailUrl(value);
+                if (thumbnail != null) {
+                  thumbnailUrl ??= thumbnail;
                 }
               case 'blurhash':
                 // Blurhash for progressive loading
@@ -495,9 +502,9 @@ class VideoEvent {
           fileSize = int.tryParse(tagValue);
         case 'thumb':
           // Thumbnail URL - prefer static thumbnails for grid display
-          if (tagValue.isNotEmpty &&
-              VideoUrlResolver.isValidVideoUrl(tagValue)) {
-            thumbnailUrl = tagValue;
+          final thumbnail = _usableThumbnailUrl(tagValue);
+          if (thumbnail != null) {
+            thumbnailUrl = thumbnail;
           }
         case 'preview':
           // Animated GIF preview - store separately, don't use as main
@@ -509,9 +516,9 @@ class VideoEvent {
           }
         case 'image':
           // Alternative to 'thumb' tag - some clients use 'image' instead
-          if (tagValue.isNotEmpty &&
-              VideoUrlResolver.isValidVideoUrl(tagValue)) {
-            thumbnailUrl ??= tagValue;
+          final thumbnail = _usableThumbnailUrl(tagValue);
+          if (thumbnail != null) {
+            thumbnailUrl ??= thumbnail;
           }
         case 'd':
           // Replaceable event ID - original vine ID
@@ -563,8 +570,7 @@ class VideoEvent {
                 VideoUrlResolver.isValidVideoUrl(url)) {
               videoUrl ??= url;
             } else if (type == 'thumbnail' &&
-                url.isNotEmpty &&
-                VideoUrlResolver.isValidVideoUrl(url) &&
+                _usableThumbnailUrl(url) != null &&
                 !url.contains('picsum.photos')) {
               thumbnailUrl ??= url;
             }

--- a/mobile/packages/models/lib/src/video_stats.dart
+++ b/mobile/packages/models/lib/src/video_stats.dart
@@ -5,6 +5,7 @@
 import 'package:meta/meta.dart';
 import 'package:models/src/engagement_count_parser.dart';
 import 'package:models/src/video_event.dart';
+import 'package:models/src/video_url_resolver.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
 
 /// Video with engagement metrics from Funnelcake API.
@@ -558,6 +559,8 @@ class VideoStats {
         publishedAt ?? createdAt.millisecondsSinceEpoch ~/ 1000;
     final normalizedDTag = dTag.isNotEmpty ? dTag : id;
     final expirationTimestamp = int.tryParse(rawTags['expiration'] ?? '');
+    final resolvedVideoUrl = _usableVideoUrl(videoUrl, sha256: sha256);
+    final resolvedThumbnailUrl = _usableThumbnailUrl(thumbnail);
     // Archival Vine counts: prefer the server-resolved embedded_* fields,
     // fall back to the archive-import event tags for relay-shaped payloads.
     final originalLikes = embeddedLikes ?? int.tryParse(rawTags['likes'] ?? '');
@@ -575,8 +578,8 @@ class VideoStats {
         isUtc: true,
       ),
       title: title.isNotEmpty ? title : null,
-      videoUrl: videoUrl.isNotEmpty ? videoUrl : null,
-      thumbnailUrl: thumbnail.isNotEmpty ? thumbnail : null,
+      videoUrl: resolvedVideoUrl,
+      thumbnailUrl: resolvedThumbnailUrl,
       vineId: normalizedDTag.isNotEmpty ? normalizedDTag : null,
       publishedAt: publishedAt?.toString(),
       sha256: sha256,
@@ -650,6 +653,25 @@ String? _firstNonEmptyString(Iterable<Object?> values) {
     }
   }
   return null;
+}
+
+String? _usableVideoUrl(String value, {required String? sha256}) {
+  if (value.isEmpty) return null;
+  if (!VideoUrlResolver.isKnownDeadMediaUrl(value)) return value;
+
+  final hash = sha256?.trim();
+  if (hash != null && hash.length == 64 && _isHex(hash)) {
+    return 'https://media.divine.video/$hash';
+  }
+
+  return value;
+}
+
+String? _usableThumbnailUrl(String value) {
+  if (value.isEmpty) return null;
+  if (!VideoUrlResolver.isValidVideoUrl(value)) return null;
+  if (VideoUrlResolver.isKnownDeadMediaUrl(value)) return null;
+  return value;
 }
 
 String? _dTagFromAddressableId(Object? value) {

--- a/mobile/packages/models/lib/src/video_url_resolver.dart
+++ b/mobile/packages/models/lib/src/video_url_resolver.dart
@@ -7,6 +7,11 @@
 class VideoUrlResolver {
   VideoUrlResolver._();
 
+  /// Delivery hosts known to be unreachable.
+  ///
+  /// Transitional pending the hostname disposition in divinevideo/divine-blossom#202.
+  static const deadMediaHosts = {'stream.divine.video'};
+
   /// Corrects the common `apt.openvine.co` typo to `api.openvine.co`.
   ///
   /// The target stays on the legacy host on purpose (#5286). These are content
@@ -49,6 +54,17 @@ class VideoUrlResolver {
     }
   }
 
+  /// Whether [url] points at a known dead media delivery host.
+  static bool isKnownDeadMediaUrl(String url) {
+    try {
+      final uri = Uri.parse(fixOpenvineTypo(url));
+      final host = uri.host.toLowerCase();
+      return deadMediaHosts.contains(host);
+    } on FormatException {
+      return false;
+    }
+  }
+
   /// Scores [url] by format preference (higher = better).
   ///
   /// For short videos MP4 is always preferred over HLS (single file, fast,
@@ -67,7 +83,11 @@ class VideoUrlResolver {
 
     // POSTEL'S LAW: Deprioritize known broken URL patterns.
     // The cdn.divine.video/*/manifest/video.m3u8 pattern is often broken;
-    // prefer stream.divine.video HLS or direct MP4 files.
+    // prefer direct MP4 files or generic HLS.
+    if (isKnownDeadMediaUrl(url)) {
+      return 1;
+    }
+
     if (urlLower.contains('cdn.divine.video') &&
         urlLower.contains('/manifest/')) {
       return 5;
@@ -84,12 +104,6 @@ class VideoUrlResolver {
 
     // Any other MP4 - still preferred.
     if (urlLower.contains('.mp4')) return 110;
-
-    // BunnyStream HLS (stream.divine.video) - reliable streaming.
-    if (urlLower.contains('.m3u8') &&
-        urlLower.contains('stream.divine.video')) {
-      return 105;
-    }
 
     // Generic HLS fallback.
     if (urlLower.contains('.m3u8') || urlLower.contains('hls')) return 100;

--- a/mobile/packages/models/lib/src/video_url_resolver.dart
+++ b/mobile/packages/models/lib/src/video_url_resolver.dart
@@ -68,8 +68,9 @@ class VideoUrlResolver {
   /// Scores [url] by format preference (higher = better).
   ///
   /// For short videos MP4 is always preferred over HLS (single file, fast,
-  /// universal). Dead `vine.co` URLs and the often-broken
-  /// `cdn.divine.video/*/manifest/*.m3u8` pattern are deprioritized.
+  /// universal). Dead `vine.co` URLs, known dead media hosts, and the
+  /// often-broken `cdn.divine.video/*/manifest/*.m3u8` pattern are
+  /// deprioritized.
   static int scoreVideoUrl(String url) {
     final urlLower = url.toLowerCase();
 
@@ -81,13 +82,14 @@ class VideoUrlResolver {
       return -1;
     }
 
-    // POSTEL'S LAW: Deprioritize known broken URL patterns.
-    // The cdn.divine.video/*/manifest/video.m3u8 pattern is often broken;
-    // prefer direct MP4 files or generic HLS.
+    // Keep dead hosts as a last resort only when no better candidate exists.
     if (isKnownDeadMediaUrl(url)) {
       return 1;
     }
 
+    // POSTEL'S LAW: Deprioritize known broken URL patterns.
+    // The cdn.divine.video/*/manifest/video.m3u8 pattern is often broken;
+    // prefer direct MP4 files or generic HLS.
     if (urlLower.contains('cdn.divine.video') &&
         urlLower.contains('/manifest/')) {
       return 5;

--- a/mobile/packages/models/test/src/video_event_multiple_imeta_test.dart
+++ b/mobile/packages/models/test/src/video_event_multiple_imeta_test.dart
@@ -1,9 +1,10 @@
 // ABOUTME: Test multiple imeta tag parsing and URL selection following Postel's Law
 // ABOUTME: Ensures best video URL is selected from events with multiple imeta tags
+// ignore_for_file: lines_longer_than_80_chars
 
-import 'package:flutter_test/flutter_test.dart';
 import 'package:models/models.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
+import 'package:test/test.dart';
 
 void main() {
   group("VideoEvent Multiple Imeta Parsing (Postel's Law)", () {
@@ -62,7 +63,7 @@ void main() {
       expect(videoEvent.videoUrl, isNot(contains('/manifest/')));
     });
 
-    test('extracts hls URL from imeta as fallback candidate', () {
+    test('deprioritizes dead stream.divine.video HLS candidates', () {
       // Event with only HLS URLs, no MP4
       final event = Event.fromJson({
         'id': 'test123',
@@ -76,19 +77,20 @@ void main() {
           [
             'imeta',
             'url',
-            'https://cdn.divine.video/broken/manifest/video.m3u8', // Broken
-            'm', 'application/vnd.apple.mpegurl',
+            'https://cdn.divine.video/broken/manifest/video.m3u8',
+            'm',
+            'application/vnd.apple.mpegurl',
             'hls',
-            'https://stream.divine.video/working/playlist.m3u8', // Working
+            'https://stream.divine.video/dead/playlist.m3u8',
           ],
         ],
       });
 
       final videoEvent = VideoEvent.fromNostrEvent(event);
 
-      // Should prefer stream.divine.video HLS (score 105) over cdn.divine.video manifest (score 5)
       expect(videoEvent.videoUrl, isNotNull);
-      expect(videoEvent.videoUrl, contains('stream.divine.video'));
+      expect(videoEvent.videoUrl, contains('cdn.divine.video'));
+      expect(videoEvent.videoUrl, isNot(contains('stream.divine.video')));
     });
 
     test('handles old space-separated imeta format with hls', () {

--- a/mobile/packages/models/test/src/video_event_parsing_test.dart
+++ b/mobile/packages/models/test/src/video_event_parsing_test.dart
@@ -294,12 +294,7 @@ void main() {
         // Assert
         expect(videoEvent.blurhash, equals('L9AAEz-o?^TK4.%gVs-o009F9E9F'));
         expect(videoEvent.dimensions, equals('720x720'));
-        expect(
-          videoEvent.thumbnailUrl,
-          equals(
-            'https://stream.divine.video/fa4a90a3-6a30-4dc6-9b9d-3f78551c9053/thumbnail.jpg',
-          ),
-        );
+        expect(videoEvent.thumbnailUrl, isNull);
         expect(
           videoEvent.videoUrl,
           equals(
@@ -315,6 +310,72 @@ void main() {
         expect(videoEvent.mimeType, equals('video/mp4'));
       },
     );
+
+    test('uses a live alternate thumbnail after a dead media thumbnail', () {
+      final nostrEvent = Event(
+        '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+        34236,
+        [
+          ['url', 'https://media.divine.video/video.mp4'],
+          [
+            'thumb',
+            'https://stream.divine.video/fa4a90a3-6a30-4dc6-9b9d-3f78551c9053/thumbnail.jpg',
+          ],
+          ['image', 'https://media.divine.video/fa4a90a3-thumbnail.jpg'],
+          ['blurhash', 'L9AAEz-o?^TK4.%gVs-o009F9E9F'],
+        ],
+        'Test video',
+        createdAt: 1757385263,
+      );
+
+      final videoEvent = VideoEvent.fromNostrEvent(nostrEvent);
+
+      expect(
+        videoEvent.thumbnailUrl,
+        equals('https://media.divine.video/fa4a90a3-thumbnail.jpg'),
+      );
+      expect(videoEvent.blurhash, equals('L9AAEz-o?^TK4.%gVs-o009F9E9F'));
+    });
+
+    test('drops a dead media thumbnail while keeping blurhash fallback', () {
+      final nostrEvent = Event(
+        '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+        34236,
+        [
+          ['url', 'https://media.divine.video/video.mp4'],
+          [
+            'thumb',
+            'https://stream.divine.video/fa4a90a3-6a30-4dc6-9b9d-3f78551c9053/thumbnail.jpg',
+          ],
+          ['blurhash', 'L9AAEz-o?^TK4.%gVs-o009F9E9F'],
+        ],
+        'Test video',
+        createdAt: 1757385263,
+      );
+
+      final videoEvent = VideoEvent.fromNostrEvent(nostrEvent);
+
+      expect(videoEvent.thumbnailUrl, isNull);
+      expect(videoEvent.blurhash, equals('L9AAEz-o?^TK4.%gVs-o009F9E9F'));
+    });
+
+    test('drops dead media thumbnails restored from persisted JSON', () {
+      final videoEvent = VideoEvent.fromJson(const {
+        'id':
+            '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+        'pubkey':
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        'createdAt': 1757385263,
+        'content': 'Test video',
+        'videoUrl': 'https://media.divine.video/video.mp4',
+        'thumbnailUrl':
+            'https://stream.divine.video/fa4a90a3-6a30-4dc6-9b9d-3f78551c9053/thumbnail.jpg',
+        'blurhash': 'L9AAEz-o?^TK4.%gVs-o009F9E9F',
+      });
+
+      expect(videoEvent.thumbnailUrl, isNull);
+      expect(videoEvent.blurhash, equals('L9AAEz-o?^TK4.%gVs-o009F9E9F'));
+    });
 
     test('should not require specific file extensions for video URLs', () {
       // Arrange - URL without typical video extension
@@ -724,10 +785,7 @@ void main() {
         videoEvent.clipSourceCredits[0].addressableId,
         '34236:$creatorPubkey:test-d-tag',
       );
-      expect(
-        videoEvent.clipSourceCredits[1].authorPubkey,
-        secondCreatorPubkey,
-      );
+      expect(videoEvent.clipSourceCredits[1].authorPubkey, secondCreatorPubkey);
       expect(
         videoEvent.clipSourceCredits[1].relayUrl,
         'wss://relay-two.divine.video',

--- a/mobile/packages/models/test/src/video_stats_test.dart
+++ b/mobile/packages/models/test/src/video_stats_test.dart
@@ -1562,6 +1562,83 @@ void main() {
         expect(videoEvent.originalLoops, equals(1000));
       });
 
+      test('drops dead REST thumbnails so blurhash fallback can render', () {
+        final stats = VideoStats(
+          id: 'test-id',
+          pubkey: 'test-pubkey',
+          createdAt: DateTime.fromMillisecondsSinceEpoch(1700000000000),
+          kind: 34236,
+          dTag: 'test-dtag',
+          title: 'Test Video',
+          thumbnail:
+              'https://stream.divine.video/fa4a90a3-6a30-4dc6-9b9d-3f78551c9053/thumbnail.jpg',
+          videoUrl: 'https://media.divine.video/video.mp4',
+          blurhash: 'LEHV6nWB2yk8',
+          reactions: 0,
+          comments: 0,
+          reposts: 0,
+          engagementScore: 0,
+        );
+
+        final videoEvent = stats.toVideoEvent();
+
+        expect(videoEvent.thumbnailUrl, isNull);
+        expect(videoEvent.blurhash, equals('LEHV6nWB2yk8'));
+      });
+
+      test('replaces dead REST video URLs with canonical sha256 media URL', () {
+        const hash =
+            '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+        final stats = VideoStats(
+          id: 'test-id',
+          pubkey: 'test-pubkey',
+          createdAt: DateTime.fromMillisecondsSinceEpoch(1700000000000),
+          kind: 34236,
+          dTag: 'test-dtag',
+          title: 'Test Video',
+          thumbnail: 'https://media.divine.video/thumb.jpg',
+          videoUrl:
+              'https://stream.divine.video/fa4a90a3-6a30-4dc6-9b9d-3f78551c9053/playlist.m3u8',
+          sha256: hash,
+          reactions: 0,
+          comments: 0,
+          reposts: 0,
+          engagementScore: 0,
+        );
+
+        final videoEvent = stats.toVideoEvent();
+
+        expect(videoEvent.videoUrl, equals('https://media.divine.video/$hash'));
+        expect(videoEvent.sha256, equals(hash));
+      });
+
+      test('keeps dead REST video URL when no sha256 fallback exists', () {
+        final stats = VideoStats(
+          id: 'test-id',
+          pubkey: 'test-pubkey',
+          createdAt: DateTime.fromMillisecondsSinceEpoch(1700000000000),
+          kind: 34236,
+          dTag: 'test-dtag',
+          title: 'Test Video',
+          thumbnail: 'https://media.divine.video/thumb.jpg',
+          videoUrl:
+              'https://stream.divine.video/fa4a90a3-6a30-4dc6-9b9d-3f78551c9053/playlist.m3u8',
+          reactions: 0,
+          comments: 0,
+          reposts: 0,
+          engagementScore: 0,
+        );
+
+        final videoEvent = stats.toVideoEvent();
+
+        expect(
+          videoEvent.videoUrl,
+          equals(
+            'https://stream.divine.video/fa4a90a3-6a30-4dc6-9b9d-3f78551c9053/playlist.m3u8',
+          ),
+        );
+      });
+
       test(
         'promotes content warning tags from REST event data into VideoEvent',
         () {

--- a/mobile/packages/models/test/src/video_url_resolver_test.dart
+++ b/mobile/packages/models/test/src/video_url_resolver_test.dart
@@ -60,6 +60,23 @@ void main() {
       });
     });
 
+    group('isKnownDeadMediaUrl', () {
+      test('matches known dead media hosts by parsed host only', () {
+        expect(
+          VideoUrlResolver.isKnownDeadMediaUrl(
+            'https://stream.divine.video/video/playlist.m3u8',
+          ),
+          isTrue,
+        );
+        expect(
+          VideoUrlResolver.isKnownDeadMediaUrl(
+            'https://example.com/stream.divine.video/video.mp4',
+          ),
+          isFalse,
+        );
+      });
+    });
+
     group('scoreVideoUrl', () {
       test('ranks MP4 on cdn.divine.video highest', () {
         expect(
@@ -75,14 +92,27 @@ void main() {
         );
       });
 
-      test('ranks stream.divine.video HLS above generic HLS', () {
+      test('ranks stream.divine.video HLS below generic HLS', () {
         expect(
           VideoUrlResolver.scoreVideoUrl('https://stream.divine.video/v.m3u8'),
-          equals(105),
+          lessThan(
+            VideoUrlResolver.scoreVideoUrl('https://example.com/v.m3u8'),
+          ),
         );
         expect(
           VideoUrlResolver.scoreVideoUrl('https://example.com/v.m3u8'),
           equals(100),
+        );
+      });
+
+      test('ranks stream.divine.video MP4 below live Divine media URLs', () {
+        expect(
+          VideoUrlResolver.scoreVideoUrl(
+            'https://stream.divine.video/video/play_240p.mp4',
+          ),
+          lessThan(
+            VideoUrlResolver.scoreVideoUrl('https://media.divine.video/v.mp4'),
+          ),
         );
       });
 
@@ -168,6 +198,13 @@ void main() {
           'https://example.com/v.mp4',
         ]);
         expect(best, equals('https://example.com/v.mp4'));
+      });
+
+      test('selects a dead media URL when it is the sole valid candidate', () {
+        final best = VideoUrlResolver.selectBestVideoUrl([
+          'https://stream.divine.video/video/play_240p.mp4',
+        ]);
+        expect(best, equals('https://stream.divine.video/video/play_240p.mp4'));
       });
     });
 

--- a/mobile/scripts/baseline/test_unit_files.txt
+++ b/mobile/scripts/baseline/test_unit_files.txt
@@ -10,7 +10,6 @@ test/unit/models/video_event_audio_reference_test.dart
 test/unit/models/video_event_blurhash_parsing_test.dart
 test/unit/models/video_event_engagement_enrichment_test.dart
 test/unit/models/video_event_expiration_test.dart
-test/unit/models/video_event_multiple_imeta_test.dart
 test/unit/models/video_event_text_track_test.dart
 test/unit/nostr_sdk/filter_h_tag_test.dart
 test/unit/nostr_sdk/filter_hashtag_test.dart

--- a/mobile/test/models/video_event_parsing_test.dart
+++ b/mobile/test/models/video_event_parsing_test.dart
@@ -222,12 +222,7 @@ void main() {
         // Assert
         expect(videoEvent.blurhash, equals('L9AAEz-o?^TK4.%gVs-o009F9E9F'));
         expect(videoEvent.dimensions, equals('720x720'));
-        expect(
-          videoEvent.thumbnailUrl,
-          equals(
-            'https://stream.divine.video/fa4a90a3-6a30-4dc6-9b9d-3f78551c9053/thumbnail.jpg',
-          ),
-        );
+        expect(videoEvent.thumbnailUrl, isNull);
         expect(
           videoEvent.videoUrl,
           equals(

--- a/mobile/test/services/video_event_publisher_test.dart
+++ b/mobile/test/services/video_event_publisher_test.dart
@@ -17,6 +17,7 @@ import 'package:models/models.dart'
         AudioExternalSource,
         AudioLicenseMetadata,
         UserProfile,
+        VideoUrlResolver,
         audioEventKind;
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/event.dart';
@@ -69,31 +70,10 @@ class ImetaTagGenerator {
   ) async {
     final imetaComponents = <String>[];
 
-    // Add URL(s) - handle Bunny Stream URLs specially
+    // Add URL(s), excluding delivery hosts known to be dead.
     if (upload.cdnUrl != null) {
       final cdnUrl = upload.cdnUrl!;
-
-      // Check if this is a Bunny Stream HLS playlist URL
-      // Format: https://stream.divine.video/{GUID}/playlist.m3u8
-      final bunnyStreamPattern = RegExp(
-        r'^https://stream\.divine\.video/([a-f0-9\-]+)/playlist\.m3u8$',
-        caseSensitive: false,
-      );
-
-      final match = bunnyStreamPattern.firstMatch(cdnUrl);
-      if (match != null) {
-        // Extract GUID and construct both MP4 and HLS URLs
-        final guid = match.group(1)!;
-        // Use 360p quality (next step up from 240p for better quality short videos)
-        final mp4Url = 'https://stream.divine.video/$guid/play_360p.mp4';
-
-        // Add MP4 URL FIRST (preferred for short videos - higher score in _scoreVideoUrl)
-        imetaComponents.add('url $mp4Url');
-
-        // Add HLS URL as fallback
-        imetaComponents.add('url $cdnUrl');
-      } else {
-        // Regular CDN URL - add as-is
+      if (!VideoUrlResolver.isKnownDeadMediaUrl(cdnUrl)) {
         imetaComponents.add('url $cdnUrl');
       }
     }
@@ -424,52 +404,26 @@ void main() {
       );
     });
 
-    test(
-      'should add BOTH MP4 and HLS URLs when Blossom returns Bunny Stream HLS URL',
-      () async {
-        // Arrange - Blossom server returns HLS playlist URL
-        const hlsUrl =
-            'https://stream.divine.video/fa4a90a3-6a30-4dc6-9b9d-3f78551c9053/playlist.m3u8';
-        final upload = PendingUpload.create(
-          localVideoPath: testVideoFile.path,
-          nostrPubkey: 'test_pubkey',
-          title: 'Test Video',
-        ).copyWith(cdnUrl: hlsUrl, status: UploadStatus.readyToPublish);
+    test('should omit Bunny Stream HLS URLs from imeta', () async {
+      const hlsUrl =
+          'https://stream.divine.video/fa4a90a3-6a30-4dc6-9b9d-3f78551c9053/playlist.m3u8';
+      final upload = PendingUpload.create(
+        localVideoPath: testVideoFile.path,
+        nostrPubkey: 'test_pubkey',
+        title: 'Test Video',
+      ).copyWith(cdnUrl: hlsUrl, status: UploadStatus.readyToPublish);
 
-        // Act
-        final imetaComponents = await ImetaTagGenerator.generateImetaComponents(
-          upload,
-        );
+      // Act
+      final imetaComponents = await ImetaTagGenerator.generateImetaComponents(
+        upload,
+      );
 
-        // Assert - Should contain BOTH URLs
-        const mp4Url =
-            'https://stream.divine.video/fa4a90a3-6a30-4dc6-9b9d-3f78551c9053/play_360p.mp4';
-
-        // Should have MP4 URL FIRST (preferred for short videos)
-        expect(
-          imetaComponents.contains('url $mp4Url'),
-          true,
-          reason: 'Should include MP4 URL variant for Bunny Stream video',
-        );
-
-        // Should also have HLS URL as fallback
-        expect(
-          imetaComponents.contains('url $hlsUrl'),
-          true,
-          reason: 'Should include original HLS URL as fallback',
-        );
-
-        // MP4 should come before HLS (preferred)
-        final mp4Index = imetaComponents.indexOf('url $mp4Url');
-        final hlsIndex = imetaComponents.indexOf('url $hlsUrl');
-        expect(
-          mp4Index,
-          lessThan(hlsIndex),
-          reason:
-              'MP4 URL should come before HLS URL (preferred for short videos)',
-        );
-      },
-    );
+      expect(
+        imetaComponents.contains('url $hlsUrl'),
+        false,
+        reason: 'Bunny Stream URLs are known dead and should not be minted',
+      );
+    });
 
     test('should only add single URL for non-Bunny Stream CDN URLs', () async {
       // Arrange - Regular CDN URL (not Bunny Stream)
@@ -629,6 +583,27 @@ void main() {
         ]),
         isTrue,
       );
+    });
+
+    test('publishVideoEvent omits known dead media URLs from imeta', () async {
+      stubSignAndPublish();
+
+      final result = await publisher.publishVideoEvent(
+        upload: createUpload().copyWith(
+          streamingMp4Url:
+              'https://stream.divine.video/fa4a90a3-6a30-4dc6-9b9d-3f78551c9053/play_360p.mp4',
+          streamingHlsUrl:
+              'https://stream.divine.video/fa4a90a3-6a30-4dc6-9b9d-3f78551c9053/playlist.m3u8',
+          fallbackUrl: 'https://media.divine.video/fa4a90a3.mp4',
+          cdnUrl: 'https://stream.divine.video/legacy/playlist.m3u8',
+        ),
+      );
+
+      expect(result, isTrue);
+      final imeta = capturedTags.singleWhere((tag) => tag.first == 'imeta');
+      final imetaText = imeta.join(' ');
+      expect(imetaText, contains('https://media.divine.video/fa4a90a3.mp4'));
+      expect(imetaText, isNot(contains('stream.divine.video')));
     });
 
     test(

--- a/mobile/test/widgets/video_thumbnail_widget_test.dart
+++ b/mobile/test/widgets/video_thumbnail_widget_test.dart
@@ -151,6 +151,39 @@ void main() {
       expect(find.byType(VineCachedImage), findsOneWidget);
     });
 
+    testWidgets('renders blurhash without image load for dead media thumbnail', (
+      tester,
+    ) async {
+      const blurhash = 'LEHV6nWB2yk8pyo0adR*.7kCMdnj';
+      final videoWithDeadThumbnail = createTestVideoEvent(
+        id: 'test-dead-thumbnail',
+        thumbnailUrl:
+            'https://stream.divine.video/fa4a90a3-6a30-4dc6-9b9d-3f78551c9053/thumbnail.jpg',
+        blurhash: blurhash,
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: VideoThumbnailWidget(
+              video: videoWithDeadThumbnail,
+              width: 200,
+              height: 200,
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byType(PassiveAuthThumbnailImage), findsNothing);
+      expect(find.byType(VineCachedImage), findsNothing);
+      expect(
+        tester.widget<BlurhashDisplay>(find.byType(BlurhashDisplay)).blurhash,
+        blurhash,
+      );
+    });
+
     testWidgets(
       'updates missing metadata aspect ratio from the displayed cached image',
       (tester) async {


### PR DESCRIPTION
## Summary
- Deprioritize known-dead media delivery hosts in VideoUrlResolver while keeping sole dead video URLs selectable as a last resort.
- Drop known-dead thumbnail URLs during Nostr parsing, JSON rehydration, REST stats conversion, and thumbnail widget loading so blurhash/live alternates render instead of retrying stream.divine.video.
- Substitute REST `stream.divine.video` video URLs with the canonical `https://media.divine.video/<sha256>` URL when the API row carries a 64-hex content hash, preserving feed slots instead of dropping videos.
- Stop publishing known-dead stream.divine.video URLs and remove its redundant trusted-domain entry.
- Move the touched multiple-imeta test out of the frozen test/unit bucket and shrink the baseline.

Closes #7403

## Allowlist decision
`stream.divine.video` remains trusted for external-link confirmation through the existing `divine.video` parent-domain suffix match. The removed explicit `stream.divine.video` entry was redundant and did not change external-link trust behavior; media selection/loading now handles the retired host instead.

## Verification
- flutter test test/src/video_url_resolver_test.dart test/src/video_event_parsing_test.dart test/src/video_event_multiple_imeta_test.dart test/src/video_stats_test.dart (from mobile/packages/models)
- flutter test test/models/video_event_parsing_test.dart test/services/video_event_publisher_test.dart test/widgets/video_thumbnail_widget_test.dart (from mobile)
- bash mobile/scripts/check_test_unit_structure.sh
- flutter analyze
- git push pre-push checks: analyzer clean; changed-file tests passed (247/247)
