### PR TITLE
fix(share): anchor every share sheet so iPad stops rejecting it

### DIFF
--- a/mobile/lib/providers/minor_account_review_providers.dart
+++ b/mobile/lib/providers/minor_account_review_providers.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Minor-account review Riverpod providers for auth restriction gating
 // ABOUTME: Wires API-backed status, repository, and developer override service
 
+import 'dart:ui' show Rect;
+
 import 'package:flutter/foundation.dart' show kDebugMode;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/models/minor_account_review_status.dart';
@@ -17,6 +19,7 @@ typedef MinorAccountReviewComposeEmail =
       required String toEmail,
       required String subject,
       required String body,
+      Rect? sharePositionOrigin,
     });
 
 /// Support-email composer used by minor-account review screens.

--- a/mobile/lib/screens/auth/nostr_connect_screen.dart
+++ b/mobile/lib/screens/auth/nostr_connect_screen.dart
@@ -16,7 +16,6 @@ import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/utils/share_sheet.dart';
 import 'package:openvine/widgets/auth_back_button.dart';
 import 'package:qr_flutter/qr_flutter.dart';
-import 'package:share_plus/share_plus.dart';
 import 'package:skeletonizer/skeletonizer.dart';
 import 'package:unified_logger/unified_logger.dart';
 

--- a/mobile/lib/screens/auth/nostr_connect_screen.dart
+++ b/mobile/lib/screens/auth/nostr_connect_screen.dart
@@ -13,6 +13,7 @@ import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/screens/feed/video_feed_page.dart';
 import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/utils/share_sheet.dart';
 import 'package:openvine/widgets/auth_back_button.dart';
 import 'package:qr_flutter/qr_flutter.dart';
 import 'package:share_plus/share_plus.dart';
