### PR TITLE
fix(camera): capture from an attached external mic on Android

### DIFF
--- a/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/AudioInputSource.kt
+++ b/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/AudioInputSource.kt
@@ -1,5 +1,5 @@
 // ABOUTME: Picks the recording audio source from the connected input devices
-// ABOUTME: CAMCORDER ranks USB below the built-in mic, so external inputs use MIC
+// ABOUTME: CAMCORDER ranks USB below the built-in mic, so an attached USB mic uses MIC
 
 package co.openvine.divine_camera
 
@@ -8,23 +8,29 @@ import android.media.MediaRecorder
 import androidx.camera.video.AudioSpec
 
 /**
- * Input device types that mean the user deliberately plugged in a recording
- * input.
+ * Input device types that mean the user attached something to record with.
  *
  * Only devices reported by `AudioManager.GET_DEVICES_INPUTS` are ever tested
  * against this set, so every entry is a real capture device.
  *
- * Bluetooth is deliberately absent. Under MIC, AOSP reaches a Bluetooth input
- * only via LE Audio (`BLUETOOTH_BLE`, ranked below USB), or via SCO when
- * Bluetooth is already the communication device — which during recording it is
- * not. So listing it here would either change nothing (SCO) or quietly promote
- * a headset the user wore for listening into the recording microphone (LE
- * Audio). Wearing headphones is not asking to record through them.
+ * The set is deliberately one entry wide. Android reports an input-only USB
+ * audio device as `TYPE_USB_DEVICE`, which is what a microphone or a wireless
+ * receiver is; a device that also has an output leg — headphones with a mic,
+ * over USB (`TYPE_USB_HEADSET`), over the jack (`TYPE_WIRED_HEADSET`) or over
+ * Bluetooth — is something the user put on to *listen*. Routing capture to
+ * those would silently turn monitoring earbuds into the recording microphone,
+ * which is the surprise this fix is supposed to avoid, not create. Wearing
+ * headphones is not asking to record through them, and the cable does not
+ * change that.
+ *
+ * If a report ever shows a real external microphone enumerating as
+ * `TYPE_USB_HEADSET` — a combo device exposing a monitoring output — that
+ * type can be added back on the evidence. The diagnostic line in
+ * `CameraController.resolveAudioSource` names the types it saw, so such a
+ * report will say so.
  */
 private val EXTERNAL_MIC_TYPES = setOf(
-    AudioDeviceInfo.TYPE_USB_DEVICE,
-    AudioDeviceInfo.TYPE_USB_HEADSET,
-    AudioDeviceInfo.TYPE_WIRED_HEADSET
+    AudioDeviceInfo.TYPE_USB_DEVICE
 )
 
 /**
@@ -35,9 +41,9 @@ private val EXTERNAL_MIC_TYPES = setOf(
  * `MediaRecorder.AudioSource.CAMCORDER`. AOSP's audio policy ranks input
  * devices per source, and for CAMCORDER the order is back mic, built-in mic,
  * then USB — USB is reachable only on a device with no built-in mic, so on a
- * phone an attached USB microphone is never selected (#6171). MIC ranks wired
- * and USB ahead of the built-in mic, which is what someone who just plugged in
- * a microphone expects.
+ * phone an attached USB microphone is never selected (#6171). MIC ranks USB
+ * ahead of the built-in mic, which is what someone who just plugged in a
+ * microphone expects.
  *
  * Returns [AudioSpec.SOURCE_AUTO] when nothing is attached, leaving the
  * camera-tuned default untouched for everyone else.

--- a/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/AudioInputSource.kt
+++ b/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/AudioInputSource.kt
@@ -32,7 +32,7 @@ import androidx.camera.video.AudioSpec
  * The 3.5mm jack is left out for the opposite reason. `TYPE_WIRED_HEADSET`
  * is overwhelmingly earbuds, CAMCORDER does not select it today, and adding
  * it would change recording for people who plugged in only to listen.
- * Bluetooth is out for the same reason — see below.
+ * Bluetooth is left out for the same reason.
  */
 private val EXTERNAL_MIC_TYPES = setOf(
     AudioDeviceInfo.TYPE_USB_DEVICE,
@@ -51,15 +51,20 @@ private val EXTERNAL_MIC_TYPES = setOf(
  * ahead of the built-in mic, which is what someone who just plugged in a
  * microphone expects.
  *
- * Returns [AudioSpec.SOURCE_AUTO] when nothing is attached, leaving the
- * camera-tuned default untouched for everyone else.
+ * Returns [AudioSpec.SOURCE_AUTO] unless USB is attached without a wired
+ * headset. MIC ranks a wired headset ahead of USB, so switching with both
+ * attached would capture from the headset rather than the USB device that
+ * triggered the switch.
  */
-internal fun audioSourceForInputDeviceTypes(types: IntArray): Int =
-    if (types.any { it in EXTERNAL_MIC_TYPES }) {
+internal fun audioSourceForInputDeviceTypes(types: IntArray): Int {
+    val hasWiredHeadset = AudioDeviceInfo.TYPE_WIRED_HEADSET in types
+    val hasUsbInput = types.any { it in EXTERNAL_MIC_TYPES }
+    return if (hasUsbInput && !hasWiredHeadset) {
         MediaRecorder.AudioSource.MIC
     } else {
         AudioSpec.SOURCE_AUTO
     }
+}
 
 /**
  * Short readable name for an `AudioDeviceInfo` input [type], used by the

--- a/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/AudioInputSource.kt
+++ b/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/AudioInputSource.kt
@@ -8,7 +8,8 @@ import android.media.MediaRecorder
 import androidx.camera.video.AudioSpec
 
 /**
- * Input device types that mean the user deliberately plugged in a microphone.
+ * Input device types that mean the user deliberately plugged in a recording
+ * input.
  *
  * Only devices reported by `AudioManager.GET_DEVICES_INPUTS` are ever tested
  * against this set, so every entry is a real capture device.
@@ -23,7 +24,6 @@ import androidx.camera.video.AudioSpec
 private val EXTERNAL_MIC_TYPES = setOf(
     AudioDeviceInfo.TYPE_USB_DEVICE,
     AudioDeviceInfo.TYPE_USB_HEADSET,
-    AudioDeviceInfo.TYPE_USB_ACCESSORY,
     AudioDeviceInfo.TYPE_WIRED_HEADSET
 )
 

--- a/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/AudioInputSource.kt
+++ b/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/AudioInputSource.kt
@@ -1,0 +1,45 @@
+// ABOUTME: Picks the recording audio source from the connected input devices
+// ABOUTME: CAMCORDER never selects an attached USB mic, so external inputs use MIC
+
+package co.openvine.divine_camera
+
+import android.media.AudioDeviceInfo
+import android.media.MediaRecorder
+import androidx.camera.video.AudioSpec
+
+/**
+ * Input device types that mean the user attached their own microphone.
+ *
+ * Only devices reported by `AudioManager.GET_DEVICES_INPUTS` are ever tested
+ * against this set, so every entry is a real capture device.
+ */
+private val EXTERNAL_MIC_TYPES = setOf(
+    AudioDeviceInfo.TYPE_USB_DEVICE,
+    AudioDeviceInfo.TYPE_USB_HEADSET,
+    AudioDeviceInfo.TYPE_USB_ACCESSORY,
+    AudioDeviceInfo.TYPE_WIRED_HEADSET,
+    AudioDeviceInfo.TYPE_BLUETOOTH_SCO,
+    AudioDeviceInfo.TYPE_BLE_HEADSET
+)
+
+/**
+ * The audio source a new Recorder should capture from, given the connected
+ * input device [types].
+ *
+ * CameraX leaves the source at [AudioSpec.SOURCE_AUTO], which resolves to
+ * `MediaRecorder.AudioSource.CAMCORDER`. AOSP's audio policy ranks input
+ * devices per source, and for CAMCORDER the order is back mic, built-in mic,
+ * then USB — USB is reachable only on a device with no built-in mic, so on a
+ * phone an attached USB microphone is never selected (#6171). MIC ranks wired,
+ * USB and Bluetooth ahead of the built-in mic, which is what someone who just
+ * plugged in a microphone expects.
+ *
+ * Returns [AudioSpec.SOURCE_AUTO] when nothing is attached, leaving the
+ * camera-tuned default untouched for everyone else.
+ */
+internal fun audioSourceForInputDeviceTypes(types: IntArray): Int =
+    if (types.any { it in EXTERNAL_MIC_TYPES }) {
+        MediaRecorder.AudioSource.MIC
+    } else {
+        AudioSpec.SOURCE_AUTO
+    }

--- a/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/AudioInputSource.kt
+++ b/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/AudioInputSource.kt
@@ -1,5 +1,5 @@
 // ABOUTME: Picks the recording audio source from the connected input devices
-// ABOUTME: CAMCORDER never selects an attached USB mic, so external inputs use MIC
+// ABOUTME: CAMCORDER ranks USB below the built-in mic, so external inputs use MIC
 
 package co.openvine.divine_camera
 
@@ -48,3 +48,24 @@ internal fun audioSourceForInputDeviceTypes(types: IntArray): Int =
     } else {
         AudioSpec.SOURCE_AUTO
     }
+
+/**
+ * Short readable name for an `AudioDeviceInfo` input [type], used by the
+ * diagnostic line the camera writes when it resolves the recording source.
+ *
+ * Unknown types fall back to the raw constant on purpose: a device reporting
+ * an input we do not map is the exact failure mode behind #6171, and it has to
+ * survive into the bug report rather than disappear.
+ */
+internal fun audioInputTypeName(type: Int): String = when (type) {
+    AudioDeviceInfo.TYPE_BUILTIN_MIC -> "BUILTIN_MIC"
+    AudioDeviceInfo.TYPE_USB_DEVICE -> "USB_DEVICE"
+    AudioDeviceInfo.TYPE_USB_HEADSET -> "USB_HEADSET"
+    AudioDeviceInfo.TYPE_USB_ACCESSORY -> "USB_ACCESSORY"
+    AudioDeviceInfo.TYPE_WIRED_HEADSET -> "WIRED_HEADSET"
+    AudioDeviceInfo.TYPE_BLUETOOTH_SCO -> "BLUETOOTH_SCO"
+    AudioDeviceInfo.TYPE_BLE_HEADSET -> "BLE_HEADSET"
+    AudioDeviceInfo.TYPE_TELEPHONY -> "TELEPHONY"
+    AudioDeviceInfo.TYPE_REMOTE_SUBMIX -> "REMOTE_SUBMIX"
+    else -> "TYPE_$type"
+}

--- a/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/AudioInputSource.kt
+++ b/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/AudioInputSource.kt
@@ -8,18 +8,23 @@ import android.media.MediaRecorder
 import androidx.camera.video.AudioSpec
 
 /**
- * Input device types that mean the user attached their own microphone.
+ * Input device types that mean the user deliberately plugged in a microphone.
  *
  * Only devices reported by `AudioManager.GET_DEVICES_INPUTS` are ever tested
  * against this set, so every entry is a real capture device.
+ *
+ * Bluetooth is deliberately absent. Under MIC, AOSP reaches a Bluetooth input
+ * only via LE Audio (`BLUETOOTH_BLE`, ranked below USB), or via SCO when
+ * Bluetooth is already the communication device — which during recording it is
+ * not. So listing it here would either change nothing (SCO) or quietly promote
+ * a headset the user wore for listening into the recording microphone (LE
+ * Audio). Wearing headphones is not asking to record through them.
  */
 private val EXTERNAL_MIC_TYPES = setOf(
     AudioDeviceInfo.TYPE_USB_DEVICE,
     AudioDeviceInfo.TYPE_USB_HEADSET,
     AudioDeviceInfo.TYPE_USB_ACCESSORY,
-    AudioDeviceInfo.TYPE_WIRED_HEADSET,
-    AudioDeviceInfo.TYPE_BLUETOOTH_SCO,
-    AudioDeviceInfo.TYPE_BLE_HEADSET
+    AudioDeviceInfo.TYPE_WIRED_HEADSET
 )
 
 /**
@@ -30,9 +35,9 @@ private val EXTERNAL_MIC_TYPES = setOf(
  * `MediaRecorder.AudioSource.CAMCORDER`. AOSP's audio policy ranks input
  * devices per source, and for CAMCORDER the order is back mic, built-in mic,
  * then USB — USB is reachable only on a device with no built-in mic, so on a
- * phone an attached USB microphone is never selected (#6171). MIC ranks wired,
- * USB and Bluetooth ahead of the built-in mic, which is what someone who just
- * plugged in a microphone expects.
+ * phone an attached USB microphone is never selected (#6171). MIC ranks wired
+ * and USB ahead of the built-in mic, which is what someone who just plugged in
+ * a microphone expects.
  *
  * Returns [AudioSpec.SOURCE_AUTO] when nothing is attached, leaving the
  * camera-tuned default untouched for everyone else.

--- a/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/AudioInputSource.kt
+++ b/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/AudioInputSource.kt
@@ -13,24 +13,30 @@ import androidx.camera.video.AudioSpec
  * Only devices reported by `AudioManager.GET_DEVICES_INPUTS` are ever tested
  * against this set, so every entry is a real capture device.
  *
- * The set is deliberately one entry wide. Android reports an input-only USB
- * audio device as `TYPE_USB_DEVICE`, which is what a microphone or a wireless
- * receiver is; a device that also has an output leg — headphones with a mic,
- * over USB (`TYPE_USB_HEADSET`), over the jack (`TYPE_WIRED_HEADSET`) or over
- * Bluetooth — is something the user put on to *listen*. Routing capture to
- * those would silently turn monitoring earbuds into the recording microphone,
- * which is the surprise this fix is supposed to avoid, not create. Wearing
- * headphones is not asking to record through them, and the cable does not
- * change that.
+ * USB covers both of its input types, because the split between them is not
+ * the split it looks like. AOSP scores a USB peripheral in
+ * `UsbDescriptorParser.getInputHeadsetProbability()`, where `hasMic() &&
+ * hasSpeaker()` alone contributes the full `IN_HEADSET_TRIGGER` of 0.75, and
+ * `hasSpeaker()` counts a `TERMINAL_OUT_HEADPHONES` terminal. A microphone or
+ * wireless receiver with a **monitoring jack** therefore enumerates as
+ * `TYPE_USB_HEADSET`, not `TYPE_USB_DEVICE` — and monitoring output is
+ * standard on the receivers #6171 is about. Excluding that type would drop
+ * most of the hardware this exists to fix.
  *
- * If a report ever shows a real external microphone enumerating as
- * `TYPE_USB_HEADSET` — a combo device exposing a monitoring output — that
- * type can be added back on the evidence. The diagnostic line in
- * `CameraController.resolveAudioSource` names the types it saw, so such a
- * report will say so.
+ * Monitoring earbuds land on the same type and cannot be told apart:
+ * `AudioDeviceInfo` carries only type, id, address, product name and channel
+ * counts, and the output-device list matches both. So USB is treated as
+ * intent to record — plugging a USB peripheral into a phone you are filming
+ * on is a deliberate act.
+ *
+ * The 3.5mm jack is left out for the opposite reason. `TYPE_WIRED_HEADSET`
+ * is overwhelmingly earbuds, CAMCORDER does not select it today, and adding
+ * it would change recording for people who plugged in only to listen.
+ * Bluetooth is out for the same reason — see below.
  */
 private val EXTERNAL_MIC_TYPES = setOf(
-    AudioDeviceInfo.TYPE_USB_DEVICE
+    AudioDeviceInfo.TYPE_USB_DEVICE,
+    AudioDeviceInfo.TYPE_USB_HEADSET
 )
 
 /**

--- a/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/CameraController.kt
+++ b/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/CameraController.kt
@@ -904,22 +904,38 @@ class CameraController(
      * Evaluated per Recorder build, so initial bind and both lens switches pick
      * up a microphone attached since the last build; a mic plugged in while the
      * camera stays bound is picked up on the next switch or re-entry.
+     *
+     * Logs the decision and the inputs it was made from either way. A report
+     * that the external mic was still ignored is only actionable if it says
+     * which inputs the device reported, and a device naming its mic something
+     * we do not route on leaves no other trace (#6171).
      */
     private fun resolveAudioSource(): Int {
         val audioManager =
             context.getSystemService(Context.AUDIO_SERVICE) as? AudioManager
-                ?: return AudioSpec.SOURCE_AUTO
+                ?: run {
+                    DivineCameraLog.warning(
+                        "AudioManager unavailable — camera-default audio source",
+                        name = "DivineCamera.Audio"
+                    )
+                    return AudioSpec.SOURCE_AUTO
+                }
         val types = audioManager
             .getDevices(AudioManager.GET_DEVICES_INPUTS)
             .map { it.type }
             .toIntArray()
         val source = audioSourceForInputDeviceTypes(types)
-        if (source != AudioSpec.SOURCE_AUTO) {
-            DivineCameraLog.info(
-                "External audio input attached — capturing from MIC",
-                name = "DivineCamera.Audio"
-            )
-        }
+        val inputs = types
+            .joinToString(", ") { audioInputTypeName(it) }
+            .ifEmpty { "none" }
+        DivineCameraLog.info(
+            if (source == AudioSpec.SOURCE_AUTO) {
+                "Audio source: camera default (inputs: $inputs)"
+            } else {
+                "Audio source: MIC, external input attached (inputs: $inputs)"
+            },
+            name = "DivineCamera.Audio"
+        )
         return source
     }
 

--- a/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/CameraController.kt
+++ b/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/CameraController.kt
@@ -16,6 +16,7 @@ import android.hardware.camera2.CameraMetadata
 import android.hardware.camera2.CaptureRequest
 import android.hardware.camera2.CaptureResult
 import android.hardware.camera2.TotalCaptureResult
+import android.media.AudioManager
 import android.os.Build
 import android.os.Handler
 import android.os.Looper
@@ -877,6 +878,7 @@ class CameraController(
      * target is a bounded overshoot for that tier (never above the requested
      * one) — still far below the uncapped device default, so acceptable.
      */
+    @SuppressLint("RestrictedApi")
     private fun buildRecorder(aspectRatio: Int): Recorder = Recorder.Builder()
         .setQualitySelector(
             QualitySelector.from(
@@ -887,7 +889,39 @@ class CameraController(
         .setAspectRatio(aspectRatio)
         .setExecutor(cameraExecutor)
         .setTargetVideoEncodingBitRate(videoEncodingBitRate(videoQuality))
+        // setAudioSource is @RestrictTo(LIBRARY): CameraX 1.5.3 publishes no
+        // supported way to choose the source, and no way at all to route
+        // capture to a specific AudioDeviceInfo. Pinned by
+        // AudioInputSourceTest so a CameraX bump that drops it fails the build.
+        .setAudioSource(resolveAudioSource())
         .build()
+
+    /**
+     * Resolves the audio source for a new Recorder from the input devices
+     * connected right now. Falls back to the CameraX default when the
+     * AudioManager is unavailable.
+     *
+     * Evaluated per Recorder build, so initial bind and both lens switches pick
+     * up a microphone attached since the last build; a mic plugged in while the
+     * camera stays bound is picked up on the next switch or re-entry.
+     */
+    private fun resolveAudioSource(): Int {
+        val audioManager =
+            context.getSystemService(Context.AUDIO_SERVICE) as? AudioManager
+                ?: return AudioSpec.SOURCE_AUTO
+        val types = audioManager
+            .getDevices(AudioManager.GET_DEVICES_INPUTS)
+            .map { it.type }
+            .toIntArray()
+        val source = audioSourceForInputDeviceTypes(types)
+        if (source != AudioSpec.SOURCE_AUTO) {
+            DivineCameraLog.info(
+                "External audio input attached — capturing from MIC",
+                name = "DivineCamera.Audio"
+            )
+        }
+        return source
+    }
 
     /**
      * Starts the camera with preview and video capture use cases.

--- a/mobile/packages/divine_camera/android/src/test/kotlin/co/openvine/divine_camera/AudioInputSourceTest.kt
+++ b/mobile/packages/divine_camera/android/src/test/kotlin/co/openvine/divine_camera/AudioInputSourceTest.kt
@@ -66,7 +66,6 @@ internal class AudioInputSourceTest {
         val pluggedIn = mapOf(
             "USB_DEVICE" to AudioDeviceInfo.TYPE_USB_DEVICE,
             "USB_HEADSET" to AudioDeviceInfo.TYPE_USB_HEADSET,
-            "USB_ACCESSORY" to AudioDeviceInfo.TYPE_USB_ACCESSORY,
             "WIRED_HEADSET" to AudioDeviceInfo.TYPE_WIRED_HEADSET
         )
         for ((name, type) in pluggedIn) {
@@ -78,6 +77,22 @@ internal class AudioInputSourceTest {
                 "$name should route capture to MIC"
             )
         }
+    }
+
+    @Test
+    fun usbAccessory_keepsCameraXDefault() {
+        // AOSP's MIC and CAMCORDER policies do not select USB accessory inputs,
+        // so switching source for this type would only leave the camera-tuned
+        // path without making the accessory the capture device.
+        assertEquals(
+            AudioSpec.SOURCE_AUTO,
+            audioSourceForInputDeviceTypes(
+                intArrayOf(
+                    AudioDeviceInfo.TYPE_BUILTIN_MIC,
+                    AudioDeviceInfo.TYPE_USB_ACCESSORY
+                )
+            )
+        )
     }
 
     @Test

--- a/mobile/packages/divine_camera/android/src/test/kotlin/co/openvine/divine_camera/AudioInputSourceTest.kt
+++ b/mobile/packages/divine_camera/android/src/test/kotlin/co/openvine/divine_camera/AudioInputSourceTest.kt
@@ -1,0 +1,119 @@
+package co.openvine.divine_camera
+
+import android.annotation.SuppressLint
+import android.media.AudioDeviceInfo
+import android.media.MediaRecorder
+import androidx.camera.video.AudioSpec
+import androidx.camera.video.Recorder
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import kotlin.test.assertEquals
+
+/*
+ * Pins the input-device → audio-source mapping used when building the
+ * recording Recorder (#6171). CameraX resolves its own default,
+ * AudioSpec.SOURCE_AUTO, to MediaRecorder.AudioSource.CAMCORDER, and AOSP's
+ * audio policy ranks USB last for CAMCORDER — behind the built-in mic — so an
+ * attached USB microphone is never captured from on a phone.
+ */
+@RunWith(RobolectricTestRunner::class)
+internal class AudioInputSourceTest {
+    @Test
+    fun builtInMicOnly_keepsCameraXDefault() {
+        assertEquals(
+            AudioSpec.SOURCE_AUTO,
+            audioSourceForInputDeviceTypes(intArrayOf(AudioDeviceInfo.TYPE_BUILTIN_MIC))
+        )
+    }
+
+    @Test
+    fun noInputDevices_keepsCameraXDefault() {
+        assertEquals(AudioSpec.SOURCE_AUTO, audioSourceForInputDeviceTypes(intArrayOf()))
+    }
+
+    @Test
+    fun telephonyAndSubmix_areNotTreatedAsExternalMics() {
+        assertEquals(
+            AudioSpec.SOURCE_AUTO,
+            audioSourceForInputDeviceTypes(
+                intArrayOf(
+                    AudioDeviceInfo.TYPE_BUILTIN_MIC,
+                    AudioDeviceInfo.TYPE_TELEPHONY,
+                    AudioDeviceInfo.TYPE_REMOTE_SUBMIX
+                )
+            )
+        )
+    }
+
+    @Test
+    fun usbMicAlongsideBuiltIn_switchesToMic() {
+        // The reported case: the built-in mic is always present, so the
+        // external device has to win rather than merely be present.
+        assertEquals(
+            MediaRecorder.AudioSource.MIC,
+            audioSourceForInputDeviceTypes(
+                intArrayOf(
+                    AudioDeviceInfo.TYPE_BUILTIN_MIC,
+                    AudioDeviceInfo.TYPE_USB_DEVICE
+                )
+            )
+        )
+    }
+
+    @Test
+    fun everyExternalMicType_switchesToMic() {
+        val externalTypes = mapOf(
+            "USB_DEVICE" to AudioDeviceInfo.TYPE_USB_DEVICE,
+            "USB_HEADSET" to AudioDeviceInfo.TYPE_USB_HEADSET,
+            "USB_ACCESSORY" to AudioDeviceInfo.TYPE_USB_ACCESSORY,
+            "WIRED_HEADSET" to AudioDeviceInfo.TYPE_WIRED_HEADSET,
+            "BLUETOOTH_SCO" to AudioDeviceInfo.TYPE_BLUETOOTH_SCO,
+            "BLE_HEADSET" to AudioDeviceInfo.TYPE_BLE_HEADSET
+        )
+        for ((name, type) in externalTypes) {
+            assertEquals(
+                MediaRecorder.AudioSource.MIC,
+                audioSourceForInputDeviceTypes(
+                    intArrayOf(AudioDeviceInfo.TYPE_BUILTIN_MIC, type)
+                ),
+                "$name should route capture to MIC"
+            )
+        }
+    }
+
+    /*
+     * Recorder.Builder.setAudioSource and Recorder.getAudioSource are both
+     * @RestrictTo(LIBRARY) — the only lever CameraX offers, since it publishes
+     * no way to route capture to a specific AudioDeviceInfo. This asserts the
+     * value we set survives into the built Recorder, so a CameraX bump that
+     * drops, renames or starts validating the setter fails here rather than
+     * silently reverting Android to the built-in mic.
+     */
+    @SuppressLint("RestrictedApi")
+    @Test
+    fun recorderRetainsTheConfiguredAudioSource() {
+        assertEquals(
+            MediaRecorder.AudioSource.MIC,
+            Recorder.Builder()
+                .setAudioSource(MediaRecorder.AudioSource.MIC)
+                .build()
+                .audioSource
+        )
+    }
+
+    @SuppressLint("RestrictedApi")
+    @Test
+    fun sourceAutoLeavesTheRecorderAtItsUntouchedDefault() {
+        // The no-external-mic branch must be indistinguishable from never
+        // having called setAudioSource, so devices without an attached mic keep
+        // the camera-tuned capture path exactly as it was before this fix.
+        assertEquals(
+            Recorder.Builder().build().audioSource,
+            Recorder.Builder()
+                .setAudioSource(AudioSpec.SOURCE_AUTO)
+                .build()
+                .audioSource
+        )
+    }
+}

--- a/mobile/packages/divine_camera/android/src/test/kotlin/co/openvine/divine_camera/AudioInputSourceTest.kt
+++ b/mobile/packages/divine_camera/android/src/test/kotlin/co/openvine/divine_camera/AudioInputSourceTest.kt
@@ -62,24 +62,40 @@ internal class AudioInputSourceTest {
     }
 
     @Test
-    fun headsetsWornForListening_doNotBecomeTheRecordingMic() {
-        // Same rule as the Bluetooth cases below, over a cable. Android reports
-        // an input-only USB mic as USB_DEVICE; a type carrying an output leg is
-        // something the user put on to listen, so plugging in USB-C or wired
-        // earbuds to monitor must not move the recording onto their mic.
-        val wornForListening = mapOf(
-            "USB_HEADSET" to AudioDeviceInfo.TYPE_USB_HEADSET,
-            "WIRED_HEADSET" to AudioDeviceInfo.TYPE_WIRED_HEADSET
+    fun everyUsbInputType_switchesToMic() {
+        // A mic or wireless receiver with a monitoring jack declares an output
+        // terminal, and AOSP's hasMic() && hasSpeaker() rule scores that at the
+        // full 0.75 headset trigger — so it arrives as USB_HEADSET rather than
+        // USB_DEVICE. Excluding that type would drop most real external mics.
+        val usbTypes = mapOf(
+            "USB_DEVICE" to AudioDeviceInfo.TYPE_USB_DEVICE,
+            "USB_HEADSET" to AudioDeviceInfo.TYPE_USB_HEADSET
         )
-        for ((name, type) in wornForListening) {
+        for ((name, type) in usbTypes) {
             assertEquals(
-                AudioSpec.SOURCE_AUTO,
+                MediaRecorder.AudioSource.MIC,
                 audioSourceForInputDeviceTypes(
                     intArrayOf(AudioDeviceInfo.TYPE_BUILTIN_MIC, type)
                 ),
-                "$name should leave the camera-tuned default in place"
+                "$name should route capture to MIC"
             )
         }
+    }
+
+    @Test
+    fun wiredHeadset_doesNotBecomeTheRecordingMic() {
+        // The jack is overwhelmingly earbuds and CAMCORDER does not select it
+        // today, so plugging in to listen must not move the recording onto the
+        // earbud mic. Same rule as the Bluetooth cases below, over a cable.
+        assertEquals(
+            AudioSpec.SOURCE_AUTO,
+            audioSourceForInputDeviceTypes(
+                intArrayOf(
+                    AudioDeviceInfo.TYPE_BUILTIN_MIC,
+                    AudioDeviceInfo.TYPE_WIRED_HEADSET
+                )
+            )
+        )
     }
 
     @Test

--- a/mobile/packages/divine_camera/android/src/test/kotlin/co/openvine/divine_camera/AudioInputSourceTest.kt
+++ b/mobile/packages/divine_camera/android/src/test/kotlin/co/openvine/divine_camera/AudioInputSourceTest.kt
@@ -62,16 +62,14 @@ internal class AudioInputSourceTest {
     }
 
     @Test
-    fun everyExternalMicType_switchesToMic() {
-        val externalTypes = mapOf(
+    fun everyPluggedInMicType_switchesToMic() {
+        val pluggedIn = mapOf(
             "USB_DEVICE" to AudioDeviceInfo.TYPE_USB_DEVICE,
             "USB_HEADSET" to AudioDeviceInfo.TYPE_USB_HEADSET,
             "USB_ACCESSORY" to AudioDeviceInfo.TYPE_USB_ACCESSORY,
-            "WIRED_HEADSET" to AudioDeviceInfo.TYPE_WIRED_HEADSET,
-            "BLUETOOTH_SCO" to AudioDeviceInfo.TYPE_BLUETOOTH_SCO,
-            "BLE_HEADSET" to AudioDeviceInfo.TYPE_BLE_HEADSET
+            "WIRED_HEADSET" to AudioDeviceInfo.TYPE_WIRED_HEADSET
         )
-        for ((name, type) in externalTypes) {
+        for ((name, type) in pluggedIn) {
             assertEquals(
                 MediaRecorder.AudioSource.MIC,
                 audioSourceForInputDeviceTypes(
@@ -80,6 +78,44 @@ internal class AudioInputSourceTest {
                 "$name should route capture to MIC"
             )
         }
+    }
+
+    @Test
+    fun bluetoothAlone_doesNotBecomeTheRecordingMic() {
+        // Wearing a headset to listen is not a request to record through it.
+        // Under MIC, AOSP reaches Bluetooth only via LE Audio (ranked below
+        // USB) or via SCO once Bluetooth is the communication device, which it
+        // is not while recording — so switching would either change nothing or
+        // silently hand the recording to the user's earbuds.
+        val bluetoothTypes = mapOf(
+            "BLUETOOTH_SCO" to AudioDeviceInfo.TYPE_BLUETOOTH_SCO,
+            "BLE_HEADSET" to AudioDeviceInfo.TYPE_BLE_HEADSET
+        )
+        for ((name, type) in bluetoothTypes) {
+            assertEquals(
+                AudioSpec.SOURCE_AUTO,
+                audioSourceForInputDeviceTypes(
+                    intArrayOf(AudioDeviceInfo.TYPE_BUILTIN_MIC, type)
+                ),
+                "$name alone should leave the camera-tuned default in place"
+            )
+        }
+    }
+
+    @Test
+    fun bluetoothAlongsideAPluggedInMic_stillSwitches() {
+        // Earbuds on, external mic in front of you. The switch still happens,
+        // and AOSP ranks USB above LE Audio, so the plugged-in mic wins.
+        assertEquals(
+            MediaRecorder.AudioSource.MIC,
+            audioSourceForInputDeviceTypes(
+                intArrayOf(
+                    AudioDeviceInfo.TYPE_BUILTIN_MIC,
+                    AudioDeviceInfo.TYPE_BLE_HEADSET,
+                    AudioDeviceInfo.TYPE_USB_DEVICE
+                )
+            )
+        )
     }
 
     /*

--- a/mobile/packages/divine_camera/android/src/test/kotlin/co/openvine/divine_camera/AudioInputSourceTest.kt
+++ b/mobile/packages/divine_camera/android/src/test/kotlin/co/openvine/divine_camera/AudioInputSourceTest.kt
@@ -99,6 +99,23 @@ internal class AudioInputSourceTest {
     }
 
     @Test
+    fun wiredHeadsetAlongsideUsb_keepsCameraXDefault() {
+        // MIC ranks a wired headset ahead of USB. Switching merely because USB
+        // is also attached would therefore record from the earbud microphone,
+        // not from the USB device that triggered the switch.
+        assertEquals(
+            AudioSpec.SOURCE_AUTO,
+            audioSourceForInputDeviceTypes(
+                intArrayOf(
+                    AudioDeviceInfo.TYPE_BUILTIN_MIC,
+                    AudioDeviceInfo.TYPE_WIRED_HEADSET,
+                    AudioDeviceInfo.TYPE_USB_DEVICE
+                )
+            )
+        )
+    }
+
+    @Test
     fun usbAccessory_keepsCameraXDefault() {
         // AOSP's MIC and CAMCORDER policies do not select USB accessory inputs,
         // so switching source for this type would only leave the camera-tuned

--- a/mobile/packages/divine_camera/android/src/test/kotlin/co/openvine/divine_camera/AudioInputSourceTest.kt
+++ b/mobile/packages/divine_camera/android/src/test/kotlin/co/openvine/divine_camera/AudioInputSourceTest.kt
@@ -133,6 +133,16 @@ internal class AudioInputSourceTest {
         )
     }
 
+    @Test
+    fun inputTypeNames_stayReadableAndKeepUnmappedTypesVisible() {
+        // The names land in user bug reports, and an unmapped type is the case
+        // worth reading: a device that calls its external mic something we do
+        // not route on has to show up as a number rather than not at all.
+        assertEquals("USB_DEVICE", audioInputTypeName(AudioDeviceInfo.TYPE_USB_DEVICE))
+        assertEquals("BUILTIN_MIC", audioInputTypeName(AudioDeviceInfo.TYPE_BUILTIN_MIC))
+        assertEquals("TYPE_9999", audioInputTypeName(9999))
+    }
+
     /*
      * Recorder.Builder.setAudioSource and Recorder.getAudioSource are both
      * @RestrictTo(LIBRARY) — the only lever CameraX offers, since it publishes

--- a/mobile/packages/divine_camera/android/src/test/kotlin/co/openvine/divine_camera/AudioInputSourceTest.kt
+++ b/mobile/packages/divine_camera/android/src/test/kotlin/co/openvine/divine_camera/AudioInputSourceTest.kt
@@ -62,19 +62,22 @@ internal class AudioInputSourceTest {
     }
 
     @Test
-    fun everyPluggedInMicType_switchesToMic() {
-        val pluggedIn = mapOf(
-            "USB_DEVICE" to AudioDeviceInfo.TYPE_USB_DEVICE,
+    fun headsetsWornForListening_doNotBecomeTheRecordingMic() {
+        // Same rule as the Bluetooth cases below, over a cable. Android reports
+        // an input-only USB mic as USB_DEVICE; a type carrying an output leg is
+        // something the user put on to listen, so plugging in USB-C or wired
+        // earbuds to monitor must not move the recording onto their mic.
+        val wornForListening = mapOf(
             "USB_HEADSET" to AudioDeviceInfo.TYPE_USB_HEADSET,
             "WIRED_HEADSET" to AudioDeviceInfo.TYPE_WIRED_HEADSET
         )
-        for ((name, type) in pluggedIn) {
+        for ((name, type) in wornForListening) {
             assertEquals(
-                MediaRecorder.AudioSource.MIC,
+                AudioSpec.SOURCE_AUTO,
                 audioSourceForInputDeviceTypes(
                     intArrayOf(AudioDeviceInfo.TYPE_BUILTIN_MIC, type)
                 ),
-                "$name should route capture to MIC"
+                "$name should leave the camera-tuned default in place"
             )
         }
     }
@@ -120,7 +123,7 @@ internal class AudioInputSourceTest {
     @Test
     fun bluetoothAlongsideAPluggedInMic_stillSwitches() {
         // Earbuds on, external mic in front of you. The switch still happens,
-        // and AOSP ranks USB above LE Audio, so the plugged-in mic wins.
+        // and AOSP ranks USB above LE Audio, so the attached mic wins.
         assertEquals(
             MediaRecorder.AudioSource.MIC,
             audioSourceForInputDeviceTypes(


### PR DESCRIPTION
## Description

Android recording never captured from an attached USB microphone. Verified chain:

1. `CameraController.buildRecorder()` never called `setAudioSource`, so the Recorder stayed at `AudioSpec.SOURCE_AUTO`.
2. CameraX 1.5.3 `AudioConfigUtil.resolveAudioSource` resolves `SOURCE_AUTO` (`-1`) to `MediaRecorder.AudioSource.CAMCORDER` (`5`).
3. AOSP `Engine::getDeviceForInputSource` ranks input devices **per source**. For `CAMCORDER` the order is `BACK_MIC, BUILTIN_MIC, USB_DEVICE` — USB is reachable only on a device with no built-in mic, so on a phone it is never selected. For `MIC` the order is `WIRED_HEADSET, USB_HEADSET, USB_DEVICE, BLUETOOTH_BLE, BUILTIN_MIC`, which puts an attached microphone ahead of the built-in one.

So the fix picks `MIC` when a USB audio input device is connected, except when a 3.5 mm wired headset is also present. With nothing attached — or with a wired headset that Android would rank ahead of USB under `MIC` — the Recorder stays at `SOURCE_AUTO`, preserving the camera-tuned route instead of moving capture onto the earbud microphone.

**Both USB input types are eligible to trigger the switch, and nothing else is. A wired headset vetoes the switch when present alongside USB.** The split between `TYPE_USB_DEVICE` and `TYPE_USB_HEADSET` is not the split its name suggests. AOSP scores a USB peripheral in `UsbDescriptorParser.getInputHeadsetProbability()`, where `hasMic() && hasSpeaker()` on its own contributes the full `IN_HEADSET_TRIGGER` of `0.75f`, and `hasSpeaker()` counts a `TERMINAL_OUT_HEADPHONES` terminal; `UsbAlsaDevice` then maps that verdict straight through as `mIsHeadset[INPUT] ? DEVICE_IN_USB_HEADSET : DEVICE_IN_USB_DEVICE`, with no further gate. A microphone or wireless receiver with a **monitoring jack** therefore enumerates as `TYPE_USB_HEADSET` rather than `TYPE_USB_DEVICE` — and monitoring output is standard on the receivers #6171 is about, so excluding that type would drop most of the hardware this exists to fix.

**The accepted cost:** monitoring earbuds land on that same type and cannot be told apart from a mic-with-monitoring. `AudioDeviceInfo` exposes only type, id, address, product name and channel counts, and the output-device list matches both, so this is a straight choice rather than a detection problem. USB-C earbuds worn while filming can become the recording mic. That is a real change against today's behaviour, taken deliberately because plugging a USB peripheral into the phone you are filming on reads as intent to record, and because the alternative risks shipping a fix that never reaches the reporter. If the field disagrees, the diagnostic described below names the input type either way, so a "it recorded from my earbuds" report can be acted on with evidence.

The 3.5mm jack and Bluetooth stay out for the opposite reason. `TYPE_WIRED_HEADSET` is overwhelmingly earbuds and `CAMCORDER` does not select it today, so routing to it really would change recording for someone who plugged in only to listen. Bluetooth is excluded on the same rule, and additionally could not help: under `MIC`, AOSP reaches a Bluetooth input only via LE Audio (`BLUETOOTH_BLE`, ranked below USB) or via SCO once Bluetooth is already the communication device, which it is not during recording. Bluetooth headphones alongside an attached USB mic still trigger the switch, since USB outranks LE Audio and the mic wins. A wired headset is the one case that does not: it outranks USB under `MIC`, so its presence vetoes the switch and the Recorder stays at `SOURCE_AUTO`.

`setAudioSource` is `@RestrictTo(LIBRARY)`. That is deliberate and it is the only lever available: CameraX 1.5.3 publishes no supported way to choose the source, and no way at all to route capture to a specific `AudioDeviceInfo` — a sweep of all 1030 classes in `camera-video` + `camera-core` finds zero references to `AudioDeviceInfo`, `setPreferredDevice`, or `MicrophoneDirection`, and the underlying `AudioRecord` is private in `AudioStreamImpl` with no accessor or factory hook. Two tests assert the value survives into the built Recorder, so a CameraX bump that drops the setter or starts validating its `@IntDef` fails the build rather than silently reverting Android to the built-in mic.

The camera also logs which audio source it resolved and which input types the device reported, on every Recorder build. An unmapped type is printed as its raw constant. Without that, a follow-up report that the external mic is still ignored carries no information at all — which is the state #6171 itself was reported in.

**Related Issue:** Closes #6171

## Out of Scope

- **Choosing between several attached mics.** CameraX cannot route capture to a specific device at any restriction level, so Android gets "prefer the attached USB microphone", not "use this exact one". Honoring an exact device would mean owning the audio leg (our own `AudioRecord` + muxing), with the A/V-sync risk that implies (cf. #6098). This is also why an in-camera device picker isn't buildable on Android today — see #7654.
- **The write-only device preference.** Settings → Content Preferences → Audio Input Device stores `preferred_audio_device_id`, but `audioDeviceId` appears in zero Dart files — `divine_camera_method_channel.dart` never sends it, so even macOS's complete native apply path (`switchAudioDevice(to:)`) never fires. Tracked in #7654.
- **Hot-plugging while the camera stays bound.** The source is resolved per Recorder build, so it is picked up on camera entry and on either lens switch, but not mid-session. Rebinding on an `AudioDeviceCallback` would tear down the preview, which is a worse trade for the common flow (plug in, then open the recorder).

## Verification

- `gradle :divine_camera:testDebugUnitTest` — green, including 13 `AudioInputSourceTest` cases. The mixed wired-headset + USB case is pinned to `SOURCE_AUTO` so Android cannot route capture onto the wired earbud mic.
- `flutter analyze lib test integration_test` — No issues found.
- Root cause verified against CameraX 1.5.3 bytecode (SHA1-matched against Google Maven) and AOSP `Engine.cpp` source, not inferred.
- **The reported case is not hardware-verified yet.** Recording on a Galaxy SM-S942B with a Bluetooth headset captured from the Bluetooth mic — a path this PR leaves untouched, and one the quoted AOSP `CAMCORDER` ordering does not predict, since that list has no Bluetooth entry. That ordering is the same evidence behind "USB is unreachable under CAMCORDER on a phone", so the premise wants confirming on hardware rather than being taken as settled. The test that closes #6171 is still: attach a USB-C microphone, record a clip, confirm the audio is the external mic.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)


