### PR TITLE
chore(scripts): add a safe merged-branch prune report

### DIFF
--- a/.claude/rules/agent_workflow.md
+++ b/.claude/rules/agent_workflow.md
@@ -38,8 +38,10 @@ elsewhere. Do not mix unrelated work into one worktree.
 ### Pruning after merge
 
 `AGENTS.md` says to prune the worktree and branch once a branch merges or
-is abandoned. Do it with `scripts/prune-merged-branches.sh`, which reports
-by default and only deletes under `--execute`.
+is abandoned. Start with `scripts/prune-merged-branches.sh`, which is a
+report-only classifier for likely stale local branches and worktrees. It
+does not delete anything; prune the reported rows manually after reviewing
+the output.
 
 Do **not** improvise the classification. Three things that look like they
 work do not:
@@ -54,11 +56,12 @@ work do not:
   `fix/7606-semantic-tokens` was destroyed exactly this way: unpushed
   local work on a parallel attempt at the same task.
 
-The one trustworthy signal is GitHub reporting a merged PR with that head
-ref. Everything else is KEEP, and two vetoes apply on top even to merged
-branches: uncommitted work in the worktree, and local commits ahead of the
-remote. That second veto is not theoretical — it caught 10 branches on its
-first run.
+The useful signal is GitHub reporting a same-repo merged PR to `main` with
+that head ref. Everything else is KEEP, and two vetoes apply on top even
+to matched branches: the local branch tip must exist in GitHub's repository
+object database, and the worktree must have no uncommitted or ignored
+files. That keeps branch-name reuse, unpushed commits, and local-only
+worktree files out of the prunable set.
 
 ### Optional: warn on concurrent sessions in one worktree
 

--- a/.claude/rules/agent_workflow.md
+++ b/.claude/rules/agent_workflow.md
@@ -35,6 +35,31 @@ One task per worktree. If the current worktree is dirty, commit, stash
 intentionally, or discard intentionally before starting new work
 elsewhere. Do not mix unrelated work into one worktree.
 
+### Pruning after merge
+
+`AGENTS.md` says to prune the worktree and branch once a branch merges or
+is abandoned. Do it with `scripts/prune-merged-branches.sh`, which reports
+by default and only deletes under `--execute`.
+
+Do **not** improvise the classification. Three things that look like they
+work do not:
+
+- `git branch --merged main` reports 5 of 1185 branches here. This repo
+  squash-merges, and a squash rewrites the commit, so a merged branch
+  never becomes an ancestor of `main`. Ancestry is not the signal.
+- "Empty diff against `main`" is symmetric — a branch that merged months
+  ago still differs by everything that landed since. It reported 2445
+  changed files for a long-merged branch.
+- Matching branch names against an issue number deletes live work.
+  `fix/7606-semantic-tokens` was destroyed exactly this way: unpushed
+  local work on a parallel attempt at the same task.
+
+The one trustworthy signal is GitHub reporting a merged PR with that head
+ref. Everything else is KEEP, and two vetoes apply on top even to merged
+branches: uncommitted work in the worktree, and local commits ahead of the
+remote. That second veto is not theoretical — it caught 10 branches on its
+first run.
+
 ### Optional: warn on concurrent sessions in one worktree
 
 Two agent sessions in the same working tree is the failure this rule

