### PR TITLE
fix(bookmarks): tell the Saved tab's empty state from a failed load

### DIFF
--- a/mobile/lib/blocs/profile_liked_videos/profile_liked_videos_state.dart
+++ b/mobile/lib/blocs/profile_liked_videos/profile_liked_videos_state.dart
@@ -79,6 +79,15 @@ final class ProfileLikedVideosState extends Equatable {
   /// due to relay unavailability or unsupported format filtering).
   final int nextPageOffset;
 
+  /// Whether the profile has likes that none of the fetches resolved.
+  ///
+  /// `videos.isEmpty` on its own conflates "nothing liked" with "we could not
+  /// load them", and only [likedEventIds] separates the two. The distinction
+  /// cannot be recovered further down: `getVideosByIds` returns an empty list
+  /// for a relay that never answered as readily as for an event that does not
+  /// exist.
+  bool get hasUnresolvedLikes => videos.isEmpty && likedEventIds.isNotEmpty;
+
   /// Whether data has been successfully loaded
   bool get isLoaded => status == ProfileLikedVideosStatus.success;
 

--- a/mobile/lib/blocs/profile_liked_videos/profile_liked_videos_state.dart
+++ b/mobile/lib/blocs/profile_liked_videos/profile_liked_videos_state.dart
@@ -79,15 +79,6 @@ final class ProfileLikedVideosState extends Equatable {
   /// due to relay unavailability or unsupported format filtering).
   final int nextPageOffset;
 
-  /// Whether the profile has likes that none of the fetches resolved.
-  ///
-  /// `videos.isEmpty` on its own conflates "nothing liked" with "we could not
-  /// load them", and only [likedEventIds] separates the two. The distinction
-  /// cannot be recovered further down: `getVideosByIds` returns an empty list
-  /// for a relay that never answered as readily as for an event that does not
-  /// exist.
-  bool get hasUnresolvedLikes => videos.isEmpty && likedEventIds.isNotEmpty;
-
   /// Whether data has been successfully loaded
   bool get isLoaded => status == ProfileLikedVideosStatus.success;
 

--- a/mobile/lib/blocs/profile_reposted_videos/profile_reposted_videos_bloc.dart
+++ b/mobile/lib/blocs/profile_reposted_videos/profile_reposted_videos_bloc.dart
@@ -217,7 +217,8 @@ class ProfileRepostedVideosBloc
     final firstPageIds = addressableIds
         .take(ProfileTabPagination.pageSize)
         .toList();
-    final videos = await _fetchVideos(firstPageIds, cacheResults: true);
+    final fetchResult = await _fetchVideos(firstPageIds, cacheResults: true);
+    final videos = fetchResult.videos;
     if (isClosed) return;
 
     final snapshot = ProfileVideoListSnapshot(
@@ -234,6 +235,9 @@ class ProfileRepostedVideosBloc
         nextPageOffset: snapshot.nextPageOffset,
         hasMoreContent: snapshot.hasMoreContent,
         isRefreshing: false,
+        lastFetchResolvedVideoCount: videos.isEmpty
+            ? fetchResult.resolvedVideoCount
+            : null,
         clearError: true,
       ),
     );
@@ -269,6 +273,7 @@ class ProfileRepostedVideosBloc
         nextPageOffset: reconciled.nextPageOffset,
         hasMoreContent: reconciled.hasMoreContent,
         isRefreshing: false,
+        lastFetchResolvedVideoCount: reconciled.resolvedVideoCount,
         clearError: true,
       ),
     );
@@ -285,7 +290,14 @@ class ProfileRepostedVideosBloc
   /// Reconciles displayed videos against a fresh [freshIds] list: keeps reposts
   /// still present, drops the rest, and fetches only the newly-reposted IDs in
   /// the loaded window. Bounded so it never bulk-fetches.
-  Future<({List<VideoEvent> videos, int nextPageOffset, bool hasMoreContent})>
+  Future<
+    ({
+      List<VideoEvent> videos,
+      int nextPageOffset,
+      bool hasMoreContent,
+      int resolvedVideoCount,
+    })
+  >
   _reconcile(List<String> freshIds) async {
     final byId = <String, VideoEvent>{};
     for (final video in state.videos) {
@@ -293,6 +305,7 @@ class ProfileRepostedVideosBloc
       final id = _computeAddressableId(video);
       if (id != null) byId[id] = video;
     }
+    var resolvedVideoCount = byId.length;
     // Anchor on the previous top ID rather than a length delta, so a capped
     // persisted ID list can't balloon the reconcile window into a full
     // re-fetch on reopen (see ProfileLikedVideosBloc for the rationale).
@@ -309,7 +322,9 @@ class ProfileRepostedVideosBloc
 
     final missingIds = windowIds.where((id) => !byId.containsKey(id)).toList();
     if (missingIds.isNotEmpty) {
-      for (final video in await _fetchVideos(missingIds, cacheResults: true)) {
+      final fetchResult = await _fetchVideos(missingIds, cacheResults: true);
+      resolvedVideoCount += fetchResult.resolvedVideoCount;
+      for (final video in fetchResult.videos) {
         final id = _computeAddressableId(video);
         if (id != null) byId[id] = video;
       }
@@ -323,6 +338,7 @@ class ProfileRepostedVideosBloc
       videos: videos,
       nextPageOffset: windowIds.length,
       hasMoreContent: windowIds.length < freshIds.length,
+      resolvedVideoCount: videos.isEmpty ? resolvedVideoCount : 0,
     );
   }
 
@@ -496,6 +512,7 @@ class ProfileRepostedVideosBloc
           repostedAddressableIds: freshIds,
           nextPageOffset: reconciled.nextPageOffset,
           hasMoreContent: reconciled.hasMoreContent,
+          lastFetchResolvedVideoCount: reconciled.resolvedVideoCount,
           clearError: true,
         ),
       );
@@ -544,7 +561,8 @@ class ProfileRepostedVideosBloc
           .skip(offset)
           .take(ProfileTabPagination.pageSize)
           .toList();
-      final newVideos = await _fetchVideos(nextPageIds, cacheResults: true);
+      final fetchResult = await _fetchVideos(nextPageIds, cacheResults: true);
+      final newVideos = fetchResult.videos;
 
       final existingIds = state.videos
           .map(_computeAddressableId)
@@ -643,11 +661,13 @@ class ProfileRepostedVideosBloc
   /// Returns videos in the same order as [addressableIds], excluding:
   /// - Videos not found in cache or relay
   /// - Unsupported video formats (WebM on iOS/macOS)
-  Future<List<VideoEvent>> _fetchVideos(
+  Future<({List<VideoEvent> videos, int resolvedVideoCount})> _fetchVideos(
     List<String> addressableIds, {
     bool cacheResults = false,
   }) async {
-    if (addressableIds.isEmpty) return [];
+    if (addressableIds.isEmpty) {
+      return (videos: <VideoEvent>[], resolvedVideoCount: 0);
+    }
 
     // VideosRepository handles relay + Funnelcake fallback internally
     final videos = await _videosRepository.getVideosByAddressableIds(
@@ -662,8 +682,10 @@ class ProfileRepostedVideosBloc
       category: LogCategory.video,
     );
 
-    // Filter unsupported formats
-    return videos.where((v) => v.isSupportedOnCurrentPlatform).toList();
+    return (
+      videos: videos.where((v) => v.isSupportedOnCurrentPlatform).toList(),
+      resolvedVideoCount: videos.length,
+    );
   }
 
   /// Compute the addressable ID for a video event.

--- a/mobile/lib/blocs/profile_reposted_videos/profile_reposted_videos_bloc.dart
+++ b/mobile/lib/blocs/profile_reposted_videos/profile_reposted_videos_bloc.dart
@@ -305,7 +305,6 @@ class ProfileRepostedVideosBloc
       final id = _computeAddressableId(video);
       if (id != null) byId[id] = video;
     }
