### PR TITLE
fix(video): retry deep-link lookup when relays connect mid-fetch

### DIFF
--- a/mobile/lib/screens/video_detail_screen.dart
+++ b/mobile/lib/screens/video_detail_screen.dart
@@ -147,7 +147,6 @@ class _VideoDetailScreenState extends ConsumerState<VideoDetailScreen> {
       );
 
       final nostrClient = ref.read(nostrServiceProvider);
-      final videoEventService = ref.read(videoEventServiceProvider);
       final canQueryRelays =
           nostrClient.isInitialized && nostrClient.connectedRelayCount > 0;
 
@@ -162,26 +161,6 @@ class _VideoDetailScreenState extends ConsumerState<VideoDetailScreen> {
             );
 
       if (video != null) {
-        // Even when the repository returns a video, it may still be hidden by
-        // the viewer's block/mute/divine-host/content filters or a deletion
-        // tombstone. Those are view-time filters, not lookup failures, so they
-        // correctly surface as "not found" rather than deferring to a relay
-        // retry — retrying would keep returning the same filtered row.
-        if (videoEventService.shouldHideVideo(video) ||
-            videoEventService.isVideoEventKnownDeleted(video)) {
-          Log.warning(
-            '❌ Video not found (filtered/deleted): ${widget.videoId}',
-            name: 'VideoDetailScreen',
-            category: LogCategory.video,
-          );
-          if (mounted) {
-            setState(() {
-              _error = _VideoDetailError.notFound;
-              _isLoading = false;
-            });
-          }
-          return;
-        }
         Log.info(
           '✅ Loaded video: ${video.title}',
           name: 'VideoDetailScreen',

--- a/mobile/lib/screens/video_detail_screen.dart
+++ b/mobile/lib/screens/video_detail_screen.dart
@@ -147,6 +147,7 @@ class _VideoDetailScreenState extends ConsumerState<VideoDetailScreen> {
       );
 
       final nostrClient = ref.read(nostrServiceProvider);
+      final videoEventService = ref.read(videoEventServiceProvider);
       final canQueryRelays =
           nostrClient.isInitialized && nostrClient.connectedRelayCount > 0;
 
@@ -161,6 +162,26 @@ class _VideoDetailScreenState extends ConsumerState<VideoDetailScreen> {
             );
 
       if (video != null) {
+        // Even when the repository returns a video, it may still be hidden by
+        // the viewer's block/mute/divine-host/content filters or a deletion
+        // tombstone. Those are view-time filters, not lookup failures, so they
+        // correctly surface as "not found" rather than deferring to a relay
+        // retry — retrying would keep returning the same filtered row.
+        if (videoEventService.shouldHideVideo(video) ||
+            videoEventService.isVideoEventKnownDeleted(video)) {
+          Log.warning(
+            '❌ Video not found (filtered/deleted): ${widget.videoId}',
+            name: 'VideoDetailScreen',
+            category: LogCategory.video,
+          );
+          if (mounted) {
+            setState(() {
+              _error = _VideoDetailError.notFound;
+              _isLoading = false;
+            });
+          }
+          return;
+        }
         Log.info(
           '✅ Loaded video: ${video.title}',
           name: 'VideoDetailScreen',
@@ -177,12 +198,20 @@ class _VideoDetailScreenState extends ConsumerState<VideoDetailScreen> {
               .markDataLoaded('video_detail');
         }
       } else {
+        // A null result is ambiguous: it can mean the video is genuinely
+        // absent, or that the relay layer was not yet queryable when the
+        // lookup ran (cold start, app resume, or a 3–5s per-query timeout that
+        // fired before EOSE). The original check only retried when
+        // !canQueryRelays at the *start* of the lookup; a lookup that started
+        // with 0 relays but saw a connection arrive mid-flight would still
+        // surface a permanent "not found". Re-check queryability after the
+        // fetch and defer the not-found until the relay-ready retry has had a
+        // chance.
+        final canQueryRelaysNow =
+            nostrClient.isInitialized && nostrClient.connectedRelayCount > 0;
         if (allowRelayReadyRetry &&
-            !canQueryRelays &&
+            (!canQueryRelays || !canQueryRelaysNow) &&
             _scheduleRelayReadyRetry(nostrClient)) {
-          // Cold-start links can arrive before the relay layer is queryable.
-          // Retry once after the first relay connection instead of surfacing a
-          // permanent "Video not found" during startup.
           Log.info(
             '⏳ Video lookup deferred until relay connection is ready',
             name: 'VideoDetailScreen',

--- a/mobile/lib/screens/video_detail_screen.dart
+++ b/mobile/lib/screens/video_detail_screen.dart
@@ -177,15 +177,12 @@ class _VideoDetailScreenState extends ConsumerState<VideoDetailScreen> {
               .markDataLoaded('video_detail');
         }
       } else {
-        // A null result is ambiguous: it can mean the video is genuinely
-        // absent, or that the relay layer was not yet queryable when the
-        // lookup ran (cold start, app resume, or a 3–5s per-query timeout that
-        // fired before EOSE). The original check only retried when
-        // !canQueryRelays at the *start* of the lookup; a lookup that started
-        // with 0 relays but saw a connection arrive mid-flight would still
-        // surface a permanent "not found". Re-check queryability after the
-        // fetch and defer the not-found until the relay-ready retry has had a
-        // chance.
+        // A null result only establishes absence when relays were queryable
+        // for the whole lookup. Checking that at the start alone misses the
+        // resume case: a REQ can begin against a relay that is gone by the
+        // time the per-query timeout fires, and an empty result from a lookup
+        // that lost its relays is not a confirmed "not found". Check both
+        // ends and defer to the relay-ready retry when either fails.
         final canQueryRelaysNow =
             nostrClient.isInitialized && nostrClient.connectedRelayCount > 0;
         if (allowRelayReadyRetry &&

--- a/mobile/test/screens/video_detail_screen_test.dart
+++ b/mobile/test/screens/video_detail_screen_test.dart
@@ -709,6 +709,58 @@ void main() {
           );
         },
       );
+
+      testWidgets('retries when the relay connection drops mid-fetch', (
+        tester,
+      ) async {
+        // Resume case: the lookup starts with a relay that is gone by the
+        // time the per-query timeout fires. The empty result never
+        // established absence, so it must not surface a permanent
+        // "not found".
+        var connectedRelayCount = 1;
+        when(
+          () => mockNostrClient.connectedRelayCount,
+        ).thenAnswer((_) => connectedRelayCount);
+
+        final video = createTestVideoEvent(
+          id: 'dropped_relay_video',
+          pubkey: 'test_pubkey',
+          title: 'Dropped Relay Video',
+        );
+
+        var attempts = 0;
+        when(
+          () => mockVideosRepository.fetchVideoWithStatsForRouteId(
+            'dropped_relay_video',
+          ),
+        ).thenAnswer((_) async {
+          attempts++;
+          if (attempts == 1) {
+            connectedRelayCount = 0;
+            return null;
+          }
+          return video;
+        });
+
+        await tester.pumpWidget(buildSubject(videoId: 'dropped_relay_video'));
+        await tester.pump();
+
+        expect(find.byType(BrandedLoadingIndicator), findsOneWidget);
+        expect(find.text(l10n.videoErrorNotFound), findsNothing);
+
+        connectedRelayCount = 1;
+        relayStatusController.add({
+          'wss://relay.divine.video': RelayConnectionStatus.connected(
+            'wss://relay.divine.video',
+          ),
+        });
+
+        await tester.pump();
+        await tester.pump();
+
+        expect(attempts, 2);
+        expect(find.byKey(const Key('video-feed-placeholder')), findsOneWidget);
+      });
     });
 
     group('fetch error', () {

--- a/mobile/test/screens/video_detail_screen_test.dart
+++ b/mobile/test/screens/video_detail_screen_test.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'package:content_blocklist_repository/content_blocklist_repository.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:follow_repository/follow_repository.dart';
 import 'package:go_router/go_router.dart';
@@ -951,6 +952,46 @@ void main() {
           find.bySemanticsLabel(l10n.videoDetailCloseSemanticLabel),
           findsOneWidget,
         );
+      });
+
+      testWidgets('renders the player once an unblock clears the filter', (
+        tester,
+      ) async {
+        // The hide filters are view-time state, not a lookup result: build()
+        // watches the moderation version providers so unblocking the author
+        // brings the video back without a refetch. Latching the load-time
+        // verdict into the error state would strand the screen on not-found.
+        final video = createTestVideoEvent(
+          id: 'unblocked_video_id',
+          pubkey: 'unblocked_pubkey',
+          title: 'Unblocked Video',
+        );
+
+        when(
+          () => mockVideosRepository.fetchVideoWithStatsForRouteId(
+            'unblocked_video_id',
+          ),
+        ).thenAnswer((_) async => video);
+        when(
+          () => mockVideoEventService.shouldHideVideo(video),
+        ).thenReturn(true);
+
+        await tester.pumpWidget(buildSubject(videoId: 'unblocked_video_id'));
+        await tester.pump();
+
+        expect(find.text(l10n.videoErrorNotFound), findsOneWidget);
+
+        when(
+          () => mockVideoEventService.shouldHideVideo(video),
+        ).thenReturn(false);
+        ProviderScope.containerOf(
+          tester.element(find.byType(VideoDetailScreen)),
+        ).read(blocklistVersionProvider.notifier).increment();
+
+        await tester.pump();
+
+        expect(find.byKey(const Key('video-feed-placeholder')), findsOneWidget);
+        expect(find.text(l10n.videoErrorNotFound), findsNothing);
       });
     });
   });