--- a/mobile/test/tools/prune_merged_branches_test.dart
+++ b/mobile/test/tools/prune_merged_branches_test.dart
@@ -1,0 +1,221 @@
+// ABOUTME: Tests for scripts/prune-merged-branches.sh.
+// ABOUTME: Pins conservative report-only branch classification.
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+
+void main() {
+  group('prune-merged-branches.sh', () {
+    late Directory sandbox;
+    late Directory repo;
+    late String scriptPath;
+    late File fakeGh;
+    late File ghArgs;
+
+    void git(
+      List<String> args, {
+      String? workingDirectory,
+      Map<String, String>? environment,
+    }) {
+      final result = Process.runSync(
+        'git',
+        args,
+        workingDirectory: workingDirectory ?? repo.path,
+        environment: environment,
+      );
+      expect(
+        result.exitCode,
+        0,
+        reason:
+            'git ${args.join(' ')}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}',
+      );
+    }
+
+    String branchTip(String branch) {
+      final result = Process.runSync('git', [
+        'rev-parse',
+        branch,
+      ], workingDirectory: repo.path);
+      expect(result.exitCode, 0, reason: result.stderr.toString());
+      return result.stdout.toString().trim();
+    }
+
+    void write(String relativePath, String contents, {String? root}) {
+      final file = File(p.join(root ?? repo.path, relativePath));
+      file.parent.createSync(recursive: true);
+      file.writeAsStringSync(contents);
+    }
+
+    void commit(String message) {
+      git(['add', '.']);
+      git(['commit', '-m', message]);
+    }
+
+    void makeBranch(String branch, String contents) {
+      git(['checkout', '-B', branch, 'main']);
+      write('$branch.txt', contents);
+      commit('add $branch');
+      git(['checkout', 'main']);
+    }
+
+    ProcessResult runScript({
+      required List<String> mergedHeadRefs,
+      required List<String> githubCommitShas,
+      List<String> args = const [],
+    }) {
+      return Process.runSync(
+        'bash',
+        [scriptPath, ...args],
+        workingDirectory: repo.path,
+        environment: {
+          'PATH':
+              '${p.join(sandbox.path, 'bin')}:${Platform.environment['PATH']}',
+          'GH': fakeGh.path,
+          'REPO': 'divinevideo/divine-mobile',
+          'MERGED_PR_LIMIT': '100000',
+          'FAKE_MERGED_HEAD_REFS': mergedHeadRefs.join('\n'),
+          'FAKE_GITHUB_COMMIT_SHAS': githubCommitShas.join('\n'),
+          'FAKE_GH_ARGS': ghArgs.path,
+        },
+      );
+    }
+
+    setUp(() {
+      sandbox = Directory.systemTemp.createTempSync('prune_merged_branches_');
+      scriptPath = File(
+        p.join(
+          Directory.current.parent.path,
+          'scripts',
+          'prune-merged-branches.sh',
+        ),
+      ).absolute.path;
+      repo = Directory(p.join(sandbox.path, 'repo'))..createSync();
+      final remote = Directory(p.join(sandbox.path, 'remote.git'));
+      ghArgs = File(p.join(sandbox.path, 'gh-args.txt'));
+
+      fakeGh = File(p.join(sandbox.path, 'bin', 'gh'))
+        ..parent.createSync(recursive: true)
+        ..writeAsStringSync(
+          '#!/usr/bin/env bash\n'
+          r'''
+set -euo pipefail
+
+printf '%s\n' "$*" >> "${FAKE_GH_ARGS:?}"
+
+if [ "$1" = "pr" ] && [ "$2" = "list" ]; then
+  if [ -n "${FAKE_MERGED_HEAD_REFS:-}" ]; then
+    printf '%s\n' "$FAKE_MERGED_HEAD_REFS"
+  fi
+  exit 0
+fi
+
+if [ "$1" = "api" ]; then
+  sha="${*: -1}"
+  sha="${sha##*/}"
+  if printf '%s\n' "${FAKE_GITHUB_COMMIT_SHAS:-}" | grep -qxF -- "$sha"; then
+    printf '{}\n'
+    exit 0
+  fi
+  exit 1
+fi
+
+echo "Unexpected gh invocation: $*" >&2
+exit 2
+''',
+        );
+      Process.runSync('chmod', ['+x', fakeGh.path]);
+
+      git(['init', '--bare', remote.path], workingDirectory: sandbox.path);
+      git(['init']);
+      git(['config', 'user.email', 'test@example.com']);
+      git(['config', 'user.name', 'Test User']);
+      write('.gitignore', '.env\nbuild/\n');
+      write('README.md', 'fixture\n');
+      commit('initial');
+      git(['branch', '-M', 'main']);
+      git(['remote', 'add', 'origin', remote.path]);
+      git(['push', '-u', 'origin', 'main']);
+    });
+
+    tearDown(() {
+      if (sandbox.existsSync()) sandbox.deleteSync(recursive: true);
+    });
+
+    test('reports merged branch only when the local tip exists on GitHub', () {
+      makeBranch('merged-branch', 'merged');
+      final mergedTip = branchTip('merged-branch');
+      makeBranch('reused-branch-name', 'local only');
+
+      final result = runScript(
+        mergedHeadRefs: ['merged-branch', 'reused-branch-name'],
+        githubCommitShas: [mergedTip],
+      );
+
+      expect(result.exitCode, 0, reason: result.stderr.toString());
+      expect(result.stdout, contains('MERGED-PR      merged-branch'));
+      expect(result.stdout, contains('KEEP-LOCAL     reused-branch-name'));
+    });
+
+    test('keeps merged branches whose worktree contains ignored files', () {
+      makeBranch('dirty-worktree', 'merged');
+      final tip = branchTip('dirty-worktree');
+      final worktree = Directory(p.join(sandbox.path, 'dirty-worktree'));
+      git(['worktree', 'add', worktree.path, 'dirty-worktree']);
+      write('.env', 'local secret\n', root: worktree.path);
+
+      final result = runScript(
+        mergedHeadRefs: ['dirty-worktree'],
+        githubCommitShas: [tip],
+      );
+
+      expect(result.exitCode, 0, reason: result.stderr.toString());
+      expect(result.stdout, contains('KEEP-DIRTY'));
+      expect(result.stdout, contains('dirty-worktree'));
+      expect(File(p.join(worktree.path, '.env')).existsSync(), isTrue);
+    });
+
+    test('asks GitHub for a broad filtered merged PR set', () {
+      makeBranch('merged-branch', 'merged');
+
+      final result = runScript(
+        mergedHeadRefs: ['merged-branch'],
+        githubCommitShas: [branchTip('merged-branch')],
+      );
+
+      expect(result.exitCode, 0, reason: result.stderr.toString());
+      final args = ghArgs.readAsStringSync();
+      expect(args, contains('--limit 100000'));
+      expect(
+        args,
+        contains('--json headRefName,isCrossRepository,baseRefName'),
+      );
+      expect(args, contains('isCrossRepository == false'));
+      expect(args, contains('baseRefName == "main"'));
+    });
+
+    test('--help prints usage and exits without fetching', () {
+      final result = runScript(
+        args: ['--help'],
+        mergedHeadRefs: const [],
+        githubCommitShas: const [],
+      );
+
+      expect(result.exitCode, 0, reason: result.stderr.toString());
+      expect(result.stdout, contains('bash scripts/prune-merged-branches.sh'));
+      expect(result.stdout, isNot(contains('Fetching origin')));
+    });
+
+    test('--execute is rejected while deletion lives outside this PR', () {
+      final result = runScript(
+        args: ['--execute'],
+        mergedHeadRefs: const [],
+        githubCommitShas: const [],
+      );
+
+      expect(result.exitCode, 2);
+      expect(result.stderr, contains('unknown argument: --execute'));
+    });
+  });
+}

