### PR TITLE
test(nostr): pin that a failed auth-gated send still counts as participation

### DIFF
--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_query_settle_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_query_settle_test.dart
@@ -897,6 +897,55 @@ void main() {
         },
       );
 
+      // Participation is acceptance, not a successful write. `relayDoQuery`
+      // saves the query before sending on the auth-gated branch, so the REQ is
+      // replayed after NIP-42 even though the frame never landed — counting
+      // that relay out would waive the hold on one still about to answer.
+      test(
+        'an auth-gated relay whose send failed still holds the query open',
+        () async {
+          final nostr = _newNostr();
+          final authGated = _SilentRelay('wss://auth-gated.example')
+            ..sendSucceeds = false;
+          expect(await nostr.relayPool.add(authGated), isTrue);
+          authGated.relayStatus.alwaysAuth = true;
+
+          final stopwatch = Stopwatch()..start();
+          final result = await nostr.queryEventsDetailed(
+            [
+              {
+                'kinds': [10003],
+              },
+            ],
+            timeout: unacceptedTimeout,
+            requireAllRelaysSettled: true,
+          );
+          stopwatch.stop();
+
+          expect(result.timedOut, isTrue);
+          expect(
+            result.noRelaysParticipated,
+            isFalse,
+            reason:
+                'the query is saved for post-AUTH replay, so this relay can '
+                'still serve it — reporting nobody was asked would tell the '
+                'user their relays are unreachable when one is mid-handshake',
+          );
+          expect(
+            stopwatch.elapsed,
+            // Half the deadline, not the whole of it: the timeout fires off a
+            // Timer while this measures a Stopwatch, and the two disagree by
+            // microseconds — CI saw 399.958ms against a 400ms bound. Waived
+            // participation completes in single-digit ms, so nothing lands
+            // between the two readings and the margin costs no discrimination.
+            greaterThan(unacceptedTimeout ~/ 2),
+            reason:
+                'and a participant that has not answered holds the caller to '
+                'its own deadline, exactly as a relay gone quiet does',
+          );
+        },
+      );
+
       // The fan-out can outlive its caller: `relayDoQuery` waits up to
       // `perRelaySendTimeout` on a half-open socket, which is the default
       // query deadline over again. Whatever it records on the way out must


### PR DESCRIPTION
## Description

**This PR was rewritten.** It originally carried its own fix for the zero-relay stall on #7481. [#7594](https://github.com/divinevideo/divine-mobile/pull/7594) merged first with a broader version of the same change — `RelayPool.query` returning `sentTo` rather than an accepted count, plus the `noRelays` folding and a guard on `_queryReachedNoRelay` — so the production half of this branch is now redundant and has been dropped. What remains is one test covering a property #7594 shipped and left unguarded end to end.

`relayDoQuery` returns `true` on the auth-gated branch **even when the send fails**:

```dart
if ((sendAfterAuth || relay.relayStatus.alwaysAuth) && !relay.relayStatus.authed) {
  relay.saveQuery(subscription);
  final result = await relay.send(message, forceSend: true).timeout(...);
  if (!result) { log('… query remains saved for replay after reconnect/auth …'); }
  return true;
}
```

The query was saved before the send, so the `REQ` is replayed after NIP-42 and that relay is still going to answer. Counting it out of `sentTo` would waive the full-settlement hold and hand an empty box back as authoritative — the truncation `requireAllRelaysSettled` exists to prevent — and report `noRelays` for a relay that is merely mid-handshake.

## Why the existing coverage isn't enough

`relay_pool_auth_test.dart` already asserts `relayDoQuery` returns `true` here. Nothing pinned the chain **below** that return: the bool-to-url mapping in `sendQueryTo`, the `sentTo` collection, `noRelaysParticipated`, and the settle hold.

Both were checked by mutation:

| Mutation | `relay_pool_auth_test` | New test |
|---|---|---|
| `return true` → `return result` in the auth-gated branch | fails | fails |
| `sendQueryTo` drops auth-gated relays from `sentTo` | **passes** | fails |

The second mutation leaves the existing package suite green. The new test asserts through the public `queryEventsDetailed` API, so it fails on any break in that chain rather than on one function's return value.

## Verification

- `flutter analyze lib test` in `packages/nostr_sdk` — clean
- `flutter test` in `packages/nostr_sdk` — clean
- Both mutations above applied and reverted; source confirmed byte-identical to `origin/main` afterwards

The timing assertion uses a half-deadline lower bound (`greaterThan(unacceptedTimeout ~/ 2)`) rather than the full 400 ms. The timeout fires off a `Timer` while the test measures a `Stopwatch`, and CI saw a 399.958 ms reading against the original 400 ms floor. Waived participation returns in single-digit milliseconds, so the looser bound still distinguishes the regression without making the test sensitive to microsecond drift.

**Related Issue:** Refs #7481 (closed by #7594)

## Out of Scope

The original branch also carried two empty-relay-pool tests. `RelayPool.query` has no early return for an empty pool — `Future.wait([])` resolves immediately onto the same `sentTo.isEmpty` branch as a relay that refuses the send — so they restated `main`'s existing `'completes a query no relay took at once, still inconclusive'` and were dropped rather than banked as coverage.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore (test coverage only — no production code changes)

