### PR TITLE
fix(ios): release App Attest assertion state after timeout

### DIFF
--- a/mobile/overrides/app_device_integrity-1.1.0/OVERRIDE.md
+++ b/mobile/overrides/app_device_integrity-1.1.0/OVERRIDE.md
@@ -31,6 +31,19 @@ local fixes needed by Divine.
   returns explicit Flutter errors instead of leaving callers waiting forever.
 - `android/src/test/kotlin/co/bubotech/app_device_integrity/AppDeviceIntegrityPluginTest.kt`
   covers nonce generation, lifecycle detach safety, and argument validation.
+- `ios/Classes/AppDeviceIntegrity.swift` scopes App Attest state to the
+  publishing account, reuses each account's rate-limited key, resumes one
+  generated-but-unattested key before replacing it, and serializes concurrent
+  provisioning behind a 30-second watchdog.
+- The iOS challenge binds the media proof hash to the publishing pubkey. Cached
+  credentials answer later challenges with assertions, and invalid restored
+  key identifiers re-provision once without clearing a newer replacement.
+- The iOS assertion callback has a 15-second native watchdog above Dart's
+  10-second attestation budget. Each `generateAssertion` leg releases its
+  pending completion at that deadline when Apple's callback never returns,
+  without shortening Dart's existing success window. Provisioning, retry, and
+  recursive re-provisioning have their own deadlines, so the complete native
+  flow is not capped at 15 seconds.
 
 ## Removal Condition
 

--- a/mobile/overrides/app_device_integrity-1.1.0/ios/Classes/AppDeviceIntegrity.swift
+++ b/mobile/overrides/app_device_integrity-1.1.0/ios/Classes/AppDeviceIntegrity.swift
@@ -82,9 +82,23 @@ final class AppDeviceIntegrity {
     /// — turning a single native hang into an account-wide publish stall.
     private static let provisioningTimeout: DispatchTimeInterval = .seconds(30)
 
+    /// Native backstop for a generateAssertion callback that never returns.
+    ///
+    /// Dart gives the complete attestation call 10 seconds, so this deadline
+    /// deliberately sits above that budget. It releases the pending assertion
+    /// completion after Dart has already degraded the publish to no attestation
+    /// without rejecting assertions inside Dart's success window. The deadline
+    /// applies to each generateAssertion leg, not the complete native flow.
+    private static let assertionTimeout: DispatchTimeInterval = .seconds(15)
+
     /// - Parameter keyScope: identifies whose key this is. An empty scope would
     ///   silently collapse every account back onto one shared key, so it is
     ///   rejected rather than defaulted.
+    /// - Parameter challengeString: minted client-side at publish time, never
+    ///   issued by a server. The current format is
+    ///   `"<proofHash>:<pubkeyHex>"`; its UTF-8 bytes are hashed with SHA-256
+    ///   before reaching Apple. The verifier contract and legacy cutover are
+    ///   documented in `mobile/docs/NOSTR_VIDEO_EVENTS.md`.
     init?(challengeString: String, keyScope: String) {
         self.inputString = challengeString
         self.keyScope = keyScope
@@ -167,7 +181,36 @@ final class AppDeviceIntegrity {
         keyID: String,
         completion: @escaping (String?, DCError.Code?) -> Void
     ) {
+        // Whichever side wins the race takes and clears the completion. Apple's
+        // callback and the queued watchdog therefore retain only this shared
+        // box after settlement, not the FlutterResult chain behind completion.
+        let assertionLock = NSLock()
+        var pendingCompletion: ((String?, DCError.Code?) -> Void)? = completion
+
+        DispatchQueue.global(qos: .userInitiated).asyncAfter(
+            deadline: .now() + Self.assertionTimeout
+        ) {
+            assertionLock.lock()
+            guard let completion = pendingCompletion else {
+                assertionLock.unlock()
+                return
+            }
+            pendingCompletion = nil
+            assertionLock.unlock()
+
+            print("App Attest assertion generation timed out")
+            completion(nil, nil)
+        }
+
         attestService.generateAssertion(keyID, clientDataHash: challengeHash) { assertion, error in
+            assertionLock.lock()
+            guard let completion = pendingCompletion else {
+                assertionLock.unlock()
+                return
+            }
+            pendingCompletion = nil
+            assertionLock.unlock()
+
             if let error = error {
                 print("Assertion error: \(error.localizedDescription)")
                 completion(nil, (error as? DCError)?.code)


### PR DESCRIPTION
## Summary

Closes #7756. Follow-up to #6490. Related to the broader
indefinite-attestation report in #3324.

An iOS App Attest assertion request can fail to call its completion handler.
When that happens, the native callback retains the Flutter result chain
indefinitely even after Dart gives up on the publish-time attestation request.

This PR adds a native deadline and makes the callback and watchdog share one
take-and-clear completion box. Whichever side wins the race clears the box under
an `NSLock`, so the other closure retains only the empty box rather than the
Flutter result chain.

## Implementation

- Adds an `NSLock`-protected once-only completion race between Apple's callback
  and a native watchdog.
- Stores the completion in a shared optional box that the race winner takes and
  clears, releasing the result chain on both the timeout and success paths.
- Sets each `generateAssertion` watchdog to 15 seconds, deliberately above
  Dart's existing 10-second attestation budget. Dart remains the user-visible
  timeout; the native deadline is only a backstop and does not cap the complete
  provisioning/retry flow at 15 seconds.
- Preserves #6490's pending-key retry behavior so provisioning timeouts do not
  spend another rate-limited `generateKey()` call.
- Documents the actual client-minted challenge format,
  `"<proofHash>:<pubkeyHex>"`, and records the Divine-specific iOS override
  behavior in `OVERRIDE.md`.

The watchdog remains an `asyncAfter` block. Canceling a `DispatchWorkItem` does
not release its captured resources immediately; the shared box is what releases
the result chain promptly, while keeping the change aligned with the existing
provisioning watchdog.

## Verification

- `flutter test test/services/ios_device_attestation_service_test.dart test/services/video_event_publisher_native_proof_test.dart`
  — 12 passed.
- `flutter analyze lib test integration_test` — no issues.
- `xcrun swiftc -parse -target arm64-apple-ios14.0 overrides/app_device_integrity-1.1.0/ios/Classes/AppDeviceIntegrity.swift`
  — parsed successfully, with the expected host-sysroot warning.

The Dart timeout test uses a Dart fake and does not cross the method channel.
This override has no native iOS test target, and CI does not compile the Swift
file, so the native watchdog is compiler-parsed rather than unit-tested here.
The once-only race was also exercised off-device during review over 3,000
simultaneous deadline/callback runs without a missing or duplicate completion.

## Review findings addressed

- Restored the shared completion-box fix that was accidentally dropped during
  the earlier history rewrite.
- Kept the native deadline above Dart's timeout and corrected its rationale.
- Preserved the existing bounded pending-key retry instead of clearing the key
  on provisioning timeout.
- Corrected the challenge-format documentation.
- Clarified that 15 seconds caps each assertion leg, not the complete native
  flow.

## Type of change

- [x] Bug fix
- [x] Documentation
