### PR TITLE
docs(metrics): the display floor is live for everyone, not feature-gated

### DIFF
--- a/docs/superpowers/specs/2026-08-13-view-and-loop-findings.md
+++ b/docs/superpowers/specs/2026-08-13-view-and-loop-findings.md
@@ -260,7 +260,8 @@ Recorded because each was stated confidently and may have been repeated.
    have loops below views.
 4. **"The display floor is mis-set and starves creators"** — wrong. Creators
    always see their own count (`isOwnVideo`), so the floor never gated the
-   retention effect. Only 0.04% of videos reach 1000; that is deliberate.
+   retention effect. The corrected public-count census shows 52.30% of videos
+   reach 1000; that public display threshold is still deliberate.
 5. **"Loops are lost behind the comment sheet"** — wrong. The video pauses on
    route push. The real defect is the opposite (§3.4).
 6. **Persistent bias toward conservatism.** Framing the view-definition

--- a/docs/superpowers/specs/2026-08-13-view-and-loop-metrics-baseline.md
+++ b/docs/superpowers/specs/2026-08-13-view-and-loop-metrics-baseline.md
@@ -218,7 +218,7 @@ Caveats, stated so the number is not over-read:
 ## 5. The display floor, restated on current numbers
 
 **This section corrects the design doc, which measures the wrong column.**
-`mobile/lib/widgets/video_feed_item/video_card_meta.dart:79` defines the gated
+`mobile/lib/widgets/video_feed_item/video_card_meta.dart:70` defines the gated
 quantity as `video.isOriginalVine ? video.originalLoops ?? 0 :
 video.totalLoops` — i.e. the archival `loops` tag for classic Vines (about 98%
 of the `nostr.videos` catalogue; derived by the appendix query), and
@@ -246,19 +246,23 @@ originally gated the rule as a kill switch, but it defaulted off and nothing
 ever set `FF_VIDEO_CARD_POST_DATE`, so it never reached a normal build. #7452
 (merged 2026-08-15 04:31 UTC) deleted the dead flag; `_resolveLoopCount` now
 applies the floor unconditionally to any viewer who is not the video's owner.
-An earlier revision of this paragraph said production was unchanged while the
-flag stayed off — that was written hours before #7452 landed and is no longer
-true.
+An earlier revision of this paragraph introduced the stale
+"production unchanged while the flag stayed off" framing after #7452 had
+already removed that flag.
+
+Scope: this is the Flutter-client card rule. Divine Web currently diverges: its
+card renders any positive playback count and `formatLoopCount` applies only K/M
+abbreviation, not a display floor.
 
 **The floor decision survives the correction; only its stated rationale
 changes.** The design doc argued the floor was harmless because almost
 nobody ever sees a count. The real argument is the one on the constant
 itself (`mobile/lib/widgets/video_feed_item/video_card_meta.dart:9`): a number
 below the floor "tells a viewer not to bother", and a wall of small counts on
-*other people's* videos discourages posting. On the real distribution, once the
-feature is enabled, the floor would show visitors a count on ~52% of videos,
-every one of them ≥1000, and a date on the rest instead of a discouraging 47.
-Creators are never gated in that code path: `_resolveLoopCount` returns
+*other people's* videos discourages posting. On the real distribution, the
+floor shows visitors a count on ~52% of videos, every one of them ≥1000, and a
+date on the rest instead of a discouraging 47. Creators are never gated:
+`_resolveLoopCount` returns
 `video.totalLoops` unconditionally when `isOwnVideo`, and `totalLoops` is
 additive (`mobile/packages/models/lib/src/video_event.dart:1181-1183`), so a
 creator sees the larger number.

--- a/docs/superpowers/specs/2026-08-13-view-and-loop-metrics-baseline.md
+++ b/docs/superpowers/specs/2026-08-13-view-and-loop-metrics-baseline.md
@@ -237,13 +237,18 @@ actually gates:
 
 Median public count across the catalogue: **1,417**.
 
-When the post-date/count-hiding feature is enabled, a public count renders on
-about **half** the catalogue, not on 0.044% of it. The design doc's prior
-conclusion — "the public count is effectively never shown; 9,996 videos in
-10,000 render a date" — does not hold under the feature-gated code path.
-Production remains unchanged while `FeatureFlag.videoCardPostDate` is off:
-`resolveVideoCardMeta` returns `video.totalLoops` directly, so every card keeps
-today's count-only behavior until the flag is enabled.
+A public count renders on about **half** the catalogue, not on 0.044% of it.
+The design doc's prior conclusion — "the public count is effectively never
+shown; 9,996 videos in 10,000 render a date" — does not hold.
+
+This is live for everyone, not feature-gated. `FeatureFlag.videoCardPostDate`
+originally gated the rule as a kill switch, but it defaulted off and nothing
+ever set `FF_VIDEO_CARD_POST_DATE`, so it never reached a normal build. #7452
+(merged 2026-08-15 04:31 UTC) deleted the dead flag; `_resolveLoopCount` now
+applies the floor unconditionally to any viewer who is not the video's owner.
+An earlier revision of this paragraph said production was unchanged while the
+flag stayed off — that was written hours before #7452 landed and is no longer
+true.
 
 **The floor decision survives the correction; only its stated rationale
 changes.** The design doc argued the floor was harmless because almost

