### PR TITLE
fix(feed-tuning): stop macOS edge back-swipe from tuning

### DIFF
--- a/mobile/lib/widgets/feed_tuning/feed_tuning_swipe_overlay.dart
+++ b/mobile/lib/widgets/feed_tuning/feed_tuning_swipe_overlay.dart
@@ -143,26 +143,16 @@ class _FeedTuningSwipeOverlayState extends State<FeedTuningSwipeOverlay> {
     final committed =
         _dragIntent == _DragIntent.horizontal &&
         _passedThreshold &&
-        direction != null &&
-        _isRouteAnimationComplete();
+        direction != null;
     _reset();
     if (committed) widget.onTuned(direction);
   }
 
-  /// Returns true if the enclosing route is fully visible.
-  ///
-  /// Prevents tuning commits while the route is animating (e.g., during
-  /// iOS back-gesture dismissal or page transitions). A route that is not
-  /// animating or has no animation returns true.
-  bool _isRouteAnimationComplete() {
-    final route = ModalRoute.of(context);
-    final animation = route?.animation;
-    if (animation == null) return true;
-    return animation.status == AnimationStatus.completed;
-  }
-
   bool _isPlatformBackGestureStart(Offset globalPosition) {
-    if (Theme.of(context).platform != TargetPlatform.iOS) return false;
+    final platform = Theme.of(context).platform;
+    if (platform != TargetPlatform.iOS && platform != TargetPlatform.macOS) {
+      return false;
+    }
 
     final route = ModalRoute.of(context);
     if (route is! PageRoute<dynamic> || !route.popGestureEnabled) return false;

--- a/mobile/lib/widgets/feed_tuning/feed_tuning_swipe_overlay.dart
+++ b/mobile/lib/widgets/feed_tuning/feed_tuning_swipe_overlay.dart
@@ -143,9 +143,22 @@ class _FeedTuningSwipeOverlayState extends State<FeedTuningSwipeOverlay> {
     final committed =
         _dragIntent == _DragIntent.horizontal &&
         _passedThreshold &&
-        direction != null;
+        direction != null &&
+        _isRouteAnimationComplete();
     _reset();
     if (committed) widget.onTuned(direction);
+  }
+
+  /// Returns true if the enclosing route is fully visible.
+  ///
+  /// Prevents tuning commits while the route is animating (e.g., during
+  /// iOS back-gesture dismissal or page transitions). A route that is not
+  /// animating or has no animation returns true.
+  bool _isRouteAnimationComplete() {
+    final route = ModalRoute.of(context);
+    final animation = route?.animation;
+    if (animation == null) return true;
+    return animation.status == AnimationStatus.completed;
   }
 
   bool _isPlatformBackGestureStart(Offset globalPosition) {

--- a/mobile/test/widgets/feed_tuning/feed_tuning_swipe_overlay_test.dart
+++ b/mobile/test/widgets/feed_tuning/feed_tuning_swipe_overlay_test.dart
@@ -165,6 +165,17 @@ void main() {
       );
       handle.dispose();
     });
+    testWidgets(
+      'route animation guard prevents tuning',
+      (tester) async {
+        // The _isRouteAnimationComplete() guard prevents commits when
+        // ModalRoute.animation.status != completed (e.g. during route
+        // transitions). Existing tests already cover back-gesture + tuning
+        // scenarios via pumpPushedOverlay, which exercises the real
+        // Navigator animation lifecycle. No additional test needed.
+        expect(true, isTrue);
+      },
+    );
   });
 
   group('platform back gesture', () {

--- a/mobile/test/widgets/feed_tuning/feed_tuning_swipe_overlay_test.dart
+++ b/mobile/test/widgets/feed_tuning/feed_tuning_swipe_overlay_test.dart
@@ -165,17 +165,6 @@ void main() {
       );
       handle.dispose();
     });
-    testWidgets(
-      'route animation guard prevents tuning',
-      (tester) async {
-        // The _isRouteAnimationComplete() guard prevents commits when
-        // ModalRoute.animation.status != completed (e.g. during route
-        // transitions). Existing tests already cover back-gesture + tuning
-        // scenarios via pumpPushedOverlay, which exercises the real
-        // Navigator animation lifecycle. No additional test needed.
-        expect(true, isTrue);
-      },
-    );
   });
 
   group('platform back gesture', () {
@@ -221,6 +210,21 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(tuned, [FeedTuningDirection.more]);
+    });
+
+    testWidgets('macOS pushed route edge swipe pops without tuning', (
+      tester,
+    ) async {
+      final tuned = await pumpPushedOverlay(
+        tester,
+        platform: TargetPlatform.macOS,
+      );
+
+      await tester.dragFrom(const Offset(5, 300), const Offset(500, 0));
+      await tester.pumpAndSettle();
+
+      expect(tuned, isEmpty);
+      expect(find.text('home'), findsOneWidget);
     });
 
     testWidgets('non-iOS pushed route edge swipe can still tune', (

--- a/mobile/test/widgets/feed_tuning/feed_tuning_swipe_overlay_test.dart
+++ b/mobile/test/widgets/feed_tuning/feed_tuning_swipe_overlay_test.dart
@@ -227,7 +227,7 @@ void main() {
       expect(find.text('home'), findsOneWidget);
     });
 
-    testWidgets('non-iOS pushed route edge swipe can still tune', (
+    testWidgets('Android pushed route edge swipe can still tune', (
       tester,
     ) async {
       final tuned = await pumpPushedOverlay(


### PR DESCRIPTION
## Summary

Closes #7628: a leading-edge back swipe on a pushed fullscreen feed route no longer commits a Feed Tuning Swipe action on macOS or Divine web running in a Mac browser.

## Changes

- Treat macOS like iOS in the platform back-gesture strip guard, matching Flutter's Cupertino page transition behavior for both platforms.
- Remove the route-animation guard because it was broader than this bug and did not cover every tuning input path.
- Replace the tautological route-animation test with a macOS pushed-route regression test that fails without the macOS guard.

## Test Plan

- `cd mobile && flutter test test/widgets/feed_tuning/feed_tuning_swipe_overlay_test.dart`
- `cd mobile && flutter analyze`
- Verified the new macOS regression test fails when the macOS guard is removed.
