### PR TITLE
fix(theming): default appearance to dark when unset

### DIFF
--- a/mobile/lib/features/appearance/bloc/appearance_cubit.dart
+++ b/mobile/lib/features/appearance/bloc/appearance_cubit.dart
@@ -6,7 +6,7 @@ import 'package:unified_logger/unified_logger.dart';
 
 /// Owns the user's appearance selection and applies it for the current run.
 class AppearanceCubit extends Cubit<AppearanceMode> {
-  AppearanceCubit(this._repository) : super(AppearanceMode.system);
+  AppearanceCubit(this._repository) : super(defaultAppearanceMode);
 
   final AppearanceRepository _repository;
 

--- a/mobile/lib/features/appearance/models/appearance_mode.dart
+++ b/mobile/lib/features/appearance/models/appearance_mode.dart
@@ -1,2 +1,5 @@
 /// User-selected appearance mode for the application.
 enum AppearanceMode { system, light, dark }
+
+/// Appearance applied when the user has never chosen one.
+const AppearanceMode defaultAppearanceMode = AppearanceMode.dark;

--- a/mobile/lib/features/appearance/repositories/appearance_repository.dart
+++ b/mobile/lib/features/appearance/repositories/appearance_repository.dart
@@ -13,7 +13,7 @@ class AppearanceRepository {
     final storedValue = _preferences.getString(_preferenceKey);
     return AppearanceMode.values.firstWhere(
       (mode) => mode.name == storedValue,
-      orElse: () => AppearanceMode.system,
+      orElse: () => defaultAppearanceMode,
     );
   }
 

--- a/mobile/test/features/appearance/appearance_cubit_test.dart
+++ b/mobile/test/features/appearance/appearance_cubit_test.dart
@@ -18,6 +18,13 @@ void main() {
       repository = _MockAppearanceRepository();
     });
 
+    test('starts with the default mode before loading preferences', () {
+      final cubit = AppearanceCubit(repository);
+      addTearDown(cubit.close);
+
+      expect(cubit.state, defaultAppearanceMode);
+    });
+
     blocTest<AppearanceCubit, AppearanceMode>(
       'loads the persisted mode',
       setUp: () {
@@ -30,7 +37,7 @@ void main() {
     );
 
     blocTest<AppearanceCubit, AppearanceMode>(
-      'keeps System mode when load fails',
+      'keeps the default mode when load fails',
       setUp: () {
         when(repository.load).thenThrow(StateError('read failed'));
       },

--- a/mobile/test/features/appearance/appearance_mode_test.dart
+++ b/mobile/test/features/appearance/appearance_mode_test.dart
@@ -1,0 +1,15 @@
+// ABOUTME: Pins the appearance default that unset and invalid values resolve to.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/features/appearance/models/appearance_mode.dart';
+
+void main() {
+  group(AppearanceMode, () {
+    test('defaults to Dark', () {
+      // Every other appearance test asserts against defaultAppearanceMode, so
+      // this is the only place that fails if the default flips back to System
+      // or Light — the exact regression #7545 is about.
+      expect(defaultAppearanceMode, AppearanceMode.dark);
+    });
+  });
+}

--- a/mobile/test/features/appearance/appearance_repository_test.dart
+++ b/mobile/test/features/appearance/appearance_repository_test.dart
@@ -18,12 +18,12 @@ void main() {
       repository = AppearanceRepository(prefs);
     });
 
-    test('loads System when no preference is stored', () {
+    test('loads the default mode when no preference is stored', () {
       when(
         () => prefs.getString('appearance_mode_preference'),
       ).thenReturn(null);
 
-      expect(repository.load(), completion(equals(AppearanceMode.system)));
+      expect(repository.load(), completion(equals(defaultAppearanceMode)));
     });
 
     test('loads a stored Light preference', () {
@@ -34,12 +34,20 @@ void main() {
       expect(repository.load(), completion(equals(AppearanceMode.light)));
     });
 
-    test('invalid stored values fall back to System', () {
+    test('loads a stored System preference', () {
+      when(
+        () => prefs.getString('appearance_mode_preference'),
+      ).thenReturn('system');
+
+      expect(repository.load(), completion(equals(AppearanceMode.system)));
+    });
+
+    test('invalid stored values fall back to the default mode', () {
       when(
         () => prefs.getString('appearance_mode_preference'),
       ).thenReturn('sepia');
 
-      expect(repository.load(), completion(equals(AppearanceMode.system)));
+      expect(repository.load(), completion(equals(defaultAppearanceMode)));
     });
 
     test('saves the enum name', () async {


### PR DESCRIPTION
## Summary
- add a single default appearance constant set to dark
- use that default for unset or invalid stored appearance values
- initialize AppearanceCubit with the same default to avoid a first-frame system/light flash
- add regression coverage that stored System still remains explicit System

Closes #7545

## Verification
- flutter test test/features/appearance/appearance_repository_test.dart test/features/appearance/appearance_cubit_test.dart test/screens/settings/appearance_settings_screen_test.dart test/screens/settings/settings_screens_light_mode_test.dart
- flutter analyze
- mobile/scripts/golden.sh verify
- pre-push analyzer and changed-file tests