### PR TITLE
fix(notifications): keep an invalid-pubkey follow-back out of Crashlytics

### DIFF
--- a/mobile/lib/notifications/bloc/notification_feed_bloc.dart
+++ b/mobile/lib/notifications/bloc/notification_feed_bloc.dart
@@ -481,8 +481,15 @@ class NotificationFeedBloc
       // are NOT Reportable.
       addError(e, s);
     } catch (e, s) {
-      // Errors (StateError, TypeError from the post-await
-      // `_applyFollowState` transform) — matrix-YES invariant.
+      if (e is ArgumentError) {
+        // `FollowRepository.follow` rejects a malformed pubkey before it can
+        // poison the Kind 3 list. The value comes off a relay/FunnelCake
+        // payload, so this is input validation — matrix-NO, not an invariant.
+        addError(e, s);
+        return;
+      }
+      // Any other `Error` — e.g. a signer `StateError` raised while
+      // broadcasting the contact list — is a matrix-YES invariant.
       addError(
         Reportable(
           e,

--- a/mobile/lib/notifications/bloc/notification_feed_bloc.dart
+++ b/mobile/lib/notifications/bloc/notification_feed_bloc.dart
@@ -481,15 +481,20 @@ class NotificationFeedBloc
       // are NOT Reportable.
       addError(e, s);
     } catch (e, s) {
-      if (e is ArgumentError) {
-        // `FollowRepository.follow` rejects a malformed pubkey before it can
-        // poison the Kind 3 list. The value comes off a relay/FunnelCake
-        // payload, so this is input validation — matrix-NO, not an invariant.
+      if (e is ArgumentError && e.invalidValue == event.pubkey) {
+        // `FollowRepository.follow` rejects a malformed follow target before
+        // it can poison the Kind 3 list. The value comes off a
+        // relay/FunnelCake payload, so this is input validation — matrix-NO,
+        // not an invariant. Matching on the value keeps the arm to that one
+        // throw: `RangeError` and `IndexError` extend `ArgumentError`, and
+        // the Kind 3 broadcast throws the same type for our *own* pubkey.
+        // `follow` returns early on self-follow, so the two cannot collide.
         addError(e, s);
         return;
       }
-      // Any other `Error` — e.g. a signer `StateError` raised while
-      // broadcasting the contact list — is a matrix-YES invariant.
+      // Any other `Error` — a signer `StateError` raised while broadcasting
+      // the contact list, a `RangeError`, or an `ArgumentError` carrying our
+      // own pubkey — is a matrix-YES invariant.
       addError(
         Reportable(
           e,

--- a/mobile/lib/notifications/bloc/reportable_sites.dart
+++ b/mobile/lib/notifications/bloc/reportable_sites.dart
@@ -48,8 +48,9 @@ abstract class NotificationFeedBlocReportableSites {
 
   /// `_onFollowBack` generic-catch arm — `Error` types that escape
   /// `FollowRepository.follow`, such as a signer `StateError` raised while
-  /// broadcasting the contact list. Its `ArgumentError` on a malformed
-  /// pubkey is input validation and is caught ahead of this arm, so it
-  /// stays matrix-NO.
+  /// broadcasting the contact list, a `RangeError`, or an `ArgumentError`
+  /// carrying our own pubkey. The arm short-circuits just before the wrap
+  /// for the single matrix-NO case: `follow` rejecting the follow target's
+  /// malformed pubkey, which is input validation.
   static const String onFollowBack = '_onFollowBack';
 }

--- a/mobile/lib/notifications/bloc/reportable_sites.dart
+++ b/mobile/lib/notifications/bloc/reportable_sites.dart
@@ -47,9 +47,9 @@ abstract class NotificationFeedBlocReportableSites {
   static const String clearAppBadge = '_clearAppBadge';
 
   /// `_onFollowBack` generic-catch arm — `Error` types that escape
-  /// `FollowRepository.follow`'s Exception-only throws, plus a
-  /// hypothetical `TypeError` from the post-await `_applyFollowState`
-  /// transform (impossible under the current pure-`copyWith` shape; the
-  /// wrap is defence-in-depth).
+  /// `FollowRepository.follow`, such as a signer `StateError` raised while
+  /// broadcasting the contact list. Its `ArgumentError` on a malformed
+  /// pubkey is input validation and is caught ahead of this arm, so it
+  /// stays matrix-NO.
   static const String onFollowBack = '_onFollowBack';
 }

--- a/mobile/test/notifications/bloc/notification_feed_bloc_test.dart
+++ b/mobile/test/notifications/bloc/notification_feed_bloc_test.dart
@@ -1171,6 +1171,18 @@ void main() {
       );
 
       blocTest<NotificationFeedBloc, NotificationFeedState>(
+        'forwards an invalid-pubkey ArgumentError without wrapping it',
+        setUp: () {
+          when(() => mockFollowRepo.follow(_bobPubkey)).thenThrow(
+            ArgumentError.value(_bobPubkey, 'pubkey', 'Invalid key'),
+          );
+        },
+        build: createBloc,
+        act: (bloc) => bloc.add(NotificationFeedFollowBack(_bobPubkey)),
+        errors: () => [isA<ArgumentError>()],
+      );
+
+      blocTest<NotificationFeedBloc, NotificationFeedState>(
         'wraps unexpected Error from follow as Reportable',
         setUp: () {
           when(

--- a/mobile/test/notifications/bloc/notification_feed_bloc_test.dart
+++ b/mobile/test/notifications/bloc/notification_feed_bloc_test.dart
@@ -1179,7 +1179,49 @@ void main() {
         },
         build: createBloc,
         act: (bloc) => bloc.add(NotificationFeedFollowBack(_bobPubkey)),
-        errors: () => [isA<ArgumentError>()],
+        errors: () => [
+          isA<ArgumentError>().having(
+            (e) => e.invalidValue,
+            'invalidValue',
+            _bobPubkey,
+          ),
+        ],
+      );
+
+      blocTest<NotificationFeedBloc, NotificationFeedState>(
+        'wraps a RangeError from follow as Reportable',
+        setUp: () {
+          when(
+            () => mockFollowRepo.follow(_bobPubkey),
+          ).thenThrow(RangeError.range(5, 0, 1));
+        },
+        build: createBloc,
+        act: (bloc) => bloc.add(NotificationFeedFollowBack(_bobPubkey)),
+        errors: () => [
+          isA<Reportable<Object>>().having(
+            (r) => r.unwrap(),
+            'unwrap',
+            isA<RangeError>(),
+          ),
+        ],
+      );
+
+      blocTest<NotificationFeedBloc, NotificationFeedState>(
+        'wraps an ArgumentError carrying our own pubkey as Reportable',
+        setUp: () {
+          when(() => mockFollowRepo.follow(_bobPubkey)).thenThrow(
+            ArgumentError.value(_alicePubkey, 'pubkey', 'Invalid key'),
+          );
+        },
+        build: createBloc,
+        act: (bloc) => bloc.add(NotificationFeedFollowBack(_bobPubkey)),
+        errors: () => [
+          isA<Reportable<Object>>().having(
+            (r) => r.unwrap(),
+            'unwrap',
+            isA<ArgumentError>(),
+          ),
+        ],
       );
 
       blocTest<NotificationFeedBloc, NotificationFeedState>(


### PR DESCRIPTION
## Description

`FollowRepository.follow` validates the pubkey ahead of its own `try` block and throws `ArgumentError`. That is an `Error`, not an `Exception`, so the `on Exception` arm in `NotificationFeedBloc._onFollowBack` never saw it — it fell through to the generic arm, got wrapped in `Reportable(...)`, and `DivineBlocObserver` shipped it to Crashlytics.

An actor pubkey arrives from a relay or a FunnelCake payload, so a malformed one is untrusted input, not a broken invariant. Per the decision matrix in `.claude/rules/error_handling.md`, input validation is matrix-**NO**; reporting it erodes what the reportable gate means. It now goes through `addError` unwrapped, exactly like the auth/relay-IO failures the sibling arm already handles.

Two notes on how, since neither is obvious from the diff:

- The classification is an `is ArgumentError` check **inside** the generic catch rather than an `on ArgumentError catch` arm. The typed arm trips `avoid_catching_errors` and would need an `// ignore:` comment; the `is` check needs none and matches the existing idiom in `ConversationBloc._onMessageDeleted`.
- The type alone turned out to be too wide, so the check also matches on `invalidValue`. `RangeError` and `IndexError` extend `ArgumentError` in `dart:core`, and `NostrClient.sendContactList` throws the same type for our *own* malformed pubkey — all three are matrix-**YES**. Comparing the value against the follow target keeps the carve-out to the repository's input-validation throw; `follow` returns early on self-follow, so the two values cannot collide. Both cases were found in review by @realmeylisdev.
- No state emission is added. The follow-back path has no UI status today — its expected-failure arm is `addError`-only — so `ArgumentError` now behaves identically to every other expected failure there. Giving this one path a status enum nobody renders would be scope creep.

Also corrects the arm's comment, which blamed a `TypeError` from the post-await `_applyFollowState` transform. That transform cannot throw: `isFollowing` is a `List<String>.contains` over a field that is only ever reassigned, never mutated in place. The comment (and the matching doc on `NotificationFeedBlocReportableSites.onFollowBack`) now names the real source — an `Error` escaping the repository, such as a signer `StateError` raised during the Kind 3 broadcast.

**Related Issue:** Closes #7426

## Out of Scope

- `FollowRepository.follow` keeps throwing `ArgumentError`. Changing the package's declared contract would touch every caller for no gain here; the classification belongs at the bloc boundary, which is where the matrix is applied.
- The other `follow()` caller, `ScreenshotModeService`, is not a bloc and never reaches the observer.
- The UI status path #7426 also asks for. The follow-back handler renders no status today, and per @realmeylisdev's check funnelcake stores the actor as `source_pubkey FixedString(64)` taken from the source event's author, so a malformed one should not reach `follow()` at all. A status enum nobody renders would be scope creep.

## Verification

- `flutter analyze lib/notifications test/notifications` — no issues
- `flutter test test/notifications/bloc/notification_feed_bloc_test.dart` — 43/43 pass
- Three regression tests confirmed to fail without the fix, each by reverting the lib change and re-running: the invalid-target case sees `Reportable<Object>` instead of a bare `ArgumentError`, and the `RangeError` and own-pubkey cases see a bare error instead of the `Reportable` wrap
- No device run: this changes error classification only, with no user-visible surface. The invalid-pubkey branch was found by code inspection in #7426 and is not known to be reachable from live relay data.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

