### PR TITLE
fix(overlays): make bottom sheets owner-backed

### DIFF
--- a/mobile/lib/providers/overlay_visibility_provider.dart
+++ b/mobile/lib/providers/overlay_visibility_provider.dart
@@ -47,15 +47,19 @@ class OverlayVisibilityState {
 @Riverpod(keepAlive: true)
 class OverlayVisibility extends _$OverlayVisibility {
   final Set<Object> _pageOpenOwners = {};
+  final Set<Object> _bottomSheetOwners = {};
 
   @override
-  OverlayVisibilityState build() =>
-      OverlayVisibilityState(isPageOpen: _isPageOpen);
+  OverlayVisibilityState build() => OverlayVisibilityState(
+    isPageOpen: _isPageOpen,
+    isBottomSheetOpen: _isBottomSheetOpen,
+  );
 
   /// Whether this notifier can still accept writes.
   bool get isMounted => ref.mounted;
 
   bool get _isPageOpen => _pageOpenOwners.isNotEmpty;
+  bool get _isBottomSheetOpen => _bottomSheetOwners.isNotEmpty;
 
   /// Sets page visibility for one independently mounted owner.
   void setPageOpenForOwner(Object owner, {required bool isOpen}) {
@@ -73,6 +77,14 @@ class OverlayVisibility extends _$OverlayVisibility {
     _updatePageOpen();
   }
 
+  /// Clears every overlay-open source after navigation proves none remain.
+  void clearOverlays() {
+    _pageOpenOwners.clear();
+    _bottomSheetOwners.clear();
+    _updatePageOpen();
+    _updateBottomSheetOpen();
+  }
+
   void _updatePageOpen() {
     final isOpen = _isPageOpen;
     if (state.isPageOpen != isOpen) {
@@ -85,9 +97,19 @@ class OverlayVisibility extends _$OverlayVisibility {
     }
   }
 
-  /// Set bottom sheet overlay state.
+  /// Sets bottom sheet visibility for one independently mounted owner.
   /// When a bottom sheet is open, only the current player is paused.
-  void setBottomSheetOpen(bool isOpen) {
+  void setBottomSheetOpenForOwner(Object owner, {required bool isOpen}) {
+    if (isOpen) {
+      _bottomSheetOwners.add(owner);
+    } else {
+      _bottomSheetOwners.remove(owner);
+    }
+    _updateBottomSheetOpen();
+  }
+
+  void _updateBottomSheetOpen() {
+    final isOpen = _isBottomSheetOpen;
     if (state.isBottomSheetOpen != isOpen) {
       Log.info(
         'BottomSheet ${isOpen ? 'opened' : 'closed'}',

--- a/mobile/lib/providers/overlay_visibility_provider.g.dart
+++ b/mobile/lib/providers/overlay_visibility_provider.g.dart
@@ -44,7 +44,7 @@ final class OverlayVisibilityProvider
   }
 }
 
-String _$overlayVisibilityHash() => r'50bbcaac3fc89727bec050b7dd15cffe25fb7dfd';
+String _$overlayVisibilityHash() => r'078a09e97c2941476d63ca46c3e91c8611028967';
 
 /// Notifier for managing overlay visibility state
 

--- a/mobile/lib/providers/shell_obscured_provider.dart
+++ b/mobile/lib/providers/shell_obscured_provider.dart
@@ -18,13 +18,14 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 /// without a pop event (e.g. sign-out → /welcome → back to home) cannot keep
 /// the feed paused.
 ///
-/// AppShell also reconciles `overlayVisibilityProvider.isPageOpen` when this
-/// flag becomes `false`. A fresh shell mount clears page owners only when the
-/// shell is the current route because it can still sit below a live page owner.
-/// `didPopNext` clears every page owner because popping the route directly
-/// above the shell proves no page overlay should continue blocking autoplay,
-/// even if go_router removed the route with `go()` and never completed the
-/// original `pushWithVideoPause` future.
+/// AppShell also reconciles `overlayVisibilityProvider` when this flag becomes
+/// `false`. A fresh shell mount clears overlay owners only when the shell is
+/// the current route because it can still sit below a live page owner.
+/// `didPopNext` clears every page and bottom-sheet owner because popping the
+/// route directly above the shell proves no overlay should continue blocking
+/// autoplay, even if go_router removed the route with `go()` and never
+/// completed the original `pushWithVideoPause` future or the sheet's own
+/// dismiss callback.
 ///
 /// The home feed reads this to know it is offstage behind a pushed screen.
 /// GoRouter's `routeInformationProvider` collapses to the shell location

--- a/mobile/lib/router/app_shell.dart
+++ b/mobile/lib/router/app_shell.dart
@@ -105,7 +105,7 @@ class _AppShellState extends ConsumerState<AppShell> with RouteAware {
 
   void _setShellObscured({
     required bool obscured,
-    bool clearPageOwners = false,
+    bool clearOverlayOwners = false,
   }) {
     // RouteAware callbacks can fire mid-frame; defer the provider write so it
     // never lands during this shell's own build.
@@ -114,7 +114,7 @@ class _AppShellState extends ConsumerState<AppShell> with RouteAware {
       ref.read(shellObscuredProvider.notifier).setObscured(obscured: obscured);
       if (!obscured) {
         final overlayVisibility = ref.read(overlayVisibilityProvider.notifier);
-        if (clearPageOwners) {
+        if (clearOverlayOwners) {
           // Popping the route directly above the shell proves no overlay owner
           // remains. Force-clear because a `go()`-style back can skip an
           // overlay route's own completion callback (#6239).
@@ -140,7 +140,7 @@ class _AppShellState extends ConsumerState<AppShell> with RouteAware {
 
   @override
   void didPopNext() =>
-      _setShellObscured(obscured: false, clearPageOwners: true);
+      _setShellObscured(obscured: false, clearOverlayOwners: true);
 
   String _titleFor(BuildContext context, WidgetRef ref, RouteContext? ctx) {
     final l10n = context.l10n;

--- a/mobile/lib/router/app_shell.dart
+++ b/mobile/lib/router/app_shell.dart
@@ -115,14 +115,14 @@ class _AppShellState extends ConsumerState<AppShell> with RouteAware {
       if (!obscured) {
         final overlayVisibility = ref.read(overlayVisibilityProvider.notifier);
         if (clearPageOwners) {
-          // Popping the route directly above the shell proves no page owner
-          // remains. Force-clear because a `go()`-style back can skip the
-          // pushed route's own completion callback (#6239).
-          overlayVisibility.clearPageOpen();
+          // Popping the route directly above the shell proves no overlay owner
+          // remains. Force-clear because a `go()`-style back can skip an
+          // overlay route's own completion callback (#6239).
+          overlayVisibility.clearOverlays();
         } else if (ModalRoute.of(context)?.isCurrent ?? false) {
           // A freshly mounted shell can still sit below a live page owner.
           // Clear only when navigation proves the shell is the top route.
-          overlayVisibility.clearPageOpen();
+          overlayVisibility.clearOverlays();
         }
       }
     });

--- a/mobile/lib/utils/pause_aware_modals.dart
+++ b/mobile/lib/utils/pause_aware_modals.dart
@@ -1,6 +1,6 @@
 // ABOUTME: BuildContext extensions for showing modals/navigating that pause
 // ABOUTME: video playback. Uses owner-held page tokens for full-screen pages
-// ABOUTME: and dialogs, and setBottomSheetOpen for retained bottom sheets.
+// ABOUTME: and dialogs, and owner-held sheet tokens for retained bottom sheets.
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
@@ -141,16 +141,21 @@ extension PauseAwareModals on BuildContext {
   }) {
     final container = ProviderScope.containerOf(this, listen: false);
     final overlayNotifier = container.read(overlayVisibilityProvider.notifier);
+    final bottomSheetOwner = Object();
 
     // Custom builder path: raw modal bottom sheet with video pause integration
-    // Uses setBottomSheetOpen to retain current player for instant resume.
+    // Uses an owner-backed sheet hold to retain current player for instant
+    // resume.
     //
     // The custom-builder path is an escape hatch for sheets that do not fit
     // the VineBottomSheet structure (e.g. Share's custom Material header).
     // New VineBottomSheet-specific parameters are intentionally NOT forwarded
     // here — the caller owns the full sheet layout in this mode.
     if (builder != null) {
-      overlayNotifier.setBottomSheetOpen(true);
+      overlayNotifier.setBottomSheetOpenForOwner(
+        bottomSheetOwner,
+        isOpen: true,
+      );
       return showModalBottomSheet<T>(
         context: this,
         builder: builder,
@@ -159,12 +164,17 @@ extension PauseAwareModals on BuildContext {
         useRootNavigator: useRootNavigator,
         backgroundColor: VineTheme.transparent,
       ).whenComplete(() {
-        overlayNotifier.setBottomSheetOpen(false);
+        if (!overlayNotifier.isMounted) return;
+        overlayNotifier.setBottomSheetOpenForOwner(
+          bottomSheetOwner,
+          isOpen: false,
+        );
       });
     }
 
     // Standard VineBottomSheet path
-    // Uses setBottomSheetOpen to retain current player for instant resume.
+    // Uses an owner-backed sheet hold to retain current player for instant
+    // resume.
     return VineBottomSheet.show<T>(
       context: this,
       children: children,
@@ -189,8 +199,17 @@ extension PauseAwareModals on BuildContext {
       tapOutsideToDismiss: tapOutsideToDismiss,
       contentWrapper: contentWrapper,
       draggableController: draggableController,
-      onShow: () => overlayNotifier.setBottomSheetOpen(true),
-      onDismiss: () => overlayNotifier.setBottomSheetOpen(false),
+      onShow: () => overlayNotifier.setBottomSheetOpenForOwner(
+        bottomSheetOwner,
+        isOpen: true,
+      ),
+      onDismiss: () {
+        if (!overlayNotifier.isMounted) return;
+        overlayNotifier.setBottomSheetOpenForOwner(
+          bottomSheetOwner,
+          isOpen: false,
+        );
+      },
     );
   }
 
@@ -199,7 +218,7 @@ extension PauseAwareModals on BuildContext {
   ///
   /// [VineBottomSheetSelectionMenu.show] does not expose
   /// `onShow`/`onDismiss`, so the overlay flag is toggled here around the
-  /// returned future. Uses `setBottomSheetOpen` — same semantics as
+  /// returned future. Uses the same owner-backed semantics as
   /// [showVideoPausingVineBottomSheet], so the current player is paused but
   /// retained for instant resume.
   Future<String?> showVideoPausingSelectionMenu({
@@ -212,8 +231,9 @@ extension PauseAwareModals on BuildContext {
   }) {
     final container = ProviderScope.containerOf(this, listen: false);
     final overlayNotifier = container.read(overlayVisibilityProvider.notifier);
+    final bottomSheetOwner = Object();
 
-    overlayNotifier.setBottomSheetOpen(true);
+    overlayNotifier.setBottomSheetOpenForOwner(bottomSheetOwner, isOpen: true);
 
     return VineBottomSheetSelectionMenu.show(
       context: this,
@@ -223,6 +243,12 @@ extension PauseAwareModals on BuildContext {
       headerPadding: headerPadding,
       headerLeadingAction: headerLeadingAction,
       headerTrailingAction: headerTrailingAction,
-    ).whenComplete(() => overlayNotifier.setBottomSheetOpen(false));
+    ).whenComplete(() {
+      if (!overlayNotifier.isMounted) return;
+      overlayNotifier.setBottomSheetOpenForOwner(
+        bottomSheetOwner,
+        isOpen: false,
+      );
+    });
   }
 }

--- a/mobile/lib/widgets/video_feed_item/metadata/metadata_verification_info_sheet.dart
+++ b/mobile/lib/widgets/video_feed_item/metadata/metadata_verification_info_sheet.dart
@@ -6,6 +6,7 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/utils/external_link_launcher.dart';
+import 'package:openvine/utils/pause_aware_modals.dart';
 import 'package:openvine/widgets/video_recorder/modes/upload/upload_explainer_constants.dart';
 
 /// Vertical slack around the learn-more link so its tap target clears the
@@ -25,23 +26,12 @@ class MetadataVerificationInfoSheet extends StatelessWidget {
   const MetadataVerificationInfoSheet({super.key});
 
   /// Opens the explainer over the metadata sheet.
-  ///
-  /// Deliberately uses [VineBottomSheet.show] rather than the pause-aware
-  /// `showVideoPausingVineBottomSheet`: the metadata sheet underneath has
-  /// already flipped `OverlayVisibility.setBottomSheetOpen(true)`, and that
-  /// flag is a plain bool rather than a counter — so a nested pause-aware
-  /// sheet would clear it on dismiss and resume playback behind the
-  /// still-open metadata sheet.
   static Future<void> show(BuildContext context) {
-    return VineBottomSheet.show<void>(
-      context: context,
+    return context.showVideoPausingVineBottomSheet<void>(
       contentTitle: context.l10n.metadataVerificationInfoTitle,
       scrollable: false,
       isScrollControlled: true,
-      useRootNavigator: true,
-      body: const SingleChildScrollView(
-        child: MetadataVerificationInfoSheet(),
-      ),
+      body: const SingleChildScrollView(child: MetadataVerificationInfoSheet()),
     );
   }
 
@@ -149,9 +139,7 @@ class _LearnMoreLink extends StatelessWidget {
           padding: const EdgeInsets.symmetric(vertical: _linkTapSlack),
           child: ExcludeSemantics(
             child: Text.rich(
-              TextSpan(
-                children: _spans(context, sentence, displayUrl),
-              ),
+              TextSpan(children: _spans(context, sentence, displayUrl)),
               style: VineTheme.bodyMediumFont(
                 color: context.vineColors.onSurfaceVariant,
               ),

--- a/mobile/test/providers/overlay_visibility_provider_test.dart
+++ b/mobile/test/providers/overlay_visibility_provider_test.dart
@@ -159,9 +159,10 @@ void main() {
       expect(notifier.isMounted, isFalse);
     });
 
-    test('setBottomSheetOpen updates state', () {
+    test('setBottomSheetOpenForOwner updates state', () {
       final container = ProviderContainer();
       addTearDown(container.dispose);
+      final owner = Object();
 
       expect(
         container.read(overlayVisibilityProvider).isBottomSheetOpen,
@@ -170,11 +171,71 @@ void main() {
 
       container
           .read(overlayVisibilityProvider.notifier)
-          .setBottomSheetOpen(true);
+          .setBottomSheetOpenForOwner(owner, isOpen: true);
       expect(
         container.read(overlayVisibilityProvider).isBottomSheetOpen,
         isTrue,
       );
+    });
+
+    test('bottom sheet stays open until every owner releases it', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final notifier = container.read(overlayVisibilityProvider.notifier);
+      final firstOwner = Object();
+      final secondOwner = Object();
+
+      notifier.setBottomSheetOpenForOwner(firstOwner, isOpen: true);
+      notifier.setBottomSheetOpenForOwner(secondOwner, isOpen: true);
+      notifier.setBottomSheetOpenForOwner(firstOwner, isOpen: false);
+
+      expect(
+        container.read(overlayVisibilityProvider).isBottomSheetOpen,
+        isTrue,
+      );
+
+      notifier.setBottomSheetOpenForOwner(secondOwner, isOpen: false);
+
+      expect(
+        container.read(overlayVisibilityProvider).isBottomSheetOpen,
+        isFalse,
+      );
+    });
+
+    test('provider rebuild preserves owner-held bottom sheet overlays', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final notifier = container.read(overlayVisibilityProvider.notifier);
+      final owner = Object();
+
+      notifier.setBottomSheetOpenForOwner(owner, isOpen: true);
+      container.invalidate(overlayVisibilityProvider);
+
+      expect(
+        container.read(overlayVisibilityProvider).isBottomSheetOpen,
+        isTrue,
+      );
+
+      notifier.setBottomSheetOpenForOwner(owner, isOpen: false);
+
+      expect(
+        container.read(overlayVisibilityProvider).isBottomSheetOpen,
+        isFalse,
+      );
+    });
+
+    test('clearOverlays resets page and bottom sheet overlay owners', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final notifier = container.read(overlayVisibilityProvider.notifier);
+
+      notifier.setPageOpenForOwner(Object(), isOpen: true);
+      notifier.setBottomSheetOpenForOwner(Object(), isOpen: true);
+      notifier.clearOverlays();
+
+      final state = container.read(overlayVisibilityProvider);
+      expect(state.isPageOpen, isFalse);
+      expect(state.isBottomSheetOpen, isFalse);
     });
   });
 
@@ -202,7 +263,7 @@ void main() {
 
       container
           .read(overlayVisibilityProvider.notifier)
-          .setBottomSheetOpen(true);
+          .setBottomSheetOpenForOwner(Object(), isOpen: true);
       expect(container.read(hasVisibleOverlayProvider), isTrue);
     });
 
@@ -227,17 +288,18 @@ void main() {
     test('bottom sheet open/close cycle returns to false', () {
       final container = ProviderContainer();
       addTearDown(container.dispose);
+      final owner = Object();
 
       expect(container.read(hasVisibleOverlayProvider), isFalse);
 
       container
           .read(overlayVisibilityProvider.notifier)
-          .setBottomSheetOpen(true);
+          .setBottomSheetOpenForOwner(owner, isOpen: true);
       expect(container.read(hasVisibleOverlayProvider), isTrue);
 
       container
           .read(overlayVisibilityProvider.notifier)
-          .setBottomSheetOpen(false);
+          .setBottomSheetOpenForOwner(owner, isOpen: false);
       expect(container.read(hasVisibleOverlayProvider), isFalse);
     });
   });
@@ -327,7 +389,7 @@ void main() {
 
         container
             .read(overlayVisibilityProvider.notifier)
-            .setBottomSheetOpen(true);
+            .setBottomSheetOpenForOwner(Object(), isOpen: true);
         expect(container.read(activeVideoIdProvider), isNull);
       },
     );

--- a/mobile/test/providers/upload_media_providers_test.dart
+++ b/mobile/test/providers/upload_media_providers_test.dart
@@ -50,7 +50,7 @@ void main() {
       container.read(activeBranchIndexProvider.notifier).state = 0;
       container
           .read(overlayVisibilityProvider.notifier)
-          .setBottomSheetOpen(true);
+          .setBottomSheetOpenForOwner(Object(), isOpen: true);
 
       expect(container.read(uploadBackpressureActiveProvider), isFalse);
     });

--- a/mobile/test/router/app_shell_obscured_test.dart
+++ b/mobile/test/router/app_shell_obscured_test.dart
@@ -346,6 +346,9 @@ void main() {
       container
           .read(overlayVisibilityProvider.notifier)
           .setPageOpenForOwner(Object(), isOpen: true);
+      container
+          .read(overlayVisibilityProvider.notifier)
+          .setBottomSheetOpenForOwner(Object(), isOpen: true);
 
       // A go()-style back removes the pushed route declaratively, so
       // pushWithVideoPause's future never completes. AppShell must still notice
@@ -359,6 +362,11 @@ void main() {
         container.read(overlayVisibilityProvider).isPageOpen,
         isFalse,
         reason: 'a stranded page flag keeps the home feed from autoplaying',
+      );
+      expect(
+        container.read(overlayVisibilityProvider).isBottomSheetOpen,
+        isFalse,
+        reason: 'a stranded bottom-sheet flag keeps the home feed paused',
       );
     },
   );

--- a/mobile/test/screens/feed/video_feed_page_test.dart
+++ b/mobile/test/screens/feed/video_feed_page_test.dart
@@ -1306,10 +1306,14 @@ void main() {
             index;
       }
 
-      void setBottomSheetOpen(WidgetTester tester, {required bool open}) {
-        containerOf(
-          tester,
-        ).read(overlayVisibilityProvider.notifier).setBottomSheetOpen(open);
+      void setBottomSheetOpen(
+        WidgetTester tester, {
+        required Object owner,
+        required bool open,
+      }) {
+        containerOf(tester)
+            .read(overlayVisibilityProvider.notifier)
+            .setBottomSheetOpenForOwner(owner, isOpen: open);
       }
 
       final pageOpenOwner = Object();
@@ -1388,6 +1392,7 @@ void main() {
         (tester) async {
           await pumpFeed(tester);
           await tester.pump();
+          final bottomSheetOwner = Object();
 
           // Active home feed releases neighbours when it backgrounds.
           expect(feedVideos(tester).isActive, isTrue);
@@ -1395,13 +1400,13 @@ void main() {
 
           // A bottom sheet (comments/share) pauses the current player but must
           // NOT tear down the off-screen neighbours or prefetch.
-          setBottomSheetOpen(tester, open: true);
+          setBottomSheetOpen(tester, owner: bottomSheetOwner, open: true);
           await tester.pump();
           expect(feedVideos(tester).isActive, isFalse);
           expect(feedVideos(tester).releaseNeighboursWhenInactive, isFalse);
 
           // Closing the sheet restores the release-on-background behaviour.
-          setBottomSheetOpen(tester, open: false);
+          setBottomSheetOpen(tester, owner: bottomSheetOwner, open: false);
           await tester.pump();
           expect(feedVideos(tester).isActive, isTrue);
           expect(feedVideos(tester).releaseNeighboursWhenInactive, isTrue);
@@ -1431,8 +1436,9 @@ void main() {
         (tester) async {
           await pumpFeed(tester);
           await tester.pump();
+          final bottomSheetOwner = Object();
 
-          setBottomSheetOpen(tester, open: true);
+          setBottomSheetOpen(tester, owner: bottomSheetOwner, open: true);
           await tester.pump();
           expect(feedVideos(tester).isActive, isFalse);
           expect(feedVideos(tester).releaseNeighboursWhenInactive, isFalse);

--- a/mobile/test/utils/pause_aware_modals_test.dart
+++ b/mobile/test/utils/pause_aware_modals_test.dart
@@ -115,6 +115,102 @@ void main() {
     );
 
     testWidgets(
+      'keeps isBottomSheetOpen true until nested sheets all dismiss',
+      (tester) async {
+        await setSheetTestSurface(tester);
+
+        late ProviderContainer container;
+        await tester.pumpWidget(
+          ProviderScope(
+            child: Consumer(
+              builder: (context, ref, _) {
+                container = ProviderScope.containerOf(context, listen: false);
+                return MaterialApp(
+                  home: Scaffold(
+                    body: Builder(
+                      builder: (innerContext) => ElevatedButton(
+                        onPressed: () {
+                          innerContext.showVideoPausingVineBottomSheet<void>(
+                            title: const Text('Sheet A'),
+                            children: [
+                              Builder(
+                                builder: (sheetContext) => ElevatedButton(
+                                  onPressed: () {
+                                    sheetContext
+                                        .showVideoPausingVineBottomSheet<void>(
+                                          title: const Text('Sheet B'),
+                                          children: [
+                                            const Text('Body B'),
+                                            ElevatedButton(
+                                              onPressed: () => Navigator.of(
+                                                sheetContext,
+                                                rootNavigator: true,
+                                              ).pop(),
+                                              child: const Text('Close B'),
+                                            ),
+                                          ],
+                                        );
+                                  },
+                                  child: const Text('Open nested'),
+                                ),
+                              ),
+                              Builder(
+                                builder: (sheetContext) => ElevatedButton(
+                                  onPressed: () => Navigator.of(
+                                    sheetContext,
+                                    rootNavigator: true,
+                                  ).pop(),
+                                  child: const Text('Close A'),
+                                ),
+                              ),
+                            ],
+                          );
+                        },
+                        child: const Text('Open'),
+                      ),
+                    ),
+                  ),
+                );
+              },
+            ),
+          ),
+        );
+
+        await tester.tap(find.text('Open'));
+        await tester.pumpAndSettle();
+        expect(
+          container.read(overlayVisibilityProvider).isBottomSheetOpen,
+          isTrue,
+        );
+
+        await tester.tap(find.text('Open nested'));
+        await tester.pumpAndSettle();
+        expect(find.text('Body B'), findsOneWidget);
+        expect(
+          container.read(overlayVisibilityProvider).isBottomSheetOpen,
+          isTrue,
+        );
+
+        await tester.tap(find.text('Close B'));
+        await tester.pumpAndSettle();
+        expect(find.text('Body B'), findsNothing);
+        expect(find.text('Sheet A'), findsOneWidget);
+        expect(
+          container.read(overlayVisibilityProvider).isBottomSheetOpen,
+          isTrue,
+        );
+
+        await tester.tap(find.text('Close A'));
+        await tester.pumpAndSettle();
+        expect(find.text('Sheet A'), findsNothing);
+        expect(
+          container.read(overlayVisibilityProvider).isBottomSheetOpen,
+          isFalse,
+        );
+      },
+    );
+
+    testWidgets(
       'tapOutsideToDismiss: false keeps the sheet open on outside tap',
       (tester) async {
         await setSheetTestSurface(tester);

--- a/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart
+++ b/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart
@@ -18,6 +18,7 @@ import 'package:models/models.dart';
 import 'package:openvine/blocs/video_interactions/video_interactions_bloc.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/overlay_visibility_provider.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/sounds_providers.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
@@ -1888,6 +1889,53 @@ void main() {
         expect(urlLauncher.launched, isNotEmpty);
         expect(urlLauncher.launched.last.url, equals(proofmodeLearnMoreUrl));
         expect(urlLauncher.launched.last.useExternalApplication, isTrue);
+      },
+    );
+
+    testWidgetsWithSurfaceSize(
+      'dismissing nested explainer preserves parent metadata sheet hold',
+      (tester) async {
+        final video = _makeVideo(rawTags: {'verification': 'verified_mobile'});
+        await tester.pumpWidget(
+          buildSubject(child: MetadataVerificationSection(video: video)),
+        );
+
+        final container = ProviderScope.containerOf(
+          tester.element(find.byType(MetadataVerificationSection)),
+          listen: false,
+        );
+        final parentOwner = Object();
+        container
+            .read(overlayVisibilityProvider.notifier)
+            .setBottomSheetOpenForOwner(parentOwner, isOpen: true);
+
+        final l10n = _l10n(tester);
+        await tester.tap(find.text(l10n.metadataVerificationLabel));
+        await tester.pumpAndSettle();
+        expect(find.byType(MetadataVerificationInfoSheet), findsOneWidget);
+        expect(
+          container.read(overlayVisibilityProvider).isBottomSheetOpen,
+          isTrue,
+        );
+
+        Navigator.of(
+          tester.element(find.byType(MetadataVerificationInfoSheet)),
+          rootNavigator: true,
+        ).pop();
+        await tester.pumpAndSettle();
+        expect(find.byType(MetadataVerificationInfoSheet), findsNothing);
+        expect(
+          container.read(overlayVisibilityProvider).isBottomSheetOpen,
+          isTrue,
+        );
+
+        container
+            .read(overlayVisibilityProvider.notifier)
+            .setBottomSheetOpenForOwner(parentOwner, isOpen: false);
+        expect(
+          container.read(overlayVisibilityProvider).isBottomSheetOpen,
+          isFalse,
+        );
       },
     );
 


### PR DESCRIPTION
## Summary

- make bottom-sheet overlay visibility owner-backed, matching the page overlay owner model
- preserve bottom-sheet overlay state across provider rebuilds and clear stranded sheet owners through the AppShell recovery path
- route the metadata verification explainer back through the pause-aware sheet wrapper now that nested sheets release independently

Fixes #7501.
Fixes #7494.

## Validation

- `dart run build_runner build --delete-conflicting-outputs`
- `flutter analyze`
- `flutter test test/providers/overlay_visibility_provider_test.dart test/utils/pause_aware_modals_test.dart test/router/app_shell_obscured_test.dart test/providers/upload_media_providers_test.dart test/screens/feed/video_feed_page_test.dart test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart`
- pre-push hook: analyzer, generated-file verification, changed-file tests
