### PR TITLE
fix(bookmarks): serialize global bookmark syncs and publishes

### DIFF
--- a/mobile/lib/services/bookmark_service.dart
+++ b/mobile/lib/services/bookmark_service.dart
@@ -170,6 +170,16 @@ class BookmarkService {
 
   static const String globalBookmarksStorageKey = 'global_bookmarks';
 
+  /// Storage key for [_revision].
+  ///
+  /// Persisted next to the snapshot because the writing surface builds a new
+  /// [BookmarkService] per sheet (#7596): an in-memory-only watermark is blank
+  /// again by the next save, which is the ordinary save/close/save loss in
+  /// #7163. Cleared with the snapshot on identity change — see
+  /// `UserDataCleanupService.userSpecificKeys`.
+  static const String globalBookmarksRevisionStorageKey =
+      'global_bookmarks_revision';
+
   /// NIP-51 kind for the uncategorized ("global") bookmark list.
   static const int globalBookmarksKind = 10003;
 
@@ -256,6 +266,11 @@ class BookmarkService {
   ({int createdAt, String id, DateTime acceptedAt})? _localPublishRevision;
 
   /// Tail of the serialized operation queue. See [_serialized].
+  ///
+  /// Depth is not capped. Every leg is individually bounded — a 5 s relay
+  /// query, a 20 s Keycast `sign_event`, a 15 s publish — so a caller cannot
+  /// wait on a hung operation, but it does wait for each one queued ahead of
+  /// it. Bounded is not the same as short.
   Future<void> _queue = Future<void>.value();
 
   /// Runs [operation] only after every operation queued before it.
@@ -1141,6 +1156,25 @@ class BookmarkService {
         );
       }
     }
+
+    final revisionJson = _prefs.getString(globalBookmarksRevisionStorageKey);
+    if (revisionJson != null) {
+      try {
+        final revision = jsonDecode(revisionJson) as Map<String, dynamic>;
+        _revision = (
+          createdAt: revision['createdAt'] as int,
+          id: revision['id'] as String,
+        );
+      } catch (e) {
+        // A corrupt watermark only costs the staleness guard, so drop it and
+        // let the next read establish one rather than failing the load.
+        Log.error(
+          'Failed to load the global bookmark revision: $e',
+          name: 'BookmarkService',
+          category: LogCategory.system,
+        );
+      }
+    }
   }
 
   /// Save bookmarks to SharedPreferences cache
@@ -1154,6 +1188,18 @@ class BookmarkService {
         globalBookmarksStorageKey,
         jsonEncode(globalBookmarksJson),
       );
