### PR TITLE
fix(nostr): count an initial subscription's pre-EOSE events for pagination

### DIFF
--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -82,6 +82,7 @@ class PaginationState {
 
   void startQuery() {
     eventsReceivedInCurrentQuery = 0;
+    hasMore = true;
     isLoading = true;
   }
 
@@ -2202,12 +2203,6 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
           nip50Sort: nip50Sort,
         );
 
-        // Set per-subscription loading state to show loading UI
-        final paginationState = _paginationStates[subscriptionType];
-        if (paginationState != null) {
-          paginationState.isLoading = true;
-        }
-
         // Generate deterministic subscription ID based on subscription parameters
         final subscriptionId = _generateSubscriptionId(
           subscriptionType: subscriptionType,
@@ -2241,6 +2236,11 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
         }
         _pendingSubscriptionIds.add(subscriptionId);
         pendingClaimId = subscriptionId;
+
+        // Set per-subscription loading state after duplicate detection so a
+        // reused in-flight subscription keeps its current query tally intact.
+        final paginationState = _paginationStates[subscriptionType];
+        paginationState?.startQuery();
 
         // Create direct subscription using NostrService with proper filters
         final subscriptionStartTime = DateTime.now();

--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -89,6 +89,21 @@ class PaginationState {
     eventsReceivedInCurrentQuery++;
   }
 
