### PR TITLE
fix(ios): socket errors and passive auth retry logging

### DIFF
--- a/mobile/lib/models/account_restore_failed_exception.dart
+++ b/mobile/lib/models/account_restore_failed_exception.dart
@@ -1,0 +1,24 @@
+// ABOUTME: Describes an account restore that resolved to the wrong identity.
+// ABOUTME: Lets auth callers route failed restores back through full login.
+
+import 'package:openvine/models/auth_state.dart';
+
+/// Thrown when a returning-user sign-in does not restore the requested account.
+class AccountRestoreFailedException implements Exception {
+  const AccountRestoreFailedException(
+    this.pubkeyHex,
+    this.resolvedState, {
+    this.resolvedPubkeyHex,
+  });
+
+  final String pubkeyHex;
+  final AuthState resolvedState;
+  final String? resolvedPubkeyHex;
+
+  @override
+  String toString() =>
+      'AccountRestoreFailedException: sign-in for $pubkeyHex resolved to '
+      '$resolvedState'
+      '${resolvedPubkeyHex == null ? '' : ' as $resolvedPubkeyHex'} '
+      'instead of the requested account';
+}

--- a/mobile/lib/models/auth_state.dart
+++ b/mobile/lib/models/auth_state.dart
@@ -1,0 +1,11 @@
+// ABOUTME: Defines the lifecycle states exposed by AuthService.
+// ABOUTME: Keeps authentication state independent from service implementation.
+
+/// Authentication state for the user.
+enum AuthState {
+  unauthenticated,
+  awaitingTosAcceptance,
+  authenticated,
+  checking,
+  authenticating,
+}

--- a/mobile/lib/models/auth_user_profile.dart
+++ b/mobile/lib/models/auth_user_profile.dart
@@ -1,0 +1,35 @@
+// ABOUTME: Stores the minimal user profile maintained by AuthService.
+// ABOUTME: Builds auth profiles from securely stored identity containers.
+
+import 'package:nostr_key_manager/nostr_key_manager.dart'
+    show SecureKeyContainer;
+
+/// Minimal profile state for the authenticated user.
+class UserProfile {
+  const UserProfile({
+    required this.npub,
+    required this.publicKeyHex,
+    required this.displayName,
+    this.keyCreatedAt,
+    this.lastAccessAt,
+    this.about,
+    this.picture,
+    this.nip05,
+  });
+
+  factory UserProfile.fromSecureContainer(SecureKeyContainer keyContainer) =>
+      UserProfile(
+        npub: keyContainer.npub,
+        publicKeyHex: keyContainer.publicKeyHex,
+        displayName: keyContainer.npub,
+      );
+
+  final String npub;
+  final String publicKeyHex;
+  final DateTime? keyCreatedAt;
+  final DateTime? lastAccessAt;
+  final String displayName;
+  final String? about;
+  final String? picture;
+  final String? nip05;
+}

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -15,8 +15,11 @@ import 'package:nostr_key_manager/nostr_key_manager.dart'
     show SecureKeyContainer, SecureKeyStorage, SecureKeyStorageException;
 import 'package:nostr_sdk/nostr_sdk.dart';
 import 'package:openvine/constants/app_constants.dart';
+import 'package:openvine/models/account_restore_failed_exception.dart';
 import 'package:openvine/models/auth_result.dart';
 import 'package:openvine/models/auth_rpc_capability.dart';
+import 'package:openvine/models/auth_state.dart';
+import 'package:openvine/models/auth_user_profile.dart';
 import 'package:openvine/models/authentication_source.dart';
 import 'package:openvine/models/known_account.dart';
 import 'package:openvine/services/account_deletion_proof_signer.dart';
@@ -41,7 +44,10 @@ import 'package:unified_logger/unified_logger.dart';
 
 // AuthResult moved to its own file (#4741) so auth/ collaborators can return it
 // without a facade import cycle; external consumers keep importing it here.
+export 'package:openvine/models/account_restore_failed_exception.dart';
 export 'package:openvine/models/auth_result.dart';
+export 'package:openvine/models/auth_state.dart';
+export 'package:openvine/models/auth_user_profile.dart';
 export 'package:openvine/models/authentication_source.dart';
 // Discovery callback contracts moved with the orchestrator (#4741); external
 // consumers (NostrService wiring) keep importing them from this facade.
@@ -60,24 +66,6 @@ const _kSessionRecoveryAnchorKey = 'session_recovery_anchor_npub';
 
 const _accountDeletionSessionExpiryMargin = Duration(minutes: 10);
 
-/// Authentication state for the user
-enum AuthState {
-  /// User is not authenticated (no keys stored)
-  unauthenticated,
-
-  /// User has keys but hasn't accepted Terms of Service yet
-  awaitingTosAcceptance,
-
-  /// User is authenticated (has valid keys and accepted TOS)
-  authenticated,
-
-  /// Authentication state is being checked
-  checking,
-
-  /// Authentication is in progress (generating/importing keys)
-  authenticating,
-}
-
 /// Whether the account-deletion flow may start.
 ///
 /// Deletion publishes irreversible events before it can attempt the reversible
@@ -92,72 +80,6 @@ enum AccountDeletionReadiness {
   /// destroy the user's content and leave their account alive. A fresh sign-in
   /// resolves it. Nothing has been published.
   requiresReauthentication,
-}
-
-/// Thrown by [AuthService.signInForAccount] when a returning-user sign-in
-/// does not restore the requested account — for example when an
-/// `importedKeys`/`automatic` account's identity keys are missing from secure
-/// storage, when a fallback authenticates a different primary account, or when
-/// [AuthService] lands in [AuthState.awaitingTosAcceptance] after an internal
-/// session-setup failure.
-///
-/// Previously these paths returned normally, leaving the caller (WelcomeBloc)
-/// believing the sign-in succeeded while the router kept the user pinned to
-/// `/welcome` — an invisible login loop. Throwing lets the caller route the
-/// user to the full login flow instead. See #5195.
-class AccountRestoreFailedException implements Exception {
-  const AccountRestoreFailedException(
-    this.pubkeyHex,
-    this.resolvedState, {
-    this.resolvedPubkeyHex,
-  });
-
-  /// The account (hex pubkey) whose restore was attempted.
-  final String pubkeyHex;
-
-  /// The [AuthState] the service resolved to.
-  final AuthState resolvedState;
-
-  /// The account (hex pubkey) that became active, if any.
-  final String? resolvedPubkeyHex;
-
-  @override
-  String toString() =>
-      'AccountRestoreFailedException: sign-in for $pubkeyHex resolved to '
-      '$resolvedState'
-      '${resolvedPubkeyHex == null ? '' : ' as $resolvedPubkeyHex'} '
-      'instead of the requested account';
-}
-
-/// User profile information
-class UserProfile {
-  const UserProfile({
-    required this.npub,
-    required this.publicKeyHex,
-    required this.displayName,
-    this.keyCreatedAt,
-    this.lastAccessAt,
-    this.about,
-    this.picture,
-    this.nip05,
-  });
-
-  /// Create minimal profile from secure key container
-  factory UserProfile.fromSecureContainer(SecureKeyContainer keyContainer) =>
-      UserProfile(
-        npub: keyContainer.npub,
-        publicKeyHex: keyContainer.publicKeyHex,
-        displayName: keyContainer.npub,
-      );
-
-  final String npub;
-  final String publicKeyHex;
-  final DateTime? keyCreatedAt;
-  final DateTime? lastAccessAt;
-  final String displayName;
-  final String? about;
-  final String? picture;
-  final String? nip05;
 }
 
 /// Callback to pre-fetch following list from REST API before auth state is set.
@@ -4540,10 +4462,8 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   /// this seam's parameter rather than the production call site's choice, so
   /// it cannot fail when that call site stops passing it.
   @visibleForTesting
-  void debugSetKeycastSigner(
-    KeycastRpc? signer, {
-    bool closePrevious = true,
-  }) => _setKeycastSigner(signer, closePrevious: closePrevious);
+  void debugSetKeycastSigner(KeycastRpc? signer, {bool closePrevious = true}) =>
+      _setKeycastSigner(signer, closePrevious: closePrevious);
 
   /// Test seam that lets unit tests install a [SecureKeyContainer] so
   /// `signOut`'s account-scoped invalidation (and any other code path

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -2813,11 +2813,6 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
     _hasExpiredOAuthSession = false;
 
     try {
-      // Sign-in runs during startup restore or from unauthenticated login
-      // screens, before any app-wide NostrClient can hold the previous
-      // signer (#5909 keeps the client across same-pubkey swaps), so
-      // closing the replaced signer here is safe — unlike the same-pubkey
-      // background RPC upgrade path, which deliberately retains it.
       if (session.hasRpcAccess) {
         _setKeycastSigner(_newKeycastSigner(session));
       } else {
@@ -4254,7 +4249,8 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
           name: 'AuthService',
           category: LogCategory.auth,
         );
-        _setKeycastSigner(null);
+        // Never close: same-pubkey swaps (importing your own nsec) keep the live client's RPC open (#5909).
+        _setKeycastSigner(null, closePrevious: false);
       }
     }
     if (source != AuthenticationSource.bunker && _bunkerSigner != null) {

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -2813,6 +2813,11 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
     _hasExpiredOAuthSession = false;
 
     try {
+      // Sign-in runs during startup restore or from unauthenticated login
+      // screens, before any app-wide NostrClient can hold the previous
+      // signer (#5909 keeps the client across same-pubkey swaps), so
+      // closing the replaced signer here is safe — unlike the same-pubkey
+      // background RPC upgrade path, which deliberately retains it.
       if (session.hasRpcAccess) {
         _setKeycastSigner(_newKeycastSigner(session));
       } else {

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -804,8 +804,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
           );
           return;
         }
-        // Keep the signer held by the live NostrClient across #5909's
-        // same-pubkey re-emission; closing it strands the retained client.
+        // Same-pubkey re-emission: retain the live client's signer (#5909).
         _setKeycastSigner(_newKeycastSigner(refreshed), closePrevious: false);
         _currentIdentity = _buildIdentity();
         _hasExpiredOAuthSession = false;
@@ -2809,7 +2808,11 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
     _hasExpiredOAuthSession = false;
 
     try {
-      final closePrevious = session.userPubkey != currentPublicKeyHex;
+      // Unbound session: pubkey unknown here, treat as same — a wrong close
+      // strands the live client; a wrong retain leaks one HTTP client (#5909).
+      final closePrevious =
+          (session.userPubkey?.isNotEmpty ?? false) &&
+          session.userPubkey != currentPublicKeyHex;
       if (session.hasRpcAccess) {
         _setKeycastSigner(
           _newKeycastSigner(session),
@@ -2819,10 +2822,9 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
         _setKeycastSigner(null, closePrevious: closePrevious);
       }
 
-      // Prefer the pubkey stored in the session over an RPC call.
-      // session.userPubkey is ground truth once populated — it is
-      // bound to the session at the first sign-in, so subsequent
-      // reads get a pubkey that cannot mismatch the token.
+      // Prefer the pubkey stored in the session over an RPC call:
+      // userPubkey is ground truth once bound at first sign-in, so
+      // subsequent reads cannot mismatch the token.
       String? publicKeyHex = session.userPubkey;
       if (publicKeyHex == null || publicKeyHex.isEmpty) {
         publicKeyHex = await _keycastSigner?.getPublicKey();
@@ -2831,11 +2833,9 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
         throw Exception('Could not retrieve public key from server');
       }
 
-      // If the session was created before userPubkey was populated
-      // (legacy or fresh from fromTokenResponse), bind the pubkey now
-      // and re-save. This is the fix for Bug 2: every saved session
-      // must carry its owning pubkey so subsequent archive/restore
-      // operations can validate ownership.
+      // If userPubkey was never populated (legacy or fresh from
+      // fromTokenResponse), bind the resolved pubkey now and re-save so
+      // archive/restore can validate ownership.
       if (session.userPubkey == null || session.userPubkey!.isEmpty) {
         final boundSession = session.copyWith(userPubkey: publicKeyHex);
         await boundSession.save(_flutterSecureStorage);

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -805,11 +805,10 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
           return;
         }
         // Deliberately does NOT close the previous signer, unlike the
-        // sign-out/dispose sites. The live NostrClient still holds it: #5909
-        // keeps that client across a same-pubkey re-emission, so nothing
-        // swaps its injected signer and the old RPC must stay usable until
-        // the client is rebuilt or disposed. Closing it here strands every
-        // publish on the retained client. See [KeycastRpc.close].
+        // sign-out/dispose sites: the live NostrClient still holds it (#5909
+        // keeps that client across a same-pubkey re-emission), so closing it
+        // here strands every publish on the retained client until the client
+        // is rebuilt or disposed. See [KeycastRpc.close].
         _setKeycastSigner(_newKeycastSigner(refreshed), closePrevious: false);
         _currentIdentity = _buildIdentity();
         _hasExpiredOAuthSession = false;
@@ -2813,6 +2812,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
     _hasExpiredOAuthSession = false;
 
     try {
+      // Closing is safe: no live NostrClient holds the replaced signer on any caller of this path.
       if (session.hasRpcAccess) {
         _setKeycastSigner(_newKeycastSigner(session));
       } else {

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -679,11 +679,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
       // Keycast signer before building the identity so we get a
       // KeycastNostrIdentity instead of a LocalNostrIdentity.
       if (session != null && session.hasRpcAccess) {
-        _keycastSigner = KeycastRpc.fromSession(
-          _oauthConfig,
-          session,
-          onTokenRefresh: _refreshAccessToken,
-        );
+        _setKeycastSigner(_newKeycastSigner(session));
       }
 
       await _setupUserSession(localKey!, AuthenticationSource.divineOAuth);
@@ -808,11 +804,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
           );
           return;
         }
-        _keycastSigner = KeycastRpc.fromSession(
-          _oauthConfig,
-          refreshed,
-          onTokenRefresh: _refreshAccessToken,
-        );
+        _setKeycastSigner(_newKeycastSigner(refreshed));
         _currentIdentity = _buildIdentity();
         _hasExpiredOAuthSession = false;
         _setRpcCapability(AuthRpcCapability.rpcReady);
@@ -1088,6 +1080,20 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   /// app-resume refresh all share a single refresh token exchange.
   Future<String?> _refreshAccessToken() =>
       _oauthCoordinator.refreshAccessToken();
+
+  KeycastRpc _newKeycastSigner(KeycastSession session) =>
+      KeycastRpc.fromSession(
+        _oauthConfig,
+        session,
+        onTokenRefresh: _refreshAccessToken,
+      );
+
+  void _setKeycastSigner(KeycastRpc? signer) {
+    if (identical(_keycastSigner, signer)) return;
+    final previous = _keycastSigner;
+    _keycastSigner = signer;
+    previous?.close();
+  }
 
   /// Get discovered user relays (NIP-65)
   List<DiscoveredRelay> get userRelays => List.unmodifiable(_userRelays);
@@ -2802,13 +2808,9 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
 
     try {
       if (session.hasRpcAccess) {
-        _keycastSigner = KeycastRpc.fromSession(
-          _oauthConfig,
-          session,
-          onTokenRefresh: _refreshAccessToken,
-        );
+        _setKeycastSigner(_newKeycastSigner(session));
       } else {
-        _keycastSigner = null;
+        _setKeycastSigner(null);
       }
 
       // Prefer the pubkey stored in the session over an RPC call.
@@ -3514,7 +3516,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
       }
 
       // Clean up Keycast RPC signer if active
-      _keycastSigner = null;
+      _setKeycastSigner(null);
       _setRpcCapability(AuthRpcCapability.unavailable);
 
       // Detach any in-flight token refresh so post-signout logins start a
@@ -3687,7 +3689,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
     try {
       await _clearAmberInfo();
     } catch (_) {}
-    _keycastSigner = null;
+    _setKeycastSigner(null);
     _setRpcCapability(AuthRpcCapability.unavailable);
     _keyStorage.clearCache();
 
@@ -4241,7 +4243,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
           name: 'AuthService',
           category: LogCategory.auth,
         );
-        _keycastSigner = null;
+        _setKeycastSigner(null);
       }
     }
     if (source != AuthenticationSource.bunker && _bunkerSigner != null) {
@@ -4648,11 +4650,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
           );
           await clearDismissedDivineLoginBannerForCurrentUser();
           if (!resumeContextStillCurrent()) return;
