### PR TITLE
docs(profile): trim _SessionExpiredPromptTrigger class documentation

### DIFF
--- a/mobile/lib/widgets/profile/profile_header_widget.dart
+++ b/mobile/lib/widgets/profile/profile_header_widget.dart
@@ -543,19 +543,12 @@ class _ProfileHeaderWidgetState extends ConsumerState<ProfileHeaderWidget> {
   }
 }
 
-/// Presents the session-expired prompt from condition edges without stacking.
+/// Triggers session-expired prompt on condition edges, preventing stacks.
 ///
-/// The prompt is a route, and its condition stays true for as long as the
-/// session is expired. Owning the trigger here reduces that repeated signal to
-/// an edge: [initState] covers a header that mounts already expired, and
-/// [didUpdateWidget] ignores rebuilds that merely re-report true (#7308).
-///
-/// The edge alone is not enough to rule out stacking, because one term of the
-/// condition flickers without the session changing: `isRpcUpgradeInProgress`
-/// goes true then false on every app resume while the session is expired
-/// (`AuthService._refreshOAuthTokenOnResume`). That is a real `false -> true`
-/// edge arriving while the first sheet is still on screen, so a presentation
-/// that has not been closed yet also suppresses the next one.
+/// Converts the always-true expiry condition to an edge signal via [initState]
+/// and [didUpdateWidget] (#7308). Guards against flickers in
+/// `isRpcUpgradeInProgress` with an `_isPresenting` flag — when a true edge
+/// arrives while a sheet is open, the pending presentation suppresses the next.
 class _SessionExpiredPromptTrigger extends StatefulWidget {
   const _SessionExpiredPromptTrigger({
     required this.shouldPrompt,

--- a/mobile/lib/widgets/profile/profile_header_widget.dart
+++ b/mobile/lib/widgets/profile/profile_header_widget.dart
@@ -543,12 +543,16 @@ class _ProfileHeaderWidgetState extends ConsumerState<ProfileHeaderWidget> {
   }
 }
 
-/// Triggers session-expired prompt on condition edges, preventing stacks.
+/// Presents the session-expired prompt on condition edges, without stacking.
 ///
-/// Converts the always-true expiry condition to an edge signal via [initState]
-/// and [didUpdateWidget] (#7308). Guards against flickers in
-/// `isRpcUpgradeInProgress` with an `_isPresenting` flag — when a true edge
-/// arrives while a sheet is open, the pending presentation suppresses the next.
+/// The condition stays true while the session is expired, so this reduces it
+/// to an edge: [initState] covers a header that mounts already expired,
+/// [didUpdateWidget] ignores rebuilds that merely re-report true (#7308).
+/// Edges alone are not enough — `isRpcUpgradeInProgress` flickers true then
+/// false on every app resume while expired, from
+/// `AuthService._refreshOAuthTokenOnResume`. That `false -> true` edge can
+/// arrive while the first sheet is open, so `_isPresenting` also suppresses a
+/// prompt whose predecessor has not closed.
 class _SessionExpiredPromptTrigger extends StatefulWidget {
   const _SessionExpiredPromptTrigger({
     required this.shouldPrompt,


### PR DESCRIPTION
Closes #7780

## Summary

Condense the `_SessionExpiredPromptTrigger` class documentation from 13 lines to 10, keeping every fact the comment exists to record.

`code_style.md` asks for short comments but explicitly exempts explanations of non-obvious causes. The two facts that qualify here are kept verbatim in substance: that `isRpcUpgradeInProgress` flickers true-then-false on **every app resume** while the session is expired, and that `AuthService._refreshOAuthTokenOnResume` is where that flicker originates. Without those, "guards against flickers" is not rediscoverable from the code.

## Changed files

- `mobile/lib/widgets/profile/profile_header_widget.dart` — `_SessionExpiredPromptTrigger` class doc: 13 lines to 10

## Verification

- `dart format` and `flutter analyze` clean on the changed file
- Pre-push hook ran `profile_header_widget` tests — 86 passing
- Comment-only change; no behavior touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)