### PR TITLE
fix(comments): enable spell check in the comment composers

### DIFF
--- a/mobile/lib/screens/comments/widgets/comment_input.dart
+++ b/mobile/lib/screens/comments/widgets/comment_input.dart
@@ -392,6 +392,13 @@ class _CommentTextField extends StatelessWidget {
               : TextInputAction.send,
           onSubmitted: isComposingMultiline ? null : (_) => onSubmitted(),
           enableInteractiveSelection: true,
+          // A posted comment cannot be edited away from every relay that
+          // already has it, so catching the typo before send is the only
+          // real fix. This is the same region-aware config DivineTextField
+          // applies by default; the pill styling here needs a raw TextField,
+          // which opts out of spell check unless it is passed explicitly.
+          spellCheckConfiguration:
+              DivineTextField.defaultSpellCheckConfiguration,
           style: VineTheme.bodyLargeFont(color: context.vineColors.onSurface),
           cursorColor: VineTheme.tabIndicatorGreen,
           decoration: InputDecoration(

--- a/mobile/lib/screens/comments/widgets/comment_input.dart
+++ b/mobile/lib/screens/comments/widgets/comment_input.dart
@@ -392,11 +392,9 @@ class _CommentTextField extends StatelessWidget {
               : TextInputAction.send,
           onSubmitted: isComposingMultiline ? null : (_) => onSubmitted(),
           enableInteractiveSelection: true,
-          // A posted comment cannot be edited away from every relay that
-          // already has it, so catching the typo before send is the only
-          // real fix. This is the same region-aware config DivineTextField
-          // applies by default; the pill styling here needs a raw TextField,
-          // which opts out of spell check unless it is passed explicitly.
+          // The pill styling needs a raw TextField, which leaves spell check
+          // off unless a config is passed — DivineTextField applies this same
+          // one by default.
           spellCheckConfiguration:
               DivineTextField.defaultSpellCheckConfiguration,
           style: VineTheme.bodyLargeFont(color: context.vineColors.onSurface),

--- a/mobile/lib/widgets/video_feed_item/inline_comment_composer_bar.dart
+++ b/mobile/lib/widgets/video_feed_item/inline_comment_composer_bar.dart
@@ -244,6 +244,12 @@ class _ComposerField extends StatelessWidget {
                     // convention.
                     onTapOutside: (_) =>
                         FocusManager.instance.primaryFocus?.unfocus(),
+                    // Matches the comments-sheet composer: a raw TextField
+                    // has spell check off unless it is passed explicitly,
+                    // and a posted comment is not something the user can
+                    // take back cleanly.
+                    spellCheckConfiguration:
+                        DivineTextField.defaultSpellCheckConfiguration,
                     cursorColor: VineTheme.tabIndicatorGreen,
                     style: VineTheme.bodyLargeFont(
                       color: context.vineColors.primaryText,

--- a/mobile/lib/widgets/video_feed_item/inline_comment_composer_bar.dart
+++ b/mobile/lib/widgets/video_feed_item/inline_comment_composer_bar.dart
@@ -244,10 +244,8 @@ class _ComposerField extends StatelessWidget {
                     // convention.
                     onTapOutside: (_) =>
                         FocusManager.instance.primaryFocus?.unfocus(),
-                    // Matches the comments-sheet composer: a raw TextField
-                    // has spell check off unless it is passed explicitly,
-                    // and a posted comment is not something the user can
-                    // take back cleanly.
+                    // Raw TextFields leave spell check off unless a config is
+                    // passed; matches the comments-sheet composer.
                     spellCheckConfiguration:
                         DivineTextField.defaultSpellCheckConfiguration,
                     cursorColor: VineTheme.tabIndicatorGreen,

--- a/mobile/test/screens/comments/comment_input_test.dart
+++ b/mobile/test/screens/comments/comment_input_test.dart
@@ -535,5 +535,26 @@ void main() {
       expect(selectedStart, 0);
       expect(selectedEnd, 8);
     });
+
+    testWidgets('enables spell check on the composer field', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: CommentInput(
+              controller: controller,
+              onSubmit: () {},
+            ),
+          ),
+        ),
+      );
+
+      final textField = tester.widget<TextField>(find.byType(TextField));
+      expect(
+        textField.spellCheckConfiguration,
+        DivineTextField.defaultSpellCheckConfiguration,
+      );
+    });
   });
 }

--- a/mobile/test/widgets/video_feed_item/inline_comment_composer_bar_test.dart
+++ b/mobile/test/widgets/video_feed_item/inline_comment_composer_bar_test.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 
 import 'package:bloc_test/bloc_test.dart';
+import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -142,6 +143,22 @@ void main() {
         expect(field.keyboardType, TextInputType.multiline);
       },
     );
+
+    testWidgets('enables spell check on the composer field', (tester) async {
+      await tester.pumpWidget(buildBar());
+
+      final field = tester.widget<TextField>(
+        find.descendant(
+          of: find.bySemanticsIdentifier('inline_comment_composer_field'),
+          matching: find.byType(TextField),
+        ),
+      );
+
+      expect(
+        field.spellCheckConfiguration,
+        DivineTextField.defaultSpellCheckConfiguration,
+      );
+    });
 
     testWidgets(
       'still hides the send button when the field only has whitespace',


### PR DESCRIPTION
Closes #7511

## Description

Comment composers had no spell check. `DivineTextField` enables the region-aware checker by default since #5886, whose stated goal was to turn the OS spell-check underline and the "Replace" suggestion flow on for *every* text field in the app — but it did so inside `DivineTextField`. Both comment composers are raw `TextField`s, because the rounded pill they render needs one, and a raw `TextField` leaves `spellCheckConfiguration` null. So the one surface users type the most prose into was left out.

That is also the surface where it matters most: a posted comment cannot be pulled back from every relay that already carries it, so catching the typo before send is the only real fix. This came in as user feedback — *"Maybe spellcheck when we type a comment out. It's difficult to erase them after you accidentally posted."*

Both fields now point at `DivineTextField.defaultSpellCheckConfiguration` rather than constructing their own config. It is one shared instance, so `RegionAwareSpellCheckService` keeps its resolved-locale cache instead of re-probing the platform on every rebuild.

## Out of Scope

- **Other raw `TextField`s that still lack spell check.** The same one-line gap exists in the DM composer (`message_input_bar.dart`, `reel_dm_reply_bar.dart`), the share-sheet message, the video-editor text sticker, and the bug/feature/report dialogs. Deliberately not touched here — this PR answers the comment-specific feedback. Worth a follow-up, especially the text sticker, since the original request (#2575) named overlaid text explicitly.
- **The Android fallback contract in `RegionAwareSpellCheckService`.** The service advances to the next locale candidate only when the delegate returns `null`, which is iOS' `UITextChecker` semantics. Whether Android signals an unsupported locale the same way is unverified — see Verification below. Not changed here; a speculative fix without a reproducible root cause would be worse than the open question.

## Verification

- `flutter analyze lib test` — clean
- `flutter test test/screens/comments test/widgets/video_feed_item/inline_comment_composer_bar_test.dart` — 144 passing, including a new regression test per composer asserting the config reaches the `TextField`

Platform behaviour was measured with a throwaway probe app driving `DefaultSpellCheckService` directly against `halo weld wie geht es ech` (not committed):

| Locale | iOS Simulator | Samsung Galaxy S25 (SM-S942B) |
|---|---|---|
| `de-CH` | `null` — unsupported | `[]` |
| `de-DE` | 3 spans (`halo → hallo`, `weld → Held/Feld/wild`, `ech → ich/euch/echt`) | `[]` |
| `en-US` | 3 spans | `[]` |

iOS behaves exactly as intended, including the `de_CH → de_DE` fallback that `RegionAwareSpellCheckService` exists for.

On the Galaxy nothing renders, and that is device-side rather than app-side: `dumpsys textservices` lists exactly one spell checker service, Samsung's `HoneyBoardSpellCheckerService`, and it answers Flutter's `getSentenceSuggestions()` with an empty list for every locale — including `en-US` against unambiguous misspellings. No Gboard / Google spell checker is installed. Any Flutter field on that device behaves the same, including every existing `DivineTextField`.

Because every locale comes back empty there, that measurement cannot distinguish "locale unsupported" from "no working service", which is why the Android half of the fallback contract above stays an open question rather than a fix.


## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
