### PR TITLE
fix(auth): bound the NIP-46 callback relay handoff

### DIFF
--- a/mobile/lib/services/deep_link_service.dart
+++ b/mobile/lib/services/deep_link_service.dart
@@ -470,7 +470,7 @@ class DeepLinkService {
     if (trimmed == null || trimmed.isEmpty) return null;
     if (!isSignerCallbackRelayUrlAllowed(trimmed)) {
       Log.warning(
-        'Refused signer callback relay $trimmed',
+        'Refused signer callback relay ${redactUriStringForLogs(trimmed)}',
         name: 'DeepLinkService',
         category: LogCategory.auth,
       );

--- a/mobile/lib/services/deep_link_service.dart
+++ b/mobile/lib/services/deep_link_service.dart
@@ -5,6 +5,7 @@ import 'dart:async';
 
 import 'package:app_links/app_links.dart';
 import 'package:openvine/utils/public_identifier_normalizer.dart';
+import 'package:openvine/utils/relay_url_utils.dart';
 import 'package:openvine/utils/sensitive_uri_for_logs.dart';
 import 'package:unified_logger/unified_logger.dart';
 
@@ -459,11 +460,13 @@ class DeepLinkService {
     return null;
   }
 
+  /// The relay a signer named in its callback, or null when we may not dial it.
+  ///
+  /// Any app can open this scheme, so the hint is only as trustworthy as the
+  /// caller. Dropping it leaves the callback itself intact: the pairing
+  /// handoff still reconnects the relays the session advertised.
   static String? _validSignerCallbackRelay(String? relay) {
-    if (relay == null || relay.isEmpty) return null;
-    final uri = Uri.tryParse(relay);
-    if (uri == null || uri.host.isEmpty) return null;
-    if (uri.scheme != 'wss' && uri.scheme != 'ws') return null;
+    if (relay == null || !isSignerCallbackRelayUrlAllowed(relay)) return null;
     return relay;
   }
 

--- a/mobile/lib/services/deep_link_service.dart
+++ b/mobile/lib/services/deep_link_service.dart
@@ -466,8 +466,17 @@ class DeepLinkService {
   /// caller. Dropping it leaves the callback itself intact: the pairing
   /// handoff still reconnects the relays the session advertised.
   static String? _validSignerCallbackRelay(String? relay) {
-    if (relay == null || !isSignerCallbackRelayUrlAllowed(relay)) return null;
-    return relay;
+    final trimmed = relay?.trim();
+    if (trimmed == null || trimmed.isEmpty) return null;
+    if (!isSignerCallbackRelayUrlAllowed(trimmed)) {
+      Log.warning(
+        'Refused signer callback relay $trimmed',
+        name: 'DeepLinkService',
+        category: LogCategory.auth,
+      );
+      return null;
+    }
+    return trimmed;
   }
 
   static String _describeUriForLogs(Uri uri) {

--- a/mobile/lib/utils/relay_url_utils.dart
+++ b/mobile/lib/utils/relay_url_utils.dart
@@ -18,7 +18,8 @@ export 'package:nostr_sdk/nostr_sdk.dart'
         isLoopbackHost,
         isPrivateOrLinkLocalHost,
         isRelayUrlAllowed,
-        isRemoteSuppliedRelayUrlAllowed;
+        isRemoteSuppliedRelayUrlAllowed,
+        isSignerCallbackRelayUrlAllowed;
 
 const _divineRelayHost = 'relay.divine.video';
 const _divineApiBaseUrl = 'https://api.divine.video';

--- a/mobile/packages/nostr_sdk/lib/nip46/nostr_connect_session.dart
+++ b/mobile/packages/nostr_sdk/lib/nip46/nostr_connect_session.dart
@@ -17,6 +17,7 @@ import '../relay/relay_base.dart';
 import '../relay/relay_mode.dart';
 import '../relay/relay_status.dart';
 import '../signer/local_nostr_signer.dart';
+import '../utils/relay_url_policy.dart';
 import '../utils/string_util.dart';
 import 'nostr_remote_response.dart';
 import 'nostr_remote_signer_info.dart';
@@ -171,6 +172,10 @@ class NostrConnectSession {
   // Internal state
   LocalNostrSigner? _localSigner;
   final List<Relay> _relays = [];
+
+  /// How many of [_relays] a signer named in a callback rather than the
+  /// session advertising them. Bounded by [RelayListCaps.nip46Callback].
+  int _signerSuppliedRelayCount = 0;
   Completer<NostrConnectResult?>? _connectionCompleter;
   Timer? _timeoutTimer;
   bool _isClosed = false;
@@ -325,10 +330,23 @@ class NostrConnectSession {
   /// Some same-device signers return a callback relay after the user approves
   /// the connection. Connect to it in addition to the original nostrconnect://
   /// relays so the response event can arrive on the signer's chosen transport.
+  ///
+  /// At most [RelayListCaps.nip46Callback] of them are adopted per session:
+  /// the callback is a deep link, so anything on the device can deliver one,
+  /// and nothing else bounds how many arrive while a session is listening.
+  /// Only relays that actually connected count — a failed dial leaves the
+  /// budget for the signer's next attempt.
   Future<void> addRelay(String relayUrl) async {
     if (_isClosed || _state != NostrConnectState.listening) return;
     if (relays.contains(relayUrl) ||
         _relays.any((relay) => relay.relayStatus.addr == relayUrl)) {
+      return;
+    }
+    if (_signerSuppliedRelayCount >= RelayListCaps.nip46Callback) {
+      logger(
+        '[NostrConnectSession] Ignoring callback relay $relayUrl - '
+        'already holding ${RelayListCaps.nip46Callback}',
+      );
       return;
     }
 
@@ -339,6 +357,7 @@ class NostrConnectSession {
         return;
       }
       _relays.add(relay);
+      _signerSuppliedRelayCount++;
       logger('[NostrConnectSession] Added callback relay $relayUrl');
     } catch (e) {
       logger(

--- a/mobile/packages/nostr_sdk/lib/nip46/nostr_connect_session.dart
+++ b/mobile/packages/nostr_sdk/lib/nip46/nostr_connect_session.dart
@@ -17,6 +17,7 @@ import '../relay/relay_base.dart';
 import '../relay/relay_mode.dart';
 import '../relay/relay_status.dart';
 import '../signer/local_nostr_signer.dart';
+import '../utils/relay_addr_util.dart';
 import '../utils/relay_url_policy.dart';
 import '../utils/string_util.dart';
 import 'nostr_remote_response.dart';
@@ -175,7 +176,17 @@ class NostrConnectSession {
 
   /// How many of [_relays] a signer named in a callback rather than the
   /// session advertising them. Bounded by [RelayListCaps.nip46Callback].
+  ///
+  /// A slot is taken before the dial and released if the dial fails, so
+  /// callbacks that arrive inside one connect window cannot each observe a
+  /// pre-dial count and collectively overshoot the cap.
   int _signerSuppliedRelayCount = 0;
+
+  /// Dedupe keys of callback relays currently being dialed.
+  ///
+  /// [_relays] only holds relays that finished connecting, so without this a
+  /// second callback naming the same URL opens a second socket to it.
+  final Set<String> _pendingSignerRelays = {};
   Completer<NostrConnectResult?>? _connectionCompleter;
   Timer? _timeoutTimer;
   bool _isClosed = false;
@@ -336,10 +347,18 @@ class NostrConnectSession {
   /// and nothing else bounds how many arrive while a session is listening.
   /// Only relays that actually connected count — a failed dial leaves the
   /// budget for the signer's next attempt.
+  ///
+  /// Callers dispatch this without awaiting, so the cap is claimed before the
+  /// dial rather than after it: reading the count, awaiting, then incrementing
+  /// would let every call in one connect window see the same pre-dial count.
   Future<void> addRelay(String relayUrl) async {
     if (_isClosed || _state != NostrConnectState.listening) return;
-    if (relays.contains(relayUrl) ||
-        _relays.any((relay) => relay.relayStatus.addr == relayUrl)) {
+    final key = _relayDedupeKey(relayUrl);
+    if (relays.any((url) => _relayDedupeKey(url) == key) ||
+        _relays.any(
+          (relay) => _relayDedupeKey(relay.relayStatus.addr) == key,
+        ) ||
+        _pendingSignerRelays.contains(key)) {
       return;
     }
     if (_signerSuppliedRelayCount >= RelayListCaps.nip46Callback) {
@@ -350,20 +369,37 @@ class NostrConnectSession {
       return;
     }
 
+    _signerSuppliedRelayCount++;
+    _pendingSignerRelays.add(key);
     try {
       final relay = await _connectToRelay(relayUrl);
       if (_isClosed) {
         relay.disconnect();
+        _signerSuppliedRelayCount--;
         return;
       }
       _relays.add(relay);
-      _signerSuppliedRelayCount++;
       logger('[NostrConnectSession] Added callback relay $relayUrl');
     } catch (e) {
+      _signerSuppliedRelayCount--;
       logger(
         '[NostrConnectSession] Failed to add callback relay $relayUrl: $e',
       );
+    } finally {
+      _pendingSignerRelays.remove(key);
     }
+  }
+
+  /// The identity callback relays are deduplicated under.
+  ///
+  /// [RelayAddrUtil.handle] collapses a bare address to a root path for every
+  /// address this package dials, so `wss://h` and `wss://h/` are one relay to
+  /// the pool. Matching that here keeps a respelling from costing a second
+  /// slot of the cap. An unparseable address keys under itself.
+  String _relayDedupeKey(String url) {
+    final trimmed = url.trim();
+    if (Uri.tryParse(trimmed) == null) return trimmed;
+    return RelayAddrUtil.handle(trimmed);
   }
 
   /// Clean up resources.

--- a/mobile/packages/nostr_sdk/lib/nip46/nostr_connect_session.dart
+++ b/mobile/packages/nostr_sdk/lib/nip46/nostr_connect_session.dart
@@ -174,12 +174,12 @@ class NostrConnectSession {
   LocalNostrSigner? _localSigner;
   final List<Relay> _relays = [];
 
-  /// How many of [_relays] a signer named in a callback rather than the
-  /// session advertising them. Bounded by [RelayListCaps.nip46Callback].
+  /// How many relays a signer named in a callback rather than the session
+  /// advertising them. Bounded by [RelayListCaps.nip46Callback].
   ///
-  /// A slot is taken before the dial and released if the dial fails, so
-  /// callbacks that arrive inside one connect window cannot each observe a
-  /// pre-dial count and collectively overshoot the cap.
+  /// Counts slots, not entries in [_relays]: one is taken before the dial and
+  /// released if the dial fails, so callbacks arriving inside one connect
+  /// window cannot each observe a pre-dial count and overshoot the cap.
   int _signerSuppliedRelayCount = 0;
 
   /// Dedupe keys of callback relays currently being dialed.

--- a/mobile/packages/nostr_sdk/lib/nip46/nostr_connect_session.dart
+++ b/mobile/packages/nostr_sdk/lib/nip46/nostr_connect_session.dart
@@ -24,6 +24,7 @@ import 'nostr_remote_response.dart';
 import 'nostr_remote_signer_info.dart';
 
 const _relayConnectTimeout = Duration(seconds: 8);
+const _relayFailedConnectCleanupTimeout = Duration(seconds: 1);
 
 /// State of a nostrconnect:// session.
 enum NostrConnectState {
@@ -459,16 +460,24 @@ class NostrConnectSession {
       }
     };
 
-    // Add subscription for listening to responses
-    await _addSubscription(relay);
+    try {
+      // Add subscription for listening to responses
+      await _addSubscription(relay);
 
-    final connected = await relay.connect().timeout(_relayConnectTimeout);
-    if (!connected) {
-      throw StateError('Relay connect returned false');
+      final connected = await relay.connect().timeout(_relayConnectTimeout);
+      if (!connected) {
+        throw StateError('Relay connect returned false');
+      }
+      logger('[NostrConnectSession] Connected to $relayAddr');
+
+      return relay;
+    } catch (_) {
+      relay.onMessage = null;
+      try {
+        await relay.disconnect().timeout(_relayFailedConnectCleanupTimeout);
+      } catch (_) {}
+      rethrow;
     }
-    logger('[NostrConnectSession] Connected to $relayAddr');
-
-    return relay;
   }
 
   Future<void> _reconnectRelay(Relay relay) async {

--- a/mobile/packages/nostr_sdk/lib/utils/loopback_host.dart
+++ b/mobile/packages/nostr_sdk/lib/utils/loopback_host.dart
@@ -4,15 +4,14 @@
 
 import 'package:flutter/foundation.dart';
 
+/// The hosts that name an interface on this device. `::1` is the IPv6
+/// loopback.
+const Set<String> _onDeviceLoopbackHosts = {'localhost', '127.0.0.1', '::1'};
+
 /// The hosts the local Docker stack is reachable on (see AGENTS.md,
 /// "Local Stack Development"). `10.0.2.2` is the Android emulator's alias
-/// for the host machine; `::1` is the IPv6 loopback.
-const Set<String> _loopbackHosts = {
-  'localhost',
-  '127.0.0.1',
-  '::1',
-  '10.0.2.2',
-};
+/// for the host machine.
+const Set<String> _loopbackHosts = {..._onDeviceLoopbackHosts, '10.0.2.2'};
 
 /// Whether [host] is a local-stack loopback host.
 ///
@@ -21,6 +20,17 @@ const Set<String> _loopbackHosts = {
 /// these hosts, but remote hosts (the divine relay, the funnelcake API)
 /// must always pass platform certificate validation.
 bool isLoopbackHost(String host) => _loopbackHosts.contains(host.toLowerCase());
+
+/// Whether [host] names a loopback interface on this device.
+///
+/// Narrower than [isLoopbackHost], which also admits `10.0.2.2`. Only the
+/// Android emulator maps that alias to the host machine; everywhere else it is
+/// an ordinary routable 10/8 LAN address, and [isPrivateOrLinkLocalHost]
+/// refuses it. Use this where the point is "traffic here never leaves the
+/// device" — a same-device NIP-46 signer naming its own relay, say — rather
+/// than "the local stack is reachable here".
+bool isOnDeviceLoopbackHost(String host) =>
+    _onDeviceLoopbackHosts.contains(host.toLowerCase());
 
 /// Whether a bad TLS certificate may be tolerated for [host].
 ///

--- a/mobile/packages/nostr_sdk/lib/utils/loopback_host.dart
+++ b/mobile/packages/nostr_sdk/lib/utils/loopback_host.dart
@@ -58,9 +58,19 @@ bool isPrivateOrLinkLocalHost(String host) {
   final normalized = host.toLowerCase().trim();
   if (normalized.isEmpty) return true;
   // A bracketed IPv6 literal arrives with its brackets when read off a URI.
-  final bare = normalized.startsWith('[') && normalized.endsWith(']')
+  final bracketless = normalized.startsWith('[') && normalized.endsWith(']')
       ? normalized.substring(1, normalized.length - 1)
       : normalized;
+
+  // A trailing dot root-anchors a name without changing what it resolves to,
+  // so `localhost.` and `192.168.1.1.` must be judged as their bare forms.
+  // Left in, the dot breaks every lookup below: it adds an empty fifth part
+  // that defeats [_tryParseIPv4], and it misses both [isLoopbackHost] and
+  // [_privateHostSuffixes] on the name comparison.
+  final bare = bracketless.endsWith('.')
+      ? bracketless.substring(0, bracketless.length - 1)
+      : bracketless;
+  if (bare.isEmpty) return true;
 
   final ipv4 = _tryParseIPv4(bare);
   if (ipv4 != null) return _isPrivateIPv4(ipv4);

--- a/mobile/packages/nostr_sdk/lib/utils/loopback_host.dart
+++ b/mobile/packages/nostr_sdk/lib/utils/loopback_host.dart
@@ -77,9 +77,7 @@ bool isPrivateOrLinkLocalHost(String host) {
   // Left in, the dot breaks every lookup below: it adds an empty fifth part
   // that defeats [_tryParseIPv4], and it misses both [isLoopbackHost] and
   // [_privateHostSuffixes] on the name comparison.
-  final bare = bracketless.endsWith('.')
-      ? bracketless.substring(0, bracketless.length - 1)
-      : bracketless;
+  final bare = bracketless.replaceFirst(RegExp(r'\.+$'), '');
   if (bare.isEmpty) return true;
 
   final ipv4 = _tryParseIPv4(bare);

--- a/mobile/packages/nostr_sdk/lib/utils/relay_url_policy.dart
+++ b/mobile/packages/nostr_sdk/lib/utils/relay_url_policy.dart
@@ -86,11 +86,17 @@ bool isRemoteSuppliedRelayUrlAllowed(String url) {
 /// link, so whoever opened it chose this URL, and it must not be able to point
 /// the device at the user's LAN or VPN. Cleartext stays confined to loopback,
 /// where it never leaves the device.
+///
+/// That last claim is why the carve-out is [isOnDeviceLoopbackHost] rather
+/// than [isLoopbackHost]: the latter also admits `10.0.2.2`, which only the
+/// Android emulator maps to the host machine and which is a routable LAN
+/// address on a physical device. A signer running on this device reaches its
+/// own relay at `localhost` / `127.0.0.1` / `::1`, so nothing legitimate is
+/// lost, and the local-stack allowance in [isRelayUrlAllowed] is untouched.
 bool isSignerCallbackRelayUrlAllowed(String url) {
   final uri = _tryParseRelayUri(url);
   if (uri == null) return false;
-  final host = uri.host;
-  if (isLoopbackHost(host)) return isRelayUrlAllowed(url);
+  if (isOnDeviceLoopbackHost(uri.host)) return isRelayUrlAllowed(url);
   return _isRemoteSuppliedUriAllowed(uri);
 }
 

--- a/mobile/packages/nostr_sdk/lib/utils/relay_url_policy.dart
+++ b/mobile/packages/nostr_sdk/lib/utils/relay_url_policy.dart
@@ -23,6 +23,17 @@ abstract final class RelayListCaps {
   /// NIP-65: "Clients SHOULD guide users to keep `kind:10002` lists small
   /// (2-4 relays of each category)" — read and write, hence the larger bound.
   static const int nip65 = 16;
+
+  /// Cap on the relays a NIP-46 signer may add to one pairing session by
+  /// naming them in its deep-link callback.
+  ///
+  /// A signer returning control names the transport it answered on, so the
+  /// protocol-meaningful count is one. This sits above that for the same
+  /// reason the other two do — a signer retrying on a second transport is
+  /// plausible, and a cap that bites costs the user the pairing. It matches
+  /// the advertised set the session already dials, so one pairing opens at
+  /// most twice the sockets it started with.
+  static const int nip46Callback = 4;
 }
 
 /// Whether [url] is a relay URL the app may connect to.

--- a/mobile/packages/nostr_sdk/lib/utils/relay_url_policy.dart
+++ b/mobile/packages/nostr_sdk/lib/utils/relay_url_policy.dart
@@ -74,6 +74,26 @@ bool isRemoteSuppliedRelayUrlAllowed(String url) {
   return uri != null && _isRemoteSuppliedUriAllowed(uri);
 }
 
+/// Whether [url] may be dialed when a NIP-46 signer named it in its callback.
+///
+/// Sits between the other two. A signer app on this device is not the stranger
+/// [isRemoteSuppliedRelayUrlAllowed] guards against — same-device signers run
+/// their relay on loopback and hand the client that address, and NIP-46 puts
+/// the signer "in control of what relays are being used", so refusing loopback
+/// would break the flow the callback exists to serve.
+///
+/// The rest of that predicate's reasoning still holds: the callback is a deep
+/// link, so whoever opened it chose this URL, and it must not be able to point
+/// the device at the user's LAN or VPN. Cleartext stays confined to loopback,
+/// where it never leaves the device.
+bool isSignerCallbackRelayUrlAllowed(String url) {
+  final uri = _tryParseRelayUri(url);
+  if (uri == null) return false;
+  final host = uri.host;
+  if (isLoopbackHost(host)) return isRelayUrlAllowed(url);
+  return _isRemoteSuppliedUriAllowed(uri);
+}
+
 bool _isRemoteSuppliedUriAllowed(Uri uri) =>
     uri.scheme.toLowerCase() == 'wss' && !isPrivateOrLinkLocalHost(uri.host);
 

--- a/mobile/packages/nostr_sdk/test/unit/loopback_host_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/loopback_host_test.dart
@@ -90,10 +90,13 @@ void main() {
       for (final host in [
         'localhost.',
         '127.0.0.1.',
+        '127.0.0.1..',
         '192.168.1.1.',
+        '192.168.1.1..',
         '10.0.2.2.',
         '169.254.169.254.',
         'printer.local.',
+        'printer.local..',
         'db.internal.',
       ]) {
         expect(isPrivateOrLinkLocalHost(host), isTrue, reason: host);
@@ -106,6 +109,7 @@ void main() {
 
     test('a trailing dot does not make a public host private', () {
       expect(isPrivateOrLinkLocalHost('relay.divine.video.'), isFalse);
+      expect(isPrivateOrLinkLocalHost('relay.divine.video..'), isFalse);
     });
 
     test('treats an empty or unparseable host as private', () {

--- a/mobile/packages/nostr_sdk/test/unit/loopback_host_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/loopback_host_test.dart
@@ -54,6 +54,28 @@ void main() {
     });
   });
 
+  group('isOnDeviceLoopbackHost', () {
+    test('accepts the hosts that name this device', () {
+      for (final host in ['localhost', '127.0.0.1', '::1', 'LOCALHOST']) {
+        expect(isOnDeviceLoopbackHost(host), isTrue, reason: host);
+      }
+    });
+
+    test('rejects the emulator alias that isLoopbackHost admits', () {
+      // 10.0.2.2 is the developer's host machine, not this device, and it is
+      // an ordinary routable 10/8 address anywhere but the emulator.
+      expect(isLoopbackHost('10.0.2.2'), isTrue);
+      expect(isOnDeviceLoopbackHost('10.0.2.2'), isFalse);
+      expect(isPrivateOrLinkLocalHost('10.0.2.2'), isTrue);
+    });
+
+    test('rejects LAN and public hosts', () {
+      for (final host in ['192.168.1.10', 'relay.divine.video', '8.8.8.8']) {
+        expect(isOnDeviceLoopbackHost(host), isFalse, reason: host);
+      }
+    });
+  });
+
   group('isPrivateOrLinkLocalHost', () {
     test('covers every loopback host the local stack uses', () {
       for (final host in ['localhost', '127.0.0.1', '10.0.2.2', '::1']) {

--- a/mobile/packages/nostr_sdk/test/unit/loopback_host_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/loopback_host_test.dart
@@ -61,6 +61,31 @@ void main() {
       }
     });
 
+    test('root-anchored names are judged as their bare form', () {
+      // A trailing dot is a fully-qualified spelling of the same name. Left
+      // in, it adds an empty fifth part that defeats the IPv4 literal parse
+      // and misses both the loopback set and the private-suffix list.
+      for (final host in [
+        'localhost.',
+        '127.0.0.1.',
+        '192.168.1.1.',
+        '10.0.2.2.',
+        '169.254.169.254.',
+        'printer.local.',
+        'db.internal.',
+      ]) {
+        expect(isPrivateOrLinkLocalHost(host), isTrue, reason: host);
+      }
+    });
+
+    test('a bare root label carries no host at all', () {
+      expect(isPrivateOrLinkLocalHost('.'), isTrue);
+    });
+
+    test('a trailing dot does not make a public host private', () {
+      expect(isPrivateOrLinkLocalHost('relay.divine.video.'), isFalse);
+    });
+
     test('treats an empty or unparseable host as private', () {
       expect(isPrivateOrLinkLocalHost(''), isTrue);
       expect(isPrivateOrLinkLocalHost('   '), isTrue);

--- a/mobile/packages/nostr_sdk/test/unit/nostr_connect_session_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/nostr_connect_session_test.dart
@@ -318,6 +318,58 @@ void main() {
       );
     });
 
+    test('addRelay stops admitting signer relays at the cap', () async {
+      final primaryRelay = await _TestRelayServer.start();
+      addTearDown(primaryRelay.close);
+
+      final session = NostrConnectSession(relays: [primaryRelay.url]);
+      addTearDown(session.dispose);
+
+      await session.start();
+
+      final callbackRelays = <_TestRelayServer>[];
+      for (var i = 0; i <= RelayListCaps.nip46Callback; i++) {
+        final relay = await _TestRelayServer.start();
+        addTearDown(relay.close);
+        callbackRelays.add(relay);
+        await session.addRelay(relay.url);
+      }
+
+      for (final relay in callbackRelays.take(RelayListCaps.nip46Callback)) {
+        expect(relay.connectionCount, equals(1));
+      }
+      expect(
+        callbackRelays.last.connectionCount,
+        equals(0),
+        reason: 'a signer relay past the cap must never be dialed',
+      );
+    });
+
+    test('addRelay does not spend the cap on a relay that failed', () async {
+      final primaryRelay = await _TestRelayServer.start();
+      final failedPort = await _unusedLoopbackPort();
+      addTearDown(primaryRelay.close);
+
+      final session = NostrConnectSession(relays: [primaryRelay.url]);
+      addTearDown(session.dispose);
+
+      await session.start();
+
+      for (var i = 0; i < RelayListCaps.nip46Callback; i++) {
+        await session.addRelay('ws://127.0.0.1:$failedPort');
+      }
+
+      final callbackRelay = await _TestRelayServer.start();
+      addTearDown(callbackRelay.close);
+
+      await session.addRelay(callbackRelay.url);
+      expect(
+        callbackRelay.connectionCount,
+        equals(1),
+        reason: 'only retained relays count against the cap',
+      );
+    });
+
     test('addRelay is a no-op unless the session is listening', () async {
       final callbackRelay = await _TestRelayServer.start();
       addTearDown(callbackRelay.close);

--- a/mobile/packages/nostr_sdk/test/unit/nostr_connect_session_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/nostr_connect_session_test.dart
@@ -512,6 +512,38 @@ void main() {
       },
       timeout: const Timeout(Duration(seconds: 20)),
     );
+
+    test(
+      'addRelay disconnects a relay that connects after the session timeout',
+      () async {
+        final primaryRelay = await _TestRelayServer.start();
+        final delayedRelay = await _DelayedUpgradeRelayServer.start(
+          delay: const Duration(seconds: 9),
+        );
+        addTearDown(primaryRelay.close);
+        addTearDown(delayedRelay.close);
+
+        final session = NostrConnectSession(relays: [primaryRelay.url]);
+        addTearDown(session.dispose);
+
+        await session.start();
+        await session.addRelay(delayedRelay.url);
+
+        await Future<void>.delayed(const Duration(seconds: 2));
+
+        expect(
+          delayedRelay.receivedMessages.where(_isReqMessage),
+          isEmpty,
+          reason: 'a relay that missed the session timeout must not subscribe',
+        );
+        expect(
+          delayedRelay.activeSocketCount,
+          equals(0),
+          reason: 'timed-out relays must not stay connected invisibly',
+        );
+      },
+      timeout: const Timeout(Duration(seconds: 20)),
+    );
   });
 
   group('NostrConnectState enum', () {
@@ -1265,6 +1297,7 @@ class _TestRelayServer {
 
   final HttpServer _server;
   final _sockets = <WebSocket>[];
+  final receivedMessages = <List<dynamic>>[];
   late final StreamSubscription<HttpRequest> _requests;
   int connectionCount = 0;
   bool _closed = false;
@@ -1299,7 +1332,65 @@ class _TestRelayServer {
     final socket = await WebSocketTransformer.upgrade(request);
     _sockets.add(socket);
     connectionCount += 1;
-    socket.listen((_) {});
+    socket.listen((message) {
+      receivedMessages.add(jsonDecode(message as String) as List<dynamic>);
+    });
+  }
+
+  Future<void> close() async {
+    if (_closed) return;
+    _closed = true;
+    for (final socket in _sockets) {
+      await socket.close();
+    }
+    await _requests.cancel();
+    await _server.close(force: true);
+  }
+}
+
+bool _isReqMessage(List<dynamic> message) =>
+    message.isNotEmpty && message.first == 'REQ';
+
+class _DelayedUpgradeRelayServer {
+  _DelayedUpgradeRelayServer._(this._server, this._delay) {
+    _requests = _server.listen(_handleRequest);
+  }
+
+  final HttpServer _server;
+  final Duration _delay;
+  final _sockets = <WebSocket>[];
+  final receivedMessages = <List<dynamic>>[];
+  late final StreamSubscription<HttpRequest> _requests;
+  bool _closed = false;
+
+  String get url => 'ws://127.0.0.1:${_server.port}';
+  int get activeSocketCount => _sockets.where((socket) {
+    return socket.readyState == WebSocket.open ||
+        socket.readyState == WebSocket.connecting;
+  }).length;
+
+  static Future<_DelayedUpgradeRelayServer> start({
+    required Duration delay,
+  }) async {
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    return _DelayedUpgradeRelayServer._(server, delay);
+  }
+
+  Future<void> _handleRequest(HttpRequest request) async {
+    if (!WebSocketTransformer.isUpgradeRequest(request)) {
+      request.response.statusCode = HttpStatus.badRequest;
+      await request.response.close();
+      return;
+    }
+
+    await Future<void>.delayed(_delay);
+    if (_closed) return;
+
+    final socket = await WebSocketTransformer.upgrade(request);
+    _sockets.add(socket);
+    socket.listen((message) {
+      receivedMessages.add(jsonDecode(message as String) as List<dynamic>);
+    });
   }
 
   Future<void> close() async {

--- a/mobile/packages/nostr_sdk/test/unit/nostr_connect_session_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/nostr_connect_session_test.dart
@@ -370,6 +370,81 @@ void main() {
       );
     });
 
+    test('addRelay holds the cap when callbacks arrive together', () async {
+      final primaryRelay = await _TestRelayServer.start();
+      addTearDown(primaryRelay.close);
+
+      final session = NostrConnectSession(relays: [primaryRelay.url]);
+      addTearDown(session.dispose);
+
+      await session.start();
+
+      final callbackRelays = <_TestRelayServer>[];
+      for (var i = 0; i < RelayListCaps.nip46Callback + 3; i++) {
+        final relay = await _TestRelayServer.start();
+        addTearDown(relay.close);
+        callbackRelays.add(relay);
+      }
+
+      // The coordinator dispatches every callback with `unawaited`, so these
+      // all land between the cap check and the first dial completing.
+      await Future.wait([
+        for (final relay in callbackRelays) session.addRelay(relay.url),
+      ]);
+
+      expect(
+        callbackRelays.fold<int>(0, (n, relay) => n + relay.connectionCount),
+        equals(RelayListCaps.nip46Callback),
+        reason: 'concurrent callbacks must not each spend the same free slot',
+      );
+    });
+
+    test('addRelay dials a repeated callback relay once', () async {
+      final primaryRelay = await _TestRelayServer.start();
+      addTearDown(primaryRelay.close);
+
+      final session = NostrConnectSession(relays: [primaryRelay.url]);
+      addTearDown(session.dispose);
+
+      await session.start();
+
+      final callbackRelay = await _TestRelayServer.start();
+      addTearDown(callbackRelay.close);
+
+      await Future.wait([
+        for (var i = 0; i < RelayListCaps.nip46Callback; i++)
+          session.addRelay(callbackRelay.url),
+      ]);
+
+      expect(
+        callbackRelay.connectionCount,
+        equals(1),
+        reason: 'an in-flight dial must absorb a repeat of the same URL',
+      );
+    });
+
+    test('addRelay treats a trailing slash as the same relay', () async {
+      final primaryRelay = await _TestRelayServer.start();
+      addTearDown(primaryRelay.close);
+
+      final session = NostrConnectSession(relays: [primaryRelay.url]);
+      addTearDown(session.dispose);
+
+      await session.start();
+
+      final callbackRelay = await _TestRelayServer.start();
+      addTearDown(callbackRelay.close);
+
+      await session.addRelay(callbackRelay.url);
+      await session.addRelay('${callbackRelay.url}/');
+
+      expect(
+        callbackRelay.connectionCount,
+        equals(1),
+        reason: 'a respelling must not cost a second slot of the cap',
+      );
+    });
+
     test('addRelay is a no-op unless the session is listening', () async {
       final callbackRelay = await _TestRelayServer.start();
       addTearDown(callbackRelay.close);

--- a/mobile/packages/nostr_sdk/test/unit/relay_url_policy_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_url_policy_test.dart
@@ -157,6 +157,56 @@ void main() {
     );
   });
 
+  group('isSignerCallbackRelayUrlAllowed', () {
+    test('accepts the loopback relay a same-device signer runs', () {
+      // Aegis hands back exactly these two after approving a pairing.
+      expect(isSignerCallbackRelayUrlAllowed('wss://127.0.0.1:28443'), isTrue);
+      expect(isSignerCallbackRelayUrlAllowed('ws://127.0.0.1:8081'), isTrue);
+      expect(isSignerCallbackRelayUrlAllowed('ws://localhost:8081'), isTrue);
+    });
+
+    test('accepts wss:// for a publicly routable host', () {
+      expect(
+        isSignerCallbackRelayUrlAllowed('wss://localrelay.link:28443'),
+        isTrue,
+      );
+      expect(isSignerCallbackRelayUrlAllowed('wss://relay.damus.io'), isTrue);
+    });
+
+    test('rejects the private network the signer does not live on', () {
+      for (final url in [
+        'wss://192.168.1.10:28443',
+        'wss://10.5.0.1:28443',
+        'wss://172.16.0.1:28443',
+        'wss://169.254.1.1:28443',
+        'wss://signer.local:28443',
+      ]) {
+        expect(isSignerCallbackRelayUrlAllowed(url), isFalse, reason: url);
+      }
+    });
+
+    test('rejects cleartext anywhere but loopback', () {
+      expect(
+        isSignerCallbackRelayUrlAllowed('ws://localrelay.link:28443'),
+        isFalse,
+      );
+      expect(isSignerCallbackRelayUrlAllowed('ws://relay.damus.io'), isFalse);
+      expect(isSignerCallbackRelayUrlAllowed('ws://192.168.1.10'), isFalse);
+    });
+
+    test('rejects non-WebSocket, malformed, and mis-nested URLs', () {
+      for (final url in [
+        'https://localrelay.link:28443',
+        'http://127.0.0.1:8081',
+        '',
+        'wss://',
+        'wss://http://evil.example',
+      ]) {
+        expect(isSignerCallbackRelayUrlAllowed(url), isFalse, reason: url);
+      }
+    });
+  });
+
   group('admitRemoteSuppliedRelays', () {
     test('caps the list and reports the truncation', () {
       final urls = [for (var i = 0; i < 50; i++) 'wss://relay-$i.example'];

--- a/mobile/packages/nostr_sdk/test/unit/relay_url_policy_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_url_policy_test.dart
@@ -105,8 +105,11 @@ void main() {
       for (final url in [
         'wss://192.168.1.1.',
         'wss://127.0.0.1.',
+        'wss://127.0.0.1..',
         'wss://localhost.',
+        'wss://localhost..',
         'wss://printer.local.',
+        'wss://printer.local..',
       ]) {
         expect(isRemoteSuppliedRelayUrlAllowed(url), isFalse, reason: url);
       }
@@ -218,9 +221,13 @@ void main() {
     test('rejects root-anchored respellings of loopback and LAN', () {
       for (final url in [
         'wss://localhost.',
+        'wss://localhost..',
         'wss://127.0.0.1.',
+        'wss://127.0.0.1..',
         'wss://192.168.1.1.',
+        'wss://192.168.1.1..',
         'ws://localhost.',
+        'ws://localhost..',
       ]) {
         expect(isSignerCallbackRelayUrlAllowed(url), isFalse, reason: url);
       }

--- a/mobile/packages/nostr_sdk/test/unit/relay_url_policy_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_url_policy_test.dart
@@ -205,6 +205,16 @@ void main() {
       expect(isSignerCallbackRelayUrlAllowed('ws://192.168.1.10'), isFalse);
     });
 
+    test('rejects the emulator host alias the local stack uses', () {
+      // 10.0.2.2 is the developer's laptop seen from an Android emulator, and
+      // a routable 10/8 LAN address everywhere else. A signer on this device
+      // names 127.0.0.1, never this. The self-supplied rule keeps it.
+      for (final url in ['ws://10.0.2.2:7777', 'wss://10.0.2.2:7777']) {
+        expect(isSignerCallbackRelayUrlAllowed(url), isFalse, reason: url);
+      }
+      expect(isRelayUrlAllowed('ws://10.0.2.2:7777'), isTrue);
+    });
+
     test('rejects root-anchored respellings of loopback and LAN', () {
       for (final url in [
         'wss://localhost.',

--- a/mobile/packages/nostr_sdk/test/unit/relay_url_policy_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_url_policy_test.dart
@@ -101,6 +101,17 @@ void main() {
       }
     });
 
+    test('refuses root-anchored respellings of private targets', () {
+      for (final url in [
+        'wss://192.168.1.1.',
+        'wss://127.0.0.1.',
+        'wss://localhost.',
+        'wss://printer.local.',
+      ]) {
+        expect(isRemoteSuppliedRelayUrlAllowed(url), isFalse, reason: url);
+      }
+    });
+
     test('refuses private-network hostname suffixes', () {
       for (final url in [
         'wss://printer.local',
@@ -192,6 +203,17 @@ void main() {
       );
       expect(isSignerCallbackRelayUrlAllowed('ws://relay.damus.io'), isFalse);
       expect(isSignerCallbackRelayUrlAllowed('ws://192.168.1.10'), isFalse);
+    });
+
+    test('rejects root-anchored respellings of loopback and LAN', () {
+      for (final url in [
+        'wss://localhost.',
+        'wss://127.0.0.1.',
+        'wss://192.168.1.1.',
+        'ws://localhost.',
+      ]) {
+        expect(isSignerCallbackRelayUrlAllowed(url), isFalse, reason: url);
+      }
     });
 
     test('rejects non-WebSocket, malformed, and mis-nested URLs', () {

--- a/mobile/test/services/deep_link_service_test.dart
+++ b/mobile/test/services/deep_link_service_test.dart
@@ -412,6 +412,10 @@ void main() {
         'wss://signer.local:28443',
         'ws://localrelay.link:28443',
         'http://localrelay.link:28443',
+        // Root-anchored respellings of the same private targets.
+        'wss://127.0.0.1.',
+        'wss://192.168.1.10.',
+        'wss://signer.local.',
       ]) {
         test('drops the callback relay hint $relay', () {
           final result = parseCallback(relay);
@@ -420,6 +424,17 @@ void main() {
           expect(result.signerCallbackRelay, isNull);
         });
       }
+
+      test('hands on the address it checked, not the raw parameter', () {
+        final result = parseCallback('  wss://localrelay.link:28443  ');
+
+        // The policy validates a trimmed URL, so returning the raw one would
+        // dial and store a string that was never the one admitted.
+        expect(
+          result.signerCallbackRelay,
+          equals('wss://localrelay.link:28443'),
+        );
+      });
     });
 
     // The divine:// scheme splits three ways on the authority: `nostrconnect`

--- a/mobile/test/services/deep_link_service_test.dart
+++ b/mobile/test/services/deep_link_service_test.dart
@@ -378,6 +378,48 @@ void main() {
           equals('wss://localrelay.link:28443'),
         );
       });
+
+      DeepLink parseCallback(String relay) => DeepLinkService.parseDeepLink(
+        'divine://nostrconnect?x-source=aegis&relay='
+        '${Uri.encodeComponent(relay)}',
+      );
+
+      // A same-device signer runs its relay on loopback and hands us that
+      // address; NIP-46 puts the signer in control of the relays. These are
+      // the two Aegis returns, and dropping them would break the pairing the
+      // callback exists to finish.
+      for (final relay in const [
+        'wss://127.0.0.1:28443',
+        'ws://127.0.0.1:8081',
+        'wss://localrelay.link:28443',
+      ]) {
+        test('keeps the callback relay hint $relay', () {
+          final result = parseCallback(relay);
+
+          expect(result.type, equals(DeepLinkType.signerCallback));
+          expect(result.signerCallbackRelay, equals(relay));
+        });
+      }
+
+      // Anything can open a deep link, so the hint must not point the device
+      // at the user's LAN, and cleartext must not leave the device. Dropping
+      // a hint leaves the callback itself intact — the handoff still
+      // reconnects the relays the session advertised.
+      for (final relay in const [
+        'wss://192.168.1.10:28443',
+        'wss://10.5.0.1:28443',
+        'wss://169.254.1.1:28443',
+        'wss://signer.local:28443',
+        'ws://localrelay.link:28443',
+        'http://localrelay.link:28443',
+      ]) {
+        test('drops the callback relay hint $relay', () {
+          final result = parseCallback(relay);
+
+          expect(result.type, equals(DeepLinkType.signerCallback));
+          expect(result.signerCallbackRelay, isNull);
+        });
+      }
     });
 
     // The divine:// scheme splits three ways on the authority: `nostrconnect`

--- a/mobile/test/services/deep_link_service_test.dart
+++ b/mobile/test/services/deep_link_service_test.dart
@@ -412,6 +412,9 @@ void main() {
         'wss://signer.local:28443',
         'ws://localrelay.link:28443',
         'http://localrelay.link:28443',
+        // The emulator's alias for the developer's laptop, not this device.
+        'ws://10.0.2.2:47777',
+        'wss://10.0.2.2:47777',
         // Root-anchored respellings of the same private targets.
         'wss://127.0.0.1.',
         'wss://192.168.1.10.',

--- a/mobile/test/services/deep_link_service_test.dart
+++ b/mobile/test/services/deep_link_service_test.dart
@@ -417,8 +417,11 @@ void main() {
         'wss://10.0.2.2:47777',
         // Root-anchored respellings of the same private targets.
         'wss://127.0.0.1.',
+        'wss://127.0.0.1..',
         'wss://192.168.1.10.',
+        'wss://192.168.1.10..',
         'wss://signer.local.',
+        'wss://signer.local..',
       ]) {
         test('drops the callback relay hint $relay', () {
           final result = parseCallback(relay);


### PR DESCRIPTION
## Description

The `relay` parameter on a `divine://nostrconnect` callback was accepted as any `ws://` or `wss://` URL, and nothing bounded how many relays one pairing session could take on. Both are follow-ups to #7105, whose `0cacb304c0` narrowed *who* can send a callback but deliberately left what the callback can carry.

The branch is split into focused commits so the relay-counting, URL-admission, and review-fix pieces stay independently reviewable.

### 1. Cap the relays one pairing session adopts

`NostrConnectSession.addRelay` had no bound: every distinct URL opened another socket and NIP-46 subscription for as long as the session stayed listening. The callback is a deep link, so nothing outside the session limits how many arrive.

Adopts at most `RelayListCaps.nip46Callback` (4) per session. Slots are reserved before the dial, released on failure, and keyed with the same normalized relay handle the pool uses, so concurrent callbacks and equivalent URL spellings cannot outrun the cap.

Timed-out dials are detached and disconnected before their slot is refunded. A relay that completes after the session-level connect timeout cannot subscribe, feed the session, or stay connected invisibly.

### 2. Bound which host the hint may name

**Set-matching was considered and rejected.** `addRelay` already dedupes against the advertised set, so "accept only advertised relays" collapses to ignoring the hint entirely, deleting the capability its doc comment exists to describe. NIP-46 is explicit that this is the signer's call:

> At all times, the _remote-signer_ should be in control of what relays are being used for the connection between it and the _client_.

Answering off the client's advertised set is ordinary signer behaviour, not an anomaly. `isSignerCallbackRelayUrlAllowed` takes the middle ground this callback needs: loopback for same-device signers is allowed, LAN/link-local targets are refused, and cleartext is confined to true on-device loopback. `10.0.2.2` stays allowed for app-configured local-stack URLs through `isRelayUrlAllowed`, but is not treated as signer loopback.

Dropping a hint leaves the callback itself intact: the handoff still fires and still reconnects the relays the session advertised.

**Related Issue:** Closes #7159

## Out of Scope

- Amber is the only signer implementing the spec's `switch_relays`; Aegis, nsec.app and nowser do not, so that sanctioned path reaches nothing today.

## Verification

- `cd mobile/packages/nostr_sdk && flutter test`
- `cd mobile/packages/nostr_sdk && flutter analyze lib test`
- `cd mobile && flutter test test/services/deep_link_service_test.dart`
- `cd mobile && flutter analyze lib test integration_test`
- Push hook: merge-conflict check, analyzer, and changed-file tests including `packages/nostr_sdk/test/unit/loopback_host_test.dart`, `packages/nostr_sdk/test/unit/nostr_connect_session_test.dart`, `packages/nostr_sdk/test/unit/relay_url_policy_test.dart`, `test/services/deep_link_service_test.dart`, and `test/utils/relay_url_utils_test.dart`

The new late-connect regression was watched fail before the cleanup fix: a relay that completed the handshake after the 8 s session timeout still received the queued `REQ`. It now stays unsubscribed and disconnected.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
