### PR TITLE
fix(subtitles): use playback fallback sources in editor

### DIFF
--- a/mobile/lib/extensions/video_event_extensions.dart
+++ b/mobile/lib/extensions/video_event_extensions.dart
@@ -3,6 +3,7 @@
 // ABOUTME: detection (dart:io) that don't belong in the pure data model.
 
 import 'package:flutter/foundation.dart';
+import 'package:infinite_video_feed/infinite_video_feed.dart';
 import 'package:models/models.dart';
 import 'package:openvine/services/bandwidth_tracker_service.dart';
 import 'package:openvine/services/m3u8_resolver_service.dart';
@@ -20,14 +21,6 @@ String _getBandwidthBasedQuality() {
     case VideoQuality.low:
       return 'low';
   }
-}
-
-List<String> _orderedUniqueUrls(Iterable<String?> urls) {
-  final seen = <String>{};
-  return [
-    for (final url in urls)
-      if (url != null && url.isNotEmpty && seen.add(url)) url,
-  ];
 }
 
 /// Extension methods for VideoEvent that require app-level dependencies.
@@ -264,29 +257,19 @@ extension VideoEventAppExtensions on VideoEvent {
     return url;
   }
 
-  /// Ordered network sources to attempt in short-form preview players.
+  /// Ordered network sources to attempt in a preview player, best rendition
+  /// first.
   ///
-  /// Mirrors the feed's default source selection: Divine blobs start from the
-  /// transcoded MP4 derivative and fall back to HLS, while the broken bare blob
-  /// URL is withheld unless the user explicitly forces raw playback.
-  List<String> get playbackSourceUrlsForPlatform {
-    final primary = getOptimalVideoUrlForPlatform();
-    final original = videoUrl;
-    final originalIsUnsafeRawBlob =
-        _isRawDivineBlobUrl(original) && primary != original;
-    return _orderedUniqueUrls([
-      primary,
-      getFallbackUrl(),
-      if (!originalIsUnsafeRawBlob) original,
-    ]);
-  }
-
-  bool _isRawDivineBlobUrl(String? url) {
-    if (url == null || url.isEmpty || !isFromDivineServer) return false;
-    final uri = Uri.tryParse(url);
-    if (uri == null) return false;
-    return _extractVideoHash(url) != null && uri.pathSegments.length == 1;
-  }
+  /// This is the feed's ladder, not a second one: [resolvePlaybackSources]
+  /// expands the platform pick into its canonical alternatives and withholds
+  /// the bare Divine blob, which answers a Range request with a cached
+  /// `NoSuchKey` body dressed up as a 206 (divine-blossom#198). Hand the result
+  /// to [setSourceWithFallbacks] — the HLS entry is a master playlist the
+  /// native player takes directly.
+  List<String> get previewPlaybackSources => resolvePlaybackSources(
+    this,
+    urlResolver: (video) => video.getOptimalVideoUrlForPlatform(),
+  );
 
   /// HLS URL selected by bandwidth tracker quality.
   String? _hlsForBandwidth() {

--- a/mobile/lib/extensions/video_event_extensions.dart
+++ b/mobile/lib/extensions/video_event_extensions.dart
@@ -10,19 +10,6 @@ import 'package:openvine/services/m3u8_resolver_service.dart';
 import 'package:openvine/services/video_format_preference.dart';
 import 'package:unified_logger/unified_logger.dart';
 
-/// Get quality string based on bandwidth tracker recommendation (3-tier)
-String _getBandwidthBasedQuality() {
-  final tracker = bandwidthTracker;
-  switch (tracker.recommendedQuality) {
-    case VideoQuality.high:
-      return 'high';
-    case VideoQuality.medium:
-      return 'medium';
-    case VideoQuality.low:
-      return 'low';
-  }
-}
-
 /// Extension methods for VideoEvent that require app-level dependencies.
 ///
 /// These methods are separated from the core VideoEvent model because they
@@ -289,48 +276,6 @@ extension VideoEventAppExtensions on VideoEvent {
     // HLS can't be single-file cached; progressive formats can
     if (isFromDivineServer && videoFormatPreference.isHlsFormat) return null;
     return getOptimalVideoUrlForPlatform() ?? videoUrl;
-  }
-
-  /// Get fallback URL when the primary playback URL fails.
-  ///
-  /// For Divine MP4 quality variants, falls back to HLS (bandwidth-selected).
-  /// HLS is the proven reliable format and avoids the same-URL retry loop.
-  /// Returns null for non-Divine videos or when no fallback is available.
-  String? getFallbackUrl() {
-    if (!isFromDivineServer) return null;
-    return _hlsForBandwidth();
-  }
-
-  /// Get HLS fallback URL for Android codec errors.
-  ///
-  /// Called when original video fails with a codec error on Android.
-  /// HLS transcoding provides H.264 Baseline Profile which is universally
-  /// supported, unlike High Profile which some devices can't decode.
-  ///
-  /// Uses 3-tier bandwidth quality: high (720p HLS), medium (720p HLS),
-  /// low (480p HLS).
-  ///
-  /// Returns null if:
-  /// - Not on Android
-  /// - Video is not from Divine servers (no HLS available)
-  String? getHlsFallbackUrl() {
-    if (kIsWeb || defaultTargetPlatform != TargetPlatform.android) return null;
-
-    final quality = _getBandwidthBasedQuality();
-    // Map 3-tier quality to HLS stream quality
-    // 'medium' maps to 'high' HLS since 720p is already the "medium" tier
-    final hlsQuality = quality == 'low' ? 'low' : 'high';
-    final hls = getHlsUrl(quality: hlsQuality);
-
-    if (hls != null) {
-      Log.debug(
-        '📱 Android: HLS fallback available ($quality -> $hlsQuality HLS): $hls',
-        name: 'VideoEventExtensions',
-        category: LogCategory.video,
-      );
-    }
-
-    return hls;
   }
 
   // ---------------------------------------------------------------------------

--- a/mobile/lib/extensions/video_event_extensions.dart
+++ b/mobile/lib/extensions/video_event_extensions.dart
@@ -22,6 +22,14 @@ String _getBandwidthBasedQuality() {
   }
 }
 
+List<String> _orderedUniqueUrls(Iterable<String?> urls) {
+  final seen = <String>{};
+  return [
+    for (final url in urls)
+      if (url != null && url.isNotEmpty && seen.add(url)) url,
+  ];
+}
+
 /// Extension methods for VideoEvent that require app-level dependencies.
 ///
 /// These methods are separated from the core VideoEvent model because they
@@ -254,6 +262,30 @@ extension VideoEventAppExtensions on VideoEvent {
       return getOptimalVideoUrlForPlatform() ?? url;
     }
     return url;
