### PR TITLE
fix(analytics): handle partial creator stats failures

### DIFF
--- a/mobile/lib/features/creator_analytics/creator_analytics_repository.dart
+++ b/mobile/lib/features/creator_analytics/creator_analytics_repository.dart
@@ -136,6 +136,12 @@ class FunnelcakeCreatorAnalyticsRepository
     try {
       authorResult = await _fetchAuthorVideos(pubkey);
     } on Exception catch (e) {
+      // The concurrent social-counts fetch can still complete with an Error
+      // (the tolerant wrapper only catches Exceptions, so invariants keep
+      // propagating on the success path). Nobody awaits it anymore once this
+      // load aborts, so absorb it here rather than leaking an unhandled
+      // async error.
+      socialFuture.ignore();
       throw CreatorAnalyticsLoadException(
         _classifyRequiredLoadFailure(e),
         cause: e,
@@ -262,7 +268,11 @@ class FunnelcakeCreatorAnalyticsRepository
     Set<AnalyticsDataSource> failedSources,
   ) async {
     try {
-      return await _enrichVideosWithBulkStats(videos);
+      final result = await _enrichVideosWithBulkStats(videos);
+      if (result.hadFailures) {
+        failedSources.add(AnalyticsDataSource.bulkVideoStats);
+      }
+      return result;
     } on Exception catch (e, stackTrace) {
       failedSources.add(AnalyticsDataSource.bulkVideoStats);
       Log.error(
@@ -286,14 +296,32 @@ class FunnelcakeCreatorAnalyticsRepository
     final ids = videos.map((video) => video.id).where((id) => id.isNotEmpty);
     final chunks = _chunkStrings(ids.toList(), 100);
     final statsById = <String, BulkVideoStatsEntry>{};
+    var hadFailures = false;
 
     for (final chunk in chunks) {
-      final chunkResponse = await _client.getBulkVideoStats(chunk);
-      statsById.addAll(chunkResponse.stats);
+      // Tolerance is per chunk: a later chunk failing must not discard the
+      // stats earlier chunks already fetched.
+      try {
+        final chunkResponse = await _client.getBulkVideoStats(chunk);
+        statsById.addAll(chunkResponse.stats);
+      } on Exception catch (e, stackTrace) {
+        hadFailures = true;
+        Log.error(
+          'Failed to hydrate creator analytics videos with bulk stats',
+          name: 'CreatorAnalyticsRepository',
+          category: LogCategory.video,
+          error: e,
+          stackTrace: stackTrace,
+        );
+      }
     }
 
     if (statsById.isEmpty) {
-      return _HydrationResult(videos: videos, hydratedCount: 0);
+      return _HydrationResult(
+        videos: videos,
+        hydratedCount: 0,
+        hadFailures: hadFailures,
+      );
     }
 
     var hydratedCount = 0;
@@ -333,7 +361,11 @@ class FunnelcakeCreatorAnalyticsRepository
       );
     }).toList();
 
-    return _HydrationResult(videos: hydrated, hydratedCount: hydratedCount);
+    return _HydrationResult(
+      videos: hydrated,
+      hydratedCount: hydratedCount,
+      hadFailures: hadFailures,
+    );
   }
 
   Future<_HydrationResult> _hydrateVideoViewsTolerant(

--- a/mobile/lib/features/creator_analytics/creator_analytics_repository.dart
+++ b/mobile/lib/features/creator_analytics/creator_analytics_repository.dart
@@ -446,9 +446,12 @@ CreatorAnalyticsFailureKind _classifyRequiredLoadFailure(Exception error) {
   if (error is FunnelcakeApiException && error.statusCode >= 500) {
     return CreatorAnalyticsFailureKind.serverUnavailable;
   }
+  // The client wraps every transport failure before it reaches here: a
+  // timeout becomes FunnelcakeTimeoutException, and a raw SocketException is
+  // carried as the `cause` of a FunnelcakeException. So we match the wrapped
+  // timeout type and unwrap the cause; a bare TimeoutException or an
+  // unwrapped network error never arrives on this path.
   if (error is FunnelcakeTimeoutException ||
-      error is TimeoutException ||
-      _isExpectedNetworkException(error) ||
       _isExpectedNetworkException(_funnelcakeCause(error))) {
     return CreatorAnalyticsFailureKind.connectionIssue;
   }

--- a/mobile/lib/features/creator_analytics/creator_analytics_repository.dart
+++ b/mobile/lib/features/creator_analytics/creator_analytics_repository.dart
@@ -5,10 +5,16 @@ import 'dart:math' as math;
 
 import 'package:funnelcake_api_client/funnelcake_api_client.dart';
 import 'package:models/models.dart';
+import 'package:unified_logger/unified_logger.dart';
 import 'package:videos_repository/videos_repository.dart';
 
 /// Provenance source for analytics values.
-enum AnalyticsDataSource { authorVideos, bulkVideoStats, videoViewsEndpoint }
+enum AnalyticsDataSource {
+  authorVideos,
+  bulkVideoStats,
+  videoViewsEndpoint,
+  socialCounts,
+}
 
 /// Diagnostics to explain data quality and endpoint contribution.
 class CreatorAnalyticsDiagnostics {
@@ -20,6 +26,7 @@ class CreatorAnalyticsDiagnostics {
     required this.videosHydratedByViewsEndpoint,
     required this.sourcesUsed,
     required this.fetchedAt,
+    this.failedSources = const {},
     this.videoCatalogTruncated = false,
   });
 
@@ -29,6 +36,7 @@ class CreatorAnalyticsDiagnostics {
   final int videosHydratedByBulkStats;
   final int videosHydratedByViewsEndpoint;
   final Set<AnalyticsDataSource> sourcesUsed;
+  final Set<AnalyticsDataSource> failedSources;
   final DateTime fetchedAt;
   final bool videoCatalogTruncated;
 
@@ -97,20 +105,27 @@ class FunnelcakeCreatorAnalyticsRepository
     }
 
     final sourcesUsed = <AnalyticsDataSource>{};
+    final failedSources = <AnalyticsDataSource>{};
 
-    final socialFuture = _getSocialCounts(pubkey);
+    final socialFuture = _getSocialCountsTolerant(pubkey, failedSources);
     final authorResult = await _fetchAuthorVideos(pubkey);
     if (authorResult.videos.isNotEmpty) {
       sourcesUsed.add(AnalyticsDataSource.authorVideos);
     }
 
-    final bulkResult = await _enrichVideosWithBulkStats(authorResult.videos);
+    final bulkResult = await _enrichVideosWithBulkStatsTolerant(
+      authorResult.videos,
+      failedSources,
+    );
     var hydratedVideos = bulkResult.videos;
     if (bulkResult.hydratedCount > 0) {
       sourcesUsed.add(AnalyticsDataSource.bulkVideoStats);
     }
 
-    final endpointResult = await _hydrateVideoViews(hydratedVideos);
+    final endpointResult = await _hydrateVideoViewsTolerant(
+      hydratedVideos,
+      failedSources,
+    );
     hydratedVideos = endpointResult.videos;
     if (endpointResult.hydratedCount > 0) {
       sourcesUsed.add(AnalyticsDataSource.videoViewsEndpoint);
@@ -123,6 +138,9 @@ class FunnelcakeCreatorAnalyticsRepository
     final videos = mergeProfileFeedVideoLists(const [], hydratedVideos);
 
     final social = await socialFuture;
+    if (social != null) {
+      sourcesUsed.add(AnalyticsDataSource.socialCounts);
+    }
     final withViewData = videos
         .where((video) => extractViewLikeCount(video) != null)
         .length;
@@ -137,6 +155,7 @@ class FunnelcakeCreatorAnalyticsRepository
         videosHydratedByBulkStats: bulkResult.hydratedCount,
         videosHydratedByViewsEndpoint: endpointResult.hydratedCount,
         sourcesUsed: sourcesUsed,
+        failedSources: failedSources,
         fetchedAt: DateTime.now(),
         videoCatalogTruncated: authorResult.truncated,
       ),
@@ -185,6 +204,44 @@ class FunnelcakeCreatorAnalyticsRepository
         .where((video) => !video.isRepost && video.pubkey == pubkey)
         .toList();
     return _AuthorVideosResult(videos: authored, truncated: truncated);
+  }
+
+  Future<SocialCounts?> _getSocialCountsTolerant(
+    String pubkey,
+    Set<AnalyticsDataSource> failedSources,
+  ) async {
+    try {
+      return await _getSocialCounts(pubkey);
+    } on Object catch (e, stackTrace) {
+      failedSources.add(AnalyticsDataSource.socialCounts);
+      Log.error(
+        'Failed to fetch creator analytics social counts',
+        name: 'CreatorAnalyticsRepository',
+        category: LogCategory.video,
+        error: e,
+        stackTrace: stackTrace,
+      );
+      return null;
+    }
+  }
+
+  Future<_HydrationResult> _enrichVideosWithBulkStatsTolerant(
+    List<VideoEvent> videos,
+    Set<AnalyticsDataSource> failedSources,
+  ) async {
+    try {
+      return await _enrichVideosWithBulkStats(videos);
+    } on Object catch (e, stackTrace) {
+      failedSources.add(AnalyticsDataSource.bulkVideoStats);
+      Log.error(
+        'Failed to hydrate creator analytics videos with bulk stats',
+        name: 'CreatorAnalyticsRepository',
+        category: LogCategory.video,
+        error: e,
+        stackTrace: stackTrace,
+      );
+      return _HydrationResult(videos: videos, hydratedCount: 0);
+    }
   }
 
   Future<_HydrationResult> _enrichVideosWithBulkStats(
@@ -247,6 +304,29 @@ class FunnelcakeCreatorAnalyticsRepository
     return _HydrationResult(videos: hydrated, hydratedCount: hydratedCount);
   }
 
+  Future<_HydrationResult> _hydrateVideoViewsTolerant(
+    List<VideoEvent> videos,
+    Set<AnalyticsDataSource> failedSources,
+  ) async {
+    try {
+      final result = await _hydrateVideoViews(videos);
+      if (result.hadFailures) {
+        failedSources.add(AnalyticsDataSource.videoViewsEndpoint);
+      }
+      return result;
+    } on Object catch (e, stackTrace) {
+      failedSources.add(AnalyticsDataSource.videoViewsEndpoint);
+      Log.error(
+        'Failed to hydrate creator analytics videos with view counts',
+        name: 'CreatorAnalyticsRepository',
+        category: LogCategory.video,
+        error: e,
+        stackTrace: stackTrace,
+      );
+      return _HydrationResult(videos: videos, hydratedCount: 0);
+    }
+  }
+
   Future<_HydrationResult> _hydrateVideoViews(List<VideoEvent> videos) async {
     if (videos.isEmpty) {
       return const _HydrationResult(videos: [], hydratedCount: 0);
@@ -262,6 +342,7 @@ class FunnelcakeCreatorAnalyticsRepository
     }
 
     final fetchedViews = <String, int>{};
+    var hadFailures = false;
     final chunks = <List<VideoEvent>>[];
     for (var i = 0; i < missingViewVideos.length; i += 12) {
       final end = math.min(i + 12, missingViewVideos.length);
@@ -270,15 +351,36 @@ class FunnelcakeCreatorAnalyticsRepository
 
     for (final chunk in chunks) {
       final counts = await Future.wait(
-        chunk.map((video) => _client.getVideoViews(video.id)),
+        chunk.map((video) async {
+          try {
+            return await _client.getVideoViews(video.id);
+          } on Object catch (e, stackTrace) {
+            hadFailures = true;
+            Log.error(
+              'Failed to hydrate creator analytics video view count',
+              name: 'CreatorAnalyticsRepository',
+              category: LogCategory.video,
+              error: e,
+              stackTrace: stackTrace,
+            );
+            return null;
+          }
+        }),
       );
       for (var i = 0; i < chunk.length; i++) {
-        fetchedViews[chunk[i].id] = counts[i];
+        final count = counts[i];
+        if (count != null) {
+          fetchedViews[chunk[i].id] = count;
+        }
       }
     }
 
     if (fetchedViews.isEmpty) {
-      return _HydrationResult(videos: videos, hydratedCount: 0);
+      return _HydrationResult(
+        videos: videos,
+        hydratedCount: 0,
+        hadFailures: hadFailures,
+      );
     }
 
     var hydratedCount = 0;
@@ -290,7 +392,11 @@ class FunnelcakeCreatorAnalyticsRepository
       return video.copyWith(rawTags: mergedTags);
     }).toList();
 
-    return _HydrationResult(videos: hydrated, hydratedCount: hydratedCount);
+    return _HydrationResult(
+      videos: hydrated,
+      hydratedCount: hydratedCount,
+      hadFailures: hadFailures,
+    );
   }
 
   List<List<String>> _chunkStrings(List<String> input, int chunkSize) {
@@ -305,10 +411,15 @@ class FunnelcakeCreatorAnalyticsRepository
 }
 
 class _HydrationResult {
-  const _HydrationResult({required this.videos, required this.hydratedCount});
+  const _HydrationResult({
+    required this.videos,
+    required this.hydratedCount,
+    this.hadFailures = false,
+  });
 
   final List<VideoEvent> videos;
   final int hydratedCount;
+  final bool hadFailures;
 }
 
 class _AuthorVideosResult {

--- a/mobile/lib/features/creator_analytics/creator_analytics_repository.dart
+++ b/mobile/lib/features/creator_analytics/creator_analytics_repository.dart
@@ -1,10 +1,12 @@
 // ABOUTME: Typed repository and diagnostics for creator analytics data loading.
 // ABOUTME: Normalizes Funnelcake responses and tracks metric provenance.
 
+import 'dart:async';
 import 'dart:math' as math;
 
 import 'package:funnelcake_api_client/funnelcake_api_client.dart';
 import 'package:models/models.dart';
+import 'package:openvine/utils/expected_network_error.dart';
 import 'package:unified_logger/unified_logger.dart';
 import 'package:videos_repository/videos_repository.dart';
 
@@ -14,6 +16,24 @@ enum AnalyticsDataSource {
   bulkVideoStats,
   videoViewsEndpoint,
   socialCounts,
+}
+
+/// User-facing failure class for the required analytics load.
+enum CreatorAnalyticsFailureKind {
+  serverUnavailable,
+  connectionIssue,
+  unableToLoad,
+}
+
+/// Exception thrown when the required creator analytics load cannot continue.
+class CreatorAnalyticsLoadException implements Exception {
+  const CreatorAnalyticsLoadException(this.kind, {this.cause});
+
+  final CreatorAnalyticsFailureKind kind;
+  final Object? cause;
+
+  @override
+  String toString() => 'CreatorAnalyticsLoadException: ${kind.name}';
 }
 
 /// Diagnostics to explain data quality and endpoint contribution.
@@ -107,8 +127,20 @@ class FunnelcakeCreatorAnalyticsRepository
     final sourcesUsed = <AnalyticsDataSource>{};
     final failedSources = <AnalyticsDataSource>{};
 
-    final socialFuture = _getSocialCountsTolerant(pubkey, failedSources);
-    final authorResult = await _fetchAuthorVideos(pubkey);
+    final socialFuture = _getSocialCountsTolerant(
+      pubkey,
+      failedSources,
+      sourcesUsed,
+    );
+    final _AuthorVideosResult authorResult;
+    try {
+      authorResult = await _fetchAuthorVideos(pubkey);
+    } on Exception catch (e) {
+      throw CreatorAnalyticsLoadException(
+        _classifyRequiredLoadFailure(e),
+        cause: e,
+      );
+    }
     if (authorResult.videos.isNotEmpty) {
       sourcesUsed.add(AnalyticsDataSource.authorVideos);
     }
@@ -138,9 +170,6 @@ class FunnelcakeCreatorAnalyticsRepository
     final videos = mergeProfileFeedVideoLists(const [], hydratedVideos);
 
     final social = await socialFuture;
-    if (social != null) {
-      sourcesUsed.add(AnalyticsDataSource.socialCounts);
-    }
     final withViewData = videos
         .where((video) => extractViewLikeCount(video) != null)
         .length;
@@ -209,10 +238,13 @@ class FunnelcakeCreatorAnalyticsRepository
   Future<SocialCounts?> _getSocialCountsTolerant(
     String pubkey,
     Set<AnalyticsDataSource> failedSources,
+    Set<AnalyticsDataSource> sourcesUsed,
   ) async {
     try {
-      return await _getSocialCounts(pubkey);
-    } on Object catch (e, stackTrace) {
+      final result = await _getSocialCounts(pubkey);
+      sourcesUsed.add(AnalyticsDataSource.socialCounts);
+      return result;
+    } on Exception catch (e, stackTrace) {
       failedSources.add(AnalyticsDataSource.socialCounts);
       Log.error(
         'Failed to fetch creator analytics social counts',
@@ -231,7 +263,7 @@ class FunnelcakeCreatorAnalyticsRepository
   ) async {
     try {
       return await _enrichVideosWithBulkStats(videos);
-    } on Object catch (e, stackTrace) {
+    } on Exception catch (e, stackTrace) {
       failedSources.add(AnalyticsDataSource.bulkVideoStats);
       Log.error(
         'Failed to hydrate creator analytics videos with bulk stats',
@@ -314,7 +346,7 @@ class FunnelcakeCreatorAnalyticsRepository
         failedSources.add(AnalyticsDataSource.videoViewsEndpoint);
       }
       return result;
-    } on Object catch (e, stackTrace) {
+    } on Exception catch (e, stackTrace) {
       failedSources.add(AnalyticsDataSource.videoViewsEndpoint);
       Log.error(
         'Failed to hydrate creator analytics videos with view counts',
@@ -354,7 +386,7 @@ class FunnelcakeCreatorAnalyticsRepository
         chunk.map((video) async {
           try {
             return await _client.getVideoViews(video.id);
-          } on Object catch (e, stackTrace) {
+          } on Exception catch (e, stackTrace) {
             hadFailures = true;
             Log.error(
               'Failed to hydrate creator analytics video view count',
@@ -409,6 +441,27 @@ class FunnelcakeCreatorAnalyticsRepository
     return chunks;
   }
 }
+
+CreatorAnalyticsFailureKind _classifyRequiredLoadFailure(Exception error) {
+  if (error is FunnelcakeApiException && error.statusCode >= 500) {
+    return CreatorAnalyticsFailureKind.serverUnavailable;
+  }
+  if (error is FunnelcakeTimeoutException ||
+      error is TimeoutException ||
+      _isExpectedNetworkException(error) ||
+      _isExpectedNetworkException(_funnelcakeCause(error))) {
+    return CreatorAnalyticsFailureKind.connectionIssue;
+  }
+  return CreatorAnalyticsFailureKind.unableToLoad;
+}
+
+Object? _funnelcakeCause(Exception error) {
+  if (error is FunnelcakeException) return error.cause;
+  return null;
+}
+
+bool _isExpectedNetworkException(Object? error) =>
+    error != null && isExpectedNetworkFailure(error);
 
 class _HydrationResult {
   const _HydrationResult({

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -1698,6 +1698,8 @@
   "analyticsDiagnosticsSemanticLabel": "Toggle diagnostics",
   "analyticsRetry": "Retry",
   "analyticsUnableToLoad": "Unable to load analytics.",
+  "analyticsServerUnavailable": "Creator analytics is having server trouble. Please try again in a moment.",
+  "analyticsConnectionIssue": "Creator analytics could not connect. Check your connection and try again.",
   "analyticsSignInRequired": "Sign in to view creator analytics.",
   "analyticsViewDataUnavailable": "Views are currently unavailable from the relay for these posts. Like/comment/repost metrics are still accurate.",
   "analyticsViewDataTitle": "View Data",
@@ -1833,6 +1835,14 @@
   },
   "analyticsDiagnosticsSources": "Sources: {sources}",
   "@analyticsDiagnosticsSources": {
+    "placeholders": {
+      "sources": {
+        "type": "String"
+      }
+    }
+  },
+  "analyticsDiagnosticsFailedSources": "Failed sources: {sources}",
+  "@analyticsDiagnosticsFailedSources": {
     "placeholders": {
       "sources": {
         "type": "String"

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -4751,6 +4751,18 @@ abstract class AppLocalizations {
   /// **'Unable to load analytics.'**
   String get analyticsUnableToLoad;
 
+  /// No description provided for @analyticsServerUnavailable.
+  ///
+  /// In en, this message translates to:
+  /// **'Creator analytics is having server trouble. Please try again in a moment.'**
+  String get analyticsServerUnavailable;
+
+  /// No description provided for @analyticsConnectionIssue.
+  ///
+  /// In en, this message translates to:
+  /// **'Creator analytics could not connect. Check your connection and try again.'**
+  String get analyticsConnectionIssue;
+
   /// No description provided for @analyticsSignInRequired.
   ///
   /// In en, this message translates to:
@@ -5050,6 +5062,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Sources: {sources}'**
   String analyticsDiagnosticsSources(String sources);
+
+  /// No description provided for @analyticsDiagnosticsFailedSources.
+  ///
+  /// In en, this message translates to:
+  /// **'Failed sources: {sources}'**
+  String analyticsDiagnosticsFailedSources(String sources);
 
   /// No description provided for @analyticsDiagnosticsUseFixture.
   ///

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -2674,6 +2674,14 @@ class AppLocalizationsAm extends AppLocalizations {
   String get analyticsUnableToLoad => 'ትንታኔዎችን መጫን አልተቻለም።';
 
   @override
+  String get analyticsServerUnavailable =>
+      'Creator analytics is having server trouble. Please try again in a moment.';
+
+  @override
+  String get analyticsConnectionIssue =>
+      'Creator analytics could not connect. Check your connection and try again.';
+
+  @override
   String get analyticsSignInRequired => 'የፈጣሪ ትንታኔን ለማየት ይግቡ።';
 
   @override
@@ -2855,6 +2863,11 @@ class AppLocalizationsAm extends AppLocalizations {
   @override
   String analyticsDiagnosticsSources(String sources) {
     return 'ምንጮች፡ $sources';
+  }
+
+  @override
+  String analyticsDiagnosticsFailedSources(String sources) {
+    return 'Failed sources: $sources';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -2701,6 +2701,14 @@ class AppLocalizationsAr extends AppLocalizations {
   String get analyticsUnableToLoad => 'تعذّر تحميل التحليلات.';
 
   @override
+  String get analyticsServerUnavailable =>
+      'Creator analytics is having server trouble. Please try again in a moment.';
+
+  @override
+  String get analyticsConnectionIssue =>
+      'Creator analytics could not connect. Check your connection and try again.';
+
+  @override
   String get analyticsSignInRequired => 'سجل الدخول لعرض تحليلات الصانع.';
 
   @override
@@ -2882,6 +2890,11 @@ class AppLocalizationsAr extends AppLocalizations {
   @override
   String analyticsDiagnosticsSources(String sources) {
     return 'المصادر: $sources';
+  }
+
+  @override
+  String analyticsDiagnosticsFailedSources(String sources) {
+    return 'Failed sources: $sources';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -2767,6 +2767,14 @@ class AppLocalizationsBg extends AppLocalizations {
   String get analyticsUnableToLoad => 'Анализът не може да се зареди.';
 
   @override
+  String get analyticsServerUnavailable =>
+      'Creator analytics is having server trouble. Please try again in a moment.';
+
+  @override
+  String get analyticsConnectionIssue =>
+      'Creator analytics could not connect. Check your connection and try again.';
+
+  @override
   String get analyticsSignInRequired =>
       'Влез, за да видиш анализите за създатели.';
 
@@ -2953,6 +2961,11 @@ class AppLocalizationsBg extends AppLocalizations {
   @override
   String analyticsDiagnosticsSources(String sources) {
     return 'Източници: $sources';
+  }
+
+  @override
+  String analyticsDiagnosticsFailedSources(String sources) {
+    return 'Failed sources: $sources';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -2758,6 +2758,14 @@ class AppLocalizationsDe extends AppLocalizations {
   String get analyticsUnableToLoad => 'Analytics konnten nicht geladen werden.';
 
   @override
+  String get analyticsServerUnavailable =>
+      'Creator analytics is having server trouble. Please try again in a moment.';
+
+  @override
+  String get analyticsConnectionIssue =>
+      'Creator analytics could not connect. Check your connection and try again.';
+
+  @override
   String get analyticsSignInRequired =>
       'Melde dich an, um Creator-Analytics zu sehen.';
 
@@ -2943,6 +2951,11 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String analyticsDiagnosticsSources(String sources) {
     return 'Quellen: $sources';
+  }
+
+  @override
+  String analyticsDiagnosticsFailedSources(String sources) {
+    return 'Failed sources: $sources';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -2724,6 +2724,14 @@ class AppLocalizationsEn extends AppLocalizations {
   String get analyticsUnableToLoad => 'Unable to load analytics.';
 
   @override
+  String get analyticsServerUnavailable =>
+      'Creator analytics is having server trouble. Please try again in a moment.';
+
+  @override
+  String get analyticsConnectionIssue =>
+      'Creator analytics could not connect. Check your connection and try again.';
+
+  @override
   String get analyticsSignInRequired => 'Sign in to view creator analytics.';
 
   @override
@@ -2905,6 +2913,11 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String analyticsDiagnosticsSources(String sources) {
     return 'Sources: $sources';
+  }
+
+  @override
+  String analyticsDiagnosticsFailedSources(String sources) {
+    return 'Failed sources: $sources';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -2758,6 +2758,14 @@ class AppLocalizationsEs extends AppLocalizations {
   String get analyticsUnableToLoad => 'No se pueden cargar las analíticas.';
 
   @override
+  String get analyticsServerUnavailable =>
+      'Creator analytics is having server trouble. Please try again in a moment.';
+
+  @override
+  String get analyticsConnectionIssue =>
+      'Creator analytics could not connect. Check your connection and try again.';
+
+  @override
   String get analyticsSignInRequired =>
       'Iniciá sesión para ver las analíticas del creador.';
 
@@ -2944,6 +2952,11 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String analyticsDiagnosticsSources(String sources) {
     return 'Fuentes: $sources';
+  }
+
+  @override
+  String analyticsDiagnosticsFailedSources(String sources) {
+    return 'Failed sources: $sources';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -2772,6 +2772,14 @@ class AppLocalizationsFil extends AppLocalizations {
   String get analyticsUnableToLoad => 'Hindi na-load ang analytics.';
 
   @override
+  String get analyticsServerUnavailable =>
+      'Creator analytics is having server trouble. Please try again in a moment.';
+
+  @override
+  String get analyticsConnectionIssue =>
+      'Creator analytics could not connect. Check your connection and try again.';
+
+  @override
   String get analyticsSignInRequired =>
       'Mag-sign in para makita ang creator analytics.';
 
@@ -2957,6 +2965,11 @@ class AppLocalizationsFil extends AppLocalizations {
   @override
   String analyticsDiagnosticsSources(String sources) {
     return 'Mga source: $sources';
+  }
+
+  @override
+  String analyticsDiagnosticsFailedSources(String sources) {
+    return 'Failed sources: $sources';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -2769,6 +2769,14 @@ class AppLocalizationsFr extends AppLocalizations {
   String get analyticsUnableToLoad => 'Impossible de charger les stats.';
 
   @override
+  String get analyticsServerUnavailable =>
+      'Creator analytics is having server trouble. Please try again in a moment.';
+
+  @override
+  String get analyticsConnectionIssue =>
+      'Creator analytics could not connect. Check your connection and try again.';
+
+  @override
   String get analyticsSignInRequired =>
       'Connecte-toi pour voir les stats créateur.';
 
@@ -2955,6 +2963,11 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String analyticsDiagnosticsSources(String sources) {
     return 'Sources : $sources';
+  }
+
+  @override
+  String analyticsDiagnosticsFailedSources(String sources) {
+    return 'Failed sources: $sources';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -2689,6 +2689,14 @@ class AppLocalizationsId extends AppLocalizations {
   String get analyticsUnableToLoad => 'Tidak bisa memuat analitik.';
 
   @override
+  String get analyticsServerUnavailable =>
+      'Creator analytics is having server trouble. Please try again in a moment.';
+
+  @override
+  String get analyticsConnectionIssue =>
+      'Creator analytics could not connect. Check your connection and try again.';
+
+  @override
   String get analyticsSignInRequired => 'Masuk untuk melihat analitik kreator.';
 
   @override
@@ -2872,6 +2880,11 @@ class AppLocalizationsId extends AppLocalizations {
   @override
   String analyticsDiagnosticsSources(String sources) {
     return 'Sumber: $sources';
+  }
+
+  @override
+  String analyticsDiagnosticsFailedSources(String sources) {
+    return 'Failed sources: $sources';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -2759,6 +2759,14 @@ class AppLocalizationsIt extends AppLocalizations {
   String get analyticsUnableToLoad => 'Impossibile caricare le statistiche.';
 
   @override
+  String get analyticsServerUnavailable =>
+      'Creator analytics is having server trouble. Please try again in a moment.';
+
+  @override
+  String get analyticsConnectionIssue =>
+      'Creator analytics could not connect. Check your connection and try again.';
+
+  @override
   String get analyticsSignInRequired =>
       'Accedi per vedere le statistiche creator.';
 
@@ -2945,6 +2953,11 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String analyticsDiagnosticsSources(String sources) {
     return 'Sorgenti: $sources';
+  }
+
+  @override
+  String analyticsDiagnosticsFailedSources(String sources) {
+    return 'Failed sources: $sources';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -2573,6 +2573,14 @@ class AppLocalizationsJa extends AppLocalizations {
   String get analyticsUnableToLoad => '分析データを読み込めなかった。';
 
   @override
+  String get analyticsServerUnavailable =>
+      'Creator analytics is having server trouble. Please try again in a moment.';
+
+  @override
+  String get analyticsConnectionIssue =>
+      'Creator analytics could not connect. Check your connection and try again.';
+
+  @override
   String get analyticsSignInRequired => 'クリエイター分析を見るにはサインインしてね。';
 
   @override
@@ -2753,6 +2761,11 @@ class AppLocalizationsJa extends AppLocalizations {
   @override
   String analyticsDiagnosticsSources(String sources) {
     return 'ソース: $sources';
+  }
+
+  @override
+  String analyticsDiagnosticsFailedSources(String sources) {
+    return 'Failed sources: $sources';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -2586,6 +2586,14 @@ class AppLocalizationsKo extends AppLocalizations {
   String get analyticsUnableToLoad => '분석을 불러올 수 없어요.';
 
   @override
+  String get analyticsServerUnavailable =>
+      'Creator analytics is having server trouble. Please try again in a moment.';
+
+  @override
+  String get analyticsConnectionIssue =>
+      'Creator analytics could not connect. Check your connection and try again.';
+
+  @override
   String get analyticsSignInRequired => '크리에이터 분석을 보려면 로그인해주세요.';
 
   @override
@@ -2765,6 +2773,11 @@ class AppLocalizationsKo extends AppLocalizations {
   @override
   String analyticsDiagnosticsSources(String sources) {
     return '소스: $sources';
+  }
+
+  @override
+  String analyticsDiagnosticsFailedSources(String sources) {
+    return 'Failed sources: $sources';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -2749,6 +2749,14 @@ class AppLocalizationsMs extends AppLocalizations {
   String get analyticsUnableToLoad => 'Tidak dapat memuatkan analitik.';
 
   @override
+  String get analyticsServerUnavailable =>
+      'Creator analytics is having server trouble. Please try again in a moment.';
+
+  @override
+  String get analyticsConnectionIssue =>
+      'Creator analytics could not connect. Check your connection and try again.';
+
+  @override
   String get analyticsSignInRequired =>
       'Log masuk untuk melihat analitik pencipta.';
 
@@ -2933,6 +2941,11 @@ class AppLocalizationsMs extends AppLocalizations {
   @override
   String analyticsDiagnosticsSources(String sources) {
     return 'Sumber: $sources';
+  }
+
+  @override
+  String analyticsDiagnosticsFailedSources(String sources) {
+    return 'Failed sources: $sources';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -2736,6 +2736,14 @@ class AppLocalizationsNl extends AppLocalizations {
   String get analyticsUnableToLoad => 'Statistieken laden lukt niet.';
 
   @override
+  String get analyticsServerUnavailable =>
+      'Creator analytics is having server trouble. Please try again in a moment.';
+
+  @override
+  String get analyticsConnectionIssue =>
+      'Creator analytics could not connect. Check your connection and try again.';
+
+  @override
   String get analyticsSignInRequired =>
       'Log in om creator-statistieken te bekijken.';
 
@@ -2921,6 +2929,11 @@ class AppLocalizationsNl extends AppLocalizations {
   @override
   String analyticsDiagnosticsSources(String sources) {
     return 'Bronnen: $sources';
+  }
+
+  @override
+  String analyticsDiagnosticsFailedSources(String sources) {
+    return 'Failed sources: $sources';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -2811,6 +2811,14 @@ class AppLocalizationsPl extends AppLocalizations {
   String get analyticsUnableToLoad => 'Nie można wczytać statystyk.';
 
   @override
+  String get analyticsServerUnavailable =>
+      'Creator analytics is having server trouble. Please try again in a moment.';
+
+  @override
+  String get analyticsConnectionIssue =>
+      'Creator analytics could not connect. Check your connection and try again.';
+
+  @override
   String get analyticsSignInRequired =>
       'Zaloguj się, żeby zobaczyć statystyki twórcy.';
 
@@ -2994,6 +3002,11 @@ class AppLocalizationsPl extends AppLocalizations {
   @override
   String analyticsDiagnosticsSources(String sources) {
     return 'Źródła: $sources';
+  }
+
+  @override
+  String analyticsDiagnosticsFailedSources(String sources) {
+    return 'Failed sources: $sources';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -2748,6 +2748,14 @@ class AppLocalizationsPt extends AppLocalizations {
       'Não foi possível carregar as estatísticas.';
 
   @override
+  String get analyticsServerUnavailable =>
+      'Creator analytics is having server trouble. Please try again in a moment.';
+
+  @override
+  String get analyticsConnectionIssue =>
+      'Creator analytics could not connect. Check your connection and try again.';
+
+  @override
   String get analyticsSignInRequired =>
       'Entre para ver as estatísticas de criador.';
 
@@ -2932,6 +2940,11 @@ class AppLocalizationsPt extends AppLocalizations {
   @override
   String analyticsDiagnosticsSources(String sources) {
     return 'Fontes: $sources';
+  }
+
+  @override
+  String analyticsDiagnosticsFailedSources(String sources) {
+    return 'Failed sources: $sources';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -2820,6 +2820,14 @@ class AppLocalizationsRo extends AppLocalizations {
   String get analyticsUnableToLoad => 'Nu am putut încărca statisticile.';
 
   @override
+  String get analyticsServerUnavailable =>
+      'Creator analytics is having server trouble. Please try again in a moment.';
+
+  @override
+  String get analyticsConnectionIssue =>
+      'Creator analytics could not connect. Check your connection and try again.';
+
+  @override
   String get analyticsSignInRequired =>
       'Autentifică-te ca să vezi statisticile pentru creatori.';
 
@@ -3005,6 +3013,11 @@ class AppLocalizationsRo extends AppLocalizations {
   @override
   String analyticsDiagnosticsSources(String sources) {
     return 'Surse: $sources';
+  }
+
+  @override
+  String analyticsDiagnosticsFailedSources(String sources) {
+    return 'Failed sources: $sources';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -2720,6 +2720,14 @@ class AppLocalizationsSv extends AppLocalizations {
   String get analyticsUnableToLoad => 'Kunde inte läsa in statistik.';
 
   @override
+  String get analyticsServerUnavailable =>
+      'Creator analytics is having server trouble. Please try again in a moment.';
+
+  @override
+  String get analyticsConnectionIssue =>
+      'Creator analytics could not connect. Check your connection and try again.';
+
+  @override
   String get analyticsSignInRequired =>
       'Logga in för att se kreatörsstatistik.';
 
@@ -2905,6 +2913,11 @@ class AppLocalizationsSv extends AppLocalizations {
   @override
   String analyticsDiagnosticsSources(String sources) {
     return 'Källor: $sources';
+  }
+
+  @override
+  String analyticsDiagnosticsFailedSources(String sources) {
+    return 'Failed sources: $sources';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -2695,6 +2695,14 @@ class AppLocalizationsTr extends AppLocalizations {
   String get analyticsUnableToLoad => 'Analitikler yüklenemiyor.';
 
   @override
+  String get analyticsServerUnavailable =>
+      'Creator analytics is having server trouble. Please try again in a moment.';
+
+  @override
+  String get analyticsConnectionIssue =>
+      'Creator analytics could not connect. Check your connection and try again.';
+
+  @override
   String get analyticsSignInRequired =>
       'İçerik üretici analitiklerini görmek için giriş yap.';
 
@@ -2878,6 +2886,11 @@ class AppLocalizationsTr extends AppLocalizations {
   @override
   String analyticsDiagnosticsSources(String sources) {
     return 'Kaynaklar: $sources';
+  }
+
+  @override
+  String analyticsDiagnosticsFailedSources(String sources) {
+    return 'Failed sources: $sources';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -2724,6 +2724,14 @@ class AppLocalizationsUr extends AppLocalizations {
   String get analyticsUnableToLoad => 'تجزیات لوڈ نہیں ہو سکے۔';
 
   @override
+  String get analyticsServerUnavailable =>
+      'Creator analytics is having server trouble. Please try again in a moment.';
+
+  @override
+  String get analyticsConnectionIssue =>
+      'Creator analytics could not connect. Check your connection and try again.';
+
+  @override
   String get analyticsSignInRequired =>
       'کریئیٹر تجزیات دیکھنے کے لیے سائن ان کریں۔';
 
@@ -2907,6 +2915,11 @@ class AppLocalizationsUr extends AppLocalizations {
   @override
   String analyticsDiagnosticsSources(String sources) {
     return 'ذرائع: $sources';
+  }
+
+  @override
+  String analyticsDiagnosticsFailedSources(String sources) {
+    return 'Failed sources: $sources';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -2731,6 +2731,14 @@ class AppLocalizationsVi extends AppLocalizations {
   String get analyticsUnableToLoad => 'Không thể tải phân tích.';
 
   @override
+  String get analyticsServerUnavailable =>
+      'Creator analytics is having server trouble. Please try again in a moment.';
+
+  @override
+  String get analyticsConnectionIssue =>
+      'Creator analytics could not connect. Check your connection and try again.';
+
+  @override
   String get analyticsSignInRequired =>
       'Đăng nhập để xem phân tích nhà sáng tạo.';
 
@@ -2914,6 +2922,11 @@ class AppLocalizationsVi extends AppLocalizations {
   @override
   String analyticsDiagnosticsSources(String sources) {
     return 'Nguồn: $sources';
+  }
+
+  @override
+  String analyticsDiagnosticsFailedSources(String sources) {
+    return 'Failed sources: $sources';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -2592,6 +2592,14 @@ class AppLocalizationsZh extends AppLocalizations {
   String get analyticsUnableToLoad => '无法加载数据。';
 
   @override
+  String get analyticsServerUnavailable =>
+      'Creator analytics is having server trouble. Please try again in a moment.';
+
+  @override
+  String get analyticsConnectionIssue =>
+      'Creator analytics could not connect. Check your connection and try again.';
+
+  @override
   String get analyticsSignInRequired => '登录后即可查看创作者数据。';
 
   @override
@@ -2770,6 +2778,11 @@ class AppLocalizationsZh extends AppLocalizations {
   @override
   String analyticsDiagnosticsSources(String sources) {
     return '来源：$sources';
+  }
+
+  @override
+  String analyticsDiagnosticsFailedSources(String sources) {
+    return 'Failed sources: $sources';
   }
 
   @override

--- a/mobile/lib/screens/creator_analytics_screen.dart
+++ b/mobile/lib/screens/creator_analytics_screen.dart
@@ -1536,12 +1536,23 @@ class _CreatorAnalyticsSummary {
             )
             .toList()
           ..sort((a, b) {
-            final interactionCompare = b.interactions.compareTo(a.interactions);
-            if (interactionCompare != 0) return interactionCompare;
-            if (a.views == null && b.views == null) return 0;
+            // While engagement is degraded the numbers are hidden, so ranking
+            // by them would still assert an order the rest of the dashboard
+            // refuses to show. Fall back to views, then recency.
+            if (hasEngagementData) {
+              final interactionCompare = b.interactions.compareTo(
+                a.interactions,
+              );
+              if (interactionCompare != 0) return interactionCompare;
+            }
+            if (a.views == null && b.views == null) {
+              return b.video.createdAt.compareTo(a.video.createdAt);
+            }
             if (a.views == null) return 1;
             if (b.views == null) return -1;
-            return b.views!.compareTo(a.views!);
+            final viewCompare = b.views!.compareTo(a.views!);
+            if (viewCompare != 0) return viewCompare;
+            return b.video.createdAt.compareTo(a.video.createdAt);
           });
 
     final likes = performance.fold<int>(0, (sum, video) => sum + video.likes);

--- a/mobile/lib/screens/creator_analytics_screen.dart
+++ b/mobile/lib/screens/creator_analytics_screen.dart
@@ -560,7 +560,8 @@ class _KpiGrid extends StatelessWidget {
             _KpiCard(
               width: cardWidth,
               label: context.l10n.analyticsEngagement,
-              value: summary.engagementRate == null
+              value:
+                  !summary.hasEngagementData || summary.engagementRate == null
                   ? context.l10n.analyticsNa
                   : '${NumberFormat.decimalPattern().format(summary.engagementRate! * 100)}%',
               icon: DivineIconName.trendUp,

--- a/mobile/lib/screens/creator_analytics_screen.dart
+++ b/mobile/lib/screens/creator_analytics_screen.dart
@@ -1,13 +1,11 @@
 // ABOUTME: Creator analytics dashboard draft for profile owners.
 // ABOUTME: Aggregates Funnelcake video and social metrics into creator insights.
 
-import 'dart:async';
 import 'dart:math' as math;
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:funnelcake_api_client/funnelcake_api_client.dart';
 import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
 import 'package:models/models.dart' hide LogCategory;
@@ -19,7 +17,6 @@ import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/creator_analytics_providers.dart';
 import 'package:openvine/router/route_paths.dart';
 import 'package:openvine/screens/video_detail_screen.dart';
-import 'package:openvine/utils/expected_network_error.dart';
 import 'package:openvine/utils/string_utils.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
 
@@ -86,9 +83,13 @@ class _CreatorAnalyticsScreenState
     return [
       _KpiGrid(
         summary: summary,
-        followerCount: data.socialCounts?.followerCount ?? 0,
+        followerValue: data.socialCountsFailed
+            ? context.l10n.analyticsNa
+            : StringUtils.formatCompactNumber(
+                data.socialCounts?.followerCount ?? 0,
+              ),
       ),
-      if (!summary.hasViewData) ...[
+      if (!summary.hasViewData && summary.hasEngagementData) ...[
         const SizedBox(height: 12),
         _AnalyticsCard(
           title: context.l10n.analyticsViewDataTitle,
@@ -126,9 +127,11 @@ class _CreatorAnalyticsScreenState
         children: [
           Text(
             context.l10n.analyticsFollowersCount(
-              StringUtils.formatCompactNumber(
-                data.socialCounts?.followerCount ?? 0,
-              ),
+              data.socialCountsFailed
+                  ? context.l10n.analyticsNa
+                  : StringUtils.formatCompactNumber(
+                      data.socialCounts?.followerCount ?? 0,
+                    ),
             ),
             style: VineTheme.bodyMediumFont(
               color: context.vineColors.primaryText,
@@ -137,9 +140,11 @@ class _CreatorAnalyticsScreenState
           const SizedBox(height: 6),
           Text(
             context.l10n.analyticsFollowingCount(
-              StringUtils.formatCompactNumber(
-                data.socialCounts?.followingCount ?? 0,
-              ),
+              data.socialCountsFailed
+                  ? context.l10n.analyticsNa
+                  : StringUtils.formatCompactNumber(
+                      data.socialCounts?.followingCount ?? 0,
+                    ),
             ),
             style: VineTheme.bodyMediumFont(
               color: context.vineColors.primaryText,
@@ -347,13 +352,14 @@ String _analyticsErrorMessage(BuildContext context, Object? error) {
   if (error is _CreatorAnalyticsSignInRequiredException) {
     return l10n.analyticsSignInRequired;
   }
-  if (error is FunnelcakeApiException && error.statusCode >= 500) {
-    return l10n.analyticsServerUnavailable;
-  }
-  if (error is FunnelcakeTimeoutException ||
-      error is TimeoutException ||
-      (error != null && isExpectedNetworkFailure(error))) {
-    return l10n.analyticsConnectionIssue;
+  if (error is CreatorAnalyticsLoadException) {
+    return switch (error.kind) {
+      CreatorAnalyticsFailureKind.serverUnavailable =>
+        l10n.analyticsServerUnavailable,
+      CreatorAnalyticsFailureKind.connectionIssue =>
+        l10n.analyticsConnectionIssue,
+      CreatorAnalyticsFailureKind.unableToLoad => l10n.analyticsUnableToLoad,
+    };
   }
   return l10n.analyticsUnableToLoad;
 }
@@ -509,10 +515,10 @@ class _DiagnosticsPanel extends StatelessWidget {
 }
 
 class _KpiGrid extends StatelessWidget {
-  const _KpiGrid({required this.summary, required this.followerCount});
+  const _KpiGrid({required this.summary, required this.followerValue});
 
   final _CreatorAnalyticsSummary summary;
-  final int followerCount;
+  final String followerValue;
 
   @override
   Widget build(BuildContext context) {
@@ -541,7 +547,9 @@ class _KpiGrid extends StatelessWidget {
             _KpiCard(
               width: cardWidth,
               label: context.l10n.analyticsInteractions,
-              value: StringUtils.formatCompactNumber(summary.totalInteractions),
+              value: summary.hasEngagementData
+                  ? StringUtils.formatCompactNumber(summary.totalInteractions)
+                  : context.l10n.analyticsNa,
               // No design-system glyph for these two yet (#4833).
               iconWidget: const Icon(
                 Icons.touch_app_outlined,
@@ -560,13 +568,15 @@ class _KpiGrid extends StatelessWidget {
             _KpiCard(
               width: cardWidth,
               label: context.l10n.analyticsFollowers,
-              value: StringUtils.formatCompactNumber(followerCount),
+              value: followerValue,
               icon: DivineIconName.users,
             ),
             _KpiCard(
               width: cardWidth,
               label: context.l10n.analyticsAvgPerPost,
-              value: summary.videoCount == 0
+              value: !summary.hasEngagementData
+                  ? context.l10n.analyticsNa
+                  : summary.videoCount == 0
                   ? '0'
                   : NumberFormat.decimalPattern().format(
                       summary.averageInteractionsPerVideo,
@@ -648,6 +658,18 @@ class _EngagementBreakdown extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    if (!summary.hasEngagementData) {
+      return _AnalyticsCard(
+        title: context.l10n.analyticsInteractionMix,
+        child: Text(
+          context.l10n.analyticsNa,
+          style: VineTheme.bodySmallFont(
+            color: context.vineColors.onSurfaceMuted,
+          ),
+        ),
+      );
+    }
+
     final total = summary.totalInteractions;
     final likesShare = total == 0 ? 0.0 : summary.totalLikes / total;
     final commentsShare = total == 0 ? 0.0 : summary.totalComments / total;
@@ -765,30 +787,36 @@ class _PerformanceHighlights extends StatelessWidget {
           const SizedBox(height: 10),
           _HighlightRow(
             label: context.l10n.analyticsMostDiscussed,
-            metricText: context.l10n.analyticsCommentsCount(
-              StringUtils.formatCompactNumber(
-                summary.mostDiscussed?.comments ?? 0,
-              ),
-            ),
-            title:
-                summary.mostDiscussed?.displayTitle ??
-                context.l10n.analyticsNoVideosYet,
-            onTap: summary.mostDiscussed == null
+            metricText: summary.hasEngagementData
+                ? context.l10n.analyticsCommentsCount(
+                    StringUtils.formatCompactNumber(
+                      summary.mostDiscussed?.comments ?? 0,
+                    ),
+                  )
+                : context.l10n.analyticsNa,
+            title: summary.hasEngagementData
+                ? (summary.mostDiscussed?.displayTitle ??
+                      context.l10n.analyticsNoVideosYet)
+                : context.l10n.analyticsNa,
+            onTap: !summary.hasEngagementData || summary.mostDiscussed == null
                 ? null
                 : () => onTapPerformance(summary.mostDiscussed!),
           ),
           const SizedBox(height: 10),
           _HighlightRow(
             label: context.l10n.analyticsMostReposted,
-            metricText: context.l10n.analyticsRepostsCount(
-              StringUtils.formatCompactNumber(
-                summary.mostReposted?.reposts ?? 0,
-              ),
-            ),
-            title:
-                summary.mostReposted?.displayTitle ??
-                context.l10n.analyticsNoVideosYet,
-            onTap: summary.mostReposted == null
+            metricText: summary.hasEngagementData
+                ? context.l10n.analyticsRepostsCount(
+                    StringUtils.formatCompactNumber(
+                      summary.mostReposted?.reposts ?? 0,
+                    ),
+                  )
+                : context.l10n.analyticsNa,
+            title: summary.hasEngagementData
+                ? (summary.mostReposted?.displayTitle ??
+                      context.l10n.analyticsNoVideosYet)
+                : context.l10n.analyticsNa,
+            onTap: !summary.hasEngagementData || summary.mostReposted == null
                 ? null
                 : () => onTapPerformance(summary.mostReposted!),
           ),
@@ -904,6 +932,7 @@ class _TopVideosList extends StatelessWidget {
                   _TopVideoRow(
                     rank: i + 1,
                     performance: topVideos[i],
+                    hasEngagementData: summary.hasEngagementData,
                     onTap: () => onTapPerformance(topVideos[i]),
                   ),
                   if (i != topVideos.length - 1) const SizedBox(height: 12),
@@ -918,11 +947,13 @@ class _TopVideoRow extends StatelessWidget {
   const _TopVideoRow({
     required this.rank,
     required this.performance,
+    required this.hasEngagementData,
     required this.onTap,
   });
 
   final int rank;
   final VideoPerformance performance;
+  final bool hasEngagementData;
   final VoidCallback onTap;
 
   @override
@@ -965,7 +996,7 @@ class _TopVideoRow extends StatelessWidget {
                   const SizedBox(height: 3),
                   Text(
                     '${performance.views != null ? context.l10n.analyticsViewsCount(StringUtils.formatCompactNumber(performance.views!)) : context.l10n.analyticsViewsUnavailable} \u2022 '
-                    '${context.l10n.analyticsInteractionsCount(StringUtils.formatCompactNumber(performance.interactions))}',
+                    '${hasEngagementData ? context.l10n.analyticsInteractionsCount(StringUtils.formatCompactNumber(performance.interactions)) : context.l10n.analyticsNa}',
                     style: VineTheme.bodySmallFont(
                       color: context.vineColors.onSurfaceMuted,
                     ),
@@ -975,7 +1006,7 @@ class _TopVideoRow extends StatelessWidget {
             ),
             const SizedBox(width: 8),
             Text(
-              performance.engagementRate == null
+              !hasEngagementData || performance.engagementRate == null
                   ? context.l10n.analyticsNa
                   : '${(performance.engagementRate! * 100).toStringAsFixed(1)}%',
               style: VineTheme.bodySmallFont(color: VineTheme.vineGreen),
@@ -1035,8 +1066,16 @@ class _PostAnalyticsDetailScreenState
 
     final repository = ref.read(creatorAnalyticsRepositoryProvider);
     final snapshot = await repository.fetchCreatorAnalytics(pubkey);
+    final hasEngagementData = !snapshot.diagnostics.failedSources.contains(
+      AnalyticsDataSource.bulkVideoStats,
+    );
     for (final video in snapshot.videos) {
-      if (video.id == widget.videoId) return VideoPerformance.fromVideo(video);
+      if (video.id == widget.videoId) {
+        return VideoPerformance.fromVideo(
+          video,
+          hasEngagementData: hasEngagementData,
+        );
+      }
     }
     return null;
   }
@@ -1108,7 +1147,8 @@ class _PostAnalyticsDetailView extends StatelessWidget {
     final likes = performance.likes;
     final comments = performance.comments;
     final reposts = performance.reposts;
-    final total = performance.interactions;
+    final hasEngagementData = performance.hasEngagementData;
+    final total = hasEngagementData ? performance.interactions : 0;
 
     final likesShare = total == 0 ? 0.0 : likes / total;
     final commentsShare = total == 0 ? 0.0 : comments / total;
@@ -1150,45 +1190,61 @@ class _PostAnalyticsDetailView extends StatelessWidget {
                         ),
                         _MetricPill(
                           label: context.l10n.analyticsLikes,
-                          value: StringUtils.formatCompactNumber(likes),
+                          value: hasEngagementData
+                              ? StringUtils.formatCompactNumber(likes)
+                              : context.l10n.analyticsNa,
                         ),
                         _MetricPill(
                           label: context.l10n.analyticsComments,
-                          value: StringUtils.formatCompactNumber(comments),
+                          value: hasEngagementData
+                              ? StringUtils.formatCompactNumber(comments)
+                              : context.l10n.analyticsNa,
                         ),
                         _MetricPill(
                           label: context.l10n.analyticsReposts,
-                          value: StringUtils.formatCompactNumber(reposts),
+                          value: hasEngagementData
+                              ? StringUtils.formatCompactNumber(reposts)
+                              : context.l10n.analyticsNa,
                         ),
                         _MetricPill(
                           label: context.l10n.analyticsEngagement,
-                          value: performance.engagementRate == null
+                          value:
+                              !hasEngagementData ||
+                                  performance.engagementRate == null
                               ? context.l10n.analyticsNa
                               : '${(performance.engagementRate! * 100).toStringAsFixed(1)}%',
                         ),
                       ],
                     ),
                     const SizedBox(height: 14),
-                    _BreakdownRow(
-                      label: context.l10n.analyticsLikes,
-                      value: likes,
-                      share: likesShare,
-                      color: VineTheme.likeRed,
-                    ),
-                    const SizedBox(height: 8),
-                    _BreakdownRow(
-                      label: context.l10n.analyticsComments,
-                      value: comments,
-                      share: commentsShare,
-                      color: VineTheme.commentBlue,
-                    ),
-                    const SizedBox(height: 8),
-                    _BreakdownRow(
-                      label: context.l10n.analyticsReposts,
-                      value: reposts,
-                      share: repostShare,
-                      color: VineTheme.vineGreenDark,
-                    ),
+                    if (hasEngagementData) ...[
+                      _BreakdownRow(
+                        label: context.l10n.analyticsLikes,
+                        value: likes,
+                        share: likesShare,
+                        color: VineTheme.likeRed,
+                      ),
+                      const SizedBox(height: 8),
+                      _BreakdownRow(
+                        label: context.l10n.analyticsComments,
+                        value: comments,
+                        share: commentsShare,
+                        color: VineTheme.commentBlue,
+                      ),
+                      const SizedBox(height: 8),
+                      _BreakdownRow(
+                        label: context.l10n.analyticsReposts,
+                        value: reposts,
+                        share: repostShare,
+                        color: VineTheme.vineGreenDark,
+                      ),
+                    ] else
+                      Text(
+                        context.l10n.analyticsNa,
+                        style: VineTheme.bodySmallFont(
+                          color: context.vineColors.onSurfaceMuted,
+                        ),
+                      ),
                     const SizedBox(height: 14),
                     DivineButton(
                       label: context.l10n.analyticsOpenPost,
@@ -1255,6 +1311,18 @@ class _DailyTrendCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    if (!summary.hasEngagementData) {
+      return _AnalyticsCard(
+        title: context.l10n.analyticsRecentDailyInteractions,
+        child: Text(
+          context.l10n.analyticsNa,
+          style: VineTheme.bodySmallFont(
+            color: context.vineColors.onSurfaceMuted,
+          ),
+        ),
+      );
+    }
+
     final points = summary.dailyInteractions;
     final locale = Localizations.localeOf(context).toLanguageTag();
     final maxValue = points.fold<int>(
@@ -1396,6 +1464,12 @@ class _CreatorAnalyticsData {
   final SocialCounts? socialCounts;
   final CreatorAnalyticsDiagnostics diagnostics;
   final DateTime fetchedAt;
+
+  bool get socialCountsFailed =>
+      diagnostics.failedSources.contains(AnalyticsDataSource.socialCounts);
+
+  bool get engagementFailed =>
+      diagnostics.failedSources.contains(AnalyticsDataSource.bulkVideoStats);
 }
 
 class _CreatorAnalyticsSummary {
@@ -1403,6 +1477,7 @@ class _CreatorAnalyticsSummary {
     required this.videoCount,
     required this.totalViews,
     required this.hasViewData,
+    required this.hasEngagementData,
     required this.totalLikes,
     required this.totalComments,
     required this.totalReposts,
@@ -1419,6 +1494,7 @@ class _CreatorAnalyticsSummary {
   final int videoCount;
   final int totalViews;
   final bool hasViewData;
+  final bool hasEngagementData;
   final int totalLikes;
   final int totalComments;
   final int totalReposts;
@@ -1445,15 +1521,24 @@ class _CreatorAnalyticsSummary {
       return !_videoTimestamp(video).isBefore(start);
     }).toList();
 
-    final performance = videos.map(VideoPerformance.fromVideo).toList()
-      ..sort((a, b) {
-        final interactionCompare = b.interactions.compareTo(a.interactions);
-        if (interactionCompare != 0) return interactionCompare;
-        if (a.views == null && b.views == null) return 0;
-        if (a.views == null) return 1;
-        if (b.views == null) return -1;
-        return b.views!.compareTo(a.views!);
-      });
+    final hasEngagementData = !data.engagementFailed;
+    final performance =
+        videos
+            .map(
+              (video) => VideoPerformance.fromVideo(
+                video,
+                hasEngagementData: hasEngagementData,
+              ),
+            )
+            .toList()
+          ..sort((a, b) {
+            final interactionCompare = b.interactions.compareTo(a.interactions);
+            if (interactionCompare != 0) return interactionCompare;
+            if (a.views == null && b.views == null) return 0;
+            if (a.views == null) return 1;
+            if (b.views == null) return -1;
+            return b.views!.compareTo(a.views!);
+          });
 
     final likes = performance.fold<int>(0, (sum, video) => sum + video.likes);
     final comments = performance.fold<int>(
@@ -1514,6 +1599,7 @@ class _CreatorAnalyticsSummary {
       videoCount: performance.length,
       totalViews: views,
       hasViewData: hasViewData,
+      hasEngagementData: hasEngagementData,
       totalLikes: likes,
       totalComments: comments,
       totalReposts: reposts,
@@ -1572,6 +1658,7 @@ class VideoPerformance {
   const VideoPerformance({
     required this.video,
     required this.views,
+    required this.hasEngagementData,
     required this.likes,
     required this.comments,
     required this.reposts,
@@ -1580,7 +1667,10 @@ class VideoPerformance {
     required this.displayTitle,
   });
 
-  factory VideoPerformance.fromVideo(VideoEvent video) {
+  factory VideoPerformance.fromVideo(
+    VideoEvent video, {
+    bool hasEngagementData = true,
+  }) {
     final likes = liveLikeCountSeed(video) ?? 0;
     final comments = liveCommentCountSeed(video) ?? 0;
     final reposts = liveRepostCountSeed(video) ?? 0;
@@ -1596,6 +1686,7 @@ class VideoPerformance {
     return VideoPerformance(
       video: video,
       views: views,
+      hasEngagementData: hasEngagementData,
       likes: likes,
       comments: comments,
       reposts: reposts,
@@ -1607,6 +1698,7 @@ class VideoPerformance {
 
   final VideoEvent video;
   final int? views;
+  final bool hasEngagementData;
   final int likes;
   final int comments;
   final int reposts;

--- a/mobile/lib/screens/creator_analytics_screen.dart
+++ b/mobile/lib/screens/creator_analytics_screen.dart
@@ -345,6 +345,9 @@ class _ErrorView extends StatelessWidget {
 
 class _CreatorAnalyticsSignInRequiredException implements Exception {
   const _CreatorAnalyticsSignInRequiredException();
+
+  @override
+  String toString() => 'CreatorAnalyticsSignInRequiredException';
 }
 
 String _analyticsErrorMessage(BuildContext context, Object? error) {

--- a/mobile/lib/screens/creator_analytics_screen.dart
+++ b/mobile/lib/screens/creator_analytics_screen.dart
@@ -1,11 +1,13 @@
 // ABOUTME: Creator analytics dashboard draft for profile owners.
 // ABOUTME: Aggregates Funnelcake video and social metrics into creator insights.
 
+import 'dart:async';
 import 'dart:math' as math;
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:funnelcake_api_client/funnelcake_api_client.dart';
 import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
 import 'package:models/models.dart' hide LogCategory;
@@ -17,6 +19,7 @@ import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/creator_analytics_providers.dart';
 import 'package:openvine/router/route_paths.dart';
 import 'package:openvine/screens/video_detail_screen.dart';
+import 'package:openvine/utils/expected_network_error.dart';
 import 'package:openvine/utils/string_utils.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
 
@@ -55,7 +58,7 @@ class _CreatorAnalyticsScreenState
     final authService = ref.read(authServiceProvider);
     final pubkey = authService.currentPublicKeyHex;
     if (pubkey == null || pubkey.isEmpty) {
-      throw StateError(context.l10n.analyticsSignInRequired);
+      throw const _CreatorAnalyticsSignInRequiredException();
     }
 
     final repository = ref.read(creatorAnalyticsRepositoryProvider);
@@ -302,6 +305,8 @@ class _ErrorView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final message = _analyticsErrorMessage(context, error);
+
     return Center(
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 24),
@@ -315,7 +320,7 @@ class _ErrorView extends StatelessWidget {
             ),
             const SizedBox(height: 12),
             Text(
-              '$error',
+              message,
               textAlign: TextAlign.center,
               style: VineTheme.bodyMediumFont(
                 color: context.vineColors.onSurfaceMuted,
@@ -331,6 +336,26 @@ class _ErrorView extends StatelessWidget {
       ),
     );
   }
+}
+
+class _CreatorAnalyticsSignInRequiredException implements Exception {
+  const _CreatorAnalyticsSignInRequiredException();
+}
+
+String _analyticsErrorMessage(BuildContext context, Object? error) {
+  final l10n = context.l10n;
+  if (error is _CreatorAnalyticsSignInRequiredException) {
+    return l10n.analyticsSignInRequired;
+  }
+  if (error is FunnelcakeApiException && error.statusCode >= 500) {
+    return l10n.analyticsServerUnavailable;
+  }
+  if (error is FunnelcakeTimeoutException ||
+      error is TimeoutException ||
+      (error != null && isExpectedNetworkFailure(error))) {
+    return l10n.analyticsConnectionIssue;
+  }
+  return l10n.analyticsUnableToLoad;
 }
 
 class _RangeSelector extends StatelessWidget {
@@ -385,12 +410,16 @@ class _DiagnosticsPanel extends StatelessWidget {
         AnalyticsDataSource.authorVideos => 'author-videos',
         AnalyticsDataSource.bulkVideoStats => 'bulk-video-stats',
         AnalyticsDataSource.videoViewsEndpoint => 'video-views-endpoint',
+        AnalyticsDataSource.socialCounts => 'social-counts',
       };
     }
 
     final sourceText = diagnostics.sourcesUsed.isEmpty
         ? 'none'
         : diagnostics.sourcesUsed.map(sourceLabel).join(', ');
+    final failedSourceText = diagnostics.failedSources.isEmpty
+        ? 'none'
+        : diagnostics.failedSources.map(sourceLabel).join(', ');
 
     return _AnalyticsCard(
       title: context.l10n.analyticsDiagnostics,
@@ -444,6 +473,13 @@ class _DiagnosticsPanel extends StatelessWidget {
           const SizedBox(height: 6),
           Text(
             context.l10n.analyticsDiagnosticsSources(sourceText),
+            style: VineTheme.bodySmallFont(
+              color: context.vineColors.onSurfaceMuted,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            context.l10n.analyticsDiagnosticsFailedSources(failedSourceText),
             style: VineTheme.bodySmallFont(
               color: context.vineColors.onSurfaceMuted,
             ),

--- a/mobile/packages/funnelcake_api_client/lib/src/exceptions.dart
+++ b/mobile/packages/funnelcake_api_client/lib/src/exceptions.dart
@@ -4,13 +4,20 @@
 /// Base exception for all Funnelcake API errors.
 class FunnelcakeException implements Exception {
   /// Creates a new Funnelcake exception.
-  const FunnelcakeException(this.message);
+  const FunnelcakeException(this.message, {this.cause});
 
   /// The error message describing what went wrong.
   final String message;
 
+  /// The lower-level error that caused this exception, when one was wrapped.
+  final Object? cause;
+
   @override
-  String toString() => 'FunnelcakeException: $message';
+  String toString() {
+    final wrapped = cause;
+    if (wrapped == null) return 'FunnelcakeException: $message';
+    return 'FunnelcakeException: $message (cause: $wrapped)';
+  }
 }
 
 /// Exception thrown when the Funnelcake API is not configured.

--- a/mobile/packages/funnelcake_api_client/lib/src/exceptions.dart
+++ b/mobile/packages/funnelcake_api_client/lib/src/exceptions.dart
@@ -10,6 +10,13 @@ class FunnelcakeException implements Exception {
   final String message;
 
   /// The lower-level error that caused this exception, when one was wrapped.
+  ///
+  /// Contract: only some wrap sites populate this today — currently the
+  /// author-videos fetch. A wrap site that does not pass `cause:` leaves it
+  /// null, and callers classifying failures by cause (for example creator
+  /// analytics' connection-vs-server copy) silently fall back to their
+  /// generic verdict for those endpoints. Populate the field before relying
+  /// on it for a new call site.
   final Object? cause;
 
   @override

--- a/mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart
+++ b/mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart
@@ -493,7 +493,7 @@ class FunnelcakeApiClient {
     } on FunnelcakeException {
       rethrow;
     } catch (e) {
-      throw FunnelcakeException('Failed to fetch author videos: $e');
+      throw FunnelcakeException('Failed to fetch author videos: $e', cause: e);
     }
   }
 

--- a/mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart
+++ b/mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart
@@ -186,6 +186,13 @@ class FunnelcakeApiClient {
           continue;
         }
         return response;
+      } on TimeoutException catch (e) {
+        // Future.timeout sets duration; transport timeouts constructed by
+        // the client stack usually do not. The former has spent this call's
+        // whole budget and must not start another attempt.
+        if (e.duration != null) rethrow;
+        if (!_canRetry(attempt, remaining())) rethrow;
+        await _awaitRetryDelay(attempt, remaining());
       } on Object {
         // Nothing above constructs a FunnelcakeException, so any throw here
         // is transport-level and worth another attempt.

--- a/mobile/packages/funnelcake_api_client/test/src/funnelcake_api_client_test.dart
+++ b/mobile/packages/funnelcake_api_client/test/src/funnelcake_api_client_test.dart
@@ -5806,6 +5806,20 @@ void main() {
       expect(exception.toString(), equals('FunnelcakeException: Test error'));
     });
 
+    test('FunnelcakeException preserves wrapped cause', () {
+      const cause = FormatException('bad response');
+      const exception = FunnelcakeException('Test error', cause: cause);
+
+      expect(exception.cause, same(cause));
+      expect(
+        exception.toString(),
+        equals(
+          'FunnelcakeException: Test error '
+          '(cause: FormatException: bad response)',
+        ),
+      );
+    });
+
     test('FunnelcakeNotConfiguredException has correct message', () {
       const exception = FunnelcakeNotConfiguredException();
       expect(exception.message, equals('Funnelcake API not configured'));

--- a/mobile/test/features/creator_analytics/creator_analytics_repository_test.dart
+++ b/mobile/test/features/creator_analytics/creator_analytics_repository_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:funnelcake_api_client/funnelcake_api_client.dart';
 import 'package:mocktail/mocktail.dart';
@@ -116,12 +118,7 @@ void main() {
       ).thenAnswer(
         (_) async => VideosByAuthorResponse(
           videos: [
-            _videoStats(
-              id: 'a',
-              pubkey: pubkey,
-              reactions: 0,
-              comments: 0,
-            ),
+            _videoStats(id: 'a', pubkey: pubkey, reactions: 0, comments: 0),
           ],
         ),
       );
@@ -429,6 +426,233 @@ void main() {
 
       expect(snapshot.diagnostics.totalVideos, 400);
       expect(snapshot.diagnostics.videoCatalogTruncated, isTrue);
+    });
+
+    test('keeps author videos when bulk stats hydration fails', () async {
+      const pubkey = 'pubkey';
+      final api = MockFunnelcakeApiClient();
+
+      when(() => api.isAvailable).thenReturn(true);
+      when(() => api.getSocialCounts(pubkey)).thenAnswer((_) async => null);
+      when(() => api.getBulkVideoStats(any())).thenThrow(
+        const FunnelcakeApiException(
+          message: 'bulk failed',
+          statusCode: 500,
+          url: 'https://api.divine.video/api/videos/stats/bulk',
+        ),
+      );
+      when(() => api.getVideoViews(any())).thenThrow(
+        const FunnelcakeApiException(message: 'views failed', statusCode: 500),
+      );
+      when(
+        () => api.getVideosByAuthor(
+          pubkey: pubkey,
+          limit: 100,
+          before: any(named: 'before'),
+        ),
+      ).thenAnswer(
+        (_) async => VideosByAuthorResponse(
+          videos: [_videoStats(id: 'bulk-failure-video', pubkey: pubkey)],
+        ),
+      );
+
+      final repo = FunnelcakeCreatorAnalyticsRepository(api);
+      final snapshot = await repo.fetchCreatorAnalytics(pubkey);
+
+      expect(snapshot.videos.single.id, 'bulk-failure-video');
+      expect(snapshot.diagnostics.videosWithAnyViews, 0);
+      expect(snapshot.diagnostics.videosMissingViews, 1);
+      expect(snapshot.diagnostics.videosHydratedByBulkStats, 0);
+      expect(snapshot.diagnostics.failedSources, {
+        AnalyticsDataSource.bulkVideoStats,
+        AnalyticsDataSource.videoViewsEndpoint,
+      });
+    });
+
+    test('keeps author videos when a video views request fails', () async {
+      const pubkey = 'pubkey';
+      final api = MockFunnelcakeApiClient();
+
+      when(() => api.isAvailable).thenReturn(true);
+      when(() => api.getSocialCounts(pubkey)).thenAnswer((_) async => null);
+      when(
+        () => api.getBulkVideoStats(any()),
+      ).thenAnswer((_) async => const BulkVideoStatsResponse(stats: {}));
+      when(() => api.getVideoViews('views-failure-video')).thenThrow(
+        const FunnelcakeApiException(message: 'views failed', statusCode: 500),
+      );
+      when(
+        () => api.getVideosByAuthor(
+          pubkey: pubkey,
+          limit: 100,
+          before: any(named: 'before'),
+        ),
+      ).thenAnswer(
+        (_) async => VideosByAuthorResponse(
+          videos: [_videoStats(id: 'views-failure-video', pubkey: pubkey)],
+        ),
+      );
+
+      final repo = FunnelcakeCreatorAnalyticsRepository(api);
+      final snapshot = await repo.fetchCreatorAnalytics(pubkey);
+
+      expect(snapshot.videos.single.id, 'views-failure-video');
+      expect(snapshot.diagnostics.videosWithAnyViews, 0);
+      expect(snapshot.diagnostics.videosMissingViews, 1);
+      expect(snapshot.diagnostics.videosHydratedByViewsEndpoint, 0);
+      expect(snapshot.diagnostics.failedSources, {
+        AnalyticsDataSource.videoViewsEndpoint,
+      });
+    });
+
+    test('hydrates remaining video views when one request fails', () async {
+      const pubkey = 'pubkey';
+      final api = MockFunnelcakeApiClient();
+
+      when(() => api.isAvailable).thenReturn(true);
+      when(() => api.getSocialCounts(pubkey)).thenAnswer((_) async => null);
+      when(
+        () => api.getBulkVideoStats(any()),
+      ).thenAnswer((_) async => const BulkVideoStatsResponse(stats: {}));
+      when(() => api.getVideoViews('bad-video')).thenThrow(
+        const FunnelcakeApiException(message: 'views failed', statusCode: 500),
+      );
+      when(() => api.getVideoViews('good-video')).thenAnswer((_) async => 33);
+      when(
+        () => api.getVideosByAuthor(
+          pubkey: pubkey,
+          limit: 100,
+          before: any(named: 'before'),
+        ),
+      ).thenAnswer(
+        (_) async => VideosByAuthorResponse(
+          videos: [
+            _videoStats(id: 'bad-video', pubkey: pubkey),
+            _videoStats(id: 'good-video', pubkey: pubkey),
+          ],
+        ),
+      );
+
+      final repo = FunnelcakeCreatorAnalyticsRepository(api);
+      final snapshot = await repo.fetchCreatorAnalytics(pubkey);
+
+      expect(snapshot.diagnostics.videosHydratedByViewsEndpoint, 1);
+      expect(snapshot.diagnostics.videosWithAnyViews, 1);
+      expect(snapshot.diagnostics.videosMissingViews, 1);
+      expect(
+        snapshot.videos
+            .singleWhere((video) => video.id == 'good-video')
+            .rawTags['views'],
+        '33',
+      );
+      expect(snapshot.diagnostics.failedSources, {
+        AnalyticsDataSource.videoViewsEndpoint,
+      });
+    });
+
+    test(
+      'keeps videos and nulls social counts when social counts fail',
+      () async {
+        const pubkey = 'pubkey';
+        final api = MockFunnelcakeApiClient();
+
+        when(() => api.isAvailable).thenReturn(true);
+        when(() => api.getSocialCounts(pubkey)).thenThrow(
+          const FunnelcakeApiException(
+            message: 'social failed',
+            statusCode: 500,
+          ),
+        );
+        when(
+          () => api.getBulkVideoStats(any()),
+        ).thenAnswer((_) async => const BulkVideoStatsResponse(stats: {}));
+        when(() => api.getVideoViews(any())).thenAnswer((_) async => 12);
+        when(
+          () => api.getVideosByAuthor(
+            pubkey: pubkey,
+            limit: 100,
+            before: any(named: 'before'),
+          ),
+        ).thenAnswer(
+          (_) async => VideosByAuthorResponse(
+            videos: [_videoStats(id: 'social-failure-video', pubkey: pubkey)],
+          ),
+        );
+
+        final repo = FunnelcakeCreatorAnalyticsRepository(api);
+        final snapshot = await repo.fetchCreatorAnalytics(pubkey);
+
+        expect(snapshot.videos.single.id, 'social-failure-video');
+        expect(snapshot.socialCounts, isNull);
+        expect(snapshot.diagnostics.failedSources, {
+          AnalyticsDataSource.socialCounts,
+        });
+      },
+    );
+
+    test('rethrows author video failures', () async {
+      const pubkey = 'pubkey';
+      final api = MockFunnelcakeApiClient();
+
+      when(() => api.isAvailable).thenReturn(true);
+      when(() => api.getSocialCounts(pubkey)).thenAnswer((_) async => null);
+      when(
+        () => api.getVideosByAuthor(
+          pubkey: pubkey,
+          limit: 100,
+          before: any(named: 'before'),
+        ),
+      ).thenThrow(
+        const FunnelcakeApiException(message: 'author failed', statusCode: 500),
+      );
+
+      final repo = FunnelcakeCreatorAnalyticsRepository(api);
+
+      await expectLater(
+        repo.fetchCreatorAnalytics(pubkey),
+        throwsA(isA<FunnelcakeApiException>()),
+      );
+    });
+
+    test('handles social failure when author video fetch also fails', () async {
+      const pubkey = 'pubkey';
+      final api = MockFunnelcakeApiClient();
+      final unhandledErrors = <Object>[];
+
+      when(() => api.isAvailable).thenReturn(true);
+      when(() => api.getSocialCounts(pubkey)).thenAnswer((_) async {
+        await Future<void>.delayed(Duration.zero);
+        throw const FunnelcakeApiException(
+          message: 'social failed',
+          statusCode: 500,
+        );
+      });
+      when(
+        () => api.getVideosByAuthor(
+          pubkey: pubkey,
+          limit: 100,
+          before: any(named: 'before'),
+        ),
+      ).thenThrow(
+        const FunnelcakeApiException(message: 'author failed', statusCode: 500),
+      );
+
+      final repo = FunnelcakeCreatorAnalyticsRepository(api);
+
+      await runZonedGuarded<Future<void>>(
+        () async {
+          await expectLater(
+            repo.fetchCreatorAnalytics(pubkey),
+            throwsA(isA<FunnelcakeApiException>()),
+          );
+          await Future<void>.delayed(Duration.zero);
+        },
+        (error, stackTrace) {
+          unhandledErrors.add(error);
+        },
+      );
+
+      expect(unhandledErrors, isEmpty);
     });
   });
 }

--- a/mobile/test/features/creator_analytics/creator_analytics_repository_test.dart
+++ b/mobile/test/features/creator_analytics/creator_analytics_repository_test.dart
@@ -761,5 +761,135 @@ void main() {
 
       expect(unhandledErrors, isEmpty);
     });
+
+    test('absorbs a social Error racing an author video failure', () async {
+      const pubkey = 'pubkey';
+      final api = MockFunnelcakeApiClient();
+      final unhandledErrors = <Object>[];
+
+      when(() => api.isAvailable).thenReturn(true);
+      // The tolerant wrapper only catches Exceptions, so an Error (an
+      // invariant) escapes it and would otherwise surface as an unhandled
+      // async error when the required load aborts first.
+      when(() => api.getSocialCounts(pubkey)).thenAnswer((_) async {
+        await Future<void>.delayed(Duration.zero);
+        throw StateError('social invariant failed');
+      });
+      when(
+        () => api.getVideosByAuthor(
+          pubkey: pubkey,
+          limit: 100,
+          before: any(named: 'before'),
+        ),
+      ).thenThrow(
+        const FunnelcakeApiException(message: 'author failed', statusCode: 500),
+      );
+
+      final repo = FunnelcakeCreatorAnalyticsRepository(api);
+
+      await runZonedGuarded<Future<void>>(
+        () async {
+          await expectLater(
+            repo.fetchCreatorAnalytics(pubkey),
+            throwsA(isA<CreatorAnalyticsLoadException>()),
+          );
+          await Future<void>.delayed(Duration.zero);
+        },
+        (error, stackTrace) {
+          unhandledErrors.add(error);
+        },
+      );
+
+      expect(unhandledErrors, isEmpty);
+    });
+
+    test('keeps earlier bulk-stats chunks when a later chunk fails', () async {
+      const pubkey = 'pubkey';
+      final api = MockFunnelcakeApiClient();
+      var authorCalls = 0;
+
+      when(() => api.isAvailable).thenReturn(true);
+      when(() => api.getSocialCounts(pubkey)).thenAnswer((_) async => null);
+      when(() => api.getVideoViews(any())).thenAnswer((_) async => 12);
+      when(
+        () => api.getBulkVideoStats(any()),
+      ).thenAnswer((invocation) async {
+        final ids = invocation.positionalArguments[0] as List<String>;
+        // Second chunk (the video-100 tail) fails; the first chunk succeeds.
+        if (ids.contains('video-100')) {
+          throw const FunnelcakeApiException(
+            message: 'bulk chunk failed',
+            statusCode: 500,
+          );
+        }
+        return BulkVideoStatsResponse(
+          stats: {
+            for (final id in ids)
+              id: BulkVideoStatsEntry(
+                eventId: id,
+                reactions: 4,
+                comments: 2,
+                reposts: 1,
+                views: 15,
+              ),
+          },
+        );
+      });
+      when(
+        () => api.getVideosByAuthor(
+          pubkey: pubkey,
+          limit: 100,
+          before: any(named: 'before'),
+        ),
+      ).thenAnswer((_) async {
+        final page = authorCalls++;
+        if (page == 0) {
+          return VideosByAuthorResponse(
+            videos: [
+              for (var i = 0; i < 100; i++)
+                _videoStats(
+                  id: 'video-$i',
+                  pubkey: pubkey,
+                  createdAtSeconds: 1739350000 - i,
+                ),
+            ],
+            hasMore: true,
+          );
+        }
+        return VideosByAuthorResponse(
+          videos: [
+            _videoStats(
+              id: 'video-100',
+              pubkey: pubkey,
+              createdAtSeconds: 1739349900,
+            ),
+          ],
+          hasMore: false,
+        );
+      });
+
+      final repo = FunnelcakeCreatorAnalyticsRepository(api);
+      final snapshot = await repo.fetchCreatorAnalytics(pubkey);
+
+      expect(snapshot.diagnostics.totalVideos, 101);
+      // The first chunk's stats survive the second chunk's failure.
+      expect(
+        snapshot.videos
+            .singleWhere((video) => video.id == 'video-0')
+            .rawTags['views'],
+        '15',
+      );
+      expect(snapshot.diagnostics.videosHydratedByBulkStats, 100);
+      expect(snapshot.diagnostics.failedSources, {
+        AnalyticsDataSource.bulkVideoStats,
+      });
+      // video-100 still gets views from the per-video endpoint.
+      expect(
+        snapshot.videos
+            .singleWhere((video) => video.id == 'video-100')
+            .rawTags['views'],
+        '12',
+      );
+    });
   });
 }

--- a/mobile/test/features/creator_analytics/creator_analytics_repository_test.dart
+++ b/mobile/test/features/creator_analytics/creator_analytics_repository_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:funnelcake_api_client/funnelcake_api_client.dart';
@@ -590,6 +591,73 @@ void main() {
       },
     );
 
+    test(
+      'records social counts as used when the endpoint returns null',
+      () async {
+        const pubkey = 'pubkey';
+        final api = MockFunnelcakeApiClient();
+
+        when(() => api.isAvailable).thenReturn(true);
+        when(() => api.getSocialCounts(pubkey)).thenAnswer((_) async => null);
+        when(
+          () => api.getBulkVideoStats(any()),
+        ).thenAnswer((_) async => const BulkVideoStatsResponse(stats: {}));
+        when(() => api.getVideoViews(any())).thenAnswer((_) async => 12);
+        when(
+          () => api.getVideosByAuthor(
+            pubkey: pubkey,
+            limit: 100,
+            before: any(named: 'before'),
+          ),
+        ).thenAnswer(
+          (_) async => VideosByAuthorResponse(
+            videos: [_videoStats(id: 'social-null-video', pubkey: pubkey)],
+          ),
+        );
+
+        final repo = FunnelcakeCreatorAnalyticsRepository(api);
+        final snapshot = await repo.fetchCreatorAnalytics(pubkey);
+
+        expect(
+          snapshot.diagnostics.sourcesUsed,
+          contains(AnalyticsDataSource.socialCounts),
+        );
+        expect(
+          snapshot.diagnostics.failedSources,
+          isNot(contains(AnalyticsDataSource.socialCounts)),
+        );
+      },
+    );
+
+    test('does not tolerate invariant failures from bulk hydration', () async {
+      const pubkey = 'pubkey';
+      final api = MockFunnelcakeApiClient();
+
+      when(() => api.isAvailable).thenReturn(true);
+      when(() => api.getSocialCounts(pubkey)).thenAnswer((_) async => null);
+      when(() => api.getBulkVideoStats(any())).thenThrow(
+        StateError('bulk stats invariant failed'),
+      );
+      when(
+        () => api.getVideosByAuthor(
+          pubkey: pubkey,
+          limit: 100,
+          before: any(named: 'before'),
+        ),
+      ).thenAnswer(
+        (_) async => VideosByAuthorResponse(
+          videos: [_videoStats(id: 'bulk-invariant-video', pubkey: pubkey)],
+        ),
+      );
+
+      final repo = FunnelcakeCreatorAnalyticsRepository(api);
+
+      await expectLater(
+        repo.fetchCreatorAnalytics(pubkey),
+        throwsA(isA<StateError>()),
+      );
+    });
+
     test('rethrows author video failures', () async {
       const pubkey = 'pubkey';
       final api = MockFunnelcakeApiClient();
@@ -610,7 +678,46 @@ void main() {
 
       await expectLater(
         repo.fetchCreatorAnalytics(pubkey),
-        throwsA(isA<FunnelcakeApiException>()),
+        throwsA(
+          isA<CreatorAnalyticsLoadException>().having(
+            (error) => error.kind,
+            'kind',
+            CreatorAnalyticsFailureKind.serverUnavailable,
+          ),
+        ),
+      );
+    });
+
+    test('classifies wrapped DNS failures as connection issues', () async {
+      const pubkey = 'pubkey';
+      final api = MockFunnelcakeApiClient();
+
+      when(() => api.isAvailable).thenReturn(true);
+      when(() => api.getSocialCounts(pubkey)).thenAnswer((_) async => null);
+      when(
+        () => api.getVideosByAuthor(
+          pubkey: pubkey,
+          limit: 100,
+          before: any(named: 'before'),
+        ),
+      ).thenThrow(
+        const FunnelcakeException(
+          'Failed to fetch author videos',
+          cause: SocketException("Failed host lookup: 'api.divine.video'"),
+        ),
+      );
+
+      final repo = FunnelcakeCreatorAnalyticsRepository(api);
+
+      await expectLater(
+        repo.fetchCreatorAnalytics(pubkey),
+        throwsA(
+          isA<CreatorAnalyticsLoadException>().having(
+            (error) => error.kind,
+            'kind',
+            CreatorAnalyticsFailureKind.connectionIssue,
+          ),
+        ),
       );
     });
 
@@ -643,7 +750,7 @@ void main() {
         () async {
           await expectLater(
             repo.fetchCreatorAnalytics(pubkey),
-            throwsA(isA<FunnelcakeApiException>()),
+            throwsA(isA<CreatorAnalyticsLoadException>()),
           );
           await Future<void>.delayed(Duration.zero);
         },

--- a/mobile/test/l10n/arb_consistency_test.dart
+++ b/mobile/test/l10n/arb_consistency_test.dart
@@ -418,11 +418,10 @@ void main() {
 // Keys intentionally allowed to fall back to English until a translation pass.
 // Keep this list small and reviewable so new translation gaps stay visible.
 const _knownUntranslatedDebt = <String>{
-  // Creator analytics resilience copy needs a translation pass outside en.
+  // Translation pass tracked in #7632.
   'analyticsConnectionIssue',
   'analyticsDiagnosticsFailedSources',
   'analyticsServerUnavailable',
-  // People-search video-count copy still needs a translation pass outside en.
   'searchUserVideoCount',
 };
 

--- a/mobile/test/l10n/arb_consistency_test.dart
+++ b/mobile/test/l10n/arb_consistency_test.dart
@@ -418,6 +418,10 @@ void main() {
 // Keys intentionally allowed to fall back to English until a translation pass.
 // Keep this list small and reviewable so new translation gaps stay visible.
 const _knownUntranslatedDebt = <String>{
+  // Creator analytics resilience copy needs a translation pass outside en.
+  'analyticsConnectionIssue',
+  'analyticsDiagnosticsFailedSources',
+  'analyticsServerUnavailable',
   // People-search video-count copy still needs a translation pass outside en.
   'searchUserVideoCount',
 };

--- a/mobile/test/screens/creator_analytics_screen_test.dart
+++ b/mobile/test/screens/creator_analytics_screen_test.dart
@@ -5,6 +5,7 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:funnelcake_api_client/funnelcake_api_client.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/features/creator_analytics/creator_analytics_repository.dart';
@@ -48,6 +49,33 @@ void main() {
         ),
       ),
     );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          authServiceProvider.overrideWithValue(authService),
+          creatorAnalyticsRepositoryProvider.overrideWithValue(repository),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          theme: VineTheme.theme,
+          home: const CreatorAnalyticsScreen(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  Future<void> pumpAnalyticsErrorScreen(
+    WidgetTester tester, {
+    required Object error,
+  }) async {
+    final authService = _MockAuthService();
+    final repository = _MockCreatorAnalyticsRepository();
+
+    when(() => authService.currentPublicKeyHex).thenReturn('a' * 64);
+    when(() => repository.fetchCreatorAnalytics(any())).thenThrow(error);
 
     await tester.pumpWidget(
       ProviderScope(
@@ -183,5 +211,25 @@ void main() {
 
     expect(find.text('Total videos: 1'), findsOneWidget);
     expect(find.text('Sources: bulk-video-stats'), findsOneWidget);
+    expect(find.text('Failed sources: none'), findsOneWidget);
+  });
+
+  testWidgets('maps server errors to localized copy without raw details', (
+    tester,
+  ) async {
+    final l10n = lookupAppLocalizations(const Locale('en'));
+
+    await pumpAnalyticsErrorScreen(
+      tester,
+      error: const FunnelcakeApiException(
+        message: 'Failed to fetch bulk video stats',
+        statusCode: 500,
+        url: 'https://api.divine.video/api/videos/stats/bulk',
+      ),
+    );
+
+    expect(find.text(l10n.analyticsServerUnavailable), findsOneWidget);
+    expect(find.textContaining('FunnelcakeApiException'), findsNothing);
+    expect(find.textContaining('https://api.divine.video'), findsNothing);
   });
 }

--- a/mobile/test/screens/creator_analytics_screen_test.dart
+++ b/mobile/test/screens/creator_analytics_screen_test.dart
@@ -330,6 +330,34 @@ void main() {
     },
   );
 
+  testWidgets(
+    'renders the engagement rate as unavailable when bulk stats fail',
+    (tester) async {
+      final l10n = lookupAppLocalizations(const Locale('en'));
+
+      await pumpAnalyticsScreen(
+        tester,
+        videos: [
+          analyticsVideo(
+            id: 'engagement-rate-video',
+            views: 120,
+            nostrLikeCount: 19,
+            nostrCommentCount: 7,
+            nostrRepostCount: 1,
+          ),
+        ],
+        failedSources: const {AnalyticsDataSource.bulkVideoStats},
+      );
+
+      // Seed counts survive a bulk-stats failure, so the rate is computable
+      // (27/120). Bulk stats are authoritative, so the KPI must read N/A like
+      // every other engagement surface, not a confident percentage beside an
+      // "Interactions: N/A" card.
+      expect(find.textContaining('%'), findsNothing);
+      expect(find.text(l10n.analyticsNa), findsWidgets);
+    },
+  );
+
   testWidgets('renders non-empty failed sources diagnostics', (tester) async {
     final l10n = lookupAppLocalizations(const Locale('en'));
 

--- a/mobile/test/screens/creator_analytics_screen_test.dart
+++ b/mobile/test/screens/creator_analytics_screen_test.dart
@@ -362,6 +362,53 @@ void main() {
     },
   );
 
+  testWidgets(
+    'ranks top content by views, not hidden likes, when bulk stats fail',
+    (tester) async {
+      tester.view.physicalSize = const Size(900, 3000);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      final now = DateTime.now();
+      final older = now.subtract(const Duration(days: 2));
+
+      await pumpAnalyticsScreen(
+        tester,
+        videos: [
+          VideoEvent(
+            id: 'high-likes-older',
+            pubkey: 'a' * 64,
+            createdAt: older.millisecondsSinceEpoch ~/ 1000,
+            content: 'older high likes',
+            timestamp: older,
+            title: 'Older High Likes',
+            rawTags: const {'views': '120'},
+            nostrLikeCount: 50,
+          ),
+          VideoEvent(
+            id: 'low-likes-newer',
+            pubkey: 'a' * 64,
+            createdAt: now.millisecondsSinceEpoch ~/ 1000,
+            content: 'newer low likes',
+            timestamp: now,
+            title: 'Newer Low Likes',
+            rawTags: const {'views': '120'},
+            nostrLikeCount: 1,
+          ),
+        ],
+        failedSources: const {AnalyticsDataSource.bulkVideoStats},
+      );
+
+      // Same views, so recency (not the hidden 50-vs-1 likes) decides order.
+      // The newer title also appears in the most-viewed highlight; the last
+      // match is the top-content row.
+      final newerTop = tester.getTopLeft(find.text('Newer Low Likes').last).dy;
+      final olderTop = tester.getTopLeft(find.text('Older High Likes')).dy;
+      expect(newerTop, lessThan(olderTop));
+    },
+  );
+
   testWidgets('renders non-empty failed sources diagnostics', (tester) async {
     final l10n = lookupAppLocalizations(const Locale('en'));
 

--- a/mobile/test/screens/creator_analytics_screen_test.dart
+++ b/mobile/test/screens/creator_analytics_screen_test.dart
@@ -220,6 +220,8 @@ void main() {
   });
 
   testWidgets('toggles diagnostics from the app bar action', (tester) async {
+    final l10n = lookupAppLocalizations(const Locale('en'));
+
     await pumpAnalyticsScreen(
       tester,
       videos: [
@@ -233,14 +235,16 @@ void main() {
       ],
     );
 
-    expect(find.text('Total videos: 1'), findsNothing);
+    expect(find.text(l10n.analyticsDiagnosticsTotalVideos(1)), findsNothing);
 
     await tester.tap(find.bySemanticsLabel('Toggle diagnostics'));
     await tester.pumpAndSettle();
 
-    expect(find.text('Total videos: 1'), findsOneWidget);
-    expect(find.text('Sources: bulk-video-stats'), findsOneWidget);
-    final l10n = lookupAppLocalizations(const Locale('en'));
+    expect(find.text(l10n.analyticsDiagnosticsTotalVideos(1)), findsOneWidget);
+    expect(
+      find.text(l10n.analyticsDiagnosticsSources('bulk-video-stats')),
+      findsOneWidget,
+    );
     expect(
       find.text(l10n.analyticsDiagnosticsFailedSources('none')),
       findsOneWidget,

--- a/mobile/test/screens/creator_analytics_screen_test.dart
+++ b/mobile/test/screens/creator_analytics_screen_test.dart
@@ -5,7 +5,6 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:funnelcake_api_client/funnelcake_api_client.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/features/creator_analytics/creator_analytics_repository.dart';
@@ -24,6 +23,9 @@ void main() {
   Future<void> pumpAnalyticsScreen(
     WidgetTester tester, {
     required List<VideoEvent> videos,
+    SocialCounts? socialCounts,
+    bool hasSocialCounts = true,
+    Set<AnalyticsDataSource> failedSources = const {},
   }) async {
     final authService = _MockAuthService();
     final repository = _MockCreatorAnalyticsRepository();
@@ -33,11 +35,14 @@ void main() {
     when(() => repository.fetchCreatorAnalytics(any())).thenAnswer(
       (_) async => CreatorAnalyticsSnapshot(
         videos: videos,
-        socialCounts: SocialCounts(
-          pubkey: 'a' * 64,
-          followerCount: 10,
-          followingCount: 2,
-        ),
+        socialCounts: hasSocialCounts
+            ? socialCounts ??
+                  SocialCounts(
+                    pubkey: 'a' * 64,
+                    followerCount: 10,
+                    followingCount: 2,
+                  )
+            : null,
         diagnostics: CreatorAnalyticsDiagnostics(
           totalVideos: videos.length,
           videosWithAnyViews: videos.length,
@@ -45,10 +50,34 @@ void main() {
           videosHydratedByBulkStats: 1,
           videosHydratedByViewsEndpoint: 0,
           sourcesUsed: const {AnalyticsDataSource.bulkVideoStats},
+          failedSources: failedSources,
           fetchedAt: now,
         ),
       ),
     );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          authServiceProvider.overrideWithValue(authService),
+          creatorAnalyticsRepositoryProvider.overrideWithValue(repository),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          theme: VineTheme.theme,
+          home: const CreatorAnalyticsScreen(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  Future<void> pumpAnalyticsSignedOutScreen(WidgetTester tester) async {
+    final authService = _MockAuthService();
+    final repository = _MockCreatorAnalyticsRepository();
+
+    when(() => authService.currentPublicKeyHex).thenReturn(null);
 
     await tester.pumpWidget(
       ProviderScope(
@@ -211,7 +240,11 @@ void main() {
 
     expect(find.text('Total videos: 1'), findsOneWidget);
     expect(find.text('Sources: bulk-video-stats'), findsOneWidget);
-    expect(find.text('Failed sources: none'), findsOneWidget);
+    final l10n = lookupAppLocalizations(const Locale('en'));
+    expect(
+      find.text(l10n.analyticsDiagnosticsFailedSources('none')),
+      findsOneWidget,
+    );
   });
 
   testWidgets('maps server errors to localized copy without raw details', (
@@ -221,15 +254,106 @@ void main() {
 
     await pumpAnalyticsErrorScreen(
       tester,
-      error: const FunnelcakeApiException(
-        message: 'Failed to fetch bulk video stats',
-        statusCode: 500,
-        url: 'https://api.divine.video/api/videos/stats/bulk',
+      error: const CreatorAnalyticsLoadException(
+        CreatorAnalyticsFailureKind.serverUnavailable,
+        cause: 'raw server detail',
       ),
     );
 
     expect(find.text(l10n.analyticsServerUnavailable), findsOneWidget);
-    expect(find.textContaining('FunnelcakeApiException'), findsNothing);
-    expect(find.textContaining('https://api.divine.video'), findsNothing);
+    expect(find.textContaining('raw server detail'), findsNothing);
+  });
+
+  testWidgets('maps connection errors to localized copy', (tester) async {
+    final l10n = lookupAppLocalizations(const Locale('en'));
+
+    await pumpAnalyticsErrorScreen(
+      tester,
+      error: const CreatorAnalyticsLoadException(
+        CreatorAnalyticsFailureKind.connectionIssue,
+      ),
+    );
+
+    expect(find.text(l10n.analyticsConnectionIssue), findsOneWidget);
+  });
+
+  testWidgets('shows sign-in copy when no user is authenticated', (
+    tester,
+  ) async {
+    final l10n = lookupAppLocalizations(const Locale('en'));
+
+    await pumpAnalyticsSignedOutScreen(tester);
+
+    expect(find.text(l10n.analyticsSignInRequired), findsOneWidget);
+  });
+
+  testWidgets('renders failed social counts as unavailable', (tester) async {
+    final l10n = lookupAppLocalizations(const Locale('en'));
+
+    await pumpAnalyticsScreen(
+      tester,
+      videos: [
+        analyticsVideo(
+          id: 'social-failed-video',
+          views: 120,
+          nostrLikeCount: 19,
+          nostrCommentCount: 7,
+          nostrRepostCount: 1,
+        ),
+      ],
+      hasSocialCounts: false,
+      failedSources: const {AnalyticsDataSource.socialCounts},
+    );
+
+    expect(find.text(l10n.analyticsNa), findsWidgets);
+    expect(find.text(l10n.analyticsFollowersCount('0')), findsNothing);
+    expect(find.text(l10n.analyticsFollowingCount('0')), findsNothing);
+  });
+
+  testWidgets(
+    'does not claim engagement metrics are accurate when stats fail',
+    (
+      tester,
+    ) async {
+      final l10n = lookupAppLocalizations(const Locale('en'));
+
+      await pumpAnalyticsScreen(
+        tester,
+        videos: [
+          analyticsVideo(id: 'bulk-failed-video', views: 0),
+        ],
+        failedSources: const {AnalyticsDataSource.bulkVideoStats},
+      );
+
+      expect(find.text(l10n.analyticsViewDataUnavailable), findsNothing);
+      expect(find.text(l10n.analyticsNa), findsWidgets);
+    },
+  );
+
+  testWidgets('renders non-empty failed sources diagnostics', (tester) async {
+    final l10n = lookupAppLocalizations(const Locale('en'));
+
+    await pumpAnalyticsScreen(
+      tester,
+      videos: [
+        analyticsVideo(id: 'diagnostics-failure-video', views: 120),
+      ],
+      failedSources: const {
+        AnalyticsDataSource.bulkVideoStats,
+        AnalyticsDataSource.socialCounts,
+      },
+    );
+
+    await tester.tap(find.bySemanticsLabel('Toggle diagnostics'));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.text(
+        l10n.analyticsDiagnosticsFailedSources(
+          'bulk-video-stats, social-counts',
+        ),
+      ),
+      findsOneWidget,
+    );
   });
 }


### PR DESCRIPTION
## Description

Creator Analytics now treats bulk stats, per-video views, and social counts as optional enrichment so one failing stats endpoint does not collapse the whole dashboard when author videos still load. This is a mobile-side resilience and UX cleanup: the reported incident was likely caused by the Funnelcake read-layer outage, and this PR does not remediate that backend failure.

**Related Issue:** Relates to #7603

## Out of Scope

Backend read-layer outage remediation. If the required author-videos endpoint is down, Creator Analytics still cannot populate the dashboard; this PR only improves partial-failure behavior and user-facing error copy.

## Verification

- `flutter test test/features/creator_analytics/creator_analytics_repository_test.dart test/screens/creator_analytics_screen_test.dart test/l10n/arb_consistency_test.dart`
- `flutter analyze lib/features/creator_analytics/creator_analytics_repository.dart lib/screens/creator_analytics_screen.dart test/features/creator_analytics/creator_analytics_repository_test.dart test/screens/creator_analytics_screen_test.dart test/l10n/arb_consistency_test.dart`
- Pre-push hook: locale consistency, analyzer, and changed-file tests passed
- GitHub CI passed on PR #7615

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore