### PR TITLE
test(comments): assert pending replies keep options closed

### DIFF
--- a/mobile/test/screens/comments/comment_item_test.dart
+++ b/mobile/test/screens/comments/comment_item_test.dart
@@ -251,7 +251,10 @@ void main() {
     await tester.longPress(find.byType(CommentItem));
     await tester.pumpAndSettle();
 
-    expect(find.bySemanticsIdentifier('delete_comment_option'), findsNothing);
+    // The title is shared by both modal variants; a delete-option assertion
+    // would pass even with the sheet open, since isCurrentUser is false here.
+    final l10n = lookupAppLocalizations(const Locale('en'));
+    expect(find.text(l10n.commentOptionsTitle), findsNothing);
     verifyNever(() => mocks.composer.add(any()));
     verifyNever(() => mocks.reactions.add(any()));
   });


### PR DESCRIPTION
## Summary

- strengthen the pending-placeholder long-press regression test to assert that the shared comment-options modal title stays absent
- avoid the old false-positive assertion: the fake client is not the comment author, so the delete action could never render even when the modal opened

## Rebase note

#7671 landed the original relay-echo grace-window and unreachable-guard work while this PR was waiting. This branch is rebased onto current `main`; Git dropped that superseded commit and this PR now retains only the approved follow-up assertion from `aa91e103a9`.

## Verification

- `cd mobile && flutter test test/screens/comments/comment_item_test.dart`
- `cd mobile && flutter analyze test/screens/comments/comment_item_test.dart`
