### PR TITLE
fix(l10n): localize the app bar back button and remaining hardcoded strings

### DIFF
--- a/mobile/e2e/maestro/flows/commentFlow.yaml
+++ b/mobile/e2e/maestro/flows/commentFlow.yaml
@@ -8,7 +8,7 @@ appId: co.openvine.app
 - runFlow: ../tests/deleteComment.yaml
 
 # Leave the player. DiVineAppBar's back control is addressed by identifier;
-# its label ("Go back") is copy that has already moved once.
+# its label is localized, so text matching would break outside English.
 - tapOn:
     id: back_button
 - assertVisible:

--- a/mobile/e2e/maestro/tests/follow.yaml
+++ b/mobile/e2e/maestro/tests/follow.yaml
@@ -37,27 +37,19 @@ tags:
 
 
 # 3. Browse to the home screen: VIDEO_USER videos are displayed validated thru username
-# Back button on iOS devices
+# Leave via the app bar's back control, addressed by identifier.
+# This used to be two platform branches matching display text: iOS merged the
+# back button's semantic label and tooltip into one accessibility string
+# ("Go back" + "Back") while Android exposed only the label. Both are now the
+# localized MaterialLocalizations.backButtonTooltip, so text matching would
+# also break in every non-English locale. The identifier is stable across both.
 - runFlow:
     when:
-      visible: |-
-        Go back
-        Back
+      visible:
+        id: "back_button"
     commands:
-      - assertVisible: |-
-          Go back
-          Back
-      - tapOn: |-
-          Go back
-          Back
-
-# Back button on Android devices
-- runFlow:
-    when:
-      visible: Go back
-    commands:
-      - assertVisible: Go back
-      - tapOn: Go back
+      - tapOn:
+          id: "back_button"
 
 
 - doubleTapOn:

--- a/mobile/e2e/maestro/tests/videoLike.yaml
+++ b/mobile/e2e/maestro/tests/videoLike.yaml
@@ -20,27 +20,19 @@ tags:
 - tapOn:
     id: like_button
 - runFlow: "../asserts/assertVideoLiked.yaml"
-# Back button on iOS devices
+# Leave via the app bar's back control, addressed by identifier.
+# This used to be two platform branches matching display text: iOS merged the
+# back button's semantic label and tooltip into one accessibility string
+# ("Go back" + "Back") while Android exposed only the label. Both are now the
+# localized MaterialLocalizations.backButtonTooltip, so text matching would
+# also break in every non-English locale. The identifier is stable across both.
 - runFlow:
     when:
-      visible: |-
-        Go back
-        Back
+      visible:
+        id: "back_button"
     commands:
-      - assertVisible: |-
-          Go back
-          Back
-      - tapOn: |-
-          Go back
-          Back
-
-# Back button on Android devices
-- runFlow:
-    when:
-      visible: Go back
-    commands:
-      - assertVisible: Go back
-      - tapOn: Go back
+      - tapOn:
+          id: "back_button"
 
 # 3. Tap on the profile: Validate profile is loaded
 - tapOn:
@@ -56,6 +48,6 @@ tags:
 # The liked-grid tap opens PooledFullscreenVideoFeedScreen, which has no
 # "Close video player" control -- that label belongs to VideoDetailScreen,
 # a different route. This screen dismisses through the app bar's back
-# button, whose default label is "Go back".
+# button, addressed by identifier rather than its localized label.
 - tapOn:
     id: "back_button"

--- a/mobile/e2e/maestro/tests/videoUnlike.yaml
+++ b/mobile/e2e/maestro/tests/videoUnlike.yaml
@@ -39,7 +39,7 @@ tags:
 # The liked-grid tap opens PooledFullscreenVideoFeedScreen, which has no
 # "Close video player" control -- that label belongs to VideoDetailScreen,
 # a different route. This screen dismisses through the app bar's back
-# button, whose default label is "Go back".
+# button, addressed by identifier rather than its localized label.
 - tapOn:
     id: "back_button"
 - tapOn:

--- a/mobile/e2e/maestro/utils/openSettings.yaml
+++ b/mobile/e2e/maestro/utils/openSettings.yaml
@@ -2,10 +2,9 @@ appId: co.openvine.app
 ---
 #Utility: given the user is signed in, open Settings.
 #
-# The old route -- double-tap Home, tap "Open menu", tap "Settings" -- is
-# gone. There is no hamburger menu in the app; "Open menu" exists only as a
-# divine_ui default that no screen passes. Settings is now reached from the
-# gear on the user's own profile header, which is its only entry point.
+# The old route -- double-tap Home, open the hamburger menu, tap "Settings" --
+# is gone. There is no hamburger menu in the app. Settings is now reached from
+# the gear on the user's own profile header, which is its only entry point.
 
 - tapOn:
     id: "profile_tab"

--- a/mobile/integration_test/auth/auth_journey_test.dart
+++ b/mobile/integration_test/auth/auth_journey_test.dart
@@ -556,8 +556,9 @@ void main() {
 
         // Pop the fullscreen feed route to return to the explore grid.
         // The pooled feed uses a DivineAppBarIconButton with semanticLabel
-        // 'Go back'. Fall back to Navigator.pop if not found.
-        final backButton = find.bySemanticsLabel('Go back');
+        // the stable 'back_button' identifier rather than its localized
+        // label. Fall back to Navigator.pop if not found.
+        final backButton = find.bySemanticsIdentifier('back_button');
         if (backButton.evaluate().isNotEmpty) {
           await tester.tap(backButton.first);
         } else {
@@ -768,7 +769,7 @@ void main() {
 
             logPhase('Phase 3n complete -- Settings screen verified');
 
-            final backNav = find.bySemanticsLabel('Go back');
+            final backNav = find.bySemanticsIdentifier('back_button');
             if (backNav.evaluate().isNotEmpty) {
               await tester.tap(backNav.first);
               await tester.pump(const Duration(seconds: 1));

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -5371,5 +5371,12 @@
     "dbFailureResetDoneBody": "Divineን ዝጋ እና እንደገና ክፈተው — ቀጣዩ ጅምር አዲስ የአካባቢ ዳታቤዝ ይገነባል።",
   "authSignInOptionsInfo": "ስለ መግቢያ አማራጮች",
   "authShowPassword": "የይለፍ ቃል አሳይ",
-  "authHidePassword": "የይለፍ ቃል ደብቅ"
+  "authHidePassword": "የይለፍ ቃል ደብቅ",
+    "followUserSemanticLabel": "ተጠቃሚን ተከታተል",
+    "unfollowUserSemanticLabel": "ተጠቃሚን መከታተል አቁም",
+    "commentsLoadingSemanticLabel": "አስተያየቶች በመጫን ላይ",
+    "analyticsWindowAll": "ሁሉም",
+    "followUserIndexedSemanticLabel": "ተጠቃሚን ተከታተል {index}",
+    "unfollowUserIndexedSemanticLabel": "ተጠቃሚን መከታተል አቁም {index}",
+    "supporterTierMonthlyLabel": "{title} — {price} / በወር"
 }

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -5246,5 +5246,12 @@
     "dbFailureResetDoneBody": "أغلق Divine ثم افتحه مجددًا — سيبني التشغيل التالي قاعدة بيانات محلية جديدة.",
   "authSignInOptionsInfo": "حول خيارات تسجيل الدخول",
   "authShowPassword": "إظهار كلمة المرور",
-  "authHidePassword": "إخفاء كلمة المرور"
+  "authHidePassword": "إخفاء كلمة المرور",
+    "followUserSemanticLabel": "متابعة المستخدم",
+    "unfollowUserSemanticLabel": "إلغاء متابعة المستخدم",
+    "commentsLoadingSemanticLabel": "جارٍ تحميل التعليقات",
+    "analyticsWindowAll": "الكل",
+    "followUserIndexedSemanticLabel": "متابعة المستخدم {index}",
+    "unfollowUserIndexedSemanticLabel": "إلغاء متابعة المستخدم {index}",
+    "supporterTierMonthlyLabel": "{title} — {price} / شهريًا"
 }

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -5377,5 +5377,12 @@
     "dbFailureResetDoneBody": "Затвори Divine и го отвори отново — следващото стартиране изгражда нова локална база данни.",
   "authSignInOptionsInfo": "Относно опциите за вход",
   "authShowPassword": "Показване на паролата",
-  "authHidePassword": "Скриване на паролата"
+  "authHidePassword": "Скриване на паролата",
+    "followUserSemanticLabel": "Последвай потребителя",
+    "unfollowUserSemanticLabel": "Спри да следваш потребителя",
+    "commentsLoadingSemanticLabel": "Зареждане на коментарите",
+    "analyticsWindowAll": "Всички",
+    "followUserIndexedSemanticLabel": "Последвай потребителя {index}",
+    "unfollowUserIndexedSemanticLabel": "Спри да следваш потребителя {index}",
+    "supporterTierMonthlyLabel": "{title} — {price} / месец"
 }

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -5246,5 +5246,12 @@
     "dbFailureResetDoneBody": "Schließe Divine und öffne es erneut — der nächste Start legt eine frische lokale Datenbank an.",
   "authSignInOptionsInfo": "Über Anmeldeoptionen",
   "authShowPassword": "Passwort anzeigen",
-  "authHidePassword": "Passwort ausblenden"
+  "authHidePassword": "Passwort ausblenden",
+    "followUserSemanticLabel": "Nutzer folgen",
+    "unfollowUserSemanticLabel": "Nutzer nicht mehr folgen",
+    "commentsLoadingSemanticLabel": "Kommentare werden geladen",
+    "analyticsWindowAll": "Alle",
+    "followUserIndexedSemanticLabel": "Nutzer folgen {index}",
+    "unfollowUserIndexedSemanticLabel": "Nutzer nicht mehr folgen {index}",
+    "supporterTierMonthlyLabel": "{title} — {price} / Monat"
 }

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -7703,9 +7703,9 @@
   "analyticsWindowAll": "All",
   "@analyticsWindowAll": {"description": "Creator-analytics time window covering all time, shown next to 7D / 28D / 90D."},
   "followUserIndexedSemanticLabel": "Follow user {index}",
-  "@followUserIndexedSemanticLabel": {"description": "Screen-reader label for the follow button on a user row inside a list, carrying the row position so end-to-end flows can target a specific row.", "placeholders": {"index": {"type": "int"}}},
+  "@followUserIndexedSemanticLabel": {"description": "Screen-reader label for the follow button on a user row inside a list, carrying the row position so end-to-end flows can target a specific row.", "placeholders": {"index": {"type": "String"}}},
   "unfollowUserIndexedSemanticLabel": "Unfollow user {index}",
-  "@unfollowUserIndexedSemanticLabel": {"description": "Screen-reader label for the unfollow button on a user row inside a list, carrying the row position so end-to-end flows can target a specific row.", "placeholders": {"index": {"type": "int"}}},
+  "@unfollowUserIndexedSemanticLabel": {"description": "Screen-reader label for the unfollow button on a user row inside a list, carrying the row position so end-to-end flows can target a specific row.", "placeholders": {"index": {"type": "String"}}},
   "supporterTierMonthlyLabel": "{title} — {price} / month",
   "@supporterTierMonthlyLabel": {"description": "Label on a supporter subscription button: the tier name, its price, and the monthly billing period.", "placeholders": {"title": {"type": "String"}, "price": {"type": "String"}}}
 }

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -7693,5 +7693,19 @@
   "authShowPassword": "Show password",
   "@authShowPassword": {"description": "Screen-reader label for the control that reveals the typed password."},
   "authHidePassword": "Hide password",
-  "@authHidePassword": {"description": "Screen-reader label for the control that re-masks the typed password."}
+  "@authHidePassword": {"description": "Screen-reader label for the control that re-masks the typed password."},
+  "followUserSemanticLabel": "Follow user",
+  "@followUserSemanticLabel": {"description": "Screen-reader label for the follow button on a user row."},
+  "unfollowUserSemanticLabel": "Unfollow user",
+  "@unfollowUserSemanticLabel": {"description": "Screen-reader label for the unfollow button on a user row."},
+  "commentsLoadingSemanticLabel": "Loading comments",
+  "@commentsLoadingSemanticLabel": {"description": "Screen-reader label announced while the comment list is still loading."},
+  "analyticsWindowAll": "All",
+  "@analyticsWindowAll": {"description": "Creator-analytics time window covering all time, shown next to 7D / 28D / 90D."},
+  "followUserIndexedSemanticLabel": "Follow user {index}",
+  "@followUserIndexedSemanticLabel": {"description": "Screen-reader label for the follow button on a user row inside a list, carrying the row position so end-to-end flows can target a specific row.", "placeholders": {"index": {"type": "int"}}},
+  "unfollowUserIndexedSemanticLabel": "Unfollow user {index}",
+  "@unfollowUserIndexedSemanticLabel": {"description": "Screen-reader label for the unfollow button on a user row inside a list, carrying the row position so end-to-end flows can target a specific row.", "placeholders": {"index": {"type": "int"}}},
+  "supporterTierMonthlyLabel": "{title} — {price} / month",
+  "@supporterTierMonthlyLabel": {"description": "Label on a supporter subscription button: the tier name, its price, and the monthly billing period.", "placeholders": {"title": {"type": "String"}, "price": {"type": "String"}}}
 }

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -5246,5 +5246,12 @@
     "dbFailureResetDoneBody": "Cerrá Divine y volvé a abrirlo — el próximo inicio crea una base de datos local nueva.",
   "authSignInOptionsInfo": "Acerca de las opciones de inicio de sesión",
   "authShowPassword": "Mostrar contraseña",
