### PR TITLE
fix(cache): clarify budget status in log exports

### DIFF
--- a/mobile/lib/services/bug_report_service.dart
+++ b/mobile/lib/services/bug_report_service.dart
@@ -671,7 +671,17 @@ class BugReportService {
     final limitBytes = usage.limitBytes;
     final used = _formatBytesShort(usage.usedBytes);
     if (limitBytes == null) return used;
-    return '$used/${_formatBytesShort(limitBytes)}';
+    final ratio = limitBytes == 0 ? 0 : usage.usedBytes / limitBytes;
+    final percent = (ratio * 100).toStringAsFixed(1);
+    final status = _cacheBudgetStatus(usage.usedBytes, limitBytes);
+    return '$used/${_formatBytesShort(limitBytes)} '
+        '($percent%, $status, ${usage.usedBytes}/$limitBytes bytes)';
+  }
+
+  static String _cacheBudgetStatus(int usedBytes, int limitBytes) {
+    if (usedBytes < limitBytes) return 'within limit';
+    if (usedBytes == limitBytes) return 'at limit';
+    return 'over limit by ${_formatBytesShort(usedBytes - limitBytes)}';
   }
 
   /// Human-readable device identifier for the export header, e.g.

--- a/mobile/test/unit/services/bug_report_log_export_test.dart
+++ b/mobile/test/unit/services/bug_report_log_export_test.dart
@@ -226,12 +226,57 @@ void main() {
       expect(
         diagnostics,
         contains(
-          'Cache: video 1.5 GB/2.0 GB · images 128.0 MB/256.0 MB · '
-          'seams 64.0 MB/200.0 MB · temp 32.0 MB',
+          'Cache: video 1.5 GB/2.0 GB '
+          '(75.0%, within limit, 1610612736/2147483648 bytes) · '
+          'images 128.0 MB/256.0 MB '
+          '(50.0%, within limit, 134217728/268435456 bytes) · '
+          'seams 64.0 MB/200.0 MB '
+          '(32.0%, within limit, 67108864/209715200 bytes) · '
+          'temp 32.0 MB',
         ),
       );
       expect(diagnostics, isNot(contains('used /')));
-      expect(diagnostics, isNot(contains('limit')));
+      expect(diagnostics, contains('within limit'));
+    });
+
+    test('reports exact cache limit status at and over budget', () async {
+      final storage = _MockStorageManagementService();
+      when(storage.cacheUsage).thenAnswer(
+        (_) async => const CacheUsage(
+          video: CacheUsageCategory(
+            usedBytes: 2 * 1024 * 1024 * 1024,
+            limitBytes: 2 * 1024 * 1024 * 1024,
+          ),
+          images: CacheUsageCategory(
+            usedBytes: 300 * 1024 * 1024,
+            limitBytes: 256 * 1024 * 1024,
+          ),
+          transitionSeams: CacheUsageCategory(
+            usedBytes: 0,
+            limitBytes: 200 * 1024 * 1024,
+          ),
+          tempRenders: CacheUsageCategory(usedBytes: 0),
+        ),
+      );
+
+      final diagnostics = await BugReportService(
+        storageManagementService: storage,
+      ).buildEnvironmentDiagnostics();
+
+      expect(
+        diagnostics,
+        contains(
+          'video 2.0 GB/2.0 GB '
+          '(100.0%, at limit, 2147483648/2147483648 bytes)',
+        ),
+      );
+      expect(
+        diagnostics,
+        contains(
+          'images 300.0 MB/256.0 MB '
+          '(117.2%, over limit by 44.0 MB, 314572800/268435456 bytes)',
+        ),
+      );
     });
   });
 


### PR DESCRIPTION
## Summary
- add exact byte counts and percentage/status labels to cache usage in exported logs
- distinguish within-limit, at-limit, and over-limit cache states so rounded 2.0 GB/2.0 GB exports are actionable
- keep media-cache eviction behavior unchanged because the log did not prove a cache failure

Relates to #7554

## Verification
- flutter test test/unit/services/bug_report_log_export_test.dart
- flutter analyze
- pre-push hook: analyzer + test/unit/services/bug_report_log_export_test.dart + test/unit/services/bug_report_service_test.dart
