### PR TITLE
refactor(profile): finish endpoint injection and fix NIP-98 URL canonicalization

### DIFF
--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -94,12 +94,28 @@ const defaultNameServerBaseUrl = 'https://names.divine.video';
 const defaultKeycastNip05Url =
     'https://login.divine.video/.well-known/nostr.json';
 
-/// Normalizes an injected endpoint so composition cannot leave a stray
-/// separator. `'$base/name'` on a base ending in `/` yields `//name`, and
-/// `'$url?name='` yields `nostr.json/?name=`; both are paths the origin
-/// routes to a 404 rather than the intended handler.
-String _stripTrailingSlash(String url) =>
-    url.endsWith('/') ? url.substring(0, url.length - 1) : url;
+/// Canonicalizes an injected endpoint, then strips a trailing separator.
+///
+/// Both steps are load-bearing, and the order matters.
+///
+/// `Uri.parse` normalizes exactly the way the wire URL and the name server
+/// do — it lowercases the host, drops a default port, and resolves dot
+/// segments. Without it, a non-canonical injected base makes the NIP-98 `u`
+/// tag (signed from this string verbatim) differ from the request URL
+/// (built via `Uri.parse`), and the server compares them as raw strings, so
+/// every claim and release 401s while the unauthenticated `/check` keeps
+/// working.
+///
+/// Stripping runs afterwards because canonicalization can reintroduce a
+/// trailing slash (`https://x/.` becomes `https://x/`), and `'$base/name'`
+/// on a base ending in `/` yields `//name`, which the origin routes to a
+/// 404 rather than the intended handler.
+String _normalizeEndpoint(String url) {
+  final canonical = Uri.parse(url).toString();
+  return canonical.endsWith('/')
+      ? canonical.substring(0, canonical.length - 1)
+      : canonical;
+}
 
 /// Repository for fetching and publishing user profiles (Kind 0 metadata).
 class ProfileRepository implements ProfileReader {
@@ -118,8 +134,8 @@ class ProfileRepository implements ProfileReader {
     List<String> indexerRelays = defaultProfileIndexerRelays,
     String nameServerBaseUrl = defaultNameServerBaseUrl,
     String keycastNip05Url = defaultKeycastNip05Url,
-  }) : _nameServerBaseUrl = _stripTrailingSlash(nameServerBaseUrl),
-       _keycastNip05Url = _stripTrailingSlash(keycastNip05Url),
+  }) : _nameServerBaseUrl = _normalizeEndpoint(nameServerBaseUrl),
+       _keycastNip05Url = _normalizeEndpoint(keycastNip05Url),
        _nostrClient = nostrClient,
        _userProfilesDao = userProfilesDao,
        _httpClient = httpClient,

--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -19,8 +19,7 @@ import 'package:unified_logger/unified_logger.dart';
 
 // TODO(e2e): Add divine-name-server to local_stack Docker dependencies
 // so username check/claim flows can be tested against it in E2E tests.
-// Tracked by #3367 while this repository still uses the production name
-// server in local builds.
+// Tracked by #7692.
 
 // How long a Divine-identity determination is trusted before re-querying.
 //

--- a/mobile/packages/profile_repository/test/src/profile_repository_divine_identity_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_divine_identity_test.dart
@@ -11,6 +11,10 @@ class _MockUserProfilesDao extends Mock implements UserProfilesDao {}
 
 class _MockHttpClient extends Mock implements Client {}
 