-    var resolvedVideoCount = byId.length;
     // Anchor on the previous top ID rather than a length delta, so a capped
     // persisted ID list can't balloon the reconcile window into a full
     // re-fetch on reopen (see ProfileLikedVideosBloc for the rationale).
@@ -321,9 +320,14 @@ class ProfileRepostedVideosBloc
     final windowIds = freshIds.take(windowSize).toList();
 
     final missingIds = windowIds.where((id) => !byId.containsKey(id)).toList();
+    // Counts this window's fetch only. A video carried over in [byId] but
+    // absent from [windowIds] is no longer reposted, so it is no evidence
+    // that the window resolved — seeding the count with it would send an
+    // all-unresolved window back to the empty state this fix exists to avoid.
+    var resolvedVideoCount = 0;
     if (missingIds.isNotEmpty) {
       final fetchResult = await _fetchVideos(missingIds, cacheResults: true);
-      resolvedVideoCount += fetchResult.resolvedVideoCount;
+      resolvedVideoCount = fetchResult.resolvedVideoCount;
       for (final video in fetchResult.videos) {
         final id = _computeAddressableId(video);
         if (id != null) byId[id] = video;

--- a/mobile/lib/blocs/profile_reposted_videos/profile_reposted_videos_bloc.dart
+++ b/mobile/lib/blocs/profile_reposted_videos/profile_reposted_videos_bloc.dart
@@ -583,6 +583,13 @@ class ProfileRepostedVideosBloc
           isLoadingMore: false,
           hasMoreContent: hasMore,
           nextPageOffset: newOffset,
+          // The page just fetched is now the evidence behind an empty list,
+          // so it has to replace the earlier page's count. Without this a
+          // first page that resolved nothing keeps asserting failure even
+          // after a later page resolved videos that were filtered out here.
+          lastFetchResolvedVideoCount: allVideos.isEmpty
+              ? fetchResult.resolvedVideoCount
+              : null,
         ),
       );
       await _persistSnapshot(

--- a/mobile/lib/blocs/profile_reposted_videos/profile_reposted_videos_state.dart
+++ b/mobile/lib/blocs/profile_reposted_videos/profile_reposted_videos_state.dart
@@ -77,6 +77,16 @@ final class ProfileRepostedVideosState extends Equatable {
   /// Offset into [repostedAddressableIds] for the next page fetch.
   final int nextPageOffset;
 
+  /// Whether the profile has reposts that none of the fetches resolved.
+  ///
+  /// `videos.isEmpty` on its own conflates "nothing reposted" with "we could
+  /// not load them", and only [repostedAddressableIds] separates the two. The
+  /// distinction cannot be recovered further down: the repository returns an
+  /// empty list for a relay that never answered as readily as for a
+  /// coordinate that resolves to nothing.
+  bool get hasUnresolvedReposts =>
+      videos.isEmpty && repostedAddressableIds.isNotEmpty;
+
   /// Whether data has been successfully loaded
   bool get isLoaded => status == ProfileRepostedVideosStatus.success;
 

--- a/mobile/lib/blocs/profile_reposted_videos/profile_reposted_videos_state.dart
+++ b/mobile/lib/blocs/profile_reposted_videos/profile_reposted_videos_state.dart
@@ -49,6 +49,7 @@ final class ProfileRepostedVideosState extends Equatable {
     this.isRefreshing = false,
     this.hasMoreContent = true,
     this.nextPageOffset = 0,
+    this.lastFetchResolvedVideoCount = 0,
   });
 
   /// The current loading status
@@ -77,15 +78,20 @@ final class ProfileRepostedVideosState extends Equatable {
   /// Offset into [repostedAddressableIds] for the next page fetch.
   final int nextPageOffset;
 
-  /// Whether the profile has reposts that none of the fetches resolved.
+  /// Number of videos returned by the repository before platform filtering in
+  /// the last fetch that produced the current empty rendered list.
+  final int lastFetchResolvedVideoCount;
+
+  /// Whether the profile has reposts that the repository did not resolve.
   ///
   /// `videos.isEmpty` on its own conflates "nothing reposted" with "we could
-  /// not load them", and only [repostedAddressableIds] separates the two. The
-  /// distinction cannot be recovered further down: the repository returns an
-  /// empty list for a relay that never answered as readily as for a
-  /// coordinate that resolves to nothing.
+  /// not load them", and only [repostedAddressableIds] separates the two. This
+  /// is deliberately gated on the pre-filter resolve count: an unsupported
+  /// video format can leave the rendered list empty after a successful fetch.
   bool get hasUnresolvedReposts =>
-      videos.isEmpty && repostedAddressableIds.isNotEmpty;
+      videos.isEmpty &&
+      repostedAddressableIds.isNotEmpty &&
+      lastFetchResolvedVideoCount == 0;
 
   /// Whether data has been successfully loaded
   bool get isLoaded => status == ProfileRepostedVideosStatus.success;
@@ -106,6 +112,7 @@ final class ProfileRepostedVideosState extends Equatable {
     bool? isRefreshing,
     bool? hasMoreContent,
     int? nextPageOffset,
+    int? lastFetchResolvedVideoCount,
   }) {
     return ProfileRepostedVideosState(
       status: status ?? this.status,
@@ -117,6 +124,8 @@ final class ProfileRepostedVideosState extends Equatable {
       isRefreshing: isRefreshing ?? this.isRefreshing,
       hasMoreContent: hasMoreContent ?? this.hasMoreContent,
       nextPageOffset: nextPageOffset ?? this.nextPageOffset,
+      lastFetchResolvedVideoCount:
+          lastFetchResolvedVideoCount ?? this.lastFetchResolvedVideoCount,
     );
   }
 
@@ -130,5 +139,6 @@ final class ProfileRepostedVideosState extends Equatable {
     isRefreshing,
     hasMoreContent,
     nextPageOffset,
+    lastFetchResolvedVideoCount,
   ];
 }

--- a/mobile/lib/blocs/profile_saved_videos/profile_saved_videos_bloc.dart
+++ b/mobile/lib/blocs/profile_saved_videos/profile_saved_videos_bloc.dart
@@ -467,6 +467,13 @@ class ProfileSavedVideosBloc
           isLoadingMore: false,
           hasMoreContent: hasMore,
           nextPageOffset: newOffset,
+          // The page just fetched is now the evidence behind an empty list,
+          // so it has to replace the earlier page's count. Without this a
+          // first page that resolved nothing keeps asserting failure even
+          // after a later page resolved videos that were filtered out here.
+          lastFetchResolvedVideoCount: allVideos.isEmpty
+              ? fetchResult.resolvedVideoCount
+              : null,
         ),
       );
       await _persistSnapshot(

--- a/mobile/lib/blocs/profile_saved_videos/profile_saved_videos_bloc.dart
+++ b/mobile/lib/blocs/profile_saved_videos/profile_saved_videos_bloc.dart
@@ -279,7 +279,6 @@ class ProfileSavedVideosBloc
       for (final video in state.videos)
         if (!_deletedVideoFilter(video)) video.id: video,
     };
