### PR TITLE
fix(support): clarify long clip editor limit

### DIFF
--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -10,6 +10,8 @@
     "publishErrorServerNotFound": "የሚዲያ አገልጋዩ ({serverName}) አይገኝም። በቅንብሮችዎ ውስጥ ሌላ መምረጥ ይችላሉ።",
     "@publishErrorServerNotFound": {"placeholders": {"serverName": {"type": "String"}}},
     "publishErrorFileTooLarge": "የቪዲዮ ፋይሉ ለአገልጋዩ በጣም ትልቅ ነው። ቆርጠው ለማሳጠር ወይም ጥራቱን ለመቀነስ ይሞክሩ።",
+    "videoEditorOverLimitCanvas": "ከ6.3 ሰከንድ ገደብ አልፏል። ለመለጠፍ ቆርጠው አሳጥሩ",
+    "videoEditorOverLimitTimeline": "ለመለጠፍ ይህን ክፍል ይቁረጡ",
     "publishErrorServerInternalError": "የሚዲያ አገልጋዩ ({serverName}) የውስጥ ስህተት አጋጥሞታል። በቅንብሮችዎ ውስጥ ሌላ መምረጥ ይችላሉ።",
     "@publishErrorServerInternalError": {"placeholders": {"serverName": {"type": "String"}}},
     "publishErrorServerDown": "የሚዲያ አገልጋዩ ({serverName}) ለጊዜው ተቋርጧል። ከጥቂት ጊዜ በኋላ እንደገና ይሞክሩ ወይም በቅንብሮችዎ ውስጥ ሌላ ይምረጡ።",

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -10,7 +10,7 @@
     "publishErrorServerNotFound": "የሚዲያ አገልጋዩ ({serverName}) አይገኝም። በቅንብሮችዎ ውስጥ ሌላ መምረጥ ይችላሉ።",
     "@publishErrorServerNotFound": {"placeholders": {"serverName": {"type": "String"}}},
     "publishErrorFileTooLarge": "የቪዲዮ ፋይሉ ለአገልጋዩ በጣም ትልቅ ነው። ቆርጠው ለማሳጠር ወይም ጥራቱን ለመቀነስ ይሞክሩ።",
-    "videoEditorOverLimitCanvas": "ከ6.3 ሰከንድ ገደብ አልፏል። ለመለጠፍ ቆርጠው አሳጥሩ",
+    "videoEditorOverLimitCanvas": "ከ6.3 ሰከንድ ገደብ አልፏል። ለመለጠፍ ቆርጠው ያሳጥሩ",
     "videoEditorOverLimitTimeline": "ለመለጠፍ ይህን ክፍል ይቁረጡ",
     "publishErrorServerInternalError": "የሚዲያ አገልጋዩ ({serverName}) የውስጥ ስህተት አጋጥሞታል። በቅንብሮችዎ ውስጥ ሌላ መምረጥ ይችላሉ።",
     "@publishErrorServerInternalError": {"placeholders": {"serverName": {"type": "String"}}},

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -10,6 +10,8 @@
     "publishErrorServerNotFound": "خادم الوسائط ({serverName}) غير متاح. يمكنك اختيار خادم آخر من الإعدادات.",
     "@publishErrorServerNotFound": {"placeholders": {"serverName": {"type": "String"}}},
     "publishErrorFileTooLarge": "ملف الفيديو أكبر من أن يقبله الخادم. جرّب قصّه أو خفض الجودة.",
+    "videoEditorOverLimitCanvas": "تجاوزت حد 6.3 ثانية، قصّ الفيديو للنشر",
+    "videoEditorOverLimitTimeline": "قصّ هذا الجزء للنشر",
     "publishErrorServerInternalError": "واجه خادم الوسائط ({serverName}) خطأً داخليًا. يمكنك اختيار خادم آخر من الإعدادات.",
     "@publishErrorServerInternalError": {"placeholders": {"serverName": {"type": "String"}}},
     "publishErrorServerDown": "خادم الوسائط ({serverName}) متوقّف مؤقتًا. حاول مرّة أخرى بعد قليل أو اختر خادمًا آخر من الإعدادات.",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -10,6 +10,8 @@
     "publishErrorServerNotFound": "Медийният сървър ({serverName}) не е наличен. Можеш да избереш друг в настройките.",
     "@publishErrorServerNotFound": {"placeholders": {"serverName": {"type": "String"}}},
     "publishErrorFileTooLarge": "Видеофайлът е твърде голям за сървъра. Опитай да го скъсиш или да намалиш качеството.",
+    "videoEditorOverLimitCanvas": "Над лимита от 6,3 сек — скъси, за да публикуваш",
+    "videoEditorOverLimitTimeline": "Отрежи тази част, за да публикуваш",
     "publishErrorServerInternalError": "Медийният сървър ({serverName}) получи вътрешна грешка. Можеш да избереш друг в настройките.",
     "@publishErrorServerInternalError": {"placeholders": {"serverName": {"type": "String"}}},
     "publishErrorServerDown": "Медийният сървър ({serverName}) временно не работи. Опитай пак скоро или избери друг в настройките.",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -11,7 +11,7 @@
     "@publishErrorServerNotFound": {"placeholders": {"serverName": {"type": "String"}}},
     "publishErrorFileTooLarge": "Видеофайлът е твърде голям за сървъра. Опитай да го скъсиш или да намалиш качеството.",
     "videoEditorOverLimitCanvas": "Над лимита от 6,3 сек — скъси, за да публикуваш",
-    "videoEditorOverLimitTimeline": "Отрежи тази част, за да публикуваш",
+    "videoEditorOverLimitTimeline": "Отрежи, за да публикуваш",
     "publishErrorServerInternalError": "Медийният сървър ({serverName}) получи вътрешна грешка. Можеш да избереш друг в настройките.",
     "@publishErrorServerInternalError": {"placeholders": {"serverName": {"type": "String"}}},
     "publishErrorServerDown": "Медийният сървър ({serverName}) временно не работи. Опитай пак скоро или избери друг в настройките.",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -11,7 +11,7 @@
     "@publishErrorServerNotFound": {"placeholders": {"serverName": {"type": "String"}}},
     "publishErrorFileTooLarge": "Die Videodatei ist zu groß für den Server. Kürze sie oder verringere die Qualität.",
     "videoEditorOverLimitCanvas": "Über dem Limit von 6,3 s — kürze zum Posten",
-    "videoEditorOverLimitTimeline": "Schneide diesen Teil weg zum Posten",
+    "videoEditorOverLimitTimeline": "Schneide diesen Teil zum Posten weg",
     "publishErrorServerInternalError": "Beim Medienserver ({serverName}) ist ein interner Fehler aufgetreten. In den Einstellungen kannst du einen anderen auswählen.",
     "@publishErrorServerInternalError": {"placeholders": {"serverName": {"type": "String"}}},
     "publishErrorServerDown": "Der Medienserver ({serverName}) ist vorübergehend nicht erreichbar. Versuch's gleich noch einmal oder wähle in den Einstellungen einen anderen.",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -11,7 +11,7 @@
     "@publishErrorServerNotFound": {"placeholders": {"serverName": {"type": "String"}}},
     "publishErrorFileTooLarge": "Die Videodatei ist zu groß für den Server. Kürze sie oder verringere die Qualität.",
     "videoEditorOverLimitCanvas": "Über dem Limit von 6,3 s — kürze zum Posten",
-    "videoEditorOverLimitTimeline": "Schneide diesen Teil zum Posten weg",
+    "videoEditorOverLimitTimeline": "Zum Posten wegschneiden",
     "publishErrorServerInternalError": "Beim Medienserver ({serverName}) ist ein interner Fehler aufgetreten. In den Einstellungen kannst du einen anderen auswählen.",
     "@publishErrorServerInternalError": {"placeholders": {"serverName": {"type": "String"}}},
     "publishErrorServerDown": "Der Medienserver ({serverName}) ist vorübergehend nicht erreichbar. Versuch's gleich noch einmal oder wähle in den Einstellungen einen anderen.",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -10,6 +10,8 @@
     "publishErrorServerNotFound": "Der Medienserver ({serverName}) ist nicht verfügbar. In den Einstellungen kannst du einen anderen auswählen.",
     "@publishErrorServerNotFound": {"placeholders": {"serverName": {"type": "String"}}},
     "publishErrorFileTooLarge": "Die Videodatei ist zu groß für den Server. Kürze sie oder verringere die Qualität.",
+    "videoEditorOverLimitCanvas": "Über dem Limit von 6,3 s — kürze zum Posten",
+    "videoEditorOverLimitTimeline": "Schneide diesen Teil weg zum Posten",
     "publishErrorServerInternalError": "Beim Medienserver ({serverName}) ist ein interner Fehler aufgetreten. In den Einstellungen kannst du einen anderen auswählen.",
     "@publishErrorServerInternalError": {"placeholders": {"serverName": {"type": "String"}}},
     "publishErrorServerDown": "Der Medienserver ({serverName}) ist vorübergehend nicht erreichbar. Versuch's gleich noch einmal oder wähle in den Einstellungen einen anderen.",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -4528,6 +4528,8 @@
   "publishErrorServerNotFound": "The media server ({serverName}) is not available. You can choose another in your settings.",
   "@publishErrorServerNotFound": {"description": "Shown when the media (Blossom) server returns 404. {serverName} is the server host.", "placeholders": {"serverName": {"type": "String"}}},
   "publishErrorFileTooLarge": "The video file is too large for the server. Try trimming it or lowering the quality.",
+  "videoEditorOverLimitCanvas": "Over the 6.3s limit — trim to post",
+  "videoEditorOverLimitTimeline": "Trim this part out to post",
   "publishErrorServerInternalError": "The media server ({serverName}) had an internal error. You can choose another in your settings.",
   "@publishErrorServerInternalError": {"description": "Shown when the media (Blossom) server returns 500. {serverName} is the server host.", "placeholders": {"serverName": {"type": "String"}}},
   "publishErrorServerDown": "The media server ({serverName}) is temporarily down. Try again shortly or choose another in your settings.",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -10,6 +10,8 @@
     "publishErrorServerNotFound": "El servidor de medios ({serverName}) no está disponible. Podés elegir otro en tus ajustes.",
     "@publishErrorServerNotFound": {"placeholders": {"serverName": {"type": "String"}}},
     "publishErrorFileTooLarge": "El archivo de vídeo es demasiado grande para el servidor. Probá recortándolo o bajando la calidad.",
+    "videoEditorOverLimitCanvas": "Supera el límite de 6,3 s: recortá para publicar",
+    "videoEditorOverLimitTimeline": "Recortá esta parte para publicar",
     "publishErrorServerInternalError": "El servidor de medios ({serverName}) tuvo un error interno. Podés elegir otro en tus ajustes.",
     "@publishErrorServerInternalError": {"placeholders": {"serverName": {"type": "String"}}},
     "publishErrorServerDown": "El servidor de medios ({serverName}) está caído temporalmente. Intentá de nuevo en un rato o elegí otro en tus ajustes.",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -11,7 +11,7 @@
     "@publishErrorServerNotFound": {"placeholders": {"serverName": {"type": "String"}}},
     "publishErrorFileTooLarge": "Masyadong malaki ang video file para sa server. Subukang i-trim ito o babaan ang quality.",
     "videoEditorOverLimitCanvas": "Lampas sa 6.3s na limit — i-trim para makapag-post",
-    "videoEditorOverLimitTimeline": "I-trim ang bahaging ito para maka-post",
+    "videoEditorOverLimitTimeline": "I-trim ang bahaging ito para makapag-post",
     "publishErrorServerInternalError": "Nagka-internal error ang media server ({serverName}). Puwede kang pumili ng iba sa iyong settings.",
     "@publishErrorServerInternalError": {"placeholders": {"serverName": {"type": "String"}}},
     "publishErrorServerDown": "Pansamantalang down ang media server ({serverName}). Subukan ulit saglit o pumili ng iba sa iyong settings.",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -10,6 +10,8 @@
     "publishErrorServerNotFound": "Hindi available ang media server ({serverName}). Puwede kang pumili ng iba sa iyong settings.",
     "@publishErrorServerNotFound": {"placeholders": {"serverName": {"type": "String"}}},
     "publishErrorFileTooLarge": "Masyadong malaki ang video file para sa server. Subukang i-trim ito o babaan ang quality.",
