### PR TITLE
docs(bookmark-toggle): clarify publishDidNotComplete failure doc

### DIFF
--- a/mobile/lib/blocs/share_sheet/share_sheet_bloc.dart
+++ b/mobile/lib/blocs/share_sheet/share_sheet_bloc.dart
@@ -472,7 +472,9 @@ class ShareSheetBloc extends Bloc<ShareSheetEvent, ShareSheetState> {
       final result = await bookmarkService.toggleVideoInGlobalBookmarks(
         _video.id,
       );
-      if (isClosed) return;
+      if (isClosed) {
+        return;
+      }
 
       wasBookmarked = result.wasBookmarked;
       emit(
@@ -505,7 +507,9 @@ class ShareSheetBloc extends Bloc<ShareSheetEvent, ShareSheetState> {
         name: 'ShareSheetBloc',
         category: LogCategory.ui,
       );
-      if (isClosed) return;
+      if (isClosed) {
+        return;
+      }
 
       emit(
         state.copyWith(

--- a/mobile/lib/blocs/share_sheet/share_sheet_bloc.dart
+++ b/mobile/lib/blocs/share_sheet/share_sheet_bloc.dart
@@ -472,9 +472,7 @@ class ShareSheetBloc extends Bloc<ShareSheetEvent, ShareSheetState> {
       final result = await bookmarkService.toggleVideoInGlobalBookmarks(
         _video.id,
       );
-      if (isClosed) {
-        return;
-      }
+      if (isClosed) return;
 
       wasBookmarked = result.wasBookmarked;
       emit(
@@ -507,9 +505,7 @@ class ShareSheetBloc extends Bloc<ShareSheetEvent, ShareSheetState> {
         name: 'ShareSheetBloc',
         category: LogCategory.ui,
       );
-      if (isClosed) {
-        return;
-      }
+      if (isClosed) return;
 
       emit(
         state.copyWith(

--- a/mobile/lib/services/bookmark_service.dart
+++ b/mobile/lib/services/bookmark_service.dart
@@ -106,7 +106,9 @@ enum BookmarkToggleFailure {
   /// Relays were reachable but did not answer before the query deadline.
   timedOut,
 
-  /// The list reconciled, but the new version was not published.
+  /// The list reconciled, but the change failed to complete: auth
+  /// disappeared mid-flow, signing failed, a relay never sent OK, or the
+  /// publish path threw for another reason.
   publishDidNotComplete,
 
   /// There is no signed-in identity to read or publish as.

--- a/mobile/lib/services/bookmark_service.dart
+++ b/mobile/lib/services/bookmark_service.dart
@@ -107,8 +107,9 @@ enum BookmarkToggleFailure {
   timedOut,
 
   /// The list reconciled, but the change failed to complete: auth
-  /// disappeared mid-flow, signing failed, a relay never sent OK, or the
-  /// publish path threw for another reason.
+  /// disappeared mid-flow, signing failed, the private items could not
+  /// be re-encrypted, no relay accepted the publish, or the publish
+  /// path threw for another reason.
   publishDidNotComplete,
 
   /// There is no signed-in identity to read or publish as.
@@ -701,8 +702,9 @@ class BookmarkService {
       wasBookmarked: wasBookmarked,
       isBookmarked: succeeded ? !wasBookmarked : wasBookmarked,
       // The read already reconciled, so anything failing past this point is
-      // the publish leg: auth disappeared, signing failed, relay OK never came
-      // back true, or the publish path threw.
+      // the publish leg: auth disappeared, signing failed, the private items
+      // could not be re-encrypted, no relay accepted the publish, or the
+      // publish path threw.
       failure: succeeded ? null : BookmarkToggleFailure.publishDidNotComplete,
     );
   }


### PR DESCRIPTION
Closes #7721

## Summary
- Clarify the `publishDidNotComplete` enum documentation to match the failure modes represented by the implementation.

## Review resolution
- Dropped the `ShareSheetBloc` brace-only changes. The three `isClosed` guards already landed in #7141 (`e7497e4e8f`).
- Confirmed `_onSaveRequested` uses its event handler `Emitter`, which the post-close detector deliberately excludes because Bloc cancels that emitter on close.
- Confirmed `dart run scripts/lib/post_close_emit_detector.dart lib/blocs/share_sheet --detail` reports no findings.

## Test plan
- `dart format --output=none --set-exit-if-changed lib/services/bookmark_service.dart`
- `flutter analyze lib/services/bookmark_service.dart`
- `flutter test test/services/bookmark_service_test.dart` (71 tests)
- All 17 GitHub checks passed on `bb8061d3ae`, including Analyze, Format, Generated Files, Goldens, all four test shards, and semantic-pull-request.
