### PR TITLE
fix(a11y): label the auth-flow icon buttons and localize the password toggle

### DIFF
--- a/mobile/lib/constants/semantic_ids.dart
+++ b/mobile/lib/constants/semantic_ids.dart
@@ -100,6 +100,10 @@ abstract class SemanticIds {
   static const String authContinueAsButton = 'continue_as_button';
   static const String authUseAnotherAccountButton =
       'use_another_account_button';
+
+  /// Sign-in options screen. The info button opens the sheet explaining each
+  /// sign-in method; the back control there reuses
+  /// `DiVineAppBarLeading.backButtonSemanticId`.
   static const String authSignInOptionsInfoButton =
       'sign_in_options_info_button';
 

--- a/mobile/lib/constants/semantic_ids.dart
+++ b/mobile/lib/constants/semantic_ids.dart
@@ -100,6 +100,8 @@ abstract class SemanticIds {
   static const String authContinueAsButton = 'continue_as_button';
   static const String authUseAnotherAccountButton =
       'use_another_account_button';
+  static const String authSignInOptionsInfoButton =
+      'sign_in_options_info_button';
 
   /// Invite gate. Account creation is gated on a code here, so these two sit
   /// on the critical path of every flow that signs up.

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -5368,5 +5368,8 @@
     "dbFailureCancel": "ሰርዝ",
     "dbFailureResetFailed": "ያ አልሰራም። Divineን ዘግተው እንደገና ይሞክሩ።",
     "dbFailureResetDoneTitle": "የአካባቢ ዳታቤዝ ዳግም ተጀምሯል",
-    "dbFailureResetDoneBody": "Divineን ዝጋ እና እንደገና ክፈተው — ቀጣዩ ጅምር አዲስ የአካባቢ ዳታቤዝ ይገነባል።"
+    "dbFailureResetDoneBody": "Divineን ዝጋ እና እንደገና ክፈተው — ቀጣዩ ጅምር አዲስ የአካባቢ ዳታቤዝ ይገነባል።",
+  "authSignInOptionsInfo": "ስለ መግቢያ አማራጮች",
+  "authShowPassword": "የይለፍ ቃል አሳይ",
+  "authHidePassword": "የይለፍ ቃል ደብቅ"
 }

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -5243,5 +5243,8 @@
     "dbFailureCancel": "إلغاء",
     "dbFailureResetFailed": "لم ينجح ذلك. أغلق Divine وحاول مرة أخرى.",
     "dbFailureResetDoneTitle": "تمت إعادة تعيين قاعدة البيانات المحلية",
-    "dbFailureResetDoneBody": "أغلق Divine ثم افتحه مجددًا — سيبني التشغيل التالي قاعدة بيانات محلية جديدة."
+    "dbFailureResetDoneBody": "أغلق Divine ثم افتحه مجددًا — سيبني التشغيل التالي قاعدة بيانات محلية جديدة.",
+  "authSignInOptionsInfo": "حول خيارات تسجيل الدخول",
+  "authShowPassword": "إظهار كلمة المرور",
+  "authHidePassword": "إخفاء كلمة المرور"
 }

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -5374,5 +5374,8 @@
     "dbFailureCancel": "отказ",
     "dbFailureResetFailed": "Това не сработи. Затвори Divine и опитай отново.",
     "dbFailureResetDoneTitle": "локалната база данни е нулирана",
-    "dbFailureResetDoneBody": "Затвори Divine и го отвори отново — следващото стартиране изгражда нова локална база данни."
+    "dbFailureResetDoneBody": "Затвори Divine и го отвори отново — следващото стартиране изгражда нова локална база данни.",
+  "authSignInOptionsInfo": "Относно опциите за вход",
+  "authShowPassword": "Показване на паролата",
+  "authHidePassword": "Скриване на паролата"
 }

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -5243,5 +5243,8 @@
     "dbFailureCancel": "Abbrechen",
     "dbFailureResetFailed": "Das hat nicht geklappt. Schließe Divine und versuche es erneut.",
     "dbFailureResetDoneTitle": "Lokale Datenbank zurückgesetzt",
-    "dbFailureResetDoneBody": "Schließe Divine und öffne es erneut — der nächste Start legt eine frische lokale Datenbank an."
+    "dbFailureResetDoneBody": "Schließe Divine und öffne es erneut — der nächste Start legt eine frische lokale Datenbank an.",
+  "authSignInOptionsInfo": "Über Anmeldeoptionen",
+  "authShowPassword": "Passwort anzeigen",
+  "authHidePassword": "Passwort ausblenden"
 }

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -7669,5 +7669,11 @@
   "dbFailureResetDoneTitle": "local database reset",
   "@dbFailureResetDoneTitle": {"description": "Title of the terminal step after a successful local-database reset."},
   "dbFailureResetDoneBody": "Close Divine and open it again — the next launch builds a fresh local database.",
-  "@dbFailureResetDoneBody": {"description": "Body of the terminal step after a successful reset, telling the user to relaunch."}
+  "@dbFailureResetDoneBody": {"description": "Body of the terminal step after a successful reset, telling the user to relaunch."},
+  "authSignInOptionsInfo": "About sign-in options",
+  "@authSignInOptionsInfo": {"description": "Screen-reader label for the info button on the sign-in options screen, which opens a sheet explaining each sign-in method."},
+  "authShowPassword": "Show password",
+  "@authShowPassword": {"description": "Screen-reader label for the control that reveals the typed password."},
+  "authHidePassword": "Hide password",
+  "@authHidePassword": {"description": "Screen-reader label for the control that re-masks the typed password."}
 }

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -5243,5 +5243,8 @@
     "dbFailureCancel": "cancelar",
     "dbFailureResetFailed": "Eso no funcionó. Cerrá Divine y probá de nuevo.",
     "dbFailureResetDoneTitle": "base de datos local restablecida",
-    "dbFailureResetDoneBody": "Cerrá Divine y volvé a abrirlo — el próximo inicio crea una base de datos local nueva."
+    "dbFailureResetDoneBody": "Cerrá Divine y volvé a abrirlo — el próximo inicio crea una base de datos local nueva.",
+  "authSignInOptionsInfo": "Acerca de las opciones de inicio de sesión",
+  "authShowPassword": "Mostrar contraseña",
+  "authHidePassword": "Ocultar contraseña"
 }

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -3837,5 +3837,8 @@
     "dbFailureCancel": "kanselahin",
     "dbFailureResetFailed": "Hindi ito gumana. Isara ang Divine at subukan ulit.",
     "dbFailureResetDoneTitle": "na-reset ang lokal na database",
-    "dbFailureResetDoneBody": "Isara ang Divine at buksan itong muli — gagawa ng bagong lokal na database sa susunod na paglulunsad."
+    "dbFailureResetDoneBody": "Isara ang Divine at buksan itong muli — gagawa ng bagong lokal na database sa susunod na paglulunsad.",
+  "authSignInOptionsInfo": "Tungkol sa mga opsyon sa pag-sign in",
+  "authShowPassword": "Ipakita ang password",
+  "authHidePassword": "Itago ang password"
 }

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -5243,5 +5243,8 @@
     "dbFailureCancel": "annuler",
     "dbFailureResetFailed": "Ça n'a pas fonctionné. Fermez Divine et réessayez.",
     "dbFailureResetDoneTitle": "base de données locale réinitialisée",
-    "dbFailureResetDoneBody": "Fermez Divine et rouvrez-le — le prochain lancement crée une nouvelle base de données locale."
+    "dbFailureResetDoneBody": "Fermez Divine et rouvrez-le — le prochain lancement crée une nouvelle base de données locale.",
+  "authSignInOptionsInfo": "À propos des options de connexion",
+  "authShowPassword": "Afficher le mot de passe",
+  "authHidePassword": "Masquer le mot de passe"
 }

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -5243,5 +5243,8 @@
     "dbFailureCancel": "batal",
     "dbFailureResetFailed": "Itu tidak berhasil. Tutup Divine dan coba lagi.",
     "dbFailureResetDoneTitle": "basis data lokal telah diatur ulang",
-    "dbFailureResetDoneBody": "Tutup Divine lalu buka lagi — peluncuran berikutnya membangun basis data lokal yang baru."
+    "dbFailureResetDoneBody": "Tutup Divine lalu buka lagi — peluncuran berikutnya membangun basis data lokal yang baru.",
+  "authSignInOptionsInfo": "Tentang opsi masuk",
+  "authShowPassword": "Tampilkan sandi",
+  "authHidePassword": "Sembunyikan sandi"
 }

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -5243,5 +5243,8 @@
     "dbFailureCancel": "annulla",
     "dbFailureResetFailed": "Non ha funzionato. Chiudi Divine e riprova.",
     "dbFailureResetDoneTitle": "database locale reimpostato",
-    "dbFailureResetDoneBody": "Chiudi Divine e riaprilo — al prossimo avvio verrà creato un nuovo database locale."
+    "dbFailureResetDoneBody": "Chiudi Divine e riaprilo — al prossimo avvio verrà creato un nuovo database locale.",
+  "authSignInOptionsInfo": "Informazioni sulle opzioni di accesso",
+  "authShowPassword": "Mostra password",
+  "authHidePassword": "Nascondi password"
 }

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -5243,5 +5243,8 @@
     "dbFailureCancel": "キャンセル",
     "dbFailureResetFailed": "うまくいきませんでした。Divine を閉じてもう一度お試しください。",
     "dbFailureResetDoneTitle": "ローカルデータベースをリセットしました",
-    "dbFailureResetDoneBody": "Divine を閉じてもう一度開いてください。次回の起動で新しいローカルデータベースが作成されます。"
+    "dbFailureResetDoneBody": "Divine を閉じてもう一度開いてください。次回の起動で新しいローカルデータベースが作成されます。",
+  "authSignInOptionsInfo": "ログイン方法について",
+  "authShowPassword": "パスワードを表示",
+  "authHidePassword": "パスワードを非表示"
 }

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -4589,5 +4589,8 @@
     "dbFailureCancel": "취소",
     "dbFailureResetFailed": "실패했습니다. Divine을 닫고 다시 시도하세요.",
     "dbFailureResetDoneTitle": "로컬 데이터베이스가 초기화되었습니다",
-    "dbFailureResetDoneBody": "Divine을 닫았다가 다시 여세요. 다음 실행에서 새 로컬 데이터베이스가 만들어집니다."
+    "dbFailureResetDoneBody": "Divine을 닫았다가 다시 여세요. 다음 실행에서 새 로컬 데이터베이스가 만들어집니다.",
+  "authSignInOptionsInfo": "로그인 옵션 정보",
+  "authShowPassword": "비밀번호 표시",
+  "authHidePassword": "비밀번호 숨기기"
 }

--- a/mobile/lib/l10n/app_ms.arb
+++ b/mobile/lib/l10n/app_ms.arb
@@ -7073,5 +7073,8 @@
   "dbFailureCancel": "batal",
   "dbFailureResetFailed": "Itu tidak berjaya. Tutup Divine dan cuba lagi.",
   "dbFailureResetDoneTitle": "pangkalan data setempat ditetapkan semula",
-  "dbFailureResetDoneBody": "Tutup Divine dan buka semula — pelancaran seterusnya membina pangkalan data setempat yang baharu."
+  "dbFailureResetDoneBody": "Tutup Divine dan buka semula — pelancaran seterusnya membina pangkalan data setempat yang baharu.",
+  "authSignInOptionsInfo": "Tentang pilihan log masuk",
+  "authShowPassword": "Tunjukkan kata laluan",
+  "authHidePassword": "Sembunyikan kata laluan"
 }

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -5243,5 +5243,8 @@
     "dbFailureCancel": "annuleren",
     "dbFailureResetFailed": "Dat werkte niet. Sluit Divine en probeer het opnieuw.",
     "dbFailureResetDoneTitle": "lokale database gereset",
-    "dbFailureResetDoneBody": "Sluit Divine en open het opnieuw — bij de volgende start wordt een nieuwe lokale database aangemaakt."
+    "dbFailureResetDoneBody": "Sluit Divine en open het opnieuw — bij de volgende start wordt een nieuwe lokale database aangemaakt.",
+  "authSignInOptionsInfo": "Over aanmeldopties",
+  "authShowPassword": "Wachtwoord tonen",
+  "authHidePassword": "Wachtwoord verbergen"
 }

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -5243,5 +5243,8 @@
     "dbFailureCancel": "anuluj",
     "dbFailureResetFailed": "To nie zadziałało. Zamknij Divine i spróbuj ponownie.",
     "dbFailureResetDoneTitle": "lokalna baza danych zresetowana",