+/// Injected name server: not the production host, so these tests prove the
+/// repository uses the injected endpoint rather than the default.
+const _testNameServer = 'https://names.test.example';
+
 void main() {
   group('ProfileRepository.resolveDivineIdentity', () {
     late _MockNostrClient mockNostrClient;
@@ -21,7 +25,7 @@ void main() {
     const pubkey =
         'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2';
     final byPubkeyUri = Uri.parse(
-      'https://names.divine.video/api/username/by-pubkey/$pubkey',
+      '$_testNameServer/api/username/by-pubkey/$pubkey',
     );
 
     setUpAll(() {
@@ -36,6 +40,7 @@ void main() {
         nostrClient: mockNostrClient,
         userProfilesDao: mockUserProfilesDao,
         httpClient: mockHttpClient,
+        nameServerBaseUrl: _testNameServer,
       );
     });
 
@@ -141,7 +146,7 @@ void main() {
       }
 
       final evictedUri = Uri.parse(
-        'https://names.divine.video/api/username/by-pubkey/'
+        '$_testNameServer/api/username/by-pubkey/'
         '${pubkeyForIndex(0)}',
       );
       await repository.resolveDivineIdentity(pubkeyForIndex(0));

--- a/mobile/packages/profile_repository/test/src/profile_repository_endpoints_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_endpoints_test.dart
@@ -244,6 +244,55 @@ void main() {
         expect(signed, equals(posted.toString()));
         expect(signed, equals('$_testNameServer/api/username/release'));
       });
+
+      // The request URL is built with Uri.parse, which lowercases the host
+      // and drops a default port; the `u` tag is signed from the base
+      // verbatim. Unless the base is canonicalized first, the two strings
+      // differ and the name server — which compares them raw — 401s every
+      // claim and release, while the unauthenticated /check still returns
+      // 200. Only the signed endpoints can catch this.
+      test('a non-canonical base still signs the URL it posts to', () async {
+        when(
+          () => nostrClient.createNip98AuthHeader(
+            url: any(named: 'url'),
+            method: any(named: 'method'),
+            payload: any(named: 'payload'),
+          ),
+        ).thenAnswer((_) async => 'Nostr fake');
+        when(
+          () => httpClient.post(
+            any(),
+            headers: any(named: 'headers'),
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer((_) async => Response('{}', 500));
+
+        await buildRepository(
+          nameServerBaseUrl: 'https://NAMES.TEST.example:443',
+        ).claimUsername(username: 'alice');
+
+        final signed =
+            verify(
+                  () => nostrClient.createNip98AuthHeader(
+                    url: captureAny(named: 'url'),
+                    method: any(named: 'method'),
+                    payload: any(named: 'payload'),
+                  ),
+                ).captured.single
+                as String;
+        final posted =
+            verify(
+                  () => httpClient.post(
+                    captureAny(),
+                    headers: any(named: 'headers'),
+                    body: any(named: 'body'),
+                  ),
+                ).captured.single
+                as Uri;
+
+        expect(signed, equals(posted.toString()));
+        expect(signed, equals('$_testNameServer/api/username/claim'));
+      });
     });
   });
 }

