### PR TITLE
fix(l10n): localize the database bootstrap failure screen

### DIFF
--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -5342,5 +5342,18 @@
   "socialProofFollowerCount": "{count, plural, =1{{formattedCount} ተከታይ} other{{formattedCount} ተከታዮች}}",
   "searchUserVideoCount": "{count, plural, =1{{formattedCount} ቪዲዮ} other{{formattedCount} ቪዲዮዎች}}",
   "feedOutageMessage": "ቪዲዮዎች አሁን እየተጫኑ አይደሉም።\nችግሩ የእኛ ነው፤ እየሠራንበት ነው።",
-  "feedOfflineMessage": "ከመስመር ውጭ ነዎት።\nግንኙነትዎን አረጋግጠው እንደገና ይሞክሩ።"
+  "feedOfflineMessage": "ከመስመር ውጭ ነዎት።\nግንኙነትዎን አረጋግጠው እንደገና ይሞክሩ።",
+    "dbFailureTitle": "የአካባቢ ዳታቤዝዎን መክፈት አልተቻለም",
+    "dbFailureAdviceResettable": "እንደገና ማስጀመር ይህን አያስተካክለውም። ከታች ያለውን የአካባቢ ዳታቤዝ ዳግም ማስጀመር ለDivine ንጹህ ጅምር ይሰጣል — መለያዎ ይቀራል።",
+    "dbFailureAdviceRestart": "መሣሪያዎን ከከፈቱ በኋላ Divineን እንደገና ያስጀምሩ። ይህ የሚቀጥል ከሆነ መተግበሪያውን ያዘምኑ ወይም ድጋፍን ያግኙ።",
+    "dbFailureDiagnostic": "ምርመራ: {code}",
+    "dbFailureCloseApp": "Divineን ዝጋ",
+    "dbFailureResetAction": "የአካባቢ ዳታቤዝ ዳግም አስጀምር",
+    "dbFailureConfirmTitle": "የአካባቢ ዳታቤዝዎን ዳግም ያስጀምሩ?",
+    "dbFailureConfirmBody": "መለያዎ ይቀራል። በዚህ መሣሪያ ላይ የተቀመጡ ረቂቆች እና ክሊፖች ይሰረዛሉ — መልእክቶች እና ምግቦች ከአውታረ መረቡ ይመለሳሉ።",
+    "dbFailureResetConfirm": "ዳግም አስጀምር እና ዝጋ",
+    "dbFailureCancel": "ሰርዝ",
+    "dbFailureResetFailed": "ያ አልሰራም። Divineን ዘግተው እንደገና ይሞክሩ።",
+    "dbFailureResetDoneTitle": "የአካባቢ ዳታቤዝ ዳግም ተጀምሯል",
+    "dbFailureResetDoneBody": "Divineን ዝጋ እና እንደገና ክፈተው — ቀጣዩ ጅምር አዲስ የአካባቢ ዳታቤዝ ይገነባል።"
 }

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -5217,5 +5217,18 @@
   "socialProofFollowerCount": "{count, plural, =1{{formattedCount} متابِع} other{{formattedCount} متابِع}}",
   "searchUserVideoCount": "{count, plural, =1{{formattedCount} فيديو} other{{formattedCount} فيديو}}",
   "feedOutageMessage": "الفيديوهات لا تُحمَّل الآن.\nالمشكلة من عندنا، ونحن نصلحها.",
-  "feedOfflineMessage": "أنت غير متصل.\nتحقق من اتصالك وحاول مرة أخرى."
+  "feedOfflineMessage": "أنت غير متصل.\nتحقق من اتصالك وحاول مرة أخرى.",
+    "dbFailureTitle": "تعذّر فتح قاعدة البيانات المحلية",
+    "dbFailureAdviceResettable": "إعادة التشغيل لن تحل هذه المشكلة. إعادة تعيين قاعدة البيانات المحلية أدناه تمنح Divine بداية نظيفة — يبقى حسابك كما هو.",
+    "dbFailureAdviceRestart": "أعد تشغيل Divine بعد فتح قفل جهازك. إذا استمر هذا، فحدّث التطبيق أو تواصل مع الدعم.",
+    "dbFailureDiagnostic": "التشخيص: {code}",
+    "dbFailureCloseApp": "إغلاق Divine",
+    "dbFailureResetAction": "إعادة تعيين قاعدة البيانات المحلية",
+    "dbFailureConfirmTitle": "إعادة تعيين قاعدة البيانات المحلية؟",
+    "dbFailureConfirmBody": "يبقى حسابك. تُحذف المسودات والمقاطع المحفوظة على هذا الجهاز — أما الرسائل والخلاصات فتعود من الشبكة.",
+    "dbFailureResetConfirm": "إعادة التعيين والإغلاق",
+    "dbFailureCancel": "إلغاء",
+    "dbFailureResetFailed": "لم ينجح ذلك. أغلق Divine وحاول مرة أخرى.",
+    "dbFailureResetDoneTitle": "تمت إعادة تعيين قاعدة البيانات المحلية",
+    "dbFailureResetDoneBody": "أغلق Divine ثم افتحه مجددًا — سيبني التشغيل التالي قاعدة بيانات محلية جديدة."
 }

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -5348,5 +5348,18 @@
   "socialProofFollowerCount": "{count, plural, =1{{formattedCount} последовател} other{{formattedCount} последователи}}",
   "searchUserVideoCount": "{count, plural, =1{{formattedCount} видео} other{{formattedCount} видеа}}",
   "feedOutageMessage": "Видеата не се зареждат в момента.\nПроблемът е от нас и вече го оправяме.",
-  "feedOfflineMessage": "Няма връзка с интернет.\nПровери връзката си и опитай пак."
+  "feedOfflineMessage": "Няма връзка с интернет.\nПровери връзката си и опитай пак.",
+    "dbFailureTitle": "локалната база данни не може да се отключи",
+    "dbFailureAdviceResettable": "Рестартирането няма да помогне. Нулирането на локалната база данни по-долу дава на Divine чист старт — акаунтът ти остава.",
+    "dbFailureAdviceRestart": "Рестартирай Divine, след като отключиш устройството си. Ако това продължава, обнови приложението или се свържи с поддръжката.",
+    "dbFailureDiagnostic": "Диагностика: {code}",
+    "dbFailureCloseApp": "затвори Divine",
+    "dbFailureResetAction": "нулирай локалната база данни",
+    "dbFailureConfirmTitle": "да нулираме ли локалната база данни?",
+    "dbFailureConfirmBody": "Акаунтът ти остава. Черновите и клиповете, запазени на това устройство, се изтриват — съобщенията и емисиите се връщат от мрежата.",
+    "dbFailureResetConfirm": "нулирай и затвори",
+    "dbFailureCancel": "отказ",
+    "dbFailureResetFailed": "Това не сработи. Затвори Divine и опитай отново.",
+    "dbFailureResetDoneTitle": "локалната база данни е нулирана",
+    "dbFailureResetDoneBody": "Затвори Divine и го отвори отново — следващото стартиране изгражда нова локална база данни."
 }

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -5217,5 +5217,18 @@
   "socialProofFollowerCount": "{count, plural, =1{{formattedCount} Follower} other{{formattedCount} Follower}}",
   "searchUserVideoCount": "{count, plural, =1{{formattedCount} Video} other{{formattedCount} Videos}}",
   "feedOutageMessage": "Videos laden gerade nicht.\nDas liegt an uns, nicht an dir – wir sind dran.",
-  "feedOfflineMessage": "Du bist offline.\nPrüfe deine Verbindung und versuch es nochmal."
+  "feedOfflineMessage": "Du bist offline.\nPrüfe deine Verbindung und versuch es nochmal.",
+    "dbFailureTitle": "Lokale Datenbank konnte nicht entsperrt werden",
+    "dbFailureAdviceResettable": "Ein Neustart hilft hier nicht. Das Zurücksetzen der lokalen Datenbank unten gibt Divine einen sauberen Start — dein Konto bleibt bestehen.",
+    "dbFailureAdviceRestart": "Starte Divine neu, nachdem du dein Gerät entsperrt hast. Wenn das weiterhin passiert, aktualisiere die App oder wende dich an den Support.",
+    "dbFailureDiagnostic": "Diagnose: {code}",
+    "dbFailureCloseApp": "Divine schließen",
+    "dbFailureResetAction": "Lokale Datenbank zurücksetzen",
+    "dbFailureConfirmTitle": "Lokale Datenbank zurücksetzen?",
+    "dbFailureConfirmBody": "Dein Konto bleibt. Auf diesem Gerät gespeicherte Entwürfe und Clips werden gelöscht — Nachrichten und Feeds kommen aus dem Netzwerk zurück.",
+    "dbFailureResetConfirm": "Zurücksetzen und schließen",
+    "dbFailureCancel": "Abbrechen",
+    "dbFailureResetFailed": "Das hat nicht geklappt. Schließe Divine und versuche es erneut.",
+    "dbFailureResetDoneTitle": "Lokale Datenbank zurückgesetzt",
+    "dbFailureResetDoneBody": "Schließe Divine und öffne es erneut — der nächste Start legt eine frische lokale Datenbank an."
 }

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -7617,5 +7617,31 @@
   "feedOfflineMessage": "You're offline.\nCheck your connection and try again.",
   "@feedOfflineMessage": {
     "description": "Shown on the video feed when the device has no network, or when even the status page (on a different CDN) is unreachable."
-  }
+  },
+  "dbFailureTitle": "couldn't unlock your local database",
+  "@dbFailureTitle": {"description": "Title of the fail-closed startup screen shown when the encrypted local database cannot be opened."},
+  "dbFailureAdviceResettable": "A restart won't fix this one. Resetting the local database below gives Divine a clean start — your account stays.",
+  "@dbFailureAdviceResettable": {"description": "Advice on the database-failure screen when a reset is offered, because the database is provably unusable."},
+  "dbFailureAdviceRestart": "Restart Divine after unlocking your device. If this keeps happening, update the app or contact support.",
+  "@dbFailureAdviceRestart": {"description": "Advice on the database-failure screen when no reset is offered, because the database is intact and only its keystore was unreachable."},
+  "dbFailureDiagnostic": "Diagnostic: {code}",
+  "@dbFailureDiagnostic": {"description": "Short diagnostic code rendered on the database-failure screen so a support report can name the cause without a stack trace.", "placeholders": {"code": {"type": "String"}}},
+  "dbFailureCloseApp": "close Divine",
+  "@dbFailureCloseApp": {"description": "Button that quits the app from the database-failure screen."},
+  "dbFailureResetAction": "reset local database",
+  "@dbFailureResetAction": {"description": "Button that opens the confirmation step for the destructive local-database reset."},
+  "dbFailureConfirmTitle": "reset your local database?",
+  "@dbFailureConfirmTitle": {"description": "Title of the confirmation step before the local database is reset."},
+  "dbFailureConfirmBody": "Your account stays. Drafts and clips saved on this device are deleted — messages and feeds come back from the network.",
+  "@dbFailureConfirmBody": {"description": "Body of the confirmation step explaining what a local-database reset deletes and what survives."},
+  "dbFailureResetConfirm": "reset and close",
+  "@dbFailureResetConfirm": {"description": "Button that performs the local-database reset and then closes the app."},
+  "dbFailureCancel": "cancel",
+  "@dbFailureCancel": {"description": "Button that returns from the reset confirmation to the failure screen."},
+  "dbFailureResetFailed": "That didn't work. Close Divine and try again.",
+  "@dbFailureResetFailed": {"description": "Message shown when the local-database reset itself failed or timed out."},
+  "dbFailureResetDoneTitle": "local database reset",
+  "@dbFailureResetDoneTitle": {"description": "Title of the terminal step after a successful local-database reset."},
+  "dbFailureResetDoneBody": "Close Divine and open it again — the next launch builds a fresh local database.",
+  "@dbFailureResetDoneBody": {"description": "Body of the terminal step after a successful reset, telling the user to relaunch."}
 }

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -5217,5 +5217,18 @@
   "socialProofFollowerCount": "{count, plural, =1{{formattedCount} seguidor} other{{formattedCount} seguidores}}",
   "searchUserVideoCount": "{count, plural, =1{{formattedCount} video} other{{formattedCount} videos}}",
   "feedOutageMessage": "Los videos no se están cargando.\nEs cosa nuestra, no tuya: ya estamos en ello.",
-  "feedOfflineMessage": "Estás sin conexión.\nRevisa tu conexión e inténtalo de nuevo."
+  "feedOfflineMessage": "Estás sin conexión.\nRevisa tu conexión e inténtalo de nuevo.",
+    "dbFailureTitle": "no se pudo desbloquear tu base de datos local",
+    "dbFailureAdviceResettable": "Reiniciar no va a arreglar esto. Restablecer la base de datos local de abajo le da a Divine un comienzo limpio — tu cuenta se mantiene.",
+    "dbFailureAdviceRestart": "Reiniciá Divine después de desbloquear tu dispositivo. Si esto sigue pasando, actualizá la app o contactá con soporte.",
+    "dbFailureDiagnostic": "Diagnóstico: {code}",
+    "dbFailureCloseApp": "cerrar Divine",
+    "dbFailureResetAction": "restablecer base de datos local",
+    "dbFailureConfirmTitle": "¿restablecer tu base de datos local?",
+    "dbFailureConfirmBody": "Tu cuenta se mantiene. Los borradores y clips guardados en este dispositivo se eliminan — los mensajes y feeds vuelven desde la red.",
+    "dbFailureResetConfirm": "restablecer y cerrar",
+    "dbFailureCancel": "cancelar",
+    "dbFailureResetFailed": "Eso no funcionó. Cerrá Divine y probá de nuevo.",
+    "dbFailureResetDoneTitle": "base de datos local restablecida",
+    "dbFailureResetDoneBody": "Cerrá Divine y volvé a abrirlo — el próximo inicio crea una base de datos local nueva."
 }

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -3811,5 +3811,18 @@
   "socialProofFollowerCount": "{count, plural, =1{{formattedCount} follower} other{{formattedCount} follower}}",
   "searchUserVideoCount": "{count, plural, =1{{formattedCount} video} other{{formattedCount} video}}",
   "feedOutageMessage": "Hindi nagloload ang mga video ngayon.\nSa amin ito, hindi sa iyo — inaayos na namin.",
