### PR TITLE
fix(notifications): always send mark-all read

### DIFF
--- a/mobile/lib/notifications/bloc/notification_feed_bloc.dart
+++ b/mobile/lib/notifications/bloc/notification_feed_bloc.dart
@@ -143,13 +143,14 @@ class NotificationFeedBloc
   /// (loading -> loaded / failure) are emitted here so the UI can render
   /// the initial spinner and error states.
   ///
-  /// After a successful refresh, advances the server "seen" watermark via
+  /// After a successful refresh, sends the server mark-all write via
   /// [_markSeenOnOpen] so opening the notifications surface clears the unread
   /// badge and the badge thereafter reflects "new since last seen" rather than
   /// the accumulated untapped total (#4708). `_onStarted` fires once per open
   /// (it is dispatched from the keyed `BlocProvider.create` on every mount of
-  /// the notifications surface) and is NOT dispatched on app resume or
-  /// pull-to-refresh, so the watermark only advances on a deliberate open.
+  /// the notifications surface) and is NOT dispatched on app resume. The
+  /// unfiltered pull-to-refresh handler also marks seen after a successful
+  /// refresh because the notifications surface is already deliberately open.
   Future<void> _onStarted(
     NotificationFeedStarted event,
     Emitter<NotificationFeedState> emit,
@@ -227,11 +228,11 @@ class NotificationFeedBloc
     }
   }
 
-  /// Advances the server "seen" watermark when the notifications surface opens.
+  /// Marks notifications seen when the notifications surface is open.
   ///
   /// Reuses [NotificationRepository.markAllAsRead] — the single source of truth
-  /// that posts `read_until = now()` to FunnelCake, optimistically flips the
-  /// snapshot (so the badge clears immediately), and rolls back on failure.
+  /// that sends the server mark-all write, optimistically flips the snapshot
+  /// (so the badge clears immediately), and rolls back on failure.
   /// Going through the repository (not a widget lifecycle hook) is what keeps
   /// the badge convergent; the previous `MarkAllReadOnDispose` widget that
   /// marked-on-*leave* fought the snapshot and was removed in #4758. This marks
@@ -339,6 +340,9 @@ class NotificationFeedBloc
         ),
       );
       _flushPendingEmptyPageContinuation();
