### PR TITLE
fix(auth): normalize email before Keycast auth

### DIFF
--- a/mobile/lib/blocs/divine_auth/divine_auth_cubit.dart
+++ b/mobile/lib/blocs/divine_auth/divine_auth_cubit.dart
@@ -183,10 +183,11 @@ class DivineAuthCubit extends Cubit<DivineAuthState>
     );
 
     try {
+      final email = Validators.normalizeAuthEmail(current.email);
       if (current.isSignIn) {
-        await _handleSignIn(current.email, current.password);
+        await _handleSignIn(email, current.password);
       } else {
-        await _handleSignUp(current.email, current.password);
+        await _handleSignUp(email, current.password);
       }
     } catch (e, stackTrace) {
       Log.error(
@@ -431,14 +432,15 @@ class DivineAuthCubit extends Cubit<DivineAuthState>
 
   /// Send password reset email
   Future<void> sendPasswordResetEmail(String email) async {
+    final normalizedEmail = Validators.normalizeAuthEmail(email);
     Log.info(
-      'Sending password reset email to ${redactEmailForLogs(email)}',
+      'Sending password reset email to ${redactEmailForLogs(normalizedEmail)}',
       name: 'DivineAuthCubit',
       category: LogCategory.auth,
     );
 
     try {
-      final result = await _oauthClient.sendPasswordResetEmail(email);
+      final result = await _oauthClient.sendPasswordResetEmail(normalizedEmail);
 
       if (!result.success) {
         Log.warning(

--- a/mobile/lib/utils/validators.dart
+++ b/mobile/lib/utils/validators.dart
@@ -61,6 +61,8 @@ enum PasswordValidationError { missing, tooShort }
 enum ConfirmPasswordValidationError { missing, mismatch }
 
 class Validators {
+  static String normalizeAuthEmail(String value) => value.trim().toLowerCase();
+
   static String? validateEmail(
     String? value, {
     required AuthValidationMessages messages,

--- a/mobile/test/blocs/divine_auth/divine_auth_cubit_test.dart
+++ b/mobile/test/blocs/divine_auth/divine_auth_cubit_test.dart
@@ -385,6 +385,51 @@ void main() {
           },
         );
 
+        blocTest<DivineAuthCubit, DivineAuthState>(
+          'normalizes email before sign in',
+          setUp: () {
+            when(
+              () => mockOAuth.headlessLogin(
+                email: any(named: 'email'),
+                password: any(named: 'password'),
+                scope: any(named: 'scope'),
+              ),
+            ).thenAnswer(
+              (_) async => (
+                HeadlessLoginResult(success: true, code: testCode),
+                testVerifier,
+              ),
+            );
+            when(
+              () => mockOAuth.exchangeCode(
+                code: any(named: 'code'),
+                verifier: any(named: 'verifier'),
+              ),
+            ).thenAnswer(
+              (_) async => const TokenResponse(bunkerUrl: 'bunker://test'),
+            );
+            when(
+              () => mockAuthService.signInWithDivineOAuth(any()),
+            ).thenAnswer((_) async {});
+          },
+          build: buildCubit,
+          seed: () => const DivineAuthFormState(
+            email: ' Test@Example.com ',
+            password: testPassword,
+            isSignIn: true,
+          ),
+          act: (cubit) => cubit.submit(),
+          verify: (_) {
+            verify(
+              () => mockOAuth.headlessLogin(
+                email: testEmail,
+                password: testPassword,
+                scope: 'policy:full',
+              ),
+            ).called(1);
+          },
+        );
+
         test(
           'closing mid-sign-in reports no error to the bloc observer',
           () async {
@@ -1046,6 +1091,61 @@ void main() {
         );
 
         blocTest<DivineAuthCubit, DivineAuthState>(
+          'normalizes email before sign up and pending verification',
+          setUp: () {
+            when(
+              () => mockOAuth.headlessRegister(
+                email: any(named: 'email'),
+                password: any(named: 'password'),
+                scope: any(named: 'scope'),
+              ),
+            ).thenAnswer(
+              (_) async => (
+                HeadlessRegisterResult(
+                  success: true,
+                  pubkey: 'test-pubkey',
+                  verificationRequired: true,
+                  deviceCode: testDeviceCode,
+                  email: testEmail,
+                ),
+                testVerifier,
+              ),
+            );
+            when(
+              () => mockPendingVerification.save(
+                deviceCode: any(named: 'deviceCode'),
+                verifier: any(named: 'verifier'),
+                email: any(named: 'email'),
+                inviteCode: any(named: 'inviteCode'),
+              ),
+            ).thenAnswer((_) async {});
+          },
+          build: buildCubit,
+          seed: () => const DivineAuthFormState(
+            email: ' Test@Example.com ',
+            password: testPassword,
+          ),
+          act: (cubit) => cubit.submit(),
+          verify: (_) {
+            verify(
+              () => mockOAuth.headlessRegister(
+                email: testEmail,
+                password: testPassword,
+                scope: 'policy:full',
+              ),
+            ).called(1);
+            verify(
+              () => mockPendingVerification.save(
+                deviceCode: testDeviceCode,
+                verifier: testVerifier,
+                email: testEmail,
+                inviteCode: any(named: 'inviteCode'),
+              ),
+            ).called(1);
+          },
+        );
+
+        blocTest<DivineAuthCubit, DivineAuthState>(
           'persists invite code with pending verification data',
           setUp: () {
             when(
@@ -1627,6 +1727,21 @@ void main() {
         },
         build: buildCubit,
         act: (cubit) => cubit.sendPasswordResetEmail(testEmail),
+        expect: () => <DivineAuthState>[],
+        verify: (_) {
+          verify(() => mockOAuth.sendPasswordResetEmail(testEmail)).called(1);
+        },
+      );
+
+      blocTest<DivineAuthCubit, DivineAuthState>(
+        'normalizes email before password reset',
+        setUp: () {
+          when(
+            () => mockOAuth.sendPasswordResetEmail(any()),
+          ).thenAnswer((_) async => ForgotPasswordResult(success: true));
+        },
+        build: buildCubit,
+        act: (cubit) => cubit.sendPasswordResetEmail(' Test@Example.com '),
         expect: () => <DivineAuthState>[],
         verify: (_) {
           verify(() => mockOAuth.sendPasswordResetEmail(testEmail)).called(1);

--- a/mobile/test/utils/validators_test.dart
+++ b/mobile/test/utils/validators_test.dart
@@ -7,6 +7,15 @@ void main() {
   const messages = AuthValidationMessages.englishDefaults;
 
   group(Validators, () {
+    group('normalizeAuthEmail', () {
+      test('trims and lowercases email before auth submission', () {
+        expect(
+          Validators.normalizeAuthEmail(' Person@Example.com '),
+          equals('person@example.com'),
+        );
+      });
+    });
+
     group('validateEmail', () {
       test('rejects malformed domains with consecutive dots', () {
         expect(


### PR DESCRIPTION
## Description

Normalize auth email input before sending it to Keycast for sign-in, sign-up, and password reset. This keeps field editing unchanged while aligning the submission boundary with the validation and registration normalization behavior.

**Related Issue:** Relates to #7528; Relates to #6715

## Out of Scope

Keycast server-side normalization remains a separate repo fix.

## Verification

- `dart format --output=none --set-exit-if-changed lib test integration_test tools`
- `flutter analyze lib test integration_test tools`
- `flutter test test/blocs/divine_auth/divine_auth_cubit_test.dart test/utils/validators_test.dart`: 77 tests passed
- GitHub Mobile CI: Analyze, Format, Generated Files, all four test shards, and the aggregate Mobile CI check passed

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
