### PR TITLE
refactor(profile): fold banner dismissal into a store

### DIFF
--- a/mobile/lib/utils/divine_login_banner_dismissal.dart
+++ b/mobile/lib/utils/divine_login_banner_dismissal.dart
@@ -1,53 +1,86 @@
+// ABOUTME: Per-account dismissal state for the Divine login banner.
+// ABOUTME: Owns the preference key, the 30-day TTL, and the reads and writes.
+
+import 'package:openvine/utils/local_content_owner.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+/// How long a dismissal keeps the banner hidden.
 const Duration divineLoginBannerDismissalTtl = Duration(days: 30);
+
 const _dismissedDivineLoginBannerPrefix = 'dismissed_divine_login_banner_';
 
-String divineLoginBannerDismissalKey(String userIdHex) =>
-    '$_dismissedDivineLoginBannerPrefix$userIdHex';
+/// Whether the Divine login banner is hidden for one account.
+///
+/// Scoped to a single account at construction, so a call site cannot pair the
+/// key with the wrong pubkey.
+///
+/// [isDismissed] is synchronous, and a [dismiss] is visible through it before
+/// the returned future completes — `setInt` updates the in-memory
+/// [SharedPreferences] cache synchronously. The session-expired sheet pops
+/// before awaiting the write and depends on that ordering (#7297), so keep
+/// both methods free of any debounce or extra async hop.
+class DivineLoginBannerDismissalStore {
+  const DivineLoginBannerDismissalStore({
+    required SharedPreferences prefs,
+    required String userIdHex,
+  }) : _prefs = prefs,
+       _userIdHex = userIdHex;
 
-bool isDivineLoginBannerDismissed(
-  SharedPreferences prefs,
-  String userIdHex, {
-  DateTime? now,
-}) {
-  final rawValue = prefs.get(divineLoginBannerDismissalKey(userIdHex));
-  if (rawValue is! int) {
-    return false;
+  final SharedPreferences _prefs;
+  final String _userIdHex;
+
+  /// Preference holding the dismissal timestamp for [userIdHex].
+  static String keyFor(String userIdHex) =>
+      '$_dismissedDivineLoginBannerPrefix$userIdHex';
+
+  /// Preference holding this store's dismissal timestamp.
+  String get key => keyFor(_userIdHex);
+
+  /// Whether a dismissal is stored and still within
+  /// [divineLoginBannerDismissalTtl] as of [now], defaulting to the wall clock.
+  ///
+  /// A missing or non-integer value reads as "not dismissed".
+  bool isDismissed({DateTime? now}) {
+    final rawValue = _prefs.get(key);
+    if (rawValue is! int) {
+      return false;
+    }
+
+    final dismissedAt = DateTime.fromMillisecondsSinceEpoch(rawValue);
+    final comparisonTime = now ?? DateTime.now();
+    return comparisonTime.difference(dismissedAt) <
+        divineLoginBannerDismissalTtl;
   }
 
-  final dismissedAt = DateTime.fromMillisecondsSinceEpoch(rawValue);
-  final comparisonTime = now ?? DateTime.now();
-  return comparisonTime.difference(dismissedAt) < divineLoginBannerDismissalTtl;
+  /// Hides the banner as of [now], defaulting to the wall clock.
+  Future<void> dismiss({DateTime? now}) {
+    final dismissedAt = now ?? DateTime.now();
+    return _prefs.setInt(key, dismissedAt.millisecondsSinceEpoch);
+  }
+
+  /// Drops the stored dismissal so the banner can show again.
+  Future<void> clear() => _prefs.remove(key);
 }
 
-Future<void> dismissDivineLoginBanner(
-  SharedPreferences prefs,
-  String userIdHex, {
-  DateTime? now,
-}) {
-  final dismissedAt = now ?? DateTime.now();
-  return prefs.setInt(
-    divineLoginBannerDismissalKey(userIdHex),
-    dismissedAt.millisecondsSinceEpoch,
-  );
-}
-
-Future<void> clearDivineLoginBannerDismissal(
-  SharedPreferences prefs,
-  String userIdHex,
-) {
-  return prefs.remove(divineLoginBannerDismissalKey(userIdHex));
-}
-
+/// Clears the dismissal for [publicKeyHex], or for the account named by
+/// [currentUserPubkeyHexPrefKey] when it is omitted.
+///
+/// Resolves [SharedPreferences] itself rather than taking one, because
+/// `AuthService` holds no instance and calls this from five session-recovery
+/// paths. Pass [publicKeyHex] whenever the caller knows it: the stored pubkey
+/// is a weaker signal than it looks, as [currentUserPubkeyHexPrefKey]
+/// documents.
 Future<void> clearDismissedDivineLoginBannerForCurrentUser([
   String? publicKeyHex,
 ]) async {
   final prefs = await SharedPreferences.getInstance();
   final targetPubkey =
-      publicKeyHex ?? prefs.getString('current_user_pubkey_hex');
+      publicKeyHex ?? prefs.getString(currentUserPubkeyHexPrefKey);
   if (targetPubkey == null || targetPubkey.isEmpty) {
     return;
   }
-  await clearDivineLoginBannerDismissal(prefs, targetPubkey);
+  await DivineLoginBannerDismissalStore(
+    prefs: prefs,
+    userIdHex: targetPubkey,
+  ).clear();
 }

--- a/mobile/lib/widgets/profile/profile_header_widget.dart
+++ b/mobile/lib/widgets/profile/profile_header_widget.dart
@@ -277,10 +277,10 @@ class _ProfileHeaderWidgetState extends ConsumerState<ProfileHeaderWidget> {
     final hasExpiredSession = authService.hasExpiredOAuthSession;
     final isRpcUpgradeInProgress = authService.isRpcUpgradeInProgress;
     final prefs = ref.watch(sharedPreferencesProvider);
-    final isDivineLoginBannerHidden = isDivineLoginBannerDismissed(
-      prefs,
-      widget.userIdHex,
-    );
+    final isDivineLoginBannerHidden = DivineLoginBannerDismissalStore(
+      prefs: prefs,
+      userIdHex: widget.userIdHex,
+    ).isDismissed();
 
     // This is the condition, not the trigger. It stays true while the session
     // is expired, so _SessionExpiredPromptTrigger owns the edge (#7308).
@@ -495,7 +495,10 @@ class _ProfileHeaderWidgetState extends ConsumerState<ProfileHeaderWidget> {
     // `ref` or looking up an ancestor from a button callback throws once the
     // header is gone (#7297).
     final authService = ref.read(authServiceProvider);
-    final prefs = ref.read(sharedPreferencesProvider);
+    final bannerDismissal = DivineLoginBannerDismissalStore(
+      prefs: ref.read(sharedPreferencesProvider),
+      userIdHex: userIdHex,
+    );
     final publishBloc = context.read<BackgroundPublishBloc>();
     final navigator = Navigator.of(context);
 
@@ -523,9 +526,9 @@ class _ProfileHeaderWidgetState extends ConsumerState<ProfileHeaderWidget> {
         // repeatedly (#7297), so a second tap would pop the screen underneath.
         // Awaiting first buys nothing — `setInt` updates the in-memory
         // SharedPreferences cache synchronously, so the dismissal is already
-        // visible to `isDivineLoginBannerDismissed` before the pop.
+        // visible to `isDismissed` before the pop.
         navigator.pop();
-        await dismissDivineLoginBanner(prefs, userIdHex);
+        await bannerDismissal.dismiss();
       },
     );
   }

--- a/mobile/test/services/auth_service_expired_session_downgrade_test.dart
+++ b/mobile/test/services/auth_service_expired_session_downgrade_test.dart
@@ -931,7 +931,8 @@ void main() {
         final prefs = await SharedPreferences.getInstance();
         final delayedPrefs = _DelayingSharedPreferencesStore.withData(
           prefixedSharedPreferencesData(prefs),
-          delayedRemoveKey: 'flutter.${divineLoginBannerDismissalKey(pubkey)}',
+          delayedRemoveKey:
+              'flutter.${DivineLoginBannerDismissalStore.keyFor(pubkey)}',
         );
         SharedPreferencesStorePlatform.instance = delayedPrefs;
         SharedPreferences.resetStatic();

--- a/mobile/test/utils/divine_login_banner_dismissal_test.dart
+++ b/mobile/test/utils/divine_login_banner_dismissal_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/utils/divine_login_banner_dismissal.dart';
+import 'package:openvine/utils/local_content_owner.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
@@ -9,48 +10,124 @@ void main() {
     SharedPreferences.setMockInitialValues({});
   });
 
-  test('dismissal remains active within 30 days', () async {
-    final prefs = await SharedPreferences.getInstance();
-
-    await dismissDivineLoginBanner(prefs, pubkey, now: DateTime(2026, 3, 22));
-
-    expect(
-      isDivineLoginBannerDismissed(prefs, pubkey, now: DateTime(2026, 4, 20)),
-      isTrue,
+  Future<DivineLoginBannerDismissalStore> storeFor(String userIdHex) async {
+    return DivineLoginBannerDismissalStore(
+      prefs: await SharedPreferences.getInstance(),
+      userIdHex: userIdHex,
     );
+  }
+
+  group(DivineLoginBannerDismissalStore, () {
+    test('dismissal remains active within 30 days', () async {
+      final store = await storeFor(pubkey);
+
+      await store.dismiss(now: DateTime(2026, 3, 22));
+
+      expect(store.isDismissed(now: DateTime(2026, 4, 20)), isTrue);
+    });
+
+    test('dismissal expires after 30 days', () async {
+      final store = await storeFor(pubkey);
+
+      await store.dismiss(now: DateTime(2026, 3, 22));
+
+      expect(store.isDismissed(now: DateTime(2026, 4, 22)), isFalse);
+    });
+
+    test('returns false when no dismissal stored', () async {
+      final store = await storeFor(pubkey);
+
+      expect(store.isDismissed(), isFalse);
+    });
+
+    test('returns false when the stored value is not a timestamp', () async {
+      SharedPreferences.setMockInitialValues({
+        DivineLoginBannerDismissalStore.keyFor(pubkey): 'corrupted',
+      });
+      final store = await storeFor(pubkey);
+
+      expect(store.isDismissed(), isFalse);
+    });
+
+    test('clear removes the key', () async {
+      final store = await storeFor(pubkey);
+
+      await store.dismiss();
+      expect(store.isDismissed(), isTrue);
+
+      await store.clear();
+      expect(store.isDismissed(), isFalse);
+    });
+
+    test('key includes the user pubkey', () async {
+      final store = await storeFor(pubkey);
+
+      expect(store.key, equals('dismissed_divine_login_banner_$pubkey'));
+      expect(store.key, equals(DivineLoginBannerDismissalStore.keyFor(pubkey)));
+    });
+
+    test("one account's dismissal does not hide another's banner", () async {
+      final other = await storeFor('other_pubkey_hex');
+      await (await storeFor(pubkey)).dismiss();
+
+      expect(other.isDismissed(), isFalse);
+    });
   });
 
-  test('dismissal expires after 30 days', () async {
-    final prefs = await SharedPreferences.getInstance();
+  group('clearDismissedDivineLoginBannerForCurrentUser', () {
+    test('clears the dismissal for an explicitly named account', () async {
+      final store = await storeFor(pubkey);
+      await store.dismiss();
 
-    await dismissDivineLoginBanner(prefs, pubkey, now: DateTime(2026, 3, 22));
+      await clearDismissedDivineLoginBannerForCurrentUser(pubkey);
 
-    expect(
-      isDivineLoginBannerDismissed(prefs, pubkey, now: DateTime(2026, 4, 22)),
-      isFalse,
-    );
-  });
+      expect(store.isDismissed(), isFalse);
+    });
 
-  test('returns false when no dismissal stored', () async {
-    final prefs = await SharedPreferences.getInstance();
+    test('falls back to the stored current-user pubkey', () async {
+      SharedPreferences.setMockInitialValues({
+        currentUserPubkeyHexPrefKey: pubkey,
+      });
+      final store = await storeFor(pubkey);
+      await store.dismiss();
 
-    expect(isDivineLoginBannerDismissed(prefs, pubkey), isFalse);
-  });
+      await clearDismissedDivineLoginBannerForCurrentUser();
 
-  test('clearDivineLoginBannerDismissal removes the key', () async {
-    final prefs = await SharedPreferences.getInstance();
+      expect(store.isDismissed(), isFalse);
+    });
 
-    await dismissDivineLoginBanner(prefs, pubkey);
-    expect(isDivineLoginBannerDismissed(prefs, pubkey), isTrue);
+    test('explicit pubkey wins over the stored current-user pubkey', () async {
+      SharedPreferences.setMockInitialValues({
+        currentUserPubkeyHexPrefKey: 'signed_in_pubkey_hex',
+      });
+      final signedIn = await storeFor('signed_in_pubkey_hex');
+      final target = await storeFor(pubkey);
+      await signedIn.dismiss();
+      await target.dismiss();
 
-    await clearDivineLoginBannerDismissal(prefs, pubkey);
-    expect(isDivineLoginBannerDismissed(prefs, pubkey), isFalse);
-  });
+      await clearDismissedDivineLoginBannerForCurrentUser(pubkey);
 
-  test('dismissalKey includes user pubkey', () {
-    expect(
-      divineLoginBannerDismissalKey(pubkey),
-      equals('dismissed_divine_login_banner_$pubkey'),
-    );
+      expect(target.isDismissed(), isFalse);
+      expect(signedIn.isDismissed(), isTrue);
+    });
+
+    test('does nothing when no account is named or stored', () async {
+      final store = await storeFor(pubkey);
+      await store.dismiss();
+
+      await clearDismissedDivineLoginBannerForCurrentUser();
+
+      expect(store.isDismissed(), isTrue);
+    });
+
+    test('does nothing when the stored pubkey is empty', () async {
+      SharedPreferences.setMockInitialValues({currentUserPubkeyHexPrefKey: ''});
+      final store = await storeFor(pubkey);
+      await store.dismiss();
+
+      await clearDismissedDivineLoginBannerForCurrentUser();
+
+      expect(store.isDismissed(), isTrue);
+    });
   });
 }

--- a/mobile/test/widgets/profile/profile_header_widget_test.dart
+++ b/mobile/test/widgets/profile/profile_header_widget_test.dart
@@ -36,6 +36,7 @@ import 'package:openvine/screens/badges/badges_screen.dart';
 import 'package:openvine/screens/other_profile_screen.dart';
 import 'package:openvine/services/auth_service.dart' hide UserProfile;
 import 'package:openvine/services/og_viner_cache_service.dart';
+import 'package:openvine/utils/divine_login_banner_dismissal.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/og_viner_badge.dart';
@@ -204,7 +205,8 @@ const issuerUserHex =
     '4f071cf08328c9d9dbb21f5d9d1e51fe2ecf4e7de5a4e59ecdf356f6a6f49f22';
 const recipientUserHex =
     '4ac3abe4d7c0bdfb3e5f2f904f4c7e7f60cd4b4ebe1f8b6eea9e969fbac0b7aa';
-const _dismissedDivineLoginBannerPrefix = 'dismissed_divine_login_banner_';
+final String _dismissedDivineLoginBannerKey =
+    DivineLoginBannerDismissalStore.keyFor(testUserHex);
 
 /// Minimal fake [DivineVideoDraft] for use in [BackgroundUpload] test fixtures.
 class _FakeDraft extends Fake implements DivineVideoDraft {
@@ -2289,7 +2291,7 @@ void main() {
               .millisecondsSinceEpoch;
 
           SharedPreferences.setMockInitialValues({
-            '$_dismissedDivineLoginBannerPrefix$testUserHex': dismissedAt,
+            _dismissedDivineLoginBannerKey: dismissedAt,
           });
           final prefs = await SharedPreferences.getInstance();
 
@@ -2687,10 +2689,7 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(tester.takeException(), isNull);
-        expect(
-          prefs.getInt('$_dismissedDivineLoginBannerPrefix$testUserHex'),
-          isNotNull,
-        );
+        expect(prefs.getInt(_dismissedDivineLoginBannerKey), isNotNull);
         expect(find.byType(VineBottomSheetPrompt), findsNothing);
       });
 
@@ -2740,10 +2739,7 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(tester.takeException(), isNull);
-        expect(
-          prefs.getInt('$_dismissedDivineLoginBannerPrefix$testUserHex'),
-          isNotNull,
-        );
+        expect(prefs.getInt(_dismissedDivineLoginBannerKey), isNotNull);
         expect(find.byType(VineBottomSheetPrompt), findsNothing);
       });
 


### PR DESCRIPTION
Closes #7754

## What

`mobile/lib/utils/divine_login_banner_dismissal.dart` was four free functions taking `SharedPreferences` positionally, plus a fifth that reached for the singleton itself — with the key prefix, the 30-day TTL and the key builder spread across all of them. Any caller could pair the key with any pubkey.

`DivineLoginBannerDismissalStore` scopes to one account at construction and owns the key, the TTL and the clock seam, matching the shape `FeedModePreferenceStore` and `AppearanceRepository` already use.

## Why here, and why the file did not move

`lib/services/` is where the repo's other `*Store` classes live, but `check_ui_service_boundary.sh` bars `lib/widgets/**` from importing `package:openvine/services/…`, and the consumer is `lib/widgets/profile/profile_header_widget.dart`. It is already on that guard's baseline, so CI would have tolerated another services import — deepening a violation #4338 exists to remove is the wrong direction. `lib/repositories/` is network-backed clients only. Keeping the path also means **`auth_service.dart` is not edited at all**: it sits at 4761 lines against a 4780 ceiling, and #7630 carried an explicit "keep auth service line count flat" commit.

## Behaviour is unchanged

The preference key `dismissed_divine_login_banner_<pubkeyHex>` is identical, so existing dismissals survive. Four invariants were preserved deliberately:

- **`isDismissed` stays synchronous** — `profile_header_widget.dart` calls it inline in `build()`.
- **The store handle is captured outside the sheet callback** — the header unmounts while the sheet route survives (#7297).
- **`dismiss()` is a thin `setInt`**, so the write is visible to `isDismissed` before the future completes; the sheet pops first and depends on that ordering.
- **`clearDismissedDivineLoginBannerForCurrentUser` keeps its signature and still resolves prefs itself.** `AuthService` holds no instance and calls it from five session-recovery paths. Resolving late is also what lets `auth_service_expired_session_downgrade_test.dart` swap the platform store between the call and the write — capturing prefs at construction would hang that test.

It now reads the canonical `currentUserPubkeyHexPrefKey` instead of repeating the string literal.

## Tests

`profile_header_widget_test.dart` seeds prefs and asserts the raw key directly, so those tests passing unchanged (beyond swapping a hand-copied prefix constant for `DivineLoginBannerDismissalStore.keyFor`) is the proof the key contract held.

Added the coverage `clearDismissedDivineLoginBannerForCurrentUser` never had: explicit-pubkey path, stored-pubkey fallback, explicit-wins-over-stored, and both no-op cases (absent and empty). Plus a corrupt-value case and a cross-account isolation case on the store.

## Not requested by this change

Two pre-existing findings surfaced while mapping the call sites. Neither is touched here — both would change behaviour. Happy to file them.

1. **The no-arg clear can target the wrong account.** `current_user_pubkey_hex` is written only by `AuthService._setupUserSession`; `_reconnectBunker` / `_reconnectAmber` establish sessions without it, so the pref can still name the previous account — documented at `lib/utils/local_content_owner.dart:8-17`. `resolveLocalContentOwnerPubkey` cross-checks `KnownAccountsRegistry`; this helper does not. All five call sites are OAuth/Keycast paths, so it is likely unreachable today.
2. **The key is never garbage-collected.** `dismissed_divine_login_banner_<pubkey>` is not in `UserDataCleanupService.identityChangePrefixes`. Re-checked since opening this PR: that list is caches only (`following_list_`, `relay_discovery_`, `dm.*SyncedAt.`), and because the banner key is pubkey-scoped it cannot bleed into another account — a returning account correctly keeps its own dismissal. So this is stale-key housekeeping, not a correctness problem. Noting it only so a reviewer does not have to re-derive that.

## Verification

- `flutter analyze lib test integration_test` — no issues
- `flutter test` on all three affected suites — 122 passing
- `check_ui_service_boundary.sh`, `check_layer_direction.sh`, `check_service_god_file_ceiling.sh`, `check_untested_services_floor.sh`, `check_test_unit_structure.sh` — all pass
- `auth_service.dart` still 4761 lines, unmodified

No UI change, so no screenshots.

