### PR TITLE
feat(identity): show social proof instead of a truncated npub

### DIFF
--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -5342,5 +5342,10 @@
   "changeEmailSentTitle": "ሁለት ማገናኛዎች በመንገድ ላይ ናቸው",
   "changeEmailSentMessage": "ከ{email} እና በመለያህ ላይ ካለው አድራሻ አረጋግጥ። ሁለቱም ሲጠናቀቁ ኢሜይልህ ይቀየራል።",
   "changeEmailSentExpiry": "ማገናኛዎቹ ከ24 ሰዓት በኋላ አይሠሩም።",
-  "changeEmailSentDone": "ገባኝ"
+  "changeEmailSentDone": "ገባኝ",
+  "socialProofMutual": "እርስ በርስ",
+  "socialProofFollowsYou": "ይከተልዎታል",
+  "socialProofYouFollow": "ይከተላሉ",
+  "socialProofFollowerCount": "{count, plural, =1{{formattedCount} ተከታይ} other{{formattedCount} ተከታዮች}}",
+  "searchUserVideoCount": "{count, plural, =1{{formattedCount} ቪዲዮ} other{{formattedCount} ቪዲዮዎች}}"
 }

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -5217,5 +5217,10 @@
   "changeEmailSentTitle": "رابطان في الطريق",
   "changeEmailSentMessage": "أكّد من {email} ومن العنوان المسجّل في حسابك. يتبدّل بريدك بعد إتمام الاثنين.",
   "changeEmailSentExpiry": "تتوقف الروابط عن العمل بعد 24 ساعة.",
-  "changeEmailSentDone": "فهمت"
+  "changeEmailSentDone": "فهمت",
+  "socialProofMutual": "متابعة متبادلة",
+  "socialProofFollowsYou": "يتابعك",
+  "socialProofYouFollow": "تتابعه",
+  "socialProofFollowerCount": "{count, plural, =1{{formattedCount} متابِع} other{{formattedCount} متابِع}}",
+  "searchUserVideoCount": "{count, plural, =1{{formattedCount} فيديو} other{{formattedCount} فيديو}}"
 }

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -5348,5 +5348,10 @@
   "changeEmailSentTitle": "Два линка са на път",
   "changeEmailSentMessage": "Потвърди от {email} и от адреса в акаунта ти. Имейлът се сменя, щом направиш и двете.",
   "changeEmailSentExpiry": "Линковете спират да работят след 24 часа.",
-  "changeEmailSentDone": "Ясно"
+  "changeEmailSentDone": "Ясно",
+  "socialProofMutual": "Взаимно",
+  "socialProofFollowsYou": "Следва те",
+  "socialProofYouFollow": "Следваш",
+  "socialProofFollowerCount": "{count, plural, =1{{formattedCount} последовател} other{{formattedCount} последователи}}",
+  "searchUserVideoCount": "{count, plural, =1{{formattedCount} видео} other{{formattedCount} видеа}}"
 }

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -5217,5 +5217,10 @@
   "changeEmailSentTitle": "Zwei Links sind unterwegs",
   "changeEmailSentMessage": "Bestätige über {email} und über die Adresse in deinem Konto. Deine E-Mail wechselt, sobald beides erledigt ist.",
   "changeEmailSentExpiry": "Die Links laufen nach 24 Stunden ab.",
-  "changeEmailSentDone": "Alles klar"
+  "changeEmailSentDone": "Alles klar",
+  "socialProofMutual": "Gegenseitig",
+  "socialProofFollowsYou": "Folgt dir",
+  "socialProofYouFollow": "Du folgst",
+  "socialProofFollowerCount": "{count, plural, =1{{formattedCount} Follower} other{{formattedCount} Follower}}",
+  "searchUserVideoCount": "{count, plural, =1{{formattedCount} Video} other{{formattedCount} Videos}}"
 }

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -7563,5 +7563,29 @@
                 "type": "String"
             }
         }
+    },
+  "socialProofMutual": "Mutual",
+  "@socialProofMutual": {
+    "description": "Secondary line on a user row: the viewer and this account follow each other. Shown in place of a truncated npub, which cannot tell two same-named people apart."
+  },
+  "socialProofFollowsYou": "Follows you",
+  "@socialProofFollowsYou": {
+    "description": "Secondary line on a user row: this account follows the viewer, who does not follow back."
+  },
+  "socialProofYouFollow": "You follow",
+  "@socialProofYouFollow": {
+    "description": "Secondary line on a user row: the viewer follows this account, which does not follow back."
+  },
+  "socialProofFollowerCount": "{count, plural, =1{{formattedCount} follower} other{{formattedCount} followers}}",
+  "@socialProofFollowerCount": {
+    "description": "Secondary line on a user row: how many followers this account has. Joined to the relationship label with a middot.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "formattedCount": {
+        "type": "String"
+      }
     }
+  }
 }

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -5217,5 +5217,10 @@
   "changeEmailSentTitle": "Dos enlaces van en camino",
   "changeEmailSentMessage": "Confirma desde {email} y desde la dirección de tu cuenta. Tu correo cambia cuando hagas las dos.",
   "changeEmailSentExpiry": "Los enlaces caducan a las 24 horas.",
-  "changeEmailSentDone": "Entendido"
+  "changeEmailSentDone": "Entendido",
+  "socialProofMutual": "Mutuo",
+  "socialProofFollowsYou": "Te sigue",
+  "socialProofYouFollow": "Siguiendo",
+  "socialProofFollowerCount": "{count, plural, =1{{formattedCount} seguidor} other{{formattedCount} seguidores}}",
+  "searchUserVideoCount": "{count, plural, =1{{formattedCount} video} other{{formattedCount} videos}}"
 }

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -3803,5 +3803,10 @@
   "changeEmailSentTitle": "Papunta na ang dalawang link",
   "changeEmailSentMessage": "I-confirm mula sa {email} at mula sa address na nasa account mo. Magpapalit ang email mo kapag tapos na pareho.",
   "changeEmailSentExpiry": "Titigil gumana ang mga link pagkatapos ng 24 oras.",
-  "changeEmailSentDone": "Sige"
+  "changeEmailSentDone": "Sige",
+  "socialProofMutual": "Mutual",
+  "socialProofFollowsYou": "Sinusundan ka",
+  "socialProofYouFollow": "Sinusundan mo",
+  "socialProofFollowerCount": "{count, plural, =1{{formattedCount} follower} other{{formattedCount} follower}}",
+  "searchUserVideoCount": "{count, plural, =1{{formattedCount} video} other{{formattedCount} video}}"
 }

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -5219,8 +5219,8 @@
   "changeEmailSentExpiry": "Les liens expirent au bout de 24 heures.",
   "changeEmailSentDone": "Compris",
   "socialProofMutual": "Mutuel",
-  "socialProofFollowsYou": "Vous suit",
-  "socialProofYouFollow": "Vous suivez",
+  "socialProofFollowsYou": "Te suit",
+  "socialProofYouFollow": "Tu suis",
   "socialProofFollowerCount": "{count, plural, =1{{formattedCount} abonné} other{{formattedCount} abonnés}}",
   "searchUserVideoCount": "{count, plural, =1{{formattedCount} vidéo} other{{formattedCount} vidéos}}"
 }

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -5217,5 +5217,10 @@
   "changeEmailSentTitle": "Deux liens sont en route",
   "changeEmailSentMessage": "Confirme depuis {email} et depuis l'adresse de ton compte. Ton e-mail change une fois les deux faits.",
   "changeEmailSentExpiry": "Les liens expirent au bout de 24 heures.",
-  "changeEmailSentDone": "Compris"
+  "changeEmailSentDone": "Compris",
+  "socialProofMutual": "Mutuel",
+  "socialProofFollowsYou": "Vous suit",
+  "socialProofYouFollow": "Vous suivez",
+  "socialProofFollowerCount": "{count, plural, =1{{formattedCount} abonné} other{{formattedCount} abonnés}}",
+  "searchUserVideoCount": "{count, plural, =1{{formattedCount} vidéo} other{{formattedCount} vidéos}}"
 }

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -5217,5 +5217,10 @@
   "changeEmailSentTitle": "Dua tautan sedang dikirim",
   "changeEmailSentMessage": "Konfirmasi dari {email} dan dari alamat di akunmu. Emailmu berganti setelah keduanya selesai.",
   "changeEmailSentExpiry": "Tautan berhenti berlaku setelah 24 jam.",
-  "changeEmailSentDone": "Oke"
+  "changeEmailSentDone": "Oke",
+  "socialProofMutual": "Saling mengikuti",
+  "socialProofFollowsYou": "Mengikuti kamu",
+  "socialProofYouFollow": "Kamu ikuti",
+  "socialProofFollowerCount": "{count, plural, other{{formattedCount} pengikut}}",
+  "searchUserVideoCount": "{count, plural, other{{formattedCount} video}}"
 }

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -5220,7 +5220,7 @@
   "changeEmailSentDone": "Ok, capito",
   "socialProofMutual": "Reciproco",
   "socialProofFollowsYou": "Ti segue",
-  "socialProofYouFollow": "Segui",
+  "socialProofYouFollow": "Segui già",
   "socialProofFollowerCount": "{count, plural, =1{{formattedCount} follower} other{{formattedCount} follower}}",
   "searchUserVideoCount": "{count, plural, =1{{formattedCount} video} other{{formattedCount} video}}"
 }

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -5217,5 +5217,10 @@
   "changeEmailSentTitle": "Due link sono in arrivo",
   "changeEmailSentMessage": "Conferma da {email} e dall'indirizzo del tuo account. L'e-mail cambia quando hai fatto entrambi.",
   "changeEmailSentExpiry": "I link scadono dopo 24 ore.",
-  "changeEmailSentDone": "Ok, capito"
+  "changeEmailSentDone": "Ok, capito",
+  "socialProofMutual": "Reciproco",
+  "socialProofFollowsYou": "Ti segue",
+  "socialProofYouFollow": "Segui",
+  "socialProofFollowerCount": "{count, plural, =1{{formattedCount} follower} other{{formattedCount} follower}}",
+  "searchUserVideoCount": "{count, plural, =1{{formattedCount} video} other{{formattedCount} video}}"
 }

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -5217,5 +5217,10 @@
   "changeEmailSentTitle": "確認リンクを2通送りました",
   "changeEmailSentMessage": "{email} と、アカウントに登録中のアドレスの両方で確認してください。両方が終わるとメールアドレスが切り替わります。",
   "changeEmailSentExpiry": "リンクは24時間で使えなくなります。",
-  "changeEmailSentDone": "わかりました"
+  "changeEmailSentDone": "わかりました",
+  "socialProofMutual": "相互フォロー",
+  "socialProofFollowsYou": "フォローされています",
+  "socialProofYouFollow": "フォロー中",
+  "socialProofFollowerCount": "{count, plural, other{フォロワー{formattedCount}人}}",
+  "searchUserVideoCount": "{count, plural, other{{formattedCount}本の動画}}"
 }

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -4555,5 +4555,10 @@
   "changeEmailSentTitle": "링크 두 통을 보냈어요",
   "changeEmailSentMessage": "{email}과 계정에 등록된 주소에서 확인해 주세요. 둘 다 끝나면 이메일이 바뀝니다.",
   "changeEmailSentExpiry": "링크는 24시간 뒤에 만료돼요.",
-  "changeEmailSentDone": "알겠어요"
+  "changeEmailSentDone": "알겠어요",
+  "socialProofMutual": "맞팔로우",
+  "socialProofFollowsYou": "나를 팔로우함",
+  "socialProofYouFollow": "팔로우 중",
+  "socialProofFollowerCount": "{count, plural, other{팔로워 {formattedCount}명}}",
+  "searchUserVideoCount": "{count, plural, other{영상 {formattedCount}개}}"
 }

--- a/mobile/lib/l10n/app_ms.arb
+++ b/mobile/lib/l10n/app_ms.arb
@@ -7047,5 +7047,10 @@
   "changeEmailSentTitle": "Dua pautan dalam perjalanan",
   "changeEmailSentMessage": "Sahkan dari {email} dan dari alamat dalam akaun anda. E-mel anda bertukar sebaik kedua-duanya selesai.",
   "changeEmailSentExpiry": "Pautan tamat selepas 24 jam.",
-  "changeEmailSentDone": "Faham"
+  "changeEmailSentDone": "Faham",
+  "socialProofMutual": "Saling mengikuti",
+  "socialProofFollowsYou": "Mengikuti anda",
+  "socialProofYouFollow": "Anda ikuti",
+  "socialProofFollowerCount": "{count, plural, other{{formattedCount} pengikut}}",
+  "searchUserVideoCount": "{count, plural, other{{formattedCount} video}}"
 }

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -5217,5 +5217,10 @@
   "changeEmailSentTitle": "Er zijn twee links onderweg",
   "changeEmailSentMessage": "Bevestig vanaf {email} en vanaf het adres op je account. Je e-mail wisselt zodra beide gedaan zijn.",
   "changeEmailSentExpiry": "De links werken 24 uur.",
-  "changeEmailSentDone": "Duidelijk"
+  "changeEmailSentDone": "Duidelijk",
+  "socialProofMutual": "Wederzijds",
+  "socialProofFollowsYou": "Volgt jou",
+  "socialProofYouFollow": "Jij volgt",
+  "socialProofFollowerCount": "{count, plural, =1{{formattedCount} volger} other{{formattedCount} volgers}}",
+  "searchUserVideoCount": "{count, plural, =1{{formattedCount} video} other{{formattedCount} video''s}}"
 }

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -5217,5 +5217,10 @@
   "changeEmailSentTitle": "Dwa linki są w drodze",
   "changeEmailSentMessage": "Potwierdź z {email} i z adresu na twoim koncie. E-mail zmieni się, gdy zrobisz oba.",
   "changeEmailSentExpiry": "Linki przestają działać po 24 godzinach.",
-  "changeEmailSentDone": "Jasne"
+  "changeEmailSentDone": "Jasne",
+  "socialProofMutual": "Obserwujecie się",
+  "socialProofFollowsYou": "Obserwuje Cię",
+  "socialProofYouFollow": "Obserwujesz",
+  "socialProofFollowerCount": "{count, plural, =1{{formattedCount} obserwujący} few{{formattedCount} obserwujących} many{{formattedCount} obserwujących} other{{formattedCount} obserwujących}}",
+  "searchUserVideoCount": "{count, plural, =1{{formattedCount} film} few{{formattedCount} filmy} many{{formattedCount} filmów} other{{formattedCount} filmu}}"
 }

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -5217,5 +5217,10 @@
   "changeEmailSentTitle": "Dois links estão a caminho",
   "changeEmailSentMessage": "Confirme em {email} e no endereço da sua conta. Seu e-mail muda quando os dois estiverem prontos.",
   "changeEmailSentExpiry": "Os links expiram em 24 horas.",
-  "changeEmailSentDone": "Entendi"
+  "changeEmailSentDone": "Entendi",
+  "socialProofMutual": "Mútuo",
+  "socialProofFollowsYou": "Segue você",
+  "socialProofYouFollow": "Você segue",
+  "socialProofFollowerCount": "{count, plural, =1{{formattedCount} seguidor} other{{formattedCount} seguidores}}",
+  "searchUserVideoCount": "{count, plural, =1{{formattedCount} vídeo} other{{formattedCount} vídeos}}"
 }

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -5217,5 +5217,10 @@
   "changeEmailSentTitle": "Două linkuri sunt pe drum",
   "changeEmailSentMessage": "Confirmă din {email} și din adresa contului tău. E-mailul se schimbă după ce le faci pe amândouă.",
   "changeEmailSentExpiry": "Linkurile expiră după 24 de ore.",
-  "changeEmailSentDone": "Am înțeles"
+  "changeEmailSentDone": "Am înțeles",
+  "socialProofMutual": "Reciproc",
+  "socialProofFollowsYou": "Te urmărește",
+  "socialProofYouFollow": "Urmărești",
+  "socialProofFollowerCount": "{count, plural, =1{{formattedCount} urmăritor} other{{formattedCount} urmăritori}}",
+  "searchUserVideoCount": "{count, plural, =1{{formattedCount} videoclip} other{{formattedCount} videoclipuri}}"
 }

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -5217,5 +5217,10 @@
   "changeEmailSentTitle": "Två länkar är på väg",
   "changeEmailSentMessage": "Bekräfta från {email} och från adressen på ditt konto. E-posten byts när båda är klara.",
   "changeEmailSentExpiry": "Länkarna slutar fungera efter 24 timmar.",
-  "changeEmailSentDone": "Okej"
+  "changeEmailSentDone": "Okej",
+  "socialProofMutual": "Ömsesidigt",
+  "socialProofFollowsYou": "Följer dig",
+  "socialProofYouFollow": "Du följer",
+  "socialProofFollowerCount": "{count, plural, =1{{formattedCount} följare} other{{formattedCount} följare}}",
+  "searchUserVideoCount": "{count, plural, =1{{formattedCount} video} other{{formattedCount} videor}}"
 }

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -5217,5 +5217,10 @@
   "changeEmailSentTitle": "İki bağlantı yolda",
   "changeEmailSentMessage": "{email} adresinden ve hesabındaki adresten onayla. İkisi de bitince e-postan değişir.",
   "changeEmailSentExpiry": "Bağlantılar 24 saat sonra geçersiz olur.",
-  "changeEmailSentDone": "Anladım"
+  "changeEmailSentDone": "Anladım",
+  "socialProofMutual": "Karşılıklı",
+  "socialProofFollowsYou": "Seni takip ediyor",
+  "socialProofYouFollow": "Takip ediyorsun",
+  "socialProofFollowerCount": "{count, plural, other{{formattedCount} takipçi}}",
+  "searchUserVideoCount": "{count, plural, other{{formattedCount} video}}"
 }

--- a/mobile/lib/l10n/app_ur.arb
+++ b/mobile/lib/l10n/app_ur.arb
@@ -7047,5 +7047,10 @@
   "changeEmailSentTitle": "دو لنک بھیج دیے گئے ہیں",
   "changeEmailSentMessage": "{email} سے اور اپنے اکاؤنٹ والے پتے سے تصدیق کریں۔ دونوں مکمل ہونے پر ای میل بدل جائے گی۔",
   "changeEmailSentExpiry": "لنک 24 گھنٹے بعد کام کرنا بند کر دیتے ہیں۔",
-  "changeEmailSentDone": "سمجھ گیا"
+  "changeEmailSentDone": "سمجھ گیا",
+  "socialProofMutual": "باہمی",
+  "socialProofFollowsYou": "آپ کو فالو کرتا ہے",
+  "socialProofYouFollow": "آپ فالو کرتے ہیں",
+  "socialProofFollowerCount": "{count, plural, =1{{formattedCount} فالوور} other{{formattedCount} فالوورز}}",
+  "searchUserVideoCount": "{count, plural, =1{{formattedCount} ویڈیو} other{{formattedCount} ویڈیوز}}"
 }

