### PR TITLE
ci: route review requests with CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,28 @@
+# Routes review requests automatically when a pull request opens.
+#
+# This exists because requesting a reviewer was a step an author had to
+# remember. Branch protection already stops an unreviewed pull request from
+# merging, so nothing was landing unreviewed — but nothing decided *who* should
+# look, so pull requests sat until someone chased them. GitHub applies this file
+# the moment a pull request opens, for humans and agents alike, which is why it
+# replaces a convention that had to be read to be followed.
+#
+# Order matters: the LAST matching pattern wins. Keep the catch-all first.
+#
+# Paths here are only those that exist in this repository. Adding a pattern for
+# a path that does not exist is silently inert, as is naming a team without
+# write access to this repository — GitHub reports neither.
+
+* @divinevideo/reviewers
+
+# Platform-sensitive paths, per PR_REVIEW_TEAMS.md: an incorrect final state
+# here can affect production deployment, signing, or secrets rather than one
+# feature. `codemagic.yaml` builds and publishes the shipping app, and a single
+# bad line in it fails every workflow in the file before any step runs — that
+# took the whole pipeline down for ~21 hours in #7203.
+/.github/workflows/          @divinevideo/platform
+/codemagic.yaml              @divinevideo/platform
+/.github/dependabot.yml      @divinevideo/platform
+
+# Changing who reviews what is itself a platform decision.
+/.github/CODEOWNERS          @divinevideo/platform


### PR DESCRIPTION
## Summary

Adds `.github/CODEOWNERS` so review requests are routed automatically when a pull request opens.

## Why

Branch protection already prevents an unreviewed pull request from merging here, so nothing has been landing unreviewed. The gap is **routing**: nothing decides *who* should look, so pull requests wait until someone notices and asks.

Requesting the mapped team is documented in `divine-context/PR_REVIEW.md`, but as a step the author has to remember — three hops away from this repository, and skippable with no signal that it was skipped. This repo has **6 authors and 260 commits in the last 90 days**. A convention that must be read to be followed will keep leaking at that rate.

CODEOWNERS is applied by GitHub the moment a pull request opens. No author action, no agent action, identical for both.

## Routing

```
*                        @divinevideo/reviewers
/.github/workflows/      @divinevideo/platform
/codemagic.yaml          @divinevideo/platform
/.github/dependabot.yml  @divinevideo/platform
/.github/CODEOWNERS      @divinevideo/platform
```

The platform paths follow `PR_REVIEW_TEAMS.md` — *"where an incorrect final PR state could affect authentication, signing, secrets, production deployment, routing, or shared storage."* `codemagic.yaml` qualifies twice over: it builds and publishes the shipping app, and one bad line in it fails **every** workflow in the file before any step runs. That is what took iOS, Android, macOS and both E2E lanes down for ~21 hours in #7203.

## Two things reviewers should check, because GitHub will not tell us

Both failure modes here are silent:

1. **A team without write access to this repository is ignored.** If `@divinevideo/platform` or `@divinevideo/reviewers` lacks access, those lines do nothing and no error appears anywhere.
2. **A pattern matching no existing path is inert.** Every path above was verified to exist in this repo, but that is worth a second pair of eyes.

Last matching pattern wins, so the catch-all is deliberately first.

## Deliberately not included

`require_code_owner_reviews` on branch protection. That would make these teams' approval *mandatory* to merge. Worth doing, but let the file simply request for a week first — if the routing is wrong, the failure should be "the wrong person was asked", not "nobody can merge".

## Verification after merge

Open a throwaway PR and confirm reviewers appear without anyone requesting them. Given both failure modes above are invisible, the file working should be demonstrated rather than assumed.
