### PR TITLE
fix(comments): Resolve PR #6960 blockers for optimistic comment UI and relay echo timing

### DIFF
--- a/mobile/lib/screens/comments/comments_screen.dart
+++ b/mobile/lib/screens/comments/comments_screen.dart
@@ -533,8 +533,9 @@ class OutboxBridges extends StatelessWidget {
 
 /// How long an in-flight video-reply placeholder stays up after a successful
 /// publish, waiting for the relay echo to swap it for the canonical comment
-/// before the bridge rolls it back (#6960 review: 5s was too tight on poor
-/// networks). Public-by-test only — tests pump exactly this duration.
+/// before the bridge rolls it back. Widened from 5s because slow-network
+/// echoes could exceed the old window and make the row disappear before it
+/// re-appeared. Public-by-test only — tests pump exactly this duration.
 @visibleForTesting
 const Duration videoReplyRelayEchoGrace = Duration(seconds: 10);
 

--- a/mobile/lib/screens/comments/comments_screen.dart
+++ b/mobile/lib/screens/comments/comments_screen.dart
@@ -531,6 +531,13 @@ class OutboxBridges extends StatelessWidget {
   }
 }
 
+/// How long an in-flight video-reply placeholder stays up after a successful
+/// publish, waiting for the relay echo to swap it for the canonical comment
+/// before the bridge rolls it back (#6960 review: 5s was too tight on poor
+/// networks). Public-by-test only — tests pump exactly this duration.
+@visibleForTesting
+const Duration videoReplyRelayEchoGrace = Duration(seconds: 10);
+
 /// Surfaces an in-flight video reply as a pending row on its destination sheet.
 ///
 /// The video-reply flow publishes in the background and navigates to the root
@@ -559,8 +566,6 @@ class VideoReplyPlaceholderBridge extends StatefulWidget {
 
 class _VideoReplyPlaceholderBridgeState
     extends State<VideoReplyPlaceholderBridge> {
-  static const _relayEchoGrace = Duration(seconds: 10);
-
   /// Draft ids this bridge has already inserted a placeholder for.
   ///
   /// Guards re-insertion after the relay echo swaps the placeholder out: the
@@ -635,7 +640,7 @@ class _VideoReplyPlaceholderBridgeState
       _awaitingRelayEcho.add(draftId);
       _relayEchoGraceTimers.putIfAbsent(
         draftId,
-        () => Timer(_relayEchoGrace, () {
+        () => Timer(videoReplyRelayEchoGrace, () {
           if (!mounted) return;
           _awaitingRelayEcho.remove(draftId);
           _inserted.remove(draftId);

--- a/mobile/lib/screens/comments/comments_screen.dart
+++ b/mobile/lib/screens/comments/comments_screen.dart
@@ -559,7 +559,7 @@ class VideoReplyPlaceholderBridge extends StatefulWidget {
 
 class _VideoReplyPlaceholderBridgeState
     extends State<VideoReplyPlaceholderBridge> {
-  static const _relayEchoGrace = Duration(seconds: 5);
+  static const _relayEchoGrace = Duration(seconds: 10);
 
   /// Draft ids this bridge has already inserted a placeholder for.
   ///

--- a/mobile/lib/screens/comments/widgets/comment_item.dart
+++ b/mobile/lib/screens/comments/widgets/comment_item.dart
@@ -252,6 +252,11 @@ class _CommentItemState extends ConsumerState<CommentItem> {
   }) async {
     if (!mounted) return;
 
+    // Prevent options modal on placeholder comments (in-flight video replies).
+    // IDs like "pending_comment_1234" should never reach here, as the long-press
+    // is gated upstream, but guard defensively.
+    if (widget.comment.id.startsWith(commentPlaceholderIdPrefix)) return;
+
     // Capture BLoC references before async gap to avoid using context
     // after the widget may have been unmounted.
     final reactionsBloc = context.read<CommentReactionsBloc>();

--- a/mobile/test/screens/comments/video_reply_placeholder_bridge_test.dart
+++ b/mobile/test/screens/comments/video_reply_placeholder_bridge_test.dart
@@ -272,7 +272,7 @@ void main() {
 
       await pumpBridge(tester);
       await tester.pump();
-      await tester.pump(const Duration(seconds: 5));
+      await tester.pump(videoReplyRelayEchoGrace);
 
       final rollbacks = verify(
         () => list.add(captureAny()),


### PR DESCRIPTION
Closes #7663

## Summary

Follow-up to the review of #6960. The long-press gating for placeholder comments and the `commentPlaceholderIdPrefix` constant reuse from that review already landed on `main` with #6960 itself; this PR adds what remained open:

**Placeholder options-modal guard**
- Added a defensive check in `_showOptionsModal()` to return early for in-flight placeholder video replies (IDs starting with `pending_comment_`), behind the existing upstream long-press gate.

**Relay echo grace window 5s → 10s**
- Widened the relay-echo grace window in `VideoReplyPlaceholderBridge` so slow-network relay echoes are less likely to arrive after the placeholder has already been rolled back (which made the row disappear and then re-appear). This moves the timeout threshold; the rollback mechanism is unchanged.

**Placeholder prefix constant usage**
- Verified production `pending_comment_` references use the `commentPlaceholderIdPrefix` constant; no production code change was needed.

## Test plan

- [x] `flutter analyze` and `dart format` clean on affected files
- [x] Comments-area test suites pass: bridge, comment item, outbox bridges, comments-list bloc
