### PR TITLE
fix(notifications): show pending state for mark-all-as-read

### DIFF
--- a/mobile/lib/blocs/notification_settings/notification_settings_cubit.dart
+++ b/mobile/lib/blocs/notification_settings/notification_settings_cubit.dart
@@ -1,8 +1,11 @@
 // ABOUTME: Screen-scoped Cubit for the notification settings screen.
 // ABOUTME: Owns the notification preferences, persisting changes via
-// ABOUTME: NotificationPreferencesService.
+// ABOUTME: NotificationPreferencesService, and runs the mark-all-as-read
+// ABOUTME: action against NotificationRepository.
 
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:notification_repository/notification_repository.dart';
+import 'package:openvine/blocs/close_guard.dart';
 import 'package:openvine/blocs/notification_settings/notification_settings_state.dart';
 import 'package:openvine/models/notification_preferences.dart';
 import 'package:openvine/services/notification_preferences_service.dart';
@@ -10,26 +13,60 @@ import 'package:openvine/services/notification_preferences_service.dart';
 /// Cubit backing `NotificationSettingsScreen`.
 ///
 /// Holds the notification [NotificationSettingsState.preferences] and writes
-/// mutations through [NotificationPreferencesService].
-class NotificationSettingsCubit extends Cubit<NotificationSettingsState> {
+/// mutations through [NotificationPreferencesService]. A null
+/// [NotificationRepository] — the signed-out case — leaves the
+/// mark-all-as-read action permanently
+/// [MarkAllAsReadStatus.unavailable].
+class NotificationSettingsCubit extends Cubit<NotificationSettingsState>
+    with CloseGuardedEmit<NotificationSettingsState> {
   NotificationSettingsCubit({
     required NotificationPreferencesService preferencesService,
+    NotificationRepository? notificationRepository,
   }) : _preferencesService = preferencesService,
-       super(const NotificationSettingsState());
+       _notificationRepository = notificationRepository,
+       super(
+         NotificationSettingsState(
+           markAllAsReadStatus: notificationRepository == null
+               ? MarkAllAsReadStatus.unavailable
+               : MarkAllAsReadStatus.idle,
+         ),
+       );
 
   final NotificationPreferencesService _preferencesService;
+  final NotificationRepository? _notificationRepository;
 
   /// Loads the persisted preferences. `loadPreferences` is itself defensive
   /// (returns defaults on storage/decoding errors), so this does not throw.
   Future<void> load() async {
     emit(state.copyWith(status: NotificationSettingsStatus.loading));
     final preferences = await _preferencesService.loadPreferences();
-    emit(
+    emitIfOpen(
       state.copyWith(
         status: NotificationSettingsStatus.ready,
         preferences: preferences,
       ),
     );
+  }
+
+  /// Marks every notification as read, ignoring taps that arrive while a
+  /// previous call is still in flight.
+  Future<void> markAllAsRead() async {
+    final repository = _notificationRepository;
+    if (repository == null || !state.canMarkAllAsRead) return;
+    emit(
+      state.copyWith(markAllAsReadStatus: MarkAllAsReadStatus.inProgress),
+    );
+    try {
+      await repository.markAllAsRead();
+      emitIfOpen(
+        state.copyWith(markAllAsReadStatus: MarkAllAsReadStatus.success),
+      );
+    } catch (error, stackTrace) {
+      addError(error, stackTrace);
+      emitIfOpen(
+        state.copyWith(markAllAsReadStatus: MarkAllAsReadStatus.failure),
+      );
+    }
   }
 
   /// Applies [preferences] optimistically, then persists them.

--- a/mobile/lib/blocs/notification_settings/notification_settings_state.dart
+++ b/mobile/lib/blocs/notification_settings/notification_settings_state.dart
@@ -7,6 +7,12 @@ import 'package:openvine/models/notification_preferences.dart';
 /// Load lifecycle of the notification settings screen.
 enum NotificationSettingsStatus { initial, loading, ready }
 
+/// Lifecycle of the mark-all-as-read action.
+///
+/// [unavailable] means there is no notification repository to call — the
+/// signed-out case — and is fixed for the cubit's lifetime.
+enum MarkAllAsReadStatus { unavailable, idle, inProgress, success, failure }
+
 /// State for [NotificationSettingsCubit].
 ///
 /// [preferences] is persisted via `NotificationPreferencesService`.
@@ -14,21 +20,30 @@ class NotificationSettingsState extends Equatable {
   const NotificationSettingsState({
     this.status = NotificationSettingsStatus.initial,
     this.preferences = const NotificationPreferences(),
+    this.markAllAsReadStatus = MarkAllAsReadStatus.unavailable,
   });
 
   final NotificationSettingsStatus status;
   final NotificationPreferences preferences;
+  final MarkAllAsReadStatus markAllAsReadStatus;
+
+  /// Whether the mark-all-as-read action should accept a tap right now.
+  bool get canMarkAllAsRead =>
+      markAllAsReadStatus != MarkAllAsReadStatus.unavailable &&
+      markAllAsReadStatus != MarkAllAsReadStatus.inProgress;
 
   NotificationSettingsState copyWith({
     NotificationSettingsStatus? status,
     NotificationPreferences? preferences,
+    MarkAllAsReadStatus? markAllAsReadStatus,
   }) {
     return NotificationSettingsState(
       status: status ?? this.status,
       preferences: preferences ?? this.preferences,
+      markAllAsReadStatus: markAllAsReadStatus ?? this.markAllAsReadStatus,
     );
   }
 
   @override
-  List<Object?> get props => [status, preferences];
+  List<Object?> get props => [status, preferences, markAllAsReadStatus];
 }

--- a/mobile/lib/screens/notification_settings_screen.dart
+++ b/mobile/lib/screens/notification_settings_screen.dart
@@ -312,9 +312,12 @@ class _ActionCard extends StatelessWidget {
       trailing: isBusy
           ? SizedBox.square(
               dimension: DivineIcon.scaleSize(context, 24),
-              child: const CircularProgressIndicator(
+              child: CircularProgressIndicator(
                 strokeWidth: 2,
-                valueColor: AlwaysStoppedAnimation<Color>(VineTheme.primary),
+                semanticsLabel: context.l10n.commonLoading,
+                valueColor: const AlwaysStoppedAnimation<Color>(
+                  VineTheme.primary,
+                ),
               ),
             )
           : const DivineIcon(

--- a/mobile/lib/screens/notification_settings_screen.dart
+++ b/mobile/lib/screens/notification_settings_screen.dart
@@ -6,7 +6,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-import 'package:notification_repository/notification_repository.dart';
 import 'package:openvine/blocs/notification_settings/notification_settings_cubit.dart';
 import 'package:openvine/blocs/notification_settings/notification_settings_state.dart';
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
@@ -34,49 +33,27 @@ class NotificationSettingsScreen extends ConsumerWidget {
     final repository = ref.watch(notificationRepositoryProvider);
 
     return BlocProvider(
-      // notificationPreferencesServiceProvider watches authServiceProvider, so
-      // its identity can change on auth flip; re-key so the Cubit reloads with
-      // the fresh service instead of operating on a stale one.
-      key: ValueKey(preferencesService),
-      create: (_) =>
-          NotificationSettingsCubit(preferencesService: preferencesService)
-            ..load(),
+      // Both providers watch authServiceProvider, so their identities can
+      // change on auth flip; re-key so the Cubit reloads with the fresh
+      // dependencies instead of operating on stale ones.
+      key: ValueKey((preferencesService, repository)),
+      create: (_) => NotificationSettingsCubit(
+        preferencesService: preferencesService,
+        notificationRepository: repository,
+      )..load(),
       child: NotificationSettingsView(
-        onMarkAllAsRead: repository == null
-            ? null
-            : () => _markAllAsRead(repository),
         showNewPosts: ref.watch(
           isFeatureEnabledProvider(FeatureFlag.newPostNotifications),
         ),
       ),
     );
   }
-
-  Future<bool> _markAllAsRead(NotificationRepository repository) async {
-    try {
-      await repository.markAllAsRead();
-      return true;
-    } catch (_) {
-      return false;
-    }
-  }
 }
 
 /// View: renders the notification settings UI from the Cubit state.
-///
-/// [onMarkAllAsRead] performs the bridge-level repository call and resolves to
-/// whether it succeeded; `null` disables the mark-all-as-read action. That
-/// action stays out of the Cubit because it uses a separate, auth-nullable
-/// notification repository (see #4744 scope decision).
 class NotificationSettingsView extends StatelessWidget {
   @visibleForTesting
-  const NotificationSettingsView({
-    required this.onMarkAllAsRead,
-    required this.showNewPosts,
-    super.key,
-  });
-
-  final Future<bool> Function()? onMarkAllAsRead;
+  const NotificationSettingsView({required this.showNewPosts, super.key});
 
   /// Whether to offer the new-post ("bell") toggle. Hidden until the push
   /// service delivers kind 34236, since there is no bell to switch off and
@@ -98,117 +75,147 @@ class NotificationSettingsView extends StatelessWidget {
         ),
       ],
     ),
-    body: Align(
-      alignment: Alignment.topCenter,
-      child: ConstrainedBox(
-        constraints: const BoxConstraints(maxWidth: 600),
-        child:
-            BlocBuilder<NotificationSettingsCubit, NotificationSettingsState>(
-              builder: (context, state) {
-                final cubit = context.read<NotificationSettingsCubit>();
-                final prefs = state.preferences;
-                return ListView(
-                  padding: .fromLTRB(
-                    16,
-                    16,
-                    16,
-                    16 + MediaQuery.viewPaddingOf(context).bottom,
-                  ),
-                  children: [
-                    DivineSectionHeader(
-                      context.l10n.notificationSettingsTypes,
-                      padding: const EdgeInsets.only(bottom: 8),
+    body: BlocListener<NotificationSettingsCubit, NotificationSettingsState>(
+      listenWhen: (previous, current) =>
+          previous.markAllAsReadStatus != current.markAllAsReadStatus,
+      listener: _onMarkAllAsReadStatusChanged,
+      child: Align(
+        alignment: Alignment.topCenter,
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 600),
+          child:
+              BlocBuilder<NotificationSettingsCubit, NotificationSettingsState>(
+                builder: (context, state) {
+                  final cubit = context.read<NotificationSettingsCubit>();
+                  final prefs = state.preferences;
+                  return ListView(
+                    padding: .fromLTRB(
+                      16,
+                      16,
+                      16,
+                      16 + MediaQuery.viewPaddingOf(context).bottom,
                     ),
-                    _NotificationCard(
-                      icon: DivineIconName.heart,
-                      iconColor: VineTheme.likeRed,
-                      title: context.l10n.notificationSettingsLikes,
-                      subtitle: context.l10n.notificationSettingsLikesSubtitle,
-                      value: prefs.likesEnabled,
-                      onChanged: (value) => cubit.setPreferences(
-                        prefs.copyWith(likesEnabled: value),
+                    children: [
+                      DivineSectionHeader(
+                        context.l10n.notificationSettingsTypes,
+                        padding: const EdgeInsets.only(bottom: 8),
                       ),
-                    ),
-                    _NotificationCard(
-                      icon: DivineIconName.chat,
-                      iconColor: VineTheme.commentBlue,
-                      title: context.l10n.notificationSettingsComments,
-                      subtitle:
-                          context.l10n.notificationSettingsCommentsSubtitle,
-                      value: prefs.commentsEnabled,
-                      onChanged: (value) => cubit.setPreferences(
-                        prefs.copyWith(commentsEnabled: value),
-                      ),
-                    ),
-                    _NotificationCard(
-                      icon: DivineIconName.user,
-                      iconColor: VineTheme.vineGreen,
-                      title: context.l10n.notificationSettingsFollows,
-                      subtitle:
-                          context.l10n.notificationSettingsFollowsSubtitle,
-                      value: prefs.followsEnabled,
-                      onChanged: (value) => cubit.setPreferences(
-                        prefs.copyWith(followsEnabled: value),
-                      ),
-                    ),
-                    _NotificationCard(
-                      icon: DivineIconName.chat,
-                      iconColor: VineTheme.warning,
-                      title: context.l10n.notificationSettingsMentions,
-                      subtitle:
-                          context.l10n.notificationSettingsMentionsSubtitle,
-                      value: prefs.mentionsEnabled,
-                      onChanged: (value) => cubit.setPreferences(
-                        prefs.copyWith(mentionsEnabled: value),
-                      ),
-                    ),
-                    _NotificationCard(
-                      icon: DivineIconName.repeat,
-                      iconColor: VineTheme.vineGreenDark,
-                      title: context.l10n.notificationSettingsReposts,
-                      subtitle:
-                          context.l10n.notificationSettingsRepostsSubtitle,
-                      value: prefs.repostsEnabled,
-                      onChanged: (value) => cubit.setPreferences(
-                        prefs.copyWith(repostsEnabled: value),
-                      ),
-                    ),
-                    if (showNewPosts)
                       _NotificationCard(
-                        icon: DivineIconName.bellSimple,
-                        iconColor: VineTheme.vineGreen,
-                        title: context.l10n.notificationSettingsNewPosts,
+                        icon: DivineIconName.heart,
+                        iconColor: VineTheme.likeRed,
+                        title: context.l10n.notificationSettingsLikes,
                         subtitle:
-                            context.l10n.notificationSettingsNewPostsSubtitle,
-                        value: prefs.newPostsEnabled,
+                            context.l10n.notificationSettingsLikesSubtitle,
+                        value: prefs.likesEnabled,
                         onChanged: (value) => cubit.setPreferences(
-                          prefs.copyWith(newPostsEnabled: value),
+                          prefs.copyWith(likesEnabled: value),
                         ),
                       ),
-                    DivineSectionHeader(
-                      context.l10n.notificationSettingsActions,
-                      padding: const EdgeInsets.only(top: 24, bottom: 8),
-                    ),
-                    _ActionCard(
-                      icon: DivineIconName.checkCircle,
-                      iconColor: VineTheme.vineGreenDark,
-                      title: context.l10n.notificationSettingsMarkAllAsRead,
-                      subtitle: context
-                          .l10n
-                          .notificationSettingsMarkAllAsReadSubtitle,
-                      onTap: onMarkAllAsRead == null
-                          ? null
-                          : () => _onMarkAllAsReadPressed(context),
-                    ),
-                    const SizedBox(height: 24),
-                    const _InfoCard(),
-                  ],
-                );
-              },
-            ),
+                      _NotificationCard(
+                        icon: DivineIconName.chat,
+                        iconColor: VineTheme.commentBlue,
+                        title: context.l10n.notificationSettingsComments,
+                        subtitle:
+                            context.l10n.notificationSettingsCommentsSubtitle,
+                        value: prefs.commentsEnabled,
+                        onChanged: (value) => cubit.setPreferences(
+                          prefs.copyWith(commentsEnabled: value),
+                        ),
+                      ),
+                      _NotificationCard(
+                        icon: DivineIconName.user,
+                        iconColor: VineTheme.vineGreen,
+                        title: context.l10n.notificationSettingsFollows,
+                        subtitle:
+                            context.l10n.notificationSettingsFollowsSubtitle,
+                        value: prefs.followsEnabled,
+                        onChanged: (value) => cubit.setPreferences(
+                          prefs.copyWith(followsEnabled: value),
+                        ),
+                      ),
+                      _NotificationCard(
+                        icon: DivineIconName.chat,
+                        iconColor: VineTheme.warning,
+                        title: context.l10n.notificationSettingsMentions,
+                        subtitle:
+                            context.l10n.notificationSettingsMentionsSubtitle,
+                        value: prefs.mentionsEnabled,
+                        onChanged: (value) => cubit.setPreferences(
+                          prefs.copyWith(mentionsEnabled: value),
+                        ),
+                      ),
+                      _NotificationCard(
+                        icon: DivineIconName.repeat,
+                        iconColor: VineTheme.vineGreenDark,
+                        title: context.l10n.notificationSettingsReposts,
+                        subtitle:
+                            context.l10n.notificationSettingsRepostsSubtitle,
+                        value: prefs.repostsEnabled,
+                        onChanged: (value) => cubit.setPreferences(
+                          prefs.copyWith(repostsEnabled: value),
+                        ),
+                      ),
+                      if (showNewPosts)
+                        _NotificationCard(
+                          icon: DivineIconName.bellSimple,
+                          iconColor: VineTheme.vineGreen,
+                          title: context.l10n.notificationSettingsNewPosts,
+                          subtitle:
+                              context.l10n.notificationSettingsNewPostsSubtitle,
+                          value: prefs.newPostsEnabled,
+                          onChanged: (value) => cubit.setPreferences(
+                            prefs.copyWith(newPostsEnabled: value),
+                          ),
+                        ),
+                      DivineSectionHeader(
+                        context.l10n.notificationSettingsActions,
+                        padding: const EdgeInsets.only(top: 24, bottom: 8),
+                      ),
+                      _ActionCard(
+                        icon: DivineIconName.checkCircle,
+                        iconColor: VineTheme.vineGreenDark,
+                        title: context.l10n.notificationSettingsMarkAllAsRead,
+                        subtitle: context
+                            .l10n
+                            .notificationSettingsMarkAllAsReadSubtitle,
+                        isBusy:
+                            state.markAllAsReadStatus ==
+                            MarkAllAsReadStatus.inProgress,
+                        onTap: state.canMarkAllAsRead
+                            ? cubit.markAllAsRead
+                            : null,
+                      ),
+                      const SizedBox(height: 24),
+                      const _InfoCard(),
+                    ],
+                  );
+                },
+              ),
+        ),
       ),
     ),
   );
+
+  void _onMarkAllAsReadStatusChanged(
+    BuildContext context,
+    NotificationSettingsState state,
+  ) {
+    final status = state.markAllAsReadStatus;
+    if (status != MarkAllAsReadStatus.success &&
+        status != MarkAllAsReadStatus.failure) {
+      return;
+    }
+    final failed = status == MarkAllAsReadStatus.failure;
+    ScaffoldMessenger.of(context).showSnackBar(
+      DivineSnackbarContainer.snackBar(
+        failed
+            ? context.l10n.notificationSettingsMarkAllAsReadFailed
+            : context.l10n.notificationSettingsAllMarkedAsRead,
+        error: failed,
+        duration: const Duration(seconds: 2),
+      ),
+    );
+  }
 
   Future<void> _onResetPressed(BuildContext context) async {
     await context.read<NotificationSettingsCubit>().resetToDefaults();
@@ -216,20 +223,6 @@ class NotificationSettingsView extends StatelessWidget {
     ScaffoldMessenger.of(context).showSnackBar(
       DivineSnackbarContainer.snackBar(
         context.l10n.notificationSettingsResetToDefaults,
-        duration: const Duration(seconds: 2),
-      ),
-    );
-  }
-
-  Future<void> _onMarkAllAsReadPressed(BuildContext context) async {
-    final success = await onMarkAllAsRead!();
-    if (!context.mounted) return;
-    ScaffoldMessenger.of(context).showSnackBar(
-      DivineSnackbarContainer.snackBar(
-        success
-            ? context.l10n.notificationSettingsAllMarkedAsRead
-            : context.l10n.notificationSettingsMarkAllAsReadFailed,
-        error: !success,
         duration: const Duration(seconds: 2),
       ),
     );
@@ -282,6 +275,7 @@ class _ActionCard extends StatelessWidget {
     required this.title,
     required this.subtitle,
     required this.onTap,
+    this.isBusy = false,
   });
 
   final DivineIconName icon;
@@ -289,6 +283,9 @@ class _ActionCard extends StatelessWidget {
   final String title;
   final String subtitle;
   final VoidCallback? onTap;
+
+  /// Swaps the trailing caret for a spinner while the action runs.
+  final bool isBusy;
 
   @override
   Widget build(BuildContext context) => Card(
@@ -312,10 +309,18 @@ class _ActionCard extends StatelessWidget {
         subtitle,
         style: VineTheme.bodySmallFont(color: context.vineColors.secondaryText),
       ),
-      trailing: const DivineIcon(
-        icon: DivineIconName.caretRight,
-        color: VineTheme.primary,
-      ),
+      trailing: isBusy
+          ? SizedBox.square(
+              dimension: DivineIcon.scaleSize(context, 24),
+              child: const CircularProgressIndicator(
+                strokeWidth: 2,
+                valueColor: AlwaysStoppedAnimation<Color>(VineTheme.primary),
+              ),
+            )
+          : const DivineIcon(
+              icon: DivineIconName.caretRight,
+              color: VineTheme.primary,
+            ),
       onTap: onTap,
     ),
   );

--- a/mobile/scripts/baseline/post_close_emit.txt
+++ b/mobile/scripts/baseline/post_close_emit.txt
@@ -25,7 +25,6 @@ lib/blocs/dm/unread_count/dm_unread_count_cubit.dart	1
 lib/blocs/email_verification/email_verification_cubit.dart	14
 lib/blocs/inline_comment_composer/inline_comment_composer_cubit.dart	2
 lib/blocs/locale/locale_cubit.dart	2
-lib/blocs/notification_settings/notification_settings_cubit.dart	1
 lib/blocs/notifications/badge/notification_badge_cubit.dart	1
 lib/blocs/profile_reposted_videos/profile_reposted_videos_bloc.dart	1
 lib/blocs/saved_sounds/saved_sounds_bloc.dart	1

--- a/mobile/test/blocs/notification_settings/notification_settings_cubit_test.dart
+++ b/mobile/test/blocs/notification_settings/notification_settings_cubit_test.dart
@@ -1,9 +1,12 @@
 // ABOUTME: Unit tests for NotificationSettingsCubit — load, preference
-// ABOUTME: persistence, and reset-to-defaults.
+// ABOUTME: persistence, reset-to-defaults, and mark-all-as-read.
+
+import 'dart:async';
 
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:notification_repository/notification_repository.dart';
 import 'package:openvine/blocs/notification_settings/notification_settings_cubit.dart';
 import 'package:openvine/blocs/notification_settings/notification_settings_state.dart';
 import 'package:openvine/models/notification_preferences.dart';
@@ -12,6 +15,9 @@ import 'package:openvine/services/notification_preferences_service.dart';
 class _MockNotificationPreferencesService extends Mock
     implements NotificationPreferencesService {}
 
+class _MockNotificationRepository extends Mock
+    implements NotificationRepository {}
+
 void main() {
   setUpAll(() {
     registerFallbackValue(const NotificationPreferences());
@@ -19,17 +25,29 @@ void main() {
 
   group(NotificationSettingsCubit, () {
     late _MockNotificationPreferencesService service;
+    late _MockNotificationRepository repository;
+    late Completer<void> inFlight;
 
     setUp(() {
       service = _MockNotificationPreferencesService();
+      repository = _MockNotificationRepository();
       when(
         service.loadPreferences,
       ).thenAnswer((_) async => const NotificationPreferences());
       when(() => service.updatePreferences(any())).thenAnswer((_) async {});
+      when(repository.markAllAsRead).thenAnswer((_) async {});
     });
 
+    // No repository: the signed-out shape, where mark-all-as-read is
+    // permanently unavailable.
     NotificationSettingsCubit buildCubit() =>
         NotificationSettingsCubit(preferencesService: service);
+
+    NotificationSettingsCubit buildCubitWithRepository() =>
+        NotificationSettingsCubit(
+          preferencesService: service,
+          notificationRepository: repository,
+        );
 
     blocTest<NotificationSettingsCubit, NotificationSettingsState>(
       'load emits loading then ready with the loaded preferences',
@@ -86,5 +104,80 @@ void main() {
         ).called(1);
       },
     );
+
+    group('markAllAsRead', () {
+      blocTest<NotificationSettingsCubit, NotificationSettingsState>(
+        'emits inProgress then success on a successful write',
+        build: buildCubitWithRepository,
+        act: (cubit) => cubit.markAllAsRead(),
+        expect: () => const [
+          NotificationSettingsState(
+            markAllAsReadStatus: MarkAllAsReadStatus.inProgress,
+          ),
+          NotificationSettingsState(
+            markAllAsReadStatus: MarkAllAsReadStatus.success,
+          ),
+        ],
+        verify: (_) {
+          verify(repository.markAllAsRead).called(1);
+        },
+      );
+
+      blocTest<NotificationSettingsCubit, NotificationSettingsState>(
+        'emits inProgress then failure and reports the error when it throws',
+        setUp: () {
+          when(repository.markAllAsRead).thenThrow(Exception('server fail'));
+        },
+        build: buildCubitWithRepository,
+        act: (cubit) => cubit.markAllAsRead(),
+        expect: () => const [
+          NotificationSettingsState(
+            markAllAsReadStatus: MarkAllAsReadStatus.inProgress,
+          ),
+          NotificationSettingsState(
+            markAllAsReadStatus: MarkAllAsReadStatus.failure,
+          ),
+        ],
+        errors: () => [isA<Exception>()],
+      );
+
+      blocTest<NotificationSettingsCubit, NotificationSettingsState>(
+        // Guards against reordering the null check after a status emit:
+        // signed-out must produce no state churn at all.
+        'emits nothing without a repository',
+        build: buildCubit,
+        act: (cubit) => cubit.markAllAsRead(),
+        expect: () => const <NotificationSettingsState>[],
+      );
+
+      blocTest<NotificationSettingsCubit, NotificationSettingsState>(
+        'drops a second call while the first is still in flight',
+        setUp: () {
+          inFlight = Completer<void>();
+          when(repository.markAllAsRead).thenAnswer((_) => inFlight.future);
+        },
+        build: buildCubitWithRepository,
+        act: (cubit) async {
+          final first = cubit.markAllAsRead();
+          // Deliberately not awaited: if the guard regresses, this call
+          // blocks on the same completer, and awaiting it here would
+          // deadlock the test instead of failing it.
+          unawaited(cubit.markAllAsRead());
+          inFlight.complete();
+          await first;
+        },
+        expect: () => const [
+          NotificationSettingsState(
+            markAllAsReadStatus: MarkAllAsReadStatus.inProgress,
+          ),
+          NotificationSettingsState(
+            markAllAsReadStatus: MarkAllAsReadStatus.success,
+          ),
+        ],
+        verify: (_) {
+          verify(repository.markAllAsRead).called(1);
+        },
+      );
+    });
   });
 }

--- a/mobile/test/screens/notification_settings_screen_test.dart
+++ b/mobile/test/screens/notification_settings_screen_test.dart
@@ -67,111 +67,108 @@ void main() {
       );
     }
 
-    testWidgets(
-      'shows success snackbar when markAllAsRead succeeds',
-      (tester) async {
-        when(mockRepo.markAllAsRead).thenAnswer((_) async {});
+    testWidgets('shows success snackbar when markAllAsRead succeeds', (
+      tester,
+    ) async {
+      when(mockRepo.markAllAsRead).thenAnswer((_) async {});
 
-        await tester.pumpWidget(buildSubject(repo: mockRepo));
-        await tester.pumpAndSettle();
+      await tester.pumpWidget(buildSubject(repo: mockRepo));
+      await tester.pumpAndSettle();
 
-        final l10n = AppLocalizations.of(
-          tester.element(find.byType(NotificationSettingsScreen)),
-        );
+      final l10n = AppLocalizations.of(
+        tester.element(find.byType(NotificationSettingsScreen)),
+      );
 
-        await scrollUntilTappable(
-          tester,
-          find.text(l10n.notificationSettingsMarkAllAsRead),
-          200,
-          scrollable: find.byType(Scrollable).first,
-        );
+      await scrollUntilTappable(
+        tester,
+        find.text(l10n.notificationSettingsMarkAllAsRead),
+        200,
+        scrollable: find.byType(Scrollable).first,
+      );
 
-        await tester.tap(find.text(l10n.notificationSettingsMarkAllAsRead));
-        await tester.pump();
-        await tester.pump(const Duration(milliseconds: 100));
+      await tester.tap(find.text(l10n.notificationSettingsMarkAllAsRead));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
 
-        verify(mockRepo.markAllAsRead).called(1);
-        expect(
-          find.text(l10n.notificationSettingsAllMarkedAsRead),
-          findsOneWidget,
-        );
-        final banner = tester.widget<DivineSnackbarContainer>(
-          find.byType(DivineSnackbarContainer),
-        );
-        expect(banner.error, isFalse);
-      },
-    );
+      verify(mockRepo.markAllAsRead).called(1);
+      expect(
+        find.text(l10n.notificationSettingsAllMarkedAsRead),
+        findsOneWidget,
+      );
+      final banner = tester.widget<DivineSnackbarContainer>(
+        find.byType(DivineSnackbarContainer),
+      );
+      expect(banner.error, isFalse);
+    });
 
-    testWidgets(
-      'shows failure snackbar when markAllAsRead throws',
-      (tester) async {
-        when(mockRepo.markAllAsRead).thenThrow(Exception('server fail'));
+    testWidgets('shows failure snackbar when markAllAsRead throws', (
+      tester,
+    ) async {
+      when(mockRepo.markAllAsRead).thenThrow(Exception('server fail'));
 
-        await tester.pumpWidget(buildSubject(repo: mockRepo));
-        await tester.pumpAndSettle();
+      await tester.pumpWidget(buildSubject(repo: mockRepo));
+      await tester.pumpAndSettle();
 
-        final l10n = AppLocalizations.of(
-          tester.element(find.byType(NotificationSettingsScreen)),
-        );
+      final l10n = AppLocalizations.of(
+        tester.element(find.byType(NotificationSettingsScreen)),
+      );
 
-        await scrollUntilTappable(
-          tester,
-          find.text(l10n.notificationSettingsMarkAllAsRead),
-          200,
-          scrollable: find.byType(Scrollable).first,
-        );
+      await scrollUntilTappable(
+        tester,
+        find.text(l10n.notificationSettingsMarkAllAsRead),
+        200,
+        scrollable: find.byType(Scrollable).first,
+      );
 
-        await tester.tap(find.text(l10n.notificationSettingsMarkAllAsRead));
-        await tester.pump();
-        await tester.pump(const Duration(milliseconds: 100));
+      await tester.tap(find.text(l10n.notificationSettingsMarkAllAsRead));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
 
-        verify(mockRepo.markAllAsRead).called(1);
-        expect(
-          find.text(l10n.notificationSettingsMarkAllAsReadFailed),
-          findsOneWidget,
-        );
-        final banner = tester.widget<DivineSnackbarContainer>(
-          find.byType(DivineSnackbarContainer),
-        );
-        expect(banner.error, isTrue);
-      },
-    );
+      verify(mockRepo.markAllAsRead).called(1);
+      expect(
+        find.text(l10n.notificationSettingsMarkAllAsReadFailed),
+        findsOneWidget,
+      );
+      final banner = tester.widget<DivineSnackbarContainer>(
+        find.byType(DivineSnackbarContainer),
+      );
+      expect(banner.error, isTrue);
+    });
 
-    testWidgets(
-      'ignores repeat taps while markAllAsRead is still in flight',
-      (tester) async {
-        final inFlight = Completer<void>();
-        var callCount = 0;
-        when(mockRepo.markAllAsRead).thenAnswer((_) {
-          callCount++;
-          return inFlight.future;
-        });
+    testWidgets('ignores repeat taps while markAllAsRead is still in flight', (
+      tester,
+    ) async {
+      final inFlight = Completer<void>();
+      var callCount = 0;
+      when(mockRepo.markAllAsRead).thenAnswer((_) {
+        callCount++;
+        return inFlight.future;
+      });
 
-        await tester.pumpWidget(buildSubject(repo: mockRepo));
-        await tester.pumpAndSettle();
+      await tester.pumpWidget(buildSubject(repo: mockRepo));
+      await tester.pumpAndSettle();
 
-        final l10n = AppLocalizations.of(
-          tester.element(find.byType(NotificationSettingsScreen)),
-        );
+      final l10n = AppLocalizations.of(
+        tester.element(find.byType(NotificationSettingsScreen)),
+      );
 
-        await scrollUntilTappable(
-          tester,
-          find.text(l10n.notificationSettingsMarkAllAsRead),
-          200,
-          scrollable: find.byType(Scrollable).first,
-        );
+      await scrollUntilTappable(
+        tester,
+        find.text(l10n.notificationSettingsMarkAllAsRead),
+        200,
+        scrollable: find.byType(Scrollable).first,
+      );
 
-        await tester.tap(find.text(l10n.notificationSettingsMarkAllAsRead));
-        await tester.pump();
-        await tester.tap(find.text(l10n.notificationSettingsMarkAllAsRead));
-        await tester.pump();
+      await tester.tap(find.text(l10n.notificationSettingsMarkAllAsRead));
+      await tester.pump();
+      await tester.tap(find.text(l10n.notificationSettingsMarkAllAsRead));
+      await tester.pump();
 
-        expect(callCount, equals(1));
+      expect(callCount, equals(1));
 
-        inFlight.complete();
-        await tester.pumpAndSettle();
-      },
-    );
+      inFlight.complete();
+      await tester.pumpAndSettle();
+    });
 
     testWidgets(
       'swaps the action card caret for a spinner while marking as read',
@@ -210,6 +207,10 @@ void main() {
         await tester.pump();
 
         expect(spinner, findsOneWidget);
+        expect(
+          tester.widget<CircularProgressIndicator>(spinner).semanticsLabel,
+          equals(l10n.commonLoading),
+        );
 
         inFlight.complete();
         await tester.pumpAndSettle();

--- a/mobile/test/screens/notification_settings_screen_test.dart
+++ b/mobile/test/screens/notification_settings_screen_test.dart
@@ -3,6 +3,8 @@
 // ABOUTME: snackbar, disabled-when-repo-null behaviour, and that toggling a
 // ABOUTME: notification-type switch persists the flipped preference.
 
+import 'dart:async';
+
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -132,6 +134,87 @@ void main() {
           find.byType(DivineSnackbarContainer),
         );
         expect(banner.error, isTrue);
+      },
+    );
+
+    testWidgets(
+      'ignores repeat taps while markAllAsRead is still in flight',
+      (tester) async {
+        final inFlight = Completer<void>();
+        var callCount = 0;
+        when(mockRepo.markAllAsRead).thenAnswer((_) {
+          callCount++;
+          return inFlight.future;
+        });
+
+        await tester.pumpWidget(buildSubject(repo: mockRepo));
+        await tester.pumpAndSettle();
+
+        final l10n = AppLocalizations.of(
+          tester.element(find.byType(NotificationSettingsScreen)),
+        );
+
+        await scrollUntilTappable(
+          tester,
+          find.text(l10n.notificationSettingsMarkAllAsRead),
+          200,
+          scrollable: find.byType(Scrollable).first,
+        );
+
+        await tester.tap(find.text(l10n.notificationSettingsMarkAllAsRead));
+        await tester.pump();
+        await tester.tap(find.text(l10n.notificationSettingsMarkAllAsRead));
+        await tester.pump();
+
+        expect(callCount, equals(1));
+
+        inFlight.complete();
+        await tester.pumpAndSettle();
+      },
+    );
+
+    testWidgets(
+      'swaps the action card caret for a spinner while marking as read',
+      (tester) async {
+        final inFlight = Completer<void>();
+        when(mockRepo.markAllAsRead).thenAnswer((_) => inFlight.future);
+
+        await tester.pumpWidget(buildSubject(repo: mockRepo));
+        await tester.pumpAndSettle();
+
+        final l10n = AppLocalizations.of(
+          tester.element(find.byType(NotificationSettingsScreen)),
+        );
+
+        await scrollUntilTappable(
+          tester,
+          find.text(l10n.notificationSettingsMarkAllAsRead),
+          200,
+          scrollable: find.byType(Scrollable).first,
+        );
+
+        final actionTile = find
+            .ancestor(
+              of: find.text(l10n.notificationSettingsMarkAllAsRead),
+              matching: find.byType(ListTile),
+            )
+            .first;
+        final spinner = find.descendant(
+          of: actionTile,
+          matching: find.byType(CircularProgressIndicator),
+        );
+
+        expect(spinner, findsNothing);
+
+        await tester.tap(find.text(l10n.notificationSettingsMarkAllAsRead));
+        await tester.pump();
+
+        expect(spinner, findsOneWidget);
+
+        inFlight.complete();
+        await tester.pumpAndSettle();
+
+        expect(spinner, findsNothing);
       },
     );
 

--- a/mobile/test/screens/notification_settings_screen_test.dart
+++ b/mobile/test/screens/notification_settings_screen_test.dart
@@ -208,7 +208,7 @@ void main() {
 
         expect(spinner, findsOneWidget);
         expect(
-          tester.widget<CircularProgressIndicator>(spinner).semanticsLabel,
+          tester.getSemantics(spinner).getSemanticsData().label,
           equals(l10n.commonLoading),
         );
 


### PR DESCRIPTION
## Description

The mark-all-as-read action card on Notification Settings had no busy or disabled affordance. It stayed tappable for the whole round trip, so two taps sent **two** `markAllAsRead` writes, and the user got no feedback until the result snackbar landed — worst on a slow or offline network, which is exactly when the extra taps happen.

Reproduced first as a failing widget test: two taps during one in-flight request produced `Expected: <1>, Actual: <2>` repository calls.

The fix moves the action into `NotificationSettingsCubit` — the follow-up #4749 explicitly deferred, since `markAllAsRead` uses the separate auth-nullable `notificationRepositoryProvider` rather than the settings service:

- **`MarkAllAsReadStatus`** (`unavailable` / `idle` / `inProgress` / `success` / `failure`) drives the card. `unavailable` is the signed-out shape and is fixed for the cubit's lifetime, preserving today's disabled-when-repo-null behaviour.
- **Concurrent calls are dropped** at the cubit, not just hidden by the disabled button — a double tap can land inside a single frame, before the rebuild disables the tile.
- **The trailing caret swaps to a spinner** while the write runs, matching `DivineButton`'s existing loading treatment, and the spinner uses the existing `commonLoading` accessibility label.
- **The Page injects the repository** and re-keys the `BlocProvider` on `(preferencesService, repository)`, so an auth flip rebuilds the Cubit instead of stranding it on a stale repository.
- Result snackbars now fire from a `BlocListener` on status transitions; copy and error styling are unchanged.

**Related Issue:** Closes #7439

## Out of Scope

- The `_ActionCard` disabled state still renders title, subtitle and caret at full opacity. Dimming disabled rows is a design decision, not a bug fix.

## Not requested by the issue

Adding the `CloseGuardedEmit` mixin put `emitIfOpen` one character away from `load()`'s post-await `emit`, so that is guarded too. It was the cubit's last unguarded post-close emit, so `scripts/baseline/post_close_emit.txt` **shrinks by one entry**. Flagging it separately because it touches a CI baseline; it reverts cleanly on its own.

## Takeover update

- Added the existing `commonLoading` semantics label to the in-progress spinner.
- Added a widget test assertion that the spinner exposes that label.

## Verification

- `flutter analyze lib test integration_test` → No issues found.
- `dart format --set-exit-if-changed` → clean.
- `flutter test` over the screen, cubit, settings-scaffold, settings-nav, route-coverage and push-sync suites → **169 passed**, and again after rebasing onto `origin/main`.
- All 8 CI-only ratchets green (`post_close_emit`, `raw_colors`, `raw_textstyle`, `material_button`, `raw_dialog`, `layer_direction`, `test_unit_structure`, `untested_services_floor`).
- **Both new widget tests were watched failing first.** The repeat-tap test failed `Expected: <1>, Actual: <2>`; the spinner test failed `Found 0 widgets with type "CircularProgressIndicator"`.
- The cubit's in-flight guard test was verified by mutation — forcing `canMarkAllAsRead` to `true` makes it fail cleanly with `Expected: <1>, Actual: <2>`. It deliberately does not await the dropped call, so a future regression fails the test instead of deadlocking CI.
- Takeover verification on `39dc04ce94`: pre-push `flutter analyze` passed for the changed files, and pre-push `flutter test test/blocs/notification_settings/notification_settings_cubit_test.dart test/screens/notification_settings_screen_test.dart` passed 15 tests.

6 new tests (2 widget, 4 cubit); the 6 pre-existing widget tests pass unmodified, so snackbar and disabled-state behaviour is unchanged.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore