### PR TITLE
fix(nostr): distinguish zero-relay participation from an empty query result

### DIFF
--- a/mobile/packages/nostr_client/lib/src/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/src/nostr_client.dart
@@ -842,10 +842,15 @@ class NostrClient {
   /// partial answer — and an incomplete answer arrives as `timedOut: true`
   /// instead. That covers the answers nobody gave as well as the partial ones:
   /// a fan-out no relay accepted, and a query skipped because the client is
-  /// being disposed, both report `timedOut: true` rather than an empty answer
-  /// (a client with no reachable relay at all reports `noRelays` instead).
+  /// being disposed, both report `timedOut: true` rather than an empty answer.
   /// Note this only bounds the WebSocket leg; cached rows are merged in either
   /// way.
+  ///
+  /// `noRelays` says nothing was asked, whatever the flag. It covers a client
+  /// with no connected relay and no temp relay, a disposed client, and a
+  /// fan-out no relay took — the last of which a connected-relay snapshot
+  /// cannot see, since a write-only relay and one whose socket died since its
+  /// last status update both still count as connected.
   Future<({List<Event> events, bool timedOut, bool noRelays})>
   queryEventsDetailed(
     List<Filter> filters, {
@@ -899,7 +904,10 @@ class NostrClient {
         (effectiveTempRelays == null || effectiveTempRelays.isEmpty)) {
       await retryDisconnectedRelays();
     }
-    final noRelays =
+    // A pre-flight snapshot, so it can only catch the relayless case it can
+    // see from here; the fan-out's own account of who took the REQ is folded
+    // in below.
+    final noConnectedRelays =
         _relayManager.connectedRelays.isEmpty &&
         (effectiveTempRelays == null || effectiveTempRelays.isEmpty);
     final filtersJson = filters.map((f) => f.toJson()).toList();
@@ -970,7 +978,7 @@ class NostrClient {
     return (
       events: _mergeEvents(cacheResults, websocketEvents, limit: limit),
       timedOut: websocketResult.timedOut,
-      noRelays: noRelays,
+      noRelays: noConnectedRelays || websocketResult.noRelaysParticipated,
     );
   }
 

--- a/mobile/packages/nostr_client/lib/src/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/src/nostr_client.dart
@@ -903,16 +903,16 @@ class NostrClient {
         _relayManager.connectedRelays.isEmpty &&
         (effectiveTempRelays == null || effectiveTempRelays.isEmpty);
     final filtersJson = filters.map((f) => f.toJson()).toList();
-    Future<({List<Event> events, bool timedOut})> runWebSocketQuery() =>
-        _nostr.queryEventsDetailed(
-          filtersJson,
-          id: subscriptionId,
-          tempRelays: effectiveTempRelays,
-          relayTypes: relayTypes,
-          sendAfterAuth: sendAfterAuth,
-          timeout: timeout,
-          requireAllRelaysSettled: requireAllRelaysSettled,
-        );
+    Future<({List<Event> events, bool timedOut, bool noRelaysParticipated})>
+    runWebSocketQuery() => _nostr.queryEventsDetailed(
+      filtersJson,
+      id: subscriptionId,
+      tempRelays: effectiveTempRelays,
+      relayTypes: relayTypes,
+      sendAfterAuth: sendAfterAuth,
+      timeout: timeout,
+      requireAllRelaysSettled: requireAllRelaysSettled,
+    );
     // Throttle concurrent one-shot REQs so high fan-out (a profile with many
     // videos → per-item like-count/badge/profile/repost fetches) can't trip a
     // relay's "too many concurrent REQs" limit. `withResource` releases the
@@ -928,15 +928,19 @@ class NostrClient {
     // the NIP-50 search relays and leak temp relays nothing would clean up.
     // This check-then-call has no await before the query, so it closes the
     // race rather than narrowing it. See #5952.
-    final ({List<Event> events, bool timedOut}) websocketResult;
+    final ({List<Event> events, bool timedOut, bool noRelaysParticipated})
+    websocketResult;
     if (_queryPool.isClosed) {
       // Nothing was asked of the relays here, which is a different thing from
       // their having nothing. A display read is content to fall back on cache;
       // a full-settlement caller is about to replace what it read, so it gets
       // the same inconclusive answer a relay that never settled would give.
+      // The relays themselves are still reachable, so this is not a
+      // participation failure — `timedOut` is what carries it.
       websocketResult = (
         events: <Event>[],
         timedOut: requireAllRelaysSettled,
+        noRelaysParticipated: false,
       );
     } else {
       websocketResult = useQueryPool

--- a/mobile/packages/nostr_client/lib/src/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/src/nostr_client.dart
@@ -847,10 +847,17 @@ class NostrClient {
   /// way.
   ///
   /// `noRelays` says nothing was asked, whatever the flag. It covers a client
-  /// with no connected relay and no temp relay, a disposed client, and a
-  /// fan-out no relay took — the last of which a connected-relay snapshot
-  /// cannot see, since a write-only relay and one whose socket died since its
-  /// last status update both still count as connected.
+  /// with no connected relay and no temp relay, a client already disposed when
+  /// the call arrived, and a fan-out no relay took — the last of which a
+  /// connected-relay snapshot cannot see, since a write-only relay and one
+  /// whose socket died since its last status update both still count as
+  /// connected. A relay that answers only out of the local event cache counts
+  /// as participation, so this is "nothing took the REQ", not "no network
+  /// relay took it".
+  ///
+  /// A client disposed *mid-call* is deliberately not in that list: the relays
+  /// were reachable and only this one query was dropped, so it arrives as
+  /// `timedOut` for a full-settlement caller instead.
   Future<({List<Event> events, bool timedOut, bool noRelays})>
   queryEventsDetailed(
     List<Filter> filters, {

--- a/mobile/packages/nostr_client/test/src/nostr_client_test.dart
+++ b/mobile/packages/nostr_client/test/src/nostr_client_test.dart
@@ -1576,6 +1576,14 @@ void main() {
         // a partial answer means.
         expect(result.events, equals(events));
         expect(result.timedOut, isTrue);
+        expect(
+          result.noRelays,
+          isFalse,
+          reason:
+              'the relays were reachable and slow. bookmark_service tests '
+              'noRelays first, so conflating the two tells the user their '
+              'relays are unreachable when they are not',
+        );
       });
 
       test('reports noRelays when nothing reconnected', () async {

--- a/mobile/packages/nostr_client/test/src/nostr_client_test.dart
+++ b/mobile/packages/nostr_client/test/src/nostr_client_test.dart
@@ -14,6 +14,11 @@ class _MockNostr extends Mock implements Nostr {
   /// Drives the `timedOut` field of the record synthesized below.
   bool timedOut = false;
 
+  /// Drives the `noRelaysParticipated` field of that same record — the SDK
+  /// reporting that no relay took the REQ, which a connected-relay snapshot
+  /// cannot see.
+  bool noRelaysParticipated = false;
+
   /// What the client last asked for full relay settlement, so a test can pin
   /// that the flag is threaded down rather than dropped on the floor.
   bool? lastRequireAllRelaysSettled;
@@ -24,7 +29,8 @@ class _MockNostr extends Mock implements Nostr {
   /// list-returning method that tests stub. Tests that care about the timeout
   /// signal set [timedOut] instead of stubbing a second method.
   @override
-  Future<({List<Event> events, bool timedOut})> queryEventsDetailed(
+  Future<({List<Event> events, bool timedOut, bool noRelaysParticipated})>
+  queryEventsDetailed(
     List<Map<String, dynamic>> filters, {
     String? id,
     List<String>? tempRelays,
@@ -42,7 +48,11 @@ class _MockNostr extends Mock implements Nostr {
       sendAfterAuth: sendAfterAuth,
       timeout: timeout,
     );
-    return (events: events, timedOut: timedOut);
+    return (
+      events: events,
+      timedOut: timedOut,
+      noRelaysParticipated: noRelaysParticipated,
+    );
   }
 }
 

--- a/mobile/packages/nostr_client/test/src/nostr_client_test.dart
+++ b/mobile/packages/nostr_client/test/src/nostr_client_test.dart
@@ -1589,6 +1589,34 @@ void main() {
         expect(result.noRelays, isTrue);
       });
 
+      test(
+        'reports noRelays when no relay took the REQ despite being connected',
+        () async {
+          // The pre-flight snapshot cannot see this: a write-only relay, or
+          // one whose socket died since its last status update, is still
+          // reported as connected. Only the fan-out knows nothing was asked.
+          stubWebSocketEvents([]);
+          mockNostr.noRelaysParticipated = true;
+
+          final result = await client.queryEventsDetailed([textNoteFilter()]);
+
+          expect(
+            mockRelayManager.connectedRelays,
+            isNotEmpty,
+            reason: 'otherwise the pre-flight check would have flagged it',
+          );
+          expect(result.events, isEmpty);
+          expect(
+            result.noRelays,
+            isTrue,
+            reason:
+                'reported as a timeout, this reads as "the relays were '
+                'reachable and slow" — the caller retries instead of telling '
+                'the user their relays are unreachable',
+          );
+        },
+      );
+
       test('reports noRelays on a disposed client', () async {
         await client.dispose();
 

--- a/mobile/packages/nostr_sdk/API_REFERENCE.md
+++ b/mobile/packages/nostr_sdk/API_REFERENCE.md
@@ -159,7 +159,7 @@ Create a one-time query subscription.
 - `sendAfterAuth`: Send query after relay authentication
 - `requireAllRelaysSettled`: Report an incomplete answer as incomplete rather than as a result — for callers about to replace what they read
 
-**Returns:** the subscription id, plus `sentTo` — the relays that took the REQ. The future resolves when the fan-out is done, ahead of `onComplete`. An empty `sentTo` means no relay was asked, which an empty result set on its own cannot distinguish from every relay holding nothing.
+**Returns:** the subscription id, plus `sentTo` — the relays that took the REQ, cache relays included. An empty `sentTo` means nothing was asked, which an empty result set on its own cannot distinguish from every relay holding nothing. The future resolves when the fan-out is done; `onComplete` may already have fired, since a fan-out that settles the query calls it inline.
 
 ##### queryEvents()
 ```dart

--- a/mobile/packages/nostr_sdk/API_REFERENCE.md
+++ b/mobile/packages/nostr_sdk/API_REFERENCE.md
@@ -140,10 +140,10 @@ Create a persistent subscription.
 
 ##### query()
 ```dart
-String query(
+Future<({String id, List<String> sentTo})> query(
   List<Map<String, dynamic>> filters,
   Function(Event) onEvent,
-  {String? id, Function? onComplete, List<String>? tempRelays, List<String>? targetRelays, List<int> relayTypes = RelayType.ALL, bool sendAfterAuth = false}
+  {String? id, Function? onComplete, List<String>? tempRelays, List<String>? targetRelays, List<int> relayTypes = RelayType.all, bool sendAfterAuth = false, bool requireAllRelaysSettled = false}
 )
 ```
 Create a one-time query subscription.
@@ -157,6 +157,9 @@ Create a one-time query subscription.
 - `targetRelays`: Optional target relays
 - `relayTypes`: Types of relays to use
 - `sendAfterAuth`: Send query after relay authentication
+- `requireAllRelaysSettled`: Report an incomplete answer as incomplete rather than as a result — for callers about to replace what they read
+
+**Returns:** the subscription id, plus `sentTo` — the relays that took the REQ. The future resolves when the fan-out is done, ahead of `onComplete`. An empty `sentTo` means no relay was asked, which an empty result set on its own cannot distinguish from every relay holding nothing.
 
 ##### queryEvents()
 ```dart

--- a/mobile/packages/nostr_sdk/lib/nostr.dart
+++ b/mobile/packages/nostr_sdk/lib/nostr.dart
@@ -321,8 +321,14 @@ class Nostr {
   }
 
   /// Set [requireAllRelaysSettled] when an incomplete answer must be reported
-  /// as [timedOut] rather than as a result — see [RelayPool.query].
-  Future<({List<Event> events, bool timedOut})> queryEventsDetailed(
+  /// as `timedOut` rather than as a result — see [RelayPool.query].
+  ///
+  /// `noRelaysParticipated` reports that no relay took the REQ at all, which
+  /// an empty `events` on its own cannot distinguish from every relay holding
+  /// nothing. It stays `false` when the fan-out itself ran out of time, since
+  /// that leaves participation genuinely unknown.
+  Future<({List<Event> events, bool timedOut, bool noRelaysParticipated})>
+  queryEventsDetailed(
     List<Map<String, dynamic>> filters, {
     String? id,
     List<String>? tempRelays,
@@ -336,6 +342,7 @@ class Nostr {
     final subscriptionId = id ?? StringUtil.rndNameStr(16);
     final deadline = DateTime.now().add(timeout);
     var timedOut = false;
+    var noRelaysParticipated = false;
 
     Duration remainingTimeout() {
       final remaining = deadline.difference(DateTime.now());
@@ -346,7 +353,7 @@ class Nostr {
     }
 
     try {
-      await query(
+      final fanout = await query(
         filters,
         id: subscriptionId,
         tempRelays: tempRelays,
@@ -362,13 +369,22 @@ class Nostr {
           }
         },
       ).timeout(remainingTimeout());
+      noRelaysParticipated = fanout.sentTo.isEmpty;
       await completer.future.timeout(remainingTimeout());
     } on TimeoutException {
       timedOut = true;
       unsubscribe(subscriptionId);
     }
 
-    return (events: eventBox.all(), timedOut: timedOut);
+    return (
+      events: eventBox.all(),
+      // A full-settlement caller is about to replace what it read, so a
+      // fan-out no relay took stays as inconclusive as a relay that never
+      // answered. A default read is content with what the reachable relays
+      // hold and keeps its prompt empty answer.
+      timedOut: timedOut || (requireAllRelaysSettled && noRelaysParticipated),
+      noRelaysParticipated: noRelaysParticipated,
+    );
   }
 
   Future<List<Event>> queryEvents(
@@ -412,7 +428,8 @@ class Nostr {
     );
   }
 
-  Future<String> query(
+  /// See [RelayPool.query] for what `sentTo` means and when it is empty.
+  Future<({String id, List<String> sentTo})> query(
     List<Map<String, dynamic>> filters,
     Function(Event) onEvent, {
     String? id,

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -211,6 +211,16 @@ class RelayPool {
   /// replaceable event must treat that as inconclusive, the same as silence.
   final Set<String> _queryClosedWithoutAnswer = {};
 
+  /// One-shot queries no relay took at all, so nothing can ever answer them.
+  ///
+  /// Nothing was saved on any relay, which means no terminal frame, no
+  /// post-AUTH replay, and no reconnect re-issue. Waiting is therefore
+  /// pointless — the caller's answer cannot change between here and its
+  /// deadline. The reason [requireAllRelaysSettled] used to wait anyway was
+  /// that completing looked identical to "every relay says there is nothing";
+  /// `sentTo` from [query] is what tells those apart now.
+  final Set<String> _queryReachedNoRelay = {};
+
   /// Track publishes awaiting OK confirmations (per event id).
   final Map<String, PublishTracker> _pendingPublishes = {};
 
@@ -871,13 +881,17 @@ class RelayPool {
 
     // Nothing is pending — but for a full-settlement caller that only means
     // the query is finished if some relay actually answered it, and no relay
-    // refused to answer. When every `relayDoQuery` send failed, no relay ever
-    // saved the query, so this sweep finds nothing outstanding and would hand
-    // back an empty box no relay contributed to. Likewise, a relay `CLOSED` the
-    // REQ has made no data claim. A caller about to replace what it read cannot
-    // tell either apart from "every relay says there is nothing", so let it run
-    // out to its own timeout instead.
+    // refused to answer. A relay that `CLOSED` the REQ has made no data claim,
+    // and a relay that stayed silent may still be about to speak, so a caller
+    // about to replace what it read waits both out rather than read an empty
+    // box as "every relay says there is nothing".
+    //
+    // A fan-out no relay took is the one shape that cannot improve by waiting
+    // — see [_queryReachedNoRelay] — and `sentTo` already tells the caller the
+    // answer is not authoritative, so it completes now instead of costing the
+    // caller its whole deadline.
     if (_queriesRequiringFullSettlement.contains(subId) &&
+        !_queryReachedNoRelay.contains(subId) &&
         (!_queryAnswered.contains(subId) ||
             _queryClosedWithoutAnswer.contains(subId))) {
       return;
@@ -953,6 +967,7 @@ class RelayPool {
     _queryCompleteCallbacks.remove(subId);
     _queryAnswered.remove(subId);
     _queryClosedWithoutAnswer.remove(subId);
+    _queryReachedNoRelay.remove(subId);
     _queriesRequiringFullSettlement.remove(subId);
     _querySettleTimers.remove(subId)?.cancel();
     _releaseQuery(subId);
@@ -1844,6 +1859,7 @@ class RelayPool {
       _queryFanoutInProgress.remove(id);
       _queryAnswered.remove(id);
       _queryClosedWithoutAnswer.remove(id);
+      _queryReachedNoRelay.remove(id);
       _queriesRequiringFullSettlement.remove(id);
       _querySettleTimers.remove(id)?.cancel();
       _releaseQuery(id);
@@ -2000,6 +2016,7 @@ class RelayPool {
     final sentTo = fanout.nonNulls.toList();
 
     if (onComplete != null) {
+      if (sentTo.isEmpty) _queryReachedNoRelay.add(subscription.id);
       _fireQueryCompleteIfSettled(subscription.id);
     }
 

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -213,12 +213,21 @@ class RelayPool {
 
   /// One-shot queries no relay took at all, so nothing can ever answer them.
   ///
-  /// Nothing was saved on any relay, which means no terminal frame, no
-  /// post-AUTH replay, and no reconnect re-issue. Waiting is therefore
-  /// pointless — the caller's answer cannot change between here and its
-  /// deadline. The reason [requireAllRelaysSettled] used to wait anyway was
-  /// that completing looked identical to "every relay says there is nothing";
+  /// No relay ran `saveQuery`, so there is no terminal frame still owed and no
+  /// post-AUTH replay. A failed send does leave the raw `REQ` in the relay's
+  /// `pendingMessages` for the next `onConnected` to replay — `_isReqNaming`
+  /// only skips REQs naming a *saved* subscription — but a query that was
+  /// never saved has no [Subscription] to admit the results, so anything it
+  /// draws back drops at the subscription lookup. Waiting is therefore
+  /// pointless: the caller's answer cannot change between here and its
+  /// deadline. [requireAllRelaysSettled] used to wait anyway because
+  /// completing looked identical to "every relay says there is nothing";
   /// `sentTo` from [query] is what tells those apart now.
+  ///
+  /// Recorded only while the query still has a live completion callback, so a
+  /// fan-out that resolves after its caller gave up cannot strand an entry
+  /// here — which would both grow unbounded and, if the id were ever reused,
+  /// let a later full-settlement query skip its hold.
   final Set<String> _queryReachedNoRelay = {};
 
   /// Track publishes awaiting OK confirmations (per event id).
@@ -852,15 +861,23 @@ class RelayPool {
   /// what arms [querySettleWindow] for whichever relays are still silent.
   /// Set [afterClosedWithoutAnswer] for `CLOSED` frames that cannot prove
   /// absence for callers that require full settlement.
+  /// Set [afterFanoutReachedNoRelay] when the REQ fan-out ended with no relay
+  /// having taken the query.
+  ///
+  /// Every set this records into is written *after* the `callback == null`
+  /// return, so a query the caller already abandoned cannot re-enter the
+  /// bookkeeping that [_completeQuery] and [unsubscribe] have swept.
   void _fireQueryCompleteIfSettled(
     String subId, {
     bool afterTerminalFrame = false,
     bool afterClosedWithoutAnswer = false,
+    bool afterFanoutReachedNoRelay = false,
   }) {
     final callback = _queryCompleteCallbacks[subId];
     if (callback == null) return;
     if (afterTerminalFrame) _queryAnswered.add(subId);
     if (afterClosedWithoutAnswer) _queryClosedWithoutAnswer.add(subId);
+    if (afterFanoutReachedNoRelay) _queryReachedNoRelay.add(subId);
     if (_queryFanoutInProgress.contains(subId)) return;
 
     final list = [
@@ -1919,8 +1936,11 @@ class RelayPool {
   /// parked for post-NIP-42 replay. Only those relays can ever answer, so an
   /// empty `sentTo` means nothing was asked — which is not the same as every
   /// relay having nothing, and is the distinction a caller about to replace a
-  /// replaceable event has to make. The future resolves once the fan-out is
-  /// done, ahead of `onComplete`.
+  /// replaceable event has to make. Cache relays count toward it, so it
+  /// answers "did anything take this REQ", not "did a network relay take it".
+  ///
+  /// The future resolves once the fan-out is done. `onComplete` may already
+  /// have fired by then — a fan-out that settles the query calls it inline.
   Future<({String id, List<String> sentTo})> query(
     List<Map<String, dynamic>> filters,
     Function(Event) onEvent, {
@@ -2016,8 +2036,10 @@ class RelayPool {
     final sentTo = fanout.nonNulls.toList();
 
     if (onComplete != null) {
-      if (sentTo.isEmpty) _queryReachedNoRelay.add(subscription.id);
-      _fireQueryCompleteIfSettled(subscription.id);
+      _fireQueryCompleteIfSettled(
+        subscription.id,
+        afterFanoutReachedNoRelay: sentTo.isEmpty,
+      );
     }
 
     return (id: subscription.id, sentTo: sentTo);

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -1896,9 +1896,16 @@ class RelayPool {
   /// caller than no answer — see [_queriesRequiringFullSettlement]. The query
   /// then completes only once every relay that can still answer has, so a relay
   /// that stays connected and never sends a terminal frame runs the caller out
-  /// to its own timeout instead of being skipped past — as does a fan-out no
-  /// relay accepted at all.
-  Future<String> query(
+  /// to its own timeout instead of being skipped past.
+  ///
+  /// The returned `sentTo` names the relays that took the REQ: the frame
+  /// reached the socket, or the relay is behind an auth gate and the query is
+  /// parked for post-NIP-42 replay. Only those relays can ever answer, so an
+  /// empty `sentTo` means nothing was asked — which is not the same as every
+  /// relay having nothing, and is the distinction a caller about to replace a
+  /// replaceable event has to make. The future resolves once the fan-out is
+  /// done, ahead of `onComplete`.
+  Future<({String id, List<String> sentTo})> query(
     List<Map<String, dynamic>> filters,
     Function(Event) onEvent, {
     String? id,
@@ -1929,8 +1936,20 @@ class RelayPool {
 
     // Collect futures so we can await them before the early-completion
     // check. Each relayDoQuery call only resolves after relay.send()
-    // and saveQuery(), which is fast with skipReconnect: true.
-    final queryFutures = <Future<bool>>[];
+    // and saveQuery(), which is fast with skipReconnect: true. Each resolves
+    // to the relay's url when it took the REQ, so the fan-out can report who
+    // is actually able to answer.
+    final queryFutures = <Future<String?>>[];
+
+    Future<String?> sendQueryTo(
+      Relay relay, {
+      bool runBeforeConnected = false,
+    }) => relayDoQuery(
+      relay,
+      subscription,
+      sendAfterAuth,
+      runBeforeConnected: runBeforeConnected,
+    ).then((accepted) => accepted ? relay.url : null);
 
     // tempRelay, only query those relay which has bean provide
     if (tempRelays != null &&
@@ -1941,14 +1960,7 @@ class RelayPool {
         Relay? relay = _relays[tempRelayAddr];
         relay ??= checkAndGenTempRelay(tempRelayAddr);
 
-        queryFutures.add(
-          relayDoQuery(
-            relay,
-            subscription,
-            sendAfterAuth,
-            runBeforeConnected: true,
-          ),
-        );
+        queryFutures.add(sendQueryTo(relay, runBeforeConnected: true));
       }
     }
 
@@ -1964,32 +1976,34 @@ class RelayPool {
           }
         }
 
-        queryFutures.add(relayDoQuery(relay, subscription, sendAfterAuth));
+        queryFutures.add(sendQueryTo(relay));
       }
     }
 
     // cache relay
     if (relayTypes.contains(RelayType.cache)) {
       for (final relay in _cacheRelaysSnapshot()) {
-        queryFutures.add(relayDoQuery(relay, subscription, sendAfterAuth));
+        queryFutures.add(sendQueryTo(relay));
       }
     }
 
+    final List<String?> fanout;
     try {
       // Wait for all sends to complete (and saveQuery to run) before allowing
       // terminal frames to decide whether every relay has settled.
-      await Future.wait(queryFutures);
+      fanout = await Future.wait(queryFutures);
     } finally {
       if (onComplete != null) {
         _queryFanoutInProgress.remove(subscription.id);
       }
     }
+    final sentTo = fanout.nonNulls.toList();
 
     if (onComplete != null) {
       _fireQueryCompleteIfSettled(subscription.id);
     }
 
-    return subscription.id;
+    return (id: subscription.id, sentTo: sentTo);
   }
 
   /// send message to relay

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_query_settle_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_query_settle_test.dart
@@ -654,6 +654,71 @@ void main() {
       expect(result.timedOut, isFalse);
     });
 
+    // A relay-participation count is the only thing that separates "every
+    // relay says there is nothing" from "nobody was asked". A connected-relay
+    // snapshot cannot: a relay counts as connected while being write-only, or
+    // while its socket is dead but not yet observed.
+    group('noRelaysParticipated', () {
+      test('reports a fan-out no relay took', () async {
+        final nostr = _newNostr();
+        final unreachable = _SilentRelay('wss://send-fails.example')
+          ..sendSucceeds = false;
+        expect(await nostr.relayPool.add(unreachable), isTrue);
+
+        final result = await nostr.queryEventsDetailed([
+          {
+            'kinds': [1],
+          },
+        ], timeout: _timeout);
+
+        expect(result.noRelaysParticipated, isTrue);
+      });
+
+      test(
+        'reports a connected write-only relay as no participation',
+        () async {
+          final nostr = _newNostr();
+          final writeOnly = _SilentRelay('wss://write-only.example');
+          expect(await nostr.relayPool.add(writeOnly), isTrue);
+          writeOnly.relayStatus.readAccess = false;
+
+          final result = await nostr.queryEventsDetailed([
+            {
+              'kinds': [1],
+            },
+          ], timeout: _timeout);
+
+          expect(
+            writeOnly.relayStatus.connected,
+            equals(ClientConnected.connected),
+            reason:
+                'the point of this case is that the relay looks healthy to '
+                'everything except the REQ',
+          );
+          expect(result.noRelaysParticipated, isTrue);
+        },
+      );
+
+      test('reports participation once a relay answers', () async {
+        final nostr = _newNostr();
+        final answering = _SilentRelay('wss://answers.example');
+        expect(await nostr.relayPool.add(answering), isTrue);
+
+        final pending = nostr.queryEventsDetailed([
+          {
+            'kinds': [1],
+          },
+        ], timeout: _timeout);
+
+        final subId = await answering.awaitPendingQuery();
+        await answering.deliver(['EOSE', subId]);
+
+        final result = await pending;
+
+        expect(result.noRelaysParticipated, isFalse);
+      });
+    });
+
     group('requireAllRelaysSettled', () {
       // Long enough that the settle window would have completed the query
       // well before it, so a timeout here can only mean the window was

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_query_settle_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_query_settle_test.dart
@@ -717,6 +717,37 @@ void main() {
 
         expect(result.noRelaysParticipated, isFalse);
       });
+
+      test(
+        'reports participation when only some relays took the REQ',
+        () async {
+          final nostr = _newNostr();
+          final answering = _SilentRelay('wss://answers.example');
+          final unreachable = _SilentRelay('wss://send-fails.example')
+            ..sendSucceeds = false;
+          expect(await nostr.relayPool.add(answering), isTrue);
+          expect(await nostr.relayPool.add(unreachable), isTrue);
+
+          final pending = nostr.queryEventsDetailed([
+            {
+              'kinds': [1],
+            },
+          ], timeout: _timeout);
+
+          final subId = await answering.awaitPendingQuery();
+          await answering.deliver(['EOSE', subId]);
+
+          final result = await pending;
+
+          expect(
+            result.noRelaysParticipated,
+            isFalse,
+            reason:
+                'one relay answered, so the box is what that relay holds — not '
+                'an answer nobody gave',
+          );
+        },
+      );
     });
 
     group('requireAllRelaysSettled', () {
@@ -761,6 +792,14 @@ void main() {
                 'complete answer, which a caller about to republish a '
                 'replaceable event would act on and truncate the list',
           );
+          expect(
+            result.noRelaysParticipated,
+            isFalse,
+            reason:
+                'both relays took the REQ — one is just slow. Conflating this '
+                'with "nobody was asked" tells the user their relays are '
+                'unreachable when they are reachable and mid-answer',
+          );
         },
       );
 
@@ -800,11 +839,14 @@ void main() {
           );
           expect(
             stopwatch.elapsed,
-            lessThan(_timeout),
+            // Well under the deadline rather than merely inside it: holding
+            // the query runs it to ~4.002s, which `lessThan(_timeout)` would
+            // reject by a margin thin enough to depend on the machine.
+            lessThan(_timeout ~/ 2),
             reason:
-                'no relay saved the REQ, so no terminal frame, post-AUTH '
-                'replay or reconnect can change the answer — waiting out the '
-                'deadline only delays the error the caller is going to show',
+                'no relay saved the REQ, so nothing it could still draw back '
+                'has a subscription to land in — waiting out the deadline '
+                'only delays the error the caller is going to show',
           );
         },
       );
@@ -846,6 +888,84 @@ void main() {
             reason:
                 'a relay refusal is not a data-bearing answer, so a '
                 'replaceable-event caller must treat it as inconclusive',
+          );
+          expect(
+            result.noRelaysParticipated,
+            isFalse,
+            reason: 'the relay took the REQ before refusing it',
+          );
+        },
+      );
+
+      // The fan-out can outlive its caller: `relayDoQuery` waits up to
+      // `perRelaySendTimeout` on a half-open socket, which is the default
+      // query deadline over again. Whatever it records on the way out must
+      // not land on an id the caller has already abandoned.
+      test(
+        'a fan-out that resolves after its caller gave up records nothing',
+        () async {
+          const reusedId = 'reused-one-shot-subscription-id';
+          final nostr = _newNostr();
+          final relay = _SilentRelay('wss://send-fails.example')
+            ..sendSucceeds = false
+            ..reqGate = Completer<void>();
+          expect(await nostr.relayPool.add(relay), isTrue);
+
+          final abandoned = nostr.relayPool.query(
+            [
+              {
+                'kinds': [10003],
+              },
+            ],
+            (_) {},
+            id: reusedId,
+            onComplete: () {},
+            requireAllRelaysSettled: true,
+          );
+
+          // Park inside the REQ write, then give the query up the way
+          // Nostr.queryEventsDetailed does when its deadline beats the
+          // fan-out.
+          for (var i = 0; i < 1000 && relay.capturedSubId == null; i++) {
+            await Future<void>.delayed(Duration.zero);
+          }
+          expect(relay.capturedSubId, equals(reusedId));
+          nostr.unsubscribe(reusedId);
+          relay.releaseReq();
+          expect((await abandoned).sentTo, isEmpty);
+
+          // A later query on that id must still get the full-settlement hold.
+          // A stale "no relay took it" would skip it and hand the empty box
+          // back as authoritative.
+          relay
+            ..sendSucceeds = true
+            ..reqGate = null;
+          final pending = nostr.queryEventsDetailed(
+            [
+              {
+                'kinds': [10003],
+              },
+            ],
+            id: reusedId,
+            timeout: unacceptedTimeout,
+            requireAllRelaysSettled: true,
+          );
+
+          final subId = await relay.awaitPendingQuery();
+          await relay.deliver([
+            'CLOSED',
+            subId,
+            'error: too many concurrent REQs',
+          ]);
+
+          final result = await pending;
+
+          expect(
+            result.timedOut,
+            isTrue,
+            reason:
+                'the refusal is still inconclusive; the abandoned fan-out '
+                'must not have left anything behind that waives the hold',
           );
         },
       );

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_query_settle_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_query_settle_test.dart
@@ -764,42 +764,54 @@ void main() {
         },
       );
 
-      // Short: this query is never going to be answered, so the test pays it
-      // in full. Nothing races it, so it cannot flake short.
-      const unacceptedTimeout = Duration(milliseconds: 400);
-
       test(
-        'reports a query no relay accepted as a timeout, not an empty answer',
+        'completes a query no relay took at once, still inconclusive',
         () async {
           final nostr = _newNostr();
           final unreachable = _SilentRelay('wss://send-fails.example')
             ..sendSucceeds = false;
           expect(await nostr.relayPool.add(unreachable), isTrue);
 
-          final pending = nostr.queryEventsDetailed(
+          final stopwatch = Stopwatch()..start();
+          final result = await nostr.queryEventsDetailed(
             [
               {
                 'kinds': [10003],
               },
             ],
-            timeout: unacceptedTimeout,
+            timeout: _timeout,
             requireAllRelaysSettled: true,
           );
-
-          final result = await pending;
+          stopwatch.stop();
 
           expect(result.events, isEmpty);
           expect(
             result.timedOut,
             isTrue,
             reason:
-                'no relay took the REQ, so nothing was pending for the '
-                'post-fan-out sweep to wait on and it completed the query '
-                'with no relay having answered at all — an empty box that '
-                'reads exactly like "every relay says there is nothing"',
+                'an empty box no relay contributed to reads exactly like '
+                '"every relay says there is nothing", which is what lets a '
+                'caller about to republish truncate a replaceable list',
+          );
+          expect(
+            result.noRelaysParticipated,
+            isTrue,
+            reason: 'and this is what tells it apart from a relay gone quiet',
+          );
+          expect(
+            stopwatch.elapsed,
+            lessThan(_timeout),
+            reason:
+                'no relay saved the REQ, so no terminal frame, post-AUTH '
+                'replay or reconnect can change the answer — waiting out the '
+                'deadline only delays the error the caller is going to show',
           );
         },
       );
+
+      // Short: this query is never going to be answered, so the test pays it
+      // in full. Nothing races it, so it cannot flake short.
+      const unacceptedTimeout = Duration(milliseconds: 400);
 
       test(
         'reports a relay CLOSED refusal as a timeout, not an empty answer',

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_query_zombie_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_query_zombie_test.dart
@@ -38,7 +38,8 @@ void main() {
       await nostr.relayPool.add(relay);
     });
 
-    Future<({List<Event> events, bool timedOut})> queryOnce() {
+    Future<({List<Event> events, bool timedOut, bool noRelaysParticipated})>
+    queryOnce() {
       return nostr.queryEventsDetailed([
         {
           'kinds': [1],


### PR DESCRIPTION
## Description

`RelayPool.query` collected the result of every `relayDoQuery` call and threw it away, so an empty answer could not be told apart from a fan-out no relay took.

`NostrClient.queryEventsDetailed` already exposed `noRelays`, but only as a pre-flight snapshot of `RelayManager.connectedRelays` — a manager-side status list that cannot see a relay which is connected and still never takes the REQ:

- a **write-only relay** — `relayDoQuery` refuses on `!readAccess` without sending;
- a socket that died since its last status update — query sends use `skipReconnect: true`, so they just fail.

Both arrived as `timedOut`, and `bookmark_service` turned that into "relays were reachable and slow" rather than "couldn't reach relays".

Separately, `requireAllRelaysSettled` deliberately held a zero-participation query open until the caller's own deadline, because completing looked identical to "every relay says there is nothing" — the exact confusion the flag exists to prevent. That cost every offline bookmark toggle a full 5 s before the error surfaced.

Three commits, each revertable alone:

1. **`feat(nostr): report which relays took a one-shot REQ`** — `RelayPool.query` returns `({String id, List<String> sentTo})`, and `Nostr.queryEventsDetailed` surfaces that as `noRelaysParticipated`. `sentTo` names the relays that took the REQ: the frame reached the socket, or the relay is behind an auth gate and the query is parked for post-NIP-42 replay. `timedOut` keeps its current meaning for both kinds of caller — a full-settlement read still treats an unasked fan-out as inconclusive, a default read still gets its prompt empty answer.
2. **`fix(nostr): stop stalling a full-settlement query no relay took`** — no relay saved the query, so no terminal frame, post-AUTH replay or reconnect re-issue can change the answer; waiting only delays the error the caller is going to show. It completes at once now, still flagged inconclusive. Relays that `CLOSED` the REQ, and relays that took it and went quiet, still hold the caller exactly as before.
3. **`fix(nostr): flag a query no relay took as noRelays`** — folds the fan-out's own account of participation into `noRelays`.

### Behaviour change worth a second look

`noRelays` gets wider. Its five consumers — `bookmark_service`, `account_deletion_service`, `vault_key_service`, `sync_index_client`, `notify_subscriptions_repository_impl` — all treat `noRelays || timedOut` as "inconclusive, don't act", so nothing changes shape for them; the only difference is which of the two a caller reports, and it is now the accurate one. The case that newly reports inconclusive rather than a silent empty result is a user whose only reachable relay is unreadable (write-only, or a dead socket). That is the fix rather than a regression, but it is the one part of this with blast radius outside the two packages.

**Related Issue:** Closes #7481

## Out of Scope

The issue also names "blocklist_service" as affected. That is `ContentBlocklistRepository`, and it has a **separate, worse bug that does not depend on this fix**: `_refreshLatestOwnMuteList` reads kind 10000 with `queryEvents`, which discards `timedOut` and `noRelays` entirely, and on a failed read `_buildMuteListPublishShape` republishes the list from local state alone — dropping every foreign `t`/`word`/`e` mute tag and wiping the encrypted private mute list to `''`. It is fixable today with the existing API, and making blocking fail closed offline is a UX decision, so it belongs in its own issue and PR rather than here.

A sweep for the same read-before-write shape turned up five more sites with no guard — `badge_repository` (10008), `dm_repository` (10050), `people_lists_repository_impl` (30000, write base is the local cache only), `follow_repository` (kind 3, `initialize()` sets `_isInitialized` even when every relay leg returned `null`), and `curated_list_service` (30005) — plus `notify_subscriptions_repository_impl`, which checks both flags correctly but does not pass `requireAllRelaysSettled`. All are being filed separately.

## Verification

- `flutter analyze lib test integration_test` — clean
- `flutter analyze packages/nostr_sdk packages/nostr_client` — clean
- `flutter test` in `packages/nostr_sdk` — 527 passed
- `flutter test` in `packages/nostr_client` — 340 passed
- `flutter test test/services/bookmark_service_test.dart test/services/account_deletion_service_test.dart` — 85 passed
- `flutter test` in `packages/creator_sync` (141) and `packages/people_lists_repository` (89) — the other `noRelays` consumers, unchanged

New tests: three in `relay_pool_query_settle_test.dart` pinning participation reporting (fan-out nobody took, connected write-only relay, healthy answered query), one rewritten to pin that a full-settlement query no relay took now completes inside its deadline while still reporting inconclusive, and one in `nostr_client_test.dart` pinning `noRelays` for a fan-out nobody took while relays are connected.

No new test in `bookmark_service_test.dart`: it stubs `queryEventsDetailed` with a hand-built record, so the mapping it would assert (`noRelays` → `couldNotReachRelays`) is already pinned there and unchanged by this diff. The behaviour change lives in `nostr_client` and is tested there.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
