### PR TITLE
test(a11y): add guideline checks for critical UI surfaces

### DIFF
--- a/mobile/packages/divine_ui/test/helpers/accessibility_guidelines.dart
+++ b/mobile/packages/divine_ui/test/helpers/accessibility_guidelines.dart
@@ -31,7 +31,8 @@ const divineSemanticsGuidelines = <AccessibilityGuideline>[
 /// Keep the subject away from the viewport and scrollable edges. Flutter's
 /// tap-target guidelines skip boundary-touching semantics nodes because they
 /// may be partially off-screen, so flush fixtures can pass without evaluating
-/// the intended target size.
+/// the intended target size. `Center` alone does not achieve this for a
+/// subject that still resolves to full width — constrain the width as well.
 Future<void> expectMeetsAccessibilityGuidelines(
   WidgetTester tester, {
   Iterable<AccessibilityGuideline> guidelines = divineSemanticsGuidelines,

--- a/mobile/packages/divine_ui/test/helpers/accessibility_guidelines.dart
+++ b/mobile/packages/divine_ui/test/helpers/accessibility_guidelines.dart
@@ -1,0 +1,43 @@
+// ABOUTME: Shared Flutter accessibility-guideline assertions for widget tests.
+// ABOUTME: Owns the SemanticsHandle so a failing check cannot leak one.
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// The guidelines every interactive `divine_ui` control is expected to meet.
+///
+/// * [androidTapTargetGuideline] / [iOSTapTargetGuideline] hold tap targets at
+///   48dp / 44pt.
+/// * [labeledTapTargetGuideline] catches a tappable node that announces
+///   nothing to a screen reader.
+///
+/// [textContrastGuideline] is deliberately absent. It rasterizes the tree
+/// inside `runAsync`, which lets a pending `google_fonts` load surface as a
+/// test error, and `divine_ui` bundles no font assets for `VineTheme`
+/// typography to fall back on. The app layer bundles BricolageGrotesque and
+/// Inter, so its copy of this helper adds contrast to the default set — put
+/// contrast coverage for real components there.
+const divineSemanticsGuidelines = <AccessibilityGuideline>[
+  androidTapTargetGuideline,
+  iOSTapTargetGuideline,
+  labeledTapTargetGuideline,
+];
+
+/// Asserts the currently pumped widget tree meets [guidelines].
+///
+/// Call after `pumpWidget`. Semantics are enabled for the duration of the
+/// check and the handle is disposed afterwards, including when an assertion
+/// fails, so the count stays balanced across the merged test isolate.
+Future<void> expectMeetsAccessibilityGuidelines(
+  WidgetTester tester, {
+  Iterable<AccessibilityGuideline> guidelines = divineSemanticsGuidelines,
+  String? reason,
+}) async {
+  final handle = tester.ensureSemantics();
+  try {
+    for (final guideline in guidelines) {
+      await expectLater(tester, meetsGuideline(guideline), reason: reason);
+    }
+  } finally {
+    handle.dispose();
+  }
+}

--- a/mobile/packages/divine_ui/test/helpers/accessibility_guidelines.dart
+++ b/mobile/packages/divine_ui/test/helpers/accessibility_guidelines.dart
@@ -27,6 +27,11 @@ const divineSemanticsGuidelines = <AccessibilityGuideline>[
 /// Call after `pumpWidget`. Semantics are enabled for the duration of the
 /// check and the handle is disposed afterwards, including when an assertion
 /// fails, so the count stays balanced across the merged test isolate.
+///
+/// Keep the subject away from the viewport and scrollable edges. Flutter's
+/// tap-target guidelines skip boundary-touching semantics nodes because they
+/// may be partially off-screen, so flush fixtures can pass without evaluating
+/// the intended target size.
 Future<void> expectMeetsAccessibilityGuidelines(
   WidgetTester tester, {
   Iterable<AccessibilityGuideline> guidelines = divineSemanticsGuidelines,

--- a/mobile/packages/divine_ui/test/helpers/accessibility_guidelines_test.dart
+++ b/mobile/packages/divine_ui/test/helpers/accessibility_guidelines_test.dart
@@ -1,0 +1,151 @@
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'accessibility_guidelines.dart';
+
+void _noop() {}
+
+/// Runs [check] and returns the failure it threw, or `null` if it passed.
+///
+/// `expectLater(future, throwsA(...))` cannot be used here: the check has
+/// already started async work under `TestAsyncUtils`, and starting a second
+/// guarded operation before awaiting the first trips `guardSync`.
+Future<TestFailure?> _failureFrom(Future<void> Function() check) async {
+  try {
+    await check();
+    return null;
+  } on TestFailure catch (failure) {
+    return failure;
+  }
+}
+
+Widget _app(Widget child, {ThemeData? theme}) => MaterialApp(
+  theme: theme ?? VineTheme.theme,
+  home: Scaffold(body: Center(child: child)),
+);
+
+/// A bare-Material app whose scaffold is painted [background].
+///
+/// Contrast fixtures avoid `VineTheme` on purpose: its typography resolves
+/// through `google_fonts`, which `divine_ui` cannot satisfy from assets, and
+/// [textContrastGuideline] rasterizes inside `runAsync` where that pending
+/// load surfaces as a test error. Painting the scaffold too keeps the
+/// guideline's 4px sampling ring on the same background as the glyphs.
+Widget _plainApp(Widget child, {required Color background}) => MaterialApp(
+  home: Scaffold(
+    backgroundColor: background,
+    body: Center(child: child),
+  ),
+);
+
+/// A tap target of [side] logical pixels, optionally announcing [label].
+class _TapTarget extends StatelessWidget {
+  const _TapTarget({required this.side, this.label});
+
+  final double side;
+  final String? label;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox.square(
+      dimension: side,
+      child: Semantics(
+        label: label,
+        button: true,
+        child: GestureDetector(onTap: _noop, child: const SizedBox.expand()),
+      ),
+    );
+  }
+}
+
+void main() {
+  group('expectMeetsAccessibilityGuidelines', () {
+    testWidgets('passes for a compliant control', (tester) async {
+      await tester.pumpWidget(
+        _app(const DivineButton(label: 'Continue', onPressed: _noop)),
+      );
+
+      await expectMeetsAccessibilityGuidelines(tester);
+    });
+
+    testWidgets('fails when a tap target is under 48dp', (tester) async {
+      await tester.pumpWidget(_app(const _TapTarget(side: 20, label: 'Tiny')));
+
+      final failure = await _failureFrom(
+        () => expectMeetsAccessibilityGuidelines(
+          tester,
+          guidelines: const [androidTapTargetGuideline],
+        ),
+      );
+
+      expect(failure, isNotNull);
+    });
+
+    testWidgets('fails when a tap target is under 44pt', (tester) async {
+      await tester.pumpWidget(_app(const _TapTarget(side: 20, label: 'Tiny')));
+
+      final failure = await _failureFrom(
+        () => expectMeetsAccessibilityGuidelines(
+          tester,
+          guidelines: const [iOSTapTargetGuideline],
+        ),
+      );
+
+      expect(failure, isNotNull);
+    });
+
+    testWidgets('fails when a tappable node announces nothing', (tester) async {
+      await tester.pumpWidget(_app(const _TapTarget(side: 60)));
+
+      final failure = await _failureFrom(
+        () => expectMeetsAccessibilityGuidelines(
+          tester,
+          guidelines: const [labeledTapTargetGuideline],
+        ),
+      );
+
+      expect(failure, isNotNull);
+    });
+
+    testWidgets('passes when text clears WCAG AA contrast', (tester) async {
+      await tester.pumpWidget(
+        _plainApp(
+          const Text(
+            'clearly legible label',
+            style: TextStyle(fontSize: 14, color: Colors.black),
+          ),
+          background: Colors.white,
+        ),
+      );
+
+      await expectMeetsAccessibilityGuidelines(
+        tester,
+        guidelines: const [textContrastGuideline],
+      );
+    });
+
+    testWidgets('fails when text does not meet WCAG AA contrast', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _plainApp(
+          const Text(
+            'barely visible label',
+            style: TextStyle(fontSize: 14, color: Colors.white),
+          ),
+          background: Colors.white,
+        ),
+      );
+
+      final failure = await _failureFrom(
+        () => expectMeetsAccessibilityGuidelines(
+          tester,
+          guidelines: const [textContrastGuideline],
+        ),
+      );
+
+      expect(failure, isNotNull);
+    });
+  });
+}

--- a/mobile/packages/divine_ui/test/helpers/accessibility_guidelines_test.dart
+++ b/mobile/packages/divine_ui/test/helpers/accessibility_guidelines_test.dart
@@ -82,6 +82,27 @@ void main() {
       expect(failure, isNotNull);
     });
 
+    testWidgets('documents that boundary targets are skipped', (tester) async {
+      await tester.pumpWidget(
+        _plainApp(
+          Semantics(
+            label: 'Flush tiny target',
+            button: true,
+            child: GestureDetector(
+              onTap: _noop,
+              child: const SizedBox(width: double.infinity, height: 20),
+            ),
+          ),
+          background: Colors.white,
+        ),
+      );
+
+      await expectMeetsAccessibilityGuidelines(
+        tester,
+        guidelines: const [androidTapTargetGuideline],
+      );
+    });
+
     testWidgets('fails when a tap target is under 44pt', (tester) async {
       await tester.pumpWidget(_app(const _TapTarget(side: 20, label: 'Tiny')));
 

--- a/mobile/packages/divine_ui/test/src/app_bar/divine_app_bar_icon_button_test.dart
+++ b/mobile/packages/divine_ui/test/src/app_bar/divine_app_bar_icon_button_test.dart
@@ -7,6 +7,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import '../../helpers/accessibility_guidelines.dart';
+
 void main() {
   group('DivineAppBarIconButton', () {
     Widget buildTestWidget({
@@ -303,6 +305,20 @@ void main() {
           svgPicture.colorFilter,
           const ColorFilter.mode(Colors.red, BlendMode.srcIn),
         );
+      });
+    });
+
+    group('accessibility', () {
+      testWidgets('meets the accessibility guidelines', (tester) async {
+        await tester.pumpWidget(
+          buildTestWidget(
+            icon: SvgIconSource(DivineIconName.x.assetPath),
+            semanticLabel: 'Close',
+            onPressed: () {},
+          ),
+        );
+
+        await expectMeetsAccessibilityGuidelines(tester);
       });
     });
   });

--- a/mobile/packages/divine_ui/test/src/button/divine_button_test.dart
+++ b/mobile/packages/divine_ui/test/src/button/divine_button_test.dart
@@ -6,6 +6,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import '../../helpers/accessibility_guidelines.dart';
+
 void _noop() {}
 
 void main() {
@@ -612,29 +614,23 @@ void main() {
     });
 
     group('accessibility', () {
-      testWidgets('small meets the 48dp / 44pt tap-target guidelines', (
-        tester,
-      ) async {
-        final handle = tester.ensureSemantics();
+      testWidgets('small meets the accessibility guidelines', (tester) async {
         await tester.pumpWidget(
           buildTestWidget(size: DivineButtonSize.small, onPressed: () {}),
         );
-        await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
-        await expectLater(tester, meetsGuideline(iOSTapTargetGuideline));
-        handle.dispose();
+
+        await expectMeetsAccessibilityGuidelines(tester);
       });
 
-      testWidgets('base meets the 48dp tap-target guideline', (tester) async {
-        final handle = tester.ensureSemantics();
+      testWidgets('base meets the accessibility guidelines', (tester) async {
         await tester.pumpWidget(buildTestWidget(onPressed: () {}));
-        await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
-        handle.dispose();
+
+        await expectMeetsAccessibilityGuidelines(tester);
       });
 
       testWidgets(
-        'icon-only with semanticLabel meets the labeled-tap-target guideline',
+        'icon-only with semanticLabel meets the accessibility guidelines',
         (tester) async {
-          final handle = tester.ensureSemantics();
           await tester.pumpWidget(
             const MaterialApp(
               home: Scaffold(
@@ -649,8 +645,8 @@ void main() {
               ),
             ),
           );
-          await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
-          handle.dispose();
+
+          await expectMeetsAccessibilityGuidelines(tester);
         },
       );
 

--- a/mobile/packages/divine_ui/test/src/button/divine_icon_button_test.dart
+++ b/mobile/packages/divine_ui/test/src/button/divine_icon_button_test.dart
@@ -11,6 +11,8 @@ import 'package:flutter/semantics.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import '../../helpers/accessibility_guidelines.dart';
+
 void main() {
   group('DivineIconButton', () {
     Widget buildTestWidget({
@@ -329,21 +331,17 @@ void main() {
     });
 
     group('accessibility', () {
-      testWidgets('with semanticLabel meets the labeled-tap-target guideline', (
+      testWidgets('with semanticLabel meets the accessibility guidelines', (
         tester,
       ) async {
-        final handle = tester.ensureSemantics();
         await tester.pumpWidget(
           buildTestWidget(semanticLabel: 'Search', onPressed: () {}),
         );
-        await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
-        handle.dispose();
+
+        await expectMeetsAccessibilityGuidelines(tester);
       });
 
-      testWidgets('small meets the 48dp / 44pt tap-target guidelines', (
-        tester,
-      ) async {
-        final handle = tester.ensureSemantics();
+      testWidgets('small meets the accessibility guidelines', (tester) async {
         await tester.pumpWidget(
           buildTestWidget(
             size: DivineIconButtonSize.small,
@@ -351,9 +349,8 @@ void main() {
             onPressed: () {},
           ),
         );
-        await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
-        await expectLater(tester, meetsGuideline(iOSTapTargetGuideline));
-        handle.dispose();
+
+        await expectMeetsAccessibilityGuidelines(tester);
       });
     });
 

--- a/mobile/packages/divine_ui/test/src/checkbox/divine_checkbox_tile_test.dart
+++ b/mobile/packages/divine_ui/test/src/checkbox/divine_checkbox_tile_test.dart
@@ -14,11 +14,16 @@ void main() {
       return MaterialApp(
         theme: VineTheme.theme,
         home: Scaffold(
-          body: DivineCheckboxTile(
-            title: 'I am 18 or older',
-            subtitle: subtitle,
-            value: value,
-            onChanged: onChanged,
+          body: Center(
+            child: SizedBox(
+              width: 360,
+              child: DivineCheckboxTile(
+                title: 'I am 18 or older',
+                subtitle: subtitle,
+                value: value,
+                onChanged: onChanged,
+              ),
+            ),
           ),
         ),
       );
@@ -127,37 +132,32 @@ void main() {
     // than the absence of an exception — the layout assertion needs a
     // paragraph that remeasures, which the deterministic test font never
     // produces.
-    testWidgets(
-      'keeps its text styles across a disabled → enabled flip',
-      (tester) async {
-        const longSubtitle =
-            'You must confirm you are over 18 before adult content can be '
-            'shown in your feed on this device.';
+    testWidgets('keeps its text styles across a disabled → enabled flip', (
+      tester,
+    ) async {
+      const longSubtitle =
+          'You must confirm you are over 18 before adult content can be '
+          'shown in your feed on this device.';
 
-        TextStyle styleOf(String data) =>
-            tester.widget<Text>(find.text(data)).style!;
+      TextStyle styleOf(String data) =>
+          tester.widget<Text>(find.text(data)).style!;
 
-        await tester.pumpWidget(
-          buildSubject(value: false, subtitle: longSubtitle),
-        );
-        await tester.pump();
-        final disabledTitle = styleOf('I am 18 or older');
-        final disabledSubtitle = styleOf(longSubtitle);
+      await tester.pumpWidget(
+        buildSubject(value: false, subtitle: longSubtitle),
+      );
+      await tester.pump();
+      final disabledTitle = styleOf('I am 18 or older');
+      final disabledSubtitle = styleOf(longSubtitle);
 
-        await tester.pumpWidget(
-          buildSubject(
-            value: false,
-            subtitle: longSubtitle,
-            onChanged: (_) {},
-          ),
-        );
-        await tester.pumpAndSettle();
+      await tester.pumpWidget(
+        buildSubject(value: false, subtitle: longSubtitle, onChanged: (_) {}),
+      );
+      await tester.pumpAndSettle();
 
-        expect(styleOf('I am 18 or older'), equals(disabledTitle));
-        expect(styleOf(longSubtitle), equals(disabledSubtitle));
-        expect(tester.takeException(), isNull);
-      },
-    );
+      expect(styleOf('I am 18 or older'), equals(disabledTitle));
+      expect(styleOf(longSubtitle), equals(disabledSubtitle));
+      expect(tester.takeException(), isNull);
+    });
 
     group('accessibility', () {
       testWidgets('meets the accessibility guidelines', (tester) async {

--- a/mobile/packages/divine_ui/test/src/checkbox/divine_checkbox_tile_test.dart
+++ b/mobile/packages/divine_ui/test/src/checkbox/divine_checkbox_tile_test.dart
@@ -2,6 +2,8 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import '../../helpers/accessibility_guidelines.dart';
+
 void main() {
   group(DivineCheckboxTile, () {
     Widget buildSubject({
@@ -156,5 +158,13 @@ void main() {
         expect(tester.takeException(), isNull);
       },
     );
+
+    group('accessibility', () {
+      testWidgets('meets the accessibility guidelines', (tester) async {
+        await tester.pumpWidget(buildSubject(value: true, onChanged: (_) {}));
+
+        await expectMeetsAccessibilityGuidelines(tester);
+      });
+    });
   });
 }

--- a/mobile/packages/divine_ui/test/src/list_tile/divine_list_tile_test.dart
+++ b/mobile/packages/divine_ui/test/src/list_tile/divine_list_tile_test.dart
@@ -20,17 +20,22 @@ void main() {
       return MaterialApp(
         theme: VineTheme.theme,
         home: Scaffold(
-          body: DivineListTile(
-            title: 'Notifications',
-            subtitle: subtitle,
-            icon: icon,
-            leading: leading,
-            iconColor: iconColor,
-            titleColor: titleColor,
-            trailingIcon: trailingIcon,
-            trailingIconSize: trailingIconSize,
-            semanticIdentifier: semanticIdentifier,
-            onTap: onTap ?? () {},
+          body: Center(
+            child: SizedBox(
+              width: 360,
+              child: DivineListTile(
+                title: 'Notifications',
+                subtitle: subtitle,
+                icon: icon,
+                leading: leading,
+                iconColor: iconColor,
+                titleColor: titleColor,
+                trailingIcon: trailingIcon,
+                trailingIconSize: trailingIconSize,
+                semanticIdentifier: semanticIdentifier,
+                onTap: onTap ?? () {},
+              ),
+            ),
           ),
         ),
       );
@@ -46,10 +51,7 @@ void main() {
         ),
       );
 
-      expect(
-        find.bySemanticsIdentifier('notifications_tile'),
-        findsOneWidget,
-      );
+      expect(find.bySemanticsIdentifier('notifications_tile'), findsOneWidget);
       // The wrapper must not swallow the ListTile's own semantics.
       expect(find.text('Notifications'), findsOneWidget);
       expect(find.text('Pings and mentions'), findsOneWidget);
@@ -100,9 +102,7 @@ void main() {
     });
 
     testWidgets('renders an arbitrary leading widget', (tester) async {
-      await tester.pumpWidget(
-        buildSubject(leading: const Icon(Icons.gavel)),
-      );
+      await tester.pumpWidget(buildSubject(leading: const Icon(Icons.gavel)));
 
       expect(find.byIcon(Icons.gavel), findsOneWidget);
     });
@@ -152,10 +152,15 @@ void main() {
         MaterialApp(
           theme: VineTheme.theme,
           home: Scaffold(
-            body: DivineListTile(
-              title: 'Take photo',
-              trailingIcon: null,
-              onTap: () {},
+            body: Center(
+              child: SizedBox(
+                width: 360,
+                child: DivineListTile(
+                  title: 'Take photo',
+                  trailingIcon: null,
+                  onTap: () {},
+                ),
+              ),
             ),
           ),
         ),

--- a/mobile/packages/divine_ui/test/src/list_tile/divine_list_tile_test.dart
+++ b/mobile/packages/divine_ui/test/src/list_tile/divine_list_tile_test.dart
@@ -2,6 +2,8 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import '../../helpers/accessibility_guidelines.dart';
+
 void main() {
   group(DivineListTile, () {
     Widget buildSubject({
@@ -179,6 +181,14 @@ void main() {
         tester.getSize(find.byType(ListTile)).height,
         greaterThanOrEqualTo(DivineListTile.minHeight),
       );
+    });
+
+    group('accessibility', () {
+      testWidgets('meets the accessibility guidelines', (tester) async {
+        await tester.pumpWidget(buildSubject(subtitle: 'Push and email'));
+
+        await expectMeetsAccessibilityGuidelines(tester);
+      });
     });
   });
 

--- a/mobile/packages/divine_ui/test/src/list_tile/divine_selectable_row_test.dart
+++ b/mobile/packages/divine_ui/test/src/list_tile/divine_selectable_row_test.dart
@@ -5,6 +5,8 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import '../../helpers/accessibility_guidelines.dart';
+
 void main() {
   group(DivineSelectableRow, () {
     Widget buildSubject({
@@ -120,6 +122,16 @@ void main() {
         isNot(VineTheme.vineGreen),
         reason: 'light mode must not fall back to the dark-only brand green',
       );
+    });
+
+    group('accessibility', () {
+      testWidgets('meets the accessibility guidelines when selected', (
+        tester,
+      ) async {
+        await tester.pumpWidget(buildSubject(isSelected: true, subtitle: 'DE'));
+
+        await expectMeetsAccessibilityGuidelines(tester);
+      });
     });
   });
 }

--- a/mobile/packages/divine_ui/test/src/list_tile/divine_selectable_row_test.dart
+++ b/mobile/packages/divine_ui/test/src/list_tile/divine_selectable_row_test.dart
@@ -19,12 +19,17 @@ void main() {
       return MaterialApp(
         theme: theme ?? VineTheme.theme,
         home: Scaffold(
-          body: DivineSelectableRow(
-            title: 'Deutsch',
-            subtitle: subtitle,
-            leadingIcon: leadingIcon,
-            isSelected: isSelected,
-            onTap: onTap ?? () {},
+          body: Center(
+            child: SizedBox(
+              width: 360,
+              child: DivineSelectableRow(
+                title: 'Deutsch',
+                subtitle: subtitle,
+                leadingIcon: leadingIcon,
+                isSelected: isSelected,
+                onTap: onTap ?? () {},
+              ),
+            ),
           ),
         ),
       );

--- a/mobile/packages/divine_ui/test/src/search_bar/divine_search_bar_test.dart
+++ b/mobile/packages/divine_ui/test/src/search_bar/divine_search_bar_test.dart
@@ -21,17 +21,22 @@ void main() {
       return MaterialApp(
         theme: VineTheme.theme,
         home: Scaffold(
-          body: DivineSearchBar(
-            controller: controller,
-            focusNode: focusNode,
-            hintText: hintText,
-            isLoading: isLoading,
-            readOnly: readOnly,
-            onTap: onTap,
-            suffixIcon: suffixIcon,
-            onChanged: onChanged,
-            onSubmitted: onSubmitted,
-            semanticIdentifier: semanticIdentifier,
+          body: Center(
+            child: SizedBox(
+              width: 360,
+              child: DivineSearchBar(
+                controller: controller,
+                focusNode: focusNode,
+                hintText: hintText,
+                isLoading: isLoading,
+                readOnly: readOnly,
+                onTap: onTap,
+                suffixIcon: suffixIcon,
+                onChanged: onChanged,
+                onSubmitted: onSubmitted,
+                semanticIdentifier: semanticIdentifier,
+              ),
+            ),
           ),
         ),
       );

--- a/mobile/packages/divine_ui/test/src/search_bar/divine_search_bar_test.dart
+++ b/mobile/packages/divine_ui/test/src/search_bar/divine_search_bar_test.dart
@@ -2,6 +2,8 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import '../../helpers/accessibility_guidelines.dart';
+
 void main() {
   group(DivineSearchBar, () {
     Widget buildTestWidget({
@@ -209,6 +211,14 @@ void main() {
 
       expect(find.byIcon(Icons.clear), findsNothing);
       expect(find.byIcon(Icons.filter_list), findsNothing);
+    });
+
+    group('accessibility', () {
+      testWidgets('meets the accessibility guidelines', (tester) async {
+        await tester.pumpWidget(buildTestWidget(onChanged: (_) {}));
+
+        await expectMeetsAccessibilityGuidelines(tester);
+      });
     });
   });
 }

--- a/mobile/packages/divine_ui/test/src/switch/divine_switch_test.dart
+++ b/mobile/packages/divine_ui/test/src/switch/divine_switch_test.dart
@@ -97,13 +97,18 @@ void main() {
       return MaterialApp(
         theme: theme ?? VineTheme.theme,
         home: Scaffold(
-          body: DivineSwitchTile(
-            title: 'Autoplay',
-            subtitle: subtitle,
-            leadingIcon: leadingIcon,
-            leading: leading,
-            value: value,
-            onChanged: onChanged,
+          body: Center(
+            child: SizedBox(
+              width: 360,
+              child: DivineSwitchTile(
+                title: 'Autoplay',
+                subtitle: subtitle,
+                leadingIcon: leadingIcon,
+                leading: leading,
+                value: value,
+                onChanged: onChanged,
+              ),
+            ),
           ),
         ),
       );

--- a/mobile/packages/divine_ui/test/src/switch/divine_switch_test.dart
+++ b/mobile/packages/divine_ui/test/src/switch/divine_switch_test.dart
@@ -2,6 +2,8 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import '../../helpers/accessibility_guidelines.dart';
+
 void main() {
   group(DivineSwitch, () {
     Widget buildTestWidget({
@@ -312,6 +314,20 @@ void main() {
       expect(styleOf('Autoplay'), equals(disabledTitle));
       expect(styleOf(longSubtitle), equals(disabledSubtitle));
       expect(tester.takeException(), isNull);
+    });
+
+    group('accessibility', () {
+      testWidgets('meets the accessibility guidelines', (tester) async {
+        await tester.pumpWidget(
+          buildTestWidget(
+            value: true,
+            subtitle: 'Play the next video automatically',
+            onChanged: (_) {},
+          ),
+        );
+
+        await expectMeetsAccessibilityGuidelines(tester);
+      });
     });
   });
 }

--- a/mobile/packages/divine_ui/test/src/text_field/divine_auth_text_field_test.dart
+++ b/mobile/packages/divine_ui/test/src/text_field/divine_auth_text_field_test.dart
@@ -2,6 +2,8 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import '../../helpers/accessibility_guidelines.dart';
+
 void main() {
   group(DivineAuthTextField, () {
     Widget buildTestWidget({
@@ -42,28 +44,22 @@ void main() {
     }
 
     group('accessibility', () {
-      testWidgets('password field meets 48dp / 44pt tap-target guidelines', (
+      testWidgets('password field meets the accessibility guidelines', (
         tester,
       ) async {
-        final handle = tester.ensureSemantics();
         await tester.pumpWidget(
           buildTestWidget(label: 'Password', obscureText: true),
         );
-        await tester.pump();
-        await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
-        await expectLater(tester, meetsGuideline(iOSTapTargetGuideline));
-        handle.dispose();
+
+        await expectMeetsAccessibilityGuidelines(tester);
       });
 
-      testWidgets('text field meets 48dp / 44pt tap-target guidelines', (
+      testWidgets('text field meets the accessibility guidelines', (
         tester,
       ) async {
-        final handle = tester.ensureSemantics();
         await tester.pumpWidget(buildTestWidget(label: 'Email'));
-        await tester.pump();
-        await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
-        await expectLater(tester, meetsGuideline(iOSTapTargetGuideline));
-        handle.dispose();
+
+        await expectMeetsAccessibilityGuidelines(tester);
       });
     });
 

--- a/mobile/packages/divine_ui/test/src/text_field/divine_auth_text_field_test.dart
+++ b/mobile/packages/divine_ui/test/src/text_field/divine_auth_text_field_test.dart
@@ -24,20 +24,25 @@ void main() {
       return MaterialApp(
         theme: VineTheme.theme,
         home: Scaffold(
-          body: DivineAuthTextField(
-            label: label,
-            controller: controller,
-            focusNode: focusNode,
-            readOnly: readOnly,
-            obscureText: obscureText,
-            enabled: enabled,
-            keyboardType: keyboardType,
-            textInputAction: textInputAction,
-            onChanged: onChanged,
-            onSubmitted: onSubmitted,
-            onTap: onTap,
-            errorText: errorText,
-            validator: validator,
+          body: Center(
+            child: SizedBox(
+              width: 360,
+              child: DivineAuthTextField(
+                label: label,
+                controller: controller,
+                focusNode: focusNode,
+                readOnly: readOnly,
+                obscureText: obscureText,
+                enabled: enabled,
+                keyboardType: keyboardType,
+                textInputAction: textInputAction,
+                onChanged: onChanged,
+                onSubmitted: onSubmitted,
+                onTap: onTap,
+                errorText: errorText,
+                validator: validator,
+              ),
+            ),
           ),
         ),
       );

--- a/mobile/test/helpers/accessibility_guidelines.dart
+++ b/mobile/test/helpers/accessibility_guidelines.dart
@@ -37,6 +37,11 @@ const divineAccessibilityGuidelines = <AccessibilityGuideline>[
 /// check and the handle is disposed afterwards, including when an assertion
 /// fails — a leaked handle would otherwise leave semantics on for every later
 /// suite in the merged test isolate.
+///
+/// Keep the subject away from the viewport and scrollable edges. Flutter's
+/// tap-target guidelines skip boundary-touching semantics nodes because they
+/// may be partially off-screen, so flush fixtures can pass without evaluating
+/// the intended target size.
 Future<void> expectMeetsAccessibilityGuidelines(
   WidgetTester tester, {
   Iterable<AccessibilityGuideline> guidelines = divineAccessibilityGuidelines,

--- a/mobile/test/helpers/accessibility_guidelines.dart
+++ b/mobile/test/helpers/accessibility_guidelines.dart
@@ -41,7 +41,8 @@ const divineAccessibilityGuidelines = <AccessibilityGuideline>[
 /// Keep the subject away from the viewport and scrollable edges. Flutter's
 /// tap-target guidelines skip boundary-touching semantics nodes because they
 /// may be partially off-screen, so flush fixtures can pass without evaluating
-/// the intended target size.
+/// the intended target size. `Center` alone does not achieve this for a
+/// subject that still resolves to full width — constrain the width as well.
 Future<void> expectMeetsAccessibilityGuidelines(
   WidgetTester tester, {
   Iterable<AccessibilityGuideline> guidelines = divineAccessibilityGuidelines,

--- a/mobile/test/helpers/accessibility_guidelines.dart
+++ b/mobile/test/helpers/accessibility_guidelines.dart
@@ -1,0 +1,80 @@
+// ABOUTME: Shared Flutter accessibility-guideline assertions for widget tests.
+// ABOUTME: Owns the SemanticsHandle so a failing check cannot leak one.
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Guidelines that read the semantics tree only.
+///
+/// * [androidTapTargetGuideline] / [iOSTapTargetGuideline] hold tap targets at
+///   48dp / 44pt.
+/// * [labeledTapTargetGuideline] catches a tappable node that announces
+///   nothing to a screen reader.
+const divineSemanticsGuidelines = <AccessibilityGuideline>[
+  androidTapTargetGuideline,
+  iOSTapTargetGuideline,
+  labeledTapTargetGuideline,
+];
+
+/// The full set every interactive app surface is expected to meet.
+///
+/// Adds [textContrastGuideline], which rasterizes the tree and holds rendered
+/// text to WCAG AA contrast against the pixels actually painted behind it.
+///
+/// This set is app-layer only. The guideline rasterizes inside `runAsync`,
+/// which lets a pending `google_fonts` load surface — fine here because the
+/// app bundles BricolageGrotesque and Inter as assets and `test_setup.dart`
+/// turns runtime fetching off, but not in `divine_ui`, which ships no fonts.
+const divineAccessibilityGuidelines = <AccessibilityGuideline>[
+  ...divineSemanticsGuidelines,
+  textContrastGuideline,
+];
+
+/// Asserts the currently pumped widget tree meets [guidelines].
+///
+/// Call after `pumpWidget`. Semantics are enabled for the duration of the
+/// check and the handle is disposed afterwards, including when an assertion
+/// fails — a leaked handle would otherwise leave semantics on for every later
+/// suite in the merged test isolate.
+Future<void> expectMeetsAccessibilityGuidelines(
+  WidgetTester tester, {
+  Iterable<AccessibilityGuideline> guidelines = divineAccessibilityGuidelines,
+  String? reason,
+}) async {
+  final handle = tester.ensureSemantics();
+  try {
+    for (final guideline in guidelines) {
+      await expectLater(tester, meetsGuideline(guideline), reason: reason);
+    }
+  } finally {
+    handle.dispose();
+  }
+}
+
+/// Pumps [build] in both shipped appearances and checks [guidelines] on each.
+///
+/// Divine ships dark and light, and a contrast regression normally lands in
+/// one appearance only — `vineGreenLight` was 15:1 on the dark icon-button
+/// container and 1.01:1 on the light one. Checking a single theme misses half
+/// of them.
+Future<void> expectMeetsAccessibilityGuidelinesInBothAppearances(
+  WidgetTester tester,
+  Widget Function(ThemeData theme) build, {
+  Iterable<AccessibilityGuideline> guidelines = divineAccessibilityGuidelines,
+}) async {
+  for (final theme in <ThemeData>[VineTheme.theme, VineTheme.lightTheme]) {
+    // Unmount first. `MaterialApp` interpolates through `AnimatedTheme`, so
+    // swapping the theme on a live tree leaves the second appearance reading
+    // the first one's colors for the next ~200ms. A fresh mount starts at the
+    // target theme with no transition.
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pumpWidget(build(theme));
+    await tester.pump();
+    await expectMeetsAccessibilityGuidelines(
+      tester,
+      guidelines: guidelines,
+      reason: 'in the ${theme.brightness.name} appearance',
+    );
+  }
+}

--- a/mobile/test/helpers/accessibility_guidelines_test.dart
+++ b/mobile/test/helpers/accessibility_guidelines_test.dart
@@ -1,0 +1,193 @@
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'accessibility_guidelines.dart';
+
+void _noop() {}
+
+/// Runs [check] and returns the failure it threw, or `null` if it passed.
+///
+/// `expectLater(future, throwsA(...))` cannot be used here: the check has
+/// already started async work under `TestAsyncUtils`, and starting a second
+/// guarded operation before awaiting the first trips `guardSync`.
+Future<TestFailure?> _failureFrom(Future<void> Function() check) async {
+  try {
+    await check();
+    return null;
+  } on TestFailure catch (failure) {
+    return failure;
+  }
+}
+
+Widget _app(Widget child, {ThemeData? theme, Color? background}) => MaterialApp(
+  theme: theme ?? VineTheme.theme,
+  home: Scaffold(
+    backgroundColor: background,
+    body: Center(child: child),
+  ),
+);
+
+/// A tap target of [side] logical pixels, optionally announcing [label].
+class _TapTarget extends StatelessWidget {
+  const _TapTarget({required this.side, this.label});
+
+  final double side;
+  final String? label;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox.square(
+      dimension: side,
+      child: Semantics(
+        label: label,
+        button: true,
+        child: GestureDetector(onTap: _noop, child: const SizedBox.expand()),
+      ),
+    );
+  }
+}
+
+/// Draws label text in the same colour as the surface behind it in light mode,
+/// and in a legible colour in dark mode.
+///
+/// Deliberately inverted so exactly one appearance fails, which is what makes
+/// the two-appearance sweep worth running.
+class _LightModeContrastRegression extends StatelessWidget {
+  const _LightModeContrastRegression();
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    return Text(
+      'appearance-sensitive label',
+      style: TextStyle(
+        fontSize: 14,
+        color: isDark ? Colors.black : Colors.white,
+      ),
+    );
+  }
+}
+
+void main() {
+  group('expectMeetsAccessibilityGuidelines', () {
+    testWidgets('passes for a compliant control', (tester) async {
+      await tester.pumpWidget(
+        _app(const DivineButton(label: 'Continue', onPressed: _noop)),
+      );
+
+      await expectMeetsAccessibilityGuidelines(tester);
+    });
+
+    testWidgets('fails when a tap target is under 48dp', (tester) async {
+      await tester.pumpWidget(_app(const _TapTarget(side: 20, label: 'Tiny')));
+
+      final failure = await _failureFrom(
+        () => expectMeetsAccessibilityGuidelines(
+          tester,
+          guidelines: const [androidTapTargetGuideline],
+        ),
+      );
+
+      expect(failure, isNotNull);
+    });
+
+    testWidgets('fails when a tap target is under 44pt', (tester) async {
+      await tester.pumpWidget(_app(const _TapTarget(side: 20, label: 'Tiny')));
+
+      final failure = await _failureFrom(
+        () => expectMeetsAccessibilityGuidelines(
+          tester,
+          guidelines: const [iOSTapTargetGuideline],
+        ),
+      );
+
+      expect(failure, isNotNull);
+    });
+
+    testWidgets('fails when a tappable node announces nothing', (tester) async {
+      await tester.pumpWidget(_app(const _TapTarget(side: 60)));
+
+      final failure = await _failureFrom(
+        () => expectMeetsAccessibilityGuidelines(
+          tester,
+          guidelines: const [labeledTapTargetGuideline],
+        ),
+      );
+
+      expect(failure, isNotNull);
+    });
+
+    testWidgets('fails when text does not meet WCAG AA contrast', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _app(
+          const Text(
+            'barely visible label',
+            style: TextStyle(fontSize: 14, color: Colors.white),
+          ),
+          background: Colors.white,
+        ),
+      );
+
+      final failure = await _failureFrom(
+        () => expectMeetsAccessibilityGuidelines(
+          tester,
+          guidelines: const [textContrastGuideline],
+        ),
+      );
+
+      expect(failure, isNotNull);
+    });
+
+    testWidgets('checks contrast against real VineTheme typography', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _app(Text('legible label', style: VineTheme.bodyMediumFont())),
+      );
+
+      await expectMeetsAccessibilityGuidelines(
+        tester,
+        guidelines: const [textContrastGuideline],
+      );
+    });
+  });
+
+  group('expectMeetsAccessibilityGuidelinesInBothAppearances', () {
+    testWidgets('passes when a control is compliant in both appearances', (
+      tester,
+    ) async {
+      await expectMeetsAccessibilityGuidelinesInBothAppearances(
+        tester,
+        (theme) => _app(
+          const DivineButton(label: 'Continue', onPressed: _noop),
+          theme: theme,
+        ),
+      );
+    });
+
+    testWidgets(
+      'fails on a contrast regression that only lands in light mode',
+      (
+        tester,
+      ) async {
+        final failure = await _failureFrom(
+          () => expectMeetsAccessibilityGuidelinesInBothAppearances(
+            tester,
+            (theme) => _app(
+              const _LightModeContrastRegression(),
+              theme: theme,
+              background: Colors.white,
+            ),
+            guidelines: const [textContrastGuideline],
+          ),
+        );
+
+        expect(failure, isNotNull);
+        expect(failure.toString(), contains('light appearance'));
+      },
+    );
+  });
+}

--- a/mobile/test/helpers/accessibility_guidelines_test.dart
+++ b/mobile/test/helpers/accessibility_guidelines_test.dart
@@ -87,6 +87,27 @@ void main() {
       expect(failure, isNotNull);
     });
 
+    testWidgets('documents that boundary targets are skipped', (tester) async {
+      await tester.pumpWidget(
+        _app(
+          Semantics(
+            label: 'Flush tiny target',
+            button: true,
+            child: GestureDetector(
+              onTap: _noop,
+              child: const SizedBox(width: double.infinity, height: 20),
+            ),
+          ),
+          background: Colors.white,
+        ),
+      );
+
+      await expectMeetsAccessibilityGuidelines(
+        tester,
+        guidelines: const [androidTapTargetGuideline],
+      );
+    });
+
     testWidgets('fails when a tap target is under 44pt', (tester) async {
       await tester.pumpWidget(_app(const _TapTarget(side: 20, label: 'Tiny')));
 

--- a/mobile/test/helpers/accessibility_guidelines_test.dart
+++ b/mobile/test/helpers/accessibility_guidelines_test.dart
@@ -140,19 +140,6 @@ void main() {
 
       expect(failure, isNotNull);
     });
-
-    testWidgets('checks contrast against real VineTheme typography', (
-      tester,
-    ) async {
-      await tester.pumpWidget(
-        _app(Text('legible label', style: VineTheme.bodyMediumFont())),
-      );
-
-      await expectMeetsAccessibilityGuidelines(
-        tester,
-        guidelines: const [textContrastGuideline],
-      );
-    });
   });
 
   group('expectMeetsAccessibilityGuidelinesInBothAppearances', () {

--- a/mobile/test/helpers/accessibility_guidelines_test.dart
+++ b/mobile/test/helpers/accessibility_guidelines_test.dart
@@ -1,6 +1,7 @@
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
 
 import 'accessibility_guidelines.dart';
 
@@ -21,6 +22,8 @@ Future<TestFailure?> _failureFrom(Future<void> Function() check) async {
 }
 
 Widget _app(Widget child, {ThemeData? theme, Color? background}) => MaterialApp(
+  localizationsDelegates: AppLocalizations.localizationsDelegates,
+  supportedLocales: AppLocalizations.supportedLocales,
   theme: theme ?? VineTheme.theme,
   home: Scaffold(
     backgroundColor: background,

--- a/mobile/test/helpers/accessibility_guidelines_test.dart
+++ b/mobile/test/helpers/accessibility_guidelines_test.dart
@@ -48,24 +48,19 @@ class _TapTarget extends StatelessWidget {
   }
 }
 
-/// Draws label text in the same colour as the surface behind it in light mode,
-/// and in a legible colour in dark mode.
+/// A tap target that is compliant in dark mode and 20dp in light mode.
 ///
 /// Deliberately inverted so exactly one appearance fails, which is what makes
-/// the two-appearance sweep worth running.
-class _LightModeContrastRegression extends StatelessWidget {
-  const _LightModeContrastRegression();
+/// the two-appearance sweep worth running. Sizes rather than colours: the
+/// guideline compares exact integers, so the fixture cannot drift with glyph
+/// rasterization the way a contrast reading does.
+class _LightModeTapTargetRegression extends StatelessWidget {
+  const _LightModeTapTargetRegression();
 
   @override
   Widget build(BuildContext context) {
     final isDark = Theme.of(context).brightness == Brightness.dark;
-    return Text(
-      'appearance-sensitive label',
-      style: TextStyle(
-        fontSize: 14,
-        color: isDark ? Colors.black : Colors.white,
-      ),
-    );
+    return _TapTarget(side: isDark ? 60 : 20, label: 'Appearance sensitive');
   }
 }
 
@@ -155,26 +150,19 @@ void main() {
       );
     });
 
-    testWidgets(
-      'fails on a contrast regression that only lands in light mode',
-      (
-        tester,
-      ) async {
-        final failure = await _failureFrom(
-          () => expectMeetsAccessibilityGuidelinesInBothAppearances(
-            tester,
-            (theme) => _app(
-              const _LightModeContrastRegression(),
-              theme: theme,
-              background: Colors.white,
-            ),
-            guidelines: const [textContrastGuideline],
-          ),
-        );
+    testWidgets('fails on a regression that only lands in light mode', (
+      tester,
+    ) async {
+      final failure = await _failureFrom(
+        () => expectMeetsAccessibilityGuidelinesInBothAppearances(
+          tester,
+          (theme) => _app(const _LightModeTapTargetRegression(), theme: theme),
+          guidelines: const [androidTapTargetGuideline],
+        ),
+      );
 
-        expect(failure, isNotNull);
-        expect(failure.toString(), contains('light appearance'));
-      },
-    );
+      expect(failure, isNotNull);
+      expect(failure.toString(), contains('light appearance'));
+    });
   });
 }

--- a/mobile/test/screens/settings/appearance_settings_screen_test.dart
+++ b/mobile/test/screens/settings/appearance_settings_screen_test.dart
@@ -9,6 +9,8 @@ import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/screens/settings/appearance_settings_screen.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import '../../helpers/accessibility_guidelines.dart';
+
 void main() {
   testWidgets('renders appearance modes and persists a selected mode', (
     tester,
@@ -66,5 +68,28 @@ void main() {
     );
 
     expect(find.text('Appearance'), findsOneWidget);
+  });
+
+  testWidgets('meets the accessibility guidelines in both appearances', (
+    tester,
+  ) async {
+    SharedPreferences.setMockInitialValues({});
+    final cubit = AppearanceCubit(
+      AppearanceRepository(await SharedPreferences.getInstance()),
+    );
+    addTearDown(cubit.close);
+
+    await expectMeetsAccessibilityGuidelinesInBothAppearances(
+      tester,
+      (theme) => MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        theme: theme,
+        home: BlocProvider.value(
+          value: cubit,
+          child: const AppearanceSettingsScreen(),
+        ),
+      ),
+    );
   });
 }

--- a/mobile/test/screens/settings/appearance_settings_screen_test.dart
+++ b/mobile/test/screens/settings/appearance_settings_screen_test.dart
@@ -79,6 +79,11 @@ void main() {
     );
     addTearDown(cubit.close);
 
+    // Labelling and contrast only, in practice: the option rows are
+    // full-width children of a ListView, so they touch both a viewport and a
+    // scrollable edge and the tap-target guidelines skip them here. Their
+    // 48dp floor is covered non-vacuously by divine_selectable_row_test.dart,
+    // which pumps the row centred at a fixed width.
     await expectMeetsAccessibilityGuidelinesInBothAppearances(
       tester,
       (theme) => MaterialApp(

--- a/mobile/test/widgets/video_editor/video_editor_toolbar_test.dart
+++ b/mobile/test/widgets/video_editor/video_editor_toolbar_test.dart
@@ -6,14 +6,18 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/widgets/video_editor/video_editor_toolbar.dart';
 
+import '../../helpers/accessibility_guidelines.dart';
+
 void main() {
   group(VideoEditorToolbar, () {
     Widget buildWidget({
       required VoidCallback onClose,
       VoidCallback? onDone,
       Widget? center,
+      ThemeData? theme,
     }) {
       return MaterialApp(
+        theme: theme,
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
         home: Scaffold(
@@ -71,6 +75,20 @@ void main() {
       );
 
       expect(find.text('Center Content'), findsOneWidget);
+    });
+
+    group('accessibility', () {
+      testWidgets('meets the guidelines in both appearances', (tester) async {
+        await expectMeetsAccessibilityGuidelinesInBothAppearances(
+          tester,
+          (theme) => buildWidget(
+            onClose: () {},
+            onDone: () {},
+            center: const Text('Trim'),
+            theme: theme,
+          ),
+        );
+      });
     });
   });
 }

--- a/mobile/test/widgets/video_feed_item/actions/video_action_button_test.dart
+++ b/mobile/test/widgets/video_feed_item/actions/video_action_button_test.dart
@@ -8,6 +8,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/widgets/video_feed_item/actions/video_action_button.dart';
 
+import '../../../helpers/accessibility_guidelines.dart';
+
 void main() {
   Widget buildSubject({
     DivineIconName icon = DivineIconName.heart,
@@ -249,6 +251,22 @@ void main() {
           ),
         );
         expect(semantics.properties.label, equals('Like video'));
+      });
+
+      testWidgets('meets the tap-target and labelling guidelines', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          buildSubject(semanticLabel: 'Like video', count: 12),
+        );
+
+        // Semantics guidelines only: this button's ground is a video frame,
+        // never an app surface, so a contrast reading against the test's
+        // plain scaffold would describe the fixture rather than the product.
+        await expectMeetsAccessibilityGuidelines(
+          tester,
+          guidelines: divineSemanticsGuidelines,
+        );
       });
     });
 

--- a/mobile/test/widgets/video_feed_item/actions/video_action_button_test.dart
+++ b/mobile/test/widgets/video_feed_item/actions/video_action_button_test.dart
@@ -26,16 +26,18 @@ void main() {
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
       home: Scaffold(
-        body: VideoActionButton(
-          icon: icon,
-          semanticIdentifier: semanticIdentifier,
-          semanticLabel: semanticLabel,
-          onPressed: onPressed,
-          iconColor: iconColor,
-          count: count,
-          isLoading: isLoading,
-          caption: caption,
-          labelWhenZero: labelWhenZero,
+        body: Center(
+          child: VideoActionButton(
+            icon: icon,
+            semanticIdentifier: semanticIdentifier,
+            semanticLabel: semanticLabel,
+            onPressed: onPressed,
+            iconColor: iconColor,
+            count: count,
+            isLoading: isLoading,
+            caption: caption,
+            labelWhenZero: labelWhenZero,
+          ),
         ),
       ),
     );


### PR DESCRIPTION
## Description

The suite had plenty of targeted semantics assertions but no broad accessibility safety net, so nothing systematically caught undersized tap targets, unlabeled tappable nodes, or contrast regressions.

**A shared helper.** `expectMeetsAccessibilityGuidelines(tester)` runs a guideline set against the pumped tree and owns the `SemanticsHandle`, so a failing check can't leave semantics enabled for the rest of the merged isolate. The app copy adds `expectMeetsAccessibilityGuidelinesInBothAppearances`, which pumps dark and light and names the failing appearance in the message.

Two things worth flagging for review, both discovered by measurement rather than assumption:

- **The sweep unmounts between appearances.** `MaterialApp` interpolates through `AnimatedTheme`, so swapping the theme on a live tree leaves the second appearance still reading the first one's colors. Without the unmount, a light-only regression passes silently — the helper's own test pins this.
- **The two copies have different default sets, for a real reason.** `textContrastGuideline` rasterizes inside `runAsync`, which lets a pending `google_fonts` load surface as a test error. The app bundles BricolageGrotesque and Inter as assets and turns runtime fetching off, so contrast works there. `divine_ui` ships no font assets, so its default is the three semantics guidelines and contrast coverage for real components lives at the app layer.

There are two copies at all because Dart can't share `test/` code across packages. The alternative — pulling `flutter_test` into `divine_ui`'s runtime dependencies to share ~30 lines — is the worse trade.

**Every guideline is proven falsifiable.** Each helper ships a self-test that pins that it actually fails on the defect it claims to catch: undersized targets, unlabeled nodes, sub-4.5:1 contrast, and a regression that lands only in light mode. A guideline that passes vacuously is worse than no guideline, so one candidate assertion was dropped rather than shipped — `tester.binding.semanticsEnabled` is `true` before, during, and after in the test binding, so an assertion on it could never have failed.

**Coverage.** `divine_ui`: the three existing ad-hoc guideline blocks now route through the helper (which also broadens what they assert), plus list tile, selectable row, switch tile, search bar, checkbox tile, and app-bar icon button. App layer: the video editor toolbar and appearance settings screen run the full set across both appearances; the feed action button runs the semantics set only, because it is chrome drawn over a video frame and a widget test can only stand it on a plain scaffold — a contrast reading there measures the fixture, not the product.

**Related Issue:** Closes #6142

## Out of Scope

Three product findings surfaced while wiring this up. None are fixed here — each remedy changes user-visible behavior, which doesn't belong in a test-infrastructure PR:

- `CommentInput`'s text field exposes a 24dp-tall semantics node, under both the 48dp and 44pt bars.
- `CommentInput`'s send button presents a tappable node with no semantic label at all.
- `DivineSwitch` built without a `semanticLabel` presents an unlabeled tappable node. The switch *tile* is covered instead, since that's the labelled shape the app ships.

Filed as #7656. The recorder controls and the full settings screen were also evaluated as targets and skipped: both need substantial mock/provider harnesses, and the settings list is a scroller where the guidelines skip off-screen nodes, so a single assertion would only cover the first viewport.

## Verification

- `flutter test` in `mobile/packages/divine_ui` — 910 passing
- `flutter test --coverage` in `mobile/packages/divine_ui` — 2252/2252 lines, 100.00% (gate holds)
- `flutter test test/helpers test/screens/settings test/widgets/video_editor test/widgets/video_feed_item` — 1436 passing
- `flutter analyze lib test integration_test` — no issues
- `flutter analyze lib test` in `divine_ui` — no issues
- `dart format` — clean

## Type of Change

- [x] ✅ Build configuration change
