### PR TITLE
fix(network): retry Funnelcake reads and stop reporting unreachable as empty

### DIFF
--- a/mobile/lib/blocs/profile_feed/profile_feed_cubit.dart
+++ b/mobile/lib/blocs/profile_feed/profile_feed_cubit.dart
@@ -397,11 +397,6 @@ class ProfileFeedCubit extends Bloc<ProfileFeedEvent, ProfileFeedState> {
           isFetchingTotalCount: false,
         ),
       );
-      // Keep the last window we could show. Only guard the empty case: a
-      // successful load returning zero videos still needs to be able to clear
-      // the snapshot, or a fully-deleted profile would serve its old videos
-      // forever.
-      if (_unfilteredVideos.isNotEmpty) _persistSnapshot();
       return null;
     }
   }

--- a/mobile/lib/blocs/profile_feed/profile_feed_cubit.dart
+++ b/mobile/lib/blocs/profile_feed/profile_feed_cubit.dart
@@ -213,6 +213,11 @@ class ProfileFeedCubit extends Bloc<ProfileFeedEvent, ProfileFeedState> {
       ),
     );
 
+    // Persist before the network is consulted. Waiting for a successful REST
+    // load means a user whose loads keep failing never accumulates a snapshot,
+    // so the cache is empty for exactly the connections that need it most.
+    if (relaySeed.isNotEmpty) _persistSnapshot();
+
     final result = await _loadFromRest(
       emit,
       relaySeed: relaySeed,
@@ -392,6 +397,11 @@ class ProfileFeedCubit extends Bloc<ProfileFeedEvent, ProfileFeedState> {
           isFetchingTotalCount: false,
         ),
       );
+      // Keep the last window we could show. Only guard the empty case: a
+      // successful load returning zero videos still needs to be able to clear
+      // the snapshot, or a fully-deleted profile would serve its old videos
+      // forever.
+      if (_unfilteredVideos.isNotEmpty) _persistSnapshot();
       return null;
     }
   }

--- a/mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart
+++ b/mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart
@@ -3,6 +3,7 @@
 
 import 'dart:async';
 import 'dart:convert';
+import 'dart:math' as math;
 
 import 'package:funnelcake_api_client/src/exceptions.dart';
 import 'package:funnelcake_api_client/src/leaderboard_period.dart';
