### PR TITLE
fix(notifications): close app-badge review findings from #7423

### DIFF
--- a/mobile/lib/notifications/bloc/notification_feed_bloc.dart
+++ b/mobile/lib/notifications/bloc/notification_feed_bloc.dart
@@ -13,7 +13,6 @@ import 'package:notification_repository/notification_repository.dart';
 import 'package:openvine/notifications/bloc/reportable_sites.dart';
 import 'package:openvine/observability/reportable_error.dart';
 import 'package:openvine/services/app_badge_service.dart';
-import 'package:unified_logger/unified_logger.dart';
 
 part 'notification_feed_event.dart';
 part 'notification_feed_state.dart';
@@ -264,14 +263,29 @@ class NotificationFeedBloc
     }
   }
 
+  /// Clears the platform app-icon badge once the seen watermark has advanced.
+  ///
+  /// Best-effort: a badge failure must never affect feed state, so nothing here
+  /// is rethrown. [AppBadgeService] already absorbs `PlatformException` and
+  /// `MissingPluginException` itself, so anything reaching these arms is
+  /// unexpected and worth surfacing through the observer rather than a log
+  /// line.
   Future<void> _clearAppBadge() async {
     try {
       await _appBadgeClearer.clear();
-    } catch (e, st) {
-      Log.warning(
-        'App badge clear failed after notification feed open: $e\n$st',
-        name: 'NotificationFeedBloc',
-        category: LogCategory.system,
+    } on Exception catch (e, s) {
+      // Platform/plugin failures the service did not already absorb. Per
+      // .claude/rules/error_handling.md these are expected domain failures,
+      // NOT Reportable.
+      addError(e, s);
+    } catch (e, s) {
+      // Errors (StateError, TypeError) — matrix-YES invariant violation.
+      addError(
+        Reportable(
+          e,
+          context: NotificationFeedBlocReportableSites.clearAppBadge,
+        ),
+        s,
       );
     }
   }

--- a/mobile/lib/notifications/bloc/notification_feed_bloc.dart
+++ b/mobile/lib/notifications/bloc/notification_feed_bloc.dart
@@ -267,9 +267,8 @@ class NotificationFeedBloc
   ///
   /// Best-effort: a badge failure must never affect feed state, so nothing here
   /// is rethrown. [AppBadgeService] already absorbs `PlatformException` and
-  /// `MissingPluginException` itself, so anything reaching these arms is
-  /// unexpected and worth surfacing through the observer rather than a log
-  /// line.
+  /// `MissingPluginException` itself, so failures reaching these arms are
+  /// surfaced through the observer rather than a direct warning log.
   Future<void> _clearAppBadge() async {
     try {
       await _appBadgeClearer.clear();

--- a/mobile/lib/notifications/bloc/reportable_sites.dart
+++ b/mobile/lib/notifications/bloc/reportable_sites.dart
@@ -40,6 +40,12 @@ abstract class NotificationFeedBlocReportableSites {
   /// Realistically a Drift DAO `TypeError` from a row-shape mismatch.
   static const String onItemTapped = '_onItemTapped';
 
+  /// `_clearAppBadge` generic-catch arm — `Error` types thrown by an
+  /// `AppBadgeClearer` implementation. `AppBadgeService` already absorbs
+  /// `PlatformException` and `MissingPluginException` itself, so anything
+  /// reaching here is an invariant violation rather than a platform failure.
+  static const String clearAppBadge = '_clearAppBadge';
+
   /// `_onFollowBack` generic-catch arm — `Error` types that escape
   /// `FollowRepository.follow`'s Exception-only throws, plus a
   /// hypothetical `TypeError` from the post-await `_applyFollowState`

--- a/mobile/lib/services/app_badge_service.dart
+++ b/mobile/lib/services/app_badge_service.dart
@@ -29,8 +29,12 @@ class AppBadgeService implements AppBadgeClearer {
     try {
       await _channel.invokeMethod<void>('clear');
     } on PlatformException catch (e) {
+      // Log the whole exception, not just `e.code`: BADGE_CLEAR_FAILED is the
+      // only code the native handler emits, so the code alone says nothing.
+      // `message` carries the underlying `error.localizedDescription` set in
+      // `setupAppBadgeChannel` — that is the part worth having.
       Log.warning(
-        'App badge clear failed: ${e.code}',
+        'App badge clear failed: $e',
         name: 'AppBadgeService',
         category: LogCategory.system,
       );

--- a/mobile/test/notifications/bloc/notification_feed_bloc_test.dart
+++ b/mobile/test/notifications/bloc/notification_feed_bloc_test.dart
@@ -280,7 +280,7 @@ void main() {
       );
 
       blocTest<NotificationFeedBloc, NotificationFeedState>(
-        'ignores platform app badge clear failures',
+        'surfaces platform app badge clear failures without affecting feed state',
         setUp: () {
           when(
             () => mockAppBadgeClearer.clear(),
@@ -293,9 +293,7 @@ void main() {
           NotificationFeedState(isRefreshing: true),
           NotificationFeedState(status: NotificationFeedStatus.loaded),
         ],
-        errors: () => [
-          allOf(isA<Exception>(), isNot(isA<ReportableError>())),
-        ],
+        errors: () => [allOf(isA<Exception>(), isNot(isA<ReportableError>()))],
         verify: (_) {
           verify(() => mockAppBadgeClearer.clear()).called(1);
         },

--- a/mobile/test/notifications/bloc/notification_feed_bloc_test.dart
+++ b/mobile/test/notifications/bloc/notification_feed_bloc_test.dart
@@ -346,6 +346,10 @@ void main() {
         verify: (_) {
           verify(() => mockNotificationRepo.refreshFeed(null)).called(1);
           verify(() => mockNotificationRepo.markAllAsRead()).called(1);
+          // The seen watermark did not advance, so the OS badge must stay put
+          // — clearing it here would hide notifications the server still
+          // considers unread.
+          verifyNever(() => mockAppBadgeClearer.clear());
         },
       );
 
@@ -375,6 +379,10 @@ void main() {
         verify: (_) {
           verify(() => mockNotificationRepo.refreshFeed(null)).called(1);
           verify(() => mockNotificationRepo.markAllAsRead()).called(1);
+          // The seen watermark did not advance, so the OS badge must stay put
+          // — clearing it here would hide notifications the server still
+          // considers unread.
+          verifyNever(() => mockAppBadgeClearer.clear());
         },
       );
 

--- a/mobile/test/notifications/bloc/notification_feed_bloc_test.dart
+++ b/mobile/test/notifications/bloc/notification_feed_bloc_test.dart
@@ -293,6 +293,36 @@ void main() {
           NotificationFeedState(isRefreshing: true),
           NotificationFeedState(status: NotificationFeedStatus.loaded),
         ],
+        errors: () => [isA<Exception>()],
+        verify: (_) {
+          verify(() => mockAppBadgeClearer.clear()).called(1);
+        },
+      );
+
+      blocTest<NotificationFeedBloc, NotificationFeedState>(
+        'wraps unexpected Error from the app badge clear as Reportable '
+        'without blackening the feed',
+        setUp: () {
+          when(
+            () => mockAppBadgeClearer.clear(),
+          ).thenThrow(StateError('badge invariant'));
+        },
+        build: () => createBloc(appBadgeClearer: mockAppBadgeClearer),
+        act: (bloc) => bloc.add(NotificationFeedStarted()),
+        wait: const Duration(milliseconds: 1),
+        expect: () => [
+          NotificationFeedState(isRefreshing: true),
+          NotificationFeedState(status: NotificationFeedStatus.loaded),
+        ],
+        errors: () => [
+          isA<Reportable<Object>>()
+              .having(
+                (r) => r.context,
+                'context',
+                NotificationFeedBlocReportableSites.clearAppBadge,
+              )
+              .having((r) => r.unwrap(), 'unwrap', isA<StateError>()),
+        ],
         verify: (_) {
           verify(() => mockAppBadgeClearer.clear()).called(1);
         },

--- a/mobile/test/notifications/bloc/notification_feed_bloc_test.dart
+++ b/mobile/test/notifications/bloc/notification_feed_bloc_test.dart
@@ -293,7 +293,9 @@ void main() {
           NotificationFeedState(isRefreshing: true),
           NotificationFeedState(status: NotificationFeedStatus.loaded),
         ],
-        errors: () => [isA<Exception>()],
+        errors: () => [
+          allOf(isA<Exception>(), isNot(isA<ReportableError>())),
+        ],
         verify: (_) {
           verify(() => mockAppBadgeClearer.clear()).called(1);
         },

--- a/mobile/test/services/app_badge_service_test.dart
+++ b/mobile/test/services/app_badge_service_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/services/app_badge_service.dart';
+import 'package:unified_logger/unified_logger.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -25,12 +26,15 @@ void main() {
   }
 
   group(AppBadgeService, () {
-    tearDown(() {
+    setUp(() => LogCaptureService().clearAllLogs());
+
+    tearDown(() async {
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(defaultChannel, null);
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(testChannel, null);
       debugDefaultTargetPlatformOverride = null;
+      await LogCaptureService().clearAllLogs();
     });
 
     test('invokes the clear method channel on iOS', () async {
@@ -85,17 +89,25 @@ void main() {
       });
     });
 
-    test('swallows PlatformException from the native badge clear', () async {
+    test('logs the native reason and swallows PlatformException', () async {
       await withPlatform(TargetPlatform.iOS, () async {
         TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
             .setMockMethodCallHandler(testChannel, (call) async {
-              throw PlatformException(code: 'BADGE_CLEAR_FAILED');
+              throw PlatformException(
+                code: 'BADGE_CLEAR_FAILED',
+                message: 'Notifications are unavailable',
+              );
             });
 
         await expectLater(
           const AppBadgeService(channel: testChannel).clear(),
           completes,
         );
+
+        final warning = LogCaptureService().getRecentLogs().singleWhere(
+          (log) => log.message.contains('App badge clear failed'),
+        );
+        expect(warning.message, contains('Notifications are unavailable'));
       });
     });
 

--- a/mobile/test/services/app_badge_service_test.dart
+++ b/mobile/test/services/app_badge_service_test.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Tests for the platform app-icon badge clear service.
 // ABOUTME: Verifies iOS channel invocation and best-effort failure handling.
 
+import 'dart:io';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -63,14 +65,17 @@ void main() {
             });
 
         // Exercises the production constructor rather than an injected
-        // channel, so renaming `_channelName` fails here instead of surfacing
-        // only on device as a swallowed MissingPluginException. Nothing in CI
-        // compiles the iOS half, so keep `channelName` above in step with
-        // `setupAppBadgeChannel` in ios/Runner/AppDelegate.swift.
+        // channel, and also checks the Swift registration string because CI
+        // does not compile ios/Runner/AppDelegate.swift.
         await const AppBadgeService().clear();
 
         expect(calls, hasLength(1));
         expect(calls.single.method, 'clear');
+
+        final appDelegate = File(
+          'ios/Runner/AppDelegate.swift',
+        ).readAsStringSync();
+        expect(appDelegate, contains('name: "$channelName"'));
       });
     });
 

--- a/mobile/test/services/app_badge_service_test.dart
+++ b/mobile/test/services/app_badge_service_test.dart
@@ -49,6 +49,27 @@ void main() {
       });
     });
 
+    test('defaults to the channel name the native side registers', () async {
+      await withPlatform(TargetPlatform.iOS, () async {
+        final calls = <MethodCall>[];
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(defaultChannel, (call) async {
+              calls.add(call);
+              return null;
+            });
+
+        // Exercises the production constructor rather than an injected
+        // channel, so renaming `_channelName` fails here instead of surfacing
+        // only on device as a swallowed MissingPluginException. Nothing in CI
+        // compiles the iOS half, so keep `channelName` above in step with
+        // `setupAppBadgeChannel` in ios/Runner/AppDelegate.swift.
+        await const AppBadgeService().clear();
+
+        expect(calls, hasLength(1));
+        expect(calls.single.method, 'clear');
+      });
+    });
+
     test('does not invoke the channel on non-iOS platforms', () async {
       await withPlatform(TargetPlatform.android, () async {
         var callCount = 0;


### PR DESCRIPTION
Closes #7473

## Summary

Four review findings on #7423 that landed after it merged. All are follow-ups to
the badge-clear work, no behaviour change to the feature itself.

- `_clearAppBadge` used a single bare `catch` that downgraded everything to a
  warning log, so an `Error` from an `AppBadgeClearer` never reached
  DivineBlocObserver or Crashlytics. Now uses the same two-arm shape as the rest
  of the bloc, per the matrix in `.claude/rules/error_handling.md`.
- The `if (markSucceeded)` gate — the whole reason `_markSeenOnOpen` returns a
  bool — had no coverage. Deleting it left every test green.
- No test touched the production channel name or the `const AppBadgeService()`
  constructor, so renaming `_channelName` away from the Swift side stayed green.
- The `PlatformException` warning logged only `e.code`, which is always
  `BADGE_CLEAR_FAILED`, discarding the `message` the native handler populates.

## Motivation

#7423 was approved and merged before these came out of a second review pass. The
first is an observability hole against an explicit repo rule; the middle two are
places where the code could regress with nothing noticing, which matters more
than usual because no CI job compiles `ios/Runner/AppDelegate.swift` — every job
in `mobile_ci.yaml` runs on ubuntu.

## Validation

Both test commits were verified by mutation, not just by passing:

- remove the `if (markSucceeded)` gate → the two mark-all-failure tests now fail
  (before this PR: 42/42 still passed)
- rename `_channelName` → the new channel-name test now fails

Also run on this branch:

- `flutter analyze` — no issues
- `flutter test test/notifications test/services test/widgets` — 7805 passed, 88 skipped
- `bash mobile/scripts/check_untested_services_floor.sh` — no new entries

Related: #7423, #7411. The dead `NotificationService.initialize()` path is
tracked separately in #7437 and is not touched here.