-    "dbFailureResetDoneBody": "Zamknij Divine i otwórz go ponownie — następne uruchomienie utworzy nową lokalną bazę danych."
+    "dbFailureResetDoneBody": "Zamknij Divine i otwórz go ponownie — następne uruchomienie utworzy nową lokalną bazę danych.",
+  "authSignInOptionsInfo": "Informacje o opcjach logowania",
+  "authShowPassword": "Pokaż hasło",
+  "authHidePassword": "Ukryj hasło"
 }

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -5243,5 +5243,8 @@
     "dbFailureCancel": "cancelar",
     "dbFailureResetFailed": "Isso não funcionou. Feche o Divine e tente de novo.",
     "dbFailureResetDoneTitle": "banco de dados local redefinido",
-    "dbFailureResetDoneBody": "Feche o Divine e abra de novo — a próxima inicialização cria um banco de dados local novo."
+    "dbFailureResetDoneBody": "Feche o Divine e abra de novo — a próxima inicialização cria um banco de dados local novo.",
+  "authSignInOptionsInfo": "Sobre as opções de login",
+  "authShowPassword": "Mostrar senha",
+  "authHidePassword": "Ocultar senha"
 }

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -5243,5 +5243,8 @@
     "dbFailureCancel": "anulează",
     "dbFailureResetFailed": "Nu a funcționat. Închide Divine și încearcă din nou.",
     "dbFailureResetDoneTitle": "baza de date locală a fost resetată",
-    "dbFailureResetDoneBody": "Închide Divine și deschide-l din nou — următoarea pornire creează o bază de date locală nouă."
+    "dbFailureResetDoneBody": "Închide Divine și deschide-l din nou — următoarea pornire creează o bază de date locală nouă.",
+  "authSignInOptionsInfo": "Despre opțiunile de conectare",
+  "authShowPassword": "Afișați parola",
+  "authHidePassword": "Ascundeți parola"
 }

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -5243,5 +5243,8 @@
     "dbFailureCancel": "avbryt",
     "dbFailureResetFailed": "Det fungerade inte. Stäng Divine och försök igen.",
     "dbFailureResetDoneTitle": "lokal databas återställd",
-    "dbFailureResetDoneBody": "Stäng Divine och öppna det igen — nästa start skapar en ny lokal databas."
+    "dbFailureResetDoneBody": "Stäng Divine och öppna det igen — nästa start skapar en ny lokal databas.",
+  "authSignInOptionsInfo": "Om inloggningsalternativ",
+  "authShowPassword": "Visa lösenord",
+  "authHidePassword": "Dölj lösenord"
 }

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -5243,5 +5243,8 @@
     "dbFailureCancel": "iptal",
     "dbFailureResetFailed": "Bu işe yaramadı. Divine’ı kapatıp tekrar deneyin.",
     "dbFailureResetDoneTitle": "yerel veritabanı sıfırlandı",
-    "dbFailureResetDoneBody": "Divine’ı kapatıp yeniden açın — sonraki başlatmada yeni bir yerel veritabanı oluşturulur."
+    "dbFailureResetDoneBody": "Divine’ı kapatıp yeniden açın — sonraki başlatmada yeni bir yerel veritabanı oluşturulur.",
+  "authSignInOptionsInfo": "Oturum açma seçenekleri hakkında",
+  "authShowPassword": "Şifreyi göster",
+  "authHidePassword": "Şifreyi gizle"
 }

--- a/mobile/lib/l10n/app_ur.arb
+++ b/mobile/lib/l10n/app_ur.arb
@@ -7073,5 +7073,8 @@
   "dbFailureCancel": "منسوخ کریں",
   "dbFailureResetFailed": "یہ کام نہیں کیا۔ Divine بند کریں اور دوبارہ کوشش کریں۔",
   "dbFailureResetDoneTitle": "مقامی ڈیٹابیس ری سیٹ ہو گیا",
-  "dbFailureResetDoneBody": "Divine بند کریں اور دوبارہ کھولیں — اگلی بار شروع ہونے پر نیا مقامی ڈیٹابیس بنے گا۔"
+  "dbFailureResetDoneBody": "Divine بند کریں اور دوبارہ کھولیں — اگلی بار شروع ہونے پر نیا مقامی ڈیٹابیس بنے گا۔",
+  "authSignInOptionsInfo": "سائن ان کے اختیارات کے بارے میں",
+  "authShowPassword": "پاس ورڈ دکھائیں",
+  "authHidePassword": "پاس ورڈ چھپائیں"
 }

--- a/mobile/lib/l10n/app_vi.arb
+++ b/mobile/lib/l10n/app_vi.arb
@@ -7073,5 +7073,8 @@
   "dbFailureCancel": "hủy",
   "dbFailureResetFailed": "Không thành công. Hãy đóng Divine và thử lại.",
   "dbFailureResetDoneTitle": "đã đặt lại cơ sở dữ liệu cục bộ",
-  "dbFailureResetDoneBody": "Đóng Divine rồi mở lại — lần khởi chạy tiếp theo sẽ tạo cơ sở dữ liệu cục bộ mới."
+  "dbFailureResetDoneBody": "Đóng Divine rồi mở lại — lần khởi chạy tiếp theo sẽ tạo cơ sở dữ liệu cục bộ mới.",
+  "authSignInOptionsInfo": "Giới thiệu về tùy chọn đăng nhập",
+  "authShowPassword": "Hiện mật khẩu",
+  "authHidePassword": "Ẩn mật khẩu"
 }

--- a/mobile/lib/l10n/app_zh.arb
+++ b/mobile/lib/l10n/app_zh.arb
@@ -7073,5 +7073,8 @@
   "dbFailureCancel": "取消",
   "dbFailureResetFailed": "没有成功。请关闭 Divine 后重试。",
   "dbFailureResetDoneTitle": "本地数据库已重置",
-  "dbFailureResetDoneBody": "关闭 Divine 后重新打开 — 下次启动会建立全新的本地数据库。"
+  "dbFailureResetDoneBody": "关闭 Divine 后重新打开 — 下次启动会建立全新的本地数据库。",
+  "authSignInOptionsInfo": "关于登录选项",
+  "authShowPassword": "显示密码",
+  "authHidePassword": "隐藏密码"
 }

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -20865,6 +20865,24 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Close Divine and open it again — the next launch builds a fresh local database.'**
   String get dbFailureResetDoneBody;