+
+      final revision = _revision;
+      if (revision == null) {
+        // A confirmed-empty answer established there is no list; leaving the
+        // old watermark behind would refuse the next one this device adopts.
+        await _prefs.remove(globalBookmarksRevisionStorageKey);
+      } else {
+        await _prefs.setString(
+          globalBookmarksRevisionStorageKey,
+          jsonEncode({'createdAt': revision.createdAt, 'id': revision.id}),
+        );
+      }
     } catch (e) {
       Log.error(
         'Failed to save bookmarks to SharedPreferences: $e',

--- a/mobile/lib/services/bookmark_service.dart
+++ b/mobile/lib/services/bookmark_service.dart
@@ -234,6 +234,14 @@ class BookmarkService {
   /// and pays nothing for it.
   static const absenceConfirmationTtl = Duration(minutes: 5);
 
+  /// How long a confirmed-empty answer is allowed to lag behind a local publish.
+  ///
+  /// Relay `OK` means the event was accepted, not that every later query can
+  /// read it back. During that indexing window, an empty answer is not evidence
+  /// that the user deleted the list elsewhere; after the window expires, a
+  /// confirmed absence is allowed to clear the list normally.
+  static const localPublishAbsenceGracePeriod = Duration(seconds: 30);
+
   /// When a full-settlement read last established that this user has no
   /// kind-10003 at all.
   DateTime? _absenceConfirmedAt;
@@ -242,6 +250,10 @@ class BookmarkService {
   /// adopted, or the one it last published. `null` once a confirmed-empty
   /// answer established that no list exists.
   ({int createdAt, String id})? _revision;
+
+  /// The locally published revision that is still inside the relay read-after-
+  /// write grace period.
+  ({int createdAt, String id, DateTime acceptedAt})? _localPublishRevision;
 
   /// Tail of the serialized operation queue. See [_serialized].
   Future<void> _queue = Future<void>.value();
@@ -287,6 +299,16 @@ class BookmarkService {
       return event.createdAt < revision.createdAt;
     }
     return event.id.compareTo(revision.id) > 0;
+  }
+
+  bool get _hasRecentLocalPublish {
+    final revision = _revision;
+    final local = _localPublishRevision;
+    if (revision == null || local == null) return false;
+    if (revision.createdAt != local.createdAt || revision.id != local.id) {
+      return false;
+    }
+    return _now().difference(local.acceptedAt) < localPublishAbsenceGracePeriod;
   }
 
   /// Whether an empty answer from a partial set of relays still has to be
@@ -423,6 +445,16 @@ class BookmarkService {
       }
 
       if (events.isEmpty) {
+        if (_hasRecentLocalPublish) {
+          Log.info(
+            'Ignoring empty kind 10003 answer inside local publish grace '
+            'period, keeping ${globalBookmarks.length} bookmarks',
+            name: 'BookmarkService',
+            category: LogCategory.system,
+          );
+          return null;
+        }
+
         // Nobody holds a list, and — because of the confirmation above — that
         // is either an authoritative answer or one that had nothing to
         // destroy. The first save may create one.
@@ -437,6 +469,7 @@ class BookmarkService {
         _privateItemsState = _PrivateItemsState.none;
         _lastKnownRemoteContent = '';
         _revision = null;
+        _localPublishRevision = null;
       } else {
         // Seeing the event disproves the absence, so the stamp cannot stand.
         // A list whose items are all private has no public tags, leaving
@@ -462,6 +495,7 @@ class BookmarkService {
           return null;
         }
         await _adoptGlobalBookmarksFromEvent(newest);
+        _localPublishRevision = null;
       }
 
       await _saveBookmarksToSharedPreferences();
@@ -872,6 +906,11 @@ class BookmarkService {
       // The revision this device now holds. A read that still answers with the
       // one this replaced is stale, not a correction — see [_isStaleRevision].
       _revision = (createdAt: event.createdAt, id: event.id);
+      _localPublishRevision = (
+        createdAt: event.createdAt,
+        id: event.id,
+        acceptedAt: _now(),
+      );
       _globalBookmarks
         ..clear()
         ..addAll(candidate);

--- a/mobile/lib/services/bookmark_service.dart
+++ b/mobile/lib/services/bookmark_service.dart
@@ -238,6 +238,57 @@ class BookmarkService {
   /// kind-10003 at all.
   DateTime? _absenceConfirmedAt;
 
+  /// The kind-10003 revision this device has established — the newest event it
+  /// adopted, or the one it last published. `null` once a confirmed-empty
+  /// answer established that no list exists.
+  ({int createdAt, String id})? _revision;
+
+  /// Tail of the serialized operation queue. See [_serialized].
+  Future<void> _queue = Future<void>.value();
+
+  /// Runs [operation] only after every operation queued before it.
+  ///
+  /// Reading and publishing both reach the relay, suspend, and then replace
+  /// the whole in-memory list and the persisted snapshot. Left overlapping,
+  /// the last one to resume wins whatever revision it happened to read, so a
+  /// display read issued before a save lands after it and undoes it (#7163).
+  ///
+  /// Only the public entry points take this. The private cores they compose
+  /// must not, or a toggle would wait on the queue slot it already holds.
+  Future<T> _serialized<T>(Future<T> Function() operation) {
+    final result = Completer<T>();
+    _queue = _queue.then((_) async {
+      try {
+        result.complete(await operation());
+      } catch (error, stackTrace) {
+        // Kept off the queue future: letting it reject would strand every
+        // operation queued behind this one.
+        result.completeError(error, stackTrace);
+      }
+    });
+    return result.future;
+  }
+
+  /// NIP-01's order for two versions of a replaceable event: newer
+  /// `created_at` first, and on a tie the lexically lower id — the one relays
+  /// are told to retain. Sorting the same way keeps this device's idea of the
+  /// current revision identical to theirs.
+  static int _newestRevisionFirst(Event a, Event b) =>
+      a.createdAt != b.createdAt
+      ? b.createdAt.compareTo(a.createdAt)
+      : a.id.compareTo(b.id);
+
+  /// Whether [event] is an older revision than the one this device already
+  /// holds, by that same comparison.
+  bool _isStaleRevision(Event event) {
+    final revision = _revision;
+    if (revision == null) return false;
+    if (event.createdAt != revision.createdAt) {
+      return event.createdAt < revision.createdAt;
+    }
+    return event.id.compareTo(revision.id) > 0;
+  }
+
   /// Whether an empty answer from a partial set of relays still has to be
   /// confirmed before it is believed.
   ///
@@ -300,12 +351,22 @@ class BookmarkService {
   /// keeps going missing is re-confirmed every time rather than once per
   /// window. An answer that stays unconfirmed changes nothing. A read that
   /// finds a list keeps the fast trade and pays for none of this.
-  Future<bool> syncGlobalBookmarks({bool requireAuthoritative = false}) async =>
-      // Equality to success, never `!= someFailure`: a blacklist would let any
-      // failure member added later fall through as "reconciled" and publish
-      // kind 10003 from an inconclusive read — the #6966 regression.
-      await _syncGlobalBookmarks(requireAuthoritative: requireAuthoritative) ==
-      null;
+  ///
+  /// Runs after any bookmark operation already in flight ([_serialized]), so
+  /// its answer is applied to — and observed against — that operation's
+  /// result rather than interleaved with it.
+  Future<bool> syncGlobalBookmarks({bool requireAuthoritative = false}) =>
+      _serialized(
+        () async =>
+            // Equality to success, never `!= someFailure`: a blacklist would
+            // let any failure member added later fall through as "reconciled"
+            // and publish kind 10003 from an inconclusive read — the #6966
+            // regression.
+            await _syncGlobalBookmarks(
+              requireAuthoritative: requireAuthoritative,
+            ) ==
+            null,
+      );
 
   /// [syncGlobalBookmarks], but reporting *why* it failed.
   ///
@@ -375,6 +436,7 @@ class BookmarkService {
         _privateTags = const [];
         _privateItemsState = _PrivateItemsState.none;
         _lastKnownRemoteContent = '';
+        _revision = null;
       } else {
         // Seeing the event disproves the absence, so the stamp cannot stand.
         // A list whose items are all private has no public tags, leaving
@@ -382,9 +444,24 @@ class BookmarkService {
         // another client's ciphertext — a stale stamp would let the next
         // partial empty answer through unconfirmed and wipe it.
         _absenceConfirmedAt = null;
-        final newestFirst = [...events]
-          ..sort((a, b) => b.createdAt.compareTo(a.createdAt));
-        await _adoptGlobalBookmarksFromEvent(newestFirst.first);
+        final newest = ([...events]..sort(_newestRevisionFirst)).first;
+
+        // A replaceable event has exactly one current version, so a revision
+        // older than the one this device established is never the user's list
+        // — it is a copy the relay had not replaced yet. The relay answers
+        // `OK` once the event is queued for storage rather than once it is
+        // stored, so that copy is what a read right after a save sees.
+        // Adopting it would undo the publish (#7163).
+        if (_isStaleRevision(newest)) {
+          Log.info(
+            'Ignoring kind 10003 ${newest.id} - older than the revision this '
+            'device holds, keeping ${globalBookmarks.length} bookmarks',
+            name: 'BookmarkService',
+            category: LogCategory.system,
+          );
+          return null;
+        }
+        await _adoptGlobalBookmarksFromEvent(newest);
       }
 
       await _saveBookmarksToSharedPreferences();
@@ -462,7 +539,23 @@ class BookmarkService {
   /// The returned [BookmarkToggleResult] carries both the reconciled
   /// before-state and the resulting state; callers must not assume the
   /// direction from their own pre-read.
+  ///
+  /// Reconcile and publish run as one serialized operation ([_serialized]), so
+  /// no other read can land between the direction being decided and the new
+  /// list being published.
   Future<BookmarkToggleResult> toggleVideoInGlobalBookmarks(
+    String videoEventId, {
+    String? relay,
+    String? petname,
+  }) => _serialized(
+    () => _toggleVideoInGlobalBookmarks(
+      videoEventId,
+      relay: relay,
+      petname: petname,
+    ),
+  );
+
+  Future<BookmarkToggleResult> _toggleVideoInGlobalBookmarks(
     String videoEventId, {
     String? relay,
     String? petname,
@@ -492,11 +585,11 @@ class BookmarkService {
     }
 
     final succeeded = wasBookmarked
-        ? await removeFromGlobalBookmarks(
+        ? await _removeFromGlobalBookmarks(
             BookmarkItem(type: 'e', id: videoEventId),
             alreadyReconciled: true,
           )
-        : await addToGlobalBookmarks(
+        : await _addToGlobalBookmarks(
             BookmarkItem(
               type: 'e',
               id: videoEventId,
@@ -527,13 +620,22 @@ class BookmarkService {
   /// [syncGlobalBookmarks] with `requireAuthoritative: true` and the extra
   /// round trip would be redundant. Callers that have not just completed that
   /// authoritative sync must leave it false so this method reconciles first.
+  ///
+  /// Reconcile and publish run as one serialized operation ([_serialized]).
   Future<bool> addToGlobalBookmarks(
     BookmarkItem item, {
     bool alreadyReconciled = false,
+  }) => _serialized(
+    () => _addToGlobalBookmarks(item, alreadyReconciled: alreadyReconciled),
+  );
+
+  Future<bool> _addToGlobalBookmarks(
+    BookmarkItem item, {
+    required bool alreadyReconciled,
   }) async {
     try {
       if (!alreadyReconciled &&
-          !await syncGlobalBookmarks(requireAuthoritative: true)) {
+          await _syncGlobalBookmarks(requireAuthoritative: true) != null) {
         Log.warning(
           'Not adding to global bookmarks: could not reconcile with relay',
           name: 'BookmarkService',
@@ -596,13 +698,23 @@ class BookmarkService {
   /// [syncGlobalBookmarks] with `requireAuthoritative: true` and the extra
   /// round trip would be redundant. Callers that have not just completed that
   /// authoritative sync must leave it false so this method reconciles first.
+  ///
+  /// Reconcile and publish run as one serialized operation ([_serialized]).
   Future<bool> removeFromGlobalBookmarks(
     BookmarkItem item, {
     bool alreadyReconciled = false,
+  }) => _serialized(
+    () =>
+        _removeFromGlobalBookmarks(item, alreadyReconciled: alreadyReconciled),
+  );
+
+  Future<bool> _removeFromGlobalBookmarks(
+    BookmarkItem item, {
+    required bool alreadyReconciled,
   }) async {
     try {
       if (!alreadyReconciled &&
-          !await syncGlobalBookmarks(requireAuthoritative: true)) {
+          await _syncGlobalBookmarks(requireAuthoritative: true) != null) {
         Log.warning(
           'Not removing from global bookmarks: could not reconcile with relay',
           name: 'BookmarkService',
@@ -757,6 +869,9 @@ class BookmarkService {
         return false;
       }
 
+      // The revision this device now holds. A read that still answers with the
+      // one this replaced is stale, not a correction — see [_isStaleRevision].
+      _revision = (createdAt: event.createdAt, id: event.id);
       _globalBookmarks
         ..clear()
         ..addAll(candidate);
@@ -864,6 +979,7 @@ class BookmarkService {
       ..clear()
       ..addAll(_itemsFromTags(private.tags));
     _privateItemsState = private.state;
+    _revision = (createdAt: event.createdAt, id: event.id);
   }
 
   /// The bookmark items among [tags], in order.

--- a/mobile/lib/services/user_data_cleanup_service.dart
+++ b/mobile/lib/services/user_data_cleanup_service.dart
@@ -47,6 +47,7 @@ class UserDataCleanupService {
     // Bookmark services
     'bookmark_sets',
     'global_bookmarks',
+    'global_bookmarks_revision',
     'bookmark_published_hashes',
     'bookmark_pending_changes',
     // Mute/moderation services

--- a/mobile/test/services/bookmark_service_test.dart
+++ b/mobile/test/services/bookmark_service_test.dart
@@ -1088,6 +1088,48 @@ void main() {
       });
 
       test(
+        'a service built after the save still refuses the revision it '
+        'replaced',
+        () async {
+          // The writing surface builds a fresh BookmarkService per sheet
+          // (#7596), so an in-memory-only watermark is blank again by the
+          // next save. That makes the ordinary save / close / save loop
+          // reproduce #7163 with no concurrency involved at all.
+          stubRelay(
+            events: [
+              supersededRevision(['video-a']),
+            ],
+          );
+
+          final firstSheet = createService();
+          expect(
+            (await firstSheet.toggleVideoInGlobalBookmarks(
+              'video-b',
+            )).succeeded,
+            isTrue,
+          );
+          expect(signedEventIds(), ['video-a', 'video-b']);
+
+          // The sheet closes and that instance is dropped. The relay still
+          // answers with the revision the save replaced, because `OK` means
+          // queued for storage, not readable back.
+          final secondSheet = createService();
+          expect(
+            (await secondSheet.toggleVideoInGlobalBookmarks(
+              'video-c',
+            )).succeeded,
+            isTrue,
+          );
+
+          expect(
+            signedEventIds(),
+            ['video-a', 'video-b', 'video-c'],
+            reason: 'the second sheet must not publish over video-b',
+          );
+        },
+      );
+
+      test(
         'a display read issued before a save cannot land after it',
         () async {
           final staleRead = supersededRevision(['video-a']);
@@ -1214,6 +1256,10 @@ void main() {
         final service = createService();
         final first = service.toggleVideoInGlobalBookmarks('video-b');
         final second = service.toggleVideoInGlobalBookmarks('video-c');
+        // _serialized schedules on a microtask, so completing synchronously
+        // here would resolve before the first publish ever awaits it and the
+        // hold would gate nothing. Let the queue reach the publish first.
+        await pumpEventQueue();
         holdFirstPublish.complete();
         await Future.wait([first, second]);
 
@@ -1234,14 +1280,18 @@ void main() {
         final other = bookmarkListEvent(['video-b'], createdAt: createdAt);
         // NIP-01 tells relays to retain the lexically lower id on a tie, so
         // reading the same way keeps this device and the relays agreeing.
-        final expected = one.id.compareTo(other.id) < 0 ? one : other;
-        stubRelay(events: [one, other]);
+        final lower = one.id.compareTo(other.id) < 0 ? one : other;
+        final higher = identical(lower, one) ? other : one;
+        // The ids are random per run, so the higher one has to go in first: a
+        // comparator that returns 0 on the tie leaves the pair in input order,
+        // which would otherwise match on about half of runs by luck.
+        stubRelay(events: [higher, lower]);
         final service = createService();
 
         await service.syncGlobalBookmarks();
 
         expect(service.globalBookmarks.map((item) => item.id), [
-          expected.tags.first[1],
+          lower.tags.first[1],
         ]);
       });
     });

--- a/mobile/test/services/bookmark_service_test.dart
+++ b/mobile/test/services/bookmark_service_test.dart
@@ -1087,6 +1087,100 @@ void main() {
         );
       });
 
+      test(
+        'a display read issued before a save cannot land after it',
+        () async {
+          final staleRead = supersededRevision(['video-a']);
+          var relayHeld = staleRead;
+          final releaseRead = Completer<void>();
+          var queries = 0;
+
+          when(
+            () => nostrClient.queryEventsDetailed(
+              any(),
+              useCache: any(named: 'useCache'),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+            ),
+          ).thenAnswer((_) async {
+            if (++queries == 1) {
+              await releaseRead.future;
+              return (events: [staleRead], timedOut: false, noRelays: false);
+            }
+            return (events: [relayHeld], timedOut: false, noRelays: false);
+          });
+          when(() => nostrClient.publishEventAwaitOk(any())).thenAnswer((
+            invocation,
+          ) async {
+            final event = invocation.positionalArguments.first as Event;
+            relayHeld = event;
+            if (!releaseRead.isCompleted) releaseRead.complete();
+            return PublishOutcome(
+              eventId: event.id,
+              acceptedBy: const ['wss://relay.example'],
+              rejectedBy: const {},
+              noResponseFrom: const [],
+            );
+          });
+
+          final service = createService();
+          final read = service.syncGlobalBookmarks();
+          final save = service.toggleVideoInGlobalBookmarks('video-b');
+
+          await Future<void>.delayed(Duration.zero);
+          if (queries == 1 && !releaseRead.isCompleted) releaseRead.complete();
+          await Future.wait([read, save]);
+
+          expect(service.globalBookmarks.map((item) => item.id), [
+            'video-a',
+            'video-b',
+          ]);
+        },
+      );
+
+      test('an empty relay answer cannot undo a recent first save', () async {
+        final clock = DateTime(2026);
+        stubRelay(events: []);
+        final service = createService(now: () => clock);
+
+        final first = await service.toggleVideoInGlobalBookmarks('video-b');
+        expect(first.succeeded, isTrue);
+
+        final second = await service.toggleVideoInGlobalBookmarks('video-c');
+        expect(second.succeeded, isTrue);
+        expect(signedEventIds(), ['video-b', 'video-c']);
+        expect(service.globalBookmarks.map((item) => item.id), [
+          'video-b',
+          'video-c',
+        ]);
+      });
+
+      test(
+        'a confirmed absence clears after the local publish grace expires',
+        () async {
+          var clock = DateTime(2026);
+          stubRelay(events: []);
+          final service = createService(now: () => clock);
+
+          final result = await service.toggleVideoInGlobalBookmarks('video-b');
+          expect(result.succeeded, isTrue);
+
+          clock = clock.add(
+            BookmarkService.localPublishAbsenceGracePeriod +
+                const Duration(seconds: 1),
+          );
+          expect(
+            await service.syncGlobalBookmarks(requireAuthoritative: true),
+            isTrue,
+          );
+
+          expect(
+            service.globalBookmarks,
+            isEmpty,
+            reason: 'a real delete elsewhere must not be hidden forever',
+          );
+        },
+      );
+
       test('overlapping toggles do not publish from the same base', () async {
         var relayHeld = supersededRevision(['video-a']);
         final holdFirstPublish = Completer<void>();

--- a/mobile/test/services/bookmark_service_test.dart
+++ b/mobile/test/services/bookmark_service_test.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Tests BookmarkService's NIP-51 kind 10003 read-modify-write contract
 // ABOUTME: Pins that an unreconciled publish can never truncate the relay list
 
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
@@ -45,7 +46,11 @@ void main() {
     List<List<String>>? signedTags;
     String? signedContent;
 
-    Event bookmarkListEvent(List<String> eventIds, {String content = ''}) {
+    Event bookmarkListEvent(
+      List<String> eventIds, {
+      String content = '',
+      int? createdAt,
+    }) {
       return Event(
         pubkey,
         10003,
@@ -53,6 +58,7 @@ void main() {
           for (final id in eventIds) ['e', id],
         ],
         content,
+        createdAt: createdAt,
       );
     }
 
@@ -1038,6 +1044,111 @@ void main() {
 
         expect(result.succeeded, isTrue);
         expect(result.failure, isNull);
+      });
+    });
+
+    group('concurrent syncs and publishes', () {
+      /// A revision published a minute ago — what a relay still answers with
+      /// while a newer one from this device has not replaced it yet.
+      Event supersededRevision(List<String> eventIds) => bookmarkListEvent(
+        eventIds,
+        createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000 - 60,
+      );
+
+      test('a stale relay answer cannot undo a completed save', () async {
+        stubRelay(
+          events: [
+            supersededRevision(['video-a']),
+          ],
+        );
+        final service = createService();
+
+        final toggle = await service.toggleVideoInGlobalBookmarks('video-b');
+        expect(toggle.succeeded, isTrue);
+        expect(signedEventIds(), ['video-a', 'video-b']);
+
+        // The relay still answers with the revision the save replaced: `OK`
+        // means the new one is queued for storage, not that it is stored. This
+        // is the share sheet's display read landing after the toggle.
+        await service.syncGlobalBookmarks();
+
+        expect(service.globalBookmarks.map((item) => item.id), [
+          'video-a',
+          'video-b',
+        ]);
+        expect(
+          jsonDecode(
+            prefs.getString(BookmarkService.globalBookmarksStorageKey)!,
+          ),
+          [
+            {'type': 'e', 'id': 'video-a', 'relay': null, 'petname': null},
+            {'type': 'e', 'id': 'video-b', 'relay': null, 'petname': null},
+          ],
+        );
+      });
+
+      test('overlapping toggles do not publish from the same base', () async {
+        var relayHeld = supersededRevision(['video-a']);
+        final holdFirstPublish = Completer<void>();
+        var publishes = 0;
+
+        when(
+          () => nostrClient.queryEventsDetailed(
+            any(),
+            useCache: any(named: 'useCache'),
+            requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+          ),
+        ).thenAnswer(
+          (_) async => (events: [relayHeld], timedOut: false, noRelays: false),
+        );
+        when(() => nostrClient.publishEventAwaitOk(any())).thenAnswer((
+          invocation,
+        ) async {
+          final event = invocation.positionalArguments.first as Event;
+          // Acknowledging the first publish only after the second toggle has
+          // had its chance to read is what an unserialized pair would see.
+          if (++publishes == 1) await holdFirstPublish.future;
+          relayHeld = event;
+          return PublishOutcome(
+            eventId: event.id,
+            acceptedBy: const ['wss://relay.example'],
+            rejectedBy: const {},
+            noResponseFrom: const [],
+          );
+        });
+
+        final service = createService();
+        final first = service.toggleVideoInGlobalBookmarks('video-b');
+        final second = service.toggleVideoInGlobalBookmarks('video-c');
+        holdFirstPublish.complete();
+        await Future.wait([first, second]);
+
+        final published = verify(
+          () => nostrClient.publishEventAwaitOk(captureAny()),
+        ).captured.cast<Event>();
+        expect(published, hasLength(2));
+        expect(
+          published.last.tags.map((tag) => tag[1]),
+          ['video-a', 'video-b', 'video-c'],
+          reason: "the second toggle must build on the first one's result",
+        );
+      });
+
+      test('keeps the lower id when two revisions share a timestamp', () async {
+        final createdAt = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+        final one = bookmarkListEvent(['video-a'], createdAt: createdAt);
+        final other = bookmarkListEvent(['video-b'], createdAt: createdAt);
+        // NIP-01 tells relays to retain the lexically lower id on a tie, so
+        // reading the same way keeps this device and the relays agreeing.
+        final expected = one.id.compareTo(other.id) < 0 ? one : other;
+        stubRelay(events: [one, other]);
+        final service = createService();
+
+        await service.syncGlobalBookmarks();
+
+        expect(service.globalBookmarks.map((item) => item.id), [
+          expected.tags.first[1],
+        ]);
       });
     });
 


### PR DESCRIPTION
## Description

`BookmarkService` had no ordering between operations. `syncGlobalBookmarks` and both publish paths each read the relay, suspend, and then replace the whole in-memory list, the private-item state, `_lastKnownRemoteContent` and the `SharedPreferences` snapshot. Whichever resumed last won, with whatever revision it happened to read.

Three failures follow from that, all reproduced as tests that are red on `main` and green here:

**1. A stale read undoes a completed save.** The share sheet's display read (`ShareSheetBookmarkStatusRequested`) and the save (`ShareSheetSaveRequested`) sit in different `droppable()` buckets, so bloc runs them concurrently. The display read resolves after the toggle publishes and adopts the revision the toggle just replaced — the saved bookmark disappears from memory and from the persisted snapshot, and the row goes back to `Save`.

This is not only an in-flight race. A relay's `OK` acknowledges the event; it does not promise the event is readable back yet. Measured against the production relay with a throwaway key: a just-accepted kind 10003 was not immediately queryable, and took on the order of ten seconds or more to appear. So a read issued *after* a successful save still sees the superseded revision.

**2. Overlapping toggles publish from the same base.** Two toggles each reconcile, each build a candidate from the same list, and each publish. Kind 10003 is replaceable, so the second publish deletes the first one's item **from the relay**. On this device the Keycast signer takes 238–361 ms per `sign_event`, so the window between deciding the direction and the event landing is that wide on every save.

**3. Same-timestamp revisions were resolved arbitrarily.** `created_at` is second-granularity, and the previous sort compared only `createdAt`, returning 0 for a tie and leaving the winner to list order.

The relay is no help here, which I measured rather than inferred: seven rounds against production, each publishing two kind-10003 revisions from a throwaway key with an identical `created_at`, **retained the higher id in five of seven** — and publish order did not explain the other two. Exactly one revision survived every time, so the item in the losing one was permanently lost. Tracked internally against the relay.

### Approach

**One serialized queue for every public entry point.** `syncGlobalBookmarks`, `toggleVideoInGlobalBookmarks`, `addToGlobalBookmarks` and `removeFromGlobalBookmarks` now run through `_serialized`. The private cores they compose (`_syncGlobalBookmarks`, `_addToGlobalBookmarks`, `_removeFromGlobalBookmarks`) deliberately do not take it — a toggle would otherwise wait on the queue slot it already holds. An operation that throws completes its own caller with the error and leaves the queue future resolved, so it cannot strand everything behind it.

**A revision watermark, because serializing is not sufficient.** Serializing removes the interleaving, but a sequential read can still answer with the revision a just-accepted publish replaced. `_revision` records what this device established — the newest event it adopted, or the one it published — and `_isStaleRevision` refuses anything older. A confirmed-empty answer clears it unless it lands inside a short local-publish grace window, so relay indexing lag cannot erase a just-accepted save while a list genuinely deleted elsewhere still clears after the grace expires.

**Revisions ordered the way NIP-01 tells relays to resolve them** — newest `created_at`, and on a tie the lexically lower id. The client is now deterministic about which revision is current even where the relay is not.

**The queue cannot stall.** Every leg of an operation is time-bounded: the relay query at 5 s (`queryEventsDetailed`), a Keycast `sign_event` at 20 s (`keycast_flutter` `KeycastRpc.defaultRequestTimeout`, applied with `.timeout(...)`), and `publishEventAwaitOk` at 15 s. Queue depth is not capped, so a caller can still wait for each bounded operation ahead of it, but it cannot wait on an indefinitely hung operation. Measured on device: three concurrent `syncGlobalBookmarks` calls now complete sequentially in 703 ms total (233 ms apart), against an overlapping pair on `main`.

The absence-confirmation machinery still confirms empty answers across every relay before believing them. A recent local publish temporarily vetoes even a confirmed absence; once that grace expires, confirmed deletion from another device still clears normally.

**Related Issue:** Closes #7163

## Out of Scope

Three things this does not fix, each with its own blast radius:

- **`bookmarkServiceProvider` is `autoDispose` and is only ever read via `ref.read(...future)`** (`repository_providers.dart:527`, generated `isAutoDispose: true`), so nothing retains it and each read builds a new `BookmarkService`. Verified on a physical iPhone against the running app: two reads 400 ms apart returned `identical=false`. Every instance writes the same unscoped `global_bookmarks` key, so the guard added here is per-instance and does not cover two instances alive at once (the Saved screen stays mounted under a pushed feed that opens the share sheet). Filed as #7596.
- **`divine-space` writes the same kind-10003 slot** (`src/hooks/usePageSave.ts:7`) with no failed-read guard — an unanswered read yields `existingTags = []` and it publishes a one-tag list, blanking NIP-51 private items in `content` along with it. Filed as divinevideo/divine-space#12.
- The known follow-ups already listed on #7133 (non-item tags dropped on republish, `BookmarkItem` truncating tags past the fourth position, bookmarks keyed on event id while kind 34236 is addressable) are untouched.

## Verification

- `flutter test test/services/bookmark_service_test.dart test/blocs/share_sheet/share_sheet_bloc_test.dart test/blocs/profile_saved_videos/profile_saved_videos_bloc_test.dart test/widgets/share_video_menu_comprehensive_test.dart` — 175 passing
- `flutter analyze lib test` — clean
- `dart format` — clean
- Mutation-checked before takeover: with `lib/services/bookmark_service.dart` reverted, the original three new tests fail, each on its own assertion (dropped bookmark / `['video-a', 'video-c']` published / wrong revision adopted)
- Exercised on a physical iPhone (iOS 26.6, Keycast identity) over the VM service: two concurrent `syncGlobalBookmarks` calls on one live instance were confirmed overlapping in the app's own logs, one reporting `noRelays=true` while the other reconciled

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

