### PR TITLE
fix(nostr): retry temp relay auth publishes

### DIFF
--- a/mobile/packages/follow_repository/test/src/follow_repository_test.dart
+++ b/mobile/packages/follow_repository/test/src/follow_repository_test.dart
@@ -62,7 +62,6 @@ class _FakeRelay extends RelayBase {
   @override
   Future<bool> send(
     List<dynamic> message, {
-    bool? forceSend,
     bool queueIfFailed = true,
     bool skipReconnect = false,
     DateTime? deadline,

--- a/mobile/packages/nostr_sdk/lib/nip46/nostr_remote_signer.dart
+++ b/mobile/packages/nostr_sdk/lib/nip46/nostr_remote_signer.dart
@@ -333,7 +333,7 @@ class NostrRemoteSigner extends NostrSigner {
           );
           for (var entry in _pendingRequestEvents.entries) {
             log('[NIP46] _reconnectRelay: resending request id=${entry.key}');
-            relay.send(entry.value, forceSend: true);
+            relay.send(entry.value);
           }
         }
       } else {
@@ -466,7 +466,7 @@ class NostrRemoteSigner extends NostrSigner {
           log(
             '[NIP46] sendAndWaitForResult: sending to ${relay.relayStatus.addr}, connected=${relay.relayStatus.connected}',
           );
-          relay.send(json, forceSend: true);
+          relay.send(json);
         }
 
         log(

--- a/mobile/packages/nostr_sdk/lib/relay/relay.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay.dart
@@ -5,6 +5,8 @@ import 'dart:async';
 import 'dart:collection';
 import 'dart:developer';
 
+import 'package:meta/meta.dart';
+
 import '../count_response.dart';
 import '../subscription.dart';
 import 'client_connected.dart';
@@ -157,6 +159,7 @@ abstract class Relay {
     _recentSentEvents.remove(eventId);
   }
 
+  @visibleForTesting
   bool hasRetainedSentEvent(String eventId) =>
       _recentSentEvents.containsKey(eventId);
 

--- a/mobile/packages/nostr_sdk/lib/relay/relay.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay.dart
@@ -2,6 +2,7 @@
 // ABOUTME: Manages subscriptions, queries, COUNT queries, and pending messages.
 
 import 'dart:async';
+import 'dart:collection';
 import 'dart:developer';
 
 import '../count_response.dart';
@@ -14,6 +15,8 @@ import 'relay_status.dart';
 enum WriteAccess { readOnly, writeOnly, readWrite, nothing }
 
 abstract class Relay {
+  static const int _recentSentEventLimit = 64;
+
   final String url;
 
   RelayStatus relayStatus;
@@ -33,6 +36,9 @@ abstract class Relay {
 
   // queries
   final Map<String, Subscription> _queries = {};
+
+  final LinkedHashMap<String, List<dynamic>> _recentSentEvents =
+      LinkedHashMap<String, List<dynamic>>();
 
   // NIP-45 COUNT queries
   final Map<String, Completer<CountResponse>> _countQueries = {};
@@ -136,6 +142,24 @@ abstract class Relay {
   bool _isReqNaming(List<dynamic> message, Set<String> ids) =>
       message.length > 1 && message[0] == 'REQ' && ids.contains(message[1]);
 
+  void retainSentEvent(String eventId, List<dynamic> message) {
+    _recentSentEvents.remove(eventId);
+    _recentSentEvents[eventId] = List<dynamic>.from(message);
+    while (_recentSentEvents.length > _recentSentEventLimit) {
+      _recentSentEvents.remove(_recentSentEvents.keys.first);
+    }
+  }
+
+  List<dynamic>? takeSentEvent(String eventId) =>
+      _recentSentEvents.remove(eventId);
+
+  void forgetSentEvent(String eventId) {
+    _recentSentEvents.remove(eventId);
+  }
+
+  bool hasRetainedSentEvent(String eventId) =>
+      _recentSentEvents.containsKey(eventId);
+
   /// Re-sends every REQ this relay is still holding on the fresh socket.
   ///
   /// `skipReconnect` matches how these REQs were sent the first time
@@ -170,7 +194,6 @@ abstract class Relay {
   /// queue the message after it has expired.
   Future<bool> send(
     List<dynamic> message, {
-    bool? forceSend,
     bool queueIfFailed = true,
     bool skipReconnect = false,
     DateTime? deadline,

--- a/mobile/packages/nostr_sdk/lib/relay/relay_base.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_base.dart
@@ -140,7 +140,6 @@ class RelayBase extends Relay {
   @override
   Future<bool> send(
     List<dynamic> message, {
-    bool? forceSend,
     bool queueIfFailed = true,
     bool skipReconnect = false,
     DateTime? deadline,

--- a/mobile/packages/nostr_sdk/lib/relay/relay_isolate.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_isolate.dart
@@ -98,7 +98,6 @@ class RelayIsolate extends Relay {
   @override
   Future<bool> send(
     List message, {
-    bool? forceSend,
     bool queueIfFailed = true,
     bool skipReconnect = false,
     DateTime? deadline,

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -443,6 +443,26 @@ class RelayPool {
     }
   }
 
+  void _flushPendingAuthedMessages(Relay relay) {
+    for (var message in relay.pendingAuthedMessages) {
+      relay.send(message);
+    }
+    relay.pendingAuthedMessages.clear();
+  }
+
+  /// Fire-and-forget frames parked behind a NIP-42 handshake that failed.
+  /// Nothing will ever flush them, so drop them rather than growing the queue
+  /// without bound — and, for temp relays, pinning a dead socket that the
+  /// reaper treats a non-empty queue as reason to keep.
+  void _dropPendingAuthedMessages(Relay relay) {
+    if (relay.pendingAuthedMessages.isEmpty) return;
+    log(
+      '🔐 Dropping ${relay.pendingAuthedMessages.length} messages parked for '
+      'auth on ${relay.url}: auth failed',
+    );
+    relay.pendingAuthedMessages.clear();
+  }
+
   List<MapEntry<String, _AuthRequiredPublishRetry>> _retryEntriesForRelay(
     Relay relay,
   ) {
@@ -1538,6 +1558,12 @@ class RelayPool {
             '🔐 Queueing untracked auth-required EVENT for post-AUTH retry '
             'eventId=$eventId relay=${relay.url}',
           );
+          // Mirror the tracked branch: an auth-required rejection on a relay
+          // we already authed means no fresh challenge is coming to drain the
+          // queue, so flush it right away.
+          if (relay.relayStatus.authed) {
+            _flushPendingAuthedMessages(relay);
+          }
         }
       } else {
         relay.forgetSentEvent(eventId);
@@ -1553,10 +1579,7 @@ class RelayPool {
           log('🔐 AUTH succeeded for ${relay.url}');
 
           // Send pending messages
-          for (var message in relay.pendingAuthedMessages) {
-            relay.send(message);
-          }
-          relay.pendingAuthedMessages.clear();
+          _flushPendingAuthedMessages(relay);
 
           // Send subscriptions
           if (relay.hasSubscription()) {
@@ -1591,6 +1614,7 @@ class RelayPool {
           relay.relayStatus.authed = false;
           log('🔐 AUTH failed for ${relay.url}: $message');
           _rejectAuthRequiredPublishesForRelay(relay, message);
+          _dropPendingAuthedMessages(relay);
           // The gate stayed shut, so the queries parked for the post-AUTH
           // replay will never be replayed.
           _closeAuthGate(relay);
@@ -1651,11 +1675,13 @@ class RelayPool {
         } else {
           log('🔐 AUTH signing returned null for ${relay.url}');
           _rejectAuthRequiredPublishesForRelay(relay, '');
+          _dropPendingAuthedMessages(relay);
           _closeAuthGate(relay);
         }
       } catch (err, stackTrace) {
         log('🔐 AUTH handling failed for ${relay.url}: $err\n$stackTrace');
         _rejectAuthRequiredPublishesForRelay(relay, '');
+        _dropPendingAuthedMessages(relay);
         _closeAuthGate(relay);
       }
     } else if (messageType == 'COUNT') {
@@ -2286,16 +2312,13 @@ class RelayPool {
         if (timeout == Duration.zero) break;
 
         var tempRelay = checkAndGenTempRelay(tempRelayAddr);
-        if (tempRelay.relayStatus.alwaysAuth &&
-            !tempRelay.relayStatus.authed &&
-            deadline == null) {
-          log(
-            '🔐 Queueing temp relay message for authentication: ${message[0]}',
-          );
-          tempRelay.pendingAuthedMessages.add(message);
-          sentTo.add(tempRelay.url);
-          continue;
-        }
+        // A known-auth unauthed temp relay still gets the frame on the wire
+        // rather than a queue slot: temp relays carry no subscriptions or
+        // queries, so nothing else can trigger the AUTH challenge the
+        // post-AUTH flush depends on, and a parked frame would strand the
+        // publish while send() reports success. Sending the retained frame
+        // is what prompts the relay to challenge (or accept); an
+        // auth-required rejection re-queues it via the retained-copy path.
 
         // Same skipReconnect rationale as the main loop above: a fresh
         // tempRelay whose initial connection is still in-flight must not

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -395,6 +395,24 @@ class RelayPool {
         !relay.relayStatus.authed;
   }
 
+  String? _untrackedEventId(List<dynamic> message) {
+    if (message.length < 2 || message[0] != 'EVENT') return null;
+    final event = message[1];
+    if (event is! Map) return null;
+    final eventId = event['id'];
+    if (eventId is! String) return null;
+    if (_pendingPublishes.containsKey(eventId)) return null;
+    return eventId;
+  }
+
+  String? _retainUntrackedEvent(Relay relay, List<dynamic> message) {
+    final eventId = _untrackedEventId(message);
+    if (eventId != null) {
+      relay.retainSentEvent(eventId, message);
+    }
+    return eventId;
+  }
+
   void _trackAuthRequiredPublish({
     required Relay relay,
     required List<dynamic> message,
@@ -622,7 +640,7 @@ class RelayPool {
         log('🔐 Auth-required query - sending to trigger AUTH challenge');
         relay.saveQuery(subscription);
         final result = await relay
-            .send(message, forceSend: true)
+            .send(message)
             .timeout(perRelaySendTimeout, onTimeout: () => false);
         if (!result) {
           log(
@@ -1505,6 +1523,24 @@ class RelayPool {
           _removeAuthRequiredPublish(eventId, relay.url);
           publishTracker.onRejected(relay.url, message);
         }
+      } else if (success) {
+        relay.forgetSentEvent(eventId);
+      } else if (_shouldRetryPublishAfterAuth(
+        relay: relay,
+        eventId: eventId,
+        message: message,
+      )) {
+        final originalMessage = relay.takeSentEvent(eventId);
+        if (originalMessage != null) {
+          relay.relayStatus.alwaysAuth = true;
+          relay.pendingAuthedMessages.add(originalMessage);
+          log(
+            '🔐 Queueing untracked auth-required EVENT for post-AUTH retry '
+            'eventId=$eventId relay=${relay.url}',
+          );
+        }
+      } else {
+        relay.forgetSentEvent(eventId);
       }
 
       // Check if this is responding to our AUTH event
@@ -1604,7 +1640,7 @@ class RelayPool {
           // Track this AUTH event to match with OK response
           _pendingAuthEvents[event.id] = relay.url;
 
-          relay.send(["AUTH", event.toJson()], forceSend: true);
+          relay.send(["AUTH", event.toJson()]);
           log('🔐 AUTH response sent, waiting for relay confirmation...');
 
           if (relay.pendingAuthedMessages.isNotEmpty) {
@@ -1817,7 +1853,7 @@ class RelayPool {
           '🔐 Auth-required subscription - sending to trigger AUTH challenge',
         );
         final result = await relay
-            .send(message, forceSend: true)
+            .send(message)
             .timeout(perRelaySendTimeout, onTimeout: () => false);
         if (result) {
           return true;
@@ -2154,14 +2190,10 @@ class RelayPool {
             log(
               '🔐 Deadline-bound auth publish - sending to trigger AUTH challenge',
             );
+            final retainedEventId = _retainUntrackedEvent(relay, message);
             var timedOut = false;
             var result = await relay
-                .send(
-                  message,
-                  forceSend: true,
-                  queueIfFailed: false,
-                  deadline: deadline,
-                )
+                .send(message, queueIfFailed: false, deadline: deadline)
                 .timeout(
                   timeout,
                   onTimeout: () {
@@ -2182,6 +2214,8 @@ class RelayPool {
             }
             if (result) {
               sentTo.add(relay.url);
+            } else if (retainedEventId != null) {
+              relay.forgetSentEvent(retainedEventId);
             }
           } else {
             log('🔐 Queueing message for authentication: ${message[0]}');
@@ -2200,6 +2234,7 @@ class RelayPool {
           // while one dead relay tries exponential backoff (can hang the
           // publish for many minutes). Same convention as relayDoQuery /
           // relayDoSubscribe above.
+          final retainedEventId = _retainUntrackedEvent(relay, message);
           var timedOut = false;
           var result = await relay
               .send(
@@ -2228,6 +2263,8 @@ class RelayPool {
           }
           if (result) {
             sentTo.add(relay.url);
+          } else if (retainedEventId != null && deadline != null) {
+            relay.forgetSentEvent(retainedEventId);
           }
         }
       } catch (err) {
@@ -2249,9 +2286,21 @@ class RelayPool {
         if (timeout == Duration.zero) break;
 
         var tempRelay = checkAndGenTempRelay(tempRelayAddr);
+        if (tempRelay.relayStatus.alwaysAuth &&
+            !tempRelay.relayStatus.authed &&
+            deadline == null) {
+          log(
+            '🔐 Queueing temp relay message for authentication: ${message[0]}',
+          );
+          tempRelay.pendingAuthedMessages.add(message);
+          sentTo.add(tempRelay.url);
+          continue;
+        }
+
         // Same skipReconnect rationale as the main loop above: a fresh
         // tempRelay whose initial connection is still in-flight must not
         // block the publish.
+        final retainedEventId = _retainUntrackedEvent(tempRelay, message);
         var result = await tempRelay
             .send(
               message,
@@ -2271,6 +2320,9 @@ class RelayPool {
               },
             );
         if (!result) {
+          if (retainedEventId != null) {
+            tempRelay.forgetSentEvent(retainedEventId);
+          }
           removeExpiredTempRelay(tempRelay);
         }
         if (result) {

--- a/mobile/packages/nostr_sdk/test/integration/nip50_search_test.dart
+++ b/mobile/packages/nostr_sdk/test/integration/nip50_search_test.dart
@@ -45,7 +45,6 @@ class _MockRelay extends RelayBase {
   @override
   Future<bool> send(
     List<dynamic> message, {
-    bool? forceSend,
     bool queueIfFailed = true,
     bool skipReconnect = false,
     DateTime? deadline,

--- a/mobile/packages/nostr_sdk/test/integration/relay_auth_test.dart
+++ b/mobile/packages/nostr_sdk/test/integration/relay_auth_test.dart
@@ -15,7 +15,6 @@ class MockRelay extends RelayBase {
   @override
   Future<bool> send(
     List<dynamic> message, {
-    bool? forceSend,
     bool queueIfFailed = true,
     bool skipReconnect = false,
     DateTime? deadline,

--- a/mobile/packages/nostr_sdk/test/unit/relay_count_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_count_test.dart
@@ -17,7 +17,6 @@ class TestRelay extends Relay {
   @override
   Future<bool> send(
     List<dynamic> message, {
-    bool? forceSend,
     bool queueIfFailed = true,
     bool skipReconnect = false,
     DateTime? deadline,

--- a/mobile/packages/nostr_sdk/test/unit/relay_pending_messages_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pending_messages_test.dart
@@ -26,7 +26,6 @@ class _RequeueingRelay extends Relay {
   @override
   Future<bool> send(
     List<dynamic> message, {
-    bool? forceSend,
     bool queueIfFailed = true,
     bool skipReconnect = false,
     DateTime? deadline,

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_auth_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_auth_test.dart
@@ -556,6 +556,35 @@ void main() {
         expect(relay.pendingAuthedMessages, isEmpty);
       },
     );
+
+    test(
+      'flushes an untracked auth-required rejection immediately when already authed',
+      () async {
+        const eventId =
+            'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
+        relay.relayStatus.alwaysAuth = true;
+        relay.relayStatus.authed = true;
+
+        final sent = await nostr.relayPool.send(eventMessage(eventId));
+
+        expect(sent, isTrue);
+        expect(sentMessagesOfType(relay, 'EVENT'), hasLength(1));
+
+        // The relay drops our auth session without reconnecting and rejects
+        // with auth-required. No fresh challenge will arrive (there is none
+        // in this test), so the parked frame must flush on its own instead
+        // of waiting in pendingAuthedMessages forever.
+        await relay.deliver([
+          'OK',
+          eventId,
+          false,
+          'auth-required: you must auth',
+        ]);
+
+        expect(sentMessagesOfType(relay, 'EVENT'), hasLength(2));
+        expect(relay.pendingAuthedMessages, isEmpty);
+      },
+    );
   });
 
   group('RelayPool temp relay auth-required publish retry', () {
@@ -612,34 +641,79 @@ void main() {
       },
     );
 
-    test('parks known-auth temp relay EVENT until AUTH succeeds', () async {
-      const relayUrl = 'wss://temp-known-auth.example';
-      const eventId =
-          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
-      nostr = Nostr(signer, [], (url) {
-        tempRelay = _AuthFakeRelay(url)
-          ..relayStatus.alwaysAuth = true
-          ..relayStatus.authed = false;
-        return tempRelay;
-      });
-      await nostr.refreshPublicKey();
+    test(
+      'sends to a known-auth unauthed temp relay instead of parking',
+      () async {
+        const relayUrl = 'wss://temp-known-auth.example';
+        const eventId =
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+        nostr = Nostr(signer, [], (url) {
+          tempRelay = _AuthFakeRelay(url)
+            ..relayStatus.alwaysAuth = true
+            ..relayStatus.authed = false;
+          return tempRelay;
+        });
+        await nostr.refreshPublicKey();
 
-      final sent = await nostr.relayPool.send(
-        eventMessage(eventId),
-        tempRelays: [relayUrl],
-      );
+        final sent = await nostr.relayPool.send(
+          eventMessage(eventId),
+          tempRelays: [relayUrl],
+        );
 
-      expect(sent, isTrue);
-      expect(sentMessagesOfType(tempRelay, 'EVENT'), isEmpty);
-      expect(tempRelay.pendingAuthedMessages, hasLength(1));
+        // A temp relay carries no other traffic, so nothing but the frame
+        // itself can trigger the AUTH challenge the post-AUTH flush waits
+        // for. Parking it here would strand the publish forever while
+        // send() reports success.
+        expect(sent, isTrue);
+        expect(sentMessagesOfType(tempRelay, 'EVENT'), hasLength(1));
+        expect(tempRelay.pendingAuthedMessages, isEmpty);
 
-      await tempRelay.deliver(['AUTH', challenge]);
-      final authEventId = sentAuthEventId(tempRelay);
-      await tempRelay.deliver(['OK', authEventId, true, '']);
+        await tempRelay.deliver([
+          'OK',
+          eventId,
+          false,
+          'auth-required: you must auth',
+        ]);
+        expect(tempRelay.pendingAuthedMessages, hasLength(1));
 
-      expect(sentMessagesOfType(tempRelay, 'EVENT'), hasLength(1));
-      expect(tempRelay.pendingAuthedMessages, isEmpty);
-    });
+        await tempRelay.deliver(['AUTH', challenge]);
+        final authEventId = sentAuthEventId(tempRelay);
+        await tempRelay.deliver(['OK', authEventId, true, '']);
+
+        expect(sentMessagesOfType(tempRelay, 'EVENT'), hasLength(2));
+        expect(tempRelay.pendingAuthedMessages, isEmpty);
+      },
+    );
+
+    test(
+      'drops parked untracked frames when the AUTH handshake fails',
+      () async {
+        const relayUrl = 'wss://temp-auth-failed.example';
+        const eventId =
+            'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd';
+
+        final sent = await nostr.relayPool.send(
+          eventMessage(eventId),
+          tempRelays: [relayUrl],
+        );
+        expect(sent, isTrue);
+
+        await tempRelay.deliver([
+          'OK',
+          eventId,
+          false,
+          'auth-required: you must auth',
+        ]);
+        expect(tempRelay.pendingAuthedMessages, hasLength(1));
+
+        await tempRelay.deliver(['AUTH', challenge]);
+        final authEventId = sentAuthEventId(tempRelay);
+        await tempRelay.deliver(['OK', authEventId, false, 'unauthorized']);
+
+        expect(tempRelay.pendingAuthedMessages, isEmpty);
+        expect(tempRelay.relayStatus.authed, isFalse);
+      },
+    );
 
     test(
       'drops retained fire-and-forget temp relay EVENT on OK true',

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_auth_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_auth_test.dart
@@ -60,7 +60,6 @@ class _AuthFakeRelay extends Relay {
   @override
   Future<bool> send(
     List<dynamic> message, {
-    bool? forceSend,
     bool queueIfFailed = true,
     bool skipReconnect = false,
     DateTime? deadline,
@@ -101,6 +100,11 @@ void main() {
     expect(id, isA<String>());
     return id as String;
   }
+
+  List<dynamic> eventMessage(String eventId) => [
+    'EVENT',
+    {'id': eventId, 'kind': EventKind.giftWrap},
+  ];
 
   group('RelayPool AUTH branch empty-pubkey guard', () {
     Relay dummyTempRelay(String url) => RelayBase(url, RelayStatus(url));
@@ -197,10 +201,7 @@ void main() {
       const eventId =
           '1111111111111111111111111111111111111111111111111111111111111111';
       final outcomeFuture = nostr.relayPool.sendEventAwaitOk(
-        [
-          'EVENT',
-          {'id': eventId, 'kind': EventKind.giftWrap},
-        ],
+        eventMessage(eventId),
         eventId: eventId,
         targetRelays: [relay.url],
         timeout: const Duration(seconds: 1),
@@ -267,10 +268,7 @@ void main() {
       const eventId =
           '3333333333333333333333333333333333333333333333333333333333333333';
       final outcomeFuture = nostr.relayPool.sendEventAwaitOk(
-        [
-          'EVENT',
-          {'id': eventId, 'kind': EventKind.giftWrap},
-        ],
+        eventMessage(eventId),
         eventId: eventId,
         targetRelays: [relay.url],
         timeout: const Duration(seconds: 1),
@@ -299,10 +297,7 @@ void main() {
       const eventId =
           '2222222222222222222222222222222222222222222222222222222222222222';
       final outcomeFuture = nostr.relayPool.sendEventAwaitOk(
-        [
-          'EVENT',
-          {'id': eventId, 'kind': EventKind.giftWrap},
-        ],
+        eventMessage(eventId),
         eventId: eventId,
         targetRelays: [relay.url],
         timeout: const Duration(seconds: 1),
@@ -342,10 +337,7 @@ void main() {
       const eventId =
           '4444444444444444444444444444444444444444444444444444444444444444';
       final outcomeFuture = nostr.relayPool.sendEventAwaitOk(
-        [
-          'EVENT',
-          {'id': eventId, 'kind': EventKind.giftWrap},
-        ],
+        eventMessage(eventId),
         eventId: eventId,
         targetRelays: [relay.url],
         timeout: const Duration(seconds: 1),
@@ -378,10 +370,7 @@ void main() {
       const eventId =
           '5555555555555555555555555555555555555555555555555555555555555555';
       final outcomeFuture = nostr.relayPool.sendEventAwaitOk(
-        [
-          'EVENT',
-          {'id': eventId, 'kind': EventKind.giftWrap},
-        ],
+        eventMessage(eventId),
         eventId: eventId,
         targetRelays: [relay.url],
         timeout: const Duration(seconds: 1),
@@ -420,10 +409,7 @@ void main() {
       const eventId =
           '7777777777777777777777777777777777777777777777777777777777777777';
       final outcomeFuture = nostr.relayPool.sendEventAwaitOk(
-        [
-          'EVENT',
-          {'id': eventId, 'kind': EventKind.giftWrap},
-        ],
+        eventMessage(eventId),
         eventId: eventId,
         targetRelays: [relay.url],
         timeout: const Duration(milliseconds: 10),
@@ -462,10 +448,7 @@ void main() {
       );
       expect(added, isTrue);
       final outcomeFuture = unauthenticatedNostr.relayPool.sendEventAwaitOk(
-        [
-          'EVENT',
-          {'id': eventId, 'kind': EventKind.giftWrap},
-        ],
+        eventMessage(eventId),
         eventId: eventId,
         targetRelays: [unauthenticatedRelay.url],
         timeout: const Duration(seconds: 1),
@@ -495,10 +478,7 @@ void main() {
         const eventId =
             '6666666666666666666666666666666666666666666666666666666666666666';
         final outcomeFuture = nostr.relayPool.sendEventAwaitOk(
-          [
-            'EVENT',
-            {'id': eventId, 'kind': EventKind.giftWrap},
-          ],
+          eventMessage(eventId),
           eventId: eventId,
           targetRelays: [relay.url],
           timeout: const Duration(seconds: 1),
@@ -534,6 +514,149 @@ void main() {
           hasLength(2),
           reason: 'the resend is attempted once before giving up',
         );
+      },
+    );
+  });
+
+  group('RelayPool temp relay auth-required publish retry', () {
+    late LocalNostrSigner signer;
+    late Nostr nostr;
+    late _AuthFakeRelay tempRelay;
+
+    setUp(() async {
+      signer = LocalNostrSigner(testPrivateKey);
+      nostr = Nostr(signer, [], (url) {
+        tempRelay = _AuthFakeRelay(url);
+        return tempRelay;
+      });
+      await nostr.refreshPublicKey();
+    });
+
+    test(
+      'republishes a fire-and-forget temp relay EVENT after NIP-42 succeeds',
+      () async {
+        const relayUrl = 'wss://temp-auth-required.example';
+        const eventId =
+            '9999999999999999999999999999999999999999999999999999999999999999';
+
+        final sent = await nostr.relayPool.send(
+          eventMessage(eventId),
+          tempRelays: [relayUrl],
+        );
+
+        expect(sent, isTrue);
+        expect(sentMessagesOfType(tempRelay, 'EVENT'), hasLength(1));
+        expect(tempRelay.hasRetainedSentEvent(eventId), isTrue);
+
+        await tempRelay.deliver([
+          'OK',
+          eventId,
+          false,
+          'auth-required: you must auth',
+        ]);
+        expect(tempRelay.pendingAuthedMessages, hasLength(1));
+        expect(tempRelay.hasRetainedSentEvent(eventId), isFalse);
+
+        await tempRelay.deliver(['AUTH', challenge]);
+        final authEventId = sentAuthEventId(tempRelay);
+        await tempRelay.deliver(['OK', authEventId, true, '']);
+
+        expect(
+          sentMessagesOfType(tempRelay, 'EVENT'),
+          hasLength(2),
+          reason: 'the original EVENT should be retried once after AUTH',
+        );
+
+        await tempRelay.deliver(['OK', eventId, true, '']);
+        expect(sentMessagesOfType(tempRelay, 'EVENT'), hasLength(2));
+      },
+    );
+
+    test('parks known-auth temp relay EVENT until AUTH succeeds', () async {
+      const relayUrl = 'wss://temp-known-auth.example';
+      const eventId =
+          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+      nostr = Nostr(signer, [], (url) {
+        tempRelay = _AuthFakeRelay(url)
+          ..relayStatus.alwaysAuth = true
+          ..relayStatus.authed = false;
+        return tempRelay;
+      });
+      await nostr.refreshPublicKey();
+
+      final sent = await nostr.relayPool.send(
+        eventMessage(eventId),
+        tempRelays: [relayUrl],
+      );
+
+      expect(sent, isTrue);
+      expect(sentMessagesOfType(tempRelay, 'EVENT'), isEmpty);
+      expect(tempRelay.pendingAuthedMessages, hasLength(1));
+
+      await tempRelay.deliver(['AUTH', challenge]);
+      final authEventId = sentAuthEventId(tempRelay);
+      await tempRelay.deliver(['OK', authEventId, true, '']);
+
+      expect(sentMessagesOfType(tempRelay, 'EVENT'), hasLength(1));
+      expect(tempRelay.pendingAuthedMessages, isEmpty);
+    });
+
+    test(
+      'drops retained fire-and-forget temp relay EVENT on OK true',
+      () async {
+        const relayUrl = 'wss://temp-no-auth.example';
+        const eventId =
+            'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+        final sent = await nostr.relayPool.send(
+          eventMessage(eventId),
+          tempRelays: [relayUrl],
+        );
+
+        expect(sent, isTrue);
+        expect(sentMessagesOfType(tempRelay, 'EVENT'), hasLength(1));
+        expect(tempRelay.hasRetainedSentEvent(eventId), isTrue);
+
+        await tempRelay.deliver(['OK', eventId, true, '']);
+
+        expect(sentMessagesOfType(tempRelay, 'EVENT'), hasLength(1));
+        expect(tempRelay.hasRetainedSentEvent(eventId), isFalse);
+      },
+    );
+
+    test(
+      'republishes an awaited temp relay EVENT after NIP-42 succeeds',
+      () async {
+        const relayUrl = 'wss://temp-awaited-auth-required.example';
+        const eventId =
+            'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
+        final outcomeFuture = nostr.relayPool.sendEventAwaitOk(
+          eventMessage(eventId),
+          eventId: eventId,
+          tempRelays: [relayUrl],
+          timeout: const Duration(seconds: 1),
+        );
+
+        expect(sentMessagesOfType(tempRelay, 'EVENT'), hasLength(1));
+
+        await tempRelay.deliver([
+          'OK',
+          eventId,
+          false,
+          'auth-required: you must auth',
+        ]);
+        await tempRelay.deliver(['AUTH', challenge]);
+        final authEventId = sentAuthEventId(tempRelay);
+        await tempRelay.deliver(['OK', authEventId, true, '']);
+
+        expect(sentMessagesOfType(tempRelay, 'EVENT'), hasLength(2));
+
+        await tempRelay.deliver(['OK', eventId, true, '']);
+        final outcome = await outcomeFuture;
+
+        expect(outcome.confirmed, isTrue);
+        expect(outcome.acceptedBy, equals([relayUrl]));
+        expect(outcome.rejectedBy, isEmpty);
       },
     );
   });

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_auth_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_auth_test.dart
@@ -516,6 +516,46 @@ void main() {
         );
       },
     );
+
+    test(
+      'keeps the retained EVENT when a deadline-free send is queued',
+      () async {
+        const eventId =
+            '8888888888888888888888888888888888888888888888888888888888888888';
+        // A deadline-free send passes `queueIfFailed: true`, so a failed write is
+        // still parked in `pendingMessages` and replayed on reconnect. Dropping
+        // the retained copy here would leave that replay unrecoverable when the
+        // relay answers `auth-required`, which is the bug this PR fixes.
+        relay.failSends = true;
+
+        final sent = await nostr.relayPool.send(eventMessage(eventId));
+
+        expect(sent, isFalse);
+        expect(relay.hasRetainedSentEvent(eventId), isTrue);
+
+        relay.failSends = false;
+        await relay.deliver([
+          'OK',
+          eventId,
+          false,
+          'auth-required: you must auth',
+        ]);
+
+        expect(relay.pendingAuthedMessages, hasLength(1));
+        expect(relay.hasRetainedSentEvent(eventId), isFalse);
+
+        await relay.deliver(['AUTH', challenge]);
+        final authEventId = sentAuthEventId(relay);
+        await relay.deliver(['OK', authEventId, true, '']);
+
+        expect(
+          sentMessagesOfType(relay, 'EVENT'),
+          hasLength(2),
+          reason: 'the queued EVENT should still be retried after AUTH',
+        );
+        expect(relay.pendingAuthedMessages, isEmpty);
+      },
+    );
   });
 
   group('RelayPool temp relay auth-required publish retry', () {

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_closed_frame_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_closed_frame_test.dart
@@ -33,7 +33,6 @@ class _ControlledQueryRelay extends Relay {
   @override
   Future<bool> send(
     List<dynamic> message, {
-    bool? forceSend,
     bool queueIfFailed = true,
     bool skipReconnect = false,
     DateTime? deadline,

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_concurrency_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_concurrency_test.dart
@@ -29,7 +29,6 @@ class _MutatingRelay extends Relay {
   @override
   Future<bool> send(
     List<dynamic> message, {
-    bool? forceSend,
     bool queueIfFailed = true,
     bool skipReconnect = false,
     DateTime? deadline,
@@ -65,7 +64,6 @@ class _SucceedingRelay extends Relay {
   @override
   Future<bool> send(
     List<dynamic> message, {
-    bool? forceSend,
     bool queueIfFailed = true,
     bool skipReconnect = false,
     DateTime? deadline,
@@ -106,7 +104,6 @@ class _CountRelay extends Relay {
   @override
   Future<bool> send(
     List<dynamic> message, {
-    bool? forceSend,
     bool queueIfFailed = true,
     bool skipReconnect = false,
     DateTime? deadline,
@@ -149,7 +146,6 @@ class _FailingSendRelay extends Relay {
   @override
   Future<bool> send(
     List<dynamic> message, {
-    bool? forceSend,
     bool queueIfFailed = true,
     bool skipReconnect = false,
     DateTime? deadline,
@@ -190,7 +186,6 @@ class _StallingReconnectRelay extends Relay {
   @override
   Future<bool> send(
     List<dynamic> message, {
-    bool? forceSend,
     bool queueIfFailed = true,
     bool skipReconnect = false,
     DateTime? deadline,
@@ -233,7 +228,6 @@ class _AlwaysHangingRelay extends Relay {
   @override
   Future<bool> send(
     List<dynamic> message, {
-    bool? forceSend,
     bool queueIfFailed = true,
     bool skipReconnect = false,
     DateTime? deadline,
@@ -266,7 +260,6 @@ class _DeferredSendRelay extends Relay {
   @override
   Future<bool> send(
     List<dynamic> message, {
-    bool? forceSend,
     bool queueIfFailed = true,
     bool skipReconnect = false,
     DateTime? deadline,
@@ -319,7 +312,6 @@ class _ConnectionAwareTempRelay extends Relay {
   @override
   Future<bool> send(
     List<dynamic> message, {
-    bool? forceSend,
     bool queueIfFailed = true,
     bool skipReconnect = false,
     DateTime? deadline,
@@ -348,7 +340,6 @@ class _HangingSendRelay extends Relay {
   @override
   Future<bool> send(
     List<dynamic> message, {
-    bool? forceSend,
     bool queueIfFailed = true,
     bool skipReconnect = false,
     DateTime? deadline,

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_event_signature_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_event_signature_test.dart
@@ -24,7 +24,6 @@ class _FakeRelay extends Relay {
   @override
   Future<bool> send(
     List<dynamic> message, {
-    bool? forceSend,
     bool queueIfFailed = true,
     bool skipReconnect = false,
     DateTime? deadline,

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_malformed_frame_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_malformed_frame_test.dart
@@ -24,7 +24,6 @@ class _MalformedFrameRelay extends Relay {
   @override
   Future<bool> send(
     List<dynamic> message, {
-    bool? forceSend,
     bool queueIfFailed = true,
     bool skipReconnect = false,
     DateTime? deadline,

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_offmain_verify_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_offmain_verify_test.dart
@@ -24,7 +24,6 @@ class _FakeRelay extends Relay {
   @override
   Future<bool> send(
     List<dynamic> message, {
-    bool? forceSend,
     bool queueIfFailed = true,
     bool skipReconnect = false,
     DateTime? deadline,

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_query_settle_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_query_settle_test.dart
@@ -53,7 +53,6 @@ class _SilentRelay extends Relay {
   @override
   Future<bool> send(
     List<dynamic> message, {
-    bool? forceSend,
     bool queueIfFailed = true,
     bool skipReconnect = false,
     DateTime? deadline,

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_signature_verification_policy_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_signature_verification_policy_test.dart
@@ -24,7 +24,6 @@ class _FakeRelay extends Relay {
   @override
   Future<bool> send(
     List<dynamic> message, {
-    bool? forceSend,
     bool queueIfFailed = true,
     bool skipReconnect = false,
     DateTime? deadline,

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_temp_relay_reap_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_temp_relay_reap_test.dart
@@ -22,7 +22,6 @@ class _NeverConnectsRelay extends Relay {
   @override
   Future<bool> send(
     List<dynamic> message, {
-    bool? forceSend,
     bool queueIfFailed = true,
     bool skipReconnect = false,
     DateTime? deadline,

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_verify_dedup_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_verify_dedup_test.dart
@@ -25,7 +25,6 @@ class _FakeRelay extends Relay {
   @override
   Future<bool> send(
     List<dynamic> message, {
-    bool? forceSend,
     bool queueIfFailed = true,
     bool skipReconnect = false,
     DateTime? deadline,


### PR DESCRIPTION
## Description

Fire-and-forget EVENT publishes now retain their frame long enough to survive a first NIP-42 auth-required rejection, including temp relay publishes. Known-auth temp relays send the retained frame so the relay's AUTH challenge (or acceptance) can happen, an untracked auth-required rejection on an already-authed relay flushes immediately, and frames parked behind a failed AUTH handshake are dropped. The dead Relay.send forceSend parameter is removed.

**Related Issue:** Closes #7701

## Out of Scope

None.

## Verification

- `flutter test test/unit/relay_pool_auth_test.dart` from `mobile/packages/nostr_sdk`
- `flutter analyze` from `mobile/packages/nostr_sdk`
- `flutter test` from `mobile/packages/nostr_sdk`
- Pre-push hook: analyzer plus changed-file tests

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
