### PR TITLE
fix(tools): refuse to guess when the dark-parity base has no merge base

### DIFF
--- a/.claude/rules/ui_theming.md
+++ b/.claude/rules/ui_theming.md
@@ -233,6 +233,18 @@ It pairs each removed reference with its replacement per hunk and compares
 **dark** values. It cannot catch a wrong pick among tokens that share a dark
 value (trap 1) — that part still needs eyes, and a light-mode contrast check.
 
+**Shallow clones need an explicit base.** Isolating your branch's own changes
+needs a merge base, and a `--depth` clone or worktree may not have one against
+`origin/main`. The script refuses rather than guessing — an earlier version
+silently fell back to a two-dot diff, which reads every commit `main` has and
+your branch lacks as a *removal* and reports unrelated work as your dark
+mismatches. If it exits with `No merge base`, either `git fetch --unshallow`,
+or pass the commit your branch started from:
+
+```bash
+dart run scripts/check_dark_value_parity.dart --base <branch-point-sha>
+```
+
 ### Adding a token
 
 If the semantically right token would change dark, do **not** accept the

--- a/mobile/scripts/check_dark_value_parity.dart
+++ b/mobile/scripts/check_dark_value_parity.dart
@@ -381,25 +381,32 @@ void main(List<String> args) {
   if (diffArgument.isNotEmpty) {
     diff = File(diffArgument).readAsStringSync();
   } else {
-    // Three-dot needs a merge base, which a shallow clone (CI, and any
-    // `--depth` worktree) may not have; two-dot still answers "what does this
-    // branch look like next to that ref".
-    var result = Process.runSync('git', [
+    // Three-dot isolates what this branch changed, and needs a merge base —
+    // which a shallow clone (CI, and any `--depth` worktree) may not have.
+    // Two-dot still runs there, but answers a different question: every
+    // commit the base has and HEAD lacks reads as a removal, so unrelated
+    // work gets paired against this branch's additions and reported as dark
+    // mismatches. A guard that quietly returns wrong answers is worse than
+    // one that refuses, so refuse.
+    final mergeBase = Process.runSync('git', ['merge-base', base, 'HEAD']);
+    if (mergeBase.exitCode != 0) {
+      stderr.writeln(
+        'No merge base between $base and HEAD, so this branch\'s own '
+        'changes cannot be isolated.\n'
+        'This is usually a shallow clone. Pick one:\n'
+        '  git fetch --unshallow      then rerun\n'
+        '  --base <branch-point-sha>  the commit this branch started from\n'
+        '  --diff <patch>             a diff you produced yourself',
+      );
+      exit(2);
+    }
+    final result = Process.runSync('git', [
       'diff',
       '-U0',
       '$base...HEAD',
       '--',
       '*.dart',
     ]);
-    if (result.exitCode != 0) {
-      result = Process.runSync('git', [
-        'diff',
-        '-U0',
-        '$base..HEAD',
-        '--',
-        '*.dart',
-      ]);
-    }
     if (result.exitCode != 0) {
       stderr.writeln('git diff failed: ${result.stderr}');
       exit(2);

--- a/mobile/scripts/check_dark_value_parity.dart
+++ b/mobile/scripts/check_dark_value_parity.dart
@@ -389,15 +389,24 @@ void main(List<String> args) {
     // mismatches. A guard that quietly returns wrong answers is worse than
     // one that refuses, so refuse.
     final mergeBase = Process.runSync('git', ['merge-base', base, 'HEAD']);
-    if (mergeBase.exitCode != 0) {
+    // merge-base exits 1 for a genuine no-common-ancestor (the shallow
+    // clone / unrelated-history case) and 128 for an error like a missing
+    // or misspelled ref. Only the first is "no merge base" — sending an
+    // unfetched origin/main to `git fetch --unshallow` points at a fix
+    // that cannot work, so surface git's real error for the rest.
+    if (mergeBase.exitCode == 1) {
       stderr.writeln(
-        'No merge base between $base and HEAD, so this branch\'s own '
+        "No merge base between $base and HEAD, so this branch's own "
         'changes cannot be isolated.\n'
         'This is usually a shallow clone. Pick one:\n'
         '  git fetch --unshallow      then rerun\n'
         '  --base <branch-point-sha>  the commit this branch started from\n'
         '  --diff <patch>             a diff you produced yourself',
       );
+      exit(2);
+    }
+    if (mergeBase.exitCode != 0) {
+      stderr.writeln('git merge-base failed: ${mergeBase.stderr}');
       exit(2);
     }
     final result = Process.runSync('git', [

--- a/mobile/test/tools/check_dark_value_parity_test.dart
+++ b/mobile/test/tools/check_dark_value_parity_test.dart
@@ -203,5 +203,47 @@ class VineTheme {
       expect(res.exitCode, 2);
       expect(res.stderr, contains('Theme file not found'));
     });
+
+    // A shallow clone has no merge base with its own base ref. The guard used
+    // to fall back to a two-dot diff there, which reads every commit the base
+    // has and HEAD lacks as a removal — pairing unrelated work against this
+    // branch's additions and reporting confident, wrong DARK MISMATCH lines.
+    // Two orphan roots reproduce "no merge base" without a shallow fixture.
+    test('refuses to guess when the base shares no history with HEAD', () {
+      void git(List<String> arguments) {
+        final res = Process.runSync(
+          'git',
+          arguments,
+          workingDirectory: sandbox.path,
+        );
+        expect(res.exitCode, 0, reason: 'git ${arguments.join(' ')}');
+      }
+
+      git(['init', '--initial-branch=main']);
+      git(['config', 'user.email', 'test@example.com']);
+      git(['config', 'user.name', 'Test']);
+      File(p.join(sandbox.path, 'a.dart')).writeAsStringSync('// base\n');
+      git(['add', '.']);
+      git(['commit', '-m', 'base']);
+
+      git(['checkout', '--orphan', 'unrelated']);
+      File(p.join(sandbox.path, 'a.dart')).writeAsStringSync('// other\n');
+      git(['add', '.']);
+      git(['commit', '-m', 'unrelated root']);
+
+      final res = Process.runSync('dart', [
+        'run',
+        scriptPath,
+        '--theme',
+        themePath,
+        '--base',
+        'main',
+      ], workingDirectory: sandbox.path);
+
+      expect(res.exitCode, 2);
+      expect(res.stderr, contains('No merge base between main and HEAD'));
+      expect(res.stderr, contains('git fetch --unshallow'));
+      expect(res.stdout, isNot(contains('DARK MISMATCH')));
+    });
   });
 }

--- a/mobile/test/tools/check_dark_value_parity_test.dart
+++ b/mobile/test/tools/check_dark_value_parity_test.dart
@@ -245,5 +245,40 @@ class VineTheme {
       expect(res.stderr, contains('git fetch --unshallow'));
       expect(res.stdout, isNot(contains('DARK MISMATCH')));
     });
+
+    // A missing or misspelled base ref is a different failure than a missing
+    // merge base: git merge-base exits 128, not 1. Blaming a shallow clone
+    // and suggesting `git fetch --unshallow` sends the reader after a fix
+    // that cannot resolve a ref that was never there. Surface git's error.
+    test('surfaces the git error when the base ref does not exist', () {
+      void git(List<String> arguments) {
+        final res = Process.runSync(
+          'git',
+          arguments,
+          workingDirectory: sandbox.path,
+        );
+        expect(res.exitCode, 0, reason: 'git ${arguments.join(' ')}');
+      }
+
+      git(['init', '--initial-branch=main']);
+      git(['config', 'user.email', 'test@example.com']);
+      git(['config', 'user.name', 'Test']);
+      File(p.join(sandbox.path, 'a.dart')).writeAsStringSync('// base\n');
+      git(['add', '.']);
+      git(['commit', '-m', 'base']);
+
+      final res = Process.runSync('dart', [
+        'run',
+        scriptPath,
+        '--theme',
+        themePath,
+        '--base',
+        'no-such-ref',
+      ], workingDirectory: sandbox.path);
+
+      expect(res.exitCode, 2);
+      expect(res.stderr, contains('git merge-base failed'));
+      expect(res.stderr, isNot(contains('shallow clone')));
+    });
   });
 }


### PR DESCRIPTION
Closes #7668

A theme-migration guard that silently returns wrong answers is worse than one that refuses. This makes `check_dark_value_parity.dart` refuse.

## Description

`check_dark_value_parity.dart` isolates a branch's own changes with a three-dot diff, which needs a merge base. A shallow clone (CI, and every `--depth` worktree here) may not have one against `origin/main`. The script fell back to a two-dot diff in that case, deliberately and with a comment.

Two-dot answers a different question. Every commit the base has and HEAD lacks reads as a *removal*, so unrelated main-only work gets paired against this branch's additions and reported as `DARK MISMATCH`. The output is confident and wrong, on the exact invocation `ui_theming.md` tells everyone to run.

Found on #7624: `--base origin/main` reported two dark mismatches that did not exist. Scoping the run to the branch's real base gave 0 mismatches across 20 compared replacements.

The script now probes for a merge base first and exits 2 with the three ways out — `git fetch --unshallow`, an explicit `--base <branch-point-sha>`, or a supplied `--diff`.

## Changes

- `scripts/check_dark_value_parity.dart` — merge-base probe replaces the silent two-dot fallback.
- `test/tools/check_dark_value_parity_test.dart` — regression test using two orphan roots to reproduce "no merge base" without a shallow fixture. Verified red before the fix, green after.
- `.claude/rules/ui_theming.md` — documents the shallow-clone case and the explicit-base escape hatch.

## Verification

- `flutter test test/tools/check_dark_value_parity_test.dart` — 11 passed
- `flutter analyze lib test integration_test` — clean
- New test confirmed failing against the pre-fix script

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] 📝 Documentation
- [ ] 🗑️ Chore