+
+  /// Screen-reader label for the info button on the sign-in options screen, which opens a sheet explaining each sign-in method.
+  ///
+  /// In en, this message translates to:
+  /// **'About sign-in options'**
+  String get authSignInOptionsInfo;
+
+  /// Screen-reader label for the control that reveals the typed password.
+  ///
+  /// In en, this message translates to:
+  /// **'Show password'**
+  String get authShowPassword;
+
+  /// Screen-reader label for the control that re-masks the typed password.
+  ///
+  /// In en, this message translates to:
+  /// **'Hide password'**
+  String get authHidePassword;
 }
 
 class _AppLocalizationsDelegate

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -11985,4 +11985,13 @@ class AppLocalizationsAm extends AppLocalizations {
   @override
   String get dbFailureResetDoneBody =>
       'Divineን ዝጋ እና እንደገና ክፈተው — ቀጣዩ ጅምር አዲስ የአካባቢ ዳታቤዝ ይገነባል።';
+
+  @override
+  String get authSignInOptionsInfo => 'ስለ መግቢያ አማራጮች';
+
+  @override
+  String get authShowPassword => 'የይለፍ ቃል አሳይ';
+
+  @override
+  String get authHidePassword => 'የይለፍ ቃል ደብቅ';
 }

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -12210,4 +12210,13 @@ class AppLocalizationsAr extends AppLocalizations {
   @override
   String get dbFailureResetDoneBody =>
       'أغلق Divine ثم افتحه مجددًا — سيبني التشغيل التالي قاعدة بيانات محلية جديدة.';
+
+  @override
+  String get authSignInOptionsInfo => 'حول خيارات تسجيل الدخول';
+
+  @override
+  String get authShowPassword => 'إظهار كلمة المرور';
+
+  @override
+  String get authHidePassword => 'إخفاء كلمة المرور';
 }

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -12425,4 +12425,13 @@ class AppLocalizationsBg extends AppLocalizations {
   @override
   String get dbFailureResetDoneBody =>
       'Затвори Divine и го отвори отново — следващото стартиране изгражда нова локална база данни.';
+
+  @override
+  String get authSignInOptionsInfo => 'Относно опциите за вход';
+
+  @override
+  String get authShowPassword => 'Показване на паролата';
+
+  @override
+  String get authHidePassword => 'Скриване на паролата';
 }

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -12459,4 +12459,13 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get dbFailureResetDoneBody =>
       'Schließe Divine und öffne es erneut — der nächste Start legt eine frische lokale Datenbank an.';
+
+  @override
+  String get authSignInOptionsInfo => 'Über Anmeldeoptionen';
+
+  @override
+  String get authShowPassword => 'Passwort anzeigen';
+
+  @override
+  String get authHidePassword => 'Passwort ausblenden';
 }

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -12253,4 +12253,13 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get dbFailureResetDoneBody =>
       'Close Divine and open it again — the next launch builds a fresh local database.';
+
+  @override
+  String get authSignInOptionsInfo => 'About sign-in options';
+
+  @override
+  String get authShowPassword => 'Show password';
+
+  @override
+  String get authHidePassword => 'Hide password';
 }

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -12438,4 +12438,14 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get dbFailureResetDoneBody =>
       'Cerrá Divine y volvé a abrirlo — el próximo inicio crea una base de datos local nueva.';
+
+  @override
+  String get authSignInOptionsInfo =>
+      'Acerca de las opciones de inicio de sesión';
+
+  @override
+  String get authShowPassword => 'Mostrar contraseña';
+
+  @override
+  String get authHidePassword => 'Ocultar contraseña';
 }

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -12424,4 +12424,13 @@ class AppLocalizationsFil extends AppLocalizations {
   @override
   String get dbFailureResetDoneBody =>
       'Isara ang Divine at buksan itong muli — gagawa ng bagong lokal na database sa susunod na paglulunsad.';
+
+  @override
+  String get authSignInOptionsInfo => 'Tungkol sa mga opsyon sa pag-sign in';
+
+  @override
+  String get authShowPassword => 'Ipakita ang password';
+
+  @override
+  String get authHidePassword => 'Itago ang password';
 }

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -12490,4 +12490,13 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get dbFailureResetDoneBody =>
       'Fermez Divine et rouvrez-le — le prochain lancement crée une nouvelle base de données locale.';
+
+  @override
+  String get authSignInOptionsInfo => 'À propos des options de connexion';
+
+  @override
+  String get authShowPassword => 'Afficher le mot de passe';
+
+  @override
+  String get authHidePassword => 'Masquer le mot de passe';
 }

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -12219,4 +12219,13 @@ class AppLocalizationsId extends AppLocalizations {
   @override
   String get dbFailureResetDoneBody =>
       'Tutup Divine lalu buka lagi — peluncuran berikutnya membangun basis data lokal yang baru.';
+
+  @override
+  String get authSignInOptionsInfo => 'Tentang opsi masuk';
+
+  @override
+  String get authShowPassword => 'Tampilkan sandi';
+
+  @override
+  String get authHidePassword => 'Sembunyikan sandi';
 }

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -12451,4 +12451,13 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String get dbFailureResetDoneBody =>
       'Chiudi Divine e riaprilo — al prossimo avvio verrà creato un nuovo database locale.';
