### PR TITLE
fix(notifications): clear iOS app badge defensively

### DIFF
--- a/mobile/ios/Runner/AppDelegate.swift
+++ b/mobile/ios/Runner/AppDelegate.swift
@@ -77,6 +77,9 @@ extension FlutterError: @retroactive Error {}
     // AppUpdateRepository's download-URL resolution (#6296).
     setupInstallSourceChannel(with: engineBridge)
 
+    // Set up app-icon badge channel.
+    setupAppBadgeChannel(with: engineBridge)
+
     NSLog("✅ AppDelegate: Implicit Flutter engine initialized with UIScene lifecycle")
   }
 
@@ -230,6 +233,43 @@ extension FlutterError: @retroactive Error {}
     }
 
     NSLog("✅ InstallSource: Platform channel registered")
+  }
+
+  /// App-icon badge platform channel.
+  ///
+  /// The Dart side invokes this best-effort on launch, resume, and when the
+  /// unfiltered notifications surface advances the seen watermark. Divine does
+  /// not currently own a persistent app-icon badge count, so the only native
+  /// operation exposed here is clearing it.
+  private func setupAppBadgeChannel(with engineBridge: FlutterImplicitEngineBridge) {
+    let channel = FlutterMethodChannel(
+      name: "divine/app_badge",
+      binaryMessenger: engineBridge.applicationRegistrar.messenger()
+    )
+
+    channel.setMethodCallHandler { (call, result) in
+      switch call.method {
+      case "clear":
+        UNUserNotificationCenter.current().setBadgeCount(0) { error in
+          DispatchQueue.main.async {
+            if let error = error {
+              result(FlutterError(
+                code: "BADGE_CLEAR_FAILED",
+                message: error.localizedDescription,
+                details: nil
+              ))
+              return
+            }
+            result(nil)
+          }
+        }
+
+      default:
+        result(FlutterMethodNotImplemented)
+      }
+    }
+
+    NSLog("✅ AppBadge: Platform channel registered")
   }
 
   private func setupZendeskChannel(with engineBridge: FlutterImplicitEngineBridge) {

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -225,7 +225,9 @@ Future<void> _renderBackgroundLocalPush({
 }) async {
   final plugin = FlutterLocalNotificationsPlugin();
   const androidInit = AndroidInitializationSettings('@mipmap/ic_launcher');
-  const darwinInit = DarwinInitializationSettings();
+  const darwinInit = DarwinInitializationSettings(
+    requestBadgePermission: false,
+  );
   const initSettings = InitializationSettings(
     android: androidInit,
     iOS: darwinInit,
@@ -242,7 +244,8 @@ Future<void> _renderBackgroundLocalPush({
   );
   const details = NotificationDetails(
     android: androidDetails,
-    iOS: DarwinNotificationDetails(),
+    iOS: DarwinNotificationDetails(presentBadge: false),
+    macOS: DarwinNotificationDetails(presentBadge: false),
   );
 
   await plugin.show(

--- a/mobile/lib/notifications/bloc/notification_feed_bloc.dart
+++ b/mobile/lib/notifications/bloc/notification_feed_bloc.dart
@@ -12,6 +12,7 @@ import 'package:models/models.dart';
 import 'package:notification_repository/notification_repository.dart';
 import 'package:openvine/notifications/bloc/reportable_sites.dart';
 import 'package:openvine/observability/reportable_error.dart';
+import 'package:openvine/services/app_badge_service.dart';
 
 part 'notification_feed_event.dart';
 part 'notification_feed_state.dart';
@@ -28,9 +29,11 @@ class NotificationFeedBloc
   NotificationFeedBloc({
     required NotificationRepository notificationRepository,
     required FollowRepository followRepository,
+    AppBadgeClearer? appBadgeClearer,
     NotificationKind? filter,
   }) : _notificationRepository = notificationRepository,
        _followRepository = followRepository,
+       _appBadgeClearer = appBadgeClearer,
        _filter = filter,
        super(const NotificationFeedState()) {
     on<_SnapshotChanged>(_onSnapshotChanged);
@@ -49,6 +52,7 @@ class NotificationFeedBloc
 
   final NotificationRepository _notificationRepository;
   final FollowRepository _followRepository;
+  final AppBadgeClearer? _appBadgeClearer;
   final NotificationKind? _filter;
   late final StreamSubscription<NotificationPage> _snapshotSubscription;
   int _emptyPageContinuations = 0;
@@ -167,7 +171,10 @@ class NotificationFeedBloc
       );
       _flushPendingEmptyPageContinuation();
       if (_filter == null) {
-        await _markSeenOnOpen();
+        final markSucceeded = await _markSeenOnOpen();
+        if (markSucceeded) {
+          unawaited(_clearAppBadge());
+        }
       }
     } on Exception catch (e, s) {
       // `NotificationRepository.refresh` propagates typed
@@ -232,15 +239,17 @@ class NotificationFeedBloc
   /// A seen-advance failure must never blacken the feed, so every error is
   /// caught here and never rethrown — the repository has already restored the
   /// snapshot on failure, so the list stays usable.
-  Future<void> _markSeenOnOpen() async {
+  Future<bool> _markSeenOnOpen() async {
     try {
       await _notificationRepository.markAllAsRead();
+      return true;
     } on Exception catch (e, s) {
       // Typed `FunnelcakeException` (4xx/5xx/timeout) + Drift DAO failures the
       // repository rethrows after rolling the optimistic flip back. Per
       // .claude/rules/error_handling.md these are expected domain failures,
       // NOT Reportable.
       addError(e, s);
+      return false;
     } catch (e, s) {
       // Errors (StateError, TypeError) — matrix-YES invariant violation.
       addError(
@@ -250,6 +259,16 @@ class NotificationFeedBloc
         ),
         s,
       );
+      return false;
+    }
+  }
+
+  Future<void> _clearAppBadge() async {
+    try {
+      await _appBadgeClearer?.clear();
+    } catch (_) {
+      // AppBadgeService is already best-effort and logs platform failures.
+      // Keep test fakes or future implementations from affecting feed state.
     }
   }
 

--- a/mobile/lib/notifications/bloc/notification_feed_bloc.dart
+++ b/mobile/lib/notifications/bloc/notification_feed_bloc.dart
@@ -13,6 +13,7 @@ import 'package:notification_repository/notification_repository.dart';
 import 'package:openvine/notifications/bloc/reportable_sites.dart';
 import 'package:openvine/observability/reportable_error.dart';
 import 'package:openvine/services/app_badge_service.dart';
+import 'package:unified_logger/unified_logger.dart';
 
 part 'notification_feed_event.dart';
 part 'notification_feed_state.dart';
@@ -29,7 +30,7 @@ class NotificationFeedBloc
   NotificationFeedBloc({
     required NotificationRepository notificationRepository,
     required FollowRepository followRepository,
-    AppBadgeClearer? appBadgeClearer,
+    required AppBadgeClearer appBadgeClearer,
     NotificationKind? filter,
   }) : _notificationRepository = notificationRepository,
        _followRepository = followRepository,
@@ -52,7 +53,7 @@ class NotificationFeedBloc
 
   final NotificationRepository _notificationRepository;
   final FollowRepository _followRepository;
-  final AppBadgeClearer? _appBadgeClearer;
+  final AppBadgeClearer _appBadgeClearer;
   final NotificationKind? _filter;
   late final StreamSubscription<NotificationPage> _snapshotSubscription;
   int _emptyPageContinuations = 0;
@@ -265,10 +266,13 @@ class NotificationFeedBloc
 
   Future<void> _clearAppBadge() async {
     try {
-      await _appBadgeClearer?.clear();
-    } catch (_) {
-      // AppBadgeService is already best-effort and logs platform failures.
-      // Keep test fakes or future implementations from affecting feed state.
+      await _appBadgeClearer.clear();
+    } catch (e, st) {
+      Log.warning(
+        'App badge clear failed after notification feed open: $e\n$st',
+        name: 'NotificationFeedBloc',
+        category: LogCategory.system,
+      );
     }
   }
 

--- a/mobile/lib/notifications/view/inbox_notifications_page.dart
+++ b/mobile/lib/notifications/view/inbox_notifications_page.dart
@@ -201,7 +201,6 @@ class _NotificationTabState extends ConsumerState<_NotificationTab>
       key: ValueKey((
         widget.notificationRepository,
         widget.followRepository,
-        appBadgeClearer,
         widget.filter,
       )),
       create: (_) => NotificationFeedBloc(

--- a/mobile/lib/notifications/view/inbox_notifications_page.dart
+++ b/mobile/lib/notifications/view/inbox_notifications_page.dart
@@ -168,7 +168,7 @@ class _InboxNotificationsScaffoldState
   }
 }
 
-class _NotificationTab extends StatefulWidget {
+class _NotificationTab extends ConsumerStatefulWidget {
   const _NotificationTab({
     required this.notificationRepository,
     required this.followRepository,
@@ -182,10 +182,10 @@ class _NotificationTab extends StatefulWidget {
   final Widget child;
 
   @override
-  State<_NotificationTab> createState() => _NotificationTabState();
+  ConsumerState<_NotificationTab> createState() => _NotificationTabState();
 }
 
-class _NotificationTabState extends State<_NotificationTab>
+class _NotificationTabState extends ConsumerState<_NotificationTab>
     with AutomaticKeepAliveClientMixin {
   @override
   bool get wantKeepAlive => true;
@@ -193,6 +193,7 @@ class _NotificationTabState extends State<_NotificationTab>
   @override
   Widget build(BuildContext context) {
     super.build(context);
+    final appBadgeClearer = ref.watch(appBadgeServiceProvider);
     // Key on the watched dependency identities plus filter so each tab's bloc
     // rebuilds when repositories swap and keeps an independent pagination
     // stream for its server-side category.
@@ -200,11 +201,13 @@ class _NotificationTabState extends State<_NotificationTab>
       key: ValueKey((
         widget.notificationRepository,
         widget.followRepository,
+        appBadgeClearer,
         widget.filter,
       )),
       create: (_) => NotificationFeedBloc(
         notificationRepository: widget.notificationRepository,
         followRepository: widget.followRepository,
+        appBadgeClearer: appBadgeClearer,
         filter: widget.filter,
       )..add(const NotificationFeedStarted()),
       child: widget.child,

--- a/mobile/lib/notifications/view/notifications_page.dart
+++ b/mobile/lib/notifications/view/notifications_page.dart
@@ -50,6 +50,7 @@ class NotificationsPage extends ConsumerWidget {
     }
 
     final followRepository = ref.watch(followRepositoryProvider);
+    final appBadgeClearer = ref.watch(appBadgeServiceProvider);
 
     // Key on the watched dependency identities so the bloc rebuilds when
     // either repository swaps (account switch, sign-out → sign-in, or
@@ -62,6 +63,7 @@ class NotificationsPage extends ConsumerWidget {
       create: (_) => NotificationFeedBloc(
         notificationRepository: notificationRepository,
         followRepository: followRepository,
+        appBadgeClearer: appBadgeClearer,
       )..add(const NotificationFeedStarted()),
       child: const NotificationsView(),
     );

--- a/mobile/lib/providers/notifications_providers.dart
+++ b/mobile/lib/providers/notifications_providers.dart
@@ -11,6 +11,7 @@ import 'package:openvine/providers/database_provider.dart';
 import 'package:openvine/providers/environment_provider.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/providers/relay_providers.dart';
+import 'package:openvine/services/app_badge_service.dart';
 import 'package:openvine/services/notification_preferences_service.dart';
 import 'package:openvine/services/notification_service.dart';
 import 'package:openvine/services/push_notification_service.dart';
@@ -34,6 +35,10 @@ final notificationServiceProvider = Provider<NotificationService>((ref) {
   ref.onDispose(service.dispose);
   return service;
 });
+
+final appBadgeServiceProvider = Provider<AppBadgeClearer>(
+  (ref) => const AppBadgeService(),
+);
 
 final notificationPreferencesStoreProvider =
     Provider<NotificationPreferencesStore>((ref) {

--- a/mobile/lib/services/app_badge_service.dart
+++ b/mobile/lib/services/app_badge_service.dart
@@ -1,0 +1,45 @@
+// ABOUTME: Clears the platform app-icon notification badge through native code.
+// ABOUTME: Keeps badge cleanup best-effort so app launch and inbox rendering proceed.
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:unified_logger/unified_logger.dart';
+
+/// Contract for best-effort platform app-icon badge cleanup.
+abstract interface class AppBadgeClearer {
+  /// Clears the app-icon badge when the current platform supports it.
+  Future<void> clear();
+}
+
+/// Method-channel-backed app-icon badge service.
+class AppBadgeService implements AppBadgeClearer {
+  const AppBadgeService({MethodChannel? channel})
+    : _channel = channel ?? const MethodChannel(_channelName);
+
+  static const _channelName = 'divine/app_badge';
+
+  final MethodChannel _channel;
+
+  @override
+  Future<void> clear() async {
+    if (kIsWeb || defaultTargetPlatform != TargetPlatform.iOS) {
+      return;
+    }
+
+    try {
+      await _channel.invokeMethod<void>('clear');
+    } on PlatformException catch (e) {
+      Log.warning(
+        'App badge clear failed: ${e.code}',
+        name: 'AppBadgeService',
+        category: LogCategory.system,
+      );
+    } on MissingPluginException catch (e) {
+      Log.warning(
+        'App badge channel missing; skipping clear: $e',
+        name: 'AppBadgeService',
+        category: LogCategory.system,
+      );
+    }
+  }
+}

--- a/mobile/lib/services/notification_service.dart
+++ b/mobile/lib/services/notification_service.dart
@@ -286,7 +286,7 @@ class NotificationService {
                 .resolvePlatformSpecificImplementation<
                   IOSFlutterLocalNotificationsPlugin
                 >()
-                ?.requestPermissions(alert: true, sound: true) ??
+                ?.requestPermissions(alert: true, badge: true, sound: true) ??
             false;
 
         _permissionsGranted = granted;

--- a/mobile/lib/services/notification_service.dart
+++ b/mobile/lib/services/notification_service.dart
@@ -286,7 +286,7 @@ class NotificationService {
                 .resolvePlatformSpecificImplementation<
                   IOSFlutterLocalNotificationsPlugin
                 >()
-                ?.requestPermissions(alert: true, badge: true, sound: true) ??
+                ?.requestPermissions(alert: true, sound: true) ??
             false;
 
         _permissionsGranted = granted;
@@ -557,14 +557,14 @@ class NotificationService {
       // Define iOS notification details
       const iosDetails = DarwinNotificationDetails(
         presentAlert: true,
-        presentBadge: true,
+        presentBadge: false,
         presentSound: true,
       );
 
       // Define macOS notification details
       const macosDetails = DarwinNotificationDetails(
         presentAlert: true,
-        presentBadge: true,
+        presentBadge: false,
         presentSound: true,
       );
 

--- a/mobile/lib/widgets/app_lifecycle_handler.dart
+++ b/mobile/lib/widgets/app_lifecycle_handler.dart
@@ -47,6 +47,7 @@ class _AppLifecycleHandlerState extends ConsumerState<AppLifecycleHandler>
     // but only once the user is authenticated.
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       if (!mounted) return;
+      unawaited(_clearAppBadge());
 
       final authService = ref.read(authServiceProvider);
       if (!authService.isAuthenticated) {
@@ -131,6 +132,7 @@ class _AppLifecycleHandlerState extends ConsumerState<AppLifecycleHandler>
         // dropped by iOS/Android when app is backgrounded. Without this,
         // subscriptions sent to stale sockets will timeout (30s) with no response.
         _reconnectRelays();
+        unawaited(_clearAppBadge());
         unawaited(
           ref
               .read(notificationRefreshCoordinatorProvider)
@@ -217,6 +219,18 @@ class _AppLifecycleHandlerState extends ConsumerState<AppLifecycleHandler>
     } catch (e) {
       Log.warning(
         '📱 Failed to reconnect relays on resume: $e',
+        name: 'AppLifecycleHandler',
+        category: LogCategory.system,
+      );
+    }
+  }
+
+  Future<void> _clearAppBadge() async {
+    try {
+      await ref.read(appBadgeServiceProvider).clear();
+    } catch (e, st) {
+      Log.warning(
+        'App badge clear failed during lifecycle handling: $e\n$st',
         name: 'AppLifecycleHandler',
         category: LogCategory.system,
       );

--- a/mobile/test/notifications/badge_converges_after_tap_read_back_test.dart
+++ b/mobile/test/notifications/badge_converges_after_tap_read_back_test.dart
@@ -13,9 +13,17 @@ import 'package:models/models.dart';
 import 'package:notification_repository/notification_repository.dart';
 import 'package:openvine/blocs/notifications/badge/notification_badge_cubit.dart';
 import 'package:openvine/notifications/bloc/notification_feed_bloc.dart';
+import 'package:openvine/services/app_badge_service.dart';
 import 'package:rxdart/rxdart.dart' hide NotificationKind;
 
 class _MockFollowRepository extends Mock implements FollowRepository {}
+
+class _NoopAppBadgeClearer implements AppBadgeClearer {
+  const _NoopAppBadgeClearer();
+
+  @override
+  Future<void> clear() async {}
+}
 
 /// Controllable fake that mirrors the real repository's shared-source-of-truth
 /// behaviour: a single [BehaviorSubject] feeds both [watchSnapshot] and
@@ -122,6 +130,7 @@ void main() {
         final bloc = NotificationFeedBloc(
           notificationRepository: repository,
           followRepository: followRepository,
+          appBadgeClearer: const _NoopAppBadgeClearer(),
         );
         addTearDown(bloc.close);
         final badge = NotificationBadgeCubit(repository: repository);
@@ -166,6 +175,7 @@ void main() {
         final bloc = NotificationFeedBloc(
           notificationRepository: repository,
           followRepository: followRepository,
+          appBadgeClearer: const _NoopAppBadgeClearer(),
         );
         addTearDown(bloc.close);
         final badge = NotificationBadgeCubit(repository: repository);
@@ -192,6 +202,7 @@ void main() {
       final bloc = NotificationFeedBloc(
         notificationRepository: repository,
         followRepository: followRepository,
+        appBadgeClearer: const _NoopAppBadgeClearer(),
       );
       addTearDown(bloc.close);
       final badge = NotificationBadgeCubit(repository: repository);

--- a/mobile/test/notifications/bloc/notification_feed_bloc_test.dart
+++ b/mobile/test/notifications/bloc/notification_feed_bloc_test.dart
@@ -117,14 +117,14 @@ void main() {
         NotificationFeedBloc(
           notificationRepository: mockNotificationRepo,
           followRepository: mockFollowRepo,
-          appBadgeClearer: appBadgeClearer,
+          appBadgeClearer: appBadgeClearer ?? mockAppBadgeClearer,
         );
 
     NotificationFeedBloc createFollowBloc({AppBadgeClearer? appBadgeClearer}) =>
         NotificationFeedBloc(
           notificationRepository: mockNotificationRepo,
           followRepository: mockFollowRepo,
-          appBadgeClearer: appBadgeClearer,
+          appBadgeClearer: appBadgeClearer ?? mockAppBadgeClearer,
           filter: NotificationKind.follow,
         );
 

--- a/mobile/test/notifications/bloc/notification_feed_bloc_test.dart
+++ b/mobile/test/notifications/bloc/notification_feed_bloc_test.dart
@@ -16,11 +16,14 @@ import 'package:notification_repository/notification_repository.dart';
 import 'package:openvine/notifications/bloc/notification_feed_bloc.dart';
 import 'package:openvine/notifications/bloc/reportable_sites.dart';
 import 'package:openvine/observability/reportable_error.dart';
+import 'package:openvine/services/app_badge_service.dart';
 
 class _MockNotificationRepository extends Mock
     implements NotificationRepository {}
 
 class _MockFollowRepository extends Mock implements FollowRepository {}
+
+class _MockAppBadgeClearer extends Mock implements AppBadgeClearer {}
 
 const _alicePubkey =
     'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
@@ -75,14 +78,17 @@ void main() {
   group(NotificationFeedBloc, () {
     late _MockNotificationRepository mockNotificationRepo;
     late _MockFollowRepository mockFollowRepo;
+    late _MockAppBadgeClearer mockAppBadgeClearer;
     late StreamController<NotificationPage> snapshotController;
 
     setUp(() {
       mockNotificationRepo = _MockNotificationRepository();
       mockFollowRepo = _MockFollowRepository();
+      mockAppBadgeClearer = _MockAppBadgeClearer();
       snapshotController = StreamController<NotificationPage>.broadcast();
 
       when(() => mockFollowRepo.isFollowing(any())).thenReturn(false);
+      when(() => mockAppBadgeClearer.clear()).thenAnswer((_) async {});
       when(
         () => mockNotificationRepo.watchSnapshot(filter: any(named: 'filter')),
       ).thenAnswer((_) => snapshotController.stream);
@@ -107,16 +113,20 @@ void main() {
       await snapshotController.close();
     });
 
-    NotificationFeedBloc createBloc() => NotificationFeedBloc(
-      notificationRepository: mockNotificationRepo,
-      followRepository: mockFollowRepo,
-    );
+    NotificationFeedBloc createBloc({AppBadgeClearer? appBadgeClearer}) =>
+        NotificationFeedBloc(
+          notificationRepository: mockNotificationRepo,
+          followRepository: mockFollowRepo,
+          appBadgeClearer: appBadgeClearer,
+        );
 
-    NotificationFeedBloc createFollowBloc() => NotificationFeedBloc(
-      notificationRepository: mockNotificationRepo,
-      followRepository: mockFollowRepo,
-      filter: NotificationKind.follow,
-    );
+    NotificationFeedBloc createFollowBloc({AppBadgeClearer? appBadgeClearer}) =>
+        NotificationFeedBloc(
+          notificationRepository: mockNotificationRepo,
+          followRepository: mockFollowRepo,
+          appBadgeClearer: appBadgeClearer,
+          filter: NotificationKind.follow,
+        );
 
     test('resets pagination depth when the feed closes', () async {
       final bloc = createBloc();
@@ -230,6 +240,61 @@ void main() {
             () => mockNotificationRepo.refreshFeed(null),
             () => mockNotificationRepo.markAllAsRead(),
           ]);
+        },
+      );
+
+      blocTest<NotificationFeedBloc, NotificationFeedState>(
+        'clears the platform app badge after successful unfiltered open',
+        build: () => createBloc(appBadgeClearer: mockAppBadgeClearer),
+        act: (bloc) => bloc.add(NotificationFeedStarted()),
+        wait: const Duration(milliseconds: 1),
+        expect: () => [
+          NotificationFeedState(isRefreshing: true),
+          NotificationFeedState(status: NotificationFeedStatus.loaded),
+        ],
+        verify: (_) {
+          verifyInOrder([
+            () => mockNotificationRepo.refreshFeed(null),
+            () => mockNotificationRepo.markAllAsRead(),
+            () => mockAppBadgeClearer.clear(),
+          ]);
+        },
+      );
+
+      blocTest<NotificationFeedBloc, NotificationFeedState>(
+        'does not clear the platform app badge for filtered opens',
+        build: () => createFollowBloc(appBadgeClearer: mockAppBadgeClearer),
+        act: (bloc) => bloc.add(NotificationFeedStarted()),
+        wait: const Duration(milliseconds: 1),
+        expect: () => [
+          NotificationFeedState(isRefreshing: true),
+          NotificationFeedState(status: NotificationFeedStatus.loaded),
+        ],
+        verify: (_) {
+          verify(
+            () => mockNotificationRepo.refreshFeed(NotificationKind.follow),
+          ).called(1);
+          verifyNever(() => mockNotificationRepo.markAllAsRead());
+          verifyNever(() => mockAppBadgeClearer.clear());
+        },
+      );
+
+      blocTest<NotificationFeedBloc, NotificationFeedState>(
+        'ignores platform app badge clear failures',
+        setUp: () {
+          when(
+            () => mockAppBadgeClearer.clear(),
+          ).thenThrow(Exception('badge clear failed'));
+        },
+        build: () => createBloc(appBadgeClearer: mockAppBadgeClearer),
+        act: (bloc) => bloc.add(NotificationFeedStarted()),
+        wait: const Duration(milliseconds: 1),
+        expect: () => [
+          NotificationFeedState(isRefreshing: true),
+          NotificationFeedState(status: NotificationFeedStatus.loaded),
+        ],
+        verify: (_) {
+          verify(() => mockAppBadgeClearer.clear()).called(1);
         },
       );
 

--- a/mobile/test/services/app_badge_service_test.dart
+++ b/mobile/test/services/app_badge_service_test.dart
@@ -1,0 +1,84 @@
+// ABOUTME: Tests for the platform app-icon badge clear service.
+// ABOUTME: Verifies iOS channel invocation and best-effort failure handling.
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/services/app_badge_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  const channelName = 'divine/app_badge';
+  const channel = MethodChannel(channelName);
+
+  Future<void> withPlatform(
+    TargetPlatform platform,
+    Future<void> Function() body,
+  ) async {
+    debugDefaultTargetPlatformOverride = platform;
+    try {
+      await body();
+    } finally {
+      debugDefaultTargetPlatformOverride = null;
+    }
+  }
+
+  group(AppBadgeService, () {
+    tearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, null);
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    test('invokes the clear method channel on iOS', () async {
+      await withPlatform(TargetPlatform.iOS, () async {
+        final calls = <MethodCall>[];
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(channel, (call) async {
+              calls.add(call);
+              return null;
+            });
+
+        await const AppBadgeService().clear();
+
+        expect(calls, hasLength(1));
+        expect(calls.single.method, 'clear');
+      });
+    });
+
+    test('does not invoke the channel on non-iOS platforms', () async {
+      await withPlatform(TargetPlatform.android, () async {
+        var callCount = 0;
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(channel, (call) async {
+              callCount++;
+              return null;
+            });
+
+        await const AppBadgeService().clear();
+
+        expect(callCount, 0);
+      });
+    });
+
+    test('swallows PlatformException from the native badge clear', () async {
+      await withPlatform(TargetPlatform.iOS, () async {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(channel, (call) async {
+              throw PlatformException(code: 'BADGE_CLEAR_FAILED');
+            });
+
+        await expectLater(const AppBadgeService().clear(), completes);
+      });
+    });
+
+    test(
+      'swallows MissingPluginException when the native channel is absent',
+      () async {
+        await withPlatform(TargetPlatform.iOS, () async {
+          await expectLater(const AppBadgeService().clear(), completes);
+        });
+      },
+    );
+  });
+}

--- a/mobile/test/services/app_badge_service_test.dart
+++ b/mobile/test/services/app_badge_service_test.dart
@@ -9,7 +9,8 @@ import 'package:openvine/services/app_badge_service.dart';
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
   const channelName = 'divine/app_badge';
-  const channel = MethodChannel(channelName);
+  const defaultChannel = MethodChannel(channelName);
+  const testChannel = MethodChannel('divine/app_badge_test');
 
   Future<void> withPlatform(
     TargetPlatform platform,
@@ -26,7 +27,9 @@ void main() {
   group(AppBadgeService, () {
     tearDown(() {
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockMethodCallHandler(channel, null);
+          .setMockMethodCallHandler(defaultChannel, null);
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(testChannel, null);
       debugDefaultTargetPlatformOverride = null;
     });
 
@@ -34,12 +37,12 @@ void main() {
       await withPlatform(TargetPlatform.iOS, () async {
         final calls = <MethodCall>[];
         TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-            .setMockMethodCallHandler(channel, (call) async {
+            .setMockMethodCallHandler(testChannel, (call) async {
               calls.add(call);
               return null;
             });
 
-        await const AppBadgeService().clear();
+        await const AppBadgeService(channel: testChannel).clear();
 
         expect(calls, hasLength(1));
         expect(calls.single.method, 'clear');
@@ -50,12 +53,12 @@ void main() {
       await withPlatform(TargetPlatform.android, () async {
         var callCount = 0;
         TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-            .setMockMethodCallHandler(channel, (call) async {
+            .setMockMethodCallHandler(testChannel, (call) async {
               callCount++;
               return null;
             });
 
-        await const AppBadgeService().clear();
+        await const AppBadgeService(channel: testChannel).clear();
 
         expect(callCount, 0);
       });
@@ -64,11 +67,14 @@ void main() {
     test('swallows PlatformException from the native badge clear', () async {
       await withPlatform(TargetPlatform.iOS, () async {
         TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-            .setMockMethodCallHandler(channel, (call) async {
+            .setMockMethodCallHandler(testChannel, (call) async {
               throw PlatformException(code: 'BADGE_CLEAR_FAILED');
             });
 
-        await expectLater(const AppBadgeService().clear(), completes);
+        await expectLater(
+          const AppBadgeService(channel: testChannel).clear(),
+          completes,
+        );
       });
     });
 
@@ -76,7 +82,10 @@ void main() {
       'swallows MissingPluginException when the native channel is absent',
       () async {
         await withPlatform(TargetPlatform.iOS, () async {
-          await expectLater(const AppBadgeService().clear(), completes);
+          await expectLater(
+            const AppBadgeService(channel: testChannel).clear(),
+            completes,
+          );
         });
       },
     );

--- a/mobile/test/widgets/app_lifecycle_handler_test.dart
+++ b/mobile/test/widgets/app_lifecycle_handler_test.dart
@@ -8,10 +8,12 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/models/video_editor/video_editor_provider_state.dart';
 import 'package:openvine/models/video_publish/video_publish_provider_state.dart';
+import 'package:openvine/notifications/services/notification_refresh_coordinator.dart';
 import 'package:openvine/providers/app_foreground_provider.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
 import 'package:openvine/providers/video_publish_provider.dart';
+import 'package:openvine/services/app_badge_service.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/background_activity_manager.dart';
 import 'package:openvine/services/clip_library_service.dart';
@@ -23,6 +25,21 @@ class _MockAuthService extends Mock implements AuthService {}
 class _MockClipLibraryService extends Mock implements ClipLibraryService {}
 
 class _MockDraftStorageService extends Mock implements DraftStorageService {}
+
+class _CountingAppBadgeClearer implements AppBadgeClearer {
+  _CountingAppBadgeClearer({this.throwOnClear = false});
+
+  final bool throwOnClear;
+  int clearCalls = 0;
+
+  @override
+  Future<void> clear() async {
+    clearCalls++;
+    if (throwOnClear) {
+      throw Exception('badge clear failed');
+    }
+  }
+}
 
 class _NoopVideoPublishNotifier extends VideoPublishNotifier {
   @override
@@ -140,5 +157,101 @@ void main() {
     expect(container.read(appForegroundProvider), isFalse);
     await tester.pump(const Duration(seconds: 31));
     debugDefaultTargetPlatformOverride = null;
+  });
+
+  testWidgets('clears the app badge on launch and resume', (tester) async {
+    final authService = _MockAuthService();
+    addTearDown(() {
+      BackgroundActivityManager().onAppLifecycleStateChanged(
+        AppLifecycleState.resumed,
+      );
+    });
+
+    when(() => authService.isAuthenticated).thenReturn(true);
+    when(
+      () => authService.authStateStream,
+    ).thenAnswer((_) => const Stream<AuthState>.empty());
+    final clipLibraryService = _MockClipLibraryService();
+    when(clipLibraryService.migrateOldClips).thenAnswer((_) async {});
+    when(clipLibraryService.purgeExpiredTrash).thenAnswer((_) async => 0);
+    final draftStorageService = _MockDraftStorageService();
+    when(draftStorageService.migrateOldDrafts).thenAnswer((_) async {});
+
+    final appBadgeClearer = _CountingAppBadgeClearer();
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          appBadgeServiceProvider.overrideWithValue(appBadgeClearer),
+          authServiceProvider.overrideWithValue(authService),
+          notificationRefreshCoordinatorProvider.overrideWithValue(null),
+          videoPublishProvider.overrideWith(_NoopVideoPublishNotifier.new),
+          clipLibraryServiceProvider.overrideWithValue(clipLibraryService),
+          draftStorageServiceProvider.overrideWithValue(draftStorageService),
+        ],
+        child: const MaterialApp(
+          home: AppLifecycleHandler(child: SizedBox.shrink()),
+        ),
+      ),
+    );
+
+    await tester.pump();
+    expect(appBadgeClearer.clearCalls, 1);
+
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+    await tester.pump();
+
+    expect(appBadgeClearer.clearCalls, 2);
+  });
+
+  testWidgets('badge clear failure does not break resume handling', (
+    tester,
+  ) async {
+    final authService = _MockAuthService();
+    addTearDown(() {
+      BackgroundActivityManager().onAppLifecycleStateChanged(
+        AppLifecycleState.resumed,
+      );
+    });
+
+    when(() => authService.isAuthenticated).thenReturn(true);
+    when(
+      () => authService.authStateStream,
+    ).thenAnswer((_) => const Stream<AuthState>.empty());
+    final clipLibraryService = _MockClipLibraryService();
+    when(clipLibraryService.migrateOldClips).thenAnswer((_) async {});
+    when(clipLibraryService.purgeExpiredTrash).thenAnswer((_) async => 0);
+    final draftStorageService = _MockDraftStorageService();
+    when(draftStorageService.migrateOldDrafts).thenAnswer((_) async {});
+
+    final appBadgeClearer = _CountingAppBadgeClearer(throwOnClear: true);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          appBadgeServiceProvider.overrideWithValue(appBadgeClearer),
+          authServiceProvider.overrideWithValue(authService),
+          notificationRefreshCoordinatorProvider.overrideWithValue(null),
+          videoPublishProvider.overrideWith(_NoopVideoPublishNotifier.new),
+          clipLibraryServiceProvider.overrideWithValue(clipLibraryService),
+          draftStorageServiceProvider.overrideWithValue(draftStorageService),
+        ],
+        child: const MaterialApp(
+          home: AppLifecycleHandler(child: SizedBox.shrink()),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    final context = tester.element(find.byType(AppLifecycleHandler));
+    final container = ProviderScope.containerOf(context);
+
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+    await tester.pump();
+
+    expect(container.read(appForegroundProvider), isTrue);
+    expect(appBadgeClearer.clearCalls, 2);
+    await tester.pump(const Duration(seconds: 31));
   });
 }


### PR DESCRIPTION
## Summary
- add an iOS-only app badge clear service backed by a `divine/app_badge` MethodChannel
- clear the platform app badge on launch, resume, and after the unfiltered notifications open path successfully advances the seen watermark
- stop requesting/presenting Darwin local-notification badge ownership
- note: this is defensive today; current push payloads do not set `aps.badge`, so the app is clearing any platform badge state it inherits rather than correcting a known badge writer

## Verification
- `flutter test test/services/app_badge_service_test.dart test/widgets/app_lifecycle_handler_test.dart test/notifications/bloc/notification_feed_bloc_test.dart test/notifications/badge_converges_after_tap_read_back_test.dart`
- `flutter analyze`
- `bash mobile/scripts/check_untested_services_floor.sh`
- pre-push hook: analyzer, generated-file check, untested-services floor, and changed-file tests

Follow-up: #7437 tracks the pre-existing dead `NotificationService.initialize()` path and foreground local-notification rendering gap.

Closes #7411