### PR TITLE
fix(notifications): render the feed before the mark-all write settles

### DIFF
--- a/mobile/lib/notifications/bloc/notification_feed_bloc.dart
+++ b/mobile/lib/notifications/bloc/notification_feed_bloc.dart
@@ -143,7 +143,7 @@ class NotificationFeedBloc
   /// the initial spinner and error states.
   ///
   /// After a successful refresh, sends the server mark-all write via
-  /// [_markSeen] so opening the notifications surface clears the unread
+  /// [_markSeenOnOpen] so opening the notifications surface clears the unread
   /// badge and the badge thereafter reflects "new since last seen" rather than
   /// the accumulated untapped total (#4708). `_onStarted` fires once per open
   /// (it is dispatched from the keyed `BlocProvider.create` on every mount of

--- a/mobile/lib/notifications/bloc/notification_feed_bloc.dart
+++ b/mobile/lib/notifications/bloc/notification_feed_bloc.dart
@@ -348,6 +348,9 @@ class NotificationFeedBloc
     NotificationFeedRefreshed event,
     Emitter<NotificationFeedState> emit,
   ) async {
+    // Started and Refreshed have separate droppable transformers, so guard the
+    // shared busy state explicitly to prevent the two handlers overlapping.
+    if (state.isRefreshing) return;
     _emptyPageContinuations = 0;
     _loadMoreFailed = false;
     _emptyPageContinuationPending = false;

--- a/mobile/lib/notifications/bloc/notification_feed_bloc.dart
+++ b/mobile/lib/notifications/bloc/notification_feed_bloc.dart
@@ -166,6 +166,13 @@ class NotificationFeedBloc
       await _notificationRepository.refreshFeed(_filter);
       var markSucceeded = false;
       if (_filter == null) {
+        // `loaded` is what dismisses the cold-start full-screen spinner, and
+        // it has to land with the data: holding it across the mark-all write
+        // blanks an empty inbox for the whole sign + POST (15s client
+        // timeout). `isRefreshing` stays up instead, because the revalidation
+        // bar has to span the droppable handler's drop window so a second
+        // pull is never dropped against an idle-looking UI.
+        emit(state.copyWith(status: NotificationFeedStatus.loaded));
         markSucceeded = await _markSeenOnOpen();
       }
       emit(
@@ -348,6 +355,11 @@ class NotificationFeedBloc
     try {
       await _notificationRepository.refreshFeed(_filter);
       if (_filter == null) {
+        // Same split as `_onStarted`, and it also matters here: a retry
+        // dispatched from `_FailureBody` leaves `status: failure` until this
+        // emit, so holding it would keep the error screen up over a refresh
+        // that already succeeded.
+        emit(state.copyWith(status: NotificationFeedStatus.loaded));
         await _markSeenOnOpen();
       }
       emit(

--- a/mobile/lib/notifications/bloc/reportable_sites.dart
+++ b/mobile/lib/notifications/bloc/reportable_sites.dart
@@ -17,7 +17,7 @@ abstract class NotificationFeedBlocReportableSites {
   /// `_fetchWithRetry` if the analyzer's loop invariant ever breaks.
   static const String onStarted = '_onStarted';
 
-  /// `_markSeen` generic-catch arm — `Error` types that escape
+  /// `_markSeenOnOpen` generic-catch arm — `Error` types that escape
   /// `NotificationRepository.markAllAsRead`'s rollback `catch (_)` rethrow
   /// when the notifications surface sends the server mark-all write.
   /// Realistically a Drift DAO `TypeError` from a row-shape mismatch.

--- a/mobile/test/notifications/bloc/notification_feed_bloc_test.dart
+++ b/mobile/test/notifications/bloc/notification_feed_bloc_test.dart
@@ -284,6 +284,42 @@ void main() {
         expect(bloc.state.isRefreshing, isFalse);
       });
 
+      test(
+        'drops refresh events while the initial mark-all is pending',
+        () async {
+          final markCompleter = Completer<void>();
+          when(
+            () => mockNotificationRepo.markAllAsRead(),
+          ).thenAnswer((_) => markCompleter.future);
+
+          final bloc = createBloc();
+          addTearDown(bloc.close);
+
+          bloc.add(NotificationFeedStarted());
+          await Future<void>.delayed(Duration.zero);
+
+          bloc.add(NotificationFeedRefreshed());
+          await Future<void>.delayed(Duration.zero);
+
+          verify(() => mockNotificationRepo.refreshFeed(null)).called(1);
+          verify(() => mockNotificationRepo.markAllAsRead()).called(1);
+          expect(bloc.state.isRefreshing, isTrue);
+
+          markCompleter.complete();
+          await Future<void>.delayed(Duration.zero);
+
+          when(
+            () => mockNotificationRepo.markAllAsRead(),
+          ).thenAnswer((_) async {});
+          bloc.add(NotificationFeedRefreshed());
+          await Future<void>.delayed(Duration.zero);
+
+          verify(() => mockNotificationRepo.refreshFeed(null)).called(1);
+          verify(() => mockNotificationRepo.markAllAsRead()).called(1);
+          expect(bloc.state.isRefreshing, isFalse);
+        },
+      );
+
       blocTest<NotificationFeedBloc, NotificationFeedState>(
         'clears the platform app badge after successful unfiltered open',
         build: () => createBloc(appBadgeClearer: mockAppBadgeClearer),

--- a/mobile/test/notifications/bloc/notification_feed_bloc_test.dart
+++ b/mobile/test/notifications/bloc/notification_feed_bloc_test.dart
@@ -262,8 +262,9 @@ void main() {
         bloc.add(NotificationFeedStarted());
         await Future<void>.delayed(Duration.zero);
         // Empty inbox: the repository emits an empty page from inside
-        // `refreshFeed`, so `notifications` stays empty and the view falls
-        // through to the `status == initial` full-screen spinner branch.
+        // `refreshFeed`, so `notifications` stays empty. This is the case
+        // that would fall through to the full-screen spinner branch if
+        // `loaded` were held across the mark-all write.
         snapshotController.add(NotificationPage.empty);
         await Future<void>.delayed(Duration.zero);
 
@@ -805,16 +806,13 @@ void main() {
         // Refresh resolved, mark-all still pending: content is renderable
         // (`loaded` dismisses the cold-start spinner) but the revalidation bar
         // is still up, because this is the droppable handler's drop window.
-        expect(
-          states,
-          [
-            NotificationFeedState(isRefreshing: true),
-            NotificationFeedState(
-              status: NotificationFeedStatus.loaded,
-              isRefreshing: true,
-            ),
-          ],
-        );
+        expect(states, [
+          NotificationFeedState(isRefreshing: true),
+          NotificationFeedState(
+            status: NotificationFeedStatus.loaded,
+            isRefreshing: true,
+          ),
+        ]);
 
         bloc.add(NotificationFeedRefreshed());
         await Future<void>.delayed(Duration.zero);
@@ -823,17 +821,14 @@ void main() {
         markCompleter.complete();
         await Future<void>.delayed(Duration.zero);
 
-        expect(
-          states,
-          [
-            NotificationFeedState(isRefreshing: true),
-            NotificationFeedState(
-              status: NotificationFeedStatus.loaded,
-              isRefreshing: true,
-            ),
-            NotificationFeedState(status: NotificationFeedStatus.loaded),
-          ],
-        );
+        expect(states, [
+          NotificationFeedState(isRefreshing: true),
+          NotificationFeedState(
+            status: NotificationFeedStatus.loaded,
+            isRefreshing: true,
+          ),
+          NotificationFeedState(status: NotificationFeedStatus.loaded),
+        ]);
         verify(() => mockNotificationRepo.markAllAsRead()).called(1);
       });
 

--- a/mobile/test/notifications/bloc/notification_feed_bloc_test.dart
+++ b/mobile/test/notifications/bloc/notification_feed_bloc_test.dart
@@ -397,6 +397,10 @@ void main() {
         wait: const Duration(milliseconds: 1),
         expect: () => [
           NotificationFeedState(isRefreshing: true),
+          NotificationFeedState(
+            isRefreshing: true,
+            status: NotificationFeedStatus.loaded,
+          ),
           NotificationFeedState(status: NotificationFeedStatus.loaded),
         ],
         errors: () => [

--- a/mobile/test/notifications/bloc/notification_feed_bloc_test.dart
+++ b/mobile/test/notifications/bloc/notification_feed_bloc_test.dart
@@ -231,6 +231,12 @@ void main() {
         act: (bloc) => bloc.add(NotificationFeedStarted()),
         expect: () => [
           NotificationFeedState(isRefreshing: true),
+          // `loaded` lands with the data, before the mark-all write, so the
+          // cold-start spinner is not held open across the POST.
+          NotificationFeedState(
+            isRefreshing: true,
+            status: NotificationFeedStatus.loaded,
+          ),
           NotificationFeedState(status: NotificationFeedStatus.loaded),
         ],
         verify: (_) {
@@ -243,6 +249,40 @@ void main() {
         },
       );
 
+      test('drops the cold-start spinner before the mark-all write '
+          'settles', () async {
+        final markCompleter = Completer<void>();
+        when(
+          () => mockNotificationRepo.markAllAsRead(),
+        ).thenAnswer((_) => markCompleter.future);
+
+        final bloc = createBloc();
+        addTearDown(bloc.close);
+
+        bloc.add(NotificationFeedStarted());
+        await Future<void>.delayed(Duration.zero);
+        // Empty inbox: the repository emits an empty page from inside
+        // `refreshFeed`, so `notifications` stays empty and the view falls
+        // through to the `status == initial` full-screen spinner branch.
+        snapshotController.add(NotificationPage.empty);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(bloc.state.notifications, isEmpty);
+        expect(
+          bloc.state.status,
+          NotificationFeedStatus.loaded,
+          reason:
+              'empty state renders instead of a spinner held open for the '
+              'duration of the mark-all POST',
+        );
+        expect(bloc.state.isRefreshing, isTrue);
+
+        markCompleter.complete();
+        await Future<void>.delayed(Duration.zero);
+
+        expect(bloc.state.isRefreshing, isFalse);
+      });
+
       blocTest<NotificationFeedBloc, NotificationFeedState>(
         'clears the platform app badge after successful unfiltered open',
         build: () => createBloc(appBadgeClearer: mockAppBadgeClearer),
@@ -250,6 +290,10 @@ void main() {
         wait: const Duration(milliseconds: 1),
         expect: () => [
           NotificationFeedState(isRefreshing: true),
+          NotificationFeedState(
+            isRefreshing: true,
+            status: NotificationFeedStatus.loaded,
+          ),
           NotificationFeedState(status: NotificationFeedStatus.loaded),
         ],
         verify: (_) {
@@ -291,6 +335,10 @@ void main() {
         wait: const Duration(milliseconds: 1),
         expect: () => [
           NotificationFeedState(isRefreshing: true),
+          NotificationFeedState(
+            isRefreshing: true,
+            status: NotificationFeedStatus.loaded,
+          ),
           NotificationFeedState(status: NotificationFeedStatus.loaded),
         ],
         errors: () => [allOf(isA<Exception>(), isNot(isA<ReportableError>()))],
@@ -340,6 +388,10 @@ void main() {
         act: (bloc) => bloc.add(NotificationFeedStarted()),
         expect: () => [
           NotificationFeedState(isRefreshing: true),
+          NotificationFeedState(
+            isRefreshing: true,
+            status: NotificationFeedStatus.loaded,
+          ),
           NotificationFeedState(status: NotificationFeedStatus.loaded),
         ],
         errors: () => [isA<Exception>()],
@@ -365,6 +417,10 @@ void main() {
         act: (bloc) => bloc.add(NotificationFeedStarted()),
         expect: () => [
           NotificationFeedState(isRefreshing: true),
+          NotificationFeedState(
+            isRefreshing: true,
+            status: NotificationFeedStatus.loaded,
+          ),
           NotificationFeedState(status: NotificationFeedStatus.loaded),
         ],
         errors: () => [
@@ -714,6 +770,13 @@ void main() {
             status: NotificationFeedStatus.failure,
             isRefreshing: true,
           ),
+          // A retry dispatched from `_FailureBody` leaves `failure` as soon as
+          // the refresh succeeds, rather than holding the error screen up
+          // across the mark-all write.
+          NotificationFeedState(
+            status: NotificationFeedStatus.loaded,
+            isRefreshing: true,
+          ),
           NotificationFeedState(status: NotificationFeedStatus.loaded),
         ],
         verify: (_) {
@@ -739,9 +802,18 @@ void main() {
         bloc.add(NotificationFeedRefreshed());
         await Future<void>.delayed(Duration.zero);
 
+        // Refresh resolved, mark-all still pending: content is renderable
+        // (`loaded` dismisses the cold-start spinner) but the revalidation bar
+        // is still up, because this is the droppable handler's drop window.
         expect(
           states,
-          [NotificationFeedState(isRefreshing: true)],
+          [
+            NotificationFeedState(isRefreshing: true),
+            NotificationFeedState(
+              status: NotificationFeedStatus.loaded,
+              isRefreshing: true,
+            ),
+          ],
         );
 
         bloc.add(NotificationFeedRefreshed());
@@ -755,6 +827,10 @@ void main() {
           states,
           [
             NotificationFeedState(isRefreshing: true),
+            NotificationFeedState(
+              status: NotificationFeedStatus.loaded,
+              isRefreshing: true,
+            ),
             NotificationFeedState(status: NotificationFeedStatus.loaded),
           ],
         );


### PR DESCRIPTION
Closes #7498

## Summary

Follow-up to #7421. That PR moved the `status: loaded` / `isRefreshing: false` emit in `_onStarted` and `_onRefreshed` behind the mark-all write, so the visible busy state would span the `droppable()` handler's drop window. The drop-window part is right and stays.

The side effect is that `loaded` is also the flag that dismisses the cold-start full-screen spinner (`notifications_view.dart:144`, reached only when `notifications.isEmpty`), and the flag that dismisses `_FailureBody`. Holding it across the mark-all write means:

- **Empty inbox, cold open** — blank full-screen spinner for the whole NIP-98 sign + POST rather than the empty state. Worst case is the `FunnelcakeApiClient` 15s timeout, and the sign is a NIP-46 round trip for a Keycast identity. There is nothing to mark read in this case; the user is waiting on a write that exists only to advance the server marker.
- **Retry from `_FailureBody`** — the error screen stays up over a refresh that already succeeded, for the same window.

Both are new as of `bbe2786a3d`; before it, the emit came first and the content rendered as soon as `refreshFeed` returned.

## Fix

Split the emit: `loaded` lands with the data, `isRefreshing` stays true across the write. The revalidation bar (`_RevalidationBar(visible: state.isRefreshing)`, present in both the list and empty-state branches) still covers the entire drop window, so the #7421 behavior is preserved — a second pull is still visibly busy rather than silently dropped.

Only the unfiltered path emits the intermediate state, since only it sends the mark-all write. Filtered tabs keep the single emit and their existing state sequences.

## Also here

`5c84c4baa` renamed `_markSeenOnOpen` to `_markSeen` in two doc comments only — the declaration, both call sites, and the `NotificationFeedBlocReportableSites.markSeenOnOpen` constant all still carry the old name, so `[_markSeen]` is a dartdoc link to nothing. Pointed the comments back at the real symbol. If the rename is still wanted, it needs the declaration, both call sites, and a decision about whether the `context:` string moves with it — leaving that to @NotThatKindOfDrLiz rather than inferring it.

## Verification

- `cd mobile && flutter test test/notifications test/screens/notification_settings_screen_test.dart` — 242 pass
- `cd mobile && flutter analyze lib test integration_test` — clean
- New test `drops the cold-start spinner before the mark-all write settles` fails on current `main` with `Expected loaded / Actual initial`, passes here.
- Seven existing exact-sequence tests gained the intermediate state; each still pins what it pinned. The seventh is `wraps unexpected Error from the app badge clear as Reportable without blackening the feed`, which arrived on `main` via #7447 after this branch's base and was picked up on the rebase. `keeps refresh visible while mark seen is pending` additionally now asserts the busy flag is up *and* the content is renderable while a second refresh is dropped.
