### PR TITLE
docs(metrics): correct the display-floor measurement in the design doc

### DIFF
--- a/docs/superpowers/specs/2026-08-13-view-and-loop-metrics-design.md
+++ b/docs/superpowers/specs/2026-08-13-view-and-loop-metrics-design.md
@@ -302,37 +302,57 @@ Treat every figure here as the least the number should move, not the most.
 
 ### The display floor, and why most cards show a date
 
-`publicLoopCountFloor` is 1000. Measured against the catalogue:
+`publicLoopCountFloor` is 1000, applied by
+`video_card_meta.dart:79` to `video.isOriginalVine ? video.originalLoops ?? 0
+: video.totalLoops` — the archival `loops` tag for classic Vines (98% of the
+catalogue), `originalLoops + views` for native ones. Measured against that
+quantity:
 
-| Threshold | Videos at or above | Share of 2,201,983 |
+| Threshold | Videos at or above | Share of 2,203,822 |
 |---|---|---|
-| 1000 (today's floor) | 961 | **0.04%** |
-| 333 (floor reached at ×3) | 2,441 | 0.11% |
-| 100 (floor reached at ×10) | 12,571 | 0.57% |
+| 1000 (today's floor) | 1,152,593 | **52.30%** |
+| 333 (floor reached at ×3) | 1,375,711 | 62.42% |
+| 100 (floor reached at ×10) | 1,621,923 | 73.60% |
 
-So the public count is effectively never shown — 9,996 videos in 10,000 render
-a date instead. Correcting the metrics does not change that: an
-order-of-magnitude improvement moves it from 0.04% to 0.57%.
+Median public count: 1,417. So a public count renders on **about half** the
+catalogue, and correcting the metrics moves it from 52% toward 74%.
 
-**This is intended, and it is not a defect.** Two reasons it holds:
+**The floor is intended, and it is not a defect** — but for one reason, not
+the two this document previously gave:
 
-- **Creator retention does not run through the public count.** The video-card
-  spec's `isOwnVideo` case shows a creator their own number *always, however
-  small*. The retention effect it cites — crossing ~100 views roughly doubling
-  the chance a new creator keeps posting — operates on the creator's own view,
-  which has no floor. The public floor never gated it.
-- **A date is the better default for this catalogue.** With ~2.2M archived
-  vines from 2013–16, "Apr 22, 2014" reframes a clip as an artifact in a way a
-  view count does not. Suppression is not a fallback here; it is often the
-  stronger presentation.
+- **A wall of small numbers suppresses posting.** The constant's own doc
+  comment is the argument: a number below the floor "tells a viewer not to
+  bother", and seeing other people's videos sitting at 50 loops discourages
+  a visitor from posting at all. Above the floor the number does useful work.
+  On the real distribution the floor does that job — a visitor sees a count
+  on ~52% of videos, every one of them ≥1000, and a date on the rest.
+- **Creators are never gated.** `_resolveLoopCount` returns
+  `video.totalLoops` unconditionally when `isOwnVideo`, and `totalLoops` is
+  additive (`originalLoops + views`), so a creator always sees their own
+  number and sees the larger of the two figures.
 
-Two earlier drafts of this document got this wrong in opposite directions:
-first claiming the correction would lift "a large share of the catalogue" above
-the floor, then claiming the floor was mis-set by two orders of magnitude and
-was starving creators of encouragement. Neither holds. The floor governs public
-display only, the constant is deliberately one line, and re-tuning it is a
-product call to make on its own evidence rather than a consequence of this
-work.
+Three earlier drafts of this document got this wrong in three different
+directions: first claiming the correction would lift "a large share of the
+catalogue" above the floor; then claiming the floor was mis-set by two orders
+of magnitude and was starving creators of encouragement; then — the version
+this replaces — claiming the public count is "effectively never shown", that
+"9,996 videos in 10,000 render a date", and justifying the floor on the
+grounds that a date is the better default for an archival catalogue.
+
+That third version measured `video_total_views_data.total_views`, a column the
+floor is never applied to, and was wrong by three orders of magnitude. The
+archival-artifact argument was built on top of it and does not survive: dates
+are not what most cards show. Re-tuning the floor remains a product call, and
+it should be made against the ~52% census above rather than against any of
+these drafts.
+
+One unreconciled discrepancy, stated rather than smoothed over: the constant's
+doc comment reports "roughly 64% of the archive" hidden with "p50 is 298
+loops", measured against a 1,000-Vine sample. The full-catalogue census gives
+47.7% hidden at p50 1,417. Both contradict the 0.04% figure, but the sample
+and the census disagree by more than sampling noise should allow, so prefer
+the census. The re-runnable query is in the
+[baseline doc](2026-08-13-view-and-loop-metrics-baseline.md) appendix §5.
 
 ## Testing
 


### PR DESCRIPTION
Closes #7471

## Description

The merged design doc's display-floor section measures the wrong column and lands three orders of magnitude off. The conclusion it reaches — keep the floor — is right; the number and the reasoning behind it are not.

`publicLoopCountFloor` is applied by `video_card_meta.dart:79` to:

```dart
video.isOriginalVine ? video.originalLoops ?? 0 : video.totalLoops
```

i.e. the archival `loops` tag for classic Vines (98% of the catalogue) and `originalLoops + views` for native ones. The doc measured `video_total_views_data.total_views`, which the floor is never applied to.

**Measured against the quantity the code actually gates:**

| Threshold | Videos at or above | Share of 2,203,822 | Doc said |
|---|---|---|---|
| 1000 (today's floor) | 1,152,593 | **52.30%** | 0.04% |
| 333 | 1,375,711 | 62.42% | 0.11% |
| 100 | 1,621,923 | 73.60% | 0.57% |

Median public count 1,417. A public count renders on **about half** the catalogue, not on one video in 2,300.

### What that invalidates

Two claims fall with the number:

- *"The public count is effectively never shown — 9,996 videos in 10,000 render a date instead."*
- *"A date is the better default for this catalogue"* — the archival-artifact argument was built on the premise that dates are what almost every card shows. They are not.

### What replaces it

The floor still holds, on the argument the constant's own doc comment gives: a number below it "tells a viewer not to bother", and a wall of small counts on **other people's** videos discourages a visitor from posting at all. On the real distribution the floor does exactly that job — a visitor sees a count on ~52% of videos, every one ≥1000, and a date on the rest instead of a discouraging 47.

Creators are never gated either way: `_resolveLoopCount` returns `video.totalLoops` unconditionally when `isOwnVideo`, and `totalLoops` is additive (`originalLoops + views`), so a creator who claimed a Vine account sees archival loops *plus* live views — the larger number, not the smaller.

**Related Issue:** Relates to #7218

## Out of Scope

- Re-tuning the floor value itself. That is a product call; this PR only makes the evidence for it correct.
- The sibling `2026-08-08-video-card-view-count-display-design.md` does not carry this error and is untouched.

## Verification

Measured read-only against production ClickHouse (`nostr`) at 2026-08-15:

```sql
WITH
  arrayExists(t -> t[1] = 'platform' AND t[2] = 'vine', tags)  AS is_vine,
  toUInt64OrZero(arrayFirst(t -> t[1] = 'views', tags)[2])     AS views_tag,
  if(is_vine, loops, loops + views_tag)                        AS public_count
SELECT count(), countIf(public_count >= 1000), countIf(public_count >= 333),
       countIf(public_count >= 100), median(public_count)
FROM nostr.videos;
```

Before trusting that, I confirmed `nostr.videos.loops` really is the `loops` tag the client reads — over a 200,000-row Vine sample, 198,061 rows carry the tag and the column equals it in all 198,061, zero mismatches. Without that check the correction would rest on the same class of assumption as the error it fixes.

Docs-only change; no code, no tests.

**Not verified:** the constant's doc comment reports "roughly 64% of the archive" hidden at "p50 298 loops" from a 1,000-Vine sample, against the census's 47.7% at p50 1,417. Both contradict 0.04%, but they disagree with each other by more than sampling noise should allow, and I did not track down why. That discrepancy is written into the doc as open rather than resolved — the census is the better basis, but the sample's provenance is unexplained.

## Type of Change

- [x] 📝 Documentation