+    "videoEditorOverLimitCanvas": "Lampas sa 6.3s na limit — i-trim para makapag-post",
+    "videoEditorOverLimitTimeline": "I-trim ang bahaging ito para maka-post",
     "publishErrorServerInternalError": "Nagka-internal error ang media server ({serverName}). Puwede kang pumili ng iba sa iyong settings.",
     "@publishErrorServerInternalError": {"placeholders": {"serverName": {"type": "String"}}},
     "publishErrorServerDown": "Pansamantalang down ang media server ({serverName}). Subukan ulit saglit o pumili ng iba sa iyong settings.",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -11,7 +11,7 @@
     "@publishErrorServerNotFound": {"placeholders": {"serverName": {"type": "String"}}},
     "publishErrorFileTooLarge": "Masyadong malaki ang video file para sa server. Subukang i-trim ito o babaan ang quality.",
     "videoEditorOverLimitCanvas": "Lampas sa 6.3s na limit — i-trim para makapag-post",
-    "videoEditorOverLimitTimeline": "I-trim ang bahaging ito para makapag-post",
+    "videoEditorOverLimitTimeline": "I-trim ito para makapag-post",
     "publishErrorServerInternalError": "Nagka-internal error ang media server ({serverName}). Puwede kang pumili ng iba sa iyong settings.",
     "@publishErrorServerInternalError": {"placeholders": {"serverName": {"type": "String"}}},
     "publishErrorServerDown": "Pansamantalang down ang media server ({serverName}). Subukan ulit saglit o pumili ng iba sa iyong settings.",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -10,6 +10,8 @@
     "publishErrorServerNotFound": "Le serveur multimédia ({serverName}) n'est pas disponible. Tu peux en choisir un autre dans tes réglages.",
     "@publishErrorServerNotFound": {"placeholders": {"serverName": {"type": "String"}}},
     "publishErrorFileTooLarge": "Le fichier vidéo est trop volumineux pour le serveur. Essaie de le raccourcir ou de baisser la qualité.",
+    "videoEditorOverLimitCanvas": "Au-delà de la limite de 6,3 s — raccourcis pour publier",
+    "videoEditorOverLimitTimeline": "Coupe cette partie pour publier",
     "publishErrorServerInternalError": "Le serveur multimédia ({serverName}) a rencontré une erreur interne. Tu peux en choisir un autre dans tes réglages.",
     "@publishErrorServerInternalError": {"placeholders": {"serverName": {"type": "String"}}},
     "publishErrorServerDown": "Le serveur multimédia ({serverName}) est temporairement hors service. Réessaie bientôt ou choisis-en un autre dans tes réglages.",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -10,6 +10,8 @@
     "publishErrorServerNotFound": "Server media ({serverName}) tidak tersedia. Kamu bisa memilih yang lain di pengaturan.",
     "@publishErrorServerNotFound": {"placeholders": {"serverName": {"type": "String"}}},
     "publishErrorFileTooLarge": "File video terlalu besar untuk server. Coba pangkas videonya atau turunkan kualitasnya.",
+    "videoEditorOverLimitCanvas": "Melebihi batas 6,3 dtk — pangkas untuk posting",
+    "videoEditorOverLimitTimeline": "Pangkas bagian ini untuk posting",
     "publishErrorServerInternalError": "Server media ({serverName}) mengalami kesalahan internal. Kamu bisa memilih yang lain di pengaturan.",
     "@publishErrorServerInternalError": {"placeholders": {"serverName": {"type": "String"}}},
     "publishErrorServerDown": "Server media ({serverName}) sedang tidak aktif sementara. Coba lagi sebentar lagi atau pilih yang lain di pengaturan.",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -11,7 +11,7 @@
     "@publishErrorServerNotFound": {"placeholders": {"serverName": {"type": "String"}}},
     "publishErrorFileTooLarge": "File video terlalu besar untuk server. Coba pangkas videonya atau turunkan kualitasnya.",
     "videoEditorOverLimitCanvas": "Melebihi batas 6,3 dtk — pangkas untuk posting",
-    "videoEditorOverLimitTimeline": "Pangkas bagian ini untuk posting",
+    "videoEditorOverLimitTimeline": "Pangkas ini untuk posting",
     "publishErrorServerInternalError": "Server media ({serverName}) mengalami kesalahan internal. Kamu bisa memilih yang lain di pengaturan.",
     "@publishErrorServerInternalError": {"placeholders": {"serverName": {"type": "String"}}},
     "publishErrorServerDown": "Server media ({serverName}) sedang tidak aktif sementara. Coba lagi sebentar lagi atau pilih yang lain di pengaturan.",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -10,6 +10,8 @@
   "publishErrorServerNotFound": "Il server multimediale ({serverName}) non è disponibile. Puoi sceglierne un altro nelle impostazioni.",
   "@publishErrorServerNotFound": {"placeholders": {"serverName": {"type": "String"}}},
   "publishErrorFileTooLarge": "Il file video è troppo grande per il server. Prova a tagliarlo o ad abbassare la qualità.",
+  "videoEditorOverLimitCanvas": "Oltre il limite di 6,3 s — taglia per pubblicare",
+  "videoEditorOverLimitTimeline": "Taglia via questa parte per pubblicare",
   "publishErrorServerInternalError": "Il server multimediale ({serverName}) ha avuto un errore interno. Puoi sceglierne un altro nelle impostazioni.",
   "@publishErrorServerInternalError": {"placeholders": {"serverName": {"type": "String"}}},
   "publishErrorServerDown": "Il server multimediale ({serverName}) è temporaneamente fuori uso. Riprova tra poco o scegline un altro nelle impostazioni.",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -11,7 +11,7 @@
   "@publishErrorServerNotFound": {"placeholders": {"serverName": {"type": "String"}}},
   "publishErrorFileTooLarge": "Il file video è troppo grande per il server. Prova a tagliarlo o ad abbassare la qualità.",
   "videoEditorOverLimitCanvas": "Oltre il limite di 6,3 s — taglia per pubblicare",
-  "videoEditorOverLimitTimeline": "Taglia via questa parte per pubblicare",
+  "videoEditorOverLimitTimeline": "Taglia via per pubblicare",
   "publishErrorServerInternalError": "Il server multimediale ({serverName}) ha avuto un errore interno. Puoi sceglierne un altro nelle impostazioni.",
   "@publishErrorServerInternalError": {"placeholders": {"serverName": {"type": "String"}}},
   "publishErrorServerDown": "Il server multimediale ({serverName}) è temporaneamente fuori uso. Riprova tra poco o scegline un altro nelle impostazioni.",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -10,7 +10,7 @@
     "publishErrorServerNotFound": "メディアサーバー（{serverName}）が利用できないよ。設定で別のサーバーを選べるよ。",
     "@publishErrorServerNotFound": {"placeholders": {"serverName": {"type": "String"}}},
     "publishErrorFileTooLarge": "動画ファイルがサーバーには大きすぎるよ。トリミングするか、画質を下げて試してみて。",
-    "videoEditorOverLimitCanvas": "6.3秒の上限を超えてるよ。投稿するにはトリミングしてね",
+    "videoEditorOverLimitCanvas": "6.3秒の上限を超えてるよ。投稿するにはトリムしてね",
     "videoEditorOverLimitTimeline": "投稿するにはこの部分をカットしてね",
     "publishErrorServerInternalError": "メディアサーバー（{serverName}）で内部エラーが起きたよ。設定で別のサーバーを選べるよ。",
     "@publishErrorServerInternalError": {"placeholders": {"serverName": {"type": "String"}}},

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -11,7 +11,7 @@
     "@publishErrorServerNotFound": {"placeholders": {"serverName": {"type": "String"}}},
     "publishErrorFileTooLarge": "動画ファイルがサーバーには大きすぎるよ。トリミングするか、画質を下げて試してみて。",
     "videoEditorOverLimitCanvas": "6.3秒の上限を超えてるよ。投稿するにはトリムしてね",
-    "videoEditorOverLimitTimeline": "投稿するにはこの部分をカットしてね",
+    "videoEditorOverLimitTimeline": "この部分をカットして投稿",
     "publishErrorServerInternalError": "メディアサーバー（{serverName}）で内部エラーが起きたよ。設定で別のサーバーを選べるよ。",
     "@publishErrorServerInternalError": {"placeholders": {"serverName": {"type": "String"}}},
     "publishErrorServerDown": "メディアサーバー（{serverName}）が一時的にダウンしてるよ。少し待ってからもう一回試すか、設定で別のサーバーを選んでみて。",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -10,6 +10,8 @@
     "publishErrorServerNotFound": "メディアサーバー（{serverName}）が利用できないよ。設定で別のサーバーを選べるよ。",
     "@publishErrorServerNotFound": {"placeholders": {"serverName": {"type": "String"}}},
     "publishErrorFileTooLarge": "動画ファイルがサーバーには大きすぎるよ。トリミングするか、画質を下げて試してみて。",
+    "videoEditorOverLimitCanvas": "6.3秒の上限を超えてるよ。投稿するにはトリミングしてね",
+    "videoEditorOverLimitTimeline": "投稿するにはこの部分をカットしてね",
     "publishErrorServerInternalError": "メディアサーバー（{serverName}）で内部エラーが起きたよ。設定で別のサーバーを選べるよ。",
     "@publishErrorServerInternalError": {"placeholders": {"serverName": {"type": "String"}}},
     "publishErrorServerDown": "メディアサーバー（{serverName}）が一時的にダウンしてるよ。少し待ってからもう一回試すか、設定で別のサーバーを選んでみて。",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -10,6 +10,8 @@
     "publishErrorServerNotFound": "미디어 서버({serverName})를 사용할 수 없어요. 설정에서 다른 서버를 고를 수 있어요.",
     "@publishErrorServerNotFound": {"placeholders": {"serverName": {"type": "String"}}},
     "publishErrorFileTooLarge": "영상 파일이 서버에 올리기엔 너무 커요. 영상을 자르거나 화질을 낮춰서 시도해보세요.",
+    "videoEditorOverLimitCanvas": "6.3초 제한을 넘었어요. 올리려면 잘라내세요",
+    "videoEditorOverLimitTimeline": "올리려면 이 부분을 잘라내세요",
     "publishErrorServerInternalError": "미디어 서버({serverName})에 내부 오류가 발생했어요. 설정에서 다른 서버를 고를 수 있어요.",
     "@publishErrorServerInternalError": {"placeholders": {"serverName": {"type": "String"}}},
     "publishErrorServerDown": "미디어 서버({serverName})가 일시적으로 다운됐어요. 잠시 후 다시 시도하거나 설정에서 다른 서버를 골라보세요.",

--- a/mobile/lib/l10n/app_ms.arb
+++ b/mobile/lib/l10n/app_ms.arb
@@ -4281,6 +4281,8 @@
     }
   },
   "publishErrorFileTooLarge": "Fail video terlalu besar untuk pelayan. Cuba memangkasnya atau mengurangkan kualiti.",
+  "videoEditorOverLimitCanvas": "Melebihi had 6.3s — pangkas untuk menyiarkan",
+  "videoEditorOverLimitTimeline": "Pangkas bahagian ini untuk menyiarkan",
   "publishErrorServerInternalError": "Pelayan media ({serverName}) mengalami ralat dalaman. Anda boleh memilih yang lain dalam tetapan anda.",
   "@publishErrorServerInternalError": {
     "description": "Shown when the media (Blossom) server returns 500. {serverName} is the server host.",

--- a/mobile/lib/l10n/app_ms.arb
+++ b/mobile/lib/l10n/app_ms.arb
@@ -4282,7 +4282,7 @@
   },
   "publishErrorFileTooLarge": "Fail video terlalu besar untuk pelayan. Cuba memangkasnya atau mengurangkan kualiti.",
   "videoEditorOverLimitCanvas": "Melebihi had 6.3s — pangkas untuk disiarkan",
-  "videoEditorOverLimitTimeline": "Pangkas bahagian ini untuk disiarkan",
+  "videoEditorOverLimitTimeline": "Pangkas ini untuk disiarkan",
   "publishErrorServerInternalError": "Pelayan media ({serverName}) mengalami ralat dalaman. Anda boleh memilih yang lain dalam tetapan anda.",
   "@publishErrorServerInternalError": {
     "description": "Shown when the media (Blossom) server returns 500. {serverName} is the server host.",

--- a/mobile/lib/l10n/app_ms.arb
+++ b/mobile/lib/l10n/app_ms.arb
@@ -4281,8 +4281,8 @@
     }
   },
   "publishErrorFileTooLarge": "Fail video terlalu besar untuk pelayan. Cuba memangkasnya atau mengurangkan kualiti.",