-  "authHidePassword": "Ocultar contraseña"
+  "authHidePassword": "Ocultar contraseña",
+    "followUserSemanticLabel": "Seguir usuario",
+    "unfollowUserSemanticLabel": "Dejar de seguir al usuario",
+    "commentsLoadingSemanticLabel": "Cargando comentarios",
+    "analyticsWindowAll": "Todo",
+    "followUserIndexedSemanticLabel": "Seguir usuario {index}",
+    "unfollowUserIndexedSemanticLabel": "Dejar de seguir al usuario {index}",
+    "supporterTierMonthlyLabel": "{title} — {price} / mes"
 }

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -3840,5 +3840,12 @@
     "dbFailureResetDoneBody": "Isara ang Divine at buksan itong muli — gagawa ng bagong lokal na database sa susunod na paglulunsad.",
   "authSignInOptionsInfo": "Tungkol sa mga opsyon sa pag-sign in",
   "authShowPassword": "Ipakita ang password",
-  "authHidePassword": "Itago ang password"
+  "authHidePassword": "Itago ang password",
+    "followUserSemanticLabel": "Sundan ang user",
+    "unfollowUserSemanticLabel": "I-unfollow ang user",
+    "commentsLoadingSemanticLabel": "Nilo-load ang mga komento",
+    "analyticsWindowAll": "Lahat",
+    "followUserIndexedSemanticLabel": "Sundan ang user {index}",
+    "unfollowUserIndexedSemanticLabel": "I-unfollow ang user {index}",
+    "supporterTierMonthlyLabel": "{title} — {price} / buwan"
 }

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -5246,5 +5246,12 @@
     "dbFailureResetDoneBody": "Fermez Divine et rouvrez-le — le prochain lancement crée une nouvelle base de données locale.",
   "authSignInOptionsInfo": "À propos des options de connexion",
   "authShowPassword": "Afficher le mot de passe",
-  "authHidePassword": "Masquer le mot de passe"
+  "authHidePassword": "Masquer le mot de passe",
+    "followUserSemanticLabel": "Suivre l'utilisateur",
+    "unfollowUserSemanticLabel": "Ne plus suivre l'utilisateur",
+    "commentsLoadingSemanticLabel": "Chargement des commentaires",
+    "analyticsWindowAll": "Tout",
+    "followUserIndexedSemanticLabel": "Suivre l'utilisateur {index}",
+    "unfollowUserIndexedSemanticLabel": "Ne plus suivre l'utilisateur {index}",
+    "supporterTierMonthlyLabel": "{title} — {price} / mois"
 }

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -5246,5 +5246,12 @@
     "dbFailureResetDoneBody": "Tutup Divine lalu buka lagi — peluncuran berikutnya membangun basis data lokal yang baru.",
   "authSignInOptionsInfo": "Tentang opsi masuk",
   "authShowPassword": "Tampilkan sandi",
-  "authHidePassword": "Sembunyikan sandi"
+  "authHidePassword": "Sembunyikan sandi",
+    "followUserSemanticLabel": "Ikuti pengguna",
+    "unfollowUserSemanticLabel": "Berhenti mengikuti pengguna",
+    "commentsLoadingSemanticLabel": "Memuat komentar",
+    "analyticsWindowAll": "Semua",
+    "followUserIndexedSemanticLabel": "Ikuti pengguna {index}",
+    "unfollowUserIndexedSemanticLabel": "Berhenti mengikuti pengguna {index}",
+    "supporterTierMonthlyLabel": "{title} — {price} / bulan"
 }

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -5246,5 +5246,12 @@
     "dbFailureResetDoneBody": "Chiudi Divine e riaprilo — al prossimo avvio verrà creato un nuovo database locale.",
   "authSignInOptionsInfo": "Informazioni sulle opzioni di accesso",
   "authShowPassword": "Mostra password",
-  "authHidePassword": "Nascondi password"
+  "authHidePassword": "Nascondi password",
+    "followUserSemanticLabel": "Segui utente",
+    "unfollowUserSemanticLabel": "Smetti di seguire l'utente",
+    "commentsLoadingSemanticLabel": "Caricamento commenti",
+    "analyticsWindowAll": "Tutto",
+    "followUserIndexedSemanticLabel": "Segui utente {index}",
+    "unfollowUserIndexedSemanticLabel": "Smetti di seguire l'utente {index}",
+    "supporterTierMonthlyLabel": "{title} — {price} / mese"
 }

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -5246,5 +5246,12 @@
     "dbFailureResetDoneBody": "Divine を閉じてもう一度開いてください。次回の起動で新しいローカルデータベースが作成されます。",
   "authSignInOptionsInfo": "ログイン方法について",
   "authShowPassword": "パスワードを表示",
-  "authHidePassword": "パスワードを非表示"
+  "authHidePassword": "パスワードを非表示",
+    "followUserSemanticLabel": "ユーザーをフォロー",
+    "unfollowUserSemanticLabel": "ユーザーのフォローを解除",
+    "commentsLoadingSemanticLabel": "コメントを読み込み中",
+    "analyticsWindowAll": "すべて",
+    "followUserIndexedSemanticLabel": "ユーザーをフォロー {index}",
+    "unfollowUserIndexedSemanticLabel": "ユーザーのフォローを解除 {index}",
+    "supporterTierMonthlyLabel": "{title} — {price} / 月"
 }

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -4592,5 +4592,12 @@
     "dbFailureResetDoneBody": "Divine을 닫았다가 다시 여세요. 다음 실행에서 새 로컬 데이터베이스가 만들어집니다.",
   "authSignInOptionsInfo": "로그인 옵션 정보",
   "authShowPassword": "비밀번호 표시",
-  "authHidePassword": "비밀번호 숨기기"
+  "authHidePassword": "비밀번호 숨기기",
+    "followUserSemanticLabel": "사용자 팔로우",
+    "unfollowUserSemanticLabel": "사용자 팔로우 취소",
+    "commentsLoadingSemanticLabel": "댓글 불러오는 중",
+    "analyticsWindowAll": "전체",
+    "followUserIndexedSemanticLabel": "사용자 팔로우 {index}",
+    "unfollowUserIndexedSemanticLabel": "사용자 팔로우 취소 {index}",
+    "supporterTierMonthlyLabel": "{title} — {price} / 월"
 }

--- a/mobile/lib/l10n/app_ms.arb
+++ b/mobile/lib/l10n/app_ms.arb
@@ -7076,5 +7076,12 @@
   "dbFailureResetDoneBody": "Tutup Divine dan buka semula — pelancaran seterusnya membina pangkalan data setempat yang baharu.",
   "authSignInOptionsInfo": "Tentang pilihan log masuk",
   "authShowPassword": "Tunjukkan kata laluan",
-  "authHidePassword": "Sembunyikan kata laluan"
+  "authHidePassword": "Sembunyikan kata laluan",
+  "followUserSemanticLabel": "Ikut pengguna",
+  "unfollowUserSemanticLabel": "Nyahikut pengguna",
+  "commentsLoadingSemanticLabel": "Memuatkan komen",
+  "analyticsWindowAll": "Semua",
+  "followUserIndexedSemanticLabel": "Ikut pengguna {index}",
+  "unfollowUserIndexedSemanticLabel": "Nyahikut pengguna {index}",
+  "supporterTierMonthlyLabel": "{title} — {price} / bulan"
 }

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -5246,5 +5246,12 @@
     "dbFailureResetDoneBody": "Sluit Divine en open het opnieuw — bij de volgende start wordt een nieuwe lokale database aangemaakt.",
   "authSignInOptionsInfo": "Over aanmeldopties",
   "authShowPassword": "Wachtwoord tonen",
-  "authHidePassword": "Wachtwoord verbergen"
+  "authHidePassword": "Wachtwoord verbergen",
+    "followUserSemanticLabel": "Gebruiker volgen",
+    "unfollowUserSemanticLabel": "Gebruiker ontvolgen",
+    "commentsLoadingSemanticLabel": "Reacties laden",
+    "analyticsWindowAll": "Alles",
+    "followUserIndexedSemanticLabel": "Gebruiker volgen {index}",
+    "unfollowUserIndexedSemanticLabel": "Gebruiker ontvolgen {index}",
+    "supporterTierMonthlyLabel": "{title} — {price} / maand"
 }

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -5246,5 +5246,12 @@
     "dbFailureResetDoneBody": "Zamknij Divine i otwórz go ponownie — następne uruchomienie utworzy nową lokalną bazę danych.",
   "authSignInOptionsInfo": "Informacje o opcjach logowania",
   "authShowPassword": "Pokaż hasło",
-  "authHidePassword": "Ukryj hasło"
+  "authHidePassword": "Ukryj hasło",
+    "followUserSemanticLabel": "Obserwuj użytkownika",
+    "unfollowUserSemanticLabel": "Przestań obserwować użytkownika",
+    "commentsLoadingSemanticLabel": "Wczytywanie komentarzy",
+    "analyticsWindowAll": "Wszystko",
+    "followUserIndexedSemanticLabel": "Obserwuj użytkownika {index}",
+    "unfollowUserIndexedSemanticLabel": "Przestań obserwować użytkownika {index}",
+    "supporterTierMonthlyLabel": "{title} — {price} / miesiąc"
 }

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -5246,5 +5246,12 @@
     "dbFailureResetDoneBody": "Feche o Divine e abra de novo — a próxima inicialização cria um banco de dados local novo.",
   "authSignInOptionsInfo": "Sobre as opções de login",
   "authShowPassword": "Mostrar senha",
-  "authHidePassword": "Ocultar senha"
+  "authHidePassword": "Ocultar senha",
+    "followUserSemanticLabel": "Seguir usuário",
+    "unfollowUserSemanticLabel": "Deixar de seguir usuário",
+    "commentsLoadingSemanticLabel": "Carregando comentários",
+    "analyticsWindowAll": "Tudo",
+    "followUserIndexedSemanticLabel": "Seguir usuário {index}",
+    "unfollowUserIndexedSemanticLabel": "Deixar de seguir usuário {index}",
+    "supporterTierMonthlyLabel": "{title} — {price} / mês"
 }

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -5246,5 +5246,12 @@
     "dbFailureResetDoneBody": "Închide Divine și deschide-l din nou — următoarea pornire creează o bază de date locală nouă.",
   "authSignInOptionsInfo": "Despre opțiunile de conectare",
   "authShowPassword": "Afișați parola",
-  "authHidePassword": "Ascundeți parola"
+  "authHidePassword": "Ascundeți parola",
+    "followUserSemanticLabel": "Urmărește utilizatorul",
+    "unfollowUserSemanticLabel": "Nu mai urmări utilizatorul",
+    "commentsLoadingSemanticLabel": "Se încarcă comentariile",
+    "analyticsWindowAll": "Tot",
+    "followUserIndexedSemanticLabel": "Urmărește utilizatorul {index}",
+    "unfollowUserIndexedSemanticLabel": "Nu mai urmări utilizatorul {index}",
+    "supporterTierMonthlyLabel": "{title} — {price} / lună"
 }

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -5246,5 +5246,12 @@
     "dbFailureResetDoneBody": "Stäng Divine och öppna det igen — nästa start skapar en ny lokal databas.",
   "authSignInOptionsInfo": "Om inloggningsalternativ",
   "authShowPassword": "Visa lösenord",
-  "authHidePassword": "Dölj lösenord"
+  "authHidePassword": "Dölj lösenord",
+    "followUserSemanticLabel": "Följ användare",
+    "unfollowUserSemanticLabel": "Sluta följa användare",
+    "commentsLoadingSemanticLabel": "Läser in kommentarer",
+    "analyticsWindowAll": "Alla",
+    "followUserIndexedSemanticLabel": "Följ användare {index}",
+    "unfollowUserIndexedSemanticLabel": "Sluta följa användare {index}",
+    "supporterTierMonthlyLabel": "{title} — {price} / månad"
 }

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -5246,5 +5246,12 @@
     "dbFailureResetDoneBody": "Divine’ı kapatıp yeniden açın — sonraki başlatmada yeni bir yerel veritabanı oluşturulur.",
   "authSignInOptionsInfo": "Oturum açma seçenekleri hakkında",
   "authShowPassword": "Şifreyi göster",
-  "authHidePassword": "Şifreyi gizle"
+  "authHidePassword": "Şifreyi gizle",
+    "followUserSemanticLabel": "Kullanıcıyı takip et",
+    "unfollowUserSemanticLabel": "Kullanıcıyı takipten çık",
+    "commentsLoadingSemanticLabel": "Yorumlar yükleniyor",
+    "analyticsWindowAll": "Tümü",
+    "followUserIndexedSemanticLabel": "Kullanıcıyı takip et {index}",
+    "unfollowUserIndexedSemanticLabel": "Kullanıcıyı takipten çık {index}",
+    "supporterTierMonthlyLabel": "{title} — {price} / ay"
 }

--- a/mobile/lib/l10n/app_ur.arb
+++ b/mobile/lib/l10n/app_ur.arb
@@ -7076,5 +7076,12 @@
   "dbFailureResetDoneBody": "Divine بند کریں اور دوبارہ کھولیں — اگلی بار شروع ہونے پر نیا مقامی ڈیٹابیس بنے گا۔",
   "authSignInOptionsInfo": "سائن ان کے اختیارات کے بارے میں",
   "authShowPassword": "پاس ورڈ دکھائیں",
