### PR TITLE
chore(playback): lower handled media processing logs

### DIFF
--- a/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
+++ b/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
@@ -1469,12 +1469,22 @@ internal class DivineVideoPlayerInstance(
 
         override fun onPlayerError(error: PlaybackException) {
             val currentUri = player?.currentMediaItem?.localConfiguration?.uri
-            DivineVideoPlayerLog.error(
+            val nativeErrorCode = errorCodeFor(error)
+            val message =
                 "Player $playerId playback error [${error.errorCodeName}]: " +
                     "source=${currentUri ?: "unknown"} " +
-                    (error.message ?: "unknown"),
-                name = "DivineVideoPlayer.Playback",
-            )
+                    (error.message ?: "unknown")
+            if (nativeErrorCode == "media_processing") {
+                DivineVideoPlayerLog.warning(
+                    message,
+                    name = "DivineVideoPlayer.Playback",
+                )
+            } else {
+                DivineVideoPlayerLog.error(
+                    message,
+                    name = "DivineVideoPlayer.Playback",
+                )
+            }
             // A transient decoder failure may recover on a re-prepare; keep the
             // pending setClips result open so a successful retry still resolves
             // it (or the 10 s watchdog fires if every retry fails).
@@ -1485,7 +1495,7 @@ internal class DivineVideoPlayerInstance(
             pendingSetClipsResult?.error(
                 "PLAYER_ERROR",
                 error.message ?: "Unknown playback error",
-                mapOf("errorCode" to errorCodeFor(error)),
+                mapOf("errorCode" to nativeErrorCode),
             )
             pendingSetClipsResult = null
             sendStateUpdate()

--- a/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/DivineVideoPlayerInstance.swift
+++ b/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/DivineVideoPlayerInstance.swift
@@ -327,11 +327,20 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
                 self.errorCode = self.errorCode(for: error as NSError)
                 self.clearSetClipsTimeout()
                 self.clearBufferingWatchdog(resetReported: true)
-                DivineVideoPlayerLog.shared.error(
+                let message =
                     "Player \(self.playerId) composition failed: "
-                        + "\(error.localizedDescription)",
-                    name: "DivineVideoPlayer.Load"
-                )
+                    + "\(error.localizedDescription)"
+                if self.errorCode == "media_processing" {
+                    DivineVideoPlayerLog.shared.warning(
+                        message,
+                        name: "DivineVideoPlayer.Load"
+                    )
+                } else {
+                    DivineVideoPlayerLog.shared.error(
+                        message,
+                        name: "DivineVideoPlayer.Load"
+                    )
+                }
                 self.sendStateUpdate()
                 result(
                     FlutterError(
@@ -1127,11 +1136,20 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
                     } else {
                         self.errorCode = nil
                     }
-                    DivineVideoPlayerLog.shared.error(
+                    let message =
                         "Player \(self.playerId) item failed: "
-                            + "\(item.error?.localizedDescription ?? "unknown")",
-                        name: "DivineVideoPlayer.Playback"
-                    )
+                        + "\(item.error?.localizedDescription ?? "unknown")"
+                    if self.errorCode == "media_processing" {
+                        DivineVideoPlayerLog.shared.warning(
+                            message,
+                            name: "DivineVideoPlayer.Playback"
+                        )
+                    } else {
+                        DivineVideoPlayerLog.shared.error(
+                            message,
+                            name: "DivineVideoPlayer.Playback"
+                        )
+                    }
                 default:
                     break
                 }

--- a/mobile/packages/divine_video_player/test/src/media_processing_log_contract_test.dart
+++ b/mobile/packages/divine_video_player/test/src/media_processing_log_contract_test.dart
@@ -1,0 +1,125 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('native media-processing log contract', () {
+    test('Android logs HTTP 202 media_processing as warning', () {
+      final source = _androidSourceFile().readAsStringSync();
+
+      final statusMapping = source.indexOf('status == 202');
+      final mediaProcessingMapping = source.indexOf(
+        '"media_processing"',
+        statusMapping,
+      );
+      final errorCodeCapture = source.indexOf(
+        'val nativeErrorCode = errorCodeFor(error)',
+      );
+      final mediaProcessingLogBranch = source.indexOf(
+        'nativeErrorCode == "media_processing"',
+        errorCodeCapture,
+      );
+      final warningLog = source.indexOf(
+        'DivineVideoPlayerLog.warning',
+        mediaProcessingLogBranch,
+      );
+      final errorLog = source.indexOf(
+        'DivineVideoPlayerLog.error',
+        mediaProcessingLogBranch,
+      );
+
+      expect(statusMapping, greaterThanOrEqualTo(0));
+      expect(mediaProcessingMapping, greaterThan(statusMapping));
+      expect(errorCodeCapture, greaterThan(mediaProcessingMapping));
+      expect(mediaProcessingLogBranch, greaterThan(errorCodeCapture));
+      expect(warningLog, greaterThan(mediaProcessingLogBranch));
+      expect(
+        warningLog,
+        lessThan(errorLog),
+        reason:
+            'Handled HTTP 202 transcode-in-progress failures should stay out '
+            'of ERROR telemetry while still preserving true playback errors.',
+      );
+    });
+
+    test('Apple logs HTTP 202 media_processing as warning', () {
+      final source = _appleSourceFile().readAsStringSync();
+
+      final statusMapping = source.indexOf('httpResponse.statusCode == 202');
+      final mediaProcessingMapping = source.indexOf(
+        'return "media_processing"',
+        statusMapping,
+      );
+      final compositionBranch = source.indexOf(
+        'self.errorCode == "media_processing"',
+      );
+      final compositionWarning = source.indexOf(
+        'DivineVideoPlayerLog.shared.warning',
+        compositionBranch,
+      );
+      final compositionError = source.indexOf(
+        'DivineVideoPlayerLog.shared.error',
+        compositionBranch,
+      );
+      final itemBranch = source.indexOf(
+        'self.errorCode == "media_processing"',
+        compositionError,
+      );
+      final itemWarning = source.indexOf(
+        'DivineVideoPlayerLog.shared.warning',
+        itemBranch,
+      );
+      final itemError = source.indexOf(
+        'DivineVideoPlayerLog.shared.error',
+        itemBranch,
+      );
+
+      expect(statusMapping, greaterThanOrEqualTo(0));
+      expect(mediaProcessingMapping, greaterThan(statusMapping));
+      expect(compositionBranch, greaterThanOrEqualTo(0));
+      expect(compositionWarning, greaterThan(compositionBranch));
+      expect(compositionWarning, lessThan(compositionError));
+      expect(itemBranch, greaterThan(compositionError));
+      expect(itemWarning, greaterThan(itemBranch));
+      expect(
+        itemWarning,
+        lessThan(itemError),
+        reason:
+            'Both Darwin composition-load and AVPlayerItem HTTP 202 failures '
+            'should be warning-level because Dart handles media_processing.',
+      );
+    });
+  });
+}
+
+File _androidSourceFile() {
+  final packageRelative = File(
+    'android/src/main/kotlin/com/divinevideo/divine_video_player/'
+    'DivineVideoPlayerInstance.kt',
+  );
+  if (packageRelative.existsSync()) {
+    return packageRelative;
+  }
+
+  return File(
+    'packages/divine_video_player/'
+    'android/src/main/kotlin/com/divinevideo/divine_video_player/'
+    'DivineVideoPlayerInstance.kt',
+  );
+}
+
+File _appleSourceFile() {
+  final packageRelative = File(
+    'darwin/divine_video_player/Sources/divine_video_player/'
+    'DivineVideoPlayerInstance.swift',
+  );
+  if (packageRelative.existsSync()) {
+    return packageRelative;
+  }
+
+  return File(
+    'packages/divine_video_player/'
+    'darwin/divine_video_player/Sources/divine_video_player/'
+    'DivineVideoPlayerInstance.swift',
+  );
+}


### PR DESCRIPTION
## Description

Downgrades native DivineVideoPlayer logs for HTTP 202 media-processing failures from error to warning while preserving typed error details and keeping other playback failures at error level. This keeps expected transcode-in-progress retry behavior out of ERROR telemetry for the native player layer.

**Related Issue:** Refs #7553

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [ ] Build configuration change
- [ ] Documentation
- [x] Chore