-  "videoEditorOverLimitCanvas": "Melebihi had 6.3s — pangkas untuk menyiarkan",
-  "videoEditorOverLimitTimeline": "Pangkas bahagian ini untuk menyiarkan",
+  "videoEditorOverLimitCanvas": "Melebihi had 6.3s — pangkas untuk disiarkan",
+  "videoEditorOverLimitTimeline": "Pangkas bahagian ini untuk disiarkan",
   "publishErrorServerInternalError": "Pelayan media ({serverName}) mengalami ralat dalaman. Anda boleh memilih yang lain dalam tetapan anda.",
   "@publishErrorServerInternalError": {
     "description": "Shown when the media (Blossom) server returns 500. {serverName} is the server host.",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -10,6 +10,8 @@
     "publishErrorServerNotFound": "De mediaserver ({serverName}) is niet beschikbaar. Je kunt een andere kiezen in je instellingen.",
     "@publishErrorServerNotFound": {"placeholders": {"serverName": {"type": "String"}}},
     "publishErrorFileTooLarge": "Het videobestand is te groot voor de server. Knip het in of verlaag de kwaliteit.",
+    "videoEditorOverLimitCanvas": "Boven de limiet van 6,3 s — knip in om te posten",
+    "videoEditorOverLimitTimeline": "Knip dit stuk eruit om te posten",
     "publishErrorServerInternalError": "De mediaserver ({serverName}) had een interne fout. Je kunt een andere kiezen in je instellingen.",
     "@publishErrorServerInternalError": {"placeholders": {"serverName": {"type": "String"}}},
     "publishErrorServerDown": "De mediaserver ({serverName}) is tijdelijk uit de lucht. Probeer het zo opnieuw of kies een andere in je instellingen.",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -10,7 +10,7 @@
     "publishErrorServerNotFound": "De mediaserver ({serverName}) is niet beschikbaar. Je kunt een andere kiezen in je instellingen.",
     "@publishErrorServerNotFound": {"placeholders": {"serverName": {"type": "String"}}},
     "publishErrorFileTooLarge": "Het videobestand is te groot voor de server. Knip het in of verlaag de kwaliteit.",
-    "videoEditorOverLimitCanvas": "Boven de limiet van 6,3 s — knip in om te posten",
+    "videoEditorOverLimitCanvas": "Boven de limiet van 6,3 s — knip het in om te posten",
     "videoEditorOverLimitTimeline": "Knip dit stuk eruit om te posten",
     "publishErrorServerInternalError": "De mediaserver ({serverName}) had een interne fout. Je kunt een andere kiezen in je instellingen.",
     "@publishErrorServerInternalError": {"placeholders": {"serverName": {"type": "String"}}},

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -10,6 +10,8 @@
     "publishErrorServerNotFound": "Serwer multimediów ({serverName}) jest niedostępny. Możesz wybrać inny w ustawieniach.",
     "@publishErrorServerNotFound": {"placeholders": {"serverName": {"type": "String"}}},
     "publishErrorFileTooLarge": "Plik wideo jest za duży dla serwera. Spróbuj go przyciąć lub obniżyć jakość.",
+    "videoEditorOverLimitCanvas": "Ponad limit 6,3 s — przytnij, żeby opublikować",
+    "videoEditorOverLimitTimeline": "Wytnij tę część, żeby opublikować",
     "publishErrorServerInternalError": "Serwer multimediów ({serverName}) napotkał błąd wewnętrzny. Możesz wybrać inny w ustawieniach.",
     "@publishErrorServerInternalError": {"placeholders": {"serverName": {"type": "String"}}},
     "publishErrorServerDown": "Serwer multimediów ({serverName}) jest chwilowo niedostępny. Spróbuj ponownie za moment lub wybierz inny w ustawieniach.",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -11,7 +11,7 @@
     "@publishErrorServerNotFound": {"placeholders": {"serverName": {"type": "String"}}},
     "publishErrorFileTooLarge": "Plik wideo jest za duży dla serwera. Spróbuj go przyciąć lub obniżyć jakość.",
     "videoEditorOverLimitCanvas": "Ponad limit 6,3 s — przytnij, żeby opublikować",
-    "videoEditorOverLimitTimeline": "Wytnij tę część, żeby opublikować",
+    "videoEditorOverLimitTimeline": "Wytnij to, żeby opublikować",
     "publishErrorServerInternalError": "Serwer multimediów ({serverName}) napotkał błąd wewnętrzny. Możesz wybrać inny w ustawieniach.",
     "@publishErrorServerInternalError": {"placeholders": {"serverName": {"type": "String"}}},
     "publishErrorServerDown": "Serwer multimediów ({serverName}) jest chwilowo niedostępny. Spróbuj ponownie za moment lub wybierz inny w ustawieniach.",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -10,6 +10,8 @@
     "publishErrorServerNotFound": "O servidor de mídia ({serverName}) não está disponível. Você pode escolher outro nas configurações.",
     "@publishErrorServerNotFound": {"placeholders": {"serverName": {"type": "String"}}},
     "publishErrorFileTooLarge": "O arquivo de vídeo é grande demais para o servidor. Tente cortá-lo ou reduzir a qualidade.",
+    "videoEditorOverLimitCanvas": "Acima do limite de 6,3 s — corte para publicar",
+    "videoEditorOverLimitTimeline": "Corte esta parte para publicar",
     "publishErrorServerInternalError": "O servidor de mídia ({serverName}) teve um erro interno. Você pode escolher outro nas configurações.",
     "@publishErrorServerInternalError": {"placeholders": {"serverName": {"type": "String"}}},
     "publishErrorServerDown": "O servidor de mídia ({serverName}) está temporariamente fora do ar. Tente novamente em breve ou escolha outro nas configurações.",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -10,6 +10,8 @@
     "publishErrorServerNotFound": "Serverul media ({serverName}) nu este disponibil. Poți alege altul în setări.",
     "@publishErrorServerNotFound": {"placeholders": {"serverName": {"type": "String"}}},
     "publishErrorFileTooLarge": "Fișierul video este prea mare pentru server. Încearcă să-l scurtezi sau să reduci calitatea.",
+    "videoEditorOverLimitCanvas": "Peste limita de 6,3 s — scurtează ca să postezi",
+    "videoEditorOverLimitTimeline": "Taie această parte ca să postezi",
     "publishErrorServerInternalError": "Serverul media ({serverName}) a avut o eroare internă. Poți alege altul în setări.",
     "@publishErrorServerInternalError": {"placeholders": {"serverName": {"type": "String"}}},
     "publishErrorServerDown": "Serverul media ({serverName}) este temporar indisponibil. Încearcă din nou în scurt timp sau alege altul în setări.",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -10,6 +10,8 @@
     "publishErrorServerNotFound": "Mediaservern ({serverName}) är inte tillgänglig. Du kan välja en annan i dina inställningar.",
     "@publishErrorServerNotFound": {"placeholders": {"serverName": {"type": "String"}}},
     "publishErrorFileTooLarge": "Videofilen är för stor för servern. Prova att korta ner den eller sänka kvaliteten.",
+    "videoEditorOverLimitCanvas": "Över gränsen på 6,3 s — korta ner för att posta",
+    "videoEditorOverLimitTimeline": "Klipp bort den här delen för att posta",
     "publishErrorServerInternalError": "Mediaservern ({serverName}) råkade ut för ett internt fel. Du kan välja en annan i dina inställningar.",
     "@publishErrorServerInternalError": {"placeholders": {"serverName": {"type": "String"}}},
     "publishErrorServerDown": "Mediaservern ({serverName}) är tillfälligt nere. Försök igen snart eller välj en annan i dina inställningar.",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -11,7 +11,7 @@
     "@publishErrorServerNotFound": {"placeholders": {"serverName": {"type": "String"}}},
     "publishErrorFileTooLarge": "Videofilen är för stor för servern. Prova att korta ner den eller sänka kvaliteten.",
     "videoEditorOverLimitCanvas": "Över gränsen på 6,3 s — korta ner för att posta",
-    "videoEditorOverLimitTimeline": "Klipp bort den här delen för att posta",
+    "videoEditorOverLimitTimeline": "Trimma bort för att posta",
     "publishErrorServerInternalError": "Mediaservern ({serverName}) råkade ut för ett internt fel. Du kan välja en annan i dina inställningar.",
     "@publishErrorServerInternalError": {"placeholders": {"serverName": {"type": "String"}}},
     "publishErrorServerDown": "Mediaservern ({serverName}) är tillfälligt nere. Försök igen snart eller välj en annan i dina inställningar.",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -10,6 +10,8 @@
     "publishErrorServerNotFound": "Medya sunucusu ({serverName}) kullanılamıyor. Ayarlarından başka birini seçebilirsin.",
     "@publishErrorServerNotFound": {"placeholders": {"serverName": {"type": "String"}}},
     "publishErrorFileTooLarge": "Video dosyası sunucu için fazla büyük. Kırpmayı ya da kaliteyi düşürmeyi dene.",
+    "videoEditorOverLimitCanvas": "6,3 sn sınırını aştın — paylaşmak için kırp",
+    "videoEditorOverLimitTimeline": "Paylaşmak için bu kısmı kırp",
     "publishErrorServerInternalError": "Medya sunucusunda ({serverName}) dahili bir hata oluştu. Ayarlarından başka birini seçebilirsin.",
     "@publishErrorServerInternalError": {"placeholders": {"serverName": {"type": "String"}}},
     "publishErrorServerDown": "Medya sunucusu ({serverName}) geçici olarak çalışmıyor. Birazdan tekrar dene ya da ayarlarından başka birini seç.",

--- a/mobile/lib/l10n/app_ur.arb
+++ b/mobile/lib/l10n/app_ur.arb
@@ -4281,7 +4281,7 @@
     }
   },
   "publishErrorFileTooLarge": "ویڈیو فائل سرور کے لیے بہت بڑی ہے۔ اسے چھوٹا کریں یا کوالٹی کم کر کے دیکھیں۔",
-  "videoEditorOverLimitCanvas": "6.3 سیکنڈ کی حد سے زیادہ۔ پوسٹ کرنے کے لیے چھوٹا کریں",
+  "videoEditorOverLimitCanvas": "6.3 سیکنڈ کی حد سے زیادہ ہے۔ پوسٹ کرنے کے لیے چھوٹا کریں",
   "videoEditorOverLimitTimeline": "پوسٹ کرنے کے لیے یہ حصہ نکالیں",
   "publishErrorServerInternalError": "میڈیا سرور ({serverName}) میں اندرونی خرابی آئی۔ آپ اپنی ترتیبات میں کوئی اور منتخب کر سکتے ہیں۔",
   "@publishErrorServerInternalError": {

--- a/mobile/lib/l10n/app_ur.arb
+++ b/mobile/lib/l10n/app_ur.arb
@@ -4282,7 +4282,7 @@
   },
   "publishErrorFileTooLarge": "ویڈیو فائل سرور کے لیے بہت بڑی ہے۔ اسے چھوٹا کریں یا کوالٹی کم کر کے دیکھیں۔",
   "videoEditorOverLimitCanvas": "6.3 سیکنڈ کی حد سے زیادہ ہے۔ پوسٹ کرنے کے لیے چھوٹا کریں",
-  "videoEditorOverLimitTimeline": "پوسٹ کرنے کے لیے یہ حصہ نکالیں",
+  "videoEditorOverLimitTimeline": "پوسٹ کرنے کے لیے یہ نکالیں",
   "publishErrorServerInternalError": "میڈیا سرور ({serverName}) میں اندرونی خرابی آئی۔ آپ اپنی ترتیبات میں کوئی اور منتخب کر سکتے ہیں۔",
   "@publishErrorServerInternalError": {
     "description": "Shown when the media (Blossom) server returns 500. {serverName} is the server host.",

--- a/mobile/lib/l10n/app_ur.arb
+++ b/mobile/lib/l10n/app_ur.arb
@@ -4281,6 +4281,8 @@
     }
   },
   "publishErrorFileTooLarge": "ویڈیو فائل سرور کے لیے بہت بڑی ہے۔ اسے چھوٹا کریں یا کوالٹی کم کر کے دیکھیں۔",
+  "videoEditorOverLimitCanvas": "6.3 سیکنڈ کی حد سے زیادہ۔ پوسٹ کرنے کے لیے چھوٹا کریں",
+  "videoEditorOverLimitTimeline": "پوسٹ کرنے کے لیے یہ حصہ نکالیں",
   "publishErrorServerInternalError": "میڈیا سرور ({serverName}) میں اندرونی خرابی آئی۔ آپ اپنی ترتیبات میں کوئی اور منتخب کر سکتے ہیں۔",
   "@publishErrorServerInternalError": {
     "description": "Shown when the media (Blossom) server returns 500. {serverName} is the server host.",

--- a/mobile/lib/l10n/app_vi.arb
+++ b/mobile/lib/l10n/app_vi.arb
@@ -4281,6 +4281,8 @@
     }
   },
   "publishErrorFileTooLarge": "Tệp video quá lớn so với máy chủ. Thử cắt ngắn hoặc giảm chất lượng.",