-  "feedOfflineMessage": "Offline ka.\nTingnan ang koneksyon mo at subukan ulit."
+  "feedOfflineMessage": "Offline ka.\nTingnan ang koneksyon mo at subukan ulit.",
+    "dbFailureTitle": "hindi ma-unlock ang iyong lokal na database",
+    "dbFailureAdviceResettable": "Hindi ito maaayos ng pag-restart. Ang pag-reset ng lokal na database sa ibaba ay nagbibigay sa Divine ng malinis na simula — mananatili ang iyong account.",
+    "dbFailureAdviceRestart": "I-restart ang Divine matapos i-unlock ang iyong device. Kung patuloy itong nangyayari, i-update ang app o makipag-ugnayan sa suporta.",
+    "dbFailureDiagnostic": "Diagnostic: {code}",
+    "dbFailureCloseApp": "isara ang Divine",
+    "dbFailureResetAction": "i-reset ang lokal na database",
+    "dbFailureConfirmTitle": "i-reset ang iyong lokal na database?",
+    "dbFailureConfirmBody": "Mananatili ang iyong account. Buburahin ang mga draft at clip na naka-save sa device na ito — babalik ang mga mensahe at feed mula sa network.",
+    "dbFailureResetConfirm": "i-reset at isara",
+    "dbFailureCancel": "kanselahin",
+    "dbFailureResetFailed": "Hindi ito gumana. Isara ang Divine at subukan ulit.",
+    "dbFailureResetDoneTitle": "na-reset ang lokal na database",
+    "dbFailureResetDoneBody": "Isara ang Divine at buksan itong muli — gagawa ng bagong lokal na database sa susunod na paglulunsad."
 }

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -5217,5 +5217,18 @@
   "socialProofFollowerCount": "{count, plural, =1{{formattedCount} abonné} other{{formattedCount} abonnés}}",
   "searchUserVideoCount": "{count, plural, =1{{formattedCount} vidéo} other{{formattedCount} vidéos}}",
   "feedOutageMessage": "Les vidéos ne se chargent pas pour le moment.\nÇa vient de nous, pas de vous — on s'en occupe.",
-  "feedOfflineMessage": "Vous êtes hors ligne.\nVérifiez votre connexion et réessayez."
+  "feedOfflineMessage": "Vous êtes hors ligne.\nVérifiez votre connexion et réessayez.",
+    "dbFailureTitle": "impossible de déverrouiller votre base de données locale",
+    "dbFailureAdviceResettable": "Un redémarrage ne réglera pas ça. Réinitialiser la base de données locale ci-dessous donne à Divine un nouveau départ — votre compte est conservé.",
+    "dbFailureAdviceRestart": "Redémarrez Divine après avoir déverrouillé votre appareil. Si cela persiste, mettez l'application à jour ou contactez l'assistance.",
+    "dbFailureDiagnostic": "Diagnostic : {code}",
+    "dbFailureCloseApp": "fermer Divine",
+    "dbFailureResetAction": "réinitialiser la base de données locale",
+    "dbFailureConfirmTitle": "réinitialiser votre base de données locale ?",
+    "dbFailureConfirmBody": "Votre compte est conservé. Les brouillons et clips enregistrés sur cet appareil sont supprimés — les messages et fils reviennent du réseau.",
+    "dbFailureResetConfirm": "réinitialiser et fermer",
+    "dbFailureCancel": "annuler",
+    "dbFailureResetFailed": "Ça n'a pas fonctionné. Fermez Divine et réessayez.",
+    "dbFailureResetDoneTitle": "base de données locale réinitialisée",
+    "dbFailureResetDoneBody": "Fermez Divine et rouvrez-le — le prochain lancement crée une nouvelle base de données locale."
 }

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -5217,5 +5217,18 @@
   "socialProofFollowerCount": "{count, plural, other{{formattedCount} pengikut}}",
   "searchUserVideoCount": "{count, plural, other{{formattedCount} video}}",
   "feedOutageMessage": "Video sedang tidak bisa dimuat.\nIni dari kami, bukan kamu — sedang kami perbaiki.",
-  "feedOfflineMessage": "Kamu sedang offline.\nPeriksa koneksimu lalu coba lagi."
+  "feedOfflineMessage": "Kamu sedang offline.\nPeriksa koneksimu lalu coba lagi.",
+    "dbFailureTitle": "tidak dapat membuka basis data lokalmu",
+    "dbFailureAdviceResettable": "Memulai ulang tidak akan memperbaikinya. Mengatur ulang basis data lokal di bawah memberi Divine awal yang bersih — akunmu tetap ada.",
+    "dbFailureAdviceRestart": "Mulai ulang Divine setelah membuka kunci perangkatmu. Jika ini terus terjadi, perbarui aplikasi atau hubungi dukungan.",
+    "dbFailureDiagnostic": "Diagnostik: {code}",
+    "dbFailureCloseApp": "tutup Divine",
+    "dbFailureResetAction": "atur ulang basis data lokal",
+    "dbFailureConfirmTitle": "atur ulang basis data lokalmu?",
+    "dbFailureConfirmBody": "Akunmu tetap ada. Draf dan klip yang tersimpan di perangkat ini akan dihapus — pesan dan feed kembali dari jaringan.",
+    "dbFailureResetConfirm": "atur ulang dan tutup",
+    "dbFailureCancel": "batal",
+    "dbFailureResetFailed": "Itu tidak berhasil. Tutup Divine dan coba lagi.",
+    "dbFailureResetDoneTitle": "basis data lokal telah diatur ulang",
+    "dbFailureResetDoneBody": "Tutup Divine lalu buka lagi — peluncuran berikutnya membangun basis data lokal yang baru."
 }

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -5217,5 +5217,18 @@
   "socialProofFollowerCount": "{count, plural, =1{{formattedCount} follower} other{{formattedCount} follower}}",
   "searchUserVideoCount": "{count, plural, =1{{formattedCount} video} other{{formattedCount} video}}",
   "feedOutageMessage": "I video non si caricano al momento.\nDipende da noi, non da te — ci stiamo lavorando.",
-  "feedOfflineMessage": "Sei offline.\nControlla la connessione e riprova."
+  "feedOfflineMessage": "Sei offline.\nControlla la connessione e riprova.",
+    "dbFailureTitle": "impossibile sbloccare il database locale",
+    "dbFailureAdviceResettable": "Riavviare non risolverà il problema. Reimpostare il database locale qui sotto dà a Divine un nuovo inizio — il tuo account resta.",
+    "dbFailureAdviceRestart": "Riavvia Divine dopo aver sbloccato il dispositivo. Se continua a succedere, aggiorna l'app o contatta l'assistenza.",
+    "dbFailureDiagnostic": "Diagnostica: {code}",
+    "dbFailureCloseApp": "chiudi Divine",
+    "dbFailureResetAction": "reimposta database locale",
+    "dbFailureConfirmTitle": "reimpostare il database locale?",
+    "dbFailureConfirmBody": "Il tuo account resta. Le bozze e le clip salvate su questo dispositivo vengono eliminate — messaggi e feed tornano dalla rete.",
+    "dbFailureResetConfirm": "reimposta e chiudi",
+    "dbFailureCancel": "annulla",
+    "dbFailureResetFailed": "Non ha funzionato. Chiudi Divine e riprova.",
+    "dbFailureResetDoneTitle": "database locale reimpostato",
+    "dbFailureResetDoneBody": "Chiudi Divine e riaprilo — al prossimo avvio verrà creato un nuovo database locale."
 }

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -5217,5 +5217,18 @@
   "socialProofFollowerCount": "{count, plural, other{フォロワー{formattedCount}人}}",
   "searchUserVideoCount": "{count, plural, other{{formattedCount}本の動画}}",
   "feedOutageMessage": "いま動画を読み込めません。\nこちらの不具合だよ。すぐ直すね。",
-  "feedOfflineMessage": "オフラインだよ。\n接続を確認して、もう一度試してね。"
+  "feedOfflineMessage": "オフラインだよ。\n接続を確認して、もう一度試してね。",
+    "dbFailureTitle": "ローカルデータベースのロックを解除できませんでした",
+    "dbFailureAdviceResettable": "再起動では解決しません。下のローカルデータベースをリセットすると Divine をきれいな状態から始められます。アカウントはそのまま残ります。",
+    "dbFailureAdviceRestart": "デバイスのロックを解除してから Divine を再起動してください。これが続く場合は、アプリを更新するかサポートにご連絡ください。",
+    "dbFailureDiagnostic": "診断: {code}",
+    "dbFailureCloseApp": "Divine を閉じる",
+    "dbFailureResetAction": "ローカルデータベースをリセット",
+    "dbFailureConfirmTitle": "ローカルデータベースをリセットしますか？",
+    "dbFailureConfirmBody": "アカウントはそのまま残ります。この端末に保存された下書きとクリップは削除されます。メッセージとフィードはネットワークから復元されます。",
+    "dbFailureResetConfirm": "リセットして閉じる",
+    "dbFailureCancel": "キャンセル",
+    "dbFailureResetFailed": "うまくいきませんでした。Divine を閉じてもう一度お試しください。",
+    "dbFailureResetDoneTitle": "ローカルデータベースをリセットしました",
+    "dbFailureResetDoneBody": "Divine を閉じてもう一度開いてください。次回の起動で新しいローカルデータベースが作成されます。"
 }

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -4563,5 +4563,18 @@
   "socialProofFollowerCount": "{count, plural, other{팔로워 {formattedCount}명}}",
   "searchUserVideoCount": "{count, plural, other{영상 {formattedCount}개}}",
   "feedOutageMessage": "지금 영상을 불러올 수 없어요.\n저희 문제예요. 고치는 중이에요.",
-  "feedOfflineMessage": "오프라인 상태예요.\n연결을 확인하고 다시 시도해 주세요."
+  "feedOfflineMessage": "오프라인 상태예요.\n연결을 확인하고 다시 시도해 주세요.",
+    "dbFailureTitle": "로컬 데이터베이스를 열지 못했습니다",
+    "dbFailureAdviceResettable": "재시작으로는 해결되지 않습니다. 아래에서 로컬 데이터베이스를 초기화하면 Divine을 깨끗한 상태로 시작할 수 있습니다. 계정은 그대로 유지됩니다.",
+    "dbFailureAdviceRestart": "기기 잠금을 해제한 뒤 Divine을 다시 실행하세요. 계속 발생하면 앱을 업데이트하거나 고객지원에 문의하세요.",
+    "dbFailureDiagnostic": "진단: {code}",
+    "dbFailureCloseApp": "Divine 닫기",
+    "dbFailureResetAction": "로컬 데이터베이스 초기화",
+    "dbFailureConfirmTitle": "로컬 데이터베이스를 초기화할까요?",
+    "dbFailureConfirmBody": "계정은 그대로 유지됩니다. 이 기기에 저장된 초안과 클립은 삭제됩니다. 메시지와 피드는 네트워크에서 다시 불러옵니다.",
+    "dbFailureResetConfirm": "초기화하고 닫기",
+    "dbFailureCancel": "취소",
+    "dbFailureResetFailed": "실패했습니다. Divine을 닫고 다시 시도하세요.",
+    "dbFailureResetDoneTitle": "로컬 데이터베이스가 초기화되었습니다",
+    "dbFailureResetDoneBody": "Divine을 닫았다가 다시 여세요. 다음 실행에서 새 로컬 데이터베이스가 만들어집니다."
 }

--- a/mobile/lib/l10n/app_ms.arb
+++ b/mobile/lib/l10n/app_ms.arb
@@ -7047,5 +7047,18 @@
   "socialProofFollowerCount": "{count, plural, other{{formattedCount} pengikut}}",
   "searchUserVideoCount": "{count, plural, other{{formattedCount} video}}",
   "feedOutageMessage": "Video tidak dapat dimuatkan sekarang.\nIni masalah kami, bukan anda — kami sedang membaikinya.",
-  "feedOfflineMessage": "Anda di luar talian.\nSemak sambungan anda dan cuba lagi."
+  "feedOfflineMessage": "Anda di luar talian.\nSemak sambungan anda dan cuba lagi.",
+  "dbFailureTitle": "tidak dapat membuka kunci pangkalan data setempat anda",
+  "dbFailureAdviceResettable": "Memulakan semula tidak akan membaikinya. Menetapkan semula pangkalan data setempat di bawah memberi Divine permulaan yang bersih — akaun anda kekal.",
+  "dbFailureAdviceRestart": "Mulakan semula Divine selepas membuka kunci peranti anda. Jika ini berterusan, kemas kini apl atau hubungi sokongan.",
+  "dbFailureDiagnostic": "Diagnostik: {code}",
+  "dbFailureCloseApp": "tutup Divine",
+  "dbFailureResetAction": "tetapkan semula pangkalan data setempat",
+  "dbFailureConfirmTitle": "tetapkan semula pangkalan data setempat anda?",
+  "dbFailureConfirmBody": "Akaun anda kekal. Draf dan klip yang disimpan pada peranti ini akan dipadamkan — mesej dan suapan kembali daripada rangkaian.",
+  "dbFailureResetConfirm": "tetapkan semula dan tutup",
+  "dbFailureCancel": "batal",
+  "dbFailureResetFailed": "Itu tidak berjaya. Tutup Divine dan cuba lagi.",
+  "dbFailureResetDoneTitle": "pangkalan data setempat ditetapkan semula",
+  "dbFailureResetDoneBody": "Tutup Divine dan buka semula — pelancaran seterusnya membina pangkalan data setempat yang baharu."
 }

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -5217,5 +5217,18 @@
   "socialProofFollowerCount": "{count, plural, =1{{formattedCount} volger} other{{formattedCount} volgers}}",
   "searchUserVideoCount": "{count, plural, =1{{formattedCount} video} other{{formattedCount} video''s}}",
   "feedOutageMessage": "Er laden nu geen video's.\nHet ligt aan ons, niet aan jou — we zijn ermee bezig.",
