### PR TITLE
fix(skills): stop routing divine-context PRs through a /tmp worktree

### DIFF
--- a/.agents/skills/divine-context/SKILL.md
+++ b/.agents/skills/divine-context/SKILL.md
@@ -56,15 +56,15 @@ When you learn a **cross-repo** fact while working in a divine-* repo, propose i
    ```bash
    cd ~/code/divine/divine-context
    git fetch origin main
-   git worktree add /tmp/dc-<topic> -b update-from-<thisrepo>-<topic>-$(date +%Y-%m-%d) origin/main
+   git worktree add .claude/worktrees/dc-<topic> -b update-from-<thisrepo>-<topic>-$(date +%Y-%m-%d) origin/main
    # edit files
-   cd /tmp/dc-<topic>
+   cd .claude/worktrees/dc-<topic>
    git add <only the files you changed>          # never -A
    git commit -m "<short desc>: <what changed>"
    git push -u origin HEAD
    gh pr create --title "..." --body "..."
    ```
-   **Use a `/tmp` worktree.** Other agents may be editing divine-context concurrently; isolating in a worktree avoids branch-state collisions.
+   **Use a worktree inside the divine-context checkout.** Other agents may be editing divine-context concurrently; isolating in a worktree avoids branch-state collisions. Put it in `.claude/worktrees/` (gitignored there) — **not `/tmp`**. On macOS `/tmp` is swept, and a worktree there takes any uncommitted work with it; see `WORKTREES.md` in divine-context. Remove it with `git worktree remove` once the PR merges, since nothing cleans it up for you.
 6. **One logical change per PR.** Five unrelated improvements = five PRs.
 
 ### What goes in divine-context (and what doesn't)
@@ -107,7 +107,8 @@ PR opened: <url>
 | "I'll just edit divine-context directly without showing the user first" | Some proposals may be intentional omissions. Show the list first. |
 | "This is repo-local but feels useful, so I'll add it anyway" | Cross-repo only. Repo-local belongs in `AGENTS.md`. |
 | "Local main looks fine, no need to fetch" | Local main may be days stale. Always branch from `origin/main`. |
-| "I'll skip the worktree, just `git checkout` in place" | Concurrent agents may be editing. Use `/tmp/dc-<topic>` worktree. |
+| "I'll skip the worktree, just `git checkout` in place" | Concurrent agents may be editing. Use a `.claude/worktrees/dc-<topic>` worktree. |
+| "I'll put the worktree in `/tmp`, it's throwaway" | `/tmp` is swept on macOS and takes uncommitted work with it. Keep it inside the divine-context checkout. |
 | "I'll bundle five small fixes into one PR — easier to review" | One logical change per PR. Reviewers can disagree with one without blocking the others. |
 | "I'll `git add -A` — faster" | Catches unrelated files. Stage by name. |
 | "I can't verify this fact, but it sounds right" | Mark `<!-- TODO: verify -->` instead of inventing. |

--- a/.claude/skills/divine-context/SKILL.md
+++ b/.claude/skills/divine-context/SKILL.md
@@ -56,15 +56,15 @@ When you learn a **cross-repo** fact while working in a divine-* repo, propose i
    ```bash
    cd ~/code/divine/divine-context
    git fetch origin main
-   git worktree add /tmp/dc-<topic> -b update-from-<thisrepo>-<topic>-$(date +%Y-%m-%d) origin/main
+   git worktree add .claude/worktrees/dc-<topic> -b update-from-<thisrepo>-<topic>-$(date +%Y-%m-%d) origin/main
    # edit files
-   cd /tmp/dc-<topic>
+   cd .claude/worktrees/dc-<topic>
    git add <only the files you changed>          # never -A
    git commit -m "<short desc>: <what changed>"
    git push -u origin HEAD
    gh pr create --title "..." --body "..."
    ```
-   **Use a `/tmp` worktree.** Other agents may be editing divine-context concurrently; isolating in a worktree avoids branch-state collisions.
+   **Use a worktree inside the divine-context checkout.** Other agents may be editing divine-context concurrently; isolating in a worktree avoids branch-state collisions. Put it in `.claude/worktrees/` (gitignored there) — **not `/tmp`**. On macOS `/tmp` is swept, and a worktree there takes any uncommitted work with it; see `WORKTREES.md` in divine-context. Remove it with `git worktree remove` once the PR merges, since nothing cleans it up for you.
 6. **One logical change per PR.** Five unrelated improvements = five PRs.
 
 ### What goes in divine-context (and what doesn't)
