### PR TITLE
fix(share): render share-sheet contacts cache-first, hydrate in background

### DIFF
--- a/mobile/lib/blocs/share_sheet/share_sheet_bloc.dart
+++ b/mobile/lib/blocs/share_sheet/share_sheet_bloc.dart
@@ -79,22 +79,6 @@ class ShareSheetBloc extends Bloc<ShareSheetEvent, ShareSheetState> {
   final BaseCacheManager? _cacheManager;
   final VideoClipImportService? _videoClipImportService;
 
-  /// Whether two contact rows render identically, compared over the fields
-  /// the row actually shows. Used to skip a hydration re-emit that would
-  /// only rebuild the row for zero new information.
-  static bool _sameContacts(List<ShareableUser> a, List<ShareableUser> b) {
-    if (a.length != b.length) return false;
-    for (var i = 0; i < a.length; i++) {
-      if (a[i].pubkey != b[i].pubkey ||
-          a[i].displayName != b[i].displayName ||
-          a[i].handle != b[i].handle ||
-          a[i].picture != b[i].picture) {
-        return false;
-      }
-    }
-    return true;
-  }
-
   void _addUnexpectedError(
     Object error,
     StackTrace stackTrace,
@@ -154,26 +138,30 @@ class ShareSheetBloc extends Bloc<ShareSheetEvent, ShareSheetState> {
       );
 
       if (remainingFollows.isEmpty) return;
+      final cacheMisses = [
+        for (final pubkey in remainingFollows)
+          if (!cachedByPubkey.containsKey(pubkey)) pubkey,
+      ];
+      if (cacheMisses.isEmpty) return;
 
       // Hydrate the misses in the background and re-emit only when the row
       // would actually change. A failure here must not erase the cache-first
       // render already on screen.
       try {
         final profiles = await _profileRepository.fetchBatchProfiles(
-          pubkeys: remainingFollows,
+          pubkeys: cacheMisses,
         );
         if (isClosed) return;
 
-        final hydrated = buildContacts(profiles);
+        final hydrated = buildContacts({...cachedByPubkey, ...profiles});
         // A recipient picked via Find People mid-hydration was prepended to
-        // the row by the toggle handler; keep them visible through the swap.
+        // the row by the toggle handler; keep any still-visible extra contacts
+        // in their current order through the swap.
         final merged = [
-          for (final r in state.selectedRecipients)
-            if (!hydrated.any((c) => c.pubkey == r.pubkey)) r,
+          for (final contact in state.contacts)
+            if (!hydrated.any((c) => c.pubkey == contact.pubkey)) contact,
           ...hydrated,
         ];
-        if (_sameContacts(state.contacts, merged)) return;
-
         emit(
           state.copyWith(
             status: ShareSheetStatus.ready,

--- a/mobile/lib/blocs/share_sheet/share_sheet_bloc.dart
+++ b/mobile/lib/blocs/share_sheet/share_sheet_bloc.dart
@@ -108,11 +108,36 @@ class ShareSheetBloc extends Bloc<ShareSheetEvent, ShareSheetState> {
           .where((pk) => !recentPubkeys.contains(pk))
           .toList();
 
-      List<ShareableUser> buildContacts(Map<String, UserProfile> profiles) => [
+      ShareableUser? identifiedContact(
+        String pubkey,
+        UserProfile? profile,
+      ) {
+        final contact = ShareableUser.fromProfile(pubkey, profile);
+        return contact.hasVisibleIdentity ? contact : null;
+      }
+
+      List<ShareableUser> buildContacts(
+        Map<String, UserProfile> profiles, {
+        required bool includeMisses,
+      }) => [
         ...recentUsers,
         for (final pubkey in remainingFollows)
-          ShareableUser.fromProfile(pubkey, profiles[pubkey]),
+          if (identifiedContact(pubkey, profiles[pubkey]) case final contact?)
+            contact
+          else if (includeMisses)
+            ShareableUser.fromProfile(pubkey, null),
       ];
+
+      List<ShareableUser> mergeVisibleExtras(List<ShareableUser> base) {
+        final basePubkeys = {for (final contact in base) contact.pubkey};
+        return [
+          for (final contact in state.contacts)
+            if (contact.hasVisibleIdentity &&
+                !basePubkeys.contains(contact.pubkey))
+              contact,
+          ...base,
+        ];
+      }
 
       // Cache-first: one batched Drift read already covers what the visible
       // row needs, so the sheet renders now instead of shimmering through
@@ -127,12 +152,20 @@ class ShareSheetBloc extends Bloc<ShareSheetEvent, ShareSheetState> {
           : await _profileRepository.getCachedProfiles(
               pubkeys: remainingFollows,
             );
-      final cachedByPubkey = {for (final p in cached) p.pubkey: p};
+      final cachedByPubkey = {
+        for (final profile in cached)
+          if (identifiedContact(profile.pubkey, profile) != null)
+            profile.pubkey: profile,
+      };
+      final cacheFirstContacts = buildContacts(
+        cachedByPubkey,
+        includeMisses: true,
+      );
 
       emit(
         state.copyWith(
           status: ShareSheetStatus.ready,
-          contacts: buildContacts(cachedByPubkey),
+          contacts: mergeVisibleExtras(cacheFirstContacts),
           clearActionResult: true,
         ),
       );
@@ -153,15 +186,14 @@ class ShareSheetBloc extends Bloc<ShareSheetEvent, ShareSheetState> {
         );
         if (isClosed) return;
 
-        final hydrated = buildContacts({...cachedByPubkey, ...profiles});
+        final hydrated = buildContacts(
+          {...cachedByPubkey, ...profiles},
+          includeMisses: false,
+        );
         // A recipient picked via Find People mid-hydration was prepended to
         // the row by the toggle handler; keep any still-visible extra contacts
         // in their current order through the swap.
-        final merged = [
-          for (final contact in state.contacts)
-            if (!hydrated.any((c) => c.pubkey == contact.pubkey)) contact,
-          ...hydrated,
-        ];
+        final merged = mergeVisibleExtras(hydrated);
         emit(
           state.copyWith(
             status: ShareSheetStatus.ready,

--- a/mobile/lib/blocs/share_sheet/share_sheet_bloc.dart
+++ b/mobile/lib/blocs/share_sheet/share_sheet_bloc.dart
@@ -79,6 +79,22 @@ class ShareSheetBloc extends Bloc<ShareSheetEvent, ShareSheetState> {
   final BaseCacheManager? _cacheManager;
   final VideoClipImportService? _videoClipImportService;
 
+  /// Whether two contact rows render identically, compared over the fields
+  /// the row actually shows. Used to skip a hydration re-emit that would
+  /// only rebuild the row for zero new information.
+  static bool _sameContacts(List<ShareableUser> a, List<ShareableUser> b) {
+    if (a.length != b.length) return false;
+    for (var i = 0; i < a.length; i++) {
+      if (a[i].pubkey != b[i].pubkey ||
+          a[i].displayName != b[i].displayName ||
+          a[i].handle != b[i].handle ||
+          a[i].picture != b[i].picture) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   void _addUnexpectedError(
     Object error,
     StackTrace stackTrace,
@@ -108,34 +124,75 @@ class ShareSheetBloc extends Bloc<ShareSheetEvent, ShareSheetState> {
           .where((pk) => !recentPubkeys.contains(pk))
           .toList();
 
-      // One batched read (cache + bulk REST + relays, in the repository)
-      // instead of a per-pubkey DB/network storm fired on sheet open. The
-      // repository owns the source-selection strategy. Recents already carry
-      // their display data snapshotted at last-send time, so only the
-      // remaining follows need profiles. Staleness is session-bounded:
-      // VideoSharingService._recentlySharedWith is in-memory only and resets
-      // to empty on app restart, so a stale avatar or name is visible at most
-      // within the same session until the user shares with that contact again.
-      // Skip the call entirely when there are no follows to fetch. See #5391.
-      final profiles = remainingFollows.isEmpty
-          ? const <String, UserProfile>{}
-          : await _profileRepository.fetchBatchProfiles(
-              pubkeys: remainingFollows,
-            );
-
-      final contacts = <ShareableUser>[
+      List<ShareableUser> buildContacts(Map<String, UserProfile> profiles) => [
         ...recentUsers,
         for (final pubkey in remainingFollows)
           ShareableUser.fromProfile(pubkey, profiles[pubkey]),
       ];
 
+      // Cache-first: one batched Drift read already covers what the visible
+      // row needs, so the sheet renders now instead of shimmering through
+      // the network batch. Recents already carry their display data
+      // snapshotted at last-send time. Staleness is session-bounded:
+      // VideoSharingService._recentlySharedWith is in-memory only and resets
+      // to empty on app restart, so a stale avatar or name is visible at most
+      // within the same session until the user shares with that contact
+      // again. See #5391.
+      final cached = remainingFollows.isEmpty
+          ? const <UserProfile>[]
+          : await _profileRepository.getCachedProfiles(
+              pubkeys: remainingFollows,
+            );
+      final cachedByPubkey = {for (final p in cached) p.pubkey: p};
+
       emit(
         state.copyWith(
           status: ShareSheetStatus.ready,
-          contacts: contacts,
+          contacts: buildContacts(cachedByPubkey),
           clearActionResult: true,
         ),
       );
+
+      if (remainingFollows.isEmpty) return;
+
+      // Hydrate the misses in the background and re-emit only when the row
+      // would actually change. A failure here must not erase the cache-first
+      // render already on screen.
+      try {
+        final profiles = await _profileRepository.fetchBatchProfiles(
+          pubkeys: remainingFollows,
+        );
+        if (isClosed) return;
+
+        final hydrated = buildContacts(profiles);
+        // A recipient picked via Find People mid-hydration was prepended to
+        // the row by the toggle handler; keep them visible through the swap.
+        final merged = [
+          for (final r in state.selectedRecipients)
+            if (!hydrated.any((c) => c.pubkey == r.pubkey)) r,
+          ...hydrated,
+        ];
+        if (_sameContacts(state.contacts, merged)) return;
+
+        emit(
+          state.copyWith(
+            status: ShareSheetStatus.ready,
+            contacts: merged,
+            clearActionResult: true,
+          ),
+        );
+      } catch (e, stackTrace) {
+        _addUnexpectedError(
+          e,
+          stackTrace,
+          ShareSheetBlocReportableSites.onContactsLoadRequested,
+        );
+        Log.warning(
+          'Background contact hydration failed: $e',
+          name: 'ShareSheetBloc',
+          category: LogCategory.ui,
+        );
+      }
     } catch (e, stackTrace) {
       _addUnexpectedError(
         e,

--- a/mobile/lib/services/video_sharing_service.dart
+++ b/mobile/lib/services/video_sharing_service.dart
@@ -83,6 +83,10 @@ class ShareableUser {
   final String? handle;
   final String? picture;
 
+  /// Whether the share row has enough user-visible data for a recipient tile.
+  bool get hasVisibleIdentity =>
+      displayName != null || handle != null || picture != null;
+
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||

--- a/mobile/lib/services/video_sharing_service.dart
+++ b/mobile/lib/services/video_sharing_service.dart
@@ -4,6 +4,7 @@
 import 'dart:async';
 
 import 'package:dm_repository/dm_repository.dart';
+import 'package:meta/meta.dart';
 import 'package:models/models.dart' hide LogCategory;
 import 'package:nostr_client/nostr_client.dart';
 // `auth_service` exports an unrelated `UserProfile`; hide it so the models
@@ -14,6 +15,7 @@ import 'package:unified_logger/unified_logger.dart';
 
 /// Represents a user that can receive shared videos
 /// REFACTORED: Removed ChangeNotifier - now uses pure state management via Riverpod
+@immutable
 class ShareableUser {
   const ShareableUser({
     required this.pubkey,
@@ -80,6 +82,19 @@ class ShareableUser {
   /// secondary line at all rather than falling back to an npub.
   final String? handle;
   final String? picture;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ShareableUser &&
+          runtimeType == other.runtimeType &&
+          pubkey == other.pubkey &&
+          displayName == other.displayName &&
+          handle == other.handle &&
+          picture == other.picture;
+
+  @override
+  int get hashCode => Object.hash(pubkey, displayName, handle, picture);
 }
 
 /// Structured share metadata for the platform share sheet.

--- a/mobile/lib/widgets/video_feed_item/actions/share_with_section.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/share_with_section.dart
@@ -7,6 +7,10 @@ final List<ShareableUser> _skeletonContacts = List.generate(
   6,
   (_) => const ShareableUser(pubkey: '', displayName: 'Username'),
 );
+const ShareableUser _skeletonContact = ShareableUser(
+  pubkey: '',
+  displayName: 'Username',
+);
 
 // ---------------------------------------------------------------------------
 // "Share with" horizontal contact row
@@ -78,13 +82,20 @@ class _ShareWithSection extends StatelessWidget {
                     }
 
                     final contact = displayContacts[index - 1];
-                    if (!contactsLoaded) {
+                    final isPendingIdentity =
+                        !contactsLoaded || !contact.hasVisibleIdentity;
+                    if (isPendingIdentity) {
                       // Placeholder bone — not interactive, excluded from a11y.
-                      return ExcludeSemantics(
-                        child: _ContactItem(
-                          user: contact,
-                          isSelected: false,
-                          onTap: () {},
+                      return IgnorePointer(
+                        child: ExcludeSemantics(
+                          child: IdentitySkeletonizer(
+                            isLoading: true,
+                            child: _ContactItem(
+                              user: _skeletonContact,
+                              isSelected: false,
+                              onTap: () {},
+                            ),
+                          ),
                         ),
                       );
                     }

--- a/mobile/packages/profile_repository/lib/src/profile_reader.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_reader.dart
@@ -39,6 +39,17 @@ abstract interface class ProfileReader {
   /// Returns `null` if no cached profile exists for the given pubkey.
   Future<UserProfile?> getCachedProfile({required String pubkey});
 
+  /// Returns the cached profiles for [pubkeys] in a single Drift query.
+  ///
+  /// The batch counterpart to [getCachedProfile]: same local-storage-only
+  /// semantics — one `WHERE pubkey IN (...)` read, no relay, no REST — so it
+  /// satisfies the signer-free, relay-optional invariant this interface
+  /// guards. Pubkeys without a cached profile are absent from the result,
+  /// which is not order-aligned with [pubkeys].
+  Future<List<UserProfile>> getCachedProfiles({
+    required List<String> pubkeys,
+  });
+
   /// Watches the cached profile for [pubkey], emitting on every cache write.
   Stream<UserProfile?> watchProfile({required String pubkey});
 

--- a/mobile/packages/profile_repository/lib/src/profile_reader.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_reader.dart
@@ -44,8 +44,9 @@ abstract interface class ProfileReader {
   /// The batch counterpart to [getCachedProfile]: same local-storage-only
   /// semantics — one `WHERE pubkey IN (...)` read, no relay, no REST — so it
   /// satisfies the signer-free, relay-optional invariant this interface
-  /// guards. Pubkeys without a cached profile are absent from the result,
-  /// which is not order-aligned with [pubkeys].
+  /// guards. Pubkeys without a cached profile, or profiles filtered by the
+  /// repository's block policy, are absent from the result, which is not
+  /// order-aligned with [pubkeys].
   Future<List<UserProfile>> getCachedProfiles({
     required List<String> pubkeys,
   });

--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -390,9 +390,9 @@ class ProfileRepository implements ProfileReader {
   /// pubkey. Callers resolving a whole list (follow lists, pickers) should use
   /// this — the per-pubkey variant costs a Drift round trip each.
   ///
-  /// Pubkeys without a cached profile are absent from the result, so the
-  /// returned list may be shorter than [pubkeys] and is not order-aligned
-  /// with it.
+  /// Pubkeys without a cached profile, or profiles filtered by this
+  /// repository's block policy, are absent from the result. The returned list
+  /// may be shorter than [pubkeys] and is not order-aligned with it.
   @override
   Future<List<UserProfile>> getCachedProfiles({
     required List<String> pubkeys,
@@ -2378,6 +2378,14 @@ class ProfileRepository implements ProfileReader {
     final results = <String, UserProfile>{};
     final remaining = Set<String>.of(pubkeys);
 
+    Map<String, UserProfile> filteredResults() {
+      final blockFilter = _blockFilter;
+      if (blockFilter != null) {
+        results.removeWhere((pubkey, _) => blockFilter(pubkey));
+      }
+      return results;
+    }
+
     // Step 1: Batch-read Drift cache
     final cached = await _userProfilesDao.getProfilesByPubkeys(pubkeys);
     for (final profile in cached) {
@@ -2392,7 +2400,7 @@ class ProfileRepository implements ProfileReader {
       revalidateVanishOnce(pubkey);
       return true;
     });
-    if (remaining.isEmpty) return results;
+    if (remaining.isEmpty) return filteredResults();
 
     Log.debug(
       'Batch fetch: ${cached.length} cached, ${remaining.length} uncached',
@@ -2539,10 +2547,7 @@ class ProfileRepository implements ProfileReader {
       _confirmedMissing.addAll(remaining);
     }
 
-    final blockFilter = _blockFilter;
-    if (blockFilter != null) {
-      results.removeWhere((pubkey, _) => blockFilter(pubkey));
-    }
+    filteredResults();
 
     Log.debug(
       'Batch complete: ${results.length}/${pubkeys.length} resolved, '

--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -398,7 +398,10 @@ class ProfileRepository implements ProfileReader {
     required List<String> pubkeys,
   }) async {
     if (pubkeys.isEmpty) return const [];
-    return _userProfilesDao.getProfilesByPubkeys(pubkeys);
+    final profiles = await _userProfilesDao.getProfilesByPubkeys(pubkeys);
+    final blockFilter = _blockFilter;
+    if (blockFilter == null) return profiles;
+    return profiles.where((p) => !blockFilter(p.pubkey)).toList();
   }
 
   /// Persists a profile to local storage (SQLite).

--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -393,6 +393,7 @@ class ProfileRepository implements ProfileReader {
   /// Pubkeys without a cached profile are absent from the result, so the
   /// returned list may be shorter than [pubkeys] and is not order-aligned
   /// with it.
+  @override
   Future<List<UserProfile>> getCachedProfiles({
     required List<String> pubkeys,
   }) async {

--- a/mobile/packages/profile_repository/test/src/profile_reader_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_reader_test.dart
@@ -31,6 +31,13 @@ class _ExhaustiveReader implements ProfileReader {
   @override
   Future<UserProfile?> getCachedProfile({required String pubkey}) async => null;
 
+  // Widened consciously: this is a batch Drift read — signer-free and
+  // relay-optional, the same invariant as getCachedProfile.
+  @override
+  Future<List<UserProfile>> getCachedProfiles({
+    required List<String> pubkeys,
+  }) async => const [];
+
   @override
   Stream<UserProfile?> watchProfile({required String pubkey}) =>
       const Stream.empty();
@@ -97,6 +104,26 @@ void main() {
 
       expect(await reader.getCachedProfile(pubkey: _pubkey), cached);
     });
+
+    test(
+      'reads the Drift cache in batch through the interface handle',
+      () async {
+        final cached = UserProfile(
+          pubkey: _pubkey,
+          name: 'real-name',
+          rawData: const {},
+          createdAt: DateTime.utc(2026),
+          eventId: 'event-id',
+        );
+        when(
+          () => userProfilesDao.getProfilesByPubkeys([_pubkey]),
+        ).thenAnswer((_) async => [cached]);
+
+        final ProfileReader reader = repository;
+
+        expect(await reader.getCachedProfiles(pubkeys: [_pubkey]), [cached]);
+      },
+    );
 
     test('an implementation needs no signer and no relay client', () {
       // _ExhaustiveReader satisfies the contract with neither. If this stops

--- a/mobile/packages/profile_repository/test/src/profile_reader_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_reader_test.dart
@@ -125,6 +125,29 @@ void main() {
       },
     );
 
+    test('filters blocked profiles from batch cache reads', () async {
+      final blocked = UserProfile(
+        pubkey: _pubkey,
+        name: 'blocked-name',
+        rawData: const {},
+        createdAt: DateTime.utc(2026),
+        eventId: 'event-id',
+      );
+      when(
+        () => userProfilesDao.getProfilesByPubkeys([_pubkey]),
+      ).thenAnswer((_) async => [blocked]);
+      repository = ProfileRepository(
+        nostrClient: _MockNostrClient(),
+        userProfilesDao: userProfilesDao,
+        httpClient: _MockHttpClient(),
+        blockFilter: (pubkey) => pubkey == _pubkey,
+      );
+
+      final ProfileReader reader = repository;
+
+      expect(await reader.getCachedProfiles(pubkeys: [_pubkey]), isEmpty);
+    });
+
     test('an implementation needs no signer and no relay client', () {
       // _ExhaustiveReader satisfies the contract with neither. If this stops
       // compiling, a signing member reached the interface.

--- a/mobile/packages/profile_repository/test/src/profile_repository_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_test.dart
@@ -6551,6 +6551,44 @@ void main() {
         verifyNever(() => mockNostrClient.fetchProfile(any()));
       });
 
+      test('filters blocked profiles when all results are cached', () async {
+        final blocked = UserProfile(
+          pubkey: testPubkey,
+          displayName: 'Blocked Cached',
+          rawData: const {},
+          createdAt: DateTime(2026),
+          eventId: 'blocked-cached-event',
+        );
+        final allowed = UserProfile(
+          pubkey: testPubkey2,
+          displayName: 'Allowed Cached',
+          rawData: const {},
+          createdAt: DateTime(2026),
+          eventId: 'allowed-cached-event',
+        );
+        when(
+          () => mockUserProfilesDao.getProfilesByPubkeys([
+            testPubkey,
+            testPubkey2,
+          ]),
+        ).thenAnswer((_) async => [blocked, allowed]);
+
+        final repoWithBlockFilter = ProfileRepository(
+          nostrClient: mockNostrClient,
+          userProfilesDao: mockUserProfilesDao,
+          httpClient: mockHttpClient,
+          blockFilter: (pubkey) => pubkey == testPubkey,
+        );
+
+        final result = await repoWithBlockFilter.fetchBatchProfiles(
+          pubkeys: [testPubkey, testPubkey2],
+        );
+
+        expect(result.containsKey(testPubkey), isFalse);
+        expect(result[testPubkey2]?.displayName, equals('Allowed Cached'));
+        verifyNever(() => mockNostrClient.fetchProfile(any()));
+      });
+
       test('fetches uncached from Funnelcake API', () async {
         when(
           () => mockUserProfilesDao.getProfilesByPubkeys(any()),

--- a/mobile/test/blocs/share_sheet/share_sheet_bloc_test.dart
+++ b/mobile/test/blocs/share_sheet/share_sheet_bloc_test.dart
@@ -123,6 +123,11 @@ void main() {
           pubkeys: any(named: 'pubkeys'),
         ),
       ).thenAnswer((_) async => <String, UserProfile>{});
+      when(
+        () => mockProfileRepository.getCachedProfiles(
+          pubkeys: any(named: 'pubkeys'),
+        ),
+      ).thenAnswer((_) async => <UserProfile>[]);
     });
 
     ShareSheetBloc createBloc({
@@ -236,6 +241,220 @@ void main() {
       );
 
       blocTest<ShareSheetBloc, ShareSheetState>(
+        'renders cached profiles immediately, then re-emits after hydration',
+        setUp: () {
+          when(() => mockSharingService.recentlySharedWith).thenReturn([]);
+          when(() => mockFollowRepository.followingPubkeys).thenReturn([
+            profiledFollow,
+            unprofiledFollow,
+          ]);
+          when(
+            () => mockProfileRepository.getCachedProfiles(
+              pubkeys: any(named: 'pubkeys'),
+            ),
+          ).thenAnswer(
+            (_) async => [
+              UserProfile(
+                pubkey: profiledFollow,
+                createdAt: DateTime.now(),
+                eventId: 'event-$profiledFollow',
+                rawData: const {},
+                name: 'CachedAlice',
+              ),
+            ],
+          );
+          when(
+            () => mockProfileRepository.fetchBatchProfiles(
+              pubkeys: any(named: 'pubkeys'),
+            ),
+          ).thenAnswer(
+            (_) async => {
+              profiledFollow: UserProfile(
+                pubkey: profiledFollow,
+                createdAt: DateTime.now(),
+                eventId: 'event-$profiledFollow',
+                rawData: const {},
+                name: 'HydratedAlice',
+              ),
+              unprofiledFollow: UserProfile(
+                pubkey: unprofiledFollow,
+                createdAt: DateTime.now(),
+                eventId: 'event-$unprofiledFollow',
+                rawData: const {},
+                name: 'HydratedBob',
+              ),
+            },
+          );
+        },
+        build: createBloc,
+        act: (bloc) => bloc.add(const ShareSheetContactsLoadRequested()),
+        expect: () => [
+          const ShareSheetState(status: ShareSheetStatus.loading),
+          // Cache-first render: the Drift-cached name shows now; the uncached
+          // follow is present but nameless rather than blocking the row.
+          isA<ShareSheetState>()
+              .having((s) => s.status, 'status', ShareSheetStatus.ready)
+              .having((s) => s.contacts.length, 'contacts.length', 2)
+              .having(
+                (s) => s.contacts[0].displayName,
+                'first contact name',
+                'CachedAlice',
+              )
+              .having(
+                (s) => s.contacts[1].displayName,
+                'second contact name',
+                isNull,
+              ),
+          // Hydration re-emit: misses filled in from the network batch.
+          isA<ShareSheetState>()
+              .having((s) => s.status, 'status', ShareSheetStatus.ready)
+              .having(
+                (s) => s.contacts[0].displayName,
+                'first contact name',
+                'HydratedAlice',
+              )
+              .having(
+                (s) => s.contacts[1].displayName,
+                'second contact name',
+                'HydratedBob',
+              ),
+        ],
+        verify: (_) {
+          verify(
+            () => mockProfileRepository.getCachedProfiles(
+              pubkeys: [profiledFollow, unprofiledFollow],
+            ),
+          ).called(1);
+          verify(
+            () => mockProfileRepository.fetchBatchProfiles(
+              pubkeys: [profiledFollow, unprofiledFollow],
+            ),
+          ).called(1);
+        },
+      );
+
+      late Completer<Map<String, UserProfile>> hydration;
+
+      blocTest<ShareSheetBloc, ShareSheetState>(
+        'preserves a find-people-added recipient through the hydration re-emit',
+        setUp: () {
+          hydration = Completer<Map<String, UserProfile>>();
+          when(() => mockSharingService.recentlySharedWith).thenReturn([]);
+          when(() => mockFollowRepository.followingPubkeys).thenReturn([
+            profiledFollow,
+          ]);
+          when(
+            () => mockProfileRepository.getCachedProfiles(
+              pubkeys: any(named: 'pubkeys'),
+            ),
+          ).thenAnswer((_) async => <UserProfile>[]);
+          when(
+            () => mockProfileRepository.fetchBatchProfiles(
+              pubkeys: any(named: 'pubkeys'),
+            ),
+          ).thenAnswer((_) => hydration.future);
+        },
+        build: createBloc,
+        act: (bloc) async {
+          bloc.add(const ShareSheetContactsLoadRequested());
+          await pumpEventQueue();
+          bloc.add(
+            const ShareSheetRecipientToggled(
+              ShareableUser(
+                pubkey:
+                    'zzzz56789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+                displayName: 'Picked Stranger',
+              ),
+            ),
+          );
+          await pumpEventQueue();
+          hydration.complete({
+            profiledFollow: UserProfile(
+              pubkey: profiledFollow,
+              createdAt: DateTime.now(),
+              eventId: 'event-$profiledFollow',
+              rawData: const {},
+              name: 'HydratedAlice',
+            ),
+          });
+        },
+        expect: () => [
+          const ShareSheetState(status: ShareSheetStatus.loading),
+          isA<ShareSheetState>().having(
+            (s) => s.status,
+            'status',
+            ShareSheetStatus.ready,
+          ),
+          // The toggle prepends the picked stranger.
+          isA<ShareSheetState>()
+              .having(
+                (s) => s.contacts.first.displayName,
+                'picked first',
+                'Picked Stranger',
+              )
+              .having((s) => s.selectedRecipients.length, 'selected', 1),
+          // Hydration re-emit must not drop them from the row or the selection.
+          isA<ShareSheetState>()
+              .having(
+                (s) => s.contacts.first.displayName,
+                'picked still first',
+                'Picked Stranger',
+              )
+              .having((s) => s.selectedRecipients.length, 'selected', 1)
+              .having(
+                (s) => s.contacts.map((c) => c.displayName).toList(),
+                'row contents',
+                ['Picked Stranger', 'HydratedAlice'],
+              ),
+        ],
+      );
+
+      blocTest<ShareSheetBloc, ShareSheetState>(
+        'keeps the cache-first render when background hydration fails',
+        setUp: () {
+          when(() => mockSharingService.recentlySharedWith).thenReturn([]);
+          when(() => mockFollowRepository.followingPubkeys).thenReturn([
+            profiledFollow,
+          ]);
+          when(
+            () => mockProfileRepository.getCachedProfiles(
+              pubkeys: any(named: 'pubkeys'),
+            ),
+          ).thenAnswer(
+            (_) async => [
+              UserProfile(
+                pubkey: profiledFollow,
+                createdAt: DateTime.now(),
+                eventId: 'event-$profiledFollow',
+                rawData: const {},
+                name: 'CachedAlice',
+              ),
+            ],
+          );
+          when(
+            () => mockProfileRepository.fetchBatchProfiles(
+              pubkeys: any(named: 'pubkeys'),
+            ),
+          ).thenThrow(Exception('relay storm down'));
+        },
+        build: createBloc,
+        act: (bloc) => bloc.add(const ShareSheetContactsLoadRequested()),
+        errors: () => [isA<Exception>()],
+        expect: () => [
+          const ShareSheetState(status: ShareSheetStatus.loading),
+          // The failure must not erase what was already on screen.
+          isA<ShareSheetState>()
+              .having((s) => s.status, 'status', ShareSheetStatus.ready)
+              .having((s) => s.contacts.length, 'contacts.length', 1)
+              .having(
+                (s) => s.contacts[0].displayName,
+                'first contact name',
+                'CachedAlice',
+              ),
+        ],
+      );
+
+      blocTest<ShareSheetBloc, ShareSheetState>(
         'loads follow profiles via one fetchBatchProfiles call, no per-pubkey '
         'storm',
         setUp: () {
@@ -253,7 +472,8 @@ void main() {
                 pubkey: profiledFollow,
                 createdAt: DateTime.now(),
                 eventId: 'event-$profiledFollow',
-                rawData: const {'name': 'Bob'},
+                rawData: const {},
+                name: 'Bob',
               ),
             },
           );
@@ -265,6 +485,15 @@ void main() {
           isA<ShareSheetState>()
               .having((s) => s.status, 'status', ShareSheetStatus.ready)
               .having((s) => s.contacts.length, 'contacts.length', 2),
+          // The hydration re-emit lands when it changes what is on screen.
+          isA<ShareSheetState>()
+              .having((s) => s.status, 'status', ShareSheetStatus.ready)
+              .having((s) => s.contacts.length, 'contacts.length', 2)
+              .having(
+                (s) => s.contacts[0].displayName,
+                'hydrated name',
+                'Bob',
+              ),
         ],
         verify: (_) {
           // Exactly one batched read covering both follows, in order — the

--- a/mobile/test/blocs/share_sheet/share_sheet_bloc_test.dart
+++ b/mobile/test/blocs/share_sheet/share_sheet_bloc_test.dart
@@ -204,6 +204,14 @@ void main() {
                 'first contact pubkey',
                 testRecipient.pubkey,
               ),
+          isA<ShareSheetState>()
+              .having((s) => s.status, 'status', ShareSheetStatus.ready)
+              .having((s) => s.contacts.length, 'contacts.length', 1)
+              .having(
+                (s) => s.contacts.first.pubkey,
+                'first contact pubkey',
+                testRecipient.pubkey,
+              ),
         ],
       );
 
@@ -268,13 +276,6 @@ void main() {
             ),
           ).thenAnswer(
             (_) async => {
-              profiledFollow: UserProfile(
-                pubkey: profiledFollow,
-                createdAt: DateTime.now(),
-                eventId: 'event-$profiledFollow',
-                rawData: const {},
-                name: 'HydratedAlice',
-              ),
               unprofiledFollow: UserProfile(
                 pubkey: unprofiledFollow,
                 createdAt: DateTime.now(),
@@ -290,7 +291,8 @@ void main() {
         expect: () => [
           const ShareSheetState(status: ShareSheetStatus.loading),
           // Cache-first render: the Drift-cached name shows now; the uncached
-          // follow is present but nameless rather than blocking the row.
+          // follow is present as a pending, non-interactive skeleton row rather
+          // than blocking the whole row.
           isA<ShareSheetState>()
               .having((s) => s.status, 'status', ShareSheetStatus.ready)
               .having((s) => s.contacts.length, 'contacts.length', 2)
@@ -310,7 +312,7 @@ void main() {
               .having(
                 (s) => s.contacts[0].displayName,
                 'first contact name',
-                'HydratedAlice',
+                'CachedAlice',
               )
               .having(
                 (s) => s.contacts[1].displayName,
@@ -332,7 +334,73 @@ void main() {
         },
       );
 
+      late Completer<List<UserProfile>> cacheRead;
       late Completer<Map<String, UserProfile>> hydration;
+
+      blocTest<ShareSheetBloc, ShareSheetState>(
+        'preserves a find-people recipient picked during the cache read',
+        setUp: () {
+          cacheRead = Completer<List<UserProfile>>();
+          when(() => mockSharingService.recentlySharedWith).thenReturn([]);
+          when(
+            () => mockFollowRepository.followingPubkeys,
+          ).thenReturn([profiledFollow]);
+          when(
+            () => mockProfileRepository.getCachedProfiles(
+              pubkeys: any(named: 'pubkeys'),
+            ),
+          ).thenAnswer((_) => cacheRead.future);
+          when(
+            () => mockProfileRepository.fetchBatchProfiles(
+              pubkeys: any(named: 'pubkeys'),
+            ),
+          ).thenAnswer((_) async => <String, UserProfile>{});
+        },
+        build: createBloc,
+        act: (bloc) async {
+          bloc.add(const ShareSheetContactsLoadRequested());
+          await pumpEventQueue();
+          bloc.add(
+            const ShareSheetRecipientToggled(
+              ShareableUser(
+                pubkey:
+                    'zzzz56789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+                displayName: 'Picked Stranger',
+              ),
+            ),
+          );
+          await pumpEventQueue();
+          cacheRead.complete([
+            UserProfile(
+              pubkey: profiledFollow,
+              createdAt: DateTime.now(),
+              eventId: 'event-$profiledFollow',
+              rawData: const {},
+              name: 'CachedAlice',
+            ),
+          ]);
+          await pumpEventQueue();
+        },
+        expect: () => [
+          const ShareSheetState(status: ShareSheetStatus.loading),
+          isA<ShareSheetState>()
+              .having((s) => s.status, 'status', ShareSheetStatus.loading)
+              .having(
+                (s) => s.contacts.first.displayName,
+                'picked first while loading',
+                'Picked Stranger',
+              )
+              .having((s) => s.selectedRecipients.length, 'selected', 1),
+          isA<ShareSheetState>()
+              .having((s) => s.status, 'status', ShareSheetStatus.ready)
+              .having(
+                (s) => s.contacts.map((c) => c.displayName).toList(),
+                'row contents',
+                ['Picked Stranger', 'CachedAlice'],
+              )
+              .having((s) => s.selectedRecipients.length, 'selected', 1),
+        ],
+      );
 
       blocTest<ShareSheetBloc, ShareSheetState>(
         'preserves a find-people-added recipient through the hydration re-emit',
@@ -604,7 +672,7 @@ void main() {
       );
 
       blocTest<ShareSheetBloc, ShareSheetState>(
-        'does not re-emit when hydration leaves rendered contacts unchanged',
+        'drops unresolved cache misses after hydration returns no profile',
         setUp: () {
           when(() => mockSharingService.recentlySharedWith).thenReturn([]);
           when(
@@ -633,6 +701,9 @@ void main() {
                 'contact name',
                 isNull,
               ),
+          isA<ShareSheetState>()
+              .having((s) => s.status, 'status', ShareSheetStatus.ready)
+              .having((s) => s.contacts, 'contacts', isEmpty),
         ],
         verify: (_) {
           verify(
@@ -677,7 +748,7 @@ void main() {
           // The hydration re-emit lands when it changes what is on screen.
           isA<ShareSheetState>()
               .having((s) => s.status, 'status', ShareSheetStatus.ready)
-              .having((s) => s.contacts.length, 'contacts.length', 2)
+              .having((s) => s.contacts.length, 'contacts.length', 1)
               .having((s) => s.contacts[0].displayName, 'hydrated name', 'Bob'),
         ],
         verify: (_) {
@@ -729,6 +800,20 @@ void main() {
           isA<ShareSheetState>()
               .having((s) => s.status, 'status', ShareSheetStatus.ready)
               .having((s) => s.contacts.length, 'contacts.length', 2)
+              .having(
+                (s) => s.contacts.first.displayName,
+                'first is from recents',
+                'Alice (recent)',
+              )
+              .having(
+                (s) =>
+                    s.contacts.where((c) => c.pubkey == duplicatePubkey).length,
+                'no duplicate pubkey',
+                1,
+              ),
+          isA<ShareSheetState>()
+              .having((s) => s.status, 'status', ShareSheetStatus.ready)
+              .having((s) => s.contacts.length, 'contacts.length', 1)
               .having(
                 (s) => s.contacts.first.displayName,
                 'first is from recents',

--- a/mobile/test/blocs/share_sheet/share_sheet_bloc_test.dart
+++ b/mobile/test/blocs/share_sheet/share_sheet_bloc_test.dart
@@ -244,10 +244,9 @@ void main() {
         'renders cached profiles immediately, then re-emits after hydration',
         setUp: () {
           when(() => mockSharingService.recentlySharedWith).thenReturn([]);
-          when(() => mockFollowRepository.followingPubkeys).thenReturn([
-            profiledFollow,
-            unprofiledFollow,
-          ]);
+          when(
+            () => mockFollowRepository.followingPubkeys,
+          ).thenReturn([profiledFollow, unprofiledFollow]);
           when(
             () => mockProfileRepository.getCachedProfiles(
               pubkeys: any(named: 'pubkeys'),
@@ -327,7 +326,7 @@ void main() {
           ).called(1);
           verify(
             () => mockProfileRepository.fetchBatchProfiles(
-              pubkeys: [profiledFollow, unprofiledFollow],
+              pubkeys: [unprofiledFollow],
             ),
           ).called(1);
         },
@@ -340,9 +339,9 @@ void main() {
         setUp: () {
           hydration = Completer<Map<String, UserProfile>>();
           when(() => mockSharingService.recentlySharedWith).thenReturn([]);
-          when(() => mockFollowRepository.followingPubkeys).thenReturn([
-            profiledFollow,
-          ]);
+          when(
+            () => mockFollowRepository.followingPubkeys,
+          ).thenReturn([profiledFollow]);
           when(
             () => mockProfileRepository.getCachedProfiles(
               pubkeys: any(named: 'pubkeys'),
@@ -410,12 +409,157 @@ void main() {
       );
 
       blocTest<ShareSheetBloc, ShareSheetState>(
+        'keeps a deselected find-people recipient visible through hydration',
+        setUp: () {
+          hydration = Completer<Map<String, UserProfile>>();
+          when(() => mockSharingService.recentlySharedWith).thenReturn([]);
+          when(
+            () => mockFollowRepository.followingPubkeys,
+          ).thenReturn([profiledFollow]);
+          when(
+            () => mockProfileRepository.getCachedProfiles(
+              pubkeys: any(named: 'pubkeys'),
+            ),
+          ).thenAnswer((_) async => <UserProfile>[]);
+          when(
+            () => mockProfileRepository.fetchBatchProfiles(
+              pubkeys: any(named: 'pubkeys'),
+            ),
+          ).thenAnswer((_) => hydration.future);
+        },
+        build: createBloc,
+        act: (bloc) async {
+          const picked = ShareableUser(
+            pubkey:
+                'zzzz56789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+            displayName: 'Picked Stranger',
+          );
+          bloc.add(const ShareSheetContactsLoadRequested());
+          await pumpEventQueue();
+          bloc.add(const ShareSheetRecipientToggled(picked));
+          await pumpEventQueue();
+          bloc.add(const ShareSheetRecipientToggled(picked));
+          await pumpEventQueue();
+          hydration.complete({
+            profiledFollow: UserProfile(
+              pubkey: profiledFollow,
+              createdAt: DateTime.now(),
+              eventId: 'event-$profiledFollow',
+              rawData: const {},
+              name: 'HydratedAlice',
+            ),
+          });
+        },
+        expect: () => [
+          const ShareSheetState(status: ShareSheetStatus.loading),
+          isA<ShareSheetState>().having(
+            (s) => s.status,
+            'status',
+            ShareSheetStatus.ready,
+          ),
+          isA<ShareSheetState>()
+              .having(
+                (s) => s.contacts.first.displayName,
+                'picked first',
+                'Picked Stranger',
+              )
+              .having((s) => s.selectedRecipients.length, 'selected', 1),
+          isA<ShareSheetState>()
+              .having(
+                (s) => s.contacts.first.displayName,
+                'picked remains visible',
+                'Picked Stranger',
+              )
+              .having((s) => s.selectedRecipients, 'selected', isEmpty),
+          isA<ShareSheetState>()
+              .having((s) => s.selectedRecipients, 'selected', isEmpty)
+              .having(
+                (s) => s.contacts.map((c) => c.displayName).toList(),
+                'row contents',
+                ['Picked Stranger', 'HydratedAlice'],
+              ),
+        ],
+      );
+
+      blocTest<ShareSheetBloc, ShareSheetState>(
+        'preserves find-people row order through hydration',
+        setUp: () {
+          hydration = Completer<Map<String, UserProfile>>();
+          when(() => mockSharingService.recentlySharedWith).thenReturn([]);
+          when(
+            () => mockFollowRepository.followingPubkeys,
+          ).thenReturn([profiledFollow]);
+          when(
+            () => mockProfileRepository.getCachedProfiles(
+              pubkeys: any(named: 'pubkeys'),
+            ),
+          ).thenAnswer((_) async => <UserProfile>[]);
+          when(
+            () => mockProfileRepository.fetchBatchProfiles(
+              pubkeys: any(named: 'pubkeys'),
+            ),
+          ).thenAnswer((_) => hydration.future);
+        },
+        build: createBloc,
+        act: (bloc) async {
+          const firstPicked = ShareableUser(
+            pubkey:
+                'yyyy56789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+            displayName: 'Picked First',
+          );
+          const secondPicked = ShareableUser(
+            pubkey:
+                'zzzz56789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+            displayName: 'Picked Second',
+          );
+          bloc.add(const ShareSheetContactsLoadRequested());
+          await pumpEventQueue();
+          bloc.add(const ShareSheetRecipientToggled(firstPicked));
+          await pumpEventQueue();
+          bloc.add(const ShareSheetRecipientToggled(secondPicked));
+          await pumpEventQueue();
+          hydration.complete({
+            profiledFollow: UserProfile(
+              pubkey: profiledFollow,
+              createdAt: DateTime.now(),
+              eventId: 'event-$profiledFollow',
+              rawData: const {},
+              name: 'HydratedAlice',
+            ),
+          });
+        },
+        expect: () => [
+          const ShareSheetState(status: ShareSheetStatus.loading),
+          isA<ShareSheetState>().having(
+            (s) => s.status,
+            'status',
+            ShareSheetStatus.ready,
+          ),
+          isA<ShareSheetState>().having(
+            (s) => s.contacts.map((c) => c.displayName).toList(),
+            'row contents',
+            ['Picked First', null],
+          ),
+          isA<ShareSheetState>().having(
+            (s) => s.contacts.map((c) => c.displayName).toList(),
+            'row contents',
+            ['Picked Second', 'Picked First', null],
+          ),
+          isA<ShareSheetState>().having(
+            (s) => s.contacts.map((c) => c.displayName).toList(),
+            'row contents',
+            ['Picked Second', 'Picked First', 'HydratedAlice'],
+          ),
+        ],
+      );
+
+      blocTest<ShareSheetBloc, ShareSheetState>(
         'keeps the cache-first render when background hydration fails',
         setUp: () {
           when(() => mockSharingService.recentlySharedWith).thenReturn([]);
-          when(() => mockFollowRepository.followingPubkeys).thenReturn([
-            profiledFollow,
-          ]);
+          when(
+            () => mockFollowRepository.followingPubkeys,
+          ).thenReturn([profiledFollow, unprofiledFollow]);
           when(
             () => mockProfileRepository.getCachedProfiles(
               pubkeys: any(named: 'pubkeys'),
@@ -445,13 +589,58 @@ void main() {
           // The failure must not erase what was already on screen.
           isA<ShareSheetState>()
               .having((s) => s.status, 'status', ShareSheetStatus.ready)
-              .having((s) => s.contacts.length, 'contacts.length', 1)
+              .having((s) => s.contacts.length, 'contacts.length', 2)
               .having(
                 (s) => s.contacts[0].displayName,
                 'first contact name',
                 'CachedAlice',
+              )
+              .having(
+                (s) => s.contacts[1].displayName,
+                'second contact name',
+                isNull,
               ),
         ],
+      );
+
+      blocTest<ShareSheetBloc, ShareSheetState>(
+        'does not re-emit when hydration leaves rendered contacts unchanged',
+        setUp: () {
+          when(() => mockSharingService.recentlySharedWith).thenReturn([]);
+          when(
+            () => mockFollowRepository.followingPubkeys,
+          ).thenReturn([unprofiledFollow]);
+          when(
+            () => mockProfileRepository.getCachedProfiles(
+              pubkeys: any(named: 'pubkeys'),
+            ),
+          ).thenAnswer((_) async => <UserProfile>[]);
+          when(
+            () => mockProfileRepository.fetchBatchProfiles(
+              pubkeys: any(named: 'pubkeys'),
+            ),
+          ).thenAnswer((_) async => <String, UserProfile>{});
+        },
+        build: createBloc,
+        act: (bloc) => bloc.add(const ShareSheetContactsLoadRequested()),
+        expect: () => [
+          const ShareSheetState(status: ShareSheetStatus.loading),
+          isA<ShareSheetState>()
+              .having((s) => s.status, 'status', ShareSheetStatus.ready)
+              .having((s) => s.contacts.length, 'contacts.length', 1)
+              .having(
+                (s) => s.contacts[0].displayName,
+                'contact name',
+                isNull,
+              ),
+        ],
+        verify: (_) {
+          verify(
+            () => mockProfileRepository.fetchBatchProfiles(
+              pubkeys: [unprofiledFollow],
+            ),
+          ).called(1);
+        },
       );
 
       blocTest<ShareSheetBloc, ShareSheetState>(
@@ -489,14 +678,10 @@ void main() {
           isA<ShareSheetState>()
               .having((s) => s.status, 'status', ShareSheetStatus.ready)
               .having((s) => s.contacts.length, 'contacts.length', 2)
-              .having(
-                (s) => s.contacts[0].displayName,
-                'hydrated name',
-                'Bob',
-              ),
+              .having((s) => s.contacts[0].displayName, 'hydrated name', 'Bob'),
         ],
         verify: (_) {
-          // Exactly one batched read covering both follows, in order — the
+          // Exactly one network batch covering both follows, in order — the
           // per-pubkey getCachedProfile/fetchFreshProfile storm is gone.
           final captured = verify(
             () => mockProfileRepository.fetchBatchProfiles(
@@ -1771,10 +1956,8 @@ void main() {
         build: createBloc,
         act: (bloc) => bloc.add(const ShareSheetBookmarkStatusRequested()),
         expect: () => <ShareSheetState>[],
-        verify: (bloc) => expect(
-          bloc.state.bookmarkStatus,
-          ShareSheetBookmarkStatus.unknown,
-        ),
+        verify: (bloc) =>
+            expect(bloc.state.bookmarkStatus, ShareSheetBookmarkStatus.unknown),
       );
 
       blocTest<ShareSheetBloc, ShareSheetState>(

--- a/mobile/test/widgets/video_feed_item/actions/share_action_button_test.dart
+++ b/mobile/test/widgets/video_feed_item/actions/share_action_button_test.dart
@@ -2,6 +2,8 @@
 // ABOUTME: Verifies share icon renders, share sheet opens with correct sections,
 // ABOUTME: and standard action items display in the unified share sheet.
 
+import 'dart:async';
+
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -56,6 +58,16 @@ void main() {
           pubkey: any(named: 'pubkey'),
         ),
       ).thenAnswer((_) async => null);
+      when(
+        () => mockProfileRepository.getCachedProfiles(
+          pubkeys: any(named: 'pubkeys'),
+        ),
+      ).thenAnswer((_) async => <UserProfile>[]);
+      when(
+        () => mockProfileRepository.fetchBatchProfiles(
+          pubkeys: any(named: 'pubkeys'),
+        ),
+      ).thenAnswer((_) async => <String, UserProfile>{});
 
       testVideo = VideoEvent(
         id: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
@@ -373,6 +385,38 @@ void main() {
             );
           },
         );
+
+        testWidgets('pending cache-miss rows are not selectable', (
+          tester,
+        ) async {
+          const unknownPubkey =
+              '22222222222222222222222222222222'
+              '22222222222222222222222222222222';
+          final hydration = Completer<Map<String, UserProfile>>();
+          when(() => mockVideoSharingService.recentlySharedWith).thenReturn([]);
+          when(
+            () => mockFollowRepository.followingPubkeys,
+          ).thenReturn([unknownPubkey]);
+          when(
+            () => mockProfileRepository.fetchBatchProfiles(
+              pubkeys: [unknownPubkey],
+            ),
+          ).thenAnswer((_) => hydration.future);
+
+          await pumpOpenSheet(tester);
+
+          expect(find.text('Username'), findsOneWidget);
+
+          await tester.tap(find.text('Username'), warnIfMissed: false);
+          await tester.pump();
+
+          final blocContext = tester.element(find.text('Share with'));
+          expect(
+            blocContext.read<ShareSheetBloc>().state.selectedRecipients,
+            isEmpty,
+          );
+          expect(find.byType(TextField), findsNothing);
+        });
 
         testWidgets(
           'tapping the last selected contact again deselects, restores '


### PR DESCRIPTION
Closes #7458

## Summary

Fixes the share sheet's contact row sitting on a shimmer for seconds before rendering. Root cause: `_onContactsLoadRequested` awaited `fetchBatchProfiles` (bulk REST + one relay fetch per uncached pubkey, 5s timeouts) before emitting anything, while the Drift cache already had the visible cached avatars.

**The fix:**
1. **Cache-first emit** - one batched Drift read (new `ProfileReader.getCachedProfiles`) renders recents + cached follow profiles immediately.
2. **Pending miss skeletons** - uncached follow pubkeys stay as non-interactive, semantics-excluded skeleton tiles until hydration identifies them.
3. **Background hydration** - the network batch fills cache misses and re-emits only when the rendered row changes; misses still unresolved after hydration are dropped from the row.
4. **Failure keeps the render** - a hydration error no longer erases the cache-first contacts or pending skeletons already on screen.
5. **Visible row survives** - recipients picked through Find People during either cache read or hydration stay visible in row order, including after deselect.
6. **Blocked rows stay hidden** - batch cache reads and the all-cached `fetchBatchProfiles` path both apply the repository block filter.

## The interface question (reviewer attention requested)

`ProfileReader` is a deliberate security boundary: signer-free, relay-optional, guarded by an exhaustive-reader tripwire test and `check_profile_read_write_split.sh`. `getCachedProfiles` already existed on `ProfileRepository` but was absent from the read-only view, which is exactly why the bloc reached for the networked call. Widening the interface here is a **conscious act**: a batch Drift `WHERE pubkey IN (...)` read satisfies the invariant (no signer, no relay, no network of any kind). The tripwire test was updated with that reasoning inline, and the split guard still passes.

## Test plan

- New/updated bloc tests: cache-first render then hydration re-emit; hydration failure keeps the render; Find People recipient survives the cache-read race and hydration swap; deselected Find People recipient stays visible; multi-pick row order is preserved; unresolved cache misses drop after hydration
- New/updated widget test: pending cache-miss rows are not selectable
- New/updated repository tests: exhaustive-reader tripwire + batch-read-through-the-interface test; blocked batch cache read test; all-cached `fetchBatchProfiles` block-filter regression
- `flutter test test/blocs/share_sheet/share_sheet_bloc_test.dart` - 59 passed
- `flutter test test/widgets/video_feed_item/actions/share_action_button_test.dart` - 19 passed
- `flutter test` in `mobile/packages/profile_repository` - 439 passed
- `flutter analyze` - no issues
- `bash scripts/check_profile_read_write_split.sh` - pass

Part 1 of the share/DM contact-picker fixes. Parts 2 (DM-history contact source) and 3 (contact ranking) follow as separate PRs.