-  "feedOfflineMessage": "Je bent offline.\nControleer je verbinding en probeer het opnieuw."
+  "feedOfflineMessage": "Je bent offline.\nControleer je verbinding en probeer het opnieuw.",
+    "dbFailureTitle": "kan je lokale database niet ontgrendelen",
+    "dbFailureAdviceResettable": "Opnieuw opstarten lost dit niet op. De lokale database hieronder resetten geeft Divine een schone start — je account blijft behouden.",
+    "dbFailureAdviceRestart": "Start Divine opnieuw nadat je je apparaat hebt ontgrendeld. Blijft dit gebeuren, werk de app dan bij of neem contact op met support.",
+    "dbFailureDiagnostic": "Diagnose: {code}",
+    "dbFailureCloseApp": "Divine sluiten",
+    "dbFailureResetAction": "lokale database resetten",
+    "dbFailureConfirmTitle": "je lokale database resetten?",
+    "dbFailureConfirmBody": "Je account blijft behouden. Concepten en clips die op dit apparaat zijn opgeslagen worden verwijderd — berichten en feeds komen terug van het netwerk.",
+    "dbFailureResetConfirm": "resetten en sluiten",
+    "dbFailureCancel": "annuleren",
+    "dbFailureResetFailed": "Dat werkte niet. Sluit Divine en probeer het opnieuw.",
+    "dbFailureResetDoneTitle": "lokale database gereset",
+    "dbFailureResetDoneBody": "Sluit Divine en open het opnieuw — bij de volgende start wordt een nieuwe lokale database aangemaakt."
 }

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -5217,5 +5217,18 @@
   "socialProofFollowerCount": "{count, plural, =1{{formattedCount} obserwujący} few{{formattedCount} obserwujących} many{{formattedCount} obserwujących} other{{formattedCount} obserwujących}}",
   "searchUserVideoCount": "{count, plural, =1{{formattedCount} film} few{{formattedCount} filmy} many{{formattedCount} filmów} other{{formattedCount} filmu}}",
   "feedOutageMessage": "Filmy się teraz nie ładują.\nTo po naszej stronie — już to naprawiamy.",
-  "feedOfflineMessage": "Jesteś offline.\nSprawdź połączenie i spróbuj ponownie."
+  "feedOfflineMessage": "Jesteś offline.\nSprawdź połączenie i spróbuj ponownie.",
+    "dbFailureTitle": "nie można odblokować lokalnej bazy danych",
+    "dbFailureAdviceResettable": "Ponowne uruchomienie tego nie naprawi. Zresetowanie lokalnej bazy danych poniżej da Divine czysty start — Twoje konto zostaje.",
+    "dbFailureAdviceRestart": "Uruchom Divine ponownie po odblokowaniu urządzenia. Jeśli to się powtarza, zaktualizuj aplikację lub skontaktuj się z pomocą techniczną.",
+    "dbFailureDiagnostic": "Diagnostyka: {code}",
+    "dbFailureCloseApp": "zamknij Divine",
+    "dbFailureResetAction": "zresetuj lokalną bazę danych",
+    "dbFailureConfirmTitle": "zresetować lokalną bazę danych?",
+    "dbFailureConfirmBody": "Twoje konto zostaje. Wersje robocze i klipy zapisane na tym urządzeniu zostaną usunięte — wiadomości i kanały wrócą z sieci.",
+    "dbFailureResetConfirm": "zresetuj i zamknij",
+    "dbFailureCancel": "anuluj",
+    "dbFailureResetFailed": "To nie zadziałało. Zamknij Divine i spróbuj ponownie.",
+    "dbFailureResetDoneTitle": "lokalna baza danych zresetowana",
+    "dbFailureResetDoneBody": "Zamknij Divine i otwórz go ponownie — następne uruchomienie utworzy nową lokalną bazę danych."
 }

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -5217,5 +5217,18 @@
   "socialProofFollowerCount": "{count, plural, =1{{formattedCount} seguidor} other{{formattedCount} seguidores}}",
   "searchUserVideoCount": "{count, plural, =1{{formattedCount} vídeo} other{{formattedCount} vídeos}}",
   "feedOutageMessage": "Os vídeos não estão carregando.\nO problema é nosso, não seu — já estamos resolvendo.",
-  "feedOfflineMessage": "Você está offline.\nVerifique sua conexão e tente de novo."
+  "feedOfflineMessage": "Você está offline.\nVerifique sua conexão e tente de novo.",
+    "dbFailureTitle": "não foi possível desbloquear seu banco de dados local",
+    "dbFailureAdviceResettable": "Reiniciar não vai resolver. Redefinir o banco de dados local abaixo dá ao Divine um começo limpo — sua conta permanece.",
+    "dbFailureAdviceRestart": "Reinicie o Divine depois de desbloquear seu dispositivo. Se continuar acontecendo, atualize o app ou fale com o suporte.",
+    "dbFailureDiagnostic": "Diagnóstico: {code}",
+    "dbFailureCloseApp": "fechar o Divine",
+    "dbFailureResetAction": "redefinir banco de dados local",
+    "dbFailureConfirmTitle": "redefinir seu banco de dados local?",
+    "dbFailureConfirmBody": "Sua conta permanece. Rascunhos e clipes salvos neste dispositivo são excluídos — mensagens e feeds voltam da rede.",
+    "dbFailureResetConfirm": "redefinir e fechar",
+    "dbFailureCancel": "cancelar",
+    "dbFailureResetFailed": "Isso não funcionou. Feche o Divine e tente de novo.",
+    "dbFailureResetDoneTitle": "banco de dados local redefinido",
+    "dbFailureResetDoneBody": "Feche o Divine e abra de novo — a próxima inicialização cria um banco de dados local novo."
 }

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -5217,5 +5217,18 @@
   "socialProofFollowerCount": "{count, plural, =1{{formattedCount} urmăritor} other{{formattedCount} urmăritori}}",
   "searchUserVideoCount": "{count, plural, =1{{formattedCount} videoclip} other{{formattedCount} videoclipuri}}",
   "feedOutageMessage": "Videoclipurile nu se încarcă acum.\nE de la noi, nu de la tine — lucrăm la asta.",
-  "feedOfflineMessage": "Ești offline.\nVerifică-ți conexiunea și încearcă din nou."
+  "feedOfflineMessage": "Ești offline.\nVerifică-ți conexiunea și încearcă din nou.",
+    "dbFailureTitle": "nu am putut debloca baza de date locală",
+    "dbFailureAdviceResettable": "O repornire nu rezolvă asta. Resetarea bazei de date locale de mai jos îi oferă lui Divine un start curat — contul tău rămâne.",
+    "dbFailureAdviceRestart": "Repornește Divine după ce îți deblochezi dispozitivul. Dacă se repetă, actualizează aplicația sau contactează asistența.",
+    "dbFailureDiagnostic": "Diagnostic: {code}",
+    "dbFailureCloseApp": "închide Divine",
+    "dbFailureResetAction": "resetează baza de date locală",
+    "dbFailureConfirmTitle": "resetezi baza de date locală?",
+    "dbFailureConfirmBody": "Contul tău rămâne. Ciornele și clipurile salvate pe acest dispozitiv sunt șterse — mesajele și fluxurile revin din rețea.",
+    "dbFailureResetConfirm": "resetează și închide",
+    "dbFailureCancel": "anulează",
+    "dbFailureResetFailed": "Nu a funcționat. Închide Divine și încearcă din nou.",
+    "dbFailureResetDoneTitle": "baza de date locală a fost resetată",
+    "dbFailureResetDoneBody": "Închide Divine și deschide-l din nou — următoarea pornire creează o bază de date locală nouă."
 }

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -5217,5 +5217,18 @@
   "socialProofFollowerCount": "{count, plural, =1{{formattedCount} följare} other{{formattedCount} följare}}",
   "searchUserVideoCount": "{count, plural, =1{{formattedCount} video} other{{formattedCount} videor}}",
   "feedOutageMessage": "Videor laddas inte just nu.\nDet är vårt fel, inte ditt – vi jobbar på det.",
-  "feedOfflineMessage": "Du är offline.\nKolla din anslutning och försök igen."
+  "feedOfflineMessage": "Du är offline.\nKolla din anslutning och försök igen.",
+    "dbFailureTitle": "kunde inte låsa upp din lokala databas",
+    "dbFailureAdviceResettable": "En omstart löser inte det här. Att återställa den lokala databasen nedan ger Divine en ren start — ditt konto finns kvar.",
+    "dbFailureAdviceRestart": "Starta om Divine när du har låst upp din enhet. Om det fortsätter, uppdatera appen eller kontakta supporten.",
+    "dbFailureDiagnostic": "Diagnostik: {code}",
+    "dbFailureCloseApp": "stäng Divine",
+    "dbFailureResetAction": "återställ lokal databas",
+    "dbFailureConfirmTitle": "återställa din lokala databas?",
+    "dbFailureConfirmBody": "Ditt konto finns kvar. Utkast och klipp som sparats på den här enheten raderas — meddelanden och flöden hämtas tillbaka från nätverket.",
+    "dbFailureResetConfirm": "återställ och stäng",
+    "dbFailureCancel": "avbryt",
+    "dbFailureResetFailed": "Det fungerade inte. Stäng Divine och försök igen.",
+    "dbFailureResetDoneTitle": "lokal databas återställd",
+    "dbFailureResetDoneBody": "Stäng Divine och öppna det igen — nästa start skapar en ny lokal databas."
 }

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -5217,5 +5217,18 @@
   "socialProofFollowerCount": "{count, plural, other{{formattedCount} takipçi}}",
   "searchUserVideoCount": "{count, plural, other{{formattedCount} video}}",
   "feedOutageMessage": "Videolar şu anda yüklenmiyor.\nSorun bizde, sende değil — üzerinde çalışıyoruz.",
-  "feedOfflineMessage": "Çevrimdışısın.\nBağlantını kontrol edip tekrar dene."
+  "feedOfflineMessage": "Çevrimdışısın.\nBağlantını kontrol edip tekrar dene.",
+    "dbFailureTitle": "yerel veritabanınız açılamadı",
+    "dbFailureAdviceResettable": "Yeniden başlatmak bunu düzeltmez. Aşağıdaki yerel veritabanını sıfırlamak Divine’a temiz bir başlangıç verir — hesabınız kalır.",
+    "dbFailureAdviceRestart": "Cihazınızın kilidini açtıktan sonra Divine’ı yeniden başlatın. Bu sürerse uygulamayı güncelleyin veya destekle iletişime geçin.",
+    "dbFailureDiagnostic": "Tanılama: {code}",
+    "dbFailureCloseApp": "Divine’ı kapat",
+    "dbFailureResetAction": "yerel veritabanını sıfırla",
+    "dbFailureConfirmTitle": "yerel veritabanınız sıfırlansın mı?",
+    "dbFailureConfirmBody": "Hesabınız kalır. Bu cihazda kayıtlı taslaklar ve klipler silinir — mesajlar ve akışlar ağdan geri gelir.",
+    "dbFailureResetConfirm": "sıfırla ve kapat",
+    "dbFailureCancel": "iptal",
+    "dbFailureResetFailed": "Bu işe yaramadı. Divine’ı kapatıp tekrar deneyin.",
+    "dbFailureResetDoneTitle": "yerel veritabanı sıfırlandı",
+    "dbFailureResetDoneBody": "Divine’ı kapatıp yeniden açın — sonraki başlatmada yeni bir yerel veritabanı oluşturulur."
 }

--- a/mobile/lib/l10n/app_ur.arb
+++ b/mobile/lib/l10n/app_ur.arb
@@ -7047,5 +7047,18 @@
   "socialProofFollowerCount": "{count, plural, =1{{formattedCount} فالوور} other{{formattedCount} فالوورز}}",
   "searchUserVideoCount": "{count, plural, =1{{formattedCount} ویڈیو} other{{formattedCount} ویڈیوز}}",
   "feedOutageMessage": "ابھی ویڈیوز لوڈ نہیں ہو رہیں۔\nمسئلہ ہماری طرف سے ہے، ہم اسے ٹھیک کر رہے ہیں۔",
-  "feedOfflineMessage": "آپ آف لائن ہیں۔\nاپنا کنکشن چیک کریں اور دوبارہ کوشش کریں۔"
+  "feedOfflineMessage": "آپ آف لائن ہیں۔\nاپنا کنکشن چیک کریں اور دوبارہ کوشش کریں۔",
+  "dbFailureTitle": "آپ کا مقامی ڈیٹابیس کھولا نہیں جا سکا",
+  "dbFailureAdviceResettable": "دوبارہ شروع کرنے سے یہ ٹھیک نہیں ہوگا۔ نیچے مقامی ڈیٹابیس ری سیٹ کرنے سے Divine کو صاف آغاز ملتا ہے — آپ کا اکاؤنٹ برقرار رہتا ہے۔",
+  "dbFailureAdviceRestart": "اپنا ڈیوائس اَن لاک کرنے کے بعد Divine دوبارہ شروع کریں۔ اگر یہ ہوتا رہے تو ایپ اپ ڈیٹ کریں یا سپورٹ سے رابطہ کریں۔",
+  "dbFailureDiagnostic": "تشخیص: {code}",
+  "dbFailureCloseApp": "Divine بند کریں",
+  "dbFailureResetAction": "مقامی ڈیٹابیس ری سیٹ کریں",
+  "dbFailureConfirmTitle": "اپنا مقامی ڈیٹابیس ری سیٹ کریں؟",
+  "dbFailureConfirmBody": "آپ کا اکاؤنٹ برقرار رہتا ہے۔ اس ڈیوائس پر محفوظ ڈرافٹس اور کلپس حذف ہو جائیں گے — پیغامات اور فیڈز نیٹ ورک سے واپس آ جاتے ہیں۔",
+  "dbFailureResetConfirm": "ری سیٹ کریں اور بند کریں",
+  "dbFailureCancel": "منسوخ کریں",
+  "dbFailureResetFailed": "یہ کام نہیں کیا۔ Divine بند کریں اور دوبارہ کوشش کریں۔",
+  "dbFailureResetDoneTitle": "مقامی ڈیٹابیس ری سیٹ ہو گیا",
+  "dbFailureResetDoneBody": "Divine بند کریں اور دوبارہ کھولیں — اگلی بار شروع ہونے پر نیا مقامی ڈیٹابیس بنے گا۔"
 }

--- a/mobile/lib/l10n/app_vi.arb
+++ b/mobile/lib/l10n/app_vi.arb
@@ -7047,5 +7047,18 @@
   "socialProofFollowerCount": "{count, plural, other{{formattedCount} người theo dõi}}",
   "searchUserVideoCount": "{count, plural, other{{formattedCount} video}}",
   "feedOutageMessage": "Hiện không tải được video.\nLỗi từ phía chúng tôi — chúng tôi đang khắc phục.",
