### PR TITLE
fix(library): drop the grid-size button from the editor clip picker

### DIFF
--- a/mobile/lib/screens/library_screen.dart
+++ b/mobile/lib/screens/library_screen.dart
@@ -718,16 +718,10 @@ class _LibraryViewState extends ConsumerState<_LibraryView>
                             tabs: _tabs,
                             tabController: tabController,
                             selectionMode: widget.selectionMode,
-                            currentColumns: clipsState.gridColumnCount,
                             scrollController: widget.scrollController,
                             targetAspectRatio: targetAspectRatio,
                             sortedClips: sortedClips,
                             selectionEnabled: selectionEnabled,
-                            onOpenGridSizeMenu: () => _openGridSizeMenu(
-                              context,
-                              clipsBloc,
-                              clipsState.gridColumnCount,
-                            ),
                             onCreateVideo: () => _createVideoFromSelected(
                               context,
                               selectedClips: clipsState.selectedClips,
@@ -806,10 +800,8 @@ class _LibraryContent extends StatelessWidget {
     required this.tabs,
     required this.tabController,
     required this.selectionMode,
-    required this.currentColumns,
     required this.sortedClips,
     required this.selectionEnabled,
-    required this.onOpenGridSizeMenu,
     required this.onCreateVideo,
     this.scrollController,
     this.targetAspectRatio,
@@ -818,10 +810,8 @@ class _LibraryContent extends StatelessWidget {
   final List<_LibraryTab> tabs;
   final TabController tabController;
   final bool selectionMode;
-  final int currentColumns;
   final List<DivineVideoClip> sortedClips;
   final bool selectionEnabled;
-  final VoidCallback onOpenGridSizeMenu;
   final VoidCallback onCreateVideo;
   final ScrollController? scrollController;
   final double? targetAspectRatio;
@@ -867,10 +857,8 @@ class _LibraryContent extends StatelessWidget {
         Expanded(
           child: selectionMode
               ? _SelectionBody(
-                  currentColumns: currentColumns,
                   scrollController: scrollController,
                   targetAspectRatio: targetAspectRatio,
-                  onOpenGridSizeMenu: onOpenGridSizeMenu,
                   onCreate: onCreateVideo,
                 )
               : _TabBody(
@@ -1011,15 +999,11 @@ class _LibraryWebUnavailableScreen extends StatelessWidget {
 
 class _SelectionBody extends StatelessWidget {
   const _SelectionBody({
-    required this.currentColumns,
-    required this.onOpenGridSizeMenu,
     required this.onCreate,
     this.targetAspectRatio,
     this.scrollController,
   });
 
-  final int currentColumns;
-  final VoidCallback onOpenGridSizeMenu;
   final VoidCallback onCreate;
   final double? targetAspectRatio;
   final ScrollController? scrollController;
@@ -1028,22 +1012,6 @@ class _SelectionBody extends StatelessWidget {
   Widget build(BuildContext context) {
     return Column(
       children: [
-        Align(
-          alignment: AlignmentDirectional.centerEnd,
-          child: Padding(
-            padding: const EdgeInsetsDirectional.fromSTEB(16, 8, 16, 0),
-            child: DivineIconButton(
-              size: .small,
-              type: .secondary,
-              icon: .gridNine,
-              semanticLabel: context.l10n.libraryGridSizeLabel,
-              semanticValue: context.l10n.libraryGridSizeColumns(
-                currentColumns,
-              ),
-              onPressed: onOpenGridSizeMenu,
-            ),
-          ),
-        ),
         Expanded(
           child: ClipsTab(
             targetAspectRatio: targetAspectRatio,

--- a/mobile/test/screens/library_screen_test.dart
+++ b/mobile/test/screens/library_screen_test.dart
@@ -257,26 +257,6 @@ void main() {
         expect(announcements, contains(en.libraryGridSizeColumns(2)));
       });
 
-      testWidgets('changes the grid size from the selection sheet', (
-        tester,
-      ) async {
-        final announcements = _captureAnnouncements(tester);
-        await tester.pumpWidget(buildWidget(selectionMode: true));
-        await tester.pumpAndSettle();
-
-        await tester.tap(find.bySemanticsLabel(en.libraryGridSizeLabel));
-        await tester.pumpAndSettle();
-
-        expect(find.text(en.libraryGridSizeColumns(2)), findsOneWidget);
-        expect(find.text(en.libraryGridSizeColumns(5)), findsOneWidget);
-
-        await tester.tap(find.text(en.libraryGridSizeColumns(5)));
-        await tester.pumpAndSettle();
-
-        expect(sharedPreferences.getInt(ClipGridColumns.prefsKey), equals(5));
-        expect(announcements, contains(en.libraryGridSizeColumns(5)));
-      });
-
       testWidgets('$ClipSelectionFooter in selection mode', (tester) async {
         await tester.pumpWidget(buildWidget(selectionMode: true));
         await tester.pump();


### PR DESCRIPTION
Closes #7791

## Description

The clip picker the video editor opens was the only clip-library surface showing a grid-size button. Every other library surface leaves the column count to the pinch gesture and to the row inside the display-options menu, so this button read as a stray control — on the one sheet that has no toolbar to host it in the first place.

Removed the button from `_SelectionBody` along with the now-dead `currentColumns` / `onOpenGridSizeMenu` plumbing through `_LibraryContent`. `_openGridSizeMenu` itself stays: it is still reached from the display-options menu on the library toolbar.

One consequence worth naming: inside the selection sheet, the pinch is now the only way to the column count, and pinching is the one gesture assistive technology cannot perform. The setting remains reachable from the normal library, and the sheet simply inherits whatever count was last chosen there.

**Related Issue:** 

## Out of Scope

None.

## Verification

- `dart format` — clean
- `flutter analyze lib/screens/library_screen.dart test/screens/library_screen_test.dart` — no issues
- `flutter test test/screens/library_screen_test.dart` — 28 passed (dropped `changes the grid size from the selection sheet`, which covered exactly the removed button)
- Manual check on a real Samsung Galaxy: the picker sheet still opens, scrolls and selects clips with the button gone

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