--- a/scripts/prune-merged-branches.sh
+++ b/scripts/prune-merged-branches.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# ABOUTME: Reports which local branches and worktrees are safe to prune.
-# ABOUTME: Report-only by default; deletion is a separate explicit opt-in.
+# ABOUTME: Reports which local branches and worktrees look safe to prune.
+# ABOUTME: Report-only until deletion has a separately reviewed implementation.
 #
 # Why the obvious approaches are wrong here
 # -----------------------------------------
@@ -16,65 +16,74 @@
 # 3. Name matching destroys work. Deleting everything matching "7606" took out
 #    `fix/7606-semantic-tokens` — unpushed local work on a parallel attempt.
 #
-# So there is exactly one trustworthy signal in a squash-merge repo: GitHub
-# says a PR with this head ref merged. Everything else is KEEP.
+# So the useful signal in a squash-merge repo is GitHub reporting a same-repo PR
+# to main with this head ref merged. Everything else is KEEP.
 #
 # The bias is deliberate. A false KEEP costs disk. A false DELETE costs work
 # that exists nowhere else — an unpushed branch has no backup.
 #
 # Usage:
-#   bash prune-stale-worktrees.sh                  # report only (default)
-#   bash prune-stale-worktrees.sh --execute        # delete, with confirmation
-#   bash prune-stale-worktrees.sh --execute --yes  # no confirmation
+#   bash scripts/prune-merged-branches.sh
+#   bash scripts/prune-merged-branches.sh --help
 #
-# Requires: gh (authenticated), git. Run from the repo root.
+# Requires: gh (authenticated), git, perl. Run from the repo root.
 
 set -euo pipefail
 