--- a/mobile/lib/l10n/app_vi.arb
+++ b/mobile/lib/l10n/app_vi.arb
@@ -7047,5 +7047,10 @@
   "changeEmailSentTitle": "Hai liên kết đang trên đường tới",
   "changeEmailSentMessage": "Xác nhận từ {email} và từ địa chỉ trong tài khoản của bạn. Email đổi khi xong cả hai.",
   "changeEmailSentExpiry": "Liên kết hết hạn sau 24 giờ.",
-  "changeEmailSentDone": "Đã hiểu"
+  "changeEmailSentDone": "Đã hiểu",
+  "socialProofMutual": "Theo dõi lẫn nhau",
+  "socialProofFollowsYou": "Đang theo dõi bạn",
+  "socialProofYouFollow": "Bạn đang theo dõi",
+  "socialProofFollowerCount": "{count, plural, other{{formattedCount} người theo dõi}}",
+  "searchUserVideoCount": "{count, plural, other{{formattedCount} video}}"
 }

--- a/mobile/lib/l10n/app_zh.arb
+++ b/mobile/lib/l10n/app_zh.arb
@@ -7047,5 +7047,10 @@
   "changeEmailSentTitle": "两封确认邮件已在路上",
   "changeEmailSentMessage": "请在 {email} 和账号上的地址两边都确认。两边都完成后邮箱就会切换。",
   "changeEmailSentExpiry": "链接 24 小时后失效。",
-  "changeEmailSentDone": "知道了"
+  "changeEmailSentDone": "知道了",
+  "socialProofMutual": "互相关注",
+  "socialProofFollowsYou": "关注了你",
+  "socialProofYouFollow": "已关注",
+  "socialProofFollowerCount": "{count, plural, other{{formattedCount} 位粉丝}}",
+  "searchUserVideoCount": "{count, plural, other{{formattedCount} 条视频}}"
 }

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -20655,6 +20655,30 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'{count, plural, =1{{formattedCount} video} other{{formattedCount} videos}}'**
   String searchUserVideoCount(int count, String formattedCount);
+
+  /// Secondary line on a user row: the viewer and this account follow each other. Shown in place of a truncated npub, which cannot tell two same-named people apart.
+  ///
+  /// In en, this message translates to:
+  /// **'Mutual'**
+  String get socialProofMutual;
+
+  /// Secondary line on a user row: this account follows the viewer, who does not follow back.
+  ///
+  /// In en, this message translates to:
+  /// **'Follows you'**
+  String get socialProofFollowsYou;
+
+  /// Secondary line on a user row: the viewer follows this account, which does not follow back.
+  ///
+  /// In en, this message translates to:
+  /// **'You follow'**
+  String get socialProofYouFollow;
+
+  /// Secondary line on a user row: how many followers this account has. Joined to the relationship label with a middot.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{{formattedCount} follower} other{{formattedCount} followers}}'**
+  String socialProofFollowerCount(int count, String formattedCount);
 }
 
 class _AppLocalizationsDelegate

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -11817,28 +11817,28 @@ class AppLocalizationsAm extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$formattedCount videos',
-      one: '$formattedCount video',
+      other: '$formattedCount ቪዲዮዎች',
+      one: '$formattedCount ቪዲዮ',
     );
     return '$_temp0';
   }
 
   @override
-  String get socialProofMutual => 'Mutual';
+  String get socialProofMutual => 'እርስ በርስ';
 
   @override
-  String get socialProofFollowsYou => 'Follows you';
+  String get socialProofFollowsYou => 'ይከተልዎታል';
 
   @override
-  String get socialProofYouFollow => 'You follow';
+  String get socialProofYouFollow => 'ይከተላሉ';
 
   @override
   String socialProofFollowerCount(int count, String formattedCount) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$formattedCount followers',
-      one: '$formattedCount follower',
+      other: '$formattedCount ተከታዮች',
+      one: '$formattedCount ተከታይ',
     );
     return '$_temp0';
   }

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -11822,4 +11822,24 @@ class AppLocalizationsAm extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get socialProofMutual => 'Mutual';
+
+  @override
+  String get socialProofFollowsYou => 'Follows you';
+
+  @override
+  String get socialProofYouFollow => 'You follow';
+
+  @override
+  String socialProofFollowerCount(int count, String formattedCount) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$formattedCount followers',
+      one: '$formattedCount follower',
+    );
+    return '$_temp0';
+  }
 }

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -12040,28 +12040,28 @@ class AppLocalizationsAr extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$formattedCount videos',
-      one: '$formattedCount video',
+      other: '$formattedCount فيديو',
+      one: '$formattedCount فيديو',
     );
     return '$_temp0';
   }
 
   @override
-  String get socialProofMutual => 'Mutual';
+  String get socialProofMutual => 'متابعة متبادلة';
 
   @override
-  String get socialProofFollowsYou => 'Follows you';
+  String get socialProofFollowsYou => 'يتابعك';
 
   @override
-  String get socialProofYouFollow => 'You follow';
+  String get socialProofYouFollow => 'تتابعه';
 
   @override
   String socialProofFollowerCount(int count, String formattedCount) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$formattedCount followers',
-      one: '$formattedCount follower',
+      other: '$formattedCount متابِع',
+      one: '$formattedCount متابِع',
     );
     return '$_temp0';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -12045,4 +12045,24 @@ class AppLocalizationsAr extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get socialProofMutual => 'Mutual';
+
+  @override
+  String get socialProofFollowsYou => 'Follows you';
+
+  @override
+  String get socialProofYouFollow => 'You follow';
+
+  @override
+  String socialProofFollowerCount(int count, String formattedCount) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$formattedCount followers',
+      one: '$formattedCount follower',
+    );
+    return '$_temp0';
+  }
 }

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -12257,4 +12257,24 @@ class AppLocalizationsBg extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get socialProofMutual => 'Mutual';
+
+  @override
+  String get socialProofFollowsYou => 'Follows you';
+
+  @override
+  String get socialProofYouFollow => 'You follow';
+
+  @override
+  String socialProofFollowerCount(int count, String formattedCount) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$formattedCount followers',
+      one: '$formattedCount follower',
+    );
+    return '$_temp0';
+  }
 }

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -12252,28 +12252,28 @@ class AppLocalizationsBg extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$formattedCount videos',
-      one: '$formattedCount video',
+      other: '$formattedCount видеа',
+      one: '$formattedCount видео',
     );
     return '$_temp0';
   }
 
   @override
-  String get socialProofMutual => 'Mutual';
+  String get socialProofMutual => 'Взаимно';
 
   @override
-  String get socialProofFollowsYou => 'Follows you';
+  String get socialProofFollowsYou => 'Следва те';
 
   @override
-  String get socialProofYouFollow => 'You follow';
+  String get socialProofYouFollow => 'Следваш';
 
   @override
   String socialProofFollowerCount(int count, String formattedCount) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$formattedCount followers',
-      one: '$formattedCount follower',
+      other: '$formattedCount последователи',
+      one: '$formattedCount последовател',
     );
     return '$_temp0';
   }

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -12286,28 +12286,28 @@ class AppLocalizationsDe extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$formattedCount videos',
-      one: '$formattedCount video',
+      other: '$formattedCount Videos',
+      one: '$formattedCount Video',
     );
     return '$_temp0';
   }
 
   @override
-  String get socialProofMutual => 'Mutual';
+  String get socialProofMutual => 'Gegenseitig';
 
   @override
-  String get socialProofFollowsYou => 'Follows you';
+  String get socialProofFollowsYou => 'Folgt dir';
 
   @override
-  String get socialProofYouFollow => 'You follow';
+  String get socialProofYouFollow => 'Du folgst';
 
   @override
   String socialProofFollowerCount(int count, String formattedCount) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$formattedCount followers',
-      one: '$formattedCount follower',
+      other: '$formattedCount Follower',
+      one: '$formattedCount Follower',
     );
     return '$_temp0';
   }

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -12291,4 +12291,24 @@ class AppLocalizationsDe extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get socialProofMutual => 'Mutual';
+
+  @override
+  String get socialProofFollowsYou => 'Follows you';
+
+  @override
+  String get socialProofYouFollow => 'You follow';
+
+  @override
+  String socialProofFollowerCount(int count, String formattedCount) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$formattedCount followers',
+      one: '$formattedCount follower',
+    );
+    return '$_temp0';
+  }
 }

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -12087,4 +12087,24 @@ class AppLocalizationsEn extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get socialProofMutual => 'Mutual';
+
+  @override
+  String get socialProofFollowsYou => 'Follows you';
+
+  @override
+  String get socialProofYouFollow => 'You follow';
+
+  @override
+  String socialProofFollowerCount(int count, String formattedCount) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$formattedCount followers',
+      one: '$formattedCount follower',
+    );
+    return '$_temp0';
+  }
 }

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -12271,4 +12271,24 @@ class AppLocalizationsEs extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get socialProofMutual => 'Mutual';
+
+  @override
+  String get socialProofFollowsYou => 'Follows you';
+
+  @override
+  String get socialProofYouFollow => 'You follow';
+
+  @override
+  String socialProofFollowerCount(int count, String formattedCount) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$formattedCount followers',
+      one: '$formattedCount follower',
+    );
+    return '$_temp0';
+  }
 }

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -12273,21 +12273,21 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get socialProofMutual => 'Mutual';
+  String get socialProofMutual => 'Mutuo';
 
   @override
-  String get socialProofFollowsYou => 'Follows you';
+  String get socialProofFollowsYou => 'Te sigue';
 
   @override
-  String get socialProofYouFollow => 'You follow';
+  String get socialProofYouFollow => 'Siguiendo';
 
   @override
   String socialProofFollowerCount(int count, String formattedCount) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$formattedCount followers',
-      one: '$formattedCount follower',
+      other: '$formattedCount seguidores',
+      one: '$formattedCount seguidor',
     );
     return '$_temp0';
   }

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -12290,4 +12290,24 @@ class AppLocalizationsFil extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get socialProofMutual => 'Mutual';
+
+  @override
+  String get socialProofFollowsYou => 'Follows you';
+
+  @override
+  String get socialProofYouFollow => 'You follow';
+
+  @override
+  String socialProofFollowerCount(int count, String formattedCount) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$formattedCount followers',
+      one: '$formattedCount follower',
+    );
+    return '$_temp0';
+  }
 }

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -12285,7 +12285,7 @@ class AppLocalizationsFil extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$formattedCount videos',
+      other: '$formattedCount video',
       one: '$formattedCount video',
     );
     return '$_temp0';
@@ -12295,17 +12295,17 @@ class AppLocalizationsFil extends AppLocalizations {
   String get socialProofMutual => 'Mutual';
 
   @override
-  String get socialProofFollowsYou => 'Follows you';
+  String get socialProofFollowsYou => 'Sinusundan ka';
 
   @override
-  String get socialProofYouFollow => 'You follow';
+  String get socialProofYouFollow => 'Sinusundan mo';
 
   @override
   String socialProofFollowerCount(int count, String formattedCount) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$formattedCount followers',
+      other: '$formattedCount follower',
       one: '$formattedCount follower',
     );
     return '$_temp0';

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -12319,4 +12319,24 @@ class AppLocalizationsFr extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get socialProofMutual => 'Mutual';
+
+  @override
+  String get socialProofFollowsYou => 'Follows you';
+
+  @override
+  String get socialProofYouFollow => 'You follow';
+
+  @override
+  String socialProofFollowerCount(int count, String formattedCount) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$formattedCount followers',
+      one: '$formattedCount follower',
+    );
+    return '$_temp0';
+  }
 }

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -12314,28 +12314,28 @@ class AppLocalizationsFr extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$formattedCount videos',
-      one: '$formattedCount video',
+      other: '$formattedCount vidéos',
+      one: '$formattedCount vidéo',
     );
     return '$_temp0';
   }
 
   @override
-  String get socialProofMutual => 'Mutual';
+  String get socialProofMutual => 'Mutuel';
 
   @override
-  String get socialProofFollowsYou => 'Follows you';
+  String get socialProofFollowsYou => 'Vous suit';
 
   @override
-  String get socialProofYouFollow => 'You follow';
+  String get socialProofYouFollow => 'Vous suivez';
 
   @override
   String socialProofFollowerCount(int count, String formattedCount) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$formattedCount followers',
-      one: '$formattedCount follower',
+      other: '$formattedCount abonnés',
+      one: '$formattedCount abonné',
     );
     return '$_temp0';
   }

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -12324,10 +12324,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get socialProofMutual => 'Mutuel';
 
   @override
-  String get socialProofFollowsYou => 'Vous suit';
+  String get socialProofFollowsYou => 'Te suit';
 
   @override
-  String get socialProofYouFollow => 'Vous suivez';
+  String get socialProofYouFollow => 'Tu suis';
 
   @override
   String socialProofFollowerCount(int count, String formattedCount) {

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -12080,28 +12080,26 @@ class AppLocalizationsId extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$formattedCount videos',
-      one: '$formattedCount video',
+      other: '$formattedCount video',
     );
     return '$_temp0';
   }
 
   @override
-  String get socialProofMutual => 'Mutual';
+  String get socialProofMutual => 'Saling mengikuti';
 
   @override
-  String get socialProofFollowsYou => 'Follows you';
+  String get socialProofFollowsYou => 'Mengikuti kamu';
 
   @override
-  String get socialProofYouFollow => 'You follow';
+  String get socialProofYouFollow => 'Kamu ikuti';
 
   @override
   String socialProofFollowerCount(int count, String formattedCount) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$formattedCount followers',
-      one: '$formattedCount follower',
+      other: '$formattedCount pengikut',
     );
     return '$_temp0';
   }

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -12085,4 +12085,24 @@ class AppLocalizationsId extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get socialProofMutual => 'Mutual';
+
+  @override
+  String get socialProofFollowsYou => 'Follows you';
+
+  @override
+  String get socialProofYouFollow => 'You follow';
+
+  @override
+  String socialProofFollowerCount(int count, String formattedCount) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$formattedCount followers',
+      one: '$formattedCount follower',
+    );
+    return '$_temp0';
+  }
 }

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -12278,27 +12278,27 @@ class AppLocalizationsIt extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$formattedCount videos',
+      other: '$formattedCount video',
       one: '$formattedCount video',
     );
     return '$_temp0';
   }
 
   @override
-  String get socialProofMutual => 'Mutual';
+  String get socialProofMutual => 'Reciproco';
 
   @override
-  String get socialProofFollowsYou => 'Follows you';
+  String get socialProofFollowsYou => 'Ti segue';
 
   @override
-  String get socialProofYouFollow => 'You follow';
+  String get socialProofYouFollow => 'Segui';
 
   @override
   String socialProofFollowerCount(int count, String formattedCount) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$formattedCount followers',
+      other: '$formattedCount follower',
       one: '$formattedCount follower',
     );
     return '$_temp0';

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -12291,7 +12291,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get socialProofFollowsYou => 'Ti segue';
 
   @override
-  String get socialProofYouFollow => 'Segui';
+  String get socialProofYouFollow => 'Segui già';
 
   @override
   String socialProofFollowerCount(int count, String formattedCount) {

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -12283,4 +12283,24 @@ class AppLocalizationsIt extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get socialProofMutual => 'Mutual';
+
+  @override
+  String get socialProofFollowsYou => 'Follows you';
+
+  @override
+  String get socialProofYouFollow => 'You follow';
+
+  @override
+  String socialProofFollowerCount(int count, String formattedCount) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$formattedCount followers',
+      one: '$formattedCount follower',
+    );
+    return '$_temp0';
+  }
 }

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -11558,28 +11558,26 @@ class AppLocalizationsJa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$formattedCount videos',
-      one: '$formattedCount video',
+      other: '$formattedCount本の動画',
     );
     return '$_temp0';
   }
 
   @override
-  String get socialProofMutual => 'Mutual';
+  String get socialProofMutual => '相互フォロー';
 
   @override
-  String get socialProofFollowsYou => 'Follows you';
+  String get socialProofFollowsYou => 'フォローされています';
 
   @override
-  String get socialProofYouFollow => 'You follow';
+  String get socialProofYouFollow => 'フォロー中';
 
   @override
   String socialProofFollowerCount(int count, String formattedCount) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$formattedCount followers',
-      one: '$formattedCount follower',
+      other: 'フォロワー$formattedCount人',
     );
     return '$_temp0';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -11563,4 +11563,24 @@ class AppLocalizationsJa extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get socialProofMutual => 'Mutual';
+
+  @override
+  String get socialProofFollowsYou => 'Follows you';
+
+  @override
+  String get socialProofYouFollow => 'You follow';
+
+  @override
+  String socialProofFollowerCount(int count, String formattedCount) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$formattedCount followers',
+      one: '$formattedCount follower',
+    );
+    return '$_temp0';
+  }
 }

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -11588,4 +11588,24 @@ class AppLocalizationsKo extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get socialProofMutual => 'Mutual';
+
+  @override
+  String get socialProofFollowsYou => 'Follows you';
+
+  @override
+  String get socialProofYouFollow => 'You follow';
+
+  @override
+  String socialProofFollowerCount(int count, String formattedCount) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$formattedCount followers',
+      one: '$formattedCount follower',
+    );
+    return '$_temp0';
+  }
 }

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -11583,28 +11583,26 @@ class AppLocalizationsKo extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$formattedCount videos',
-      one: '$formattedCount video',
+      other: '영상 $formattedCount개',
     );
     return '$_temp0';
   }
 
   @override
-  String get socialProofMutual => 'Mutual';
+  String get socialProofMutual => '맞팔로우';
 
   @override
-  String get socialProofFollowsYou => 'Follows you';
+  String get socialProofFollowsYou => '나를 팔로우함';
 
   @override
-  String get socialProofYouFollow => 'You follow';
+  String get socialProofYouFollow => '팔로우 중';
 
   @override
   String socialProofFollowerCount(int count, String formattedCount) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$formattedCount followers',
-      one: '$formattedCount follower',
+      other: '팔로워 $formattedCount명',
     );
     return '$_temp0';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -12183,4 +12183,24 @@ class AppLocalizationsMs extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get socialProofMutual => 'Mutual';
+
+  @override
+  String get socialProofFollowsYou => 'Follows you';
+
+  @override
+  String get socialProofYouFollow => 'You follow';
+
+  @override
+  String socialProofFollowerCount(int count, String formattedCount) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$formattedCount followers',
+      one: '$formattedCount follower',
+    );
+    return '$_temp0';
+  }
 }

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -12178,28 +12178,26 @@ class AppLocalizationsMs extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$formattedCount videos',
-      one: '$formattedCount video',
+      other: '$formattedCount video',
     );
     return '$_temp0';
   }
 
   @override