@@ -51,10 +52,13 @@ class FunnelcakeApiClient {
   /// (e.g., 'https://api.example.com').
   /// [httpClient] is an optional HTTP client for making requests.
   /// [timeout] is the request timeout duration (defaults to 15 seconds).
+  /// [retryBaseDelay] seeds the backoff between GET retries; pass
+  /// [Duration.zero] in tests to keep suites fast.
   FunnelcakeApiClient({
     required String baseUrl,
     http.Client? httpClient,
     Duration timeout = const Duration(seconds: 15),
+    Duration retryBaseDelay = const Duration(milliseconds: 300),
     String moderationProfile = defaultModerationProfile,
   }) : _baseUrl = baseUrl.endsWith('/')
            ? baseUrl.substring(0, baseUrl.length - 1)
@@ -62,7 +66,18 @@ class FunnelcakeApiClient {
        _httpClient = httpClient ?? http.Client(),
        _ownsHttpClient = httpClient == null,
        _timeout = timeout,
+       _retryBaseDelay = retryBaseDelay,
        _moderationProfile = moderationProfile;
+
+  /// Total attempts an idempotent GET makes before giving up.
+  ///
+  /// Reads retry because a flaky last mile is far more likely than the API
+  /// being down: the production host is CDN-replicated, so a GET that fails
+  /// once usually succeeds moments later on the same connection.
+  static const int maxGetAttempts = 3;
+
+  /// Upper bound on a single backoff wait, before jitter.
+  static const Duration _maxRetryDelay = Duration(seconds: 4);
 
   /// Default moderation profile sent with video-bearing Funnelcake requests.
   static const String defaultModerationProfile = 'default';
@@ -117,7 +132,9 @@ class FunnelcakeApiClient {
   final http.Client _httpClient;
   final bool _ownsHttpClient;
   final Duration _timeout;
+  final Duration _retryBaseDelay;
   final String _moderationProfile;
+  final math.Random _retryJitter = math.Random();
 
   /// Whether the API is available (has a non-empty base URL).
   bool get isAvailable => _baseUrl.isNotEmpty;
@@ -126,16 +143,56 @@ class FunnelcakeApiClient {
   @visibleForTesting
   String get baseUrl => _baseUrl;
 
-  Future<http.Response> _get(Uri uri) {
-    return _httpClient
-        .get(
-          uri,
-          headers: {
-            'Accept': 'application/json',
-            'User-Agent': 'OpenVine-Mobile/1.0',
-          },
-        )
-        .timeout(_timeout);
+  /// Performs an idempotent GET, retrying transient failures.
+  ///
+  /// Retries cover the two shapes a flaky connection produces: a thrown
+  /// transport error (timeout, dropped socket) and a retryable status
+  /// (429, 5xx). A definitive answer — including 404 — is returned on the
+  /// first attempt, because absence is information and must not be
+  /// confused with an unreachable server.
+  Future<http.Response> _get(Uri uri) async {
+    var attempt = 0;
+    while (true) {
+      attempt++;
+      try {
+        final response = await _httpClient
+            .get(
+              uri,
+              headers: {
+                'Accept': 'application/json',
+                'User-Agent': 'OpenVine-Mobile/1.0',
+              },
+            )
+            .timeout(_timeout);
+
+        if (attempt < maxGetAttempts &&
+            _isRetryableStatus(response.statusCode)) {
+          await _awaitRetryDelay(attempt);
+          continue;
+        }
+        return response;
+      } on Object {
+        // Nothing above constructs a FunnelcakeException, so any throw here
+        // is transport-level and worth another attempt.
+        if (attempt >= maxGetAttempts) rethrow;
+        await _awaitRetryDelay(attempt);
+      }
+    }
+  }
+
+  /// Whether [statusCode] represents a failure the server may recover from.
+  bool _isRetryableStatus(int statusCode) =>
+      statusCode == 429 || (statusCode >= 500 && statusCode < 600);
+
+  /// Waits out the backoff for [attempt], using full jitter so clients that
+  /// lost the same flaky link do not retry in lockstep when it returns.
+  Future<void> _awaitRetryDelay(int attempt) async {
+    if (_retryBaseDelay == Duration.zero) return;
+    final exponential = _retryBaseDelay.inMilliseconds * (1 << (attempt - 1));
+    final capped = math.min(exponential, _maxRetryDelay.inMilliseconds);
+    await Future<void>.delayed(
+      Duration(milliseconds: _retryJitter.nextInt(capped + 1)),
+    );
   }
 
   Future<http.Response> _post(Uri uri, {required Object body}) {

--- a/mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart
+++ b/mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart
@@ -51,7 +51,9 @@ class FunnelcakeApiClient {
   /// [baseUrl] is the base URL for the Funnelcake API
   /// (e.g., 'https://api.example.com').
   /// [httpClient] is an optional HTTP client for making requests.
-  /// [timeout] is the request timeout duration (defaults to 15 seconds).
+  /// [timeout] bounds a whole call, not a single attempt: a GET spends it
+  /// across every retry and backoff wait, so retrying never multiplies a
+  /// caller's worst case (defaults to 15 seconds).
   /// [retryBaseDelay] seeds the backoff between GET retries; pass
   /// [Duration.zero] in tests to keep suites fast.
   FunnelcakeApiClient({
@@ -150,7 +152,20 @@ class FunnelcakeApiClient {
   /// (429, 5xx). A definitive answer — including 404 — is returned on the
   /// first attempt, because absence is information and must not be
   /// confused with an unreachable server.
+  ///
+  /// [_timeout] bounds the whole call, not one attempt: every attempt and
+  /// backoff wait draws from the same budget. A caller's worst case is
+  /// therefore unchanged by retrying — which matters because callers await
+  /// this inline (the login pre-fetch blocks the post-auth redirect on it),
+  /// and a per-attempt bound would have multiplied that stall by
+  /// [maxGetAttempts]. The trade is that a request which burns the entire
+  /// budget in one attempt is not retried; the fast failures a flaky link
+  /// actually produces — reset sockets, refused connections, 5xx — leave
+  /// almost the whole budget intact and still get every attempt.
   Future<http.Response> _get(Uri uri) async {
+    final elapsed = Stopwatch()..start();
+    Duration remaining() => _timeout - elapsed.elapsed;
+
     var attempt = 0;
     while (true) {
       attempt++;
@@ -163,22 +178,27 @@ class FunnelcakeApiClient {
                 'User-Agent': 'OpenVine-Mobile/1.0',
               },
             )
-            .timeout(_timeout);
+            .timeout(remaining());
 
-        if (attempt < maxGetAttempts &&
+        if (_canRetry(attempt, remaining()) &&
             _isRetryableStatus(response.statusCode)) {
-          await _awaitRetryDelay(attempt);
+          await _awaitRetryDelay(attempt, remaining());
           continue;
         }
         return response;
       } on Object {
         // Nothing above constructs a FunnelcakeException, so any throw here
         // is transport-level and worth another attempt.
-        if (attempt >= maxGetAttempts) rethrow;
-        await _awaitRetryDelay(attempt);
+        if (!_canRetry(attempt, remaining())) rethrow;
+        await _awaitRetryDelay(attempt, remaining());
       }
     }
   }
+
+  /// Whether another GET attempt is allowed after [attempt] failed, with
+  /// [remaining] left of the call's timeout budget.
+  bool _canRetry(int attempt, Duration remaining) =>
+      attempt < maxGetAttempts && remaining > Duration.zero;
 
   /// Whether [statusCode] represents a failure the server may recover from.
   bool _isRetryableStatus(int statusCode) =>
@@ -186,10 +206,17 @@ class FunnelcakeApiClient {
 
   /// Waits out the backoff for [attempt], using full jitter so clients that
   /// lost the same flaky link do not retry in lockstep when it returns.
-  Future<void> _awaitRetryDelay(int attempt) async {
+  ///
+  /// Never waits longer than [remaining], so backoff cannot overrun the
+  /// call's timeout budget on its own.
+  Future<void> _awaitRetryDelay(int attempt, Duration remaining) async {
     if (_retryBaseDelay == Duration.zero) return;
     final exponential = _retryBaseDelay.inMilliseconds * (1 << (attempt - 1));
-    final capped = math.min(exponential, _maxRetryDelay.inMilliseconds);
+    final capped = math.min(
+      math.min(exponential, _maxRetryDelay.inMilliseconds),
+      remaining.inMilliseconds,
+    );
+    if (capped <= 0) return;
     await Future<void>.delayed(
       Duration(milliseconds: _retryJitter.nextInt(capped + 1)),
     );

--- a/mobile/packages/funnelcake_api_client/test/src/funnelcake_api_client_retry_test.dart
+++ b/mobile/packages/funnelcake_api_client/test/src/funnelcake_api_client_retry_test.dart
@@ -123,5 +123,64 @@ void main() {
       );
       expect(attempts, equals(FunnelcakeApiClient.maxGetAttempts));
     });
+
+    test(
+      'spends the timeout budget across attempts, not per attempt',
+      () async {
+        var attempts = 0;
+        when(
+          () => httpClient.get(any(), headers: any(named: 'headers')),
+        ).thenAnswer((_) async {
+          attempts++;
+          // Dead air, the shape that costs a full timeout to detect.
+          await Future<void>.delayed(const Duration(seconds: 5));
+          return http.Response(eventBody, 200);
+        });
+
+        final bounded = FunnelcakeApiClient(
+          baseUrl: baseUrl,
+          httpClient: httpClient,
+          timeout: const Duration(milliseconds: 200),
+          retryBaseDelay: Duration.zero,
+        );
+
+        final elapsed = Stopwatch()..start();
+        await expectLater(
+          bounded.getVideoEvent(eventId),
+          throwsA(isA<FunnelcakeTimeoutException>()),
+        );
+        elapsed.stop();
+
+        // Retrying an attempt that already spent the whole budget would
+        // multiply every caller's worst case by maxGetAttempts. Callers await
+        // this inline — the login pre-fetch blocks the post-auth redirect on
+        // it — so the budget has to bound the call, not each attempt.
+        expect(attempts, equals(1));
+        expect(elapsed.elapsed, lessThan(const Duration(milliseconds: 600)));
+      },
+    );
+
+    test('still retries fast failures that leave budget behind', () async {
+      var attempts = 0;
+      when(
+        () => httpClient.get(any(), headers: any(named: 'headers')),
+      ).thenAnswer((_) async {
+        attempts++;
+        if (attempts == 1) throw const SocketException('connection reset');
+        return http.Response(eventBody, 200);
+      });
+
+      final bounded = FunnelcakeApiClient(
+        baseUrl: baseUrl,
+        httpClient: httpClient,
+        timeout: const Duration(milliseconds: 200),
+        retryBaseDelay: Duration.zero,
+      );
+
+      // A reset socket costs almost nothing to detect, so bounding the total
+      // must not cost the retry that a flaky link actually needs.
+      expect(await bounded.getVideoEvent(eventId), isNotNull);
+      expect(attempts, equals(2));
+    });
   });
 }

--- a/mobile/packages/funnelcake_api_client/test/src/funnelcake_api_client_retry_test.dart
+++ b/mobile/packages/funnelcake_api_client/test/src/funnelcake_api_client_retry_test.dart
@@ -1,0 +1,127 @@
+// ABOUTME: Tests that idempotent Funnelcake GETs retry transient failures.
+// ABOUTME: Pins that definitive 4xx answers are never retried.
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:funnelcake_api_client/funnelcake_api_client.dart';
+import 'package:http/http.dart' as http;
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+
+class _MockHttpClient extends Mock implements http.Client {}
+
+class _FakeUri extends Fake implements Uri {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(_FakeUri());
+  });
+
+  group('FunnelcakeApiClient GET retry', () {
+    late _MockHttpClient httpClient;
+    late FunnelcakeApiClient client;
+
+    const baseUrl = 'https://api.example.com';
+    const eventId =
+        '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef';
+
+    const eventBody =
+        '{"event":{"id":"$eventId","pubkey":"$eventId","created_at":1,'
+        '"kind":34236,"tags":[],"content":"","sig":""}}';
+
+    setUp(() {
+      httpClient = _MockHttpClient();
+      client = FunnelcakeApiClient(
+        baseUrl: baseUrl,
+        httpClient: httpClient,
+        // Zero backoff keeps the suite fast; the retry policy itself is
+        // what these tests pin, not the wall-clock delay.
+        retryBaseDelay: Duration.zero,
+      );
+    });
+
+    test('retries a timed-out GET and returns the retried response', () async {
+      var attempts = 0;
+      when(
+        () => httpClient.get(any(), headers: any(named: 'headers')),
+      ).thenAnswer((_) async {
+        attempts++;
+        if (attempts == 1) {
+          throw TimeoutException('boom');
+        }
+        return http.Response(eventBody, 200);
+      });
+
+      final event = await client.getVideoEvent(eventId);
+
+      expect(event, isNotNull);
+      expect(attempts, equals(2));
+    });
+
+    test('retries a 503 and returns the retried response', () async {
+      var attempts = 0;
+      when(
+        () => httpClient.get(any(), headers: any(named: 'headers')),
+      ).thenAnswer((_) async {
+        attempts++;
+        if (attempts == 1) return http.Response('upstream down', 503);
+        return http.Response(eventBody, 200);
+      });
+
+      final event = await client.getVideoEvent(eventId);
+
+      expect(event, isNotNull);
+      expect(attempts, equals(2));
+    });
+
+    test('retries a dropped connection', () async {
+      var attempts = 0;
+      when(
+        () => httpClient.get(any(), headers: any(named: 'headers')),
+      ).thenAnswer((_) async {
+        attempts++;
+        if (attempts == 1) {
+          throw const SocketException('connection reset');
+        }
+        return http.Response(eventBody, 200);
+      });
+
+      final event = await client.getVideoEvent(eventId);
+
+      expect(event, isNotNull);
+      expect(attempts, equals(2));
+    });
+
+    test('does not retry a 404 — absence is a definitive answer', () async {
+      var attempts = 0;
+      when(
+        () => httpClient.get(any(), headers: any(named: 'headers')),
+      ).thenAnswer((_) async {
+        attempts++;
+        return http.Response('not found', 404);
+      });
+
+      final event = await client.getVideoEvent(eventId);
+
+      expect(event, isNull);
+      expect(attempts, equals(1));
+    });
+
+    test('gives up after the attempt budget and throws', () async {
+      var attempts = 0;
+      when(
+        () => httpClient.get(any(), headers: any(named: 'headers')),
+      ).thenAnswer((_) async {
+        attempts++;
+        throw TimeoutException('still down');
+      });
+
+      await expectLater(
+        client.getVideoEvent(eventId),
+        throwsA(isA<FunnelcakeTimeoutException>()),
+      );
+      expect(attempts, equals(FunnelcakeApiClient.maxGetAttempts));
+    });
+  });
+}

--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -2357,18 +2357,27 @@ class VideosRepository {
   ///    drops backend-leaked p-tagged collaborator events
   ///    (`v.pubkey != authorPubkey`); merges with [relaySeed] under the #3384
   ///    cross-source max policy; caches the initial page.
-  /// 3. When Funnelcake is unavailable (or throws [FunnelcakeException]),
-  ///    returns the [relaySeed] alone — the relay/realtime source is owned by
-  ///    the caller (the profile cubit, over `VideoEventService`); this package
-  ///    stays Flutter-free and does not query relays here.
+  /// 3. When Funnelcake is not configured, or throws [FunnelcakeException]
+  ///    while [relaySeed] is non-empty, returns the [relaySeed] alone — the
+  ///    relay/realtime source is owned by the caller (the profile cubit, over
+  ///    `VideoEventService`); this package stays Flutter-free and does not
+  ///    query relays here.
   ///
   /// [relaySeed] is the caller's current relay snapshot for the author, merged
   /// as the cross-source "primary" set. Pass `const []` for load-more pages
   /// (the caller accumulates new pages into its existing list via
   /// [mergeProfileFeedVideoLists]).
   ///
-  /// Returned videos are **unfiltered** (see [AuthorFeedResult]). Throws
-  /// non-[FunnelcakeException] errors to the caller.
+  /// Returned videos are **unfiltered** (see [AuthorFeedResult]).
+  ///
+  /// Throws:
+  ///
+  /// * [FunnelcakeException] when the API call fails and [relaySeed] is empty,
+  ///   so there is nothing to serve instead. An empty result here would be
+  ///   indistinguishable from an author who genuinely has no videos, and the
+  ///   profile would render "No videos yet" for a network failure. Load-more
+  ///   pages pass no seed, so they always surface the failure.
+  /// * any non-[FunnelcakeException] error, unchanged.
   Future<AuthorFeedResult> getAuthorFeed({
     required String authorPubkey,
     int? offset,

--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -2419,7 +2419,12 @@ class VideosRepository {
         }
         return result;
       } on FunnelcakeException {
-        // Fall through to the relay seed.
+        // The client already exhausted its retry budget, so this means the
+        // API was unreachable — not that the author has no videos. Serving an
+        // empty result here is indistinguishable from an empty account, and
+        // the profile renders "No videos yet" for a network failure. Fall
+        // through only when the relay seed can still show something.
+        if (relaySeed.isEmpty) rethrow;
       }
     }
 

--- a/mobile/packages/videos_repository/test/src/videos_repository_get_author_feed_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_get_author_feed_test.dart
@@ -390,5 +390,27 @@ void main() {
 
       expect(result.videos.map((v) => v.id).toList(), equals(['a']));
     });
+
+    test(
+      'rethrows on FunnelcakeException when there is no relay seed to serve',
+      () async {
+        when(
+          () => funnelcake.getVideosByAuthor(
+            pubkey: any(named: 'pubkey'),
+            limit: any(named: 'limit'),
+            offset: any(named: 'offset'),
+            before: any(named: 'before'),
+          ),
+        ).thenThrow(const FunnelcakeException('boom'));
+
+        // An empty result here would be indistinguishable from an author who
+        // genuinely has no videos, and the profile would claim the account is
+        // empty because the network was unreachable.
+        await expectLater(
+          repository.getAuthorFeed(authorPubkey: _author),
+          throwsA(isA<FunnelcakeException>()),
+        );
+      },
+    );
   });
 }

--- a/mobile/test/blocs/profile_feed/profile_feed_cubit_test.dart
+++ b/mobile/test/blocs/profile_feed/profile_feed_cubit_test.dart
@@ -256,33 +256,19 @@ void main() {
         expect(persisted!.videos.map((v) => v.id), ['v1']);
       });
 
-      test(
-        'does not overwrite a persisted snapshot with an empty one',
-        () async {
-          await seedSnapshot(
-            ProfileVideoOffsetSnapshot(
-              videos: [_video('v1', createdAt: 5000)],
-              nextOffset: 50,
-              totalVideoCount: 10,
-              hasMoreContent: true,
-            ),
-          );
-          when(
-            () => h.ves.authorVideos(any()),
-          ).thenReturn(const <VideoEvent>[]);
-          h.stubAuthorFeedThrows(const FunnelcakeException('offline'));
+      test('does not persist a cold open that has nothing to show', () async {
+        when(() => h.ves.authorVideos(any())).thenReturn(const <VideoEvent>[]);
+        h.stubAuthorFeedThrows(const FunnelcakeException('offline'));
 
-          final cubit = h.build();
-          addTearDown(cubit.close);
-          await pumpEventQueue();
+        final cubit = h.build();
+        addTearDown(cubit.close);
+        await pumpEventQueue();
 
-          // Losing the last good window to a failed load is worse than serving
-          // it stale.
-          final persisted = await readSnapshot();
-          expect(persisted, isNotNull);
-          expect(persisted!.videos.map((v) => v.id), ['v1']);
-        },
-      );
+        // Persisting an empty window would make the next cold start restore
+        // nothing and skip straight past the stale-while-revalidate path it
+        // exists for.
+        expect(await readSnapshot(), isNull);
+      });
     });
 
     group('CacheSync stale-while-revalidate', () {

--- a/mobile/test/blocs/profile_feed/profile_feed_cubit_test.dart
+++ b/mobile/test/blocs/profile_feed/profile_feed_cubit_test.dart
@@ -8,6 +8,7 @@ import 'package:cache_sync/cache_sync.dart';
 import 'package:content_blocklist_repository/content_blocklist_repository.dart';
 import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:funnelcake_api_client/funnelcake_api_client.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/profile_feed/profile_feed_cubit.dart';
@@ -234,6 +235,54 @@ void main() {
       await cubit.close();
 
       verify(() => h.ves.unsubscribeFromUserVideos(_author)).called(1);
+    });
+
+    group('CacheSync fills on bad networks', () {
+      test('persists the relay seed when the REST load fails', () async {
+        // A cache that only fills after a successful round-trip is empty for
+        // exactly the users who need it: every cold start on a bad connection
+        // re-fails and still persists nothing.
+        when(
+          () => h.ves.authorVideos(any()),
+        ).thenReturn([_video('v1', createdAt: 5000)]);
+        h.stubAuthorFeedThrows(const FunnelcakeException('offline'));
+
+        final cubit = h.build();
+        addTearDown(cubit.close);
+        await pumpEventQueue();
+
+        final persisted = await readSnapshot();
+        expect(persisted, isNotNull);
+        expect(persisted!.videos.map((v) => v.id), ['v1']);
+      });
+
+      test(
+        'does not overwrite a persisted snapshot with an empty one',
+        () async {
+          await seedSnapshot(
+            ProfileVideoOffsetSnapshot(
+              videos: [_video('v1', createdAt: 5000)],
+              nextOffset: 50,
+              totalVideoCount: 10,
+              hasMoreContent: true,
+            ),
+          );
+          when(
+            () => h.ves.authorVideos(any()),
+          ).thenReturn(const <VideoEvent>[]);
+          h.stubAuthorFeedThrows(const FunnelcakeException('offline'));
+
+          final cubit = h.build();
+          addTearDown(cubit.close);
+          await pumpEventQueue();
+
+          // Losing the last good window to a failed load is worse than serving
+          // it stale.
+          final persisted = await readSnapshot();
+          expect(persisted, isNotNull);
+          expect(persisted!.videos.map((v) => v.id), ['v1']);
+        },
+      );
     });
 
     group('CacheSync stale-while-revalidate', () {


### PR DESCRIPTION
## Description

Beta testers on slow, flaky connections reported three separate-looking bugs: their profile said "No videos yet" when they had 60+ published videos, tapping a notification showed "Video not found" for their own video, and a video published from drafts appeared to vanish.

All three are the same bug class. **The app treats "I couldn't reach the server" as "the content does not exist."**

Verified against production while investigating: every one of those items is served by `api.divine.video` right now. The "not found" video returns HTTP 200 in ~40ms warm. The API was fine; the client discarded the answer and then reported absence.

Three commits, each independently revertable:

### 1. `fix(funnelcake): retry idempotent GETs on transient failures`

Every Funnelcake read went out exactly once. A single dropped GET on a bad last mile was indistinguishable from an authoritative answer.

Retry is applied at the shared `_get` chokepoint, so all ~30 GET endpoints inherit it. Transient means the two shapes a bad connection produces: a thrown transport error (timeout, dropped socket) and a retryable status (429, 5xx). **A definitive answer — including 404 — still returns on the first attempt**, because absence is information and has to stay distinguishable from an unreachable server. Backoff uses full jitter so clients that lost the same access point do not retry in lockstep when it returns.

### 2. `fix(videos_repository): stop reporting an unreachable API as an empty author feed`

`getAuthorFeed` swallowed `FunnelcakeException` and returned a *successful* `AuthorFeedResult` with no videos. `ProfileFeedCubit` only reaches `ProfileFeedStatus.failure` when the call throws, so an unreachable API produced `status: ready` with zero videos, and the grid rendered "No videos yet."

Now that the client exhausts its own retry budget first, a `FunnelcakeException` here means the API was genuinely unreachable — so it is rethrown when there is no relay seed to fall back on. When a seed exists it is still served: showing something beats showing an error.

⚠️ **Contract change reviewers should look at:** `getAuthorFeed` previously never threw on an unreachable API. It now can. All four call sites are inside `ProfileFeedCubit` and all four sit within `on Object catch` blocks (the load-more path surfaces `hasLoadMoreError`), so the blast radius is contained — but this is not visible from the diff alone.

### 3. `fix(profile-feed): fill the offline snapshot before the network is consulted`

Every `_persistSnapshot()` call site sat downstream of a *successful* load. The cold-open branch of `_onStarted` and the `_loadFromRest` catch both wrote nothing.

That makes the persistent cache useless to the people it exists for: a user on a bad connection fails the load, persists nothing, and the next cold start finds an empty snapshot, falls through to REST, and fails again. The cache only ever filled for users whose network already worked.

Now the relay seed persists on cold open, and a failed refresh keeps the last shown window. Both guard the empty case at the call site rather than inside `_persistSnapshot` — deliberately, because a *successful* load returning zero videos still has to be able to clear the snapshot, or a fully-deleted profile would serve its old videos forever.

**Related Issue:** Relates to #7520

## Out of Scope

- **The notification misroute** (#7520) — `resolvePinnedApiBaseUrlFromRelays` is missing the `relay.divine.video → api.divine.video` mapping its sibling has, so notification polls bypass the CDN. Genuinely independent; filed separately rather than bundled here.
- **The video-detail path** — same shape as `getAuthorFeed`: eleven unlogged `return null` sites between an HTTP 200 and "Video not found", any of which demotes to the websocket. Not fixed here to keep this PR reviewable.
- **Failure copy** — `profileFeedError` still reads "Couldn't load videos." It should name the network and offer a retry. Left out because it is a product-voice change that deserves its own review.
- **Instrumentation** — `ProfileFeedCubit` and `getAuthorFeed` still have zero `Log.` calls, which is why the original beta report could not be diagnosed from the log export at all.
- **Event publish targeting the relay origin** — deliberate and documented (`video_providers.dart:265`): NIP-98 signs the exact URL, so moving it requires moving the signing target too.

## Verification

- `flutter test` — `funnelcake_api_client`: 424 tests + 5 new retry tests
- `flutter test --coverage` — `videos_repository`: 484 tests (per AGENTS.md requirement for this package)
- `flutter test test/blocs/profile_feed/` — 40 tests incl. 2 new snapshot tests
- `dart format` and `flutter analyze` clean on every touched path
- `bash mobile/scripts/check_post_close_emit_ceiling.sh` — passes (30 keys tracked, none grew)
- Rebased onto `origin/main` and all three commits verified present after the rebase

**Not verified:** no manual device testing on a genuinely degraded connection. The behaviour is pinned by unit tests that simulate timeouts and dropped sockets, not by a real flaky link. Worth a TestFlight pass with network conditioning before trusting it end to end.

**Also not established:** which of the eleven silent-null paths actually fired in the reported session. The beta log export contains no line from the profile-feed path at all, so the specific branch is inferred from code, not observed.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
