### PR TITLE
fix(badges): let recipients get rid of unwanted badges

### DIFF
--- a/mobile/lib/blocs/badges/badges_cubit.dart
+++ b/mobile/lib/blocs/badges/badges_cubit.dart
@@ -46,19 +46,28 @@ class BadgesCubit extends Cubit<BadgesState> {
     );
   }
 
-  /// Locally hides an awarded badge without publishing anything.
-  Future<void> hideAward(BadgeAwardViewData award) {
-    return _runAction(
-      BadgeActionStatus.hiding,
-      () => _repository.hideAward(award.awardEventId),
-    );
+  /// Rejects an awarded badge: unpins it from the profile when it was
+  /// accepted, then hides it from the awarded list.
+  ///
+  /// Hiding alone would leave an accepted badge on the profile while it is
+  /// gone from the dashboard — the user asked to be rid of it, so both
+  /// halves have to go.
+  Future<void> rejectAward(BadgeAwardViewData award) {
+    return _runAction(BadgeActionStatus.hiding, () async {
+      if (award.isAccepted) await _repository.removeAward(award);
+      await _repository.hideAward(award.definitionCoordinate);
+    });
   }
 
   /// Restores a locally hidden award.
+  ///
+  /// Undoes the hiding only. A rejection that also unpinned the badge does
+  /// not re-pin it: restoring the row puts the accept decision back in the
+  /// user's hands rather than republishing their profile for them.
   Future<void> unhideAward(BadgeAwardViewData award) {
     return _runAction(
       BadgeActionStatus.hiding,
-      () => _repository.unhideAward(award.awardEventId),
+      () => _repository.unhideAward(award.definitionCoordinate),
     );
   }
 

--- a/mobile/lib/providers/repository_providers.dart
+++ b/mobile/lib/providers/repository_providers.dart
@@ -52,11 +52,16 @@ part 'repository_providers.g.dart';
 
 final badgeRepositoryProvider = Provider<BadgeRepository>((ref) {
   final authService = ref.watch(authServiceProvider);
+  final blocklistRepository = ref.watch(contentBlocklistRepositoryProvider);
   return BadgeRepository(
     nostrClient: ref.watch(nostrServiceProvider),
     sharedPreferences: ref.watch(sharedPreferencesProvider),
     currentPubkey: () => authService.currentPublicKeyHex,
     signEvent: authService.createAndSignEvent,
+    // Read through the repository rather than a snapshot: the hide buckets
+    // are mutated in place, so a block made after this provider was built
+    // still takes effect on the next badge load.
+    isHiddenPubkey: blocklistRepository.shouldFilterFromFeeds,
   );
 });
 

--- a/mobile/lib/screens/badges/badges_screen.dart
+++ b/mobile/lib/screens/badges/badges_screen.dart
@@ -413,13 +413,19 @@ class _AwardedBadgeCard extends StatelessWidget {
                   isLoading: actionStatus == BadgeActionStatus.removing,
                   onPressed: _isBusy ? null : () => cubit.removeAward(award),
                 )
-              else ...[
+              else
                 DivineButton(
                   label: context.l10n.badgesActionAccept,
                   size: DivineButtonSize.small,
                   isLoading: actionStatus == BadgeActionStatus.accepting,
                   onPressed: _isBusy ? null : () => cubit.acceptAward(award),
                 ),
+              // Offered for an accepted badge too: removing only unpins it,
+              // and the badge stays on the list until it is also rejected.
+              // Withheld when the award event is gone — the badge is pinned
+              // and unremovable anywhere else, so dismissing the row is the
+              // one thing that must not be possible.
+              if (award.hasAwardEvent)
                 DivineButton(
                   label: context.l10n.badgesActionReject,
                   type: DivineButtonType.secondary,
@@ -429,7 +435,6 @@ class _AwardedBadgeCard extends StatelessWidget {
                       ? null
                       : () => _hideWithUndo(context, award),
                 ),
-              ],
             ],
           ),
         ],
@@ -438,10 +443,10 @@ class _AwardedBadgeCard extends StatelessWidget {
   }
 }
 
-/// Hides [award] and offers an immediate way back.
+/// Rejects [award] and offers an immediate way back.
 ///
