### PR TITLE
fix(video-detail): stop reporting an unreachable lookup as a missing video

### DIFF
--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -35,7 +35,7 @@
     "dmReactionRetryAction": "እንደገና ሞክር",
     "dmMessageBubbleVideoReplyHint": "የተጠቀሰውን ቪዲዮ ክፈት",
     "commonSomethingWentWrong": "የሆነ ችግር ተፈጥሯል",
-    "profileFeedError": "ቪዲዮዎችን መጫን አልተቻለም።",
+    "profileFeedError": "አገልጋዩ ጋር መድረስ አልተቻለም። ግንኙነትዎን አረጋግጠው እንደገና ይሞክሩ።",
     "profileFeedLoadMoreError": "ተጨማሪ ቪዲዮዎችን መጫን አልተቻለም። ለማደስ ወደታች ሳብ።",
     "appTitle": "Divine",
     "@appTitle": {

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -35,7 +35,7 @@
     "dmReactionRetryAction": "إعادة المحاولة",
     "dmMessageBubbleVideoReplyHint": "افتح الفيديو المُشار إليه",
     "commonSomethingWentWrong": "حدث خطأ ما",
-    "profileFeedError": "تعذّر تحميل الفيديوهات.",
+    "profileFeedError": "تعذّر الوصول إلى الخادم. تحقق من اتصالك وحاول مرة أخرى.",
     "profileFeedLoadMoreError": "تعذّر تحميل المزيد من الفيديوهات. اسحب للتحديث.",
     "appTitle": "Divine",
     "@appTitle": {

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -35,7 +35,7 @@
     "dmReactionRetryAction": "Опитай отново",
     "dmMessageBubbleVideoReplyHint": "Отваряне на посочения видеоклип",
     "commonSomethingWentWrong": "Нещо се обърка",
-    "profileFeedError": "Видеата не можаха да се заредят.",
+    "profileFeedError": "Сървърът е недостъпен. Провери връзката си и опитай отново.",
     "profileFeedLoadMoreError": "Още видеа не можаха да се заредят. Дръпни надолу за обновяване.",
     "appTitle": "Divine",
     "@appTitle": {

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -35,7 +35,7 @@
     "dmReactionRetryAction": "Erneut versuchen",
     "dmMessageBubbleVideoReplyHint": "Referenziertes Video öffnen",
     "commonSomethingWentWrong": "Etwas ist schiefgelaufen",
-    "profileFeedError": "Videos konnten nicht geladen werden.",
+    "profileFeedError": "Server nicht erreichbar. Prüf deine Verbindung und versuch es noch mal.",
     "profileFeedLoadMoreError": "Weitere Videos konnten nicht geladen werden. Zieh nach unten zum Aktualisieren.",
     "appTitle": "Divine",
     "@appTitle": {

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -2675,9 +2675,9 @@
       }
     }
   },
-  "profileFeedError": "Couldn't load videos.",
+  "profileFeedError": "Can't reach the server. Check your connection and try again.",
   "@profileFeedError": {
-    "description": "Full-screen message shown when an author's profile feed fails to load."
+    "description": "Full-screen message shown when an author's profile feed fails to load. This state is only reached when the API could not be reached at all — an author with genuinely no videos gets the empty state instead — so the copy names the connection rather than implying the profile is empty. Wording deliberately matches authSignInErrorNetwork."
   },
   "profileFeedLoadMoreError": "Couldn't load more videos. Pull to refresh.",
   "@profileFeedLoadMoreError": {

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -35,7 +35,7 @@
     "dmReactionRetryAction": "Reintentar",
     "dmMessageBubbleVideoReplyHint": "Abrir el vídeo referenciado",
     "commonSomethingWentWrong": "Algo salió mal",
-    "profileFeedError": "No se pudieron cargar los videos.",
+    "profileFeedError": "No se puede conectar con el servidor. Comprueba tu conexión e inténtalo de nuevo.",
     "profileFeedLoadMoreError": "No se pudieron cargar más videos. Desliza para actualizar.",
     "appTitle": "Divine",
     "@appTitle": {

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -35,7 +35,7 @@
     "dmReactionRetryAction": "Subukan muli",
     "dmMessageBubbleVideoReplyHint": "Buksan ang tinukoy na video",
     "commonSomethingWentWrong": "May nangyaring problema",
-    "profileFeedError": "Hindi na-load ang mga video.",
+    "profileFeedError": "Hindi maabot ang server. Tingnan ang iyong koneksyon at subukan ulit.",
     "profileFeedLoadMoreError": "Hindi na-load ang iba pang video. Hilahin pababa para mag-refresh.",
     "appTitle": "Divine",
     "settingsTitle": "Mga Setting",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -35,7 +35,7 @@
     "dmReactionRetryAction": "Réessayer",
     "dmMessageBubbleVideoReplyHint": "Ouvrir la vidéo référencée",
     "commonSomethingWentWrong": "Un problème est survenu",
-    "profileFeedError": "Impossible de charger les vidéos.",
+    "profileFeedError": "Impossible de joindre le serveur. Vérifie ta connexion et réessaie.",
     "profileFeedLoadMoreError": "Impossible de charger d'autres vidéos. Tire pour actualiser.",
     "appTitle": "Divine",
     "@appTitle": {

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -35,7 +35,7 @@
     "dmReactionRetryAction": "Coba lagi",
     "dmMessageBubbleVideoReplyHint": "Buka video yang dirujuk",
     "commonSomethingWentWrong": "Terjadi kesalahan",
-    "profileFeedError": "Video gagal dimuat.",
+    "profileFeedError": "Tidak dapat menjangkau server. Periksa koneksimu dan coba lagi.",
     "profileFeedLoadMoreError": "Video lainnya gagal dimuat. Tarik untuk menyegarkan.",
     "appTitle": "Divine",
     "@appTitle": {

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -35,7 +35,7 @@
     "dmReactionRetryAction": "Riprova",
     "dmMessageBubbleVideoReplyHint": "Apri il video di riferimento",
     "commonSomethingWentWrong": "Qualcosa è andato storto",
-    "profileFeedError": "Non è stato possibile caricare i video.",
+    "profileFeedError": "Impossibile raggiungere il server. Controlla la connessione e riprova.",
     "profileFeedLoadMoreError": "Non è stato possibile caricare altri video. Trascina per aggiornare.",
     "appTitle": "Divine",
     "@appTitle": {

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -35,7 +35,7 @@
     "dmReactionRetryAction": "再試行",
     "dmMessageBubbleVideoReplyHint": "参照先の動画を開く",
     "commonSomethingWentWrong": "問題が発生しました",
-    "profileFeedError": "動画を読み込めませんでした。",
+    "profileFeedError": "サーバーに接続できません。接続を確認してもう一度お試しください。",
     "profileFeedLoadMoreError": "これ以上の動画を読み込めませんでした。引っ張って更新してください。",
     "appTitle": "Divine",
     "@appTitle": {

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -35,7 +35,7 @@
     "dmReactionRetryAction": "다시 시도",
     "dmMessageBubbleVideoReplyHint": "참조된 동영상 열기",
     "commonSomethingWentWrong": "문제가 생겼어요",
-    "profileFeedError": "영상을 불러오지 못했어요.",
+    "profileFeedError": "서버에 연결할 수 없습니다. 연결을 확인하고 다시 시도해 주세요.",
     "profileFeedLoadMoreError": "영상을 더 불러오지 못했어요. 당겨서 새로고침하세요.",
     "appTitle": "Divine",
     "settingsTitle": "설정",

--- a/mobile/lib/l10n/app_ms.arb
+++ b/mobile/lib/l10n/app_ms.arb
@@ -2444,7 +2444,7 @@
       }
     }
   },
-  "profileFeedError": "Tidak dapat memuatkan video.",
+  "profileFeedError": "Tidak dapat mencapai pelayan. Semak sambungan anda dan cuba lagi.",
   "@profileFeedError": {
     "description": "Full-screen message shown when an author's profile feed fails to load."
   },

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -35,7 +35,7 @@
     "dmReactionRetryAction": "Opnieuw proberen",
     "dmMessageBubbleVideoReplyHint": "Verwezen video openen",
     "commonSomethingWentWrong": "Er ging iets mis",
-    "profileFeedError": "Video's konden niet worden geladen.",
+    "profileFeedError": "Kan de server niet bereiken. Controleer je verbinding en probeer het opnieuw.",
     "profileFeedLoadMoreError": "Meer video's konden niet worden geladen. Trek omlaag om te vernieuwen.",
     "appTitle": "Divine",
     "@appTitle": {

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -35,7 +35,7 @@
     "dmReactionRetryAction": "Spróbuj ponownie",
     "dmMessageBubbleVideoReplyHint": "Otwórz przywołane wideo",
     "commonSomethingWentWrong": "Coś poszło nie tak",
-    "profileFeedError": "Nie udało się wczytać filmów.",
+    "profileFeedError": "Nie można połączyć się z serwerem. Sprawdź połączenie i spróbuj ponownie.",
     "profileFeedLoadMoreError": "Nie udało się wczytać kolejnych filmów. Pociągnij, aby odświeżyć.",
     "appTitle": "Divine",
     "@appTitle": {

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -35,7 +35,7 @@
     "dmReactionRetryAction": "Tentar novamente",
     "dmMessageBubbleVideoReplyHint": "Abrir o vídeo referenciado",
     "commonSomethingWentWrong": "Algo deu errado",
-    "profileFeedError": "Não foi possível carregar os vídeos.",
+    "profileFeedError": "Não foi possível conectar ao servidor. Verifique sua conexão e tente de novo.",
     "profileFeedLoadMoreError": "Não foi possível carregar mais vídeos. Puxe para atualizar.",
     "appTitle": "Divine",
     "@appTitle": {

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -35,7 +35,7 @@
     "dmReactionRetryAction": "Reîncearcă",
     "dmMessageBubbleVideoReplyHint": "Deschide videoclipul referențiat",
     "commonSomethingWentWrong": "Ceva nu a mers bine",
-    "profileFeedError": "Nu am putut încărca videoclipurile.",
+    "profileFeedError": "Serverul nu poate fi contactat. Verifică-ți conexiunea și încearcă din nou.",
     "profileFeedLoadMoreError": "Nu am putut încărca mai multe videoclipuri. Trage în jos pentru reîmprospătare.",
     "appTitle": "Divine",
     "@appTitle": {

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -35,7 +35,7 @@
     "dmReactionRetryAction": "Försök igen",
     "dmMessageBubbleVideoReplyHint": "Öppna den refererade videon",
     "commonSomethingWentWrong": "Något gick fel",
-    "profileFeedError": "Kunde inte läsa in videor.",
+    "profileFeedError": "Kan inte nå servern. Kontrollera din anslutning och försök igen.",
     "profileFeedLoadMoreError": "Kunde inte läsa in fler videor. Dra för att uppdatera.",
     "appTitle": "Divine",
     "@appTitle": {

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -35,7 +35,7 @@
     "dmReactionRetryAction": "Yeniden dene",
     "dmMessageBubbleVideoReplyHint": "Atıfta bulunulan videoyu aç",
     "commonSomethingWentWrong": "Bir hata oluştu",
-    "profileFeedError": "Videolar yüklenemedi.",
+    "profileFeedError": "Sunucuya ulaşılamıyor. Bağlantını kontrol edip tekrar dene.",
     "profileFeedLoadMoreError": "Daha fazla video yüklenemedi. Yenilemek için aşağı çek.",
     "appTitle": "Divine",
     "@appTitle": {

--- a/mobile/lib/l10n/app_ur.arb
+++ b/mobile/lib/l10n/app_ur.arb
@@ -2444,7 +2444,7 @@
       }
     }
   },
-  "profileFeedError": "ویڈیوز لوڈ نہیں ہو سکیں۔",
+  "profileFeedError": "سرور تک رسائی نہیں ہو رہی۔ اپنا کنکشن چیک کر کے دوبارہ کوشش کریں۔",
   "@profileFeedError": {
     "description": "Full-screen message shown when an author's profile feed fails to load."
   },

--- a/mobile/lib/l10n/app_vi.arb
+++ b/mobile/lib/l10n/app_vi.arb
@@ -2444,7 +2444,7 @@
       }
     }
   },
-  "profileFeedError": "Không tải được video.",
+  "profileFeedError": "Không kết nối được với máy chủ. Kiểm tra kết nối của bạn rồi thử lại nhé.",
   "@profileFeedError": {
     "description": "Full-screen message shown when an author's profile feed fails to load."
   },

--- a/mobile/lib/l10n/app_zh.arb
+++ b/mobile/lib/l10n/app_zh.arb
@@ -2444,7 +2444,7 @@
       }
     }
   },
-  "profileFeedError": "视频加载失败。",
+  "profileFeedError": "连不上服务器。请检查网络连接后重试。",
   "@profileFeedError": {
     "description": "Full-screen message shown when an author's profile feed fails to load."
   },

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -7703,10 +7703,10 @@ abstract class AppLocalizations {
   /// **'Error: {error}'**
   String profileError(String error);
 
-  /// Full-screen message shown when an author's profile feed fails to load.
+  /// Full-screen message shown when an author's profile feed fails to load. This state is only reached when the API could not be reached at all — an author with genuinely no videos gets the empty state instead — so the copy names the connection rather than implying the profile is empty. Wording deliberately matches authSignInErrorNetwork.
   ///
   /// In en, this message translates to:
-  /// **'Couldn\'t load videos.'**
+  /// **'Can\'t reach the server. Check your connection and try again.'**
   String get profileFeedError;
 
   /// Transient message shown when paginating an author's profile feed fails.

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -4344,7 +4344,8 @@ class AppLocalizationsAm extends AppLocalizations {
   }
 
   @override
-  String get profileFeedError => 'ቪዲዮዎችን መጫን አልተቻለም።';
+  String get profileFeedError =>
+      'አገልጋዩ ጋር መድረስ አልተቻለም። ግንኙነትዎን አረጋግጠው እንደገና ይሞክሩ።';
 
   @override
   String get profileFeedLoadMoreError =>

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -4398,7 +4398,8 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
-  String get profileFeedError => 'تعذّر تحميل الفيديوهات.';
+  String get profileFeedError =>
+      'تعذّر الوصول إلى الخادم. تحقق من اتصالك وحاول مرة أخرى.';
 
   @override
   String get profileFeedLoadMoreError =>

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -4485,7 +4485,8 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
-  String get profileFeedError => 'Видеата не можаха да се заредят.';
+  String get profileFeedError =>
+      'Сървърът е недостъпен. Провери връзката си и опитай отново.';
 
   @override
   String get profileFeedLoadMoreError =>

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -4495,7 +4495,8 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get profileFeedError => 'Videos konnten nicht geladen werden.';
+  String get profileFeedError =>
+      'Server nicht erreichbar. Prüf deine Verbindung und versuch es noch mal.';
 
   @override
   String get profileFeedLoadMoreError =>

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -4435,7 +4435,8 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get profileFeedError => 'Couldn\'t load videos.';
+  String get profileFeedError =>
+      'Can\'t reach the server. Check your connection and try again.';
 
   @override
   String get profileFeedLoadMoreError =>

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -4486,7 +4486,8 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get profileFeedError => 'No se pudieron cargar los videos.';
+  String get profileFeedError =>
+      'No se puede conectar con el servidor. Comprueba tu conexión e inténtalo de nuevo.';
 
   @override
   String get profileFeedLoadMoreError =>

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -4504,7 +4504,8 @@ class AppLocalizationsFil extends AppLocalizations {
   }
 
   @override
-  String get profileFeedError => 'Hindi na-load ang mga video.';
+  String get profileFeedError =>
+      'Hindi maabot ang server. Tingnan ang iyong koneksyon at subukan ulit.';
 
   @override
   String get profileFeedLoadMoreError =>

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -4505,7 +4505,8 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get profileFeedError => 'Impossible de charger les vidéos.';
+  String get profileFeedError =>
+      'Impossible de joindre le serveur. Vérifie ta connexion et réessaie.';
 
   @override
   String get profileFeedLoadMoreError =>

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -4401,7 +4401,8 @@ class AppLocalizationsId extends AppLocalizations {
   }
 
   @override
-  String get profileFeedError => 'Video gagal dimuat.';
+  String get profileFeedError =>
+      'Tidak dapat menjangkau server. Periksa koneksimu dan coba lagi.';
 
   @override
   String get profileFeedLoadMoreError =>

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -4490,7 +4490,8 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String get profileFeedError => 'Non è stato possibile caricare i video.';
+  String get profileFeedError =>
+      'Impossibile raggiungere il server. Controlla la connessione e riprova.';
 
   @override
   String get profileFeedLoadMoreError =>

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -4209,7 +4209,7 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
-  String get profileFeedError => '動画を読み込めませんでした。';
+  String get profileFeedError => 'サーバーに接続できません。接続を確認してもう一度お試しください。';
 
   @override
   String get profileFeedLoadMoreError => 'これ以上の動画を読み込めませんでした。引っ張って更新してください。';

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -4228,7 +4228,7 @@ class AppLocalizationsKo extends AppLocalizations {
   }
 
   @override
-  String get profileFeedError => '영상을 불러오지 못했어요.';
+  String get profileFeedError => '서버에 연결할 수 없습니다. 연결을 확인하고 다시 시도해 주세요.';
 
   @override
   String get profileFeedLoadMoreError => '영상을 더 불러오지 못했어요. 당겨서 새로고침하세요.';

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -4471,7 +4471,8 @@ class AppLocalizationsMs extends AppLocalizations {
   }
 
   @override
-  String get profileFeedError => 'Tidak dapat memuatkan video.';
+  String get profileFeedError =>
+      'Tidak dapat mencapai pelayan. Semak sambungan anda dan cuba lagi.';
 
   @override
   String get profileFeedLoadMoreError =>

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -4457,7 +4457,8 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
-  String get profileFeedError => 'Video\'s konden niet worden geladen.';
+  String get profileFeedError =>
+      'Kan de server niet bereiken. Controleer je verbinding en probeer het opnieuw.';
 
   @override
   String get profileFeedLoadMoreError =>

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -4552,7 +4552,8 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
-  String get profileFeedError => 'Nie udało się wczytać filmów.';
+  String get profileFeedError =>
+      'Nie można połączyć się z serwerem. Sprawdź połączenie i spróbuj ponownie.';
 
   @override
   String get profileFeedLoadMoreError =>

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -4468,7 +4468,8 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String get profileFeedError => 'Não foi possível carregar os vídeos.';
+  String get profileFeedError =>
+      'Não foi possível conectar ao servidor. Verifique sua conexão e tente de novo.';
 
   @override
   String get profileFeedLoadMoreError =>

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -4562,7 +4562,8 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String get profileFeedError => 'Nu am putut încărca videoclipurile.';
+  String get profileFeedError =>
+      'Serverul nu poate fi contactat. Verifică-ți conexiunea și încearcă din nou.';
 
   @override
   String get profileFeedLoadMoreError =>

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -4435,7 +4435,8 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
-  String get profileFeedError => 'Kunde inte läsa in videor.';
+  String get profileFeedError =>
+      'Kan inte nå servern. Kontrollera din anslutning och försök igen.';
 
   @override
   String get profileFeedLoadMoreError =>

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -4407,7 +4407,8 @@ class AppLocalizationsTr extends AppLocalizations {
   }
 
   @override
-  String get profileFeedError => 'Videolar yüklenemedi.';
+  String get profileFeedError =>
+      'Sunucuya ulaşılamıyor. Bağlantını kontrol edip tekrar dene.';
 
   @override
   String get profileFeedLoadMoreError =>

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -4445,7 +4445,8 @@ class AppLocalizationsUr extends AppLocalizations {
   }
 
   @override
-  String get profileFeedError => 'ویڈیوز لوڈ نہیں ہو سکیں۔';
+  String get profileFeedError =>
+      'سرور تک رسائی نہیں ہو رہی۔ اپنا کنکشن چیک کر کے دوبارہ کوشش کریں۔';
 
   @override
   String get profileFeedLoadMoreError =>

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -4440,7 +4440,8 @@ class AppLocalizationsVi extends AppLocalizations {
   }
 
   @override
-  String get profileFeedError => 'Không tải được video.';
+  String get profileFeedError =>
+      'Không kết nối được với máy chủ. Kiểm tra kết nối của bạn rồi thử lại nhé.';
 
   @override
   String get profileFeedLoadMoreError =>

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -4203,7 +4203,7 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
-  String get profileFeedError => '视频加载失败。';
+  String get profileFeedError => '连不上服务器。请检查网络连接后重试。';
 
   @override
   String get profileFeedLoadMoreError => '无法加载更多视频。下拉刷新试试。';

--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -2625,6 +2625,15 @@ class VideosRepository {
   /// rather than restalling the spinner). The orchestrator deliberately does
   /// not wrap the helpers themselves — a successful relay result followed by
   /// slow stats enrichment must not be killed as if the relay had hung.
+  ///
+  /// Returns `null` only when a source positively answered that the video is
+  /// absent — callers may render "not found" on `null`.
+  ///
+  /// Throws:
+  ///
+  /// * [FunnelcakeException] when the API could not be reached and no relay
+  ///   answered either. Absence was never established, so callers must offer a
+  ///   retry rather than claim the video is missing.
   Future<VideoEvent?> fetchVideoWithStatsForRouteId(
     String routeId, {
     List<String> fallbackRouteIds = const [],

--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -2652,6 +2652,7 @@ class VideosRepository {
     final cached = await _fetchRouteVideoFromLocalCache(candidate);
     if (cached != null) return cached;
 
+    FunnelcakeException? apiFailure;
     final funnelcakeRouteId = candidate.stableId ?? candidate.eventId;
     if (funnelcakeRouteId != null) {
       try {
@@ -2669,6 +2670,7 @@ class VideosRepository {
           error: e,
           stackTrace: stackTrace,
         );
+        apiFailure = e;
       }
     }
 
@@ -2692,6 +2694,12 @@ class VideosRepository {
       );
       if (byStableId != null) return byStableId;
     }
+
+    // Nothing answered. When the API was unreachable we cannot claim the video
+    // is missing: null renders a permanent "could be gone, out of reach, or
+    // hidden by your settings" for a video the API serves fine once the
+    // connection recovers. A confirmed 404 still returns null below.
+    if (apiFailure != null) throw apiFailure;
 
     return null;
   }

--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -2626,28 +2626,40 @@ class VideosRepository {
   /// not wrap the helpers themselves — a successful relay result followed by
   /// slow stats enrichment must not be killed as if the relay had hung.
   ///
-  /// Returns `null` only when a source positively answered that the video is
-  /// absent — callers may render "not found" on `null`.
+  /// Returns `null` when every candidate came back empty without an error —
+  /// a confirmed absence, an unparseable route ID, or relay-only lookups that
+  /// returned nothing. Callers may render "not found" on `null`.
   ///
   /// Throws:
   ///
-  /// * [FunnelcakeException] when the API could not be reached and no relay
-  ///   answered either. Absence was never established, so callers must offer a
-  ///   retry rather than claim the video is missing.
+  /// * [FunnelcakeException] when a lookup could not reach the API and neither
+  ///   the relay fallbacks nor any [fallbackRouteIds] produced a video.
+  ///   Absence was never established, so callers must offer a retry rather
+  ///   than claim the video is missing.
   Future<VideoEvent?> fetchVideoWithStatsForRouteId(
     String routeId, {
     List<String> fallbackRouteIds = const [],
   }) async {
-    final primary = await _fetchVideoWithStatsForSingleRouteId(routeId);
-    if (primary != null) return primary;
+    FunnelcakeException? apiFailure;
+    final attempted = <String>{};
 
-    for (final fallbackRouteId in fallbackRouteIds) {
-      if (fallbackRouteId == routeId) continue;
-      final fallback = await _fetchVideoWithStatsForSingleRouteId(
-        fallbackRouteId,
-      );
-      if (fallback != null) return fallback;
+    for (final candidateRouteId in [routeId, ...fallbackRouteIds]) {
+      if (!attempted.add(candidateRouteId)) continue;
+      try {
+        final video = await _fetchVideoWithStatsForSingleRouteId(
+          candidateRouteId,
+        );
+        if (video != null) return video;
+      } on FunnelcakeException catch (e) {
+        // Keep going: a fallback route is a different query shape (an
+        // author-scoped addressable resolves against relays alone) and can
+        // still answer while the API is unreachable.
+        apiFailure ??= e;
+      }
     }
+
+    final failure = apiFailure;
+    if (failure != null) throw failure;
 
     return null;
   }

--- a/mobile/packages/videos_repository/test/src/videos_repository_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_test.dart
@@ -10552,6 +10552,93 @@ void main() {
         expect(result!.id, equals(fallbackEventId));
       });
 
+      test(
+        'still tries fallback route IDs when the primary lookup was '
+        'unreachable',
+        () async {
+          // The unreachable-lookup rethrow must not pre-empt the fallbacks.
+          // A DM-shared video passes the bare stable ID as the primary route
+          // and the author-scoped addressable as a fallback, which is a
+          // relay-only query that resolves fine while Funnelcake is down.
+          const fallbackEventId =
+              'e46ff7d0d71d6c8114b58728afa43f08'
+              'd6286fd9a704683af799fd8f855586c2';
+          const author =
+              '076c979382b90f5d3a2b21f95e1ee86b'
+              '6033f14c92e79b7fad3fe1f1073f4886';
+          const missingAddressableId = '34236:$author:missing-stable-id';
+          final fallbackEvent = _createVideoEvent(
+            id: fallbackEventId,
+            pubkey: author,
+            videoUrl: 'https://example.com/fallback.mp4',
+            createdAt: 1777868006,
+          );
+
+          when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+          when(
+            () => mockFunnelcakeClient.getVideoEvent(any()),
+          ).thenThrow(const FunnelcakeTimeoutException('https://example.com'));
+          when(() => mockNostrClient.queryEvents(any())).thenAnswer((
+            invocation,
+          ) async {
+            final filters =
+                invocation.positionalArguments.single as List<Filter>;
+            final filter = filters.single;
+            if (filter.ids?.contains(fallbackEventId) ?? false) {
+              return [fallbackEvent];
+            }
+            return <Event>[];
+          });
+
+          final repo = VideosRepository(
+            nostrClient: mockNostrClient,
+            funnelcakeApiClient: mockFunnelcakeClient,
+          );
+
+          final result = await repo.fetchVideoWithStatsForRouteId(
+            missingAddressableId,
+            fallbackRouteIds: const [fallbackEventId],
+          );
+
+          expect(result, isNotNull);
+          expect(result!.id, equals(fallbackEventId));
+        },
+      );
+
+      test(
+        'rethrows once every fallback route ID has also come up empty',
+        () async {
+          const fallbackEventId =
+              'e46ff7d0d71d6c8114b58728afa43f08'
+              'd6286fd9a704683af799fd8f855586c2';
+          const author =
+              '076c979382b90f5d3a2b21f95e1ee86b'
+              '6033f14c92e79b7fad3fe1f1073f4886';
+          const missingAddressableId = '34236:$author:missing-stable-id';
+
+          when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+          when(
+            () => mockFunnelcakeClient.getVideoEvent(any()),
+          ).thenThrow(const FunnelcakeTimeoutException('https://example.com'));
+          when(
+            () => mockNostrClient.queryEvents(any()),
+          ).thenAnswer((_) async => const <Event>[]);
+
+          final repo = VideosRepository(
+            nostrClient: mockNostrClient,
+            funnelcakeApiClient: mockFunnelcakeClient,
+          );
+
+          await expectLater(
+            repo.fetchVideoWithStatsForRouteId(
+              missingAddressableId,
+              fallbackRouteIds: const [fallbackEventId],
+            ),
+            throwsA(isA<FunnelcakeException>()),
+          );
+        },
+      );
+
       test('returns null without blocking when relay queries hang past the '
           'route timeout', () async {
         const stableId =

--- a/mobile/packages/videos_repository/test/src/videos_repository_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_test.dart
@@ -1211,16 +1211,19 @@ void main() {
             ),
           ).thenAnswer((invocation) async {
             final limit = invocation.namedArguments[#limit] as int;
-            return _recentPage([
-              for (var i = 0; i < limit; i++)
-                _createVideoStats(
-                  id: 'v$i',
-                  pubkey: 'p$i',
-                  dTag: 'd$i',
-                  videoUrl: 'https://example.com/v$i.mp4',
-                  createdAt: 1704060000 - i,
-                ),
-            ], hasMore: false);
+            return _recentPage(
+              [
+                for (var i = 0; i < limit; i++)
+                  _createVideoStats(
+                    id: 'v$i',
+                    pubkey: 'p$i',
+                    dTag: 'd$i',
+                    videoUrl: 'https://example.com/v$i.mp4',
+                    createdAt: 1704060000 - i,
+                  ),
+              ],
+              hasMore: false,
+            );
           });
 
           final page = await repoWithCache.getNewVideos(limit: 3);

--- a/mobile/packages/videos_repository/test/src/videos_repository_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_test.dart
@@ -1211,19 +1211,16 @@ void main() {
             ),
           ).thenAnswer((invocation) async {
             final limit = invocation.namedArguments[#limit] as int;
-            return _recentPage(
-              [
-                for (var i = 0; i < limit; i++)
-                  _createVideoStats(
-                    id: 'v$i',
-                    pubkey: 'p$i',
-                    dTag: 'd$i',
-                    videoUrl: 'https://example.com/v$i.mp4',
-                    createdAt: 1704060000 - i,
-                  ),
-              ],
-              hasMore: false,
-            );
+            return _recentPage([
+              for (var i = 0; i < limit; i++)
+                _createVideoStats(
+                  id: 'v$i',
+                  pubkey: 'p$i',
+                  dTag: 'd$i',
+                  videoUrl: 'https://example.com/v$i.mp4',
+                  createdAt: 1704060000 - i,
+                ),
+            ], hasMore: false);
           });
 
           final page = await repoWithCache.getNewVideos(limit: 3);
@@ -10085,6 +10082,63 @@ void main() {
         mockFunnelcakeClient = MockFunnelcakeApiClient();
         when(() => mockFunnelcakeClient.isAvailable).thenReturn(false);
       });
+
+      const unreachableRouteId =
+          'a695f6b60119d9521934a691347d9f78e8770b56da16bb255ee77ac112b4c1f6';
+      const absentRouteId =
+          'b695f6b60119d9521934a691347d9f78e8770b56da16bb255ee77ac112b4c1f6';
+
+      test(
+        'rethrows when Funnelcake was unreachable and no relay answered',
+        () async {
+          // Returning null here renders "Video not found - it could be gone,
+          // out of reach, or hidden by your settings" for a video that exists
+          // and that the API serves fine. A failed lookup must stay
+          // distinguishable from a confirmed absence.
+          when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+          when(
+            () => mockFunnelcakeClient.getVideoEvent(any()),
+          ).thenThrow(const FunnelcakeTimeoutException('https://example.com'));
+          when(
+            () => mockNostrClient.queryEvents(any()),
+          ).thenAnswer((_) async => const <Event>[]);
+
+          final repo = VideosRepository(
+            nostrClient: mockNostrClient,
+            funnelcakeApiClient: mockFunnelcakeClient,
+          );
+
+          await expectLater(
+            repo.fetchVideoWithStatsForRouteId(unreachableRouteId),
+            throwsA(isA<FunnelcakeException>()),
+          );
+        },
+      );
+
+      test(
+        'returns null when Funnelcake confirms absence and no relay answered',
+        () async {
+          // A 404 surfaces as null from getVideoEvent. That is a real answer,
+          // so "not found" is the honest result.
+          when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+          when(
+            () => mockFunnelcakeClient.getVideoEvent(any()),
+          ).thenAnswer((_) async => null);
+          when(
+            () => mockNostrClient.queryEvents(any()),
+          ).thenAnswer((_) async => const <Event>[]);
+
+          final repo = VideosRepository(
+            nostrClient: mockNostrClient,
+            funnelcakeApiClient: mockFunnelcakeClient,
+          );
+
+          expect(
+            await repo.fetchVideoWithStatsForRouteId(absentRouteId),
+            isNull,
+          );
+        },
+      );
 
       test('resolves note1 route IDs via event ID lookup', () async {
         const eventId =


### PR DESCRIPTION
## Description

Follow-up to #7521, on the second surface that reports a network failure as missing content.

A beta tester on a slow connection tapped a notification about **his own published video** and got:

> **Video not found**
> It could be gone, out of reach, or hidden by your settings.

The video exists. `api.divine.video` serves it in ~40ms. The lookup had timed out 4.06s earlier:

```
23:25:15.858  Loading video from route ref: 34236:076c979…:6ef2bc22…
23:25:19.913  ❌ Video not found: 34236:076c979…:6ef2bc22…
```

### 1. `fix(videos_repository): distinguish an unreachable lookup from a missing video`

`fetchVideoWithStatsForRouteId` returned bare `null` whether Funnelcake confirmed absence or was simply unreachable.

**The screen already models the difference.** `_VideoDetailError.loadFailed` renders `TvStaticMessageScreen` with its own copy — *"Something went sideways on the way here. Give it another try."* — and a working Retry button. It never appeared because nothing ever threw.

So this records the Funnelcake failure and rethrows it once every relay fallback has also come up empty. A confirmed 404 still returns `null`, so absence stays absence. The fix is a few lines; the plumbing was all there.

### 2. `fix(l10n): name the connection in the profile feed error`

`profileFeedError` read "Couldn't load videos." — a statement about the videos. That state is only reachable when the API could not be reached at all (an author with genuinely no videos gets the empty state instead), so the copy now names the connection.

The wording is lifted verbatim from `authSignInErrorNetwork` rather than invented, which also makes it translatable without a translator pass — see section 5.

### 3. `docs(videos_repository): document fetchVideoWithStatsForRouteId's throw`

`error_handling.md` requires a `Throws:` section on any public method that can throw. #7521 needed exactly this correction on `getAuthorFeed` after review, so it is fixed here before review rather than after.

---

## Review fixes (pushed by @hm21)

### 4. `fix(videos_repository): keep trying fallback route IDs after an unreachable lookup`

Section 1 put the rethrow in `_fetchVideoWithStatsForSingleRouteId`, which the public method calls once for the primary route and then once per entry in `fallbackRouteIds`. Throwing from the primary attempt propagated straight out of that loop, so **the fallbacks were never tried**.

That regressed all three callers that pass fallbacks. `DmVideoTarget.fallbackRouteIds` is the author-scoped addressable `<kind>:<pubkey>:<stableId>` — a NIP-33 relay query, not a Funnelcake one. It resolves fine while the API is unreachable, which is precisely the situation the rethrow was added for, so the original fix turned a recoverable lookup into a hard failure for DM-shared videos and deep links carrying fallback IDs.

The decision now lives in the public method: remember the first `FunnelcakeException`, keep walking the candidates, rethrow only once every one of them has come up empty. Attempted route IDs are tracked in a set, which subsumes the old `fallbackRouteId == routeId` skip and additionally drops duplicate fallbacks.

The doc comment is tightened at the same time. `null` is not returned "only when a source positively answered that the video is absent" — an unparseable route ID and a relay-only lookup that returns nothing both produce `null` with nothing having confirmed absence, and a caller relying on the stronger wording would be relying on a contract the method does not keep.

Two tests, both watched red before the fix:
- `still tries fallback route IDs when the primary lookup was unreachable`
- `rethrows once every fallback route ID has also come up empty`

### 5. `fix(l10n): translate the profile feed network error into every locale`

Section 2 changed the English value and left the 21 other locales on "Couldn't load videos." — the exact wording it had just judged misleading. Every non-English user would have kept seeing the old copy indefinitely.

No translator is needed. Because the new English string is lifted verbatim from `authSignInErrorNetwork`, and that key is already translated in all 21 locales, each locale's `profileFeedError` is now set to its own `authSignInErrorNetwork` value. Verified per locale that the two keys hold identical text and that every file still parses as JSON.

This removes the product caveat this PR previously carried.

### 6. `style(videos_repository): revert unrelated formatting churn in the test`

The `_recentPage` call in the `getNewVideos` test had been reflowed from its trailing-comma-split form to a collapsed one. Both forms are format-clean under the pinned formatter once the workspace package config is resolved, so the reflow was not a required fix — it is the signature of `dart format` running before `flutter pub get`, where the missing package config makes the formatter fall back to a language version that ignores trailing commas. Reverted, so the test diff is pure additions.

---

**Related Issue:** Relates to #7520
**Closes #none**

## Caller audit

The throw is a contract change, so every caller was checked:

| Caller | Passes fallbacks | Handling |
|---|---|---|
| `video_detail_screen.dart:204` | yes | bare `catch (e)` → `loadFailed` → retry screen — **this is the fix** |
| `video_reply_parent_provider.dart:12` | no | `FutureProvider` → surfaces as `AsyncError`, Riverpod-handled |
| `shared_video_save_cubit.dart:55` | yes | `catch (error)` |
| `video_link_preview_cubit.dart:74` | yes | `catch (e)` falls through to the same `VideoLinkPreviewNotFound` as its null path — behaviour-neutral, and now logs a warning it previously had no way to emit |

The three callers passing fallbacks are what section 4 restores.

## Out of Scope

- **A retry affordance on the profile failure state.** It is still a bare `Center(child: Text(...))` in both `profile_screen_router.dart:488` and `other_profile_screen.dart:480`. The copy is now honest, but the user's only recovery is to leave and come back. Adding a retry means a shared widget across both screens and deserves its own change.
- **The notification CDN misroute** (#7520) — independent, filed separately.
- **Instrumentation** — `ProfileFeedCubit` and `getAuthorFeed` still have zero `Log.` calls, which is why the original beta report could not be diagnosed from the log export.

## Verification

- `flutter test --coverage` — `videos_repository`: **487 tests, 100.00% line coverage** (per AGENTS.md requirement for this package)
- `flutter test test/l10n/arb_consistency_test.dart` — green after `flutter gen-l10n`; the only remaining untranslated key is the pre-existing `searchUserVideoCount` debt
- `flutter test` on the affected callers — `video_detail_screen`, `shared_video_save_cubit`, `video_link_preview_cubit`, `dm_video_target`: 41 tests green
- `dart format` + `flutter analyze lib test integration_test` clean
- Both rethrow tests and both fallback tests were watched **red before their fix** and green after, so they pin the changes rather than merely covering them

**Not verified:** no manual testing on a genuinely degraded connection — the behaviour is pinned by unit tests simulating a timeout, not by a real flaky link. No screenshot of the `loadFailed` screen in situ; it is existing UI that this change merely makes reachable, but nobody has seen it render from this path.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
