### PR TITLE
ci(shorebird): reject patches that do not match their store release

### DIFF
--- a/.github/scripts/tests/test_codemagic_shorebird_config.py
+++ b/.github/scripts/tests/test_codemagic_shorebird_config.py
@@ -13,14 +13,30 @@ WORKFLOWS_PATH = Path(__file__).resolve().parents[2] / "workflows"
 SHOREBIRD_DOC_PATH = (
     Path(__file__).resolve().parents[3] / "mobile" / "docs" / "SHOREBIRD_CODE_PUSH.md"
 )
+PROVENANCE_STORE_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "mobile"
+    / "scripts"
+    / "shorebird_provenance_store.sh"
+)
+CAPTION_GENERATOR_GRADLE_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "mobile"
+    / "packages"
+    / "caption_generator"
+    / "android"
+    / "build.gradle.kts"
+)
 
 
-class CodemagicAndroidBuildNumberTest(unittest.TestCase):
+class CodemagicShorebirdConfigTest(unittest.TestCase):
     def setUp(self) -> None:
         self.contents = CODEMAGIC_PATH.read_text()
         self.mobile_ci_contents = MOBILE_CI_PATH.read_text()
         self.mise_contents = MISE_PATH.read_text()
         self.shorebird_doc_contents = SHOREBIRD_DOC_PATH.read_text()
+        self.provenance_store_contents = PROVENANCE_STORE_PATH.read_text()
+        self.caption_generator_gradle_contents = CAPTION_GENERATOR_GRADLE_PATH.read_text()
 
     def test_codemagic_yaml_parses_with_aliases(self) -> None:
         result = subprocess.run(
@@ -72,12 +88,29 @@ class CodemagicAndroidBuildNumberTest(unittest.TestCase):
 
     def test_shorebird_install_reuses_only_the_expected_cached_version(self) -> None:
         self.assertIn('EXPECTED_SHOREBIRD_VERSION="Shorebird 1.6.117"', self.contents)
+        self.assertIn(
+            'EXPECTED_SHOREBIRD_REVISION="45facdd4e4b3c39e0d260107977584f0b7c66bec"',
+            self.contents,
+        )
         self.assertIn('if [ -x "$SHOREBIRD_BIN" ]; then', self.contents)
-        self.assertIn("bash -s -- --force", self.contents)
+        self.assertIn('git -C "$HOME/.shorebird" rev-parse HEAD', self.contents)
         self.assertRegex(
             self.contents,
             r"(?s)&shorebird_install.*?script: \|\n\s+set -euo pipefail\n",
         )
+
+    def test_shorebird_installer_and_cli_are_pinned_to_full_commits(self) -> None:
+        installer_url = re.search(r'INSTALLER_URL="([^"]+)"', self.contents)
+        self.assertIsNotNone(installer_url)
+        self.assertRegex(installer_url.group(1), r"/install/[0-9a-f]{40}/install\.sh$")
+        self.assertNotIn("/main/", installer_url.group(1))
+        self.assertRegex(
+            self.contents,
+            r'EXPECTED_SHOREBIRD_REVISION="[0-9a-f]{40}"',
+        )
+        self.assertIn("shasum -a 256 -c -", self.contents)
+        self.assertIn('checkout --quiet --detach FETCH_HEAD', self.contents)
+        self.assertNotIn("curl -sSf | bash", self.contents)
 
     def test_shorebird_release_commands_are_signed_and_preflighted(self) -> None:
         self.assertIn("*preflight_shorebird_ios_release", self.contents)
@@ -150,12 +183,41 @@ class CodemagicAndroidBuildNumberTest(unittest.TestCase):
         self.assertIn("--private-key-path=build/shorebird/patch_private_key.pem", self.contents)
         self.assertNotIn("--track=stable", self.contents)
 
-    def test_shorebird_patch_workflows_gate_branch_and_release_commit(self) -> None:
+    def test_shorebird_patch_workflows_use_private_provenance(self) -> None:
         self.assertIn('if [ "$CM_BRANCH" != "main" ]; then', self.contents)
         self.assertIn("RELEASE_COMMIT:", self.contents)
-        self.assertIn("git merge-base --is-ancestor", self.contents)
+        self.assertIn("*fetch_and_verify_shorebird_provenance", self.contents)
+        self.assertIn("shorebird_provenance_store.sh fetch", self.contents)
+        self.assertIn("shorebird_provenance.rb verify", self.contents)
         self.assertIn("git diff --name-only", self.contents)
         self.assertIn("*prepare_patch_source", self.contents)
+
+    def test_store_release_workflows_require_main_and_emit_provenance(self) -> None:
+        for workflow_name in ("ios-build", "android-build"):
+            workflow = self._workflow_block(workflow_name)
+            self.assertIn("- *verify_shorebird_release_source", workflow)
+            self.assertIn("- *emit_shorebird_provenance", workflow)
+        self.assertIn("shorebird_provenance_store.sh create", self.contents)
+        self.assertIn("refusing to overwrite it", self.provenance_store_contents.lower())
+
+    def test_existing_ios_release_has_verified_main_tree_equivalence(self) -> None:
+        baseline_commit = "2504f4d871a9c1790e3e39f8398027bdc5105d04"
+        expected_tree = "a17e0660a782e439c5d405c2d06dd49e5b7fbc81"
+        repo_root = CODEMAGIC_PATH.parent
+
+        result = subprocess.run(
+            ["git", "rev-parse", f"{baseline_commit}^{{tree}}"],
+            cwd=repo_root,
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+        self.assertEqual(expected_tree, result.stdout.strip())
+
+    def test_caption_generator_names_missing_flutter_embedding_jar(self) -> None:
+        self.assertIn("if (!flutterDebugEmbeddingJar.isFile)", self.caption_generator_gradle_contents)
+        self.assertIn("Flutter debug embedding JAR not found at", self.caption_generator_gradle_contents)
+        self.assertIn("flutterDebugEmbeddingJar.absolutePath", self.caption_generator_gradle_contents)
 
     def test_shorebird_patch_workflows_block_native_asset_and_dependency_changes(self) -> None:
         self.assertIn("BLOCKED_PATCH_PATHS=$(git diff --name-only", self.contents)

--- a/.github/scripts/tests/test_codemagic_shorebird_config.py
+++ b/.github/scripts/tests/test_codemagic_shorebird_config.py
@@ -100,18 +100,14 @@ class CodemagicShorebirdConfigTest(unittest.TestCase):
             r"(?s)&shorebird_install.*?script: \|\n\s+set -euo pipefail\n",
         )
 
-    def test_shorebird_installer_and_cli_are_pinned_to_full_commits(self) -> None:
-        installer_url = re.search(r'INSTALLER_URL="([^"]+)"', self.contents)
-        self.assertIsNotNone(installer_url)
-        self.assertRegex(installer_url.group(1), r"/install/[0-9a-f]{40}/install\.sh$")
-        self.assertNotIn("/main/", installer_url.group(1))
+    def test_shorebird_cli_install_is_pinned_to_a_full_commit(self) -> None:
         self.assertRegex(
             self.contents,
             r'EXPECTED_SHOREBIRD_REVISION="[0-9a-f]{40}"',
         )
-        self.assertIn("shasum -a 256 -c -", self.contents)
         self.assertIn('checkout --quiet --detach FETCH_HEAD', self.contents)
-        self.assertNotIn("curl -sSf | bash", self.contents)
+        self.assertNotIn("raw.githubusercontent.com/shorebirdtech/install", self.contents)
+        self.assertNotRegex(self.contents, r"git clone .* (?:stable|v[0-9])")
 
     def test_shorebird_release_commands_are_signed_and_preflighted(self) -> None:
         self.assertIn("*preflight_shorebird_ios_release", self.contents)

--- a/.github/scripts/tests/test_codemagic_shorebird_config.py
+++ b/.github/scripts/tests/test_codemagic_shorebird_config.py
@@ -214,6 +214,13 @@ class CodemagicShorebirdConfigTest(unittest.TestCase):
         )
         self.assertEqual(expected_tree, result.stdout.strip())
 
