### PR TITLE
fix(bookmarks): stamp kind 10003 past the revision it replaces

### DIFF
--- a/mobile/lib/services/bookmark_service.dart
+++ b/mobile/lib/services/bookmark_service.dart
@@ -8,6 +8,7 @@ import 'package:meta/meta.dart';
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
 import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/utils/nostr_timestamp.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:unified_logger/unified_logger.dart';
 
@@ -183,6 +184,13 @@ class BookmarkService {
   /// NIP-51 kind for the uncategorized ("global") bookmark list.
   static const int globalBookmarksKind = 10003;
 
+  /// How far past this device's clock a kind-10003 may be stamped.
+  ///
+  /// The relay refuses `created_at` more than 60 s in the future, so a stamp
+  /// that steps over another client's revision has to stay well under that —
+  /// this device's clock and the relay's are not the same clock.
+  static const int maxPublishFutureSkew = 30;
+
   /// The `content` Divine wrote into kind 10003 before it respected NIP-51's
   /// reservation of that field for the encrypted private-item array.
   ///
@@ -324,6 +332,28 @@ class BookmarkService {
       return false;
     }
     return _now().difference(local.acceptedAt) < localPublishAbsenceGracePeriod;
+  }
+
+  /// The `created_at` for the next publish, or `null` when this device cannot
+  /// stamp one that both supersedes [_revision] and stays acceptable.
+  ///
+  /// Kind 10003 is normally stamped `now - 30s` for relay clock drift. A
+  /// NIP-51 client that does not backdate can therefore hold the current
+  /// revision at a timestamp this device's stamp cannot beat, and the relay
+  /// keeps the higher `created_at` — so the publish is accepted, the user is
+  /// told "Saved", and the merge discards it (#7629). Step past that revision
+  /// instead, unless doing so would land beyond [maxPublishFutureSkew], where
+  /// the relay would refuse the event outright.
+  int? _nextPublishCreatedAt() {
+    final nowSeconds = _now().millisecondsSinceEpoch ~/ 1000;
+    final backdated =
+        nowSeconds -
+        NostrTimestamp.getDriftToleranceForKind(globalBookmarksKind);
+    final revision = _revision;
+    if (revision == null || backdated > revision.createdAt) return backdated;
+
+    final superseding = revision.createdAt + 1;
+    return superseding > nowSeconds + maxPublishFutureSkew ? null : superseding;
   }
 
   /// Whether an empty answer from a partial set of relays still has to be
@@ -899,10 +929,23 @@ class BookmarkService {
         content = encrypted;
       }
 
+      final createdAt = _nextPublishCreatedAt();
+      if (createdAt == null) {
+        Log.warning(
+          'Not publishing global bookmarks: cannot stamp a revision newer '
+          'than ${_revision?.createdAt} without exceeding the relay clock '
+          'tolerance',
+          name: 'BookmarkService',
+          category: LogCategory.system,
+        );
+        return false;
+      }
+
       final event = await _authService.createAndSignEvent(
         kind: globalBookmarksKind,
         content: content,
         tags: [for (final item in candidate) item.toTag()],
+        createdAt: createdAt,
       );
 
       if (event == null) return false;

