### PR TITLE
fix(bookmarks): decrypt NIP-04 private items instead of refusing them

### DIFF
--- a/mobile/lib/services/bookmark_service.dart
+++ b/mobile/lib/services/bookmark_service.dart
@@ -127,8 +127,8 @@ enum _PrivateItemsState {
   /// The private item array was decrypted and parsed.
   readable,
 
-  /// `content` is non-empty but did not yield items — a deprecated NIP-04
-  /// payload, a signer that declined, or malformed plaintext.
+  /// `content` is non-empty but did not yield items — a payload encrypted to
+  /// another key, a signer that declined, or malformed plaintext.
   ///
   /// Distinct from [none] on purpose: treating it as "no private items" is
   /// what lets the write path publish a public duplicate of an item it cannot
@@ -870,6 +870,11 @@ class BookmarkService {
   /// NIP-51 encrypts private items to the author's own key, so this needs only
   /// the signer this device already has — every identity that can publish a
   /// bookmark can also decrypt one.
+  ///
+  /// Both schemes are read. NIP-51 deprecated NIP-04 for this field but tells
+  /// clients to detect it by the `iv` marker and decrypt accordingly, and lists
+  /// written under it are still live. Refusing them instead left the write path
+  /// permanently blocked on a list it could have read.
   Future<_PrivateItemsRead> _readPrivateItems(String content) async {
     const unreadable = _PrivateItemsRead(
       state: _PrivateItemsState.unreadable,
@@ -880,25 +885,16 @@ class BookmarkService {
       return const _PrivateItemsRead(state: _PrivateItemsState.none, tags: []);
     }
 
-    // NIP-51 deprecated NIP-04 for this field and tells clients to detect it by
-    // the `iv` marker. Divine does not read that scheme; reporting it as
-    // unreadable is what stops the write path from guessing "not bookmarked".
-    if (content.contains('?iv=')) {
-      Log.warning(
-        'Bookmark list uses the deprecated NIP-04 private-item scheme - '
-        'private items left unread',
-        name: 'BookmarkService',
-        category: LogCategory.system,
-      );
-      return unreadable;
-    }
-
     final pubkey = _authService.currentPublicKeyHex;
     final identity = _authService.currentIdentity;
     if (pubkey == null || identity == null) return unreadable;
 
     try {
-      final plaintext = await identity.nip44Decrypt(pubkey, content);
+      // A NIP-44 payload is base64, and `?` is outside that alphabet, so the
+      // marker cannot appear in one.
+      final plaintext = NIP04.isEncrypted(content)
+          ? await identity.decrypt(pubkey, content)
+          : await identity.nip44Decrypt(pubkey, content);
       if (plaintext == null) {
         Log.warning(
           'Signer could not decrypt the private bookmark items',

--- a/mobile/test/services/bookmark_service_test.dart
+++ b/mobile/test/services/bookmark_service_test.dart
@@ -10,6 +10,7 @@ import 'package:nostr_key_manager/nostr_key_manager.dart';
 import 'package:nostr_sdk/client_utils/keys.dart';
 import 'package:nostr_sdk/event.dart';
 import 'package:nostr_sdk/filter.dart';
+import 'package:nostr_sdk/nip04/nip04.dart';
 import 'package:nostr_sdk/relay/publish_outcome.dart';
 import 'package:openvine/services/auth/nostr_identity.dart';
 import 'package:openvine/services/auth_service.dart';
@@ -139,6 +140,14 @@ void main() {
     /// encrypted to the author's own key.
     Future<String> encryptToSelf(List<List<String>> items) async {
       final ciphertext = await identity.nip44Encrypt(pubkey, jsonEncode(items));
+      return ciphertext!;
+    }
+
+    /// The same payload under the scheme NIP-51 deprecated but still tells
+    /// clients to read. Genuine ciphertext, not a `?iv=`-shaped literal: only
+    /// a real one exercises the decrypt branch rather than the failure path.
+    Future<String> encryptToSelfNip04(List<List<String>> items) async {
+      final ciphertext = await identity.encrypt(pubkey, jsonEncode(items));
       return ciphertext!;
     }
 
@@ -1335,27 +1344,89 @@ void main() {
         );
       });
 
-      group('unreadable content', () {
-        test('refuses to publish when the payload is NIP-04', () async {
-          // NIP-51 deprecated NIP-04 here but tells clients to detect it by
-          // the `iv` marker; one such list is live on relay.divine.video.
+      group('deprecated NIP-04 payloads', () {
+        test('reads private items written under NIP-04', () async {
           stubRelay(
             events: [
-              bookmarkListEvent([], content: 'c29tZQ==?iv=aXY='),
+              bookmarkListEvent(
+                [],
+                content: await encryptToSelfNip04([
+                  ['e', privateVideo],
+                ]),
+              ),
+            ],
+          );
+          final service = createService();
+
+          await service.syncGlobalBookmarks();
+
+          expect(service.hasUnreadablePrivateItems, isFalse);
+          expect(
+            service.globalBookmarks.map((item) => item.id),
+            contains(privateVideo),
+          );
+        });
+
+        test('toggles a list whose private items are NIP-04', () async {
+          // The list this unblocks: before, every mutation was refused and the
+          // user could never save or unsave again.
+          stubRelay(
+            events: [
+              bookmarkListEvent(
+                [],
+                content: await encryptToSelfNip04([
+                  ['e', privateVideo],
+                ]),
+              ),
             ],
           );
           final service = createService();
 
           final result = await service.toggleVideoInGlobalBookmarks('wanted');
 
-          expect(result.succeeded, isFalse);
-          expect(
-            result.failure,
-            equals(BookmarkToggleFailure.privateItemsUnreadable),
-          );
-          expect(signedTags, isNull, reason: 'nothing may be published');
+          expect(result.succeeded, isTrue);
+          expect(result.failure, isNull);
+          expect(signedEventIds(), contains('wanted'));
         });
 
+        test(
+          're-encrypts the array as NIP-44 when an item is removed',
+          () async {
+            stubRelay(
+              events: [
+                bookmarkListEvent(
+                  [],
+                  content: await encryptToSelfNip04([
+                    ['e', privateVideo],
+                    ['e', 'kept-private'],
+                  ]),
+                ),
+              ],
+            );
+            final service = createService();
+
+            final result = await service.toggleVideoInGlobalBookmarks(
+              privateVideo,
+            );
+
+            expect(result.succeeded, isTrue);
+            expect(
+              NIP04.isEncrypted(signedContent!),
+              isFalse,
+              reason: 'a rewrite upgrades the array off the deprecated scheme',
+            );
+            expect(
+              await decryptToSelf(signedContent!),
+              equals([
+                ['e', 'kept-private'],
+              ]),
+              reason: 'only the removed entry is dropped',
+            );
+          },
+        );
+      });
+
+      group('unreadable content', () {
         test('refuses to publish when the signer cannot decrypt', () async {
           // Content encrypted to a different identity: real ciphertext this
           // signer will never read.
@@ -1410,6 +1481,8 @@ void main() {
         test(
           'reports the blind spot so callers can stay indeterminate',
           () async {
+            // Carries the `iv` marker but is not decryptable under either
+            // scheme, so it stays a blind spot rather than reading as empty.
             stubRelay(
               events: [
                 bookmarkListEvent([], content: 'c29tZQ==?iv=aXY='),


### PR DESCRIPTION
## Description

A kind-10003 whose `.content` carried the deprecated NIP-04 scheme was classified unreadable without an attempt to decrypt it (`bookmark_service.dart:886`). That latched `hasUnreadablePrivateItems`, which gates **every** bookmark mutation (`:474`, `:534`, `:603`) — so the account could never save or unsave again, and the UI showed a generic "Failed to add bookmark". The state was sticky: `.content` is only rewritten by a successful publish, and that publish was exactly what the flag refused.

NIP-51 tells clients to sniff the `iv` marker and decrypt accordingly:

> An earlier version of this specification used NIP-04 for encryptions. Those are now deprecated. For backward compatibility, Clients can automatically discover if the encryption is NIP-04 or NIP-44 by searching for "iv" in the ciphertext and decrypting accordingly.

This app already does that for kind 30005 in `CuratedListRelayGateway.unsealItemTags` (`curated_list_relay_gateway.dart:503-505`). `BookmarkService` was the outlier; this reuses the same two-branch read via the NIP-04 pair every `NostrIdentity` already implements. No new imports, no new API surface — the change is net-negative in lines.

Payloads that are genuinely undecryptable (encrypted to another key, malformed, or a signer that declines) still report unreadable, so the write path keeps refusing to publish over a list it cannot see.

### Behaviour changes worth a reviewer's attention

1. **Divine now reads a payload form it previously refused.** That is the point of the change, and it is what NIP-51 prescribes.
2. **A removal upgrades a NIP-04 array to NIP-44.** `_encryptPrivateItems` has always written NIP-44, so the first edit to a NIP-04 list rewrites the whole array under the current scheme. NIP-04 is deprecated here so this is the right direction, but it is irreversible for that list, and a third-party client that only reads NIP-04 would lose access. The existing decrypt-verify round trip (`:809-817`) still refuses to publish a payload that does not read back. Pinned by a new test.

## Related Issue

Closes #7585

Found while investigating #7480, which turned out to rest on a mistaken kind number — see the correction there.

## Out of Scope

Filed separately rather than folded in:

- #7586 — `privateItemsUnreadable` still falls into the generic "Failed to add bookmark" branch, so the residue this PR does not cover (a payload encrypted to another key, a signer that declines) is still reported as if it were a network blip.
- #7587 — the Saved tab reports "Nothing saved yet" when videos merely failed to resolve.
- #7588 — kind 30005 writes prose into `.content`, the same defect #6966 fixed for kind 10003.

Not touched: #7134 / #7137 (public-tag losses) and #7163 (serialize syncs) remain open and cover their own ground.

## Verification

- `flutter test test/services/bookmark_service_test.dart` — 58 passing (was 56).
- `flutter test` on `share_sheet_bloc_test.dart`, `profile_saved_videos_bloc_test.dart`, `curated_list_service_crud_test.dart` — 165 passing. The first two mock `hasUnreadablePrivateItems`, so the service change cannot reach them; the third has its own `?iv=` fixture on the untouched kind-30005 path.
- `flutter analyze lib test integration_test` — no issues.
- `dart format` — clean.
- Reproduced the original defect on device first (iOS Simulator against the local stack, with a seeded NIP-04 kind-10003): the log read `Bookmark list uses the deprecated NIP-04 private-item scheme - private items left unread` / `Synced 1 global bookmarks from relay (0 private)`. After the fix the same fixture reads `Read 1 private bookmark items`.

### Note on the test changes

Two existing tests used the fixture `'c29tZQ==?iv=aXY='`, which is *malformed* NIP-04. It is still refused after this change, so both would have stayed green while no longer testing what their names claimed. They are handled differently on purpose:

- `'refuses to publish when the payload is NIP-04'` is **removed** and replaced by NIP-04 tests built from genuine ciphertext (`encryptToSelfNip04`), so the new decrypt branch is actually exercised.
- `'reports the blind spot so callers can stay indeterminate'` **keeps** the malformed fixture — it now pins that an undecryptable payload stays indeterminate rather than reading as empty — with a comment saying so.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)