### PR TITLE
test(tools): hoist the duplicated git helper in the dark-parity tests

### DIFF
--- a/mobile/test/tools/check_dark_value_parity_test.dart
+++ b/mobile/test/tools/check_dark_value_parity_test.dart
@@ -55,6 +55,25 @@ class VineTheme {
       ], workingDirectory: sandbox.path);
     }
 
+    void git(List<String> arguments) {
+      final res = Process.runSync(
+        'git',
+        arguments,
+        workingDirectory: sandbox.path,
+      );
+      expect(res.exitCode, 0, reason: 'git ${arguments.join(' ')}');
+    }
+
+    /// Commits a `main` root in the sandbox so a base ref exists to diff from.
+    void initRepo() {
+      git(['init', '--initial-branch=main']);
+      git(['config', 'user.email', 'test@example.com']);
+      git(['config', 'user.name', 'Test']);
+      File(p.join(sandbox.path, 'a.dart')).writeAsStringSync('// base\n');
+      git(['add', '.']);
+      git(['commit', '-m', 'base']);
+    }
+
     setUp(() {
       sandbox = Directory.systemTemp.createTempSync('dark_parity_');
       themePath = p.join(sandbox.path, 'vine_theme.dart');
@@ -210,21 +229,7 @@ class VineTheme {
     // branch's additions and reporting confident, wrong DARK MISMATCH lines.
     // Two orphan roots reproduce "no merge base" without a shallow fixture.
     test('refuses to guess when the base shares no history with HEAD', () {
-      void git(List<String> arguments) {
-        final res = Process.runSync(
-          'git',
-          arguments,
-          workingDirectory: sandbox.path,
-        );
-        expect(res.exitCode, 0, reason: 'git ${arguments.join(' ')}');
-      }
-
-      git(['init', '--initial-branch=main']);
-      git(['config', 'user.email', 'test@example.com']);
-      git(['config', 'user.name', 'Test']);
-      File(p.join(sandbox.path, 'a.dart')).writeAsStringSync('// base\n');
-      git(['add', '.']);
-      git(['commit', '-m', 'base']);
+      initRepo();
 
       git(['checkout', '--orphan', 'unrelated']);
       File(p.join(sandbox.path, 'a.dart')).writeAsStringSync('// other\n');
@@ -251,21 +256,7 @@ class VineTheme {
     // and suggesting `git fetch --unshallow` sends the reader after a fix
     // that cannot resolve a ref that was never there. Surface git's error.
     test('surfaces the git error when the base ref does not exist', () {
-      void git(List<String> arguments) {
-        final res = Process.runSync(
-          'git',
-          arguments,
-          workingDirectory: sandbox.path,
-        );
-        expect(res.exitCode, 0, reason: 'git ${arguments.join(' ')}');
-      }
-
-      git(['init', '--initial-branch=main']);
-      git(['config', 'user.email', 'test@example.com']);
-      git(['config', 'user.name', 'Test']);
-      File(p.join(sandbox.path, 'a.dart')).writeAsStringSync('// base\n');
-      git(['add', '.']);
-      git(['commit', '-m', 'base']);
+      initRepo();
 
       final res = Process.runSync('dart', [
         'run',


### PR DESCRIPTION
Closes #7685

Cleanup caught while reviewing #7667 and deliberately deferred rather than held against an approved, green PR.

## Description

The two shallow-clone guard tests added in #7667 each declared their own byte-identical `void git(List<String> arguments)` closure and then repeated the same six-command repo bootstrap inline. The enclosing group already owns a shared `run(String diff)` helper — that is where both belong.

Net −9 lines, and the next test that needs a git sandbox gets `initRepo()` for free instead of copying the block a third time.

## Changes

- `mobile/test/tools/check_dark_value_parity_test.dart`
  - `git(...)` hoisted to group scope, next to `run(String diff)`. It closes over `sandbox`, which `setUp` assigns before every test.
  - The shared bootstrap extracted as `initRepo()`, ending at the `base` commit. The orphan-branch step stays in the one test that needs it.

Behavior is unchanged: same assertions, same exit codes, same stderr substrings. No production code touched.

## Verification

- `flutter test test/tools/check_dark_value_parity_test.dart` — 12 passed
- `flutter analyze lib test integration_test` — clean
- Both refactored tests re-run against the **pre-#7667** script (`044ff28cfc^`) and confirmed still failing, so the refactor did not weaken them into tests that cannot fail

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

🤖 Generated with [Claude Code](https://claude.com/claude-code)