### PR TITLE
feat(settings): ungate light mode, always show Appearance

### DIFF
--- a/mobile/lib/features/appearance/bloc/appearance_cubit.dart
+++ b/mobile/lib/features/appearance/bloc/appearance_cubit.dart
@@ -38,10 +38,7 @@ class AppearanceCubit extends Cubit<AppearanceMode> {
 
 ThemeMode resolveThemeMode({
   required AppearanceMode mode,
-  required bool lightModeEnabled,
 }) {
-  if (!lightModeEnabled) return ThemeMode.dark;
-
   return switch (mode) {
     AppearanceMode.system => ThemeMode.system,
     AppearanceMode.light => ThemeMode.light,

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -2740,12 +2740,8 @@ class _DivineAppState extends ConsumerState<DivineApp>
       if (locale != null) {
         Intl.defaultLocale = locale.toLanguageTag();
       }
-      final lightModeEnabled = ref.watch(
-        isFeatureEnabledProvider(FeatureFlag.lightMode),
-      );
       final themeMode = resolveThemeMode(
         mode: appearanceMode,
-        lightModeEnabled: lightModeEnabled,
       );
       final effectiveBrightness = themeMode == ThemeMode.system
           ? WidgetsBinding.instance.platformDispatcher.platformBrightness

--- a/mobile/lib/screens/settings/general_settings_screen.dart
+++ b/mobile/lib/screens/settings/general_settings_screen.dart
@@ -38,9 +38,6 @@ class GeneralSettingsScreen extends ConsumerWidget {
     final showBluesky = ref.watch(
       isFeatureEnabledProvider(FeatureFlag.blueskyPublishing),
     );
-    final showAppearance = ref.watch(
-      isFeatureEnabledProvider(FeatureFlag.lightMode),
-    );
     final showCrossposting = ref.watch(crosspostingEligibleProvider);
     // Only a Divine-login account has an email and password to change; every
     // other identity signs with a key and has no credentials on file.
@@ -113,8 +110,7 @@ class GeneralSettingsScreen extends ConsumerWidget {
               const _LongPressRecordingToggle(),
               DivineSectionHeader(context.l10n.generalSettingsSectionApp),
               const _AppLanguageTile(),
-              if (showAppearance)
-                ListTile(
+              ListTile(
                   leading: const DivineIcon(
                     icon: DivineIconName.sun,
                     color: VineTheme.vineGreen,

--- a/mobile/test/features/appearance/appearance_cubit_test.dart
+++ b/mobile/test/features/appearance/appearance_cubit_test.dart
@@ -66,38 +66,25 @@ void main() {
       expect: () => [AppearanceMode.light],
     );
 
-    test('resolves disabled Light Mode to dark', () {
-      expect(
-        resolveThemeMode(
-          mode: AppearanceMode.light,
-          lightModeEnabled: false,
-        ),
-        ThemeMode.dark,
-      );
-    });
-
     test('resolves System to the platform-reactive ThemeMode', () {
       expect(
         resolveThemeMode(
           mode: AppearanceMode.system,
-          lightModeEnabled: true,
         ),
         ThemeMode.system,
       );
     });
 
-    test('resolves enabled explicit modes', () {
+    test('resolves explicit modes without a feature flag', () {
       expect(
         resolveThemeMode(
           mode: AppearanceMode.light,
-          lightModeEnabled: true,
         ),
         ThemeMode.light,
       );
       expect(
         resolveThemeMode(
           mode: AppearanceMode.dark,
-          lightModeEnabled: true,
         ),
         ThemeMode.dark,
       );

--- a/mobile/test/screens/settings/settings_taxonomy_test.dart
+++ b/mobile/test/screens/settings/settings_taxonomy_test.dart
@@ -298,7 +298,7 @@ void main() {
     expect(find.text('Closed Captions'), findsOneWidget);
     expect(find.text('Square videos only'), findsOneWidget);
     expect(find.text('App Language'), findsOneWidget);
-    expect(find.text('Appearance'), findsNothing);
+    expect(find.text('Appearance'), findsOneWidget);
     await tester.scrollUntilVisible(
       find.text('Make my audio available for reuse'),
       120,
@@ -344,18 +344,13 @@ void main() {
     );
   });
 
-  testWidgets('General Settings shows Appearance when Light Mode is enabled', (
+  testWidgets('General Settings shows Appearance', (
     tester,
   ) async {
     await setStandardSurface(tester);
     await tester.pumpWidget(
       wrap(
         const GeneralSettingsScreen(),
-        overrides: [
-          isFeatureEnabledProvider(
-            FeatureFlag.lightMode,
-          ).overrideWithValue(true),
-        ],
       ),
     );
     await tester.pumpAndSettle();


### PR DESCRIPTION
Closes #7516

Light mode is no longer behind FeatureFlag.lightMode. Users can choose light/dark/system directly:

- Appearance tile always visible in General Settings (was gated on FF_LIGHT_MODE)
- resolveThemeMode no longer takes lightModeEnabled, returns selected mode directly
- main.dart no longer watches FF_LIGHT_MODE
- Tests updated: appearance_cubit now tests without flag, settings taxonomy expects Appearance always present

Flag FF_LIGHT_MODE remains defined but unused for gating (adaptiveMediaChrome still flagged). Closes light-mode user-choice request.