### PR TITLE
fix(nostr): use raw timestamps for video replacements

### DIFF
--- a/mobile/lib/services/video_event_publisher.dart
+++ b/mobile/lib/services/video_event_publisher.dart
@@ -40,6 +40,7 @@ import 'package:openvine/services/video_thumbnail_service.dart';
 import 'package:openvine/utils/collaborator_tags.dart';
 import 'package:openvine/utils/inspired_by_tags.dart';
 import 'package:openvine/utils/log_tag_sanitizer.dart';
+import 'package:openvine/utils/nostr_replacement_timestamp.dart';
 import 'package:openvine/utils/proofmode_publishing_helpers.dart';
 import 'package:profile_repository/profile_repository.dart';
 import 'package:unified_logger/unified_logger.dart';
@@ -2041,7 +2042,7 @@ class VideoEventPublisher {
       kind: NIP71VideoKinds.getPreferredAddressableKind(),
       content: existingEvent.content,
       tags: tags,
-      createdAt: existingEvent.createdAt + 1,
+      createdAt: nextReplacementCreatedAt(existingEvent),
     );
 
     if (event == null) {

--- a/mobile/lib/services/video_metadata_update_service.dart
+++ b/mobile/lib/services/video_metadata_update_service.dart
@@ -16,6 +16,7 @@ import 'package:openvine/services/video_event_service.dart';
 import 'package:openvine/services/video_event_tag_source.dart';
 import 'package:openvine/utils/collaborator_tags.dart';
 import 'package:openvine/utils/inspired_by_tags.dart';
+import 'package:openvine/utils/nostr_replacement_timestamp.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 /// Result returned by [VideoMetadataUpdateService.updateVideo].
@@ -407,13 +408,13 @@ class VideoMetadataUpdateService {
         content = content.isEmpty ? ibText.trim() : '$content$ibText';
       }
 
-      // Use original created_at + 1 so relays treat this as a replacement
-      // while preserving the video's chronological position in feeds.
+      // Use raw Nostr created_at, not the stable NIP-71 published_at value
+      // exposed through VideoEvent.createdAt, so relays accept replacements.
       final event = await _authService.createAndSignEvent(
         kind: NIP71VideoKinds.addressableShortVideo,
         content: content,
         tags: tags,
-        createdAt: originalVideo.createdAt + 1,
+        createdAt: nextReplacementCreatedAt(originalVideo),
       );
 
       if (event == null) {

--- a/mobile/lib/utils/nostr_replacement_timestamp.dart
+++ b/mobile/lib/utils/nostr_replacement_timestamp.dart
@@ -1,0 +1,17 @@
+// ABOUTME: Computes monotonic created_at values for replaceable Nostr events.
+// ABOUTME: Keeps kind 34236 edits relay-replaceable while preserving published_at.
+
+import 'package:models/models.dart';
+import 'package:openvine/utils/nostr_timestamp.dart';
+
+/// Returns the next `created_at` to use when replacing [previousEvent].
+///
+/// NIP-01 replacement is based on the raw event `created_at`, not NIP-71's
+/// stable `published_at` tag. [VideoEvent.createdAt] intentionally prefers
+/// `published_at` for app display/feed ordering, so replacement publishes must
+/// use [VideoEvent.nostrCreatedAt] instead.
+int nextReplacementCreatedAt(VideoEvent previousEvent) {
+  final now = NostrTimestamp.now();
+  final nextAfterPrevious = previousEvent.nostrCreatedAt + 1;
+  return now > nextAfterPrevious ? now : nextAfterPrevious;
+}

--- a/mobile/packages/models/lib/src/video_stats.dart
+++ b/mobile/packages/models/lib/src/video_stats.dart
@@ -578,6 +578,7 @@ class VideoStats {
       id: id,
       pubkey: pubkey,
       createdAt: effectiveTimestamp,
+      eventCreatedAt: createdAt.millisecondsSinceEpoch ~/ 1000,
       content: description ?? '',
       timestamp: DateTime.fromMillisecondsSinceEpoch(
         effectiveTimestamp * 1000,

--- a/mobile/packages/models/lib/src/video_stats.dart
+++ b/mobile/packages/models/lib/src/video_stats.dart
@@ -30,6 +30,7 @@ class VideoStats {
     required this.reposts,
     required this.engagementScore,
     this.publishedAt,
+    this.eventCreatedAt,
     this.description,
     this.sha256,
     this.authorName,
@@ -90,16 +91,21 @@ class VideoStats {
     pubkey = pubkey.toLowerCase();
 
     // Parse created_at - funnelcake returns Unix timestamp (int), not ISO
-    DateTime createdAt;
+    late final DateTime createdAt;
+    int? eventCreatedAt;
     final rawCreatedAt = eventData['created_at'];
     if (rawCreatedAt is int) {
       createdAt = DateTime.fromMillisecondsSinceEpoch(
         rawCreatedAt * 1000,
         isUtc: true,
       );
+      eventCreatedAt = rawCreatedAt;
     } else if (rawCreatedAt is String) {
-      createdAt =
-          DateTime.tryParse(rawCreatedAt)?.toUtc() ?? DateTime.now().toUtc();
+      final parsedCreatedAt = DateTime.tryParse(rawCreatedAt)?.toUtc();
+      createdAt = parsedCreatedAt ?? DateTime.now().toUtc();
+      eventCreatedAt = parsedCreatedAt == null
+          ? null
+          : parsedCreatedAt.millisecondsSinceEpoch ~/ 1000;
     } else {
       createdAt = DateTime.now().toUtc();
     }
@@ -390,6 +396,7 @@ class VideoStats {
       id: id,
       pubkey: pubkey,
       createdAt: createdAt,
+      eventCreatedAt: eventCreatedAt,
       publishedAt: publishedAt,
       kind: (eventData['kind'] as int?) ?? 34236,
       dTag: dTag,
@@ -435,6 +442,10 @@ class VideoStats {
 
   /// When the video was created.
   final DateTime createdAt;
+
+  /// Parsed raw Nostr event `created_at`, or null when the REST value was
+  /// missing or invalid and [createdAt] had to use a display fallback.
+  final int? eventCreatedAt;
 
   /// Unix timestamp of when the video was published (`published_at` tag).
   ///
@@ -578,7 +589,7 @@ class VideoStats {
       id: id,
       pubkey: pubkey,
       createdAt: effectiveTimestamp,
-      eventCreatedAt: createdAt.millisecondsSinceEpoch ~/ 1000,
+      eventCreatedAt: eventCreatedAt,
       content: description ?? '',
       timestamp: DateTime.fromMillisecondsSinceEpoch(
         effectiveTimestamp * 1000,

--- a/mobile/packages/models/test/src/video_stats_test.dart
+++ b/mobile/packages/models/test/src/video_stats_test.dart
@@ -1449,6 +1449,32 @@ void main() {
         expect(video.nostrCreatedAt, 1700000100);
       });
 
+      test(
+        'does not treat an invalid created_at fallback as raw event time',
+        () {
+          final stats = VideoStats.fromJson(const {
+            'event': {
+              'id': 'test-id',
+              'pubkey': 'test-pubkey',
+              'created_at': 'not-a-date',
+              'kind': 34236,
+              'content': 'Test',
+              'tags': [
+                ['d', 'video-1'],
+                ['published_at', '1700000000'],
+                ['url', 'https://example.com/video.mp4'],
+              ],
+            },
+          });
+
+          final video = stats.toVideoEvent();
+
+          expect(video.createdAt, 1700000000);
+          expect(video.eventCreatedAt, isNull);
+          expect(video.nostrCreatedAt, 1700000000);
+        },
+      );
+
       test('carries the event kind through to the VideoEvent', () {
         final stats = VideoStats.fromJson(const {
           'event': {

--- a/mobile/packages/models/test/src/video_stats_test.dart
+++ b/mobile/packages/models/test/src/video_stats_test.dart
@@ -1427,6 +1427,28 @@ void main() {
     });
 
     group('toVideoEvent', () {
+      test('preserves raw created_at when published_at controls display', () {
+        final stats = VideoStats.fromJson(const {
+          'event': {
+            'id': 'test-id',
+            'pubkey': 'test-pubkey',
+            'created_at': 1700000100,
+            'kind': 34236,
+            'content': 'Test',
+            'tags': [
+              ['d', 'video-1'],
+              ['published_at', '1700000000'],
+              ['url', 'https://example.com/video.mp4'],
+            ],
+          },
+        });
+
+        final video = stats.toVideoEvent();
+
+        expect(video.createdAt, 1700000000);
+        expect(video.nostrCreatedAt, 1700000100);
+      });
+
       test('carries the event kind through to the VideoEvent', () {
         final stats = VideoStats.fromJson(const {
           'event': {

--- a/mobile/test/services/video_event_publisher_subtitle_test.dart
+++ b/mobile/test/services/video_event_publisher_subtitle_test.dart
@@ -88,9 +88,11 @@ void main() {
       ['d', 'test-vine-id'],
       ['imeta', 'url https://cdn.example.com/video.mp4', 'm video/mp4'],
       ['title', 'Test Video'],
+      ['published_at', '1700000000'],
       ['t', 'test'],
       Nip89ClientTag.tag,
     ];
+    const rawEventCreatedAt = 4102444800;
 
     final existingEvent = VideoEvent(
       id: 'b' * 64,
@@ -101,6 +103,7 @@ void main() {
       title: 'Test Video',
       vineId: 'test-vine-id',
       nostrEventTags: existingTags,
+      eventCreatedAt: rawEventCreatedAt,
     );
 
     final textTrackRef = '34236:$testPubkey:subtitle-event-id';
@@ -163,7 +166,7 @@ void main() {
             kind: NIP71VideoKinds.getPreferredAddressableKind(),
             content: existingEvent.content,
             tags: any(named: 'tags'),
-            createdAt: existingEvent.createdAt + 1,
+            createdAt: rawEventCreatedAt + 1,
           ),
         ).called(1);
 
@@ -277,7 +280,7 @@ void main() {
           kind: 34236,
           content: any(named: 'content'),
           tags: any(named: 'tags'),
-          createdAt: existingEvent.createdAt + 1,
+          createdAt: rawEventCreatedAt + 1,
         ),
       ).called(1);
     });

--- a/mobile/test/services/video_metadata_update_service_test.dart
+++ b/mobile/test/services/video_metadata_update_service_test.dart
@@ -1,6 +1,6 @@
 // ABOUTME: Unit tests for VideoMetadataUpdateService.
 // ABOUTME: Covers auth guard, video-URL guard, original-tag preservation,
-// ABOUTME: edited-field replacement, createdAt bumping, successful publish,
+// ABOUTME: edited-field replacement, replacement created_at, successful publish,
 // ABOUTME: publish failure, and invite failure via inviteFailureCount.
 
 import 'dart:ui' show Locale;
@@ -41,6 +41,7 @@ const _ownerPubkey =
 
 VideoEvent _testVideo({
   List<List<String>> extraTags = const [],
+  int? eventCreatedAt,
 }) {
   return VideoEvent(
     id: 'event-id',
@@ -51,6 +52,7 @@ VideoEvent _testVideo({
     videoUrl: 'https://cdn.example.com/video.mp4',
     title: 'Test Video Title',
     vineId: 'video-d-tag',
+    eventCreatedAt: eventCreatedAt,
     nostrEventTags: [
       const ['imeta', 'url https://cdn.example.com/video.mp4', 'm video/mp4'],
       ...extraTags,
@@ -105,6 +107,7 @@ void main() {
         NIP71VideoKinds.addressableShortVideo,
         capturedTags,
         invocation.namedArguments[#content] as String,
+        createdAt: capturedCreatedAt,
       );
     });
 
@@ -182,19 +185,21 @@ void main() {
       );
     });
 
-    group('createdAt bumping', () {
+    group('replacement created_at', () {
       test(
-        'signs the event with createdAt = originalVideo.createdAt + 1',
+        'uses raw Nostr created_at instead of stable published_at',
         () async {
-          const originalCreatedAt = 1757385263;
+          const stablePublishedAt = 1757385263;
+          const rawEventCreatedAt = 4102444800;
           final result = await service.updateVideo(
-            originalVideo: _testVideo(),
+            originalVideo: _testVideo(eventCreatedAt: rawEventCreatedAt),
             editorState: VideoEditorProviderState(),
             initialCollaboratorPubkeys: const {},
           );
 
           expect(result, isA<VideoUpdateSuccess>());
-          expect(capturedCreatedAt, equals(originalCreatedAt + 1));
+          expect(capturedCreatedAt, equals(rawEventCreatedAt + 1));
+          expect(capturedCreatedAt, isNot(equals(stablePublishedAt + 1)));
         },
       );
     });
@@ -310,11 +315,7 @@ void main() {
             NIP71VideoKinds.addressableShortVideo,
             const [
               ['d', 'video-d-tag'],
-              [
-                'imeta',
-                'url https://cdn.example.com/video.mp4',
-                'm video/mp4',
-              ],
+              ['imeta', 'url https://cdn.example.com/video.mp4', 'm video/mp4'],
               ['A', rootAddressableId, ''],
               ['P', rootAuthorPubkey],
               ['k', '34236'],
@@ -357,10 +358,7 @@ void main() {
         expect(addressableTags, [
           ['a', rootAddressableId, ''],
         ]);
-        expect(
-          capturedTags,
-          contains(equals(['A', rootAddressableId, ''])),
-        );
+        expect(capturedTags, contains(equals(['A', rootAddressableId, ''])));
         expect(capturedTags, contains(equals(['P', rootAuthorPubkey])));
         expect(capturedTags, contains(equals(['p', rootAuthorPubkey])));
         expect(
@@ -376,85 +374,76 @@ void main() {
         );
       });
 
-      test(
-        'preserves a genuine inspired-by a-tag on a reply instead of '
-        'dropping it',
-        () async {
-          const rootEventId =
-              'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd';
-          const rootAuthorPubkey =
-              'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
-          const rootAddressableId = '34236:$rootAuthorPubkey:root-vid';
-          const inspiringAuthorPubkey =
-              '2222222222222222222222222222222222222222222222222222222222222222';
-          const inspiringAddressableId =
-              '34236:$inspiringAuthorPubkey:inspiring-vid';
-          final video = VideoEvent.fromNostrEvent(
-            Event(
-              _ownerPubkey,
-              NIP71VideoKinds.addressableShortVideo,
-              const [
-                ['d', 'video-d-tag'],
-                [
-                  'imeta',
-                  'url https://cdn.example.com/video.mp4',
-                  'm video/mp4',
-                ],
-                ['A', rootAddressableId, ''],
-                ['K', '34236'],
-                ['E', rootEventId, '', rootAuthorPubkey],
-                ['a', rootAddressableId, ''],
-                // A genuine inspired-by reference that co-exists with the
-                // reply threading tags.
-                [
-                  'a',
-                  inspiringAddressableId,
-                  'wss://relay.divine.video',
-                  'mention',
-                ],
-              ],
-              'Reply video that is also inspired by another',
-              createdAt: 1757385263,
-            ),
-          );
-
-          expect(video.isVideoReply, isTrue);
-
-          final result = await service.updateVideo(
-            originalVideo: video,
-            editorState: VideoEditorProviderState(
-              inspiredByVideo: video.inspiredByVideo,
-            ),
-            initialCollaboratorPubkeys: const {},
-          );
-
-          expect(result, isA<VideoUpdateSuccess>());
-          // The genuine inspired-by tag survives verbatim.
-          expect(
-            capturedTags,
-            contains(
-              equals([
+      test('preserves a genuine inspired-by a-tag on a reply instead of '
+          'dropping it', () async {
+        const rootEventId =
+            'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd';
+        const rootAuthorPubkey =
+            'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
+        const rootAddressableId = '34236:$rootAuthorPubkey:root-vid';
+        const inspiringAuthorPubkey =
+            '2222222222222222222222222222222222222222222222222222222222222222';
+        const inspiringAddressableId =
+            '34236:$inspiringAuthorPubkey:inspiring-vid';
+        final video = VideoEvent.fromNostrEvent(
+          Event(
+            _ownerPubkey,
+            NIP71VideoKinds.addressableShortVideo,
+            const [
+              ['d', 'video-d-tag'],
+              ['imeta', 'url https://cdn.example.com/video.mp4', 'm video/mp4'],
+              ['A', rootAddressableId, ''],
+              ['K', '34236'],
+              ['E', rootEventId, '', rootAuthorPubkey],
+              ['a', rootAddressableId, ''],
+              // A genuine inspired-by reference that co-exists with the
+              // reply threading tags.
+              [
                 'a',
                 inspiringAddressableId,
                 'wss://relay.divine.video',
                 'mention',
-              ]),
-            ),
-          );
-          // The reply-parent a-tag survives.
-          expect(capturedTags, contains(equals(['a', rootAddressableId, ''])));
-          // No parent reference is turned into 'inspired-by' attribution.
-          expect(
-            capturedTags.where(
-              (tag) =>
-                  tag.length >= 4 &&
-                  tag.first == 'a' &&
-                  tag[3] == 'inspired-by',
-            ),
-            isEmpty,
-          );
-        },
-      );
+              ],
+            ],
+            'Reply video that is also inspired by another',
+            createdAt: 1757385263,
+          ),
+        );
+
+        expect(video.isVideoReply, isTrue);
+
+        final result = await service.updateVideo(
+          originalVideo: video,
+          editorState: VideoEditorProviderState(
+            inspiredByVideo: video.inspiredByVideo,
+          ),
+          initialCollaboratorPubkeys: const {},
+        );
+
+        expect(result, isA<VideoUpdateSuccess>());
+        // The genuine inspired-by tag survives verbatim.
+        expect(
+          capturedTags,
+          contains(
+            equals([
+              'a',
+              inspiringAddressableId,
+              'wss://relay.divine.video',
+              'mention',
+            ]),
+          ),
+        );
+        // The reply-parent a-tag survives.
+        expect(capturedTags, contains(equals(['a', rootAddressableId, ''])));
+        // No parent reference is turned into 'inspired-by' attribution.
+        expect(
+          capturedTags.where(
+            (tag) =>
+                tag.length >= 4 && tag.first == 'a' && tag[3] == 'inspired-by',
+          ),
+          isEmpty,
+        );
+      });
 
       test('removes collaborator tags with mixed-case markers', () async {
         const removedCollaborator =
@@ -525,94 +514,83 @@ void main() {
         },
       );
 
-      test(
-        'recovers preserved tags from the personal cache when '
-        'nostrEventTags is empty',
-        () async {
-          final cachedEvent = Event(
-            _ownerPubkey,
-            NIP71VideoKinds.addressableShortVideo,
-            const [
-              ['d', 'video-d-tag'],
-              [
-                'imeta',
-                'url https://cdn.example.com/video.mp4',
-                'm video/mp4',
-              ],
-              ['e', audioEventId, 'wss://relay.divine.video', 'audio'],
-              ['expiration', '1799999999'],
-            ],
-            'Test video content',
-          );
-          // A VideoEvent rehydrated from a JSON cache has empty
-          // nostrEventTags; the raw event still lives in the personal cache.
-          final video = VideoEvent(
-            id: 'event-id',
-            pubkey: _ownerPubkey,
-            createdAt: 1757385263,
-            content: 'Test video content',
-            timestamp: DateTime.fromMillisecondsSinceEpoch(1757385263 * 1000),
-            videoUrl: 'https://cdn.example.com/video.mp4',
-            title: 'Test Video Title',
-            vineId: 'video-d-tag',
-          );
-          when(
-            () => mockPersonalEventCacheService.getEventById('event-id'),
-          ).thenReturn(cachedEvent);
+      test('recovers preserved tags from the personal cache when '
+          'nostrEventTags is empty', () async {
+        final cachedEvent = Event(
+          _ownerPubkey,
+          NIP71VideoKinds.addressableShortVideo,
+          const [
+            ['d', 'video-d-tag'],
+            ['imeta', 'url https://cdn.example.com/video.mp4', 'm video/mp4'],
+            ['e', audioEventId, 'wss://relay.divine.video', 'audio'],
+            ['expiration', '1799999999'],
+          ],
+          'Test video content',
+        );
+        // A VideoEvent rehydrated from a JSON cache has empty
+        // nostrEventTags; the raw event still lives in the personal cache.
+        final video = VideoEvent(
+          id: 'event-id',
+          pubkey: _ownerPubkey,
+          createdAt: 1757385263,
+          content: 'Test video content',
+          timestamp: DateTime.fromMillisecondsSinceEpoch(1757385263 * 1000),
+          videoUrl: 'https://cdn.example.com/video.mp4',
+          title: 'Test Video Title',
+          vineId: 'video-d-tag',
+        );
+        when(
+          () => mockPersonalEventCacheService.getEventById('event-id'),
+        ).thenReturn(cachedEvent);
 
-          final result = await service.updateVideo(
-            originalVideo: video,
-            editorState: VideoEditorProviderState(),
-            initialCollaboratorPubkeys: const {},
-          );
+        final result = await service.updateVideo(
+          originalVideo: video,
+          editorState: VideoEditorProviderState(),
+          initialCollaboratorPubkeys: const {},
+        );
 
-          expect(result, isA<VideoUpdateSuccess>());
-          expect(
-            capturedTags,
-            contains(
-              equals(['e', audioEventId, 'wss://relay.divine.video', 'audio']),
-            ),
-          );
-          expect(capturedTags, contains(equals(['expiration', '1799999999'])));
-        },
-      );
+        expect(result, isA<VideoUpdateSuccess>());
+        expect(
+          capturedTags,
+          contains(
+            equals(['e', audioEventId, 'wss://relay.divine.video', 'audio']),
+          ),
+        );
+        expect(capturedTags, contains(equals(['expiration', '1799999999'])));
+      });
 
-      test(
-        'rebuilds imeta from videoUrl when nostrEventTags is empty and the '
-        'event is not cached',
-        () async {
-          final video = VideoEvent(
-            id: 'uncached-event-id',
-            pubkey: _ownerPubkey,
-            createdAt: 1757385263,
-            content: 'Test video content',
-            timestamp: DateTime.fromMillisecondsSinceEpoch(1757385263 * 1000),
-            videoUrl: 'https://cdn.example.com/video.mp4',
-            title: 'Test Video Title',
-            vineId: 'video-d-tag',
-          );
-          when(
-            () =>
-                mockPersonalEventCacheService.getEventById('uncached-event-id'),
-          ).thenReturn(null);
+      test('rebuilds imeta from videoUrl when nostrEventTags is empty and the '
+          'event is not cached', () async {
+        final video = VideoEvent(
+          id: 'uncached-event-id',
+          pubkey: _ownerPubkey,
+          createdAt: 1757385263,
+          content: 'Test video content',
+          timestamp: DateTime.fromMillisecondsSinceEpoch(1757385263 * 1000),
+          videoUrl: 'https://cdn.example.com/video.mp4',
+          title: 'Test Video Title',
+          vineId: 'video-d-tag',
+        );
+        when(
+          () => mockPersonalEventCacheService.getEventById('uncached-event-id'),
+        ).thenReturn(null);
 
-          final result = await service.updateVideo(
-            originalVideo: video,
-            editorState: VideoEditorProviderState(),
-            initialCollaboratorPubkeys: const {},
-          );
+        final result = await service.updateVideo(
+          originalVideo: video,
+          editorState: VideoEditorProviderState(),
+          initialCollaboratorPubkeys: const {},
+        );
 
-          expect(result, isA<VideoUpdateSuccess>());
-          final imetaTags = capturedTags
-              .where((t) => t.isNotEmpty && t.first == 'imeta')
-              .toList();
-          expect(imetaTags, hasLength(1));
-          expect(
-            imetaTags.single,
-            contains('url https://cdn.example.com/video.mp4'),
-          );
-        },
-      );
+        expect(result, isA<VideoUpdateSuccess>());
+        final imetaTags = capturedTags
+            .where((t) => t.isNotEmpty && t.first == 'imeta')
+            .toList();
+        expect(imetaTags, hasLength(1));
+        expect(
+          imetaTags.single,
+          contains('url https://cdn.example.com/video.mp4'),
+        );
+      });
     });
 
     group('edited field replacement', () {
@@ -710,10 +688,7 @@ void main() {
         );
 
         expect(result, isA<VideoUpdateSuccess>());
-        expect(
-          capturedTags,
-          contains(equals(['content-warning', 'violence'])),
-        );
+        expect(capturedTags, contains(equals(['content-warning', 'violence'])));
         expect(capturedTags, contains(equals(['L', 'content-warning'])));
         expect(
           capturedTags,
@@ -838,24 +813,14 @@ void main() {
           const sourceAddressableId = '34236:$sourceCreator:source-vid';
           final video = _testVideo(
             extraTags: const [
-              [
-                'a',
-                sourceAddressableId,
-                'wss://source.relay',
-                'mention',
-              ],
+              ['a', sourceAddressableId, 'wss://source.relay', 'mention'],
               [
                 'a',
                 sourceAddressableId,
                 'wss://source.relay',
                 clipSourceCreditTagMarker,
               ],
-              [
-                'p',
-                sourceCreator,
-                'wss://source.relay',
-                'inspired-by',
-              ],
+              ['p', sourceCreator, 'wss://source.relay', 'inspired-by'],
             ],
           );
 
@@ -1122,46 +1087,40 @@ void main() {
       const newCollaborator =
           'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
 
-      test(
-        'returns VideoUpdateSuccess with inviteFailureCount > 0 when DM '
-        'send fails for a newly added collaborator',
-        () async {
-          when(
-            () => mockDmRepository.sendMessage(
-              recipientPubkey: any(named: 'recipientPubkey'),
-              content: any(named: 'content'),
-              additionalTags: any(named: 'additionalTags'),
-              skipNip04Fallback: any(named: 'skipNip04Fallback'),
-            ),
-          ).thenAnswer(
-            (_) async => const NIP17SendResult.failure('relay unreachable'),
-          );
+      test('returns VideoUpdateSuccess with inviteFailureCount > 0 when DM '
+          'send fails for a newly added collaborator', () async {
+        when(
+          () => mockDmRepository.sendMessage(
+            recipientPubkey: any(named: 'recipientPubkey'),
+            content: any(named: 'content'),
+            additionalTags: any(named: 'additionalTags'),
+            skipNip04Fallback: any(named: 'skipNip04Fallback'),
+          ),
+        ).thenAnswer(
+          (_) async => const NIP17SendResult.failure('relay unreachable'),
+        );
 
-          final editorState = VideoEditorProviderState(
-            collaboratorPubkeys: const {newCollaborator},
-          );
+        final editorState = VideoEditorProviderState(
+          collaboratorPubkeys: const {newCollaborator},
+        );
 
-          final result = await service.updateVideo(
-            originalVideo: _testVideo(),
-            editorState: editorState,
-            initialCollaboratorPubkeys: const {},
-          );
+        final result = await service.updateVideo(
+          originalVideo: _testVideo(),
+          editorState: editorState,
+          initialCollaboratorPubkeys: const {},
+        );
 
-          expect(result, isA<VideoUpdateSuccess>());
-          expect(
-            (result as VideoUpdateSuccess).inviteFailureCount,
-            equals(1),
-          );
-          verify(
-            () => mockDmRepository.sendMessage(
-              recipientPubkey: newCollaborator,
-              content: any(named: 'content'),
-              additionalTags: any(named: 'additionalTags'),
-              skipNip04Fallback: any(named: 'skipNip04Fallback'),
-            ),
-          ).called(1);
-        },
-      );
+        expect(result, isA<VideoUpdateSuccess>());
+        expect((result as VideoUpdateSuccess).inviteFailureCount, equals(1));
+        verify(
+          () => mockDmRepository.sendMessage(
+            recipientPubkey: newCollaborator,
+            content: any(named: 'content'),
+            additionalTags: any(named: 'additionalTags'),
+            skipNip04Fallback: any(named: 'skipNip04Fallback'),
+          ),
+        ).called(1);
+      });
 
       test(
         'returns inviteFailureCount = 0 when no new collaborators were added',
@@ -1173,10 +1132,7 @@ void main() {
           );
 
           expect(result, isA<VideoUpdateSuccess>());
-          expect(
-            (result as VideoUpdateSuccess).inviteFailureCount,
-            equals(0),
-          );
+          expect((result as VideoUpdateSuccess).inviteFailureCount, equals(0));
           verifyNever(
             () => mockDmRepository.sendMessage(
               recipientPubkey: any(named: 'recipientPubkey'),
@@ -1240,12 +1196,7 @@ void main() {
       test('mints the p-tag when editing a pre-fix video', () async {
         final video = _testVideo(
           extraTags: const [
-            [
-              'a',
-              inspiredAddressableId,
-              'wss://relay.divine.video',
-              'mention',
-            ],
+            ['a', inspiredAddressableId, 'wss://relay.divine.video', 'mention'],
           ],
         );
 
@@ -1312,17 +1263,14 @@ void main() {
         );
 
         expect(result, isA<VideoUpdateSuccess>());
-        expect(
-          inspiredByPTags(),
-          [
-            equals([
-              'p',
-              otherCreator,
-              'wss://relay.divine.video',
-              'inspired-by',
-            ]),
-          ],
-        );
+        expect(inspiredByPTags(), [
+          equals([
+            'p',
+            otherCreator,
+            'wss://relay.divine.video',
+            'inspired-by',
+          ]),
+        ]);
       });
 
       test('emits a p-tag for a person (npub) attribution', () async {
@@ -1338,107 +1286,96 @@ void main() {
         expect(inspiredByPTags(), [equals(inspiredPTag)]);
       });
 
-      test(
-        'keeps a single collaborator p-tag when the creator is promoted '
-        'to collaborator',
-        () async {
-          final video = _testVideo(
-            extraTags: const [
-              [
-                'a',
-                inspiredAddressableId,
-                'wss://relay.divine.video',
-                'inspired-by',
-              ],
-              inspiredPTag,
-            ],
-          );
-
-          final result = await service.updateVideo(
-            originalVideo: video,
-            editorState: VideoEditorProviderState(
-              collaboratorPubkeys: {inspiredCreator},
-              inspiredByVideo: const InspiredByInfo(
-                addressableId: inspiredAddressableId,
-                relayUrl: 'wss://relay.divine.video',
-              ),
-            ),
-            initialCollaboratorPubkeys: const {inspiredCreator},
-          );
-
-          expect(result, isA<VideoUpdateSuccess>());
-          final pTagsForCreator = capturedTags
-              .where(
-                (tag) =>
-                    tag.length >= 2 &&
-                    tag.first == 'p' &&
-                    tag[1] == inspiredCreator,
-              )
-              .toList();
-          expect(pTagsForCreator, hasLength(1));
-          expect(
-            pTagsForCreator.single,
-            equals([
-              'p',
-              inspiredCreator,
+      test('keeps a single collaborator p-tag when the creator is promoted '
+          'to collaborator', () async {
+        final video = _testVideo(
+          extraTags: const [
+            [
+              'a',
+              inspiredAddressableId,
               'wss://relay.divine.video',
-              'collaborator',
-            ]),
-          );
-        },
-      );
+              'inspired-by',
+            ],
+            inspiredPTag,
+          ],
+        );
 
-      test(
-        're-mints the inspired-by p-tag when the creator is demoted from '
-        'collaborator',
-        () async {
-          // The original event was produced by a promotion edit: it carries
-          // the collaborator p-tag and no inspired-by p-tag.
-          final promotedVideo = _testVideo(
-            extraTags: const [
-              [
-                'a',
-                inspiredAddressableId,
-                'wss://relay.divine.video',
-                'inspired-by',
-              ],
-              [
+        final result = await service.updateVideo(
+          originalVideo: video,
+          editorState: VideoEditorProviderState(
+            collaboratorPubkeys: {inspiredCreator},
+            inspiredByVideo: const InspiredByInfo(
+              addressableId: inspiredAddressableId,
+              relayUrl: 'wss://relay.divine.video',
+            ),
+          ),
+          initialCollaboratorPubkeys: const {inspiredCreator},
+        );
+
+        expect(result, isA<VideoUpdateSuccess>());
+        final pTagsForCreator = capturedTags
+            .where(
+              (tag) =>
+                  tag.length >= 2 &&
+                  tag.first == 'p' &&
+                  tag[1] == inspiredCreator,
+            )
+            .toList();
+        expect(pTagsForCreator, hasLength(1));
+        expect(
+          pTagsForCreator.single,
+          equals([
+            'p',
+            inspiredCreator,
+            'wss://relay.divine.video',
+            'collaborator',
+          ]),
+        );
+      });
+
+      test('re-mints the inspired-by p-tag when the creator is demoted from '
+          'collaborator', () async {
+        // The original event was produced by a promotion edit: it carries
+        // the collaborator p-tag and no inspired-by p-tag.
+        final promotedVideo = _testVideo(
+          extraTags: const [
+            [
+              'a',
+              inspiredAddressableId,
+              'wss://relay.divine.video',
+              'inspired-by',
+            ],
+            ['p', inspiredCreator, 'wss://relay.divine.video', 'collaborator'],
+          ],
+        );
+
+        final result = await service.updateVideo(
+          originalVideo: promotedVideo,
+          editorState: VideoEditorProviderState(
+            inspiredByVideo: const InspiredByInfo(
+              addressableId: inspiredAddressableId,
+              relayUrl: 'wss://relay.divine.video',
+            ),
+          ),
+          initialCollaboratorPubkeys: const {inspiredCreator},
+        );
+
+        expect(result, isA<VideoUpdateSuccess>());
+        expect(inspiredByPTags(), [equals(inspiredPTag)]);
+        expect(
+          capturedTags,
+          isNot(
+            contains(
+              equals([
                 'p',
                 inspiredCreator,
                 'wss://relay.divine.video',
                 'collaborator',
-              ],
-            ],
-          );
-
-          final result = await service.updateVideo(
-            originalVideo: promotedVideo,
-            editorState: VideoEditorProviderState(
-              inspiredByVideo: const InspiredByInfo(
-                addressableId: inspiredAddressableId,
-                relayUrl: 'wss://relay.divine.video',
-              ),
+              ]),
             ),
-            initialCollaboratorPubkeys: const {inspiredCreator},
-          );
-
-          expect(result, isA<VideoUpdateSuccess>());
-          expect(inspiredByPTags(), [equals(inspiredPTag)]);
-          expect(
-            capturedTags,
-            isNot(
-              contains(
-                equals([
-                  'p',
-                  inspiredCreator,
-                  'wss://relay.divine.video',
-                  'collaborator',
-                ]),
-              ),
-            ),
-          );
-        },
-      );
+          ),
+        );
+      });
 
       test('never strips caption-mention p-tags', () async {
         const mentioned =
@@ -1524,11 +1461,7 @@ void main() {
             NIP71VideoKinds.addressableShortVideo,
             const [
               ['d', 'video-d-tag'],
-              [
-                'imeta',
-                'url https://cdn.example.com/video.mp4',
-                'm video/mp4',
-              ],
+              ['imeta', 'url https://cdn.example.com/video.mp4', 'm video/mp4'],
               ['A', rootAddressableId, ''],
               ['P', rootAuthorPubkey],
               ['E', rootEventId, '', rootAuthorPubkey],

--- a/mobile/test/services/video_metadata_update_service_test.dart
+++ b/mobile/test/services/video_metadata_update_service_test.dart
@@ -202,6 +202,27 @@ void main() {
           expect(capturedCreatedAt, isNot(equals(stablePublishedAt + 1)));
         },
       );
+
+      test('keeps successive replacements strictly monotonic', () async {
+        const rawEventCreatedAt = 4102444800;
+        final firstResult = await service.updateVideo(
+          originalVideo: _testVideo(eventCreatedAt: rawEventCreatedAt),
+          editorState: VideoEditorProviderState(),
+          initialCollaboratorPubkeys: const {},
+        );
+
+        final firstVideo = (firstResult as VideoUpdateSuccess).updatedEvent;
+        final firstReplacementCreatedAt = firstVideo.nostrCreatedAt;
+        final secondResult = await service.updateVideo(
+          originalVideo: firstVideo,
+          editorState: VideoEditorProviderState(),
+          initialCollaboratorPubkeys: const {},
+        );
+
+        expect(secondResult, isA<VideoUpdateSuccess>());
+        expect(firstReplacementCreatedAt, rawEventCreatedAt + 1);
+        expect(capturedCreatedAt, firstReplacementCreatedAt + 1);
+      });
     });
 
     group('engagement tag preservation', () {

--- a/mobile/test/utils/nostr_replacement_timestamp_test.dart
+++ b/mobile/test/utils/nostr_replacement_timestamp_test.dart
@@ -1,0 +1,43 @@
+// ABOUTME: Tests monotonic timestamps for replaceable Nostr video events.
+// ABOUTME: Covers published_at/raw-created_at split and now clamping.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart';
+import 'package:openvine/utils/nostr_replacement_timestamp.dart';
+import 'package:openvine/utils/nostr_timestamp.dart';
+
+void main() {
+  group(nextReplacementCreatedAt, () {
+    test('uses raw event created_at when published_at is older', () {
+      final previous = VideoEvent(
+        id: 'event-id',
+        pubkey: 'pubkey',
+        createdAt: 1700000000,
+        content: 'edited video',
+        timestamp: DateTime.fromMillisecondsSinceEpoch(1700000000 * 1000),
+        eventCreatedAt: 4102444800,
+      );
+
+      expect(nextReplacementCreatedAt(previous), 4102444801);
+    });
+
+    test('clamps old replacements up toward current Nostr time', () {
+      final before = NostrTimestamp.now();
+      final previous = VideoEvent(
+        id: 'event-id',
+        pubkey: 'pubkey',
+        createdAt: 1700000000,
+        content: 'old video',
+        timestamp: DateTime.fromMillisecondsSinceEpoch(1700000000 * 1000),
+        eventCreatedAt: 1700000100,
+      );
+
+      final replacementCreatedAt = nextReplacementCreatedAt(previous);
+      final after = NostrTimestamp.now();
+
+      expect(replacementCreatedAt, greaterThan(1700000101));
+      expect(replacementCreatedAt, greaterThanOrEqualTo(before));
+      expect(replacementCreatedAt, lessThanOrEqualTo(after));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add a shared helper for monotonic replaceable-event created_at values using raw VideoEvent.nostrCreatedAt and current Nostr time
- use it for subtitle republish and video metadata edits
- update regression coverage for stable published_at versus raw created_at replacements

Closes #7546

## Verification
- flutter test test/services/video_event_publisher_subtitle_test.dart test/services/video_metadata_update_service_test.dart test/utils/nostr_replacement_timestamp_test.dart
- flutter analyze
- pre-push checks: analyzer plus changed-file tests