### PR TITLE
fix(relay): Fix race condition in relay ledger loading during pre-init

### DIFF
--- a/mobile/lib/providers/nostr_client_provider.dart
+++ b/mobile/lib/providers/nostr_client_provider.dart
@@ -405,10 +405,9 @@ class NostrService extends _$NostrService {
     try {
       await (() async {
         if (userRelayUrls.isNotEmpty) {
-          // Warm the user-removal ledger once, so the per-relay suppression
-          // checks below don't each race the same storage read. addRelays()
-          // awaits the same load internally, so this is ordering, not a
-          // correctness gate.
+          // Loads the user-removal ledger up front. addRelays() awaits the
+          // same idempotent load on its first relay, so this moves when the
+          // storage read happens, not whether removed relays are suppressed.
           await client.ensureUserRemovedRelaysLoaded();
           final addedRelayCount = await client.addRelays(userRelayUrls);
           Log.info(

--- a/mobile/lib/providers/nostr_client_provider.dart
+++ b/mobile/lib/providers/nostr_client_provider.dart
@@ -405,7 +405,10 @@ class NostrService extends _$NostrService {
     try {
       await (() async {
         if (userRelayUrls.isNotEmpty) {
-          // Ensure user-removal ledger is loaded before adding relays
+          // Warm the user-removal ledger once, so the per-relay suppression
+          // checks below don't each race the same storage read. addRelays()
+          // awaits the same load internally, so this is ordering, not a
+          // correctness gate.
           await client.ensureUserRemovedRelaysLoaded();
           final addedRelayCount = await client.addRelays(userRelayUrls);
           Log.info(

--- a/mobile/lib/providers/nostr_client_provider.dart
+++ b/mobile/lib/providers/nostr_client_provider.dart
@@ -405,6 +405,8 @@ class NostrService extends _$NostrService {
     try {
       await (() async {
         if (userRelayUrls.isNotEmpty) {
+          // Ensure user-removal ledger is loaded before adding relays
+          await client.ensureUserRemovedRelaysLoaded();
           final addedRelayCount = await client.addRelays(userRelayUrls);
           Log.info(
             '[NostrService] Initialization stage completed: source=$source, '

--- a/mobile/lib/providers/nostr_client_provider.g.dart
+++ b/mobile/lib/providers/nostr_client_provider.g.dart
@@ -109,7 +109,7 @@ final class NostrServiceProvider
   }
 }
 
-String _$nostrServiceHash() => r'eadbbe3f376aa1b94a263bbd724397146bdd7178';
+String _$nostrServiceHash() => r'be0862ba9cb359ab09c27336de1efc0e477c7f71';
 
 /// Core Nostr service via NostrClient for relay communication
 /// Uses a Notifier to react to auth state changes and recreate the client

--- a/mobile/packages/nostr_client/lib/src/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/src/nostr_client.dart
@@ -540,6 +540,14 @@ class NostrClient {
   /// Returns true if the relay manager is initialized
   bool get isInitialized => _relayManager.isInitialized;
 
+  /// Ensure the user-removal intent ledger has been loaded from storage.
+  ///
+  /// This delegates to the relay manager's ledger loading. Designed for
+  /// eager loading before initialize() to ensure that pre-init addRelay()
+  /// calls can properly suppress user-removed relays.
+  Future<void> ensureUserRemovedRelaysLoaded() =>
+      _relayManager.ensureUserRemovedRelaysLoaded();
+
   /// Whether the client has been disposed
   ///
   /// After disposal, the client should not be used
@@ -926,10 +934,7 @@ class NostrClient {
       // their having nothing. A display read is content to fall back on cache;
       // a full-settlement caller is about to replace what it read, so it gets
       // the same inconclusive answer a relay that never settled would give.
-      websocketResult = (
-        events: <Event>[],
-        timedOut: requireAllRelaysSettled,
-      );
+      websocketResult = (events: <Event>[], timedOut: requireAllRelaysSettled);
     } else {
       websocketResult = useQueryPool
           ? await _queryPool.withResource(runWebSocketQuery)

--- a/mobile/packages/nostr_client/lib/src/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/src/nostr_client.dart
@@ -542,9 +542,9 @@ class NostrClient {
 
   /// Ensure the user-removal intent ledger has been loaded from storage.
   ///
-  /// This delegates to the relay manager's ledger loading. Designed for
-  /// eager loading before initialize() to ensure that pre-init addRelay()
-  /// calls can properly suppress user-removed relays.
+  /// Delegates to [RelayManager.ensureUserRemovedRelaysLoaded]. See that
+  /// method for when a caller needs this: [addRelay], [addRelays] and
+  /// [initialize] already load the ledger themselves.
   Future<void> ensureUserRemovedRelaysLoaded() =>
       _relayManager.ensureUserRemovedRelaysLoaded();
 
@@ -934,7 +934,10 @@ class NostrClient {
       // their having nothing. A display read is content to fall back on cache;
       // a full-settlement caller is about to replace what it read, so it gets
       // the same inconclusive answer a relay that never settled would give.
-      websocketResult = (events: <Event>[], timedOut: requireAllRelaysSettled);
+      websocketResult = (
+        events: <Event>[],
+        timedOut: requireAllRelaysSettled,
+      );
     } else {
       websocketResult = useQueryPool
           ? await _queryPool.withResource(runWebSocketQuery)

--- a/mobile/packages/nostr_client/lib/src/relay_manager.dart
+++ b/mobile/packages/nostr_client/lib/src/relay_manager.dart
@@ -175,6 +175,17 @@ class RelayManager {
   /// Whether the manager has been initialized
   bool get isInitialized => _initialized;
 
+  /// Ensure the user-removal intent ledger has been loaded from storage.
+  ///
+  /// This is idempotent and thread-safe. Designed for eager loading before
+  /// initialize() to ensure that pre-init addRelay() calls can properly
+  /// suppress user-removed relays.
+  ///
+  /// Call this before any relay operations that need to respect user-removal
+  /// intent.
+  Future<void> ensureUserRemovedRelaysLoaded() =>
+      _ensureUserRemovedRelaysLoaded();
+
   // ---------------------------------------------------------------------------
   // Initialization
   // ---------------------------------------------------------------------------

--- a/mobile/packages/nostr_client/lib/src/relay_manager.dart
+++ b/mobile/packages/nostr_client/lib/src/relay_manager.dart
@@ -177,12 +177,13 @@ class RelayManager {
 
   /// Ensure the user-removal intent ledger has been loaded from storage.
   ///
-  /// This is idempotent and thread-safe. Designed for eager loading before
-  /// initialize() to ensure that pre-init addRelay() calls can properly
-  /// suppress user-removed relays.
+  /// Idempotent: concurrent callers share a single storage read, and later
+  /// calls return immediately once the ledger is loaded.
   ///
-  /// Call this before any relay operations that need to respect user-removal
-  /// intent.
+  /// [addRelay], [removeRelay], [isUserRemovedRelay] and [initialize] already
+  /// await this internally, so suppression is correct without it. Use it only
+  /// to warm the ledger ahead of those calls, or to surface a storage read
+  /// failure at a point the caller chooses.
   Future<void> ensureUserRemovedRelaysLoaded() =>
       _ensureUserRemovedRelaysLoaded();
 

--- a/mobile/packages/nostr_client/test/src/relay_manager_test.dart
+++ b/mobile/packages/nostr_client/test/src/relay_manager_test.dart
@@ -899,6 +899,40 @@ void main() {
         verify(() => mockStorage.saveRemovedRelays([])).called(1);
       });
 
+      test(
+        'ensureUserRemovedRelaysLoaded warms the ledger for later callers',
+        () async {
+          var removedRelaysLoadCount = 0;
+          when(() => mockStorage.loadRemovedRelays()).thenAnswer((_) async {
+            removedRelaysLoadCount++;
+            return [testCustomRelayUrl];
+          });
+          when(() => mockStorage.loadRelays()).thenAnswer((_) async => []);
+          when(() => mockStorage.saveRelays(any())).thenAnswer((_) async {});
+          when(
+            () => mockStorage.saveRemovedRelays(any()),
+          ).thenAnswer((_) async {});
+
+          final managerWithStorage = RelayManager(
+            config: _createTestConfig(storage: mockStorage),
+            relayPool: mockRelayPool,
+          );
+
+          await managerWithStorage.ensureUserRemovedRelaysLoaded();
+          await managerWithStorage.ensureUserRemovedRelaysLoaded();
+
+          expect(removedRelaysLoadCount, equals(1));
+
+          // A later automatic add reuses the warmed ledger rather than
+          // re-reading storage, and is still suppressed by it.
+          expect(
+            await managerWithStorage.addRelay(testCustomRelayUrl),
+            isFalse,
+          );
+          expect(removedRelaysLoadCount, equals(1));
+        },
+      );
+
       test('automatic removal does not persist user removal intent', () async {
         final storage = InMemoryRelayStorage([testCustomRelayUrl]);
         final managerWithStorage = RelayManager(

--- a/mobile/test/providers/nostr_service_identity_source_test.dart
+++ b/mobile/test/providers/nostr_service_identity_source_test.dart
@@ -87,6 +87,9 @@ class _RecordingFactory {
       initializePubkeys.add(pubkey);
       return initializeCompleter?.future ?? Future<void>.value();
     });
+    when(client.ensureUserRemovedRelaysLoaded).thenAnswer(
+      (_) => Future<void>.value(),
+    );
     when(() => client.addRelays(any())).thenAnswer((_) async {
       addRelaysPubkeys.add(pubkey);
       await addRelaysCompleter?.future;


### PR DESCRIPTION
Closes #7526

## Summary



Exposes the user-removal relay ledger load as a public method on `RelayManager` and `NostrClient`, and warms it once in `NostrService._runClientInitialization` before the per-relay `addRelays` loop.

**Scope correction (reviewer, @hm21):** this branch was opened as a fix for a pre-init race in which user-removed relays were re-added on restart. That race does not exist on `main`. `RelayManager.addRelay` has awaited `_ensureUserRemovedRelaysLoaded()` as its first statement since #6475, and `NostrClient.addRelays` delegates to it, so a pre-init add already consults the ledger. `relay_manager_test.dart` pins exactly that in *"automatic add before initialize honors persisted removal ledger"*, and it passes on this branch with and without the change. #6471 was already fixed and closed by #6475.

What remains here is a behaviour-neutral refactor: one shared ledger read ahead of the loop instead of the first `addRelay` triggering it, plus a public entry point for callers that want the read to happen at a point they choose. Merge it on that basis, not as a bug fix.

## Solution

- Public `ensureUserRemovedRelaysLoaded()` on `RelayManager` and `NostrClient`, delegating to the existing idempotent private load.
- `NostrService._runClientInitialization` warms the ledger once before `addRelays`.
- Doc comments state what the method is for rather than claiming it is what makes pre-init suppression correct.

## Test plan

Run by the reviewer on `77979966`:

- `flutter test` in `mobile/packages/nostr_client` — 339 pass, including the new warm-up coverage in `relay_manager_test.dart`.
- `flutter test test/providers/nostr_service_identity_source_test.dart test/providers/nostr_client_provider_bootstrap_test.dart test/unit/providers/relay_set_change_bridge_test.dart test/services/relay_discovery_service_test.dart` — 87 pass.
- `flutter analyze lib test integration_test` and `flutter analyze` in `nostr_client` — clean.
- `dart run build_runner build --delete-conflicting-outputs` — `nostr_client_provider.g.dart` committed.

Not device-verified. The change is behaviour-neutral by inspection and by the pre-existing suppression test, so no on-device relay-deletion run was performed.