-/// Rejecting is local and publishes nothing, so without an undo a mistap
-/// would strand the badge until the issuer awarded it again.
+/// Without an undo a mistap would strand the badge in the hidden section,
+/// so the way back is offered right where the mistake happened.
 Future<void> _hideWithUndo(
   BuildContext context,
   BadgeAwardViewData award,
@@ -450,7 +455,7 @@ Future<void> _hideWithUndo(
   final messenger = ScaffoldMessenger.of(context);
   final l10n = context.l10n;
 
-  await cubit.hideAward(award);
+  await cubit.rejectAward(award);
   if (cubit.state.actionStatus != BadgeActionStatus.completed) return;
 
   messenger.showSnackBar(

--- a/mobile/packages/badge_repository/lib/src/badge_repository.dart
+++ b/mobile/packages/badge_repository/lib/src/badge_repository.dart
@@ -7,6 +7,14 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 typedef BadgeCurrentPubkeyReader = String? Function();
 
+/// Whether [pubkey] is hidden for the current user — blocked, muted, or on
+/// the platform blocklist.
+///
+/// A function rather than the blocklist repository itself: a repository does
+/// not depend on another repository, and the app layer already owns the
+/// canonical hide set.
+typedef BadgeHiddenPubkeyReader = bool Function(String pubkey);
+
 // Trust-safety bulk actions must stay bounded even when a public badge is
 // claimed by a very large group. These limits keep relay/cache reads finite:
 // first discover the newest claim events, then verify latest profile-badge
@@ -180,20 +188,58 @@ class ProfileBadgeViewData {
 }
 
 class BadgeAwardViewData {
-  const BadgeAwardViewData({
-    required this.award,
+  /// A badge delivered by an award event addressed to the user.
+  BadgeAwardViewData({
+    required Nip58BadgeAward award,
     this.definition,
     this.isAccepted = false,
     this.isHidden = false,
-  });
+  }) : award = award,
+       definitionCoordinate = award.definitionCoordinate,
+       awardEventId = award.event.id,
+       awardedAt = award.event.createdAt;
 
-  final Nip58BadgeAward award;
+  /// A badge pinned to the user's own profile whose award event could not
+  /// be found.
+  ///
+  /// The award is the issuer's event, so it can disappear — a deletion
+  /// request, a banned account, a relay that no longer carries it — while
+  /// the pin, which is the user's own event, stays. Without this the badge
+  /// renders on their profile with no row anywhere to take it down from.
+  const BadgeAwardViewData.pinnedWithoutAward({
+    required this.definitionCoordinate,
+    required this.awardEventId,
+    required this.awardedAt,
+    this.definition,
+  }) : award = null,
+       isAccepted = true,
+       // A pin cannot be dismissed: hiding the row is what stranded the
+       // badge in the first place.
+       isHidden = false;
+
+  /// Null when the award event backing this badge could not be found.
+  final Nip58BadgeAward? award;
+
   final Nip58BadgeDefinition? definition;
   final bool isAccepted;
   final bool isHidden;
 
-  String get awardEventId => award.event.id;
-  String get definitionCoordinate => award.definitionCoordinate;
+  /// Address of the badge, which survives the award event going missing.
+  final String definitionCoordinate;
+
+  final String awardEventId;
+
+  /// When the badge arrived — the award's timestamp, or the pin's when the
+  /// award is gone. Orders the awarded list.
+  final int awardedAt;
+
+  /// Whether the award event behind this badge was found.
+  ///
+  /// False means the only action that makes sense is removing it: it is
+  /// already pinned, and dismissing the row would hide it while leaving it
+  /// on the profile.
+  bool get hasAwardEvent => award != null;
+
   String get displayName =>
       definition?.name ?? _definitionNameFromCoordinate(definitionCoordinate);
   String? get imageUrl => definition?.imageUrl;
@@ -261,15 +307,21 @@ class BadgeRepository {
     required SharedPreferences sharedPreferences,
     required BadgeCurrentPubkeyReader currentPubkey,
     required BadgeEventSigner signEvent,
+    BadgeHiddenPubkeyReader? isHiddenPubkey,
   }) : _nostrClient = nostrClient,
        _sharedPreferences = sharedPreferences,
        _currentPubkey = currentPubkey,
-       _signEvent = signEvent;
+       _signEvent = signEvent,
+       _isHiddenPubkey = isHiddenPubkey;
 
   final NostrClient _nostrClient;
   final SharedPreferences _sharedPreferences;
   final BadgeCurrentPubkeyReader _currentPubkey;
   final BadgeEventSigner _signEvent;
+
+  /// Null leaves awards unfiltered, which is what an anonymous or test
+  /// repository wants — there is no blocklist to consult.
+  final BadgeHiddenPubkeyReader? _isHiddenPubkey;
 
   /// The profile badge list this repository last published, and whose it is.
   ///
@@ -325,7 +377,6 @@ class BadgeRepository {
     _DashboardLookupMemo memo,
   ) async {
     final pubkey = _requireCurrentPubkey();
-    final dismissedAwardIds = _dismissedAwardIds(pubkey);
     final awardsFuture = _queryAwardsForRecipient(pubkey);
     final profileBadgesFuture = memo.profileBadges(
       pubkey,
@@ -340,10 +391,6 @@ class BadgeRepository {
     final awards = results[0]! as List<Nip58BadgeAward>;
     final profileBadges = results[1] as Nip58ProfileBadges?;
 
-    final definitions = await _definitionsByCoordinate(memo, [
-      for (final award in awards) award.definitionCoordinate,
-    ]);
-
     // Newest award per badge, the same rule the issued list uses: being
     // awarded a badge twice is normal, and listing both leaves one row that
     // can never resolve.
@@ -356,20 +403,75 @@ class BadgeRepository {
       }
     }
 
-    final viewData =
-        [
-          for (final award in newestPerCoordinate.values)
-            BadgeAwardViewData(
-              award: award,
-              definition: definitions[award.definitionCoordinate],
-              isAccepted: _containsBadgeCoordinate(profileBadges, award),
-              isHidden: dismissedAwardIds.contains(award.event.id),
-            ),
-        ]..sort(
-          (left, right) =>
-              right.award.event.createdAt.compareTo(left.award.event.createdAt),
-        );
+    final pinnedWithoutAward = _pinnedWithoutAward(
+      profileBadges,
+      newestPerCoordinate.keys.toSet(),
+    );
+
+    final dismissedCoordinates = await _dismissedCoordinates(pubkey, awards);
+    final definitions = await _definitionsByCoordinate(memo, [
+      for (final award in awards) award.definitionCoordinate,
+      for (final ref in pinnedWithoutAward) ref.definitionCoordinate,
+    ]);
+
+    final isHiddenPubkey = _isHiddenPubkey;
+    final viewData = <BadgeAwardViewData>[];
+    for (final award in newestPerCoordinate.values) {
+      final isAccepted = _containsBadgeCoordinate(profileBadges, award);
+      // An award lands on you without your consent, so an account you
+      // blocked can keep handing you badges. Dropping them is what makes
+      // blocking the account the answer to unwanted badges, instead of
+      // dismissing each one by hand forever. An accepted award stays: it is
+      // pinned to the user's own profile, and hiding the row would strand it
+      // there with no way to take it down.
+      if (!isAccepted && (isHiddenPubkey?.call(award.event.pubkey) ?? false)) {
+        continue;
+      }
+      viewData.add(
+        BadgeAwardViewData(
+          award: award,
+          definition: definitions[award.definitionCoordinate],
+          isAccepted: isAccepted,
+          isHidden: dismissedCoordinates.contains(award.definitionCoordinate),
+        ),
+      );
+    }
+    for (final ref in pinnedWithoutAward) {
+      viewData.add(
+        BadgeAwardViewData.pinnedWithoutAward(
+          definitionCoordinate: ref.definitionCoordinate,
+          awardEventId: ref.awardEventId,
+          // The pin is the only event left to date this by.
+          awardedAt: profileBadges?.event.createdAt ?? 0,
+          definition: definitions[ref.definitionCoordinate],
+        ),
+      );
+    }
+
+    viewData.sort(
+      (left, right) => right.awardedAt.compareTo(left.awardedAt),
+    );
     return List<BadgeAwardViewData>.unmodifiable(viewData);
+  }
+
+  /// The badges pinned to [profileBadges] that no award in
+  /// [coordinatesWithAward] backs.
+  ///
+  /// Deduplicated by coordinate: the list is another client's event and can
+  /// name the same badge twice, which would render two rows that both
+  /// remove the same pin.
+  static List<Nip58ProfileBadgeRef> _pinnedWithoutAward(
+    Nip58ProfileBadges? profileBadges,
+    Set<String> coordinatesWithAward,
+  ) {
+    final seen = <String>{};
+    return [
+      for (final ref in profileBadges?.badges ?? const <Nip58ProfileBadgeRef>[])
+        if (ref.definitionCoordinate.isNotEmpty &&
+            !coordinatesWithAward.contains(ref.definitionCoordinate) &&
+            seen.add(ref.definitionCoordinate))
+          ref,
+    ];
   }
 
   Future<List<ProfileBadgeViewData>> loadAcceptedBadgesForProfile(
@@ -982,8 +1084,8 @@ class BadgeRepository {
   Future<void> acceptAward(BadgeAwardViewData award) async {
     final pubkey = _requireCurrentPubkey();
     final currentProfileBadges = await _latestProfileBadges(pubkey);
-    final coordinate = award.award.definitionCoordinate;
-    final awardEventId = award.award.event.id;
+    final coordinate = award.definitionCoordinate;
+    final awardEventId = award.awardEventId;
     final current =
         currentProfileBadges?.badges ?? const <Nip58ProfileBadgeRef>[];
 
@@ -1025,34 +1127,35 @@ class BadgeRepository {
     final refs =
         (currentProfileBadges?.badges ?? const <Nip58ProfileBadgeRef>[])
             .where(
-              (ref) =>
-                  ref.definitionCoordinate != award.award.definitionCoordinate,
+              (ref) => ref.definitionCoordinate != award.definitionCoordinate,
             )
             .toList(growable: false);
 
     await _publishProfileBadges(refs);
   }
 
-  /// Brings a dismissed award back into the awarded list.
-  Future<void> unhideAward(String awardEventId) async {
+  /// Brings the dismissed badge at [definitionCoordinate] back into the
+  /// awarded list.
+  Future<void> unhideAward(String definitionCoordinate) async {
     final pubkey = _requireCurrentPubkey();
-    final dismissed = _dismissedAwardIds(pubkey);
-    if (dismissed.remove(awardEventId)) {
-      await _sharedPreferences.setStringList(
-        _dismissedAwardsKey(pubkey),
-        dismissed.toList(growable: false),
-      );
+    final dismissed = _storedDismissedCoordinates(pubkey);
+    if (dismissed.remove(definitionCoordinate)) {
+      await _writeDismissedCoordinates(pubkey, dismissed);
     }
   }
 
-  Future<void> hideAward(String awardEventId) async {
+  /// Dismisses the badge at [definitionCoordinate] for the current user.
+  ///
+  /// Keyed on the badge, not on the award event that delivered it: the
+  /// awarded list shows one row per badge — the newest award wins — so a
+  /// dismissal keyed on an event id died the moment the same badge was
+  /// awarded again, which is exactly what an account handing out unwanted
+  /// badges does.
+  Future<void> hideAward(String definitionCoordinate) async {
     final pubkey = _requireCurrentPubkey();
-    final dismissed = _dismissedAwardIds(pubkey);
-    if (dismissed.add(awardEventId)) {
-      await _sharedPreferences.setStringList(
-        _dismissedAwardsKey(pubkey),
-        dismissed.toList(growable: false),
-      );
+    final dismissed = _storedDismissedCoordinates(pubkey);
+    if (dismissed.add(definitionCoordinate)) {
+      await _writeDismissedCoordinates(pubkey, dismissed);
     }
   }
 
@@ -1283,10 +1386,61 @@ class BadgeRepository {
     return event;
   }
 
-  Set<String> _dismissedAwardIds(String pubkey) {
-    return (_sharedPreferences.getStringList(_dismissedAwardsKey(pubkey)) ??
+  Set<String> _storedDismissedCoordinates(String pubkey) {
+    return (_sharedPreferences.getStringList(
+              _dismissedCoordinatesKey(pubkey),
+            ) ??
             const <String>[])
         .toSet();
+  }
+
+  Future<void> _writeDismissedCoordinates(
+    String pubkey,
+    Set<String> coordinates,
+  ) {
+    return _sharedPreferences.setStringList(
+      _dismissedCoordinatesKey(pubkey),
+      coordinates.toList(growable: false),
+    );
+  }
+
+  /// The dismissed badge coordinates, absorbing dismissals still stored
+  /// under the older award-event key.
+  ///
+  /// Dismissals used to be keyed on the award event id. Rewriting them here
+  /// rather than dropping them keeps a rejection the user already made, and
+  /// each id is retired only once its award has actually been seen — an
+  /// award missing from this relay pass is left for a later load instead of
+  /// being discarded.
+  Future<Set<String>> _dismissedCoordinates(
+    String pubkey,
+    List<Nip58BadgeAward> awards,
+  ) async {
+    final dismissed = _storedDismissedCoordinates(pubkey);
+    final legacyIds =
+        (_sharedPreferences.getStringList(_dismissedAwardsKey(pubkey)) ??
+                const <String>[])
+            .toSet();
+    if (legacyIds.isEmpty) return dismissed;
+
+    final retired = <String>{};
+    for (final award in awards) {
+      if (legacyIds.contains(award.event.id)) {
+        retired.add(award.event.id);
+        dismissed.add(award.definitionCoordinate);
+      }
+    }
+    if (retired.isEmpty) return dismissed;
+
+    legacyIds.removeAll(retired);
+    await _writeDismissedCoordinates(pubkey, dismissed);
+    await (legacyIds.isEmpty
+        ? _sharedPreferences.remove(_dismissedAwardsKey(pubkey))
+        : _sharedPreferences.setStringList(
+            _dismissedAwardsKey(pubkey),
+            legacyIds.toList(growable: false),
+          ));
+    return dismissed;
   }
 
   String _requireCurrentPubkey() {
@@ -1351,6 +1505,11 @@ class BadgeRepository {
     return (kind: kind, pubkey: parts[1], dTag: parts.sublist(2).join(':'));
   }
 
+  static String _dismissedCoordinatesKey(String pubkey) {
+    return 'dismissed_badge_coordinates_$pubkey';
+  }
+
+  /// Key of the retired per-award dismissal list, read only to migrate it.
   static String _dismissedAwardsKey(String pubkey) {
     return 'dismissed_badge_awards_$pubkey';
   }

--- a/mobile/packages/badge_repository/lib/src/badge_repository.dart
+++ b/mobile/packages/badge_repository/lib/src/badge_repository.dart
@@ -432,7 +432,16 @@ class BadgeRepository {
           award: award,
           definition: definitions[award.definitionCoordinate],
           isAccepted: isAccepted,
-          isHidden: dismissedCoordinates.contains(award.definitionCoordinate),
+          // A pinned badge is never hidden, the same rule
+          // [BadgeAwardViewData.pinnedWithoutAward] hardcodes: the hidden
+          // section only offers a way back, so hiding a pinned badge leaves
+          // it on the profile with no row that can take it down. Rejecting
+          // unpins first, so this only bites on a dismissal made before it
+          // did — a legacy per-award one migrating onto a badge accepted
+          // since, or one carried over from another device.
+          isHidden:
+              !isAccepted &&
+              dismissedCoordinates.contains(award.definitionCoordinate),
         ),
       );
     }

--- a/mobile/packages/badge_repository/lib/src/badge_repository.dart
+++ b/mobile/packages/badge_repository/lib/src/badge_repository.dart
@@ -457,9 +457,14 @@ class BadgeRepository {
       );
     }
 
-    viewData.sort(
-      (left, right) => right.awardedAt.compareTo(left.awardedAt),
-    );
+    viewData.sort((left, right) {
+      final byRecency = right.awardedAt.compareTo(left.awardedAt);
+      if (byRecency != 0) return byRecency;
+      // Pinned-without-award rows all carry the profile list's timestamp,
+      // so tie-break on the coordinate to keep the order stable across
+      // loads rather than leaving equal timestamps to a non-stable sort.
+      return left.definitionCoordinate.compareTo(right.definitionCoordinate);
+    });
     return List<BadgeAwardViewData>.unmodifiable(viewData);
   }
 

--- a/mobile/packages/badge_repository/test/src/badge_repository_test.dart
+++ b/mobile/packages/badge_repository/test/src/badge_repository_test.dart
@@ -80,7 +80,7 @@ void main() {
       final awards = await repository.loadAwardedBadges();
 
       expect(awards, hasLength(1));
-      expect(awards.single.award.event.id, _eventId(1));
+      expect(awards.single.awardEventId, _eventId(1));
       expect(awards.single.isAccepted, isTrue);
       expect(awards.single.definition?.name, 'Diviner of the Day');
       expect(awards.single.isHidden, isFalse);
@@ -346,6 +346,104 @@ void main() {
       },
     );
 
+    group('a badge pinned without a reachable award', () {
+      final coordinate = '30009:${_pubkey(3)}:unwanted';
+
+      void stubPinOnly() {
+        _stubQueries(nostrClient, {
+          'awarded': const [],
+          'profileCurrent:${_pubkey(1)}': [
+            _profileBadgesEvent(
+              id: _eventId(50),
+              pubkey: _pubkey(1),
+              createdAt: 4000,
+              tags: [
+                ['a', coordinate],
+                ['e', _eventId(51)],
+              ],
+            ),
+          ],
+        });
+      }
+
+      test('is still listed so it can be taken off the profile', () async {
+        stubPinOnly();
+
+        final awards = await repository.loadAwardedBadges();
+
+        expect(awards.single.definitionCoordinate, coordinate);
+        expect(awards.single.awardEventId, _eventId(51));
+        expect(awards.single.isAccepted, isTrue);
+        expect(awards.single.hasAwardEvent, isFalse);
+        expect(awards.single.awardedAt, 4000);
+      });
+
+      test('cannot be dismissed, only removed', () async {
+        stubPinOnly();
+
+        await repository.hideAward(coordinate);
+
+        expect((await repository.loadAwardedBadges()).single.isHidden, isFalse);
+      });
+
+      test('removeAward unpins it', () async {
+        stubPinOnly();
+        final award = (await repository.loadAwardedBadges()).single;
+
+        await repository.removeAward(award);
+
+        expect(lastSignedEvent()!.tags, isEmpty);
+      });
+
+      test('is not listed twice when the pin names it twice', () async {
+        _stubQueries(nostrClient, {
+          'awarded': const [],
+          'profileCurrent:${_pubkey(1)}': [
+            _profileBadgesEvent(
+              id: _eventId(52),
+              pubkey: _pubkey(1),
+              tags: [
+                ['a', coordinate],
+                ['e', _eventId(51)],
+                ['a', coordinate],
+                ['e', _eventId(53)],
+              ],
+            ),
+          ],
+        });
+
+        expect(await repository.loadAwardedBadges(), hasLength(1));
+      });
+
+      test('gives way to the award once it is reachable again', () async {
+        _stubQueries(nostrClient, {
+          'awarded': [
+            _awardEvent(
+              id: _eventId(51),
+              issuerPubkey: _pubkey(3),
+              definitionCoordinate: coordinate,
+              recipients: [_pubkey(1)],
+            ),
+          ],
+          'profileCurrent:${_pubkey(1)}': [
+            _profileBadgesEvent(
+              id: _eventId(50),
+              pubkey: _pubkey(1),
+              tags: [
+                ['a', coordinate],
+                ['e', _eventId(51)],
+              ],
+            ),
+          ],
+        });
+
+        final awards = await repository.loadAwardedBadges();
+
+        expect(awards, hasLength(1));
+        expect(awards.single.hasAwardEvent, isTrue);
+      });
+    });
+
     test('hideAward stores a local per-user dismissal', () async {
       final award = _awardEvent(
         id: _eventId(11),
@@ -357,15 +455,194 @@ void main() {
         'awarded': [award],
       });
 
-      await repository.hideAward(_eventId(11));
+      await repository.hideAward('30009:${_pubkey(2)}:daily-diviner');
 
       // Still returned, flagged rather than dropped, so it can be restored.
       final awards = await repository.loadAwardedBadges();
       expect(awards.single.isHidden, isTrue);
       expect(
-        preferences.getStringList('dismissed_badge_awards_${_pubkey(1)}'),
-        [_eventId(11)],
+        preferences.getStringList(
+          'dismissed_badge_coordinates_${_pubkey(1)}',
+        ),
+        ['30009:${_pubkey(2)}:daily-diviner'],
       );
+    });
+
+    test('hideAward survives the same badge being awarded again', () async {
+      final coordinate = '30009:${_pubkey(2)}:daily-diviner';
+      final first = _awardEvent(
+        id: _eventId(11),
+        issuerPubkey: _pubkey(2),
+        definitionCoordinate: coordinate,
+        recipients: [_pubkey(1)],
+      );
+      final reAward = _awardEvent(
+        id: _eventId(12),
+        issuerPubkey: _pubkey(2),
+        definitionCoordinate: coordinate,
+        recipients: [_pubkey(1)],
+        createdAt: 2000,
+      );
+      _stubQueries(nostrClient, {
+        'awarded': [first],
+      });
+      await repository.hideAward(coordinate);
+
+      _stubQueries(nostrClient, {
+        'awarded': [first, reAward],
+      });
+
+      final awards = await repository.loadAwardedBadges();
+      expect(awards.single.awardEventId, _eventId(12));
+      expect(awards.single.isHidden, isTrue);
+    });
+
+    test('a dismissal stored per award event migrates to its badge', () async {
+      final coordinate = '30009:${_pubkey(2)}:daily-diviner';
+      final dismissed = _awardEvent(
+        id: _eventId(13),
+        issuerPubkey: _pubkey(2),
+        definitionCoordinate: coordinate,
+        recipients: [_pubkey(1)],
+      );
+      final reAward = _awardEvent(
+        id: _eventId(14),
+        issuerPubkey: _pubkey(2),
+        definitionCoordinate: coordinate,
+        recipients: [_pubkey(1)],
+        createdAt: 2000,
+      );
+      await preferences.setStringList('dismissed_badge_awards_${_pubkey(1)}', [
+        _eventId(13),
+      ]);
+      _stubQueries(nostrClient, {
+        'awarded': [dismissed, reAward],
+      });
+
+      final awards = await repository.loadAwardedBadges();
+
+      expect(awards.single.isHidden, isTrue);
+      expect(
+        preferences.getStringList(
+          'dismissed_badge_coordinates_${_pubkey(1)}',
+        ),
+        [coordinate],
+      );
+      expect(
+        preferences.getStringList('dismissed_badge_awards_${_pubkey(1)}'),
+        isNull,
+      );
+    });
+
+    test('a dismissal whose award is unavailable is kept for later', () async {
+      await preferences.setStringList('dismissed_badge_awards_${_pubkey(1)}', [
+        _eventId(15),
+      ]);
+
+      await repository.loadAwardedBadges();
+
+      expect(
+        preferences.getStringList('dismissed_badge_awards_${_pubkey(1)}'),
+        [_eventId(15)],
+      );
+    });
+
+    test('migrating one dismissal leaves the unresolved one behind', () async {
+      final coordinate = '30009:${_pubkey(2)}:daily-diviner';
+      await preferences.setStringList('dismissed_badge_awards_${_pubkey(1)}', [
+        _eventId(18),
+        _eventId(19),
+      ]);
+      _stubQueries(nostrClient, {
+        'awarded': [
+          _awardEvent(
+            id: _eventId(18),
+            issuerPubkey: _pubkey(2),
+            definitionCoordinate: coordinate,
+            recipients: [_pubkey(1)],
+          ),
+        ],
+      });
+
+      await repository.loadAwardedBadges();
+
+      expect(
+        preferences.getStringList(
+          'dismissed_badge_coordinates_${_pubkey(1)}',
+        ),
+        [coordinate],
+      );
+      expect(
+        preferences.getStringList('dismissed_badge_awards_${_pubkey(1)}'),
+        [_eventId(19)],
+      );
+    });
+
+    group('a hidden issuer', () {
+      late BadgeRepository blocked;
+
+      setUp(() {
+        blocked = BadgeRepository(
+          nostrClient: nostrClient,
+          sharedPreferences: preferences,
+          currentPubkey: () => _pubkey(1),
+          signEvent: ({required kind, required content, required tags}) async =>
+              null,
+          isHiddenPubkey: (pubkey) => pubkey == _pubkey(3),
+        );
+      });
+
+      test('has its unaccepted awards dropped', () async {
+        _stubQueries(nostrClient, {
+          'awarded': [
+            _awardEvent(
+              id: _eventId(16),
+              issuerPubkey: _pubkey(2),
+              definitionCoordinate: '30009:${_pubkey(2)}:daily-diviner',
+              recipients: [_pubkey(1)],
+            ),
+            _awardEvent(
+              id: _eventId(17),
+              issuerPubkey: _pubkey(3),
+              definitionCoordinate: '30009:${_pubkey(3)}:unwanted',
+              recipients: [_pubkey(1)],
+            ),
+          ],
+        });
+
+        final awards = await blocked.loadAwardedBadges();
+
+        expect(awards.single.awardEventId, _eventId(16));
+      });
+
+      test('keeps an award the user already accepted', () async {
+        final coordinate = '30009:${_pubkey(3)}:unwanted';
+        _stubQueries(nostrClient, {
+          'awarded': [
+            _awardEvent(
+              id: _eventId(17),
+              issuerPubkey: _pubkey(3),
+              definitionCoordinate: coordinate,
+              recipients: [_pubkey(1)],
+            ),
+          ],
+          'profileCurrent:${_pubkey(1)}': [
+            _profileBadgesEvent(
+              id: _eventId(18),
+              pubkey: _pubkey(1),
+              tags: [
+                ['a', coordinate],
+                ['e', _eventId(17)],
+              ],
+            ),
+          ],
+        });
+
+        final awards = await blocked.loadAwardedBadges();
+
+        // Pinned to the profile, so it has to stay reachable to be removed.
+        expect(awards.single.isAccepted, isTrue);
+      });
     });
 
     test('loadAwardedBadges loads each unique definition once', () async {
@@ -592,7 +869,9 @@ void main() {
 
         final awards = await repository.loadAwardedBadges();
 
-        expect(awards.single.isAccepted, isFalse);
+        // The winning list pins a different badge, so this one is unaccepted.
+        // That other pin has no award event and is listed on its own.
+        expect(_byCoordinate(awards, coordinate).isAccepted, isFalse);
       },
     );
 
@@ -757,7 +1036,9 @@ void main() {
 
         final awards = await repository.loadAwardedBadges();
 
-        expect(awards.single.isAccepted, isFalse);
+        // The winning list pins a different badge, so this one is unaccepted.
+        // That other pin has no award event and is listed on its own.
+        expect(_byCoordinate(awards, coordinate).isAccepted, isFalse);
       },
     );
 
@@ -1450,22 +1731,26 @@ void main() {
             ),
           ],
         });
-        await repository.hideAward(_eventId(84));
+        await repository.hideAward('30009:${_pubkey(2)}:daily-diviner');
 
-        await repository.unhideAward(_eventId(84));
+        await repository.unhideAward('30009:${_pubkey(2)}:daily-diviner');
 
         expect((await repository.loadAwardedBadges()).single.isHidden, isFalse);
         expect(
-          preferences.getStringList('dismissed_badge_awards_${_pubkey(1)}'),
+          preferences.getStringList(
+            'dismissed_badge_coordinates_${_pubkey(1)}',
+          ),
           isEmpty,
         );
       });
 
-      test('does nothing for an award that was never dismissed', () async {
-        await repository.unhideAward(_eventId(85));
+      test('does nothing for a badge that was never dismissed', () async {
+        await repository.unhideAward('30009:${_pubkey(2)}:weekly-diviner');
 
         expect(
-          preferences.getStringList('dismissed_badge_awards_${_pubkey(1)}'),
+          preferences.getStringList(
+            'dismissed_badge_coordinates_${_pubkey(1)}',
+          ),
           isNull,
         );
       });
@@ -1480,7 +1765,7 @@ void main() {
         );
 
         await expectLater(
-          anonymous.unhideAward(_eventId(86)),
+          anonymous.unhideAward('30009:${_pubkey(2)}:daily-diviner'),
           throwsA(isA<StateError>()),
         );
       });
@@ -1503,7 +1788,7 @@ void main() {
           ),
         ],
       });
-      await repository.hideAward(_eventId(88));
+      await repository.hideAward('30009:${_pubkey(2)}:weekly-diviner');
 
       final dashboard = await repository.loadDashboard();
 
@@ -2728,6 +3013,15 @@ Event _event({
 }
 
 const _artworkUrl = 'https://media.divine.video/scene.png';
+
+BadgeAwardViewData _byCoordinate(
+  List<BadgeAwardViewData> awards,
+  String coordinate,
+) {
+  return awards.firstWhere(
+    (award) => award.definitionCoordinate == coordinate,
+  );
+}
 
 String _eventId(int seed) => seed.toRadixString(16).padLeft(64, '0');
 

--- a/mobile/packages/badge_repository/test/src/badge_repository_test.dart
+++ b/mobile/packages/badge_repository/test/src/badge_repository_test.dart
@@ -976,8 +976,10 @@ void main() {
 
         final awards = await repository.loadAwardedBadges();
 
-        // The winning list pins a different badge, so this one is unaccepted.
-        // That other pin has no award event and is listed on its own.
+        // The list is length 2: the winning list pins a different badge,
+        // so this one is unaccepted, and that other pin has no award event
+        // and is listed on its own.
+        expect(awards, hasLength(2));
         expect(_byCoordinate(awards, coordinate).isAccepted, isFalse);
       },
     );
@@ -1143,8 +1145,10 @@ void main() {
 
         final awards = await repository.loadAwardedBadges();
 
-        // The winning list pins a different badge, so this one is unaccepted.
-        // That other pin has no award event and is listed on its own.
+        // The list is length 2: the winning list pins a different badge,
+        // so this one is unaccepted, and that other pin has no award event
+        // and is listed on its own.
+        expect(awards, hasLength(2));
         expect(_byCoordinate(awards, coordinate).isAccepted, isFalse);
       },
     );

--- a/mobile/packages/badge_repository/test/src/badge_repository_test.dart
+++ b/mobile/packages/badge_repository/test/src/badge_repository_test.dart
@@ -442,6 +442,34 @@ void main() {
         expect(awards, hasLength(1));
         expect(awards.single.hasAwardEvent, isTrue);
       });
