### PR TITLE
fix(profile): cache author video lists

### DIFF
--- a/mobile/lib/services/author_video_buckets.dart
+++ b/mobile/lib/services/author_video_buckets.dart
@@ -1,0 +1,145 @@
+// ABOUTME: Owns per-author video buckets and memoized sorted profile views.
+// ABOUTME: Keeps profile feed reads identity-stable until an author's bucket changes.
+
+import 'package:models/models.dart';
+
+typedef VideoMerge =
+    VideoEvent Function(VideoEvent existing, VideoEvent updated);
+typedef BucketRemoved = void Function(String authorPubkey, int removedCount);
+
+class AuthorVideoBuckets {
+  final Map<String, List<VideoEvent>> _buckets = {};
+  final Map<String, List<VideoEvent>> _sortedViews = {};
+
+  bool contains(String authorPubkey) => _buckets.containsKey(authorPubkey);
+
+  void seed(String authorPubkey, List<VideoEvent> videos) {
+    _buckets[authorPubkey] = List.of(videos);
+    _invalidate(authorPubkey);
+  }
+
+  Iterable<VideoEvent> videosForAuthorUnsorted(String authorPubkey) sync* {
+    final videos = _buckets[authorPubkey];
+    if (videos != null) yield* videos;
+  }
+
+  Iterable<VideoEvent> get allVideos sync* {
+    for (final videos in _buckets.values) {
+      yield* videos;
+    }
+  }
+
+  List<VideoEvent> videosFor(String authorPubkey) {
+    final bucket = _buckets[authorPubkey];
+    if (bucket == null || bucket.isEmpty) return const [];
+
+    return _sortedViews.putIfAbsent(authorPubkey, () {
+      final sorted = List<VideoEvent>.from(bucket)..sort(_newestFirstThenId);
+      return List<VideoEvent>.unmodifiable(sorted);
+    });
+  }
+
+  int backfillUniqueById(String authorPubkey, Iterable<VideoEvent> candidates) {
+    final bucket = _buckets.putIfAbsent(authorPubkey, () => []);
+    final seenBucketIds = {for (final video in bucket) video.id.toLowerCase()};
+    var added = 0;
+
+    for (final video in candidates) {
+      if (seenBucketIds.add(video.id.toLowerCase())) {
+        bucket.add(video);
+        added++;
+      }
+    }
+
+    if (added > 0) _invalidate(authorPubkey);
+    return added;
+  }
+
+  bool replaceById(String authorPubkey, String videoId, VideoEvent updated) {
+    final bucket = _buckets[authorPubkey];
+    if (bucket == null) return false;
+
+    final index = bucket.indexWhere((video) => video.id == videoId);
+    if (index == -1) return false;
+
+    bucket[index] = updated;
+    _invalidate(authorPubkey);
+    return true;
+  }
+
+  bool addOrUpdateByVine(
+    VideoEvent video, {
+    required String authorPubkey,
+    required bool isHistorical,
+  }) {
+    final bucket = _buckets.putIfAbsent(authorPubkey, () => []);
+    final existingIndex = bucket.indexWhere(
+      (existing) =>
+          existing.vineId == video.vineId && existing.pubkey == video.pubkey,
+    );
+
+    if (existingIndex != -1) {
+      if (video.createdAt > bucket[existingIndex].createdAt) {
+        bucket[existingIndex] = video;
+        _invalidate(authorPubkey);
+      }
+      return false;
+    }
+
+    if (isHistorical) {
+      bucket.add(video);
+    } else {
+      bucket.insert(0, video);
+    }
+    _invalidate(authorPubkey);
+    return true;
+  }
+
+  bool replaceByStableId(
+    String authorPubkey,
+    VideoEvent updated, {
+    required VideoMerge merge,
+  }) {
+    final bucket = _buckets[authorPubkey];
+    if (bucket == null) return false;
+
+    final index = bucket.indexWhere(
+      (existing) =>
+          existing.stableId == updated.stableId &&
+          existing.pubkey == updated.pubkey,
+    );
+    if (index == -1) return false;
+
+    bucket[index] = merge(bucket[index], updated);
+    _invalidate(authorPubkey);
+    return true;
+  }
+
+  int removeWhere(
+    bool Function(VideoEvent video) shouldRemove, {
+    BucketRemoved? onBucketRemoved,
+  }) {
+    var removedTotal = 0;
+    for (final entry in _buckets.entries) {
+      final initialLength = entry.value.length;
+      entry.value.removeWhere(shouldRemove);
+      final removed = initialLength - entry.value.length;
+      if (removed > 0) {
+        removedTotal += removed;
+        _invalidate(entry.key);
+        onBucketRemoved?.call(entry.key, removed);
+      }
+    }
+    return removedTotal;
+  }
+
+  void _invalidate(String authorPubkey) {
+    _sortedViews.remove(authorPubkey);
+  }
+}
+
+int _newestFirstThenId(VideoEvent a, VideoEvent b) {
+  final createdAt = b.createdAt.compareTo(a.createdAt);
+  if (createdAt != 0) return createdAt;
+  return b.id.compareTo(a.id);
+}

