### PR TITLE
test(divine-ui): pin info card tone tokens

### DIFF
--- a/mobile/docs/DESIGN_SYSTEM_COMPONENTS.md
+++ b/mobile/docs/DESIGN_SYSTEM_COMPONENTS.md
@@ -69,7 +69,7 @@ Complete dark-mode design system providing:
 | `DivineInfoCard` | Explanation callout — icon, optional title, body, optional footer. Four tones (`info`, `neutral`, `warning`, `error`) and a `compact` step. Replaces the per-screen "about this setting" boxes. |
 
 **DivineInfoCard tones:**
-- `info` — brand green, for explaining a feature or a concept (default)
+- `info` — `accentPositive`, for explaining a feature or a concept (default). This is brand green in dark mode and a darker green in light mode.
 - `neutral` — card surface with a muted outline, for detail that should recede
 - `warning` — something to read before acting
 - `error` — a risk or a failure

--- a/mobile/packages/divine_ui/lib/src/info_card/divine_info_card.dart
+++ b/mobile/packages/divine_ui/lib/src/info_card/divine_info_card.dart
@@ -85,7 +85,8 @@ class DivineInfoCard extends StatelessWidget {
   /// supporting rows a longer explanation breaks into.
   final Widget? footer;
 
-  /// Accent colour for the icon, surface, border, and a tinted tone's title.
+  /// Accent colour for the icon, and for a tinted tone's surface, border,
+  /// and title.
   Color _accent(VineThemeColors colors) => switch (tone) {
     DivineInfoCardTone.info => colors.accentPositive,
     DivineInfoCardTone.neutral => colors.secondaryText,

--- a/mobile/packages/divine_ui/lib/src/info_card/divine_info_card.dart
+++ b/mobile/packages/divine_ui/lib/src/info_card/divine_info_card.dart
@@ -4,7 +4,8 @@ import 'package:flutter/material.dart';
 
 /// What a [DivineInfoCard] means, which picks its accent colour.
 enum DivineInfoCardTone {
-  /// Explains a feature or a concept. The default, in brand green.
+  /// Explains a feature or a concept. The default, using `accentPositive`:
+  /// brand green in dark mode and a darker green in light mode.
   info,
 
   /// Supporting detail that should not compete with the content around it.
@@ -84,7 +85,7 @@ class DivineInfoCard extends StatelessWidget {
   /// supporting rows a longer explanation breaks into.
   final Widget? footer;
 
-  /// Accent colour for the icon, the border, and a tinted tone's title.
+  /// Accent colour for the icon, surface, border, and a tinted tone's title.
   Color _accent(VineThemeColors colors) => switch (tone) {
     DivineInfoCardTone.info => colors.accentPositive,
     DivineInfoCardTone.neutral => colors.secondaryText,

--- a/mobile/packages/divine_ui/test/src/info_card/divine_info_card_test.dart
+++ b/mobile/packages/divine_ui/test/src/info_card/divine_info_card_test.dart
@@ -10,9 +10,10 @@ void main() {
       DivineInfoCardTone tone = DivineInfoCardTone.info,
       bool compact = false,
       Widget? footer,
+      ThemeData? theme,
     }) {
       return MaterialApp(
-        theme: VineTheme.theme,
+        theme: theme ?? VineTheme.theme,
         home: Scaffold(
           body: DivineInfoCard(
             message: 'Your keys are your account.',
@@ -186,28 +187,51 @@ void main() {
     });
 
     group('tone', () {
-      testWidgets('info tints surface and border with brand green', (
+      testWidgets('info follows accentPositive in both appearances', (
         tester,
       ) async {
         await tester.pumpWidget(buildSubject(title: 'Heading'));
+        await tester.pumpAndSettle();
 
         final decoration = decorationOf(tester);
+        final darkAccent = VineTheme.darkColors.accentPositive;
         expect(
           decoration.color,
-          VineTheme.vineGreen.withValues(alpha: DivineInfoCard.surfaceOpacity),
+          darkAccent.withValues(alpha: DivineInfoCard.surfaceOpacity),
         );
         expect(
           (decoration.border! as Border).top.color,
-          VineTheme.vineGreen.withValues(alpha: DivineInfoCard.borderOpacity),
+          darkAccent.withValues(alpha: DivineInfoCard.borderOpacity),
         );
-        expect(iconOf(tester).color, VineTheme.vineGreen);
-        expect(styleOf(tester, 'Heading').color, VineTheme.vineGreen);
+        expect(iconOf(tester).color, darkAccent);
+        expect(styleOf(tester, 'Heading').color, darkAccent);
+
+        await tester.pumpWidget(
+          buildSubject(title: 'Heading', theme: VineTheme.lightTheme),
+        );
+        await tester.pumpAndSettle();
+
+        final lightDecoration = decorationOf(tester);
+        final lightAccent = VineTheme.lightColors.accentPositive;
+        expect(
+          lightDecoration.color,
+          lightAccent.withValues(alpha: DivineInfoCard.surfaceOpacity),
+        );
+        expect(
+          (lightDecoration.border! as Border).top.color,
+          lightAccent.withValues(alpha: DivineInfoCard.borderOpacity),
+        );
+        expect(iconOf(tester).color, lightAccent);
+        expect(styleOf(tester, 'Heading').color, lightAccent);
+        expect(
+          lightAccent,
+          isNot(VineTheme.vineGreen),
+          reason: 'light mode must use accentPositive, not raw brand green',
+        );
       });
 
       testWidgets('warning tints with the warning colour', (tester) async {
-        await tester.pumpWidget(
-          buildSubject(tone: DivineInfoCardTone.warning),
-        );
+        await tester.pumpWidget(buildSubject(tone: DivineInfoCardTone.warning));
 
         expect(
           decorationOf(tester).color,
@@ -232,15 +256,40 @@ void main() {
         await tester.pumpWidget(
           buildSubject(title: 'Heading', tone: DivineInfoCardTone.neutral),
         );
+        await tester.pumpAndSettle();
 
         final decoration = decorationOf(tester);
-        expect(decoration.color, VineTheme.cardBackground);
+        expect(decoration.color, VineTheme.darkColors.card);
         expect(
           (decoration.border! as Border).top.color,
-          VineTheme.outlineMuted,
+          VineTheme.darkColors.outlineMuted,
         );
-        expect(iconOf(tester).color, VineTheme.secondaryText);
-        expect(styleOf(tester, 'Heading').color, VineTheme.primaryText);
+        expect(iconOf(tester).color, VineTheme.darkColors.secondaryText);
+        expect(
+          styleOf(tester, 'Heading').color,
+          VineTheme.darkColors.primaryText,
+        );
+
+        await tester.pumpWidget(
+          buildSubject(
+            title: 'Heading',
+            tone: DivineInfoCardTone.neutral,
+            theme: VineTheme.lightTheme,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final lightDecoration = decorationOf(tester);
+        expect(lightDecoration.color, VineTheme.lightColors.card);
+        expect(
+          (lightDecoration.border! as Border).top.color,
+          VineTheme.lightColors.outlineMuted,
+        );
+        expect(iconOf(tester).color, VineTheme.lightColors.secondaryText);
+        expect(
+          styleOf(tester, 'Heading').color,
+          VineTheme.lightColors.primaryText,
+        );
       });
     });
 
@@ -248,10 +297,7 @@ void main() {
       testWidgets('uses the section-level metrics by default', (tester) async {
         await tester.pumpWidget(buildSubject(title: 'Heading'));
 
-        expect(
-          decorationOf(tester).borderRadius,
-          BorderRadius.circular(12),
-        );
+        expect(decorationOf(tester).borderRadius, BorderRadius.circular(12));
         expect(iconOf(tester).size, 24);
         expect(
           tester


### PR DESCRIPTION
## Summary
- update DivineInfoCard info-tone docs to name accentPositive instead of raw brand green
- assert info-tone icon, title, surface, and border against accentPositive in both dark and light appearances
- extend the adjacent neutral-tone test to cover light-mode theme tokens too

The default info-card wash intentionally follows accentPositive in light mode. Because DivineInfoCard derives foreground, border, and surface wash from one accent, the light fill and border should stay on accentPositive rather than special-casing a separate raw brand-green wash.

Closes #7605.

## Verification
- cd mobile/packages/divine_ui && flutter test
- cd mobile/packages/divine_ui && flutter analyze
- pre-push hook: analyzer and packages/divine_ui/test/src/info_card/divine_info_card_test.dart