-  "feedOfflineMessage": "Bạn đang ngoại tuyến.\nKiểm tra kết nối rồi thử lại."
+  "feedOfflineMessage": "Bạn đang ngoại tuyến.\nKiểm tra kết nối rồi thử lại.",
+  "dbFailureTitle": "không thể mở khóa cơ sở dữ liệu cục bộ của bạn",
+  "dbFailureAdviceResettable": "Khởi động lại sẽ không khắc phục được. Đặt lại cơ sở dữ liệu cục bộ bên dưới giúp Divine bắt đầu lại từ đầu — tài khoản của bạn vẫn còn.",
+  "dbFailureAdviceRestart": "Khởi động lại Divine sau khi mở khóa thiết bị. Nếu vẫn tiếp diễn, hãy cập nhật ứng dụng hoặc liên hệ bộ phận hỗ trợ.",
+  "dbFailureDiagnostic": "Chẩn đoán: {code}",
+  "dbFailureCloseApp": "đóng Divine",
+  "dbFailureResetAction": "đặt lại cơ sở dữ liệu cục bộ",
+  "dbFailureConfirmTitle": "đặt lại cơ sở dữ liệu cục bộ của bạn?",
+  "dbFailureConfirmBody": "Tài khoản của bạn vẫn còn. Bản nháp và clip đã lưu trên thiết bị này sẽ bị xóa — tin nhắn và bảng tin sẽ được tải lại từ mạng.",
+  "dbFailureResetConfirm": "đặt lại và đóng",
+  "dbFailureCancel": "hủy",
+  "dbFailureResetFailed": "Không thành công. Hãy đóng Divine và thử lại.",
+  "dbFailureResetDoneTitle": "đã đặt lại cơ sở dữ liệu cục bộ",
+  "dbFailureResetDoneBody": "Đóng Divine rồi mở lại — lần khởi chạy tiếp theo sẽ tạo cơ sở dữ liệu cục bộ mới."
 }

--- a/mobile/lib/l10n/app_zh.arb
+++ b/mobile/lib/l10n/app_zh.arb
@@ -7047,5 +7047,18 @@
   "socialProofFollowerCount": "{count, plural, other{{formattedCount} 位粉丝}}",
   "searchUserVideoCount": "{count, plural, other{{formattedCount} 条视频}}",
   "feedOutageMessage": "视频暂时加载不出来。\n是我们的问题，正在修复。",
-  "feedOfflineMessage": "你当前处于离线状态。\n请检查网络后重试。"
+  "feedOfflineMessage": "你当前处于离线状态。\n请检查网络后重试。",
+  "dbFailureTitle": "无法解锁你的本地数据库",
+  "dbFailureAdviceResettable": "重启无法解决这个问题。重置下方的本地数据库可以让 Divine 全新开始 — 你的账号会保留。",
+  "dbFailureAdviceRestart": "解锁设备后重新启动 Divine。如果问题持续出现，请更新应用或联系支持。",
+  "dbFailureDiagnostic": "诊断：{code}",
+  "dbFailureCloseApp": "关闭 Divine",
+  "dbFailureResetAction": "重置本地数据库",
+  "dbFailureConfirmTitle": "重置你的本地数据库？",
+  "dbFailureConfirmBody": "你的账号会保留。保存在此设备上的草稿和片段将被删除 — 消息和信息流会从网络重新获取。",
+  "dbFailureResetConfirm": "重置并关闭",
+  "dbFailureCancel": "取消",
+  "dbFailureResetFailed": "没有成功。请关闭 Divine 后重试。",
+  "dbFailureResetDoneTitle": "本地数据库已重置",
+  "dbFailureResetDoneBody": "关闭 Divine 后重新打开 — 下次启动会建立全新的本地数据库。"
 }

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -20709,6 +20709,84 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'You\'re offline.\nCheck your connection and try again.'**
   String get feedOfflineMessage;