--- a/mobile/lib/services/author_video_buckets.dart
+++ b/mobile/lib/services/author_video_buckets.dart
@@ -3,32 +3,53 @@
 
 import 'package:models/models.dart';
 
+/// Combines the cached and the incoming version of the same video.
 typedef VideoMerge =
     VideoEvent Function(VideoEvent existing, VideoEvent updated);
+
+/// Reports how many videos [AuthorVideoBuckets.removeWhere] dropped from one
+/// author's bucket.
 typedef BucketRemoved = void Function(String authorPubkey, int removedCount);
 
+/// Per-author video buckets behind a memoized newest-first view.
+///
+/// Every mutating method invalidates the cached view for the author it
+/// touched, so [videosFor] keeps returning the same list instance until that
+/// author's bucket actually changes. Profile feeds read on every app-wide
+/// `VideoEventService` notification, so a read must not sort or allocate.
 class AuthorVideoBuckets {
   final Map<String, List<VideoEvent>> _buckets = {};
   final Map<String, List<VideoEvent>> _sortedViews = {};
 
+  /// Whether a bucket exists for [authorPubkey], even when it holds no videos.
   bool contains(String authorPubkey) => _buckets.containsKey(authorPubkey);
 
+  /// Replaces [authorPubkey]'s bucket with a copy of [videos].
   void seed(String authorPubkey, List<VideoEvent> videos) {
     _buckets[authorPubkey] = List.of(videos);
     _invalidate(authorPubkey);
   }
 
+  /// Lazily yields [authorPubkey]'s videos in bucket order.
+  ///
+  /// Use this for membership checks; [videosFor] is the ordered read.
   Iterable<VideoEvent> videosForAuthorUnsorted(String authorPubkey) sync* {
     final videos = _buckets[authorPubkey];
     if (videos != null) yield* videos;
   }
 
+  /// Lazily yields every cached video across all authors, in no useful order.
   Iterable<VideoEvent> get allVideos sync* {
     for (final videos in _buckets.values) {
       yield* videos;
     }
   }
 
+  /// Returns [authorPubkey]'s videos newest first, as an unmodifiable list.
+  ///
+  /// The same instance comes back on every call until that author's bucket
+  /// changes, so `identical` comparisons upstream stay meaningful. An author
+  /// with no videos always yields the canonical empty list.
   List<VideoEvent> videosFor(String authorPubkey) {
     final bucket = _buckets[authorPubkey];
     if (bucket == null || bucket.isEmpty) return const [];
@@ -39,6 +60,9 @@ class AuthorVideoBuckets {
     });
   }
 
