### PR TITLE
fix(discover): bound public list relay reads

### DIFF
--- a/mobile/lib/screens/discover_lists_screen.dart
+++ b/mobile/lib/screens/discover_lists_screen.dart
@@ -39,7 +39,6 @@ class _DiscoverListsScreenState extends ConsumerState<DiscoverListsScreen>
   String? _errorMessage;
   StreamSubscription<List<CuratedList>>? _subscription;
   final _scrollController = ScrollController();
-  Timer? _streamTimeoutTimer;
 
   // Debounce timer for batching rapid stream updates
   Timer? _updateDebounceTimer;
@@ -52,7 +51,6 @@ class _DiscoverListsScreenState extends ConsumerState<DiscoverListsScreen>
   int _autoPaginationAttempts = 0;
   static const int _maxAutoPaginationAttempts = 5;
   static const int _minListsBeforeAutoPaginate = 10;
-  static const Duration _streamTimeout = Duration(seconds: 8);
 
   @override
   ScrollController get paginationScrollController => _scrollController;
@@ -80,7 +78,6 @@ class _DiscoverListsScreenState extends ConsumerState<DiscoverListsScreen>
 
   @override
   void dispose() {
-    _streamTimeoutTimer?.cancel();
     _updateDebounceTimer?.cancel();
     _subscription?.cancel();
     disposePagination();
@@ -124,28 +121,10 @@ class _DiscoverListsScreenState extends ConsumerState<DiscoverListsScreen>
 
       // Stream results - UI updates with debouncing to handle rapid events
       await _subscription?.cancel();
-      _streamTimeoutTimer?.cancel();
       var hasReceivedStreamUpdate = false;
-      // Only guard the empty screen. The error view replaces the list
-      // entirely, so arming this during a refresh would wipe lists the user
-      // is already reading whenever a relay answers slowly.
-      _streamTimeoutTimer = Timer(_streamTimeout, () {
-        if (!mounted || hasReceivedStreamUpdate) return;
-
-        unawaited(_subscription?.cancel());
-        _subscription = null;
-        provider.setLoading(false);
-        setState(() {
-          _isRefreshing = false;
-          if (!hadExistingLists) {
-            _errorMessage = context.l10n.discoverListsRelayTimeout;
-          }
-        });
-      });
       _subscription = service.streamPublicListsFromRelays().listen(
         (lists) {
           hasReceivedStreamUpdate = true;
-          _streamTimeoutTimer?.cancel();
           if (mounted) {
             // Track oldest timestamp for pagination
             for (final list in lists) {
@@ -219,19 +198,19 @@ class _DiscoverListsScreenState extends ConsumerState<DiscoverListsScreen>
           }
         },
         onError: (error) {
-          _streamTimeoutTimer?.cancel();
           if (mounted) {
             provider.setLoading(false);
             setState(() {
               _isRefreshing = false;
-              _errorMessage = context.l10n.discoverListsFailedToLoadWithError(
-                '$error',
-              );
+              if (!hadExistingLists || error is! TimeoutException) {
+                _errorMessage = error is TimeoutException
+                    ? context.l10n.discoverListsRelayTimeout
+                    : context.l10n.discoverListsFailedToLoadWithError('$error');
+              }
             });
           }
         },
         onDone: () {
-          _streamTimeoutTimer?.cancel();
           if (mounted && !hasReceivedStreamUpdate) {
             provider.setLoading(false);
             setState(() {
@@ -241,7 +220,6 @@ class _DiscoverListsScreenState extends ConsumerState<DiscoverListsScreen>
         },
       );
     } catch (e) {
-      _streamTimeoutTimer?.cancel();
       if (mounted) {
         ref.read(discoveredListsProvider.notifier).setLoading(false);
         setState(() {
@@ -268,9 +246,8 @@ class _DiscoverListsScreenState extends ConsumerState<DiscoverListsScreen>
       _isLoadingMore = true;
     });
 
-    StreamSubscription<List<CuratedList>>? subscription;
-    Timer? timeoutTimer;
     var foundNewLists = false;
+    var timedOut = false;
 
     try {
       final service = ref.read(curatedListsStateProvider.notifier).service;
@@ -287,66 +264,45 @@ class _DiscoverListsScreenState extends ConsumerState<DiscoverListsScreen>
         category: LogCategory.ui,
       );
 
-      final completer = Completer<void>();
-
-      // Stop after 3 seconds
-      timeoutTimer = Timer(const Duration(seconds: 3), () {
-        Log.info(
-          '📋 Pagination timeout - found ${existingIds.length - initialCount} new lists',
-          category: LogCategory.ui,
-        );
-        subscription?.cancel();
-        subscription = null; // Prevent double-cancel in finally
-        if (!completer.isCompleted) completer.complete();
-      });
-
       final stream = service.streamPublicListsFromRelays(
         until: providerState.oldestTimestamp,
         excludeIds: existingIds,
       );
 
-      subscription = stream.listen(
-        (lists) {
-          if (!mounted) return;
+      await for (final lists in stream) {
+        if (!mounted) continue;
 
-          // Add new lists that we don't already have
-          final newLists = lists
-              .where((l) => !existingIds.contains(l.id))
-              .toList();
+        // Add new lists that we don't already have
+        final newLists = lists
+            .where((l) => !existingIds.contains(l.id))
+            .toList();
 
-          if (newLists.isNotEmpty) {
-            foundNewLists = true;
-            for (final list in newLists) {
-              existingIds.add(list.id);
-              // Update oldest timestamp in provider
-              provider.updateOldestTimestamp(list.createdAt);
-            }
-
-            // Add to provider (handles deduplication and sorting)
-            provider.addLists(newLists);
+        if (newLists.isNotEmpty) {
+          foundNewLists = true;
+          for (final list in newLists) {
+            existingIds.add(list.id);
+            // Update oldest timestamp in provider
+            provider.updateOldestTimestamp(list.createdAt);
           }
-        },
-        onError: (error) {
-          Log.error('Pagination error: $error', category: LogCategory.ui);
-          if (!completer.isCompleted) completer.complete();
-        },
-        onDone: () {
-          if (!completer.isCompleted) completer.complete();
-        },
-      );
 
-      await completer.future;
+          // Add to provider (handles deduplication and sorting)
+          provider.addLists(newLists);
+        }
+      }
 
       final finalState = ref.read(discoveredListsProvider);
       Log.info(
         'Pagination done: ${finalState.lists.length} total lists',
         category: LogCategory.ui,
       );
+    } on TimeoutException catch (error) {
+      timedOut = true;
+      Log.warning('Pagination timeout: $error', category: LogCategory.ui);
+    } catch (error) {
+      Log.error('Pagination error: $error', category: LogCategory.ui);
     } finally {
-      timeoutTimer?.cancel();
-      await subscription?.cancel();
       if (mounted) {
-        if (!foundNewLists) {
+        if (!foundNewLists && !timedOut) {
           _hasReachedEnd = true;
         }
 
@@ -357,6 +313,7 @@ class _DiscoverListsScreenState extends ConsumerState<DiscoverListsScreen>
         // Continue auto-paginating if we still have few results
         final finalState = ref.read(discoveredListsProvider);
         if (!_hasReachedEnd &&
+            !timedOut &&
             finalState.lists.length < _minListsBeforeAutoPaginate &&
             finalState.oldestTimestamp != null &&
             _autoPaginationAttempts < _maxAutoPaginationAttempts) {

--- a/mobile/lib/screens/discover_lists_screen.dart
+++ b/mobile/lib/screens/discover_lists_screen.dart
@@ -51,6 +51,7 @@ class _DiscoverListsScreenState extends ConsumerState<DiscoverListsScreen>
   int _autoPaginationAttempts = 0;
   static const int _maxAutoPaginationAttempts = 5;
   static const int _minListsBeforeAutoPaginate = 10;
+  static const Duration _paginationRelayReadTimeout = Duration(seconds: 3);
 
   @override
   ScrollController get paginationScrollController => _scrollController;
@@ -202,7 +203,11 @@ class _DiscoverListsScreenState extends ConsumerState<DiscoverListsScreen>
             provider.setLoading(false);
             setState(() {
               _isRefreshing = false;
-              if (!hadExistingLists || error is! TimeoutException) {
+              final hasRenderedLists = ref
+                  .read(discoveredListsProvider)
+                  .lists
+                  .isNotEmpty;
+              if (!hasRenderedLists || error is! TimeoutException) {
                 _errorMessage = error is TimeoutException
                     ? context.l10n.discoverListsRelayTimeout
                     : context.l10n.discoverListsFailedToLoadWithError('$error');
@@ -267,6 +272,7 @@ class _DiscoverListsScreenState extends ConsumerState<DiscoverListsScreen>
       final stream = service.streamPublicListsFromRelays(
         until: providerState.oldestTimestamp,
         excludeIds: existingIds,
+        timeout: _paginationRelayReadTimeout,
       );
 
       await for (final lists in stream) {

--- a/mobile/lib/screens/discover_lists_screen.dart
+++ b/mobile/lib/screens/discover_lists_screen.dart
@@ -270,7 +270,7 @@ class _DiscoverListsScreenState extends ConsumerState<DiscoverListsScreen>
       );
 
       await for (final lists in stream) {
-        if (!mounted) continue;
+        if (!mounted) break;
 
         // Add new lists that we don't already have
         final newLists = lists

--- a/mobile/lib/services/curated_list_relay_gateway.dart
+++ b/mobile/lib/services/curated_list_relay_gateway.dart
@@ -376,31 +376,6 @@ class CuratedListRelayGateway {
         0;
   }
 
-  /// Fetch public curated lists from Nostr relays for discovery.
-  ///
-  /// Prefer [streamPublicListsFromRelays] when the caller can render
-  /// progressive updates.
-  Future<List<CuratedList>> fetchPublicListsFromRelays({
-    List<String>? searchTags,
-    Duration timeout = kPublicCuratedListsRelayReadTimeout,
-  }) async {
-    final lists = <CuratedList>[];
-    await for (final update in streamPublicListsFromRelays(timeout: timeout)) {
-      lists
-        ..clear()
-        ..addAll(update);
-    }
-
-    // Apply tag filter if specified
-    if (searchTags != null && searchTags.isNotEmpty) {
-      return lists.where((list) {
-        return list.tags.any((tag) => searchTags.contains(tag.toLowerCase()));
-      }).toList();
-    }
-
-    return lists;
-  }
-
   /// Fetch public lists from any user that contain a specific video
   /// Uses Nostr #e filter to find kind 30005 events referencing the video
   /// Returns list of CuratedList objects (progressive loading via stream version)

--- a/mobile/lib/services/curated_list_relay_gateway.dart
+++ b/mobile/lib/services/curated_list_relay_gateway.dart
@@ -21,6 +21,10 @@ import 'package:unified_logger/unified_logger.dart';
 
 enum UnsealItemTagsStatus { notSealed, unsealed, failed }
 
+// Keeps the read alive past nostr_sdk's 8s subscription silence probe and 10s
+// teardown repair floor so a repaired relay can still answer this request.
+const Duration kPublicCuratedListsRelayReadTimeout = Duration(seconds: 12);
+
 final class UnsealedItemTags {
   const UnsealedItemTags._(this.status, [this.tags]);
 
@@ -123,8 +127,11 @@ class CuratedListRelayGateway {
     return utf8.encode(_privateItemPlaintext(list)).length <= 65535;
   }
 
-  /// Stream public curated lists from Nostr relays for discovery
-  /// Yields lists immediately as they arrive - no waiting for EOSE
+  /// Stream public curated lists from Nostr relays for discovery.
+  ///
+  /// Yields lists immediately as they arrive, completes on EOSE, and times out
+  /// after [timeout] so a silent subscription can trigger relay repair before
+  /// the caller gives up.
   /// Handles deduplication by 'd' tag (keeps newest version)
   /// Use [until] to paginate backwards (set to oldest createdAt from previous batch)
   /// Use [limit] to control how many events to request (default: 500)
@@ -133,7 +140,8 @@ class CuratedListRelayGateway {
     DateTime? until,
     int limit = 500,
     Set<String>? excludeIds,
-  }) async* {
+    Duration timeout = kPublicCuratedListsRelayReadTimeout,
+  }) {
     Log.info(
       '📋 Streaming public curated lists from relays (limit: $limit)${until != null ? ' (until: $until)' : ''}'
       '${excludeIds != null ? ' (excluding ${excludeIds.length} known)' : ''}...',
@@ -162,9 +170,37 @@ class CuratedListRelayGateway {
       category: LogCategory.system,
     );
 
-    final subscription = _nostrService.subscribe([filter]);
+    late final StreamController<List<CuratedList>> controller;
+    // The subscription is cancelled by finish(), which is wired to timeout,
+    // EOSE, source close/error, and caller cancellation.
+    // ignore: cancel_subscriptions
+    StreamSubscription<Event>? relaySubscription;
+    Timer? timeoutTimer;
+    var finished = false;
 
-    await for (final event in subscription) {
+    Future<void> finish({Object? error}) async {
+      if (finished) return;
+      finished = true;
+      timeoutTimer?.cancel();
+      timeoutTimer = null;
+
+      if (error != null && !controller.isClosed) {
+        controller.addError(error);
+      }
+
+      final subscription = relaySubscription;
+      relaySubscription = null;
+      await subscription?.cancel();
+
+      if (controller.isClosed) return;
+      await controller.close();
+    }
+
+    void finishFromCallback({Object? error}) {
+      unawaited(finish(error: error));
+    }
+
+    void handleEvent(Event event) {
       totalEventsReceived++;
       // Log progress every 100 events (reduced spam)
       if (totalEventsReceived % 100 == 0) {
@@ -188,7 +224,7 @@ class CuratedListRelayGateway {
 
         // Skip lists we already know about (for pagination)
         if (skipIds.contains(dTag)) {
-          continue;
+          return;
         }
 
         final existing = listsByDTag[dTag];
@@ -204,18 +240,95 @@ class CuratedListRelayGateway {
               (a, b) =>
                   b.videoEventIds.length.compareTo(a.videoEventIds.length),
             );
-          yield sortedLists;
+          controller.add(sortedLists);
         }
       }
     }
 
-    // Log final stats when stream completes
-    Log.info(
-      '📋 Stream complete: received $totalEventsReceived events, '
-      '$listsWithVideos had videos, ${listsByDTag.length} unique lists',
-      name: 'CuratedListRelayGateway',
-      category: LogCategory.system,
+    controller = StreamController<List<CuratedList>>(
+      onListen: () {
+        timeoutTimer = Timer(timeout, () {
+          final message =
+              'Public curated lists relay read timed out after '
+              '${timeout.inSeconds}s';
+          Log.warning(
+            '📋 $message: received $totalEventsReceived events, '
+            '$listsWithVideos had videos, ${listsByDTag.length} unique lists',
+            name: 'CuratedListRelayGateway',
+            category: LogCategory.system,
+          );
+          finishFromCallback(error: TimeoutException(message, timeout));
+        });
+
+        try {
+          final subscription = _nostrService.subscribe(
+            [filter],
+            onEose: () {
+              Log.info(
+                '📋 EOSE received for public curated lists: '
+                '$totalEventsReceived events, $listsWithVideos had videos, '
+                '${listsByDTag.length} unique lists',
+                name: 'CuratedListRelayGateway',
+                category: LogCategory.system,
+              );
+              finishFromCallback();
+            },
+          );
+
+          relaySubscription = subscription.listen(
+            handleEvent,
+            onError: (Object error, StackTrace stackTrace) {
+              Log.error(
+                '📋 Public curated lists relay stream failed: $error',
+                name: 'CuratedListRelayGateway',
+                category: LogCategory.system,
+              );
+              if (!controller.isClosed) {
+                controller.addError(error, stackTrace);
+              }
+              finishFromCallback();
+            },
+            onDone: () {
+              Log.info(
+                '📋 Public curated lists relay stream closed: '
+                '$totalEventsReceived events, $listsWithVideos had videos, '
+                '${listsByDTag.length} unique lists',
+                name: 'CuratedListRelayGateway',
+                category: LogCategory.system,
+              );
+              finishFromCallback();
+            },
+          );
+        } catch (error, stackTrace) {
+          finished = true;
+          timeoutTimer?.cancel();
+          timeoutTimer = null;
+          Log.error(
+            '📋 Public curated lists relay subscription setup failed: $error',
+            name: 'CuratedListRelayGateway',
+            category: LogCategory.system,
+          );
+          if (!controller.isClosed) {
+            controller.addError(error, stackTrace);
+          }
+          unawaited(controller.close());
+        }
+      },
+      onCancel: () {
+        if (!finished) {
+          Log.info(
+            '📋 Public curated lists relay read cancelled: '
+            '$totalEventsReceived events, $listsWithVideos had videos, '
+            '${listsByDTag.length} unique lists',
+            name: 'CuratedListRelayGateway',
+            category: LogCategory.system,
+          );
+        }
+        return finish();
+      },
     );
+
+    return controller.stream;
   }
 
   /// Fetches a single public curated list (kind 30005) by author + d-tag.
@@ -263,14 +376,16 @@ class CuratedListRelayGateway {
         0;
   }
 
-  /// Fetch public curated lists from Nostr relays for discovery (legacy)
-  /// Prefer streamPublicListsFromRelays for immediate results
-  /// WARNING: This waits forever since Nostr streams don't close - use stream version
+  /// Fetch public curated lists from Nostr relays for discovery.
+  ///
+  /// Prefer [streamPublicListsFromRelays] when the caller can render
+  /// progressive updates.
   Future<List<CuratedList>> fetchPublicListsFromRelays({
     List<String>? searchTags,
+    Duration timeout = kPublicCuratedListsRelayReadTimeout,
   }) async {
     final lists = <CuratedList>[];
-    await for (final update in streamPublicListsFromRelays()) {
+    await for (final update in streamPublicListsFromRelays(timeout: timeout)) {
       lists
         ..clear()
         ..addAll(update);

--- a/mobile/lib/services/curated_list_service.dart
+++ b/mobile/lib/services/curated_list_service.dart
@@ -1737,10 +1737,12 @@ class CuratedListService extends ChangeNotifier {
     DateTime? until,
     int limit = 500,
     Set<String>? excludeIds,
+    Duration timeout = kPublicCuratedListsRelayReadTimeout,
   }) => _relayGateway.streamPublicListsFromRelays(
     until: until,
     limit: limit,
     excludeIds: excludeIds,
+    timeout: timeout,
   );
 
   /// See [CuratedListRelayGateway.fetchPublicList].
@@ -1753,7 +1755,11 @@ class CuratedListService extends ChangeNotifier {
   /// See [CuratedListRelayGateway.fetchPublicListsFromRelays].
   Future<List<CuratedList>> fetchPublicListsFromRelays({
     List<String>? searchTags,
-  }) => _relayGateway.fetchPublicListsFromRelays(searchTags: searchTags);
+    Duration timeout = kPublicCuratedListsRelayReadTimeout,
+  }) => _relayGateway.fetchPublicListsFromRelays(
+    searchTags: searchTags,
+    timeout: timeout,
+  );
 
   /// See [CuratedListRelayGateway.fetchPublicListsContainingVideo].
   Future<List<CuratedList>> fetchPublicListsContainingVideo(

--- a/mobile/lib/services/curated_list_service.dart
+++ b/mobile/lib/services/curated_list_service.dart
@@ -1752,15 +1752,6 @@ class CuratedListService extends ChangeNotifier {
   }) =>
       _relayGateway.fetchPublicList(authorPubkey: authorPubkey, listId: listId);
 
-  /// See [CuratedListRelayGateway.fetchPublicListsFromRelays].
-  Future<List<CuratedList>> fetchPublicListsFromRelays({
-    List<String>? searchTags,
-    Duration timeout = kPublicCuratedListsRelayReadTimeout,
-  }) => _relayGateway.fetchPublicListsFromRelays(
-    searchTags: searchTags,
-    timeout: timeout,
-  );
-
   /// See [CuratedListRelayGateway.fetchPublicListsContainingVideo].
   Future<List<CuratedList>> fetchPublicListsContainingVideo(
     String videoEventId,

--- a/mobile/test/screens/discover_lists_screen_test.dart
+++ b/mobile/test/screens/discover_lists_screen_test.dart
@@ -52,6 +52,10 @@ CuratedList _makeList(String id, {DateTime? createdAt}) {
 }
 
 void main() {
+  setUpAll(() {
+    registerFallbackValue(Duration.zero);
+  });
+
   group(DiscoverListsScreen, () {
     late _MockCuratedListService mockService;
     late List<CuratedList> preloadedLists;
@@ -122,9 +126,14 @@ void main() {
           () => mockService.streamPublicListsFromRelays(
             until: any(named: 'until'),
             excludeIds: any(named: 'excludeIds'),
+            timeout: any(named: 'timeout'),
           ),
-        ).thenAnswer((_) {
+        ).thenAnswer((invocation) {
           streamCalls++;
+          expect(
+            invocation.namedArguments[#timeout],
+            const Duration(seconds: 3),
+          );
           return const Stream<List<CuratedList>>.empty();
         });
 
@@ -152,7 +161,7 @@ void main() {
         expect(
           find.byType(CircularProgressIndicator),
           findsNothing,
-          reason: '_loadMoreLists should have completed via timeout',
+          reason: '_loadMoreLists should have completed on empty stream',
         );
 
         // --- Second scroll: should NOT trigger pagination again ---
@@ -202,6 +211,42 @@ void main() {
       expect(find.text(l10n.discoverListsRelayTimeout), findsOneWidget);
       expect(find.text(l10n.commonRetry), findsOneWidget);
     });
+
+    testWidgets('initial partial results stay visible after relay timeout', (
+      tester,
+    ) async {
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      final controller = StreamController<List<CuratedList>>();
+      addTearDown(controller.close);
+
+      when(
+        () => mockService.streamPublicListsFromRelays(),
+      ).thenAnswer((_) => controller.stream);
+
+      await tester.pumpWidget(buildSubject(initialLists: []));
+      await tester.pump();
+      await tester.pump();
+
+      final partialLists = List.generate(
+        10,
+        (index) => _makeList('partial_$index'),
+      );
+      controller.add(partialLists);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(find.text('List partial_0'), findsOneWidget);
+
+      controller.addError(
+        TimeoutException('Public curated lists relay read timed out'),
+      );
+      await tester.pump();
+
+      expect(find.text('List partial_0'), findsOneWidget);
+      expect(find.text(l10n.discoverListsFailedToLoad), findsNothing);
+      expect(find.text(l10n.discoverListsRelayTimeout), findsNothing);
+    });
+
     testWidgets('refresh that never emits keeps the lists already on screen', (
       tester,
     ) async {
@@ -235,6 +280,75 @@ void main() {
       expect(find.text('List list_0'), findsOneWidget);
       expect(find.text(l10n.discoverListsFailedToLoad), findsNothing);
       expect(find.text(l10n.discoverListsRelayTimeout), findsNothing);
+    });
+
+    testWidgets('dispose cancels the active initial relay stream', (
+      tester,
+    ) async {
+      var streamCanceled = false;
+      final controller = StreamController<List<CuratedList>>(
+        onCancel: () {
+          streamCanceled = true;
+        },
+      );
+      addTearDown(controller.close);
+
+      when(
+        () => mockService.streamPublicListsFromRelays(),
+      ).thenAnswer((_) => controller.stream);
+
+      await tester.pumpWidget(buildSubject(initialLists: []));
+      await tester.pump();
+      await tester.pump();
+
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump();
+
+      expect(streamCanceled, isTrue);
+    });
+
+    testWidgets('pagination cancels the relay stream after unmount', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(390, 844);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      var paginationStreamCanceled = false;
+      final controller = StreamController<List<CuratedList>>(
+        onCancel: () {
+          paginationStreamCanceled = true;
+        },
+      );
+      addTearDown(controller.close);
+
+      when(
+        () => mockService.streamPublicListsFromRelays(
+          until: any(named: 'until'),
+          excludeIds: any(named: 'excludeIds'),
+          timeout: any(named: 'timeout'),
+        ),
+      ).thenAnswer((_) => controller.stream);
+
+      await tester.pumpWidget(buildSubject());
+      await tester.pump();
+      await tester.pump();
+
+      await tester.scrollUntilVisible(
+        find.text('List list_49'),
+        500,
+        scrollable: find.byType(Scrollable),
+      );
+      await tester.pump();
+
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump();
+
+      controller.add([_makeList('after_unmount')]);
+      await tester.pump();
+
+      expect(paginationStreamCanceled, isTrue);
     });
 
     testWidgets('initial EOSE with zero lists renders empty state', (

--- a/mobile/test/screens/discover_lists_screen_test.dart
+++ b/mobile/test/screens/discover_lists_screen_test.dart
@@ -116,16 +116,7 @@ void main() {
         addTearDown(tester.view.resetPhysicalSize);
         addTearDown(tester.view.resetDevicePixelRatio);
 
-        // Each call gets a fresh StreamController. The stream stays open
-        // (no data, no close) so _loadMoreLists relies on its 3-second
-        // timeout timer to complete. The timeout fires within FakeAsync,
-        // resolving the Completer and running the finally block.
-        final controllers = <StreamController<List<CuratedList>>>[];
-        addTearDown(() async {
-          for (final controller in controllers) {
-            await controller.close();
-          }
-        });
+        var streamCalls = 0;
 
         when(
           () => mockService.streamPublicListsFromRelays(
@@ -133,9 +124,8 @@ void main() {
             excludeIds: any(named: 'excludeIds'),
           ),
         ).thenAnswer((_) {
-          final c = StreamController<List<CuratedList>>();
-          controllers.add(c);
-          return c.stream;
+          streamCalls++;
+          return const Stream<List<CuratedList>>.empty();
         });
 
         await tester.pumpWidget(buildSubject());
@@ -154,16 +144,8 @@ void main() {
         );
 
         // pump() processes microtasks: _loadMoreLists starts, calls mock,
-        // listens to stream, awaits completer. Stream stays open.
+        // listens to the bounded stream, and completes when it closes empty.
         await tester.pump();
-        expect(controllers, hasLength(1));
-
-        // Advance past the 3-second timeout. The timer fires within
-        // FakeAsync: cancels subscription, completes the Completer.
-        // elapse() also flushes microtasks after each timer, so the
-        // continuation runs: finally block → _isLoadingMore = false.
-        await tester.pump(const Duration(seconds: 4));
-        // Extra pump to process any remaining microtasks + rebuild
         await tester.pump();
 
         // _loadMoreLists should have completed: spinner gone
@@ -184,39 +166,35 @@ void main() {
           scrollable: find.byType(Scrollable),
         );
         await tester.pump();
-        await tester.pump(const Duration(seconds: 4));
         await tester.pump();
 
         // With _hasReachedEnd: _onScroll returns early → 1 controller
         // Without _hasReachedEnd: _loadMoreLists is called again → 2+
         expect(
-          controllers.length,
+          streamCalls,
           1,
           reason:
               '_loadMoreLists should not be called again after finding '
-              'no new lists (controllers created: ${controllers.length})',
+              'no new lists (streams created: $streamCalls)',
         );
       },
     );
 
-    testWidgets('initial load times out when relay stream never emits', (
+    testWidgets('initial load shows retry when service stream times out', (
       tester,
     ) async {
       final l10n = lookupAppLocalizations(const Locale('en'));
-      final controller = StreamController<List<CuratedList>>();
-      addTearDown(controller.close);
 
-      when(
-        () => mockService.streamPublicListsFromRelays(),
-      ).thenAnswer((_) => controller.stream);
+      when(() => mockService.streamPublicListsFromRelays()).thenAnswer(
+        (_) => Stream<List<CuratedList>>.error(
+          TimeoutException('Public curated lists relay read timed out'),
+        ),
+      );
 
       await tester.pumpWidget(buildSubject(initialLists: []));
       await tester.pump();
       await tester.pump();
 
-      expect(find.byType(CircularProgressIndicator), findsOneWidget);
-
-      await tester.pump(const Duration(seconds: 9));
       await tester.pump();
 
       expect(find.byType(CircularProgressIndicator), findsNothing);
@@ -233,17 +211,12 @@ void main() {
       addTearDown(tester.view.resetDevicePixelRatio);
 
       final l10n = lookupAppLocalizations(const Locale('en'));
-      var refreshStreamCanceled = false;
-      final controller = StreamController<List<CuratedList>>(
-        onCancel: () {
-          refreshStreamCanceled = true;
-        },
-      );
-      addTearDown(controller.close);
 
-      when(
-        () => mockService.streamPublicListsFromRelays(),
-      ).thenAnswer((_) => controller.stream);
+      when(() => mockService.streamPublicListsFromRelays()).thenAnswer(
+        (_) => Stream<List<CuratedList>>.error(
+          TimeoutException('Public curated lists relay read timed out'),
+        ),
+      );
 
       await tester.pumpWidget(buildSubject());
       await tester.pump();
@@ -255,7 +228,6 @@ void main() {
       await tester.fling(find.text('List list_0'), const Offset(0, 400), 1000);
       await tester.pump();
       await tester.pump(const Duration(seconds: 1));
-      await tester.pump(const Duration(seconds: 9));
       await tester.pump();
 
       // The initial-load timeout must not fire here: replacing a populated
@@ -263,7 +235,25 @@ void main() {
       expect(find.text('List list_0'), findsOneWidget);
       expect(find.text(l10n.discoverListsFailedToLoad), findsNothing);
       expect(find.text(l10n.discoverListsRelayTimeout), findsNothing);
-      expect(refreshStreamCanceled, isTrue);
+    });
+
+    testWidgets('initial EOSE with zero lists renders empty state', (
+      tester,
+    ) async {
+      final l10n = lookupAppLocalizations(const Locale('en'));
+
+      when(
+        () => mockService.streamPublicListsFromRelays(),
+      ).thenAnswer((_) => const Stream<List<CuratedList>>.empty());
+
+      await tester.pumpWidget(buildSubject(initialLists: []));
+      await tester.pump();
+      await tester.pump();
+
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+      expect(find.text(l10n.discoverListsEmptyTitle), findsOneWidget);
+      expect(find.text(l10n.discoverListsFailedToLoad), findsNothing);
+      expect(find.text(l10n.discoverListsRelayTimeout), findsNothing);
     });
   });
 }

--- a/mobile/test/services/curated_list_service_query_test.dart
+++ b/mobile/test/services/curated_list_service_query_test.dart
@@ -558,7 +558,7 @@ void main() {
 
         // Mock subscribe to return events as a stream
         when(
-          () => mockNostr.subscribe(any()),
+          () => mockNostr.subscribe(any(), onEose: any(named: 'onEose')),
         ).thenAnswer((_) => Stream.fromIterable([event1, event2]));
 
         // Act: Collect streamed results
@@ -617,7 +617,7 @@ void main() {
 
         // Send older first, then newer
         when(
-          () => mockNostr.subscribe(any()),
+          () => mockNostr.subscribe(any(), onEose: any(named: 'onEose')),
         ).thenAnswer((_) => Stream.fromIterable([olderEvent, newerEvent]));
 
         List<CuratedList>? finalLists;
@@ -671,7 +671,7 @@ void main() {
         });
 
         when(
-          () => mockNostr.subscribe(any()),
+          () => mockNostr.subscribe(any(), onEose: any(named: 'onEose')),
         ).thenAnswer((_) => Stream.fromIterable([emptyList, nonEmptyList]));
 
         List<CuratedList>? finalLists;
@@ -701,7 +701,7 @@ void main() {
         });
 
         when(
-          () => mockNostr.subscribe(any()),
+          () => mockNostr.subscribe(any(), onEose: any(named: 'onEose')),
         ).thenAnswer((_) => Stream.value(malformedList));
 
         final updates = await service.streamPublicListsFromRelays().toList();
@@ -729,7 +729,7 @@ void main() {
         });
 
         when(
-          () => mockNostr.subscribe(any()),
+          () => mockNostr.subscribe(any(), onEose: any(named: 'onEose')),
         ).thenAnswer((_) => Stream.fromIterable([oldEvent]));
 
         // Act: Request with until date
@@ -743,7 +743,9 @@ void main() {
         }
 
         // Verify subscribe was called (filter construction is internal)
-        verify(() => mockNostr.subscribe(any())).called(1);
+        verify(
+          () => mockNostr.subscribe(any(), onEose: any(named: 'onEose')),
+        ).called(1);
         expect(results?.isNotEmpty, true);
       });
     });

--- a/mobile/test/services/curated_list_service_stream_test.dart
+++ b/mobile/test/services/curated_list_service_stream_test.dart
@@ -3,6 +3,7 @@
 
 import 'dart:async';
 
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart' hide LogCategory;
@@ -414,6 +415,120 @@ void main() {
         expect(finalList[0].name, 'Large List'); // 5 videos
         expect(finalList[1].name, 'Medium List'); // 3 videos
         expect(finalList[2].name, 'Small List'); // 1 video
+      });
+
+      test('completes empty when relays EOSE without events', () async {
+        void Function()? onEose;
+        when(
+          () => mockNostr.subscribe(any(), onEose: any(named: 'onEose')),
+        ).thenAnswer((invocation) {
+          onEose = invocation.namedArguments[#onEose] as void Function()?;
+          return eventController.stream;
+        });
+
+        final updates = <List<CuratedList>>[];
+        var completed = false;
+        service.streamPublicListsFromRelays().listen(
+          updates.add,
+          onDone: () {
+            completed = true;
+          },
+        );
+
+        await pumpEventQueue();
+        onEose!();
+        await pumpEventQueue();
+
+        expect(updates, isEmpty);
+        expect(completed, isTrue);
+      });
+
+      test('completes with received events when relays EOSE', () async {
+        void Function()? onEose;
+        when(
+          () => mockNostr.subscribe(any(), onEose: any(named: 'onEose')),
+        ).thenAnswer((invocation) {
+          onEose = invocation.namedArguments[#onEose] as void Function()?;
+          return eventController.stream;
+        });
+
+        final updates = <List<CuratedList>>[];
+        var completed = false;
+        service.streamPublicListsFromRelays().listen(
+          updates.add,
+          onDone: () {
+            completed = true;
+          },
+        );
+
+        await pumpEventQueue();
+        eventController.add(
+          createListEvent(
+            dTag: 'list_with_videos',
+            name: 'List With Videos',
+            videoIds: ['video1'],
+          ),
+        );
+        await pumpEventQueue();
+        onEose!();
+        await pumpEventQueue();
+
+        expect(updates, hasLength(1));
+        expect(updates.single.single.name, 'List With Videos');
+        expect(completed, isTrue);
+      });
+
+      test('silent relay read times out and cancels subscription', () {
+        fakeAsync((async) {
+          var canceled = false;
+          eventController = StreamController<Event>(
+            onCancel: () {
+              canceled = true;
+            },
+          );
+          when(
+            () => mockNostr.subscribe(any(), onEose: any(named: 'onEose')),
+          ).thenAnswer((_) => eventController.stream);
+
+          Object? receivedError;
+          service
+              .streamPublicListsFromRelays(
+                timeout: const Duration(milliseconds: 100),
+              )
+              .listen(
+                (_) {},
+                onError: (Object error) {
+                  receivedError = error;
+                },
+              );
+
+          async.flushMicrotasks();
+          async.elapse(const Duration(milliseconds: 100));
+          async.flushMicrotasks();
+
+          expect(receivedError, isA<TimeoutException>());
+          expect(canceled, isTrue);
+        });
+      });
+
+      test('listener cancellation cleans up relay subscription', () async {
+        var canceled = false;
+        eventController = StreamController<Event>(
+          onCancel: () {
+            canceled = true;
+          },
+        );
+        when(
+          () => mockNostr.subscribe(any(), onEose: any(named: 'onEose')),
+        ).thenAnswer((_) => eventController.stream);
+
+        final subscription = service.streamPublicListsFromRelays().listen(
+          (_) {},
+        );
+        await pumpEventQueue();
+        await subscription.cancel();
+
+        expect(canceled, isTrue);
       });
     });
   });


### PR DESCRIPTION
## Summary
- move Discover Lists public kind-30005 reads to a gateway-owned bounded lifecycle
- complete normally on EOSE so empty relay answers render the empty state instead of retry
- use a 12s relay-read timeout so the SDK subscription silence repair window can run before the UI gives up
- simplify Discover Lists initial load and pagination by removing screen-owned relay timers

## Root cause
Discover Lists treated a live Nostr subscription as a bounded query from the widget layer. The screen cancelled the read at 8s, which matched the SDK subscription silence probe timing and also landed before the 10s teardown repair floor. That made a half-open relay stay half-open across retries, while a valid EOSE-with-zero-events response was indistinguishable from a silent socket.

## User impact
Silent relay reads now surface the existing retry state after the gateway timeout, while relays that answer EOSE with no lists show the existing empty state. The timeout is now long enough for subscription-level relay repair to cycle a silent connection and give the reissued request time to answer.

Closes #7558

## Verification
- cd mobile && flutter test test/services/curated_list_service_stream_test.dart test/services/curated_list_service_query_test.dart test/screens/discover_lists_screen_test.dart test/services/curated_list_relay_gateway_test.dart
- cd mobile && flutter analyze lib test integration_test
- pre-push hook: analyzer and changed-file tests passed