### PR TITLE
test(profile): re-enable profile router URL sync tests

### DIFF
--- a/mobile/scripts/baseline/skip_tests.txt
+++ b/mobile/scripts/baseline/skip_tests.txt
@@ -39,7 +39,6 @@ test/screens/hashtag_feed_loading_test.dart
 test/screens/hashtag_feed_screen_tdd_test.dart
 test/screens/hashtag_grid_view_simple_test.dart
 test/screens/profile_menu_drafts_navigation_test.dart
-test/screens/profile_screen_router_test.dart
 test/screens/profile_share_edit_buttons_test.dart
 test/screens/relay_settings_nip11_info_test.dart
 test/screens/video_editor/video_text_editor_screen_test.dart

--- a/mobile/test/screens/profile_screen_router_test.dart
+++ b/mobile/test/screens/profile_screen_router_test.dart
@@ -1,5 +1,7 @@
 // ABOUTME: Tests for router-driven ProfileScreen implementation
-// ABOUTME: Verifies URL ↔ PageView synchronization for profile feeds
+// ABOUTME: Verifies URL ↔ playback synchronization for profile feeds
+
+import 'dart:async';
 
 import 'package:content_blocklist_repository/content_blocklist_repository.dart';
 import 'package:divine_ui/divine_ui.dart';
@@ -8,13 +10,16 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/active_video_provider.dart';
-import 'package:openvine/providers/app_lifecycle_provider.dart';
+import 'package:openvine/providers/app_foreground_provider.dart';
 import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/profile_feed_providers.dart';
 import 'package:openvine/router/router.dart';
 import 'package:openvine/screens/feed/video_feed_page.dart';
 import 'package:openvine/screens/profile_screen_router.dart';
+import 'package:openvine/state/video_feed_state.dart';
 import 'package:openvine/widgets/profile/blocked_user_screen.dart';
 
 import '../helpers/test_provider_overrides.dart';
@@ -22,81 +27,121 @@ import '../helpers/test_provider_overrides.dart';
 class _MockContentBlocklistRepository extends Mock
     implements ContentBlocklistRepository {}
 
+const _npub = 'npub1424242424242424242424242424242424242424242424242424qamrcaj';
+const _authorPubkeyHex =
+    'aaaa552aaaa552aaaa552aaaa552aaaa552aaaa552aaaa552aaaa552aaaa552a';
+
 void main() {
-  Widget shell(ProviderContainer c) => UncontrolledProviderScope(
-    container: c,
-    child: MaterialApp.router(
-      localizationsDelegates: AppLocalizations.localizationsDelegates,
-      supportedLocales: AppLocalizations.supportedLocales,
-      routerConfig: c.read(goRouterProvider),
-    ),
+  final now = DateTime.now();
+  final nowUnix = now.millisecondsSinceEpoch ~/ 1000;
+
+  VideoEvent video(String id) => VideoEvent(
+    id: id,
+    pubkey: _authorPubkeyHex,
+    createdAt: nowUnix,
+    content: 'Profile video $id',
+    timestamp: now,
+    title: id,
+    videoUrl: 'https://example.com/$id.mp4',
   );
 
-  // The three skipped tests below used to seed the profile feed by overriding
-  // videosForProfileRouteProvider. #7680 deleted that provider — the profile
-  // feed is the REST-backed ProfileFeedCubit — so whoever re-enables them
-  // seeds through ProfileFeedScope instead.
-  testWidgets('PROFILE: URL ↔ PageView sync', (tester) async {
-    final c = ProviderContainer();
-    addTearDown(c.dispose);
+  final mockVideos = [
+    video('profile-video-0'),
+    video('profile-video-1'),
+    video('profile-video-2'),
+  ];
 
-    await tester.pumpWidget(shell(c));
-    c.read(goRouterProvider).go(ProfileScreenRouter.pathForIndex('npubXYZ', 0));
-    await tester.pumpAndSettle();
+  // The URL is the source of truth for which profile video plays:
+  // routerLocationStreamProvider -> pageContextProvider -> activeVideoIdProvider.
+  // videosForProfileRouteProvider is the list that provider indexes into; the
+  // grid/feed widgets get their own copy from ProfileFeedCubit.
+  group('profile URL drives the active video', () {
+    ProviderContainer profileContainer({
+      required Stream<String> locations,
+      required List<VideoEvent> videos,
+    }) {
+      final container = ProviderContainer(
+        overrides: [
+          routerLocationStreamProvider.overrideWithValue(locations),
+          videosForProfileRouteProvider.overrideWithValue(
+            AsyncValue.data(
+              VideoFeedState(videos: videos, hasMoreContent: false),
+            ),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      // Keep the location stream subscribed for the whole test; no widget
+      // tree is mounted here to do it.
+      container.listen(pageContextProvider, (_, _) {}, fireImmediately: true);
+      container.listen(activeVideoIdProvider, (_, _) {}, fireImmediately: true);
+      return container;
+    }
 
-    expect(find.byType(ProfileScreenRouter), findsOneWidget);
+    test('the index segment selects the matching video', () async {
+      final locations = StreamController<String>();
+      addTearDown(locations.close);
+      final container = profileContainer(
+        locations: locations.stream,
+        videos: mockVideos,
+      );
 
-    // Verify first video shown
-    expect(find.text('Profile 0/3'), findsOneWidget);
+      locations.add(ProfileScreenRouter.pathForIndex(_npub, 0));
+      await pumpEventQueue();
 
-    // Navigate to index 1
-    c.read(goRouterProvider).go(ProfileScreenRouter.pathForIndex('npubXYZ', 1));
-    await tester.pumpAndSettle();
+      expect(container.read(activeVideoIdProvider), mockVideos[0].stableId);
 
-    // Verify second video shown
-    expect(find.text('Profile 1/3'), findsOneWidget);
-    // TODO(#7160): Fix and re-enable this test.
-  }, skip: true);
+      locations.add(ProfileScreenRouter.pathForIndex(_npub, 1));
+      await pumpEventQueue();
 
-  testWidgets('PROFILE: Empty state shows when no videos', (tester) async {
-    final c = ProviderContainer();
-    addTearDown(c.dispose);
+      expect(container.read(activeVideoIdProvider), mockVideos[1].stableId);
+    });
 
-    await tester.pumpWidget(shell(c));
-    c.read(goRouterProvider).go(ProfileScreenRouter.pathForIndex('npubXYZ', 0));
-    await tester.pumpAndSettle();
+    test('an empty profile feed leaves nothing playing', () async {
+      final locations = StreamController<String>();
+      addTearDown(locations.close);
+      final container = profileContainer(
+        locations: locations.stream,
+        videos: const [],
+      );
 
-    expect(find.textContaining('No posts yet'), findsOneWidget);
-    // TODO(#7160): Fix and re-enable this test.
-  }, skip: true);
+      locations.add(ProfileScreenRouter.pathForIndex(_npub, 0));
+      await pumpEventQueue();
 
-  testWidgets('PROFILE: Lifecycle pause → activeVideoId becomes null', (
-    tester,
-  ) async {
-    final c = ProviderContainer(
-      overrides: [
-        appForegroundProvider.overrideWithValue(const AsyncValue.data(false)),
-      ],
+      expect(container.read(activeVideoIdProvider), isNull);
+    });
+
+    test(
+      'backgrounding clears the active video, resuming restores it',
+      () async {
+        final locations = StreamController<String>();
+        addTearDown(locations.close);
+        final container = profileContainer(
+          locations: locations.stream,
+          videos: mockVideos,
+        );
+
+        locations.add(ProfileScreenRouter.pathForIndex(_npub, 1));
+        await pumpEventQueue();
+
+        expect(container.read(activeVideoIdProvider), mockVideos[1].stableId);
+
+        container.read(appForegroundProvider.notifier).setForeground(false);
+
+        expect(container.read(activeVideoIdProvider), isNull);
+
+        container.read(appForegroundProvider.notifier).setForeground(true);
+
+        expect(container.read(activeVideoIdProvider), mockVideos[1].stableId);
+      },
     );
-    addTearDown(c.dispose);
-
-    await tester.pumpWidget(shell(c));
-    c.read(goRouterProvider).go(ProfileScreenRouter.pathForIndex('npubXYZ', 1));
-    await tester.pumpAndSettle();
-
-    // When backgrounded, active video should be null
-    expect(c.read(activeVideoIdProvider), isNull);
-    // TODO(#7160): Fix and re-enable this test.
-  }, skip: true);
+  });
 
   // A divine:///profile/<npub> or https://divine.video/profile/<npub> deep
   // link lands on this route with a one-entry stack. When that account has
   // blocked or muted the viewer the screen swaps to BlockedUserScreen, whose
   // app-bar back used to be a raw context.pop — GoError, dead caret.
   group('$BlockedUserScreen back affordance', () {
-    const npub =
-        'npub1424242424242424242424242424242424242424242424242424qamrcaj';
-
     testWidgets('back lands on the feed when there is nothing to pop', (
       tester,
     ) async {
@@ -104,7 +149,7 @@ void main() {
       when(() => blocklistRepository.hasBlockedUs(any())).thenReturn(true);
       when(() => blocklistRepository.hasMutedUs(any())).thenReturn(false);
 
-      final profilePath = ProfileScreenRouter.pathForNpub(npub);
+      final profilePath = ProfileScreenRouter.pathForNpub(_npub);
       final router = GoRouter(
         initialLocation: profilePath,
         routes: [

--- a/mobile/test/screens/profile_screen_router_test.dart
+++ b/mobile/test/screens/profile_screen_router_test.dart
@@ -89,8 +89,12 @@ class _InMemoryCacheDao implements CacheDao {
 }
 
 const _npub = 'npub1424242424242424242424242424242424242424242424242424qamrcaj';
+
+/// The hex [_npub] decodes to. The profile route carries the npub while the
+/// feed carries hex, and [ProfileFeedCubit] drops live updates whose pubkey
+/// does not match the profile's, so the two must describe one identity.
 const _authorPubkeyHex =
-    'aaaa552aaaa552aaaa552aaaa552aaaa552aaaa552aaaa552aaaa552aaaa552a';
+    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
 
 void main() {
   final now = DateTime.now();

--- a/mobile/test/screens/profile_screen_router_test.dart
+++ b/mobile/test/screens/profile_screen_router_test.dart
@@ -10,7 +10,6 @@ import 'package:content_policy/content_policy.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mocktail/mocktail.dart';
@@ -20,16 +19,12 @@ import 'package:openvine/blocs/fullscreen_feed/fullscreen_feed_bloc.dart';
 import 'package:openvine/blocs/video_volume/video_volume_cubit.dart';
 import 'package:openvine/features/people_lists/bloc/people_lists_bloc.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
-import 'package:openvine/providers/active_video_provider.dart';
-import 'package:openvine/providers/app_foreground_provider.dart';
 import 'package:openvine/providers/app_providers.dart';
-import 'package:openvine/providers/profile_feed_providers.dart';
 import 'package:openvine/router/router.dart';
 import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
 import 'package:openvine/screens/feed/video_feed_page.dart';
 import 'package:openvine/screens/profile_screen_router.dart';
 import 'package:openvine/services/video_event_service.dart';
-import 'package:openvine/state/video_feed_state.dart';
 import 'package:openvine/widgets/profile/blocked_user_screen.dart';
 import 'package:videos_repository/videos_repository.dart';
 
@@ -117,96 +112,10 @@ void main() {
     video('profile-video-2'),
   ];
 
-  // The URL is the source of truth for which profile video plays:
-  // routerLocationStreamProvider -> pageContextProvider -> activeVideoIdProvider.
-  // videosForProfileRouteProvider is the list that provider indexes into; the
-  // grid/feed widgets get their own copy from ProfileFeedCubit.
-  group('profile URL drives the active video', () {
-    ProviderContainer profileContainer({
-      required Stream<String> locations,
-      required List<VideoEvent> videos,
-    }) {
-      final container = ProviderContainer(
-        overrides: [
-          routerLocationStreamProvider.overrideWithValue(locations),
-          videosForProfileRouteProvider.overrideWithValue(
-            AsyncValue.data(
-              VideoFeedState(videos: videos, hasMoreContent: false),
-            ),
-          ),
-        ],
-      );
-      addTearDown(container.dispose);
-      // Keep the location stream subscribed for the whole test; no widget
-      // tree is mounted here to do it.
-      container.listen(pageContextProvider, (_, _) {}, fireImmediately: true);
-      container.listen(activeVideoIdProvider, (_, _) {}, fireImmediately: true);
-      return container;
-    }
-
-    test('the index segment selects the matching video', () async {
-      final locations = StreamController<String>();
-      addTearDown(locations.close);
-      final container = profileContainer(
-        locations: locations.stream,
-        videos: mockVideos,
-      );
-
-      locations.add(ProfileScreenRouter.pathForIndex(_npub, 0));
-      await pumpEventQueue();
-
-      expect(container.read(activeVideoIdProvider), mockVideos[0].stableId);
-
-      locations.add(ProfileScreenRouter.pathForIndex(_npub, 1));
-      await pumpEventQueue();
-
-      expect(container.read(activeVideoIdProvider), mockVideos[1].stableId);
-    });
-
-    test('an empty profile feed leaves nothing playing', () async {
-      final locations = StreamController<String>();
-      addTearDown(locations.close);
-      final container = profileContainer(
-        locations: locations.stream,
-        videos: const [],
-      );
-
-      locations.add(ProfileScreenRouter.pathForIndex(_npub, 0));
-      await pumpEventQueue();
-
-      expect(container.read(activeVideoIdProvider), isNull);
-    });
-
-    test(
-      'backgrounding clears the active video, resuming restores it',
-      () async {
-        final locations = StreamController<String>();
-        addTearDown(locations.close);
-        final container = profileContainer(
-          locations: locations.stream,
-          videos: mockVideos,
-        );
-
-        locations.add(ProfileScreenRouter.pathForIndex(_npub, 1));
-        await pumpEventQueue();
-
-        expect(container.read(activeVideoIdProvider), mockVideos[1].stableId);
-
-        container.read(appForegroundProvider.notifier).setForeground(false);
-
-        expect(container.read(activeVideoIdProvider), isNull);
-
-        container.read(appForegroundProvider.notifier).setForeground(true);
-
-        expect(container.read(activeVideoIdProvider), mockVideos[1].stableId);
-      },
-    );
-  });
-
-  // The provider group above stops at activeVideoIdProvider, whose profile
-  // branch only feeds upload gating. What actually opens a page is the chain
+  // The URL is the source of truth for which profile video plays, through
   // URL -> ProfileScreenRouter -> ProfileViewSwitcher -> ProfileVideoFeedView
-  // -> PooledFullscreenVideoFeedScreen, so pin that end to end (#7160).
+  // -> PooledFullscreenVideoFeedScreen. Assert the video the fullscreen feed
+  // actually shows, so a dropped index anywhere in that chain fails (#7160).
   group('profile feed URL opens the matching page', () {
     late _MockVideosRepository videosRepository;
     late _MockVideoEventService videoEventService;

--- a/mobile/test/screens/profile_screen_router_test.dart
+++ b/mobile/test/screens/profile_screen_router_test.dart
@@ -3,29 +3,95 @@
 
 import 'dart:async';
 
+import 'package:bloc_test/bloc_test.dart';
+import 'package:cache_sync/cache_sync.dart';
 import 'package:content_blocklist_repository/content_blocklist_repository.dart';
+import 'package:content_policy/content_policy.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
+import 'package:openvine/blocs/background_publish/background_publish_bloc.dart';
+import 'package:openvine/blocs/fullscreen_feed/fullscreen_feed_bloc.dart';
+import 'package:openvine/blocs/video_volume/video_volume_cubit.dart';
+import 'package:openvine/features/people_lists/bloc/people_lists_bloc.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/active_video_provider.dart';
 import 'package:openvine/providers/app_foreground_provider.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/profile_feed_providers.dart';
 import 'package:openvine/router/router.dart';
+import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
 import 'package:openvine/screens/feed/video_feed_page.dart';
 import 'package:openvine/screens/profile_screen_router.dart';
+import 'package:openvine/services/video_event_service.dart';
 import 'package:openvine/state/video_feed_state.dart';
 import 'package:openvine/widgets/profile/blocked_user_screen.dart';
+import 'package:videos_repository/videos_repository.dart';
 
 import '../helpers/test_provider_overrides.dart';
 
 class _MockContentBlocklistRepository extends Mock
     implements ContentBlocklistRepository {}
+
+class _MockVideosRepository extends Mock implements VideosRepository {}
+
+class _MockVideoEventService extends Mock implements VideoEventService {}
+
+class _MockBackgroundPublishBloc
+    extends MockBloc<BackgroundPublishEvent, BackgroundPublishState>
+    implements BackgroundPublishBloc {}
+
+class _MockPeopleListsBloc extends MockBloc<PeopleListsEvent, PeopleListsState>
+    implements PeopleListsBloc {}
+
+class _FakeVideoEvent extends Fake implements VideoEvent {}
+
+class _FakeSystemVolumeListener implements SystemVolumeListener {
+  @override
+  void hideSystemUI() {}
+
+  @override
+  StreamSubscription<double> listen(void Function(double volume) onData) {
+    return const Stream<double>.empty().listen(onData);
+  }
+}
+
+/// In-memory [CacheDao] so the [ProfileFeedCubit]'s [CacheSync] reads/writes
+/// stay isolated per test under the merged `--optimization` isolate.
+class _InMemoryCacheDao implements CacheDao {
+  final Map<String, String> _store = {};
+
+  @override
+  Future<String?> read(String key) async => _store[key];
+
+  @override
+  Future<void> write({
+    required String key,
+    required String payload,
+    Duration? ttl,
+  }) async {
+    _store[key] = payload;
+  }
+
+  @override
+  Future<void> delete(String key) async => _store.remove(key);
+
+  @override
+  Future<void> deletePrefix(String prefix) async =>
+      _store.removeWhere((key, _) => key.startsWith(prefix));
+
+  @override
+  Future<int> totalPayloadBytes() async =>
+      _store.values.fold<int>(0, (sum, v) => sum + v.length);
+
+  @override
+  Future<void> evictOldest(int bytesToFree) async {}
+}
 
 const _npub = 'npub1424242424242424242424242424242424242424242424242424qamrcaj';
 const _authorPubkeyHex =
@@ -135,6 +201,171 @@ void main() {
         expect(container.read(activeVideoIdProvider), mockVideos[1].stableId);
       },
     );
+  });
+
+  // The provider group above stops at activeVideoIdProvider, whose profile
+  // branch only feeds upload gating. What actually opens a page is the chain
+  // URL -> ProfileScreenRouter -> ProfileViewSwitcher -> ProfileVideoFeedView
+  // -> PooledFullscreenVideoFeedScreen, so pin that end to end (#7160).
+  group('profile feed URL opens the matching page', () {
+    late _MockVideosRepository videosRepository;
+    late _MockVideoEventService videoEventService;
+    late _MockContentBlocklistRepository blocklistRepository;
+    late _MockBackgroundPublishBloc backgroundPublishBloc;
+    late _MockPeopleListsBloc peopleListsBloc;
+
+    setUpAll(() {
+      registerFallbackValue(_FakeVideoEvent());
+    });
+
+    setUp(() async {
+      await CacheSync.init(dao: _InMemoryCacheDao());
+
+      videosRepository = _MockVideosRepository();
+      videoEventService = _MockVideoEventService();
+      blocklistRepository = _MockContentBlocklistRepository();
+      backgroundPublishBloc = _MockBackgroundPublishBloc();
+      peopleListsBloc = _MockPeopleListsBloc();
+
+      whenListen(
+        backgroundPublishBloc,
+        const Stream<BackgroundPublishState>.empty(),
+        initialState: const BackgroundPublishState(),
+      );
+      whenListen(
+        peopleListsBloc,
+        const Stream<PeopleListsState>.empty(),
+        initialState: const PeopleListsState(),
+      );
+
+      when(
+        () => videosRepository.getAuthorFeed(
+          authorPubkey: any(named: 'authorPubkey'),
+          offset: any(named: 'offset'),
+          relaySeed: any(named: 'relaySeed'),
+          skipCache: any(named: 'skipCache'),
+        ),
+      ).thenAnswer(
+        (_) async => AuthorFeedResult(
+          authorPubkey: _authorPubkeyHex,
+          videos: mockVideos,
+          hasMore: false,
+        ),
+      );
+
+      when(
+        () => videosRepository.removedVideoIds,
+      ).thenAnswer((_) => const Stream<String>.empty());
+
+      when(
+        () => videoEventService.authorVideos(any()),
+      ).thenReturn(const <VideoEvent>[]);
+      when(
+        () => videoEventService.filterVideoList(any()),
+      ).thenAnswer((i) => i.positionalArguments.first as List<VideoEvent>);
+      when(() => videoEventService.shouldHideVideo(any())).thenReturn(false);
+      when(
+        () => videoEventService.isVideoEventKnownDeleted(any()),
+      ).thenReturn(false);
+      when(
+        () => videoEventService.subscribeToUserVideos(any()),
+      ).thenAnswer((_) async {});
+      when(() => videoEventService.addListener(any())).thenReturn(null);
+      when(() => videoEventService.removeListener(any())).thenReturn(null);
+      when(
+        () => videoEventService.addVideoUpdateListener(any()),
+      ).thenReturn(() {});
+      when(
+        () => videoEventService.removedVideoIds,
+      ).thenAnswer((_) => const Stream<String>.empty());
+      when(
+        () => blocklistRepository.shouldFilterFromFeeds(any()),
+      ).thenReturn(false);
+      when(() => blocklistRepository.isBlocked(any())).thenReturn(false);
+      when(() => blocklistRepository.hasBlockedUs(any())).thenReturn(false);
+      when(() => blocklistRepository.hasMutedUs(any())).thenReturn(false);
+      when(
+        () => blocklistRepository.currentState,
+      ).thenReturn(ContentPolicyState.empty());
+      when(
+        () => blocklistRepository.stateStream,
+      ).thenAnswer((_) => const Stream<ContentPolicyState>.empty());
+    });
+
+    Future<FullscreenFeedBloc> pumpProfileAt(
+      WidgetTester tester,
+      int index,
+    ) async {
+      final location = ProfileScreenRouter.pathForIndex(_npub, index);
+      final router = GoRouter(
+        initialLocation: location,
+        routes: [
+          GoRoute(
+            path: ProfileScreenRouter.pathWithIndex,
+            builder: (_, _) => const ProfileScreenRouter(),
+          ),
+        ],
+      );
+      addTearDown(router.dispose);
+
+      await tester.pumpWidget(
+        testProviderScope(
+          additionalOverrides: [
+            videosRepositoryProvider.overrideWithValue(videosRepository),
+            videoEventServiceProvider.overrideWithValue(videoEventService),
+            contentBlocklistRepositoryProvider.overrideWithValue(
+              blocklistRepository,
+            ),
+            routerLocationStreamProvider.overrideWithValue(
+              Stream.value(location),
+            ),
+          ],
+          child: MaterialApp.router(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            routerConfig: router,
+            builder: (context, child) => MultiBlocProvider(
+              providers: [
+                BlocProvider<BackgroundPublishBloc>.value(
+                  value: backgroundPublishBloc,
+                ),
+                BlocProvider<PeopleListsBloc>.value(value: peopleListsBloc),
+                BlocProvider<VideoVolumeCubit>(
+                  create: (_) => VideoVolumeCubit(
+                    sharedPreferences: createMockSharedPreferences(),
+                    systemVolumeListener: _FakeSystemVolumeListener(),
+                  ),
+                ),
+              ],
+              // The app shell supplies the Scaffold for in-shell profile
+              // routes; this stand-in does the same.
+              child: Scaffold(body: child ?? const SizedBox.shrink()),
+            ),
+          ),
+        ),
+      );
+
+      await tester.runAsync(() async {
+        await Future<void>.delayed(Duration.zero);
+      });
+      await tester.pump();
+      await tester.pump();
+
+      final content = tester.element(find.byType(FullscreenFeedContent));
+      return content.read<FullscreenFeedBloc>();
+    }
+
+    testWidgets('index 0 in the URL opens the first video', (tester) async {
+      final bloc = await pumpProfileAt(tester, 0);
+
+      expect(bloc.state.currentVideo?.id, mockVideos[0].id);
+    });
+
+    testWidgets('index 1 in the URL opens the second video', (tester) async {
+      final bloc = await pumpProfileAt(tester, 1);
+
+      expect(bloc.state.currentVideo?.id, mockVideos[1].id);
+    });
   });
 
   // A divine:///profile/<npub> or https://divine.video/profile/<npub> deep


### PR DESCRIPTION
## Description

`mobile/test/screens/profile_screen_router_test.dart` carried three `skip: true` widget tests for profile URL ↔ feed synchronization, tracked by #7160. This replaces them with coverage that runs the real router → fullscreen chain, and drops the file from the skip baseline.

**Why the originals could not simply be un-skipped.** All three built a bare `ProviderContainer` and called `c.read(goRouterProvider)`, which pulls `authServiceProvider` → `sharedPreferencesProvider` and throws `UnimplementedError` by design outside `main.dart`. Every one died in the `shell()` helper before reaching an assertion. Their assertions had rotted independently of that: `find.text('Profile 0/3')` matches nothing in `lib/`, the "No posts yet" empty state is already covered by `test/widgets/profile/profile_videos_grid_test.dart`, and the lifecycle test overrode the legacy `appForegroundProvider` rather than the generated notifier that actually gates playback.

**What the tests assert now.** The URL is the source of truth for which profile video plays, so the tests mount the whole production chain and assert the video the fullscreen feed actually shows:

```
/profile/<npub>/<index>
  → ProfileScreenRouter → ProfileViewSwitcher → ProfileVideoFeedView
  → PooledFullscreenVideoFeedScreen → FullscreenFeedBloc.state.currentVideo
```

| Test | Pins |
|---|---|
| index 0 in the URL opens the first video | `/profile/<npub>/0` → the fullscreen bloc holds video 0 |
| index 1 in the URL opens the second video | `/profile/<npub>/1` → the fullscreen bloc holds video 1 |
| `BlockedUserScreen` back lands on the feed when there is nothing to pop | cold deep link into a blocked profile leaves a one-entry stack, and the app-bar back still reaches the feed instead of throwing `GoError` |

Because the assertion is on the bloc's selected video rather than a provider alongside it, a dropped index anywhere in that chain fails the test. The profile feed is seeded through `ProfileFeedScope` / `ProfileFeedCubit` (funnelcake REST via `videos_repository`), matching how the screen loads in production.

**Related Issue:** Closes #7160

## Out of Scope

Two adjacent findings are deliberately left alone rather than widening this PR, both tracked in #7651 because they share a file:

- `lib/providers/app_lifecycle_provider.dart` has no production importer; its `appForegroundProvider` is referenced only by tests that override it believing it gates playback.
- `test/providers/explore_active_video_test.dart` still has two `skip: true` tests carrying anonymous `TODO(any)` markers — the same shape #7160 was filed to remove, in a different file.

## Verification

Run from `mobile/`, rebased onto `origin/main` at `bf3f583823`:

- `flutter test test/screens/profile_screen_router_test.dart` — 3/3 pass, 0 skipped
- `flutter test` over the profile screen neighbours, `--test-randomize-ordering-seed random` — 80 pass, 8 pre-existing skips
- `flutter analyze lib test integration_test` — no issues
- `dart analyze --fatal-infos` on the changed file — no issues
- `dart format` — clean
- `bash scripts/check_skip_ceiling.sh`, `check_test_unit_structure.sh`, `check_l10n_delegates_ceiling.sh` — all OK
- Mutation check: forcing `videoIndex: 0` at the `ProfileVideoFeedView` call site in `lib/screens/profile_screen_router.dart` turns the index-1 test red (`Expected: 'profile-video-1' Actual: 'profile-video-0'`), then reverted. This is the mutation that survived the previous revision of these tests.

## Type of Change

- [x] 🗑️ Chore