+
+  /// Title of the fail-closed startup screen shown when the encrypted local database cannot be opened.
+  ///
+  /// In en, this message translates to:
+  /// **'couldn\'t unlock your local database'**
+  String get dbFailureTitle;
+
+  /// Advice on the database-failure screen when a reset is offered, because the database is provably unusable.
+  ///
+  /// In en, this message translates to:
+  /// **'A restart won\'t fix this one. Resetting the local database below gives Divine a clean start — your account stays.'**
+  String get dbFailureAdviceResettable;
+
+  /// Advice on the database-failure screen when no reset is offered, because the database is intact and only its keystore was unreachable.
+  ///
+  /// In en, this message translates to:
+  /// **'Restart Divine after unlocking your device. If this keeps happening, update the app or contact support.'**
+  String get dbFailureAdviceRestart;
+
+  /// Short diagnostic code rendered on the database-failure screen so a support report can name the cause without a stack trace.
+  ///
+  /// In en, this message translates to:
+  /// **'Diagnostic: {code}'**
+  String dbFailureDiagnostic(String code);
+
+  /// Button that quits the app from the database-failure screen.
+  ///
+  /// In en, this message translates to:
+  /// **'close Divine'**
+  String get dbFailureCloseApp;
+
+  /// Button that opens the confirmation step for the destructive local-database reset.
+  ///
+  /// In en, this message translates to:
+  /// **'reset local database'**
+  String get dbFailureResetAction;
+
+  /// Title of the confirmation step before the local database is reset.
+  ///
+  /// In en, this message translates to:
+  /// **'reset your local database?'**
+  String get dbFailureConfirmTitle;
+
+  /// Body of the confirmation step explaining what a local-database reset deletes and what survives.
+  ///
+  /// In en, this message translates to:
+  /// **'Your account stays. Drafts and clips saved on this device are deleted — messages and feeds come back from the network.'**
+  String get dbFailureConfirmBody;
+
+  /// Button that performs the local-database reset and then closes the app.
+  ///
+  /// In en, this message translates to:
+  /// **'reset and close'**
+  String get dbFailureResetConfirm;
+
+  /// Button that returns from the reset confirmation to the failure screen.
+  ///
+  /// In en, this message translates to:
+  /// **'cancel'**
+  String get dbFailureCancel;
+
+  /// Message shown when the local-database reset itself failed or timed out.
+  ///
+  /// In en, this message translates to:
+  /// **'That didn\'t work. Close Divine and try again.'**
+  String get dbFailureResetFailed;
+
+  /// Title of the terminal step after a successful local-database reset.
+  ///
+  /// In en, this message translates to:
+  /// **'local database reset'**
+  String get dbFailureResetDoneTitle;
+
+  /// Body of the terminal step after a successful reset, telling the user to relaunch.
+  ///
+  /// In en, this message translates to:
+  /// **'Close Divine and open it again — the next launch builds a fresh local database.'**
+  String get dbFailureResetDoneBody;
 }
 
 class _AppLocalizationsDelegate

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -11862,4 +11862,49 @@ class AppLocalizationsAm extends AppLocalizations {
 
   @override
   String get feedOfflineMessage => 'ከመስመር ውጭ ነዎት።\nግንኙነትዎን አረጋግጠው እንደገና ይሞክሩ።';
+
+  @override
+  String get dbFailureTitle => 'የአካባቢ ዳታቤዝዎን መክፈት አልተቻለም';
+
+  @override
+  String get dbFailureAdviceResettable =>
+      'እንደገና ማስጀመር ይህን አያስተካክለውም። ከታች ያለውን የአካባቢ ዳታቤዝ ዳግም ማስጀመር ለDivine ንጹህ ጅምር ይሰጣል — መለያዎ ይቀራል።';
+
+  @override
+  String get dbFailureAdviceRestart =>
+      'መሣሪያዎን ከከፈቱ በኋላ Divineን እንደገና ያስጀምሩ። ይህ የሚቀጥል ከሆነ መተግበሪያውን ያዘምኑ ወይም ድጋፍን ያግኙ።';
+
+  @override
+  String dbFailureDiagnostic(String code) {
+    return 'ምርመራ: $code';
+  }
+
+  @override
+  String get dbFailureCloseApp => 'Divineን ዝጋ';
+
+  @override
+  String get dbFailureResetAction => 'የአካባቢ ዳታቤዝ ዳግም አስጀምር';
+
+  @override
+  String get dbFailureConfirmTitle => 'የአካባቢ ዳታቤዝዎን ዳግም ያስጀምሩ?';
+
+  @override
+  String get dbFailureConfirmBody =>
+      'መለያዎ ይቀራል። በዚህ መሣሪያ ላይ የተቀመጡ ረቂቆች እና ክሊፖች ይሰረዛሉ — መልእክቶች እና ምግቦች ከአውታረ መረቡ ይመለሳሉ።';
+
+  @override
+  String get dbFailureResetConfirm => 'ዳግም አስጀምር እና ዝጋ';
+
+  @override
+  String get dbFailureCancel => 'ሰርዝ';
+
+  @override
+  String get dbFailureResetFailed => 'ያ አልሰራም። Divineን ዘግተው እንደገና ይሞክሩ።';
+
+  @override
+  String get dbFailureResetDoneTitle => 'የአካባቢ ዳታቤዝ ዳግም ተጀምሯል';
+
+  @override
+  String get dbFailureResetDoneBody =>
+      'Divineን ዝጋ እና እንደገና ክፈተው — ቀጣዩ ጅምር አዲስ የአካባቢ ዳታቤዝ ይገነባል።';
 }

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -12086,4 +12086,50 @@ class AppLocalizationsAr extends AppLocalizations {
   @override
   String get feedOfflineMessage =>
       'أنت غير متصل.\nتحقق من اتصالك وحاول مرة أخرى.';
+
+  @override
+  String get dbFailureTitle => 'تعذّر فتح قاعدة البيانات المحلية';
+
+  @override
+  String get dbFailureAdviceResettable =>
+      'إعادة التشغيل لن تحل هذه المشكلة. إعادة تعيين قاعدة البيانات المحلية أدناه تمنح Divine بداية نظيفة — يبقى حسابك كما هو.';
+
+  @override
+  String get dbFailureAdviceRestart =>
+      'أعد تشغيل Divine بعد فتح قفل جهازك. إذا استمر هذا، فحدّث التطبيق أو تواصل مع الدعم.';
+
+  @override
+  String dbFailureDiagnostic(String code) {
+    return 'التشخيص: $code';
+  }
+
+  @override
+  String get dbFailureCloseApp => 'إغلاق Divine';
+
+  @override
+  String get dbFailureResetAction => 'إعادة تعيين قاعدة البيانات المحلية';
+
+  @override
+  String get dbFailureConfirmTitle => 'إعادة تعيين قاعدة البيانات المحلية؟';
+
+  @override
+  String get dbFailureConfirmBody =>
+      'يبقى حسابك. تُحذف المسودات والمقاطع المحفوظة على هذا الجهاز — أما الرسائل والخلاصات فتعود من الشبكة.';
+
+  @override
+  String get dbFailureResetConfirm => 'إعادة التعيين والإغلاق';
+
+  @override
+  String get dbFailureCancel => 'إلغاء';
+
+  @override
+  String get dbFailureResetFailed => 'لم ينجح ذلك. أغلق Divine وحاول مرة أخرى.';
+
+  @override
+  String get dbFailureResetDoneTitle =>
+      'تمت إعادة تعيين قاعدة البيانات المحلية';
+
+  @override
+  String get dbFailureResetDoneBody =>
+      'أغلق Divine ثم افتحه مجددًا — سيبني التشغيل التالي قاعدة بيانات محلية جديدة.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -12299,4 +12299,50 @@ class AppLocalizationsBg extends AppLocalizations {
   @override
   String get feedOfflineMessage =>
       'Няма връзка с интернет.\nПровери връзката си и опитай пак.';
+
+  @override
+  String get dbFailureTitle => 'локалната база данни не може да се отключи';
+
+  @override
+  String get dbFailureAdviceResettable =>
+      'Рестартирането няма да помогне. Нулирането на локалната база данни по-долу дава на Divine чист старт — акаунтът ти остава.';
+
+  @override
+  String get dbFailureAdviceRestart =>
+      'Рестартирай Divine, след като отключиш устройството си. Ако това продължава, обнови приложението или се свържи с поддръжката.';
+
+  @override
+  String dbFailureDiagnostic(String code) {
+    return 'Диагностика: $code';
+  }
+
+  @override
+  String get dbFailureCloseApp => 'затвори Divine';
+
+  @override
+  String get dbFailureResetAction => 'нулирай локалната база данни';
+
+  @override
+  String get dbFailureConfirmTitle => 'да нулираме ли локалната база данни?';
+
+  @override
+  String get dbFailureConfirmBody =>
+      'Акаунтът ти остава. Черновите и клиповете, запазени на това устройство, се изтриват — съобщенията и емисиите се връщат от мрежата.';
+
+  @override
+  String get dbFailureResetConfirm => 'нулирай и затвори';
+
+  @override
+  String get dbFailureCancel => 'отказ';
+
+  @override
+  String get dbFailureResetFailed =>
+      'Това не сработи. Затвори Divine и опитай отново.';
+
+  @override
+  String get dbFailureResetDoneTitle => 'локалната база данни е нулирана';
+
+  @override
+  String get dbFailureResetDoneBody =>
+      'Затвори Divine и го отвори отново — следващото стартиране изгражда нова локална база данни.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -12332,4 +12332,50 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get feedOfflineMessage =>
       'Du bist offline.\nPrüfe deine Verbindung und versuch es nochmal.';
+
+  @override
+  String get dbFailureTitle => 'Lokale Datenbank konnte nicht entsperrt werden';
+
+  @override
+  String get dbFailureAdviceResettable =>
+      'Ein Neustart hilft hier nicht. Das Zurücksetzen der lokalen Datenbank unten gibt Divine einen sauberen Start — dein Konto bleibt bestehen.';
+
+  @override
+  String get dbFailureAdviceRestart =>
+      'Starte Divine neu, nachdem du dein Gerät entsperrt hast. Wenn das weiterhin passiert, aktualisiere die App oder wende dich an den Support.';
+
+  @override
+  String dbFailureDiagnostic(String code) {
+    return 'Diagnose: $code';
+  }
+
+  @override
+  String get dbFailureCloseApp => 'Divine schließen';
+
+  @override
+  String get dbFailureResetAction => 'Lokale Datenbank zurücksetzen';
+
+  @override
+  String get dbFailureConfirmTitle => 'Lokale Datenbank zurücksetzen?';
+
+  @override
+  String get dbFailureConfirmBody =>
+      'Dein Konto bleibt. Auf diesem Gerät gespeicherte Entwürfe und Clips werden gelöscht — Nachrichten und Feeds kommen aus dem Netzwerk zurück.';
+
+  @override
+  String get dbFailureResetConfirm => 'Zurücksetzen und schließen';
+
+  @override
+  String get dbFailureCancel => 'Abbrechen';
+
+  @override
+  String get dbFailureResetFailed =>
+      'Das hat nicht geklappt. Schließe Divine und versuche es erneut.';
+
+  @override
+  String get dbFailureResetDoneTitle => 'Lokale Datenbank zurückgesetzt';
+
+  @override
+  String get dbFailureResetDoneBody =>
+      'Schließe Divine und öffne es erneut — der nächste Start legt eine frische lokale Datenbank an.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -12128,4 +12128,50 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get feedOfflineMessage =>
       'You\'re offline.\nCheck your connection and try again.';
+
+  @override
+  String get dbFailureTitle => 'couldn\'t unlock your local database';
+
+  @override
+  String get dbFailureAdviceResettable =>
+      'A restart won\'t fix this one. Resetting the local database below gives Divine a clean start — your account stays.';
+
+  @override
+  String get dbFailureAdviceRestart =>
+      'Restart Divine after unlocking your device. If this keeps happening, update the app or contact support.';
+
+  @override
+  String dbFailureDiagnostic(String code) {
+    return 'Diagnostic: $code';
+  }
+
+  @override
+  String get dbFailureCloseApp => 'close Divine';
+
+  @override
+  String get dbFailureResetAction => 'reset local database';
+
+  @override
+  String get dbFailureConfirmTitle => 'reset your local database?';
+
+  @override
+  String get dbFailureConfirmBody =>
+      'Your account stays. Drafts and clips saved on this device are deleted — messages and feeds come back from the network.';
+
+  @override
+  String get dbFailureResetConfirm => 'reset and close';
+
+  @override
+  String get dbFailureCancel => 'cancel';
+
+  @override
+  String get dbFailureResetFailed =>
+      'That didn\'t work. Close Divine and try again.';
+
+  @override
+  String get dbFailureResetDoneTitle => 'local database reset';
+
+  @override
+  String get dbFailureResetDoneBody =>
+      'Close Divine and open it again — the next launch builds a fresh local database.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -12314,4 +12314,50 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get feedOfflineMessage =>
       'Estás sin conexión.\nRevisa tu conexión e inténtalo de nuevo.';
+
+  @override
+  String get dbFailureTitle => 'no se pudo desbloquear tu base de datos local';
+
+  @override
+  String get dbFailureAdviceResettable =>
+      'Reiniciar no va a arreglar esto. Restablecer la base de datos local de abajo le da a Divine un comienzo limpio — tu cuenta se mantiene.';
+
+  @override
+  String get dbFailureAdviceRestart =>
+      'Reiniciá Divine después de desbloquear tu dispositivo. Si esto sigue pasando, actualizá la app o contactá con soporte.';
+
+  @override
+  String dbFailureDiagnostic(String code) {
+    return 'Diagnóstico: $code';
+  }
+
+  @override
+  String get dbFailureCloseApp => 'cerrar Divine';
+
+  @override
+  String get dbFailureResetAction => 'restablecer base de datos local';
+
+  @override
+  String get dbFailureConfirmTitle => '¿restablecer tu base de datos local?';
+
+  @override
+  String get dbFailureConfirmBody =>
+      'Tu cuenta se mantiene. Los borradores y clips guardados en este dispositivo se eliminan — los mensajes y feeds vuelven desde la red.';
+
+  @override
+  String get dbFailureResetConfirm => 'restablecer y cerrar';
+
+  @override
+  String get dbFailureCancel => 'cancelar';
+
+  @override
+  String get dbFailureResetFailed =>
+      'Eso no funcionó. Cerrá Divine y probá de nuevo.';
+
+  @override
+  String get dbFailureResetDoneTitle => 'base de datos local restablecida';
+
+  @override
+  String get dbFailureResetDoneBody =>
+      'Cerrá Divine y volvé a abrirlo — el próximo inicio crea una base de datos local nueva.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -12330,4 +12330,50 @@ class AppLocalizationsFil extends AppLocalizations {
   @override
   String get feedOfflineMessage =>
       'Offline ka.\nTingnan ang koneksyon mo at subukan ulit.';
+
+  @override
+  String get dbFailureTitle => 'hindi ma-unlock ang iyong lokal na database';
+
+  @override
+  String get dbFailureAdviceResettable =>
+      'Hindi ito maaayos ng pag-restart. Ang pag-reset ng lokal na database sa ibaba ay nagbibigay sa Divine ng malinis na simula — mananatili ang iyong account.';
+
+  @override
+  String get dbFailureAdviceRestart =>
+      'I-restart ang Divine matapos i-unlock ang iyong device. Kung patuloy itong nangyayari, i-update ang app o makipag-ugnayan sa suporta.';
+
+  @override
+  String dbFailureDiagnostic(String code) {
+    return 'Diagnostic: $code';
+  }
+
+  @override
+  String get dbFailureCloseApp => 'isara ang Divine';
+
+  @override
+  String get dbFailureResetAction => 'i-reset ang lokal na database';
+
+  @override
+  String get dbFailureConfirmTitle => 'i-reset ang iyong lokal na database?';
+
+  @override
+  String get dbFailureConfirmBody =>
+      'Mananatili ang iyong account. Buburahin ang mga draft at clip na naka-save sa device na ito — babalik ang mga mensahe at feed mula sa network.';
+
+  @override
+  String get dbFailureResetConfirm => 'i-reset at isara';
+
+  @override
+  String get dbFailureCancel => 'kanselahin';
+
+  @override
+  String get dbFailureResetFailed =>
+      'Hindi ito gumana. Isara ang Divine at subukan ulit.';
+
+  @override
+  String get dbFailureResetDoneTitle => 'na-reset ang lokal na database';
+
+  @override
+  String get dbFailureResetDoneBody =>
+      'Isara ang Divine at buksan itong muli — gagawa ng bagong lokal na database sa susunod na paglulunsad.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -12361,4 +12361,52 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get feedOfflineMessage =>
       'Vous êtes hors ligne.\nVérifiez votre connexion et réessayez.';
+
+  @override
+  String get dbFailureTitle =>
+      'impossible de déverrouiller votre base de données locale';
+
+  @override
+  String get dbFailureAdviceResettable =>
+      'Un redémarrage ne réglera pas ça. Réinitialiser la base de données locale ci-dessous donne à Divine un nouveau départ — votre compte est conservé.';
+
+  @override
+  String get dbFailureAdviceRestart =>
+      'Redémarrez Divine après avoir déverrouillé votre appareil. Si cela persiste, mettez l\'application à jour ou contactez l\'assistance.';
+
+  @override
+  String dbFailureDiagnostic(String code) {
+    return 'Diagnostic : $code';
+  }
+
+  @override
+  String get dbFailureCloseApp => 'fermer Divine';
+
+  @override
+  String get dbFailureResetAction => 'réinitialiser la base de données locale';
+
+  @override
+  String get dbFailureConfirmTitle =>
+      'réinitialiser votre base de données locale ?';
+
+  @override
+  String get dbFailureConfirmBody =>
+      'Votre compte est conservé. Les brouillons et clips enregistrés sur cet appareil sont supprimés — les messages et fils reviennent du réseau.';
+
+  @override
+  String get dbFailureResetConfirm => 'réinitialiser et fermer';
+
+  @override
+  String get dbFailureCancel => 'annuler';
+
+  @override
+  String get dbFailureResetFailed =>
+      'Ça n\'a pas fonctionné. Fermez Divine et réessayez.';
+
+  @override
+  String get dbFailureResetDoneTitle => 'base de données locale réinitialisée';
+
+  @override
+  String get dbFailureResetDoneBody =>
+      'Fermez Divine et rouvrez-le — le prochain lancement crée une nouvelle base de données locale.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -12125,4 +12125,50 @@ class AppLocalizationsId extends AppLocalizations {
   @override
   String get feedOfflineMessage =>
       'Kamu sedang offline.\nPeriksa koneksimu lalu coba lagi.';
+
+  @override
+  String get dbFailureTitle => 'tidak dapat membuka basis data lokalmu';
+
+  @override
+  String get dbFailureAdviceResettable =>
+      'Memulai ulang tidak akan memperbaikinya. Mengatur ulang basis data lokal di bawah memberi Divine awal yang bersih — akunmu tetap ada.';
+
+  @override
+  String get dbFailureAdviceRestart =>
+      'Mulai ulang Divine setelah membuka kunci perangkatmu. Jika ini terus terjadi, perbarui aplikasi atau hubungi dukungan.';
+
+  @override
+  String dbFailureDiagnostic(String code) {
+    return 'Diagnostik: $code';
+  }
+
+  @override
+  String get dbFailureCloseApp => 'tutup Divine';
+
+  @override
+  String get dbFailureResetAction => 'atur ulang basis data lokal';
+
+  @override
+  String get dbFailureConfirmTitle => 'atur ulang basis data lokalmu?';
+
+  @override
+  String get dbFailureConfirmBody =>
+      'Akunmu tetap ada. Draf dan klip yang tersimpan di perangkat ini akan dihapus — pesan dan feed kembali dari jaringan.';
+
+  @override
+  String get dbFailureResetConfirm => 'atur ulang dan tutup';
+
+  @override
+  String get dbFailureCancel => 'batal';
+
+  @override
+  String get dbFailureResetFailed =>
+      'Itu tidak berhasil. Tutup Divine dan coba lagi.';
+
+  @override
+  String get dbFailureResetDoneTitle => 'basis data lokal telah diatur ulang';
+
+  @override
+  String get dbFailureResetDoneBody =>
+      'Tutup Divine lalu buka lagi — peluncuran berikutnya membangun basis data lokal yang baru.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -12325,4 +12325,50 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String get feedOfflineMessage =>
       'Sei offline.\nControlla la connessione e riprova.';
+
+  @override
+  String get dbFailureTitle => 'impossibile sbloccare il database locale';
+
+  @override
+  String get dbFailureAdviceResettable =>
+      'Riavviare non risolverà il problema. Reimpostare il database locale qui sotto dà a Divine un nuovo inizio — il tuo account resta.';
+
+  @override
+  String get dbFailureAdviceRestart =>
+      'Riavvia Divine dopo aver sbloccato il dispositivo. Se continua a succedere, aggiorna l\'app o contatta l\'assistenza.';
+
+  @override
+  String dbFailureDiagnostic(String code) {
+    return 'Diagnostica: $code';
+  }
+
+  @override
+  String get dbFailureCloseApp => 'chiudi Divine';
+
+  @override
+  String get dbFailureResetAction => 'reimposta database locale';
+
+  @override
+  String get dbFailureConfirmTitle => 'reimpostare il database locale?';
+
+  @override
+  String get dbFailureConfirmBody =>
+      'Il tuo account resta. Le bozze e le clip salvate su questo dispositivo vengono eliminate — messaggi e feed tornano dalla rete.';
+
+  @override
+  String get dbFailureResetConfirm => 'reimposta e chiudi';
+
+  @override
+  String get dbFailureCancel => 'annulla';
+
+  @override
+  String get dbFailureResetFailed =>
+      'Non ha funzionato. Chiudi Divine e riprova.';
+
+  @override
+  String get dbFailureResetDoneTitle => 'database locale reimpostato';
+
+  @override
+  String get dbFailureResetDoneBody =>
+      'Chiudi Divine e riaprilo — al prossimo avvio verrà creato un nuovo database locale.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -11600,4 +11600,49 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get feedOfflineMessage => 'オフラインだよ。\n接続を確認して、もう一度試してね。';
+
+  @override
+  String get dbFailureTitle => 'ローカルデータベースのロックを解除できませんでした';
+
+  @override
+  String get dbFailureAdviceResettable =>
+      '再起動では解決しません。下のローカルデータベースをリセットすると Divine をきれいな状態から始められます。アカウントはそのまま残ります。';
+
+  @override
+  String get dbFailureAdviceRestart =>
+      'デバイスのロックを解除してから Divine を再起動してください。これが続く場合は、アプリを更新するかサポートにご連絡ください。';
+
+  @override
+  String dbFailureDiagnostic(String code) {
+    return '診断: $code';
+  }
+
+  @override
+  String get dbFailureCloseApp => 'Divine を閉じる';
+
+  @override
+  String get dbFailureResetAction => 'ローカルデータベースをリセット';
+
+  @override
+  String get dbFailureConfirmTitle => 'ローカルデータベースをリセットしますか？';
+
+  @override
+  String get dbFailureConfirmBody =>
+      'アカウントはそのまま残ります。この端末に保存された下書きとクリップは削除されます。メッセージとフィードはネットワークから復元されます。';
+
+  @override
+  String get dbFailureResetConfirm => 'リセットして閉じる';
+
+  @override
+  String get dbFailureCancel => 'キャンセル';
+
+  @override
+  String get dbFailureResetFailed => 'うまくいきませんでした。Divine を閉じてもう一度お試しください。';
+
+  @override
+  String get dbFailureResetDoneTitle => 'ローカルデータベースをリセットしました';
+
+  @override
+  String get dbFailureResetDoneBody =>
+      'Divine を閉じてもう一度開いてください。次回の起動で新しいローカルデータベースが作成されます。';
 }

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -11625,4 +11625,49 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get feedOfflineMessage => '오프라인 상태예요.\n연결을 확인하고 다시 시도해 주세요.';
+
+  @override
+  String get dbFailureTitle => '로컬 데이터베이스를 열지 못했습니다';
+
+  @override
+  String get dbFailureAdviceResettable =>
+      '재시작으로는 해결되지 않습니다. 아래에서 로컬 데이터베이스를 초기화하면 Divine을 깨끗한 상태로 시작할 수 있습니다. 계정은 그대로 유지됩니다.';
+
+  @override
+  String get dbFailureAdviceRestart =>
+      '기기 잠금을 해제한 뒤 Divine을 다시 실행하세요. 계속 발생하면 앱을 업데이트하거나 고객지원에 문의하세요.';
+
+  @override
+  String dbFailureDiagnostic(String code) {
+    return '진단: $code';
+  }
+
+  @override
+  String get dbFailureCloseApp => 'Divine 닫기';
+
+  @override
+  String get dbFailureResetAction => '로컬 데이터베이스 초기화';
+
+  @override
+  String get dbFailureConfirmTitle => '로컬 데이터베이스를 초기화할까요?';
+
+  @override
+  String get dbFailureConfirmBody =>
+      '계정은 그대로 유지됩니다. 이 기기에 저장된 초안과 클립은 삭제됩니다. 메시지와 피드는 네트워크에서 다시 불러옵니다.';
+
+  @override
+  String get dbFailureResetConfirm => '초기화하고 닫기';
+
+  @override
+  String get dbFailureCancel => '취소';
+
+  @override
+  String get dbFailureResetFailed => '실패했습니다. Divine을 닫고 다시 시도하세요.';
+
+  @override
+  String get dbFailureResetDoneTitle => '로컬 데이터베이스가 초기화되었습니다';
+
+  @override
+  String get dbFailureResetDoneBody =>
+      'Divine을 닫았다가 다시 여세요. 다음 실행에서 새 로컬 데이터베이스가 만들어집니다.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -12222,4 +12222,53 @@ class AppLocalizationsMs extends AppLocalizations {
   @override
   String get feedOfflineMessage =>
       'Anda di luar talian.\nSemak sambungan anda dan cuba lagi.';
