### PR TITLE
fix(c2pa): remove stale signing debris

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -99,6 +99,7 @@ import 'package:openvine/services/app_engagement_store.dart';
 import 'package:openvine/services/back_button_handler.dart';
 import 'package:openvine/services/bandwidth_tracker_service.dart';
 import 'package:openvine/services/build_provenance_service.dart';
+import 'package:openvine/services/c2pa_debris_janitor.dart';
 import 'package:openvine/services/c2pa_signing_service.dart';
 import 'package:openvine/services/collaborator_invite_service.dart';
 import 'package:openvine/services/corrupted_video_repair_service.dart';
@@ -147,6 +148,7 @@ import 'package:openvine/widgets/geo_blocking_gate.dart';
 import 'package:openvine/widgets/upload_failure_sheet.dart';
 import 'package:openvine/widgets/vine_cached_image.dart';
 import 'package:package_info_plus/package_info_plus.dart';
+import 'package:path_provider/path_provider.dart';
 import 'package:permissions_service/permissions_service.dart';
 import 'package:pro_image_editor/pro_image_editor.dart'
     show LayerRasterizerHost;
@@ -778,6 +780,13 @@ StartupCoordinator _createStartupCoordinator(ProviderContainer container) {
   );
 
   if (!kIsWeb) {
+    coordinator.registerService(
+      name: 'C2paDebrisSweep',
+      phase: StartupPhase.deferred,
+      initialize: _sweepC2paDebris,
+      optional: true,
+    );
+
     coordinator.registerService(
       name: 'SeedMediaPreload',
       phase: StartupPhase.deferred,
@@ -1684,6 +1693,14 @@ Future<void> _initializeVideoCacheManifest() async {
       }
     },
   );
+}
+
+Future<void> _sweepC2paDebris() async {
+  final directories = await Future.wait([
+    getApplicationDocumentsDirectory(),
+    getTemporaryDirectory(),
+  ]);
+  directories.forEach(C2paDebrisJanitor.deleteStaleDebris);
 }
 
 Future<void> _initializeSeedDataPreload(ProviderContainer container) async {

--- a/mobile/lib/services/c2pa_debris_janitor.dart
+++ b/mobile/lib/services/c2pa_debris_janitor.dart
@@ -49,7 +49,7 @@ abstract final class C2paDebrisJanitor {
           );
         }
       }
-    } on Object {
+    } on Object catch (error, stackTrace) {
       // Best-effort; a listing failure must not block startup, but a janitor
       // that can never list its directory should be visible in logs rather
       // than indistinguishable from a clean device.
@@ -57,6 +57,8 @@ abstract final class C2paDebrisJanitor {
         'Could not list ${directory.path} while sweeping C2PA signing debris',
         name: 'C2paDebrisJanitor',
         category: LogCategory.video,
+        error: error,
+        stackTrace: stackTrace,
       );
     }
 

--- a/mobile/lib/services/c2pa_debris_janitor.dart
+++ b/mobile/lib/services/c2pa_debris_janitor.dart
@@ -1,0 +1,60 @@
+// ABOUTME: Removes stale empty files left by legacy failed C2PA signing.
+// ABOUTME: Protects recordings, valid derived media, and fresh signing output.
+
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:unified_logger/unified_logger.dart';
+
+/// Best-effort cleanup for abandoned C2PA signing destinations.
+abstract final class C2paDebrisJanitor {
+  /// Files newer than this may still belong to an active signing operation.
+  static const staleDebrisAge = Duration(hours: 1);
+
+  static final RegExp _debrisName = RegExp(r'^c2pa_signed_[0-9]+\.mp4$');
+
+  /// Deletes stale, empty signing destinations directly inside [directory].
+  ///
+  /// This is intentionally non-recursive and best-effort: inaccessible files
+  /// are retried on a later launch, and filesystem failures never reach the
+  /// startup coordinator.
+  static void deleteStaleDebris(
+    Directory directory, {
+    DateTime? now,
+    Duration staleAge = staleDebrisAge,
+  }) {
+    final cutoff = (now ?? DateTime.now()).subtract(staleAge);
+    var deletedCount = 0;
+
+    try {
+      for (final entity in directory.listSync(followLinks: false)) {
+        if (entity is! File) continue;
+        if (!_debrisName.hasMatch(p.basename(entity.path))) continue;
+
+        try {
+          final stat = entity.statSync();
+          if (stat.type != FileSystemEntityType.file || stat.size != 0) {
+            continue;
+          }
+          if (!stat.modified.isBefore(cutoff)) continue;
+
+          entity.deleteSync();
+          deletedCount++;
+        } on Object {
+          // Best-effort; a file we cannot delete is retried next launch.
+        }
+      }
+    } on Object {
+      // Best-effort; a listing failure must not block startup.
+    }
+
+    if (deletedCount > 0) {
+      Log.info(
+        'Removed $deletedCount stale C2PA signing file(s) from '
+        '${directory.path}',
+        name: 'C2paDebrisJanitor',
+        category: LogCategory.video,
+      );
+    }
+  }
+}

