### PR TITLE
fix(zendesk): Synchronize SDK initialization with JWT identity upgrade

### DIFF
--- a/mobile/lib/services/zendesk_support_service.dart
+++ b/mobile/lib/services/zendesk_support_service.dart
@@ -28,11 +28,13 @@ class ZendeskSupportService {
     'com.openvine/zendesk_support',
   );
   static const Duration _jwtRefreshReuseWindow = Duration(minutes: 4);
+  static const Duration _initializationTimeout = Duration(seconds: 10);
 
   static final CrashReportingService _crashlytics =
       CrashReportingService.instance;
 
   static bool _initialized = false;
+  static Completer<void> _initializationCompleter = Completer<void>();
 
   /// Check if Zendesk is available (credentials configured and initialized)
   static bool get isAvailable => _initialized;
@@ -64,6 +66,7 @@ class ZendeskSupportService {
     _clearAuthContext();
     _now = DateTime.now;
     _jwtIdentityRefreshOverride = null;
+    _initializationCompleter = Completer<void>();
   }
 
   @visibleForTesting
@@ -113,6 +116,7 @@ class ZendeskSupportService {
         'Zendesk credentials not configured - bug reports will use email fallback',
         category: LogCategory.system,
       );
+      _initializationCompleter.complete();
       return false;
     }
 
@@ -137,6 +141,7 @@ class ZendeskSupportService {
         );
       }
 
+      _initializationCompleter.complete();
       return _initialized;
     } on PlatformException catch (e) {
       Log.error(
@@ -144,6 +149,7 @@ class ZendeskSupportService {
         category: LogCategory.system,
       );
       _initialized = false;
+      _initializationCompleter.complete();
       return false;
     } catch (e) {
       Log.error(
@@ -151,6 +157,7 @@ class ZendeskSupportService {
         category: LogCategory.system,
       );
       _initialized = false;
+      _initializationCompleter.complete();
       return false;
     }
   }
@@ -385,6 +392,16 @@ class ZendeskSupportService {
     required Nip98AuthService nip98Service,
     required String relayManagerUrl,
   }) async {
+    // Wait for initialization to complete before checking _initialized flag
+    try {
+      await _initializationCompleter.future.timeout(_initializationTimeout);
+    } catch (e) {
+      Log.warning(
+        'Zendesk JWT: Initialization timeout or error - $e',
+        category: LogCategory.system,
+      );
+    }
+
     if (!_initialized) {
       Log.warning(
         'Zendesk JWT: SDK not initialized',

--- a/mobile/lib/services/zendesk_support_service.dart
+++ b/mobile/lib/services/zendesk_support_service.dart
@@ -116,7 +116,7 @@ class ZendeskSupportService {
         'Zendesk credentials not configured - bug reports will use email fallback',
         category: LogCategory.system,
       );
-      _initializationCompleter.complete();
+      _completeInitialization();
       return false;
     }
 
@@ -141,7 +141,7 @@ class ZendeskSupportService {
         );
       }
 
-      _initializationCompleter.complete();
+      _completeInitialization();
       return _initialized;
     } on PlatformException catch (e) {
       Log.error(
@@ -149,7 +149,7 @@ class ZendeskSupportService {
         category: LogCategory.system,
       );
       _initialized = false;
-      _initializationCompleter.complete();
+      _completeInitialization();
       return false;
     } catch (e) {
       Log.error(
@@ -157,8 +157,16 @@ class ZendeskSupportService {
         category: LogCategory.system,
       );
       _initialized = false;
-      _initializationCompleter.complete();
+      _completeInitialization();
       return false;
+    }
+  }
+
+  /// Opens the initialization gate. Safe to call on every exit path of
+  /// [initialize], including a repeat call after the SDK is already up.
+  static void _completeInitialization() {
+    if (!_initializationCompleter.isCompleted) {
+      _initializationCompleter.complete();
     }
   }
 

--- a/mobile/lib/services/zendesk_support_service.dart
+++ b/mobile/lib/services/zendesk_support_service.dart
@@ -170,6 +170,21 @@ class ZendeskSupportService {
     }
   }
 
+  /// Blocks until [initialize] has settled, so identity calls made during the
+  /// deferred startup phase do not read a [_initialized] that is only
+  /// transiently false.
+  static Future<void> _awaitInitialization() async {
+    try {
+      await _initializationCompleter.future.timeout(_initializationTimeout);
+    } on TimeoutException {
+      Log.warning(
+        'Zendesk: initialization did not settle within '
+        '${_initializationTimeout.inSeconds}s',
+        category: LogCategory.system,
+      );
+    }
+  }
+
   /// Store user identity for Zendesk tickets.
   ///
   /// Call this after user login. Stores name/email/npub locally.