+
+  @override
+  String get dbFailureTitle =>
+      'tidak dapat membuka kunci pangkalan data setempat anda';
+
+  @override
+  String get dbFailureAdviceResettable =>
+      'Memulakan semula tidak akan membaikinya. Menetapkan semula pangkalan data setempat di bawah memberi Divine permulaan yang bersih — akaun anda kekal.';
+
+  @override
+  String get dbFailureAdviceRestart =>
+      'Mulakan semula Divine selepas membuka kunci peranti anda. Jika ini berterusan, kemas kini apl atau hubungi sokongan.';
+
+  @override
+  String dbFailureDiagnostic(String code) {
+    return 'Diagnostik: $code';
+  }
+
+  @override
+  String get dbFailureCloseApp => 'tutup Divine';
+
+  @override
+  String get dbFailureResetAction => 'tetapkan semula pangkalan data setempat';
+
+  @override
+  String get dbFailureConfirmTitle =>
+      'tetapkan semula pangkalan data setempat anda?';
+
+  @override
+  String get dbFailureConfirmBody =>
+      'Akaun anda kekal. Draf dan klip yang disimpan pada peranti ini akan dipadamkan — mesej dan suapan kembali daripada rangkaian.';
+
+  @override
+  String get dbFailureResetConfirm => 'tetapkan semula dan tutup';
+
+  @override
+  String get dbFailureCancel => 'batal';
+
+  @override
+  String get dbFailureResetFailed =>
+      'Itu tidak berjaya. Tutup Divine dan cuba lagi.';
+
+  @override
+  String get dbFailureResetDoneTitle =>
+      'pangkalan data setempat ditetapkan semula';
+
+  @override
+  String get dbFailureResetDoneBody =>
+      'Tutup Divine dan buka semula — pelancaran seterusnya membina pangkalan data setempat yang baharu.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -12241,4 +12241,50 @@ class AppLocalizationsNl extends AppLocalizations {
   @override
   String get feedOfflineMessage =>
       'Je bent offline.\nControleer je verbinding en probeer het opnieuw.';
+
+  @override
+  String get dbFailureTitle => 'kan je lokale database niet ontgrendelen';
+
+  @override
+  String get dbFailureAdviceResettable =>
+      'Opnieuw opstarten lost dit niet op. De lokale database hieronder resetten geeft Divine een schone start — je account blijft behouden.';
+
+  @override
+  String get dbFailureAdviceRestart =>
+      'Start Divine opnieuw nadat je je apparaat hebt ontgrendeld. Blijft dit gebeuren, werk de app dan bij of neem contact op met support.';
+
+  @override
+  String dbFailureDiagnostic(String code) {
+    return 'Diagnose: $code';
+  }
+
+  @override
+  String get dbFailureCloseApp => 'Divine sluiten';
+
+  @override
+  String get dbFailureResetAction => 'lokale database resetten';
+
+  @override
+  String get dbFailureConfirmTitle => 'je lokale database resetten?';
+
+  @override
+  String get dbFailureConfirmBody =>
+      'Je account blijft behouden. Concepten en clips die op dit apparaat zijn opgeslagen worden verwijderd — berichten en feeds komen terug van het netwerk.';
+
+  @override
+  String get dbFailureResetConfirm => 'resetten en sluiten';
+
+  @override
+  String get dbFailureCancel => 'annuleren';
+
+  @override
+  String get dbFailureResetFailed =>
+      'Dat werkte niet. Sluit Divine en probeer het opnieuw.';
+
+  @override
+  String get dbFailureResetDoneTitle => 'lokale database gereset';
+
+  @override
+  String get dbFailureResetDoneBody =>
+      'Sluit Divine en open het opnieuw — bij de volgende start wordt een nieuwe lokale database aangemaakt.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -12420,4 +12420,50 @@ class AppLocalizationsPl extends AppLocalizations {
   @override
   String get feedOfflineMessage =>
       'Jesteś offline.\nSprawdź połączenie i spróbuj ponownie.';
+
+  @override
+  String get dbFailureTitle => 'nie można odblokować lokalnej bazy danych';
+
+  @override
+  String get dbFailureAdviceResettable =>
+      'Ponowne uruchomienie tego nie naprawi. Zresetowanie lokalnej bazy danych poniżej da Divine czysty start — Twoje konto zostaje.';
+
+  @override
+  String get dbFailureAdviceRestart =>
+      'Uruchom Divine ponownie po odblokowaniu urządzenia. Jeśli to się powtarza, zaktualizuj aplikację lub skontaktuj się z pomocą techniczną.';
+
+  @override
+  String dbFailureDiagnostic(String code) {
+    return 'Diagnostyka: $code';
+  }
+
+  @override
+  String get dbFailureCloseApp => 'zamknij Divine';
+
+  @override
+  String get dbFailureResetAction => 'zresetuj lokalną bazę danych';
+
+  @override
+  String get dbFailureConfirmTitle => 'zresetować lokalną bazę danych?';
+
+  @override
+  String get dbFailureConfirmBody =>
+      'Twoje konto zostaje. Wersje robocze i klipy zapisane na tym urządzeniu zostaną usunięte — wiadomości i kanały wrócą z sieci.';
+
+  @override
+  String get dbFailureResetConfirm => 'zresetuj i zamknij';
+
+  @override
+  String get dbFailureCancel => 'anuluj';
+
+  @override
+  String get dbFailureResetFailed =>
+      'To nie zadziałało. Zamknij Divine i spróbuj ponownie.';
+
+  @override
+  String get dbFailureResetDoneTitle => 'lokalna baza danych zresetowana';
+
+  @override
+  String get dbFailureResetDoneBody =>
+      'Zamknij Divine i otwórz go ponownie — następne uruchomienie utworzy nową lokalną bazę danych.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -12273,4 +12273,51 @@ class AppLocalizationsPt extends AppLocalizations {
   @override
   String get feedOfflineMessage =>
       'Você está offline.\nVerifique sua conexão e tente de novo.';
+
+  @override
+  String get dbFailureTitle =>
+      'não foi possível desbloquear seu banco de dados local';
+
+  @override
+  String get dbFailureAdviceResettable =>
+      'Reiniciar não vai resolver. Redefinir o banco de dados local abaixo dá ao Divine um começo limpo — sua conta permanece.';
+
+  @override
+  String get dbFailureAdviceRestart =>
+      'Reinicie o Divine depois de desbloquear seu dispositivo. Se continuar acontecendo, atualize o app ou fale com o suporte.';
+
+  @override
+  String dbFailureDiagnostic(String code) {
+    return 'Diagnóstico: $code';
+  }
+
+  @override
+  String get dbFailureCloseApp => 'fechar o Divine';
+
+  @override
+  String get dbFailureResetAction => 'redefinir banco de dados local';
+
+  @override
+  String get dbFailureConfirmTitle => 'redefinir seu banco de dados local?';
+
+  @override
+  String get dbFailureConfirmBody =>
+      'Sua conta permanece. Rascunhos e clipes salvos neste dispositivo são excluídos — mensagens e feeds voltam da rede.';
+
+  @override
+  String get dbFailureResetConfirm => 'redefinir e fechar';
+
+  @override
+  String get dbFailureCancel => 'cancelar';
+
+  @override
+  String get dbFailureResetFailed =>
+      'Isso não funcionou. Feche o Divine e tente de novo.';
+
+  @override
+  String get dbFailureResetDoneTitle => 'banco de dados local redefinido';
+
+  @override
+  String get dbFailureResetDoneBody =>
+      'Feche o Divine e abra de novo — a próxima inicialização cria um banco de dados local novo.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -12429,4 +12429,50 @@ class AppLocalizationsRo extends AppLocalizations {
   @override
   String get feedOfflineMessage =>
       'Ești offline.\nVerifică-ți conexiunea și încearcă din nou.';
+
+  @override
+  String get dbFailureTitle => 'nu am putut debloca baza de date locală';
+
+  @override
+  String get dbFailureAdviceResettable =>
+      'O repornire nu rezolvă asta. Resetarea bazei de date locale de mai jos îi oferă lui Divine un start curat — contul tău rămâne.';
+
+  @override
+  String get dbFailureAdviceRestart =>
+      'Repornește Divine după ce îți deblochezi dispozitivul. Dacă se repetă, actualizează aplicația sau contactează asistența.';
+
+  @override
+  String dbFailureDiagnostic(String code) {
+    return 'Diagnostic: $code';
+  }
+
+  @override
+  String get dbFailureCloseApp => 'închide Divine';
+
+  @override
+  String get dbFailureResetAction => 'resetează baza de date locală';
+
+  @override
+  String get dbFailureConfirmTitle => 'resetezi baza de date locală?';
+
+  @override
+  String get dbFailureConfirmBody =>
+      'Contul tău rămâne. Ciornele și clipurile salvate pe acest dispozitiv sunt șterse — mesajele și fluxurile revin din rețea.';
+
+  @override
+  String get dbFailureResetConfirm => 'resetează și închide';
+
+  @override
+  String get dbFailureCancel => 'anulează';
+
+  @override
+  String get dbFailureResetFailed =>
+      'Nu a funcționat. Închide Divine și încearcă din nou.';
+
+  @override
+  String get dbFailureResetDoneTitle => 'baza de date locală a fost resetată';
+
+  @override
+  String get dbFailureResetDoneBody =>
+      'Închide Divine și deschide-l din nou — următoarea pornire creează o bază de date locală nouă.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -12180,4 +12180,50 @@ class AppLocalizationsSv extends AppLocalizations {
   @override
   String get feedOfflineMessage =>
       'Du är offline.\nKolla din anslutning och försök igen.';
+
+  @override
+  String get dbFailureTitle => 'kunde inte låsa upp din lokala databas';
+
+  @override
+  String get dbFailureAdviceResettable =>
+      'En omstart löser inte det här. Att återställa den lokala databasen nedan ger Divine en ren start — ditt konto finns kvar.';
+
+  @override
+  String get dbFailureAdviceRestart =>
+      'Starta om Divine när du har låst upp din enhet. Om det fortsätter, uppdatera appen eller kontakta supporten.';
+
+  @override
+  String dbFailureDiagnostic(String code) {
+    return 'Diagnostik: $code';
+  }
+
+  @override
+  String get dbFailureCloseApp => 'stäng Divine';
+
+  @override
+  String get dbFailureResetAction => 'återställ lokal databas';
+
+  @override
+  String get dbFailureConfirmTitle => 'återställa din lokala databas?';
+
+  @override
+  String get dbFailureConfirmBody =>
+      'Ditt konto finns kvar. Utkast och klipp som sparats på den här enheten raderas — meddelanden och flöden hämtas tillbaka från nätverket.';
+
+  @override
+  String get dbFailureResetConfirm => 'återställ och stäng';
+
+  @override
+  String get dbFailureCancel => 'avbryt';
+
+  @override
+  String get dbFailureResetFailed =>
+      'Det fungerade inte. Stäng Divine och försök igen.';
+
+  @override
+  String get dbFailureResetDoneTitle => 'lokal databas återställd';
+
+  @override
+  String get dbFailureResetDoneBody =>
+      'Stäng Divine och öppna det igen — nästa start skapar en ny lokal databas.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -12139,4 +12139,50 @@ class AppLocalizationsTr extends AppLocalizations {
   @override
   String get feedOfflineMessage =>
       'Çevrimdışısın.\nBağlantını kontrol edip tekrar dene.';
+
+  @override
+  String get dbFailureTitle => 'yerel veritabanınız açılamadı';
+
+  @override
+  String get dbFailureAdviceResettable =>
+      'Yeniden başlatmak bunu düzeltmez. Aşağıdaki yerel veritabanını sıfırlamak Divine’a temiz bir başlangıç verir — hesabınız kalır.';
+
+  @override
+  String get dbFailureAdviceRestart =>
+      'Cihazınızın kilidini açtıktan sonra Divine’ı yeniden başlatın. Bu sürerse uygulamayı güncelleyin veya destekle iletişime geçin.';
+
+  @override
+  String dbFailureDiagnostic(String code) {
+    return 'Tanılama: $code';
+  }
+
+  @override
+  String get dbFailureCloseApp => 'Divine’ı kapat';
+
+  @override
+  String get dbFailureResetAction => 'yerel veritabanını sıfırla';
+
+  @override
+  String get dbFailureConfirmTitle => 'yerel veritabanınız sıfırlansın mı?';
+
+  @override
+  String get dbFailureConfirmBody =>
+      'Hesabınız kalır. Bu cihazda kayıtlı taslaklar ve klipler silinir — mesajlar ve akışlar ağdan geri gelir.';
+
+  @override
+  String get dbFailureResetConfirm => 'sıfırla ve kapat';
+
+  @override
+  String get dbFailureCancel => 'iptal';
+
+  @override
+  String get dbFailureResetFailed =>
+      'Bu işe yaramadı. Divine’ı kapatıp tekrar deneyin.';
+
+  @override
+  String get dbFailureResetDoneTitle => 'yerel veritabanı sıfırlandı';
+
+  @override
+  String get dbFailureResetDoneBody =>
+      'Divine’ı kapatıp yeniden açın — sonraki başlatmada yeni bir yerel veritabanı oluşturulur.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -12168,4 +12168,50 @@ class AppLocalizationsUr extends AppLocalizations {
   @override
   String get feedOfflineMessage =>
       'آپ آف لائن ہیں۔\nاپنا کنکشن چیک کریں اور دوبارہ کوشش کریں۔';
