### PR TITLE
fix(notifications): mark inbox seen on visibility

### DIFF
--- a/mobile/lib/notifications/bloc/notification_feed_bloc.dart
+++ b/mobile/lib/notifications/bloc/notification_feed_bloc.dart
@@ -40,6 +40,10 @@ class NotificationFeedBloc
     on<NotificationFeedStarted>(_onStarted, transformer: droppable());
     on<NotificationFeedLoadMore>(_onLoadMore, transformer: droppable());
     on<NotificationFeedRefreshed>(_onRefreshed, transformer: droppable());
+    on<NotificationFeedBecameVisible>(
+      _onBecameVisible,
+      transformer: droppable(),
+    );
     on<NotificationFeedItemTapped>(_onItemTapped);
     on<NotificationFeedFollowBack>(_onFollowBack, transformer: sequential());
 
@@ -58,6 +62,7 @@ class NotificationFeedBloc
   int _emptyPageContinuations = 0;
   bool _loadMoreFailed = false;
   bool _emptyPageContinuationPending = false;
+  bool _markSeenInFlight = false;
 
   static const _maxEmptyPageContinuations = 3;
 
@@ -249,6 +254,8 @@ class NotificationFeedBloc
   /// caught here and never rethrown — the repository has already restored the
   /// snapshot on failure, so the list stays usable.
   Future<bool> _markSeenOnOpen() async {
+    if (_markSeenInFlight) return false;
+    _markSeenInFlight = true;
     try {
       await _notificationRepository.markAllAsRead();
       return true;
@@ -269,6 +276,8 @@ class NotificationFeedBloc
         s,
       );
       return false;
+    } finally {
+      _markSeenInFlight = false;
     }
   }
 
@@ -406,6 +415,18 @@ class NotificationFeedBloc
           refreshError: true,
         ),
       );
+    }
+  }
+
+  /// Handle the kept-alive inbox branch becoming visible again.
+  Future<void> _onBecameVisible(
+    NotificationFeedBecameVisible event,
+    Emitter<NotificationFeedState> emit,
+  ) async {
+    if (_filter != null) return;
+    final markSucceeded = await _markSeenOnOpen();
+    if (markSucceeded) {
+      unawaited(_clearAppBadge());
     }
   }
 

--- a/mobile/lib/notifications/bloc/notification_feed_event.dart
+++ b/mobile/lib/notifications/bloc/notification_feed_event.dart
@@ -34,6 +34,14 @@ final class NotificationFeedRefreshed extends NotificationFeedEvent {
   List<Object?> get props => [];
 }
 