+
+  @override
+  String get authSignInOptionsInfo => 'Informazioni sulle opzioni di accesso';
+
+  @override
+  String get authShowPassword => 'Mostra password';
+
+  @override
+  String get authHidePassword => 'Nascondi password';
 }

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -11693,4 +11693,13 @@ class AppLocalizationsJa extends AppLocalizations {
   @override
   String get dbFailureResetDoneBody =>
       'Divine を閉じてもう一度開いてください。次回の起動で新しいローカルデータベースが作成されます。';
+
+  @override
+  String get authSignInOptionsInfo => 'ログイン方法について';
+
+  @override
+  String get authShowPassword => 'パスワードを表示';
+
+  @override
+  String get authHidePassword => 'パスワードを非表示';
 }

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -11718,4 +11718,13 @@ class AppLocalizationsKo extends AppLocalizations {
   @override
   String get dbFailureResetDoneBody =>
       'Divine을 닫았다가 다시 여세요. 다음 실행에서 새 로컬 데이터베이스가 만들어집니다.';
+
+  @override
+  String get authSignInOptionsInfo => '로그인 옵션 정보';
+
+  @override
+  String get authShowPassword => '비밀번호 표시';
+
+  @override
+  String get authHidePassword => '비밀번호 숨기기';
 }

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -12320,4 +12320,13 @@ class AppLocalizationsMs extends AppLocalizations {
   @override
   String get dbFailureResetDoneBody =>
       'Tutup Divine dan buka semula — pelancaran seterusnya membina pangkalan data setempat yang baharu.';
+
+  @override
+  String get authSignInOptionsInfo => 'Tentang pilihan log masuk';
+
+  @override
+  String get authShowPassword => 'Tunjukkan kata laluan';
+
+  @override
+  String get authHidePassword => 'Sembunyikan kata laluan';
 }

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -12366,4 +12366,13 @@ class AppLocalizationsNl extends AppLocalizations {
   @override
   String get dbFailureResetDoneBody =>
       'Sluit Divine en open het opnieuw — bij de volgende start wordt een nieuwe lokale database aangemaakt.';
+
+  @override
+  String get authSignInOptionsInfo => 'Over aanmeldopties';
+
+  @override
+  String get authShowPassword => 'Wachtwoord tonen';
+
+  @override
+  String get authHidePassword => 'Wachtwoord verbergen';
 }

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -12550,4 +12550,13 @@ class AppLocalizationsPl extends AppLocalizations {
   @override
   String get dbFailureResetDoneBody =>
       'Zamknij Divine i otwórz go ponownie — następne uruchomienie utworzy nową lokalną bazę danych.';
+
+  @override
+  String get authSignInOptionsInfo => 'Informacje o opcjach logowania';
+
+  @override
+  String get authShowPassword => 'Pokaż hasło';
+
+  @override
+  String get authHidePassword => 'Ukryj hasło';
 }

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -12398,4 +12398,13 @@ class AppLocalizationsPt extends AppLocalizations {
   @override
   String get dbFailureResetDoneBody =>
       'Feche o Divine e abra de novo — a próxima inicialização cria um banco de dados local novo.';
+
+  @override
+  String get authSignInOptionsInfo => 'Sobre as opções de login';
+
+  @override
+  String get authShowPassword => 'Mostrar senha';
+
+  @override
+  String get authHidePassword => 'Ocultar senha';
 }

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -12558,4 +12558,13 @@ class AppLocalizationsRo extends AppLocalizations {
   @override
   String get dbFailureResetDoneBody =>
       'Închide Divine și deschide-l din nou — următoarea pornire creează o bază de date locală nouă.';
+
+  @override
+  String get authSignInOptionsInfo => 'Despre opțiunile de conectare';
+
+  @override
+  String get authShowPassword => 'Afișați parola';
+
+  @override
+  String get authHidePassword => 'Ascundeți parola';
 }

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -12305,4 +12305,13 @@ class AppLocalizationsSv extends AppLocalizations {
   @override
   String get dbFailureResetDoneBody =>
       'Stäng Divine och öppna det igen — nästa start skapar en ny lokal databas.';
+
+  @override
+  String get authSignInOptionsInfo => 'Om inloggningsalternativ';
+
+  @override
+  String get authShowPassword => 'Visa lösenord';
+
+  @override
+  String get authHidePassword => 'Dölj lösenord';
 }

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -12233,4 +12233,13 @@ class AppLocalizationsTr extends AppLocalizations {
   @override
   String get dbFailureResetDoneBody =>
       'Divine’ı kapatıp yeniden açın — sonraki başlatmada yeni bir yerel veritabanı oluşturulur.';
+
+  @override
+  String get authSignInOptionsInfo => 'Oturum açma seçenekleri hakkında';
+
+  @override
+  String get authShowPassword => 'Şifreyi göster';
+
+  @override
+  String get authHidePassword => 'Şifreyi gizle';
 }

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -12293,4 +12293,13 @@ class AppLocalizationsUr extends AppLocalizations {
   @override
   String get dbFailureResetDoneBody =>
       'Divine بند کریں اور دوبارہ کھولیں — اگلی بار شروع ہونے پر نیا مقامی ڈیٹابیس بنے گا۔';
+
+  @override
+  String get authSignInOptionsInfo => 'سائن ان کے اختیارات کے بارے میں';
+
+  @override
+  String get authShowPassword => 'پاس ورڈ دکھائیں';
+
+  @override
+  String get authHidePassword => 'پاس ورڈ چھپائیں';
 }

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -12257,4 +12257,13 @@ class AppLocalizationsVi extends AppLocalizations {
   @override
   String get dbFailureResetDoneBody =>
       'Đóng Divine rồi mở lại — lần khởi chạy tiếp theo sẽ tạo cơ sở dữ liệu cục bộ mới.';
+
+  @override
+  String get authSignInOptionsInfo => 'Giới thiệu về tùy chọn đăng nhập';
+
+  @override
+  String get authShowPassword => 'Hiện mật khẩu';
+
+  @override
+  String get authHidePassword => 'Ẩn mật khẩu';
 }

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -11587,4 +11587,13 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get dbFailureResetDoneBody => '关闭 Divine 后重新打开 — 下次启动会建立全新的本地数据库。';
+
+  @override
+  String get authSignInOptionsInfo => '关于登录选项';
+
+  @override
+  String get authShowPassword => '显示密码';
+
+  @override
+  String get authHidePassword => '隐藏密码';
 }

