### PR TITLE
chore(playback): lower media-processing retry logs

### DIFF
--- a/mobile/packages/infinite_video_feed/lib/src/utils/playback_failure_log.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/utils/playback_failure_log.dart
@@ -1,0 +1,30 @@
+import 'package:infinite_video_feed/src/utils/playback_sources.dart';
+import 'package:unified_logger/unified_logger.dart';
+
+/// Logs playback failures without promoting handled media-processing retries
+/// into error telemetry.
+void logPlaybackFailure(
+  String message, {
+  required String name,
+  required Object error,
+  required StackTrace stackTrace,
+}) {
+  if (isMediaProcessingError(error)) {
+    Log.warning(
+      message,
+      name: name,
+      category: LogCategory.video,
+      error: error,
+      stackTrace: stackTrace,
+    );
+    return;
+  }
+
+  Log.error(
+    message,
+    name: name,
+    category: LogCategory.video,
+    error: error,
+    stackTrace: stackTrace,
+  );
+}

--- a/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
@@ -13,6 +13,7 @@ import 'package:infinite_video_feed/src/services/disk_prefetcher.dart';
 import 'package:infinite_video_feed/src/services/load_watchdog.dart';
 import 'package:infinite_video_feed/src/services/playback_source_registry.dart';
 import 'package:infinite_video_feed/src/services/stale_playback_detector.dart';
+import 'package:infinite_video_feed/src/utils/playback_failure_log.dart';
 import 'package:infinite_video_feed/src/utils/playback_sources.dart';
 import 'package:infinite_video_feed/src/utils/source_loader.dart';
 import 'package:infinite_video_feed/src/widgets/video_item.dart';
@@ -1262,10 +1263,9 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
           ? ''
           : ' failedSource=$lastFailedSource';
       _log('Error loading index $index (${video.id}):$sourceDetail $e');
-      Log.error(
+      logPlaybackFailure(
         'Player init failed$sourceDetail',
         name: _logName,
-        category: LogCategory.video,
         error: e,
         stackTrace: stackTrace,
       );
@@ -1437,10 +1437,9 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
       }
     } on Object catch (e, stackTrace) {
       _log('Source failover failed index $index source=$nextSource: $e');
-      Log.error(
+      logPlaybackFailure(
         'Source failover failed',
         name: _logName,
-        category: LogCategory.video,
         error: e,
         stackTrace: stackTrace,
       );
@@ -1542,10 +1541,9 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
         return;
       }
       _log('Processing retry failed index $index source=$source: $e');
-      Log.error(
+      logPlaybackFailure(
         'Processing retry failed',
         name: _logName,
-        category: LogCategory.video,
         error: e,
         stackTrace: stackTrace,
       );

--- a/mobile/packages/infinite_video_feed/test/src/utils/playback_failure_log_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/utils/playback_failure_log_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:infinite_video_feed/src/utils/playback_failure_log.dart';
+import 'package:unified_logger/unified_logger.dart';
+
+void main() {
+  late LogCaptureService logService;
+
+  setUp(() async {
+    logService = LogCaptureService();
+    await logService.clearAllLogs();
+  });
+
+  void logFailure(Object error) {
+    logPlaybackFailure(
+      'Playback failed',
+      name: 'PlaybackFailureLogTest',
+      error: error,
+      stackTrace: StackTrace.current,
+    );
+  }
+
+  test('logs HTTP 202 media-processing failures as warnings', () {
+    logFailure(Exception('CoreMediaErrorDomain error -12667 - HTTP 202'));
+
+    final log = logService.getRecentLogs().single;
+    expect(log.level, LogLevel.warning);
+    expect(log.message, 'Playback failed');
+    expect(log.category, LogCategory.video);
+    expect(log.name, 'PlaybackFailureLogTest');
+    expect(log.error, contains('HTTP 202'));
+    expect(log.stackTrace, isNotNull);
+  });
+
+  test('logs HTTP 422 media-processing failures as warnings', () {
+    logFailure(Exception('Source error. Response code: 422'));
+
+    final log = logService.getRecentLogs().single;
+    expect(log.level, LogLevel.warning);
+    expect(log.error, contains('Response code: 422'));
+    expect(log.stackTrace, isNotNull);
+  });
+
+  test('logs generic playback failures as errors', () {
+    logFailure(Exception('Decoder failed'));
+
+    final log = logService.getRecentLogs().single;
+    expect(log.level, LogLevel.error);
+    expect(log.error, contains('Decoder failed'));
+    expect(log.stackTrace, isNotNull);
+  });
+}

--- a/mobile/packages/unified_logger/lib/src/unified_logger.dart
+++ b/mobile/packages/unified_logger/lib/src/unified_logger.dart
@@ -207,9 +207,22 @@ class UnifiedLogger {
     _log(message, name: name, category: category, level: LogLevel.info);
   }
 
-  /// Warning logging - potential issues
-  static void warning(String message, {String? name, LogCategory? category}) {
-    _log(message, name: name, category: category, level: LogLevel.warning);
+  /// Warning logging - potential issues with optional error object
+  static void warning(
+    String message, {
+    String? name,
+    LogCategory? category,
+    Object? error,
+    StackTrace? stackTrace,
+  }) {
+    _log(
+      message,
+      name: name,
+      category: category,
+      level: LogLevel.warning,
+      error: error,
+      stackTrace: stackTrace,
+    );
   }
 
   /// Error logging - actual errors with optional error object

--- a/mobile/packages/unified_logger/test/src/unified_logger_test.dart
+++ b/mobile/packages/unified_logger/test/src/unified_logger_test.dart
@@ -188,6 +188,33 @@ void main() {
       expect(log.category, equals(LogCategory.relay));
     });
 
+    test('should capture warning details to file', () async {
+      final beforeCount = logService.getRecentLogs().length;
+
+      final exception = Exception('Warning exception');
+      final stackTrace = StackTrace.current;
+
+      Log.warning(
+        'Warning occurred',
+        category: LogCategory.video,
+        error: exception,
+        stackTrace: stackTrace,
+      );
+
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+
+      final capturedLogs = logService.getRecentLogs();
+      final newLogsCount = capturedLogs.length - beforeCount;
+
+      expect(newLogsCount, equals(1));
+      final log = capturedLogs.last;
+      expect(log.level, equals(LogLevel.warning));
+      expect(log.message, equals('Warning occurred'));
+      expect(log.error, contains('Warning exception'));
+      expect(log.stackTrace, isNotNull);
+      expect(log.category, equals(LogCategory.video));
+    });
+
     test(
       'captures logs from disabled categories '
       'for bug report export',


### PR DESCRIPTION
## Summary
- add warning-level error/stack support to unified logger
- route media-processing playback failures through a covered helper that logs HTTP 202/422 as warnings and other failures as errors
- apply the helper to player init exhaustion, processing retry, and source failover paths

Closes #7573

## Verification
- flutter test test/src/unified_logger_test.dart (mobile/packages/unified_logger)
- flutter test test/src/utils/playback_failure_log_test.dart (mobile/packages/infinite_video_feed)
- flutter test --coverage (mobile/packages/unified_logger)
- flutter test --coverage (mobile/packages/infinite_video_feed)
- flutter analyze (mobile)
- pre-push hook: analyzer + changed-file tests