+
+  @override
+  String get dbFailureTitle => 'آپ کا مقامی ڈیٹابیس کھولا نہیں جا سکا';
+
+  @override
+  String get dbFailureAdviceResettable =>
+      'دوبارہ شروع کرنے سے یہ ٹھیک نہیں ہوگا۔ نیچے مقامی ڈیٹابیس ری سیٹ کرنے سے Divine کو صاف آغاز ملتا ہے — آپ کا اکاؤنٹ برقرار رہتا ہے۔';
+
+  @override
+  String get dbFailureAdviceRestart =>
+      'اپنا ڈیوائس اَن لاک کرنے کے بعد Divine دوبارہ شروع کریں۔ اگر یہ ہوتا رہے تو ایپ اپ ڈیٹ کریں یا سپورٹ سے رابطہ کریں۔';
+
+  @override
+  String dbFailureDiagnostic(String code) {
+    return 'تشخیص: $code';
+  }
+
+  @override
+  String get dbFailureCloseApp => 'Divine بند کریں';
+
+  @override
+  String get dbFailureResetAction => 'مقامی ڈیٹابیس ری سیٹ کریں';
+
+  @override
+  String get dbFailureConfirmTitle => 'اپنا مقامی ڈیٹابیس ری سیٹ کریں؟';
+
+  @override
+  String get dbFailureConfirmBody =>
+      'آپ کا اکاؤنٹ برقرار رہتا ہے۔ اس ڈیوائس پر محفوظ ڈرافٹس اور کلپس حذف ہو جائیں گے — پیغامات اور فیڈز نیٹ ورک سے واپس آ جاتے ہیں۔';
+
+  @override
+  String get dbFailureResetConfirm => 'ری سیٹ کریں اور بند کریں';
+
+  @override
+  String get dbFailureCancel => 'منسوخ کریں';
+
+  @override
+  String get dbFailureResetFailed =>
+      'یہ کام نہیں کیا۔ Divine بند کریں اور دوبارہ کوشش کریں۔';
+
+  @override
+  String get dbFailureResetDoneTitle => 'مقامی ڈیٹابیس ری سیٹ ہو گیا';
+
+  @override
+  String get dbFailureResetDoneBody =>
+      'Divine بند کریں اور دوبارہ کھولیں — اگلی بار شروع ہونے پر نیا مقامی ڈیٹابیس بنے گا۔';
 }

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -12163,4 +12163,50 @@ class AppLocalizationsVi extends AppLocalizations {
   @override
   String get feedOfflineMessage =>
       'Bạn đang ngoại tuyến.\nKiểm tra kết nối rồi thử lại.';
+
+  @override
+  String get dbFailureTitle => 'không thể mở khóa cơ sở dữ liệu cục bộ của bạn';
+
+  @override
+  String get dbFailureAdviceResettable =>
+      'Khởi động lại sẽ không khắc phục được. Đặt lại cơ sở dữ liệu cục bộ bên dưới giúp Divine bắt đầu lại từ đầu — tài khoản của bạn vẫn còn.';
+
+  @override
+  String get dbFailureAdviceRestart =>
+      'Khởi động lại Divine sau khi mở khóa thiết bị. Nếu vẫn tiếp diễn, hãy cập nhật ứng dụng hoặc liên hệ bộ phận hỗ trợ.';
+
+  @override
+  String dbFailureDiagnostic(String code) {
+    return 'Chẩn đoán: $code';
+  }
+
+  @override
+  String get dbFailureCloseApp => 'đóng Divine';
+
+  @override
+  String get dbFailureResetAction => 'đặt lại cơ sở dữ liệu cục bộ';
+
+  @override
+  String get dbFailureConfirmTitle => 'đặt lại cơ sở dữ liệu cục bộ của bạn?';
+
+  @override
+  String get dbFailureConfirmBody =>
+      'Tài khoản của bạn vẫn còn. Bản nháp và clip đã lưu trên thiết bị này sẽ bị xóa — tin nhắn và bảng tin sẽ được tải lại từ mạng.';
+
+  @override
+  String get dbFailureResetConfirm => 'đặt lại và đóng';
+
+  @override
+  String get dbFailureCancel => 'hủy';
+
+  @override
+  String get dbFailureResetFailed =>
+      'Không thành công. Hãy đóng Divine và thử lại.';
+
+  @override
+  String get dbFailureResetDoneTitle => 'đã đặt lại cơ sở dữ liệu cục bộ';
+
+  @override
+  String get dbFailureResetDoneBody =>
+      'Đóng Divine rồi mở lại — lần khởi chạy tiếp theo sẽ tạo cơ sở dữ liệu cục bộ mới.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -11496,4 +11496,47 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get feedOfflineMessage => '你当前处于离线状态。\n请检查网络后重试。';
+
+  @override
+  String get dbFailureTitle => '无法解锁你的本地数据库';
+
+  @override
+  String get dbFailureAdviceResettable =>
+      '重启无法解决这个问题。重置下方的本地数据库可以让 Divine 全新开始 — 你的账号会保留。';
+
+  @override
+  String get dbFailureAdviceRestart => '解锁设备后重新启动 Divine。如果问题持续出现，请更新应用或联系支持。';
+
+  @override
+  String dbFailureDiagnostic(String code) {
+    return '诊断：$code';
+  }
+
+  @override
+  String get dbFailureCloseApp => '关闭 Divine';
+
+  @override
+  String get dbFailureResetAction => '重置本地数据库';
+
+  @override
+  String get dbFailureConfirmTitle => '重置你的本地数据库？';
+
+  @override
+  String get dbFailureConfirmBody =>
+      '你的账号会保留。保存在此设备上的草稿和片段将被删除 — 消息和信息流会从网络重新获取。';
+
+  @override
+  String get dbFailureResetConfirm => '重置并关闭';
+
+  @override
+  String get dbFailureCancel => '取消';
+
+  @override
+  String get dbFailureResetFailed => '没有成功。请关闭 Divine 后重试。';
+
+  @override
+  String get dbFailureResetDoneTitle => '本地数据库已重置';
+
+  @override
+  String get dbFailureResetDoneBody => '关闭 Divine 后重新打开 — 下次启动会建立全新的本地数据库。';
 }

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -1286,7 +1286,15 @@ Future<void> _startOpenVineApp() async {
         onDatabaseReset: () => DmSyncState(sharedPreferences).clearAll(),
       );
 
