### PR TITLE
feat(feed): say whether a failed feed is our outage or your network

### DIFF
--- a/.github/workflows/divine_status_client.yaml
+++ b/.github/workflows/divine_status_client.yaml
@@ -1,0 +1,27 @@
+# ABOUTME: CI workflow for the divine_status_client package.
+# ABOUTME: Runs tests, formatting, and analysis only when its files change.
+
+name: Divine Status Client CI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "mobile/packages/divine_status_client/**"
+      - ".github/workflows/divine_status_client.yaml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "mobile/packages/divine_status_client/**"
+      - ".github/workflows/divine_status_client.yaml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
+    with:
+      working_directory: "mobile/packages/divine_status_client"
+      flutter_version: "3.44.0"

--- a/mobile/lib/blocs/outage_notice/outage_notice_cubit.dart
+++ b/mobile/lib/blocs/outage_notice/outage_notice_cubit.dart
@@ -1,0 +1,43 @@
+// ABOUTME: Diagnoses a failed load so the failure view can explain itself
+// ABOUTME: Runs only while a failure is on screen, never in the background
+
+import 'package:bloc/bloc.dart';
+import 'package:equatable/equatable.dart';
+import 'package:openvine/blocs/close_guard.dart';
+import 'package:openvine/services/outage_diagnosis_service.dart';
+
+part 'outage_notice_state.dart';
+
+/// Explains why a surface failed to load.
+///
+/// Constructed by the failure view itself, so the status page is consulted
+/// only when a user is already looking at a failure — never on a healthy
+/// session, and never for a subsystem the user is not using.
+class OutageNoticeCubit extends Cubit<OutageNoticeState>
+    with CloseGuardedEmit<OutageNoticeState> {
+  OutageNoticeCubit({
+    required OutageDiagnosisService diagnosisService,
+    this.components = OutageDiagnosisService.feedComponents,
+  }) : _diagnosisService = diagnosisService,
+       super(const OutageNoticeState());
+
+  final OutageDiagnosisService _diagnosisService;
+
+  /// Status-page components this surface actually depends on.
+  final List<String> components;
+
+  Future<void> diagnose() async {
+    final diagnosis = await _diagnosisService.diagnose(components: components);
+
+    emitIfOpen(
+      OutageNoticeState(
+        status: switch (diagnosis.verdict) {
+          OutageVerdict.divineOutage => OutageNoticeStatus.divineOutage,
+          OutageVerdict.noConnection => OutageNoticeStatus.noConnection,
+          OutageVerdict.indeterminate => OutageNoticeStatus.indeterminate,
+        },
+        operatorMessage: diagnosis.operatorMessage,
+      ),
+    );
+  }
+}

--- a/mobile/lib/blocs/outage_notice/outage_notice_cubit.dart
+++ b/mobile/lib/blocs/outage_notice/outage_notice_cubit.dart
@@ -27,7 +27,16 @@ class OutageNoticeCubit extends Cubit<OutageNoticeState>
   final List<String> components;
 
   Future<void> diagnose() async {
-    final diagnosis = await _diagnosisService.diagnose(components: components);
+    final OutageDiagnosis diagnosis;
+    try {
+      diagnosis = await _diagnosisService.diagnose(components: components);
+    } on Object catch (error, stackTrace) {
+      addError(error, stackTrace);
+      emitIfOpen(
+        const OutageNoticeState(status: OutageNoticeStatus.indeterminate),
+      );
+      return;
+    }
 
     emitIfOpen(
       OutageNoticeState(

--- a/mobile/lib/blocs/outage_notice/outage_notice_state.dart
+++ b/mobile/lib/blocs/outage_notice/outage_notice_state.dart
@@ -1,0 +1,31 @@
+part of 'outage_notice_cubit.dart';
+
+/// What the failure view should say.
+enum OutageNoticeStatus {
+  /// Diagnosis has not finished; keep the generic failure copy.
+  checking,
+
+  /// The status page corroborates an outage on our side.
+  divineOutage,
+
+  /// The device cannot reach anything, including a host on another CDN.
+  noConnection,
+
+  /// Nothing explains the failure; stay generic.
+  indeterminate,
+}
+
+final class OutageNoticeState extends Equatable {
+  const OutageNoticeState({
+    this.status = OutageNoticeStatus.checking,
+    this.operatorMessage,
+  });
+
+  final OutageNoticeStatus status;
+
+  /// The on-call operator's own words, when the status page carried any.
+  final String? operatorMessage;
+
+  @override
+  List<Object?> get props => [status, operatorMessage];
+}

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -5339,5 +5339,7 @@
   "socialProofFollowsYou": "ይከተልዎታል",
   "socialProofYouFollow": "ይከተላሉ",
   "socialProofFollowerCount": "{count, plural, =1{{formattedCount} ተከታይ} other{{formattedCount} ተከታዮች}}",
-  "searchUserVideoCount": "{count, plural, =1{{formattedCount} ቪዲዮ} other{{formattedCount} ቪዲዮዎች}}"
+  "searchUserVideoCount": "{count, plural, =1{{formattedCount} ቪዲዮ} other{{formattedCount} ቪዲዮዎች}}",
+  "feedOutageMessage": "ቪዲዮዎች አሁን እየተጫኑ አይደሉም።\nችግሩ የእኛ ነው፤ እየሠራንበት ነው።",
+  "feedOfflineMessage": "ከመስመር ውጭ ነዎት።\nግንኙነትዎን አረጋግጠው እንደገና ይሞክሩ።"
 }

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -5214,5 +5214,7 @@
   "socialProofFollowsYou": "يتابعك",
   "socialProofYouFollow": "تتابعه",
   "socialProofFollowerCount": "{count, plural, =1{{formattedCount} متابِع} other{{formattedCount} متابِع}}",
-  "searchUserVideoCount": "{count, plural, =1{{formattedCount} فيديو} other{{formattedCount} فيديو}}"
+  "searchUserVideoCount": "{count, plural, =1{{formattedCount} فيديو} other{{formattedCount} فيديو}}",
+  "feedOutageMessage": "الفيديوهات لا تُحمَّل الآن.\nالمشكلة من عندنا، ونحن نصلحها.",
+  "feedOfflineMessage": "أنت غير متصل.\nتحقق من اتصالك وحاول مرة أخرى."
 }

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -5345,5 +5345,7 @@
   "socialProofFollowsYou": "Следва те",
   "socialProofYouFollow": "Следваш",
   "socialProofFollowerCount": "{count, plural, =1{{formattedCount} последовател} other{{formattedCount} последователи}}",
-  "searchUserVideoCount": "{count, plural, =1{{formattedCount} видео} other{{formattedCount} видеа}}"
+  "searchUserVideoCount": "{count, plural, =1{{formattedCount} видео} other{{formattedCount} видеа}}",
+  "feedOutageMessage": "Видеата не се зареждат в момента.\nПроблемът е от нас и вече го оправяме.",
+  "feedOfflineMessage": "Няма връзка с интернет.\nПровери връзката си и опитай пак."
 }

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -5214,5 +5214,7 @@
   "socialProofFollowsYou": "Folgt dir",
   "socialProofYouFollow": "Du folgst",
   "socialProofFollowerCount": "{count, plural, =1{{formattedCount} Follower} other{{formattedCount} Follower}}",
-  "searchUserVideoCount": "{count, plural, =1{{formattedCount} Video} other{{formattedCount} Videos}}"
+  "searchUserVideoCount": "{count, plural, =1{{formattedCount} Video} other{{formattedCount} Videos}}",
+  "feedOutageMessage": "Videos laden gerade nicht.\nDas liegt an uns, nicht an dir – wir sind dran.",
+  "feedOfflineMessage": "Du bist offline.\nPrüfe deine Verbindung und versuch es nochmal."
 }

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -7585,5 +7585,13 @@
         "type": "String"
       }
     }
+  },
+  "feedOutageMessage": "Videos aren't loading right now.\nIt's us, not you — we're on it.",
+  "@feedOutageMessage": {
+    "description": "Shown on the video feed when the Divine status page confirms a component the feed depends on is impaired. Says plainly that the fault is ours."
+  },
+  "feedOfflineMessage": "You're offline.\nCheck your connection and try again.",
+  "@feedOfflineMessage": {
+    "description": "Shown on the video feed when the device has no network, or when even the status page (on a different CDN) is unreachable."
   }
 }

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -5214,5 +5214,7 @@
   "socialProofFollowsYou": "Te sigue",
   "socialProofYouFollow": "Siguiendo",
   "socialProofFollowerCount": "{count, plural, =1{{formattedCount} seguidor} other{{formattedCount} seguidores}}",
-  "searchUserVideoCount": "{count, plural, =1{{formattedCount} video} other{{formattedCount} videos}}"
+  "searchUserVideoCount": "{count, plural, =1{{formattedCount} video} other{{formattedCount} videos}}",
+  "feedOutageMessage": "Los videos no se están cargando.\nEs cosa nuestra, no tuya: ya estamos en ello.",
+  "feedOfflineMessage": "Estás sin conexión.\nRevisa tu conexión e inténtalo de nuevo."
 }

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -3808,5 +3808,7 @@
   "socialProofFollowsYou": "Sinusundan ka",
   "socialProofYouFollow": "Sinusundan mo",
   "socialProofFollowerCount": "{count, plural, =1{{formattedCount} follower} other{{formattedCount} follower}}",
-  "searchUserVideoCount": "{count, plural, =1{{formattedCount} video} other{{formattedCount} video}}"
+  "searchUserVideoCount": "{count, plural, =1{{formattedCount} video} other{{formattedCount} video}}",
+  "feedOutageMessage": "Hindi nagloload ang mga video ngayon.\nSa amin ito, hindi sa iyo — inaayos na namin.",
+  "feedOfflineMessage": "Offline ka.\nTingnan ang koneksyon mo at subukan ulit."
 }

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -5214,5 +5214,7 @@
   "socialProofFollowsYou": "Te suit",
   "socialProofYouFollow": "Tu suis",
   "socialProofFollowerCount": "{count, plural, =1{{formattedCount} abonné} other{{formattedCount} abonnés}}",
-  "searchUserVideoCount": "{count, plural, =1{{formattedCount} vidéo} other{{formattedCount} vidéos}}"
+  "searchUserVideoCount": "{count, plural, =1{{formattedCount} vidéo} other{{formattedCount} vidéos}}",
+  "feedOutageMessage": "Les vidéos ne se chargent pas pour le moment.\nÇa vient de nous, pas de vous — on s'en occupe.",
+  "feedOfflineMessage": "Vous êtes hors ligne.\nVérifiez votre connexion et réessayez."
 }

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -5214,5 +5214,7 @@
   "socialProofFollowsYou": "Mengikuti kamu",
   "socialProofYouFollow": "Kamu ikuti",
   "socialProofFollowerCount": "{count, plural, other{{formattedCount} pengikut}}",
-  "searchUserVideoCount": "{count, plural, other{{formattedCount} video}}"
+  "searchUserVideoCount": "{count, plural, other{{formattedCount} video}}",
+  "feedOutageMessage": "Video sedang tidak bisa dimuat.\nIni dari kami, bukan kamu — sedang kami perbaiki.",
+  "feedOfflineMessage": "Kamu sedang offline.\nPeriksa koneksimu lalu coba lagi."
 }

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -5214,5 +5214,7 @@
   "socialProofFollowsYou": "Ti segue",
   "socialProofYouFollow": "Segui già",
   "socialProofFollowerCount": "{count, plural, =1{{formattedCount} follower} other{{formattedCount} follower}}",
-  "searchUserVideoCount": "{count, plural, =1{{formattedCount} video} other{{formattedCount} video}}"
+  "searchUserVideoCount": "{count, plural, =1{{formattedCount} video} other{{formattedCount} video}}",
+  "feedOutageMessage": "I video non si caricano al momento.\nDipende da noi, non da te — ci stiamo lavorando.",
+  "feedOfflineMessage": "Sei offline.\nControlla la connessione e riprova."
 }

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -5214,5 +5214,7 @@
   "socialProofFollowsYou": "フォローされています",
   "socialProofYouFollow": "フォロー中",
   "socialProofFollowerCount": "{count, plural, other{フォロワー{formattedCount}人}}",
-  "searchUserVideoCount": "{count, plural, other{{formattedCount}本の動画}}"
+  "searchUserVideoCount": "{count, plural, other{{formattedCount}本の動画}}",
+  "feedOutageMessage": "いま動画を読み込めません。\nこちらの不具合だよ。すぐ直すね。",
+  "feedOfflineMessage": "オフラインだよ。\n接続を確認して、もう一度試してね。"
 }

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -4560,5 +4560,7 @@
   "socialProofFollowsYou": "나를 팔로우함",
   "socialProofYouFollow": "팔로우 중",
   "socialProofFollowerCount": "{count, plural, other{팔로워 {formattedCount}명}}",
-  "searchUserVideoCount": "{count, plural, other{영상 {formattedCount}개}}"
+  "searchUserVideoCount": "{count, plural, other{영상 {formattedCount}개}}",
+  "feedOutageMessage": "지금 영상을 불러올 수 없어요.\n저희 문제예요. 고치는 중이에요.",
+  "feedOfflineMessage": "오프라인 상태예요.\n연결을 확인하고 다시 시도해 주세요."
 }

--- a/mobile/lib/l10n/app_ms.arb
+++ b/mobile/lib/l10n/app_ms.arb
@@ -7044,5 +7044,7 @@
   "socialProofFollowsYou": "Mengikuti anda",
   "socialProofYouFollow": "Anda ikuti",
   "socialProofFollowerCount": "{count, plural, other{{formattedCount} pengikut}}",
-  "searchUserVideoCount": "{count, plural, other{{formattedCount} video}}"
+  "searchUserVideoCount": "{count, plural, other{{formattedCount} video}}",
+  "feedOutageMessage": "Video tidak dapat dimuatkan sekarang.\nIni masalah kami, bukan anda — kami sedang membaikinya.",
+  "feedOfflineMessage": "Anda di luar talian.\nSemak sambungan anda dan cuba lagi."
 }

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -5214,5 +5214,7 @@
   "socialProofFollowsYou": "Volgt jou",
   "socialProofYouFollow": "Jij volgt",
   "socialProofFollowerCount": "{count, plural, =1{{formattedCount} volger} other{{formattedCount} volgers}}",
-  "searchUserVideoCount": "{count, plural, =1{{formattedCount} video} other{{formattedCount} video''s}}"
+  "searchUserVideoCount": "{count, plural, =1{{formattedCount} video} other{{formattedCount} video''s}}",
+  "feedOutageMessage": "Er laden nu geen video's.\nHet ligt aan ons, niet aan jou — we zijn ermee bezig.",
+  "feedOfflineMessage": "Je bent offline.\nControleer je verbinding en probeer het opnieuw."
 }

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -5214,5 +5214,7 @@
   "socialProofFollowsYou": "Obserwuje Cię",
   "socialProofYouFollow": "Obserwujesz",
   "socialProofFollowerCount": "{count, plural, =1{{formattedCount} obserwujący} few{{formattedCount} obserwujących} many{{formattedCount} obserwujących} other{{formattedCount} obserwujących}}",
-  "searchUserVideoCount": "{count, plural, =1{{formattedCount} film} few{{formattedCount} filmy} many{{formattedCount} filmów} other{{formattedCount} filmu}}"
+  "searchUserVideoCount": "{count, plural, =1{{formattedCount} film} few{{formattedCount} filmy} many{{formattedCount} filmów} other{{formattedCount} filmu}}",
+  "feedOutageMessage": "Filmy się teraz nie ładują.\nTo po naszej stronie — już to naprawiamy.",
+  "feedOfflineMessage": "Jesteś offline.\nSprawdź połączenie i spróbuj ponownie."
 }

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -5214,5 +5214,7 @@
   "socialProofFollowsYou": "Segue você",
   "socialProofYouFollow": "Você segue",
   "socialProofFollowerCount": "{count, plural, =1{{formattedCount} seguidor} other{{formattedCount} seguidores}}",
-  "searchUserVideoCount": "{count, plural, =1{{formattedCount} vídeo} other{{formattedCount} vídeos}}"
+  "searchUserVideoCount": "{count, plural, =1{{formattedCount} vídeo} other{{formattedCount} vídeos}}",
+  "feedOutageMessage": "Os vídeos não estão carregando.\nO problema é nosso, não seu — já estamos resolvendo.",
+  "feedOfflineMessage": "Você está offline.\nVerifique sua conexão e tente de novo."
 }

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -5214,5 +5214,7 @@
   "socialProofFollowsYou": "Te urmărește",
   "socialProofYouFollow": "Urmărești",
   "socialProofFollowerCount": "{count, plural, =1{{formattedCount} urmăritor} other{{formattedCount} urmăritori}}",
-  "searchUserVideoCount": "{count, plural, =1{{formattedCount} videoclip} other{{formattedCount} videoclipuri}}"
+  "searchUserVideoCount": "{count, plural, =1{{formattedCount} videoclip} other{{formattedCount} videoclipuri}}",
+  "feedOutageMessage": "Videoclipurile nu se încarcă acum.\nE de la noi, nu de la tine — lucrăm la asta.",
+  "feedOfflineMessage": "Ești offline.\nVerifică-ți conexiunea și încearcă din nou."
 }

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -5214,5 +5214,7 @@
   "socialProofFollowsYou": "Följer dig",
   "socialProofYouFollow": "Du följer",
   "socialProofFollowerCount": "{count, plural, =1{{formattedCount} följare} other{{formattedCount} följare}}",
-  "searchUserVideoCount": "{count, plural, =1{{formattedCount} video} other{{formattedCount} videor}}"
+  "searchUserVideoCount": "{count, plural, =1{{formattedCount} video} other{{formattedCount} videor}}",
+  "feedOutageMessage": "Videor laddas inte just nu.\nDet är vårt fel, inte ditt – vi jobbar på det.",
+  "feedOfflineMessage": "Du är offline.\nKolla din anslutning och försök igen."
 }

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -5214,5 +5214,7 @@
   "socialProofFollowsYou": "Seni takip ediyor",
   "socialProofYouFollow": "Takip ediyorsun",
   "socialProofFollowerCount": "{count, plural, other{{formattedCount} takipçi}}",
-  "searchUserVideoCount": "{count, plural, other{{formattedCount} video}}"
+  "searchUserVideoCount": "{count, plural, other{{formattedCount} video}}",
+  "feedOutageMessage": "Videolar şu anda yüklenmiyor.\nSorun bizde, sende değil — üzerinde çalışıyoruz.",
+  "feedOfflineMessage": "Çevrimdışısın.\nBağlantını kontrol edip tekrar dene."
 }

--- a/mobile/lib/l10n/app_ur.arb
+++ b/mobile/lib/l10n/app_ur.arb
@@ -7044,5 +7044,7 @@
   "socialProofFollowsYou": "آپ کو فالو کرتا ہے",
   "socialProofYouFollow": "آپ فالو کرتے ہیں",
   "socialProofFollowerCount": "{count, plural, =1{{formattedCount} فالوور} other{{formattedCount} فالوورز}}",
-  "searchUserVideoCount": "{count, plural, =1{{formattedCount} ویڈیو} other{{formattedCount} ویڈیوز}}"
+  "searchUserVideoCount": "{count, plural, =1{{formattedCount} ویڈیو} other{{formattedCount} ویڈیوز}}",
+  "feedOutageMessage": "ابھی ویڈیوز لوڈ نہیں ہو رہیں۔\nمسئلہ ہماری طرف سے ہے، ہم اسے ٹھیک کر رہے ہیں۔",
+  "feedOfflineMessage": "آپ آف لائن ہیں۔\nاپنا کنکشن چیک کریں اور دوبارہ کوشش کریں۔"
 }

--- a/mobile/lib/l10n/app_vi.arb
+++ b/mobile/lib/l10n/app_vi.arb
@@ -7044,5 +7044,7 @@
   "socialProofFollowsYou": "Đang theo dõi bạn",
   "socialProofYouFollow": "Bạn đang theo dõi",
   "socialProofFollowerCount": "{count, plural, other{{formattedCount} người theo dõi}}",
-  "searchUserVideoCount": "{count, plural, other{{formattedCount} video}}"
+  "searchUserVideoCount": "{count, plural, other{{formattedCount} video}}",
+  "feedOutageMessage": "Hiện không tải được video.\nLỗi từ phía chúng tôi — chúng tôi đang khắc phục.",
+  "feedOfflineMessage": "Bạn đang ngoại tuyến.\nKiểm tra kết nối rồi thử lại."
 }

--- a/mobile/lib/l10n/app_zh.arb
+++ b/mobile/lib/l10n/app_zh.arb
@@ -7044,5 +7044,7 @@
   "socialProofFollowsYou": "关注了你",
   "socialProofYouFollow": "已关注",
   "socialProofFollowerCount": "{count, plural, other{{formattedCount} 位粉丝}}",
-  "searchUserVideoCount": "{count, plural, other{{formattedCount} 条视频}}"
+  "searchUserVideoCount": "{count, plural, other{{formattedCount} 条视频}}",
+  "feedOutageMessage": "视频暂时加载不出来。\n是我们的问题，正在修复。",
+  "feedOfflineMessage": "你当前处于离线状态。\n请检查网络后重试。"
 }

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -20679,6 +20679,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'{count, plural, =1{{formattedCount} follower} other{{formattedCount} followers}}'**
   String socialProofFollowerCount(int count, String formattedCount);
+
+  /// Shown on the video feed when the Divine status page confirms a component the feed depends on is impaired. Says plainly that the fault is ours.
+  ///
+  /// In en, this message translates to:
+  /// **'Videos aren\'t loading right now.\nIt\'s us, not you — we\'re on it.'**
+  String get feedOutageMessage;
+
+  /// Shown on the video feed when the device has no network, or when even the status page (on a different CDN) is unreachable.
+  ///
+  /// In en, this message translates to:
+  /// **'You\'re offline.\nCheck your connection and try again.'**
+  String get feedOfflineMessage;
 }
 
 class _AppLocalizationsDelegate

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -11842,4 +11842,11 @@ class AppLocalizationsAm extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get feedOutageMessage =>
+      'ቪዲዮዎች አሁን እየተጫኑ አይደሉም።\nችግሩ የእኛ ነው፤ እየሠራንበት ነው።';
+
+  @override
+  String get feedOfflineMessage => 'ከመስመር ውጭ ነዎት።\nግንኙነትዎን አረጋግጠው እንደገና ይሞክሩ።';
 }

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -12065,4 +12065,12 @@ class AppLocalizationsAr extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get feedOutageMessage =>
+      'الفيديوهات لا تُحمَّل الآن.\nالمشكلة من عندنا، ونحن نصلحها.';
+
+  @override
+  String get feedOfflineMessage =>
+      'أنت غير متصل.\nتحقق من اتصالك وحاول مرة أخرى.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -12278,4 +12278,12 @@ class AppLocalizationsBg extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get feedOutageMessage =>
+      'Видеата не се зареждат в момента.\nПроблемът е от нас и вече го оправяме.';
+
+  @override
+  String get feedOfflineMessage =>
+      'Няма връзка с интернет.\nПровери връзката си и опитай пак.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -12311,4 +12311,12 @@ class AppLocalizationsDe extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get feedOutageMessage =>
+      'Videos laden gerade nicht.\nDas liegt an uns, nicht an dir – wir sind dran.';
+
+  @override
+  String get feedOfflineMessage =>
+      'Du bist offline.\nPrüfe deine Verbindung und versuch es nochmal.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -12107,4 +12107,12 @@ class AppLocalizationsEn extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get feedOutageMessage =>
+      'Videos aren\'t loading right now.\nIt\'s us, not you — we\'re on it.';
+
+  @override
+  String get feedOfflineMessage =>
+      'You\'re offline.\nCheck your connection and try again.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -12293,4 +12293,12 @@ class AppLocalizationsEs extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get feedOutageMessage =>
+      'Los videos no se están cargando.\nEs cosa nuestra, no tuya: ya estamos en ello.';
+
+  @override
+  String get feedOfflineMessage =>
+      'Estás sin conexión.\nRevisa tu conexión e inténtalo de nuevo.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -12309,4 +12309,12 @@ class AppLocalizationsFil extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get feedOutageMessage =>
+      'Hindi nagloload ang mga video ngayon.\nSa amin ito, hindi sa iyo — inaayos na namin.';
+
+  @override
+  String get feedOfflineMessage =>
+      'Offline ka.\nTingnan ang koneksyon mo at subukan ulit.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -12340,4 +12340,12 @@ class AppLocalizationsFr extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get feedOutageMessage =>
+      'Les vidéos ne se chargent pas pour le moment.\nÇa vient de nous, pas de vous — on s\'en occupe.';
+
+  @override
+  String get feedOfflineMessage =>
+      'Vous êtes hors ligne.\nVérifiez votre connexion et réessayez.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -12104,4 +12104,12 @@ class AppLocalizationsId extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get feedOutageMessage =>
+      'Video sedang tidak bisa dimuat.\nIni dari kami, bukan kamu — sedang kami perbaiki.';
+
+  @override
+  String get feedOfflineMessage =>
+      'Kamu sedang offline.\nPeriksa koneksimu lalu coba lagi.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -12304,4 +12304,12 @@ class AppLocalizationsIt extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get feedOutageMessage =>
+      'I video non si caricano al momento.\nDipende da noi, non da te — ci stiamo lavorando.';
+
+  @override
+  String get feedOfflineMessage =>
+      'Sei offline.\nControlla la connessione e riprova.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -11581,4 +11581,10 @@ class AppLocalizationsJa extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get feedOutageMessage => 'いま動画を読み込めません。\nこちらの不具合だよ。すぐ直すね。';
+
+  @override
+  String get feedOfflineMessage => 'オフラインだよ。\n接続を確認して、もう一度試してね。';
 }

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -11606,4 +11606,10 @@ class AppLocalizationsKo extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get feedOutageMessage => '지금 영상을 불러올 수 없어요.\n저희 문제예요. 고치는 중이에요.';
+
+  @override
+  String get feedOfflineMessage => '오프라인 상태예요.\n연결을 확인하고 다시 시도해 주세요.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -12201,4 +12201,12 @@ class AppLocalizationsMs extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get feedOutageMessage =>
+      'Video tidak dapat dimuatkan sekarang.\nIni masalah kami, bukan anda — kami sedang membaikinya.';
+
+  @override
+  String get feedOfflineMessage =>
+      'Anda di luar talian.\nSemak sambungan anda dan cuba lagi.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -12220,4 +12220,12 @@ class AppLocalizationsNl extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get feedOutageMessage =>
+      'Er laden nu geen video\'s.\nHet ligt aan ons, niet aan jou — we zijn ermee bezig.';
+
+  @override
+  String get feedOfflineMessage =>
+      'Je bent offline.\nControleer je verbinding en probeer het opnieuw.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -12399,4 +12399,12 @@ class AppLocalizationsPl extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get feedOutageMessage =>
+      'Filmy się teraz nie ładują.\nTo po naszej stronie — już to naprawiamy.';
+
+  @override
+  String get feedOfflineMessage =>
+      'Jesteś offline.\nSprawdź połączenie i spróbuj ponownie.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -12252,4 +12252,12 @@ class AppLocalizationsPt extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get feedOutageMessage =>
+      'Os vídeos não estão carregando.\nO problema é nosso, não seu — já estamos resolvendo.';
+
+  @override
+  String get feedOfflineMessage =>
+      'Você está offline.\nVerifique sua conexão e tente de novo.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -12408,4 +12408,12 @@ class AppLocalizationsRo extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get feedOutageMessage =>
+      'Videoclipurile nu se încarcă acum.\nE de la noi, nu de la tine — lucrăm la asta.';
+
+  @override
+  String get feedOfflineMessage =>
+      'Ești offline.\nVerifică-ți conexiunea și încearcă din nou.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -12159,4 +12159,12 @@ class AppLocalizationsSv extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get feedOutageMessage =>
+      'Videor laddas inte just nu.\nDet är vårt fel, inte ditt – vi jobbar på det.';
+
+  @override
+  String get feedOfflineMessage =>
+      'Du är offline.\nKolla din anslutning och försök igen.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -12118,4 +12118,12 @@ class AppLocalizationsTr extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get feedOutageMessage =>
+      'Videolar şu anda yüklenmiyor.\nSorun bizde, sende değil — üzerinde çalışıyoruz.';
+
+  @override
+  String get feedOfflineMessage =>
+      'Çevrimdışısın.\nBağlantını kontrol edip tekrar dene.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -12147,4 +12147,12 @@ class AppLocalizationsUr extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get feedOutageMessage =>
+      'ابھی ویڈیوز لوڈ نہیں ہو رہیں۔\nمسئلہ ہماری طرف سے ہے، ہم اسے ٹھیک کر رہے ہیں۔';
+
+  @override
+  String get feedOfflineMessage =>
+      'آپ آف لائن ہیں۔\nاپنا کنکشن چیک کریں اور دوبارہ کوشش کریں۔';
 }

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -12142,4 +12142,12 @@ class AppLocalizationsVi extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get feedOutageMessage =>
+      'Hiện không tải được video.\nLỗi từ phía chúng tôi — chúng tôi đang khắc phục.';
+
+  @override
+  String get feedOfflineMessage =>
+      'Bạn đang ngoại tuyến.\nKiểm tra kết nối rồi thử lại.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -11477,4 +11477,10 @@ class AppLocalizationsZh extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get feedOutageMessage => '视频暂时加载不出来。\n是我们的问题，正在修复。';
+
+  @override
+  String get feedOfflineMessage => '你当前处于离线状态。\n请检查网络后重试。';
 }

--- a/mobile/lib/providers/outage_diagnosis_provider.dart
+++ b/mobile/lib/providers/outage_diagnosis_provider.dart
@@ -1,0 +1,19 @@
+// ABOUTME: Provides the shared outage-diagnosis service
+// ABOUTME: Kept alive so its verdict cache is shared across failure surfaces
+
+import 'package:openvine/services/outage_diagnosis_service.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'outage_diagnosis_provider.g.dart';
+
+/// The app-wide [OutageDiagnosisService].
+///
+/// Kept alive so the verdict cache survives a failure view being disposed and
+/// rebuilt — a user tapping "try again" repeatedly during one incident must
+/// not turn into one status request per tap.
+@Riverpod(keepAlive: true)
+OutageDiagnosisService outageDiagnosisService(Ref ref) {
+  final service = OutageDiagnosisService();
+  ref.onDispose(service.dispose);
+  return service;
+}

--- a/mobile/lib/providers/outage_diagnosis_provider.g.dart
+++ b/mobile/lib/providers/outage_diagnosis_provider.g.dart
@@ -1,0 +1,74 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'outage_diagnosis_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// The app-wide [OutageDiagnosisService].
+///
+/// Kept alive so the verdict cache survives a failure view being disposed and
+/// rebuilt — a user tapping "try again" repeatedly during one incident must
+/// not turn into one status request per tap.
+
+@ProviderFor(outageDiagnosisService)
+final outageDiagnosisServiceProvider = OutageDiagnosisServiceProvider._();
+
+/// The app-wide [OutageDiagnosisService].
+///
+/// Kept alive so the verdict cache survives a failure view being disposed and
+/// rebuilt — a user tapping "try again" repeatedly during one incident must
+/// not turn into one status request per tap.
+
+final class OutageDiagnosisServiceProvider
+    extends
+        $FunctionalProvider<
+          OutageDiagnosisService,
+          OutageDiagnosisService,
+          OutageDiagnosisService
+        >
+    with $Provider<OutageDiagnosisService> {
+  /// The app-wide [OutageDiagnosisService].
+  ///
+  /// Kept alive so the verdict cache survives a failure view being disposed and
+  /// rebuilt — a user tapping "try again" repeatedly during one incident must
+  /// not turn into one status request per tap.
+  OutageDiagnosisServiceProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'outageDiagnosisServiceProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$outageDiagnosisServiceHash();
+
+  @$internal
+  @override
+  $ProviderElement<OutageDiagnosisService> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  OutageDiagnosisService create(Ref ref) {
+    return outageDiagnosisService(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(OutageDiagnosisService value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<OutageDiagnosisService>(value),
+    );
+  }
+}
+
+String _$outageDiagnosisServiceHash() =>
+    r'26a5b41fc25a78f8acbb3fa187b3d99e275bcff6';

--- a/mobile/lib/screens/feed/video_feed_page.dart
+++ b/mobile/lib/screens/feed/video_feed_page.dart
@@ -450,10 +450,7 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
 
                 // Error state
                 if (state.status == VideoFeedStatus.failure) {
-                  return FeedErrorWidget(
-                    error: state.error,
-                    onRetry: () => _refreshFeed(context),
-                  );
+                  return FeedErrorWidget(onRetry: () => _refreshFeed(context));
                 }
 
                 // Empty state

--- a/mobile/lib/screens/feed/video_feed_page/feed_error_widget.dart
+++ b/mobile/lib/screens/feed/video_feed_page/feed_error_widget.dart
@@ -8,7 +8,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/blocs/outage_notice/outage_notice_cubit.dart';
-import 'package:openvine/blocs/video_feed/video_feed_bloc.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/outage_diagnosis_provider.dart';
 
@@ -20,9 +19,8 @@ import 'package:openvine/providers/outage_diagnosis_provider.dart';
 /// at this screen — never in the background, and only for the components the
 /// feed itself depends on.
 class FeedErrorWidget extends ConsumerWidget {
-  const FeedErrorWidget({required this.onRetry, this.error, super.key});
+  const FeedErrorWidget({required this.onRetry, super.key});
 
-  final VideoFeedError? error;
   final Future<void> Function() onRetry;
 
   @override

--- a/mobile/lib/screens/feed/video_feed_page/feed_error_widget.dart
+++ b/mobile/lib/screens/feed/video_feed_page/feed_error_widget.dart
@@ -48,10 +48,12 @@ class FeedErrorView extends StatelessWidget {
     final state = context.watch<OutageNoticeCubit>().state;
 
     return Center(
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 32),
+      // Scrollable so a long operator message — an operator writes this, and
+      // could paste a paragraph — cannot push the Retry button off-screen or
+      // overflow the column during the incident it is explaining.
+      child: SingleChildScrollView(
+        padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 24),
         child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
           mainAxisSize: MainAxisSize.min,
           spacing: 16,
           children: [

--- a/mobile/lib/screens/feed/video_feed_page/feed_error_widget.dart
+++ b/mobile/lib/screens/feed/video_feed_page/feed_error_widget.dart
@@ -1,54 +1,108 @@
 // ABOUTME: Feed error state widget — shown when the home feed fails to load,
-// ABOUTME: with a localized message, optional detail, and a retry action.
+// ABOUTME: saying whether the fault is ours, the network's, or unknown.
 
 import 'dart:async';
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:openvine/blocs/outage_notice/outage_notice_cubit.dart';
 import 'package:openvine/blocs/video_feed/video_feed_bloc.dart';
 import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/providers/outage_diagnosis_provider.dart';
 
-/// Error state for the home video feed: a warning icon, a localized failure
-/// message, the optional underlying [error] detail, and a retry button.
-class FeedErrorWidget extends StatelessWidget {
+/// Error state for the home video feed.
+///
+/// Diagnoses the failure on mount by cross-checking the Divine status page,
+/// which is hosted away from the services it reports on and so stays
+/// reachable when they are not. The check runs only while a user is looking
+/// at this screen — never in the background, and only for the components the
+/// feed itself depends on.
+class FeedErrorWidget extends ConsumerWidget {
   const FeedErrorWidget({required this.onRetry, this.error, super.key});
 
   final VideoFeedError? error;
   final Future<void> Function() onRetry;
 
   @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final diagnosisService = ref.watch(outageDiagnosisServiceProvider);
+
+    return BlocProvider(
+      key: ValueKey(diagnosisService),
+      create: (_) =>
+          OutageNoticeCubit(diagnosisService: diagnosisService)..diagnose(),
+      child: FeedErrorView(onRetry: onRetry),
+    );
+  }
+}
+
+/// The rendered failure copy.
+@visibleForTesting
+class FeedErrorView extends StatelessWidget {
+  const FeedErrorView({required this.onRetry, super.key});
+
+  final Future<void> Function() onRetry;
+
+  @override
   Widget build(BuildContext context) {
+    final state = context.watch<OutageNoticeCubit>().state;
+
     return Center(
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          const DivineIcon(
-            icon: DivineIconName.warningCircle,
-            color: VineTheme.error,
-            size: 64,
-          ),
-          const SizedBox(height: 16),
-          Text(
-            context.l10n.feedFailedToLoadVideos,
-            style: TextStyle(
-              color: context.vineColors.primaryText,
-              fontSize: 18,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 32),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          mainAxisSize: MainAxisSize.min,
+          spacing: 16,
+          children: [
+            DivineIcon(
+              icon: switch (state.status) {
+                OutageNoticeStatus.noConnection => DivineIconName.globe,
+                _ => DivineIconName.warningCircle,
+              },
+              color: VineTheme.error,
+              size: 64,
             ),
-          ),
-          if (error != null) ...[
-            const SizedBox(height: 8),
-            Text(
-              error.toString(),
-              style: TextStyle(color: context.vineColors.mutedText),
+            ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 320),
+              child: Text(
+                _message(context, state),
+                style: VineTheme.bodyLargeFont(
+                  color: context.vineColors.primaryText,
+                ),
+                textAlign: TextAlign.center,
+              ),
+            ),
+            DivineButton(
+              label: context.l10n.feedRetry,
+              onPressed: () => unawaited(onRetry()),
             ),
           ],
-          const SizedBox(height: 24),
-          ElevatedButton(
-            onPressed: () => unawaited(onRetry()),
-            child: Text(context.l10n.feedRetry),
-          ),
-        ],
+        ),
       ),
     );
+  }
+
+  String _message(BuildContext context, OutageNoticeState state) {
+    // An operator writing "fix rolling out, ~20 min" beats any canned line, so
+    // it wins whenever the status page carries one.
+    final operatorMessage = state.operatorMessage;
+    if (state.status == OutageNoticeStatus.divineOutage &&
+        operatorMessage != null &&
+        operatorMessage.isNotEmpty) {
+      return operatorMessage;
+    }
+
+    return switch (state.status) {
+      OutageNoticeStatus.divineOutage => context.l10n.feedOutageMessage,
+      OutageNoticeStatus.noConnection => context.l10n.feedOfflineMessage,
+      // While the diagnosis runs, and whenever nothing corroborates a cause,
+      // claim nothing: a wrong "it's us" that flips a second later is worse
+      // than staying generic.
+      OutageNoticeStatus.checking ||
+      OutageNoticeStatus.indeterminate => context.l10n.feedFailedToLoadVideos,
+    };
   }
 }

--- a/mobile/lib/services/outage_diagnosis_service.dart
+++ b/mobile/lib/services/outage_diagnosis_service.dart
@@ -69,11 +69,7 @@ class OutageDiagnosisService {
   final ConnectivityProbe _connectivityProbe;
   final DateTime Function() _now;
 
-  // Keyed by component set: a verdict for [api, relay] does not answer a
-  // question about [uploads]. Sharing one entry across sets would hand a
-  // second surface the feed's verdict.
-  final Map<String, OutageDiagnosis> _cached = {};
-  final Map<String, DateTime> _cachedAt = {};
+  final Map<String, _CachedDiagnosis> _cached = {};
   final Map<String, Future<OutageDiagnosis>> _inFlight = {};
 
   /// Diagnoses why a load of [components] failed.
@@ -81,28 +77,23 @@ class OutageDiagnosisService {
   /// Concurrent callers asking about the same components share one request, so
   /// several failing surfaces do not multiply into several status fetches.
   Future<OutageDiagnosis> diagnose({List<String> components = feedComponents}) {
-    final key = _cacheKey(components);
-    final cached = _cached[key];
-    final cachedAt = _cachedAt[key];
-    if (cached != null &&
-        cachedAt != null &&
-        _now().difference(cachedAt) < cacheDuration) {
-      return Future.value(cached);
+    final cacheKey = _cacheKey(components);
+    final cached = _cached[cacheKey];
+    if (cached != null && _now().difference(cached.cachedAt) < cacheDuration) {
+      return Future.value(cached.diagnosis);
     }
 
-    return _inFlight[key] ??= _diagnose(key, components).whenComplete(() {
-      _inFlight.remove(key);
+    return _inFlight[cacheKey] ??= _diagnose(components).whenComplete(() {
+      _inFlight.remove(cacheKey);
     });
   }
 
-  /// Order-independent key for a component set.
-  static String _cacheKey(List<String> components) =>
-      (components.toSet().toList()..sort()).join(',');
-
-  Future<OutageDiagnosis> _diagnose(String key, List<String> components) async {
+  Future<OutageDiagnosis> _diagnose(List<String> components) async {
     final diagnosis = await _resolve(components);
-    _cached[key] = diagnosis;
-    _cachedAt[key] = _now();
+    _cached[_cacheKey(components)] = _CachedDiagnosis(
+      diagnosis: diagnosis,
+      cachedAt: _now(),
+    );
     return diagnosis;
   }
 
@@ -113,10 +104,11 @@ class OutageDiagnosisService {
 
     final status = await _statusClient.fetchStatus();
     if (status == null) {
-      // The status page lives on a different host and CDN from the services
-      // that just failed. Both being unreachable points at the path they
-      // share — the user's own connection — rather than at Divine.
-      return const OutageDiagnosis(OutageVerdict.noConnection);
+      // A null status read is no opinion: it can be a transport failure, but it
+      // can also be a malformed payload, a wrong endpoint serving the SPA shell,
+      // or another status-page problem. Do not blame the user's network unless
+      // the connectivity probe gives direct evidence.
+      return OutageDiagnosis.indeterminate;
     }
 
     if (status.anyImpaired(components)) {
@@ -143,12 +135,18 @@ class OutageDiagnosisService {
     }
   }
 
-  /// Drops every cached verdict, so the next diagnosis re-checks.
-  @visibleForTesting
-  void invalidateCache() {
-    _cached.clear();
-    _cachedAt.clear();
-  }
-
   void dispose() => _statusClient.close();
+
+  /// Order-independent key for a component set.
+  static String _cacheKey(Iterable<String> components) {
+    final normalized = components.toSet().toList()..sort();
+    return normalized.join(',');
+  }
+}
+
+final class _CachedDiagnosis {
+  const _CachedDiagnosis({required this.diagnosis, required this.cachedAt});
+
+  final OutageDiagnosis diagnosis;
+  final DateTime cachedAt;
 }

--- a/mobile/lib/services/outage_diagnosis_service.dart
+++ b/mobile/lib/services/outage_diagnosis_service.dart
@@ -1,0 +1,148 @@
+// ABOUTME: Decides whether a failed load is our outage or the user's network
+// ABOUTME: Consults status.divine.video only when something already failed
+
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:divine_status_client/divine_status_client.dart';
+import 'package:meta/meta.dart';
+
+/// Why something failed to load.
+enum OutageVerdict {
+  /// The status page corroborates that a component we depend on is impaired.
+  divineOutage,
+
+  /// The device has no usable network, or nothing at all is reachable.
+  noConnection,
+
+  /// Nothing corroborates a cause; the caller should stay generic.
+  ///
+  /// This is the default whenever evidence is missing or contradictory. The
+  /// app must not claim an outage it cannot substantiate — a wrong "we're
+  /// fixing it" teaches users to ignore the message that matters.
+  indeterminate,
+}
+
+/// The outcome of one diagnosis.
+@immutable
+class OutageDiagnosis {
+  const OutageDiagnosis(this.verdict, {this.operatorMessage});
+
+  final OutageVerdict verdict;
+
+  /// What the on-call operator wrote on the status page, when they wrote
+  /// anything. Always preferred over canned copy.
+  final String? operatorMessage;
+
+  static const indeterminate = OutageDiagnosis(OutageVerdict.indeterminate);
+}
+
+/// Signature of the connectivity probe, injected so tests need no plugin.
+typedef ConnectivityProbe = Future<List<ConnectivityResult>> Function();
+
+/// Explains a failed load by cross-checking the Divine status page.
+///
+/// Only ever called after something has already failed, so a healthy session
+/// never issues a request. Results are cached because during a real outage
+/// every client fails at once, and each one asking repeatedly would pile onto
+/// the status page exactly when it is most needed.
+class OutageDiagnosisService {
+  OutageDiagnosisService({
+    DivineStatusClient? statusClient,
+    ConnectivityProbe? connectivityProbe,
+    DateTime Function()? now,
+  }) : _statusClient = statusClient ?? DivineStatusClient(),
+       _connectivityProbe =
+           connectivityProbe ?? Connectivity().checkConnectivity,
+       _now = now ?? DateTime.now;
+
+  /// How long a verdict is reused. Long enough that repeated retries during
+  /// one incident cost a single request, short enough to notice recovery.
+  static const cacheDuration = Duration(minutes: 2);
+
+  /// Components the video feed depends on. A viewer is not told about
+  /// uploads: it is not what they are doing and not why their feed is empty.
+  static const List<String> feedComponents = [
+    DivineStatusComponents.api,
+    DivineStatusComponents.relay,
+  ];
+
+  final DivineStatusClient _statusClient;
+  final ConnectivityProbe _connectivityProbe;
+  final DateTime Function() _now;
+
+  OutageDiagnosis? _cached;
+  DateTime? _cachedAt;
+  Future<OutageDiagnosis>? _inFlight;
+
+  /// Diagnoses why a load of [components] failed.
+  ///
+  /// Concurrent callers share one request, so several failing surfaces do not
+  /// multiply into several status fetches.
+  Future<OutageDiagnosis> diagnose({
+    List<String> components = feedComponents,
+  }) {
+    final cached = _cached;
+    final cachedAt = _cachedAt;
+    if (cached != null &&
+        cachedAt != null &&
+        _now().difference(cachedAt) < cacheDuration) {
+      return Future.value(cached);
+    }
+
+    return _inFlight ??= _diagnose(components).whenComplete(() {
+      _inFlight = null;
+    });
+  }
+
+  Future<OutageDiagnosis> _diagnose(List<String> components) async {
+    final diagnosis = await _resolve(components);
+    _cached = diagnosis;
+    _cachedAt = _now();
+    return diagnosis;
+  }
+
+  Future<OutageDiagnosis> _resolve(List<String> components) async {
+    if (await _hasNoNetworkInterface()) {
+      return const OutageDiagnosis(OutageVerdict.noConnection);
+    }
+
+    final status = await _statusClient.fetchStatus();
+    if (status == null) {
+      // The status page lives on a different host and CDN from the services
+      // that just failed. Both being unreachable points at the path they
+      // share — the user's own connection — rather than at Divine.
+      return const OutageDiagnosis(OutageVerdict.noConnection);
+    }
+
+    if (status.anyImpaired(components)) {
+      return OutageDiagnosis(
+        OutageVerdict.divineOutage,
+        operatorMessage: status.incidentMessage,
+      );
+    }
+
+    // Reachable and reportedly healthy: something failed, but nothing here
+    // says what, so say nothing.
+    return OutageDiagnosis.indeterminate;
+  }
+
+  Future<bool> _hasNoNetworkInterface() async {
+    try {
+      final results = await _connectivityProbe();
+      return results.isEmpty ||
+          results.every((r) => r == ConnectivityResult.none);
+    } on Object {
+      // Plugin unavailable (tests, unsupported platform): fall through to the
+      // status check rather than guessing.
+      return false;
+    }
+  }
+
+  /// Drops any cached verdict, so the next diagnosis re-checks.
+  @visibleForTesting
+  void invalidateCache() {
+    _cached = null;
+    _cachedAt = null;
+  }
+
+  void dispose() => _statusClient.close();
+}

--- a/mobile/lib/services/outage_diagnosis_service.dart
+++ b/mobile/lib/services/outage_diagnosis_service.dart
@@ -69,34 +69,40 @@ class OutageDiagnosisService {
   final ConnectivityProbe _connectivityProbe;
   final DateTime Function() _now;
 
-  OutageDiagnosis? _cached;
-  DateTime? _cachedAt;
-  Future<OutageDiagnosis>? _inFlight;
+  // Keyed by component set: a verdict for [api, relay] does not answer a
+  // question about [uploads]. Sharing one entry across sets would hand a
+  // second surface the feed's verdict.
+  final Map<String, OutageDiagnosis> _cached = {};
+  final Map<String, DateTime> _cachedAt = {};
+  final Map<String, Future<OutageDiagnosis>> _inFlight = {};
 
   /// Diagnoses why a load of [components] failed.
   ///
-  /// Concurrent callers share one request, so several failing surfaces do not
-  /// multiply into several status fetches.
-  Future<OutageDiagnosis> diagnose({
-    List<String> components = feedComponents,
-  }) {
-    final cached = _cached;
-    final cachedAt = _cachedAt;
+  /// Concurrent callers asking about the same components share one request, so
+  /// several failing surfaces do not multiply into several status fetches.
+  Future<OutageDiagnosis> diagnose({List<String> components = feedComponents}) {
+    final key = _cacheKey(components);
+    final cached = _cached[key];
+    final cachedAt = _cachedAt[key];
     if (cached != null &&
         cachedAt != null &&
         _now().difference(cachedAt) < cacheDuration) {
       return Future.value(cached);
     }
 
-    return _inFlight ??= _diagnose(components).whenComplete(() {
-      _inFlight = null;
+    return _inFlight[key] ??= _diagnose(key, components).whenComplete(() {
+      _inFlight.remove(key);
     });
   }
 
-  Future<OutageDiagnosis> _diagnose(List<String> components) async {
+  /// Order-independent key for a component set.
+  static String _cacheKey(List<String> components) =>
+      (components.toSet().toList()..sort()).join(',');
+
+  Future<OutageDiagnosis> _diagnose(String key, List<String> components) async {
     final diagnosis = await _resolve(components);
-    _cached = diagnosis;
-    _cachedAt = _now();
+    _cached[key] = diagnosis;
+    _cachedAt[key] = _now();
     return diagnosis;
   }
 
@@ -137,11 +143,11 @@ class OutageDiagnosisService {
     }
   }
 
-  /// Drops any cached verdict, so the next diagnosis re-checks.
+  /// Drops every cached verdict, so the next diagnosis re-checks.
   @visibleForTesting
   void invalidateCache() {
-    _cached = null;
-    _cachedAt = null;
+    _cached.clear();
+    _cachedAt.clear();
   }
 
   void dispose() => _statusClient.close();

--- a/mobile/packages/divine_status_client/analysis_options.yaml
+++ b/mobile/packages/divine_status_client/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:very_good_analysis/analysis_options.yaml

--- a/mobile/packages/divine_status_client/lib/divine_status_client.dart
+++ b/mobile/packages/divine_status_client/lib/divine_status_client.dart
@@ -1,0 +1,6 @@
+/// Reads component health from the Divine status page.
+library;
+
+export 'src/divine_status_client.dart';
+export 'src/models/component_health.dart';
+export 'src/models/divine_status.dart';

--- a/mobile/packages/divine_status_client/lib/src/divine_status_client.dart
+++ b/mobile/packages/divine_status_client/lib/src/divine_status_client.dart
@@ -1,0 +1,67 @@
+import 'dart:convert';
+
+import 'package:divine_status_client/src/models/divine_status.dart';
+import 'package:http/http.dart' as http;
+
+/// Component ids the app asks about. Mirrors the status page's own ids.
+abstract final class DivineStatusComponents {
+  static const api = 'api';
+  static const relay = 'relay';
+  static const uploads = 'uploads';
+  static const playback = 'playback';
+  static const cdn = 'cdn';
+  static const login = 'login';
+}
+
+/// Reads component health from the Divine status page.
+///
+/// The status page is hosted on a different provider from the services it
+/// reports on (Cloudflare vs Fastly), which is what makes asking it during an
+/// outage worthwhile — it is expected to answer when the API cannot.
+class DivineStatusClient {
+  DivineStatusClient({http.Client? httpClient, Uri? endpoint})
+    : _httpClient = httpClient ?? http.Client(),
+      _endpoint = endpoint ?? defaultEndpoint;
+
+  /// The status page's machine-readable endpoint.
+  ///
+  /// Deliberately a different host — and a different CDN — from the services
+  /// it reports on, so it stays reachable when they are not.
+  static final Uri defaultEndpoint = Uri.parse(
+    'https://status.divine.video/api/status',
+  );
+
+  /// Short by design: this is only ever called on a path where the user is
+  /// already looking at a failure, so a slow status page must not extend it.
+  static const requestTimeout = Duration(seconds: 5);
+
+  final http.Client _httpClient;
+  final Uri _endpoint;
+
+  /// Fetches the current status, or `null` when it cannot be established.
+  ///
+  /// Never throws: every failure — offline, timeout, non-200, HTML shell,
+  /// malformed JSON — collapses to `null`, meaning "no opinion". Callers must
+  /// treat `null` as "do not claim an outage" rather than as an outage.
+  ///
+  /// `FormatException` from a bad decode is an `Exception`, so the single
+  /// catch covers it.
+  Future<DivineStatus?> fetchStatus() async {
+    try {
+      final response = await _httpClient
+          .get(_endpoint, headers: const {'Accept': 'application/json'})
+          .timeout(requestTimeout);
+
+      if (response.statusCode != 200) return null;
+
+      return DivineStatus.tryParse(
+        jsonDecode(utf8.decode(response.bodyBytes)) as Object?,
+      );
+    } on Exception {
+      return null;
+    }
+  }
+
+  /// Releases the underlying HTTP client.
+  void close() => _httpClient.close();
+}

--- a/mobile/packages/divine_status_client/lib/src/divine_status_client.dart
+++ b/mobile/packages/divine_status_client/lib/src/divine_status_client.dart
@@ -5,11 +5,22 @@ import 'package:http/http.dart' as http;
 
 /// Component ids the app asks about. Mirrors the status page's own ids.
 abstract final class DivineStatusComponents {
+  /// The public REST API.
   static const api = 'api';
+
+  /// The Nostr relay.
   static const relay = 'relay';
+
+  /// The upload and publishing path.
   static const uploads = 'uploads';
+
+  /// Playback and public media delivery.
   static const playback = 'playback';
+
+  /// The media CDN.
   static const cdn = 'cdn';
+
+  /// Account login and authentication.
   static const login = 'login';
 }
 
@@ -19,6 +30,8 @@ abstract final class DivineStatusComponents {
 /// reports on (Cloudflare vs Fastly), which is what makes asking it during an
 /// outage worthwhile — it is expected to answer when the API cannot.
 class DivineStatusClient {
+  /// Creates a client. Both parameters exist for tests; production uses the
+  /// real HTTP client and [defaultEndpoint].
   DivineStatusClient({http.Client? httpClient, Uri? endpoint})
     : _httpClient = httpClient ?? http.Client(),
       _endpoint = endpoint ?? defaultEndpoint;

--- a/mobile/packages/divine_status_client/lib/src/models/component_health.dart
+++ b/mobile/packages/divine_status_client/lib/src/models/component_health.dart
@@ -1,0 +1,58 @@
+import 'package:equatable/equatable.dart';
+import 'package:meta/meta.dart';
+
+/// How healthy one status-page component is.
+///
+/// The status page owns the vocabulary and can add to it, so parsing is
+/// deliberately asymmetric: only the literal `operational` reads as healthy,
+/// only a literal `unknown` (or a missing/unreadable value) reads as
+/// [ComponentHealth.unknown], and every other value reads as [impaired].
+///
+/// The asymmetry is the safety property. Guessing the full set of failure
+/// words would go quiet during an outage that used a word we did not
+/// anticipate, which is the one moment this has to work.
+enum ComponentHealth {
+  /// The status page affirms the component is working.
+  operational,
+
+  /// The status page reports something other than operational.
+  impaired,
+
+  /// The status page has no usable opinion, so neither do we.
+  unknown;
+
+  /// Maps a raw `status` string from the status page.
+  static ComponentHealth parse(Object? raw) {
+    if (raw is! String) return ComponentHealth.unknown;
+    return switch (raw.trim().toLowerCase()) {
+      'operational' => ComponentHealth.operational,
+      '' || 'unknown' => ComponentHealth.unknown,
+      _ => ComponentHealth.impaired,
+    };
+  }
+}
+
+/// One component of the Divine platform, as the status page sees it.
+@immutable
+class StatusComponent extends Equatable {
+  const StatusComponent({
+    required this.id,
+    required this.health,
+    this.label,
+    this.message,
+  });
+
+  /// Stable identifier, such as `api` or `relay`.
+  final String id;
+
+  final ComponentHealth health;
+
+  /// Human-readable name, such as `Video Playback`.
+  final String? label;
+
+  /// The status page's own note about the latest probe.
+  final String? message;
+
+  @override
+  List<Object?> get props => [id, health, label, message];
+}

--- a/mobile/packages/divine_status_client/lib/src/models/component_health.dart
+++ b/mobile/packages/divine_status_client/lib/src/models/component_health.dart
@@ -35,6 +35,7 @@ enum ComponentHealth {
 /// One component of the Divine platform, as the status page sees it.
 @immutable
 class StatusComponent extends Equatable {
+  /// Creates a component snapshot.
   const StatusComponent({
     required this.id,
     required this.health,
@@ -45,6 +46,7 @@ class StatusComponent extends Equatable {
   /// Stable identifier, such as `api` or `relay`.
   final String id;
 
+  /// How healthy the status page reports this component to be.
   final ComponentHealth health;
 
   /// Human-readable name, such as `Video Playback`.

--- a/mobile/packages/divine_status_client/lib/src/models/divine_status.dart
+++ b/mobile/packages/divine_status_client/lib/src/models/divine_status.dart
@@ -5,6 +5,7 @@ import 'package:meta/meta.dart';
 /// A snapshot of the Divine status page.
 @immutable
 class DivineStatus extends Equatable {
+  /// Creates a status snapshot.
   const DivineStatus({
     required this.components,
     this.updatedAt,

--- a/mobile/packages/divine_status_client/lib/src/models/divine_status.dart
+++ b/mobile/packages/divine_status_client/lib/src/models/divine_status.dart
@@ -53,18 +53,32 @@ class DivineStatus extends Equatable {
       components[entry.key] = StatusComponent(
         id: entry.key,
         health: ComponentHealth.parse(value['status']),
-        label: value['label'] as String?,
-        message: value['message'] as String?,
+        label: _asString(value['label']),
+        message: _asString(value['message']),
       );
     }
     if (components.isEmpty) return null;
 
     return DivineStatus(
       components: components,
-      updatedAt: DateTime.tryParse(body['updatedAt'] as String? ?? ''),
+      updatedAt: _dateTime(body['updatedAt']),
       incidentMessage: _incidentMessage(body['incident']),
     );
   }
+
+  /// The value as a `String`, or `null` when it is any other JSON type.
+  ///
+  /// The status page owns the payload shape and can emit a number, bool, or
+  /// object where a string was expected. A bare `as String?` would throw a
+  /// `TypeError` — an `Error`, not an `Exception` — escaping the caller's
+  /// `on Exception` guard and breaking the never-throws contract. Every field
+  /// here is read the same defensive way for that reason.
+  static String? _asString(Object? value) => value is String ? value : null;
+
+  /// Parses a timestamp only when the page gave a string, tolerating a
+  /// numeric or missing `updatedAt` rather than throwing on the cast.
+  static DateTime? _dateTime(Object? value) =>
+      value is String ? DateTime.tryParse(value) : null;
 
   /// Pulls a displayable sentence out of the `incident` field.
   ///

--- a/mobile/packages/divine_status_client/lib/src/models/divine_status.dart
+++ b/mobile/packages/divine_status_client/lib/src/models/divine_status.dart
@@ -1,0 +1,88 @@
+import 'package:divine_status_client/src/models/component_health.dart';
+import 'package:equatable/equatable.dart';
+import 'package:meta/meta.dart';
+
+/// A snapshot of the Divine status page.
+@immutable
+class DivineStatus extends Equatable {
+  const DivineStatus({
+    required this.components,
+    this.updatedAt,
+    this.incidentMessage,
+  });
+
+  /// Components keyed by id (`api`, `relay`, `uploads`, `playback`, ...).
+  final Map<String, StatusComponent> components;
+
+  /// When the status page last recomputed, if it said.
+  final DateTime? updatedAt;
+
+  /// The on-call operator's own words about an open incident.
+  ///
+  /// Preferred over any canned copy when present: a human saying what is
+  /// happening beats the app guessing from component states.
+  final String? incidentMessage;
+
+  /// Health of [id], or [ComponentHealth.unknown] when the page omits it.
+  ComponentHealth healthOf(String id) =>
+      components[id]?.health ?? ComponentHealth.unknown;
+
+  /// Whether any of [ids] is explicitly reported as impaired.
+  ///
+  /// [ComponentHealth.unknown] deliberately does not count — an absent
+  /// opinion is not corroboration.
+  bool anyImpaired(Iterable<String> ids) =>
+      ids.any((id) => healthOf(id) == ComponentHealth.impaired);
+
+  /// Parses the `/api/status` payload.
+  ///
+  /// Returns `null` when [body] is not a status document. Every non-API path
+  /// on the status host answers `200` with the single-page-app shell, so a
+  /// wrong URL or an intercepting portal yields HTML rather than an error
+  /// code; treating that as "all clear" would silently disable the feature.
+  static DivineStatus? tryParse(Object? body) {
+    if (body is! Map<String, dynamic>) return null;
+    final rawComponents = body['components'];
+    if (rawComponents is! Map<String, dynamic>) return null;
+
+    final components = <String, StatusComponent>{};
+    for (final entry in rawComponents.entries) {
+      final value = entry.value;
+      if (value is! Map<String, dynamic>) continue;
+      components[entry.key] = StatusComponent(
+        id: entry.key,
+        health: ComponentHealth.parse(value['status']),
+        label: value['label'] as String?,
+        message: value['message'] as String?,
+      );
+    }
+    if (components.isEmpty) return null;
+
+    return DivineStatus(
+      components: components,
+      updatedAt: DateTime.tryParse(body['updatedAt'] as String? ?? ''),
+      incidentMessage: _incidentMessage(body['incident']),
+    );
+  }
+
+  /// Pulls a displayable sentence out of the `incident` field.
+  ///
+  /// The field is `null` outside an incident, so its populated shape is
+  /// unverified here — it is read defensively as either a bare string or a
+  /// map carrying one of the usual message keys, and ignored otherwise.
+  static String? _incidentMessage(Object? incident) {
+    if (incident is String) {
+      final trimmed = incident.trim();
+      return trimmed.isEmpty ? null : trimmed;
+    }
+    if (incident is! Map<String, dynamic>) return null;
+    for (final key in const ['message', 'body', 'description', 'title']) {
+      final value = incident[key];
+      if (value is String && value.trim().isNotEmpty) return value.trim();
+    }
+    return null;
+  }
+
+  @override
+  List<Object?> get props => [components, updatedAt, incidentMessage];
+}

--- a/mobile/packages/divine_status_client/pubspec.yaml
+++ b/mobile/packages/divine_status_client/pubspec.yaml
@@ -1,0 +1,19 @@
+name: divine_status_client
+description: Reads component health from the Divine status page
+version: 0.1.0+1
+publish_to: none
+
+environment:
+  sdk: ^3.11.0
+
+resolution: workspace
+
+dependencies:
+  equatable: ^2.0.7
+  http: ^1.4.0
+  meta: ^1.17.0
+
+dev_dependencies:
+  mocktail: ^1.0.4
+  test: ^1.26.3
+  very_good_analysis: ^10.0.0

--- a/mobile/packages/divine_status_client/test/src/divine_status_client_test.dart
+++ b/mobile/packages/divine_status_client/test/src/divine_status_client_test.dart
@@ -1,0 +1,301 @@
+// ABOUTME: Tests the Divine status page client.
+// ABOUTME: Pins that nothing but a real status document reads as an opinion.
+
+import 'dart:convert';
+
+import 'package:divine_status_client/divine_status_client.dart';
+import 'package:http/http.dart' as http;
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+
+class _MockHttpClient extends Mock implements http.Client {}
+
+/// The single-page-app shell every non-API path on the status host returns.
+const _spaShell = '<!doctype html><html><body>Operational</body></html>';
+
+String _statusBody({
+  String apiStatus = 'operational',
+  String relayStatus = 'operational',
+  Object? incident,
+}) {
+  return jsonEncode({
+    'updatedAt': '2026-08-17T03:18:41.874Z',
+    'components': {
+      'api': {
+        'id': 'api',
+        'label': 'API',
+        'status': apiStatus,
+        'message': 'api-readyz passed',
+      },
+      'relay': {'id': 'relay', 'label': 'Relay', 'status': relayStatus},
+    },
+    'incident': incident,
+  });
+}
+
+void main() {
+  group(DivineStatusClient, () {
+    late _MockHttpClient httpClient;
+    late DivineStatusClient client;
+    final endpoint = Uri.parse('https://status.example/api/status');
+
+    setUp(() {
+      httpClient = _MockHttpClient();
+      client = DivineStatusClient(httpClient: httpClient, endpoint: endpoint);
+    });
+
+    void stubResponse(String body, {int statusCode = 200}) {
+      when(
+        () => httpClient.get(endpoint, headers: any(named: 'headers')),
+      ).thenAnswer(
+        (_) async => http.Response(
+          body,
+          statusCode,
+          headers: const {'content-type': 'application/json; charset=utf-8'},
+        ),
+      );
+    }
+
+    group('fetchStatus', () {
+      test('reads component health from a status document', () async {
+        stubResponse(_statusBody(apiStatus: 'degraded'));
+
+        final status = await client.fetchStatus();
+
+        expect(status, isNotNull);
+        expect(
+          status!.healthOf(DivineStatusComponents.api),
+          equals(ComponentHealth.impaired),
+        );
+        expect(
+          status.healthOf(DivineStatusComponents.relay),
+          equals(ComponentHealth.operational),
+        );
+        expect(status.components['api']?.label, equals('API'));
+      });
+
+      test('returns null for the SPA shell served on non-API paths', () async {
+        // A 200 with HTML is the shape a wrong path or a captive portal
+        // produces. Reading it as "all operational" would quietly disable
+        // outage messaging, so it has to be no-opinion instead.
+        stubResponse(_spaShell);
+
+        expect(await client.fetchStatus(), isNull);
+      });
+
+      test('returns null for a non-200 response', () async {
+        stubResponse(_statusBody(), statusCode: 503);
+
+        expect(await client.fetchStatus(), isNull);
+      });
+
+      test('returns null for malformed JSON', () async {
+        stubResponse('{"components":');
+
+        expect(await client.fetchStatus(), isNull);
+      });
+
+      test('returns null when the document carries no components', () async {
+        stubResponse(jsonEncode({'updatedAt': '2026-08-17T03:18:41.874Z'}));
+
+        expect(await client.fetchStatus(), isNull);
+      });
+
+      test(
+        'returns null rather than throwing when the request fails',
+        () async {
+          when(
+            () => httpClient.get(endpoint, headers: any(named: 'headers')),
+          ).thenThrow(http.ClientException('offline'));
+
+          expect(await client.fetchStatus(), isNull);
+        },
+      );
+
+      test('surfaces an operator incident message', () async {
+        stubResponse(
+          _statusBody(
+            apiStatus: 'down',
+            incident: {'message': 'Uploads degraded, fix rolling out.'},
+          ),
+        );
+
+        final status = await client.fetchStatus();
+
+        expect(
+          status!.incidentMessage,
+          equals('Uploads degraded, fix rolling out.'),
+        );
+      });
+
+      test('reads a bare-string incident', () async {
+        stubResponse(_statusBody(incident: 'Investigating elevated errors.'));
+
+        final status = await client.fetchStatus();
+
+        expect(
+          status!.incidentMessage,
+          equals('Investigating elevated errors.'),
+        );
+      });
+
+      test('ignores an incident with no readable message', () async {
+        stubResponse(_statusBody(incident: {'startedAt': 'now'}));
+
+        expect((await client.fetchStatus())!.incidentMessage, isNull);
+      });
+
+      test('has no incident message outside an incident', () async {
+        stubResponse(_statusBody());
+
+        expect((await client.fetchStatus())!.incidentMessage, isNull);
+      });
+
+      test('parses updatedAt', () async {
+        stubResponse(_statusBody());
+
+        expect(
+          (await client.fetchStatus())!.updatedAt,
+          equals(DateTime.parse('2026-08-17T03:18:41.874Z')),
+        );
+      });
+
+      test('defaults to the status host, which is not the API host', () {
+        // Hosting the status page away from the services it reports on is
+        // the whole reason asking it during an outage is worth anything.
+        // Repointing it at api.divine.video would silently neuter this.
+        expect(
+          DivineStatusClient.defaultEndpoint,
+          equals(Uri.parse('https://status.divine.video/api/status')),
+        );
+        expect(
+          DivineStatusClient.defaultEndpoint.host,
+          isNot('api.divine.video'),
+        );
+
+        // Constructing without injection must not throw.
+        DivineStatusClient().close();
+      });
+
+      test('closes the underlying client', () {
+        when(() => httpClient.close()).thenAnswer((_) {});
+
+        client.close();
+
+        verify(() => httpClient.close()).called(1);
+      });
+    });
+
+    group('anyImpaired', () {
+      test('reports an impaired component', () async {
+        stubResponse(_statusBody(relayStatus: 'down'));
+        final status = await client.fetchStatus();
+
+        expect(status!.anyImpaired(const ['api', 'relay']), isTrue);
+      });
+
+      test('does not treat an unknown component as corroboration', () async {
+        stubResponse(_statusBody(apiStatus: 'unknown'));
+        final status = await client.fetchStatus();
+
+        expect(status!.anyImpaired(const ['api']), isFalse);
+      });
+
+      test('does not treat a missing component as corroboration', () async {
+        stubResponse(_statusBody());
+        final status = await client.fetchStatus();
+
+        expect(status!.anyImpaired(const ['uploads']), isFalse);
+      });
+
+      test('reports healthy when everything is operational', () async {
+        stubResponse(_statusBody());
+        final status = await client.fetchStatus();
+
+        expect(status!.anyImpaired(const ['api', 'relay']), isFalse);
+      });
+    });
+
+    group('equality', () {
+      // Callers cache a status snapshot and compare against the next one to
+      // decide whether anything changed, so value equality has to be real.
+      test('$StatusComponent compares by value', () {
+        const a = StatusComponent(
+          id: 'api',
+          health: ComponentHealth.operational,
+          label: 'API',
+          message: 'passed',
+        );
+        const same = StatusComponent(
+          id: 'api',
+          health: ComponentHealth.operational,
+          label: 'API',
+          message: 'passed',
+        );
+        const differentHealth = StatusComponent(
+          id: 'api',
+          health: ComponentHealth.impaired,
+          label: 'API',
+          message: 'passed',
+        );
+
+        expect(a, equals(same));
+        expect(a, isNot(equals(differentHealth)));
+      });
+
+      test('$DivineStatus compares by value', () async {
+        stubResponse(_statusBody());
+        final first = await client.fetchStatus();
+        final second = await client.fetchStatus();
+
+        expect(first, equals(second));
+
+        stubResponse(_statusBody(apiStatus: 'down'));
+        expect(await client.fetchStatus(), isNot(equals(first)));
+      });
+    });
+
+    group(ComponentHealth, () {
+      test('treats only "operational" as healthy', () {
+        expect(
+          ComponentHealth.parse('operational'),
+          equals(ComponentHealth.operational),
+        );
+        expect(
+          ComponentHealth.parse('OPERATIONAL'),
+          equals(ComponentHealth.operational),
+        );
+      });
+
+      test('treats an unfamiliar failure word as impaired', () {
+        // The status page owns this vocabulary and may extend it. An
+        // unanticipated word must still read as trouble, or the app goes
+        // quiet during exactly the outage it exists to explain.
+        for (final raw in const [
+          'degraded',
+          'down',
+          'partial_outage',
+          'major_outage',
+          'maintenance',
+          'something_new',
+        ]) {
+          expect(
+            ComponentHealth.parse(raw),
+            equals(ComponentHealth.impaired),
+            reason: '$raw should read as impaired',
+          );
+        }
+      });
+
+      test('treats an absent or unusable value as unknown', () {
+        for (final raw in [null, '', '  ', 'unknown', 42]) {
+          expect(
+            ComponentHealth.parse(raw),
+            equals(ComponentHealth.unknown),
+            reason: '$raw should read as unknown',
+          );
+        }
+      });
+    });
+  });
+}

--- a/mobile/packages/divine_status_client/test/src/divine_status_client_test.dart
+++ b/mobile/packages/divine_status_client/test/src/divine_status_client_test.dart
@@ -160,6 +160,37 @@ void main() {
         );
       });
 
+      test('tolerates non-string updatedAt, label, and message', () async {
+        // The status page owns the payload shape. A numeric epoch or a
+        // non-string label must degrade to null — a bare cast would throw a
+        // TypeError (an Error, not an Exception) past the on-Exception guard
+        // and collapse the whole document instead of one field.
+        stubResponse(
+          jsonEncode({
+            'updatedAt': 1723800000,
+            'components': {
+              'api': {
+                'id': 'api',
+                'status': 'down',
+                'label': 3,
+                'message': false,
+              },
+            },
+          }),
+        );
+
+        final status = await client.fetchStatus();
+
+        expect(status, isNotNull);
+        expect(status!.updatedAt, isNull);
+        expect(status.components['api']?.label, isNull);
+        expect(status.components['api']?.message, isNull);
+        expect(
+          status.healthOf(DivineStatusComponents.api),
+          equals(ComponentHealth.impaired),
+        );
+      });
+
       test('defaults to the status host, which is not the API host', () {
         // Hosting the status page away from the services it reports on is
         // the whole reason asking it during an outage is worth anything.

--- a/mobile/packages/divine_status_client/test/src/divine_status_client_test.dart
+++ b/mobile/packages/divine_status_client/test/src/divine_status_client_test.dart
@@ -101,6 +101,29 @@ void main() {
         expect(await client.fetchStatus(), isNull);
       });
 
+      test('ignores non-string optional fields rather than throwing', () async {
+        stubResponse(
+          jsonEncode({
+            'updatedAt': {'value': '2026-08-17T03:18:41.874Z'},
+            'components': {
+              'api': {
+                'id': 'api',
+                'label': {'text': 'API'},
+                'status': 'operational',
+                'message': {'text': 'ready'},
+              },
+            },
+          }),
+        );
+
+        final status = await client.fetchStatus();
+
+        expect(status, isNotNull);
+        expect(status!.updatedAt, isNull);
+        expect(status.components['api']?.label, isNull);
+        expect(status.components['api']?.message, isNull);
+      });
+
       test(
         'returns null rather than throwing when the request fails',
         () async {

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -46,6 +46,7 @@ workspace:
   - packages/db_client
   - packages/divine_camera
   - packages/divine_quick_actions
+  - packages/divine_status_client
   - packages/dm_repository
   - packages/divine_video_player
   - packages/feed_repository
@@ -252,6 +253,9 @@ dependencies:
   nostr_key_manager:
 
   keycast_flutter:
+
+  # Divine Status Client - component health from status.divine.video
+  divine_status_client:
 
   # Follow Repository - Follow relationship management
   follow_repository:

--- a/mobile/scripts/baseline/material_buttons.txt
+++ b/mobile/scripts/baseline/material_buttons.txt
@@ -19,7 +19,6 @@ lib/screens/comments/widgets/comment_options_modal.dart	1
 lib/screens/curated_list_feed_screen.dart	4
 lib/screens/discover_lists_screen.dart	2
 lib/screens/feed/video_feed_page/feed_empty_widget.dart	1
-lib/screens/feed/video_feed_page/feed_error_widget.dart	1
 lib/screens/followers/my_followers_screen.dart	1
 lib/screens/followers/others_followers_screen.dart	1
 lib/screens/following/my_following_screen.dart	1

--- a/mobile/scripts/baseline/package_coverage_floors.txt
+++ b/mobile/scripts/baseline/package_coverage_floors.txt
@@ -26,6 +26,7 @@ db_client 40
 divine_blurhash 100
 divine_camera 100
 divine_quick_actions 76
+divine_status_client 100
 divine_ui 100
 divine_video_player 100
 dm_repository 93

--- a/mobile/scripts/baseline/raw_textstyle.txt
+++ b/mobile/scripts/baseline/raw_textstyle.txt
@@ -27,7 +27,6 @@ lib/screens/explore/tabs/explore_lists_tab.dart	5
 lib/screens/explore/widgets/explore_buffered_videos_banner.dart	1
 lib/screens/explore_screen_router.dart	1
 lib/screens/feed/video_feed_page/feed_empty_widget.dart	1
-lib/screens/feed/video_feed_page/feed_error_widget.dart	2
 lib/screens/followers/my_followers_screen.dart	2
 lib/screens/followers/others_followers_screen.dart	2
 lib/screens/following/my_following_screen.dart	2

--- a/mobile/test/blocs/outage_notice/outage_notice_cubit_test.dart
+++ b/mobile/test/blocs/outage_notice/outage_notice_cubit_test.dart
@@ -1,0 +1,117 @@
+// ABOUTME: Tests the outage notice cubit that feeds user-facing failure copy.
+// ABOUTME: Pins diagnosis mapping and async error handling.
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/blocs/outage_notice/outage_notice_cubit.dart';
+import 'package:openvine/services/outage_diagnosis_service.dart';
+
+class _MockOutageDiagnosisService extends Mock
+    implements OutageDiagnosisService {}
+
+void main() {
+  group(OutageNoticeCubit, () {
+    late _MockOutageDiagnosisService diagnosisService;
+
+    setUp(() {
+      diagnosisService = _MockOutageDiagnosisService();
+    });
+
+    blocTest<OutageNoticeCubit, OutageNoticeState>(
+      'maps a Divine outage verdict',
+      build: () {
+        when(
+          () => diagnosisService.diagnose(
+            components: any(named: 'components'),
+          ),
+        ).thenAnswer(
+          (_) async => const OutageDiagnosis(
+            OutageVerdict.divineOutage,
+            operatorMessage: 'Fix rolling out.',
+          ),
+        );
+        return OutageNoticeCubit(diagnosisService: diagnosisService);
+      },
+      act: (cubit) => cubit.diagnose(),
+      expect: () => const [
+        OutageNoticeState(
+          status: OutageNoticeStatus.divineOutage,
+          operatorMessage: 'Fix rolling out.',
+        ),
+      ],
+    );
+
+    blocTest<OutageNoticeCubit, OutageNoticeState>(
+      'maps a no-connection verdict',
+      build: () {
+        when(
+          () => diagnosisService.diagnose(
+            components: any(named: 'components'),
+          ),
+        ).thenAnswer(
+          (_) async => const OutageDiagnosis(OutageVerdict.noConnection),
+        );
+        return OutageNoticeCubit(diagnosisService: diagnosisService);
+      },
+      act: (cubit) => cubit.diagnose(),
+      expect: () => const [
+        OutageNoticeState(status: OutageNoticeStatus.noConnection),
+      ],
+    );
+
+    blocTest<OutageNoticeCubit, OutageNoticeState>(
+      'maps an indeterminate verdict',
+      build: () {
+        when(
+          () => diagnosisService.diagnose(
+            components: any(named: 'components'),
+          ),
+        ).thenAnswer((_) async => OutageDiagnosis.indeterminate);
+        return OutageNoticeCubit(diagnosisService: diagnosisService);
+      },
+      act: (cubit) => cubit.diagnose(),
+      expect: () => const [
+        OutageNoticeState(status: OutageNoticeStatus.indeterminate),
+      ],
+    );
+
+    blocTest<OutageNoticeCubit, OutageNoticeState>(
+      'reports diagnosis errors and stays generic',
+      build: () {
+        when(
+          () => diagnosisService.diagnose(
+            components: any(named: 'components'),
+          ),
+        ).thenThrow(StateError('bad status payload'));
+        return OutageNoticeCubit(diagnosisService: diagnosisService);
+      },
+      act: (cubit) => cubit.diagnose(),
+      expect: () => const [
+        OutageNoticeState(status: OutageNoticeStatus.indeterminate),
+      ],
+      errors: () => [isA<StateError>()],
+    );
+
+    blocTest<OutageNoticeCubit, OutageNoticeState>(
+      'passes custom component scope to the diagnosis service',
+      build: () {
+        when(
+          () => diagnosisService.diagnose(components: const ['uploads']),
+        ).thenAnswer(
+          (_) async => const OutageDiagnosis(OutageVerdict.divineOutage),
+        );
+        return OutageNoticeCubit(
+          diagnosisService: diagnosisService,
+          components: const ['uploads'],
+        );
+      },
+      act: (cubit) => cubit.diagnose(),
+      verify: (_) {
+        verify(
+          () => diagnosisService.diagnose(components: const ['uploads']),
+        ).called(1);
+      },
+    );
+  });
+}

--- a/mobile/test/screens/feed/video_feed_page/feed_error_widget_test.dart
+++ b/mobile/test/screens/feed/video_feed_page/feed_error_widget_test.dart
@@ -4,16 +4,92 @@
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/blocs/outage_notice/outage_notice_cubit.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/providers/outage_diagnosis_provider.dart';
 import 'package:openvine/screens/feed/video_feed_page/feed_error_widget.dart';
+import 'package:openvine/services/outage_diagnosis_service.dart';
 
 class _MockOutageNoticeCubit extends MockCubit<OutageNoticeState>
     implements OutageNoticeCubit {}
 
+class _MockOutageDiagnosisService extends Mock
+    implements OutageDiagnosisService {}
+
 void main() {
+  group(FeedErrorWidget, () {
+    testWidgets('starts diagnosis when mounted', (tester) async {
+      final diagnosisService = _MockOutageDiagnosisService();
+      when(
+        () => diagnosisService.diagnose(
+          components: any(named: 'components'),
+        ),
+      ).thenAnswer((_) async => OutageDiagnosis.indeterminate);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            outageDiagnosisServiceProvider.overrideWithValue(diagnosisService),
+          ],
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(body: FeedErrorWidget(onRetry: () async {})),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      verify(
+        () => diagnosisService.diagnose(
+          components: any(named: 'components'),
+        ),
+      ).called(1);
+    });
+
+    testWidgets('starts a fresh diagnosis when the service changes', (
+      tester,
+    ) async {
+      final firstService = _MockOutageDiagnosisService();
+      final secondService = _MockOutageDiagnosisService();
+      for (final service in [firstService, secondService]) {
+        when(
+          () => service.diagnose(components: any(named: 'components')),
+        ).thenAnswer((_) async => OutageDiagnosis.indeterminate);
+      }
+
+      Future<void> pumpWithService(OutageDiagnosisService service) {
+        return tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              outageDiagnosisServiceProvider.overrideWithValue(service),
+            ],
+            child: MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: Scaffold(body: FeedErrorWidget(onRetry: () async {})),
+            ),
+          ),
+        );
+      }
+
+      await pumpWithService(firstService);
+      await tester.pump();
+      await pumpWithService(secondService);
+      await tester.pump();
+
+      verify(
+        () => firstService.diagnose(components: any(named: 'components')),
+      ).called(1);
+      verify(
+        () => secondService.diagnose(components: any(named: 'components')),
+      ).called(1);
+    });
+  });
+
   group(FeedErrorView, () {
     final l10n = lookupAppLocalizations(const Locale('en'));
     late _MockOutageNoticeCubit cubit;

--- a/mobile/test/screens/feed/video_feed_page/feed_error_widget_test.dart
+++ b/mobile/test/screens/feed/video_feed_page/feed_error_widget_test.dart
@@ -1,0 +1,139 @@
+// ABOUTME: Widget tests for the home feed's failure state.
+// ABOUTME: Pins that it distinguishes our outage from the user's network.
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/blocs/outage_notice/outage_notice_cubit.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/screens/feed/video_feed_page/feed_error_widget.dart';
+
+class _MockOutageNoticeCubit extends MockCubit<OutageNoticeState>
+    implements OutageNoticeCubit {}
+
+void main() {
+  group(FeedErrorView, () {
+    final l10n = lookupAppLocalizations(const Locale('en'));
+    late _MockOutageNoticeCubit cubit;
+
+    setUp(() {
+      cubit = _MockOutageNoticeCubit();
+    });
+
+    Future<void> pumpWith(WidgetTester tester, OutageNoticeState state) {
+      when(() => cubit.state).thenReturn(state);
+      return tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: BlocProvider<OutageNoticeCubit>.value(
+              value: cubit,
+              child: FeedErrorView(onRetry: () async {}),
+            ),
+          ),
+        ),
+      );
+    }
+
+    testWidgets('stays generic while the diagnosis is still running', (
+      tester,
+    ) async {
+      // Blaming ourselves before we know, then flipping to "you're offline",
+      // is worse than one honest generic line.
+      await pumpWith(tester, const OutageNoticeState());
+
+      expect(find.text(l10n.feedFailedToLoadVideos), findsOneWidget);
+      expect(find.text(l10n.feedOutageMessage), findsNothing);
+    });
+
+    testWidgets('says the fault is ours on a corroborated outage', (
+      tester,
+    ) async {
+      await pumpWith(
+        tester,
+        const OutageNoticeState(status: OutageNoticeStatus.divineOutage),
+      );
+
+      expect(find.text(l10n.feedOutageMessage), findsOneWidget);
+    });
+
+    testWidgets('prefers the operator message over canned copy', (
+      tester,
+    ) async {
+      await pumpWith(
+        tester,
+        const OutageNoticeState(
+          status: OutageNoticeStatus.divineOutage,
+          operatorMessage: 'Feed degraded, fix rolling out.',
+        ),
+      );
+
+      expect(find.text('Feed degraded, fix rolling out.'), findsOneWidget);
+      expect(find.text(l10n.feedOutageMessage), findsNothing);
+    });
+
+    testWidgets('points at the connection when nothing is reachable', (
+      tester,
+    ) async {
+      await pumpWith(
+        tester,
+        const OutageNoticeState(status: OutageNoticeStatus.noConnection),
+      );
+
+      expect(find.text(l10n.feedOfflineMessage), findsOneWidget);
+    });
+
+    testWidgets('claims nothing when the status page reports health', (
+      tester,
+    ) async {
+      await pumpWith(
+        tester,
+        const OutageNoticeState(status: OutageNoticeStatus.indeterminate),
+      );
+
+      expect(find.text(l10n.feedFailedToLoadVideos), findsOneWidget);
+      expect(find.text(l10n.feedOutageMessage), findsNothing);
+      expect(find.text(l10n.feedOfflineMessage), findsNothing);
+    });
+
+    testWidgets('never renders a raw enum name', (tester) async {
+      // The previous implementation printed error.toString(), putting
+      // "VideoFeedError.loadFailed" on screen for users.
+      await pumpWith(
+        tester,
+        const OutageNoticeState(status: OutageNoticeStatus.indeterminate),
+      );
+
+      expect(find.textContaining('VideoFeedError'), findsNothing);
+    });
+
+    testWidgets('retries when the button is tapped', (tester) async {
+      var retried = false;
+      when(() => cubit.state).thenReturn(const OutageNoticeState());
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: BlocProvider<OutageNoticeCubit>.value(
+              value: cubit,
+              child: FeedErrorView(
+                onRetry: () async {
+                  retried = true;
+                },
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text(l10n.feedRetry));
+      await tester.pump();
+
+      expect(retried, isTrue);
+    });
+  });
+}

--- a/mobile/test/services/outage_diagnosis_service_test.dart
+++ b/mobile/test/services/outage_diagnosis_service_test.dart
@@ -28,6 +28,7 @@ void main() {
   group(OutageDiagnosisService, () {
     late _MockHttpClient httpClient;
     final endpoint = Uri.parse('https://status.example/api/status');
+    const spaShell = '<!doctype html><html><body>Operational</body></html>';
 
     setUpAll(() {
       registerFallbackValue(Uri.parse('https://status.example'));
@@ -113,20 +114,25 @@ void main() {
       verifyNever(() => httpClient.get(any(), headers: any(named: 'headers')));
     });
 
-    test(
-      'blames the network when the status page is unreachable too',
-      () async {
-        // The status host is on a different CDN from the API. Both failing
-        // points at the one thing they share: the user's own connection.
-        when(
-          () => httpClient.get(endpoint, headers: any(named: 'headers')),
-        ).thenThrow(http.ClientException('unreachable'));
+    test('stays indeterminate when the status page is unreachable', () async {
+      // The client returns null for both transport failure and invalid payloads.
+      // Only the connectivity probe may produce a user-network claim.
+      when(
+        () => httpClient.get(endpoint, headers: any(named: 'headers')),
+      ).thenThrow(http.ClientException('unreachable'));
 
-        final diagnosis = await buildService().diagnose();
+      final diagnosis = await buildService().diagnose();
 
-        expect(diagnosis.verdict, equals(OutageVerdict.noConnection));
-      },
-    );
+      expect(diagnosis.verdict, equals(OutageVerdict.indeterminate));
+    });
+
+    test('stays indeterminate for a non-status document', () async {
+      stubStatus(spaShell);
+
+      final diagnosis = await buildService().diagnose();
+
+      expect(diagnosis.verdict, equals(OutageVerdict.indeterminate));
+    });
 
     test('surfaces the operator message over canned copy', () async {
       stubStatus(
@@ -184,6 +190,22 @@ void main() {
       ).called(1);
     });
 
+    test('caches verdicts by component set', () async {
+      stubStatus(_statusBody());
+      final service = buildService();
+
+      final feedDiagnosis = await service.diagnose();
+      final uploadsDiagnosis = await service.diagnose(
+        components: const [DivineStatusComponents.uploads],
+      );
+
+      expect(feedDiagnosis.verdict, equals(OutageVerdict.indeterminate));
+      expect(uploadsDiagnosis.verdict, equals(OutageVerdict.divineOutage));
+      verify(
+        () => httpClient.get(endpoint, headers: any(named: 'headers')),
+      ).called(2);
+    });
+
     test(
       'falls through to the status check when connectivity throws',
       () async {
@@ -202,18 +224,5 @@ void main() {
         );
       },
     );
-
-    test('invalidateCache forces a fresh diagnosis', () async {
-      stubStatus(_statusBody(apiStatus: 'down'));
-      final service = buildService();
-
-      await service.diagnose();
-      service.invalidateCache();
-      await service.diagnose();
-
-      verify(
-        () => httpClient.get(endpoint, headers: any(named: 'headers')),
-      ).called(2);
-    });
   });
 }

--- a/mobile/test/services/outage_diagnosis_service_test.dart
+++ b/mobile/test/services/outage_diagnosis_service_test.dart
@@ -85,6 +85,22 @@ void main() {
       expect(diagnosis.verdict, equals(OutageVerdict.indeterminate));
     });
 
+    test('keeps verdicts separate per component set', () async {
+      // `uploads` is down in the fixture while `api`/`relay` are healthy. A
+      // surface asking about uploads must get its own verdict, not the feed's
+      // cached one.
+      stubStatus(_statusBody());
+      final service = buildService();
+
+      final feed = await service.diagnose();
+      final uploads = await service.diagnose(
+        components: const [DivineStatusComponents.uploads],
+      );
+
+      expect(feed.verdict, equals(OutageVerdict.indeterminate));
+      expect(uploads.verdict, equals(OutageVerdict.divineOutage));
+    });
+
     test('blames the network when there is no interface', () async {
       stubStatus(_statusBody(apiStatus: 'down'));
 

--- a/mobile/test/services/outage_diagnosis_service_test.dart
+++ b/mobile/test/services/outage_diagnosis_service_test.dart
@@ -1,0 +1,203 @@
+// ABOUTME: Tests the outage-vs-your-network diagnosis.
+// ABOUTME: Pins that we never claim an outage we cannot substantiate.
+
+import 'dart:convert';
+
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:divine_status_client/divine_status_client.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/services/outage_diagnosis_service.dart';
+
+class _MockHttpClient extends Mock implements http.Client {}
+
+String _statusBody({String apiStatus = 'operational', Object? incident}) {
+  return jsonEncode({
+    'updatedAt': '2026-08-17T03:18:41.874Z',
+    'components': {
+      'api': {'id': 'api', 'status': apiStatus},
+      'relay': {'id': 'relay', 'status': 'operational'},
+      'uploads': {'id': 'uploads', 'status': 'down'},
+    },
+    'incident': incident,
+  });
+}
+
+void main() {
+  group(OutageDiagnosisService, () {
+    late _MockHttpClient httpClient;
+    final endpoint = Uri.parse('https://status.example/api/status');
+
+    setUpAll(() {
+      registerFallbackValue(Uri.parse('https://status.example'));
+    });
+
+    setUp(() {
+      httpClient = _MockHttpClient();
+    });
+
+    OutageDiagnosisService buildService({
+      List<ConnectivityResult> connectivity = const [ConnectivityResult.wifi],
+      DateTime Function()? now,
+    }) {
+      return OutageDiagnosisService(
+        statusClient: DivineStatusClient(
+          httpClient: httpClient,
+          endpoint: endpoint,
+        ),
+        connectivityProbe: () async => connectivity,
+        now: now,
+      );
+    }
+
+    void stubStatus(String body, {int statusCode = 200}) {
+      when(
+        () => httpClient.get(endpoint, headers: any(named: 'headers')),
+      ).thenAnswer((_) async => http.Response(body, statusCode));
+    }
+
+    test('blames Divine when a feed component is impaired', () async {
+      stubStatus(_statusBody(apiStatus: 'down'));
+
+      final diagnosis = await buildService().diagnose();
+
+      expect(diagnosis.verdict, equals(OutageVerdict.divineOutage));
+    });
+
+    test('stays indeterminate when the status page reports health', () async {
+      // Something failed, but nothing corroborates why. Claiming an outage
+      // here is how the message loses its credibility.
+      stubStatus(_statusBody());
+
+      final diagnosis = await buildService().diagnose();
+
+      expect(diagnosis.verdict, equals(OutageVerdict.indeterminate));
+    });
+
+    test('ignores components the feed does not depend on', () async {
+      // `uploads` is down in the fixture. A viewer scrolling videos is not
+      // uploading and must not be told about it.
+      stubStatus(_statusBody());
+
+      final diagnosis = await buildService().diagnose();
+
+      expect(diagnosis.verdict, equals(OutageVerdict.indeterminate));
+    });
+
+    test('blames the network when there is no interface', () async {
+      stubStatus(_statusBody(apiStatus: 'down'));
+
+      final diagnosis = await buildService(
+        connectivity: const [ConnectivityResult.none],
+      ).diagnose();
+
+      expect(diagnosis.verdict, equals(OutageVerdict.noConnection));
+      // The status page must not even be asked when the radio is off.
+      verifyNever(() => httpClient.get(any(), headers: any(named: 'headers')));
+    });
+
+    test(
+      'blames the network when the status page is unreachable too',
+      () async {
+        // The status host is on a different CDN from the API. Both failing
+        // points at the one thing they share: the user's own connection.
+        when(
+          () => httpClient.get(endpoint, headers: any(named: 'headers')),
+        ).thenThrow(http.ClientException('unreachable'));
+
+        final diagnosis = await buildService().diagnose();
+
+        expect(diagnosis.verdict, equals(OutageVerdict.noConnection));
+      },
+    );
+
+    test('surfaces the operator message over canned copy', () async {
+      stubStatus(
+        _statusBody(
+          apiStatus: 'down',
+          incident: {'message': 'Feed degraded, fix rolling out.'},
+        ),
+      );
+
+      final diagnosis = await buildService().diagnose();
+
+      expect(
+        diagnosis.operatorMessage,
+        equals('Feed degraded, fix rolling out.'),
+      );
+    });
+
+    test('serves a cached verdict rather than re-asking', () async {
+      // During an incident every client fails at once; repeated retries must
+      // not turn into repeated requests to the page that is explaining it.
+      stubStatus(_statusBody(apiStatus: 'down'));
+      final service = buildService();
+
+      await service.diagnose();
+      await service.diagnose();
+      await service.diagnose();
+
+      verify(
+        () => httpClient.get(endpoint, headers: any(named: 'headers')),
+      ).called(1);
+    });
+
+    test('re-asks once the cache expires', () async {
+      stubStatus(_statusBody(apiStatus: 'down'));
+      var clock = DateTime(2026, 8, 17, 12);
+      final service = buildService(now: () => clock);
+
+      await service.diagnose();
+      clock = clock.add(OutageDiagnosisService.cacheDuration * 2);
+      await service.diagnose();
+
+      verify(
+        () => httpClient.get(endpoint, headers: any(named: 'headers')),
+      ).called(2);
+    });
+
+    test('shares one request between concurrent callers', () async {
+      stubStatus(_statusBody(apiStatus: 'down'));
+      final service = buildService();
+
+      await Future.wait([service.diagnose(), service.diagnose()]);
+
+      verify(
+        () => httpClient.get(endpoint, headers: any(named: 'headers')),
+      ).called(1);
+    });
+
+    test(
+      'falls through to the status check when connectivity throws',
+      () async {
+        stubStatus(_statusBody(apiStatus: 'down'));
+        final service = OutageDiagnosisService(
+          statusClient: DivineStatusClient(
+            httpClient: httpClient,
+            endpoint: endpoint,
+          ),
+          connectivityProbe: () async => throw Exception('no plugin'),
+        );
+
+        expect(
+          (await service.diagnose()).verdict,
+          equals(OutageVerdict.divineOutage),
+        );
+      },
+    );
+
+    test('invalidateCache forces a fresh diagnosis', () async {
+      stubStatus(_statusBody(apiStatus: 'down'));
+      final service = buildService();
+
+      await service.diagnose();
+      service.invalidateCache();
+      await service.diagnose();
+
+      verify(
+        () => httpClient.get(endpoint, headers: any(named: 'headers')),
+      ).called(2);
+    });
+  });
+}


### PR DESCRIPTION
## Description

When the home feed fails to load, the app used to say **"Failed to load videos"** and render `error.toString()` underneath, putting the raw enum `VideoFeedError.loadFailed` on screen for users.

The failure view now diagnoses itself against `status.divine.video` and says which cause is actually supported by evidence.

### What the user sees

| Feed failed, and... | Message |
|---|---|
| the device reports no network interface | "You're offline. Check your connection and try again." |
| status page says `api` or `relay` is impaired | "Videos aren't loading right now. It's us, not you -- we're on it." |
| status page carries an operator incident message | that message, verbatim |
| check is still running, status page reports health, or the status read has no usable opinion | "Failed to load videos" |

The important safety rule is that the app does not blame either side without evidence. A confirmed no-interface probe can use offline copy; an invalid, malformed, unavailable, or non-status status-page response stays generic because that single `null` result can mean several different things.

### Scoped to what the user is actually doing

A viewer scrolling videos is never told that uploads are degraded. The diagnosis asks only about `api` and `relay`; the test fixture has `uploads: down` precisely to pin that it is ignored. There is no global banner and no background polling -- the check runs only while someone is looking at a broken feed, and verdicts are cached for 2 minutes per component set with concurrent callers sharing one request.

### Parsing is deliberately asymmetric

Only the literal `operational` reads as healthy; only `unknown` (or missing) reads as no-opinion; every other value reads as impaired. Guessing the complete set of failure words would go quiet during an outage that used a word we did not anticipate.

Every non-API path on the status host answers 200 with the single-page-app shell, so a wrong URL or a captive portal yields HTML rather than an error code. Reading that as "all clear" would silently disable the feature, so the client validates shape rather than status code.

**Related Issue:** Relates to #7706

## Out of Scope

- Uploads, playback, and every other surface. Only the feed failure view is wired.
- `ConnectionStatusService` is not the offline signal. Its `checkConnection()` is a stub, so this uses `connectivity_plus` instead.
- The baseline hand-edits are limited to files this branch touched; broader baseline drift remains separate cleanup.

## Verification

- `flutter test test/services/outage_diagnosis_service_test.dart test/blocs/outage_notice/outage_notice_cubit_test.dart test/screens/feed/video_feed_page/feed_error_widget_test.dart`
- `flutter analyze lib test integration_test`
- `dart analyze` from `mobile/packages/divine_status_client`
- `dart test` from `mobile/packages/divine_status_client`
- `very_good test --coverage --min-coverage 100` from `mobile/packages/divine_status_client`

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