-  String get socialProofMutual => 'Mutual';
+  String get socialProofMutual => 'Saling mengikuti';
 
   @override
-  String get socialProofFollowsYou => 'Follows you';
+  String get socialProofFollowsYou => 'Mengikuti anda';
 
   @override
-  String get socialProofYouFollow => 'You follow';
+  String get socialProofYouFollow => 'Anda ikuti';
 
   @override
   String socialProofFollowerCount(int count, String formattedCount) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$formattedCount followers',
-      one: '$formattedCount follower',
+      other: '$formattedCount pengikut',
     );
     return '$_temp0';
   }

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -12201,4 +12201,24 @@ class AppLocalizationsNl extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get socialProofMutual => 'Mutual';
+
+  @override
+  String get socialProofFollowsYou => 'Follows you';
+
+  @override
+  String get socialProofYouFollow => 'You follow';
+
+  @override
+  String socialProofFollowerCount(int count, String formattedCount) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$formattedCount followers',
+      one: '$formattedCount follower',
+    );
+    return '$_temp0';
+  }
 }

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -12196,28 +12196,28 @@ class AppLocalizationsNl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$formattedCount videos',
+      other: '$formattedCount video\'\'s',
       one: '$formattedCount video',
     );
     return '$_temp0';
   }
 
   @override
-  String get socialProofMutual => 'Mutual';
+  String get socialProofMutual => 'Wederzijds';
 
   @override
-  String get socialProofFollowsYou => 'Follows you';
+  String get socialProofFollowsYou => 'Volgt jou';
 
   @override
-  String get socialProofYouFollow => 'You follow';
+  String get socialProofYouFollow => 'Jij volgt';
 
   @override
   String socialProofFollowerCount(int count, String formattedCount) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$formattedCount followers',
-      one: '$formattedCount follower',
+      other: '$formattedCount volgers',
+      one: '$formattedCount volger',
     );
     return '$_temp0';
   }

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -12369,28 +12369,32 @@ class AppLocalizationsPl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$formattedCount videos',
-      one: '$formattedCount video',
+      other: '$formattedCount filmu',
+      many: '$formattedCount filmów',
+      few: '$formattedCount filmy',
+      one: '$formattedCount film',
     );
     return '$_temp0';
   }
 
   @override
-  String get socialProofMutual => 'Mutual';
+  String get socialProofMutual => 'Obserwujecie się';
 
   @override
-  String get socialProofFollowsYou => 'Follows you';
+  String get socialProofFollowsYou => 'Obserwuje Cię';
 
   @override
-  String get socialProofYouFollow => 'You follow';
+  String get socialProofYouFollow => 'Obserwujesz';
 
   @override
   String socialProofFollowerCount(int count, String formattedCount) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$formattedCount followers',
-      one: '$formattedCount follower',
+      other: '$formattedCount obserwujących',
+      many: '$formattedCount obserwujących',
+      few: '$formattedCount obserwujących',
+      one: '$formattedCount obserwujący',
     );
     return '$_temp0';
   }

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -12374,4 +12374,24 @@ class AppLocalizationsPl extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get socialProofMutual => 'Mutual';
+
+  @override
+  String get socialProofFollowsYou => 'Follows you';
+
+  @override
+  String get socialProofYouFollow => 'You follow';
+
+  @override
+  String socialProofFollowerCount(int count, String formattedCount) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$formattedCount followers',
+      one: '$formattedCount follower',
+    );
+    return '$_temp0';
+  }
 }

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -12230,4 +12230,24 @@ class AppLocalizationsPt extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get socialProofMutual => 'Mutual';
+
+  @override
+  String get socialProofFollowsYou => 'Follows you';
+
+  @override
+  String get socialProofYouFollow => 'You follow';
+
+  @override
+  String socialProofFollowerCount(int count, String formattedCount) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$formattedCount followers',
+      one: '$formattedCount follower',
+    );
+    return '$_temp0';
+  }
 }

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -12225,28 +12225,28 @@ class AppLocalizationsPt extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$formattedCount videos',
-      one: '$formattedCount video',
+      other: '$formattedCount vídeos',
+      one: '$formattedCount vídeo',
     );
     return '$_temp0';
   }
 
   @override
-  String get socialProofMutual => 'Mutual';
+  String get socialProofMutual => 'Mútuo';
 
   @override
-  String get socialProofFollowsYou => 'Follows you';
+  String get socialProofFollowsYou => 'Segue você';
 
   @override
-  String get socialProofYouFollow => 'You follow';
+  String get socialProofYouFollow => 'Você segue';
 
   @override
   String socialProofFollowerCount(int count, String formattedCount) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$formattedCount followers',
-      one: '$formattedCount follower',
+      other: '$formattedCount seguidores',
+      one: '$formattedCount seguidor',
     );
     return '$_temp0';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -12387,4 +12387,24 @@ class AppLocalizationsRo extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get socialProofMutual => 'Mutual';
+
+  @override
+  String get socialProofFollowsYou => 'Follows you';
+
+  @override
+  String get socialProofYouFollow => 'You follow';
+
+  @override
+  String socialProofFollowerCount(int count, String formattedCount) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$formattedCount followers',
+      one: '$formattedCount follower',
+    );
+    return '$_temp0';
+  }
 }

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -12382,28 +12382,28 @@ class AppLocalizationsRo extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$formattedCount videos',
-      one: '$formattedCount video',
+      other: '$formattedCount videoclipuri',
+      one: '$formattedCount videoclip',
     );
     return '$_temp0';
   }
 
   @override
-  String get socialProofMutual => 'Mutual';
+  String get socialProofMutual => 'Reciproc';
 
   @override
-  String get socialProofFollowsYou => 'Follows you';
+  String get socialProofFollowsYou => 'Te urmărește';
 
   @override
-  String get socialProofYouFollow => 'You follow';
+  String get socialProofYouFollow => 'Urmărești';
 
   @override
   String socialProofFollowerCount(int count, String formattedCount) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$formattedCount followers',
-      one: '$formattedCount follower',
+      other: '$formattedCount urmăritori',
+      one: '$formattedCount urmăritor',
     );
     return '$_temp0';
   }

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -12134,28 +12134,28 @@ class AppLocalizationsSv extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$formattedCount videos',
+      other: '$formattedCount videor',
       one: '$formattedCount video',
     );
     return '$_temp0';
   }
 
   @override
-  String get socialProofMutual => 'Mutual';
+  String get socialProofMutual => 'Ömsesidigt';
 
   @override
-  String get socialProofFollowsYou => 'Follows you';
+  String get socialProofFollowsYou => 'Följer dig';
 
   @override
-  String get socialProofYouFollow => 'You follow';
+  String get socialProofYouFollow => 'Du följer';
 
   @override
   String socialProofFollowerCount(int count, String formattedCount) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$formattedCount followers',
-      one: '$formattedCount follower',
+      other: '$formattedCount följare',
+      one: '$formattedCount följare',
     );
     return '$_temp0';
   }

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -12139,4 +12139,24 @@ class AppLocalizationsSv extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get socialProofMutual => 'Mutual';
+
+  @override
+  String get socialProofFollowsYou => 'Follows you';
+
+  @override
+  String get socialProofYouFollow => 'You follow';
+
+  @override
+  String socialProofFollowerCount(int count, String formattedCount) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$formattedCount followers',
+      one: '$formattedCount follower',
+    );
+    return '$_temp0';
+  }
 }

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -12095,28 +12095,26 @@ class AppLocalizationsTr extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$formattedCount videos',
-      one: '$formattedCount video',
+      other: '$formattedCount video',
     );
     return '$_temp0';
   }
 
   @override
-  String get socialProofMutual => 'Mutual';
+  String get socialProofMutual => 'Karşılıklı';
 
   @override
-  String get socialProofFollowsYou => 'Follows you';
+  String get socialProofFollowsYou => 'Seni takip ediyor';
 
   @override
-  String get socialProofYouFollow => 'You follow';
+  String get socialProofYouFollow => 'Takip ediyorsun';
 
   @override
   String socialProofFollowerCount(int count, String formattedCount) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$formattedCount followers',
-      one: '$formattedCount follower',
+      other: '$formattedCount takipçi',
     );
     return '$_temp0';
   }

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -12100,4 +12100,24 @@ class AppLocalizationsTr extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get socialProofMutual => 'Mutual';
+
+  @override
+  String get socialProofFollowsYou => 'Follows you';
+
+  @override
+  String get socialProofYouFollow => 'You follow';
+
+  @override
+  String socialProofFollowerCount(int count, String formattedCount) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$formattedCount followers',
+      one: '$formattedCount follower',
+    );
+    return '$_temp0';
+  }
 }

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -12126,4 +12126,24 @@ class AppLocalizationsUr extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get socialProofMutual => 'Mutual';
+
+  @override
+  String get socialProofFollowsYou => 'Follows you';
+
+  @override
+  String get socialProofYouFollow => 'You follow';
+
+  @override
+  String socialProofFollowerCount(int count, String formattedCount) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$formattedCount followers',
+      one: '$formattedCount follower',
+    );
+    return '$_temp0';
+  }
 }

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -12121,28 +12121,28 @@ class AppLocalizationsUr extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$formattedCount videos',
-      one: '$formattedCount video',
+      other: '$formattedCount ویڈیوز',
+      one: '$formattedCount ویڈیو',
     );
     return '$_temp0';
   }
 
   @override
-  String get socialProofMutual => 'Mutual';
+  String get socialProofMutual => 'باہمی';
 
   @override
-  String get socialProofFollowsYou => 'Follows you';
+  String get socialProofFollowsYou => 'آپ کو فالو کرتا ہے';
 
   @override
-  String get socialProofYouFollow => 'You follow';
+  String get socialProofYouFollow => 'آپ فالو کرتے ہیں';
 
   @override
   String socialProofFollowerCount(int count, String formattedCount) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$formattedCount followers',
-      one: '$formattedCount follower',
+      other: '$formattedCount فالوورز',
+      one: '$formattedCount فالوور',
     );
     return '$_temp0';
   }

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -12118,28 +12118,26 @@ class AppLocalizationsVi extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$formattedCount videos',
-      one: '$formattedCount video',
+      other: '$formattedCount video',
     );
     return '$_temp0';
   }
 
   @override
-  String get socialProofMutual => 'Mutual';
+  String get socialProofMutual => 'Theo dõi lẫn nhau';
 
   @override
-  String get socialProofFollowsYou => 'Follows you';
+  String get socialProofFollowsYou => 'Đang theo dõi bạn';
 
   @override
-  String get socialProofYouFollow => 'You follow';
+  String get socialProofYouFollow => 'Bạn đang theo dõi';
 
   @override
   String socialProofFollowerCount(int count, String formattedCount) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$formattedCount followers',
-      one: '$formattedCount follower',
+      other: '$formattedCount người theo dõi',
     );
     return '$_temp0';
   }

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -12123,4 +12123,24 @@ class AppLocalizationsVi extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get socialProofMutual => 'Mutual';
+
+  @override
+  String get socialProofFollowsYou => 'Follows you';
+
+  @override
+  String get socialProofYouFollow => 'You follow';
+
+  @override
+  String socialProofFollowerCount(int count, String formattedCount) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$formattedCount followers',
+      one: '$formattedCount follower',
+    );
+    return '$_temp0';
+  }
 }

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -11458,4 +11458,24 @@ class AppLocalizationsZh extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get socialProofMutual => 'Mutual';
+
+  @override
+  String get socialProofFollowsYou => 'Follows you';
+
+  @override
+  String get socialProofYouFollow => 'You follow';
+
+  @override
+  String socialProofFollowerCount(int count, String formattedCount) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$formattedCount followers',
+      one: '$formattedCount follower',
+    );
+    return '$_temp0';
+  }
 }

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -11453,28 +11453,26 @@ class AppLocalizationsZh extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$formattedCount videos',
-      one: '$formattedCount video',
+      other: '$formattedCount 条视频',
     );
     return '$_temp0';
   }
 
   @override
-  String get socialProofMutual => 'Mutual';
+  String get socialProofMutual => '互相关注';
 
   @override
-  String get socialProofFollowsYou => 'Follows you';
+  String get socialProofFollowsYou => '关注了你';
 
   @override
-  String get socialProofYouFollow => 'You follow';
+  String get socialProofYouFollow => '已关注';
 
   @override
   String socialProofFollowerCount(int count, String formattedCount) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$formattedCount followers',
-      one: '$formattedCount follower',
+      other: '$formattedCount 位粉丝',
     );
     return '$_temp0';
   }

--- a/mobile/lib/providers/follow_relationship_provider.dart
+++ b/mobile/lib/providers/follow_relationship_provider.dart
@@ -1,0 +1,47 @@
+// ABOUTME: Reactive per-pubkey follow relationship for user rows
+// ABOUTME: Backs the social-proof identifier line that replaced truncated npubs
+
+import 'package:follow_repository/follow_repository.dart';
+import 'package:openvine/providers/repository_providers.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'follow_relationship_provider.g.dart';
+
+/// Populates the current user's follower cache once per session.
+///
+/// [FollowRepository.relationshipTo] reads that cache but never fills it, and
+/// a user row must not trigger its own fetch — one shared warm-up keeps the
+/// cost at one request per session instead of one per visible row.
+///
+/// Completes with no value on failure: an unreachable relay degrades the
+/// relationship to "unknown", which [FollowRelationship] already models, and
+/// is not worth surfacing on a secondary identifier line.
+@Riverpod(keepAlive: true)
+Future<void> myFollowersWarmup(Ref ref) async {
+  final repository = ref.watch(followRepositoryProvider);
+  try {
+    await repository.getMyFollowers();
+  } on Exception {
+    return;
+  }
+}
+
+/// The current user's follow relationship with [pubkey], kept live.
+///
+/// Re-emits when the current user's following list changes and again when the
+/// follower warm-up lands, so a row that first renders as
+/// [FollowRelationship.youFollow] upgrades to [FollowRelationship.mutual]
+/// without a rebuild of the surrounding list.
+@riverpod
+Stream<FollowRelationship> followRelationship(Ref ref, String pubkey) async* {
+  final repository = ref.watch(followRepositoryProvider);
+
+  // Watched, not read: the loading -> data transition re-runs this body, which
+  // is what promotes a relationship once the follower cache is populated.
+  ref.watch(myFollowersWarmupProvider);
+
+  yield repository.relationshipTo(pubkey);
+  yield* repository.followingStream.map(
+    (_) => repository.relationshipTo(pubkey),
+  );
+}

--- a/mobile/lib/providers/follow_relationship_provider.dart
+++ b/mobile/lib/providers/follow_relationship_provider.dart
@@ -2,6 +2,7 @@
 // ABOUTME: Backs the social-proof identifier line that replaced truncated npubs
 
 import 'package:follow_repository/follow_repository.dart';
