### PR TITLE
feat(settings): make light mode a user-selectable setting, not a feature flag

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -43,7 +43,7 @@ Generic Flutter and Dart standards live in `.claude/rules/`:
 
 ## UI And Product Constraints
 
-- Divine is dark-mode only.
+- Divine ships dark and light appearances, dark by default; users choose in Settings → General → Appearance. Adaptive surfaces read `context.vineColors.<token>`; static `VineTheme.*` colors are for brand and fixed media chrome only.
 - Use `VineTheme` and shared components from `mobile/packages/divine_ui` before adding one-off styling or raw `Colors.*`.
 - Prefer full-screen flows over introducing new dialogs or bottom sheets unless the task explicitly asks for one or the existing UX already uses that pattern.
 - For user-facing copy, follow `brand-guidelines/AGENT_QUICK_REFERENCE.md` and `brand-guidelines/TONE_OF_VOICE.md`.

--- a/.claude/hooks/pre-edit-vinetheme-guard.sh
+++ b/.claude/hooks/pre-edit-vinetheme-guard.sh
@@ -2,7 +2,8 @@
 # Hook: PreToolUse (Edit|Write)
 # Block edits that use raw Colors.* instead of VineTheme
 #
-# Enforces: Always use VineTheme color constants for dark-mode-only app
+# Enforces: Always use VineTheme / context.vineColors instead of raw Colors.*
+#           (Divine ships both a dark and a light appearance)
 # Allowed: Colors.transparent (universal constant)
 # Input: JSON with tool_input (old_string, new_string for Edit; content for Write)
 # Output: JSON with permissionDecision: "deny" if violation found

--- a/.claude/rules/accessibility.md
+++ b/.claude/rules/accessibility.md
@@ -256,7 +256,7 @@ For hero animations, video auto-play, and parallax effects — check `disableAni
 - **Large text (≥ 18pt or 14pt bold):** Minimum **3:1** contrast ratio
 - **Interactive elements:** Minimum **3:1** contrast ratio against adjacent colors
 
-Since Divine is dark-mode only, verify contrast against `VineTheme` dark backgrounds. Don't rely on Material defaults — custom overlays and gradients on video content need manual checking.
+Divine ships both appearances, so verify contrast against **both** `VineTheme.darkColors` and `VineTheme.lightColors`. A token pair can clear the bar in dark and fail in light — `vineGreenLight` was 15:1 on the dark container and 1.01:1 on the light one. Don't rely on Material defaults — custom overlays and gradients on video content need manual checking.
 
 ---
 

--- a/.claude/rules/ui_theming.md
+++ b/.claude/rules/ui_theming.md
@@ -183,6 +183,70 @@ ThemeData(
 
 ---
 
+## Appearance modes: which colors adapt
+
+Divine ships **two** appearances — `VineTheme.theme` (dark, the default) and
+`VineTheme.lightTheme`. Users choose System / Light / Dark in
+Settings → General → Appearance. There is no feature flag.
+
+Two color systems coexist, and picking the wrong one is the most common
+light-mode bug:
+
+| Use | For | Example |
+|---|---|---|
+| `context.vineColors.<token>` | Anything drawn on an **app surface** — page backgrounds, cards, sheets, list rows, body text, dividers, form fields | `context.vineColors.primaryText` |
+| `VineTheme.<const>` | **Brand** colors and **fixed media chrome** — anything whose ground is a video frame, a scrim, a gradient, or a saturated brand fill | `VineTheme.vineGreen`, `VineTheme.scrim50` |
+
+The test is **what is underneath**, not what the widget is. The same white
+text is correct over a video thumbnail and invisible on a warm off-white page.
+
+Fixed-by-design surfaces: fullscreen playback chrome, the camera and video
+editor canvas, scrims and gradients, ink on a filled brand button, and the
+database-failure screen (it runs before the appearance preference is
+readable).
+
+### Three traps
+
+1. **Equal dark values, different light values.** `iconButtonBackground`,
+   `surfaceContainer` and `skeletonBase` are all `#FF032017` in dark but map
+   to three different light colors. Choose the token by what the surface
+   *means*, never by matching the hex.
+2. **Name collisions that invert.** `VineTheme.primaryContainer` (pale mint)
+   is not `vineColors.primaryContainer` (dark green);
+   `VineTheme.onErrorContainer` (near-white) is not
+   `vineColors.onErrorContainer` (red). Never auto-map by name.
+3. **Alpha carriers and shadows are not colors.** A `whiteText` inside a
+   `ShaderMask` with `BlendMode.dstIn` is an alpha channel, and
+   `backgroundColor.withValues(alpha: 0.2)` used as a `BoxShadow` would
+   become a *white* shadow in light mode. Leave both static.
+
+### Verify dark did not change
+
+Any migration from a static constant to a token must leave dark mode
+pixel-identical. Prove it mechanically rather than by reading the diff:
+
+```bash
+cd mobile && dart run scripts/check_dark_value_parity.dart --base origin/main
+```
+
+It pairs each removed reference with its replacement per hunk and compares
+**dark** values. It cannot catch a wrong pick among tokens that share a dark
+value (trap 1) — that part still needs eyes, and a light-mode contrast check.
+
+### Adding a token
+
+If the semantically right token would change dark, do **not** accept the
+shift — add a token whose dark value is the constant you are replacing.
+`onIconButton` exists for exactly this: `vineGreenLight` is 15:1 on the dark
+container and 1.01:1 on the light one, so the token keeps the pale mint in
+dark and substitutes a darkened green in light. Every new token needs an
+entry in `VineThemeColors`' constructor, field, `copyWith`, `lerp`, `==`,
+`hashCode`, `darkColors`, and `lightColors` — plus the token maps in
+`packages/divine_ui/test/src/divine_ui_test.dart`, which fail the build if
+you miss one.
+
+---
+
 ## Icons
 
 ### Use DivineIcon

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,7 +115,7 @@ If a Divine Brain search or ask tool is available, you may use it for company me
 
 - Follow the existing `go_router` patterns in `mobile/lib/router/app_router.dart`.
 - Prefer full-screen flows over introducing new dialogs or bottom sheets unless the task explicitly calls for one or the existing UX already uses that pattern.
-- Divine is dark-mode only. Use `VineTheme` and existing components from `mobile/packages/divine_ui` instead of raw `Colors.*` values or one-off styling.
+- Divine ships dark and light appearances; dark is the default and users pick System / Light / Dark in Settings → General → Appearance. Never hardcode for one mode: read adaptive surfaces and content through `context.vineColors.<token>`, and reserve the static `VineTheme.*` color constants for brand colors and fixed media chrome (scrims, over-video controls, the camera and editor canvas). Use `VineTheme` and existing components from `mobile/packages/divine_ui` instead of raw `Colors.*` values or one-off styling.
 - Reuse shared components like `DivineButton`, `DivineIconButton`, `DivineAuthTextField`, and `VineBottomSheet` when they fit the job.
 - When changing user-facing copy, align with `brand-guidelines/AGENT_QUICK_REFERENCE.md` and `brand-guidelines/TONE_OF_VOICE.md`: direct, human, slightly playful, and never corporate.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Divine is a decentralized short-form video app that revives Vine's 6-second loop
 
 Most application code lives under `mobile/`. The Flutter entry points are `mobile/lib/main.dart` and `mobile/lib/router/app_router.dart` (routing uses `go_router`). App screens and feature wiring sit in `mobile/lib/`; the repo is a Melos workspace whose shared logic lives in packages under `mobile/packages/`.
 
-New feature work follows the layered flow `UI -> BLoC/Cubit -> Repository -> Client`. State management is mid-migration: `flutter_bloc` (BLoC/Cubit) is the target for new UI state, while `flutter_riverpod` remains as legacy compatibility glue. See `docs/STATE_MANAGEMENT.md` and `docs/BLOC_UI_MIGRATION_PRD.md`. Divine is dark-mode only; shared components and theme primitives come from `mobile/packages/divine_ui`.
+New feature work follows the layered flow `UI -> BLoC/Cubit -> Repository -> Client`. State management is mid-migration: `flutter_bloc` (BLoC/Cubit) is the target for new UI state, while `flutter_riverpod` remains as legacy compatibility glue. See `docs/STATE_MANAGEMENT.md` and `docs/BLOC_UI_MIGRATION_PRD.md`. Divine ships dark and light appearances (dark by default, user-selectable in Settings); shared components and theme primitives come from `mobile/packages/divine_ui`.
 
 The workspace is organized into around 75 packages, grouped roughly as:
 

--- a/docs/vgv-plugin-guide.md
+++ b/docs/vgv-plugin-guide.md
@@ -41,7 +41,7 @@ The plugin hooks complement our existing pre-commit hooks (format, analyze, code
 | `/vgv-testing` | VGV test naming, `pumpApp`, golden test patterns | 685+ tests with mocktail, bloc_test, Patrol |
 | `/vgv-navigation` | Type-safe GoRouter patterns, redirect strategies | GoRouter with `@TypedGoRoute` already in use |
 | `/vgv-layered-architecture` | Validates 4-layer package structure | 21 packages already follow Data → Repo → BLoC → UI |
-| `/vgv-material-theming` | Material 3 theming patterns and spacing system | Aligned with architecture — just note divine is **dark-mode only** |
+| `/vgv-material-theming` | Material 3 theming patterns and spacing system | Aligned with architecture — divine ships **both** appearances via `VineTheme.theme` / `VineTheme.lightTheme` |
 | `/vgv-create-project` | Scaffolds from VGV templates | Useful for new packages — adapt to existing monorepo workspace |
 
 ---
@@ -161,7 +161,7 @@ await Future.delayed(AppConstants.defaultRetryDelay);
 
 VGV's `material-theming` skill generates light + dark theme variants.
 
-**Divine is dark-mode only.** When the skill suggests `AppTheme.light` and `AppTheme.dark`, only use the dark variant. Reference `VineTheme` and `divine_ui` components before adding custom styling.
+**Divine ships dark and light appearances.** The equivalents are `VineTheme.theme` (dark, the default) and `VineTheme.lightTheme`; per-widget colors come from `context.vineColors`. Reference `VineTheme` and `divine_ui` components before adding custom styling.
 
 **Source:** `.claude/rules/ui_theming.md`
 
@@ -236,7 +236,7 @@ When adding a new domain to the data layer:
 | Accept VGV `errorMessage` in BLoC state | Violates state_management rules | Use `addError()` + status enum |
 | Use `extra:` in GoRouter | Breaks deep linking and web support | Pass resource IDs via path parameters |
 | Let VGV generate Riverpod providers | Riverpod is legacy-only | Insist on BLoC/Cubit for all new code |
-| Accept light theme from material-theming | Divine is dark-mode only | Only use dark theme variant |
+| Accept light theme from material-theming | Divine has its own light palette | Use `VineTheme.lightTheme` / `context.vineColors`, not a generated one |
 | Use `Widget _buildX()` methods | Violates code_style rules | Extract to separate widget classes |
 | Accept hardcoded URLs or magic numbers | Violates code_style constants rule | Extract to `Constants`/`Config` class |
 | Run `/vgv-create-project` without updating workspace | New package won't be found | Add to `pubspec.yaml` workspace section |

--- a/mobile/lib/features/appearance/bloc/appearance_cubit.dart
+++ b/mobile/lib/features/appearance/bloc/appearance_cubit.dart
@@ -36,15 +36,10 @@ class AppearanceCubit extends Cubit<AppearanceMode> {
   }
 }
 
-ThemeMode resolveThemeMode({
-  required AppearanceMode mode,
-  required bool lightModeEnabled,
-}) {
-  if (!lightModeEnabled) return ThemeMode.dark;
-
-  return switch (mode) {
-    AppearanceMode.system => ThemeMode.system,
-    AppearanceMode.light => ThemeMode.light,
-    AppearanceMode.dark => ThemeMode.dark,
-  };
-}
+/// Maps the user's [AppearanceMode] choice onto the [ThemeMode] the root
+/// `MaterialApp` consumes.
+ThemeMode resolveThemeMode({required AppearanceMode mode}) => switch (mode) {
+  AppearanceMode.system => ThemeMode.system,
+  AppearanceMode.light => ThemeMode.light,
+  AppearanceMode.dark => ThemeMode.dark,
+};

--- a/mobile/lib/features/feature_flags/models/feature_flag.dart
+++ b/mobile/lib/features/feature_flags/models/feature_flag.dart
@@ -57,16 +57,6 @@ enum FeatureFlag {
     'Profile Monetization Links',
     'Enable outbound tip and subscription links on profiles.',
   ),
