### PR TITLE
test(nostr_sdk): pin publish-denominator tracking when relay status lags the socket

### DIFF
--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -2086,9 +2086,6 @@ class RelayPool {
 
       final sendStartedWhileConnecting =
           relay.relayStatus.connected == ClientConnected.connecting;
-      final shouldTrackAttempt =
-          sendStartedWhileConnecting ||
-          relay.relayStatus.connected == ClientConnected.connected;
       try {
         // Check if relay requires authentication
         if (relay.relayStatus.alwaysAuth && !relay.relayStatus.authed) {
@@ -2124,11 +2121,10 @@ class RelayPool {
                     return false;
                   },
                 );
-            if ((result ||
-                    timedOut ||
-                    sendStartedWhileConnecting ||
-                    deadlineExpired()) &&
-                shouldTrackAttempt) {
+            if (result ||
+                timedOut ||
+                sendStartedWhileConnecting ||
+                deadlineExpired()) {
               attemptedRelayUrls.add(relay.url);
             }
             if (result) {
@@ -2138,9 +2134,7 @@ class RelayPool {
             log('🔐 Queueing message for authentication: ${message[0]}');
             relay.pendingAuthedMessages.add(message);
             sentTo.add(relay.url);
-            if (shouldTrackAttempt) {
-              attemptedRelayUrls.add(relay.url);
-            }
+            attemptedRelayUrls.add(relay.url);
           }
           log(
             '🔐 Pending authed messages count: ${relay.pendingAuthedMessages.length}',
@@ -2173,11 +2167,10 @@ class RelayPool {
                   return false;
                 },
               );
-          if ((result ||
-                  timedOut ||
-                  sendStartedWhileConnecting ||
-                  deadlineExpired()) &&
-              shouldTrackAttempt) {
+          if (result ||
+              timedOut ||
+              sendStartedWhileConnecting ||
+              deadlineExpired()) {
             attemptedRelayUrls.add(relay.url);
           }
           if (result) {
@@ -2185,7 +2178,7 @@ class RelayPool {
           }
         }
       } catch (err) {
-        if (shouldTrackAttempt) {
+        if (sendStartedWhileConnecting) {
           attemptedRelayUrls.add(relay.url);
         }
         log(err.toString());

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -2086,6 +2086,9 @@ class RelayPool {
 
       final sendStartedWhileConnecting =
           relay.relayStatus.connected == ClientConnected.connecting;
+      final shouldTrackAttempt =
+          sendStartedWhileConnecting ||
+          relay.relayStatus.connected == ClientConnected.connected;
       try {
         // Check if relay requires authentication
         if (relay.relayStatus.alwaysAuth && !relay.relayStatus.authed) {
@@ -2121,10 +2124,11 @@ class RelayPool {
                     return false;
                   },
                 );
-            if (result ||
-                timedOut ||
-                sendStartedWhileConnecting ||
-                deadlineExpired()) {
+            if ((result ||
+                    timedOut ||
+                    sendStartedWhileConnecting ||
+                    deadlineExpired()) &&
+                shouldTrackAttempt) {
               attemptedRelayUrls.add(relay.url);
             }
             if (result) {
@@ -2134,7 +2138,9 @@ class RelayPool {
             log('🔐 Queueing message for authentication: ${message[0]}');
             relay.pendingAuthedMessages.add(message);
             sentTo.add(relay.url);
-            attemptedRelayUrls.add(relay.url);
+            if (shouldTrackAttempt) {
+              attemptedRelayUrls.add(relay.url);
+            }
           }
           log(
             '🔐 Pending authed messages count: ${relay.pendingAuthedMessages.length}',
@@ -2167,10 +2173,11 @@ class RelayPool {
                   return false;
                 },
               );
-          if (result ||
-              timedOut ||
-              sendStartedWhileConnecting ||
-              deadlineExpired()) {
+          if ((result ||
+                  timedOut ||
+                  sendStartedWhileConnecting ||
+                  deadlineExpired()) &&
+              shouldTrackAttempt) {
             attemptedRelayUrls.add(relay.url);
           }
           if (result) {
@@ -2178,7 +2185,7 @@ class RelayPool {
           }
         }
       } catch (err) {
-        if (sendStartedWhileConnecting) {
+        if (shouldTrackAttempt) {
           attemptedRelayUrls.add(relay.url);
         }
         log(err.toString());

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_publish_targets_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_publish_targets_test.dart
@@ -399,5 +399,72 @@ void main() {
         expect(outcome.acceptedByAll, isFalse);
       },
     );
+
+    test(
+      'counts an attempted relay whose status still lags the socket',
+      () async {
+        final signer = LocalNostrSigner(
+          '5ee1c8000ab28edd64d74a7d951ac2dd559814887b1b9e1ac7c5f89e96125c12',
+        );
+        final nostr = Nostr(
+          signer,
+          [],
+          (url) => RelayBase(url, RelayStatus(url)),
+        );
+        await nostr.refreshPublicKey();
+
+        final fastFactory = FakeWebSocketChannelFactory();
+        await nostr.relayPool.add(
+          RelayBase(fastUrl, RelayStatus(fastUrl), channelFactory: fastFactory),
+        );
+
+        final slowRelay = RelayBase(
+          slowUrl,
+          RelayStatus(slowUrl),
+          channelFactory: FakeWebSocketChannelFactory(
+            readyDelay: const Duration(milliseconds: 800),
+          ),
+        );
+        final slowAdd = nostr.relayPool.add(slowRelay);
+        await _waitForRelayState(slowRelay, ClientConnected.connecting);
+
+        // `relayStatus.connected` is written from the connection manager's
+        // state stream, so it trails the socket it describes. Force the stale
+        // reading the fan-out can genuinely observe: the manager is already
+        // connecting, the pool-visible status still says disconnect.
+        slowRelay.relayStatus.connected = ClientConnected.disconnect;
+
+        _acceptEventWhenSent(fastFactory, eventId);
+
+        final outcome = await nostr.relayPool.sendEventAwaitOk(
+          [
+            'EVENT',
+            {'id': eventId, 'kind': 5},
+          ],
+          eventId: eventId,
+          timeout: const Duration(milliseconds: 250),
+        );
+        await slowAdd;
+
+        expect(outcome.acceptedBy, equals([fastUrl]));
+        expect(
+          outcome.unreachableTargets,
+          equals([slowUrl]),
+          reason:
+              'the fan-out waited out this relay and spent its whole budget '
+              'on it, so it was attempted — deciding that from the lagging '
+              'status field instead would drop it from the denominator',
+        );
+        expect(outcome.targetCount, equals(2));
+        expect(
+          outcome.acceptedByAll,
+          isFalse,
+          reason:
+              'reporting a publish as accepted by all while one relay was '
+              'attempted and stayed silent is the exact signal this outcome '
+              'exists to prevent',
+        );
+      },
+    );
   });
 }


### PR DESCRIPTION
Closes #7474

Taken over after review. The original guard is reverted and the PR now ships the regression test that was missing — net effect on `relay_pool.dart` against `main` is zero lines.

## Why the guard came out

`shouldTrackAttempt` keyed attempt tracking on `relay.relayStatus.connected`. That field is written from the connection manager's state stream (`relay_base.dart:89`), so it trails the socket — `_intendedPublishTargets` documents exactly this: it "starts at `ClientConnected.disconnect` and only advances when the state stream delivers".

In that window the manager is already `connecting`, so `send()` takes the `ConnectionState.connecting` branch, waits out the handshake and spends the relay's whole budget. The relay was attempted and never answered — but the guard read the stale status and dropped it from the denominator:

| | `unreachableTargets` | `acceptedByAll` | `targetCount` |
| --- | --- | --- | --- |
| `main` | `[wss://relay.slow.example]` | `false` | 2 |
| guard | `[]` | **`true`** | 1 |

A publish that burned its per-relay timeout on a silent relay reporting "accepted by all" is the same wrong signal #6613 and #6681 fixed in the other direction.

## Why the case in #7474 could not occur

For a relay whose status is `disconnect`, `send()` returns through the `skipReconnect` short-circuit (`web_socket_connection_manager.dart:331`) in microseconds. So `result`, `timedOut` and `sendStartedWhileConnecting` are all false, and `deadlineExpired()` cannot have flipped inside that window — the loop already `break`s at the top once the budget is gone.

That is what makes `deadlineExpired()` the discriminator rather than a stray clock read:

| relay | `send()` returns | `deadlineExpired()` | counted |
| --- | --- | --- | --- |
| genuinely offline | in microseconds | false | no |
| socket still coming up | only at the deadline | true | yes |

The systemic version of the reported scenario was already correct and covered: `a configured relay that never connected is not a publish target`, the first test in `relay_pool_publish_targets_test.dart`, asserts `targetCount == 1` and `acceptedByAll == true` for exactly that shape and is green on `main`.

## What this PR adds

`counts an attempted relay whose status still lags the socket` — it drives a relay into the real lag state (manager `connecting`, pool-visible status still `disconnect`) and asserts the relay stays in the denominator.

Nothing covered this before, which is what let the guard look correct: the suite was green both with and without it. The new test fails against the guard, and also fails if `deadlineExpired()` is removed from the attempt conditions, so it pins the behaviour from both sides.

## Verification

- `nostr_sdk` package suite: 524/524 green
- Counter-check: with the guard re-applied the new test fails (`Expected: ['wss://relay.slow.example']`, `Actual: []`) and the rest stays green — it can fail for the right reason
- Ran 5× to check for timing flakiness, green each time
- `flutter analyze lib test integration_test`: no issues
- `dart format`: clean

No behaviour change ships here, so there is nothing to verify on device.
