### PR TITLE
feat(storage): add a developer footprint diagnostic for unexplained disk usage

### DIFF
--- a/mobile/lib/blocs/storage/storage_cubit.dart
+++ b/mobile/lib/blocs/storage/storage_cubit.dart
@@ -187,6 +187,32 @@ class StorageCubit extends Cubit<StorageState> {
     }
   }
 
+  /// Measures every directory the app writes to for the developer diagnostic.
+  ///
+  /// Unlike [loadCacheSize], this includes what no in-app action can reclaim —
+  /// the documents directory and the durable database — which is the whole
+  /// point: it answers where an unexplained OS-reported footprint sits.
+  ///
+  /// The walk takes seconds on a large install and the user can navigate away
+  /// while it runs, so the result is dropped if the cubit closed first.
+  Future<void> measureFootprint() async {
+    emit(state.copyWith(footprintStatus: StorageFootprintStatus.measuring));
+    try {
+      final footprint = await _service.measureFootprint();
+      if (isClosed) return;
+      emit(
+        state.copyWith(
+          footprintStatus: StorageFootprintStatus.measured,
+          footprint: footprint,
+        ),
+      );
+    } catch (error, stackTrace) {
+      addError(error, stackTrace);
+      if (isClosed) return;
+      emit(state.copyWith(footprintStatus: StorageFootprintStatus.failure));
+    }
+  }
+
   /// Removes the broken clips found by [scanLibrary].
   Future<void> removeBrokenClips() async {
     if (state.brokenClips.isEmpty) return;

--- a/mobile/lib/blocs/storage/storage_cubit.dart
+++ b/mobile/lib/blocs/storage/storage_cubit.dart
@@ -2,6 +2,7 @@ import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:openvine/constants/storage_cache_constants.dart';
 import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/storage_footprint.dart';
 import 'package:openvine/services/cache_recovery_service.dart';
 import 'package:openvine/services/storage_management_service.dart';
 

--- a/mobile/lib/blocs/storage/storage_state.dart
+++ b/mobile/lib/blocs/storage/storage_state.dart
@@ -67,6 +67,21 @@ enum StorageRecoveryStatus {
   failure,
 }
 
+/// Lifecycle of the developer footprint diagnostic.
+enum StorageFootprintStatus {
+  /// Not measured yet.
+  idle,
+
+  /// Walking every directory the app writes to.
+  measuring,
+
+  /// Footprint known; see [StorageState.footprint].
+  measured,
+
+  /// The measurement failed.
+  failure,
+}
+
 /// State for the settings "Storage" screen.
 class StorageState extends Equatable {
   /// Creates a state.
@@ -79,6 +94,8 @@ class StorageState extends Equatable {
     this.brokenClips = const [],
     this.recoveryStatus = StorageRecoveryStatus.idle,
     this.recoveryFootprintBytes = 0,
+    this.footprintStatus = StorageFootprintStatus.idle,
+    this.footprint = StorageFootprint.empty,
   });
 
   /// Lifecycle of the cache section.
@@ -105,6 +122,12 @@ class StorageState extends Equatable {
   /// Total bytes a repair wipe would clear, or zero while unmeasured.
   final int recoveryFootprintBytes;
 
+  /// Lifecycle of the developer footprint diagnostic.
+  final StorageFootprintStatus footprintStatus;
+
+  /// Every directory the app writes to, measured on demand.
+  final StorageFootprint footprint;
+
   /// Returns a copy with the given fields replaced.
   StorageState copyWith({
     StorageCacheStatus? cacheStatus,
@@ -115,6 +138,8 @@ class StorageState extends Equatable {
     List<DivineVideoClip>? brokenClips,
     StorageRecoveryStatus? recoveryStatus,
     int? recoveryFootprintBytes,
+    StorageFootprintStatus? footprintStatus,
+    StorageFootprint? footprint,
   }) {
     return StorageState(
       cacheStatus: cacheStatus ?? this.cacheStatus,
@@ -126,6 +151,8 @@ class StorageState extends Equatable {
       recoveryStatus: recoveryStatus ?? this.recoveryStatus,
       recoveryFootprintBytes:
           recoveryFootprintBytes ?? this.recoveryFootprintBytes,
+      footprintStatus: footprintStatus ?? this.footprintStatus,
+      footprint: footprint ?? this.footprint,
     );
   }
 
@@ -139,5 +166,7 @@ class StorageState extends Equatable {
     brokenClips,
     recoveryStatus,
     recoveryFootprintBytes,
+    footprintStatus,
+    footprint,
   ];
 }

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -1,5 +1,11 @@
 {
     "@@locale": "am",
+    "devOptionsStorageFootprint": "የማከማቻ አጠቃቀም",
+    "devOptionsStorageFootprintDescription": "መተግበሪያው የሚጽፍበት እያንዳንዱ አቃፊ። መሸጎጫን ማጽዳት ከዚህ ውስጥ የተወሰነውን ብቻ ነው የሚለቀው።",
+    "devOptionsStorageFootprintMeasure": "ለካ",
+    "devOptionsStorageFootprintTotal": "ጠቅላላ፦ {size}",
+    "devOptionsStorageFootprintCopied": "የማከማቻ ሪፖርት ተቀድቷል",
+    "devOptionsStorageFootprintFailure": "ማከማቻውን መለካት አልተቻለም",
     "commentAuthorAvatarSemanticLabel": "የ{name}ን መገለጫ ይመልከቱ",
     "publishErrorNotSignedIn": "ቪዲዮዎችን ለማተም እባክዎ ይግቡ።",
     "publishErrorNoRetry": "እንደገና የሚሞከር ስቀላ የለም።",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -1,5 +1,11 @@
 {
     "@@locale": "ar",
+    "devOptionsStorageFootprint": "مساحة التخزين المستخدمة",
+    "devOptionsStorageFootprintDescription": "كل مجلد يكتب فيه التطبيق. مسح ذاكرة التخزين المؤقت يحرر جزءًا منها فقط.",
+    "devOptionsStorageFootprintMeasure": "قياس",
+    "devOptionsStorageFootprintTotal": "الإجمالي: {size}",
+    "devOptionsStorageFootprintCopied": "تم نسخ تقرير التخزين",
+    "devOptionsStorageFootprintFailure": "تعذر قياس مساحة التخزين",
     "commentAuthorAvatarSemanticLabel": "عرض ملف {name} الشخصي",
     "publishErrorNotSignedIn": "يرجى تسجيل الدخول لنشر الفيديوهات.",
     "publishErrorNoRetry": "لا يوجد رفع لإعادة محاولته.",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -1,5 +1,11 @@
 {
     "@@locale": "bg",
+    "devOptionsStorageFootprint": "Заето пространство",
+    "devOptionsStorageFootprintDescription": "Всяка папка, в която приложението пише. Изчистването на кеша освобождава само част от него.",
+    "devOptionsStorageFootprintMeasure": "Измерване",
+    "devOptionsStorageFootprintTotal": "Общо: {size}",
+    "devOptionsStorageFootprintCopied": "Отчетът за паметта е копиран",
+    "devOptionsStorageFootprintFailure": "Паметта не можа да бъде измерена",
     "commentAuthorAvatarSemanticLabel": "Преглед на профила на {name}",
     "publishErrorNotSignedIn": "Влез, за да публикуваш видеа.",
     "publishErrorNoRetry": "Няма качване, което да повториш.",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -1,5 +1,11 @@
 {
     "@@locale": "de",
+    "devOptionsStorageFootprint": "Speicherverbrauch",
+    "devOptionsStorageFootprintDescription": "Jedes Verzeichnis, in das die App schreibt. Cache leeren gibt nur einen Teil davon frei.",
+    "devOptionsStorageFootprintMeasure": "Messen",
+    "devOptionsStorageFootprintTotal": "Gesamt: {size}",
+    "devOptionsStorageFootprintCopied": "Speicherbericht kopiert",
+    "devOptionsStorageFootprintFailure": "Speicher konnte nicht gemessen werden",
     "commentAuthorAvatarSemanticLabel": "Profil von {name} ansehen",
     "publishErrorNotSignedIn": "Melde dich an, um Videos zu veröffentlichen.",
     "publishErrorNoRetry": "Kein Upload zum Wiederholen.",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -1,5 +1,17 @@
 {
   "@@locale": "en",
+  "devOptionsStorageFootprint": "Storage Footprint",
+  "@devOptionsStorageFootprint": {"description": "Header of the Developer Options section that measures the app's on-disk footprint."},
+  "devOptionsStorageFootprintDescription": "Every directory the app writes to. Clearing caches only reclaims part of this.",
+  "@devOptionsStorageFootprintDescription": {"description": "Explains that the footprint covers more than the caches the Storage screen can clear."},
+  "devOptionsStorageFootprintMeasure": "Measure",
+  "@devOptionsStorageFootprintMeasure": {"description": "Button that starts walking every directory the app writes to."},
+  "devOptionsStorageFootprintTotal": "Total: {size}",
+  "@devOptionsStorageFootprintTotal": {"description": "Total bytes across every measured directory.", "placeholders": {"size": {"type": "String"}}},
+  "devOptionsStorageFootprintCopied": "Storage report copied",
+  "@devOptionsStorageFootprintCopied": {"description": "Confirmation shown after the footprint report is copied to the clipboard."},
+  "devOptionsStorageFootprintFailure": "Could not measure storage",
+  "@devOptionsStorageFootprintFailure": {"description": "Shown when the footprint measurement failed."},
   "feedTuningMoreLabel": "More like this",
   "@feedTuningMoreLabel": {
     "description": "Indicator and snackbar text when the user swipes right to get more videos like the current one."

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -1,5 +1,11 @@
 {
     "@@locale": "es",
+    "devOptionsStorageFootprint": "Uso de almacenamiento",
+    "devOptionsStorageFootprintDescription": "Todos los directorios en los que escribe la app. Borrar la caché solo libera una parte.",
+    "devOptionsStorageFootprintMeasure": "Medir",
+    "devOptionsStorageFootprintTotal": "Total: {size}",
+    "devOptionsStorageFootprintCopied": "Informe de almacenamiento copiado",
+    "devOptionsStorageFootprintFailure": "No se pudo medir el almacenamiento",
     "commentAuthorAvatarSemanticLabel": "Ver el perfil de {name}",
     "publishErrorNotSignedIn": "Iniciá sesión para publicar vídeos.",
     "publishErrorNoRetry": "No hay ninguna subida para reintentar.",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -1,5 +1,11 @@
 {
     "@@locale": "fil",
+    "devOptionsStorageFootprint": "Paggamit ng storage",
+    "devOptionsStorageFootprintDescription": "Bawat folder na sinusulatan ng app. Bahagi lang nito ang nababawi kapag nag-clear ng cache.",
+    "devOptionsStorageFootprintMeasure": "Sukatin",
+    "devOptionsStorageFootprintTotal": "Kabuuan: {size}",
+    "devOptionsStorageFootprintCopied": "Nakopya ang storage report",
+    "devOptionsStorageFootprintFailure": "Hindi masukat ang storage",
     "commentAuthorAvatarSemanticLabel": "Tingnan ang profile ni {name}",
     "publishErrorNotSignedIn": "Mag-sign in muna para makapag-publish ng video.",
     "publishErrorNoRetry": "Walang upload na puwedeng subukan ulit.",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -1,5 +1,11 @@
 {
     "@@locale": "fr",
+    "devOptionsStorageFootprint": "Empreinte de stockage",
+    "devOptionsStorageFootprintDescription": "Tous les dossiers dans lesquels l'app écrit. Vider le cache n'en libère qu'une partie.",
+    "devOptionsStorageFootprintMeasure": "Mesurer",
+    "devOptionsStorageFootprintTotal": "Total : {size}",
+    "devOptionsStorageFootprintCopied": "Rapport de stockage copié",
+    "devOptionsStorageFootprintFailure": "Impossible de mesurer le stockage",
     "commentAuthorAvatarSemanticLabel": "Voir le profil de {name}",
     "publishErrorNotSignedIn": "Connecte-toi pour publier des vidéos.",
     "publishErrorNoRetry": "Aucun envoi à relancer.",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -1,5 +1,11 @@
 {
     "@@locale": "id",
+    "devOptionsStorageFootprint": "Penggunaan penyimpanan",
+    "devOptionsStorageFootprintDescription": "Setiap folder tempat aplikasi menulis. Menghapus cache hanya membebaskan sebagiannya.",
+    "devOptionsStorageFootprintMeasure": "Ukur",
+    "devOptionsStorageFootprintTotal": "Total: {size}",
+    "devOptionsStorageFootprintCopied": "Laporan penyimpanan disalin",
+    "devOptionsStorageFootprintFailure": "Tidak dapat mengukur penyimpanan",
     "commentAuthorAvatarSemanticLabel": "Lihat profil {name}",
     "publishErrorNotSignedIn": "Silakan masuk untuk mempublikasikan video.",
     "publishErrorNoRetry": "Tidak ada unggahan untuk dicoba ulang.",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -1,5 +1,11 @@
 {
     "@@locale": "it",
+    "devOptionsStorageFootprint": "Spazio occupato",
+    "devOptionsStorageFootprintDescription": "Ogni cartella in cui l'app scrive. Svuotare la cache ne libera solo una parte.",
+    "devOptionsStorageFootprintMeasure": "Misura",
+    "devOptionsStorageFootprintTotal": "Totale: {size}",
+    "devOptionsStorageFootprintCopied": "Report di archiviazione copiato",
+    "devOptionsStorageFootprintFailure": "Impossibile misurare lo spazio",
     "commentAuthorAvatarSemanticLabel": "Visualizza il profilo di {name}",
   "publishErrorNotSignedIn": "Accedi per pubblicare i video.",
   "publishErrorNoRetry": "Nessun caricamento da riprovare.",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -1,5 +1,11 @@
 {
     "@@locale": "ja",
+    "devOptionsStorageFootprint": "ストレージ使用量",
+    "devOptionsStorageFootprintDescription": "アプリが書き込むすべてのディレクトリ。キャッシュ削除で解放されるのはその一部だけです。",
+    "devOptionsStorageFootprintMeasure": "計測",
+    "devOptionsStorageFootprintTotal": "合計: {size}",
+    "devOptionsStorageFootprintCopied": "ストレージレポートをコピーしました",
+    "devOptionsStorageFootprintFailure": "ストレージを計測できませんでした",
     "commentAuthorAvatarSemanticLabel": "{name}のプロフィールを表示",
     "publishErrorNotSignedIn": "動画を投稿するにはサインインしてね。",
     "publishErrorNoRetry": "やり直せるアップロードがないよ。",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -1,5 +1,11 @@
 {
     "@@locale": "ko",
+    "devOptionsStorageFootprint": "저장 공간 사용량",
+    "devOptionsStorageFootprintDescription": "앱이 기록하는 모든 디렉터리입니다. 캐시를 지워도 일부만 확보됩니다.",
+    "devOptionsStorageFootprintMeasure": "측정",
+    "devOptionsStorageFootprintTotal": "합계: {size}",
+    "devOptionsStorageFootprintCopied": "저장 공간 보고서를 복사했습니다",
+    "devOptionsStorageFootprintFailure": "저장 공간을 측정할 수 없습니다",
     "commentAuthorAvatarSemanticLabel": "{name}님의 프로필 보기",
     "publishErrorNotSignedIn": "영상을 게시하려면 로그인해주세요.",
     "publishErrorNoRetry": "다시 시도할 업로드가 없어요.",

--- a/mobile/lib/l10n/app_ms.arb
+++ b/mobile/lib/l10n/app_ms.arb
@@ -1,5 +1,11 @@
 {
   "@@locale": "ms",
+  "devOptionsStorageFootprint": "Penggunaan storan",
+  "devOptionsStorageFootprintDescription": "Setiap folder yang ditulis oleh apl. Mengosongkan cache hanya membebaskan sebahagian daripadanya.",
+  "devOptionsStorageFootprintMeasure": "Ukur",
+  "devOptionsStorageFootprintTotal": "Jumlah: {size}",
+  "devOptionsStorageFootprintCopied": "Laporan storan disalin",
+  "devOptionsStorageFootprintFailure": "Storan tidak dapat diukur",
   "feedTuningMoreLabel": "Lebih banyak seperti ini",
   "@feedTuningMoreLabel": {
     "description": "Indicator and snackbar text when the user swipes right to get more videos like the current one."

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -1,5 +1,11 @@
 {
     "@@locale": "nl",
+    "devOptionsStorageFootprint": "Opslaggebruik",
+    "devOptionsStorageFootprintDescription": "Elke map waarin de app schrijft. Cache wissen maakt daar maar een deel van vrij.",
+    "devOptionsStorageFootprintMeasure": "Meten",
+    "devOptionsStorageFootprintTotal": "Totaal: {size}",
+    "devOptionsStorageFootprintCopied": "Opslagrapport gekopieerd",
+    "devOptionsStorageFootprintFailure": "Kan opslag niet meten",
     "commentAuthorAvatarSemanticLabel": "Profiel van {name} bekijken",
     "publishErrorNotSignedIn": "Log in om video's te publiceren.",
     "publishErrorNoRetry": "Geen upload om opnieuw te proberen.",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -1,5 +1,11 @@
 {
     "@@locale": "pl",
+    "devOptionsStorageFootprint": "Zajętość pamięci",
+    "devOptionsStorageFootprintDescription": "Każdy katalog, do którego zapisuje aplikacja. Czyszczenie pamięci podręcznej zwalnia tylko część.",
+    "devOptionsStorageFootprintMeasure": "Zmierz",
+    "devOptionsStorageFootprintTotal": "Łącznie: {size}",
+    "devOptionsStorageFootprintCopied": "Skopiowano raport pamięci",
+    "devOptionsStorageFootprintFailure": "Nie udało się zmierzyć pamięci",
     "commentAuthorAvatarSemanticLabel": "Zobacz profil użytkownika {name}",
     "publishErrorNotSignedIn": "Zaloguj się, aby publikować filmy.",
     "publishErrorNoRetry": "Brak przesyłania do ponowienia.",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -1,5 +1,11 @@
 {
     "@@locale": "pt",
+    "devOptionsStorageFootprint": "Uso de armazenamento",
+    "devOptionsStorageFootprintDescription": "Todas as pastas em que o app escreve. Limpar o cache libera apenas uma parte.",
+    "devOptionsStorageFootprintMeasure": "Medir",
+    "devOptionsStorageFootprintTotal": "Total: {size}",
+    "devOptionsStorageFootprintCopied": "Relatório de armazenamento copiado",
+    "devOptionsStorageFootprintFailure": "Não foi possível medir o armazenamento",
     "commentAuthorAvatarSemanticLabel": "Ver o perfil de {name}",
     "publishErrorNotSignedIn": "Entre na sua conta para publicar vídeos.",
     "publishErrorNoRetry": "Nenhum envio para tentar novamente.",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -1,5 +1,11 @@
 {
     "@@locale": "ro",
+    "devOptionsStorageFootprint": "Spațiu ocupat",
+    "devOptionsStorageFootprintDescription": "Fiecare director în care scrie aplicația. Golirea cache-ului eliberează doar o parte.",
+    "devOptionsStorageFootprintMeasure": "Măsoară",
+    "devOptionsStorageFootprintTotal": "Total: {size}",
+    "devOptionsStorageFootprintCopied": "Raport de stocare copiat",
+    "devOptionsStorageFootprintFailure": "Spațiul nu a putut fi măsurat",
     "commentAuthorAvatarSemanticLabel": "Vezi profilul lui {name}",
     "publishErrorNotSignedIn": "Autentifică-te ca să publici videoclipuri.",
     "publishErrorNoRetry": "Nu există nicio încărcare de reîncercat.",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -1,5 +1,11 @@
 {
     "@@locale": "sv",
+    "devOptionsStorageFootprint": "Lagringsanvändning",
+    "devOptionsStorageFootprintDescription": "Varje mapp appen skriver till. Att rensa cachen frigör bara en del av det.",
+    "devOptionsStorageFootprintMeasure": "Mät",
+    "devOptionsStorageFootprintTotal": "Totalt: {size}",
+    "devOptionsStorageFootprintCopied": "Lagringsrapport kopierad",
+    "devOptionsStorageFootprintFailure": "Kunde inte mäta lagringen",
     "commentAuthorAvatarSemanticLabel": "Visa {name}s profil",
     "publishErrorNotSignedIn": "Logga in för att publicera videor.",
     "publishErrorNoRetry": "Ingen uppladdning att försöka igen med.",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -1,5 +1,11 @@
 {
     "@@locale": "tr",
+    "devOptionsStorageFootprint": "Depolama kullanımı",
+    "devOptionsStorageFootprintDescription": "Uygulamanın yazdığı her klasör. Önbelleği temizlemek bunun yalnızca bir kısmını boşaltır.",
+    "devOptionsStorageFootprintMeasure": "Ölç",
+    "devOptionsStorageFootprintTotal": "Toplam: {size}",
+    "devOptionsStorageFootprintCopied": "Depolama raporu kopyalandı",
+    "devOptionsStorageFootprintFailure": "Depolama ölçülemedi",
     "commentAuthorAvatarSemanticLabel": "{name} kullanıcısının profilini görüntüle",
     "publishErrorNotSignedIn": "Video yayınlamak için lütfen giriş yap.",
     "publishErrorNoRetry": "Yeniden denenecek bir yükleme yok.",

--- a/mobile/lib/l10n/app_ur.arb
+++ b/mobile/lib/l10n/app_ur.arb
@@ -1,5 +1,11 @@
 {
   "@@locale": "ur",
+  "devOptionsStorageFootprint": "اسٹوریج کا استعمال",
+  "devOptionsStorageFootprintDescription": "ہر وہ فولڈر جس میں ایپ لکھتی ہے۔ کیشے صاف کرنے سے اس کا صرف کچھ حصہ خالی ہوتا ہے۔",
+  "devOptionsStorageFootprintMeasure": "پیمائش کریں",
+  "devOptionsStorageFootprintTotal": "کل: {size}",
+  "devOptionsStorageFootprintCopied": "اسٹوریج رپورٹ کاپی ہو گئی",
+  "devOptionsStorageFootprintFailure": "اسٹوریج کی پیمائش نہیں ہو سکی",
   "feedTuningMoreLabel": "مزید اسی طرح کی",
   "@feedTuningMoreLabel": {
     "description": "Indicator and snackbar text when the user swipes right to get more videos like the current one."

--- a/mobile/lib/l10n/app_vi.arb
+++ b/mobile/lib/l10n/app_vi.arb
@@ -1,5 +1,11 @@
 {
   "@@locale": "vi",
+  "devOptionsStorageFootprint": "Dung lượng đã dùng",
+  "devOptionsStorageFootprintDescription": "Mọi thư mục ứng dụng ghi vào. Xóa bộ nhớ đệm chỉ giải phóng một phần trong đó.",
+  "devOptionsStorageFootprintMeasure": "Đo",
+  "devOptionsStorageFootprintTotal": "Tổng: {size}",
+  "devOptionsStorageFootprintCopied": "Đã sao chép báo cáo dung lượng",
+  "devOptionsStorageFootprintFailure": "Không đo được dung lượng",
   "feedTuningMoreLabel": "Thêm kiểu này",
   "@feedTuningMoreLabel": {
     "description": "Indicator and snackbar text when the user swipes right to get more videos like the current one."

--- a/mobile/lib/l10n/app_zh.arb
+++ b/mobile/lib/l10n/app_zh.arb
@@ -1,5 +1,11 @@
 {
   "@@locale": "zh",
+  "devOptionsStorageFootprint": "存储占用",
+  "devOptionsStorageFootprintDescription": "应用写入的所有目录。清除缓存只能释放其中一部分。",
+  "devOptionsStorageFootprintMeasure": "测量",
+  "devOptionsStorageFootprintTotal": "共计：{size}",
+  "devOptionsStorageFootprintCopied": "已复制存储报告",
+  "devOptionsStorageFootprintFailure": "无法测量存储占用",
   "feedTuningMoreLabel": "更多这类内容",
   "@feedTuningMoreLabel": {
     "description": "Indicator and snackbar text when the user swipes right to get more videos like the current one."

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -138,6 +138,42 @@ abstract class AppLocalizations {
     Locale('zh'),
   ];
 
+  /// Header of the Developer Options section that measures the app's on-disk footprint.
+  ///
+  /// In en, this message translates to:
+  /// **'Storage Footprint'**
+  String get devOptionsStorageFootprint;
+
+  /// Explains that the footprint covers more than the caches the Storage screen can clear.
+  ///
+  /// In en, this message translates to:
+  /// **'Every directory the app writes to. Clearing caches only reclaims part of this.'**
+  String get devOptionsStorageFootprintDescription;
+
+  /// Button that starts walking every directory the app writes to.
+  ///
+  /// In en, this message translates to:
+  /// **'Measure'**
+  String get devOptionsStorageFootprintMeasure;
+
+  /// Total bytes across every measured directory.
+  ///
+  /// In en, this message translates to:
+  /// **'Total: {size}'**
+  String devOptionsStorageFootprintTotal(String size);
+
+  /// Confirmation shown after the footprint report is copied to the clipboard.
+  ///
+  /// In en, this message translates to:
+  /// **'Storage report copied'**
+  String get devOptionsStorageFootprintCopied;
+
+  /// Shown when the footprint measurement failed.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not measure storage'**
+  String get devOptionsStorageFootprintFailure;
+
   /// Indicator and snackbar text when the user swipes right to get more videos like the current one.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -9,6 +9,27 @@ class AppLocalizationsAm extends AppLocalizations {
   AppLocalizationsAm([String locale = 'am']) : super(locale);
 
   @override
+  String get devOptionsStorageFootprint => 'የማከማቻ አጠቃቀም';
+
+  @override
+  String get devOptionsStorageFootprintDescription =>
+      'መተግበሪያው የሚጽፍበት እያንዳንዱ አቃፊ። መሸጎጫን ማጽዳት ከዚህ ውስጥ የተወሰነውን ብቻ ነው የሚለቀው።';
+
+  @override
+  String get devOptionsStorageFootprintMeasure => 'ለካ';
+
+  @override
+  String devOptionsStorageFootprintTotal(String size) {
+    return 'ጠቅላላ፦ $size';
+  }
+
+  @override
+  String get devOptionsStorageFootprintCopied => 'የማከማቻ ሪፖርት ተቀድቷል';
+
+  @override
+  String get devOptionsStorageFootprintFailure => 'ማከማቻውን መለካት አልተቻለም';
+
+  @override
   String get feedTuningMoreLabel => 'እንደዚህ ያሉ ተጨማሪ';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -9,6 +9,27 @@ class AppLocalizationsAr extends AppLocalizations {
   AppLocalizationsAr([String locale = 'ar']) : super(locale);
 
   @override
+  String get devOptionsStorageFootprint => 'مساحة التخزين المستخدمة';
+
+  @override
+  String get devOptionsStorageFootprintDescription =>
+      'كل مجلد يكتب فيه التطبيق. مسح ذاكرة التخزين المؤقت يحرر جزءًا منها فقط.';
+
+  @override
+  String get devOptionsStorageFootprintMeasure => 'قياس';
+
+  @override
+  String devOptionsStorageFootprintTotal(String size) {
+    return 'الإجمالي: $size';
+  }
+
+  @override
+  String get devOptionsStorageFootprintCopied => 'تم نسخ تقرير التخزين';
+
+  @override
+  String get devOptionsStorageFootprintFailure => 'تعذر قياس مساحة التخزين';
+
+  @override
   String get feedTuningMoreLabel => 'المزيد مثل هذا';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -9,6 +9,28 @@ class AppLocalizationsBg extends AppLocalizations {
   AppLocalizationsBg([String locale = 'bg']) : super(locale);
 
   @override
+  String get devOptionsStorageFootprint => 'Заето пространство';
+
+  @override
+  String get devOptionsStorageFootprintDescription =>
+      'Всяка папка, в която приложението пише. Изчистването на кеша освобождава само част от него.';
+
+  @override
+  String get devOptionsStorageFootprintMeasure => 'Измерване';
+
+  @override
+  String devOptionsStorageFootprintTotal(String size) {
+    return 'Общо: $size';
+  }
+
+  @override
+  String get devOptionsStorageFootprintCopied => 'Отчетът за паметта е копиран';
+
+  @override
+  String get devOptionsStorageFootprintFailure =>
+      'Паметта не можа да бъде измерена';
+
+  @override
   String get feedTuningMoreLabel => 'Повече такива';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -9,6 +9,28 @@ class AppLocalizationsDe extends AppLocalizations {
   AppLocalizationsDe([String locale = 'de']) : super(locale);
 
   @override
+  String get devOptionsStorageFootprint => 'Speicherverbrauch';
+
+  @override
+  String get devOptionsStorageFootprintDescription =>
+      'Jedes Verzeichnis, in das die App schreibt. Cache leeren gibt nur einen Teil davon frei.';
+
+  @override
+  String get devOptionsStorageFootprintMeasure => 'Messen';
+
+  @override
+  String devOptionsStorageFootprintTotal(String size) {
+    return 'Gesamt: $size';
+  }
+
+  @override
+  String get devOptionsStorageFootprintCopied => 'Speicherbericht kopiert';
+
+  @override
+  String get devOptionsStorageFootprintFailure =>
+      'Speicher konnte nicht gemessen werden';
+
+  @override
   String get feedTuningMoreLabel => 'Mehr davon';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -9,6 +9,27 @@ class AppLocalizationsEn extends AppLocalizations {
   AppLocalizationsEn([String locale = 'en']) : super(locale);
 
   @override
+  String get devOptionsStorageFootprint => 'Storage Footprint';
+
+  @override
+  String get devOptionsStorageFootprintDescription =>
+      'Every directory the app writes to. Clearing caches only reclaims part of this.';
+
+  @override
+  String get devOptionsStorageFootprintMeasure => 'Measure';
+
+  @override
+  String devOptionsStorageFootprintTotal(String size) {
+    return 'Total: $size';
+  }
+
+  @override
+  String get devOptionsStorageFootprintCopied => 'Storage report copied';
+
+  @override
+  String get devOptionsStorageFootprintFailure => 'Could not measure storage';
+
+  @override
   String get feedTuningMoreLabel => 'More like this';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -9,6 +9,29 @@ class AppLocalizationsEs extends AppLocalizations {
   AppLocalizationsEs([String locale = 'es']) : super(locale);
 
   @override
+  String get devOptionsStorageFootprint => 'Uso de almacenamiento';
+
+  @override
+  String get devOptionsStorageFootprintDescription =>
+      'Todos los directorios en los que escribe la app. Borrar la caché solo libera una parte.';
+
+  @override
+  String get devOptionsStorageFootprintMeasure => 'Medir';
+
+  @override
+  String devOptionsStorageFootprintTotal(String size) {
+    return 'Total: $size';
+  }
+
+  @override
+  String get devOptionsStorageFootprintCopied =>
+      'Informe de almacenamiento copiado';
+
+  @override
+  String get devOptionsStorageFootprintFailure =>
+      'No se pudo medir el almacenamiento';
+
+  @override
   String get feedTuningMoreLabel => 'Más como esto';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -9,6 +9,27 @@ class AppLocalizationsFil extends AppLocalizations {
   AppLocalizationsFil([String locale = 'fil']) : super(locale);
 
   @override
+  String get devOptionsStorageFootprint => 'Paggamit ng storage';
+
+  @override
+  String get devOptionsStorageFootprintDescription =>
+      'Bawat folder na sinusulatan ng app. Bahagi lang nito ang nababawi kapag nag-clear ng cache.';
+
+  @override
+  String get devOptionsStorageFootprintMeasure => 'Sukatin';
+
+  @override
+  String devOptionsStorageFootprintTotal(String size) {
+    return 'Kabuuan: $size';
+  }
+
+  @override
+  String get devOptionsStorageFootprintCopied => 'Nakopya ang storage report';
+
+  @override
+  String get devOptionsStorageFootprintFailure => 'Hindi masukat ang storage';
+
+  @override
   String get feedTuningMoreLabel => 'Mas marami pa nito';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -9,6 +9,28 @@ class AppLocalizationsFr extends AppLocalizations {
   AppLocalizationsFr([String locale = 'fr']) : super(locale);
 
   @override
+  String get devOptionsStorageFootprint => 'Empreinte de stockage';
+
+  @override
+  String get devOptionsStorageFootprintDescription =>
+      'Tous les dossiers dans lesquels l\'app écrit. Vider le cache n\'en libère qu\'une partie.';
+
+  @override
+  String get devOptionsStorageFootprintMeasure => 'Mesurer';
+
+  @override
+  String devOptionsStorageFootprintTotal(String size) {
+    return 'Total : $size';
+  }
+
+  @override
+  String get devOptionsStorageFootprintCopied => 'Rapport de stockage copié';
+
+  @override
+  String get devOptionsStorageFootprintFailure =>
+      'Impossible de mesurer le stockage';
+
+  @override
   String get feedTuningMoreLabel => 'Plus comme ça';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -9,6 +9,28 @@ class AppLocalizationsId extends AppLocalizations {
   AppLocalizationsId([String locale = 'id']) : super(locale);
 
   @override
+  String get devOptionsStorageFootprint => 'Penggunaan penyimpanan';
+
+  @override
+  String get devOptionsStorageFootprintDescription =>
+      'Setiap folder tempat aplikasi menulis. Menghapus cache hanya membebaskan sebagiannya.';
+
+  @override
+  String get devOptionsStorageFootprintMeasure => 'Ukur';
+
+  @override
+  String devOptionsStorageFootprintTotal(String size) {
+    return 'Total: $size';
+  }
+
+  @override
+  String get devOptionsStorageFootprintCopied => 'Laporan penyimpanan disalin';
+
+  @override
+  String get devOptionsStorageFootprintFailure =>
+      'Tidak dapat mengukur penyimpanan';
+
+  @override
   String get feedTuningMoreLabel => 'Lebih banyak seperti ini';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -9,6 +9,29 @@ class AppLocalizationsIt extends AppLocalizations {
   AppLocalizationsIt([String locale = 'it']) : super(locale);
 
   @override
+  String get devOptionsStorageFootprint => 'Spazio occupato';
+
+  @override
+  String get devOptionsStorageFootprintDescription =>
+      'Ogni cartella in cui l\'app scrive. Svuotare la cache ne libera solo una parte.';
+
+  @override
+  String get devOptionsStorageFootprintMeasure => 'Misura';
+
+  @override
+  String devOptionsStorageFootprintTotal(String size) {
+    return 'Totale: $size';
+  }
+
+  @override
+  String get devOptionsStorageFootprintCopied =>
+      'Report di archiviazione copiato';
+
+  @override
+  String get devOptionsStorageFootprintFailure =>
+      'Impossibile misurare lo spazio';
+
+  @override
   String get feedTuningMoreLabel => 'Più contenuti così';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -9,6 +9,27 @@ class AppLocalizationsJa extends AppLocalizations {
   AppLocalizationsJa([String locale = 'ja']) : super(locale);
 
   @override
+  String get devOptionsStorageFootprint => 'ストレージ使用量';
+
+  @override
+  String get devOptionsStorageFootprintDescription =>
+      'アプリが書き込むすべてのディレクトリ。キャッシュ削除で解放されるのはその一部だけです。';
+
+  @override
+  String get devOptionsStorageFootprintMeasure => '計測';
+
+  @override
+  String devOptionsStorageFootprintTotal(String size) {
+    return '合計: $size';
+  }
+
+  @override
+  String get devOptionsStorageFootprintCopied => 'ストレージレポートをコピーしました';
+
+  @override
+  String get devOptionsStorageFootprintFailure => 'ストレージを計測できませんでした';
+
+  @override
   String get feedTuningMoreLabel => 'もっと見たい';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -9,6 +9,27 @@ class AppLocalizationsKo extends AppLocalizations {
   AppLocalizationsKo([String locale = 'ko']) : super(locale);
 
   @override
+  String get devOptionsStorageFootprint => '저장 공간 사용량';
+
+  @override
+  String get devOptionsStorageFootprintDescription =>
+      '앱이 기록하는 모든 디렉터리입니다. 캐시를 지워도 일부만 확보됩니다.';
+
+  @override
+  String get devOptionsStorageFootprintMeasure => '측정';
+
+  @override
+  String devOptionsStorageFootprintTotal(String size) {
+    return '합계: $size';
+  }
+
+  @override
+  String get devOptionsStorageFootprintCopied => '저장 공간 보고서를 복사했습니다';
+
+  @override
+  String get devOptionsStorageFootprintFailure => '저장 공간을 측정할 수 없습니다';
+
+  @override
   String get feedTuningMoreLabel => '이런 영상 더 보기';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -9,6 +9,27 @@ class AppLocalizationsMs extends AppLocalizations {
   AppLocalizationsMs([String locale = 'ms']) : super(locale);
 
   @override
+  String get devOptionsStorageFootprint => 'Penggunaan storan';
+
+  @override
+  String get devOptionsStorageFootprintDescription =>
+      'Setiap folder yang ditulis oleh apl. Mengosongkan cache hanya membebaskan sebahagian daripadanya.';
+
+  @override
+  String get devOptionsStorageFootprintMeasure => 'Ukur';
+
+  @override
+  String devOptionsStorageFootprintTotal(String size) {
+    return 'Jumlah: $size';
+  }
+
+  @override
+  String get devOptionsStorageFootprintCopied => 'Laporan storan disalin';
+
+  @override
+  String get devOptionsStorageFootprintFailure => 'Storan tidak dapat diukur';
+
+  @override
   String get feedTuningMoreLabel => 'Lebih banyak seperti ini';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -9,6 +9,27 @@ class AppLocalizationsNl extends AppLocalizations {
   AppLocalizationsNl([String locale = 'nl']) : super(locale);
 
   @override
+  String get devOptionsStorageFootprint => 'Opslaggebruik';
+
+  @override
+  String get devOptionsStorageFootprintDescription =>
+      'Elke map waarin de app schrijft. Cache wissen maakt daar maar een deel van vrij.';
+
+  @override
+  String get devOptionsStorageFootprintMeasure => 'Meten';
+
+  @override
+  String devOptionsStorageFootprintTotal(String size) {
+    return 'Totaal: $size';
+  }
+
+  @override
+  String get devOptionsStorageFootprintCopied => 'Opslagrapport gekopieerd';
+
+  @override
+  String get devOptionsStorageFootprintFailure => 'Kan opslag niet meten';
+
+  @override
   String get feedTuningMoreLabel => 'Meer zoals dit';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -9,6 +9,28 @@ class AppLocalizationsPl extends AppLocalizations {
   AppLocalizationsPl([String locale = 'pl']) : super(locale);
 
   @override
+  String get devOptionsStorageFootprint => 'Zajętość pamięci';
+
+  @override
+  String get devOptionsStorageFootprintDescription =>
+      'Każdy katalog, do którego zapisuje aplikacja. Czyszczenie pamięci podręcznej zwalnia tylko część.';
+
+  @override
+  String get devOptionsStorageFootprintMeasure => 'Zmierz';
+
+  @override
+  String devOptionsStorageFootprintTotal(String size) {
+    return 'Łącznie: $size';
+  }
+
+  @override
+  String get devOptionsStorageFootprintCopied => 'Skopiowano raport pamięci';
+
+  @override
+  String get devOptionsStorageFootprintFailure =>
+      'Nie udało się zmierzyć pamięci';
+
+  @override
   String get feedTuningMoreLabel => 'Więcej takich';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -9,6 +9,29 @@ class AppLocalizationsPt extends AppLocalizations {
   AppLocalizationsPt([String locale = 'pt']) : super(locale);
 
   @override
+  String get devOptionsStorageFootprint => 'Uso de armazenamento';
+
+  @override
+  String get devOptionsStorageFootprintDescription =>
+      'Todas as pastas em que o app escreve. Limpar o cache libera apenas uma parte.';
+
+  @override
+  String get devOptionsStorageFootprintMeasure => 'Medir';
+
+  @override
+  String devOptionsStorageFootprintTotal(String size) {
+    return 'Total: $size';
+  }
+
+  @override
+  String get devOptionsStorageFootprintCopied =>
+      'Relatório de armazenamento copiado';
+
+  @override
+  String get devOptionsStorageFootprintFailure =>
+      'Não foi possível medir o armazenamento';
+
+  @override
   String get feedTuningMoreLabel => 'Mais como este';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -9,6 +9,28 @@ class AppLocalizationsRo extends AppLocalizations {
   AppLocalizationsRo([String locale = 'ro']) : super(locale);
 
   @override
+  String get devOptionsStorageFootprint => 'Spațiu ocupat';
+
+  @override
+  String get devOptionsStorageFootprintDescription =>
+      'Fiecare director în care scrie aplicația. Golirea cache-ului eliberează doar o parte.';
+
+  @override
+  String get devOptionsStorageFootprintMeasure => 'Măsoară';
+
+  @override
+  String devOptionsStorageFootprintTotal(String size) {
+    return 'Total: $size';
+  }
+
+  @override
+  String get devOptionsStorageFootprintCopied => 'Raport de stocare copiat';
+
+  @override
+  String get devOptionsStorageFootprintFailure =>
+      'Spațiul nu a putut fi măsurat';
+
+  @override
   String get feedTuningMoreLabel => 'Mai multe ca ăsta';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -9,6 +9,27 @@ class AppLocalizationsSv extends AppLocalizations {
   AppLocalizationsSv([String locale = 'sv']) : super(locale);
 
   @override
+  String get devOptionsStorageFootprint => 'Lagringsanvändning';
+
+  @override
+  String get devOptionsStorageFootprintDescription =>
+      'Varje mapp appen skriver till. Att rensa cachen frigör bara en del av det.';
+
+  @override
+  String get devOptionsStorageFootprintMeasure => 'Mät';
+
+  @override
+  String devOptionsStorageFootprintTotal(String size) {
+    return 'Totalt: $size';
+  }
+
+  @override
+  String get devOptionsStorageFootprintCopied => 'Lagringsrapport kopierad';
+
+  @override
+  String get devOptionsStorageFootprintFailure => 'Kunde inte mäta lagringen';
+
+  @override
   String get feedTuningMoreLabel => 'Mer så här';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -9,6 +9,27 @@ class AppLocalizationsTr extends AppLocalizations {
   AppLocalizationsTr([String locale = 'tr']) : super(locale);
 
   @override
+  String get devOptionsStorageFootprint => 'Depolama kullanımı';
+
+  @override
+  String get devOptionsStorageFootprintDescription =>
+      'Uygulamanın yazdığı her klasör. Önbelleği temizlemek bunun yalnızca bir kısmını boşaltır.';
+
+  @override
+  String get devOptionsStorageFootprintMeasure => 'Ölç';
+
+  @override
+  String devOptionsStorageFootprintTotal(String size) {
+    return 'Toplam: $size';
+  }
+
+  @override
+  String get devOptionsStorageFootprintCopied => 'Depolama raporu kopyalandı';
+
+  @override
+  String get devOptionsStorageFootprintFailure => 'Depolama ölçülemedi';
+
+  @override
   String get feedTuningMoreLabel => 'Bunun gibi daha fazla';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -9,6 +9,28 @@ class AppLocalizationsUr extends AppLocalizations {
   AppLocalizationsUr([String locale = 'ur']) : super(locale);
 
   @override
+  String get devOptionsStorageFootprint => 'اسٹوریج کا استعمال';
+
+  @override
+  String get devOptionsStorageFootprintDescription =>
+      'ہر وہ فولڈر جس میں ایپ لکھتی ہے۔ کیشے صاف کرنے سے اس کا صرف کچھ حصہ خالی ہوتا ہے۔';
+
+  @override
+  String get devOptionsStorageFootprintMeasure => 'پیمائش کریں';
+
+  @override
+  String devOptionsStorageFootprintTotal(String size) {
+    return 'کل: $size';
+  }
+
+  @override
+  String get devOptionsStorageFootprintCopied => 'اسٹوریج رپورٹ کاپی ہو گئی';
+
+  @override
+  String get devOptionsStorageFootprintFailure =>
+      'اسٹوریج کی پیمائش نہیں ہو سکی';
+
+  @override
   String get feedTuningMoreLabel => 'مزید اسی طرح کی';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -9,6 +9,28 @@ class AppLocalizationsVi extends AppLocalizations {
   AppLocalizationsVi([String locale = 'vi']) : super(locale);
 
   @override
+  String get devOptionsStorageFootprint => 'Dung lượng đã dùng';
+
+  @override
+  String get devOptionsStorageFootprintDescription =>
+      'Mọi thư mục ứng dụng ghi vào. Xóa bộ nhớ đệm chỉ giải phóng một phần trong đó.';
+
+  @override
+  String get devOptionsStorageFootprintMeasure => 'Đo';
+
+  @override
+  String devOptionsStorageFootprintTotal(String size) {
+    return 'Tổng: $size';
+  }
+
+  @override
+  String get devOptionsStorageFootprintCopied =>
+      'Đã sao chép báo cáo dung lượng';
+
+  @override
+  String get devOptionsStorageFootprintFailure => 'Không đo được dung lượng';
+
+  @override
   String get feedTuningMoreLabel => 'Thêm kiểu này';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -9,6 +9,27 @@ class AppLocalizationsZh extends AppLocalizations {
   AppLocalizationsZh([String locale = 'zh']) : super(locale);
 
   @override
+  String get devOptionsStorageFootprint => '存储占用';
+
+  @override
+  String get devOptionsStorageFootprintDescription =>
+      '应用写入的所有目录。清除缓存只能释放其中一部分。';
+
+  @override
+  String get devOptionsStorageFootprintMeasure => '测量';
+
+  @override
+  String devOptionsStorageFootprintTotal(String size) {
+    return '共计：$size';
+  }
+
+  @override
+  String get devOptionsStorageFootprintCopied => '已复制存储报告';
+
+  @override
+  String get devOptionsStorageFootprintFailure => '无法测量存储占用';
+
+  @override
   String get feedTuningMoreLabel => '更多这类内容';
 
   @override

--- a/mobile/lib/models/storage_footprint.dart
+++ b/mobile/lib/models/storage_footprint.dart
@@ -1,0 +1,103 @@
+// ABOUTME: Measured on-disk footprint of every directory the app writes to.
+// ABOUTME: Lives in the model layer so the developer diagnostic UI can read it
+// ABOUTME: without importing the service that produces it.
+
+import 'package:equatable/equatable.dart';
+import 'package:openvine/utils/byte_size_format.dart';
+
+/// One immediate child of a measured footprint root.
+class StorageFootprintEntry extends Equatable {
+  /// Creates an entry.
+  const StorageFootprintEntry({
+    required this.name,
+    required this.bytes,
+    required this.isDirectory,
+  });
+
+  /// Entry name, relative to its root.
+  final String name;
+
+  /// Bytes held by this entry — recursive when it is a directory.
+  final int bytes;
+
+  /// Whether this entry is a directory.
+  final bool isDirectory;
+
+  @override
+  List<Object?> get props => [name, bytes, isDirectory];
+}
+
+/// One root directory of the app's on-disk footprint.
+class StorageFootprintRoot extends Equatable {
+  /// Creates a measured root.
+  const StorageFootprintRoot({
+    required this.label,
+    required this.path,
+    required this.totalBytes,
+    required this.largestChildren,
+  });
+
+  /// Which platform directory this is, e.g. `Documents`.
+  final String label;
+
+  /// Absolute path on this device.
+  final String path;
+
+  /// Bytes held by the whole subtree.
+  final int totalBytes;
+
+  /// The biggest immediate children, largest first.
+  final List<StorageFootprintEntry> largestChildren;
+
+  @override
+  List<Object?> get props => [label, path, totalBytes, largestChildren];
+}
+
+/// The app's full on-disk footprint, split by root directory.
+class StorageFootprint extends Equatable {
+  /// Creates a footprint.
+  const StorageFootprint({required this.roots});
+
+  /// Nothing measured yet.
+  static const empty = StorageFootprint(roots: []);
+
+  /// Every root the app writes to, in measurement order.
+  final List<StorageFootprintRoot> roots;
+
+  /// Bytes across all roots.
+  int get totalBytes => roots.fold(0, (sum, root) => sum + root.totalBytes);
+
+  /// A plain-text report for pasting into a support thread.
+  ///
+  /// Deliberately unlocalized: it is read by whoever triages the report, not
+  /// by the user, and mixed-locale reports are harder to compare. Raw byte
+  /// counts sit alongside the readable size so a report stays sortable.
+  String toReportText() {
+    final buffer = StringBuffer()
+      ..writeln('Divine storage footprint')
+      ..writeln('Total: ${formatByteSize(totalBytes)} ($totalBytes bytes)');
+    for (final root in roots) {
+      buffer
+        ..writeln()
+        ..writeln(
+          '${root.label}: ${formatByteSize(root.totalBytes)} '
+          '(${root.totalBytes} bytes)',
+        )
+        ..writeln('  path: ${root.path}');
+      if (root.largestChildren.isEmpty) {
+        buffer.writeln('  (empty)');
+        continue;
+      }
+      for (final child in root.largestChildren) {
+        final suffix = child.isDirectory ? '/' : '';
+        buffer.writeln(
+          '  ${formatByteSize(child.bytes)}\t${child.name}$suffix',
+        );
+      }
+    }
+    return buffer.toString();
+  }
+
+  @override
+  List<Object?> get props => [roots];
+}

--- a/mobile/lib/models/storage_footprint.dart
+++ b/mobile/lib/models/storage_footprint.dart
@@ -36,6 +36,7 @@ class StorageFootprintRoot extends Equatable {
     required this.totalBytes,
     required this.largestChildren,
     required this.childCount,
+    this.isIncomplete = false,
   });
 
   /// Which platform directory this is, e.g. `Documents`.
@@ -57,6 +58,12 @@ class StorageFootprintRoot extends Equatable {
   /// whether the rest is spread across entries that were left out.
   final int childCount;
 
+  /// Whether part of this root could not be walked.
+  ///
+  /// When true, [totalBytes] and child sizes are best-effort lower bounds
+  /// rather than a complete measurement.
+  final bool isIncomplete;
+
   /// Bytes held by the children [largestChildren] left out.
   int get omittedBytes =>
       totalBytes - largestChildren.fold(0, (sum, child) => sum + child.bytes);
@@ -71,6 +78,7 @@ class StorageFootprintRoot extends Equatable {
     totalBytes,
     largestChildren,
     childCount,
+    isIncomplete,
   ];
 }
 
@@ -105,8 +113,13 @@ class StorageFootprint extends Equatable {
           '(${root.totalBytes} bytes)',
         )
         ..writeln('  path: ${root.path}');
+      if (root.isIncomplete) {
+        buffer.writeln('  (walk incomplete; totals may be low)');
+      }
       if (root.largestChildren.isEmpty) {
-        buffer.writeln('  (empty)');
+        if (!root.isIncomplete) {
+          buffer.writeln('  (empty)');
+        }
         continue;
       }
       for (final child in root.largestChildren) {

--- a/mobile/lib/models/storage_footprint.dart
+++ b/mobile/lib/models/storage_footprint.dart
@@ -35,6 +35,7 @@ class StorageFootprintRoot extends Equatable {
     required this.path,
     required this.totalBytes,
     required this.largestChildren,
+    required this.childCount,
   });
 
   /// Which platform directory this is, e.g. `Documents`.
@@ -49,8 +50,28 @@ class StorageFootprintRoot extends Equatable {
   /// The biggest immediate children, largest first.
   final List<StorageFootprintEntry> largestChildren;
 
+  /// How many immediate children the root has in total.
+  ///
+  /// [largestChildren] keeps only the biggest, so without this a reader
+  /// cannot tell whether the listed entries add up to [totalBytes] or
+  /// whether the rest is spread across entries that were left out.
+  final int childCount;
+
+  /// Bytes held by the children [largestChildren] left out.
+  int get omittedBytes =>
+      totalBytes - largestChildren.fold(0, (sum, child) => sum + child.bytes);
+
+  /// How many children [largestChildren] left out.
+  int get omittedCount => childCount - largestChildren.length;
+
   @override
-  List<Object?> get props => [label, path, totalBytes, largestChildren];
+  List<Object?> get props => [
+    label,
+    path,
+    totalBytes,
+    largestChildren,
+    childCount,
+  ];
 }
 
 /// The app's full on-disk footprint, split by root directory.
@@ -92,6 +113,15 @@ class StorageFootprint extends Equatable {
         final suffix = child.isDirectory ? '/' : '';
         buffer.writeln(
           '  ${formatByteSize(child.bytes)}\t${child.name}$suffix',
+        );
+      }
+      // Only the biggest children are listed, so say what the rest holds —
+      // otherwise the entries above look like they should add up to the
+      // root total and the difference reads as a measurement bug.
+      if (root.omittedCount > 0) {
+        buffer.writeln(
+          '  ${formatByteSize(root.omittedBytes)}\t'
+          '(${root.omittedCount} smaller entries not listed)',
         );
       }
     }

--- a/mobile/lib/screens/developer_options_screen.dart
+++ b/mobile/lib/screens/developer_options_screen.dart
@@ -25,6 +25,7 @@ import 'package:openvine/providers/protected_minor_providers.dart';
 import 'package:openvine/router/route_paths.dart';
 import 'package:openvine/services/openvine_media_cache.dart';
 import 'package:openvine/services/video_format_preference.dart';
+import 'package:openvine/widgets/developer/storage_footprint_section.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 /// Returns a color indicating speed: green (<1s), orange (1-3s), red (>3s).
@@ -293,6 +294,10 @@ class _DeveloperOptionsScreenState
                   );
                 }),
               ],
+
+              Divider(color: context.vineColors.outline, height: 32),
+
+              const StorageFootprintSection(),
 
               Divider(color: context.vineColors.outline, height: 32),
 

--- a/mobile/lib/screens/settings/storage/storage_management_page.dart
+++ b/mobile/lib/screens/settings/storage/storage_management_page.dart
@@ -14,6 +14,7 @@ import 'package:openvine/constants/storage_cache_constants.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/storage_providers.dart';
 import 'package:openvine/router/route_paths.dart';
+import 'package:openvine/utils/byte_size_format.dart';
 
 /// Settings screen for clearing caches and auditing the clip library.
 class StorageManagementPage extends ConsumerWidget {
@@ -174,7 +175,7 @@ class _CacheSection extends StatelessWidget {
           Text(
             busy
                 ? l10n.settingsStorageMeasuring
-                : l10n.settingsStorageCacheInUse(_formatBytes(bytes)),
+                : l10n.settingsStorageCacheInUse(formatByteSize(bytes)),
             style: VineTheme.titleMediumFont(
               color: context.vineColors.primaryText,
             ),
@@ -204,7 +205,7 @@ class _CacheSection extends StatelessWidget {
         Padding(
           padding: const EdgeInsets.fromLTRB(16, 8, 16, 4),
           child: Text(
-            l10n.settingsStorageClearConfirmMessage(_formatBytes(bytes)),
+            l10n.settingsStorageClearConfirmMessage(formatByteSize(bytes)),
             style: VineTheme.bodyMediumFont(
               color: context.vineColors.mutedText,
             ),
@@ -267,7 +268,7 @@ class _CacheLimitControl extends StatelessWidget {
               ),
             ),
             Text(
-              _formatBytes(limit),
+              formatByteSize(limit),
               style: VineTheme.bodyMediumFont(
                 color: context.vineColors.accentPositive,
               ),
@@ -529,23 +530,10 @@ class _RepairFootprint extends StatelessWidget {
         style: VineTheme.bodyMediumFont(color: context.vineColors.mutedText),
       ),
       StorageRecoveryStatus.measured => Text(
-        l10n.settingsStorageRepairFootprint(_formatBytes(bytes)),
+        l10n.settingsStorageRepairFootprint(formatByteSize(bytes)),
         style: VineTheme.titleMediumFont(color: context.vineColors.primaryText),
       ),
       _ => const SizedBox.shrink(),
     };
   }
-}
-
-/// Formats [bytes] as a short human-readable size (e.g. `1.2 MB`).
-String _formatBytes(int bytes) {
-  if (bytes < 1024) return '$bytes B';
-  const units = ['KB', 'MB', 'GB', 'TB'];
-  var size = bytes / 1024;
-  var unit = 0;
-  while (size >= 1024 && unit < units.length - 1) {
-    size /= 1024;
-    unit++;
-  }
-  return '${size.toStringAsFixed(size >= 10 ? 0 : 1)} ${units[unit]}';
 }

--- a/mobile/lib/services/storage_management_service.dart
+++ b/mobile/lib/services/storage_management_service.dart
@@ -10,9 +10,9 @@ import 'package:media_cache/media_cache.dart';
 import 'package:openvine/constants/storage_cache_constants.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/stop_motion/stop_motion_frame_ops.dart';
+import 'package:openvine/models/storage_footprint.dart';
 import 'package:openvine/services/clip_library_service.dart';
 import 'package:openvine/services/temp_render_janitor.dart';
-import 'package:openvine/utils/byte_size_format.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -78,103 +78,6 @@ class CacheUsage extends Equatable {
 
   @override
   List<Object?> get props => [video, images, transitionSeams, tempRenders];
-}
-
-/// One immediate child of a measured footprint root.
-class StorageFootprintEntry extends Equatable {
-  /// Creates an entry.
-  const StorageFootprintEntry({
-    required this.name,
-    required this.bytes,
-    required this.isDirectory,
-  });
-
-  /// Entry name, relative to its root.
-  final String name;
-
-  /// Bytes held by this entry — recursive when it is a directory.
-  final int bytes;
-
-  /// Whether this entry is a directory.
-  final bool isDirectory;
-
-  @override
-  List<Object?> get props => [name, bytes, isDirectory];
-}
-
-/// One root directory of the app's on-disk footprint.
-class StorageFootprintRoot extends Equatable {
-  /// Creates a measured root.
-  const StorageFootprintRoot({
-    required this.label,
-    required this.path,
-    required this.totalBytes,
-    required this.largestChildren,
-  });
-
-  /// Which platform directory this is, e.g. `Documents`.
-  final String label;
-
-  /// Absolute path on this device.
-  final String path;
-
-  /// Bytes held by the whole subtree.
-  final int totalBytes;
-
-  /// The biggest immediate children, largest first.
-  final List<StorageFootprintEntry> largestChildren;
-
-  @override
-  List<Object?> get props => [label, path, totalBytes, largestChildren];
-}
-
-/// The app's full on-disk footprint, split by root directory.
-class StorageFootprint extends Equatable {
-  /// Creates a footprint.
-  const StorageFootprint({required this.roots});
-
-  /// Nothing measured yet.
-  static const empty = StorageFootprint(roots: []);
-
-  /// Every root the app writes to, in measurement order.
-  final List<StorageFootprintRoot> roots;
-
-  /// Bytes across all roots.
-  int get totalBytes => roots.fold(0, (sum, root) => sum + root.totalBytes);
-
-  /// A plain-text report for pasting into a support thread.
-  ///
-  /// Deliberately unlocalized: it is read by whoever triages the report, not
-  /// by the user, and mixed-locale reports are harder to compare. Raw byte
-  /// counts sit alongside the readable size so a report stays sortable.
-  String toReportText() {
-    final buffer = StringBuffer()
-      ..writeln('Divine storage footprint')
-      ..writeln('Total: ${formatByteSize(totalBytes)} ($totalBytes bytes)');
-    for (final root in roots) {
-      buffer
-        ..writeln()
-        ..writeln(
-          '${root.label}: ${formatByteSize(root.totalBytes)} '
-          '(${root.totalBytes} bytes)',
-        )
-        ..writeln('  path: ${root.path}');
-      if (root.largestChildren.isEmpty) {
-        buffer.writeln('  (empty)');
-        continue;
-      }
-      for (final child in root.largestChildren) {
-        final suffix = child.isDirectory ? '/' : '';
-        buffer.writeln(
-          '  ${formatByteSize(child.bytes)}\t${child.name}$suffix',
-        );
-      }
-    }
-    return buffer.toString();
-  }
-
-  @override
-  List<Object?> get props => [roots];
 }
 
 /// Clears re-downloadable / regenerable media caches and audits the clip

--- a/mobile/lib/services/storage_management_service.dart
+++ b/mobile/lib/services/storage_management_service.dart
@@ -80,6 +80,13 @@ class CacheUsage extends Equatable {
   List<Object?> get props => [video, images, transitionSeams, tempRenders];
 }
 
+class _DirectorySize {
+  const _DirectorySize({required this.bytes, this.isIncomplete = false});
+
+  final int bytes;
+  final bool isIncomplete;
+}
+
 /// Clears re-downloadable / regenerable media caches and audits the clip
 /// library for broken entries.
 ///
@@ -107,6 +114,7 @@ class StorageManagementService {
     Future<Directory> Function()? applicationSupportDirectoryProvider,
     @visibleForTesting
     Future<Directory> Function()? applicationCacheDirectoryProvider,
+    @visibleForTesting Future<int> Function(File file)? fileLengthProvider,
     Set<String> Function()? protectedTempRenderPaths,
   }) : _videoCache = videoCache,
        _imageCache = imageCache,
@@ -121,6 +129,7 @@ class StorageManagementService {
            getApplicationSupportDirectory,
        _applicationCacheDirectoryProvider =
            applicationCacheDirectoryProvider ?? getApplicationCacheDirectory,
+       _fileLengthProvider = fileLengthProvider,
        _protectedTempRenderPaths =
            protectedTempRenderPaths ?? _noProtectedPaths;
 
@@ -132,6 +141,7 @@ class StorageManagementService {
   final Future<Directory> Function() _documentsDirectoryProvider;
   final Future<Directory> Function() _applicationSupportDirectoryProvider;
   final Future<Directory> Function() _applicationCacheDirectoryProvider;
+  final Future<int> Function(File file)? _fileLengthProvider;
   final Set<String> Function() _protectedTempRenderPaths;
 
   static const String _logName = 'StorageManagementService';
@@ -152,15 +162,21 @@ class StorageManagementService {
     final protectedPaths = _normalizedProtectedTempRenderPaths();
     return CacheUsage(
       video: CacheUsageCategory(
-        usedBytes: await _dirSize(Directory(p.join(temp.path, _videoCacheDir))),
+        usedBytes: (await _dirSize(
+          Directory(p.join(temp.path, _videoCacheDir)),
+        )).bytes,
         limitBytes: videoCacheLimitBytes(),
       ),
       images: CacheUsageCategory(
-        usedBytes: await _dirSize(Directory(p.join(temp.path, _imageCacheDir))),
+        usedBytes: (await _dirSize(
+          Directory(p.join(temp.path, _imageCacheDir)),
+        )).bytes,
         limitBytes: _imageCache.maxCacheSizeBytes,
       ),
       transitionSeams: CacheUsageCategory(
-        usedBytes: await _dirSize(Directory(p.join(docs.path, _seamDir))),
+        usedBytes: (await _dirSize(
+          Directory(p.join(docs.path, _seamDir)),
+        )).bytes,
         limitBytes: kSeamCacheLimitBytes,
       ),
       tempRenders: CacheUsageCategory(
@@ -269,15 +285,18 @@ class StorageManagementService {
   }) async {
     final children = <StorageFootprintEntry>[];
     var totalBytes = 0;
+    var isIncomplete = false;
     if (dir.existsSync()) {
       try {
         await for (final entity in dir.list(followLinks: false)) {
           final isDirectory = entity is Directory;
-          final bytes = switch (entity) {
+          final size = switch (entity) {
             Directory() => await _dirSize(entity),
-            File() => await _fileLength(entity),
-            _ => 0,
+            File() => _DirectorySize(bytes: await _fileLength(entity)),
+            _ => const _DirectorySize(bytes: 0),
           };
+          isIncomplete = isIncomplete || size.isIncomplete;
+          final bytes = size.bytes;
           totalBytes += bytes;
           children.add(
             StorageFootprintEntry(
@@ -288,6 +307,7 @@ class StorageManagementService {
           );
         }
       } on Object catch (error) {
+        isIncomplete = true;
         Log.warning(
           '$_logName: listing ${dir.path} failed: $error',
           name: _logName,
@@ -302,6 +322,7 @@ class StorageManagementService {
       totalBytes: totalBytes,
       largestChildren: children.take(childrenPerRoot).toList(),
       childCount: children.length,
+      isIncomplete: isIncomplete,
     );
   }
 
@@ -360,9 +381,10 @@ class StorageManagementService {
   /// [_fileLength] absorbs a file that vanished between listing and stat —
   /// routine here, since the cache trim and the temp-render janitor delete
   /// files while a walk of the same root is still running.
-  Future<int> _dirSize(Directory dir) async {
-    if (!dir.existsSync()) return 0;
+  Future<_DirectorySize> _dirSize(Directory dir) async {
+    if (!dir.existsSync()) return const _DirectorySize(bytes: 0);
     var size = 0;
+    var isIncomplete = false;
     final pending = <Directory>[dir];
     while (pending.isNotEmpty) {
       final current = pending.removeLast();
@@ -375,6 +397,7 @@ class StorageManagementService {
           }
         }
       } on Object catch (error) {
+        isIncomplete = true;
         Log.warning(
           '$_logName: sizing ${current.path} failed: $error',
           name: _logName,
@@ -382,13 +405,16 @@ class StorageManagementService {
         );
       }
     }
-    return size;
+    return _DirectorySize(bytes: size, isIncomplete: isIncomplete);
   }
 
   /// Length of [file], or zero when it vanished mid-walk or cannot be read.
   Future<int> _fileLength(File file) async {
     try {
-      return await file.length();
+      final lengthProvider = _fileLengthProvider;
+      return lengthProvider == null
+          ? await file.length()
+          : await lengthProvider(file);
     } on Object {
       return 0;
     }
@@ -402,7 +428,7 @@ class StorageManagementService {
     await _forEachTempRender(
       temp,
       protectedPaths: protectedPaths,
-      action: (file) async => size += await file.length(),
+      action: (file) async => size += await _fileLength(file),
     );
     return size;
   }

--- a/mobile/lib/services/storage_management_service.dart
+++ b/mobile/lib/services/storage_management_service.dart
@@ -200,10 +200,13 @@ class StorageManagementService {
   /// documents directory (clip library, drafts, rendered videos) and the
   /// durable database, which even the repair wipe preserves.
   ///
-  /// Roots that resolve to the same directory are reported once — on Android
+  /// Roots that resolve to the same directory are measured once — on Android
   /// the temporary and cache directories are both `getCacheDir()` — so the
-  /// totals never double-count. A root the platform cannot resolve is omitted
-  /// rather than failing the whole measurement.
+  /// totals never double-count. Such a root is labelled with every name that
+  /// pointed at it (`Caches + Temporary`) rather than silently dropping the
+  /// later one, so a report that lists three roots on Android and four on iOS
+  /// says why. A root the platform cannot resolve is omitted rather than
+  /// failing the whole measurement.
   ///
   /// Walks the full tree of every root, so it is slow on a large install and
   /// belongs behind an explicit user action.
@@ -214,29 +217,41 @@ class StorageManagementService {
       'Caches': _applicationCacheDirectoryProvider,
       'Temporary': _temporaryDirectoryProvider,
     };
-    final roots = <StorageFootprintRoot>[];
-    final measuredPaths = <String>{};
+
+    // Resolve every root before measuring any, so the ones that share a
+    // directory can be collapsed into a single labelled walk.
+    final byPath = <String, ({Directory dir, List<String> labels})>{};
     for (final entry in providers.entries) {
-      final root = await _measureRoot(
-        label: entry.key,
-        provider: entry.value,
-        childrenPerRoot: childrenPerRoot,
-        measuredPaths: measuredPaths,
+      final dir = await _resolveRoot(entry.key, entry.value);
+      if (dir == null) continue;
+      final resolved = byPath.putIfAbsent(
+        _normalizePath(dir.path),
+        () => (dir: dir, labels: <String>[]),
       );
-      if (root != null) roots.add(root);
+      resolved.labels.add(entry.key);
+    }
+
+    final roots = <StorageFootprintRoot>[];
+    for (final resolved in byPath.values) {
+      roots.add(
+        await _measureRoot(
+          label: resolved.labels.join(' + '),
+          dir: resolved.dir,
+          childrenPerRoot: childrenPerRoot,
+        ),
+      );
     }
     return StorageFootprint(roots: roots);
   }
 
-  Future<StorageFootprintRoot?> _measureRoot({
-    required String label,
-    required Future<Directory> Function() provider,
-    required int childrenPerRoot,
-    required Set<String> measuredPaths,
-  }) async {
-    final Directory dir;
+  /// The directory [provider] points at, or null when the platform has no
+  /// such root — a missing root must not fail the whole measurement.
+  Future<Directory?> _resolveRoot(
+    String label,
+    Future<Directory> Function() provider,
+  ) async {
     try {
-      dir = await provider();
+      return await provider();
     } on Object catch (error) {
       Log.warning(
         '$_logName: resolving $label failed: $error',
@@ -245,8 +260,13 @@ class StorageManagementService {
       );
       return null;
     }
-    if (!measuredPaths.add(_normalizePath(dir.path))) return null;
+  }
 
+  Future<StorageFootprintRoot> _measureRoot({
+    required String label,
+    required Directory dir,
+    required int childrenPerRoot,
+  }) async {
     final children = <StorageFootprintEntry>[];
     var totalBytes = 0;
     if (dir.existsSync()) {
@@ -281,6 +301,7 @@ class StorageManagementService {
       path: dir.path,
       totalBytes: totalBytes,
       largestChildren: children.take(childrenPerRoot).toList(),
+      childCount: children.length,
     );
   }
 
@@ -329,22 +350,37 @@ class StorageManagementService {
     await _videoCache.enforceCacheLimits(force: true);
   }
 
+  /// Recursive size of [dir], counting every file the process can still read.
+  ///
+  /// Descends one level at a time rather than with `list(recursive: true)`,
+  /// because a recursive listing surfaces the whole tree through a single
+  /// stream: the first unreadable subdirectory throws and abandons everything
+  /// not yet visited, which silently reported zero for an otherwise readable
+  /// tree. Failures are isolated to the directory that caused them, and
+  /// [_fileLength] absorbs a file that vanished between listing and stat —
+  /// routine here, since the cache trim and the temp-render janitor delete
+  /// files while a walk of the same root is still running.
   Future<int> _dirSize(Directory dir) async {
     if (!dir.existsSync()) return 0;
     var size = 0;
-    try {
-      await for (final entity in dir.list(
-        recursive: true,
-        followLinks: false,
-      )) {
-        if (entity is File) size += await entity.length();
+    final pending = <Directory>[dir];
+    while (pending.isNotEmpty) {
+      final current = pending.removeLast();
+      try {
+        await for (final entity in current.list(followLinks: false)) {
+          if (entity is File) {
+            size += await _fileLength(entity);
+          } else if (entity is Directory) {
+            pending.add(entity);
+          }
+        }
+      } on Object catch (error) {
+        Log.warning(
+          '$_logName: sizing ${current.path} failed: $error',
+          name: _logName,
+          category: LogCategory.system,
+        );
       }
-    } on Object catch (error) {
-      Log.warning(
-        '$_logName: sizing ${dir.path} failed: $error',
-        name: _logName,
-        category: LogCategory.system,
-      );
     }
     return size;
   }

--- a/mobile/lib/services/storage_management_service.dart
+++ b/mobile/lib/services/storage_management_service.dart
@@ -12,6 +12,7 @@ import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/stop_motion/stop_motion_frame_ops.dart';
 import 'package:openvine/services/clip_library_service.dart';
 import 'package:openvine/services/temp_render_janitor.dart';
+import 'package:openvine/utils/byte_size_format.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -79,6 +80,103 @@ class CacheUsage extends Equatable {
   List<Object?> get props => [video, images, transitionSeams, tempRenders];
 }
 
+/// One immediate child of a measured footprint root.
+class StorageFootprintEntry extends Equatable {
+  /// Creates an entry.
+  const StorageFootprintEntry({
+    required this.name,
+    required this.bytes,
+    required this.isDirectory,
+  });
+
+  /// Entry name, relative to its root.
+  final String name;
+
+  /// Bytes held by this entry — recursive when it is a directory.
+  final int bytes;
+
+  /// Whether this entry is a directory.
+  final bool isDirectory;
+
+  @override
+  List<Object?> get props => [name, bytes, isDirectory];
+}
+
+/// One root directory of the app's on-disk footprint.
+class StorageFootprintRoot extends Equatable {
+  /// Creates a measured root.
+  const StorageFootprintRoot({
+    required this.label,
+    required this.path,
+    required this.totalBytes,
+    required this.largestChildren,
+  });
+
+  /// Which platform directory this is, e.g. `Documents`.
+  final String label;
+
+  /// Absolute path on this device.
+  final String path;
+
+  /// Bytes held by the whole subtree.
+  final int totalBytes;
+
+  /// The biggest immediate children, largest first.
+  final List<StorageFootprintEntry> largestChildren;
+
+  @override
+  List<Object?> get props => [label, path, totalBytes, largestChildren];
+}
+
+/// The app's full on-disk footprint, split by root directory.
+class StorageFootprint extends Equatable {
+  /// Creates a footprint.
+  const StorageFootprint({required this.roots});
+
+  /// Nothing measured yet.
+  static const empty = StorageFootprint(roots: []);
+
+  /// Every root the app writes to, in measurement order.
+  final List<StorageFootprintRoot> roots;
+
+  /// Bytes across all roots.
+  int get totalBytes => roots.fold(0, (sum, root) => sum + root.totalBytes);
+
+  /// A plain-text report for pasting into a support thread.
+  ///
+  /// Deliberately unlocalized: it is read by whoever triages the report, not
+  /// by the user, and mixed-locale reports are harder to compare. Raw byte
+  /// counts sit alongside the readable size so a report stays sortable.
+  String toReportText() {
+    final buffer = StringBuffer()
+      ..writeln('Divine storage footprint')
+      ..writeln('Total: ${formatByteSize(totalBytes)} ($totalBytes bytes)');
+    for (final root in roots) {
+      buffer
+        ..writeln()
+        ..writeln(
+          '${root.label}: ${formatByteSize(root.totalBytes)} '
+          '(${root.totalBytes} bytes)',
+        )
+        ..writeln('  path: ${root.path}');
+      if (root.largestChildren.isEmpty) {
+        buffer.writeln('  (empty)');
+        continue;
+      }
+      for (final child in root.largestChildren) {
+        final suffix = child.isDirectory ? '/' : '';
+        buffer.writeln(
+          '  ${formatByteSize(child.bytes)}\t${child.name}$suffix',
+        );
+      }
+    }
+    return buffer.toString();
+  }
+
+  @override
+  List<Object?> get props => [roots];
+}
+
 /// Clears re-downloadable / regenerable media caches and audits the clip
 /// library for broken entries.
 ///
@@ -102,6 +200,10 @@ class StorageManagementService {
     required SharedPreferences prefs,
     @visibleForTesting Future<Directory> Function()? temporaryDirectoryProvider,
     @visibleForTesting Future<Directory> Function()? documentsDirectoryProvider,
+    @visibleForTesting
+    Future<Directory> Function()? applicationSupportDirectoryProvider,
+    @visibleForTesting
+    Future<Directory> Function()? applicationCacheDirectoryProvider,
     Set<String> Function()? protectedTempRenderPaths,
   }) : _videoCache = videoCache,
        _imageCache = imageCache,
@@ -111,6 +213,11 @@ class StorageManagementService {
            temporaryDirectoryProvider ?? getTemporaryDirectory,
        _documentsDirectoryProvider =
            documentsDirectoryProvider ?? getApplicationDocumentsDirectory,
+       _applicationSupportDirectoryProvider =
+           applicationSupportDirectoryProvider ??
+           getApplicationSupportDirectory,
+       _applicationCacheDirectoryProvider =
+           applicationCacheDirectoryProvider ?? getApplicationCacheDirectory,
        _protectedTempRenderPaths =
            protectedTempRenderPaths ?? _noProtectedPaths;
 
@@ -120,6 +227,8 @@ class StorageManagementService {
   final SharedPreferences _prefs;
   final Future<Directory> Function() _temporaryDirectoryProvider;
   final Future<Directory> Function() _documentsDirectoryProvider;
+  final Future<Directory> Function() _applicationSupportDirectoryProvider;
+  final Future<Directory> Function() _applicationCacheDirectoryProvider;
   final Set<String> Function() _protectedTempRenderPaths;
 
   static const String _logName = 'StorageManagementService';
@@ -176,6 +285,100 @@ class StorageManagementService {
     );
     final docs = await _documentsDirectoryProvider();
     await _deleteDirContents(Directory(p.join(docs.path, _seamDir)));
+  }
+
+  /// Every directory the app writes to, each with its largest immediate
+  /// children — the diagnostic for "the OS reports tens of GB but the cache
+  /// readout says megabytes".
+  ///
+  /// [cacheUsage] deliberately covers only what [clearCaches] can reclaim, so
+  /// it cannot locate a footprint that sits anywhere else. This walks all four
+  /// platform roots instead, including the ones no in-app action clears: the
+  /// documents directory (clip library, drafts, rendered videos) and the
+  /// durable database, which even the repair wipe preserves.
+  ///
+  /// Roots that resolve to the same directory are reported once — on Android
+  /// the temporary and cache directories are both `getCacheDir()` — so the
+  /// totals never double-count. A root the platform cannot resolve is omitted
+  /// rather than failing the whole measurement.
+  ///
+  /// Walks the full tree of every root, so it is slow on a large install and
+  /// belongs behind an explicit user action.
+  Future<StorageFootprint> measureFootprint({int childrenPerRoot = 12}) async {
+    final providers = <String, Future<Directory> Function()>{
+      'Documents': _documentsDirectoryProvider,
+      'Application Support': _applicationSupportDirectoryProvider,
+      'Caches': _applicationCacheDirectoryProvider,
+      'Temporary': _temporaryDirectoryProvider,
+    };
+    final roots = <StorageFootprintRoot>[];
+    final measuredPaths = <String>{};
+    for (final entry in providers.entries) {
+      final root = await _measureRoot(
+        label: entry.key,
+        provider: entry.value,
+        childrenPerRoot: childrenPerRoot,
+        measuredPaths: measuredPaths,
+      );
+      if (root != null) roots.add(root);
+    }
+    return StorageFootprint(roots: roots);
+  }
+
+  Future<StorageFootprintRoot?> _measureRoot({
+    required String label,
+    required Future<Directory> Function() provider,
+    required int childrenPerRoot,
+    required Set<String> measuredPaths,
+  }) async {
+    final Directory dir;
+    try {
+      dir = await provider();
+    } on Object catch (error) {
+      Log.warning(
+        '$_logName: resolving $label failed: $error',
+        name: _logName,
+        category: LogCategory.system,
+      );
+      return null;
+    }
+    if (!measuredPaths.add(_normalizePath(dir.path))) return null;
+
+    final children = <StorageFootprintEntry>[];
+    var totalBytes = 0;
+    if (dir.existsSync()) {
+      try {
+        await for (final entity in dir.list(followLinks: false)) {
+          final isDirectory = entity is Directory;
+          final bytes = switch (entity) {
+            Directory() => await _dirSize(entity),
+            File() => await _fileLength(entity),
+            _ => 0,
+          };
+          totalBytes += bytes;
+          children.add(
+            StorageFootprintEntry(
+              name: p.basename(entity.path),
+              bytes: bytes,
+              isDirectory: isDirectory,
+            ),
+          );
+        }
+      } on Object catch (error) {
+        Log.warning(
+          '$_logName: listing ${dir.path} failed: $error',
+          name: _logName,
+          category: LogCategory.system,
+        );
+      }
+    }
+    children.sort((a, b) => b.bytes.compareTo(a.bytes));
+    return StorageFootprintRoot(
+      label: label,
+      path: dir.path,
+      totalBytes: totalBytes,
+      largestChildren: children.take(childrenPerRoot).toList(),
+    );
   }
 
   /// Library clips whose backing media is gone — broken entries that can
@@ -241,6 +444,15 @@ class StorageManagementService {
       );
     }
     return size;
+  }
+
+  /// Length of [file], or zero when it vanished mid-walk or cannot be read.
+  Future<int> _fileLength(File file) async {
+    try {
+      return await file.length();
+    } on Object {
+      return 0;
+    }
   }
 
   Future<int> _tempRenderBytes(

--- a/mobile/lib/utils/byte_size_format.dart
+++ b/mobile/lib/utils/byte_size_format.dart
@@ -1,0 +1,17 @@
+// ABOUTME: Shared human-readable byte-size formatting for storage readouts.
+
+/// Formats [bytes] as a short human-readable size (e.g. `1.2 MB`).
+///
+/// Units step at 1024, and the fraction is dropped from 10 upwards so a
+/// column of sizes stays roughly the same width.
+String formatByteSize(int bytes) {
+  if (bytes < 1024) return '$bytes B';
+  const units = ['KB', 'MB', 'GB', 'TB'];
+  var size = bytes / 1024;
+  var unit = 0;
+  while (size >= 1024 && unit < units.length - 1) {
+    size /= 1024;
+    unit++;
+  }
+  return '${size.toStringAsFixed(size >= 10 ? 0 : 1)} ${units[unit]}';
+}

--- a/mobile/lib/widgets/developer/storage_footprint_section.dart
+++ b/mobile/lib/widgets/developer/storage_footprint_section.dart
@@ -7,8 +7,8 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/blocs/storage/storage_cubit.dart';
 import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/models/storage_footprint.dart';
 import 'package:openvine/providers/storage_providers.dart';
-import 'package:openvine/services/storage_management_service.dart';
 import 'package:openvine/utils/byte_size_format.dart';
 import 'package:openvine/utils/clipboard_utils.dart';
 

--- a/mobile/lib/widgets/developer/storage_footprint_section.dart
+++ b/mobile/lib/widgets/developer/storage_footprint_section.dart
@@ -1,0 +1,213 @@
+// ABOUTME: Developer-only readout of every directory the app writes to.
+// ABOUTME: Answers "the OS reports tens of GB but the cache readout says MB".
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:openvine/blocs/storage/storage_cubit.dart';
+import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/providers/storage_providers.dart';
+import 'package:openvine/services/storage_management_service.dart';
+import 'package:openvine/utils/byte_size_format.dart';
+import 'package:openvine/utils/clipboard_utils.dart';
+
+/// Developer Options section that measures the app's on-disk footprint.
+///
+/// The Storage settings screen reports only what "Clear caches" can reclaim,
+/// so it cannot explain a footprint that sits in the documents directory or
+/// the durable database. This walks every root and lists the biggest entries
+/// in each, with a copy action so a support thread gets numbers instead of
+/// guesses.
+class StorageFootprintSection extends ConsumerWidget {
+  /// Creates the section.
+  const StorageFootprintSection({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final service = ref.watch(storageManagementServiceProvider);
+    return BlocProvider<StorageCubit>(
+      key: ValueKey(service),
+      create: (_) => StorageCubit(service: service),
+      child: const StorageFootprintView(),
+    );
+  }
+}
+
+/// The section UI. Split from [StorageFootprintSection] so it can be tested
+/// with a stubbed [StorageCubit].
+class StorageFootprintView extends StatelessWidget {
+  /// Creates the view.
+  @visibleForTesting
+  const StorageFootprintView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    final status = context.select((StorageCubit c) => c.state.footprintStatus);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          child: Text(
+            l10n.devOptionsStorageFootprint,
+            style: VineTheme.titleMediumFont(
+              color: context.vineColors.accentPositive,
+            ),
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            spacing: 12,
+            children: [
+              Text(
+                l10n.devOptionsStorageFootprintDescription,
+                style: VineTheme.bodyMediumFont(
+                  color: context.vineColors.secondaryText,
+                ),
+              ),
+              if (status == StorageFootprintStatus.measuring)
+                Text(
+                  l10n.settingsStorageMeasuring,
+                  style: VineTheme.titleMediumFont(
+                    color: context.vineColors.primaryText,
+                  ),
+                )
+              else if (status == StorageFootprintStatus.failure)
+                Text(
+                  l10n.devOptionsStorageFootprintFailure,
+                  style: VineTheme.titleMediumFont(color: VineTheme.error),
+                )
+              else if (status == StorageFootprintStatus.measured)
+                const _FootprintResult(),
+              const _FootprintActions(),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _FootprintResult extends StatelessWidget {
+  const _FootprintResult();
+
+  @override
+  Widget build(BuildContext context) {
+    final footprint = context.select((StorageCubit c) => c.state.footprint);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      spacing: 12,
+      children: [
+        Text(
+          context.l10n.devOptionsStorageFootprintTotal(
+            formatByteSize(footprint.totalBytes),
+          ),
+          style: VineTheme.titleMediumFont(
+            color: context.vineColors.primaryText,
+          ),
+        ),
+        ...footprint.roots.map(_RootBreakdown.new),
+      ],
+    );
+  }
+}
+
+class _RootBreakdown extends StatelessWidget {
+  const _RootBreakdown(this.root);
+
+  final StorageFootprintRoot root;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          '${root.label} — ${formatByteSize(root.totalBytes)}',
+          style: VineTheme.labelLargeFont(
+            color: context.vineColors.primaryText,
+          ),
+        ),
+        ...root.largestChildren.map(_ChildRow.new),
+      ],
+    );
+  }
+}
+
+class _ChildRow extends StatelessWidget {
+  const _ChildRow(this.entry);
+
+  final StorageFootprintEntry entry;
+
+  @override
+  Widget build(BuildContext context) {
+    final style = VineTheme.bodySmallFont(
+      color: context.vineColors.secondaryText,
+    );
+
+    return Padding(
+      padding: const EdgeInsets.only(top: 2),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        spacing: 8,
+        children: [
+          SizedBox(
+            width: 72,
+            child: Text(formatByteSize(entry.bytes), style: style),
+          ),
+          Expanded(
+            child: Text(
+              entry.isDirectory ? '${entry.name}/' : entry.name,
+              style: style,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _FootprintActions extends StatelessWidget {
+  const _FootprintActions();
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    final status = context.select((StorageCubit c) => c.state.footprintStatus);
+
+    return Row(
+      spacing: 12,
+      children: [
+        Expanded(
+          child: DivineButton(
+            label: l10n.devOptionsStorageFootprintMeasure,
+            type: DivineButtonType.secondary,
+            expanded: true,
+            onPressed: status == StorageFootprintStatus.measuring
+                ? null
+                : () => context.read<StorageCubit>().measureFootprint(),
+          ),
+        ),
+        if (status == StorageFootprintStatus.measured)
+          Expanded(
+            child: DivineButton(
+              label: l10n.shareSheetCopy,
+              type: DivineButtonType.secondary,
+              expanded: true,
+              onPressed: () => ClipboardUtils.copy(
+                context,
+                context.read<StorageCubit>().state.footprint.toReportText(),
+                message: l10n.devOptionsStorageFootprintCopied,
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+}

--- a/mobile/lib/widgets/developer/storage_footprint_section.dart
+++ b/mobile/lib/widgets/developer/storage_footprint_section.dart
@@ -200,7 +200,7 @@ class _FootprintActions extends StatelessWidget {
               label: l10n.shareSheetCopy,
               type: DivineButtonType.secondary,
               expanded: true,
-              onPressed: () => ClipboardUtils.copy(
+              onPressed: () => ClipboardUtils.copyVerified(
                 context,
                 context.read<StorageCubit>().state.footprint.toReportText(),
                 message: l10n.devOptionsStorageFootprintCopied,

--- a/mobile/test/blocs/storage/storage_cubit_test.dart
+++ b/mobile/test/blocs/storage/storage_cubit_test.dart
@@ -378,5 +378,65 @@ void main() {
         await expectLater(pumpEventQueue(), completes);
       });
     });
+
+    group('measureFootprint', () {
+      const footprint = StorageFootprint(
+        roots: [
+          StorageFootprintRoot(
+            label: 'Documents',
+            path: '/documents',
+            totalBytes: 2048,
+            largestChildren: [
+              StorageFootprintEntry(
+                name: 'divine_1.mp4',
+                bytes: 2048,
+                isDirectory: false,
+              ),
+            ],
+          ),
+        ],
+      );
+
+      blocTest<StorageCubit, StorageState>(
+        'emits the measured footprint',
+        setUp: () => when(
+          () => service.measureFootprint(),
+        ).thenAnswer((_) async => footprint),
+        build: build,
+        act: (cubit) => cubit.measureFootprint(),
+        expect: () => const [
+          StorageState(footprintStatus: StorageFootprintStatus.measuring),
+          StorageState(
+            footprintStatus: StorageFootprintStatus.measured,
+            footprint: footprint,
+          ),
+        ],
+      );
+
+      blocTest<StorageCubit, StorageState>(
+        'emits failure when the walk throws',
+        setUp: () =>
+            when(() => service.measureFootprint()).thenThrow(Exception('boom')),
+        build: build,
+        act: (cubit) => cubit.measureFootprint(),
+        expect: () => const [
+          StorageState(footprintStatus: StorageFootprintStatus.measuring),
+          StorageState(footprintStatus: StorageFootprintStatus.failure),
+        ],
+        errors: () => [isA<Exception>()],
+      );
+
+      test('a measurement landing after close does not emit', () async {
+        final walk = Completer<StorageFootprint>();
+        when(() => service.measureFootprint()).thenAnswer((_) => walk.future);
+        final cubit = build();
+
+        unawaited(cubit.measureFootprint());
+        await cubit.close();
+        walk.complete(footprint);
+
+        await expectLater(pumpEventQueue(), completes);
+      });
+    });
   });
 }

--- a/mobile/test/blocs/storage/storage_cubit_test.dart
+++ b/mobile/test/blocs/storage/storage_cubit_test.dart
@@ -394,6 +394,7 @@ void main() {
                 isDirectory: false,
               ),
             ],
+            childCount: 1,
           ),
         ],
       );

--- a/mobile/test/blocs/storage/storage_cubit_test.dart
+++ b/mobile/test/blocs/storage/storage_cubit_test.dart
@@ -8,6 +8,7 @@ import 'package:models/models.dart' as model;
 import 'package:openvine/blocs/storage/storage_cubit.dart';
 import 'package:openvine/constants/storage_cache_constants.dart';
 import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/storage_footprint.dart';
 import 'package:openvine/services/storage_management_service.dart';
 import 'package:pro_video_editor/pro_video_editor.dart' as editor;
 

--- a/mobile/test/services/storage_management_service_test.dart
+++ b/mobile/test/services/storage_management_service_test.dart
@@ -14,6 +14,16 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 class _MockCache extends Mock implements MediaCacheManager {}
 
+/// Whether [dir] can still be listed, i.e. the mode bits actually took.
+bool _isReadable(Directory dir) {
+  try {
+    dir.listSync();
+    return true;
+  } on FileSystemException {
+    return false;
+  }
+}
+
 class _MockClipLibrary extends Mock implements ClipLibraryService {}
 
 void main() {
@@ -357,21 +367,27 @@ void main() {
         expect(footprint.totalBytes, 4096);
       });
 
-      test('reports a root shared by two providers once', () async {
-        writeFile('${temp.path}/leftover.mp4', 500);
+      test(
+        'reports a root shared by two providers once, naming both',
+        () async {
+          writeFile('${temp.path}/leftover.mp4', 500);
 
-        // Android resolves the temporary and cache directories to the same
-        // getCacheDir(); counting both would double the reported total.
-        final footprint = await footprintService(
-          cacheDirectory: temp,
-        ).measureFootprint();
+          // Android resolves the temporary and cache directories to the same
+          // getCacheDir(); counting both would double the reported total.
+          final footprint = await footprintService(
+            cacheDirectory: temp,
+          ).measureFootprint();
 
-        expect(
-          footprint.roots.where((root) => root.path == temp.path),
-          hasLength(1),
-        );
-        expect(footprint.totalBytes, 500);
-      });
+          final shared = footprint.roots.where(
+            (root) => root.path == temp.path,
+          );
+          expect(shared, hasLength(1));
+          expect(footprint.totalBytes, 500);
+          // Both names appear, so a report with one root fewer than another
+          // platform's reads as a merge rather than as a failed walk.
+          expect(shared.single.label, 'Caches + Temporary');
+        },
+      );
 
       test('report text carries the totals and the biggest entries', () async {
         writeFile('${docs.path}/divine_big.mp4', 2048);
@@ -382,6 +398,59 @@ void main() {
         expect(report, contains('Total: 2.0 KB (2048 bytes)'));
         expect(report, contains('Documents: 2.0 KB (2048 bytes)'));
         expect(report, contains('divine_big.mp4'));
+      });
+
+      test('report accounts for the entries it did not list', () async {
+        for (var i = 0; i < 15; i++) {
+          writeFile('${docs.path}/divine_$i.mp4', 100 + i);
+        }
+
+        final report = (await footprintService().measureFootprint())
+            .toReportText();
+
+        // 15 children, 12 listed: the three smallest (100, 101, 102) are
+        // left out, so the report has to name them or the listed sizes look
+        // like they should add up to the root total and do not.
+        expect(report, contains('(3 smaller entries not listed)'));
+        expect(report, contains('303 B\t(3 smaller entries not listed)'));
+      });
+
+      test('an unreadable subdirectory does not zero its readable '
+          'siblings', () async {
+        if (Platform.isWindows) {
+          markTestSkipped(
+            'POSIX permission bits are needed to make a '
+            'directory unreadable.',
+          );
+          return;
+        }
+
+        writeFile('${docs.path}/media/locked/inside.mp4', 10);
+        writeFile('${docs.path}/media/keep.mp4', 400);
+        writeFile('${docs.path}/media/sub/also_keep.mp4', 600);
+        final locked = Directory('${docs.path}/media/locked');
+
+        Process.runSync('chmod', ['000', locked.path]);
+        // Restore before the group tearDown, which cannot delete an
+        // unreadable directory. addTearDown runs first.
+        addTearDown(() => Process.runSync('chmod', ['755', locked.path]));
+        if (_isReadable(locked)) {
+          markTestSkipped(
+            'Running with permissions that ignore the mode '
+            'bits (e.g. as root), so the walk cannot be made to fail.',
+          );
+          return;
+        }
+
+        final footprint = await footprintService().measureFootprint();
+        final documents = footprint.roots.firstWhere(
+          (root) => root.label == 'Documents',
+        );
+
+        // A single recursive listing surfaces the whole tree through one
+        // stream, so the throw on `locked` used to abandon everything not
+        // yet visited and report zero for the entire subtree (#7642).
+        expect(documents.totalBytes, 1000);
       });
     });
   });

--- a/mobile/test/services/storage_management_service_test.dart
+++ b/mobile/test/services/storage_management_service_test.dart
@@ -7,6 +7,7 @@ import 'package:models/models.dart' as model;
 import 'package:openvine/constants/storage_cache_constants.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/stop_motion_clip_frame.dart';
+import 'package:openvine/models/storage_footprint.dart';
 import 'package:openvine/services/clip_library_service.dart';
 import 'package:openvine/services/storage_management_service.dart';
 import 'package:pro_video_editor/pro_video_editor.dart' as editor;
@@ -140,6 +141,33 @@ void main() {
           ),
         );
         expect(usage.tempRenders, const CacheUsageCategory(usedBytes: 10));
+      });
+
+      test('keeps scanning temp renders when one vanishes mid-walk', () async {
+        final vanished = writeFile('${temp.path}/watermarked_vanished.mp4', 20);
+        final merged = writeFile('${temp.path}/merged_2.mp4', 10);
+        final audio = writeFile('${temp.path}/merged_audio_3.wav', 40);
+        service = StorageManagementService(
+          videoCache: videoCache,
+          imageCache: imageCache,
+          clipLibrary: clipLibrary,
+          prefs: prefs,
+          temporaryDirectoryProvider: () async => temp,
+          documentsDirectoryProvider: () async => docs,
+          fileLengthProvider: (file) async {
+            if (file.path == vanished.path) {
+              throw const FileSystemException('vanished');
+            }
+            return file.length();
+          },
+        );
+
+        final usage = await service.cacheUsage();
+
+        expect(
+          usage.tempRenders.usedBytes,
+          merged.lengthSync() + audio.lengthSync(),
+        );
       });
     });
 
@@ -346,10 +374,11 @@ void main() {
         );
 
         expect(documents.totalBytes, 1400);
-        expect(
-          documents.largestChildren.map((child) => child.name),
-          ['divine_big.mp4', 'transition_seams', 'divine_small.mp4'],
-        );
+        expect(documents.largestChildren.map((child) => child.name), [
+          'divine_big.mp4',
+          'transition_seams',
+          'divine_small.mp4',
+        ]);
         expect(documents.largestChildren.first.isDirectory, isFalse);
         expect(documents.largestChildren[1].isDirectory, isTrue);
         expect(footprint.totalBytes, 2100);
@@ -413,6 +442,27 @@ void main() {
         // like they should add up to the root total and do not.
         expect(report, contains('(3 smaller entries not listed)'));
         expect(report, contains('303 B\t(3 smaller entries not listed)'));
+      });
+
+      test('report marks a root when part of its walk was incomplete', () {
+        const footprint = StorageFootprint(
+          roots: [
+            StorageFootprintRoot(
+              label: 'Documents',
+              path: '/documents',
+              totalBytes: 0,
+              largestChildren: [],
+              childCount: 0,
+              isIncomplete: true,
+            ),
+          ],
+        );
+
+        final report = footprint.toReportText();
+
+        expect(report, contains('Documents: 0 B (0 bytes)'));
+        expect(report, contains('(walk incomplete; totals may be low)'));
+        expect(report, isNot(contains('(empty)')));
       });
 
       test('an unreadable subdirectory does not zero its readable '

--- a/mobile/test/services/storage_management_service_test.dart
+++ b/mobile/test/services/storage_management_service_test.dart
@@ -296,5 +296,93 @@ void main() {
         expect(prefs.getInt(kCacheLimitPrefKey), kCacheLimitMinBytes);
       });
     });
+
+    group('measureFootprint', () {
+      late Directory appSupport;
+      late Directory caches;
+
+      StorageManagementService footprintService({Directory? cacheDirectory}) =>
+          StorageManagementService(
+            videoCache: videoCache,
+            imageCache: imageCache,
+            clipLibrary: clipLibrary,
+            prefs: prefs,
+            temporaryDirectoryProvider: () async => temp,
+            documentsDirectoryProvider: () async => docs,
+            applicationSupportDirectoryProvider: () async => appSupport,
+            applicationCacheDirectoryProvider: () async =>
+                cacheDirectory ?? caches,
+          );
+
+      setUp(() {
+        appSupport = Directory.systemTemp.createTempSync('storage_support_');
+        caches = Directory.systemTemp.createTempSync('storage_caches_');
+      });
+
+      tearDown(() {
+        if (appSupport.existsSync()) appSupport.deleteSync(recursive: true);
+        if (caches.existsSync()) caches.deleteSync(recursive: true);
+      });
+
+      test('totals each root and ranks its children largest first', () async {
+        writeFile('${docs.path}/divine_small.mp4', 100);
+        writeFile('${docs.path}/divine_big.mp4', 900);
+        writeFile('${docs.path}/transition_seams/seam.jpg', 400);
+        writeFile('${appSupport.path}/openvine/database/divine_db.db', 700);
+
+        final footprint = await footprintService().measureFootprint();
+        final documents = footprint.roots.firstWhere(
+          (root) => root.label == 'Documents',
+        );
+
+        expect(documents.totalBytes, 1400);
+        expect(
+          documents.largestChildren.map((child) => child.name),
+          ['divine_big.mp4', 'transition_seams', 'divine_small.mp4'],
+        );
+        expect(documents.largestChildren.first.isDirectory, isFalse);
+        expect(documents.largestChildren[1].isDirectory, isTrue);
+        expect(footprint.totalBytes, 2100);
+      });
+
+      test('counts the durable database no in-app action clears', () async {
+        writeFile('${appSupport.path}/openvine/database/divine_db.db', 4096);
+
+        final footprint = await footprintService().measureFootprint();
+
+        // cacheUsage() reports only what clearCaches() reclaims, so the
+        // database is invisible there — this is what makes the diagnostic
+        // able to explain an unaccounted-for footprint.
+        expect(await footprintService().cacheSizeBytes(), 0);
+        expect(footprint.totalBytes, 4096);
+      });
+
+      test('reports a root shared by two providers once', () async {
+        writeFile('${temp.path}/leftover.mp4', 500);
+
+        // Android resolves the temporary and cache directories to the same
+        // getCacheDir(); counting both would double the reported total.
+        final footprint = await footprintService(
+          cacheDirectory: temp,
+        ).measureFootprint();
+
+        expect(
+          footprint.roots.where((root) => root.path == temp.path),
+          hasLength(1),
+        );
+        expect(footprint.totalBytes, 500);
+      });
+
+      test('report text carries the totals and the biggest entries', () async {
+        writeFile('${docs.path}/divine_big.mp4', 2048);
+
+        final report = (await footprintService().measureFootprint())
+            .toReportText();
+
+        expect(report, contains('Total: 2.0 KB (2048 bytes)'));
+        expect(report, contains('Documents: 2.0 KB (2048 bytes)'));
+        expect(report, contains('divine_big.mp4'));
+      });
+    });
   });
 }

--- a/mobile/test/utils/byte_size_format_test.dart
+++ b/mobile/test/utils/byte_size_format_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/utils/byte_size_format.dart';
+
+void main() {
+  group('formatByteSize', () {
+    test('keeps raw bytes below one kilobyte', () {
+      expect(formatByteSize(0), '0 B');
+      expect(formatByteSize(1023), '1023 B');
+    });
+
+    test('steps up a unit every 1024', () {
+      expect(formatByteSize(1024), '1.0 KB');
+      expect(formatByteSize(1024 * 1024), '1.0 MB');
+      expect(formatByteSize(1024 * 1024 * 1024), '1.0 GB');
+      expect(formatByteSize(1024 * 1024 * 1024 * 1024), '1.0 TB');
+    });
+
+    test('drops the fraction from ten upwards to keep sizes column-width', () {
+      expect(formatByteSize(9 * 1024 * 1024), '9.0 MB');
+      expect(formatByteSize(42 * 1024 * 1024), '42 MB');
+    });
+
+    test('saturates at terabytes rather than inventing a unit', () {
+      expect(formatByteSize(4096 * 1024 * 1024 * 1024), '4.0 TB');
+    });
+  });
+}

--- a/mobile/test/widgets/developer/storage_footprint_section_test.dart
+++ b/mobile/test/widgets/developer/storage_footprint_section_test.dart
@@ -1,5 +1,6 @@
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -95,5 +96,37 @@ void main() {
 
     expect(find.text(l10n.devOptionsStorageFootprintFailure), findsOneWidget);
     expect(find.text(l10n.shareSheetCopy), findsNothing);
+  });
+
+  testWidgets('copy does not claim success when the clipboard refuses it', (
+    tester,
+  ) async {
+    when(service.measureFootprint).thenAnswer((_) async => footprint);
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, (call) async {
+          switch (call.method) {
+            case 'Clipboard.setData':
+              return null;
+            case 'Clipboard.getData':
+              return null;
+          }
+          return null;
+        });
+    addTearDown(
+      () => TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(SystemChannels.platform, null),
+    );
+    final cubit = StorageCubit(service: service);
+    addTearDown(cubit.close);
+
+    await tester.pumpWidget(wrap(cubit));
+    await tester.tap(
+      find.widgetWithText(DivineButton, l10n.devOptionsStorageFootprintMeasure),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(DivineButton, l10n.shareSheetCopy));
+    await tester.pumpAndSettle();
+
+    expect(find.text(l10n.devOptionsStorageFootprintCopied), findsNothing);
   });
 }

--- a/mobile/test/widgets/developer/storage_footprint_section_test.dart
+++ b/mobile/test/widgets/developer/storage_footprint_section_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/blocs/storage/storage_cubit.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/models/storage_footprint.dart';
 import 'package:openvine/services/storage_management_service.dart';
 import 'package:openvine/widgets/developer/storage_footprint_section.dart';
 

--- a/mobile/test/widgets/developer/storage_footprint_section_test.dart
+++ b/mobile/test/widgets/developer/storage_footprint_section_test.dart
@@ -32,6 +32,7 @@ void main() {
             isDirectory: true,
           ),
         ],
+        childCount: 2,
       ),
     ],
   );

--- a/mobile/test/widgets/developer/storage_footprint_section_test.dart
+++ b/mobile/test/widgets/developer/storage_footprint_section_test.dart
@@ -1,0 +1,97 @@
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/blocs/storage/storage_cubit.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/services/storage_management_service.dart';
+import 'package:openvine/widgets/developer/storage_footprint_section.dart';
+
+class _MockService extends Mock implements StorageManagementService {}
+
+void main() {
+  final l10n = lookupAppLocalizations(const Locale('en'));
+
+  const footprint = StorageFootprint(
+    roots: [
+      StorageFootprintRoot(
+        label: 'Documents',
+        path: '/documents',
+        totalBytes: 3 * 1024 * 1024,
+        largestChildren: [
+          StorageFootprintEntry(
+            name: 'divine_1712.mp4',
+            bytes: 2 * 1024 * 1024,
+            isDirectory: false,
+          ),
+          StorageFootprintEntry(
+            name: 'transition_seams',
+            bytes: 1024 * 1024,
+            isDirectory: true,
+          ),
+        ],
+      ),
+    ],
+  );
+
+  late _MockService service;
+
+  setUp(() => service = _MockService());
+
+  Widget wrap(StorageCubit cubit) => MaterialApp(
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    home: Scaffold(
+      body: BlocProvider.value(
+        value: cubit,
+        child: const SingleChildScrollView(child: StorageFootprintView()),
+      ),
+    ),
+  );
+
+  testWidgets('measuring lists every root with its biggest entries', (
+    tester,
+  ) async {
+    when(service.measureFootprint).thenAnswer((_) async => footprint);
+    final cubit = StorageCubit(service: service);
+    addTearDown(cubit.close);
+
+    await tester.pumpWidget(wrap(cubit));
+    await tester.tap(
+      find.widgetWithText(
+        DivineButton,
+        l10n.devOptionsStorageFootprintMeasure,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.text(l10n.devOptionsStorageFootprintTotal('3.0 MB')),
+      findsOneWidget,
+    );
+    expect(find.text('Documents — 3.0 MB'), findsOneWidget);
+    expect(find.text('divine_1712.mp4'), findsOneWidget);
+    expect(find.text('transition_seams/'), findsOneWidget);
+  });
+
+  testWidgets('a failed walk says so instead of showing a stale total', (
+    tester,
+  ) async {
+    when(service.measureFootprint).thenThrow(Exception('boom'));
+    final cubit = StorageCubit(service: service);
+    addTearDown(cubit.close);
+
+    await tester.pumpWidget(wrap(cubit));
+    await tester.tap(
+      find.widgetWithText(
+        DivineButton,
+        l10n.devOptionsStorageFootprintMeasure,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text(l10n.devOptionsStorageFootprintFailure), findsOneWidget);
+    expect(find.text(l10n.shareSheetCopy), findsNothing);
+  });
+}


### PR DESCRIPTION
## Description

Settings → Storage measures and clears only what "Clear cache" can reclaim — the two media cache directories, `documents/transition_seams`, and three temp-render filename patterns. It therefore cannot explain a footprint that sits anywhere else, and there is no other in-app way to find out where the bytes are.

The support report that prompted this: iOS, the OS reports 42 GB, the Storage screen reports 2 GB, "Repair" already run, only a handful of clips in the library. Ruling out what "Repair" wipes leaves the documents directory and the durable database, but nothing in the shipped build can confirm which — or how much.

This adds **Developer Options → Storage Footprint**. It walks all four platform roots (Documents, Application Support, Caches, Temporary), reports each root's total plus its 12 largest immediate entries, and offers a copy action that produces a plain-text report for a support thread.

Details worth calling out:

- **Roots that resolve to the same directory are reported once.** On Android `getTemporaryDirectory()` and `getApplicationCacheDirectory()` both return `getCacheDir()`; counting both would double the total.
- **The report is deliberately unlocalized.** It is read by whoever triages, not by the user, and mixed-locale reports are hard to compare. Raw byte counts sit next to the readable size so a report stays sortable.
- **The measurement sits behind an explicit action.** It walks every root in full, which is slow on a large install.
- **`measureFootprint()` guards on `isClosed` after its await**, so the walk landing after the user navigated away cannot emit and the post-close-emit ceiling does not grow.
- **A size walk no longer stops at the first directory it cannot read.** `_dirSize` listed with `recursive: true`, which surfaces the whole tree through one stream, so the first unreadable subdirectory — or a file deleted between listing and `stat` — threw and abandoned everything not yet visited. A tree holding 1000 readable bytes reported 0. It now descends one level at a time, isolating a failure to the directory that caused it. The realistic trigger on device is the file race rather than permissions: the cache trim and the temp-render janitor delete files while a walk of the same root is still running.
- **This changes existing behaviour beyond the diagnostic.** `_dirSize` also backs `cacheUsage()`, so the Storage screen could report 0 for a category whose directory the walk could not finish. That number may now go up. Flagging it explicitly because it is a user-visible change this PR did not set out to make.
- **The report says what it left out.** Each root printed its full total but only its 12 biggest children, so the listed sizes looked like they should add up and did not. Roots carry `childCount` and the report ends each one with `<size>	(N smaller entries not listed)`.
- **A merged root names both providers.** On Android `getTemporaryDirectory()` and `getApplicationCacheDirectory()` are the same directory; the later label used to be dropped without a trace, so an Android report had one root fewer than an iOS one with no explanation. Such a root is now labelled `Caches + Temporary`.
- **The byte formatter was already duplicated** between the Storage screen and `BugReportService`. The screen's copy moves to `lib/utils/byte_size_format.dart` and is now shared; `BugReportService` keeps its own `_formatBytesShort`, which has different semantics (always MB/GB).

**Related Issue:** Relates to #7641. Closes #none — that issue tracks the actual fix (accounting for the documents directory, an orphan sweep, and the missing temp-render patterns); this PR only makes the footprint measurable.

## Out of Scope

- The fix itself — documents-directory accounting, the orphan sweep for files with no clip or draft row, and the temp-render patterns `clearCaches()` misses. Tracked in #7641.
- Database retention, the missing `VACUUM`, and surfacing the SQLite file in the Storage screen. Tracked in #6987.
- Anything user-facing: this is developer-mode only (Settings → 7 taps on the version → Developer Options).

## Verification

- `flutter analyze lib test integration_test` — clean.
- `flutter test` for `test/services/storage_management_service_test.dart`, `test/blocs/storage/storage_cubit_test.dart`, `test/widgets/developer/storage_footprint_section_test.dart`, `test/utils/byte_size_format_test.dart`, `test/screens/settings/storage/`, `test/screens/developer_options_screen_test.dart` — all green.
- `flutter test test/l10n/arb_consistency_test.dart` — green. The six new keys are translated in all 22 locales, not left as English fallback.
- Ratchets run locally, all OK: `post_close_emit`, `untested_services_floor`, `raw_textstyle`, `raw_colors`, `material_button`, `raw_dialog`, `layer_direction`, `test_unit_structure`.
- Manually verified on device: measure, per-root breakdown, and copy.
- The walk-truncation regression test was confirmed to fail against the pre-fix `_dirSize` with `Expected: <1000> Actual: <0>`.

New test coverage: root totals and child ranking, the same-directory dedupe and its merged label, an unreadable subdirectory not zeroing its readable siblings, the report's accounting for unlisted entries, the durable database being counted by the footprint while `cacheSizeBytes()` still reports zero for it, the report text, the cubit's measured/failure/after-close paths, and the two view states.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