@@ -213,6 +228,11 @@ class ZendeskSupportService {
   /// after login without a network call. JWT identity upgrade happens
   /// asynchronously afterward and overrides this when successful.
   static Future<bool> setAnonymousIdentityWithUserInfo() async {
+    // Races startup for the same reason setJwtIdentity does: this is the
+    // fallback identity the JWT upgrade is allowed to fail back to, so it
+    // must not be the one that silently loses the race.
+    await _awaitInitialization();
+
     if (!_initialized) return false;
     if (_userName == null || _userEmail == null) return false;
 
@@ -400,15 +420,7 @@ class ZendeskSupportService {
     required Nip98AuthService nip98Service,
     required String relayManagerUrl,
   }) async {
-    // Wait for initialization to complete before checking _initialized flag
-    try {
-      await _initializationCompleter.future.timeout(_initializationTimeout);
-    } catch (e) {
-      Log.warning(
-        'Zendesk JWT: Initialization timeout or error - $e',
-        category: LogCategory.system,
-      );
-    }
+    await _awaitInitialization();
 
     if (!_initialized) {
       Log.warning(

--- a/mobile/test/services/zendesk_support_service_test.dart
+++ b/mobile/test/services/zendesk_support_service_test.dart
@@ -109,6 +109,81 @@ void main() {
     });
   });
 
+  group('ZendeskSupportService initialization gate', () {
+    // The deferred startup phase kicks off initialize() without awaiting it,
+    // so the auth listener can reach these identity calls while the native
+    // handshake is still in flight. Both must wait for it rather than read a
+    // transiently false _initialized and give up.
+    test('setJwtIdentity waits for an in-flight initialization', () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (MethodCall call) async {
+            if (call.method == 'initialize') {
+              await Future<void>.delayed(const Duration(milliseconds: 20));
+              return true;
+            }
+            return null;
+          });
+
+      final nip98Service = _RecordingNip98AuthService();
+
+      final initialization = ZendeskSupportService.initialize(
+        appId: 'test',
+        clientId: 'test',
+        zendeskUrl: 'https://test.zendesk.com',
+      );
+
+      await ZendeskSupportService.setJwtIdentity(
+        nip98Service: nip98Service,
+        relayManagerUrl: 'https://test-relay.divine.video',
+      );
+      await initialization;
+
+      // Reaching token creation is the observable: bailing at the
+      // not-initialized check would leave this at zero.
+      expect(nip98Service.createAuthTokenCalls, 1);
+    });
+
+    test(
+      'setAnonymousIdentityWithUserInfo waits for an in-flight initialization',
+      () async {
+        var userIdentityCalls = 0;
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(channel, (MethodCall call) async {
+              if (call.method == 'initialize') {
+                await Future<void>.delayed(const Duration(milliseconds: 20));
+                return true;
+              }
+              if (call.method == 'setUserIdentity') {
+                userIdentityCalls++;
+                return true;
+              }
+              return null;
+            });
+
+        ZendeskSupportService.setUserIdentity(
+          npub: 'npub1testuser',
+          displayName: 'Test User',
+        );
+
+        final initialization = ZendeskSupportService.initialize(
+          appId: 'test',
+          clientId: 'test',
+          zendeskUrl: 'https://test.zendesk.com',
+        );
+
+        final identitySet =
+            await ZendeskSupportService.setAnonymousIdentityWithUserInfo();
+        await initialization;
+
+        // This is the identity the JWT upgrade is allowed to fall back to, so
+        // losing the startup race here leaves a logged-in reporter with no
+        // Zendesk identity at all.
+        expect(identitySet, true);
+        expect(userIdentityCalls, 1);
+      },
+    );
+  });
+
   group('ZendeskSupportService.showNewTicketScreen', () {
     test('returns false when not initialized', () async {
       final result = await ZendeskSupportService.showNewTicketScreen();
@@ -1550,6 +1625,22 @@ void main() {
       },
     );
   });
+}
+
+/// Fails token creation like [_FakeNip98AuthService], but records whether
+/// fetchPreAuthToken was reached at all. That count is what separates "the
+/// initialization gate let the caller through" from "the caller bailed at the
+/// not-initialized check", since both end in a false return.
+class _RecordingNip98AuthService implements Nip98AuthService {
+  int createAuthTokenCalls = 0;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) {
+    if (invocation.memberName == #createAuthToken) {
+      createAuthTokenCalls++;
+    }
+    return null;
+  }
 }
 
 /// Minimal fake for Nip98AuthService that always fails token creation.

--- a/mobile/test/services/zendesk_support_service_test.dart
+++ b/mobile/test/services/zendesk_support_service_test.dart
@@ -81,6 +81,32 @@ void main() {
       expect(result, false);
       expect(ZendeskSupportService.isAvailable, false);
     });
+
+    test('a repeat call keeps a successful initialization', () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (MethodCall call) async {
+            if (call.method == 'initialize') return true;
+            return null;
+          });
+
+      await ZendeskSupportService.initialize(
+        appId: 'test',
+        clientId: 'test',
+        zendeskUrl: 'https://test.zendesk.com',
+      );
+
+      final second = await ZendeskSupportService.initialize(
+        appId: 'test',
+        clientId: 'test',
+        zendeskUrl: 'https://test.zendesk.com',
+      );
+
+      // Completing the initialization gate twice used to throw out of
+      // initialize() and, on the way through the catch-all, reset
+      // _initialized on an SDK that had just come up fine.
+      expect(second, true);
+      expect(ZendeskSupportService.isAvailable, true);
+    });
   });
 
   group('ZendeskSupportService.showNewTicketScreen', () {


### PR DESCRIPTION
## Summary

Fixes a race condition in Zendesk support service initialization where `setJwtIdentity()` could check `_initialized` before `initialize()` had completed, as both methods run concurrently during startup.

## The Problem

In the deferred startup phase:
1. `initialize()` starts asynchronously (no await)
2. `setJwtIdentity()` immediately calls `!_initialized` check
3. Both operations race — `setJwtIdentity()` sees `_initialized == false` even as `initialize()` is still running
4. This causes incorrect behavior in the JWT token upgrade flow

## The Solution

- Added `Completer<void>` field to synchronize initialization state across methods
- Added initialization timeout constant (10 seconds)
- All four exit points in `initialize()` now complete the `Completer`
- `setJwtIdentity()` waits for initialization completion before checking `_initialized` flag
- Updated `resetForTesting()` to reinitialize the `Completer` for test isolation

## Test Plan

- [x] Local flutter analyze: no issues
- [x] Code formatted with dart format
- [x] Pre-commit hook verification passed
- [x] Branch rebased onto fresh origin/main
- [x] Working tree clean — ready for review

The fix ensures `setJwtIdentity()` never runs while initialization is in progress, eliminating the race condition.