### PR TITLE
fix(video-editor): bump pro_video_editor to 2.11.3 for the cancelled-export crash

### DIFF
--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1832,10 +1832,10 @@ packages:
     dependency: "direct main"
     description:
       name: pro_video_editor
-      sha256: "80adbf5eb40b92c7b889e10feb4fd422cbdd2ffa3c39b3672bfd2810c8b49725"
+      sha256: "2c2ab71dc8d34e4554ad9c64f5bfb774853a4111542ff21f9d886c55bc556103"
       url: "https://pub.dev"
     source: hosted
-    version: "2.11.2"
+    version: "2.11.3"
   process:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -344,7 +344,7 @@ dependencies:
   # extra Flutter-specific native SQLite providers can make plain SQLite win.
   sqlite3: ^3.3.3
   audio_session: ^0.2.2
-  pro_video_editor: ^2.11.2
+  pro_video_editor: ^2.11.3
   pro_image_editor: ^13.3.1
   flutter_colorpicker: ^1.1.0
   file_picker: ^10.3.7


### PR DESCRIPTION
Closes #7532

## Description

Bumps `pro_video_editor` from 2.11.2 to 2.11.3, which closes a fatal crash in the video editor on iOS/iPadOS.

Cancelling a render or split while its export was still queued for the encoder gate reached `cancelExport()` on an `AVAssetExportSession` that had never run. `.cancelled` counts as "started", so when the gate later let the queued job through, `export(to:as:)` assigned `outputURL` on a session that had already left `.unknown` — AVFoundation answers that assignment with an Objective-C `NSInternalInconsistencyException`, which Swift cannot catch from an async context, so it took the whole app down.

Crashlytics (iOS, last 30 days): [35 events across 7 users](https://console.firebase.google.com/v1/appid/project/openvine-co/crashlytics/app/1:972941478875:ios:f61272b3cf485df244b5fe/issues/b0914a639eb5e4b996dec3e8f1147a4b), first seen in 1.0.16 and still live in 1.0.19. Every sample lands within seconds of the editor being opened and dismissed again — the last breadcrumb is `editor_opened { mode: capture }` — and the blame frame is the plugin's own `ExportWatchdog.swift:90`.

The 2.11.3 release also removes the half-written file a cancelled or failed export used to leave behind, unwinds a cancelled render at the HDR pre-transcode or transition pre-render it is in instead of building the whole composition first, and stops a cancelled audio merge from running its container to completion. Full notes: [pro_video_editor 2.11.3 changelog](https://pub.dev/packages/pro_video_editor/changelog).

**Why no app-side change:** the package's Dart `lib/` is byte-identical between 2.11.2 and 2.11.3 (verified with `diff -rq` over both pub-cache copies). The fix is entirely in the Darwin native layer, so the version constraint and the lockfile are the whole diff.

**Related Issue:**  — I searched open and closed issues for this crash and found none; it was triaged straight from Crashlytics.

## Out of Scope

The other open video-editor Crashlytics issues are untouched: the `BitrateCappedExporter` `AVAssetWriterInput ... status is 4` crash (last seen 1.0.17) and the `_TimelineOverlayStripState` `Invalid argument(s): 0` crashes, which are app-side.

## Verification

- `flutter pub get` — resolved cleanly to 2.11.3
- `flutter analyze lib test integration_test` — no issues
- `diff -rq` between the 2.11.2 and 2.11.3 pub-cache `lib/` trees — identical, so no Dart surface changed and no test is affected



## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore