### PR TITLE
fix(nostr_sdk): handle temp relay auth fire-and-forget publishes

### DIFF
--- a/mobile/packages/follow_repository/test/src/follow_repository_test.dart
+++ b/mobile/packages/follow_repository/test/src/follow_repository_test.dart
@@ -62,7 +62,6 @@ class _FakeRelay extends RelayBase {
   @override
   Future<bool> send(
     List<dynamic> message, {
-    bool? forceSend,
     bool queueIfFailed = true,
     bool skipReconnect = false,
     DateTime? deadline,

--- a/mobile/packages/nostr_sdk/lib/nip46/nostr_remote_signer.dart
+++ b/mobile/packages/nostr_sdk/lib/nip46/nostr_remote_signer.dart
@@ -333,7 +333,7 @@ class NostrRemoteSigner extends NostrSigner {
           );
           for (var entry in _pendingRequestEvents.entries) {
             log('[NIP46] _reconnectRelay: resending request id=${entry.key}');
-            relay.send(entry.value, forceSend: true);
+            relay.send(entry.value);
           }
         }
       } else {
@@ -466,7 +466,7 @@ class NostrRemoteSigner extends NostrSigner {
           log(
             '[NIP46] sendAndWaitForResult: sending to ${relay.relayStatus.addr}, connected=${relay.relayStatus.connected}',
           );
-          relay.send(json, forceSend: true);
+          relay.send(json);
         }
 
         log(

--- a/mobile/packages/nostr_sdk/lib/relay/relay.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay.dart
@@ -26,6 +26,14 @@ abstract class Relay {
   // to hold the message when the ws haven't authed and should be send after auth.
   List<List<dynamic>> pendingAuthedMessages = [];
 
+  /// Cap on [_sentFramesForAuthRetry]. Sized for the burst a single user action
+  /// can fan out (a gift-wrapped DM writes one frame per recipient relay), not
+  /// for a backlog: anything still held past that is a relay that never
+  /// answered, and replaying it is no longer useful.
+  static const int _maxSentFramesForAuthRetry = 32;
+
+  /// Written EVENT frames held for a possible post-NIP-42 replay, keyed by
+  /// event id. Insertion-ordered, so eviction drops the oldest first.
   final Map<String, List<dynamic>> _sentFramesForAuthRetry = {};
 
   Function(Relay, List<dynamic>)? onMessage;
@@ -166,15 +174,34 @@ abstract class Relay {
     info ??= await RelayInfoUtil.get(url);
   }
 
-  /// Records a frame that was sent, keyed by event ID for later retrieval if needed.
+  /// Retains an already-written EVENT frame so it can be replayed if the relay
+  /// turns out to want NIP-42 first.
+  ///
+  /// [RelayStatus.alwaysAuth] only flips once a challenge has landed, so the
+  /// very first publish on a connection cannot be parked in
+  /// [pendingAuthedMessages] — it has to go out to provoke the challenge. A
+  /// fire-and-forget caller keeps no handle on that frame, so without a copy
+  /// here the post-AUTH flush has nothing to replay and the event is gone.
+  ///
+  /// Bounded by [_maxSentFramesForAuthRetry], evicting oldest-first: this holds
+  /// frames the relay has not answered, and a peer that stays silent must not
+  /// grow the map without limit.
   void recordSentFrame(List<dynamic> frame) {
     final eventId = _extractEventId(frame);
-    if (eventId != null) {
-      _sentFramesForAuthRetry[eventId] = frame;
+    if (eventId == null) return;
+    // Re-insert last so the eviction order below stays newest-last.
+    _sentFramesForAuthRetry
+      ..remove(eventId)
+      ..[eventId] = frame;
+    while (_sentFramesForAuthRetry.length > _maxSentFramesForAuthRetry) {
+      _sentFramesForAuthRetry.remove(_sentFramesForAuthRetry.keys.first);
     }
   }
 
   /// Retrieves and removes a previously recorded frame by event ID.
+  ///
+  /// Called once the relay has spoken for that event — accepted it, or refused
+  /// it for a reason NIP-42 cannot fix — so it is never replayed.
   List<dynamic>? takeSentFrame(String eventId) {
     return _sentFramesForAuthRetry.remove(eventId);
   }
@@ -186,13 +213,16 @@ abstract class Relay {
     return frames;
   }
 
-  /// Extracts the event ID from an EVENT message frame.
-  /// Returns null if the frame is not an EVENT message or doesn't contain a valid event ID.
+  /// Extracts the event id from a client-to-relay EVENT frame.
+  ///
+  /// Only the publish shape `["EVENT", <event>]` is recognised. The three-element
+  /// `["EVENT", <subId>, <event>]` shape is the relay-to-client direction and is
+  /// never something this client sent, so it is not a retry candidate.
   String? _extractEventId(List<dynamic> frame) {
-    if (frame.length < 3 || frame[0] != 'EVENT') {
+    if (frame.length != 2 || frame[0] != 'EVENT') {
       return null;
     }
-    final event = frame[2];
+    final event = frame[1];
     if (event is Map && event['id'] is String) {
       return event['id'] as String;
     }

--- a/mobile/packages/nostr_sdk/lib/relay/relay.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay.dart
@@ -26,6 +26,8 @@ abstract class Relay {
   // to hold the message when the ws haven't authed and should be send after auth.
   List<List<dynamic>> pendingAuthedMessages = [];
 
+  final Map<String, List<dynamic>> _sentFramesForAuthRetry = {};
+
   Function(Relay, List<dynamic>)? onMessage;
 
   // subscriptions
@@ -164,13 +166,45 @@ abstract class Relay {
     info ??= await RelayInfoUtil.get(url);
   }
 
+  /// Records a frame that was sent, keyed by event ID for later retrieval if needed.
+  void recordSentFrame(List<dynamic> frame) {
+    final eventId = _extractEventId(frame);
+    if (eventId != null) {
+      _sentFramesForAuthRetry[eventId] = frame;
+    }
+  }
+
+  /// Retrieves and removes a previously recorded frame by event ID.
+  List<dynamic>? takeSentFrame(String eventId) {
+    return _sentFramesForAuthRetry.remove(eventId);
+  }
+
+  /// Returns all retained frames and clears the map.
+  List<List<dynamic>> drainSentFramesForAuthRetry() {
+    final frames = _sentFramesForAuthRetry.values.toList();
+    _sentFramesForAuthRetry.clear();
+    return frames;
+  }
+
+  /// Extracts the event ID from an EVENT message frame.
+  /// Returns null if the frame is not an EVENT message or doesn't contain a valid event ID.
+  String? _extractEventId(List<dynamic> frame) {
+    if (frame.length < 3 || frame[0] != 'EVENT') {
+      return null;
+    }
+    final event = frame[2];
+    if (event is Map && event['id'] is String) {
+      return event['id'] as String;
+    }
+    return null;
+  }
+
   /// Sends [message] to this relay.
   ///
   /// [deadline] is a hard send deadline: implementations must not write or
   /// queue the message after it has expired.
   Future<bool> send(
     List<dynamic> message, {
-    bool? forceSend,
     bool queueIfFailed = true,
     bool skipReconnect = false,
     DateTime? deadline,

--- a/mobile/packages/nostr_sdk/lib/relay/relay_base.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_base.dart
@@ -140,7 +140,6 @@ class RelayBase extends Relay {
   @override
   Future<bool> send(
     List<dynamic> message, {
-    bool? forceSend,
     bool queueIfFailed = true,
     bool skipReconnect = false,
     DateTime? deadline,

--- a/mobile/packages/nostr_sdk/lib/relay/relay_isolate.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_isolate.dart
@@ -98,7 +98,6 @@ class RelayIsolate extends Relay {
   @override
   Future<bool> send(
     List message, {
-    bool? forceSend,
     bool queueIfFailed = true,
     bool skipReconnect = false,
     DateTime? deadline,

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -622,7 +622,7 @@ class RelayPool {
         log('🔐 Auth-required query - sending to trigger AUTH challenge');
         relay.saveQuery(subscription);
         final result = await relay
-            .send(message, forceSend: true)
+            .send(message)
             .timeout(perRelaySendTimeout, onTimeout: () => false);
         if (!result) {
           log(
@@ -1522,6 +1522,11 @@ class RelayPool {
           }
           relay.pendingAuthedMessages.clear();
 
+          // Flush and re-send frames that were retained while waiting for auth
+          for (final frame in relay.drainSentFramesForAuthRetry()) {
+            relay.send(frame);
+          }
+
           // Send subscriptions
           if (relay.hasSubscription()) {
             var subs = relay.getSubscriptions();
@@ -1604,7 +1609,7 @@ class RelayPool {
           // Track this AUTH event to match with OK response
           _pendingAuthEvents[event.id] = relay.url;
 
-          relay.send(["AUTH", event.toJson()], forceSend: true);
+          relay.send(["AUTH", event.toJson()]);
           log('🔐 AUTH response sent, waiting for relay confirmation...');
 
           if (relay.pendingAuthedMessages.isNotEmpty) {
@@ -1817,7 +1822,7 @@ class RelayPool {
           '🔐 Auth-required subscription - sending to trigger AUTH challenge',
         );
         final result = await relay
-            .send(message, forceSend: true)
+            .send(message)
             .timeout(perRelaySendTimeout, onTimeout: () => false);
         if (result) {
           return true;
@@ -2156,12 +2161,7 @@ class RelayPool {
             );
             var timedOut = false;
             var result = await relay
-                .send(
-                  message,
-                  forceSend: true,
-                  queueIfFailed: false,
-                  deadline: deadline,
-                )
+                .send(message, queueIfFailed: false, deadline: deadline)
                 .timeout(
                   timeout,
                   onTimeout: () {
@@ -2252,6 +2252,16 @@ class RelayPool {
         // Same skipReconnect rationale as the main loop above: a fresh
         // tempRelay whose initial connection is still in-flight must not
         // block the publish.
+
+        // If this is a fire-and-forget (deadline == null) and the relay requires
+        // auth and is not yet authenticated, park the message for retry after auth.
+        if (tempRelay.relayStatus.alwaysAuth &&
+            !tempRelay.relayStatus.authed &&
+            deadline == null) {
+          tempRelay.pendingAuthedMessages.add(message);
+          continue;
+        }
+
         var result = await tempRelay
             .send(
               message,

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -481,6 +481,16 @@ class RelayPool {
     }
   }
 
+  /// Fails everything that was waiting on [relay]'s NIP-42 handshake, after
+  /// that handshake has definitively concluded without authenticating.
+  ///
+  /// Fire-and-forget publishes are dropped rather than held. Nothing will flush
+  /// them now, and a temp relay is reaped only once
+  /// [Relay.pendingAuthedMessages] is empty (see [_isTempRelayReapable]) — so
+  /// holding them would pin the socket open for the life of the pool and grow
+  /// the queue on every later publish. A fresh challenge on this connection
+  /// reopens the gate and re-parks whatever is published after it, so the loss
+  /// is bounded to frames no caller is awaiting.
   void _rejectAuthRequiredPublishesForRelay(Relay relay, String authMessage) {
     for (final entry in _retryEntriesForRelay(relay)) {
       entry.value.tracker.onRejected(
@@ -489,6 +499,33 @@ class RelayPool {
       );
       _removeAuthRequiredPublish(entry.key, relay.url);
     }
+    if (relay.pendingAuthedMessages.isNotEmpty) {
+      log(
+        '🔐 Dropping ${relay.pendingAuthedMessages.length} message(s) parked '
+        'behind the failed auth handshake for ${relay.url}',
+      );
+      relay.pendingAuthedMessages.clear();
+    }
+    relay.drainSentFramesForAuthRetry();
+  }
+
+  /// Keeps a copy of a just-written fire-and-forget EVENT in case [relay]
+  /// answers it with a NIP-42 challenge.
+  ///
+  /// Only the first publish on a connection needs this. Once a challenge has
+  /// landed, [RelayStatus.alwaysAuth] is set and [_sendCollect] parks
+  /// subsequent frames in [Relay.pendingAuthedMessages] instead — and once the
+  /// handshake succeeds, `authed` is set and nothing needs replaying at all.
+  /// Deadline-bound publishes are excluded because [PublishTracker] already
+  /// carries their message through [_trackAuthRequiredPublish]; retaining them
+  /// here as well would republish the same event twice after AUTH.
+  void _retainForAuthRetry(
+    Relay relay,
+    List<dynamic> message,
+    DateTime? deadline,
+  ) {
+    if (deadline != null || relay.relayStatus.authed) return;
+    relay.recordSentFrame(message);
   }
 
   Future<bool> add(
@@ -1460,6 +1497,18 @@ class RelayPool {
       );
       if (message == null) return;
 
+      // The relay has spoken for this event. Unless it refused for a reason
+      // NIP-42 can fix, a frame retained by [_retainForAuthRetry] has served
+      // its purpose and must not be replayed after a later, unrelated AUTH.
+      if (success ||
+          !_shouldRetryPublishAfterAuth(
+            relay: relay,
+            eventId: eventId,
+            message: message,
+          )) {
+        relay.takeSentFrame(eventId);
+      }
+
       // Check if this OK is for a publish we are awaiting.
       //
       // Trackers are keyed on event id alone, so without the membership check
@@ -2220,6 +2269,9 @@ class RelayPool {
                   return false;
                 },
               );
+          if (result) {
+            _retainForAuthRetry(relay, message, deadline);
+          }
           if (result ||
               timedOut ||
               sendStartedWhileConnecting ||
@@ -2253,12 +2305,15 @@ class RelayPool {
         // tempRelay whose initial connection is still in-flight must not
         // block the publish.
 
-        // If this is a fire-and-forget (deadline == null) and the relay requires
-        // auth and is not yet authenticated, park the message for retry after auth.
+        // A known-auth relay that has not authed yet would answer this frame
+        // with `auth-required`, and a fire-and-forget publish has no tracker to
+        // notice. Park it behind the handshake instead, exactly as the main
+        // loop above does; `_onEvent` flushes the queue once AUTH lands.
         if (tempRelay.relayStatus.alwaysAuth &&
             !tempRelay.relayStatus.authed &&
             deadline == null) {
           tempRelay.pendingAuthedMessages.add(message);
+          sentTo.add(tempRelay.url);
           continue;
         }
 
@@ -2284,6 +2339,7 @@ class RelayPool {
           removeExpiredTempRelay(tempRelay);
         }
         if (result) {
+          _retainForAuthRetry(tempRelay, message, deadline);
           sentTo.add(tempRelay.url);
         }
       }

--- a/mobile/packages/nostr_sdk/test/integration/nip50_search_test.dart
+++ b/mobile/packages/nostr_sdk/test/integration/nip50_search_test.dart
@@ -45,7 +45,6 @@ class _MockRelay extends RelayBase {
   @override
   Future<bool> send(
     List<dynamic> message, {
-    bool? forceSend,
     bool queueIfFailed = true,
     bool skipReconnect = false,
     DateTime? deadline,

--- a/mobile/packages/nostr_sdk/test/integration/relay_auth_test.dart
+++ b/mobile/packages/nostr_sdk/test/integration/relay_auth_test.dart
@@ -15,7 +15,6 @@ class MockRelay extends RelayBase {
   @override
   Future<bool> send(
     List<dynamic> message, {
-    bool? forceSend,
     bool queueIfFailed = true,
     bool skipReconnect = false,
     DateTime? deadline,

--- a/mobile/packages/nostr_sdk/test/unit/relay_count_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_count_test.dart
@@ -17,7 +17,6 @@ class TestRelay extends Relay {
   @override
   Future<bool> send(
     List<dynamic> message, {
-    bool? forceSend,
     bool queueIfFailed = true,
     bool skipReconnect = false,
     DateTime? deadline,

--- a/mobile/packages/nostr_sdk/test/unit/relay_pending_messages_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pending_messages_test.dart
@@ -26,7 +26,6 @@ class _RequeueingRelay extends Relay {
   @override
   Future<bool> send(
     List<dynamic> message, {
-    bool? forceSend,
     bool queueIfFailed = true,
     bool skipReconnect = false,
     DateTime? deadline,

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_auth_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_auth_test.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Regression tests for RelayPool AUTH branch empty-pubkey race.
 // ABOUTME: Ensures NIP-42 AUTH challenges do not crash when the cached
-// ABOUTME: public key is empty (post-signOut, mid-init, account switch).
+// ABOUTME: public key is empty (post-signOut, mid-init, account switch), and
+// ABOUTME: that fire-and-forget temp-relay publishes survive the handshake.
 
 import 'dart:async';
 
@@ -60,7 +61,6 @@ class _AuthFakeRelay extends Relay {
   @override
   Future<bool> send(
     List<dynamic> message, {
-    bool? forceSend,
     bool queueIfFailed = true,
     bool skipReconnect = false,
     DateTime? deadline,
@@ -536,5 +536,271 @@ void main() {
         );
       },
     );
+  });
+
+  // Regression coverage for #7701: a fire-and-forget `RelayPool.send` to a temp
+  // relay creates no PublishTracker, so the auth-required recovery the awaited
+  // path relies on never runs and the event used to vanish silently.
+  group('fire-and-forget temp-relay publish across NIP-42', () {
+    const tempRelayUrl = 'wss://temp-auth.example';
+    late LocalNostrSigner signer;
+    late Nostr nostr;
+    late _AuthFakeRelay tempRelay;
+
+    setUp(() async {
+      signer = LocalNostrSigner(testPrivateKey);
+      tempRelay = _AuthFakeRelay(tempRelayUrl);
+      nostr = Nostr(signer, [], (_) => tempRelay);
+      await nostr.refreshPublicKey();
+    });
+
+    List<dynamic> eventFrame(String id) => [
+      'EVENT',
+      {'id': id, 'kind': EventKind.giftWrap},
+    ];
+
+    /// Completes the NIP-42 handshake the relay is asking for, returning the
+    /// id of the AUTH event the pool signed.
+    Future<String> completeHandshake({bool succeed = true}) async {
+      await tempRelay.deliver(['AUTH', challenge]);
+      final authEventId = sentAuthEventId(tempRelay);
+      await tempRelay.deliver([
+        'OK',
+        authEventId,
+        succeed,
+        succeed ? '' : 'auth failed: bad signature',
+      ]);
+      return authEventId;
+    }
+
+    test('replays the first-round frame the relay answered with '
+        'auth-required', () async {
+      const eventId =
+          'aaaa111111111111111111111111111111111111111111111111111111111111';
+
+      final sent = await nostr.relayPool.send(
+        eventFrame(eventId),
+        tempRelays: [tempRelayUrl],
+      );
+
+      expect(sent, isTrue);
+      // alwaysAuth is still false on a fresh connection, so the frame has to go
+      // out to provoke the challenge — it cannot be parked up front.
+      expect(sentMessagesOfType(tempRelay, 'EVENT'), hasLength(1));
+
+      await tempRelay.deliver([
+        'OK',
+        eventId,
+        false,
+        'auth-required: you must auth',
+      ]);
+      await completeHandshake();
+
+      // BEFORE FIX: nothing recorded the written frame, so the post-AUTH flush
+      // had nothing to replay and the event was gone.
+      expect(
+        sentMessagesOfType(tempRelay, 'EVENT'),
+        hasLength(2),
+        reason: 'the retained first-round frame must be replayed after AUTH',
+      );
+      expect(
+        sentMessagesOfType(tempRelay, 'EVENT').last,
+        equals(eventFrame(eventId)),
+      );
+    });
+
+    test('replays even when the relay challenges without answering the '
+        'EVENT', () async {
+      const eventId =
+          'aaaa222222222222222222222222222222222222222222222222222222222222';
+
+      await nostr.relayPool.send(
+        eventFrame(eventId),
+        tempRelays: [tempRelayUrl],
+      );
+      // Some relays send the challenge and never OK the frame that provoked it.
+      await completeHandshake();
+
+      expect(sentMessagesOfType(tempRelay, 'EVENT'), hasLength(2));
+    });
+
+    test(
+      'parks instead of sending once the relay is known to need auth',
+      () async {
+        const firstEventId =
+            'aaaa333333333333333333333333333333333333333333333333333333333333';
+        const parkedEventId =
+            'aaaa444444444444444444444444444444444444444444444444444444444444';
+
+        // First publish creates the temp relay and provokes the challenge.
+        await nostr.relayPool.send(
+          eventFrame(firstEventId),
+          tempRelays: [tempRelayUrl],
+        );
+        await tempRelay.deliver(['AUTH', challenge]);
+        expect(tempRelay.relayStatus.alwaysAuth, isTrue);
+        expect(tempRelay.relayStatus.authed, isFalse);
+
+        final sent = await nostr.relayPool.send(
+          eventFrame(parkedEventId),
+          tempRelays: [tempRelayUrl],
+        );
+
+        expect(
+          sent,
+          isTrue,
+          reason: 'a parked frame is queued for delivery, not dropped',
+        );
+        expect(
+          tempRelay.pendingAuthedMessages,
+          contains(equals(eventFrame(parkedEventId))),
+        );
+        expect(
+          sentMessagesOfType(tempRelay, 'EVENT'),
+          hasLength(1),
+          reason: 'the parked frame must not be written before AUTH completes',
+        );
+
+        final authEventId = sentAuthEventId(tempRelay);
+        await tempRelay.deliver(['OK', authEventId, true, '']);
+
+        expect(tempRelay.pendingAuthedMessages, isEmpty);
+        expect(
+          sentMessagesOfType(
+            tempRelay,
+            'EVENT',
+          ).where((e) => (e[1] as Map)['id'] == parkedEventId),
+          hasLength(1),
+          reason: 'the parked frame is sent exactly once, after AUTH',
+        );
+      },
+    );
+
+    test('does not replay an event the relay already accepted', () async {
+      const eventId =
+          'aaaa555555555555555555555555555555555555555555555555555555555555';
+
+      await nostr.relayPool.send(
+        eventFrame(eventId),
+        tempRelays: [tempRelayUrl],
+      );
+      await tempRelay.deliver(['OK', eventId, true, '']);
+      // A challenge for some later frame must not resurrect an accepted event.
+      await completeHandshake();
+
+      expect(
+        sentMessagesOfType(tempRelay, 'EVENT'),
+        hasLength(1),
+        reason: 'an accepted event must not be published twice',
+      );
+    });
+
+    test('does not replay an event rejected for a non-auth reason', () async {
+      const eventId =
+          'aaaa666666666666666666666666666666666666666666666666666666666666';
+
+      await nostr.relayPool.send(
+        eventFrame(eventId),
+        tempRelays: [tempRelayUrl],
+      );
+      await tempRelay.deliver(['OK', eventId, false, 'invalid: bad signature']);
+      await completeHandshake();
+
+      expect(
+        sentMessagesOfType(tempRelay, 'EVENT'),
+        hasLength(1),
+        reason: 'NIP-42 cannot fix an invalid event, so it must not be resent',
+      );
+    });
+
+    test(
+      'releases parked and retained frames when the handshake fails',
+      () async {
+        const retainedEventId =
+            'aaaa777777777777777777777777777777777777777777777777777777777777';
+        const parkedEventId =
+            'aaaa888888888888888888888888888888888888888888888888888888888888';
+
+        await nostr.relayPool.send(
+          eventFrame(retainedEventId),
+          tempRelays: [tempRelayUrl],
+        );
+        await tempRelay.deliver([
+          'OK',
+          retainedEventId,
+          false,
+          'auth-required: you must auth',
+        ]);
+        // The challenge is what flips alwaysAuth, so only publishes after it
+        // take the parking branch.
+        await tempRelay.deliver(['AUTH', challenge]);
+        await nostr.relayPool.send(
+          eventFrame(parkedEventId),
+          tempRelays: [tempRelayUrl],
+        );
+        expect(tempRelay.pendingAuthedMessages, isNotEmpty);
+
+        await tempRelay.deliver([
+          'OK',
+          sentAuthEventId(tempRelay),
+          false,
+          'auth failed: bad signature',
+        ]);
+
+        // `_isTempRelayReapable` refuses to close a relay while
+        // pendingAuthedMessages is non-empty, so a handshake that fails without
+        // clearing the queue would pin this socket open for the life of the pool.
+        expect(tempRelay.pendingAuthedMessages, isEmpty);
+        expect(tempRelay.drainSentFramesForAuthRetry(), isEmpty);
+        expect(
+          sentMessagesOfType(tempRelay, 'EVENT'),
+          hasLength(1),
+          reason: 'a failed handshake must not replay anything',
+        );
+      },
+    );
+  });
+
+  group('Relay.recordSentFrame', () {
+    test('only retains client publish frames', () {
+      final relay = _AuthFakeRelay('wss://shape.example');
+      const eventId =
+          'bbbb111111111111111111111111111111111111111111111111111111111111';
+
+      // The three-element shape is the relay-to-client direction; this client
+      // never sends it, so it is not a retry candidate.
+      relay.recordSentFrame([
+        'EVENT',
+        'sub-id',
+        {'id': eventId},
+      ]);
+      relay.recordSentFrame(['REQ', 'sub-id', <String, dynamic>{}]);
+      expect(relay.drainSentFramesForAuthRetry(), isEmpty);
+
+      relay.recordSentFrame([
+        'EVENT',
+        {'id': eventId},
+      ]);
+      expect(relay.drainSentFramesForAuthRetry(), hasLength(1));
+    });
+
+    test('is bounded, evicting the oldest frame first', () {
+      final relay = _AuthFakeRelay('wss://bounded.example');
+      // One past the cap, so the very first frame must have been evicted.
+      for (var i = 0; i <= 32; i++) {
+        relay.recordSentFrame([
+          'EVENT',
+          {'id': 'event-$i'},
+        ]);
+      }
+
+      final retained = relay.drainSentFramesForAuthRetry();
+      expect(retained, hasLength(32));
+      expect(
+        retained.map((f) => (f[1] as Map)['id']),
+        isNot(contains('event-0')),
+      );
+      expect(retained.map((f) => (f[1] as Map)['id']), contains('event-32'));
+    });
   });
 }

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_auth_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_auth_test.dart
@@ -761,6 +761,74 @@ void main() {
     );
   });
 
+  group('fire-and-forget pool-relay publish across NIP-42', () {
+    late LocalNostrSigner signer;
+    late Nostr nostr;
+    late _AuthFakeRelay relay;
+
+    setUp(() async {
+      signer = LocalNostrSigner(testPrivateKey);
+      nostr = Nostr(signer, [], (url) => RelayBase(url, RelayStatus(url)));
+      await nostr.refreshPublicKey();
+      relay = _AuthFakeRelay('wss://pool-auth.example');
+      expect(await nostr.relayPool.add(relay), isTrue);
+    });
+
+    List<dynamic> eventFrame(String id) => [
+      'EVENT',
+      {'id': id, 'kind': EventKind.giftWrap},
+    ];
+
+    // A user's NIP-65 list can put a NIP-42 relay in the configured pool, so
+    // the main-relay loop needs the same first-round retention the temp loop
+    // has. Without it this publish is dropped exactly as in #7701 — and no
+    // other test in the suite covers that loop's `_retainForAuthRetry` call.
+    test('replays the first-round frame a pool relay refused', () async {
+      const eventId =
+          'cccc111111111111111111111111111111111111111111111111111111111111';
+
+      final sent = await nostr.relayPool.send(eventFrame(eventId));
+
+      expect(sent, isTrue);
+      expect(sentMessagesOfType(relay, 'EVENT'), hasLength(1));
+
+      await relay.deliver([
+        'OK',
+        eventId,
+        false,
+        'auth-required: you must auth',
+      ]);
+      await relay.deliver(['AUTH', challenge]);
+      await relay.deliver(['OK', sentAuthEventId(relay), true, '']);
+
+      expect(
+        sentMessagesOfType(relay, 'EVENT'),
+        hasLength(2),
+        reason: 'the retained first-round frame must be replayed after AUTH',
+      );
+      expect(
+        sentMessagesOfType(relay, 'EVENT').last,
+        equals(eventFrame(eventId)),
+      );
+    });
+
+    test('does not replay a pool-relay event the relay accepted', () async {
+      const eventId =
+          'cccc222222222222222222222222222222222222222222222222222222222222';
+
+      await nostr.relayPool.send(eventFrame(eventId));
+      await relay.deliver(['OK', eventId, true, '']);
+      await relay.deliver(['AUTH', challenge]);
+      await relay.deliver(['OK', sentAuthEventId(relay), true, '']);
+
+      expect(
+        sentMessagesOfType(relay, 'EVENT'),
+        hasLength(1),
+        reason: 'an accepted event must not be replayed by a later AUTH',
+      );
+    });
+  });
+
   group('Relay.recordSentFrame', () {
     test('only retains client publish frames', () {
       final relay = _AuthFakeRelay('wss://shape.example');

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_closed_frame_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_closed_frame_test.dart
@@ -33,7 +33,6 @@ class _ControlledQueryRelay extends Relay {
   @override
   Future<bool> send(
     List<dynamic> message, {
-    bool? forceSend,
     bool queueIfFailed = true,
     bool skipReconnect = false,
     DateTime? deadline,

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_concurrency_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_concurrency_test.dart
@@ -29,7 +29,6 @@ class _MutatingRelay extends Relay {
   @override
   Future<bool> send(
     List<dynamic> message, {
-    bool? forceSend,
     bool queueIfFailed = true,
     bool skipReconnect = false,
     DateTime? deadline,
@@ -65,7 +64,6 @@ class _SucceedingRelay extends Relay {
   @override
   Future<bool> send(
     List<dynamic> message, {
-    bool? forceSend,
     bool queueIfFailed = true,
     bool skipReconnect = false,
     DateTime? deadline,
@@ -106,7 +104,6 @@ class _CountRelay extends Relay {
   @override
   Future<bool> send(
     List<dynamic> message, {
-    bool? forceSend,
     bool queueIfFailed = true,
     bool skipReconnect = false,
     DateTime? deadline,
@@ -149,7 +146,6 @@ class _FailingSendRelay extends Relay {
   @override
   Future<bool> send(
     List<dynamic> message, {
-    bool? forceSend,
     bool queueIfFailed = true,
     bool skipReconnect = false,
     DateTime? deadline,
@@ -190,7 +186,6 @@ class _StallingReconnectRelay extends Relay {
   @override
   Future<bool> send(
     List<dynamic> message, {
-    bool? forceSend,
     bool queueIfFailed = true,
     bool skipReconnect = false,
     DateTime? deadline,
@@ -233,7 +228,6 @@ class _AlwaysHangingRelay extends Relay {
   @override
   Future<bool> send(
     List<dynamic> message, {
-    bool? forceSend,
     bool queueIfFailed = true,
     bool skipReconnect = false,
     DateTime? deadline,
@@ -266,7 +260,6 @@ class _DeferredSendRelay extends Relay {
   @override
   Future<bool> send(
     List<dynamic> message, {
-    bool? forceSend,
     bool queueIfFailed = true,
     bool skipReconnect = false,
     DateTime? deadline,
@@ -319,7 +312,6 @@ class _ConnectionAwareTempRelay extends Relay {
   @override
   Future<bool> send(
     List<dynamic> message, {
-    bool? forceSend,
     bool queueIfFailed = true,
     bool skipReconnect = false,
     DateTime? deadline,
@@ -348,7 +340,6 @@ class _HangingSendRelay extends Relay {
   @override
   Future<bool> send(
     List<dynamic> message, {
-    bool? forceSend,
     bool queueIfFailed = true,
     bool skipReconnect = false,
     DateTime? deadline,

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_event_signature_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_event_signature_test.dart
@@ -24,7 +24,6 @@ class _FakeRelay extends Relay {
   @override
   Future<bool> send(
     List<dynamic> message, {
-    bool? forceSend,
     bool queueIfFailed = true,
     bool skipReconnect = false,
     DateTime? deadline,

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_malformed_frame_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_malformed_frame_test.dart
@@ -24,7 +24,6 @@ class _MalformedFrameRelay extends Relay {
   @override
   Future<bool> send(
     List<dynamic> message, {
-    bool? forceSend,
     bool queueIfFailed = true,
     bool skipReconnect = false,
     DateTime? deadline,

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_offmain_verify_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_offmain_verify_test.dart
@@ -24,7 +24,6 @@ class _FakeRelay extends Relay {
   @override
   Future<bool> send(
     List<dynamic> message, {
-    bool? forceSend,
     bool queueIfFailed = true,
     bool skipReconnect = false,
     DateTime? deadline,

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_query_settle_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_query_settle_test.dart
@@ -53,7 +53,6 @@ class _SilentRelay extends Relay {
   @override
   Future<bool> send(
     List<dynamic> message, {
-    bool? forceSend,
     bool queueIfFailed = true,
     bool skipReconnect = false,
     DateTime? deadline,

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_signature_verification_policy_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_signature_verification_policy_test.dart
@@ -24,7 +24,6 @@ class _FakeRelay extends Relay {
   @override
   Future<bool> send(
     List<dynamic> message, {
-    bool? forceSend,
     bool queueIfFailed = true,
     bool skipReconnect = false,
     DateTime? deadline,

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_temp_relay_reap_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_temp_relay_reap_test.dart
@@ -22,7 +22,6 @@ class _NeverConnectsRelay extends Relay {
   @override
   Future<bool> send(
     List<dynamic> message, {
-    bool? forceSend,
     bool queueIfFailed = true,
     bool skipReconnect = false,
     DateTime? deadline,

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_verify_dedup_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_verify_dedup_test.dart
@@ -25,7 +25,6 @@ class _FakeRelay extends Relay {
   @override
   Future<bool> send(
     List<dynamic> message, {
-    bool? forceSend,
     bool queueIfFailed = true,
     bool skipReconnect = false,
     DateTime? deadline,


### PR DESCRIPTION
## Summary

Fixes #7701: a fire-and-forget `RelayPool.send(..., tempRelays: [...])` no longer disappears when the relay wants NIP-42 first. Both halves of the issue are covered — parking a frame behind a handshake the relay has already announced, and replaying the frame that provoked the very first challenge.

## Changes

### Step 1 — park behind a known handshake

`_sendCollect`'s temp-relay loop now mirrors the configured-relay loop above it: when `alwaysAuth && !authed` and there is no deadline, the frame goes into `pendingAuthedMessages` instead of onto the socket, and `_onEvent`'s existing post-AUTH flush drains it. A parked frame counts as sent, which is what `sendRelays` documents ("or it was queued for pending-auth delivery") and what the configured loop already did — otherwise a publish whose only target parked would report failure while sitting queued for delivery.

### Step 2 — retain the first-round frame

`RelayStatus.alwaysAuth` only flips once a challenge has landed, so the first publish on a connection cannot be parked up front; it has to go out to provoke the challenge, and a fire-and-forget caller keeps no handle on it. `Relay` therefore holds the written EVENT frame, keyed by event id, and `_onEvent` replays it alongside `pendingAuthedMessages` once AUTH succeeds.

Retention is deliberately narrow:

- Only client publish frames (`["EVENT", <event>]`) are retained; REQ/CLOSE/AUTH are not.
- Only fire-and-forget publishes. A deadline-bound publish is already carried by `PublishTracker` via `_trackAuthRequiredPublish`, and retaining it as well would republish the same event twice after AUTH.
- A retained frame is released the moment the relay speaks for that event — accepted, or refused for a reason NIP-42 cannot fix — so a later unrelated AUTH cannot resurrect it.
- The map is capped at 32 entries, evicting oldest-first. It holds frames the relay has *not* answered, so a silent peer must not be able to grow it without limit.

### Releasing what a failed handshake leaves behind

`_rejectAuthRequiredPublishesForRelay` now also clears `pendingAuthedMessages` and the retained frames. A temp relay is reapable only while `pendingAuthedMessages` is empty (`_isTempRelayReapable`), so without this a relay whose handshake failed would pin its socket open for the life of the pool and grow the queue on every later publish. A fresh challenge on the same connection reopens the gate and re-parks whatever is published after it, so the loss is bounded to frames no caller is awaiting.

### Cleanup: removed the dead `forceSend` parameter

`forceSend` was declared on `Relay.send` and read by neither implementation. Removed from the abstract signature, `relay_base.dart`, `relay_isolate.dart`, the 6 call sites in `relay_pool.dart` / `nostr_remote_signer.dart`, and the 15 test doubles that still declared it.

## Testing

`mobile/packages/nostr_sdk/test/unit/relay_pool_auth_test.dart` gains a `fire-and-forget temp-relay publish across NIP-42` group plus direct coverage of the retention bounds:

- replays the first-round frame the relay answered with `auth-required`
- replays even when the relay challenges without ever answering the EVENT
- parks instead of sending once the relay is known to need auth, and sends it exactly once afterwards
- does not replay an event the relay already accepted
- does not replay an event rejected for a non-auth reason
- releases parked and retained frames when the handshake fails
- retains only the client publish frame shape, and evicts oldest-first at the cap

Six of these fail against the first revision of this branch.

Full `nostr_sdk` suite (560 tests) and `follow_repository` suite (335 tests) pass; `flutter analyze` and `dart format` clean.

## Files modified

- `mobile/packages/nostr_sdk/lib/relay/relay.dart`
- `mobile/packages/nostr_sdk/lib/relay/relay_pool.dart`
- `mobile/packages/nostr_sdk/lib/relay/relay_base.dart`
- `mobile/packages/nostr_sdk/lib/relay/relay_isolate.dart`
- `mobile/packages/nostr_sdk/lib/nip46/nostr_remote_signer.dart`
- `mobile/packages/nostr_sdk/test/unit/relay_pool_auth_test.dart` and 14 other test files (dead-parameter cleanup)

Closes #7701
