### PR TITLE
fix(text): close the remaining unsanitized UTF-16 surfaces

### DIFF
--- a/mobile/integration_test/creator_sync/helpers/sync_e2e_harness.dart
+++ b/mobile/integration_test/creator_sync/helpers/sync_e2e_harness.dart
@@ -62,7 +62,7 @@ class SyncE2eHarness {
   /// and "after" edits apart by [label] alone.
   Map<String, dynamic> soundBody({required String label}) {
     return SavedSound(
-      audio: const AudioEvent(
+      audio: AudioEvent(
         id: _soundId,
         pubkey: _audioPubkey,
         createdAt: 1700000000,

--- a/mobile/lib/providers/classic_vines_provider.dart
+++ b/mobile/lib/providers/classic_vines_provider.dart
@@ -385,7 +385,16 @@ class ClassicViner {
   final String pubkey;
   final int totalLoops;
   final int videoCount;
-  final String? authorName; // Display name from classic Vine data
+
+  /// Display name carried over from the classic Vine archive.
+  ///
+  /// Already well-formed UTF-16: [topClassicViners] only ever copies this from
+  /// [VideoEvent.authorName], and that constructor is the sanitizing display
+  /// boundary. Feeding it from anything else would need its own boundary —
+  /// the viner slider renders this straight into a `Text`, and a lone
+  /// surrogate throws out of Flutter's paragraph builder.
+  final String? authorName;
+
   final String? authorAvatar; // Profile picture URL from API
 }
 

--- a/mobile/packages/badge_repository/lib/src/badge_repository.dart
+++ b/mobile/packages/badge_repository/lib/src/badge_repository.dart
@@ -4,6 +4,7 @@ import 'package:badge_repository/src/nip58_badge_parser.dart';
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:text_sanitizer/text_sanitizer.dart';
 
 typedef BadgeCurrentPubkeyReader = String? Function();
 
@@ -1568,8 +1569,16 @@ class _DashboardLookupMemo {
   ) => _issuedAwards.putIfAbsent(pubkey, load);
 }
 
+/// Badge label to fall back on when no kind-30009 definition loaded: the
+/// d-tag half of the coordinate, or the whole coordinate when it has no
+/// d-tag.
+///
+/// The coordinate comes from an `a` tag on someone else's award or profile
+/// badges event, so it is remote text and it renders as a badge name.
+/// [Nip58BadgeDefinition] sanitizes the definition-backed path; this covers
+/// the one that bypasses it.
 String _definitionNameFromCoordinate(String coordinate) {
   final parts = coordinate.split(':');
-  if (parts.length < 3) return coordinate;
-  return parts.sublist(2).join(':');
+  if (parts.length < 3) return sanitizeUtf16(coordinate);
+  return sanitizeUtf16(parts.sublist(2).join(':'));
 }

--- a/mobile/packages/badge_repository/lib/src/badge_repository.dart
+++ b/mobile/packages/badge_repository/lib/src/badge_repository.dart
@@ -103,7 +103,16 @@ class CreatedBadgeViewData {
   final int recipientCount;
 
   String get coordinate => definition.coordinate;
-  String get displayName => definition.name ?? definition.dTag;
+
+  /// Badge name, falling back to the identifier when the definition carries
+  /// no `name` tag.
+  ///
+  /// [Nip58BadgeDefinition.dTag] stays raw on the model because the badge
+  /// editor republishes it as the event's `d` tag — rewriting a code unit
+  /// there would address a different badge. Sanitizing on the way out keeps
+  /// the rendered name well-formed without moving the address, the same split
+  /// [_definitionNameFromCoordinate] uses.
+  String get displayName => definition.name ?? sanitizeUtf16(definition.dTag);
   String? get imageUrl =>
       definition.imageUrl ??
       (definition.thumbnails.isNotEmpty ? definition.thumbnails.first : null);

--- a/mobile/packages/badge_repository/lib/src/nip58_badge_models.dart
+++ b/mobile/packages/badge_repository/lib/src/nip58_badge_models.dart
@@ -1,15 +1,26 @@
 import 'package:nostr_sdk/nostr_sdk.dart';
+import 'package:text_sanitizer/text_sanitizer.dart';
 
 class Nip58BadgeDefinition {
-  const Nip58BadgeDefinition({
+  /// Creates a badge definition, normalizing [name] and [description] to
+  /// well-formed UTF-16.
+  ///
+  /// A kind-30009 definition can be authored by any pubkey, and the badge
+  /// dashboard, detail screen and profile badge sheet render both values as
+  /// plain `Text`. Flutter's paragraph builder throws `Invalid argument(s):
+  /// string is not well-formed UTF-16` on a lone surrogate, so the
+  /// constructor is the display boundary — the same shape `UserProfile` and
+  /// `VideoEvent` use.
+  Nip58BadgeDefinition({
     required this.event,
     required this.coordinate,
     required this.dTag,
-    this.name,
-    this.description,
+    String? name,
+    String? description,
     this.imageUrl,
     this.thumbnails = const [],
-  });
+  }) : name = sanitizeUtf16OrNull(name),
+       description = sanitizeUtf16OrNull(description);
 
   final Event event;
   final String coordinate;

--- a/mobile/packages/badge_repository/lib/src/nip58_badge_models.dart
+++ b/mobile/packages/badge_repository/lib/src/nip58_badge_models.dart
@@ -24,7 +24,16 @@ class Nip58BadgeDefinition {
 
   final Event event;
   final String coordinate;
+
+  /// The event's `d` tag, deliberately left raw.
+  ///
+  /// It addresses the definition: the coordinate is built from it and the
+  /// badge editor republishes it verbatim, so rewriting a code unit here
+  /// would edit a different badge. The one place it is rendered —
+  /// `CreatedBadgeViewData.displayName`, when the definition has no `name`
+  /// tag — sanitizes on the way out instead.
   final String dTag;
+
   final String? name;
   final String? description;
   final String? imageUrl;

--- a/mobile/packages/badge_repository/pubspec.yaml
+++ b/mobile/packages/badge_repository/pubspec.yaml
@@ -17,6 +17,8 @@ dependencies:
   nostr_sdk:
     path: ../nostr_sdk
   shared_preferences: ^2.5.3
+  text_sanitizer:
+    path: ../text_sanitizer
 
 dev_dependencies:
   flutter_test:

--- a/mobile/packages/badge_repository/test/src/badge_repository_test.dart
+++ b/mobile/packages/badge_repository/test/src/badge_repository_test.dart
@@ -2891,6 +2891,33 @@ void main() {
       expect(viewData.description, isNull);
       expect(viewData.imageUrl, isNull);
     });
+
+    // The coordinate comes from someone else's `a` tag, so the fallback name
+    // is remote text too. The headless flutter_tester does not throw on a lone
+    // surrogate — only the real engine does — so this asserts the value.
+    test('replaces a lone surrogate in the coordinate-derived name', () {
+      final coordinate =
+          '30009:${_pubkey(5)}:daily${String.fromCharCode(0xD83D)}diviner';
+      final viewData = ProfileBadgeViewData(
+        badge: Nip58ProfileBadgeRef(
+          definitionCoordinate: coordinate,
+          awardEventId: _eventId(40),
+        ),
+      );
+
+      expect(viewData.displayName, 'daily�diviner');
+    });
+
+    test('replaces a lone surrogate in a coordinate with no d-tag', () {
+      final viewData = ProfileBadgeViewData(
+        badge: Nip58ProfileBadgeRef(
+          definitionCoordinate: 'broken${String.fromCharCode(0xDE00)}',
+          awardEventId: _eventId(40),
+        ),
+      );
+
+      expect(viewData.displayName, 'broken�');
+    });
   });
 
   group(BadgeAwardViewData, () {

--- a/mobile/packages/badge_repository/test/src/badge_repository_test.dart
+++ b/mobile/packages/badge_repository/test/src/badge_repository_test.dart
@@ -1508,6 +1508,37 @@ void main() {
         },
       );
 
+      // A definition with no `name` tag falls back to the identifier, which
+      // is raw event text. The headless flutter_tester does not throw on a
+      // lone surrogate — only the real engine does — so this asserts the
+      // value rather than a rendered badge row.
+      test(
+        'replaces a lone surrogate in the identifier fallback name',
+        () async {
+          final dTag = 'scene${String.fromCharCode(0xD83D)}stealer';
+          _stubQueries(nostrClient, {
+            'created:${_pubkey(1)}': [
+              // No `name` tag, so displayName falls back to the identifier.
+              _event(
+                id: _eventId(90),
+                pubkey: _pubkey(1),
+                kind: EventKind.badgeDefinition,
+                tags: [
+                  ['d', dTag],
+                ],
+              ),
+            ],
+          });
+
+          final created = await repository.loadCreatedBadges();
+
+          expect(created.single.displayName, 'scene\u{FFFD}stealer');
+          // The address keeps the raw identifier: sanitizing it would point
+          // at a badge that does not exist.
+          expect(created.single.coordinate, '30009:${_pubkey(1)}:$dTag');
+        },
+      );
+
       test('counts awards and distinct recipients per definition', () async {
         const coordinate = 'scene-stealer';
         _stubQueries(nostrClient, {

--- a/mobile/packages/badge_repository/test/src/nip58_badge_parser_test.dart
+++ b/mobile/packages/badge_repository/test/src/nip58_badge_parser_test.dart
@@ -147,6 +147,27 @@ void main() {
         'https://media.divine.video/badge-64.png',
       ]);
     });
+
+    // The headless flutter_tester does not throw on a lone surrogate — only
+    // the real engine does — so this asserts the parsed model value rather
+    // than a rendered badge row.
+    test('replaces lone surrogates in the badge name and description', () {
+      final event = _event(
+        id: _eventId(12),
+        pubkey: _pubkey(10),
+        kind: EventKind.badgeDefinition,
+        tags: [
+          ['d', 'diviner-of-the-day'],
+          ['name', 'Diviner${String.fromCharCode(0xD83D)}'],
+          ['description', 'loudest${String.fromCharCode(0xDE00)} loops'],
+        ],
+      );
+
+      final definition = Nip58BadgeParser.parseDefinition(event);
+
+      expect(definition!.name, 'Diviner�');
+      expect(definition.description, 'loudest� loops');
+    });
   });
 }
 

--- a/mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart
+++ b/mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart
@@ -1307,12 +1307,16 @@ class FunnelcakeApiClient {
           jsonDecode(response.body),
         );
 
+        // Both branches go through HashtagSearchResult so a bare-string item
+        // gets the same UTF-16 normalization as a mapped one — these tags end
+        // up as chip labels, and a lone surrogate throws out of Flutter's
+        // paragraph builder.
         return items
             .map((item) {
               if (item is Map<String, dynamic>) {
                 return HashtagSearchResult.fromJson(item).tag;
               }
-              return item.toString();
+              return HashtagSearchResult(tag: item.toString()).tag;
             })
             .where((tag) => tag.isNotEmpty)
             .toList();

--- a/mobile/packages/funnelcake_api_client/test/src/funnelcake_api_client_test.dart
+++ b/mobile/packages/funnelcake_api_client/test/src/funnelcake_api_client_test.dart
@@ -1972,6 +1972,20 @@ void main() {
         expect(hashtags, equals(['bitcoin', 'nostr']));
       });
 
+      // A lone surrogate in a chip label throws out of Flutter's paragraph
+      // builder, and the plain-string branch bypasses HashtagSearchResult.
+      // fromJson, so it needs the same normalization as the mapped one.
+      test('normalizes malformed UTF-16 in both response shapes', () async {
+        const malformedResponse = r'["bit\ud83dcoin", {"tag": "no\ud83dstr"}]';
+        when(
+          () => mockHttpClient.get(any(), headers: any(named: 'headers')),
+        ).thenAnswer((_) async => http.Response(malformedResponse, 200));
+
+        final hashtags = await client.searchHashtags(query: 'bit');
+
+        expect(hashtags, equals(['bit�coin', 'no�str']));
+      });
+
       test('constructs correct URL with query parameter', () async {
         when(
           () => mockHttpClient.get(any(), headers: any(named: 'headers')),

--- a/mobile/packages/hashtag_repository/test/src/hashtag_repository_test.dart
+++ b/mobile/packages/hashtag_repository/test/src/hashtag_repository_test.dart
@@ -310,13 +310,13 @@ void main() {
         'delegates to FunnelcakeApiClient with correct parameters',
         () async {
           final trendingHashtags = [
-            const TrendingHashtag(
+            TrendingHashtag(
               tag: 'bitcoin',
               videoCount: 42,
               uniqueCreators: 10,
               totalLoops: 1000,
             ),
-            const TrendingHashtag(
+            TrendingHashtag(
               tag: 'nostr',
               videoCount: 30,
               uniqueCreators: 8,
@@ -338,7 +338,7 @@ void main() {
       test('passes custom limit to client', () async {
         when(() => mockClient.fetchTrendingHashtags(limit: 50)).thenAnswer(
           (_) async => [
-            const TrendingHashtag(
+            TrendingHashtag(
               tag: 'bitcoin',
               videoCount: 42,
               uniqueCreators: 10,
@@ -418,7 +418,7 @@ void main() {
 
       test('fetches from client on cache miss', () async {
         final trendingHashtags = [
-          const TrendingHashtag(
+          TrendingHashtag(
             tag: 'bitcoin',
             videoCount: 42,
             uniqueCreators: 10,
@@ -439,7 +439,7 @@ void main() {
         'returns cached result on second call without force refresh',
         () async {
           final trendingHashtags = [
-            const TrendingHashtag(
+            TrendingHashtag(
               tag: 'nostr',
               videoCount: 30,
               uniqueCreators: 8,
@@ -461,7 +461,7 @@ void main() {
 
       test('bypasses cache when forceRefresh is true', () async {
         final firstBatch = [
-          const TrendingHashtag(
+          TrendingHashtag(
             tag: 'vine',
             videoCount: 10,
             uniqueCreators: 3,
@@ -469,7 +469,7 @@ void main() {
           ),
         ];
         final secondBatch = [
-          const TrendingHashtag(
+          TrendingHashtag(
             tag: 'openvine',
             videoCount: 20,
             uniqueCreators: 5,
@@ -499,7 +499,7 @@ void main() {
           cacheDuration: Duration.zero,
         );
         final hashtags = [
-          const TrendingHashtag(
+          TrendingHashtag(
             tag: 'bitcoin',
             videoCount: 42,
             uniqueCreators: 10,

--- a/mobile/packages/models/lib/src/actor_notification.dart
+++ b/mobile/packages/models/lib/src/actor_notification.dart
@@ -9,8 +9,12 @@ part of 'notification_item.dart';
 /// No video reference; one row per event.
 @immutable
 class ActorNotification extends NotificationItem {
-  /// Creates an [ActorNotification].
-  const ActorNotification({
+  /// Creates an [ActorNotification], normalizing [commentText] to well-formed
+  /// UTF-16.
+  ///
+  /// [commentText] is the source event's body — relay text the row renders as
+  /// a quote. See [VideoNotification] for the boundary rationale.
+  ActorNotification({
     required super.id,
     required super.type,
     required this.actor,
@@ -19,11 +23,12 @@ class ActorNotification extends NotificationItem {
     super.targetEventId,
     super.sourceEventIds,
     super.notificationIds,
-    this.commentText,
+    String? commentText,
     this.isFollowingBack = false,
     this.videoAddressableId,
     this.hasCommentTarget = false,
-  }) : assert(
+  }) : commentText = sanitizeUtf16OrNull(commentText),
+       assert(
          type == NotificationKind.follow ||
              type == NotificationKind.like ||
              type == NotificationKind.mention ||

--- a/mobile/packages/models/lib/src/audio_event.dart
+++ b/mobile/packages/models/lib/src/audio_event.dart
@@ -7,6 +7,7 @@ import 'package:models/src/nostr_hex_utils.dart';
 import 'package:models/src/video_event.dart';
 import 'package:models/src/vine_sound.dart';
 import 'package:nostr_sdk/event.dart';
+import 'package:text_sanitizer/text_sanitizer.dart';
 
 /// Kind number for audio file metadata events (NIP-94)
 const int audioEventKind = 1063;
@@ -37,8 +38,23 @@ enum AudioSourceKind {
 /// See NIP-94 for the full file metadata specification.
 @immutable
 class AudioEvent {
-  /// Creates a new AudioEvent with the specified fields.
-  const AudioEvent({
+  /// Creates a new AudioEvent, normalizing its display text to well-formed
+  /// UTF-16.
+  ///
+  /// Kind 1063 tags are remote text that reaches layout verbatim — the sound
+  /// detail screen and the public-credit editor render [title], [source],
+  /// [creatorName] and [licenseName] as plain `Text`, and [publicTags] as
+  /// chips. Flutter's paragraph builder throws `Invalid argument(s): string
+  /// is not well-formed UTF-16` on a lone surrogate, so this constructor is
+  /// the display boundary, matching `UserProfile` and `VideoEvent`. Every
+  /// factory below funnels through it, so a poisoned tag is repaired once at
+  /// the point the event becomes a typed model rather than at each widget.
+  ///
+  /// [url], [proxyId], [sha256], [mimeType] and the id/reference fields are
+  /// left untouched: they select a playback source or address an event, never
+  /// reach text layout, and rewriting a code unit inside one would change
+  /// which file is resolved.
+  AudioEvent({
     required this.id,
     required this.pubkey,
     required this.createdAt,
@@ -47,17 +63,17 @@ class AudioEvent {
     this.sha256,
     this.fileSize,
     this.duration,
-    this.title,
-    this.source,
+    String? title,
+    String? source,
     this.sourceVideoReference,
     this.sourceVideoRelay,
     this.externalSource,
-    this.creatorName,
+    String? creatorName,
     this.creatorPubkey,
     this.creatorUrl,
-    this.licenseName,
+    String? licenseName,
     this.licenseUrl,
-    this.publicTags = const [],
+    List<String> publicTags = const [],
     this.proxyId,
     this.proxyProtocol,
     this.startOffset = Duration.zero,
@@ -67,7 +83,11 @@ class AudioEvent {
     this.anchorClipId,
     this.allowsReuse = true,
     this.hasExplicitReuseConsent = false,
-  });
+  }) : title = sanitizeUtf16OrNull(title),
+       source = sanitizeUtf16OrNull(source),
+       creatorName = sanitizeUtf16OrNull(creatorName),
+       licenseName = sanitizeUtf16OrNull(licenseName),
+       publicTags = sanitizeUtf16List(publicTags);
 
   /// Parse an AudioEvent from a Nostr Event.
   ///
@@ -796,17 +816,26 @@ AudioExternalSource? _parseExternalSource(Object? value) {
 /// Normalized metadata for a sound result served by the sound library proxy.
 @immutable
 class AudioExternalSource {
-  const AudioExternalSource({
+  /// Creates external-source metadata, normalizing its display text to
+  /// well-formed UTF-16.
+  ///
+  /// The proxy normalizes third-party catalog data (Freesound, Openverse) but
+  /// does not own the strings inside it, and the sound detail screen renders
+  /// [providerName], [creatorName] and [catalogTags] directly. See
+  /// [AudioEvent] for why the constructor is the boundary.
+  AudioExternalSource({
     required this.provider,
     required this.providerSoundId,
-    required this.providerName,
+    required String providerName,
     required this.license,
-    this.creatorName,
+    String? creatorName,
     this.creatorUrl,
     this.sourceUrl,
     this.previewUrl,
-    this.catalogTags = const [],
-  });
+    List<String> catalogTags = const [],
+  }) : providerName = sanitizeUtf16(providerName),
+       creatorName = sanitizeUtf16OrNull(creatorName),
+       catalogTags = sanitizeUtf16List(catalogTags);
 
   factory AudioExternalSource.fromJson(Map<String, dynamic> json) {
     final licenseJson = json['license'];
@@ -902,14 +931,18 @@ bool _stringListsEqual(List<String> left, List<String> right) {
 /// License metadata that has already been normalized by the sound proxy.
 @immutable
 class AudioLicenseMetadata {
-  const AudioLicenseMetadata({
+  /// Creates license metadata, normalizing [name] to well-formed UTF-16.
+  ///
+  /// [name] is the human-readable licence label the credit UI renders;
+  /// [type] and [url] are machine values. See [AudioEvent].
+  AudioLicenseMetadata({
     required this.type,
-    required this.name,
+    required String name,
     required this.url,
     required this.allowsCommercialUse,
     required this.allowsDerivatives,
     required this.requiresAttribution,
-  });
+  }) : name = sanitizeUtf16(name);
 
   factory AudioLicenseMetadata.fromJson(Map<String, dynamic> json) {
     return AudioLicenseMetadata(

--- a/mobile/packages/models/lib/src/curated_list.dart
+++ b/mobile/packages/models/lib/src/curated_list.dart
@@ -4,6 +4,7 @@
 // ABOUTME: (event IDs + addressable coordinates).
 
 import 'package:equatable/equatable.dart';
+import 'package:text_sanitizer/text_sanitizer.dart';
 
 /// Ordering options for playlist playback.
 enum PlayOrder {
@@ -66,15 +67,23 @@ extension PlayOrderExtension on PlayOrder {
 /// public list puts them in `e`/`a` tags, a private one seals them into the
 /// event content with NIP-44. Both are published, so both survive a device.
 class CuratedList extends Equatable {
-  /// Creates a curated list.
-  const CuratedList({
+  /// Creates a curated list, normalizing [name] and [description] to
+  /// well-formed UTF-16.
+  ///
+  /// Both come from a kind-30005 event that anyone may author — a
+  /// collaborative list, or someone else's list surfaced by search — and both
+  /// render as plain `Text`. A lone surrogate there throws `Invalid
+  /// argument(s): string is not well-formed UTF-16` out of Flutter's
+  /// paragraph builder, so the constructor is the display boundary, matching
+  /// `UserProfile` and `VideoEvent`.
+  CuratedList({
     required this.id,
-    required this.name,
+    required String name,
     required this.videoEventIds,
     required this.createdAt,
     required this.updatedAt,
     this.pubkey,
-    this.description,
+    String? description,
     this.imageUrl,
     this.isPublic = true,
     this.nostrEventId,
@@ -85,7 +94,8 @@ class CuratedList extends Equatable {
     this.thumbnailEventId,
     this.thumbnailUrls = const [],
     this.playOrder = PlayOrder.chronological,
-  });
+  }) : name = sanitizeUtf16(name),
+       description = sanitizeUtf16OrNull(description);
 
   /// Creates a [CuratedList] from a JSON map.
   factory CuratedList.fromJson(Map<String, dynamic> json) => CuratedList(

--- a/mobile/packages/models/lib/src/hashtag_search_result.dart
+++ b/mobile/packages/models/lib/src/hashtag_search_result.dart
@@ -2,6 +2,7 @@
 // ABOUTME: Represents hashtag data returned from the search/trending endpoints.
 
 import 'package:meta/meta.dart';
+import 'package:text_sanitizer/text_sanitizer.dart';
 
 /// Hashtag result from Funnelcake search API.
 ///
@@ -12,14 +13,19 @@ import 'package:meta/meta.dart';
 /// - `/analytics/hashtags/trending`: `{"tag": "funny", "score": 95.2, ...}`
 @immutable
 class HashtagSearchResult {
-  /// Creates a new [HashtagSearchResult] instance.
-  const HashtagSearchResult({
-    required this.tag,
+  /// Creates a new [HashtagSearchResult], normalizing [tag] to well-formed
+  /// UTF-16.
+  ///
+  /// Same origin and same chip rendering as `TrendingHashtag`: the API
+  /// aggregates `t` tag values authored by anyone, and a lone surrogate in a
+  /// chip label throws out of Flutter's paragraph builder.
+  HashtagSearchResult({
+    required String tag,
     this.videoCount,
     this.score,
     this.totalViews,
     this.momentum,
-  });
+  }) : tag = sanitizeUtf16(tag);
 
   /// Creates a [HashtagSearchResult] from JSON response.
   ///

--- a/mobile/packages/models/lib/src/notification_item.dart
+++ b/mobile/packages/models/lib/src/notification_item.dart
@@ -4,6 +4,7 @@
 import 'package:equatable/equatable.dart';
 import 'package:meta/meta.dart';
 import 'package:models/src/actor_info.dart';
+import 'package:text_sanitizer/text_sanitizer.dart';
 
 part 'video_notification.dart';
 part 'actor_notification.dart';

--- a/mobile/packages/models/lib/src/trending_hashtag.dart
+++ b/mobile/packages/models/lib/src/trending_hashtag.dart
@@ -2,20 +2,26 @@
 // ABOUTME: Represents a hashtag with usage metrics for discovery features.
 
 import 'package:meta/meta.dart';
+import 'package:text_sanitizer/text_sanitizer.dart';
 
 /// A trending hashtag with associated metrics from the Funnelcake API.
 ///
 /// Used for hashtag discovery and the trending hashtags feed.
 @immutable
 class TrendingHashtag {
-  /// Creates a new [TrendingHashtag] instance.
-  const TrendingHashtag({
-    required this.tag,
+  /// Creates a new [TrendingHashtag], normalizing [tag] to well-formed
+  /// UTF-16.
+  ///
+  /// The API aggregates `t` tag values authored by anyone, and the trending
+  /// row renders each one as a chip label. A lone surrogate throws out of
+  /// Flutter's paragraph builder, so the constructor is the display boundary.
+  TrendingHashtag({
+    required String tag,
     required this.videoCount,
     this.uniqueCreators = 0,
     this.totalLoops = 0,
     this.lastUsed,
-  });
+  }) : tag = sanitizeUtf16(tag);
 
   /// Creates a [TrendingHashtag] from JSON response.
   ///

--- a/mobile/packages/models/lib/src/user_list.dart
+++ b/mobile/packages/models/lib/src/user_list.dart
@@ -2,21 +2,29 @@
 // ABOUTME: Contains pubkeys and metadata for lists of people.
 
 import 'package:equatable/equatable.dart';
+import 'package:text_sanitizer/text_sanitizer.dart';
 
 /// Represents a user list (NIP-51 kind 30000) containing pubkeys.
 class UserList extends Equatable {
-  const UserList({
+  /// Creates a user list, normalizing [name] and [description] to well-formed
+  /// UTF-16.
+  ///
+  /// Both come from a kind-30000 event that any pubkey may author and both
+  /// render as plain `Text`; a lone surrogate throws out of Flutter's
+  /// paragraph builder. See `CuratedList` for the boundary rationale.
+  UserList({
     required this.id,
-    required this.name,
+    required String name,
     required this.pubkeys,
     required this.createdAt,
     required this.updatedAt,
-    this.description,
+    String? description,
     this.imageUrl,
     this.isPublic = true,
     this.nostrEventId,
     this.isEditable = true,
-  });
+  }) : name = sanitizeUtf16(name),
+       description = sanitizeUtf16OrNull(description);
 
   factory UserList.fromJson(Map<String, dynamic> json) => UserList(
     id: json['id'] as String,

--- a/mobile/packages/models/lib/src/video_event.dart
+++ b/mobile/packages/models/lib/src/video_event.dart
@@ -178,8 +178,12 @@ class VideoEvent {
   /// it would rewrite valid text a user typed — and stays on the display
   /// getters for that reason.
   ///
-  /// Identifier, URL, and tag fields are left untouched — they are either hex
-  /// (`id`, `pubkey`, `sha256`) or structural.
+  /// [hashtags] is sanitized element-wise for the same reason: `t` tag values
+  /// are free-form relay text and every hashtag chip renders one verbatim.
+  ///
+  /// The remaining identifier, URL, and tag fields are left untouched — they
+  /// are either hex (`id`, `pubkey`, `sha256`) or structural. [categories] is
+  /// derived locally and is always empty for relay-sourced events.
   VideoEvent({
     required this.id,
     required this.pubkey,
@@ -195,7 +199,7 @@ class VideoEvent {
     this.mimeType,
     this.sha256,
     this.fileSize,
-    this.hashtags = const [],
+    List<String> hashtags = const [],
     this.categories = const [],
     this.publishedAt,
     this.rawTags = const {},
@@ -240,7 +244,8 @@ class VideoEvent {
   }) : content = sanitizeUtf16(content),
        title = sanitizeUtf16OrNull(title),
        altText = sanitizeUtf16OrNull(altText),
-       authorName = sanitizeUtf16OrNull(authorName);
+       authorName = sanitizeUtf16OrNull(authorName),
+       hashtags = sanitizeUtf16List(hashtags);
 
   /// Reconstructs a [VideoEvent] from a map produced by [toJson].
   ///

--- a/mobile/packages/models/lib/src/video_notification.dart
+++ b/mobile/packages/models/lib/src/video_notification.dart
@@ -11,8 +11,18 @@ part of 'notification_item.dart';
 /// holds the full actor count.
 @immutable
 class VideoNotification extends NotificationItem {
-  /// Creates a [VideoNotification].
-  const VideoNotification({
+  /// Creates a [VideoNotification], normalizing its quoted text to
+  /// well-formed UTF-16.
+  ///
+  /// [videoTitle], [commentText] and [listTitle] are relay-authored strings —
+  /// a video's title, a commenter's body, someone else's curated-list name —
+  /// that the notification row renders straight into a `Text.rich` span. A
+  /// lone surrogate there throws `Invalid argument(s): string is not
+  /// well-formed UTF-16` out of Flutter's paragraph builder. The repository
+  /// builds these rows from four different sources (REST payload, Drift
+  /// placeholder rows, grouped merges, cache rehydration), so the constructor
+  /// is the one boundary all of them cross.
+  VideoNotification({
     required super.id,
     required super.type,
     required this.videoEventId,
@@ -23,13 +33,16 @@ class VideoNotification extends NotificationItem {
     super.sourceEventIds,
     super.notificationIds,
     this.videoThumbnailUrl,
-    this.videoTitle,
+    String? videoTitle,
     this.videoAddressableId,
-    this.commentText,
-    this.listTitle,
+    String? commentText,
+    String? listTitle,
     this.listCoordinate,
     this.addedVideoCount,
-  }) : assert(
+  }) : videoTitle = sanitizeUtf16OrNull(videoTitle),
+       commentText = sanitizeUtf16OrNull(commentText),
+       listTitle = sanitizeUtf16OrNull(listTitle),
+       assert(
          type == NotificationKind.like ||
              type == NotificationKind.likeComment ||
              type == NotificationKind.comment ||
@@ -40,7 +53,7 @@ class VideoNotification extends NotificationItem {
          'VideoNotification only supports like, likeComment, comment, '
          'mention, repost, newPost, listAdd',
        ),
-       assert(actors.length > 0, 'must have at least one actor'),
+       assert(actors.isNotEmpty, 'must have at least one actor'),
        assert(
          totalCount >= actors.length,
          'totalCount cannot be less than actors.length',

--- a/mobile/packages/models/test/src/actor_notification_test.dart
+++ b/mobile/packages/models/test/src/actor_notification_test.dart
@@ -314,5 +314,35 @@ void main() {
         expect(a, isNot(equals(b)));
       });
     });
+
+    group('UTF-16 well-formedness', () {
+      // The headless flutter_tester does not throw on a lone surrogate — only
+      // the real engine does — so this asserts the model value rather than the
+      // rendered quote.
+      test('replaces a lone surrogate in commentText', () {
+        final notification = ActorNotification(
+          id: 'n1',
+          type: NotificationKind.reply,
+          actor: actor,
+          timestamp: timestamp,
+          commentText: 'nice${String.fromCharCode(0xDE00)} one',
+        );
+
+        expect(notification.commentText, equals('nice� one'));
+      });
+
+      test('keeps well-formed commentText identical', () {
+        const commentText = 'nice \u{1F600} one';
+        final notification = ActorNotification(
+          id: 'n1',
+          type: NotificationKind.reply,
+          actor: actor,
+          timestamp: timestamp,
+          commentText: commentText,
+        );
+
+        expect(notification.commentText, same(commentText));
+      });
+    });
   });
 }

--- a/mobile/packages/models/test/src/audio_event_test.dart
+++ b/mobile/packages/models/test/src/audio_event_test.dart
@@ -326,7 +326,7 @@ void main() {
       });
 
       test('isBundled returns false for Nostr sounds', () {
-        const audioEvent = AudioEvent(
+        final audioEvent = AudioEvent(
           id: testHexId,
           pubkey: testPubkey,
           createdAt: 1700000000,
@@ -350,7 +350,7 @@ void main() {
       });
 
       test('assetPath returns null for Nostr sounds', () {
-        const audioEvent = AudioEvent(
+        final audioEvent = AudioEvent(
           id: testHexId,
           pubkey: testPubkey,
           createdAt: 1700000000,
@@ -513,7 +513,7 @@ void main() {
       });
 
       test('defaults allowsReuse to true for a plain AudioEvent', () {
-        const audioEvent = AudioEvent(
+        final audioEvent = AudioEvent(
           id: testHexId,
           pubkey: testPubkey,
           createdAt: 1700000000,
@@ -658,7 +658,7 @@ void main() {
       });
 
       test('classifies remote sounds as a network source', () {
-        const event = AudioEvent(
+        final event = AudioEvent(
           id: 'remote',
           pubkey: 'abc',
           createdAt: 0,
@@ -677,7 +677,7 @@ void main() {
       test('classifies a bare absolute path as a file source', () {
         // Clip-extracted J-cut audio: not a `local_import_` id, `url` is a
         // raw on-disk path (clip_editor_bloc writes `result.audioFilePath`).
-        const event = AudioEvent(
+        final event = AudioEvent(
           id: 'local_extracted_1700000000000',
           pubkey: '',
           createdAt: 0,
@@ -694,7 +694,7 @@ void main() {
       });
 
       test('classifies a file:// URI as a file source', () {
-        const event = AudioEvent(
+        final event = AudioEvent(
           id: 'local_extracted_1700000000000',
           pubkey: '',
           createdAt: 0,
@@ -711,7 +711,7 @@ void main() {
       });
 
       test('returns null when no source url is present', () {
-        const event = AudioEvent(id: 'empty', pubkey: 'abc', createdAt: 0);
+        final event = AudioEvent(id: 'empty', pubkey: 'abc', createdAt: 0);
 
         expect(event.resolvedSource, isNull);
       });
@@ -719,7 +719,7 @@ void main() {
 
     group('external provider metadata', () {
       test('round trips external source and license metadata through JSON', () {
-        const audioEvent = AudioEvent(
+        final audioEvent = AudioEvent(
           id: 'freesound_502915',
           pubkey: AudioEvent.externalProviderMarker,
           createdAt: 1779120000,
@@ -736,7 +736,7 @@ void main() {
             creatorUrl: 'https://freesound.org/people/ThePauny/',
             sourceUrl: 'https://freesound.org/people/ThePauny/sounds/502915/',
             previewUrl: 'https://cdn.freesound.org/previews/502/502915.mp3',
-            catalogTags: ['crowd', 'field recording'],
+            catalogTags: const ['crowd', 'field recording'],
             license: AudioLicenseMetadata(
               type: 'cc0',
               name: 'Creative Commons 0',
@@ -766,7 +766,7 @@ void main() {
       });
 
       test('external source and license metadata use value equality', () {
-        const license = AudioLicenseMetadata(
+        final license = AudioLicenseMetadata(
           type: 'cc0',
           name: 'Creative Commons 0',
           url: 'https://creativecommons.org/publicdomain/zero/1.0/',
@@ -774,7 +774,7 @@ void main() {
           allowsDerivatives: true,
           requiresAttribution: false,
         );
-        const sameLicense = AudioLicenseMetadata(
+        final sameLicense = AudioLicenseMetadata(
           type: 'cc0',
           name: 'Creative Commons 0',
           url: 'https://creativecommons.org/publicdomain/zero/1.0/',
@@ -782,7 +782,7 @@ void main() {
           allowsDerivatives: true,
           requiresAttribution: false,
         );
-        const source = AudioExternalSource(
+        final source = AudioExternalSource(
           provider: 'freesound',
           providerSoundId: '502915',
           providerName: 'Freesound',
@@ -792,7 +792,7 @@ void main() {
           previewUrl: 'https://cdn.freesound.org/previews/502/502915.mp3',
           license: license,
         );
-        const sameSource = AudioExternalSource(
+        final sameSource = AudioExternalSource(
           provider: 'freesound',
           providerSoundId: '502915',
           providerName: 'Freesound',
@@ -810,7 +810,7 @@ void main() {
       });
 
       test('omits external source metadata when it is absent', () {
-        const audioEvent = AudioEvent(
+        final audioEvent = AudioEvent(
           id: testHexId,
           pubkey: testPubkey,
           createdAt: 1700000000,
@@ -824,7 +824,7 @@ void main() {
     group('toTags', () {
       test('generates complete tags list', () {
         // Arrange
-        const audioEvent = AudioEvent(
+        final audioEvent = AudioEvent(
           id: 'test-id-123456789012345678901234567890123456789012345678901234',
           pubkey: 'test-pubkey',
           createdAt: 1700000000,
@@ -863,7 +863,7 @@ void main() {
 
       test('generates minimal tags for sparse event', () {
         // Arrange
-        const audioEvent = AudioEvent(
+        final audioEvent = AudioEvent(
           id: 'minimal-id-123456789012345678901234567890123456789012345678',
           pubkey: 'test-pubkey',
           createdAt: 1700000000,
@@ -894,7 +894,7 @@ void main() {
 
       test('generates a tag without relay when relay is null', () {
         // Arrange
-        const audioEvent = AudioEvent(
+        final audioEvent = AudioEvent(
           id: 'no-relay-id-12345678901234567890123456789012345678901234567',
           pubkey: 'test-pubkey',
           createdAt: 1700000000,
@@ -911,7 +911,7 @@ void main() {
       });
 
       test('publishes explicit consent and durable public credit', () {
-        const audioEvent = AudioEvent(
+        final audioEvent = AudioEvent(
           id: testHexId,
           pubkey: testPubkey,
           createdAt: 1700000000,
@@ -921,7 +921,7 @@ void main() {
           creatorUrl: 'https://creator.example/profile',
           licenseName: 'CC BY 4.0',
           licenseUrl: 'https://creativecommons.org/licenses/by/4.0/',
-          publicTags: ['birds', ' field-recording ', 'birds', ''],
+          publicTags: const ['birds', ' field-recording ', 'birds', ''],
           proxyId: '12345',
           proxyProtocol: 'freesound',
         );
@@ -963,12 +963,12 @@ void main() {
       });
 
       test('cannot leak private saved-library metadata into public tags', () {
-        const audioEvent = AudioEvent(
+        final audioEvent = AudioEvent(
           id: testHexId,
           pubkey: testPubkey,
           createdAt: 1700000000,
           title: 'Public title',
-          publicTags: ['public-tag'],
+          publicTags: const ['public-tag'],
         );
 
         final published = audioEvent.toTags().expand((tag) => tag).join(' ');
@@ -981,7 +981,7 @@ void main() {
     group('copyWith', () {
       test('creates copy with updated fields', () {
         // Arrange
-        const original = AudioEvent(
+        final original = AudioEvent(
           id: 'original-id-1234567890123456789012345678901234567890123456',
           pubkey: 'original-pubkey',
           createdAt: 1700000000,
@@ -1007,7 +1007,7 @@ void main() {
     group('equality', () {
       test('events with same id are equal', () {
         // Arrange
-        const event1 = AudioEvent(
+        final event1 = AudioEvent(
           id: 'same-id-123456789012345678901234567890123456789012345678901',
           pubkey: 'pubkey1',
           createdAt: 1700000000,
@@ -1015,7 +1015,7 @@ void main() {
           mimeType: 'audio/aac',
         );
 
-        const event2 = AudioEvent(
+        final event2 = AudioEvent(
           id: 'same-id-123456789012345678901234567890123456789012345678901',
           pubkey: 'pubkey2', // Different pubkey
           createdAt: 1700000001, // Different timestamp
@@ -1030,7 +1030,7 @@ void main() {
 
       test('events with different ids are not equal', () {
         // Arrange
-        const event1 = AudioEvent(
+        final event1 = AudioEvent(
           id: 'id-one-123456789012345678901234567890123456789012345678901',
           pubkey: 'pubkey',
           createdAt: 1700000000,
@@ -1038,7 +1038,7 @@ void main() {
           mimeType: 'audio/aac',
         );
 
-        const event2 = AudioEvent(
+        final event2 = AudioEvent(
           id: 'id-two-123456789012345678901234567890123456789012345678901',
           pubkey: 'pubkey',
           createdAt: 1700000000,
@@ -1052,7 +1052,7 @@ void main() {
 
       test('events with same id but different startOffset are not equal', () {
         // Arrange
-        const event1 = AudioEvent(
+        final event1 = AudioEvent(
           id: 'same-id-123456789012345678901234567890123456789012345678901',
           pubkey: 'pubkey',
           createdAt: 1700000000,
@@ -1061,13 +1061,13 @@ void main() {
           // Using default startOffset (Duration.zero)
         );
 
-        const event2 = AudioEvent(
+        final event2 = AudioEvent(
           id: 'same-id-123456789012345678901234567890123456789012345678901',
           pubkey: 'pubkey',
           createdAt: 1700000000,
           url: 'https://example.com/audio.aac',
           mimeType: 'audio/aac',
-          startOffset: Duration(seconds: 5),
+          startOffset: const Duration(seconds: 5),
         );
 
         // Assert - same audio with different start positions are distinct
@@ -1076,7 +1076,7 @@ void main() {
       });
 
       test('events with same id but different anchorClipId are not equal', () {
-        const event1 = AudioEvent(
+        final event1 = AudioEvent(
           id: 'same-id-123456789012345678901234567890123456789012345678901',
           pubkey: 'pubkey',
           createdAt: 1700000000,
@@ -1085,7 +1085,7 @@ void main() {
           anchorClipId: 'clip-a',
         );
 
-        const event2 = AudioEvent(
+        final event2 = AudioEvent(
           id: 'same-id-123456789012345678901234567890123456789012345678901',
           pubkey: 'pubkey',
           createdAt: 1700000000,
@@ -1101,7 +1101,7 @@ void main() {
     group('toString', () {
       test('returns readable debug string', () {
         // Arrange
-        const audioEvent = AudioEvent(
+        final audioEvent = AudioEvent(
           id: 'test-id-123456789012345678901234567890123456789012345678901234',
           pubkey: 'test-pubkey',
           createdAt: 1700000000,
@@ -1130,7 +1130,7 @@ void main() {
     group('sourceVideoKind getter', () {
       test('extracts kind from sourceVideoReference', () {
         // Arrange
-        const audioEvent = AudioEvent(
+        final audioEvent = AudioEvent(
           id: 'test-id-123456789012345678901234567890123456789012345678901234',
           pubkey: 'test-pubkey',
           createdAt: 1700000000,
@@ -1145,7 +1145,7 @@ void main() {
 
       test('returns null when sourceVideoReference is null', () {
         // Arrange
-        const audioEvent = AudioEvent(
+        final audioEvent = AudioEvent(
           id: 'test-id-123456789012345678901234567890123456789012345678901234',
           pubkey: 'test-pubkey',
           createdAt: 1700000000,
@@ -1161,7 +1161,7 @@ void main() {
     group('sourceVideoPubkey getter', () {
       test('extracts pubkey from sourceVideoReference', () {
         // Arrange
-        const audioEvent = AudioEvent(
+        final audioEvent = AudioEvent(
           id: 'test-id-123456789012345678901234567890123456789012345678901234',
           pubkey: 'test-pubkey',
           createdAt: 1700000000,
@@ -1178,7 +1178,7 @@ void main() {
     group('sourceVideoIdentifier getter', () {
       test('extracts d-tag identifier from sourceVideoReference', () {
         // Arrange
-        const audioEvent = AudioEvent(
+        final audioEvent = AudioEvent(
           id: 'test-id-123456789012345678901234567890123456789012345678901234',
           pubkey: 'test-pubkey',
           createdAt: 1700000000,
@@ -1195,7 +1195,7 @@ void main() {
     group('formattedDuration getter', () {
       test('formats duration as mm:ss', () {
         // Arrange - 65.4 rounds to 65 seconds = 1:05
-        const audioEvent = AudioEvent(
+        final audioEvent = AudioEvent(
           id: 'test-id-123456789012345678901234567890123456789012345678901234',
           pubkey: 'test-pubkey',
           createdAt: 1700000000,
@@ -1210,7 +1210,7 @@ void main() {
 
       test('handles sub-minute duration', () {
         // Arrange
-        const audioEvent = AudioEvent(
+        final audioEvent = AudioEvent(
           id: 'test-id-123456789012345678901234567890123456789012345678901234',
           pubkey: 'test-pubkey',
           createdAt: 1700000000,
@@ -1225,7 +1225,7 @@ void main() {
 
       test('returns empty string when duration is null', () {
         // Arrange
-        const audioEvent = AudioEvent(
+        final audioEvent = AudioEvent(
           id: 'test-id-123456789012345678901234567890123456789012345678901234',
           pubkey: 'test-pubkey',
           createdAt: 1700000000,
@@ -1241,7 +1241,7 @@ void main() {
     group('fileSizeKB getter', () {
       test('returns file size in KB', () {
         // Arrange
-        const audioEvent = AudioEvent(
+        final audioEvent = AudioEvent(
           id: 'test-id-123456789012345678901234567890123456789012345678901234',
           pubkey: 'test-pubkey',
           createdAt: 1700000000,
@@ -1257,7 +1257,7 @@ void main() {
 
     group('toJson', () {
       test('serializes all fields', () {
-        const audioEvent = AudioEvent(
+        final audioEvent = AudioEvent(
           id: 'test-id-123456789012345678901234567890123456789012345678901234',
           pubkey: testPubkey,
           createdAt: 1700000000,
@@ -1270,7 +1270,7 @@ void main() {
           source: 'Original Sound',
           sourceVideoReference: '34236:pubkey:vine-id',
           sourceVideoRelay: 'wss://relay.example',
-          startOffset: Duration(milliseconds: 1500),
+          startOffset: const Duration(milliseconds: 1500),
           volume: 0.4,
         );
 
@@ -1298,7 +1298,7 @@ void main() {
       });
 
       test('omits null optional fields', () {
-        const audioEvent = AudioEvent(
+        final audioEvent = AudioEvent(
           id: 'minimal-id-123456789012345678901234567890123456789012345678',
           pubkey: testPubkey,
           createdAt: 1700000000,
@@ -1318,7 +1318,7 @@ void main() {
       });
 
       test('omits startOffsetMs when offset is zero', () {
-        const audioEvent = AudioEvent(
+        final audioEvent = AudioEvent(
           id: 'zero-offset-123456789012345678901234567890123456789012345678',
           pubkey: testPubkey,
           createdAt: 1700000000,
@@ -1330,7 +1330,7 @@ void main() {
       });
 
       test('always serializes volume for backward-compatible snapshots', () {
-        const audioEvent = AudioEvent(
+        final audioEvent = AudioEvent(
           id: 'default-volume-123456789012345678901234567890123456789012345',
           pubkey: testPubkey,
           createdAt: 1700000000,
@@ -1434,7 +1434,7 @@ void main() {
 
     group('toJson/fromJson roundtrip', () {
       test('roundtrips complete AudioEvent preserving all data', () {
-        const original = AudioEvent(
+        final original = AudioEvent(
           id: 'roundtrip-1234567890123456789012345678901234567890123456789',
           pubkey: testPubkey,
           createdAt: 1700000000,
@@ -1447,7 +1447,7 @@ void main() {
           source: 'SoundCloud',
           sourceVideoReference: '34236:creator:vine-abc',
           sourceVideoRelay: 'wss://relay.example',
-          startOffset: Duration(milliseconds: 3200),
+          startOffset: const Duration(milliseconds: 3200),
         );
 
         final restored = AudioEvent.fromJson(original.toJson());
@@ -1471,7 +1471,7 @@ void main() {
       });
 
       test('roundtrips minimal AudioEvent', () {
-        const original = AudioEvent(
+        final original = AudioEvent(
           id: 'minimal-rt-12345678901234567890123456789012345678901234567',
           pubkey: testPubkey,
           createdAt: 1700000000,
@@ -1489,7 +1489,7 @@ void main() {
 
     group('copyWith startOffset', () {
       test('updates startOffset', () {
-        const original = AudioEvent(
+        final original = AudioEvent(
           id: 'offset-id-12345678901234567890123456789012345678901234567890',
           pubkey: testPubkey,
           createdAt: 1700000000,
@@ -1505,11 +1505,11 @@ void main() {
       });
 
       test('preserves startOffset when not specified in copyWith', () {
-        const original = AudioEvent(
+        final original = AudioEvent(
           id: 'preserve-id-1234567890123456789012345678901234567890123456789',
           pubkey: testPubkey,
           createdAt: 1700000000,
-          startOffset: Duration(seconds: 5),
+          startOffset: const Duration(seconds: 5),
         );
 
         final updated = original.copyWith(title: 'New Title');
@@ -1520,7 +1520,7 @@ void main() {
     });
 
     group('anchorClipId', () {
-      const anchored = AudioEvent(
+      final anchored = AudioEvent(
         id: 'anchor-id-123456789012345678901234567890123456789012345678901',
         pubkey: testPubkey,
         createdAt: 1700000000,
@@ -1552,7 +1552,7 @@ void main() {
       });
 
       test('is omitted from JSON when null', () {
-        const original = AudioEvent(
+        final original = AudioEvent(
           id: 'plain-id-1234567890123456789012345678901234567890123456789012',
           pubkey: testPubkey,
           createdAt: 1700000000,
@@ -1564,7 +1564,7 @@ void main() {
 
     group('isClipAnchoredOriginalSound', () {
       test('is true for an original sound anchored to a clip', () {
-        const event = AudioEvent(
+        final event = AudioEvent(
           id: 'video_source-abc_copy_1',
           pubkey: testPubkey,
           createdAt: 1700000000,
@@ -1580,7 +1580,7 @@ void main() {
         // A network "Original Sound" the user added from the sound browser:
         // its id is video_-prefixed but it is free-standing, so it keeps its
         // own volume arc.
-        const event = AudioEvent(
+        final event = AudioEvent(
           id: 'video_source-abc_copy_1',
           pubkey: testPubkey,
           createdAt: 1700000000,
@@ -1591,7 +1591,7 @@ void main() {
       });
 
       test('is false for a non-original (custom/imported) track', () {
-        const event = AudioEvent(
+        final event = AudioEvent(
           id: 'local_import_1234567890',
           pubkey: testPubkey,
           createdAt: 1700000000,
@@ -1599,6 +1599,97 @@ void main() {
         );
         expect(event.isOriginalSound, isFalse);
         expect(event.isClipAnchoredOriginalSound, isFalse);
+      });
+    });
+
+    group('UTF-16 well-formedness', () {
+      // The headless flutter_tester does not throw on a lone surrogate — only
+      // the real engine does — so the assertion has to be on the model value
+      // rather than on a rendered widget.
+      String poisoned(String text) => '$text${String.fromCharCode(0xD83D)}!';
+
+      test('replaces lone surrogates in the display text tags', () {
+        final event = AudioEvent(
+          id: testHexId,
+          pubkey: testPubkey,
+          createdAt: 1700000000,
+          title: poisoned('Beat'),
+          source: poisoned('Freesound'),
+          creatorName: poisoned('ThePauny'),
+          licenseName: poisoned('CC0'),
+          publicTags: ['crowd', poisoned('field')],
+        );
+
+        expect(event.title, equals('Beat�!'));
+        expect(event.source, equals('Freesound�!'));
+        expect(event.creatorName, equals('ThePauny�!'));
+        expect(event.licenseName, equals('CC0�!'));
+        expect(event.publicTags, equals(['crowd', 'field�!']));
+      });
+
+      test('republishes the sanitized values rather than the raw ones', () {
+        final tags = AudioEvent(
+          id: testHexId,
+          pubkey: testPubkey,
+          createdAt: 1700000000,
+          title: poisoned('Beat'),
+          creatorName: poisoned('ThePauny'),
+          licenseName: poisoned('CC0'),
+        ).toTags();
+
+        expect(_findTag(tags, 'title'), equals(['title', 'Beat�!']));
+        expect(_findTag(tags, 'creator'), equals(['creator', 'ThePauny�!']));
+        expect(_findTag(tags, 'license'), equals(['license', 'CC0�!']));
+      });
+
+      test('leaves the playback source and identifiers untouched', () {
+        final url =
+            'https://cdn.example.com/${String.fromCharCode(0xD83D)}.mp3';
+        final event = AudioEvent(
+          id: testHexId,
+          pubkey: testPubkey,
+          createdAt: 1700000000,
+          url: url,
+          sha256: testSha256,
+        );
+
+        expect(event.url, same(url));
+        expect(event.sha256, equals(testSha256));
+      });
+
+      test('preserves valid emoji and keeps clean text identical', () {
+        const title = 'Beat \u{1F600}';
+        final event = AudioEvent(
+          id: testHexId,
+          pubkey: testPubkey,
+          createdAt: 1700000000,
+          title: title,
+        );
+
+        expect(event.title, same(title));
+      });
+
+      test('sanitizes external source and license display text', () {
+        final source = AudioExternalSource(
+          provider: 'freesound',
+          providerSoundId: '502915',
+          providerName: poisoned('Freesound'),
+          creatorName: poisoned('ThePauny'),
+          catalogTags: [poisoned('crowd')],
+          license: AudioLicenseMetadata(
+            type: 'cc0',
+            name: poisoned('CC0 1.0'),
+            url: 'https://creativecommons.org/publicdomain/zero/1.0/',
+            allowsCommercialUse: true,
+            allowsDerivatives: true,
+            requiresAttribution: false,
+          ),
+        );
+
+        expect(source.providerName, equals('Freesound�!'));
+        expect(source.creatorName, equals('ThePauny�!'));
+        expect(source.catalogTags, equals(['crowd�!']));
+        expect(source.license.name, equals('CC0 1.0�!'));
       });
     });
   });

--- a/mobile/packages/models/test/src/curated_list_test.dart
+++ b/mobile/packages/models/test/src/curated_list_test.dart
@@ -219,6 +219,28 @@ void main() {
         expect(roundtripped, equals(original));
       });
     });
+
+    group('UTF-16 well-formedness', () {
+      // The headless flutter_tester does not throw on a lone surrogate — only
+      // the real engine does — so this asserts the model value rather than a
+      // rendered widget.
+      test('replaces lone surrogates in name and description', () {
+        final list = createSubject(
+          name: 'Skate${String.fromCharCode(0xD83D)} picks',
+          description: 'best of${String.fromCharCode(0xDE00)} 2025',
+        );
+
+        expect(list.name, equals('Skate� picks'));
+        expect(list.description, equals('best of� 2025'));
+      });
+
+      test('keeps well-formed name and description identical', () {
+        const name = 'Skate \u{1F600} picks';
+
+        expect(createSubject(name: name).name, same(name));
+        expect(createSubject(description: null).description, isNull);
+      });
+    });
   });
 
   group(PlayOrder, () {

--- a/mobile/packages/models/test/src/hashtag_search_result_test.dart
+++ b/mobile/packages/models/test/src/hashtag_search_result_test.dart
@@ -8,7 +8,7 @@ void main() {
   group(HashtagSearchResult, () {
     group('constructor', () {
       test('creates instance with required fields', () {
-        const result = HashtagSearchResult(tag: 'bitcoin');
+        final result = HashtagSearchResult(tag: 'bitcoin');
 
         expect(result.tag, equals('bitcoin'));
         expect(result.videoCount, isNull);
@@ -18,7 +18,7 @@ void main() {
       });
 
       test('creates instance with all optional fields', () {
-        const result = HashtagSearchResult(
+        final result = HashtagSearchResult(
           tag: 'nostr',
           videoCount: 156,
           score: 95.2,
@@ -214,12 +214,12 @@ void main() {
 
     group('equality', () {
       test('two instances with same tag are equal', () {
-        const result1 = HashtagSearchResult(
+        final result1 = HashtagSearchResult(
           tag: 'bitcoin',
           videoCount: 100,
         );
 
-        const result2 = HashtagSearchResult(
+        final result2 = HashtagSearchResult(
           tag: 'bitcoin',
           videoCount: 200,
         );
@@ -229,8 +229,8 @@ void main() {
       });
 
       test('two instances with different tags are not equal', () {
-        const result1 = HashtagSearchResult(tag: 'bitcoin');
-        const result2 = HashtagSearchResult(tag: 'nostr');
+        final result1 = HashtagSearchResult(tag: 'bitcoin');
+        final result2 = HashtagSearchResult(tag: 'nostr');
 
         expect(result1, isNot(equals(result2)));
       });
@@ -238,7 +238,7 @@ void main() {
 
     group('toString', () {
       test('returns formatted string with tag and videoCount', () {
-        const result = HashtagSearchResult(
+        final result = HashtagSearchResult(
           tag: 'bitcoin',
           videoCount: 156,
         );
@@ -250,12 +250,39 @@ void main() {
       });
 
       test('returns formatted string with null videoCount', () {
-        const result = HashtagSearchResult(tag: 'nostr');
+        final result = HashtagSearchResult(tag: 'nostr');
 
         expect(
           result.toString(),
           equals('HashtagSearchResult(tag: nostr, videoCount: null)'),
         );
+      });
+    });
+
+    group('UTF-16 well-formedness', () {
+      // The headless flutter_tester does not throw on a lone surrogate — only
+      // the real engine does — so this asserts the model value rather than the
+      // rendered chip label.
+      test('replaces a lone surrogate in tag', () {
+        final result = HashtagSearchResult(
+          tag: 'sun${String.fromCharCode(0xD83D)}set',
+        );
+
+        expect(result.tag, equals('sun\uFFFDset'));
+      });
+
+      test('keeps a well-formed tag identical', () {
+        const tag = 'sunset\u{1F600}';
+
+        expect(HashtagSearchResult(tag: tag).tag, same(tag));
+      });
+
+      test('sanitizes a tag parsed from JSON', () {
+        final result = HashtagSearchResult.fromJson({
+          'hashtag': 'sun${String.fromCharCode(0xD83D)}set',
+        });
+
+        expect(result.tag, equals('sun\uFFFDset'));
       });
     });
   });

--- a/mobile/packages/models/test/src/trending_hashtag_test.dart
+++ b/mobile/packages/models/test/src/trending_hashtag_test.dart
@@ -5,7 +5,7 @@ void main() {
   group(TrendingHashtag, () {
     group('constructor', () {
       test('creates instance with required fields', () {
-        const hashtag = TrendingHashtag(
+        final hashtag = TrendingHashtag(
           tag: 'flutter',
           videoCount: 42,
         );
@@ -128,16 +128,16 @@ void main() {
 
     group('equality', () {
       test('two hashtags with same tag are equal', () {
-        const a = TrendingHashtag(tag: 'flutter', videoCount: 1);
-        const b = TrendingHashtag(tag: 'flutter', videoCount: 99);
+        final a = TrendingHashtag(tag: 'flutter', videoCount: 1);
+        final b = TrendingHashtag(tag: 'flutter', videoCount: 99);
 
         expect(a, equals(b));
         expect(a.hashCode, equals(b.hashCode));
       });
 
       test('two hashtags with different tags are not equal', () {
-        const a = TrendingHashtag(tag: 'flutter', videoCount: 1);
-        const b = TrendingHashtag(tag: 'dart', videoCount: 1);
+        final a = TrendingHashtag(tag: 'flutter', videoCount: 1);
+        final b = TrendingHashtag(tag: 'dart', videoCount: 1);
 
         expect(a, isNot(equals(b)));
       });
@@ -145,7 +145,7 @@ void main() {
 
     group('toString', () {
       test('returns readable representation', () {
-        const hashtag = TrendingHashtag(
+        final hashtag = TrendingHashtag(
           tag: 'flutter',
           videoCount: 42,
         );
@@ -156,6 +156,35 @@ void main() {
             'TrendingHashtag(tag: flutter, videoCount: 42)',
           ),
         );
+      });
+    });
+
+    group('UTF-16 well-formedness', () {
+      // The headless flutter_tester does not throw on a lone surrogate — only
+      // the real engine does — so this asserts the model value rather than the
+      // rendered chip label.
+      test('replaces a lone surrogate in tag', () {
+        final hashtag = TrendingHashtag(
+          tag: 'sun${String.fromCharCode(0xD83D)}set',
+          videoCount: 42,
+        );
+
+        expect(hashtag.tag, equals('sun\uFFFDset'));
+      });
+
+      test('keeps a well-formed tag identical', () {
+        const tag = 'sunset\u{1F600}';
+
+        expect(TrendingHashtag(tag: tag, videoCount: 42).tag, same(tag));
+      });
+
+      test('sanitizes a tag parsed from JSON', () {
+        final hashtag = TrendingHashtag.fromJson({
+          'hashtag': 'sun${String.fromCharCode(0xD83D)}set',
+          'video_count': 3,
+        });
+
+        expect(hashtag.tag, equals('sun\uFFFDset'));
       });
     });
   });

--- a/mobile/packages/models/test/src/user_list_test.dart
+++ b/mobile/packages/models/test/src/user_list_test.dart
@@ -142,5 +142,38 @@ void main() {
         expect(a, isNot(equals(b)));
       });
     });
+
+    group('UTF-16 well-formedness', () {
+      // The headless flutter_tester does not throw on a lone surrogate — only
+      // the real engine does — so this asserts the model value rather than a
+      // rendered widget.
+      test('replaces lone surrogates in name and description', () {
+        final list = UserList(
+          id: 'id',
+          name: 'Friends${String.fromCharCode(0xD83D)}',
+          description: 'people I${String.fromCharCode(0xDE00)} follow',
+          pubkeys: const [],
+          createdAt: now,
+          updatedAt: now,
+        );
+
+        expect(list.name, equals('Friends�'));
+        expect(list.description, equals('people I� follow'));
+      });
+
+      test('keeps a well-formed name identical', () {
+        const name = 'Friends \u{1F600}';
+        final list = UserList(
+          id: 'id',
+          name: name,
+          pubkeys: const [],
+          createdAt: now,
+          updatedAt: now,
+        );
+
+        expect(list.name, same(name));
+        expect(list.description, isNull);
+      });
+    });
   });
 }

--- a/mobile/packages/models/test/src/video_event_display_test.dart
+++ b/mobile/packages/models/test/src/video_event_display_test.dart
@@ -13,6 +13,7 @@ void main() {
     int createdAt = 1735689600,
     String? publishedAt,
     Map<String, String> rawTags = const {},
+    List<String> hashtags = const [],
   }) => VideoEvent(
     id: 'a' * 64,
     pubkey: 'b' * 64,
@@ -27,6 +28,7 @@ void main() {
     altText: altText,
     publishedAt: publishedAt,
     rawTags: rawTags,
+    hashtags: hashtags,
   );
 
   group('VideoEvent.displayTitle', () {
@@ -193,6 +195,20 @@ void main() {
       final video = build(altText: 'a${String.fromCharCode(0xDE00)}dog');
 
       expect(video.altText, equals('a�dog'));
+    });
+
+    test('replaces a lone surrogate in a hashtag', () {
+      final video = build(
+        hashtags: ['skate', 'sun${String.fromCharCode(0xD83D)}set'],
+      );
+
+      expect(video.hashtags, equals(['skate', 'sun�set']));
+    });
+
+    test('keeps the hashtag list identical when every tag is well-formed', () {
+      final hashtags = ['skate', 'sunset \u{1F600}'];
+
+      expect(build(hashtags: hashtags).hashtags, same(hashtags));
     });
 
     // Zalgo capping stays on the display getters so the raw field keeps the

--- a/mobile/packages/models/test/src/video_notification_test.dart
+++ b/mobile/packages/models/test/src/video_notification_test.dart
@@ -342,5 +342,58 @@ void main() {
         expect(a, isNot(equals(b)));
       });
     });
+
+    group('UTF-16 well-formedness', () {
+      // The headless flutter_tester does not throw on a lone surrogate — only
+      // the real engine does — so this asserts the model value rather than the
+      // rendered Text.rich span.
+      test('replaces lone surrogates in the quoted relay text', () {
+        final notification = VideoNotification(
+          id: 'n1',
+          type: NotificationKind.listAdd,
+          videoEventId: 'v1',
+          actors: [actorAlice],
+          totalCount: 1,
+          timestamp: timestamp,
+          videoTitle: 'my clip${String.fromCharCode(0xD83D)}',
+          commentText: 'nice${String.fromCharCode(0xDE00)} one',
+          listTitle: 'Best of${String.fromCharCode(0xD83D)} 2025',
+        );
+
+        expect(notification.videoTitle, equals('my clip�'));
+        expect(notification.commentText, equals('nice� one'));
+        expect(notification.listTitle, equals('Best of� 2025'));
+      });
+
+      test('keeps well-formed text identical and nulls null', () {
+        const listTitle = 'Best of \u{1F600} 2025';
+        final notification = VideoNotification(
+          id: 'n1',
+          type: NotificationKind.listAdd,
+          videoEventId: 'v1',
+          actors: [actorAlice],
+          totalCount: 1,
+          timestamp: timestamp,
+          listTitle: listTitle,
+        );
+
+        expect(notification.listTitle, same(listTitle));
+        expect(notification.videoTitle, isNull);
+        expect(notification.commentText, isNull);
+      });
+
+      test('survives copyWith', () {
+        final notification = VideoNotification(
+          id: 'n1',
+          type: NotificationKind.listAdd,
+          videoEventId: 'v1',
+          actors: [actorAlice],
+          totalCount: 1,
+          timestamp: timestamp,
+        ).copyWith(listTitle: 'Best of${String.fromCharCode(0xD83D)} 2025');
+
+        expect(notification.listTitle, equals('Best of� 2025'));
+      });
+    });
   });
 }

--- a/mobile/packages/sounds_repository/test/src/sounds_repository_external_test.dart
+++ b/mobile/packages/sounds_repository/test/src/sounds_repository_external_test.dart
@@ -57,14 +57,14 @@ void main() {
     test(
       'searchExternalLibrary routes the request through to the API client',
       () async {
-        const externalSound = AudioEvent(
+        final externalSound = AudioEvent(
           id: 'freesound_1',
           pubkey: AudioEvent.externalProviderMarker,
           createdAt: 0,
           url: 'https://cdn.example.com/p.mp3',
           mimeType: 'audio/mpeg',
         );
-        const response = SoundLibrarySearchResponse(
+        final response = SoundLibrarySearchResponse(
           sounds: [externalSound],
           count: 1,
           nextPage: 2,

--- a/mobile/packages/text_sanitizer/lib/src/text_sanitizer.dart
+++ b/mobile/packages/text_sanitizer/lib/src/text_sanitizer.dart
@@ -49,6 +49,27 @@ String sanitizeUtf16(String text) {
 String? sanitizeUtf16OrNull(String? text) =>
     text == null ? null : sanitizeUtf16(text);
 
+/// Element-wise [sanitizeUtf16] for list-valued fields such as hashtags.
+///
+/// Returns [values] itself when every element is already well-formed, so a
+/// clean list keeps its identity — and, with it, any `unmodifiable` wrapper
+/// the caller built it with.
+List<String> sanitizeUtf16List(List<String> values) {
+  List<String>? result;
+
+  for (var i = 0; i < values.length; i++) {
+    final sanitized = sanitizeUtf16(values[i]);
+    if (identical(sanitized, values[i])) {
+      result?.add(sanitized);
+      continue;
+    }
+    result ??= values.sublist(0, i);
+    result.add(sanitized);
+  }
+
+  return result ?? values;
+}
+
 /// Normalizes malformed UTF-16 and caps combining diacritical characters per
 /// grapheme cluster to prevent Zalgo text from overflowing layout bounds.
 ///

--- a/mobile/packages/text_sanitizer/test/src/text_sanitizer_test.dart
+++ b/mobile/packages/text_sanitizer/test/src/text_sanitizer_test.dart
@@ -135,6 +135,36 @@ void main() {
     });
   });
 
+  group(sanitizeUtf16List, () {
+    test('returns the identical list when every element is well-formed', () {
+      final input = List<String>.unmodifiable(['clean', '\u{1F600}']);
+
+      expect(sanitizeUtf16List(input), same(input));
+    });
+
+    test('returns the identical list when empty', () {
+      const input = <String>[];
+
+      expect(sanitizeUtf16List(input), same(input));
+    });
+
+    test('replaces lone surrogates and keeps well-formed neighbours', () {
+      final poisoned = String.fromCharCodes([0x61, 0xD83D]);
+      final input = ['before', poisoned, 'after'];
+
+      expect(sanitizeUtf16List(input), equals(['before', 'a�', 'after']));
+    });
+
+    test('leaves the source list untouched', () {
+      final poisoned = String.fromCharCodes([0xDC00]);
+      final input = [poisoned];
+
+      sanitizeUtf16List(input);
+
+      expect(input, equals([poisoned]));
+    });
+  });
+
   group(sanitizeForDisplay, () {
     test('replaces lone surrogates and caps combining chars', () {
       // lone high surrogate, then o + 4 combining chars

--- a/mobile/test/blocs/saved_sounds/saved_sounds_bloc_test.dart
+++ b/mobile/test/blocs/saved_sounds/saved_sounds_bloc_test.dart
@@ -54,7 +54,7 @@ AudioEvent _sound({
     provider: 'freesound',
     providerSoundId: id,
     providerName: 'Freesound',
-    license: const AudioLicenseMetadata(
+    license: AudioLicenseMetadata(
       type: 'cc0',
       name: 'CC0',
       url: 'https://creativecommons.org/publicdomain/zero/1.0/',

--- a/mobile/test/blocs/sound_waveform/sound_waveform_bloc_test.dart
+++ b/mobile/test/blocs/sound_waveform/sound_waveform_bloc_test.dart
@@ -254,7 +254,7 @@ void main() {
       });
 
       test('returns a network-kind event for remote sounds', () {
-        const sound = AudioEvent(
+        final sound = AudioEvent(
           id: 'remote',
           pubkey: 'abc',
           createdAt: 0,
@@ -269,7 +269,7 @@ void main() {
       });
 
       test('returns null when the sound has no usable source', () {
-        const sound = AudioEvent(id: 'no-source', pubkey: 'abc', createdAt: 0);
+        final sound = AudioEvent(id: 'no-source', pubkey: 'abc', createdAt: 0);
 
         expect(SoundWaveformExtract.forSound(sound), isNull);
       });

--- a/mobile/test/blocs/video_editor/timeline_overlay/timeline_overlay_bloc_test.dart
+++ b/mobile/test/blocs/video_editor/timeline_overlay/timeline_overlay_bloc_test.dart
@@ -574,9 +574,9 @@ void main() {
         'spans the whole video when a sound has no endTime',
         build: TimelineOverlayBloc.new,
         act: (bloc) => bloc.add(
-          const TimelineOverlayItemsUpdate(
-            layers: <Layer>[],
-            filters: <FilterState>[],
+          TimelineOverlayItemsUpdate(
+            layers: const <Layer>[],
+            filters: const <FilterState>[],
             audioTracks: [
               // endTime omitted (null): a probe that never resolved leaves the
               // composition window open.
@@ -587,7 +587,7 @@ void main() {
                 title: 'Beat',
               ),
             ],
-            totalVideoDuration: Duration(seconds: 12),
+            totalVideoDuration: const Duration(seconds: 12),
           ),
         ),
         expect: () => [

--- a/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
+++ b/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
@@ -1154,7 +1154,7 @@ void main() {
       blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
         'loads remote audio via loadAudio',
         build: () => buildBlocWithSound(
-          const model.AudioEvent(
+          model.AudioEvent(
             id: 'remote',
             pubkey: 'abc',
             createdAt: 0,

--- a/mobile/test/extensions/draft_local_audio_extensions_test.dart
+++ b/mobile/test/extensions/draft_local_audio_extensions_test.dart
@@ -98,20 +98,20 @@ void main() {
     test('ignores non-local audio (bundled, network, original sound)', () {
       final draft = _draft(
         editorStateHistory: _historyWithAudio([
-          const AudioEvent(
+          AudioEvent(
             id: 'bundled_chime',
             pubkey: AudioEvent.bundledMarker,
             createdAt: 0,
             url: 'asset://sounds/chime.mp3',
           ),
-          const AudioEvent(
+          AudioEvent(
             id: 'remote-sound-id',
             pubkey: _testPubkey,
             createdAt: 1700000000,
             url: 'https://cdn.example.com/audio.mp3',
           ),
         ]),
-        selectedSound: const AudioEvent(
+        selectedSound: AudioEvent(
           id: 'video_remote',
           pubkey: _testPubkey,
           createdAt: 1700000000,

--- a/mobile/test/extensions/video_editor_extensions_test.dart
+++ b/mobile/test/extensions/video_editor_extensions_test.dart
@@ -86,14 +86,14 @@ void main() {
     });
 
     test('setClipAndAudioState carries current markers atomically', () {
-      const audio = AudioEvent(id: 'audio-1', pubkey: 'pub', createdAt: 1);
+      final audio = AudioEvent(id: 'audio-1', pubkey: 'pub', createdAt: 1);
       when(() => stateManager.activeMeta).thenReturn({
         VideoEditorConstants.timelineMarkersStateHistoryKey: [1500],
       });
 
       editor.setClipAndAudioState(
         clips: [_clip('clip-1')],
-        audioTracks: const [audio],
+        audioTracks: [audio],
       );
 
       final meta =
@@ -121,13 +121,13 @@ void main() {
       // when it was added, then the user shoots more stills from the editor's
       // camera (or merges a set in from the clips picker) and the composition
       // becomes 6s. Without the grow, publish muxes a 6s video with 3s audio.
-      const covering = AudioEvent(
+      final covering = AudioEvent(
         id: 'sound-1',
         pubkey: 'bundled',
         createdAt: 0,
         url: 'asset://sounds/loop.mp3',
         duration: 30,
-        endTime: Duration(seconds: 3),
+        endTime: const Duration(seconds: 3),
       );
 
       List<AudioEvent> capturedAudio() {
@@ -158,13 +158,13 @@ void main() {
       });
 
       test('leaves a sound the user trimmed short of the old end', () {
-        const trimmed = AudioEvent(
+        final trimmed = AudioEvent(
           id: 'sound-1',
           pubkey: 'bundled',
           createdAt: 0,
           url: 'asset://sounds/loop.mp3',
           duration: 30,
-          endTime: Duration(seconds: 1),
+          endTime: const Duration(seconds: 1),
         );
         when(() => stateManager.activeMeta).thenReturn({
           VideoEditorConstants.audioStateHistoryKey: [trimmed.toJson()],
@@ -219,16 +219,16 @@ void main() {
   });
 
   group('buildAppendedAudioMeta', () {
-    const existing = AudioEvent(id: 'existing', pubkey: 'p', createdAt: 1);
-    const incoming = AudioEvent(id: 'incoming', pubkey: 'p', createdAt: 2);
+    final existing = AudioEvent(id: 'existing', pubkey: 'p', createdAt: 1);
+    final incoming = AudioEvent(id: 'incoming', pubkey: 'p', createdAt: 2);
 
     test('appends new tracks after existing ones and carries other meta', () {
       final meta = buildAppendedAudioMeta(
         activeMeta: {
           VideoEditorConstants.timelineMarkersStateHistoryKey: [1200],
         },
-        existingTracks: const [existing],
-        newTracks: const [incoming],
+        existingTracks: [existing],
+        newTracks: [incoming],
       );
 
       expect(
@@ -246,8 +246,8 @@ void main() {
         activeMeta: {
           VideoEditorConstants.audioStateHistoryKey: ['stale'],
         },
-        existingTracks: const [existing],
-        newTracks: const [incoming],
+        existingTracks: [existing],
+        newTracks: [incoming],
       );
 
       expect(
@@ -259,7 +259,7 @@ void main() {
     test('keeps the existing tracks when no new tracks are appended', () {
       final meta = buildAppendedAudioMeta(
         activeMeta: const {},
-        existingTracks: const [existing],
+        existingTracks: [existing],
         newTracks: const [],
       );
 

--- a/mobile/test/models/divine_video_draft_copy_with_test.dart
+++ b/mobile/test/models/divine_video_draft_copy_with_test.dart
@@ -35,13 +35,13 @@ DivineVideoDraft _createDraft({AudioEvent? selectedSound}) => DivineVideoDraft(
   proofManifestJson: '{"videoHash":"abc"}',
   selectedSound:
       selectedSound ??
-      const AudioEvent(
+      AudioEvent(
         id: 'sound-id-12345678901234567890123456789012345678901234567890123',
         pubkey: _testPubkey,
         createdAt: 1700000000,
         url: 'https://blossom.example/audio.aac',
         title: 'Test Sound',
-        startOffset: Duration(milliseconds: 2000),
+        startOffset: const Duration(milliseconds: 2000),
       ),
 );
 
@@ -94,7 +94,7 @@ void main() {
       test('replaces selectedSound when new value is provided', () {
         final draft = _createDraft();
 
-        const newSound = AudioEvent(
+        final newSound = AudioEvent(
           id: 'new-sound-1234567890123456789012345678901234567890123456789012',
           pubkey: _testPubkey,
           createdAt: 1700000001,
@@ -115,7 +115,7 @@ void main() {
       test('clearSelectedSound takes precedence over new selectedSound', () {
         final draft = _createDraft();
 
-        const newSound = AudioEvent(
+        final newSound = AudioEvent(
           id: 'ignored-id-123456789012345678901234567890123456789012345678901',
           pubkey: _testPubkey,
           createdAt: 1700000001,
@@ -131,12 +131,12 @@ void main() {
       });
 
       test('preserves selectedSound startOffset through copyWith', () {
-        const sound = AudioEvent(
+        final sound = AudioEvent(
           id: 'offset-sound-12345678901234567890123456789012345678901234567',
           pubkey: _testPubkey,
           createdAt: 1700000000,
           url: 'https://blossom.example/audio.aac',
-          startOffset: Duration(milliseconds: 3500),
+          startOffset: const Duration(milliseconds: 3500),
         );
 
         final draft = _createDraft(selectedSound: sound);

--- a/mobile/test/models/divine_video_draft_has_been_edited_test.dart
+++ b/mobile/test/models/divine_video_draft_has_been_edited_test.dart
@@ -173,7 +173,7 @@ void main() {
 
       test('returns true when draft has selectedSound', () {
         final draft = _minimalDraft().copyWith(
-          selectedSound: const AudioEvent(
+          selectedSound: AudioEvent(
             id: 'sound-id-12345678901234567890123456789012345678901234567890123',
             pubkey: _testPubkey,
             createdAt: 1700000000,
@@ -287,7 +287,7 @@ void main() {
             addressableId: '34236:$_testPubkey:dtag',
           ),
           inspiredByNpub: _testPubkey,
-          selectedSound: const AudioEvent(
+          selectedSound: AudioEvent(
             id:
                 'snd-1234567890123456789012345678901234'
                 '5678901234567890123456',

--- a/mobile/test/models/video_editor_state_test.dart
+++ b/mobile/test/models/video_editor_state_test.dart
@@ -206,7 +206,7 @@ void main() {
   });
 }
 
-const _sound = AudioEvent(
+final _sound = AudioEvent(
   id: 'sound-id',
   pubkey: 'pubkey',
   createdAt: 1704067200,

--- a/mobile/test/providers/top_classic_viners_test.dart
+++ b/mobile/test/providers/top_classic_viners_test.dart
@@ -1,0 +1,121 @@
+// ABOUTME: Pins that ClassicViner.authorName reaches the viner slider as
+// ABOUTME: well-formed UTF-16, inherited from the VideoEvent boundary.
+
+import 'package:content_blocklist_repository/content_blocklist_repository.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/classic_vines_provider.dart';
+import 'package:openvine/providers/curation_providers.dart';
+import 'package:openvine/providers/readiness_gate_providers.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
+import 'package:openvine/services/video_event_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:videos_repository/videos_repository.dart';
+
+class _MockVideosRepository extends Mock implements VideosRepository {}
+
+class _MockVideoEventService extends Mock implements VideoEventService {}
+
+class _MockContentBlocklistRepository extends Mock
+    implements ContentBlocklistRepository {}
+
+class _TestFunnelcakeAvailable extends FunnelcakeAvailable {
+  @override
+  Future<bool> build() async => true;
+}
+
+void main() {
+  group('topClassicViners', () {
+    late _MockVideosRepository mockVideosRepository;
+    late _MockVideoEventService mockVideoEventService;
+    late _MockContentBlocklistRepository mockBlocklistRepository;
+    late SharedPreferences sharedPreferences;
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      sharedPreferences = await SharedPreferences.getInstance();
+
+      mockVideosRepository = _MockVideosRepository();
+      mockVideoEventService = _MockVideoEventService();
+      mockBlocklistRepository = _MockContentBlocklistRepository();
+
+      when(() => mockVideoEventService.discoveryVideos).thenReturn(const []);
+      when(() => mockVideoEventService.filterVideoList(any())).thenAnswer(
+        (invocation) =>
+            invocation.positionalArguments.first as List<VideoEvent>,
+      );
+      when(
+        () => mockBlocklistRepository.shouldFilterFromFeeds(any()),
+      ).thenReturn(false);
+    });
+
+    ProviderContainer createContainer() => ProviderContainer(
+      overrides: [
+        appReadyProvider.overrideWithValue(true),
+        sharedPreferencesProvider.overrideWithValue(sharedPreferences),
+        videosRepositoryProvider.overrideWithValue(mockVideosRepository),
+        videoEventServiceProvider.overrideWithValue(mockVideoEventService),
+        contentBlocklistRepositoryProvider.overrideWithValue(
+          mockBlocklistRepository,
+        ),
+        funnelcakeAvailableProvider.overrideWith(_TestFunnelcakeAvailable.new),
+      ],
+    );
+
+    // The archive's author names are free text, and the slider renders them
+    // straight into a Text. VideoEvent's constructor is the sanitizing
+    // boundary — this pins that ClassicViner inherits it, so nothing between
+    // the repository and the slider has to repeat the guard. The headless
+    // flutter_tester does not throw on a lone surrogate (only the real engine
+    // does), so the assertion is on the value rather than on a rendered frame.
+    test('carries a sanitized authorName through from the video', () async {
+      when(
+        () => mockVideosRepository.getClassicVideos(
+          limit: any(named: 'limit'),
+          cursor: any(named: 'cursor'),
+          skipCache: any(named: 'skipCache'),
+        ),
+      ).thenAnswer(
+        (_) async => HomeFeedResult(
+          videos: [
+            _classicVideo(authorName: 'Zach${String.fromCharCode(0xD83D)}'),
+          ],
+          hasMore: false,
+        ),
+      );
+
+      final container = createContainer();
+      addTearDown(container.dispose);
+
+      await container.read(funnelcakeAvailableProvider.future);
+      // topClassicViners auto-disposes; without a listener it is torn down
+      // mid-load and never emits.
+      final subscription = container.listen(
+        topClassicVinersProvider,
+        (_, _) {},
+      );
+      addTearDown(subscription.close);
+      final viners = await container.read(topClassicVinersProvider.future);
+
+      expect(viners.single.authorName, equals('Zach�'));
+    });
+  });
+}
+
+VideoEvent _classicVideo({required String authorName}) => VideoEvent(
+  id: 'classic-1',
+  pubkey: 'author-classic-1',
+  createdAt: DateTime(2026, 3, 17).millisecondsSinceEpoch ~/ 1000,
+  content: 'classic-1',
+  timestamp: DateTime(2026, 3, 17),
+  title: 'classic-1',
+  videoUrl: 'https://example.com/classic-1.mp4',
+  thumbnailUrl: 'https://example.com/classic-1.jpg',
+  originalLoops: 100,
+  authorName: authorName,
+  // Non-null so the provider skips its profile prefetch side effect.
+  authorAvatar: 'https://example.com/classic-1-avatar.jpg',
+);

--- a/mobile/test/providers/video_editor_provider_test.dart
+++ b/mobile/test/providers/video_editor_provider_test.dart
@@ -309,7 +309,7 @@ void main() {
       });
 
       test('selected absolute-path url is rendered as file audio', () {
-        const sound = AudioEvent(
+        final sound = AudioEvent(
           id: 'video_source_copy_3',
           pubkey: 'pk',
           createdAt: 1700000000,
@@ -326,7 +326,7 @@ void main() {
       });
 
       test('selected sound without a resolvable source is skipped', () {
-        const sound = AudioEvent(
+        final sound = AudioEvent(
           id: 'video_source_no_url',
           pubkey: 'pk',
           createdAt: 1700000000,
@@ -337,7 +337,7 @@ void main() {
       });
 
       test('selected sound without a known duration is skipped', () {
-        const sound = AudioEvent(
+        final sound = AudioEvent(
           id: 'video_source_no_duration',
           pubkey: 'pk',
           createdAt: 1700000000,
@@ -350,13 +350,13 @@ void main() {
       test(
         'selected sound with a start offset gets a valid composition window',
         () {
-          const sound = AudioEvent(
+          final sound = AudioEvent(
             id: 'video_selected_offset',
             pubkey: 'pk',
             createdAt: 1700000000,
             url: 'https://media.divine.video/abc',
             duration: 6.533,
-            startOffset: Duration(milliseconds: 292),
+            startOffset: const Duration(milliseconds: 292),
           );
 
           final track = audioTrackFromSoundForRender(sound);
@@ -380,14 +380,14 @@ void main() {
         'meta network original sound renders with its composition window and '
         'plays to file end',
         () {
-          const event = AudioEvent(
+          final event = AudioEvent(
             id: 'video_source_copy_1',
             pubkey: 'pk',
             createdAt: 1700000000,
             url: 'https://media.divine.video/abc123',
             duration: 6.533,
-            startOffset: Duration(milliseconds: 292),
-            endTime: Duration(milliseconds: 3966),
+            startOffset: const Duration(milliseconds: 292),
+            endTime: const Duration(milliseconds: 3966),
           );
 
           final track = audioTrackFromMetaForRender(event);
@@ -410,12 +410,12 @@ void main() {
         'meta track with an invalid window plays across the whole video',
         () {
           // A sound added before its duration was known persists endTime=0.
-          const event = AudioEvent(
+          final event = AudioEvent(
             id: 'video_source_no_window',
             pubkey: 'pk',
             createdAt: 1700000000,
             url: 'https://media.divine.video/abc123',
-            startOffset: Duration(milliseconds: 100),
+            startOffset: const Duration(milliseconds: 100),
           );
 
           final track = audioTrackFromMetaForRender(event);
@@ -434,7 +434,7 @@ void main() {
       );
 
       test('meta absolute-path url renders as file audio', () {
-        const event = AudioEvent(
+        final event = AudioEvent(
           id: 'video_source_copy_2',
           pubkey: 'pk',
           createdAt: 1700000000,
@@ -467,7 +467,7 @@ void main() {
       });
 
       test('meta track without a resolvable source is skipped', () {
-        const event = AudioEvent(
+        final event = AudioEvent(
           id: 'video_source_no_url',
           pubkey: 'pk',
           createdAt: 1700000000,

--- a/mobile/test/providers/video_recorder_audio_service_factory_test.dart
+++ b/mobile/test/providers/video_recorder_audio_service_factory_test.dart
@@ -60,7 +60,7 @@ void main() {
         );
         await mockCamera.initialize();
 
-        const selectedSound = AudioEvent(
+        final selectedSound = AudioEvent(
           id: 'sound_123',
           pubkey:
               'test_pubkey_0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',

--- a/mobile/test/router/routes/restored_route_extras_test.dart
+++ b/mobile/test/router/routes/restored_route_extras_test.dart
@@ -71,7 +71,7 @@ void main() {
     });
 
     testWidgets('sound route accepts restored object maps', (tester) async {
-      const sound = AudioEvent(
+      final sound = AudioEvent(
         id: 'sound-1',
         pubkey: 'pubkey',
         createdAt: 1700000000,
@@ -86,7 +86,7 @@ void main() {
                   _FakeGoRouterState(
                     location: '/sound/sound-1',
                     pathParameters: const {'id': 'sound-1'},
-                    extra: const <Object?, Object?>{'sound': sound},
+                    extra: <Object?, Object?>{'sound': sound},
                   ),
                 )
                 as SoundDetailScreen;

--- a/mobile/test/screens/sound_detail_screen_test.dart
+++ b/mobile/test/screens/sound_detail_screen_test.dart
@@ -292,7 +292,7 @@ void main() {
         // Note: testSound created inline in widget for direct testing
         await tester.pumpWidget(
           createTestWidget(
-            child: const SoundDetailScreen(
+            child: SoundDetailScreen(
               sound: AudioEvent(
                 id: 'sound1',
                 pubkey:
@@ -1099,7 +1099,7 @@ void main() {
       });
 
       testWidgets('shows snackbar when sound has no URL', (tester) async {
-        const testSound = AudioEvent(
+        final testSound = AudioEvent(
           id: 'sound1',
           pubkey:
               'test_pubkey_0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
@@ -1111,7 +1111,7 @@ void main() {
 
         await tester.pumpWidget(
           createTestWidget(
-            child: const SoundDetailScreen(sound: testSound),
+            child: SoundDetailScreen(sound: testSound),
             overrides: [
               soundUsageCountProvider(
                 testSound.id,

--- a/mobile/test/screens/video_editor/video_audio_editor_timing_screen_test.dart
+++ b/mobile/test/screens/video_editor/video_audio_editor_timing_screen_test.dart
@@ -294,7 +294,7 @@ void main() {
     });
 
     testWidgets('renders with bundled sound', (tester) async {
-      const bundledSound = AudioEvent(
+      final bundledSound = AudioEvent(
         id: 'bundled__lofi-beat',
         pubkey: 'bundled_',
         createdAt: 0,

--- a/mobile/test/screens/video_metadata_screen_test.dart
+++ b/mobile/test/screens/video_metadata_screen_test.dart
@@ -348,7 +348,7 @@ void main() {
       testWidgets('shows provider credit read-only and honors license limits', (
         tester,
       ) async {
-        const providerSound = models.AudioEvent(
+        final providerSound = models.AudioEvent(
           id: 'external_provider_freesound_42',
           pubkey: models.AudioEvent.externalProviderMarker,
           createdAt: 1700000000,

--- a/mobile/test/services/video_editor/draft_render_parameters_service_test.dart
+++ b/mobile/test/services/video_editor/draft_render_parameters_service_test.dart
@@ -131,7 +131,7 @@ void main() {
         // library.
         final draft = _draft(
           editorEditingParameters: _persistedParameters(),
-          selectedSound: const AudioEvent(
+          selectedSound: AudioEvent(
             id: 'sound-1',
             pubkey: 'pubkey-1',
             createdAt: 1735689600,

--- a/mobile/test/services/video_event_publisher_test.dart
+++ b/mobile/test/services/video_event_publisher_test.dart
@@ -476,7 +476,7 @@ void main() {
       registerFallbackValue(UploadStatus.pending);
       registerFallbackValue(File('fallback.mp3'));
       registerFallbackValue(
-        const AudioEvent(id: 'fallback', pubkey: 'fallback', createdAt: 0),
+        AudioEvent(id: 'fallback', pubkey: 'fallback', createdAt: 0),
       );
       registerFallbackValue(Duration.zero);
     });
@@ -862,7 +862,7 @@ void main() {
         // A bundled sound has no Nostr event to reference, so the video's own
         // audio is the user's to offer and "Publish this sound" must still
         // take effect instead of being silently dropped (#6185).
-        const bundledSound = AudioEvent(
+        final bundledSound = AudioEvent(
           id: '${AudioEvent.bundledMarker}_oh_no_no_no_crowd',
           pubkey: AudioEvent.bundledMarker,
           createdAt: 0,
@@ -1031,7 +1031,7 @@ void main() {
         () async {
           stubSignAndPublish();
 
-          const externalProviderSound = AudioEvent(
+          final externalProviderSound = AudioEvent(
             id: 'freesound:12345',
             pubkey: AudioEvent.externalProviderMarker,
             createdAt: 0,
@@ -1045,7 +1045,7 @@ void main() {
               creatorUrl: 'https://freesound.org/people/catalog-artist/',
               sourceUrl:
                   'https://freesound.org/people/catalog-artist/sounds/12345/',
-              catalogTags: ['birds', 'field-recording'],
+              catalogTags: const ['birds', 'field-recording'],
               license: AudioLicenseMetadata(
                 type: 'cc-by',
                 name: 'Creative Commons Attribution',
@@ -1115,7 +1115,7 @@ void main() {
         'provider bridge keeps reuse off when the video toggle is off',
         () async {
           stubSignAndPublish();
-          const externalProviderSound = AudioEvent(
+          final externalProviderSound = AudioEvent(
             id: 'freesound:12345',
             pubkey: AudioEvent.externalProviderMarker,
             createdAt: 0,
@@ -1165,7 +1165,7 @@ void main() {
 
     test('provider license can forbid further reuse', () async {
       stubSignAndPublish();
-      const sound = AudioEvent(
+      final sound = AudioEvent(
         id: 'freesound:locked',
         pubkey: AudioEvent.externalProviderMarker,
         createdAt: 0,
@@ -1259,7 +1259,7 @@ void main() {
 
     test('credits the provider when the catalog row has no creator', () async {
       stubSignAndPublish();
-      const thinCatalogRow = AudioEvent(
+      final thinCatalogRow = AudioEvent(
         id: 'freesound:thin',
         pubkey: AudioEvent.externalProviderMarker,
         createdAt: 0,
@@ -1803,7 +1803,7 @@ void main() {
 
 /// A catalog row with neither a creator nor a source URL — no durable public
 /// credit can be built from it.
-const _uncreditedProviderSound = AudioEvent(
+final _uncreditedProviderSound = AudioEvent(
   id: 'freesound:uncredited',
   pubkey: AudioEvent.externalProviderMarker,
   createdAt: 0,

--- a/mobile/test/widgets/audio_attribution_row_test.dart
+++ b/mobile/test/widgets/audio_attribution_row_test.dart
@@ -25,7 +25,7 @@ void main() {
     late AudioEvent testAudio;
 
     setUp(() {
-      testAudio = const AudioEvent(
+      testAudio = AudioEvent(
         id: testAudioEventId,
         pubkey: testPubkey,
         createdAt: 1704067200,
@@ -148,7 +148,7 @@ void main() {
 
       testWidgets('displays fallback when sound has no title', (tester) async {
         final video = createVideoWithAudio();
-        const noTitleAudio = AudioEvent(
+        final noTitleAudio = AudioEvent(
           id: testAudioEventId,
           pubkey: testPubkey,
           createdAt: 1704067200,
@@ -448,7 +448,7 @@ void main() {
         tester,
       ) async {
         final video = createVideoWithAudio();
-        const bundledAudio = AudioEvent(
+        final bundledAudio = AudioEvent(
           id: 'bundled_freesound_crowd',
           pubkey: 'bundled',
           createdAt: 0,
@@ -472,7 +472,7 @@ void main() {
         tester,
       ) async {
         final video = createVideoWithAudio();
-        const bundledAudio = AudioEvent(
+        final bundledAudio = AudioEvent(
           id: 'bundled_freesound_crowd',
           pubkey: 'bundled',
           createdAt: 0,

--- a/mobile/test/widgets/library/saved_sound_card_test.dart
+++ b/mobile/test/widgets/library/saved_sound_card_test.dart
@@ -15,7 +15,7 @@ import 'package:openvine/widgets/vine_cached_image.dart';
 
 import '../../helpers/contrast.dart';
 
-SavedSound _richSound() => const SavedSound(
+SavedSound _richSound() => SavedSound(
   audio: AudioEvent(
     id: 'sound-id',
     pubkey: 'creator',
@@ -24,10 +24,10 @@ SavedSound _richSound() => const SavedSound(
     duration: 6,
   ),
   personalLabel: 'Morning inspiration',
-  personalHashtags: ['ideas', 'funny'],
-  catalogTags: ['field recording', 'birds'],
-  waveformSamples: [0.1, 0.8, 0.4],
-  sourceContext: SavedSoundSourceContext(
+  personalHashtags: const ['ideas', 'funny'],
+  catalogTags: const ['field recording', 'birds'],
+  waveformSamples: const [0.1, 0.8, 0.4],
+  sourceContext: const SavedSoundSourceContext(
     title: 'A tiny bird visits',
     creatorName: 'Alice',
     description: 'Filmed outside before breakfast.',
@@ -115,16 +115,16 @@ void main() {
     (
       tester,
     ) async {
-      const sound = SavedSound(
+      final sound = SavedSound(
         audio: AudioEvent(
           id: 'music',
           pubkey: 'creator',
           createdAt: 1,
           title: 'Instrumental loop',
         ),
-        personalHashtags: [],
-        catalogTags: [],
-        waveformSamples: [],
+        personalHashtags: const [],
+        catalogTags: const [],
+        waveformSamples: const [],
       );
 
       await tester.pumpWidget(_app(sound));
@@ -144,11 +144,11 @@ void main() {
   );
 
   testWidgets('falls back to localized generic title shape', (tester) async {
-    const sound = SavedSound(
+    final sound = SavedSound(
       audio: AudioEvent(id: 'empty', pubkey: 'creator', createdAt: 1),
-      personalHashtags: [],
-      catalogTags: [],
-      waveformSamples: [],
+      personalHashtags: const [],
+      catalogTags: const [],
+      waveformSamples: const [],
     );
 
     await tester.pumpWidget(_app(sound));

--- a/mobile/test/widgets/library/saved_sound_details_editor_test.dart
+++ b/mobile/test/widgets/library/saved_sound_details_editor_test.dart
@@ -30,7 +30,7 @@ class _FailingService extends SavedSoundsService {
   }
 }
 
-const _audio = AudioEvent(
+final _audio = AudioEvent(
   id: 'sound-id',
   pubkey: 'creator',
   createdAt: 1,

--- a/mobile/test/widgets/metadata_sounds_section_test.dart
+++ b/mobile/test/widgets/metadata_sounds_section_test.dart
@@ -39,7 +39,7 @@ void main() {
     late AudioEvent testAudio;
 
     setUp(() {
-      testAudio = const AudioEvent(
+      testAudio = AudioEvent(
         id: testAudioEventId,
         pubkey: testPubkey,
         createdAt: 1704067200,
@@ -475,7 +475,7 @@ void main() {
         (tester) async {
           const sourceVideoId =
               'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789';
-          const reusedSynth = AudioEvent(
+          final reusedSynth = AudioEvent(
             id: 'video_$sourceVideoId',
             pubkey: reusedCreatorPubkey,
             createdAt: 1704067200,

--- a/mobile/test/widgets/sound_tile_test.dart
+++ b/mobile/test/widgets/sound_tile_test.dart
@@ -16,7 +16,7 @@ void main() {
     late AudioEvent testSound;
 
     setUp(() {
-      testSound = const AudioEvent(
+      testSound = AudioEvent(
         id: 'test-audio-event-id-0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
         pubkey:
             'test-pubkey-0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
@@ -277,7 +277,7 @@ void main() {
       });
 
       testWidgets('handles null duration', (tester) async {
-        const nullDurationSound = AudioEvent(
+        final nullDurationSound = AudioEvent(
           id: 'null-duration-id-0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
           pubkey:
               'null-duration-pubkey-0123456789abcdef0123456789abcdef0123456789abcdef0123',
@@ -293,7 +293,7 @@ void main() {
       testWidgets('uses full Vine duration for legacy original sounds', (
         tester,
       ) async {
-        const legacyOriginalSound = AudioEvent(
+        final legacyOriginalSound = AudioEvent(
           id: 'video_legacy-original-id-0123456789abcdef0123456789abcdef0123456789abcdef',
           pubkey:
               'legacy-original-pubkey-0123456789abcdef0123456789abcdef0123456789abcdef',
@@ -322,7 +322,7 @@ void main() {
 
     group('Title handling', () {
       testWidgets('displays fallback for null title', (tester) async {
-        const noTitleSound = AudioEvent(
+        final noTitleSound = AudioEvent(
           id: 'no-title-id-0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
           pubkey:
               'no-title-pubkey-0123456789abcdef0123456789abcdef0123456789abcdef01234567',

--- a/mobile/test/widgets/video_editor/stop_motion/stop_motion_frame_commands_test.dart
+++ b/mobile/test/widgets/video_editor/stop_motion/stop_motion_frame_commands_test.dart
@@ -196,13 +196,13 @@ void main() {
       tester,
     ) async {
       final captured = framesHeldFor(StopMotionFrameOps.defaultFramesPerImage);
-      const sound = AudioEvent(
+      final sound = AudioEvent(
         id: 'sound-1',
         pubkey: 'bundled',
         createdAt: 0,
         url: 'asset://sounds/loop.mp3',
         duration: 30,
-        endTime: Duration(milliseconds: 200),
+        endTime: const Duration(milliseconds: 200),
       );
       when(() => stateManager.activeMeta).thenReturn({
         VideoEditorConstants.audioStateHistoryKey: [sound.toJson()],

--- a/mobile/test/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls_test.dart
@@ -670,13 +670,13 @@ void main() {
       late _MockStateManager stateManager;
       late _MockTimelineOverlayBloc overlayBloc;
 
-      const coveringSound = AudioEvent(
+      final coveringSound = AudioEvent(
         id: 'sound-1',
         pubkey: 'bundled',
         createdAt: 0,
         url: 'asset://sounds/loop.mp3',
         duration: 30,
-        endTime: Duration(seconds: 3),
+        endTime: const Duration(seconds: 3),
       );
 
       setUp(() {

--- a/mobile/test/widgets/video_editor/timeline_editor/controls/video_editor_timeline_overlay_controls_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/controls/video_editor_timeline_overlay_controls_test.dart
@@ -713,21 +713,21 @@ void main() {
         'sound duplicate serializes updated tracks under the audio history key '
         'and selects the copy',
         (tester) async {
-          const trackA = AudioEvent(
+          final trackA = AudioEvent(
             id: 'sound-1',
             pubkey: 'pub',
             createdAt: 0,
-            startOffset: Duration(seconds: 2),
-            startTime: Duration(seconds: 3),
-            endTime: Duration(seconds: 8),
+            startOffset: const Duration(seconds: 2),
+            startTime: const Duration(seconds: 3),
+            endTime: const Duration(seconds: 8),
           );
-          const trackB = AudioEvent(
+          final trackB = AudioEvent(
             id: 'sound-2',
             pubkey: 'pub',
             createdAt: 1,
-            startOffset: Duration(seconds: 1),
-            startTime: Duration(seconds: 8),
-            endTime: Duration(seconds: 12),
+            startOffset: const Duration(seconds: 1),
+            startTime: const Duration(seconds: 8),
+            endTime: const Duration(seconds: 12),
           );
           when(() => mockStateManager.activeMeta).thenReturn({
             VideoEditorConstants.audioStateHistoryKey: [
@@ -784,13 +784,13 @@ void main() {
         'sound split sets startOffset of second segment to '
         'originalOffset + (splitAt - startTime)',
         (tester) async {
-          const track = AudioEvent(
+          final track = AudioEvent(
             id: 'sound-1',
             pubkey: 'pub',
             createdAt: 0,
-            startOffset: Duration(seconds: 2),
-            startTime: Duration(seconds: 3),
-            endTime: Duration(seconds: 8),
+            startOffset: const Duration(seconds: 2),
+            startTime: const Duration(seconds: 3),
+            endTime: const Duration(seconds: 8),
           );
           when(() => mockStateManager.activeMeta).thenReturn({
             VideoEditorConstants.audioStateHistoryKey: [track.toJson()],

--- a/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_geometry_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_geometry_test.dart
@@ -1330,7 +1330,7 @@ void main() {
     });
 
     test('leaves an unbounded window to the render clamp', () {
-      const track = AudioEvent(
+      final track = AudioEvent(
         id: 'sound',
         pubkey: '',
         createdAt: 0,
@@ -1419,7 +1419,7 @@ void main() {
         endTime: const Duration(milliseconds: 200),
         duration: 30,
       );
-      const unbounded = AudioEvent(
+      final unbounded = AudioEvent(
         id: 'ambience',
         pubkey: '',
         createdAt: 0,

--- a/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_test.dart
@@ -681,13 +681,13 @@ void main() {
       late _MockProImageEditorState editor;
       late _MockStateManager stateManager;
 
-      const coveringSound = AudioEvent(
+      final coveringSound = AudioEvent(
         id: 'sound-1',
         pubkey: 'bundled',
         createdAt: 0,
         url: 'asset://sounds/loop.mp3',
         duration: 30,
-        endTime: Duration(seconds: 2),
+        endTime: const Duration(seconds: 2),
       );
 
       setUp(() {

--- a/mobile/test/widgets/video_editor/video_editor_scaffold_test.dart
+++ b/mobile/test/widgets/video_editor/video_editor_scaffold_test.dart
@@ -215,7 +215,7 @@ void main() {
         final clipBloc = _MockClipEditorBloc();
         final mockEditor = _MockProImageEditorState();
         final mockStateManager = _MockStateManager();
-        const audioEvent = AudioEvent(
+        final audioEvent = AudioEvent(
           id: 'audio-1',
           pubkey: '',
           createdAt: 1,

--- a/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart
+++ b/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart
@@ -131,7 +131,7 @@ VideoEvent _makeVideo({
   nostrEventTags: nostrEventTags,
 );
 
-const _testAudio = AudioEvent(
+final _testAudio = AudioEvent(
   id: _audioEventId,
   pubkey: _audioPubkey,
   createdAt: 1700000000,

--- a/mobile/test/widgets/video_recorder/modes/lip_sync/video_recorder_lip_sync_stack_test.dart
+++ b/mobile/test/widgets/video_recorder/modes/lip_sync/video_recorder_lip_sync_stack_test.dart
@@ -123,7 +123,7 @@ void main() {
       ) async {
         await tester.pumpWidget(
           buildWidget(
-            selectedSound: const AudioEvent(
+            selectedSound: AudioEvent(
               id: 'sound-1',
               pubkey: 'pubkey',
               createdAt: 1704067200,


### PR DESCRIPTION
## Description

#7352 moved UTF-16 sanitization into the `UserProfile` and `VideoEvent` constructors. The surfaces #7359 lists were deliberately left out of that diff, and each one is remote text with no sanitizing boundary between the relay and `_NativeParagraphBuilder.addText` — Flutter's paragraph builder throws `Invalid argument(s): string is not well-formed UTF-16` on a lone surrogate. The same Crashlytics signature has been closed as completed three times now (#6111, #6463, #7295), which is what makes closing the remaining set deliberately worth more than fixing the next crash report when it arrives.

**Why the boundary is the generative constructor, again.** #7352 established this and nothing here argues with it: a widget chokepoint cannot work, because `TextPainter.layout` used for measurement, `Semantics` labels, tooltips, and `EditableText` all reach the same native call without going through a `Text` widget. Per-field display getters were the previous approach and they are exactly what leaked. Sanitizing in the one constructor every factory funnels through means `copyWith`, JSON restore, Drift/Hive reads, and fields added later are all covered by default, at zero call sites.

Surface by surface:

- **`AudioEvent`** — `title`, `source`, `creatorName`, `licenseName`, `publicTags`, plus `AudioExternalSource` (`providerName`, `creatorName`, `catalogTags`) and `AudioLicenseMetadata` (`name`). Dropping `const` is what #7352 declined to do as disproportionate for a vector that issue did not name; here it is the point. Every blocked call site turned out to be in tests. `source` and `publicTags` come along because they share the constructor and the render path — the sound detail screen and the public-credit editor put all of them into plain `Text`, and `publicTags` into chips. `url`, `sha256`, `mimeType`, `proxyId` and the id/reference fields stay untouched: they select a playback source or address an event, and rewriting a code unit inside one changes which file resolves.
- **`CuratedList` / `UserList`** — `name`, `description`. Both are kind-30005/30000 events any pubkey may author, reachable through search and collaborative lists, and both render as plain `Text`.
- **NIP-58 badge** — `Nip58BadgeDefinition.name` / `.description`, plus the two paths that render a badge name without one. `_definitionNameFromCoordinate` reads the d-tag out of an `a` tag on someone else's award or profile-badges event, and `CreatedBadgeViewData.displayName` falls back to the definition's own `d` identifier when the event carries no `name` tag. Both are raw tag values with no model in between. Both sanitize on the way out rather than on the field, because the identifier also *addresses* the definition — the coordinate is built from it and the badge editor republishes it verbatim, so rewriting a code unit there would edit a different badge. `Nip58BadgeDefinition.dTag` now documents that invariant.
- **Notifications** — `VideoNotification.listTitle`, and `videoTitle` / `commentText` alongside it. Same relay origin, same `Text.rich` span, and the repository builds these rows from four different sources (REST payload, Drift placeholder rows, grouped page merges, cache rehydration) — guarding one of the three and leaving the other two is the partial coverage this issue exists to end. `ActorNotification.commentText` for the same reason.
- **Hashtags** — `VideoEvent.hashtags` element-wise, `TrendingHashtag.tag`, `HashtagSearchResult.tag`, and the bare-string branch of `FunnelcakeApiClient.searchHashtags`. That last one mattered: the endpoint returns either objects or bare strings, and only the object branch went through `HashtagSearchResult.fromJson`, so the scalar shape reached a chip label unguarded. Both branches now construct the model.

**`ClassicViner.authorName` gets a comment, not a guard.** The issue's premise does not hold for it: `topClassicViners` only ever copies it from `VideoEvent.authorName`, and #7352 already made that constructor the sanitizing boundary. A second `sanitizeUtf16` call there would be dead code by our own rules, so the invariant is documented on the field — including what a future non-`VideoEvent` source would have to do — and pinned by a provider test that drives the real path.

**`sanitizeUtf16List`** is new in `text_sanitizer` for the three list-valued fields. It returns the source list itself when every element is already well-formed, so a clean list keeps its identity and any `unmodifiable` wrapper the caller built it with; only a poisoned list allocates.

**Related Issue:** Closes #7359

## Out of Scope

`HashtagCacheService` writes "popular hashtags" to Hive as bare strings, so unlike the Drift/Hive paths #7352 covered there is no model constructor on its read path to heal an already-poisoned entry. Left alone deliberately: the box carries a 1-hour TTL and every write from now on comes from sanitized `VideoEvent.hashtags`, so a stale entry self-heals within the hour. A cache-key bump would invalidate every device to buy at most 60 minutes.

## Verification

- `flutter analyze lib test integration_test packages` — clean.
- `dart format` — no drift.
- Full app suite via `mise run test` — 17387 passing, 284 skipped.
- Package suites: `models` (953), `funnelcake_api_client` (433), `notification_repository` (188), `badge_repository` (149), `text_sanitizer` (29), plus `hashtag_repository`, `sounds_repository`, `curated_list_repository`, `people_lists_repository`.
- Ratchets run locally and green: `dependency_provenance`, `layer_direction`, `untested_services_floor`, `test_unit_structure`, `post_close_emit_ceiling`, `l10n_delegates_ceiling`, `service_god_file_ceiling`. The new `text_sanitizer` path dependency in `badge_repository` produces no new lockfile entry, so provenance is unchanged.
- Every new assertion is model-layer on purpose, and that is a limitation rather than a preference: the headless `flutter_tester` does not throw on an unpaired surrogate, only the real engine does. This was measured during review of #7352 by running the same `TextPainter.layout` both ways — headless returned no throw, the iOS simulator produced the #7295 stack verbatim. A widget test rendering a poisoned string would therefore pass in CI while the same code crashes on device, which is why the tests assert the sanitized value at the boundary instead.
- Re-run in full after rebasing onto `origin/main` at 59e318c183: analyze clean, every package suite above green, plus `test/blocs/badges`, `test/screens/badges` and `test/providers/top_classic_viners_test.dart`. `badge_repository` and `text_sanitizer` have no `min_coverage` override, so their gate is 100% — both measured at 100% locally after the badge fix.
- The bulk of the diff is mechanical: removing `const` from test call sites that the constructor changes invalidated, and the `prefer_const_*` follow-ups the analyzer then asked for. No behaviour in those tests changed.
- Manually verified on a real Samsung Galaxy, no regression on the affected surfaces. The change is model-layer with no UI diff, so the device pass is a no-regression check rather than a reproduction: the crash it prevents needs a relay to serve a lone surrogate, which a manual pass cannot trigger on demand. The model-layer assertions above stay the evidence for the fix itself.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)


