### PR TITLE
fix(c2pa): stop failed signing from leaving debris or destroying the recording

### DIFF
--- a/mobile/lib/services/c2pa_signing_service.dart
+++ b/mobile/lib/services/c2pa_signing_service.dart
@@ -367,6 +367,15 @@ class C2paSigningService {
           signer: signer,
         );
 
+        if (result.signedData.isEmpty) {
+          return C2paSigningResult(
+            signedFilePath: outputPath,
+            success: false,
+            error: 'Signed derived file is empty',
+            failureReason: C2paSigningFailureReason.outputMissing,
+          );
+        }
+
         await outputFile.writeAsBytes(result.signedData, flush: true);
 
         Log.info(

--- a/mobile/lib/services/c2pa_signing_service.dart
+++ b/mobile/lib/services/c2pa_signing_service.dart
@@ -29,6 +29,10 @@ abstract class C2paEditActions {
 /// High-level reason a C2PA signing operation failed.
 enum C2paSigningFailureReason {
   inputMissing,
+
+  /// Signing produced no usable output: either nothing was written, or the
+  /// file it wrote was empty. Both are reported here because neither can
+  /// replace the recording.
   outputMissing,
   tls,
   network,

--- a/mobile/lib/services/c2pa_signing_service.dart
+++ b/mobile/lib/services/c2pa_signing_service.dart
@@ -129,6 +129,9 @@ class C2paSigningService {
     Map<String, dynamic>? cawgIdentityAssertion,
     bool enableAdvancedCawgEmbedding = false,
   }) async {
+    // Declared outside the try so every failure exit can clean up a partial
+    // output the native call may already have created (#7739).
+    String? signedPath;
     try {
       // Opted-out builds must not reach the signer: the endpoint is a sentinel,
       // not a URL, so attempting the call would fail with a confusing error.
@@ -165,7 +168,7 @@ class C2paSigningService {
       // Generate output path for signed video
       final directory = inputFile.parent.path;
       final timestamp = DateTime.now().millisecondsSinceEpoch;
-      final signedPath = '$directory/c2pa_signed_$timestamp.mp4';
+      signedPath = '$directory/c2pa_signed_$timestamp.mp4';
 
       final filename = inputFile.path.split('/').last;
       final manifestResult = _manifestService.buildCreatedVideoManifest(
@@ -223,6 +226,18 @@ class C2paSigningService {
         );
       }
 
+      // The rename below replaces the user's recording in place, so an empty
+      // output would destroy it. Treat it as a failed signing pass (#7739).
+      if (signedFile.lengthSync() == 0) {
+        _deleteSignedOutput(signedPath);
+        return C2paSigningResult(
+          signedFilePath: videoPath,
+          success: false,
+          error: 'Signed file is empty',
+          failureReason: C2paSigningFailureReason.outputMissing,
+        );
+      }
+
       final sFileNew = signedFile.renameSync(inputFile.path);
       Log.debug(
         'Signed file renamed: ${sFileNew.path}',
@@ -247,6 +262,12 @@ class C2paSigningService {
         error: e,
         stackTrace: stackTrace,
       );
+
+      // A throw from the native call can still leave a partial output behind;
+      // nothing will ever pick it up, so it would sit in the documents
+      // directory forever (#7739). The timeout path additionally re-runs this
+      // once the abandoned call settles, since the file may appear later.
+      _deleteSignedOutput(signedPath);
 
       // Return original path - signing is best-effort, not blocking
       return C2paSigningResult(
@@ -388,6 +409,16 @@ class C2paSigningService {
     } catch (_) {
       // The abandoned call failed on its own — still clean up any partial file.
     }
+    _deleteSignedOutput(signedPath);
+  }
+
+  /// Removes a signing output that no caller will ever use.
+  ///
+  /// Signing writes its output next to the input, which for a recorded clip is
+  /// the documents directory. Every failure exit has to remove it or the debris
+  /// accumulates one file per attempt (#7739).
+  static void _deleteSignedOutput(String? signedPath) {
+    if (signedPath == null) return;
     try {
       final orphan = File(signedPath);
       if (orphan.existsSync()) orphan.deleteSync();

--- a/mobile/lib/services/c2pa_signing_service.dart
+++ b/mobile/lib/services/c2pa_signing_service.dart
@@ -368,6 +368,15 @@ class C2paSigningService {
         );
 
         if (result.signedData.isEmpty) {
+          // The sole caller discards this result, so without a log the
+          // failure would be invisible in the field — the exact conditions
+          // that let #7739's debris go unnoticed.
+          Log.warning(
+            'Derived re-sign produced empty signed data; leaving '
+            '"$outputPath" unsigned',
+            name: 'C2paSigningService',
+            category: LogCategory.video,
+          );
           return C2paSigningResult(
             signedFilePath: outputPath,
             success: false,

--- a/mobile/test/services/c2pa_signing_service_test.dart
+++ b/mobile/test/services/c2pa_signing_service_test.dart
@@ -52,6 +52,13 @@ void main() {
       return file;
     }
 
+    List<String> signedLeftovers() => tempDir
+        .listSync()
+        .whereType<File>()
+        .map((file) => file.uri.pathSegments.last)
+        .where((name) => name.startsWith('c2pa_signed_'))
+        .toList();
+
     group('failure classification', () {
       test('classifies iOS secure connection failures as TLS errors', () {
         final reason = C2paSigningService.classifyFailureReason(
@@ -163,13 +170,8 @@ void main() {
           // writing the signed file and for the cleanup to remove the orphan.
           await Future<void>.delayed(const Duration(milliseconds: 150));
 
-          final orphans = tempDir
-              .listSync()
-              .whereType<File>()
-              .where((f) => f.uri.pathSegments.last.startsWith('c2pa_signed_'))
-              .toList();
           expect(
-            orphans,
+            signedLeftovers(),
             isEmpty,
             reason:
                 'a signing call that finishes past the timeout must not leave '
@@ -180,13 +182,6 @@ void main() {
     });
 
     group('signVideo', () {
-      List<String> signedLeftovers() => tempDir
-          .listSync()
-          .whereType<File>()
-          .map((file) => file.uri.pathSegments.last)
-          .where((name) => name.startsWith('c2pa_signed_'))
-          .toList();
-
       test(
         'deletes the partial output when the native call throws (#7739)',
         () async {

--- a/mobile/test/services/c2pa_signing_service_test.dart
+++ b/mobile/test/services/c2pa_signing_service_test.dart
@@ -180,6 +180,71 @@ void main() {
     });
 
     group('signVideo', () {
+      List<String> signedLeftovers() => tempDir
+          .listSync()
+          .whereType<File>()
+          .map((file) => file.uri.pathSegments.last)
+          .where((name) => name.startsWith('c2pa_signed_'))
+          .toList();
+
+      test(
+        'deletes the partial output when the native call throws (#7739)',
+        () async {
+          final video = writeFile('video.mp4', const [0, 1, 2, 3]);
+          final failingService = C2paSigningService(
+            c2pa: _WriteThenThrowC2pa(
+              const [7, 7, 7],
+              PlatformException(
+                code: 'ERROR',
+                message: 'Signature: internal error (COSE signature invalid)',
+              ),
+            ),
+          );
+
+          final result = await failingService.signVideo(videoPath: video.path);
+
+          expect(result.success, isFalse);
+          expect(
+            result.failureReason,
+            C2paSigningFailureReason.signingCredential,
+          );
+          expect(result.signedFilePath, video.path);
+          expect(video.readAsBytesSync(), equals([0, 1, 2, 3]));
+          expect(
+            signedLeftovers(),
+            isEmpty,
+            reason:
+                'a signing call that throws after writing its output must not '
+                'leave a stray c2pa_signed_*.mp4 behind',
+          );
+        },
+      );
+
+      test(
+        'does not replace the recording with a zero-byte output (#7739)',
+        () async {
+          final video = writeFile('video.mp4', const [0, 1, 2, 3]);
+          final emptyOutputService = C2paSigningService(
+            c2pa: _WritingC2pa(const []),
+          );
+
+          final result = await emptyOutputService.signVideo(
+            videoPath: video.path,
+          );
+
+          expect(result.success, isFalse);
+          expect(result.failureReason, C2paSigningFailureReason.outputMissing);
+          expect(result.signedFilePath, video.path);
+          expect(
+            video.readAsBytesSync(),
+            equals([0, 1, 2, 3]),
+            reason:
+                'an empty signing output must never overwrite the recording',
+          );
+          expect(signedLeftovers(), isEmpty);
+        },
+      );
+
       test(
         'replaces the original in place and leaves nothing else behind',
         () async {
@@ -352,6 +417,26 @@ class _SlowWritingC2pa extends C2pa {
   }) async {
     await Future<void>.delayed(delay);
     File(destPath).writeAsBytesSync(const [7, 7, 7]);
+  }
+}
+
+/// Simulates a remote-signing call that fails *after* the native side has
+/// already created its output — the leak observed in #7739.
+class _WriteThenThrowC2pa extends C2pa {
+  _WriteThenThrowC2pa(this.bytes, this.error);
+
+  final List<int> bytes;
+  final Object error;
+
+  @override
+  Future<void> signFile({
+    required String sourcePath,
+    required String destPath,
+    required String manifestJson,
+    required C2paSigner signer,
+  }) async {
+    File(destPath).writeAsBytesSync(bytes);
+    throw error;
   }
 }
 

--- a/mobile/test/services/c2pa_signing_service_test.dart
+++ b/mobile/test/services/c2pa_signing_service_test.dart
@@ -350,6 +350,51 @@ void main() {
       });
 
       test(
+        'leaves the derived file untouched when signing returns empty bytes',
+        () async {
+          when(() => mockC2pa.readManifestFromFile(any())).thenAnswer(
+            (_) async => const ManifestStoreInfo(activeManifest: 'urn:c2pa:x'),
+          );
+
+          final builder = _MockManifestBuilder();
+          when(
+            () => mockC2pa.createBuilder(any()),
+          ).thenAnswer((_) async => builder);
+          when(
+            () => builder.addIngredient(
+              data: any(named: 'data'),
+              mimeType: any(named: 'mimeType'),
+              config: any(named: 'config'),
+            ),
+          ).thenAnswer((_) async {});
+          when(
+            () => builder.sign(
+              sourceData: any(named: 'sourceData'),
+              mimeType: any(named: 'mimeType'),
+              signer: any(named: 'signer'),
+            ),
+          ).thenAnswer(
+            (_) async =>
+                BuilderSignResult(signedData: Uint8List(0), manifestSize: 0),
+          );
+
+          final output = writeFile('out.mp4', const [1, 2, 3]);
+          final source = writeFile('src.mp4', const [4, 5, 6]);
+
+          final result = await service.resignDerived(
+            outputPath: output.path,
+            sourcePath: source.path,
+            action: C2paEditActions.edited,
+          );
+
+          expect(result.success, isFalse);
+          expect(result.failureReason, C2paSigningFailureReason.outputMissing);
+          expect(output.readAsBytesSync(), equals([1, 2, 3]));
+          verify(builder.dispose).called(1);
+        },
+      );
+
+      test(
         'returns failure without signing when the output does not exist',
         () async {
           final result = await service.resignDerived(


### PR DESCRIPTION
## Description

`C2paSigningService.signVideo` writes its output to `<input parent>/c2pa_signed_<timestamp>.mp4`, which for a recorded clip is the app's documents directory. Cleanup was only ever wired for one failure mode — #6058 added `_deleteAbandonedSignedFile` for the `TimeoutException` path — so every other throw from the native `signFile` left its partial output sitting there forever. On a device where signing fails repeatedly (#7386) that is one file per recorded clip; 22 of them were found on a real device.

Three changes in `C2paSigningService`:

- **Cleanup on every failure exit.** `signedPath` moves out of the `try` so the generic `catch` can see it, and both it and the existing timeout path now delete through a shared `_deleteSignedOutput` helper. The timeout path still needs its deferred variant on top: `timeout()` does not cancel the native call, so the file can appear *after* we have already bailed.
- **The success path validates size, not just existence.** `renameSync` replaces the user's recording in place, so `existsSync()` alone would let a signing pass that returns without throwing but writes an empty file overwrite the recording with zero bytes. That was not what happened here — the leaked files still carry the `c2pa_signed_` name, so the rename never ran — but it is the same missing validation with a far worse outcome, so it is closed in the same fix. An empty output is now deleted and reported as `outputMissing`.
- **Derived re-signing preserves its input on empty output.** `resignDerived` also writes signed bytes back in place. It now rejects empty `signedData` before that write, reports `outputMissing`, and leaves the unsigned derived video intact.

A follow-up commit is self-review cleanup only: the leftover-listing the new tests do is hoisted next to `writeFile` so the #6058 orphan test and the #7739 tests read the directory the same way instead of drifting apart, and `outputMissing` gets a doc line saying it now also covers an output that exists but is empty.

**Related Issue:** Closes #7739

## Out of Scope

- The 22 files already on the device. This stops new debris; #7760 tracks a safe legacy sweep because the clip-recovery tool in #7737 deliberately excludes `c2pa_signed_*` outputs.
- Making signing actually succeed — that is #7386. This fix stays relevant regardless of why a future attempt fails.
- Rejecting a *truncated but non-empty* output before the rename. It would be a stronger guard, but nothing observed produces one, and a size floor can only be justified by guessing at how the native signer fails. Zero bytes is the failure that was actually seen.

## Verification

- New regression test per path, all three re-verified to fail against the pre-fix service:
  - a `signFile` that throws *after* writing its output → `Expected: empty / Actual: ['c2pa_signed_1786964993571.mp4']`
  - a zero-byte `signVideo` output → `Expected: false / Actual: <true>` (reported success, and would have overwritten the recording)
  - empty `resignDerived` signed data → `Expected: false / Actual: <true>` (reported success, truncated the derived file)
- `flutter test test/services/c2pa_signing_service_test.dart` plus the six sibling C2PA/ProofMode suites — all green.
- `flutter analyze` and `dart format` clean on both changed files.
- Not yet confirmed on the real Samsung Galaxy: the debris only appears once signing fails, which needs the #7386 device state to reproduce. The unit tests cover both failure paths directly against the filesystem.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)