--- a/mobile/lib/services/c2pa_debris_janitor.dart
+++ b/mobile/lib/services/c2pa_debris_janitor.dart
@@ -42,10 +42,22 @@ abstract final class C2paDebrisJanitor {
           deletedCount++;
         } on Object {
           // Best-effort; a file we cannot delete is retried next launch.
+          Log.debug(
+            'Could not remove C2PA signing debris at ${entity.path}',
+            name: 'C2paDebrisJanitor',
+            category: LogCategory.video,
+          );
         }
       }
     } on Object {
-      // Best-effort; a listing failure must not block startup.
+      // Best-effort; a listing failure must not block startup, but a janitor
+      // that can never list its directory should be visible in logs rather
+      // than indistinguishable from a clean device.
+      Log.warning(
+        'Could not list ${directory.path} while sweeping C2PA signing debris',
+        name: 'C2paDebrisJanitor',
+        category: LogCategory.video,
+      );
     }
 
     if (deletedCount > 0) {

--- a/mobile/test/services/c2pa_debris_janitor_test.dart
+++ b/mobile/test/services/c2pa_debris_janitor_test.dart
@@ -58,25 +58,30 @@ void main() {
     test('preserves recordings and other derived media', () {
       final protected =
           [
-            'VID_20260814_113531.mp4',
-            'VID_1786700133469.mp4',
-            'trimmed_1.mp4',
-            'merged_1.mp4',
-            'watermarked_1.mp4',
-            'normalized_1.mp4',
-            '1786964993571.mp4',
-            'C2PA_SIGNED_1.mp4',
-            'c2pa_signed.mp4',
-            'c2pa_signed_abc.mp4',
-            'pre_c2pa_signed_1.mp4',
-            'c2pa_signed_1.mov',
-          ].map(
-            (name) => writeFile(
-              name,
-              age:
-                  C2paDebrisJanitor.staleDebrisAge + const Duration(seconds: 1),
-            ),
-          );
+                'VID_20260814_113531.mp4',
+                'VID_1786700133469.mp4',
+                'trimmed_1.mp4',
+                'merged_1.mp4',
+                'watermarked_1.mp4',
+                'normalized_1.mp4',
+                '1786964993571.mp4',
+                'C2PA_SIGNED_1.mp4',
+                'c2pa_signed.mp4',
+                'c2pa_signed_abc.mp4',
+                'pre_c2pa_signed_1.mp4',
+                'c2pa_signed_1.mov',
+                'c2pa_signed_1786964993575.mp4.tmp',
+                'c2pa_signed_1786964993576.mp4.bak',
+              ]
+              .map(
+                (name) => writeFile(
+                  name,
+                  age:
+                      C2paDebrisJanitor.staleDebrisAge +
+                      const Duration(seconds: 1),
+                ),
+              )
+              .toList();
       final matchingDirectory = Directory(
         p.join(tempDir.path, 'c2pa_signed_2.mp4'),
       )..createSync();

--- a/mobile/test/services/c2pa_debris_janitor_test.dart
+++ b/mobile/test/services/c2pa_debris_janitor_test.dart
@@ -1,0 +1,127 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/services/c2pa_debris_janitor.dart';
+import 'package:path/path.dart' as p;
+
+void main() {
+  group(C2paDebrisJanitor, () {
+    late Directory tempDir;
+    late DateTime now;
+
+    setUp(() {
+      tempDir = Directory.systemTemp.createTempSync('c2pa_debris_janitor_');
+      now = DateTime(2026, 8, 18, 12);
+    });
+
+    tearDown(() {
+      if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+    });
+
+    File writeFile(
+      String name, {
+      required Duration age,
+      List<int> bytes = const [],
+    }) {
+      final file = File(p.join(tempDir.path, name))..writeAsBytesSync(bytes);
+      file.setLastModifiedSync(now.subtract(age));
+      return file;
+    }
+
+    test('deletes only empty C2PA output older than the cutoff', () {
+      final stale = writeFile(
+        'c2pa_signed_1786964993571.mp4',
+        age: C2paDebrisJanitor.staleDebrisAge + const Duration(seconds: 1),
+      );
+      final atCutoff = writeFile(
+        'c2pa_signed_1786964993572.mp4',
+        age: C2paDebrisJanitor.staleDebrisAge,
+      );
+      final fresh = writeFile(
+        'c2pa_signed_1786964993573.mp4',
+        age: C2paDebrisJanitor.staleDebrisAge - const Duration(seconds: 1),
+      );
+      final nonEmpty = writeFile(
+        'c2pa_signed_1786964993574.mp4',
+        age: C2paDebrisJanitor.staleDebrisAge + const Duration(seconds: 1),
+        bytes: const [1],
+      );
+
+      C2paDebrisJanitor.deleteStaleDebris(tempDir, now: now);
+
+      expect(stale.existsSync(), isFalse);
+      expect(atCutoff.existsSync(), isTrue);
+      expect(fresh.existsSync(), isTrue);
+      expect(nonEmpty.existsSync(), isTrue);
+    });
+
+    test('preserves recordings and other derived media', () {
+      final protected =
+          [
+            'VID_20260814_113531.mp4',
+            'VID_1786700133469.mp4',
+            'trimmed_1.mp4',
+            'merged_1.mp4',
+            'watermarked_1.mp4',
+            'normalized_1.mp4',
+            '1786964993571.mp4',
+            'C2PA_SIGNED_1.mp4',
+            'c2pa_signed.mp4',
+            'c2pa_signed_abc.mp4',
+            'pre_c2pa_signed_1.mp4',
+            'c2pa_signed_1.mov',
+          ].map(
+            (name) => writeFile(
+              name,
+              age:
+                  C2paDebrisJanitor.staleDebrisAge + const Duration(seconds: 1),
+            ),
+          );
+      final matchingDirectory = Directory(
+        p.join(tempDir.path, 'c2pa_signed_2.mp4'),
+      )..createSync();
+
+      C2paDebrisJanitor.deleteStaleDebris(tempDir, now: now);
+
+      for (final file in protected) {
+        expect(file.existsSync(), isTrue, reason: p.basename(file.path));
+      }
+      expect(matchingDirectory.existsSync(), isTrue);
+    });
+
+    test('does not recurse into subdirectories', () {
+      final nestedDirectory = Directory(p.join(tempDir.path, 'nested'))
+        ..createSync();
+      final nested = File(
+        p.join(nestedDirectory.path, 'c2pa_signed_1786964993571.mp4'),
+      )..writeAsBytesSync(const []);
+      nested.setLastModifiedSync(
+        now.subtract(
+          C2paDebrisJanitor.staleDebrisAge + const Duration(seconds: 1),
+        ),
+      );
+
+      C2paDebrisJanitor.deleteStaleDebris(tempDir, now: now);
+
+      expect(nested.existsSync(), isTrue);
+    });
+
+    test('missing and invalid directories do not throw', () {
+      final missing = Directory(p.join(tempDir.path, 'missing'));
+      final regularFile = File(p.join(tempDir.path, 'not_a_directory'))
+        ..writeAsBytesSync(const []);
+
+      expect(
+        () => C2paDebrisJanitor.deleteStaleDebris(missing, now: now),
+        returnsNormally,
+      );
+      expect(
+        () => C2paDebrisJanitor.deleteStaleDebris(
+          Directory(regularFile.path),
+          now: now,
+        ),
+        returnsNormally,
+      );
+    });
+  });
+}

--- a/mobile/test/services/c2pa_debris_janitor_test.dart
+++ b/mobile/test/services/c2pa_debris_janitor_test.dart
@@ -111,6 +111,20 @@ void main() {
       expect(nested.existsSync(), isTrue);
     });
 
+    test('does not follow or delete symlinked debris', () {
+      final target = writeFile(
+        'link_target.bin',
+        age: C2paDebrisJanitor.staleDebrisAge + const Duration(seconds: 1),
+      );
+      final link = Link(p.join(tempDir.path, 'c2pa_signed_1786964993571.mp4'))
+        ..createSync(target.path);
+
+      C2paDebrisJanitor.deleteStaleDebris(tempDir, now: now);
+
+      expect(link.existsSync(), isTrue);
+      expect(target.existsSync(), isTrue);
+    });
+
     test('missing and invalid directories do not throw', () {
       final missing = Directory(p.join(tempDir.path, 'missing'));
       final regularFile = File(p.join(tempDir.path, 'not_a_directory'))

--- a/mobile/test/services/clip_recovery_service_test.dart
+++ b/mobile/test/services/clip_recovery_service_test.dart
@@ -312,7 +312,7 @@ void main() {
         writeVideo('VID_1755400000000.mp4.work.mp4');
         writeVideo('merged_1755400000000.mp4');
         writeVideo('watermarked_1755400000000.mp4');
-        writeVideo('c2pa_signed_1755400000000.mp4', bytes: 0);
+        writeVideo('c2pa_signed_1755400000000.mp4');
         writeVideo('clip_1755400000000_0_reversed.mp4');
         writeVideo('trimmed_1755400000000.mp4');
         writeVideo('1755400000000.mp4');

--- a/mobile/test/services/clip_recovery_service_test.dart
+++ b/mobile/test/services/clip_recovery_service_test.dart
@@ -312,7 +312,7 @@ void main() {
         writeVideo('VID_1755400000000.mp4.work.mp4');
         writeVideo('merged_1755400000000.mp4');
         writeVideo('watermarked_1755400000000.mp4');
-        writeVideo('c2pa_signed_1755400000000.mp4');
+        writeVideo('c2pa_signed_1755400000000.mp4', bytes: 0);
         writeVideo('clip_1755400000000_0_reversed.mp4');
         writeVideo('trimmed_1755400000000.mp4');
         writeVideo('1755400000000.mp4');

--- a/mobile/test/startup/main_startup_registration_test.dart
+++ b/mobile/test/startup/main_startup_registration_test.dart
@@ -67,4 +67,17 @@ void main() {
       isEmpty,
     );
   });
+
+  test('runs C2PA debris cleanup as optional deferred startup work', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    final coordinator = app.createStartupCoordinatorForTesting(container);
+    final registration = coordinator.serviceRegistrationForTesting(
+      'C2paDebrisSweep',
+    );
+
+    expect(registration?.phase, StartupPhase.deferred);
+    expect(registration?.optional, isTrue);
+  });
 }


### PR DESCRIPTION
## Summary

- add a best-effort janitor for legacy empty `c2pa_signed_<timestamp>.mp4` files
- sweep application documents and temporary directories during optional deferred startup
- preserve fresh signing destinations, non-empty media, recordings, near-miss names, directories, and nested files
- keep clip recovery's derived-media exclusion covered

## Safety

Cleanup is non-recursive and matches only the exact, case-sensitive generated filename family. A file must also be empty and strictly older than the one-hour cutoff, so current signing destinations remain protected. Filesystem failures are retried on a later launch and never block startup.

## Verification

- `flutter test test/services/c2pa_debris_janitor_test.dart test/services/clip_recovery_service_test.dart test/startup/main_startup_registration_test.dart`
- `flutter analyze`
- `bash scripts/check_untested_services_floor.sh`
- `.codex/scripts/test-config.sh`
- pre-push analyzer and changed-file tests

Closes #7760