### PR TITLE
feat(profile): give the Divine team the profile checkmark

### DIFF
--- a/mobile/lib/config/official_accounts.dart
+++ b/mobile/lib/config/official_accounts.dart
@@ -1,6 +1,6 @@
-// ABOUTME: Pinned set of official Divine accounts a protected minor (13-15) may
-// ABOUTME: DM (#176). The pin blocks attacker ADDITION (no key the app didn't ship
-// ABOUTME: can join); the NIP-05 leg is the revocation lever (see OfficialAccountsService).
+// ABOUTME: Shipped identities Divine treats as its own: the pinned accounts a
+// ABOUTME: protected minor (13-15) may DM (#176), and the team pubkeys that carry
+// ABOUTME: the profile checkmark. The NIP-05 leg is the revocation lever.
 
 /// One pinned official account. `pubkeyHex` is the shipped identity; `nip05` is
 /// the canonical identifier whose live resolution must still map back to
@@ -30,9 +30,18 @@ abstract class OfficialAccountRole {
   static const String moderation = 'moderation';
 }
 
+/// The Divine HQ pubkey — the pinned identity below and the HQ entry in
+/// [kDivineTeamPubkeys].
+///
+/// Single-sourced for the same reason as [kModerationPubkeyHex]: a second copy
+/// would let the checkmark and the protected-minor pin drift onto different
+/// keys.
+const String kHqPubkeyHex =
+    'c4a39f1291291d452405cd8ddd798c4a29a3858c52cd0d843f1f6852cf17682e';
+
 /// Divine HQ's pinned identity.
 const OfficialAccount kHqAccount = OfficialAccount(
-  pubkeyHex: 'c4a39f1291291d452405cd8ddd798c4a29a3858c52cd0d843f1f6852cf17682e',
+  pubkeyHex: kHqPubkeyHex,
   nip05: '_@divinehq.divine.video',
   role: OfficialAccountRole.hq,
   minorContactable: true,
@@ -68,6 +77,66 @@ const List<OfficialAccount> kPinnedOfficialAccounts = [
   kHqAccount,
   kModerationAccount,
 ];
+
+/// The Divine team and Divine's own accounts, by pubkey. Drives the profile
+/// checkmark.
+///
+/// Pubkey-keyed, never by NIP-05 handle: a handle is a name
+/// `divine-name-server` hands out and can reassign, so a handle rule moves the
+/// checkmark to whoever claims that name next.
+///
+/// Distinct from `AppConstants.divineTeamPubkeys`, which grants kind-30005
+/// curation authority. Being on the team and curating official lists are
+/// different permissions; folding them into one list would mean every new
+/// curator silently gained a checkmark.
+const Set<String> kDivineTeamPubkeys = {
+  // Rabble
+  'd95aa8fc0eff8e488952495b8064991d27fb96ed8652f12cdedc5a4e8b5ae540',
+  // Liz
+  '0edc2f474484769bc9bf6d471d180e4e280b0bcd719b6da791001beb730cff1b',
+  // Daniel
+  '89ef92b9ebe6dc1e4ea398f6477f227e95429627b0a33dc89b640e137b256be5',
+  // Alex
+  '04c106a7b7b1ac0a26f0e2ad22aaa2cfc3263bb7749a165545689282d1975c23',
+  // Sebastian
+  '295dbec79ee785496f703c9648f246665d46839c1d5f582c0342b4583da5ccb4',
+  // Meylis
+  '9be8bd90d818407bcf574d11b1c57f104fd53f40fa767abc4a631ee2694b43a3',
+  // Matt
+  '9cfa7d570af5dde1d79b476ac2c8b543b1970065d5488f4d86faf3c34c167e31',
+  // Martin
+  '076c979382b90f5d3a2b21f95e1ee86b6033f14c92e79b7fad3fe1f1073f4886',
+  // Susan
+  '1f0fa01371871502efbbb45f933ea07251265c940de279301dba3af4ccda085b',
+  // Charlie
+  'a7e9d5d90b17fad6e4526ce58f0af997b8c14826ecbdbc2c3955e6e258f4000c',
+  // Kate
+  'fb42392125a2c80acf3cd6ac30db8a2cdf9d44ef63865a95fded2f6a2186d44d',
+  // Alice
+  'fc7031a810ce4b02b6195a7e477cfe3d08c0386038bd45b4431f82d9b3f5ffb0',
+  // Lauren
+  '4e61fa221df35d3975d1c6abefa1dce1bd3beef3ce99b3b2883f5fe7467ca0ef',
+  // Aleysha
+  'ae35ec87e49f3ca2c92a0bbb40c507ae4a6a8e01de29eb9518bc941ed285f943',
+  // Divine HQ
+  kHqPubkeyHex,
+};
+
+/// Checkmarks granted before the team rule existed, kept so the switch to
+/// [kDivineTeamPubkeys] does not silently strip a mark someone already has.
+///
+/// These are not team members. They render the same badge and the same
+/// explanation as the team, so each should either move into
+/// [kDivineTeamPubkeys] or go away once its status is settled.
+const Set<String> kLegacyProfileCheckmarkPubkeys = {
+  // Kirsten Swasey, granted in #3445 by NIP-05 host; resolved to her pubkey
+  // via kirstenswasey.divine.video/.well-known/nostr.json.
+  'cd4ce30f980c960757b46179608a4946fc06cad47f6dc8960f638e41312c1643',
+  // Added in #4537 as a bare npub with no owner named in the PR or its issue.
+  'aa50001ef150418f30f62f827399d5c26a5ade52ab45ca4849f99b1726bb47b4',
+  // Improvising
+  '5ab67f7d7fed4f781008c0ec0d26c8113f9fb46094a8346246c70c75e75db9fb',
+};
 
 /// Moderation pubkeys the account has rotated away from.
 ///

--- a/mobile/lib/config/official_accounts.dart
+++ b/mobile/lib/config/official_accounts.dart
@@ -122,19 +122,24 @@ const Set<String> kDivineTeamPubkeys = {
   kHqPubkeyHex,
 };
 
-/// Checkmarks granted before the team rule existed, kept so the switch to
-/// [kDivineTeamPubkeys] does not silently strip a mark someone already has.
+/// Checkmarks that are not team membership.
 ///
-/// These are not team members. They render the same badge and the same
-/// explanation as the team, so each should either move into
-/// [kDivineTeamPubkeys] or go away once its status is settled.
+/// Two are grandfathered: [kDivineTeamPubkeys] replaced a NIP-05-host rule, and
+/// dropping them would have stripped a badge someone already had. The third was
+/// granted here, so this is not purely a legacy set — it is every checkmark the
+/// team rule does not explain.
+///
+/// All of them render the same badge and the same explanation as the team, so
+/// each should either move into [kDivineTeamPubkeys] or go away once its status
+/// is settled.
 const Set<String> kLegacyProfileCheckmarkPubkeys = {
   // Kirsten Swasey, granted in #3445 by NIP-05 host; resolved to her pubkey
   // via kirstenswasey.divine.video/.well-known/nostr.json.
   'cd4ce30f980c960757b46179608a4946fc06cad47f6dc8960f638e41312c1643',
   // Added in #4537 as a bare npub with no owner named in the PR or its issue.
   'aa50001ef150418f30f62f827399d5c26a5ade52ab45ca4849f99b1726bb47b4',
-  // Improvising
+  // Improvising. Granted here, not grandfathered — it predates neither the
+  // team rule nor this set.
   '5ab67f7d7fed4f781008c0ec0d26c8113f9fb46094a8346246c70c75e75db9fb',
 };
 

--- a/mobile/lib/config/official_accounts.dart
+++ b/mobile/lib/config/official_accounts.dart
@@ -1,6 +1,9 @@
 // ABOUTME: Shipped identities Divine treats as its own: the pinned accounts a
 // ABOUTME: protected minor (13-15) may DM (#176), and the team pubkeys that carry
-// ABOUTME: the profile checkmark. The NIP-05 leg is the revocation lever.
+// ABOUTME: the profile checkmark. Pinned accounts keep NIP-05 as a revocation
+// ABOUTME: lever; checkmark-only entries are release-gated.
+
+import 'package:openvine/constants/app_constants.dart';
 
 /// One pinned official account. `pubkeyHex` is the shipped identity; `nip05` is
 /// the canonical identifier whose live resolution must still map back to
@@ -91,7 +94,7 @@ const List<OfficialAccount> kPinnedOfficialAccounts = [
 /// curator silently gained a checkmark.
 const Set<String> kDivineTeamPubkeys = {
   // Rabble
-  'd95aa8fc0eff8e488952495b8064991d27fb96ed8652f12cdedc5a4e8b5ae540',
+  AppConstants.divineTeamPubkey2,
   // Liz
   '0edc2f474484769bc9bf6d471d180e4e280b0bcd719b6da791001beb730cff1b',
   // Daniel
@@ -99,7 +102,7 @@ const Set<String> kDivineTeamPubkeys = {
   // Alex
   '04c106a7b7b1ac0a26f0e2ad22aaa2cfc3263bb7749a165545689282d1975c23',
   // Sebastian
-  '295dbec79ee785496f703c9648f246665d46839c1d5f582c0342b4583da5ccb4',
+  AppConstants.divineTeamPubkey1,
   // Meylis
   '9be8bd90d818407bcf574d11b1c57f104fd53f40fa767abc4a631ee2694b43a3',
   // Matt

--- a/mobile/lib/config/official_accounts.dart
+++ b/mobile/lib/config/official_accounts.dart
@@ -3,8 +3,6 @@
 // ABOUTME: the profile checkmark. Pinned accounts keep NIP-05 as a revocation
 // ABOUTME: lever; checkmark-only entries are release-gated.
 
-import 'package:openvine/constants/app_constants.dart';
-
 /// One pinned official account. `pubkeyHex` is the shipped identity; `nip05` is
 /// the canonical identifier whose live resolution must still map back to
 /// `pubkeyHex` for the account to count as reachable (revocation lever).
@@ -94,7 +92,7 @@ const List<OfficialAccount> kPinnedOfficialAccounts = [
 /// curator silently gained a checkmark.
 const Set<String> kDivineTeamPubkeys = {
   // Rabble
-  AppConstants.divineTeamPubkey2,
+  'd95aa8fc0eff8e488952495b8064991d27fb96ed8652f12cdedc5a4e8b5ae540',
   // Liz
   '0edc2f474484769bc9bf6d471d180e4e280b0bcd719b6da791001beb730cff1b',
   // Daniel
@@ -102,7 +100,7 @@ const Set<String> kDivineTeamPubkeys = {
   // Alex
   '04c106a7b7b1ac0a26f0e2ad22aaa2cfc3263bb7749a165545689282d1975c23',
   // Sebastian
-  AppConstants.divineTeamPubkey1,
+  '295dbec79ee785496f703c9648f246665d46839c1d5f582c0342b4583da5ccb4',
   // Meylis
   '9be8bd90d818407bcf574d11b1c57f104fd53f40fa767abc4a631ee2694b43a3',
   // Matt

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -5017,7 +5017,7 @@
     "ogVinerBadgeLabel": "OG Viner",
     "profileBadgeOgVinerBody": "ይህ ሰው Divine በማህደር ውስጥ ያገኘውን ዋና Vine ለጥፏል። ይህ የመለያ ማረጋገጫ ባጅ አይደለም።",
     "profileBadgeCheckmarkTitle": "የመገለጫ ምልክት",
-    "profileBadgeCheckmarkBody": "Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.",
+    "profileBadgeCheckmarkBody": "Divine ይህን ምልክት ለቡድን መለያዎች እና በእጅ ለጸደቁ ጥቂት መገለጫዎች ይሰጣል። ከNIP-05፣ ከተረጋገጡ የመለያ አገናኞች እና ከOG Viner ሁኔታ የተለየ ነው።",
     "shareVideoInListsCount": "{count, plural, =1{በ{count} ዝርዝር ውስጥ} other{በ{count} ዝርዝሮች ውስጥ}}",
     "@shareVideoInListsCount": {"placeholders": {"count": {"type": "int"}}},
     "unfollowConfirmButton": "አትከተል",

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -5017,7 +5017,7 @@
     "ogVinerBadgeLabel": "OG Viner",
     "profileBadgeOgVinerBody": "ይህ ሰው Divine በማህደር ውስጥ ያገኘውን ዋና Vine ለጥፏል። ይህ የመለያ ማረጋገጫ ባጅ አይደለም።",
     "profileBadgeCheckmarkTitle": "የመገለጫ ምልክት",
-    "profileBadgeCheckmarkBody": "ይህ መለያ በDivine የመገለጫ ምልክት ዝርዝር ውስጥ ነው። ከNIP-05፣ ከተረጋገጡ የመለያ አገናኞች እና ከOG Viner ሁኔታ የተለየ ነው።",
+    "profileBadgeCheckmarkBody": "Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.",
     "shareVideoInListsCount": "{count, plural, =1{በ{count} ዝርዝር ውስጥ} other{በ{count} ዝርዝሮች ውስጥ}}",
     "@shareVideoInListsCount": {"placeholders": {"count": {"type": "int"}}},
     "unfollowConfirmButton": "አትከተል",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -4892,7 +4892,7 @@
     "ogVinerBadgeLabel": "OG Viner",
     "profileBadgeOgVinerBody": "نشر هذا الشخص مقطع Vine أصليًا عثرت عليه Divine في الأرشيف. هذه ليست شارة توثيق حساب.",
     "profileBadgeCheckmarkTitle": "علامة الملف الشخصي",
-    "profileBadgeCheckmarkBody": "Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.",
+    "profileBadgeCheckmarkBody": "تمنح Divine هذه العلامة لحسابات الفريق ولمجموعة صغيرة من الملفات الشخصية المعتمدة يدويًا. وهي منفصلة عن NIP-05 وروابط الحسابات الموثّقة وحالة OG Viner.",
     "shareVideoInListsCount": "{count, plural, zero{في لا قوائم} one{في قائمة واحدة} two{في قائمتين} few{في {count} قوائم} many{في {count} قائمة} other{في {count} قائمة}}",
     "@shareVideoInListsCount": {"placeholders": {"count": {"type": "int"}}},
     "unfollowConfirmButton": "إلغاء المتابعة",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -4892,7 +4892,7 @@
     "ogVinerBadgeLabel": "OG Viner",
     "profileBadgeOgVinerBody": "نشر هذا الشخص مقطع Vine أصليًا عثرت عليه Divine في الأرشيف. هذه ليست شارة توثيق حساب.",
     "profileBadgeCheckmarkTitle": "علامة الملف الشخصي",
-    "profileBadgeCheckmarkBody": "هذا الحساب مدرج في قائمة علامات الملف الشخصي لدى Divine. وهي منفصلة عن NIP-05 وروابط الحسابات الموثّقة وحالة OG Viner.",
+    "profileBadgeCheckmarkBody": "Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.",
     "shareVideoInListsCount": "{count, plural, zero{في لا قوائم} one{في قائمة واحدة} two{في قائمتين} few{في {count} قوائم} many{في {count} قائمة} other{في {count} قائمة}}",
     "@shareVideoInListsCount": {"placeholders": {"count": {"type": "int"}}},
     "unfollowConfirmButton": "إلغاء المتابعة",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -5023,7 +5023,7 @@
     "ogVinerBadgeLabel": "OG Viner",
     "profileBadgeOgVinerBody": "Този човек е публикувал оригинален Vine, който Divine намери в архива. Това не е значка за потвърден профил.",
     "profileBadgeCheckmarkTitle": "Отметка на профила",
-    "profileBadgeCheckmarkBody": "Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.",
+    "profileBadgeCheckmarkBody": "Divine дава тази отметка на профилите на екипа и на малка група ръчно одобрени профили. Това е различно от NIP-05, потвърдените връзки към профила и статуса OG Viner.",
     "shareVideoInListsCount": "{count, plural, =1{В 1 списък} other{В {count} списъка}}",
     "@shareVideoInListsCount": {"placeholders": {"count": {"type": "int"}}},
     "unfollowConfirmButton": "Спри да следваш",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -5023,7 +5023,7 @@
     "ogVinerBadgeLabel": "OG Viner",
     "profileBadgeOgVinerBody": "Този човек е публикувал оригинален Vine, който Divine намери в архива. Това не е значка за потвърден профил.",
     "profileBadgeCheckmarkTitle": "Отметка на профила",
-    "profileBadgeCheckmarkBody": "Този профил е в списъка с отметки на профил на Divine. Това е различно от NIP-05, потвърдените връзки към профила и статуса OG Viner.",
+    "profileBadgeCheckmarkBody": "Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.",
     "shareVideoInListsCount": "{count, plural, =1{В 1 списък} other{В {count} списъка}}",
     "@shareVideoInListsCount": {"placeholders": {"count": {"type": "int"}}},
     "unfollowConfirmButton": "Спри да следваш",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -4892,7 +4892,7 @@
     "ogVinerBadgeLabel": "OG Viner",
     "profileBadgeOgVinerBody": "Diese Person hat ein Original-Vine gepostet, das Divine im Archiv gefunden hat. Das ist kein Verifizierungs-Badge fürs Konto.",
     "profileBadgeCheckmarkTitle": "Profil-Häkchen",
-    "profileBadgeCheckmarkBody": "Dieses Konto steht auf Divines Liste für Profil-Häkchen. Das ist unabhängig von NIP-05, verifizierten Konto-Links und dem OG-Viner-Status.",
+    "profileBadgeCheckmarkBody": "Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.",
     "shareVideoInListsCount": "{count, plural, =1{In 1 Liste} other{In {count} Listen}}",
     "@shareVideoInListsCount": {"placeholders": {"count": {"type": "int"}}},
     "unfollowConfirmButton": "Nicht mehr folgen",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -4892,7 +4892,7 @@
     "ogVinerBadgeLabel": "OG Viner",
     "profileBadgeOgVinerBody": "Diese Person hat ein Original-Vine gepostet, das Divine im Archiv gefunden hat. Das ist kein Verifizierungs-Badge fürs Konto.",
     "profileBadgeCheckmarkTitle": "Profil-Häkchen",
-    "profileBadgeCheckmarkBody": "Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.",
+    "profileBadgeCheckmarkBody": "Divine vergibt dieses Häkchen an Team-Konten und an eine kleine Zahl manuell freigegebener Profile. Das ist unabhängig von NIP-05, verifizierten Konto-Links und dem OG-Viner-Status.",
     "shareVideoInListsCount": "{count, plural, =1{In 1 Liste} other{In {count} Listen}}",
     "@shareVideoInListsCount": {"placeholders": {"count": {"type": "int"}}},
     "unfollowConfirmButton": "Nicht mehr folgen",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -4572,9 +4572,9 @@
   "@profileBadgeCheckmarkTitle": {
     "description": "Title for the dialog explaining the special profile checkmark badge."
   },
-  "profileBadgeCheckmarkBody": "This account is on Divine's profile checkmark list. It is separate from NIP-05, verified account links, and OG Viner status.",
+  "profileBadgeCheckmarkBody": "Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.",
   "@profileBadgeCheckmarkBody": {
-    "description": "Body copy explaining that the special profile checkmark is a Divine-specific profile marker, not NIP-05, verified-account links, or OG Viner status."
+    "description": "Body copy explaining that the special profile checkmark marks Divine team accounts and manually approved profiles, not NIP-05, verified-account links, or OG Viner status."
   },
   "shareVideoInListsCount": "{count, plural, =1{In 1 list} other{In {count} lists}}",
   "@shareVideoInListsCount": {"placeholders": {"count": {"type": "int"}}},

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -4892,7 +4892,7 @@
     "ogVinerBadgeLabel": "OG Viner",
     "profileBadgeOgVinerBody": "Esta persona publicó un Vine original que Divine encontró en el archivo. No es una insignia de verificación de cuenta.",
     "profileBadgeCheckmarkTitle": "Tilde de perfil",
-    "profileBadgeCheckmarkBody": "Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.",
+    "profileBadgeCheckmarkBody": "Divine da esta tilde a las cuentas del equipo y a un pequeño grupo de perfiles aprobados manualmente. Es independiente de NIP-05, de los enlaces de cuenta verificados y del estado OG Viner.",
     "shareVideoInListsCount": "{count, plural, =1{En 1 lista} other{En {count} listas}}",
     "@shareVideoInListsCount": {"placeholders": {"count": {"type": "int"}}},
     "unfollowConfirmButton": "Dejar de seguir",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -4892,7 +4892,7 @@
     "ogVinerBadgeLabel": "OG Viner",
     "profileBadgeOgVinerBody": "Esta persona publicó un Vine original que Divine encontró en el archivo. No es una insignia de verificación de cuenta.",
     "profileBadgeCheckmarkTitle": "Tilde de perfil",
-    "profileBadgeCheckmarkBody": "Esta cuenta está en la lista de tildes de perfil de Divine. Es independiente de NIP-05, de los enlaces de cuenta verificados y del estado OG Viner.",
+    "profileBadgeCheckmarkBody": "Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.",
     "shareVideoInListsCount": "{count, plural, =1{En 1 lista} other{En {count} listas}}",
     "@shareVideoInListsCount": {"placeholders": {"count": {"type": "int"}}},
     "unfollowConfirmButton": "Dejar de seguir",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -3471,7 +3471,7 @@
     "ogVinerBadgeLabel": "OG Viner",
     "profileBadgeOgVinerBody": "Nag-post ang taong ito ng orihinal na Vine na nakita ng Divine sa archive. Hindi ito badge ng verification ng account.",
     "profileBadgeCheckmarkTitle": "Tsek sa profile",
-    "profileBadgeCheckmarkBody": "Nasa listahan ng profile checkmark ng Divine ang account na ito. Hiwalay ito sa NIP-05, sa mga verified na link ng account, at sa OG Viner status.",
+    "profileBadgeCheckmarkBody": "Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.",
     "shareVideoInListsCount": "{count, plural, =1{Nasa {count} list} other{Nasa {count} list}}",
     "@shareVideoInListsCount": {"placeholders": {"count": {"type": "int"}}},
     "unfollowConfirmButton": "I-unfollow",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -3471,7 +3471,7 @@
     "ogVinerBadgeLabel": "OG Viner",
     "profileBadgeOgVinerBody": "Nag-post ang taong ito ng orihinal na Vine na nakita ng Divine sa archive. Hindi ito badge ng verification ng account.",
     "profileBadgeCheckmarkTitle": "Tsek sa profile",
-    "profileBadgeCheckmarkBody": "Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.",
+    "profileBadgeCheckmarkBody": "Ibinibigay ng Divine ang tsek na ito sa mga account ng team at sa iilang profile na manu-manong inaprubahan. Hiwalay ito sa NIP-05, sa mga verified na link ng account, at sa OG Viner status.",
     "shareVideoInListsCount": "{count, plural, =1{Nasa {count} list} other{Nasa {count} list}}",
     "@shareVideoInListsCount": {"placeholders": {"count": {"type": "int"}}},
     "unfollowConfirmButton": "I-unfollow",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -4892,7 +4892,7 @@
     "ogVinerBadgeLabel": "OG Viner",
     "profileBadgeOgVinerBody": "Cette personne a publié un Vine original que Divine a retrouvé dans les archives. Ce n'est pas un badge de vérification de compte.",
     "profileBadgeCheckmarkTitle": "Coche de profil",
-    "profileBadgeCheckmarkBody": "Ce compte figure sur la liste des coches de profil de Divine. C'est indépendant de NIP-05, des liens de compte vérifiés et du statut OG Viner.",
+    "profileBadgeCheckmarkBody": "Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.",
     "shareVideoInListsCount": "{count, plural, =1{Dans {count} liste} other{Dans {count} listes}}",
     "@shareVideoInListsCount": {"placeholders": {"count": {"type": "int"}}},
     "unfollowConfirmButton": "Ne plus suivre",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -4892,7 +4892,7 @@
     "ogVinerBadgeLabel": "OG Viner",
     "profileBadgeOgVinerBody": "Cette personne a publié un Vine original que Divine a retrouvé dans les archives. Ce n'est pas un badge de vérification de compte.",
     "profileBadgeCheckmarkTitle": "Coche de profil",
-    "profileBadgeCheckmarkBody": "Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.",
+    "profileBadgeCheckmarkBody": "Divine attribue cette coche aux comptes de l'équipe et à un petit nombre de profils approuvés manuellement. C'est indépendant de NIP-05, des liens de compte vérifiés et du statut OG Viner.",
     "shareVideoInListsCount": "{count, plural, =1{Dans {count} liste} other{Dans {count} listes}}",
     "@shareVideoInListsCount": {"placeholders": {"count": {"type": "int"}}},
     "unfollowConfirmButton": "Ne plus suivre",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -4892,7 +4892,7 @@
     "ogVinerBadgeLabel": "OG Viner",
     "profileBadgeOgVinerBody": "Orang ini pernah memposting Vine asli yang ditemukan Divine di arsip. Ini bukan lencana verifikasi akun.",
     "profileBadgeCheckmarkTitle": "Centang profil",
-    "profileBadgeCheckmarkBody": "Akun ini ada di daftar centang profil Divine. Ini terpisah dari NIP-05, tautan akun terverifikasi, dan status OG Viner.",
+    "profileBadgeCheckmarkBody": "Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.",
     "shareVideoInListsCount": "{count, plural, =1{Di 1 daftar} other{Di {count} daftar}}",
     "@shareVideoInListsCount": {"placeholders": {"count": {"type": "int"}}},
     "unfollowConfirmButton": "Berhenti mengikuti",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -4892,7 +4892,7 @@
     "ogVinerBadgeLabel": "OG Viner",
     "profileBadgeOgVinerBody": "Orang ini pernah memposting Vine asli yang ditemukan Divine di arsip. Ini bukan lencana verifikasi akun.",
     "profileBadgeCheckmarkTitle": "Centang profil",
-    "profileBadgeCheckmarkBody": "Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.",
+    "profileBadgeCheckmarkBody": "Divine memberikan centang ini kepada akun tim dan sejumlah kecil profil yang disetujui secara manual. Ini terpisah dari NIP-05, tautan akun terverifikasi, dan status OG Viner.",
     "shareVideoInListsCount": "{count, plural, =1{Di 1 daftar} other{Di {count} daftar}}",
     "@shareVideoInListsCount": {"placeholders": {"count": {"type": "int"}}},
     "unfollowConfirmButton": "Berhenti mengikuti",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -4892,7 +4892,7 @@
     "ogVinerBadgeLabel": "OG Viner",
     "profileBadgeOgVinerBody": "Questa persona ha pubblicato un Vine originale che Divine ha trovato nell'archivio. Non è un badge di verifica dell'account.",
     "profileBadgeCheckmarkTitle": "Spunta del profilo",
-    "profileBadgeCheckmarkBody": "Questo account è nella lista delle spunte di profilo di Divine. È separato da NIP-05, dai link di account verificati e dallo status OG Viner.",
+    "profileBadgeCheckmarkBody": "Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.",
     "shareVideoInListsCount": "{count, plural, =1{In 1 lista} other{In {count} liste}}",
     "@shareVideoInListsCount": {"placeholders": {"count": {"type": "int"}}},
     "unfollowConfirmButton": "Smetti di seguire",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -4892,7 +4892,7 @@
     "ogVinerBadgeLabel": "OG Viner",
     "profileBadgeOgVinerBody": "Questa persona ha pubblicato un Vine originale che Divine ha trovato nell'archivio. Non è un badge di verifica dell'account.",
     "profileBadgeCheckmarkTitle": "Spunta del profilo",
-    "profileBadgeCheckmarkBody": "Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.",
+    "profileBadgeCheckmarkBody": "Divine assegna questa spunta agli account del team e a un piccolo gruppo di profili approvati manualmente. È separato da NIP-05, dai link di account verificati e dallo status OG Viner.",
     "shareVideoInListsCount": "{count, plural, =1{In 1 lista} other{In {count} liste}}",
     "@shareVideoInListsCount": {"placeholders": {"count": {"type": "int"}}},
     "unfollowConfirmButton": "Smetti di seguire",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -4892,7 +4892,7 @@
     "ogVinerBadgeLabel": "OG Viner",
     "profileBadgeOgVinerBody": "この人はオリジナルの Vine を投稿していて、Divine がアーカイブで見つけたよ。アカウントの認証バッジではないので注意。",
     "profileBadgeCheckmarkTitle": "プロフィールのチェックマーク",
-    "profileBadgeCheckmarkBody": "Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.",
+    "profileBadgeCheckmarkBody": "Divine はこのチェックマークをチームのアカウントと、手動で承認したごく少数のプロフィールに付けてるよ。 NIP-05、認証済みアカウントのリンク、OG Viner ステータスとは別物だよ。",
     "shareVideoInListsCount": "{count, plural, =1{1件のリストに含まれてるよ} other{{count}件のリストに含まれてるよ}}",
     "@shareVideoInListsCount": {"placeholders": {"count": {"type": "int"}}},
     "unfollowConfirmButton": "フォロー解除",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -4892,7 +4892,7 @@
     "ogVinerBadgeLabel": "OG Viner",
     "profileBadgeOgVinerBody": "この人はオリジナルの Vine を投稿していて、Divine がアーカイブで見つけたよ。アカウントの認証バッジではないので注意。",
     "profileBadgeCheckmarkTitle": "プロフィールのチェックマーク",
-    "profileBadgeCheckmarkBody": "このアカウントは Divine のプロフィールチェックマークのリストに入ってる。NIP-05、認証済みアカウントのリンク、OG Viner ステータスとは別物だよ。",
+    "profileBadgeCheckmarkBody": "Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.",
     "shareVideoInListsCount": "{count, plural, =1{1件のリストに含まれてるよ} other{{count}件のリストに含まれてるよ}}",
     "@shareVideoInListsCount": {"placeholders": {"count": {"type": "int"}}},
     "unfollowConfirmButton": "フォロー解除",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -4223,7 +4223,7 @@
     "ogVinerBadgeLabel": "OG Viner",
     "profileBadgeOgVinerBody": "이 사람은 Divine이 아카이브에서 찾은 오리지널 Vine을 올렸어요. 계정 인증 배지는 아니에요.",
     "profileBadgeCheckmarkTitle": "프로필 체크마크",
-    "profileBadgeCheckmarkBody": "이 계정은 Divine의 프로필 체크마크 목록에 있어요. NIP-05, 인증된 계정 링크, OG Viner 상태와는 별개예요.",
+    "profileBadgeCheckmarkBody": "Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.",
     "shareVideoInListsCount": "{count, plural, =1{목록 1개에 있음} other{목록 {count}개에 있음}}",
     "@shareVideoInListsCount": {"placeholders": {"count": {"type": "int"}}},
     "unfollowConfirmButton": "언팔로우",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -4223,7 +4223,7 @@
     "ogVinerBadgeLabel": "OG Viner",
     "profileBadgeOgVinerBody": "이 사람은 Divine이 아카이브에서 찾은 오리지널 Vine을 올렸어요. 계정 인증 배지는 아니에요.",
     "profileBadgeCheckmarkTitle": "프로필 체크마크",
-    "profileBadgeCheckmarkBody": "Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.",
+    "profileBadgeCheckmarkBody": "Divine는 이 체크마크를 팀 계정과 직접 승인한 소수의 프로필에 부여해요. NIP-05, 인증된 계정 링크, OG Viner 상태와는 별개예요.",
     "shareVideoInListsCount": "{count, plural, =1{목록 1개에 있음} other{목록 {count}개에 있음}}",
     "@shareVideoInListsCount": {"placeholders": {"count": {"type": "int"}}},
     "unfollowConfirmButton": "언팔로우",

--- a/mobile/lib/l10n/app_ms.arb
+++ b/mobile/lib/l10n/app_ms.arb
@@ -4404,7 +4404,7 @@
   "ogVinerBadgeLabel": "OG Viner",
   "profileBadgeOgVinerBody": "Orang ini pernah menyiarkan Vine asli yang ditemui Divine dalam arkib. Ini bukan lencana pengesahan akaun.",
   "profileBadgeCheckmarkTitle": "Tanda semak profil",
-  "profileBadgeCheckmarkBody": "Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.",
+  "profileBadgeCheckmarkBody": "Divine memberikan tanda semak ini kepada akaun pasukan dan sebilangan kecil profil yang diluluskan secara manual. Ia berasingan daripada NIP-05, pautan akaun disahkan dan status OG Viner.",
   "shareVideoInListsCount": "{count, plural, =1{Dalam 1 senarai} other{Dalam {count} senarai}}",
   "@shareVideoInListsCount": {
     "placeholders": {

--- a/mobile/lib/l10n/app_ms.arb
+++ b/mobile/lib/l10n/app_ms.arb
@@ -4404,7 +4404,7 @@
   "ogVinerBadgeLabel": "OG Viner",
   "profileBadgeOgVinerBody": "Orang ini pernah menyiarkan Vine asli yang ditemui Divine dalam arkib. Ini bukan lencana pengesahan akaun.",
   "profileBadgeCheckmarkTitle": "Tanda semak profil",
-  "profileBadgeCheckmarkBody": "Akaun ini ada dalam senarai tanda semak profil Divine. Ia berasingan daripada NIP-05, pautan akaun disahkan dan status OG Viner.",
+  "profileBadgeCheckmarkBody": "Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.",
   "shareVideoInListsCount": "{count, plural, =1{Dalam 1 senarai} other{Dalam {count} senarai}}",
   "@shareVideoInListsCount": {
     "placeholders": {

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -4892,7 +4892,7 @@
     "ogVinerBadgeLabel": "OG Viner",
     "profileBadgeOgVinerBody": "Deze persoon plaatste een originele Vine die Divine in het archief vond. Dit is geen verificatiebadge voor het account.",
     "profileBadgeCheckmarkTitle": "Profielvinkje",
-    "profileBadgeCheckmarkBody": "Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.",
+    "profileBadgeCheckmarkBody": "Divine geeft dit vinkje aan teamaccounts en aan een klein aantal handmatig goedgekeurde profielen. Dat staat los van NIP-05, geverifieerde accountlinks en de OG Viner-status.",
     "shareVideoInListsCount": "{count, plural, =1{In 1 lijst} other{In {count} lijsten}}",
     "@shareVideoInListsCount": {"placeholders": {"count": {"type": "int"}}},
     "unfollowConfirmButton": "Ontvolgen",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -4892,7 +4892,7 @@
     "ogVinerBadgeLabel": "OG Viner",
     "profileBadgeOgVinerBody": "Deze persoon plaatste een originele Vine die Divine in het archief vond. Dit is geen verificatiebadge voor het account.",
     "profileBadgeCheckmarkTitle": "Profielvinkje",
-    "profileBadgeCheckmarkBody": "Dit account staat op Divine's lijst met profielvinkjes. Dat staat los van NIP-05, geverifieerde accountlinks en de OG Viner-status.",
+    "profileBadgeCheckmarkBody": "Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.",
     "shareVideoInListsCount": "{count, plural, =1{In 1 lijst} other{In {count} lijsten}}",
     "@shareVideoInListsCount": {"placeholders": {"count": {"type": "int"}}},
     "unfollowConfirmButton": "Ontvolgen",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -4892,7 +4892,7 @@
     "ogVinerBadgeLabel": "OG Viner",
     "profileBadgeOgVinerBody": "Ta osoba opublikowała oryginalnego Vine'a, którego Divine znalazło w archiwum. To nie jest odznaka weryfikacji konta.",
     "profileBadgeCheckmarkTitle": "Znacznik profilu",
-    "profileBadgeCheckmarkBody": "Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.",
+    "profileBadgeCheckmarkBody": "Divine przyznaje ten znacznik kontom zespołu i niewielkiej grupie ręcznie zatwierdzonych profili. To coś innego niż NIP-05, zweryfikowane linki konta i status OG Viner.",
     "shareVideoInListsCount": "{count, plural, =1{Na 1 liście} few{Na {count} listach} many{Na {count} listach} other{Na {count} listach}}",
     "@shareVideoInListsCount": {"placeholders": {"count": {"type": "int"}}},
     "unfollowConfirmButton": "Przestań obserwować",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -4892,7 +4892,7 @@
     "ogVinerBadgeLabel": "OG Viner",
     "profileBadgeOgVinerBody": "Ta osoba opublikowała oryginalnego Vine'a, którego Divine znalazło w archiwum. To nie jest odznaka weryfikacji konta.",
     "profileBadgeCheckmarkTitle": "Znacznik profilu",
-    "profileBadgeCheckmarkBody": "To konto jest na liście znaczników profilu Divine. To coś innego niż NIP-05, zweryfikowane linki konta i status OG Viner.",
+    "profileBadgeCheckmarkBody": "Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.",
     "shareVideoInListsCount": "{count, plural, =1{Na 1 liście} few{Na {count} listach} many{Na {count} listach} other{Na {count} listach}}",
     "@shareVideoInListsCount": {"placeholders": {"count": {"type": "int"}}},
     "unfollowConfirmButton": "Przestań obserwować",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -4892,7 +4892,7 @@
     "ogVinerBadgeLabel": "Viner OG",
     "profileBadgeOgVinerBody": "Essa pessoa postou um Vine original que a Divine encontrou no arquivo. Não é um selo de verificação de conta.",
     "profileBadgeCheckmarkTitle": "Marca de verificação do perfil",
-    "profileBadgeCheckmarkBody": "Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.",
+    "profileBadgeCheckmarkBody": "A Divine dá essa marca às contas da equipe e a um pequeno grupo de perfis aprovados manualmente. É separado do NIP-05, dos links de conta verificados e do status de Viner OG.",
     "shareVideoInListsCount": "{count, plural, =1{Em {count} lista} other{Em {count} listas}}",
     "@shareVideoInListsCount": {"placeholders": {"count": {"type": "int"}}},
     "unfollowConfirmButton": "Deixar de seguir",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -4892,7 +4892,7 @@
     "ogVinerBadgeLabel": "Viner OG",
     "profileBadgeOgVinerBody": "Essa pessoa postou um Vine original que a Divine encontrou no arquivo. Não é um selo de verificação de conta.",
     "profileBadgeCheckmarkTitle": "Marca de verificação do perfil",
-    "profileBadgeCheckmarkBody": "Essa conta está na lista de marcas de verificação de perfil da Divine. É separado do NIP-05, dos links de conta verificados e do status de Viner OG.",
+    "profileBadgeCheckmarkBody": "Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.",
     "shareVideoInListsCount": "{count, plural, =1{Em {count} lista} other{Em {count} listas}}",
     "@shareVideoInListsCount": {"placeholders": {"count": {"type": "int"}}},
     "unfollowConfirmButton": "Deixar de seguir",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -4892,7 +4892,7 @@
     "ogVinerBadgeLabel": "OG Viner",
     "profileBadgeOgVinerBody": "Persoana asta a postat un Vine original pe care Divine l-a găsit în arhivă. Nu e o insignă de verificare a contului.",
     "profileBadgeCheckmarkTitle": "Bifa de profil",
-    "profileBadgeCheckmarkBody": "Contul ăsta e pe lista de bife de profil a Divine. E separat de NIP-05, de linkurile de cont verificate și de statutul OG Viner.",
+    "profileBadgeCheckmarkBody": "Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.",
     "shareVideoInListsCount": "{count, plural, =1{În 1 listă} few{În {count} liste} other{În {count} de liste}}",
     "@shareVideoInListsCount": {"placeholders": {"count": {"type": "int"}}},
     "unfollowConfirmButton": "Nu mai urmări",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -4892,7 +4892,7 @@
     "ogVinerBadgeLabel": "OG Viner",
     "profileBadgeOgVinerBody": "Persoana asta a postat un Vine original pe care Divine l-a găsit în arhivă. Nu e o insignă de verificare a contului.",
     "profileBadgeCheckmarkTitle": "Bifa de profil",
-    "profileBadgeCheckmarkBody": "Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.",
+    "profileBadgeCheckmarkBody": "Divine dă bifa asta conturilor echipei și unui număr mic de profiluri aprobate manual. E separat de NIP-05, de linkurile de cont verificate și de statutul OG Viner.",
     "shareVideoInListsCount": "{count, plural, =1{În 1 listă} few{În {count} liste} other{În {count} de liste}}",
     "@shareVideoInListsCount": {"placeholders": {"count": {"type": "int"}}},
     "unfollowConfirmButton": "Nu mai urmări",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -4892,7 +4892,7 @@
     "ogVinerBadgeLabel": "OG Viner",
     "profileBadgeOgVinerBody": "Den här personen postade en originalvine som Divine hittade i arkivet. Det är inte en verifieringsbadge för kontot.",
     "profileBadgeCheckmarkTitle": "Profilbock",
-    "profileBadgeCheckmarkBody": "Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.",
+    "profileBadgeCheckmarkBody": "Divine ger den här bocken till teamets konton och till ett litet antal manuellt godkända profiler. Det är skilt från NIP-05, verifierade kontolänkar och OG Viner-status.",
     "shareVideoInListsCount": "{count, plural, =1{I 1 lista} other{I {count} listor}}",
     "@shareVideoInListsCount": {"placeholders": {"count": {"type": "int"}}},
     "unfollowConfirmButton": "Sluta följa",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -4892,7 +4892,7 @@
     "ogVinerBadgeLabel": "OG Viner",
     "profileBadgeOgVinerBody": "Den här personen postade en originalvine som Divine hittade i arkivet. Det är inte en verifieringsbadge för kontot.",
     "profileBadgeCheckmarkTitle": "Profilbock",
-    "profileBadgeCheckmarkBody": "Det här kontot finns på Divines lista över profilbockar. Det är skilt från NIP-05, verifierade kontolänkar och OG Viner-status.",
+    "profileBadgeCheckmarkBody": "Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.",
     "shareVideoInListsCount": "{count, plural, =1{I 1 lista} other{I {count} listor}}",
     "@shareVideoInListsCount": {"placeholders": {"count": {"type": "int"}}},
     "unfollowConfirmButton": "Sluta följa",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -4892,7 +4892,7 @@
     "ogVinerBadgeLabel": "OG Viner",
     "profileBadgeOgVinerBody": "Bu kişi, Divine'ın arşivde bulduğu orijinal bir Vine paylaşmış. Bu bir hesap doğrulama rozeti değil.",
     "profileBadgeCheckmarkTitle": "Profil onay işareti",
-    "profileBadgeCheckmarkBody": "Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.",
+    "profileBadgeCheckmarkBody": "Divine bu onay işaretini ekip hesaplarına ve elle onaylanmış az sayıda profile veriyor. NIP-05'ten, doğrulanmış hesap bağlantılarından ve OG Viner durumundan ayrıdır.",
     "shareVideoInListsCount": "{count, plural, =1{1 listede} other{{count} listede}}",
     "@shareVideoInListsCount": {"placeholders": {"count": {"type": "int"}}},
     "unfollowConfirmButton": "Takipten çık",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -4892,7 +4892,7 @@
     "ogVinerBadgeLabel": "OG Viner",
     "profileBadgeOgVinerBody": "Bu kişi, Divine'ın arşivde bulduğu orijinal bir Vine paylaşmış. Bu bir hesap doğrulama rozeti değil.",
     "profileBadgeCheckmarkTitle": "Profil onay işareti",
-    "profileBadgeCheckmarkBody": "Bu hesap Divine'ın profil onay işareti listesinde. NIP-05'ten, doğrulanmış hesap bağlantılarından ve OG Viner durumundan ayrıdır.",
+    "profileBadgeCheckmarkBody": "Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.",
     "shareVideoInListsCount": "{count, plural, =1{1 listede} other{{count} listede}}",
     "@shareVideoInListsCount": {"placeholders": {"count": {"type": "int"}}},
     "unfollowConfirmButton": "Takipten çık",

--- a/mobile/lib/l10n/app_ur.arb
+++ b/mobile/lib/l10n/app_ur.arb
@@ -4404,7 +4404,7 @@
   "ogVinerBadgeLabel": "OG Viner",
   "profileBadgeOgVinerBody": "اس شخص نے ایک اصل Vine پوسٹ کیا تھا جو Divine کو آرکائیو میں ملا۔ یہ اکاؤنٹ کی تصدیق کا بیج نہیں ہے۔",
   "profileBadgeCheckmarkTitle": "پروفائل چیک مارک",
-  "profileBadgeCheckmarkBody": "Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.",
+  "profileBadgeCheckmarkBody": "Divine یہ چیک مارک ٹیم کے اکاؤنٹس اور دستی طور پر منظور شدہ چند پروفائلز کو دیتا ہے۔ یہ NIP-05، تصدیق شدہ اکاؤنٹ لنکس اور OG Viner اسٹیٹس سے الگ ہے۔",
   "shareVideoInListsCount": "{count, plural, =1{1 فہرست میں} other{{count} فہرستوں میں}}",
   "@shareVideoInListsCount": {
     "placeholders": {

--- a/mobile/lib/l10n/app_ur.arb
+++ b/mobile/lib/l10n/app_ur.arb
@@ -4404,7 +4404,7 @@
   "ogVinerBadgeLabel": "OG Viner",
   "profileBadgeOgVinerBody": "اس شخص نے ایک اصل Vine پوسٹ کیا تھا جو Divine کو آرکائیو میں ملا۔ یہ اکاؤنٹ کی تصدیق کا بیج نہیں ہے۔",
   "profileBadgeCheckmarkTitle": "پروفائل چیک مارک",
-  "profileBadgeCheckmarkBody": "یہ اکاؤنٹ Divine کی پروفائل چیک مارک فہرست میں ہے۔ یہ NIP-05، تصدیق شدہ اکاؤنٹ لنکس اور OG Viner اسٹیٹس سے الگ ہے۔",
+  "profileBadgeCheckmarkBody": "Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.",
   "shareVideoInListsCount": "{count, plural, =1{1 فہرست میں} other{{count} فہرستوں میں}}",
   "@shareVideoInListsCount": {
     "placeholders": {

--- a/mobile/lib/l10n/app_vi.arb
+++ b/mobile/lib/l10n/app_vi.arb
@@ -4404,7 +4404,7 @@
   "ogVinerBadgeLabel": "OG Viner",
   "profileBadgeOgVinerBody": "Người này đã đăng một Vine gốc mà Divine tìm thấy trong kho lưu trữ. Đây không phải huy hiệu xác minh tài khoản.",
   "profileBadgeCheckmarkTitle": "Dấu tích hồ sơ",
-  "profileBadgeCheckmarkBody": "Tài khoản này nằm trong danh sách dấu tích hồ sơ của Divine. Nó tách biệt với NIP-05, liên kết tài khoản đã xác minh và trạng thái OG Viner.",
+  "profileBadgeCheckmarkBody": "Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.",
   "shareVideoInListsCount": "{count, plural, =1{Trong 1 danh sách} other{Trong {count} danh sách}}",
   "@shareVideoInListsCount": {
     "placeholders": {

--- a/mobile/lib/l10n/app_vi.arb
+++ b/mobile/lib/l10n/app_vi.arb
@@ -4404,7 +4404,7 @@
   "ogVinerBadgeLabel": "OG Viner",
   "profileBadgeOgVinerBody": "Người này đã đăng một Vine gốc mà Divine tìm thấy trong kho lưu trữ. Đây không phải huy hiệu xác minh tài khoản.",
   "profileBadgeCheckmarkTitle": "Dấu tích hồ sơ",
-  "profileBadgeCheckmarkBody": "Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.",
+  "profileBadgeCheckmarkBody": "Divine trao dấu tích này cho các tài khoản của đội ngũ và một số ít hồ sơ được duyệt thủ công. Nó tách biệt với NIP-05, liên kết tài khoản đã xác minh và trạng thái OG Viner.",
   "shareVideoInListsCount": "{count, plural, =1{Trong 1 danh sách} other{Trong {count} danh sách}}",
   "@shareVideoInListsCount": {
     "placeholders": {

--- a/mobile/lib/l10n/app_zh.arb
+++ b/mobile/lib/l10n/app_zh.arb
@@ -4404,7 +4404,7 @@
   "ogVinerBadgeLabel": "OG Viner",
   "profileBadgeOgVinerBody": "这个人发过一条原版 Vine，被 Divine 在存档里找到了。这不是账号认证徽章。",
   "profileBadgeCheckmarkTitle": "个人资料对勾",
-  "profileBadgeCheckmarkBody": "这个账号在 Divine 的个人资料对勾名单里。它与 NIP-05、已验证的账号链接和 OG Viner 状态无关。",
+  "profileBadgeCheckmarkBody": "Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.",
   "shareVideoInListsCount": "{count, plural, =1{已在 1 个列表中} other{已在 {count} 个列表中}}",
   "@shareVideoInListsCount": {
     "placeholders": {

--- a/mobile/lib/l10n/app_zh.arb
+++ b/mobile/lib/l10n/app_zh.arb
@@ -4404,7 +4404,7 @@
   "ogVinerBadgeLabel": "OG Viner",
   "profileBadgeOgVinerBody": "这个人发过一条原版 Vine，被 Divine 在存档里找到了。这不是账号认证徽章。",
   "profileBadgeCheckmarkTitle": "个人资料对勾",
-  "profileBadgeCheckmarkBody": "Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.",
+  "profileBadgeCheckmarkBody": "Divine 把这个对勾给团队账号，以及少数经过人工审核的个人资料。它与 NIP-05、已验证的账号链接和 OG Viner 状态无关。",
   "shareVideoInListsCount": "{count, plural, =1{已在 1 个列表中} other{已在 {count} 个列表中}}",
   "@shareVideoInListsCount": {
     "placeholders": {

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -13163,10 +13163,10 @@ abstract class AppLocalizations {
   /// **'Profile checkmark'**
   String get profileBadgeCheckmarkTitle;
 
-  /// Body copy explaining that the special profile checkmark is a Divine-specific profile marker, not NIP-05, verified-account links, or OG Viner status.
+  /// Body copy explaining that the special profile checkmark marks Divine team accounts and manually approved profiles, not NIP-05, verified-account links, or OG Viner status.
   ///
   /// In en, this message translates to:
-  /// **'This account is on Divine\'s profile checkmark list. It is separate from NIP-05, verified account links, and OG Viner status.'**
+  /// **'Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.'**
   String get profileBadgeCheckmarkBody;
 
   /// No description provided for @shareVideoInListsCount.

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -7454,7 +7454,7 @@ class AppLocalizationsAm extends AppLocalizations {
 
   @override
   String get profileBadgeCheckmarkBody =>
-      'ይህ መለያ በDivine የመገለጫ ምልክት ዝርዝር ውስጥ ነው። ከNIP-05፣ ከተረጋገጡ የመለያ አገናኞች እና ከOG Viner ሁኔታ የተለየ ነው።';
+      'Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.';
 
   @override
   String shareVideoInListsCount(int count) {

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -7454,7 +7454,7 @@ class AppLocalizationsAm extends AppLocalizations {
 
   @override
   String get profileBadgeCheckmarkBody =>
-      'Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.';
+      'Divine ይህን ምልክት ለቡድን መለያዎች እና በእጅ ለጸደቁ ጥቂት መገለጫዎች ይሰጣል። ከNIP-05፣ ከተረጋገጡ የመለያ አገናኞች እና ከOG Viner ሁኔታ የተለየ ነው።';
 
   @override
   String shareVideoInListsCount(int count) {

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -7564,7 +7564,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get profileBadgeCheckmarkBody =>
-      'هذا الحساب مدرج في قائمة علامات الملف الشخصي لدى Divine. وهي منفصلة عن NIP-05 وروابط الحسابات الموثّقة وحالة OG Viner.';
+      'Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.';
 
   @override
   String shareVideoInListsCount(int count) {

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -7564,7 +7564,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get profileBadgeCheckmarkBody =>
-      'Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.';
+      'تمنح Divine هذه العلامة لحسابات الفريق ولمجموعة صغيرة من الملفات الشخصية المعتمدة يدويًا. وهي منفصلة عن NIP-05 وروابط الحسابات الموثّقة وحالة OG Viner.';
 
   @override
   String shareVideoInListsCount(int count) {

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -7691,7 +7691,7 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get profileBadgeCheckmarkBody =>
-      'Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.';
+      'Divine дава тази отметка на профилите на екипа и на малка група ръчно одобрени профили. Това е различно от NIP-05, потвърдените връзки към профила и статуса OG Viner.';
 
   @override
   String shareVideoInListsCount(int count) {

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -7691,7 +7691,7 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get profileBadgeCheckmarkBody =>
-      'Този профил е в списъка с отметки на профил на Divine. Това е различно от NIP-05, потвърдените връзки към профила и статуса OG Viner.';
+      'Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.';
 
   @override
   String shareVideoInListsCount(int count) {

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -7716,7 +7716,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get profileBadgeCheckmarkBody =>
-      'Dieses Konto steht auf Divines Liste für Profil-Häkchen. Das ist unabhängig von NIP-05, verifizierten Konto-Links und dem OG-Viner-Status.';
+      'Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.';
 
   @override
   String shareVideoInListsCount(int count) {

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -7716,7 +7716,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get profileBadgeCheckmarkBody =>
-      'Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.';
+      'Divine vergibt dieses Häkchen an Team-Konten und an eine kleine Zahl manuell freigegebener Profile. Das ist unabhängig von NIP-05, verifizierten Konto-Links und dem OG-Viner-Status.';
 
   @override
   String shareVideoInListsCount(int count) {

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -7604,7 +7604,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get profileBadgeCheckmarkBody =>
-      'This account is on Divine\'s profile checkmark list. It is separate from NIP-05, verified account links, and OG Viner status.';
+      'Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.';
 
   @override
   String shareVideoInListsCount(int count) {

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -7691,7 +7691,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get profileBadgeCheckmarkBody =>
-      'Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.';
+      'Divine da esta tilde a las cuentas del equipo y a un pequeño grupo de perfiles aprobados manualmente. Es independiente de NIP-05, de los enlaces de cuenta verificados y del estado OG Viner.';
 
   @override
   String shareVideoInListsCount(int count) {

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -7691,7 +7691,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get profileBadgeCheckmarkBody =>
-      'Esta cuenta está en la lista de tildes de perfil de Divine. Es independiente de NIP-05, de los enlaces de cuenta verificados y del estado OG Viner.';
+      'Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.';
 
   @override
   String shareVideoInListsCount(int count) {

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -7711,7 +7711,7 @@ class AppLocalizationsFil extends AppLocalizations {
 
   @override
   String get profileBadgeCheckmarkBody =>
-      'Nasa listahan ng profile checkmark ng Divine ang account na ito. Hiwalay ito sa NIP-05, sa mga verified na link ng account, at sa OG Viner status.';
+      'Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.';
 
   @override
   String shareVideoInListsCount(int count) {

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -7711,7 +7711,7 @@ class AppLocalizationsFil extends AppLocalizations {
 
   @override
   String get profileBadgeCheckmarkBody =>
-      'Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.';
+      'Ibinibigay ng Divine ang tsek na ito sa mga account ng team at sa iilang profile na manu-manong inaprubahan. Hiwalay ito sa NIP-05, sa mga verified na link ng account, at sa OG Viner status.';
 
   @override
   String shareVideoInListsCount(int count) {

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -7720,7 +7720,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get profileBadgeCheckmarkBody =>
-      'Ce compte figure sur la liste des coches de profil de Divine. C\'est indépendant de NIP-05, des liens de compte vérifiés et du statut OG Viner.';
+      'Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.';
 
   @override
   String shareVideoInListsCount(int count) {

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -7720,7 +7720,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get profileBadgeCheckmarkBody =>
-      'Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.';
+      'Divine attribue cette coche aux comptes de l\'équipe et à un petit nombre de profils approuvés manuellement. C\'est indépendant de NIP-05, des liens de compte vérifiés et du statut OG Viner.';
 
   @override
   String shareVideoInListsCount(int count) {

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -7580,7 +7580,7 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get profileBadgeCheckmarkBody =>
-      'Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.';
+      'Divine memberikan centang ini kepada akun tim dan sejumlah kecil profil yang disetujui secara manual. Ini terpisah dari NIP-05, tautan akun terverifikasi, dan status OG Viner.';
 
   @override
   String shareVideoInListsCount(int count) {

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -7580,7 +7580,7 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get profileBadgeCheckmarkBody =>
-      'Akun ini ada di daftar centang profil Divine. Ini terpisah dari NIP-05, tautan akun terverifikasi, dan status OG Viner.';
+      'Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.';
 
   @override
   String shareVideoInListsCount(int count) {

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -7695,7 +7695,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get profileBadgeCheckmarkBody =>
-      'Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.';
+      'Divine assegna questa spunta agli account del team e a un piccolo gruppo di profili approvati manualmente. È separato da NIP-05, dai link di account verificati e dallo status OG Viner.';
 
   @override
   String shareVideoInListsCount(int count) {

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -7695,7 +7695,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get profileBadgeCheckmarkBody =>
-      'Questo account è nella lista delle spunte di profilo di Divine. È separato da NIP-05, dai link di account verificati e dallo status OG Viner.';
+      'Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.';
 
   @override
   String shareVideoInListsCount(int count) {

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -7274,7 +7274,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get profileBadgeCheckmarkBody =>
-      'このアカウントは Divine のプロフィールチェックマークのリストに入ってる。NIP-05、認証済みアカウントのリンク、OG Viner ステータスとは別物だよ。';
+      'Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.';
 
   @override
   String shareVideoInListsCount(int count) {

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -7274,7 +7274,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get profileBadgeCheckmarkBody =>
-      'Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.';
+      'Divine はこのチェックマークをチームのアカウントと、手動で承認したごく少数のプロフィールに付けてるよ。 NIP-05、認証済みアカウントのリンク、OG Viner ステータスとは別物だよ。';
 
   @override
   String shareVideoInListsCount(int count) {

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -7299,7 +7299,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get profileBadgeCheckmarkBody =>
-      'Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.';
+      'Divine는 이 체크마크를 팀 계정과 직접 승인한 소수의 프로필에 부여해요. NIP-05, 인증된 계정 링크, OG Viner 상태와는 별개예요.';
 
   @override
   String shareVideoInListsCount(int count) {

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -7299,7 +7299,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get profileBadgeCheckmarkBody =>
-      '이 계정은 Divine의 프로필 체크마크 목록에 있어요. NIP-05, 인증된 계정 링크, OG Viner 상태와는 별개예요.';
+      'Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.';
 
   @override
   String shareVideoInListsCount(int count) {

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -7668,7 +7668,7 @@ class AppLocalizationsMs extends AppLocalizations {
 
   @override
   String get profileBadgeCheckmarkBody =>
-      'Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.';
+      'Divine memberikan tanda semak ini kepada akaun pasukan dan sebilangan kecil profil yang diluluskan secara manual. Ia berasingan daripada NIP-05, pautan akaun disahkan dan status OG Viner.';
 
   @override
   String shareVideoInListsCount(int count) {

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -7668,7 +7668,7 @@ class AppLocalizationsMs extends AppLocalizations {
 
   @override
   String get profileBadgeCheckmarkBody =>
-      'Akaun ini ada dalam senarai tanda semak profil Divine. Ia berasingan daripada NIP-05, pautan akaun disahkan dan status OG Viner.';
+      'Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.';
 
   @override
   String shareVideoInListsCount(int count) {

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -7652,7 +7652,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get profileBadgeCheckmarkBody =>
-      'Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.';
+      'Divine geeft dit vinkje aan teamaccounts en aan een klein aantal handmatig goedgekeurde profielen. Dat staat los van NIP-05, geverifieerde accountlinks en de OG Viner-status.';
 
   @override
   String shareVideoInListsCount(int count) {

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -7652,7 +7652,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get profileBadgeCheckmarkBody =>
-      'Dit account staat op Divine\'s lijst met profielvinkjes. Dat staat los van NIP-05, geverifieerde accountlinks en de OG Viner-status.';
+      'Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.';
 
   @override
   String shareVideoInListsCount(int count) {

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -7792,7 +7792,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get profileBadgeCheckmarkBody =>
-      'Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.';
+      'Divine przyznaje ten znacznik kontom zespołu i niewielkiej grupie ręcznie zatwierdzonych profili. To coś innego niż NIP-05, zweryfikowane linki konta i status OG Viner.';
 
   @override
   String shareVideoInListsCount(int count) {

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -7792,7 +7792,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get profileBadgeCheckmarkBody =>
-      'To konto jest na liście znaczników profilu Divine. To coś innego niż NIP-05, zweryfikowane linki konta i status OG Viner.';
+      'Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.';
 
   @override
   String shareVideoInListsCount(int count) {

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -7674,7 +7674,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get profileBadgeCheckmarkBody =>
-      'Essa conta está na lista de marcas de verificação de perfil da Divine. É separado do NIP-05, dos links de conta verificados e do status de Viner OG.';
+      'Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.';
 
   @override
   String shareVideoInListsCount(int count) {

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -7674,7 +7674,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get profileBadgeCheckmarkBody =>
-      'Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.';
+      'A Divine dá essa marca às contas da equipe e a um pequeno grupo de perfis aprovados manualmente. É separado do NIP-05, dos links de conta verificados e do status de Viner OG.';
 
   @override
   String shareVideoInListsCount(int count) {

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -7793,7 +7793,7 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get profileBadgeCheckmarkBody =>
-      'Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.';
+      'Divine dă bifa asta conturilor echipei și unui număr mic de profiluri aprobate manual. E separat de NIP-05, de linkurile de cont verificate și de statutul OG Viner.';
 
   @override
   String shareVideoInListsCount(int count) {

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -7793,7 +7793,7 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get profileBadgeCheckmarkBody =>
-      'Contul ăsta e pe lista de bife de profil a Divine. E separat de NIP-05, de linkurile de cont verificate și de statutul OG Viner.';
+      'Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.';
 
   @override
   String shareVideoInListsCount(int count) {

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -7612,7 +7612,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get profileBadgeCheckmarkBody =>
-      'Det här kontot finns på Divines lista över profilbockar. Det är skilt från NIP-05, verifierade kontolänkar och OG Viner-status.';
+      'Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.';
 
   @override
   String shareVideoInListsCount(int count) {

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -7612,7 +7612,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get profileBadgeCheckmarkBody =>
-      'Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.';
+      'Divine ger den här bocken till teamets konton och till ett litet antal manuellt godkända profiler. Det är skilt från NIP-05, verifierade kontolänkar och OG Viner-status.';
 
   @override
   String shareVideoInListsCount(int count) {

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -7580,7 +7580,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get profileBadgeCheckmarkBody =>
-      'Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.';
+      'Divine bu onay işaretini ekip hesaplarına ve elle onaylanmış az sayıda profile veriyor. NIP-05\'ten, doğrulanmış hesap bağlantılarından ve OG Viner durumundan ayrıdır.';
 
   @override
   String shareVideoInListsCount(int count) {

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -7580,7 +7580,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get profileBadgeCheckmarkBody =>
-      'Bu hesap Divine\'ın profil onay işareti listesinde. NIP-05\'ten, doğrulanmış hesap bağlantılarından ve OG Viner durumundan ayrıdır.';
+      'Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.';
 
   @override
   String shareVideoInListsCount(int count) {

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -7623,7 +7623,7 @@ class AppLocalizationsUr extends AppLocalizations {
 
   @override
   String get profileBadgeCheckmarkBody =>
-      'Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.';
+      'Divine یہ چیک مارک ٹیم کے اکاؤنٹس اور دستی طور پر منظور شدہ چند پروفائلز کو دیتا ہے۔ یہ NIP-05، تصدیق شدہ اکاؤنٹ لنکس اور OG Viner اسٹیٹس سے الگ ہے۔';
 
   @override
   String shareVideoInListsCount(int count) {

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -7623,7 +7623,7 @@ class AppLocalizationsUr extends AppLocalizations {
 
   @override
   String get profileBadgeCheckmarkBody =>
-      'یہ اکاؤنٹ Divine کی پروفائل چیک مارک فہرست میں ہے۔ یہ NIP-05، تصدیق شدہ اکاؤنٹ لنکس اور OG Viner اسٹیٹس سے الگ ہے۔';
+      'Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.';
 
   @override
   String shareVideoInListsCount(int count) {

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -7624,7 +7624,7 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get profileBadgeCheckmarkBody =>
-      'Tài khoản này nằm trong danh sách dấu tích hồ sơ của Divine. Nó tách biệt với NIP-05, liên kết tài khoản đã xác minh và trạng thái OG Viner.';
+      'Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.';
 
   @override
   String shareVideoInListsCount(int count) {

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -7624,7 +7624,7 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get profileBadgeCheckmarkBody =>
-      'Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.';
+      'Divine trao dấu tích này cho các tài khoản của đội ngũ và một số ít hồ sơ được duyệt thủ công. Nó tách biệt với NIP-05, liên kết tài khoản đã xác minh và trạng thái OG Viner.';
 
   @override
   String shareVideoInListsCount(int count) {

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -7234,7 +7234,7 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get profileBadgeCheckmarkBody =>
-      '这个账号在 Divine 的个人资料对勾名单里。它与 NIP-05、已验证的账号链接和 OG Viner 状态无关。';
+      'Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.';
 
   @override
   String shareVideoInListsCount(int count) {

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -7234,7 +7234,7 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get profileBadgeCheckmarkBody =>
-      'Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.';
+      'Divine 把这个对勾给团队账号，以及少数经过人工审核的个人资料。它与 NIP-05、已验证的账号链接和 OG Viner 状态无关。';
 
   @override
   String shareVideoInListsCount(int count) {

--- a/mobile/lib/widgets/og_viner_badge.dart
+++ b/mobile/lib/widgets/og_viner_badge.dart
@@ -6,9 +6,10 @@ import 'package:flutter/material.dart';
 import 'package:openvine/l10n/l10n.dart';
 
 class OgVinerBadge extends StatelessWidget {
-  const OgVinerBadge({super.key, this.size = 14});
+  const OgVinerBadge({super.key, this.size = 14, this.leadingGap = 4});
 
   final double size;
+  final double leadingGap;
 
   @override
   Widget build(BuildContext context) {
@@ -18,7 +19,7 @@ class OgVinerBadge extends StatelessWidget {
       container: true,
       child: ExcludeSemantics(
         child: Container(
-          margin: const EdgeInsetsDirectional.only(start: 4),
+          margin: EdgeInsetsDirectional.only(start: leadingGap),
           width: dimension,
           height: dimension,
           alignment: Alignment.center,

--- a/mobile/lib/widgets/profile/profile_header_identity.dart
+++ b/mobile/lib/widgets/profile/profile_header_identity.dart
@@ -141,7 +141,7 @@ class _ProfileHeaderNameRow extends ConsumerWidget {
         (service) => service.isOgViner(userIdHex),
       ),
     );
-    final showCheckmark = shouldShowSpecialProfileCheckmark(profile);
+    final showCheckmark = shouldShowSpecialProfileCheckmark(userIdHex);
     final name = isVanished
         // Deliberately not a UserName: that widget re-resolves the profile
         // through its own provider and falls back to a generated handle, which

--- a/mobile/lib/widgets/profile/profile_header_identity.dart
+++ b/mobile/lib/widgets/profile/profile_header_identity.dart
@@ -265,12 +265,14 @@ extension on ProfileBadgeExplanationType {
     return switch (this) {
       ProfileBadgeExplanationType.ogViner => const OgVinerBadge(
         size: _profileHeaderBadgeDiameter,
+        leadingGap: 0,
       ),
       // The checkmark sizes from the inside out: glyph plus ring padding.
       ProfileBadgeExplanationType.profileCheckmark =>
         const SpecialProfileCheckmark(
           iconSize: _profileHeaderBadgeDiameter - _checkmarkRing * 2,
           padding: _checkmarkRing,
+          leadingGap: 0,
         ),
     };
   }

--- a/mobile/lib/widgets/profile/profile_header_identity.dart
+++ b/mobile/lib/widgets/profile/profile_header_identity.dart
@@ -199,6 +199,18 @@ class _ProfileHeaderNameRow extends ConsumerWidget {
   }
 }
 
+/// Diameter of a header badge. Sized off the 22px display name beside it,
+/// where the inline badges elsewhere sit beside much smaller name rows.
+const double _profileHeaderBadgeDiameter = 22;
+
+/// Padding between the checkmark glyph and the edge of its filled circle.
+const double _checkmarkRing = 4;
+
+/// A profile badge in the header name row, tappable for its explainer.
+///
+/// Renders the same badge the feed and inline name rows show, so a checkmark
+/// reads identically wherever it appears. The header is the one place with
+/// room for a real touch target, so only here it opens the explainer.
 class _ProfileHeaderBadgeExplanationButton extends StatelessWidget {
   const _ProfileHeaderBadgeExplanationButton({required this.type});
 
@@ -206,16 +218,28 @@ class _ProfileHeaderBadgeExplanationButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final l10n = context.l10n;
-    return DivineIconButton(
-      icon: type.icon,
-      type: DivineIconButtonType.ghostSecondary,
-      size: DivineIconButtonSize.small,
-      showShadow: false,
-      tooltip: type.title(l10n),
-      semanticLabel: type.title(l10n),
-      semanticValue: type.body(l10n),
-      onPressed: () => showProfileBadgeExplanationSheet(context, type),
+    final title = type.title(context.l10n);
+    return Semantics(
+      label: title,
+      value: type.body(context.l10n),
+      button: true,
+      child: Material(
+        type: MaterialType.transparency,
+        child: InkResponse(
+          onTap: () => showProfileBadgeExplanationSheet(context, type),
+          child: Tooltip(
+            message: title,
+            // Same text as the label; announcing it twice adds nothing.
+            excludeFromSemantics: true,
+            child: SizedBox.square(
+              // The badge itself is smaller than the 48dp minimum, so the
+              // box around it — not the badge — carries the touch target.
+              dimension: DivineIcon.scaleSize(context, 48),
+              child: Center(child: ExcludeSemantics(child: type.badge)),
+            ),
+          ),
+        ),
+      ),
     );
   }
 }
@@ -237,10 +261,17 @@ extension on ProfileBadgeExplanationType {
     };
   }
 
-  DivineIconName get icon {
+  Widget get badge {
     return switch (this) {
-      ProfileBadgeExplanationType.ogViner => DivineIconName.videoCamera,
-      ProfileBadgeExplanationType.profileCheckmark => DivineIconName.check,
+      ProfileBadgeExplanationType.ogViner => const OgVinerBadge(
+        size: _profileHeaderBadgeDiameter,
+      ),
+      // The checkmark sizes from the inside out: glyph plus ring padding.
+      ProfileBadgeExplanationType.profileCheckmark =>
+        const SpecialProfileCheckmark(
+          iconSize: _profileHeaderBadgeDiameter - _checkmarkRing * 2,
+          padding: _checkmarkRing,
+        ),
     };
   }
 }

--- a/mobile/lib/widgets/profile/profile_header_widget.dart
+++ b/mobile/lib/widgets/profile/profile_header_widget.dart
@@ -41,6 +41,7 @@ import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:openvine/utils/user_profile_utils.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/linkified_text/linkified_text_widgets.dart';
+import 'package:openvine/widgets/og_viner_badge.dart';
 import 'package:openvine/widgets/profile/profile_action_buttons_widget.dart';
 import 'package:openvine/widgets/profile/profile_actions_sheet/profile_actions_sheet.dart';
 import 'package:openvine/widgets/profile/profile_followers_stat.dart';

--- a/mobile/lib/widgets/special_profile_checkmark.dart
+++ b/mobile/lib/widgets/special_profile_checkmark.dart
@@ -27,10 +27,12 @@ class SpecialProfileCheckmark extends StatelessWidget {
     super.key,
     this.iconSize = 10,
     this.padding = 2,
+    this.leadingGap = 4,
   });
 
   final double iconSize;
   final double padding;
+  final double leadingGap;
 
   @override
   Widget build(BuildContext context) {
@@ -39,9 +41,9 @@ class SpecialProfileCheckmark extends StatelessWidget {
       container: true,
       child: ExcludeSemantics(
         child: Padding(
-          padding: const EdgeInsetsDirectional.only(start: 4),
+          padding: EdgeInsetsDirectional.only(start: leadingGap),
           child: Container(
-            padding: EdgeInsets.all(padding),
+            padding: EdgeInsets.all(DivineIcon.scaleSize(context, padding)),
             decoration: const BoxDecoration(
               color: VineTheme.info,
               shape: BoxShape.circle,

--- a/mobile/lib/widgets/special_profile_checkmark.dart
+++ b/mobile/lib/widgets/special_profile_checkmark.dart
@@ -1,45 +1,22 @@
-// ABOUTME: Hosts explicit exceptions for profile checkmark display.
-// ABOUTME: Keeps special-case badges separate from generic NIP-05 validation.
+// ABOUTME: Decides which profiles carry the Divine team checkmark.
+// ABOUTME: Keeps the team badge separate from generic NIP-05 validation.
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:models/models.dart';
+import 'package:openvine/config/official_accounts.dart';
 import 'package:openvine/l10n/l10n.dart';
 
-const _specialProfileHosts = {
-  'kirstenswasey.divine.video',
-  'rabble.divine.video',
-};
-
-const _specialProfilePubkeys = {
-  'aa50001ef150418f30f62f827399d5c26a5ade52ab45ca4849f99b1726bb47b4',
-};
-
+/// Whether [profile] carries the Divine team checkmark.
+///
+/// Matches on pubkey alone. A NIP-05 identifier is not an input: the name
+/// server can reassign a handle, which would carry the checkmark to whoever
+/// claims it next.
 bool shouldShowSpecialProfileCheckmark(UserProfile? profile) {
   if (profile == null) return false;
-  return _specialProfilePubkeys.contains(profile.pubkey.toLowerCase()) ||
-      _matchesSpecialProfile(profile.nip05) ||
-      _matchesSpecialProfile(profile.displayNip05);
-}
-
-bool _matchesSpecialProfile(String? identifier) {
-  final host = _hostFromProfileIdentifier(identifier);
-  return _specialProfileHosts.contains(host);
-}
-
-String? _hostFromProfileIdentifier(String? identifier) {
-  if (identifier == null) return null;
-  final value = identifier.trim().toLowerCase();
-  if (value.isEmpty) return null;
-
-  final uri = Uri.tryParse(value);
-  if ((uri?.hasScheme ?? false) && uri!.host.isNotEmpty) {
-    return uri.host;
-  }
-
-  final atIndex = value.indexOf('@');
-  final hostLikeValue = atIndex == -1 ? value : value.substring(atIndex + 1);
-  return hostLikeValue.split('/').first;
+  final pubkey = profile.pubkey.toLowerCase();
+  return kDivineTeamPubkeys.contains(pubkey) ||
+      kLegacyProfileCheckmarkPubkeys.contains(pubkey);
 }
 
 class SpecialProfileCheckmark extends StatelessWidget {

--- a/mobile/lib/widgets/special_profile_checkmark.dart
+++ b/mobile/lib/widgets/special_profile_checkmark.dart
@@ -3,18 +3,21 @@
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
-import 'package:models/models.dart';
 import 'package:openvine/config/official_accounts.dart';
 import 'package:openvine/l10n/l10n.dart';
 
-/// Whether [profile] carries the Divine team checkmark.
+/// Whether [pubkeyHex] carries the Divine team checkmark.
 ///
 /// Matches on pubkey alone. A NIP-05 identifier is not an input: the name
 /// server can reassign a handle, which would carry the checkmark to whoever
 /// claims it next.
-bool shouldShowSpecialProfileCheckmark(UserProfile? profile) {
-  if (profile == null) return false;
-  final pubkey = profile.pubkey.toLowerCase();
+///
+/// Takes the pubkey rather than the profile so the badge does not wait on a
+/// kind-0 that cannot change the answer — a team member whose profile is slow
+/// or never resolves still gets their checkmark on first paint.
+bool shouldShowSpecialProfileCheckmark(String? pubkeyHex) {
+  if (pubkeyHex == null) return false;
+  final pubkey = pubkeyHex.toLowerCase();
   return kDivineTeamPubkeys.contains(pubkey) ||
       kLegacyProfileCheckmarkPubkeys.contains(pubkey);
 }

--- a/mobile/lib/widgets/user_name.dart
+++ b/mobile/lib/widgets/user_name.dart
@@ -108,7 +108,6 @@ class UserName extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     late String displayName;
     late String effectivePubkey;
-    UserProfile? resolvedProfile;
 
     // When [neverGenerateName] is set, an empty placeholder replaces the
     // generated handle everywhere it would otherwise appear, so the caller
@@ -120,12 +119,10 @@ class UserName extends ConsumerWidget {
     final placeholder = anonymousName ?? (neverGenerateName ? '' : null);
 
     if (userProfile case final userProfile?) {
-      resolvedProfile = userProfile;
       effectivePubkey = userProfile.pubkey;
       displayName = userProfile.betterDisplayName(placeholder);
     } else {
       final profileAsync = ref.watch(userProfileReactiveProvider(pubkey!));
-      resolvedProfile = profileAsync.value;
       effectivePubkey = pubkey!;
 
       // Precedence mirrors UserProfile.betterDisplayName: a real name embedded
@@ -183,7 +180,7 @@ class UserName extends ConsumerWidget {
                 ),
         ),
         if (showProfileBadges &&
-            shouldShowSpecialProfileCheckmark(resolvedProfile))
+            shouldShowSpecialProfileCheckmark(effectivePubkey))
           const SpecialProfileCheckmark(),
         if (isOgViner) const OgVinerBadge(),
       ],

--- a/mobile/lib/widgets/video_feed_item/video_feed_item.dart
+++ b/mobile/lib/widgets/video_feed_item/video_feed_item.dart
@@ -376,7 +376,7 @@ class VideoOverlayActions extends ConsumerWidget {
                                       ),
                                     ),
                                     if (shouldShowSpecialProfileCheckmark(
-                                      profile,
+                                      authorPubkey,
                                     ))
                                       const SpecialProfileCheckmark(),
                                     if (isOgViner) const OgVinerBadge(),

--- a/mobile/test/config/official_accounts_test.dart
+++ b/mobile/test/config/official_accounts_test.dart
@@ -116,11 +116,16 @@ void main() {
         );
       });
 
-      // Sebastian and Rabble are on the team list and in the curation
-      // constants. The two lists grant different things and are allowed to
-      // diverge, so this only pins that the shared entries agree today —
-      // catching a typo in one copy, not forbidding a future split.
-      test('shared entries agree with the curation constants', () {
+      // Sebastian and Rabble are spelled out in both this file and the
+      // curation constants, so a rotation or a typo can move one copy and
+      // leave the other behind.
+      //
+      // Pinned in one direction only, and deliberately: an account trusted to
+      // publish Divine's official kind-30005 lists is acting as Divine, so it
+      // should carry the badge too. The reverse is not required — the lists
+      // stay separate so that adding a team member never hands out curation
+      // authority, which is the direction that actually matters.
+      test('every curation pubkey is also a team pubkey', () {
         for (final pubkey in AppConstants.divineTeamPubkeys) {
           expect(kDivineTeamPubkeys, contains(pubkey));
         }

--- a/mobile/test/config/official_accounts_test.dart
+++ b/mobile/test/config/official_accounts_test.dart
@@ -4,6 +4,7 @@
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/config/official_accounts.dart';
+import 'package:openvine/constants/app_constants.dart';
 import 'package:openvine/services/moderation_label_service.dart';
 
 void main() {
@@ -87,6 +88,43 @@ void main() {
     // de-duplicating.
     test('no retired key is also the current key', () {
       expect(kLegacyModerationPubkeys, isNot(contains(kModerationPubkeyHex)));
+    });
+
+    group('profile checkmark pubkeys', () {
+      // Lookups lowercase the profile's pubkey before testing membership, so
+      // an entry pasted in mixed case matches nobody — no crash, no analyzer
+      // complaint, just a team member who never gets the checkmark.
+      final checkmarkPubkeys = {
+        ...kDivineTeamPubkeys,
+        ...kLegacyProfileCheckmarkPubkeys,
+      };
+
+      test('every entry is a 64-character lowercase hex pubkey', () {
+        for (final pubkey in checkmarkPubkeys) {
+          expect(
+            pubkey,
+            matches(RegExp(r'^[0-9a-f]{64}$')),
+            reason: '$pubkey is not a lowercase hex pubkey',
+          );
+        }
+      });
+
+      test('the two sets do not overlap', () {
+        expect(
+          kDivineTeamPubkeys.intersection(kLegacyProfileCheckmarkPubkeys),
+          isEmpty,
+        );
+      });
+
+      // Sebastian and Rabble are on the team list and in the curation
+      // constants. The two lists grant different things and are allowed to
+      // diverge, so this only pins that the shared entries agree today —
+      // catching a typo in one copy, not forbidding a future split.
+      test('shared entries agree with the curation constants', () {
+        for (final pubkey in AppConstants.divineTeamPubkeys) {
+          expect(kDivineTeamPubkeys, contains(pubkey));
+        }
+      });
     });
   });
 }

--- a/mobile/test/widgets/profile/profile_header_widget_test.dart
+++ b/mobile/test/widgets/profile/profile_header_widget_test.dart
@@ -344,6 +344,7 @@ void main() {
       bool monetizationLinksEnabled = false,
       ThemeData? theme,
       bool disableAnimations = false,
+      TextScaler? textScaler,
       bool renderHeader = true,
       MockAuthService? authService,
     }) {
@@ -468,9 +469,10 @@ void main() {
           theme: theme,
           home: Builder(
             builder: (context) => MediaQuery(
-              data: MediaQuery.of(
-                context,
-              ).copyWith(disableAnimations: disableAnimations),
+              data: MediaQuery.of(context).copyWith(
+                disableAnimations: disableAnimations,
+                textScaler: textScaler ?? MediaQuery.textScalerOf(context),
+              ),
               child: Scaffold(body: SingleChildScrollView(child: header)),
             ),
           ),
@@ -630,6 +632,37 @@ void main() {
       expect(find.text(l10n.profileBadgeCheckmarkTitle), findsWidgets);
       expect(find.text(l10n.profileBadgeCheckmarkBody), findsOneWidget);
       expect(find.text(l10n.commonClose), findsOneWidget);
+    });
+
+    testWidgets('header badges keep matching diameters at capped text scale', (
+      tester,
+    ) async {
+      final teamPubkey = kDivineTeamPubkeys.first;
+      SharedPreferences.setMockInitialValues({
+        ogVinerPubkeysCacheKey: jsonEncode([teamPubkey]),
+      });
+      final prefs = await SharedPreferences.getInstance();
+
+      await tester.pumpWidget(
+        buildTestWidget(
+          userIdHex: teamPubkey,
+          isOwnProfile: false,
+          suppliedProfile: createTestProfile(
+            displayName: 'Checked OG User',
+            pubkey: teamPubkey,
+          ),
+          sharedPreferences: prefs,
+          textScaler: const TextScaler.linear(2),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(SpecialProfileCheckmark), findsOneWidget);
+      expect(find.byType(OgVinerBadge), findsOneWidget);
+      expect(
+        tester.getSize(find.byType(SpecialProfileCheckmark)),
+        equals(tester.getSize(find.byType(OgVinerBadge))),
+      );
     });
 
     testWidgets('badge detail sheet opens the in-app badge editor', (

--- a/mobile/test/widgets/profile/profile_header_widget_test.dart
+++ b/mobile/test/widgets/profile/profile_header_widget_test.dart
@@ -20,6 +20,7 @@ import 'package:nostr_sdk/nostr_sdk.dart';
 import 'package:openvine/blocs/background_publish/background_publish_bloc.dart';
 import 'package:openvine/blocs/my_profile/my_profile_bloc.dart';
 import 'package:openvine/blocs/others_followers/others_followers_bloc.dart';
+import 'package:openvine/config/official_accounts.dart';
 import 'package:openvine/constants/semantic_ids.dart';
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
 import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
@@ -37,10 +38,12 @@ import 'package:openvine/services/auth_service.dart' hide UserProfile;
 import 'package:openvine/services/og_viner_cache_service.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
+import 'package:openvine/widgets/og_viner_badge.dart';
 import 'package:openvine/widgets/profile/profile_action_buttons_widget.dart';
 import 'package:openvine/widgets/profile/profile_header_widget.dart';
 import 'package:openvine/widgets/profile/profile_stats_row_widget.dart';
 import 'package:openvine/widgets/profile/profile_website_row.dart';
+import 'package:openvine/widgets/special_profile_checkmark.dart';
 import 'package:openvine/widgets/user_avatar.dart';
 import 'package:openvine/widgets/user_profile_tile.dart';
 import 'package:openvine/widgets/vine_cached_image.dart';
@@ -277,9 +280,10 @@ void main() {
       Map<String, dynamic> rawData = const {},
       DateTime? createdAt,
       String eventId = 'test-event',
+      String pubkey = testUserHex,
     }) {
       return UserProfile(
-        pubkey: testUserHex,
+        pubkey: pubkey,
         rawData: {
           'display_name': ?displayName,
           'name': ?name,
@@ -570,14 +574,10 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      final target = find.byTooltip(l10n.ogVinerBadgeLabel);
-      expect(target, findsOneWidget);
-      expect(find.text('V'), findsNothing);
-      final button = find.ancestor(
-        of: target,
-        matching: find.byType(DivineIconButton),
-      );
+      final button = find.byTooltip(l10n.ogVinerBadgeLabel);
       expect(button, findsOneWidget);
+      // The header shows the same badge as the feed, glyph and all.
+      expect(find.byType(OgVinerBadge), findsOneWidget);
       // The badge must stay a real tap target; the exact box is the design
       // system's to decide, so assert the 48dp floor rather than a number.
       final buttonSize = tester.getSize(button);
@@ -599,23 +599,25 @@ void main() {
 
       await tester.pumpWidget(
         buildTestWidget(
-          userIdHex: testUserHex,
+          userIdHex: kDivineTeamPubkeys.first,
           isOwnProfile: false,
           suppliedProfile: createTestProfile(
             displayName: 'Checked User',
-            nip05: 'rabble.divine.video',
+            pubkey: kDivineTeamPubkeys.first,
           ),
         ),
       );
       await tester.pumpAndSettle();
 
-      final target = find.byTooltip(l10n.profileBadgeCheckmarkTitle);
-      expect(target, findsOneWidget);
-      final button = find.ancestor(
-        of: target,
-        matching: find.byType(DivineIconButton),
-      );
+      final button = find.byTooltip(l10n.profileBadgeCheckmarkTitle);
       expect(button, findsOneWidget);
+      // The header shows the same blue checkmark badge as the feed.
+      expect(find.byType(SpecialProfileCheckmark), findsOneWidget);
+      // The badge widget carries its own label; announcing the meaning once,
+      // as the tappable node, is the contract the header has to keep.
+      final semantics = tester.getSemantics(button);
+      expect(semantics.label, equals(l10n.profileBadgeCheckmarkTitle));
+      expect(semantics.value, equals(l10n.profileBadgeCheckmarkBody));
       // The badge must stay a real tap target; the exact box is the design
       // system's to decide, so assert the 48dp floor rather than a number.
       final buttonSize = tester.getSize(button);

--- a/mobile/test/widgets/user_name_nip05_test.dart
+++ b/mobile/test/widgets/user_name_nip05_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:models/models.dart';
+import 'package:openvine/config/official_accounts.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/nip05_verification_provider.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
@@ -59,11 +60,29 @@ void main() {
     expect(_specialCheckmark(), findsNothing);
   });
 
-  testWidgets('shows a checkmark for Kirsten Swasey special profile', (
+  testWidgets('shows a checkmark for a Divine team pubkey', (tester) async {
+    await tester.pumpWidget(buildSubject(pubkey: kDivineTeamPubkeys.first));
+    await tester.pump();
+
+    expect(find.text('Alice'), findsOneWidget);
+    expect(_specialCheckmark(), findsOneWidget);
+  });
+
+  testWidgets('shows a checkmark for a grandfathered pubkey', (tester) async {
+    await tester.pumpWidget(
+      buildSubject(pubkey: kLegacyProfileCheckmarkPubkeys.first),
+    );
+    await tester.pump();
+
+    expect(find.text('Alice'), findsOneWidget);
+    expect(_specialCheckmark(), findsOneWidget);
+  });
+
+  testWidgets('matches a Divine team pubkey case-insensitively', (
     tester,
   ) async {
     await tester.pumpWidget(
-      buildSubject(nip05: '_@kirstenswasey.divine.video'),
+      buildSubject(pubkey: kDivineTeamPubkeys.first.toUpperCase()),
     );
     await tester.pump();
 
@@ -71,35 +90,14 @@ void main() {
     expect(_specialCheckmark(), findsOneWidget);
   });
 
-  testWidgets('matches the Kirsten Swasey profile URL host', (tester) async {
-    await tester.pumpWidget(
-      buildSubject(nip05: 'http://kirstenswasey.divine.video'),
-    );
-    await tester.pump();
-
-    expect(find.text('Alice'), findsOneWidget);
-    expect(_specialCheckmark(), findsOneWidget);
-  });
-
-  testWidgets('shows a checkmark for Rabble special profile', (tester) async {
+  testWidgets('does not show a checkmark for a divine.video NIP-05', (
+    tester,
+  ) async {
     await tester.pumpWidget(buildSubject(nip05: '_@rabble.divine.video'));
     await tester.pump();
 
     expect(find.text('Alice'), findsOneWidget);
-    expect(_specialCheckmark(), findsOneWidget);
-  });
-
-  testWidgets('shows a checkmark for special profile pubkey', (tester) async {
-    await tester.pumpWidget(
-      buildSubject(
-        pubkey:
-            'aa50001ef150418f30f62f827399d5c26a5ade52ab45ca4849f99b1726bb47b4',
-      ),
-    );
-    await tester.pump();
-
-    expect(find.text('Alice'), findsOneWidget);
-    expect(_specialCheckmark(), findsOneWidget);
+    expect(_specialCheckmark(), findsNothing);
   });
 
   testWidgets('sanitizes embedded display name fallback while profile loads', (

--- a/mobile/test/widgets/user_name_nip05_test.dart
+++ b/mobile/test/widgets/user_name_nip05_test.dart
@@ -90,6 +90,35 @@ void main() {
     expect(_specialCheckmark(), findsOneWidget);
   });
 
+  // The badge is decided by pubkey, so it must not wait on a kind-0 that
+  // cannot change the answer. The OG Viner badge beside it already resolves
+  // from the pubkey; gating this one on the profile made the two arrive at
+  // different times, and never at all when the profile failed to resolve.
+  testWidgets('shows a checkmark before the profile resolves', (tester) async {
+    final teamPubkey = kDivineTeamPubkeys.first;
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          userProfileReactiveProvider(
+            teamPubkey,
+          ).overrideWith((ref) => const Stream<UserProfile?>.empty()),
+          nip05VerificationProvider.overrideWith(
+            (ref, pubkey) async => Nip05VerificationStatus.none,
+          ),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(body: UserName.fromPubKey(teamPubkey)),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(_specialCheckmark(), findsOneWidget);
+  });
+
   testWidgets('does not show a checkmark for a divine.video NIP-05', (
     tester,
   ) async {

--- a/mobile/test/widgets/video_feed_item/video_overlay_actions_description_test.dart
+++ b/mobile/test/widgets/video_feed_item/video_overlay_actions_description_test.dart
@@ -10,6 +10,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/video_interactions/video_interactions_bloc.dart';
+import 'package:openvine/config/official_accounts.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/nip05_verification_provider.dart';
@@ -205,10 +206,12 @@ void main() {
   });
 
   testWidgets(
-    'author line shows checkmark for Kirsten Swasey special profile',
+    'author line shows checkmark for a Divine team pubkey',
     (
       tester,
     ) async {
+      testVideo = testVideo.copyWith(pubkey: kDivineTeamPubkeys.first);
+
       await tester.pumpWidget(
         testProviderScope(
           additionalOverrides: [
@@ -217,7 +220,7 @@ void main() {
               yield UserProfile(
                 pubkey: pubkey,
                 name: 'Alice',
-                nip05: '_@kirstenswasey.divine.video',
+                nip05: 'alice@example.com',
                 rawData: const {},
                 createdAt: DateTime(2026),
                 eventId: 'kind0_event_id',


### PR DESCRIPTION
Closes #7420

## Description

The profile checkmark reached exactly two accounts and matched partly on NIP-05 host. Because it renders next to the NIP-05 identifier line, it read as "this NIP-05 is verified" — while everyone else with a valid, verified `*.divine.video` NIP-05 got nothing, and people kept asking how to get one. There was no answer to give them: no criteria, no application, no backend.

This extends the mark to the Divine team, so the badge stands for something we can state out loud, and removes the host matching that made it look like NIP-05 verification.

### Matching is pubkey-only now

A NIP-05 host is a name `divine-name-server` hands out and can reassign, so a host rule carries the checkmark to whoever claims the handle next. The host set and its two parsing helpers (`_matchesSpecialProfile`, `_hostFromProfileIdentifier`) are gone. Kirsten's existing mark is preserved by resolving her handle through `kirstenswasey.divine.video/.well-known/nostr.json` to a pubkey — nobody loses a badge they already had.

Every npub in this PR was decoded with bech32 checksum validation rather than string munging, so a typo would have failed loudly instead of resolving to a wrong-but-plausible hex value.

Because the answer now depends on nothing but the pubkey, `shouldShowSpecialProfileCheckmark` takes the pubkey rather than the profile. Gating it on a resolved kind-0 meant the badge waited on a fetch that could not change the outcome: the OG Viner badge sitting in the same row already resolves from the pubkey, so one badge painted immediately and the other arrived late — or never, when the profile failed to resolve. All three call sites already had the pubkey in hand.

### Where the list lives

`kDivineTeamPubkeys` in `official_accounts.dart`, next to the other shipped identities, with each entry named. **15 entries**: 14 people plus Divine HQ, which reuses the new `kHqPubkeyHex` rather than repeating the literal already declared in that file — same single-sourcing rule `kModerationPubkeyHex` already follows, and for the same reason: two copies can drift onto different keys on the next rotation.

Deliberately kept separate from `AppConstants.divineTeamPubkeys`, which grants kind-30005 curation authority. Being on the team and curating official lists are different permissions, and the separation exists to protect one direction in particular: adding a team member must never hand out curation authority. The other direction is pinned by a test — an account trusted to publish Divine's official lists is acting as Divine, so it carries the badge too. That test is also what catches Sebastian's and Rabble's duplicated keys drifting apart on the next rotation.

`kLegacyProfileCheckmarkPubkeys` holds 3 entries that are not team members, so they are visible as exactly that rather than quietly relabelled as staff. Two are grandfathered from the host rule; "Improvising" is a new grant, and the set's doc says so rather than implying all three predate the team rule.

### Header badge

The header now renders the same blue checkmark the feed shows. The ghost icon button drew a plain white glyph, which reads as an action rather than as the badge it explains. The 48dp touch target and the semantics contract are unchanged, and both are still asserted.

## Related Issues

- Closes #7420
- Refs #6154 for moving the roster out of the app binary / backend-managed checkmark state.
- Refs #7248 for detecting stale English revisions and wrong-language ARB values.

## Out of Scope

- **`kLegacyProfileCheckmarkPubkeys` needs a decision.** One entry (`aa50001e…`) has no owner named in the PR or issue that introduced it (#4537). Each entry should either move into `kDivineTeamPubkeys` or go away once its status is settled. The set is now described accurately, but describing it is not deciding it.
- No backend. The list is still a `const` in the app binary, so every change needs a PR plus a release. See #6154.
- ARB parity still does not detect a translated locale whose value is accidentally left in English. See #7248.

## Verification

- `flutter analyze lib test integration_test` — no issues
- 503 tests green across `test/config/official_accounts_test.dart`, `test/widgets/user_name_nip05_test.dart`, `test/widgets/user_name_og_viner_badge_test.dart`, `test/widgets/user_name_generated_fallback_test.dart`, `test/widgets/special_profile_checkmark_test.dart`, `test/widgets/video_feed_item/`, `test/widgets/profile/profile_header_widget_test.dart`
- `mobile/scripts/golden.sh verify` — all goldens pass, none needed updating
- Manually verified on a real Samsung Galaxy
- The three removed host rules were re-resolved live against `.well-known/nostr.json` to confirm the pubkeys they map to are the ones this PR ships: `rabble` → `d95aa8fc…`, `kirstenswasey` → `cd4ce30f…`, `divinehq` → `c4a39f12…`
- New invariants in `official_accounts_test.dart`: every entry is 64-char lowercase hex (lookups lowercase the profile pubkey, so a mixed-case entry silently matches nobody — no crash, no analyzer warning, just a team member without a checkmark), the two sets do not overlap, and every curation pubkey is also a team pubkey
- Tests rewired rather than deleted: the three host-based tests now go through team pubkeys, plus a case-insensitivity test and a regression test that a `*.divine.video` NIP-05 renders no checkmark — re-adding a host rule fails the suite
- A regression test pins that the checkmark renders before the profile resolves; it was confirmed to fail against the profile-gated version rather than merely passing against the new one

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
