### PR TITLE
fix(analytics): name shell route pages

### DIFF
--- a/mobile/lib/router/fade_upwards_page.dart
+++ b/mobile/lib/router/fade_upwards_page.dart
@@ -3,6 +3,7 @@
 
 import 'package:flutter/widgets.dart';
 import 'package:go_router/go_router.dart';
+import 'package:openvine/router/go_router_page_name.dart';
 
 /// Wraps [child] in a page that fades in while sliding up the last
 /// quarter — the classic pre-Pie Android transition.
@@ -17,7 +18,7 @@ CustomTransitionPage<void> fadeUpwardsPage({
 }) {
   return CustomTransitionPage<void>(
     key: state.pageKey,
-    name: state.name ?? state.path,
+    name: goRouterPageName(state),
     arguments: <String, String>{
       ...state.pathParameters,
       ...state.uri.queryParameters,

--- a/mobile/lib/router/go_router_page_name.dart
+++ b/mobile/lib/router/go_router_page_name.dart
@@ -1,0 +1,13 @@
+// ABOUTME: Shared go_router page-name resolution for analytics route settings.
+// ABOUTME: Keeps ShellRoute pages from falling back to unknown_route.
+
+import 'package:go_router/go_router.dart';
+
+/// Returns the stable page name go_router would put on a regular [GoRoute].
+///
+/// Shell route states do not receive [GoRouterState.name] or
+/// [GoRouterState.path], so fall back to the matched leaf route exposed through
+/// [GoRouterState.topRoute].
+String? goRouterPageName(GoRouterState state) {
+  return state.name ?? state.path ?? state.topRoute?.name ?? state.fullPath;
+}

--- a/mobile/lib/router/routes/settings_routes.dart
+++ b/mobile/lib/router/routes/settings_routes.dart
@@ -11,6 +11,7 @@ import 'package:openvine/features/feature_flags/screens/feature_flag_screen.dart
 import 'package:openvine/models/authentication_source.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/invite_availability_providers.dart';
+import 'package:openvine/router/go_router_page_name.dart';
 import 'package:openvine/router/invite_availability_redirects.dart';
 import 'package:openvine/screens/badges/badge_award_screen.dart';
 import 'package:openvine/screens/badges/badge_detail_screen.dart';
@@ -244,8 +245,14 @@ List<RouteBase> settingsRoutes(Ref ref) {
     GoRoute(
       path: DeveloperOptionsScreen.path,
       name: DeveloperOptionsScreen.routeName,
-      pageBuilder: (context, state) => CustomTransitionPage(
+      pageBuilder: (_, state) => CustomTransitionPage(
         key: state.pageKey,
+        name: goRouterPageName(state),
+        arguments: <String, String>{
+          ...state.pathParameters,
+          ...state.uri.queryParameters,
+        },
+        restorationId: state.pageKey.value,
         child: const DeveloperOptionsScreen(),
         transitionsBuilder: (context, animation, secondaryAnimation, child) {
           return SlideTransition(

--- a/mobile/lib/router/routes/shell.dart
+++ b/mobile/lib/router/routes/shell.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:openvine/notifications/view/notifications_page.dart';
 import 'package:openvine/router/app_shell.dart';
+import 'package:openvine/router/go_router_page_name.dart';
 import 'package:openvine/router/navigator_keys.dart';
 import 'package:openvine/router/providers/page_context_provider.dart';
 import 'package:openvine/router/routes/router_guards.dart';
@@ -36,7 +37,7 @@ List<RouteBase> shellRoutes() {
       // #5242 in its post-splash form. Pinned by shell_transition_test.
       pageBuilder: (context, state, navigationShell) => NoTransitionPage<void>(
         key: state.pageKey,
-        name: state.name ?? state.path,
+        name: goRouterPageName(state),
         arguments: <String, String>{
           ...state.pathParameters,
           ...state.uri.queryParameters,
@@ -190,7 +191,7 @@ List<RouteBase> shellRoutes() {
 Page<void> _branchPage(GoRouterState state, Widget child) {
   return NoTransitionPage<void>(
     key: state.pageKey,
-    name: state.name ?? state.path,
+    name: goRouterPageName(state),
     arguments: <String, String>{
       ...state.pathParameters,
       ...state.uri.queryParameters,

--- a/mobile/test/router/go_router_page_name_test.dart
+++ b/mobile/test/router/go_router_page_name_test.dart
@@ -1,0 +1,72 @@
+// ABOUTME: Pins shared go_router page-name fallback behavior.
+// ABOUTME: Covers shell states whose name and path are null in production.
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:openvine/router/go_router_page_name.dart';
+
+class _FakeGoRouterState extends Fake implements GoRouterState {
+  _FakeGoRouterState({this.name, this.path, this.topRoute, this.fullPath});
+
+  @override
+  final String? name;
+
+  @override
+  final String? path;
+
+  @override
+  final GoRoute? topRoute;
+
+  @override
+  final String? fullPath;
+}
+
+GoRoute _goRoute({required String path, required String name}) {
+  return GoRoute(
+    path: path,
+    name: name,
+    builder: (_, _) => const SizedBox.shrink(),
+  );
+}
+
+void main() {
+  group(goRouterPageName, () {
+    test('prefers the explicit route name', () {
+      expect(
+        goRouterPageName(
+          _FakeGoRouterState(
+            name: 'video-recorder',
+            path: '/video-recorder',
+            topRoute: _goRoute(path: '/home', name: 'home'),
+            fullPath: '/home',
+          ),
+        ),
+        'video-recorder',
+      );
+    });
+
+    test('falls back to route path when a route has no name', () {
+      expect(goRouterPageName(_FakeGoRouterState(path: '/drafts')), '/drafts');
+    });
+
+    test('uses topRoute name for shell states', () {
+      expect(
+        goRouterPageName(
+          _FakeGoRouterState(
+            topRoute: _goRoute(path: '/home', name: 'home'),
+            fullPath: '/home',
+          ),
+        ),
+        'home',
+      );
+    });
+
+    test('falls back to fullPath when no stable name is available', () {
+      expect(
+        goRouterPageName(_FakeGoRouterState(fullPath: '/explore/:name')),
+        '/explore/:name',
+      );
+    });
+  });
+}

--- a/mobile/test/router/shell_route_analytics_test.dart
+++ b/mobile/test/router/shell_route_analytics_test.dart
@@ -1,0 +1,61 @@
+// ABOUTME: Regression coverage for shell route names reaching observers.
+// ABOUTME: Prevents normal home navigation from reporting unknown_route.
+
+import 'package:analytics/analytics.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:openvine/router/go_router_page_name.dart';
+import 'package:openvine/screens/feed/video_feed_page.dart';
+
+class _RecordingNavigatorObserver extends NavigatorObserver {
+  final pushedNames = <String?>[];
+
+  @override
+  void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    super.didPush(route, previousRoute);
+    pushedNames.add(route.settings.name);
+  }
+}
+
+void main() {
+  testWidgets('shell home route pushes a named root route for analytics', (
+    tester,
+  ) async {
+    final observer = _RecordingNavigatorObserver();
+    final router = GoRouter(
+      initialLocation: VideoFeedPage.path,
+      observers: [observer],
+      routes: [
+        StatefulShellRoute.indexedStack(
+          pageBuilder: (_, state, navigationShell) => NoTransitionPage<void>(
+            key: state.pageKey,
+            name: goRouterPageName(state),
+            child: navigationShell,
+          ),
+          branches: [
+            StatefulShellBranch(
+              routes: [
+                GoRoute(
+                  path: VideoFeedPage.path,
+                  name: VideoFeedPage.routeName,
+                  builder: (_, _) => const SizedBox.shrink(),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ],
+    );
+    addTearDown(router.dispose);
+
+    await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+    await tester.pump();
+
+    expect(observer.pushedNames, contains(VideoFeedPage.routeName));
+    expect(
+      AnalyticsSurface.routeSurfaceName(VideoFeedPage.routeName),
+      isNot(AnalyticsSurface.unknownRoute),
+    );
+  });
+}

--- a/mobile/test/router/shell_route_analytics_test.dart
+++ b/mobile/test/router/shell_route_analytics_test.dart
@@ -55,7 +55,7 @@ void main() {
     expect(observer.pushedNames, contains(VideoFeedPage.routeName));
     expect(
       AnalyticsSurface.routeSurfaceName(VideoFeedPage.routeName),
-      isNot(AnalyticsSurface.unknownRoute),
+      AnalyticsSurface.homeFeed,
     );
   });
 }

--- a/mobile/test/router/shell_transition_test.dart
+++ b/mobile/test/router/shell_transition_test.dart
@@ -9,16 +9,24 @@ import 'package:go_router/go_router.dart';
 import 'package:openvine/router/router.dart';
 import 'package:openvine/router/routes/shell.dart';
 import 'package:openvine/screens/feed/home_feed_retap_cubit.dart';
+import 'package:openvine/screens/feed/video_feed_page.dart';
 
 class _FakeGoRouterState extends Fake implements GoRouterState {
   @override
   ValueKey<String> get pageKey => const ValueKey('shell');
 
   @override
-  String? get name => 'home';
+  String? get name => null;
 
   @override
-  String? get path => '/home';
+  String? get path => null;
+
+  @override
+  GoRoute? get topRoute => GoRoute(
+    path: VideoFeedPage.path,
+    name: VideoFeedPage.routeName,
+    builder: (_, _) => const SizedBox.shrink(),
+  );
 
   @override
   Map<String, String> get pathParameters => const {'tab': 'feed'};
@@ -71,7 +79,7 @@ void main() {
       expect(transitionPage.key, const ValueKey('shell'));
       // Page metadata feeds PageLoadObserver; without it the shell route
       // reports as an unnamed page and startup navigations go untracked.
-      expect(transitionPage.name, 'home');
+      expect(transitionPage.name, VideoFeedPage.routeName);
       expect(transitionPage.restorationId, 'shell');
       expect(transitionPage.arguments, <String, String>{
         'tab': 'feed',


### PR DESCRIPTION
## Summary
- add shared go_router page-name resolution that falls back to `topRoute` for shell states
- apply the resolved page name to the bottom-nav shell, branch pages, fade-upwards pages, and Developer Options transition page
- add regression coverage for shell route names reaching root navigator observers

## Verification
- `flutter test test/router/go_router_page_name_test.dart test/router/fade_upwards_page_test.dart test/router/shell_transition_test.dart test/router/shell_route_analytics_test.dart`
- `flutter analyze`
- pre-push hook: analyzer + changed-file router tests

Closes #7405
