### PR TITLE
docs(bookmarks): say what the absence-confirmation TTL actually bounds

### DIFF
--- a/mobile/lib/services/bookmark_service.dart
+++ b/mobile/lib/services/bookmark_service.dart
@@ -218,6 +218,12 @@ class BookmarkService {
   /// How long a full-settlement "this user has no list" answer is reused
   /// before the next empty answer is confirmed again.
   ///
+  /// Reuse, not a query budget. Every sync still queries; what the window
+  /// skips is the *second*, full-settlement query that confirms an empty
+  /// answer. And it is keyed on a confirmed absence rather than on having
+  /// tried: a confirmation that could not settle establishes nothing, so it
+  /// opens no window and the next empty answer is confirmed again.
+  ///
   /// Bounds two opposing costs: without it a user who genuinely has no
   /// bookmarks pays a full-settlement wait every time Saved opens, and with an
   /// unbounded latch a list created on another device stays invisible for the
@@ -286,12 +292,14 @@ class BookmarkService {
   ///
   /// A non-authoritative read still never *discards* a list on a partial
   /// answer. An empty answer is confirmed against every relay before it is
-  /// believed — always while this device holds bookmarks, otherwise at most
-  /// once per [absenceConfirmationTtl] counted from the last confirmed
-  /// absence. Seeing a list resets that count, so a list that keeps going
-  /// missing is re-confirmed each time rather than once per window. An answer
-  /// that stays unconfirmed changes nothing. A read that finds a list keeps
-  /// the fast trade and pays for none of this.
+  /// believed — always while this device holds bookmarks, otherwise whenever
+  /// the last confirmed absence is older than [absenceConfirmationTtl].
+  /// Inside that window an empty answer is believed on the strength of that
+  /// earlier confirmation instead of being re-confirmed; the sync itself is
+  /// never skipped. Seeing a list clears the confirmation, so a list that
+  /// keeps going missing is re-confirmed every time rather than once per
+  /// window. An answer that stays unconfirmed changes nothing. A read that
+  /// finds a list keeps the fast trade and pays for none of this.
   Future<bool> syncGlobalBookmarks({bool requireAuthoritative = false}) async =>
       // Equality to success, never `!= someFailure`: a blacklist would let any
       // failure member added later fall through as "reconciled" and publish
@@ -339,6 +347,9 @@ class BookmarkService {
         );
         events = confirmation.events;
         if (events == null) {
+          // The absence stamp is deliberately left alone. A confirmation that
+          // could not settle establishes nothing, so opening a window on it
+          // would let the next partial empty answer through unconfirmed.
           Log.warning(
             'Empty bookmark answer not confirmed by every relay - keeping '
             'the ${globalBookmarks.length} bookmarks this device has',

--- a/mobile/test/services/bookmark_service_test.dart
+++ b/mobile/test/services/bookmark_service_test.dart
@@ -535,6 +535,34 @@ void main() {
         },
       );
 
+      test(
+        'does not start a window on a confirmation that could not settle',
+        () async {
+          // The window is keyed on a *confirmed* absence, not on having
+          // tried. A confirmation that times out establishes nothing, so
+          // suppressing the next one would leave the reinstall case resting
+          // on an empty answer nobody stood behind — #6627 all over again.
+          stubRelayForSettlementMode(fullSettlement: false, events: []);
+          stubRelayForSettlementMode(
+            fullSettlement: true,
+            events: [],
+            timedOut: true,
+          );
+          var clock = DateTime(2026);
+          final service = createService(now: () => clock);
+
+          expect(await service.syncGlobalBookmarks(), isFalse);
+          clock = clock.add(const Duration(minutes: 1));
+          expect(await service.syncGlobalBookmarks(), isFalse);
+
+          expect(
+            capturedSettlementDemands(),
+            equals([false, true, false, true]),
+            reason: 'well inside the TTL, but nothing was ever confirmed',
+          );
+        },
+      );
+
       test('reports failure when signed out, without throwing', () async {
         when(() => authService.isAuthenticated).thenReturn(false);
         when(() => authService.currentPublicKeyHex).thenReturn(null);


### PR DESCRIPTION
## Description

#7482 reports that the absence-confirmation TTL docs in `bookmark_service.dart` don't match the code. The docs are substantially right, but one phrase is genuinely misleading, and the question the issue asks — *"is this 'one query per TTL window' or 'once set, ignore for TTL duration'?"* — deserves a straight answer in the file.

**It is the second.** `_absenceConfirmedAt` records a confirmed *outcome*, and while it is fresh, empty answers are believed without re-confirming. The wording `at most once per [absenceConfirmationTtl]` framed that as a rate limit on queries, which invited both misreadings in the issue: that a sync inside the window is skipped (it isn't — every sync still queries; only the *second*, full-settlement confirming query is skipped), and that the window is a query budget (it isn't — it opens on a confirmed absence, never on an attempt).

The issue's other two claims don't hold against the code, and the docs now say why rather than leaving the reader to re-derive it:

- *"only tracks a single timestamp, not a sliding window"* — deliberate, and already load-bearing. `_absenceConfirmedAt` is renewed only by an authoritative answer (`bookmark_service.dart:373`), precisely so unconfirmed reads can't slide the deadline forward; `does not let unconfirmed reads slide the confirmation window` pins it.
- *"consider tracking `attempted_at` separately"* — declined, because it would be a behaviour regression, not a clarification. A confirmation that times out establishes nothing. If a failed attempt opened a window, the next partial empty answer would be believed unconfirmed, clearing `_globalBookmarks` / `_privateBookmarks` / `_lastKnownRemoteContent` — the #6627 shape #6966 closed.

## Changes

Docs only, plus the regression test for the one claim nothing pinned.

- `absenceConfirmationTtl` — states that it is reuse rather than a query budget, and that it is keyed on a confirmed absence rather than on having tried.
- `syncGlobalBookmarks` — replaces `at most once per …` with what actually happens inside the window, and says explicitly that the sync itself is never skipped.
- The unconfirmed-empty early return — one comment at the site explaining why the stamp is deliberately left alone.
- New test: `does not start a window on a confirmation that could not settle`.

No behaviour change. `absenceConfirmationTtl` is still 5 minutes and no control flow moved.

## Verification

`flutter analyze lib test integration_test` — clean. `test/services/bookmark_service_test.dart` — 57 passing (56 before).

Verified the new test can fail: stamping `_absenceConfirmedAt` in the unconfirmed-empty early return — the `attempted_at` variant the issue floats — turns it red and **only** it red, so nothing previously covered this and the test discriminates the exact claim the docs now make.

## Type of Change

- [x] 📝 Documentation update

Closes #7482