### PR TITLE
feat(ui): paint the green heart emoji in Divine green

### DIFF
--- a/mobile/lib/notifications/widgets/notification_comment_quote.dart
+++ b/mobile/lib/notifications/widgets/notification_comment_quote.dart
@@ -47,7 +47,7 @@ class NotificationCommentQuote extends ConsumerStatefulWidget {
 
 class _NotificationCommentQuoteState
     extends ConsumerState<NotificationCommentQuote> {
-  List<TextSpan> _currentBodySpans = const [];
+  List<InlineSpan> _currentBodySpans = const [];
 
   @override
   Widget build(BuildContext context) {
@@ -117,7 +117,7 @@ class _NotificationCommentQuoteState
     LinkifiedTextNavigation.navigateToSearch(context, username);
   }
 
-  void _replaceCurrentBodySpans(List<TextSpan> spans) {
+  void _replaceCurrentBodySpans(List<InlineSpan> spans) {
     final previousSpans = _currentBodySpans;
     _currentBodySpans = spans;
     LinkifiedTextSupport.disposeSpans(previousSpans);

--- a/mobile/lib/screens/inbox/conversation/widgets/message_bubble.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/message_bubble.dart
@@ -461,13 +461,25 @@ class _MessageTextState extends ConsumerState<_MessageText> {
     final codeStyle = VineTheme.codeFont(color: defaultStyle.color);
 
     final ast = const InlineMarkdownParser().parse(widget.message);
+    // The heart budget spans the whole message: each markdown leaf below
+    // builds its own linkifier, so a per-leaf cap would reset on every
+    // emphasis boundary (`**x**<heart>` x N would paint N SVG widgets).
+    var heartBudget = kDivineHeartMaxPainted;
     final builder = MarkdownTextSpanBuilder(
       defaultStyle: defaultStyle,
       codeStyle: codeStyle,
       codeBackgroundColor: codeBackground,
       linkStyle: referenceStyle,
-      buildPlainSpans: (text, effectiveStyle) =>
-          _buildLinkifiedPlain(text, effectiveStyle, referenceStyle),
+      buildPlainSpans: (text, effectiveStyle) {
+        final run = _buildLinkifiedPlain(
+          text,
+          effectiveStyle,
+          referenceStyle,
+          heartBudget,
+        );
+        heartBudget -= run.whereType<WidgetSpan>().length;
+        return run;
+      },
       onLinkTap: (rawUrl) => _openLink(context, rawUrl),
     );
     final spans = builder.build(ast);
@@ -482,10 +494,14 @@ class _MessageTextState extends ConsumerState<_MessageText> {
   /// Delegates plain markdown leaves to [LinkifiedTextSpanBuilder] so
   /// the linkifier's URL / @mention / #hashtag / nostr-ref pipeline
   /// runs inside markdown wrappers.
+  ///
+  /// [heartBudget] is the message-wide cap on painted brand hearts, shared
+  /// across leaves by the caller.
   List<InlineSpan> _buildLinkifiedPlain(
     String text,
     TextStyle plainStyle,
     TextStyle linkStyle,
+    int heartBudget,
   ) {
     if (text.isEmpty) return const [];
     // Apply the surrounding emphasis to linked / mentioned tokens too
@@ -508,6 +524,7 @@ class _MessageTextState extends ConsumerState<_MessageText> {
       defaultStyle: plainStyle,
       linkStyle: emphasizedLink,
       mentionStyle: emphasizedLink,
+      initialHeartBudget: heartBudget,
       videoLabel: Localizations.of<AppLocalizations>(
         context,
         AppLocalizations,

--- a/mobile/lib/screens/inbox/conversation/widgets/reaction_picker_overlay.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/reaction_picker_overlay.dart
@@ -158,7 +158,10 @@ class _EmojiButton extends StatelessWidget {
             customBorder: const CircleBorder(),
             onTap: onTap,
             child: Center(
-              child: Text(emoji, style: const TextStyle(fontSize: 28)),
+              child: DivineHeartText(
+                emoji,
+                style: const TextStyle(fontSize: 28),
+              ),
             ),
           ),
         ),

--- a/mobile/lib/screens/inbox/conversation/widgets/reactions_detail_sheet.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/reactions_detail_sheet.dart
@@ -247,7 +247,10 @@ class _Trailing extends StatelessWidget {
   Widget build(BuildContext context) {
     // Natural leading — a forced line-height drops the colour-emoji glyph low
     // on Android (see ReactionsRow emoji styling).
-    final emojiText = Text(emoji, style: const TextStyle(fontSize: 18));
+    final emojiText = DivineHeartText(
+      emoji,
+      style: const TextStyle(fontSize: 18),
+    );
     if (!isOwn) return emojiText;
 
     final Widget action;

--- a/mobile/lib/screens/inbox/conversation/widgets/reactions_row.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/reactions_row.dart
@@ -331,7 +331,7 @@ class _PoppingEmojiState extends State<_PoppingEmoji>
   Widget build(BuildContext context) {
     return ScaleTransition(
       scale: _scale,
-      child: Text(widget.emoji, style: _emojiTextStyle),
+      child: DivineHeartText(widget.emoji, style: _emojiTextStyle),
     );
   }
 }

--- a/mobile/lib/screens/inbox/widgets/conversation_tile.dart
+++ b/mobile/lib/screens/inbox/widgets/conversation_tile.dart
@@ -172,7 +172,7 @@ class ConversationTile extends ConsumerWidget {
                       Row(
                         children: [
                           Expanded(
-                            child: Text(
+                            child: DivineHeartText(
                               displayName,
                               style: VineTheme.titleMediumFont(
                                 color: context.vineColors.primaryText,

--- a/mobile/lib/screens/inbox/widgets/conversation_tile.dart
+++ b/mobile/lib/screens/inbox/widgets/conversation_tile.dart
@@ -295,7 +295,7 @@ class _ConversationPreviewText extends StatelessWidget {
         ? VineTheme.labelLargeFont(color: context.vineColors.primaryText)
         : VineTheme.bodyMediumFont(color: context.vineColors.onSurfaceVariant);
     if (!payload.isDivineVideoShare) {
-      return Text(
+      return DivineHeartText(
         payload.text,
         style: style,
         maxLines: 2,

--- a/mobile/lib/widgets/linkified_text/linkified_text.dart
+++ b/mobile/lib/widgets/linkified_text/linkified_text.dart
@@ -41,7 +41,7 @@ class LinkifiedText extends ConsumerStatefulWidget {
 }
 
 class _LinkifiedTextState extends ConsumerState<LinkifiedText> {
-  List<TextSpan> _currentSpans = const [];
+  List<InlineSpan> _currentSpans = const [];
 
   @override
   Widget build(BuildContext context) {
@@ -211,10 +211,15 @@ class _LinkifiedTextState extends ConsumerState<LinkifiedText> {
     );
   }
 
-  bool _hasClickableOrStylableToken(List<TextSpan> spans, TextStyle style) =>
-      spans.any((span) => span.recognizer != null || span.style != style);
+  /// A non-[TextSpan] — today a brand-green heart — cannot be painted by the
+  /// plain `Text` fast path, so its presence alone forces the rich path.
+  bool _hasClickableOrStylableToken(List<InlineSpan> spans, TextStyle style) =>
+      spans.any(
+        (span) =>
+            span is! TextSpan || span.recognizer != null || span.style != style,
+      );
 
-  void _replaceCurrentSpans(List<TextSpan> spans) {
+  void _replaceCurrentSpans(List<InlineSpan> spans) {
     final previousSpans = _currentSpans;
     _currentSpans = spans;
     LinkifiedTextSupport.disposeSpans(previousSpans);

--- a/mobile/lib/widgets/linkified_text/linkified_text_span_builder.dart
+++ b/mobile/lib/widgets/linkified_text/linkified_text_span_builder.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/painting.dart';
+import 'package:flutter/widgets.dart' show WidgetSpan;
 import 'package:nostr_sdk/nip19/nip19.dart';
 import 'package:nostr_sdk/nip19/nip19_tlv.dart';
 import 'package:openvine/utils/npub_hex.dart';
@@ -107,10 +108,19 @@ class LinkifiedTextSpanBuilder {
     final safeText = sanitizeUtf16(text);
     final spans = <InlineSpan>[];
     var lastEnd = 0;
+    // The heart budget is shared across every run of one build: the splitter
+    // is invoked once per plain run between tokens, so a per-run cap would
+    // let an interleaved note (one heart per hashtag, say) reset it to full.
+    var heartBudget = kDivineHeartMaxPainted;
 
     for (final match in _combinedRegex.allMatches(safeText)) {
       if (match.start > lastEnd) {
-        spans.addAll(_plainSpans(safeText.substring(lastEnd, match.start)));
+        final run = _plainSpans(
+          safeText.substring(lastEnd, match.start),
+          heartBudget,
+        );
+        heartBudget -= run.whereType<WidgetSpan>().length;
+        spans.addAll(run);
       }
 
       final matchedUrl = match.group(1);
@@ -120,7 +130,9 @@ class LinkifiedTextSpanBuilder {
       final plainMention = match.group(5);
 
       if (matchedUrl != null) {
-        spans.addAll(_buildUrlSpans(matchedUrl));
+        final urlSpans = _buildUrlSpans(matchedUrl, heartBudget);
+        heartBudget -= urlSpans.whereType<WidgetSpan>().length;
+        spans.addAll(urlSpans);
       } else if (hashtag != null) {
         spans.add(_buildHashtagSpan(hashtag));
       } else if (nostrId != null) {
@@ -135,10 +147,12 @@ class LinkifiedTextSpanBuilder {
     }
 
     if (lastEnd < safeText.length) {
-      spans.addAll(_plainSpans(safeText.substring(lastEnd)));
+      final run = _plainSpans(safeText.substring(lastEnd), heartBudget);
+      heartBudget -= run.whereType<WidgetSpan>().length;
+      spans.addAll(run);
     }
 
-    if (spans.isEmpty) return _plainSpans(safeText);
+    if (spans.isEmpty) return _plainSpans(safeText, heartBudget);
     return spans;
   }
 
@@ -146,12 +160,21 @@ class LinkifiedTextSpanBuilder {
   /// brand green rather than the platform emoji font's own green — unless
   /// [allowWidgetSpans] is false, for surfaces where a widget span cannot
   /// survive, such as selectable text.
-  List<InlineSpan> _plainSpans(String value) {
-    if (!allowWidgetSpans) return [TextSpan(text: value, style: defaultStyle)];
-    return divineHeartSpans(value, style: defaultStyle);
+  ///
+  /// [heartBudget] is the shared per-build cap on painted hearts; past it,
+  /// hearts stay on the platform emoji font.
+  List<InlineSpan> _plainSpans(String value, int heartBudget) {
+    if (!allowWidgetSpans || heartBudget == 0) {
+      return [TextSpan(text: value, style: defaultStyle)];
+    }
+    return divineHeartSpans(
+      value,
+      style: defaultStyle,
+      maxPainted: heartBudget,
+    );
   }
 
-  List<InlineSpan> _buildUrlSpans(String matchedUrl) {
+  List<InlineSpan> _buildUrlSpans(String matchedUrl, int heartBudget) {
     final linkText = _trimTrailingUrlPunctuation(matchedUrl);
     final trailingText = matchedUrl.substring(linkText.length);
     return [
@@ -164,7 +187,7 @@ class LinkifiedTextSpanBuilder {
             if (callback != null) unawaited(callback(linkText));
           },
       ),
-      if (trailingText.isNotEmpty) ..._plainSpans(trailingText),
+      if (trailingText.isNotEmpty) ..._plainSpans(trailingText, heartBudget),
     ];
   }
 

--- a/mobile/lib/widgets/linkified_text/linkified_text_span_builder.dart
+++ b/mobile/lib/widgets/linkified_text/linkified_text_span_builder.dart
@@ -41,6 +41,7 @@ class LinkifiedTextSpanBuilder {
     this.profilePubkeyForMention,
     this.videoLabel,
     this.allowWidgetSpans = true,
+    this.initialHeartBudget = kDivineHeartMaxPainted,
   });
 
   static final _combinedRegex = RegExp(
@@ -95,6 +96,14 @@ class LinkifiedTextSpanBuilder {
   /// the character. Selectable callers pass false to keep copied text intact.
   final bool allowWidgetSpans;
 
+  /// Starting budget of brand-green hearts one [build] may paint as widgets.
+  ///
+  /// Callers that run one builder per fragment of a larger string (the DM
+  /// markdown path builds one per leaf) pass the remaining budget down from
+  /// the fragment's owner, so the cap bounds the whole rendered message
+  /// rather than each fragment.
+  final int initialHeartBudget;
+
   /// Builds spans preserving the token precedence from [LinkifiedText].
   ///
   /// Unpaired UTF-16 surrogates are normalized here rather than at each
@@ -111,7 +120,7 @@ class LinkifiedTextSpanBuilder {
     // The heart budget is shared across every run of one build: the splitter
     // is invoked once per plain run between tokens, so a per-run cap would
     // let an interleaved note (one heart per hashtag, say) reset it to full.
-    var heartBudget = kDivineHeartMaxPainted;
+    var heartBudget = initialHeartBudget;
 
     for (final match in _combinedRegex.allMatches(safeText)) {
       if (match.start > lastEnd) {

--- a/mobile/lib/widgets/linkified_text/linkified_text_span_builder.dart
+++ b/mobile/lib/widgets/linkified_text/linkified_text_span_builder.dart
@@ -39,6 +39,7 @@ class LinkifiedTextSpanBuilder {
     this.profileLabelForHex,
     this.profilePubkeyForMention,
     this.videoLabel,
+    this.allowWidgetSpans = true,
   });
 
   static final _combinedRegex = RegExp(
@@ -84,6 +85,14 @@ class LinkifiedTextSpanBuilder {
 
   /// Display label for video/event references.
   final String? videoLabel;
+
+  /// Whether plain runs may be split into non-text spans — today, the
+  /// brand-green heart.
+  ///
+  /// Selectable text seeds its editing controller from the span plain text,
+  /// where a [WidgetSpan] contributes U+FFFC, so a copied run silently loses
+  /// the character. Selectable callers pass false to keep copied text intact.
+  final bool allowWidgetSpans;
 
   /// Builds spans preserving the token precedence from [LinkifiedText].
   ///
@@ -134,9 +143,13 @@ class LinkifiedTextSpanBuilder {
   }
 
   /// Plain runs are split on the green heart so Divine paints it in the
-  /// brand green rather than the platform emoji font's own green.
-  List<InlineSpan> _plainSpans(String value) =>
-      divineHeartSpans(value, style: defaultStyle);
+  /// brand green rather than the platform emoji font's own green — unless
+  /// [allowWidgetSpans] is false, for surfaces where a widget span cannot
+  /// survive, such as selectable text.
+  List<InlineSpan> _plainSpans(String value) {
+    if (!allowWidgetSpans) return [TextSpan(text: value, style: defaultStyle)];
+    return divineHeartSpans(value, style: defaultStyle);
+  }
 
   List<InlineSpan> _buildUrlSpans(String matchedUrl) {
     final linkText = _trimTrailingUrlPunctuation(matchedUrl);

--- a/mobile/lib/widgets/linkified_text/linkified_text_span_builder.dart
+++ b/mobile/lib/widgets/linkified_text/linkified_text_span_builder.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/painting.dart';
 import 'package:nostr_sdk/nip19/nip19.dart';
@@ -93,14 +94,14 @@ class LinkifiedTextSpanBuilder {
   /// references. This is the one point every span passes through, so guarding
   /// it covers both. Sanitizing is code-unit-for-code-unit, so match offsets
   /// stay valid.
-  List<TextSpan> build() {
+  List<InlineSpan> build() {
     final safeText = sanitizeUtf16(text);
-    final spans = <TextSpan>[];
+    final spans = <InlineSpan>[];
     var lastEnd = 0;
 
     for (final match in _combinedRegex.allMatches(safeText)) {
       if (match.start > lastEnd) {
-        spans.add(_plainSpan(safeText.substring(lastEnd, match.start)));
+        spans.addAll(_plainSpans(safeText.substring(lastEnd, match.start)));
       }
 
       final matchedUrl = match.group(1);
@@ -125,17 +126,19 @@ class LinkifiedTextSpanBuilder {
     }
 
     if (lastEnd < safeText.length) {
-      spans.add(_plainSpan(safeText.substring(lastEnd)));
+      spans.addAll(_plainSpans(safeText.substring(lastEnd)));
     }
 
-    if (spans.isEmpty) return [_plainSpan(safeText)];
+    if (spans.isEmpty) return _plainSpans(safeText);
     return spans;
   }
 
-  TextSpan _plainSpan(String value) =>
-      TextSpan(text: value, style: defaultStyle);
+  /// Plain runs are split on the green heart so Divine paints it in the
+  /// brand green rather than the platform emoji font's own green.
+  List<InlineSpan> _plainSpans(String value) =>
+      divineHeartSpans(value, style: defaultStyle);
 
-  List<TextSpan> _buildUrlSpans(String matchedUrl) {
+  List<InlineSpan> _buildUrlSpans(String matchedUrl) {
     final linkText = _trimTrailingUrlPunctuation(matchedUrl);
     final trailingText = matchedUrl.substring(linkText.length);
     return [
@@ -148,7 +151,7 @@ class LinkifiedTextSpanBuilder {
             if (callback != null) unawaited(callback(linkText));
           },
       ),
-      if (trailingText.isNotEmpty) _plainSpan(trailingText),
+      if (trailingText.isNotEmpty) ..._plainSpans(trailingText),
     ];
   }
 

--- a/mobile/lib/widgets/linkified_text/selectable_linkified_text.dart
+++ b/mobile/lib/widgets/linkified_text/selectable_linkified_text.dart
@@ -75,6 +75,9 @@ class _SelectableLinkifiedTextState
       onVideoTap: (routeReference) => _navigateToVideo(context, routeReference),
       onMentionTap: (username) => _navigateToMention(context, username),
       onUrlTap: _handleUrlTap,
+      // A WidgetSpan seeds the editing controller with U+FFFC, so a copied
+      // bio would lose the character. Copy fidelity over brand color here.
+      allowWidgetSpans: false,
     ).build();
 
     if (!_hasClickableOrStylableToken(spans, defaultStyle)) {
@@ -143,8 +146,10 @@ class _SelectableLinkifiedTextState
     );
   }
 
-  /// A non-[TextSpan] — today a brand-green heart — cannot be painted by the
-  /// plain `SelectableText` fast path, so its presence forces the rich path.
+  /// Defensive: a non-[TextSpan] cannot be painted by the plain
+  /// `SelectableText` fast path. None is emitted for this widget today — the
+  /// builder runs with `allowWidgetSpans: false` — but if one ever arrives it
+  /// takes the rich path rather than being dropped.
   bool _hasClickableOrStylableToken(List<InlineSpan> spans, TextStyle style) =>
       spans.any(
         (span) =>

--- a/mobile/lib/widgets/linkified_text/selectable_linkified_text.dart
+++ b/mobile/lib/widgets/linkified_text/selectable_linkified_text.dart
@@ -35,7 +35,7 @@ class SelectableLinkifiedText extends ConsumerStatefulWidget {
 
 class _SelectableLinkifiedTextState
     extends ConsumerState<SelectableLinkifiedText> {
-  List<TextSpan> _currentSpans = const [];
+  List<InlineSpan> _currentSpans = const [];
 
   @override
   Widget build(BuildContext context) {
@@ -143,10 +143,15 @@ class _SelectableLinkifiedTextState
     );
   }
 
-  bool _hasClickableOrStylableToken(List<TextSpan> spans, TextStyle style) =>
-      spans.any((span) => span.recognizer != null || span.style != style);
+  /// A non-[TextSpan] — today a brand-green heart — cannot be painted by the
+  /// plain `SelectableText` fast path, so its presence forces the rich path.
+  bool _hasClickableOrStylableToken(List<InlineSpan> spans, TextStyle style) =>
+      spans.any(
+        (span) =>
+            span is! TextSpan || span.recognizer != null || span.style != style,
+      );
 
-  void _replaceCurrentSpans(List<TextSpan> spans) {
+  void _replaceCurrentSpans(List<InlineSpan> spans) {
     final previousSpans = _currentSpans;
     _currentSpans = spans;
     LinkifiedTextSupport.disposeSpans(previousSpans);

--- a/mobile/lib/widgets/user_name.dart
+++ b/mobile/lib/widgets/user_name.dart
@@ -172,7 +172,7 @@ class UserName extends ConsumerWidget {
                   style: textStyle,
                   maxLines: maxLines ?? 1,
                 )
-              : Text(
+              : DivineHeartText(
                   displayName,
                   style: textStyle,
                   maxLines: maxLines ?? 1,

--- a/mobile/lib/widgets/video_feed_item/reel_dm_reply_bar.dart
+++ b/mobile/lib/widgets/video_feed_item/reel_dm_reply_bar.dart
@@ -805,7 +805,10 @@ class _ReactionEmojiButtonState extends State<_ReactionEmojiButton>
           child: Center(
             child: ScaleTransition(
               scale: _scale,
-              child: Text(widget.emoji, style: const TextStyle(fontSize: 28)),
+              child: DivineHeartText(
+                widget.emoji,
+                style: const TextStyle(fontSize: 28),
+              ),
             ),
           ),
         ),

--- a/mobile/lib/widgets/video_feed_item/video_feed_item.dart
+++ b/mobile/lib/widgets/video_feed_item/video_feed_item.dart
@@ -364,7 +364,7 @@ class VideoOverlayActions extends ConsumerWidget {
                                             .videoAuthorSemanticLabel(
                                               displayName,
                                             ),
-                                        child: Text(
+                                        child: DivineHeartText(
                                           displayName,
                                           style: VineTheme.titleSmallFont(
                                             color: VineTheme.whiteText,

--- a/mobile/lib/widgets/video_feed_item/video_feed_item.dart
+++ b/mobile/lib/widgets/video_feed_item/video_feed_item.dart
@@ -453,7 +453,7 @@ class VideoOverlayActions extends ConsumerWidget {
                                 onInteracted?.call();
                                 MetadataExpandedSheet.show(context, video);
                               },
-                        child: Text(
+                        child: DivineHeartText(
                           titleText,
                           style: VineTheme.labelMediumFont(
                             color: VineTheme.whiteText,

--- a/mobile/packages/divine_ui/lib/divine_ui.dart
+++ b/mobile/packages/divine_ui/lib/divine_ui.dart
@@ -5,6 +5,7 @@ export 'src/button/button.dart';
 export 'src/checkbox/checkbox.dart';
 export 'src/divine_snackbar_container.dart';
 export 'src/emoji/divine_heart_spans.dart';
+export 'src/emoji/divine_heart_text.dart';
 export 'src/icon/icon.dart';
 export 'src/info_card/info_card.dart';
 export 'src/list_tile/list_tile.dart';

--- a/mobile/packages/divine_ui/lib/divine_ui.dart
+++ b/mobile/packages/divine_ui/lib/divine_ui.dart
@@ -4,6 +4,7 @@ export 'src/bottom_sheet/bottom_sheet.dart';
 export 'src/button/button.dart';
 export 'src/checkbox/checkbox.dart';
 export 'src/divine_snackbar_container.dart';
+export 'src/emoji/divine_heart_spans.dart';
 export 'src/icon/icon.dart';
 export 'src/info_card/info_card.dart';
 export 'src/list_tile/list_tile.dart';

--- a/mobile/packages/divine_ui/lib/src/emoji/divine_heart_spans.dart
+++ b/mobile/packages/divine_ui/lib/src/emoji/divine_heart_spans.dart
@@ -1,0 +1,55 @@
+// ABOUTME: Paints the green-heart codepoint in Divine's brand green instead
+// ABOUTME: of the platform emoji font's own green, for user-authored text.
+
+import 'package:divine_ui/src/icon/divine_icon.dart';
+import 'package:divine_ui/src/theme/vine_theme.dart';
+import 'package:flutter/widgets.dart';
+
+/// The green heart Divine paints in [VineTheme.vineGreen].
+///
+/// Divine keeps publishing this standard codepoint, so other clients still
+/// render a green heart of their own; only the local painting changes.
+const String divineGreenHeart = '\u{1F49A}';
+
+/// Heart size as a multiple of the surrounding run's font size.
+///
+/// Emoji glyphs sit slightly larger than their nominal point size, so a 1:1
+/// heart reads as undersized beside the text it replaces.
+const double kDivineHeartFontScale = 1.2;
+
+/// Size assumed for a run whose style carries no explicit font size.
+const double kDivineHeartFallbackFontSize = 14;
+
+/// Splits [text] on [divineGreenHeart], painting each occurrence as a
+/// brand-green heart and leaving every other character to the platform.
+///
+/// Returns a single [TextSpan] when [text] holds no green heart, so callers
+/// pay nothing on the common path.
+List<InlineSpan> divineHeartSpans(String text, {required TextStyle style}) {
+  if (!text.contains(divineGreenHeart)) {
+    return [TextSpan(text: text, style: style)];
+  }
+
+  final size =
+      (style.fontSize ?? kDivineHeartFallbackFontSize) * kDivineHeartFontScale;
+  final spans = <InlineSpan>[];
+
+  for (final (index, segment) in text.split(divineGreenHeart).indexed) {
+    if (index > 0) spans.add(_heartSpan(size));
+    if (segment.isNotEmpty) spans.add(TextSpan(text: segment, style: style));
+  }
+
+  return spans;
+}
+
+InlineSpan _heartSpan(double size) => WidgetSpan(
+  alignment: PlaceholderAlignment.middle,
+  child: Semantics(
+    label: divineGreenHeart,
+    child: DivineIcon(
+      icon: DivineIconName.heartFill,
+      size: size,
+      color: VineTheme.vineGreen,
+    ),
+  ),
+);

--- a/mobile/packages/divine_ui/lib/src/emoji/divine_heart_spans.dart
+++ b/mobile/packages/divine_ui/lib/src/emoji/divine_heart_spans.dart
@@ -11,7 +11,7 @@ import 'package:flutter/widgets.dart';
 /// render a green heart of their own; only the local painting changes.
 const String divineGreenHeart = '\u{1F49A}';
 
-/// Heart size as a multiple of the surrounding run's font size.
+/// Heart size as a multiple of the surrounding run's scaled font size.
 ///
 /// Emoji glyphs sit slightly larger than their nominal point size, so a 1:1
 /// heart reads as undersized beside the text it replaces.
@@ -30,26 +30,42 @@ List<InlineSpan> divineHeartSpans(String text, {required TextStyle style}) {
     return [TextSpan(text: text, style: style)];
   }
 
-  final size =
-      (style.fontSize ?? kDivineHeartFallbackFontSize) * kDivineHeartFontScale;
+  final fontSize = style.fontSize ?? kDivineHeartFallbackFontSize;
   final spans = <InlineSpan>[];
 
   for (final (index, segment) in text.split(divineGreenHeart).indexed) {
-    if (index > 0) spans.add(_heartSpan(size));
+    if (index > 0) spans.add(_heartSpan(fontSize));
     if (segment.isNotEmpty) spans.add(TextSpan(text: segment, style: style));
   }
 
   return spans;
 }
 
-InlineSpan _heartSpan(double size) => WidgetSpan(
+InlineSpan _heartSpan(double fontSize) => WidgetSpan(
   alignment: PlaceholderAlignment.middle,
   child: Semantics(
     label: divineGreenHeart,
-    child: DivineIcon(
-      icon: DivineIconName.heartFill,
-      size: size,
-      color: VineTheme.vineGreen,
-    ),
+    child: _DivineHeartGlyph(fontSize: fontSize),
   ),
 );
+
+/// The heart glyph, sized off the run's *scaled* font size.
+///
+/// A [WidgetSpan] child is laid out at its own intrinsic size, so the text
+/// scaler that grows the surrounding run never reaches it. Reading the scaler
+/// here keeps the heart in proportion at every accessibility font size
+/// instead of shrinking to a dot beside doubled text.
+class _DivineHeartGlyph extends StatelessWidget {
+  const _DivineHeartGlyph({required this.fontSize});
+
+  final double fontSize;
+
+  @override
+  Widget build(BuildContext context) => DivineIcon(
+    icon: DivineIconName.heartFill,
+    size:
+        MediaQuery.textScalerOf(context).scale(fontSize) *
+        kDivineHeartFontScale,
+    color: VineTheme.vineGreen,
+  );
+}

--- a/mobile/packages/divine_ui/lib/src/emoji/divine_heart_spans.dart
+++ b/mobile/packages/divine_ui/lib/src/emoji/divine_heart_spans.dart
@@ -20,6 +20,14 @@ const double kDivineHeartFontScale = 1.2;
 /// Size assumed for a run whose style carries no explicit font size.
 const double kDivineHeartFallbackFontSize = 14;
 
+/// The most hearts painted as brand-green widgets in a single run.
+///
+/// Each painted heart is a real widget — an SVG-backed [DivineIcon] — and
+/// user-authored text is arbitrary remote content, so an uncapped split is a
+/// jank vector a note author controls for free. Past the cap, remaining
+/// hearts fall back to the platform emoji font.
+const int kDivineHeartMaxPainted = 32;
+
 /// Splits [text] on [divineGreenHeart], painting each occurrence as a
 /// brand-green heart and leaving every other character to the platform.
 ///
@@ -33,11 +41,25 @@ List<InlineSpan> divineHeartSpans(String text, {required TextStyle style}) {
   final fontSize = style.fontSize ?? kDivineHeartFallbackFontSize;
   final spans = <InlineSpan>[];
 
-  for (final (index, segment) in text.split(divineGreenHeart).indexed) {
-    if (index > 0) spans.add(_heartSpan(fontSize));
+  var rest = text;
+  var painted = 0;
+  while (painted < kDivineHeartMaxPainted) {
+    final index = rest.indexOf(divineGreenHeart);
+    if (index < 0) break;
+
+    final segment = rest.substring(0, index);
     if (segment.isNotEmpty) spans.add(TextSpan(text: segment, style: style));
+    spans.add(_heartSpan(fontSize));
+    painted++;
+
+    rest = rest.substring(index + divineGreenHeart.length);
+    // A VS16 (U+FE0F) after a painted heart has no base character left and
+    // would apply to whatever follows it. Hearts left to the platform font
+    // keep theirs — there it is the standard emoji presentation sequence.
+    if (rest.startsWith('\u{FE0F}')) rest = rest.substring(1);
   }
 
+  if (rest.isNotEmpty) spans.add(TextSpan(text: rest, style: style));
   return spans;
 }
 

--- a/mobile/packages/divine_ui/lib/src/emoji/divine_heart_spans.dart
+++ b/mobile/packages/divine_ui/lib/src/emoji/divine_heart_spans.dart
@@ -33,8 +33,17 @@ const int kDivineHeartMaxPainted = 32;
 ///
 /// Returns a single [TextSpan] when [text] holds no green heart, so callers
 /// pay nothing on the common path.
-List<InlineSpan> divineHeartSpans(String text, {required TextStyle style}) {
-  if (!text.contains(divineGreenHeart)) {
+///
+/// [maxPainted] bounds how many hearts this call turns into widgets; the
+/// rest stay on the platform font. Callers that split one string into
+/// several runs (the linkifier) must thread a shared budget through it —
+/// a per-call default would reset on every run.
+List<InlineSpan> divineHeartSpans(
+  String text, {
+  required TextStyle style,
+  int maxPainted = kDivineHeartMaxPainted,
+}) {
+  if (!text.contains(divineGreenHeart) || maxPainted <= 0) {
     return [TextSpan(text: text, style: style)];
   }
 
@@ -43,7 +52,7 @@ List<InlineSpan> divineHeartSpans(String text, {required TextStyle style}) {
 
   var rest = text;
   var painted = 0;
-  while (painted < kDivineHeartMaxPainted) {
+  while (painted < maxPainted) {
     final index = rest.indexOf(divineGreenHeart);
     if (index < 0) break;
 

--- a/mobile/packages/divine_ui/lib/src/emoji/divine_heart_spans.dart
+++ b/mobile/packages/divine_ui/lib/src/emoji/divine_heart_spans.dart
@@ -51,21 +51,29 @@ InlineSpan _heartSpan(double fontSize) => WidgetSpan(
 
 /// The heart glyph, sized off the run's *scaled* font size.
 ///
-/// A [WidgetSpan] child is laid out at its own intrinsic size, so the text
-/// scaler that grows the surrounding run never reaches it. Reading the scaler
-/// here keeps the heart in proportion at every accessibility font size
-/// instead of shrinking to a dot beside doubled text.
+/// A [WidgetSpan] child is laid out at its own intrinsic size, so the run's
+/// font size arrives here unscaled — hence the explicit scaler read. Chrome
+/// caps how far it grows; a glyph standing in for a character must not, so
+/// this tracks the run 1:1 rather than [DivineIcon.maxScaleFactor].
 class _DivineHeartGlyph extends StatelessWidget {
   const _DivineHeartGlyph({required this.fontSize});
 
   final double fontSize;
 
   @override
-  Widget build(BuildContext context) => DivineIcon(
-    icon: DivineIconName.heartFill,
-    size:
+  Widget build(BuildContext context) {
+    final size =
         MediaQuery.textScalerOf(context).scale(fontSize) *
-        kDivineHeartFontScale,
-    color: VineTheme.vineGreen,
-  );
+        kDivineHeartFontScale;
+
+    // [DivineIcon] scales `size` by the ambient scaler itself, which would
+    // apply it a second time on top of the one already baked into [size].
+    return MediaQuery.withNoTextScaling(
+      child: DivineIcon(
+        icon: DivineIconName.heartFill,
+        size: size,
+        color: VineTheme.vineGreen,
+      ),
+    );
+  }
 }

--- a/mobile/packages/divine_ui/lib/src/emoji/divine_heart_text.dart
+++ b/mobile/packages/divine_ui/lib/src/emoji/divine_heart_text.dart
@@ -1,0 +1,55 @@
+// ABOUTME: Drop-in Text replacement that paints U+1F49A in the Divine brand
+// ABOUTME: green, for surfaces that do not route through the linkifier.
+
+import 'package:divine_ui/src/emoji/divine_heart_spans.dart';
+import 'package:flutter/widgets.dart';
+
+/// Renders [text], painting any [divineGreenHeart] in the Divine brand green.
+///
+/// Behaves like [Text] for every other character. Use this on surfaces that
+/// carry user-authored content but do not go through the linkifier — display
+/// names, reaction glyphs, titles, list previews.
+class DivineHeartText extends StatelessWidget {
+  /// Creates a heart-aware [Text].
+  const DivineHeartText(
+    this.text, {
+    this.style,
+    this.maxLines,
+    this.overflow,
+    this.textAlign,
+    super.key,
+  });
+
+  /// The text to render.
+  final String text;
+
+  /// Style for the text, merged over the inherited [DefaultTextStyle].
+  ///
+  /// The merged font size also drives the heart's size, so the glyph tracks
+  /// whatever the surrounding run resolves to.
+  final TextStyle? style;
+
+  /// Maximum lines before [overflow] applies.
+  final int? maxLines;
+
+  /// How visual overflow is handled.
+  final TextOverflow? overflow;
+
+  /// Horizontal alignment of the text.
+  final TextAlign? textAlign;
+
+  @override
+  Widget build(BuildContext context) {
+    final effectiveStyle = DefaultTextStyle.of(context).style.merge(style);
+
+    return Text.rich(
+      TextSpan(children: divineHeartSpans(text, style: effectiveStyle)),
+      // Carried on the Text as well as the spans so this stays a drop-in
+      // replacement: callers and tests still read [Text.style].
+      style: style,
+      maxLines: maxLines,
+      overflow: overflow,
+      textAlign: textAlign,
+    );
+  }
+}

--- a/mobile/packages/divine_ui/test/src/emoji/divine_heart_spans_test.dart
+++ b/mobile/packages/divine_ui/test/src/emoji/divine_heart_spans_test.dart
@@ -121,6 +121,28 @@ void main() {
       expect(icon.size, kDivineHeartFallbackFontSize * kDivineHeartFontScale);
     });
 
+    testWidgets('grows the heart with the text scaler', (tester) async {
+      // A WidgetSpan child is laid out at its intrinsic size, so the scaler
+      // that doubles the surrounding run does not reach the glyph on its own.
+      // Without scaling here the heart shrinks to a dot beside large text.
+      final spans = divineHeartSpans(
+        divineGreenHeart,
+        style: const TextStyle(fontSize: 16),
+      );
+
+      await tester.pumpWidget(
+        MediaQuery(
+          data: const MediaQueryData(textScaler: TextScaler.linear(2)),
+          child: MaterialApp(
+            home: Scaffold(body: Text.rich(TextSpan(children: spans))),
+          ),
+        ),
+      );
+
+      final icon = tester.widget<DivineIcon>(find.byType(DivineIcon));
+      expect(icon.size, 16 * 2 * kDivineHeartFontScale);
+    });
+
     testWidgets('keeps the heart readable to screen readers', (tester) async {
       final handle = tester.ensureSemantics();
       final spans = divineHeartSpans(divineGreenHeart, style: style);

--- a/mobile/packages/divine_ui/test/src/emoji/divine_heart_spans_test.dart
+++ b/mobile/packages/divine_ui/test/src/emoji/divine_heart_spans_test.dart
@@ -139,8 +139,40 @@ void main() {
         ),
       );
 
-      final icon = tester.widget<DivineIcon>(find.byType(DivineIcon));
-      expect(icon.size, 16 * 2 * kDivineHeartFontScale);
+      // Measured, not read off the constructor. DivineIcon scales `size` by
+      // the ambient scaler again, so asserting `icon.size` stays green even
+      // when the glyph paints 1.3x larger than it was asked for.
+      expect(
+        tester.getSize(find.byType(DivineIcon)).width,
+        16 * 2 * kDivineHeartFontScale,
+      );
+    });
+
+    testWidgets('pins the heart under MediaQuery.withNoTextScaling', (
+      tester,
+    ) async {
+      final spans = divineHeartSpans(
+        divineGreenHeart,
+        style: const TextStyle(fontSize: 16),
+      );
+
+      await tester.pumpWidget(
+        MediaQuery(
+          data: const MediaQueryData(textScaler: TextScaler.linear(2)),
+          child: MaterialApp(
+            home: Scaffold(
+              body: MediaQuery.withNoTextScaling(
+                child: Text.rich(TextSpan(children: spans)),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(
+        tester.getSize(find.byType(DivineIcon)).width,
+        16 * kDivineHeartFontScale,
+      );
     });
 
     testWidgets('keeps the heart readable to screen readers', (tester) async {

--- a/mobile/packages/divine_ui/test/src/emoji/divine_heart_spans_test.dart
+++ b/mobile/packages/divine_ui/test/src/emoji/divine_heart_spans_test.dart
@@ -73,6 +73,47 @@ void main() {
       expect((spans[1] as TextSpan).text, '!');
     });
 
+    test('consumes an orphaned VS16 after a painted heart', () {
+      // U+1F49A U+FE0F is the explicit emoji presentation sequence. Once the
+      // heart is a widget the VS16 has no base character; leaving it would
+      // apply it to whatever follows.
+      final spans = divineHeartSpans(
+        'a$divineGreenHeart\u{FE0F}b',
+        style: style,
+      );
+
+      expect(spans, hasLength(3));
+      expect((spans[0] as TextSpan).text, 'a');
+      expect(spans[1], isA<WidgetSpan>());
+      expect((spans[2] as TextSpan).text, 'b');
+    });
+
+    test('caps the painted hearts and leaves the rest to the platform', () {
+      // Each painted heart is a real SVG widget on arbitrary remote text, so
+      // the count must stay bounded no matter what a note contains.
+      final spans = divineHeartSpans(
+        divineGreenHeart * (kDivineHeartMaxPainted + 2),
+        style: style,
+      );
+
+      expect(spans.whereType<WidgetSpan>(), hasLength(kDivineHeartMaxPainted));
+      expect(spans.last, isA<TextSpan>());
+      expect(
+        (spans.last as TextSpan).text,
+        divineGreenHeart * 2,
+      );
+    });
+
+    test('keeps the VS16 on hearts left to the platform font', () {
+      final spans = divineHeartSpans(
+        '${divineGreenHeart * kDivineHeartMaxPainted}$divineGreenHeart\u{FE0F}',
+        style: style,
+      );
+
+      expect(spans.last, isA<TextSpan>());
+      expect((spans.last as TextSpan).text, '$divineGreenHeart\u{FE0F}');
+    });
+
     testWidgets('paints the heart in the Divine brand green', (tester) async {
       final spans = divineHeartSpans(divineGreenHeart, style: style);
 

--- a/mobile/packages/divine_ui/test/src/emoji/divine_heart_spans_test.dart
+++ b/mobile/packages/divine_ui/test/src/emoji/divine_heart_spans_test.dart
@@ -1,0 +1,142 @@
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const style = TextStyle(fontSize: 16);
+
+  group('divineGreenHeart', () {
+    test('is U+1F49A', () {
+      expect(divineGreenHeart, '\u{1F49A}');
+      expect(divineGreenHeart.runes.single, 0x1F49A);
+    });
+  });
+
+  group('divineHeartSpans', () {
+    test('returns a single text span when the text has no green heart', () {
+      final spans = divineHeartSpans('plain text', style: style);
+
+      expect(spans, hasLength(1));
+      expect(spans.single, isA<TextSpan>());
+      expect((spans.single as TextSpan).text, 'plain text');
+      expect((spans.single as TextSpan).style, style);
+    });
+
+    test('returns a single text span for empty text', () {
+      final spans = divineHeartSpans('', style: style);
+
+      expect(spans, hasLength(1));
+      expect((spans.single as TextSpan).text, '');
+    });
+
+    test('replaces a lone green heart with a widget span', () {
+      final spans = divineHeartSpans(divineGreenHeart, style: style);
+
+      expect(spans, hasLength(1));
+      expect(spans.single, isA<WidgetSpan>());
+    });
+
+    test('keeps the surrounding text around a green heart', () {
+      final spans = divineHeartSpans(
+        'love $divineGreenHeart you',
+        style: style,
+      );
+
+      expect(spans, hasLength(3));
+      expect((spans[0] as TextSpan).text, 'love ');
+      expect(spans[1], isA<WidgetSpan>());
+      expect((spans[2] as TextSpan).text, ' you');
+    });
+
+    test('replaces every occurrence', () {
+      final spans = divineHeartSpans(
+        '$divineGreenHeart$divineGreenHeart',
+        style: style,
+      );
+
+      expect(spans, hasLength(2));
+      expect(spans.every((s) => s is WidgetSpan), isTrue);
+    });
+
+    test('leaves other heart emoji untouched', () {
+      final spans = divineHeartSpans('❤️ and \u{1F499}', style: style);
+
+      expect(spans, hasLength(1));
+      expect(spans.single, isA<TextSpan>());
+    });
+
+    test('does not emit empty text spans at the edges', () {
+      final spans = divineHeartSpans('$divineGreenHeart!', style: style);
+
+      expect(spans, hasLength(2));
+      expect(spans[0], isA<WidgetSpan>());
+      expect((spans[1] as TextSpan).text, '!');
+    });
+
+    testWidgets('paints the heart in the Divine brand green', (tester) async {
+      final spans = divineHeartSpans(divineGreenHeart, style: style);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: Text.rich(TextSpan(children: spans))),
+        ),
+      );
+
+      final icon = tester.widget<DivineIcon>(find.byType(DivineIcon));
+      expect(icon.icon, DivineIconName.heartFill);
+      expect(icon.color, VineTheme.vineGreen);
+    });
+
+    testWidgets('sizes the heart from the run font size', (tester) async {
+      final spans = divineHeartSpans(
+        divineGreenHeart,
+        style: const TextStyle(fontSize: 20),
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: Text.rich(TextSpan(children: spans))),
+        ),
+      );
+
+      final icon = tester.widget<DivineIcon>(find.byType(DivineIcon));
+      expect(icon.size, 20 * kDivineHeartFontScale);
+    });
+
+    testWidgets('falls back to a default size when the style has none', (
+      tester,
+    ) async {
+      final spans = divineHeartSpans(
+        divineGreenHeart,
+        style: const TextStyle(),
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: Text.rich(TextSpan(children: spans))),
+        ),
+      );
+
+      final icon = tester.widget<DivineIcon>(find.byType(DivineIcon));
+      expect(icon.size, kDivineHeartFallbackFontSize * kDivineHeartFontScale);
+    });
+
+    testWidgets('keeps the heart readable to screen readers', (tester) async {
+      final handle = tester.ensureSemantics();
+      final spans = divineHeartSpans(divineGreenHeart, style: style);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: Text.rich(TextSpan(children: spans))),
+        ),
+      );
+
+      expect(
+        find.bySemanticsLabel(divineGreenHeart),
+        findsOneWidget,
+        reason: 'the swapped glyph must still announce as a green heart',
+      );
+      handle.dispose();
+    });
+  });
+}

--- a/mobile/packages/divine_ui/test/src/emoji/divine_heart_text_test.dart
+++ b/mobile/packages/divine_ui/test/src/emoji/divine_heart_text_test.dart
@@ -18,7 +18,7 @@ void main() {
     });
 
     testWidgets('paints a green heart in the brand green', (tester) async {
-      await pump(tester, DivineHeartText('hi $divineGreenHeart'));
+      await pump(tester, const DivineHeartText('hi $divineGreenHeart'));
 
       final icon = tester.widget<DivineIcon>(find.byType(DivineIcon));
       expect(icon.color, VineTheme.vineGreen);
@@ -29,8 +29,8 @@ void main() {
     ) async {
       await pump(
         tester,
-        DefaultTextStyle(
-          style: const TextStyle(fontSize: 30),
+        const DefaultTextStyle(
+          style: TextStyle(fontSize: 30),
           child: DivineHeartText(divineGreenHeart),
         ),
       );
@@ -44,11 +44,11 @@ void main() {
     ) async {
       await pump(
         tester,
-        DefaultTextStyle(
-          style: const TextStyle(fontSize: 30),
+        const DefaultTextStyle(
+          style: TextStyle(fontSize: 30),
           child: DivineHeartText(
             divineGreenHeart,
-            style: const TextStyle(fontSize: 10),
+            style: TextStyle(fontSize: 10),
           ),
         ),
       );

--- a/mobile/packages/divine_ui/test/src/emoji/divine_heart_text_test.dart
+++ b/mobile/packages/divine_ui/test/src/emoji/divine_heart_text_test.dart
@@ -1,0 +1,86 @@
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  Future<void> pump(WidgetTester tester, Widget child) => tester.pumpWidget(
+    MaterialApp(home: Scaffold(body: child)),
+  );
+
+  group(DivineHeartText, () {
+    testWidgets('renders text with no green heart as plain text', (
+      tester,
+    ) async {
+      await pump(tester, const DivineHeartText('hello'));
+
+      expect(find.text('hello'), findsOneWidget);
+      expect(find.byType(DivineIcon), findsNothing);
+    });
+
+    testWidgets('paints a green heart in the brand green', (tester) async {
+      await pump(tester, DivineHeartText('hi $divineGreenHeart'));
+
+      final icon = tester.widget<DivineIcon>(find.byType(DivineIcon));
+      expect(icon.color, VineTheme.vineGreen);
+    });
+
+    testWidgets('sizes the heart from the inherited default style', (
+      tester,
+    ) async {
+      await pump(
+        tester,
+        DefaultTextStyle(
+          style: const TextStyle(fontSize: 30),
+          child: DivineHeartText(divineGreenHeart),
+        ),
+      );
+
+      final icon = tester.widget<DivineIcon>(find.byType(DivineIcon));
+      expect(icon.size, 30 * kDivineHeartFontScale);
+    });
+
+    testWidgets('lets an explicit style win over the inherited one', (
+      tester,
+    ) async {
+      await pump(
+        tester,
+        DefaultTextStyle(
+          style: const TextStyle(fontSize: 30),
+          child: DivineHeartText(
+            divineGreenHeart,
+            style: const TextStyle(fontSize: 10),
+          ),
+        ),
+      );
+
+      final icon = tester.widget<DivineIcon>(find.byType(DivineIcon));
+      expect(icon.size, 10 * kDivineHeartFontScale);
+    });
+
+    testWidgets('exposes the caller style on the Text, like Text does', (
+      tester,
+    ) async {
+      const style = TextStyle(fontWeight: FontWeight.w600);
+      await pump(tester, const DivineHeartText('hello', style: style));
+
+      expect(tester.widget<Text>(find.byType(Text)).style, style);
+    });
+
+    testWidgets('forwards maxLines, overflow and textAlign', (tester) async {
+      await pump(
+        tester,
+        const DivineHeartText(
+          'a long line that wraps',
+          maxLines: 2,
+          overflow: TextOverflow.ellipsis,
+          textAlign: TextAlign.center,
+        ),
+      );
+
+      final rich = tester.widget<Text>(find.byType(Text));
+      expect(rich.maxLines, 2);
+      expect(rich.overflow, TextOverflow.ellipsis);
+      expect(rich.textAlign, TextAlign.center);
+    });
+  });
+}

--- a/mobile/test/screens/inbox/conversation/widgets/message_bubble_test.dart
+++ b/mobile/test/screens/inbox/conversation/widgets/message_bubble_test.dart
@@ -132,6 +132,33 @@ void main() {
         expect(find.text('Hello there'), findsOneWidget);
       });
 
+      testWidgets('bounds painted hearts across markdown leaves', (
+        tester,
+      ) async {
+        // Each plain markdown leaf builds its own linkifier, so a per-leaf
+        // heart cap would reset at every emphasis boundary. The budget is
+        // shared across the whole message instead.
+        await tester.pumpWidget(
+          MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: MessageBubble(
+                message:
+                    '**x**$divineGreenHeart' * (kDivineHeartMaxPainted + 2),
+                timestamp: '2:30 PM',
+                isSent: true,
+              ),
+            ),
+          ),
+        );
+
+        expect(
+          _divineIcon(DivineIconName.heartFill),
+          findsNWidgets(kDivineHeartMaxPainted),
+        );
+      });
+
       testWidgets('renders timestamp when isFirstInGroup is true', (
         tester,
       ) async {

--- a/mobile/test/screens/inbox/widgets/conversation_tile_test.dart
+++ b/mobile/test/screens/inbox/widgets/conversation_tile_test.dart
@@ -122,6 +122,43 @@ void main() {
         expect(find.text('Alice'), findsOneWidget);
       });
 
+      testWidgets('paints a brand-green heart in a display name', (
+        tester,
+      ) async {
+        final testProfile = createTestProfile(
+          displayName: 'Alice $divineGreenHeart',
+        );
+        final testConversation = createTestConversation();
+
+        await tester.pumpWidget(
+          testMaterialApp(
+            additionalOverrides: [
+              fetchUserProfileProvider(
+                otherPubkey,
+              ).overrideWith((ref) async => testProfile),
+            ],
+            home: Scaffold(
+              body: ConversationTile(
+                conversation: testConversation,
+                currentUserPubkey: currentPubkey,
+                onTap: () {},
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final heartFinder = find.byWidgetPredicate(
+          (widget) =>
+              widget is DivineIcon && widget.icon == DivineIconName.heartFill,
+        );
+        expect(heartFinder, findsOneWidget);
+        expect(
+          tester.widget<DivineIcon>(heartFinder).color,
+          VineTheme.vineGreen,
+        );
+      });
+
       testWidgets('renders last message content', (tester) async {
         final testProfile = createTestProfile(displayName: 'Alice');
         final testConversation = createTestConversation(

--- a/mobile/test/widgets/linkified_text/linkified_text_green_heart_test.dart
+++ b/mobile/test/widgets/linkified_text/linkified_text_green_heart_test.dart
@@ -56,13 +56,35 @@ void main() {
       expect(find.byType(DivineIcon), findsNothing);
     });
 
-    testWidgets('paints a green heart in selectable text', (tester) async {
+    testWidgets('keeps the platform glyph in selectable text so copy keeps '
+        'the character', (tester) async {
+      // SelectableText seeds its editing controller from the span plain
+      // text, where a WidgetSpan heart contributes U+FFFC — a copied bio
+      // would silently lose the character. That copy fidelity is why the
+      // PR leaves selectable surfaces on the platform emoji font.
       await pump(
         tester,
         const SelectableLinkifiedText(text: 'bio $divineGreenHeart'),
       );
 
-      expect(find.byType(DivineIcon), findsOneWidget);
+      expect(find.byType(DivineIcon), findsNothing);
+      final editable = tester.widget<EditableText>(find.byType(EditableText));
+      expect(editable.controller.text, contains(divineGreenHeart));
+      expect(editable.controller.text.contains('\u{FFFC}'), isFalse);
+    });
+
+    testWidgets('keeps copy intact on the selectable rich path too', (
+      tester,
+    ) async {
+      await pump(
+        tester,
+        const SelectableLinkifiedText(text: 'bio $divineGreenHeart #vine'),
+      );
+
+      expect(find.byType(DivineIcon), findsNothing);
+      final editable = tester.widget<EditableText>(find.byType(EditableText));
+      expect(editable.controller.text, contains(divineGreenHeart));
+      expect(editable.controller.text.contains('\u{FFFC}'), isFalse);
     });
   });
 }

--- a/mobile/test/widgets/linkified_text/linkified_text_green_heart_test.dart
+++ b/mobile/test/widgets/linkified_text/linkified_text_green_heart_test.dart
@@ -39,6 +39,23 @@ void main() {
       expect(find.byType(DivineIcon), findsOneWidget);
     });
 
+    testWidgets('bounds painted hearts across runs split by tokens', (
+      tester,
+    ) async {
+      // The builder runs the splitter once per plain run between tokens, so
+      // a per-run cap would reset on every hashtag and an interleaved note
+      // (one heart per tag) would still build one SVG widget per heart.
+      // The budget is shared across the whole build instead.
+      await pump(
+        tester,
+        LinkifiedText(
+          text: '#tag $divineGreenHeart ' * (kDivineHeartMaxPainted + 2),
+        ),
+      );
+
+      expect(find.byType(DivineIcon), findsNWidgets(kDivineHeartMaxPainted));
+    });
+
     testWidgets('leaves text without a green heart on the plain path', (
       tester,
     ) async {

--- a/mobile/test/widgets/linkified_text/linkified_text_green_heart_test.dart
+++ b/mobile/test/widgets/linkified_text/linkified_text_green_heart_test.dart
@@ -1,0 +1,65 @@
+// ABOUTME: Divine paints U+1F49A in its own brand green, so the green heart
+// ABOUTME: must survive LinkifiedText's plain-text fast path as a widget span.
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/widgets/linkified_text/linkified_text_widgets.dart';
+
+void main() {
+  Future<void> pump(WidgetTester tester, Widget child) => tester.pumpWidget(
+    MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(body: child),
+    ),
+  );
+
+  group('LinkifiedText green heart', () {
+    testWidgets('paints a green heart in text carrying no other token', (
+      tester,
+    ) async {
+      // The plain-text fast path returns a bare Text and drops the spans,
+      // so a heart with no neighbouring link/mention/hashtag is the case
+      // most likely to regress.
+      await pump(tester, LinkifiedText(text: 'so good $divineGreenHeart'));
+
+      expect(find.byType(DivineIcon), findsOneWidget);
+      final icon = tester.widget<DivineIcon>(find.byType(DivineIcon));
+      expect(icon.color, VineTheme.vineGreen);
+    });
+
+    testWidgets('paints a green heart alongside a hashtag', (tester) async {
+      await pump(tester, LinkifiedText(text: '#vine $divineGreenHeart'));
+
+      expect(find.byType(DivineIcon), findsOneWidget);
+    });
+
+    testWidgets('leaves text without a green heart on the plain path', (
+      tester,
+    ) async {
+      await pump(tester, const LinkifiedText(text: 'nothing to see'));
+
+      expect(find.byType(DivineIcon), findsNothing);
+      expect(find.text('nothing to see'), findsOneWidget);
+    });
+
+    testWidgets('leaves a red heart to the platform emoji font', (
+      tester,
+    ) async {
+      await pump(tester, const LinkifiedText(text: 'love ❤️'));
+
+      expect(find.byType(DivineIcon), findsNothing);
+    });
+
+    testWidgets('paints a green heart in selectable text', (tester) async {
+      await pump(
+        tester,
+        SelectableLinkifiedText(text: 'bio $divineGreenHeart'),
+      );
+
+      expect(find.byType(DivineIcon), findsOneWidget);
+    });
+  });
+}

--- a/mobile/test/widgets/linkified_text/linkified_text_green_heart_test.dart
+++ b/mobile/test/widgets/linkified_text/linkified_text_green_heart_test.dart
@@ -23,7 +23,10 @@ void main() {
       // The plain-text fast path returns a bare Text and drops the spans,
       // so a heart with no neighbouring link/mention/hashtag is the case
       // most likely to regress.
-      await pump(tester, LinkifiedText(text: 'so good $divineGreenHeart'));
+      await pump(
+        tester,
+        const LinkifiedText(text: 'so good $divineGreenHeart'),
+      );
 
       expect(find.byType(DivineIcon), findsOneWidget);
       final icon = tester.widget<DivineIcon>(find.byType(DivineIcon));
@@ -31,7 +34,7 @@ void main() {
     });
 
     testWidgets('paints a green heart alongside a hashtag', (tester) async {
-      await pump(tester, LinkifiedText(text: '#vine $divineGreenHeart'));
+      await pump(tester, const LinkifiedText(text: '#vine $divineGreenHeart'));
 
       expect(find.byType(DivineIcon), findsOneWidget);
     });
@@ -56,7 +59,7 @@ void main() {
     testWidgets('paints a green heart in selectable text', (tester) async {
       await pump(
         tester,
-        SelectableLinkifiedText(text: 'bio $divineGreenHeart'),
+        const SelectableLinkifiedText(text: 'bio $divineGreenHeart'),
       );
 
       expect(find.byType(DivineIcon), findsOneWidget);

--- a/mobile/test/widgets/linkified_text/linkified_text_span_builder_test.dart
+++ b/mobile/test/widgets/linkified_text/linkified_text_span_builder_test.dart
@@ -377,9 +377,18 @@ void main() {
   });
 }
 
-extension on List<TextSpan> {
-  List<TextSpan> get tappableSpans =>
-      where((span) => span.recognizer is TapGestureRecognizer).toList();
+extension on List<InlineSpan> {
+  List<TextSpan> get tappableSpans => whereType<TextSpan>()
+      .where((span) => span.recognizer is TapGestureRecognizer)
+      .toList();
+}
+
+/// The builder emits `InlineSpan` so a green heart can arrive as a
+/// `WidgetSpan`; these keep the text-span assertions below readable.
+extension on InlineSpan {
+  String? get text => (this as TextSpan).text;
+
+  GestureRecognizer? get recognizer => (this as TextSpan).recognizer;
 }
 
 extension on TextSpan {

--- a/mobile/test/widgets/video_feed_item/video_overlay_actions_description_test.dart
+++ b/mobile/test/widgets/video_feed_item/video_overlay_actions_description_test.dart
@@ -108,6 +108,47 @@ void main() {
     expect(find.text('Likes'), findsOneWidget);
   });
 
+  testWidgets('paints a brand-green heart in the author name', (tester) async {
+    await tester.pumpWidget(
+      testProviderScope(
+        additionalOverrides: [
+          repostsRepositoryProvider.overrideWithValue(mockRepostsRepository),
+          userProfileReactiveProvider.overrideWith((ref, pubkey) async* {
+            yield UserProfile(
+              pubkey: pubkey,
+              displayName: 'Alice $divineGreenHeart',
+              rawData: const {},
+              createdAt: DateTime(2026),
+              eventId: 'kind0_event_id',
+            );
+          }),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: BlocProvider<VideoInteractionsBloc>.value(
+              value: mockInteractionsBloc,
+              child: VideoOverlayActions(
+                video: testVideo,
+                isVisible: true,
+                isActive: true,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    final heartFinder = find.byWidgetPredicate(
+      (w) => w is DivineIcon && w.icon == DivineIconName.heartFill,
+    );
+    expect(heartFinder, findsOneWidget);
+    expect(tester.widget<DivineIcon>(heartFinder).color, VineTheme.vineGreen);
+  });
+
   testWidgets('author line uses localized singular loop label for 1', (
     tester,
   ) async {


### PR DESCRIPTION
Closes #7732

## Description

U+1F49A (💚) is painted by the platform emoji font, so the same green heart renders as Apple's green on iOS and Google's on Android — never Divine's `#27C58B`. This swaps it locally for the brand heart glyph (`heart_fill.svg` tinted `VineTheme.vineGreen`).

**Divine keeps publishing the standard codepoint.** Only the local painting changes, so other Nostr clients still show a green heart of their own. That degrades better than a NIP-30 custom emoji, which renders as a literal `:shortcode:` wherever it isn't implemented.

Two pieces:

1. **`divine_ui` primitives** — `divineHeartSpans(text, style:)` splits a string on the codepoint and returns `List<InlineSpan>` with a `WidgetSpan` per heart, sized off the run's resolved font size and labelled for screen readers. Painted hearts are capped at 32 per rendered text run (`kDivineHeartMaxPainted`, shared across linkifier runs and DM markdown leaves) — hearts past the cap keep the platform glyph, so arbitrary remote text cannot inflate the widget tree. `DivineHeartText` wraps it as a drop-in `Text` replacement for surfaces that don't route through the linkifier.
2. **Call sites** — hooked into `LinkifiedTextSpanBuilder._plainSpans` (covers bios, captions, comments, DM bodies, metadata sheets, list descriptions, notification quotes), plus the reaction glyphs, display names, feed video title, and DM inbox preview.

### A bug this surfaced

`LinkifiedText`'s plain-text fast path returned a bare `Text` and **discarded the spans entirely** whenever the text carried no link, mention, or hashtag. That is exactly the common case for a bio reading "good vibes 💚", so the feature would have silently done nothing most of the time. `_hasClickableOrStylableToken` now treats any non-`TextSpan` as forcing the rich path, and the span builders widen from `TextSpan` to `InlineSpan` to carry the `WidgetSpan`.

**Related Issue:** Relates to #

## Out of Scope

Three surfaces deliberately keep the platform glyph — each is a judgment call, not an oversight:

- **`SelectableText` paths** (`UserName` when `selectable: true`, expanded profile bios). A `WidgetSpan` does not survive text selection intact, so a copied display name or bio would silently lose the character. Copy fidelity was judged more valuable than brand color here. Enforced in code: the span builder takes `allowWidgetSpans` and the selectable surfaces pass `false`, so copying a bio keeps the real codepoint instead of a U+FFFC placeholder. Consequence: the same bio flips glyph on "Show more" — collapsed paints the brand heart, expanded paints the platform one.
- **The full reaction emoji picker** (`full_reaction_emoji_picker_sheet.dart`) renders `pro_image_editor`'s own grid. Reaching into a third-party widget's emoji set was out of proportion to the win.
- **The DM default reaction stays ❤️.** Swapping it to 💚 would change what we publish and leave old ❤️ reactions showing as a second row on existing threads. Consequence worth stating plainly: 💚 now only appears when a user *types* it, so the brand heart will be common in bios and captions and rare in reactions. Adding 💚 alongside ❤️ in `kDefaultDmReactionEmojis` is the cheap follow-up if we want it visible there.

## Known limitation

The profile bio's "Show more" threshold is measured by a raw `TextPainter` at `profile_header_media.dart:67` that does not run text through the linkifier. It was **already** approximate — it ignores mention-label substitution and link styling too — and the heart is sized at 1.2× the font size versus an emoji's natural advance, so the threshold shifts slightly for bios containing 💚. Making it exact requires feeding placeholder dimensions into the `TextPainter`; that felt disproportionate next to the approximations already present. Flagging rather than absorbing silently.

## Verification

- `flutter analyze lib test integration_test` — clean.
- `flutter test test/widgets test/screens` — **5535 passed, 0 failed** (103 pre-existing skips). This is the broad run that covers the `UserName`, feed-title, and inbox-preview call sites, since replacing `Text` with `Text.rich` can break `find.text()` assertions app-wide.
- `flutter test test/widgets/linkified_text/` — 24 passed.
- `divine_ui` package: 944 passed. **New files at 100% line coverage** (`divine_heart_spans.dart` 11/11, `divine_heart_text.dart` 9/9), confirmed by reading `coverage/lcov.info` — required, since `divine_ui` is a strict 100%-gate package.

**Not verified:** no on-device or simulator run. Every claim above is from the test suite, so the mint heart's *appearance* next to the platform's full-color 😂 🔥 👍 in a reaction row is unconfirmed. A flat single-color vector among shaded color emoji can read as a broken glyph rather than a branded one — worth an eyeball before merge.

**Goldens:** `test/goldens` shows the three documented macOS failures (`divine_button_types` 2.79%, `divine_button_sizes` 2.67%, `divine_snackbars` 3.65%). Verified these fail **identically on `origin/main`** via a detached checkout — they are the Ubuntu-vs-macOS antialiasing drift `AGENTS.md` documents at those exact figures. Not caused by this diff; CI's `Goldens` job is authoritative.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)