--- a/mobile/packages/profile_repository/test/src/profile_repository_pending_save_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_pending_save_test.dart
@@ -43,7 +43,7 @@ void main() {
         'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2';
 
     setUpAll(() {
-      registerFallbackValue(Uri.parse('https://names.divine.video'));
+      registerFallbackValue(Uri.parse('https://names.test.example'));
       registerFallbackValue(<String, dynamic>{});
       registerFallbackValue(
         UserProfile(

--- a/mobile/packages/profile_repository/test/src/profile_repository_pending_save_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_pending_save_test.dart
@@ -29,6 +29,8 @@ class _MockEvent extends Mock implements Event {
   List<List<String>> get tags => const [];
 }
 
+const _testNameServer = 'https://names.test.example';
+
 void main() {
   group('ProfileRepository pending-save slot (#3161)', () {
     late _MockNostrClient nostrClient;
@@ -43,7 +45,7 @@ void main() {
         'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2';
 
     setUpAll(() {
-      registerFallbackValue(Uri.parse('https://names.test.example'));
+      registerFallbackValue(Uri.parse(_testNameServer));
       registerFallbackValue(<String, dynamic>{});
       registerFallbackValue(
         UserProfile(
@@ -66,6 +68,7 @@ void main() {
         userProfilesDao: userProfilesDao,
         httpClient: httpClient,
         pendingProfileSavesDao: slotDao,
+        nameServerBaseUrl: _testNameServer,
       );
 
       event = _MockEvent();

--- a/mobile/packages/profile_repository/test/src/profile_repository_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_test.dart
@@ -36,6 +36,15 @@ class MockVanishedProfilesDao extends Mock implements VanishedProfilesDao {}
 
 class MockIdentityEventsDao extends Mock implements IdentityEventsDao {}
 
+/// Injected endpoints for the username tests.
+///
+/// Deliberately not the production hosts: these tests must prove the
+/// repository uses the *injected* endpoints, which a production literal
+/// cannot distinguish from the default. Distinct per backend so a call site
+/// that reads the wrong one fails loudly.
+const _testNameServer = 'https://names.test.example';
+const _testKeycastNip05 = 'https://login.test.example/.well-known/nostr.json';
+
 void main() {
   group('ProfileRepository', () {
     late MockNostrClient mockNostrClient;
@@ -77,6 +86,8 @@ void main() {
         nostrClient: mockNostrClient,
         userProfilesDao: mockUserProfilesDao,
         httpClient: mockHttpClient,
+        nameServerBaseUrl: _testNameServer,
+        keycastNip05Url: _testKeycastNip05,
       );
 
       // The publish seed falls back to the signing key when the caller
@@ -5243,7 +5254,7 @@ void main() {
         ).captured;
         expect(
           (captured[0] as Uri).toString(),
-          equals('https://names.divine.video/api/username/release'),
+          equals('$_testNameServer/api/username/release'),
         );
         expect(captured[1], equals(jsonEncode({'name': 'alice'})));
       });
@@ -5425,7 +5436,7 @@ void main() {
                 as Uri;
         expect(
           captured.toString(),
-          equals('https://names.divine.video/api/username/by-pubkey/$pubkey'),
+          equals('$_testNameServer/api/username/by-pubkey/$pubkey'),
         );
       });
 
@@ -5772,7 +5783,7 @@ void main() {
           expect(result, equals(const UsernameClaimSuccess()));
           verify(
             () => mockHttpClient.post(
-              Uri.parse('https://names.divine.video/api/username/claim'),
+              Uri.parse('$_testNameServer/api/username/claim'),
               headers: any(named: 'headers'),
               body: expectedPayload,
             ),
@@ -5942,7 +5953,7 @@ void main() {
         when(
           () => mockHttpClient.get(
             Uri.parse(
-              'https://names.divine.video/api/username/check/$username',
+              '$_testNameServer/api/username/check/$username',
             ),
           ),
         ).thenAnswer(
@@ -5966,7 +5977,7 @@ void main() {
         when(
           () => mockHttpClient.get(
             Uri.parse(
-              'https://login.divine.video/.well-known/nostr.json'
+              '$_testKeycastNip05'
               '?name=$username',
             ),
           ),
@@ -6025,7 +6036,7 @@ void main() {
         when(
           () => mockHttpClient.get(
             Uri.parse(
-              'https://login.divine.video/.well-known/nostr.json'
+              '$_testKeycastNip05'
               '?name=testuser',
             ),
           ),
@@ -6062,7 +6073,7 @@ void main() {
         );
         verifyNever(
           () => mockHttpClient.get(
-            Uri.parse('https://names.divine.video/api/username/check/ab'),
+            Uri.parse('$_testNameServer/api/username/check/ab'),
           ),
         );
       });
@@ -6103,7 +6114,7 @@ void main() {
       test('returns UsernameCheckError when name-server returns 500', () async {
         when(
           () => mockHttpClient.get(
-            Uri.parse('https://names.divine.video/api/username/check/testuser'),
+            Uri.parse('$_testNameServer/api/username/check/testuser'),
           ),
         ).thenAnswer((_) async => Response('Server error', 500));
 
@@ -6124,7 +6135,7 @@ void main() {
       test('returns UsernameCheckError on network exception', () async {
         when(
           () => mockHttpClient.get(
-            Uri.parse('https://names.divine.video/api/username/check/testuser'),
+            Uri.parse('$_testNameServer/api/username/check/testuser'),
           ),
         ).thenThrow(Exception('Connection timeout'));
 
@@ -6154,7 +6165,7 @@ void main() {
 
         verify(
           () => mockHttpClient.get(
-            Uri.parse('https://names.divine.video/api/username/check/alice'),
+            Uri.parse('$_testNameServer/api/username/check/alice'),
           ),
         ).called(1);
       });
@@ -6262,7 +6273,7 @@ void main() {
         // Simulate the name-server returning pubkey for an active name
         when(
           () => mockHttpClient.get(
-            Uri.parse('https://names.divine.video/api/username/check/vipuser'),
+            Uri.parse('$_testNameServer/api/username/check/vipuser'),
           ),
         ).thenAnswer(
           (_) async => Response(
@@ -6289,7 +6300,7 @@ void main() {
           'current user', () async {
         when(
           () => mockHttpClient.get(
-            Uri.parse('https://names.divine.video/api/username/check/vipuser'),
+            Uri.parse('$_testNameServer/api/username/check/vipuser'),
           ),
         ).thenAnswer(
           (_) async => Response(
@@ -6316,7 +6327,7 @@ void main() {
           'provided (backwards compatible)', () async {
         when(
           () => mockHttpClient.get(
-            Uri.parse('https://names.divine.video/api/username/check/vipuser'),
+            Uri.parse('$_testNameServer/api/username/check/vipuser'),
           ),
         ).thenAnswer(
           (_) async => Response(
@@ -6343,7 +6354,7 @@ void main() {
           when(
             () => mockHttpClient.get(
               Uri.parse(
-                'https://names.divine.video/api/username/check/testuser',
+                '$_testNameServer/api/username/check/testuser',
               ),
             ),
           ).thenAnswer((_) async {


### PR DESCRIPTION
Closes #3367.

## What

#3367 asked for `ProfileRepository`'s hardcoded name-server and Keycast NIP-05 URLs to become injectable. PR #7167 shipped the injection and merged, but left the issue open on purpose — its own description says *"Existing username tests are not all migrated to injected URLs yet, so #3367 remains open."* This finishes that, and fixes a defect found inside the injection surface itself.

Three commits: the original two commits are independently revertable, and the third is a takeover follow-up that retargets the local-stack TODO to #7692 and wires the pending-save test repository to the injected name-server base.

## 1. `fix(profile)`: canonicalize injected endpoints so NIP-98 signing holds

Three strings have to agree and only two were normalized:

| stage | string | normalized? |
|---|---|---|
| signed `u` tag | `createNip98AuthHeader` signs the base verbatim (`nostr_client.dart:1775`) | no |
| wire URL | `http.post(Uri.parse(...))` | yes, by `Uri` |
| server check | `urlTag[1] !== new URL(req.url).toString()` (divine-name-server `src/middleware/nip98.ts:128`, `src/routes/username.ts:430`) | normalizes its side, compares raw |

NIP-98 §43 requires the `u` tag to be exactly the absolute request URL, and the server enforces that with `!==`. `_stripTrailingSlash` only handled a trailing slash, so a non-canonical injected base made the signed string and the wire URL diverge.

Measured — Node and Dart normalize identically, 7/7:

| injected base | what changes | result |
|---|---|---|
| `https://NAMES.divine.video` | host lowercased | **401 on claim + release** |
| `https://names.divine.video:443` | default port dropped | **401 on claim + release** |
| `https://names.divine.video/.` | dot segment resolved | **401 on claim + release** |
| `http://localhost:8787` | nothing | ok — non-default ports are preserved |

The nasty part is that `/check` and `/by-pubkey` are unauthenticated GETs, so they keep working: the symptom is "availability works, claiming is broken", which is a misleading thing to debug.

`_normalizeEndpoint` canonicalizes first, then strips. Order matters — canonicalization can reintroduce a trailing slash (`https://x/.` → `https://x/`), and `Uri.parse` alone does not subsume the strip. Verified that `.well-known` survives (it is a path segment, not a dot segment), so the Keycast default is byte-identical.

**No production impact.** Both shipped defaults are already canonical; the two `production defaults` tests fail loudly if that ever stops being true.

One behavior change worth naming: `Uri.parse` throws on a genuinely malformed base. Measured, it is permissive — of 8 malformed inputs it throws on 3 (illegal scheme char, empty scheme, unclosed IPv6 bracket); `''`, `'not a url'` and a scheme-less host all pass through. No shipped call site passes malformed input, and failing at construction beats a mystery 401 later.

## 2. `test(profile)`: assert injected endpoints instead of production URLs

Acceptance criterion 4. Sixteen sites asserted the production hosts, so they could not distinguish "used the injected endpoint" from "used the default" — the one thing the parameters exist to make testable.

Smaller than it looks: all 14 sites in `profile_repository_test.dart` are served by a **single shared `setUp` repository**, so it is one construction change plus the literals. The file has 67 `ProfileRepository(` occurrences but the only other one in the username range belongs to a search test. The two sibling files get the same treatment.

Fakes are distinct per backend (`names.test.example` vs `login.test.example`) so a call site reading the wrong endpoint fails loudly instead of passing by coincidence.

**Deliberately not migrated:** the two `production defaults` tests in `profile_repository_endpoints_test.dart`. They assert the shipped constants against production literals and are what makes acceptance criterion 1 falsifiable.

## Acceptance criteria

- [x] Production URLs remain the app default
- [x] Tests can inject fake username/check/NIP-05 endpoints
- [x] No package-level production endpoint constants required by repository internals — every internal read goes through the injected fields
- [x] Existing username tests assert injected URLs instead of production URLs

## Verification

- `profile_repository`: **446 tests pass, coverage 1180/1180 = 100.0000 %** (the package is gated at 100 with zero headroom)
- The new NIP-98 test was **mutation-checked**: reverting the fix turns exactly that test red (`+8 -1`) and leaves the other 8 green
- `dart analyze lib test` clean in the package; `flutter analyze lib test integration_test` clean from `mobile/`; format clean
- Registry probes were read-only GETs. No claim or release was issued against production.

## Follow-ups filed, deliberately not ridden on this PR

- #7690 — `verifier_client` carries the identical NIP-98 normalization defect
- #7691 — a LOCAL build writes to the production username registry
- #7692 — add divine-name-server to local_stack (takes over the `TODO(e2e)` that named #3367)
- #7693 — the Keycast and name-server username namespaces can hold different pubkeys under one handle