+  // The fail-closed screen below renders before the app's own MaterialApp
+  // exists, so it cannot inherit a locale — pass the user's language override
+  // through. Null falls back to the device locales, same as the running app.
+  final savedUiLocale = LocalePreferenceService(
+    sharedPreferences: sharedPreferences,
+  ).getLocale();
+
   final dbCipherKeyResult = await resolveDatabaseBootstrapForAppStart(
+    locale: savedUiLocale == null ? null : Locale(savedUiLocale),
     resolveCipherKey: () => resolveStartupDatabaseCipherKey(
       // resetOnError MUST stay false here: the cipher key is the one secret
       // whose loss makes the encrypted DB unrecoverable. A transient keystore

--- a/mobile/lib/startup/database_bootstrap_failure_app.dart
+++ b/mobile/lib/startup/database_bootstrap_failure_app.dart
@@ -3,6 +3,8 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/semantics.dart' show SemanticsService;
 import 'package:flutter/services.dart';
+import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/l10n/resolve_app_ui_locale.dart';
 import 'package:openvine/services/database_encryption_bootstrap.dart';
 
 /// Result of resolving the DB cipher key during app startup.
@@ -28,6 +30,7 @@ Future<DatabaseBootstrapStartupResult> resolveDatabaseBootstrapForAppStart({
   required Future<String?> Function() resolveCipherKey,
   required void Function(Widget app) runApp,
   required VoidCallback removeNativeSplash,
+  Locale? locale,
   Future<void> Function(Object error, StackTrace stack)?
   repairLocalDatabaseCache,
   bool Function(Object error)? shouldRepairLocalDatabaseCache,
@@ -52,6 +55,7 @@ Future<DatabaseBootstrapStartupResult> resolveDatabaseBootstrapForAppStart({
       DatabaseBootstrapFailureApp(
         error: error,
         stack: stack,
+        locale: locale,
         onResetLocalDatabase: resetLocalDatabase,
       ),
     );
@@ -84,13 +88,6 @@ const _diagnosticStyle = TextStyle(
   decoration: TextDecoration.none,
 );
 
-/// Titles are reused as screen-reader announcements when a step replaces the
-/// one before it, so they live next to each other rather than inline.
-const _failureTitle = "couldn't unlock your local database";
-const _confirmTitle = 'reset your local database?';
-const _resetDoneTitle = 'local database reset';
-const _resetFailedMessage = "That didn't work. Close Divine and try again.";
-
 /// Ceiling on the manual reset. It renames a few files and clears
 /// SharedPreferences, so anything approaching this means a platform channel is
 /// wedged — better to report a failure the user can act on than to leave the
@@ -104,6 +101,7 @@ class DatabaseBootstrapFailureApp extends StatelessWidget {
   const DatabaseBootstrapFailureApp({
     required this.error,
     required this.stack,
+    this.locale,
     this.onCloseApp = SystemNavigator.pop,
     this.onResetLocalDatabase,
     super.key,
@@ -111,6 +109,15 @@ class DatabaseBootstrapFailureApp extends StatelessWidget {
 
   final Object error;
   final StackTrace stack;
+
+  /// The user's in-app language override, when they set one.
+  ///
+  /// `null` falls through to [resolveAppUiLocale] on the device locales, which
+  /// is also what the running app does. Passed in rather than read here so
+  /// this screen keeps no dependency on SharedPreferences — it has to render
+  /// even when startup did not get far enough to have one.
+  final Locale? locale;
+
   final VoidCallback onCloseApp;
 
   /// Clears the local database so the next launch rebuilds it.
@@ -130,6 +137,14 @@ class DatabaseBootstrapFailureApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       debugShowCheckedModeBanner: false,
+      // This screen replaces the whole app before startup finishes, so it
+      // needs its own delegates — nothing above it has registered any. It
+      // shipped entirely in English to all 21 other locales without them.
+      // AppLocalizations does not touch the database, so it is safe here.
+      locale: locale,
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      localeListResolutionCallback: resolveAppUiLocale,
       home: _FailureScreen(
         error: error,
         stack: stack,
@@ -198,7 +213,7 @@ class _FailureScreenState extends State<_FailureScreen> {
         _resetting = false;
         _resetFailed = true;
       });
-      _announce(_resetFailedMessage);
+      _announce(context.l10n.dbFailureResetFailed);
       return;
     }
     if (mounted) {
@@ -206,7 +221,7 @@ class _FailureScreenState extends State<_FailureScreen> {
         _step = _Step.done;
         _resetting = false;
       });
-      _announce(_resetDoneTitle);
+      _announce(context.l10n.dbFailureResetDoneTitle);
     }
     // Finishes the activity on Android. On iOS the process stays alive, which
     // is what the done step renders for.
@@ -235,14 +250,18 @@ class _FailureScreenState extends State<_FailureScreen> {
                   stack: widget.stack,
                   onCloseApp: widget.onCloseApp,
                   onResetRequested: _canReset
-                      ? () => _goTo(_Step.confirm, _confirmTitle)
+                      ? () => _goTo(
+                          _Step.confirm,
+                          context.l10n.dbFailureConfirmTitle,
+                        )
                       : null,
                 ),
                 _Step.confirm => _ResetConfirmView(
                   isResetting: _resetting,
                   didFail: _resetFailed,
                   onConfirm: _resetLocalDatabase,
-                  onCancel: () => _goTo(_Step.failure, _failureTitle),
+                  onCancel: () =>
+                      _goTo(_Step.failure, context.l10n.dbFailureTitle),
                 ),
                 _Step.done => _ResetDoneView(onCloseApp: widget.onCloseApp),
               },
@@ -270,14 +289,13 @@ class _FailureView extends StatelessWidget {
   /// The advice and the reset offer answer the same question, so one condition
   /// decides both: unlocking and restarting is the fix for the transient
   /// keystore case, and misleading for the diagnoses a reset is offered for.
-  String get _advice => onResetRequested != null
-      ? "A restart won't fix this one. Resetting the local database below "
-            'gives Divine a clean start — your account stays.'
-      : 'Restart Divine after unlocking your device. If this '
-            'keeps happening, update the app or contact support.';
+  String _advice(AppLocalizations l10n) => onResetRequested != null
+      ? l10n.dbFailureAdviceResettable
+      : l10n.dbFailureAdviceRestart;
 
   @override
   Widget build(BuildContext context) {
+    final l10n = context.l10n;
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: [
@@ -287,29 +305,29 @@ class _FailureView extends StatelessWidget {
           size: 48,
         ),
         const SizedBox(height: 20),
-        const Text(
-          _failureTitle,
+        Text(
+          l10n.dbFailureTitle,
           textAlign: TextAlign.center,
           style: _titleStyle,
         ),
         const SizedBox(height: 12),
-        Text(_advice, textAlign: TextAlign.center, style: _bodyStyle),
+        Text(_advice(l10n), textAlign: TextAlign.center, style: _bodyStyle),
         const SizedBox(height: 12),
         Text(
-          'Diagnostic: ${databaseBootstrapDiagnosticCode(error)}',
+          l10n.dbFailureDiagnostic(databaseBootstrapDiagnosticCode(error)),
           textAlign: TextAlign.center,
           style: _diagnosticStyle,
         ),
         const SizedBox(height: 24),
         DivineButton(
-          label: 'close Divine',
+          label: l10n.dbFailureCloseApp,
           onPressed: onCloseApp,
           type: DivineButtonType.secondary,
         ),
         if (onResetRequested != null) ...[
           const SizedBox(height: 12),
           DivineButton(
-            label: 'reset local database',
+            label: l10n.dbFailureResetAction,
             onPressed: onResetRequested,
             type: DivineButtonType.link,
           ),
@@ -338,6 +356,7 @@ class _ResetConfirmView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = context.l10n;
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: [
@@ -347,36 +366,35 @@ class _ResetConfirmView extends StatelessWidget {
           size: 48,
         ),
         const SizedBox(height: 20),
-        const Text(
-          _confirmTitle,
+        Text(
+          l10n.dbFailureConfirmTitle,
           textAlign: TextAlign.center,
           style: _titleStyle,
         ),
         const SizedBox(height: 12),
-        const Text(
-          'Your account stays. Drafts and clips saved on this device are '
-          'deleted — messages and feeds come back from the network.',
+        Text(
+          l10n.dbFailureConfirmBody,
           textAlign: TextAlign.center,
           style: _bodyStyle,
         ),
         if (didFail) ...[
           const SizedBox(height: 12),
           Text(
-            _resetFailedMessage,
+            l10n.dbFailureResetFailed,
             textAlign: TextAlign.center,
             style: _diagnosticStyle.copyWith(color: VineTheme.error),
           ),
         ],
         const SizedBox(height: 24),
         DivineButton(
-          label: 'reset and close',
+          label: l10n.dbFailureResetConfirm,
           onPressed: isResetting ? null : onConfirm,
           isLoading: isResetting,
           type: DivineButtonType.error,
         ),
         const SizedBox(height: 12),
         DivineButton(
-          label: 'cancel',
+          label: l10n.dbFailureCancel,
           onPressed: isResetting ? null : onCancel,
           type: DivineButtonType.secondary,
         ),
@@ -398,6 +416,7 @@ class _ResetDoneView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = context.l10n;
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: [
@@ -407,21 +426,20 @@ class _ResetDoneView extends StatelessWidget {
           size: 48,
         ),
         const SizedBox(height: 20),
-        const Text(
-          _resetDoneTitle,
+        Text(
+          l10n.dbFailureResetDoneTitle,
           textAlign: TextAlign.center,
           style: _titleStyle,
         ),
         const SizedBox(height: 12),
-        const Text(
-          'Close Divine and open it again — the next launch builds a fresh '
-          'local database.',
+        Text(
+          l10n.dbFailureResetDoneBody,
           textAlign: TextAlign.center,
           style: _bodyStyle,
         ),
         const SizedBox(height: 24),
         DivineButton(
-          label: 'close Divine',
+          label: l10n.dbFailureCloseApp,
           onPressed: onCloseApp,
           type: DivineButtonType.secondary,
         ),

--- a/mobile/test/startup/database_bootstrap_failure_app_test.dart
+++ b/mobile/test/startup/database_bootstrap_failure_app_test.dart
@@ -3,11 +3,17 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/services/database_encryption_bootstrap.dart';
 import 'package:openvine/startup/database_bootstrap_failure_app.dart';
 import 'package:sqlite3/sqlite3.dart';
 
 void main() {
+  // Resolved from the ARB rather than hardcoded, so the assertions
+  // survive copy changes and break loudly if the screen stops reading
+  // from l10n (it shipped fully hardcoded until this change).
+  final l10n = lookupAppLocalizations(const Locale('en'));
+
   group('resolveDatabaseBootstrapForAppStart', () {
     test('returns the cipher key without rendering failure UI', () async {
       var removedSplash = false;
@@ -277,15 +283,18 @@ void main() {
       );
 
       expect(
-        find.text("couldn't unlock your local database"),
+        find.text(l10n.dbFailureTitle),
         findsOneWidget,
       );
-      expect(find.textContaining('Restart Divine'), findsOneWidget);
+      expect(find.text(l10n.dbFailureAdviceRestart), findsOneWidget);
       // The rendered code is what a support report is triaged from, so pin the
       // value rather than just the label.
-      expect(find.text('Diagnostic: db-secure-storage'), findsOneWidget);
+      expect(
+        find.text(l10n.dbFailureDiagnostic('db-secure-storage')),
+        findsOneWidget,
+      );
 
-      await tester.tap(find.text('close Divine'));
+      await tester.tap(find.text(l10n.dbFailureCloseApp));
       expect(closed, isTrue);
     });
 
@@ -343,7 +352,7 @@ void main() {
         ),
       );
 
-      expect(find.text('reset local database'), findsNothing);
+      expect(find.text(l10n.dbFailureResetAction), findsNothing);
     });
 
     testWidgets('offers no reset for a locked keystore', (tester) async {
@@ -359,8 +368,11 @@ void main() {
         ),
       );
 
-      expect(find.text('Diagnostic: db-secure-storage'), findsOneWidget);
-      expect(find.text('reset local database'), findsNothing);
+      expect(
+        find.text(l10n.dbFailureDiagnostic('db-secure-storage')),
+        findsOneWidget,
+      );
+      expect(find.text(l10n.dbFailureResetAction), findsNothing);
     });
 
     testWidgets('drops the unlock-and-restart advice when a reset is offered', (
@@ -377,11 +389,11 @@ void main() {
       );
 
       expect(
-        find.textContaining('Restart Divine after unlocking'),
+        find.text(l10n.dbFailureAdviceRestart),
         findsNothing,
       );
       expect(
-        find.textContaining("A restart won't fix this one"),
+        find.text(l10n.dbFailureAdviceResettable),
         findsOneWidget,
       );
     });
@@ -399,14 +411,14 @@ void main() {
         ),
       );
 
-      await tester.tap(find.text('reset local database'));
+      await tester.tap(find.text(l10n.dbFailureResetAction));
       await tester.pump();
 
-      expect(find.text('reset your local database?'), findsOneWidget);
-      expect(find.textContaining('Your account stays'), findsOneWidget);
+      expect(find.text(l10n.dbFailureConfirmTitle), findsOneWidget);
+      expect(find.text(l10n.dbFailureConfirmBody), findsOneWidget);
       expect(resetDiagnosis, isNull, reason: 'confirmation must gate the wipe');
 
-      await tester.tap(find.text('reset and close'));
+      await tester.tap(find.text(l10n.dbFailureResetConfirm));
       await tester.pump();
 
       expect(resetDiagnosis, DatabaseBootstrapDiagnosis.bootstrapFailed);
@@ -426,9 +438,9 @@ void main() {
         ),
       );
 
-      await tester.tap(find.text('reset local database'));
+      await tester.tap(find.text(l10n.dbFailureResetAction));
       await tester.pump();
-      await tester.tap(find.text('reset and close'));
+      await tester.tap(find.text(l10n.dbFailureResetConfirm));
       await tester.pump();
 
       expect(resetDiagnosis, DatabaseBootstrapDiagnosis.databaseUnreadable);
@@ -445,12 +457,12 @@ void main() {
         ),
       );
 
-      await tester.tap(find.text('reset local database'));
+      await tester.tap(find.text(l10n.dbFailureResetAction));
       await tester.pump();
-      await tester.tap(find.text('cancel'));
+      await tester.tap(find.text(l10n.dbFailureCancel));
       await tester.pump();
 
-      expect(find.text("couldn't unlock your local database"), findsOneWidget);
+      expect(find.text(l10n.dbFailureTitle), findsOneWidget);
       expect(resets, isZero);
     });
 
@@ -469,12 +481,12 @@ void main() {
         ),
       );
 
-      await tester.tap(find.text('reset local database'));
+      await tester.tap(find.text(l10n.dbFailureResetAction));
       await tester.pump();
-      await tester.tap(find.text('reset and close'));
+      await tester.tap(find.text(l10n.dbFailureResetConfirm));
       await tester.pump();
 
-      expect(find.textContaining("That didn't work"), findsOneWidget);
+      expect(find.text(l10n.dbFailureResetFailed), findsOneWidget);
       expect(
         closed,
         isFalse,
@@ -498,16 +510,16 @@ void main() {
         ),
       );
 
-      await tester.tap(find.text('reset local database'));
+      await tester.tap(find.text(l10n.dbFailureResetAction));
       await tester.pump();
-      await tester.tap(find.text('reset and close'));
+      await tester.tap(find.text(l10n.dbFailureResetConfirm));
       await tester.pump();
 
-      expect(find.text('local database reset'), findsOneWidget);
-      expect(find.text('reset and close'), findsNothing);
+      expect(find.text(l10n.dbFailureResetDoneTitle), findsOneWidget);
+      expect(find.text(l10n.dbFailureResetConfirm), findsNothing);
       expect(closes, equals(1));
 
-      await tester.tap(find.text('close Divine'));
+      await tester.tap(find.text(l10n.dbFailureCloseApp));
       expect(
         closes,
         equals(2),
@@ -526,17 +538,17 @@ void main() {
         ),
       );
 
-      await tester.tap(find.text('reset local database'));
+      await tester.tap(find.text(l10n.dbFailureResetAction));
       await tester.pump();
-      await tester.tap(find.text('reset and close'));
+      await tester.tap(find.text(l10n.dbFailureResetConfirm));
       await tester.pump(const Duration(seconds: 16));
 
-      expect(find.textContaining("That didn't work"), findsOneWidget);
+      expect(find.text(l10n.dbFailureResetFailed), findsOneWidget);
 
-      await tester.tap(find.text('cancel'));
+      await tester.tap(find.text(l10n.dbFailureCancel));
       await tester.pump();
       expect(
-        find.text("couldn't unlock your local database"),
+        find.text(l10n.dbFailureTitle),
         findsOneWidget,
         reason: 'a wedged platform call must not disable the way back',
       );
@@ -553,19 +565,19 @@ void main() {
         ),
       );
 
-      await tester.tap(find.text('reset local database'));
+      await tester.tap(find.text(l10n.dbFailureResetAction));
       await tester.pump();
-      await tester.tap(find.text('reset and close'));
+      await tester.tap(find.text(l10n.dbFailureResetConfirm));
       await tester.pump();
-      expect(find.textContaining("That didn't work"), findsOneWidget);
+      expect(find.text(l10n.dbFailureResetFailed), findsOneWidget);
 
-      await tester.tap(find.text('cancel'));
+      await tester.tap(find.text(l10n.dbFailureCancel));
       await tester.pump();
-      await tester.tap(find.text('reset local database'));
+      await tester.tap(find.text(l10n.dbFailureResetAction));
       await tester.pump();
 
       expect(
-        find.textContaining("That didn't work"),
+        find.text(l10n.dbFailureResetFailed),
         findsNothing,
         reason: 'the banner belongs to an attempt, not to the step',
       );
@@ -643,6 +655,70 @@ void main() {
             'expectation that follows passes no matter what the function does',
       );
       expect(shouldRepairLocalDatabaseCacheAfterBootstrapError(error), isFalse);
+    });
+  });
+
+  group('DatabaseBootstrapFailureApp localization', () {
+    // This screen shipped 100% hardcoded English to all 21 non-English
+    // locales — it builds its own MaterialApp before startup finishes, so it
+    // inherited no delegates from anywhere. These are the tests a regression
+    // back to constants cannot pass.
+    final es = lookupAppLocalizations(const Locale('es'));
+
+    testWidgets('renders the failure step in the requested locale', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        DatabaseBootstrapFailureApp(
+          error: DatabaseCipherStorageUnavailableException(
+            _lockedKeychainFailure(),
+          ),
+          stack: StackTrace.current,
+          locale: const Locale('es'),
+        ),
+      );
+
+      expect(find.text(es.dbFailureTitle), findsOneWidget);
+      expect(find.text(es.dbFailureAdviceRestart), findsOneWidget);
+      expect(find.text(es.dbFailureCloseApp), findsOneWidget);
+      expect(find.text(l10n.dbFailureTitle), findsNothing);
+    });
+
+    testWidgets('carries the locale through the reset confirmation', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        DatabaseBootstrapFailureApp(
+          error: StateError('SQLITE_NOTADB: demo'),
+          stack: StackTrace.current,
+          locale: const Locale('es'),
+          onResetLocalDatabase: (_) async {},
+        ),
+      );
+
+      await tester.tap(find.text(es.dbFailureResetAction));
+      await tester.pumpAndSettle();
+
+      expect(find.text(es.dbFailureConfirmTitle), findsOneWidget);
+      expect(find.text(es.dbFailureConfirmBody), findsOneWidget);
+      expect(find.text(es.dbFailureCancel), findsOneWidget);
+    });
+
+    testWidgets('falls back to the device locale when none is given', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        DatabaseBootstrapFailureApp(
+          error: DatabaseCipherStorageUnavailableException(
+            _lockedKeychainFailure(),
+          ),
+          stack: StackTrace.current,
+        ),
+      );
+
+      // resolveAppUiLocale picks English rather than supportedLocales.first,
+      // which is Arabic.
+      expect(find.text(l10n.dbFailureTitle), findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
Closes #7712

Found during the #3613 investigation and flagged as out of scope in #7708. This is the last shipping l10n gap that pass turned up.

## What was wrong

`lib/startup/database_bootstrap_failure_app.dart` replaces the entire app when the encrypted local database cannot be opened. **Every string on it was a hardcoded English literal**, and its `MaterialApp` registered no localization delegates at all — so all 21 non-English locales saw a fully English screen at the exact moment they most needed to read it.

It could never crash, which is why it stayed invisible: it makes zero `context.l10n` calls, so there was nothing to throw. A delegate-less `MaterialApp` also reads as deliberate here, sitting next to the fixed-dark palette this same screen uses on purpose (it runs before the appearance preference is readable).

## What changed

- **13 strings** now come from the ARB, translated into **all 21** non-English locales.
- The `MaterialApp` registers `AppLocalizations.localizationsDelegates` / `supportedLocales` and resolves through `resolveAppUiLocale` — the same callback the running app uses, including its "`supportedLocales.first` is Arabic" guard that would otherwise hand an unmatched device locale Arabic.
- The user's in-app language override is **threaded in from `main.dart`** rather than read here. This screen has to render even when startup never got far enough to have `SharedPreferences`, so it takes a plain `Locale?` and falls back to the device locales when none is given.

## Verification

- `flutter analyze lib test integration_test` → **No issues found**
- `test/startup` → **77 pass** (74 existing + 3 new), including after the rebase
- `test/l10n/arb_consistency_test.dart` → pass
- Root `main_*_test.dart` → **60 pass**
- Untranslated-key set is **unchanged**: 8 keys, all pre-existing. This PR adds zero l10n debt.

Existing test assertions now resolve from the ARB instead of hardcoding English, per `.claude/rules/localization.md`. Three new tests pin the actual translation — a hardcoded default cannot render `no se pudo desbloquear tu base de datos local`, which is the regression this PR exists to prevent.

## Note on the rebase

`origin/main` added l10n keys while this was in flight, conflicting across all 22 ARBs and their generated files. Resolved by taking `main`'s ARBs, re-applying these 13 keys, and regenerating — not by hand-merging generated output. Re-verified after.