-  "authHidePassword": "پاس ورڈ چھپائیں"
+  "authHidePassword": "پاس ورڈ چھپائیں",
+  "followUserSemanticLabel": "صارف کو فالو کریں",
+  "unfollowUserSemanticLabel": "صارف کو ان فالو کریں",
+  "commentsLoadingSemanticLabel": "تبصرے لوڈ ہو رہے ہیں",
+  "analyticsWindowAll": "سب",
+  "followUserIndexedSemanticLabel": "صارف کو فالو کریں {index}",
+  "unfollowUserIndexedSemanticLabel": "صارف کو ان فالو کریں {index}",
+  "supporterTierMonthlyLabel": "{title} — {price} / ماہ"
 }

--- a/mobile/lib/l10n/app_vi.arb
+++ b/mobile/lib/l10n/app_vi.arb
@@ -7076,5 +7076,12 @@
   "dbFailureResetDoneBody": "Đóng Divine rồi mở lại — lần khởi chạy tiếp theo sẽ tạo cơ sở dữ liệu cục bộ mới.",
   "authSignInOptionsInfo": "Giới thiệu về tùy chọn đăng nhập",
   "authShowPassword": "Hiện mật khẩu",
-  "authHidePassword": "Ẩn mật khẩu"
+  "authHidePassword": "Ẩn mật khẩu",
+  "followUserSemanticLabel": "Theo dõi người dùng",
+  "unfollowUserSemanticLabel": "Bỏ theo dõi người dùng",
+  "commentsLoadingSemanticLabel": "Đang tải bình luận",
+  "analyticsWindowAll": "Tất cả",
+  "followUserIndexedSemanticLabel": "Theo dõi người dùng {index}",
+  "unfollowUserIndexedSemanticLabel": "Bỏ theo dõi người dùng {index}",
+  "supporterTierMonthlyLabel": "{title} — {price} / tháng"
 }

--- a/mobile/lib/l10n/app_zh.arb
+++ b/mobile/lib/l10n/app_zh.arb
@@ -7076,5 +7076,12 @@
   "dbFailureResetDoneBody": "关闭 Divine 后重新打开 — 下次启动会建立全新的本地数据库。",
   "authSignInOptionsInfo": "关于登录选项",
   "authShowPassword": "显示密码",
-  "authHidePassword": "隐藏密码"
+  "authHidePassword": "隐藏密码",
+  "followUserSemanticLabel": "关注用户",
+  "unfollowUserSemanticLabel": "取消关注用户",
+  "commentsLoadingSemanticLabel": "正在加载评论",
+  "analyticsWindowAll": "全部",
+  "followUserIndexedSemanticLabel": "关注用户 {index}",
+  "unfollowUserIndexedSemanticLabel": "取消关注用户 {index}",
+  "supporterTierMonthlyLabel": "{title} — {price} / 月"
 }

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -20883,6 +20883,48 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Hide password'**
   String get authHidePassword;