@@ -107,7 +107,8 @@ PR opened: <url>
 | "I'll just edit divine-context directly without showing the user first" | Some proposals may be intentional omissions. Show the list first. |
 | "This is repo-local but feels useful, so I'll add it anyway" | Cross-repo only. Repo-local belongs in `CLAUDE.md`. |
 | "Local main looks fine, no need to fetch" | Local main may be days stale. Always branch from `origin/main`. |
-| "I'll skip the worktree, just `git checkout` in place" | Concurrent agents may be editing. Use `/tmp/dc-<topic>` worktree. |
+| "I'll skip the worktree, just `git checkout` in place" | Concurrent agents may be editing. Use a `.claude/worktrees/dc-<topic>` worktree. |
+| "I'll put the worktree in `/tmp`, it's throwaway" | `/tmp` is swept on macOS and takes uncommitted work with it. Keep it inside the divine-context checkout. |
 | "I'll bundle five small fixes into one PR — easier to review" | One logical change per PR. Reviewers can disagree with one without blocking the others. |
 | "I'll `git add -A` — faster" | Catches unrelated files. Stage by name. |
 | "I can't verify this fact, but it sounds right" | Mark `<!-- TODO: verify -->` instead of inventing. |


### PR DESCRIPTION
Closes #7661

## Summary

The `divine-context` skill instructs agents to isolate in `/tmp/dc-<topic>` when proposing a change back to `divine-context`. On macOS `/tmp` is swept, so a worktree there takes any uncommitted work with it. Points both copies at `.claude/worktrees/dc-<topic>` inside the `divine-context` checkout instead, and notes that the worktree needs removing by hand.

## Motivation

Surfaced while reviewing [divinevideo/divine-context#81](https://github.com/divinevideo/divine-context/pull/81), which adds `WORKTREES.md` — a rule that worktrees must never live in a swept location. This skill is the documented route for filing a `divine-context` PR, so as written it points agents at exactly the failure that document exists to prevent.

That failure is not hypothetical. A survey of `~/code/divine` found 11 worktree registrations pointing at deleted scratchpad and `/tmp` directories, including two in `divine-mobile` itself.

## Changes

Two files, identical edits — `.claude/skills/divine-context/SKILL.md` and `.agents/skills/divine-context/SKILL.md`:

- Step 5's `git worktree add /tmp/dc-<topic>` → `.claude/worktrees/dc-<topic>`, which is gitignored in `divine-context`.
- The "Use a `/tmp` worktree" note now says why `/tmp` is wrong and that the worktree must be removed by hand, since nothing sweeps it up.
- Rationalization table: the existing row no longer prescribes `/tmp`, and a new row covers "it's throwaway anyway".

The two copies differ only in `CLAUDE.md` vs `AGENTS.md` references elsewhere in the file; the worktree block was byte-identical in both, so both took the same patch.

## Verification

- `grep` confirms the only remaining `/tmp` mentions in both files are the new text explaining why not to use it.
- The two copies remain in sync on this block.
- Followed this repo's own worktree convention from `AGENTS.md:46` (`git worktree add .worktrees/<task-name> -b <branch> origin/main`) rather than the harness mechanism, and confirmed isolation via `--git-dir` != `--git-common-dir`. `.worktrees/` is gitignored here (`.gitignore:15`).

## Not done

- **The primary `divine-mobile` checkout is on `fix/light-mode-ungate-main`** with an untracked `crawler/` directory. Left untouched — someone is mid-flight there. This branch came from `origin/main`, not from that state.
- **No behavioral test.** This is agent instruction text; nothing executes it.
- **`divine-context` PR #81 is still open** and its final wording may shift. The `/tmp` prohibition is the stable part and is not in dispute, but the `.claude/worktrees/` path could in principle change if that PR's location convention changes.
- Left the `diVine` casing in this file alone (brand guidance says `Divine`) — unrelated to this fix and out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)