### PR TITLE
fix(analytics): name shell route surfaces

### DIFF
--- a/mobile/lib/router/go_router_page_name.dart
+++ b/mobile/lib/router/go_router_page_name.dart
@@ -2,6 +2,7 @@
 // ABOUTME: Keeps ShellRoute pages from falling back to unknown_route.
 
 import 'package:go_router/go_router.dart';
+import 'package:openvine/router/route_paths.dart';
 
 /// Returns the stable page name go_router would put on a regular [GoRoute].
 ///
@@ -9,5 +10,42 @@ import 'package:go_router/go_router.dart';
 /// [GoRouterState.path], so fall back to the matched leaf route exposed through
 /// [GoRouterState.topRoute].
 String? goRouterPageName(GoRouterState state) {
-  return state.name ?? state.path ?? state.topRoute?.name ?? state.fullPath;
+  final explicitName = _nonEmpty(state.name);
+  if (explicitName != null) return explicitName;
+
+  return _shellSurfaceNameForPath(state.path) ??
+      _nonEmpty(state.topRoute?.name) ??
+      _shellSurfaceNameForPath(state.topRoute?.path) ??
+      _shellSurfaceNameForPath(state.fullPath) ??
+      _shellSurfaceNameForPath(state.uri.path) ??
+      _nonEmpty(state.path) ??
+      _nonEmpty(state.fullPath);
+}
+
+String? _nonEmpty(String? value) {
+  if (value == null || value.trim().isEmpty) return null;
+  return value;
+}
+
+String? _shellSurfaceNameForPath(String? path) {
+  final candidate = _nonEmpty(path);
+  if (candidate == null) return null;
+
+  final pathOnly = Uri.tryParse(candidate)?.path ?? candidate;
+  final segments = pathOnly.split('/').where((s) => s.isNotEmpty);
+  final firstSegment = segments.isEmpty ? null : segments.first;
+  return switch (firstSegment) {
+    'home' => 'home',
+    'explore' => 'explore',
+    'notifications' => 'notifications',
+    'inbox' => 'inbox',
+    'profile' => 'profile',
+    'liked-videos' => 'liked-videos',
+    _ when pathOnly == RoutePaths.explore => 'explore',
+    _ when pathOnly == RoutePaths.notifications => 'notifications',
+    _ when pathOnly == RoutePaths.inbox => 'inbox',
+    _ when pathOnly == RoutePaths.profile => 'profile',
+    _ when pathOnly == RoutePaths.likedVideos => 'liked-videos',
+    _ => null,
+  };
 }

--- a/mobile/lib/router/go_router_page_name.dart
+++ b/mobile/lib/router/go_router_page_name.dart
@@ -2,7 +2,6 @@
 // ABOUTME: Keeps ShellRoute pages from falling back to unknown_route.
 
 import 'package:go_router/go_router.dart';
-import 'package:openvine/router/route_paths.dart';
 
 /// Returns the stable page name go_router would put on a regular [GoRoute].
 ///
@@ -41,11 +40,6 @@ String? _shellSurfaceNameForPath(String? path) {
     'inbox' => 'inbox',
     'profile' => 'profile',
     'liked-videos' => 'liked-videos',
-    _ when pathOnly == RoutePaths.explore => 'explore',
-    _ when pathOnly == RoutePaths.notifications => 'notifications',
-    _ when pathOnly == RoutePaths.inbox => 'inbox',
-    _ when pathOnly == RoutePaths.profile => 'profile',
-    _ when pathOnly == RoutePaths.likedVideos => 'liked-videos',
     _ => null,
   };
 }

--- a/mobile/test/router/fade_upwards_page_test.dart
+++ b/mobile/test/router/fade_upwards_page_test.dart
@@ -25,6 +25,12 @@ class _FakeGoRouterState extends Fake implements GoRouterState {
   final String? path;
 
   @override
+  GoRoute? get topRoute => null;
+
+  @override
+  String? get fullPath => null;
+
+  @override
   final Map<String, String> pathParameters;
 
   @override

--- a/mobile/test/router/go_router_page_name_test.dart
+++ b/mobile/test/router/go_router_page_name_test.dart
@@ -7,7 +7,13 @@ import 'package:go_router/go_router.dart';
 import 'package:openvine/router/go_router_page_name.dart';
 
 class _FakeGoRouterState extends Fake implements GoRouterState {
-  _FakeGoRouterState({this.name, this.path, this.topRoute, this.fullPath});
+  _FakeGoRouterState({
+    this.name,
+    this.path,
+    this.topRoute,
+    this.fullPath,
+    Uri? uri,
+  }) : uri = uri ?? Uri(path: '/');
 
   @override
   final String? name;
@@ -20,6 +26,9 @@ class _FakeGoRouterState extends Fake implements GoRouterState {
 
   @override
   final String? fullPath;
+
+  @override
+  final Uri uri;
 }
 
 GoRoute _goRoute({required String path, required String name}) {
@@ -64,9 +73,38 @@ void main() {
 
     test('falls back to fullPath when no stable name is available', () {
       expect(
-        goRouterPageName(_FakeGoRouterState(fullPath: '/explore/:name')),
-        '/explore/:name',
+        goRouterPageName(_FakeGoRouterState(fullPath: '/search/:query')),
+        '/search/:query',
       );
     });
+
+    test('normalizes unnamed shell tab path templates to screen names', () {
+      expect(
+        goRouterPageName(_FakeGoRouterState(path: '/notifications/:index')),
+        'notifications',
+      );
+      expect(
+        goRouterPageName(_FakeGoRouterState(path: '/explore/tab/:name')),
+        'explore',
+      );
+      expect(
+        goRouterPageName(_FakeGoRouterState(path: '/profile/:npub/:index')),
+        'profile',
+      );
+      expect(
+        goRouterPageName(_FakeGoRouterState(path: '/liked-videos/:index')),
+        'liked-videos',
+      );
+    });
+
+    test(
+      'uses concrete shell URI path when go_router leaves name and path null',
+      () {
+        expect(
+          goRouterPageName(_FakeGoRouterState(uri: Uri(path: '/inbox'))),
+          'inbox',
+        );
+      },
+    );
   });
 }


### PR DESCRIPTION
## Description
- derive stable analytics page names for shell tab routes when go_router leaves the explicit route name empty
- normalize shell path templates and concrete URI paths for home, explore, notifications, inbox, profile, and liked videos
- add regression tests for unnamed shell route states

**Related Issue:** Closes #7552

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor
- [ ] Performance improvement
- [x] Test update

## Testing
- [x] flutter test test/router/go_router_page_name_test.dart test/router/shell_route_analytics_test.dart
- [x] flutter analyze
- [x] pre-push hook (analyzer + changed-file tests)

## Screenshots
Not applicable.