--- a/mobile/lib/screens/auth/invite_gate_screen.dart
+++ b/mobile/lib/screens/auth/invite_gate_screen.dart
@@ -264,7 +264,8 @@ class _InviteCodeEntryPage extends StatelessWidget {
                                 child: RoundedIconButton(
                                   onPressed: onBack,
                                   semanticLabel: context.l10n.commonBack,
-                                  semanticIdentifier: 'back_button',
+                                  semanticIdentifier:
+                                      DiVineAppBarLeading.backButtonSemanticId,
                                   icon: DivineIcon(
                                     icon: DivineIconName.caretLeft,
                                     color: context.vineColors.onIconButton,

--- a/mobile/lib/screens/auth/invite_gate_screen.dart
+++ b/mobile/lib/screens/auth/invite_gate_screen.dart
@@ -263,6 +263,8 @@ class _InviteCodeEntryPage extends StatelessWidget {
                                 alignment: AlignmentDirectional.centerStart,
                                 child: RoundedIconButton(
                                   onPressed: onBack,
+                                  semanticLabel: context.l10n.commonBack,
+                                  semanticIdentifier: 'back_button',
                                   icon: DivineIcon(
                                     icon: DivineIconName.caretLeft,
                                     color: context.vineColors.onIconButton,

--- a/mobile/lib/screens/auth/login_options_screen.dart
+++ b/mobile/lib/screens/auth/login_options_screen.dart
@@ -361,6 +361,8 @@ class _SignInContentState extends ConsumerState<_SignInContent> {
                               context,
                               showNip07: isNip07Available,
                             ),
+                      semanticLabel: context.l10n.authSignInOptionsInfo,
+                      semanticIdentifier: 'sign_in_options_info_button',
                       icon: DivineIcon(
                         icon: DivineIconName.info,
                         color: context.vineColors.onIconButton,
@@ -423,6 +425,10 @@ class _SignInContentState extends ConsumerState<_SignInContent> {
                           onSubmitted: isDisabled
                               ? null
                               : (_) => context.read<DivineAuthCubit>().submit(),
+                          showPasswordSemanticLabel:
+                              context.l10n.authShowPassword,
+                          hidePasswordSemanticLabel:
+                              context.l10n.authHidePassword,
                         ),
                       ],
                     ),

--- a/mobile/lib/screens/auth/login_options_screen.dart
+++ b/mobile/lib/screens/auth/login_options_screen.dart
@@ -14,6 +14,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:nostr_sdk/nostr_sdk.dart' show AndroidPlugin;
 import 'package:openvine/blocs/divine_auth/divine_auth_cubit.dart';
+import 'package:openvine/constants/semantic_ids.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/analytics_providers.dart';
 import 'package:openvine/providers/app_providers.dart';
@@ -362,7 +363,8 @@ class _SignInContentState extends ConsumerState<_SignInContent> {
                               showNip07: isNip07Available,
                             ),
                       semanticLabel: context.l10n.authSignInOptionsInfo,
-                      semanticIdentifier: 'sign_in_options_info_button',
+                      semanticIdentifier:
+                          SemanticIds.authSignInOptionsInfoButton,
                       icon: DivineIcon(
                         icon: DivineIconName.info,
                         color: context.vineColors.onIconButton,

--- a/mobile/lib/screens/auth/reset_password.dart
+++ b/mobile/lib/screens/auth/reset_password.dart
@@ -222,6 +222,10 @@ class _ResetPasswordScreenState extends ConsumerState<ResetPasswordScreen> {
                                   }
                                 },
                                 textInputAction: TextInputAction.next,
+                                showPasswordSemanticLabel:
+                                    context.l10n.authShowPassword,
+                                hidePasswordSemanticLabel:
+                                    context.l10n.authHidePassword,
                               ),
                               const SizedBox(height: 16),
                               DivineAuthTextField(
@@ -242,6 +246,10 @@ class _ResetPasswordScreenState extends ConsumerState<ResetPasswordScreen> {
                                 },
                                 textInputAction: TextInputAction.done,
                                 onSubmitted: (_) => _handleSubmit(),
+                                showPasswordSemanticLabel:
+                                    context.l10n.authShowPassword,
+                                hidePasswordSemanticLabel:
+                                    context.l10n.authHidePassword,
                               ),
                             ],
                           ),

--- a/mobile/lib/screens/key_import_screen.dart
+++ b/mobile/lib/screens/key_import_screen.dart
@@ -140,6 +140,10 @@ class _KeyImportScreenState extends ConsumerState<KeyImportScreen> {
                                 setState(() => _passwordError = null);
                               }
                             },
+                            showPasswordSemanticLabel:
+                                context.l10n.authShowPassword,
+                            hidePasswordSemanticLabel:
+                                context.l10n.authHidePassword,
                           ),
                         ],
 

--- a/mobile/lib/screens/key_management/keycast_key_export_card.dart
+++ b/mobile/lib/screens/key_management/keycast_key_export_card.dart
@@ -319,6 +319,8 @@ class _PasswordStep extends StatelessWidget {
             if (!blocked) onSubmit();
           },
           onChanged: (_) => onEdited(),
+          showPasswordSemanticLabel: context.l10n.authShowPassword,
+          hidePasswordSemanticLabel: context.l10n.authHidePassword,
         ),
         Row(
           mainAxisAlignment: MainAxisAlignment.end,

--- a/mobile/lib/screens/settings/account/change_email_screen.dart
+++ b/mobile/lib/screens/settings/account/change_email_screen.dart
@@ -187,6 +187,10 @@ class _Form extends StatelessWidget {
                         textInputAction: TextInputAction.done,
                         onSubmitted: (_) => cubit.submit(),
                         onChanged: cubit.updatePassword,
+                        showPasswordSemanticLabel:
+                            context.l10n.authShowPassword,
+                        hidePasswordSemanticLabel:
+                            context.l10n.authHidePassword,
                       ),
                     ],
                   ),

--- a/mobile/lib/screens/settings/account/change_password_screen.dart
+++ b/mobile/lib/screens/settings/account/change_password_screen.dart
@@ -154,6 +154,10 @@ class _ChangePasswordViewState extends State<ChangePasswordView> {
                                         : null,
                                     textInputAction: TextInputAction.next,
                                     onChanged: cubit.updateCurrentPassword,
+                                    showPasswordSemanticLabel:
+                                        context.l10n.authShowPassword,
+                                    hidePasswordSemanticLabel:
+                                        context.l10n.authHidePassword,
                                   ),
                                   DivineAuthTextField(
                                     controller: _newPasswordController,
@@ -169,6 +173,10 @@ class _ChangePasswordViewState extends State<ChangePasswordView> {
                                     ),
                                     textInputAction: TextInputAction.next,
                                     onChanged: cubit.updateNewPassword,
+                                    showPasswordSemanticLabel:
+                                        context.l10n.authShowPassword,
+                                    hidePasswordSemanticLabel:
+                                        context.l10n.authHidePassword,
                                   ),
                                   DivineAuthTextField(
                                     controller: _confirmPasswordController,
@@ -187,6 +195,10 @@ class _ChangePasswordViewState extends State<ChangePasswordView> {
                                     textInputAction: TextInputAction.done,
                                     onSubmitted: (_) => cubit.submit(),
                                     onChanged: cubit.updateConfirmPassword,
+                                    showPasswordSemanticLabel:
+                                        context.l10n.authShowPassword,
+                                    hidePasswordSemanticLabel:
+                                        context.l10n.authHidePassword,
                                   ),
                                 ],
                               ),

--- a/mobile/lib/widgets/auth/auth_form_scaffold.dart
+++ b/mobile/lib/widgets/auth/auth_form_scaffold.dart
@@ -8,6 +8,7 @@ import 'dart:math';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/widgets/auth_back_button.dart';
 
 /// A shared scaffold layout for authentication form screens.
@@ -184,6 +185,10 @@ class AuthFormScaffold extends StatelessWidget {
                                     errorText: passwordError,
                                     enabled: enabled,
                                     onChanged: onPasswordChanged,
+                                    showPasswordSemanticLabel:
+                                        context.l10n.authShowPassword,
+                                    hidePasswordSemanticLabel:
+                                        context.l10n.authHidePassword,
                                   ),
 
                                   if (confirmPasswordController != null) ...[
@@ -198,6 +203,10 @@ class AuthFormScaffold extends StatelessWidget {
                                       errorText: confirmPasswordError,
                                       enabled: enabled,
                                       onChanged: onConfirmPasswordChanged,
+                                      showPasswordSemanticLabel:
+                                          context.l10n.authShowPassword,
+                                      hidePasswordSemanticLabel:
+                                          context.l10n.authHidePassword,
                                     ),
                                   ],
                                 ],

