### PR TITLE
fix(video-editor): make teardown and render cancel idempotent

### DIFF
--- a/mobile/lib/providers/clip_manager_provider.dart
+++ b/mobile/lib/providers/clip_manager_provider.dart
@@ -485,6 +485,11 @@ class ClipManagerNotifier extends Notifier<ClipManagerState> {
       clearMergeOutputPath: true,
     );
 
+    // Guard against provider disposal during the async gap above: both
+    // branches below reach for providers through `ref` and would throw on a
+    // disposed notifier.
+    if (!ref.mounted) return true;
+
     // Force immediate autosave so draft references are updated before cleanup.
     // The last clip is different: an empty autosave is not recoverable, so clear
     // the session instead of writing a zero-clip draft that the reaper later
@@ -495,7 +500,7 @@ class ClipManagerNotifier extends Notifier<ClipManagerState> {
       await _forceAutosave();
     }
 
-    // Guard against provider disposal during the async gap above.
+    // Persisting above is another async gap.
     if (!ref.mounted) return true;
 
     // File cleanup is best-effort: the clip is already gone from state and

--- a/mobile/lib/providers/clip_manager_provider.dart
+++ b/mobile/lib/providers/clip_manager_provider.dart
@@ -485,8 +485,15 @@ class ClipManagerNotifier extends Notifier<ClipManagerState> {
       clearMergeOutputPath: true,
     );
 
-    // Force immediate autosave so draft references are updated before cleanup
-    await _forceAutosave();
+    // Force immediate autosave so draft references are updated before cleanup.
+    // The last clip is different: an empty autosave is not recoverable, so clear
+    // the session instead of writing a zero-clip draft that the reaper later
+    // treats as corruption.
+    if (_clips.isEmpty) {
+      await _clearProviders();
+    } else {
+      await _forceAutosave();
+    }
 
     // Guard against provider disposal during the async gap above.
     if (!ref.mounted) return true;
