### PR TITLE
fix(profile): suppress repeated unauthorized thumbnails

### DIFF
--- a/mobile/lib/widgets/video_thumbnail_widget.dart
+++ b/mobile/lib/widgets/video_thumbnail_widget.dart
@@ -222,12 +222,38 @@ class PassiveAuthThumbnailImage extends StatefulWidget {
     return host == 'divine.video' || host.endsWith('.divine.video');
   }
 
-  static final Set<String> _unauthorizedWithoutPassiveAuth = <String>{};
+  static const int _maxUnauthorizedCacheEntries = 128;
+  static const Duration _unauthorizedCacheTtl = Duration(minutes: 5);
+  static final Map<_PassiveAuthSuppressionKey, DateTime>
+  _unauthorizedWithoutPassiveAuth = <_PassiveAuthSuppressionKey, DateTime>{};
+
+  static void _rememberUnauthorized(_PassiveAuthSuppressionKey key) {
+    _unauthorizedWithoutPassiveAuth
+      ..remove(key)
+      ..[key] = DateTime.now().add(_unauthorizedCacheTtl);
+    while (_unauthorizedWithoutPassiveAuth.length >
+        _maxUnauthorizedCacheEntries) {
+      _unauthorizedWithoutPassiveAuth.remove(
+        _unauthorizedWithoutPassiveAuth.keys.first,
+      );
+    }
+  }
+
+  static bool _isUnauthorized(_PassiveAuthSuppressionKey key) {
+    final expiresAt = _unauthorizedWithoutPassiveAuth.remove(key);
+    if (expiresAt == null || !DateTime.now().isBefore(expiresAt)) return false;
+    _unauthorizedWithoutPassiveAuth[key] = expiresAt;
+    return true;
+  }
 
   @visibleForTesting
   static void debugClearUnauthorizedCache() {
     _unauthorizedWithoutPassiveAuth.clear();
   }
+
+  @visibleForTesting
+  static int get debugUnauthorizedCacheLength =>
+      _unauthorizedWithoutPassiveAuth.length;
 
   @override
   State<PassiveAuthThumbnailImage> createState() =>
@@ -240,6 +266,14 @@ class PassiveAuthUnavailableThumbnailException implements Exception {
   @override
   String toString() => 'Passive thumbnail auth unavailable';
 }
