### PR TITLE
fix(feed): track pause-aware overlays by owner

### DIFF
--- a/mobile/lib/providers/overlay_visibility_provider.dart
+++ b/mobile/lib/providers/overlay_visibility_provider.dart
@@ -47,7 +47,6 @@ class OverlayVisibilityState {
 @Riverpod(keepAlive: true)
 class OverlayVisibility extends _$OverlayVisibility {
   final Set<Object> _pageOpenOwners = {};
-  bool _pageOpenWithoutOwner = false;
 
   @override
   OverlayVisibilityState build() =>
@@ -56,14 +55,7 @@ class OverlayVisibility extends _$OverlayVisibility {
   /// Whether this notifier can still accept writes.
   bool get isMounted => ref.mounted;
 
-  bool get _isPageOpen => _pageOpenWithoutOwner || _pageOpenOwners.isNotEmpty;
-
-  /// Sets page visibility for callers without an independent owner token.
-  /// Owner-held pages remain open when this is set to false.
-  void setPageOpen(bool isOpen) {
-    _pageOpenWithoutOwner = isOpen;
-    _updatePageOpen();
-  }
+  bool get _isPageOpen => _pageOpenOwners.isNotEmpty;
 
   /// Sets page visibility for one independently mounted owner.
   void setPageOpenForOwner(Object owner, {required bool isOpen}) {
@@ -77,7 +69,6 @@ class OverlayVisibility extends _$OverlayVisibility {
 
   /// Clears every page-open source after navigation proves none remain.
   void clearPageOpen() {
-    _pageOpenWithoutOwner = false;
     _pageOpenOwners.clear();
     _updatePageOpen();
   }

--- a/mobile/lib/providers/overlay_visibility_provider.g.dart
+++ b/mobile/lib/providers/overlay_visibility_provider.g.dart
@@ -44,7 +44,7 @@ final class OverlayVisibilityProvider
   }
 }
 
-String _$overlayVisibilityHash() => r'ea10b79382c58b122d7d69058aa2db2f9e837c08';
+String _$overlayVisibilityHash() => r'50bbcaac3fc89727bec050b7dd15cffe25fb7dfd';
 
 /// Notifier for managing overlay visibility state
 

--- a/mobile/lib/providers/shell_obscured_provider.dart
+++ b/mobile/lib/providers/shell_obscured_provider.dart
@@ -19,12 +19,12 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 /// the feed paused.
 ///
 /// AppShell also reconciles `overlayVisibilityProvider.isPageOpen` when this
-/// flag becomes `false`. A fresh shell mount clears only stale unowned page
-/// state because it can still sit below a live page owner. `didPopNext` clears
-/// every page owner because popping the route directly above the shell proves
-/// no page overlay should continue blocking autoplay, even if go_router removed
-/// the route with `go()` and never completed the original `pushWithVideoPause`
-/// future.
+/// flag becomes `false`. A fresh shell mount clears page owners only when the
+/// shell is the current route because it can still sit below a live page owner.
+/// `didPopNext` clears every page owner because popping the route directly
+/// above the shell proves no page overlay should continue blocking autoplay,
+/// even if go_router removed the route with `go()` and never completed the
+/// original `pushWithVideoPause` future.
 ///
 /// The home feed reads this to know it is offstage behind a pushed screen.
 /// GoRouter's `routeInformationProvider` collapses to the shell location

--- a/mobile/lib/router/app_shell.dart
+++ b/mobile/lib/router/app_shell.dart
@@ -113,18 +113,16 @@ class _AppShellState extends ConsumerState<AppShell> with RouteAware {
       if (!mounted) return;
       ref.read(shellObscuredProvider.notifier).setObscured(obscured: obscured);
       if (!obscured) {
-        final overlayVisibility = ref.read(
-          overlayVisibilityProvider.notifier,
-        );
+        final overlayVisibility = ref.read(overlayVisibilityProvider.notifier);
         if (clearPageOwners) {
           // Popping the route directly above the shell proves no page owner
           // remains. Force-clear because a `go()`-style back can skip the
           // pushed route's own completion callback (#6239).
           overlayVisibility.clearPageOpen();
-        } else {
+        } else if (ModalRoute.of(context)?.isCurrent ?? false) {
           // A freshly mounted shell can still sit below a live page owner.
-          // Clear only stale unowned state until a pop proves the stack empty.
-          overlayVisibility.setPageOpen(false);
+          // Clear only when navigation proves the shell is the top route.
+          overlayVisibility.clearPageOpen();
         }
       }
     });

--- a/mobile/lib/utils/pause_aware_modals.dart
+++ b/mobile/lib/utils/pause_aware_modals.dart
@@ -1,6 +1,6 @@
 // ABOUTME: BuildContext extensions for showing modals/navigating that pause
-// ABOUTME: video playback. Uses setPageOpen for full-screen pages/dialogs
-// ABOUTME: and setBottomSheetOpen for bottom sheets (retains current player).
+// ABOUTME: video playback. Uses owner-held page tokens for full-screen pages
+// ABOUTME: and dialogs, and setBottomSheetOpen for retained bottom sheets.
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
@@ -29,8 +29,8 @@ import 'package:openvine/providers/overlay_visibility_provider.dart';
 extension PauseAwareModals on BuildContext {
   /// Pushes a route that automatically pauses video playback.
   ///
-  /// Calls [OverlayVisibility.setPageOpen(true)] before pushing and
-  /// [setPageOpen(false)] when the pushed route is popped.
+  /// Takes an [OverlayVisibility] owner token before pushing and releases that
+  /// token when the pushed route is popped.
   /// This releases all video players to free memory.
   ///
   /// The returned future only completes on a **pop**: go_router completes an
@@ -47,18 +47,20 @@ extension PauseAwareModals on BuildContext {
   }) {
     final container = ProviderScope.containerOf(this, listen: false);
     final overlayNotifier = container.read(overlayVisibilityProvider.notifier);
+    final owner = Object();
 
-    overlayNotifier.setPageOpen(true);
+    overlayNotifier.setPageOpenForOwner(owner, isOpen: true);
 
     return push<T>(location, extra: extra).whenComplete(() {
-      overlayNotifier.setPageOpen(false);
+      if (!overlayNotifier.isMounted) return;
+      overlayNotifier.setPageOpenForOwner(owner, isOpen: false);
     });
   }
 
   /// Shows a dialog that automatically pauses video playback.
   ///
-  /// Calls [OverlayVisibility.setPageOpen(true)] before showing and
-  /// [setPageOpen(false)] after the dialog is dismissed.
+  /// Takes an [OverlayVisibility] owner token before showing and releases that
+  /// token after the dialog is dismissed.
   /// This releases all video players (dialogs block full UI).
   Future<T?> showVideoPausingDialog<T>({
     required WidgetBuilder builder,
@@ -73,8 +75,9 @@ extension PauseAwareModals on BuildContext {
   }) {
     final container = ProviderScope.containerOf(this, listen: false);
     final overlayNotifier = container.read(overlayVisibilityProvider.notifier);
+    final owner = Object();
 
-    overlayNotifier.setPageOpen(true);
+    overlayNotifier.setPageOpenForOwner(owner, isOpen: true);
 
     return showDialog<T>(
       context: this,
@@ -88,7 +91,8 @@ extension PauseAwareModals on BuildContext {
       anchorPoint: anchorPoint,
       traversalEdgeBehavior: traversalEdgeBehavior,
     ).whenComplete(() {
-      overlayNotifier.setPageOpen(false);
+      if (!overlayNotifier.isMounted) return;
+      overlayNotifier.setPageOpenForOwner(owner, isOpen: false);
     });
   }
 

--- a/mobile/test/providers/overlay_visibility_provider_test.dart
+++ b/mobile/test/providers/overlay_visibility_provider_test.dart
@@ -59,13 +59,16 @@ void main() {
   });
 
   group('OverlayVisibility notifier', () {
-    test('setPageOpen updates state', () {
+    test('setPageOpenForOwner updates state', () {
       final container = ProviderContainer();
       addTearDown(container.dispose);
+      final owner = Object();
 
       expect(container.read(overlayVisibilityProvider).isPageOpen, isFalse);
 
-      container.read(overlayVisibilityProvider.notifier).setPageOpen(true);
+      container
+          .read(overlayVisibilityProvider.notifier)
+          .setPageOpenForOwner(owner, isOpen: true);
       expect(container.read(overlayVisibilityProvider).isPageOpen, isTrue);
     });
 
@@ -87,31 +90,14 @@ void main() {
       expect(container.read(overlayVisibilityProvider).isPageOpen, isFalse);
     });
 
-    test('owner release preserves an explicitly opened page overlay', () {
-      final container = ProviderContainer();
-      addTearDown(container.dispose);
-      final notifier = container.read(overlayVisibilityProvider.notifier);
-      final owner = Object();
-
-      notifier.setPageOpen(true);
-      notifier.setPageOpenForOwner(owner, isOpen: true);
-      notifier.setPageOpenForOwner(owner, isOpen: false);
-
-      expect(container.read(overlayVisibilityProvider).isPageOpen, isTrue);
-
-      notifier.setPageOpen(false);
-
-      expect(container.read(overlayVisibilityProvider).isPageOpen, isFalse);
-    });
-
-    test('explicit close preserves an owner-held page overlay', () {
+    test('releasing an unknown owner preserves active page overlays', () {
       final container = ProviderContainer();
       addTearDown(container.dispose);
       final notifier = container.read(overlayVisibilityProvider.notifier);
       final owner = Object();
 
       notifier.setPageOpenForOwner(owner, isOpen: true);
-      notifier.setPageOpen(false);
+      notifier.setPageOpenForOwner(Object(), isOpen: false);
 
       expect(container.read(overlayVisibilityProvider).isPageOpen, isTrue);
 
@@ -120,34 +106,42 @@ void main() {
       expect(container.read(overlayVisibilityProvider).isPageOpen, isFalse);
     });
 
-    test(
-      'provider rebuild preserves explicit and owner-held page overlays',
-      () {
-        final container = ProviderContainer();
-        addTearDown(container.dispose);
-        final notifier = container.read(overlayVisibilityProvider.notifier);
-        final owner = Object();
+    test('duplicate open for the same owner is idempotent', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final notifier = container.read(overlayVisibilityProvider.notifier);
+      final owner = Object();
 
-        notifier.setPageOpen(true);
-        notifier.setPageOpenForOwner(owner, isOpen: true);
-        container.invalidate(overlayVisibilityProvider);
+      notifier.setPageOpenForOwner(owner, isOpen: true);
+      notifier.setPageOpenForOwner(owner, isOpen: true);
 
-        expect(container.read(overlayVisibilityProvider).isPageOpen, isTrue);
+      expect(container.read(overlayVisibilityProvider).isPageOpen, isTrue);
 
-        notifier.setPageOpen(false);
-        expect(container.read(overlayVisibilityProvider).isPageOpen, isTrue);
+      notifier.setPageOpenForOwner(owner, isOpen: false);
 
-        notifier.setPageOpenForOwner(owner, isOpen: false);
-        expect(container.read(overlayVisibilityProvider).isPageOpen, isFalse);
-      },
-    );
+      expect(container.read(overlayVisibilityProvider).isPageOpen, isFalse);
+    });
 
-    test('clearPageOpen resets explicit and owner-held page overlays', () {
+    test('provider rebuild preserves owner-held page overlays', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final notifier = container.read(overlayVisibilityProvider.notifier);
+      final owner = Object();
+
+      notifier.setPageOpenForOwner(owner, isOpen: true);
+      container.invalidate(overlayVisibilityProvider);
+
+      expect(container.read(overlayVisibilityProvider).isPageOpen, isTrue);
+
+      notifier.setPageOpenForOwner(owner, isOpen: false);
+      expect(container.read(overlayVisibilityProvider).isPageOpen, isFalse);
+    });
+
+    test('clearPageOpen resets owner-held page overlays', () {
       final container = ProviderContainer();
       addTearDown(container.dispose);
       final notifier = container.read(overlayVisibilityProvider.notifier);
 
-      notifier.setPageOpen(true);
       notifier.setPageOpenForOwner(Object(), isOpen: true);
       notifier.clearPageOpen();
 
@@ -196,7 +190,9 @@ void main() {
       final container = ProviderContainer();
       addTearDown(container.dispose);
 
-      container.read(overlayVisibilityProvider.notifier).setPageOpen(true);
+      container
+          .read(overlayVisibilityProvider.notifier)
+          .setPageOpenForOwner(Object(), isOpen: true);
       expect(container.read(hasVisibleOverlayProvider), isTrue);
     });
 
@@ -216,10 +212,15 @@ void main() {
 
       expect(container.read(hasVisibleOverlayProvider), isFalse);
 
-      container.read(overlayVisibilityProvider.notifier).setPageOpen(true);
+      final owner = Object();
+      container
+          .read(overlayVisibilityProvider.notifier)
+          .setPageOpenForOwner(owner, isOpen: true);
       expect(container.read(hasVisibleOverlayProvider), isTrue);
 
-      container.read(overlayVisibilityProvider.notifier).setPageOpen(false);
+      container
+          .read(overlayVisibilityProvider.notifier)
+          .setPageOpenForOwner(owner, isOpen: false);
       expect(container.read(hasVisibleOverlayProvider), isFalse);
     });
 
@@ -304,7 +305,9 @@ void main() {
 
       await pumpEventQueue();
 
-      container.read(overlayVisibilityProvider.notifier).setPageOpen(true);
+      container
+          .read(overlayVisibilityProvider.notifier)
+          .setPageOpenForOwner(Object(), isOpen: true);
       expect(container.read(activeVideoIdProvider), isNull);
     });
 
@@ -339,10 +342,15 @@ void main() {
 
       expect(container.read(activeVideoIdProvider), 'v0');
 
-      container.read(overlayVisibilityProvider.notifier).setPageOpen(true);
+      final owner = Object();
+      container
+          .read(overlayVisibilityProvider.notifier)
+          .setPageOpenForOwner(owner, isOpen: true);
       expect(container.read(activeVideoIdProvider), isNull);
 
-      container.read(overlayVisibilityProvider.notifier).setPageOpen(false);
+      container
+          .read(overlayVisibilityProvider.notifier)
+          .setPageOpenForOwner(owner, isOpen: false);
       expect(container.read(activeVideoIdProvider), 'v0');
     });
   });

--- a/mobile/test/router/app_shell_obscured_test.dart
+++ b/mobile/test/router/app_shell_obscured_test.dart
@@ -80,11 +80,22 @@ Widget _wrapWithBlocs(Widget child) {
 
 // The shell subscribes to [routeObserver] to learn when a full-screen route
 // covers it, so the test app must register it on the navigator.
-Widget _appShellMaterialApp() => MaterialApp(
+Widget _appShellMaterialApp({bool shellCovered = false}) => MaterialApp(
   localizationsDelegates: AppLocalizations.localizationsDelegates,
   supportedLocales: AppLocalizations.supportedLocales,
   navigatorObservers: [routeObserver],
-  home: const AppShell(currentIndex: 0, child: SizedBox.shrink()),
+  routes: {
+    '/': (_) => const AppShell(currentIndex: 0, child: SizedBox.shrink()),
+  },
+  onGenerateInitialRoutes: (_) => [
+    MaterialPageRoute<void>(
+      builder: (_) => const AppShell(currentIndex: 0, child: SizedBox.shrink()),
+    ),
+    if (shellCovered)
+      MaterialPageRoute<void>(
+        builder: (_) => const Scaffold(body: Text('Covering route')),
+      ),
+  ],
 );
 
 Widget _buildSubject({
@@ -166,9 +177,10 @@ void main() {
     },
   );
 
-  testWidgets(
-    'a freshly mounted shell clears a stale obscured flag from a removed shell',
-    (tester) async {
+  group('fresh shell mount page-owner recovery', () {
+    testWidgets('clears stale owners when the shell is current', (
+      tester,
+    ) async {
       final container = ProviderContainer(
         overrides: _overrides(
           mockAuthService: mockAuthService,
@@ -186,9 +198,7 @@ void main() {
       final overlayVisibility = container.read(
         overlayVisibilityProvider.notifier,
       );
-      final liveOwner = Object();
-      overlayVisibility.setPageOpen(true);
-      overlayVisibility.setPageOpenForOwner(liveOwner, isOpen: true);
+      overlayVisibility.setPageOpenForOwner(Object(), isOpen: true);
       expect(container.read(shellObscuredProvider), isTrue);
 
       await tester.pumpWidget(
@@ -202,16 +212,49 @@ void main() {
       await tester.pumpAndSettle();
 
       // didPush fires once as the fresh shell subscribes, clearing the stale
-      // obscured flag without dropping a live page owner.
+      // obscured flag and any owner left behind by the removed shell.
+      expect(container.read(shellObscuredProvider), isFalse);
+      expect(container.read(overlayVisibilityProvider).isPageOpen, isFalse);
+    });
+
+    testWidgets('preserves live owners when the shell is not current', (
+      tester,
+    ) async {
+      final container = ProviderContainer(
+        overrides: _overrides(
+          mockAuthService: mockAuthService,
+          sharedPreferences: sharedPreferences,
+        ),
+      );
+      addTearDown(container.dispose);
+
+      container
+          .read(shellObscuredProvider.notifier)
+          .setObscured(obscured: true);
+      final overlayVisibility = container.read(
+        overlayVisibilityProvider.notifier,
+      );
+      final liveOwner = Object();
+      overlayVisibility.setPageOpenForOwner(liveOwner, isOpen: true);
+
+      await tester.pumpWidget(
+        _wrapWithBlocs(
+          UncontrolledProviderScope(
+            container: container,
+            child: _appShellMaterialApp(shellCovered: true),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Covering route'), findsOneWidget);
       expect(container.read(shellObscuredProvider), isFalse);
       expect(container.read(overlayVisibilityProvider).isPageOpen, isTrue);
 
-      // Fresh-shell recovery clears stale unowned state without destroying a
-      // live route owner's hold.
       overlayVisibility.setPageOpenForOwner(liveOwner, isOpen: false);
       expect(container.read(overlayVisibilityProvider).isPageOpen, isFalse);
-    },
-  );
+    });
+  });
 
   testWidgets(
     'router.go() uncovering the shell clears a page overlay stranded by '

--- a/mobile/test/screens/feed/video_feed_page_test.dart
+++ b/mobile/test/screens/feed/video_feed_page_test.dart
@@ -1312,10 +1312,11 @@ void main() {
         ).read(overlayVisibilityProvider.notifier).setBottomSheetOpen(open);
       }
 
+      final pageOpenOwner = Object();
       void setPageOpen(WidgetTester tester, {required bool open}) {
-        containerOf(
-          tester,
-        ).read(overlayVisibilityProvider.notifier).setPageOpen(open);
+        containerOf(tester)
+            .read(overlayVisibilityProvider.notifier)
+            .setPageOpenForOwner(pageOpenOwner, isOpen: open);
       }
 
       testWidgets(

--- a/mobile/test/utils/pause_aware_modals_test.dart
+++ b/mobile/test/utils/pause_aware_modals_test.dart
@@ -222,11 +222,53 @@ void main() {
             key: state.pageKey,
             child: Scaffold(
               body: Builder(
-                builder: (context) => TextButton(
-                  onPressed: () =>
-                      unawaited(context.pushWithVideoPause<void>('/hashtag')),
-                  child: const Text('Open'),
+                builder: (context) => Column(
+                  children: [
+                    TextButton(
+                      onPressed: () => unawaited(
+                        context.pushWithVideoPause<void>('/hashtag'),
+                      ),
+                      child: const Text('Open'),
+                    ),
+                    TextButton(
+                      onPressed: () => unawaited(
+                        context.pushWithVideoPause<void>('/profile'),
+                      ),
+                      child: const Text('Open profile'),
+                    ),
+                  ],
                 ),
+              ),
+            ),
+          ),
+        ),
+        GoRoute(
+          path: '/profile',
+          pageBuilder: (_, state) => MaterialPage<void>(
+            key: state.pageKey,
+            child: Scaffold(
+              body: Column(
+                children: [
+                  Builder(
+                    builder: (context) => TextButton(
+                      onPressed: () => unawaited(
+                        context.pushWithVideoPause<void>('/hashtag'),
+                      ),
+                      child: const Text('Open nested route'),
+                    ),
+                  ),
+                  Builder(
+                    builder: (context) => TextButton(
+                      onPressed: () => unawaited(
+                        context.showVideoPausingDialog<void>(
+                          builder: (_) =>
+                              const AlertDialog(content: Text('Route dialog')),
+                        ),
+                      ),
+                      child: const Text('Open route dialog'),
+                    ),
+                  ),
+                ],
               ),
             ),
           ),
@@ -278,6 +320,50 @@ void main() {
       expect(container.read(overlayVisibilityProvider).isPageOpen, isFalse);
     });
 
+    testWidgets('keeps page open while an outer pushed route remains', (
+      tester,
+    ) async {
+      final (router, container) = await pumpApp(tester);
+
+      await tester.tap(find.text('Open profile'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Open nested route'));
+      await tester.pumpAndSettle();
+      expect(find.text('Hashtag'), findsOneWidget);
+      expect(container.read(overlayVisibilityProvider).isPageOpen, isTrue);
+
+      router.pop();
+      await tester.pumpAndSettle();
+      expect(find.text('Open nested route'), findsOneWidget);
+      expect(container.read(overlayVisibilityProvider).isPageOpen, isTrue);
+
+      router.pop();
+      await tester.pumpAndSettle();
+      expect(container.read(overlayVisibilityProvider).isPageOpen, isFalse);
+    });
+
+    testWidgets('dialog release preserves an outer pushed route hold', (
+      tester,
+    ) async {
+      final (router, container) = await pumpApp(tester);
+
+      await tester.tap(find.text('Open profile'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Open route dialog'));
+      await tester.pumpAndSettle();
+      expect(find.text('Route dialog'), findsOneWidget);
+      expect(container.read(overlayVisibilityProvider).isPageOpen, isTrue);
+
+      router.pop();
+      await tester.pumpAndSettle();
+      expect(find.text('Open route dialog'), findsOneWidget);
+      expect(container.read(overlayVisibilityProvider).isPageOpen, isTrue);
+
+      router.pop();
+      await tester.pumpAndSettle();
+      expect(container.read(overlayVisibilityProvider).isPageOpen, isFalse);
+    });
+
     testWidgets(
       'leaves isPageOpen set when a go() removes the pushed route — the '
       'go_router behaviour AppShell has to compensate for (#6239)',
@@ -306,5 +392,71 @@ void main() {
         );
       },
     );
+  });
+
+  group('showVideoPausingDialog', () {
+    testWidgets('nested dialog release preserves the outer dialog hold', (
+      tester,
+    ) async {
+      late ProviderContainer container;
+      await tester.pumpWidget(
+        ProviderScope(
+          child: Consumer(
+            builder: (context, ref, _) {
+              container = ProviderScope.containerOf(context, listen: false);
+              return MaterialApp(
+                home: Scaffold(
+                  body: Builder(
+                    builder: (context) => TextButton(
+                      onPressed: () => unawaited(
+                        context.showVideoPausingDialog<void>(
+                          builder: (_) => AlertDialog(
+                            content: Builder(
+                              builder: (dialogContext) => TextButton(
+                                onPressed: () => unawaited(
+                                  dialogContext.showVideoPausingDialog<void>(
+                                    builder: (_) => const AlertDialog(
+                                      content: Text('Inner dialog'),
+                                    ),
+                                  ),
+                                ),
+                                child: const Text('Open inner dialog'),
+                              ),
+                            ),
+                          ),
+                        ),
+                      ),
+                      child: const Text('Open outer dialog'),
+                    ),
+                  ),
+                ),
+              );
+            },
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Open outer dialog'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Open inner dialog'));
+      await tester.pumpAndSettle();
+      expect(find.text('Inner dialog'), findsOneWidget);
+      expect(container.read(overlayVisibilityProvider).isPageOpen, isTrue);
+
+      Navigator.of(
+        tester.element(find.text('Inner dialog')),
+        rootNavigator: true,
+      ).pop();
+      await tester.pumpAndSettle();
+      expect(find.text('Open inner dialog'), findsOneWidget);
+      expect(container.read(overlayVisibilityProvider).isPageOpen, isTrue);
+
+      Navigator.of(
+        tester.element(find.text('Open inner dialog')),
+        rootNavigator: true,
+      ).pop();
+      await tester.pumpAndSettle();
+      expect(container.read(overlayVisibilityProvider).isPageOpen, isFalse);
+    });
   });
 }


### PR DESCRIPTION
## Summary
- migrate pause-aware pushed routes and dialogs to per-invocation page owner tokens
- remove the legacy unowned page-open boolean path from overlay visibility
- make fresh AppShell recovery clear page owners only when the shell is current
- add nested route/dialog regression coverage for owner-token holds

Closes #7489

## Verification
- dart run build_runner build --delete-conflicting-outputs
- flutter test test/utils/pause_aware_modals_test.dart test/providers/overlay_visibility_provider_test.dart test/router/app_shell_obscured_test.dart test/screens/feed/video_feed_page_test.dart
- flutter analyze lib test integration_test
- pre-push hook: analyzer, generated files, changed-file tests