### PR TITLE
test(divine_ui): refresh light accent assertions

### DIFF
--- a/mobile/packages/divine_ui/test/src/checkbox/checkbox_test.dart
+++ b/mobile/packages/divine_ui/test/src/checkbox/checkbox_test.dart
@@ -74,9 +74,7 @@ void main() {
 
     group('states', () {
       testWidgets('renders unselected state', (tester) async {
-        await tester.pumpWidget(
-          buildTestWidget(),
-        );
+        await tester.pumpWidget(buildTestWidget());
 
         final animatedOpacity = tester.widget<AnimatedOpacity>(
           find.byType(AnimatedOpacity),
@@ -165,9 +163,7 @@ void main() {
       });
 
       testWidgets('renders with custom label widget', (tester) async {
-        await tester.pumpWidget(
-          buildTestWidget(label: const Icon(Icons.star)),
-        );
+        await tester.pumpWidget(buildTestWidget(label: const Icon(Icons.star)));
 
         expect(find.byType(DivineSpriteCheckbox), findsOneWidget);
         expect(find.byType(Icon), findsOneWidget);
@@ -229,8 +225,10 @@ void main() {
       Widget label = const Text('Test label'),
       CrossAxisAlignment crossAxisAlignment = CrossAxisAlignment.center,
       Duration animationDuration = const Duration(milliseconds: 100),
+      ThemeData? theme,
     }) {
       return MaterialApp(
+        theme: theme,
         home: Scaffold(
           body: Center(
             child: DivineRowCheckbox(
@@ -247,18 +245,14 @@ void main() {
 
     group('rendering', () {
       testWidgets('renders checkbox with border', (tester) async {
-        await tester.pumpWidget(
-          buildTestWidget(onChanged: (_) {}),
-        );
+        await tester.pumpWidget(buildTestWidget(onChanged: (_) {}));
 
         expect(find.byType(DivineCheckbox), findsOneWidget);
         expect(find.byType(AnimatedContainer), findsOneWidget);
       });
 
       testWidgets('renders with label', (tester) async {
-        await tester.pumpWidget(
-          buildTestWidget(onChanged: (_) {}),
-        );
+        await tester.pumpWidget(buildTestWidget(onChanged: (_) {}));
 
         expect(find.text('Test label'), findsOneWidget);
       });
@@ -270,9 +264,7 @@ void main() {
       ) async {
         bool? newValue;
         await tester.pumpWidget(
-          buildTestWidget(
-            onChanged: (value) => newValue = value,
-          ),
+          buildTestWidget(onChanged: (value) => newValue = value),
         );
 
         await tester.tap(find.byType(DivineRowCheckbox));
@@ -345,11 +337,7 @@ void main() {
 
         expect(
           tester.getSemantics(find.byType(DivineRowCheckbox)),
-          isSemantics(
-            hasCheckedState: true,
-            isChecked: true,
-            isEnabled: true,
-          ),
+          isSemantics(hasCheckedState: true, isChecked: true, isEnabled: true),
         );
         handle.dispose();
       });
@@ -387,48 +375,109 @@ void main() {
     });
 
     group('border styling', () {
-      testWidgets('has muted border when unselected', (tester) async {
-        await tester.pumpWidget(
-          buildTestWidget(
-            onChanged: (_) {},
-          ),
-        );
-
+      Color borderColor(WidgetTester tester) {
         final container = tester.widget<AnimatedContainer>(
           find.byType(AnimatedContainer),
         );
         final boxDecoration = container.decoration! as BoxDecoration;
-        expect(boxDecoration.border!.top.color, VineTheme.outlineMuted);
+        return boxDecoration.border!.top.color;
+      }
+
+      setUp(() => VineThemeColors.debugFallbackCount = 0);
+      tearDown(() => VineThemeColors.debugFallbackCount = 0);
+
+      testWidgets('uses light outlineMuted border when unselected', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          buildTestWidget(onChanged: (_) {}, theme: VineTheme.lightTheme),
+        );
+
+        expect(borderColor(tester), VineTheme.lightColors.outlineMuted);
+        expect(VineThemeColors.debugFallbackCount, 0);
       });
 
-      testWidgets('has primary border when selected', (tester) async {
+      testWidgets('uses dark outlineMuted border when unselected', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          buildTestWidget(onChanged: (_) {}, theme: VineTheme.theme),
+        );
+
+        expect(borderColor(tester), VineTheme.darkColors.outlineMuted);
+        expect(VineThemeColors.debugFallbackCount, 0);
+      });
+
+      testWidgets('uses light accentPositive border when selected', (
+        tester,
+      ) async {
         await tester.pumpWidget(
           buildTestWidget(
             state: DivineCheckboxState.selected,
             onChanged: (_) {},
+            theme: VineTheme.lightTheme,
           ),
         );
 
-        final container = tester.widget<AnimatedContainer>(
-          find.byType(AnimatedContainer),
+        final color = borderColor(tester);
+        expect(color, VineTheme.lightColors.accentPositive);
+        expect(
+          color,
+          isNot(VineTheme.primary),
+          reason: 'light mode must not fall back to the dark brand green',
         );
-        final boxDecoration = container.decoration! as BoxDecoration;
-        expect(boxDecoration.border!.top.color, VineTheme.primary);
+        expect(VineThemeColors.debugFallbackCount, 0);
       });
 
-      testWidgets('has primary border when intermediate', (tester) async {
+      testWidgets('uses dark accentPositive border when selected', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          buildTestWidget(
+            state: DivineCheckboxState.selected,
+            onChanged: (_) {},
+            theme: VineTheme.theme,
+          ),
+        );
+
+        expect(borderColor(tester), VineTheme.darkColors.accentPositive);
+        expect(VineThemeColors.debugFallbackCount, 0);
+      });
+
+      testWidgets('uses light accentPositive border when intermediate', (
+        tester,
+      ) async {
         await tester.pumpWidget(
           buildTestWidget(
             state: DivineCheckboxState.intermediate,
             onChanged: (_) {},
+            theme: VineTheme.lightTheme,
           ),
         );
 
-        final container = tester.widget<AnimatedContainer>(
-          find.byType(AnimatedContainer),
+        final color = borderColor(tester);
+        expect(color, VineTheme.lightColors.accentPositive);
+        expect(
+          color,
+          isNot(VineTheme.primary),
+          reason: 'light mode must not fall back to the dark brand green',
         );
-        final boxDecoration = container.decoration! as BoxDecoration;
-        expect(boxDecoration.border!.top.color, VineTheme.primary);
+        expect(VineThemeColors.debugFallbackCount, 0);
+      });
+
+      testWidgets('uses dark accentPositive border when intermediate', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          buildTestWidget(
+            state: DivineCheckboxState.intermediate,
+            onChanged: (_) {},
+            theme: VineTheme.theme,
+          ),
+        );
+
+        expect(borderColor(tester), VineTheme.darkColors.accentPositive);
+        expect(VineThemeColors.debugFallbackCount, 0);
       });
     });
 
@@ -452,10 +501,7 @@ void main() {
       testWidgets('passes animation duration to checkbox', (tester) async {
         const customDuration = Duration(milliseconds: 200);
         await tester.pumpWidget(
-          buildTestWidget(
-            animationDuration: customDuration,
-            onChanged: (_) {},
-          ),
+          buildTestWidget(animationDuration: customDuration, onChanged: (_) {}),
         );
 
         final checkbox = tester.widget<DivineCheckbox>(
@@ -467,10 +513,7 @@ void main() {
       testWidgets('passes animation duration to container', (tester) async {
         const customDuration = Duration(milliseconds: 200);
         await tester.pumpWidget(
-          buildTestWidget(
-            animationDuration: customDuration,
-            onChanged: (_) {},
-          ),
+          buildTestWidget(animationDuration: customDuration, onChanged: (_) {}),
         );
 
         final container = tester.widget<AnimatedContainer>(

--- a/mobile/packages/divine_ui/test/src/switch/divine_switch_test.dart
+++ b/mobile/packages/divine_ui/test/src/switch/divine_switch_test.dart
@@ -54,9 +54,7 @@ void main() {
     });
 
     testWidgets('paints the brand palette when on', (tester) async {
-      await tester.pumpWidget(
-        buildTestWidget(value: true, onChanged: (_) {}),
-      );
+      await tester.pumpWidget(buildTestWidget(value: true, onChanged: (_) {}));
 
       final toggle = tester.widget<Switch>(find.byType(Switch));
       expect(toggle.activeTrackColor, equals(VineTheme.primary));
@@ -92,9 +90,10 @@ void main() {
       String? subtitle,
       DivineIconName? leadingIcon,
       Widget? leading,
+      ThemeData? theme,
     }) {
       return MaterialApp(
-        theme: VineTheme.theme,
+        theme: theme ?? VineTheme.theme,
         home: Scaffold(
           body: DivineSwitchTile(
             title: 'Autoplay',
@@ -108,10 +107,11 @@ void main() {
       );
     }
 
+    setUp(() => VineThemeColors.debugFallbackCount = 0);
+    tearDown(() => VineThemeColors.debugFallbackCount = 0);
+
     testWidgets('renders the title', (tester) async {
-      await tester.pumpWidget(
-        buildTestWidget(value: false, onChanged: (_) {}),
-      );
+      await tester.pumpWidget(buildTestWidget(value: false, onChanged: (_) {}));
 
       expect(find.text('Autoplay'), findsOneWidget);
     });
@@ -129,9 +129,7 @@ void main() {
     });
 
     testWidgets('omits the subtitle when absent', (tester) async {
-      await tester.pumpWidget(
-        buildTestWidget(value: false, onChanged: (_) {}),
-      );
+      await tester.pumpWidget(buildTestWidget(value: false, onChanged: (_) {}));
 
       expect(tester.widget<ListTile>(find.byType(ListTile)).subtitle, isNull);
     });
@@ -148,10 +146,47 @@ void main() {
       expect(find.byType(DivineIcon), findsOneWidget);
     });
 
-    testWidgets('omits the leading icon when absent', (tester) async {
+    testWidgets('uses light accentPositive for the leading icon', (
+      tester,
+    ) async {
       await tester.pumpWidget(
-        buildTestWidget(value: false, onChanged: (_) {}),
+        buildTestWidget(
+          value: false,
+          onChanged: (_) {},
+          leadingIcon: DivineIconName.gear,
+          theme: VineTheme.lightTheme,
+        ),
       );
+
+      final icon = tester.widget<DivineIcon>(find.byType(DivineIcon));
+      expect(icon.color, VineTheme.lightColors.accentPositive);
+      expect(
+        icon.color,
+        isNot(VineTheme.primary),
+        reason: 'light mode must not fall back to the dark brand green',
+      );
+      expect(VineThemeColors.debugFallbackCount, 0);
+    });
+
+    testWidgets('uses dark accentPositive for the leading icon', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          value: false,
+          onChanged: (_) {},
+          leadingIcon: DivineIconName.gear,
+          theme: VineTheme.theme,
+        ),
+      );
+
+      final icon = tester.widget<DivineIcon>(find.byType(DivineIcon));
+      expect(icon.color, VineTheme.darkColors.accentPositive);
+      expect(VineThemeColors.debugFallbackCount, 0);
+    });
+
+    testWidgets('omits the leading icon when absent', (tester) async {
+      await tester.pumpWidget(buildTestWidget(value: false, onChanged: (_) {}));
 
       expect(find.byType(DivineIcon), findsNothing);
     });
@@ -252,36 +287,31 @@ void main() {
     // Assert the styles themselves are unchanged: the assertion only fires
     // when the rebuilt paragraph measures differently, which the test font
     // never does, so `takeException()` cannot catch a regression here.
-    testWidgets(
-      'keeps its text styles across a disabled → enabled flip',
-      (tester) async {
-        const longSubtitle =
-            'Include a Divine client tag on events you publish so other Nostr '
-            'apps can attribute them correctly.';
+    testWidgets('keeps its text styles across a disabled → enabled flip', (
+      tester,
+    ) async {
+      const longSubtitle =
+          'Include a Divine client tag on events you publish so other Nostr '
+          'apps can attribute them correctly.';
 
-        TextStyle styleOf(String data) =>
-            tester.widget<Text>(find.text(data)).style!;
+      TextStyle styleOf(String data) =>
+          tester.widget<Text>(find.text(data)).style!;
 
-        await tester.pumpWidget(
-          buildTestWidget(value: true, subtitle: longSubtitle),
-        );
-        await tester.pump();
-        final disabledTitle = styleOf('Autoplay');
-        final disabledSubtitle = styleOf(longSubtitle);
+      await tester.pumpWidget(
+        buildTestWidget(value: true, subtitle: longSubtitle),
+      );
+      await tester.pump();
+      final disabledTitle = styleOf('Autoplay');
+      final disabledSubtitle = styleOf(longSubtitle);
 
-        await tester.pumpWidget(
-          buildTestWidget(
-            value: true,
-            subtitle: longSubtitle,
-            onChanged: (_) {},
-          ),
-        );
-        await tester.pumpAndSettle();
+      await tester.pumpWidget(
+        buildTestWidget(value: true, subtitle: longSubtitle, onChanged: (_) {}),
+      );
+      await tester.pumpAndSettle();
 
-        expect(styleOf('Autoplay'), equals(disabledTitle));
-        expect(styleOf(longSubtitle), equals(disabledSubtitle));
-        expect(tester.takeException(), isNull);
-      },
-    );
+      expect(styleOf('Autoplay'), equals(disabledTitle));
+      expect(styleOf(longSubtitle), equals(disabledSubtitle));
+      expect(tester.takeException(), isNull);
+    });
   });
 }


### PR DESCRIPTION
## Summary
- add explicit light and dark token assertions for DivineRowCheckbox borders
- add light and dark leading-icon color assertions for DivineSwitchTile
- guard the themed assertions with VineThemeColors.debugFallbackCount checks so silent theme fallback is caught

## Notes
- Closes #7608
- Info card assertions remain scoped to sibling issue #7605, per the issue plan.

## Verification
- cd mobile/packages/divine_ui && flutter test test/src/checkbox/checkbox_test.dart test/src/switch/divine_switch_test.dart
- mutation check: temporarily reverted checkbox/switch accent token usage to raw VineTheme constants and confirmed the new light-mode tests fail
- cd mobile/packages/divine_ui && flutter test --coverage
- cd mobile && flutter analyze lib test integration_test
- cd mobile && flutter test test/screens/settings/settings_screens_light_mode_test.dart