-EXECUTE=0
-ASSUME_YES=0
+usage() {
+  sed -n '/^# Usage:/,/^# Requires:/s/^# \{0,1\}//p' "$0"
+}
+
 for arg in "$@"; do
   case "$arg" in
-    --execute) EXECUTE=1 ;;
-    --yes) ASSUME_YES=1 ;;
+    -h|--help) usage; exit 0 ;;
     *) echo "unknown argument: $arg" >&2; exit 2 ;;
   esac
 done
 
-command -v gh >/dev/null || { echo "gh not found" >&2; exit 2; }
+GH="${GH:-gh}"
+BASE="${BASE:-origin/main}"
+REPO="${REPO:-${GITHUB_REPOSITORY:-divinevideo/divine-mobile}}"
+MERGED_PR_LIMIT="${MERGED_PR_LIMIT:-100000}"
+
+command -v "$GH" >/dev/null || { echo "$GH not found" >&2; exit 2; }
 git rev-parse --git-dir >/dev/null || exit 2
 
-BASE=origin/main
 echo "Fetching origin..."
 git fetch origin --prune --quiet
 git rev-parse --verify --quiet "$BASE" >/dev/null || {
   echo "$BASE not found" >&2; exit 2
 }
 
-# Shallow is fine for the signals used here: the GitHub lookup needs no local
-# history, and the unpushed check compares a branch tip against its own remote
-# tracking ref. Only note it, because `git branch -d`'s built-in safety check
-# does need ancestry and will refuse more often than it strictly must.
+# Shallow is fine for the signals used here: the GitHub lookups need no local
+# history, and the worktree checks inspect only the current checkout state.
 if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
-  echo "Note: shallow repository. Classification is unaffected, but git's own"
-  echo "      -d safety check may refuse some deletions. That is safe."
+  echo "Note: shallow repository. Classification is unaffected."
 fi
 
 echo "Loading merged PR head refs from GitHub..."
 MERGED_REFS="$(mktemp)"
-DELETABLE="$(mktemp)"
-trap 'rm -f "$MERGED_REFS" "$DELETABLE"' EXIT
+WORKTREE_FIELDS="$(mktemp)"
+trap 'rm -f "$MERGED_REFS" "$WORKTREE_FIELDS"' EXIT
 
-gh pr list --state merged --limit 2000 --json headRefName \
-  --jq '.[].headRefName' | sort -u > "$MERGED_REFS"
+"$GH" pr list --state merged --limit "$MERGED_PR_LIMIT" \
+  --json headRefName,isCrossRepository,baseRefName \
+  --jq '.[] | select(.isCrossRepository == false and .baseRefName == "main") | .headRefName' \
+  | sort -u > "$MERGED_REFS"
 echo "  $(wc -l < "$MERGED_REFS" | tr -d ' ') merged head refs known"
 
+git worktree list --porcelain -z > "$WORKTREE_FIELDS"
+
 worktree_for() {
-  git worktree list --porcelain \
-    | awk -v want="refs/heads/$1" '
-        /^worktree /  { path = substr($0, 10) }
-        /^branch /    { if (substr($0, 8) == want) print path }
-      '
+  WANT="refs/heads/$1" perl -0ne '
+    chomp;
+    if (/^worktree (.*)\z/s) { $path = $1; next }
+    if (/^branch (.*)\z/s && $1 eq $ENV{"WANT"}) { print $path; exit }
+  ' "$WORKTREE_FIELDS"
+}
+
+commit_exists_on_github() {
+  "$GH" api -X GET "repos/$REPO/commits/$1" >/dev/null 2>&1
 }
 
 CURRENT="$(git rev-parse --abbrev-ref HEAD)"
@@ -88,73 +97,43 @@ while IFS= read -r branch; do
   [ "$branch" = "$CURRENT" ] && continue
 
   wt="$(worktree_for "$branch")"
+  tip="$(git rev-parse "$branch")"
 
-  if grep -qxF "$branch" "$MERGED_REFS"; then
+  if grep -qxF -- "$branch" "$MERGED_REFS"; then
     verdict="MERGED-PR"
   else
     verdict="KEEP"
   fi
 
-  # Two independent vetoes, applied even to MERGED-PR branches.
+  # Vetoes are applied even to MERGED-PR branches.
 