--- a/docs/superpowers/specs/2026-08-13-view-and-loop-metrics-design.md
+++ b/docs/superpowers/specs/2026-08-13-view-and-loop-metrics-design.md
@@ -300,11 +300,10 @@ sampled video above 400 against a displayed 108, which is a larger correction
 than this table accounts for, and it counts only viewers who interacted.
 Treat every figure here as the least the number should move, not the most.
 
-### The display floor under the post-date feature
+### The display floor
 
 `publicLoopCountFloor` is 1000. The pre-change baseline corrected this section:
-the floor is applied only when `FeatureFlag.videoCardPostDate` is enabled, and
-then only to
+the floor applies to
 `mobile/lib/widgets/video_feed_item/video_card_meta.dart`'s public count
 (`loops` for classic Vines, `originalLoops + views` otherwise), not to
 `video_total_views_data.total_views`. Measured against the gated quantity:
@@ -315,12 +314,20 @@ then only to
 | 333 (floor reached at ×3) | 1,375,711 | 62.42% |
 | 100 (floor reached at ×10) | 1,621,923 | 73.60% |
 
-When that feature is enabled, the public count renders on about half the
-catalogue, not on 0.04% of it. Production remains unchanged while the flag is
-off: cards keep showing the raw count and no date. The floor still matters
-after the metric correction, but the reason is not that the count is
-effectively never shown; it is that the visible counts in the feature-gated
-path are all large enough to read as social proof rather than a warning.
+Median public count: 1,417. A public count renders on about half the
+catalogue, not on 0.04% of it.
+
+**This is live for everyone.** `FeatureFlag.videoCardPostDate` originally
+gated the rule as a kill switch, but it defaulted off and nothing ever set
+`FF_VIDEO_CARD_POST_DATE`, so it never reached a normal build. #7452 (merged
+2026-08-15) deleted the dead flag, and `_resolveLoopCount` now applies the
+floor unconditionally for anyone who is not the video's owner. Earlier drafts
+of this section — including the one this replaces — describe the floor as
+feature-gated; that stopped being true before those words merged.
+
+The floor still matters after the metric correction, but the reason is not
+that the count is effectively never shown; it is that the counts which do
+appear are all large enough to read as social proof rather than a warning.
 
 **This is intended, and it is not a defect.** Two reasons it holds:
 

--- a/docs/superpowers/specs/2026-08-13-view-and-loop-metrics-design.md
+++ b/docs/superpowers/specs/2026-08-13-view-and-loop-metrics-design.md
@@ -325,6 +325,10 @@ floor unconditionally for anyone who is not the video's owner. Earlier drafts
 of this section — including the one this replaces — describe the floor as
 feature-gated; that stopped being true before those words merged.
 
+This is Flutter-client behavior. Divine Web currently diverges: its card
+renders any positive playback count and `formatLoopCount` applies only K/M
+abbreviation, not a display floor.
+
 The floor still matters after the metric correction, but the reason is not
 that the count is effectively never shown; it is that the counts which do
 appear are all large enough to read as social proof rather than a warning.


### PR DESCRIPTION
## Description

#7452 deleted the dead `FeatureFlag.videoCardPostDate` kill switch at **2026-08-15 04:31 UTC**, making the small-count floor apply to every viewer who is not the video's owner. #7218 merged at **06:47 UTC** -- two hours later -- still describing the floor as gated behind that flag.

So both metrics specs currently claim a conditional that no longer exists:

> the floor is applied only when `FeatureFlag.videoCardPostDate` is enabled

> Production remains unchanged while `FeatureFlag.videoCardPostDate` is off

Neither is true on `main`. `_resolveLoopCount` has no flag check: it returns `video.totalLoops` for an owner, and otherwise gates `_publicCount` on `publicLoopCountFloor` unconditionally.

This matters because the two claims point in opposite directions for a live product decision. The gated reading says the ~52% figure is hypothetical and production is unaffected; the truth is that ~52% describes what Flutter-client visitors see right now.

**Related:** Relates to #7218, #7452, supersedes #7465

## Out of Scope

- The measurement and threshold table are already correct on `main` via #7218 and are untouched here.
- Re-tuning `publicLoopCountFloor`. Still a product call.
- Changing Divine Web. This PR only documents that web currently diverges by rendering any positive playback count without the mobile display floor.

## Verification

Docs only. Verified against `origin/main`:

- `git log -S"showPostDate" -- video_card_meta.dart` -> #6872 added the flag gate, #7452 removed it.
- `resolveVideoCardMeta` on `main` takes `{video, isOwnVideo}`: no `showPostDate` parameter, no flag read anywhere in the file.
- `grep -rn videoCardPostDate` across `main` returns **docs only**, zero Dart hits.
- The sibling video-card spec already records why: the flag "defaulted off and nothing in CI, Codemagic, build scripts, or dart-defines ever set `FF_VIDEO_CARD_POST_DATE`, so the rule never reached normal builds."
- Divine Web checked: `VideoCard.tsx` renders `playbackCountLabel` when `viewCount > 0`, and `formatLoopCount` only formats K/M notation; it does not apply the mobile floor.
- `git diff --check`

## Type of Change

- [x] Documentation