--- a/mobile/lib/services/bookmark_service.dart
+++ b/mobile/lib/services/bookmark_service.dart
@@ -186,9 +186,10 @@ class BookmarkService {
 
   /// How far past this device's clock a kind-10003 may be stamped.
   ///
-  /// The relay refuses `created_at` more than 60 s in the future, so a stamp
-  /// that steps over another client's revision has to stay well under that —
-  /// this device's clock and the relay's are not the same clock.
+  /// A publish goes to the whole pool and only needs `acceptedByAny`, so this
+  /// is a best-effort pool-wide compromise rather than any one relay's limit:
+  /// Divine's refuses `created_at` more than 60 s ahead, a stricter relay may
+  /// refuse sooner, and this device's clock is not the relay's either.
   static const int maxPublishFutureSkew = 30;
 
   /// The `content` Divine wrote into kind 10003 before it respected NIP-51's
@@ -334,17 +335,23 @@ class BookmarkService {
     return _now().difference(local.acceptedAt) < localPublishAbsenceGracePeriod;
   }
 
-  /// The `created_at` for the next publish, or `null` when this device cannot
-  /// stamp one that both supersedes [_revision] and stays acceptable.
+  /// The `created_at` for the next publish.
   ///
   /// Kind 10003 is normally stamped `now - 30s` for relay clock drift. A
   /// NIP-51 client that does not backdate can therefore hold the current
   /// revision at a timestamp this device's stamp cannot beat, and the relay
   /// keeps the higher `created_at` — so the publish is accepted, the user is
   /// told "Saved", and the merge discards it (#7629). Step past that revision
-  /// instead, unless doing so would land beyond [maxPublishFutureSkew], where
-  /// the relay would refuse the event outright.
-  int? _nextPublishCreatedAt() {
+  /// instead, capped at [maxPublishFutureSkew].
+  ///
+  /// The cap is best-effort, never a refusal. Adoption applies no upper bound
+  /// on how far ahead a revision may be stamped ([_isStaleRevision] only
+  /// rejects older), and [_revision] is persisted, so one implausibly
+  /// future-dated event — a skewed clock, or milliseconds written as seconds —
+  /// would otherwise block every later write on this device until the wall
+  /// clock caught up, across restarts. A capped stamp still beats the plain
+  /// backdated one everywhere the bogus revision is absent.
+  int _nextPublishCreatedAt() {
     final nowSeconds = _now().millisecondsSinceEpoch ~/ 1000;
     final backdated =
         nowSeconds -
@@ -353,7 +360,16 @@ class BookmarkService {
     if (revision == null || backdated > revision.createdAt) return backdated;
 
     final superseding = revision.createdAt + 1;
-    return superseding > nowSeconds + maxPublishFutureSkew ? null : superseding;
+    final ceiling = nowSeconds + maxPublishFutureSkew;
+    if (superseding <= ceiling) return superseding;
+
+    Log.warning(
+      'Cannot stamp past kind 10003 revision ${revision.createdAt}; '
+      'publishing at $ceiling, which the relay merge may discard',
+      name: 'BookmarkService',
+      category: LogCategory.system,
+    );
+    return ceiling;
   }
 
   /// Whether an empty answer from a partial set of relays still has to be
@@ -929,23 +945,11 @@ class BookmarkService {
         content = encrypted;
       }
 
-      final createdAt = _nextPublishCreatedAt();
-      if (createdAt == null) {
-        Log.warning(
-          'Not publishing global bookmarks: cannot stamp a revision newer '
-          'than ${_revision?.createdAt} without exceeding the relay clock '
-          'tolerance',
-          name: 'BookmarkService',
-          category: LogCategory.system,
-        );
-        return false;
-      }
-
       final event = await _authService.createAndSignEvent(
         kind: globalBookmarksKind,
         content: content,
         tags: [for (final item in candidate) item.toTag()],
-        createdAt: createdAt,
+        createdAt: _nextPublishCreatedAt(),
       );
 
       if (event == null) return false;

--- a/mobile/test/services/bookmark_service_test.dart
+++ b/mobile/test/services/bookmark_service_test.dart
@@ -1370,18 +1370,39 @@ void main() {
         },
       );
 
+      test('steps past a revision that lands exactly on the cap', () async {
+        // The boundary is inclusive: this is still a stamp the relay accepts,
+        // so it must be used rather than treated as over the line.
+        final theirs = bookmarkListEvent(
+          ['video-a'],
+          createdAt: nowSeconds + BookmarkService.maxPublishFutureSkew - 1,
+        );
+        stubRelay(events: [theirs]);
+        final service = createService(now: () => clock);
+
+        expect(
+          (await service.toggleVideoInGlobalBookmarks('video-b')).succeeded,
+          isTrue,
+        );
+
+        expect(
+          signedCreatedAt,
+          nowSeconds + BookmarkService.maxPublishFutureSkew,
+        );
+      });
+
       test(
-        'refuses to publish when it cannot stamp past the revision',
+        'still publishes, capped, against an implausible revision',
         () async {
-          // Their clock runs far enough ahead that stepping past it would land
-          // outside what the relay accepts. Publishing anyway would be accepted
-          // and then discarded by the merge, while the user is told "Saved".
+          // Milliseconds written as seconds. Refusing here would block every
+          // later write on this device until the wall clock caught up — and
+          // `_revision` is persisted, so a restart would not clear it. A capped
+          // stamp still wins everywhere the bogus revision is absent.
           stubRelay(
             events: [
               bookmarkListEvent(
                 ['video-a'],
-                createdAt:
-                    nowSeconds + BookmarkService.maxPublishFutureSkew + 5,
+                createdAt: clock.millisecondsSinceEpoch,
               ),
             ],
           );
@@ -1389,10 +1410,35 @@ void main() {
 
           final result = await service.toggleVideoInGlobalBookmarks('video-b');
 
-          expect(result.succeeded, isFalse);
-          verifyNever(() => nostrClient.publishEventAwaitOk(any()));
+          expect(result.succeeded, isTrue);
+          expect(
+            signedCreatedAt,
+            nowSeconds + BookmarkService.maxPublishFutureSkew,
+          );
         },
       );
+
+      test('stays monotonic across two publishes in the same second', () async {
+        stubRelay(events: []);
+        final service = createService(now: () => clock);
+
+        expect(
+          (await service.toggleVideoInGlobalBookmarks('video-a')).succeeded,
+          isTrue,
+        );
+        final first = signedCreatedAt!;
+
+        expect(
+          (await service.toggleVideoInGlobalBookmarks('video-b')).succeeded,
+          isTrue,
+        );
+
+        expect(
+          signedCreatedAt,
+          greaterThan(first),
+          reason: 'the clock has not moved, so the revision has to carry it',
+        );
+      });
     });
 
     group('NIP-51 private items', () {

--- a/mobile/test/services/bookmark_service_test.dart
+++ b/mobile/test/services/bookmark_service_test.dart
@@ -16,6 +16,7 @@ import 'package:nostr_sdk/relay/publish_outcome.dart';
 import 'package:openvine/services/auth/nostr_identity.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/bookmark_service.dart';
+import 'package:openvine/utils/nostr_timestamp.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class _MockNostrClient extends Mock implements NostrClient {}
@@ -45,6 +46,7 @@ void main() {
     /// The tags of the last kind-10003 handed to the signer.
     List<List<String>>? signedTags;
     String? signedContent;
+    int? signedCreatedAt;
 
     Event bookmarkListEvent(
       List<String> eventIds, {
@@ -175,6 +177,7 @@ void main() {
       authService = _MockAuthService();
       signedTags = null;
       signedContent = null;
+      signedCreatedAt = null;
 
       SharedPreferences.setMockInitialValues({});
       prefs = await SharedPreferences.getInstance();
@@ -189,16 +192,19 @@ void main() {
           kind: any(named: 'kind'),
           content: any(named: 'content'),
           tags: any(named: 'tags'),
+          createdAt: any(named: 'createdAt'),
         ),
       ).thenAnswer((invocation) async {
         signedTags =
             invocation.namedArguments[#tags] as List<List<String>>? ?? [];
         signedContent = invocation.namedArguments[#content] as String?;
+        signedCreatedAt = invocation.namedArguments[#createdAt] as int?;
         return Event(
           pubkey,
           invocation.namedArguments[#kind] as int,
           signedTags!,
           signedContent!,
+          createdAt: signedCreatedAt,
         );
       });
 
@@ -469,13 +475,25 @@ void main() {
             ['e', 'their-private-one'],
           ]);
           var clock = DateTime(2026);
+          // Contemporaneous with the injected clock: left at the SDK's
+          // real-wall-clock default the event sits months ahead of it, a skew
+          // no relay would serve and one the publish path now declines (#7629).
+          final theirRevisionAt = clock.millisecondsSinceEpoch ~/ 1000;
           final service = createService(now: () => clock);
 
           stubRelay(events: []);
           await service.syncGlobalBookmarks();
 
           clock = clock.add(const Duration(minutes: 1));
-          stubRelay(events: [bookmarkListEvent([], content: ciphertext)]);
+          stubRelay(
+            events: [
+              bookmarkListEvent(
+                [],
+                content: ciphertext,
+                createdAt: theirRevisionAt,
+              ),
+            ],
+          );
           await service.syncGlobalBookmarks();
 
           clock = clock.add(const Duration(minutes: 1));
@@ -489,7 +507,15 @@ void main() {
 
           // The unconfirmed empty must not have reached the content, so a
           // publish still carries the other client's private items.
-          stubRelay(events: [bookmarkListEvent([], content: ciphertext)]);
+          stubRelay(
+            events: [
+              bookmarkListEvent(
+                [],
+                content: ciphertext,
+                createdAt: theirRevisionAt,
+              ),
+            ],
+          );
           await service.addToGlobalBookmarks(
             const BookmarkItem(type: 'e', id: 'mine'),
           );
@@ -1294,6 +1320,79 @@ void main() {
           lower.tags.first[1],
         ]);
       });
+    });
+
+    group('publish timestamps', () {
+      final clock = DateTime.utc(2026);
+      final nowSeconds = clock.millisecondsSinceEpoch ~/ 1000;
+      final drift = NostrTimestamp.getDriftToleranceForKind(
+        BookmarkService.globalBookmarksKind,
+      );
+
+      test(
+        'backdates for relay clock drift when there is nothing to supersede',
+        () async {
+          stubRelay(events: []);
+          final service = createService(now: () => clock);
+
+          expect(
+            (await service.toggleVideoInGlobalBookmarks('video-a')).succeeded,
+            isTrue,
+          );
+
+          expect(signedCreatedAt, nowSeconds - drift);
+        },
+      );
+
+      test(
+        'steps past a revision a non-backdating client left behind',
+        () async {
+          // NIP-51 interop: a client that stamps exact wall clock leaves the
+          // current revision newer than this device's backdated stamp, and the
+          // relay keeps the higher created_at.
+          final theirs = bookmarkListEvent(
+            ['video-a'],
+            createdAt: nowSeconds - 5,
+          );
+          stubRelay(events: [theirs]);
+          final service = createService(now: () => clock);
+
+          expect(
+            (await service.toggleVideoInGlobalBookmarks('video-b')).succeeded,
+            isTrue,
+          );
+
+          expect(
+            signedCreatedAt,
+            theirs.createdAt + 1,
+            reason: 'a backdated stamp would lose the relay merge silently',
+          );
+        },
+      );
+
+      test(
+        'refuses to publish when it cannot stamp past the revision',
+        () async {
+          // Their clock runs far enough ahead that stepping past it would land
+          // outside what the relay accepts. Publishing anyway would be accepted
+          // and then discarded by the merge, while the user is told "Saved".
+          stubRelay(
+            events: [
+              bookmarkListEvent(
+                ['video-a'],
+                createdAt:
+                    nowSeconds + BookmarkService.maxPublishFutureSkew + 5,
+              ),
+            ],
+          );
+          final service = createService(now: () => clock);
+
+          final result = await service.toggleVideoInGlobalBookmarks('video-b');
+
+          expect(result.succeeded, isFalse);
+          verifyNever(() => nostrClient.publishEventAwaitOk(any()));
+        },
+      );
     });
 
     group('NIP-51 private items', () {

--- a/mobile/test/services/bookmark_service_test.dart
+++ b/mobile/test/services/bookmark_service_test.dart
@@ -477,7 +477,8 @@ void main() {
           var clock = DateTime(2026);
           // Contemporaneous with the injected clock: left at the SDK's
           // real-wall-clock default the event sits months ahead of it, a skew
-          // no relay would serve and one the publish path now declines (#7629).
+          // no relay would serve and one that would force the publish stamp to
+          // cap instead of exercising the ordinary carried-content path (#7629).
           final theirRevisionAt = clock.millisecondsSinceEpoch ~/ 1000;
           final service = createService(now: () => clock);
 
@@ -1370,9 +1371,9 @@ void main() {
         },
       );
 
-      test('steps past a revision that lands exactly on the cap', () async {
-        // The boundary is inclusive: this is still a stamp the relay accepts,
-        // so it must be used rather than treated as over the line.
+      test('steps to the cap when it still supersedes the revision', () async {
+        // Pins the boundary where the superseding stamp equals the cap: this
+        // publish should use the step-past value, not the backdated default.
         final theirs = bookmarkListEvent(
           ['video-a'],
           createdAt: nowSeconds + BookmarkService.maxPublishFutureSkew - 1,


### PR DESCRIPTION
## Description

Kind 10003 is stamped `now - 30s` by default (`NostrTimestamp.getDriftToleranceForKind` has no entry for 10003, so it takes the 30 s default, and `NostrTimestamp.now` subtracts it). The bookmark publish passed no `createdAt`, so `signer_factory` filled in that backdated value.

Against a NIP-51 client that does **not** backdate, this device can publish a list stamped *older* than the revision it just adopted:

1. Other client publishes at wall `t_O` -> `created_at = floor(t_O)`.
2. This device adopts it, so `_revision.createdAt = floor(t_O)`.
3. This device publishes at wall `t_A` -> `created_at = floor(t_A) - 30`.
4. Strictly older whenever `floor(t_A) - floor(t_O) < 30`.

The relay accepts it, but replaceable-event ordering keeps the higher timestamp and discards ours. `publishEventAwaitOk` reports success, the share sheet says **"Saved"**, and the write is gone. The next read re-adopts the other client's event, whose `created_at` is greater, so the staleness guard correctly lets it through and the bookmark visibly reverts. The display self-corrects; the write does not.

The write path always reconciles immediately before publishing, so the adopt->publish gap is one round trip. The condition reduces to "did a non-backdating client write this list in the last 30 seconds."

**This is third-party interop, not device-to-device.** Between two Divine devices the backdate cancels - both stamp `now - 30`, so strictly-older needs clock skew or a same-wall-clock-second tie, and that tie exists with or without the drift tolerance.

## Approach

Compute the stamp rather than letting it default. Normally it is the same backdated value; when the revision this device holds would otherwise win, step to `revision.createdAt + 1`.

The step is bounded deliberately. `_revision.createdAt` comes from another client's clock - exactly the one at issue. A publish goes to the whole relay pool and only needs `acceptedByAny`, so the bound is a best-effort pool-wide compromise: Divine's relay refuses `created_at` more than 60 s ahead, stricter relays may refuse sooner, and this device's clock is not the relay's either.

When `revision.createdAt + 1` would exceed the bound, publish at the cap instead of refusing. A capped stamp still beats the old backdated default everywhere the implausible revision is absent, so it is strictly better than the previous behavior and cannot lock this device out of writing. If the cap cannot actually supersede the held revision, the write may still be discarded by relay merge; that residual adoption-bound issue is tracked in #7643.

The stamp derives from the service's injected `now` rather than `NostrTimestamp.now()`, which reads `DateTime.now()` directly and no test can move. Production behavior is unchanged: `now` defaults to `DateTime.now`.

**Related Issue:** Closes #7629

## Out of Scope

- The per-instance limitations tracked in #7596 - `bookmarkServiceProvider` is `autoDispose` and read only via `.future`, so two live instances still race on the shared snapshot. #7598 persisted the revision watermark, which closes the sequential save/close/save case; the concurrent one and the local-publish grace window remain there.
- Generalizing the bounded replacement timestamp helper and bounding future revision adoption are tracked in #7643.

## Verification

- Local/pre-push validation on `75a5db3614`: analyzer clean, `test/services/bookmark_service_test.dart` passed.
- CI on `75a5db3614`: Mobile CI, analyze, format, generated files, all test shards, semantic PR, mergeability, and preview build all green.
- Added publish timestamp coverage for:
  - default backdating when there is no revision to supersede
  - stepping past a non-backdating client's revision
  - stepping to the cap when that still supersedes the revision
  - publishing capped against an implausibly future revision
  - monotonic same-second publishes
- The signer mock now forwards `createdAt`, and an existing fixture is anchored to its injected clock so that test continues to exercise the ordinary carried-content path instead of the capped branch.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