+  "videoEditorOverLimitCanvas": "Vượt giới hạn 6,3 giây — cắt ngắn để đăng",
+  "videoEditorOverLimitTimeline": "Cắt bỏ phần này để đăng",
   "publishErrorServerInternalError": "Máy chủ media ({serverName}) gặp lỗi nội bộ. Bạn có thể chọn máy chủ khác trong cài đặt.",
   "@publishErrorServerInternalError": {
     "description": "Shown when the media (Blossom) server returns 500. {serverName} is the server host.",

--- a/mobile/lib/l10n/app_zh.arb
+++ b/mobile/lib/l10n/app_zh.arb
@@ -4281,6 +4281,8 @@
     }
   },
   "publishErrorFileTooLarge": "视频文件对服务器来说太大了。试试剪辑一下或降低画质。",
+  "videoEditorOverLimitCanvas": "超过 6.3 秒上限，剪短才能发布",
+  "videoEditorOverLimitTimeline": "剪掉这段才能发布",
   "publishErrorServerInternalError": "媒体服务器（{serverName}）内部出错。你可以在设置中换一个。",
   "@publishErrorServerInternalError": {
     "description": "Shown when the media (Blossom) server returns 500. {serverName} is the server host.",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -12974,6 +12974,18 @@ abstract class AppLocalizations {
   /// **'The video file is too large for the server. Try trimming it or lowering the quality.'**
   String get publishErrorFileTooLarge;
 
+  /// No description provided for @videoEditorOverLimitCanvas.
+  ///
+  /// In en, this message translates to:
+  /// **'Over the 6.3s limit — trim to post'**
+  String get videoEditorOverLimitCanvas;
+
+  /// No description provided for @videoEditorOverLimitTimeline.
+  ///
+  /// In en, this message translates to:
+  /// **'Trim this part out to post'**
+  String get videoEditorOverLimitTimeline;
+
   /// Shown when the media (Blossom) server returns 500. {serverName} is the server host.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -7322,7 +7322,7 @@ class AppLocalizationsAm extends AppLocalizations {
 
   @override
   String get videoEditorOverLimitCanvas =>
-      'ከ6.3 ሰከንድ ገደብ አልፏል። ለመለጠፍ ቆርጠው አሳጥሩ';
+      'ከ6.3 ሰከንድ ገደብ አልፏል። ለመለጠፍ ቆርጠው ያሳጥሩ';
 
   @override
   String get videoEditorOverLimitTimeline => 'ለመለጠፍ ይህን ክፍል ይቁረጡ';

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -7321,6 +7321,12 @@ class AppLocalizationsAm extends AppLocalizations {
       'የቪዲዮ ፋይሉ ለአገልጋዩ በጣም ትልቅ ነው። ቆርጠው ለማሳጠር ወይም ጥራቱን ለመቀነስ ይሞክሩ።';
 
   @override
+  String get videoEditorOverLimitCanvas => 'Over the 6.3s limit — trim to post';
+
+  @override
+  String get videoEditorOverLimitTimeline => 'Trim this part out to post';
+
+  @override
   String publishErrorServerInternalError(String serverName) {
     return 'የሚዲያ አገልጋዩ ($serverName) የውስጥ ስህተት አጋጥሞታል። በቅንብሮችዎ ውስጥ ሌላ መምረጥ ይችላሉ።';
   }

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -7321,10 +7321,11 @@ class AppLocalizationsAm extends AppLocalizations {
       'የቪዲዮ ፋይሉ ለአገልጋዩ በጣም ትልቅ ነው። ቆርጠው ለማሳጠር ወይም ጥራቱን ለመቀነስ ይሞክሩ።';
 
   @override
-  String get videoEditorOverLimitCanvas => 'Over the 6.3s limit — trim to post';
+  String get videoEditorOverLimitCanvas =>
+      'ከ6.3 ሰከንድ ገደብ አልፏል። ለመለጠፍ ቆርጠው አሳጥሩ';
 
   @override
-  String get videoEditorOverLimitTimeline => 'Trim this part out to post';
+  String get videoEditorOverLimitTimeline => 'ለመለጠፍ ይህን ክፍል ይቁረጡ';
 
   @override
   String publishErrorServerInternalError(String serverName) {

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -7429,10 +7429,11 @@ class AppLocalizationsAr extends AppLocalizations {
       'ملف الفيديو أكبر من أن يقبله الخادم. جرّب قصّه أو خفض الجودة.';
 
   @override
-  String get videoEditorOverLimitCanvas => 'Over the 6.3s limit — trim to post';
+  String get videoEditorOverLimitCanvas =>
+      'تجاوزت حد 6.3 ثانية، قصّ الفيديو للنشر';
 
   @override
-  String get videoEditorOverLimitTimeline => 'Trim this part out to post';
+  String get videoEditorOverLimitTimeline => 'قصّ هذا الجزء للنشر';
 
   @override
   String publishErrorServerInternalError(String serverName) {

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -7429,6 +7429,12 @@ class AppLocalizationsAr extends AppLocalizations {
       'ملف الفيديو أكبر من أن يقبله الخادم. جرّب قصّه أو خفض الجودة.';
 
   @override
+  String get videoEditorOverLimitCanvas => 'Over the 6.3s limit — trim to post';
+
+  @override
+  String get videoEditorOverLimitTimeline => 'Trim this part out to post';
+
+  @override
   String publishErrorServerInternalError(String serverName) {
     return 'واجه خادم الوسائط ($serverName) خطأً داخليًا. يمكنك اختيار خادم آخر من الإعدادات.';
   }

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -7555,6 +7555,12 @@ class AppLocalizationsBg extends AppLocalizations {
       'Видеофайлът е твърде голям за сървъра. Опитай да го скъсиш или да намалиш качеството.';
 
   @override
+  String get videoEditorOverLimitCanvas => 'Over the 6.3s limit — trim to post';
+
+  @override
+  String get videoEditorOverLimitTimeline => 'Trim this part out to post';
+
+  @override
   String publishErrorServerInternalError(String serverName) {
     return 'Медийният сървър ($serverName) получи вътрешна грешка. Можеш да избереш друг в настройките.';
   }

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -7559,8 +7559,7 @@ class AppLocalizationsBg extends AppLocalizations {
       'Над лимита от 6,3 сек — скъси, за да публикуваш';
 
   @override
-  String get videoEditorOverLimitTimeline =>
-      'Отрежи тази част, за да публикуваш';
+  String get videoEditorOverLimitTimeline => 'Отрежи, за да публикуваш';
 
   @override
   String publishErrorServerInternalError(String serverName) {

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -7555,10 +7555,12 @@ class AppLocalizationsBg extends AppLocalizations {
       'Видеофайлът е твърде голям за сървъра. Опитай да го скъсиш или да намалиш качеството.';
 
   @override
-  String get videoEditorOverLimitCanvas => 'Over the 6.3s limit — trim to post';
+  String get videoEditorOverLimitCanvas =>
+      'Над лимита от 6,3 сек — скъси, за да публикуваш';
 
   @override
-  String get videoEditorOverLimitTimeline => 'Trim this part out to post';
+  String get videoEditorOverLimitTimeline =>
+      'Отрежи тази част, за да публикуваш';
 
   @override
   String publishErrorServerInternalError(String serverName) {

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -7579,6 +7579,12 @@ class AppLocalizationsDe extends AppLocalizations {
       'Die Videodatei ist zu groß für den Server. Kürze sie oder verringere die Qualität.';
 
   @override
+  String get videoEditorOverLimitCanvas => 'Over the 6.3s limit — trim to post';
+
+  @override
+  String get videoEditorOverLimitTimeline => 'Trim this part out to post';
+
+  @override
   String publishErrorServerInternalError(String serverName) {
     return 'Beim Medienserver ($serverName) ist ein interner Fehler aufgetreten. In den Einstellungen kannst du einen anderen auswählen.';
   }

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -7583,8 +7583,7 @@ class AppLocalizationsDe extends AppLocalizations {
       'Über dem Limit von 6,3 s — kürze zum Posten';
 
   @override
-  String get videoEditorOverLimitTimeline =>
-      'Schneide diesen Teil zum Posten weg';
+  String get videoEditorOverLimitTimeline => 'Zum Posten wegschneiden';
 
   @override
   String publishErrorServerInternalError(String serverName) {

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -7584,7 +7584,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get videoEditorOverLimitTimeline =>
-      'Schneide diesen Teil weg zum Posten';
+      'Schneide diesen Teil zum Posten weg';
 
   @override
   String publishErrorServerInternalError(String serverName) {

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -7579,10 +7579,12 @@ class AppLocalizationsDe extends AppLocalizations {
       'Die Videodatei ist zu groß für den Server. Kürze sie oder verringere die Qualität.';
 
   @override
-  String get videoEditorOverLimitCanvas => 'Over the 6.3s limit — trim to post';
+  String get videoEditorOverLimitCanvas =>
+      'Über dem Limit von 6,3 s — kürze zum Posten';
 
   @override
-  String get videoEditorOverLimitTimeline => 'Trim this part out to post';
+  String get videoEditorOverLimitTimeline =>
+      'Schneide diesen Teil weg zum Posten';
 
   @override
   String publishErrorServerInternalError(String serverName) {

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -7468,6 +7468,12 @@ class AppLocalizationsEn extends AppLocalizations {
       'The video file is too large for the server. Try trimming it or lowering the quality.';
 
   @override
+  String get videoEditorOverLimitCanvas => 'Over the 6.3s limit — trim to post';
+
+  @override
+  String get videoEditorOverLimitTimeline => 'Trim this part out to post';
+
+  @override
   String publishErrorServerInternalError(String serverName) {
     return 'The media server ($serverName) had an internal error. You can choose another in your settings.';
   }

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -7555,6 +7555,12 @@ class AppLocalizationsEs extends AppLocalizations {
       'El archivo de vídeo es demasiado grande para el servidor. Probá recortándolo o bajando la calidad.';
 
   @override
+  String get videoEditorOverLimitCanvas => 'Over the 6.3s limit — trim to post';
+
+  @override
+  String get videoEditorOverLimitTimeline => 'Trim this part out to post';
+
+  @override
   String publishErrorServerInternalError(String serverName) {
     return 'El servidor de medios ($serverName) tuvo un error interno. Podés elegir otro en tus ajustes.';
   }

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -7555,10 +7555,11 @@ class AppLocalizationsEs extends AppLocalizations {
       'El archivo de vídeo es demasiado grande para el servidor. Probá recortándolo o bajando la calidad.';
 
   @override
-  String get videoEditorOverLimitCanvas => 'Over the 6.3s limit — trim to post';
+  String get videoEditorOverLimitCanvas =>
+      'Supera el límite de 6,3 s: recortá para publicar';
 
   @override
-  String get videoEditorOverLimitTimeline => 'Trim this part out to post';
+  String get videoEditorOverLimitTimeline => 'Recortá esta parte para publicar';
 
   @override
   String publishErrorServerInternalError(String serverName) {

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -7575,10 +7575,12 @@ class AppLocalizationsFil extends AppLocalizations {
       'Masyadong malaki ang video file para sa server. Subukang i-trim ito o babaan ang quality.';
 
   @override
-  String get videoEditorOverLimitCanvas => 'Over the 6.3s limit — trim to post';
+  String get videoEditorOverLimitCanvas =>
+      'Lampas sa 6.3s na limit — i-trim para makapag-post';
 
   @override
-  String get videoEditorOverLimitTimeline => 'Trim this part out to post';
+  String get videoEditorOverLimitTimeline =>
+      'I-trim ang bahaging ito para maka-post';
 
   @override
   String publishErrorServerInternalError(String serverName) {

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -7579,8 +7579,7 @@ class AppLocalizationsFil extends AppLocalizations {
       'Lampas sa 6.3s na limit — i-trim para makapag-post';
 
   @override
-  String get videoEditorOverLimitTimeline =>
-      'I-trim ang bahaging ito para makapag-post';
+  String get videoEditorOverLimitTimeline => 'I-trim ito para makapag-post';
 
   @override
   String publishErrorServerInternalError(String serverName) {

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -7575,6 +7575,12 @@ class AppLocalizationsFil extends AppLocalizations {
       'Masyadong malaki ang video file para sa server. Subukang i-trim ito o babaan ang quality.';
 
   @override
+  String get videoEditorOverLimitCanvas => 'Over the 6.3s limit — trim to post';
+
+  @override
+  String get videoEditorOverLimitTimeline => 'Trim this part out to post';
+
+  @override
   String publishErrorServerInternalError(String serverName) {
     return 'Nagka-internal error ang media server ($serverName). Puwede kang pumili ng iba sa iyong settings.';
   }

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -7580,7 +7580,7 @@ class AppLocalizationsFil extends AppLocalizations {
 
   @override
   String get videoEditorOverLimitTimeline =>
-      'I-trim ang bahaging ito para maka-post';
+      'I-trim ang bahaging ito para makapag-post';
 
   @override
   String publishErrorServerInternalError(String serverName) {

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -7584,10 +7584,11 @@ class AppLocalizationsFr extends AppLocalizations {
       'Le fichier vidéo est trop volumineux pour le serveur. Essaie de le raccourcir ou de baisser la qualité.';
 
   @override
-  String get videoEditorOverLimitCanvas => 'Over the 6.3s limit — trim to post';
+  String get videoEditorOverLimitCanvas =>
+      'Au-delà de la limite de 6,3 s — raccourcis pour publier';
 
   @override
-  String get videoEditorOverLimitTimeline => 'Trim this part out to post';
+  String get videoEditorOverLimitTimeline => 'Coupe cette partie pour publier';
 
   @override
   String publishErrorServerInternalError(String serverName) {

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -7584,6 +7584,12 @@ class AppLocalizationsFr extends AppLocalizations {
       'Le fichier vidéo est trop volumineux pour le serveur. Essaie de le raccourcir ou de baisser la qualité.';
 
   @override
+  String get videoEditorOverLimitCanvas => 'Over the 6.3s limit — trim to post';
+
+  @override
+  String get videoEditorOverLimitTimeline => 'Trim this part out to post';
+
+  @override
   String publishErrorServerInternalError(String serverName) {
     return 'Le serveur multimédia ($serverName) a rencontré une erreur interne. Tu peux en choisir un autre dans tes réglages.';
   }

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -7448,7 +7448,7 @@ class AppLocalizationsId extends AppLocalizations {
       'Melebihi batas 6,3 dtk — pangkas untuk posting';
 
   @override
-  String get videoEditorOverLimitTimeline => 'Pangkas bagian ini untuk posting';
+  String get videoEditorOverLimitTimeline => 'Pangkas ini untuk posting';
 
   @override
   String publishErrorServerInternalError(String serverName) {

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -7444,10 +7444,11 @@ class AppLocalizationsId extends AppLocalizations {
       'File video terlalu besar untuk server. Coba pangkas videonya atau turunkan kualitasnya.';
 
   @override
-  String get videoEditorOverLimitCanvas => 'Over the 6.3s limit — trim to post';
+  String get videoEditorOverLimitCanvas =>
+      'Melebihi batas 6,3 dtk — pangkas untuk posting';
 
   @override
-  String get videoEditorOverLimitTimeline => 'Trim this part out to post';
+  String get videoEditorOverLimitTimeline => 'Pangkas bagian ini untuk posting';
 
   @override
   String publishErrorServerInternalError(String serverName) {

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -7444,6 +7444,12 @@ class AppLocalizationsId extends AppLocalizations {
       'File video terlalu besar untuk server. Coba pangkas videonya atau turunkan kualitasnya.';
 
   @override
+  String get videoEditorOverLimitCanvas => 'Over the 6.3s limit — trim to post';
+
+  @override
+  String get videoEditorOverLimitTimeline => 'Trim this part out to post';
+
+  @override
   String publishErrorServerInternalError(String serverName) {
     return 'Server media ($serverName) mengalami kesalahan internal. Kamu bisa memilih yang lain di pengaturan.';
   }

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -7564,8 +7564,7 @@ class AppLocalizationsIt extends AppLocalizations {
       'Oltre il limite di 6,3 s — taglia per pubblicare';
 
   @override
-  String get videoEditorOverLimitTimeline =>
-      'Taglia via questa parte per pubblicare';
+  String get videoEditorOverLimitTimeline => 'Taglia via per pubblicare';
 
   @override
   String publishErrorServerInternalError(String serverName) {

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -7560,10 +7560,12 @@ class AppLocalizationsIt extends AppLocalizations {
       'Il file video è troppo grande per il server. Prova a tagliarlo o ad abbassare la qualità.';
 
   @override
-  String get videoEditorOverLimitCanvas => 'Over the 6.3s limit — trim to post';
+  String get videoEditorOverLimitCanvas =>
+      'Oltre il limite di 6,3 s — taglia per pubblicare';
 
   @override
-  String get videoEditorOverLimitTimeline => 'Trim this part out to post';
+  String get videoEditorOverLimitTimeline =>
+      'Taglia via questa parte per pubblicare';
 
   @override
   String publishErrorServerInternalError(String serverName) {

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -7560,6 +7560,12 @@ class AppLocalizationsIt extends AppLocalizations {
       'Il file video è troppo grande per il server. Prova a tagliarlo o ad abbassare la qualità.';
 
   @override
+  String get videoEditorOverLimitCanvas => 'Over the 6.3s limit — trim to post';
+
+  @override
+  String get videoEditorOverLimitTimeline => 'Trim this part out to post';
+
+  @override
   String publishErrorServerInternalError(String serverName) {
     return 'Il server multimediale ($serverName) ha avuto un errore interno. Puoi sceglierne un altro nelle impostazioni.';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -7142,6 +7142,12 @@ class AppLocalizationsJa extends AppLocalizations {
       '動画ファイルがサーバーには大きすぎるよ。トリミングするか、画質を下げて試してみて。';
 
   @override
+  String get videoEditorOverLimitCanvas => 'Over the 6.3s limit — trim to post';
+
+  @override
+  String get videoEditorOverLimitTimeline => 'Trim this part out to post';
+
+  @override
   String publishErrorServerInternalError(String serverName) {
     return 'メディアサーバー（$serverName）で内部エラーが起きたよ。設定で別のサーバーを選べるよ。';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -7145,7 +7145,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get videoEditorOverLimitCanvas => '6.3秒の上限を超えてるよ。投稿するにはトリムしてね';
 
   @override
-  String get videoEditorOverLimitTimeline => '投稿するにはこの部分をカットしてね';
+  String get videoEditorOverLimitTimeline => 'この部分をカットして投稿';
 
   @override
   String publishErrorServerInternalError(String serverName) {

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -7142,7 +7142,7 @@ class AppLocalizationsJa extends AppLocalizations {
       '動画ファイルがサーバーには大きすぎるよ。トリミングするか、画質を下げて試してみて。';
 
   @override
-  String get videoEditorOverLimitCanvas => '6.3秒の上限を超えてるよ。投稿するにはトリミングしてね';
+  String get videoEditorOverLimitCanvas => '6.3秒の上限を超えてるよ。投稿するにはトリムしてね';
 
   @override
   String get videoEditorOverLimitTimeline => '投稿するにはこの部分をカットしてね';

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -7142,10 +7142,10 @@ class AppLocalizationsJa extends AppLocalizations {
       '動画ファイルがサーバーには大きすぎるよ。トリミングするか、画質を下げて試してみて。';
 
   @override
-  String get videoEditorOverLimitCanvas => 'Over the 6.3s limit — trim to post';
+  String get videoEditorOverLimitCanvas => '6.3秒の上限を超えてるよ。投稿するにはトリミングしてね';
 
   @override
-  String get videoEditorOverLimitTimeline => 'Trim this part out to post';
+  String get videoEditorOverLimitTimeline => '投稿するにはこの部分をカットしてね';
 
   @override
   String publishErrorServerInternalError(String serverName) {

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -7169,10 +7169,10 @@ class AppLocalizationsKo extends AppLocalizations {
       '영상 파일이 서버에 올리기엔 너무 커요. 영상을 자르거나 화질을 낮춰서 시도해보세요.';
 
   @override
-  String get videoEditorOverLimitCanvas => 'Over the 6.3s limit — trim to post';
+  String get videoEditorOverLimitCanvas => '6.3초 제한을 넘었어요. 올리려면 잘라내세요';
 
   @override
-  String get videoEditorOverLimitTimeline => 'Trim this part out to post';
+  String get videoEditorOverLimitTimeline => '올리려면 이 부분을 잘라내세요';
 
   @override
   String publishErrorServerInternalError(String serverName) {

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -7169,6 +7169,12 @@ class AppLocalizationsKo extends AppLocalizations {
       '영상 파일이 서버에 올리기엔 너무 커요. 영상을 자르거나 화질을 낮춰서 시도해보세요.';
 
   @override
+  String get videoEditorOverLimitCanvas => 'Over the 6.3s limit — trim to post';
+
+  @override
+  String get videoEditorOverLimitTimeline => 'Trim this part out to post';
+
+  @override
   String publishErrorServerInternalError(String serverName) {
     return '미디어 서버($serverName)에 내부 오류가 발생했어요. 설정에서 다른 서버를 고를 수 있어요.';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -7533,6 +7533,12 @@ class AppLocalizationsMs extends AppLocalizations {
       'Fail video terlalu besar untuk pelayan. Cuba memangkasnya atau mengurangkan kualiti.';
 
   @override
+  String get videoEditorOverLimitCanvas => 'Over the 6.3s limit — trim to post';
+
+  @override
+  String get videoEditorOverLimitTimeline => 'Trim this part out to post';
+
+  @override
   String publishErrorServerInternalError(String serverName) {
     return 'Pelayan media ($serverName) mengalami ralat dalaman. Anda boleh memilih yang lain dalam tetapan anda.';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -7537,8 +7537,7 @@ class AppLocalizationsMs extends AppLocalizations {
       'Melebihi had 6.3s — pangkas untuk disiarkan';
 
   @override
-  String get videoEditorOverLimitTimeline =>
-      'Pangkas bahagian ini untuk disiarkan';
+  String get videoEditorOverLimitTimeline => 'Pangkas ini untuk disiarkan';
 
   @override
   String publishErrorServerInternalError(String serverName) {

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -7534,11 +7534,11 @@ class AppLocalizationsMs extends AppLocalizations {
 
   @override
   String get videoEditorOverLimitCanvas =>
-      'Melebihi had 6.3s — pangkas untuk menyiarkan';
+      'Melebihi had 6.3s — pangkas untuk disiarkan';
 
   @override
   String get videoEditorOverLimitTimeline =>
-      'Pangkas bahagian ini untuk menyiarkan';
+      'Pangkas bahagian ini untuk disiarkan';
 
   @override
   String publishErrorServerInternalError(String serverName) {

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -7533,10 +7533,12 @@ class AppLocalizationsMs extends AppLocalizations {
       'Fail video terlalu besar untuk pelayan. Cuba memangkasnya atau mengurangkan kualiti.';
 
   @override
-  String get videoEditorOverLimitCanvas => 'Over the 6.3s limit — trim to post';
+  String get videoEditorOverLimitCanvas =>
+      'Melebihi had 6.3s — pangkas untuk menyiarkan';
 
   @override
-  String get videoEditorOverLimitTimeline => 'Trim this part out to post';
+  String get videoEditorOverLimitTimeline =>
+      'Pangkas bahagian ini untuk menyiarkan';
 
   @override
   String publishErrorServerInternalError(String serverName) {

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -7516,10 +7516,11 @@ class AppLocalizationsNl extends AppLocalizations {
       'Het videobestand is te groot voor de server. Knip het in of verlaag de kwaliteit.';
 
   @override
-  String get videoEditorOverLimitCanvas => 'Over the 6.3s limit — trim to post';
+  String get videoEditorOverLimitCanvas =>
+      'Boven de limiet van 6,3 s — knip in om te posten';
 
   @override
-  String get videoEditorOverLimitTimeline => 'Trim this part out to post';
+  String get videoEditorOverLimitTimeline => 'Knip dit stuk eruit om te posten';
 
   @override
   String publishErrorServerInternalError(String serverName) {

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -7516,6 +7516,12 @@ class AppLocalizationsNl extends AppLocalizations {
       'Het videobestand is te groot voor de server. Knip het in of verlaag de kwaliteit.';
 
   @override
+  String get videoEditorOverLimitCanvas => 'Over the 6.3s limit — trim to post';
+
+  @override
+  String get videoEditorOverLimitTimeline => 'Trim this part out to post';
+
+  @override
   String publishErrorServerInternalError(String serverName) {
     return 'De mediaserver ($serverName) had een interne fout. Je kunt een andere kiezen in je instellingen.';
   }

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -7517,7 +7517,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get videoEditorOverLimitCanvas =>
-      'Boven de limiet van 6,3 s — knip in om te posten';
+      'Boven de limiet van 6,3 s — knip het in om te posten';
 
   @override
   String get videoEditorOverLimitTimeline => 'Knip dit stuk eruit om te posten';

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -7656,10 +7656,12 @@ class AppLocalizationsPl extends AppLocalizations {
       'Plik wideo jest za duży dla serwera. Spróbuj go przyciąć lub obniżyć jakość.';
 
   @override
-  String get videoEditorOverLimitCanvas => 'Over the 6.3s limit — trim to post';
+  String get videoEditorOverLimitCanvas =>
+      'Ponad limit 6,3 s — przytnij, żeby opublikować';
 
   @override
-  String get videoEditorOverLimitTimeline => 'Trim this part out to post';
+  String get videoEditorOverLimitTimeline =>
+      'Wytnij tę część, żeby opublikować';
 
   @override
   String publishErrorServerInternalError(String serverName) {

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -7660,8 +7660,7 @@ class AppLocalizationsPl extends AppLocalizations {
       'Ponad limit 6,3 s — przytnij, żeby opublikować';
 
   @override
-  String get videoEditorOverLimitTimeline =>
-      'Wytnij tę część, żeby opublikować';
+  String get videoEditorOverLimitTimeline => 'Wytnij to, żeby opublikować';
 
   @override
   String publishErrorServerInternalError(String serverName) {

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -7656,6 +7656,12 @@ class AppLocalizationsPl extends AppLocalizations {
       'Plik wideo jest za duży dla serwera. Spróbuj go przyciąć lub obniżyć jakość.';
 
   @override
+  String get videoEditorOverLimitCanvas => 'Over the 6.3s limit — trim to post';
+
+  @override
+  String get videoEditorOverLimitTimeline => 'Trim this part out to post';
+
+  @override
   String publishErrorServerInternalError(String serverName) {
     return 'Serwer multimediów ($serverName) napotkał błąd wewnętrzny. Możesz wybrać inny w ustawieniach.';
   }

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -7538,6 +7538,12 @@ class AppLocalizationsPt extends AppLocalizations {
       'O arquivo de vídeo é grande demais para o servidor. Tente cortá-lo ou reduzir a qualidade.';
 
   @override
+  String get videoEditorOverLimitCanvas => 'Over the 6.3s limit — trim to post';
+
+  @override
+  String get videoEditorOverLimitTimeline => 'Trim this part out to post';
+
+  @override
   String publishErrorServerInternalError(String serverName) {
     return 'O servidor de mídia ($serverName) teve um erro interno. Você pode escolher outro nas configurações.';
   }

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -7538,10 +7538,11 @@ class AppLocalizationsPt extends AppLocalizations {
       'O arquivo de vídeo é grande demais para o servidor. Tente cortá-lo ou reduzir a qualidade.';
 
   @override
-  String get videoEditorOverLimitCanvas => 'Over the 6.3s limit — trim to post';
+  String get videoEditorOverLimitCanvas =>
+      'Acima do limite de 6,3 s — corte para publicar';
 
   @override
-  String get videoEditorOverLimitTimeline => 'Trim this part out to post';
+  String get videoEditorOverLimitTimeline => 'Corte esta parte para publicar';
 
   @override
   String publishErrorServerInternalError(String serverName) {

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -7656,10 +7656,11 @@ class AppLocalizationsRo extends AppLocalizations {
       'Fișierul video este prea mare pentru server. Încearcă să-l scurtezi sau să reduci calitatea.';
 
   @override
-  String get videoEditorOverLimitCanvas => 'Over the 6.3s limit — trim to post';
+  String get videoEditorOverLimitCanvas =>
+      'Peste limita de 6,3 s — scurtează ca să postezi';
 
   @override
-  String get videoEditorOverLimitTimeline => 'Trim this part out to post';
+  String get videoEditorOverLimitTimeline => 'Taie această parte ca să postezi';
 
   @override
   String publishErrorServerInternalError(String serverName) {

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -7656,6 +7656,12 @@ class AppLocalizationsRo extends AppLocalizations {
       'Fișierul video este prea mare pentru server. Încearcă să-l scurtezi sau să reduci calitatea.';
 
   @override
+  String get videoEditorOverLimitCanvas => 'Over the 6.3s limit — trim to post';
+
+  @override
+  String get videoEditorOverLimitTimeline => 'Trim this part out to post';
+
+  @override
   String publishErrorServerInternalError(String serverName) {
     return 'Serverul media ($serverName) a avut o eroare internă. Poți alege altul în setări.';
   }

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -7477,10 +7477,12 @@ class AppLocalizationsSv extends AppLocalizations {
       'Videofilen är för stor för servern. Prova att korta ner den eller sänka kvaliteten.';
 
   @override
-  String get videoEditorOverLimitCanvas => 'Over the 6.3s limit — trim to post';
+  String get videoEditorOverLimitCanvas =>
+      'Över gränsen på 6,3 s — korta ner för att posta';
 
   @override
-  String get videoEditorOverLimitTimeline => 'Trim this part out to post';
+  String get videoEditorOverLimitTimeline =>
+      'Klipp bort den här delen för att posta';
 
   @override
   String publishErrorServerInternalError(String serverName) {

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -7477,6 +7477,12 @@ class AppLocalizationsSv extends AppLocalizations {
       'Videofilen är för stor för servern. Prova att korta ner den eller sänka kvaliteten.';
 
   @override
+  String get videoEditorOverLimitCanvas => 'Over the 6.3s limit — trim to post';
+
+  @override
+  String get videoEditorOverLimitTimeline => 'Trim this part out to post';
+
+  @override
   String publishErrorServerInternalError(String serverName) {
     return 'Mediaservern ($serverName) råkade ut för ett internt fel. Du kan välja en annan i dina inställningar.';
   }

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -7481,8 +7481,7 @@ class AppLocalizationsSv extends AppLocalizations {
       'Över gränsen på 6,3 s — korta ner för att posta';
 
   @override
-  String get videoEditorOverLimitTimeline =>
-      'Klipp bort den här delen för att posta';
+  String get videoEditorOverLimitTimeline => 'Trimma bort för att posta';
 
   @override
   String publishErrorServerInternalError(String serverName) {

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -7444,10 +7444,11 @@ class AppLocalizationsTr extends AppLocalizations {
       'Video dosyası sunucu için fazla büyük. Kırpmayı ya da kaliteyi düşürmeyi dene.';
 
   @override
-  String get videoEditorOverLimitCanvas => 'Over the 6.3s limit — trim to post';
+  String get videoEditorOverLimitCanvas =>
+      '6,3 sn sınırını aştın — paylaşmak için kırp';
 
   @override
-  String get videoEditorOverLimitTimeline => 'Trim this part out to post';
+  String get videoEditorOverLimitTimeline => 'Paylaşmak için bu kısmı kırp';
 
   @override
   String publishErrorServerInternalError(String serverName) {

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -7444,6 +7444,12 @@ class AppLocalizationsTr extends AppLocalizations {
       'Video dosyası sunucu için fazla büyük. Kırpmayı ya da kaliteyi düşürmeyi dene.';
 
   @override
+  String get videoEditorOverLimitCanvas => 'Over the 6.3s limit — trim to post';
+
+  @override
+  String get videoEditorOverLimitTimeline => 'Trim this part out to post';
+
+  @override
   String publishErrorServerInternalError(String serverName) {
     return 'Medya sunucusunda ($serverName) dahili bir hata oluştu. Ayarlarından başka birini seçebilirsin.';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -7490,7 +7490,7 @@ class AppLocalizationsUr extends AppLocalizations {
       '6.3 سیکنڈ کی حد سے زیادہ ہے۔ پوسٹ کرنے کے لیے چھوٹا کریں';
 
   @override
-  String get videoEditorOverLimitTimeline => 'پوسٹ کرنے کے لیے یہ حصہ نکالیں';
+  String get videoEditorOverLimitTimeline => 'پوسٹ کرنے کے لیے یہ نکالیں';
 
   @override
   String publishErrorServerInternalError(String serverName) {

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -7486,6 +7486,12 @@ class AppLocalizationsUr extends AppLocalizations {
       'ویڈیو فائل سرور کے لیے بہت بڑی ہے۔ اسے چھوٹا کریں یا کوالٹی کم کر کے دیکھیں۔';
 
   @override
+  String get videoEditorOverLimitCanvas => 'Over the 6.3s limit — trim to post';
+
+  @override
+  String get videoEditorOverLimitTimeline => 'Trim this part out to post';
+
+  @override
   String publishErrorServerInternalError(String serverName) {
     return 'میڈیا سرور ($serverName) میں اندرونی خرابی آئی۔ آپ اپنی ترتیبات میں کوئی اور منتخب کر سکتے ہیں۔';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -7486,10 +7486,11 @@ class AppLocalizationsUr extends AppLocalizations {
       'ویڈیو فائل سرور کے لیے بہت بڑی ہے۔ اسے چھوٹا کریں یا کوالٹی کم کر کے دیکھیں۔';
 
   @override
-  String get videoEditorOverLimitCanvas => 'Over the 6.3s limit — trim to post';
+  String get videoEditorOverLimitCanvas =>
+      '6.3 سیکنڈ کی حد سے زیادہ۔ پوسٹ کرنے کے لیے چھوٹا کریں';
 
   @override
-  String get videoEditorOverLimitTimeline => 'Trim this part out to post';
+  String get videoEditorOverLimitTimeline => 'پوسٹ کرنے کے لیے یہ حصہ نکالیں';
 
   @override
   String publishErrorServerInternalError(String serverName) {

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -7487,7 +7487,7 @@ class AppLocalizationsUr extends AppLocalizations {
 
   @override
   String get videoEditorOverLimitCanvas =>
-      '6.3 سیکنڈ کی حد سے زیادہ۔ پوسٹ کرنے کے لیے چھوٹا کریں';
+      '6.3 سیکنڈ کی حد سے زیادہ ہے۔ پوسٹ کرنے کے لیے چھوٹا کریں';
 
   @override
   String get videoEditorOverLimitTimeline => 'پوسٹ کرنے کے لیے یہ حصہ نکالیں';

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -7489,10 +7489,11 @@ class AppLocalizationsVi extends AppLocalizations {
       'Tệp video quá lớn so với máy chủ. Thử cắt ngắn hoặc giảm chất lượng.';
 
   @override
-  String get videoEditorOverLimitCanvas => 'Over the 6.3s limit — trim to post';
+  String get videoEditorOverLimitCanvas =>
+      'Vượt giới hạn 6,3 giây — cắt ngắn để đăng';
 
   @override
-  String get videoEditorOverLimitTimeline => 'Trim this part out to post';
+  String get videoEditorOverLimitTimeline => 'Cắt bỏ phần này để đăng';
 
   @override
   String publishErrorServerInternalError(String serverName) {

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -7489,6 +7489,12 @@ class AppLocalizationsVi extends AppLocalizations {
       'Tệp video quá lớn so với máy chủ. Thử cắt ngắn hoặc giảm chất lượng.';
 
   @override
+  String get videoEditorOverLimitCanvas => 'Over the 6.3s limit — trim to post';
+
+  @override
+  String get videoEditorOverLimitTimeline => 'Trim this part out to post';
+
+  @override
   String publishErrorServerInternalError(String serverName) {
     return 'Máy chủ media ($serverName) gặp lỗi nội bộ. Bạn có thể chọn máy chủ khác trong cài đặt.';
   }

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -7108,6 +7108,12 @@ class AppLocalizationsZh extends AppLocalizations {
   String get publishErrorFileTooLarge => '视频文件对服务器来说太大了。试试剪辑一下或降低画质。';
 
   @override
+  String get videoEditorOverLimitCanvas => 'Over the 6.3s limit — trim to post';
+
+  @override
+  String get videoEditorOverLimitTimeline => 'Trim this part out to post';
+
+  @override
   String publishErrorServerInternalError(String serverName) {
     return '媒体服务器（$serverName）内部出错。你可以在设置中换一个。';
   }

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -7108,10 +7108,10 @@ class AppLocalizationsZh extends AppLocalizations {
   String get publishErrorFileTooLarge => '视频文件对服务器来说太大了。试试剪辑一下或降低画质。';
 
   @override
-  String get videoEditorOverLimitCanvas => 'Over the 6.3s limit — trim to post';
+  String get videoEditorOverLimitCanvas => '超过 6.3 秒上限，剪短才能发布';
 
   @override
-  String get videoEditorOverLimitTimeline => 'Trim this part out to post';
+  String get videoEditorOverLimitTimeline => '剪掉这段才能发布';
 
   @override
   String publishErrorServerInternalError(String serverName) {

--- a/mobile/lib/providers/clip_manager_provider.dart
+++ b/mobile/lib/providers/clip_manager_provider.dart
@@ -442,10 +442,12 @@ class ClipManagerNotifier extends Notifier<ClipManagerState> {
     return insertedClip;
   }
 
-  /// Add multiple clips at once (e.g., from draft restoration).
+  /// Add multiple clips at once, each seeded with an import trim that keeps
+  /// the batch inside the editor budget.
   ///
   /// Appends all clips to the end of the current clip list and updates state.
-  /// Used when restoring drafts or importing multiple clips from library.
+  /// This is the library import that happens while the editor is already open
+  /// (`VideoEditorScreen`); draft restoration goes through [replaceClips].
   void addMultipleClips(List<DivineVideoClip> clips) {
     if (clips.isEmpty) {
       Log.debug(
@@ -457,7 +459,19 @@ class ClipManagerNotifier extends Notifier<ClipManagerState> {
     }
 
     final previousCount = _clips.length;
-    _clips.addAll(clips);
+    // Seed against the clips already accepted in this batch, so a batch that
+    // fills the budget partway through trims the rest — the same accumulation
+    // the other library import path gets from calling insertClip in a loop.
+    final seededClips = <DivineVideoClip>[];
+    for (final clip in clips) {
+      seededClips.add(
+        seedImportTrimForEditorBudget(
+          clip: clip,
+          existingClips: [..._clips, ...seededClips],
+        ),
+      );
+    }
+    _clips.addAll(seededClips);
 
     Log.info(
       '📎 Added ${clips.length} clips '

--- a/mobile/lib/providers/clip_manager_provider.dart
+++ b/mobile/lib/providers/clip_manager_provider.dart
@@ -65,6 +65,33 @@ class ClipManagerNotifier extends Notifier<ClipManagerState> {
     );
   }
 
+  /// Returns [clip] with an end trim that keeps its visible window within the
+  /// remaining editor budget after [existingClips].
+  static DivineVideoClip seedImportTrimForEditorBudget({
+    required DivineVideoClip clip,
+    required List<DivineVideoClip> existingClips,
+  }) {
+    final usedDuration = existingClips.fold<Duration>(
+      Duration.zero,
+      (sum, existing) => sum + existing.playbackDuration,
+    );
+    final remainingDuration = VideoEditorConstants.maxDuration - usedDuration;
+
+    if (remainingDuration <= Duration.zero) {
+      return clip.copyWith(trimEnd: clip.duration - clip.trimStart);
+    }
+
+    if (clip.playbackDuration <= remainingDuration) return clip;
+
+    final visibleSourceDuration = clip.playbackDurationToSourceDuration(
+      remainingDuration,
+    );
+    final trimEnd = clip.duration - clip.trimStart - visibleSourceDuration;
+    if (trimEnd <= clip.trimEnd) return clip;
+
+    return clip.copyWith(trimEnd: trimEnd);
+  }
+
   @override
   ClipManagerState build() {
     ref.onDispose(() {
@@ -381,11 +408,15 @@ class ClipManagerNotifier extends Notifier<ClipManagerState> {
   /// Adds [clip] at [index], shifting subsequent clips forward.
   /// Returns the inserted clip.
   DivineVideoClip insertClip(int index, DivineVideoClip clip) {
-    _clips.insert(index, clip);
+    final insertedClip = seedImportTrimForEditorBudget(
+      clip: clip,
+      existingClips: _clips,
+    );
+    _clips.insert(index, insertedClip);
     Log.info(
-      '📎 Insert clip: ${clip.id}, '
+      '📎 Insert clip: ${insertedClip.id}, '
       'position: $index '
-      'duration: ${clip.durationInSeconds}s',
+      'duration: ${insertedClip.durationInSeconds}s',
       name: 'ClipManagerNotifier',
       category: .video,
     );
@@ -393,7 +424,7 @@ class ClipManagerNotifier extends Notifier<ClipManagerState> {
     state = state.copyWith(clips: List.unmodifiable(_clips));
 
     _triggerAutosave();
-    return clip;
+    return insertedClip;
   }
 
   /// Add multiple clips at once (e.g., from draft restoration).

--- a/mobile/lib/providers/clip_manager_provider.dart
+++ b/mobile/lib/providers/clip_manager_provider.dart
@@ -90,15 +90,17 @@ class ClipManagerNotifier extends Notifier<ClipManagerState> {
 
     // Never seed a window shorter than the floor the editor's own trim paths
     // enforce, or a multi-select whose earlier clips already fill the budget
-    // lands the rest as zero-length strips nobody can grab a handle on.
-    final targetPlaybackDuration =
-        remainingDuration > TimelineConstants.minTrimDuration
-        ? remainingDuration
+    // lands the rest as zero-length strips nobody can grab a handle on. The
+    // floor is applied in source time because that is what those paths clamp
+    // (`clip.duration - minTrimDuration`), so it holds at any playback speed.
+    final budgetSourceDuration = clip.playbackDurationToSourceDuration(
+      remainingDuration,
+    );
+    final visibleSourceDuration =
+        budgetSourceDuration > TimelineConstants.minTrimDuration
+        ? budgetSourceDuration
         : TimelineConstants.minTrimDuration;
 
-    final visibleSourceDuration = clip.playbackDurationToSourceDuration(
-      targetPlaybackDuration,
-    );
     final trimEnd = clip.duration - clip.trimStart - visibleSourceDuration;
     if (trimEnd <= clip.trimEnd) return clip;
 

--- a/mobile/lib/providers/clip_manager_provider.dart
+++ b/mobile/lib/providers/clip_manager_provider.dart
@@ -9,6 +9,7 @@ import 'package:divine_camera/divine_camera.dart' show CameraLensMetadata;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:models/models.dart' as model show AspectRatio;
 import 'package:openvine/constants/video_editor_constants.dart';
+import 'package:openvine/constants/video_editor_timeline_constants.dart';
 import 'package:openvine/models/clip_manager_state.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/stop_motion_clip_frame.dart';
@@ -77,14 +78,18 @@ class ClipManagerNotifier extends Notifier<ClipManagerState> {
     );
     final remainingDuration = VideoEditorConstants.maxDuration - usedDuration;
 
-    if (remainingDuration <= Duration.zero) {
-      return clip.copyWith(trimEnd: clip.duration - clip.trimStart);
-    }
-
     if (clip.playbackDuration <= remainingDuration) return clip;
 
+    // Never seed a window shorter than the floor the editor's own trim paths
+    // enforce, or a multi-select whose earlier clips already fill the budget
+    // lands the rest as zero-length strips nobody can grab a handle on.
+    final targetPlaybackDuration =
+        remainingDuration > TimelineConstants.minTrimDuration
+        ? remainingDuration
+        : TimelineConstants.minTrimDuration;
+
     final visibleSourceDuration = clip.playbackDurationToSourceDuration(
-      remainingDuration,
+      targetPlaybackDuration,
     );
     final trimEnd = clip.duration - clip.trimStart - visibleSourceDuration;
     if (trimEnd <= clip.trimEnd) return clip;

--- a/mobile/lib/providers/clip_manager_provider.dart
+++ b/mobile/lib/providers/clip_manager_provider.dart
@@ -68,10 +68,18 @@ class ClipManagerNotifier extends Notifier<ClipManagerState> {
 
   /// Returns [clip] with an end trim that keeps its visible window within the
   /// remaining editor budget after [existingClips].
+  ///
+  /// Frames-only stop-motion clips are returned untouched: their strip lays
+  /// out from the frame holds and ignores trim, so an end trim would shrink
+  /// the composition total — hiding the over-limit overlays — while every
+  /// frame stayed on screen. Stop-motion overflow is resolved by deleting
+  /// frames instead.
   static DivineVideoClip seedImportTrimForEditorBudget({
     required DivineVideoClip clip,
     required List<DivineVideoClip> existingClips,
   }) {
+    if (clip.isStopMotion) return clip;
+
     final usedDuration = existingClips.fold<Duration>(
       Duration.zero,
       (sum, existing) => sum + existing.playbackDuration,

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
@@ -23,6 +23,7 @@ import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/extensions/tune_adjustment_matrix_extensions.dart';
 import 'package:openvine/extensions/video_editor_extensions.dart';
 import 'package:openvine/extensions/video_editor_history_extensions.dart';
+import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/stop_motion/stop_motion_frame_ops.dart';
 import 'package:openvine/models/timeline_overlay_item.dart';
@@ -1034,9 +1035,7 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
     if (audio != null) {
       // Re-anchoring is a clock set, not a tick: a resume that lands mid-window
       // must re-seek even when it re-anchors only slightly ahead.
-      unawaited(
-        audio.syncTo(_stopMotionAnchor, isPlaying: true, isSeek: true),
-      );
+      unawaited(audio.syncTo(_stopMotionAnchor, isPlaying: true, isSeek: true));
     }
 
     context.read<VideoEditorMainBloc>()
@@ -1502,9 +1501,7 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
     try {
       loaded = await _setClipsSafely(
         player,
-        [
-          ..._buildPlayerClips(clips),
-        ],
+        [..._buildPlayerClips(clips)],
         startPosition: startPosition != null && startPosition > Duration.zero
             ? _timelineToPlayer(startPosition)
             : null,
@@ -1895,11 +1892,7 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
     final tuneEditor = scope.tuneEditor;
     final active = scope.editor?.stateManager.activeTuneAdjustments;
     if (tuneEditor == null || active == null) return;
-    seedTuneEditorPreview(
-      tuneEditor: tuneEditor,
-      active: active,
-      setId: setId,
-    );
+    seedTuneEditorPreview(tuneEditor: tuneEditor, active: active, setId: setId);
   }
 
   /// Handles state history changes and exports the history to the provider.
@@ -2001,9 +1994,7 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
     final gate = _decoderReleaseGate = Completer<void>();
     _isMetadataRouteActive = true;
     final navigation = context.push(
-      VideoMetadataScreen.pathForDraft(
-        isStopMotion: _isStopMotionComposition,
-      ),
+      VideoMetadataScreen.pathForDraft(isStopMotion: _isStopMotionComposition),
     );
     try {
       await (awaitCover?.call() ??
@@ -2112,9 +2103,7 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
           _setClipsForGeneration(
             generation,
             _videoPlayer,
-            [
-              ..._buildPlayerClips(clips),
-            ],
+            [..._buildPlayerClips(clips)],
             startPosition: _timelineToPlayer(currentPosition),
           ),
         );
@@ -2146,9 +2135,7 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
           _setClipsForGeneration(
             generation,
             _videoPlayer,
-            [
-              ..._buildPlayerClips(clips),
-            ],
+            [..._buildPlayerClips(clips)],
             startPosition: _timelineToPlayer(currentPosition),
           ),
         );
@@ -2408,9 +2395,7 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
               final loaded = await _setClipsForGeneration(
                 generation,
                 _videoPlayer,
-                [
-                  ..._buildPlayerClips(state.clips),
-                ],
+                [..._buildPlayerClips(state.clips)],
                 startPosition: _timelineToPlayer(currentPosition),
               );
               if (!loaded) return;
@@ -2469,9 +2454,7 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
               final loaded = await _setClipsForGeneration(
                 generation,
                 _videoPlayer,
-                [
-                  ..._buildPlayerClips(state.clips),
-                ],
+                [..._buildPlayerClips(state.clips)],
                 startPosition: _timelineToPlayer(startPosition),
               );
               if (!loaded) return;
@@ -2641,10 +2624,34 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
                               return IgnorePointer(
                                 child: ColoredBox(
                                   color: context.vineColors.background
-                                      .withAlpha(
-                                        128,
+                                      .withAlpha(160),
+                                  child: Center(
+                                    child: DecoratedBox(
+                                      decoration: BoxDecoration(
+                                        color: context
+                                            .vineColors
+                                            .surfaceContainerHigh
+                                            .withAlpha(230),
+                                        borderRadius: BorderRadius.circular(8),
                                       ),
-                                  child: const SizedBox.expand(),
+                                      child: Padding(
+                                        padding: const EdgeInsets.symmetric(
+                                          horizontal: 14,
+                                          vertical: 10,
+                                        ),
+                                        child: Text(
+                                          context
+                                              .l10n
+                                              .videoEditorOverLimitCanvas,
+                                          textAlign: TextAlign.center,
+                                          style: VineTheme.labelLargeFont(
+                                            color:
+                                                context.vineColors.primaryText,
+                                          ),
+                                        ),
+                                      ),
+                                    ),
+                                  ),
                                 ),
                               );
                             },

--- a/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_body.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_body.dart
@@ -9,6 +9,7 @@ import 'package:openvine/blocs/video_editor/main_editor/video_editor_main_bloc.d
 import 'package:openvine/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart';
 import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/constants/video_editor_timeline_constants.dart';
+import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/stop_motion/stop_motion_frame_ops.dart';
 import 'package:openvine/models/timeline_overlay_item.dart';
@@ -458,7 +459,20 @@ class _TimelineMaxDurationDimOverlay extends StatelessWidget {
             color: context.vineColors.surfaceContainerHigh.withValues(
               alpha: 0.3,
             ),
-            child: const SizedBox.expand(),
+            child: Align(
+              alignment: Alignment.topLeft,
+              child: Padding(
+                padding: const EdgeInsets.only(left: 8, top: 8),
+                child: Text(
+                  context.l10n.videoEditorOverLimitTimeline,
+                  style: VineTheme.labelSmallFont(
+                    color: context.vineColors.primaryText,
+                  ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+            ),
           ),
         ),
       ),

--- a/mobile/test/l10n/arb_consistency_test.dart
+++ b/mobile/test/l10n/arb_consistency_test.dart
@@ -420,6 +420,9 @@ void main() {
 const _knownUntranslatedDebt = <String>{
   // People-search video-count copy still needs a translation pass outside en.
   'searchUserVideoCount',
+  // Video-editor over-limit affordance needs a translation pass outside en.
+  'videoEditorOverLimitCanvas',
+  'videoEditorOverLimitTimeline',
 };
 
 const _profileBadgeSheetKeys = <String>{

--- a/mobile/test/l10n/arb_consistency_test.dart
+++ b/mobile/test/l10n/arb_consistency_test.dart
@@ -420,9 +420,6 @@ void main() {
 const _knownUntranslatedDebt = <String>{
   // People-search video-count copy still needs a translation pass outside en.
   'searchUserVideoCount',
-  // Video-editor over-limit affordance needs a translation pass outside en.
-  'videoEditorOverLimitCanvas',
-  'videoEditorOverLimitTimeline',
 };
 
 const _profileBadgeSheetKeys = <String>{

--- a/mobile/test/providers/clip_manager_provider_test.dart
+++ b/mobile/test/providers/clip_manager_provider_test.dart
@@ -1144,6 +1144,35 @@ void main() {
         );
       });
 
+      test('leaves a frames-only stop-motion clip untouched', () {
+        // The frames strip lays out from the frame holds and never reads
+        // trimEnd, so trimming here would drop the composition total below
+        // the limit — hiding the over-limit overlays — while every frame
+        // stayed on screen.
+        const frame = StopMotionClipFrame(
+          path: '/tmp/frame_0.jpg',
+          duration: Duration(seconds: 10),
+        );
+        final clip = DivineVideoClip(
+          id: 'frames',
+          duration: const Duration(seconds: 10),
+          recordedAt: DateTime(2026),
+          targetAspectRatio: .vertical,
+          originalAspectRatio: 9 / 16,
+          stopMotionFrames: const [frame],
+        );
+
+        expect(clip.isStopMotion, isTrue);
+
+        final seeded = ClipManagerNotifier.seedImportTrimForEditorBudget(
+          clip: clip,
+          existingClips: const [],
+        );
+
+        expect(seeded, same(clip));
+        expect(seeded.trimEnd, equals(Duration.zero));
+      });
+
       test('leaves a clip shorter than the trim minimum untouched', () {
         final clip = _budgetClip(
           id: 'sliver',

--- a/mobile/test/providers/clip_manager_provider_test.dart
+++ b/mobile/test/providers/clip_manager_provider_test.dart
@@ -1144,6 +1144,30 @@ void main() {
         );
       });
 
+      test('applies the trim floor in source time on a slowed clip', () {
+        // The floor has to be applied to the source window, not the playback
+        // window: at 0.5x a 60ms playback window is only 30ms of source, which
+        // is under the floor ClipEditorBloc clamps trims to.
+        final seeded = ClipManagerNotifier.seedImportTrimForEditorBudget(
+          clip: _budgetClip(
+            id: 'slow',
+            duration: const Duration(seconds: 60),
+            playbackSpeed: 0.5,
+          ),
+          existingClips: [
+            _budgetClip(
+              id: 'fills',
+              duration: VideoEditorConstants.maxDuration,
+            ),
+          ],
+        );
+
+        expect(
+          seeded.trimmedDuration,
+          equals(TimelineConstants.minTrimDuration),
+        );
+      });
+
       test('leaves a frames-only stop-motion clip untouched', () {
         // The frames strip lays out from the frame holds and never reads
         // trimEnd, so trimming here would drop the composition total below

--- a/mobile/test/providers/clip_manager_provider_test.dart
+++ b/mobile/test/providers/clip_manager_provider_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/constants/video_editor_constants.dart';
+import 'package:openvine/constants/video_editor_timeline_constants.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/stop_motion_clip_frame.dart';
 import 'package:openvine/providers/app_providers.dart';
@@ -1073,6 +1074,94 @@ void main() {
         );
 
         expect(seeded, same(clip));
+      });
+
+      test('converts the remaining budget through the clip playback speed', () {
+        final clip = _budgetClip(
+          id: 'fast',
+          duration: const Duration(seconds: 60),
+          playbackSpeed: 2,
+        );
+
+        final seeded = ClipManagerNotifier.seedImportTrimForEditorBudget(
+          clip: clip,
+          existingClips: const [],
+        );
+
+        // A 2x clip covers twice as much source media per second of playback,
+        // so the visible source window is 12.6s for a 6.3s budget.
+        expect(
+          seeded.trimmedDuration,
+          equals(const Duration(seconds: 12, milliseconds: 600)),
+        );
+        expect(
+          seeded.playbackDuration,
+          equals(VideoEditorConstants.maxDuration),
+        );
+      });
+
+      test('floors the seeded window at the editor trim minimum when the '
+          'budget is already spent', () {
+        // library_screen inserts each selected clip in turn, so a multi-select
+        // whose first pick fills the budget leaves nothing for the rest.
+        final existing = _budgetClip(
+          id: 'fills',
+          duration: VideoEditorConstants.maxDuration,
+        );
+
+        final seeded = ClipManagerNotifier.seedImportTrimForEditorBudget(
+          clip: _budgetClip(
+            id: 'second',
+            duration: const Duration(seconds: 60),
+          ),
+          existingClips: [existing],
+        );
+
+        expect(
+          seeded.trimmedDuration,
+          equals(TimelineConstants.minTrimDuration),
+        );
+      });
+
+      test('floors the seeded window when the remaining budget is below the '
+          'editor trim minimum', () {
+        final existing = _budgetClip(
+          id: 'nearly-fills',
+          duration: const Duration(seconds: 6, milliseconds: 280),
+        );
+
+        final seeded = ClipManagerNotifier.seedImportTrimForEditorBudget(
+          clip: _budgetClip(
+            id: 'second',
+            duration: const Duration(seconds: 60),
+          ),
+          existingClips: [existing],
+        );
+
+        expect(
+          seeded.trimmedDuration,
+          equals(TimelineConstants.minTrimDuration),
+        );
+      });
+
+      test('leaves a clip shorter than the trim minimum untouched', () {
+        final clip = _budgetClip(
+          id: 'sliver',
+          duration: const Duration(milliseconds: 30),
+        );
+
+        final seeded = ClipManagerNotifier.seedImportTrimForEditorBudget(
+          clip: clip,
+          existingClips: [
+            _budgetClip(
+              id: 'fills',
+              duration: VideoEditorConstants.maxDuration,
+            ),
+          ],
+        );
+
+        expect(seeded, same(clip));
+        expect(seeded.trimEnd, equals(Duration.zero));
       });
     });
   });

--- a/mobile/test/providers/clip_manager_provider_test.dart
+++ b/mobile/test/providers/clip_manager_provider_test.dart
@@ -1144,6 +1144,29 @@ void main() {
         );
       });
 
+      test('addMultipleClips seeds each clip in the batch', () {
+        // VideoEditorScreen imports from the library through addMultipleClips
+        // while the editor is already open, so that path needs the same
+        // seeding the library screen gets from its insertClip loop.
+        final notifier = container.read(clipManagerProvider.notifier);
+
+        notifier.addMultipleClips([
+          _budgetClip(id: 'first', duration: const Duration(seconds: 60)),
+          _budgetClip(id: 'second', duration: const Duration(seconds: 60)),
+        ]);
+
+        final clips = container.read(clipManagerProvider).clips;
+        expect(clips, hasLength(2));
+        expect(
+          clips[0].playbackDuration,
+          equals(VideoEditorConstants.maxDuration),
+        );
+        expect(
+          clips[1].trimmedDuration,
+          equals(TimelineConstants.minTrimDuration),
+        );
+      });
+
       test('applies the trim floor in source time on a slowed clip', () {
         // The floor has to be applied to the source window, not the playback
         // window: at 0.5x a 60ms playback window is only 30ms of source, which

--- a/mobile/test/providers/clip_manager_provider_test.dart
+++ b/mobile/test/providers/clip_manager_provider_test.dart
@@ -19,6 +19,26 @@ class _MockDraftStorageService extends Mock implements DraftStorageService {}
 
 class _MockClipLibraryService extends Mock implements ClipLibraryService {}
 
+DivineVideoClip _budgetClip({
+  required String id,
+  required Duration duration,
+  Duration trimStart = Duration.zero,
+  Duration trimEnd = Duration.zero,
+  double? playbackSpeed,
+}) {
+  return DivineVideoClip(
+    id: id,
+    video: EditorVideo.file('/tmp/$id.mp4'),
+    duration: duration,
+    recordedAt: DateTime(2026),
+    targetAspectRatio: .vertical,
+    originalAspectRatio: 9 / 16,
+    trimStart: trimStart,
+    trimEnd: trimEnd,
+    playbackSpeed: playbackSpeed,
+  );
+}
+
 void main() {
   group('ClipManagerProvider', () {
     late ProviderContainer container;
@@ -989,6 +1009,70 @@ void main() {
         verify(
           () => mockClipLibraryService.deleteClipRow('clip_sm_frame_0'),
         ).called(1);
+      });
+    });
+
+    group('seedImportTrimForEditorBudget', () {
+      test('trims a long imported clip to the full editor budget', () {
+        final clip = _budgetClip(
+          id: 'long',
+          duration: const Duration(seconds: 60),
+        );
+
+        final seeded = ClipManagerNotifier.seedImportTrimForEditorBudget(
+          clip: clip,
+          existingClips: const [],
+        );
+
+        expect(seeded.duration, equals(clip.duration));
+        expect(seeded.trimStart, equals(Duration.zero));
+        expect(
+          seeded.trimEnd,
+          equals(clip.duration - VideoEditorConstants.maxDuration),
+        );
+        expect(
+          seeded.playbackDuration,
+          equals(VideoEditorConstants.maxDuration),
+        );
+      });
+
+      test('uses the remaining budget after existing clips', () {
+        final existing = _budgetClip(
+          id: 'existing',
+          duration: const Duration(seconds: 4),
+        );
+        final clip = _budgetClip(
+          id: 'long',
+          duration: const Duration(seconds: 10),
+        );
+
+        final seeded = ClipManagerNotifier.seedImportTrimForEditorBudget(
+          clip: clip,
+          existingClips: [existing],
+        );
+
+        expect(
+          seeded.playbackDuration,
+          equals(const Duration(seconds: 2, milliseconds: 300)),
+        );
+        expect(
+          seeded.trimEnd,
+          equals(const Duration(seconds: 7, milliseconds: 700)),
+        );
+      });
+
+      test('keeps clips already within the remaining budget unchanged', () {
+        final clip = _budgetClip(
+          id: 'short',
+          duration: const Duration(seconds: 3),
+        );
+
+        final seeded = ClipManagerNotifier.seedImportTrimForEditorBudget(
+          clip: clip,
+          existingClips: const [],
+        );
+
+        expect(seeded, same(clip));
       });
     });
   });

--- a/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_body_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_body_test.dart
@@ -13,6 +13,7 @@ import 'package:openvine/blocs/video_editor/timeline_overlay/timeline_overlay_bl
 import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/constants/video_editor_timeline_constants.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/l10n/generated/app_localizations_en.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/timeline_overlay_item.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/strips/timeline_trim_handles.dart';
@@ -49,6 +50,7 @@ void main() {
   group(VideoEditorTimelineBody, () {
     late _MockVideoEditorMainBloc mainBloc;
     late _MockTimelineOverlayBloc overlayBloc;
+    final strings = AppLocalizationsEn();
 
     setUp(() {
       mainBloc = _MockVideoEditorMainBloc();
@@ -229,6 +231,10 @@ void main() {
         findsOneWidget,
       );
       expect(dimOverlayFinder, findsOneWidget);
+      expect(
+        find.text(strings.videoEditorOverLimitTimeline),
+        findsOneWidget,
+      );
     });
 
     testWidgets('hides outside-area overlays when reordering', (tester) async {


### PR DESCRIPTION
## Summary
- seed imported library clips with an end trim so long clips enter the editor inside the 6.3s posting budget
- replace the unlabeled over-budget canvas/timeline dimming with localized guidance
- add provider and timeline coverage for the import budget and over-limit copy

Fixes #7571

## Verification
- flutter test test/providers/clip_manager_provider_test.dart
- flutter test test/widgets/video_editor/timeline_editor/video_editor_timeline_body_test.dart
- flutter test test/l10n/arb_consistency_test.dart
- flutter analyze
- mobile/scripts/golden.sh verify
- pre-push hook changed-file tests/analyze/l10n checks passed