+    def test_ci_config_job_fetches_history_for_release_tree_verification(self) -> None:
+        job_start = self.mobile_ci_contents.index("  ci-config-tests:")
+        next_job = self.mobile_ci_contents.index("\n  generated-files:", job_start)
+        job = self.mobile_ci_contents[job_start:next_job]
+
+        self.assertIn("fetch-depth: 0", job)
+
     def test_caption_generator_names_missing_flutter_embedding_jar(self) -> None:
         self.assertIn("if (!flutterDebugEmbeddingJar.isFile)", self.caption_generator_gradle_contents)
         self.assertIn("Flutter debug embedding JAR not found at", self.caption_generator_gradle_contents)

--- a/.github/scripts/tests/test_codemagic_shorebird_config.py
+++ b/.github/scripts/tests/test_codemagic_shorebird_config.py
@@ -1,3 +1,4 @@
+import json
 import re
 import subprocess
 import unittest
@@ -191,6 +192,35 @@ class CodemagicShorebirdConfigTest(unittest.TestCase):
         self.assertIn("shorebird_provenance.rb verify", self.contents)
         self.assertIn("git diff --name-only", self.contents)
         self.assertIn("*prepare_patch_source", self.contents)
+
+    def test_shorebird_workflows_define_every_variable_their_scripts_read(self) -> None:
+        resolved = json.loads(
+            subprocess.run(
+                [
+                    "ruby",
+                    "-ryaml",
+                    "-rjson",
+                    "-e",
+                    "print JSON.generate(YAML.safe_load(File.read(ARGV[0]), aliases: true))",
+                    str(CODEMAGIC_PATH),
+                ],
+                check=True,
+                text=True,
+                capture_output=True,
+            ).stdout
+        )
+
+        for name in ("ios-build", "android-build", "ios-patch", "android-patch"):
+            workflow = resolved["workflows"][name]
+            declared = set(workflow["environment"].get("vars") or {})
+            scripts = "\n".join(
+                step.get("script", "") for step in workflow["scripts"] if isinstance(step, dict)
+            )
+            # Every provenance step runs under `set -u`, so a workflow-local
+            # variable its scripts read but never declare aborts the build.
+            for variable in ("FLUTTER_VERSION", "SHOREBIRD_PLATFORM"):
+                if re.search(rf"\${{?{variable}}}?\b", scripts):
+                    self.assertIn(variable, declared, f"{name} reads ${variable} without declaring it")
 
     def test_store_release_workflows_require_main_and_emit_provenance(self) -> None:
         for workflow_name in ("ios-build", "android-build"):