+
+      test('lists multiple orphan pins in a stable coordinate order', () async {
+        final issuer = _pubkey(3);
+        final coordA = '30009:$issuer:aaa';
+        final coordB = '30009:$issuer:bbb';
+        _stubQueries(nostrClient, {
+          'awarded': const [],
+          'profileCurrent:${_pubkey(1)}': [
+            _profileBadgesEvent(
+              id: _eventId(54),
+              pubkey: _pubkey(1),
+              tags: [
+                ['a', coordB],
+                ['e', _eventId(55)],
+                ['a', coordA],
+                ['e', _eventId(56)],
+              ],
+            ),
+          ],
+        });
+
+        final awards = await repository.loadAwardedBadges();
+
+        expect(
+          awards.map((award) => award.definitionCoordinate),
+          [coordA, coordB],
+        );
+      });
     });
 
     test('hideAward stores a local per-user dismissal', () async {

--- a/mobile/packages/badge_repository/test/src/badge_repository_test.dart
+++ b/mobile/packages/badge_repository/test/src/badge_repository_test.dart
@@ -534,6 +534,85 @@ void main() {
       );
     });
 
+    test('a dismissal never hides a badge pinned to the profile', () async {
+      // Reachable from data an older build left behind: reject award A,
+      // the issuer re-awards the badge as B, the old per-award dismissal
+      // no longer matches so the row comes back, the user accepts it. The
+      // migration then maps A onto the badge — and hiding it would strand
+      // the badge on the profile, since the hidden section only restores.
+      final coordinate = '30009:${_pubkey(2)}:daily-diviner';
+      await preferences.setStringList('dismissed_badge_awards_${_pubkey(1)}', [
+        _eventId(60),
+      ]);
+      _stubQueries(nostrClient, {
+        'awarded': [
+          _awardEvent(
+            id: _eventId(60),
+            issuerPubkey: _pubkey(2),
+            definitionCoordinate: coordinate,
+            recipients: [_pubkey(1)],
+          ),
+          _awardEvent(
+            id: _eventId(61),
+            issuerPubkey: _pubkey(2),
+            definitionCoordinate: coordinate,
+            recipients: [_pubkey(1)],
+            createdAt: 2000,
+          ),
+        ],
+        'profileCurrent:${_pubkey(1)}': [
+          _profileBadgesEvent(
+            id: _eventId(62),
+            pubkey: _pubkey(1),
+            createdAt: 3000,
+            tags: [
+              ['a', coordinate],
+              ['e', _eventId(61)],
+            ],
+          ),
+        ],
+      });
+
+      final awards = await repository.loadAwardedBadges();
+
+      expect(awards.single.isAccepted, isTrue);
+      expect(awards.single.isHidden, isFalse);
+    });
+
+    test(
+      'the dismissal takes effect again once the badge is unpinned',
+      () async {
+        final coordinate = '30009:${_pubkey(2)}:daily-diviner';
+        final award = _awardEvent(
+          id: _eventId(63),
+          issuerPubkey: _pubkey(2),
+          definitionCoordinate: coordinate,
+          recipients: [_pubkey(1)],
+        );
+        _stubQueries(nostrClient, {
+          'awarded': [award],
+          'profileCurrent:${_pubkey(1)}': [
+            _profileBadgesEvent(
+              id: _eventId(64),
+              pubkey: _pubkey(1),
+              tags: [
+                ['a', coordinate],
+                ['e', _eventId(63)],
+              ],
+            ),
+          ],
+        });
+        await repository.hideAward(coordinate);
+        expect((await repository.loadAwardedBadges()).single.isHidden, isFalse);
+
+        _stubQueries(nostrClient, {
+          'awarded': [award],
+        });
+
+        expect((await repository.loadAwardedBadges()).single.isHidden, isTrue);
+      },
+    );
+
     test('a dismissal whose award is unavailable is kept for later', () async {
       await preferences.setStringList('dismissed_badge_awards_${_pubkey(1)}', [
         _eventId(15),

--- a/mobile/test/blocs/badges/badges_cubit_test.dart
+++ b/mobile/test/blocs/badges/badges_cubit_test.dart
@@ -145,7 +145,7 @@ void main() {
     );
 
     blocTest<BadgesCubit, BadgesState>(
-      'hideAward stores dismissal by award event id then refreshes dashboard',
+      'rejectAward dismisses the badge then refreshes dashboard',
       setUp: () {
         when(() => repository.hideAward(any())).thenAnswer((_) async {});
         when(
@@ -163,7 +163,7 @@ void main() {
         status: BadgesStatus.loaded,
         awarded: [awardedBadge],
       ),
-      act: (cubit) => cubit.hideAward(awardedBadge),
+      act: (cubit) => cubit.rejectAward(awardedBadge),
       expect: () => [
         BadgesState(
           status: BadgesStatus.loaded,
@@ -176,7 +176,33 @@ void main() {
         ),
       ],
       verify: (_) {
-        verify(() => repository.hideAward(awardedBadge.awardEventId)).called(1);
+        verify(
+          () => repository.hideAward(awardedBadge.definitionCoordinate),
+        ).called(1);
+        verifyNever(() => repository.removeAward(any()));
+      },
+    );
+
+    blocTest<BadgesCubit, BadgesState>(
+      'rejectAward unpins an accepted badge before dismissing it',
+      setUp: () {
+        when(() => repository.hideAward(any())).thenAnswer((_) async {});
+        when(() => repository.removeAward(any())).thenAnswer((_) async {});
+        when(repository.loadDashboard).thenAnswer(
+          (_) async => const BadgeDashboardData(
+            awarded: [],
+            issued: [],
+            created: [],
+          ),
+        );
+      },
+      build: () => BadgesCubit(repository: repository),
+      act: (cubit) => cubit.rejectAward(_awardViewData(isAccepted: true)),
+      verify: (_) {
+        verifyInOrder([
+          () => repository.removeAward(any()),
+          () => repository.hideAward(awardedBadge.definitionCoordinate),
+        ]);
       },
     );
 
@@ -209,7 +235,7 @@ void main() {
       ],
       verify: (_) {
         verify(
-          () => repository.unhideAward(awardedBadge.awardEventId),
+          () => repository.unhideAward(awardedBadge.definitionCoordinate),
         ).called(1);
       },
     );
@@ -353,10 +379,11 @@ void main() {
   });
 }
 
-BadgeAwardViewData _awardViewData() {
+BadgeAwardViewData _awardViewData({bool isAccepted = false}) {
   final issuerPubkey = _pubkey(2);
   final definitionCoordinate = '30009:$issuerPubkey:daily-diviner';
   return BadgeAwardViewData(
+    isAccepted: isAccepted,
     award: Nip58BadgeAward(
       event: _event(
         id: _eventId(1),

--- a/mobile/test/screens/badges/badges_screen_test.dart
+++ b/mobile/test/screens/badges/badges_screen_test.dart
@@ -182,7 +182,71 @@ void main() {
       await tester.tap(find.text(l10n.badgesHiddenSnackbarUndo));
       await tester.pumpAndSettle();
 
-      verify(() => repository.unhideAward(awardedBadge.awardEventId)).called(1);
+      verify(
+        () => repository.unhideAward(awardedBadge.definitionCoordinate),
+      ).called(1);
+    });
+
+    testWidgets('an accepted award can be rejected, not only removed', (
+      tester,
+    ) async {
+      final accepted = _awardViewData(isAccepted: true);
+      when(repository.loadDashboard).thenAnswer(
+        (_) async => BadgeDashboardData(
+          awarded: [accepted],
+          issued: const [],
+          created: const [],
+        ),
+      );
+      when(() => repository.hideAward(any())).thenAnswer((_) async {});
+      when(() => repository.removeAward(any())).thenAnswer((_) async {});
+
+      await tester.pumpWidget(buildSubject());
+      await tester.pumpAndSettle();
+
+      expect(find.text(l10n.badgesActionRemove), findsOneWidget);
+      await tester.tap(find.text(l10n.badgesActionReject));
+      await tester.pumpAndSettle();
+
+      // Unpinned as well as dismissed: hiding alone would leave it on the
+      // profile while it is gone from the dashboard.
+      verify(() => repository.removeAward(accepted)).called(1);
+      verify(
+        () => repository.hideAward(accepted.definitionCoordinate),
+      ).called(1);
+    });
+
+    testWidgets('a badge pinned without an award can only be removed', (
+      tester,
+    ) async {
+      const coordinate = '30009:pinned-issuer:orphan';
+      when(repository.loadDashboard).thenAnswer(
+        (_) async => const BadgeDashboardData(
+          awarded: [
+            BadgeAwardViewData.pinnedWithoutAward(
+              definitionCoordinate: coordinate,
+              awardEventId: 'orphan-award',
+              awardedAt: 1000,
+            ),
+          ],
+          issued: [],
+          created: [],
+        ),
+      );
+      when(() => repository.removeAward(any())).thenAnswer((_) async {});
+
+      await tester.pumpWidget(buildSubject());
+      await tester.pumpAndSettle();
+
+      // Dismissing it would hide the only row that can take it off the
+      // profile, so the action is not offered.
+      expect(find.text(l10n.badgesActionReject), findsNothing);
+      expect(find.text(l10n.badgesActionAccept), findsNothing);
+
+      await tester.tap(find.text(l10n.badgesActionRemove));
+      await tester.pumpAndSettle();
+
+      verify(() => repository.removeAward(any())).called(1);
     });
 
     testWidgets('restores a dismissed award from the hidden section', (
@@ -209,7 +273,9 @@ void main() {
       await tester.tap(find.text(l10n.badgesActionRestore));
       await tester.pumpAndSettle();
 
-      verify(() => repository.unhideAward(awardedBadge.awardEventId)).called(1);
+      verify(
+        () => repository.unhideAward(awardedBadge.definitionCoordinate),
+      ).called(1);
     });
 
     testWidgets('accept button delegates to the repository', (tester) async {


### PR DESCRIPTION
## Description

A user reported being unable to remove badges awarded by accounts that appear to be blocked or deleted from the platform. Four defects combined to make an unwanted badge effectively permanent for the recipient. Each is small on its own; together they left no working way out.

**1. Rejecting did not survive a re-award.** The dismissal was stored under the *award event id*, but the awarded list shows one row per *badge* and the newest award wins. Handing the same badge out again produced an id the dismissed set had never seen, so the badge came straight back — and re-awarding is exactly what an account handing out unwanted badges does. The asymmetry was clearly unintended: acceptance was already resolved per coordinate (there is even a test named "marks a newer re-award accepted by coordinate"); only the dismissal was not. Reproduced as a failing test before fixing.

Dismissals now key on the badge coordinate, under a new `dismissed_badge_coordinates_<pubkey>` preference. Existing dismissals are rewritten rather than dropped, so nobody's rejections reset on upgrade. Each legacy id is retired only once its award has actually been seen in a load, so an award that is simply missing from one relay pass is left for a later pass instead of being discarded.

**2. Blocking the account did nothing to its badges.** No badge path consulted the blocklist, so the awarded list kept every badge from an account the user had already blocked. Blocking is the natural answer to "this account keeps sending me junk", and it did not work — leaving the user to dismiss each badge by hand, forever.

`BadgeRepository` now takes an optional hidden-pubkey reader, wired to `shouldFilterFromFeeds` (the canonical hide set: own block, mute, mutual mute, blocked-by-others, platform list). It is a **function rather than the blocklist repository** deliberately — `architecture.md` forbids a repository depending on another repository, and the app layer already owns that set. It matches the `BadgeCurrentPubkeyReader` typedef already sitting beside it.

The filter deliberately **spares awards the user already accepted**. An accepted badge is pinned to the user's own profile; dropping its row on block would hide the only control that can take it down — the same trap this PR exists to close.

**3. An accepted badge could not be rejected, only removed.** "Remove" only unpins it from the profile; the row stayed in the list until it was *also* rejected. Two overlapping actions, neither of which alone does what the label suggests, which reads as deletion being broken. Reject is now offered in both states, and unpins before hiding — otherwise the badge lingers on the profile while it is gone from the dashboard.

**4. A badge pinned to the profile whose award event is unreachable had no row at all.** The awarded list was built purely from `kind:8` awards, while the profile renders from the user's own `kind:10008` pin, which intentionally keeps refs whose award cannot be found. So a deleted, banned, or relay-dropped award left the badge visible on the profile with nothing anywhere in the app to take it down from. Confirmed with a throwaway test: `loadAwardedBadges` empty, `loadAcceptedBadgesForProfile` still returning the badge.

Such pins are now listed from the profile badge list, deduplicated by coordinate (the list is an event another client may have written and can name the same badge twice). They offer **removal only** — no accept, since it is already pinned, and no reject, since dismissing the row is what stranded the badge in the first place. That is enforced in two places: `isHidden` is pinned to `false` in the constructor, and the button hangs off `hasAwardEvent`.

This required `BadgeAwardViewData.definitionCoordinate` / `awardEventId` / `awardedAt` to become real fields rather than getters over a required `award`, so the badge's identity survives its award event going missing.

**5. A dismissal could land on a badge pinned to the profile.** The hidden section only offers a way back, so hiding a pinned badge leaves it on the profile with no row that can take it down — the same trap as defect 4, reachable from data an older build left behind: reject award A, the issuer re-awards the badge as B, the per-award dismissal no longer matches so the row returns, the user accepts it. Migrating A onto the coordinate then hides a badge that is pinned. Confirmed with a failing test before fixing.

`isHidden` now applies the rule `BadgeAwardViewData.pinnedWithoutAward` already hardcodes: a pinned badge is never hidden. Rejecting unpins before hiding, so the live path is unaffected, and the dismissal takes effect again once the badge is unpinned.

**Related Issue:** Closes #none

Very likely also fixes #7496 ("Badge Still Appears On Profile After Deleting it and Rejecting it") — that report accepted a badge, then deleted and rejected it, and it returned. Defects 1 and 3 both produce exactly that. Not auto-closing it, so the reporter can confirm on their own device first.

Related: #7071 (bulk block/mute of badge claimants) shares the trust-and-safety motivation but is a separate, unblocked piece of work.

## Out of Scope

- **Recipient lists are still unfiltered.** The badge detail recipient list and the Issued tab do not apply the blocklist. Filtering *other people's* badge recipients through *your* blocklist is a different product question, not part of this report.
- **Undo does not re-pin.** Undoing a rejection restores the row; if the rejection also unpinned an accepted badge, it does not republish the profile to put it back. Restoring the row hands the accept decision back to the user rather than writing to their profile for them.
- **Platform-level bans have no client hook today.** `_internalBlocklist` in `ContentBlocklistRepository` is a hardcoded, currently empty `const` — there is no server-driven blocklist sync, so banning an account cannot take effect without a code change and a release. Worth its own issue; not touched here.

## Verification

- `flutter analyze lib test packages/badge_repository` — clean
- `flutter test` in `mobile/packages/badge_repository` — 145 tests, **100% line coverage** (the package runs the VGV workflow with a 100% gate)
- `flutter test test/blocs/badges test/screens/badges test/widgets/profile/profile_header_widget_test.dart` — 173 tests green
- `dart format` — clean
- No new ARB keys; `badgesActionReject` already existed, so no locale work

New regression coverage: dismissal surviving a re-award, the legacy-dismissal migration in all three states (all resolve / some resolve / none resolve), a blocked issuer's unaccepted awards dropped and accepted ones kept, reject-unpins-then-hides, the pinned-without-award row in all four of its behaviours, and a dismissal never hiding a pinned badge while still taking effect once it is unpinned.

Two existing tests were adjusted rather than fixed: both pin a second coordinate with no award in their fixture to test profile-list precedence, which now correctly produces its own row, so `.single` no longer applies. They assert on the coordinate under test instead; what they check is unchanged.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