+  }
+
+  /// Ordered network sources to attempt in short-form preview players.
+  ///
+  /// Mirrors the feed's default source selection: Divine blobs start from the
+  /// transcoded MP4 derivative and fall back to HLS, while the broken bare blob
+  /// URL is withheld unless the user explicitly forces raw playback.
+  List<String> get playbackSourceUrlsForPlatform {
+    final primary = getOptimalVideoUrlForPlatform();
+    final original = videoUrl;
+    final originalIsUnsafeRawBlob =
+        _isRawDivineBlobUrl(original) && primary != original;
+    return _orderedUniqueUrls([
+      primary,
+      getFallbackUrl(),
+      if (!originalIsUnsafeRawBlob) original,
+    ]);
+  }
+
+  bool _isRawDivineBlobUrl(String? url) {
+    if (url == null || url.isEmpty || !isFromDivineServer) return false;
+    final uri = Uri.tryParse(url);
+    if (uri == null) return false;
+    return _extractVideoHash(url) != null && uri.pathSegments.length == 1;
   }
 
   /// HLS URL selected by bandwidth tracker quality.

--- a/mobile/lib/screens/subtitle_editor/subtitle_editor_screen.dart
+++ b/mobile/lib/screens/subtitle_editor/subtitle_editor_screen.dart
@@ -11,6 +11,7 @@ import 'package:go_router/go_router.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/subtitle_editor/subtitle_editor_cubit.dart';
 import 'package:openvine/extensions/safe_pop_extension.dart';
+import 'package:openvine/extensions/video_event_extensions.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/mixins/codec_heavy_surface_guard.dart';
 import 'package:openvine/models/subtitle_editor/timeline_frame.dart';
