### PR TITLE
fix(theme): resolve brand green through accentPositive on light surfaces

### DIFF
--- a/mobile/lib/screens/apps/app_detail_screen.dart
+++ b/mobile/lib/screens/apps/app_detail_screen.dart
@@ -86,9 +86,9 @@ class _AppDetailContent extends StatelessWidget {
                     CircleAvatar(
                       radius: 28,
                       backgroundColor: context.vineColors.card,
-                      child: const DivineIcon(
+                      child: DivineIcon(
                         icon: DivineIconName.gridNine,
-                        color: VineTheme.vineGreen,
+                        color: context.vineColors.accentPositive,
                       ),
                     ),
                     const SizedBox(height: 16),
@@ -129,7 +129,7 @@ class _AppDetailContent extends StatelessWidget {
                       child: Text(
                         app.primaryOrigin,
                         style: VineTheme.bodyMediumFont(
-                          color: VineTheme.vineGreen,
+                          color: context.vineColors.accentPositive,
                         ),
                       ),
                     ),
@@ -217,7 +217,9 @@ class _PillList extends StatelessWidget {
               decoration: BoxDecoration(
                 color: context.vineColors.background,
                 borderRadius: BorderRadius.circular(999),
-                border: Border.all(color: VineTheme.vineGreen.withAlpha(80)),
+                border: Border.all(
+                  color: context.vineColors.accentPositive.withAlpha(80),
+                ),
               ),
               child: Text(
                 item,

--- a/mobile/lib/screens/apps/apps_directory_screen.dart
+++ b/mobile/lib/screens/apps/apps_directory_screen.dart
@@ -190,7 +190,7 @@ class _AppsDirectoryRow extends StatelessWidget {
                           Text(
                             app.tagline,
                             style: VineTheme.labelLargeFont(
-                              color: VineTheme.vineGreen,
+                              color: context.vineColors.accentPositive,
                             ),
                           ),
                           const SizedBox(height: 8),
@@ -238,9 +238,9 @@ class _AppsDirectoryIcon extends StatelessWidget {
         color: context.vineColors.background,
         borderRadius: BorderRadius.circular(16),
       ),
-      child: const DivineIcon(
+      child: DivineIcon(
         icon: DivineIconName.gridNine,
-        color: VineTheme.vineGreen,
+        color: context.vineColors.accentPositive,
       ),
     );
 

--- a/mobile/lib/screens/apps/apps_permissions_screen.dart
+++ b/mobile/lib/screens/apps/apps_permissions_screen.dart
@@ -108,9 +108,9 @@ class _AppsPermissionsEmptyState extends StatelessWidget {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            const DivineIcon(
+            DivineIcon(
               icon: DivineIconName.lockSimple,
-              color: VineTheme.vineGreen,
+              color: context.vineColors.accentPositive,
               size: 28,
             ),
             const SizedBox(height: 16),
@@ -170,7 +170,9 @@ class _GrantCard extends StatelessWidget {
           const SizedBox(height: 8),
           Text(
             grant.capability,
-            style: VineTheme.labelLargeFont(color: VineTheme.vineGreen),
+            style: VineTheme.labelLargeFont(
+              color: context.vineColors.accentPositive,
+            ),
           ),
           const SizedBox(height: 16),
           Align(

--- a/mobile/lib/screens/apps/nostr_app_sandbox_screen.dart
+++ b/mobile/lib/screens/apps/nostr_app_sandbox_screen.dart
@@ -734,9 +734,9 @@ class _SandboxStatusCard extends StatelessWidget {
                   ),
                   const SizedBox(height: 20),
                 ] else ...[
-                  const DivineIcon(
+                  DivineIcon(
                     icon: DivineIconName.shieldCheck,
-                    color: VineTheme.vineGreen,
+                    color: context.vineColors.accentPositive,
                     size: 28,
                   ),
                   const SizedBox(height: 20),

--- a/mobile/lib/screens/auth/create_account_screen.dart
+++ b/mobile/lib/screens/auth/create_account_screen.dart
@@ -104,8 +104,10 @@ class _CreateAccountView extends StatelessWidget {
           }
           return Scaffold(
             backgroundColor: context.vineColors.background,
-            body: const Center(
-              child: CircularProgressIndicator(color: VineTheme.vineGreen),
+            body: Center(
+              child: CircularProgressIndicator(
+                color: context.vineColors.accentPositive,
+              ),
             ),
           );
         },

--- a/mobile/lib/screens/auth/email_verification_screen.dart
+++ b/mobile/lib/screens/auth/email_verification_screen.dart
@@ -1048,7 +1048,7 @@ class _ResendRow extends StatelessWidget {
                         style: VineTheme.labelLargeFont(
                           color: disabled
                               ? context.vineColors.secondaryText
-                              : VineTheme.vineGreen,
+                              : context.vineColors.accentPositive,
                         ),
                       ),
                     ),

--- a/mobile/lib/screens/auth/invite_gate_screen.dart
+++ b/mobile/lib/screens/auth/invite_gate_screen.dart
@@ -198,8 +198,10 @@ class _InviteLoadingPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: context.vineColors.background,
-      body: const Center(
-        child: CircularProgressIndicator(color: VineTheme.vineGreen),
+      body: Center(
+        child: CircularProgressIndicator(
+          color: context.vineColors.accentPositive,
+        ),
       ),
     );
   }
@@ -392,7 +394,9 @@ class _InviteCodeInput extends StatelessWidget {
                 fontSize: 11,
                 fontWeight: FontWeight.w600,
                 letterSpacing: 0.5,
-                color: hasError ? VineTheme.error : VineTheme.vineGreen,
+                color: hasError
+                    ? VineTheme.error
+                    : context.vineColors.accentPositive,
               ),
               floatingLabelBehavior: FloatingLabelBehavior.always,
               hintText: context.l10n.authEnterYourCode,
@@ -417,7 +421,9 @@ class _InviteCodeInput extends StatelessWidget {
               focusedBorder: OutlineInputBorder(
                 borderRadius: BorderRadius.circular(24),
                 borderSide: BorderSide(
-                  color: hasError ? VineTheme.error : VineTheme.vineGreen,
+                  color: hasError
+                      ? VineTheme.error
+                      : context.vineColors.accentPositive,
                 ),
               ),
               contentPadding: const EdgeInsets.symmetric(

--- a/mobile/lib/screens/auth/invite_protected_create_account_screen.dart
+++ b/mobile/lib/screens/auth/invite_protected_create_account_screen.dart
@@ -72,8 +72,10 @@ class _InviteGuardLoadingPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: context.vineColors.background,
-      body: const Center(
-        child: CircularProgressIndicator(color: VineTheme.vineGreen),
+      body: Center(
+        child: CircularProgressIndicator(
+          color: context.vineColors.accentPositive,
+        ),
       ),
     );
   }

--- a/mobile/lib/screens/auth/login_options_screen.dart
+++ b/mobile/lib/screens/auth/login_options_screen.dart
@@ -176,8 +176,10 @@ class _LoginOptionsView extends StatelessWidget {
               if (state is DivineAuthFormState) {
                 return _SignInContent(state: state);
               }
-              return const Center(
-                child: CircularProgressIndicator(color: VineTheme.vineGreen),
+              return Center(
+                child: CircularProgressIndicator(
+                  color: context.vineColors.accentPositive,
+                ),
               );
             },
           ),
@@ -578,7 +580,9 @@ class _SignInOptionsHint extends ConsumerWidget {
                   TextSpan(text: l10n.authSignInOptionsHintPrefix),
                   TextSpan(
                     text: l10n.authSignInOptionsHintCta,
-                    style: VineTheme.bodyMediumFont(color: VineTheme.vineGreen),
+                    style: VineTheme.bodyMediumFont(
+                      color: context.vineColors.accentPositive,
+                    ),
                   ),
                 ],
               ),

--- a/mobile/lib/screens/auth/nostr_connect_screen.dart
+++ b/mobile/lib/screens/auth/nostr_connect_screen.dart
@@ -951,7 +951,11 @@ class _ErrorContent extends StatelessWidget {
                     onPressed: onRetry,
                     style: ElevatedButton.styleFrom(
                       backgroundColor: VineTheme.vineGreen,
-                      foregroundColor: context.vineColors.background,
+                      // Ink on a fixed brand fill, so it is a constant rather
+                      // than a token: `background` follows the appearance and
+                      // turned the label near-white on the green in light
+                      // (1.9:1), beside an icon that was already `onPrimary`.
+                      foregroundColor: VineTheme.onPrimary,
                       shape: RoundedRectangleBorder(
                         borderRadius: BorderRadius.circular(20),
                       ),

--- a/mobile/lib/screens/auth/nostr_connect_screen.dart
+++ b/mobile/lib/screens/auth/nostr_connect_screen.dart
@@ -305,16 +305,20 @@ class _NostrConnectScreenState extends ConsumerState<NostrConnectScreen> {
               ),
               decoration: InputDecoration(
                 hintText: context.l10n.authBunkerUrlHint,
-                hintStyle: const TextStyle(color: VineTheme.vineGreen),
+                hintStyle: TextStyle(
+                  color: context.vineColors.accentPositive,
+                ),
                 filled: true,
                 fillColor: context.vineColors.surfaceContainer,
                 enabledBorder: OutlineInputBorder(
-                  borderSide: const BorderSide(color: VineTheme.vineGreen),
+                  borderSide: BorderSide(
+                    color: context.vineColors.accentPositive,
+                  ),
                   borderRadius: BorderRadius.circular(16),
                 ),
                 focusedBorder: OutlineInputBorder(
-                  borderSide: const BorderSide(
-                    color: VineTheme.vineGreen,
+                  borderSide: BorderSide(
+                    color: context.vineColors.accentPositive,
                     width: 2,
                   ),
                   borderRadius: BorderRadius.circular(16),
@@ -637,12 +641,12 @@ class _StatusIndicator extends StatelessWidget {
     return Center(
       child: Column(
         children: [
-          const SizedBox(
+          SizedBox(
             width: 20,
             height: 20,
             child: CircularProgressIndicator(
               strokeWidth: 2,
-              color: VineTheme.vineGreen,
+              color: context.vineColors.accentPositive,
             ),
           ),
           const SizedBox(height: 12),
@@ -698,25 +702,25 @@ class _ActionBar extends StatelessWidget {
               spacing: 10,
               children: [
                 _ActionButton(
-                  icon: const DivineIcon(
+                  icon: DivineIcon(
                     icon: DivineIconName.linkSimple,
-                    color: VineTheme.vineGreen,
+                    color: context.vineColors.accentPositive,
                   ),
                   label: context.l10n.authCopyUrl,
                   onTap: isLoading ? null : onCopyUrl,
                 ),
                 _ActionButton(
-                  icon: const DivineIcon(
+                  icon: DivineIcon(
                     icon: DivineIconName.shareFat,
-                    color: VineTheme.vineGreen,
+                    color: context.vineColors.accentPositive,
                   ),
                   label: context.l10n.authShare,
                   onTap: isLoading ? null : onShareUrl,
                 ),
                 _ActionButton(
-                  icon: const DivineIcon(
+                  icon: DivineIcon(
                     icon: DivineIconName.plus,
-                    color: VineTheme.vineGreen,
+                    color: context.vineColors.accentPositive,
                   ),
                   label: context.l10n.authAddBunker,
                   onTap: isLoading ? null : onAddBunker,
@@ -759,8 +763,8 @@ class _ActionButton extends StatelessWidget {
             icon,
             Text(
               label,
-              style: const TextStyle(
-                color: VineTheme.vineGreen,
+              style: TextStyle(
+                color: context.vineColors.accentPositive,
                 fontSize: 13,
                 fontWeight: FontWeight.w600,
               ),
@@ -865,23 +869,23 @@ class _SignerRow extends StatelessWidget {
               ),
             ),
           ),
-          _checkOrEmpty(android),
+          _checkOrEmpty(context, android),
           const SizedBox(width: 24),
-          _checkOrEmpty(ios),
+          _checkOrEmpty(context, ios),
           const SizedBox(width: 24),
-          _checkOrEmpty(web),
+          _checkOrEmpty(context, web),
         ],
       ),
     );
   }
 
-  Widget _checkOrEmpty(bool supported) {
+  Widget _checkOrEmpty(BuildContext context, bool supported) {
     return SizedBox(
       width: 22,
       child: supported
-          ? const DivineIcon(
+          ? DivineIcon(
               icon: DivineIconName.check,
-              color: VineTheme.vineGreen,
+              color: context.vineColors.accentPositive,
               size: 22,
             )
           : const SizedBox.shrink(),

--- a/mobile/lib/screens/auth/welcome_screen.dart
+++ b/mobile/lib/screens/auth/welcome_screen.dart
@@ -575,7 +575,7 @@ class _TermsNoticeState extends State<_TermsNotice> {
     final linkStyle = TextStyle(
       color: context.vineColors.primaryText,
       decoration: TextDecoration.underline,
-      decorationColor: VineTheme.vineGreen,
+      decorationColor: context.vineColors.accentPositive,
     );
 
     return RichText(
@@ -618,7 +618,7 @@ class _TermsNoticeState extends State<_TermsNotice> {
 /// Inline link that lets under-16 users discover the family-guidance flow.
 ///
 /// Renders "Not 16 yet? That's OK." in white, followed by the tappable
-/// "Here are your choices." call-to-action in [VineTheme.vineGreen].
+/// "Here are your choices." call-to-action in `accentPositive`.
 class _Under16Choices extends StatefulWidget {
   const _Under16Choices();
 
@@ -659,7 +659,9 @@ class _Under16ChoicesState extends State<_Under16Choices> {
             TextSpan(text: context.l10n.authUnder16Prefix),
             TextSpan(
               text: context.l10n.authUnder16ChoicesCta,
-              style: VineTheme.bodyMediumFont(color: VineTheme.vineGreen),
+              style: VineTheme.bodyMediumFont(
+                color: context.vineColors.accentPositive,
+              ),
               recognizer: _ctaRecognizer,
             ),
           ],

--- a/mobile/lib/screens/badges/widgets/badge_status_pill.dart
+++ b/mobile/lib/screens/badges/widgets/badge_status_pill.dart
@@ -31,7 +31,9 @@ class BadgeStatusPill extends StatelessWidget {
             : pending.container,
         borderRadius: BorderRadius.circular(999),
         border: Border.all(
-          color: accepted ? VineTheme.vineGreen : pending.onContainer,
+          color: accepted
+              ? context.vineColors.accentPositive
+              : pending.onContainer,
         ),
       ),
       child: Padding(
@@ -39,7 +41,9 @@ class BadgeStatusPill extends StatelessWidget {
         child: Text(
           label,
           style: VineTheme.labelSmallFont(
-            color: accepted ? VineTheme.vineGreen : pending.onContainer,
+            color: accepted
+                ? context.vineColors.accentPositive
+                : pending.onContainer,
           ),
         ),
       ),

--- a/mobile/lib/screens/comments/widgets/comment_item.dart
+++ b/mobile/lib/screens/comments/widgets/comment_item.dart
@@ -635,7 +635,7 @@ class _CommentVoteButtons extends StatelessWidget {
                     icon: DivineIconName.arrowFatUp,
                     size: 16,
                     color: voteState.isUpvoted
-                        ? VineTheme.vineGreen
+                        ? context.vineColors.accentPositive
                         : context.vineColors.onSurfaceMuted,
                   ),
                 ),
@@ -649,7 +649,7 @@ class _CommentVoteButtons extends StatelessWidget {
                   netScore.formatScore,
                   style: VineTheme.labelMediumFont(
                     color: voteState.isUpvoted
-                        ? VineTheme.vineGreen
+                        ? context.vineColors.accentPositive
                         : voteState.isDownvoted
                         ? VineTheme.likeRed
                         : context.vineColors.onSurfaceMuted,

--- a/mobile/lib/screens/developer_options_screen.dart
+++ b/mobile/lib/screens/developer_options_screen.dart
@@ -186,9 +186,9 @@ class _DeveloperOptionsScreenState
                     ),
                   ),
                   trailing: isSelected
-                      ? const DivineIcon(
+                      ? DivineIcon(
                           icon: DivineIconName.check,
-                          color: VineTheme.vineGreen,
+                          color: context.vineColors.accentPositive,
                         )
                       : null,
                   onTap: () => _switchEnvironment(context, env, isSelected),
@@ -206,7 +206,9 @@ class _DeveloperOptionsScreenState
                 ),
                 child: Text(
                   context.l10n.devOptionsPageLoadTimes,
-                  style: VineTheme.titleMediumFont(color: VineTheme.vineGreen),
+                  style: VineTheme.titleMediumFont(
+                    color: context.vineColors.accentPositive,
+                  ),
                 ),
               ),
 
@@ -258,7 +260,7 @@ class _DeveloperOptionsScreenState
                   child: Text(
                     context.l10n.devOptionsSlowestScreens,
                     style: VineTheme.titleMediumFont(
-                      color: VineTheme.vineGreen,
+                      color: context.vineColors.accentPositive,
                     ),
                   ),
                 ),
@@ -301,7 +303,9 @@ class _DeveloperOptionsScreenState
                 ),
                 child: Text(
                   context.l10n.devOptionsVideoPlaybackFormat,
-                  style: VineTheme.titleMediumFont(color: VineTheme.vineGreen),
+                  style: VineTheme.titleMediumFont(
+                    color: context.vineColors.accentPositive,
+                  ),
                 ),
               ),
 
@@ -322,9 +326,9 @@ class _DeveloperOptionsScreenState
                     ),
                   ),
                   trailing: isSelected
-                      ? const DivineIcon(
+                      ? DivineIcon(
                           icon: DivineIconName.check,
-                          color: VineTheme.vineGreen,
+                          color: context.vineColors.accentPositive,
                         )
                       : null,
                   onTap: () => _switchFormat(option.format),
@@ -341,7 +345,7 @@ class _DeveloperOptionsScreenState
                   child: Text(
                     context.l10n.devOptionsMinorReviewSimulationTitle,
                     style: VineTheme.titleMediumFont(
-                      color: VineTheme.vineGreen,
+                      color: context.vineColors.accentPositive,
                     ),
                   ),
                 ),
@@ -427,7 +431,7 @@ class _DeveloperOptionsScreenState
                   child: Text(
                     context.l10n.devOptionsProtectedMinorSimulationTitle,
                     style: VineTheme.titleMediumFont(
-                      color: VineTheme.vineGreen,
+                      color: context.vineColors.accentPositive,
                     ),
                   ),
                 ),
@@ -502,7 +506,9 @@ class _DeveloperOptionsScreenState
                 ),
                 child: Text(
                   context.l10n.devOptionsInviteAvailabilityTitle,
-                  style: VineTheme.titleMediumFont(color: VineTheme.vineGreen),
+                  style: VineTheme.titleMediumFont(
+                    color: context.vineColors.accentPositive,
+                  ),
                 ),
               ),
               BlocBuilder<InviteAvailabilityCubit, InviteAvailabilityState>(
@@ -541,9 +547,9 @@ class _DeveloperOptionsScreenState
                         trailing:
                             availability.developerOverride ==
                                 InviteAvailabilityOverride.useServer
-                            ? const DivineIcon(
+                            ? DivineIcon(
                                 icon: DivineIconName.check,
-                                color: VineTheme.vineGreen,
+                                color: context.vineColors.accentPositive,
                               )
                             : null,
                         onTap: () => _setInviteAvailabilityOverride(
@@ -568,9 +574,9 @@ class _DeveloperOptionsScreenState
                         trailing:
                             availability.developerOverride ==
                                 InviteAvailabilityOverride.forceEnabled
-                            ? const DivineIcon(
+                            ? DivineIcon(
                                 icon: DivineIconName.check,
-                                color: VineTheme.vineGreen,
+                                color: context.vineColors.accentPositive,
                               )
                             : null,
                         onTap: () => _setInviteAvailabilityOverride(
@@ -597,9 +603,9 @@ class _DeveloperOptionsScreenState
                         trailing:
                             availability.developerOverride ==
                                 InviteAvailabilityOverride.forceDisabled
-                            ? const DivineIcon(
+                            ? DivineIcon(
                                 icon: DivineIconName.check,
-                                color: VineTheme.vineGreen,
+                                color: context.vineColors.accentPositive,
                               )
                             : null,
                         onTap: () => _setInviteAvailabilityOverride(

--- a/mobile/lib/screens/explore/tabs/explore_lists_tab.dart
+++ b/mobile/lib/screens/explore/tabs/explore_lists_tab.dart
@@ -129,9 +129,9 @@ class ExploreListsTab extends ConsumerWidget {
                       ),
                       child: Row(
                         children: [
-                          const DivineIcon(
+                          DivineIcon(
                             icon: DivineIconName.playlist,
-                            color: VineTheme.vineGreen,
+                            color: context.vineColors.accentPositive,
                             size: 20,
                           ),
                           const SizedBox(width: 8),
@@ -167,9 +167,9 @@ class ExploreListsTab extends ConsumerWidget {
                       ),
                       child: Row(
                         children: [
-                          const DivineIcon(
+                          DivineIcon(
                             icon: DivineIconName.user,
-                            color: VineTheme.vineGreen,
+                            color: context.vineColors.accentPositive,
                             size: 20,
                           ),
                           const SizedBox(width: 8),
@@ -243,9 +243,9 @@ class _SubscribedListsSection extends ConsumerWidget {
           children: [
             Row(
               children: [
-                const DivineIcon(
+                DivineIcon(
                   icon: DivineIconName.checks,
-                  color: VineTheme.vineGreen,
+                  color: context.vineColors.accentPositive,
                   size: 20,
                 ),
                 const SizedBox(width: 8),
@@ -285,9 +285,9 @@ class _SubscribedListsSection extends ConsumerWidget {
           padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
           child: Row(
             children: [
-              const DivineIcon(
+              DivineIcon(
                 icon: DivineIconName.checks,
-                color: VineTheme.vineGreen,
+                color: context.vineColors.accentPositive,
                 size: 20,
               ),
               const SizedBox(width: 8),
@@ -341,7 +341,11 @@ class _ListKindExplainer extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.start,
       spacing: 8,
       children: [
-        DivineIcon(icon: icon, color: VineTheme.vineGreen, size: 18),
+        DivineIcon(
+          icon: icon,
+          color: context.vineColors.accentPositive,
+          size: 18,
+        ),
         Expanded(
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,

--- a/mobile/lib/screens/inbox/conversation/conversation_view.dart
+++ b/mobile/lib/screens/inbox/conversation/conversation_view.dart
@@ -630,9 +630,10 @@ class _ConversationContent extends StatelessWidget {
           (status: state.status, messages: state.displayedMessages),
       builder: (context, selected) {
         return switch (selected.status) {
-          ConversationStatus.initial ||
-          ConversationStatus.loading => const Center(
-            child: CircularProgressIndicator(color: VineTheme.primary),
+          ConversationStatus.initial || ConversationStatus.loading => Center(
+            child: CircularProgressIndicator(
+              color: context.vineColors.accentPositive,
+            ),
           ),
           ConversationStatus.error => Center(
             child: Text(

--- a/mobile/lib/screens/inbox/conversation/widgets/collaborator_invite_card.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/collaborator_invite_card.dart
@@ -532,7 +532,7 @@ class _InviteActions extends StatelessWidget {
     return switch (state) {
       CollaboratorInviteState.accepted => _StatusText(
         label: l10n.inboxCollabInviteAcceptedStatus,
-        color: VineTheme.primary,
+        color: context.vineColors.accentPositive,
       ),
       CollaboratorInviteState.ignored => _StatusText(
         label: l10n.inboxCollabInviteIgnoredStatus,

--- a/mobile/lib/screens/inbox/conversation/widgets/empty_conversation.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/empty_conversation.dart
@@ -115,7 +115,9 @@ class _ViewProfileButton extends StatelessWidget {
         ),
         child: Text(
           context.l10n.inboxConversationViewProfileButton,
-          style: VineTheme.titleMediumFont(color: VineTheme.primary),
+          style: VineTheme.titleMediumFont(
+            color: context.vineColors.accentPositive,
+          ),
         ),
       ),
     );

--- a/mobile/lib/screens/inbox/conversation/widgets/message_bubble.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/message_bubble.dart
@@ -444,7 +444,9 @@ class _MessageTextState extends ConsumerState<_MessageText> {
     );
     // The primary green reads cleanly on the received bubble; on the sent
     // bubble it would sit green-on-green, so links there stay white.
-    final linkColor = widget.isSent ? VineTheme.whiteText : VineTheme.primary;
+    final linkColor = widget.isSent
+        ? VineTheme.whiteText
+        : context.vineColors.accentPositive;
     final referenceStyle = defaultStyle.copyWith(
       color: linkColor,
       decoration: TextDecoration.underline,
@@ -623,13 +625,13 @@ class _VideoLinkPreview extends ConsumerWidget {
         width: _videoCardWidth,
         height: _videoCardHeight,
         color: context.vineColors.card,
-        child: const Center(
+        child: Center(
           child: SizedBox(
             width: 24,
             height: 24,
             child: CircularProgressIndicator(
               strokeWidth: 2,
-              color: VineTheme.vineGreen,
+              color: context.vineColors.accentPositive,
             ),
           ),
         ),
@@ -736,7 +738,9 @@ class _QuotedVideoFrame extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final accent = isSent ? VineTheme.whiteText : VineTheme.primary;
+    final accent = isSent
+        ? VineTheme.whiteText
+        : context.vineColors.accentPositive;
     final frame = SizedBox(
       width: _quotedPreviewWidth,
       child: DecoratedBox(

--- a/mobile/lib/screens/inbox/conversation/widgets/message_input_bar.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/message_input_bar.dart
@@ -89,7 +89,7 @@ class _MessageInputBarState extends State<MessageInputBar> {
                   style: VineTheme.bodyLargeFont(
                     color: context.vineColors.primaryText,
                   ),
-                  cursorColor: VineTheme.primary,
+                  cursorColor: context.vineColors.accentPositive,
                   keyboardType: TextInputType.multiline,
                   // Return = newline; send via button only (#4620).
                   textInputAction: TextInputAction.newline,

--- a/mobile/lib/screens/inbox/conversation/widgets/reactions_row.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/reactions_row.dart
@@ -195,7 +195,7 @@ class _ReactionPill extends StatelessWidget {
     final borderColor = isOwnFailed
         ? VineTheme.error
         : hasOwn
-        ? VineTheme.vineGreen
+        ? context.vineColors.accentPositive
         : context.vineColors.outline;
     final borderRadius = BorderRadius.circular(_height / 2);
 

--- a/mobile/lib/screens/inbox/inbox_view.dart
+++ b/mobile/lib/screens/inbox/inbox_view.dart
@@ -420,7 +420,7 @@ class _RestoringHistoryIndicator extends StatelessWidget {
           ? LinearProgressIndicator(
               minHeight: 2,
               backgroundColor: context.vineColors.surfaceContainerHigh,
-              color: VineTheme.primary,
+              color: context.vineColors.accentPositive,
               semanticsLabel: context.l10n.inboxRestoringMessages,
             )
           : const SizedBox.shrink(),
@@ -677,12 +677,13 @@ class _MessagesScrollViewState extends ConsumerState<_MessagesScrollView>
         // loading spinner and InboxErrorState branches are unaffected.
         const SliverToBoxAdapter(child: _RestorePausedBannerGate()),
         ...switch (status) {
-          ConversationListStatus.initial ||
-          ConversationListStatus.loading => const [
+          ConversationListStatus.initial || ConversationListStatus.loading => [
             SliverFillRemaining(
               hasScrollBody: false,
               child: Center(
-                child: CircularProgressIndicator(color: VineTheme.primary),
+                child: CircularProgressIndicator(
+                  color: context.vineColors.accentPositive,
+                ),
               ),
             ),
           ],
@@ -899,15 +900,15 @@ class _MessagesScrollViewState extends ConsumerState<_MessagesScrollView>
         // can't scroll to trigger a load — leaving a spinner that never
         // resolves.
         if (hasMore && !isFiltering)
-          const SliverToBoxAdapter(
+          SliverToBoxAdapter(
             child: Padding(
-              padding: EdgeInsets.symmetric(vertical: 24),
+              padding: const EdgeInsets.symmetric(vertical: 24),
               child: Center(
                 child: SizedBox(
                   width: 24,
                   height: 24,
                   child: CircularProgressIndicator(
-                    color: VineTheme.primary,
+                    color: context.vineColors.accentPositive,
                     strokeWidth: 2,
                   ),
                 ),

--- a/mobile/lib/screens/inbox/message_requests/message_requests_view.dart
+++ b/mobile/lib/screens/inbox/message_requests/message_requests_view.dart
@@ -93,8 +93,10 @@ class _RequestList extends StatelessWidget {
       builder: (context, state) {
         if (state.status == ConversationListStatus.initial ||
             state.status == ConversationListStatus.loading) {
-          return const Center(
-            child: CircularProgressIndicator(color: VineTheme.primary),
+          return Center(
+            child: CircularProgressIndicator(
+              color: context.vineColors.accentPositive,
+            ),
           );
         }
 
@@ -104,8 +106,8 @@ class _RequestList extends StatelessWidget {
             return Center(
               child: Semantics(
                 label: context.l10n.inboxRestoringMessages,
-                child: const CircularProgressIndicator(
-                  color: VineTheme.primary,
+                child: CircularProgressIndicator(
+                  color: context.vineColors.accentPositive,
                 ),
               ),
             );

--- a/mobile/lib/screens/inbox/message_requests/request_preview_view.dart
+++ b/mobile/lib/screens/inbox/message_requests/request_preview_view.dart
@@ -77,8 +77,10 @@ class RequestPreviewView extends ConsumerWidget {
     // `_resolveParticipants` returns `[]` for a conversation the local
     // database does not have, reaching this same layout without ever failing.
     if (status == RequestPreviewStatus.loading) {
-      return const _UnresolvedRequestScaffold(
-        child: CircularProgressIndicator(color: VineTheme.primary),
+      return _UnresolvedRequestScaffold(
+        child: CircularProgressIndicator(
+          color: context.vineColors.accentPositive,
+        ),
       );
     }
     if (status == RequestPreviewStatus.error || otherPubkey.isEmpty) {
@@ -549,7 +551,9 @@ class _OutlinedActionButton extends StatelessWidget {
             padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
             child: Text(
               label,
-              style: VineTheme.titleMediumFont(color: VineTheme.primary),
+              style: VineTheme.titleMediumFont(
+                color: context.vineColors.accentPositive,
+              ),
               textAlign: TextAlign.center,
             ),
           ),
@@ -587,7 +591,9 @@ class _SecondaryActionButton extends StatelessWidget {
               padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
               child: Text(
                 label,
-                style: VineTheme.titleMediumFont(color: VineTheme.primary),
+                style: VineTheme.titleMediumFont(
+                  color: context.vineColors.accentPositive,
+                ),
                 textAlign: TextAlign.center,
               ),
             ),

--- a/mobile/lib/screens/inbox/new_message_sheet.dart
+++ b/mobile/lib/screens/inbox/new_message_sheet.dart
@@ -124,17 +124,20 @@ class _ResultsBody extends StatelessWidget {
     return BlocBuilder<NewMessageSearchBloc, NewMessageSearchState>(
       builder: (context, state) {
         return switch (state.status) {
-          NewMessageSearchStatus.loadingContacts => const Center(
-            child: CircularProgressIndicator(color: VineTheme.primary),
+          NewMessageSearchStatus.loadingContacts => Center(
+            child: CircularProgressIndicator(
+              color: context.vineColors.accentPositive,
+            ),
           ),
           NewMessageSearchStatus.idle => _UserProfileList(
             profiles: state.contacts,
             emptyMessage: l10n.newMessageNoContacts,
           ),
-          NewMessageSearchStatus.searching when state.results.isEmpty =>
-            const Center(
-              child: CircularProgressIndicator(color: VineTheme.primary),
+          NewMessageSearchStatus.searching when state.results.isEmpty => Center(
+            child: CircularProgressIndicator(
+              color: context.vineColors.accentPositive,
             ),
+          ),
           NewMessageSearchStatus.searching => _UserProfileList(
             profiles: state.results,
           ),

--- a/mobile/lib/screens/search_results/widgets/search_filter_pill.dart
+++ b/mobile/lib/screens/search_results/widgets/search_filter_pill.dart
@@ -57,7 +57,9 @@ class _SearchFilterButton extends StatelessWidget {
           ),
           child: Text(
             filter.label,
-            style: VineTheme.titleSmallFont(color: VineTheme.vineGreen),
+            style: VineTheme.titleSmallFont(
+              color: context.vineColors.accentPositive,
+            ),
           ),
         ),
       ),
@@ -111,11 +113,13 @@ class _VideoSearchSortButton extends StatelessWidget {
               children: [
                 Text(
                   label,
-                  style: VineTheme.titleSmallFont(color: VineTheme.vineGreen),
+                  style: VineTheme.titleSmallFont(
+                    color: context.vineColors.accentPositive,
+                  ),
                 ),
-                const DivineIcon(
+                DivineIcon(
                   icon: DivineIconName.caretDown,
-                  color: VineTheme.vineGreen,
+                  color: context.vineColors.accentPositive,
                 ),
               ],
             ),

--- a/mobile/lib/screens/search_results/widgets/search_tag_chip.dart
+++ b/mobile/lib/screens/search_results/widgets/search_tag_chip.dart
@@ -29,7 +29,9 @@ class SearchTagChip extends StatelessWidget {
             children: [
               Text(
                 '#',
-                style: VineTheme.bodyLargeFont(color: VineTheme.vineGreen),
+                style: VineTheme.bodyLargeFont(
+                  color: context.vineColors.accentPositive,
+                ),
               ),
               Flexible(
                 child: Text(

--- a/mobile/lib/screens/search_results/widgets/section_header.dart
+++ b/mobile/lib/screens/search_results/widgets/section_header.dart
@@ -61,9 +61,9 @@ class SectionHeader extends StatelessWidget {
                   ),
                 ),
                 if (onTap != null)
-                  const DivineIcon(
+                  DivineIcon(
                     icon: DivineIconName.caretRight,
-                    color: VineTheme.vineGreen,
+                    color: context.vineColors.accentPositive,
                   ),
               ],
             ),

--- a/mobile/lib/screens/settings/account_content_labels_tile.dart
+++ b/mobile/lib/screens/settings/account_content_labels_tile.dart
@@ -35,9 +35,9 @@ class _AccountContentLabelsTileView extends StatelessWidget {
     return BlocBuilder<AccountContentLabelsCubit, AccountContentLabelsState>(
       builder: (context, state) {
         return ListTile(
-          leading: const DivineIcon(
+          leading: DivineIcon(
             icon: DivineIconName.warning,
-            color: VineTheme.vineGreen,
+            color: context.vineColors.accentPositive,
           ),
           title: Text(
             context.l10n.contentPreferencesAccountLabels,

--- a/mobile/lib/screens/settings/bluesky_settings_screen.dart
+++ b/mobile/lib/screens/settings/bluesky_settings_screen.dart
@@ -292,7 +292,10 @@ class _HandleInfo extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ListTile(
-      leading: const Icon(Icons.alternate_email, color: VineTheme.vineGreen),
+      leading: Icon(
+        Icons.alternate_email,
+        color: context.vineColors.accentPositive,
+      ),
       title: Text(
         context.l10n.blueskyHandle,
         style: VineTheme.titleMediumFont(color: context.vineColors.primaryText),
@@ -313,9 +316,9 @@ class _DidInfo extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ListTile(
-      leading: const DivineIcon(
+      leading: DivineIcon(
         icon: DivineIconName.fingerprint,
-        color: VineTheme.vineGreen,
+        color: context.vineColors.accentPositive,
       ),
       title: Text(
         context.l10n.blueskyDid,
@@ -352,7 +355,7 @@ class _ProvisioningStatus extends StatelessWidget {
           };
 
     final statusColor = switch (state.provisioningState) {
-      AtprotoProvisioningState.ready => VineTheme.vineGreen,
+      AtprotoProvisioningState.ready => context.vineColors.accentPositive,
       AtprotoProvisioningState.pending => VineTheme.accentOrange,
       AtprotoProvisioningState.failed => VineTheme.error,
       _ => context.vineColors.mutedText,

--- a/mobile/lib/screens/settings/content_preferences_screen.dart
+++ b/mobile/lib/screens/settings/content_preferences_screen.dart
@@ -59,9 +59,9 @@ class _ContentFiltersTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ListTile(
-      leading: const DivineIcon(
+      leading: DivineIcon(
         icon: DivineIconName.funnelSimple,
-        color: VineTheme.vineGreen,
+        color: context.vineColors.accentPositive,
       ),
       title: Text(
         context.l10n.contentPreferencesContentFilters,
@@ -110,9 +110,9 @@ class _LanguageSettingTile extends StatelessWidget {
           );
 
     return ListTile(
-      leading: const DivineIcon(
+      leading: DivineIcon(
         icon: DivineIconName.globe,
-        color: VineTheme.vineGreen,
+        color: context.vineColors.accentPositive,
       ),
       title: Text(
         context.l10n.contentPreferencesContentLanguage,
@@ -292,9 +292,9 @@ class _AudioDeviceSelectorTile extends StatelessWidget {
         );
 
         return ListTile(
-          leading: const DivineIcon(
+          leading: DivineIcon(
             icon: DivineIconName.microphone,
-            color: VineTheme.vineGreen,
+            color: context.vineColors.accentPositive,
           ),
           title: Text(
             context.l10n.contentPreferencesAudioInputDevice,

--- a/mobile/lib/screens/settings/general_settings_screen.dart
+++ b/mobile/lib/screens/settings/general_settings_screen.dart
@@ -65,9 +65,9 @@ class GeneralSettingsScreen extends ConsumerWidget {
                 ),
               if (showBluesky)
                 ListTile(
-                  leading: const Icon(
+                  leading: Icon(
                     Icons.cloud_upload,
-                    color: VineTheme.vineGreen,
+                    color: context.vineColors.accentPositive,
                   ),
                   title: Text(
                     context.l10n.settingsBlueskyPublishing,
@@ -85,9 +85,9 @@ class GeneralSettingsScreen extends ConsumerWidget {
                 ),
               if (showCrossposting)
                 ListTile(
-                  leading: const DivineIcon(
+                  leading: DivineIcon(
                     icon: DivineIconName.shareNetwork,
-                    color: VineTheme.vineGreen,
+                    color: context.vineColors.accentPositive,
                   ),
                   title: Text(
                     context.l10n.settingsCrosspostingTitle,
@@ -112,9 +112,9 @@ class GeneralSettingsScreen extends ConsumerWidget {
               DivineSectionHeader(context.l10n.generalSettingsSectionApp),
               const _AppLanguageTile(),
               ListTile(
-                leading: const DivineIcon(
+                leading: DivineIcon(
                   icon: DivineIconName.sun,
-                  color: VineTheme.vineGreen,
+                  color: context.vineColors.accentPositive,
                 ),
                 title: Text(
                   context.l10n.appearanceSettingsTitle,
@@ -131,9 +131,9 @@ class GeneralSettingsScreen extends ConsumerWidget {
                 onTap: () => context.push(AppearanceSettingsScreen.path),
               ),
               ListTile(
-                leading: const DivineIcon(
+                leading: DivineIcon(
                   icon: DivineIconName.stackSimple,
-                  color: VineTheme.vineGreen,
+                  color: context.vineColors.accentPositive,
                 ),
                 title: Text(
                   context.l10n.settingsStorageTitle,
@@ -148,9 +148,9 @@ class GeneralSettingsScreen extends ConsumerWidget {
               DivineSectionHeader(context.l10n.generalSettingsSectionIdentity),
               if (showAccountCredentials) ...[
                 ListTile(
-                  leading: const DivineIcon(
+                  leading: DivineIcon(
                     icon: DivineIconName.envelope,
-                    color: VineTheme.vineGreen,
+                    color: context.vineColors.accentPositive,
                   ),
                   title: Text(
                     context.l10n.accountSettingsChangeEmail,
@@ -167,9 +167,9 @@ class GeneralSettingsScreen extends ConsumerWidget {
                   onTap: () => context.push(ChangeEmailScreen.path),
                 ),
                 ListTile(
-                  leading: const DivineIcon(
+                  leading: DivineIcon(
                     icon: DivineIconName.lockSimple,
-                    color: VineTheme.vineGreen,
+                    color: context.vineColors.accentPositive,
                   ),
                   title: Text(
                     context.l10n.accountSettingsChangePassword,
@@ -187,9 +187,9 @@ class GeneralSettingsScreen extends ConsumerWidget {
                 ),
               ],
               ListTile(
-                leading: const DivineIcon(
+                leading: DivineIcon(
                   icon: DivineIconName.sealCheck,
-                  color: VineTheme.vineGreen,
+                  color: context.vineColors.accentPositive,
                 ),
                 title: Text(
                   context.l10n.verifyTitle,
@@ -330,9 +330,9 @@ class _AppLanguageTile extends StatelessWidget {
             : LocalePreferenceService.nativeNameFor(locale.languageCode);
 
         return ListTile(
-          leading: const DivineIcon(
+          leading: DivineIcon(
             icon: DivineIconName.globe,
-            color: VineTheme.vineGreen,
+            color: context.vineColors.accentPositive,
           ),
           title: Text(
             context.l10n.settingsAppLanguage,

--- a/mobile/lib/screens/settings/invites_screen.dart
+++ b/mobile/lib/screens/settings/invites_screen.dart
@@ -235,7 +235,7 @@ class _InviteCodeCard extends StatelessWidget {
               // actions have always had, while the DS widget supplies the
               // 48px tap target and semantics.
               backgroundColor: VineTheme.transparent,
-              foregroundColor: VineTheme.vineGreen,
+              foregroundColor: context.vineColors.accentPositive,
               showShadow: false,
               tooltip: context.l10n.invitesCopyInvite,
               onPressed: () => ClipboardUtils.copy(
@@ -247,7 +247,7 @@ class _InviteCodeCard extends StatelessWidget {
             DivineIconButton(
               icon: DivineIconName.shareFat,
               backgroundColor: VineTheme.transparent,
-              foregroundColor: VineTheme.vineGreen,
+              foregroundColor: context.vineColors.accentPositive,
               showShadow: false,
               tooltip: context.l10n.invitesShareInvite,
               onPressed: () => showShareSheet(
@@ -284,9 +284,9 @@ class _ClaimedCodeRow extends StatelessWidget {
               ),
             ),
           ),
-          const DivineIcon(
+          DivineIcon(
             icon: DivineIconName.check,
-            color: VineTheme.vineGreen,
+            color: context.vineColors.accentPositive,
             size: 16,
           ),
           const SizedBox(width: 4),

--- a/mobile/lib/screens/settings/legal_screen.dart
+++ b/mobile/lib/screens/settings/legal_screen.dart
@@ -33,7 +33,7 @@ class LegalScreen extends StatelessWidget {
                 leading: Icon(
                   Icons.description,
                   size: DivineIcon.scaleSize(context, 24),
-                  color: VineTheme.vineGreen,
+                  color: context.vineColors.accentPositive,
                 ),
                 title: l10n.legalTermsOfService,
                 subtitle: l10n.legalTermsOfServiceSubtitle,
@@ -49,7 +49,7 @@ class LegalScreen extends StatelessWidget {
                 leading: Icon(
                   Icons.privacy_tip,
                   size: DivineIcon.scaleSize(context, 24),
-                  color: VineTheme.vineGreen,
+                  color: context.vineColors.accentPositive,
                 ),
                 title: l10n.legalPrivacyPolicy,
                 subtitle: l10n.legalPrivacyPolicySubtitle,
@@ -63,7 +63,7 @@ class LegalScreen extends StatelessWidget {
               ),
               DivineListTile(
                 icon: DivineIconName.shieldCheck,
-                iconColor: VineTheme.vineGreen,
+                iconColor: context.vineColors.accentPositive,
                 title: l10n.legalSafetyStandards,
                 subtitle: l10n.legalSafetyStandardsSubtitle,
                 trailingIcon: DivineIconName.arrowUpRight,
@@ -78,7 +78,7 @@ class LegalScreen extends StatelessWidget {
                 leading: Icon(
                   Icons.copyright,
                   size: DivineIcon.scaleSize(context, 24),
-                  color: VineTheme.vineGreen,
+                  color: context.vineColors.accentPositive,
                 ),
                 title: l10n.legalDmca,
                 subtitle: l10n.legalDmcaSubtitle,
@@ -94,7 +94,7 @@ class LegalScreen extends StatelessWidget {
                 leading: Icon(
                   Icons.source,
                   size: DivineIcon.scaleSize(context, 24),
-                  color: VineTheme.vineGreen,
+                  color: context.vineColors.accentPositive,
                 ),
                 title: l10n.legalOpenSourceLicenses,
                 subtitle: l10n.legalOpenSourceLicensesSubtitle,

--- a/mobile/lib/screens/settings/monetization_links_settings_screen.dart
+++ b/mobile/lib/screens/settings/monetization_links_settings_screen.dart
@@ -323,7 +323,9 @@ class _SectionIntro extends StatelessWidget {
         appStoreTipPolicy
             ? context.l10n.monetizationTipsSettingsConfiguredCount(configured)
             : context.l10n.monetizationSettingsConfiguredCount(configured),
-        style: VineTheme.bodySmallFont(color: VineTheme.primary),
+        style: VineTheme.bodySmallFont(
+          color: context.vineColors.accentPositive,
+        ),
       ),
     );
   }

--- a/mobile/lib/screens/settings/nostr_settings_screen.dart
+++ b/mobile/lib/screens/settings/nostr_settings_screen.dart
@@ -75,7 +75,7 @@ class NostrSettingsScreen extends ConsumerWidget {
                   leading: Icon(
                     Icons.hub,
                     size: DivineIcon.scaleSize(context, 24),
-                    color: VineTheme.vineGreen,
+                    color: context.vineColors.accentPositive,
                   ),
                   title: context.l10n.nostrSettingsRelays,
                   subtitle: context.l10n.nostrSettingsRelaysSubtitle,
@@ -85,7 +85,7 @@ class NostrSettingsScreen extends ConsumerWidget {
                   leading: Icon(
                     Icons.troubleshoot,
                     size: DivineIcon.scaleSize(context, 24),
-                    color: VineTheme.vineGreen,
+                    color: context.vineColors.accentPositive,
                   ),
                   title: context.l10n.nostrSettingsRelayDiagnostics,
                   subtitle: context.l10n.nostrSettingsRelayDiagnosticsSubtitle,
@@ -96,7 +96,7 @@ class NostrSettingsScreen extends ConsumerWidget {
                 leading: Icon(
                   Icons.cloud_upload,
                   size: DivineIcon.scaleSize(context, 24),
-                  color: VineTheme.vineGreen,
+                  color: context.vineColors.accentPositive,
                 ),
                 title: context.l10n.nostrSettingsMediaServers,
                 subtitle: context.l10n.nostrSettingsMediaServersSubtitle,
@@ -109,7 +109,7 @@ class NostrSettingsScreen extends ConsumerWidget {
                 DivineSectionHeader(context.l10n.nostrSettingsSectionAccount),
                 DivineListTile(
                   icon: DivineIconName.key,
-                  iconColor: VineTheme.vineGreen,
+                  iconColor: context.vineColors.accentPositive,
                   title: context.l10n.nostrSettingsKeyManagement,
                   subtitle: context.l10n.nostrSettingsKeyManagementSubtitle,
                   onTap: () => context.push(KeyManagementScreen.path),
@@ -119,7 +119,7 @@ class NostrSettingsScreen extends ConsumerWidget {
                   leading: Icon(
                     Icons.alternate_email,
                     size: DivineIcon.scaleSize(context, 24),
-                    color: VineTheme.vineGreen,
+                    color: context.vineColors.accentPositive,
                   ),
                   title: context.l10n.nostrSettingsNip05Address,
                   subtitle: context.l10n.nostrSettingsNip05AddressSubtitle,
@@ -127,7 +127,7 @@ class NostrSettingsScreen extends ConsumerWidget {
                 ),
                 DivineListTile(
                   icon: DivineIconName.downloadSimple,
-                  iconColor: VineTheme.vineGreen,
+                  iconColor: context.vineColors.accentPositive,
                   title: context.l10n.nostrSettingsMoveAccount,
                   subtitle: context.l10n.nostrSettingsMoveAccountSubtitle,
                   semanticIdentifier: SemanticIds.settingsMoveAccountRow,
@@ -268,7 +268,7 @@ class _SignatureVerificationTile extends ConsumerWidget {
 
     return DivineListTile(
       icon: DivineIconName.shieldCheck,
-      iconColor: VineTheme.vineGreen,
+      iconColor: context.vineColors.accentPositive,
       title: context.l10n.nostrSettingsSignatureVerification,
       subtitle: signatureVerificationPolicySubtitle(context, policy),
       onTap: () =>

--- a/mobile/lib/screens/settings/settings_screen.dart
+++ b/mobile/lib/screens/settings/settings_screen.dart
@@ -550,14 +550,14 @@ class _AccountHeader extends StatelessWidget {
                               mainAxisSize: MainAxisSize.min,
                               spacing: 8,
                               children: [
-                                const DivineIcon(
+                                DivineIcon(
                                   icon: DivineIconName.shareNetwork,
-                                  color: VineTheme.vineGreen,
+                                  color: context.vineColors.accentPositive,
                                 ),
                                 Text(
                                   context.l10n.settingsInvites,
                                   style: VineTheme.titleMediumFont(
-                                    color: VineTheme.vineGreen,
+                                    color: context.vineColors.accentPositive,
                                   ),
                                 ),
                                 if (inviteState.hasAvailableInvites)
@@ -611,20 +611,20 @@ class _AccountHeader extends StatelessWidget {
                         spacing: 8,
                         children: [
                           if (!hasMultipleAccounts)
-                            const DivineIcon(
+                            DivineIcon(
                               icon: DivineIconName.userPlus,
-                              color: VineTheme.vineGreen,
+                              color: context.vineColors.accentPositive,
                             ),
                           Text(
                             buttonLabel,
                             style: VineTheme.titleMediumFont(
-                              color: VineTheme.vineGreen,
+                              color: context.vineColors.accentPositive,
                             ),
                           ),
                           if (hasMultipleAccounts)
-                            const DivineIcon(
+                            DivineIcon(
                               icon: DivineIconName.caretDown,
-                              color: VineTheme.vineGreen,
+                              color: context.vineColors.accentPositive,
                             ),
                         ],
                       ),
@@ -843,9 +843,9 @@ class _AccountSwitchTile extends ConsumerWidget {
                   ),
                 ),
                 if (isCurrentAccount)
-                  const DivineIcon(
+                  DivineIcon(
                     icon: DivineIconName.check,
-                    color: VineTheme.vineGreen,
+                    color: context.vineColors.accentPositive,
                   ),
               ],
             ),
@@ -888,9 +888,9 @@ class _AddAccountTile extends StatelessWidget {
                     ),
                   ),
                 ),
-                const DivineIcon(
+                DivineIcon(
                   icon: DivineIconName.caretRight,
-                  color: VineTheme.primary,
+                  color: context.vineColors.accentPositive,
                 ),
               ],
             ),

--- a/mobile/lib/screens/settings/storage/storage_management_page.dart
+++ b/mobile/lib/screens/settings/storage/storage_management_page.dart
@@ -268,7 +268,9 @@ class _CacheLimitControl extends StatelessWidget {
             ),
             Text(
               _formatBytes(limit),
-              style: VineTheme.bodyMediumFont(color: VineTheme.vineGreen),
+              style: VineTheme.bodyMediumFont(
+                color: context.vineColors.accentPositive,
+              ),
             ),
           ],
         ),
@@ -321,7 +323,9 @@ class _LibrarySection extends StatelessWidget {
               status == StorageLibraryStatus.cleaned)
             Text(
               l10n.settingsStorageLibraryHealthy,
-              style: VineTheme.titleMediumFont(color: VineTheme.vineGreen),
+              style: VineTheme.titleMediumFont(
+                color: context.vineColors.accentPositive,
+              ),
             )
           else if (status == StorageLibraryStatus.scanned && brokenCount > 0)
             Text(
@@ -424,7 +428,9 @@ class _RepairSection extends StatelessWidget {
           else if (status == StorageRecoveryStatus.recovered)
             Text(
               l10n.settingsStorageRepairSuccess,
-              style: VineTheme.titleMediumFont(color: VineTheme.vineGreen),
+              style: VineTheme.titleMediumFont(
+                color: context.vineColors.accentPositive,
+              ),
             )
           else if (status == StorageRecoveryStatus.failure)
             Text(

--- a/mobile/lib/screens/settings/support_center_screen.dart
+++ b/mobile/lib/screens/settings/support_center_screen.dart
@@ -273,7 +273,10 @@ class _SupportTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ListTile(
-      leading: DivineIcon(icon: icon, color: iconColor ?? VineTheme.vineGreen),
+      leading: DivineIcon(
+        icon: icon,
+        color: iconColor ?? context.vineColors.accentPositive,
+      ),
       title: Text(
         title,
         style: VineTheme.titleMediumFont(

--- a/mobile/lib/screens/video_editor/voice_over_recorder_screen.dart
+++ b/mobile/lib/screens/video_editor/voice_over_recorder_screen.dart
@@ -322,7 +322,7 @@ class _WaveState extends State<_Wave> with SingleTickerProviderStateMixin {
         child: CustomPaint(
           painter: _VoiceOverWaveformPainter(
             bars: bars,
-            color: VineTheme.primary,
+            color: context.vineColors.accentPositive,
             scroll: _scroll,
           ),
           size: Size.infinite,

--- a/mobile/lib/services/video_editor/draft_render_parameters_service.dart
+++ b/mobile/lib/services/video_editor/draft_render_parameters_service.dart
@@ -237,6 +237,17 @@ class DraftRenderParametersService {
       // editor canvas overrides none of them. Both sides reading the same
       // defaults is what keeps a re-render identical to what the user saw; if
       // the canvas ever overrides one, mirror it here.
+      //
+      // `configs.theme` is the one exception, and it is deliberate. The canvas
+      // does override it (so its subtree can resolve `context.vineColors`
+      // instead of the silent dark fallback), and the rasterizer host wraps
+      // captured layers in it too. It stays unmirrored because nothing this
+      // app puts in a layer reads the ambient text theme: emoji layers — the
+      // only layer type that does, via `platformTextStyle` — cannot be created
+      // here, and every `TextLayer` carries an explicit `textStyle`, which
+      // `RoundedBackgroundText` uses instead of `DefaultTextStyle`. Introducing
+      // an emoji layer, or a text layer with a null `textStyle`, makes the two
+      // sides diverge and this has to be mirrored after all.
       final captured = await _rasterizer.capture(
         layers: layers,
         editorBodySize: bodySize,

--- a/mobile/lib/widgets/add_to_list_dialog.dart
+++ b/mobile/lib/widgets/add_to_list_dialog.dart
@@ -68,7 +68,7 @@ class SelectListDialog extends StatelessWidget {
                           ? DivineIconName.checkCircle
                           : DivineIconName.playlist,
                       color: isInList
-                          ? VineTheme.vineGreen
+                          ? context.vineColors.accentPositive
                           : context.vineColors.primaryText,
                     ),
                     title: Text(

--- a/mobile/lib/widgets/age_verification_dialog.dart
+++ b/mobile/lib/widgets/age_verification_dialog.dart
@@ -23,7 +23,7 @@ class AgeVerificationDialog extends StatelessWidget {
     backgroundColor: context.vineColors.background,
     shape: RoundedRectangleBorder(
       borderRadius: BorderRadius.circular(16),
-      side: const BorderSide(color: VineTheme.vineGreen, width: 2),
+      side: BorderSide(color: context.vineColors.accentPositive, width: 2),
     ),
     child: Container(
       padding: const EdgeInsets.all(24),
@@ -31,9 +31,9 @@ class AgeVerificationDialog extends StatelessWidget {
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          const DivineIcon(
+          DivineIcon(
             icon: DivineIconName.user,
-            color: VineTheme.vineGreen,
+            color: context.vineColors.accentPositive,
             size: 64,
           ),
           const SizedBox(height: 16),

--- a/mobile/lib/widgets/camera_permission_gate.dart
+++ b/mobile/lib/widgets/camera_permission_gate.dart
@@ -227,8 +227,10 @@ class _LoadingIndicator extends StatelessWidget {
       body: Stack(
         fit: StackFit.expand,
         children: [
-          const Center(
-            child: CircularProgressIndicator(color: VineTheme.vineGreen),
+          Center(
+            child: CircularProgressIndicator(
+              color: context.vineColors.accentPositive,
+            ),
           ),
           if (onClose case final onClose?)
             SafeArea(

--- a/mobile/lib/widgets/classic_viners_slider.dart
+++ b/mobile/lib/widgets/classic_viners_slider.dart
@@ -40,7 +40,7 @@ class ClassicVinersSlider extends ConsumerWidget {
               children: [
                 Icon(
                   Icons.star,
-                  color: VineTheme.vineGreen,
+                  color: context.vineColors.accentPositive,
                   size: DivineIcon.scaleSize(context, 20),
                 ),
                 Text(

--- a/mobile/lib/widgets/classic_vines_tab.dart
+++ b/mobile/lib/widgets/classic_vines_tab.dart
@@ -265,12 +265,12 @@ class _ClassicVinesContentState extends ConsumerState<_ClassicVinesContent>
                 padding: const EdgeInsets.symmetric(vertical: 16),
                 alignment: Alignment.center,
                 child: widget.isLoadingMore
-                    ? const SizedBox(
+                    ? SizedBox(
                         width: 24,
                         height: 24,
                         child: CircularProgressIndicator(
                           strokeWidth: 2,
-                          color: VineTheme.vineGreen,
+                          color: context.vineColors.accentPositive,
                         ),
                       )
                     : const SizedBox.shrink(),

--- a/mobile/lib/widgets/composable_video_grid.dart
+++ b/mobile/lib/widgets/composable_video_grid.dart
@@ -116,8 +116,10 @@ class _ComposableVideoGridState extends ConsumerState<ComposableVideoGrid>
     final brokenTrackerAsync = ref.watch(brokenVideoTrackerProvider);
 
     return brokenTrackerAsync.when(
-      loading: () => const Center(
-        child: CircularProgressIndicator(color: VineTheme.vineGreen),
+      loading: () => Center(
+        child: CircularProgressIndicator(
+          color: context.vineColors.accentPositive,
+        ),
       ),
       error: (error, stack) {
         // Fallback: show all videos if tracker fails
@@ -300,9 +302,9 @@ class _ComposableVideoGridState extends ConsumerState<ComposableVideoGrid>
                   color: sheetContext.vineColors.card,
                   borderRadius: BorderRadius.circular(8),
                 ),
-                child: const DivineIcon(
+                child: DivineIcon(
                   icon: DivineIconName.pencilSimple,
-                  color: VineTheme.vineGreen,
+                  color: sheetContext.vineColors.accentPositive,
                   size: 20,
                 ),
               ),

--- a/mobile/lib/widgets/crosspost_sheet.dart
+++ b/mobile/lib/widgets/crosspost_sheet.dart
@@ -279,12 +279,12 @@ class _JobRow extends StatelessWidget {
             spacing: 12,
             children: [
               if (job.status.isPending)
-                const SizedBox(
+                SizedBox(
                   width: 20,
                   height: 20,
                   child: CircularProgressIndicator(
                     strokeWidth: 2,
-                    color: VineTheme.vineGreen,
+                    color: context.vineColors.accentPositive,
                   ),
                 )
               else
@@ -298,7 +298,7 @@ class _JobRow extends StatelessWidget {
                   color:
                       job.status == CrosspostJobStatus.posted ||
                           job.status == CrosspostJobStatus.skipped
-                      ? VineTheme.vineGreen
+                      ? context.vineColors.accentPositive
                       : VineTheme.error,
                 ),
               Expanded(
@@ -380,12 +380,14 @@ class _ViewPostLink extends StatelessWidget {
             children: [
               Text(
                 label,
-                style: VineTheme.labelLargeFont(color: VineTheme.vineGreen),
+                style: VineTheme.labelLargeFont(
+                  color: context.vineColors.accentPositive,
+                ),
               ),
-              const DivineIcon(
+              DivineIcon(
                 icon: DivineIconName.arrowUpRight,
                 size: 16,
-                color: VineTheme.vineGreen,
+                color: context.vineColors.accentPositive,
               ),
             ],
           ),

--- a/mobile/lib/widgets/delete_account_dialog.dart
+++ b/mobile/lib/widgets/delete_account_dialog.dart
@@ -370,7 +370,7 @@ class _DeletionProgressSheetContent extends StatelessWidget {
                     [
                       CircularProgressIndicator(
                         value: current / total,
-                        color: VineTheme.vineGreen,
+                        color: context.vineColors.accentPositive,
                         backgroundColor: context.vineColors.card,
                       ),
                       const SizedBox(height: 16),
@@ -392,7 +392,9 @@ class _DeletionProgressSheetContent extends StatelessWidget {
                       ),
                     ],
                   AccountDeletionProgressPreparing() => [
-                    const CircularProgressIndicator(color: VineTheme.vineGreen),
+                    CircularProgressIndicator(
+                      color: context.vineColors.accentPositive,
+                    ),
                     const SizedBox(height: 16),
                     Text(
                       context.l10n.deleteAccountPreparingDeletion,

--- a/mobile/lib/widgets/find_people_sheet.dart
+++ b/mobile/lib/widgets/find_people_sheet.dart
@@ -192,8 +192,10 @@ class _ResultsList extends StatelessWidget {
                 scrollController: scrollController,
                 onSelectUser: onSelectUser,
               ),
-            UserSearchStatus.loading => const Center(
-              child: CircularProgressIndicator(color: VineTheme.vineGreen),
+            UserSearchStatus.loading => Center(
+              child: CircularProgressIndicator(
+                color: context.vineColors.accentPositive,
+              ),
             ),
             UserSearchStatus.success when state.results.isNotEmpty =>
               _SearchResultsList(

--- a/mobile/lib/widgets/for_you_tab.dart
+++ b/mobile/lib/widgets/for_you_tab.dart
@@ -253,9 +253,9 @@ class _ForYouContentState extends ConsumerState<_ForYouContent>
                   padding: const EdgeInsets.symmetric(horizontal: 16),
                   child: Row(
                     children: [
-                      const DivineIcon(
+                      DivineIcon(
                         icon: DivineIconName.sparkle,
-                        color: VineTheme.vineGreen,
+                        color: context.vineColors.accentPositive,
                         size: 20,
                       ),
                       const SizedBox(width: 8),
@@ -263,7 +263,7 @@ class _ForYouContentState extends ConsumerState<_ForYouContent>
                         child: Text(
                           context.l10n.forYouAlgorithmTitle,
                           style: VineTheme.labelLargeFont(
-                            color: VineTheme.vineGreen,
+                            color: context.vineColors.accentPositive,
                           ),
                         ),
                       ),
@@ -309,9 +309,9 @@ class _AlgorithmExplainerSheet extends StatelessWidget {
         Row(
           spacing: 12,
           children: [
-            const DivineIcon(
+            DivineIcon(
               icon: DivineIconName.sparkle,
-              color: VineTheme.vineGreen,
+              color: context.vineColors.accentPositive,
               size: 28,
             ),
             Expanded(
@@ -328,7 +328,7 @@ class _AlgorithmExplainerSheet extends StatelessWidget {
         Text(
           context.l10n.forYouAlgorithmSubtitle,
           style: VineTheme.bodySmallFont(
-            color: VineTheme.vineGreen,
+            color: context.vineColors.accentPositive,
           ).copyWith(fontStyle: FontStyle.italic),
         ),
         const SizedBox(height: 24),
@@ -459,7 +459,11 @@ class _InteractionItem extends StatelessWidget {
               color: context.vineColors.card,
               borderRadius: BorderRadius.circular(8),
             ),
-            child: DivineIcon(icon: icon, color: VineTheme.vineGreen, size: 18),
+            child: DivineIcon(
+              icon: icon,
+              color: context.vineColors.accentPositive,
+              size: 18,
+            ),
           ),
           Expanded(
             child: Column(
@@ -501,9 +505,9 @@ class _FutureFeatureItem extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         spacing: 8,
         children: [
-          const DivineIcon(
+          DivineIcon(
             icon: DivineIconName.checkCircle,
-            color: VineTheme.vineGreen,
+            color: context.vineColors.accentPositive,
             size: 18,
           ),
           Expanded(child: Text(text, style: _bodyTextStyleOf(context))),

--- a/mobile/lib/widgets/global_error_widget.dart
+++ b/mobile/lib/widgets/global_error_widget.dart
@@ -158,10 +158,10 @@ class _GlobalErrorWidget extends StatelessWidget {
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        const Text(
+                        Text(
                           'debug info',
                           style: TextStyle(
-                            color: VineTheme.vineGreen,
+                            color: context.vineColors.accentPositive,
                             fontSize: 11,
                             fontWeight: FontWeight.w600,
                             decoration: TextDecoration.none,

--- a/mobile/lib/widgets/hashtag_search_view.dart
+++ b/mobile/lib/widgets/hashtag_search_view.dart
@@ -96,8 +96,10 @@ class _HashtagSearchLoadingState extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const Center(
-      child: CircularProgressIndicator(color: VineTheme.vineGreen),
+    return Center(
+      child: CircularProgressIndicator(
+        color: context.vineColors.accentPositive,
+      ),
     );
   }
 }
@@ -173,10 +175,12 @@ class _HashtagSearchResultsListState extends State<_HashtagSearchResultsList>
             ],
           ),
           if (widget.isLoadingMore)
-            const Padding(
-              padding: EdgeInsets.symmetric(vertical: 16),
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 16),
               child: Center(
-                child: CircularProgressIndicator(color: VineTheme.vineGreen),
+                child: CircularProgressIndicator(
+                  color: context.vineColors.accentPositive,
+                ),
               ),
             ),
         ],

--- a/mobile/lib/widgets/image_attachment_picker.dart
+++ b/mobile/lib/widgets/image_attachment_picker.dart
@@ -237,7 +237,7 @@ class _AddButton extends StatelessWidget {
               borderRadius: BorderRadius.circular(8),
               border: Border.all(
                 color: enabled
-                    ? VineTheme.vineGreen.withValues(alpha: 0.7)
+                    ? context.vineColors.accentPositive.withValues(alpha: 0.7)
                     : context.vineColors.mutedText.withValues(alpha: 0.7),
               ),
             ),
@@ -245,7 +245,7 @@ class _AddButton extends StatelessWidget {
               child: DivineIcon(
                 icon: DivineIconName.imagesSquare,
                 color: enabled
-                    ? VineTheme.vineGreen
+                    ? context.vineColors.accentPositive
                     : context.vineColors.mutedText,
               ),
             ),

--- a/mobile/lib/widgets/library/drafts_tab.dart
+++ b/mobile/lib/widgets/library/drafts_tab.dart
@@ -61,8 +61,10 @@ class DraftsTab extends ConsumerWidget {
       },
       builder: (context, state) {
         return switch (state) {
-          DraftsLibraryInitial() || DraftsLibraryLoading() => const Center(
-            child: CircularProgressIndicator(color: VineTheme.vineGreen),
+          DraftsLibraryInitial() || DraftsLibraryLoading() => Center(
+            child: CircularProgressIndicator(
+              color: context.vineColors.accentPositive,
+            ),
           ),
           DraftsLibraryError() => Center(
             child: Padding(
@@ -442,13 +444,17 @@ class _DraftStatusBadge extends StatelessWidget {
       decoration: BoxDecoration(
         color: VineTheme.vineGreen.withValues(alpha: 0.16),
         borderRadius: BorderRadius.circular(4),
-        border: Border.all(color: VineTheme.vineGreen.withValues(alpha: 0.45)),
+        border: Border.all(
+          color: context.vineColors.accentPositive.withValues(alpha: 0.45),
+        ),
       ),
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
         child: Text(
           label,
-          style: VineTheme.labelSmallFont(color: VineTheme.vineGreen),
+          style: VineTheme.labelSmallFont(
+            color: context.vineColors.accentPositive,
+          ),
           maxLines: 1,
           overflow: TextOverflow.ellipsis,
         ),

--- a/mobile/lib/widgets/library/saved_sound_card.dart
+++ b/mobile/lib/widgets/library/saved_sound_card.dart
@@ -229,7 +229,9 @@ class _SavedSoundText extends StatelessWidget {
         if (source?.creatorName case final creator?)
           Text(
             context.l10n.soundCreatorBy(creator),
-            style: VineTheme.labelMediumFont(color: VineTheme.vineGreen),
+            style: VineTheme.labelMediumFont(
+              color: context.vineColors.accentPositive,
+            ),
           ),
         if (source?.description case final description?)
           Text(
@@ -304,7 +306,7 @@ class _WaveformBars extends StatelessWidget {
         painter: StereoWaveformPainter(
           leftChannel: Float32List.fromList(sound.waveformSamples),
           progress: progress,
-          activeColor: VineTheme.vineGreen,
+          activeColor: context.vineColors.accentPositive,
           inactiveColor: context.vineColors.onSurfaceVariant,
           audioDuration: duration,
           maxDuration: duration,
@@ -355,7 +357,7 @@ class _SavedSoundTag extends StatelessWidget {
           label,
           style: VineTheme.labelSmallFont(
             color: isPersonal
-                ? VineTheme.vineGreen
+                ? context.vineColors.accentPositive
                 : context.vineColors.onSurfaceVariant,
           ),
         ),

--- a/mobile/lib/widgets/library/sounds_tab.dart
+++ b/mobile/lib/widgets/library/sounds_tab.dart
@@ -675,9 +675,9 @@ class _SectionHeader extends StatelessWidget {
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
       child: Row(
         children: [
-          const DivineIcon(
+          DivineIcon(
             icon: DivineIconName.musicNote,
-            color: VineTheme.vineGreen,
+            color: context.vineColors.accentPositive,
             size: 20,
           ),
           const SizedBox(width: 8),

--- a/mobile/lib/widgets/list_card.dart
+++ b/mobile/lib/widgets/list_card.dart
@@ -30,9 +30,9 @@ class UserListCard extends StatelessWidget {
             children: [
               Row(
                 children: [
-                  const DivineIcon(
+                  DivineIcon(
                     icon: DivineIconName.users,
-                    color: VineTheme.vineGreen,
+                    color: context.vineColors.accentPositive,
                   ),
                   const SizedBox(width: 12),
                   Expanded(
@@ -120,9 +120,9 @@ class CuratedListCard extends StatelessWidget {
             children: [
               Row(
                 children: [
-                  const Icon(
+                  Icon(
                     Icons.video_library,
-                    color: VineTheme.vineGreen,
+                    color: context.vineColors.accentPositive,
                     size: 24,
                   ),
                   const SizedBox(width: 12),
@@ -184,8 +184,8 @@ class CuratedListCard extends StatelessWidget {
                     Expanded(
                       child: Text(
                         curatedList.tags.take(3).map((t) => '#$t').join(' '),
-                        style: const TextStyle(
-                          color: VineTheme.vineGreen,
+                        style: TextStyle(
+                          color: context.vineColors.accentPositive,
                           fontSize: 12,
                         ),
                         maxLines: 1,

--- a/mobile/lib/widgets/profile/more_sheet/unblock_confirmation_view.dart
+++ b/mobile/lib/widgets/profile/more_sheet/unblock_confirmation_view.dart
@@ -77,7 +77,7 @@ class UnblockConfirmationView extends StatelessWidget {
                           color: context.vineColors.onSurface,
                         ).copyWith(
                           decoration: TextDecoration.underline,
-                          decorationColor: VineTheme.vineGreen,
+                          decorationColor: context.vineColors.accentPositive,
                           decorationThickness: 2,
                         ),
                   ),

--- a/mobile/lib/widgets/profile/new_people_list_sheet.dart
+++ b/mobile/lib/widgets/profile/new_people_list_sheet.dart
@@ -204,9 +204,9 @@ class _CollaboratorsRow extends StatelessWidget {
                           ),
                         ),
                 ),
-                const DivineIcon(
+                DivineIcon(
                   icon: DivineIconName.caretRight,
-                  color: VineTheme.primary,
+                  color: context.vineColors.accentPositive,
                 ),
               ],
             ),

--- a/mobile/lib/widgets/profile/nostr_info_sheet_content.dart
+++ b/mobile/lib/widgets/profile/nostr_info_sheet_content.dart
@@ -116,7 +116,7 @@ class NostrInfoSheetContent extends StatelessWidget {
               onPressed: onDismiss ?? () => Navigator.of(context).pop(),
               style: OutlinedButton.styleFrom(
                 backgroundColor: context.vineColors.surfaceContainer,
-                foregroundColor: VineTheme.vineGreen,
+                foregroundColor: context.vineColors.accentPositive,
                 padding: const EdgeInsets.symmetric(
                   vertical: 12,
                   horizontal: 16,
@@ -131,7 +131,9 @@ class NostrInfoSheetContent extends StatelessWidget {
               ),
               child: Text(
                 context.l10n.nostrInfoGotIt,
-                style: VineTheme.titleMediumFont(color: VineTheme.vineGreen),
+                style: VineTheme.titleMediumFont(
+                  color: context.vineColors.accentPositive,
+                ),
                 maxLines: 1,
                 overflow: TextOverflow.ellipsis,
               ),

--- a/mobile/lib/widgets/profile/profile_cache_load_indicator.dart
+++ b/mobile/lib/widgets/profile/profile_cache_load_indicator.dart
@@ -17,12 +17,12 @@ class ProfileCacheLoadIndicator extends StatelessWidget {
   Widget build(BuildContext context) {
     // Purely decorative background-refresh hint; the cached grid is already
     // on screen, so keep it out of the semantics tree.
-    return const ExcludeSemantics(
+    return ExcludeSemantics(
       child: SizedBox(
         height: height,
         child: LinearProgressIndicator(
           minHeight: height,
-          color: VineTheme.primary,
+          color: context.vineColors.accentPositive,
           backgroundColor: VineTheme.transparent,
         ),
       ),

--- a/mobile/lib/widgets/profile/profile_grid.dart
+++ b/mobile/lib/widgets/profile/profile_grid.dart
@@ -599,7 +599,7 @@ class _ProfileGridViewState extends ConsumerState<ProfileGridView>
     );
 
     final content = RefreshIndicator(
-      color: VineTheme.primary,
+      color: context.vineColors.accentPositive,
       backgroundColor: context.vineColors.surfaceContainer,
       notificationPredicate: (_) => true,
       onRefresh: _refreshProfileContent,

--- a/mobile/lib/widgets/profile/profile_header_identity.dart
+++ b/mobile/lib/widgets/profile/profile_header_identity.dart
@@ -718,7 +718,7 @@ class _UniqueIdentifier extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final hasNip05 = nip05 != null && nip05!.isNotEmpty;
     final npub = NostrKeyUtils.encodePubKey(userIdHex);
-    const linkColor = VineTheme.vineGreen;
+    final linkColor = context.vineColors.accentPositive;
 
     // Watch NIP-05 verification status
     final verificationStatus = hasNip05

--- a/mobile/lib/widgets/profile/profile_header_media.dart
+++ b/mobile/lib/widgets/profile/profile_header_media.dart
@@ -94,7 +94,9 @@ class _AboutTextState extends State<_AboutText> {
                     _isExpanded
                         ? context.l10n.profileShowLess
                         : context.l10n.profileShowMore,
-                    style: VineTheme.bodySmallFont(color: VineTheme.vineGreen),
+                    style: VineTheme.bodySmallFont(
+                      color: context.vineColors.accentPositive,
+                    ),
                   ),
                 ),
               ),

--- a/mobile/lib/widgets/profile/profile_support_sheet.dart
+++ b/mobile/lib/widgets/profile/profile_support_sheet.dart
@@ -104,9 +104,9 @@ class _SupportLinkTile extends StatelessWidget {
       type: MaterialType.transparency,
       child: ListTile(
         minTileHeight: 56,
-        leading: const DivineIcon(
+        leading: DivineIcon(
           icon: DivineIconName.linkSimple,
-          color: VineTheme.primary,
+          color: context.vineColors.accentPositive,
         ),
         title: Text(
           link.provider.displayName,

--- a/mobile/lib/widgets/profile/profile_videos_grid.dart
+++ b/mobile/lib/widgets/profile/profile_videos_grid.dart
@@ -550,7 +550,7 @@ class _OwnVideoActionsSheetBody extends StatelessWidget {
       children: [
         _OwnVideoActionTile(
           icon: DivineIconName.pencilSimple,
-          iconColor: VineTheme.vineGreen,
+          iconColor: context.vineColors.accentPositive,
           title: context.l10n.videoGridEditVideo,
           subtitle: context.l10n.videoGridEditVideoSubtitle,
           onTap: onEditVideo,
@@ -694,14 +694,14 @@ class _PendingCollaboratorInviteBanner extends ConsumerWidget {
                         child: Row(
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
-                            const Padding(
-                              padding: EdgeInsets.only(
+                            Padding(
+                              padding: const EdgeInsets.only(
                                 top: _PendingInviteBannerTokens.iconTopPadding,
                               ),
                               child: ExcludeSemantics(
                                 child: DivineIcon(
                                   icon: DivineIconName.envelopeSimple,
-                                  color: VineTheme.vineGreen,
+                                  color: context.vineColors.accentPositive,
                                   size: 20,
                                 ),
                               ),

--- a/mobile/lib/widgets/profile/profile_website_row.dart
+++ b/mobile/lib/widgets/profile/profile_website_row.dart
@@ -46,15 +46,17 @@ class ProfileWebsiteRow extends StatelessWidget {
             mainAxisSize: MainAxisSize.min,
             spacing: 6,
             children: [
-              const DivineIcon(
+              DivineIcon(
                 icon: DivineIconName.globe,
                 size: 14,
-                color: VineTheme.vineGreen,
+                color: context.vineColors.accentPositive,
               ),
               Flexible(
                 child: Text(
                   displayUrl,
-                  style: VineTheme.bodySmallFont(color: VineTheme.vineGreen),
+                  style: VineTheme.bodySmallFont(
+                    color: context.vineColors.accentPositive,
+                  ),
                   maxLines: 1,
                   overflow: TextOverflow.ellipsis,
                 ),

--- a/mobile/lib/widgets/profile_editor/username_status_indicator.dart
+++ b/mobile/lib/widgets/profile_editor/username_status_indicator.dart
@@ -111,15 +111,18 @@ class _UsernameAvailableIndicator extends StatelessWidget {
       padding: const EdgeInsets.only(top: 8),
       child: Row(
         children: [
-          const DivineIcon(
+          DivineIcon(
             icon: DivineIconName.checkCircle,
-            color: VineTheme.vineGreen,
+            color: context.vineColors.accentPositive,
             size: 16,
           ),
           const SizedBox(width: 8),
           Text(
             context.l10n.profileSetupUsernameAvailable,
-            style: const TextStyle(color: VineTheme.vineGreen, fontSize: 12),
+            style: TextStyle(
+              color: context.vineColors.accentPositive,
+              fontSize: 12,
+            ),
           ),
         ],
       ),
@@ -194,8 +197,8 @@ class _UsernameReservedIndicator extends StatelessWidget {
                 },
                 child: Text(
                   context.l10n.profileSetupContactSupport,
-                  style: const TextStyle(
-                    color: VineTheme.primary,
+                  style: TextStyle(
+                    color: context.vineColors.accentPositive,
                     fontSize: 12,
                   ),
                 ),
@@ -207,8 +210,8 @@ class _UsernameReservedIndicator extends StatelessWidget {
                 ),
                 child: Text(
                   context.l10n.profileSetupCheckAgain,
-                  style: const TextStyle(
-                    color: VineTheme.primary,
+                  style: TextStyle(
+                    color: context.vineColors.accentPositive,
                     fontSize: 12,
                   ),
                 ),
@@ -373,8 +376,10 @@ class _UsernameReservedDialogState extends State<UsernameReservedDialog> {
                   color: context.vineColors.surfaceContainer,
                 ),
               ),
-              focusedBorder: const OutlineInputBorder(
-                borderSide: BorderSide(color: VineTheme.vineGreen),
+              focusedBorder: OutlineInputBorder(
+                borderSide: BorderSide(
+                  color: context.vineColors.accentPositive,
+                ),
               ),
               contentPadding: const EdgeInsets.all(12),
             ),
@@ -404,7 +409,7 @@ class _UsernameReservedDialogState extends State<UsernameReservedDialog> {
           },
           child: Text(
             context.l10n.profileSetupCheckAgain,
-            style: const TextStyle(color: VineTheme.vineGreen),
+            style: TextStyle(color: context.vineColors.accentPositive),
           ),
         ),
         FilledButton(

--- a/mobile/lib/widgets/report_content_confirmation.dart
+++ b/mobile/lib/widgets/report_content_confirmation.dart
@@ -31,9 +31,9 @@ class ReportConfirmationBody extends StatelessWidget {
         Row(
           spacing: 12,
           children: [
-            const DivineIcon(
+            DivineIcon(
               icon: DivineIconName.checkCircle,
-              color: VineTheme.vineGreen,
+              color: context.vineColors.accentPositive,
               size: 28,
             ),
             Expanded(
@@ -103,7 +103,9 @@ class _SafetyPolicyLink extends StatelessWidget {
               ),
               TextSpan(
                 text: l10n.reportSafetyUrl,
-                style: VineTheme.bodyMediumFont(color: VineTheme.vineGreen),
+                style: VineTheme.bodyMediumFont(
+                  color: context.vineColors.accentPositive,
+                ),
               ),
             ],
           ),

--- a/mobile/lib/widgets/report_content_dialog.dart
+++ b/mobile/lib/widgets/report_content_dialog.dart
@@ -536,7 +536,9 @@ class _ReportFormBody extends StatelessWidget {
                 children: [
                   Text(
                     l10n.reportDetailsRequired,
-                    style: VineTheme.labelSmallFont(color: VineTheme.vineGreen),
+                    style: VineTheme.labelSmallFont(
+                      color: context.vineColors.accentPositive,
+                    ),
                   ),
                   _CappedDetailsField(
                     fieldKey: detailsFieldKey,
@@ -630,7 +632,7 @@ class _ReasonCard extends StatelessWidget {
             borderRadius: BorderRadius.circular(24),
             border: Border.all(
               color: isSelected
-                  ? VineTheme.vineGreen
+                  ? context.vineColors.accentPositive
                   : context.vineColors.surfaceContainer,
               width: 1.5,
             ),
@@ -681,7 +683,10 @@ class _RadioIndicator extends StatelessWidget {
         decoration: BoxDecoration(
           shape: BoxShape.circle,
           color: isSelected ? VineTheme.vineGreen : VineTheme.transparent,
-          border: Border.all(color: VineTheme.vineGreen, width: 2),
+          border: Border.all(
+            color: context.vineColors.accentPositive,
+            width: 2,
+          ),
         ),
         child: isSelected
             ? Center(

--- a/mobile/lib/widgets/report_content_dialog.dart
+++ b/mobile/lib/widgets/report_content_dialog.dart
@@ -682,7 +682,12 @@ class _RadioIndicator extends StatelessWidget {
       child: DecoratedBox(
         decoration: BoxDecoration(
           shape: BoxShape.circle,
-          color: isSelected ? VineTheme.vineGreen : VineTheme.transparent,
+          // Fill and ring resolve from the same token: a raw-green fill under
+          // an `accentPositive` ring reads two-tone in light (2.92:1 between
+          // them), and it left the white check at 2.11:1 on the fill.
+          color: isSelected
+              ? context.vineColors.accentPositive
+              : VineTheme.transparent,
           border: Border.all(
             color: context.vineColors.accentPositive,
             width: 2,

--- a/mobile/lib/widgets/save_original_progress_sheet.dart
+++ b/mobile/lib/widgets/save_original_progress_sheet.dart
@@ -106,12 +106,12 @@ class _SaveOriginalProgressViewState extends State<_SaveOriginalProgressView>
                     ),
                     const SizedBox(height: 24),
                     if (state.isProcessing) ...[
-                      const SizedBox(
+                      SizedBox(
                         width: 32,
                         height: 32,
                         child: CircularProgressIndicator(
                           strokeWidth: 3,
-                          color: VineTheme.vineGreen,
+                          color: context.vineColors.accentPositive,
                         ),
                       ),
                       const SizedBox(height: 16),
@@ -146,9 +146,9 @@ class _SaveOriginalProgressViewState extends State<_SaveOriginalProgressView>
   ) {
     return switch (result) {
       WatermarkDownloadSuccess() => [
-        const DivineIcon(
+        DivineIcon(
           icon: DivineIconName.checkCircle,
-          color: VineTheme.vineGreen,
+          color: context.vineColors.accentPositive,
           size: 48,
         ),
         const SizedBox(height: 16),
@@ -187,9 +187,9 @@ class _SaveOriginalProgressViewState extends State<_SaveOriginalProgressView>
         ),
       ],
       WatermarkDownloadPermissionDenied() => [
-        const DivineIcon(
+        DivineIcon(
           icon: DivineIconName.lockSimple,
-          color: VineTheme.vineGreen,
+          color: context.vineColors.accentPositive,
           size: 48,
         ),
         const SizedBox(height: 16),

--- a/mobile/lib/widgets/sound_tile.dart
+++ b/mobile/lib/widgets/sound_tile.dart
@@ -135,9 +135,9 @@ class SoundTile extends StatelessWidget {
             child: Column(
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
-                const DivineIcon(
+                DivineIcon(
                   icon: DivineIconName.musicNote,
-                  color: VineTheme.vineGreen,
+                  color: context.vineColors.accentPositive,
                 ),
                 const SizedBox(height: 4),
                 Text(
@@ -192,9 +192,9 @@ class SoundTile extends StatelessWidget {
                       children: [
                         Row(
                           children: [
-                            const DivineIcon(
+                            DivineIcon(
                               icon: DivineIconName.musicNote,
-                              color: VineTheme.vineGreen,
+                              color: context.vineColors.accentPositive,
                               size: 16,
                             ),
                             const SizedBox(width: 4),
@@ -216,7 +216,9 @@ class SoundTile extends StatelessWidget {
                           const SizedBox(height: 6),
                           _SoundStatusBadge(
                             label: statusBadgeLabel!,
-                            color: statusBadgeColor ?? VineTheme.vineGreen,
+                            color:
+                                statusBadgeColor ??
+                                context.vineColors.accentPositive,
                           ),
                         ],
                         const SizedBox(height: 4),
@@ -273,7 +275,7 @@ class SoundTile extends StatelessWidget {
           ),
           child: Icon(
             isPlaying ? Icons.stop : Icons.play_arrow,
-            color: VineTheme.vineGreen,
+            color: context.vineColors.accentPositive,
             size: 28,
           ),
         ),

--- a/mobile/lib/widgets/unfollow_confirmation_sheet.dart
+++ b/mobile/lib/widgets/unfollow_confirmation_sheet.dart
@@ -27,7 +27,7 @@ Future<bool?> showUnfollowConfirmation(
                 onPressed: () => Navigator.of(context).pop(false),
                 style: OutlinedButton.styleFrom(
                   backgroundColor: context.vineColors.surfaceContainer,
-                  foregroundColor: VineTheme.vineGreen,
+                  foregroundColor: context.vineColors.accentPositive,
                   padding: const EdgeInsets.symmetric(
                     vertical: 12,
                     horizontal: 16,
@@ -42,7 +42,9 @@ Future<bool?> showUnfollowConfirmation(
                 ),
                 child: Text(
                   context.l10n.commonCancel,
-                  style: VineTheme.titleMediumFont(color: VineTheme.vineGreen),
+                  style: VineTheme.titleMediumFont(
+                    color: context.vineColors.accentPositive,
+                  ),
                   maxLines: 1,
                   overflow: TextOverflow.ellipsis,
                 ),

--- a/mobile/lib/widgets/user_picker_sheet.dart
+++ b/mobile/lib/widgets/user_picker_sheet.dart
@@ -439,7 +439,7 @@ class _UserPickerSheetState extends ConsumerState<UserPickerSheet> {
               enableSuggestions: false,
               onChanged: _onSearchChanged,
               onSubmitted: _onSearchChanged,
-              cursorColor: VineTheme.vineGreen,
+              cursorColor: context.vineColors.accentPositive,
               style: VineTheme.bodyLargeFont(
                 color: context.vineColors.onSurface,
               ),
@@ -475,8 +475,8 @@ class _UserPickerSheetState extends ConsumerState<UserPickerSheet> {
                 enabledBorder: .none,
                 focusedBorder: OutlineInputBorder(
                   borderRadius: .circular(_searchInputBorderRadius),
-                  borderSide: const BorderSide(
-                    color: VineTheme.primary,
+                  borderSide: BorderSide(
+                    color: context.vineColors.accentPositive,
                     width: 2,
                   ),
                 ),
@@ -684,7 +684,9 @@ class _EmptyFollowList extends StatelessWidget {
                 child: Text(
                   context.l10n.userPickerGoBack,
                   textAlign: TextAlign.center,
-                  style: VineTheme.titleMediumFont(color: VineTheme.primary),
+                  style: VineTheme.titleMediumFont(
+                    color: context.vineColors.accentPositive,
+                  ),
                 ),
               ),
             ),

--- a/mobile/lib/widgets/video_editor/audio_editor/audio_category_bar.dart
+++ b/mobile/lib/widgets/video_editor/audio_editor/audio_category_bar.dart
@@ -76,7 +76,7 @@ class _Chip extends StatelessWidget {
             label,
             style: VineTheme.titleSmallFont(
               color: isSelected
-                  ? VineTheme.primary
+                  ? context.vineColors.accentPositive
                   : context.vineColors.onSurfaceVariant,
             ),
           ),

--- a/mobile/lib/widgets/video_editor/audio_editor/audio_editor_selection_overlay.dart
+++ b/mobile/lib/widgets/video_editor/audio_editor/audio_editor_selection_overlay.dart
@@ -200,6 +200,7 @@ class _AudioPlaybackProgressButtonState
                             foregroundPainter: _CircularProgressBorderPainter(
                               progress: progress,
                               borderRadius: _buttonBorderRadius,
+                              color: context.vineColors.accentPositive,
                             ),
                             child: Center(
                               child: DivineIconButton(
@@ -231,10 +232,12 @@ class _CircularProgressBorderPainter extends CustomPainter {
   const _CircularProgressBorderPainter({
     required this.progress,
     required this.borderRadius,
+    required this.color,
   });
 
   final double progress;
   final double borderRadius;
+  final Color color;
   static const double _innerInset = 1;
 
   @override
@@ -245,7 +248,7 @@ class _CircularProgressBorderPainter extends CustomPainter {
     }
 
     final strokePaint = Paint()
-      ..color = VineTheme.primary
+      ..color = color
       ..style = .stroke
       ..strokeWidth = 2
       ..strokeCap = .round;
@@ -303,6 +306,7 @@ class _CircularProgressBorderPainter extends CustomPainter {
   @override
   bool shouldRepaint(_CircularProgressBorderPainter oldDelegate) {
     return progress != oldDelegate.progress ||
-        borderRadius != oldDelegate.borderRadius;
+        borderRadius != oldDelegate.borderRadius ||
+        color != oldDelegate.color;
   }
 }

--- a/mobile/lib/widgets/video_editor/audio_editor/audio_list_tile.dart
+++ b/mobile/lib/widgets/video_editor/audio_editor/audio_list_tile.dart
@@ -196,7 +196,7 @@ class _AudioBars extends StatelessWidget {
 
           return DecoratedBox(
             decoration: BoxDecoration(
-              color: VineTheme.primary,
+              color: context.vineColors.accentPositive,
               borderRadius: BorderRadius.circular(999),
             ),
             child: SizedBox(width: 2, height: height),

--- a/mobile/lib/widgets/video_editor/audio_editor/audio_list_tile.dart
+++ b/mobile/lib/widgets/video_editor/audio_editor/audio_list_tile.dart
@@ -63,7 +63,7 @@ class _Tile extends StatelessWidget {
           audio.title ?? context.l10n.videoEditorAudioUntitledSound,
           style: VineTheme.titleMediumFont(
             color: isSelected
-                ? VineTheme.primary
+                ? context.vineColors.accentPositive
                 : context.vineColors.onSurface,
           ),
           maxLines: 1,

--- a/mobile/lib/widgets/video_editor/draw_editor/video_editor_draw_item_indicator.dart
+++ b/mobile/lib/widgets/video_editor/draw_editor/video_editor_draw_item_indicator.dart
@@ -34,7 +34,7 @@ class VideoEditorDrawItemIndicator extends StatelessWidget {
         child: Container(
           width: VideoEditorConstants.drawItemWidth,
           height: 4,
-          color: VineTheme.primary,
+          color: context.vineColors.accentPositive,
         ),
       ),
     );

--- a/mobile/lib/widgets/video_editor/filter_editor/video_editor_filter_bottom_bar.dart
+++ b/mobile/lib/widgets/video_editor/filter_editor/video_editor_filter_bottom_bar.dart
@@ -122,7 +122,7 @@ class _FilterItem extends StatelessWidget {
                   borderRadius: .circular(20),
                   border: .all(
                     color: isSelected
-                        ? VineTheme.primary
+                        ? context.vineColors.accentPositive
                         : context.vineColors.outlineMuted,
                     width: 2,
                   ),

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
@@ -2559,6 +2559,11 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
           _proVideoController,
           key: scope.editorKey,
           configs: ProImageEditorConfigs(
+            // pro_image_editor falls back to its own bare ThemeData,
+            // which carries no VineThemeColors. Everything under it
+            // would resolve context.vineColors through the silent dark
+            // fallback and paint dark tokens on a light page.
+            theme: Theme.of(context),
             stateHistory: StateHistoryConfigs(
               initStateHistory: editorStateHistory.isNotEmpty
                   ? .fromMap(

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_main_actions_sheet.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_main_actions_sheet.dart
@@ -243,7 +243,10 @@ class _ItemButton extends StatelessWidget {
                   ),
                 ),
                 child: Center(
-                  child: DivineIcon(icon: icon, color: VineTheme.primary),
+                  child: DivineIcon(
+                    icon: icon,
+                    color: context.vineColors.accentPositive,
+                  ),
                 ),
               ),
             ),

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_main_bottom_bar.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_main_bottom_bar.dart
@@ -118,7 +118,10 @@ class _ActionButton extends StatelessWidget {
                 border: .all(width: 2, color: context.vineColors.outlineMuted),
                 borderRadius: .circular(16),
               ),
-              child: DivineIcon(icon: icon, color: VineTheme.primary),
+              child: DivineIcon(
+                icon: icon,
+                color: context.vineColors.accentPositive,
+              ),
             ),
           ),
         ),

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_thumbnail.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_thumbnail.dart
@@ -36,8 +36,10 @@ class VideoEditorThumbnail extends ConsumerWidget {
             )
           : SizedBox.fromSize(
               size: contentSize,
-              child: const Center(
-                child: CircularProgressIndicator(color: VineTheme.primary),
+              child: Center(
+                child: CircularProgressIndicator(
+                  color: context.vineColors.accentPositive,
+                ),
               ),
             ),
     );

--- a/mobile/lib/widgets/video_editor/text_editor/video_editor_text_font_selector.dart
+++ b/mobile/lib/widgets/video_editor/text_editor/video_editor_text_font_selector.dart
@@ -97,9 +97,9 @@ class _FontListItem extends StatelessWidget {
                 ),
               ),
               if (isSelected)
-                const DivineIcon(
+                DivineIcon(
                   icon: DivineIconName.check,
-                  color: VineTheme.primary,
+                  color: context.vineColors.accentPositive,
                   size: 28,
                 ),
             ],

--- a/mobile/lib/widgets/video_editor/text_editor/video_editor_text_style_bar.dart
+++ b/mobile/lib/widgets/video_editor/text_editor/video_editor_text_style_bar.dart
@@ -220,15 +220,17 @@ class _FontSelectorButton extends StatelessWidget {
                   child: Text(
                     display,
                     overflow: .ellipsis,
-                    style: VineTheme.titleMediumFont(color: VineTheme.primary),
+                    style: VineTheme.titleMediumFont(
+                      color: context.vineColors.accentPositive,
+                    ),
                   ),
                 ),
                 AnimatedRotation(
                   turns: isOpen ? 0.5 : 0,
                   duration: const Duration(milliseconds: 200),
-                  child: const DivineIcon(
+                  child: DivineIcon(
                     icon: .caretDown,
-                    color: VineTheme.primary,
+                    color: context.vineColors.accentPositive,
                   ),
                 ),
               ],

--- a/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_caption_custom_style_sheet.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_caption_custom_style_sheet.dart
@@ -300,9 +300,9 @@ class _FontField extends StatelessWidget {
                   ),
                 ),
               ),
-              const DivineIcon(
+              DivineIcon(
                 icon: DivineIconName.caretDown,
-                color: VineTheme.primary,
+                color: context.vineColors.accentPositive,
               ),
             ],
           ),
@@ -390,7 +390,7 @@ class _ColorSwatch extends StatelessWidget {
             borderRadius: BorderRadius.circular(16),
             border: Border.all(
               color: selected
-                  ? VineTheme.primary
+                  ? context.vineColors.accentPositive
                   : context.vineColors.outlineMuted,
               width: 2,
             ),
@@ -478,7 +478,7 @@ class _AnimationChip extends StatelessWidget {
             borderRadius: BorderRadius.circular(20),
             border: Border.all(
               color: selected
-                  ? VineTheme.primary
+                  ? context.vineColors.accentPositive
                   : context.vineColors.outlineMuted,
               width: 2,
             ),
@@ -487,7 +487,7 @@ class _AnimationChip extends StatelessWidget {
             label,
             style: VineTheme.bodyMediumFont(
               color: selected
-                  ? VineTheme.primary
+                  ? context.vineColors.accentPositive
                   : context.vineColors.onSurfaceVariant,
             ),
           ),

--- a/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_caption_font_sheet.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_caption_font_sheet.dart
@@ -74,9 +74,9 @@ class _FontListItem extends StatelessWidget {
                 ),
               ),
               if (selected)
-                const DivineIcon(
+                DivineIcon(
                   icon: DivineIconName.check,
-                  color: VineTheme.primary,
+                  color: context.vineColors.accentPositive,
                   size: 28,
                 ),
             ],

--- a/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_caption_preset_sheet.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_caption_preset_sheet.dart
@@ -214,7 +214,7 @@ class _CaptionTileFrame extends StatelessWidget {
                     borderRadius: BorderRadius.circular(10),
                     border: Border.all(
                       color: selected
-                          ? VineTheme.primary
+                          ? context.vineColors.accentPositive
                           : VineTheme.transparent,
                       width: 2,
                     ),
@@ -233,7 +233,7 @@ class _CaptionTileFrame extends StatelessWidget {
                   label,
                   style: VineTheme.labelSmallFont(
                     color: selected
-                        ? VineTheme.primary
+                        ? context.vineColors.accentPositive
                         : context.vineColors.mutedText,
                   ),
                 ),

--- a/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_layer_animation_sheet.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_layer_animation_sheet.dart
@@ -398,10 +398,12 @@ class _LayerAnimationPickerViewState extends State<LayerAnimationPickerView>
                                     child: DivineIcon(
                                       icon: _directionIcon(direction),
                                       size: 18,
-                                      // Same rule as the curve glyphs: the
-                                      // chip's light fill leaves the accent
-                                      // at 2.22:1, so light resolves
-                                      // `onSurface`.
+                                      // Matches the curve glyphs, which
+                                      // already resolve `onSurface` in
+                                      // light. Not a contrast call —
+                                      // `accentPositive` is 5.78:1 on the
+                                      // chip's `primaryContainer` fill —
+                                      // but a consistency one.
                                       color: direction == active.direction
                                           ? context.vineColors.isLight
                                                 ? context.vineColors.onSurface

--- a/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_layer_animation_sheet.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_layer_animation_sheet.dart
@@ -398,8 +398,14 @@ class _LayerAnimationPickerViewState extends State<LayerAnimationPickerView>
                                     child: DivineIcon(
                                       icon: _directionIcon(direction),
                                       size: 18,
+                                      // Same rule as the curve glyphs: the
+                                      // chip's light fill leaves the accent
+                                      // at 2.22:1, so light resolves
+                                      // `onSurface`.
                                       color: direction == active.direction
-                                          ? VineTheme.primary
+                                          ? context.vineColors.isLight
+                                                ? context.vineColors.onSurface
+                                                : VineTheme.primary
                                           : context.vineColors.secondaryText,
                                     ),
                                   ),
@@ -731,8 +737,10 @@ class _LayerTypeTile extends StatelessWidget {
                   label,
                   style: VineTheme.labelSmallFont(
                     color: selected
-                        ? VineTheme.primary
-                        : context.vineColors.mutedText,
+                        ? colors.isLight
+                              ? colors.onSurface
+                              : VineTheme.primary
+                        : colors.mutedText,
                   ),
                 ),
               ),

--- a/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_transition_sheet.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_transition_sheet.dart
@@ -469,8 +469,13 @@ class _TransitionPickerViewState extends State<TransitionPickerView>
                             child: DivineIcon(
                               icon: _directionIcon(direction),
                               size: 18,
+                              // Same rule as the curve glyphs directly above:
+                              // the chip's light fill leaves the accent at
+                              // 2.22:1, so light mode resolves `onSurface`.
                               color: direction == _direction
-                                  ? VineTheme.primary
+                                  ? context.vineColors.isLight
+                                        ? context.vineColors.onSurface
+                                        : VineTheme.primary
                                   : context.vineColors.secondaryText,
                             ),
                           ),
@@ -560,7 +565,9 @@ class _TransitionTile extends StatelessWidget {
                 decoration: BoxDecoration(
                   borderRadius: BorderRadius.circular(10),
                   border: Border.all(
-                    color: selected ? VineTheme.primary : Colors.transparent,
+                    color: selected
+                        ? context.vineColors.accentPositive
+                        : Colors.transparent,
                     width: 2,
                   ),
                 ),
@@ -590,7 +597,7 @@ class _TransitionTile extends StatelessWidget {
                   label,
                   style: VineTheme.labelSmallFont(
                     color: selected
-                        ? VineTheme.primary
+                        ? context.vineColors.accentPositive
                         : context.vineColors.mutedText,
                   ),
                 ),

--- a/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_transition_sheet.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_transition_sheet.dart
@@ -469,9 +469,12 @@ class _TransitionPickerViewState extends State<TransitionPickerView>
                             child: DivineIcon(
                               icon: _directionIcon(direction),
                               size: 18,
-                              // Same rule as the curve glyphs directly above:
-                              // the chip's light fill leaves the accent at
-                              // 2.22:1, so light mode resolves `onSurface`.
+                              // Matches the curve glyphs directly above,
+                              // which already resolve `onSurface` in light.
+                              // Contrast is not the reason — `accentPositive`
+                              // is 5.78:1 on the chip's `primaryContainer`
+                              // fill — a lone green glyph beside neutral
+                              // siblings in one sheet is.
                               color: direction == _direction
                                   ? context.vineColors.isLight
                                         ? context.vineColors.onSurface

--- a/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip.dart
@@ -1176,7 +1176,7 @@ class _LoopTransitionButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final foreground = hasTransition
-        ? VineTheme.primary
+        ? context.vineColors.accentPositive
         : context.vineColors.secondaryText;
     final left = math.max(
       0.0,
@@ -1237,7 +1237,7 @@ class _TransitionButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final foreground = hasTransition
-        ? VineTheme.primary
+        ? context.vineColors.accentPositive
         : context.vineColors.secondaryText;
     return Semantics(
       button: true,

--- a/mobile/lib/widgets/video_editor/tune_editor/video_editor_tune_bottom_bar.dart
+++ b/mobile/lib/widgets/video_editor/tune_editor/video_editor_tune_bottom_bar.dart
@@ -74,10 +74,12 @@ class _TuneSlider extends StatelessWidget {
       child: SliderTheme(
         data: SliderTheme.of(context).copyWith(
           trackHeight: 3,
-          activeTrackColor: VineTheme.primary,
+          activeTrackColor: context.vineColors.accentPositive,
           inactiveTrackColor: context.vineColors.outlineMuted,
-          thumbColor: VineTheme.primary,
-          overlayColor: VineTheme.primary.withValues(alpha: 0.12),
+          thumbColor: context.vineColors.accentPositive,
+          overlayColor: context.vineColors.accentPositive.withValues(
+            alpha: 0.12,
+          ),
           overlayShape: const RoundSliderOverlayShape(overlayRadius: 14),
           valueIndicatorColor: context.vineColors.surfaceContainer,
           valueIndicatorTextStyle: VineTheme.bodySmallFont(

--- a/mobile/lib/widgets/video_editor/tune_editor/video_editor_tune_bottom_bar.dart
+++ b/mobile/lib/widgets/video_editor/tune_editor/video_editor_tune_bottom_bar.dart
@@ -187,7 +187,7 @@ class _TuneChip extends StatelessWidget {
             borderRadius: .circular(16),
             border: .all(
               color: isSelected
-                  ? VineTheme.primary
+                  ? context.vineColors.accentPositive
                   : context.vineColors.outlineMuted,
               width: 2,
             ),
@@ -202,7 +202,7 @@ class _TuneChip extends StatelessWidget {
                   label,
                   style: VineTheme.bodySmallFont(
                     color: isSelected
-                        ? VineTheme.primary
+                        ? context.vineColors.accentPositive
                         : context.vineColors.onSurface,
                   ),
                 ),

--- a/mobile/lib/widgets/video_editor/video_editor_color_picker_sheet.dart
+++ b/mobile/lib/widgets/video_editor/video_editor_color_picker_sheet.dart
@@ -245,7 +245,10 @@ class _ColorButton extends StatelessWidget {
           : context.vineColors.disabled,
       borderWidth: isColorPicker ? 2 : 1,
       child: isColorPicker
-          ? const DivineIcon(icon: .paintBrush, color: VineTheme.primary)
+          ? DivineIcon(
+              icon: .paintBrush,
+              color: context.vineColors.accentPositive,
+            )
           : null,
     );
   }

--- a/mobile/lib/widgets/video_feed_item/actions/share_sheet_more_actions.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/share_sheet_more_actions.dart
@@ -215,7 +215,7 @@ class _ActionCircle extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final bgColor = VineTheme.vineGreen.withValues(alpha: 0.15);
-    const iconColor = VineTheme.vineGreen;
+    final iconColor = context.vineColors.accentPositive;
 
     return Semantics(
       button: true,
@@ -242,7 +242,7 @@ class _ActionCircle extends StatelessWidget {
                       // Same footprint as the icon it replaces, so the row does
                       // not reflow while the save is in flight. Mirrors the
                       // send button in share_sheet_message_input.dart.
-                      ? const SizedBox.square(
+                      ? SizedBox.square(
                           dimension: _iconSize,
                           child: CircularProgressIndicator(
                             strokeWidth: 2,

--- a/mobile/lib/widgets/video_feed_item/actions/share_with_section.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/share_with_section.dart
@@ -147,10 +147,10 @@ class _FindPeopleItem extends StatelessWidget {
                     _ShareWithSection._avatarRadius,
                   ),
                 ),
-                child: const Center(
+                child: Center(
                   child: DivineIcon(
                     icon: DivineIconName.search,
-                    color: VineTheme.vineGreen,
+                    color: context.vineColors.accentPositive,
                   ),
                 ),
               ),
@@ -229,7 +229,7 @@ class _ContactItem extends StatelessWidget {
                 user.displayName ?? context.l10n.shareUserFallback,
                 style: TextStyle(
                   color: isSelected
-                      ? VineTheme.vineGreen
+                      ? context.vineColors.accentPositive
                       : context.vineColors.secondaryText,
                   fontSize: 11,
                 ),

--- a/mobile/lib/widgets/video_feed_item/list_attribution_chip.dart
+++ b/mobile/lib/widgets/video_feed_item/list_attribution_chip.dart
@@ -55,23 +55,25 @@ class ListAttributionChip extends StatelessWidget {
               color: context.vineColors.card,
               borderRadius: BorderRadius.circular(12),
               border: Border.all(
-                color: VineTheme.vineGreen.withValues(alpha: 0.5),
+                color: context.vineColors.accentPositive.withValues(
+                  alpha: 0.5,
+                ),
               ),
             ),
             child: Row(
               mainAxisSize: MainAxisSize.min,
               children: [
-                const DivineIcon(
+                DivineIcon(
                   icon: DivineIconName.playlist,
                   size: 14,
-                  color: VineTheme.vineGreen,
+                  color: context.vineColors.accentPositive,
                 ),
                 const SizedBox(width: 4),
                 Text(
                   listName,
-                  style: const TextStyle(
+                  style: TextStyle(
                     fontSize: 12,
-                    color: VineTheme.vineGreen,
+                    color: context.vineColors.accentPositive,
                   ),
                 ),
               ],

--- a/mobile/lib/widgets/video_feed_item/metadata/metadata_sounds_section.dart
+++ b/mobile/lib/widgets/video_feed_item/metadata/metadata_sounds_section.dart
@@ -327,7 +327,7 @@ class _SoundListItem extends ConsumerWidget {
                           : context.l10n.soundCreditOnly,
                       style: VineTheme.labelSmallFont(
                         color: reuseAllowed
-                            ? VineTheme.vineGreen
+                            ? context.vineColors.accentPositive
                             : context.vineColors.onSurfaceVariant,
                       ),
                     ),

--- a/mobile/lib/widgets/video_feed_item/metadata/metadata_tags_section.dart
+++ b/mobile/lib/widgets/video_feed_item/metadata/metadata_tags_section.dart
@@ -89,7 +89,12 @@ class _HashtagChip extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         spacing: 4,
         children: [
-          Text('#', style: VineTheme.bodyLargeFont(color: VineTheme.vineGreen)),
+          Text(
+            '#',
+            style: VineTheme.bodyLargeFont(
+              color: context.vineColors.accentPositive,
+            ),
+          ),
           Flexible(
             child: Text(
               tag,

--- a/mobile/lib/widgets/video_feed_item/video_feed_item.dart
+++ b/mobile/lib/widgets/video_feed_item/video_feed_item.dart
@@ -1023,15 +1023,15 @@ class _ContentWarningDetailsSheet extends StatelessWidget {
                   Navigator.of(context).pop();
                   context.push('/content-filters');
                 },
-                icon: const DivineIcon(
+                icon: DivineIcon(
                   icon: DivineIconName.slidersHorizontal,
                   size: 18,
-                  color: VineTheme.vineGreen,
+                  color: context.vineColors.accentPositive,
                 ),
                 label: Text(
                   context.l10n.contentWarningManageFilters,
-                  style: const TextStyle(
-                    color: VineTheme.vineGreen,
+                  style: TextStyle(
+                    color: context.vineColors.accentPositive,
                     fontSize: 14,
                     fontWeight: FontWeight.w600,
                   ),

--- a/mobile/lib/widgets/video_metadata/video_metadata_help_sheet.dart
+++ b/mobile/lib/widgets/video_metadata/video_metadata_help_sheet.dart
@@ -68,7 +68,7 @@ class VideoMetadataHelpSheet extends StatelessWidget {
                       context.l10n.videoMetadataGotItButton,
                       textAlign: TextAlign.center,
                       style: VineTheme.titleMediumFont(
-                        color: VineTheme.primary,
+                        color: context.vineColors.accentPositive,
                       ),
                     ),
                   ),

--- a/mobile/lib/widgets/video_metadata/video_metadata_selection_tile.dart
+++ b/mobile/lib/widgets/video_metadata/video_metadata_selection_tile.dart
@@ -70,9 +70,9 @@ class _VideoMetadataSelectionTileState
                     ),
                   ),
                 ),
-                const DivineIcon(
+                DivineIcon(
                   icon: .caretDown,
-                  color: VineTheme.primary,
+                  color: context.vineColors.accentPositive,
                 ),
               ],
             ),

--- a/mobile/lib/widgets/video_metadata/video_metadata_tags_selector.dart
+++ b/mobile/lib/widgets/video_metadata/video_metadata_tags_selector.dart
@@ -235,7 +235,7 @@ class _TagsPickerViewState extends State<_TagsPickerView> {
                 FilteringTextInputFormatter.allow(RegExp('[a-zA-Z0-9 ,]')),
               ],
               onSubmitted: _addTag,
-              cursorColor: VineTheme.vineGreen,
+              cursorColor: context.vineColors.accentPositive,
               style: VineTheme.bodyLargeFont(
                 color: context.vineColors.onSurface,
               ),
@@ -255,8 +255,8 @@ class _TagsPickerViewState extends State<_TagsPickerView> {
                 enabledBorder: InputBorder.none,
                 focusedBorder: OutlineInputBorder(
                   borderRadius: BorderRadius.circular(_searchInputBorderRadius),
-                  borderSide: const BorderSide(
-                    color: VineTheme.primary,
+                  borderSide: BorderSide(
+                    color: context.vineColors.accentPositive,
                     width: 2,
                   ),
                 ),
@@ -311,9 +311,9 @@ class _TagsPickerViewState extends State<_TagsPickerView> {
             return AnimatedOpacity(
               opacity: isLoading ? 1.0 : 0.0,
               duration: const Duration(milliseconds: 200),
-              child: const LinearProgressIndicator(
+              child: LinearProgressIndicator(
                 backgroundColor: Colors.transparent,
-                color: VineTheme.primary,
+                color: context.vineColors.accentPositive,
                 minHeight: 2,
               ),
             );
@@ -418,12 +418,17 @@ class _SuggestionChip extends StatelessWidget {
                   ),
                 ),
               ),
-              const Padding(
-                padding: EdgeInsets.only(left: 8, right: 12, top: 8, bottom: 8),
+              Padding(
+                padding: const EdgeInsets.only(
+                  left: 8,
+                  right: 12,
+                  top: 8,
+                  bottom: 8,
+                ),
                 child: DivineIcon(
                   icon: .plus,
                   size: 16,
-                  color: VineTheme.primary,
+                  color: context.vineColors.accentPositive,
                 ),
               ),
             ],

--- a/mobile/lib/widgets/video_reply_parent_link.dart
+++ b/mobile/lib/widgets/video_reply_parent_link.dart
@@ -149,9 +149,9 @@ class _MetadataReplyLink extends StatelessWidget {
         padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
         child: Row(
           children: [
-            const DivineIcon(
+            DivineIcon(
               icon: DivineIconName.arrowBendUpLeft,
-              color: VineTheme.vineGreen,
+              color: context.vineColors.accentPositive,
               size: 20,
             ),
             const SizedBox(width: 12),

--- a/mobile/lib/widgets/watermark_download_progress_sheet.dart
+++ b/mobile/lib/widgets/watermark_download_progress_sheet.dart
@@ -118,12 +118,12 @@ class _WatermarkDownloadProgressViewState
                     ),
                     const SizedBox(height: 24),
                     if (state.isProcessing) ...[
-                      const SizedBox(
+                      SizedBox(
                         width: 32,
                         height: 32,
                         child: CircularProgressIndicator(
                           strokeWidth: 3,
-                          color: VineTheme.vineGreen,
+                          color: context.vineColors.accentPositive,
                         ),
                       ),
                       const SizedBox(height: 16),
@@ -158,9 +158,9 @@ class _WatermarkDownloadProgressViewState
     final l10n = context.l10n;
     return switch (result) {
       WatermarkDownloadSuccess() => [
-        const DivineIcon(
+        DivineIcon(
           icon: DivineIconName.checkCircle,
-          color: VineTheme.vineGreen,
+          color: context.vineColors.accentPositive,
           size: 48,
         ),
         const SizedBox(height: 16),
@@ -199,9 +199,9 @@ class _WatermarkDownloadProgressViewState
         ),
       ],
       WatermarkDownloadPermissionDenied() => [
-        const DivineIcon(
+        DivineIcon(
           icon: DivineIconName.lockSimple,
-          color: VineTheme.vineGreen,
+          color: context.vineColors.accentPositive,
           size: 48,
         ),
         const SizedBox(height: 16),

--- a/mobile/packages/divine_ui/lib/src/bottom_sheet/vine_bottom_sheet_selection_menu.dart
+++ b/mobile/packages/divine_ui/lib/src/bottom_sheet/vine_bottom_sheet_selection_menu.dart
@@ -133,7 +133,10 @@ class _VineBottomSheetSelectionOption extends StatelessWidget {
                   ),
                 ),
                 if (isSelected)
-                  const DivineIcon(icon: .check, color: VineTheme.vineGreen),
+                  DivineIcon(
+                    icon: .check,
+                    color: context.vineColors.accentPositive,
+                  ),
               ],
             ),
           ),

--- a/mobile/packages/divine_ui/lib/src/checkbox/divine_checkbox.dart
+++ b/mobile/packages/divine_ui/lib/src/checkbox/divine_checkbox.dart
@@ -185,7 +185,7 @@ class DivineRowCheckbox extends StatelessWidget {
             decoration: BoxDecoration(
               border: Border.all(
                 color: isSelected
-                    ? VineTheme.primary
+                    ? context.vineColors.accentPositive
                     : context.vineColors.outlineMuted,
               ),
               borderRadius: BorderRadius.circular(20),

--- a/mobile/packages/divine_ui/lib/src/info_card/divine_info_card.dart
+++ b/mobile/packages/divine_ui/lib/src/info_card/divine_info_card.dart
@@ -86,7 +86,7 @@ class DivineInfoCard extends StatelessWidget {
 
   /// Accent colour for the icon, the border, and a tinted tone's title.
   Color _accent(VineThemeColors colors) => switch (tone) {
-    DivineInfoCardTone.info => VineTheme.vineGreen,
+    DivineInfoCardTone.info => colors.accentPositive,
     DivineInfoCardTone.neutral => colors.secondaryText,
     DivineInfoCardTone.warning => VineTheme.warning,
     DivineInfoCardTone.error => VineTheme.error,

--- a/mobile/packages/divine_ui/lib/src/list_tile/divine_selectable_row.dart
+++ b/mobile/packages/divine_ui/lib/src/list_tile/divine_selectable_row.dart
@@ -65,10 +65,14 @@ class DivineSelectableRow extends StatelessWidget {
               style: VineTheme.bodySmallFont(color: colors.mutedText),
               overflow: TextOverflow.ellipsis,
             ),
+      // The tick is the only thing marking which row is chosen, so it has to
+      // clear contrast on the selected row's own fill. The raw brand green is
+      // 1.92:1 on light `surfaceContainer`; the token keeps that green in dark
+      // and swaps to the darkened one in light (5.61:1).
       trailing: isSelected
-          ? const DivineIcon(
+          ? DivineIcon(
               icon: DivineIconName.check,
-              color: VineTheme.vineGreen,
+              color: colors.accentPositive,
             )
           : null,
       onTap: onTap,

--- a/mobile/packages/divine_ui/lib/src/switch/divine_switch.dart
+++ b/mobile/packages/divine_ui/lib/src/switch/divine_switch.dart
@@ -124,7 +124,10 @@ class DivineSwitchTile extends StatelessWidget {
               leading ??
               (leadingIcon == null
                   ? null
-                  : DivineIcon(icon: leadingIcon!, color: VineTheme.primary)),
+                  : DivineIcon(
+                      icon: leadingIcon!,
+                      color: colors.accentPositive,
+                    )),
           title: Text(
             title,
             style: VineTheme.titleMediumFont(color: colors.primaryText),

--- a/mobile/packages/divine_ui/lib/src/theme/vine_theme.dart
+++ b/mobile/packages/divine_ui/lib/src/theme/vine_theme.dart
@@ -210,10 +210,12 @@ class VineThemeColors extends ThemeExtension<VineThemeColors> {
   /// integration, a completed step.
   ///
   /// Its dark value is [VineTheme.vineGreen], so dark mode is unchanged. The
-  /// brand green is 2.08:1 on the light canvas, below the 3:1 non-text floor,
-  /// so the light value is the seeded tone the light `colorScheme.primary`
-  /// already resolves to. Reusing it keeps one green in light mode rather
-  /// than introducing a second, near-identical one.
+  /// brand green is 2.08:1 on the light canvas, below the 3:1 non-text floor.
+  /// The light value is that green darkened 20% at the same hue: it now
+  /// labels body copy as well as icons, and the seeded `colorScheme.primary`
+  /// tone it used to borrow read 5.13:1 on [surfaceContainerHigh] — clearing
+  /// 4.5:1 flat, but trailing its dark counterpart by more than the third
+  /// this palette allows.
   final Color accentPositive;
 
   /// Attention-status accent, drawn directly on [background] — an expired
@@ -221,8 +223,10 @@ class VineThemeColors extends ThemeExtension<VineThemeColors> {
   ///
   /// Its dark value is [VineTheme.accentOrange], so dark mode is unchanged.
   /// This one labels body copy as well as icons, so the light value clears
-  /// 4.5:1 rather than 3:1 — and is pitched at [accentPositive]'s ratio on
-  /// [background] so the two accents carry the same weight side by side.
+  /// 4.5:1 rather than 3:1. It was originally pitched at [accentPositive]'s
+  /// ratio on [background] so the two read at equal weight; darkening
+  /// `accentPositive` for its own body-copy duty broke that pairing, and
+  /// re-darkening the orange to chase it was judged the larger brand change.
   final Color accentWarning;
 
   /// Decorative accent chips, drawn on [background] or [card] — notification
@@ -1241,7 +1245,7 @@ class VineTheme {
     skeleton: Color(0xFFE7E4E1),
     errorContainer: Color(0xFFFFE7E2),
     onErrorContainer: Color(0xFF8C1D18),
-    accentPositive: Color(0xFF226A4C),
+    accentPositive: Color(0xFF1B553D),
     accentWarning: Color(0xFFAE3100),
     // Pale tint / darkened accent. Each pair clears 4.5:1 foreground-on-
     // container (6.30–7.51) and holds 1.18–1.30 container-on-background, which

--- a/mobile/packages/divine_ui/test/src/list_tile/divine_selectable_row_test.dart
+++ b/mobile/packages/divine_ui/test/src/list_tile/divine_selectable_row_test.dart
@@ -12,9 +12,10 @@ void main() {
       String? subtitle,
       DivineIconName? leadingIcon,
       VoidCallback? onTap,
+      ThemeData? theme,
     }) {
       return MaterialApp(
-        theme: VineTheme.theme,
+        theme: theme ?? VineTheme.theme,
         home: Scaffold(
           body: DivineSelectableRow(
             title: 'Deutsch',
@@ -87,6 +88,38 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(tapped, isTrue);
+    });
+
+    testWidgets('the selection tick clears contrast in both appearances', (
+      tester,
+    ) async {
+      // The tick is the row's only selected-state cue, so it has to stay
+      // readable on the selected fill. The raw brand green is 1.92:1 on the
+      // light `surfaceContainer`; the token keeps dark unchanged and swaps to
+      // the darkened green in light.
+      await tester.pumpWidget(buildSubject(isSelected: true));
+      await tester.pumpAndSettle();
+      expect(
+        (tester.widget<ListTile>(find.byType(ListTile)).trailing! as DivineIcon)
+            .color,
+        VineTheme.darkColors.accentPositive,
+      );
+
+      await tester.pumpWidget(
+        buildSubject(isSelected: true, theme: VineTheme.lightTheme),
+      );
+      // MaterialApp lerps between themes, so a single pump samples the
+      // transition rather than the destination palette.
+      await tester.pumpAndSettle();
+      final lightTick =
+          tester.widget<ListTile>(find.byType(ListTile)).trailing!
+              as DivineIcon;
+      expect(lightTick.color, VineTheme.lightColors.accentPositive);
+      expect(
+        lightTick.color,
+        isNot(VineTheme.vineGreen),
+        reason: 'light mode must not fall back to the dark-only brand green',
+      );
     });
   });
 }

--- a/mobile/packages/divine_ui/test/src/theme/vine_theme_light_palette_test.dart
+++ b/mobile/packages/divine_ui/test/src/theme/vine_theme_light_palette_test.dart
@@ -94,6 +94,15 @@ const _bodyPairs = <(String, String)>[
   // `accentWarning` labels the copy next to its icon ("Reconnect needed"), not
   // just the icon, so it is held to the body ratio rather than the 3:1 floor.
   ('accentWarning', 'background'),
+  // `accentPositive` was icon-only when this list was written. It now colors
+  // copy too — link text, active labels, the selected-row tick that is the
+  // only marker of which row is chosen — on every app surface it reaches, so
+  // it moved up from the 3:1 floor to the body ratio on each of them.
+  ('accentPositive', 'background'),
+  ('accentPositive', 'card'),
+  ('accentPositive', 'surface'),
+  ('accentPositive', 'surfaceContainer'),
+  ('accentPositive', 'surfaceContainerHigh'),
 ];
 
 /// Supporting copy — hints, placeholders, secondary labels — held to the
@@ -102,10 +111,6 @@ const _supportingPairs = <(String, String)>[
   ('onSurfaceVariant', 'surface'),
   ('onSurfaceMuted', 'surface'),
   ('onErrorContainer', 'errorContainer'),
-  // `accentPositive` only ever tints an icon — the connected row's label is
-  // `primaryText` and its identity line is `secondaryText` — so the non-text
-  // floor is the honest bar for it. Promote it if it ever colors copy.
-  ('accentPositive', 'background'),
 ];
 
 /// Token pairs that share a dark value while differing in light.


### PR DESCRIPTION
## What

Brand green stops being invisible on light surfaces. 238 foreground references move from `VineTheme.vineGreen` / `VineTheme.primary` to `context.vineColors.accentPositive`, and `accentPositive`'s light value is darkened to carry the copy it now colors.

This is the follow-up hm21 asked for in #7523 ("worth its own issue and pass") — with the addition that a visual audit found it goes wider than settings icons.

## Why

`#27C58B` was picked against black, where it is 9.45:1. On the light palette:

| light surface | vineGreen | accentPositive |
|---|---|---|
| `background` | **2.08** | 8.15 |
| `card` / `surface` | **2.22** | 8.70 |
| `surfaceContainer` | **1.92** | 7.52 |
| `surfaceContainerHigh` | **1.76** | 6.87 |
| `containerLow` / `primaryContainer` / `iconButton` | **1.98** | 7.73 |

Every one of those is under the 3:1 floor for icons. `accentPositive` clears text-grade 4.5:1 on all eight, and its **dark value is `vineGreen`**, so dark mode does not move.

## How it was found

Rendered real screens under `VineTheme.lightTheme` and looked at them. The settings-row icons, the Appearance tick, the editor bottom bars and the auth CTAs all read as faded rather than styled. Full audit with screenshots: https://claude.ai/code/artifact/3f01f2d9-a9f5-49ef-b2c3-12ae7fd05182

## Two sites worth calling out

- **`DivineSelectableRow`** — the tick is the *only* mark showing which row is selected, and it sat at 1.92:1 on the selected row's own fill. The Appearance screen exists to report that state and had the lowest-contrast element on it.
- **`DivineSwitchTile`** — its leading icon draws every settings-row glyph, so one call site covers most of what the audit showed.

## The palette change, and what it costs

`accentPositive`'s light value moves from `#226A4C` to `#1B553D` — the same hue, 20% darker. Dark is untouched.

The old value was chosen when the token only ever tinted an icon, so the palette guard held it to the 3:1 non-text floor with a comment saying to promote it if that changed. This PR made it color copy — links, active labels, and the selection tick — so it is now held to the body ratio on all five app surfaces it reaches. At `#226A4C` it cleared 4.5:1 flat but failed the repo's stricter `lightRatio >= darkRatio * 2/3` rule on two of eight grounds (`background` 6.08 vs 6.30 required, `surfaceContainerHigh` 5.13 vs 6.02). `#1B553D` clears every ground with ≥0.85 of slack.

**The cost, stated plainly:** `accentWarning`'s doc says it was "pitched at `accentPositive`'s ratio on `background` so the two accents carry the same weight side by side" — 6.07 vs 6.08. Darkening `accentPositive` to 8.15 breaks that pairing. Re-darkening the orange to chase it is a wider brand change than this PR should make unilaterally, so the pairing is retired and both doc comments now say so. **If the design team wants equal-weight accents back, that is a follow-up palette decision, not a bug in this diff.**

## What was deliberately NOT migrated

Roughly as many green references stayed on the constant. Green is correct there:

- **fills whose ground does not follow the theme** — a green pill or badge over media, ink on a filled brand colour
- **over media** — fullscreen playback chrome, camera, clip thumbnails, scrims, gradients
- **`const` contexts and pure-Dart models** with no `BuildContext`

247 `vineGreen`/`primary` references remain, down from 483.

Note that "fills are always fine" is *not* the rule, and an earlier revision of this description overstated it. A fill that **is** the accent, sitting on an adaptive light sheet, needed migrating like any foreground — the tune slider's active track and the audio equalizer bars were both raw green on a white sheet and are fixed here.

Three video-editor sheets already carried an explicit `isLight ? onSurface : VineTheme.primary` fix, and this PR adds two more conditionals matching them rather than introducing a second, differently-coloured green in the same sheet. That leaves a split — transition/caption tiles show a green selected ring, layer tiles a neutral one — which predates this PR but is now slightly wider. Preserved, not resolved; easy to unify either way.

## Dark mode is unchanged

```
dart run scripts/check_dark_value_parity.dart --base origin/main
→ 238 replacement(s) compared, 0 dark mismatch(es), 7 left for manual review
```

**What that guard does and does not prove.** It pairs each removed reference with its replacement inside a hunk and compares their **dark** values, so it proves no swap shifted a dark pixel *for the pairs it could form*. It has a documented blind spot: tokens that share a dark value are interchangeable to it, so picking the semantically wrong one of such a pair renders wrong in light and the guard stays green. That part was checked by eye, not mechanically. The 7 it skipped are structurally unpairable (a doc-comment edit, and the `isLight ?` hunks above, where the removed and added references genuinely do not sit one-to-one) — those were read by hand.

**One migration was reverted for exactly this reason.** `DivineInfoCard`'s warning tone looked like a match for `accentWarning` — but that token's dark value is `accentOrange` (`#FF7640`), not `warning` (`#FF9800`), so the swap would have shifted dark mode. An existing test caught it. Reverted; the warning tone still fails on light and is in the follow-up below.

## Self-review found four defects in this diff

I reviewed this PR adversarially before asking for review, and it was not clean. All four are fixed in `07b318f`:

1. **The video editor canvas dropped the theme extension.** `pro_image_editor` built its subtree under the package's own bare `ThemeData`, which carries no `VineThemeColors` — so everything below it resolved `context.vineColors` through the **silent dark fallback** and painted dark tokens on a light page. This is the worst class of bug here, because the fallback is silent by design.
2. The palette guard's promote-me-if-this-changes comment, described above.
3. The tune slider's active track, thumb and overlay stayed raw green.
4. The audio equalizer bars stayed raw green.

Plus a regression this PR itself introduced: a migrated ring around an unmigrated fill in the report dialog read two-tone in light and left the check at 2.11:1.

## Verification

- `flutter analyze lib test` — clean
- `flutter test` — **17,093 passed, 0 failed**, 305 skipped (pre-existing), on the pre-`07b318f` tree; `test/widgets/video_editor` (856), the settings light-mode suites, and the report-dialog suite re-run green after it
- `divine_ui` (100% coverage gate) — 893 passed
- `check_dark_value_parity.dart` — 0 mismatches
- New test in `divine_selectable_row_test.dart` pins the tick in **both** appearances and asserts light is not `vineGreen`, so this cannot silently regress

**Not verified:** no on-device run. Screens were rendered through the widget layer under the real light theme, not driven on a simulator.

**No automated test covers defect 1, and I established that one is not currently possible.** `settings_screens_light_mode_test.dart` asserts `VineThemeColors.debugFallbackCount == 0` after pumping a screen, which is exactly the right shape. I wrote the equivalent for the editor canvas — pump `VideoEditorCanvas` under `VineTheme.lightTheme`, assert the counter stays zero — and then checked it against the *unfixed* code. **It passed there too**, so it could not have caught the bug and I deleted it rather than bank a green line over a real gap. The cause is the constraint already noted at `video_editor_canvas.dart:2555`: `ProImageEditor` needs a live video pipeline to mount, so in a widget test its subtree never builds far enough to resolve a single token. A real guard needs an integration test with a video pipeline, or a lint that flags handing a child a `ThemeData` that isn't derived from `Theme.of(context)`. Neither is in scope here; the defect itself is fixed.

**A layout difference in my screenshots turned out to be my own harness, not this diff** — verified by running the identical harness against unmodified code and getting the same layout. Calling it out because the intermediate screenshots look like a spacing change and are not one.

## Still broken after this (follow-up)

Eleven other fixed constants also fail on every light surface. None has a token whose dark value matches, so each needs a new token pair rather than a swap — out of scope here:

| constant | best ratio on light | refs |
|---|---|---|
| `contentWarningAmber` | 1.72 | 11 |
| `warning` | 2.16 | 25 |
| `accentViolet` / `accentBlue` / `accentPink` | 2.17–2.36 | 8 |
| `accentOrange` | 2.65 | 23 |
| `success` | 2.78 | 14 |
| `accentYellow` / `accentLime` / `vineGreenLight` / `cameraButtonGreen` | 1.16–2.69 | 28 |

Many are over-media and correct as-is; the adaptive-surface subset needs the same treatment applied here.