+import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/providers/repository_providers.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -18,6 +19,9 @@ part 'follow_relationship_provider.g.dart';
 /// is not worth surfacing on a secondary identifier line.
 @Riverpod(keepAlive: true)
 Future<void> myFollowersWarmup(Ref ref) async {
+  final readiness = ref.watch(nostrSessionProvider);
+  if (!readiness.isReadyForActiveClient) return;
+
   final repository = ref.watch(followRepositoryProvider);
   try {
     await repository.getMyFollowers();

--- a/mobile/lib/providers/follow_relationship_provider.g.dart
+++ b/mobile/lib/providers/follow_relationship_provider.g.dart
@@ -1,0 +1,183 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'follow_relationship_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// Populates the current user's follower cache once per session.
+///
+/// [FollowRepository.relationshipTo] reads that cache but never fills it, and
+/// a user row must not trigger its own fetch — one shared warm-up keeps the
+/// cost at one request per session instead of one per visible row.
+///
+/// Completes with no value on failure: an unreachable relay degrades the
+/// relationship to "unknown", which [FollowRelationship] already models, and
+/// is not worth surfacing on a secondary identifier line.
+
+@ProviderFor(myFollowersWarmup)
+final myFollowersWarmupProvider = MyFollowersWarmupProvider._();
+
+/// Populates the current user's follower cache once per session.
+///
+/// [FollowRepository.relationshipTo] reads that cache but never fills it, and
+/// a user row must not trigger its own fetch — one shared warm-up keeps the
+/// cost at one request per session instead of one per visible row.
+///
+/// Completes with no value on failure: an unreachable relay degrades the
+/// relationship to "unknown", which [FollowRelationship] already models, and
+/// is not worth surfacing on a secondary identifier line.
+
+final class MyFollowersWarmupProvider
+    extends $FunctionalProvider<AsyncValue<void>, void, FutureOr<void>>
+    with $FutureModifier<void>, $FutureProvider<void> {
+  /// Populates the current user's follower cache once per session.
+  ///
+  /// [FollowRepository.relationshipTo] reads that cache but never fills it, and
+  /// a user row must not trigger its own fetch — one shared warm-up keeps the
+  /// cost at one request per session instead of one per visible row.
+  ///
+  /// Completes with no value on failure: an unreachable relay degrades the
+  /// relationship to "unknown", which [FollowRelationship] already models, and
+  /// is not worth surfacing on a secondary identifier line.
+  MyFollowersWarmupProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'myFollowersWarmupProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$myFollowersWarmupHash();
+
+  @$internal
+  @override
+  $FutureProviderElement<void> $createElement($ProviderPointer pointer) =>
+      $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<void> create(Ref ref) {
+    return myFollowersWarmup(ref);
+  }
+}
+
+String _$myFollowersWarmupHash() => r'8b56b34a7e4e51590b2355d89ac76e7931355ad8';
+
+/// The current user's follow relationship with [pubkey], kept live.
+///
+/// Re-emits when the current user's following list changes and again when the
+/// follower warm-up lands, so a row that first renders as
+/// [FollowRelationship.youFollow] upgrades to [FollowRelationship.mutual]
+/// without a rebuild of the surrounding list.
+
+@ProviderFor(followRelationship)
+final followRelationshipProvider = FollowRelationshipFamily._();
+
+/// The current user's follow relationship with [pubkey], kept live.
+///
+/// Re-emits when the current user's following list changes and again when the
+/// follower warm-up lands, so a row that first renders as
+/// [FollowRelationship.youFollow] upgrades to [FollowRelationship.mutual]
+/// without a rebuild of the surrounding list.
+
+final class FollowRelationshipProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<FollowRelationship>,
+          FollowRelationship,
+          Stream<FollowRelationship>
+        >
+    with
+        $FutureModifier<FollowRelationship>,
+        $StreamProvider<FollowRelationship> {
+  /// The current user's follow relationship with [pubkey], kept live.
+  ///
+  /// Re-emits when the current user's following list changes and again when the
+  /// follower warm-up lands, so a row that first renders as
+  /// [FollowRelationship.youFollow] upgrades to [FollowRelationship.mutual]
+  /// without a rebuild of the surrounding list.
+  FollowRelationshipProvider._({
+    required FollowRelationshipFamily super.from,
+    required String super.argument,
+  }) : super(
+         retry: null,
+         name: r'followRelationshipProvider',
+         isAutoDispose: true,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$followRelationshipHash();
+
+  @override
+  String toString() {
+    return r'followRelationshipProvider'
+        ''
+        '($argument)';
+  }
+
+  @$internal
+  @override
+  $StreamProviderElement<FollowRelationship> $createElement(
+    $ProviderPointer pointer,
+  ) => $StreamProviderElement(pointer);
+
+  @override
+  Stream<FollowRelationship> create(Ref ref) {
+    final argument = this.argument as String;
+    return followRelationship(ref, argument);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is FollowRelationshipProvider && other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$followRelationshipHash() =>
+    r'702f16242ad7aa7ef1bfc36c1128a2b6199efad9';
+
+/// The current user's follow relationship with [pubkey], kept live.
+///
+/// Re-emits when the current user's following list changes and again when the
+/// follower warm-up lands, so a row that first renders as
+/// [FollowRelationship.youFollow] upgrades to [FollowRelationship.mutual]
+/// without a rebuild of the surrounding list.
+
+final class FollowRelationshipFamily extends $Family
+    with $FunctionalFamilyOverride<Stream<FollowRelationship>, String> {
+  FollowRelationshipFamily._()
+    : super(
+        retry: null,
+        name: r'followRelationshipProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: true,
+      );
+
+  /// The current user's follow relationship with [pubkey], kept live.
+  ///
+  /// Re-emits when the current user's following list changes and again when the
+  /// follower warm-up lands, so a row that first renders as
+  /// [FollowRelationship.youFollow] upgrades to [FollowRelationship.mutual]
+  /// without a rebuild of the surrounding list.
+
+  FollowRelationshipProvider call(String pubkey) =>
+      FollowRelationshipProvider._(argument: pubkey, from: this);
+
+  @override
+  String toString() => r'followRelationshipProvider';
+}

--- a/mobile/lib/providers/follow_relationship_provider.g.dart
+++ b/mobile/lib/providers/follow_relationship_provider.g.dart
@@ -68,7 +68,7 @@ final class MyFollowersWarmupProvider
   }
 }
 
-String _$myFollowersWarmupHash() => r'8b56b34a7e4e51590b2355d89ac76e7931355ad8';
+String _$myFollowersWarmupHash() => r'544631a238ec616cf74ef8ff475a97020eed7686';
 
 /// The current user's follow relationship with [pubkey], kept live.
 ///

--- a/mobile/lib/screens/inbox/conversation/conversation_view.dart
+++ b/mobile/lib/screens/inbox/conversation/conversation_view.dart
@@ -187,7 +187,7 @@ class _ConversationViewState extends ConsumerState<ConversationView> {
                 relationship:
                     ref.watch(followRelationshipProvider(otherPubkey)).value ??
                     FollowRelationship.none,
-                followerCount: profile?.followerCount,
+                followerCount: profile?.restFollowerCount,
               ) ??
               '';
 

--- a/mobile/lib/screens/inbox/conversation/conversation_view.dart
+++ b/mobile/lib/screens/inbox/conversation/conversation_view.dart
@@ -8,6 +8,8 @@ import 'package:flutter/semantics.dart' show SemanticsService;
 import 'package:flutter/services.dart' show HapticFeedback;
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:follow_repository/follow_repository.dart'
+    show FollowRelationship;
 import 'package:go_router/go_router.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/dm/conversation/conversation_bloc.dart';
@@ -18,6 +20,7 @@ import 'package:openvine/config/official_accounts.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/l10n/localized_time_formatter.dart';
 import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/follow_relationship_provider.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/screens/feed/dm_reply_context.dart';
 import 'package:openvine/screens/inbox/conversation/conversation_page.dart';
@@ -30,10 +33,9 @@ import 'package:openvine/services/collaborator_invite_service.dart';
 import 'package:openvine/utils/clipboard_utils.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:openvine/utils/string_utils.dart';
+import 'package:openvine/utils/user_identifier_line_resolver.dart';
 import 'package:openvine/widgets/profile/more_sheet/more_sheet_content.dart';
 import 'package:openvine/widgets/profile/more_sheet/more_sheet_result.dart';
-import 'package:openvine/widgets/profile/profile_header_widget.dart'
-    show truncateNpubForDisplay;
 import 'package:openvine/widgets/report_content_dialog.dart';
 import 'package:openvine/widgets/save_original_progress_sheet.dart';
 import 'package:openvine/widgets/watermark_download_progress_sheet.dart';
@@ -165,19 +167,21 @@ class _ConversationViewState extends ConsumerState<ConversationView> {
         : moderationDisplayName(context, otherPubkey) ??
               profile?.bestDisplayName ??
               UserProfile.defaultDisplayNameFor(otherPubkey);
-    // Prefer the profile's NIP-05 / divine handle when set, otherwise
-    // fall back to a truncated npub so the header always carries a
-    // stable secondary identifier under the display name. Format
-    // mirrors the profile header (`profile_header_widget.dart`): first
-    // 16 chars of the npub + ellipsis.
-    final profileHandle = profile?.handle;
+    // Prefer the profile's NIP-05 / divine handle when set, otherwise the
+    // follow relationship — which tells the viewer which of several
+    // same-named people they are messaging, as a truncated npub never did.
     final handle = isDeleted
         ? context.l10n.inboxConversationDeletedAccountSubtitle
-        : (profileHandle != null && profileHandle.isNotEmpty)
-        ? profileHandle
-        : (otherPubkey.isNotEmpty
-              ? truncateNpubForDisplay(NostrKeyUtils.encodePubKey(otherPubkey))
-              : '');
+        : resolveUserIdentifierLine(
+                l10n: context.l10n,
+                locale: Localizations.localeOf(context).toLanguageTag(),
+                handle: profile?.handle,
+                relationship:
+                    ref.watch(followRelationshipProvider(otherPubkey)).value ??
+                    FollowRelationship.none,
+                followerCount: profile?.followerCount,
+              ) ??
+              '';
 
     return BlocProvider(
       create: (_) => SharedVideoSaveCubit(

--- a/mobile/lib/screens/inbox/conversation/conversation_view.dart
+++ b/mobile/lib/screens/inbox/conversation/conversation_view.dart
@@ -21,6 +21,7 @@ import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/l10n/localized_time_formatter.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/follow_relationship_provider.dart';
+import 'package:openvine/providers/nip05_verification_provider.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/screens/feed/dm_reply_context.dart';
 import 'package:openvine/screens/inbox/conversation/conversation_page.dart';
@@ -167,6 +168,12 @@ class _ConversationViewState extends ConsumerState<ConversationView> {
         : moderationDisplayName(context, otherPubkey) ??
               profile?.bestDisplayName ??
               UserProfile.defaultDisplayNameFor(otherPubkey);
+    final claimedNip05 = profile?.shortDisplayNip05;
+    final verificationStatus = claimedNip05 != null && claimedNip05.isNotEmpty
+        ? ref
+              .watch(nip05VerificationProvider(otherPubkey))
+              .whenOrNull(data: (status) => status)
+        : null;
     // Prefer the profile's NIP-05 / divine handle when set, otherwise the
     // follow relationship — which tells the viewer which of several
     // same-named people they are messaging, as a truncated npub never did.
@@ -175,7 +182,8 @@ class _ConversationViewState extends ConsumerState<ConversationView> {
         : resolveUserIdentifierLine(
                 l10n: context.l10n,
                 locale: Localizations.localeOf(context).toLanguageTag(),
-                handle: profile?.handle,
+                handle: claimedNip05,
+                verificationStatus: verificationStatus,
                 relationship:
                     ref.watch(followRelationshipProvider(otherPubkey)).value ??
                     FollowRelationship.none,

--- a/mobile/lib/screens/safety_settings_screen.dart
+++ b/mobile/lib/screens/safety_settings_screen.dart
@@ -293,7 +293,8 @@ class _CustomLabelerTile extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final profile = ref.watch(userProfileReactiveProvider(pubkey)).value;
-    final identifier = profile?.shortDisplayNip05 ?? _fullNpub(pubkey);
+    final identifier =
+        profile?.shortDisplayNip05 ?? NostrKeyUtils.npubOrHex(pubkey);
 
     return ListTile(
       leading: Icon(Icons.label_outline, color: context.vineColors.disabled),
@@ -450,7 +451,8 @@ class _BlockedUserTile extends ConsumerWidget {
         profile?.bestDisplayName ?? UserProfile.defaultDisplayNameFor(pubkey);
     // No relationship line here: "You follow" under an account you have
     // blocked reads as a contradiction, so the handle is the whole signal.
-    final identifier = profile?.shortDisplayNip05 ?? _fullNpub(pubkey);
+    final identifier =
+        profile?.shortDisplayNip05 ?? NostrKeyUtils.npubOrHex(pubkey);
 
     return ListTile(
       leading: Container(
@@ -507,13 +509,5 @@ class _BlockedUserTile extends ConsumerWidget {
         onPressed: onUnblock,
       ),
     );
-  }
-}
-
-String _fullNpub(String pubkey) {
-  try {
-    return NostrKeyUtils.encodePubKey(pubkey);
-  } on Exception {
-    return pubkey;
   }
 }

--- a/mobile/lib/screens/safety_settings_screen.dart
+++ b/mobile/lib/screens/safety_settings_screen.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:models/models.dart';
 import 'package:openvine/blocs/safety_settings/safety_settings_cubit.dart';
 import 'package:openvine/blocs/safety_settings/safety_settings_state.dart';
 import 'package:openvine/l10n/l10n.dart';
@@ -15,7 +16,6 @@ import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/router/route_paths.dart';
 import 'package:openvine/screens/content_filters_screen.dart';
 import 'package:openvine/screens/settings/account_content_labels_tile.dart';
-import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/vine_cached_image.dart';
 
@@ -241,31 +241,7 @@ class _CustomLabelersSection extends StatelessWidget {
     );
     return Column(
       children: [
-        ...customLabelers.map(
-          (pubkey) => ListTile(
-            leading: Icon(
-              Icons.label_outline,
-              color: context.vineColors.disabled,
-            ),
-            title: Text(
-              NostrKeyUtils.truncateNpub(pubkey),
-              style: VineTheme.bodyLargeFont(
-                color: context.vineColors.primaryText,
-              ),
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-            ),
-            trailing: DivineIconButton(
-              icon: DivineIconName.minus,
-              backgroundColor: VineTheme.transparent,
-              foregroundColor: context.vineColors.secondaryText,
-              showShadow: false,
-              tooltip: context.l10n.safetySettingsRemoveLabeler,
-              onPressed: () =>
-                  context.read<SafetySettingsCubit>().removeLabeler(pubkey),
-            ),
-          ),
-        ),
+        ...customLabelers.map((pubkey) => _CustomLabelerTile(pubkey: pubkey)),
         ListTile(
           leading: DivineIcon(
             icon: DivineIconName.plus,
@@ -300,6 +276,52 @@ class _CustomLabelersSection extends StatelessWidget {
     if (result != null && result.isNotEmpty) {
       await cubit.addLabeler(result);
     }
+  }
+}
+
+/// One subscribed labeler, identified by profile rather than by raw key.
+///
+/// Labelers are ordinary accounts with a kind 0, so the name and handle a
+/// person recognises are available; a truncated npub told them nothing about
+/// which service they had subscribed to.
+class _CustomLabelerTile extends ConsumerWidget {
+  const _CustomLabelerTile({required this.pubkey});
+
+  final String pubkey;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final profile = ref.watch(userProfileReactiveProvider(pubkey)).value;
+    final handle = profile?.shortDisplayNip05;
+
+    return ListTile(
+      leading: Icon(Icons.label_outline, color: context.vineColors.disabled),
+      title: Text(
+        profile?.bestDisplayName ?? UserProfile.defaultDisplayNameFor(pubkey),
+        style: VineTheme.bodyLargeFont(color: context.vineColors.primaryText),
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+      ),
+      subtitle: handle != null && handle.isNotEmpty
+          ? Text(
+              handle,
+              style: VineTheme.bodyMediumFont(
+                color: context.vineColors.secondaryText,
+              ),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            )
+          : null,
+      trailing: DivineIconButton(
+        icon: DivineIconName.minus,
+        backgroundColor: VineTheme.transparent,
+        foregroundColor: context.vineColors.secondaryText,
+        showShadow: false,
+        tooltip: context.l10n.safetySettingsRemoveLabeler,
+        onPressed: () =>
+            context.read<SafetySettingsCubit>().removeLabeler(pubkey),
+      ),
+    );
   }
 }
 
@@ -425,8 +447,11 @@ class _BlockedUserTile extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final profileAsync = ref.watch(userProfileReactiveProvider(pubkey));
     final profile = profileAsync.value;
-    final truncatedNpub = NostrKeyUtils.truncateNpub(pubkey);
-    final displayName = profile?.bestDisplayName ?? truncatedNpub;
+    final displayName =
+        profile?.bestDisplayName ?? UserProfile.defaultDisplayNameFor(pubkey);
+    // No relationship line here: "You follow" under an account you have
+    // blocked reads as a contradiction, so the handle is the whole signal.
+    final handle = profile?.shortDisplayNip05;
 
     return ListTile(
       leading: Container(
@@ -470,12 +495,16 @@ class _BlockedUserTile extends ConsumerWidget {
         maxLines: 1,
         overflow: TextOverflow.ellipsis,
       ),
-      subtitle: Text(
-        truncatedNpub,
-        style: VineTheme.bodySmallFont(color: context.vineColors.secondaryText),
-        maxLines: 1,
-        overflow: TextOverflow.ellipsis,
-      ),
+      subtitle: handle != null && handle.isNotEmpty
+          ? Text(
+              handle,
+              style: VineTheme.bodySmallFont(
+                color: context.vineColors.secondaryText,
+              ),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            )
+          : null,
       trailing: DivineButton(
         label: context.l10n.safetySettingsUnblock,
         type: DivineButtonType.link,

--- a/mobile/lib/screens/safety_settings_screen.dart
+++ b/mobile/lib/screens/safety_settings_screen.dart
@@ -16,6 +16,7 @@ import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/router/route_paths.dart';
 import 'package:openvine/screens/content_filters_screen.dart';
 import 'package:openvine/screens/settings/account_content_labels_tile.dart';
+import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/vine_cached_image.dart';
 
@@ -292,7 +293,7 @@ class _CustomLabelerTile extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final profile = ref.watch(userProfileReactiveProvider(pubkey)).value;
-    final handle = profile?.shortDisplayNip05;
+    final identifier = profile?.shortDisplayNip05 ?? _fullNpub(pubkey);
 
     return ListTile(
       leading: Icon(Icons.label_outline, color: context.vineColors.disabled),
@@ -302,16 +303,14 @@ class _CustomLabelerTile extends ConsumerWidget {
         maxLines: 1,
         overflow: TextOverflow.ellipsis,
       ),
-      subtitle: handle != null && handle.isNotEmpty
-          ? Text(
-              handle,
-              style: VineTheme.bodyMediumFont(
-                color: context.vineColors.secondaryText,
-              ),
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-            )
-          : null,
+      subtitle: Text(
+        identifier,
+        style: VineTheme.bodyMediumFont(
+          color: context.vineColors.secondaryText,
+        ),
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+      ),
       trailing: DivineIconButton(
         icon: DivineIconName.minus,
         backgroundColor: VineTheme.transparent,
@@ -451,7 +450,7 @@ class _BlockedUserTile extends ConsumerWidget {
         profile?.bestDisplayName ?? UserProfile.defaultDisplayNameFor(pubkey);
     // No relationship line here: "You follow" under an account you have
     // blocked reads as a contradiction, so the handle is the whole signal.
-    final handle = profile?.shortDisplayNip05;
+    final identifier = profile?.shortDisplayNip05 ?? _fullNpub(pubkey);
 
     return ListTile(
       leading: Container(
@@ -495,16 +494,12 @@ class _BlockedUserTile extends ConsumerWidget {
         maxLines: 1,
         overflow: TextOverflow.ellipsis,
       ),
-      subtitle: handle != null && handle.isNotEmpty
-          ? Text(
-              handle,
-              style: VineTheme.bodySmallFont(
-                color: context.vineColors.secondaryText,
-              ),
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-            )
-          : null,
+      subtitle: Text(
+        identifier,
+        style: VineTheme.bodySmallFont(color: context.vineColors.secondaryText),
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+      ),
       trailing: DivineButton(
         label: context.l10n.safetySettingsUnblock,
         type: DivineButtonType.link,
@@ -512,5 +507,13 @@ class _BlockedUserTile extends ConsumerWidget {
         onPressed: onUnblock,
       ),
     );
+  }
+}
+
+String _fullNpub(String pubkey) {
+  try {
+    return NostrKeyUtils.encodePubKey(pubkey);
+  } on Exception {
+    return pubkey;
   }
 }

--- a/mobile/lib/screens/search_results/widgets/search_user_tile.dart
+++ b/mobile/lib/screens/search_results/widgets/search_user_tile.dart
@@ -56,7 +56,7 @@ class SearchUserTile extends ConsumerWidget {
             relationship:
                 ref.watch(followRelationshipProvider(profile.pubkey)).value ??
                 FollowRelationship.none,
-            followerCount: profile.followerCount,
+            followerCount: profile.restFollowerCount,
           );
 
     final profileListFeaturesEnabled = ref.watch(

--- a/mobile/lib/screens/search_results/widgets/search_user_tile.dart
+++ b/mobile/lib/screens/search_results/widgets/search_user_tile.dart
@@ -2,6 +2,7 @@ import 'package:count_formatter/count_formatter.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:follow_repository/follow_repository.dart';
 import 'package:models/models.dart';
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
 import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
@@ -9,16 +10,17 @@ import 'package:openvine/features/people_lists/models/people_list_entry_point.da
 import 'package:openvine/features/people_lists/view/add_to_people_lists_sheet.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/follow_relationship_provider.dart';
 import 'package:openvine/providers/nip05_verification_provider.dart';
-import 'package:openvine/utils/user_profile_utils.dart';
+import 'package:openvine/utils/user_identifier_line_resolver.dart';
 import 'package:openvine/widgets/user_avatar.dart';
 
 /// Reusable tile widget for displaying a user profile in search results.
 ///
 /// Shows avatar, display name, and a secondary line that disambiguates users:
-/// REST video count when known, otherwise a verified NIP-05 handle or npub
-/// fallback. Uses [ConsumerWidget] (Riverpod) for the providers that gate the
-/// add-to-list action and legacy NIP-05 verification.
+/// REST video count when known, otherwise a NIP-05 handle, otherwise social
+/// proof via [resolveUserIdentifierLine]. Uses [ConsumerWidget] (Riverpod) for
+/// the providers that gate the add-to-list action and NIP-05 verification.
 class SearchUserTile extends ConsumerWidget {
   const SearchUserTile({required this.profile, this.onTap, super.key});
 
@@ -38,16 +40,24 @@ class SearchUserTile extends ConsumerWidget {
               .watch(nip05VerificationProvider(profile.pubkey))
               .whenOrNull(data: (status) => status)
         : null;
-    final verifiedNip05 = verificationStatus?.name == 'verified'
-        ? claimedNip05
-        : null;
+    final ownPubkey = ref.watch(authServiceProvider).currentPublicKeyHex;
     final locale = Localizations.localeOf(context).toLanguageTag();
     final secondaryText = videoCount != null && videoCount > 0
         ? context.l10n.searchUserVideoCount(
             videoCount,
             CountFormatter.formatCompact(videoCount, locale: locale),
           )
-        : verifiedNip05 ?? profile.truncatedNpub;
+        : resolveUserIdentifierLine(
+            l10n: context.l10n,
+            locale: locale,
+            handle: claimedNip05,
+            verificationStatus: verificationStatus,
+            isOwnProfile: profile.pubkey == ownPubkey,
+            relationship:
+                ref.watch(followRelationshipProvider(profile.pubkey)).value ??
+                FollowRelationship.none,
+            followerCount: profile.followerCount,
+          );
 
     final profileListFeaturesEnabled = ref.watch(
       isFeatureEnabledProvider(FeatureFlag.profileListFeatures),
@@ -58,7 +68,6 @@ class SearchUserTile extends ConsumerWidget {
     final curatedListsEnabled = ref.watch(
       isFeatureEnabledProvider(FeatureFlag.curatedLists),
     );
-    final ownPubkey = ref.watch(authServiceProvider).currentPublicKeyHex;
     final showAddToList =
         profileListFeaturesEnabled &&
         curatedListsEnabled &&
@@ -92,14 +101,15 @@ class SearchUserTile extends ConsumerWidget {
                         color: context.vineColors.primaryText,
                       ),
                     ),
-                    Text(
-                      secondaryText,
-                      style: VineTheme.bodyMediumFont(
-                        color: context.vineColors.secondaryText,
+                    if (secondaryText != null)
+                      Text(
+                        secondaryText,
+                        style: VineTheme.bodyMediumFont(
+                          color: context.vineColors.secondaryText,
+                        ),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
                       ),
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                    ),
                   ],
                 ),
               ),

--- a/mobile/lib/screens/settings/settings_screen.dart
+++ b/mobile/lib/screens/settings/settings_screen.dart
@@ -45,10 +45,10 @@ import 'package:openvine/screens/settings/nostr_settings_screen.dart';
 import 'package:openvine/screens/settings/support_center_screen.dart';
 import 'package:openvine/screens/settings/supporter_screen.dart';
 import 'package:openvine/services/auth_service.dart' hide UserProfile;
-import 'package:openvine/services/nip05_verification_service.dart';
 import 'package:openvine/utils/deferred_login_options_navigator.dart';
 import 'package:openvine/utils/nostr_apps_platform_support.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
+import 'package:openvine/utils/user_identifier_line_resolver.dart';
 import 'package:openvine/widgets/signup_invites_availability_builder.dart';
 import 'package:openvine/widgets/user_avatar.dart';
 import 'package:package_info_plus/package_info_plus.dart';
@@ -659,18 +659,22 @@ class _AccountHeaderProfile extends ConsumerWidget {
     final displayName =
         profile?.bestDisplayName ?? UserProfile.defaultDisplayNameFor(pubkey);
 
-    final truncatedNpub = NostrKeyUtils.truncateNpub(pubkey);
     final claimedNip05 = profile?.displayNip05;
     final verificationStatus = claimedNip05 != null && claimedNip05.isNotEmpty
         ? ref
               .watch(nip05VerificationProvider(pubkey))
               .whenOrNull(data: (status) => status)
         : null;
-    final hasVerifiedNip05 =
-        verificationStatus == Nip05VerificationStatus.verified;
-    final uniqueIdentifier = hasVerifiedNip05 && claimedNip05 != null
-        ? claimedNip05
-        : truncatedNpub;
+    // Always the signed-in account, so a failed check never hides the handle:
+    // the owner needs to see what they claimed in order to fix it.
+    final uniqueIdentifier = resolveUserIdentifierLine(
+      l10n: context.l10n,
+      locale: Localizations.localeOf(context).toLanguageTag(),
+      handle: claimedNip05,
+      verificationStatus: verificationStatus,
+      isOwnProfile: true,
+      followerCount: profile?.followerCount,
+    );
 
     return Column(
       children: [
@@ -690,15 +694,16 @@ class _AccountHeaderProfile extends ConsumerWidget {
           maxLines: 1,
           overflow: TextOverflow.ellipsis,
         ),
-        Text(
-          uniqueIdentifier,
-          style: VineTheme.bodyMediumFont(
-            color: context.vineColors.onSurfaceVariant,
+        if (uniqueIdentifier != null)
+          Text(
+            uniqueIdentifier,
+            style: VineTheme.bodyMediumFont(
+              color: context.vineColors.onSurfaceVariant,
+            ),
+            textAlign: TextAlign.center,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
           ),
-          textAlign: TextAlign.center,
-          maxLines: 1,
-          overflow: TextOverflow.ellipsis,
-        ),
       ],
     );
   }

--- a/mobile/lib/screens/settings/settings_screen.dart
+++ b/mobile/lib/screens/settings/settings_screen.dart
@@ -667,14 +667,16 @@ class _AccountHeaderProfile extends ConsumerWidget {
         : null;
     // Always the signed-in account, so a failed check never hides the handle:
     // the owner needs to see what they claimed in order to fix it.
-    final uniqueIdentifier = resolveUserIdentifierLine(
-      l10n: context.l10n,
-      locale: Localizations.localeOf(context).toLanguageTag(),
-      handle: claimedNip05,
-      verificationStatus: verificationStatus,
-      isOwnProfile: true,
-      followerCount: profile?.followerCount,
-    );
+    final uniqueIdentifier =
+        resolveUserIdentifierLine(
+          l10n: context.l10n,
+          locale: Localizations.localeOf(context).toLanguageTag(),
+          handle: claimedNip05,
+          verificationStatus: verificationStatus,
+          isOwnProfile: true,
+          followerCount: profile?.followerCount,
+        ) ??
+        _fullNpub(pubkey);
 
     return Column(
       children: [
@@ -694,16 +696,15 @@ class _AccountHeaderProfile extends ConsumerWidget {
           maxLines: 1,
           overflow: TextOverflow.ellipsis,
         ),
-        if (uniqueIdentifier != null)
-          Text(
-            uniqueIdentifier,
-            style: VineTheme.bodyMediumFont(
-              color: context.vineColors.onSurfaceVariant,
-            ),
-            textAlign: TextAlign.center,
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
+        Text(
+          uniqueIdentifier,
+          style: VineTheme.bodyMediumFont(
+            color: context.vineColors.onSurfaceVariant,
           ),
+          textAlign: TextAlign.center,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+        ),
       ],
     );
   }
@@ -803,8 +804,7 @@ class _AccountSwitchTile extends ConsumerWidget {
     final displayName =
         profile?.bestDisplayName ??
         UserProfile.defaultDisplayNameFor(account.pubkeyHex);
-    final identifier =
-        profile?.displayNip05 ?? NostrKeyUtils.truncateNpub(account.pubkeyHex);
+    final identifier = profile?.displayNip05 ?? _fullNpub(account.pubkeyHex);
 
     return Semantics(
       button: true,
@@ -863,6 +863,14 @@ class _AccountSwitchTile extends ConsumerWidget {
         ),
       ),
     );
+  }
+}
+
+String _fullNpub(String pubkey) {
+  try {
+    return NostrKeyUtils.encodePubKey(pubkey);
+  } on Exception {
+    return pubkey;
   }
 }
 

--- a/mobile/lib/screens/settings/settings_screen.dart
+++ b/mobile/lib/screens/settings/settings_screen.dart
@@ -667,6 +667,10 @@ class _AccountHeaderProfile extends ConsumerWidget {
         : null;
     // Always the signed-in account, so a failed check never hides the handle:
     // the owner needs to see what they claimed in order to fix it.
+    //
+    // No social proof either. This line answers "which account am I signed in
+    // as", and the owner's own follower count does not identify an account —
+    // passing it would shadow the npub below for everyone with a follower.
     final uniqueIdentifier =
         resolveUserIdentifierLine(
           l10n: context.l10n,
@@ -674,7 +678,6 @@ class _AccountHeaderProfile extends ConsumerWidget {
           handle: claimedNip05,
           verificationStatus: verificationStatus,
           isOwnProfile: true,
-          followerCount: profile?.followerCount,
         ) ??
         NostrKeyUtils.npubOrHex(pubkey);
 

--- a/mobile/lib/screens/settings/settings_screen.dart
+++ b/mobile/lib/screens/settings/settings_screen.dart
@@ -676,7 +676,7 @@ class _AccountHeaderProfile extends ConsumerWidget {
           isOwnProfile: true,
           followerCount: profile?.followerCount,
         ) ??
-        _fullNpub(pubkey);
+        NostrKeyUtils.npubOrHex(pubkey);
 
     return Column(
       children: [
@@ -804,7 +804,8 @@ class _AccountSwitchTile extends ConsumerWidget {
     final displayName =
         profile?.bestDisplayName ??
         UserProfile.defaultDisplayNameFor(account.pubkeyHex);
-    final identifier = profile?.displayNip05 ?? _fullNpub(account.pubkeyHex);
+    final identifier =
+        profile?.displayNip05 ?? NostrKeyUtils.npubOrHex(account.pubkeyHex);
 
     return Semantics(
       button: true,
@@ -863,14 +864,6 @@ class _AccountSwitchTile extends ConsumerWidget {
         ),
       ),
     );
-  }
-}
-
-String _fullNpub(String pubkey) {
-  try {
-    return NostrKeyUtils.encodePubKey(pubkey);
-  } on Exception {
-    return pubkey;
   }
 }
 

--- a/mobile/lib/utils/nostr_key_utils.dart
+++ b/mobile/lib/utils/nostr_key_utils.dart
@@ -51,6 +51,20 @@ class NostrKeyUtils {
     }
   }
 
+  /// The full npub for [hexPubkey], or the hex itself when it cannot be
+  /// encoded.
+  ///
+  /// For UI that shows a key as an identifier of last resort. Never truncates:
+  /// the caller's `maxLines` / `TextOverflow.ellipsis` decides how much fits,
+  /// so a copied or read value is always the exact identifier.
+  static String npubOrHex(String hexPubkey) {
+    try {
+      return encodePubKey(hexPubkey);
+    } on Exception {
+      return hexPubkey;
+    }
+  }
+
   /// Create a truncated npub for display (e.g., "npub1abc...xyz")
   ///
   /// Converts a hex pubkey to npub format and truncates for UI display.

--- a/mobile/lib/utils/user_identifier_line_resolver.dart
+++ b/mobile/lib/utils/user_identifier_line_resolver.dart
@@ -33,8 +33,11 @@ String? resolveUserIdentifierLine({
 }) {
   final impersonationRisk =
       verificationStatus == Nip05VerificationStatus.failed && !isOwnProfile;
-  if (handle != null && handle.isNotEmpty && !impersonationRisk) {
-    return handle;
+  // Trim before the emptiness test: a kind-0 nip05 of only whitespace is not
+  // a usable handle, and sanitizeForDisplay does not strip it.
+  final trimmedHandle = handle?.trim();
+  if (trimmedHandle != null && trimmedHandle.isNotEmpty && !impersonationRisk) {
+    return trimmedHandle;
   }
 
   final relationshipLabel = switch (relationship) {

--- a/mobile/lib/utils/user_identifier_line_resolver.dart
+++ b/mobile/lib/utils/user_identifier_line_resolver.dart
@@ -1,0 +1,62 @@
+// ABOUTME: Resolves the secondary identifier line under a user's display name
+// ABOUTME: Prefers a NIP-05 handle, falls back to social proof, else nothing
+
+import 'package:count_formatter/count_formatter.dart';
+import 'package:follow_repository/follow_repository.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/services/nip05_verification_service.dart';
+
+/// Separator between social-proof segments, matching the convention used by
+/// the sound and video metadata rows.
+const _segmentSeparator = ' · ';
+
+/// Returns the line to render under a user's display name, or `null` when
+/// nothing worth showing is known.
+///
+/// A claimed NIP-05 wins whenever it is safe to show. Only
+/// [Nip05VerificationStatus.failed] — an actual pubkey mismatch — suppresses
+/// it, and only on someone else's profile, since that is the sole status that
+/// signals impersonation. Pending and [Nip05VerificationStatus.error] are
+/// network conditions, not identity claims, so they must not demote a handle.
+///
+/// Without a usable handle the line falls back to social proof, which answers
+/// the question the identifier is really there for: which of the several
+/// accounts sharing this display name is this? A truncated npub never could.
+String? resolveUserIdentifierLine({
+  required AppLocalizations l10n,
+  required String locale,
+  String? handle,
+  Nip05VerificationStatus? verificationStatus,
+  bool isOwnProfile = false,
+  FollowRelationship relationship = FollowRelationship.none,
+  int? followerCount,
+}) {
+  final impersonationRisk =
+      verificationStatus == Nip05VerificationStatus.failed && !isOwnProfile;
+  if (handle != null && handle.isNotEmpty && !impersonationRisk) {
+    return handle;
+  }
+
+  final relationshipLabel = switch (relationship) {
+    FollowRelationship.mutual => l10n.socialProofMutual,
+    FollowRelationship.followsYou => l10n.socialProofFollowsYou,
+    FollowRelationship.youFollow => l10n.socialProofYouFollow,
+    FollowRelationship.none => null,
+  };
+
+  // A zero count is either a genuinely unfollowed account or a stat that has
+  // not loaded; neither earns space on the line.
+  final countLabel = followerCount != null && followerCount > 0
+      ? l10n.socialProofFollowerCount(
+          followerCount,
+          CountFormatter.formatCompact(followerCount, locale: locale),
+        )
+      : null;
+
+  final segments = [
+    ?relationshipLabel,
+    ?countLabel,
+  ];
+
+  return segments.isEmpty ? null : segments.join(_segmentSeparator);
+}

--- a/mobile/lib/widgets/user_profile_tile.dart
+++ b/mobile/lib/widgets/user_profile_tile.dart
@@ -4,6 +4,7 @@
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:follow_repository/follow_repository.dart';
 import 'package:models/models.dart';
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
 import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
@@ -11,10 +12,10 @@ import 'package:openvine/features/people_lists/models/people_list_entry_point.da
 import 'package:openvine/features/people_lists/view/add_to_people_lists_sheet.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/follow_relationship_provider.dart';
 import 'package:openvine/providers/nip05_verification_provider.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
-import 'package:openvine/services/nip05_verification_service.dart';
-import 'package:openvine/utils/nostr_key_utils.dart';
+import 'package:openvine/utils/user_identifier_line_resolver.dart';
 import 'package:openvine/widgets/unfollow_confirmation_sheet.dart';
 import 'package:openvine/widgets/user_avatar.dart';
 
@@ -86,8 +87,6 @@ class UserProfileTile extends ConsumerWidget {
     final showAddToList =
         profileListFeaturesEnabled && curatedListsEnabled && !isCurrentUser;
 
-    // Get display name or truncated npub (fallback for users without Kind 0)
-    final truncatedNpub = NostrKeyUtils.truncateNpub(pubkey);
     final displayName =
         profile?.bestDisplayName ?? UserProfile.defaultDisplayNameFor(pubkey);
 
@@ -97,13 +96,18 @@ class UserProfileTile extends ConsumerWidget {
               .watch(nip05VerificationProvider(pubkey))
               .whenOrNull(data: (status) => status)
         : null;
-    final hasVerifiedNip05 =
-        verificationStatus == Nip05VerificationStatus.verified;
 
-    // Only show NIP-05 when verification succeeds; otherwise show npub.
-    final uniqueIdentifier = hasVerifiedNip05 && claimedNip05 != null
-        ? claimedNip05
-        : truncatedNpub;
+    final uniqueIdentifier = resolveUserIdentifierLine(
+      l10n: context.l10n,
+      locale: Localizations.localeOf(context).toLanguageTag(),
+      handle: claimedNip05,
+      verificationStatus: verificationStatus,
+      isOwnProfile: isCurrentUser,
+      relationship:
+          ref.watch(followRelationshipProvider(pubkey)).value ??
+          FollowRelationship.none,
+      followerCount: profile?.followerCount,
+    );
 
     return Semantics(
       identifier: 'user_profile_tile_$pubkey',
@@ -138,14 +142,15 @@ class UserProfileTile extends ConsumerWidget {
                       maxLines: 1,
                       overflow: TextOverflow.ellipsis,
                     ),
-                    Text(
-                      uniqueIdentifier,
-                      style: VineTheme.bodySmallFont(
-                        color: context.vineColors.onSurfaceVariant,
+                    if (uniqueIdentifier != null)
+                      Text(
+                        uniqueIdentifier,
+                        style: VineTheme.bodySmallFont(
+                          color: context.vineColors.onSurfaceVariant,
+                        ),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
                       ),
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                    ),
                   ],
                 ),
               ),

--- a/mobile/lib/widgets/user_profile_tile.dart
+++ b/mobile/lib/widgets/user_profile_tile.dart
@@ -106,7 +106,7 @@ class UserProfileTile extends ConsumerWidget {
       relationship:
           ref.watch(followRelationshipProvider(pubkey)).value ??
           FollowRelationship.none,
-      followerCount: profile?.followerCount,
+      followerCount: profile?.restFollowerCount,
     );
 
     return Semantics(

--- a/mobile/packages/follow_repository/lib/follow_repository.dart
+++ b/mobile/packages/follow_repository/lib/follow_repository.dart
@@ -7,6 +7,7 @@ library;
 export 'package:cache_sync/cache_sync.dart' show CacheResult;
 
 export 'src/follow_list_kind.dart';
+export 'src/follow_relationship.dart';
 export 'src/follow_repository.dart';
 export 'src/follow_sort_order.dart';
 export 'src/follower_stats.dart';

--- a/mobile/packages/follow_repository/lib/src/follow_relationship.dart
+++ b/mobile/packages/follow_repository/lib/src/follow_relationship.dart
@@ -1,0 +1,23 @@
+/// The current user's follow relationship with another account.
+///
+/// Answers "which of the several people with this display name am I looking
+/// at?" — the question a truncated npub was never able to answer. Derived
+/// entirely from data the repository already holds in memory, so it is safe
+/// to read per row while a list scrolls.
+enum FollowRelationship {
+  /// No known relationship, or the follower list has not been fetched yet.
+  ///
+  /// Deliberately conflates "no relationship" with "not yet known": claiming
+  /// [followsYou] before the follower list has loaded would show a
+  /// relationship that may not exist.
+  none,
+
+  /// The current user follows this account, which does not follow back.
+  youFollow,
+
+  /// This account follows the current user, who does not follow back.
+  followsYou,
+
+  /// The current user and this account follow each other.
+  mutual,
+}

--- a/mobile/packages/follow_repository/lib/src/follow_repository.dart
+++ b/mobile/packages/follow_repository/lib/src/follow_repository.dart
@@ -5,6 +5,7 @@ import 'dart:math';
 import 'package:cache_sync/cache_sync.dart';
 import 'package:db_client/db_client.dart' hide Filter;
 import 'package:follow_repository/src/follow_list_kind.dart';
+import 'package:follow_repository/src/follow_relationship.dart';
 import 'package:follow_repository/src/follower_stats.dart';
 import 'package:follow_repository/src/followers_snapshot.dart';
 import 'package:follow_repository/src/following_snapshot.dart';
@@ -156,6 +157,8 @@ class FollowRepository {
 
   // In-memory cache — my followers (populated after first fetch)
   List<String> _cachedMyFollowersPubkeys = [];
+  List<String>? _myFollowersLookupSource;
+  Set<String> _myFollowersLookupCache = const {};
   int _cachedMyFollowersDatedCount = 0;
   int _cachedMyFollowerCount = 0;
   bool _hasMyFollowersCache = false;
@@ -249,6 +252,45 @@ class FollowRepository {
 
   /// Check if current user is following a specific pubkey
   bool isFollowing(String pubkey) => _followingPubkeys.contains(pubkey);
+
+  /// The current user's follow relationship with [pubkey].
+  ///
+  /// Reads only the in-memory following and follower caches, so it is cheap
+  /// enough to call per row while a list scrolls and never issues a network
+  /// request. Returns [FollowRelationship.none] for the current user's own
+  /// pubkey and for an empty [pubkey].
+  ///
+  /// Before [getMyFollowers] has populated the follower cache, "follows you"
+  /// is unknowable, so a mutual reads as [FollowRelationship.youFollow] and a
+  /// one-way follower reads as [FollowRelationship.none]. The relationship
+  /// only ever upgrades as data arrives; it never claims one that turns out
+  /// to be wrong.
+  FollowRelationship relationshipTo(String pubkey) {
+    if (pubkey.isEmpty || pubkey == _nostrClient.publicKey) {
+      return FollowRelationship.none;
+    }
+    final youFollow = isFollowing(pubkey);
+    final followsYou =
+        _hasMyFollowersCache && _myFollowersLookup.contains(pubkey);
+    return switch ((youFollow, followsYou)) {
+      (true, true) => FollowRelationship.mutual,
+      (true, false) => FollowRelationship.youFollow,
+      (false, true) => FollowRelationship.followsYou,
+      (false, false) => FollowRelationship.none,
+    };
+  }
+
+  /// [_cachedMyFollowersPubkeys] as a set, rebuilt only when that list is
+  /// replaced, so per-row membership tests stay O(1) on accounts with many
+  /// thousands of followers. Both writers assign a fresh list instance, which
+  /// is what makes the identity check a sufficient invalidation signal.
+  Set<String> get _myFollowersLookup {
+    if (!identical(_myFollowersLookupSource, _cachedMyFollowersPubkeys)) {
+      _myFollowersLookupSource = _cachedMyFollowersPubkeys;
+      _myFollowersLookupCache = _cachedMyFollowersPubkeys.toSet();
+    }
+    return _myFollowersLookupCache;
+  }
 
   /// Get the list of followers for the current user.
   ///

--- a/mobile/packages/follow_repository/lib/src/follow_repository.dart
+++ b/mobile/packages/follow_repository/lib/src/follow_repository.dart
@@ -262,9 +262,13 @@ class FollowRepository {
   ///
   /// Before [getMyFollowers] has populated the follower cache, "follows you"
   /// is unknowable, so a mutual reads as [FollowRelationship.youFollow] and a
-  /// one-way follower reads as [FollowRelationship.none]. The relationship
-  /// only ever upgrades as data arrives; it never claims one that turns out
-  /// to be wrong.
+  /// one-way follower reads as [FollowRelationship.none]. That cold-cache
+  /// degradation only under-claims and upgrades as data arrives. It is not a
+  /// guarantee against a stale contact list, though: the following and
+  /// follower sets are unions across sources that are never pruned, so a
+  /// superseded kind 3 from one relay can still read as
+  /// [FollowRelationship.followsYou] or [FollowRelationship.mutual] after an
+  /// unfollow.
   FollowRelationship relationshipTo(String pubkey) {
     if (pubkey.isEmpty || pubkey == _nostrClient.publicKey) {
       return FollowRelationship.none;

--- a/mobile/packages/follow_repository/lib/src/follow_repository.dart
+++ b/mobile/packages/follow_repository/lib/src/follow_repository.dart
@@ -305,7 +305,10 @@ class FollowRepository {
 
   /// [getMyFollowers] plus the size of the datable prefix.
   Future<({List<String> pubkeys, int datedCount})> _fetchMyFollowers() async {
-    final result = await _fetchOrderedFollowers(_nostrClient.publicKey);
+    final pubkey = _nostrClient.publicKey;
+    if (pubkey.isEmpty) return (pubkeys: <String>[], datedCount: 0);
+
+    final result = await _fetchOrderedFollowers(pubkey);
     _cachedMyFollowersPubkeys = result.pubkeys;
     _cachedMyFollowersDatedCount = result.datedCount;
     _hasMyFollowersCache = true;

--- a/mobile/packages/follow_repository/test/src/follow_repository_test.dart
+++ b/mobile/packages/follow_repository/test/src/follow_repository_test.dart
@@ -466,6 +466,115 @@ void main() {
       });
     });
 
+    group('relationshipTo', () {
+      /// Stubs the relay query so [pubkeys] each follow the current user.
+      void stubFollowersOfMe(List<String> pubkeys) {
+        when(() => mockNostrClient.queryEvents(any())).thenAnswer(
+          (_) async => [
+            for (final pubkey in pubkeys)
+              Event(
+                pubkey,
+                3,
+                [
+                  ['p', testCurrentUserPubkey],
+                ],
+                '',
+                createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+              ),
+          ],
+        );
+      }
+
+      test('returns none for a stranger', () async {
+        await repository.initialize();
+
+        expect(
+          repository.relationshipTo(testTargetPubkey),
+          equals(FollowRelationship.none),
+        );
+      });
+
+      test('returns youFollow when only the current user follows', () async {
+        SharedPreferences.setMockInitialValues({
+          'following_list_$testCurrentUserPubkey': '["$testTargetPubkey"]',
+        });
+        stubFollowersOfMe([testTargetPubkey2]);
+
+        await repository.initialize();
+        await repository.getMyFollowers();
+
+        expect(
+          repository.relationshipTo(testTargetPubkey),
+          equals(FollowRelationship.youFollow),
+        );
+      });
+
+      test('returns followsYou when only the target follows', () async {
+        stubFollowersOfMe([testTargetPubkey]);
+
+        await repository.initialize();
+        await repository.getMyFollowers();
+
+        expect(
+          repository.relationshipTo(testTargetPubkey),
+          equals(FollowRelationship.followsYou),
+        );
+      });
+
+      test('returns mutual when both follow each other', () async {
+        SharedPreferences.setMockInitialValues({
+          'following_list_$testCurrentUserPubkey': '["$testTargetPubkey"]',
+        });
+        stubFollowersOfMe([testTargetPubkey]);
+
+        await repository.initialize();
+        await repository.getMyFollowers();
+
+        expect(
+          repository.relationshipTo(testTargetPubkey),
+          equals(FollowRelationship.mutual),
+        );
+      });
+
+      test('reports youFollow, not mutual, while the follower cache is '
+          'cold', () async {
+        SharedPreferences.setMockInitialValues({
+          'following_list_$testCurrentUserPubkey': '["$testTargetPubkey"]',
+        });
+        stubFollowersOfMe([testTargetPubkey]);
+
+        await repository.initialize();
+
+        // getMyFollowers() has not run, so "follows you" is unknowable and
+        // must not be claimed.
+        expect(
+          repository.relationshipTo(testTargetPubkey),
+          equals(FollowRelationship.youFollow),
+        );
+      });
+
+      test('returns none for the current user', () async {
+        stubFollowersOfMe([testTargetPubkey]);
+
+        await repository.initialize();
+        await repository.getMyFollowers();
+
+        expect(
+          repository.relationshipTo(testCurrentUserPubkey),
+          equals(FollowRelationship.none),
+        );
+      });
+
+      test('returns none for an empty pubkey', () async {
+        await repository.initialize();
+
+        expect(
+          repository.relationshipTo(''),
+          equals(FollowRelationship.none),
+        );
+      });
+    });
+
     group('follow', () {
       test('throws when not authenticated', () async {
         when(() => mockNostrClient.hasKeys).thenReturn(false);

--- a/mobile/packages/follow_repository/test/src/follow_repository_test.dart
+++ b/mobile/packages/follow_repository/test/src/follow_repository_test.dart
@@ -1876,6 +1876,36 @@ void main() {
         verifyNever(() => mockNostrClient.queryEvents(any()));
       });
 
+      test('does not mark an empty-pubkey follower result as cached', () async {
+        const follower =
+            'e5f6789012345678901234567890abcdef1234567890123456789012abcd1234';
+        var currentPubkey = '';
+        when(() => mockNostrClient.publicKey).thenAnswer((_) => currentPubkey);
+
+        final unauthenticatedFollowers = await repository.getMyFollowers();
+        expect(unauthenticatedFollowers, isEmpty);
+        verifyNever(() => mockNostrClient.queryEvents(any()));
+
+        currentPubkey = testCurrentUserPubkey;
+        when(() => mockNostrClient.queryEvents(any())).thenAnswer(
+          (_) async => [
+            Event(
+              follower,
+              3,
+              [
+                ['p', testCurrentUserPubkey],
+              ],
+              '',
+              createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+            ),
+          ],
+        );
+
+        final firstEmission = await repository.watchMyFollowers().first;
+
+        expect(firstEmission.pubkeys, equals([follower]));
+      });
+
       test('returns followers for current user', () async {
         const follower1 =
             'e5f6789012345678901234567890abcdef1234567890123456789012abcd1234';

--- a/mobile/scripts/baseline/ui_service_imports.txt
+++ b/mobile/scripts/baseline/ui_service_imports.txt
@@ -49,7 +49,6 @@ lib/widgets/profile_editor/username_status_indicator.dart
 lib/widgets/report_content_dialog.dart
 lib/widgets/save_original_progress_sheet.dart
 lib/widgets/upload_failure_sheet.dart
-lib/widgets/user_profile_tile.dart
 lib/widgets/video_clip/video_clip_preview.dart
 lib/widgets/video_editor/audio_editor/audio_selection_bottom_sheet.dart
 lib/widgets/video_editor/main_editor/video_editor_canvas.dart

--- a/mobile/test/l10n/arb_consistency_test.dart
+++ b/mobile/test/l10n/arb_consistency_test.dart
@@ -418,20 +418,12 @@ void main() {
 // Keys intentionally allowed to fall back to English until a translation pass.
 // Keep this list small and reviewable so new translation gaps stay visible.
 const _knownUntranslatedDebt = <String>{
-  // Translation pass tracked in #7632.
-  'analyticsConnectionIssue',
-  'analyticsDiagnosticsFailedSources',
-  'analyticsServerUnavailable',
-  'searchUserVideoCount',
   // Account restore failure copy is new; translation pass tracked in #7659.
+  // The social-proof and #7632 keys left this list when this branch
+  // translated them into every locale.
   'authAccountRestoreFailed',
   'settingsAccountRestoreFailed',
   'settingsAccountRestoreFailedSwitchMessage',
-  // Social-proof identifier copy rides the #7632 pass.
-  'socialProofMutual',
-  'socialProofFollowsYou',
-  'socialProofYouFollow',
-  'socialProofFollowerCount',
 };
 
 const _profileBadgeSheetKeys = <String>{

--- a/mobile/test/l10n/arb_consistency_test.dart
+++ b/mobile/test/l10n/arb_consistency_test.dart
@@ -427,6 +427,11 @@ const _knownUntranslatedDebt = <String>{
   'authAccountRestoreFailed',
   'settingsAccountRestoreFailed',
   'settingsAccountRestoreFailedSwitchMessage',
+  // Social-proof identifier copy rides the #7632 pass.
+  'socialProofMutual',
+  'socialProofFollowsYou',
+  'socialProofYouFollow',
+  'socialProofFollowerCount',
 };
 
 const _profileBadgeSheetKeys = <String>{

--- a/mobile/test/l10n/arb_consistency_test.dart
+++ b/mobile/test/l10n/arb_consistency_test.dart
@@ -418,12 +418,16 @@ void main() {
 // Keys intentionally allowed to fall back to English until a translation pass.
 // Keep this list small and reviewable so new translation gaps stay visible.
 const _knownUntranslatedDebt = <String>{
+  // Translation pass tracked in #7632.
+  'analyticsConnectionIssue',
+  'analyticsDiagnosticsFailedSources',
+  'analyticsServerUnavailable',
   // Account restore failure copy is new; translation pass tracked in #7659.
-  // The social-proof and #7632 keys left this list when this branch
-  // translated them into every locale.
   'authAccountRestoreFailed',
   'settingsAccountRestoreFailed',
   'settingsAccountRestoreFailedSwitchMessage',
+  // The four social-proof keys and searchUserVideoCount left this list when
+  // this branch translated them into every locale.
 };
 
 const _profileBadgeSheetKeys = <String>{

--- a/mobile/test/providers/follow_relationship_provider_test.dart
+++ b/mobile/test/providers/follow_relationship_provider_test.dart
@@ -1,0 +1,127 @@
+// ABOUTME: Tests for Riverpod follow relationship warm-up lifecycle.
+// ABOUTME: Pins signed-out to ready transitions so follower cache warm-up reruns.
+
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:follow_repository/follow_repository.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:openvine/providers/follow_relationship_provider.dart';
+import 'package:openvine/providers/nostr_client_provider.dart';
+import 'package:openvine/providers/repository_providers.dart';
+
+class _MockFollowRepository extends Mock implements FollowRepository {}
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _TestNostrSession extends NostrSession {
+  _TestNostrSession(this._readiness);
+
+  final NostrSessionReadiness _readiness;
+
+  @override
+  NostrSessionReadiness build() => _readiness;
+}
+
+void main() {
+  const currentPubkey =
+      'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+  const targetPubkey =
+      'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+  test(
+    'warm-up waits for a ready Nostr session and reruns in the same container',
+    () async {
+      final repository = _MockFollowRepository();
+      final nostrClient = _MockNostrClient();
+      when(() => nostrClient.hasKeys).thenReturn(true);
+      when(() => nostrClient.publicKey).thenReturn(currentPubkey);
+      when(repository.getMyFollowers).thenAnswer((_) async => const <String>[]);
+
+      final container = ProviderContainer(
+        overrides: [
+          followRepositoryProvider.overrideWithValue(repository),
+          nostrSessionProvider.overrideWith(
+            () => _TestNostrSession(const NostrSessionReadiness.signedOut()),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await container.read(myFollowersWarmupProvider.future);
+      verifyNever(repository.getMyFollowers);
+
+      container
+          .read(nostrSessionProvider.notifier)
+          .update(
+            NostrSessionReadiness.nostrReady(
+              pubkey: currentPubkey,
+              client: nostrClient,
+            ),
+          );
+
+      await container.read(myFollowersWarmupProvider.future);
+      verify(repository.getMyFollowers).called(1);
+    },
+  );
+
+  test(
+    'relationship stream upgrades when follower warm-up completes',
+    () async {
+      final repository = _MockFollowRepository();
+      final nostrClient = _MockNostrClient();
+      final warmupCompleter = Completer<List<String>>();
+      var warmupComplete = false;
+
+      when(() => nostrClient.hasKeys).thenReturn(true);
+      when(() => nostrClient.publicKey).thenReturn(currentPubkey);
+      when(repository.getMyFollowers).thenAnswer((_) async {
+        final followers = await warmupCompleter.future;
+        warmupComplete = true;
+        return followers;
+      });
+      when(() => repository.relationshipTo(targetPubkey)).thenAnswer(
+        (_) => warmupComplete
+            ? FollowRelationship.mutual
+            : FollowRelationship.youFollow,
+      );
+      when(
+        () => repository.followingStream,
+      ).thenAnswer((_) => const Stream<List<String>>.empty());
+
+      final container = ProviderContainer(
+        overrides: [
+          followRepositoryProvider.overrideWithValue(repository),
+          nostrSessionProvider.overrideWith(
+            () => _TestNostrSession(
+              NostrSessionReadiness.nostrReady(
+                pubkey: currentPubkey,
+                client: nostrClient,
+              ),
+            ),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final emitted = <AsyncValue<FollowRelationship>>[];
+      final subscription = container.listen(
+        followRelationshipProvider(targetPubkey),
+        (_, next) => emitted.add(next),
+        fireImmediately: true,
+      );
+      addTearDown(subscription.close);
+
+      await Future<void>.delayed(Duration.zero);
+      expect(emitted.last.value, FollowRelationship.youFollow);
+
+      warmupCompleter.complete(const <String>[targetPubkey]);
+      await container.read(myFollowersWarmupProvider.future);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(emitted.last.value, FollowRelationship.mutual);
+    },
+  );
+}

--- a/mobile/test/screens/inbox/conversation/conversation_view_test.dart
+++ b/mobile/test/screens/inbox/conversation/conversation_view_test.dart
@@ -955,6 +955,28 @@ void main() {
         );
       });
 
+      testWidgets('does not render a self-reported Vine follower count', (
+        tester,
+      ) async {
+        final profile = UserProfile(
+          pubkey: otherPubkey,
+          name: 'Jack',
+          rawData: const {'vine_followers': 430},
+          createdAt: now,
+          eventId:
+              'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc',
+        );
+
+        await tester.pumpWidget(buildSubject(otherProfile: profile));
+        await tester.pump();
+        await tester.pump();
+
+        // vine_followers is the account's own kind-0 claim; only an
+        // authoritative follower_count earns a spot on the line.
+        expect(find.text(l10n.socialProofMutual), findsOneWidget);
+        expect(find.textContaining('430'), findsNothing);
+      });
+
       testWidgets(
         'renders collaborator invite as an inline video preview with co-post actions',
         (tester) async {

--- a/mobile/test/screens/inbox/conversation/conversation_view_test.dart
+++ b/mobile/test/screens/inbox/conversation/conversation_view_test.dart
@@ -14,6 +14,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:follow_repository/follow_repository.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/dm/conversation/collaborator_invite_actions_cubit.dart';
@@ -24,11 +25,14 @@ import 'package:openvine/config/official_accounts.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/collaborator_invite.dart';
 import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/follow_relationship_provider.dart';
+import 'package:openvine/providers/nip05_verification_provider.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/providers/watermark_download_provider.dart';
 import 'package:openvine/screens/inbox/conversation/conversation_page.dart';
 import 'package:openvine/screens/inbox/conversation/conversation_view.dart';
 import 'package:openvine/screens/inbox/conversation/widgets/widgets.dart';
+import 'package:openvine/services/nip05_verification_service.dart';
 import 'package:openvine/services/watermark_download_service.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
 import 'package:videos_repository/videos_repository.dart';
@@ -220,6 +224,12 @@ void main() {
           // The view now reads the blocklist eagerly in build() to filter
           // reaction reactors, so every pump needs a stubbed repository.
           contentBlocklistRepositoryProvider.overrideWithValue(mockBlocklist),
+          nip05VerificationProvider.overrideWith(
+            (ref, pubkey) async => Nip05VerificationStatus.none,
+          ),
+          followRelationshipProvider.overrideWith(
+            (ref, pubkey) => Stream.value(FollowRelationship.mutual),
+          ),
         ],
         home: BlocProvider<ConversationBloc>.value(
           value: mockBloc,
@@ -916,6 +926,33 @@ void main() {
         await tester.pump();
 
         expect(find.text('Alice'), findsOneWidget);
+      });
+
+      testWidgets('uses social proof instead of kind-0 name as handle', (
+        tester,
+      ) async {
+        final profile = UserProfile(
+          pubkey: otherPubkey,
+          name: 'Jack',
+          rawData: const {'follower_count': 2100},
+          createdAt: now,
+          eventId:
+              'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc',
+        );
+
+        await tester.pumpWidget(buildSubject(otherProfile: profile));
+        await tester.pump();
+        await tester.pump();
+
+        expect(find.text('Jack'), findsOneWidget);
+        expect(find.text('@Jack'), findsNothing);
+        expect(
+          find.text(
+            '${l10n.socialProofMutual} · '
+            '${l10n.socialProofFollowerCount(2100, '2.1K')}',
+          ),
+          findsOneWidget,
+        );
       });
 
       testWidgets(

--- a/mobile/test/screens/safety_settings_screen_test.dart
+++ b/mobile/test/screens/safety_settings_screen_test.dart
@@ -9,10 +9,12 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:follow_repository/follow_repository.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/content_label.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/protected_minor_providers.dart';
+import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/screens/safety_settings_screen.dart';
 import 'package:openvine/services/account_label_service.dart';
 import 'package:openvine/services/age_verification_service.dart';
@@ -21,6 +23,7 @@ import 'package:openvine/services/content_reporting_service.dart';
 import 'package:openvine/services/divine_host_filter_service.dart';
 import 'package:openvine/services/moderation_label_service.dart';
 import 'package:openvine/services/video_event_service.dart';
+import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class _MockContentBlocklistRepository extends Mock
@@ -107,6 +110,10 @@ void main() {
     late _MockContentFilterService mockContentFilterService;
     late _MockVideoEventService mockVideoEventService;
     late DivineHostFilterService divineHostFilterService;
+    const blockedPubkey =
+        'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+    const labelerPubkey =
+        'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
 
     setUp(() async {
       SharedPreferences.setMockInitialValues({});
@@ -158,7 +165,10 @@ void main() {
       ).thenAnswer((_) => const Stream<List<String>>.empty());
     });
 
-    Widget createTestWidget({bool isProtectedMinor = false}) {
+    Widget createTestWidget({
+      bool isProtectedMinor = false,
+      Map<String, UserProfile?> profiles = const {},
+    }) {
       final container = ProviderContainer(
         overrides: [
           contentBlocklistRepositoryProvider.overrideWithValue(
@@ -186,6 +196,9 @@ void main() {
             divineHostFilterService,
           ),
           isProtectedMinorProvider.overrideWithValue(isProtectedMinor),
+          userProfileReactiveProvider.overrideWith(
+            (ref, pubkey) => Stream.value(profiles[pubkey]),
+          ),
         ],
       );
 
@@ -222,6 +235,49 @@ void main() {
 
       expect(find.text(l10n.safetySettingsBlockedUsers), findsOneWidget);
     });
+
+    testWidgets('blocked users without profiles keep a full npub identifier', (
+      tester,
+    ) async {
+      await mockBlocklistRepository.blockUser(blockedPubkey);
+
+      await tester.pumpWidget(createTestWidget());
+      await tester.pumpAndSettle();
+
+      final npub = NostrKeyUtils.encodePubKey(blockedPubkey);
+      await tester.scrollUntilVisible(find.text(npub), 200);
+
+      expect(
+        find.text(UserProfile.defaultDisplayNameFor(blockedPubkey)),
+        findsOneWidget,
+      );
+      expect(find.text(npub), findsOneWidget);
+    });
+
+    testWidgets(
+      'custom labelers without profiles keep a full npub identifier',
+      (tester) async {
+        when(
+          () => mockModerationLabelService.customLabelers,
+        ).thenReturn({labelerPubkey});
+        when(() => mockModerationLabelService.subscribedLabelers).thenReturn({
+          ModerationLabelService.fallbackModerationPubkeyHex,
+          labelerPubkey,
+        });
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        final npub = NostrKeyUtils.encodePubKey(labelerPubkey);
+        await tester.scrollUntilVisible(find.text(npub), 200);
+
+        expect(
+          find.text(UserProfile.defaultDisplayNameFor(labelerPubkey)),
+          findsOneWidget,
+        );
+        expect(find.text(npub), findsOneWidget);
+      },
+    );
 
     testWidgets('should use dark background color', (tester) async {
       await tester.pumpWidget(createTestWidget());
@@ -339,10 +395,7 @@ void main() {
         );
         expect(tile.onChanged, isNull); // disabled: cannot be toggled
         expect(tile.value, isFalse);
-        expect(
-          find.text(l10n.safetySettingsAgeLockedForMinor),
-          findsOneWidget,
-        );
+        expect(find.text(l10n.safetySettingsAgeLockedForMinor), findsOneWidget);
       },
     );
 

--- a/mobile/test/screens/search_results/widgets/search_user_tile_test.dart
+++ b/mobile/test/screens/search_results/widgets/search_user_tile_test.dart
@@ -144,6 +144,23 @@ void main() {
       expect(find.textContaining('videos'), findsNothing);
     });
 
+    testWidgets('does not render a self-reported Vine follower count', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        buildSubject(
+          profileWith(nip05: '', rawData: const {'vine_followers': 430}),
+          relationship: FollowRelationship.mutual,
+        ),
+      );
+      await tester.pump();
+
+      // vine_followers is the account's own kind-0 claim; only an
+      // authoritative follower_count earns a spot on the line.
+      expect(find.text(l10n.socialProofMutual), findsOneWidget);
+      expect(find.textContaining('430'), findsNothing);
+    });
+
     testWidgets('shows social proof when there is no handle or video count', (
       tester,
     ) async {

--- a/mobile/test/screens/search_results/widgets/search_user_tile_test.dart
+++ b/mobile/test/screens/search_results/widgets/search_user_tile_test.dart
@@ -4,8 +4,10 @@
 import 'package:count_formatter/count_formatter.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:follow_repository/follow_repository.dart';
 import 'package:models/models.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/providers/follow_relationship_provider.dart';
 import 'package:openvine/providers/nip05_verification_provider.dart';
 import 'package:openvine/screens/search_results/widgets/search_user_tile.dart';
 import 'package:openvine/services/nip05_verification_service.dart';
@@ -34,11 +36,15 @@ void main() {
     Widget buildSubject(
       UserProfile profile, {
       Nip05VerificationStatus verificationStatus = Nip05VerificationStatus.none,
+      FollowRelationship relationship = FollowRelationship.none,
     }) {
       return testProviderScope(
         additionalOverrides: [
           nip05VerificationProvider.overrideWith(
             (ref, pubkey) async => verificationStatus,
+          ),
+          followRelationshipProvider.overrideWith(
+            (ref, pubkey) => Stream.value(relationship),
           ),
         ],
         child: MaterialApp(
@@ -115,13 +121,16 @@ void main() {
       expect(find.textContaining('npub'), findsNothing);
     });
 
-    testWidgets('falls back to the npub when the count and verified NIP-05 are '
-        'unknown', (tester) async {
+    testWidgets('keeps the claimed handle while verification is unresolved', (
+      tester,
+    ) async {
       await tester.pumpWidget(buildSubject(profileWith()));
       await tester.pump();
 
-      expect(find.textContaining('npub'), findsOneWidget);
-      expect(find.textContaining('_@lauren'), findsNothing);
+      // A pending or failed well-known fetch is a network condition, not an
+      // identity claim, so it must not demote the handle to a bare key.
+      expect(find.text('@lauren'), findsOneWidget);
+      expect(find.textContaining('npub'), findsNothing);
     });
 
     testWidgets('does not render Vine loop count as a video count', (
@@ -131,9 +140,40 @@ void main() {
         buildSubject(profileWith(rawData: const {'vine_loops': 5000})),
       );
 
-      expect(find.textContaining('npub'), findsOneWidget);
       expect(find.textContaining('5000'), findsNothing);
       expect(find.textContaining('videos'), findsNothing);
+    });
+
+    testWidgets('shows social proof when there is no handle or video count', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        buildSubject(
+          profileWith(nip05: '', rawData: const {'follower_count': 2100}),
+          relationship: FollowRelationship.mutual,
+        ),
+      );
+      await tester.pump();
+
+      expect(
+        find.text(
+          '${l10n.socialProofMutual} · '
+          '${l10n.socialProofFollowerCount(2100, '2.1K')}',
+        ),
+        findsOneWidget,
+      );
+      expect(find.textContaining('npub'), findsNothing);
+    });
+
+    testWidgets('renders no secondary line when nothing is known', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildSubject(profileWith(nip05: '')));
+      await tester.pump();
+
+      // An npub here would be noise, not disambiguation.
+      expect(find.text('Lauren Test'), findsOneWidget);
+      expect(find.textContaining('npub'), findsNothing);
     });
   });
 }

--- a/mobile/test/utils/user_identifier_line_resolver_test.dart
+++ b/mobile/test/utils/user_identifier_line_resolver_test.dart
@@ -140,5 +140,66 @@ void main() {
         expect(resolve(followerCount: 0), isNull);
       });
     });
+
+    group('localization', () {
+      String? resolveIn(
+        String locale, {
+        FollowRelationship relationship = FollowRelationship.none,
+        int? followerCount,
+      }) {
+        return resolveUserIdentifierLine(
+          l10n: lookupAppLocalizations(Locale(locale)),
+          locale: locale,
+          relationship: relationship,
+          followerCount: followerCount,
+        );
+      }
+
+      // One locale per plural shape the ARB files have to get right:
+      // Polish selects few/many, Japanese has no plural category at all,
+      // and Arabic is RTL with its own noun.
+      test('renders Polish, which selects a distinct few/many form', () {
+        expect(
+          resolveIn('pl', relationship: FollowRelationship.mutual),
+          equals('Obserwujecie się'),
+        );
+        expect(resolveIn('pl', followerCount: 1), equals('1 obserwujący'));
+        expect(resolveIn('pl', followerCount: 3), equals('3 obserwujących'));
+      });
+
+      test('renders Japanese, which has no plural distinction', () {
+        expect(
+          resolveIn('ja', relationship: FollowRelationship.followsYou),
+          equals('フォローされています'),
+        );
+        expect(resolveIn('ja', followerCount: 1), equals('フォロワー1人'));
+      });
+
+      test('renders Arabic', () {
+        expect(
+          resolveIn('ar', relationship: FollowRelationship.youFollow),
+          equals('تتابعه'),
+        );
+        expect(resolveIn('ar', followerCount: 12), equals('12 متابِع'));
+      });
+
+      test('translates every locale, leaving none on the English string', () {
+        final english = lookupAppLocalizations(const Locale('en'));
+        // 'fil' keeps the English loanword "Mutual" by design, matching how
+        // its sibling keys already borrow "Follower" and "video".
+        const sharesEnglishWording = {'fil'};
+
+        for (final locale in AppLocalizations.supportedLocales) {
+          final code = locale.languageCode;
+          if (code == 'en' || sharesEnglishWording.contains(code)) continue;
+
+          expect(
+            resolveIn(code, relationship: FollowRelationship.mutual),
+            isNot(equals(english.socialProofMutual)),
+            reason: '$code still falls back to the English "Mutual"',
+          );
+        }
+      });
+    });
   });
 }

--- a/mobile/test/utils/user_identifier_line_resolver_test.dart
+++ b/mobile/test/utils/user_identifier_line_resolver_test.dart
@@ -87,6 +87,17 @@ void main() {
           equals('Mutual'),
         );
       });
+
+      test('falls through when the handle is only whitespace', () {
+        expect(
+          resolve(handle: '   ', relationship: FollowRelationship.mutual),
+          equals('Mutual'),
+        );
+      });
+
+      test('trims surrounding whitespace off a usable handle', () {
+        expect(resolve(handle: '  @jack  '), equals('@jack'));
+      });
     });
 
     group('social proof fallback', () {

--- a/mobile/test/utils/user_identifier_line_resolver_test.dart
+++ b/mobile/test/utils/user_identifier_line_resolver_test.dart
@@ -1,0 +1,144 @@
+// ABOUTME: Tests the secondary identifier line shown under a display name
+// ABOUTME: Covers NIP-05 precedence and the social-proof fallback
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:follow_repository/follow_repository.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/services/nip05_verification_service.dart';
+import 'package:openvine/utils/user_identifier_line_resolver.dart';
+
+void main() {
+  group('resolveUserIdentifierLine', () {
+    late AppLocalizations l10n;
+
+    setUp(() {
+      l10n = lookupAppLocalizations(const Locale('en'));
+    });
+
+    String? resolve({
+      String? handle,
+      Nip05VerificationStatus? verificationStatus,
+      bool isOwnProfile = false,
+      FollowRelationship relationship = FollowRelationship.none,
+      int? followerCount,
+    }) {
+      return resolveUserIdentifierLine(
+        l10n: l10n,
+        locale: 'en',
+        handle: handle,
+        verificationStatus: verificationStatus,
+        isOwnProfile: isOwnProfile,
+        relationship: relationship,
+        followerCount: followerCount,
+      );
+    }
+
+    group('NIP-05 precedence', () {
+      test('shows the handle while verification is still pending', () {
+        expect(resolve(handle: '@jack'), equals('@jack'));
+      });
+
+      test('shows the handle when verification errored on the network', () {
+        expect(
+          resolve(
+            handle: '@jack',
+            verificationStatus: Nip05VerificationStatus.error,
+          ),
+          equals('@jack'),
+        );
+      });
+
+      test('shows the handle once verified', () {
+        expect(
+          resolve(
+            handle: '@jack',
+            verificationStatus: Nip05VerificationStatus.verified,
+          ),
+          equals('@jack'),
+        );
+      });
+
+      test('hides a handle that failed verification on another profile', () {
+        expect(
+          resolve(
+            handle: '@jack',
+            verificationStatus: Nip05VerificationStatus.failed,
+            followerCount: 12,
+          ),
+          equals('12 followers'),
+        );
+      });
+
+      test("keeps a failed handle on the viewer's own profile", () {
+        expect(
+          resolve(
+            handle: '@jack',
+            verificationStatus: Nip05VerificationStatus.failed,
+            isOwnProfile: true,
+          ),
+          equals('@jack'),
+        );
+      });
+
+      test('falls through when the handle is empty', () {
+        expect(
+          resolve(handle: '', relationship: FollowRelationship.mutual),
+          equals('Mutual'),
+        );
+      });
+    });
+
+    group('social proof fallback', () {
+      test('combines relationship and follower count', () {
+        expect(
+          resolve(
+            relationship: FollowRelationship.mutual,
+            followerCount: 2100,
+          ),
+          equals('Mutual · 2.1K followers'),
+        );
+      });
+
+      test('reports when the account follows the viewer', () {
+        expect(
+          resolve(relationship: FollowRelationship.followsYou),
+          equals('Follows you'),
+        );
+      });
+
+      test('reports when the viewer follows the account', () {
+        expect(
+          resolve(relationship: FollowRelationship.youFollow),
+          equals('You follow'),
+        );
+      });
+
+      test('shows only the count when there is no relationship', () {
+        expect(resolve(followerCount: 430), equals('430 followers'));
+      });
+
+      test('singularizes a lone follower', () {
+        expect(resolve(followerCount: 1), equals('1 follower'));
+      });
+
+      test('omits a zero follower count rather than showing "0 followers"', () {
+        expect(
+          resolve(
+            relationship: FollowRelationship.youFollow,
+            followerCount: 0,
+          ),
+          equals('You follow'),
+        );
+      });
+
+      test('returns null when nothing useful is known', () {
+        expect(resolve(), isNull);
+      });
+
+      test('returns null when the only signal is a zero count', () {
+        expect(resolve(followerCount: 0), isNull);
+      });
+    });
+  });
+}

--- a/mobile/test/widgets/settings_screen_test.dart
+++ b/mobile/test/widgets/settings_screen_test.dart
@@ -10,6 +10,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart' show UserProfile;
 import 'package:openvine/blocs/background_publish/background_publish_bloc.dart';
 import 'package:openvine/blocs/invite_availability/invite_availability_cubit.dart';
 import 'package:openvine/blocs/invite_status/invite_status_cubit.dart';
@@ -31,9 +32,10 @@ import 'package:openvine/screens/apps/apps_permissions_screen.dart';
 import 'package:openvine/screens/badges/badges_screen.dart';
 import 'package:openvine/screens/developer_options_screen.dart';
 import 'package:openvine/screens/settings/settings_screen.dart';
-import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/auth_service.dart' hide UserProfile;
 import 'package:openvine/services/draft_storage_service.dart';
 import 'package:openvine/services/environment_service.dart';
+import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:openvine/widgets/user_avatar.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -73,6 +75,8 @@ void main() {
     late _MockLocaleCubit mockLocaleCubit;
     late SharedPreferences sharedPreferences;
     final l10n = lookupAppLocalizations(const Locale('en'));
+    const currentPubkey =
+        'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
     final twoAccounts = [
       KnownAccount(
         pubkeyHex:
@@ -100,9 +104,7 @@ void main() {
 
       when(() => mockAuthService.isAuthenticated).thenReturn(true);
       when(() => mockAuthService.isAnonymous).thenReturn(false);
-      when(
-        () => mockAuthService.currentPublicKeyHex,
-      ).thenReturn('abc123pubkey');
+      when(() => mockAuthService.currentPublicKeyHex).thenReturn(currentPubkey);
       when(() => mockAuthService.authState).thenReturn(AuthState.authenticated);
       when(
         () => mockAuthService.authStateStream,
@@ -216,6 +218,10 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.byType(UserAvatar), findsOneWidget);
+      expect(
+        find.text(NostrKeyUtils.encodePubKey(currentPubkey)),
+        findsOneWidget,
+      );
 
       await tester.pumpWidget(const SizedBox());
       await tester.pump();
@@ -430,6 +436,103 @@ void main() {
       await tester.pumpWidget(const SizedBox());
       await tester.pump();
     });
+
+    testWidgets(
+      'account switcher uses full npub fallback for same-name accounts',
+      (tester) async {
+        const firstPubkey =
+            '1111111111111111111111111111111111111111111111111111111111111111';
+        const secondPubkey =
+            '2222222222222222222222222222222222222222222222222222222222222222';
+        final accounts = [
+          KnownAccount(
+            pubkeyHex: firstPubkey,
+            authSource: AuthenticationSource.automatic,
+            addedAt: DateTime(2024),
+            lastUsedAt: DateTime(2024),
+          ),
+          KnownAccount(
+            pubkeyHex: secondPubkey,
+            authSource: AuthenticationSource.automatic,
+            addedAt: DateTime(2024),
+            lastUsedAt: DateTime(2024),
+          ),
+        ];
+
+        await sharedPreferences.setBool('ff_accountSwitching', true);
+        when(() => mockAuthService.currentPublicKeyHex).thenReturn(firstPubkey);
+        when(
+          () => mockAuthService.getKnownAccounts(),
+        ).thenAnswer((_) async => accounts);
+        final publishBloc = _MockBackgroundPublishBloc();
+        when(
+          () => publishBloc.state,
+        ).thenReturn(const BackgroundPublishState());
+        whenListen(
+          publishBloc,
+          const Stream<BackgroundPublishState>.empty(),
+          initialState: const BackgroundPublishState(),
+        );
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              sharedPreferencesProvider.overrideWithValue(sharedPreferences),
+              authServiceProvider.overrideWithValue(mockAuthService),
+              draftStorageServiceProvider.overrideWithValue(
+                mockDraftStorageService,
+              ),
+              currentAuthStateProvider.overrideWith(
+                (ref) => AuthState.authenticated,
+              ),
+              knownAccountsProvider.overrideWith((ref) async => accounts),
+              userProfileReactiveProvider.overrideWith(
+                (ref, pubkey) => Stream.value(
+                  UserProfile(
+                    pubkey: pubkey,
+                    name: 'Jack',
+                    rawData: const {},
+                    createdAt: DateTime(2024),
+                    eventId: 'event-$pubkey',
+                  ),
+                ),
+              ),
+            ],
+            child: MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: MultiBlocProvider(
+                providers: [
+                  BlocProvider<InviteStatusCubit>.value(
+                    value: _createMockInviteCubit(),
+                  ),
+                  BlocProvider<LocaleCubit>.value(value: mockLocaleCubit),
+                  BlocProvider<BackgroundPublishBloc>.value(value: publishBloc),
+                ],
+                child: const SettingsScreen(),
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Switch account'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Jack'), findsWidgets);
+        expect(
+          find.text(NostrKeyUtils.encodePubKey(firstPubkey)),
+          findsWidgets,
+        );
+        expect(
+          find.text(NostrKeyUtils.encodePubKey(secondPubkey)),
+          findsOneWidget,
+        );
+
+        await tester.pumpWidget(const SizedBox());
+        await tester.pump();
+      },
+    );
 
     testWidgets('renders navigation tiles', (tester) async {
       await tester.pumpWidget(buildSubject());

--- a/mobile/test/widgets/settings_screen_test.dart
+++ b/mobile/test/widgets/settings_screen_test.dart
@@ -68,6 +68,17 @@ _MockInviteStatusCubit _createMockInviteCubit() {
   return cubit;
 }
 
+_MockBackgroundPublishBloc _stubbedPublishBloc() {
+  final bloc = _MockBackgroundPublishBloc();
+  when(() => bloc.state).thenReturn(const BackgroundPublishState());
+  whenListen(
+    bloc,
+    const Stream<BackgroundPublishState>.empty(),
+    initialState: const BackgroundPublishState(),
+  );
+  return bloc;
+}
+
 void main() {
   group(SettingsScreen, () {
     late _MockAuthService mockAuthService;
@@ -222,6 +233,65 @@ void main() {
         find.text(NostrKeyUtils.encodePubKey(currentPubkey)),
         findsOneWidget,
       );
+
+      await tester.pumpWidget(const SizedBox());
+      await tester.pump();
+    });
+
+    testWidgets('account header keeps the npub over the own follower count', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            sharedPreferencesProvider.overrideWithValue(sharedPreferences),
+            authServiceProvider.overrideWithValue(mockAuthService),
+            draftStorageServiceProvider.overrideWithValue(
+              mockDraftStorageService,
+            ),
+            currentAuthStateProvider.overrideWith(
+              (ref) => AuthState.authenticated,
+            ),
+            knownAccountsProvider.overrideWith((ref) async => const []),
+            // No NIP-05, but a follower count from the REST profile. Social
+            // proof must not stand in for the signed-in account's identifier.
+            userProfileReactiveProvider.overrideWith(
+              (ref, pubkey) => Stream.value(
+                UserProfile(
+                  pubkey: pubkey,
+                  name: 'Jack',
+                  rawData: const {'follower_count': 12},
+                  createdAt: DateTime(2024),
+                  eventId: 'event-$pubkey',
+                ),
+              ),
+            ),
+          ],
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: MultiBlocProvider(
+              providers: [
+                BlocProvider<InviteStatusCubit>.value(
+                  value: _createMockInviteCubit(),
+                ),
+                BlocProvider<LocaleCubit>.value(value: mockLocaleCubit),
+                BlocProvider<BackgroundPublishBloc>.value(
+                  value: _stubbedPublishBloc(),
+                ),
+              ],
+              child: const SettingsScreen(),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text(NostrKeyUtils.encodePubKey(currentPubkey)),
+        findsOneWidget,
+      );
+      expect(find.text(l10n.socialProofFollowerCount(12, '12')), findsNothing);
 
       await tester.pumpWidget(const SizedBox());
       await tester.pump();

--- a/mobile/test/widgets/user_profile_tile_identifier_test.dart
+++ b/mobile/test/widgets/user_profile_tile_identifier_test.dart
@@ -132,6 +132,23 @@ void main() {
       expect(find.textContaining('npub'), findsNothing);
     });
 
+    testWidgets('does not render a self-reported Vine follower count', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        buildSubject(
+          profile: profileWith(rawData: const {'vine_followers': 430}),
+          relationship: FollowRelationship.mutual,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // vine_followers is the account's own kind-0 claim; only an
+      // authoritative follower_count earns a spot on the line.
+      expect(find.text(l10n.socialProofMutual), findsOneWidget);
+      expect(find.textContaining('430'), findsNothing);
+    });
+
     testWidgets('renders no identifier line when nothing is known', (
       tester,
     ) async {

--- a/mobile/test/widgets/user_profile_tile_identifier_test.dart
+++ b/mobile/test/widgets/user_profile_tile_identifier_test.dart
@@ -1,0 +1,145 @@
+// ABOUTME: Widget tests for the user tile's secondary identifier line.
+// ABOUTME: Pins NIP-05 precedence and the social-proof fallback over npubs.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:follow_repository/follow_repository.dart';
+import 'package:models/models.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/providers/follow_relationship_provider.dart';
+import 'package:openvine/providers/nip05_verification_provider.dart';
+import 'package:openvine/providers/user_profile_providers.dart';
+import 'package:openvine/services/nip05_verification_service.dart';
+import 'package:openvine/widgets/user_profile_tile.dart';
+
+import '../helpers/test_provider_overrides.dart';
+
+void main() {
+  group('$UserProfileTile identifier line', () {
+    final l10n = lookupAppLocalizations(const Locale('en'));
+    const pubkey =
+        'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+    UserProfile profileWith({
+      String? nip05,
+      Map<String, dynamic> rawData = const {},
+    }) {
+      return UserProfile(
+        pubkey: pubkey,
+        name: 'Jack',
+        nip05: nip05,
+        rawData: rawData,
+        createdAt: DateTime(2024),
+        eventId: 'event1',
+      );
+    }
+
+    Widget buildSubject({
+      UserProfile? profile,
+      Nip05VerificationStatus verificationStatus = Nip05VerificationStatus.none,
+      FollowRelationship relationship = FollowRelationship.none,
+    }) {
+      return testProviderScope(
+        additionalOverrides: [
+          userProfileReactiveProvider.overrideWith(
+            (ref, key) => Stream.value(profile),
+          ),
+          nip05VerificationProvider.overrideWith(
+            (ref, key) async => verificationStatus,
+          ),
+          followRelationshipProvider.overrideWith(
+            (ref, key) => Stream.value(relationship),
+          ),
+        ],
+        child: const MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: UserProfileTile(pubkey: pubkey),
+          ),
+        ),
+      );
+    }
+
+    testWidgets('shows the handle rather than a key', (tester) async {
+      await tester.pumpWidget(
+        buildSubject(profile: profileWith(nip05: '_@jack.divine.video')),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('@jack'), findsOneWidget);
+      expect(find.textContaining('npub'), findsNothing);
+    });
+
+    testWidgets('keeps the handle when the well-known fetch errors', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        buildSubject(
+          profile: profileWith(nip05: '_@jack.divine.video'),
+          verificationStatus: Nip05VerificationStatus.error,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // A network failure is not an impersonation signal.
+      expect(find.text('@jack'), findsOneWidget);
+    });
+
+    testWidgets('replaces a mismatched handle with social proof', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        buildSubject(
+          profile: profileWith(
+            nip05: '_@jack.divine.video',
+            rawData: const {'follower_count': 430},
+          ),
+          verificationStatus: Nip05VerificationStatus.failed,
+          relationship: FollowRelationship.followsYou,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('@jack'), findsNothing);
+      expect(
+        find.text(
+          '${l10n.socialProofFollowsYou} · '
+          '${l10n.socialProofFollowerCount(430, '430')}',
+        ),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('falls back to social proof when there is no handle', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        buildSubject(
+          profile: profileWith(rawData: const {'follower_count': 2100}),
+          relationship: FollowRelationship.mutual,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text(
+          '${l10n.socialProofMutual} · '
+          '${l10n.socialProofFollowerCount(2100, '2.1K')}',
+        ),
+        findsOneWidget,
+      );
+      expect(find.textContaining('npub'), findsNothing);
+    });
+
+    testWidgets('renders no identifier line when nothing is known', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildSubject(profile: profileWith()));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Jack'), findsOneWidget);
+      expect(find.textContaining('npub'), findsNothing);
+    });
+  });
+}

--- a/mobile/test/widgets/user_profile_tile_layout_test.dart
+++ b/mobile/test/widgets/user_profile_tile_layout_test.dart
@@ -562,9 +562,11 @@ void main() {
 
         await tester.pumpAndSettle();
 
-        // Should still render with fallback content
+        // Should still render with fallback content. With no profile there is
+        // no handle and no social proof, so the row carries the generated
+        // display name alone rather than a bare key.
         expect(find.byType(UserProfileTile), findsOneWidget);
-        expect(find.text('npub1mis'), findsOneWidget); // Abbreviated pubkey
+        expect(find.textContaining('npub1mis'), findsNothing);
 
         // Should not crash
         expect(tester.takeException(), isNull);


### PR DESCRIPTION
## Description

Truncated npubs appear as the secondary identifier under a display name across the app. They are useless to essentially every user, and they do not answer the question that line exists to answer: *which* of the several accounts sharing this display name is this one?

This replaces them. Where a NIP-05 handle exists it is shown; otherwise the line carries social proof (follow relationship + follower count); when neither is known the line is omitted rather than filled with a key.

### 1. NIP-05 was being demoted by network conditions, not identity claims

`Nip05VerificationStatus` distinguishes `failed` (pubkey mismatch — a genuine impersonation signal) from `error` (the well-known fetch did not complete). Three call sites gated on `status == verified` and collapsed `error`, `pending`, and still-loading into "show an npub":

- `widgets/user_profile_tile.dart`
- `screens/search_results/widgets/search_user_tile.dart`
- `screens/settings/settings_screen.dart` — the **signed-in user's own** account header

Verification is a per-pubkey HTTP request to an arbitrary domain, and `.whenOrNull(data:)` yields `null` while in flight. Scrolling a list starts one request per row, so the npub was the *default* rendering rather than the exception — including for your own valid handle in Settings whenever the fetch was slow.

`widgets/profile/profile_header_identity.dart` already had this right: it demotes only on explicit `failed`, and only on someone else's profile. The other three now match it.

### 2. Social proof replaces the npub fallback

`FollowRepository` already holds both the following list and the my-followers cache in memory, so the relationship is a set-membership test — no network request at render time, and it is safe to read per row while a list scrolls. One shared warm-up populates the follower cache per session rather than per row.

It degrades honestly: before the follower cache lands, "follows you" is unknowable, so a mutual reads as "You follow" rather than claiming a relationship that may not exist. The answer only ever upgrades as data arrives.

`Mutual · 2.1K followers` / `Follows you · 12 followers` / `430 followers`

### 3. Two lists never consulted NIP-05 at all

- `safety_settings_screen.dart` — the blocked-user subtitle rendered a bare key even with the profile loaded and a handle sitting in it.
- `safety_settings_screen.dart` — custom labeler rows did no profile lookup whatsoever. Labelers are ordinary accounts with a kind 0, so the name and handle a person recognises were available all along. Extracted into a widget class to do the lookup, which also removes a `Widget`-returning closure.

Blocked users deliberately get **no** relationship line — "You follow" under an account you have blocked reads as a contradiction.

### 4. Translated into every locale, and `searchUserVideoCount` with it

All 21 non-English locales carry the four social-proof keys. `searchUserVideoCount` is translated in the same pass because it renders on the same line of the same search row — translating only the new keys would have produced a half-English line, which is worse than either extreme. `_knownUntranslatedDebt` is now **empty**, so the ARB key-parity test runs with no allowlist.

Plural categories and nouns follow **each locale's own precedent** rather than one template applied 21 times — `videoFeedLoopCountLine` for the compact-count shape, `messageRequestFollowersCount` for the follower noun, `exploreNewVideosCount` for the video noun. Consequences worth spot-checking in review:

- Polish selects `one/few/many/other`; Japanese, Korean and Chinese carry no plural category at all
- Japanese uses 動画 and Korean 영상, not transliterations; Polish uses *film*, not *wideo*
- Gendered languages take a form that avoids agreement — *Siguiendo*, *Segui*, *Urmărești*, *Obserwujesz* — because the subject's gender is unknown at the call site
- Filipino keeps the English loanword "Mutual", matching how its sibling keys already borrow "Follower" and "video". It is the one locale explicitly exempted from the no-English-fallback sweep test

**These are my translations, not a translation vendor's.** They are consistent with each locale's existing vocabulary in this repo, but a native speaker should sanity-check the short relationship labels in particular — "Mutual" as a standalone chip is the kind of string that reads naturally in one language and stilted in another.

**Related Issue:** Closes #7616

## Out of Scope

- **Nothing translation-related.** See section 4 above — `_knownUntranslatedDebt` is now empty.
- **"Followed by Alice and 3 others you follow."** This is the strongest disambiguation signal for a stranger, but it needs the *target's* follower list — a per-row network request with the same latency profile as the NIP-05 fetch this PR is working around. It needs a batched social-graph intersection endpoint first; adding it now would reintroduce the flicker in a new place.
- `test/widgets/user_profile_tile_layout_test.dart` remains `skip: true` with its pre-existing `// TODO(any): Fix and re-enable`. I did not re-enable it, but I corrected the one assertion my change made actively false rather than leave it lying.

## Verification

- `flutter analyze lib test integration_test` — clean
- `flutter test` over `test/widgets test/utils test/l10n test/screens/settings test/screens/search_results test/screens/safety_settings_screen_test.dart` — **4196 passed, 43 skipped** (skips pre-existing)
- `flutter test test/screens/inbox/conversation/` — 231 passed
- `follow_repository`: full suite **286 passed**, `flutter test --coverage` at **100.00% (852/852)**, no uncovered lines. This package sets no `min_coverage`, so the VGV default of 100% is a hard gate.
- `flutter test test/l10n/arb_consistency_test.dart` — 28 passed, key parity and placeholder parity both green with an **empty** debt allowlist
- `flutter gen-l10n` — clean, no ICU parse errors in any of the 22 locales
- Re-ran after the translation pass: `flutter test test/utils test/l10n test/widgets test/screens/search_results test/screens/settings test/screens/safety_settings_screen_test.dart` — **4200 passed, 43 skipped**
- `dart run build_runner build --delete-conflicting-outputs` then `git status` — clean, generated files in sync
- Golden tests: `flutter test --dart-define=DIVINE_GOLDEN_TESTS=true test/goldens/` — 2 passed
- Ratchets run locally, all OK: raw-TextStyle, raw-colors, material-button, raw-dialog, untested-services floor, test/unit structure, post-close-emit, layer-direction

**What I could not verify:** I have not run this on a device or simulator, so there are no screenshots. The line's rendered width under a long handle plus a large follower count is untested visually — every call site keeps `maxLines: 1` + `TextOverflow.ellipsis`, but I have not seen it. `mobile/scripts/golden.sh` itself fails in my environment before running anything, on an unrelated `objective_c` native-assets `Invalid SDK hash` error; I ran the underlying golden test path directly instead, which is why the wrapper is not cited above.

**New UI text colors** use `context.vineColors.*` tokens, so both appearances are covered by construction — but I have not eyeballed light mode.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)