-  # Veto 1: uncommitted work in the branch's worktree exists in no commit
-  # anywhere, merged PR or not.
-  if [ "$verdict" = "MERGED-PR" ] && [ -n "$wt" ] && [ -d "$wt" ]; then
-    if [ -n "$(git -C "$wt" status --porcelain 2>/dev/null)" ]; then
-      verdict="KEEP-DIRTY"
+  # Veto 1: the local tip must exist in GitHub's repository object database.
+  # This catches unpushed work and branch-name reuse after an older PR merged.
+  if [ "$verdict" = "MERGED-PR" ]; then
+    if ! commit_exists_on_github "$tip"; then
+      verdict="KEEP-LOCAL"
     fi
   fi
 
-  # Veto 2: local commits the remote tracking ref does not have. Covers the
-  # "merged, then someone kept working on the branch" case.
-  if [ "$verdict" = "MERGED-PR" ]; then
-    upstream="$(git rev-parse --abbrev-ref --symbolic-full-name \
-      "$branch@{upstream}" 2>/dev/null || true)"
-    if [ -n "$upstream" ]; then
-      ahead="$(git rev-list --count "$upstream..$branch" 2>/dev/null || echo 0)"
-      [ "$ahead" -gt 0 ] && verdict="KEEP-AHEAD"
+  # Veto 2: uncommitted or ignored work in the branch's worktree exists in no
+  # commit anywhere, merged PR or not.
+  if [ "$verdict" = "MERGED-PR" ] && [ -n "$wt" ] && [ -d "$wt" ]; then
+    if [ -n "$(git -C "$wt" status --porcelain --ignored=matching 2>/dev/null)" ]; then
+      verdict="KEEP-DIRTY"
     fi
   fi
 
   printf '%-14s %-50s %s\n' "$verdict" "$branch" "${wt:-—}"
   if [ "$verdict" = "MERGED-PR" ]; then
     merged=$((merged + 1))
-    printf '%s\t%s\n' "$branch" "$wt" >> "$DELETABLE"
   else
     keep=$((keep + 1))
   fi
 done < <(git for-each-ref --format='%(refname:short)' refs/heads/ | sort)
 
-printf '\n%s deletable (merged PR, clean, not ahead) / %s kept.\n' "$merged" "$keep"
+printf '\n%s likely prunable (merged same-repo PR to main, local tip on GitHub, clean) / %s kept.\n' "$merged" "$keep"
 echo
-echo "KEEP includes every branch with no merged PR — which is where unpushed"
-echo "local work lives. Review those by hand; this script will never touch them."
-
-if [ "$EXECUTE" -ne 1 ]; then
-  echo
-  echo "Report only. Re-run with --execute to delete the MERGED-PR rows."
-  exit 0
-fi
-
-[ "$merged" -eq 0 ] && exit 0
-
-if [ "$ASSUME_YES" -ne 1 ]; then
-  printf '\nDelete %s branches and their worktrees? [y/N] ' "$merged"
-  read -r reply
-  case "$reply" in [yY]*) ;; *) echo "Aborted."; exit 0 ;; esac
-fi
-
-while IFS=$'\t' read -r branch wt; do
-  if [ -n "$wt" ] && [ -d "$wt" ]; then
-    git worktree remove "$wt" || {
-      echo "  worktree busy: $wt — skipping $branch"; continue
-    }
-  fi
-  # -d, never -D. Git's own unmerged check is a second safety net under the
-  # classification above; when it refuses, that disagreement is worth a look.
-  git branch -d "$branch" 2>/dev/null \
-    || echo "  git refused to delete $branch — kept, review by hand"
-done < "$DELETABLE"
-
-git worktree prune
-echo "Done."
+echo "Report only. This script does not delete branches or worktrees."
+echo "KEEP includes branches with no matching merged same-repo PR to main,"
+echo "branches whose local tip is not on GitHub, and branches with dirty or"
+echo "ignored worktree files. Review kept branches by hand."