-          _keycastSigner = KeycastRpc.fromSession(
-            _oauthConfig,
-            session,
-            onTokenRefresh: _refreshAccessToken,
-          );
+          _setKeycastSigner(_newKeycastSigner(session));
           _currentIdentity = _buildIdentity();
           _hasExpiredOAuthSession = false;
           _setRpcCapability(AuthRpcCapability.rpcReady);
@@ -4720,6 +4718,8 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
     // Close Amber signer if active
     _amberSigner?.close();
     _amberSigner = null;
+
+    _setKeycastSigner(null);
 
     _nostrConnect.dispose();
 

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -804,6 +804,12 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
           );
           return;
         }
+        // Deliberately does NOT close the previous signer, unlike the
+        // sign-out/dispose sites. The live NostrClient still holds it: #5909
+        // keeps that client across a same-pubkey re-emission, so nothing
+        // swaps its injected signer and the old RPC must stay usable until
+        // the client is rebuilt or disposed. Closing it here strands every
+        // publish on the retained client. See [KeycastRpc.close].
         _setKeycastSigner(_newKeycastSigner(refreshed), closePrevious: false);
         _currentIdentity = _buildIdentity();
         _hasExpiredOAuthSession = false;
@@ -4517,13 +4523,21 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   Future<void> debugDiscoverUserRelays(String npub) =>
       _discoveryOrchestrator.discoverUserRelays(npub, _currentIdentity?.pubkey);
 
-  /// Test seam for code paths that need [currentIdentity] without full sign-in.
+  /// Test seam that lets unit tests install a [NostrIdentity] without
+  /// going through the full sign-in pipeline. Used by tests that exercise
+  /// code paths (e.g. the bootstrap kind:10002 publish) which depend on
+  /// [currentIdentity] being set.
   @visibleForTesting
   void debugSetIdentity(NostrIdentity? identity) {
     _currentIdentity = identity;
   }
 
-  /// Test seam for signer lifecycle policy.
+  /// Test seam that installs a [KeycastRpc] signer without a real OAuth flow.
+  ///
+  /// Arrange the *starting* signer here and drive the real code path for the
+  /// transition under test: a test that supplies [closePrevious] itself pins
+  /// this seam's parameter rather than the production call site's choice, so
+  /// it cannot fail when that call site stops passing it.
   @visibleForTesting
   void debugSetKeycastSigner(
     KeycastRpc? signer, {
@@ -4535,8 +4549,12 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   /// keyed on the current pubkey) can be exercised without driving the
   /// full sign-in pipeline.
   ///
-  /// Scope warning: this sets only `_currentKeyContainer`; tests needing
-  /// identity, auth state, or signer wiring must install those separately.
+  /// **Scope warning**: this only sets `_currentKeyContainer`. It does
+  /// not touch `_authSource`, `_currentIdentity`, signer wiring, auth
+  /// state, or any other field that real sign-in initialises. Safe for
+  /// tests that exercise branches keyed solely on `_currentKeyContainer`
+  /// (e.g. the pubkey-capture step in `signOut`); using it as a general
+  /// "pretend to be signed in" shim will produce inconsistent state.
   @visibleForTesting
   void debugSetCurrentKeyContainer(SecureKeyContainer? container) {
     _currentKeyContainer = container;

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -804,11 +804,8 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
           );
           return;
         }
-        // Deliberately does NOT close the previous signer, unlike the
-        // sign-out/dispose sites: the live NostrClient still holds it (#5909
-        // keeps that client across a same-pubkey re-emission), so closing it
-        // here strands every publish on the retained client until the client
-        // is rebuilt or disposed. See [KeycastRpc.close].
+        // Keep the signer held by the live NostrClient across #5909's
+        // same-pubkey re-emission; closing it strands the retained client.
         _setKeycastSigner(_newKeycastSigner(refreshed), closePrevious: false);
         _currentIdentity = _buildIdentity();
         _hasExpiredOAuthSession = false;
@@ -2812,11 +2809,14 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
     _hasExpiredOAuthSession = false;
 
     try {
-      // Closing is safe: no live NostrClient holds the replaced signer on any caller of this path.
+      final closePrevious = session.userPubkey != currentPublicKeyHex;
       if (session.hasRpcAccess) {
-        _setKeycastSigner(_newKeycastSigner(session));
+        _setKeycastSigner(
+          _newKeycastSigner(session),
+          closePrevious: closePrevious,
+        );
       } else {
-        _setKeycastSigner(null);
+        _setKeycastSigner(null, closePrevious: closePrevious);
       }
 
       // Prefer the pubkey stored in the session over an RPC call.

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -804,7 +804,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
           );
           return;
         }
-        _setKeycastSigner(_newKeycastSigner(refreshed));
+        _setKeycastSigner(_newKeycastSigner(refreshed), closePrevious: false);
         _currentIdentity = _buildIdentity();
         _hasExpiredOAuthSession = false;
         _setRpcCapability(AuthRpcCapability.rpcReady);
@@ -1088,11 +1088,11 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
         onTokenRefresh: _refreshAccessToken,
       );
 