+/// The notifications surface became visible again while still mounted.
+final class NotificationFeedBecameVisible extends NotificationFeedEvent {
+  const NotificationFeedBecameVisible();
+
+  @override
+  List<Object?> get props => [];
+}
+
 /// User tapped a notification — mark it as read.
 final class NotificationFeedItemTapped extends NotificationFeedEvent {
   const NotificationFeedItemTapped(this.notificationId);

--- a/mobile/lib/notifications/view/inbox_notifications_page.dart
+++ b/mobile/lib/notifications/view/inbox_notifications_page.dart
@@ -27,7 +27,10 @@ import 'package:openvine/widgets/signup_invites_availability_builder.dart';
 /// tab. Each tab owns a feed BLoC with independent server-side pagination.
 class InboxNotificationsPage extends ConsumerWidget {
   /// Creates an [InboxNotificationsPage].
-  const InboxNotificationsPage({super.key});
+  const InboxNotificationsPage({this.isVisible = true, super.key});
+
+  /// Whether the kept-alive inbox notifications pane is currently visible.
+  final bool isVisible;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -45,6 +48,7 @@ class InboxNotificationsPage extends ConsumerWidget {
     return _InboxNotificationsScaffold(
       notificationRepository: notificationRepository,
       followRepository: followRepository,
+      isVisible: isVisible,
     );
   }
 }
@@ -53,10 +57,12 @@ class _InboxNotificationsScaffold extends StatefulWidget {
   const _InboxNotificationsScaffold({
     required this.notificationRepository,
     required this.followRepository,
+    required this.isVisible,
   });
 
   final NotificationRepository notificationRepository;
   final FollowRepository followRepository;
+  final bool isVisible;
 
   @override
   State<_InboxNotificationsScaffold> createState() =>
@@ -131,6 +137,7 @@ class _InboxNotificationsScaffoldState
                   _NotificationTab(
                     notificationRepository: widget.notificationRepository,
                     followRepository: widget.followRepository,
+                    isVisible: widget.isVisible,
                     child: const Column(
                       children: [
                         _InvitesBanner(),
@@ -141,21 +148,25 @@ class _InboxNotificationsScaffoldState
                   _NotificationTab(
                     notificationRepository: widget.notificationRepository,
                     followRepository: widget.followRepository,
+                    isVisible: widget.isVisible,
                     filter: NotificationKind.like,
                   ),
                   _NotificationTab(
                     notificationRepository: widget.notificationRepository,
                     followRepository: widget.followRepository,
+                    isVisible: widget.isVisible,
                     filter: NotificationKind.comment,
                   ),
                   _NotificationTab(
                     notificationRepository: widget.notificationRepository,
                     followRepository: widget.followRepository,
+                    isVisible: widget.isVisible,
                     filter: NotificationKind.follow,
                   ),
                   _NotificationTab(
                     notificationRepository: widget.notificationRepository,
                     followRepository: widget.followRepository,
+                    isVisible: widget.isVisible,
                     filter: NotificationKind.repost,
                   ),
                 ],
@@ -172,12 +183,14 @@ class _NotificationTab extends ConsumerStatefulWidget {
   const _NotificationTab({
     required this.notificationRepository,
     required this.followRepository,
+    required this.isVisible,
     this.filter,
     this.child = const NotificationsView(),
   });
 
   final NotificationRepository notificationRepository;
   final FollowRepository followRepository;
+  final bool isVisible;
   final NotificationKind? filter;
   final Widget child;
 
@@ -209,8 +222,50 @@ class _NotificationTabState extends ConsumerState<_NotificationTab>
         appBadgeClearer: appBadgeClearer,
         filter: widget.filter,
       )..add(const NotificationFeedStarted()),
-      child: widget.child,
+      child: _NotificationVisibilityDispatcher(
+        isVisible: widget.isVisible,
+        child: widget.child,
+      ),
     );
+  }
+}
+
+class _NotificationVisibilityDispatcher extends StatefulWidget {
+  const _NotificationVisibilityDispatcher({
+    required this.isVisible,
+    required this.child,
+  });
+
+  final bool isVisible;
+  final Widget child;
+
+  @override
+  State<_NotificationVisibilityDispatcher> createState() =>
+      _NotificationVisibilityDispatcherState();
+}
+
+class _NotificationVisibilityDispatcherState
+    extends State<_NotificationVisibilityDispatcher> {
+  bool? _wasVisible;
+
+  void _observeVisibility() {
+    final visible = widget.isVisible;
+    final wasVisible = _wasVisible;
+    _wasVisible = visible;
+    if (wasVisible == false && visible) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        context.read<NotificationFeedBloc>().add(
+          const NotificationFeedBecameVisible(),
+        );
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    _observeVisibility();
+    return widget.child;
   }
 }
 

--- a/mobile/lib/screens/inbox/inbox_view.dart
+++ b/mobile/lib/screens/inbox/inbox_view.dart
@@ -20,6 +20,7 @@ import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/mixins/scroll_pagination_mixin.dart';
 import 'package:openvine/notifications/view/inbox_notifications_page.dart';
 import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/route_feed_providers.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/screens/inbox/conversation/conversation_page.dart';
 import 'package:openvine/screens/inbox/message_requests/message_requests_page.dart';
@@ -137,6 +138,7 @@ class _InboxViewState extends ConsumerState<InboxView>
     final notificationCount = context.watch<NotificationBadgeCubit>().state;
     final messageCount = context.watch<DmUnreadCountCubit>().state;
     final currentPubkey = ref.read(authServiceProvider).currentPublicKeyHex;
+    final isInboxBranchVisible = ref.watch(activeBranchIndexProvider) == 2;
     _syncToIdentity(currentPubkey);
 
     return ColoredBox(
@@ -171,7 +173,11 @@ class _InboxViewState extends ConsumerState<InboxView>
                     // lib/notifications/view/inbox_notifications_page.dart.
                     notifications: KeyedSubtree(
                       key: ValueKey('notifications-$currentPubkey'),
-                      child: const InboxNotificationsPage(),
+                      child: InboxNotificationsPage(
+                        isVisible:
+                            isInboxBranchVisible &&
+                            _selectedTab == InboxTab.notifications,
+                      ),
                     ),
                     messages: _messagesActivated
                         ? KeyedSubtree(

--- a/mobile/test/notifications/bloc/notification_feed_bloc_test.dart
+++ b/mobile/test/notifications/bloc/notification_feed_bloc_test.dart
@@ -852,6 +852,37 @@ void main() {
           verify(() => mockAppBadgeClearer.clear()).called(1);
         },
       );
+
+      test(
+        'drops the visible mark while the initial open mark is in flight',
+        () async {
+          final markCompleter = Completer<void>();
+          when(
+            () => mockNotificationRepo.markAllAsRead(),
+          ).thenAnswer((_) => markCompleter.future);
+
+          final bloc = createBloc(appBadgeClearer: mockAppBadgeClearer);
+          addTearDown(bloc.close);
+
+          // _onStarted marks seen after refreshFeed; hold that write in
+          // flight so a became-visible mark would overlap it.
+          bloc.add(NotificationFeedStarted());
+          await Future<void>.delayed(Duration.zero);
+
+          // Different event type from Started, so droppable() cannot drop
+          // it. Only _markSeenInFlight prevents the second mark-all POST.
+          bloc.add(NotificationFeedBecameVisible());
+          await Future<void>.delayed(Duration.zero);
+
+          verify(() => mockNotificationRepo.markAllAsRead()).called(1);
+          verifyNever(() => mockAppBadgeClearer.clear());
+
+          markCompleter.complete();
+          await Future<void>.delayed(Duration.zero);
+
+          verify(() => mockAppBadgeClearer.clear()).called(1);
+        },
+      );
     });
 
     group('NotificationFeedRefreshed', () {

--- a/mobile/test/notifications/bloc/notification_feed_bloc_test.dart
+++ b/mobile/test/notifications/bloc/notification_feed_bloc_test.dart
@@ -799,6 +799,61 @@ void main() {
       );
     });
 