--- a/scripts/prune-merged-branches.sh
+++ b/scripts/prune-merged-branches.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# ABOUTME: Reports which local branches and worktrees are safe to prune.
+# ABOUTME: Report-only by default; deletion is a separate explicit opt-in.
+#
+# Why the obvious approaches are wrong here
+# -----------------------------------------
+# 1. `git branch --merged main` reports 5 of 1185 branches. This repo
+#    squash-merges, and a squash rewrites the commit, so a merged branch never
+#    becomes an ancestor of main. Ancestry is not the signal.
+#
+# 2. "Empty diff against main" does not work either. `git diff main <branch>`
+#    is symmetric: a branch that merged months ago still differs from today's
+#    main by everything that landed since. It reports 2445 changed files for a
+#    long-merged branch here.
+#
+# 3. Name matching destroys work. Deleting everything matching "7606" took out
+#    `fix/7606-semantic-tokens` — unpushed local work on a parallel attempt.
+#
+# So there is exactly one trustworthy signal in a squash-merge repo: GitHub
+# says a PR with this head ref merged. Everything else is KEEP.
+#
+# The bias is deliberate. A false KEEP costs disk. A false DELETE costs work
+# that exists nowhere else — an unpushed branch has no backup.
+#
+# Usage:
+#   bash prune-stale-worktrees.sh                  # report only (default)
+#   bash prune-stale-worktrees.sh --execute        # delete, with confirmation
+#   bash prune-stale-worktrees.sh --execute --yes  # no confirmation
+#
+# Requires: gh (authenticated), git. Run from the repo root.
+
+set -euo pipefail
+
+EXECUTE=0
+ASSUME_YES=0
+for arg in "$@"; do
+  case "$arg" in
+    --execute) EXECUTE=1 ;;
+    --yes) ASSUME_YES=1 ;;
+    *) echo "unknown argument: $arg" >&2; exit 2 ;;
+  esac
+done
+
+command -v gh >/dev/null || { echo "gh not found" >&2; exit 2; }
+git rev-parse --git-dir >/dev/null || exit 2
+
+BASE=origin/main
+echo "Fetching origin..."
+git fetch origin --prune --quiet
+git rev-parse --verify --quiet "$BASE" >/dev/null || {
+  echo "$BASE not found" >&2; exit 2
+}
+
+# Shallow is fine for the signals used here: the GitHub lookup needs no local
+# history, and the unpushed check compares a branch tip against its own remote
+# tracking ref. Only note it, because `git branch -d`'s built-in safety check
+# does need ancestry and will refuse more often than it strictly must.
+if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
+  echo "Note: shallow repository. Classification is unaffected, but git's own"
+  echo "      -d safety check may refuse some deletions. That is safe."
+fi
+
+echo "Loading merged PR head refs from GitHub..."
+MERGED_REFS="$(mktemp)"
+DELETABLE="$(mktemp)"
+trap 'rm -f "$MERGED_REFS" "$DELETABLE"' EXIT
+
+gh pr list --state merged --limit 2000 --json headRefName \
+  --jq '.[].headRefName' | sort -u > "$MERGED_REFS"
+echo "  $(wc -l < "$MERGED_REFS" | tr -d ' ') merged head refs known"
+
+worktree_for() {
+  git worktree list --porcelain \
+    | awk -v want="refs/heads/$1" '
+        /^worktree /  { path = substr($0, 10) }
+        /^branch /    { if (substr($0, 8) == want) print path }
+      '
+}
+
+CURRENT="$(git rev-parse --abbrev-ref HEAD)"
+
+printf '\n%-14s %-50s %s\n' "VERDICT" "BRANCH" "WORKTREE"
+printf '%s\n' "--------------------------------------------------------------------------------"
+
+merged=0; keep=0
+while IFS= read -r branch; do
+  case "$branch" in main|master) continue ;; esac
+  [ "$branch" = "$CURRENT" ] && continue
+
+  wt="$(worktree_for "$branch")"
+
+  if grep -qxF "$branch" "$MERGED_REFS"; then
+    verdict="MERGED-PR"
+  else
+    verdict="KEEP"
+  fi
+
+  # Two independent vetoes, applied even to MERGED-PR branches.
+
+  # Veto 1: uncommitted work in the branch's worktree exists in no commit
+  # anywhere, merged PR or not.
+  if [ "$verdict" = "MERGED-PR" ] && [ -n "$wt" ] && [ -d "$wt" ]; then
+    if [ -n "$(git -C "$wt" status --porcelain 2>/dev/null)" ]; then
+      verdict="KEEP-DIRTY"
+    fi
+  fi
+
+  # Veto 2: local commits the remote tracking ref does not have. Covers the
+  # "merged, then someone kept working on the branch" case.
+  if [ "$verdict" = "MERGED-PR" ]; then
+    upstream="$(git rev-parse --abbrev-ref --symbolic-full-name \
+      "$branch@{upstream}" 2>/dev/null || true)"
+    if [ -n "$upstream" ]; then
+      ahead="$(git rev-list --count "$upstream..$branch" 2>/dev/null || echo 0)"
+      [ "$ahead" -gt 0 ] && verdict="KEEP-AHEAD"
+    fi
+  fi
+
+  printf '%-14s %-50s %s\n' "$verdict" "$branch" "${wt:-—}"
+  if [ "$verdict" = "MERGED-PR" ]; then
+    merged=$((merged + 1))
+    printf '%s\t%s\n' "$branch" "$wt" >> "$DELETABLE"
+  else
+    keep=$((keep + 1))
+  fi
+done < <(git for-each-ref --format='%(refname:short)' refs/heads/ | sort)
+
+printf '\n%s deletable (merged PR, clean, not ahead) / %s kept.\n' "$merged" "$keep"
+echo
+echo "KEEP includes every branch with no merged PR — which is where unpushed"
+echo "local work lives. Review those by hand; this script will never touch them."
+
+if [ "$EXECUTE" -ne 1 ]; then
+  echo
+  echo "Report only. Re-run with --execute to delete the MERGED-PR rows."
+  exit 0
+fi
+
+[ "$merged" -eq 0 ] && exit 0
+
+if [ "$ASSUME_YES" -ne 1 ]; then
+  printf '\nDelete %s branches and their worktrees? [y/N] ' "$merged"
+  read -r reply
+  case "$reply" in [yY]*) ;; *) echo "Aborted."; exit 0 ;; esac
+fi
+
+while IFS=$'\t' read -r branch wt; do
+  if [ -n "$wt" ] && [ -d "$wt" ]; then
+    git worktree remove "$wt" || {
+      echo "  worktree busy: $wt — skipping $branch"; continue
+    }
+  fi
+  # -d, never -D. Git's own unmerged check is a second safety net under the
+  # classification above; when it refuses, that disagreement is worth a look.
+  git branch -d "$branch" 2>/dev/null \
+    || echo "  git refused to delete $branch — kept, review by hand"
+done < "$DELETABLE"
+
+git worktree prune
+echo "Done."


