### PR TITLE
fix(overlays): preserve bottom sheet visibility on rebuild

### DIFF
--- a/mobile/lib/providers/overlay_visibility_provider.dart
+++ b/mobile/lib/providers/overlay_visibility_provider.dart
@@ -48,10 +48,14 @@ class OverlayVisibilityState {
 class OverlayVisibility extends _$OverlayVisibility {
   final Set<Object> _pageOpenOwners = {};
   bool _pageOpenWithoutOwner = false;
+  bool _isBottomSheetOpen = false;
 
   @override
-  OverlayVisibilityState build() =>
-      OverlayVisibilityState(isPageOpen: _isPageOpen);
+  /// Rebuild from fields because keepAlive notifiers survive provider rebuilds.
+  OverlayVisibilityState build() => OverlayVisibilityState(
+    isPageOpen: _isPageOpen,
+    isBottomSheetOpen: _isBottomSheetOpen,
+  );
 
   /// Whether this notifier can still accept writes.
   bool get isMounted => ref.mounted;
@@ -97,14 +101,16 @@ class OverlayVisibility extends _$OverlayVisibility {
   /// Set bottom sheet overlay state.
   /// When a bottom sheet is open, only the current player is paused.
   void setBottomSheetOpen(bool isOpen) {
-    if (state.isBottomSheetOpen != isOpen) {
-      Log.info(
-        'BottomSheet ${isOpen ? 'opened' : 'closed'}',
-        name: 'OverlayVisibility',
-        category: LogCategory.ui,
-      );
-      state = state.copyWith(isBottomSheetOpen: isOpen);
+    if (_isBottomSheetOpen == isOpen) {
+      return;
     }
+    _isBottomSheetOpen = isOpen;
+    Log.info(
+      'BottomSheet ${isOpen ? 'opened' : 'closed'}',
+      name: 'OverlayVisibility',
+      category: LogCategory.ui,
+    );
+    state = state.copyWith(isBottomSheetOpen: isOpen);
   }
 }
 

--- a/mobile/lib/providers/overlay_visibility_provider.g.dart
+++ b/mobile/lib/providers/overlay_visibility_provider.g.dart
@@ -44,7 +44,7 @@ final class OverlayVisibilityProvider
   }
 }
 
-String _$overlayVisibilityHash() => r'ea10b79382c58b122d7d69058aa2db2f9e837c08';
+String _$overlayVisibilityHash() => r'533132b5195512a71f1ff2bcd9d43e082e984bf5';
 
 /// Notifier for managing overlay visibility state
 

--- a/mobile/test/providers/overlay_visibility_provider_test.dart
+++ b/mobile/test/providers/overlay_visibility_provider_test.dart
@@ -142,6 +142,35 @@ void main() {
       },
     );
 
+    test('provider rebuild preserves an open bottom sheet overlay', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final notifier = container.read(overlayVisibilityProvider.notifier);
+
+      notifier.setBottomSheetOpen(true);
+      container.invalidate(overlayVisibilityProvider);
+
+      final state = container.read(overlayVisibilityProvider);
+      expect(state.isBottomSheetOpen, isTrue);
+      expect(state.hasVisibleOverlay, isTrue);
+      expect(state.shouldRetainPlayer, isTrue);
+    });
+
+    test('provider rebuild preserves a closed bottom sheet overlay', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final notifier = container.read(overlayVisibilityProvider.notifier);
+
+      notifier.setBottomSheetOpen(true);
+      notifier.setBottomSheetOpen(false);
+      container.invalidate(overlayVisibilityProvider);
+
+      final state = container.read(overlayVisibilityProvider);
+      expect(state.isBottomSheetOpen, isFalse);
+      expect(state.hasVisibleOverlay, isFalse);
+      expect(state.shouldRetainPlayer, isFalse);
+    });
+
     test('clearPageOpen resets explicit and owner-held page overlays', () {
       final container = ProviderContainer();
       addTearDown(container.dispose);


### PR DESCRIPTION
## Summary
- back bottom-sheet overlay visibility with a notifier field so provider rebuilds preserve it
- rederive both page and bottom-sheet flags in build()
- add regression coverage for open and closed bottom-sheet rebuild state

Closes #7494

## Verification
- flutter test test/providers/overlay_visibility_provider_test.dart test/screens/feed/video_feed_page_test.dart test/providers/upload_media_providers_test.dart
- flutter analyze lib test
- pre-push hook: analyzer, generated-files check, changed provider test