### PR TITLE
fix(db): stop reporting downstream echoes of a handled DB corruption

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -1423,7 +1423,13 @@ Future<void> _startOpenVineApp() async {
   // Forward Bloc/Cubit errors (addError, uncaught handler throws, emit
   // failures) to Crashlytics + UnifiedLogger. Surfaced during the #3503
   // investigation as a missing observability hook. See #3526.
-  Bloc.observer = DivineBlocObserver();
+  Bloc.observer = DivineBlocObserver(
+    // Once the database has reported corruption, the service above has already
+    // recorded the incident and scheduled the next-launch salvage, so the
+    // Drift failures every downstream bloc then hits are echoes of a handled
+    // event rather than five separate defects. See #7507.
+    isDatabaseCorrupted: () => databaseCorruptionService.isCorrupted.value,
+  );
 
   // Tag every crash report with the running build so per-error triage doesn't
   // have to cross-reference the release dashboard. Set once, not per-error.

--- a/mobile/lib/observability/divine_bloc_observer.dart
+++ b/mobile/lib/observability/divine_bloc_observer.dart
@@ -44,8 +44,8 @@ const String kBlocDiagnosticNotObserved = '<not observed>';
 /// #3758.
 ///
 /// A second gate suppresses Crashlytics forwarding for database failures once
-/// the local database has already reported corruption — see
-/// [isDatabaseCorrupted].
+/// the local database has already reported corruption — see the
+/// `isDatabaseCorrupted` constructor argument.
 ///
 /// Wire once at app start, before `runApp`:
 ///

--- a/mobile/lib/observability/divine_bloc_observer.dart
+++ b/mobile/lib/observability/divine_bloc_observer.dart
@@ -139,13 +139,16 @@ class DivineBlocObserver extends BlocObserver {
   /// already reported and scheduled recovery for.
   ///
   /// Both halves are required. The session flag alone would drop unrelated
-  /// defects that happen to fire after the flag flips; the text match alone
+  /// defects that happen to fire after the flag flips; classification alone
   /// would drop the very first corrupt statement, which is the report worth
   /// keeping. Ordered flag-first because it is a field read, and it is false
-  /// for every healthy session — the text scan only runs on a database that is
-  /// already known to be broken.
+  /// for every healthy session — classification only runs on a database that
+  /// is already known to be broken.
   bool _echoesHandledCorruption(Object error) =>
-      _isDatabaseCorrupted() && mentionsDatabaseCorruption(error);
+      _isDatabaseCorrupted() &&
+      mentionsDatabaseCorruption(
+        error is Reportable<Object> ? error.unwrap() : error,
+      );
 
   ReportableError? _asReportable(Object error) {
     if (error is ReportableError) return error;

--- a/mobile/lib/observability/divine_bloc_observer.dart
+++ b/mobile/lib/observability/divine_bloc_observer.dart
@@ -3,6 +3,7 @@
 
 import 'dart:async';
 
+import 'package:db_client/db_client.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:openvine/observability/reportable_error.dart';
 import 'package:openvine/services/crash_reporting_service.dart';
@@ -42,17 +43,47 @@ const String kBlocDiagnosticNotObserved = '<not observed>';
 /// is the one that made the #3503 auth-timing investigation expensive. See
 /// #3758.
 ///
+/// A second gate suppresses Crashlytics forwarding for database failures once
+/// the local database has already reported corruption — see
+/// [isDatabaseCorrupted].
+///
 /// Wire once at app start, before `runApp`:
 ///
 /// ```dart
-/// Bloc.observer = DivineBlocObserver();
+/// Bloc.observer = DivineBlocObserver(
+///   isDatabaseCorrupted: () => corruptionService.isCorrupted.value,
+/// );
 /// runApp(...);
 /// ```
 class DivineBlocObserver extends BlocObserver {
-  DivineBlocObserver({CrashReportingService? crashReporting})
-    : _crashReporting = crashReporting ?? CrashReportingService.instance;
+  DivineBlocObserver({
+    CrashReportingService? crashReporting,
+    bool Function()? isDatabaseCorrupted,
+  }) : _crashReporting = crashReporting ?? CrashReportingService.instance,
+       _isDatabaseCorrupted = isDatabaseCorrupted ?? _databaseIsHealthy;
+
+  static bool _databaseIsHealthy() => false;
 
   final CrashReportingService _crashReporting;
+
+  /// Whether this session has already classified the local database as
+  /// corrupt. Wired to `DatabaseCorruptionService.isCorrupted`, which flips in
+  /// exactly one place — the first statement that fails with `SQLITE_CORRUPT` /
+  /// `SQLITE_NOTADB` — and never resets.
+  ///
+  /// While it reads `true`, recovery is already scheduled for the next launch
+  /// and the corruption gate has already replaced the UI with the restart
+  /// prompt, so every further database failure is a duplicate of a handled
+  /// event rather than a defect: matrix-NO per
+  /// `.claude/rules/error_handling.md`. Without this, one corrupt database
+  /// raised five distinct Crashlytics groups for the same incident, because
+  /// each downstream bloc wrapped and reported it independently (#7507).
+  ///
+  /// The flip itself is still reported once, by the service that sets it, so
+  /// suppression here cannot hide the incident — only its echoes. Defaults to
+  /// "healthy" so tests and any container built without the corruption service
+  /// keep the previous behaviour.
+  final bool Function() _isDatabaseCorrupted;
 
   /// Per-bloc diagnostics. An [Expando] holds its keys weakly, so a bloc's
   /// entry becomes collectible the moment the bloc itself is — observing every
@@ -90,6 +121,7 @@ class DivineBlocObserver extends BlocObserver {
     );
     final reportableError = _asReportable(error);
     if (reportableError == null) return;
+    if (_echoesHandledCorruption(error)) return;
     // Dispatch the diagnostic keys before recordError so they attach to the
     // report it emits. Both are fire-and-forget, but invoked synchronously and
     // in order, so the platform-channel messages stay ordered without blocking
@@ -102,6 +134,18 @@ class DivineBlocObserver extends BlocObserver {
       _crashReporting.recordError(reportableError, stackTrace, reason: reason),
     );
   }
+
+  /// Whether [error] is another view of the corruption this session has
+  /// already reported and scheduled recovery for.
+  ///
+  /// Both halves are required. The session flag alone would drop unrelated
+  /// defects that happen to fire after the flag flips; the text match alone
+  /// would drop the very first corrupt statement, which is the report worth
+  /// keeping. Ordered flag-first because it is a field read, and it is false
+  /// for every healthy session — the text scan only runs on a database that is
+  /// already known to be broken.
+  bool _echoesHandledCorruption(Object error) =>
+      _isDatabaseCorrupted() && mentionsDatabaseCorruption(error);
 
   ReportableError? _asReportable(Object error) {
     if (error is ReportableError) return error;

--- a/mobile/packages/db_client/lib/src/database/database_corruption.dart
+++ b/mobile/packages/db_client/lib/src/database/database_corruption.dart
@@ -36,13 +36,23 @@ bool indicatesDatabaseCorruption(Object error) {
 }
 
 /// Whether [error] mentions on-disk corruption **anywhere** in its text,
-/// including inside a wrapper that embeds a cause's `toString()`.
+/// including inside a wrapper that prints its cause below its own first line.
 ///
 /// Deliberately looser than [indicatesDatabaseCorruption], which reads the
-/// header line only. Aggregate and wrapper errors bury the SQLite header
-/// arbitrarily deep — a `ParallelWaitError` stringifies its whole failed
-/// record, so the corrupt statement can land on any line — and those wrappers
-/// are exactly what downstream callers see.
+/// header line only. Most wrappers a downstream caller sees keep the SQLite
+/// header on line 1, so the strict classifier already covers them:
+/// `DriftRemoteException` forwards `remoteCause.toString()` verbatim,
+/// `DriftWrappedException` opens with `'$cause at …'`, and `ParallelWaitError`
+/// prints only its *default* error — the first leg to fail — never its
+/// `values` or `errors` records.
+///
+/// `CouldNotRollBackException` is the shape that defeats it: it prints the
+/// failure raised by the `ROLLBACK` itself first, and the error that triggered
+/// the rollback on the line below. A transaction aborted by corruption whose
+/// rollback then fails for some other reason therefore carries the SQLite
+/// header on line 2, where only this classifier can see it. drift transactions
+/// are used in `event_router.dart` and the DM/conversation DAOs, so the shape
+/// is reachable rather than hypothetical.
 ///
 /// The stricter classifier is not merely stricter, it protects a different
 /// decision. It gates the salvage/wipe of a database, where a false positive

--- a/mobile/packages/db_client/lib/src/database/database_corruption.dart
+++ b/mobile/packages/db_client/lib/src/database/database_corruption.dart
@@ -32,8 +32,41 @@ bool indicatesDatabaseCorruption(Object error) {
     _sqliteExceptionHeader.firstMatch(header)?.group(1) ?? '',
   );
   if (extendedCode == null) return false;
-  // Every extended code carries its primary code in the low byte, so 779
-  // (SQLITE_CORRUPT_INDEX) and 11 (SQLITE_CORRUPT) both reduce to 11.
+  return _isCorruptionResultCode(extendedCode);
+}
+
+/// Whether [error] mentions on-disk corruption **anywhere** in its text,
+/// including inside a wrapper that embeds a cause's `toString()`.
+///
+/// Deliberately looser than [indicatesDatabaseCorruption], which reads the
+/// header line only. Aggregate and wrapper errors bury the SQLite header
+/// arbitrarily deep — a `ParallelWaitError` stringifies its whole failed
+/// record, so the corrupt statement can land on any line — and those wrappers
+/// are exactly what downstream callers see.
+///
+/// The stricter classifier is not merely stricter, it protects a different
+/// decision. It gates the salvage/wipe of a database, where a false positive
+/// destroys a healthy one, and bound parameters below the header carry user
+/// content: a Nostr event quoting SQLite's corruption message must never
+/// convince the app to recover. **Never use this function for that decision.**
+///
+/// Use it only where a false positive is harmless — specifically, to drop a
+/// duplicate report about a database some other code has already classified as
+/// corrupt via [indicatesDatabaseCorruption]. The looseness is bounded by that
+/// precondition, not by the text match.
+bool mentionsDatabaseCorruption(Object error) {
+  return _sqliteExceptionHeader
+      .allMatches(error.toString())
+      .map((match) => int.tryParse(match.group(1)!))
+      .any(
+        (extendedCode) =>
+            extendedCode != null && _isCorruptionResultCode(extendedCode),
+      );
+}
+
+/// Every extended code carries its primary code in the low byte, so 779
+/// (SQLITE_CORRUPT_INDEX) and 11 (SQLITE_CORRUPT) both reduce to 11.
+bool _isCorruptionResultCode(int extendedCode) {
   final primaryCode = extendedCode & 0xFF;
   return primaryCode == _sqliteCorrupt || primaryCode == _sqliteNotADb;
 }

--- a/mobile/packages/db_client/lib/src/database/database_corruption.dart
+++ b/mobile/packages/db_client/lib/src/database/database_corruption.dart
@@ -35,8 +35,8 @@ bool indicatesDatabaseCorruption(Object error) {
   return _isCorruptionResultCode(extendedCode);
 }
 
-/// Whether [error] mentions on-disk corruption **anywhere** in its text,
-/// including inside a wrapper that prints its cause below its own first line.
+/// Whether [error] represents on-disk corruption, including when drift wraps
+/// the corrupt cause after a failed transaction rollback.
 ///
 /// Deliberately looser than [indicatesDatabaseCorruption], which reads the
 /// header line only. Most wrappers a downstream caller sees keep the SQLite
@@ -48,11 +48,9 @@ bool indicatesDatabaseCorruption(Object error) {
 ///
 /// `CouldNotRollBackException` is the shape that defeats it: it prints the
 /// failure raised by the `ROLLBACK` itself first, and the error that triggered
-/// the rollback on the line below. A transaction aborted by corruption whose
-/// rollback then fails for some other reason therefore carries the SQLite
-/// header on line 2, where only this classifier can see it. drift transactions
-/// are used in `event_router.dart` and the DM/conversation DAOs, so the shape
-/// is reachable rather than hypothetical.
+/// the rollback on the line below. This classifier follows that typed cause
+/// instead of scanning all rendered lines, because later lines can contain
+/// bound user data that merely quotes a corruption result code.
 ///
 /// The stricter classifier is not merely stricter, it protects a different
 /// decision. It gates the salvage/wipe of a database, where a false positive
@@ -60,18 +58,12 @@ bool indicatesDatabaseCorruption(Object error) {
 /// content: a Nostr event quoting SQLite's corruption message must never
 /// convince the app to recover. **Never use this function for that decision.**
 ///
-/// Use it only where a false positive is harmless — specifically, to drop a
-/// duplicate report about a database some other code has already classified as
-/// corrupt via [indicatesDatabaseCorruption]. The looseness is bounded by that
-/// precondition, not by the text match.
+/// Use it only to drop a duplicate report about a database some other code has
+/// already classified as corrupt via [indicatesDatabaseCorruption].
 bool mentionsDatabaseCorruption(Object error) {
-  return _sqliteExceptionHeader
-      .allMatches(error.toString())
-      .map((match) => int.tryParse(match.group(1)!))
-      .any(
-        (extendedCode) =>
-            extendedCode != null && _isCorruptionResultCode(extendedCode),
-      );
+  if (indicatesDatabaseCorruption(error)) return true;
+  return error is CouldNotRollBackException &&
+      mentionsDatabaseCorruption(error.cause);
 }
 
 /// Every extended code carries its primary code in the low byte, so 779

--- a/mobile/packages/db_client/test/src/database/database_corruption_test.dart
+++ b/mobile/packages/db_client/test/src/database/database_corruption_test.dart
@@ -149,6 +149,53 @@ void main() {
     });
   });
 
+  group('mentionsDatabaseCorruption', () {
+    test('recognises the signature on the header line', () {
+      expect(mentionsDatabaseCorruption(Exception(_corruptionError)), isTrue);
+    });
+
+    test('sees a signature the header-only classifier cannot', () {
+      // The shape reported from NotificationFeedBloc._onRefreshed: the corrupt
+      // statement is one leg of a `Future.wait`, so `ParallelWaitError` prints
+      // its values before its errors. A value that stringifies over more than
+      // one line pushes the SQLite header off the header line entirely, and
+      // the strict classifier stops at that line by design.
+      final wrapped = Exception(
+        'ParallelWaitError(([NotificationItem(id: abc,\n'
+        '  body: hi)], []), (null, AsyncError: SqliteException(26): file is '
+        'not a database))',
+      );
+
+      expect(mentionsDatabaseCorruption(wrapped), isTrue);
+      expect(
+        indicatesDatabaseCorruption(wrapped),
+        isFalse,
+        reason: 'the two classifiers must stay genuinely different',
+      );
+    });
+
+    test('does not fire on an ordinary multi-line query failure', () {
+      expect(
+        mentionsDatabaseCorruption(
+          Exception(
+            'SqliteException(1): no such table: event\n'
+            '  Causing statement: SELECT * FROM event',
+          ),
+        ),
+        isFalse,
+      );
+    });
+
+    test('does not fire on an error carrying no SQLite result code', () {
+      expect(
+        mentionsDatabaseCorruption(
+          Exception('database disk image is malformed'),
+        ),
+        isFalse,
+      );
+    });
+  });
+
   group(DatabaseCorruptionInterceptor, () {
     test('reports corruption surfacing on a select', () async {
       final reported = <Object>[];
@@ -219,10 +266,7 @@ void main() {
         (e) => e.runDelete('DELETE FROM event', const []),
       );
       await expectReports('custom', (e) => e.runCustom('PRAGMA foo'));
-      await expectReports(
-        'ensureOpen',
-        (e) => e.ensureOpen(_NoopUser()),
-      );
+      await expectReports('ensureOpen', (e) => e.ensureOpen(_NoopUser()));
       // Bulk ingestion goes through batch(), so a corrupt page first reached by
       // a batched write must report too. Without the override drift's default
       // forwards it silently and the next launch never salvages.

--- a/mobile/packages/db_client/test/src/database/database_corruption_test.dart
+++ b/mobile/packages/db_client/test/src/database/database_corruption_test.dart
@@ -1,6 +1,9 @@
+import 'dart:async';
+
 import 'package:db_client/db_client.dart';
 import 'package:drift/drift.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:sqlite3/common.dart';
 
 /// A query executor whose statements all fail with [error].
 ///
@@ -59,6 +62,21 @@ class _FailingExecutor extends QueryExecutor {
 const _corruptionError =
     'SqliteException(11): while selecting from statement, database disk image '
     'is malformed, database disk image is malformed (code 11)';
+
+/// The same failure as [_corruptionError], as the real `sqlite3` type.
+///
+/// Used wherever a test asserts what a *wrapper* does to the SQLite header, so
+/// the assertion tracks `SqliteException.toString()` instead of a hand-written
+/// copy of it. Carries a bound parameter because that is what pushes content
+/// below the header line in the first place.
+final _realCorruptionException = SqliteException(
+  extendedResultCode: 11,
+  message: 'database disk image is malformed',
+  explanation: 'database disk image is malformed (code 11)',
+  operation: 'selecting from statement',
+  causingStatement: 'SELECT * FROM event WHERE id = ?',
+  parametersToStatement: <Object?>['abc123'],
+);
 
 void main() {
   group('indicatesDatabaseCorruption', () {
@@ -155,15 +173,18 @@ void main() {
     });
 
     test('sees a signature the header-only classifier cannot', () {
-      // The shape reported from NotificationFeedBloc._onRefreshed: the corrupt
-      // statement is one leg of a `Future.wait`, so `ParallelWaitError` prints
-      // its values before its errors. A value that stringifies over more than
-      // one line pushes the SQLite header off the header line entirely, and
-      // the strict classifier stops at that line by design.
-      final wrapped = Exception(
-        'ParallelWaitError(([NotificationItem(id: abc,\n'
-        '  body: hi)], []), (null, AsyncError: SqliteException(26): file is '
-        'not a database))',
+      // The one wrapper drift can raise that pushes the SQLite header off
+      // line 1: `CouldNotRollBackException` prints the failure raised by the
+      // ROLLBACK first and the error that triggered it on the line below. A
+      // transaction aborted by corruption whose rollback then fails for an
+      // unrelated reason lands exactly here.
+      //
+      // Built from the real drift type rather than a hand-written string, so
+      // the test tracks what drift actually prints.
+      final wrapped = CouldNotRollBackException(
+        _realCorruptionException,
+        StackTrace.empty,
+        StateError('connection closed'),
       );
 
       expect(mentionsDatabaseCorruption(wrapped), isTrue);
@@ -171,6 +192,52 @@ void main() {
         indicatesDatabaseCorruption(wrapped),
         isFalse,
         reason: 'the two classifiers must stay genuinely different',
+      );
+    });
+
+    test('a real ParallelWaitError keeps the header on line 1', () async {
+      // `NotificationFeedBloc._onRefreshed` reports a
+      // `Reportable<ParallelWaitError<...>>`, and #7507 assumed that wrapper
+      // buries the SQLite header. It does not: `ParallelWaitError.toString()`
+      // prints only its default error — the first leg to fail — and never its
+      // `values`/`errors` records, so the strict classifier already sees it.
+      //
+      // Pinned because the looser classifier's justification rests on which
+      // wrappers the strict one can and cannot read. If a future SDK release
+      // starts printing the whole record, this fails and the reasoning above
+      // has to be revisited rather than silently rotting.
+      Object? raised;
+      try {
+        await (
+          Future<int>.error(_realCorruptionException),
+          Future<String>.value('ok'),
+        ).wait;
+      } on Object catch (error) {
+        raised = error;
+      }
+
+      expect(raised, isA<ParallelWaitError<dynamic, dynamic>>());
+      expect(indicatesDatabaseCorruption(raised!), isTrue);
+      expect(mentionsDatabaseCorruption(raised), isTrue);
+    });
+
+    test('a ParallelWaitError whose first failure is unrelated hides it', () {
+      // The converse, and the honest limit of both classifiers: the corrupt
+      // leg's text is absent from the string entirely, so scanning the whole
+      // string buys nothing. Such a report still reaches Crashlytics.
+      expect(
+        mentionsDatabaseCorruption(
+          ParallelWaitError<Object?, Object?>(
+            null,
+            null,
+            errorCount: 2,
+            defaultError: AsyncError(
+              StateError('unrelated first failure'),
+              StackTrace.empty,
+            ),
+          ),
+        ),
+        isFalse,
       );
     });
 

--- a/mobile/packages/db_client/test/src/database/database_corruption_test.dart
+++ b/mobile/packages/db_client/test/src/database/database_corruption_test.dart
@@ -253,6 +253,21 @@ void main() {
       );
     });
 
+    test('ignores a result code quoted inside bound parameters', () {
+      final ordinaryFailure = SqliteException(
+        extendedResultCode: 19,
+        message: 'UNIQUE constraint failed: event.id',
+        explanation: 'UNIQUE constraint failed: event.id (code 19)',
+        operation: 'inserting a row',
+        causingStatement: 'INSERT INTO event (content) VALUES (?)',
+        parametersToStatement: const <Object?>[
+          'SqliteException(11): database disk image is malformed',
+        ],
+      );
+
+      expect(mentionsDatabaseCorruption(ordinaryFailure), isFalse);
+    });
+
     test('does not fire on an error carrying no SQLite result code', () {
       expect(
         mentionsDatabaseCorruption(

--- a/mobile/test/observability/divine_bloc_observer_test.dart
+++ b/mobile/test/observability/divine_bloc_observer_test.dart
@@ -374,5 +374,153 @@ void main() {
         expect(captured.single, isNot(contains(npub)));
       },
     );
+
+    group('once the local database has reported corruption (#7507)', () {
+      late bool isCorrupted;
+
+      /// The error every downstream bloc sees while the database is broken:
+      /// a Drift failure forwarded from the background isolate, wrapped at the
+      /// `addError` call site. `_publishLike` is the real reporting site behind
+      /// one of the duplicate Crashlytics groups.
+      Reportable<Object> driftCorruptionFailure() => Reportable(
+        Exception(
+          'SqliteException(26): file is not a database, '
+          'file is not a database (code 26)',
+        ),
+        context: '_publishLike',
+      );
+
+      setUp(() {
+        isCorrupted = false;
+        observer = DivineBlocObserver(
+          crashReporting: mockCrash,
+          isDatabaseCorrupted: () => isCorrupted,
+        );
+      });
+
+      void reportedBy(BlocBase<dynamic> bloc, Object error) =>
+          observer.onError(bloc, error, StackTrace.current);
+
+      test('forwards a database failure while the database looks healthy', () {
+        final cubit = _CountCubit();
+        addTearDown(cubit.close);
+
+        reportedBy(cubit, driftCorruptionFailure());
+
+        verify(
+          () => mockCrash.recordError(
+            any<dynamic>(),
+            any<StackTrace?>(),
+            reason: any(named: 'reason'),
+          ),
+        ).called(1);
+      });
+
+      test('stops forwarding the same failure once corruption is known', () {
+        final cubit = _CountCubit();
+        addTearDown(cubit.close);
+        isCorrupted = true;
+
+        reportedBy(cubit, driftCorruptionFailure());
+
+        verifyNever(
+          () => mockCrash.recordError(
+            any<dynamic>(),
+            any<StackTrace?>(),
+            reason: any(named: 'reason'),
+          ),
+        );
+      });
+
+      test('suppresses a corruption buried in an aggregate error', () {
+        // NotificationFeedBloc._onRefreshed reports this shape: the corrupt
+        // statement is one leg of a Future.wait, so the SQLite header is not
+        // the first thing the error prints.
+        final cubit = _CountCubit();
+        addTearDown(cubit.close);
+        isCorrupted = true;
+
+        reportedBy(
+          cubit,
+          Reportable(
+            Exception(
+              'ParallelWaitError(([NotificationItem(id: abc,\n'
+              '  body: hi)], []), (null, AsyncError: SqliteException(26): '
+              'file is not a database))',
+            ),
+            context: '_onRefreshed',
+          ),
+        );
+
+        verifyNever(
+          () => mockCrash.recordError(
+            any<dynamic>(),
+            any<StackTrace?>(),
+            reason: any(named: 'reason'),
+          ),
+        );
+      });
+
+      test('still forwards an unrelated defect while corruption is known', () {
+        // The gate must narrow to the handled failure. A programming-invariant
+        // error that happens to fire after the flag flips is still a defect.
+        final cubit = _CountCubit();
+        addTearDown(cubit.close);
+        isCorrupted = true;
+
+        reportedBy(cubit, Reportable(StateError('boom'), context: 'unrelated'));
+
+        verify(
+          () => mockCrash.recordError(
+            any<dynamic>(),
+            any<StackTrace?>(),
+            reason: any(named: 'reason'),
+          ),
+        ).called(1);
+      });
+
+      test('keeps the suppressed failure in the unified log', () async {
+        // Suppression is a Crashlytics decision only: the bug-report capture
+        // flow still has to show what went wrong on the device.
+        final cubit = _CountCubit();
+        addTearDown(cubit.close);
+        isCorrupted = true;
+
+        reportedBy(cubit, driftCorruptionFailure());
+        await Future<void>.delayed(Duration.zero);
+
+        // Matched anywhere in the shared ring buffer, for the reason spelled
+        // out on the sibling log assertion above.
+        final logs = LogCaptureService().getRecentLogs();
+        expect(
+          logs.map((entry) => entry.message),
+          contains(
+            allOf(
+              contains('Bloc error: _CountCubit'),
+              contains('SqliteException(26)'),
+            ),
+          ),
+        );
+      });
+
+      test('defaults to forwarding when no corruption gate is wired', () {
+        // Containers built without the corruption service (tests, web) must
+        // keep the pre-#7507 behaviour rather than silently drop reports.
+        final cubit = _CountCubit();
+        addTearDown(cubit.close);
+
+        DivineBlocObserver(
+          crashReporting: mockCrash,
+        ).onError(cubit, driftCorruptionFailure(), StackTrace.current);
+
+        verify(
+          () => mockCrash.recordError(
+            any<dynamic>(),
+            any<StackTrace?>(),
+            reason: any(named: 'reason'),
+          ),
+        ).called(1);
+      });
+    });
   });
 }

--- a/mobile/test/observability/divine_bloc_observer_test.dart
+++ b/mobile/test/observability/divine_bloc_observer_test.dart
@@ -528,6 +528,35 @@ void main() {
         ).called(1);
       });
 
+      test('still forwards quoted corruption text in bound user data', () {
+        final cubit = _CountCubit();
+        addTearDown(cubit.close);
+        isCorrupted = true;
+        final ordinaryFailure = SqliteException(
+          extendedResultCode: 19,
+          message: 'UNIQUE constraint failed: event.id',
+          explanation: 'UNIQUE constraint failed: event.id (code 19)',
+          operation: 'inserting a row',
+          causingStatement: 'INSERT INTO event (content) VALUES (?)',
+          parametersToStatement: const <Object?>[
+            'SqliteException(11): database disk image is malformed',
+          ],
+        );
+
+        reportedBy(
+          cubit,
+          Reportable(ordinaryFailure, context: '_publishLike'),
+        );
+
+        verify(
+          () => mockCrash.recordError(
+            any<dynamic>(),
+            any<StackTrace?>(),
+            reason: any(named: 'reason'),
+          ),
+        ).called(1);
+      });
+
       test('keeps the suppressed failure in the unified log', () async {
         // Suppression is a Crashlytics decision only: the bug-report capture
         // flow still has to show what went wrong on the device.

--- a/mobile/test/observability/divine_bloc_observer_test.dart
+++ b/mobile/test/observability/divine_bloc_observer_test.dart
@@ -2,16 +2,34 @@
 // ABOUTME: ReportableError, sanitizes the reason annotation, and preserves
 // ABOUTME: Log.error coverage for every Bloc onError trigger.
 
+import 'package:drift/drift.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/observability/divine_bloc_observer.dart';
 import 'package:openvine/observability/reportable_error.dart';
 import 'package:openvine/services/crash_reporting_service.dart';
+import 'package:sqlite3/common.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 class _MockCrashReportingService extends Mock
     implements CrashReportingService {}
+
+/// The corrupt statement behind #7507, as the real `sqlite3` type.
+///
+/// The database runs on a background isolate, so blocs actually see a
+/// `DriftRemoteException` — but its `toString()` is exactly
+/// `remoteCause.toString()` and its constructor is private, so the cause
+/// itself is the faithful stand-in. The bound parameter matters: it is what
+/// puts content below the header line.
+final _realCorruptionException = SqliteException(
+  extendedResultCode: 26,
+  message: 'file is not a database',
+  explanation: 'file is not a database (code 26)',
+  operation: 'preparing a statement',
+  causingStatement: 'PRAGMA user_version',
+  parametersToStatement: <Object?>['abc123'],
+);
 
 class _CountCubit extends Cubit<int> {
   _CountCubit() : super(0);
@@ -382,13 +400,8 @@ void main() {
       /// a Drift failure forwarded from the background isolate, wrapped at the
       /// `addError` call site. `_publishLike` is the real reporting site behind
       /// one of the duplicate Crashlytics groups.
-      Reportable<Object> driftCorruptionFailure() => Reportable(
-        Exception(
-          'SqliteException(26): file is not a database, '
-          'file is not a database (code 26)',
-        ),
-        context: '_publishLike',
-      );
+      Reportable<Object> driftCorruptionFailure() =>
+          Reportable(_realCorruptionException, context: '_publishLike');
 
       setUp(() {
         isCorrupted = false;
@@ -432,10 +445,46 @@ void main() {
         );
       });
 
-      test('suppresses a corruption buried in an aggregate error', () {
-        // NotificationFeedBloc._onRefreshed reports this shape: the corrupt
-        // statement is one leg of a Future.wait, so the SQLite header is not
-        // the first thing the error prints.
+      test('suppresses the real ParallelWaitError signature', () async {
+        // Signature 5 of #7507, raised from
+        // `NotificationFeedBloc._onRefreshed`: the corrupt statement is one
+        // leg of a record `.wait`, and `ParallelWaitError` extends `Error`, so
+        // it lands in that handler's generic catch and is wrapped there.
+        //
+        // Built by actually failing a `.wait` rather than by hand-writing what
+        // it prints — the gate's whole job is reading a string the SDK
+        // produces, so a fabricated one would prove nothing about the fix.
+        final cubit = _CountCubit();
+        addTearDown(cubit.close);
+        isCorrupted = true;
+
+        Object? raised;
+        try {
+          await (
+            Future<int>.error(_realCorruptionException),
+            Future<String>.value('ok'),
+          ).wait;
+        } on Object catch (error) {
+          raised = error;
+        }
+
+        reportedBy(cubit, Reportable(raised!, context: '_onRefreshed'));
+
+        verifyNever(
+          () => mockCrash.recordError(
+            any<dynamic>(),
+            any<StackTrace?>(),
+            reason: any(named: 'reason'),
+          ),
+        );
+      });
+
+      test('suppresses a corruption a wrapper pushed off the header line', () {
+        // `CouldNotRollBackException` prints the ROLLBACK's own failure first
+        // and the error that triggered the rollback below it, so the SQLite
+        // header is not on line 1. This is the shape that requires
+        // `mentionsDatabaseCorruption` rather than the header-only classifier;
+        // every other wrapper in play keeps the header on line 1.
         final cubit = _CountCubit();
         addTearDown(cubit.close);
         isCorrupted = true;
@@ -443,12 +492,12 @@ void main() {
         reportedBy(
           cubit,
           Reportable(
-            Exception(
-              'ParallelWaitError(([NotificationItem(id: abc,\n'
-              '  body: hi)], []), (null, AsyncError: SqliteException(26): '
-              'file is not a database))',
+            CouldNotRollBackException(
+              _realCorruptionException,
+              StackTrace.empty,
+              StateError('connection closed'),
             ),
-            context: '_onRefreshed',
+            context: '_onVoteCountsFetchRequested',
           ),
         );
 


### PR DESCRIPTION
## Description

One corrupted database currently raises up to five distinct Crashlytics groups for a single incident (~174 events over four days). The first corrupt statement is reported once by `DatabaseCorruptionService`, and then every downstream bloc that touches the same dead database wraps its own `DriftRemoteException` in `Reportable` and reports it again from its own call site — `VideoInteractionsBloc._publishLike`, `CommentReactionsBloc._onVoteCountsFetchRequested`, `NotificationFeedBloc._onRefreshed`.

Recovery already works automatically (#6108, #6897). The first corrupt statement flips `DatabaseCorruptionService.isCorrupted`, which persists the next-launch salvage flag and replaces the whole UI with the restart prompt. So per the decision matrix in `.claude/rules/error_handling.md`, every report after that flip is a matrix-NO: a failure the app has already classified, already reported once, and already scheduled recovery for.

This gates Crashlytics forwarding in `DivineBlocObserver` on that existing flag, narrowed to errors carrying a `SQLITE_CORRUPT` / `SQLITE_NOTADB` result code.

**Why both halves of the gate are required.** The session flag alone would drop unrelated defects that happen to fire after the flip. The text match alone would drop the very first corrupt statement, which is the report worth keeping. Only their conjunction describes "an echo of something already handled".

**Why the observer and not the three blocs.** The observer is already the single place that decides Crashlytics forwarding, and it already applies one global matrix rule (promoting bare `StateError` / `TypeError` / `RangeError`). A global de-promotion rule is symmetric with that, covers every future bloc that touches Drift without another round of per-call-site edits, and avoids threading a corruption dependency through three unrelated bloc constructors and every widget that builds them. Unified logging is untouched: only Crashlytics forwarding is skipped, so the on-device bug-report capture still shows the failure.

**Why a second classifier in `db_client`.** `indicatesDatabaseCorruption` reads the header line only, on purpose — it gates the salvage or wipe of a database, and the bound parameters printed below the header carry user content, so a Nostr event quoting SQLite.s corruption message must never trigger a recovery of a healthy database. `mentionsDatabaseCorruption` first applies that strict classifier to the error itself, then follows a typed `CouldNotRollBackException.cause` when drift wraps the triggering failure below an unrelated rollback failure. It never scans bound parameters for corruption text.

*Corrected in the second commit — the first commit justified this function with a claim about `ParallelWaitError` that is false, and pinned it with a test asserting on a string the SDK cannot produce.* `ParallelWaitError.toString()` prints only `_defaultError.error`, the first leg to fail, and never its `values` or `errors` records (dart-sdk `async/future_extensions.dart`). So for the `Reportable<ParallelWaitError<...>>(_onRefreshed)` signature the SQLite header stays on line 1 and the header-only classifier already reads it; when the corrupt leg is *not* the first to fail, its text is absent from the string entirely and scanning the whole string buys nothing either. `DriftRemoteException` (forwards `remoteCause.toString()` verbatim) and `DriftWrappedException` (opens with `'$cause at …'`) also keep the header on line 1.

The wrapper that does defeat it is drift.s `CouldNotRollBackException`, which prints the ROLLBACK.s own failure first and the error that triggered the rollback on the line below — so a transaction aborted by corruption whose rollback then fails for an unrelated reason carries the SQLite header on line 2. The classifier follows that typed cause directly rather than scanning the rendered line. Transactions are used in `event_router.dart` and the DM/conversation DAOs, so the shape is reachable rather than hypothetical. The tests that guard the difference are now built from real `SqliteException`, `ParallelWaitError` and `CouldNotRollBackException` instances rather than hand-written strings, plus a regression test pinning that a real `ParallelWaitError` keeps the header on line 1 — so a future SDK change to that `toString()` surfaces here instead of silently invalidating the reasoning.

### The sequencing question in the issue — baseline before suppression

The issue asks for the rate baseline to exist before the noise is suppressed, so that suppression cannot hide a regression. **The baseline exists, and for this change it is exact rather than approximate.**

The gate's own precondition is the argument. Suppression only applies while `isCorrupted` is `true`, and that flag flips in exactly one place: `DatabaseCorruptionService.report`, on the first corrupt statement of the session — which records the `Runtime database corruption` non-fatal on that same first report and is untouched by this PR. So every report this change suppresses is, by construction, preceded in the same session by exactly one retained non-fatal. The per-incident count does not change; only the duplicates collapse. There is no window in which corruption is suppressed but unreported.

I also verified the recovery counter that the issue names, `DatabaseEncryptionBootstrap._reportRecovery`. It fires on every path where the bootstrap itself recovers a database: salvage-succeeded, and all three `_recoverUnusableEncryptedDatabase` callers (missing key, corrupt-but-key-still-valid, key loss). The runtime-corruption flow always terminates in one of those on the next launch, because `hasPendingCorruptionRecovery` forces the `alreadyEncrypted` branch past the reactive probe. So the per-user rate signal stays intact.

Two bootstrap paths do **not** emit a `DatabaseRecoveryEvent`, and both are worth naming even though neither affects this change:

- `CipherMigrationOutcome.unreadable` throws `DatabaseUnreadableError`. There is no automatic recovery to count — the user gets the failure screen — so its absence from the recovery counter is correct.
- `resolveDatabaseBootstrapForAppStart`'s repair-and-retry (`shouldRepairLocalDatabaseCacheAfterBootstrapError` → wipe → retry) *does* recover automatically without a `DatabaseRecoveryEvent`. That is a real gap in "`DatabaseRecoveryEvent` is the complete automatic-recovery counter".

Neither is a bloc error. Both report straight through `CrashReportingService.recordError` (`DatabaseEncryptionBootstrap.resolveCipherKey failed`), and this change only touches `DivineBlocObserver`, so neither loses any signal here. That is why I did not close the second gap first: nothing this PR suppresses depended on it. Flagging it rather than fixing it inline, because adding a new startup telemetry event is a separate decision with its own blast radius — happy to fold it in if you would rather it land together.

**Related Issue:** Refs #7507

## Out of Scope

- The two primary detection signatures (`SqliteException(26)` on `PRAGMA user_version`, `SqliteException(779)` on `DELETE FROM event`) stay. They are the incident report, not the echo — this PR removes the three downstream duplicate groups only.
- The `DatabaseRecoveryEvent` gap on the bootstrap repair-and-retry path described above.
- Item (2) of the issue — deciding whether 12 users in 4 days is an acceptable corruption rate — is a product judgment, not a code change. The signals needed to answer it are unchanged by this PR.

## Verification

Run from `mobile/`:

- `dart format` on all five changed files — no reflow.
- `flutter analyze lib test integration_test` — No issues found.
- `flutter analyze lib test` in `mobile/packages/db_client` — No issues found.
- `flutter test test/observability/divine_bloc_observer_test.dart test/services/database_corruption_service_test.dart test/services/database_encryption_bootstrap_test.dart test/startup/database_corruption_gate_test.dart` — 70 passing.
- `flutter test --coverage` in `mobile/packages/db_client` (package has its own CI workflow, `min_coverage: 40`) — 973 passing, 44.15% line coverage.
- Mutation-checked the new tests, twice. With `_echoesHandledCorruption` forced to `false`, exactly the three suppression tests fail and the three control tests (unrelated-defect still forwarded, log still written, default-wiring still forwards) stay green. With `mentionsDatabaseCorruption` collapsed into `indicatesDatabaseCorruption`, exactly the one `CouldNotRollBackException` test fails in each suite — which is what establishes that the looser classifier is load-bearing, and only for that shape.

Not done: **device verification on a real Samsung Galaxy is pending.** I cannot exercise it — reproducing this needs a genuinely corrupted SQLite file on device, and the behaviour under test is the absence of a Crashlytics group, which is only observable in the dashboard after a release.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore


