### PR TITLE
docs(android): record the measured field cost of the Impeller switch

### DIFF
--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -107,9 +107,10 @@
              - Skia: 13-16ms raster, 60 FPS, correct video rendering.
 
              Nothing upstream has changed since. That measurement was
-             taken on Flutter 3.44.0, the same pin this branch builds on,
-             with both cited issues already closed - so this is not a
-             re-evaluation after an engine upgrade. What changed is the
+             taken on Flutter 3.44.0, with both cited issues already
+             closed - so this is not a re-evaluation after an engine
+             upgrade. The Flutter pin has since moved to 3.44.9 (#7202),
+             which the profiling above predates. What changed is the
              requirement: the video editor's live chroma-key preview
              needs `ui.ImageFilter.shader`, which Skia does not implement
              at all. On Skia the preview degrades to the unkeyed video

--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -116,6 +116,29 @@
              (the exported file is unaffected either way), and we decided
              a working preview is worth re-entering Impeller.
 
+             What the trade cost, measured in the field (#7123): across
+             the 1.0.17 Skia -> 1.0.19 Impeller boundary, store builds
+             only, `_st_MainActivity` screen traces with device fixed
+             effects and session weighting, Android slow frames rose
+             2.9 points (95% CI [+0.5, +5.3], p=0.019) - about one frame
+             in thirty-five. iOS across the same boundary under the same
+             estimator is the control at +0.29 points (CI [-0.01,
+             +0.59]), which is what pins this on the backend rather than
+             the shared Dart. Frozen frames did not move (+0.23 points,
+             p=0.18), and the cold-start regression the issue was opened
+             on faded to noise as the sample grew. Larger figures were
+             reported for all three before sessions were weighted:
+             averaging per-device ratios unweighted gives a device with
+             five sessions the same say as one with eight hundred.
+
+             Reverting is a stopgap, not a fix. The engine logs
+             "[Action Required]: Impeller opt-out deprecated" and says
+             the flag and this manifest entry "are going to go away in
+             an upcoming Flutter release" (shell/common/shell.cc). The
+             feed has to be fast on Impeller before that removal lands,
+             whatever the chroma-key preview is worth, so the answer to
+             those 2.9 points is raster work, not a backend flip.
+
              Two things that follow, both easy to get wrong:
 
              - "Falls back to Skia" is not what happens. Below API 29 the


### PR DESCRIPTION
## Description

The Impeller re-entry in #6483 is documented in `AndroidManifest.xml` as a deliberate trade — the video editor's live chroma-key preview needs `ui.ImageFilter.shader`, which Skia does not implement — but the comment never says what the trade cost. #7123 measured it, twice, with the estimate moving both times. This writes the settled numbers into the manifest so the next reader can judge the trade without re-running the analysis, and records why a revert is not the answer.

**What the field data says**, across the 1.0.17 (Skia) → 1.0.19 (Impeller) boundary, store builds only, `_st_MainActivity` screen traces, device fixed effects with session weighting:

| Metric | Estimate | 95% CI | p |
|---|---|---|---|
| Android slow frames | **+2.9 pts** | [+0.5, +5.3] | 0.019 |
| Android frozen frames | +0.23 pts | [−0.11, +0.56] | 0.18 |
| iOS slow frames (control) | +0.29 pts | [−0.01, +0.59] | 0.058 |

Three things changed versus the numbers in the issue, all from weighting sessions rather than averaging per-device ratios unweighted — which gives a device with 5 sessions the same say as one with 805:

- Slow frames land at +2.9 points rather than +4.5. The unweighted estimator now gives +4.8 at n≥5 and +0.5 at n≥10; the session-weighted estimate is stable across thresholds.
- Frozen frames do not survive. Unweighted they look significant (12 of 14 shared devices worse, p=0.013); weighted, p=0.18. The "2.4× frozen frames" reading is dropped.
- The cold-start regression the issue was opened on has faded to noise, as the second reading already anticipated.

iOS crossing the same boundary with the same shared Dart is flat under the identical estimator, which is what pins the remainder on the rendering backend rather than on anything in the release.

**Why reverting is off the table**, and the reason this closes as documentation rather than a code change: the pinned Flutter 3.44.9 engine already logs the opt-out as deprecated and says the flag and the `EnableImpeller` manifest entry "are going to go away in an upcoming Flutter release" (`engine/src/flutter/shell/common/shell.cc:529`). A revert buys a release or two and then the feed has to be fast on Impeller anyway — so the answer to those 2.9 points is raster work on its own merits, not a backend flip, whatever the chroma-key preview turns out to be worth.

**Related Issue:** Closes #7123

## Out of Scope

The raster work itself. The remaining Impeller-specific cost in the feed is most likely the `BackdropFilter` passes that sit over the live video texture (`center_playback_control.dart`, `feed_playback_toggles_pill.dart`, `content_warning_helpers.dart`) — the action-button shadow blurs are already `RepaintBoundary`-isolated and the fullscreen backdrop blur was replaced by the blurhash path in #5957. Confirming that needs on-device profiling and belongs in its own change.

## Verification

Comment-only change to `AndroidManifest.xml`; no Dart, no resources, no manifest elements touched. Parsed the file to confirm it is still well-formed XML. Numbers re-derived from `openvine-co.firebase_performance.co_openvine_app_{ANDROID,IOS}` over the full export through 2026-08-16 (1.0.19 store build 692 now has 6,240 screen traces, up from 1,338 when the issue's second reading was written).

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