+
+  /// Screen-reader label for the follow button on a user row.
+  ///
+  /// In en, this message translates to:
+  /// **'Follow user'**
+  String get followUserSemanticLabel;
+
+  /// Screen-reader label for the unfollow button on a user row.
+  ///
+  /// In en, this message translates to:
+  /// **'Unfollow user'**
+  String get unfollowUserSemanticLabel;
+
+  /// Screen-reader label announced while the comment list is still loading.
+  ///
+  /// In en, this message translates to:
+  /// **'Loading comments'**
+  String get commentsLoadingSemanticLabel;
+
+  /// Creator-analytics time window covering all time, shown next to 7D / 28D / 90D.
+  ///
+  /// In en, this message translates to:
+  /// **'All'**
+  String get analyticsWindowAll;
+
+  /// Screen-reader label for the follow button on a user row inside a list, carrying the row position so end-to-end flows can target a specific row.
+  ///
+  /// In en, this message translates to:
+  /// **'Follow user {index}'**
+  String followUserIndexedSemanticLabel(int index);
+
+  /// Screen-reader label for the unfollow button on a user row inside a list, carrying the row position so end-to-end flows can target a specific row.
+  ///
+  /// In en, this message translates to:
+  /// **'Unfollow user {index}'**
+  String unfollowUserIndexedSemanticLabel(int index);
+
+  /// Label on a supporter subscription button: the tier name, its price, and the monthly billing period.
+  ///
+  /// In en, this message translates to:
+  /// **'{title} — {price} / month'**
+  String supporterTierMonthlyLabel(String title, String price);
 }
 
 class _AppLocalizationsDelegate

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -20912,13 +20912,13 @@ abstract class AppLocalizations {
   ///
   /// In en, this message translates to:
   /// **'Follow user {index}'**
-  String followUserIndexedSemanticLabel(int index);
+  String followUserIndexedSemanticLabel(String index);
 
   /// Screen-reader label for the unfollow button on a user row inside a list, carrying the row position so end-to-end flows can target a specific row.
   ///
   /// In en, this message translates to:
   /// **'Unfollow user {index}'**
-  String unfollowUserIndexedSemanticLabel(int index);
+  String unfollowUserIndexedSemanticLabel(String index);
 
   /// Label on a supporter subscription button: the tier name, its price, and the monthly billing period.
   ///

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -12008,12 +12008,12 @@ class AppLocalizationsAm extends AppLocalizations {
   String get analyticsWindowAll => 'ሁሉም';
 
   @override
-  String followUserIndexedSemanticLabel(int index) {
+  String followUserIndexedSemanticLabel(String index) {
     return 'ተጠቃሚን ተከታተል $index';
   }
 
   @override
-  String unfollowUserIndexedSemanticLabel(int index) {
+  String unfollowUserIndexedSemanticLabel(String index) {
     return 'ተጠቃሚን መከታተል አቁም $index';
   }
 

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -11994,4 +11994,31 @@ class AppLocalizationsAm extends AppLocalizations {
 
   @override
   String get authHidePassword => 'የይለፍ ቃል ደብቅ';
+
+  @override
+  String get followUserSemanticLabel => 'ተጠቃሚን ተከታተል';
+
+  @override
+  String get unfollowUserSemanticLabel => 'ተጠቃሚን መከታተል አቁም';
+
+  @override
+  String get commentsLoadingSemanticLabel => 'አስተያየቶች በመጫን ላይ';
+
+  @override
+  String get analyticsWindowAll => 'ሁሉም';
+
+  @override
+  String followUserIndexedSemanticLabel(int index) {
+    return 'ተጠቃሚን ተከታተል $index';
+  }
+
+  @override
+  String unfollowUserIndexedSemanticLabel(int index) {
+    return 'ተጠቃሚን መከታተል አቁም $index';
+  }
+
+  @override
+  String supporterTierMonthlyLabel(String title, String price) {
+    return '$title — $price / በወር';
+  }
 }

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -12219,4 +12219,31 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get authHidePassword => 'إخفاء كلمة المرور';
+
+  @override
+  String get followUserSemanticLabel => 'متابعة المستخدم';
+
+  @override
+  String get unfollowUserSemanticLabel => 'إلغاء متابعة المستخدم';
+
+  @override
+  String get commentsLoadingSemanticLabel => 'جارٍ تحميل التعليقات';
+
+  @override
+  String get analyticsWindowAll => 'الكل';
+
+  @override
+  String followUserIndexedSemanticLabel(int index) {
+    return 'متابعة المستخدم $index';
+  }
+
+  @override
+  String unfollowUserIndexedSemanticLabel(int index) {
+    return 'إلغاء متابعة المستخدم $index';
+  }
+
+  @override
+  String supporterTierMonthlyLabel(String title, String price) {
+    return '$title — $price / شهريًا';
+  }
 }

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -12233,12 +12233,12 @@ class AppLocalizationsAr extends AppLocalizations {
   String get analyticsWindowAll => 'الكل';
 
   @override
-  String followUserIndexedSemanticLabel(int index) {
+  String followUserIndexedSemanticLabel(String index) {
     return 'متابعة المستخدم $index';
   }
 
   @override
-  String unfollowUserIndexedSemanticLabel(int index) {
+  String unfollowUserIndexedSemanticLabel(String index) {
     return 'إلغاء متابعة المستخدم $index';
   }
 

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -12448,12 +12448,12 @@ class AppLocalizationsBg extends AppLocalizations {
   String get analyticsWindowAll => 'Всички';
 
   @override
-  String followUserIndexedSemanticLabel(int index) {
+  String followUserIndexedSemanticLabel(String index) {
     return 'Последвай потребителя $index';
   }
 
   @override
-  String unfollowUserIndexedSemanticLabel(int index) {
+  String unfollowUserIndexedSemanticLabel(String index) {
     return 'Спри да следваш потребителя $index';
   }
 

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -12434,4 +12434,31 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get authHidePassword => 'Скриване на паролата';
+
+  @override
+  String get followUserSemanticLabel => 'Последвай потребителя';
+
+  @override
+  String get unfollowUserSemanticLabel => 'Спри да следваш потребителя';
+
+  @override
+  String get commentsLoadingSemanticLabel => 'Зареждане на коментарите';
+
+  @override
+  String get analyticsWindowAll => 'Всички';
+
+  @override
+  String followUserIndexedSemanticLabel(int index) {
+    return 'Последвай потребителя $index';
+  }
+
+  @override
+  String unfollowUserIndexedSemanticLabel(int index) {
+    return 'Спри да следваш потребителя $index';
+  }
+
+  @override
+  String supporterTierMonthlyLabel(String title, String price) {
+    return '$title — $price / месец';
+  }
 }

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -12468,4 +12468,31 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get authHidePassword => 'Passwort ausblenden';
+
+  @override
+  String get followUserSemanticLabel => 'Nutzer folgen';
+
+  @override
+  String get unfollowUserSemanticLabel => 'Nutzer nicht mehr folgen';
+
+  @override
+  String get commentsLoadingSemanticLabel => 'Kommentare werden geladen';
+
+  @override
+  String get analyticsWindowAll => 'Alle';
+
+  @override
+  String followUserIndexedSemanticLabel(int index) {
+    return 'Nutzer folgen $index';
+  }
+
+  @override
+  String unfollowUserIndexedSemanticLabel(int index) {
+    return 'Nutzer nicht mehr folgen $index';
+  }
+
+  @override
+  String supporterTierMonthlyLabel(String title, String price) {
+    return '$title — $price / Monat';
+  }
 }

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -12482,12 +12482,12 @@ class AppLocalizationsDe extends AppLocalizations {
   String get analyticsWindowAll => 'Alle';
 
   @override
-  String followUserIndexedSemanticLabel(int index) {
+  String followUserIndexedSemanticLabel(String index) {
     return 'Nutzer folgen $index';
   }
 
   @override
-  String unfollowUserIndexedSemanticLabel(int index) {
+  String unfollowUserIndexedSemanticLabel(String index) {
     return 'Nutzer nicht mehr folgen $index';
   }
 

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -12432,12 +12432,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get analyticsWindowAll => 'All';
 
   @override
-  String followUserIndexedSemanticLabel(int index) {
+  String followUserIndexedSemanticLabel(String index) {
     return 'Follow user $index';
   }
 
   @override
-  String unfollowUserIndexedSemanticLabel(int index) {
+  String unfollowUserIndexedSemanticLabel(String index) {
     return 'Unfollow user $index';
   }
 

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -12418,4 +12418,31 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get authHidePassword => 'Hide password';
+
+  @override
+  String get followUserSemanticLabel => 'Follow user';
+
+  @override
+  String get unfollowUserSemanticLabel => 'Unfollow user';
+
+  @override
+  String get commentsLoadingSemanticLabel => 'Loading comments';
+
+  @override
+  String get analyticsWindowAll => 'All';
+
+  @override
+  String followUserIndexedSemanticLabel(int index) {
+    return 'Follow user $index';
+  }
+
+  @override
+  String unfollowUserIndexedSemanticLabel(int index) {
+    return 'Unfollow user $index';
+  }
+
+  @override
+  String supporterTierMonthlyLabel(String title, String price) {
+    return '$title — $price / month';
+  }
 }

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -12462,12 +12462,12 @@ class AppLocalizationsEs extends AppLocalizations {
   String get analyticsWindowAll => 'Todo';
 
   @override
-  String followUserIndexedSemanticLabel(int index) {
+  String followUserIndexedSemanticLabel(String index) {
     return 'Seguir usuario $index';
   }
 
   @override
-  String unfollowUserIndexedSemanticLabel(int index) {
+  String unfollowUserIndexedSemanticLabel(String index) {
     return 'Dejar de seguir al usuario $index';
   }
 

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -12448,4 +12448,31 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get authHidePassword => 'Ocultar contraseña';
+
+  @override
+  String get followUserSemanticLabel => 'Seguir usuario';
+
+  @override
+  String get unfollowUserSemanticLabel => 'Dejar de seguir al usuario';
+
+  @override
+  String get commentsLoadingSemanticLabel => 'Cargando comentarios';
+
+  @override
+  String get analyticsWindowAll => 'Todo';
+
+  @override
+  String followUserIndexedSemanticLabel(int index) {
+    return 'Seguir usuario $index';
+  }
+
+  @override
+  String unfollowUserIndexedSemanticLabel(int index) {
+    return 'Dejar de seguir al usuario $index';
+  }
+
+  @override
+  String supporterTierMonthlyLabel(String title, String price) {
+    return '$title — $price / mes';
+  }
 }

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -12433,4 +12433,31 @@ class AppLocalizationsFil extends AppLocalizations {
 
   @override
   String get authHidePassword => 'Itago ang password';
+
+  @override
+  String get followUserSemanticLabel => 'Sundan ang user';
+
+  @override
+  String get unfollowUserSemanticLabel => 'I-unfollow ang user';
+
+  @override
+  String get commentsLoadingSemanticLabel => 'Nilo-load ang mga komento';
+
+  @override
+  String get analyticsWindowAll => 'Lahat';
+
+  @override
+  String followUserIndexedSemanticLabel(int index) {
+    return 'Sundan ang user $index';
+  }
+
+  @override
+  String unfollowUserIndexedSemanticLabel(int index) {
+    return 'I-unfollow ang user $index';
+  }
+
+  @override
+  String supporterTierMonthlyLabel(String title, String price) {
+    return '$title — $price / buwan';
+  }
 }

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -12447,12 +12447,12 @@ class AppLocalizationsFil extends AppLocalizations {
   String get analyticsWindowAll => 'Lahat';
 
   @override
-  String followUserIndexedSemanticLabel(int index) {
+  String followUserIndexedSemanticLabel(String index) {
     return 'Sundan ang user $index';
   }
 
   @override
-  String unfollowUserIndexedSemanticLabel(int index) {
+  String unfollowUserIndexedSemanticLabel(String index) {
     return 'I-unfollow ang user $index';
   }
 

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -12499,4 +12499,31 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get authHidePassword => 'Masquer le mot de passe';
+
+  @override
+  String get followUserSemanticLabel => 'Suivre l\'utilisateur';
+
+  @override
+  String get unfollowUserSemanticLabel => 'Ne plus suivre l\'utilisateur';
+
+  @override
+  String get commentsLoadingSemanticLabel => 'Chargement des commentaires';
+
+  @override
+  String get analyticsWindowAll => 'Tout';
+
+  @override
+  String followUserIndexedSemanticLabel(int index) {
+    return 'Suivre l\'utilisateur $index';
+  }
+
+  @override
+  String unfollowUserIndexedSemanticLabel(int index) {
+    return 'Ne plus suivre l\'utilisateur $index';
+  }
+
+  @override
+  String supporterTierMonthlyLabel(String title, String price) {
+    return '$title — $price / mois';
+  }
 }

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -12513,12 +12513,12 @@ class AppLocalizationsFr extends AppLocalizations {
   String get analyticsWindowAll => 'Tout';
 
   @override
-  String followUserIndexedSemanticLabel(int index) {
+  String followUserIndexedSemanticLabel(String index) {
     return 'Suivre l\'utilisateur $index';
   }
 
   @override
-  String unfollowUserIndexedSemanticLabel(int index) {
+  String unfollowUserIndexedSemanticLabel(String index) {
     return 'Ne plus suivre l\'utilisateur $index';
   }
 

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -12228,4 +12228,31 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get authHidePassword => 'Sembunyikan sandi';
+
+  @override
+  String get followUserSemanticLabel => 'Ikuti pengguna';
+
+  @override
+  String get unfollowUserSemanticLabel => 'Berhenti mengikuti pengguna';
+
+  @override
+  String get commentsLoadingSemanticLabel => 'Memuat komentar';
+
+  @override
+  String get analyticsWindowAll => 'Semua';
+
+  @override
+  String followUserIndexedSemanticLabel(int index) {
+    return 'Ikuti pengguna $index';
+  }
+
+  @override
+  String unfollowUserIndexedSemanticLabel(int index) {
+    return 'Berhenti mengikuti pengguna $index';
+  }
+
+  @override
+  String supporterTierMonthlyLabel(String title, String price) {
+    return '$title — $price / bulan';
+  }
 }

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -12242,12 +12242,12 @@ class AppLocalizationsId extends AppLocalizations {
   String get analyticsWindowAll => 'Semua';
 
   @override
-  String followUserIndexedSemanticLabel(int index) {
+  String followUserIndexedSemanticLabel(String index) {
     return 'Ikuti pengguna $index';
   }
 
   @override
-  String unfollowUserIndexedSemanticLabel(int index) {
+  String unfollowUserIndexedSemanticLabel(String index) {
     return 'Berhenti mengikuti pengguna $index';
   }
 

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -12474,12 +12474,12 @@ class AppLocalizationsIt extends AppLocalizations {
   String get analyticsWindowAll => 'Tutto';
 
   @override
-  String followUserIndexedSemanticLabel(int index) {
+  String followUserIndexedSemanticLabel(String index) {
     return 'Segui utente $index';
   }
 
   @override
-  String unfollowUserIndexedSemanticLabel(int index) {
+  String unfollowUserIndexedSemanticLabel(String index) {
     return 'Smetti di seguire l\'utente $index';
   }
 

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -12460,4 +12460,31 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get authHidePassword => 'Nascondi password';
+
+  @override
+  String get followUserSemanticLabel => 'Segui utente';
+
+  @override
+  String get unfollowUserSemanticLabel => 'Smetti di seguire l\'utente';
+
+  @override
+  String get commentsLoadingSemanticLabel => 'Caricamento commenti';
+
+  @override
+  String get analyticsWindowAll => 'Tutto';
+
+  @override
+  String followUserIndexedSemanticLabel(int index) {
+    return 'Segui utente $index';
+  }
+
+  @override
+  String unfollowUserIndexedSemanticLabel(int index) {
+    return 'Smetti di seguire l\'utente $index';
+  }
+
+  @override
+  String supporterTierMonthlyLabel(String title, String price) {
+    return '$title — $price / mese';
+  }
 }

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -11702,4 +11702,31 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get authHidePassword => 'パスワードを非表示';
+
+  @override
+  String get followUserSemanticLabel => 'ユーザーをフォロー';
+
+  @override
+  String get unfollowUserSemanticLabel => 'ユーザーのフォローを解除';
+
+  @override
+  String get commentsLoadingSemanticLabel => 'コメントを読み込み中';
+
+  @override
+  String get analyticsWindowAll => 'すべて';
+
+  @override
+  String followUserIndexedSemanticLabel(int index) {
+    return 'ユーザーをフォロー $index';
+  }
+
+  @override
+  String unfollowUserIndexedSemanticLabel(int index) {
+    return 'ユーザーのフォローを解除 $index';
+  }
+
+  @override
+  String supporterTierMonthlyLabel(String title, String price) {
+    return '$title — $price / 月';
+  }
 }

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -11716,12 +11716,12 @@ class AppLocalizationsJa extends AppLocalizations {
   String get analyticsWindowAll => 'すべて';
 
   @override
-  String followUserIndexedSemanticLabel(int index) {
+  String followUserIndexedSemanticLabel(String index) {
     return 'ユーザーをフォロー $index';
   }
 
   @override
-  String unfollowUserIndexedSemanticLabel(int index) {
+  String unfollowUserIndexedSemanticLabel(String index) {
     return 'ユーザーのフォローを解除 $index';
   }
 

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -11741,12 +11741,12 @@ class AppLocalizationsKo extends AppLocalizations {
   String get analyticsWindowAll => '전체';
 
   @override
-  String followUserIndexedSemanticLabel(int index) {
+  String followUserIndexedSemanticLabel(String index) {
     return '사용자 팔로우 $index';
   }
 
   @override
-  String unfollowUserIndexedSemanticLabel(int index) {
+  String unfollowUserIndexedSemanticLabel(String index) {
     return '사용자 팔로우 취소 $index';
   }
 

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -11727,4 +11727,31 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get authHidePassword => '비밀번호 숨기기';
+
+  @override
+  String get followUserSemanticLabel => '사용자 팔로우';
+
+  @override
+  String get unfollowUserSemanticLabel => '사용자 팔로우 취소';
+
+  @override
+  String get commentsLoadingSemanticLabel => '댓글 불러오는 중';
+
+  @override
+  String get analyticsWindowAll => '전체';
+
+  @override
+  String followUserIndexedSemanticLabel(int index) {
+    return '사용자 팔로우 $index';
+  }
+
+  @override
+  String unfollowUserIndexedSemanticLabel(int index) {
+    return '사용자 팔로우 취소 $index';
+  }
+
+  @override
+  String supporterTierMonthlyLabel(String title, String price) {
+    return '$title — $price / 월';
+  }
 }

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -12343,12 +12343,12 @@ class AppLocalizationsMs extends AppLocalizations {
   String get analyticsWindowAll => 'Semua';
 
   @override
-  String followUserIndexedSemanticLabel(int index) {
+  String followUserIndexedSemanticLabel(String index) {
     return 'Ikut pengguna $index';
   }
 
   @override
-  String unfollowUserIndexedSemanticLabel(int index) {
+  String unfollowUserIndexedSemanticLabel(String index) {
     return 'Nyahikut pengguna $index';
   }
 

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -12329,4 +12329,31 @@ class AppLocalizationsMs extends AppLocalizations {
 
   @override
   String get authHidePassword => 'Sembunyikan kata laluan';
+
+  @override
+  String get followUserSemanticLabel => 'Ikut pengguna';
+
+  @override
+  String get unfollowUserSemanticLabel => 'Nyahikut pengguna';
+
+  @override
+  String get commentsLoadingSemanticLabel => 'Memuatkan komen';
+
+  @override
+  String get analyticsWindowAll => 'Semua';
+
+  @override
+  String followUserIndexedSemanticLabel(int index) {
+    return 'Ikut pengguna $index';
+  }
+
+  @override
+  String unfollowUserIndexedSemanticLabel(int index) {
+    return 'Nyahikut pengguna $index';
+  }
+
+  @override
+  String supporterTierMonthlyLabel(String title, String price) {
+    return '$title — $price / bulan';
+  }
 }

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -12389,12 +12389,12 @@ class AppLocalizationsNl extends AppLocalizations {
   String get analyticsWindowAll => 'Alles';
 
   @override
-  String followUserIndexedSemanticLabel(int index) {
+  String followUserIndexedSemanticLabel(String index) {
     return 'Gebruiker volgen $index';
   }
 
   @override
-  String unfollowUserIndexedSemanticLabel(int index) {
+  String unfollowUserIndexedSemanticLabel(String index) {
     return 'Gebruiker ontvolgen $index';
   }
 

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -12375,4 +12375,31 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get authHidePassword => 'Wachtwoord verbergen';
+
+  @override
+  String get followUserSemanticLabel => 'Gebruiker volgen';
+
+  @override
+  String get unfollowUserSemanticLabel => 'Gebruiker ontvolgen';
+
+  @override
+  String get commentsLoadingSemanticLabel => 'Reacties laden';
+
+  @override
+  String get analyticsWindowAll => 'Alles';
+
+  @override
+  String followUserIndexedSemanticLabel(int index) {
+    return 'Gebruiker volgen $index';
+  }
+
+  @override
+  String unfollowUserIndexedSemanticLabel(int index) {
+    return 'Gebruiker ontvolgen $index';
+  }
+
+  @override
+  String supporterTierMonthlyLabel(String title, String price) {
+    return '$title — $price / maand';
+  }
 }

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -12573,12 +12573,12 @@ class AppLocalizationsPl extends AppLocalizations {
   String get analyticsWindowAll => 'Wszystko';
 
   @override
-  String followUserIndexedSemanticLabel(int index) {
+  String followUserIndexedSemanticLabel(String index) {
     return 'Obserwuj użytkownika $index';
   }
 
   @override
-  String unfollowUserIndexedSemanticLabel(int index) {
+  String unfollowUserIndexedSemanticLabel(String index) {
     return 'Przestań obserwować użytkownika $index';
   }
 

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -12559,4 +12559,31 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get authHidePassword => 'Ukryj hasło';
+
+  @override
+  String get followUserSemanticLabel => 'Obserwuj użytkownika';
+
+  @override
+  String get unfollowUserSemanticLabel => 'Przestań obserwować użytkownika';
+
+  @override
+  String get commentsLoadingSemanticLabel => 'Wczytywanie komentarzy';
+
+  @override
+  String get analyticsWindowAll => 'Wszystko';
+
+  @override
+  String followUserIndexedSemanticLabel(int index) {
+    return 'Obserwuj użytkownika $index';
+  }
+
+  @override
+  String unfollowUserIndexedSemanticLabel(int index) {
+    return 'Przestań obserwować użytkownika $index';
+  }
+
+  @override
+  String supporterTierMonthlyLabel(String title, String price) {
+    return '$title — $price / miesiąc';
+  }
 }

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -12407,4 +12407,31 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get authHidePassword => 'Ocultar senha';
+
+  @override
+  String get followUserSemanticLabel => 'Seguir usuário';
+
+  @override
+  String get unfollowUserSemanticLabel => 'Deixar de seguir usuário';
+
+  @override
+  String get commentsLoadingSemanticLabel => 'Carregando comentários';
+
+  @override
+  String get analyticsWindowAll => 'Tudo';
+
+  @override
+  String followUserIndexedSemanticLabel(int index) {
+    return 'Seguir usuário $index';
+  }
+
+  @override
+  String unfollowUserIndexedSemanticLabel(int index) {
+    return 'Deixar de seguir usuário $index';
+  }
+
+  @override
+  String supporterTierMonthlyLabel(String title, String price) {
+    return '$title — $price / mês';
+  }
 }

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -12421,12 +12421,12 @@ class AppLocalizationsPt extends AppLocalizations {
   String get analyticsWindowAll => 'Tudo';
 
   @override
-  String followUserIndexedSemanticLabel(int index) {
+  String followUserIndexedSemanticLabel(String index) {
     return 'Seguir usuário $index';
   }
 
   @override
-  String unfollowUserIndexedSemanticLabel(int index) {
+  String unfollowUserIndexedSemanticLabel(String index) {
     return 'Deixar de seguir usuário $index';
   }
 

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -12581,12 +12581,12 @@ class AppLocalizationsRo extends AppLocalizations {
   String get analyticsWindowAll => 'Tot';
 
   @override
-  String followUserIndexedSemanticLabel(int index) {
+  String followUserIndexedSemanticLabel(String index) {
     return 'Urmărește utilizatorul $index';
   }
 
   @override
-  String unfollowUserIndexedSemanticLabel(int index) {
+  String unfollowUserIndexedSemanticLabel(String index) {
     return 'Nu mai urmări utilizatorul $index';
   }
 

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -12567,4 +12567,31 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get authHidePassword => 'Ascundeți parola';
+
+  @override
+  String get followUserSemanticLabel => 'Urmărește utilizatorul';
+
+  @override
+  String get unfollowUserSemanticLabel => 'Nu mai urmări utilizatorul';
+
+  @override
+  String get commentsLoadingSemanticLabel => 'Se încarcă comentariile';
+
+  @override
+  String get analyticsWindowAll => 'Tot';
+
+  @override
+  String followUserIndexedSemanticLabel(int index) {
+    return 'Urmărește utilizatorul $index';
+  }
+
+  @override
+  String unfollowUserIndexedSemanticLabel(int index) {
+    return 'Nu mai urmări utilizatorul $index';
+  }
+
+  @override
+  String supporterTierMonthlyLabel(String title, String price) {
+    return '$title — $price / lună';
+  }
 }

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -12314,4 +12314,31 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get authHidePassword => 'Dölj lösenord';
+
+  @override
+  String get followUserSemanticLabel => 'Följ användare';
+
+  @override
+  String get unfollowUserSemanticLabel => 'Sluta följa användare';
+
+  @override
+  String get commentsLoadingSemanticLabel => 'Läser in kommentarer';
+
+  @override
+  String get analyticsWindowAll => 'Alla';
+
+  @override
+  String followUserIndexedSemanticLabel(int index) {
+    return 'Följ användare $index';
+  }
+
+  @override
+  String unfollowUserIndexedSemanticLabel(int index) {
+    return 'Sluta följa användare $index';
+  }
+
+  @override
+  String supporterTierMonthlyLabel(String title, String price) {
+    return '$title — $price / månad';
+  }
 }

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -12328,12 +12328,12 @@ class AppLocalizationsSv extends AppLocalizations {
   String get analyticsWindowAll => 'Alla';
 
   @override
-  String followUserIndexedSemanticLabel(int index) {
+  String followUserIndexedSemanticLabel(String index) {
     return 'Följ användare $index';
   }
 
   @override
-  String unfollowUserIndexedSemanticLabel(int index) {
+  String unfollowUserIndexedSemanticLabel(String index) {
     return 'Sluta följa användare $index';
   }
 

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -12256,12 +12256,12 @@ class AppLocalizationsTr extends AppLocalizations {
   String get analyticsWindowAll => 'Tümü';
 
   @override
-  String followUserIndexedSemanticLabel(int index) {
+  String followUserIndexedSemanticLabel(String index) {
     return 'Kullanıcıyı takip et $index';
   }
 
   @override
-  String unfollowUserIndexedSemanticLabel(int index) {
+  String unfollowUserIndexedSemanticLabel(String index) {
     return 'Kullanıcıyı takipten çık $index';
   }
 

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -12242,4 +12242,31 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get authHidePassword => 'Şifreyi gizle';
+
+  @override
+  String get followUserSemanticLabel => 'Kullanıcıyı takip et';
+
+  @override
+  String get unfollowUserSemanticLabel => 'Kullanıcıyı takipten çık';
+
+  @override
+  String get commentsLoadingSemanticLabel => 'Yorumlar yükleniyor';
+
+  @override
+  String get analyticsWindowAll => 'Tümü';
+
+  @override
+  String followUserIndexedSemanticLabel(int index) {
+    return 'Kullanıcıyı takip et $index';
+  }
+
+  @override
+  String unfollowUserIndexedSemanticLabel(int index) {
+    return 'Kullanıcıyı takipten çık $index';
+  }
+
+  @override
+  String supporterTierMonthlyLabel(String title, String price) {
+    return '$title — $price / ay';
+  }
 }

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -12316,12 +12316,12 @@ class AppLocalizationsUr extends AppLocalizations {
   String get analyticsWindowAll => 'سب';
 
   @override
-  String followUserIndexedSemanticLabel(int index) {
+  String followUserIndexedSemanticLabel(String index) {
     return 'صارف کو فالو کریں $index';
   }
 
   @override
-  String unfollowUserIndexedSemanticLabel(int index) {
+  String unfollowUserIndexedSemanticLabel(String index) {
     return 'صارف کو ان فالو کریں $index';
   }
 

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -12302,4 +12302,31 @@ class AppLocalizationsUr extends AppLocalizations {
 
   @override
   String get authHidePassword => 'پاس ورڈ چھپائیں';
+
+  @override
+  String get followUserSemanticLabel => 'صارف کو فالو کریں';
+
+  @override
+  String get unfollowUserSemanticLabel => 'صارف کو ان فالو کریں';
+
+  @override
+  String get commentsLoadingSemanticLabel => 'تبصرے لوڈ ہو رہے ہیں';
+
+  @override
+  String get analyticsWindowAll => 'سب';
+
+  @override
+  String followUserIndexedSemanticLabel(int index) {
+    return 'صارف کو فالو کریں $index';
+  }
+
+  @override
+  String unfollowUserIndexedSemanticLabel(int index) {
+    return 'صارف کو ان فالو کریں $index';
+  }
+
+  @override
+  String supporterTierMonthlyLabel(String title, String price) {
+    return '$title — $price / ماہ';
+  }
 }

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -12266,4 +12266,31 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get authHidePassword => 'Ẩn mật khẩu';
+
+  @override
+  String get followUserSemanticLabel => 'Theo dõi người dùng';
+
+  @override
+  String get unfollowUserSemanticLabel => 'Bỏ theo dõi người dùng';
+
+  @override
+  String get commentsLoadingSemanticLabel => 'Đang tải bình luận';
+
+  @override
+  String get analyticsWindowAll => 'Tất cả';
+
+  @override
+  String followUserIndexedSemanticLabel(int index) {
+    return 'Theo dõi người dùng $index';
+  }
+
+  @override
+  String unfollowUserIndexedSemanticLabel(int index) {
+    return 'Bỏ theo dõi người dùng $index';
+  }
+
+  @override
+  String supporterTierMonthlyLabel(String title, String price) {
+    return '$title — $price / tháng';
+  }
 }

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -12280,12 +12280,12 @@ class AppLocalizationsVi extends AppLocalizations {
   String get analyticsWindowAll => 'Tất cả';
 
   @override
-  String followUserIndexedSemanticLabel(int index) {
+  String followUserIndexedSemanticLabel(String index) {
     return 'Theo dõi người dùng $index';
   }
 
   @override
-  String unfollowUserIndexedSemanticLabel(int index) {
+  String unfollowUserIndexedSemanticLabel(String index) {
     return 'Bỏ theo dõi người dùng $index';
   }
 

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -11596,4 +11596,31 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get authHidePassword => '隐藏密码';
+
+  @override
+  String get followUserSemanticLabel => '关注用户';
+
+  @override
+  String get unfollowUserSemanticLabel => '取消关注用户';
+
+  @override
+  String get commentsLoadingSemanticLabel => '正在加载评论';
+
+  @override
+  String get analyticsWindowAll => '全部';
+
+  @override
+  String followUserIndexedSemanticLabel(int index) {
+    return '关注用户 $index';
+  }
+
+  @override
+  String unfollowUserIndexedSemanticLabel(int index) {
+    return '取消关注用户 $index';
+  }
+
+  @override
+  String supporterTierMonthlyLabel(String title, String price) {
+    return '$title — $price / 月';
+  }
 }

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -11610,12 +11610,12 @@ class AppLocalizationsZh extends AppLocalizations {
   String get analyticsWindowAll => '全部';
 
   @override
-  String followUserIndexedSemanticLabel(int index) {
+  String followUserIndexedSemanticLabel(String index) {
     return '关注用户 $index';
   }
 
   @override
-  String unfollowUserIndexedSemanticLabel(int index) {
+  String unfollowUserIndexedSemanticLabel(String index) {
     return '取消关注用户 $index';
   }
 

--- a/mobile/lib/screens/auth/welcome_screen.dart
+++ b/mobile/lib/screens/auth/welcome_screen.dart
@@ -197,6 +197,7 @@ class _WelcomeView extends StatelessWidget {
               ? DiVineAppBar(
                   title: '',
                   leadingIcon: SvgIconSource(DivineIconName.x.assetPath),
+                  leadingActionSemanticLabel: context.l10n.commonClose,
                   onLeadingPressed: () {
                     final bloc = context.read<WelcomeBloc>();
                     // If a specific account was pre-selected (account-switcher

--- a/mobile/lib/screens/comments/widgets/comment_skeleton_loader.dart
+++ b/mobile/lib/screens/comments/widgets/comment_skeleton_loader.dart
@@ -3,6 +3,7 @@
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
+import 'package:openvine/l10n/l10n.dart';
 import 'package:skeletonizer/skeletonizer.dart';
 
 /// Skeleton loader for comments loading state
@@ -14,7 +15,7 @@ class CommentsSkeletonLoader extends StatelessWidget {
   Widget build(BuildContext context) {
     return Semantics(
       identifier: 'comments_loading_indicator',
-      label: 'Loading comments',
+      label: context.l10n.commentsLoadingSemanticLabel,
       child: Skeletonizer(
         effect: vineSkeletonEffectOf(context),
         child: ListView.builder(

--- a/mobile/lib/screens/creator_analytics_screen.dart
+++ b/mobile/lib/screens/creator_analytics_screen.dart
@@ -381,7 +381,7 @@ class _RangeSelector extends StatelessWidget {
       children: _AnalyticsWindow.values.map((window) {
         final isSelected = window == selected;
         return ChoiceChip(
-          label: Text(window.label),
+          label: Text(window.labelFor(context.l10n)),
           selected: isSelected,
           selectedColor: VineTheme.vineGreen.withValues(alpha: 0.2),
           labelStyle: VineTheme.bodySmallFont(
@@ -1451,6 +1451,18 @@ enum _AnalyticsWindow {
 
   final String label;
   final Duration? duration;
+}
+
+extension on _AnalyticsWindow {
+  /// 7D / 28D / 90D are numeric abbreviations that read the same everywhere;
+  /// only the all-time window is a word, and it shipped as a hardcoded 'All'.
+  /// Switched exhaustively so a new window has to make this choice too.
+  String labelFor(AppLocalizations l10n) => switch (this) {
+    _AnalyticsWindow.allTime => l10n.analyticsWindowAll,
+    _AnalyticsWindow.last7Days ||
+    _AnalyticsWindow.last28Days ||
+    _AnalyticsWindow.last90Days => label,
+  };
 }
 
 class _CreatorAnalyticsData {

--- a/mobile/lib/screens/creator_analytics_screen.dart
+++ b/mobile/lib/screens/creator_analytics_screen.dart
@@ -1442,14 +1442,13 @@ class _AnalyticsCard extends StatelessWidget {
 }
 
 enum _AnalyticsWindow {
-  last7Days('7D', Duration(days: 7)),
-  last28Days('28D', Duration(days: 28)),
-  last90Days('90D', Duration(days: 90)),
-  allTime('All', null);
+  last7Days(Duration(days: 7)),
+  last28Days(Duration(days: 28)),
+  last90Days(Duration(days: 90)),
+  allTime(null);
 
-  const _AnalyticsWindow(this.label, this.duration);
+  const _AnalyticsWindow(this.duration);
 
-  final String label;
   final Duration? duration;
 }
 
@@ -1459,9 +1458,9 @@ extension on _AnalyticsWindow {
   /// Switched exhaustively so a new window has to make this choice too.
   String labelFor(AppLocalizations l10n) => switch (this) {
     _AnalyticsWindow.allTime => l10n.analyticsWindowAll,
-    _AnalyticsWindow.last7Days ||
-    _AnalyticsWindow.last28Days ||
-    _AnalyticsWindow.last90Days => label,
+    _AnalyticsWindow.last7Days => '7D',
+    _AnalyticsWindow.last28Days => '28D',
+    _AnalyticsWindow.last90Days => '90D',
   };
 }
 

--- a/mobile/lib/screens/settings/supporter_screen.dart
+++ b/mobile/lib/screens/settings/supporter_screen.dart
@@ -193,7 +193,10 @@ class _TierList extends StatelessWidget {
           Padding(
             padding: const EdgeInsets.only(bottom: 12),
             child: DivineButton(
-              label: '${tier.title} — ${tier.price} / month',
+              label: context.l10n.supporterTierMonthlyLabel(
+                tier.title,
+                tier.price,
+              ),
               onPressed: state.isBusy
                   ? null
                   : () => context.read<SupporterCubit>().subscribe(

--- a/mobile/lib/widgets/user_profile_tile.dart
+++ b/mobile/lib/widgets/user_profile_tile.dart
@@ -221,7 +221,8 @@ class _FollowButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final indexSuffix = index != null ? ' $index' : '';
+    final l10n = context.l10n;
+    final position = index;
 
     // Both states map onto a design-system button: `secondary` already is the
     // surface-container fill with a muted border and a green icon, and
@@ -231,7 +232,9 @@ class _FollowButton extends StatelessWidget {
         icon: .userMinus,
         type: .secondary,
         semanticIdentifier: 'unfollow_user',
-        semanticLabel: 'Unfollow user$indexSuffix',
+        semanticLabel: position == null
+            ? l10n.unfollowUserSemanticLabel
+            : l10n.unfollowUserIndexedSemanticLabel(position),
         onPressed: () => _confirmUnfollow(context),
       );
     }
@@ -240,7 +243,9 @@ class _FollowButton extends StatelessWidget {
       icon: .userPlus,
       size: .small,
       semanticIdentifier: 'follow_user',
-      semanticLabel: 'Follow user$indexSuffix',
+      semanticLabel: position == null
+          ? l10n.followUserSemanticLabel
+          : l10n.followUserIndexedSemanticLabel(position),
       onPressed: onToggleFollow,
     );
   }

--- a/mobile/lib/widgets/user_profile_tile.dart
+++ b/mobile/lib/widgets/user_profile_tile.dart
@@ -234,7 +234,7 @@ class _FollowButton extends StatelessWidget {
         semanticIdentifier: 'unfollow_user',
         semanticLabel: position == null
             ? l10n.unfollowUserSemanticLabel
-            : l10n.unfollowUserIndexedSemanticLabel(position),
+            : l10n.unfollowUserIndexedSemanticLabel('$position'),
         onPressed: () => _confirmUnfollow(context),
       );
     }
@@ -245,7 +245,7 @@ class _FollowButton extends StatelessWidget {
       semanticIdentifier: 'follow_user',
       semanticLabel: position == null
           ? l10n.followUserSemanticLabel
-          : l10n.followUserIndexedSemanticLabel(position),
+          : l10n.followUserIndexedSemanticLabel('$position'),
       onPressed: onToggleFollow,
     );
   }

--- a/mobile/lib/widgets/video_metadata/modes/edit/video_metadata_edit_stack.dart
+++ b/mobile/lib/widgets/video_metadata/modes/edit/video_metadata_edit_stack.dart
@@ -141,6 +141,7 @@ class _VideoMetadataEditStackContentState
       appBar: DiVineAppBar(
         backgroundColor: context.vineColors.surfaceContainerHigh,
         leadingIcon: SvgIconSource(DivineIconName.caretLeft.assetPath),
+        leadingActionSemanticLabel: context.l10n.commonBack,
         onLeadingPressed: context.pop,
         title: context.l10n.shareMenuEditVideo,
       ),

--- a/mobile/packages/divine_ui/lib/src/app_bar/divine_app_bar.dart
+++ b/mobile/packages/divine_ui/lib/src/app_bar/divine_app_bar.dart
@@ -63,8 +63,8 @@ class DiVineAppBar extends StatelessWidget implements PreferredSizeWidget {
     this.backButtonHeroTag,
     this.showMenuButton = false,
     this.onMenuPressed,
-    this.menuButtonSemanticLabel = 'Open menu',
-    this.menuButtonTooltip = 'Menu',
+    this.menuButtonSemanticLabel,
+    this.menuButtonTooltip,
     this.leadingIcon,
     this.onLeadingPressed,
     this.leadingActionSemanticLabel = 'Leading action',
@@ -185,13 +185,15 @@ class DiVineAppBar extends StatelessWidget implements PreferredSizeWidget {
 
   /// Semantic label for the menu button.
   ///
-  /// Defaults to `'Open menu'`. Pass a localized string to override.
-  final String menuButtonSemanticLabel;
+  /// Defaults to [MaterialLocalizations.openAppDrawerTooltip], which Flutter
+  /// translates for every supported locale.
+  final String? menuButtonSemanticLabel;
 
   /// Tooltip for the menu button.
   ///
-  /// Defaults to `'Menu'`. Pass a localized string to override.
-  final String menuButtonTooltip;
+  /// Defaults to [MaterialLocalizations.openAppDrawerTooltip], which Flutter
+  /// translates for every supported locale.
+  final String? menuButtonTooltip;
 
   /// Custom leading icon.
   ///

--- a/mobile/packages/divine_ui/lib/src/app_bar/divine_app_bar.dart
+++ b/mobile/packages/divine_ui/lib/src/app_bar/divine_app_bar.dart
@@ -59,7 +59,7 @@ class DiVineAppBar extends StatelessWidget implements PreferredSizeWidget {
     this.showBackButton = false,
     this.onBackPressed,
     this.backButtonSemanticLabel,
-    this.backButtonTooltip = 'Back',
+    this.backButtonTooltip,
     this.backButtonHeroTag,
     this.showMenuButton = false,
     this.onMenuPressed,
@@ -158,14 +158,16 @@ class DiVineAppBar extends StatelessWidget implements PreferredSizeWidget {
 
   /// Custom semantic label for the back button.
   ///
-  /// When provided, overrides the default 'Go back' label and suppresses the
-  /// tooltip to avoid iOS merging both into the accessibility text.
+  /// When provided, overrides the default label and suppresses the tooltip to
+  /// avoid iOS merging both into the accessibility text.
   final String? backButtonSemanticLabel;
 
   /// Tooltip for the back button.
   ///
-  /// Shown when [backButtonSemanticLabel] is null. Defaults to `'Back'`.
-  final String backButtonTooltip;
+  /// Shown when [backButtonSemanticLabel] is null. Defaults to
+  /// [MaterialLocalizations.backButtonTooltip], which Flutter translates for
+  /// every supported locale.
+  final String? backButtonTooltip;
 
   /// Optional hero tag to wrap the back button in a [Hero] animation.
   ///

--- a/mobile/packages/divine_ui/lib/src/app_bar/divine_app_bar_leading.dart
+++ b/mobile/packages/divine_ui/lib/src/app_bar/divine_app_bar_leading.dart
@@ -21,8 +21,8 @@ class DiVineAppBarLeading extends StatelessWidget {
     this.backButtonSemanticLabel,
     this.backButtonTooltip,
     this.backButtonHeroTag,
-    this.menuButtonSemanticLabel = 'Open menu',
-    this.menuButtonTooltip = 'Menu',
+    this.menuButtonSemanticLabel,
+    this.menuButtonTooltip,
     this.leadingActionSemanticLabel = 'Leading action',
     this.expandHitArea = false,
     super.key,
@@ -64,13 +64,15 @@ class DiVineAppBarLeading extends StatelessWidget {
 
   /// Semantic label for the menu button.
   ///
-  /// Defaults to `'Open menu'`. Pass a localized string to override.
-  final String menuButtonSemanticLabel;
+  /// Defaults to [MaterialLocalizations.openAppDrawerTooltip], which Flutter
+  /// translates for every supported locale.
+  final String? menuButtonSemanticLabel;
 
   /// Tooltip for the menu button.
   ///
-  /// Defaults to `'Menu'`. Pass a localized string to override.
-  final String menuButtonTooltip;
+  /// Defaults to [MaterialLocalizations.openAppDrawerTooltip], which Flutter
+  /// translates for every supported locale.
+  final String? menuButtonTooltip;
 
   /// Semantic label for a custom leading icon.
   ///
@@ -132,12 +134,19 @@ class DiVineAppBarLeading extends StatelessWidget {
     }
 
     if (showMenuButton) {
+      // Same reasoning as the back button above. openAppDrawerTooltip is what
+      // Flutter's own DrawerButton announces for this exact leading-hamburger
+      // slot, so it is the translated equivalent of the 'Open menu' / 'Menu'
+      // constants it replaces.
+      final defaultMenuLabel = MaterialLocalizations.of(
+        context,
+      ).openAppDrawerTooltip;
       return _LeadingIconButton(
         icon: const SvgIconSource(menuIconAsset),
         onPressed: onMenuPressed,
-        semanticLabel: menuButtonSemanticLabel,
+        semanticLabel: menuButtonSemanticLabel ?? defaultMenuLabel,
         semanticIdentifier: menuButtonSemanticId,
-        tooltip: menuButtonTooltip,
+        tooltip: menuButtonTooltip ?? defaultMenuLabel,
         style: style,
         expandHitArea: expandHitArea,
       );

--- a/mobile/packages/divine_ui/lib/src/app_bar/divine_app_bar_leading.dart
+++ b/mobile/packages/divine_ui/lib/src/app_bar/divine_app_bar_leading.dart
@@ -19,7 +19,7 @@ class DiVineAppBarLeading extends StatelessWidget {
     required this.onLeadingPressed,
     required this.style,
     this.backButtonSemanticLabel,
-    this.backButtonTooltip = 'Back',
+    this.backButtonTooltip,
     this.backButtonHeroTag,
     this.menuButtonSemanticLabel = 'Open menu',
     this.menuButtonTooltip = 'Menu',
@@ -48,14 +48,16 @@ class DiVineAppBarLeading extends StatelessWidget {
 
   /// Custom semantic label for the back button.
   ///
-  /// When provided, overrides the default 'Go back' label and suppresses the
-  /// tooltip to avoid iOS merging both into the accessibility text.
+  /// When provided, overrides the default label and suppresses the tooltip to
+  /// avoid iOS merging both into the accessibility text.
   final String? backButtonSemanticLabel;
 
   /// Tooltip for the back button.
   ///
-  /// Shown when [backButtonSemanticLabel] is null. Defaults to `'Back'`.
-  final String backButtonTooltip;
+  /// Shown when [backButtonSemanticLabel] is null. Defaults to
+  /// [MaterialLocalizations.backButtonTooltip], which Flutter translates for
+  /// every supported locale.
+  final String? backButtonTooltip;
 
   /// Optional hero tag to wrap the back button in a [Hero] widget.
   final Object? backButtonHeroTag;
@@ -103,12 +105,23 @@ class DiVineAppBarLeading extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     if (showBackButton) {
+      // divine_ui stays free of the app's AppLocalizations, but Flutter's own
+      // MaterialLocalizations is already translated for every supported locale
+      // and is registered by any app that ships GlobalMaterialLocalizations.
+      // Defaulting here fixes all 92 call sites at once; before this the
+      // hardcoded 'Go back' shipped untranslated to 21 locales because only 6
+      // callers passed backButtonSemanticLabel.
+      final defaultBackLabel = MaterialLocalizations.of(
+        context,
+      ).backButtonTooltip;
       final button = _LeadingIconButton(
         icon: const SvgIconSource(backIconAsset),
         onPressed: onBackPressed ?? () => Navigator.of(context).pop(),
-        semanticLabel: backButtonSemanticLabel ?? 'Go back',
+        semanticLabel: backButtonSemanticLabel ?? defaultBackLabel,
         semanticIdentifier: backButtonSemanticId,
-        tooltip: backButtonSemanticLabel == null ? backButtonTooltip : null,
+        tooltip: backButtonSemanticLabel == null
+            ? (backButtonTooltip ?? defaultBackLabel)
+            : null,
         style: style,
         expandHitArea: expandHitArea,
       );

--- a/mobile/packages/divine_ui/pubspec.yaml
+++ b/mobile/packages/divine_ui/pubspec.yaml
@@ -18,6 +18,8 @@ dependencies:
   skeletonizer: ^2.1.2
 
 dev_dependencies:
+  flutter_localizations:
+    sdk: flutter
   flutter_test:
     sdk: flutter
   mocktail: ^1.0.4

--- a/mobile/packages/divine_ui/test/src/app_bar/divine_app_bar_test.dart
+++ b/mobile/packages/divine_ui/test/src/app_bar/divine_app_bar_test.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/semantics.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -367,7 +368,9 @@ void main() {
           final node = tester.getSemantics(
             find.bySemanticsIdentifier('back_button'),
           );
-          expect(node.label, 'Go back');
+          // MaterialLocalizations.backButtonTooltip — 'Back' in English,
+          // translated by flutter_localizations everywhere else.
+          expect(node.label, 'Back');
           expect(
             node.getSemanticsData().hasAction(SemanticsAction.tap),
             isTrue,
@@ -1001,7 +1004,7 @@ void main() {
           await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
 
           // ...and the labelled button is still there afterwards.
-          expect(find.bySemanticsLabel('Go back'), findsOneWidget);
+          expect(find.bySemanticsLabel('Back'), findsOneWidget);
           handle.dispose();
         },
       );
@@ -1024,6 +1027,62 @@ void main() {
 
         expect(pressed, 1);
       });
+    });
+  });
+
+  group('DiVineAppBar back button localization', () {
+    // The default back label used to be a hardcoded 'Go back', which shipped
+    // untranslated to 21 locales because only 6 of 92 call sites passed
+    // backButtonSemanticLabel. It now defaults to
+    // MaterialLocalizations.backButtonTooltip, which flutter_localizations
+    // translates. This test is the thing that would catch a regression back to
+    // a constant: a hardcoded English default cannot produce 'Atrás'.
+    Widget buildLocalized(Locale locale) => MaterialApp(
+      locale: locale,
+      localizationsDelegates: GlobalMaterialLocalizations.delegates,
+      supportedLocales: const [Locale('en'), Locale('es'), Locale('nl')],
+      theme: VineTheme.theme,
+      home: const Scaffold(
+        appBar: DiVineAppBar(title: 'Test', showBackButton: true),
+        body: SizedBox.shrink(),
+      ),
+    );
+
+    testWidgets('uses the English MaterialLocalizations label', (tester) async {
+      await tester.pumpWidget(buildLocalized(const Locale('en')));
+
+      expect(find.bySemanticsLabel('Back'), findsOneWidget);
+    });
+
+    testWidgets('translates the back label for es', (tester) async {
+      await tester.pumpWidget(buildLocalized(const Locale('es')));
+
+      expect(find.bySemanticsLabel('Atrás'), findsOneWidget);
+      expect(find.bySemanticsLabel('Back'), findsNothing);
+    });
+
+    testWidgets('an explicit label still wins over the localized default', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          locale: const Locale('es'),
+          localizationsDelegates: GlobalMaterialLocalizations.delegates,
+          supportedLocales: const [Locale('en'), Locale('es')],
+          theme: VineTheme.theme,
+          home: const Scaffold(
+            appBar: DiVineAppBar(
+              title: 'Test',
+              showBackButton: true,
+              backButtonSemanticLabel: 'Volver al perfil',
+            ),
+            body: SizedBox.shrink(),
+          ),
+        ),
+      );
+
+      expect(find.bySemanticsLabel('Volver al perfil'), findsOneWidget);
+      expect(find.bySemanticsLabel('Atrás'), findsNothing);
     });
   });
 }

--- a/mobile/packages/divine_ui/test/src/app_bar/divine_app_bar_test.dart
+++ b/mobile/packages/divine_ui/test/src/app_bar/divine_app_bar_test.dart
@@ -78,9 +78,7 @@ void main() {
         tester,
       ) async {
         await tester.pumpWidget(
-          buildTestWidget(
-            titleWidget: const Text('Custom Widget'),
-          ),
+          buildTestWidget(titleWidget: const Text('Custom Widget')),
         );
 
         expect(find.text('Custom Widget'), findsOneWidget);
@@ -88,10 +86,7 @@ void main() {
 
       testWidgets('renders subtitle when provided', (tester) async {
         await tester.pumpWidget(
-          buildTestWidget(
-            title: 'Title',
-            subtitle: 'Subtitle text',
-          ),
+          buildTestWidget(title: 'Title', subtitle: 'Subtitle text'),
         );
 
         expect(find.text('Title'), findsOneWidget);
@@ -100,10 +95,7 @@ void main() {
 
       testWidgets('renders titleSuffix after title', (tester) async {
         await tester.pumpWidget(
-          buildTestWidget(
-            title: 'Test',
-            titleSuffix: const Text('SUFFIX'),
-          ),
+          buildTestWidget(title: 'Test', titleSuffix: const Text('SUFFIX')),
         );
 
         expect(find.text('Test'), findsOneWidget);
@@ -115,10 +107,7 @@ void main() {
       testWidgets('simple mode is not tappable', (tester) async {
         var tapped = false;
         await tester.pumpWidget(
-          buildTestWidget(
-            title: 'Test',
-            onTitleTap: () => tapped = true,
-          ),
+          buildTestWidget(title: 'Test', onTitleTap: () => tapped = true),
         );
 
         await tester.tap(find.text('Test'));
@@ -171,10 +160,7 @@ void main() {
         tester,
       ) async {
         await tester.pumpWidget(
-          buildTestWidget(
-            title: 'Test',
-            showBackButton: true,
-          ),
+          buildTestWidget(title: 'Test', showBackButton: true),
         );
 
         expect(find.byType(DivineAppBarIconButton), findsOneWidget);
@@ -265,88 +251,78 @@ void main() {
       });
 
       testWidgets('no leading when all options are false', (tester) async {
-        await tester.pumpWidget(
-          buildTestWidget(
-            title: 'Test',
-          ),
-        );
+        await tester.pumpWidget(buildTestWidget(title: 'Test'));
 
         expect(find.byType(DivineAppBarIconButton), findsNothing);
       });
 
-      testWidgets(
-        'default leading variants are anchored to their own ids',
-        (tester) async {
-          await tester.pumpWidget(
-            buildTestWidget(
-              title: 'Test',
-              showBackButton: true,
-              onBackPressed: () {},
+      testWidgets('default leading variants are anchored to their own ids', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          buildTestWidget(
+            title: 'Test',
+            showBackButton: true,
+            onBackPressed: () {},
+          ),
+        );
+
+        expect(find.bySemanticsIdentifier('back_button'), findsOneWidget);
+
+        await tester.pumpWidget(
+          buildTestWidget(
+            title: 'Test',
+            showMenuButton: true,
+            onMenuPressed: () {},
+          ),
+        );
+
+        expect(find.bySemanticsIdentifier('menu_button'), findsOneWidget);
+        expect(find.bySemanticsIdentifier('back_button'), findsNothing);
+
+        await tester.pumpWidget(
+          buildTestWidget(
+            title: 'Test',
+            leadingIcon: const SvgIconSource(DiVineAppBarLeading.menuIconAsset),
+            onLeadingPressed: () {},
+          ),
+        );
+
+        expect(
+          find.bySemanticsIdentifier('leading_action_button'),
+          findsOneWidget,
+        );
+        expect(find.bySemanticsIdentifier('back_button'), findsNothing);
+      });
+
+      testWidgets('expandLeadingHitArea routes taps in the empty part of the '
+          'leading slot to onBackPressed', (tester) async {
+        var pressed = false;
+        await tester.pumpWidget(
+          buildTestWidget(
+            title: 'Test',
+            showBackButton: true,
+            onBackPressed: () => pressed = true,
+            expandLeadingHitArea: true,
+            style: DiVineAppBarStyle.overMediaStyle.copyWith(
+              horizontalPadding: 12,
+              leadingWidth: 72,
             ),
-          );
+          ),
+        );
 
-          expect(find.bySemanticsIdentifier('back_button'), findsOneWidget);
-
-          await tester.pumpWidget(
-            buildTestWidget(
-              title: 'Test',
-              showMenuButton: true,
-              onMenuPressed: () {},
-            ),
-          );
-
-          expect(find.bySemanticsIdentifier('menu_button'), findsOneWidget);
-          expect(find.bySemanticsIdentifier('back_button'), findsNothing);
-
-          await tester.pumpWidget(
-            buildTestWidget(
-              title: 'Test',
-              leadingIcon: const SvgIconSource(
-                DiVineAppBarLeading.menuIconAsset,
-              ),
-              onLeadingPressed: () {},
-            ),
-          );
-
-          expect(
-            find.bySemanticsIdentifier('leading_action_button'),
-            findsOneWidget,
-          );
-          expect(find.bySemanticsIdentifier('back_button'), findsNothing);
-        },
-      );
-
-      testWidgets(
-        'expandLeadingHitArea routes taps in the empty part of the '
-        'leading slot to onBackPressed',
-        (tester) async {
-          var pressed = false;
-          await tester.pumpWidget(
-            buildTestWidget(
-              title: 'Test',
-              showBackButton: true,
-              onBackPressed: () => pressed = true,
-              expandLeadingHitArea: true,
-              style: DiVineAppBarStyle.overMediaStyle.copyWith(
-                horizontalPadding: 12,
-                leadingWidth: 72,
-              ),
-            ),
-          );
-
-          // Tap inside the slot but outside the visible 48 × 48 icon
-          // button (which lives at x ∈ [12, 60]).
-          final iconButtonRect = tester.getRect(
-            find.byType(DivineAppBarIconButton),
-          );
-          final tapPoint = Offset(
-            iconButtonRect.right + 4,
-            iconButtonRect.center.dy,
-          );
-          await tester.tapAt(tapPoint);
-          expect(pressed, isTrue);
-        },
-      );
+        // Tap inside the slot but outside the visible 48 × 48 icon
+        // button (which lives at x ∈ [12, 60]).
+        final iconButtonRect = tester.getRect(
+          find.byType(DivineAppBarIconButton),
+        );
+        final tapPoint = Offset(
+          iconButtonRect.right + 4,
+          iconButtonRect.center.dy,
+        );
+        await tester.tapAt(tapPoint);
+        expect(pressed, isTrue);
+      });
 
       testWidgets(
         'expandLeadingHitArea keeps the label on the node that is actually '
@@ -510,11 +486,7 @@ void main() {
           buildTestWidget(
             title: 'Test',
             customActions: const [
-              SizedBox(
-                key: Key('custom-trailing'),
-                width: 24,
-                height: 24,
-              ),
+              SizedBox(key: Key('custom-trailing'), width: 24, height: 24),
             ],
           ),
         );
@@ -535,11 +507,7 @@ void main() {
               ),
             ],
             customActions: const [
-              SizedBox(
-                key: Key('custom-trailing'),
-                width: 24,
-                height: 24,
-              ),
+              SizedBox(key: Key('custom-trailing'), width: 24, height: 24),
             ],
           ),
         );
@@ -555,16 +523,8 @@ void main() {
           buildTestWidget(
             title: 'Test',
             customActions: const [
-              SizedBox(
-                key: Key('custom-1'),
-                width: 24,
-                height: 24,
-              ),
-              SizedBox(
-                key: Key('custom-2'),
-                width: 24,
-                height: 24,
-              ),
+              SizedBox(key: Key('custom-1'), width: 24, height: 24),
+              SizedBox(key: Key('custom-2'), width: 24, height: 24),
             ],
           ),
         );
@@ -575,9 +535,7 @@ void main() {
     });
 
     group('status bar style', () {
-      testWidgets('gradient mode keeps light icons over media', (
-        tester,
-      ) async {
+      testWidgets('gradient mode keeps light icons over media', (tester) async {
         await tester.pumpWidget(
           buildTestWidget(
             title: 'Test',
@@ -624,11 +582,7 @@ void main() {
 
     group('background modes', () {
       testWidgets('solid mode uses navGreen by default', (tester) async {
-        await tester.pumpWidget(
-          buildTestWidget(
-            title: 'Test',
-          ),
-        );
+        await tester.pumpWidget(buildTestWidget(title: 'Test'));
 
         final appBar = tester.widget<AppBar>(find.byType(AppBar));
         expect(appBar.backgroundColor, VineTheme.navGreen);
@@ -636,10 +590,7 @@ void main() {
 
       testWidgets('solid mode uses custom backgroundColor', (tester) async {
         await tester.pumpWidget(
-          buildTestWidget(
-            title: 'Test',
-            backgroundColor: Colors.purple,
-          ),
+          buildTestWidget(title: 'Test', backgroundColor: Colors.purple),
         );
 
         final appBar = tester.widget<AppBar>(find.byType(AppBar));
@@ -775,10 +726,7 @@ void main() {
     group('style', () {
       testWidgets('uses default style when not provided', (tester) async {
         await tester.pumpWidget(
-          buildTestWidget(
-            title: 'Test',
-            showBackButton: true,
-          ),
+          buildTestWidget(title: 'Test', showBackButton: true),
         );
 
         final appBar = tester.widget<AppBar>(find.byType(AppBar));
@@ -793,10 +741,7 @@ void main() {
           buildTestWidget(
             title: 'Test',
             showBackButton: true,
-            style: const DiVineAppBarStyle(
-              height: 64,
-              leadingWidth: 72,
-            ),
+            style: const DiVineAppBarStyle(height: 64, leadingWidth: 72),
           ),
         );
 
@@ -807,10 +752,7 @@ void main() {
 
       testWidgets('preferredSize uses style height', (tester) async {
         const customStyle = DiVineAppBarStyle(height: 64);
-        const appBar = DiVineAppBar(
-          title: 'Test',
-          style: customStyle,
-        );
+        const appBar = DiVineAppBar(title: 'Test', style: customStyle);
 
         expect(appBar.preferredSize.height, 64);
       });
@@ -827,10 +769,7 @@ void main() {
     group('background mode auto-style', () {
       testWidgets('solid mode applies solidStyle icon color', (tester) async {
         await tester.pumpWidget(
-          buildTestWidget(
-            title: 'Test',
-            showBackButton: true,
-          ),
+          buildTestWidget(title: 'Test', showBackButton: true),
         );
 
         final iconButton = tester.widget<DivineAppBarIconButton>(
@@ -903,10 +842,7 @@ void main() {
 
     group('assertions', () {
       test('throws when neither title nor titleWidget is provided', () {
-        expect(
-          DiVineAppBar.new,
-          throwsA(isA<AssertionError>()),
-        );
+        expect(DiVineAppBar.new, throwsA(isA<AssertionError>()));
       });
 
       test('throws when both showBackButton and showMenuButton are true', () {
@@ -984,30 +920,29 @@ void main() {
     });
 
     group('accessibility', () {
-      testWidgets(
-        'expandLeadingHitArea leaves no unlabeled tappable node',
-        (tester) async {
-          final handle = tester.ensureSemantics();
-          await tester.pumpWidget(
-            buildTestWidget(
-              title: 'Feed',
-              showBackButton: true,
-              onBackPressed: () {},
-              expandLeadingHitArea: true,
-            ),
-          );
+      testWidgets('expandLeadingHitArea leaves no unlabeled tappable node', (
+        tester,
+      ) async {
+        final handle = tester.ensureSemantics();
+        await tester.pumpWidget(
+          buildTestWidget(
+            title: 'Feed',
+            showBackButton: true,
+            onBackPressed: () {},
+            expandLeadingHitArea: true,
+          ),
+        );
 
-          // The stretching GestureDetector declares the same tap action as
-          // the Semantics wrapping it, and two configs declaring one action
-          // cannot merge — so without excludeFromSemantics the tree carries
-          // an anonymous button nested inside the labelled one.
-          await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
+        // The stretching GestureDetector declares the same tap action as
+        // the Semantics wrapping it, and two configs declaring one action
+        // cannot merge — so without excludeFromSemantics the tree carries
+        // an anonymous button nested inside the labelled one.
+        await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
 
-          // ...and the labelled button is still there afterwards.
-          expect(find.bySemanticsLabel('Back'), findsOneWidget);
-          handle.dispose();
-        },
-      );
+        // ...and the labelled button is still there afterwards.
+        expect(find.bySemanticsLabel('Back'), findsOneWidget);
+        handle.dispose();
+      });
 
       testWidgets('expandLeadingHitArea still activates the callback', (
         tester,
@@ -1083,6 +1018,73 @@ void main() {
 
       expect(find.bySemanticsLabel('Volver al perfil'), findsOneWidget);
       expect(find.bySemanticsLabel('Atrás'), findsNothing);
+    });
+  });
+
+  group('DiVineAppBar menu button localization', () {
+    // Same defect as the back button: the defaults were the hardcoded English
+    // 'Open menu' / 'Menu'. They now come from
+    // MaterialLocalizations.openAppDrawerTooltip — the string Flutter's own
+    // DrawerButton uses for this slot — so a constant regression cannot
+    // produce 'Abrir el menú de navegación'.
+    Widget buildLocalized(Locale locale) => MaterialApp(
+      locale: locale,
+      localizationsDelegates: GlobalMaterialLocalizations.delegates,
+      supportedLocales: const [Locale('en'), Locale('es')],
+      theme: VineTheme.theme,
+      home: Scaffold(
+        appBar: DiVineAppBar(
+          title: 'Test',
+          showMenuButton: true,
+          onMenuPressed: () {},
+        ),
+        body: const SizedBox.shrink(),
+      ),
+    );
+
+    testWidgets('uses the English MaterialLocalizations label', (tester) async {
+      await tester.pumpWidget(buildLocalized(const Locale('en')));
+
+      expect(find.bySemanticsLabel('Open navigation menu'), findsOneWidget);
+    });
+
+    testWidgets('translates the menu label for es', (tester) async {
+      await tester.pumpWidget(buildLocalized(const Locale('es')));
+
+      expect(
+        find.bySemanticsLabel('Abrir el menú de navegación'),
+        findsOneWidget,
+      );
+      expect(find.bySemanticsLabel('Open navigation menu'), findsNothing);
+    });
+
+    testWidgets('an explicit label still wins over the localized default', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          locale: const Locale('es'),
+          localizationsDelegates: GlobalMaterialLocalizations.delegates,
+          supportedLocales: const [Locale('en'), Locale('es')],
+          theme: VineTheme.theme,
+          home: Scaffold(
+            appBar: DiVineAppBar(
+              title: 'Test',
+              showMenuButton: true,
+              onMenuPressed: () {},
+              menuButtonSemanticLabel: 'Abrir ajustes',
+              menuButtonTooltip: 'Ajustes',
+            ),
+            body: const SizedBox.shrink(),
+          ),
+        ),
+      );
+
+      expect(find.bySemanticsLabel('Abrir ajustes'), findsOneWidget);
+      expect(
+        find.bySemanticsLabel('Abrir el menú de navegación'),
+        findsNothing,
+      );
     });
   });
 }

--- a/mobile/packages/divine_ui/test/src/app_bar/divine_app_bar_test.dart
+++ b/mobile/packages/divine_ui/test/src/app_bar/divine_app_bar_test.dart
@@ -6,8 +6,8 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/semantics.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter_svg/flutter_svg.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_svg/flutter_svg.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {

--- a/mobile/test/screens/comments/comment_skeleton_loader_test.dart
+++ b/mobile/test/screens/comments/comment_skeleton_loader_test.dart
@@ -29,8 +29,21 @@ void main() {
         ),
       );
 
-      final semanticsFinder = find.bySemanticsLabel('Loading comments');
-      expect(semanticsFinder, findsOneWidget);
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      expect(
+        find.bySemanticsLabel(l10n.commentsLoadingSemanticLabel),
+        findsOneWidget,
+      );
+      // Proves the label comes from l10n rather than a constant that happens
+      // to read the same in English.
+      expect(
+        find.bySemanticsLabel(
+          lookupAppLocalizations(
+            const Locale('es'),
+          ).commentsLoadingSemanticLabel,
+        ),
+        findsNothing,
+      );
     });
 
     testWidgets('renders ListView with 6 skeleton items', (tester) async {

--- a/mobile/test/screens/hashtag_feed_safe_pop_test.dart
+++ b/mobile/test/screens/hashtag_feed_safe_pop_test.dart
@@ -75,7 +75,9 @@ void main() {
     );
     await tester.pump();
 
-    await tester.tap(find.bySemanticsLabel('Go back'));
+    // Identifier, not label: the back label is now
+    // MaterialLocalizations.backButtonTooltip and moves per locale.
+    await tester.tap(find.bySemanticsIdentifier('back_button'));
     await tester.pumpAndSettle();
 
     expect(tester.takeException(), isNull);

--- a/mobile/test/screens/inbox/conversation/widgets/conversation_app_bar_test.dart
+++ b/mobile/test/screens/inbox/conversation/widgets/conversation_app_bar_test.dart
@@ -61,9 +61,9 @@ void main() {
           buildSubject(onBack: () => onBackCalled = true),
         );
 
-        // DiVineAppBar renders the back button with a 'Go back' semantic
-        // label inside an IconButton.
-        final backButton = find.bySemanticsLabel('Go back');
+        // Identifier, not label: DiVineAppBar's back label is now
+        // MaterialLocalizations.backButtonTooltip and moves per locale.
+        final backButton = find.bySemanticsIdentifier('back_button');
         await tester.tap(backButton.first);
         await tester.pump();
 

--- a/mobile/test/screens/user_list_people_screen_test.dart
+++ b/mobile/test/screens/user_list_people_screen_test.dart
@@ -974,11 +974,12 @@ void main() {
 
         expect(find.text('Invalid list'), findsOneWidget);
         expect(find.text('People list'), findsOneWidget);
-        // Back button present (matches divine_ui DiVineAppBarLeading label).
-        expect(find.bySemanticsLabel('Go back'), findsOneWidget);
+        // Identifier, not label: the back label is now
+        // MaterialLocalizations.backButtonTooltip and moves per locale.
+        expect(find.bySemanticsIdentifier('back_button'), findsOneWidget);
 
         // Tapping the back button pops the fallback route.
-        await tester.tap(find.bySemanticsLabel('Go back'));
+        await tester.tap(find.bySemanticsIdentifier('back_button'));
         await tester.pumpAndSettle();
 
         expect(find.text('Invalid list'), findsNothing);

--- a/mobile/test/screens/welcome_screen_test.dart
+++ b/mobile/test/screens/welcome_screen_test.dart
@@ -515,6 +515,21 @@ void main() {
         expect(find.byType(AuthHeroSection), findsNothing);
       });
 
+      testWidgets('app bar close control announces a localized label', (
+        tester,
+      ) async {
+        await tester.binding.setSurfaceSize(const Size(800, 1200));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        expect(find.bySemanticsLabel(l10n.commonClose), findsOneWidget);
+        // The divine_ui default. Reaching a user means the call site forgot
+        // to pass a label, and it ships untranslated to every locale.
+        expect(find.bySemanticsLabel('Leading action'), findsNothing);
+      });
+
       testWidgets('shows explicit returning-user action labels', (
         tester,
       ) async {


### PR DESCRIPTION
Closes #7761

Found while investigating #3613. That issue is about test setup; these are the shipping defects the same investigation turned up. Verified on an iOS simulator by switching the app to Spanish and walking 14 screens.

## What was broken

| Defect | Scale |
|---|---|
| `DiVineAppBar` back button: hardcoded `'Go back'` label + `'Back'` tooltip | **86 of 92** call sites across 78 files. Only 6 passed a localized `backButtonSemanticLabel` |
| `DiVineAppBar` menu button: hardcoded `'Open menu'` label + `'Menu'` tooltip | every call site — no caller overrode either |
| `DiVineAppBar` leading action: hardcoded `'Leading action'` label | both production call sites |
| `user_profile_tile`: `'Unfollow user'` / `'Follow user'` labels | followers + following screens |
| `comment_skeleton_loader`: `'Loading comments'` | comments list |
| `supporter_screen`: `'… / month'` | a **purchase** button — the only one a sighted user reads |
| `creator_analytics_screen`: `allTime('All', …)` | the all-time range chip |

Device-confirmed in Spanish: the back button read "Go back"/"Back" on 8 screens, followers/following showed "Unfollow user 0", and analytics showed an English "All" beside 7D/28D/90D.

## The back button: one line, not 78 files

`DiVineAppBar` lives in `divine_ui`, which must stay free of the app's `AppLocalizations`. But Flutter's **own** `MaterialLocalizations.backButtonTooltip` is already translated for every locale and is not app ARB — so defaulting to it fixes all 92 sites without touching a single call site, and makes the default correct for site #93.

```dart
- semanticLabel: backButtonSemanticLabel ?? 'Go back',
+ semanticLabel: backButtonSemanticLabel ?? defaultBackLabel,  // MaterialLocalizations
```

English changes `'Go back'` → `'Back'`. That is the value `commonBack` already carries and what the 6 already-migrated screens already render, so this makes the app consistent rather than introducing new copy.

The menu button now takes the same route via `MaterialLocalizations.openAppDrawerTooltip` — the string Flutter's own `DrawerButton` announces for this exact leading-hamburger slot. English changes `'Open menu'` / `'Menu'` → `'Open navigation menu'`.

The leading-action label had no `MaterialLocalizations` equivalent, so its two production call sites now pass the already-translated `commonClose` / `commonBack` keys instead. The `'Leading action'` default survives in `divine_ui` but no longer has a production reader — which is also a copy fix, since it described nothing useful even in English.

## API contract change worth knowing about

`MaterialLocalizations.of(context)` **asserts**. Where the old code returned a constant unconditionally, `DiVineAppBarLeading` now requires a `MaterialLocalizations` ancestor — so any consumer rendering it outside a `MaterialApp` (or a `WidgetsApp` without the delegates) throws where it previously rendered English.

Nothing in the tree does that today and CI is green, but it is a real contract change on a widget with 92 call sites, and it interacts with the l10n-delegate ratchet (#3613): a *future* test that builds a bare app root around this widget now fails with an assert rather than silently rendering English. That is the better failure mode — loud instead of silent — but it should not be debugged cold.

## Please look at: E2E flows changed

`follow.yaml` and `videoLike.yaml` each had **two platform branches** matching the back button's display text — an iOS branch matching `"Go back" + "Back"` (iOS merges label and tooltip into one accessibility string) and an Android branch matching the label alone. **That split existed only because the label and tooltip differed**, which this PR removes.

Both branches are now one block keyed on the `back_button` identifier — the same move `videoLike`/`videoUnlike`/`searchUsers` already made. The flows stop depending on display text, so they no longer break when copy or locale changes.

`assertImportIdentity.yaml` is deliberately untouched: its "Go back and create a new identity…" is unrelated body copy, not a back button.

I could not execute the Maestro suite locally to confirm these two flows still pass end to end — that is the one thing here I have not verified by running.

## Translations

7 new keys, translated into **all 21** non-English locales rather than deferred to `_knownUntranslatedDebt`. The untranslated-key set is **byte-identical** before and after (8 keys, all pre-existing) — this PR adds zero l10n debt. The menu-button and leading-action fixes needed no new keys at all: one reuses Flutter's own translations, the other reuses `commonClose` / `commonBack`, which are already translated in all 22 locales.

The follow/unfollow English values are byte-identical to the old literals, so `assertUsersFollowing.yaml` (which asserts `Unfollow user 0`) keeps passing unchanged.

## Verification

- `divine_ui`: **945 tests pass, 100.00% coverage** (2292/2292) — the strict gate holds
- 6 new tests prove the localization: a hardcoded default cannot produce `'Atrás'` or `'Abrir el menú de navegación'`. Each was confirmed to fail when the production default is mutated back to a constant
- 1 new test pins the leading-action label, and fails when the call site drops it
- `flutter analyze lib test integration_test` (app) and `flutter analyze lib test` (`divine_ui`) → **No issues found**
- `flutter test test/l10n/arb_consistency_test.dart` → **10 passed**; the whole `test/l10n/` directory → **104 passed**
- Affected suites (branch-touched tests, analytics, supporter, and all 10 `UserProfileTile` consumers) → **198 passed, 0 failed**
- Goldens: 3 fail locally at 2.79% / 2.67% — the documented macOS↔Ubuntu font drift. **Proven not mine**: the identical 3 fail on the unmodified base with my changes stashed. No golden renders `DiVineAppBar`.

Rebased onto fresh `origin/main` to clear the ARB / generated-l10n conflicts. Both sides only ever appended keys at the end of each file, so the resolution is the union of both; the generated Dart was regenerated with `flutter gen-l10n` rather than hand-merged.