+    group('NotificationFeedBecameVisible', () {
+      blocTest<NotificationFeedBloc, NotificationFeedState>(
+        'marks seen without refreshing when the kept-alive inbox becomes '
+        'visible again',
+        build: () => createBloc(appBadgeClearer: mockAppBadgeClearer),
+        act: (bloc) => bloc.add(NotificationFeedBecameVisible()),
+        wait: const Duration(milliseconds: 1),
+        expect: () => <NotificationFeedState>[],
+        verify: (_) {
+          verifyNever(() => mockNotificationRepo.refreshFeed(any()));
+          verify(() => mockNotificationRepo.markAllAsRead()).called(1);
+          verify(() => mockAppBadgeClearer.clear()).called(1);
+        },
+      );
+
+      blocTest<NotificationFeedBloc, NotificationFeedState>(
+        'does not mark seen for filtered tab visibility',
+        build: createFollowBloc,
+        act: (bloc) => bloc.add(NotificationFeedBecameVisible()),
+        wait: const Duration(milliseconds: 1),
+        expect: () => <NotificationFeedState>[],
+        verify: (_) {
+          verifyNever(() => mockNotificationRepo.refreshFeed(any()));
+          verifyNever(() => mockNotificationRepo.markAllAsRead());
+          verifyNever(() => mockAppBadgeClearer.clear());
+        },
+      );
+
+      test(
+        'drops overlapping visible events while mark-all is pending',
+        () async {
+          final markCompleter = Completer<void>();
+          when(
+            () => mockNotificationRepo.markAllAsRead(),
+          ).thenAnswer((_) => markCompleter.future);
+
+          final bloc = createBloc(appBadgeClearer: mockAppBadgeClearer);
+          addTearDown(bloc.close);
+
+          bloc.add(NotificationFeedBecameVisible());
+          await Future<void>.delayed(Duration.zero);
+          bloc.add(NotificationFeedBecameVisible());
+          await Future<void>.delayed(Duration.zero);
+
+          verify(() => mockNotificationRepo.markAllAsRead()).called(1);
+          verifyNever(() => mockAppBadgeClearer.clear());
+
+          markCompleter.complete();
+          await Future<void>.delayed(Duration.zero);
+
+          verify(() => mockAppBadgeClearer.clear()).called(1);
+        },
+      );
+    });
+
     group('NotificationFeedRefreshed', () {
       blocTest<NotificationFeedBloc, NotificationFeedState>(
         'emits refreshing then loaded',

--- a/mobile/test/notifications/view/inbox_notifications_page_test.dart
+++ b/mobile/test/notifications/view/inbox_notifications_page_test.dart
@@ -55,6 +55,7 @@ void main() {
 
     Widget buildSubject({
       bool reduceMotion = false,
+      bool isVisible = true,
       InviteAvailabilityCubit? availabilityCubit,
     }) {
       return testMaterialApp(
@@ -77,7 +78,9 @@ void main() {
                   ),
                 BlocProvider<InviteStatusCubit>.value(value: mockInviteCubit),
               ],
-              child: Scaffold(body: const InboxNotificationsPage()),
+              child: Scaffold(
+                body: InboxNotificationsPage(isVisible: isVisible),
+              ),
             ),
           ),
         ),
@@ -118,6 +121,25 @@ void main() {
         verifyNever(() => mockNotificationRepo.markAllAsRead());
       },
     );
+
+    testWidgets('marks seen again when a kept-alive inbox becomes visible', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildSubject(isVisible: false));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      verify(() => mockNotificationRepo.markAllAsRead()).called(1);
+      clearInteractions(mockNotificationRepo);
+
+      await tester.pumpWidget(buildSubject());
+      await tester.pump();
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 10));
+
+      verifyNever(() => mockNotificationRepo.refreshFeed(null));
+      verify(() => mockNotificationRepo.markAllAsRead()).called(1);
+    });
 
     testWidgets(
       'opens each tab against its own server-filtered feed and marks seen '


### PR DESCRIPTION
## Summary
- add a visibility event for the kept-alive notification feed BLoC
- pass explicit inbox visibility from the shell active-branch state and Notifications/Messages segment selection
- mark all notifications seen again when the notifications pane becomes visible, without refreshing and without overlapping mark-all POSTs

Closes #7547

## Verification
- flutter test test/notifications/bloc/notification_feed_bloc_test.dart test/notifications/view/inbox_notifications_page_test.dart
- flutter analyze
- pre-push checks: analyzer plus changed-file tests