--- a/.github/scripts/tests/test_shorebird_provenance.py
+++ b/.github/scripts/tests/test_shorebird_provenance.py
@@ -1,0 +1,225 @@
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = REPO_ROOT / "mobile" / "scripts" / "shorebird_provenance.rb"
+
+
+class ShorebirdProvenanceTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.root = Path(self.temp_dir.name)
+        self.defines = self.root / "defines.json"
+        self.record = self.root / "record.json"
+        self.env_output = self.root / "patch.env"
+        self.defines.write_text(
+            json.dumps({"DEFAULT_ENV": "PRODUCTION", "SECRET_TOKEN": "release-secret"})
+        )
+        self.head = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=REPO_ROOT,
+            check=True,
+            text=True,
+            capture_output=True,
+        ).stdout.strip()
+        self.environment = {
+            **os.environ,
+            "SHOREBIRD_PROVENANCE_HMAC_KEY": "test-only-hmac-key-with-32-bytes-minimum",
+            "SHOREBIRD_PROVENANCE_HMAC_KEY_ID": "test-key-v1",
+        }
+
+    def emit(self, output: Path | None = None) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [
+                "ruby",
+                str(SCRIPT),
+                "emit",
+                "--platform",
+                "ios",
+                "--release-version",
+                "1.2.3+456",
+                "--source-commit",
+                self.head,
+                "--patch-baseline-commit",
+                self.head,
+                "--flutter-version",
+                "3.44.9",
+                "--shorebird-cli-version",
+                "Shorebird 1.6.117",
+                "--shorebird-cli-revision",
+                "45facdd4e4b3c39e0d260107977584f0b7c66bec",
+                "--defines",
+                str(self.defines),
+                "--output",
+                str(output or self.record),
+            ],
+            cwd=REPO_ROOT,
+            env=self.environment,
+            check=False,
+            text=True,
+            capture_output=True,
+        )
+
+    def verify(
+        self,
+        environment: dict[str, str] | None = None,
+        **overrides: str,
+    ) -> subprocess.CompletedProcess[str]:
+        arguments = [
+            "ruby",
+            str(SCRIPT),
+            "verify",
+            "--platform",
+            overrides.get("platform", "ios"),
+            "--release-version",
+            overrides.get("release_version", "1.2.3+456"),
+            "--flutter-version",
+            overrides.get("flutter_version", "3.44.9"),
+            "--shorebird-cli-version",
+            overrides.get("shorebird_cli_version", "Shorebird 1.6.117"),
+            "--shorebird-cli-revision",
+            overrides.get(
+                "shorebird_cli_revision",
+                "45facdd4e4b3c39e0d260107977584f0b7c66bec",
+            ),
+            "--defines",
+            str(self.defines),
+            "--record",
+            str(self.record),
+            "--env-output",
+            str(self.env_output),
+        ]
+        if "release_commit" in overrides:
+            arguments.extend(["--release-commit", overrides["release_commit"]])
+        return subprocess.run(
+            arguments,
+            cwd=REPO_ROOT,
+            env=environment or self.environment,
+            check=False,
+            text=True,
+            capture_output=True,
+        )
+
+    def test_fingerprint_is_stable_and_contains_no_values(self) -> None:
+        second_record = self.root / "second.json"
+        self.assertEqual(0, self.emit().returncode)
+        self.assertEqual(0, self.emit(second_record).returncode)
+        first = json.loads(self.record.read_text())
+        second = json.loads(second_record.read_text())
+
+        self.assertEqual(first["config_fingerprints"], second["config_fingerprints"])
+        serialized = self.record.read_text()
+        self.assertNotIn("release-secret", serialized)
+        self.assertNotIn("PRODUCTION", serialized)
+
+    def test_verify_accepts_matching_record_and_writes_baseline(self) -> None:
+        self.assertEqual(0, self.emit().returncode)
+        result = self.verify(release_commit=self.head)
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertEqual(
+            f"SHOREBIRD_PATCH_BASELINE_COMMIT={self.head}\n",
+            self.env_output.read_text(),
+        )
+
+    def test_verify_rejects_malformed_or_mismatched_provenance(self) -> None:
+        missing = self.verify()
+        self.assertNotEqual(0, missing.returncode)
+        self.assertIn("release provenance is missing", missing.stderr)
+
+        self.record.write_text("not json")
+        malformed = self.verify()
+        self.assertNotEqual(0, malformed.returncode)
+        self.assertIn("release provenance is malformed", malformed.stderr)
+
+        self.assertEqual(0, self.emit().returncode)
+        mismatch = self.verify(release_version="9.9.9+999")
+        self.assertNotEqual(0, mismatch.returncode)
+        self.assertIn("version does not match", mismatch.stderr)
+
+    def test_verify_rejects_source_override_with_a_different_tree(self) -> None:
+        self.assertEqual(0, self.emit().returncode)
+        different_commit = subprocess.run(
+            ["git", "rev-parse", "HEAD^"],
+            cwd=REPO_ROOT,
+            check=True,
+            text=True,
+            capture_output=True,
+        ).stdout.strip()
+
+        mismatch = self.verify(release_commit=different_commit)
+        self.assertNotEqual(0, mismatch.returncode)
+        self.assertIn("does not match the recorded release source", mismatch.stderr)
+
+    def test_verify_rejects_an_authenticated_record_that_was_modified(self) -> None:
+        self.assertEqual(0, self.emit().returncode)
+        record = json.loads(self.record.read_text())
+        record["patch_baseline_commit"] = "0000000000000000000000000000000000000000"
+        self.record.write_text(json.dumps(record))
+
+        result = self.verify()
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("provenance authentication failed", result.stderr)
+
+    def test_verify_rejects_toolchain_drift(self) -> None:
+        self.assertEqual(0, self.emit().returncode)
+        flutter_mismatch = self.verify(flutter_version="9.9.9")
+        self.assertNotEqual(0, flutter_mismatch.returncode)
+        self.assertIn("Flutter version does not match", flutter_mismatch.stderr)
+
+        cli_mismatch = self.verify(
+            shorebird_cli_revision="0000000000000000000000000000000000000000"
+        )
+        self.assertNotEqual(0, cli_mismatch.returncode)
+        self.assertIn("CLI revision does not match", cli_mismatch.stderr)
+
+        cli_version_mismatch = self.verify(shorebird_cli_version="Shorebird 9.9.9")
+        self.assertNotEqual(0, cli_version_mismatch.returncode)
+        self.assertIn("CLI version does not match", cli_version_mismatch.stderr)
+
+    def test_verify_identifies_fingerprint_key_rotation(self) -> None:
+        self.assertEqual(0, self.emit().returncode)
+        rotated_environment = {
+            **self.environment,
+            "SHOREBIRD_PROVENANCE_HMAC_KEY_ID": "test-key-v2",
+        }
+        result = self.verify(environment=rotated_environment)
+
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("different configuration fingerprint key", result.stderr)
+
+    def test_config_drift_reports_only_key_names(self) -> None:
+        self.assertEqual(0, self.emit().returncode)
+        self.defines.write_text(
+            json.dumps({"DEFAULT_ENV": "STAGING", "SECRET_TOKEN": "patch-secret"})
+        )
+        result = self.verify()
+
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("DEFAULT_ENV", result.stderr)
+        self.assertIn("SECRET_TOKEN", result.stderr)
+        self.assertNotIn("PRODUCTION", result.stderr)
+        self.assertNotIn("STAGING", result.stderr)
+        self.assertNotIn("release-secret", result.stderr)
+        self.assertNotIn("patch-secret", result.stderr)
+
+    def test_unpatchable_historical_record_fails_closed(self) -> None:
+        self.assertEqual(0, self.emit().returncode)
+        record = json.loads(self.record.read_text())
+        record["patchable"] = False
+        record.pop("config_fingerprints")
+        self.record.write_text(json.dumps(record))
+
+        result = self.verify()
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("verified release configuration is unavailable", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/mobile_ci.yaml
+++ b/.github/workflows/mobile_ci.yaml
@@ -83,6 +83,9 @@ jobs:
         # undeclared group fails every workflow in the file and no in-script
         # guard can catch it (#7203).
         run: bash mobile/scripts/check_codemagic_groups.sh
+
+  # Deliberately ungated: these tests protect release configuration that the
+  # app-scope detector excludes, and the Mobile CI aggregator requires them.
   ci-config-tests:
     name: CI Configuration Tests
     runs-on: ubuntu-24.04

--- a/.github/workflows/mobile_ci.yaml
+++ b/.github/workflows/mobile_ci.yaml
@@ -91,6 +91,9 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
+        with:
+          # Provenance tests verify the historical release baseline tree.
+          fetch-depth: 0
       - name: Run CI configuration unit tests
         run: python3 -m unittest discover -s .github/scripts/tests
 

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -174,8 +174,6 @@ definitions:
         SHOREBIRD_BIN="$HOME/.shorebird/bin/shorebird"
         EXPECTED_SHOREBIRD_VERSION="Shorebird 1.6.117"
         EXPECTED_SHOREBIRD_REVISION="45facdd4e4b3c39e0d260107977584f0b7c66bec"
-        INSTALLER_URL="https://raw.githubusercontent.com/shorebirdtech/install/153e5f17e27879183d8fa5b78b058b1be3551f75/install.sh"
-        INSTALLER_SHA256="068e61b0fe74d20ecc92645df9c414cdd0140041620f07460447f8d08011b20e"
         SHOREBIRD_VERSION_OUTPUT=""
         SHOREBIRD_REVISION=""
         if [ -x "$SHOREBIRD_BIN" ]; then
@@ -184,14 +182,8 @@ definitions:
         fi
         if ! printf '%s\n' "$SHOREBIRD_VERSION_OUTPUT" | grep -Fq "$EXPECTED_SHOREBIRD_VERSION" || \
            [ "$SHOREBIRD_REVISION" != "$EXPECTED_SHOREBIRD_REVISION" ]; then
-          INSTALLER_FILE=$(mktemp)
-          trap 'rm -f "$INSTALLER_FILE"' EXIT
-          curl --proto '=https' --tlsv1.2 "$INSTALLER_URL" -sSf -o "$INSTALLER_FILE"
-          printf '%s  %s\n' "$INSTALLER_SHA256" "$INSTALLER_FILE" | shasum -a 256 -c -
-
-          # The verified upstream installer clones the mutable `stable` branch
-          # and executes it immediately. Install the same checkout layout from
-          # the reviewed CLI commit directly so no mutable code runs first.
+          # The upstream installer executes the mutable `stable` branch, so
+          # install the same checkout layout from the reviewed CLI commit.
           rm -rf "$HOME/.shorebird"
           git init --quiet "$HOME/.shorebird"
           git -C "$HOME/.shorebird" remote add origin https://github.com/shorebirdtech/shorebird.git

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -35,6 +35,10 @@
 #     CI authenticates with API keys only.
 #   - SHOREBIRD_PATCH_PUBLIC_KEY (public PEM used by `shorebird release`)
 #   - SHOREBIRD_PATCH_PRIVATE_KEY (secure private PEM used by `shorebird patch`)
+#   - SHOREBIRD_PROVENANCE_HMAC_KEY (secure random value used only to compare
+#     release and patch configuration without storing or logging its values)
+#   - SHOREBIRD_PROVENANCE_HMAC_KEY_ID (non-secret identifier for that key;
+#     retain old keys while any release fingerprinted with them is patchable)
 #     Store each PEM as a single-line value whose newlines are written as
 #     literal `\n` sequences. The CI step validates the decoded PEM envelope.
 #   The key must belong to an account with access to the app_id in
@@ -169,18 +173,50 @@ definitions:
         set -euo pipefail
         SHOREBIRD_BIN="$HOME/.shorebird/bin/shorebird"
         EXPECTED_SHOREBIRD_VERSION="Shorebird 1.6.117"
+        EXPECTED_SHOREBIRD_REVISION="45facdd4e4b3c39e0d260107977584f0b7c66bec"
+        INSTALLER_URL="https://raw.githubusercontent.com/shorebirdtech/install/153e5f17e27879183d8fa5b78b058b1be3551f75/install.sh"
+        INSTALLER_SHA256="068e61b0fe74d20ecc92645df9c414cdd0140041620f07460447f8d08011b20e"
         SHOREBIRD_VERSION_OUTPUT=""
+        SHOREBIRD_REVISION=""
         if [ -x "$SHOREBIRD_BIN" ]; then
           SHOREBIRD_VERSION_OUTPUT=$("$SHOREBIRD_BIN" --version 2>/dev/null || true)
+          SHOREBIRD_REVISION=$(git -C "$HOME/.shorebird" rev-parse HEAD 2>/dev/null || true)
         fi
-        if ! printf '%s\n' "$SHOREBIRD_VERSION_OUTPUT" | grep -Fq "$EXPECTED_SHOREBIRD_VERSION"; then
-          curl --proto '=https' --tlsv1.2 https://raw.githubusercontent.com/shorebirdtech/install/main/install.sh -sSf | bash -s -- --force
+        if ! printf '%s\n' "$SHOREBIRD_VERSION_OUTPUT" | grep -Fq "$EXPECTED_SHOREBIRD_VERSION" || \
+           [ "$SHOREBIRD_REVISION" != "$EXPECTED_SHOREBIRD_REVISION" ]; then
+          INSTALLER_FILE=$(mktemp)
+          trap 'rm -f "$INSTALLER_FILE"' EXIT
+          curl --proto '=https' --tlsv1.2 "$INSTALLER_URL" -sSf -o "$INSTALLER_FILE"
+          printf '%s  %s\n' "$INSTALLER_SHA256" "$INSTALLER_FILE" | shasum -a 256 -c -
+
+          # The verified upstream installer clones the mutable `stable` branch
+          # and executes it immediately. Install the same checkout layout from
+          # the reviewed CLI commit directly so no mutable code runs first.
+          rm -rf "$HOME/.shorebird"
+          git init --quiet "$HOME/.shorebird"
+          git -C "$HOME/.shorebird" remote add origin https://github.com/shorebirdtech/shorebird.git
+          git -C "$HOME/.shorebird" fetch --quiet --depth 1 origin "$EXPECTED_SHOREBIRD_REVISION"
+          git -C "$HOME/.shorebird" checkout --quiet --detach FETCH_HEAD
           SHOREBIRD_VERSION_OUTPUT=$("$SHOREBIRD_BIN" --version)
+          SHOREBIRD_REVISION=$(git -C "$HOME/.shorebird" rev-parse HEAD)
         fi
         echo PATH="$HOME/.shorebird/bin:$PATH" >> $CM_ENV
         echo "$SHOREBIRD_VERSION_OUTPUT"
         if ! printf '%s\n' "$SHOREBIRD_VERSION_OUTPUT" | grep -Fq "$EXPECTED_SHOREBIRD_VERSION"; then
           echo "ERROR: expected $EXPECTED_SHOREBIRD_VERSION; update and validate the pinned version before continuing."
+          exit 1
+        fi
+        if [ "$SHOREBIRD_REVISION" != "$EXPECTED_SHOREBIRD_REVISION" ]; then
+          echo "ERROR: Shorebird checkout does not match the reviewed revision."
+          exit 1
+        fi
+    - &verify_shorebird_release_source
+      name: Verify Shorebird release source
+      script: |
+        set -euo pipefail
+        if [ "$CM_BRANCH" != "main" ]; then
+          echo "Refusing to create a store release from branch '$CM_BRANCH'."
+          echo "Shorebird releases must be cut from main so future patches have a reachable baseline."
           exit 1
         fi
     - &write_shorebird_dart_defines
@@ -243,6 +279,52 @@ definitions:
           File.chmod(0o644, path)
         end
         RUBY
+    - &emit_shorebird_provenance
+      name: Record private Shorebird release provenance
+      script: |
+        set -euo pipefail
+        . "build/shorebird/${SHOREBIRD_PLATFORM}_release.env"
+        SOURCE_COMMIT=$(git rev-parse HEAD)
+        SHOREBIRD_CLI_VERSION=$("$HOME/.shorebird/bin/shorebird" --version | head -1)
+        SHOREBIRD_REVISION=$(git -C "$HOME/.shorebird" rev-parse HEAD)
+        PROVENANCE_PATH="build/shorebird/${SHOREBIRD_PLATFORM}_provenance.json"
+        ruby scripts/shorebird_provenance.rb emit \
+          --platform "$SHOREBIRD_PLATFORM" \
+          --release-version "$SHOREBIRD_RELEASE_VERSION" \
+          --source-commit "$SOURCE_COMMIT" \
+          --patch-baseline-commit "$SOURCE_COMMIT" \
+          --flutter-version "$FLUTTER_VERSION" \
+          --shorebird-cli-version "$SHOREBIRD_CLI_VERSION" \
+          --shorebird-cli-revision "$SHOREBIRD_REVISION" \
+          --defines build/shorebird/dart_defines.json \
+          --output "$PROVENANCE_PATH"
+        bash scripts/shorebird_provenance_store.sh create \
+          "$SHOREBIRD_PLATFORM" "$SHOREBIRD_RELEASE_VERSION" "$PROVENANCE_PATH"
+    - &fetch_and_verify_shorebird_provenance
+      name: Verify private Shorebird release provenance
+      script: |
+        set -euo pipefail
+        mkdir -p build/shorebird
+        if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
+          git fetch --quiet --unshallow origin main
+        else
+          git fetch --quiet origin main
+        fi
+        PROVENANCE_PATH="build/shorebird/${SHOREBIRD_PLATFORM}_provenance.json"
+        SHOREBIRD_CLI_VERSION=$("$HOME/.shorebird/bin/shorebird" --version | head -1)
+        SHOREBIRD_REVISION=$(git -C "$HOME/.shorebird" rev-parse HEAD)
+        bash scripts/shorebird_provenance_store.sh fetch \
+          "$SHOREBIRD_PLATFORM" "${{ inputs.RELEASE_VERSION }}" "$PROVENANCE_PATH"
+        ruby scripts/shorebird_provenance.rb verify \
+          --platform "$SHOREBIRD_PLATFORM" \
+          --release-version "${{ inputs.RELEASE_VERSION }}" \
+          --flutter-version "$FLUTTER_VERSION" \
+          --shorebird-cli-version "$SHOREBIRD_CLI_VERSION" \
+          --shorebird-cli-revision "$SHOREBIRD_REVISION" \
+          --release-commit "${{ inputs.RELEASE_COMMIT }}" \
+          --defines build/shorebird/dart_defines.json \
+          --record "$PROVENANCE_PATH" \
+          --env-output build/shorebird/patch_source.env
     - &write_shorebird_private_key
       name: Write Shorebird patch private key
       script: |
@@ -268,31 +350,8 @@ definitions:
           echo "Patch workflows must run from main after the fix has merged."
           exit 1
         fi
-        if [ -z "${{ inputs.RELEASE_COMMIT }}" ]; then
-          echo "Refusing to patch: RELEASE_COMMIT is required."
-          echo "Use the git commit that produced the target store release."
-          exit 1
-        fi
-        if ! printf '%s\n' "${{ inputs.RELEASE_COMMIT }}" | grep -Eq '^[0-9a-fA-F]{40}$'; then
-          echo "Refusing to patch: RELEASE_COMMIT must be a full 40-character commit SHA."
-          exit 1
-        fi
-        if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
-          git fetch --quiet --unshallow origin main
-        else
-          git fetch --quiet origin main
-        fi
-        if ! git cat-file -e "${{ inputs.RELEASE_COMMIT }}^{commit}" 2>/dev/null; then
-          echo "Refusing to patch: RELEASE_COMMIT '${{ inputs.RELEASE_COMMIT }}' is not a commit in this checkout."
-          exit 1
-        fi
-        if ! git merge-base --is-ancestor "${{ inputs.RELEASE_COMMIT }}" HEAD; then
-          echo "Refusing to patch: RELEASE_COMMIT must be an ancestor of HEAD."
-          echo "release commit: ${{ inputs.RELEASE_COMMIT }}"
-          echo "current head:    $(git rev-parse HEAD)"
-          exit 1
-        fi
-        BLOCKED_PATCH_PATHS=$(git diff --name-only "${{ inputs.RELEASE_COMMIT }}..HEAD" -- \
+        . build/shorebird/patch_source.env
+        BLOCKED_PATCH_PATHS=$(git diff --name-only "$SHOREBIRD_PATCH_BASELINE_COMMIT..HEAD" -- \
           'android/**' \
           'ios/**' \
           'macos/**' \
@@ -318,13 +377,13 @@ definitions:
           exit 1
         fi
         echo "Patch source diff from release commit to current HEAD:"
-        git log --oneline --no-merges "${{ inputs.RELEASE_COMMIT }}..HEAD"
-        if git diff --quiet "${{ inputs.RELEASE_COMMIT }}..HEAD" -- '*.dart'; then
+        git log --oneline --no-merges "$SHOREBIRD_PATCH_BASELINE_COMMIT..HEAD"
+        if git diff --quiet "$SHOREBIRD_PATCH_BASELINE_COMMIT..HEAD" -- '*.dart'; then
           echo "No Dart changes found between release commit and HEAD."
         else
           echo
           echo "Dart files changed since the release commit:"
-          git diff --name-only "${{ inputs.RELEASE_COMMIT }}..HEAD" -- '*.dart'
+          git diff --name-only "$SHOREBIRD_PATCH_BASELINE_COMMIT..HEAD" -- '*.dart'
         fi
     - &preflight_shorebird_android_release
       name: Preflight Android Shorebird release
@@ -871,6 +930,7 @@ workflows:
         # release is only reproducible if we pin it to the same version
         # Codemagic provisioned.
         FLUTTER_VERSION: 3.44.9
+        SHOREBIRD_PLATFORM: ios
         BUNDLE_ID: co.openvine.app
         IOS_EXTENSION_BUNDLE_IDS: >-
           co.openvine.app.NotificationServiceExtension
@@ -886,6 +946,7 @@ workflows:
     triggering:
       events: []
     scripts:
+      - *verify_shorebird_release_source
       - *shorebird_install
       - *check_signing_endpoint
       - *check_supporters_config
@@ -899,6 +960,7 @@ workflows:
       - *pod_install
       - *write_shorebird_dart_defines
       - *build_ios
+      - *emit_shorebird_provenance
       - *upload_dsyms_to_crashlytics
       - *publish_github_release
     artifacts:
@@ -993,6 +1055,7 @@ workflows:
       vars:
         # Must match `flutter:` above — see the iOS workflow for why.
         FLUTTER_VERSION: 3.44.9
+        SHOREBIRD_PLATFORM: android
       android_signing:
         - divine_keystore
     cache:
@@ -1003,6 +1066,7 @@ workflows:
     triggering:
       events: []
     scripts:
+      - *verify_shorebird_release_source
       - *shorebird_install
       - *check_signing_endpoint
       - *check_supporters_config
@@ -1014,6 +1078,7 @@ workflows:
       - *write_shorebird_dart_defines
       - *build_apk
       - *build_aab
+      - *emit_shorebird_provenance
       - *publish_github_release
     artifacts:
       - build/app/outputs/apk/release/*.apk
@@ -1065,9 +1130,9 @@ workflows:
         type: string
       RELEASE_COMMIT:
         description: >-
-          Git commit that produced the target store release. The workflow
-          prints every commit and Dart file that will be included in the patch
-          beyond this release commit.
+          Optional source assertion. When supplied, it must be the recorded
+          build commit, patch baseline, or a commit with the recorded source
+          tree. Provenance determines the actual patch baseline.
         type: string
       DEFAULT_ENV:
         description: >-
@@ -1087,8 +1152,10 @@ workflows:
       groups:
         - zendesk_credentials
         - proofmode_credentials
+        - github_credentials
         - shorebird_credentials
       vars:
+        SHOREBIRD_PLATFORM: ios
         BUNDLE_ID: co.openvine.app
         IOS_EXTENSION_BUNDLE_IDS: >-
           co.openvine.app.NotificationServiceExtension
@@ -1105,10 +1172,12 @@ workflows:
       events: []
     scripts:
       - *confirm_patch
-      - *prepare_patch_source
       - *shorebird_install
       - *check_signing_endpoint
       - *check_supporters_config
+      - *write_shorebird_dart_defines
+      - *fetch_and_verify_shorebird_provenance
+      - *prepare_patch_source
       - *check_ios_extension_signing_contract
       - *write_shorebird_private_key
       - *setup_code_signing_xcode
@@ -1116,7 +1185,6 @@ workflows:
       - *enable_spm
       - *prepare_ios_spm_packages
       - *pod_install
-      - *write_shorebird_dart_defines
       - *patch_ios
 
   android-patch:
@@ -1143,9 +1211,9 @@ workflows:
         type: string
       RELEASE_COMMIT:
         description: >-
-          Git commit that produced the target store release. The workflow
-          prints every commit and Dart file that will be included in the patch
-          beyond this release commit.
+          Optional source assertion. When supplied, it must be the recorded
+          build commit, patch baseline, or a commit with the recorded source
+          tree. Provenance determines the actual patch baseline.
         type: string
       DEFAULT_ENV:
         description: >-
@@ -1164,7 +1232,10 @@ workflows:
       groups:
         - zendesk_credentials
         - proofmode_credentials
+        - github_credentials
         - shorebird_credentials
+      vars:
+        SHOREBIRD_PLATFORM: android
       android_signing:
         - divine_keystore
     cache:
@@ -1176,14 +1247,15 @@ workflows:
       events: []
     scripts:
       - *confirm_patch
-      - *prepare_patch_source
       - *shorebird_install
       - *check_signing_endpoint
       - *check_supporters_config
+      - *write_shorebird_dart_defines
+      - *fetch_and_verify_shorebird_provenance
+      - *prepare_patch_source
       - *setup_local_properties
       - *configure_gradle_memory
       - *write_shorebird_private_key
-      - *write_shorebird_dart_defines
       - *patch_android
 
   macos-build:

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -1155,6 +1155,9 @@ workflows:
         - github_credentials
         - shorebird_credentials
       vars:
+        # Must match `flutter:` above. Provenance verification compares this
+        # against the Flutter version recorded for the target release.
+        FLUTTER_VERSION: 3.44.9
         SHOREBIRD_PLATFORM: ios
         BUNDLE_ID: co.openvine.app
         IOS_EXTENSION_BUNDLE_IDS: >-
@@ -1235,6 +1238,9 @@ workflows:
         - github_credentials
         - shorebird_credentials
       vars:
+        # Must match `flutter:` above. Provenance verification compares this
+        # against the Flutter version recorded for the target release.
+        FLUTTER_VERSION: 3.44.9
         SHOREBIRD_PLATFORM: android
       android_signing:
         - divine_keystore

--- a/mobile/docs/SHOREBIRD_CODE_PUSH.md
+++ b/mobile/docs/SHOREBIRD_CODE_PUSH.md
@@ -63,15 +63,21 @@ minor users.
 
 | Artifact | Built by | Patchable |
 |---|---|---|
-| Play AAB | `shorebird release android` | Yes |
-| App Store IPA | `shorebird release ios` | Yes |
-| Zapstore / GitHub per-ABI APKs | `flutter build apk --split-per-abi` | **No** — deliberate |
+| Play AAB | `shorebird release android` (Shorebird Flutter fork) | Yes |
+| App Store IPA | `shorebird release ios` (Shorebird Flutter fork) | Yes |
+| Zapstore / GitHub per-ABI APKs | `flutter build apk --split-per-abi` (stock Flutter engine) | **No** — deliberate |
 | macOS DMG | `flutter build macos` | No — not wired |
 
 The Zapstore APKs are an intentional exception: Shorebird has no
 `--split-per-abi`, and its universal APK would inflate the download for every
 sideload user. Those installs cannot receive patches. Play and App Store
 installs can.
+
+Because the Play AAB and direct-download APKs use different Flutter engines,
+engine-specific behavior can differ even when both artifacts come from the same
+Codemagic run. Their build numbers can differ too: the APK uses
+`PROJECT_BUILD_NUMBER`, while the AAB uses the higher of that value and the next
+available Play build number.
 
 `auto_update` is left at its default (on), so patches apply in the background
 on launch. `shorebird_code_push` is a runtime dependency. There is no in-app UI
@@ -115,8 +121,12 @@ Release commands pass `--public-key-path`, so every new store binary only
 accepts signed Shorebird patches. A release built without the public key cannot
 be retrofitted later; cut a new store release instead.
 
-**Record the version and build number of every release you promote** — e.g.
-`1.0.9+247` — and the git commit that produced it. A future patch needs both.
+After `shorebird release` succeeds, CI writes a create-only record to the
+private `divinevideo/divine-release-provenance` repository. It binds the
+platform and complete release version to the build commit, source tree, patch
+baseline, Flutter version, exact Shorebird CLI revision, and keyed fingerprints
+of every dart-define. The record contains no dart-define values. If recording
+fails, treat the release build as incomplete and do not patch that release.
 
 ## Shipping a patch
 
@@ -125,17 +135,19 @@ be retrofitted later; cut a new store release instead.
 1. Identify the target release: `shorebird patch` needs the version of the
    build that is actually live. `shorebird releases list`, or the Shorebird
    console, shows what exists.
-1. Identify the `RELEASE_COMMIT` that produced that store release. The patch
-   workflow refuses a release commit that is not an ancestor of the current
-   checkout, then prints every commit and Dart file included after that commit.
-   Read that list before treating the patch as safe: pure Dart merged since the
-   release is exactly what Shorebird can ship.
+1. The workflow retrieves the private provenance for `RELEASE_VERSION` and
+   derives the patch baseline from it. `RELEASE_COMMIT` is optional; when used
+   as an extra operator assertion, it must be the recorded build commit, the
+   recorded patch baseline, or another commit with the exact recorded tree.
+   The workflow prints every commit and Dart file included after the verified
+   baseline. Read that list before treating the patch as safe: pure Dart merged
+   since the release is exactly what Shorebird can ship.
    If the diff includes native, asset, dependency, or Shorebird config changes,
    the workflow refuses to patch and tells you to cut a normal store release.
 1. Run `ios-patch` or `android-patch` in Codemagic with:
    - `CONFIRM_PATCH` = `YES` (defaults to `NO`; the build aborts otherwise)
    - `RELEASE_VERSION` = the exact release string, e.g. `1.0.9+247`
-   - `RELEASE_COMMIT` = the git commit that produced the target release
+   - `RELEASE_COMMIT` = optional source assertion; normally leave it empty
    - `DEFAULT_ENV` = **the same value the release was built with**
 1. The workflow publishes to Shorebird's `staging` track, not directly to
    `stable`.
@@ -152,8 +164,23 @@ be retrofitted later; cut a new store release instead.
    automation.
 1. Both platforms need their own patch run. There is no combined workflow.
 
-`DEFAULT_ENV` is the easiest thing to get wrong. A mismatch does not fail the
-build — it silently repoints patched installs at a different environment.
+The patch workflow fingerprints the regenerated dart-defines with the same
+key used by the release and fails before compiling when any key differs. It
+prints key names only, never values or mismatched fingerprints. Restore the
+release configuration when the intended patch should preserve behavior; cut a
+new store release when the configuration change is intentional.
+
+Missing, malformed, overwritten, differently keyed, or explicitly unpatchable
+provenance fails closed. Do not recreate a missing record from current values.
+Recover it only from trustworthy release-build evidence; otherwise cut a new
+store release.
+
+The iOS `1.0.21+849` release predates automatic provenance. Its actual build
+commit is `a46851e924b183fa0cb2ce6c6cfaae7ed02cc189`; the equivalent reachable
+`main` baseline is `2504f4d871a9c1790e3e39f8398027bdc5105d04`. Both have tree
+`a17e0660a782e439c5d405c2d06dd49e5b7fbc81`, which CI verifies. Its private
+record is deliberately marked unpatchable because the historical dart-defines
+cannot be established from source control.
 
 ### A patch targets a release version, not a channel
 
@@ -183,11 +210,21 @@ The same group holds patch-signing key material:
 
 - `SHOREBIRD_PATCH_PUBLIC_KEY` — public PEM passed to `shorebird release`
 - `SHOREBIRD_PATCH_PRIVATE_KEY` — secure private PEM passed to `shorebird patch`
+- `SHOREBIRD_PROVENANCE_HMAC_KEY` — secure random key for dart-define
+  fingerprints
+- `SHOREBIRD_PROVENANCE_HMAC_KEY_ID` — non-secret key identifier
 
-Store both keys as single-line values with literal `\n` sequences between PEM
-lines. CI decodes and validates that envelope before invoking Shorebird. Release
-jobs only materialize the public key; patch jobs only materialize the private
-key.
+Store both patch-signing keys as single-line values with literal `\n` sequences
+between PEM lines. CI decodes and validates that envelope before invoking
+Shorebird. Release jobs only materialize the public key; patch jobs only
+materialize the private key.
+
+The `github_credentials` token used by release and patch jobs must have read
+and write access to the private `divinevideo/divine-release-provenance`
+repository. Provenance writes are create-only. Never delete or replace a record
+for a release that may still be patched. When rotating the HMAC key, retain the
+old key and identifier until every release fingerprinted with it is no longer
+patchable; select the matching credential for an older release.
 
 The token is currently generated from an individual's account. Moving it to a
 Divine service identity is tracked in #7200.
@@ -197,14 +234,25 @@ Divine service identity is tracked in #7200.
 Installing the CLI:
 
 ```
-if [ ! -x "$HOME/.shorebird/bin/shorebird" ]; then
-  curl --proto '=https' --tlsv1.2 https://raw.githubusercontent.com/shorebirdtech/install/main/install.sh -sSf | bash
-fi
+EXPECTED_SHOREBIRD_REVISION=45facdd4e4b3c39e0d260107977584f0b7c66bec
+git init "$HOME/.shorebird"
+git -C "$HOME/.shorebird" remote add origin https://github.com/shorebirdtech/shorebird.git
+git -C "$HOME/.shorebird" fetch --depth 1 origin "$EXPECTED_SHOREBIRD_REVISION"
+git -C "$HOME/.shorebird" checkout --detach FETCH_HEAD
+"$HOME/.shorebird/bin/shorebird" --version
 ```
 
-The installer refuses to overwrite an existing installation. Existing installs
-do not need to rerun it; use `bash -s -- --force` only when deliberately
-replacing the installed CLI.
+CI also downloads the upstream installer from reviewed commit
+`153e5f17e27879183d8fa5b78b058b1be3551f75` and verifies SHA-256
+`068e61b0fe74d20ecc92645df9c414cdd0140041620f07460447f8d08011b20e`.
+It does not execute that installer because it clones and immediately runs the
+mutable `stable` branch. CI installs the exact CLI revision directly and checks
+both its git revision and friendly version output on every cache hit.
+
+To upgrade Shorebird, review a tagged CLI revision, update the 40-character CLI
+SHA and expected version together, review a newer immutable installer commit
+and digest if needed, then run the CI configuration tests. Never replace either
+pin with a branch or tag.
 
 Then `shorebird login`. You need access to the Divine organization; membership
 is managed in the Shorebird console.

--- a/mobile/docs/SHOREBIRD_CODE_PUSH.md
+++ b/mobile/docs/SHOREBIRD_CODE_PUSH.md
@@ -222,9 +222,12 @@ materialize the private key.
 The `github_credentials` token used by release and patch jobs must have read
 and write access to the private `divinevideo/divine-release-provenance`
 repository. Provenance writes are create-only. Never delete or replace a record
-for a release that may still be patched. When rotating the HMAC key, retain the
-old key and identifier until every release fingerprinted with it is no longer
-patchable; select the matching credential for an older release.
+for a release that may still be patched. The workflow accepts one HMAC key and
+identifier at a time. When patching an older release after rotation, temporarily
+replace both Codemagic values with that release's retained key pair, run only
+the intended patch workflow, then restore the current pair. Do not run a store
+release while the older pair is selected. Retain each pair securely until every
+release fingerprinted with it is no longer patchable.
 
 The token is currently generated from an individual's account. Moving it to a
 Divine service identity is tracked in #7200.
@@ -242,17 +245,14 @@ git -C "$HOME/.shorebird" checkout --detach FETCH_HEAD
 "$HOME/.shorebird/bin/shorebird" --version
 ```
 
-CI also downloads the upstream installer from reviewed commit
-`153e5f17e27879183d8fa5b78b058b1be3551f75` and verifies SHA-256
-`068e61b0fe74d20ecc92645df9c414cdd0140041620f07460447f8d08011b20e`.
-It does not execute that installer because it clones and immediately runs the
-mutable `stable` branch. CI installs the exact CLI revision directly and checks
-both its git revision and friendly version output on every cache hit.
+CI deliberately does not use the upstream installer because it clones and
+immediately runs the mutable `stable` branch. It installs the exact reviewed CLI
+revision directly and checks both its git revision and friendly version output
+on every cache hit.
 
 To upgrade Shorebird, review a tagged CLI revision, update the 40-character CLI
-SHA and expected version together, review a newer immutable installer commit
-and digest if needed, then run the CI configuration tests. Never replace either
-pin with a branch or tag.
+SHA and expected version together, then run the CI configuration tests. Never
+replace the revision pin with a branch or tag.
 
 Then `shorebird login`. You need access to the Divine organization; membership
 is managed in the Shorebird console.

--- a/mobile/packages/caption_generator/android/build.gradle.kts
+++ b/mobile/packages/caption_generator/android/build.gradle.kts
@@ -17,6 +17,12 @@ val flutterRoot = providers.environmentVariable("FLUTTER_ROOT")
     ?: throw GradleException("FLUTTER_ROOT must be set to compile caption_generator")
 val flutterDebugEmbeddingJar =
     file("$flutterRoot/bin/cache/artifacts/engine/android-arm64/flutter.jar")
+if (!flutterDebugEmbeddingJar.isFile) {
+    throw GradleException(
+        "Flutter debug embedding JAR not found at ${flutterDebugEmbeddingJar.absolutePath}. " +
+            "Run 'flutter precache --android' for the FLUTTER_ROOT toolchain.",
+    )
+}
 
 android {
     namespace = "co.openvine.caption_generator"

--- a/mobile/scripts/shorebird_provenance.rb
+++ b/mobile/scripts/shorebird_provenance.rb
@@ -1,0 +1,212 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'json'
+require 'openssl'
+require 'optparse'
+require 'open3'
+
+SCHEMA_VERSION = 1
+HEX_SHA = /\A[0-9a-f]{40}\z/
+
+def abort_with(message)
+  warn("ERROR: #{message}")
+  exit 1
+end
+
+def read_json(path, description)
+  JSON.parse(File.read(path))
+rescue Errno::ENOENT
+  abort_with("#{description} is missing")
+rescue JSON::ParserError => error
+  abort_with("#{description} is malformed: #{error.message}")
+end
+
+def required_env(name)
+  value = ENV.fetch(name, '')
+  abort_with("#{name} is required") if value.empty?
+
+  value
+end
+
+def fingerprint_key
+  key = required_env('SHOREBIRD_PROVENANCE_HMAC_KEY')
+  abort_with('SHOREBIRD_PROVENANCE_HMAC_KEY must contain at least 32 bytes') if key.bytesize < 32
+
+  key
+end
+
+def fingerprints(defines, key)
+  defines.sort.to_h do |name, value|
+    abort_with("dart-define #{name} must be a string") unless value.is_a?(String)
+
+    payload = "shorebird-provenance-v#{SCHEMA_VERSION}\0#{name}\0#{value}"
+    [name, OpenSSL::HMAC.hexdigest('SHA256', key, payload)]
+  end
+end
+
+def canonical_json(value)
+  case value
+  when Hash
+    '{' + value.keys.sort.map { |key| "#{JSON.generate(key)}:#{canonical_json(value.fetch(key))}" }.join(',') + '}'
+  when Array
+    '[' + value.map { |item| canonical_json(item) }.join(',') + ']'
+  else
+    JSON.generate(value)
+  end
+end
+
+def record_hmac(record, key)
+  OpenSSL::HMAC.hexdigest('SHA256', key, canonical_json(record.reject { |name, _| name == 'record_hmac' }))
+end
+
+def secure_compare(left, right)
+  return false unless left.is_a?(String) && left.bytesize == right.bytesize
+
+  difference = 0
+  left.bytes.zip(right.bytes) { |left_byte, right_byte| difference |= left_byte ^ right_byte }
+  difference.zero?
+end
+
+def git(*arguments)
+  stdout, stderr, status = Open3.capture3('git', *arguments)
+  abort_with("git #{arguments.join(' ')} failed: #{stderr.strip}") unless status.success?
+
+  stdout.strip
+end
+
+def parse_options(arguments)
+  options = {}
+  parser = OptionParser.new do |opts|
+    opts.on('--platform VALUE') { |value| options[:platform] = value }
+    opts.on('--release-version VALUE') { |value| options[:release_version] = value }
+    opts.on('--source-commit VALUE') { |value| options[:source_commit] = value }
+    opts.on('--patch-baseline-commit VALUE') { |value| options[:patch_baseline_commit] = value }
+    opts.on('--flutter-version VALUE') { |value| options[:flutter_version] = value }
+    opts.on('--shorebird-cli-version VALUE') { |value| options[:shorebird_cli_version] = value }
+    opts.on('--shorebird-cli-revision VALUE') { |value| options[:shorebird_cli_revision] = value }
+    opts.on('--defines PATH') { |value| options[:defines] = value }
+    opts.on('--record PATH') { |value| options[:record] = value }
+    opts.on('--output PATH') { |value| options[:output] = value }
+    opts.on('--env-output PATH') { |value| options[:env_output] = value }
+    opts.on('--release-commit VALUE') { |value| options[:release_commit] = value }
+  end
+  parser.parse!(arguments)
+  options
+end
+
+def require_options(options, *names)
+  missing = names.select { |name| options.fetch(name, '').empty? }
+  abort_with("missing option(s): #{missing.map { |name| "--#{name.to_s.tr('_', '-')}" }.join(', ')}") unless missing.empty?
+end
+
+command = ARGV.shift
+options = parse_options(ARGV)
+
+case command
+when 'emit'
+  require_options(
+    options,
+    :platform,
+    :release_version,
+    :source_commit,
+    :patch_baseline_commit,
+    :flutter_version,
+    :shorebird_cli_version,
+    :shorebird_cli_revision,
+    :defines,
+    :output,
+  )
+  abort_with('platform must be android or ios') unless %w[android ios].include?(options[:platform])
+
+  %i[source_commit patch_baseline_commit shorebird_cli_revision].each do |name|
+    abort_with("#{name} must be a full lowercase commit SHA") unless options[name].match?(HEX_SHA)
+  end
+
+  source_tree_sha = git('rev-parse', "#{options[:source_commit]}^{tree}")
+  baseline_tree_sha = git('rev-parse', "#{options[:patch_baseline_commit]}^{tree}")
+  abort_with('patch baseline tree does not match the release source tree') unless source_tree_sha == baseline_tree_sha
+
+  defines = read_json(options[:defines], 'dart-defines file')
+  abort_with('dart-defines file must contain a JSON object') unless defines.is_a?(Hash)
+
+  record = {
+    'schema_version' => SCHEMA_VERSION,
+    'platform' => options[:platform],
+    'release_version' => options[:release_version],
+    'build_source_commit' => options[:source_commit],
+    'source_tree_sha' => source_tree_sha,
+    'patch_baseline_commit' => options[:patch_baseline_commit],
+    'flutter_version' => options[:flutter_version],
+    'shorebird_cli_version' => options[:shorebird_cli_version],
+    'shorebird_cli_revision' => options[:shorebird_cli_revision],
+    'config_fingerprint_key_id' => required_env('SHOREBIRD_PROVENANCE_HMAC_KEY_ID'),
+    'config_fingerprints' => fingerprints(defines, fingerprint_key),
+    'patchable' => true,
+  }
+  record['record_hmac'] = record_hmac(record, fingerprint_key)
+
+  File.write(options[:output], JSON.pretty_generate(record) + "\n", mode: 'w', perm: 0o600)
+when 'verify'
+  require_options(
+    options,
+    :platform,
+    :release_version,
+    :flutter_version,
+    :shorebird_cli_version,
+    :shorebird_cli_revision,
+    :defines,
+    :record,
+    :env_output,
+  )
+  record = read_json(options[:record], 'release provenance')
+  abort_with('release provenance must contain a JSON object') unless record.is_a?(Hash)
+  abort_with('unsupported release provenance schema') unless record['schema_version'] == SCHEMA_VERSION
+  abort_with('release provenance platform does not match the requested platform') unless record['platform'] == options[:platform]
+  abort_with('release provenance version does not match the requested release') unless record['release_version'] == options[:release_version]
+  abort_with('target release is not patchable because verified release configuration is unavailable') unless record['patchable'] == true
+
+  current_key_id = required_env('SHOREBIRD_PROVENANCE_HMAC_KEY_ID')
+  abort_with('release provenance uses a different configuration fingerprint key') unless record['config_fingerprint_key_id'] == current_key_id
+  expected_record_hmac = record['record_hmac']
+  calculated_record_hmac = record_hmac(record, fingerprint_key)
+  unless secure_compare(expected_record_hmac, calculated_record_hmac)
+    abort_with('release provenance authentication failed')
+  end
+
+  required_shas = %w[build_source_commit source_tree_sha patch_baseline_commit shorebird_cli_revision]
+  required_shas.each do |name|
+    abort_with("release provenance #{name} is invalid") unless record[name].is_a?(String) && record[name].match?(HEX_SHA)
+  end
+  abort_with('patch Flutter version does not match release provenance') unless record['flutter_version'] == options[:flutter_version]
+  abort_with('patch Shorebird CLI version does not match release provenance') unless record['shorebird_cli_version'] == options[:shorebird_cli_version]
+  abort_with('patch Shorebird CLI revision does not match release provenance') unless record['shorebird_cli_revision'] == options[:shorebird_cli_revision]
+
+  recorded_fingerprints = record['config_fingerprints']
+  abort_with('release provenance config_fingerprints is invalid') unless recorded_fingerprints.is_a?(Hash)
+
+  defines = read_json(options[:defines], 'dart-defines file')
+  abort_with('dart-defines file must contain a JSON object') unless defines.is_a?(Hash)
+  current_fingerprints = fingerprints(defines, fingerprint_key)
+  drifted_keys = (recorded_fingerprints.keys | current_fingerprints.keys).select do |name|
+    recorded_fingerprints[name] != current_fingerprints[name]
+  end.sort
+  abort_with("release configuration drifted for: #{drifted_keys.join(', ')}") unless drifted_keys.empty?
+
+  baseline = record['patch_baseline_commit']
+  baseline_tree = git('rev-parse', "#{baseline}^{tree}")
+  abort_with('recorded patch baseline tree does not match release provenance') unless baseline_tree == record['source_tree_sha']
+  system('git', 'merge-base', '--is-ancestor', baseline, 'HEAD') || abort_with('recorded patch baseline is not an ancestor of the current checkout')
+
+  override = options.fetch(:release_commit, '')
+  unless override.empty?
+    abort_with('RELEASE_COMMIT must be a full lowercase commit SHA') unless override.match?(HEX_SHA)
+    override_tree = git('rev-parse', "#{override}^{tree}")
+    allowed = [record['build_source_commit'], baseline].include?(override) || override_tree == record['source_tree_sha']
+    abort_with('RELEASE_COMMIT does not match the recorded release source') unless allowed
+  end
+
+  File.write(options[:env_output], "SHOREBIRD_PATCH_BASELINE_COMMIT=#{baseline}\n", mode: 'w', perm: 0o600)
+else
+  abort_with('usage: shorebird_provenance.rb emit|verify [options]')
+end

--- a/mobile/scripts/shorebird_provenance_store.sh
+++ b/mobile/scripts/shorebird_provenance_store.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Fetches and creates private Shorebird release provenance records.
+set -euo pipefail
+
+repository="${SHOREBIRD_PROVENANCE_REPOSITORY:-divinevideo/divine-release-provenance}"
+command="${1:-}"
+platform="${2:-}"
+release_version="${3:-}"
+local_path="${4:-}"
+
+if [[ ! "$platform" =~ ^(android|ios)$ ]] || [[ ! "$release_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+\+[0-9]+$ ]] || [ -z "$local_path" ]; then
+  echo "usage: shorebird_provenance_store.sh fetch|create android|ios RELEASE_VERSION LOCAL_PATH" >&2
+  exit 1
+fi
+
+remote_path="releases/$platform/$release_version.json"
+
+case "$command" in
+  fetch)
+    commit_count=$(gh api --method GET "repos/$repository/commits" \
+      -f "path=$remote_path" -f per_page=2 --jq length) || {
+      echo "ERROR: could not verify private provenance history for $platform release $release_version" >&2
+      exit 1
+    }
+    if [ "$commit_count" != "1" ]; then
+      echo "ERROR: provenance history is not create-only for $platform release $release_version" >&2
+      exit 1
+    fi
+    encoded=$(gh api "repos/$repository/contents/$remote_path" --jq .content) || {
+      echo "ERROR: no private provenance exists for $platform release $release_version" >&2
+      exit 1
+    }
+    printf '%s' "$encoded" | ruby -rbase64 -e 'print Base64.decode64(STDIN.read)' > "$local_path"
+    chmod 600 "$local_path"
+    ;;
+  create)
+    [ -f "$local_path" ] || { echo "ERROR: provenance file is missing: $local_path" >&2; exit 1; }
+    if gh api "repos/$repository/contents/$remote_path" >/dev/null 2>&1; then
+      echo "ERROR: provenance already exists for $platform release $release_version; refusing to overwrite it" >&2
+      exit 1
+    fi
+    content=$(base64 < "$local_path" | tr -d '\n')
+    gh api --method PUT "repos/$repository/contents/$remote_path" \
+      -f message="Record $platform Shorebird release $release_version" \
+      -f content="$content" >/dev/null
+    ;;
+  *)
+    echo "usage: shorebird_provenance_store.sh fetch|create android|ios RELEASE_VERSION LOCAL_PATH" >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
Store releases currently trust a manually entered commit and whatever configuration happens to be in Codemagic when a patch runs. A wrong commit, changed endpoint, or changed secret can therefore turn a narrow Dart patch into a different release configuration. The Shorebird installer also executes a mutable branch on a cold cache.

This change makes releases produce authenticated, create-only records in the new private `divinevideo/divine-release-provenance` repository. Patch workflows retrieve those records, verify the platform, version, source tree, reachable baseline, Flutter and Shorebird toolchains, and keyed per-setting fingerprints before compiling. Mismatch output names keys but never values. Store releases are now restricted to `main`, and the optional `RELEASE_COMMIT` input is only an additional assertion.

The Shorebird CLI is installed directly from a reviewed commit, without executing the upstream installer's mutable `stable` checkout. Cold and cached installations are both validated by git revision as well as version.

The historical iOS `1.0.21+849` mapping is stored privately with its true build commit and equivalent reachable baseline. It is deliberately marked unpatchable because its historical secret configuration cannot be reconstructed safely.

This also completes the consolidated #7774 chores: documents the engine and build-number differences between Android artifacts, gives the broader configuration test its accurate name, clarifies the always-required CI test placement, and reports the exact missing Flutter embedding JAR path.

No app behavior or patch promotion policy changes. Patches still publish to staging first and still reject native, asset, dependency, or Shorebird configuration changes.

Operational setup before the next store release: add a random 32-byte-or-longer `SHOREBIRD_PROVENANCE_HMAC_KEY` and its non-secret `SHOREBIRD_PROVENANCE_HMAC_KEY_ID` to the existing Codemagic `shorebird_credentials` group. The existing `github_credentials` token also needs read/write access to the new private repository.

Verification:

- 49 CI configuration and provenance tests
- Flutter analyzer
- 71 caption-generator package tests
- Codemagic variable-group guard
- Ruby and shell syntax checks
- Real private-store retrieval and overwrite rejection
- Pre-push conflict, package-coverage-floor, and backend-host guards

Closes #7776