+  /// Records a per-query tally the caller counted for itself.
+  ///
+  /// [incrementEventCount] only fires for events flagged `isHistorical`, which
+  /// is set on the load-more path alone. An initial subscription delivers its
+  /// stored backlog through the real-time handler, so its tally stays at zero
+  /// and [completeQuery] would call the feed exhausted however much arrived.
+  ///
+  /// Takes the larger of the two counts so a load-more query that is already
+  /// counting for itself is never revised downward.
+  void recordReceivedCount(int count) {
+    if (count > eventsReceivedInCurrentQuery) {
+      eventsReceivedInCurrentQuery = count;
+    }
+  }
+
   void completeQuery(int requestedLimit) {
     isLoading = false;
     // If we received fewer events than requested, assume no more content
@@ -2481,6 +2496,14 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
             // and the UI never transitions from spinner to empty state.
             final paginationState = _paginationStates[subscriptionType];
             if (paginationState != null) {
+              // Everything up to EOSE is stored history by definition, but the
+              // initial subscription routes it through the real-time handler,
+              // so the per-query tally never sees it. `eventCount` is this
+              // subscription's own count of those events; it spans every kind
+              // in the filter set rather than videos alone, which can only
+              // keep `hasMore` true a page longer than needed — the safe
+              // direction, and the load-more path re-queries from there.
+              paginationState.recordReceivedCount(eventCount);
               paginationState.completeQuery(limit);
               notifyListeners();
             }

--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -97,8 +97,8 @@ class PaginationState {
   /// stored backlog through the real-time handler, so its tally stays at zero
   /// and [completeQuery] would call the feed exhausted however much arrived.
   ///
-  /// Takes the larger of the two counts so a load-more query that is already
-  /// counting for itself is never revised downward.
+  /// Takes the larger of the two counts so an externally observed tally seeds
+  /// missing events without erasing events already counted on this query.
   void recordReceivedCount(int count) {
     if (count > eventsReceivedInCurrentQuery) {
       eventsReceivedInCurrentQuery = count;
@@ -2496,12 +2496,13 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
             // and the UI never transitions from spinner to empty state.
             final paginationState = _paginationStates[subscriptionType];
             if (paginationState != null) {
-              // Everything up to EOSE is stored history by definition, but the
-              // initial subscription routes it through the real-time handler,
-              // so the per-query tally never sees it. `eventCount` is this
-              // subscription's own count of those events; it spans every kind
-              // in the filter set rather than videos alone, which can only
-              // keep `hasMore` true a page longer than needed — the safe
+              // On the first EOSE, the initial subscription's stored backlog
+              // has routed through the real-time handler, so the per-query
+              // tally never sees it. `eventCount` is this subscription's raw
+              // stream count: repeat EOSE cycles can include later live
+              // deliveries, and the filter set can include non-video kinds,
+              // duplicates, or events filtered out below. Those all skew toward
+              // keeping `hasMore` true a page longer than needed — the safe
               // direction, and the load-more path re-queries from there.
               paginationState.recordReceivedCount(eventCount);
               paginationState.completeQuery(limit);

--- a/mobile/test/services/video_event_service_initial_page_pagination_test.dart
+++ b/mobile/test/services/video_event_service_initial_page_pagination_test.dart
@@ -73,17 +73,10 @@ void main() {
       videoEventService.dispose();
     });
 
-    test('keeps hasMore when a full first page arrives before EOSE', () async {
-      // The initial subscription delivers stored events through the real-time
-      // handler, so the `isHistorical` counter — which only the load-more path
-      // drives — stays at zero. Before the fix, completeQuery read that zero
-      // and set hasMore=false however many events had actually landed.
-      //
-      // Runs on the real event loop rather than under fakeAsync: the subscribe
-      // future outlives a fake zone, and its continuation then schedules a real
-      // timer that strands whichever widget test runs next in CI's merged
-      // isolate.
-      const limit = 5;
+    Future<PaginationState> subscribeThroughEose({
+      required int eventCount,
+      required int limit,
+    }) async {
       void Function()? capturedOnEose;
       final controller = StreamController<Event>();
       addTearDown(controller.close);
@@ -101,7 +94,7 @@ void main() {
         limit: limit,
       );
 
-      for (var i = 0; i < limit; i++) {
+      for (var i = 0; i < eventCount; i++) {
         controller.add(_videoEvent(i));
       }
       await Future<void>.delayed(Duration.zero);
@@ -110,8 +103,22 @@ void main() {
       capturedOnEose!();
       await Future<void>.delayed(Duration.zero);
 
-      final state = videoEventService
+      return videoEventService
           .getPaginationStatesForTesting()[SubscriptionType.profile]!;
+    }
+
+    test('keeps hasMore when a full first page arrives before EOSE', () async {
+      // The initial subscription delivers stored events through the real-time
+      // handler, so the `isHistorical` counter — which only the load-more path
+      // drives — stays at zero. Before the fix, completeQuery read that zero
+      // and set hasMore=false however many events had actually landed.
+      //
+      // Runs on the real event loop rather than under fakeAsync: the subscribe
+      // future outlives a fake zone, and its continuation then schedules a real
+      // timer that strands whichever widget test runs next in CI's merged
+      // isolate.
+      const limit = 5;
+      final state = await subscribeThroughEose(eventCount: limit, limit: limit);
 
       expect(
         state.eventsReceivedInCurrentQuery,
@@ -128,5 +135,40 @@ void main() {
             'feed is exhausted',
       );
     });
+
+    test('clears stale query state before counting a first page', () async {
+      const limit = 5;
+      final stateBeforeSubscribe = videoEventService
+          .getPaginationStatesForTesting()[SubscriptionType.profile]!;
+      stateBeforeSubscribe.eventsReceivedInCurrentQuery = 500;
+      stateBeforeSubscribe.hasMore = false;
+
+      final state = await subscribeThroughEose(eventCount: limit, limit: limit);
+
+      expect(state.eventsReceivedInCurrentQuery, equals(limit));
+      expect(
+        state.hasMore,
+        isTrue,
+        reason:
+            'a fresh first-page subscription must not inherit the previous '
+            'profile query count or exhausted flag',
+      );
+    });
+
+    test(
+      'marks hasMore false when a short first page arrives before EOSE',
+      () async {
+        final state = await subscribeThroughEose(eventCount: 3, limit: 5);
+
+        expect(state.eventsReceivedInCurrentQuery, equals(3));
+        expect(
+          state.hasMore,
+          isFalse,
+          reason:
+              'a first page shorter than the requested limit still indicates '
+              'the feed is exhausted',
+        );
+      },
+    );
   });
 }

--- a/mobile/test/services/video_event_service_initial_page_pagination_test.dart
+++ b/mobile/test/services/video_event_service_initial_page_pagination_test.dart
@@ -3,7 +3,6 @@
 
 import 'dart:async';
 
-import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:nostr_client/nostr_client.dart';
@@ -74,11 +73,16 @@ void main() {
       videoEventService.dispose();
     });
 
-    test('keeps hasMore when a full first page arrives before EOSE', () {
+    test('keeps hasMore when a full first page arrives before EOSE', () async {
       // The initial subscription delivers stored events through the real-time
       // handler, so the `isHistorical` counter — which only the load-more path
       // drives — stays at zero. Before the fix, completeQuery read that zero
       // and set hasMore=false however many events had actually landed.
+      //
+      // Runs on the real event loop rather than under fakeAsync: the subscribe
+      // future outlives a fake zone, and its continuation then schedules a real
+      // timer that strands whichever widget test runs next in CI's merged
+      // isolate.
       const limit = 5;
       void Function()? capturedOnEose;
       final controller = StreamController<Event>();
@@ -91,41 +95,38 @@ void main() {
         return controller.stream;
       });
 
-      fakeAsync((async) {
-        videoEventService.subscribeToVideoFeed(
-          subscriptionType: SubscriptionType.profile,
-          authors: [_author],
-          limit: limit,
-        );
-        async.flushMicrotasks();
+      await videoEventService.subscribeToVideoFeed(
+        subscriptionType: SubscriptionType.profile,
+        authors: [_author],
+        limit: limit,
+      );
 
-        for (var i = 0; i < limit; i++) {
-          controller.add(_videoEvent(i));
-        }
-        async.flushMicrotasks();
+      for (var i = 0; i < limit; i++) {
+        controller.add(_videoEvent(i));
+      }
+      await Future<void>.delayed(Duration.zero);
 
-        expect(capturedOnEose, isNotNull, reason: 'onEose should be set');
-        capturedOnEose!();
-        async.flushMicrotasks();
+      expect(capturedOnEose, isNotNull, reason: 'onEose should be set');
+      capturedOnEose!();
+      await Future<void>.delayed(Duration.zero);
 
-        final state = videoEventService
-            .getPaginationStatesForTesting()[SubscriptionType.profile]!;
+      final state = videoEventService
+          .getPaginationStatesForTesting()[SubscriptionType.profile]!;
 
-        expect(
-          state.eventsReceivedInCurrentQuery,
-          greaterThanOrEqualTo(limit),
-          reason:
-              'the tally must reflect the events that actually arrived before '
-              'EOSE, not the load-more-only isHistorical count',
-        );
-        expect(
-          state.hasMore,
-          isTrue,
-          reason:
-              'a first page that filled the requested limit cannot prove the '
-              'feed is exhausted',
-        );
-      });
+      expect(
+        state.eventsReceivedInCurrentQuery,
+        greaterThanOrEqualTo(limit),
+        reason:
+            'the tally must reflect the events that actually arrived before '
+            'EOSE, not the load-more-only isHistorical count',
+      );
+      expect(
+        state.hasMore,
+        isTrue,
+        reason:
+            'a first page that filled the requested limit cannot prove the '
+            'feed is exhausted',
+      );
     });
   });
 }

--- a/mobile/test/services/video_event_service_initial_page_pagination_test.dart
+++ b/mobile/test/services/video_event_service_initial_page_pagination_test.dart
@@ -1,0 +1,131 @@
+// ABOUTME: Pins that an initial subscription's pre-EOSE events count toward
+// ABOUTME: pagination, so a full first page does not report the feed exhausted.
+
+import 'dart:async';
+
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:nostr_sdk/filter.dart';
+import 'package:openvine/services/subscription_manager.dart';
+import 'package:openvine/services/video_event_service.dart';
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _MockSubscriptionManager extends Mock implements SubscriptionManager {}
+
+const _author =
+    '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+
+Event _videoEvent(int index) {
+  final event = Event(
+    _author,
+    34236,
+    [
+      ['url', 'https://media.example.com/$index.mp4'],
+      ['m', 'video/mp4'],
+    ],
+    'video $index',
+    createdAt: 1700000000 - index,
+  );
+  event.id = index.toRadixString(16).padLeft(64, '0');
+  event.sig = 'f' * 128;
+  event.sources.add('wss://relay.example.com');
+  return event;
+}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(<Filter>[]);
+  });
+
+  group('VideoEventService initial-page pagination', () {
+    late VideoEventService videoEventService;
+    late _MockNostrClient mockNostrService;
+    late _MockSubscriptionManager mockSubscriptionManager;
+
+    setUp(() {
+      mockNostrService = _MockNostrClient();
+      mockSubscriptionManager = _MockSubscriptionManager();
+
+      when(() => mockNostrService.isInitialized).thenReturn(true);
+      when(() => mockNostrService.publicKey).thenReturn('');
+      when(() => mockNostrService.connectedRelayCount).thenReturn(1);
+      when(
+        () => mockNostrService.configuredRelays,
+      ).thenReturn(['wss://relay.example.com']);
+      when(
+        () => mockNostrService.connectedRelays,
+      ).thenReturn(['wss://relay.example.com']);
+      when(
+        () => mockNostrService.queryEvents(any()),
+      ).thenAnswer((_) async => <Event>[]);
+      when(mockNostrService.getRelayStats).thenAnswer((_) async => null);
+
+      videoEventService = VideoEventService(
+        mockNostrService,
+        subscriptionManager: mockSubscriptionManager,
+      );
+    });
+
+    tearDown(() {
+      videoEventService.dispose();
+    });
+
+    test('keeps hasMore when a full first page arrives before EOSE', () {
+      // The initial subscription delivers stored events through the real-time
+      // handler, so the `isHistorical` counter — which only the load-more path
+      // drives — stays at zero. Before the fix, completeQuery read that zero
+      // and set hasMore=false however many events had actually landed.
+      const limit = 5;
+      void Function()? capturedOnEose;
+      final controller = StreamController<Event>();
+      addTearDown(controller.close);
+
+      when(
+        () => mockNostrService.subscribe(any(), onEose: any(named: 'onEose')),
+      ).thenAnswer((invocation) {
+        capturedOnEose = invocation.namedArguments[#onEose] as void Function()?;
+        return controller.stream;
+      });
+
+      fakeAsync((async) {
+        videoEventService.subscribeToVideoFeed(
+          subscriptionType: SubscriptionType.profile,
+          authors: [_author],
+          limit: limit,
+        );
+        async.flushMicrotasks();
+
+        for (var i = 0; i < limit; i++) {
+          controller.add(_videoEvent(i));
+        }
+        async.flushMicrotasks();
+
+        expect(capturedOnEose, isNotNull, reason: 'onEose should be set');
+        capturedOnEose!();
+        async.flushMicrotasks();
+
+        final state = videoEventService
+            .getPaginationStatesForTesting()[SubscriptionType.profile]!;
+
+        expect(
+          state.eventsReceivedInCurrentQuery,
+          greaterThanOrEqualTo(limit),
+          reason:
+              'the tally must reflect the events that actually arrived before '
+              'EOSE, not the load-more-only isHistorical count',
+        );
+        expect(
+          state.hasMore,
+          isTrue,
+          reason:
+              'a first page that filled the requested limit cannot prove the '
+              'feed is exhausted',
+        );
+      });
+    });
+  });
+}

--- a/mobile/test/services/video_event_service_pagination_state_test.dart
+++ b/mobile/test/services/video_event_service_pagination_state_test.dart
@@ -93,6 +93,19 @@ void main() {
       expect(paginationState.eventsReceivedInCurrentQuery, equals(3));
     });
 