### PR DESCRIPTION
Closes #7602

Fixes the TestFlight report where a freshly-published video (34236:pubkey:dTag) was visible in feeds via Funnelcake (2 likes, thumbnail, served to users) but its notification deep-link showed "Video not found" and the profile grid showed "No videos yet" on cold start / app resume.

Root cause: `VideoDetailScreen._loadVideo` decided whether a null lookup could still be retried using only the relay state captured *before* the fetch. A lookup that starts against a connected relay and loses it before returning — the 11:07:39–11:07:40 resume in the export — surfaced a permanent not-found even though `relay.divine.video` reconnects ~200ms later. An empty result from a lookup that lost its relays never established absence. Funnelcake has the video, but the addressable relay path is needed for author-scoped verification and was not retried.

Change:

- `mobile/lib/screens/video_detail_screen.dart` — re-check `isInitialized && connectedRelayCount > 0` after `fetchVideoWithStatsForRouteId` returns null, and defer to the existing `relayStatusStream` retry when either the pre- or post-check is false. No new timeout, no repository change (per-query `_routeRelayTimeout` stays at 3s, nothing compounds).
- `mobile/test/screens/video_detail_screen_test.dart` — pins the new retry path (`retries when the relay connection drops mid-fetch`, red on `main`), and pins that the view-time hide filters stay reactive after load.

Profile empty: the 10:36 profile REQ did return 50–546 events (EOSE logs), but the user tapped profile at 11:12:51 for ~1s then left to Settings/Support before the REST + relay snapshot merged into ProfileFeedCubit. The retry fix also improves that window; a dedicated profile skeleton vs empty-state polish is separate.

Test plan: `flutter test test/screens/video_detail_screen_test.dart` passes (23/23). Deep-link and router suites that mount this screen pass (`main_video_deep_link_nav_action`, `route_coverage`, `universal_link_resolver`, `fullscreen_feed_redirect`, `app_router_divine_scheme_gating`, `notifications_view`, `comment_item`, `video_publish_provider`). `flutter analyze lib test integration_test` is clean. Not yet exercised on a physical device.

Risk: low, VideoDetailScreen only; no repo, service, or router changes.