@@ -497,8 +504,6 @@ class ClipManagerNotifier extends Notifier<ClipManagerState> {
     // rejection — callers and tests rely on the state-mutation contract,
     // not on disk effects.
     try {
-      if (_clips.isEmpty) _clearProviders();
-
       final db = ref.read(databaseProvider);
       await FileCleanupService.deleteRecordingClipFiles(
         clip,
@@ -869,15 +874,19 @@ class ClipManagerNotifier extends Notifier<ClipManagerState> {
     state = ClipManagerState();
   }
 
-  /// Remove all clips and reset state.
+  /// Remove all clips without resetting peer providers or deleting autosave.
   ///
-  /// Clears all recorded clips and resets to initial state.
-  /// Also deletes the autosave draft unless [keepAutosavedDraft] is true.
-  Future<void> clearAll({bool keepAutosavedDraft = false}) async {
+  /// Used by higher-level teardown coordinators that own the rest of the
+  /// session cleanup.
+  Future<void> clearSessionClips() async {
     _cancelPendingDeletionTimer();
     if (state.pendingDeletion != null) {
       await commitPendingDeletion();
     }
+    _clearLocalClipState();
+  }
+
+  void _clearLocalClipState() {
     final clipCount = _clips.length;
     _clips.clear();
     Log.info(
@@ -886,18 +895,22 @@ class ClipManagerNotifier extends Notifier<ClipManagerState> {
       category: .video,
     );
     state = ClipManagerState();
-
-    // Delete autosave draft and its associated files
-    if (!keepAutosavedDraft) {
-      final draftService = ref.read(draftStorageServiceProvider);
-      await draftService.deleteDraft(VideoEditorConstants.autoSaveId);
-      _clearProviders();
-    }
   }
 
-  Future<void> _clearProviders() async {
+  /// Remove all clips and reset state.
+  ///
+  /// Clears all recorded clips and resets to initial state.
+  /// Also deletes the autosave draft unless [keepAutosavedDraft] is true.
+  Future<void> clearAll({bool keepAutosavedDraft = false}) async {
+    await clearSessionClips();
+    await _clearProviders(keepAutosavedDraft: keepAutosavedDraft);
+  }
+
+  Future<void> _clearProviders({bool keepAutosavedDraft = false}) async {
     ref.read(videoPublishProvider.notifier).reset();
-    await ref.read(videoEditorProvider.notifier).reset();
+    await ref
+        .read(videoEditorProvider.notifier)
+        .reset(keepAutosavedDraft: keepAutosavedDraft);
   }
 
   /// Save clip(s) to library.

--- a/mobile/lib/providers/video_editor_provider.dart
+++ b/mobile/lib/providers/video_editor_provider.dart
@@ -278,7 +278,7 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
     unawaited(_flushDeferredFileCleanup());
     draftId = null;
     if (!keepAutosavedDraft) {
-      unawaited(removeAutosavedDraft());
+      await removeAutosavedDraft();
     }
   }
 
@@ -781,6 +781,11 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
     );
 
     try {
+      if (clipCount == 0) {
+        await removeAutosavedDraft();
+        return false;
+      }
+
       final draft = getActiveDraft(isAutosave: isAutosavedDraft);
       // Defer orphan cleanup: files this autosave drops may still be reachable
       // through the live undo/redo history (see [_deferredFileCleanup]).
@@ -1122,6 +1127,9 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
   /// after successfully publishing a video.
   Future<void> removeAutosavedDraft() async {
     try {
+      if (!await _draftService.draftExists(VideoEditorConstants.autoSaveId)) {
+        return;
+      }
       await _draftService.deleteDraft(VideoEditorConstants.autoSaveId);
       Log.debug(
         '🗑️ Deleted autosaved draft',

--- a/mobile/lib/providers/video_publish_provider.dart
+++ b/mobile/lib/providers/video_publish_provider.dart
@@ -196,13 +196,12 @@ class VideoPublishNotifier extends Notifier<VideoPublishProviderState> {
       reset();
 
       await Future.wait([
-        ref
-            .read(clipManagerProvider.notifier)
-            .clearAll(keepAutosavedDraft: keepAutosavedDraft),
-        ref
-            .read(videoEditorProvider.notifier)
-            .reset(keepAutosavedDraft: keepAutosavedDraft),
+        ref.read(clipManagerProvider.notifier).clearSessionClips(),
+        ref.read(videoEditorProvider.notifier).reset(keepAutosavedDraft: true),
       ]);
+      if (!keepAutosavedDraft) {
+        await ref.read(videoEditorProvider.notifier).removeAutosavedDraft();
+      }
     } catch (error, stackTrace) {
       Log.error(
         '❌ Failed to clear video providers: $error',

--- a/mobile/lib/providers/video_publish_provider.dart
+++ b/mobile/lib/providers/video_publish_provider.dart
@@ -195,6 +195,10 @@ class VideoPublishNotifier extends Notifier<VideoPublishProviderState> {
       ref.read(videoReplyContextProvider.notifier).clear();
       reset();
 
+      // Keep the autosave through the parallel phase: both branches used to
+      // delete it concurrently, so the same id was torn down up to three times
+      // at once. The deletion is hoisted out here and runs exactly once, after
+      // both resets have settled.
       await Future.wait([
         ref.read(clipManagerProvider.notifier).clearSessionClips(),
         ref.read(videoEditorProvider.notifier).reset(keepAutosavedDraft: true),

--- a/mobile/lib/services/draft_storage_service.dart
+++ b/mobile/lib/services/draft_storage_service.dart
@@ -377,7 +377,11 @@ class DraftStorageService {
       ownerPubkey: scopedToOwner ? ownerPubkey : null,
     );
     if (row == null) {
-      Log.debug('📝 Draft not found: $id', category: LogCategory.video);
+      Log.debug(
+        '📝 Draft not found: $id',
+        name: 'DraftStorageService',
+        category: LogCategory.video,
+      );
       return null;
     }
 

--- a/mobile/lib/services/draft_storage_service.dart
+++ b/mobile/lib/services/draft_storage_service.dart
@@ -577,18 +577,18 @@ class DraftStorageService {
 
   /// Delete a draft by ID and remove associated video/thumbnail files
   Future<void> deleteDraft(String id) async {
-    Log.debug(
-      '🗑️ Deleting draft: $id',
-      name: 'DraftStorageService',
-      category: LogCategory.video,
-    );
-
     // Fetch draft before deleting so we can clean up files. Read across
     // accounts to stay consistent with DraftsDao.deleteDraft, which deletes by
     // primary key — an owner-scoped read would turn every deletion issued by a
     // service whose ownerPubkey no longer matches the row into a silent no-op.
     final draft = await _loadDraftAcrossAccounts(id);
     if (draft == null) return;
+
+    Log.debug(
+      '🗑️ Deleting draft: $id',
+      name: 'DraftStorageService',
+      category: LogCategory.video,
+    );
 
     // Delete the draft and its clip rows first, then delete files — so the
     // reference scan in FileCleanupService no longer sees this draft's clips

--- a/mobile/lib/services/video_editor/render_cancellation_registry.dart
+++ b/mobile/lib/services/video_editor/render_cancellation_registry.dart
@@ -1,0 +1,68 @@
+// ABOUTME: Tracks cancellation requests for video render task generations
+// ABOUTME: Preserves user cancels issued before native render registration
+
+/// Registry of cancellation requests for app-owned video render tasks.
+///
+/// A render id can be reused across attempts and sessions, so each render mints
+/// a generation token. Cancellation only applies to the generation that was
+/// current when the user asked to cancel; starting a newer generation clears
+/// stale requests without erasing a cancel that arrived just before native
+/// registration.
+class RenderCancellationRegistry {
+  RenderCancellationRegistry._();
+
+  static final Map<String, Object> _activeTokens = <String, Object>{};
+  static final Map<String, Object> _cancelledTokens = <String, Object>{};
+
+  /// Starts a new render generation for [id].
+  static Object start(String id) {
+    final token = Object();
+    _activeTokens[id] = token;
+    _cancelledTokens.remove(id);
+    return token;
+  }
+
+  /// Starts a render generation only when [id] is not already active.
+  static ({Object token, bool started}) startIfIdle(String id) {
+    final activeToken = _activeTokens[id];
+    if (activeToken != null) return (token: activeToken, started: false);
+    return (token: start(id), started: true);
+  }
+
+  /// Marks the current generation for [id] as cancelled.
+  static void cancel(String id) {
+    final token = _activeTokens[id];
+    if (token == null) return;
+    _cancelledTokens[id] = token;
+  }
+
+  /// Whether cancellation is pending for [id]'s current generation.
+  static bool isCancellationRequested(String id) {
+    final token = _activeTokens[id];
+    return token != null && identical(_cancelledTokens[id], token);
+  }
+
+  /// Consumes a pending cancellation for [id]'s current generation.
+  static bool consumeCancellation(String id) {
+    final token = _activeTokens[id];
+    if (token == null || !identical(_cancelledTokens[id], token)) return false;
+    _cancelledTokens.remove(id);
+    return true;
+  }
+
+  /// Ends [id]'s render generation if [token] still owns it.
+  static void finish(String id, Object token) {
+    if (!identical(_activeTokens[id], token)) return;
+    _activeTokens.remove(id);
+    _cancelledTokens.remove(id);
+  }
+
+  /// Drops all tracking without cancelling anything.
+  ///
+  /// Test teardown only - production render generations should finish
+  /// themselves so old cancellations do not leak into later renders.
+  static void reset() {
+    _activeTokens.clear();
+    _cancelledTokens.clear();
+  }
+}

--- a/mobile/lib/services/video_editor/video_editor_render_service.dart
+++ b/mobile/lib/services/video_editor/video_editor_render_service.dart
@@ -16,8 +16,10 @@ import 'package:openvine/models/video_editor/transition_geometry.dart';
 import 'package:openvine/services/crash_reporting_service.dart';
 import 'package:openvine/services/native_proofmode_service.dart';
 import 'package:openvine/services/video_editor/native_render_task_registry.dart';
+import 'package:openvine/services/video_editor/render_cancellation_registry.dart';
 import 'package:openvine/services/video_editor/stop_motion_render_service.dart';
 import 'package:openvine/services/video_editor/video_editor_audio_render.dart';
+import 'package:openvine/services/video_editor/video_render_failures.dart';
 import 'package:openvine/services/video_thumbnail_service.dart';
 import 'package:path/path.dart' as path;
 import 'package:path_provider/path_provider.dart';
@@ -25,55 +27,7 @@ import 'package:pro_image_editor/pro_image_editor.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
 import 'package:unified_logger/unified_logger.dart';
 
-/// Why a render produced no output.
-///
-/// Carried by [VideoRenderFailedException] and reported as the
-/// `failure_reason` attribute on the `video_generation` trace, so a render
-/// that fails on device can be told apart from one that was superseded (#7125).
-enum VideoRenderFailureReason {
-  /// Nothing to render — the clip list was empty.
-  emptyClips('empty_clips'),
-
-  /// A stop-motion clip could not be assembled into its base video.
-  stopMotionAssembly('stop_motion_assembly'),
-
-  /// The native render pipeline threw.
-  nativeRender('native_render'),
-
-  /// The native task was cancelled — by the user, or by teardown
-  /// (`AppLifecycleState.detached`) cancelling every in-flight task.
-  canceled('canceled');
-
-  const VideoRenderFailureReason(this.traceValue);
-
-  /// Stable identifier used in telemetry. Independent of the enum name so a
-  /// rename cannot silently split a Firebase dimension.
-  final String traceValue;
-}
-
-/// Thrown when a render finished without producing a video.
-class VideoRenderFailedException implements Exception {
-  const VideoRenderFailedException(this.reason, {this.cause});
-
-  final VideoRenderFailureReason reason;
-
-  /// The underlying error, when the failure came from a throw rather than a
-  /// guard. Native failures surface here as `PlatformException`.
-  final Object? cause;
-
-  /// Compact telemetry label, e.g. `native_render:PlatformException`.
-  ///
-  /// The cause's type — never its message — so device paths and other
-  /// free-form native text stay out of the trace attribute.
-  String get traceValue => cause == null
-      ? reason.traceValue
-      : '${reason.traceValue}:${cause.runtimeType}';
-
-  @override
-  String toString() =>
-      'VideoRenderFailedException(${reason.traceValue})'
-      '${cause == null ? '' : ': $cause'}';
-}
+export 'package:openvine/services/video_editor/video_render_failures.dart';
 
 /// Result of normalizing clips to a target aspect ratio.
 class _NormalizationResult {
@@ -334,8 +288,6 @@ class VideoEditorRenderService {
   static final _compositeProgressController =
       StreamController<ProgressModel>.broadcast();
 
-  static final Set<String> _cancelledTaskIds = <String>{};
-
   @visibleForTesting
   static double proofModeProgressBudgetForClipCount(int clipCount) {
     final normalizedClipCount = clipCount < 1 ? 1 : clipCount;
@@ -364,12 +316,12 @@ class VideoEditorRenderService {
   @visibleForTesting
   static void resetActiveNativeTaskIdsForTesting() {
     NativeRenderTaskRegistry.reset();
-    _cancelledTaskIds.clear();
+    RenderCancellationRegistry.reset();
   }
 
   @visibleForTesting
   static bool isTaskCancellationRequestedForTesting(String taskId) =>
-      _cancelledTaskIds.contains(taskId);
+      RenderCancellationRegistry.isCancellationRequested(taskId);
 
   @visibleForTesting
   static void emitCompositeProgressForTesting({
@@ -456,6 +408,7 @@ class VideoEditorRenderService {
     }
 
     final effectiveTaskId = taskId ?? clips.first.id;
+    final renderToken = RenderCancellationRegistry.start(effectiveTaskId);
     // Frames-only stop-motion clips need an assembly pass (stills → base mp4)
     // before the composite render. That pass gets its own slice of the
     // progress budget — without it the bar sits at 0% for the whole (slow)
@@ -608,6 +561,7 @@ class VideoEditorRenderService {
 
       return (clip, proofManifestJson);
     } finally {
+      RenderCancellationRegistry.finish(effectiveTaskId, renderToken);
       await progressTracker.dispose();
       await _cleanupTempFiles(intermediateStopMotionPaths);
     }
@@ -1351,33 +1305,41 @@ class VideoEditorRenderService {
         (task: reducedTask, settle: settleDelay, reduced: true),
     ];
 
-    _cancelledTaskIds.remove(baseTask.id);
-    for (var i = 0; i < attempts.length; i++) {
-      final attempt = attempts[i];
-      if (attempt.settle > Duration.zero) {
-        await Future<void>.delayed(attempt.settle);
-      }
-      _throwIfCancellationRequested(baseTask.id);
-      try {
-        await encode(attempt.task);
+    final renderGeneration = RenderCancellationRegistry.startIfIdle(
+      baseTask.id,
+    );
+    try {
+      for (var i = 0; i < attempts.length; i++) {
+        final attempt = attempts[i];
+        if (attempt.settle > Duration.zero) {
+          await Future<void>.delayed(attempt.settle);
+        }
         _throwIfCancellationRequested(baseTask.id);
-        return;
-      } on RenderEncoderException catch (e) {
-        final isLast = i == attempts.length - 1;
-        Log.warning(
-          '⚠️ Export encoder init failed on attempt ${i + 1}/${attempts.length}'
-          '${attempt.reduced ? ' (reduced resolution)' : ''}'
-          '${isLast ? '' : '; retrying'}: $e',
-          name: _logName,
-          category: .video,
-        );
-        if (isLast) rethrow;
+        try {
+          await encode(attempt.task);
+          _throwIfCancellationRequested(baseTask.id);
+          return;
+        } on RenderEncoderException catch (e) {
+          final isLast = i == attempts.length - 1;
+          Log.warning(
+            '⚠️ Export encoder init failed on attempt ${i + 1}/${attempts.length}'
+            '${attempt.reduced ? ' (reduced resolution)' : ''}'
+            '${isLast ? '' : '; retrying'}: $e',
+            name: _logName,
+            category: .video,
+          );
+          if (isLast) rethrow;
+        }
+      }
+    } finally {
+      if (renderGeneration.started) {
+        RenderCancellationRegistry.finish(baseTask.id, renderGeneration.token);
       }
     }
   }
 
   static void _throwIfCancellationRequested(String taskId) {
-    if (_cancelledTaskIds.remove(taskId)) {
+    if (RenderCancellationRegistry.consumeCancellation(taskId)) {
       throw const RenderCanceledException();
     }
   }
@@ -1487,11 +1449,15 @@ class VideoEditorRenderService {
     String outputPath,
     VideoRenderData task,
   ) async {
-    await renderNativeVideoToFile(outputPath, task);
+    await renderNativeVideoToFile(
+      outputPath,
+      task,
+      reuseActiveCancellation: true,
+    );
   }
 
   static Future<void> cancelTask(String id) async {
-    _cancelledTaskIds.add(id);
+    RenderCancellationRegistry.cancel(id);
     await _cancelNativeTaskOnly(id);
   }
 
@@ -1529,15 +1495,27 @@ class VideoEditorRenderService {
     // Surface native renderer warnings through ProVideoEditorLogForwarder for
     // #4801 diagnostics while clean renders stay quiet.
     NativeLogLevel? nativeLogLevel = NativeLogLevel.warning,
+    bool reuseActiveCancellation = false,
   }) async {
-    _cancelledTaskIds.remove(task.id);
-    await _cancelNativeTaskOnly(task.id);
+    final renderGeneration = reuseActiveCancellation
+        ? RenderCancellationRegistry.startIfIdle(task.id)
+        : (token: RenderCancellationRegistry.start(task.id), started: true);
+    if (NativeRenderTaskRegistry.activeTaskIds.contains(task.id)) {
+      await _cancelNativeTaskOnly(task.id);
+    }
     return NativeRenderTaskRegistry.track(task.id, () {
-      return ProVideoEditor.instance.renderVideoToFile(
-        outputPath,
-        task,
-        nativeLogLevel: nativeLogLevel,
-      );
+      return Future.sync(() {
+        _throwIfCancellationRequested(task.id);
+        return ProVideoEditor.instance.renderVideoToFile(
+          outputPath,
+          task,
+          nativeLogLevel: nativeLogLevel,
+        );
+      }).whenComplete(() {
+        if (renderGeneration.started) {
+          RenderCancellationRegistry.finish(task.id, renderGeneration.token);
+        }
+      });
     });
   }
 

--- a/mobile/lib/services/video_editor/video_render_failures.dart
+++ b/mobile/lib/services/video_editor/video_render_failures.dart
@@ -1,0 +1,33 @@
+// ABOUTME: Failure types for video render operations
+// ABOUTME: Keeps render error telemetry stable across service refactors
+
+/// Why a render produced no output.
+enum VideoRenderFailureReason {
+  emptyClips('empty_clips'),
+  stopMotionAssembly('stop_motion_assembly'),
+  nativeRender('native_render'),
+  canceled('canceled');
+
+  const VideoRenderFailureReason(this.traceValue);
+
+  /// Stable telemetry value, independent of enum names.
+  final String traceValue;
+}
+
+/// Thrown when a render finished without producing a video.
+class VideoRenderFailedException implements Exception {
+  const VideoRenderFailedException(this.reason, {this.cause});
+
+  final VideoRenderFailureReason reason;
+  final Object? cause;
+
+  /// Compact telemetry label, e.g. `native_render:PlatformException`.
+  String get traceValue => cause == null
+      ? reason.traceValue
+      : '${reason.traceValue}:${cause.runtimeType}';
+
+  @override
+  String toString() =>
+      'VideoRenderFailedException(${reason.traceValue})'
+      '${cause == null ? '' : ': $cause'}';
+}

--- a/mobile/scripts/baseline/service_god_file_sizes.txt
+++ b/mobile/scripts/baseline/service_god_file_sizes.txt
@@ -9,6 +9,6 @@
 lib/services/auth_service.dart	4780
 lib/services/curated_list_service.dart	1848
 lib/services/upload_manager.dart	2317
-lib/services/video_editor/video_editor_render_service.dart	1562
+lib/services/video_editor/video_editor_render_service.dart	1539
 lib/services/video_event_publisher.dart	2331
 lib/services/video_event_service.dart	6619

--- a/mobile/test/providers/clip_manager_provider_test.dart
+++ b/mobile/test/providers/clip_manager_provider_test.dart
@@ -347,6 +347,11 @@ void main() {
 
       test('deletes the autosave draft by default', () async {
         final notifier = container.read(clipManagerProvider.notifier);
+        when(
+          () => mockDraftStorageService.draftExists(
+            VideoEditorConstants.autoSaveId,
+          ),
+        ).thenAnswer((_) async => true);
         addClip(notifier);
 
         await notifier.clearAll();

--- a/mobile/test/providers/video_editor_provider_test.dart
+++ b/mobile/test/providers/video_editor_provider_test.dart
@@ -3070,6 +3070,9 @@ void main() {
       SharedPreferences.setMockInitialValues({});
       final prefs = await SharedPreferences.getInstance();
       mockDraftStorage = _MockDraftStorageService();
+      when(
+        () => mockDraftStorage.draftExists(any()),
+      ).thenAnswer((_) async => false);
       container = ProviderContainer(
         overrides: [
           sharedPreferencesProvider.overrideWithValue(prefs),
@@ -3194,6 +3197,9 @@ void main() {
       // later wipe a new session's recovery point. So a stalled cleanup keeps
       // isSavingDraft true and the save unresolved rather than being dropped.
       when(() => mockDraftStorage.saveDraft(any())).thenAnswer((_) async {});
+      when(
+        () => mockDraftStorage.draftExists(VideoEditorConstants.autoSaveId),
+      ).thenAnswer((_) async => true);
 
       fakeAsync((async) {
         // Create the completer inside the fake zone so completing it later is
@@ -3263,6 +3269,9 @@ void main() {
       final prefs = await SharedPreferences.getInstance();
       mockDraftStorage = _MockDraftStorageService();
       database = AppDatabase.test(NativeDatabase.memory());
+      when(
+        () => mockDraftStorage.draftExists(any()),
+      ).thenAnswer((_) async => false);
       container = ProviderContainer(
         overrides: [
           sharedPreferencesProvider.overrideWithValue(prefs),
@@ -3305,6 +3314,15 @@ void main() {
 
       fakeAsync((async) {
         final notifier = container.read(videoEditorProvider.notifier);
+        container
+            .read(clipManagerProvider.notifier)
+            .addClip(
+              limitClipDuration: false,
+              video: EditorVideo.file('/path/to/video.mp4'),
+              targetAspectRatio: AspectRatio.square,
+              originalAspectRatio: 9 / 16,
+              duration: const Duration(seconds: 6),
+            );
         notifier.updateMetadata(title: 'Almost lost');
 
         bool? result;
@@ -3328,6 +3346,44 @@ void main() {
         verifyNoMoreInteractions(mockDraftStorage);
       });
     });
+
+    test('deletes autosave instead of persisting a zero-clip draft', () async {
+      when(
+        () => mockDraftStorage.draftExists(VideoEditorConstants.autoSaveId),
+      ).thenAnswer((_) async => true);
+      when(
+        () => mockDraftStorage.deleteDraft(VideoEditorConstants.autoSaveId),
+      ).thenAnswer((_) async {});
+
+      final result = await container
+          .read(videoEditorProvider.notifier)
+          .autosaveChanges();
+
+      expect(result, isFalse);
+      verify(
+        () => mockDraftStorage.deleteDraft(VideoEditorConstants.autoSaveId),
+      ).called(1);
+      verifyNever(
+        () => mockDraftStorage.saveDraft(
+          any(),
+          deferOrphanCleanup: any(named: 'deferOrphanCleanup'),
+        ),
+      );
+    });
+
+    test(
+      'removeAutosavedDraft is a no-op when autosave is already gone',
+      () async {
+        await container
+            .read(videoEditorProvider.notifier)
+            .removeAutosavedDraft();
+
+        verify(
+          () => mockDraftStorage.draftExists(VideoEditorConstants.autoSaveId),
+        ).called(1);
+        verifyNever(() => mockDraftStorage.deleteDraft(any()));
+      },
+    );
   });
 
   group('VideoEditorProvider deferred file cleanup', () {
@@ -3363,6 +3419,9 @@ void main() {
       database = AppDatabase.test(NativeDatabase.memory());
       tempDir = Directory.systemTemp.createTempSync('editor_defer_test');
       containerDisposed = false;
+      when(
+        () => mockDraftStorage.draftExists(any()),
+      ).thenAnswer((_) async => false);
       container = ProviderContainer(
         overrides: [
           sharedPreferencesProvider.overrideWithValue(prefs),
@@ -3401,6 +3460,20 @@ void main() {
       return orphan;
     }
 
+    void addTimelineClip() {
+      final source = File(p.join(tempDir.path, 'source.mp4'))
+        ..writeAsBytesSync(const [0, 1, 2, 3]);
+      container
+          .read(clipManagerProvider.notifier)
+          .addClip(
+            limitClipDuration: false,
+            video: EditorVideo.file(source.path),
+            targetAspectRatio: AspectRatio.square,
+            originalAspectRatio: 9 / 16,
+            duration: const Duration(seconds: 6),
+          );
+    }
+
     Future<void> expectFileReaped(File file, {required String reason}) async {
       for (var attempt = 0; attempt < 20; attempt++) {
         await pumpEventQueue();
@@ -3412,6 +3485,7 @@ void main() {
 
     test('an autosave keeps its orphaned files alive', () async {
       final orphan = stubDeferringAutosave();
+      addTimelineClip();
       final notifier = container.read(videoEditorProvider.notifier);
 
       await notifier.autosaveChanges();
@@ -3428,6 +3502,7 @@ void main() {
 
     test('reset reaps deferred files at editor-session end', () async {
       final orphan = stubDeferringAutosave();
+      addTimelineClip();
       final notifier = container.read(videoEditorProvider.notifier);
       await notifier.autosaveChanges();
 
@@ -3445,6 +3520,7 @@ void main() {
 
     test('container teardown reaps deferred files as a safety net', () async {
       final orphan = stubDeferringAutosave();
+      addTimelineClip();
       await container.read(videoEditorProvider.notifier).autosaveChanges();
       expect(orphan.existsSync(), isTrue);
 

--- a/mobile/test/providers/video_publish_provider_test.dart
+++ b/mobile/test/providers/video_publish_provider_test.dart
@@ -11,6 +11,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart' show NativeProofData;
+import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/l10n/publish_error_kind_l10n.dart';
 import 'package:openvine/models/divine_video_clip.dart';
@@ -18,6 +19,7 @@ import 'package:openvine/models/divine_video_draft.dart';
 import 'package:openvine/models/stop_motion_clip_frame.dart';
 import 'package:openvine/models/video_publish/video_publish_state.dart';
 import 'package:openvine/models/video_reply_context.dart';
+import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/layer_rasterizer_provider.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/social_providers.dart';
@@ -116,6 +118,31 @@ void main() {
       final state = container.read(videoPublishProvider);
       expect(state.uploadProgress, 0.0);
       expect(state.publishState, VideoPublishState.idle);
+    });
+
+    test('clearAll deletes autosave once after coordinated teardown', () async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      final draftStorage = _MockDraftStorageService();
+      when(
+        () => draftStorage.draftExists(VideoEditorConstants.autoSaveId),
+      ).thenAnswer((_) async => true);
+      when(
+        () => draftStorage.deleteDraft(VideoEditorConstants.autoSaveId),
+      ).thenAnswer((_) async {});
+      final scopedContainer = ProviderContainer(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          draftStorageServiceProvider.overrideWithValue(draftStorage),
+        ],
+      );
+      addTearDown(scopedContainer.dispose);
+
+      await scopedContainer.read(videoPublishProvider.notifier).clearAll();
+
+      verify(
+        () => draftStorage.deleteDraft(VideoEditorConstants.autoSaveId),
+      ).called(1);
     });
 
     test('setError preserves other state values', () {

--- a/mobile/test/services/video_editor/render_cancellation_registry_test.dart
+++ b/mobile/test/services/video_editor/render_cancellation_registry_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/services/video_editor/render_cancellation_registry.dart';
+
+void main() {
+  group(RenderCancellationRegistry, () {
+    tearDown(RenderCancellationRegistry.reset);
+
+    test('records cancellation for the current render generation', () {
+      final token = RenderCancellationRegistry.start('render-task');
+
+      RenderCancellationRegistry.cancel('render-task');
+
+      expect(
+        RenderCancellationRegistry.isCancellationRequested('render-task'),
+        isTrue,
+      );
+      expect(
+        RenderCancellationRegistry.consumeCancellation('render-task'),
+        isTrue,
+      );
+      expect(
+        RenderCancellationRegistry.isCancellationRequested('render-task'),
+        isFalse,
+      );
+      RenderCancellationRegistry.finish('render-task', token);
+    });
+
+    test('new generations clear stale cancellations', () {
+      final oldToken = RenderCancellationRegistry.start('render-task');
+      RenderCancellationRegistry.cancel('render-task');
+
+      final newToken = RenderCancellationRegistry.start('render-task');
+
+      expect(
+        RenderCancellationRegistry.isCancellationRequested('render-task'),
+        isFalse,
+      );
+      RenderCancellationRegistry.finish('render-task', oldToken);
+      expect(
+        RenderCancellationRegistry.isCancellationRequested('render-task'),
+        isFalse,
+      );
+      RenderCancellationRegistry.finish('render-task', newToken);
+    });
+
+    test('startIfIdle reuses an active generation', () {
+      final token = RenderCancellationRegistry.start('render-task');
+
+      final generation = RenderCancellationRegistry.startIfIdle('render-task');
+
+      expect(generation.started, isFalse);
+      expect(identical(generation.token, token), isTrue);
+    });
+  });
+}

--- a/mobile/test/services/video_editor/video_editor_render_service_progress_test.dart
+++ b/mobile/test/services/video_editor/video_editor_render_service_progress_test.dart
@@ -421,8 +421,8 @@ void main() {
         await renderStarted;
         expect(
           proVideoEditor.cancelCalls,
-          equals(['tracked-render']),
-          reason: 'renders unconditionally pre-cancel the task id',
+          isEmpty,
+          reason: 'new renders do not cancel native work before registration',
         );
         expect(
           VideoEditorRenderService.activeNativeTaskIdsForTesting,
@@ -437,7 +437,7 @@ void main() {
 
         expect(
           proVideoEditor.cancelCalls,
-          equals(['tracked-render', 'tracked-render']),
+          equals(['tracked-render']),
         );
         await renderCancellation;
         expect(VideoEditorRenderService.activeNativeTaskIdsForTesting, isEmpty);

--- a/mobile/test/services/video_editor/video_editor_render_service_test.dart
+++ b/mobile/test/services/video_editor/video_editor_render_service_test.dart
@@ -17,6 +17,7 @@ import 'package:openvine/extensions/aspect_ratio_extensions.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/stop_motion_clip_frame.dart';
 import 'package:openvine/models/video_editor/transition_geometry.dart';
+import 'package:openvine/services/video_editor/render_cancellation_registry.dart';
 import 'package:openvine/services/video_editor/stop_motion_render_service.dart';
 import 'package:openvine/services/video_editor/video_editor_render_service.dart';
 import 'package:pro_image_editor/pro_image_editor.dart' as pie;
@@ -451,6 +452,30 @@ void main() {
       });
     });
 
+    test(
+      'honors cancellation recorded before the encode loop starts',
+      () async {
+        final token = RenderCancellationRegistry.start('render-task');
+        await VideoEditorRenderService.cancelTask('render-task');
+        var calls = 0;
+
+        await expectLater(
+          VideoEditorRenderService.renderWithEncoderFallback(
+            baseTask: baseTask(),
+            encode: (_) async {
+              calls++;
+            },
+            fallbackAspectRatio: aspectRatio,
+            settleDelay: Duration.zero,
+          ),
+          throwsA(isA<RenderCanceledException>()),
+        );
+
+        expect(calls, 0);
+        RenderCancellationRegistry.finish('render-task', token);
+      },
+    );
+
     test('honors cancellation recorded while encode is running', () async {
       var calls = 0;
 
@@ -575,11 +600,7 @@ void main() {
                 'reason',
                 VideoRenderFailureReason.canceled,
               )
-              .having(
-                (e) => e.cause,
-                'cause',
-                isA<RenderCanceledException>(),
-              ),
+              .having((e) => e.cause, 'cause', isA<RenderCanceledException>()),
         ),
       );
     });

--- a/mobile/test/services/video_editor/video_editor_reverse_service_test.dart
+++ b/mobile/test/services/video_editor/video_editor_reverse_service_test.dart
@@ -122,7 +122,7 @@ void main() {
         'clip-1_reversed.mp4',
       );
       expect(result.file?.path, expectedOutputPath);
-      expect(proVideoEditor.canceledTaskIds, ['reverse-render-1']);
+      expect(proVideoEditor.canceledTaskIds, isEmpty);
       expect(proVideoEditor.renderedPaths, [expectedOutputPath]);
 
       final renderData = proVideoEditor.renderedData.single;
@@ -163,7 +163,7 @@ void main() {
     });
 
     test(
-      'continues rendering when there is no active render to cancel',
+      'does not cancel before rendering when there is no active render',
       () async {
         proVideoEditor.cancelShouldThrow = true;
         final sourceClip = _clip(
@@ -176,7 +176,7 @@ void main() {
           renderId: 'reverse-render-missing',
         );
 
-        expect(proVideoEditor.canceledTaskIds, ['reverse-render-missing']);
+        expect(proVideoEditor.canceledTaskIds, isEmpty);
         expect(proVideoEditor.renderedData, hasLength(1));
       },
     );

--- a/mobile/test/services/video_editor/video_editor_transform_service_test.dart
+++ b/mobile/test/services/video_editor/video_editor_transform_service_test.dart
@@ -128,7 +128,7 @@ void main() {
           renderId: 'transform-render-1',
         );
 
-        expect(proVideoEditor.canceledTaskIds, ['transform-render-1']);
+        expect(proVideoEditor.canceledTaskIds, isEmpty);
         expect(proVideoEditor.renderedPaths, hasLength(1));
 
         // The output filename is timestamped per render (so a repeat transform
@@ -153,7 +153,7 @@ void main() {
     );
 
     test(
-      'continues rendering when there is no active render to cancel',
+      'does not cancel before rendering when there is no active render',
       () async {
         proVideoEditor.cancelShouldThrow = true;
         final sourceClip = _clip(
@@ -167,7 +167,7 @@ void main() {
           renderId: 'transform-render-missing',
         );
 
-        expect(proVideoEditor.canceledTaskIds, ['transform-render-missing']);
+        expect(proVideoEditor.canceledTaskIds, isEmpty);
         expect(proVideoEditor.renderedData, hasLength(1));
       },
     );

--- a/mobile/test/services/video_editor/video_render_failures_test.dart
+++ b/mobile/test/services/video_editor/video_render_failures_test.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/services/video_editor/video_render_failures.dart';
+
+void main() {
+  group(VideoRenderFailedException, () {
+    test('traceValue uses the stable reason when there is no cause', () {
+      const failure = VideoRenderFailedException(
+        VideoRenderFailureReason.emptyClips,
+      );
+
+      expect(failure.traceValue, 'empty_clips');
+    });
+
+    test('traceValue adds the cause type without its message', () {
+      final failure = VideoRenderFailedException(
+        VideoRenderFailureReason.nativeRender,
+        cause: PlatformException(code: 'x', message: 'device path'),
+      );
+
+      expect(failure.traceValue, 'native_render:PlatformException');
+      expect(failure.traceValue, isNot(contains('device path')));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- make video editor autosave teardown single-owner and idempotent
- prevent zero-clip autosaves from being persisted
- add generation-scoped render cancellation so pre-registration cancels survive the native task registration gap
- remove spurious native TASK_NOT_FOUND cancel noise before first renders

Closes #7406

## Verification
- flutter test test/services/video_editor/render_cancellation_registry_test.dart test/services/video_editor/video_render_failures_test.dart test/services/video_editor/video_editor_render_service_test.dart test/services/video_editor/video_editor_render_service_progress_test.dart test/providers/video_editor_provider_test.dart test/providers/video_publish_provider_test.dart test/providers/clip_manager_provider_test.dart
- bash scripts/check_service_god_file_ceiling.sh
- bash scripts/check_untested_services_floor.sh
- flutter analyze
- git diff --check