### PR TITLE
fix(search): rank by followers then video, keep follows boosted first

### DIFF
--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -2311,14 +2311,15 @@ class ProfileRepository implements ProfileReader {
     return _boostProfiles(filtered, boostPubkeys);
   }
 
-  /// Orders a server-sorted result page, falling back when the requested
-  /// sort is a no-op on the payload.
+  /// Orders a server-sorted result page by the signals the REST payload
+  /// actually carries.
   ///
   /// For a `followers` sort, ranks by REST `follower_count` descending, then
-  /// REST `video_count` descending as a tie-breaker. This values real follower
-  /// counts first (your Alice with few followers still beats a non-followed
-  /// famous Alice via the outer `_boostProfiles` step) while keeping the most
-  /// followed among equals on top. Kind 0 Vine archive metrics are
+  /// REST `video_count` descending, then server index. The video tie-breaker
+  /// is what orders archive-imported profiles, which all carry
+  /// `follower_count: 0`, and it also separates equally followed profiles.
+  /// Profiles the viewer follows are promoted ahead of this ordering by the
+  /// outer `_boostProfiles` step. Kind 0 Vine archive metrics are
   /// intentionally not used here because they are different quantities.
   static List<UserProfile> _rankServerSortedPage(
     List<UserProfile> profiles,

--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -2314,11 +2314,12 @@ class ProfileRepository implements ProfileReader {
   /// Orders a server-sorted result page, falling back when the requested
   /// sort is a no-op on the payload.
   ///
-  /// A `followers` sort over profiles with no REST follower count is a no-op
-  /// for that part of the page — the server had nothing to order by. Keep real
-  /// REST follower counts first, then rank the no-signal remainder by the REST
-  /// video count, descending. Kind 0 Vine archive metrics are intentionally not
-  /// used here because they are different quantities.
+  /// For a `followers` sort, ranks by REST `follower_count` descending, then
+  /// REST `video_count` descending as a tie-breaker. This values real follower
+  /// counts first (your Alice with few followers still beats a non-followed
+  /// famous Alice via the outer `_boostProfiles` step) while keeping the most
+  /// followed among equals on top. Kind 0 Vine archive metrics are
+  /// intentionally not used here because they are different quantities.
   static List<UserProfile> _rankServerSortedPage(
     List<UserProfile> profiles,
     String? sortBy,
@@ -2333,11 +2334,8 @@ class ProfileRepository implements ProfileReader {
         ]..sort((a, b) {
           final aFollowers = a.$2.restFollowerCount ?? 0;
           final bFollowers = b.$2.restFollowerCount ?? 0;
-          final hasFollowerSignal = aFollowers > 0 || bFollowers > 0;
-          if (hasFollowerSignal) {
-            final byFollowers = bFollowers.compareTo(aFollowers);
-            return byFollowers != 0 ? byFollowers : a.$1.compareTo(b.$1);
-          }
+          final byFollowers = bFollowers.compareTo(aFollowers);
+          if (byFollowers != 0) return byFollowers;
 
           final byVideos = (b.$2.restVideoCount ?? 0).compareTo(
             a.$2.restVideoCount ?? 0,

--- a/mobile/packages/profile_repository/test/src/profile_repository_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_test.dart
@@ -4103,8 +4103,8 @@ void main() {
         expect(pubkeys, [pk18Videos, pk4Videos, pk1Video]);
       });
 
-      test('searchUsersProgressive ranks by followers then video when follower '
-          'counts tie', () async {
+      test('searchUsersProgressive breaks a real follower-count tie by '
+          'video count', () async {
         stubRestResults(resultsInServerOrder(followerCount: 100));
 
         final emissions = await repoWithFunnelcake

--- a/mobile/packages/profile_repository/test/src/profile_repository_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_test.dart
@@ -4103,8 +4103,8 @@ void main() {
         expect(pubkeys, [pk18Videos, pk4Videos, pk1Video]);
       });
 
-      test('searchUsersProgressive preserves server order when follower counts '
-          'are real', () async {
+      test('searchUsersProgressive ranks by followers then video when follower '
+          'counts tie', () async {
         stubRestResults(resultsInServerOrder(followerCount: 100));
 
         final emissions = await repoWithFunnelcake
@@ -4112,7 +4112,7 @@ void main() {
             .toList();
 
         final pubkeys = emissions.last.profiles.map((p) => p.pubkey).toList();
-        expect(pubkeys, [pk1Video, pk18Videos, pk4Videos]);
+        expect(pubkeys, [pk18Videos, pk4Videos, pk1Video]);
       });
 
       test('searchUsersProgressive ignores Kind 0 Vine metrics when ranking a '


### PR DESCRIPTION
Closes #7515

Follow-up to #7453 (now on main).

Your follows stay first via _boostProfiles. Within each group (boosted vs rest) rank by REST follower_count desc, then restVideoCount desc as tie-breaker, stable by server index. This makes a followed Alice beat a famous Alice while still valuing follower count among equals.

- Updated _rankServerSortedPage doc and comparator
- Updated equal-followers test to expect video tie-break
- CI: flutter test packages/profile_repository green locally