### PR TITLE
fix(dm): Add deduplication logging to diagnose duplicate messages

### DIFF
--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -1702,10 +1702,15 @@ class DmRepository {
     try {
       // Dedup: skip if already processed (message row or ledger). #5452.
       if (await _alreadyProcessed(giftWrapEvent.id)) {
-        Log.debug(
-          'Skipping already-processed gift wrap ${giftWrapEvent.id}',
-          category: LogCategory.system,
-        );
+        // History drain pass 2 re-routes already-persisted wraps through this
+        // handler (preDecrypted miss). Per-wrap debug would fill the 50k
+        // capture ring and evict the persist lines that diagnose #7631.
+        if (_historyDrain == null) {
+          Log.debug(
+            'Skipping already-processed gift wrap ${giftWrapEvent.id}',
+            category: LogCategory.system,
+          );
+        }
         return;
       }
 
@@ -2021,8 +2026,8 @@ class DmRepository {
       await _syncState?.recordSeen(_userPubkey, createdAt: persistedCreatedAt);
 
       Log.debug(
-        'Persisted NIP-17 DM (kind ${rumor.kind}) in conversation '
-        '$conversationId from ${rumor.pubkey}',
+        'Persisted NIP-17 DM ${rumor.id} (kind ${rumor.kind}) in conversation '
+        '$conversationId from ${rumor.pubkey} createdAt=$persistedCreatedAt',
         category: LogCategory.system,
       );
     } on Object catch (e, stackTrace) {
@@ -2454,10 +2459,12 @@ class DmRepository {
     try {
       // Dedup: use event ID as giftWrapId for the unique index.
       if (await _directMessagesDao.hasGiftWrap(nip04Event.id)) {
-        Log.debug(
-          'Skipping already-persisted NIP-04 event ${nip04Event.id}',
-          category: LogCategory.system,
-        );
+        if (_historyDrain == null) {
+          Log.debug(
+            'Skipping already-persisted NIP-04 event ${nip04Event.id}',
+            category: LogCategory.system,
+          );
+        }
         return;
       }
 
@@ -2589,8 +2596,10 @@ class DmRepository {
       );
 
       Log.debug(
-        'Persisted NIP-04 DM (kind ${EventKind.directMessage}) in conversation '
-        '$conversationId from $senderPubkey',
+        'Persisted NIP-04 DM ${nip04Event.id} '
+        '(kind ${EventKind.directMessage}) in conversation '
+        '$conversationId from $senderPubkey '
+        'createdAt=${nip04Event.createdAt}',
         category: LogCategory.system,
       );
     } on Object catch (e, stackTrace) {

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -1702,6 +1702,10 @@ class DmRepository {
     try {
       // Dedup: skip if already processed (message row or ledger). #5452.
       if (await _alreadyProcessed(giftWrapEvent.id)) {
+        Log.debug(
+          'Skipping already-processed gift wrap ${giftWrapEvent.id}',
+          category: LogCategory.system,
+        );
         return;
       }
 
@@ -1937,14 +1941,11 @@ class DmRepository {
       var inserted = false;
       var skippedByTransactionalGiftWrapDedup = false;
       await _conversationsDao.runInTransaction(() async {
-        // Re-check dedup inside transaction (TOCTOU protection).
+        // Re-check dedup inside transaction (TOCTOU protection). The skip is
+        // logged after the transaction below; logging here too would emit one
+        // line per skip twice.
         if (await _directMessagesDao.hasGiftWrap(giftWrapEvent.id)) {
           skippedByTransactionalGiftWrapDedup = true;
-          Log.debug(
-            'DM dedup: gift wrap ${giftWrapEvent.id} already persisted '
-            'during transaction, skipping',
-            category: LogCategory.system,
-          );
           return;
         }
 
@@ -2452,7 +2453,13 @@ class DmRepository {
   Future<void> _handleNip04Event(Event nip04Event) async {
     try {
       // Dedup: use event ID as giftWrapId for the unique index.
-      if (await _directMessagesDao.hasGiftWrap(nip04Event.id)) return;
+      if (await _directMessagesDao.hasGiftWrap(nip04Event.id)) {
+        Log.debug(
+          'Skipping already-persisted NIP-04 event ${nip04Event.id}',
+          category: LogCategory.system,
+        );
+        return;
+      }
 
       // Extract recipient from p tag
       String? recipientPubkey;
@@ -2516,14 +2523,11 @@ class DmRepository {
       var inserted = false;
       var skippedByTransactionalGiftWrapDedup = false;
       await _conversationsDao.runInTransaction(() async {
-        // Re-check dedup inside transaction (TOCTOU protection).
+        // Re-check dedup inside transaction (TOCTOU protection). The skip is
+        // logged after the transaction below; logging here too would emit one
+        // line per skip twice.
         if (await _directMessagesDao.hasGiftWrap(nip04Event.id)) {
           skippedByTransactionalGiftWrapDedup = true;
-          Log.debug(
-            'DM dedup: event ${nip04Event.id} already persisted '
-            'during transaction, skipping',
-            category: LogCategory.system,
-          );
           return;
         }
 

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -1940,6 +1940,11 @@ class DmRepository {
         // Re-check dedup inside transaction (TOCTOU protection).
         if (await _directMessagesDao.hasGiftWrap(giftWrapEvent.id)) {
           skippedByTransactionalGiftWrapDedup = true;
+          Log.debug(
+            'DM dedup: gift wrap ${giftWrapEvent.id} already persisted '
+            'during transaction, skipping',
+            category: LogCategory.system,
+          );
           return;
         }
 
@@ -2015,8 +2020,8 @@ class DmRepository {
       await _syncState?.recordSeen(_userPubkey, createdAt: persistedCreatedAt);
 
       Log.debug(
-        'Persisted DM (kind ${rumor.kind}) in conversation '
-        '$conversationId',
+        'Persisted NIP-17 DM (kind ${rumor.kind}) in conversation '
+        '$conversationId from ${rumor.pubkey}',
         category: LogCategory.system,
       );
     } on Object catch (e, stackTrace) {
@@ -2514,6 +2519,11 @@ class DmRepository {
         // Re-check dedup inside transaction (TOCTOU protection).
         if (await _directMessagesDao.hasGiftWrap(nip04Event.id)) {
           skippedByTransactionalGiftWrapDedup = true;
+          Log.debug(
+            'DM dedup: event ${nip04Event.id} already persisted '
+            'during transaction, skipping',
+            category: LogCategory.system,
+          );
           return;
         }
 
@@ -2575,7 +2585,8 @@ class DmRepository {
       );
 
       Log.debug(
-        'Persisted NIP-04 DM in conversation $conversationId',
+        'Persisted NIP-04 DM (kind ${EventKind.directMessage}) in conversation '
+        '$conversationId from $senderPubkey',
         category: LogCategory.system,
       );
     } on Object catch (e, stackTrace) {


### PR DESCRIPTION
Refs #7631

## Summary

Added logging to DM deduplication paths so persist lines carry rumor/event id, protocol, sender, and createdAt, and so skip lines are visible on the live path without flooding history-drain replay.

## Problem

When users report duplicate DMs from other peers, logs showed a persist line that did not identify the row, so two inserts of the same content could not be paired from a log export.

## Solution

- Persist logs now include rumor/event id, protocol (NIP-17 vs NIP-04), sender pubkey, and createdAt (the same timestamp the +/-5s matching window uses)
- Live-path already-processed skips are logged; the same skip is silent during a history drain so resume replay does not fill the in-memory log ring
- Transactional gift-wrap re-check still logs once after the transaction (not a second time inside it)
- Logging stays at the repository layer so db_client does not depend on app services

## Covers Issue

Observability for #7631 (duplicate DMs when a peer retries more than 5 seconds later with a new rumor). Does not change the +/-5s window or add content-hash dedup.

## Testing

- `mobile/packages/dm_repository`: flutter analyze clean; flutter test 613 passed; coverage 94.16% (package CI floor is 93)
- Pre-push: no merge conflicts with main, analyze OK

## Related

- #7631 - DM deduplication vulnerable to peer re-sends >5 seconds apart