### PR TITLE
docs(branding): correct the claim that the icon plate is flat Brand Green

### DIFF
--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -521,8 +521,11 @@ flutter_launcher_icons:
   image_path: "assets/icon/app_icon.png"
   min_sdk_android: 21
   remove_alpha_ios: true
-  # Fills the adaptive icon's reserved border behind the inset app icon, so it
-  # has to be the same Brand Green the icon's plate is drawn in.
+  # Fills the adaptive icon's reserved border behind the inset app icon. The
+  # artwork's plate is a diagonal gradient (#7BF9BC to #1B8865), not flat Brand
+  # Green, so no single colour here can match it — the border reads as a
+  # two-tone square, the same defect #7610 tracks for the web maskable icons.
+  # The fix is a plate-free foreground asset, not a different colour here.
   adaptive_icon_background: "#27C58B"
   adaptive_icon_foreground: "assets/icon/app_icon.png"
 


### PR DESCRIPTION
Closes #7653

Related to #7610 — **does not close it.** The icon fix was reverted after review; see the handback below and on #7610.

## What is left in this PR

One comment correction in `mobile/pubspec.yaml`. It said `adaptive_icon_background` has to be "the same Brand Green the icon's plate is drawn in". It isn't: `assets/icon/app_icon.png` is a diagonal gradient, `#7BF9BC` at its top-left corner down to `#1B8865` at its bottom-right. No single flat colour can match it, so the adaptive icon's reserved border reads as a two-tone square at up to **26.96 ΔE**.

That false premise is exactly what made the flat fill look sufficient on both the Android adaptive icon and the web maskable icons.

## What was reverted, and why

The first version of this PR stripped the plate out of the artwork with the favicon's colour key before compositing. @hm21 caught that it damages the logo, and the measurements back that up — the mark's anti-aliased edges and its drop shadow are *composited onto* the green plate, so a colour key removes them along with the plate. The wing feathers came out speckled and the grounding shadow disappeared entirely.

I then tried two more approaches and neither is shippable either:

| approach | field | mark | verdict |
|---|---|---|---|
| colour-key strip | flat Brand Green | **damaged** — chewed feathers, no shadow | rejected in review |
| extend the artwork's gradient outward | continuous gradient, not flat green | intact | contradicts "make everything green" |
| relight against a fitted plate model | flat to ~3 levels mean | intact | leaves a faint rectangle + diagonal banding, and needs ~50 lines of image maths in a build script |

Three distinct approaches, one shared constraint: **mark and plate cannot be cleanly separated in a flattened raster.**

## What actually fixes it

A layered export, which is what @hm21 suggested. A plate-free foreground PNG with real alpha — same 1024² canvas, mark at the same position and scale — makes this a two-line generator change, gives a perfect flat field with the shadow and anti-aliasing intact, and **fixes the Android adaptive icon with the same asset**.

Parking the icon work until that lands rather than shipping an approximation.

## Test plan

- [x] `flutter test test/tools/app_icon_set_test.dart` — 11/11
- [x] `flutter analyze lib test integration_test` — no issues
- [x] Icons, generator, and tests are byte-identical to `main`; the diff is one comment