@@ -250,7 +251,8 @@ class _NostrConnectScreenState extends ConsumerState<NostrConnectScreen> {
   Future<void> _shareUrl() async {
     if (_connectUrl == null) return;
 
-    await SharePlus.instance.share(
+    await showShareSheet(
+      context,
       ShareParams(text: _connectUrl, title: context.l10n.authConnectToDivine),
     );
   }

--- a/mobile/lib/screens/badges/badge_detail_screen.dart
+++ b/mobile/lib/screens/badges/badge_detail_screen.dart
@@ -21,7 +21,6 @@ import 'package:openvine/utils/share_sheet.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/user_profile_tile.dart';
 import 'package:openvine/widgets/vine_cached_image.dart';
-import 'package:share_plus/share_plus.dart';
 
 /// Shows one badge, its awardees, and the actions available on it.
 class BadgeDetailScreen extends ConsumerWidget {

--- a/mobile/lib/screens/badges/badge_detail_screen.dart
+++ b/mobile/lib/screens/badges/badge_detail_screen.dart
@@ -17,6 +17,7 @@ import 'package:openvine/screens/badges/badge_delete_confirmation_sheet.dart';
 import 'package:openvine/screens/badges/badge_editor_screen.dart';
 import 'package:openvine/screens/badges/badges_screen.dart';
 import 'package:openvine/screens/badges/widgets/badge_recipient_row.dart';
+import 'package:openvine/utils/share_sheet.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/user_profile_tile.dart';
 import 'package:openvine/widgets/vine_cached_image.dart';
@@ -143,7 +144,7 @@ class BadgeDetailView extends StatelessWidget {
     final message = context.l10n.badgeDetailShareMessage(
       'https://badges.divine.video/b/${coordinate.toNaddr()}',
     );
-    await SharePlus.instance.share(ShareParams(text: message));
+    await showShareSheet(context, ShareParams(text: message));
   }
 
   static Future<void> _delete(BuildContext context) async {

--- a/mobile/lib/screens/curated_list_feed_screen.dart
+++ b/mobile/lib/screens/curated_list_feed_screen.dart
@@ -23,7 +23,6 @@ import 'package:openvine/utils/share_sheet.dart';
 import 'package:openvine/widgets/add_to_list_dialog.dart';
 import 'package:openvine/widgets/composable_video_grid.dart';
 import 'package:openvine/widgets/user_name.dart';
-import 'package:share_plus/share_plus.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 enum _CuratedListAction { edit, share, delete, unfollow }

--- a/mobile/lib/screens/curated_list_feed_screen.dart
+++ b/mobile/lib/screens/curated_list_feed_screen.dart
@@ -19,7 +19,7 @@ import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
 import 'package:openvine/screens/other_profile_screen.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:openvine/utils/pause_aware_modals.dart';
-import 'package:openvine/utils/share_position_origin.dart';
+import 'package:openvine/utils/share_sheet.dart';
 import 'package:openvine/widgets/add_to_list_dialog.dart';
 import 'package:openvine/widgets/composable_video_grid.dart';
 import 'package:openvine/widgets/user_name.dart';
@@ -476,11 +476,11 @@ class _CuratedListFeedScreenState extends ConsumerState<CuratedListFeedScreen> {
     );
     final url = 'https://divine.video$path';
     try {
-      await SharePlus.instance.share(
+      await showShareSheet(
+        context,
         ShareParams(
           text: context.l10n.listShareText(list.name, url),
           subject: context.l10n.listShareSubject(list.name),
-          sharePositionOrigin: sharePositionOriginForContext(context),
         ),
       );
     } on Object catch (error, stackTrace) {

--- a/mobile/lib/screens/minor_account_review_parent_consent_screen.dart
+++ b/mobile/lib/screens/minor_account_review_parent_consent_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/constants/app_constants.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/utils/share_position_origin.dart';
 
 class MinorAccountReviewParentConsentScreen extends ConsumerWidget {
   static const routeName = 'minor-account-review-parent-consent';
@@ -98,6 +99,7 @@ class MinorAccountReviewParentConsentScreen extends ConsumerWidget {
         toEmail: AppConstants.supportEmail,
         subject: context.l10n.minorAccountReviewParentConsentEmailSubject,
         body: context.l10n.minorAccountReviewParentConsentEmailBody,
+        sharePositionOrigin: shareAnchorForContext(context),
       );
     } catch (_) {
       if (!context.mounted) return;

--- a/mobile/lib/screens/minor_account_review_under13_support_screen.dart
+++ b/mobile/lib/screens/minor_account_review_under13_support_screen.dart
@@ -12,6 +12,7 @@ import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/models/minor_account_review_status.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/screens/minor_account_review_screen.dart';
+import 'package:openvine/utils/share_position_origin.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 class MinorAccountReviewUnder13SupportScreen extends ConsumerWidget {
@@ -172,7 +173,12 @@ Future<void> _openMinorAccountReviewEmailApp({
   required String body,
 }) async {
   try {
-    await composeEmail(toEmail: supportEmail, subject: subject, body: body);
+    await composeEmail(
+      toEmail: supportEmail,
+      subject: subject,
+      body: body,
+      sharePositionOrigin: shareAnchorForContext(context),
+    );
   } catch (_) {
     if (!context.mounted) return;
     ScaffoldMessenger.of(context).showSnackBar(

--- a/mobile/lib/screens/other_profile_screen.dart
+++ b/mobile/lib/screens/other_profile_screen.dart
@@ -27,6 +27,7 @@ import 'package:openvine/utils/clipboard_utils.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:openvine/utils/npub_hex.dart';
 import 'package:openvine/utils/share_position_origin.dart';
+import 'package:openvine/utils/share_sheet.dart';
 import 'package:openvine/widgets/branded_loading_scaffold.dart';
 import 'package:openvine/widgets/profile/more_sheet/more_sheet_content.dart';
 import 'package:openvine/widgets/profile/more_sheet/more_sheet_result.dart';
@@ -209,9 +210,7 @@ class _OtherProfileViewState extends ConsumerState<OtherProfileView> {
     final shareTextFn = l10n.profileShareText;
     final shareSubjectFn = l10n.profileShareSubject;
     final fallbackName = l10n.profileUserFallback;
-    final sharePositionOrigin = sharePositionOriginForContext(
-      shareButtonContext,
-    );
+    final sharePositionOrigin = shareAnchorForContext(shareButtonContext);
 
     try {
       final profile = await ref
@@ -221,12 +220,9 @@ class _OtherProfileViewState extends ConsumerState<OtherProfileView> {
       final npub = NostrKeyUtils.encodePubKey(widget.pubkey);
       final shareText = shareTextFn(displayName, npub);
 
-      await SharePlus.instance.share(
-        ShareParams(
-          text: shareText,
-          subject: shareSubjectFn(displayName),
-          sharePositionOrigin: sharePositionOrigin,
-        ),
+      await showShareSheetAtOrigin(
+        ShareParams(text: shareText, subject: shareSubjectFn(displayName)),
+        sharePositionOrigin: sharePositionOrigin,
       );
     } catch (e) {
       Log.error(

--- a/mobile/lib/screens/other_profile_screen.dart
+++ b/mobile/lib/screens/other_profile_screen.dart
@@ -34,7 +34,6 @@ import 'package:openvine/widgets/profile/more_sheet/more_sheet_result.dart';
 import 'package:openvine/widgets/profile/new_people_list_sheet.dart';
 import 'package:openvine/widgets/profile/profile_grid.dart';
 import 'package:openvine/widgets/report_content_dialog.dart';
-import 'package:share_plus/share_plus.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 /// Fullscreen profile screen for viewing other users' profiles.

--- a/mobile/lib/screens/profile_screen_router.dart
+++ b/mobile/lib/screens/profile_screen_router.dart
@@ -28,7 +28,6 @@ import 'package:openvine/utils/share_sheet.dart';
 import 'package:openvine/widgets/profile/blocked_user_screen.dart';
 import 'package:openvine/widgets/profile/profile_grid.dart';
 import 'package:openvine/widgets/profile/profile_video_feed_view.dart';
-import 'package:share_plus/share_plus.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 /// Router-driven ProfileScreen - Instagram-style scrollable profile

--- a/mobile/lib/screens/profile_screen_router.dart
+++ b/mobile/lib/screens/profile_screen_router.dart
@@ -24,6 +24,7 @@ import 'package:openvine/screens/profile_setup/profile_setup.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:openvine/utils/npub_hex.dart';
 import 'package:openvine/utils/share_position_origin.dart';
+import 'package:openvine/utils/share_sheet.dart';
 import 'package:openvine/widgets/profile/blocked_user_screen.dart';
 import 'package:openvine/widgets/profile/profile_grid.dart';
 import 'package:openvine/widgets/profile/profile_video_feed_view.dart';
@@ -167,9 +168,7 @@ class _ProfileScreenRouterState extends ConsumerState<ProfileScreenRouter>
     final l10n = context.l10n;
     final shareTextFn = l10n.profileShareText;
     final shareSubjectFn = l10n.profileShareSubject;
-    final sharePositionOrigin = sharePositionOriginForContext(
-      shareButtonContext,
-    );
+    final sharePositionOrigin = shareAnchorForContext(shareButtonContext);
 
     try {
       // Get profile info for better share text
@@ -184,12 +183,9 @@ class _ProfileScreenRouterState extends ConsumerState<ProfileScreenRouter>
       // Create share text with divine.video URL format
       final shareText = shareTextFn(displayName, npub);
 
-      final result = await SharePlus.instance.share(
-        ShareParams(
-          text: shareText,
-          subject: shareSubjectFn(displayName),
-          sharePositionOrigin: sharePositionOrigin,
-        ),
+      final result = await showShareSheetAtOrigin(
+        ShareParams(text: shareText, subject: shareSubjectFn(displayName)),
+        sharePositionOrigin: sharePositionOrigin,
       );
 
       if (result.status == ShareResultStatus.success) {

--- a/mobile/lib/screens/settings/invites_screen.dart
+++ b/mobile/lib/screens/settings/invites_screen.dart
@@ -11,7 +11,6 @@ import 'package:openvine/models/invite_models.dart';
 import 'package:openvine/utils/clipboard_utils.dart';
 import 'package:openvine/utils/share_sheet.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
-import 'package:share_plus/share_plus.dart';
 
 class InvitesScreen extends StatefulWidget {
   const InvitesScreen({super.key});

--- a/mobile/lib/screens/settings/invites_screen.dart
+++ b/mobile/lib/screens/settings/invites_screen.dart
@@ -9,6 +9,7 @@ import 'package:openvine/blocs/invite_status/invite_status_cubit.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/models/invite_models.dart';
 import 'package:openvine/utils/clipboard_utils.dart';
+import 'package:openvine/utils/share_sheet.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:share_plus/share_plus.dart';
 
@@ -249,7 +250,8 @@ class _InviteCodeCard extends StatelessWidget {
               foregroundColor: VineTheme.vineGreen,
               showShadow: false,
               tooltip: context.l10n.invitesShareInvite,
-              onPressed: () => SharePlus.instance.share(
+              onPressed: () => showShareSheet(
+                context,
                 ShareParams(
                   text: _shareMessage(context),
                   subject: context.l10n.invitesShareSubject,

--- a/mobile/lib/screens/settings/support_center_screen.dart
+++ b/mobile/lib/screens/settings/support_center_screen.dart
@@ -143,7 +143,7 @@ class SupportCenterScreen extends ConsumerWidget {
   ) async {
     // Resolve the popover anchor before any await — iPad idiom (including
     // iOS builds on Apple Silicon Macs) rejects the share sheet without it.
-    final sharePositionOrigin = sharePositionOriginForContext(context);
+    final sharePositionOrigin = shareAnchorForContext(context);
     ScaffoldMessenger.of(context).showSnackBar(
       DivineSnackbarContainer.snackBar(
         context.l10n.supportExportingLogs,

--- a/mobile/lib/services/bug_report_service.dart
+++ b/mobile/lib/services/bug_report_service.dart
@@ -20,7 +20,6 @@ import 'package:openvine/utils/device_memory_util.dart';
 import 'package:openvine/utils/share_sheet.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:path_provider/path_provider.dart';
-import 'package:share_plus/share_plus.dart';
 import 'package:unified_logger/unified_logger.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:uuid/uuid.dart';

--- a/mobile/lib/services/bug_report_service.dart
+++ b/mobile/lib/services/bug_report_service.dart
@@ -17,6 +17,7 @@ import 'package:openvine/services/storage_management_service.dart';
 import 'package:openvine/utils/app_uptime.dart';
 import 'package:openvine/utils/browser_file_download.dart';
 import 'package:openvine/utils/device_memory_util.dart';
+import 'package:openvine/utils/share_sheet.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:share_plus/share_plus.dart';
@@ -226,8 +227,15 @@ class BugReportService {
     return jsonString.length;
   }
 
-  /// Send bug report via email by creating a file attachment
-  Future<BugReportResult> sendBugReportViaEmail(BugReportData data) async {
+  /// Send bug report via email by creating a file attachment.
+  ///
+  /// [sharePositionOrigin] anchors the iOS share sheet popover and is
+  /// required on iPad idiom — see [exportLogsToFile] for the failure mode.
+  /// Resolve it with `shareAnchorForContext` at the widget layer.
+  Future<BugReportResult> sendBugReportViaEmail(
+    BugReportData data, {
+    ui.Rect? sharePositionOrigin,
+  }) async {
     try {
       Log.info(
         'Creating bug report file for email ${data.reportId}',
@@ -306,7 +314,12 @@ class BugReportService {
         return _sendBugReportWeb(content, fileName, data.reportId);
       } else {
         // Native: Share via system dialog (user can choose email)
-        return _sendBugReportNative(content, fileName, data.reportId);
+        return _sendBugReportNative(
+          content,
+          fileName,
+          data.reportId,
+          sharePositionOrigin: sharePositionOrigin,
+        );
       }
     } catch (e, stackTrace) {
       Log.error(
@@ -393,8 +406,9 @@ class BugReportService {
   Future<BugReportResult> _sendBugReportNative(
     String content,
     String fileName,
-    String reportId,
-  ) async {
+    String reportId, {
+    ui.Rect? sharePositionOrigin,
+  }) async {
     try {
       // Get temporary directory
       final tempDir = await getTemporaryDirectory();
@@ -413,13 +427,14 @@ class BugReportService {
       );
 
       // Share the file with instructions
-      final result = await SharePlus.instance.share(
+      final result = await showShareSheetAtOrigin(
         ShareParams(
           files: [XFile(filePath)],
           subject: 'OpenVine Bug Report',
           text:
               'Please email this bug report to ${BugReportConfig.supportEmail}\n\nReport ID: $reportId',
         ),
+        sharePositionOrigin: sharePositionOrigin,
       );
 
       if (result.status == ShareResultStatus.success) {
@@ -880,13 +895,13 @@ class BugReportService {
       // Share the file
       // Note: text field is intentionally minimal to ensure the file is the primary content
       // When users select "Copy" in the share dialog, they should get the file, not metadata
-      final result = await SharePlus.instance.share(
+      final result = await showShareSheetAtOrigin(
         ShareParams(
           files: [XFile(filePath)],
           subject: 'OpenVine Full Logs',
           text: 'OpenVine Full Logs',
-          sharePositionOrigin: sharePositionOrigin,
         ),
+        sharePositionOrigin: sharePositionOrigin,
       );
 
       if (result.status == ShareResultStatus.success) {

--- a/mobile/lib/services/support_email_composer.dart
+++ b/mobile/lib/services/support_email_composer.dart
@@ -1,5 +1,8 @@
+import 'dart:ui' show Rect;
+
 import 'package:android_intent_plus/android_intent.dart';
 import 'package:flutter/foundation.dart';
+import 'package:openvine/utils/share_sheet.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:unified_logger/unified_logger.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -7,7 +10,11 @@ import 'package:url_launcher/url_launcher.dart';
 typedef ExternalUriLauncher = Future<bool> Function(Uri uri);
 typedef AndroidChooserLauncher = Future<void> Function(Uri uri, String title);
 typedef ShareTextLauncher =
-    Future<void> Function(String text, {String? subject});
+    Future<void> Function(
+      String text, {
+      String? subject,
+      Rect? sharePositionOrigin,
+    });
 
 String _buildFallbackShareText({
   required String toEmail,
@@ -29,7 +36,7 @@ class SupportEmailComposer {
   SupportEmailComposer({
     Future<bool> Function(Uri uri)? externalUriLauncher,
     Future<void> Function(Uri uri, String title)? androidChooserLauncher,
-    Future<void> Function(String text, {String? subject})? shareTextLauncher,
+    ShareTextLauncher? shareTextLauncher,
   }) : _externalUriLauncher =
            externalUriLauncher ??
            ((uri) => launchUrl(uri, mode: LaunchMode.externalApplication)),
@@ -44,9 +51,10 @@ class SupportEmailComposer {
            }),
        _shareTextLauncher =
            shareTextLauncher ??
-           ((text, {subject}) async {
-             await SharePlus.instance.share(
+           ((text, {subject, sharePositionOrigin}) async {
+             await showShareSheetAtOrigin(
                ShareParams(text: text, subject: subject),
+               sharePositionOrigin: sharePositionOrigin,
              );
            });
 
@@ -54,11 +62,16 @@ class SupportEmailComposer {
   final AndroidChooserLauncher _androidChooserLauncher;
   final ShareTextLauncher _shareTextLauncher;
 
+  /// [sharePositionOrigin] anchors the iOS share-sheet popover used as the
+  /// fallback when no mail client handles the `mailto:` URI. iPad idiom
+  /// rejects the share without it, so widget-layer callers resolve it with
+  /// `shareAnchorForContext` before calling.
   Future<void> compose({
     required String toEmail,
     required String subject,
     required String body,
     String chooserTitle = 'Choose email app',
+    Rect? sharePositionOrigin,
   }) async {
     final encodedSubject = Uri.encodeComponent(subject);
     final encodedBody = Uri.encodeComponent(body);
@@ -91,6 +104,7 @@ class SupportEmailComposer {
     await _shareTextLauncher(
       _buildFallbackShareText(toEmail: toEmail, subject: subject, body: body),
       subject: subject,
+      sharePositionOrigin: sharePositionOrigin,
     );
   }
 }

--- a/mobile/lib/services/support_email_composer.dart
+++ b/mobile/lib/services/support_email_composer.dart
@@ -3,7 +3,6 @@ import 'dart:ui' show Rect;
 import 'package:android_intent_plus/android_intent.dart';
 import 'package:flutter/foundation.dart';
 import 'package:openvine/utils/share_sheet.dart';
-import 'package:share_plus/share_plus.dart';
 import 'package:unified_logger/unified_logger.dart';
 import 'package:url_launcher/url_launcher.dart';
 

--- a/mobile/lib/utils/share_position_origin.dart
+++ b/mobile/lib/utils/share_position_origin.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+/// The global bounds of [context]'s render box, or `null` when it has no
+/// usable size.
 Rect? sharePositionOriginForContext(BuildContext context) {
   final renderObject = context.findRenderObject();
   if (renderObject is! RenderBox || !renderObject.hasSize) return null;
@@ -7,4 +9,19 @@ Rect? sharePositionOriginForContext(BuildContext context) {
   final rect = topLeft & renderObject.size;
   if (rect.isEmpty) return null;
   return rect;
+}
+
+/// The share-sheet popover anchor for [context], clamped to the view.
+///
+/// iPad idiom rejects a share whose anchor is empty or reaches outside the
+/// source view, so a widget that is unsized or scrolled partly off-screen
+/// falls back to (or is clipped against) the whole view instead of handing
+/// share_plus a rect it will refuse.
+Rect? shareAnchorForContext(BuildContext context) {
+  final viewRect = Offset.zero & MediaQuery.sizeOf(context);
+  final origin = sharePositionOriginForContext(context);
+  if (viewRect.isEmpty) return origin;
+  if (origin == null) return viewRect;
+  final clamped = origin.intersect(viewRect);
+  return clamped.isEmpty ? viewRect : clamped;
 }

--- a/mobile/lib/utils/share_sheet.dart
+++ b/mobile/lib/utils/share_sheet.dart
@@ -5,6 +5,22 @@ import 'package:flutter/widgets.dart';
 import 'package:openvine/utils/share_position_origin.dart';
 import 'package:share_plus/share_plus.dart';
 
+/// The share_plus value types call sites need, re-exported so that nothing
+/// else has to import the plugin.
+///
+/// `SharePlus` and the deprecated `Share` are deliberately absent: they are
+/// the entry points that skip the anchor, and leaving them unreachable is
+/// what makes the omission in #7506 unrepresentable rather than merely
+/// discouraged. `test/tools/share_sheet_entry_point_test.dart` fails if any
+/// other file under `lib/` or `packages/*/lib/` imports share_plus directly.
+export 'package:share_plus/share_plus.dart'
+    show
+        CupertinoActivityType,
+        ShareParams,
+        ShareResult,
+        ShareResultStatus,
+        XFile;
+
 /// Presents the platform share sheet, anchored to [context].
 ///
 /// Use this instead of `SharePlus.instance.share`. On iPad idiom (real iPads

--- a/mobile/lib/utils/share_sheet.dart
+++ b/mobile/lib/utils/share_sheet.dart
@@ -1,0 +1,67 @@
+// ABOUTME: The single sanctioned entry point to the platform share sheet.
+// ABOUTME: Fills the sharePositionOrigin anchor iPad refuses to share without.
+
+import 'package:flutter/widgets.dart';
+import 'package:openvine/utils/share_position_origin.dart';
+import 'package:share_plus/share_plus.dart';
+
+/// Presents the platform share sheet, anchored to [context].
+///
+/// Use this instead of `SharePlus.instance.share`. On iPad idiom (real iPads
+/// and iOS builds running on Apple Silicon Macs) share_plus rejects a share
+/// whose `sharePositionOrigin` is missing or empty with
+/// `PlatformException(sharePositionOrigin: argument must be set …)`. Routing
+/// every share through here is what keeps a call site from omitting it;
+/// `test/tools/share_sheet_entry_point_test.dart` holds the line.
+///
+/// [context] must still be mounted, so resolve the anchor before any
+/// `await` — callers that share after awaiting should capture
+/// [shareAnchorForContext] first and use [showShareSheetAtOrigin].
+Future<ShareResult> showShareSheet(BuildContext context, ShareParams params) {
+  return showShareSheetAtOrigin(
+    params,
+    sharePositionOrigin: shareAnchorForContext(context),
+  );
+}
+
+/// Presents the platform share sheet for callers that resolved the anchor
+/// earlier, or that have no [BuildContext] at all (services).
+///
+/// [sharePositionOrigin] comes from [shareAnchorForContext] at the widget
+/// layer. It stays nullable because a service can be driven from a headless
+/// caller, but passing `null` on iPad is what the crash in #7506 was.
+Future<ShareResult> showShareSheetAtOrigin(
+  ShareParams params, {
+  required Rect? sharePositionOrigin,
+}) {
+  return SharePlus.instance.share(
+    shareParamsWithPositionOrigin(params, sharePositionOrigin),
+  );
+}
+
+/// Copies [params] with [sharePositionOrigin] filled in, keeping an origin
+/// the caller set explicitly.
+///
+/// `ShareParams` ships no `copyWith`, so every field is forwarded by hand and
+/// a new share_plus field has to be added here as well —
+/// `test/utils/share_sheet_test.dart` fails when one is dropped.
+@visibleForTesting
+ShareParams shareParamsWithPositionOrigin(
+  ShareParams params,
+  Rect? sharePositionOrigin,
+) {
+  if (params.sharePositionOrigin != null) return params;
+  return ShareParams(
+    text: params.text,
+    subject: params.subject,
+    title: params.title,
+    previewThumbnail: params.previewThumbnail,
+    sharePositionOrigin: sharePositionOrigin,
+    uri: params.uri,
+    files: params.files,
+    fileNameOverrides: params.fileNameOverrides,
+    downloadFallbackEnabled: params.downloadFallbackEnabled,
+    mailToFallbackEnabled: params.mailToFallbackEnabled,
+    excludedCupertinoActivities: params.excludedCupertinoActivities,
+  );
+}

--- a/mobile/lib/widgets/save_original_progress_sheet.dart
+++ b/mobile/lib/widgets/save_original_progress_sheet.dart
@@ -14,7 +14,6 @@ import 'package:openvine/providers/watermark_download_provider.dart';
 import 'package:openvine/services/watermark_download_service.dart';
 import 'package:openvine/utils/share_sheet.dart';
 import 'package:openvine/widgets/retry_after_settings_on_resume.dart';
-import 'package:share_plus/share_plus.dart';
 
 /// Shows a bottom sheet that tracks original video save progress.
 Future<void> showSaveOriginalSheet({

--- a/mobile/lib/widgets/save_original_progress_sheet.dart
+++ b/mobile/lib/widgets/save_original_progress_sheet.dart
@@ -12,6 +12,7 @@ import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/watermark_download_provider.dart';
 import 'package:openvine/services/watermark_download_service.dart';
+import 'package:openvine/utils/share_sheet.dart';
 import 'package:openvine/widgets/retry_after_settings_on_resume.dart';
 import 'package:share_plus/share_plus.dart';
 
@@ -78,7 +79,8 @@ class _SaveOriginalProgressViewState extends State<_SaveOriginalProgressView>
   }
 
   Future<void> _shareFile(WatermarkDownloadSuccess success) async {
-    await SharePlus.instance.share(
+    await showShareSheet(
+      context,
       ShareParams(files: [XFile(success.filePath)]),
     );
   }

--- a/mobile/lib/widgets/video_feed_item/actions/share_action_button.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/share_action_button.dart
@@ -29,6 +29,7 @@ import 'package:openvine/services/video_clip_import_service.dart';
 import 'package:openvine/services/video_sharing_service.dart';
 import 'package:openvine/utils/delete_result_localization.dart';
 import 'package:openvine/utils/pause_aware_modals.dart';
+import 'package:openvine/utils/share_sheet.dart';
 import 'package:openvine/utils/watermark_text_resolver.dart';
 import 'package:openvine/widgets/add_to_list_dialog.dart';
 import 'package:openvine/widgets/crosspost_sheet.dart';
@@ -348,7 +349,8 @@ class _UnifiedShareSheetState extends ConsumerState<_UnifiedShareSheet> {
         :final subject,
       ):
         final files = thumbnailPath != null ? [XFile(thumbnailPath)] : null;
-        SharePlus.instance.share(
+        showShareSheet(
+          context,
           ShareParams(
             text: shareUrl,
             files: files,

--- a/mobile/lib/widgets/video_feed_item/actions/share_action_button.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/share_action_button.dart
@@ -43,7 +43,6 @@ import 'package:openvine/widgets/video_thumbnail_widget.dart';
 import 'package:openvine/widgets/vine_cached_image.dart';
 import 'package:openvine/widgets/watermark_download_progress_sheet.dart';
 import 'package:profile_repository/profile_repository.dart';
-import 'package:share_plus/share_plus.dart';
 import 'package:skeletonizer/skeletonizer.dart';
 import 'package:unified_logger/unified_logger.dart';
 

--- a/mobile/lib/widgets/watermark_download_progress_sheet.dart
+++ b/mobile/lib/widgets/watermark_download_progress_sheet.dart
@@ -14,7 +14,6 @@ import 'package:openvine/providers/watermark_download_provider.dart';
 import 'package:openvine/services/watermark_download_service.dart';
 import 'package:openvine/utils/share_sheet.dart';
 import 'package:openvine/widgets/retry_after_settings_on_resume.dart';
-import 'package:share_plus/share_plus.dart';
 
 Future<void> showWatermarkDownloadSheet({
   required BuildContext context,

--- a/mobile/lib/widgets/watermark_download_progress_sheet.dart
+++ b/mobile/lib/widgets/watermark_download_progress_sheet.dart
@@ -12,6 +12,7 @@ import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/watermark_download_provider.dart';
 import 'package:openvine/services/watermark_download_service.dart';
+import 'package:openvine/utils/share_sheet.dart';
 import 'package:openvine/widgets/retry_after_settings_on_resume.dart';
 import 'package:share_plus/share_plus.dart';
 
@@ -88,7 +89,8 @@ class _WatermarkDownloadProgressViewState
   }
 
   Future<void> _shareFile(WatermarkDownloadSuccess success) async {
-    await SharePlus.instance.share(
+    await showShareSheet(
+      context,
       ShareParams(files: [XFile(success.filePath)]),
     );
   }

--- a/mobile/test/screens/minor_account_review_parent_consent_screen_test.dart
+++ b/mobile/test/screens/minor_account_review_parent_consent_screen_test.dart
@@ -14,6 +14,7 @@ void main() {
       String? sentToEmail;
       String? sentSubject;
       String? sentBody;
+      Rect? sentOrigin;
 
       await tester.pumpWidget(
         MaterialApp(
@@ -25,10 +26,12 @@ void main() {
                   required String toEmail,
                   required String subject,
                   required String body,
+                  Rect? sharePositionOrigin,
                 }) async {
                   sentToEmail = toEmail;
                   sentSubject = subject;
                   sentBody = body;
+                  sentOrigin = sharePositionOrigin;
                 },
           ),
         ),
@@ -49,6 +52,10 @@ void main() {
       expect(sentBody, l10n.minorAccountReviewParentConsentEmailBody);
       expect(sentSubject, contains('Divine Greenlight'));
       expect(sentBody, contains('Divine Greenlight'));
+      // The composer's share-sheet fallback is refused on iPad without an
+      // anchor, so the screen has to resolve one (#7506).
+      expect(sentOrigin, isNotNull);
+      expect(sentOrigin!.isEmpty, isFalse);
     });
   });
 }

--- a/mobile/test/screens/minor_account_review_under13_support_screen_test.dart
+++ b/mobile/test/screens/minor_account_review_under13_support_screen_test.dart
@@ -83,6 +83,7 @@ void main() {
       String? sentToEmail;
       String? sentSubject;
       String? sentBody;
+      Rect? sentOrigin;
 
       await tester.pumpWidget(
         ProviderScope(
@@ -114,10 +115,12 @@ void main() {
                     required String toEmail,
                     required String subject,
                     required String body,
+                    Rect? sharePositionOrigin,
                   }) async {
                     sentToEmail = toEmail;
                     sentSubject = subject;
                     sentBody = body;
+                    sentOrigin = sharePositionOrigin;
                   },
             ),
           ),
@@ -133,6 +136,10 @@ void main() {
       expect(sentToEmail, 'support@divine.video');
       expect(sentSubject, 'Under-13 account review for case case-under13');
       expect(sentBody, contains('I am the parent or guardian'));
+      // The composer's share-sheet fallback is refused on iPad without an
+      // anchor, so the screen has to resolve one (#7506).
+      expect(sentOrigin, isNotNull);
+      expect(sentOrigin!.isEmpty, isFalse);
     });
   });
 }

--- a/mobile/test/services/support_email_composer_test.dart
+++ b/mobile/test/services/support_email_composer_test.dart
@@ -1,3 +1,5 @@
+import 'dart:ui' show Rect;
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/services/support_email_composer.dart';
@@ -28,7 +30,7 @@ void main() {
         externalLaunchCalled = true;
         return true;
       },
-      shareTextLauncher: (text, {subject}) async {
+      shareTextLauncher: (text, {subject, sharePositionOrigin}) async {
         shareCalled = true;
       },
     );
@@ -57,7 +59,7 @@ void main() {
         launchedUri = uri;
         return true;
       },
-      shareTextLauncher: (text, {subject}) async {
+      shareTextLauncher: (text, {subject, sharePositionOrigin}) async {
         shareCalled = true;
       },
     );
@@ -80,21 +82,30 @@ void main() {
 
       String? sharedText;
       String? sharedSubject;
+      Rect? sharedOrigin;
 
       final composer = SupportEmailComposer(
         externalUriLauncher: (_) async => false,
-        shareTextLauncher: (text, {subject}) async {
+        shareTextLauncher: (text, {subject, sharePositionOrigin}) async {
           sharedText = text;
           sharedSubject = subject;
+          sharedOrigin = sharePositionOrigin;
         },
       );
 
-      await composer.compose(toEmail: toEmail, subject: subject, body: body);
+      await composer.compose(
+        toEmail: toEmail,
+        subject: subject,
+        body: body,
+        sharePositionOrigin: const Rect.fromLTWH(8, 16, 32, 64),
+      );
 
       expect(sharedText, contains(toEmail));
       expect(sharedText, contains(subject));
       expect(sharedText, contains(body));
       expect(sharedSubject, subject);
+      // iPad refuses the fallback share without the popover anchor (#7506).
+      expect(sharedOrigin, const Rect.fromLTWH(8, 16, 32, 64));
     },
   );
 
@@ -107,7 +118,7 @@ void main() {
       androidChooserLauncher: (uri, title) {
         throw Exception('$title: $uri');
       },
-      shareTextLauncher: (text, {subject}) async {
+      shareTextLauncher: (text, {subject, sharePositionOrigin}) async {
         sharedText = text;
       },
     );

--- a/mobile/test/tools/share_sheet_entry_point_test.dart
+++ b/mobile/test/tools/share_sheet_entry_point_test.dart
@@ -9,28 +9,112 @@ import 'package:test/test.dart';
 /// fills the anchor for everybody else.
 const _entryPoint = 'lib/utils/share_sheet.dart';
 
+/// Any `import`/`export` of the plugin or of its platform interface.
+///
+/// The prefix deliberately stops at `share_plus` so it also catches
+/// `package:share_plus_platform_interface/...`, whose `SharePlatform.instance`
+/// reaches the same native channel without ever naming `SharePlus`.
+final _sharePlusDirective = RegExp(
+  r'''^\s*(?:import|export)\s+['"]package:share_plus''',
+  multiLine: true,
+);
+
+/// The plugin entry points that skip the anchor.
+///
+/// `SharePlus.instance`, `SharePlus.custom`, a stored `final s = SharePlus…`
+/// and the whitespace form `SharePlus . instance` all contain the class name,
+/// so matching the bare identifier covers the family rather than one spelling.
+/// The deprecated `Share` statics are unreachable once the directive check
+/// above passes, since they cannot be named without importing the plugin.
+final _pluginEntryPoint = RegExp(r'\bSharePlus\b');
+
+/// Every Dart file that ships in the app or in a workspace package.
+///
+/// Package `test/` and `example/` trees are excluded: they may exercise the
+/// plugin directly, and they never run on a user's iPad.
+List<File> _shippedDartFiles() {
+  final roots = <Directory>[
+    Directory('lib'),
+    for (final entity in Directory('packages').listSync())
+      if (entity is Directory) Directory('${entity.path}/lib'),
+  ];
+
+  return [
+    for (final root in roots)
+      if (root.existsSync())
+        ...root
+            .listSync(recursive: true)
+            .whereType<File>()
+            .where((file) => file.path.endsWith('.dart')),
+  ];
+}
+
+String _relative(File file) => file.path.replaceAll(r'\', '/');
+
 void main() {
   group('share sheet entry point', () {
-    test('only the wrapper calls SharePlus directly', () {
-      final offenders = <String>[];
+    late List<File> files;
 
-      for (final entity in Directory('lib').listSync(recursive: true)) {
-        if (entity is! File || !entity.path.endsWith('.dart')) continue;
-        final path = entity.path;
-        if (path == _entryPoint) continue;
-        if (entity.readAsStringSync().contains('SharePlus.instance')) {
-          offenders.add(path);
-        }
-      }
+    setUpAll(() {
+      files = _shippedDartFiles();
+    });
+
+    test('finds the files it is supposed to be scanning', () {
+      // A scan that silently walks an empty tree would pass forever. Both
+      // roots must actually contribute, and the entry point must be among
+      // them, or the two guards below prove nothing.
+      expect(files, isNotEmpty);
+      expect(
+        files.where((file) => _relative(file).startsWith('packages/')),
+        isNotEmpty,
+        reason: 'packages/*/lib is not being scanned',
+      );
+      expect(
+        files.map(_relative),
+        contains(_entryPoint),
+        reason: 'the entry point itself is not being scanned',
+      );
+    });
+
+    test('only the wrapper imports share_plus', () {
+      final offenders = <String>[
+        for (final file in files)
+          if (_relative(file) != _entryPoint &&
+              _sharePlusDirective.hasMatch(file.readAsStringSync()))
+            _relative(file),
+      ];
 
       expect(
         offenders,
         isEmpty,
         reason:
             'iPad rejects a share whose sharePositionOrigin is missing '
-            '(#7506). Call showShareSheet(context, params) — or '
-            'showShareSheetAtOrigin when the anchor was resolved before an '
-            'await — from $_entryPoint instead of SharePlus.instance.share.',
+            '(#7506). Import $_entryPoint instead — it re-exports '
+            'ShareParams, ShareResult, ShareResultStatus, XFile and '
+            'CupertinoActivityType — then call showShareSheet(context, '
+            'params), or showShareSheetAtOrigin when the anchor was resolved '
+            'before an await.',
+      );
+    });
+
+    test('only the wrapper names SharePlus', () {
+      // Second line of defence: if the entry point ever re-exported SharePlus
+      // itself, the import check above would still pass while every call site
+      // regained an unanchored path to the plugin.
+      final offenders = <String>[
+        for (final file in files)
+          if (_relative(file) != _entryPoint &&
+              _pluginEntryPoint.hasMatch(file.readAsStringSync()))
+            _relative(file),
+      ];
+
+      expect(
+        offenders,
+        isEmpty,
+        reason:
+            'SharePlus presents the share sheet without an anchor, which '
+            'iPad refuses (#7506). Only $_entryPoint may name it, and it '
+            'must not re-export it.',
       );
     });
   });

--- a/mobile/test/tools/share_sheet_entry_point_test.dart
+++ b/mobile/test/tools/share_sheet_entry_point_test.dart
@@ -1,0 +1,37 @@
+// ABOUTME: Freezes the share sheet behind lib/utils/share_sheet.dart so no
+// ABOUTME: call site can present a share without a sharePositionOrigin.
+
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+/// The one file allowed to reach for the plugin directly, because it is what
+/// fills the anchor for everybody else.
+const _entryPoint = 'lib/utils/share_sheet.dart';
+
+void main() {
+  group('share sheet entry point', () {
+    test('only the wrapper calls SharePlus directly', () {
+      final offenders = <String>[];
+
+      for (final entity in Directory('lib').listSync(recursive: true)) {
+        if (entity is! File || !entity.path.endsWith('.dart')) continue;
+        final path = entity.path;
+        if (path == _entryPoint) continue;
+        if (entity.readAsStringSync().contains('SharePlus.instance')) {
+          offenders.add(path);
+        }
+      }
+
+      expect(
+        offenders,
+        isEmpty,
+        reason:
+            'iPad rejects a share whose sharePositionOrigin is missing '
+            '(#7506). Call showShareSheet(context, params) — or '
+            'showShareSheetAtOrigin when the anchor was resolved before an '
+            'await — from $_entryPoint instead of SharePlus.instance.share.',
+      );
+    });
+  });
+}

--- a/mobile/test/tools/share_sheet_entry_point_test.dart
+++ b/mobile/test/tools/share_sheet_entry_point_test.dart
@@ -33,10 +33,12 @@ final _pluginEntryPoint = RegExp(r'\bSharePlus\b');
 /// Package `test/` and `example/` trees are excluded: they may exercise the
 /// plugin directly, and they never run on a user's iPad.
 List<File> _shippedDartFiles() {
+  final packages = Directory('packages');
   final roots = <Directory>[
     Directory('lib'),
-    for (final entity in Directory('packages').listSync())
-      if (entity is Directory) Directory('${entity.path}/lib'),
+    if (packages.existsSync())
+      for (final entity in packages.listSync())
+        if (entity is Directory) Directory('${entity.path}/lib'),
   ];
 
   return [

--- a/mobile/test/utils/share_sheet_test.dart
+++ b/mobile/test/utils/share_sheet_test.dart
@@ -5,7 +5,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/utils/share_sheet.dart';
-import 'package:share_plus/share_plus.dart';
 
 const _shareChannel = MethodChannel('dev.fluttercommunity.plus/share');
 

--- a/mobile/test/utils/share_sheet_test.dart
+++ b/mobile/test/utils/share_sheet_test.dart
@@ -112,6 +112,36 @@ void main() {
       expect(origin, Offset.zero & viewSize);
     });
 
+    testWidgets('falls back to the view when the anchor is fully off-screen', (
+      tester,
+    ) async {
+      final key = GlobalKey();
+      final viewSize = tester.view.physicalSize / tester.view.devicePixelRatio;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Align(
+            alignment: Alignment.topLeft,
+            child: Transform.translate(
+              offset: Offset(-viewSize.width, -viewSize.height),
+              child: SizedBox(key: key, width: 120, height: 48),
+            ),
+          ),
+        ),
+      );
+
+      await showShareSheet(
+        key.currentContext!,
+        ShareParams(text: 'divine.video'),
+      );
+
+      // Nothing of the anchor is left after clipping, and iPad refuses an
+      // empty rect exactly as firmly as a missing one — so the view has to
+      // stand in rather than the zero-area intersection being passed along.
+      final origin = originOf(shareCalls.single);
+      expect(origin.isEmpty, isFalse);
+      expect(origin, Offset.zero & viewSize);
+    });
+
     testWidgets('keeps an anchor the caller set explicitly', (tester) async {
       final key = GlobalKey();
       await tester.pumpWidget(

--- a/mobile/test/utils/share_sheet_test.dart
+++ b/mobile/test/utils/share_sheet_test.dart
@@ -1,0 +1,195 @@
+// ABOUTME: Tests the share-sheet wrapper that fills sharePositionOrigin.
+// ABOUTME: iPad refuses a share whose anchor is empty or outside the view.
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/utils/share_sheet.dart';
+import 'package:share_plus/share_plus.dart';
+
+const _shareChannel = MethodChannel('dev.fluttercommunity.plus/share');
+
+void main() {
+  late List<Map<Object?, Object?>> shareCalls;
+
+  setUp(() {
+    shareCalls = <Map<Object?, Object?>>[];
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(_shareChannel, (call) async {
+          if (call.method != 'share') return null;
+          shareCalls.add(call.arguments as Map<Object?, Object?>);
+          return 'com.apple.UIKit.activity.CopyToPasteboard';
+        });
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(_shareChannel, null);
+  });
+
+  Rect originOf(Map<Object?, Object?> call) => Rect.fromLTWH(
+    call['originX']! as double,
+    call['originY']! as double,
+    call['originWidth']! as double,
+    call['originHeight']! as double,
+  );
+
+  group('showShareSheet', () {
+    testWidgets('anchors the share sheet on the calling widget', (
+      tester,
+    ) async {
+      final key = GlobalKey();
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Center(child: SizedBox(key: key, width: 120, height: 48)),
+        ),
+      );
+
+      await showShareSheet(
+        key.currentContext!,
+        ShareParams(text: 'divine.video'),
+      );
+
+      expect(shareCalls, hasLength(1));
+      final box = key.currentContext!.findRenderObject()! as RenderBox;
+      expect(
+        originOf(shareCalls.single),
+        box.localToGlobal(Offset.zero) & box.size,
+      );
+    });
+
+    testWidgets('falls back to the view when the widget has no size', (
+      tester,
+    ) async {
+      final key = GlobalKey();
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Align(
+            alignment: Alignment.topLeft,
+            child: SizedBox.shrink(key: key),
+          ),
+        ),
+      );
+
+      await showShareSheet(
+        key.currentContext!,
+        ShareParams(text: 'divine.video'),
+      );
+
+      final origin = originOf(shareCalls.single);
+      expect(origin.isEmpty, isFalse);
+      expect(origin, Offset.zero & MediaQuery.sizeOf(key.currentContext!));
+    });
+
+    testWidgets('clips an anchor that reaches outside the view', (
+      tester,
+    ) async {
+      final key = GlobalKey();
+      final viewSize = tester.view.physicalSize / tester.view.devicePixelRatio;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Align(
+            alignment: Alignment.topLeft,
+            child: OverflowBox(
+              alignment: Alignment.topLeft,
+              maxWidth: viewSize.width * 2,
+              maxHeight: viewSize.height * 2,
+              child: SizedBox(
+                key: key,
+                width: viewSize.width * 2,
+                height: viewSize.height * 2,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await showShareSheet(
+        key.currentContext!,
+        ShareParams(text: 'divine.video'),
+      );
+
+      final origin = originOf(shareCalls.single);
+      expect(origin, Offset.zero & viewSize);
+    });
+
+    testWidgets('keeps an anchor the caller set explicitly', (tester) async {
+      final key = GlobalKey();
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Center(child: SizedBox(key: key, width: 120, height: 48)),
+        ),
+      );
+
+      await showShareSheet(
+        key.currentContext!,
+        ShareParams(
+          text: 'divine.video',
+          sharePositionOrigin: const Rect.fromLTWH(4, 8, 16, 32),
+        ),
+      );
+
+      expect(originOf(shareCalls.single), const Rect.fromLTWH(4, 8, 16, 32));
+    });
+  });
+
+  group('showShareSheetAtOrigin', () {
+    test('forwards the anchor resolved by the caller', () async {
+      await showShareSheetAtOrigin(
+        ShareParams(text: 'divine.video'),
+        sharePositionOrigin: const Rect.fromLTWH(1, 2, 3, 4),
+      );
+
+      expect(originOf(shareCalls.single), const Rect.fromLTWH(1, 2, 3, 4));
+    });
+  });
+
+  group('shareParamsWithPositionOrigin', () {
+    test('carries every ShareParams field across the copy', () {
+      final thumbnail = XFile('thumbnail.png');
+      final file = XFile('clip.mp4');
+      final params = ShareParams(
+        text: 'text',
+        subject: 'subject',
+        title: 'title',
+        previewThumbnail: thumbnail,
+        files: [file],
+        fileNameOverrides: const ['renamed.mp4'],
+        downloadFallbackEnabled: false,
+        mailToFallbackEnabled: false,
+        excludedCupertinoActivities: const [
+          CupertinoActivityType.postToFacebook,
+        ],
+      );
+
+      final copy = shareParamsWithPositionOrigin(
+        params,
+        const Rect.fromLTWH(1, 2, 3, 4),
+      );
+
+      expect(copy.text, params.text);
+      expect(copy.subject, params.subject);
+      expect(copy.title, params.title);
+      expect(copy.previewThumbnail, same(thumbnail));
+      expect(copy.files, same(params.files));
+      expect(copy.fileNameOverrides, same(params.fileNameOverrides));
+      expect(copy.downloadFallbackEnabled, isFalse);
+      expect(copy.mailToFallbackEnabled, isFalse);
+      expect(
+        copy.excludedCupertinoActivities,
+        same(params.excludedCupertinoActivities),
+      );
+      expect(copy.sharePositionOrigin, const Rect.fromLTWH(1, 2, 3, 4));
+    });
+
+    test('carries a uri, which cannot be combined with text', () {
+      final copy = shareParamsWithPositionOrigin(
+        ShareParams(uri: Uri.parse('https://divine.video')),
+        const Rect.fromLTWH(1, 2, 3, 4),
+      );
+
+      expect(copy.uri, Uri.parse('https://divine.video'));
+      expect(copy.sharePositionOrigin, const Rect.fromLTWH(1, 2, 3, 4));
+    });
+  });
+}


### PR DESCRIPTION
## Description

`share_plus` refuses a share on iPad idiom (real iPads and iOS builds on Apple Silicon Macs) when `sharePositionOrigin` is missing, empty, or reaches outside the source view — `FPPSharePlusPlugin.m` returns `PlatformException(sharePositionOrigin: argument must be set …)` before presenting anything. Only 4 of the 12 `SharePlus.instance.share` call sites in `mobile/lib` passed an anchor, which is Crashlytics `c786f6ae145ba23e8211e70954e26f73` (8 events, live since 1.0.5).

Rather than patching the reported path, this closes the set the way #7359 should have been closed: the plugin is now reachable from exactly one file, and that file fills the anchor.

**New entry point — `mobile/lib/utils/share_sheet.dart`**

- `showShareSheet(context, params)` for the widget layer. It resolves the anchor from `context` and can't be called without one.
- `showShareSheetAtOrigin(params, sharePositionOrigin:)` for callers that must resolve the anchor before an `await` (the profile screens capture it ahead of a repository fetch) and for services that have no `BuildContext` at all. The anchor is a *required* named argument, so it can't be silently dropped either.
- `shareParamsWithPositionOrigin` copies `ShareParams` field by field, because the class ships no `copyWith`. A test pins the full field set so a dropped field fails rather than silently disappearing from a share.

**New anchor helper — `shareAnchorForContext`**

The existing `sharePositionOriginForContext` returns `null` for an unsized widget, and `null` is exactly what iPad rejects. `shareAnchorForContext` falls back to the view rect in that case, and clips an anchor that reaches outside the view — the native check is `CGRectContainsRect(controller.view.frame, origin) && !CGRectIsEmpty(origin)`, so a button scrolled half off-screen would otherwise be refused too. Every migrated call site goes through it.

**Call sites changed** (the issue listed 6; the sweep found 8 — `share_action_button.dart` and the second share inside `bug_report_service.dart` were also unanchored):

| File | Before |
|---|---|
| `lib/screens/auth/nostr_connect_screen.dart` | no anchor |
| `lib/screens/badges/badge_detail_screen.dart` | no anchor |
| `lib/screens/settings/invites_screen.dart` | no anchor |
| `lib/widgets/save_original_progress_sheet.dart` | no anchor |
| `lib/widgets/watermark_download_progress_sheet.dart` | no anchor |
| `lib/widgets/video_feed_item/actions/share_action_button.dart` | no anchor (not in the issue) |
| `lib/services/support_email_composer.dart` | no anchor |
| `lib/services/bug_report_service.dart` (`_sendBugReportNative`) | no anchor (not in the issue) |
| `lib/services/bug_report_service.dart` (`_exportLogsNative`) | anchored, migrated to the wrapper |
| `lib/screens/curated_list_feed_screen.dart` | anchored, migrated |
| `lib/screens/other_profile_screen.dart` | anchored, migrated |
| `lib/screens/profile_screen_router.dart` | anchored, migrated |

`support_email_composer.dart` has no `BuildContext` and shares only as a `mailto:` fallback. Rather than reaching for a navigator key, it takes a `Rect?` the same way `BugReportService.exportLogsToFile` already did, and the two minor-account-review screens that drive it resolve the anchor from their own context. `MinorAccountReviewComposeEmail` and `ShareTextLauncher` grew the parameter accordingly.

`BugReportService.sendBugReportViaEmail` has no in-repo callers today (already true on `main`); it got the same optional `sharePositionOrigin` as its sibling `exportLogsToFile` instead of being left as a knowingly-broken share path. It could not simply be left alone — the guard below forces every `SharePlus.instance` site through the wrapper. Deleting it instead would also orphan `_sendBugReportNative` and `_sendBugReportWeb` (~120 lines) that only it reaches, which is a bigger change than a bug fix should carry, and `docs/plans/2025-11-15-zendesk-support-integration.md` still names it as a planned fallback.

**Holding the line:** `mobile/test/tools/share_sheet_entry_point_test.dart` fails if any file under `mobile/lib` or `mobile/packages/*/lib` other than `lib/utils/share_sheet.dart` imports `package:share_plus`. The wrapper re-exports the value types call sites need (`ShareParams`, `ShareResult`, `ShareResultStatus`, `XFile`, `CupertinoActivityType`) and deliberately not `SharePlus` or the deprecated `Share`, so the unanchored entry points are unreachable rather than merely discouraged; a second check keeps `SharePlus` unnameable outside the wrapper so re-exporting it later fails too, and a third asserts the scan actually walks both roots.

It started as a scan for the literal `SharePlus.instance` in `lib/`, which three bypasses walked past when tested against it — the deprecated `Share.share`/`Share.shareXFiles`/`Share.shareUri` statics, `SharePlus . instance` with whitespace, and `SharePlatform.instance` from the platform interface — and which never looked at `mobile/packages` at all. `flutter analyze` happens to reject the first three today (deprecation infos are fatal, `SharePlus.custom` is a fatal warning), but that is a different gate shielding this one by accident, and it lapses the moment share_plus renames an API.

**Related Issue:** Closes #7506

## Out of Scope

- `sendBugReportViaEmail` is pre-existing dead code (no callers on `main` either) and stays that way here, along with the two private senders only it reaches.
- No behaviour change on Android/iPhone — `sharePositionOrigin` is ignored off iPad idiom.

## Verification

Run from `mobile/`:

- `flutter analyze lib test integration_test` — no issues.
- `flutter test test/utils/share_sheet_test.dart test/utils/share_position_origin_test.dart test/tools/share_sheet_entry_point_test.dart test/services/support_email_composer_test.dart` — 14 passing.
- `flutter test test/tools test/utils` — 555 passing.
- `flutter test` for every touched screen/widget suite: `minor_account_review_under13_support_screen`, `minor_account_review_parent_consent_screen`, `settings/invites_screen`, `badges/badge_detail_screen`, `settings/support_center_screen`, `unit/services/bug_report_service`, `unit/services/bug_report_log_export`, `curated_list_feed_screen`, `other_profile_screen`, `profile_screen_router`, `auth/nostr_connect_screen`, `save_original_progress_sheet`, `watermark_download_progress_sheet`, `video_feed_item/actions/share_action_button` — all green.
- `bash scripts/check_ui_service_boundary.sh` and `bash scripts/check_untested_services_floor.sh` — OK.
- Mutation-checked every new and changed test; none passes with its production change reverted:
  - wrapper returns `params` unchanged → 6 of 7 `share_sheet_test.dart` cases red;
  - drop the caller-set-origin early return → the 7th (`keeps an anchor the caller set explicitly`) red;
  - `shareAnchorForContext` → plain `sharePositionOriginForContext` → the fallback and clipping cases red;
  - drop only the empty-intersection fallback (`return clamped;`) → `falls back to the view when the anchor is fully off-screen` red. That branch had no test until this pass: the mutation ships an empty rect, which the native side rejects on the same line as a missing one (`!isCoordinateSpaceOfSourceView || CGRectIsEmpty(origin)`), so the one branch guarding the actual bug was unguarded;
  - minor-account screens stop resolving an anchor → both screen tests red on `Expected: not null`;
  - composer stops forwarding the anchor → `falls back to share sheet when external launch returns false` red;
  - each of the four guard bypasses above, planted under `lib/` and under `packages/divine_ui/lib/` → guard red;
  - guard pointed at a bogus scan root → its own self-check red.

**Device verification is still pending.** This repo's convention is a manual pass on a real Samsung Galaxy, and this crash reproduces on iPad specifically — neither was run here. Someone with an iPad (or the iPad simulator) should confirm the share sheet now opens from: profile share, list share, invite share, badge share, Nostr Connect share, the save-original and watermark sheets, the feed "share via" action, support-center log export, and the minor-account-review support email with no mail client installed.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