+  /// Adds the [candidates] whose (case-insensitive) event id is not cached yet.
+  ///
+  /// Creates the bucket when it is missing. Returns how many were added.
   int backfillUniqueById(String authorPubkey, Iterable<VideoEvent> candidates) {
     final bucket = _buckets.putIfAbsent(authorPubkey, () => []);
     final seenBucketIds = {for (final video in bucket) video.id.toLowerCase()};
@@ -55,6 +79,9 @@ class AuthorVideoBuckets {
     return added;
   }
 
+  /// Swaps the cached video with event id [videoId] for [updated].
+  ///
+  /// Returns whether a match was found.
   bool replaceById(String authorPubkey, String videoId, VideoEvent updated) {
     final bucket = _buckets[authorPubkey];
     if (bucket == null) return false;
@@ -67,6 +94,12 @@ class AuthorVideoBuckets {
     return true;
   }
 
+  /// Caches [video], deduplicating addressable (NIP-71) events by
+  /// `(pubkey, vineId)` because each edit mints a new event id.
+  ///
+  /// An existing entry is overwritten only by a newer `createdAt`. New videos
+  /// go to the front unless [isHistorical]. Creates the bucket when it is
+  /// missing. Returns whether this added a video rather than updating one.
   bool addOrUpdateByVine(
     VideoEvent video, {
     required String authorPubkey,
@@ -95,6 +128,10 @@ class AuthorVideoBuckets {
     return true;
   }
 
+  /// Merges [updated] into the cached video with the same `stableId` and
+  /// `pubkey`, using [merge] to combine the two versions.
+  ///
+  /// Returns whether a match was found.
   bool replaceByStableId(
     String authorPubkey,
     VideoEvent updated, {
@@ -115,6 +152,10 @@ class AuthorVideoBuckets {
     return true;
   }
 
+  /// Drops every video matching [shouldRemove] from every author's bucket.
+  ///
+  /// [onBucketRemoved] fires once per author that actually lost videos.
+  /// Returns the total number removed.
   int removeWhere(
     bool Function(VideoEvent video) shouldRemove, {
     BucketRemoved? onBucketRemoved,
@@ -138,6 +179,11 @@ class AuthorVideoBuckets {
   }
 }
 
+/// Newest first, breaking `createdAt` ties on descending event id.
+///
+/// The tie-break is what makes the memoized view reproducible: `List.sort` is
+/// not stable, so videos sharing a second would otherwise land in an arbitrary
+/// order that changes every time the view is rebuilt.
 int _newestFirstThenId(VideoEvent a, VideoEvent b) {
   final createdAt = b.createdAt.compareTo(a.createdAt);
   if (createdAt != 0) return createdAt;

--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -5975,14 +5975,15 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
       }
     }
 
-    // Also update in author buckets (used by profile feeds)
-    foundAny =
-        _authorBuckets.replaceByStableId(
-          updatedVideo.pubkey,
-          updatedVideo,
-          merge: _mergeUpdatedVideo,
-        ) ||
-        foundAny;
+    // Also update in author buckets (used by profile feeds). Kept out of the
+    // `||` so the bucket update cannot be short-circuited away once an earlier
+    // cache has already matched.
+    final replacedInAuthorBucket = _authorBuckets.replaceByStableId(
+      updatedVideo.pubkey,
+      updatedVideo,
+      merge: _mergeUpdatedVideo,
+    );
+    foundAny = foundAny || replacedInAuthorBucket;
 
     if (foundAny) {
       notifyListeners();

--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -31,6 +31,7 @@ import 'package:openvine/constants/app_constants.dart';
 import 'package:openvine/constants/nip71_migration.dart';
 import 'package:openvine/extensions/video_event_extensions.dart';
 import 'package:openvine/models/content_label.dart';
+import 'package:openvine/services/author_video_buckets.dart';
 import 'package:openvine/services/broken_video_tracker.dart';
 import 'package:openvine/services/connection_status_service.dart';
 import 'package:openvine/services/content_filter_service.dart';
@@ -174,7 +175,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
 
   // Keyed event lists for hashtag and author feeds (route-aware)
   final Map<String, List<VideoEvent>> _hashtagBuckets = {};
-  final Map<String, List<VideoEvent>> _authorBuckets = {};
+  final AuthorVideoBuckets _authorBuckets = AuthorVideoBuckets();
 
   // Track active subscriptions per type
   final Map<SubscriptionType, String> _activeSubscriptions = {};
@@ -412,11 +413,8 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
     // video can appear in multiple buckets simultaneously.
     final ids = <String>{};
 
-    final authorBucket = _authorBuckets[pubkey];
-    if (authorBucket != null) {
-      for (final video in authorBucket) {
-        ids.add(video.id);
-      }
+    for (final video in _authorBuckets.videosForAuthorUnsorted(pubkey)) {
+      ids.add(video.id);
     }
 
     for (final list in _eventLists.values) {
@@ -448,7 +446,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
   /// APIs instead.
   @visibleForTesting
   void debugSeedAuthorBucket(String pubkey, List<VideoEvent> videos) {
-    _authorBuckets[pubkey] = List.of(videos);
+    _authorBuckets.seed(pubkey, videos);
   }
 
   /// Set the likes repository for fetching live like counts
@@ -913,29 +911,8 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
 
   /// Get videos for a specific author (keyed for route-aware feeds)
   /// Always returns videos sorted in reverse chronological order (newest first)
-  List<VideoEvent> authorVideos(String pubkeyHex) {
-    final cached = _authorBuckets[pubkeyHex] ?? const [];
-    Log.info(
-      'SVC authorVideos: hex=$pubkeyHex cached=${cached.length}',
-      name: 'Service',
-      category: LogCategory.video,
-    );
-    if (cached.isEmpty) {
-      return cached;
-    }
-
-    // Always sort by newest first before returning to ensure consistent ordering
-    // This is critical for profile grids to display newest videos at the top
-    final sorted = List<VideoEvent>.from(cached);
-    sorted.sort((a, b) => b.createdAt.compareTo(a.createdAt));
-
-    Log.info(
-      'SVC authorVideos: return sorted=${sorted.length} (newest first)',
-      name: 'Service',
-      category: LogCategory.video,
-    );
-    return sorted;
-  }
+  List<VideoEvent> authorVideos(String pubkeyHex) =>
+      _authorBuckets.videosFor(pubkeyHex);
 
   /// Get search results
   List<VideoEvent> get searchResults => getVideos(SubscriptionType.search);
@@ -1086,23 +1063,21 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
     }
 
     // Remove from all author buckets
-    for (final entry in _authorBuckets.entries) {
-      final initialLength = entry.value.length;
-      entry.value.removeWhere((video) {
+    _authorBuckets.removeWhere(
+      (video) {
         final remove = shouldRemove(video);
         if (remove) removedVideoIds.add(video.id);
         return remove;
-      });
-      final removed = initialLength - entry.value.length;
-      if (removed > 0) {
+      },
+      onBucketRemoved: (authorPubkey, removed) {
         removedCount += removed;
         Log.debug(
-          'Removed video $logIdentity from author bucket ${entry.key}',
+          'Removed video $logIdentity from author bucket $authorPubkey',
           name: 'VideoEventService',
           category: LogCategory.video,
         );
-      }
-    }
+      },
+    );
 
     // Remove from all hashtag buckets
     for (final entry in _hashtagBuckets.entries) {
@@ -1388,9 +1363,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
     for (final videos in _eventLists.values) {
       yield* videos;
     }
-    for (final videos in _authorBuckets.values) {
-      yield* videos;
-    }
+    yield* _authorBuckets.allVideos;
     for (final videos in _hashtagBuckets.values) {
       yield* videos;
     }
@@ -1427,15 +1400,11 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
       removedCount += initialLength - entry.value.length;
     }
 
-    for (final entry in _authorBuckets.entries) {
-      final initialLength = entry.value.length;
-      entry.value.removeWhere((video) {
-        final remove = shouldRemove(video);
-        if (remove) removedVideoIds.add(video.id);
-        return remove;
-      });
-      removedCount += initialLength - entry.value.length;
-    }
+    removedCount += _authorBuckets.removeWhere((video) {
+      final remove = shouldRemove(video);
+      if (remove) removedVideoIds.add(video.id);
+      return remove;
+    });
 
     for (final entry in _hashtagBuckets.entries) {
       final initialLength = entry.value.length;
@@ -3371,7 +3340,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
       category: LogCategory.video,
     );
 
-    // Backfill _authorBuckets with videos by this author that already exist in other subscription types
+    // Backfill the author bucket with videos by this author that already exist in other subscription types
     // This handles the case where the user's videos were already loaded in discovery/home feeds
     // Also includes reposts BY this user (where reposterPubkey matches)
     //
@@ -3380,8 +3349,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
     // allocations per comparison). This loop runs synchronously on the main
     // thread on every subscribe call, so for an author with many videos and a
     // large cross-feed cache the quadratic form blocked the UI for seconds.
-    final bucket = _authorBuckets.putIfAbsent(pubkey, () => []);
-    final seenBucketIds = {for (final e in bucket) e.id.toLowerCase()};
+    final backfillCandidates = <VideoEvent>[];
     for (final eventList in _eventLists.values) {
       for (final video in eventList) {
         // Include original videos by this author
@@ -3391,18 +3359,14 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
             video.isRepost && video.reposterPubkey == pubkey;
         if (!isOriginalByAuthor && !isRepostByAuthor) continue;
 
-        // Set.add returns false when the (case-insensitive) ID is already
-        // present, giving O(1) dedup in place of the previous linear scan.
-        if (seenBucketIds.add(video.id.toLowerCase())) {
-          bucket.add(video);
-        }
+        backfillCandidates.add(video);
       }
     }
-    // Sort backfilled videos by newest first
-    if (bucket.isNotEmpty) {
-      bucket.sort((a, b) => b.createdAt.compareTo(a.createdAt));
+    _authorBuckets.backfillUniqueById(pubkey, backfillCandidates);
+    final authorVideoCount = _authorBuckets.videosFor(pubkey).length;
+    if (authorVideoCount > 0) {
       Log.info(
-        'SVC subscribeToUser: backfilled ${bucket.length} existing videos for $pubkey',
+        'SVC subscribeToUser: backfilled $authorVideoCount existing videos for $pubkey',
         name: 'Service',
         category: LogCategory.video,
       );
@@ -5154,7 +5118,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
       // This ensures profile views stay up-to-date when videos arrive later
       // in discovery/home feeds (fixes stale 0-video profile state).
       if (authorHex != currentUserPubkey &&
-          _authorBuckets.containsKey(authorHex)) {
+          _authorBuckets.contains(authorHex)) {
         _addToAuthorBucket(videoEvent, authorHex, isHistorical: isHistorical);
       }
     }
@@ -5358,13 +5322,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
       final authorHex = videoEvent.isRepost && videoEvent.reposterPubkey != null
           ? videoEvent.reposterPubkey!
           : videoEvent.pubkey;
-      final bucket = _authorBuckets[authorHex];
-      if (bucket != null) {
-        final bucketIndex = bucket.indexWhere((v) => v.id == videoId);
-        if (bucketIndex != -1) {
-          bucket[bucketIndex] = updatedVideo;
-        }
-      }
+      _authorBuckets.replaceById(authorHex, videoId, updatedVideo);
     }
 
     return true;
@@ -5397,30 +5355,11 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
     VideoEvent videoEvent,
     String authorHex, {
     required bool isHistorical,
-  }) {
-    final bucket = _authorBuckets.putIfAbsent(authorHex, () => []);
-
-    // For addressable events (NIP-71), deduplicate by (pubkey, vineId) pair
-    // since each update creates a new event ID but same vineId
-    final existingIndex = bucket.indexWhere(
-      (e) => e.vineId == videoEvent.vineId && e.pubkey == videoEvent.pubkey,
-    );
-
-    if (existingIndex != -1) {
-      // Replace existing video with newer version (higher createdAt wins)
-      if (videoEvent.createdAt > bucket[existingIndex].createdAt) {
-        bucket[existingIndex] = videoEvent;
-      }
-      return false; // Not a new video, just an update
-    } else {
-      if (isHistorical) {
-        bucket.add(videoEvent);
-      } else {
-        bucket.insert(0, videoEvent);
-      }
-      return true; // New video was added
-    }
-  }
+  }) => _authorBuckets.addOrUpdateByVine(
+    videoEvent,
+    authorPubkey: authorHex,
+    isHistorical: isHistorical,
+  );
 
   /// Check if the given subscription parameters match the current active subscription for this type
   bool _isDuplicateSubscription(
@@ -6037,20 +5976,13 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
     }
 
     // Also update in author buckets (used by profile feeds)
-    final authorBucket = _authorBuckets[updatedVideo.pubkey];
-    if (authorBucket != null) {
-      final bucketIndex = authorBucket.indexWhere(
-        (existing) =>
-            existing.stableId == updatedVideo.stableId &&
-            existing.pubkey == updatedVideo.pubkey,
-      );
-      if (bucketIndex != -1) {
-        final existingVideo = authorBucket[bucketIndex];
-        final mergedVideo = _mergeUpdatedVideo(existingVideo, updatedVideo);
-        authorBucket[bucketIndex] = mergedVideo;
-        foundAny = true;
-      }
-    }
+    foundAny =
+        _authorBuckets.replaceByStableId(
+          updatedVideo.pubkey,
+          updatedVideo,
+          merge: _mergeUpdatedVideo,
+        ) ||
+        foundAny;
 
     if (foundAny) {
       notifyListeners();

--- a/mobile/test/services/author_video_buckets_test.dart
+++ b/mobile/test/services/author_video_buckets_test.dart
@@ -1,0 +1,104 @@
+// ABOUTME: Tests per-author video bucket memoization and invalidation.
+// ABOUTME: Guards profile feed reads against repeated sort/allocation churn.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart';
+import 'package:openvine/services/author_video_buckets.dart';
+
+const _authorA =
+    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const _authorB =
+    'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+VideoEvent _video(
+  String id, {
+  required String pubkey,
+  required int createdAt,
+  String? vineId,
+  int? nostrLikeCount,
+}) => VideoEvent(
+  id: id,
+  pubkey: pubkey,
+  createdAt: createdAt,
+  content: 'content $id',
+  timestamp: DateTime.fromMillisecondsSinceEpoch(createdAt * 1000),
+  title: 'Video $id',
+  videoUrl: 'https://example.com/$id.mp4',
+  vineId: vineId ?? id,
+  nostrLikeCount: nostrLikeCount,
+);
+
+void main() {
+  group('AuthorVideoBuckets', () {
+    test('memoizes a sorted immutable view until the bucket changes', () {
+      final buckets = AuthorVideoBuckets()
+        ..seed(_authorA, [
+          _video('old', pubkey: _authorA, createdAt: 100),
+          _video('newer-b', pubkey: _authorA, createdAt: 200),
+          _video('newer-a', pubkey: _authorA, createdAt: 200),
+        ]);
+
+      final first = buckets.videosFor(_authorA);
+      final second = buckets.videosFor(_authorA);
+
+      expect(identical(first, second), isTrue);
+      expect(first.map((video) => video.id), ['newer-b', 'newer-a', 'old']);
+      expect(
+        () => first.add(_video('x', pubkey: _authorA, createdAt: 300)),
+        throwsUnsupportedError,
+      );
+    });
+
+    test('changing another author does not invalidate this author', () {
+      final buckets = AuthorVideoBuckets()
+        ..seed(_authorA, [_video('a', pubkey: _authorA, createdAt: 100)]);
+      final before = buckets.videosFor(_authorA);
+
+      buckets.addOrUpdateByVine(
+        _video('b', pubkey: _authorB, createdAt: 200),
+        authorPubkey: _authorB,
+        isHistorical: false,
+      );
+
+      expect(identical(buckets.videosFor(_authorA), before), isTrue);
+    });
+
+    test('add, replace, stable update, and removal invalidate the author', () {
+      final buckets = AuthorVideoBuckets()
+        ..seed(_authorA, [_video('a', pubkey: _authorA, createdAt: 100)]);
+
+      final initial = buckets.videosFor(_authorA);
+      buckets.addOrUpdateByVine(
+        _video('b', pubkey: _authorA, createdAt: 200),
+        authorPubkey: _authorA,
+        isHistorical: false,
+      );
+      final afterAdd = buckets.videosFor(_authorA);
+      expect(identical(afterAdd, initial), isFalse);
+      expect(afterAdd.map((video) => video.id), ['b', 'a']);
+
+      buckets.replaceById(
+        _authorA,
+        'a',
+        _video('a', pubkey: _authorA, createdAt: 100, nostrLikeCount: 7),
+      );
+      final afterReplace = buckets.videosFor(_authorA);
+      expect(identical(afterReplace, afterAdd), isFalse);
+      expect(afterReplace.last.nostrLikeCount, 7);
+
+      buckets.replaceByStableId(
+        _authorA,
+        _video('a-new-id', pubkey: _authorA, createdAt: 300, vineId: 'a'),
+        merge: (_, updated) => updated,
+      );
+      final afterStableUpdate = buckets.videosFor(_authorA);
+      expect(identical(afterStableUpdate, afterReplace), isFalse);
+      expect(afterStableUpdate.map((video) => video.id), ['a-new-id', 'b']);
+
+      buckets.removeWhere((video) => video.id == 'b');
+      final afterRemove = buckets.videosFor(_authorA);
+      expect(identical(afterRemove, afterStableUpdate), isFalse);
+      expect(afterRemove.map((video) => video.id), ['a-new-id']);
+    });
+  });
+}

--- a/mobile/test/services/video_event_service_author_videos_identity_test.dart
+++ b/mobile/test/services/video_event_service_author_videos_identity_test.dart
@@ -1,0 +1,192 @@
+// ABOUTME: Regression tests for VideoEventService.authorVideos stable identity.
+// ABOUTME: Protects profile feeds from read-time sorting and log capture churn.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart' hide NIP71VideoKinds;
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/nostr_sdk.dart';
+import 'package:openvine/constants/nip71_migration.dart';
+import 'package:openvine/services/subscription_manager.dart';
+import 'package:openvine/services/video_event_service.dart';
+import 'package:unified_logger/unified_logger.dart';
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _MockSubscriptionManager extends Mock implements SubscriptionManager {}
+
+const _authorA =
+    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const _authorB =
+    'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+VideoEvent _video(
+  String id, {
+  required String pubkey,
+  required int createdAt,
+  String? vineId,
+  int? nostrLikeCount,
+}) => VideoEvent(
+  id: id,
+  pubkey: pubkey,
+  createdAt: createdAt,
+  content: 'content $id',
+  timestamp: DateTime.fromMillisecondsSinceEpoch(createdAt * 1000),
+  title: 'Video $id',
+  videoUrl: 'https://example.com/$id.mp4',
+  vineId: vineId ?? id,
+  nostrLikeCount: nostrLikeCount,
+);
+
+Event _event(
+  String id, {
+  required String pubkey,
+  required int createdAt,
+  String? dTag,
+}) {
+  final event = Event(
+    pubkey,
+    NIP71VideoKinds.addressableShortVideo,
+    [
+      ['d', dTag ?? id],
+      ['url', 'https://example.com/$id.mp4'],
+      ['title', 'Video $id'],
+    ],
+    'content $id',
+    createdAt: createdAt,
+  );
+  event.id = id;
+  return event;
+}
+
+void main() {
+  group('VideoEventService.authorVideos identity', () {
+    late VideoEventService service;
+    late _MockNostrClient nostr;
+
+    setUp(() async {
+      await LogCaptureService().clearAllLogs();
+      nostr = _MockNostrClient();
+      when(() => nostr.publicKey).thenReturn('');
+      service = VideoEventService(
+        nostr,
+        subscriptionManager: _MockSubscriptionManager(),
+      );
+    });
+
+    tearDown(() async {
+      service.dispose();
+      await LogCaptureService().clearAllLogs();
+    });
+
+    test('returns the same sorted list until that author changes', () {
+      service.debugSeedAuthorBucket(_authorA, [
+        _video('a-old', pubkey: _authorA, createdAt: 100),
+        _video('a-new', pubkey: _authorA, createdAt: 200),
+      ]);
+
+      final first = service.authorVideos(_authorA);
+      final second = service.authorVideos(_authorA);
+
+      expect(identical(first, second), isTrue);
+      expect(first.map((video) => video.id), ['a-new', 'a-old']);
+    });
+
+    test(
+      'ingesting another author leaves the current author list identical',
+      () {
+        service.debugSeedAuthorBucket(_authorA, [
+          _video('a-old', pubkey: _authorA, createdAt: 100),
+        ]);
+        final before = service.authorVideos(_authorA);
+
+        service.handleEventForTesting(
+          _event('b-new', pubkey: _authorB, createdAt: 300),
+          SubscriptionType.profile,
+        );
+
+        expect(identical(service.authorVideos(_authorA), before), isTrue);
+      },
+    );
+
+    test('ingesting this author yields a new newest-first list', () {
+      service.debugSeedAuthorBucket(_authorA, [
+        _video('a-old', pubkey: _authorA, createdAt: 100),
+      ]);
+      final before = service.authorVideos(_authorA);
+
+      service.handleEventForTesting(
+        _event('a-new', pubkey: _authorA, createdAt: 300),
+        SubscriptionType.profile,
+      );
+
+      final after = service.authorVideos(_authorA);
+      expect(identical(after, before), isFalse);
+      expect(after.map((video) => video.id), ['a-new', 'a-old']);
+    });
+
+    test(
+      'removal, like count, and replaceable update invalidate the author',
+      () {
+        service.handleEventForTesting(
+          _event(
+            'a-original',
+            pubkey: _authorA,
+            createdAt: 100,
+            dTag: 'stable-a',
+          ),
+          SubscriptionType.profile,
+        );
+        final initial = service.authorVideos(_authorA);
+
+        expect(
+          service.applyLikeCountForTesting(
+            'a-original',
+            9,
+            SubscriptionType.profile,
+          ),
+          isTrue,
+        );
+        final afterLikeCount = service.authorVideos(_authorA);
+        expect(identical(afterLikeCount, initial), isFalse);
+        expect(afterLikeCount.single.nostrLikeCount, 9);
+
+        service.updateVideoEvent(
+          _video(
+            'a-replaceable-update',
+            pubkey: _authorA,
+            createdAt: 300,
+            vineId: 'stable-a',
+          ),
+        );
+        final afterReplaceableUpdate = service.authorVideos(_authorA);
+        expect(identical(afterReplaceableUpdate, afterLikeCount), isFalse);
+        expect(afterReplaceableUpdate.single.id, 'a-replaceable-update');
+
+        service.removeVideoCompletely('a-replaceable-update');
+        final afterRemoval = service.authorVideos(_authorA);
+        expect(identical(afterRemoval, afterReplaceableUpdate), isFalse);
+        expect(afterRemoval, isEmpty);
+      },
+    );
+
+    test('does not capture logs when reading authorVideos', () {
+      service.debugSeedAuthorBucket(_authorA, [
+        _video('a-old', pubkey: _authorA, createdAt: 100),
+      ]);
+      LogCaptureService().clearAllLogs();
+
+      service.authorVideos(_authorA);
+      service.authorVideos(_authorA);
+
+      final messages = LogCaptureService()
+          .getRecentLogs()
+          .map((entry) => entry.message)
+          .toList();
+      expect(
+        messages.where((message) => message.startsWith('SVC authorVideos:')),
+        isEmpty,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Move profile author buckets behind an AuthorVideoBuckets helper with memoized immutable newest-first views
- Stop authorVideos() from sorting and logging on every read
- Invalidate cached author views from add, backfill, removal, like-count, and replaceable-update paths

## Notes
The issue body called out Riverpod select() as the rebuild driver. The PR fixes the real shared service hot path: ProfileFeedCubit listens to app-wide VideoEventService notifications and repeatedly reads authorVideos() during unrelated relay traffic.

Closes #7404

## Verification
- flutter test test/services/author_video_buckets_test.dart test/services/video_event_service_author_videos_identity_test.dart test/services/video_event_service_profile_logging_test.dart test/services/video_event_service_author_backfill_test.dart test/blocs/profile_feed/profile_feed_cubit_test.dart test/providers/profile_feed_providers_test.dart
- flutter analyze
- bash mobile/scripts/check_untested_services_floor.sh
- git diff --check