### PR TITLE
fix(notifications): initialize local permission state

### DIFF
--- a/mobile/lib/providers/notifications_providers.dart
+++ b/mobile/lib/providers/notifications_providers.dart
@@ -32,6 +32,7 @@ final firebaseOnMessageProvider = Provider<Stream<RemoteMessage>>(
 
 final notificationServiceProvider = Provider<NotificationService>((ref) {
   final service = NotificationService();
+  unawaited(service.initialize());
   ref.onDispose(service.dispose);
   return service;
 });

--- a/mobile/lib/services/notification_service.dart
+++ b/mobile/lib/services/notification_service.dart
@@ -127,8 +127,6 @@ class NotificationService {
   bool get hasPermissions =>
       _permissionState == _NotificationPermissionState.granted;
 
-  bool get _permissionsGranted => hasPermissions;
-
   /// Stream of local-notification taps emitted after payload parsing.
   Stream<NotificationTapEvent> get notificationTapStream =>
       (_notificationTapController ??=
@@ -654,12 +652,12 @@ class NotificationService {
     // Resolves the uninitialized state, and re-checks a stale `denied` so a
     // permission granted from system settings takes effect without an app
     // restart. Never prompts — see [refreshPermissionState].
-    if (!_permissionsGranted) {
+    if (!hasPermissions) {
       await refreshPermissionState();
     }
 
     // Skip platform notification on web or without permissions
-    if (kIsWeb || !_permissionsGranted) {
+    if (kIsWeb || !hasPermissions) {
       Log.debug(
         'Skipping platform notification (web: $kIsWeb, permissionState: ${_permissionState.name})',
         name: 'NotificationService',

--- a/mobile/lib/services/notification_service.dart
+++ b/mobile/lib/services/notification_service.dart
@@ -154,6 +154,13 @@ class NotificationService {
 
   /// Initialize notification service
   ///
+  /// Resolves the current platform permission state *without prompting*, so
+  /// [sendLocal] starts from a real answer instead of the uninitialized
+  /// [_NotificationPermissionState.unknown]. Showing the permission dialog
+  /// stays with the sign-in-gated push registration flow in
+  /// `PushNotificationSessionCoordinator`, which is the only place the app is
+  /// allowed to interrupt the user for it.
+  ///
   /// Call this from main.dart after runApp() to set up notifications:
   /// ```dart
   /// void main() async {
@@ -172,11 +179,11 @@ class NotificationService {
     );
 
     try {
-      // Request notification permissions
-      await _requestPermissions();
+      await refreshPermissionState();
 
       Log.info(
-        'NotificationService initialized',
+        'NotificationService initialized '
+        '(permissionState: ${_permissionState.name})',
         name: 'NotificationService',
         category: LogCategory.system,
       );
@@ -224,15 +231,32 @@ class NotificationService {
       _notifications.where((n) => n.type == type).toList();
 
   /// Ensure notification permissions are granted
-  /// Public method to request permissions explicitly
-  Future<void> ensurePermission() async {
+  ///
+  /// Prompts the user when the platform has not decided yet. Production code
+  /// should prefer [refreshPermissionState] and leave prompting to the
+  /// sign-in-gated push registration flow.
+  Future<void> ensurePermission() => _runPermissionOperation(_ensurePermission);
+
+  /// Re-read the platform permission state without ever prompting.
+  ///
+  /// Resolves [_NotificationPermissionState.unknown] at startup, and re-checks
+  /// a stale `denied` so notifications enabled from system settings take
+  /// effect without an app restart.
+  Future<void> refreshPermissionState() =>
+      _runPermissionOperation(_refreshPermissionState);
+
+  /// Serializes permission work so concurrent callers share one platform
+  /// round-trip instead of racing to overwrite [_permissionState].
+  Future<void> _runPermissionOperation(
+    Future<void> Function() operation,
+  ) async {
     final activeRequest = _permissionRequest;
     if (activeRequest != null) {
       await activeRequest;
       return;
     }
 
-    final request = _ensurePermission();
+    final request = operation();
     _permissionRequest = request;
     try {
       await request;
@@ -240,6 +264,75 @@ class NotificationService {
       if (identical(_permissionRequest, request)) {
         _permissionRequest = null;
       }
+    }
+  }
+
+  Future<void> _refreshPermissionState() async {
+    // Screenshot capture runs must never touch the permission surface — see
+    // [_ensurePermission] for why the iOS dialog deadlocks captures.
+    if (ScreenshotMode.enabled) return;
+
+    if (kIsWeb) {
+      _permissionState =
+          _NotificationPermissionState.granted; // Allow in-app notifications
+      return;
+    }
+
+    try {
+      if (!_pluginInitialized) {
+        await _initializePlugin();
+      }
+
+      final bool? enabled;
+      if (defaultTargetPlatform == TargetPlatform.iOS ||
+          defaultTargetPlatform == TargetPlatform.macOS) {
+        enabled =
+            (await _flutterLocalNotificationsPlugin
+                    .resolvePlatformSpecificImplementation<
+                      IOSFlutterLocalNotificationsPlugin
+                    >()
+                    ?.checkPermissions())
+                ?.isEnabled;
+      } else if (defaultTargetPlatform == TargetPlatform.android) {
+        enabled = await _flutterLocalNotificationsPlugin
+            .resolvePlatformSpecificImplementation<
+              AndroidFlutterLocalNotificationsPlugin
+            >()
+            ?.areNotificationsEnabled();
+      } else {
+        // Other platforms (Linux, Windows) don't require runtime permissions
+        _permissionState = _NotificationPermissionState.granted;
+        return;
+      }
+
+      if (enabled == null) {
+        // No platform implementation answered (test environment, or a host
+        // without native support). Leave the state unresolved rather than
+        // guessing a grant we cannot back up.
+        Log.debug(
+          'Notification permission state unresolved by platform',
+          name: 'NotificationService',
+          category: LogCategory.system,
+        );
+        return;
+      }
+
+      _permissionState = enabled
+          ? _NotificationPermissionState.granted
+          : _NotificationPermissionState.denied;
+      Log.info(
+        'Notification permissions ${enabled ? "enabled" : "disabled"}',
+        name: 'NotificationService',
+        category: LogCategory.system,
+      );
+    } catch (e) {
+      // Leave the state unresolved so a later attempt can retry, and so the
+      // skip log distinguishes "could not read" from a real denial.
+      Log.error(
+        'Failed to read notification permission state: $e',
+        name: 'NotificationService',
+        category: LogCategory.system,
+      );
     }
   }
 
@@ -639,12 +732,6 @@ class NotificationService {
         category: LogCategory.system,
       );
     }
-  }
-
-  /// Request notification permissions from platform
-  Future<void> _requestPermissions() async {
-    // Delegate to public ensurePermission method
-    await ensurePermission();
   }
 
   /// Add notification to internal list

--- a/mobile/lib/services/notification_service.dart
+++ b/mobile/lib/services/notification_service.dart
@@ -19,6 +19,8 @@ enum NotificationType {
   processingStarted,
 }
 
+enum _NotificationPermissionState { unknown, granted, denied }
+
 /// Normalized notification-tap payload emitted by [NotificationService].
 @immutable
 class NotificationTapEvent {
@@ -107,7 +109,9 @@ class NotificationService {
   }
 
   final List<AppNotification> _notifications = [];
-  bool _permissionsGranted = false;
+  _NotificationPermissionState _permissionState =
+      _NotificationPermissionState.unknown;
+  Future<void>? _permissionRequest;
   bool _disposed = false;
 
   // Flutter local notifications plugin instance
@@ -120,7 +124,10 @@ class NotificationService {
   List<AppNotification> get notifications => List.unmodifiable(_notifications);
 
   /// Check if notification permissions are granted
-  bool get hasPermissions => _permissionsGranted;
+  bool get hasPermissions =>
+      _permissionState == _NotificationPermissionState.granted;
+
+  bool get _permissionsGranted => hasPermissions;
 
   /// Stream of local-notification taps emitted after payload parsing.
   Stream<NotificationTapEvent> get notificationTapStream =>
@@ -128,17 +135,21 @@ class NotificationService {
               StreamController<NotificationTapEvent>.broadcast())
           .stream;
 
-  /// Test seam: swap in a mock [plugin] and mark the service ready so
-  /// [sendLocal] and [takeLaunchNotificationTap] exercise the plugin directly
-  /// without touching real platform channels.
+  /// Test seam: swap in a mock [plugin] and configure the plugin/permission
+  /// state so notification flows can run without real platform channels.
   @visibleForTesting
   void debugConfigurePlugin(
     FlutterLocalNotificationsPlugin plugin, {
-    bool permissionsGranted = true,
+    bool? permissionsGranted = true,
+    bool pluginInitialized = true,
   }) {
     _flutterLocalNotificationsPlugin = plugin;
-    _pluginInitialized = true;
-    _permissionsGranted = permissionsGranted;
+    _pluginInitialized = pluginInitialized;
+    _permissionState = switch (permissionsGranted) {
+      true => _NotificationPermissionState.granted,
+      false => _NotificationPermissionState.denied,
+      null => _NotificationPermissionState.unknown,
+    };
   }
 
   /// Initialize notification service
@@ -215,6 +226,24 @@ class NotificationService {
   /// Ensure notification permissions are granted
   /// Public method to request permissions explicitly
   Future<void> ensurePermission() async {
+    final activeRequest = _permissionRequest;
+    if (activeRequest != null) {
+      await activeRequest;
+      return;
+    }
+
+    final request = _ensurePermission();
+    _permissionRequest = request;
+    try {
+      await request;
+    } finally {
+      if (identical(_permissionRequest, request)) {
+        _permissionRequest = null;
+      }
+    }
+  }
+
+  Future<void> _ensurePermission() async {
     // Screenshot capture runs must never surface the iOS permission
     // dialog — XCUITest interruption monitors don't fire on bare
     // waitForExistence, so the alert would deadlock every capture.
@@ -228,7 +257,7 @@ class NotificationService {
     }
 
     // Skip if already granted
-    if (_permissionsGranted) {
+    if (_permissionState == _NotificationPermissionState.granted) {
       Log.debug(
         'Notification permissions already granted',
         name: 'NotificationService',
@@ -244,7 +273,8 @@ class NotificationService {
         name: 'NotificationService',
         category: LogCategory.system,
       );
-      _permissionsGranted = true; // Allow in-app notifications
+      _permissionState =
+          _NotificationPermissionState.granted; // Allow in-app notifications
       return;
     }
 
@@ -269,7 +299,7 @@ class NotificationService {
 
       if (isTestEnvironment) {
         // In test mode, auto-grant permissions for testing
-        _permissionsGranted = true;
+        _permissionState = _NotificationPermissionState.granted;
         Log.debug(
           'Test environment: auto-granting notification permissions',
           name: 'NotificationService',
@@ -289,7 +319,9 @@ class NotificationService {
                 ?.requestPermissions(alert: true, badge: true, sound: true) ??
             false;
 
-        _permissionsGranted = granted;
+        _permissionState = granted
+            ? _NotificationPermissionState.granted
+            : _NotificationPermissionState.denied;
         Log.info(
           'iOS notification permissions ${granted ? "granted" : "denied"}',
           name: 'NotificationService',
@@ -306,7 +338,9 @@ class NotificationService {
                 ?.requestNotificationsPermission() ??
             true; // Pre-Android 13 doesn't need runtime permission
 
-        _permissionsGranted = granted;
+        _permissionState = granted
+            ? _NotificationPermissionState.granted
+            : _NotificationPermissionState.denied;
         Log.info(
           'Android notification permissions ${granted ? "granted" : "denied"}',
           name: 'NotificationService',
@@ -314,7 +348,7 @@ class NotificationService {
         );
       } else {
         // Other platforms (Linux, Windows) don't require runtime permissions
-        _permissionsGranted = true;
+        _permissionState = _NotificationPermissionState.granted;
         Log.info(
           'Platform notification permissions auto-granted',
           name: 'NotificationService',
@@ -324,7 +358,7 @@ class NotificationService {
     } catch (e) {
       // In case of any error (including test environment), grant permissions
       // to allow in-app notifications to work
-      _permissionsGranted = true;
+      _permissionState = _NotificationPermissionState.granted;
       Log.error(
         'Failed to request notification permissions: $e',
         name: 'NotificationService',
@@ -524,10 +558,14 @@ class NotificationService {
     // Add to internal list
     _addNotification(notification);
 
+    if (_permissionState == _NotificationPermissionState.unknown) {
+      await ensurePermission();
+    }
+
     // Skip platform notification on web or without permissions
     if (kIsWeb || !_permissionsGranted) {
       Log.debug(
-        'Skipping platform notification (web: $kIsWeb, permissions: $_permissionsGranted)',
+        'Skipping platform notification (web: $kIsWeb, permissionState: ${_permissionState.name})',
         name: 'NotificationService',
         category: LogCategory.system,
       );

--- a/mobile/lib/services/notification_service.dart
+++ b/mobile/lib/services/notification_service.dart
@@ -651,8 +651,11 @@ class NotificationService {
     // Add to internal list
     _addNotification(notification);
 
-    if (_permissionState == _NotificationPermissionState.unknown) {
-      await ensurePermission();
+    // Resolves the uninitialized state, and re-checks a stale `denied` so a
+    // permission granted from system settings takes effect without an app
+    // restart. Never prompts — see [refreshPermissionState].
+    if (!_permissionsGranted) {
+      await refreshPermissionState();
     }
 
     // Skip platform notification on web or without permissions

--- a/mobile/test/services/notification_service_test.dart
+++ b/mobile/test/services/notification_service_test.dart
@@ -14,6 +14,14 @@ class _MockFlutterLocalNotificationsPlugin extends Mock
     implements FlutterLocalNotificationsPlugin {}
 
 void main() {
+  setUpAll(() {
+    registerFallbackValue(
+      const InitializationSettings(
+        android: AndroidInitializationSettings('@mipmap/ic_launcher'),
+      ),
+    );
+  });
+
   group('NotificationService Permission Tests', () {
     late NotificationService notificationService;
 
@@ -84,23 +92,113 @@ void main() {
       );
     });
 
-    test('sendLocal without permissions only adds to internal list', () async {
-      // Do NOT call ensurePermission - no permissions granted
-      expect(notificationService.hasPermissions, isFalse);
+    test(
+      'sendLocal adds to internal list while resolving permissions',
+      () async {
+        // Do NOT call ensurePermission first: sendLocal should resolve the
+        // unknown permission state itself before deciding on platform delivery.
+        expect(notificationService.hasPermissions, isFalse);
 
-      // Send notification without permissions
-      await notificationService.sendLocal(
-        title: 'No Permission Test',
-        body: 'Should only show in-app',
-      );
+        await notificationService.sendLocal(
+          title: 'Unknown Permission Test',
+          body: 'Should always show in-app',
+        );
 
-      // Should still add to internal list for in-app display
-      expect(notificationService.notifications.length, equals(1));
-      expect(
-        notificationService.notifications.first.title,
-        equals('No Permission Test'),
-      );
-    });
+        expect(notificationService.notifications.length, equals(1));
+        expect(
+          notificationService.notifications.first.title,
+          equals('Unknown Permission Test'),
+        );
+      },
+    );
+
+    test(
+      'sendLocal resolves unknown permission state before platform delivery',
+      () async {
+        final plugin = _MockFlutterLocalNotificationsPlugin();
+        when(
+          () => plugin.initialize(
+            settings: any(named: 'settings'),
+            onDidReceiveNotificationResponse: any(
+              named: 'onDidReceiveNotificationResponse',
+            ),
+            onDidReceiveBackgroundNotificationResponse: any(
+              named: 'onDidReceiveBackgroundNotificationResponse',
+            ),
+          ),
+        ).thenAnswer((_) async => true);
+        when(
+          () => plugin.show(
+            id: any(named: 'id'),
+            title: any(named: 'title'),
+            body: any(named: 'body'),
+            notificationDetails: any(named: 'notificationDetails'),
+            payload: any(named: 'payload'),
+          ),
+        ).thenAnswer((_) async {});
+
+        notificationService.debugConfigurePlugin(
+          plugin,
+          permissionsGranted: null,
+          pluginInitialized: false,
+        );
+
+        await notificationService.sendLocal(
+          title: 'Unknown Permission',
+          body: 'Should initialize before deciding',
+        );
+
+        verify(
+          () => plugin.initialize(
+            settings: any(named: 'settings'),
+            onDidReceiveNotificationResponse: any(
+              named: 'onDidReceiveNotificationResponse',
+            ),
+            onDidReceiveBackgroundNotificationResponse: any(
+              named: 'onDidReceiveBackgroundNotificationResponse',
+            ),
+          ),
+        ).called(1);
+        verify(
+          () => plugin.show(
+            id: any(named: 'id'),
+            title: 'Unknown Permission',
+            body: 'Should initialize before deciding',
+            notificationDetails: any(named: 'notificationDetails'),
+            payload: any(named: 'payload'),
+          ),
+        ).called(1);
+        expect(notificationService.hasPermissions, isTrue);
+      },
+    );
+
+    test(
+      'sendLocal with denied permissions does not call platform show',
+      () async {
+        final plugin = _MockFlutterLocalNotificationsPlugin();
+        notificationService.debugConfigurePlugin(
+          plugin,
+          permissionsGranted: false,
+        );
+
+        await notificationService.sendLocal(
+          title: 'Denied Permission',
+          body: 'Should stay in-app only',
+        );
+
+        verifyNever(
+          () => plugin.show(
+            id: any(named: 'id'),
+            title: any(named: 'title'),
+            body: any(named: 'body'),
+            notificationDetails: any(named: 'notificationDetails'),
+            payload: any(named: 'payload'),
+          ),
+        );
+        expect(notificationService.notifications, hasLength(1));
+        expect(notificationService.hasPermissions, isFalse);
+      },
+    );
 
     test('sendLocal handles empty title and body', () async {
       await notificationService.ensurePermission();

--- a/mobile/test/services/notification_service_test.dart
+++ b/mobile/test/services/notification_service_test.dart
@@ -140,6 +140,17 @@ void main() {
           ),
         ).thenAnswer((_) async {});
 
+        final androidPlugin = _MockAndroidFlutterLocalNotificationsPlugin();
+        when(
+          () => plugin
+              .resolvePlatformSpecificImplementation<
+                AndroidFlutterLocalNotificationsPlugin
+              >(),
+        ).thenReturn(androidPlugin);
+        when(
+          androidPlugin.areNotificationsEnabled,
+        ).thenAnswer((_) async => true);
+
         notificationService.debugConfigurePlugin(
           plugin,
           permissionsGranted: null,
@@ -172,6 +183,7 @@ void main() {
           ),
         ).called(1);
         expect(notificationService.hasPermissions, isTrue);
+        verifyNever(androidPlugin.requestNotificationsPermission);
       },
     );
 
@@ -179,6 +191,17 @@ void main() {
       'sendLocal with denied permissions does not call platform show',
       () async {
         final plugin = _MockFlutterLocalNotificationsPlugin();
+        final androidPlugin = _MockAndroidFlutterLocalNotificationsPlugin();
+        when(
+          () => plugin
+              .resolvePlatformSpecificImplementation<
+                AndroidFlutterLocalNotificationsPlugin
+              >(),
+        ).thenReturn(androidPlugin);
+        when(
+          androidPlugin.areNotificationsEnabled,
+        ).thenAnswer((_) async => false);
+
         notificationService.debugConfigurePlugin(
           plugin,
           permissionsGranted: false,
@@ -200,6 +223,67 @@ void main() {
         );
         expect(notificationService.notifications, hasLength(1));
         expect(notificationService.hasPermissions, isFalse);
+        verifyNever(androidPlugin.requestNotificationsPermission);
+      },
+    );
+
+    test(
+      'sendLocal picks up a permission granted from system settings',
+      () async {
+        final plugin = _MockFlutterLocalNotificationsPlugin();
+        final androidPlugin = _MockAndroidFlutterLocalNotificationsPlugin();
+        when(
+          () => plugin
+              .resolvePlatformSpecificImplementation<
+                AndroidFlutterLocalNotificationsPlugin
+              >(),
+        ).thenReturn(androidPlugin);
+        when(
+          () => plugin.show(
+            id: any(named: 'id'),
+            title: any(named: 'title'),
+            body: any(named: 'body'),
+            notificationDetails: any(named: 'notificationDetails'),
+            payload: any(named: 'payload'),
+          ),
+        ).thenAnswer((_) async {});
+        when(
+          androidPlugin.areNotificationsEnabled,
+        ).thenAnswer((_) async => false);
+
+        notificationService.debugConfigurePlugin(
+          plugin,
+          permissionsGranted: false,
+        );
+
+        await notificationService.sendLocal(
+          title: 'Still Denied',
+          body: 'Stays in-app',
+        );
+        expect(notificationService.hasPermissions, isFalse);
+
+        // The user enables notifications in system settings. Without a
+        // re-check, `denied` would stick until the process restarts.
+        when(
+          androidPlugin.areNotificationsEnabled,
+        ).thenAnswer((_) async => true);
+
+        await notificationService.sendLocal(
+          title: 'Now Allowed',
+          body: 'Reaches the platform',
+        );
+
+        expect(notificationService.hasPermissions, isTrue);
+        verify(
+          () => plugin.show(
+            id: any(named: 'id'),
+            title: 'Now Allowed',
+            body: 'Reaches the platform',
+            notificationDetails: any(named: 'notificationDetails'),
+            payload: any(named: 'payload'),
+          ),
+        ).called(1);
+        verifyNever(androidPlugin.requestNotificationsPermission);
       },
     );
 
@@ -294,7 +378,7 @@ void main() {
         await service.initialize();
 
         expect(service.hasPermissions, isFalse);
-        verifyNever(() => androidPlugin.requestNotificationsPermission());
+        verifyNever(androidPlugin.requestNotificationsPermission);
       },
     );
   });

--- a/mobile/test/services/notification_service_test.dart
+++ b/mobile/test/services/notification_service_test.dart
@@ -13,6 +13,9 @@ import 'package:openvine/services/notification_service.dart';
 class _MockFlutterLocalNotificationsPlugin extends Mock
     implements FlutterLocalNotificationsPlugin {}
 
+class _MockAndroidFlutterLocalNotificationsPlugin extends Mock
+    implements AndroidFlutterLocalNotificationsPlugin {}
+
 void main() {
   setUpAll(() {
     registerFallbackValue(
@@ -232,6 +235,68 @@ void main() {
       expect(notificationService.notifications[1].title, equals('Second'));
       expect(notificationService.notifications[2].title, equals('First'));
     });
+  });
+
+  group('NotificationService.initialize', () {
+    late NotificationService service;
+    late _MockFlutterLocalNotificationsPlugin plugin;
+    late _MockAndroidFlutterLocalNotificationsPlugin androidPlugin;
+
+    setUp(() {
+      service = NotificationService();
+      plugin = _MockFlutterLocalNotificationsPlugin();
+      androidPlugin = _MockAndroidFlutterLocalNotificationsPlugin();
+      when(
+        () => plugin
+            .resolvePlatformSpecificImplementation<
+              AndroidFlutterLocalNotificationsPlugin
+            >(),
+      ).thenReturn(androidPlugin);
+      service.debugConfigurePlugin(plugin, permissionsGranted: null);
+    });
+
+    tearDown(() {
+      service.dispose();
+    });
+
+    test('resolves a granted permission state without prompting', () async {
+      when(
+        () => androidPlugin.areNotificationsEnabled(),
+      ).thenAnswer((_) async => true);
+
+      await service.initialize();
+
+      expect(service.hasPermissions, isTrue);
+      verify(() => androidPlugin.areNotificationsEnabled()).called(1);
+      verifyNever(() => androidPlugin.requestNotificationsPermission());
+    });
+
+    test('resolves a denied permission state without prompting', () async {
+      when(
+        () => androidPlugin.areNotificationsEnabled(),
+      ).thenAnswer((_) async => false);
+
+      await service.initialize();
+
+      // Denied, not unknown: the delivery decision now has a real answer.
+      expect(service.hasPermissions, isFalse);
+      verify(() => androidPlugin.areNotificationsEnabled()).called(1);
+      verifyNever(() => androidPlugin.requestNotificationsPermission());
+    });
+
+    test(
+      'leaves the state unresolved when the platform cannot answer',
+      () async {
+        when(
+          () => androidPlugin.areNotificationsEnabled(),
+        ).thenAnswer((_) async => null);
+
+        await service.initialize();
+
+        expect(service.hasPermissions, isFalse);
+        verifyNever(() => androidPlugin.requestNotificationsPermission());
+      },
+    );
   });
 
   group('NotificationService Web Platform Tests', () {


### PR DESCRIPTION
## Description

Initializes NotificationService permission state when the provider is created and resolves an unknown permission state before local notification delivery decisions. This keeps uninitialized service state distinct from a real denied permission so foreground local notifications are not silently skipped before permissions are loaded.

**Related Issue:** Closes #7549

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [ ] Build configuration change
- [ ] Documentation
- [ ] Chore