-    var resolvedVideoCount = byId.length;
     // Anchor on the previous top ID rather than a length delta, so a capped
     // persisted ID list can't balloon the reconcile window into a full
     // re-fetch on reopen (see ProfileLikedVideosBloc for the rationale).
@@ -295,9 +294,14 @@ class ProfileSavedVideosBloc
     final windowIds = freshIds.take(windowSize).toList();
 
     final missingIds = windowIds.where((id) => !byId.containsKey(id)).toList();
+    // Counts this window's fetch only. A video carried over in [byId] but
+    // absent from [windowIds] is no longer saved, so it is no evidence that
+    // the window resolved — seeding the count with it would send an
+    // all-unresolved window back to the empty state this fix exists to avoid.
+    var resolvedVideoCount = 0;
     if (missingIds.isNotEmpty) {
       final fetchResult = await _fetchVideos(missingIds, cacheResults: true);
-      resolvedVideoCount += fetchResult.resolvedVideoCount;
+      resolvedVideoCount = fetchResult.resolvedVideoCount;
       for (final video in fetchResult.videos) {
         byId[video.id] = video;
       }

--- a/mobile/lib/blocs/profile_saved_videos/profile_saved_videos_bloc.dart
+++ b/mobile/lib/blocs/profile_saved_videos/profile_saved_videos_bloc.dart
@@ -199,7 +199,8 @@ class ProfileSavedVideosBloc
     final firstPageIds = savedEventIds
         .take(ProfileTabPagination.pageSize)
         .toList();
-    final videos = await _fetchVideos(firstPageIds, cacheResults: true);
+    final fetchResult = await _fetchVideos(firstPageIds, cacheResults: true);
+    final videos = fetchResult.videos;
     if (isClosed) return;
 
     final snapshot = ProfileVideoListSnapshot(
@@ -216,6 +217,9 @@ class ProfileSavedVideosBloc
         nextPageOffset: snapshot.nextPageOffset,
         hasMoreContent: snapshot.hasMoreContent,
         isRefreshing: false,
+        lastFetchResolvedVideoCount: videos.isEmpty
+            ? fetchResult.resolvedVideoCount
+            : null,
         clearError: true,
       ),
     );
@@ -245,6 +249,7 @@ class ProfileSavedVideosBloc
         nextPageOffset: reconciled.nextPageOffset,
         hasMoreContent: reconciled.hasMoreContent,
         isRefreshing: false,
+        lastFetchResolvedVideoCount: reconciled.resolvedVideoCount,
         clearError: true,
       ),
     );
@@ -261,12 +266,20 @@ class ProfileSavedVideosBloc
   /// Reconciles displayed videos against a fresh [freshIds] list: keeps saved
   /// videos still present, drops the rest, and fetches only the newly-saved
   /// IDs in the loaded window. Bounded so it never bulk-fetches.
-  Future<({List<VideoEvent> videos, int nextPageOffset, bool hasMoreContent})>
+  Future<
+    ({
+      List<VideoEvent> videos,
+      int nextPageOffset,
+      bool hasMoreContent,
+      int resolvedVideoCount,
+    })
+  >
   _reconcile(List<String> freshIds) async {
     final byId = {
       for (final video in state.videos)
         if (!_deletedVideoFilter(video)) video.id: video,
     };
+    var resolvedVideoCount = byId.length;
     // Anchor on the previous top ID rather than a length delta, so a capped
     // persisted ID list can't balloon the reconcile window into a full
     // re-fetch on reopen (see ProfileLikedVideosBloc for the rationale).
@@ -283,7 +296,9 @@ class ProfileSavedVideosBloc
 
     final missingIds = windowIds.where((id) => !byId.containsKey(id)).toList();
     if (missingIds.isNotEmpty) {
-      for (final video in await _fetchVideos(missingIds, cacheResults: true)) {
+      final fetchResult = await _fetchVideos(missingIds, cacheResults: true);
+      resolvedVideoCount += fetchResult.resolvedVideoCount;
+      for (final video in fetchResult.videos) {
         byId[video.id] = video;
       }
     }
@@ -296,6 +311,7 @@ class ProfileSavedVideosBloc
       videos: videos,
       nextPageOffset: windowIds.length,
       hasMoreContent: windowIds.length < freshIds.length,
+      resolvedVideoCount: videos.isEmpty ? resolvedVideoCount : 0,
     );
   }
 
@@ -427,7 +443,8 @@ class ProfileSavedVideosBloc
           .skip(offset)
           .take(ProfileTabPagination.pageSize)
           .toList();
