### PR TITLE
docs(bookmarks): clarify reconciliation helper docs

### DIFF
--- a/mobile/lib/services/bookmark_service.dart
+++ b/mobile/lib/services/bookmark_service.dart
@@ -577,9 +577,6 @@ class BookmarkService {
 
   /// Remove an item from global bookmarks.
   ///
-  /// **For tests only.** Production code should use
-  /// [toggleVideoInGlobalBookmarks] which handles reconciliation internally.
-  ///
   /// Reconciles with the relay first for the same reason as
   /// [addToGlobalBookmarks] — the republished list must be the user's real
   /// one minus [item], not this device's cache minus [item].

--- a/mobile/lib/services/bookmark_service.dart
+++ b/mobile/lib/services/bookmark_service.dart
@@ -508,16 +508,14 @@ class BookmarkService {
 
   /// Add an item to global bookmarks.
   ///
-  /// **For tests only.** Production code should use
-  /// [toggleVideoInGlobalBookmarks] which handles reconciliation internally.
-  ///
   /// Reconciles with the relay first and refuses to publish if that fails, so
   /// a device whose cache is empty (fresh install, second device) cannot
   /// replace the user's list with a one-item one.
   ///
-  /// [alreadyReconciled] is an internal implementation detail and must not be
-  /// used from production code — it is exposed for testing flexibility only.
-  @visibleForTesting
+  /// Pass [alreadyReconciled] only when the caller has just run
+  /// [syncGlobalBookmarks] with `requireAuthoritative: true` and the extra
+  /// round trip would be redundant. Callers that have not just completed that
+  /// authoritative sync must leave it false so this method reconciles first.
   Future<bool> addToGlobalBookmarks(
     BookmarkItem item, {
     bool alreadyReconciled = false,
@@ -586,9 +584,10 @@ class BookmarkService {
   /// [addToGlobalBookmarks] — the republished list must be the user's real
   /// one minus [item], not this device's cache minus [item].
   ///
-  /// [alreadyReconciled] is an internal implementation detail and must not be
-  /// used from production code — it is exposed for testing flexibility only.
-  @visibleForTesting
+  /// Pass [alreadyReconciled] only when the caller has just run
+  /// [syncGlobalBookmarks] with `requireAuthoritative: true` and the extra
+  /// round trip would be redundant. Callers that have not just completed that
+  /// authoritative sync must leave it false so this method reconciles first.
   Future<bool> removeFromGlobalBookmarks(
     BookmarkItem item, {
     bool alreadyReconciled = false,

--- a/mobile/lib/services/bookmark_service.dart
+++ b/mobile/lib/services/bookmark_service.dart
@@ -508,13 +508,16 @@ class BookmarkService {
 
   /// Add an item to global bookmarks.
   ///
+  /// **For tests only.** Production code should use
+  /// [toggleVideoInGlobalBookmarks] which handles reconciliation internally.
+  ///
   /// Reconciles with the relay first and refuses to publish if that fails, so
   /// a device whose cache is empty (fresh install, second device) cannot
   /// replace the user's list with a one-item one.
   ///
-  /// Pass [alreadyReconciled] when the caller has just run
-  /// [syncGlobalBookmarks] with `requireAuthoritative: true` and the extra
-  /// round trip would be redundant.
+  /// [alreadyReconciled] is an internal implementation detail and must not be
+  /// used from production code — it is exposed for testing flexibility only.
+  @visibleForTesting
   Future<bool> addToGlobalBookmarks(
     BookmarkItem item, {
     bool alreadyReconciled = false,
@@ -576,9 +579,16 @@ class BookmarkService {
 
   /// Remove an item from global bookmarks.
   ///
+  /// **For tests only.** Production code should use
+  /// [toggleVideoInGlobalBookmarks] which handles reconciliation internally.
+  ///
   /// Reconciles with the relay first for the same reason as
   /// [addToGlobalBookmarks] — the republished list must be the user's real
   /// one minus [item], not this device's cache minus [item].
+  ///
+  /// [alreadyReconciled] is an internal implementation detail and must not be
+  /// used from production code — it is exposed for testing flexibility only.
+  @visibleForTesting
   Future<bool> removeFromGlobalBookmarks(
     BookmarkItem item, {
     bool alreadyReconciled = false,


### PR DESCRIPTION
Closes #7446

## Summary

Clarifies the reconciliation contract for the global bookmark helper methods without changing behavior.

- Removed the misleading `@visibleForTesting` annotations from `addToGlobalBookmarks` and `removeFromGlobalBookmarks`
- Removed the incorrect test-only banners from those method docs
- Documented that `alreadyReconciled` is only valid after an authoritative `syncGlobalBookmarks` call, otherwise callers must leave it false so the helper reconciles first

## Test plan

- [x] `flutter test test/services/bookmark_service_test.dart`
- [x] `flutter analyze lib/services/bookmark_service.dart test/services/bookmark_service_test.dart`