@@ -289,6 +290,7 @@ class _CueList extends StatelessWidget {
               child: _Stage(
                 state: state,
                 videoUrl: videoUrl,
+                playbackUrls: video.playbackSourceUrlsForPlatform,
                 videoId: video.id,
                 loadFrames: loadFrames,
               ),
@@ -502,12 +504,14 @@ class _Stage extends StatelessWidget {
   const _Stage({
     required this.state,
     required this.videoUrl,
+    required this.playbackUrls,
     required this.videoId,
     required this.loadFrames,
   });
 
   final SubtitleEditorState state;
   final String videoUrl;
+  final List<String> playbackUrls;
   final String videoId;
   final TimelineFrameLoader loadFrames;
 
@@ -519,6 +523,7 @@ class _Stage extends StatelessWidget {
         Expanded(
           child: SubtitleEditorStage(
             videoUrl: videoUrl,
+            playbackUrls: playbackUrls,
             videoId: videoId,
             cues: state.cues,
             totalDuration: Duration(milliseconds: state.timelineDurationMs),

--- a/mobile/lib/screens/subtitle_editor/subtitle_editor_screen.dart
+++ b/mobile/lib/screens/subtitle_editor/subtitle_editor_screen.dart
@@ -290,7 +290,7 @@ class _CueList extends StatelessWidget {
               child: _Stage(
                 state: state,
                 videoUrl: videoUrl,
-                playbackUrls: video.playbackSourceUrlsForPlatform,
+                playbackUrls: video.previewPlaybackSources,
                 videoId: video.id,
                 loadFrames: loadFrames,
               ),

--- a/mobile/lib/widgets/subtitle_editor/subtitle_editor_stage.dart
+++ b/mobile/lib/widgets/subtitle_editor/subtitle_editor_stage.dart
@@ -24,6 +24,7 @@ typedef SubtitlePreviewSourceLoader =
       required DivineVideoPlayerController controller,
       required List<String> sources,
       required void Function(String message) log,
+      required bool Function() isLoadCurrent,
     });
 
 /// Initializes the preview player controller before source loading.
@@ -41,12 +42,14 @@ Future<void> _loadSubtitlePreviewSources({
   required DivineVideoPlayerController controller,
   required List<String> sources,
   required void Function(String message) log,
+  required bool Function() isLoadCurrent,
 }) async {
   await setSourceWithFallbacks(
     index: 0,
     controller: controller,
     sources: sources,
     log: log,
+    isLoadCurrent: isLoadCurrent,
   );
 }
 
@@ -280,12 +283,17 @@ class _SubtitleEditorStageState extends State<SubtitleEditorStage>
       await loadPreviewSources(
         controller: controller,
         sources: urls,
+        isLoadCurrent: () => mounted,
         log: (message) => Log.debug(
           message,
           name: 'SubtitleEditorStage',
           category: LogCategory.video,
         ),
       );
+      if (!mounted) {
+        await controller.dispose();
+        return;
+      }
       await controller.setLooping(looping: true);
       if (!mounted) {
         await controller.dispose();

--- a/mobile/lib/widgets/subtitle_editor/subtitle_editor_stage.dart
+++ b/mobile/lib/widgets/subtitle_editor/subtitle_editor_stage.dart
@@ -9,8 +9,8 @@ import 'package:divine_video_player/divine_video_player.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
+import 'package:infinite_video_feed/infinite_video_feed.dart';
 import 'package:openvine/blocs/subtitle_editor/subtitle_editor_cubit.dart';
-import 'package:openvine/extensions/video_event_extensions.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/models/subtitle_editor/timeline_frame.dart';
 import 'package:openvine/widgets/caption_pill.dart';
@@ -38,10 +38,10 @@ class SubtitleEditorStage extends StatefulWidget {
   /// Playable URL of the published video.
   final String videoUrl;
 
-  /// Ordered playback candidates for the preview player.
+  /// Ordered playback candidates for the preview player, tried in order.
   ///
-  /// Falls back to [videoUrl] when empty so existing tests and non-feed callers
-  /// keep their previous behavior.
+  /// Falls back to [videoUrl] when empty so non-feed callers keep their
+  /// previous behavior.
   final List<String> playbackUrls;
 
   /// Full event id of the video, used as the media-cache key.
@@ -80,22 +80,6 @@ class SubtitleEditorStage extends StatefulWidget {
     if (isPlaying || seekTarget == null) return true;
     final delta = report - seekTarget;
     return (delta.isNegative ? -delta : delta) <= seekSettleTolerance;
-  }
-
-  /// Resolves candidate URLs before they are handed to the native player.
-  @visibleForTesting
-  static Future<List<String>> resolvePreviewPlaybackUrls({
-    required Iterable<String> playbackUrls,
-    required Future<String?> Function(String? url) resolvePlayableUrl,
-  }) async {
-    final seen = <String>{};
-    final resolved = <String>[];
-    for (final source in playbackUrls) {
-      final url = await resolvePlayableUrl(source);
-      if (url == null || url.isEmpty || !seen.add(url)) continue;
-      resolved.add(url);
-    }
-    return resolved;
   }
 
   @override
@@ -222,17 +206,17 @@ class _SubtitleEditorStageState extends State<SubtitleEditorStage>
   }
 
   Future<void> _openPlayer() async {
-    final urls = await SubtitleEditorStage.resolvePreviewPlaybackUrls(
-      playbackUrls: widget.playbackUrls.isEmpty
-          ? [widget.videoUrl]
-          : widget.playbackUrls,
-      // An m3u8 source has to be resolved to its MP4 before the native player
-      // can take it; for anything else this hands back the URL unchanged.
-      resolvePlayableUrl: VideoEventAppExtensions.resolvePlayableUrl,
+    // Handed to the player as-is: an HLS master playlist is a source it takes
+    // natively on both platforms, so resolving one to an MP4 first would only
+    // buy a round-trip and a downgrade to the lowest-bandwidth variant.
+    final urls = orderedUniqueSources(
+      widget.playbackUrls.isEmpty ? [widget.videoUrl] : widget.playbackUrls,
     );
-    if (!mounted) return;
     if (urls.isEmpty) {
-      setState(() => _failed = true);
+      // Reached synchronously from initState, before the first build, so the
+      // flag is picked up without a setState that would mark a building
+      // element dirty.
+      _failed = true;
       return;
     }
 
@@ -242,7 +226,16 @@ class _SubtitleEditorStageState extends State<SubtitleEditorStage>
     );
     try {
       await controller.initialize();
-      await _setFirstPlayableSource(controller, urls);
+      await setSourceWithFallbacks(
+        index: 0,
+        controller: controller,
+        sources: urls,
+        log: (message) => Log.debug(
+          message,
+          name: 'SubtitleEditorStage',
+          category: LogCategory.video,
+        ),
+      );
       await controller.setLooping(looping: true);
       if (!mounted) {
         await controller.dispose();
@@ -271,29 +264,6 @@ class _SubtitleEditorStageState extends State<SubtitleEditorStage>
         _failed = true;
       });
     }
-  }
-
-  Future<void> _setFirstPlayableSource(
-    DivineVideoPlayerController controller,
-    List<String> urls,
-  ) async {
-    Object? lastError;
-    StackTrace? lastStackTrace;
-    for (final url in urls) {
-      try {
-        await controller.setSource(VideoClip.network(url));
-        return;
-      } on Object catch (error, stackTrace) {
-        lastError = error;
-        lastStackTrace = stackTrace;
-        Log.warning(
-          'Could not open subtitle preview source $url: $error',
-          name: 'SubtitleEditorStage',
-          category: LogCategory.video,
-        );
-      }
-    }
-    Error.throwWithStackTrace(lastError!, lastStackTrace!);
   }
 
   void _onPlayerState(DivineVideoPlayerState state) {

--- a/mobile/lib/widgets/subtitle_editor/subtitle_editor_stage.dart
+++ b/mobile/lib/widgets/subtitle_editor/subtitle_editor_stage.dart
@@ -305,6 +305,15 @@ class _SubtitleEditorStageState extends State<SubtitleEditorStage>
       // has somewhere to land. A player that never plays never decodes one,
       // and the preview would sit on its placeholder forever.
       await controller.play();
+    } on SourceLoadAborted catch (error) {
+      Log.debug(
+        'Subtitle editor preview source load cancelled: $error',
+        name: 'SubtitleEditorStage',
+        category: LogCategory.video,
+      );
+      unawaited(_playerStates?.cancel());
+      _playerStates = null;
+      unawaited(controller.dispose());
     } on Object catch (error) {
       // Without this the failure would be an unhandled async error and the
       // preview would show an unexplained black box.

--- a/mobile/lib/widgets/subtitle_editor/subtitle_editor_stage.dart
+++ b/mobile/lib/widgets/subtitle_editor/subtitle_editor_stage.dart
@@ -31,11 +31,18 @@ class SubtitleEditorStage extends StatefulWidget {
     required this.totalDuration,
     required this.selectedCue,
     required this.loadFrames,
+    this.playbackUrls = const [],
     super.key,
   });
 
   /// Playable URL of the published video.
   final String videoUrl;
+
+  /// Ordered playback candidates for the preview player.
+  ///
+  /// Falls back to [videoUrl] when empty so existing tests and non-feed callers
+  /// keep their previous behavior.
+  final List<String> playbackUrls;
 
   /// Full event id of the video, used as the media-cache key.
   final String videoId;
@@ -73,6 +80,22 @@ class SubtitleEditorStage extends StatefulWidget {
     if (isPlaying || seekTarget == null) return true;
     final delta = report - seekTarget;
     return (delta.isNegative ? -delta : delta) <= seekSettleTolerance;
+  }
+
+  /// Resolves candidate URLs before they are handed to the native player.
+  @visibleForTesting
+  static Future<List<String>> resolvePreviewPlaybackUrls({
+    required Iterable<String> playbackUrls,
+    required Future<String?> Function(String? url) resolvePlayableUrl,
+  }) async {
+    final seen = <String>{};
+    final resolved = <String>[];
+    for (final source in playbackUrls) {
+      final url = await resolvePlayableUrl(source);
+      if (url == null || url.isEmpty || !seen.add(url)) continue;
+      resolved.add(url);
+    }
+    return resolved;
   }
 
   @override
@@ -199,13 +222,16 @@ class _SubtitleEditorStageState extends State<SubtitleEditorStage>
   }
 
   Future<void> _openPlayer() async {
-    // An m3u8 source has to be resolved to its MP4 before the native player
-    // can take it; for anything else this hands back the URL unchanged.
-    final url = await VideoEventAppExtensions.resolvePlayableUrl(
-      widget.videoUrl,
+    final urls = await SubtitleEditorStage.resolvePreviewPlaybackUrls(
+      playbackUrls: widget.playbackUrls.isEmpty
+          ? [widget.videoUrl]
+          : widget.playbackUrls,
+      // An m3u8 source has to be resolved to its MP4 before the native player
+      // can take it; for anything else this hands back the URL unchanged.
+      resolvePlayableUrl: VideoEventAppExtensions.resolvePlayableUrl,
     );
     if (!mounted) return;
-    if (url == null || url.isEmpty) {
+    if (urls.isEmpty) {
       setState(() => _failed = true);
       return;
     }
@@ -216,7 +242,7 @@ class _SubtitleEditorStageState extends State<SubtitleEditorStage>
     );
     try {
       await controller.initialize();
-      await controller.setSource(VideoClip.network(url));
+      await _setFirstPlayableSource(controller, urls);
       await controller.setLooping(looping: true);
       if (!mounted) {
         await controller.dispose();
@@ -245,6 +271,29 @@ class _SubtitleEditorStageState extends State<SubtitleEditorStage>
         _failed = true;
       });
     }
+  }
+
+  Future<void> _setFirstPlayableSource(
+    DivineVideoPlayerController controller,
+    List<String> urls,
+  ) async {
+    Object? lastError;
+    StackTrace? lastStackTrace;
+    for (final url in urls) {
+      try {
+        await controller.setSource(VideoClip.network(url));
+        return;
+      } on Object catch (error, stackTrace) {
+        lastError = error;
+        lastStackTrace = stackTrace;
+        Log.warning(
+          'Could not open subtitle preview source $url: $error',
+          name: 'SubtitleEditorStage',
+          category: LogCategory.video,
+        );
+      }
+    }
+    Error.throwWithStackTrace(lastError!, lastStackTrace!);
   }
 
   void _onPlayerState(DivineVideoPlayerState state) {

--- a/mobile/lib/widgets/subtitle_editor/subtitle_editor_stage.dart
+++ b/mobile/lib/widgets/subtitle_editor/subtitle_editor_stage.dart
@@ -31,17 +31,21 @@ class SubtitleEditorStage extends StatefulWidget {
     required this.totalDuration,
     required this.selectedCue,
     required this.loadFrames,
-    this.playbackUrls = const [],
+    required this.playbackUrls,
     super.key,
   });
 
   /// Playable URL of the published video.
+  ///
+  /// Addresses the video itself — the filmstrip reads frames from it. The
+  /// preview player uses [playbackUrls] instead, which may resolve to a
+  /// different rendition of the same video.
   final String videoUrl;
 
   /// Ordered playback candidates for the preview player, tried in order.
   ///
-  /// Falls back to [videoUrl] when empty so non-feed callers keep their
-  /// previous behavior.
+  /// Build these with `VideoEvent.previewPlaybackSources` so the editor and
+  /// the feed pick renditions the same way.
   final List<String> playbackUrls;
 
   /// Full event id of the video, used as the media-cache key.
@@ -209,9 +213,7 @@ class _SubtitleEditorStageState extends State<SubtitleEditorStage>
     // Handed to the player as-is: an HLS master playlist is a source it takes
     // natively on both platforms, so resolving one to an MP4 first would only
     // buy a round-trip and a downgrade to the lowest-bandwidth variant.
-    final urls = orderedUniqueSources(
-      widget.playbackUrls.isEmpty ? [widget.videoUrl] : widget.playbackUrls,
-    );
+    final urls = orderedUniqueSources(widget.playbackUrls);
     if (urls.isEmpty) {
       // Reached synchronously from initState, before the first build, so the
       // flag is picked up without a setState that would mark a building

--- a/mobile/lib/widgets/subtitle_editor/subtitle_editor_stage.dart
+++ b/mobile/lib/widgets/subtitle_editor/subtitle_editor_stage.dart
@@ -17,6 +17,39 @@ import 'package:openvine/widgets/caption_pill.dart';
 import 'package:openvine/widgets/subtitle_editor/subtitle_cue_timeline.dart';
 import 'package:unified_logger/unified_logger.dart';
 
+/// Loads the preview player's candidate sources into [controller].
+@visibleForTesting
+typedef SubtitlePreviewSourceLoader =
+    Future<void> Function({
+      required DivineVideoPlayerController controller,
+      required List<String> sources,
+      required void Function(String message) log,
+    });
+
+/// Initializes the preview player controller before source loading.
+@visibleForTesting
+typedef SubtitlePreviewControllerInitializer =
+    Future<void> Function(DivineVideoPlayerController controller);
+
+Future<void> _initializeSubtitlePreviewController(
+  DivineVideoPlayerController controller,
+) async {
+  await controller.initialize();
+}
+
+Future<void> _loadSubtitlePreviewSources({
+  required DivineVideoPlayerController controller,
+  required List<String> sources,
+  required void Function(String message) log,
+}) async {
+  await setSourceWithFallbacks(
+    index: 0,
+    controller: controller,
+    sources: sources,
+    log: log,
+  );
+}
+
 /// The video being captioned, with its cues laid out on a timeline beneath it.
 ///
 /// Owns the player: the timeline scrubs it, playback moves the timeline, and
@@ -32,6 +65,8 @@ class SubtitleEditorStage extends StatefulWidget {
     required this.selectedCue,
     required this.loadFrames,
     required this.playbackUrls,
+    this.initializePreviewController,
+    this.loadPreviewSources,
     super.key,
   });
 
@@ -45,8 +80,17 @@ class SubtitleEditorStage extends StatefulWidget {
   /// Ordered playback candidates for the preview player, tried in order.
   ///
   /// Build these with `VideoEvent.previewPlaybackSources` so the editor and
-  /// the feed pick renditions the same way.
+  /// the feed pick renditions the same way. The preview uses the feed's source
+  /// loader too, so loop playback clamps to the shared audio/video track end.
   final List<String> playbackUrls;
+
+  /// Loads [playbackUrls] into the preview player.
+  @visibleForTesting
+  final SubtitlePreviewSourceLoader? loadPreviewSources;
+
+  /// Initializes the preview player controller.
+  @visibleForTesting
+  final SubtitlePreviewControllerInitializer? initializePreviewController;
 
   /// Full event id of the video, used as the media-cache key.
   final String videoId;
@@ -227,9 +271,13 @@ class _SubtitleEditorStageState extends State<SubtitleEditorStage>
       debugLabel: 'subtitle_editor',
     );
     try {
-      await controller.initialize();
-      await setSourceWithFallbacks(
-        index: 0,
+      final initializePreviewController =
+          widget.initializePreviewController ??
+          _initializeSubtitlePreviewController;
+      await initializePreviewController(controller);
+      final loadPreviewSources =
+          widget.loadPreviewSources ?? _loadSubtitlePreviewSources;
+      await loadPreviewSources(
         controller: controller,
         sources: urls,
         log: (message) => Log.debug(

--- a/mobile/lib/widgets/subtitle_editor/subtitle_editor_stage.dart
+++ b/mobile/lib/widgets/subtitle_editor/subtitle_editor_stage.dart
@@ -38,7 +38,9 @@ Future<void> _initializeSubtitlePreviewController(
   await controller.initialize();
 }
 
-Future<void> _loadSubtitlePreviewSources({
+/// The preview's own [SubtitlePreviewSourceLoader], used when none is injected.
+@visibleForTesting
+Future<void> loadSubtitlePreviewSources({
   required DivineVideoPlayerController controller,
   required List<String> sources,
   required void Function(String message) log,
@@ -50,6 +52,11 @@ Future<void> _loadSubtitlePreviewSources({
     sources: sources,
     log: log,
     isLoadCurrent: isLoadCurrent,
+    // The feed trims the loop seam; the editor cannot. Its timeline is drawn
+    // from the container duration, so a clamp to the shorter of the two tracks
+    // would put the last half-second of the axis out of the preview's reach —
+    // and a cue timed into it could never be watched against the picture.
+    trimToCommonTrackEnd: false,
   );
 }
 
@@ -83,8 +90,9 @@ class SubtitleEditorStage extends StatefulWidget {
   /// Ordered playback candidates for the preview player, tried in order.
   ///
   /// Build these with `VideoEvent.previewPlaybackSources` so the editor and
-  /// the feed pick renditions the same way. The preview uses the feed's source
-  /// loader too, so loop playback clamps to the shared audio/video track end.
+  /// the feed pick renditions the same way. The preview runs them through the
+  /// feed's source loader, minus its loop-seam trim: playback has to reach the
+  /// end of the timeline the cues are laid out on.
   final List<String> playbackUrls;
 
   /// Loads [playbackUrls] into the preview player.
@@ -279,7 +287,7 @@ class _SubtitleEditorStageState extends State<SubtitleEditorStage>
           _initializeSubtitlePreviewController;
       await initializePreviewController(controller);
       final loadPreviewSources =
-          widget.loadPreviewSources ?? _loadSubtitlePreviewSources;
+          widget.loadPreviewSources ?? loadSubtitlePreviewSources;
       await loadPreviewSources(
         controller: controller,
         sources: urls,

--- a/mobile/packages/infinite_video_feed/lib/infinite_video_feed.dart
+++ b/mobile/packages/infinite_video_feed/lib/infinite_video_feed.dart
@@ -3,8 +3,10 @@ library;
 
 export 'src/models/builders.dart';
 export 'src/models/video_error_type.dart';
-export 'src/utils/canonical_divine_url.dart';
-export 'src/utils/playback_sources.dart';
-export 'src/utils/source_loader.dart';
+export 'src/services/derivative_failure_cache.dart' show DerivativeFailureCache;
+export 'src/utils/canonical_divine_url.dart'
+    show canonicalDivineBlobHlsUrl, isDivineBlobRawUrl, orderedUniqueSources;
+export 'src/utils/playback_sources.dart' show resolvePlaybackSources;
+export 'src/utils/source_loader.dart' show setSourceWithFallbacks;
 export 'src/widgets/infinite_video_feed.dart';
 export 'src/widgets/video_item.dart';

--- a/mobile/packages/infinite_video_feed/lib/infinite_video_feed.dart
+++ b/mobile/packages/infinite_video_feed/lib/infinite_video_feed.dart
@@ -3,5 +3,8 @@ library;
 
 export 'src/models/builders.dart';
 export 'src/models/video_error_type.dart';
+export 'src/utils/canonical_divine_url.dart';
+export 'src/utils/playback_sources.dart';
+export 'src/utils/source_loader.dart';
 export 'src/widgets/infinite_video_feed.dart';
 export 'src/widgets/video_item.dart';

--- a/mobile/packages/infinite_video_feed/lib/infinite_video_feed.dart
+++ b/mobile/packages/infinite_video_feed/lib/infinite_video_feed.dart
@@ -4,8 +4,7 @@ library;
 export 'src/models/builders.dart';
 export 'src/models/video_error_type.dart';
 export 'src/services/derivative_failure_cache.dart' show DerivativeFailureCache;
-export 'src/utils/canonical_divine_url.dart'
-    show canonicalDivineBlobHlsUrl, isDivineBlobRawUrl, orderedUniqueSources;
+export 'src/utils/canonical_divine_url.dart' show orderedUniqueSources;
 export 'src/utils/playback_sources.dart' show resolvePlaybackSources;
 export 'src/utils/source_loader.dart' show setSourceWithFallbacks;
 export 'src/widgets/infinite_video_feed.dart';

--- a/mobile/packages/infinite_video_feed/lib/infinite_video_feed.dart
+++ b/mobile/packages/infinite_video_feed/lib/infinite_video_feed.dart
@@ -3,7 +3,6 @@ library;
 
 export 'src/models/builders.dart';
 export 'src/models/video_error_type.dart';
-export 'src/services/derivative_failure_cache.dart' show DerivativeFailureCache;
 export 'src/utils/canonical_divine_url.dart' show orderedUniqueSources;
 export 'src/utils/playback_sources.dart' show resolvePlaybackSources;
 export 'src/utils/source_loader.dart'

--- a/mobile/packages/infinite_video_feed/lib/infinite_video_feed.dart
+++ b/mobile/packages/infinite_video_feed/lib/infinite_video_feed.dart
@@ -6,6 +6,7 @@ export 'src/models/video_error_type.dart';
 export 'src/services/derivative_failure_cache.dart' show DerivativeFailureCache;
 export 'src/utils/canonical_divine_url.dart' show orderedUniqueSources;
 export 'src/utils/playback_sources.dart' show resolvePlaybackSources;
-export 'src/utils/source_loader.dart' show setSourceWithFallbacks;
+export 'src/utils/source_loader.dart'
+    show SourceLoadAborted, setSourceWithFallbacks;
 export 'src/widgets/infinite_video_feed.dart';
 export 'src/widgets/video_item.dart';

--- a/mobile/packages/infinite_video_feed/lib/src/utils/source_loader.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/utils/source_loader.dart
@@ -35,6 +35,12 @@ class SourceLoadAborted implements Exception {
 /// [maxPlaybackDuration] becomes the clip's end position, so the native
 /// player stops (and loops) there. Sources shorter than the cap are
 /// unaffected — both backends clamp the clip end to the real duration.
+///
+/// [trimToCommonTrackEnd] hides the loop seam left by a source whose audio and
+/// video tracks end a few milliseconds apart, and is what a looping feed wants.
+/// Turn it off wherever playback is measured against the container duration —
+/// an editor timeline, for instance — because the clamp can end playback up to
+/// 500 ms before the duration such an axis is drawn from.
 Future<(String, int)> setSourceWithFallbacks({
   required int index,
   required DivineVideoPlayerController controller,
@@ -43,6 +49,7 @@ Future<(String, int)> setSourceWithFallbacks({
   Map<String, String>? Function(String source)? httpHeadersForSource,
   bool Function()? isLoadCurrent,
   Duration? maxPlaybackDuration,
+  bool trimToCommonTrackEnd = true,
   Future<void> Function(Duration duration) delay = Future<void>.delayed,
   void Function(String source)? onFailoverSourceFailure,
   void Function(String source)? onSourceLoadFailure,
@@ -65,7 +72,7 @@ Future<(String, int)> setSourceWithFallbacks({
           source,
           end: maxPlaybackDuration,
           httpHeaders: httpHeadersForSource?.call(source) ?? const {},
-          trimToCommonTrackEnd: true,
+          trimToCommonTrackEnd: trimToCommonTrackEnd,
         ),
       );
       abortIfStale(source);
@@ -109,7 +116,7 @@ Future<(String, int)> setSourceWithFallbacks({
                 source,
                 end: maxPlaybackDuration,
                 httpHeaders: httpHeadersForSource?.call(source) ?? const {},
-                trimToCommonTrackEnd: true,
+                trimToCommonTrackEnd: trimToCommonTrackEnd,
               ),
             );
             abortIfStale(source);

--- a/mobile/packages/infinite_video_feed/lib/src/utils/source_loader.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/utils/source_loader.dart
@@ -9,9 +9,6 @@ const _mediaProcessingRetryDelays = <Duration>[
   Duration(seconds: 8),
 ];
 
-/// Waits before a same-source retry after media returns HTTP 202.
-typedef SourceLoadDelay = Future<void> Function(Duration duration);
-
 /// Signals that source loading was cancelled because the owning controller
 /// window moved on while fallbacks were still in flight.
 class SourceLoadAborted implements Exception {
@@ -46,7 +43,7 @@ Future<(String, int)> setSourceWithFallbacks({
   Map<String, String>? Function(String source)? httpHeadersForSource,
   bool Function()? isLoadCurrent,
   Duration? maxPlaybackDuration,
-  SourceLoadDelay delay = Future<void>.delayed,
+  Future<void> Function(Duration duration) delay = Future<void>.delayed,
   void Function(String source)? onFailoverSourceFailure,
   void Function(String source)? onSourceLoadFailure,
 }) async {

--- a/mobile/packages/infinite_video_feed/test/src/utils/source_loader_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/utils/source_loader_test.dart
@@ -91,6 +91,34 @@ void main() {
       );
     });
 
+    test('leaves every source untrimmed when the caller opts out', () async {
+      final clips = <VideoClip>[];
+      // One 202 first, so the assertion covers the retried clip as well as the
+      // first attempt — the flag has to reach both construction sites.
+      final controller = _RecordingControllerWithFailures(
+        clips.add,
+        failures: [Exception('CoreMediaErrorDomain error -12667 - HTTP 202')],
+      );
+      addTearDown(controller.dispose);
+
+      await setSourceWithFallbacks(
+        index: 0,
+        controller: controller,
+        sources: ['processingUrl'],
+        log: logs.add,
+        trimToCommonTrackEnd: false,
+        delay: (_) async {},
+      );
+
+      expect(
+        clips.map((clip) => clip.trimToCommonTrackEnd),
+        equals([false, false]),
+        reason:
+            'A caller measuring playback against the container duration loses '
+            'the tail of its axis if the clip is clamped to the shorter track.',
+      );
+    });
+
     test('passes headers for the selected source', () async {
       final controller = FakeController();
       addTearDown(controller.dispose);

--- a/mobile/test/extensions/video_event_divine_server_test.dart
+++ b/mobile/test/extensions/video_event_divine_server_test.dart
@@ -376,42 +376,55 @@ void main() {
     });
   });
 
-  group('playbackSourceUrlsForPlatform', () {
+  group('previewPlaybackSources', () {
     const hash =
         '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
 
-    test('uses derivative and HLS for extensionless Divine blobs', () {
+    test('withholds the bare blob for extensionless Divine URLs', () {
       final video = _createVideoWithUrl('https://media.divine.video/$hash');
 
+      // The regression in #7550: the preview used to be handed the bare blob,
+      // which answers a Range request with a cached NoSuchKey body dressed up
+      // as a 206 (divine-blossom#198).
       expect(
-        video.playbackSourceUrlsForPlatform,
+        video.previewPlaybackSources,
         equals([
           'https://media.divine.video/$hash/720p.mp4',
-          'https://media.divine.video/$hash/hls/stream_720p.m3u8',
+          'https://media.divine.video/$hash/hls/master.m3u8',
         ]),
       );
     });
 
-    test('keeps raw Divine blobs only when raw playback is forced', () async {
+    test('falls back to HLS after the raw blob when raw playback is '
+        'forced', () async {
       final video = _createVideoWithUrl('https://media.divine.video/$hash');
 
       await videoFormatPreference.setFormat(VideoPlaybackFormat.raw);
       addTearDown(() => videoFormatPreference.setFormat(null));
 
       expect(
-        video.playbackSourceUrlsForPlatform,
+        video.previewPlaybackSources,
         equals([
           'https://media.divine.video/$hash',
-          'https://media.divine.video/$hash/hls/stream_720p.m3u8',
+          'https://media.divine.video/$hash/hls/master.m3u8',
         ]),
       );
     });
 
-    test('deduplicates non-Divine sources', () {
+    test('offers the HLS rung as a master playlist, not a media playlist', () {
+      final video = _createVideoWithUrl('https://media.divine.video/$hash');
+
+      // A media playlist (stream_720p.m3u8) carries no #EXT-X-STREAM-INF, so
+      // anything that parses variants out of it resolves to nothing. The
+      // master is the rung the feed uses and the one the native player takes.
+      expect(video.previewPlaybackSources.last, endsWith('/hls/master.m3u8'));
+    });
+
+    test('leaves non-Divine videos with their single original source', () {
       final video = _createVideoWithUrl('https://example.com/video.mp4');
 
       expect(
-        video.playbackSourceUrlsForPlatform,
+        video.previewPlaybackSources,
         equals(['https://example.com/video.mp4']),
       );
     });

--- a/mobile/test/extensions/video_event_divine_server_test.dart
+++ b/mobile/test/extensions/video_event_divine_server_test.dart
@@ -345,37 +345,6 @@ void main() {
     });
   });
 
-  group('getFallbackUrl', () {
-    const hash =
-        '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
-
-    test('returns HLS URL for Divine-hosted videos', () {
-      final video = _createVideoWithUrl('https://media.divine.video/$hash');
-
-      final fallback = video.getFallbackUrl();
-      expect(fallback, isNotNull);
-      expect(fallback, contains('/hls/'));
-      expect(fallback, contains('.m3u8'));
-    });
-
-    test('returns null for non-Divine videos', () {
-      final video = _createVideoWithUrl(
-        'https://blossom.primal.net/test/video.mp4',
-      );
-
-      expect(video.getFallbackUrl(), isNull);
-    });
-
-    test('returns different URL than getOptimalVideoUrlForPlatform', () {
-      final video = _createVideoWithUrl('https://media.divine.video/$hash');
-
-      final primary = video.getOptimalVideoUrlForPlatform();
-      final fallback = video.getFallbackUrl();
-
-      expect(primary, isNot(equals(fallback)));
-    });
-  });
-
   group('previewPlaybackSources', () {
     const hash =
         '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';

--- a/mobile/test/extensions/video_event_divine_server_test.dart
+++ b/mobile/test/extensions/video_event_divine_server_test.dart
@@ -375,4 +375,45 @@ void main() {
       expect(primary, isNot(equals(fallback)));
     });
   });
+
+  group('playbackSourceUrlsForPlatform', () {
+    const hash =
+        '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+
+    test('uses derivative and HLS for extensionless Divine blobs', () {
+      final video = _createVideoWithUrl('https://media.divine.video/$hash');
+
+      expect(
+        video.playbackSourceUrlsForPlatform,
+        equals([
+          'https://media.divine.video/$hash/720p.mp4',
+          'https://media.divine.video/$hash/hls/stream_720p.m3u8',
+        ]),
+      );
+    });
+
+    test('keeps raw Divine blobs only when raw playback is forced', () async {
+      final video = _createVideoWithUrl('https://media.divine.video/$hash');
+
+      await videoFormatPreference.setFormat(VideoPlaybackFormat.raw);
+      addTearDown(() => videoFormatPreference.setFormat(null));
+
+      expect(
+        video.playbackSourceUrlsForPlatform,
+        equals([
+          'https://media.divine.video/$hash',
+          'https://media.divine.video/$hash/hls/stream_720p.m3u8',
+        ]),
+      );
+    });
+
+    test('deduplicates non-Divine sources', () {
+      final video = _createVideoWithUrl('https://example.com/video.mp4');
+
+      expect(
+        video.playbackSourceUrlsForPlatform,
+        equals(['https://example.com/video.mp4']),
+      );
+    });
+  });
 }

--- a/mobile/test/screens/subtitle_editor/subtitle_editor_screen_test.dart
+++ b/mobile/test/screens/subtitle_editor/subtitle_editor_screen_test.dart
@@ -6,9 +6,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:infinite_video_feed/infinite_video_feed.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/subtitle_editor/subtitle_editor_cubit.dart';
+import 'package:openvine/extensions/video_event_extensions.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/models/subtitle_editor/timeline_frame.dart';
 import 'package:openvine/providers/subtitle_repository_provider.dart';
@@ -430,6 +432,46 @@ void main() {
       reason:
           'the picture is a fixed height, so a lower sheet would only '
           'open a band of empty background under it',
+    );
+  });
+
+  testWidgets('the stage plays the renditions the feed would pick', (
+    tester,
+  ) async {
+    const hash =
+        '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+    when(() => cubit.state).thenReturn(
+      const SubtitleEditorState(
+        status: SubtitleEditorStatus.ready,
+        cues: [EditableCue(start: 0, end: 1000, text: 'one')],
+      ),
+    );
+    await tester.pumpWidget(pump(videoUrl: 'https://media.divine.video/$hash'));
+    await tester.pump();
+
+    final stage = tester.widget<SubtitleEditorStage>(
+      find.byType(SubtitleEditorStage),
+    );
+
+    // The editor must not carry its own ladder: #7550 is what happens when it
+    // does. The bare blob answers a Range request with a cached NoSuchKey body
+    // dressed up as a 206 (divine-blossom#198), so it is absent here, and the
+    // HLS rung is the master playlist the native player takes directly.
+    expect(
+      stage.playbackUrls,
+      equals(
+        resolvePlaybackSources(
+          _video(videoUrl: 'https://media.divine.video/$hash'),
+          urlResolver: (video) => video.getOptimalVideoUrlForPlatform(),
+        ),
+      ),
+    );
+    expect(
+      stage.playbackUrls,
+      equals([
+        'https://media.divine.video/$hash/720p.mp4',
+        'https://media.divine.video/$hash/hls/master.m3u8',
+      ]),
     );
   });
 

--- a/mobile/test/widgets/subtitle_editor/subtitle_editor_stage_test.dart
+++ b/mobile/test/widgets/subtitle_editor/subtitle_editor_stage_test.dart
@@ -307,5 +307,42 @@ void main() {
       final l10n = lookupAppLocalizations(const Locale('en'));
       expect(find.text(l10n.subtitleEditorPreviewUnavailable), findsNothing);
     });
+
+    test('plays the preview to the container duration, untrimmed', () async {
+      final controller = _RecordingController();
+      addTearDown(controller.dispose);
+
+      await loadSubtitlePreviewSources(
+        controller: controller,
+        sources: const ['https://example.com/720p.mp4'],
+        log: (_) {},
+        isLoadCurrent: () => true,
+      );
+
+      // The cue timeline is drawn from the container duration, so a clip
+      // clamped to the shorter of the two tracks would put the last half-second
+      // of the axis out of reach — a cue timed into it could never be watched
+      // against the picture. The feed opts in; the editor must not.
+      expect(controller.lastSource?.trimToCommonTrackEnd, isFalse);
+      expect(controller.lastSource?.end, isNull);
+    });
   });
+}
+
+/// Records the clip handed to the player, so the preview's source contract can
+/// be asserted without a platform channel.
+class _RecordingController extends DivineVideoPlayerController {
+  VideoClip? lastSource;
+
+  @override
+  int get playerId => 0;
+
+  @override
+  Future<void> initialize() async {}
+
+  @override
+  Future<void> setSource(VideoClip clip) async => lastSource = clip;
+
+  @override
+  Future<void> dispose() async {}
 }

--- a/mobile/test/widgets/subtitle_editor/subtitle_editor_stage_test.dart
+++ b/mobile/test/widgets/subtitle_editor/subtitle_editor_stage_test.dart
@@ -7,6 +7,7 @@ import 'dart:io';
 import 'package:divine_video_player/divine_video_player.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:infinite_video_feed/infinite_video_feed.dart';
 import 'package:openvine/blocs/subtitle_editor/subtitle_editor_cubit.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/models/subtitle_editor/timeline_frame.dart';
@@ -278,6 +279,33 @@ void main() {
 
       expect(currentLoadIsMounted(), isFalse);
       releaseLoader.complete();
+    });
+
+    testWidgets('treats aborted preview source loading as cancellation', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        pump(
+          cues: const [EditableCue(start: 0, end: 1000, text: 'one')],
+          initializePreviewController: (_) async {},
+          loadPreviewSources:
+              ({
+                required controller,
+                required sources,
+                required log,
+                required isLoadCurrent,
+              }) async {
+                throw const SourceLoadAborted(
+                  index: 0,
+                  source: 'https://example.com/video.mp4',
+                );
+              },
+        ),
+      );
+      await tester.pump();
+
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      expect(find.text(l10n.subtitleEditorPreviewUnavailable), findsNothing);
     });
   });
 }

--- a/mobile/test/widgets/subtitle_editor/subtitle_editor_stage_test.dart
+++ b/mobile/test/widgets/subtitle_editor/subtitle_editor_stage_test.dart
@@ -171,6 +171,40 @@ void main() {
       );
     });
 
+    test(
+      'resolves preview playback candidates in order and deduplicates',
+      () async {
+        final seen = <String?>[];
+
+        final urls = await SubtitleEditorStage.resolvePreviewPlaybackUrls(
+          playbackUrls: const [
+            'https://media.divine.video/hash/720p.mp4',
+            'https://media.divine.video/hash/hls/master.m3u8',
+            'https://media.divine.video/hash/720p.mp4',
+            '',
+          ],
+          resolvePlayableUrl: (url) async {
+            seen.add(url);
+            if (url?.endsWith('.m3u8') ?? false) {
+              return 'https://media.divine.video/hash/720p.mp4';
+            }
+            return url;
+          },
+        );
+
+        expect(
+          seen,
+          equals([
+            'https://media.divine.video/hash/720p.mp4',
+            'https://media.divine.video/hash/hls/master.m3u8',
+            'https://media.divine.video/hash/720p.mp4',
+            '',
+          ]),
+        );
+        expect(urls, equals(['https://media.divine.video/hash/720p.mp4']));
+      },
+    );
+
     testWidgets('deletes loaded filmstrip files when disposed', (tester) async {
       final frame = File('${temp.path}/frame.jpg')..writeAsStringSync('frame');
       final controller = StreamController<List<TimelineFrame>>();

--- a/mobile/test/widgets/subtitle_editor/subtitle_editor_stage_test.dart
+++ b/mobile/test/widgets/subtitle_editor/subtitle_editor_stage_test.dart
@@ -56,6 +56,7 @@ void main() {
           width: 400,
           child: SubtitleEditorStage(
             videoUrl: 'https://example.com/video.mp4',
+            playbackUrls: const ['https://example.com/video.mp4'],
             videoId:
                 '0000000000000000000000000000000000000000000000000000000000000000',
             cues: cues,

--- a/mobile/test/widgets/subtitle_editor/subtitle_editor_stage_test.dart
+++ b/mobile/test/widgets/subtitle_editor/subtitle_editor_stage_test.dart
@@ -47,6 +47,9 @@ void main() {
       required List<EditableCue> cues,
       EditableCue? selectedCue,
       TimelineFrameLoader loadFrames = _noFrames,
+      List<String> playbackUrls = const ['https://example.com/video.mp4'],
+      SubtitlePreviewControllerInitializer? initializePreviewController,
+      SubtitlePreviewSourceLoader? loadPreviewSources,
     }) => MaterialApp(
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
@@ -56,7 +59,9 @@ void main() {
           width: 400,
           child: SubtitleEditorStage(
             videoUrl: 'https://example.com/video.mp4',
-            playbackUrls: const ['https://example.com/video.mp4'],
+            playbackUrls: playbackUrls,
+            initializePreviewController: initializePreviewController,
+            loadPreviewSources: loadPreviewSources,
             videoId:
                 '0000000000000000000000000000000000000000000000000000000000000000',
             cues: cues,
@@ -198,6 +203,40 @@ void main() {
       await tester.pumpWidget(const SizedBox.shrink());
 
       expect(frame.existsSync(), isFalse);
+    });
+
+    testWidgets('hands every playback candidate to the shared loader', (
+      tester,
+    ) async {
+      final loadedSources = <List<String>>[];
+
+      await tester.pumpWidget(
+        pump(
+          cues: const [EditableCue(start: 0, end: 1000, text: 'one')],
+          playbackUrls: const [
+            'https://example.com/720p.mp4',
+            'https://example.com/hls/master.m3u8',
+          ],
+          initializePreviewController: (_) async {},
+          loadPreviewSources:
+              ({required controller, required sources, required log}) async {
+                loadedSources.add(sources);
+              },
+        ),
+      );
+      for (var i = 0; i < 10 && loadedSources.isEmpty; i++) {
+        await tester.pump(const Duration(milliseconds: 100));
+      }
+
+      expect(
+        loadedSources,
+        equals([
+          [
+            'https://example.com/720p.mp4',
+            'https://example.com/hls/master.m3u8',
+          ],
+        ]),
+      );
     });
   });
 }

--- a/mobile/test/widgets/subtitle_editor/subtitle_editor_stage_test.dart
+++ b/mobile/test/widgets/subtitle_editor/subtitle_editor_stage_test.dart
@@ -171,40 +171,6 @@ void main() {
       );
     });
 
-    test(
-      'resolves preview playback candidates in order and deduplicates',
-      () async {
-        final seen = <String?>[];
-
-        final urls = await SubtitleEditorStage.resolvePreviewPlaybackUrls(
-          playbackUrls: const [
-            'https://media.divine.video/hash/720p.mp4',
-            'https://media.divine.video/hash/hls/master.m3u8',
-            'https://media.divine.video/hash/720p.mp4',
-            '',
-          ],
-          resolvePlayableUrl: (url) async {
-            seen.add(url);
-            if (url?.endsWith('.m3u8') ?? false) {
-              return 'https://media.divine.video/hash/720p.mp4';
-            }
-            return url;
-          },
-        );
-
-        expect(
-          seen,
-          equals([
-            'https://media.divine.video/hash/720p.mp4',
-            'https://media.divine.video/hash/hls/master.m3u8',
-            'https://media.divine.video/hash/720p.mp4',
-            '',
-          ]),
-        );
-        expect(urls, equals(['https://media.divine.video/hash/720p.mp4']));
-      },
-    );
-
     testWidgets('deletes loaded filmstrip files when disposed', (tester) async {
       final frame = File('${temp.path}/frame.jpg')..writeAsStringSync('frame');
       final controller = StreamController<List<TimelineFrame>>();

--- a/mobile/test/widgets/subtitle_editor/subtitle_editor_stage_test.dart
+++ b/mobile/test/widgets/subtitle_editor/subtitle_editor_stage_test.dart
@@ -219,7 +219,12 @@ void main() {
           ],
           initializePreviewController: (_) async {},
           loadPreviewSources:
-              ({required controller, required sources, required log}) async {
+              ({
+                required controller,
+                required sources,
+                required log,
+                required isLoadCurrent,
+              }) async {
                 loadedSources.add(sources);
               },
         ),
@@ -237,6 +242,42 @@ void main() {
           ],
         ]),
       );
+    });
+
+    testWidgets('cancels preview source loading after disposal', (
+      tester,
+    ) async {
+      late bool Function() currentLoadIsMounted;
+      final loaderEntered = Completer<void>();
+      final releaseLoader = Completer<void>();
+
+      await tester.pumpWidget(
+        pump(
+          cues: const [EditableCue(start: 0, end: 1000, text: 'one')],
+          initializePreviewController: (_) async {},
+          loadPreviewSources:
+              ({
+                required controller,
+                required sources,
+                required log,
+                required isLoadCurrent,
+              }) async {
+                currentLoadIsMounted = isLoadCurrent;
+                loaderEntered.complete();
+                await releaseLoader.future;
+              },
+        ),
+      );
+      for (var i = 0; i < 10 && !loaderEntered.isCompleted; i++) {
+        await tester.pump(const Duration(milliseconds: 100));
+      }
+      expect(loaderEntered.isCompleted, isTrue);
+      expect(currentLoadIsMounted(), isTrue);
+
+      await tester.pumpWidget(const SizedBox.shrink());
+
+      expect(currentLoadIsMounted(), isFalse);
+      releaseLoader.complete();
     });
   });
 }


### PR DESCRIPTION
## Description

Opening the subtitle editor on a Divine video could leave the preview stuck on a black placeholder, so captions had to be timed blind against the filmstrip. The editor handed the player the bare published blob URL — the one URL that answers a range request with a cached `NoSuchKey` body dressed up as an HTTP 206 (divine-blossom#198) — long after the feed had stopped playing that URL directly.

The fix is to stop the editor having its own opinion about which file to play. It now asks for the same ordered list of renditions the feed would pick, and hands that list to the feed's own loader. The preview inherits the rest of the feed's behaviour for free: the retry ladder for media still transcoding after upload, the HLS master fallback, and cancelling a load whose screen has already gone away.

The one thing the preview does *not* inherit is the feed's loop-seam trim, which ends playback at the shorter of the audio and video tracks. The feed wants that; an editor cannot have it, because the cue timeline is drawn from the container duration and the trim would put the last half-second of that axis out of the preview's reach.

**Deliberately unchanged:** the filmstrip under the timeline still reads its frames from the published URL. Only the preview player moved.

- use the feed playback source ladder for subtitle editor preview instead of handing the player the raw published video URL
- load preview candidates through the shared `setSourceWithFallbacks` path, including media-processing retries, HLS master fallback, and stale-load cancellation
- narrow the `infinite_video_feed` barrel exports to the source APIs the editor actually uses
- remove the now-unused app fallback URL helpers left adjacent to the subtitle preview rewrite
- make `trimToCommonTrackEnd` a parameter of `setSourceWithFallbacks` (defaulting to the feed's existing behaviour) and opt the preview out — *pushed by @hm21 during review*
- add regression coverage for extensionless Divine blob preview sources, screen-to-stage source handoff, preview load cancellation after disposal, and the untrimmed preview clip

**Related Issue:** Closes #7550

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactor
- [ ] Performance improvement
- [x] Test update

## Testing
- [x] `flutter test test/extensions/video_event_divine_server_test.dart test/widgets/subtitle_editor/ test/screens/subtitle_editor/` (92 passing)
- [x] `flutter analyze lib test integration_test`
- [x] `flutter test --coverage` from `mobile/packages/infinite_video_feed` (256 passing, coverage still 100%)
- [x] `flutter analyze lib test` from `mobile/packages/infinite_video_feed`
- [x] pre-push hook (merge-conflict check, analyzer, changed-file tests)

## Device Verification
Not yet verified on a real handset. Worth a pass on device before merge: the parts that only exist on the native players — the HLS master fallback, the 202 retry ladder for a just-published video, and the untrimmed clip end — are exercised by contract tests here, not by a real decoder.

## Screenshots
Not applicable.