-  void _setKeycastSigner(KeycastRpc? signer) {
+  void _setKeycastSigner(KeycastRpc? signer, {bool closePrevious = true}) {
     if (identical(_keycastSigner, signer)) return;
     final previous = _keycastSigner;
     _keycastSigner = signer;
-    previous?.close();
+    if (closePrevious) previous?.close();
   }
 
   /// Get discovered user relays (NIP-65)
@@ -4517,26 +4517,26 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   Future<void> debugDiscoverUserRelays(String npub) =>
       _discoveryOrchestrator.discoverUserRelays(npub, _currentIdentity?.pubkey);
 
-  /// Test seam that lets unit tests install a [NostrIdentity] without
-  /// going through the full sign-in pipeline. Used by tests that exercise
-  /// code paths (e.g. the bootstrap kind:10002 publish) which depend on
-  /// [currentIdentity] being set.
+  /// Test seam for code paths that need [currentIdentity] without full sign-in.
   @visibleForTesting
   void debugSetIdentity(NostrIdentity? identity) {
     _currentIdentity = identity;
   }
+
+  /// Test seam for signer lifecycle policy.
+  @visibleForTesting
+  void debugSetKeycastSigner(
+    KeycastRpc? signer, {
+    bool closePrevious = true,
+  }) => _setKeycastSigner(signer, closePrevious: closePrevious);
 
   /// Test seam that lets unit tests install a [SecureKeyContainer] so
   /// `signOut`'s account-scoped invalidation (and any other code path
   /// keyed on the current pubkey) can be exercised without driving the
   /// full sign-in pipeline.
   ///
-  /// **Scope warning**: this only sets `_currentKeyContainer`. It does
-  /// not touch `_authSource`, `_currentIdentity`, signer wiring, auth
-  /// state, or any other field that real sign-in initialises. Safe for
-  /// tests that exercise branches keyed solely on `_currentKeyContainer`
-  /// (e.g. the pubkey-capture step in `signOut`); using it as a general
-  /// "pretend to be signed in" shim will produce inconsistent state.
+  /// Scope warning: this sets only `_currentKeyContainer`; tests needing
+  /// identity, auth state, or signer wiring must install those separately.
   @visibleForTesting
   void debugSetCurrentKeyContainer(SecureKeyContainer? container) {
     _currentKeyContainer = container;

--- a/mobile/lib/widgets/video_thumbnail_widget.dart
+++ b/mobile/lib/widgets/video_thumbnail_widget.dart
@@ -429,6 +429,7 @@ class _PassiveAuthThumbnailImageState extends State<PassiveAuthThumbnailImage> {
           name: widget.logName,
           category: LogCategory.video,
         );
+        _markPassiveAuthUnavailable(retryUrl);
       case ViewerAuthUnavailable():
         Log.info(
           '${widget.logPrefix}: Passive auth retry unavailable for $retryUrl',

--- a/mobile/lib/widgets/video_thumbnail_widget.dart
+++ b/mobile/lib/widgets/video_thumbnail_widget.dart
@@ -401,6 +401,11 @@ class _PassiveAuthThumbnailImageState extends State<PassiveAuthThumbnailImage> {
     _authRetryAttempted = true;
     switch (authResult) {
       case ViewerAuthAuthorized(:final headers):
+        Log.info(
+          '${widget.logPrefix}: Passive auth retry succeeded for $retryUrl',
+          name: widget.logName,
+          category: LogCategory.video,
+        );
         final suppressionKey = _suppressionKey(retryUrl);
         if (suppressionKey != null) {
           PassiveAuthThumbnailImage._unauthorizedWithoutPassiveAuth.remove(
@@ -411,9 +416,25 @@ class _PassiveAuthThumbnailImageState extends State<PassiveAuthThumbnailImage> {
           _authHeaders = headers;
         });
       case ViewerAuthSignerUnreachable():
-        break;
+        Log.warning(
+          '${widget.logPrefix}: Passive auth retry failed; signer unreachable '
+          'for $retryUrl',
+          name: widget.logName,
+          category: LogCategory.video,
+        );
       case ViewerAuthBlockedByPreference():
+        Log.info(
+          '${widget.logPrefix}: Passive auth retry disabled by viewer '
+          'preference for $retryUrl',
+          name: widget.logName,
+          category: LogCategory.video,
+        );
       case ViewerAuthUnavailable():
+        Log.info(
+          '${widget.logPrefix}: Passive auth retry unavailable for $retryUrl',
+          name: widget.logName,
+          category: LogCategory.video,
+        );
         _markPassiveAuthUnavailable(retryUrl);
     }
   }

--- a/mobile/packages/keycast_flutter/lib/src/models/exceptions.dart
+++ b/mobile/packages/keycast_flutter/lib/src/models/exceptions.dart
@@ -72,3 +72,17 @@ class RpcTimeoutException extends RpcException
 class InvalidKeyException extends KeycastException {
   InvalidKeyException(super.message);
 }
+
+/// Thrown when an RPC is attempted on a KeycastRpc after close().
+///
+/// Extends [RpcException] — not [StateError] — deliberately: close racing an
+/// in-flight call (e.g. sign-out while a token refresh is parked) is expected
+/// teardown, not a programming-invariant violation. The error-handling matrix
+/// classifies `StateError` as Crashlytics-reportable, and as an `Error` it also
+/// escapes `on Exception` handlers, which would turn routine teardown into an
+/// uncaught error. Without [TransientSignerFailure] it stays terminal: a
+/// closed signer is never retried.
+class KeycastRpcClosedException extends RpcException {
+  KeycastRpcClosedException([String? message])
+    : super(message ?? 'KeycastRpc is closed');
+}

--- a/mobile/packages/keycast_flutter/lib/src/models/exceptions.dart
+++ b/mobile/packages/keycast_flutter/lib/src/models/exceptions.dart
@@ -75,14 +75,15 @@ class InvalidKeyException extends KeycastException {
 
 /// Thrown when an RPC is attempted on a KeycastRpc after close().
 ///
-/// Extends [RpcException] — not [StateError] — deliberately: close racing an
+/// Extends [KeycastException] — not [StateError] — deliberately: close racing an
 /// in-flight call (e.g. sign-out while a token refresh is parked) is expected
 /// teardown, not a programming-invariant violation. The error-handling matrix
 /// classifies `StateError` as Crashlytics-reportable, and as an `Error` it also
 /// escapes `on Exception` handlers, which would turn routine teardown into an
-/// uncaught error. Without [TransientSignerFailure] it stays terminal: a
-/// closed signer is never retried.
-class KeycastRpcClosedException extends RpcException {
+/// uncaught error. It deliberately stays outside [RpcException] so capability
+/// fallbacks do not mistake a closed client for an unsupported method. Without
+/// [TransientSignerFailure] it stays terminal: a closed signer is never retried.
+class KeycastRpcClosedException extends KeycastException {
   KeycastRpcClosedException([String? message])
     : super(message ?? 'KeycastRpc is closed');
 }

--- a/mobile/packages/keycast_flutter/lib/src/rpc/keycast_rpc.dart
+++ b/mobile/packages/keycast_flutter/lib/src/rpc/keycast_rpc.dart
@@ -126,7 +126,7 @@ class KeycastRpc implements NostrSigner, GiftWrapBatchUnwrapper {
     Duration? timeout,
     bool classifyLocalTimeout = true,
   }) async {
-    var response = await _sendRequest(
+    var response = await _sendRequestWithRetry(
       method,
       params,
       timeout: timeout,
@@ -152,7 +152,7 @@ class KeycastRpc implements NostrSigner, GiftWrapBatchUnwrapper {
       }
       if (newToken != null) {
         _accessToken = newToken;
-        response = await _sendRequest(
+        response = await _sendRequestWithRetry(
           method,
           params,
           timeout: timeout,
@@ -188,6 +188,36 @@ class KeycastRpc implements NostrSigner, GiftWrapBatchUnwrapper {
     }
 
     return fromResult(json['result']);
+  }
+
+  Future<http.Response> _sendRequestWithRetry(
+    String method,
+    List<dynamic> params, {
+    Duration? timeout,
+    bool classifyLocalTimeout = true,
+  }) async {
+    try {
+      return await _sendRequest(
+        method,
+        params,
+        timeout: timeout,
+        classifyLocalTimeout: classifyLocalTimeout,
+      );
+    } on http.ClientException catch (e, st) {
+      Log.warn(
+        "Socket error on Keycast RPC, retrying",
+        name: "KeycastRpc",
+        category: LogCategory.auth,
+        body: "$method",
+      );
+      _client = http.Client();
+      return await _sendRequest(
+        method,
+        params,
+        timeout: timeout,
+        classifyLocalTimeout: classifyLocalTimeout,
+      );
+    }
   }
 
   Future<http.Response> _sendRequest(
@@ -428,7 +458,7 @@ class KeycastRpc implements NostrSigner, GiftWrapBatchUnwrapper {
       return value;
     }
 
-    var response = await _sendRequest(
+    var response = await _sendRequestWithRetry(
       method,
       params,
       timeout: remaining(),
@@ -449,7 +479,7 @@ class KeycastRpc implements NostrSigner, GiftWrapBatchUnwrapper {
       }
       if (newToken != null) {
         _accessToken = newToken;
-        response = await _sendRequest(
+        response = await _sendRequestWithRetry(
           method,
           params,
           timeout: remaining(),

--- a/mobile/packages/keycast_flutter/lib/src/rpc/keycast_rpc.dart
+++ b/mobile/packages/keycast_flutter/lib/src/rpc/keycast_rpc.dart
@@ -118,6 +118,7 @@ class KeycastRpc implements NostrSigner, GiftWrapBatchUnwrapper {
   final Set<http.Client> _clientsPendingClose = HashSet.identity();
   final TokenRefreshCallback? _onTokenRefresh;
   bool _signCanonicalUnsupported = false;
+  bool _isClosed = false;
 
   /// Maximum time to wait for a single-op RPC request before failing with a
   /// [RpcTimeoutException].
@@ -134,10 +135,29 @@ class KeycastRpc implements NostrSigner, GiftWrapBatchUnwrapper {
     Duration? timeout,
     bool classifyLocalTimeout = true,
   }) async {
+    final effectiveTimeout = timeout ?? requestTimeout;
+    final stopwatch = Stopwatch()..start();
+
+    Never throwTimeout() {
+      if (!classifyLocalTimeout) {
+        throw TimeoutException('$method request timed out', effectiveTimeout);
+      }
+      throw RpcTimeoutException(
+        'Local $method request timed out after ${effectiveTimeout.inSeconds}s',
+        method: method,
+      );
+    }
+
+    Duration remaining() {
+      final value = effectiveTimeout - stopwatch.elapsed;
+      if (value <= Duration.zero) throwTimeout();
+      return value;
+    }
+
     var response = await _sendRequestWithRetry(
       method,
       params,
-      timeout: () => timeout,
+      timeout: remaining,
       classifyLocalTimeout: classifyLocalTimeout,
     );
 
@@ -154,7 +174,7 @@ class KeycastRpc implements NostrSigner, GiftWrapBatchUnwrapper {
       // original 401 response flows to the error handling below.
       String? newToken;
       try {
-        newToken = await _onTokenRefresh().timeout(timeout ?? requestTimeout);
+        newToken = await _onTokenRefresh().timeout(remaining());
       } on TimeoutException {
         newToken = null;
       }
@@ -163,7 +183,7 @@ class KeycastRpc implements NostrSigner, GiftWrapBatchUnwrapper {
         response = await _sendRequestWithRetry(
           method,
           params,
-          timeout: () => timeout,
+          timeout: remaining,
           classifyLocalTimeout: classifyLocalTimeout,
         );
       }
@@ -203,13 +223,16 @@ class KeycastRpc implements NostrSigner, GiftWrapBatchUnwrapper {
   ///
   /// The retry is deliberately below RPC parsing and token-refresh handling:
   /// a call that also gets one 401 refresh can issue up to four POSTs in the
-  /// worst case, but only for idempotent Keycast verbs.
+  /// worst case. `nip17_wrap_batch` also records a server-side audit row per
+  /// call, so callers must treat the retry as transport recovery rather than
+  /// proof that the first POST had no server-side effect.
   Future<http.Response> _sendRequestWithRetry(
     String method,
     List<dynamic> params, {
     Duration? Function()? timeout,
     bool classifyLocalTimeout = true,
   }) async {
+    _ensureOpen();
     final attemptClient = _client;
     try {
       return await _sendRequest(
@@ -226,6 +249,7 @@ class KeycastRpc implements NostrSigner, GiftWrapBatchUnwrapper {
         name: 'KeycastRpc',
         category: LogCategory.auth,
       );
+      if (_isClosed) rethrow;
       _resetHttpClientAfterFailure(attemptClient);
       try {
         return await _sendRequest(
@@ -288,6 +312,7 @@ class KeycastRpc implements NostrSigner, GiftWrapBatchUnwrapper {
     Duration? timeout,
     bool classifyLocalTimeout = true,
   }) async {
+    _ensureOpen();
     Log.debug(
       '[Keycast RPC] Calling $method...',
       name: 'KeycastRpc',
@@ -665,8 +690,21 @@ class KeycastRpc implements NostrSigner, GiftWrapBatchUnwrapper {
 
   @override
   void close() {
+    if (_isClosed) return;
+    _isClosed = true;
     if (_ownsClient) {
       _client.close();
+    }
+    for (final client in _clientsPendingClose) {
+      client.close();
+    }
+    _clientsPendingClose.clear();
+    _inFlightByClient.clear();
+  }
+
+  void _ensureOpen() {
+    if (_isClosed) {
+      throw StateError('KeycastRpc is closed');
     }
   }
 }

--- a/mobile/packages/keycast_flutter/lib/src/rpc/keycast_rpc.dart
+++ b/mobile/packages/keycast_flutter/lib/src/rpc/keycast_rpc.dart
@@ -621,7 +621,7 @@ class KeycastRpc implements NostrSigner, GiftWrapBatchUnwrapper {
 
   void _ensureOpen() {
     if (_isClosed) {
-      throw StateError('KeycastRpc is closed');
+      throw KeycastRpcClosedException();
     }
   }
 }

--- a/mobile/packages/keycast_flutter/lib/src/rpc/keycast_rpc.dart
+++ b/mobile/packages/keycast_flutter/lib/src/rpc/keycast_rpc.dart
@@ -22,11 +22,14 @@ class KeycastRpc implements NostrSigner, GiftWrapBatchUnwrapper {
     required this.nostrApi,
     required String accessToken,
     http.Client? httpClient,
+    http.Client Function()? httpClientFactory,
     TokenRefreshCallback? onTokenRefresh,
     this.requestTimeout = defaultRequestTimeout,
     this.batchRequestTimeout = defaultBatchRequestTimeout,
   }) : _accessToken = accessToken,
-       _client = httpClient ?? http.Client(),
+       _clientFactory = httpClientFactory ?? http.Client.new,
+       _client = httpClient ?? (httpClientFactory ?? http.Client.new)(),
+       _ownsClient = httpClient == null,
        _onTokenRefresh = onTokenRefresh;
 
   factory KeycastRpc.fromSession(
@@ -107,7 +110,9 @@ class KeycastRpc implements NostrSigner, GiftWrapBatchUnwrapper {
 
   final String nostrApi;
   String _accessToken;
-  final http.Client _client;
+  final http.Client Function() _clientFactory;
+  http.Client _client;
+  bool _ownsClient;
   final TokenRefreshCallback? _onTokenRefresh;
   bool _signCanonicalUnsupported = false;
 
@@ -129,7 +134,7 @@ class KeycastRpc implements NostrSigner, GiftWrapBatchUnwrapper {
     var response = await _sendRequestWithRetry(
       method,
       params,
-      timeout: timeout,
+      timeout: () => timeout,
       classifyLocalTimeout: classifyLocalTimeout,
     );
 
@@ -155,7 +160,7 @@ class KeycastRpc implements NostrSigner, GiftWrapBatchUnwrapper {
         response = await _sendRequestWithRetry(
           method,
           params,
-          timeout: timeout,
+          timeout: () => timeout,
           classifyLocalTimeout: classifyLocalTimeout,
         );
       }
@@ -190,31 +195,58 @@ class KeycastRpc implements NostrSigner, GiftWrapBatchUnwrapper {
     return fromResult(json['result']);
   }
 
+  /// Sends one RPC request and, for socket-level [http.ClientException] only,
+  /// resets the HTTP transport before retrying once.
+  ///
+  /// The retry is deliberately below RPC parsing and token-refresh handling:
+  /// a call that also gets one 401 refresh can issue up to four POSTs in the
+  /// worst case, but only for idempotent Keycast verbs.
   Future<http.Response> _sendRequestWithRetry(
     String method,
     List<dynamic> params, {
-    Duration? timeout,
+    Duration? Function()? timeout,
     bool classifyLocalTimeout = true,
   }) async {
     try {
       return await _sendRequest(
         method,
         params,
-        timeout: timeout,
+        timeout: timeout?.call(),
         classifyLocalTimeout: classifyLocalTimeout,
       );
-    } on http.ClientException {
+    } on http.ClientException catch (error) {
       Log.warning(
-        '[Keycast RPC] Socket error during $method; retrying once',
+        '[Keycast RPC] Socket error during $method: $error; '
+        'resetting HTTP transport and retrying once',
         name: 'KeycastRpc',
         category: LogCategory.auth,
       );
-      return _sendRequest(
-        method,
-        params,
-        timeout: timeout,
-        classifyLocalTimeout: classifyLocalTimeout,
-      );
+      _resetHttpClient();
+      try {
+        return await _sendRequest(
+          method,
+          params,
+          timeout: timeout?.call(),
+          classifyLocalTimeout: classifyLocalTimeout,
+        );
+      } on http.ClientException catch (retryError) {
+        Log.warning(
+          '[Keycast RPC] Socket retry failed during $method: $retryError',
+          name: 'KeycastRpc',
+          category: LogCategory.auth,
+        );
+        rethrow;
+      }
+    }
+  }
+
+  void _resetHttpClient() {
+    final previousClient = _client;
+    final shouldClosePrevious = _ownsClient;
+    _client = _clientFactory();
+    _ownsClient = true;
+    if (shouldClosePrevious) {
+      previousClient.close();
     }
   }
 
@@ -459,7 +491,7 @@ class KeycastRpc implements NostrSigner, GiftWrapBatchUnwrapper {
     var response = await _sendRequestWithRetry(
       method,
       params,
-      timeout: remaining(),
+      timeout: remaining,
       classifyLocalTimeout: classifyLocalTimeout,
     );
 
@@ -480,7 +512,7 @@ class KeycastRpc implements NostrSigner, GiftWrapBatchUnwrapper {
         response = await _sendRequestWithRetry(
           method,
           params,
-          timeout: remaining(),
+          timeout: remaining,
           classifyLocalTimeout: classifyLocalTimeout,
         );
       }
@@ -597,5 +629,9 @@ class KeycastRpc implements NostrSigner, GiftWrapBatchUnwrapper {
   }
 
   @override
-  void close() {}
+  void close() {
+    if (_ownsClient) {
+      _client.close();
+    }
+  }
 }

--- a/mobile/packages/keycast_flutter/lib/src/rpc/keycast_rpc.dart
+++ b/mobile/packages/keycast_flutter/lib/src/rpc/keycast_rpc.dart
@@ -170,13 +170,13 @@ class KeycastRpc implements NostrSigner, GiftWrapBatchUnwrapper {
       // Bounded like the RPC itself: the refresh callback does its own HTTP
       // round-trip, and an unbounded await here would make one logical
       // signer op hang past every caller's budget despite [requestTimeout].
-      // A timed-out refresh counts as a failed refresh (null), so the
-      // original 401 response flows to the error handling below.
+      // A timed-out refresh is a local timeout, not an authentication failure
+      // or unsupported batch verb signal.
       String? newToken;
       try {
         newToken = await _onTokenRefresh().timeout(remaining());
       } on TimeoutException {
-        newToken = null;
+        throwTimeout();
       }
       if (newToken != null) {
         _accessToken = newToken;
@@ -243,13 +243,13 @@ class KeycastRpc implements NostrSigner, GiftWrapBatchUnwrapper {
         classifyLocalTimeout: classifyLocalTimeout,
       );
     } on http.ClientException catch (error) {
+      if (_isClosed) rethrow;
       Log.warning(
         '[Keycast RPC] Socket error during $method: $error; '
         'resetting HTTP transport and retrying once',
         name: 'KeycastRpc',
         category: LogCategory.auth,
       );
-      if (_isClosed) rethrow;
       _resetHttpClientAfterFailure(attemptClient);
       try {
         return await _sendRequest(
@@ -518,90 +518,6 @@ class KeycastRpc implements NostrSigner, GiftWrapBatchUnwrapper {
     }
   }
 
-  /// Runs a batch verb under one deadline, including token refresh and retry.
-  Future<T> _callBatch<T>(
-    String method,
-    List<dynamic> params,
-    T Function(dynamic) fromResult, {
-    bool logHttpErrors = true,
-    bool classifyLocalTimeout = true,
-  }) async {
-    final stopwatch = Stopwatch()..start();
-
-    Never throwTimeout() {
-      if (!classifyLocalTimeout) {
-        throw TimeoutException(
-          '$method request timed out',
-          batchRequestTimeout,
-        );
-      }
-      throw RpcTimeoutException(
-        'Local $method request timed out after '
-        '${batchRequestTimeout.inSeconds}s',
-        method: method,
-      );
-    }
-
-    Duration remaining() {
-      final value = batchRequestTimeout - stopwatch.elapsed;
-      if (value <= Duration.zero) throwTimeout();
-      return value;
-    }
-
-    var response = await _sendRequestWithRetry(
-      method,
-      params,
-      timeout: remaining,
-      classifyLocalTimeout: classifyLocalTimeout,
-    );
-
-    if (response.statusCode == 401 && _onTokenRefresh != null) {
-      Log.info(
-        '[Keycast RPC] $method returned 401, attempting token refresh',
-        name: 'KeycastRpc',
-        category: LogCategory.auth,
-      );
-      String? newToken;
-      try {
-        newToken = await _onTokenRefresh().timeout(remaining());
-      } on TimeoutException {
-        throwTimeout();
-      }
-      if (newToken != null) {
-        _accessToken = newToken;
-        response = await _sendRequestWithRetry(
-          method,
-          params,
-          timeout: remaining,
-          classifyLocalTimeout: classifyLocalTimeout,
-        );
-      }
-    }
-
-    if (response.statusCode != 200) {
-      if (logHttpErrors) {
-        Log.error(
-          '[Keycast RPC] Error response: ${response.body}',
-          name: 'KeycastRpc',
-          category: LogCategory.auth,
-        );
-      }
-      final message = 'HTTP ${response.statusCode}: ${response.body}';
-      throw response.statusCode == _gatewayTimeoutStatus
-          ? RpcTimeoutException(message, method: method)
-          : RpcException(message, method: method);
-    }
-
-    final json = jsonDecode(response.body) as Map<String, dynamic>;
-    if (json.containsKey('error') && json['error'] != null) {
-      throw RpcException(json['error'].toString(), method: method);
-    }
-    if (!json.containsKey('result')) {
-      throw RpcException('Missing result in response', method: method);
-    }
-    return fromResult(json['result']);
-  }
-
   /// Server-side NIP-59 gift-wrap construction for the remote-signer DM send
   /// path (`nip17_wrap_batch`).
   ///
@@ -633,7 +549,7 @@ class KeycastRpc implements NostrSigner, GiftWrapBatchUnwrapper {
     List<String> recipientPubkeys,
   ) async {
     try {
-      return await _callBatch(
+      return await _call(
         'nip17_wrap_batch',
         [rumor, recipientPubkeys],
         (result) => [
@@ -646,6 +562,7 @@ class KeycastRpc implements NostrSigner, GiftWrapBatchUnwrapper {
         // The unsupported-method probe is an expected outcome on an older
         // backend, not an incident; the branch below logs it at info instead.
         logHttpErrors: false,
+        timeout: batchRequestTimeout,
       );
     } on RpcException catch (error) {
       if (!_isUnsupportedWrapBatch(error)) rethrow;

--- a/mobile/packages/keycast_flutter/lib/src/rpc/keycast_rpc.dart
+++ b/mobile/packages/keycast_flutter/lib/src/rpc/keycast_rpc.dart
@@ -2,6 +2,7 @@
 // ABOUTME: Provides remote signing via Keycast server for Nostr events
 
 import 'dart:async';
+import 'dart:collection';
 import 'dart:convert';
 import 'dart:typed_data';
 
@@ -113,6 +114,8 @@ class KeycastRpc implements NostrSigner, GiftWrapBatchUnwrapper {
   final http.Client Function() _clientFactory;
   http.Client _client;
   bool _ownsClient;
+  final Map<http.Client, int> _inFlightByClient = HashMap.identity();
+  final Set<http.Client> _clientsPendingClose = HashSet.identity();
   final TokenRefreshCallback? _onTokenRefresh;
   bool _signCanonicalUnsupported = false;
 
@@ -195,7 +198,7 @@ class KeycastRpc implements NostrSigner, GiftWrapBatchUnwrapper {
     return fromResult(json['result']);
   }
 
-  /// Sends one RPC request and, for socket-level [http.ClientException] only,
+  /// Sends one RPC request and, for transport-level [http.ClientException],
   /// resets the HTTP transport before retrying once.
   ///
   /// The retry is deliberately below RPC parsing and token-refresh handling:
@@ -207,10 +210,12 @@ class KeycastRpc implements NostrSigner, GiftWrapBatchUnwrapper {
     Duration? Function()? timeout,
     bool classifyLocalTimeout = true,
   }) async {
+    final attemptClient = _client;
     try {
       return await _sendRequest(
         method,
         params,
+        client: attemptClient,
         timeout: timeout?.call(),
         classifyLocalTimeout: classifyLocalTimeout,
       );
@@ -221,7 +226,7 @@ class KeycastRpc implements NostrSigner, GiftWrapBatchUnwrapper {
         name: 'KeycastRpc',
         category: LogCategory.auth,
       );
-      _resetHttpClient();
+      _resetHttpClientAfterFailure(attemptClient);
       try {
         return await _sendRequest(
           method,
@@ -240,19 +245,46 @@ class KeycastRpc implements NostrSigner, GiftWrapBatchUnwrapper {
     }
   }
 
-  void _resetHttpClient() {
-    final previousClient = _client;
-    final shouldClosePrevious = _ownsClient;
+  void _resetHttpClientAfterFailure(http.Client failedClient) {
+    if (!identical(_client, failedClient)) return;
+    final shouldCloseFailedClient = _ownsClient;
     _client = _clientFactory();
     _ownsClient = true;
-    if (shouldClosePrevious) {
-      previousClient.close();
+    _retireHttpClient(failedClient, shouldClose: shouldCloseFailedClient);
+  }
+
+  void _retireHttpClient(http.Client client, {required bool shouldClose}) {
+    if (!shouldClose) return;
+    if ((_inFlightByClient[client] ?? 0) > 0) {
+      _clientsPendingClose.add(client);
+      return;
+    }
+    client.close();
+  }
+
+  http.Client _acquireHttpClient([http.Client? preferredClient]) {
+    final client = preferredClient ?? _client;
+    _inFlightByClient[client] = (_inFlightByClient[client] ?? 0) + 1;
+    return client;
+  }
+
+  void _releaseHttpClient(http.Client client) {
+    final inFlight = _inFlightByClient[client];
+    if (inFlight == null) return;
+    if (inFlight > 1) {
+      _inFlightByClient[client] = inFlight - 1;
+      return;
+    }
+    _inFlightByClient.remove(client);
+    if (_clientsPendingClose.remove(client)) {
+      client.close();
     }
   }
 
   Future<http.Response> _sendRequest(
     String method,
     List<dynamic> params, {
+    http.Client? client,
     Duration? timeout,
     bool classifyLocalTimeout = true,
   }) async {
@@ -263,9 +295,10 @@ class KeycastRpc implements NostrSigner, GiftWrapBatchUnwrapper {
     );
     final stopwatch = Stopwatch()..start();
     final effectiveTimeout = timeout ?? requestTimeout;
+    final requestClient = _acquireHttpClient(client);
     http.Response response;
     try {
-      response = await _client
+      response = await requestClient
           .post(
             Uri.parse(nostrApi),
             headers: {
@@ -281,6 +314,8 @@ class KeycastRpc implements NostrSigner, GiftWrapBatchUnwrapper {
         'Local $method request timed out after ${effectiveTimeout.inSeconds}s',
         method: method,
       );
+    } finally {
+      _releaseHttpClient(requestClient);
     }
     stopwatch.stop();
     Log.debug(

--- a/mobile/packages/keycast_flutter/lib/src/rpc/keycast_rpc.dart
+++ b/mobile/packages/keycast_flutter/lib/src/rpc/keycast_rpc.dart
@@ -203,15 +203,13 @@ class KeycastRpc implements NostrSigner, GiftWrapBatchUnwrapper {
         timeout: timeout,
         classifyLocalTimeout: classifyLocalTimeout,
       );
-    } on http.ClientException catch (e, st) {
-      Log.warn(
-        "Socket error on Keycast RPC, retrying",
-        name: "KeycastRpc",
+    } on http.ClientException {
+      Log.warning(
+        '[Keycast RPC] Socket error during $method; retrying once',
+        name: 'KeycastRpc',
         category: LogCategory.auth,
-        body: "$method",
       );
-      _client = http.Client();
-      return await _sendRequest(
+      return _sendRequest(
         method,
         params,
         timeout: timeout,

--- a/mobile/packages/keycast_flutter/test/rpc_client_test.dart
+++ b/mobile/packages/keycast_flutter/test/rpc_client_test.dart
@@ -228,6 +228,121 @@ void main() {
           expect(firstClient.closeCount, equals(1));
         },
       );
+
+      test('close drains retired transports and rejects later use', () async {
+        const pubkey =
+            '3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d';
+        final staleRequest = Completer<http.StreamedResponse>();
+        late _ControlledClient firstClient;
+        late _ControlledClient retryClient;
+        var firstClientCalls = 0;
+        var retryClientCalls = 0;
+        var factoryCalls = 0;
+
+        firstClient = _ControlledClient((request) {
+          firstClientCalls++;
+          if (firstClientCalls == 1) {
+            return staleRequest.future;
+          }
+          throw http.ClientException('Connection reset', request.url);
+        });
+        retryClient = _ControlledClient((request) async {
+          retryClientCalls++;
+          return _rpcResult(request, {'result': pubkey});
+        });
+        final clients = [firstClient, retryClient];
+
+        final rpc = KeycastRpc(
+          nostrApi: 'https://login.divine.video/api/nostr',
+          accessToken: 'test_token',
+          httpClientFactory: () => clients[factoryCalls++],
+        );
+
+        final staleFuture = rpc.getPublicKey();
+        await Future<void>.value();
+        expect(await rpc.getPublicKey(), pubkey);
+        expect(firstClient.closeCount, equals(0));
+
+        rpc.close();
+
+        expect(firstClient.closeCount, equals(1));
+        expect(retryClient.closeCount, equals(1));
+        await expectLater(rpc.getPublicKey(), throwsA(isA<StateError>()));
+
+        staleRequest.completeError(
+          http.ClientException(
+            'Bad file descriptor',
+            Uri.parse('https://login.divine.video/api/nostr'),
+          ),
+        );
+        await expectLater(staleFuture, throwsA(isA<http.ClientException>()));
+        expect(retryClientCalls, equals(1));
+      });
+
+      test('shares one single-op deadline across a socket retry', () async {
+        var firstClientCalls = 0;
+        var retryClientCalls = 0;
+        final firstClient = MockClient((request) async {
+          firstClientCalls++;
+          await Future<void>.delayed(const Duration(milliseconds: 150));
+          throw http.ClientException('Connection reset', request.url);
+        });
+        final retryClient = MockClient((request) {
+          retryClientCalls++;
+          return Completer<http.Response>().future;
+        });
+        final rpc = KeycastRpc(
+          nostrApi: 'https://login.divine.video/api/nostr',
+          accessToken: 'test_token',
+          httpClient: firstClient,
+          httpClientFactory: () => retryClient,
+          requestTimeout: const Duration(milliseconds: 250),
+        );
+        final stopwatch = Stopwatch()..start();
+
+        await expectLater(
+          rpc.getPublicKey(),
+          throwsA(isA<RpcTimeoutException>()),
+        );
+
+        expect(firstClientCalls, equals(1));
+        expect(retryClientCalls, equals(1));
+        expect(stopwatch.elapsed, lessThan(const Duration(milliseconds: 330)));
+      });
+
+      test(
+        'shares one single-op deadline across a 401 refresh retry',
+        () async {
+          var callCount = 0;
+          mockClient = MockClient((request) async {
+            callCount++;
+            if (callCount == 1) {
+              await Future<void>.delayed(const Duration(milliseconds: 150));
+              return http.Response('Unauthorized', 401);
+            }
+            return Completer<http.Response>().future;
+          });
+          final rpc = KeycastRpc(
+            nostrApi: 'https://login.divine.video/api/nostr',
+            accessToken: 'expired_token',
+            httpClient: mockClient,
+            onTokenRefresh: () async => 'fresh_token',
+            requestTimeout: const Duration(milliseconds: 250),
+          );
+          final stopwatch = Stopwatch()..start();
+
+          await expectLater(
+            rpc.getPublicKey(),
+            throwsA(isA<RpcTimeoutException>()),
+          );
+
+          expect(callCount, equals(2));
+          expect(
+            stopwatch.elapsed,
+            lessThan(const Duration(milliseconds: 330)),
+          );
+        },
+      );
     });
 
     group('signEvent', () {

--- a/mobile/packages/keycast_flutter/test/rpc_client_test.dart
+++ b/mobile/packages/keycast_flutter/test/rpc_client_test.dart
@@ -267,7 +267,10 @@ void main() {
 
         expect(firstClient.closeCount, equals(1));
         expect(retryClient.closeCount, equals(1));
-        await expectLater(rpc.getPublicKey(), throwsA(isA<StateError>()));
+        await expectLater(
+          rpc.getPublicKey(),
+          throwsA(isA<KeycastRpcClosedException>()),
+        );
 
         staleRequest.completeError(
           http.ClientException(

--- a/mobile/packages/keycast_flutter/test/rpc_client_test.dart
+++ b/mobile/packages/keycast_flutter/test/rpc_client_test.dart
@@ -917,6 +917,19 @@ void main() {
         'sig': 'b' * 128,
       };
 
+      test('throws when the RPC is closed', () async {
+        final rpc = KeycastRpc(
+          nostrApi: 'https://login.divine.video/api/nostr',
+          accessToken: 'test_token',
+          httpClient: mockClient,
+        )..close();
+
+        await expectLater(
+          rpc.nip17UnwrapBatch([giftWrap('1')]),
+          throwsA(isA<KeycastRpcClosedException>()),
+        );
+      });
+
       test('posts the verb with the gift-wrap list and parses ordered '
           'slots', () async {
         final wraps = [giftWrap('11'), giftWrap('22')];

--- a/mobile/packages/keycast_flutter/test/rpc_client_test.dart
+++ b/mobile/packages/keycast_flutter/test/rpc_client_test.dart
@@ -287,7 +287,7 @@ void main() {
         var retryClientCalls = 0;
         final firstClient = MockClient((request) async {
           firstClientCalls++;
-          await Future<void>.delayed(const Duration(milliseconds: 150));
+          await Future<void>.delayed(const Duration(milliseconds: 200));
           throw http.ClientException('Connection reset', request.url);
         });
         final retryClient = MockClient((request) {
@@ -299,7 +299,7 @@ void main() {
           accessToken: 'test_token',
           httpClient: firstClient,
           httpClientFactory: () => retryClient,
-          requestTimeout: const Duration(milliseconds: 250),
+          requestTimeout: const Duration(milliseconds: 300),
         );
         final stopwatch = Stopwatch()..start();
 
@@ -310,7 +310,10 @@ void main() {
 
         expect(firstClientCalls, equals(1));
         expect(retryClientCalls, equals(1));
-        expect(stopwatch.elapsed, lessThan(const Duration(milliseconds: 330)));
+        // Shared deadline: ~300ms. A doubled (per-attempt) deadline would take
+        // ~500ms, so this bound fails for the regression it guards while
+        // leaving slack for loaded CI runners.
+        expect(stopwatch.elapsed, lessThan(const Duration(milliseconds: 400)));
       });
 
       test(
@@ -320,7 +323,7 @@ void main() {
           mockClient = MockClient((request) async {
             callCount++;
             if (callCount == 1) {
-              await Future<void>.delayed(const Duration(milliseconds: 150));
+              await Future<void>.delayed(const Duration(milliseconds: 200));
               return http.Response('Unauthorized', 401);
             }
             return Completer<http.Response>().future;
@@ -330,7 +333,7 @@ void main() {
             accessToken: 'expired_token',
             httpClient: mockClient,
             onTokenRefresh: () async => 'fresh_token',
-            requestTimeout: const Duration(milliseconds: 250),
+            requestTimeout: const Duration(milliseconds: 300),
           );
           final stopwatch = Stopwatch()..start();
 
@@ -340,9 +343,10 @@ void main() {
           );
 
           expect(callCount, equals(2));
+          // Shared deadline: ~300ms; a doubled deadline would take ~500ms.
           expect(
             stopwatch.elapsed,
-            lessThan(const Duration(milliseconds: 330)),
+            lessThan(const Duration(milliseconds: 400)),
           );
         },
       );

--- a/mobile/packages/keycast_flutter/test/rpc_client_test.dart
+++ b/mobile/packages/keycast_flutter/test/rpc_client_test.dart
@@ -174,6 +174,60 @@ void main() {
         expect(firstClientCalls, equals(1));
         expect(retryClientCalls, equals(1));
       });
+
+      test(
+        'defers closing a retired transport until sibling requests finish',
+        () async {
+          const pubkey =
+              '3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d';
+          final staleRequest = Completer<http.StreamedResponse>();
+          late _ControlledClient firstClient;
+          late _ControlledClient retryClient;
+          var firstClientCalls = 0;
+          var retryClientCalls = 0;
+          var factoryCalls = 0;
+
+          firstClient = _ControlledClient((request) {
+            firstClientCalls++;
+            if (firstClientCalls == 1) {
+              return staleRequest.future;
+            }
+            throw http.ClientException('Connection reset', request.url);
+          });
+          retryClient = _ControlledClient((request) async {
+            retryClientCalls++;
+            return _rpcResult(request, {'result': pubkey});
+          });
+          final clients = [firstClient, retryClient];
+
+          final rpc = KeycastRpc(
+            nostrApi: 'https://login.divine.video/api/nostr',
+            accessToken: 'test_token',
+            httpClientFactory: () => clients[factoryCalls++],
+          );
+
+          final staleFuture = rpc.getPublicKey();
+          await Future<void>.value();
+          expect(firstClientCalls, equals(1));
+
+          final resetResult = await rpc.getPublicKey();
+          expect(resetResult, pubkey);
+          expect(factoryCalls, equals(2));
+          expect(firstClient.closeCount, equals(0));
+
+          staleRequest.completeError(
+            http.ClientException(
+              'Bad file descriptor',
+              Uri.parse('https://login.divine.video/api/nostr'),
+            ),
+          );
+
+          expect(await staleFuture, pubkey);
+          expect(factoryCalls, equals(2));
+          expect(retryClientCalls, equals(2));
+          expect(firstClient.closeCount, equals(1));
+        },
+      );
     });
 
     group('signEvent', () {
@@ -972,10 +1026,9 @@ void main() {
           );
         });
 
-        final slots = await rpcWith(mockClient).nip17WrapBatch(
-          rumor,
-          recipients,
-        );
+        final slots = await rpcWith(
+          mockClient,
+        ).nip17WrapBatch(rumor, recipients);
 
         expect(slots, hasLength(2));
         expect(slots![0].isSuccess, isTrue);
@@ -997,10 +1050,9 @@ void main() {
           );
         });
 
-        final slots = await rpcWith(mockClient).nip17WrapBatch(
-          rumor,
-          recipients,
-        );
+        final slots = await rpcWith(
+          mockClient,
+        ).nip17WrapBatch(rumor, recipients);
 
         expect(slots![0].isSuccess, isTrue);
         expect(slots[1].isSuccess, isFalse);
@@ -1191,4 +1243,39 @@ void main() {
       });
     });
   });
+}
+
+http.StreamedResponse _rpcResult(
+  http.BaseRequest request,
+  Object body, {
+  int statusCode = 200,
+}) {
+  return http.StreamedResponse(
+    Stream.value(utf8.encode(jsonEncode(body))),
+    statusCode,
+    request: request,
+  );
+}
+
+class _ControlledClient extends http.BaseClient {
+  _ControlledClient(this._handler);
+
+  final Future<http.StreamedResponse> Function(http.BaseRequest request)
+  _handler;
+  int closeCount = 0;
+  bool isClosed = false;
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) {
+    if (isClosed) {
+      throw http.ClientException('Client is already closed.', request.url);
+    }
+    return _handler(request);
+  }
+
+  @override
+  void close() {
+    closeCount++;
+    isClosed = true;
+  }
 }

--- a/mobile/packages/keycast_flutter/test/rpc_client_test.dart
+++ b/mobile/packages/keycast_flutter/test/rpc_client_test.dart
@@ -1048,6 +1048,39 @@ void main() {
         );
       });
 
+      test('late 401 with timed-out refresh propagates timeout rather than '
+          'returning null', () async {
+        var postCalls = 0;
+        mockClient = MockClient((request) async {
+          postCalls++;
+          await Future<void>.delayed(const Duration(milliseconds: 150));
+          return http.Response('expired', 401);
+        });
+        var refreshCalls = 0;
+        final rpc = KeycastRpc(
+          nostrApi: 'https://login.divine.video/api/nostr',
+          accessToken: 'expired_token',
+          httpClient: mockClient,
+          batchRequestTimeout: const Duration(milliseconds: 200),
+          onTokenRefresh: () async {
+            refreshCalls++;
+            await Future<void>.delayed(const Duration(milliseconds: 100));
+            return 'fresh_token';
+          },
+        );
+
+        await expectLater(
+          rpc.nip17UnwrapBatch([giftWrap('1')]),
+          throwsA(isA<TimeoutException>()),
+        );
+        expect(
+          postCalls,
+          equals(1),
+          reason: 'the refresh timed out before a retry POST could be issued.',
+        );
+        expect(refreshCalls, equals(1));
+      });
+
       test('is bounded by batchRequestTimeout, not the shorter single-op '
           'requestTimeout', () async {
         // The heavier batch verb must NOT be aborted by the short single-op

--- a/mobile/packages/keycast_flutter/test/rpc_client_test.dart
+++ b/mobile/packages/keycast_flutter/test/rpc_client_test.dart
@@ -106,14 +106,15 @@ void main() {
         );
       });
 
-      test('retries once when the first request has a socket error', () async {
-        var callCount = 0;
-        mockClient = MockClient((request) async {
-          callCount++;
-          if (callCount == 1) {
-            throw http.ClientException('Connection reset', request.url);
-          }
-
+      test('retries once on a fresh transport after a socket error', () async {
+        var firstClientCalls = 0;
+        var retryClientCalls = 0;
+        final firstClient = MockClient((request) async {
+          firstClientCalls++;
+          throw http.ClientException('Connection reset', request.url);
+        });
+        final retryClient = MockClient((request) async {
+          retryClientCalls++;
           final body = jsonDecode(request.body);
           expect(body['method'], 'get_public_key');
           return http.Response(
@@ -124,11 +125,16 @@ void main() {
             200,
           );
         });
+        var factoryCalls = 0;
 
         final rpc = KeycastRpc(
           nostrApi: 'https://login.divine.video/api/nostr',
           accessToken: 'test_token',
-          httpClient: mockClient,
+          httpClient: firstClient,
+          httpClientFactory: () {
+            factoryCalls++;
+            return retryClient;
+          },
         );
 
         final pubkey = await rpc.getPublicKey();
@@ -137,7 +143,36 @@ void main() {
           pubkey,
           '3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d',
         );
-        expect(callCount, equals(2));
+        expect(firstClientCalls, equals(1));
+        expect(factoryCalls, equals(1));
+        expect(retryClientCalls, equals(1));
+      });
+
+      test('propagates socket error when the one retry also fails', () async {
+        var firstClientCalls = 0;
+        var retryClientCalls = 0;
+        final firstClient = MockClient((request) async {
+          firstClientCalls++;
+          throw http.ClientException('Bad file descriptor', request.url);
+        });
+        final retryClient = MockClient((request) async {
+          retryClientCalls++;
+          throw http.ClientException('Connection reset', request.url);
+        });
+
+        final rpc = KeycastRpc(
+          nostrApi: 'https://login.divine.video/api/nostr',
+          accessToken: 'test_token',
+          httpClient: firstClient,
+          httpClientFactory: () => retryClient,
+        );
+
+        await expectLater(
+          rpc.getPublicKey(),
+          throwsA(isA<http.ClientException>()),
+        );
+        expect(firstClientCalls, equals(1));
+        expect(retryClientCalls, equals(1));
       });
     });
 
@@ -747,6 +782,53 @@ void main() {
         expect(slots[0].rumor, rumor);
         expect(slots[1].isSuccess, isFalse);
         expect(slots[1].error, 'sender_mismatch');
+      });
+
+      test('retries batch request once on a fresh transport after a socket '
+          'error', () async {
+        final wraps = [giftWrap('11')];
+        final rumor = {
+          'id': 'c' * 64,
+          'pubkey': 'd' * 64,
+          'created_at': 1700000001,
+          'kind': 14,
+          'tags': <List<String>>[],
+          'content': 'hello',
+        };
+        var firstClientCalls = 0;
+        var retryClientCalls = 0;
+        final firstClient = MockClient((request) async {
+          firstClientCalls++;
+          throw http.ClientException('Bad file descriptor', request.url);
+        });
+        final retryClient = MockClient((request) async {
+          retryClientCalls++;
+          final body = jsonDecode(request.body);
+          expect(body['method'], 'nip17_unwrap_batch');
+          expect(body['params'], wraps);
+          return http.Response(
+            jsonEncode({
+              'result': [
+                {'rumor': rumor, 'sender': 'd' * 64},
+              ],
+            }),
+            200,
+          );
+        });
+
+        final rpc = KeycastRpc(
+          nostrApi: 'https://login.divine.video/api/nostr',
+          accessToken: 'test_token',
+          httpClient: firstClient,
+          httpClientFactory: () => retryClient,
+        );
+
+        final slots = await rpc.nip17UnwrapBatch(wraps);
+
+        expect(slots, hasLength(1));
+        expect(slots![0].isSuccess, isTrue);
+        expect(firstClientCalls, equals(1));
+        expect(retryClientCalls, equals(1));
       });
 
       test('returns null when the backend lacks the verb', () async {

--- a/mobile/packages/keycast_flutter/test/rpc_client_test.dart
+++ b/mobile/packages/keycast_flutter/test/rpc_client_test.dart
@@ -105,6 +105,40 @@ void main() {
           '3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d',
         );
       });
+
+      test('retries once when the first request has a socket error', () async {
+        var callCount = 0;
+        mockClient = MockClient((request) async {
+          callCount++;
+          if (callCount == 1) {
+            throw http.ClientException('Connection reset', request.url);
+          }
+
+          final body = jsonDecode(request.body);
+          expect(body['method'], 'get_public_key');
+          return http.Response(
+            jsonEncode({
+              'result':
+                  '3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d',
+            }),
+            200,
+          );
+        });
+
+        final rpc = KeycastRpc(
+          nostrApi: 'https://login.divine.video/api/nostr',
+          accessToken: 'test_token',
+          httpClient: mockClient,
+        );
+
+        final pubkey = await rpc.getPublicKey();
+
+        expect(
+          pubkey,
+          '3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d',
+        );
+        expect(callCount, equals(2));
+      });
     });
 
     group('signEvent', () {

--- a/mobile/scripts/baseline/service_god_file_sizes.txt
+++ b/mobile/scripts/baseline/service_god_file_sizes.txt
@@ -6,7 +6,7 @@
 # This hard service baseline is authoritative over the advisory file_sizes.txt
 # baseline for service god-file ceilings.
 # Regenerate after shrinking/removing: UPDATE_BASELINE=1 bash scripts/check_service_god_file_ceiling.sh
-lib/services/auth_service.dart	4735
+lib/services/auth_service.dart	4674
 lib/services/curated_list_service.dart	1848
 lib/services/upload_manager.dart	2317
 lib/services/video_editor/video_editor_render_service.dart	1539

--- a/mobile/test/services/auth_service_expired_session_downgrade_test.dart
+++ b/mobile/test/services/auth_service_expired_session_downgrade_test.dart
@@ -11,7 +11,7 @@ import 'package:http/testing.dart';
 import 'package:keycast_flutter/keycast_flutter.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:nostr_key_manager/nostr_key_manager.dart';
-import 'package:nostr_sdk/nostr_sdk.dart' show generatePrivateKey;
+import 'package:nostr_sdk/nostr_sdk.dart' show Nip19, generatePrivateKey;
 import 'package:openvine/models/auth_rpc_capability.dart';
 import 'package:openvine/services/auth/nostr_identity.dart';
 import 'package:openvine/services/auth_service.dart';
@@ -1299,8 +1299,85 @@ void main() {
         activeRpc.getPublicKey(),
         throwsA(isA<KeycastRpcClosedException>()),
         reason:
-            'sign-out must close the KeycastRpc it cleared so the owned '
-            'transport is not left open',
+            'sign-out must close the KeycastRpc it cleared so later use is '
+            'terminal (KeycastRpcClosedException), not silently dead',
+      );
+    });
+
+    test("same-pubkey nsec import retains the live client's signer", () async {
+      // Pins the retain decision in _setupUserSession's non-OAuth branch:
+      // a Divine OAuth user importing their own nsec keeps the pubkey, so
+      // the app-wide NostrClient is NOT rebuilt (#5909) and still holds the
+      // previous KeycastNostrIdentity — its RPC must stay usable.
+      SharedPreferences.setMockInitialValues({
+        'authentication_source': 'divineOAuth',
+        'tos_accepted': true,
+      });
+
+      arrangeExpiredSessionWithLocalKeys();
+      final expiredSession = KeycastSession.fromJson(
+        jsonDecode(secureStorage['keycast_session']!) as Map<String, dynamic>,
+      );
+
+      // The nsec for the SAME pubkey the expired session is bound to: the
+      // arrange helper stored its private key in nostr_primary_key.
+      final storedKey = secureStorage['nostr_primary_key']!;
+      final privateKeyHex = storedKey
+          .substring(
+            storedKey.indexOf('privateKeyHex:') + 'privateKeyHex:'.length,
+          )
+          .split('|')
+          .first;
+      final expiredPubkey = expiredSession.userPubkey!;
+
+      final retainedRpc = KeycastRpc(
+        nostrApi: 'https://login.divine.video/api/nostr',
+        accessToken: 'retained_token',
+        httpClient: MockClient(
+          (request) async => http.Response(
+            jsonEncode({'result': expiredPubkey}),
+            200,
+          ),
+        ),
+      );
+
+      final authService = createAuthService();
+      final retainedIdentity = KeycastNostrIdentity(
+        pubkey: expiredPubkey,
+        rpcSigner: retainedRpc,
+      );
+
+      await runZonedGuarded(
+        () async {
+          // Stand in for the authenticated OAuth session whose live
+          // NostrClient holds the retained identity.
+          authService.debugSetKeycastSigner(retainedRpc);
+          authService.debugSetIdentity(retainedIdentity);
+
+          final result = await authService.importFromNsec(
+            Nip19.encodePrivateKey(privateKeyHex),
+          );
+          expect(result.success, isTrue);
+
+          // Anti-vacuous: the import must have actually swapped the
+          // identity off the retained one while keeping the pubkey.
+          expect(authService.currentIdentity, isNot(same(retainedIdentity)));
+          expect(authService.currentPublicKeyHex, equals(expiredPubkey));
+
+          // The production regression this pins: if the non-OAuth branch
+          // closed the previous signer, this throws
+          // KeycastRpcClosedException.
+          expect(
+            await retainedRpc.getPublicKey(),
+            equals(expiredPubkey),
+            reason:
+                'the RPC still held by the live NostrClient must survive a '
+                'same-pubkey nsec import',
+          );
+        },
+        (error, stack) {
+          // Ignore background errors (RPC connection, relay discovery)
+        },
       );
     });
 

--- a/mobile/test/services/auth_service_expired_session_downgrade_test.dart
+++ b/mobile/test/services/auth_service_expired_session_downgrade_test.dart
@@ -6,6 +6,8 @@ import 'dart:convert';
 
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
 import 'package:keycast_flutter/keycast_flutter.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:nostr_key_manager/nostr_key_manager.dart';
@@ -1250,6 +1252,57 @@ void main() {
         );
       },
     );
+
+    test('sign-out closes the active Keycast RPC signer', () async {
+      // Pins the production close-on-clear decision: signOut() clears the
+      // signer through _setKeycastSigner(null), which must close the owned
+      // KeycastRpc transport rather than abandon it.
+      SharedPreferences.setMockInitialValues({
+        'authentication_source': 'divineOAuth',
+        'tos_accepted': true,
+      });
+
+      arrangeExpiredSessionWithLocalKeys();
+      when(
+        () => mockOAuthClient.refreshSession(
+          userPubkey: any(named: 'userPubkey'),
+        ),
+      ).thenAnswer((_) async => null);
+      when(() => mockOAuthClient.logout()).thenAnswer((_) async {});
+
+      final activeRpc = KeycastRpc(
+        nostrApi: 'https://login.divine.video/api/nostr',
+        accessToken: 'active_token',
+        httpClient: MockClient(
+          (request) async => http.Response(
+            jsonEncode({'result': 'ok'}),
+            200,
+          ),
+        ),
+      );
+
+      final authService = createAuthService();
+
+      await runZonedGuarded(
+        () async {
+          await authService.initialize();
+          authService.debugSetKeycastSigner(activeRpc);
+          await authService.signOut();
+        },
+        (error, stack) {
+          // Ignore background relay/RPC errors
+        },
+      );
+
+      expect(authService.authState, equals(AuthState.unauthenticated));
+      await expectLater(
+        activeRpc.getPublicKey(),
+        throwsA(isA<KeycastRpcClosedException>()),
+        reason:
+            'sign-out must close the KeycastRpc it cleared so the owned '
+            'transport is not left open',
+      );
+    });
 
     test('isRpcUpgradeInProgress is false after upgrade completes', () async {
       // Regression for #4626: isRpcUpgradeInProgress must be false after

--- a/mobile/test/services/auth_service_expired_session_downgrade_test.dart
+++ b/mobile/test/services/auth_service_expired_session_downgrade_test.dart
@@ -1346,6 +1346,7 @@ void main() {
         pubkey: expiredPubkey,
         rpcSigner: retainedRpc,
       );
+      late AuthResult result;
 
       await runZonedGuarded(
         () async {
@@ -1354,30 +1355,33 @@ void main() {
           authService.debugSetKeycastSigner(retainedRpc);
           authService.debugSetIdentity(retainedIdentity);
 
-          final result = await authService.importFromNsec(
+          result = await authService.importFromNsec(
             Nip19.encodePrivateKey(privateKeyHex),
-          );
-          expect(result.success, isTrue);
-
-          // Anti-vacuous: the import must have actually swapped the
-          // identity off the retained one while keeping the pubkey.
-          expect(authService.currentIdentity, isNot(same(retainedIdentity)));
-          expect(authService.currentPublicKeyHex, equals(expiredPubkey));
-
-          // The production regression this pins: if the non-OAuth branch
-          // closed the previous signer, this throws
-          // KeycastRpcClosedException.
-          expect(
-            await retainedRpc.getPublicKey(),
-            equals(expiredPubkey),
-            reason:
-                'the RPC still held by the live NostrClient must survive a '
-                'same-pubkey nsec import',
           );
         },
         (error, stack) {
-          // Ignore background errors (RPC connection, relay discovery)
+          // Ignore background errors (RPC connection, relay discovery).
+          // Assertions live outside the zone: this handler must not
+          // swallow them into a framework timeout.
         },
+      );
+
+      expect(result.success, isTrue);
+
+      // Anti-vacuous: the import must have actually swapped the
+      // identity off the retained one while keeping the pubkey.
+      expect(authService.currentIdentity, isNot(same(retainedIdentity)));
+      expect(authService.currentPublicKeyHex, equals(expiredPubkey));
+
+      // The production regression this pins: if the non-OAuth branch
+      // closed the previous signer, this throws
+      // KeycastRpcClosedException.
+      expect(
+        await retainedRpc.getPublicKey(),
+        equals(expiredPubkey),
+        reason:
+            'the RPC still held by the live NostrClient must survive a '
+            'same-pubkey nsec import',
       );
     });
 

--- a/mobile/test/services/auth_service_oauth_local_signing_test.dart
+++ b/mobile/test/services/auth_service_oauth_local_signing_test.dart
@@ -540,5 +540,63 @@ void main() {
         expect(retainedCalls, equals(1));
       },
     );
+
+    test(
+      'unbound-session OAuth re-sign-in keeps retained signer open',
+      () async {
+        // A fresh code-exchange session (fromTokenResponse) carries no
+        // userPubkey, so the close decision at the top of
+        // signInWithDivineOAuth cannot know the pubkey yet. It must treat
+        // unknown as same: closing here would strand the live NostrClient
+        // holding the retained RPC — even when the sign-in itself later
+        // fails, the close has already happened.
+        var retainedCalls = 0;
+        final retainedRpc = KeycastRpc(
+          nostrApi: 'https://login.divine.video/api/nostr',
+          accessToken: 'retained_token',
+          httpClient: MockClient((request) async {
+            retainedCalls++;
+            return http.Response(jsonEncode({'result': 'ciphertext'}), 200);
+          }),
+        );
+        addTearDown(retainedRpc.close);
+
+        authService = createAuthService();
+        await _ignoringDiscoveryErrors(
+          () => authService.signInWithDivineOAuth(session),
+        );
+
+        authService.debugSetKeycastSigner(retainedRpc);
+        final retainedIdentity = KeycastNostrIdentity(
+          pubkey: matchingContainer.publicKeyHex,
+          rpcSigner: retainedRpc,
+        );
+        authService.debugSetIdentity(retainedIdentity);
+
+        final unboundSession = KeycastSession(
+          bunkerUrl: 'https://keycast.example.com',
+          accessToken: 'fresh_code_exchange_token',
+          expiresAt: DateTime.now().add(const Duration(hours: 1)),
+          refreshToken: 'fresh_refresh_token',
+        );
+
+        await _ignoringDiscoveryErrors(
+          () => authService.signInWithDivineOAuth(unboundSession),
+        );
+
+        expect(
+          await retainedIdentity.nip44Encrypt(
+            otherContainer.publicKeyHex,
+            'hello',
+          ),
+          equals('ciphertext'),
+          reason:
+              'The RPC still held by the live NostrClient must survive a '
+              'same-pubkey re-sign-in whose session has not bound its '
+              'userPubkey yet.',
+        );
+        expect(retainedCalls, equals(1));
+      },
+    );
   });
 }

--- a/mobile/test/services/auth_service_oauth_local_signing_test.dart
+++ b/mobile/test/services/auth_service_oauth_local_signing_test.dart
@@ -429,15 +429,21 @@ void main() {
         );
         addTearDown(retainedRpc.close);
 
-        final upgradedRpc = KeycastRpc(
-          nostrApi: 'https://login.divine.video/api/nostr',
-          accessToken: 'upgraded_token',
-          httpClient: MockClient((request) async {
-            return http.Response(jsonEncode({'result': 'unused'}), 200);
-          }),
-        );
+        when(
+          () => mockKeyStorage.getIdentityKeyContainer(
+            matchingContainer.npub,
+            biometricPrompt: any(named: 'biometricPrompt'),
+          ),
+        ).thenAnswer((_) async => matchingContainer);
 
         authService = createAuthService();
+        await _ignoringDiscoveryErrors(
+          () => authService.signInWithDivineOAuth(session),
+        );
+
+        // Stand in for the signer the live NostrClient was built with: #5909
+        // keeps that client across a same-pubkey re-emission, so it holds this
+        // identity — and this RPC — after AuthService moves on.
         authService.debugSetKeycastSigner(retainedRpc);
         final retainedIdentity = KeycastNostrIdentity(
           pubkey: matchingContainer.publicKeyHex,
@@ -445,18 +451,48 @@ void main() {
         );
         authService.debugSetIdentity(retainedIdentity);
 
-        // Same-pubkey RPC upgrade replaces AuthService's current signer, but
-        // NostrService deliberately retains its live client and the identity
-        // object injected into that client. That retained identity's RPC must
-        // stay usable until the client is actually rebuilt or disposed.
-        authService.debugSetKeycastSigner(upgradedRpc, closePrevious: false);
+        // Drive the real upgrade rather than calling the seam with
+        // `closePrevious: false` ourselves: the behaviour under test is
+        // _upgradeDivineRpcInBackground *choosing* not to close, so the test
+        // must go red if that call site stops passing the flag.
+        // No stored RPC session on resume forces the refresh branch.
+        when(() => mockOAuthClient.getSession()).thenAnswer((_) async => null);
+        when(
+          () => mockOAuthClient.refreshSession(
+            userPubkey: any(named: 'userPubkey'),
+          ),
+        ).thenAnswer(
+          (_) async => KeycastSession(
+            bunkerUrl: 'https://keycast.example.com',
+            accessToken: 'refreshed_access_token',
+            expiresAt: DateTime.now().add(const Duration(hours: 1)),
+            refreshToken: 'refreshed_refresh_token',
+            userPubkey: matchingContainer.publicKeyHex,
+          ),
+        );
 
+        await _ignoringDiscoveryErrors(() async {
+          authService.onAppResumed();
+          await pumpEventQueue();
+        });
+
+        expect(
+          authService.currentIdentity,
+          isNot(same(retainedIdentity)),
+          reason:
+              'The upgrade must have reached the signer swap and rebuilt the '
+              'identity — otherwise this test passes vacuously without ever '
+              'exercising the close decision.',
+        );
         expect(
           await retainedIdentity.nip44Encrypt(
             otherContainer.publicKeyHex,
             'hello',
           ),
           equals('ciphertext'),
+          reason:
+              'The RPC still held by the live NostrClient must survive the '
+              'upgrade; closing it strands every publish on that client.',
         );
         expect(retainedCalls, equals(1));
       },

--- a/mobile/test/services/auth_service_oauth_local_signing_test.dart
+++ b/mobile/test/services/auth_service_oauth_local_signing_test.dart
@@ -2,9 +2,12 @@
 // ABOUTME: Pins that locally-stored nsec bypasses Keycast RPC for signing.
 
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
 import 'package:keycast_flutter/keycast_flutter.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:nostr_key_manager/nostr_key_manager.dart';
@@ -407,6 +410,55 @@ void main() {
             biometricPrompt: any(named: 'biometricPrompt'),
           ),
         );
+      },
+    );
+
+    test(
+      'same-pubkey RPC upgrade does not close signer retained by live client',
+      () async {
+        var retainedCalls = 0;
+        final retainedRpc = KeycastRpc(
+          nostrApi: 'https://login.divine.video/api/nostr',
+          accessToken: 'retained_token',
+          httpClient: MockClient((request) async {
+            retainedCalls++;
+            final body = jsonDecode(request.body) as Map<String, dynamic>;
+            expect(body['method'], equals('nip44_encrypt'));
+            return http.Response(jsonEncode({'result': 'ciphertext'}), 200);
+          }),
+        );
+        addTearDown(retainedRpc.close);
+
+        final upgradedRpc = KeycastRpc(
+          nostrApi: 'https://login.divine.video/api/nostr',
+          accessToken: 'upgraded_token',
+          httpClient: MockClient((request) async {
+            return http.Response(jsonEncode({'result': 'unused'}), 200);
+          }),
+        );
+
+        authService = createAuthService();
+        authService.debugSetKeycastSigner(retainedRpc);
+        final retainedIdentity = KeycastNostrIdentity(
+          pubkey: matchingContainer.publicKeyHex,
+          rpcSigner: retainedRpc,
+        );
+        authService.debugSetIdentity(retainedIdentity);
+
+        // Same-pubkey RPC upgrade replaces AuthService's current signer, but
+        // NostrService deliberately retains its live client and the identity
+        // object injected into that client. That retained identity's RPC must
+        // stay usable until the client is actually rebuilt or disposed.
+        authService.debugSetKeycastSigner(upgradedRpc, closePrevious: false);
+
+        expect(
+          await retainedIdentity.nip44Encrypt(
+            otherContainer.publicKeyHex,
+            'hello',
+          ),
+          equals('ciphertext'),
+        );
+        expect(retainedCalls, equals(1));
       },
     );
   });

--- a/mobile/test/services/auth_service_oauth_local_signing_test.dart
+++ b/mobile/test/services/auth_service_oauth_local_signing_test.dart
@@ -497,5 +497,48 @@ void main() {
         expect(retainedCalls, equals(1));
       },
     );
+
+    test(
+      'same-pubkey OAuth re-sign-in keeps signer retained by live client open',
+      () async {
+        var retainedCalls = 0;
+        final retainedRpc = KeycastRpc(
+          nostrApi: 'https://login.divine.video/api/nostr',
+          accessToken: 'retained_token',
+          httpClient: MockClient((request) async {
+            retainedCalls++;
+            return http.Response(jsonEncode({'result': 'ciphertext'}), 200);
+          }),
+        );
+        addTearDown(retainedRpc.close);
+
+        authService = createAuthService();
+        await _ignoringDiscoveryErrors(
+          () => authService.signInWithDivineOAuth(session),
+        );
+
+        authService.debugSetKeycastSigner(retainedRpc);
+        final retainedIdentity = KeycastNostrIdentity(
+          pubkey: matchingContainer.publicKeyHex,
+          rpcSigner: retainedRpc,
+        );
+        authService.debugSetIdentity(retainedIdentity);
+
+        await _ignoringDiscoveryErrors(
+          () => authService.signInWithDivineOAuth(
+            session.copyWith(accessToken: 'refreshed_access_token'),
+          ),
+        );
+
+        expect(
+          await retainedIdentity.nip44Encrypt(
+            otherContainer.publicKeyHex,
+            'hello',
+          ),
+          equals('ciphertext'),
+        );
+        expect(retainedCalls, equals(1));
+      },
+    );
   });
 }

--- a/mobile/test/widgets/video_thumbnail_widget_test.dart
+++ b/mobile/test/widgets/video_thumbnail_widget_test.dart
@@ -26,7 +26,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../helpers/test_provider_overrides.dart'
-    show createMockMediaCacheManager;
+    show createMockMediaCacheManager, testMaterialApp;
 import '../test_data/video_test_data.dart';
 
 Finder _divineIcon(DivineIconName name) =>
@@ -1045,7 +1045,7 @@ void main() {
 
       Widget buildSubject(double width) => UncontrolledProviderScope(
         container: container,
-        child: MaterialApp(
+        child: testMaterialApp(
           home: PassiveAuthThumbnailImage(url: url, width: width),
         ),
       );

--- a/mobile/test/widgets/video_thumbnail_widget_test.dart
+++ b/mobile/test/widgets/video_thumbnail_widget_test.dart
@@ -915,6 +915,64 @@ void main() {
     );
 
     testWidgets(
+      'suppresses repeated unauthenticated Divine thumbnail requests after passive auth is blocked by preference',
+      (tester) async {
+        final mediaAuthInterceptor = _MockMediaAuthInterceptor();
+        const hash =
+            '72d7eda61074b17e077fb9f4a8b48166cdeb65cb07e053aafa6e69d5fa165995';
+        const url = 'https://media.divine.video/$hash.jpg';
+        when(
+          () => mediaAuthInterceptor.createPassiveAuthHeadersForAdultMedia(
+            sha256Hash: any(named: 'sha256Hash'),
+            serverUrl: any(named: 'serverUrl'),
+          ),
+        ).thenAnswer((_) async => const ViewerAuthBlockedByPreference());
+
+        final container = ProviderContainer(
+          overrides: _passiveAuthProviderOverrides(mediaAuthInterceptor),
+        );
+        addTearDown(container.dispose);
+
+        Widget buildSubject() => UncontrolledProviderScope(
+          container: container,
+          child: MaterialApp(
+            home: PassiveAuthThumbnailImage(
+              url: url,
+              errorWidget: (_, _, error) => Text('fallback: $error'),
+            ),
+          ),
+        );
+
+        await tester.pumpWidget(buildSubject());
+
+        final image = tester.widget<Image>(find.byType(Image));
+        image.errorBuilder!(
+          tester.element(find.byType(Image)),
+          NetworkImageLoadException(statusCode: 401, uri: Uri.parse(url)),
+          StackTrace.current,
+        );
+        await tester.pump();
+        await tester.pump();
+
+        expect(find.byType(Image), findsNothing);
+        expect(find.textContaining('fallback:'), findsOneWidget);
+        verify(
+          () => mediaAuthInterceptor.createPassiveAuthHeadersForAdultMedia(
+            sha256Hash: hash,
+            serverUrl: 'https://media.divine.video',
+          ),
+        ).called(1);
+
+        await tester.pumpWidget(const SizedBox.shrink());
+        await tester.pumpWidget(buildSubject());
+
+        expect(find.byType(Image), findsNothing);
+        expect(find.textContaining('fallback:'), findsOneWidget);
+        verifyNoMoreInteractions(mediaAuthInterceptor);
+      },
+    );
+
+    testWidgets(
       'retries a suppressed thumbnail after a transient signer timeout',
       (tester) async {
         final mediaAuthInterceptor = _MockMediaAuthInterceptor();
@@ -934,9 +992,7 @@ void main() {
 
         Widget buildSubject() => UncontrolledProviderScope(
           container: container,
-          child: const MaterialApp(
-            home: PassiveAuthThumbnailImage(url: url),
-          ),
+          child: const MaterialApp(home: PassiveAuthThumbnailImage(url: url)),
         );
 
         await tester.pumpWidget(buildSubject());
@@ -969,59 +1025,58 @@ void main() {
       },
     );
 
-    testWidgets(
-      'does not retry a signer timeout on a retained-state rebuild',
-      (tester) async {
-        final mediaAuthInterceptor = _MockMediaAuthInterceptor();
-        const hash =
-            '72d7eda61074b17e077fb9f4a8b48166cdeb65cb07e053aafa6e69d5fa165995';
-        const url = 'https://media.divine.video/$hash.jpg';
-        when(
-          () => mediaAuthInterceptor.createPassiveAuthHeadersForAdultMedia(
-            sha256Hash: any(named: 'sha256Hash'),
-            serverUrl: any(named: 'serverUrl'),
-          ),
-        ).thenAnswer((_) async => const ViewerAuthSignerUnreachable());
-        final container = ProviderContainer(
-          overrides: _passiveAuthProviderOverrides(mediaAuthInterceptor),
-        );
-        addTearDown(container.dispose);
+    testWidgets('does not retry a signer timeout on a retained-state rebuild', (
+      tester,
+    ) async {
+      final mediaAuthInterceptor = _MockMediaAuthInterceptor();
+      const hash =
+          '72d7eda61074b17e077fb9f4a8b48166cdeb65cb07e053aafa6e69d5fa165995';
+      const url = 'https://media.divine.video/$hash.jpg';
+      when(
+        () => mediaAuthInterceptor.createPassiveAuthHeadersForAdultMedia(
+          sha256Hash: any(named: 'sha256Hash'),
+          serverUrl: any(named: 'serverUrl'),
+        ),
+      ).thenAnswer((_) async => const ViewerAuthSignerUnreachable());
+      final container = ProviderContainer(
+        overrides: _passiveAuthProviderOverrides(mediaAuthInterceptor),
+      );
+      addTearDown(container.dispose);
 
-        Widget buildSubject(double width) => UncontrolledProviderScope(
-          container: container,
-          child: MaterialApp(
-            home: PassiveAuthThumbnailImage(url: url, width: width),
-          ),
-        );
+      Widget buildSubject(double width) => UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp(
+          home: PassiveAuthThumbnailImage(url: url, width: width),
+        ),
+      );
 
-        await tester.pumpWidget(buildSubject(100));
-        var image = tester.widget<Image>(find.byType(Image));
-        image.errorBuilder!(
-          tester.element(find.byType(Image)),
-          NetworkImageLoadException(statusCode: 401, uri: Uri.parse(url)),
-          StackTrace.current,
-        );
-        await tester.pump();
-        await tester.pump();
+      await tester.pumpWidget(buildSubject(100));
+      var image = tester.widget<Image>(find.byType(Image));
+      image.errorBuilder!(
+        tester.element(find.byType(Image)),
+        NetworkImageLoadException(statusCode: 401, uri: Uri.parse(url)),
+        StackTrace.current,
+      );
+      await tester.pump();
+      await tester.pump();
 
-        await tester.pumpWidget(buildSubject(101));
-        image = tester.widget<Image>(find.byType(Image));
-        image.errorBuilder!(
-          tester.element(find.byType(Image)),
-          NetworkImageLoadException(statusCode: 401, uri: Uri.parse(url)),
-          StackTrace.current,
-        );
-        await tester.pump();
-        await tester.pump();
+      await tester.pumpWidget(buildSubject(101));
+      image = tester.widget<Image>(find.byType(Image));
+      image.errorBuilder!(
+        tester.element(find.byType(Image)),
+        NetworkImageLoadException(statusCode: 401, uri: Uri.parse(url)),
+        StackTrace.current,
+      );
+      await tester.pump();
+      await tester.pump();
 
-        verify(
-          () => mediaAuthInterceptor.createPassiveAuthHeadersForAdultMedia(
-            sha256Hash: hash,
-            serverUrl: 'https://media.divine.video',
-          ),
-        ).called(1);
-      },
-    );
+      verify(
+        () => mediaAuthInterceptor.createPassiveAuthHeadersForAdultMedia(
+          sha256Hash: hash,
+          serverUrl: 'https://media.divine.video',
+        ),
+      ).called(1);
+    });
 
     testWidgets(
       'retries a suppressed thumbnail after filters change while unmounted',
@@ -1043,9 +1098,7 @@ void main() {
 
         Widget buildSubject() => UncontrolledProviderScope(
           container: container,
-          child: const MaterialApp(
-            home: PassiveAuthThumbnailImage(url: url),
-          ),
+          child: const MaterialApp(home: PassiveAuthThumbnailImage(url: url)),
         );
 
         await tester.pumpWidget(buildSubject());
@@ -1192,9 +1245,7 @@ void main() {
         await tester.pumpWidget(
           UncontrolledProviderScope(
             container: container,
-            child: MaterialApp(
-              home: PassiveAuthThumbnailImage(url: url),
-            ),
+            child: MaterialApp(home: PassiveAuthThumbnailImage(url: url)),
           ),
         );
         final image = tester.widget<Image>(find.byType(Image));


### PR DESCRIPTION
Closes #7544

## Summary

Fixes two iOS diagnostics/recovery issues from the socket/auth retry investigation:

**Rank 1: Socket error on app resume (KeycastRpc)**
- Retries a Keycast RPC once when `http.ClientException` indicates a socket-level transport failure after app resume
- Resets the underlying HTTP transport before the retry so a dead pooled socket is not reused
- Keeps retired transports alive until requests already using them finish, then closes them through per-client in-flight tracking
- Shares one single-op deadline across socket retry and 401 refresh retry, matching the existing batch deadline behavior
- Makes `KeycastRpc.close()` terminal and closes the owned transport on sign-out/dispose
- Keeps signers held by a live `NostrClient` open on same-pubkey swaps, including background RPC upgrade, OAuth re-sign-in, non-OAuth `_setupUserSession`, and own-nsec import (#5909)
- Classifies closed-RPC teardown outside `RpcException`, so `nip17UnwrapBatch` does not mistake it for unsupported server capability and latch batch unwrap off
- Logs the original socket exception and logs when the retry itself fails
- Treats retry as transport recovery; `nip17_wrap_batch` can record a server-side audit row if a processed response is lost and retried

**Rank 2: Silent passive auth retry outcomes (PassiveAuthThumbnailImage)**
- Adds category-tagged video logs for passive auth retry outcomes
- Preserves the repeated-unauthorized thumbnail suppression behavior from #7567, including preference-blocked passive auth
- Logs expected preference/unavailable states at `info`, with signer-unreachable at `warning`

## Changes

- **mobile/packages/keycast_flutter/lib/src/rpc/keycast_rpc.dart**: add socket retry, per-client transport retirement, shared retry deadlines, terminal close behavior, and transport-side logging
- **mobile/packages/keycast_flutter/lib/src/models/exceptions.dart**: add a typed closed-RPC exception that remains terminal without entering RPC capability fallbacks
- **mobile/packages/keycast_flutter/test/rpc_client_test.dart**: cover fresh-transport retry, retry failure propagation, deferred retired-client close, terminal close cleanup, closed batch unwrap, single-op retry deadlines, and batch-path socket retry
- **mobile/lib/services/auth_service.dart**: close replaced/cleared Keycast RPC signers while retaining signers still held by a live same-pubkey client
- **mobile/test/services/auth_service_expired_session_downgrade_test.dart**: cover signer close on sign-out
- **mobile/test/services/auth_service_oauth_local_signing_test.dart**: cover retained-signer behavior for background upgrade, own-nsec import, and same-pubkey OAuth re-sign-in
- **mobile/lib/widgets/video_thumbnail_widget.dart**: add passive-auth retry logs to the current suppression flow with `LogCategory.video`
- **mobile/test/widgets/video_thumbnail_widget_test.dart**: cover preference-blocked passive-auth suppression

## Verification

- `cd mobile/packages/keycast_flutter && flutter test --coverage` — 301 tests passed
- `cd mobile && flutter test test/services/auth_service_oauth_local_signing_test.dart` — 10 tests passed
- `cd mobile && flutter analyze lib/services/auth_service.dart test/services/auth_service_oauth_local_signing_test.dart packages/keycast_flutter/lib/src/models/exceptions.dart packages/keycast_flutter/test/rpc_client_test.dart`
- Service god-file, post-close-emit, and layer-direction ratchets
- Pre-push analyzer and changed-file tests