-  lightMode(
-    'Light Mode',
-    'Enable the experimental System, Light, and Dark appearance settings. '
-        'Accent pills and category tiles still render dark on a light page.',
-  ),
-  adaptiveMediaChrome(
-    'Adaptive Media Chrome',
-    'Use light controls around fullscreen video when Light Mode is enabled.',
-    audience: FeatureFlagAudience.internal,
-  ),
   communityContentWarnings(
     'Community Content Warnings',
     'Suggest content-warning labels on videos and blur videos whose labels '

--- a/mobile/lib/features/feature_flags/services/build_configuration.dart
+++ b/mobile/lib/features/feature_flags/services/build_configuration.dart
@@ -42,10 +42,6 @@ class BuildConfiguration {
         return const bool.fromEnvironment('FF_FEED_TUNING');
       case FeatureFlag.profileMonetizationLinks:
         return const bool.fromEnvironment('FF_PROFILE_MONETIZATION_LINKS');
-      case FeatureFlag.lightMode:
-        return const bool.fromEnvironment('FF_LIGHT_MODE');
-      case FeatureFlag.adaptiveMediaChrome:
-        return const bool.fromEnvironment('FF_ADAPTIVE_MEDIA_CHROME');
       case FeatureFlag.communityContentWarnings:
         // Default OFF pending T&S sign-off on surfacing warnings from
         // unverified community votes (#4771).
@@ -100,10 +96,6 @@ class BuildConfiguration {
         return 'FF_FEED_TUNING';
       case FeatureFlag.profileMonetizationLinks:
         return 'FF_PROFILE_MONETIZATION_LINKS';
-      case FeatureFlag.lightMode:
-        return 'FF_LIGHT_MODE';
-      case FeatureFlag.adaptiveMediaChrome:
-        return 'FF_ADAPTIVE_MEDIA_CHROME';
       case FeatureFlag.communityContentWarnings:
         return 'FF_COMMUNITY_CONTENT_WARNINGS';
       case FeatureFlag.divineSupporters:

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -47,8 +47,6 @@ import 'package:openvine/features/app_review/app_review_coordinator.dart';
 import 'package:openvine/features/appearance/bloc/appearance_cubit.dart';
 import 'package:openvine/features/appearance/models/appearance_mode.dart';
 import 'package:openvine/features/appearance/providers/appearance_providers.dart';
-import 'package:openvine/features/feature_flags/models/feature_flag.dart';
-import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
 import 'package:openvine/features/people_lists/curated_lists_gate.dart';
 import 'package:openvine/features/people_lists/people_lists.dart';
 import 'package:openvine/features/post_publish/post_publish_experiment.dart';
@@ -2740,13 +2738,7 @@ class _DivineAppState extends ConsumerState<DivineApp>
       if (locale != null) {
         Intl.defaultLocale = locale.toLanguageTag();
       }
-      final lightModeEnabled = ref.watch(
-        isFeatureEnabledProvider(FeatureFlag.lightMode),
-      );
-      final themeMode = resolveThemeMode(
-        mode: appearanceMode,
-        lightModeEnabled: lightModeEnabled,
-      );
+      final themeMode = resolveThemeMode(mode: appearanceMode);
       final effectiveBrightness = themeMode == ThemeMode.system
           ? WidgetsBinding.instance.platformDispatcher.platformBrightness
           : themeMode == ThemeMode.light

--- a/mobile/lib/notifications/widgets/notification_leading_type_icon.dart
+++ b/mobile/lib/notifications/widgets/notification_leading_type_icon.dart
@@ -3,6 +3,7 @@
 // ABOUTME: notificationTypeIconSpec and renders NotificationTypeIcon with
 // ABOUTME: the unread red dot driven by isRead.
 
+import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/widgets.dart';
 import 'package:models/models.dart';
 import 'package:openvine/notifications/widgets/notification_type_icon_spec.dart';
@@ -38,6 +39,7 @@ class NotificationLeadingTypeIcon extends StatelessWidget {
   Widget build(BuildContext context) {
     final spec = notificationTypeIconSpec(
       type,
+      colors: context.vineColors,
       isVideoSourcedMention: isVideoSourcedMention,
     );
     return NotificationTypeIcon(

--- a/mobile/lib/notifications/widgets/notification_type_icon_spec.dart
+++ b/mobile/lib/notifications/widgets/notification_type_icon_spec.dart
@@ -24,50 +24,54 @@ class NotificationTypeIconSpec {
 }
 
 /// Returns the spec for [type] used by both row widgets.
+///
+/// [colors] is the resolved palette of the active appearance mode, so the
+/// accent chips follow light mode instead of staying on the dark tints.
 NotificationTypeIconSpec notificationTypeIconSpec(
   NotificationKind type, {
+  required VineThemeColors colors,
   bool isVideoSourcedMention = false,
 }) {
   if (type == NotificationKind.mention && isVideoSourcedMention) {
-    return const NotificationTypeIconSpec(
+    return NotificationTypeIconSpec(
       icon: DivineIconName.videoCamera,
-      background: VineTheme.accentVioletBackground,
-      foreground: VineTheme.accentViolet,
+      background: colors.accentChipViolet.container,
+      foreground: colors.accentChipViolet.onContainer,
     );
   }
   return switch (type) {
     NotificationKind.like ||
-    NotificationKind.likeComment => const NotificationTypeIconSpec(
+    NotificationKind.likeComment => NotificationTypeIconSpec(
       icon: DivineIconName.heart,
-      background: VineTheme.accentPinkBackground,
-      foreground: VineTheme.accentPink,
+      background: colors.accentChipPink.container,
+      foreground: colors.accentChipPink.onContainer,
     ),
-    NotificationKind.follow => const NotificationTypeIconSpec(
+    NotificationKind.follow => NotificationTypeIconSpec(
       icon: DivineIconName.user,
-      background: VineTheme.accentLimeBackground,
-      foreground: VineTheme.accentLime,
+      background: colors.accentChipLime.container,
+      foreground: colors.accentChipLime.onContainer,
     ),
     NotificationKind.comment ||
     NotificationKind.reply ||
-    NotificationKind.mention => const NotificationTypeIconSpec(
+    NotificationKind.mention => NotificationTypeIconSpec(
       icon: DivineIconName.chat,
-      background: VineTheme.accentVioletBackground,
-      foreground: VineTheme.accentViolet,
+      background: colors.accentChipViolet.container,
+      foreground: colors.accentChipViolet.onContainer,
     ),
-    NotificationKind.repost => const NotificationTypeIconSpec(
+    NotificationKind.repost => NotificationTypeIconSpec(
       icon: DivineIconName.repeat,
-      background: VineTheme.accentYellowBackground,
-      foreground: VineTheme.accentYellow,
+      background: colors.accentChipYellow.container,
+      foreground: colors.accentChipYellow.onContainer,
     ),
-    NotificationKind.newPost => const NotificationTypeIconSpec(
+    NotificationKind.newPost => NotificationTypeIconSpec(
       icon: DivineIconName.bellSimple,
-      background: VineTheme.accentBlueBackground,
-      foreground: VineTheme.accentBlue,
+      background: colors.accentChipBlue.container,
+      foreground: colors.accentChipBlue.onContainer,
     ),
-    NotificationKind.listAdd => const NotificationTypeIconSpec(
+    NotificationKind.listAdd => NotificationTypeIconSpec(
       icon: DivineIconName.listPlus,
-      background: VineTheme.accentYellowBackground,
-      foreground: VineTheme.accentYellow,
+      background: colors.accentChipYellow.container,
+      foreground: colors.accentChipYellow.onContainer,
     ),
     NotificationKind.system => const NotificationTypeIconSpec(
       icon: DivineIconName.logo,

--- a/mobile/lib/notifications/widgets/notification_type_icon_spec.dart
+++ b/mobile/lib/notifications/widgets/notification_type_icon_spec.dart
@@ -73,10 +73,10 @@ NotificationTypeIconSpec notificationTypeIconSpec(
       background: colors.accentChipYellow.container,
       foreground: colors.accentChipYellow.onContainer,
     ),
-    NotificationKind.system => const NotificationTypeIconSpec(
+    NotificationKind.system => NotificationTypeIconSpec(
       icon: DivineIconName.logo,
-      background: VineTheme.onPrimaryButton,
-      foreground: VineTheme.primary,
+      background: colors.accentChipGreen.container,
+      foreground: colors.accentChipGreen.onContainer,
     ),
   };
 }

--- a/mobile/lib/screens/auth/email_verification_screen.dart
+++ b/mobile/lib/screens/auth/email_verification_screen.dart
@@ -631,9 +631,9 @@ class _CloseButton extends StatelessWidget {
             color: context.vineColors.surfaceContainer,
             shape: BoxShape.circle,
           ),
-          child: const DivineIcon(
+          child: DivineIcon(
             icon: DivineIconName.x,
-            color: VineTheme.vineGreenLight,
+            color: context.vineColors.onIconButton,
             size: 20,
           ),
         ),

--- a/mobile/lib/screens/auth/invite_gate_screen.dart
+++ b/mobile/lib/screens/auth/invite_gate_screen.dart
@@ -261,9 +261,9 @@ class _InviteCodeEntryPage extends StatelessWidget {
                                 alignment: AlignmentDirectional.centerStart,
                                 child: RoundedIconButton(
                                   onPressed: onBack,
-                                  icon: const DivineIcon(
+                                  icon: DivineIcon(
                                     icon: DivineIconName.caretLeft,
-                                    color: VineTheme.vineGreenLight,
+                                    color: context.vineColors.onIconButton,
                                     size: 28,
                                   ),
                                 ),

--- a/mobile/lib/screens/auth/login_options_screen.dart
+++ b/mobile/lib/screens/auth/login_options_screen.dart
@@ -357,9 +357,9 @@ class _SignInContentState extends ConsumerState<_SignInContent> {
                               context,
                               showNip07: isNip07Available,
                             ),
-                      icon: const DivineIcon(
+                      icon: DivineIcon(
                         icon: DivineIconName.info,
-                        color: VineTheme.vineGreenLight,
+                        color: context.vineColors.onIconButton,
                       ),
                     ),
                   ],

--- a/mobile/lib/screens/auth/welcome_screen.dart
+++ b/mobile/lib/screens/auth/welcome_screen.dart
@@ -424,28 +424,29 @@ class _CrossAccountRecoveryBannerState
   @override
   Widget build(BuildContext context) {
     final message = _message(context);
+    final chip = context.vineColors.accentChipYellow;
     return Padding(
       padding: const EdgeInsets.only(top: 12),
       child: Container(
         padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
         decoration: BoxDecoration(
-          color: VineTheme.accentYellowBackground,
+          color: chip.container,
           borderRadius: BorderRadius.circular(8),
         ),
         child: Row(
           spacing: 8,
           children: [
-            const ExcludeSemantics(
+            ExcludeSemantics(
               child: DivineIcon(
                 icon: DivineIconName.warningCircle,
                 size: 16,
-                color: VineTheme.accentYellow,
+                color: chip.onContainer,
               ),
             ),
             Expanded(
               child: Text(
                 message,
-                style: VineTheme.bodySmallFont(color: VineTheme.accentYellow),
+                style: VineTheme.bodySmallFont(color: chip.onContainer),
               ),
             ),
           ],

--- a/mobile/lib/screens/badges/widgets/badge_status_pill.dart
+++ b/mobile/lib/screens/badges/widgets/badge_status_pill.dart
@@ -23,14 +23,15 @@ class BadgeStatusPill extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final pending = context.vineColors.accentChipYellow;
     return DecoratedBox(
       decoration: BoxDecoration(
         color: accepted
             ? VineTheme.vineGreen.withValues(alpha: 0.14)
-            : VineTheme.accentYellowBackground,
+            : pending.container,
         borderRadius: BorderRadius.circular(999),
         border: Border.all(
-          color: accepted ? VineTheme.vineGreen : VineTheme.accentYellow,
+          color: accepted ? VineTheme.vineGreen : pending.onContainer,
         ),
       ),
       child: Padding(
@@ -38,7 +39,7 @@ class BadgeStatusPill extends StatelessWidget {
         child: Text(
           label,
           style: VineTheme.labelSmallFont(
-            color: accepted ? VineTheme.vineGreen : VineTheme.accentYellow,
+            color: accepted ? VineTheme.vineGreen : pending.onContainer,
           ),
         ),
       ),

--- a/mobile/lib/screens/inbox/conversation/widgets/message_bubble.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/message_bubble.dart
@@ -450,11 +450,12 @@ class _MessageTextState extends ConsumerState<_MessageText> {
       decoration: TextDecoration.underline,
       decorationColor: linkColor,
     );
-    // Translucent white overlay reads on both bubble colors without
-    // needing a per-side palette swap.
-    final codeBackground = VineTheme.whiteText.withValues(
-      alpha: widget.isSent ? 0.18 : 0.10,
-    );
+    // The sent bubble keeps the fixed green, so a translucent white wash
+    // reads there; the received bubble follows the palette and takes an
+    // on-surface wash so the code chip stays visible in both modes.
+    final codeBackground = widget.isSent
+        ? VineTheme.whiteText.withValues(alpha: 0.18)
+        : context.vineColors.onSurface.withValues(alpha: 0.10);
     final codeStyle = VineTheme.codeFont(color: defaultStyle.color);
 
     final ast = const InlineMarkdownParser().parse(widget.message);

--- a/mobile/lib/screens/settings/general_settings_screen.dart
+++ b/mobile/lib/screens/settings/general_settings_screen.dart
@@ -38,9 +38,6 @@ class GeneralSettingsScreen extends ConsumerWidget {
     final showBluesky = ref.watch(
       isFeatureEnabledProvider(FeatureFlag.blueskyPublishing),
     );
-    final showAppearance = ref.watch(
-      isFeatureEnabledProvider(FeatureFlag.lightMode),
-    );
     final showCrossposting = ref.watch(crosspostingEligibleProvider);
     // Only a Divine-login account has an email and password to change; every
     // other identity signs with a key and has no credentials on file.
@@ -113,26 +110,25 @@ class GeneralSettingsScreen extends ConsumerWidget {
               const _LongPressRecordingToggle(),
               DivineSectionHeader(context.l10n.generalSettingsSectionApp),
               const _AppLanguageTile(),
-              if (showAppearance)
-                ListTile(
-                  leading: const DivineIcon(
-                    icon: DivineIconName.sun,
-                    color: VineTheme.vineGreen,
-                  ),
-                  title: Text(
-                    context.l10n.appearanceSettingsTitle,
-                    style: _titleStyleOf(context),
-                  ),
-                  subtitle: Text(
-                    context.l10n.appearanceSettingsSubtitle,
-                    style: _subtitleStyleOf(context),
-                  ),
-                  trailing: DivineIcon(
-                    icon: DivineIconName.caretRight,
-                    color: context.vineColors.mutedText,
-                  ),
-                  onTap: () => context.push(AppearanceSettingsScreen.path),
+              ListTile(
+                leading: const DivineIcon(
+                  icon: DivineIconName.sun,
+                  color: VineTheme.vineGreen,
                 ),
+                title: Text(
+                  context.l10n.appearanceSettingsTitle,
+                  style: _titleStyleOf(context),
+                ),
+                subtitle: Text(
+                  context.l10n.appearanceSettingsSubtitle,
+                  style: _subtitleStyleOf(context),
+                ),
+                trailing: DivineIcon(
+                  icon: DivineIconName.caretRight,
+                  color: context.vineColors.mutedText,
+                ),
+                onTap: () => context.push(AppearanceSettingsScreen.path),
+              ),
               ListTile(
                 leading: const DivineIcon(
                   icon: DivineIconName.stackSimple,

--- a/mobile/lib/screens/sound_detail_screen.dart
+++ b/mobile/lib/screens/sound_detail_screen.dart
@@ -634,7 +634,7 @@ class _SoundHeaderState extends ConsumerState<_SoundHeader> {
                         style: VineTheme.labelSmallFont(
                           color: reuseAllowed
                               ? VineTheme.vineGreen
-                              : VineTheme.onSurfaceVariant,
+                              : context.vineColors.onSurfaceVariant,
                         ),
                       ),
                     if (sound.publicTags.isNotEmpty)
@@ -646,7 +646,7 @@ class _SoundHeaderState extends ConsumerState<_SoundHeader> {
                             Text(
                               '#$tag',
                               style: VineTheme.labelSmallFont(
-                                color: VineTheme.onSurfaceVariant,
+                                color: context.vineColors.onSurfaceVariant,
                               ),
                             ),
                         ],

--- a/mobile/lib/screens/user_list_people_screen.dart
+++ b/mobile/lib/screens/user_list_people_screen.dart
@@ -543,7 +543,7 @@ class _UserListPeopleViewState extends ConsumerState<_UserListPeopleView>
                           ),
                           child: const Icon(
                             Icons.grid_view,
-                            color: VineTheme.primaryText,
+                            color: VineTheme.whiteText,
                             size: 20,
                           ),
                         ),
@@ -563,8 +563,8 @@ class _UserListPeopleViewState extends ConsumerState<_UserListPeopleView>
                           children: [
                             Text(
                               userList.name,
-                              style: TextStyle(
-                                color: context.vineColors.primaryText,
+                              style: const TextStyle(
+                                color: VineTheme.whiteText,
                                 fontSize: 16,
                                 fontWeight: FontWeight.bold,
                               ),
@@ -574,8 +574,8 @@ class _UserListPeopleViewState extends ConsumerState<_UserListPeopleView>
                             if (userList.description != null)
                               Text(
                                 userList.description!,
-                                style: TextStyle(
-                                  color: context.vineColors.secondaryText,
+                                style: const TextStyle(
+                                  color: VineTheme.secondaryText,
                                   fontSize: 12,
                                 ),
                                 maxLines: 1,
@@ -597,7 +597,7 @@ class _UserListPeopleViewState extends ConsumerState<_UserListPeopleView>
                         child: Text(
                           '${_activeVideoIndex! + 1}/${videos.length}',
                           style: const TextStyle(
-                            color: VineTheme.primaryText,
+                            color: VineTheme.whiteText,
                             fontSize: 12,
                             fontWeight: FontWeight.w500,
                           ),

--- a/mobile/lib/widgets/auth_back_button.dart
+++ b/mobile/lib/widgets/auth_back_button.dart
@@ -38,9 +38,9 @@ class AuthBackButton extends StatelessWidget {
   Widget build(BuildContext context) {
     return RoundedIconButton(
       onPressed: !enabled ? null : onPressed ?? () => _handleBackTap(context),
-      icon: const DivineIcon(
+      icon: DivineIcon(
         icon: DivineIconName.caretLeft,
-        color: VineTheme.vineGreenLight,
+        color: context.vineColors.onIconButton,
       ),
     );
   }

--- a/mobile/lib/widgets/bug_report_dialog.dart
+++ b/mobile/lib/widgets/bug_report_dialog.dart
@@ -191,7 +191,7 @@ class _BugReportView extends StatelessWidget {
               ),
             ),
           ),
-          const Divider(height: 2, color: VineTheme.outlineDisabled),
+          Divider(height: 2, color: context.vineColors.outlineDisabled),
           SafeArea(
             top: false,
             child: BugReportActions(

--- a/mobile/lib/widgets/feature_request_dialog.dart
+++ b/mobile/lib/widgets/feature_request_dialog.dart
@@ -160,7 +160,7 @@ class _FeatureRequestView extends StatelessWidget {
               ),
             ),
           ),
-          const Divider(height: 2, color: VineTheme.outlineDisabled),
+          Divider(height: 2, color: context.vineColors.outlineDisabled),
           SafeArea(
             top: false,
             child: FeatureRequestActions(

--- a/mobile/lib/widgets/feed_tuning/feed_tuning_swipe_overlay.dart
+++ b/mobile/lib/widgets/feed_tuning/feed_tuning_swipe_overlay.dart
@@ -320,7 +320,9 @@ class _TuningIndicator extends StatelessWidget {
             scale: 0.8 + 0.2 * progress,
             child: DecoratedBox(
               decoration: BoxDecoration(
-                color: VineTheme.surfaceContainerHigh.withValues(alpha: 0.9),
+                color: context.vineColors.surfaceContainerHigh.withValues(
+                  alpha: 0.9,
+                ),
                 borderRadius: BorderRadius.circular(999),
                 border: Border.all(color: color, width: 2),
               ),

--- a/mobile/lib/widgets/library/saved_sound_card.dart
+++ b/mobile/lib/widgets/library/saved_sound_card.dart
@@ -69,7 +69,7 @@ class SavedSoundCard extends StatelessWidget {
       container: true,
       child: DecoratedBox(
         decoration: BoxDecoration(
-          color: VineTheme.cardBackground,
+          color: context.vineColors.card,
           borderRadius: BorderRadius.circular(16),
         ),
         child: Material(
@@ -180,15 +180,15 @@ class _SavedSoundThumbnailFallback extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const SizedBox.square(
-      key: Key('saved_sound_thumbnail_fallback'),
+    return SizedBox.square(
+      key: const Key('saved_sound_thumbnail_fallback'),
       dimension: _thumbnailSize,
       child: ColoredBox(
-        color: VineTheme.surfaceContainer,
+        color: context.vineColors.surfaceContainer,
         child: Center(
           child: DivineIcon(
             icon: DivineIconName.waveform,
-            color: VineTheme.onSurfaceVariant,
+            color: context.vineColors.onSurfaceVariant,
           ),
         ),
       ),
@@ -215,14 +215,16 @@ class _SavedSoundText extends StatelessWidget {
           displayTitle,
           maxLines: 2,
           overflow: TextOverflow.ellipsis,
-          style: VineTheme.titleMediumFont(color: VineTheme.onSurface),
+          style: VineTheme.titleMediumFont(color: context.vineColors.onSurface),
         ),
         if (secondaryTitle != null && secondaryTitle != displayTitle)
           Text(
             secondaryTitle,
             maxLines: 1,
             overflow: TextOverflow.ellipsis,
-            style: VineTheme.bodyMediumFont(color: VineTheme.onSurfaceVariant),
+            style: VineTheme.bodyMediumFont(
+              color: context.vineColors.onSurfaceVariant,
+            ),
           ),
         if (source?.creatorName case final creator?)
           Text(
@@ -234,7 +236,9 @@ class _SavedSoundText extends StatelessWidget {
             description,
             maxLines: 2,
             overflow: TextOverflow.ellipsis,
-            style: VineTheme.bodySmallFont(color: VineTheme.onSurfaceVariant),
+            style: VineTheme.bodySmallFont(
+              color: context.vineColors.onSurfaceVariant,
+            ),
           ),
         if (source?.transcript case final transcript?) ...[
           const SizedBox(height: 4),
@@ -243,7 +247,9 @@ class _SavedSoundText extends StatelessWidget {
             key: const Key('saved_sound_transcript'),
             maxLines: 2,
             overflow: TextOverflow.ellipsis,
-            style: VineTheme.bodySmallFont(color: VineTheme.onSurfaceVariant),
+            style: VineTheme.bodySmallFont(
+              color: context.vineColors.onSurfaceVariant,
+            ),
           ),
         ],
       ],
@@ -299,7 +305,7 @@ class _WaveformBars extends StatelessWidget {
           leftChannel: Float32List.fromList(sound.waveformSamples),
           progress: progress,
           activeColor: VineTheme.vineGreen,
-          inactiveColor: VineTheme.onSurfaceVariant,
+          inactiveColor: context.vineColors.onSurfaceVariant,
           audioDuration: duration,
           maxDuration: duration,
         ),
@@ -340,7 +346,7 @@ class _SavedSoundTag extends StatelessWidget {
       decoration: BoxDecoration(
         color: isPersonal
             ? VineTheme.vineGreen.withValues(alpha: 0.16)
-            : VineTheme.surfaceContainer,
+            : context.vineColors.surfaceContainer,
         borderRadius: BorderRadius.circular(12),
       ),
       child: Padding(
@@ -350,7 +356,7 @@ class _SavedSoundTag extends StatelessWidget {
           style: VineTheme.labelSmallFont(
             color: isPersonal
                 ? VineTheme.vineGreen
-                : VineTheme.onSurfaceVariant,
+                : context.vineColors.onSurfaceVariant,
           ),
         ),
       ),

--- a/mobile/lib/widgets/profile/profile_header_media.dart
+++ b/mobile/lib/widgets/profile/profile_header_media.dart
@@ -565,13 +565,15 @@ class _ProfileActionLabel extends StatelessWidget {
       ),
     };
 
+    final chip = context.vineColors.accentChipYellow;
+
     return Stack(
       clipBehavior: Clip.none,
       children: [
         Container(
           padding: const EdgeInsets.fromLTRB(12, 8, 16, 8),
           decoration: BoxDecoration(
-            color: VineTheme.accentYellowBackground,
+            color: chip.container,
             borderRadius: BorderRadius.circular(16),
             boxShadow: const [
               BoxShadow(
@@ -590,10 +592,10 @@ class _ProfileActionLabel extends StatelessWidget {
             mainAxisSize: MainAxisSize.min,
             spacing: 8,
             children: [
-              DivineIcon(icon: icon, size: 16, color: VineTheme.accentYellow),
+              DivineIcon(icon: icon, size: 16, color: chip.onContainer),
               Text(
                 label,
-                style: VineTheme.titleSmallFont(color: VineTheme.accentYellow),
+                style: VineTheme.titleSmallFont(color: chip.onContainer),
               ),
             ],
           ),

--- a/mobile/lib/widgets/profile_badge_explanation_sheet.dart
+++ b/mobile/lib/widgets/profile_badge_explanation_sheet.dart
@@ -49,7 +49,7 @@ class _ProfileBadgeExplanationContent extends StatelessWidget {
                 child: Text(
                   type.body(l10n),
                   style: VineTheme.bodyMediumFont(
-                    color: VineTheme.secondaryText,
+                    color: context.vineColors.secondaryText,
                   ),
                 ),
               ),

--- a/mobile/lib/widgets/report_content_dialog.dart
+++ b/mobile/lib/widgets/report_content_dialog.dart
@@ -769,7 +769,9 @@ class _CappedDetailsFieldState extends State<_CappedDetailsField> {
         if (_truncated)
           Text(
             context.l10n.supportFieldLimitReached,
-            style: VineTheme.labelSmallFont(color: VineTheme.onSurfaceVariant),
+            style: VineTheme.labelSmallFont(
+              color: context.vineColors.onSurfaceVariant,
+            ),
           ),
       ],
     );

--- a/mobile/lib/widgets/support_capped_text_field.dart
+++ b/mobile/lib/widgets/support_capped_text_field.dart
@@ -117,7 +117,9 @@ class _SupportCappedTextFieldState extends State<SupportCappedTextField> {
           // was dropped, and green reads as success.
           Text(
             context.l10n.supportFieldLimitReached,
-            style: VineTheme.labelSmallFont(color: VineTheme.onSurfaceVariant),
+            style: VineTheme.labelSmallFont(
+              color: context.vineColors.onSurfaceVariant,
+            ),
           ),
       ],
     );

--- a/mobile/lib/widgets/video_feed_item/actions/share_sheet_header.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/share_sheet_header.dart
@@ -57,8 +57,8 @@ class _ShareSheetHeader extends ConsumerWidget {
                 if (videoTitle.isNotEmpty)
                   Text(
                     videoTitle,
-                    style: const TextStyle(
-                      color: VineTheme.whiteText,
+                    style: TextStyle(
+                      color: context.vineColors.primaryText,
                       fontSize: 16,
                       fontWeight: FontWeight.w600,
                     ),

--- a/mobile/lib/widgets/video_feed_item/actions/share_sheet_message_input.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/share_sheet_message_input.dart
@@ -28,8 +28,8 @@ class _MessageInput extends StatelessWidget {
               // Selection reveals the composer; pop the keyboard right away
               // so compose-and-send is a single uninterrupted gesture.
               autofocus: true,
-              style: const TextStyle(
-                color: VineTheme.whiteText,
+              style: TextStyle(
+                color: context.vineColors.primaryText,
                 fontSize: 14,
               ),
               decoration: InputDecoration(

--- a/mobile/lib/widgets/video_feed_item/feed_playback_toggles_pill.dart
+++ b/mobile/lib/widgets/video_feed_item/feed_playback_toggles_pill.dart
@@ -12,8 +12,6 @@ import 'package:flutter/semantics.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/blocs/video_volume/video_volume_cubit.dart';
-import 'package:openvine/features/feature_flags/models/feature_flag.dart';
-import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/subtitle_providers.dart';
 import 'package:openvine/screens/feed/feed_auto_advance_cubit.dart';
@@ -24,21 +22,19 @@ import 'package:openvine/screens/feed/feed_auto_advance_cubit.dart';
 /// Auto-advance and audio mute are feed-wide controls. Captions are scoped to
 /// [videoId] when a feed surface has current-video context; otherwise the
 /// captions button falls back to the global Settings preference.
-class FeedPlaybackTogglesPill extends ConsumerWidget {
+class FeedPlaybackTogglesPill extends StatelessWidget {
   const FeedPlaybackTogglesPill({super.key, this.videoId});
 
   final String? videoId;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  Widget build(BuildContext context) {
     final colors = context.vineColors;
-    final adaptiveMediaChrome =
-        ref.watch(isFeatureEnabledProvider(FeatureFlag.adaptiveMediaChrome)) &&
-        Theme.of(context).brightness == Brightness.light;
-    final chromeBackground = adaptiveMediaChrome
-        ? colors.mediaChrome
-        : VineTheme.scrim30;
-    final chromeForeground = adaptiveMediaChrome
+    // The pill floats over video, so light mode gets the light chrome
+    // treatment; dark mode keeps the scrim-30 capsule unchanged.
+    final isLight = Theme.of(context).brightness == Brightness.light;
+    final chromeBackground = isLight ? colors.mediaChrome : VineTheme.scrim30;
+    final chromeForeground = isLight
         ? colors.mediaChromeForeground
         : VineTheme.onSurface;
     return ClipRRect(

--- a/mobile/lib/widgets/video_feed_item/metadata/metadata_sounds_section.dart
+++ b/mobile/lib/widgets/video_feed_item/metadata/metadata_sounds_section.dart
@@ -328,7 +328,7 @@ class _SoundListItem extends ConsumerWidget {
                       style: VineTheme.labelSmallFont(
                         color: reuseAllowed
                             ? VineTheme.vineGreen
-                            : VineTheme.onSurfaceVariant,
+                            : context.vineColors.onSurfaceVariant,
                       ),
                     ),
                   if (audio.licenseName case final license?)
@@ -337,7 +337,7 @@ class _SoundListItem extends ConsumerWidget {
                       maxLines: 1,
                       overflow: TextOverflow.ellipsis,
                       style: VineTheme.labelSmallFont(
-                        color: VineTheme.onSurfaceVariant,
+                        color: context.vineColors.onSurfaceVariant,
                       ),
                     ),
                   if (audio.source case final source?)
@@ -346,7 +346,7 @@ class _SoundListItem extends ConsumerWidget {
                       maxLines: 1,
                       overflow: TextOverflow.ellipsis,
                       style: VineTheme.labelSmallFont(
-                        color: VineTheme.onSurfaceVariant,
+                        color: context.vineColors.onSurfaceVariant,
                       ),
                     ),
                   if (audio.publicTags.isNotEmpty)
@@ -355,7 +355,7 @@ class _SoundListItem extends ConsumerWidget {
                       maxLines: 1,
                       overflow: TextOverflow.ellipsis,
                       style: VineTheme.labelSmallFont(
-                        color: VineTheme.onSurfaceVariant,
+                        color: context.vineColors.onSurfaceVariant,
                       ),
                     ),
                 ],

--- a/mobile/lib/widgets/video_feed_item/video_feed_item.dart
+++ b/mobile/lib/widgets/video_feed_item/video_feed_item.dart
@@ -993,8 +993,8 @@ class _ContentWarningDetailsSheet extends StatelessWidget {
                         children: [
                           Text(
                             _ContentWarningBadge._humanize(context, label),
-                            style: const TextStyle(
-                              color: VineTheme.whiteText,
+                            style: TextStyle(
+                              color: context.vineColors.primaryText,
                               fontSize: 15,
                               fontWeight: FontWeight.w600,
                             ),

--- a/mobile/packages/divine_ui/lib/src/button/divine_button.dart
+++ b/mobile/packages/divine_ui/lib/src/button/divine_button.dart
@@ -296,7 +296,7 @@ class _DivineButtonContent extends StatelessWidget {
     DivineButtonType.primary => VineTheme.primary,
     DivineButtonType.secondary => colors.surfaceContainer,
     DivineButtonType.tertiary => colors.inverseSurface,
-    DivineButtonType.ghost => VineTheme.scrim65,
+    DivineButtonType.ghost => colors.ghostFill,
     DivineButtonType.ghostSecondary => VineTheme.scrim15,
     DivineButtonType.link => VineTheme.transparent,
     DivineButtonType.error => VineTheme.error,
@@ -307,8 +307,7 @@ class _DivineButtonContent extends StatelessWidget {
     DivineButtonType.secondary =>
       colors.isLight ? colors.onSurface : VineTheme.primary,
     DivineButtonType.tertiary => colors.inverseOnSurface,
-    // The stronger ghost scrim can carry fixed light content in both modes.
-    DivineButtonType.ghost => VineTheme.onSurface,
+    DivineButtonType.ghost => colors.onSurface,
     DivineButtonType.ghostSecondary =>
       colors.isLight ? colors.onSurface : VineTheme.onSurface,
     DivineButtonType.link => colors.onSurfaceVariant,

--- a/mobile/packages/divine_ui/lib/src/button/divine_icon_button.dart
+++ b/mobile/packages/divine_ui/lib/src/button/divine_icon_button.dart
@@ -286,7 +286,7 @@ class _DivineIconButtonContent extends StatelessWidget {
         DivineIconButtonType.primary => VineTheme.primary,
         DivineIconButtonType.secondary => colors.surfaceContainer,
         DivineIconButtonType.tertiary => colors.inverseSurface,
-        DivineIconButtonType.ghost => VineTheme.scrim65,
+        DivineIconButtonType.ghost => colors.ghostFill,
         DivineIconButtonType.ghostSecondary ||
         DivineIconButtonType.ghostOverMedia => VineTheme.scrim15,
         DivineIconButtonType.error => VineTheme.error,
@@ -299,9 +299,9 @@ class _DivineIconButtonContent extends StatelessWidget {
         DivineIconButtonType.secondary =>
           colors.isLight ? colors.onSurface : VineTheme.primary,
         DivineIconButtonType.tertiary => colors.inverseOnSurface,
-        // The stronger ghost scrim, and any scrim over media, carry fixed
-        // light content in both modes.
-        DivineIconButtonType.ghost ||
+        DivineIconButtonType.ghost => colors.onSurface,
+        // A scrim over media stays dark in both modes, so its content stays
+        // fixed light.
         DivineIconButtonType.ghostOverMedia => VineTheme.onSurface,
         DivineIconButtonType.ghostSecondary =>
           colors.isLight ? colors.onSurface : VineTheme.onSurface,

--- a/mobile/packages/divine_ui/lib/src/slider/divine_range_slider.dart
+++ b/mobile/packages/divine_ui/lib/src/slider/divine_range_slider.dart
@@ -6,7 +6,8 @@ import 'package:flutter/material.dart';
 /// Wraps a Material [RangeSlider] with the same themed track (pill-shaped,
 /// uniform height) and tall rectangular thumb indicators as `DivineSlider`.
 /// The active portion between the thumbs uses the primary color and the
-/// inactive portions use [VineTheme.onSurfaceDisabled].
+/// inactive portions follow the `disabled` color of the active appearance
+/// mode.
 class DivineRangeSlider extends StatelessWidget {
   /// Creates a [DivineRangeSlider].
   ///
@@ -22,8 +23,8 @@ class DivineRangeSlider extends StatelessWidget {
     this.thumbWidth = 4,
     this.thumbHeight = 32,
     this.activeColor = VineTheme.primary,
-    this.inactiveColor = VineTheme.onSurfaceDisabled,
-    this.thumbColor = VineTheme.onSurface,
+    this.inactiveColor,
+    this.thumbColor,
     this.labels,
     super.key,
   }) : assert(min <= max, 'min must be <= max'),
@@ -67,10 +68,16 @@ class DivineRangeSlider extends StatelessWidget {
   final Color activeColor;
 
   /// Color of the unfilled (inactive) track portions.
-  final Color inactiveColor;
+  ///
+  /// Defaults to the `disabled` color of the active appearance mode.
+  final Color? inactiveColor;
 
   /// Color of the thumb indicators.
-  final Color thumbColor;
+  ///
+  /// Defaults to the `onSurface` color of the active appearance mode. Pass
+  /// [VineTheme.onSurface] explicitly for sliders that sit on a scrim over
+  /// media, where the thumbs must stay light in both modes.
+  final Color? thumbColor;
 
   /// Optional accessibility labels for the two thumbs. Passed to
   /// [RangeSlider.labels] so screen readers announce them alongside the
@@ -80,14 +87,15 @@ class DivineRangeSlider extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final colors = context.vineColors;
     return SliderTheme(
       data: SliderThemeData(
         padding: EdgeInsets.zero,
         activeTrackColor: activeColor,
-        inactiveTrackColor: inactiveColor,
+        inactiveTrackColor: inactiveColor ?? colors.disabled,
         trackHeight: trackHeight,
         rangeTrackShape: DivineRangeSliderTrackShape(trackHeight: trackHeight),
-        thumbColor: thumbColor,
+        thumbColor: thumbColor ?? colors.onSurface,
         rangeThumbShape: DivineRangeSliderThumbShape(
           width: thumbWidth,
           height: thumbHeight,

--- a/mobile/packages/divine_ui/lib/src/theme/vine_theme.dart
+++ b/mobile/packages/divine_ui/lib/src/theme/vine_theme.dart
@@ -82,6 +82,7 @@ class VineThemeColors extends ThemeExtension<VineThemeColors> {
     required this.accentChipLime,
     required this.accentChipPink,
     required this.accentChipViolet,
+    required this.accentChipGreen,
     required this.inverseSurface,
     required this.inverseOnSurface,
     required this.mediaChrome,
@@ -252,6 +253,10 @@ class VineThemeColors extends ThemeExtension<VineThemeColors> {
   /// Violet decorative accent chip. See [accentChipOrange].
   final VineAccentChip accentChipViolet;
 
+  /// Green decorative accent chip, carrying the brand mark — the system
+  /// notification glyph. See [accentChipOrange].
+  final VineAccentChip accentChipGreen;
+
   /// Surface that contrasts with [background], used by tertiary actions.
   final Color inverseSurface;
 
@@ -307,6 +312,7 @@ class VineThemeColors extends ThemeExtension<VineThemeColors> {
     VineAccentChip? accentChipLime,
     VineAccentChip? accentChipPink,
     VineAccentChip? accentChipViolet,
+    VineAccentChip? accentChipGreen,
     Color? inverseSurface,
     Color? inverseOnSurface,
     Color? mediaChrome,
@@ -347,6 +353,7 @@ class VineThemeColors extends ThemeExtension<VineThemeColors> {
     accentChipLime: accentChipLime ?? this.accentChipLime,
     accentChipPink: accentChipPink ?? this.accentChipPink,
     accentChipViolet: accentChipViolet ?? this.accentChipViolet,
+    accentChipGreen: accentChipGreen ?? this.accentChipGreen,
     inverseSurface: inverseSurface ?? this.inverseSurface,
     inverseOnSurface: inverseOnSurface ?? this.inverseOnSurface,
     mediaChrome: mediaChrome ?? this.mediaChrome,
@@ -396,6 +403,7 @@ class VineThemeColors extends ThemeExtension<VineThemeColors> {
       accentChipLime: accentChipLime.lerpTo(other.accentChipLime, t),
       accentChipPink: accentChipPink.lerpTo(other.accentChipPink, t),
       accentChipViolet: accentChipViolet.lerpTo(other.accentChipViolet, t),
+      accentChipGreen: accentChipGreen.lerpTo(other.accentChipGreen, t),
       inverseSurface: Color.lerp(inverseSurface, other.inverseSurface, t),
       inverseOnSurface: Color.lerp(inverseOnSurface, other.inverseOnSurface, t),
       mediaChrome: Color.lerp(mediaChrome, other.mediaChrome, t),
@@ -446,6 +454,7 @@ class VineThemeColors extends ThemeExtension<VineThemeColors> {
           accentChipLime == other.accentChipLime &&
           accentChipPink == other.accentChipPink &&
           accentChipViolet == other.accentChipViolet &&
+          accentChipGreen == other.accentChipGreen &&
           inverseSurface == other.inverseSurface &&
           inverseOnSurface == other.inverseOnSurface &&
           mediaChrome == other.mediaChrome &&
@@ -488,6 +497,7 @@ class VineThemeColors extends ThemeExtension<VineThemeColors> {
     accentChipLime,
     accentChipPink,
     accentChipViolet,
+    accentChipGreen,
     inverseSurface,
     inverseOnSurface,
     mediaChrome,
@@ -1191,6 +1201,10 @@ class VineTheme {
       container: accentVioletBackground,
       onContainer: accentViolet,
     ),
+    accentChipGreen: VineAccentChip(
+      container: onPrimaryButton,
+      onContainer: primary,
+    ),
     inverseSurface: inverseSurface,
     inverseOnSurface: inverseOnSurface,
     mediaChrome: scrim80,
@@ -1255,6 +1269,10 @@ class VineTheme {
     accentChipViolet: VineAccentChip(
       container: Color(0xFFD6D8FF),
       onContainer: Color(0xFF33368A),
+    ),
+    accentChipGreen: VineAccentChip(
+      container: Color(0xFFC2E9D6),
+      onContainer: Color(0xFF14563C),
     ),
     inverseSurface: Color(0xFF07241B),
     inverseOnSurface: Color(0xFFFFFFFF),

--- a/mobile/packages/divine_ui/lib/src/theme/vine_theme.dart
+++ b/mobile/packages/divine_ui/lib/src/theme/vine_theme.dart
@@ -5,6 +5,43 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:google_fonts/google_fonts.dart';
 
+/// A decorative accent chip: a tinted container and the content color drawn
+/// on it.
+///
+/// The two travel together because they are only ever legible as a pair —
+/// dark mode pairs a deep tint with a bright accent, light mode pairs a pale
+/// tint with a darkened one. Storing them as one value makes mismatching them
+/// impossible at the call site, which a pair of independent tokens does not.
+@immutable
+class VineAccentChip {
+  /// Creates an accent chip pairing.
+  const VineAccentChip({required this.container, required this.onContainer});
+
+  /// Chip background.
+  final Color container;
+
+  /// Icon or label color drawn on [container]. Clears 4.5:1 against it in
+  /// both appearance modes.
+  final Color onContainer;
+
+  /// Linearly interpolates both halves toward [other], so a theme cross-fade
+  /// never pairs a light container with a dark foreground mid-flight.
+  VineAccentChip lerpTo(VineAccentChip other, double t) => VineAccentChip(
+    container: Color.lerp(container, other.container, t)!,
+    onContainer: Color.lerp(onContainer, other.onContainer, t)!,
+  );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is VineAccentChip &&
+          container == other.container &&
+          onContainer == other.onContainer;
+
+  @override
+  int get hashCode => Object.hash(container, onContainer);
+}
+
 /// Semantic palette used by widgets that support both appearance modes.
 @immutable
 class VineThemeColors extends ThemeExtension<VineThemeColors> {
@@ -22,6 +59,8 @@ class VineThemeColors extends ThemeExtension<VineThemeColors> {
     required this.onNav,
     required this.onNavMuted,
     required this.iconButton,
+    required this.onIconButton,
+    required this.ghostFill,
     required this.primaryText,
     required this.secondaryText,
     required this.mutedText,
@@ -37,6 +76,12 @@ class VineThemeColors extends ThemeExtension<VineThemeColors> {
     required this.onErrorContainer,
     required this.accentPositive,
     required this.accentWarning,
+    required this.accentChipOrange,
+    required this.accentChipYellow,
+    required this.accentChipBlue,
+    required this.accentChipLime,
+    required this.accentChipPink,
+    required this.accentChipViolet,
     required this.inverseSurface,
     required this.inverseOnSurface,
     required this.mediaChrome,
@@ -103,6 +148,24 @@ class VineThemeColors extends ThemeExtension<VineThemeColors> {
   /// Icon button background.
   final Color iconButton;
 
+  /// Content color on [iconButton] and other tinted circular affordances.
+  ///
+  /// Its dark value is [VineTheme.vineGreenLight], so dark mode is unchanged
+  /// at 15:1. That pale mint is 1.01:1 on the light containers these icons
+  /// sit on — invisible — so light substitutes the same darkened green
+  /// [accentPositive] uses, clearing 4.5:1 on both `iconButton` (5.78:1) and
+  /// `surfaceContainer` (5.61:1).
+  final Color onIconButton;
+
+  /// Fill behind a ghost button sitting on an app surface.
+  ///
+  /// Its dark value is [VineTheme.scrim65], so dark mode is unchanged. That
+  /// 65%-black wash reads as a near-black pill on the light canvas, so light
+  /// uses a much lighter wash of the same ink. Ghost buttons drawn *over
+  /// media* use the fixed scrim directly instead — their ground is a video
+  /// frame, not a palette surface.
+  final Color ghostFill;
+
   /// Primary text.
   final Color primaryText;
 
@@ -161,6 +224,34 @@ class VineThemeColors extends ThemeExtension<VineThemeColors> {
   /// [background] so the two accents carry the same weight side by side.
   final Color accentWarning;
 
+  /// Decorative accent chips, drawn on [background] or [card] — notification
+  /// type indicators, badge status pills, onboarding highlights.
+  ///
+  /// Dark keeps the deep tint / bright accent pairing these surfaces already
+  /// shipped, so dark mode is unchanged. Light substitutes a pale tint and a
+  /// darkened accent: the bright accents are 1.2–1.9:1 on the warm off-white
+  /// canvas, so reusing them there would erase the chip.
+  ///
+  /// These are decoration, not status — [accentPositive] and [accentWarning]
+  /// carry meaning and are held to text contrast; a chip only has to stay
+  /// visible and keep its glyph legible.
+  final VineAccentChip accentChipOrange;
+
+  /// Yellow decorative accent chip. See [accentChipOrange].
+  final VineAccentChip accentChipYellow;
+
+  /// Blue decorative accent chip. See [accentChipOrange].
+  final VineAccentChip accentChipBlue;
+
+  /// Lime decorative accent chip. See [accentChipOrange].
+  final VineAccentChip accentChipLime;
+
+  /// Pink decorative accent chip. See [accentChipOrange].
+  final VineAccentChip accentChipPink;
+
+  /// Violet decorative accent chip. See [accentChipOrange].
+  final VineAccentChip accentChipViolet;
+
   /// Surface that contrasts with [background], used by tertiary actions.
   final Color inverseSurface;
 
@@ -193,6 +284,8 @@ class VineThemeColors extends ThemeExtension<VineThemeColors> {
     Color? onNav,
     Color? onNavMuted,
     Color? iconButton,
+    Color? onIconButton,
+    Color? ghostFill,
     Color? primaryText,
     Color? secondaryText,
     Color? mutedText,
@@ -208,6 +301,12 @@ class VineThemeColors extends ThemeExtension<VineThemeColors> {
     Color? onErrorContainer,
     Color? accentPositive,
     Color? accentWarning,
+    VineAccentChip? accentChipOrange,
+    VineAccentChip? accentChipYellow,
+    VineAccentChip? accentChipBlue,
+    VineAccentChip? accentChipLime,
+    VineAccentChip? accentChipPink,
+    VineAccentChip? accentChipViolet,
     Color? inverseSurface,
     Color? inverseOnSurface,
     Color? mediaChrome,
@@ -225,6 +324,8 @@ class VineThemeColors extends ThemeExtension<VineThemeColors> {
     onNav: onNav ?? this.onNav,
     onNavMuted: onNavMuted ?? this.onNavMuted,
     iconButton: iconButton ?? this.iconButton,
+    onIconButton: onIconButton ?? this.onIconButton,
+    ghostFill: ghostFill ?? this.ghostFill,
     primaryText: primaryText ?? this.primaryText,
     secondaryText: secondaryText ?? this.secondaryText,
     mutedText: mutedText ?? this.mutedText,
@@ -240,6 +341,12 @@ class VineThemeColors extends ThemeExtension<VineThemeColors> {
     onErrorContainer: onErrorContainer ?? this.onErrorContainer,
     accentPositive: accentPositive ?? this.accentPositive,
     accentWarning: accentWarning ?? this.accentWarning,
+    accentChipOrange: accentChipOrange ?? this.accentChipOrange,
+    accentChipYellow: accentChipYellow ?? this.accentChipYellow,
+    accentChipBlue: accentChipBlue ?? this.accentChipBlue,
+    accentChipLime: accentChipLime ?? this.accentChipLime,
+    accentChipPink: accentChipPink ?? this.accentChipPink,
+    accentChipViolet: accentChipViolet ?? this.accentChipViolet,
     inverseSurface: inverseSurface ?? this.inverseSurface,
     inverseOnSurface: inverseOnSurface ?? this.inverseOnSurface,
     mediaChrome: mediaChrome ?? this.mediaChrome,
@@ -266,6 +373,8 @@ class VineThemeColors extends ThemeExtension<VineThemeColors> {
       onNav: Color.lerp(onNav, other.onNav, t),
       onNavMuted: Color.lerp(onNavMuted, other.onNavMuted, t),
       iconButton: Color.lerp(iconButton, other.iconButton, t),
+      onIconButton: Color.lerp(onIconButton, other.onIconButton, t),
+      ghostFill: Color.lerp(ghostFill, other.ghostFill, t),
       primaryText: Color.lerp(primaryText, other.primaryText, t),
       secondaryText: Color.lerp(secondaryText, other.secondaryText, t),
       mutedText: Color.lerp(mutedText, other.mutedText, t),
@@ -281,6 +390,12 @@ class VineThemeColors extends ThemeExtension<VineThemeColors> {
       onErrorContainer: Color.lerp(onErrorContainer, other.onErrorContainer, t),
       accentPositive: Color.lerp(accentPositive, other.accentPositive, t),
       accentWarning: Color.lerp(accentWarning, other.accentWarning, t),
+      accentChipOrange: accentChipOrange.lerpTo(other.accentChipOrange, t),
+      accentChipYellow: accentChipYellow.lerpTo(other.accentChipYellow, t),
+      accentChipBlue: accentChipBlue.lerpTo(other.accentChipBlue, t),
+      accentChipLime: accentChipLime.lerpTo(other.accentChipLime, t),
+      accentChipPink: accentChipPink.lerpTo(other.accentChipPink, t),
+      accentChipViolet: accentChipViolet.lerpTo(other.accentChipViolet, t),
       inverseSurface: Color.lerp(inverseSurface, other.inverseSurface, t),
       inverseOnSurface: Color.lerp(inverseOnSurface, other.inverseOnSurface, t),
       mediaChrome: Color.lerp(mediaChrome, other.mediaChrome, t),
@@ -308,6 +423,8 @@ class VineThemeColors extends ThemeExtension<VineThemeColors> {
           onNav == other.onNav &&
           onNavMuted == other.onNavMuted &&
           iconButton == other.iconButton &&
+          onIconButton == other.onIconButton &&
+          ghostFill == other.ghostFill &&
           primaryText == other.primaryText &&
           secondaryText == other.secondaryText &&
           mutedText == other.mutedText &&
@@ -323,6 +440,12 @@ class VineThemeColors extends ThemeExtension<VineThemeColors> {
           onErrorContainer == other.onErrorContainer &&
           accentPositive == other.accentPositive &&
           accentWarning == other.accentWarning &&
+          accentChipOrange == other.accentChipOrange &&
+          accentChipYellow == other.accentChipYellow &&
+          accentChipBlue == other.accentChipBlue &&
+          accentChipLime == other.accentChipLime &&
+          accentChipPink == other.accentChipPink &&
+          accentChipViolet == other.accentChipViolet &&
           inverseSurface == other.inverseSurface &&
           inverseOnSurface == other.inverseOnSurface &&
           mediaChrome == other.mediaChrome &&
@@ -342,6 +465,8 @@ class VineThemeColors extends ThemeExtension<VineThemeColors> {
     onNav,
     onNavMuted,
     iconButton,
+    onIconButton,
+    ghostFill,
     primaryText,
     secondaryText,
     mutedText,
@@ -357,6 +482,12 @@ class VineThemeColors extends ThemeExtension<VineThemeColors> {
     onErrorContainer,
     accentPositive,
     accentWarning,
+    accentChipOrange,
+    accentChipYellow,
+    accentChipBlue,
+    accentChipLime,
+    accentChipPink,
+    accentChipViolet,
     inverseSurface,
     inverseOnSurface,
     mediaChrome,
@@ -390,7 +521,10 @@ extension VineThemeColorsContext on BuildContext {
 
 /// Vine-inspired theme with characteristic green colors and clean design.
 ///
-/// This is a dark-mode only design system matching the classic Vine app
+/// Design system matching the classic Vine app. Ships two appearances:
+/// [theme] (dark, the default) and [lightTheme]. The static color constants
+/// below are brand and fixed-media values; anything that must adapt reads
+/// [VineThemeColors] through `context.vineColors`
 /// aesthetic with proper color scheme and typography.
 class VineTheme {
   // ==========================================================================
@@ -1013,6 +1147,8 @@ class VineTheme {
     onNav: whiteText,
     onNavMuted: onSurfaceDisabled,
     iconButton: iconButtonBackground,
+    onIconButton: vineGreenLight,
+    ghostFill: scrim65,
     primaryText: primaryText,
     secondaryText: secondaryText,
     mutedText: lightText,
@@ -1031,6 +1167,30 @@ class VineTheme {
     onErrorContainer: error,
     accentPositive: vineGreen,
     accentWarning: accentOrange,
+    accentChipOrange: VineAccentChip(
+      container: accentOrangeBackground,
+      onContainer: accentOrange,
+    ),
+    accentChipYellow: VineAccentChip(
+      container: accentYellowBackground,
+      onContainer: accentYellow,
+    ),
+    accentChipBlue: VineAccentChip(
+      container: accentBlueBackground,
+      onContainer: accentBlue,
+    ),
+    accentChipLime: VineAccentChip(
+      container: accentLimeBackground,
+      onContainer: accentLime,
+    ),
+    accentChipPink: VineAccentChip(
+      container: accentPinkBackground,
+      onContainer: accentPink,
+    ),
+    accentChipViolet: VineAccentChip(
+      container: accentVioletBackground,
+      onContainer: accentViolet,
+    ),
     inverseSurface: inverseSurface,
     inverseOnSurface: inverseOnSurface,
     mediaChrome: scrim80,
@@ -1052,6 +1212,8 @@ class VineTheme {
     onNav: Color(0xFF07241B),
     onNavMuted: Color(0x6607241B),
     iconButton: Color(0xFFE7F5EE),
+    onIconButton: Color(0xFF226A4C),
+    ghostFill: Color(0x14000000),
     primaryText: Color(0xFF07241B),
     secondaryText: Color(0xFF385149),
     mutedText: Color(0xFF5F7069),
@@ -1067,6 +1229,33 @@ class VineTheme {
     onErrorContainer: Color(0xFF8C1D18),
     accentPositive: Color(0xFF226A4C),
     accentWarning: Color(0xFFAE3100),
+    // Pale tint / darkened accent. Each pair clears 4.5:1 foreground-on-
+    // container (6.30–7.51) and holds 1.18–1.30 container-on-background, which
+    // overlaps the dark palette's own low end (pink, 1.28).
+    accentChipOrange: VineAccentChip(
+      container: Color(0xFFFFD9C4),
+      onContainer: Color(0xFF8A3200),
+    ),
+    accentChipYellow: VineAccentChip(
+      container: Color(0xFFF2E7A0),
+      onContainer: Color(0xFF5C4D00),
+    ),
+    accentChipBlue: VineAccentChip(
+      container: Color(0xFFC4E4F7),
+      onContainer: Color(0xFF07485F),
+    ),
+    accentChipLime: VineAccentChip(
+      container: Color(0xFFDDECAB),
+      onContainer: Color(0xFF3E4D00),
+    ),
+    accentChipPink: VineAccentChip(
+      container: Color(0xFFFFCFE0),
+      onContainer: Color(0xFF8C1F4C),
+    ),
+    accentChipViolet: VineAccentChip(
+      container: Color(0xFFD6D8FF),
+      onContainer: Color(0xFF33368A),
+    ),
     inverseSurface: Color(0xFF07241B),
     inverseOnSurface: Color(0xFFFFFFFF),
     mediaChrome: Color(0xF2F9F7F6),

--- a/mobile/packages/divine_ui/test/src/divine_ui_test.dart
+++ b/mobile/packages/divine_ui/test/src/divine_ui_test.dart
@@ -89,6 +89,8 @@ void main() {
         'onNav': (c) => c.onNav,
         'onNavMuted': (c) => c.onNavMuted,
         'iconButton': (c) => c.iconButton,
+        'onIconButton': (c) => c.onIconButton,
+        'ghostFill': (c) => c.ghostFill,
         'primaryText': (c) => c.primaryText,
         'secondaryText': (c) => c.secondaryText,
         'mutedText': (c) => c.mutedText,
@@ -110,6 +112,18 @@ void main() {
         'mediaChromeForeground': (c) => c.mediaChromeForeground,
       };
 
+      // Accent chips are pairs, not flat colors, so they cannot live in
+      // `tokens`. Same purpose: a new chip that skips copyWith/lerp/== fails
+      // here rather than silently staying dark on a light page.
+      final chipTokens = <String, VineAccentChip Function(VineThemeColors)>{
+        'accentChipOrange': (c) => c.accentChipOrange,
+        'accentChipYellow': (c) => c.accentChipYellow,
+        'accentChipBlue': (c) => c.accentChipBlue,
+        'accentChipLime': (c) => c.accentChipLime,
+        'accentChipPink': (c) => c.accentChipPink,
+        'accentChipViolet': (c) => c.accentChipViolet,
+      };
+
       VineThemeColors paint(Color color) => VineThemeColors(
         background: color,
         card: color,
@@ -123,6 +137,8 @@ void main() {
         onNav: color,
         onNavMuted: color,
         iconButton: color,
+        onIconButton: color,
+        ghostFill: color,
         primaryText: color,
         secondaryText: color,
         mutedText: color,
@@ -138,6 +154,12 @@ void main() {
         onErrorContainer: color,
         accentPositive: color,
         accentWarning: color,
+        accentChipOrange: VineAccentChip(container: color, onContainer: color),
+        accentChipYellow: VineAccentChip(container: color, onContainer: color),
+        accentChipBlue: VineAccentChip(container: color, onContainer: color),
+        accentChipLime: VineAccentChip(container: color, onContainer: color),
+        accentChipPink: VineAccentChip(container: color, onContainer: color),
+        accentChipViolet: VineAccentChip(container: color, onContainer: color),
         inverseSurface: color,
         inverseOnSurface: color,
         mediaChrome: color,
@@ -154,6 +176,8 @@ void main() {
           containerLow: const Color(0xFF000011),
           nav: const Color(0xFF000006),
           iconButton: const Color(0xFF000007),
+          onIconButton: const Color(0xFF00001C),
+          ghostFill: const Color(0xFF00001F),
           primaryText: const Color(0xFF000008),
           secondaryText: const Color(0xFF000009),
           mutedText: const Color(0xFF00000A),
@@ -169,6 +193,10 @@ void main() {
           onErrorContainer: const Color(0xFF000017),
           accentPositive: const Color(0xFF00001A),
           accentWarning: const Color(0xFF00001B),
+          accentChipOrange: const VineAccentChip(
+            container: Color(0xFF00001D),
+            onContainer: Color(0xFF00001E),
+          ),
           inverseSurface: const Color(0xFF000018),
           inverseOnSurface: const Color(0xFF000019),
           mediaChrome: const Color(0xFF00000F),
@@ -183,6 +211,8 @@ void main() {
         expect(copied.containerLow, const Color(0xFF000011));
         expect(copied.nav, const Color(0xFF000006));
         expect(copied.iconButton, const Color(0xFF000007));
+        expect(copied.onIconButton, const Color(0xFF00001C));
+        expect(copied.ghostFill, const Color(0xFF00001F));
         expect(copied.primaryText, const Color(0xFF000008));
         expect(copied.secondaryText, const Color(0xFF000009));
         expect(copied.mutedText, const Color(0xFF00000A));
@@ -198,6 +228,13 @@ void main() {
         expect(copied.onErrorContainer, const Color(0xFF000017));
         expect(copied.accentPositive, const Color(0xFF00001A));
         expect(copied.accentWarning, const Color(0xFF00001B));
+        expect(
+          copied.accentChipOrange,
+          const VineAccentChip(
+            container: Color(0xFF00001D),
+            onContainer: Color(0xFF00001E),
+          ),
+        );
         expect(copied.inverseSurface, const Color(0xFF000018));
         expect(copied.inverseOnSurface, const Color(0xFF000019));
         expect(copied.mediaChrome, const Color(0xFF00000F));
@@ -217,6 +254,10 @@ void main() {
 
         for (final token in tokens.entries) {
           expect(token.value(midpoint), expected, reason: token.key);
+        }
+        for (final chip in chipTokens.entries) {
+          expect(chip.value(midpoint).container, expected, reason: chip.key);
+          expect(chip.value(midpoint).onContainer, expected, reason: chip.key);
         }
       });
 
@@ -276,6 +317,8 @@ void main() {
             onNav: token == 'onNav' ? Colors.white : null,
             onNavMuted: token == 'onNavMuted' ? Colors.white : null,
             iconButton: token == 'iconButton' ? Colors.white : null,
+            onIconButton: token == 'onIconButton' ? Colors.white : null,
+            ghostFill: token == 'ghostFill' ? Colors.white : null,
             primaryText: token == 'primaryText' ? Colors.white : null,
             secondaryText: token == 'secondaryText' ? Colors.white : null,
             mutedText: token == 'mutedText' ? Colors.white : null,
@@ -300,6 +343,23 @@ void main() {
           );
 
           expect(changed, isNot(paint(Colors.black)), reason: token);
+        }
+
+        const white = VineAccentChip(
+          container: Colors.white,
+          onContainer: Colors.white,
+        );
+        for (final chip in chipTokens.keys) {
+          final changed = paint(Colors.black).copyWith(
+            accentChipOrange: chip == 'accentChipOrange' ? white : null,
+            accentChipYellow: chip == 'accentChipYellow' ? white : null,
+            accentChipBlue: chip == 'accentChipBlue' ? white : null,
+            accentChipLime: chip == 'accentChipLime' ? white : null,
+            accentChipPink: chip == 'accentChipPink' ? white : null,
+            accentChipViolet: chip == 'accentChipViolet' ? white : null,
+          );
+
+          expect(changed, isNot(paint(Colors.black)), reason: chip);
         }
       });
     });

--- a/mobile/packages/divine_ui/test/src/divine_ui_test.dart
+++ b/mobile/packages/divine_ui/test/src/divine_ui_test.dart
@@ -122,6 +122,7 @@ void main() {
         'accentChipLime': (c) => c.accentChipLime,
         'accentChipPink': (c) => c.accentChipPink,
         'accentChipViolet': (c) => c.accentChipViolet,
+        'accentChipGreen': (c) => c.accentChipGreen,
       };
 
       VineThemeColors paint(Color color) => VineThemeColors(
@@ -160,6 +161,7 @@ void main() {
         accentChipLime: VineAccentChip(container: color, onContainer: color),
         accentChipPink: VineAccentChip(container: color, onContainer: color),
         accentChipViolet: VineAccentChip(container: color, onContainer: color),
+        accentChipGreen: VineAccentChip(container: color, onContainer: color),
         inverseSurface: color,
         inverseOnSurface: color,
         mediaChrome: color,
@@ -357,6 +359,7 @@ void main() {
             accentChipLime: chip == 'accentChipLime' ? white : null,
             accentChipPink: chip == 'accentChipPink' ? white : null,
             accentChipViolet: chip == 'accentChipViolet' ? white : null,
+            accentChipGreen: chip == 'accentChipGreen' ? white : null,
           );
 
           expect(changed, isNot(paint(Colors.black)), reason: chip);

--- a/mobile/test/core/feature_flag_test.dart
+++ b/mobile/test/core/feature_flag_test.dart
@@ -48,15 +48,19 @@ void main() {
       }
     });
 
-    test('exposes light mode to every user', () {
-      // Promoted out of staged rollout: the appearance picker is opt-in for
-      // everyone, gated only by its build default.
-      expect(FeatureFlag.lightMode.audience, FeatureFlagAudience.user);
+    test('no longer carries an appearance flag', () {
+      // Light mode graduated: appearance is a plain user setting now, so
+      // neither the picker nor media chrome is gated. A reintroduced flag
+      // here would mean the ungating regressed.
+      expect(
+        FeatureFlag.values.map((flag) => flag.name),
+        isNot(anyElement(anyOf('lightMode', 'adaptiveMediaChrome'))),
+      );
     });
 
     test('should classify staged rollout flags as internal', () {
       expect(
-        FeatureFlag.adaptiveMediaChrome.audience,
+        FeatureFlag.communityContentWarnings.audience,
         FeatureFlagAudience.internal,
       );
       expect(

--- a/mobile/test/features/appearance/appearance_cubit_test.dart
+++ b/mobile/test/features/appearance/appearance_cubit_test.dart
@@ -67,22 +67,14 @@ void main() {
     );
 
     test('resolves System to the platform-reactive ThemeMode', () {
-      expect(
-        resolveThemeMode(mode: AppearanceMode.system),
-        ThemeMode.system,
-      );
+      expect(resolveThemeMode(mode: AppearanceMode.system), ThemeMode.system);
     });
 
     test('resolves explicit modes', () {
+      // Light is the case the removed gate used to force back to dark, so
+      // this also pins that a stored Light choice now survives.
       expect(resolveThemeMode(mode: AppearanceMode.light), ThemeMode.light);
       expect(resolveThemeMode(mode: AppearanceMode.dark), ThemeMode.dark);
-    });
-
-    test('honours a stored Light choice with no flag to gate it', () {
-      // The gate used to force ThemeMode.dark here regardless of the stored
-      // choice. Removing it is the whole point of ungating: a user who picked
-      // Light gets Light.
-      expect(resolveThemeMode(mode: AppearanceMode.light), ThemeMode.light);
     });
   });
 }

--- a/mobile/test/features/appearance/appearance_cubit_test.dart
+++ b/mobile/test/features/appearance/appearance_cubit_test.dart
@@ -66,41 +66,23 @@ void main() {
       expect: () => [AppearanceMode.light],
     );
 
-    test('resolves disabled Light Mode to dark', () {
-      expect(
-        resolveThemeMode(
-          mode: AppearanceMode.light,
-          lightModeEnabled: false,
-        ),
-        ThemeMode.dark,
-      );
-    });
-
     test('resolves System to the platform-reactive ThemeMode', () {
       expect(
-        resolveThemeMode(
-          mode: AppearanceMode.system,
-          lightModeEnabled: true,
-        ),
+        resolveThemeMode(mode: AppearanceMode.system),
         ThemeMode.system,
       );
     });
 
-    test('resolves enabled explicit modes', () {
-      expect(
-        resolveThemeMode(
-          mode: AppearanceMode.light,
-          lightModeEnabled: true,
-        ),
-        ThemeMode.light,
-      );
-      expect(
-        resolveThemeMode(
-          mode: AppearanceMode.dark,
-          lightModeEnabled: true,
-        ),
-        ThemeMode.dark,
-      );
+    test('resolves explicit modes', () {
+      expect(resolveThemeMode(mode: AppearanceMode.light), ThemeMode.light);
+      expect(resolveThemeMode(mode: AppearanceMode.dark), ThemeMode.dark);
+    });
+
+    test('honours a stored Light choice with no flag to gate it', () {
+      // The gate used to force ThemeMode.dark here regardless of the stored
+      // choice. Removing it is the whole point of ungating: a user who picked
+      // Light gets Light.
+      expect(resolveThemeMode(mode: AppearanceMode.light), ThemeMode.light);
     });
   });
 }

--- a/mobile/test/notifications/widgets/notification_leading_type_icon_test.dart
+++ b/mobile/test/notifications/widgets/notification_leading_type_icon_test.dart
@@ -2,6 +2,7 @@
 // ABOUTME: that combines notificationTypeIconSpec with NotificationTypeIcon
 // ABOUTME: for use in both row variants.
 
+import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:models/models.dart';
@@ -16,6 +17,7 @@ Future<void> _pump(
 }) async {
   await tester.pumpWidget(
     MaterialApp(
+      theme: VineTheme.theme,
       home: Scaffold(
         body: NotificationLeadingTypeIcon(type: type, isRead: isRead),
       ),
@@ -39,7 +41,10 @@ void main() {
         final widget = tester.widget<NotificationTypeIcon>(
           find.byType(NotificationTypeIcon),
         );
-        final spec = notificationTypeIconSpec(NotificationKind.follow);
+        final spec = notificationTypeIconSpec(
+          NotificationKind.follow,
+          colors: VineTheme.darkColors,
+        );
         expect(widget.icon, equals(spec.icon));
         expect(widget.backgroundColor, equals(spec.background));
         expect(widget.foregroundColor, equals(spec.foreground));

--- a/mobile/test/notifications/widgets/notification_type_icon_spec_test.dart
+++ b/mobile/test/notifications/widgets/notification_type_icon_spec_test.dart
@@ -8,84 +8,142 @@ import 'package:openvine/notifications/widgets/notification_type_icon_spec.dart'
 
 void main() {
   group('notificationTypeIconSpec', () {
+    const dark = VineTheme.darkColors;
+
     test('like uses heart on accentPink', () {
-      final spec = notificationTypeIconSpec(NotificationKind.like);
+      final spec = notificationTypeIconSpec(
+        NotificationKind.like,
+        colors: dark,
+      );
       expect(spec.icon, equals(DivineIconName.heart));
-      expect(spec.background, equals(VineTheme.accentPinkBackground));
-      expect(spec.foreground, equals(VineTheme.accentPink));
+      expect(spec.background, equals(dark.accentChipPink.container));
+      expect(spec.foreground, equals(dark.accentChipPink.onContainer));
     });
 
     test('likeComment shares the heart accent with like', () {
-      final spec = notificationTypeIconSpec(NotificationKind.likeComment);
+      final spec = notificationTypeIconSpec(
+        NotificationKind.likeComment,
+        colors: dark,
+      );
       expect(spec.icon, equals(DivineIconName.heart));
-      expect(spec.background, equals(VineTheme.accentPinkBackground));
-      expect(spec.foreground, equals(VineTheme.accentPink));
+      expect(spec.background, equals(dark.accentChipPink.container));
+      expect(spec.foreground, equals(dark.accentChipPink.onContainer));
     });
 
     test('follow uses user on accentLime', () {
-      final spec = notificationTypeIconSpec(NotificationKind.follow);
+      final spec = notificationTypeIconSpec(
+        NotificationKind.follow,
+        colors: dark,
+      );
       expect(spec.icon, equals(DivineIconName.user));
-      expect(spec.background, equals(VineTheme.accentLimeBackground));
-      expect(spec.foreground, equals(VineTheme.accentLime));
+      expect(spec.background, equals(dark.accentChipLime.container));
+      expect(spec.foreground, equals(dark.accentChipLime.onContainer));
     });
 
     test('comment uses chat on accentViolet', () {
-      final spec = notificationTypeIconSpec(NotificationKind.comment);
+      final spec = notificationTypeIconSpec(
+        NotificationKind.comment,
+        colors: dark,
+      );
       expect(spec.icon, equals(DivineIconName.chat));
-      expect(spec.background, equals(VineTheme.accentVioletBackground));
-      expect(spec.foreground, equals(VineTheme.accentViolet));
+      expect(spec.background, equals(dark.accentChipViolet.container));
+      expect(spec.foreground, equals(dark.accentChipViolet.onContainer));
     });
 
     test('reply shares the chat accent with comment', () {
-      final spec = notificationTypeIconSpec(NotificationKind.reply);
+      final spec = notificationTypeIconSpec(
+        NotificationKind.reply,
+        colors: dark,
+      );
       expect(spec.icon, equals(DivineIconName.chat));
-      expect(spec.background, equals(VineTheme.accentVioletBackground));
-      expect(spec.foreground, equals(VineTheme.accentViolet));
+      expect(spec.background, equals(dark.accentChipViolet.container));
+      expect(spec.foreground, equals(dark.accentChipViolet.onContainer));
     });
 
     test('mention shares the chat accent with comment', () {
-      final spec = notificationTypeIconSpec(NotificationKind.mention);
+      final spec = notificationTypeIconSpec(
+        NotificationKind.mention,
+        colors: dark,
+      );
       expect(spec.icon, equals(DivineIconName.chat));
-      expect(spec.background, equals(VineTheme.accentVioletBackground));
-      expect(spec.foreground, equals(VineTheme.accentViolet));
+      expect(spec.background, equals(dark.accentChipViolet.container));
+      expect(spec.foreground, equals(dark.accentChipViolet.onContainer));
     });
 
     test('video-sourced mention uses video camera on mention accent', () {
       final spec = notificationTypeIconSpec(
         NotificationKind.mention,
+        colors: dark,
         isVideoSourcedMention: true,
       );
       expect(spec.icon, equals(DivineIconName.videoCamera));
-      expect(spec.background, equals(VineTheme.accentVioletBackground));
-      expect(spec.foreground, equals(VineTheme.accentViolet));
+      expect(spec.background, equals(dark.accentChipViolet.container));
+      expect(spec.foreground, equals(dark.accentChipViolet.onContainer));
     });
 
     test('repost uses repeat on accentYellow', () {
-      final spec = notificationTypeIconSpec(NotificationKind.repost);
+      final spec = notificationTypeIconSpec(
+        NotificationKind.repost,
+        colors: dark,
+      );
       expect(spec.icon, equals(DivineIconName.repeat));
-      expect(spec.background, equals(VineTheme.accentYellowBackground));
-      expect(spec.foreground, equals(VineTheme.accentYellow));
+      expect(spec.background, equals(dark.accentChipYellow.container));
+      expect(spec.foreground, equals(dark.accentChipYellow.onContainer));
     });
 
     test('newPost uses bellSimple on accentBlue', () {
-      final spec = notificationTypeIconSpec(NotificationKind.newPost);
+      final spec = notificationTypeIconSpec(
+        NotificationKind.newPost,
+        colors: dark,
+      );
       expect(spec.icon, equals(DivineIconName.bellSimple));
-      expect(spec.background, equals(VineTheme.accentBlueBackground));
-      expect(spec.foreground, equals(VineTheme.accentBlue));
+      expect(spec.background, equals(dark.accentChipBlue.container));
+      expect(spec.foreground, equals(dark.accentChipBlue.onContainer));
     });
 
     test('listAdd uses listPlus on accentYellow', () {
-      final spec = notificationTypeIconSpec(NotificationKind.listAdd);
+      final spec = notificationTypeIconSpec(
+        NotificationKind.listAdd,
+        colors: dark,
+      );
       expect(spec.icon, equals(DivineIconName.listPlus));
-      expect(spec.background, equals(VineTheme.accentYellowBackground));
-      expect(spec.foreground, equals(VineTheme.accentYellow));
+      expect(spec.background, equals(dark.accentChipYellow.container));
+      expect(spec.foreground, equals(dark.accentChipYellow.onContainer));
     });
 
     test('system uses logo on the primary accent', () {
-      final spec = notificationTypeIconSpec(NotificationKind.system);
+      final spec = notificationTypeIconSpec(
+        NotificationKind.system,
+        colors: dark,
+      );
       expect(spec.icon, equals(DivineIconName.logo));
       expect(spec.background, equals(VineTheme.onPrimaryButton));
       expect(spec.foreground, equals(VineTheme.primary));
+    });
+
+    test('the dark palette keeps the pre-light-mode accent constants', () {
+      final spec = notificationTypeIconSpec(
+        NotificationKind.like,
+        colors: dark,
+      );
+      expect(spec.background, equals(VineTheme.accentPinkBackground));
+      expect(spec.foreground, equals(VineTheme.accentPink));
+    });
+
+    test('accent chips follow the light palette', () {
+      final spec = notificationTypeIconSpec(
+        NotificationKind.follow,
+        colors: VineTheme.lightColors,
+      );
+      expect(
+        spec.background,
+        equals(VineTheme.lightColors.accentChipLime.container),
+      );
+      expect(
+        spec.foreground,
+        equals(VineTheme.lightColors.accentChipLime.onContainer),
+      );
+      expect(spec.background, isNot(VineTheme.accentLimeBackground));
     });
 
     test('every NotificationKind is covered by the switch', () {
@@ -93,7 +151,10 @@ void main() {
         // Throws if any enum case were missing — the switch is exhaustive
         // by construction, but this ensures the contract still holds when
         // a future enum case is added without updating the helper.
-        expect(notificationTypeIconSpec(kind), isA<NotificationTypeIconSpec>());
+        expect(
+          notificationTypeIconSpec(kind, colors: dark),
+          isA<NotificationTypeIconSpec>(),
+        );
       }
     });
   });

--- a/mobile/test/notifications/widgets/notification_type_icon_spec_test.dart
+++ b/mobile/test/notifications/widgets/notification_type_icon_spec_test.dart
@@ -117,8 +117,28 @@ void main() {
         colors: dark,
       );
       expect(spec.icon, equals(DivineIconName.logo));
+      expect(spec.background, equals(dark.accentChipGreen.container));
+      expect(spec.foreground, equals(dark.accentChipGreen.onContainer));
+      // Dark parity: the chip must still resolve to the constants the
+      // switch arm carried before it moved onto the palette.
       expect(spec.background, equals(VineTheme.onPrimaryButton));
       expect(spec.foreground, equals(VineTheme.primary));
+    });
+
+    test('the system chip follows the light palette', () {
+      // It used to be the one arm left on dark-only constants, so on a light
+      // notification row it rendered as a near-black blob while every other
+      // chip lightened.
+      final spec = notificationTypeIconSpec(
+        NotificationKind.system,
+        colors: VineTheme.lightColors,
+      );
+      expect(
+        spec.background,
+        equals(VineTheme.lightColors.accentChipGreen.container),
+      );
+      expect(spec.background, isNot(VineTheme.onPrimaryButton));
+      expect(spec.foreground, isNot(VineTheme.primary));
     });
 
     test('the dark palette keeps the pre-light-mode accent constants', () {

--- a/mobile/test/providers/feature_flag_provider_test.dart
+++ b/mobile/test/providers/feature_flag_provider_test.dart
@@ -145,7 +145,7 @@ void main() {
 
     test('gates internal flag overrides on developer mode', () async {
       SharedPreferences.setMockInitialValues(<String, Object>{
-        'ff_adaptiveMediaChrome': true,
+        'ff_communityContentWarnings': true,
         'ff_enhancedAnalytics': true,
       });
       final prefs = await SharedPreferences.getInstance();
@@ -161,9 +161,9 @@ void main() {
       final service = container.read(featureFlagServiceProvider);
       await service.initialize();
 
-      expect(service.isEnabled(FeatureFlag.adaptiveMediaChrome), isFalse);
+      expect(service.isEnabled(FeatureFlag.communityContentWarnings), isFalse);
       expect(service.isEnabled(FeatureFlag.enhancedAnalytics), isTrue);
-      expect(prefs.getBool('ff_adaptiveMediaChrome'), isTrue);
+      expect(prefs.getBool('ff_communityContentWarnings'), isTrue);
 
       await environment.enableDeveloperMode();
       await pumpEventQueue();
@@ -173,13 +173,13 @@ void main() {
         isTrue,
         reason: 'a new instance would strand every ref.read capture',
       );
-      expect(service.isEnabled(FeatureFlag.adaptiveMediaChrome), isTrue);
+      expect(service.isEnabled(FeatureFlag.communityContentWarnings), isTrue);
 
       await environment.disableDeveloperMode();
       await pumpEventQueue();
 
-      expect(service.isEnabled(FeatureFlag.adaptiveMediaChrome), isFalse);
-      expect(prefs.getBool('ff_adaptiveMediaChrome'), isTrue);
+      expect(service.isEnabled(FeatureFlag.communityContentWarnings), isFalse);
+      expect(prefs.getBool('ff_communityContentWarnings'), isTrue);
     });
   });
 }

--- a/mobile/test/screens/feature_flag_screen_test.dart
+++ b/mobile/test/screens/feature_flag_screen_test.dart
@@ -89,7 +89,7 @@ void main() {
         findsOneWidget,
       );
       expect(
-        find.text(FeatureFlag.adaptiveMediaChrome.displayName),
+        find.text(FeatureFlag.communityContentWarnings.displayName),
         findsNothing,
       );
       expect(
@@ -115,7 +115,7 @@ void main() {
         findsOneWidget,
       );
       expect(
-        find.text(FeatureFlag.adaptiveMediaChrome.displayName),
+        find.text(FeatureFlag.communityContentWarnings.displayName),
         findsOneWidget,
       );
       expect(

--- a/mobile/test/screens/settings/settings_taxonomy_test.dart
+++ b/mobile/test/screens/settings/settings_taxonomy_test.dart
@@ -298,7 +298,6 @@ void main() {
     expect(find.text('Closed Captions'), findsOneWidget);
     expect(find.text('Square videos only'), findsOneWidget);
     expect(find.text('App Language'), findsOneWidget);
-    expect(find.text('Appearance'), findsNothing);
     await tester.scrollUntilVisible(
       find.text('Make my audio available for reuse'),
       120,
@@ -344,20 +343,12 @@ void main() {
     );
   });
 
-  testWidgets('General Settings shows Appearance when Light Mode is enabled', (
-    tester,
-  ) async {
+  testWidgets('General Settings always shows Appearance', (tester) async {
     await setStandardSurface(tester);
-    await tester.pumpWidget(
-      wrap(
-        const GeneralSettingsScreen(),
-        overrides: [
-          isFeatureEnabledProvider(
-            FeatureFlag.lightMode,
-          ).overrideWithValue(true),
-        ],
-      ),
-    );
+    // No override: the row used to be gated on FeatureFlag.lightMode. It is
+    // unconditional now, so pumping with the default provider set must still
+    // find it.
+    await tester.pumpWidget(wrap(const GeneralSettingsScreen()));
     await tester.pumpAndSettle();
 
     await tester.scrollUntilVisible(

--- a/mobile/test/services/build_config_test.dart
+++ b/mobile/test/services/build_config_test.dart
@@ -25,8 +25,7 @@ void main() {
       // When the env vars are not set, these flags default to false
       expect(config.getDefault(FeatureFlag.accountSwitching), isFalse);
       expect(config.getDefault(FeatureFlag.enhancedAnalytics), isFalse);
-      expect(config.getDefault(FeatureFlag.lightMode), isFalse);
-      expect(config.getDefault(FeatureFlag.adaptiveMediaChrome), isFalse);
+      expect(config.getDefault(FeatureFlag.divineSupporters), isFalse);
     });
 
     test('should have debug tools enabled by default in debug builds', () {
@@ -82,12 +81,8 @@ void main() {
         equals('FF_VIDEO_REPLIES'),
       );
       expect(
-        config.getEnvironmentKey(FeatureFlag.lightMode),
-        equals('FF_LIGHT_MODE'),
-      );
-      expect(
-        config.getEnvironmentKey(FeatureFlag.adaptiveMediaChrome),
-        equals('FF_ADAPTIVE_MEDIA_CHROME'),
+        config.getEnvironmentKey(FeatureFlag.divineSupporters),
+        equals('FF_DIVINE_SUPPORTERS'),
       );
     });
 

--- a/mobile/test/services/feature_flag_service_test.dart
+++ b/mobile/test/services/feature_flag_service_test.dart
@@ -67,22 +67,25 @@ void main() {
         'ignores persisted internal flag overrides when internal access is off',
         () async {
           when(
-            () => mockPrefs.getBool('ff_adaptiveMediaChrome'),
+            () => mockPrefs.getBool('ff_communityContentWarnings'),
           ).thenReturn(true);
           when(
-            () => mockPrefs.containsKey('ff_adaptiveMediaChrome'),
+            () => mockPrefs.containsKey('ff_communityContentWarnings'),
           ).thenReturn(true);
 
           await service.initialize();
 
-          expect(service.isEnabled(FeatureFlag.adaptiveMediaChrome), isFalse);
           expect(
-            service.hasUserOverride(FeatureFlag.adaptiveMediaChrome),
+            service.isEnabled(FeatureFlag.communityContentWarnings),
+            isFalse,
+          );
+          expect(
+            service.hasUserOverride(FeatureFlag.communityContentWarnings),
             isFalse,
           );
           // Ignored, not deleted — the choice is honoured again if the flag is
           // promoted back to a user audience or internal access is restored.
-          verifyNever(() => mockPrefs.remove('ff_adaptiveMediaChrome'));
+          verifyNever(() => mockPrefs.remove('ff_communityContentWarnings'));
         },
       );
 
@@ -95,20 +98,23 @@ void main() {
             canOverrideInternalFlags: () => true,
           );
           when(
-            () => mockPrefs.getBool('ff_adaptiveMediaChrome'),
+            () => mockPrefs.getBool('ff_communityContentWarnings'),
           ).thenReturn(true);
           when(
-            () => mockPrefs.containsKey('ff_adaptiveMediaChrome'),
+            () => mockPrefs.containsKey('ff_communityContentWarnings'),
           ).thenReturn(true);
 
           await service.initialize();
 
-          expect(service.isEnabled(FeatureFlag.adaptiveMediaChrome), isTrue);
           expect(
-            service.hasUserOverride(FeatureFlag.adaptiveMediaChrome),
+            service.isEnabled(FeatureFlag.communityContentWarnings),
             isTrue,
           );
-          verifyNever(() => mockPrefs.remove('ff_adaptiveMediaChrome'));
+          expect(
+            service.hasUserOverride(FeatureFlag.communityContentWarnings),
+            isTrue,
+          );
+          verifyNever(() => mockPrefs.remove('ff_communityContentWarnings'));
         },
       );
 
@@ -144,11 +150,16 @@ void main() {
       test(
         'should not persist internal flags when internal access is off',
         () async {
-          await service.setFlag(FeatureFlag.adaptiveMediaChrome, true);
+          await service.setFlag(FeatureFlag.communityContentWarnings, true);
 
-          verifyNever(() => mockPrefs.setBool('ff_adaptiveMediaChrome', true));
-          verifyNever(() => mockPrefs.remove('ff_adaptiveMediaChrome'));
-          expect(service.isEnabled(FeatureFlag.adaptiveMediaChrome), isFalse);
+          verifyNever(
+            () => mockPrefs.setBool('ff_communityContentWarnings', true),
+          );
+          verifyNever(() => mockPrefs.remove('ff_communityContentWarnings'));
+          expect(
+            service.isEnabled(FeatureFlag.communityContentWarnings),
+            isFalse,
+          );
         },
       );
 
@@ -161,12 +172,15 @@ void main() {
             canOverrideInternalFlags: () => true,
           );
 
-          await service.setFlag(FeatureFlag.adaptiveMediaChrome, true);
+          await service.setFlag(FeatureFlag.communityContentWarnings, true);
 
           verify(
-            () => mockPrefs.setBool('ff_adaptiveMediaChrome', true),
+            () => mockPrefs.setBool('ff_communityContentWarnings', true),
           ).called(1);
-          expect(service.isEnabled(FeatureFlag.adaptiveMediaChrome), isTrue);
+          expect(
+            service.isEnabled(FeatureFlag.communityContentWarnings),
+            isTrue,
+          );
         },
       );
 
@@ -215,19 +229,22 @@ void main() {
         'preserves internal flag overrides when resetting all without access',
         () async {
           when(
-            () => mockPrefs.getBool('ff_adaptiveMediaChrome'),
+            () => mockPrefs.getBool('ff_communityContentWarnings'),
           ).thenReturn(true);
           when(
-            () => mockPrefs.containsKey('ff_adaptiveMediaChrome'),
+            () => mockPrefs.containsKey('ff_communityContentWarnings'),
           ).thenReturn(true);
 
           await service.initialize();
           await service.resetAllFlags();
 
-          verifyNever(() => mockPrefs.remove('ff_adaptiveMediaChrome'));
-          expect(service.isEnabled(FeatureFlag.adaptiveMediaChrome), isFalse);
+          verifyNever(() => mockPrefs.remove('ff_communityContentWarnings'));
           expect(
-            service.hasUserOverride(FeatureFlag.adaptiveMediaChrome),
+            service.isEnabled(FeatureFlag.communityContentWarnings),
+            isFalse,
+          );
+          expect(
+            service.hasUserOverride(FeatureFlag.communityContentWarnings),
             isFalse,
           );
         },
@@ -235,16 +252,21 @@ void main() {
     });
 
     group('state queries', () {
-      test('exposes light mode and media chrome metadata', () {
-        final lightMode = service.getFlagMetadata(FeatureFlag.lightMode);
-        final adaptiveMedia = service.getFlagMetadata(
-          FeatureFlag.adaptiveMediaChrome,
+      test('exposes user and internal flag metadata', () {
+        final supporters = service.getFlagMetadata(
+          FeatureFlag.divineSupporters,
+        );
+        final contentWarnings = service.getFlagMetadata(
+          FeatureFlag.communityContentWarnings,
         );
 
-        expect(lightMode.flag.displayName, equals('Light Mode'));
-        expect(adaptiveMedia.flag.displayName, equals('Adaptive Media Chrome'));
-        expect(lightMode.isEnabled, isFalse);
-        expect(adaptiveMedia.isEnabled, isFalse);
+        expect(supporters.flag.displayName, equals('Divine Supporters'));
+        expect(
+          contentWarnings.flag.displayName,
+          equals('Community Content Warnings'),
+        );
+        expect(supporters.isEnabled, isFalse);
+        expect(contentWarnings.isEnabled, isFalse);
       });
 
       test('should identify user overrides', () async {

--- a/mobile/test/widgets/video_feed_item/feed_playback_toggles_pill_test.dart
+++ b/mobile/test/widgets/video_feed_item/feed_playback_toggles_pill_test.dart
@@ -6,8 +6,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/blocs/video_volume/video_volume_cubit.dart';
-import 'package:openvine/features/feature_flags/models/feature_flag.dart';
-import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/subtitle_providers.dart';
@@ -42,7 +40,6 @@ void main() {
     Widget buildSubject({
       bool reducedMotion = false,
       bool provideAutoAdvance = true,
-      bool adaptiveMediaChrome = false,
       ThemeData? theme,
       String? videoId,
     }) {
@@ -64,12 +61,7 @@ void main() {
             );
 
       return ProviderScope(
-        overrides: [
-          sharedPreferencesProvider.overrideWithValue(mockPrefs),
-          isFeatureEnabledProvider(
-            FeatureFlag.adaptiveMediaChrome,
-          ).overrideWithValue(adaptiveMediaChrome),
-        ],
+        overrides: [sharedPreferencesProvider.overrideWithValue(mockPrefs)],
         child: MaterialApp(
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
@@ -113,11 +105,9 @@ void main() {
     });
 
     testWidgets(
-      'uses light media chrome when adaptive chrome flag is enabled',
+      'uses light media chrome under the light theme',
       (tester) async {
-        await tester.pumpWidget(
-          buildSubject(adaptiveMediaChrome: true, theme: VineTheme.lightTheme),
-        );
+        await tester.pumpWidget(buildSubject(theme: VineTheme.lightTheme));
 
         final chromeBox = tester
             .widgetList<DecoratedBox>(find.byType(DecoratedBox))
@@ -330,6 +320,29 @@ void main() {
         findsNothing,
       );
       expect(find.bySemanticsLabel(l10n.videoPlayerMute), findsOneWidget);
+    });
+
+    testWidgets('keeps the scrim-30 capsule under the dark theme', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildSubject(theme: VineTheme.theme));
+
+      expect(
+        tester
+            .widgetList<DecoratedBox>(find.byType(DecoratedBox))
+            .where(
+              (box) =>
+                  box.decoration is BoxDecoration &&
+                  (box.decoration as BoxDecoration).color == VineTheme.scrim30,
+            ),
+        isNotEmpty,
+      );
+      expect(
+        tester
+            .widgetList<DivineIcon>(find.byType(DivineIcon))
+            .map((i) => i.color),
+        everyElement(equals(VineTheme.onSurface)),
+      );
     });
   });
 }


### PR DESCRIPTION
Closes #7525

## What

Light mode becomes a plain user setting. Settings → General → Appearance offers System / Light / Dark, with no feature flag in front of it. Dark stays the default.

The appearance feature was already fully built and shipped — themes, cubit, repository, persistence, the full-screen picker, root wiring, l10n — and reachable only behind `FeatureFlag.lightMode`, default off. Removing the gate on its own would have exposed a partially-migrated light palette, so this PR finishes the migration first and ungates last.

## Commits

1. **`feat(theme)`** — three new adaptive token families
2. **`fix(theme)`** — migrate remaining adaptive surfaces to semantic tokens
3. **`feat(settings)`** — remove both feature flags
4. **`docs`** — replace the "dark-mode only" rule with the two-appearance contract

## Why the migration was needed

Three families still resolved from static dark constants, so they were correct in dark and broken on the warm off-white canvas:

| | Dark | Light before | Fix |
|---|---|---|---|
| Accent chips (notification icons, badge pills) | deep tint + bright accent | dark blob on a light page | `VineAccentChip` pairs, pale tint + darkened accent |
| `vineGreenLight` icons on circular affordances | 15:1 | **1.01:1 — invisible** | `onIconButton` |
| Ghost button fill (`scrim65`) | 65% black wash | near-black pill | `ghostFill` |

`VineAccentChip` keeps the container and its content colour in one value so a call site cannot mismatch them.

Contrast was computed, not eyeballed. Light chips clear 4.5:1 foreground-on-container (6.30–7.51) and hold 1.18–1.30 container-on-page, which overlaps the dark palette's own low end (pink, 1.28). `onIconButton` clears 5.61:1 on `surfaceContainer` and 5.78:1 on `iconButton`.

## Dark mode is unchanged

Every new token's dark value is the constant it replaces. Verified mechanically, not by reading the diff:

```
dart run scripts/check_dark_value_parity.dart --base origin/main
→ 40 replacement(s) compared, 0 dark mismatch(es), 36 left for manual review
```

The guard caught three real dark regressions mid-work, all fixed rather than accepted:

- a description over a video scrim that would have shifted `#FFBBBBBB → #FFFFFFFF`
- ghost button fill in `divine_button` / `divine_icon_button`, where a translucent 65% scrim would have become an opaque `#FF032017`

**What the guard cannot prove.** It compares dark values only, so two tokens sharing a dark value are interchangeable to it — picking the wrong one passes here and diverges only in light. Five such pairs exist today (`iconButtonBackground` / `surfaceContainer` / `skeletonBase` are all `#FF032017`). Those call sites were chosen by intent and reviewed by hand; they are not machine-verified. The 36 "left for manual review" hunks are the structurally unpairable ones — chip pairs (a `VineAccentChip` never lands in the guard's flat-colour map), one 1→2 split in `message_bubble`, and the nullable-default refactor in `DivineRangeSlider` — each checked against `darkColors` by hand.

## Migration rule

What sits *underneath*, not what the widget is. Content over video, over a scrim or gradient, on the camera/editor canvas, or on a filled brand colour keeps its fixed constant. Everything on a page, card, sheet or list row moves to `context.vineColors`.

Roughly 290 candidate call sites were triaged; ~60 migrated and the rest deliberately left fixed. In the fullscreen feed specifically, 7 of 76 moved — that area is fixed-dark by design.

## Bugs fixed that the review did not ask for

Flagging separately, since they are outside the literal ask:

- **`user_list_people_screen`** — an earlier migration wave had converted the over-video header's title and description to adaptive tokens, so in light mode they would render dark ink on a dark scrim. Reverted to fixed, and the two sibling sites now name the fixed over-media ink explicitly.
- **Ghost button foreground** — carried a fixed light foreground on what is now an adaptive fill; invisible once the fill lightened.
- **`DivineRangeSlider`** — two params widened `Color` → `Color?` so they resolve from the palette, matching `DivineSlider`, whose shape it already mirrored elsewhere. Existing callers still compile.

## Adaptive media chrome

`FeatureFlag.adaptiveMediaChrome` is removed too, so the playback pill uses light chrome whenever the resolved theme is light. Its widget drops to a plain `StatelessWidget` now that nothing in it reads a provider. **This changes fullscreen playback appearance in light mode** — calling it out because it has user-visible blast radius beyond the settings row.

## Flag-machinery tests

Several tests used these two flags purely as sample user/internal flags. They are repointed at `divineSupporters` and `communityContentWarnings` rather than deleted. `feature_flag_test` now asserts neither name comes back, so a reintroduced gate fails the build.

## Verification

- `flutter analyze lib test integration_test` — clean
- `flutter test` (full mobile suite) — **16,969 passed, 0 failed**, 305 skipped (pre-existing)
- `flutter test` (divine_ui, 100% coverage gate) — 892 passed
- `check_dark_value_parity.dart --base origin/main` — 0 mismatches
- Rebased onto `origin/main` (`0a87d388f1`) and re-ran analyze, the parity guard, and the full suite against the new base

**Not verified:** no screenshots. I could not launch the app in this session, so the light palette has been checked by computed contrast ratios and by widget tests that pump real screens under `VineTheme.lightTheme` and sample pixels — not by looking at it. Someone should eyeball light mode on device before merge, particularly the notification list, badge pills, and fullscreen playback chrome.

There are also **no light-mode goldens** in the repo (the only tracked goldens are notification rows and video aspect ratios), so nothing pins these surfaces visually against future drift.

## Docs

Seven places asserted "Divine is dark-mode only" — the single most misleading line in the guidance once this lands, since following it reproduces exactly these bugs. All updated. `ui_theming.md` gains the decision table, the three traps that cost the most time here, and how to verify dark did not change. Historical spec/plan docs under `docs/superpowers/` are left alone as records of what was true when written.