+
+typedef _PassiveAuthSuppressionKey = ({
+  String url,
+  ProviderContainer container,
+  Object? authState,
+  int contentFilterVersion,
+  int adultMediaAccessVersion,
+});
 
 class _PassiveAuthThumbnailImageState extends State<PassiveAuthThumbnailImage> {
   ProviderContainer? _providerContainer;
@@ -361,13 +395,17 @@ class _PassiveAuthThumbnailImageState extends State<PassiveAuthThumbnailImage> {
     _authRetryAttempted = true;
     switch (authResult) {
       case ViewerAuthAuthorized(:final headers):
-        PassiveAuthThumbnailImage._unauthorizedWithoutPassiveAuth.remove(
-          retryUrl,
-        );
+        final suppressionKey = _suppressionKey(retryUrl);
+        if (suppressionKey != null) {
+          PassiveAuthThumbnailImage._unauthorizedWithoutPassiveAuth.remove(
+            suppressionKey,
+          );
+        }
         setState(() {
           _authHeaders = headers;
         });
       case ViewerAuthSignerUnreachable():
+        break;
       case ViewerAuthBlockedByPreference():
       case ViewerAuthUnavailable():
         _markPassiveAuthUnavailable(retryUrl);
@@ -376,16 +414,30 @@ class _PassiveAuthThumbnailImageState extends State<PassiveAuthThumbnailImage> {
 
   void _markPassiveAuthUnavailable(String url) {
     _authRetryAttempted = true;
-    PassiveAuthThumbnailImage._unauthorizedWithoutPassiveAuth.add(url);
+    final suppressionKey = _suppressionKey(url);
+    if (suppressionKey == null) return;
+    PassiveAuthThumbnailImage._rememberUnauthorized(suppressionKey);
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted &&
           widget.url == url &&
-          PassiveAuthThumbnailImage._unauthorizedWithoutPassiveAuth.contains(
-            url,
-          )) {
+          PassiveAuthThumbnailImage._isUnauthorized(suppressionKey)) {
         setState(() {});
       }
     });
+  }
+
+  _PassiveAuthSuppressionKey? _suppressionKey(String url) {
+    final container = _providerContainer;
+    if (container == null) return null;
+    return (
+      url: url,
+      container: container,
+      authState: container.read(currentAuthStateProvider),
+      contentFilterVersion: container.read(contentFilterVersionProvider),
+      adultMediaAccessVersion: container.read(
+        adultMediaAccessRevocationVersionProvider,
+      ),
+    );
   }
 
   void _resetPassiveAuthState() {
@@ -415,9 +467,10 @@ class _PassiveAuthThumbnailImageState extends State<PassiveAuthThumbnailImage> {
         final resolvedUrl = widget.url;
 
         if (PassiveAuthThumbnailImage._shouldBypassCacheManager(resolvedUrl)) {
+          final suppressionKey = _suppressionKey(resolvedUrl);
           if (_authHeaders == null &&
-              PassiveAuthThumbnailImage._unauthorizedWithoutPassiveAuth
-                  .contains(resolvedUrl)) {
+              suppressionKey != null &&
+              PassiveAuthThumbnailImage._isUnauthorized(suppressionKey)) {
             final errorWidget = widget.errorWidget;
             if (errorWidget != null) {
               return errorWidget(

--- a/mobile/lib/widgets/video_thumbnail_widget.dart
+++ b/mobile/lib/widgets/video_thumbnail_widget.dart
@@ -290,6 +290,7 @@ class _PassiveAuthThumbnailImageState extends State<PassiveAuthThumbnailImage> {
   ProviderSubscription<int>? _adultMediaAccessSubscription;
   Map<String, String>? _authHeaders;
   bool _authRetryAttempted = false;
+  bool _passiveAuthSuppressed = false;
   Future<void>? _authRetryInFlight;
   int _imageGeneration = 0;
 
@@ -422,6 +423,7 @@ class _PassiveAuthThumbnailImageState extends State<PassiveAuthThumbnailImage> {
     final suppressionKey = _suppressionKey(url);
     if (suppressionKey == null) return;
     PassiveAuthThumbnailImage._rememberUnauthorized(suppressionKey);
+    _passiveAuthSuppressed = true;
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted &&
           widget.url == url &&
@@ -448,6 +450,7 @@ class _PassiveAuthThumbnailImageState extends State<PassiveAuthThumbnailImage> {
   void _resetPassiveAuthState() {
     _authHeaders = null;
     _authRetryAttempted = false;
+    _passiveAuthSuppressed = false;
     _authRetryInFlight = null;
     _imageGeneration++;
   }
@@ -489,8 +492,11 @@ class _PassiveAuthThumbnailImageState extends State<PassiveAuthThumbnailImage> {
               );
             }
 
-            // Without an active suppression entry, start a fresh retry window.
-            _authRetryAttempted = false;
+            if (_passiveAuthSuppressed) {
+              // An expired or evicted suppression starts a fresh retry window.
+              _passiveAuthSuppressed = false;
+              _authRetryAttempted = false;
+            }
           }
 
           final imageProvider = ResizeImage.resizeIfNeeded(

--- a/mobile/lib/widgets/video_thumbnail_widget.dart
+++ b/mobile/lib/widgets/video_thumbnail_widget.dart
@@ -377,7 +377,15 @@ class _PassiveAuthThumbnailImageState extends State<PassiveAuthThumbnailImage> {
   void _markPassiveAuthUnavailable(String url) {
     _authRetryAttempted = true;
     PassiveAuthThumbnailImage._unauthorizedWithoutPassiveAuth.add(url);
-    if (mounted) setState(() {});
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted &&
+          widget.url == url &&
+          PassiveAuthThumbnailImage._unauthorizedWithoutPassiveAuth.contains(
+            url,
+          )) {
+        setState(() {});
+      }
+    });
   }
 
   void _resetPassiveAuthState() {

--- a/mobile/lib/widgets/video_thumbnail_widget.dart
+++ b/mobile/lib/widgets/video_thumbnail_widget.dart
@@ -222,9 +222,23 @@ class PassiveAuthThumbnailImage extends StatefulWidget {
     return host == 'divine.video' || host.endsWith('.divine.video');
   }
 
+  static final Set<String> _unauthorizedWithoutPassiveAuth = <String>{};
+
+  @visibleForTesting
+  static void debugClearUnauthorizedCache() {
+    _unauthorizedWithoutPassiveAuth.clear();
+  }
+
   @override
   State<PassiveAuthThumbnailImage> createState() =>
       _PassiveAuthThumbnailImageState();
+}
+
+class PassiveAuthUnavailableThumbnailException implements Exception {
+  const PassiveAuthUnavailableThumbnailException();
+
+  @override
+  String toString() => 'Passive thumbnail auth unavailable';
 }
 
 class _PassiveAuthThumbnailImageState extends State<PassiveAuthThumbnailImage> {
@@ -295,7 +309,10 @@ class _PassiveAuthThumbnailImageState extends State<PassiveAuthThumbnailImage> {
 
   void _resetPassiveAuthStateInFrame() {
     if (!mounted) return;
-    setState(_resetPassiveAuthState);
+    setState(() {
+      PassiveAuthThumbnailImage._unauthorizedWithoutPassiveAuth.clear();
+      _resetPassiveAuthState();
+    });
   }
 
   Future<void> _maybeRetryWithPassiveAuth(Object error) async {
@@ -319,13 +336,13 @@ class _PassiveAuthThumbnailImageState extends State<PassiveAuthThumbnailImage> {
     final retryGeneration = _imageGeneration;
     final sha256Hash = extractSha256FromBlossomUrl(retryUrl);
     if (sha256Hash == null) {
-      _authRetryAttempted = true;
+      _markPassiveAuthUnavailable(retryUrl);
       return;
     }
 
     final container = _providerContainer;
     if (container == null) {
-      _authRetryAttempted = true;
+      _markPassiveAuthUnavailable(retryUrl);
       return;
     }
 
@@ -344,14 +361,23 @@ class _PassiveAuthThumbnailImageState extends State<PassiveAuthThumbnailImage> {
     _authRetryAttempted = true;
     switch (authResult) {
       case ViewerAuthAuthorized(:final headers):
+        PassiveAuthThumbnailImage._unauthorizedWithoutPassiveAuth.remove(
+          retryUrl,
+        );
         setState(() {
           _authHeaders = headers;
         });
       case ViewerAuthSignerUnreachable():
       case ViewerAuthBlockedByPreference():
       case ViewerAuthUnavailable():
-        break;
+        _markPassiveAuthUnavailable(retryUrl);
     }
+  }
+
+  void _markPassiveAuthUnavailable(String url) {
+    _authRetryAttempted = true;
+    PassiveAuthThumbnailImage._unauthorizedWithoutPassiveAuth.add(url);
+    if (mounted) setState(() {});
   }
 
   void _resetPassiveAuthState() {
@@ -381,6 +407,23 @@ class _PassiveAuthThumbnailImageState extends State<PassiveAuthThumbnailImage> {
         final resolvedUrl = widget.url;
 
         if (PassiveAuthThumbnailImage._shouldBypassCacheManager(resolvedUrl)) {
+          if (_authHeaders == null &&
+              PassiveAuthThumbnailImage._unauthorizedWithoutPassiveAuth
+                  .contains(resolvedUrl)) {
+            final errorWidget = widget.errorWidget;
+            if (errorWidget != null) {
+              return errorWidget(
+                context,
+                resolvedUrl,
+                const PassiveAuthUnavailableThumbnailException(),
+              );
+            }
+            return _TransparentImageBox(
+              width: widget.width,
+              height: widget.height,
+            );
+          }
+
           final imageProvider = ResizeImage.resizeIfNeeded(
             widget.memCacheWidth ?? cacheWidth,
             null,

--- a/mobile/lib/widgets/video_thumbnail_widget.dart
+++ b/mobile/lib/widgets/video_thumbnail_widget.dart
@@ -255,6 +255,14 @@ class PassiveAuthThumbnailImage extends StatefulWidget {
   static int get debugUnauthorizedCacheLength =>
       _unauthorizedWithoutPassiveAuth.length;
 
+  @visibleForTesting
+  static void debugExpireUnauthorizedCache() {
+    final expiredAt = DateTime.fromMillisecondsSinceEpoch(0);
+    for (final key in _unauthorizedWithoutPassiveAuth.keys) {
+      _unauthorizedWithoutPassiveAuth[key] = expiredAt;
+    }
+  }
+
   @override
   State<PassiveAuthThumbnailImage> createState() =>
       _PassiveAuthThumbnailImageState();
@@ -343,10 +351,7 @@ class _PassiveAuthThumbnailImageState extends State<PassiveAuthThumbnailImage> {
 
   void _resetPassiveAuthStateInFrame() {
     if (!mounted) return;
-    setState(() {
-      PassiveAuthThumbnailImage._unauthorizedWithoutPassiveAuth.clear();
-      _resetPassiveAuthState();
-    });
+    setState(_resetPassiveAuthState);
   }
 
   Future<void> _maybeRetryWithPassiveAuth(Object error) async {
@@ -468,21 +473,24 @@ class _PassiveAuthThumbnailImageState extends State<PassiveAuthThumbnailImage> {
 
         if (PassiveAuthThumbnailImage._shouldBypassCacheManager(resolvedUrl)) {
           final suppressionKey = _suppressionKey(resolvedUrl);
-          if (_authHeaders == null &&
-              suppressionKey != null &&
-              PassiveAuthThumbnailImage._isUnauthorized(suppressionKey)) {
-            final errorWidget = widget.errorWidget;
-            if (errorWidget != null) {
-              return errorWidget(
-                context,
-                resolvedUrl,
-                const PassiveAuthUnavailableThumbnailException(),
+          if (_authHeaders == null && suppressionKey != null) {
+            if (PassiveAuthThumbnailImage._isUnauthorized(suppressionKey)) {
+              final errorWidget = widget.errorWidget;
+              if (errorWidget != null) {
+                return errorWidget(
+                  context,
+                  resolvedUrl,
+                  const PassiveAuthUnavailableThumbnailException(),
+                );
+              }
+              return _TransparentImageBox(
+                width: widget.width,
+                height: widget.height,
               );
             }
-            return _TransparentImageBox(
-              width: widget.width,
-              height: widget.height,
-            );
+
+            // Without an active suppression entry, start a fresh retry window.
+            _authRetryAttempted = false;
           }
 
           final imageProvider = ResizeImage.resizeIfNeeded(

--- a/mobile/test/widgets/profile/profile_tab_thumbnail_test.dart
+++ b/mobile/test/widgets/profile/profile_tab_thumbnail_test.dart
@@ -128,6 +128,30 @@ void main() {
       const validBlurhash = 'LEHV6nWB2yk8pyo0adR*.7kCMdnj';
 
       testWidgets(
+        'uses the blurhash when passive thumbnail auth is unavailable',
+        (
+          tester,
+        ) async {
+          const url = 'https://media.divine.video/not-a-hash.jpg';
+          await tester.pumpWidget(
+            buildSubject(thumbnailUrl: url, blurhash: validBlurhash),
+          );
+          final image = tester.widget<PassiveAuthThumbnailImage>(
+            find.byType(PassiveAuthThumbnailImage),
+          );
+
+          final fallback = image.errorWidget!(
+            tester.element(find.byType(PassiveAuthThumbnailImage)),
+            url,
+            const PassiveAuthUnavailableThumbnailException(),
+          );
+          await tester.pumpWidget(MaterialApp(home: fallback));
+
+          expect(find.byType(BlurhashDisplay), findsOneWidget);
+        },
+      );
+
+      testWidgets(
         '$BlurhashDisplay when thumbnailUrl is null and blurhash is provided',
         (tester) async {
           await tester.pumpWidget(buildSubject(blurhash: validBlurhash));

--- a/mobile/test/widgets/video_thumbnail_widget_test.dart
+++ b/mobile/test/widgets/video_thumbnail_widget_test.dart
@@ -1013,6 +1013,119 @@ void main() {
       },
     );
 
+    testWidgets(
+      'keeps one container suppressed when another container changes filters',
+      (tester) async {
+        final mediaAuthInterceptor = _MockMediaAuthInterceptor();
+        const hash =
+            '72d7eda61074b17e077fb9f4a8b48166cdeb65cb07e053aafa6e69d5fa165995';
+        const url = 'https://media.divine.video/$hash.jpg';
+        when(
+          () => mediaAuthInterceptor.createPassiveAuthHeadersForAdultMedia(
+            sha256Hash: any(named: 'sha256Hash'),
+            serverUrl: any(named: 'serverUrl'),
+          ),
+        ).thenAnswer((_) async => const ViewerAuthUnavailable());
+        final containerA = ProviderContainer(
+          overrides: _passiveAuthProviderOverrides(mediaAuthInterceptor),
+        );
+        final containerB = ProviderContainer(
+          overrides: _passiveAuthProviderOverrides(mediaAuthInterceptor),
+        );
+        addTearDown(containerA.dispose);
+        addTearDown(containerB.dispose);
+
+        Widget buildSubject(ProviderContainer container) =>
+            UncontrolledProviderScope(
+              container: container,
+              child: const MaterialApp(
+                home: PassiveAuthThumbnailImage(url: url),
+              ),
+            );
+
+        await tester.pumpWidget(buildSubject(containerB));
+        final image = tester.widget<Image>(find.byType(Image));
+        image.errorBuilder!(
+          tester.element(find.byType(Image)),
+          NetworkImageLoadException(statusCode: 401, uri: Uri.parse(url)),
+          StackTrace.current,
+        );
+        await tester.pump();
+        await tester.pump();
+        expect(find.byType(Image), findsNothing);
+
+        await tester.pumpWidget(buildSubject(containerA));
+        containerA.read(contentFilterVersionProvider.notifier).increment();
+        await tester.pump();
+        await tester.pumpWidget(buildSubject(containerB));
+
+        expect(find.byType(Image), findsNothing);
+        verify(
+          () => mediaAuthInterceptor.createPassiveAuthHeadersForAdultMedia(
+            sha256Hash: hash,
+            serverUrl: 'https://media.divine.video',
+          ),
+        ).called(1);
+      },
+    );
+
+    testWidgets(
+      'retries and suppresses again after cache expiry while mounted',
+      (tester) async {
+        final mediaAuthInterceptor = _MockMediaAuthInterceptor();
+        const hash =
+            '72d7eda61074b17e077fb9f4a8b48166cdeb65cb07e053aafa6e69d5fa165995';
+        const url = 'https://media.divine.video/$hash.jpg';
+        when(
+          () => mediaAuthInterceptor.createPassiveAuthHeadersForAdultMedia(
+            sha256Hash: any(named: 'sha256Hash'),
+            serverUrl: any(named: 'serverUrl'),
+          ),
+        ).thenAnswer((_) async => const ViewerAuthUnavailable());
+        final container = ProviderContainer(
+          overrides: _passiveAuthProviderOverrides(mediaAuthInterceptor),
+        );
+        addTearDown(container.dispose);
+
+        Widget buildSubject(double width) => UncontrolledProviderScope(
+          container: container,
+          child: MaterialApp(
+            home: PassiveAuthThumbnailImage(url: url, width: width),
+          ),
+        );
+
+        await tester.pumpWidget(buildSubject(100));
+        var image = tester.widget<Image>(find.byType(Image));
+        image.errorBuilder!(
+          tester.element(find.byType(Image)),
+          NetworkImageLoadException(statusCode: 401, uri: Uri.parse(url)),
+          StackTrace.current,
+        );
+        await tester.pump();
+        await tester.pump();
+        expect(find.byType(Image), findsNothing);
+
+        PassiveAuthThumbnailImage.debugExpireUnauthorizedCache();
+        await tester.pumpWidget(buildSubject(101));
+        image = tester.widget<Image>(find.byType(Image));
+        image.errorBuilder!(
+          tester.element(find.byType(Image)),
+          NetworkImageLoadException(statusCode: 401, uri: Uri.parse(url)),
+          StackTrace.current,
+        );
+        await tester.pump();
+        await tester.pump();
+
+        expect(find.byType(Image), findsNothing);
+        verify(
+          () => mediaAuthInterceptor.createPassiveAuthHeadersForAdultMedia(
+            sha256Hash: hash,
+            serverUrl: 'https://media.divine.video',
+          ),
+        ).called(2);
+      },
+    );
+
     testWidgets('bounds the unavailable thumbnail cache', (tester) async {
       final mediaAuthInterceptor = _MockMediaAuthInterceptor();
       final container = ProviderContainer(

--- a/mobile/test/widgets/video_thumbnail_widget_test.dart
+++ b/mobile/test/widgets/video_thumbnail_widget_test.dart
@@ -98,6 +98,7 @@ void main() {
 
     setUp(() {
       SharedPreferences.setMockInitialValues({});
+      PassiveAuthThumbnailImage.debugClearUnauthorizedCache();
       // Video with only thumbnail URL
       videoWithThumbnail = createTestVideoEvent(
         id: 'test1',
@@ -120,6 +121,8 @@ void main() {
       // Video with neither
       videoWithNeither = createTestVideoEvent(id: 'test4');
     });
+
+    tearDown(PassiveAuthThumbnailImage.debugClearUnauthorizedCache);
 
     // Stub the image cache (#5158 seam) so VineCachedImage does no real
     // path_provider / cache-manager work that could settle after the test and
@@ -794,6 +797,59 @@ void main() {
             serverUrl: any(named: 'serverUrl'),
           ),
         );
+      },
+    );
+
+    testWidgets(
+      'suppresses repeated unauthenticated Divine thumbnail requests after passive auth is unavailable',
+      (tester) async {
+        final mediaAuthInterceptor = _MockMediaAuthInterceptor();
+        const hash =
+            '72d7eda61074b17e077fb9f4a8b48166cdeb65cb07e053aafa6e69d5fa165995';
+        const url = 'https://media.divine.video/$hash.jpg';
+        when(
+          () => mediaAuthInterceptor.createPassiveAuthHeadersForAdultMedia(
+            sha256Hash: any(named: 'sha256Hash'),
+            serverUrl: any(named: 'serverUrl'),
+          ),
+        ).thenAnswer((_) async => const ViewerAuthUnavailable());
+
+        Widget buildSubject() => ProviderScope(
+          overrides: _passiveAuthProviderOverrides(mediaAuthInterceptor),
+          child: MaterialApp(
+            home: PassiveAuthThumbnailImage(
+              url: url,
+              errorWidget: (_, _, error) => Text('fallback: $error'),
+            ),
+          ),
+        );
+
+        await tester.pumpWidget(buildSubject());
+
+        final image = tester.widget<Image>(find.byType(Image));
+        image.errorBuilder!(
+          tester.element(find.byType(Image)),
+          NetworkImageLoadException(statusCode: 401, uri: Uri.parse(url)),
+          StackTrace.current,
+        );
+        await tester.pump();
+        await tester.pump();
+
+        expect(find.byType(Image), findsNothing);
+        expect(find.textContaining('fallback:'), findsOneWidget);
+        verify(
+          () => mediaAuthInterceptor.createPassiveAuthHeadersForAdultMedia(
+            sha256Hash: hash,
+            serverUrl: 'https://media.divine.video',
+          ),
+        ).called(1);
+
+        await tester.pumpWidget(const SizedBox.shrink());
+        await tester.pumpWidget(buildSubject());
+
+        expect(find.byType(Image), findsNothing);
+        expect(find.textContaining('fallback:'), findsOneWidget);
+        verifyNoMoreInteractions(mediaAuthInterceptor);
       },
     );
 

--- a/mobile/test/widgets/video_thumbnail_widget_test.dart
+++ b/mobile/test/widgets/video_thumbnail_widget_test.dart
@@ -870,8 +870,13 @@ void main() {
           ),
         ).thenAnswer((_) async => const ViewerAuthUnavailable());
 
-        Widget buildSubject() => ProviderScope(
+        final container = ProviderContainer(
           overrides: _passiveAuthProviderOverrides(mediaAuthInterceptor),
+        );
+        addTearDown(container.dispose);
+
+        Widget buildSubject() => UncontrolledProviderScope(
+          container: container,
           child: MaterialApp(
             home: PassiveAuthThumbnailImage(
               url: url,
@@ -908,6 +913,140 @@ void main() {
         verifyNoMoreInteractions(mediaAuthInterceptor);
       },
     );
+
+    testWidgets(
+      'retries a suppressed thumbnail after a transient signer timeout',
+      (tester) async {
+        final mediaAuthInterceptor = _MockMediaAuthInterceptor();
+        const hash =
+            '72d7eda61074b17e077fb9f4a8b48166cdeb65cb07e053aafa6e69d5fa165995';
+        const url = 'https://media.divine.video/$hash.jpg';
+        when(
+          () => mediaAuthInterceptor.createPassiveAuthHeadersForAdultMedia(
+            sha256Hash: any(named: 'sha256Hash'),
+            serverUrl: any(named: 'serverUrl'),
+          ),
+        ).thenAnswer((_) async => const ViewerAuthSignerUnreachable());
+        final container = ProviderContainer(
+          overrides: _passiveAuthProviderOverrides(mediaAuthInterceptor),
+        );
+        addTearDown(container.dispose);
+
+        Widget buildSubject() => UncontrolledProviderScope(
+          container: container,
+          child: const MaterialApp(
+            home: PassiveAuthThumbnailImage(url: url),
+          ),
+        );
+
+        await tester.pumpWidget(buildSubject());
+        var image = tester.widget<Image>(find.byType(Image));
+        image.errorBuilder!(
+          tester.element(find.byType(Image)),
+          NetworkImageLoadException(statusCode: 401, uri: Uri.parse(url)),
+          StackTrace.current,
+        );
+        await tester.pump();
+        await tester.pump();
+
+        await tester.pumpWidget(const SizedBox.shrink());
+        await tester.pumpWidget(buildSubject());
+        image = tester.widget<Image>(find.byType(Image));
+        image.errorBuilder!(
+          tester.element(find.byType(Image)),
+          NetworkImageLoadException(statusCode: 401, uri: Uri.parse(url)),
+          StackTrace.current,
+        );
+        await tester.pump();
+        await tester.pump();
+
+        verify(
+          () => mediaAuthInterceptor.createPassiveAuthHeadersForAdultMedia(
+            sha256Hash: hash,
+            serverUrl: 'https://media.divine.video',
+          ),
+        ).called(2);
+      },
+    );
+
+    testWidgets(
+      'retries a suppressed thumbnail after filters change while unmounted',
+      (tester) async {
+        final mediaAuthInterceptor = _MockMediaAuthInterceptor();
+        const hash =
+            '72d7eda61074b17e077fb9f4a8b48166cdeb65cb07e053aafa6e69d5fa165995';
+        const url = 'https://media.divine.video/$hash.jpg';
+        when(
+          () => mediaAuthInterceptor.createPassiveAuthHeadersForAdultMedia(
+            sha256Hash: any(named: 'sha256Hash'),
+            serverUrl: any(named: 'serverUrl'),
+          ),
+        ).thenAnswer((_) async => const ViewerAuthUnavailable());
+        final container = ProviderContainer(
+          overrides: _passiveAuthProviderOverrides(mediaAuthInterceptor),
+        );
+        addTearDown(container.dispose);
+
+        Widget buildSubject() => UncontrolledProviderScope(
+          container: container,
+          child: const MaterialApp(
+            home: PassiveAuthThumbnailImage(url: url),
+          ),
+        );
+
+        await tester.pumpWidget(buildSubject());
+        final image = tester.widget<Image>(find.byType(Image));
+        image.errorBuilder!(
+          tester.element(find.byType(Image)),
+          NetworkImageLoadException(statusCode: 401, uri: Uri.parse(url)),
+          StackTrace.current,
+        );
+        await tester.pump();
+        await tester.pump();
+        expect(find.byType(Image), findsNothing);
+
+        await tester.pumpWidget(const SizedBox.shrink());
+        container.read(contentFilterVersionProvider.notifier).increment();
+        await tester.pumpWidget(buildSubject());
+
+        expect(find.byType(Image), findsOneWidget);
+      },
+    );
+
+    testWidgets('bounds the unavailable thumbnail cache', (tester) async {
+      final mediaAuthInterceptor = _MockMediaAuthInterceptor();
+      final container = ProviderContainer(
+        overrides: _passiveAuthProviderOverrides(mediaAuthInterceptor),
+      );
+      addTearDown(container.dispose);
+
+      for (var index = 0; index < 129; index++) {
+        final url = 'https://media.divine.video/not-a-hash-$index.jpg';
+        await tester.pumpWidget(
+          UncontrolledProviderScope(
+            container: container,
+            child: MaterialApp(
+              home: PassiveAuthThumbnailImage(url: url),
+            ),
+          ),
+        );
+        final image = tester.widget<Image>(find.byType(Image));
+        image.errorBuilder!(
+          tester.element(find.byType(Image)),
+          NetworkImageLoadException(statusCode: 401, uri: Uri.parse(url)),
+          StackTrace.current,
+        );
+        await tester.pump();
+      }
+
+      expect(PassiveAuthThumbnailImage.debugUnauthorizedCacheLength, 128);
+      verifyNever(
+        () => mediaAuthInterceptor.createPassiveAuthHeadersForAdultMedia(
+          sha256Hash: any(named: 'sha256Hash'),
+          serverUrl: any(named: 'serverUrl'),
+        ),
+      );
+    });
 
     testWidgets(
       'ImageWithDimensionsListener reports decoded image dimensions',

--- a/mobile/test/widgets/video_thumbnail_widget_test.dart
+++ b/mobile/test/widgets/video_thumbnail_widget_test.dart
@@ -801,6 +801,62 @@ void main() {
     );
 
     testWidgets(
+      'records unavailable non-content-addressed thumbnails without rebuilding during build',
+      (tester) async {
+        final mediaAuthInterceptor = _MockMediaAuthInterceptor();
+        const url = 'https://media.divine.video/not-a-hash.jpg';
+        late StateSetter rebuild;
+        var reportErrorDuringBuild = false;
+        Image? image;
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: _passiveAuthProviderOverrides(mediaAuthInterceptor),
+            child: MaterialApp(
+              home: StatefulBuilder(
+                builder: (context, setState) {
+                  rebuild = setState;
+                  return Row(
+                    children: [
+                      const PassiveAuthThumbnailImage(url: url),
+                      Builder(
+                        builder: (context) {
+                          if (reportErrorDuringBuild) {
+                            image!.errorBuilder!(
+                              tester.element(find.byType(Image)),
+                              NetworkImageLoadException(
+                                statusCode: 401,
+                                uri: Uri.parse(url),
+                              ),
+                              StackTrace.current,
+                            );
+                          }
+                          return const SizedBox.shrink();
+                        },
+                      ),
+                    ],
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+        image = tester.widget<Image>(find.byType(Image));
+
+        rebuild(() => reportErrorDuringBuild = true);
+        await tester.pump();
+
+        expect(tester.takeException(), isNull);
+        verifyNever(
+          () => mediaAuthInterceptor.createPassiveAuthHeadersForAdultMedia(
+            sha256Hash: any(named: 'sha256Hash'),
+            serverUrl: any(named: 'serverUrl'),
+          ),
+        );
+      },
+    );
+
+    testWidgets(
       'suppresses repeated unauthenticated Divine thumbnail requests after passive auth is unavailable',
       (tester) async {
         final mediaAuthInterceptor = _MockMediaAuthInterceptor();

--- a/mobile/test/widgets/video_thumbnail_widget_test.dart
+++ b/mobile/test/widgets/video_thumbnail_widget_test.dart
@@ -970,6 +970,60 @@ void main() {
     );
 
     testWidgets(
+      'does not retry a signer timeout on a retained-state rebuild',
+      (tester) async {
+        final mediaAuthInterceptor = _MockMediaAuthInterceptor();
+        const hash =
+            '72d7eda61074b17e077fb9f4a8b48166cdeb65cb07e053aafa6e69d5fa165995';
+        const url = 'https://media.divine.video/$hash.jpg';
+        when(
+          () => mediaAuthInterceptor.createPassiveAuthHeadersForAdultMedia(
+            sha256Hash: any(named: 'sha256Hash'),
+            serverUrl: any(named: 'serverUrl'),
+          ),
+        ).thenAnswer((_) async => const ViewerAuthSignerUnreachable());
+        final container = ProviderContainer(
+          overrides: _passiveAuthProviderOverrides(mediaAuthInterceptor),
+        );
+        addTearDown(container.dispose);
+
+        Widget buildSubject(double width) => UncontrolledProviderScope(
+          container: container,
+          child: MaterialApp(
+            home: PassiveAuthThumbnailImage(url: url, width: width),
+          ),
+        );
+
+        await tester.pumpWidget(buildSubject(100));
+        var image = tester.widget<Image>(find.byType(Image));
+        image.errorBuilder!(
+          tester.element(find.byType(Image)),
+          NetworkImageLoadException(statusCode: 401, uri: Uri.parse(url)),
+          StackTrace.current,
+        );
+        await tester.pump();
+        await tester.pump();
+
+        await tester.pumpWidget(buildSubject(101));
+        image = tester.widget<Image>(find.byType(Image));
+        image.errorBuilder!(
+          tester.element(find.byType(Image)),
+          NetworkImageLoadException(statusCode: 401, uri: Uri.parse(url)),
+          StackTrace.current,
+        );
+        await tester.pump();
+        await tester.pump();
+
+        verify(
+          () => mediaAuthInterceptor.createPassiveAuthHeadersForAdultMedia(
+            sha256Hash: hash,
+            serverUrl: 'https://media.divine.video',
+          ),
+        ).called(1);
+      },
+    );
+
+    testWidgets(
       'retries a suppressed thumbnail after filters change while unmounted',
       (tester) async {
         final mediaAuthInterceptor = _MockMediaAuthInterceptor();


### PR DESCRIPTION
## Description
- remember Divine thumbnail URLs that returned 401/403 when passive auth could not be created
- render the caller fallback immediately for those known-unavailable thumbnails instead of repeatedly remounting unauthenticated Image.network requests
- clear the suppression when auth or content-filter state changes
- add regression coverage for repeated unavailable passive-auth thumbnail loads

**Related Issue:** Closes #7551

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor
- [ ] Performance improvement
- [x] Test update

## Testing
- [x] flutter test test/widgets/video_thumbnail_widget_test.dart test/widgets/profile/profile_tab_thumbnail_test.dart
- [x] flutter analyze
- [x] pre-push hook (analyzer + changed-file tests)

## Screenshots
Not applicable.