--- a/mobile/lib/widgets/auth_back_button.dart
+++ b/mobile/lib/widgets/auth_back_button.dart
@@ -42,7 +42,7 @@ class AuthBackButton extends StatelessWidget {
       semanticLabel: context.l10n.commonBack,
       // Matches DiVineAppBarLeading.backButtonSemanticId so E2E flows can
       // address either back control by the same identifier.
-      semanticIdentifier: 'back_button',
+      semanticIdentifier: DiVineAppBarLeading.backButtonSemanticId,
       icon: DivineIcon(
         icon: DivineIconName.caretLeft,
         color: context.vineColors.onIconButton,

--- a/mobile/lib/widgets/auth_back_button.dart
+++ b/mobile/lib/widgets/auth_back_button.dart
@@ -4,6 +4,7 @@
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/widgets/rounded_icon_button.dart';
 
 /// A green rounded-square back button used in authentication flow screens.
@@ -38,6 +39,10 @@ class AuthBackButton extends StatelessWidget {
   Widget build(BuildContext context) {
     return RoundedIconButton(
       onPressed: !enabled ? null : onPressed ?? () => _handleBackTap(context),
+      semanticLabel: context.l10n.commonBack,
+      // Matches DiVineAppBarLeading.backButtonSemanticId so E2E flows can
+      // address either back control by the same identifier.
+      semanticIdentifier: 'back_button',
       icon: DivineIcon(
         icon: DivineIconName.caretLeft,
         color: context.vineColors.onIconButton,

--- a/mobile/lib/widgets/rounded_icon_button.dart
+++ b/mobile/lib/widgets/rounded_icon_button.dart
@@ -15,6 +15,7 @@ import 'package:flutter/material.dart';
 /// ```dart
 /// RoundedIconButton(
 ///   onPressed: () => context.pop(),
+///   semanticLabel: context.l10n.commonBack,
 ///   icon: Icon(Icons.chevron_left, color: VineTheme.vineGreenLight, size: 28),
 /// )
 /// ```
@@ -23,6 +24,8 @@ class RoundedIconButton extends StatelessWidget {
   const RoundedIconButton({
     required this.onPressed,
     required this.icon,
+    required this.semanticLabel,
+    this.semanticIdentifier,
     super.key,
   });
 
@@ -33,32 +36,50 @@ class RoundedIconButton extends StatelessWidget {
   /// The icon to display inside the button.
   final Widget icon;
 
+  /// Screen-reader label describing the action.
+  ///
+  /// Required: the icon alone carries no meaning, so a missing label leaves
+  /// the button announced as nothing at all. Pass a localized string.
+  final String semanticLabel;
+
+  /// Stable `Semantics(identifier:)` value used as a UI-test anchor.
+  final String? semanticIdentifier;
+
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: onPressed,
-      child: Container(
-        height: 48,
-        width: 48,
-        padding: const EdgeInsets.all(8),
-        decoration: BoxDecoration(
-          color: context.vineColors.surfaceContainer,
-          borderRadius: BorderRadius.circular(16),
-          border: Border.all(color: context.vineColors.outlineMuted, width: 2),
-          boxShadow: const [
-            BoxShadow(
-              color: VineTheme.innerShadow,
-              blurRadius: 0.6,
-              offset: Offset(0.4, 0.4),
+    return Semantics(
+      label: semanticLabel,
+      identifier: semanticIdentifier,
+      button: true,
+      enabled: onPressed != null,
+      child: GestureDetector(
+        onTap: onPressed,
+        child: Container(
+          height: 48,
+          width: 48,
+          padding: const EdgeInsets.all(8),
+          decoration: BoxDecoration(
+            color: context.vineColors.surfaceContainer,
+            borderRadius: BorderRadius.circular(16),
+            border: Border.all(
+              color: context.vineColors.outlineMuted,
+              width: 2,
             ),
-            BoxShadow(
-              color: VineTheme.innerShadow,
-              blurRadius: 1,
-              offset: Offset(1, 1),
-            ),
-          ],
+            boxShadow: const [
+              BoxShadow(
+                color: VineTheme.innerShadow,
+                blurRadius: 0.6,
+                offset: Offset(0.4, 0.4),
+              ),
+              BoxShadow(
+                color: VineTheme.innerShadow,
+                blurRadius: 1,
+                offset: Offset(1, 1),
+              ),
+            ],
+          ),
+          child: icon,
         ),
-        child: icon,
       ),
     );
   }

--- a/mobile/lib/widgets/rounded_icon_button.dart
+++ b/mobile/lib/widgets/rounded_icon_button.dart
@@ -16,7 +16,10 @@ import 'package:flutter/material.dart';
 /// RoundedIconButton(
 ///   onPressed: () => context.pop(),
 ///   semanticLabel: context.l10n.commonBack,
-///   icon: Icon(Icons.chevron_left, color: VineTheme.vineGreenLight, size: 28),
+///   icon: DivineIcon(
+///     icon: DivineIconName.caretLeft,
+///     color: context.vineColors.onIconButton,
+///   ),
 /// )
 /// ```
 class RoundedIconButton extends StatelessWidget {

--- a/mobile/test/widgets/rounded_icon_button_test.dart
+++ b/mobile/test/widgets/rounded_icon_button_test.dart
@@ -3,6 +3,7 @@
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/widgets/rounded_icon_button.dart';
@@ -12,13 +13,20 @@ void main() {
     Widget createTestWidget({
       VoidCallback? onPressed,
       Widget icon = const Icon(Icons.chevron_left),
+      String semanticLabel = 'Back',
+      String? semanticIdentifier,
     }) {
       return MaterialApp(
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
         theme: VineTheme.theme,
         home: Scaffold(
-          body: RoundedIconButton(onPressed: onPressed, icon: icon),
+          body: RoundedIconButton(
+            onPressed: onPressed,
+            icon: icon,
+            semanticLabel: semanticLabel,
+            semanticIdentifier: semanticIdentifier,
+          ),
         ),
       );
     }
@@ -67,6 +75,51 @@ void main() {
         // Should not throw when tapped with null onPressed
         await tester.tap(find.byType(GestureDetector));
         await tester.pump();
+      });
+    });
+
+    group('accessibility', () {
+      // The button was a bare GestureDetector for its whole life, so every
+      // auth-screen control it powers announced nothing at all. Observed on
+      // device before the fix: the back control appeared in the semantics
+      // tree as `actions: tap, flags: isImage` with no label.
+      testWidgets('announces its label as a button', (tester) async {
+        final handle = tester.ensureSemantics();
+        await tester.pumpWidget(
+          createTestWidget(onPressed: () {}, semanticLabel: 'Atrás'),
+        );
+
+        final node = tester.getSemantics(find.byType(RoundedIconButton));
+        expect(node.label, equals('Atrás'));
+        expect(node.flagsCollection.isButton, isTrue);
+        handle.dispose();
+      });
+
+      testWidgets('exposes the identifier as a test anchor', (tester) async {
+        final handle = tester.ensureSemantics();
+        await tester.pumpWidget(
+          createTestWidget(
+            onPressed: () {},
+            semanticIdentifier: 'back_button',
+          ),
+        );
+
+        expect(find.bySemanticsIdentifier('back_button'), findsOneWidget);
+        handle.dispose();
+      });
+
+      testWidgets('offers no tap action when onPressed is null', (
+        tester,
+      ) async {
+        final handle = tester.ensureSemantics();
+        await tester.pumpWidget(createTestWidget());
+
+        final node = tester.getSemantics(find.byType(RoundedIconButton));
+        expect(
+          node.getSemanticsData().hasAction(SemanticsAction.tap),
+          isFalse,
+        );
+        handle.dispose();
       });
     });
   });

--- a/mobile/test/widgets/rounded_icon_button_test.dart
+++ b/mobile/test/widgets/rounded_icon_button_test.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Tests for RoundedIconButton widget
 // ABOUTME: Verifies icon rendering, tap callback, and null onPressed
 
+import 'dart:ui' show Tristate;
+
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/semantics.dart';
@@ -92,6 +94,7 @@ void main() {
         final node = tester.getSemantics(find.byType(RoundedIconButton));
         expect(node.label, equals('Atrás'));
         expect(node.flagsCollection.isButton, isTrue);
+        expect(node.flagsCollection.isEnabled, Tristate.isTrue);
         handle.dispose();
       });
 
@@ -119,6 +122,7 @@ void main() {
           node.getSemanticsData().hasAction(SemanticsAction.tap),
           isFalse,
         );
+        expect(node.flagsCollection.isEnabled, Tristate.isFalse);
         handle.dispose();
       });
     });

--- a/mobile/test/widgets/rounded_icon_button_test.dart
+++ b/mobile/test/widgets/rounded_icon_button_test.dart
@@ -1,5 +1,5 @@
 // ABOUTME: Tests for RoundedIconButton widget
-// ABOUTME: Verifies icon rendering, tap callback, and null onPressed
+// ABOUTME: Verifies icon rendering, tap callback, null onPressed, and semantics
 
 import 'dart:ui' show Tristate;
 


### PR DESCRIPTION
Closes #7762

Two a11y/l10n defects in the auth flow, both found by **running the app** on an iOS simulator set to Spanish and dumping the live `SemanticsNode` tree over the Dart VM Service — not by reading code. They are the same defect class as #7708 (a hardcoded English default in a shared widget that no call site overrides), which is what sent me looking.

## 1. The auth back button announced nothing at all

`RoundedIconButton` was a bare `GestureDetector` + `Container` + icon, with **no `Semantics` anywhere**. Its own docstring says it is "used for auth screen navigation buttons (back, info, switch account)".

What the running app exposed on the sign-in and import-key screens:

```
SemanticsNode#42
  Rect.fromLTRB(24.0, 8.0, 72.0, 56.0)
  actions: tap
  flags: isImage
        <- no label, no identifier, no button flag
```

Tapping that node navigates back, so it is a real control — one a screen-reader user cannot find or identify. It is the back button on **all 7 auth screens** (`key_import`, `create_account`, `login_options`, `nostr_connect`, `invite_gate`, `reset_password`, `secure_account`, the last two via `AuthFormScaffold`), plus the invite-gate back button and the sign-in-options info button.

`accessibility.md` lists this exact shape under **Must Fix** — "`GestureDetector` or `InkWell` without `Semantics` wrapper".

`semanticLabel` is **required**, not optional, so the next call site cannot reintroduce the gap. There are only 3 construction sites, so the API change is contained. The back controls reuse the already-translated `commonBack` and adopt the same `back_button` identifier `DiVineAppBarLeading` uses, so an E2E flow can address either back control the same way.

## 2. "Show password" shipped in English to 21 locales

`DivineAuthTextField` defaults `showPasswordSemanticLabel` / `hidePasswordSemanticLabel` to the hardcoded English `'Show password'` / `'Hide password'`, and **not one of the 11 obscured call sites** overrode them.

Observed live — the Spanish sign-in screen, every other string translated:

```
label: "Iniciar sesión"
label: "Email"
label: "Contraseña"
label: "Show password"     <- English
label: "¿Olvidaste tu contraseña?"
```

Unlike #7708's back button, there is no `MaterialLocalizations` string to borrow — it has no password vocabulary — so this needs real keys. `authShowPassword` / `authHidePassword` are translated into **all 21** non-English locales and wired at every obscured field. `authSignInOptionsInfo` labels the sign-in-options info button, the third `RoundedIconButton` site.

## Verification

- 3 new `RoundedIconButton` a11y tests, each confirmed to **fail** when the `Semantics` wrapper is mutated away — not assumed
- `flutter analyze lib test integration_test` → **No issues found**
- `dart format --set-exit-if-changed lib test` → clean
- Affected suites (auth screens, account settings, key import, l10n consistency, the widget itself) → **138 passed, 0 failed**
- 3 new keys present and genuinely translated in all 22 locales; the untranslated-key set is unchanged, so this adds zero l10n debt

## Known limit, not fixed here

`DivineAuthTextField`'s English defaults still exist in `divine_ui`. With all 11 call sites now passing localized labels they are unreachable in production, but call site #12 can forget them again. Making them required would be an API break on a package whose stated contract is "widgets accept string params with English defaults" (`localization.md`), so this follows that contract rather than breaking it — the same choice #7708 made for `leadingActionSemanticLabel`. `RoundedIconButton` could take the stricter route precisely because it is app-layer, not `divine_ui`.

Not verified: I did not run the Maestro suite, and the fix is verified on the iOS Simulator only.