### PR DESCRIPTION
Closes #7670

AGENTS.md says to prune the worktree and branch after merge, but not how — so everyone improvises, and in this repo every obvious approach is wrong.

## Why this needs a script

- **`git branch --merged main` reports 5 of 1185 branches.** This repo squash-merges. A squash rewrites the commit, so a merged branch never becomes an ancestor of `main`. Ancestry is not the signal, and any script built on it concludes almost nothing is safe to delete.
- **"Empty diff against `main`" does not work either.** `git diff` is symmetric: a branch that merged months ago still differs by everything that landed since. It reports 2445 changed files for a long-merged branch here.
- **Name matching destroys work.** Deleting everything matching `7606` took out `fix/7606-semantic-tokens` — unpushed local work on a parallel attempt at the same task. That branch existed nowhere else.

## What it does

One trustworthy signal: GitHub reports a merged PR with that head ref. Everything else is `KEEP` — including every branch with no PR, which is exactly where unpushed work lives.

Two vetoes apply on top, even to merged branches:

- uncommitted changes in the branch's worktree
- local commits ahead of its remote tracking ref

The second is not theoretical — it caught **10** branches on the first run (merged, then someone kept committing). A naive "delete merged branches" script destroys those.

Deletion uses `git branch -d`, never `-D`, so git's own unmerged check is a second independent net under the classification.

## Dry run on this checkout

| Verdict | Count |
|---|---|
| MERGED-PR (deletable) | 396 |
| KEEP | 785 |
| KEEP-AHEAD (veto fired) | 10 |

Worth knowing: only **4** of the 396 deletable branches own a worktree. This clears branch sprawl but barely touches the 94 worktrees — those sit mostly on genuinely-unmerged branches, which is a human review job rather than an automatable one.

## Usage

```bash
bash scripts/prune-merged-branches.sh                  # report only (default)
bash scripts/prune-merged-branches.sh --execute        # delete, with confirmation
```

## Verification

- `bash -n` clean; run end-to-end in report mode from the committed path
- No deletions performed

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] 📝 Documentation
- [x] 🗑️ Chore