### PR TITLE
fix(dm): unwind group sends on enqueue failure

### DIFF
--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -4402,10 +4402,10 @@ class DmRepository {
   /// [NIP17SendResult.queuedRumorId], so a caller retries by re-driving the
   /// surviving siblings ([recoverFullSend]) rather than fanning out again.
   ///
-  /// A sibling whose enqueue itself fails is reported and returned as a plain
-  /// failure with no `queuedRumorId`, and its publish is skipped — never
-  /// thrown out of this method, which would strand the siblings already
-  /// parked and push the caller back onto a duplicating fresh fan-out.
+  /// If a sibling enqueue fails before any publish starts, the whole batch is
+  /// failed and the siblings already parked are best-effort deleted. Any row
+  /// that cannot be deleted is returned with its `queuedRumorId` so retry can
+  /// re-drive the surviving parked rumor instead of minting a fresh fan-out.
   @useResult
   Future<List<NIP17SendResult>> sendGroupMessage({
     required List<String> recipientPubkeys,
@@ -4518,14 +4518,14 @@ class DmRepository {
     // exist before the first (potentially slow) publish. Same contract as
     // sendMessage: no-op when the queue dao isn't wired in (older test
     // fixtures, NIP-04-only callers).
-    // Guarded per iteration, like the delivery loop below. `enqueue` swallows
-    // PK conflicts but still throws on a real write error (SQLite BUSY/LOCKED
-    // — OutgoingDmRetryService writes this table concurrently). Letting that
-    // escape would abandon the siblings already parked at 0..i-1: the caller
-    // would see a throw, hold no queuedRumorId for them, and a user retry
-    // would fan out fresh rumors alongside the sweep's replay of the parked
-    // ones — the exact double-delivery #7316 exists to close.
-    final failedToEnqueue = <int>{};
+    // `enqueue` swallows PK conflicts but still throws on a real write error
+    // (SQLite BUSY/LOCKED — OutgoingDmRetryService writes this table
+    // concurrently). Because every sibling is queued before any publish, an
+    // enqueue failure can still be made atomic from the user's perspective:
+    // unwind rows already parked, skip publish entirely, and return failures
+    // for the whole batch. If a parked row cannot be deleted, stamp that row's
+    // id onto its failure so retry re-drives the surviving rumor instead of
+    // minting a duplicating fresh fan-out (#7316).
     if (outgoingDao != null) {
       for (var i = 0; i < recipientPubkeys.length; i++) {
         final rumor = rumors[i];
@@ -4548,15 +4548,34 @@ class DmRepository {
             ),
           );
         } on Object catch (e, stackTrace) {
-          // No durable row for this sibling, so its publish is skipped below:
-          // a wire copy with no local trace is invisible to the sender and
-          // unretractable, strictly worse than not sending it.
-          failedToEnqueue.add(i);
           _errorReporter?.call(
             e,
             stackTrace,
             site: DmRepositoryReportableSites.sendGroupMessageEnqueueSibling,
           );
+
+          final failure = NIP17SendResult.failure(
+            'could not queue send for recipient: $e',
+          );
+          final unwindResults = List<NIP17SendResult>.filled(
+            recipientPubkeys.length,
+            failure,
+          );
+          for (var j = 0; j < i; j++) {
+            final parkedRumorId = rumors[j].id;
+            try {
+              await outgoingDao.deleteById(parkedRumorId);
+            } on Object catch (deleteError, deleteStackTrace) {
+              _errorReporter?.call(
+                deleteError,
+                deleteStackTrace,
+                site: DmRepositoryReportableSites
+                    .sendGroupMessageUnwindQueuedSibling,
+              );
+              unwindResults[j] = _stampQueuedRow(failure, parkedRumorId);
+            }
+          }
+          return unwindResults;
         }
       }
     }
@@ -4574,16 +4593,6 @@ class DmRepository {
     final cancelledBeforePublish = <int>{};
     for (var i = 0; i < recipientPubkeys.length; i++) {
       final pubkey = recipientPubkeys[i];
-      // A sibling whose row never got parked: publishing it would put a copy
-      // on the wire that no local row can retract or re-drive. Fail it here
-      // instead, before the cancel interlock below misreads the absent row as
-      // a user cancellation.
-      if (failedToEnqueue.contains(i)) {
-        results.add(
-          const NIP17SendResult.failure('could not queue send for recipient'),
-        );
-        continue;
-      }
       // Cancel interlock, mirroring _recoverFullSendLocked's pre-publish row
       // re-read: each publish can take up to the OK-confirm timeout, a long
       // window in which the user may delete the whole batch. Re-read the
@@ -4748,15 +4757,15 @@ class DmRepository {
     // id onto the returned result, exactly as [sendMessage] does. Without it
     // a group caller has no handle on the rows this send parked and its only
     // way to "retry" is a fresh fan-out, which mints a whole second set of
-    // rumors the receiver cannot collapse (#7316). Cancelled, un-enqueued and
-    // blocked siblings are deliberately unstamped: none leaves a row behind.
+    // rumors the receiver cannot collapse (#7316). Cancelled and blocked
+    // siblings are deliberately unstamped: none leaves a row behind.
     if (outgoingDao != null) {
       for (var i = 0; i < rumors.length; i++) {
-        // A sibling skipped for cancellation, or whose enqueue threw, has no
-        // live row to transition; an update-by-id would match zero rows
-        // anyway, but skipping is explicit and keeps such an index from
-        // resurrecting a queue transition or a thread.
-        if (cancelledBeforePublish.contains(i) || failedToEnqueue.contains(i)) {
+        // A sibling skipped for cancellation has no live row to transition; an
+        // update-by-id would match zero rows anyway, but skipping is explicit
+        // and keeps such an index from resurrecting a queue transition or a
+        // thread.
+        if (cancelledBeforePublish.contains(i)) {
           continue;
         }
         final result = results[i];
@@ -4788,14 +4797,10 @@ class DmRepository {
     // the failed bubbles to retry or delete. All-blocked sends leave no
     // rows behind (terminal), so they create no thread cruft. A fully
     // cancelled batch must NOT resurrect the thread the user just deleted,
-    // so cancelled indexes don't count as retryable failures here. Nor do
-    // un-enqueued ones: they left no row, so the thread would hold no bubble
-    // to retry or delete.
+    // so cancelled indexes don't count as retryable failures here.
     final hasRetryableFailure = results.asMap().entries.any(
       (entry) =>
-          !cancelledBeforePublish.contains(entry.key) &&
-          !failedToEnqueue.contains(entry.key) &&
-          !entry.value.blocked,
+          !cancelledBeforePublish.contains(entry.key) && !entry.value.blocked,
     );
     if (!results.any((r) => r.success) && hasRetryableFailure) {
       await _ensureConversationVisibleAfterSendFailure(

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -3206,11 +3206,13 @@ class DmRepository {
   /// durable row, and the sweep then delivers one copy while the retry
   /// delivers another.
   ///
-  /// Only ever called from the branches that finalize a surviving row — the
-  /// soft-unconfirmed and hard-failure arms of both [sendMessage] and
-  /// [sendGroupMessage]. The blocked branch deletes its row, a cancelled
-  /// group sibling never had one, and the success branch consumes it (except
-  /// on partial delivery — see [NIP17SendResult.queuedRumorId]).
+  /// Only ever called for a row that survives the call — the soft-unconfirmed
+  /// and hard-failure arms of both [sendMessage] and [sendGroupMessage], plus
+  /// a [sendGroupMessage] sibling whose enqueue-failure unwind could not
+  /// delete it. The blocked branch deletes its row, a cancelled group sibling
+  /// never had one, an unwound sibling no longer has one, and the success
+  /// branch consumes it (except on partial delivery — see
+  /// [NIP17SendResult.queuedRumorId]).
   NIP17SendResult _stampQueuedRow(NIP17SendResult result, String rumorId) =>
       switch (result) {
         NIP17SendSuccess() => result,
@@ -4574,6 +4576,19 @@ class DmRepository {
               );
               unwindResults[j] = _stampQueuedRow(failure, parkedRumorId);
             }
+          }
+          // A row that survived the unwind still holds the user's message, so
+          // a brand-new group thread must be visible for them to reach that
+          // bubble and retry or delete it — the same reason the publish-failure
+          // path below surfaces one. A fully unwound batch leaves no row and
+          // must not resurrect a thread.
+          if (unwindResults.any((r) => r.queuedRumorId != null)) {
+            await _ensureConversationVisibleAfterSendFailure(
+              conversationId: conversationId,
+              participants: participants,
+              isGroup: true,
+              content: content,
+            );
           }
           return unwindResults;
         }

--- a/mobile/packages/dm_repository/lib/src/dm_repository_reportable_sites.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository_reportable_sites.dart
@@ -64,10 +64,15 @@ abstract class DmRepositoryReportableSites {
       'sendMessage.outerTransaction';
 
   /// `sendGroupMessage`: parking one sibling's `outgoing_dms` row threw.
-  /// That recipient's publish is skipped so no untraceable wire copy goes
-  /// out; the siblings already parked keep their rows and their handles.
+  /// The batch is unwound before publish so no sibling is silently dropped.
   static const String sendGroupMessageEnqueueSibling =
       'sendGroupMessage.enqueueSibling';
+
+  /// `sendGroupMessage`: after one sibling failed to enqueue, deleting a
+  /// sibling already parked for that same not-yet-published batch also threw.
+  /// The row survives and is returned to the caller as a retry handle.
+  static const String sendGroupMessageUnwindQueuedSibling =
+      'sendGroupMessage.unwindQueuedSibling';
 
   /// `backfillHistoryIfNeeded`: the history drain hit a programming
   /// invariant failure while paging or processing recovered events.

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -15747,7 +15747,9 @@ void main() {
           // OutgoingDmRetryService writes this table concurrently. Letting it
           // escape would hand the caller a throw and no handle on the sibling
           // already parked, whose only "retry" is then a fresh fan-out the
-          // receiver cannot collapse (#7316).
+          // receiver cannot collapse (#7316). Publishing the parked sibling
+          // while skipping the unqueued one would be visible as a partial
+          // success, which callers reduce to "sent" (#7448).
           final enqueued = <OutgoingDm>[];
           when(() => mockOutgoingDmsDao.enqueue(any())).thenAnswer((
             invocation,
@@ -15773,33 +15775,111 @@ void main() {
 
           expect(enqueued, hasLength(1));
           expect(results, hasLength(2));
+          expect(results.every((r) => !r.success), isTrue);
           expect(
-            results.first.queuedRumorId,
-            equals(enqueued.single.id),
+            results.map((r) => r.queuedRumorId),
+            everyElement(isNull),
             reason:
-                'the sibling that did park must reach the caller with its row '
-                'handle, or a retry re-sends it as a second rumor',
+                'the parked sibling was unwound before any publish, so a user '
+                'retry can safely submit the whole group again',
           );
-          // No row parked for C, so nothing can re-drive or retract it: its
-          // publish must be skipped rather than put an untraceable copy on the
-          // wire.
-          expect(results.last.success, isFalse);
-          expect(results.last.queuedRumorId, isNull);
           verify(
+            () => mockOutgoingDmsDao.deleteById(enqueued.single.id),
+          ).called(1);
+          verifyNever(
             () => mockMessageService.sendRumor(
               rumorEvent: any(named: 'rumorEvent'),
-              recipientPubkey: _validPubkeyB,
+              recipientPubkey: any(named: 'recipientPubkey'),
               targetRelays: any(named: 'targetRelays'),
               awaitRecipientOk: any(named: 'awaitRecipientOk'),
               selfWrapOnSoftUnconfirmed: any(
                 named: 'selfWrapOnSoftUnconfirmed',
               ),
             ),
+          );
+          verifyNever(
+            () => mockDirectMessagesDao.insertMessage(
+              id: any(named: 'id'),
+              conversationId: any(named: 'conversationId'),
+              senderPubkey: any(named: 'senderPubkey'),
+              content: any(named: 'content'),
+              createdAt: any(named: 'createdAt'),
+              giftWrapId: any(named: 'giftWrapId'),
+              messageKind: any(named: 'messageKind'),
+              replyToId: any(named: 'replyToId'),
+              subject: any(named: 'subject'),
+              fileType: any(named: 'fileType'),
+              encryptionAlgorithm: any(named: 'encryptionAlgorithm'),
+              decryptionKey: any(named: 'decryptionKey'),
+              decryptionNonce: any(named: 'decryptionNonce'),
+              fileHash: any(named: 'fileHash'),
+              originalFileHash: any(named: 'originalFileHash'),
+              fileSize: any(named: 'fileSize'),
+              dimensions: any(named: 'dimensions'),
+              blurhash: any(named: 'blurhash'),
+              thumbnailUrl: any(named: 'thumbnailUrl'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+              tagsJson: any(named: 'tagsJson'),
+              sendBatchId: any(named: 'sendBatchId'),
+            ),
+          );
+          expect(
+            reporterCalls.map((c) => c.site),
+            contains(
+              DmRepositoryReportableSites.sendGroupMessageEnqueueSibling,
+            ),
+          );
+        },
+      );
+
+      test(
+        'a sibling enqueue write failure returns queued ids for parked '
+        'rows that cannot be unwound',
+        () async {
+          final enqueued = <OutgoingDm>[];
+          when(() => mockOutgoingDmsDao.enqueue(any())).thenAnswer((
+            invocation,
+          ) async {
+            final row = invocation.positionalArguments.first as OutgoingDm;
+            if (row.recipientPubkey == _validPubkeyC) {
+              throw StateError('database is locked');
+            }
+            enqueued.add(row);
+          });
+          when(() => mockOutgoingDmsDao.deleteById(any())).thenThrow(
+            StateError('database is still locked'),
+          );
+          stubSendRumor(
+            (_, _) async => const NIP17SendResult.failure('all relays down'),
+          );
+
+          final repository = createRepository(
+            outgoingDmsDao: mockOutgoingDmsDao,
+          );
+
+          final results = await repository.sendGroupMessage(
+            recipientPubkeys: [_validPubkeyB, _validPubkeyC],
+            content: 'one sibling cannot be parked or unwound',
+          );
+
+          expect(enqueued, hasLength(1));
+          expect(results, hasLength(2));
+          expect(results.every((r) => !r.success), isTrue);
+          expect(
+            results.first.queuedRumorId,
+            equals(enqueued.single.id),
+            reason:
+                'the row that could not be unwound must remain retryable via '
+                'recoverFullSend, not a fresh group submit',
+          );
+          expect(results.last.queuedRumorId, isNull);
+          verify(
+            () => mockOutgoingDmsDao.deleteById(enqueued.single.id),
           ).called(1);
           verifyNever(
             () => mockMessageService.sendRumor(
               rumorEvent: any(named: 'rumorEvent'),
-              recipientPubkey: _validPubkeyC,
+              recipientPubkey: any(named: 'recipientPubkey'),
               targetRelays: any(named: 'targetRelays'),
               awaitRecipientOk: any(named: 'awaitRecipientOk'),
               selfWrapOnSoftUnconfirmed: any(
@@ -15811,6 +15891,12 @@ void main() {
             reporterCalls.map((c) => c.site),
             contains(
               DmRepositoryReportableSites.sendGroupMessageEnqueueSibling,
+            ),
+          );
+          expect(
+            reporterCalls.map((c) => c.site),
+            contains(
+              DmRepositoryReportableSites.sendGroupMessageUnwindQueuedSibling,
             ),
           );
         },

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -15823,6 +15823,24 @@ void main() {
               sendBatchId: any(named: 'sendBatchId'),
             ),
           );
+          // Nothing survived the unwind, so there is no bubble to reach and
+          // the thread the user was composing into must not be resurrected.
+          verifyNever(
+            () => mockConversationsDao.upsertConversation(
+              id: any(named: 'id'),
+              participantPubkeys: any(named: 'participantPubkeys'),
+              isGroup: any(named: 'isGroup'),
+              createdAt: any(named: 'createdAt'),
+              lastMessageContent: any(named: 'lastMessageContent'),
+              lastMessageTimestamp: any(named: 'lastMessageTimestamp'),
+              lastMessageSenderPubkey: any(named: 'lastMessageSenderPubkey'),
+              subject: any(named: 'subject'),
+              isRead: any(named: 'isRead'),
+              currentUserHasSent: any(named: 'currentUserHasSent'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+              dmProtocol: any(named: 'dmProtocol'),
+            ),
+          );
           expect(
             reporterCalls.map((c) => c.site),
             contains(
@@ -15899,6 +15917,25 @@ void main() {
               DmRepositoryReportableSites.sendGroupMessageUnwindQueuedSibling,
             ),
           );
+          // The surviving row still holds the user's message, so a brand-new
+          // group thread has to exist for them to reach that bubble and retry
+          // or delete it.
+          verify(
+            () => mockConversationsDao.upsertConversation(
+              id: any(named: 'id'),
+              participantPubkeys: any(named: 'participantPubkeys'),
+              isGroup: true,
+              createdAt: any(named: 'createdAt'),
+              lastMessageContent: 'one sibling cannot be parked or unwound',
+              lastMessageTimestamp: any(named: 'lastMessageTimestamp'),
+              lastMessageSenderPubkey: _validPubkeyA,
+              subject: any(named: 'subject'),
+              isRead: any(named: 'isRead'),
+              currentUserHasSent: any(named: 'currentUserHasSent'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+              dmProtocol: any(named: 'dmProtocol'),
+            ),
+          ).called(1);
         },
       );
 


### PR DESCRIPTION
## Description

Group DM sends now unwind any siblings already queued when a later sibling cannot be queued, before any publish starts. If an already-queued row cannot be deleted, its result keeps the queued rumor id so retry re-drives the surviving row instead of minting a fresh group send.

**Related Issue:** Closes #7448

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [ ] Build configuration change
- [ ] Documentation
- [ ] Chore