### PR TITLE
fix(avatars): never request verified-dead v.cdn.vine.co image URLs

### DIFF
--- a/mobile/lib/screens/profile_setup/widgets/profile_avatar_section.dart
+++ b/mobile/lib/screens/profile_setup/widgets/profile_avatar_section.dart
@@ -12,6 +12,7 @@ import 'package:openvine/screens/image_crop_editor/image_crop_editor.dart';
 import 'package:openvine/screens/profile_setup/widgets/image_url_sheet.dart';
 import 'package:openvine/screens/profile_setup/widgets/profile_image_actions_sheet.dart';
 import 'package:openvine/screens/profile_setup/widgets/profile_image_picker.dart';
+import 'package:openvine/utils/dead_image_hosts.dart';
 import 'package:openvine/widgets/user_avatar.dart';
 import 'package:unified_logger/unified_logger.dart';
 
@@ -148,7 +149,9 @@ class _ProfileAvatarSectionState extends ConsumerState<ProfileAvatarSection> {
     }
 
     final pending = editorState.pendingPictureUrl;
-    if (pending != null && pending.isNotEmpty) {
+    if (pending != null &&
+        pending.isNotEmpty &&
+        !isKnownDeadImageHost(pending)) {
       return NetworkImage(pending);
     }
 
@@ -157,7 +160,9 @@ class _ProfileAvatarSectionState extends ConsumerState<ProfileAvatarSection> {
     if (editorState.pictureCleared) return null;
 
     final persisted = editorState.persistedPictureUrl;
-    if (persisted != null && persisted.isNotEmpty) {
+    if (persisted != null &&
+        persisted.isNotEmpty &&
+        !isKnownDeadImageHost(persisted)) {
       return NetworkImage(persisted);
     }
 

--- a/mobile/lib/utils/dead_image_hosts.dart
+++ b/mobile/lib/utils/dead_image_hosts.dart
@@ -1,0 +1,15 @@
+// ABOUTME: Hosts whose image content is verified-dead at the origin and must
+// ABOUTME: never be requested — the placeholder is the correct render.
+
+/// Whether [url] points at a host whose content is known to be permanently
+/// unavailable, so no request should ever be attempted.
+///
+/// `v.cdn.vine.co` was verified dead on 2026-08-15: cleartext returns 403
+/// for every probed object, and the TLS certificate (Twitter-issued
+/// `*.cdn.vine.co`) expired 2025-07-10, so no scheme rewrite can help.
+/// Sibling subdomains (e.g. `mt.cdn.vine.co`) are unverified and NOT
+/// matched — extend this only with per-host evidence.
+bool isKnownDeadImageHost(String url) {
+  final host = Uri.tryParse(url)?.host.toLowerCase();
+  return host == 'v.cdn.vine.co';
+}

--- a/mobile/lib/widgets/user_avatar.dart
+++ b/mobile/lib/widgets/user_avatar.dart
@@ -9,6 +9,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:openvine/blocs/avatar_svg/avatar_svg_cubit.dart';
 import 'package:openvine/repositories/avatar_svg_repository.dart';
+import 'package:openvine/utils/dead_image_hosts.dart';
 import 'package:openvine/widgets/avatar_failure_cache.dart';
 import 'package:openvine/widgets/vine_cached_image.dart';
 import 'package:unified_logger/unified_logger.dart';
@@ -128,7 +129,10 @@ class UserAvatar extends StatelessWidget {
 
   double get _borderWidth => size >= 120 ? 3 : 1;
 
-  bool get _hasNetworkImage => imageUrl != null && imageUrl!.isNotEmpty;
+  bool get _hasNetworkImage =>
+      imageUrl != null &&
+      imageUrl!.isNotEmpty &&
+      !isKnownDeadImageHost(imageUrl!);
 
   bool get _isSvgImageUrl => isSvgImageUrl(imageUrl);
 

--- a/mobile/lib/widgets/vine_cached_image.dart
+++ b/mobile/lib/widgets/vine_cached_image.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/widgets.dart';
 import 'package:media_cache/media_cache.dart';
+import 'package:openvine/utils/dead_image_hosts.dart';
 import 'package:openvine/utils/open_vine_image_cache.dart';
 
 export 'package:openvine/utils/open_vine_image_cache.dart'
@@ -159,6 +160,18 @@ class _VineCachedImageState extends State<VineCachedImage> {
 
   @override
   Widget build(BuildContext context) {
+    // A known-dead host must never be resolved: the origin is gone, so the
+    // request would only burn a failure before landing here anyway.
+    if (isKnownDeadImageHost(widget.imageUrl)) {
+      return _ErrorWidget(
+        error: StateError('known-dead image host: ${widget.imageUrl}'),
+        imageUrl: widget.imageUrl,
+        width: widget.width,
+        height: widget.height,
+        errorWidget: widget.errorWidget,
+      );
+    }
+
     if (_error != null) {
       return _ErrorWidget(
         error: _error!,

--- a/mobile/lib/widgets/vine_cached_image.dart
+++ b/mobile/lib/widgets/vine_cached_image.dart
@@ -103,6 +103,13 @@ class _VineCachedImageState extends State<VineCachedImage> {
   }
 
   void _resolveImageStream() {
+    if (isKnownDeadImageHost(widget.imageUrl)) {
+      _removeImageListener();
+      _error = null;
+      _hasImage = false;
+      return;
+    }
+
     final newStream = _imageProvider.resolve(
       createLocalImageConfiguration(context),
     );

--- a/mobile/test/screens/profile_setup/profile_avatar_section_test.dart
+++ b/mobile/test/screens/profile_setup/profile_avatar_section_test.dart
@@ -136,6 +136,41 @@ void main() {
       );
     });
 
+    testWidgets('skips dead pending avatar URLs in the preview', (
+      tester,
+    ) async {
+      when(() => bloc.state).thenReturn(
+        const ProfileEditorState(
+          pendingAvatarStatus: PendingAvatarStatus.staged,
+          pendingPictureUrl: 'https://v.cdn.vine.co/v/avatars/staged.jpg',
+        ),
+      );
+
+      await pump(tester);
+
+      expect(
+        tester.widget<UserAvatar>(find.byType(UserAvatar)).imageProvider,
+        isNull,
+      );
+    });
+
+    testWidgets('skips dead persisted avatar URLs in the preview', (
+      tester,
+    ) async {
+      when(() => bloc.state).thenReturn(
+        const ProfileEditorState(
+          persistedPictureUrl: 'https://v.cdn.vine.co/v/avatars/persisted.jpg',
+        ),
+      );
+
+      await pump(tester);
+
+      expect(
+        tester.widget<UserAvatar>(find.byType(UserAvatar)).imageProvider,
+        isNull,
+      );
+    });
+
     testWidgets(
       're-subscribes the avatar name when nameController is swapped',
       (tester) async {
@@ -228,9 +263,7 @@ void main() {
       Future<void> pickFromGallery(WidgetTester tester) async {
         await tester.tap(find.byType(DivineIconButton));
         await tester.pumpAndSettle();
-        await tester.tap(
-          find.text(l10n.profileSetupImageUploadFromCameraRoll),
-        );
+        await tester.tap(find.text(l10n.profileSetupImageUploadFromCameraRoll));
         await tester.pumpAndSettle();
       }
 

--- a/mobile/test/utils/dead_image_hosts_test.dart
+++ b/mobile/test/utils/dead_image_hosts_test.dart
@@ -1,0 +1,44 @@
+// ABOUTME: Unit tests for the known-dead image host predicate.
+// ABOUTME: Pins the exact host match — no over-blocking of sibling subdomains.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/utils/dead_image_hosts.dart';
+
+void main() {
+  group(isKnownDeadImageHost, () {
+    test('matches v.cdn.vine.co under both schemes', () {
+      expect(
+        isKnownDeadImageHost('http://v.cdn.vine.co/v/avatars/x.jpg'),
+        isTrue,
+      );
+      expect(
+        isKnownDeadImageHost('https://v.cdn.vine.co/v/avatars/x.jpg'),
+        isTrue,
+      );
+    });
+
+    test('matches case-insensitively', () {
+      expect(isKnownDeadImageHost('HTTP://V.CDN.VINE.CO/v/x.jpg'), isTrue);
+    });
+
+    test('does not match unverified sibling subdomains', () {
+      // mt.cdn.vine.co is unverified content-wise; only extend with evidence.
+      expect(
+        isKnownDeadImageHost('https://mt.cdn.vine.co/v/thumb.jpg'),
+        isFalse,
+      );
+    });
+
+    test('does not match live hosts', () {
+      expect(
+        isKnownDeadImageHost('https://blossom.example.com/x.jpg'),
+        isFalse,
+      );
+    });
+
+    test('does not throw on malformed input', () {
+      expect(isKnownDeadImageHost('not a url'), isFalse);
+      expect(isKnownDeadImageHost(''), isFalse);
+    });
+  });
+}

--- a/mobile/test/widgets/comprehensive_user_avatar_test.dart
+++ b/mobile/test/widgets/comprehensive_user_avatar_test.dart
@@ -186,6 +186,45 @@ void main() {
         expect(_clipSize(tester), const Size.square(44));
       });
 
+      testWidgets(
+        'renders the placeholder without requesting a dead http vine.co URL',
+        (tester) async {
+          const deadUrl = 'http://v.cdn.vine.co/v/avatars/dead.jpg';
+
+          await tester.pumpWidget(
+            const MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: Scaffold(body: UserAvatar(imageUrl: deadUrl)),
+            ),
+          );
+
+          // The origin is verified dead (403 on cleartext, expired cert on
+          // 443), so the request must never be attempted — the placeholder
+          // is the correct render.
+          expect(find.byType(VineCachedImage), findsNothing);
+          expect(_gradientFinder(), findsWidgets);
+        },
+      );
+
+      testWidgets(
+        'renders the placeholder without requesting a dead https vine.co URL',
+        (tester) async {
+          const deadUrl = 'https://v.cdn.vine.co/v/avatars/dead.jpg';
+
+          await tester.pumpWidget(
+            const MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: Scaffold(body: UserAvatar(imageUrl: deadUrl)),
+            ),
+          );
+
+          expect(find.byType(VineCachedImage), findsNothing);
+          expect(_gradientFinder(), findsWidgets);
+        },
+      );
+
       testWidgets('shows generated placeholder when imageUrl is null', (
         tester,
       ) async {

--- a/mobile/test/widgets/vine_cached_image_test.dart
+++ b/mobile/test/widgets/vine_cached_image_test.dart
@@ -42,6 +42,9 @@ void main() {
       'renders the error widget without resolving a known-dead host',
       (tester) async {
         const deadUrl = 'http://v.cdn.vine.co/v/avatars/dead.jpg';
+        final cache = _FakeImageCache();
+        debugImageCacheOverride = cache;
+        addTearDown(() => debugImageCacheOverride = null);
 
         await tester.pumpWidget(
           const Directionality(
@@ -53,14 +56,21 @@ void main() {
           ),
         );
 
-        // No MediaCacheImageProvider may be created for a URL whose origin
-        // is verified dead — the error path renders instead.
         expect(find.text('dead-render'), findsOneWidget);
         expect(
           find.byWidgetPredicate(
             (w) => w is Image && w.image is MediaCacheImageProvider,
           ),
           findsNothing,
+        );
+        verifyNever(() => cache.getFileFromCache(any()));
+        verifyNever(
+          () => cache.cacheFileCancellable(
+            any(),
+            key: any(named: 'key'),
+            aliasKey: any(named: 'aliasKey'),
+            authHeaders: any(named: 'authHeaders'),
+          ),
         );
       },
     );

--- a/mobile/test/widgets/vine_cached_image_test.dart
+++ b/mobile/test/widgets/vine_cached_image_test.dart
@@ -6,6 +6,10 @@ import 'package:openvine/widgets/vine_cached_image.dart';
 
 class _FakeImageCache extends Mock implements MediaCacheManager {}
 
+Widget _deadErrorBuilder(BuildContext context, String url, Object error) {
+  return const Text('dead-render', textDirection: TextDirection.ltr);
+}
+
 void main() {
   group('openVineImageCache', () {
     test('is a $MediaCacheManager', () {
@@ -33,6 +37,33 @@ void main() {
 
   group(VineCachedImage, () {
     const testUrl = 'https://example.com/image.jpg';
+
+    testWidgets(
+      'renders the error widget without resolving a known-dead host',
+      (tester) async {
+        const deadUrl = 'http://v.cdn.vine.co/v/avatars/dead.jpg';
+
+        await tester.pumpWidget(
+          const Directionality(
+            textDirection: TextDirection.ltr,
+            child: VineCachedImage(
+              imageUrl: deadUrl,
+              errorWidget: _deadErrorBuilder,
+            ),
+          ),
+        );
+
+        // No MediaCacheImageProvider may be created for a URL whose origin
+        // is verified dead — the error path renders instead.
+        expect(find.text('dead-render'), findsOneWidget);
+        expect(
+          find.byWidgetPredicate(
+            (w) => w is Image && w.image is MediaCacheImageProvider,
+          ),
+          findsNothing,
+        );
+      },
+    );
 
     testWidgets('renders Image with a MediaCacheImageProvider', (tester) async {
       await tester.pumpWidget(


### PR DESCRIPTION
Closes #7470

## Summary

Follow-up to the avatar-origin findings in divine-mobile#7453 (probe table there) and the server-side ask in divine-funnelcake#940: since `v.cdn.vine.co` is dead at the origin under **both** schemes, the client should never issue the request at all.

Measured evidence (re-run for this PR):

| Probe | Result |
|---|---|
| `http://v.cdn.vine.co/v/avatars/...` | 403 Forbidden (S3 XML error) |
| `https://v.cdn.vine.co/...` | TLS handshake fails — cert expired |
| Cert: `*.cdn.vine.co`, Twitter Inc., DigiCert | notAfter **2025-07-10** |
| `https --insecure` | 403 — content gone regardless of scheme |

## What changed

- New `isKnownDeadImageHost` predicate (exact-host match on `v.cdn.vine.co` only; sibling subdomains like `mt.cdn.vine.co` are unverified and deliberately NOT matched — extend only with per-host evidence)
- `UserAvatar` treats a dead-host URL as no URL: renders the generated placeholder directly, never builds the image loader
- `VineCachedImage` short-circuits to its error path without resolving the provider — no request, no failure-cache noise, no timeout wait

## Test plan

- 5 predicate unit tests (both schemes, case-insensitivity, sibling exclusion, live hosts, malformed input)
- 2 avatar widget tests: http and https dead URLs render the placeholder with no `VineCachedImage` in the tree
- 1 loader test: dead URL renders the error widget with no `MediaCacheImageProvider` created
- Existing avatar/loader suites (44 tests) and `golden.sh verify` green; `flutter analyze` clean
