### PR TITLE
fix(support): route For You through repository

### DIFF
--- a/mobile/lib/providers/for_you_provider.dart
+++ b/mobile/lib/providers/for_you_provider.dart
@@ -215,7 +215,7 @@ class ForYouFeed extends _$ForYouFeed {
         category: LogCategory.video,
       );
 
-      _nextCursor = _paginationCursor(result);
+      _nextCursor = result.paginationCursor;
 
       state = AsyncData(
         VideoFeedState(
@@ -256,16 +256,13 @@ class ForYouFeed extends _$ForYouFeed {
   }
 
   VideoFeedState _stateFromResult(HomeFeedResult result) {
-    _nextCursor = _paginationCursor(result);
+    _nextCursor = result.paginationCursor;
     return VideoFeedState(
       videos: dedupeByFeedKey(_filterVideos(result.videos)),
       hasMoreContent: result.hasMore == true && _nextCursor != null,
       lastUpdated: DateTime.now(),
     );
   }
-
-  String? _paginationCursor(HomeFeedResult result) =>
-      result.paginationCursor ?? result.nextCursor?.toString();
 
   List<VideoEvent> _filterVideos(List<VideoEvent> videos) {
     final videoEventService = ref.read(videoEventServiceProvider);

--- a/mobile/lib/providers/for_you_provider.dart
+++ b/mobile/lib/providers/for_you_provider.dart
@@ -108,7 +108,8 @@ class ForYouFeed extends _$ForYouFeed {
     bool preserveExistingOnError = false,
     bool skipCache = false,
   }) async {
-    _feedGeneration += 1;
+    final generation = _feedGeneration + 1;
+    _feedGeneration = generation;
     try {
       final authService = ref.read(authServiceProvider);
       final currentUserPubkey = authService.currentPublicKeyHex;
@@ -135,6 +136,10 @@ class ForYouFeed extends _$ForYouFeed {
 
       if (!ref.mounted) {
         return const VideoFeedState(videos: [], hasMoreContent: false);
+      }
+      if (_feedGeneration != generation) {
+        return state.asData?.value ??
+            const VideoFeedState(videos: [], hasMoreContent: false);
       }
 
       return _stateFromResult(result);

--- a/mobile/lib/providers/for_you_provider.dart
+++ b/mobile/lib/providers/for_you_provider.dart
@@ -10,9 +10,6 @@ import 'package:openvine/providers/feed_viewer_preference_hints.dart';
 import 'package:openvine/providers/moderation_providers.dart';
 import 'package:openvine/providers/preferences_providers.dart';
 import 'package:openvine/providers/readiness_gate_providers.dart';
-// ignore: directives_ordering
-import 'package:openvine/features/feature_flags/models/feature_flag.dart';
-import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
 import 'package:openvine/providers/video_providers.dart';
 import 'package:openvine/state/video_feed_state.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -31,7 +28,7 @@ class ForYouFeed extends _$ForYouFeed {
   static const int _pageSize = 50;
 
   String? _nextCursor;
-  String _sessionSeed = generateRecommendationSessionSeed();
+  int _feedGeneration = 0;
 
   @override
   Future<VideoFeedState> build() async {
@@ -104,84 +101,43 @@ class ForYouFeed extends _$ForYouFeed {
       return const VideoFeedState(videos: [], hasMoreContent: false);
     }
 
-    return _fetchRecommendations(
-      sessionSeed: generateRecommendationSessionSeed(),
-    );
+    return _fetchRecommendations();
   }
 
   Future<VideoFeedState> _fetchRecommendations({
     bool preserveExistingOnError = false,
-    String? sessionSeed,
+    bool skipCache = false,
   }) async {
+    _feedGeneration += 1;
     try {
-      final requestSeed = sessionSeed ?? _sessionSeed;
       final authService = ref.read(authServiceProvider);
       final currentUserPubkey = authService.currentPublicKeyHex;
       if (currentUserPubkey == null) {
         return const VideoFeedState(videos: [], hasMoreContent: false);
       }
 
-      final client = ref.read(funnelcakeApiClientProvider);
       final hints = await readFeedViewerPreferenceHints(ref.read);
-      final response = await client.getRecommendations(
-        pubkey: currentUserPubkey,
-        limit: _pageSize,
-        seed: requestSeed,
-        preferredLanguages: hints.preferredLanguages,
-        viewerCountry: hints.viewerCountry,
-      );
-      final resultVideos = response.videos.toVideoEvents();
+      final result = await ref
+          .read(videosRepositoryProvider)
+          .getRecommendedVideos(
+            userPubkey: currentUserPubkey,
+            limit: _pageSize,
+            skipCache: skipCache,
+            preferredLanguages: hints.preferredLanguages,
+            viewerCountry: hints.viewerCountry,
+          );
 
       Log.info(
-        '✅ ForYouFeed: Got ${resultVideos.length} recommendations, source: ${response.source}',
+        '✅ ForYouFeed: Got ${result.videos.length} recommendations',
         name: 'ForYouFeedProvider',
         category: LogCategory.video,
       );
 
-      // Filter for platform compatibility, content preferences, blocked
-      // users, and dedupe by addressable identity (the recommendation cursor
-      // dedupes by event id, so a republished coordinate arrives twice).
-      final videoEventService = ref.read(videoEventServiceProvider);
-      final filteredVideos = dedupeByFeedKey(
-        videoEventService.filterVideoList(
-          resultVideos.where((v) => v.isSupportedOnCurrentPlatform).toList(),
-        ),
-      );
-      final seenVideosService = ref.read(seenVideosServiceProvider);
-      await seenVideosService.initialize();
       if (!ref.mounted) {
         return const VideoFeedState(videos: [], hasMoreContent: false);
       }
 
-      final clientSeenFilteringEnabled = (() {
-        try {
-          return ref
-              .read(featureFlagServiceProvider)
-              .isEnabled(FeatureFlag.clientSeenFiltering);
-        } catch (_) {
-          return true;
-        }
-      })();
-
-      final freshOrderedVideos = clientSeenFilteringEnabled
-          ? prioritizeNotRecentlySeenVideos(
-              filteredVideos,
-              seenVideoLookup: SeenVideoLookup(
-                wasSeenRecently: seenVideosService.wasSeenRecently,
-                initialize: seenVideosService.initialize,
-              ),
-            )
-          : filteredVideos;
-
-      _sessionSeed = requestSeed;
-      _nextCursor = response.nextCursor;
-      final hasMore = response.hasMore && _nextCursor != null;
-
-      return VideoFeedState(
-        videos: freshOrderedVideos,
-        hasMoreContent: hasMore,
-        lastUpdated: DateTime.now(),
-      );
+      return _stateFromResult(result);
     } catch (e) {
       Log.error(
         '🎯 ForYouFeed: Error fetching recommendations: $e',
@@ -222,9 +178,8 @@ class ForYouFeed extends _$ForYouFeed {
         return;
       }
 
-      final client = ref.read(funnelcakeApiClientProvider);
       final cursor = _nextCursor;
-      final seed = _sessionSeed;
+      final generation = _feedGeneration;
       if (cursor == null) {
         state = AsyncData(
           currentState.copyWith(isLoadingMore: false, hasMoreContent: false),
@@ -232,49 +187,23 @@ class ForYouFeed extends _$ForYouFeed {
         return;
       }
       final hints = await readFeedViewerPreferenceHints(ref.read);
-      final response = await client.getRecommendations(
-        pubkey: currentUserPubkey,
-        limit: _pageSize,
-        cursor: cursor,
-        seed: seed,
-        preferredLanguages: hints.preferredLanguages,
-        viewerCountry: hints.viewerCountry,
-      );
-      final resultVideos = response.videos.toVideoEvents();
+      final result = await ref
+          .read(videosRepositoryProvider)
+          .getRecommendedVideos(
+            userPubkey: currentUserPubkey,
+            limit: _pageSize,
+            cursor: cursor,
+            preferredLanguages: hints.preferredLanguages,
+            viewerCountry: hints.viewerCountry,
+          );
 
       if (!ref.mounted) return;
-      if (_sessionSeed != seed) {
+      if (_feedGeneration != generation || _nextCursor != cursor) {
         return;
       }
 
-      final videoEventService = ref.read(videoEventServiceProvider);
-      final filteredVideos = videoEventService.filterVideoList(
-        resultVideos.where((v) => v.isSupportedOnCurrentPlatform).toList(),
-      );
-      final seenVideosService = ref.read(seenVideosServiceProvider);
-      await seenVideosService.initialize();
-      if (!ref.mounted) return;
-
-      final clientSeenFilteringEnabledLoadMore = (() {
-        try {
-          return ref
-              .read(featureFlagServiceProvider)
-              .isEnabled(FeatureFlag.clientSeenFiltering);
-        } catch (_) {
-          return true;
-        }
-      })();
-
       final newVideos = dedupeByFeedKey(
-        clientSeenFilteringEnabledLoadMore
-            ? prioritizeNotRecentlySeenVideos(
-                filteredVideos,
-                seenVideoLookup: SeenVideoLookup(
-                  wasSeenRecently: seenVideosService.wasSeenRecently,
-                  initialize: seenVideosService.initialize,
-                ),
-              )
-            : filteredVideos,
+        _filterVideos(result.videos),
         alreadySeen: currentState.videos.map((video) => video.feedDedupKey),
       );
       final mergedVideos = [...currentState.videos, ...newVideos];
@@ -286,12 +215,12 @@ class ForYouFeed extends _$ForYouFeed {
         category: LogCategory.video,
       );
 
-      _nextCursor = response.nextCursor;
+      _nextCursor = _paginationCursor(result);
 
       state = AsyncData(
         VideoFeedState(
           videos: mergedVideos,
-          hasMoreContent: response.hasMore && _nextCursor != null,
+          hasMoreContent: result.hasMore == true && _nextCursor != null,
           lastUpdated: DateTime.now(),
         ),
       );
@@ -321,12 +250,22 @@ class ForYouFeed extends _$ForYouFeed {
       getCurrentState: () => state,
       isMounted: () => ref.mounted,
       setState: (s) => state = s,
-      fetchFresh: () => _fetchRecommendations(
-        preserveExistingOnError: true,
-        sessionSeed: generateRecommendationSessionSeed(),
-      ),
+      fetchFresh: () =>
+          _fetchRecommendations(preserveExistingOnError: true, skipCache: true),
     );
   }
+
+  VideoFeedState _stateFromResult(HomeFeedResult result) {
+    _nextCursor = _paginationCursor(result);
+    return VideoFeedState(
+      videos: dedupeByFeedKey(_filterVideos(result.videos)),
+      hasMoreContent: result.hasMore == true && _nextCursor != null,
+      lastUpdated: DateTime.now(),
+    );
+  }
+
+  String? _paginationCursor(HomeFeedResult result) =>
+      result.paginationCursor ?? result.nextCursor?.toString();
 
   List<VideoEvent> _filterVideos(List<VideoEvent> videos) {
     final videoEventService = ref.read(videoEventServiceProvider);

--- a/mobile/lib/providers/for_you_provider.g.dart
+++ b/mobile/lib/providers/for_you_provider.g.dart
@@ -48,7 +48,7 @@ final class ForYouFeedProvider
   ForYouFeed create() => ForYouFeed();
 }
 
-String _$forYouFeedHash() => r'3f25b28d4aef40da7165bfae885c02e35cc3f279';
+String _$forYouFeedHash() => r'08bbffec68f5f887c8efb2f7a51141e96bf70451';
 
 /// For You recommendations feed provider - ML-powered personalized videos
 ///

--- a/mobile/lib/providers/for_you_provider.g.dart
+++ b/mobile/lib/providers/for_you_provider.g.dart
@@ -48,7 +48,7 @@ final class ForYouFeedProvider
   ForYouFeed create() => ForYouFeed();
 }
 
-String _$forYouFeedHash() => r'08bbffec68f5f887c8efb2f7a51141e96bf70451';
+String _$forYouFeedHash() => r'e29f630872b87f296dc29bd8d6795658deeaeace';
 
 /// For You recommendations feed provider - ML-powered personalized videos
 ///

--- a/mobile/lib/providers/for_you_provider.g.dart
+++ b/mobile/lib/providers/for_you_provider.g.dart
@@ -48,7 +48,7 @@ final class ForYouFeedProvider
   ForYouFeed create() => ForYouFeed();
 }
 
-String _$forYouFeedHash() => r'e29f630872b87f296dc29bd8d6795658deeaeace';
+String _$forYouFeedHash() => r'7077f6f95f8d2351ce9544e5c03373bd5f21a244';
 
 /// For You recommendations feed provider - ML-powered personalized videos
 ///

--- a/mobile/lib/providers/video_providers.dart
+++ b/mobile/lib/providers/video_providers.dart
@@ -131,7 +131,6 @@ SeenVideosService seenVideosService(Ref ref) {
   } catch (_) {
     db = null;
   }
-  // ignore: invalid_use_of_visible_for_testing_member
   final service = SeenVideosService(database: db);
   unawaited(service.initialize());
   ref.onDispose(() => unawaited(service.dispose()));

--- a/mobile/lib/services/seen_videos_service.dart
+++ b/mobile/lib/services/seen_videos_service.dart
@@ -86,7 +86,7 @@ class SeenVideoMetrics {
 class SeenVideosService {
   SeenVideosService({
     @visibleForTesting Duration? saveDebounceDuration,
-    @visibleForTesting AppDatabase? database,
+    AppDatabase? database,
     @visibleForTesting SharedPreferences? prefsOverride,
   }) : _saveDebounceDuration =
            saveDebounceDuration ?? const Duration(milliseconds: 100),

--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -2766,16 +2766,13 @@ class VideosRepository {
     if (effectiveUserPubkey == null ||
         _funnelcakeApiClient == null ||
         !_funnelcakeApiClient.isAvailable) {
-      return HomeFeedResult(
-        videos: await _orderBySeenFreshness(
-          await getPopularVideos(
-            limit: limit,
-            until: until,
-            skipCache: skipCache,
-            preferredLanguages: preferredLanguages,
-            viewerCountry: viewerCountry,
-          ),
-        ),
+      return _popularVideosInsteadOfRecommendations(
+        reason: 'recommendations unavailable',
+        limit: limit,
+        until: until,
+        skipCache: skipCache,
+        preferredLanguages: preferredLanguages,
+        viewerCountry: viewerCountry,
       );
     }
 
@@ -2790,18 +2787,15 @@ class VideosRepository {
         preferredLanguages: preferredLanguages,
         viewerCountry: viewerCountry,
       );
-    } on FunnelcakeException {
+    } on FunnelcakeException catch (e) {
       if (recommendationCursor != null) rethrow;
-      return HomeFeedResult(
-        videos: await _orderBySeenFreshness(
-          await getPopularVideos(
-            limit: limit,
-            until: until,
-            skipCache: skipCache,
-            preferredLanguages: preferredLanguages,
-            viewerCountry: viewerCountry,
-          ),
-        ),
+      return _popularVideosInsteadOfRecommendations(
+        reason: 'first page failed: $e',
+        limit: limit,
+        until: until,
+        skipCache: skipCache,
+        preferredLanguages: preferredLanguages,
+        viewerCountry: viewerCountry,
       );
     }
 
@@ -2816,16 +2810,13 @@ class VideosRepository {
     );
 
     if (result.videos.isEmpty) {
-      return HomeFeedResult(
-        videos: await _orderBySeenFreshness(
-          await getPopularVideos(
-            limit: limit,
-            until: until,
-            skipCache: skipCache,
-            preferredLanguages: preferredLanguages,
-            viewerCountry: viewerCountry,
-          ),
-        ),
+      return _popularVideosInsteadOfRecommendations(
+        reason: 'no recommendations survived filtering',
+        limit: limit,
+        until: until,
+        skipCache: skipCache,
+        preferredLanguages: preferredLanguages,
+        viewerCountry: viewerCountry,
       );
     }
 
@@ -2836,6 +2827,37 @@ class VideosRepository {
       _inMemoryFeedCache?.set(cacheKey, result);
     }
     return result;
+  }
+
+  /// Serves popular videos when the For You feed cannot be personalized.
+  ///
+  /// The returned [HomeFeedResult] is indistinguishable from a recommendation
+  /// result at the call site, so the substitution is logged here — otherwise
+  /// nothing records that a viewer saw popular videos under the For You tab.
+  Future<HomeFeedResult> _popularVideosInsteadOfRecommendations({
+    required String reason,
+    required int limit,
+    required int? until,
+    required bool skipCache,
+    required List<String> preferredLanguages,
+    required String? viewerCountry,
+  }) async {
+    Log.warning(
+      'For You falling back to popular videos: $reason',
+      name: 'VideosRepository',
+      category: LogCategory.video,
+    );
+    return HomeFeedResult(
+      videos: await _orderBySeenFreshness(
+        await getPopularVideos(
+          limit: limit,
+          until: until,
+          skipCache: skipCache,
+          preferredLanguages: preferredLanguages,
+          viewerCountry: viewerCountry,
+        ),
+      ),
+    );
   }
 
   Future<RecommendationsResponse> _fetchRecommendationsPage({

--- a/mobile/test/providers/explore_feed_refresh_retention_test.dart
+++ b/mobile/test/providers/explore_feed_refresh_retention_test.dart
@@ -948,6 +948,111 @@ void main() {
     });
 
     test(
+      'for you ignores stale first page results after a newer rebuild',
+      () async {
+        final staleRefreshCompleter = Completer<HomeFeedResult>();
+        final requestedCursors = <String?>[];
+        var requestCount = 0;
+
+        when(
+          () => mockVideosRepository.getRecommendedVideos(
+            userPubkey: any(named: 'userPubkey'),
+            limit: any(named: 'limit'),
+            cursor: any(named: 'cursor'),
+            skipCache: any(named: 'skipCache'),
+            preferredLanguages: any(named: 'preferredLanguages'),
+            viewerCountry: any(named: 'viewerCountry'),
+          ),
+        ).thenAnswer((invocation) {
+          final cursor = invocation.namedArguments[#cursor] as String?;
+          requestedCursors.add(cursor);
+          requestCount += 1;
+
+          if (cursor != null) {
+            return Future.value(
+              _recommendedResult(['for-you-page-2'], hasMore: false),
+            );
+          }
+          if (requestCount == 1) {
+            return Future.value(
+              _recommendedResult(['for-you-initial'], nextCursor: 'cursor-2'),
+            );
+          }
+          if (requestCount == 2) {
+            return staleRefreshCompleter.future;
+          }
+          return Future.value(
+            _recommendedResult(['for-you-rebuilt'], nextCursor: 'cursor-3'),
+          );
+        });
+
+        final container = ProviderContainer(
+          overrides: [
+            sharedPreferencesProvider.overrideWithValue(sharedPreferences),
+            appReadyProvider.overrideWithValue(true),
+            videoEventServiceProvider.overrideWithValue(mockVideoEventService),
+            contentBlocklistRepositoryProvider.overrideWithValue(
+              mockBlocklistRepository,
+            ),
+            videosRepositoryProvider.overrideWithValue(mockVideosRepository),
+            authServiceProvider.overrideWithValue(mockAuthService),
+            funnelcakeAvailableProvider.overrideWith(
+              _AlwaysAvailableFunnelcake.new,
+            ),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        await container.read(funnelcakeAvailableProvider.future);
+        final subscription = container.listen(forYouFeedProvider, (_, _) {});
+        addTearDown(subscription.close);
+
+        final initialState = await container.read(forYouFeedProvider.future);
+        expect(initialState.videos.map((video) => video.id), [
+          'for-you-initial',
+        ]);
+        expect(initialState.hasMoreContent, isTrue);
+
+        final refreshFuture = container
+            .read(forYouFeedProvider.notifier)
+            .refresh();
+        await pumpEventQueue();
+
+        container.read(blocklistVersionProvider.notifier).increment();
+        await pumpEventQueue();
+
+        final rebuiltState = await container.read(forYouFeedProvider.future);
+        expect(rebuiltState.videos.map((video) => video.id), [
+          'for-you-rebuilt',
+        ]);
+
+        staleRefreshCompleter.complete(
+          _recommendedResult([
+            'for-you-stale-refresh',
+          ], nextCursor: 'stale-cursor'),
+        );
+        await refreshFuture;
+        await pumpEventQueue();
+
+        final afterStaleRefresh = container.read(forYouFeedProvider).value;
+        expect(afterStaleRefresh, isNotNull);
+        expect(afterStaleRefresh!.videos.map((video) => video.id), [
+          'for-you-rebuilt',
+        ]);
+
+        await container.read(forYouFeedProvider.notifier).loadMore();
+
+        expect(requestedCursors, [null, null, null, 'cursor-3']);
+        final loadedState = container.read(forYouFeedProvider).value;
+        expect(loadedState, isNotNull);
+        expect(loadedState!.videos.map((video) => video.id), [
+          'for-you-rebuilt',
+          'for-you-page-2',
+        ]);
+      },
+    );
+
+    test(
       'for you keeps loading when a cursor page adds no visible videos',
       () async {
         final requestedCursors = <String?>[];

--- a/mobile/test/providers/explore_feed_refresh_retention_test.dart
+++ b/mobile/test/providers/explore_feed_refresh_retention_test.dart
@@ -285,9 +285,7 @@ void main() {
         final nativeState = await container.read(
           popularVideosFeedProvider.future,
         );
-        expect(nativeState.videos.map((video) => video.id), [
-          'popular-native',
-        ]);
+        expect(nativeState.videos.map((video) => video.id), ['popular-native']);
         expect(
           container.read(popularVideosLoadedVariantProvider),
           PopularVideosVariant.native,
@@ -508,31 +506,24 @@ void main() {
     test(
       'for you keeps existing videos visible while refresh is in flight',
       () async {
-        final refreshCompleter = Completer<RecommendationsResponse>();
-        final requestedSeeds = <String?>[];
+        final refreshCompleter = Completer<HomeFeedResult>();
+        final skipCacheRequests = <bool?>[];
         var requestCount = 0;
 
         when(
-          () => mockFunnelcakeApiClient.getRecommendations(
-            pubkey: any(named: 'pubkey'),
+          () => mockVideosRepository.getRecommendedVideos(
+            userPubkey: any(named: 'userPubkey'),
             limit: any(named: 'limit'),
-            fallback: any(named: 'fallback'),
-            category: any(named: 'category'),
             cursor: any(named: 'cursor'),
-            seed: any(named: 'seed'),
+            skipCache: any(named: 'skipCache'),
             preferredLanguages: any(named: 'preferredLanguages'),
             viewerCountry: any(named: 'viewerCountry'),
           ),
         ).thenAnswer((invocation) {
-          requestedSeeds.add(invocation.namedArguments[#seed] as String?);
+          skipCacheRequests.add(invocation.namedArguments[#skipCache] as bool?);
           requestCount += 1;
           if (requestCount == 1) {
-            return Future.value(
-              RecommendationsResponse(
-                videos: [_videoStats('for-you-initial')],
-                source: 'popular',
-              ),
-            );
+            return Future.value(_recommendedResult(['for-you-initial']));
           }
           return refreshCompleter.future;
         });
@@ -545,9 +536,7 @@ void main() {
             contentBlocklistRepositoryProvider.overrideWithValue(
               mockBlocklistRepository,
             ),
-            funnelcakeApiClientProvider.overrideWithValue(
-              mockFunnelcakeApiClient,
-            ),
+            videosRepositoryProvider.overrideWithValue(mockVideosRepository),
             authServiceProvider.overrideWithValue(mockAuthService),
             funnelcakeAvailableProvider.overrideWith(
               _AlwaysAvailableFunnelcake.new,
@@ -577,12 +566,7 @@ void main() {
         ]);
         expect(refreshingState.isRefreshing, isTrue);
 
-        refreshCompleter.complete(
-          RecommendationsResponse(
-            videos: [_videoStats('for-you-refreshed')],
-            source: 'personalized',
-          ),
-        );
+        refreshCompleter.complete(_recommendedResult(['for-you-refreshed']));
         await refreshFuture;
 
         final finalState = container.read(forYouFeedProvider).value;
@@ -591,45 +575,38 @@ void main() {
           'for-you-refreshed',
         ]);
         expect(finalState.isRefreshing, isFalse);
-        expect(requestedSeeds, hasLength(2));
-        expect(requestedSeeds.first, isNotNull);
-        expect(requestedSeeds.first, isNotEmpty);
-        expect(requestedSeeds.last, isNot(requestedSeeds.first));
+        expect(skipCacheRequests, [false, true]);
       },
     );
 
     test('for you preserves existing pagination when refresh fails', () async {
       var requestCount = 0;
       final requestedCursors = <String?>[];
-      final requestedSeeds = <String?>[];
+      final skipCacheRequests = <bool?>[];
 
       when(
-        () => mockFunnelcakeApiClient.getRecommendations(
-          pubkey: any(named: 'pubkey'),
+        () => mockVideosRepository.getRecommendedVideos(
+          userPubkey: any(named: 'userPubkey'),
           limit: any(named: 'limit'),
-          fallback: any(named: 'fallback'),
-          category: any(named: 'category'),
           cursor: any(named: 'cursor'),
-          seed: any(named: 'seed'),
+          skipCache: any(named: 'skipCache'),
           preferredLanguages: any(named: 'preferredLanguages'),
           viewerCountry: any(named: 'viewerCountry'),
         ),
       ).thenAnswer((invocation) {
         requestedCursors.add(invocation.namedArguments[#cursor] as String?);
-        requestedSeeds.add(invocation.namedArguments[#seed] as String?);
+        skipCacheRequests.add(invocation.namedArguments[#skipCache] as bool?);
         requestCount += 1;
         if (requestCount == 1) {
           return Future.value(
-            _recommendationsResponse([
-              'for-you-initial',
-            ], nextCursor: 'cursor-2'),
+            _recommendedResult(['for-you-initial'], nextCursor: 'cursor-2'),
           );
         }
         if (requestCount == 2) {
           throw StateError('recommendations refresh failed');
         }
         return Future.value(
-          _recommendationsResponse(['for-you-page-2'], nextCursor: 'cursor-3'),
+          _recommendedResult(['for-you-page-2'], nextCursor: 'cursor-3'),
         );
       });
 
@@ -641,9 +618,7 @@ void main() {
           contentBlocklistRepositoryProvider.overrideWithValue(
             mockBlocklistRepository,
           ),
-          funnelcakeApiClientProvider.overrideWithValue(
-            mockFunnelcakeApiClient,
-          ),
+          videosRepositoryProvider.overrideWithValue(mockVideosRepository),
           authServiceProvider.overrideWithValue(mockAuthService),
           funnelcakeAvailableProvider.overrideWith(
             _AlwaysAvailableFunnelcake.new,
@@ -681,45 +656,37 @@ void main() {
       ]);
       expect(loadedState.hasMoreContent, isTrue);
       expect(requestedCursors, [null, null, 'cursor-2']);
-      expect(requestedSeeds, hasLength(3));
-      expect(requestedSeeds[0], isNotNull);
-      expect(requestedSeeds[0], isNotEmpty);
-      expect(requestedSeeds[1], isNot(requestedSeeds[0]));
-      expect(requestedSeeds[2], requestedSeeds[0]);
+      expect(skipCacheRequests, [false, true, false]);
     });
 
     test(
       'for you load more uses recommendation cursor and appends unseen videos',
       () async {
         final requestedCursors = <String?>[];
-        final requestedSeeds = <String?>[];
         var recommendationsCallCount = 0;
 
         when(
-          () => mockFunnelcakeApiClient.getRecommendations(
-            pubkey: any(named: 'pubkey'),
+          () => mockVideosRepository.getRecommendedVideos(
+            userPubkey: any(named: 'userPubkey'),
             limit: any(named: 'limit'),
-            fallback: any(named: 'fallback'),
-            category: any(named: 'category'),
             cursor: any(named: 'cursor'),
-            seed: any(named: 'seed'),
+            skipCache: any(named: 'skipCache'),
             preferredLanguages: any(named: 'preferredLanguages'),
             viewerCountry: any(named: 'viewerCountry'),
           ),
         ).thenAnswer((invocation) {
           requestedCursors.add(invocation.namedArguments[#cursor] as String?);
-          requestedSeeds.add(invocation.namedArguments[#seed] as String?);
           recommendationsCallCount += 1;
           if (recommendationsCallCount == 1) {
             return Future.value(
-              _recommendationsResponse([
+              _recommendedResult([
                 'for-you-a',
                 'for-you-b',
               ], nextCursor: 'cursor-2'),
             );
           }
           return Future.value(
-            _recommendationsResponse([
+            _recommendedResult([
               'for-you-b',
               'for-you-c',
             ], nextCursor: 'cursor-3'),
@@ -734,9 +701,7 @@ void main() {
             contentBlocklistRepositoryProvider.overrideWithValue(
               mockBlocklistRepository,
             ),
-            funnelcakeApiClientProvider.overrideWithValue(
-              mockFunnelcakeApiClient,
-            ),
+            videosRepositoryProvider.overrideWithValue(mockVideosRepository),
             authServiceProvider.overrideWithValue(mockAuthService),
             funnelcakeAvailableProvider.overrideWith(
               _AlwaysAvailableFunnelcake.new,
@@ -767,10 +732,6 @@ void main() {
         ]);
         expect(loadedState.hasMoreContent, isTrue);
         expect(requestedCursors, [null, 'cursor-2']);
-        expect(requestedSeeds, hasLength(2));
-        expect(requestedSeeds.first, isNotNull);
-        expect(requestedSeeds.first, isNotEmpty);
-        expect(requestedSeeds.last, requestedSeeds.first);
       },
     );
 
@@ -778,33 +739,29 @@ void main() {
       'for you collapses a republished coordinate returned twice in one page',
       () async {
         when(
-          () => mockFunnelcakeApiClient.getRecommendations(
-            pubkey: any(named: 'pubkey'),
+          () => mockVideosRepository.getRecommendedVideos(
+            userPubkey: any(named: 'userPubkey'),
             limit: any(named: 'limit'),
-            fallback: any(named: 'fallback'),
-            category: any(named: 'category'),
             cursor: any(named: 'cursor'),
-            seed: any(named: 'seed'),
+            skipCache: any(named: 'skipCache'),
             preferredLanguages: any(named: 'preferredLanguages'),
             viewerCountry: any(named: 'viewerCountry'),
           ),
         ).thenAnswer(
           (_) => Future.value(
-            RecommendationsResponse(
+            HomeFeedResult(
               videos: [
-                _videoStats(
+                _video(
                   'for-you-a',
                   pubkey: 'author-shared',
                   dTag: 'shared-d-tag',
                 ),
-                _videoStats(
+                _video(
                   'for-you-b',
                   pubkey: 'author-shared',
                   dTag: 'shared-d-tag',
                 ),
               ],
-              source: 'personalized',
-              nextCursor: 'cursor-2',
             ),
           ),
         );
@@ -817,9 +774,7 @@ void main() {
             contentBlocklistRepositoryProvider.overrideWithValue(
               mockBlocklistRepository,
             ),
-            funnelcakeApiClientProvider.overrideWithValue(
-              mockFunnelcakeApiClient,
-            ),
+            videosRepositoryProvider.overrideWithValue(mockVideosRepository),
             authServiceProvider.overrideWithValue(mockAuthService),
             funnelcakeAvailableProvider.overrideWith(
               _AlwaysAvailableFunnelcake.new,
@@ -838,33 +793,42 @@ void main() {
     );
 
     test(
-      'for you load more keeps cursor and seed paired across rebuilds',
+      'for you uses repository deep-fetch when the first page is all seen',
       () async {
-        final geoCompleter = Completer<GeoBlockResponse>();
-        final requests = <({String? cursor, String? seed})>[];
-
+        when(() => mockFunnelcakeApiClient.isAvailable).thenReturn(true);
+        when(() => mockNostrClient.publicKey).thenReturn('');
         when(
           () => mockFunnelcakeApiClient.getRecommendations(
             pubkey: any(named: 'pubkey'),
             limit: any(named: 'limit'),
-            fallback: any(named: 'fallback'),
-            category: any(named: 'category'),
-            cursor: any(named: 'cursor'),
             seed: any(named: 'seed'),
             preferredLanguages: any(named: 'preferredLanguages'),
             viewerCountry: any(named: 'viewerCountry'),
           ),
-        ).thenAnswer((invocation) {
-          final cursor = invocation.namedArguments[#cursor] as String?;
-          final seed = invocation.namedArguments[#seed] as String?;
-          requests.add((cursor: cursor, seed: seed));
-          return Future.value(
-            _recommendationsResponse(
-              cursor == null ? ['for-you-rebuilt'] : ['for-you-page-2'],
-              nextCursor: cursor == null ? 'cursor-2' : 'cursor-3',
-            ),
-          );
-        });
+        ).thenAnswer(
+          (_) async => _recommendationsResponse([
+            'for-you-seen',
+          ], nextCursor: 'cursor-2'),
+        );
+        when(
+          () => mockFunnelcakeApiClient.getRecommendations(
+            pubkey: any(named: 'pubkey'),
+            limit: any(named: 'limit'),
+            cursor: 'cursor-2',
+            seed: any(named: 'seed'),
+            preferredLanguages: any(named: 'preferredLanguages'),
+            viewerCountry: any(named: 'viewerCountry'),
+          ),
+        ).thenAnswer((_) async => _recommendationsResponse(['for-you-fresh']));
+
+        final repository = VideosRepository(
+          nostrClient: mockNostrClient,
+          funnelcakeApiClient: mockFunnelcakeApiClient,
+          seenVideoLookup: SeenVideoLookup(
+            wasSeenRecently: (id, {within = const Duration(hours: 24)}) =>
+                id == 'for-you-seen',
+          ),
+        );
 
         final container = ProviderContainer(
           overrides: [
@@ -874,15 +838,10 @@ void main() {
             contentBlocklistRepositoryProvider.overrideWithValue(
               mockBlocklistRepository,
             ),
-            funnelcakeApiClientProvider.overrideWithValue(
-              mockFunnelcakeApiClient,
-            ),
+            videosRepositoryProvider.overrideWithValue(repository),
             authServiceProvider.overrideWithValue(mockAuthService),
             funnelcakeAvailableProvider.overrideWith(
               _AlwaysAvailableFunnelcake.new,
-            ),
-            geoBlockingServiceProvider.overrideWithValue(
-              _DelayedSecondGeoBlockingService(geoCompleter),
             ),
           ],
         );
@@ -892,79 +851,123 @@ void main() {
         final subscription = container.listen(forYouFeedProvider, (_, _) {});
         addTearDown(subscription.close);
 
-        final initialState = await container.read(forYouFeedProvider.future);
-        expect(initialState.hasMoreContent, isTrue);
-        expect(requests, hasLength(1));
-        final firstPageSeed = requests.single.seed;
-        expect(firstPageSeed, isNotNull);
-        expect(firstPageSeed, isNotEmpty);
-
-        final loadMoreFuture = container
-            .read(forYouFeedProvider.notifier)
-            .loadMore();
-        await pumpEventQueue();
-
-        container.read(blocklistVersionProvider.notifier).increment();
-        await pumpEventQueue();
-
-        geoCompleter.complete(_geoResponse());
-        await loadMoreFuture;
-        await pumpEventQueue();
-
-        final rebuiltFirstPageSeed = requests
-            .lastWhere(
-              (request) => request.cursor == null,
-            )
-            .seed;
-        expect(rebuiltFirstPageSeed, isNot(firstPageSeed));
-
-        final staleCursorPageRequest = requests.singleWhere(
-          (request) => request.cursor == 'cursor-2',
-        );
-        expect(staleCursorPageRequest.seed, firstPageSeed);
-
-        await container.read(forYouFeedProvider.notifier).loadMore();
-
-        final cursorPageRequests = requests
-            .where((request) => request.cursor == 'cursor-2')
-            .toList();
-        expect(cursorPageRequests, hasLength(2));
-        expect(cursorPageRequests.last.seed, rebuiltFirstPageSeed);
-
-        final loadedState = container.read(forYouFeedProvider).value;
-        expect(loadedState, isNotNull);
-        expect(loadedState!.videos.map((video) => video.id), [
-          'for-you-rebuilt',
-          'for-you-page-2',
+        final state = await container.read(forYouFeedProvider.future);
+        expect(state.videos.map((video) => video.id), [
+          'for-you-fresh',
+          'for-you-seen',
         ]);
+        verify(
+          () => mockFunnelcakeApiClient.getRecommendations(
+            pubkey: 'viewer-pubkey',
+            limit: 50,
+            cursor: 'cursor-2',
+            seed: any(named: 'seed'),
+            preferredLanguages: any(named: 'preferredLanguages'),
+            viewerCountry: any(named: 'viewerCountry'),
+          ),
+        ).called(1);
       },
     );
+
+    test('for you discards stale cursor pages across rebuilds', () async {
+      final geoCompleter = Completer<GeoBlockResponse>();
+      final requests = <String?>[];
+
+      when(
+        () => mockVideosRepository.getRecommendedVideos(
+          userPubkey: any(named: 'userPubkey'),
+          limit: any(named: 'limit'),
+          cursor: any(named: 'cursor'),
+          skipCache: any(named: 'skipCache'),
+          preferredLanguages: any(named: 'preferredLanguages'),
+          viewerCountry: any(named: 'viewerCountry'),
+        ),
+      ).thenAnswer((invocation) {
+        final cursor = invocation.namedArguments[#cursor] as String?;
+        requests.add(cursor);
+        return Future.value(
+          _recommendedResult(
+            cursor == null ? ['for-you-rebuilt'] : ['for-you-page-2'],
+            nextCursor: cursor == null ? 'cursor-2' : 'cursor-3',
+          ),
+        );
+      });
+
+      final container = ProviderContainer(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(sharedPreferences),
+          appReadyProvider.overrideWithValue(true),
+          videoEventServiceProvider.overrideWithValue(mockVideoEventService),
+          contentBlocklistRepositoryProvider.overrideWithValue(
+            mockBlocklistRepository,
+          ),
+          videosRepositoryProvider.overrideWithValue(mockVideosRepository),
+          authServiceProvider.overrideWithValue(mockAuthService),
+          funnelcakeAvailableProvider.overrideWith(
+            _AlwaysAvailableFunnelcake.new,
+          ),
+          geoBlockingServiceProvider.overrideWithValue(
+            _DelayedSecondGeoBlockingService(geoCompleter),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await container.read(funnelcakeAvailableProvider.future);
+      final subscription = container.listen(forYouFeedProvider, (_, _) {});
+      addTearDown(subscription.close);
+
+      final initialState = await container.read(forYouFeedProvider.future);
+      expect(initialState.hasMoreContent, isTrue);
+      expect(requests, [null]);
+
+      final loadMoreFuture = container
+          .read(forYouFeedProvider.notifier)
+          .loadMore();
+      await pumpEventQueue();
+
+      container.read(blocklistVersionProvider.notifier).increment();
+      await pumpEventQueue();
+
+      geoCompleter.complete(_geoResponse());
+      await loadMoreFuture;
+      await pumpEventQueue();
+
+      expect(requests, [null, null, 'cursor-2']);
+
+      await container.read(forYouFeedProvider.notifier).loadMore();
+
+      expect(requests, [null, null, 'cursor-2', 'cursor-2']);
+
+      final loadedState = container.read(forYouFeedProvider).value;
+      expect(loadedState, isNotNull);
+      expect(loadedState!.videos.map((video) => video.id), [
+        'for-you-rebuilt',
+        'for-you-page-2',
+      ]);
+    });
 
     test(
       'for you keeps loading when a cursor page adds no visible videos',
       () async {
         final requestedCursors = <String?>[];
-        final requestedSeeds = <String?>[];
         var recommendationsCallCount = 0;
 
         when(
-          () => mockFunnelcakeApiClient.getRecommendations(
-            pubkey: any(named: 'pubkey'),
+          () => mockVideosRepository.getRecommendedVideos(
+            userPubkey: any(named: 'userPubkey'),
             limit: any(named: 'limit'),
-            fallback: any(named: 'fallback'),
-            category: any(named: 'category'),
             cursor: any(named: 'cursor'),
-            seed: any(named: 'seed'),
+            skipCache: any(named: 'skipCache'),
             preferredLanguages: any(named: 'preferredLanguages'),
             viewerCountry: any(named: 'viewerCountry'),
           ),
         ).thenAnswer((invocation) {
           requestedCursors.add(invocation.namedArguments[#cursor] as String?);
-          requestedSeeds.add(invocation.namedArguments[#seed] as String?);
           recommendationsCallCount += 1;
           if (recommendationsCallCount == 1) {
             return Future.value(
-              _recommendationsResponse([
+              _recommendedResult([
                 'for-you-a',
                 'for-you-b',
               ], nextCursor: 'cursor-2'),
@@ -972,14 +975,14 @@ void main() {
           }
           if (recommendationsCallCount == 2) {
             return Future.value(
-              _recommendationsResponse([
+              _recommendedResult([
                 'FOR-YOU-A',
                 'for-you-b',
               ], nextCursor: 'cursor-3'),
             );
           }
           return Future.value(
-            _recommendationsResponse(
+            _recommendedResult(
               ['for-you-c'],
               nextCursor: 'cursor-4',
               hasMore: false,
@@ -995,9 +998,7 @@ void main() {
             contentBlocklistRepositoryProvider.overrideWithValue(
               mockBlocklistRepository,
             ),
-            funnelcakeApiClientProvider.overrideWithValue(
-              mockFunnelcakeApiClient,
-            ),
+            videosRepositoryProvider.overrideWithValue(mockVideosRepository),
             authServiceProvider.overrideWithValue(mockAuthService),
             funnelcakeAvailableProvider.overrideWith(
               _AlwaysAvailableFunnelcake.new,
@@ -1038,9 +1039,6 @@ void main() {
         ]);
         expect(nextPageState.hasMoreContent, isFalse);
         expect(requestedCursors, [null, 'cursor-2', 'cursor-3']);
-        expect(requestedSeeds, hasLength(3));
-        expect(requestedSeeds.toSet(), hasLength(1));
-        expect(requestedSeeds.first, isNotEmpty);
       },
     );
 
@@ -1050,19 +1048,17 @@ void main() {
         var recommendationsCallCount = 0;
 
         when(
-          () => mockFunnelcakeApiClient.getRecommendations(
-            pubkey: any(named: 'pubkey'),
+          () => mockVideosRepository.getRecommendedVideos(
+            userPubkey: any(named: 'userPubkey'),
             limit: any(named: 'limit'),
-            fallback: any(named: 'fallback'),
-            category: any(named: 'category'),
             cursor: any(named: 'cursor'),
-            seed: any(named: 'seed'),
+            skipCache: any(named: 'skipCache'),
             preferredLanguages: any(named: 'preferredLanguages'),
             viewerCountry: any(named: 'viewerCountry'),
           ),
         ).thenAnswer((_) {
           recommendationsCallCount += 1;
-          return Future.value(_recommendationsResponse(['for-you-legacy']));
+          return Future.value(_recommendedResult(['for-you-legacy']));
         });
 
         final container = ProviderContainer(
@@ -1073,9 +1069,7 @@ void main() {
             contentBlocklistRepositoryProvider.overrideWithValue(
               mockBlocklistRepository,
             ),
-            funnelcakeApiClientProvider.overrideWithValue(
-              mockFunnelcakeApiClient,
-            ),
+            videosRepositoryProvider.overrideWithValue(mockVideosRepository),
             authServiceProvider.overrideWithValue(mockAuthService),
             funnelcakeAvailableProvider.overrideWith(
               _AlwaysAvailableFunnelcake.new,
@@ -1121,6 +1115,18 @@ RecommendationsResponse _recommendationsResponse(
   );
 }
 
+HomeFeedResult _recommendedResult(
+  List<String> ids, {
+  String? nextCursor,
+  bool hasMore = true,
+}) {
+  return HomeFeedResult(
+    videos: ids.map(_video).toList(),
+    paginationCursor: nextCursor,
+    hasMore: hasMore,
+  );
+}
+
 GeoBlockResponse _geoResponse() {
   return GeoBlockResponse(
     blocked: false,
@@ -1144,6 +1150,8 @@ PopularVideosPage _popularPage(
 
 VideoEvent _video(
   String id, {
+  String? pubkey,
+  String? dTag,
   int createdAt = 1_742_169_600,
   Map<String, String> rawTags = const {
     'd': 'seed',
@@ -1154,13 +1162,14 @@ VideoEvent _video(
 }) {
   return VideoEvent(
     id: id,
-    pubkey: 'author-$id',
+    pubkey: pubkey ?? 'author-$id',
     createdAt: createdAt,
     content: 'video $id',
     timestamp: DateTime.fromMillisecondsSinceEpoch(createdAt * 1000),
     videoUrl: 'https://example.com/$id.mp4',
     thumbnailUrl: 'https://example.com/$id.jpg',
-    rawTags: rawTags,
+    rawTags: dTag == null ? rawTags : {...rawTags, 'd': dTag},
+    addressableDTag: dTag,
     originalLoops: AppConstants.paginationBatchSize,
   );
 }


### PR DESCRIPTION
## Summary
- Route Explore For You recommendation fetches through VideosRepository so the repository-owned seen-video deep-fetch path applies on cold start and refresh.
- Keep provider-level filtering/deduping and replace seed pairing with a generation guard for stale cursor and first-page responses.
- Make SeenVideosService database injection a normal app constructor path and remove the stale lint suppression.

## Behavior notes
- For You now falls back to Popular videos when recommendations are unavailable or fully filtered; that fallback is intentionally a single non-paginating page.
- For You keeps the cached first recommendation page across rebuilds. Cold start and pull-to-refresh fetch fresh recommendations; ordinary rebuilds reuse the cached page and reapply filtering/seen-freshness ordering.

Fixes #7456

## Verification
- flutter test test/providers/explore_feed_refresh_retention_test.dart
- flutter test packages/videos_repository/test/src/videos_repository_seen_filtering_test.dart
- flutter analyze
- pre-push hook: analyzer, generated files, changed-file tests