+    test('should record received count without lowering an existing tally', () {
+      // Arrange
+      final paginationState = PaginationState();
+      paginationState.startQuery();
+      paginationState.recordReceivedCount(5);
+
+      // Act
+      paginationState.recordReceivedCount(3);
+
+      // Assert
+      expect(paginationState.eventsReceivedInCurrentQuery, equals(5));
+    });
+
     test(
       'should set hasMore=false when fewer events received than requested',
       () {


### PR DESCRIPTION
Closes #7679.

## The bug

`PaginationState.incrementEventCount` only fires for events flagged `isHistorical`, and only the load-more path sets that flag. An initial subscription delivers its stored backlog through the real-time handler, so its per-query tally stayed at zero and `completeQuery` concluded the feed was exhausted however much had arrived.

A production log export (1.0.20+846, release build) shows the contradiction on one line:

```
EOSE received for SubscriptionType.profile after 1456ms with 78 events
PaginationState: No more content available - received 0 < 50 requested
```

## The fix

Everything up to EOSE is stored history by definition, and the subscription already counts those events for its own logging. Seed the tally from that count at EOSE rather than inferring it from a flag the initial path never sets.

**`isHistorical` is deliberately untouched.** It also selects append-vs-prepend ordering, so flipping it would silently reorder every feed, and an existing test pins the real contract — that live events must not inflate a historical query's count. That test still passes.

The seeded count spans every kind in the filter set rather than videos alone, so it can keep `hasMore` true a page longer than strictly needed. That is the safe direction: the load-more path already resets and re-queries, whereas a premature `hasMore=false` is what hid content.

## Verification

- **The regression test fails without the fix.** Checked by removing only the seeding line: red at the `hasMore` assertion. It drives a real subscribe → 5 events → EOSE cycle rather than poking the state object directly.
- Four existing pagination suites pass, including the one pinning that real-time events must not increment the counter.
- `flutter analyze lib test` clean.
- God-file ceiling, post-close-emit, and test-unit-structure ratchets all pass — `video_event_service.dart` is baselined at 6619 and sits at 6565 after this change.

## Not established

This is **not** a diagnosed fix for the "videos don't load on profile pages" report that surfaced it. It is a real bug on the path that report implicates, but nothing here connects it to an empty profile grid. Tracked separately.