+      if (_filter == null) {
+        await _markSeenOnOpen();
+      }
     } on Exception catch (e, s) {
       // `NotificationRepository.refresh` propagates typed
       // `FunnelcakeException` (4xx/5xx/timeout). Per

--- a/mobile/lib/notifications/bloc/notification_feed_bloc.dart
+++ b/mobile/lib/notifications/bloc/notification_feed_bloc.dart
@@ -144,7 +144,7 @@ class NotificationFeedBloc
   /// the initial spinner and error states.
   ///
   /// After a successful refresh, sends the server mark-all write via
-  /// [_markSeenOnOpen] so opening the notifications surface clears the unread
+  /// [_markSeen] so opening the notifications surface clears the unread
   /// badge and the badge thereafter reflects "new since last seen" rather than
   /// the accumulated untapped total (#4708). `_onStarted` fires once per open
   /// (it is dispatched from the keyed `BlocProvider.create` on every mount of
@@ -165,6 +165,10 @@ class NotificationFeedBloc
 
     try {
       await _notificationRepository.refreshFeed(_filter);
+      var markSucceeded = false;
+      if (_filter == null) {
+        markSucceeded = await _markSeenOnOpen();
+      }
       emit(
         state.copyWith(
           status: NotificationFeedStatus.loaded,
@@ -172,11 +176,8 @@ class NotificationFeedBloc
         ),
       );
       _flushPendingEmptyPageContinuation();
-      if (_filter == null) {
-        final markSucceeded = await _markSeenOnOpen();
-        if (markSucceeded) {
-          unawaited(_clearAppBadge());
-        }
+      if (markSucceeded) {
+        unawaited(_clearAppBadge());
       }
     } on Exception catch (e, s) {
       // `NotificationRepository.refresh` propagates typed
@@ -236,7 +237,7 @@ class NotificationFeedBloc
   /// Going through the repository (not a widget lifecycle hook) is what keeps
   /// the badge convergent; the previous `MarkAllReadOnDispose` widget that
   /// marked-on-*leave* fought the snapshot and was removed in #4758. This marks
-  /// on *open* instead.
+  /// while the notifications surface is deliberately open instead.
   ///
   /// A seen-advance failure must never blacken the feed, so every error is
   /// caught here and never rethrown — the repository has already restored the
@@ -333,6 +334,9 @@ class NotificationFeedBloc
     emit(state.copyWith(isRefreshing: true));
     try {
       await _notificationRepository.refreshFeed(_filter);
+      if (_filter == null) {
+        await _markSeenOnOpen();
+      }
       emit(
         state.copyWith(
           status: NotificationFeedStatus.loaded,
@@ -340,9 +344,6 @@ class NotificationFeedBloc
         ),
       );
       _flushPendingEmptyPageContinuation();
-      if (_filter == null) {
-        await _markSeenOnOpen();
-      }
     } on Exception catch (e, s) {
       // `NotificationRepository.refresh` propagates typed
       // `FunnelcakeException` (4xx/5xx/timeout). Per

--- a/mobile/lib/notifications/bloc/reportable_sites.dart
+++ b/mobile/lib/notifications/bloc/reportable_sites.dart
@@ -19,7 +19,7 @@ abstract class NotificationFeedBlocReportableSites {
 
   /// `_markSeenOnOpen` generic-catch arm — `Error` types that escape
   /// `NotificationRepository.markAllAsRead`'s rollback `catch (_)` rethrow
-  /// when the notifications surface advances the seen watermark on open.
+  /// when the notifications surface sends the server mark-all write.
   /// Realistically a Drift DAO `TypeError` from a row-shape mismatch.
   static const String markSeenOnOpen = '_markSeenOnOpen';
 

--- a/mobile/lib/notifications/bloc/reportable_sites.dart
+++ b/mobile/lib/notifications/bloc/reportable_sites.dart
@@ -17,7 +17,7 @@ abstract class NotificationFeedBlocReportableSites {
   /// `_fetchWithRetry` if the analyzer's loop invariant ever breaks.
   static const String onStarted = '_onStarted';
 
-  /// `_markSeenOnOpen` generic-catch arm — `Error` types that escape
+  /// `_markSeen` generic-catch arm — `Error` types that escape
   /// `NotificationRepository.markAllAsRead`'s rollback `catch (_)` rethrow
   /// when the notifications surface sends the server mark-all write.
   /// Realistically a Drift DAO `TypeError` from a row-shape mismatch.

--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -1150,9 +1150,10 @@ class NotificationRepository {
 
   /// Marks all notifications as read on the server and locally.
   ///
-  /// Optimistically flips every item in the snapshot to `isRead: true`,
-  /// then writes through to the API and the local DAO. On failure,
-  /// restores the pre-write snapshot — preserves the rollback semantics
+  /// Always sends the explicit server mark-all request, even when no live
+  /// snapshot has local unread rows. The optimistic local flip still only
+  /// touches feeds that contain unread rows. On failure, restores the
+  /// pre-write snapshot for those feeds — preserving the rollback semantics
   /// introduced by PR #4034 at the repository layer so every consumer
   /// (badge cubit, feed bloc) recovers consistently.
   ///
@@ -1169,7 +1170,6 @@ class NotificationRepository {
       pagesLoadedBefore[feed] = feed.pagesLoaded;
       feed.snapshot.add(page.copyWith(items: _flipAllRead(page.items)));
     }
-    if (snapshotsBefore.isEmpty) return;
 
     try {
       final url = _funnelcakeApiClient

--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -5806,15 +5806,44 @@ void main() {
         expect(repository.hasPaginatedBeyondFirstPage, isTrue);
       });
 
-      test('markAllAsRead is a no-op when nothing is unread', () async {
+      test('markAllAsRead posts when nothing is unread locally', () async {
         await repository.markAllAsRead();
 
-        verifyNever(
+        verify(
           () => funnelcakeApiClient.markNotificationsRead(
             pubkey: any(named: 'pubkey'),
             authHeaders: any(named: 'authHeaders'),
           ),
-        );
+        ).called(1);
+        verify(
+          () => notificationsDao.markAllAsRead(
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        ).called(1);
+      });
+
+      test('markAllAsRead does not emit when nothing flips', () async {
+        stubNotifications([
+          makeNotification(read: true),
+        ]);
+        await repository.refresh();
+
+        final emissions = <NotificationPage>[];
+        final subscription = repository.watchSnapshot().listen(emissions.add);
+        addTearDown(subscription.cancel);
+        await Future<void>.delayed(Duration.zero);
+        emissions.clear();
+
+        await repository.markAllAsRead();
+        await Future<void>.delayed(Duration.zero);
+
+        expect(emissions, isEmpty);
+        verify(
+          () => funnelcakeApiClient.markNotificationsRead(
+            pubkey: any(named: 'pubkey'),
+            authHeaders: any(named: 'authHeaders'),
+          ),
+        ).called(1);
       });
 
       test('markAllAsRead optimistically zeros every unread item', () async {

--- a/mobile/test/notifications/bloc/notification_feed_bloc_test.dart
+++ b/mobile/test/notifications/bloc/notification_feed_bloc_test.dart
@@ -234,7 +234,7 @@ void main() {
           NotificationFeedState(status: NotificationFeedStatus.loaded),
         ],
         verify: (_) {
-          // Seen-on-open advances the server watermark AFTER the refresh so
+          // Seen-on-open sends the server mark-all write AFTER the refresh so
           // the badge clears and thereafter shows "new since last seen".
           verifyInOrder([
             () => mockNotificationRepo.refreshFeed(null),
@@ -679,9 +679,25 @@ void main() {
           NotificationFeedState(status: NotificationFeedStatus.loaded),
         ],
         verify: (_) {
-          verify(() => mockNotificationRepo.refreshFeed(null)).called(1);
-          // Pull-to-refresh shows current unread; only opening (Started)
-          // advances the seen watermark (#4708).
+          verifyInOrder([
+            () => mockNotificationRepo.refreshFeed(null),
+            () => mockNotificationRepo.markAllAsRead(),
+          ]);
+        },
+      );
+
+      blocTest<NotificationFeedBloc, NotificationFeedState>(
+        'does not mark seen after filtered refresh',
+        build: createFollowBloc,
+        act: (bloc) => bloc.add(NotificationFeedRefreshed()),
+        expect: () => [
+          NotificationFeedState(isRefreshing: true),
+          NotificationFeedState(status: NotificationFeedStatus.loaded),
+        ],
+        verify: (_) {
+          verify(
+            () => mockNotificationRepo.refreshFeed(NotificationKind.follow),
+          ).called(1);
           verifyNever(() => mockNotificationRepo.markAllAsRead());
         },
       );
@@ -704,6 +720,10 @@ void main() {
           ),
         ],
         errors: () => [isA<Exception>()],
+        verify: (_) {
+          verify(() => mockNotificationRepo.refreshFeed(null)).called(1);
+          verifyNever(() => mockNotificationRepo.markAllAsRead());
+        },
       );
 
       blocTest<NotificationFeedBloc, NotificationFeedState>(

--- a/mobile/test/notifications/bloc/notification_feed_bloc_test.dart
+++ b/mobile/test/notifications/bloc/notification_feed_bloc_test.dart
@@ -686,6 +686,43 @@ void main() {
         },
       );
 
+      test('keeps refresh visible while mark seen is pending', () async {
+        final markCompleter = Completer<void>();
+        when(
+          () => mockNotificationRepo.markAllAsRead(),
+        ).thenAnswer((_) => markCompleter.future);
+
+        final bloc = createBloc();
+        addTearDown(bloc.close);
+        final states = <NotificationFeedState>[];
+        final subscription = bloc.stream.listen(states.add);
+        addTearDown(subscription.cancel);
+
+        bloc.add(NotificationFeedRefreshed());
+        await Future<void>.delayed(Duration.zero);
+
+        expect(
+          states,
+          [NotificationFeedState(isRefreshing: true)],
+        );
+
+        bloc.add(NotificationFeedRefreshed());
+        await Future<void>.delayed(Duration.zero);
+        verify(() => mockNotificationRepo.refreshFeed(null)).called(1);
+
+        markCompleter.complete();
+        await Future<void>.delayed(Duration.zero);
+
+        expect(
+          states,
+          [
+            NotificationFeedState(isRefreshing: true),
+            NotificationFeedState(status: NotificationFeedStatus.loaded),
+          ],
+        );
+        verify(() => mockNotificationRepo.markAllAsRead()).called(1);
+      });
+
       blocTest<NotificationFeedBloc, NotificationFeedState>(
         'does not mark seen after filtered refresh',
         build: createFollowBloc,

--- a/mobile/test/notifications/view/inbox_notifications_page_test.dart
+++ b/mobile/test/notifications/view/inbox_notifications_page_test.dart
@@ -109,8 +109,9 @@ void main() {
         // Leaving the inbox (toggling to the Messages segment so the
         // notifications KeyedSubtree is swapped out, or leaving the inbox tab
         // so the ShellRoute unmounts the subtree) must NOT mark read again on
-        // *leave* — the seen advance is on open only. #4758 removed the old
-        // mark-on-dispose; #4708 added mark-on-open.
+        // *leave* — #4758 removed the old mark-on-dispose. #4708 added
+        // mark-on-open, and pull-to-refresh can also mark while the
+        // notifications surface is deliberately open.
         await tester.pumpWidget(const SizedBox.shrink());
         await tester.pumpAndSettle();
 
@@ -148,8 +149,8 @@ void main() {
           ).called(1);
         }
 
-        // The seen watermark advances on open only, and only for the
-        // unfiltered feed (#4708) — never once per filter tab.
+        // The seen watermark advances for the unfiltered feed (#4708) —
+        // never once per filter tab.
         verify(() => mockNotificationRepo.markAllAsRead()).called(1);
       },
     );

--- a/mobile/test/notifications/view/notifications_page_test.dart
+++ b/mobile/test/notifications/view/notifications_page_test.dart
@@ -109,7 +109,8 @@ void main() {
           // Leaving the notifications route (e.g. switching bottom-nav tabs;
           // the ShellRoute is not stateful, so the page unmounts) must NOT
           // mark read again on *leave* — #4758 removed mark-on-dispose;
-          // #4708 added mark-on-open only.
+          // #4708 added mark-on-open, and pull-to-refresh can also mark
+          // while the notifications surface is deliberately open.
           await tester.pumpWidget(const SizedBox.shrink());
           await tester.pumpAndSettle();
 


### PR DESCRIPTION
## Summary
- always send the notifications mark-all-read server write for explicit mark-all/open-clear calls, even when no live snapshot has local unread rows
- keep optimistic snapshot flips and rollback scoped to feeds that actually changed
- mark seen after successful unfiltered pull-to-refresh, while preserving filtered-tab and failed-refresh guards
- keep the refresh/revalidation affordance visible until the follow-up mark-all write settles, so repeated pulls/retries are not silently dropped while the BLoC handler is still busy

## Behavior notes
- Unfiltered pull-to-refresh now clears the "what is new" unread state as part of the same gesture.
- With the current Funnelcake API, an empty mark-all body advances the per-pubkey read marker to server time. That can mark not-yet-materialized notifications read if their source event timestamp predates the POST. This PR accepts that tradeoff for #7410 and tracks the bounded-marker backend fix separately.

## Follow-ups filed
- divine-mobile #7438: preserve pagination that lands during notification mark-all rollback
- divine-mobile #7439: show pending state for notification settings mark-all read
- divine-web #577: align notification read marker timing with mobile
- divine-funnelcake #938: allow bounded notification read marker writes

## In-PR fixes
- Renamed `_markSeenOnOpen` → `_markSeen` for consistency with generalized use (both open and refresh now call it)
- Fixed stale comments in test file headers to document pull-to-refresh mark behavior
- Added bloc test verifying second refresh during mark-all POST is not dropped (droppable window closure)
- Updated reportable-site constant name to match method rename

Closes #7410

## Verification
- cd mobile/packages/notification_repository && flutter test --coverage
- cd mobile && flutter test test/notifications/bloc/notification_feed_bloc_test.dart test/notifications/view/notifications_page_test.dart test/notifications/view/inbox_notifications_page_test.dart
- cd mobile && flutter test test/notifications test/screens/notification_settings_screen_test.dart
- cd mobile && flutter analyze lib test integration_test