### PR TITLE
refactor(dm-restriction): pin Keycast fail directions (#7584)

### DIFF
--- a/mobile/lib/providers/protected_minor_providers.dart
+++ b/mobile/lib/providers/protected_minor_providers.dart
@@ -184,7 +184,7 @@ final keycastSignalApplicableProvider = Provider<bool>((ref) {
 /// - persisted last-known `notProtected` -> unrestricted, so adults don't eat
 ///   a lockout on every network blip;
 /// - everything else (protected, unknown, loading, missing token, never
-///   resolved) -> restricted.
+///   resolved, unauthenticated, auth source not yet restored) -> restricted.
 ///
 /// Pure self-custody accounts that have never been associated with Keycast
 /// are never restricted — they are outside Keycast's verified-minor signal and
@@ -199,7 +199,9 @@ final isDmRestrictedProvider = Provider<bool>((ref) {
   final keycastApplicable = ref.watch(keycastSignalApplicableProvider);
 
   if (authSource == AuthenticationSource.divineOAuth) {
-    // Mark as Keycast account for future self-custody detection (fire-and-forget).
+    // Intentional fire-and-forget monotonic marker; SharedPreferences updates
+    // its in-memory cache before the Future completes, so later synchronous
+    // wasKeycastAccountFor() reads see it in-session.
     store.markKeycastAccount(pubkey);
   }
 
@@ -219,6 +221,11 @@ final isDmRestrictedProvider = Provider<bool>((ref) {
   final lastKnown = store.lastKnownFor(pubkey);
   if (lastKnown != null) return lastKnown;
   if (authState != AuthState.authenticated || pubkey == null) return true;
+
+  // The auth source is restored asynchronously after the pubkey, so `none`
+  // means we do not yet know whether Keycast applies to this account. Fail
+  // closed rather than guess in the permissive direction.
+  if (authSource == AuthenticationSource.none) return true;
 
   // Fail closed only when Keycast signals are applicable to this account.
   if (!keycastApplicable) return false;

--- a/mobile/lib/providers/protected_minor_providers.dart
+++ b/mobile/lib/providers/protected_minor_providers.dart
@@ -151,6 +151,12 @@ final isProtectedMinorProvider = Provider<bool>((ref) {
 /// self-custody accounts that Keycast can never produce a verdict for (and
 /// must not be permanently restricted by an unanswerable check).
 final keycastSignalApplicableProvider = Provider<bool>((ref) {
+  // AuthService mutates its pubkey and auth-source fields in place, so watch
+  // the auth state to recompute on every account transition (sign-out,
+  // sign-in, account swap). Without this a cached value survives into the
+  // next account's session, and a stale `false` would lift the fail-closed
+  // DM restriction for a Keycast-backed account.
+  ref.watch(currentAuthStateProvider);
   final authService = ref.watch(authServiceProvider);
   final pubkey = authService.currentPublicKeyHex;
   final authSource = authService.authenticationSource;

--- a/mobile/lib/providers/protected_minor_providers.dart
+++ b/mobile/lib/providers/protected_minor_providers.dart
@@ -142,7 +142,37 @@ final isProtectedMinorProvider = Provider<bool>((ref) {
   return store.isProtectedMinorFor(pubkey);
 });
 
-/// The #176 DM-restriction seam — fail CLOSED, a deliberate divergence from
+/// Whether a Keycast-backed protected-minor verdict can apply to the current
+/// account. Returns `true` only for OAuth-authenticated accounts and for
+/// accounts that have previously been marked as Keycast-custodial.
+///
+/// The #176 DM restriction uses this to distinguish accounts that may have
+/// an unknown verdict from Keycast (and must fail closed) from pure
+/// self-custody accounts that Keycast can never produce a verdict for (and
+/// must not be permanently restricted by an unanswerable check).
+final keycastSignalApplicableProvider = Provider<bool>((ref) {
+  final authService = ref.watch(authServiceProvider);
+  final pubkey = authService.currentPublicKeyHex;
+  final authSource = authService.authenticationSource;
+  final store = ref.watch(protectedMinorStickyStoreProvider);
+
+  // OAuth accounts can receive a Keycast verdict; fail closed on unknown.
+  if (authSource == AuthenticationSource.divineOAuth) {
+    return true;
+  }
+
+  // Self-custody accounts that were previously seen by Keycast must stay
+  // fail-closed, since a pubkey can flip between auth sources on the same device.
+  if (pubkey != null && store.wasKeycastAccountFor(pubkey)) {
+    return true;
+  }
+
+  // Pure self-custody accounts that have never been seen by Keycast are not
+  // subject to Keycast signals.
+  return false;
+});
+
+/// The #176 DM-restriction seam — fail CLOSED conditionally, a deliberate divergence from
 /// [isProtectedMinorProvider] (which #175's content lock consumes fail-open):
 /// the restricted party can trivially suppress the input that produces an
 /// absent answer (airplane mode, cleared storage, blocked keycast domain,
@@ -154,10 +184,11 @@ final isProtectedMinorProvider = Provider<bool>((ref) {
 /// - persisted last-known `notProtected` -> unrestricted, so adults don't eat
 ///   a lockout on every network blip;
 /// - everything else (protected, unknown, loading, missing token, never
-///   resolved, unauthenticated) -> restricted.
+///   resolved) -> restricted.
 ///
-/// Pure self-custody accounts are outside Keycast's verified-minor signal and
-/// must not be permanently restricted by an answer Keycast can never provide.
+/// Pure self-custody accounts that have never been associated with Keycast
+/// are never restricted — they are outside Keycast's verified-minor signal and
+/// must not be permanently blocked by a check Keycast can never produce.
 final isDmRestrictedProvider = Provider<bool>((ref) {
   final authState = ref.watch(currentAuthStateProvider);
   final authService = ref.watch(authServiceProvider);
@@ -165,10 +196,10 @@ final isDmRestrictedProvider = Provider<bool>((ref) {
   final authSource = authService.authenticationSource;
   final store = ref.watch(protectedMinorStickyStoreProvider);
   final live = ref.watch(protectedMinorStatusProvider);
+  final keycastApplicable = ref.watch(keycastSignalApplicableProvider);
 
   if (authSource == AuthenticationSource.divineOAuth) {
-    // Intentional fire-and-forget monotonic marker; SharedPreferences updates
-    // its in-memory cache before the Future completes.
+    // Mark as Keycast account for future self-custody detection (fire-and-forget).
     store.markKeycastAccount(pubkey);
   }
 
@@ -188,17 +219,11 @@ final isDmRestrictedProvider = Provider<bool>((ref) {
   final lastKnown = store.lastKnownFor(pubkey);
   if (lastKnown != null) return lastKnown;
   if (authState != AuthState.authenticated || pubkey == null) return true;
-  if (authSource == AuthenticationSource.divineOAuth) return true;
-  if (store.wasKeycastAccountFor(pubkey)) return true;
-  return switch (authSource) {
-    AuthenticationSource.automatic ||
-    AuthenticationSource.importedKeys ||
-    AuthenticationSource.bunker ||
-    AuthenticationSource.amber ||
-    AuthenticationSource.nip07 => false,
-    AuthenticationSource.none => true,
-    AuthenticationSource.divineOAuth => true,
-  };
+
+  // Fail closed only when Keycast signals are applicable to this account.
+  if (!keycastApplicable) return false;
+
+  return true;
 });
 
 /// Whether the current DM restriction comes from a confirmed protected-minor

--- a/mobile/lib/providers/protected_minor_providers.dart
+++ b/mobile/lib/providers/protected_minor_providers.dart
@@ -152,10 +152,9 @@ final isProtectedMinorProvider = Provider<bool>((ref) {
 /// must not be permanently restricted by an unanswerable check).
 final keycastSignalApplicableProvider = Provider<bool>((ref) {
   // AuthService mutates its pubkey and auth-source fields in place, so watch
-  // the auth state to recompute on every account transition (sign-out,
-  // sign-in, account swap). Without this a cached value survives into the
-  // next account's session, and a stale `false` would lift the fail-closed
-  // DM restriction for a Keycast-backed account.
+  // the auth state so applicability recomputes across the current account-swap
+  // invariant: every swap transits a non-authenticated state. A future silent
+  // same-state pubkey swap must also invalidate this provider explicitly.
   ref.watch(currentAuthStateProvider);
   final authService = ref.watch(authServiceProvider);
   final pubkey = authService.currentPublicKeyHex;
@@ -168,17 +167,27 @@ final keycastSignalApplicableProvider = Provider<bool>((ref) {
   }
 
   // Self-custody accounts that were previously seen by Keycast must stay
-  // fail-closed, since a pubkey can flip between auth sources on the same device.
+  // fail-closed, since a pubkey can flip between auth sources on the same
+  // device.
   if (pubkey != null && store.wasKeycastAccountFor(pubkey)) {
     return true;
   }
 
-  // Pure self-custody accounts that have never been seen by Keycast are not
-  // subject to Keycast signals.
-  return false;
+  // Keep this exhaustive so every new auth source requires an explicit
+  // fail-direction decision at this child-safety boundary.
+  return switch (authSource) {
+    AuthenticationSource.divineOAuth => true,
+    AuthenticationSource.none ||
+    AuthenticationSource.automatic ||
+    AuthenticationSource.importedKeys ||
+    AuthenticationSource.bunker ||
+    AuthenticationSource.amber ||
+    AuthenticationSource.nip07 => false,
+  };
 });
 
-/// The #176 DM-restriction seam — fail CLOSED conditionally, a deliberate divergence from
+/// The #176 DM-restriction seam — fail CLOSED conditionally, a deliberate
+/// divergence from
 /// [isProtectedMinorProvider] (which #175's content lock consumes fail-open):
 /// the restricted party can trivially suppress the input that produces an
 /// absent answer (airplane mode, cleared storage, blocked keycast domain,
@@ -234,9 +243,7 @@ final isDmRestrictedProvider = Provider<bool>((ref) {
   if (authSource == AuthenticationSource.none) return true;
 
   // Fail closed only when Keycast signals are applicable to this account.
-  if (!keycastApplicable) return false;
-
-  return true;
+  return keycastApplicable;
 });
 
 /// Whether the current DM restriction comes from a confirmed protected-minor

--- a/mobile/test/providers/is_dm_restricted_provider_test.dart
+++ b/mobile/test/providers/is_dm_restricted_provider_test.dart
@@ -237,4 +237,105 @@ void main() {
       });
     }
   });
+
+  test('keycastSignalApplicableProvider reads per auth source', () {
+    // Direct coverage for the new provider: OAuth -> applicable, pure
+    // self-custody never seen by Keycast -> not applicable.
+    expect(
+      containerWith(
+        authState: AuthState.authenticated,
+        status: () => Completer<ProtectedMinorStatus>().future,
+      ).read(keycastSignalApplicableProvider),
+      isTrue,
+    );
+    expect(
+      containerWith(
+        authState: AuthState.authenticated,
+        authSource: AuthenticationSource.importedKeys,
+        status: () => Completer<ProtectedMinorStatus>().future,
+      ).read(keycastSignalApplicableProvider),
+      isFalse,
+    );
+  });
+
+  test(
+    'a live listener sees the restriction flip on when a Keycast account '
+    'signs in after a self-custody session',
+    () async {
+      // Regression test for the provider-cache staleness in
+      // keycastSignalApplicableProvider: AuthService mutates its pubkey and
+      // auth source in place, so without a currentAuthStateProvider watch the
+      // extracted provider keeps a stale value into the next account's
+      // session — and a stale `false` unrestricts a Keycast-backed account.
+      //
+      // Uses the REAL currentAuthStateProvider (stream + invalidateSelf) over
+      // a mock AuthService so an auth transition propagates exactly as in
+      // production; overriding currentAuthStateProvider with a value would
+      // hide the defect.
+      const pubkeyA =
+          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+      const pubkeyB =
+          'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+      final authStateController = StreamController<AuthState>.broadcast();
+      addTearDown(authStateController.close);
+
+      var state = AuthState.authenticated;
+      var source = AuthenticationSource.importedKeys;
+      var key = pubkeyA;
+
+      final liveAuth = _MockAuthService();
+      when(() => liveAuth.authState).thenAnswer((_) => state);
+      when(
+        () => liveAuth.authStateStream,
+      ).thenAnswer((_) => authStateController.stream);
+      when(() => liveAuth.authenticationSource).thenAnswer((_) => source);
+      when(() => liveAuth.currentPublicKeyHex).thenAnswer((_) => key);
+
+      final container = ProviderContainer(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          authServiceProvider.overrideWithValue(liveAuth),
+          protectedMinorStatusProvider.overrideWith(
+            // Never resolves: Keycast unreachable for both accounts.
+            (ref) => Completer<ProtectedMinorStatus>().future,
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      // Keep a listener attached across the whole sequence, as an app-shell
+      // consumer would.
+      final seen = <bool>[];
+      final sub = container.listen(
+        isDmRestrictedProvider,
+        (_, next) => seen.add(next),
+        fireImmediately: true,
+      );
+      addTearDown(sub.close);
+      await pumpEventQueue();
+
+      // Account A: pure self-custody, never seen by Keycast -> unrestricted.
+      expect(container.read(isDmRestrictedProvider), isFalse);
+
+      // Sign out.
+      state = AuthState.unauthenticated;
+      key = '';
+      authStateController.add(AuthState.unauthenticated);
+      await pumpEventQueue();
+      expect(container.read(isDmRestrictedProvider), isTrue);
+
+      // Sign in as account B: divineOAuth, protected minor, Keycast
+      // unreachable, nothing persisted for B. Must fail closed — a stale
+      // `applicable=false` from A's session would leave B unrestricted.
+      state = AuthState.authenticated;
+      source = AuthenticationSource.divineOAuth;
+      key = pubkeyB;
+      authStateController.add(AuthState.authenticated);
+      await pumpEventQueue();
+
+      expect(container.read(keycastSignalApplicableProvider), isTrue);
+      expect(container.read(isDmRestrictedProvider), isTrue);
+    },
+  );
 }

--- a/mobile/test/providers/is_dm_restricted_provider_test.dart
+++ b/mobile/test/providers/is_dm_restricted_provider_test.dart
@@ -177,4 +177,64 @@ void main() {
     final store = ProtectedMinorStickyStore(prefs: prefs);
     expect(store.lastKnownFor(pubkey), isNull);
   });
+
+  // The fail direction per auth source with no verdict anywhere (live status
+  // unresolved, nothing persisted). Keycast-backed or not-yet-known sources
+  // fail closed; pure self-custody sources Keycast can never answer for are
+  // unrestricted (#6300). Pinning every source stops a refactor from silently
+  // moving one in either direction.
+  group('per-auth-source fail direction with an absent verdict', () {
+    for (final source in AuthenticationSource.values) {
+      final expectRestricted = switch (source) {
+        // `none` is the initial value while the source restores after the
+        // pubkey on cold start: not yet known whether Keycast applies.
+        AuthenticationSource.none => true,
+        AuthenticationSource.divineOAuth => true,
+        AuthenticationSource.automatic ||
+        AuthenticationSource.importedKeys ||
+        AuthenticationSource.bunker ||
+        AuthenticationSource.amber ||
+        AuthenticationSource.nip07 => false,
+      };
+
+      test(
+        '$source -> ${expectRestricted ? 'restricted' : 'unrestricted'}',
+        () {
+          final container = containerWith(
+            authState: AuthState.authenticated,
+            authSource: source,
+            status: () => Completer<ProtectedMinorStatus>().future,
+          );
+
+          expect(container.read(isDmRestrictedProvider), expectRestricted);
+        },
+      );
+    }
+  });
+
+  // A pubkey previously seen by Keycast stays fail-closed under any
+  // self-custody source, since the same pubkey can flip auth sources on one
+  // device and Keycast may hold a verdict for it.
+  group('ever-Keycast pubkey stays restricted under self-custody sources', () {
+    for (final source in [
+      AuthenticationSource.automatic,
+      AuthenticationSource.importedKeys,
+      AuthenticationSource.bunker,
+      AuthenticationSource.amber,
+      AuthenticationSource.nip07,
+    ]) {
+      test('$source with Keycast marker -> restricted', () async {
+        final store = ProtectedMinorStickyStore(prefs: prefs);
+        await store.markKeycastAccount(pubkey);
+
+        final container = containerWith(
+          authState: AuthState.authenticated,
+          authSource: source,
+          status: () => Completer<ProtectedMinorStatus>().future,
+        );
+
+        expect(container.read(isDmRestrictedProvider), isTrue);
+      });
+    }
+  });
 }

--- a/mobile/test/providers/is_dm_restricted_provider_test.dart
+++ b/mobile/test/providers/is_dm_restricted_provider_test.dart
@@ -54,34 +54,6 @@ void main() {
     return container;
   }
 
-  test('Keycast account is restricted while unresolved with no verdict', () {
-    // Cold start / keycast outage / suppressed check on a never-seen Keycast
-    // account: fail closed. The restricted party can trivially produce this
-    // state (airplane mode, cleared storage), so it must not lift the gate.
-    final container = containerWith(
-      authState: AuthState.authenticated,
-      status: () => Completer<ProtectedMinorStatus>().future,
-    );
-
-    expect(container.read(isDmRestrictedProvider), isTrue);
-  });
-
-  test(
-    'non-Keycast account is unrestricted when Keycast verdict is absent',
-    () {
-      // Self-custody accounts are outside Keycast's verified-minor signal. An
-      // absent Keycast verdict for them is structurally inapplicable, not a
-      // suppressible signal.
-      final container = containerWith(
-        authState: AuthState.authenticated,
-        authSource: AuthenticationSource.importedKeys,
-        status: () => Completer<ProtectedMinorStatus>().future,
-      );
-
-      expect(container.read(isDmRestrictedProvider), isFalse);
-    },
-  );
-
   test('unauthenticated with no verdict persisted is restricted', () {
     final container = containerWith(authState: AuthState.unauthenticated);
 
@@ -137,22 +109,6 @@ void main() {
     expect(container.read(isDmRestrictedProvider), isTrue);
   });
 
-  test(
-    'ever-Keycast pubkey remains restricted after imported-key reauth',
-    () async {
-      final store = ProtectedMinorStickyStore(prefs: prefs);
-      await store.markKeycastAccount(pubkey);
-
-      final container = containerWith(
-        authState: AuthState.authenticated,
-        authSource: AuthenticationSource.importedKeys,
-        status: () => Completer<ProtectedMinorStatus>().future,
-      );
-
-      expect(container.read(isDmRestrictedProvider), isTrue);
-    },
-  );
-
   test('an unknown resolution falls back to the persisted verdict', () async {
     final store = ProtectedMinorStickyStore(prefs: prefs);
     await store.applyLiveStatus(pubkey, ProtectedMinorStatus.notProtected());
@@ -181,8 +137,10 @@ void main() {
   // The fail direction per auth source with no verdict anywhere (live status
   // unresolved, nothing persisted). Keycast-backed or not-yet-known sources
   // fail closed; pure self-custody sources Keycast can never answer for are
-  // unrestricted (#6300). Pinning every source stops a refactor from silently
-  // moving one in either direction.
+  // unrestricted. Pinning every source stops a refactor from silently moving
+  // one in either direction. An absent OAuth verdict can be suppressed by the
+  // restricted party, while an absent self-custody verdict is structurally
+  // inapplicable.
   group('per-auth-source fail direction with an absent verdict', () {
     for (final source in AuthenticationSource.values) {
       final expectRestricted = switch (source) {
@@ -238,29 +196,8 @@ void main() {
     }
   });
 
-  test('keycastSignalApplicableProvider reads per auth source', () {
-    // Direct coverage for the new provider: OAuth -> applicable, pure
-    // self-custody never seen by Keycast -> not applicable.
-    expect(
-      containerWith(
-        authState: AuthState.authenticated,
-        status: () => Completer<ProtectedMinorStatus>().future,
-      ).read(keycastSignalApplicableProvider),
-      isTrue,
-    );
-    expect(
-      containerWith(
-        authState: AuthState.authenticated,
-        authSource: AuthenticationSource.importedKeys,
-        status: () => Completer<ProtectedMinorStatus>().future,
-      ).read(keycastSignalApplicableProvider),
-      isFalse,
-    );
-  });
-
   test(
-    'a live listener sees the restriction flip on when a Keycast account '
-    'signs in after a self-custody session',
+    'a live provider restricts a Keycast account after a self-custody session',
     () async {
       // Regression test for the provider-cache staleness in
       // keycastSignalApplicableProvider: AuthService mutates its pubkey and
@@ -306,10 +243,9 @@ void main() {
 
       // Keep a listener attached across the whole sequence, as an app-shell
       // consumer would.
-      final seen = <bool>[];
       final sub = container.listen(
         isDmRestrictedProvider,
-        (_, next) => seen.add(next),
+        (_, _) {},
         fireImmediately: true,
       );
       addTearDown(sub.close);
@@ -334,7 +270,6 @@ void main() {
       authStateController.add(AuthState.authenticated);
       await pumpEventQueue();
 
-      expect(container.read(keycastSignalApplicableProvider), isTrue);
       expect(container.read(isDmRestrictedProvider), isTrue);
     },
   );


### PR DESCRIPTION
Closes #7584

## Summary

Refactor plus regression tests for the #176 protected-minor DM gate. The self-custody DM unblock this branch was written against already shipped in #6319 (merged 2026-07-22, which closed #6300), so this PR is decision-table-neutral versus main; its value is pinning the fail directions of a child-safety gate.

- Extracts the Keycast-applicability tail of `isDmRestrictedProvider` into `keycastSignalApplicableProvider`.
- Keeps fail-closed while the auth source is still unrestored (`AuthenticationSource.none` at cold start).
- Recomputes applicability on every auth transition: `AuthService` mutates pubkey and auth source in place, so without a `currentAuthStateProvider` watch a cached applicability value could carry into the next account's session.
- Adds a per-auth-source fail-direction table, an ever-Keycast marker sweep across the self-custody sources, and a listener-lifetime regression test in `is_dm_restricted_provider_test.dart`.

## Test plan

- `flutter test test/providers/is_dm_restricted_provider_test.dart test/providers/protected_minor_providers_test.dart` (33/33)
- `flutter analyze` and `dart format --set-exit-if-changed` clean
- Full suite green under `TZ=UTC flutter test --exclude-tags integration`
