### PR TITLE
fix(analytics): gate view events on signer readiness

### DIFF
--- a/mobile/lib/models/view_event_drop_reason.dart
+++ b/mobile/lib/models/view_event_drop_reason.dart
@@ -15,13 +15,20 @@ enum ViewEventDropReason {
   /// No signed-in identity, so nothing could sign the event.
   notAuthenticated,
 
+  /// An identity is signed in but cannot sign yet.
+  ///
+  /// A Keycast identity with no local key reaches `AuthState.authenticated`
+  /// before its signer is usable, so [notAuthenticated] never fires for the
+  /// cold-start window between the two.
+  signerNotReady,
+
   /// The video carried no addressable `d` tag, so no `a` tag could be built.
   missingAddressableDTag,
 
   /// The video kind is not addressable, so it cannot be cited by an `a` tag.
   nonAddressableVideoKind,
 
-  /// Signing returned no event.
+  /// Signing returned no event even though the signer reported it was ready.
   signingFailed,
 
   /// An unexpected exception interrupted event construction or publishing.
@@ -46,9 +53,14 @@ enum ViewEventDropReason {
   /// no minimum watch time left to fall below, so reaching it means the
   /// caller supplied a range that ends before it starts, or no segment it
   /// could use at all.
+  ///
+  /// [signerNotReady] is not structural: identity known is not signer ready
+  /// (see `.claude/rules/state_management.md`), and the gap resolves itself
+  /// once the signer warms up.
   bool get isStructural => switch (this) {
     ViewEventDropReason.invalidWatchRange => true,
     ViewEventDropReason.notAuthenticated => false,
+    ViewEventDropReason.signerNotReady => false,
     ViewEventDropReason.missingAddressableDTag => true,
     ViewEventDropReason.nonAddressableVideoKind => false,
     ViewEventDropReason.signingFailed => true,

--- a/mobile/lib/services/view_event_publisher.dart
+++ b/mobile/lib/services/view_event_publisher.dart
@@ -96,20 +96,25 @@ class ViewEventPublisher {
       return _drop(ViewEventDropReason.notAuthenticated, video.id, method);
     }
 
-    // Explicit publish-readiness gate. `isAuthenticated` only says the pubkey
-    // is known: a Keycast identity with no local key is authenticated well
-    // before its signer works, and signing in that window returns null, which
-    // used to be filed as a structural `signingFailed` invariant (#7505).
-    // Sampled at the moment of use, per `canPublishNostrWritesNow`'s contract.
-    if (!_authService.canPublishNostrWritesNow) {
-      return _drop(ViewEventDropReason.signerNotReady, video.id, method);
-    }
-
     try {
       // View events require an addressable video reference.
       final aTag = video.addressableId;
       if (aTag == null) {
         return _drop(_missingAddressableReason(video), video.id, method);
+      }
+
+      // Explicit publish-readiness gate. `isAuthenticated` only says the
+      // pubkey is known: a Keycast identity with no local key is authenticated
+      // well before its signer works, and signing in that window returns null,
+      // which used to be filed as a structural `signingFailed` invariant
+      // (#7505). Sampled at the moment of use, per the getter's contract.
+      //
+      // Deliberately below the addressable check: a missing `d` tag is a
+      // permanent defect, and `ViewEventRetryService` deletes those rows
+      // whatever the drop reason, so gating first would bin the evidence
+      // before it was ever reported.
+      if (!_authService.canPublishNostrWritesNow) {
+        return _drop(ViewEventDropReason.signerNotReady, video.id, method);
       }
 
       // Get relay hint

--- a/mobile/lib/services/view_event_publisher.dart
+++ b/mobile/lib/services/view_event_publisher.dart
@@ -96,6 +96,15 @@ class ViewEventPublisher {
       return _drop(ViewEventDropReason.notAuthenticated, video.id, method);
     }
 
+    // Explicit publish-readiness gate. `isAuthenticated` only says the pubkey
+    // is known: a Keycast identity with no local key is authenticated well
+    // before its signer works, and signing in that window returns null, which
+    // used to be filed as a structural `signingFailed` invariant (#7505).
+    // Sampled at the moment of use, per `canPublishNostrWritesNow`'s contract.
+    if (!_authService.canPublishNostrWritesNow) {
+      return _drop(ViewEventDropReason.signerNotReady, video.id, method);
+    }
+
     try {
       // View events require an addressable video reference.
       final aTag = video.addressableId;

--- a/mobile/test/models/view_event_drop_reason_test.dart
+++ b/mobile/test/models/view_event_drop_reason_test.dart
@@ -12,6 +12,13 @@ void main() {
       expect(ViewEventDropReason.relayRejected.isStructural, isFalse);
     });
 
+    test('a signer that is still warming up is not structural', () {
+      // Identity known is not signer ready: a Keycast identity with no local
+      // key is authenticated before it can sign, so this drop resolves itself
+      // and must not reach Crashlytics as an invariant (#7505).
+      expect(ViewEventDropReason.signerNotReady.isStructural, isFalse);
+    });
+
     test('failures to build a publishable event are structural', () {
       expect(ViewEventDropReason.missingAddressableDTag.isStructural, isTrue);
       expect(ViewEventDropReason.signingFailed.isStructural, isTrue);

--- a/mobile/test/models/view_event_drop_reason_test.dart
+++ b/mobile/test/models/view_event_drop_reason_test.dart
@@ -28,16 +28,6 @@ void main() {
     test('an inverted watch range is structural, not an expected skip', () {
       expect(ViewEventDropReason.invalidWatchRange.isStructural, isTrue);
     });
-
-    test('every reason states its reportability', () {
-      for (final reason in ViewEventDropReason.values) {
-        expect(
-          () => reason.isStructural,
-          returnsNormally,
-          reason: '$reason must declare whether it is a defect',
-        );
-      }
-    });
   });
 
   group(ViewEventInvariantException, () {

--- a/mobile/test/services/view_event_publisher_test.dart
+++ b/mobile/test/services/view_event_publisher_test.dart
@@ -407,6 +407,49 @@ void main() {
       );
 
       test(
+        'still reports a missing d tag while the signer warms up',
+        () async {
+          final drops =
+              <({ViewEventDropReason reason, String videoId, String method})>[];
+          publisher = ViewEventPublisher(
+            nostrService: mockNostr,
+            authService: mockAuth,
+            onDrop:
+                (reason, {required String videoId, required String method}) {
+                  drops.add((reason: reason, videoId: videoId, method: method));
+                },
+          );
+          when(() => mockAuth.canPublishNostrWritesNow).thenReturn(false);
+
+          final result = await publisher.publishViewEvent(
+            video: createTestVideoEvent(
+              id: 'addressable_video_without_d',
+              pubkey: creatorPubkey,
+              clearAddressableDTag: true,
+              eventKind: NIP71VideoKinds.addressableShortVideo,
+            ),
+            startSeconds: 0,
+            endSeconds: 5,
+          );
+
+          // The readiness gate must not mask the permanent defect. A queued
+          // row with no d tag is deleted by ViewEventRetryService whatever the
+          // drop reason, and the first sweep runs on foreground — inside the
+          // cold-start warm-up window — so a readiness-first ordering would
+          // bin every such row without ever reporting the invariant.
+          expect(result, isFalse);
+          expect(drops, [
+            (
+              reason: ViewEventDropReason.missingAddressableDTag,
+              videoId: 'addressable_video_without_d',
+              method: 'publishViewEvent',
+            ),
+          ]);
+          expect(drops.single.reason.isStructural, isTrue);
+        },
+      );
+
+      test(
         'still reports signingFailed when a ready signer returns null',
         () async {
           final drops =

--- a/mobile/test/services/view_event_publisher_test.dart
+++ b/mobile/test/services/view_event_publisher_test.dart
@@ -40,6 +40,7 @@ void main() {
       mockAuth = _MockAuthService();
 
       when(() => mockAuth.isAuthenticated).thenReturn(true);
+      when(() => mockAuth.canPublishNostrWritesNow).thenReturn(true);
       when(() => mockAuth.currentPublicKeyHex).thenReturn(viewerPubkey);
       when(() => mockNostr.connectedRelays).thenReturn([]);
 
@@ -359,6 +360,97 @@ void main() {
       });
 
       test(
+        'does not attempt to sign while an authenticated signer warms up',
+        () async {
+          final drops =
+              <({ViewEventDropReason reason, String videoId, String method})>[];
+          publisher = ViewEventPublisher(
+            nostrService: mockNostr,
+            authService: mockAuth,
+            onDrop:
+                (reason, {required String videoId, required String method}) {
+                  drops.add((reason: reason, videoId: videoId, method: method));
+                },
+          );
+          // A Keycast identity with no local key: authenticated, not yet
+          // able to sign.
+          when(() => mockAuth.canPublishNostrWritesNow).thenReturn(false);
+
+          final result = await publisher.publishViewEvent(
+            video: createTestVideoEvent(
+              id: 'warming_up_video',
+              pubkey: creatorPubkey,
+              vineId: 'warming_up_d_tag',
+            ),
+            startSeconds: 0,
+            endSeconds: 5,
+          );
+
+          expect(result, isFalse);
+          expect(drops, [
+            (
+              reason: ViewEventDropReason.signerNotReady,
+              videoId: 'warming_up_video',
+              method: 'publishViewEvent',
+            ),
+          ]);
+          expect(drops.single.reason.isStructural, isFalse);
+          verifyNever(
+            () => mockAuth.createAndSignEvent(
+              kind: any(named: 'kind'),
+              content: any(named: 'content'),
+              tags: any(named: 'tags'),
+            ),
+          );
+          verifyNever(() => mockNostr.publishEvent(any()));
+        },
+      );
+
+      test(
+        'still reports signingFailed when a ready signer returns null',
+        () async {
+          final drops =
+              <({ViewEventDropReason reason, String videoId, String method})>[];
+          publisher = ViewEventPublisher(
+            nostrService: mockNostr,
+            authService: mockAuth,
+            onDrop:
+                (reason, {required String videoId, required String method}) {
+                  drops.add((reason: reason, videoId: videoId, method: method));
+                },
+          );
+          when(
+            () => mockAuth.createAndSignEvent(
+              kind: any(named: 'kind'),
+              content: any(named: 'content'),
+              tags: any(named: 'tags'),
+            ),
+          ).thenAnswer((_) async => null);
+
+          final result = await publisher.publishViewEvent(
+            video: createTestVideoEvent(
+              id: 'ready_signer_video',
+              pubkey: creatorPubkey,
+              vineId: 'ready_signer_d_tag',
+            ),
+            startSeconds: 0,
+            endSeconds: 5,
+          );
+
+          expect(result, isFalse);
+          expect(drops, [
+            (
+              reason: ViewEventDropReason.signingFailed,
+              videoId: 'ready_signer_video',
+              method: 'publishViewEvent',
+            ),
+          ]);
+          expect(drops.single.reason.isStructural, isTrue);
+          verifyNever(() => mockNostr.publishEvent(any()));
+        },
+      );
+
+      test(
         'reports thrown signing errors as unexpected structural drops',
         () async {
           final drops =
@@ -461,6 +553,7 @@ void main() {
           reset(mockNostr);
 
           when(() => mockAuth.isAuthenticated).thenReturn(true);
+          when(() => mockAuth.canPublishNostrWritesNow).thenReturn(true);
           when(() => mockAuth.currentPublicKeyHex).thenReturn(viewerPubkey);
           when(() => mockNostr.connectedRelays).thenReturn([]);
           when(

--- a/mobile/test/services/view_event_queue_publish_repro_test.dart
+++ b/mobile/test/services/view_event_queue_publish_repro_test.dart
@@ -53,6 +53,7 @@ void main() {
       mockAuth = _MockAuthService();
 
       when(() => mockAuth.isAuthenticated).thenReturn(true);
+      when(() => mockAuth.canPublishNostrWritesNow).thenReturn(true);
       when(() => mockNostr.connectedRelays).thenReturn([]);
       when(
         () => mockAuth.createAndSignEvent(


### PR DESCRIPTION
## Description

`ViewEventPublisher` gated only on `AuthService.isAuthenticated` before signing a kind-22236 view event. That predicate only says the pubkey is known — per `.claude/rules/state_management.md` ("Signing readiness: identity known is not signer ready"), a Keycast identity with no local key reaches `AuthState.authenticated` well before its signer is usable. In that window `createAndSignEvent` returns `null`, the publisher dropped with `signingFailed`, and because `signingFailed.isStructural` is `true` the drop was wrapped in `Reportable` and filed to Crashlytics as an invariant violation — a matrix-**NO** category per `.claude/rules/error_handling.md`, for a condition that resolves itself milliseconds later.

**Direction taken: (a) gate on signer readiness before attempting to sign.**

The issue sketched two options. Only (a) is implementable on the current code, and it is also the codebase's established idiom:

- **(b) — classify the outcome of a failed sign — is not possible at this layer.** `AuthService.createAndSignEvent` collapses every failure into a bare `null`. Tracing the null paths (`AuthService` identity guard, `PubkeyOnlyNostrIdentity.signEvent`, `SignerFactory`'s signer-returned-null / remote-verify-failed / `isValid`-failed / catch-all branches), none of them are distinguishable by the caller. To tell "not ready yet" from "genuinely failed" the publisher must consult a readiness signal *before* signing — which is direction (a).
- **`canPublishNostrWritesNow` is the sanctioned signal for exactly this**, and it covers all three shapes of the window: null identity, `PubkeyOnlyNostrIdentity`, and Keycast before `rpcReady`. `PubkeyOnlyNostrIdentity`'s own doc comment already tells callers to "Gate on `AuthService.canPublishNostrWritesNow`". `VideoSharingService.shareVideo` added the same explicit gate for the same class of bug in #6423, and this change mirrors it.
- It is sampled at the moment of use, which is what that getter's contract asks for — `ViewEventPublisher` is a pull consumer that re-reads on every call, so it cannot go stale.

The gate needs its own drop reason, so `ViewEventDropReason.signerNotReady` is added and classified non-structural. This is not direction (b): `signingFailed` keeps its meaning and its `isStructural => true` classification, but it can now only be reached when the signer reported it was ready and still produced nothing — which is the invariant the reason was written to catch.

### Gate ordering

The gate sits **below** the addressable-`a`-tag check, not above it. Second commit; the first commit had it above, which was wrong.

`ViewEventRetryService.sweep` deletes a queued row whenever `video.addressableId == null`, regardless of *why* the publish returned false. And a sweep runs early and often: `social_providers.dart:600` wires `flushPendingViewEvents: retryService?.sweep`, so `AnalyticsService` triggers a full sweep immediately after every tracked `view_end` — the first one lands as soon as the first video of the session finishes, well inside the cold-start window. (The foreground stream triggers sweeps too, which covers the resume-from-background case.)

With the gate above the addressable check, a `d`-tag-less row swept in that window dropped as `signerNotReady`, got deleted anyway, and its structural `missingAddressableDTag` invariant was never reported. That is evidence destroyed rather than deferred, for any such row left over from a previous session. It also silently invalidated the retry service's `// The publisher has now reported the missing d tag` comment.

A missing `d` tag is a permanent property of the event and a genuine client defect; signer readiness is transient. Checking the permanent condition first keeps the alarm intact and leaves `signerNotReady` for events that are otherwise publishable.

Behaviour on the retry path is otherwise unchanged: for a well-formed event the gate still returns `false`, so `ViewEventRetryService` still calls `markFailed` and the row stays queued for a later sweep. Views are enqueued durably before the publish attempt (`AnalyticsService._enqueuePendingViewEvent` runs first, and the direct publish is only the fallback when there is no DAO/pubkey), so no view is lost — it is just no longer reported as a crash.

**Related Issue:** Closes #7505

## Out of Scope

`signingFailed` stays structural. After the gate it can still be reached by a remote signer (Keycast RPC, Bunker, Amber, NIP-07) that reported ready and then failed mid-call, or by a user declining an interactive signing prompt — arguably matrix-NO conditions too. That is a different condition from the one reported here (the signer was ready, so it is not a startup race), and folding it in would remove the only alarm left on the signing path. Worth a separate look with its own Crashlytics evidence rather than being bundled in here. Note that the one unambiguous invariant in that path, `EventSignerAccountMismatchException`, is already reported at the `SignerFactory` layer with its own type (`signer_factory.dart:319`).

`notAuthenticated` keeps its position above the addressable check. It has the same evidence-destroying shape in principle, but it is pre-existing behaviour that this PR does not touch, and `ViewEventRetryService` is constructed with a concrete `userPubkey`, so the signed-out case is not the one the sweep hits.

## Verification

Run from `mobile/`:

- `dart format` on the five changed files — no reflow.
- `flutter analyze lib test integration_test` — `No issues found!`
- `flutter test test/models/view_event_drop_reason_test.dart test/services/view_event_publisher_test.dart test/services/view_event_queue_publish_repro_test.dart test/services/view_event_retry_service_test.dart test/services/analytics_service_test.dart` — 57/57 passing.

Mutation-checked the new coverage rather than trusting a green run:

- Delete the readiness gate from `view_event_publisher.dart` ⇒ `does not attempt to sign while an authenticated signer warms up` fails (`Expected: false / Actual: <true>`).
- Move the gate back above the addressable check ⇒ `still reports a missing d tag while the signer warms up` fails.

Tests added:

- `view_event_drop_reason_test.dart` — pins `signerNotReady` as non-structural, so a future edit cannot silently re-route it to Crashlytics.
- `view_event_publisher_test.dart` — `does not attempt to sign while an authenticated signer warms up` (authenticated + `canPublishNostrWritesNow` false ⇒ drops `signerNotReady`, never calls `createAndSignEvent`, never publishes); `still reports a missing d tag while the signer warms up` (pins the gate ordering); and `still reports signingFailed when a ready signer returns null` (proves the gate did not swallow the real invariant).

Two existing suites needed a `canPublishNostrWritesNow` stub on their `AuthService` mock (`view_event_publisher_test.dart`, `view_event_queue_publish_repro_test.dart`); no assertions were weakened.

**Device verification is still pending** — I could not run this on the real Samsung Galaxy. The user-visible surface is nil (view events are silent either way); what needs confirming on device is the negative: that Crashlytics stops receiving `ViewEventInvariantException(signingFailed)` from cold start on a Keycast account with no local key.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
