### PR TITLE
fix(video-editor): resolve the audio in-point to one frame per pixel

### DIFF
--- a/mobile/lib/constants/video_editor_constants.dart
+++ b/mobile/lib/constants/video_editor_constants.dart
@@ -67,6 +67,14 @@ class VideoEditorConstants {
   /// Maximum recording duration for videos.
   static const maxDuration = Duration(seconds: 6, milliseconds: 300);
 
+  /// Frame grid the editor presents to the user.
+  ///
+  /// The timeline ruler labels sub-second positions in frames at this rate, so
+  /// any control that has to line up against it — the audio in-point scrubber
+  /// included — must resolve at least this finely, or it promises a precision
+  /// it cannot deliver.
+  static const int editorFps = 30;
+
   /// Minimum duration a rendered stop-motion video must reach.
   ///
   /// Very short clips (a single still ≈ 83ms) make looping players stutter and

--- a/mobile/lib/screens/video_editor/video_audio_editor_timing_screen.dart
+++ b/mobile/lib/screens/video_editor/video_audio_editor_timing_screen.dart
@@ -667,27 +667,33 @@ class _AudioWaveformSelector extends StatelessWidget {
                       duration: WaveformConstants.animationDuration,
                       curve: WaveformConstants.animationCurve,
                       builder: (context, heightFactor, child) {
-                        return ClipRRect(
-                          borderRadius: .circular(24),
-                          child: SizedBox.expand(
-                            child: CustomPaint(
-                              painter: StereoWaveformPainter(
-                                leftChannel: leftChannel ?? Float32List(0),
-                                rightChannel: rightChannel,
-                                progress: 1.0, // No progress indicator needed
-                                activeColor: VineTheme.whiteText,
-                                inactiveColor: VineTheme.whiteText,
-                                audioDuration: _secondsToDuration(
-                                  audioDurationSecs,
+                        // The strip only translates while the user scrubs, so
+                        // the boundary lets its raster be reused instead of
+                        // re-running a paint that draws one bar per 5px of a
+                        // strip many screens wide.
+                        return RepaintBoundary(
+                          child: ClipRRect(
+                            borderRadius: .circular(24),
+                            child: SizedBox.expand(
+                              child: CustomPaint(
+                                painter: StereoWaveformPainter(
+                                  leftChannel: leftChannel ?? Float32List(0),
+                                  rightChannel: rightChannel,
+                                  progress: 1.0, // No progress indicator needed
+                                  activeColor: VineTheme.whiteText,
+                                  inactiveColor: VineTheme.whiteText,
+                                  audioDuration: _secondsToDuration(
+                                    audioDurationSecs,
+                                  ),
+                                  // The canvas is `waveformSpanSecs` wide, not
+                                  // one video duration wide — telling the
+                                  // painter otherwise stretches the opening
+                                  // 6.3s across the whole track.
+                                  maxDuration: _secondsToDuration(
+                                    waveformSpanSecs,
+                                  ),
+                                  heightFactor: heightFactor,
                                 ),
-                                // The canvas is `waveformSpanSecs` wide, not
-                                // one video duration wide — telling the painter
-                                // otherwise stretches the opening 6.3s across
-                                // the whole track.
-                                maxDuration: _secondsToDuration(
-                                  waveformSpanSecs,
-                                ),
-                                heightFactor: heightFactor,
                               ),
                             ),
                           ),

--- a/mobile/lib/screens/video_editor/video_audio_editor_timing_screen.dart
+++ b/mobile/lib/screens/video_editor/video_audio_editor_timing_screen.dart
@@ -306,34 +306,8 @@ class _BottomControls extends StatelessWidget {
   final VoidCallback onDragStart;
   final VoidCallback onDragEnd;
 
-  /// Calculates the selection width ratio based on video maxDuration vs audio duration.
-  ///
-  /// The selection always represents [VideoEditorConstants.maxDuration] (6.3s).
-  /// - If audio is shorter than maxDuration: returns 1.0 (100% width, fills entire area)
-  /// - If audio is longer: returns the proportional ratio (e.g., 33% for ~19s audio)
-  /// - Minimum 10% to keep the selection visible and draggable
-  double get _selectionWidthRatio {
-    final audioDurationSecs = audioDuration;
-    if (audioDurationSecs == null || audioDurationSecs <= 0) {
-      return 1.0; // Unknown duration, assume full width
-    }
-
-    final maxDurationSecs =
-        VideoEditorConstants.maxDuration.inMilliseconds / 1000.0;
-
-    // If audio is shorter than video max duration, use full width (100%)
-    if (audioDurationSecs <= maxDurationSecs) {
-      return 1.0;
-    }
-
-    // Ratio of video duration to audio duration, clamped to [0.1, 1.0]
-    return (maxDurationSecs / audioDurationSecs).clamp(0.1, 1.0);
-  }
-
   @override
   Widget build(BuildContext context) {
-    final selectionRatio = _selectionWidthRatio;
-
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: [
@@ -354,7 +328,6 @@ class _BottomControls extends StatelessWidget {
         // Video duration timeline (top bar with green segment)
         _VideoDurationTimeline(
           startOffset: startOffset,
-          selectionWidthRatio: selectionRatio,
           audioDuration: audioDuration,
           onOffsetChanged: onOffsetChanged,
           onFling: onFling,
@@ -367,7 +340,6 @@ class _BottomControls extends StatelessWidget {
         // Audio waveform with draggable selection
         _AudioWaveformSelector(
           startOffset: startOffset,
-          selectionWidthRatio: selectionRatio,
           audioDuration: audioDuration,
           onOffsetChanged: onOffsetChanged,
           onFling: onFling,
@@ -383,7 +355,6 @@ class _BottomControls extends StatelessWidget {
 class _VideoDurationTimeline extends StatelessWidget {
   const _VideoDurationTimeline({
     required this.startOffset,
-    required this.selectionWidthRatio,
     required this.audioDuration,
     required this.onOffsetChanged,
     required this.onFling,
@@ -391,10 +362,13 @@ class _VideoDurationTimeline extends StatelessWidget {
     required this.onDragEnd,
   });
 
-  final double startOffset;
+  /// Smallest the segment marker may be drawn.
+  ///
+  /// Keeps it visible on very long tracks, where its true share of the bar
+  /// falls below a few pixels.
+  static const double _minSegmentWidth = 12;
 
-  /// The ratio of the segment width to the total timeline width.
-  final double selectionWidthRatio;
+  final double startOffset;
 
   /// Audio duration in seconds, or null if unknown.
   final double? audioDuration;
@@ -407,8 +381,22 @@ class _VideoDurationTimeline extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final screenWidth = MediaQuery.sizeOf(context).width - 32;
-    final segmentWidth = screenWidth * selectionWidthRatio;
+    final maxDurationSecs =
+        VideoEditorConstants.maxDuration.inMilliseconds / 1000.0;
     final audioDurationSecs = audioDuration ?? 0;
+
+    // This bar spans the whole track, so the marker's share of it is the
+    // segment's true share of the audio — the waveform below owns scrub
+    // precision and sets its own zoom independently.
+    final minSegmentWidth = _minSegmentWidth < screenWidth
+        ? _minSegmentWidth
+        : screenWidth;
+    final segmentWidth = audioDurationSecs <= maxDurationSecs
+        ? screenWidth
+        : (screenWidth * maxDurationSecs / audioDurationSecs).clamp(
+            minSegmentWidth,
+            screenWidth,
+          );
 
     // Scrollable distance lets the segment's left edge reach
     // `audioDuration - minRemainingAudio`, so users can pick a late start
@@ -509,7 +497,6 @@ class _VideoDurationTimeline extends StatelessWidget {
 class _AudioWaveformSelector extends StatelessWidget {
   const _AudioWaveformSelector({
     required this.startOffset,
-    required this.selectionWidthRatio,
     required this.audioDuration,
     required this.onOffsetChanged,
     required this.onFling,
@@ -518,9 +505,6 @@ class _AudioWaveformSelector extends StatelessWidget {
   });
 
   final double startOffset;
-
-  /// The ratio of the selection width to the total waveform width.
-  final double selectionWidthRatio;
 
   /// Audio duration in seconds, or null if unknown.
   final double? audioDuration;
@@ -532,17 +516,32 @@ class _AudioWaveformSelector extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final screenWidth = MediaQuery.sizeOf(context).width - 32;
-    // Selection area represents portion of audio that fits video duration
-    final selectionWidth = screenWidth * selectionWidthRatio;
+    final maxDurationSecs =
+        VideoEditorConstants.maxDuration.inMilliseconds / 1000.0;
+    final audioDurationSecs = audioDuration ?? 0;
+
+    // Zoom is chosen for scrub precision, not to mirror the overview bar above.
+    // `selectionWidth` pixels always represent [VideoEditorConstants.maxDuration]
+    // of audio, so one pixel of drag moves the in-point by
+    // `maxDuration / selectionWidth` seconds. Flooring that width at one pixel
+    // per frame keeps the in-point resolvable on the same grid the timeline
+    // ruler labels; a purely proportional width collapses on long tracks, where
+    // a single pixel used to jump roughly six frames.
+    final framePreciseWidth = maxDurationSecs * VideoEditorConstants.editorFps;
+    final minSelectionWidth = framePreciseWidth < screenWidth
+        ? framePreciseWidth
+        : screenWidth;
+    final selectionWidth = audioDurationSecs <= maxDurationSecs
+        ? screenWidth
+        : (screenWidth * maxDurationSecs / audioDurationSecs).clamp(
+            minSelectionWidth,
+            screenWidth,
+          );
     // Selection is always centered
     final selectionLeft = (screenWidth - selectionWidth) / 2;
 
     // Calculate actual waveform width based on audio duration
     final double fullWaveformWidth;
-    final maxDurationSecs =
-        VideoEditorConstants.maxDuration.inMilliseconds / 1000.0;
-    final audioDurationSecs = audioDuration ?? 0;
-
     if (audioDurationSecs <= 0 || audioDurationSecs <= maxDurationSecs) {
       // Short audio: waveform fits exactly within selection
       fullWaveformWidth = selectionWidth;

--- a/mobile/lib/screens/video_editor/video_audio_editor_timing_screen.dart
+++ b/mobile/lib/screens/video_editor/video_audio_editor_timing_screen.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Screen for adjusting audio timing/offset for video editor.
 // ABOUTME: Displays video preview with audio segment selector overlay.
 
+import 'dart:math' as math;
 import 'dart:typed_data';
 
 import 'package:divine_ui/divine_ui.dart';
@@ -351,6 +352,32 @@ class _BottomControls extends StatelessWidget {
   }
 }
 
+/// [VideoEditorConstants.maxDuration] expressed in seconds.
+double get _maxDurationSecs =>
+    VideoEditorConstants.maxDuration.inMilliseconds / 1000.0;
+
+/// Converts [seconds] of audio into a [Duration].
+Duration _secondsToDuration(double seconds) =>
+    Duration(milliseconds: (seconds * 1000).toInt());
+
+/// Width of the marker representing [VideoEditorConstants.maxDuration] of audio
+/// on a bar where [trackWidth] pixels span [audioDurationSecs] of audio.
+///
+/// [minWidth] floors the result — the two callers floor it for unrelated
+/// reasons (visibility above, scrub resolution below), so the floor stays at
+/// the call site rather than being baked in here.
+double _maxDurationSegmentWidth({
+  required double trackWidth,
+  required double audioDurationSecs,
+  required double minWidth,
+}) {
+  if (audioDurationSecs <= _maxDurationSecs) return trackWidth;
+  return (trackWidth * _maxDurationSecs / audioDurationSecs).clamp(
+    math.min(minWidth, trackWidth),
+    trackWidth,
+  );
+}
+
 /// Video duration timeline showing where the selected segment will play.
 class _VideoDurationTimeline extends StatelessWidget {
   const _VideoDurationTimeline({
@@ -381,22 +408,16 @@ class _VideoDurationTimeline extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final screenWidth = MediaQuery.sizeOf(context).width - 32;
-    final maxDurationSecs =
-        VideoEditorConstants.maxDuration.inMilliseconds / 1000.0;
     final audioDurationSecs = audioDuration ?? 0;
 
     // This bar spans the whole track, so the marker's share of it is the
     // segment's true share of the audio — the waveform below owns scrub
     // precision and sets its own zoom independently.
-    final minSegmentWidth = _minSegmentWidth < screenWidth
-        ? _minSegmentWidth
-        : screenWidth;
-    final segmentWidth = audioDurationSecs <= maxDurationSecs
-        ? screenWidth
-        : (screenWidth * maxDurationSecs / audioDurationSecs).clamp(
-            minSegmentWidth,
-            screenWidth,
-          );
+    final segmentWidth = _maxDurationSegmentWidth(
+      trackWidth: screenWidth,
+      audioDurationSecs: audioDurationSecs,
+      minWidth: _minSegmentWidth,
+    );
 
     // Scrollable distance lets the segment's left edge reach
     // `audioDuration - minRemainingAudio`, so users can pick a late start
@@ -516,8 +537,6 @@ class _AudioWaveformSelector extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final screenWidth = MediaQuery.sizeOf(context).width - 32;
-    final maxDurationSecs =
-        VideoEditorConstants.maxDuration.inMilliseconds / 1000.0;
     final audioDurationSecs = audioDuration ?? 0;
 
     // Zoom is chosen for scrub precision, not to mirror the overview bar above.
@@ -527,72 +546,52 @@ class _AudioWaveformSelector extends StatelessWidget {
     // per frame keeps the in-point resolvable on the same grid the timeline
     // ruler labels; a purely proportional width collapses on long tracks, where
     // a single pixel used to jump roughly six frames.
-    final framePreciseWidth = maxDurationSecs * VideoEditorConstants.editorFps;
-    final minSelectionWidth = framePreciseWidth < screenWidth
-        ? framePreciseWidth
-        : screenWidth;
-    final selectionWidth = audioDurationSecs <= maxDurationSecs
-        ? screenWidth
-        : (screenWidth * maxDurationSecs / audioDurationSecs).clamp(
-            minSelectionWidth,
-            screenWidth,
-          );
+    final selectionWidth = _maxDurationSegmentWidth(
+      trackWidth: screenWidth,
+      audioDurationSecs: audioDurationSecs,
+      minWidth: _maxDurationSecs * VideoEditorConstants.editorFps,
+    );
     // Selection is always centered
     final selectionLeft = (screenWidth - selectionWidth) / 2;
 
-    // Calculate actual waveform width based on audio duration
-    final double fullWaveformWidth;
-    if (audioDurationSecs <= 0 || audioDurationSecs <= maxDurationSecs) {
-      // Short audio: waveform fits exactly within selection
-      fullWaveformWidth = selectionWidth;
-    } else {
-      // Long audio: waveform extends beyond selection proportionally
-      fullWaveformWidth =
-          selectionWidth * (audioDurationSecs / maxDurationSecs);
-    }
+    // Every length below is derived from this one scale, so the bars, the
+    // scrollable range and the shrinking tail cannot disagree about where a
+    // second of audio sits.
+    final pixelsPerSecond = selectionWidth / _maxDurationSecs;
 
-    // Calculate how far the waveform can scroll.
-    //
-    // The selection's left edge (in audio time) can range from 0 to
-    // `audioDuration - minRemainingAudio`, allowing users to pick a late
+    // The canvas spans whichever is longer, the track or the video window:
+    // audio shorter than the video leaves the remainder to the painter's
+    // placeholder bars.
+    final waveformSpanSecs = math.max(audioDurationSecs, _maxDurationSecs);
+    final fullWaveformWidth = waveformSpanSecs * pixelsPerSecond;
+
+    // On-screen extent of the audio itself. Until the duration resolves there
+    // is nothing to measure it against, so the placeholder canvas stands in.
+    final trackWidth = audioDurationSecs > 0
+        ? audioDurationSecs * pixelsPerSecond
+        : fullWaveformWidth;
+
+    // The in-point ranges from 0 to `audioDuration - minRemainingAudio`, so
+    // the waveform scrolls by exactly that much audio — users can pick a late
     // start even when the trailing audio is shorter than the video.
-    // `selectionWidth` always represents min(audioDurationSecs, maxDurationSecs)
-    // worth of audio — full duration for short clips, maxDuration for long ones —
-    // so the minimum-remaining slice width must use the same basis as the
-    // denominator.
-    final double maxScrollableDistance;
-    if (audioDurationSecs <= 0 ||
-        audioDurationSecs <= AudioTimingCubit.minRemainingAudioSecs) {
-      maxScrollableDistance = 0;
-    } else {
-      // For short audio selectionWidth represents audioDurationSecs;
-      // for long audio it represents maxDurationSecs.
-      final waveformBasisSecs = audioDurationSecs < maxDurationSecs
-          ? audioDurationSecs
-          : maxDurationSecs;
-      final minVisibleWidth =
-          selectionWidth *
-          (AudioTimingCubit.minRemainingAudioSecs / waveformBasisSecs);
-      maxScrollableDistance = (fullWaveformWidth - minVisibleWidth).clamp(
-        0.0,
-        double.infinity,
-      );
-    }
-    // Waveform position: at offset 0, waveform starts at selection left edge
-    // at offset 1, waveform ends at selection right edge
+    final maxScrollableDistance =
+        ((audioDurationSecs - AudioTimingCubit.minRemainingAudioSecs) *
+                pixelsPerSecond)
+            .clamp(0.0, double.infinity);
+
+    // Waveform position: at offset 0 the track starts at the selection's left
+    // edge; at offset 1 only `minRemainingAudio` is left inside it.
     final waveformLeft = selectionLeft - startOffset * maxScrollableDistance;
 
-    // Shrink the green selection when the trailing audio is shorter than the
-    // video's max duration, so the box matches the actual playable clip
-    // (mirrors [AudioTimingCubit._setClippedAudioSource]'s end clamp).
-    final waveformRight = waveformLeft + fullWaveformWidth;
-    final remainingSelectionWidth = (waveformRight - selectionLeft).clamp(
-      0.0,
-      double.infinity,
+    // Shrink the green selection to the audio still under it, so the box
+    // matches the actual playable clip (mirrors
+    // [AudioTimingCubit._setClippedAudioSource]'s end clamp).
+    final remainingSelectionWidth = (waveformLeft + trackWidth - selectionLeft)
+        .clamp(0.0, double.infinity);
+    final effectiveSelectionWidth = math.min(
+      selectionWidth,
+      remainingSelectionWidth,
     );
-    final effectiveSelectionWidth = selectionWidth < remainingSelectionWidth
-        ? selectionWidth
-        : remainingSelectionWidth;
 
     return GestureDetector(
       behavior: HitTestBehavior.opaque,
@@ -678,11 +677,16 @@ class _AudioWaveformSelector extends StatelessWidget {
                                 progress: 1.0, // No progress indicator needed
                                 activeColor: VineTheme.whiteText,
                                 inactiveColor: VineTheme.whiteText,
-                                audioDuration: Duration(
-                                  milliseconds: ((audioDuration ?? 0) * 1000)
-                                      .toInt(),
+                                audioDuration: _secondsToDuration(
+                                  audioDurationSecs,
                                 ),
-                                maxDuration: VideoEditorConstants.maxDuration,
+                                // The canvas is `waveformSpanSecs` wide, not
+                                // one video duration wide — telling the painter
+                                // otherwise stretches the opening 6.3s across
+                                // the whole track.
+                                maxDuration: _secondsToDuration(
+                                  waveformSpanSecs,
+                                ),
                                 heightFactor: heightFactor,
                               ),
                             ),

--- a/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_rules_indicator.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_rules_indicator.dart
@@ -1,5 +1,6 @@
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/widgets.dart';
+import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/constants/video_editor_timeline_constants.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/video_editor/transition_geometry.dart';
@@ -95,7 +96,7 @@ class _RulerPainter extends CustomPainter {
   final Color labelColor;
 
   static const double _minLabelSpacing = 30;
-  static const int _fps = 30;
+  static const int _fps = VideoEditorConstants.editorFps;
   static const List<int> _frameSteps = [
     2,
     3,

--- a/mobile/test/screens/video_editor/video_audio_editor_timing_screen_test.dart
+++ b/mobile/test/screens/video_editor/video_audio_editor_timing_screen_test.dart
@@ -9,9 +9,11 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
+import 'package:openvine/blocs/video_editor/audio_timing/audio_timing_cubit.dart';
 import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/screens/video_editor/video_audio_editor_timing_screen.dart';
+import 'package:openvine/widgets/stereo_waveform_painter.dart';
 import 'package:openvine/widgets/video_editor/audio_editor/video_editor_audio_chip.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
 import 'package:sound_service/sound_service.dart';
@@ -447,6 +449,110 @@ void main() {
             )
             .width,
         closeTo(expectedWidth, 0.1),
+      );
+    });
+
+    testWidgets('draws the whole track across the waveform strip', (
+      tester,
+    ) async {
+      // The strip is as wide as the track is long, but the painter was told it
+      // only spanned one video duration — so it mapped the opening 6.3s across
+      // the entire strip and the bars under the selection never corresponded
+      // to the audio playing. Scrubbing to a visible transient landed
+      // somewhere else entirely.
+      tester.view.physicalSize = const Size(800, 1200);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      const audioDurationSecs = 120.0;
+      await tester.pumpWidget(
+        buildWidget(
+          sound: _createTestAudioEvent(
+            title: 'Long Track',
+            duration: audioDurationSecs,
+          ),
+        ),
+      );
+      await tester.pump();
+
+      final waveform = find.byWidgetPredicate(
+        (widget) =>
+            widget is CustomPaint && widget.painter is StereoWaveformPainter,
+      );
+      final painter =
+          tester.widget<CustomPaint>(waveform).painter!
+              as StereoWaveformPainter;
+
+      // The selection is the scale reference: it is maxDuration wide by
+      // construction. The strip must carry the painter's span at that same
+      // scale, or the bars are stretched relative to the in-point.
+      final maxDurationSecs =
+          VideoEditorConstants.maxDuration.inMilliseconds / 1000.0;
+      final pixelsPerSecond =
+          tester
+              .getSize(
+                find.byKey(VideoAudioEditorTimingScreen.waveformSelectionKey),
+              )
+              .width /
+          maxDurationSecs;
+
+      expect(
+        painter.maxDuration.inMilliseconds / 1000.0 * pixelsPerSecond,
+        closeTo(tester.getSize(waveform).width, 0.5),
+      );
+      expect(painter.maxDuration, equals(painter.audioDuration));
+    });
+
+    testWidgets('scrolls a short track by its own length, not the window', (
+      tester,
+    ) async {
+      // Audio shorter than the video still scrolls, up to
+      // `duration - minRemainingAudio`. The scroll range was derived from the
+      // selection window rather than the track's on-screen extent, so it ran
+      // 6.3/duration times too far and the waveform left the window entirely
+      // before the in-point reached its limit.
+      tester.view.physicalSize = const Size(800, 1200);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      const audioDurationSecs = 3.0;
+      await tester.pumpWidget(
+        buildWidget(
+          sound: _createTestAudioEvent(
+            title: 'Short Clip',
+            duration: audioDurationSecs,
+          ),
+        ),
+      );
+      await tester.pump();
+
+      const screenWidth = 800.0 - 32.0;
+      final maxDurationSecs =
+          VideoEditorConstants.maxDuration.inMilliseconds / 1000.0;
+      const pixelsPerSecond = screenWidth / 6.3;
+      final selection = find.byKey(
+        VideoAudioEditorTimingScreen.waveformSelectionKey,
+      );
+
+      // The video outlasts the audio, so the box covers the track, not the
+      // full window.
+      expect(maxDurationSecs, equals(6.3));
+      expect(
+        tester.getSize(selection).width,
+        closeTo(audioDurationSecs * pixelsPerSecond, 0.1),
+      );
+
+      // The pointer lands on the selection's border overlay rather than the
+      // keyed box, but both sit inside the strip's single drag detector.
+      await tester.drag(selection, const Offset(-1000, 0), warnIfMissed: false);
+      await tester.pump();
+
+      // At the far end only `minRemainingAudio` is still under the box.
+      expect(
+        tester.getSize(selection).width,
+        closeTo(AudioTimingCubit.minRemainingAudioSecs * pixelsPerSecond, 0.1),
       );
     });
 

--- a/mobile/test/screens/video_editor/video_audio_editor_timing_screen_test.dart
+++ b/mobile/test/screens/video_editor/video_audio_editor_timing_screen_test.dart
@@ -9,6 +9,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
+import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/screens/video_editor/video_audio_editor_timing_screen.dart';
 import 'package:openvine/widgets/video_editor/audio_editor/video_editor_audio_chip.dart';
@@ -375,6 +376,79 @@ void main() {
         );
       },
     );
+
+    testWidgets('resolves the in-point to at most one frame per pixel', (
+      tester,
+    ) async {
+      // The waveform is the fine control, and the timeline ruler labels
+      // sub-second positions in frames — so a pixel of drag may never move the
+      // in-point by more than a frame. Deriving the waveform's zoom from the
+      // overview bar's proportional width (as it once did) breaks exactly this:
+      // a 120s track collapsed the selection to ~40px, ~6 frames per pixel.
+      tester.view.physicalSize = const Size(800, 1200);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(
+        buildWidget(
+          sound: _createTestAudioEvent(title: 'Long Track', duration: 120),
+        ),
+      );
+      await tester.pump();
+
+      // The selection window always spans maxDuration worth of audio, so its
+      // width in pixels is what sets the scrub resolution.
+      final selectionWidth = tester
+          .getSize(
+            find.byKey(VideoAudioEditorTimingScreen.waveformSelectionKey),
+          )
+          .width;
+      final msPerPixel =
+          VideoEditorConstants.maxDuration.inMilliseconds / selectionWidth;
+      const frameMs = 1000 / VideoEditorConstants.editorFps;
+
+      // One pixel per frame is the design target, so this lands on equality —
+      // allow a hair of float slack rather than asserting strict inequality.
+      expect(msPerPixel, lessThan(frameMs + 0.01));
+    });
+
+    testWidgets('overview segment reflects its true share of the track', (
+      tester,
+    ) async {
+      // The upper bar spans the whole track, so its marker must not be inflated
+      // to keep it grabbable — that would claim the selection covers several
+      // times more audio than it does. Visibility is a pixel floor instead.
+      tester.view.physicalSize = const Size(800, 1200);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      const audioDurationSecs = 120.0;
+      await tester.pumpWidget(
+        buildWidget(
+          sound: _createTestAudioEvent(
+            title: 'Long Track',
+            duration: audioDurationSecs,
+          ),
+        ),
+      );
+      await tester.pump();
+
+      const screenWidth = 800.0 - 32.0;
+      final maxDurationSecs =
+          VideoEditorConstants.maxDuration.inMilliseconds / 1000.0;
+      final expectedWidth = screenWidth * (maxDurationSecs / audioDurationSecs);
+
+      expect(
+        tester
+            .getSize(
+              find.byKey(VideoAudioEditorTimingScreen.videoDurationSegmentKey),
+            )
+            .width,
+        closeTo(expectedWidth, 0.1),
+      );
+    });
 
     testWidgets('has route name and path constants', (tester) async {
       expect(


### PR DESCRIPTION
Closes #7736

## Description

A user reported publicly that audio "cannot be perfectly synced" in the editor. Three separate defects sat under that one complaint, all in the same control: the scrubber could not resolve a frame, the waveform it scrubbed over was not the audio being heard, and short tracks scrolled further than they are long.

### 1. The in-point could not resolve a frame

The audio timing screen computed a single `_selectionWidthRatio` in `_BottomControls` and handed it to both children. Its `0.1` floor existed to keep the overview bar's marker visible and grabbable — but the waveform below derived its **zoom** from the same value, and the zoom is what sets scrub resolution. Past 63s of audio the floor pinned the waveform at `6300 / (0.1 · W)` ≈ **190 ms per pixel, about six frames**, while the timeline ruler immediately beside it labels positions in single frames (`6f 8f 10f…`). One constant serving two unrelated purposes, and the accidental one won.

Both widgets now own their own geometry, and the shared ratio is gone.

**`_AudioWaveformSelector`** floors its selection width at `maxDuration × editorFps` (189px). Since that width always represents `maxDuration` of audio, one pixel of drag moves the in-point by at most one frame — at any track length, rather than degrading as the track grows. On a 412dp device a 3-minute track goes from ~166 ms/px to 33 ms/px.

**`_VideoDurationTimeline`** draws its marker at the segment's true share of the track, with a 12px pixel floor for visibility instead of the 10% ratio floor. At two minutes the old floor drew the marker 1.9× wider than the audio it actually covered.

`VideoEditorConstants.editorFps` is new; `video_editor_timeline_rules_indicator.dart` now sources its private `_fps` from it, so the ruler and the in-point cannot drift apart.

### 2. The waveform showed the opening 6.3s, stretched over the whole track

Found while reviewing the above, and older than it. The strip is as wide as the track is long, but `StereoWaveformPainter` was handed `maxDuration` (6.3s) as the span its canvas represents. It therefore mapped only the opening 6.3 seconds across the entire strip. Probed directly on a 120s track whose samples are loud only in the final 12 seconds:

```
bars=720  tall=0   ← 720 bars drawn, not one of them from the loud region
```

Nothing past the first 6.3s was ever drawn, at any offset. You line up a visible transient and get audio from somewhere else — which is the reported symptom far more directly than the pixel resolution is. Frame-accurate scrubbing over a wrong picture is not worth much, so this is fixed on the same branch rather than deferred.

### 3. Short tracks scrolled further than their own length

The matching flaw in the other direction. For audio shorter than the video, `maxScrollableDistance` took `selectionWidth` to represent the whole track, while the bars were drawn across `selectionWidth × duration / 6.3`. A 3s clip scrolled 640px where its own on-screen length is 305px, so the waveform left the selection window entirely before the in-point reached its limit — the box claimed a 0.5s tail over empty space.

Every length in `_AudioWaveformSelector` now derives from a single `pixelsPerSecond`, so the bars, the scroll range and the shrinking tail cannot disagree about where a second of audio sits. **The long-audio path is unchanged arithmetic** — the pre-existing tail test still pins it byte for byte.

**One deliberate visible change beyond the fixes:** a track shorter than the video now shows its selection box covering the track rather than the full window. That is what the box already documented itself to mean (the playable clip); it just never held for short audio.

### Why the overview bar stays coarse

The bar spans the whole track on one screen width, so it *cannot* be frame-accurate without giving up 1:1 finger tracking — a thumb that lags your finger reads as broken. Coarse seek above, frame-accurate fine control below is the right split. Only the fine control was broken, and only it changed.

### Why the offset is not quantised to frames

Snapping the committed in-point onto the 33ms video frame grid would **cap** precision rather than raise it — audio is continuous and has no reason to land on a video frame boundary. With one pixel of drag now equal to one frame, the continuous value is strictly better than a quantised one.

### Performance note

The 189px floor multiplies the strip's width by the same factor it buys in precision: a 120s track goes from ~724px to 3600px, a 5-minute one to 9000px, and the painter draws one bar per 5px. That took the per-frame cost from ~145 bars to ~720, and ~1800 on the long track — on the drag surface itself. A `RepaintBoundary` now lets the raster be reused while the strip only translates, mirroring what the timeline's sound item already does with the same painter. Real frame cost still belongs on the device pass.

## Out of Scope

The `TimelineSnapController` magnetic snap that sound items already get on the main timeline (clip edges, markers, playhead — #4847) is untouched; this PR is only about resolving the in-point *within the source track*, which is the degree of freedom that had no precision.

`StopMotionRenderService.defaultFrameRate = 30` is a third copy of the same frame grid, and its own doc comment says it must match the ruler. Linking it to `editorFps` needs either `* 1.0` (it is a `const` default parameter value, so `.toDouble()` is unavailable) or a lock-test in an unrelated feature's suite. Left for a separate PR rather than bled into this one.

## Verification

- `flutter analyze lib test integration_test` clean
- `dart format` clean
- 1526 tests green across `test/screens/video_editor/`, `test/blocs/video_editor/`, `test/widgets/video_editor/` and the waveform painter, on the final head
- Four new tests, all four verified to go **red** against the code they guard rather than assumed to: 156 ms/px against the ≤33 ms/px assertion; a 76.8px marker against the expected 40.3px; a 189px waveform span against the expected 3600px; and a 768px short-track selection against the expected 365.7px
- ⚠️ **Not yet verified on a real Samsung Galaxy.** Two things need the device: the selection window is now visibly wider on long tracks (189px vs ~33px) and the waveform scrolls correspondingly further — the numbers are right, but whether the zoom *feels* balanced needs a hand on it; and the strip is now several screens wide, so scrub and fling smoothness should be watched even with the repaint boundary in place.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