-      final newVideos = await _fetchVideos(nextPageIds, cacheResults: true);
+      final fetchResult = await _fetchVideos(nextPageIds, cacheResults: true);
+      final newVideos = fetchResult.videos;
 
       Log.info(
         'ProfileSavedVideosBloc: Loaded ${newVideos.length} more videos',
@@ -524,11 +541,13 @@ class ProfileSavedVideosBloc
   /// Returns videos in the same order as [eventIds], excluding videos not
   /// found in cache or relay and videos whose format is unsupported on the
   /// current platform.
-  Future<List<VideoEvent>> _fetchVideos(
+  Future<({List<VideoEvent> videos, int resolvedVideoCount})> _fetchVideos(
     List<String> eventIds, {
     bool cacheResults = false,
   }) async {
-    if (eventIds.isEmpty) return [];
+    if (eventIds.isEmpty) {
+      return (videos: <VideoEvent>[], resolvedVideoCount: 0);
+    }
 
     final videos = await _videosRepository.getVideosByIds(
       eventIds,
@@ -542,7 +561,10 @@ class ProfileSavedVideosBloc
       category: LogCategory.video,
     );
 
-    return videos.where((v) => v.isSupportedOnCurrentPlatform).toList();
+    return (
+      videos: videos.where((v) => v.isSupportedOnCurrentPlatform).toList(),
+      resolvedVideoCount: videos.length,
+    );
   }
 
   @override

--- a/mobile/lib/blocs/profile_saved_videos/profile_saved_videos_state.dart
+++ b/mobile/lib/blocs/profile_saved_videos/profile_saved_videos_state.dart
@@ -38,6 +38,7 @@ final class ProfileSavedVideosState extends Equatable {
     this.isRefreshing = false,
     this.hasMoreContent = true,
     this.nextPageOffset = 0,
+    this.lastFetchResolvedVideoCount = 0,
   });
 
   /// The current loading status.
@@ -69,15 +70,20 @@ final class ProfileSavedVideosState extends Equatable {
   /// unsupported format filtering).
   final int nextPageOffset;
 
-  /// Whether the viewer has bookmarks that none of the fetches resolved.
+  /// Number of videos returned by the repository before platform filtering in
+  /// the last fetch that produced the current empty rendered list.
+  final int lastFetchResolvedVideoCount;
+
+  /// Whether the viewer has bookmarks that the repository did not resolve.
   ///
   /// `videos.isEmpty` on its own conflates "you have no bookmarks" with "we
-  /// could not load them", and only [savedEventIds] separates the two. The
-  /// distinction cannot be recovered further down: `getVideosByIds` returns an
-  /// empty list for a relay that never answered as readily as for an event
-  /// that does not exist, so the ID list is the only evidence the tab holds
-  /// that the viewer saved anything at all.
-  bool get hasUnresolvedSaves => videos.isEmpty && savedEventIds.isNotEmpty;
+  /// could not load them", and only [savedEventIds] separates the two. This is
+  /// deliberately gated on the pre-filter resolve count: an unsupported video
+  /// format can leave the rendered list empty after a successful fetch.
+  bool get hasUnresolvedSaves =>
+      videos.isEmpty &&
+      savedEventIds.isNotEmpty &&
+      lastFetchResolvedVideoCount == 0;
 
   /// Whether data has been successfully loaded.
   bool get isLoaded => status == ProfileSavedVideosStatus.success;
@@ -97,6 +103,7 @@ final class ProfileSavedVideosState extends Equatable {
     bool? isRefreshing,
     bool? hasMoreContent,
     int? nextPageOffset,
+    int? lastFetchResolvedVideoCount,
   }) {
     return ProfileSavedVideosState(
       status: status ?? this.status,
@@ -107,6 +114,8 @@ final class ProfileSavedVideosState extends Equatable {
       isRefreshing: isRefreshing ?? this.isRefreshing,
       hasMoreContent: hasMoreContent ?? this.hasMoreContent,
       nextPageOffset: nextPageOffset ?? this.nextPageOffset,
+      lastFetchResolvedVideoCount:
+          lastFetchResolvedVideoCount ?? this.lastFetchResolvedVideoCount,
     );
   }
 
@@ -120,5 +129,6 @@ final class ProfileSavedVideosState extends Equatable {
     isRefreshing,
     hasMoreContent,
     nextPageOffset,
+    lastFetchResolvedVideoCount,
   ];
 }

--- a/mobile/lib/blocs/profile_saved_videos/profile_saved_videos_state.dart
+++ b/mobile/lib/blocs/profile_saved_videos/profile_saved_videos_state.dart
@@ -69,6 +69,16 @@ final class ProfileSavedVideosState extends Equatable {
   /// unsupported format filtering).
   final int nextPageOffset;
 
+  /// Whether the viewer has bookmarks that none of the fetches resolved.
+  ///
+  /// `videos.isEmpty` on its own conflates "you have no bookmarks" with "we
+  /// could not load them", and only [savedEventIds] separates the two. The
+  /// distinction cannot be recovered further down: `getVideosByIds` returns an
+  /// empty list for a relay that never answered as readily as for an event
+  /// that does not exist, so the ID list is the only evidence the tab holds
+  /// that the viewer saved anything at all.
+  bool get hasUnresolvedSaves => videos.isEmpty && savedEventIds.isNotEmpty;
+
   /// Whether data has been successfully loaded.
   bool get isLoaded => status == ProfileSavedVideosStatus.success;
 

--- a/mobile/lib/widgets/profile/profile_liked_grid.dart
+++ b/mobile/lib/widgets/profile/profile_liked_grid.dart
@@ -100,12 +100,13 @@ class _ProfileLikedGridState extends State<ProfileLikedGrid>
         // Only surface the failure screen when there is nothing cached to
         // show; a failed background refresh keeps the cached grid on screen.
         //
-        // Likes that failed to resolve land here too: a settled-empty tab that
-        // still holds liked IDs is a load failure, not an empty list, and the
-        // empty copy would claim this profile has liked nothing.
-        if (likedVideos.isEmpty &&
-            (state.status == ProfileLikedVideosStatus.failure ||
-                state.hasUnresolvedLikes)) {
+        // Unlike Saved and Reposts, this tab deliberately does NOT treat
+        // "liked IDs but no videos" as a failure. `_onBlocklistChanged` emits
+        // videos without touching `likedEventIds`, so blocking the author of
+        // every liked video reaches that shape with nothing having failed —
+        // see #7627.
+        if (state.status == ProfileLikedVideosStatus.failure &&
+            likedVideos.isEmpty) {
           return ProfileTabErrorState(
             message: context.l10n.profileErrorLoadingLiked,
           );

--- a/mobile/lib/widgets/profile/profile_liked_grid.dart
+++ b/mobile/lib/widgets/profile/profile_liked_grid.dart
@@ -99,8 +99,13 @@ class _ProfileLikedGridState extends State<ProfileLikedGrid>
 
         // Only surface the failure screen when there is nothing cached to
         // show; a failed background refresh keeps the cached grid on screen.
-        if (state.status == ProfileLikedVideosStatus.failure &&
-            likedVideos.isEmpty) {
+        //
+        // Likes that failed to resolve land here too: a settled-empty tab that
+        // still holds liked IDs is a load failure, not an empty list, and the
+        // empty copy would claim this profile has liked nothing.
+        if (likedVideos.isEmpty &&
+            (state.status == ProfileLikedVideosStatus.failure ||
+                state.hasUnresolvedLikes)) {
           return ProfileTabErrorState(
             message: context.l10n.profileErrorLoadingLiked,
           );

--- a/mobile/lib/widgets/profile/profile_reposts_grid.dart
+++ b/mobile/lib/widgets/profile/profile_reposts_grid.dart
@@ -91,7 +91,11 @@ class _ProfileRepostsGridState extends State<ProfileRepostsGrid>
           return const ProfileTabLoadingState();
         }
 
-        if (state.status == ProfileRepostedVideosStatus.failure) {
+        // Reposts that failed to resolve land here too: a settled-empty tab
+        // that still holds reposted coordinates is a load failure, not an
+        // empty list, and the empty copy would claim nothing was reposted.
+        if (state.status == ProfileRepostedVideosStatus.failure ||
+            state.hasUnresolvedReposts) {
           return ProfileTabErrorState(
             message: context.l10n.profileErrorLoadingReposts,
           );

--- a/mobile/lib/widgets/profile/profile_saved_grid.dart
+++ b/mobile/lib/widgets/profile/profile_saved_grid.dart
@@ -93,7 +93,13 @@ class _ProfileSavedGridState extends State<ProfileSavedGrid>
         // RefreshIndicator: with the tab's default clamping physics a pull
         // would stop working exactly when it is most wanted — after
         // unbookmarking the last video, or when a sync failed.
-        if (state.status == ProfileSavedVideosStatus.failure) {
+        //
+        // A settled-empty tab is two different outcomes, and the state carries
+        // both. Bookmarks that failed to resolve are a load failure, not an
+        // empty list: telling that viewer to go bookmark something is telling
+        // them to do what they already did.
+        if (state.status == ProfileSavedVideosStatus.failure ||
+            state.hasUnresolvedSaves) {
           return ProfileTabErrorState(
             message: context.l10n.profileErrorLoadingSaved,
             physics: const AlwaysScrollableScrollPhysics(),

--- a/mobile/test/blocs/profile_reposted_videos/profile_reposted_videos_bloc_test.dart
+++ b/mobile/test/blocs/profile_reposted_videos/profile_reposted_videos_bloc_test.dart
@@ -221,6 +221,7 @@ void main() {
           false, // isRefreshing
           false, // hasMoreContent
           0, // nextPageOffset
+          0, // lastFetchResolvedVideoCount
         ]);
       });
 

--- a/mobile/test/blocs/profile_reposted_videos/profile_reposted_videos_bloc_test.dart
+++ b/mobile/test/blocs/profile_reposted_videos/profile_reposted_videos_bloc_test.dart
@@ -454,6 +454,63 @@ void main() {
       );
 
       blocTest<ProfileRepostedVideosBloc, ProfileRepostedVideosState>(
+        'reconcile that resolves nothing reports the reposts as unresolved',
+        // #7587's archetype on the warm path: the previously-shown videos have
+        // all been un-reposted, so none of them is in the reconcile window.
+        // They are no evidence that the window resolved, and counting them as
+        // such would send the tab back to "Nothing reposted yet".
+        setUp: () async {
+          final id1 = createAddressableId(currentUserPubkey, 'd1');
+          final id2 = createAddressableId(currentUserPubkey, 'd2');
+          await cacheDao.write(
+            key: '$currentUserPubkey:profile_reposted_videos',
+            payload: ProfileVideoListSnapshot(
+              videos: [
+                createTestVideo(
+                  id: 'e1',
+                  pubkey: currentUserPubkey,
+                  vineId: 'd1',
+                ),
+              ],
+              itemIds: [id1],
+              nextPageOffset: 1,
+              hasMoreContent: false,
+            ).toJson(),
+          );
+          when(() => mockRepostsRepository.syncUserReposts()).thenAnswer(
+            (_) async => RepostsSyncResult(
+              orderedAddressableIds: [id2],
+              addressableIdToRepostId: const {},
+            ),
+          );
+          when(
+            () => mockVideosRepository.getVideosByAddressableIds(
+              any(),
+              cacheResults: any(named: 'cacheResults'),
+            ),
+          ).thenAnswer((_) async => []);
+        },
+        build: createBloc,
+        act: (bloc) => bloc.add(const ProfileRepostedVideosSyncRequested()),
+        wait: const Duration(milliseconds: 50),
+        skip: 1,
+        expect: () => [
+          isA<ProfileRepostedVideosState>()
+              .having((s) => s.videos, 'videos', isEmpty)
+              .having(
+                (s) => s.repostedAddressableIds.length,
+                'repostedAddressableIds',
+                1,
+              )
+              .having(
+                (s) => s.hasUnresolvedReposts,
+                'hasUnresolvedReposts',
+                true,
+              ),
+        ],
+      );
+
+      blocTest<ProfileRepostedVideosBloc, ProfileRepostedVideosState>(
         'filters tombstoned videos from cached snapshot restore',
         setUp: () async {
           final id1 = createAddressableId(currentUserPubkey, 'd1');

--- a/mobile/test/blocs/profile_saved_videos/profile_saved_videos_bloc_test.dart
+++ b/mobile/test/blocs/profile_saved_videos/profile_saved_videos_bloc_test.dart
@@ -350,6 +350,44 @@ void main() {
       );
 
       blocTest<ProfileSavedVideosBloc, ProfileSavedVideosState>(
+        'reconcile that resolves nothing reports the bookmarks as unresolved',
+        // #7587 on the warm path: the previously-shown videos have all been
+        // unbookmarked, so none of them is in the reconcile window. They are
+        // no evidence that the window resolved, and counting them as such
+        // would send the tab back to "Nothing saved yet".
+        setUp: () async {
+          await cacheDao.write(
+            key: '$currentUserPubkey:profile_saved_videos',
+            payload: ProfileVideoListSnapshot(
+              videos: [createTestVideo('video-1')],
+              itemIds: const ['video-1'],
+              nextPageOffset: 1,
+              hasMoreContent: false,
+            ).toJson(),
+          );
+          when(() => mockBookmarkService.globalBookmarks).thenReturn(const [
+            BookmarkItem(type: 'e', id: 'video-2'),
+          ]);
+          when(
+            () => mockVideosRepository.getVideosByIds(
+              any(),
+              cacheResults: any(named: 'cacheResults'),
+            ),
+          ).thenAnswer((_) async => []);
+        },
+        build: createBloc,
+        act: (bloc) => bloc.add(const ProfileSavedVideosSyncRequested()),
+        wait: const Duration(milliseconds: 50),
+        skip: 1,
+        expect: () => [
+          isA<ProfileSavedVideosState>()
+              .having((s) => s.videos, 'videos', isEmpty)
+              .having((s) => s.savedEventIds, 'savedEventIds', ['video-2'])
+              .having((s) => s.hasUnresolvedSaves, 'hasUnresolvedSaves', true),
+        ],
+      );
+
+      blocTest<ProfileSavedVideosBloc, ProfileSavedVideosState>(
         'removal event drops video and persists snapshot without it',
         build: () => createBloc(
           deletedVideoFilter: (video) => video.id == 'deleted-video',

--- a/mobile/test/blocs/profile_saved_videos/profile_saved_videos_bloc_test.dart
+++ b/mobile/test/blocs/profile_saved_videos/profile_saved_videos_bloc_test.dart
@@ -5,6 +5,7 @@ import 'dart:async';
 
 import 'package:bloc_test/bloc_test.dart';
 import 'package:cache_sync/cache_sync.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
@@ -88,7 +89,10 @@ void main() {
       deletedVideoFilter: deletedVideoFilter ?? (_) => false,
     );
 
-    VideoEvent createTestVideo(String id) {
+    VideoEvent createTestVideo(
+      String id, {
+      String videoUrl = 'https://example.com/video.mp4',
+    }) {
       final now = DateTime.now();
       return VideoEvent(
         id: id,
@@ -97,7 +101,7 @@ void main() {
         content: '',
         timestamp: now,
         title: 'Test Video $id',
-        videoUrl: 'https://example.com/video.mp4',
+        videoUrl: videoUrl,
         thumbnailUrl: 'https://example.com/thumb.jpg',
       );
     }
@@ -647,6 +651,54 @@ void main() {
       final manyBookmarks = List.generate(
         bookmarkCount,
         (i) => BookmarkItem(type: 'e', id: 'video-$i'),
+      );
+
+      // A first page that resolves nothing sets the failure evidence. A later
+      // page that resolves videos the platform filter then drops must replace
+      // it, or the tab keeps claiming a failure that a fetch already answered.
+      blocTest<ProfileSavedVideosBloc, ProfileSavedVideosState>(
+        'a later page that resolved-then-filtered clears the failure evidence',
+        setUp: () {
+          // The platform filter only drops WebM on iOS/macOS, and the test
+          // binding reports android, so the filter is inert without this.
+          debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+          when(
+            () => mockBookmarkService.globalBookmarks,
+          ).thenReturn(manyBookmarks);
+          when(
+            () => mockVideosRepository.getVideosByIds(
+              any(),
+              cacheResults: any(named: 'cacheResults'),
+            ),
+          ).thenAnswer((invocation) async {
+            final ids = invocation.positionalArguments.first as List<String>;
+            // Page 1 resolves nothing at all; page 2 resolves videos that are
+            // unplayable here, so both pages render empty for different
+            // reasons.
+            if (ids.contains('video-0')) return <VideoEvent>[];
+            return ids
+                .map(
+                  (id) =>
+                      createTestVideo(id, videoUrl: 'https://e.dev/$id.webm'),
+                )
+                .toList();
+          });
+        },
+        build: createBloc,
+        act: (bloc) async {
+          bloc.add(const ProfileSavedVideosSyncRequested());
+          await bloc.stream.firstWhere(
+            (state) => state.status == ProfileSavedVideosStatus.success,
+          );
+          expect(bloc.state.hasUnresolvedSaves, isTrue);
+          bloc.add(const ProfileSavedVideosLoadMoreRequested());
+        },
+        tearDown: () => debugDefaultTargetPlatformOverride = null,
+        verify: (bloc) {
+          expect(bloc.state.videos, isEmpty);
+          expect(bloc.state.savedEventIds, isNotEmpty);
+          expect(bloc.state.hasUnresolvedSaves, isFalse);
+        },
       );
 
       blocTest<ProfileSavedVideosBloc, ProfileSavedVideosState>(

--- a/mobile/test/widgets/profile/profile_liked_grid_test.dart
+++ b/mobile/test/widgets/profile/profile_liked_grid_test.dart
@@ -168,6 +168,28 @@ void main() {
         );
       });
 
+      // Same archetype as #7587 in the Saved tab: liked IDs that did not
+      // resolve to videos were rendered as "nothing liked yet".
+      testWidgets(
+        'error message, not empty state, when liked IDs did not resolve',
+        (tester) async {
+          const likedId =
+              '615a098cbf969c0d73b28c8f25eb59b9745db95c19d7b1998068d9b31c3df1a0';
+          when(() => mockBloc.state).thenReturn(
+            const ProfileLikedVideosState(
+              status: ProfileLikedVideosStatus.success,
+              likedEventIds: [likedId],
+            ),
+          );
+
+          await tester.pumpWidget(buildSubject());
+
+          final l10n = lookupAppLocalizations(const Locale('en'));
+          expect(find.text(l10n.profileErrorLoadingLiked), findsOneWidget);
+          expect(find.text(l10n.profileNoLikedVideosTitle), findsNothing);
+        },
+      );
+
       testWidgets('grid of liked videos when videos exist', (tester) async {
         final videos = _createTestVideos(count: 3);
         when(() => mockBloc.state).thenReturn(

--- a/mobile/test/widgets/profile/profile_liked_grid_test.dart
+++ b/mobile/test/widgets/profile/profile_liked_grid_test.dart
@@ -168,27 +168,29 @@ void main() {
         );
       });
 
-      // Same archetype as #7587 in the Saved tab: liked IDs that did not
-      // resolve to videos were rendered as "nothing liked yet".
-      testWidgets(
-        'error message, not empty state, when liked IDs did not resolve',
-        (tester) async {
-          const likedId =
-              '615a098cbf969c0d73b28c8f25eb59b9745db95c19d7b1998068d9b31c3df1a0';
-          when(() => mockBloc.state).thenReturn(
-            const ProfileLikedVideosState(
-              status: ProfileLikedVideosStatus.success,
-              likedEventIds: [likedId],
-            ),
-          );
+      // Deliberately unlike Saved and Reposts (#7587), which treat this shape
+      // as a load failure. `_onBlocklistChanged` emits videos without touching
+      // `likedEventIds`, so blocking the author of every liked video produces
+      // "IDs but no videos" with nothing having failed. Until that path stops
+      // breaking the invariant (#7627), the empty state is the safe render.
+      testWidgets('empty state when liked IDs resolved to no videos', (
+        tester,
+      ) async {
+        const likedId =
+            '615a098cbf969c0d73b28c8f25eb59b9745db95c19d7b1998068d9b31c3df1a0';
+        when(() => mockBloc.state).thenReturn(
+          const ProfileLikedVideosState(
+            status: ProfileLikedVideosStatus.success,
+            likedEventIds: [likedId],
+          ),
+        );
 
-          await tester.pumpWidget(buildSubject());
+        await tester.pumpWidget(buildSubject());
 
-          final l10n = lookupAppLocalizations(const Locale('en'));
-          expect(find.text(l10n.profileErrorLoadingLiked), findsOneWidget);
-          expect(find.text(l10n.profileNoLikedVideosTitle), findsNothing);
-        },
-      );
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        expect(find.text(l10n.profileNoLikedVideosTitle), findsOneWidget);
+        expect(find.text(l10n.profileErrorLoadingLiked), findsNothing);
+      });
 
       testWidgets('grid of liked videos when videos exist', (tester) async {
         final videos = _createTestVideos(count: 3);

--- a/mobile/test/widgets/profile/profile_reposts_grid_test.dart
+++ b/mobile/test/widgets/profile/profile_reposts_grid_test.dart
@@ -189,6 +189,27 @@ void main() {
         },
       );
 
+      testWidgets(
+        'empty state, not error, when reposted IDs resolved before filtering',
+        (tester) async {
+          const coordinate =
+              '34236:fc7031a810ce4b02b6195a7e477cfe3d08c0386038bd45b4431f82d9b3f5ffb0:d112a519c0332008b88ffc0ad2bfb562b0001571b7e6bb82819005dffa8fa24b';
+          when(() => mockBloc.state).thenReturn(
+            const ProfileRepostedVideosState(
+              status: ProfileRepostedVideosStatus.success,
+              repostedAddressableIds: [coordinate],
+              lastFetchResolvedVideoCount: 1,
+            ),
+          );
+
+          await tester.pumpWidget(buildSubject());
+
+          final l10n = lookupAppLocalizations(const Locale('en'));
+          expect(find.text(l10n.profileNoRepostsTitle), findsOneWidget);
+          expect(find.text(l10n.profileErrorLoadingReposts), findsNothing);
+        },
+      );
+
       testWidgets('grid of reposted videos when videos exist', (
         tester,
       ) async {

--- a/mobile/test/widgets/profile/profile_reposts_grid_test.dart
+++ b/mobile/test/widgets/profile/profile_reposts_grid_test.dart
@@ -167,6 +167,28 @@ void main() {
         );
       });
 
+      // Same archetype as #7587 in the Saved tab: reposted coordinates that
+      // did not resolve to videos were rendered as "nothing reposted yet".
+      testWidgets(
+        'error message, not empty state, when reposted IDs did not resolve',
+        (tester) async {
+          const coordinate =
+              '34236:fc7031a810ce4b02b6195a7e477cfe3d08c0386038bd45b4431f82d9b3f5ffb0:d112a519c0332008b88ffc0ad2bfb562b0001571b7e6bb82819005dffa8fa24b';
+          when(() => mockBloc.state).thenReturn(
+            const ProfileRepostedVideosState(
+              status: ProfileRepostedVideosStatus.success,
+              repostedAddressableIds: [coordinate],
+            ),
+          );
+
+          await tester.pumpWidget(buildSubject());
+
+          final l10n = lookupAppLocalizations(const Locale('en'));
+          expect(find.text(l10n.profileErrorLoadingReposts), findsOneWidget);
+          expect(find.text(l10n.profileNoRepostsTitle), findsNothing);
+        },
+      );
+
       testWidgets('grid of reposted videos when videos exist', (
         tester,
       ) async {

--- a/mobile/test/widgets/profile/profile_saved_grid_test.dart
+++ b/mobile/test/widgets/profile/profile_saved_grid_test.dart
@@ -134,6 +134,30 @@ void main() {
         );
       });
 
+      // Regression for #7587: a bookmark that did not resolve to a video was
+      // rendered as "Nothing saved yet", telling a viewer who has bookmarks
+      // to go make some. `savedEventIds` is what separates the two outcomes.
+      testWidgets(
+        'error message, not empty state, when saved IDs did not resolve',
+        (tester) async {
+          const savedId =
+              '615a098cbf969c0d73b28c8f25eb59b9745db95c19d7b1998068d9b31c3df1a0';
+          when(() => mockBloc.state).thenReturn(
+            const ProfileSavedVideosState(
+              status: ProfileSavedVideosStatus.success,
+              savedEventIds: [savedId],
+            ),
+          );
+
+          await tester.pumpWidget(buildSubject());
+
+          final l10n = lookupAppLocalizations(const Locale('en'));
+          expect(find.text(l10n.profileErrorLoadingSaved), findsOneWidget);
+          expect(find.text(l10n.profileNoSavedVideosTitle), findsNothing);
+          expect(find.text(l10n.profileSavedOwnEmpty), findsNothing);
+        },
+      );
+
       testWidgets('grid of saved videos when videos exist', (tester) async {
         final videos = _createTestVideos(count: 3);
         when(() => mockBloc.state).thenReturn(

--- a/mobile/test/widgets/profile/profile_saved_grid_test.dart
+++ b/mobile/test/widgets/profile/profile_saved_grid_test.dart
@@ -15,6 +15,17 @@ import 'package:openvine/widgets/profile/profile_saved_grid.dart';
 import '../../helpers/go_router.dart';
 import '../../helpers/test_provider_overrides.dart';
 
+/// Pins the ambient physics that `AlwaysScrollableScrollPhysics` wraps, so a
+/// test does not depend on process-wide target-platform state.
+class _FixedPhysicsScrollBehavior extends ScrollBehavior {
+  const _FixedPhysicsScrollBehavior(this.physics);
+
+  final ScrollPhysics physics;
+
+  @override
+  ScrollPhysics getScrollPhysics(BuildContext context) => physics;
+}
+
 class _MockProfileSavedVideosBloc
     extends MockBloc<ProfileSavedVideosEvent, ProfileSavedVideosState>
     implements ProfileSavedVideosBloc {}
@@ -50,7 +61,8 @@ void main() {
       ).thenAnswer((_) async => null);
     });
 
-    Widget buildSubject({MockGoRouter? goRouter}) {
+    Widget buildSubject({MockGoRouter? goRouter, ScrollPhysics? physics}) {
+      const grid = ProfileSavedGrid(userIdHex: 'test-user');
       final app = testProviderScope(
         additionalOverrides: [],
         child: MaterialApp(
@@ -60,7 +72,12 @@ void main() {
           home: Scaffold(
             body: BlocProvider<ProfileSavedVideosBloc>.value(
               value: mockBloc,
-              child: const ProfileSavedGrid(userIdHex: 'test-user'),
+              child: physics == null
+                  ? grid
+                  : ScrollConfiguration(
+                      behavior: _FixedPhysicsScrollBehavior(physics),
+                      child: grid,
+                    ),
             ),
           ),
         ),
@@ -233,6 +250,77 @@ void main() {
           () => mockBloc.add(const ProfileSavedVideosLoadMoreRequested()),
         ).called(greaterThanOrEqualTo(1));
       });
+
+      // Whether the unresolved state can reach page 2 depends on the ambient
+      // scroll physics, so inject them rather than relying on the target
+      // platform: `AlwaysScrollableScrollPhysics` resolves its parent through
+      // the theme's ScrollBehavior, which is built once per process, so a
+      // `debugDefaultTargetPlatformOverride` version of this test passes alone
+      // and fails in a suite (#7623, #7639).
+      //
+      // `ProfileTabErrorState` opts into AlwaysScrollableScrollPhysics, so the
+      // drag is accepted even though the content fits, and `maxScrollExtent`
+      // is 0 — which makes the mixin's near-bottom test
+      // (`pixels >= maxScrollExtent - threshold`) trivially true. What decides
+      // it is whether the drag moves `pixels` at all: bouncing overscroll
+      // notifies, clamping pins the position at the boundary and never does.
+      testWidgets(
+        'bouncing overscroll of the unresolved state requests the next page',
+        (tester) async {
+          when(() => mockBloc.state).thenReturn(
+            ProfileSavedVideosState(
+              status: ProfileSavedVideosStatus.success,
+              savedEventIds: List.generate(40, (i) => 'saved-$i'),
+              nextPageOffset: 36,
+            ),
+          );
+
+          await tester.pumpWidget(
+            buildSubject(physics: const BouncingScrollPhysics()),
+          );
+          final l10n = lookupAppLocalizations(const Locale('en'));
+          expect(find.text(l10n.profileErrorLoadingSaved), findsOneWidget);
+
+          await tester.drag(
+            find.byType(CustomScrollView),
+            const Offset(0, 400),
+          );
+          await tester.pumpAndSettle();
+
+          verify(
+            () => mockBloc.add(const ProfileSavedVideosLoadMoreRequested()),
+          ).called(greaterThanOrEqualTo(1));
+        },
+      );
+
+      testWidgets(
+        'clamping overscroll of the unresolved state cannot reach page 2',
+        (tester) async {
+          when(() => mockBloc.state).thenReturn(
+            ProfileSavedVideosState(
+              status: ProfileSavedVideosStatus.success,
+              savedEventIds: List.generate(40, (i) => 'saved-$i'),
+              nextPageOffset: 36,
+            ),
+          );
+
+          await tester.pumpWidget(
+            buildSubject(physics: const ClampingScrollPhysics()),
+          );
+          final l10n = lookupAppLocalizations(const Locale('en'));
+          expect(find.text(l10n.profileErrorLoadingSaved), findsOneWidget);
+
+          await tester.drag(
+            find.byType(CustomScrollView),
+            const Offset(0, 400),
+          );
+          await tester.pumpAndSettle();
+
+          verifyNever(
+            () => mockBloc.add(const ProfileSavedVideosLoadMoreRequested()),
+          );
+        },
+      );
 
       testWidgets('navigates to fullscreen feed when tile is tapped', (
         tester,

--- a/mobile/test/widgets/profile/profile_saved_grid_test.dart
+++ b/mobile/test/widgets/profile/profile_saved_grid_test.dart
@@ -158,6 +158,27 @@ void main() {
         },
       );
 
+      testWidgets(
+        'empty state, not error, when saved IDs resolved before filtering',
+        (tester) async {
+          const savedId =
+              '615a098cbf969c0d73b28c8f25eb59b9745db95c19d7b1998068d9b31c3df1a0';
+          when(() => mockBloc.state).thenReturn(
+            const ProfileSavedVideosState(
+              status: ProfileSavedVideosStatus.success,
+              savedEventIds: [savedId],
+              lastFetchResolvedVideoCount: 1,
+            ),
+          );
+
+          await tester.pumpWidget(buildSubject());
+
+          final l10n = lookupAppLocalizations(const Locale('en'));
+          expect(find.text(l10n.profileNoSavedVideosTitle), findsOneWidget);
+          expect(find.text(l10n.profileErrorLoadingSaved), findsNothing);
+        },
+      );
+
       testWidgets('grid of saved videos when videos exist', (tester) async {
         final videos = _createTestVideos(count: 3);
         when(() => mockBloc.state).thenReturn(


### PR DESCRIPTION
## Description

The Saved tab told a viewer who has bookmarks that they have none, whenever the bookmarked videos failed to resolve. It branched on `state.videos.isEmpty`, which conflates "you have no bookmarks" with "we could not load them", and rendered "Nothing saved yet" plus "Bookmark videos from the share sheet and they'll show up here" — instructing the user to do the exact thing they had already done.

The state object already carries both facts. `savedEventIds` is the bookmark list; `videos` is what resolved from it. Branching on the first for the genuine empty state and treating "IDs but no videos" as a load failure costs nothing and is the whole fix.

### Why the distinction cannot be made lower down

`NostrClient.queryEvents` delegates to `queryEventsDetailed` and then returns `result.events`, dropping the `timedOut` and `noRelays` flags (`nostr_client.dart:1014-1024`). So `VideosRepository.getVideosByIds` returns an empty list for a relay that never answered exactly as readily as for an event that does not exist, and it never throws. Nothing below the state object can tell a user's empty bookmark list from an unanswered query — `savedEventIds` is the only evidence the tab holds that the viewer saved anything at all.

### Root cause, verified on device against production

Run on a physical iPhone (iOS 26.6, production backend), reproducing the exact bookmark from the issue:

| step | observed |
|---|---|
| relay's kind-10003 for the viewer | one `e` tag — the list is real |
| that event on the relay | present: kind 34236, `imeta url https://media.divine.video/…`, `m video/mp4`, `dim 1080x1920`, no expiration, no reply tags |
| `getVideosByIds([id])` once cached | **1/1** — no content, block, deleted, transport-scheme or WebM filter is involved |
| cold start, uncached id the relay holds, polled every 500 ms for 30 s | `isInitialized=false`, `connectedRelayCount=0`, **`0/1` on every single call** — silently, no throw |
| Bookmarks opened after relays settle | `ProfileSavedVideosBloc: Fetched 1/1 videos` |

So the reported `Fetched 0/1 videos` was a cold-start relay race against a bookmark that is perfectly resolvable, and the tab reported it as "you have nothing". `connectedRelayCount == 0` on its own is *not* sufficient — a warm session at 0 relays still resolved 1/1 out of the client's own event cache. The discriminator is the uninitialised client plus a cold local cache.

### What changed

**Saved** and **Reposts** each gain one computed getter and one supporting field on their state, plus one branch in their grid. No new ARB keys and no copy churn across the 22 locales — the failed-load case reuses the tab's existing already-translated error string (`profileErrorLoadingSaved` / `profileErrorLoadingReposts`).

The supporting field is `lastFetchResolvedVideoCount`: the count the repository returned **before** the bloc's own platform filter, for the fetch that produced the currently-empty list. Without it the getter cannot tell "the repository returned nothing" from "the repository returned N and this bloc dropped all N", and a bookmark list that is entirely WebM on iOS would render as a load failure. Every fetch that settles on an empty list writes the field: cold load, warm reconcile, and load-more. A reconcile counts only the videos its own window fetched — a video carried over from the previous render but no longer in the window is not evidence that the window resolved.

The getter is gated on a third fact, `lastFetchResolvedVideoCount`, so it asserts failure only when the *repository* returned nothing. `_fetchVideos` drops formats this platform cannot play after the repository has answered, so an empty list can equally mean "resolved, then all filtered" — a settled success. That case falls through to the existing empty state.

The split is only sound where the remaining `videos.isEmpty && ids.isNotEmpty` can mean exactly one thing. In both these blocs every emit sets the video list and the ID list together, so the shape can only come from a fetch that resolved nothing, and neither bloc references the blocklist at all.

**Liked is deliberately excluded.** It was in this branch and was reverted after self-review: `_onBlocklistChanged` reaches two emits that set `videos` without touching `likedEventIds`, and `_dropBlockedFromCurrentList` performs no fetch — it is a pure filter over already-held videos. Blocking the author of every liked video therefore reaches "IDs but no videos" with nothing having failed, and the naive branch turned that into a live flip from a working grid to an error screen. Pruning the IDs to match is not the repair either: the re-resolve window is built from `likedEventIds`, and that is exactly what lets an unblocked author's likes reappear. Telling "filtered" from "unresolved" needs an explicit signal in state — filed as #7627. The Liked test in this branch now pins that deliberate divergence, so re-applying the naive branch turns it red.

### Behaviour worth knowing before the first support report

A bookmark that can never resolve — a deleted video, a bookmark on a non-video event, an author the viewer has blocked — now shows "Error loading saved videos" where it used to show "Nothing saved yet". (A bookmark the repository *does* return and the platform filter then drops, such as a WebM upload on iOS, deliberately keeps the empty state: that is a successful load, not a failed one.) That is the intended trade: both are wrong about *why*, but only one tells a user with bookmarks to go make some. Unlike the Liked case above, these all arise from a *load* that resolved nothing rather than from a filter applied to videos already on screen, so there is no live flip out of a populated grid.

## Out of Scope

Six related findings surfaced by the same investigation, all verified, none fixed here:

1. **`getVideosByIds` erases the transport signal.** Plumbing `queryEventsDetailed` through it would let the tab say "couldn't reach relays" instead of a generic failure, and would let the bloc emit `failure` rather than `success`-with-nothing. It changes a shared repository method on a 100 %-coverage package and every caller, so it is its own PR. Tracked at the `nostr_sdk` layer by #6238.
2. **An unresolved ID in a partly-filled window is never retried.** `_warmRevalidate` returns early when `listEquals(freshIds, state.savedEventIds) && !_isWindowUnderfilled(...)`, and `_isWindowUnderfilled` only looks at `nextPageOffset`, not at how many IDs actually resolved. So with 40 bookmarks where 30 resolve, the missing 10 are never re-fetched while the list is unchanged — including on pull-to-refresh. Identical code in `ProfileLikedVideosBloc`. The all-unresolved case this PR addresses is unaffected, because it takes the cold path instead. Filed as #7626.
3. **The Liked tab keeps the original defect** — #7627, as described above.
4. **`_resolveSavedIds` discards `syncGlobalBookmarks()`'s failure return**, so "the relay never answered" and "your list is empty" are indistinguishable one layer above this fix too, and the tab still lands on `success`.
5. **`'a'`-typed bookmarks are dropped.** `_resolveSavedIds` keeps only `item.type == 'e'`. Divine's own writer emits `'e'`, but kind 34236 is addressable, so a NIP-51-conformant third-party client would bookmark these videos as `a` coordinates and the tab would silently ignore them.

6. **The Reposts tab has no escape hatch from its error state.** Its `ProfileTabErrorState` uses the default `ClampingScrollPhysics`, so a content-fits viewport cannot be overscrolled and neither pull-to-refresh nor `LoadMoreRequested` can fire. Pre-existing — it applies equally to that tab's existing `failure` branch and its empty state — and changing scroll physics inside the profile's `NestedScrollView` needs its own device pass. The Saved *screen* does not share this: measured on device, its error state is `AlwaysScrollableScrollPhysics`, `canLoadMore` is true, and an overscroll dispatches `Loading more videos (offset: 36, total: 40)`.

Also unfixed and unrelated to the filed bug: `ProfileSavedVideosStatus.syncing` and `.loading` are never emitted by the bloc — the `initial` branch covers the cold open.

## Verification

- `flutter analyze lib test integration_test` — clean.
- `flutter test test/widgets/profile/ test/blocs/profile_saved_videos/ test/blocs/profile_liked_videos/ test/blocs/profile_reposted_videos/ test/screens/saved_videos_screen_test.dart` — 446 passing.
- **The new tests were proven able to fail**: reverting only the grid branches turns exactly those tests red and nothing else.
- Device pass on a physical iPhone against production, as tabulated above — relay state read with `nak`, app state read live through the Dart VM Service, no instrumentation added to the app.
- **Both user-facing claims verified on the device against this build.** Driving the live `ProfileSavedVideosBloc` into the unresolved state (`videos=0, ids=1, hasUnresolvedSaves=true`) and reading the mounted widget tree gives `ProfileTabErrorState` with the text `Error loading saved videos` — not the empty state — under a `RefreshIndicator`. Dispatching the refresh event from there recovers to `videos=1, ids=1, hasUnresolvedSaves=false, status=success`.

New assertions resolve their expected copy through `lookupAppLocalizations` rather than hardcoding English, so they survive copy changes and break if a grid stops reading from l10n.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

**Related Issue:** Closes #7587

