### PR TITLE
fix(support): avoid broken bare blob fallback

### DIFF
--- a/mobile/lib/extensions/video_event_extensions.dart
+++ b/mobile/lib/extensions/video_event_extensions.dart
@@ -179,7 +179,7 @@ extension VideoEventAppExtensions on VideoEvent {
   ///   raw-only uploads too: their `imeta` lists only the raw blob because it
   ///   is a publish-time snapshot taken before the derivatives transcode, but
   ///   by playback time the 720p.mp4 almost always exists, and the runtime
-  ///   fallback chain drops to the raw blob when it does not yet.
+  ///   fallback chain tries HLS while the derivative finishes processing.
   ///
   /// Non-Divine videos always use original (no transcoded variants exist).
   String? getOptimalVideoUrlForPlatform() {
@@ -215,8 +215,7 @@ extension VideoEventAppExtensions on VideoEvent {
     // Production default: progressive MP4 720p (faststart). Fastest startup
     // (1 request, moov at front), correct colors on all platforms, and 3-8x
     // smaller than the raw blob. Raw-only uploads take this path too; the
-    // runtime fallback chain drops to the raw blob if the 720p.mp4 is not
-    // transcoded yet.
+    // runtime fallback chain tries HLS if the 720p.mp4 is not transcoded yet.
     //
     // Classic Vine originals take this path as well. They must never be sent
     // to the bare blob: every Range request to `/{hash}` comes back as a

--- a/mobile/lib/extensions/video_event_extensions.dart
+++ b/mobile/lib/extensions/video_event_extensions.dart
@@ -178,8 +178,9 @@ extension VideoEventAppExtensions on VideoEvent {
   ///   manifest overhead) — it is 3-8x smaller than the raw blob. This covers
   ///   raw-only uploads too: their `imeta` lists only the raw blob because it
   ///   is a publish-time snapshot taken before the derivatives transcode, but
-  ///   by playback time the 720p.mp4 almost always exists, and the runtime
-  ///   fallback chain tries HLS while the derivative finishes processing.
+  ///   by playback time the 720p.mp4 almost always exists. Until
+  ///   divine-blossom#198 is fixed, playback waits for transcoding if neither
+  ///   MP4 nor HLS is ready because the broken bare fallback is withheld.
   ///
   /// Non-Divine videos always use original (no transcoded variants exist).
   String? getOptimalVideoUrlForPlatform() {
@@ -214,8 +215,9 @@ extension VideoEventAppExtensions on VideoEvent {
 
     // Production default: progressive MP4 720p (faststart). Fastest startup
     // (1 request, moov at front), correct colors on all platforms, and 3-8x
-    // smaller than the raw blob. Raw-only uploads take this path too; the
-    // runtime fallback chain tries HLS if the 720p.mp4 is not transcoded yet.
+    // smaller than the raw blob. Raw-only uploads take this path too. Until
+    // divine-blossom#198 is fixed, playback waits for transcoding if neither
+    // MP4 nor HLS is ready because the broken bare fallback is withheld.
     //
     // Classic Vine originals take this path as well. They must never be sent
     // to the bare blob: every Range request to `/{hash}` comes back as a

--- a/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
+++ b/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
@@ -1468,8 +1468,10 @@ internal class DivineVideoPlayerInstance(
         }
 
         override fun onPlayerError(error: PlaybackException) {
+            val currentUri = player?.currentMediaItem?.localConfiguration?.uri
             DivineVideoPlayerLog.error(
                 "Player $playerId playback error [${error.errorCodeName}]: " +
+                    "source=${currentUri ?: "unknown"} " +
                     (error.message ?: "unknown"),
                 name = "DivineVideoPlayer.Playback",
             )

--- a/mobile/packages/infinite_video_feed/lib/src/services/derivative_failure_cache.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/services/derivative_failure_cache.dart
@@ -46,9 +46,7 @@ String? derivativeHashForSource(String source) {
   final hash = extractCanonicalDivineBlobHash(source);
   if (hash == null) return null;
 
-  final rawUrl = canonicalDivineBlobRawUrl(hash);
-  final hlsUrl = canonicalDivineBlobHlsUrl(hash);
-  if (source == rawUrl || source == hlsUrl || source.contains('/hls/')) {
+  if (isDivineBlobRawUrl(source) || source.contains('/hls/')) {
     return null;
   }
 

--- a/mobile/packages/infinite_video_feed/lib/src/utils/canonical_divine_url.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/utils/canonical_divine_url.dart
@@ -20,6 +20,15 @@ String? extractCanonicalDivineBlobHash(String url) {
   }
 }
 
+/// Whether [url] points directly at a Divine blob rather than a derivative.
+bool isDivineBlobRawUrl(String url) {
+  if (extractCanonicalDivineBlobHash(url) == null) return false;
+
+  final uri = Uri.tryParse(url);
+  if (uri == null) return false;
+  return uri.pathSegments.where((segment) => segment.isNotEmpty).length == 1;
+}
+
 /// Builds the canonical HLS master URL for a Divine blob [hash].
 String canonicalDivineBlobHlsUrl(String hash) =>
     'https://media.divine.video/$hash/hls/master.m3u8';

--- a/mobile/packages/infinite_video_feed/lib/src/utils/playback_sources.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/utils/playback_sources.dart
@@ -31,22 +31,27 @@ List<String> resolvePlaybackSources(
 
   final hash = extractCanonicalDivineBlobHash(resolvedSource);
   if (hash != null) {
-    final rawUrl = canonicalDivineBlobRawUrl(hash);
     final hlsUrl = canonicalDivineBlobHlsUrl(hash);
     final isAlreadyHls = resolvedSource.contains('/hls/');
     if (isAlreadyHls) {
-      final originalFallback = originalUrl == rawUrl ? null : originalUrl;
+      final originalFallback =
+          originalUrl != null && isDivineBlobRawUrl(originalUrl)
+          ? null
+          : originalUrl;
       return orderedUniqueSources([resolvedSource, originalFallback]);
     }
 
-    final isRawBlob = resolvedSource == rawUrl;
+    final isRawBlob = isDivineBlobRawUrl(resolvedSource);
     if (isRawBlob) {
       return orderedUniqueSources([resolvedSource, hlsUrl, originalUrl]);
     }
 
     // TODO(liz): Restore the bare blob fallback after divine-blossom#198
     // fixes Range support on bare blob URLs (#7184).
-    final originalFallback = originalUrl == rawUrl ? null : originalUrl;
+    final originalFallback =
+        originalUrl != null && isDivineBlobRawUrl(originalUrl)
+        ? null
+        : originalUrl;
     if (derivativeFailureCache?.hasFreshFailureForHash(hash) ?? false) {
       return orderedUniqueSources([hlsUrl, resolvedSource, originalFallback]);
     }

--- a/mobile/packages/infinite_video_feed/lib/src/utils/playback_sources.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/utils/playback_sources.dart
@@ -11,30 +11,12 @@ import 'package:models/models.dart';
 /// [VideoEvent.videoUrl]. For Divine blob URLs the list is expanded with
 /// canonical HLS and raw variants so the runtime can fail over between them.
 ///
-/// **Fallback order rationale**: when the resolved source is progressive (raw
-/// blob or `<hash>/720p.mp4`) it is attempted first and HLS is only a fallback.
-/// (When the resolved source is itself an HLS URL — a Developer Options HLS
-/// override or an HLS-only event — that HLS URL is honoured first; the
-/// progressive-first ordering below applies to raw/MP4 resolved sources.)
-/// We deliberately do NOT prefer HLS for progressive sources, for two reasons
-/// specific to Divine:
-///
-/// 1. Divine videos are short (≤ 6.3s). HLS pays a fixed startup cost — fetch
-///    the master playlist, then a media playlist, then the first segment
-///    before a single frame renders. For a clip this short that manifest
-///    round-trip overhead makes HLS noticeably slower to first frame than a
-///    single progressive MP4 request (moov at front, one round trip).
-/// 2. HLS is bad for preloading. A progressive MP4 is one cacheable file we
-///    can warm ahead of the feed; an HLS stream is a manifest tree of many
-///    segments that cannot be single-file cached, so preloading barely helps.
-///
-/// ExoPlayer/AVPlayer use a progressive source for MP4/raw URLs and only
-/// switch to an HLS source for `.m3u8` URLs. On top of the speed and
-/// preloading costs, fresh Divine uploads publish the raw/progressive blob
-/// before their HLS rendition finishes transcoding, so probing
-/// `<hash>/hls/master.m3u8` first returns a manifest with no playable video
-/// track and stalls every video. HLS is kept only as a last-resort fallback
-/// for assets whose progressive source fails to start.
+/// For derivative-resolved Divine blobs, avoid falling back to the bare blob.
+/// Until divine-blossom#198 fixes Range support on bare blob URLs, range-
+/// requesting players can receive a cached XML NoSuchKey response as HTTP 206,
+/// so derivatives should recover through other renditions and HLS instead.
+/// Keep the raw URL only when it is the resolved source, where dropping it
+/// would leave raw/classic-Vine playback with no progressive option.
 List<String> resolvePlaybackSources(
   VideoEvent video, {
   String? Function(VideoEvent video)? urlResolver,
@@ -57,26 +39,17 @@ List<String> resolvePlaybackSources(
     }
 
     final isRawBlob = resolvedSource == rawUrl;
-    // Progressive first, HLS last. For a quality variant (e.g. 720p.mp4) the
-    // guaranteed raw blob still comes before HLS so the fallback order
-    // preserves the existing "try another progressive source before paying HLS
-    // startup" behavior. The bare blob currently fails for range-requesting
-    // players until divine-blossom#198 is fixed, so HLS remains behind it as
-    // the final recovery source.
     if (isRawBlob) {
       return orderedUniqueSources([resolvedSource, hlsUrl, originalUrl]);
     }
 
+    // TODO(liz): Restore the bare blob fallback after divine-blossom#198
+    // fixes Range support on bare blob URLs (#7184).
     if (derivativeFailureCache?.hasFreshFailureForHash(hash) ?? false) {
-      return orderedUniqueSources([
-        hlsUrl,
-        rawUrl,
-        resolvedSource,
-        originalUrl,
-      ]);
+      return orderedUniqueSources([hlsUrl, resolvedSource, originalUrl]);
     }
 
-    return orderedUniqueSources([resolvedSource, rawUrl, hlsUrl, originalUrl]);
+    return orderedUniqueSources([resolvedSource, hlsUrl, originalUrl]);
   }
 
   return orderedUniqueSources([resolvedSource, originalUrl]);

--- a/mobile/packages/infinite_video_feed/lib/src/utils/playback_sources.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/utils/playback_sources.dart
@@ -9,7 +9,7 @@ import 'package:models/models.dart';
 ///
 /// When [urlResolver] is provided, its output is preferred over
 /// [VideoEvent.videoUrl]. For Divine blob URLs the list is expanded with
-/// canonical HLS and raw variants so the runtime can fail over between them.
+/// canonical alternatives so the runtime can fail over between them.
 ///
 /// For derivative-resolved Divine blobs, avoid falling back to the bare blob.
 /// Until divine-blossom#198 fixes Range support on bare blob URLs, range-
@@ -35,7 +35,8 @@ List<String> resolvePlaybackSources(
     final hlsUrl = canonicalDivineBlobHlsUrl(hash);
     final isAlreadyHls = resolvedSource.contains('/hls/');
     if (isAlreadyHls) {
-      return orderedUniqueSources([resolvedSource, rawUrl, originalUrl]);
+      final originalFallback = originalUrl == rawUrl ? null : originalUrl;
+      return orderedUniqueSources([resolvedSource, originalFallback]);
     }
 
     final isRawBlob = resolvedSource == rawUrl;
@@ -45,11 +46,12 @@ List<String> resolvePlaybackSources(
 
     // TODO(liz): Restore the bare blob fallback after divine-blossom#198
     // fixes Range support on bare blob URLs (#7184).
+    final originalFallback = originalUrl == rawUrl ? null : originalUrl;
     if (derivativeFailureCache?.hasFreshFailureForHash(hash) ?? false) {
-      return orderedUniqueSources([hlsUrl, resolvedSource, originalUrl]);
+      return orderedUniqueSources([hlsUrl, resolvedSource, originalFallback]);
     }
 
-    return orderedUniqueSources([resolvedSource, hlsUrl, originalUrl]);
+    return orderedUniqueSources([resolvedSource, hlsUrl, originalFallback]);
   }
 
   return orderedUniqueSources([resolvedSource, originalUrl]);

--- a/mobile/packages/infinite_video_feed/lib/src/utils/source_loader.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/utils/source_loader.dart
@@ -92,9 +92,8 @@ Future<(String, int)> setSourceWithFallbacks({
         Error.throwWithStackTrace(error, stackTrace);
       }
       // Only wait-and-retry a processing (HTTP 202) source when it is the last
-      // resort. While a fallback is still queued — for Divine that is always
-      // the guaranteed raw blob — prefer it immediately instead of stalling up
-      // to ~19s for a derivative that is still transcoding.
+      // resort. While another source is queued, prefer it immediately instead
+      // of stalling up to ~19s for a derivative that is still transcoding.
       final isLastSource = attemptIndex == sources.length - 1;
       if (isLastSource && isMediaProcessingError(error)) {
         for (final retryDelay in _mediaProcessingRetryDelays) {

--- a/mobile/packages/infinite_video_feed/lib/src/utils/source_loader.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/utils/source_loader.dart
@@ -48,6 +48,7 @@ Future<(String, int)> setSourceWithFallbacks({
   Duration? maxPlaybackDuration,
   SourceLoadDelay delay = Future<void>.delayed,
   void Function(String source)? onFailoverSourceFailure,
+  void Function(String source)? onSourceLoadFailure,
 }) async {
   Object? lastError;
   StackTrace? lastStackTrace;
@@ -78,6 +79,7 @@ Future<(String, int)> setSourceWithFallbacks({
       abortIfStale(source);
       lastError = error;
       lastStackTrace = stackTrace;
+      onSourceLoadFailure?.call(source);
       final nativeErrorCode = nativePlayerErrorCodeFromError(error);
       if (nativeErrorCode == NativePlayerErrorCode.authRequired) {
         log(

--- a/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
@@ -1129,6 +1129,11 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
       // coverage:ignore-end
     }
 
+    String? lastFailedSource;
+    void rememberFailedSource(String source) {
+      lastFailedSource = source;
+    }
+
     try {
       await controller.initialize();
       if (!guardInitOwnership('initialize')) return;
@@ -1198,6 +1203,7 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
             isLoadCurrent: ownsInit,
             maxPlaybackDuration: widget.maxPlaybackDuration,
             onFailoverSourceFailure: _derivativeFailures.recordFailureForSource,
+            onSourceLoadFailure: rememberFailedSource,
           );
           if (!guardInitOwnership('setSourceWithFallbacks(cache)')) return;
           _sources.register(index, playbackSources, openedSourceIdx);
@@ -1221,6 +1227,7 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
           isLoadCurrent: ownsInit,
           maxPlaybackDuration: widget.maxPlaybackDuration,
           onFailoverSourceFailure: _derivativeFailures.recordFailureForSource,
+          onSourceLoadFailure: rememberFailedSource,
         );
         if (!guardInitOwnership('setSourceWithFallbacks(network)')) return;
         _sources.register(index, playbackSources, openedSourceIdx);
@@ -1251,9 +1258,12 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
         guardInitOwnership('error handling');
         return;
       }
-      _log('Error loading index $index (${video.id}): $e');
+      final sourceDetail = lastFailedSource == null
+          ? ''
+          : ' failedSource=$lastFailedSource';
+      _log('Error loading index $index (${video.id}):$sourceDetail $e');
       Log.error(
-        'Player init failed',
+        'Player init failed$sourceDetail',
         name: _logName,
         category: LogCategory.video,
         error: e,

--- a/mobile/packages/infinite_video_feed/test/src/services/derivative_failure_cache_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/services/derivative_failure_cache_test.dart
@@ -26,6 +26,7 @@ void main() {
     test('ignores raw and HLS sources', () {
       cache
         ..recordFailureForSource(_rawUrl)
+        ..recordFailureForSource('https://cdn.divine.video/$_hash?download=1')
         ..recordFailureForSource(_hlsUrl);
 
       expect(cache.hasFreshFailureForHash(_hash), isFalse);
@@ -46,6 +47,12 @@ void main() {
     test('returns a hash only for derivative sources', () {
       expect(derivativeHashForSource(_variantUrl), equals(_hash));
       expect(derivativeHashForSource(_rawUrl), isNull);
+      expect(
+        derivativeHashForSource(
+          'https://blossom.divine.video/$_hash?download=1',
+        ),
+        isNull,
+      );
       expect(derivativeHashForSource(_hlsUrl), isNull);
       expect(derivativeHashForSource('https://example.com/video.mp4'), isNull);
     });

--- a/mobile/packages/infinite_video_feed/test/src/utils/canonical_divine_url_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/utils/canonical_divine_url_test.dart
@@ -67,6 +67,28 @@ void main() {
     });
   });
 
+  group('isDivineBlobRawUrl', () {
+    const hash =
+        'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2';
+
+    test('recognizes query-bearing and alternate-host raw blobs', () {
+      expect(
+        isDivineBlobRawUrl('https://media.divine.video/$hash?download=1'),
+        isTrue,
+      );
+      expect(isDivineBlobRawUrl('https://cdn.divine.video/$hash'), isTrue);
+      expect(isDivineBlobRawUrl('https://blossom.divine.video/$hash/'), isTrue);
+    });
+
+    test('rejects derivatives and non-Divine URLs', () {
+      expect(
+        isDivineBlobRawUrl('https://media.divine.video/$hash/720p.mp4'),
+        isFalse,
+      );
+      expect(isDivineBlobRawUrl('https://example.com/$hash'), isFalse);
+    });
+  });
+
   group('canonicalDivineBlobRawUrl', () {
     test('builds the expected raw blob URL', () {
       const hash =

--- a/mobile/packages/infinite_video_feed/test/src/utils/playback_sources_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/utils/playback_sources_test.dart
@@ -19,6 +19,8 @@ VideoEvent _makeVideo({String id = 'vid1', String? videoUrl}) => VideoEvent(
 const _hash =
     'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2';
 const _rawUrl = 'https://media.divine.video/$_hash';
+const _cdnRawUrl = 'https://cdn.divine.video/$_hash';
+const _queryRawUrl = 'https://media.divine.video/$_hash?download=1';
 const _hlsUrl = 'https://media.divine.video/$_hash/hls/master.m3u8';
 
 void main() {
@@ -69,7 +71,7 @@ void main() {
       });
 
       test('drops a raw original when the resolver selects HLS', () {
-        final video = _makeVideo(videoUrl: _rawUrl);
+        final video = _makeVideo(videoUrl: _queryRawUrl);
         final result = resolvePlaybackSources(
           video,
           urlResolver: (_) => _hlsUrl,
@@ -95,6 +97,12 @@ void main() {
         );
         expect(result, equals([_rawUrl, _hlsUrl, otherOriginal]));
       });
+
+      test('keeps a query-bearing raw URL when it is selected', () {
+        final video = _makeVideo(videoUrl: _queryRawUrl);
+
+        expect(resolvePlaybackSources(video), equals([_queryRawUrl, _hlsUrl]));
+      });
     });
 
     group('when URL is a quality-specific Divine variant', () {
@@ -109,13 +117,27 @@ void main() {
       );
 
       test('drops a raw original when the resolver selects a variant', () {
-        final video = _makeVideo(videoUrl: _rawUrl);
+        final video = _makeVideo(videoUrl: _cdnRawUrl);
         final result = resolvePlaybackSources(
           video,
           urlResolver: (_) => variantUrl,
         );
 
         expect(result, equals([variantUrl, _hlsUrl]));
+      });
+
+      test('drops an alternate-host raw original after a fresh failure', () {
+        final video = _makeVideo(videoUrl: _cdnRawUrl);
+        final cache = DerivativeFailureCache()
+          ..recordFailureForSource(variantUrl);
+
+        final result = resolvePlaybackSources(
+          video,
+          urlResolver: (_) => variantUrl,
+          derivativeFailureCache: cache,
+        );
+
+        expect(result, equals([_hlsUrl, variantUrl]));
       });
 
       test('leads with HLS without raw fallback after a fresh failure', () {

--- a/mobile/packages/infinite_video_feed/test/src/utils/playback_sources_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/utils/playback_sources_test.dart
@@ -63,13 +63,20 @@ void main() {
     });
 
     group('when URL is a canonical HLS URL', () {
-      test(
-        'returns [hlsUrl, rawUrl] deduplicated when originalUrl equals hlsUrl',
-        () {
-          final video = _makeVideo(videoUrl: _hlsUrl);
-          expect(resolvePlaybackSources(video), equals([_hlsUrl, _rawUrl]));
-        },
-      );
+      test('does not add the raw blob as a fallback', () {
+        final video = _makeVideo(videoUrl: _hlsUrl);
+        expect(resolvePlaybackSources(video), equals([_hlsUrl]));
+      });
+
+      test('drops a raw original when the resolver selects HLS', () {
+        final video = _makeVideo(videoUrl: _rawUrl);
+        final result = resolvePlaybackSources(
+          video,
+          urlResolver: (_) => _hlsUrl,
+        );
+
+        expect(result, equals([_hlsUrl]));
+      });
     });
 
     group('when URL is the raw blob URL', () {
@@ -100,6 +107,16 @@ void main() {
           expect(resolvePlaybackSources(video), equals([variantUrl, _hlsUrl]));
         },
       );
+
+      test('drops a raw original when the resolver selects a variant', () {
+        final video = _makeVideo(videoUrl: _rawUrl);
+        final result = resolvePlaybackSources(
+          video,
+          urlResolver: (_) => variantUrl,
+        );
+
+        expect(result, equals([variantUrl, _hlsUrl]));
+      });
 
       test('leads with HLS without raw fallback after a fresh failure', () {
         final video = _makeVideo(videoUrl: variantUrl);

--- a/mobile/packages/infinite_video_feed/test/src/utils/playback_sources_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/utils/playback_sources_test.dart
@@ -94,24 +94,21 @@ void main() {
       const variantUrl = 'https://media.divine.video/$_hash/720p.mp4';
 
       test(
-        'returns [variantUrl, rawUrl, hlsUrl, originalUrl] deduplicated',
+        'returns [variantUrl, hlsUrl, originalUrl] without raw fallback',
         () {
           final video = _makeVideo(videoUrl: variantUrl);
-          expect(
-            resolvePlaybackSources(video),
-            equals([variantUrl, _rawUrl, _hlsUrl]),
-          );
+          expect(resolvePlaybackSources(video), equals([variantUrl, _hlsUrl]));
         },
       );
 
-      test('leads with HLS while the derivative has a fresh failure', () {
+      test('leads with HLS without raw fallback after a fresh failure', () {
         final video = _makeVideo(videoUrl: variantUrl);
         final cache = DerivativeFailureCache()
           ..recordFailureForSource(variantUrl);
 
         expect(
           resolvePlaybackSources(video, derivativeFailureCache: cache),
-          equals([_hlsUrl, _rawUrl, variantUrl]),
+          equals([_hlsUrl, variantUrl]),
         );
       });
 
@@ -127,7 +124,7 @@ void main() {
 
         expect(
           resolvePlaybackSources(video, derivativeFailureCache: cache),
-          equals([variantUrl, _rawUrl, _hlsUrl]),
+          equals([variantUrl, _hlsUrl]),
         );
       });
     });

--- a/mobile/packages/infinite_video_feed/test/src/utils/source_loader_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/utils/source_loader_test.dart
@@ -127,6 +127,23 @@ void main() {
       expect(logs.first, contains('badUrl'));
     });
 
+    test('notifies each failed source before failover succeeds', () async {
+      final controller = _FakeControllerWithOneFailure();
+      addTearDown(controller.dispose);
+      final failedSources = <String>[];
+
+      final result = await setSourceWithFallbacks(
+        index: 1,
+        controller: controller,
+        sources: ['badUrl', 'goodUrl'],
+        log: logs.add,
+        onSourceLoadFailure: failedSources.add,
+      );
+
+      expect(result, equals(('goodUrl', 1)));
+      expect(failedSources, equals(['badUrl']));
+    });
+
     test('fails over when Android reports NOT_READY for a source', () async {
       final clips = <VideoClip>[];
       final controller = _RecordingControllerWithFailures(

--- a/mobile/packages/infinite_video_feed/test/src/utils/source_loader_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/utils/source_loader_test.dart
@@ -192,7 +192,7 @@ void main() {
       );
 
       // The processing source is not the last resort, so we do not stall on it:
-      // the guaranteed raw fallback is preferred immediately.
+      // the queued fallback is preferred immediately.
       expect(result, equals(('rawUrl', 1)));
       expect(
         clips.map((clip) => clip.uri),

--- a/mobile/packages/infinite_video_feed/test/src/widgets/infinite_video_feed_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/widgets/infinite_video_feed_test.dart
@@ -10,6 +10,7 @@ import 'package:infinite_video_feed/src/widgets/video_item.dart';
 import 'package:media_cache/media_cache.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
+import 'package:unified_logger/unified_logger.dart';
 
 class _MockMediaCacheManager extends Mock implements MediaCacheManager {}
 
@@ -143,8 +144,9 @@ Widget _wrapFeed(InfiniteVideoFeed feed) => Directionality(
 void main() {
   late _MockMediaCacheManager cache;
 
-  setUp(() {
+  setUp(() async {
     cache = _MockMediaCacheManager();
+    await LogCaptureService().clearAllLogs();
     // Stub all cache checks to return null — nothing is cached in tests.
     when(() => cache.getCachedFileSync(any())).thenReturn(null);
     // Stub eviction (used when cache file is corrupt on failover).
@@ -1207,6 +1209,52 @@ void main() {
           await tester.pumpWidget(const SizedBox.shrink());
           await tester.pump();
           await harness.dispose();
+        }
+      });
+
+      testWidgets('player init failure log includes the failing source', (
+        tester,
+      ) async {
+        DivineVideoPlayerController.resetIdCounterForTesting();
+        final harness = _NativePlayerHarness(tester);
+        await harness.install(playerIds: const <int>[0]);
+
+        const source = 'https://example.com/broken.mp4';
+
+        try {
+          harness.setClipsFailures[0] = <Exception>[
+            PlatformException(
+              code: 'COMPOSITION_ERROR',
+              message: 'parse failed',
+              details: const <String, Object?>{'errorCode': 'parse_error'},
+            ),
+          ];
+
+          await tester.pumpWidget(
+            _wrapFeed(
+              InfiniteVideoFeed(
+                videos: [_makeVideo('init_log_source', videoUrl: source)],
+                cache: cache,
+                prefetchCount: 0,
+                preloadGracePeriod: Duration.zero,
+              ),
+            ),
+          );
+          await tester.pump();
+          await tester.pump();
+
+          final logs = LogCaptureService().getRecentLogs(
+            minLevel: LogLevel.error,
+          );
+          expect(
+            logs.map((log) => log.message),
+            contains('Player init failed failedSource=$source'),
+          );
+        } finally {
+          await tester.pumpWidget(const SizedBox.shrink());
+          await tester.pump();
+          await harness.dispose();
+          await LogCaptureService().clearAllLogs();
         }
       });
 


### PR DESCRIPTION
## Summary
- remove bare Divine-host blob URLs from derivative playback fallbacks while divine-blossom#198 keeps Range requests unsafe, including alternate supported hosts and query-bearing URLs
- keep raw blob playback when the raw URL is the resolved source so classic/raw-only playback still has a progressive source
- include the failed playback source in Dart init logs and the current MediaItem URI in Android playback error logs

## Tests
- flutter analyze packages/infinite_video_feed/lib/src/utils/playback_sources.dart packages/infinite_video_feed/lib/src/utils/source_loader.dart packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart packages/infinite_video_feed/test/src/utils/playback_sources_test.dart packages/infinite_video_feed/test/src/utils/source_loader_test.dart packages/infinite_video_feed/test/src/widgets/infinite_video_feed_test.dart
- flutter test packages/infinite_video_feed/test/src/utils/playback_sources_test.dart packages/infinite_video_feed/test/src/utils/source_loader_test.dart
- flutter test packages/infinite_video_feed/test/src/widgets/infinite_video_feed_test.dart --plain-name "player init failure log includes the failing source"
- full infinite_video_feed package suite: 251 passed
- TZ=UTC flutter test: 17,052 passed, 305 skipped
- current-head GitHub checks: Mobile CI, package CI, Android Unit Tests, and web preview passed

## Notes
Refs #7533 and #7184. This intentionally does not close #7533; divine-blossom#198 still owns the server-side Range fix.

Android native compile was attempted with flutter build apk --debug but this machine has no Java runtime available; current-head Android Unit Tests passed in GitHub Actions.
