### PR TITLE
fix(ui): stop dialog and sheet buttons from closing the wrong screen or filing fake crashes

### DIFF
--- a/mobile/lib/extensions/modal_pop_extension.dart
+++ b/mobile/lib/extensions/modal_pop_extension.dart
@@ -1,0 +1,45 @@
+// ABOUTME: BuildContext.popModalIfMounted — pop a dialog or sheet from its own
+// ABOUTME: callback context without walking a route that is already gone.
+
+import 'package:flutter/widgets.dart';
+
+/// Adds [popModalIfMounted] to [BuildContext] for dialog and sheet callbacks.
+extension ModalPopExtension on BuildContext {
+  /// Pops the modal route this context belongs to, unless it is already gone.
+  ///
+  /// A dialog or sheet callback closes over the context its builder was handed.
+  /// That context's element is unmounted the moment the route is torn down, and
+  /// a route can disappear while a tap is still in flight — a rebuild above the
+  /// modal, a redirect, a deep link. `Navigator.of` then walks a defunct
+  /// element and throws: `Looking up a deactivated widget's ancestor is unsafe`
+  /// in debug, a `_state!` null check in release AOT. Either way the pop never
+  /// happens and the tap silently does nothing, but `FlutterError.onError`
+  /// files that no-op in Crashlytics as a fatal (#6512, #7291).
+  ///
+  /// Skipping the pop is safe: the route is already closed, so the pop was
+  /// moot. Whatever awaited `showDialog` / `showModalBottomSheet` resolves off
+  /// that teardown with `null`, and every confirmation call site here already
+  /// reads `null` as "not confirmed".
+  ///
+  /// Returns whether the pop was attempted, so a callback that does more than
+  /// pop can bail out of the rest for the same reason:
+  ///
+  /// ```dart
+  /// onTap: () {
+  ///   if (!sheetContext.popModalIfMounted()) return;
+  ///   openEditor();
+  /// },
+  /// ```
+  ///
+  /// This is not `safePop` from `safe_pop_extension.dart`, which solves the
+  /// opposite problem: a *live* context whose GoRouter back stack is empty, and
+  /// which navigates to a fallback route rather than doing nothing. Reach for
+  /// that one from AppBar back buttons; reach for this one from inside a modal.
+  bool popModalIfMounted<T extends Object?>([T? result]) {
+    if (!mounted) {
+      return false;
+    }
+    Navigator.of(this).pop<T>(result);
+    return true;
+  }
+}

--- a/mobile/lib/extensions/modal_pop_extension.dart
+++ b/mobile/lib/extensions/modal_pop_extension.dart
@@ -16,10 +16,19 @@ extension ModalPopExtension on BuildContext {
   /// happens and the tap silently does nothing, but `FlutterError.onError`
   /// files that no-op in Crashlytics as a fatal (#6512, #7291).
   ///
-  /// Skipping the pop is safe: the route is already closed, so the pop was
-  /// moot. Whatever awaited `showDialog` / `showModalBottomSheet` resolves off
-  /// that teardown with `null`, and every confirmation call site here already
-  /// reads `null` as "not confirmed".
+  /// Two separate things have to hold before popping, because `Navigator.pop`
+  /// takes the navigator's *topmost* route rather than this context's own:
+  ///
+  /// 1. The context is still mounted. Otherwise `Navigator.of` throws as above.
+  /// 2. This context's modal route is still the current one. A modal stays
+  ///    mounted for the length of its exit transition, so a second tap that
+  ///    lands in that window passes the mounted check and would pop whatever
+  ///    is underneath — the screen the modal was covering.
+  ///
+  /// Skipping the pop is safe in both cases: the route is already closed or
+  /// closing, so the pop was moot. Whatever awaited `showDialog` /
+  /// `showModalBottomSheet` resolves off that teardown with `null`, and every
+  /// confirmation call site here already reads `null` as "not confirmed".
   ///
   /// Returns whether the pop was attempted, so a callback that does more than
   /// pop can bail out of the rest for the same reason:
@@ -37,6 +46,9 @@ extension ModalPopExtension on BuildContext {
   /// that one from AppBar back buttons; reach for this one from inside a modal.
   bool popModalIfMounted<T extends Object?>([T? result]) {
     if (!mounted) {
+      return false;
+    }
+    if (ModalRoute.isCurrentOf(this) != true) {
       return false;
     }
     Navigator.of(this).pop<T>(result);

--- a/mobile/lib/screens/apps/nostr_app_sandbox_screen.dart
+++ b/mobile/lib/screens/apps/nostr_app_sandbox_screen.dart
@@ -16,6 +16,7 @@ import 'package:http/http.dart' as http;
 import 'package:image_metadata_stripper/image_metadata_stripper.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:nostr_app_bridge_repository/nostr_app_bridge_repository.dart';
+import 'package:openvine/extensions/modal_pop_extension.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/screens/apps/nostr_app_sandbox_bridge.dart';
@@ -588,8 +589,8 @@ class _NostrAppSandboxScreenState extends ConsumerState<NostrAppSandboxScreen> {
             method: request.method,
             capability: request.capability,
             eventKind: request.eventKind,
-            onAllow: () => Navigator.of(bottomSheetContext).pop(true),
-            onCancel: () => Navigator.of(bottomSheetContext).pop(false),
+            onAllow: () => bottomSheetContext.popModalIfMounted(true),
+            onCancel: () => bottomSheetContext.popModalIfMounted(false),
           ),
         );
       },

--- a/mobile/lib/screens/auth/nostr_connect_screen.dart
+++ b/mobile/lib/screens/auth/nostr_connect_screen.dart
@@ -9,6 +9,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
+import 'package:openvine/extensions/modal_pop_extension.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/router/route_paths.dart';
@@ -328,7 +329,7 @@ class _NostrConnectScreenState extends ConsumerState<NostrConnectScreen> {
                   vertical: 18,
                 ),
               ),
-              onSubmitted: (value) => Navigator.pop(context, value.trim()),
+              onSubmitted: (value) => context.popModalIfMounted(value.trim()),
             ),
             const SizedBox(height: 16),
           ],

--- a/mobile/lib/screens/curated_list_feed_screen.dart
+++ b/mobile/lib/screens/curated_list_feed_screen.dart
@@ -8,6 +8,7 @@ import 'package:flutter/semantics.dart' show SemanticsService;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:models/models.dart' hide LogCategory;
+import 'package:openvine/extensions/modal_pop_extension.dart';
 import 'package:openvine/extensions/safe_pop_extension.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/models/view_traffic_source.dart';
@@ -27,18 +28,6 @@ import 'package:openvine/widgets/user_name.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 enum _CuratedListAction { edit, share, delete, unfollow }
-
-/// Pops the delete-confirmation dialog with [confirmed].
-///
-/// The route can be gone by the time a tap on one of its buttons is
-/// delivered. `Navigator.of` then walks a defunct element and throws, which
-/// `FlutterError.onError` records as a fatal even though the pop is moot.
-void _popConfirmation(BuildContext dialogContext, {required bool confirmed}) {
-  if (!dialogContext.mounted) {
-    return;
-  }
-  Navigator.of(dialogContext).pop(confirmed);
-}
 
 class CuratedListFeedScreen extends ConsumerStatefulWidget {
   /// Route name for this screen.
@@ -517,7 +506,7 @@ class _CuratedListFeedScreenState extends ConsumerState<CuratedListFeedScreen> {
         ),
         actions: [
           TextButton(
-            onPressed: () => _popConfirmation(dialogContext, confirmed: false),
+            onPressed: () => dialogContext.popModalIfMounted(false),
             child: Text(
               l10n.commonCancel,
               style: VineTheme.labelMediumFont(
@@ -526,7 +515,7 @@ class _CuratedListFeedScreenState extends ConsumerState<CuratedListFeedScreen> {
             ),
           ),
           TextButton(
-            onPressed: () => _popConfirmation(dialogContext, confirmed: true),
+            onPressed: () => dialogContext.popModalIfMounted(true),
             child: Text(
               l10n.commonDelete,
               style: VineTheme.labelMediumFont(color: VineTheme.error),

--- a/mobile/lib/screens/feed/pooled_age_restricted_retry.dart
+++ b/mobile/lib/screens/feed/pooled_age_restricted_retry.dart
@@ -9,6 +9,7 @@ import 'package:infinite_video_feed/infinite_video_feed.dart'
 import 'package:models/models.dart';
 import 'package:openvine/blocs/video_playback_status/video_playback_status_cubit.dart';
 import 'package:openvine/blocs/video_playback_status/video_playback_status_state.dart';
+import 'package:openvine/extensions/modal_pop_extension.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/models/viewer_auth_result.dart';
 import 'package:openvine/providers/app_providers.dart';
@@ -248,9 +249,9 @@ Future<void> _promptAdultContentHidden(BuildContext context) async {
         title: sheetContext.l10n.videoErrorAdultContentHiddenTitle,
         subtitle: sheetContext.l10n.videoErrorAdultContentHiddenBody,
         primaryButtonText: sheetContext.l10n.videoErrorAdultContentHiddenAction,
-        onPrimaryPressed: () => Navigator.of(sheetContext).pop(true),
+        onPrimaryPressed: () => sheetContext.popModalIfMounted(true),
         secondaryButtonText: sheetContext.l10n.commonNotNow,
-        onSecondaryPressed: () => Navigator.of(sheetContext).pop(false),
+        onSecondaryPressed: () => sheetContext.popModalIfMounted(false),
       ),
     ),
   );

--- a/mobile/lib/screens/inbox/conversation/widgets/reaction_picker_overlay.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/reaction_picker_overlay.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:openvine/extensions/modal_pop_extension.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/screens/inbox/conversation/widgets/message_actions_sheet.dart';
 
@@ -80,10 +81,10 @@ class ReactionPickerOverlay {
                   _QuickRow(
                     emojis: emojis,
                     openLabel: l10n.dmReactionAddCustomA11yLabel,
-                    onEmojiTap: (emoji) => Navigator.of(sheetContext).pop(
+                    onEmojiTap: (emoji) => sheetContext.popModalIfMounted(
                       ReactionPickerResult(emoji: emoji),
                     ),
-                    onMoreTap: () => Navigator.of(sheetContext).pop(
+                    onMoreTap: () => sheetContext.popModalIfMounted(
                       const ReactionPickerResult(openFullPicker: true),
                     ),
                   ),
@@ -91,7 +92,7 @@ class ReactionPickerOverlay {
                 _ActionList(
                   isSent: isSent,
                   isVideoShare: isVideoShare,
-                  onSelected: (action) => Navigator.of(sheetContext).pop(
+                  onSelected: (action) => sheetContext.popModalIfMounted(
                     ReactionPickerResult(action: action),
                   ),
                 ),

--- a/mobile/lib/screens/inbox/inbox_view.dart
+++ b/mobile/lib/screens/inbox/inbox_view.dart
@@ -16,6 +16,7 @@ import 'package:openvine/blocs/dm/conversation_list/conversation_list_bloc.dart'
 import 'package:openvine/blocs/dm/conversation_mute/conversation_mute_cubit.dart';
 import 'package:openvine/blocs/dm/unread_count/dm_unread_count_cubit.dart';
 import 'package:openvine/blocs/notifications/badge/notification_badge_cubit.dart';
+import 'package:openvine/extensions/modal_pop_extension.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/mixins/scroll_pagination_mixin.dart';
 import 'package:openvine/notifications/view/inbox_notifications_page.dart';
@@ -1112,7 +1113,7 @@ class _MessagesScrollViewState extends ConsumerState<_MessagesScrollView>
         ),
         actions: [
           TextButton(
-            onPressed: () => Navigator.pop(context, false),
+            onPressed: () => context.popModalIfMounted(false),
             child: Text(
               context.l10n.commonCancel,
               style: VineTheme.bodyMediumFont(
@@ -1121,7 +1122,7 @@ class _MessagesScrollViewState extends ConsumerState<_MessagesScrollView>
             ),
           ),
           TextButton(
-            onPressed: () => Navigator.pop(context, true),
+            onPressed: () => context.popModalIfMounted(true),
             child: Text(
               context.l10n.inboxRemoveConfirmConfirm,
               style: VineTheme.bodyMediumFont(color: VineTheme.error),

--- a/mobile/lib/screens/profile_setup/widgets/image_url_sheet.dart
+++ b/mobile/lib/screens/profile_setup/widgets/image_url_sheet.dart
@@ -1,6 +1,7 @@
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:openvine/blocs/profile_editor/profile_editor_bloc.dart';
+import 'package:openvine/extensions/modal_pop_extension.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/screens/profile_setup/widgets/profile_setup_rows.dart';
 
@@ -53,7 +54,7 @@ class _ImageUrlFormState extends State<_ImageUrlForm> {
     super.dispose();
   }
 
-  void _save() => Navigator.of(context).pop(_controller.text);
+  void _save() => context.popModalIfMounted(_controller.text);
 
   @override
   Widget build(BuildContext context) {
@@ -89,7 +90,7 @@ class _ImageUrlFormState extends State<_ImageUrlForm> {
                   label: context.l10n.commonCancel,
                   type: DivineButtonType.secondary,
                   expanded: true,
-                  onPressed: () => Navigator.of(context).pop(),
+                  onPressed: () => context.popModalIfMounted(),
                 ),
               ),
               Expanded(

--- a/mobile/lib/screens/profile_setup/widgets/profile_setup_listeners.dart
+++ b/mobile/lib/screens/profile_setup/widgets/profile_setup_listeners.dart
@@ -6,6 +6,7 @@ import 'package:go_router/go_router.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/my_profile/my_profile_bloc.dart';
 import 'package:openvine/blocs/profile_editor/profile_editor_bloc.dart';
+import 'package:openvine/extensions/modal_pop_extension.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
@@ -290,7 +291,7 @@ class _ProfileSetupListenersState extends ConsumerState<ProfileSetupListeners> {
                   ),
                   actions: [
                     TextButton(
-                      onPressed: () => Navigator.of(dialogContext).pop(),
+                      onPressed: () => dialogContext.popModalIfMounted(),
                       child: Text(
                         context.l10n.profileCancelButton,
                         style: TextStyle(color: context.vineColors.mutedText),
@@ -298,7 +299,10 @@ class _ProfileSetupListenersState extends ConsumerState<ProfileSetupListeners> {
                     ),
                     TextButton(
                       onPressed: () {
-                        Navigator.of(dialogContext).pop();
+                        // A tap that lands after the route is gone is not a
+                        // confirmation the user ever saw, so it must not
+                        // publish either.
+                        if (!dialogContext.popModalIfMounted()) return;
                         context.read<ProfileEditorBloc>().add(
                           const ProfileSaveConfirmed(),
                         );

--- a/mobile/lib/screens/relay_settings_screen.dart
+++ b/mobile/lib/screens/relay_settings_screen.dart
@@ -9,6 +9,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:openvine/blocs/relay_settings/relay_settings_cubit.dart';
 import 'package:openvine/blocs/relay_settings/relay_settings_state.dart';
+import 'package:openvine/extensions/modal_pop_extension.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
@@ -666,7 +667,7 @@ class _AddRelaySheetState extends State<_AddRelaySheet> {
             textInputAction: .done,
             onSubmitted: (_) {
               final url = _controller.text.trim();
-              if (url.isNotEmpty) Navigator.pop(context, url);
+              if (url.isNotEmpty) context.popModalIfMounted(url);
             },
             spellCheckConfiguration: const SpellCheckConfiguration.disabled(),
           ),
@@ -679,7 +680,7 @@ class _AddRelaySheetState extends State<_AddRelaySheet> {
                   label: context.l10n.relaySettingsCancel,
                   type: DivineButtonType.secondary,
                   expanded: true,
-                  onPressed: () => Navigator.pop(context),
+                  onPressed: () => context.popModalIfMounted(),
                 ),
               ),
               Expanded(
@@ -688,7 +689,7 @@ class _AddRelaySheetState extends State<_AddRelaySheet> {
                   expanded: true,
                   onPressed: () {
                     final url = _controller.text.trim();
-                    if (url.isNotEmpty) Navigator.pop(context, url);
+                    if (url.isNotEmpty) context.popModalIfMounted(url);
                   },
                 ),
               ),
@@ -792,28 +793,34 @@ Future<void> _confirmRemoveRelay(
           ),
         ),
       ),
-      Padding(
-        padding: const EdgeInsets.fromLTRB(16, 16, 16, 4),
-        child: Row(
-          spacing: 16,
-          children: [
-            Expanded(
-              child: DivineButton(
-                label: l10n.relaySettingsCancel,
-                type: DivineButtonType.secondary,
-                expanded: true,
-                onPressed: () => Navigator.pop(context, false),
+      // The buttons resolve the Navigator from the sheet's own subtree rather
+      // than from the relay screen's context: the list rebuilds on every relay
+      // status change, and a caller context that has gone defunct leaves both
+      // buttons inert.
+      Builder(
+        builder: (sheetContext) => Padding(
+          padding: const EdgeInsets.fromLTRB(16, 16, 16, 4),
+          child: Row(
+            spacing: 16,
+            children: [
+              Expanded(
+                child: DivineButton(
+                  label: l10n.relaySettingsCancel,
+                  type: DivineButtonType.secondary,
+                  expanded: true,
+                  onPressed: () => sheetContext.popModalIfMounted(false),
+                ),
               ),
-            ),
-            Expanded(
-              child: DivineButton(
-                label: l10n.relaySettingsRemove,
-                type: DivineButtonType.error,
-                expanded: true,
-                onPressed: () => Navigator.pop(context, true),
+              Expanded(
+                child: DivineButton(
+                  label: l10n.relaySettingsRemove,
+                  type: DivineButtonType.error,
+                  expanded: true,
+                  onPressed: () => sheetContext.popModalIfMounted(true),
+                ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     ],

--- a/mobile/lib/screens/settings/nip05_settings_screen.dart
+++ b/mobile/lib/screens/settings/nip05_settings_screen.dart
@@ -11,6 +11,7 @@ import 'package:go_router/go_router.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/my_profile/my_profile_bloc.dart';
 import 'package:openvine/blocs/profile_editor/profile_editor_bloc.dart';
+import 'package:openvine/extensions/modal_pop_extension.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/router/route_paths.dart';
@@ -409,27 +410,33 @@ class _Nip05SettingsViewState extends State<Nip05SettingsView> {
             ),
           ),
         ),
-        Padding(
-          padding: const EdgeInsets.fromLTRB(16, 16, 16, 4),
-          child: Row(
-            spacing: 16,
-            children: [
-              Expanded(
-                child: DivineButton(
-                  label: l10n.profileSetupNip05ConfirmCancel,
-                  type: DivineButtonType.secondary,
-                  expanded: true,
-                  onPressed: () => Navigator.of(context).pop(false),
+        // The buttons resolve the Navigator from the sheet's own subtree
+        // rather than from this screen's context: the settings screen can be
+        // rebuilt out from under an open sheet, and a caller context that has
+        // gone defunct leaves both buttons inert.
+        Builder(
+          builder: (sheetContext) => Padding(
+            padding: const EdgeInsets.fromLTRB(16, 16, 16, 4),
+            child: Row(
+              spacing: 16,
+              children: [
+                Expanded(
+                  child: DivineButton(
+                    label: l10n.profileSetupNip05ConfirmCancel,
+                    type: DivineButtonType.secondary,
+                    expanded: true,
+                    onPressed: () => sheetContext.popModalIfMounted(false),
+                  ),
                 ),
-              ),
-              Expanded(
-                child: DivineButton(
-                  label: l10n.profileSetupNip05ConfirmContinue,
-                  expanded: true,
-                  onPressed: () => Navigator.of(context).pop(true),
+                Expanded(
+                  child: DivineButton(
+                    label: l10n.profileSetupNip05ConfirmContinue,
+                    expanded: true,
+                    onPressed: () => sheetContext.popModalIfMounted(true),
+                  ),
                 ),
-              ),
-            ],
+              ],
+            ),
           ),
         ),
       ],

--- a/mobile/lib/screens/user_list_people_screen.dart
+++ b/mobile/lib/screens/user_list_people_screen.dart
@@ -9,6 +9,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:models/models.dart' hide LogCategory;
+import 'package:openvine/extensions/modal_pop_extension.dart';
 import 'package:openvine/features/people_lists/people_lists.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/list_providers.dart';
@@ -265,7 +266,7 @@ class _UserListPeopleViewState extends ConsumerState<_UserListPeopleView>
         ),
         actions: [
           TextButton(
-            onPressed: () => Navigator.of(dialogContext).pop(false),
+            onPressed: () => dialogContext.popModalIfMounted(false),
             child: Text(
               l10n.commonCancel,
               style: VineTheme.labelMediumFont(
@@ -274,7 +275,7 @@ class _UserListPeopleViewState extends ConsumerState<_UserListPeopleView>
             ),
           ),
           TextButton(
-            onPressed: () => Navigator.of(dialogContext).pop(true),
+            onPressed: () => dialogContext.popModalIfMounted(true),
             child: Text(
               l10n.commonDelete,
               style: VineTheme.labelMediumFont(color: VineTheme.error),
@@ -722,7 +723,7 @@ class _PeopleAvatarItem extends ConsumerWidget {
         ),
         actions: [
           TextButton(
-            onPressed: () => Navigator.of(dialogContext).pop(false),
+            onPressed: () => dialogContext.popModalIfMounted(false),
             child: Text(
               l10n.commonCancel,
               style: VineTheme.labelMediumFont(
@@ -731,7 +732,7 @@ class _PeopleAvatarItem extends ConsumerWidget {
             ),
           ),
           TextButton(
-            onPressed: () => Navigator.of(dialogContext).pop(true),
+            onPressed: () => dialogContext.popModalIfMounted(true),
             child: Text(
               l10n.peopleListsRemove,
               style: VineTheme.labelMediumFont(color: VineTheme.error),

--- a/mobile/lib/utils/external_link_launcher.dart
+++ b/mobile/lib/utils/external_link_launcher.dart
@@ -4,6 +4,7 @@
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:openvine/extensions/modal_pop_extension.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/router/universal_link_resolver.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -78,7 +79,7 @@ Future<bool?> _confirmExternalLink(BuildContext context, Uri uri) {
       ),
       actions: [
         TextButton(
-          onPressed: () => Navigator.pop(ctx, false),
+          onPressed: () => ctx.popModalIfMounted(false),
           child: Text(
             ctx.l10n.commonCancel,
             style: VineTheme.bodyMediumFont(
@@ -87,7 +88,7 @@ Future<bool?> _confirmExternalLink(BuildContext context, Uri uri) {
           ),
         ),
         TextButton(
-          onPressed: () => Navigator.pop(ctx, true),
+          onPressed: () => ctx.popModalIfMounted(true),
           child: Text(
             ctx.l10n.messageExternalLinkDialogOpen,
             style: VineTheme.bodyMediumFont(color: VineTheme.primary),

--- a/mobile/lib/widgets/add_to_list_dialog.dart
+++ b/mobile/lib/widgets/add_to_list_dialog.dart
@@ -5,6 +5,7 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:models/models.dart' hide LogCategory;
+import 'package:openvine/extensions/modal_pop_extension.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/services/curated_list_service.dart';
@@ -362,12 +363,12 @@ class _CreateListDialogState extends ConsumerState<CreateListDialog> {
           DivineButton(
             label: context.l10n.commonCancel,
             type: DivineButtonType.link,
-            onPressed: () => Navigator.of(dialogContext).pop(false),
+            onPressed: () => dialogContext.popModalIfMounted(false),
           ),
           DivineButton(
             label: context.l10n.listContinue,
             type: DivineButtonType.link,
-            onPressed: () => Navigator.of(dialogContext).pop(true),
+            onPressed: () => dialogContext.popModalIfMounted(true),
           ),
         ],
       ),

--- a/mobile/lib/widgets/composable_video_grid.dart
+++ b/mobile/lib/widgets/composable_video_grid.dart
@@ -9,6 +9,7 @@ import 'package:flutter/rendering.dart' show ScrollCacheExtent;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
 import 'package:models/models.dart' hide AspectRatio;
+import 'package:openvine/extensions/modal_pop_extension.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/mixins/scroll_pagination_mixin.dart';
 import 'package:openvine/providers/app_providers.dart';
@@ -283,7 +284,7 @@ class _ComposableVideoGridState extends ConsumerState<ComposableVideoGrid>
                     ),
                   ),
                   IconButton(
-                    onPressed: () => Navigator.of(sheetContext).pop(),
+                    onPressed: () => sheetContext.popModalIfMounted(),
                     icon: DivineIcon(
                       icon: DivineIconName.x,
                       color: sheetContext.vineColors.secondaryText,
@@ -323,7 +324,7 @@ class _ComposableVideoGridState extends ConsumerState<ComposableVideoGrid>
                 ),
               ),
               onTap: () {
-                Navigator.of(sheetContext).pop();
+                if (!sheetContext.popModalIfMounted()) return;
                 showEditDialogForVideo(context, video);
               },
             ),
@@ -358,7 +359,7 @@ class _ComposableVideoGridState extends ConsumerState<ComposableVideoGrid>
                 ),
               ),
               onTap: () {
-                Navigator.of(sheetContext).pop();
+                if (!sheetContext.popModalIfMounted()) return;
                 _showDeleteConfirmation(context, video);
               },
             ),

--- a/mobile/lib/widgets/library/drafts_tab.dart
+++ b/mobile/lib/widgets/library/drafts_tab.dart
@@ -10,6 +10,7 @@ import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
 import 'package:openvine/blocs/drafts_library/drafts_library_bloc.dart';
 import 'package:openvine/constants/video_editor_constants.dart';
+import 'package:openvine/extensions/modal_pop_extension.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/models/divine_video_draft.dart';
 import 'package:openvine/providers/video_publish_provider.dart';
@@ -276,7 +277,7 @@ class DraftsTab extends ConsumerWidget {
         ),
         actions: [
           TextButton(
-            onPressed: () => Navigator.of(dialogContext).pop(false),
+            onPressed: () => dialogContext.popModalIfMounted(false),
             child: Text(
               context.l10n.commonCancel,
               style: VineTheme.bodyMediumFont(
@@ -285,7 +286,7 @@ class DraftsTab extends ConsumerWidget {
             ),
           ),
           ElevatedButton(
-            onPressed: () => Navigator.of(dialogContext).pop(true),
+            onPressed: () => dialogContext.popModalIfMounted(true),
             style: ElevatedButton.styleFrom(
               backgroundColor: VineTheme.error,
               foregroundColor: VineTheme.whiteText,

--- a/mobile/lib/widgets/owner_video_delete_confirmation_dialog.dart
+++ b/mobile/lib/widgets/owner_video_delete_confirmation_dialog.dart
@@ -3,6 +3,7 @@
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
+import 'package:openvine/extensions/modal_pop_extension.dart';
 import 'package:openvine/l10n/l10n.dart';
 
 Future<bool> showOwnerVideoDeleteConfirmationDialog(
@@ -22,11 +23,11 @@ Future<bool> showOwnerVideoDeleteConfirmationDialog(
       ),
       actions: [
         TextButton(
-          onPressed: () => Navigator.of(dialogContext).pop(false),
+          onPressed: () => dialogContext.popModalIfMounted(false),
           child: Text(dialogContext.l10n.shareMenuCancel),
         ),
         TextButton(
-          onPressed: () => Navigator.of(dialogContext).pop(true),
+          onPressed: () => dialogContext.popModalIfMounted(true),
           style: TextButton.styleFrom(foregroundColor: VineTheme.error),
           child: Text(dialogContext.l10n.shareMenuDelete),
         ),

--- a/mobile/lib/widgets/video_feed_item/actions/share_action_button.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/share_action_button.dart
@@ -169,7 +169,17 @@ class _UnifiedShareSheetState extends ConsumerState<_UnifiedShareSheet> {
     super.dispose();
   }
 
+  /// Dismisses the share sheet from a context inside it.
+  ///
+  /// Not `popModalIfMounted`: this sheet is dismissed from bloc listeners
+  /// rather than from a button, so it has to survive being reached while
+  /// GoRouter is out of the tree. It shares that helper's mounted guard —
+  /// `canPop` reads an inherited widget and `Navigator.of` walks ancestors,
+  /// and both throw on a context whose route is already gone (#6512).
   void _safePop(BuildContext ctx) {
+    if (!ctx.mounted) {
+      return;
+    }
     try {
       if (ctx.canPop()) {
         ctx.pop();

--- a/mobile/test/extensions/modal_pop_extension_test.dart
+++ b/mobile/test/extensions/modal_pop_extension_test.dart
@@ -1,0 +1,111 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/extensions/modal_pop_extension.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+
+void main() {
+  group('ModalPopExtension', () {
+    /// Opens a dialog and hands back both its future and the callback its
+    /// button would run, so a test can invoke that callback after the route
+    /// is gone — the state a real tap lands in when the tree is rebuilt
+    /// between the pointer-down and the gesture arena resolving.
+    ///
+    /// The dead-route tests below leave `result` alone: tearing the whole tree
+    /// down is a blunter teardown than the route pop the app does, and when
+    /// that future resolves is the route's business rather than the guard's.
+    Future<({Future<Object?> result, bool Function() pop})> openDialog(
+      WidgetTester tester, {
+      required bool Function(BuildContext dialogContext) onPressed,
+    }) async {
+      late bool Function() capturedPop;
+      late BuildContext hostContext;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Builder(
+            builder: (context) {
+              hostContext = context;
+              return const Scaffold(body: SizedBox.shrink());
+            },
+          ),
+        ),
+      );
+
+      final result = showDialog<Object?>(
+        context: hostContext,
+        builder: (dialogContext) {
+          capturedPop = () => onPressed(dialogContext);
+          return const SizedBox.shrink();
+        },
+      );
+      await tester.pumpAndSettle();
+
+      return (result: result, pop: capturedPop);
+    }
+
+    testWidgets('pops the modal route with the result on a live route', (
+      tester,
+    ) async {
+      final dialog = await openDialog(
+        tester,
+        onPressed: (dialogContext) => dialogContext.popModalIfMounted(true),
+      );
+
+      expect(dialog.pop(), isTrue);
+      await tester.pumpAndSettle();
+
+      await expectLater(dialog.result, completion(isTrue));
+    });
+
+    testWidgets('completes with null when no result is given', (tester) async {
+      final dialog = await openDialog(
+        tester,
+        onPressed: (dialogContext) => dialogContext.popModalIfMounted(),
+      );
+
+      expect(dialog.pop(), isTrue);
+      await tester.pumpAndSettle();
+
+      await expectLater(dialog.result, completion(isNull));
+    });
+
+    testWidgets('returns false without throwing once the route is gone', (
+      tester,
+    ) async {
+      final dialog = await openDialog(
+        tester,
+        onPressed: (dialogContext) => dialogContext.popModalIfMounted(true),
+      );
+
+      // Stands in for anything that drops the route while a tap is in flight:
+      // a rebuild above the modal, a redirect, a deep link.
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pumpAndSettle();
+
+      expect(dialog.pop, returnsNormally);
+      expect(dialog.pop(), isFalse);
+    });
+
+    testWidgets('unguarded Navigator.of throws where the guard returns false', (
+      tester,
+    ) async {
+      // Pins the failure this extension exists to prevent: without the mounted
+      // check the same callback walks a defunct element and throws, which
+      // FlutterError.onError files in Crashlytics as a fatal (#6512).
+      final dialog = await openDialog(
+        tester,
+        onPressed: (dialogContext) {
+          Navigator.of(dialogContext).pop(true);
+          return true;
+        },
+      );
+
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pumpAndSettle();
+
+      expect(dialog.pop, throwsFlutterError);
+    });
+  });
+}

--- a/mobile/test/extensions/modal_pop_extension_test.dart
+++ b/mobile/test/extensions/modal_pop_extension_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/extensions/modal_pop_extension.dart';
@@ -43,6 +45,48 @@ void main() {
       await tester.pumpAndSettle();
 
       return (result: result, pop: capturedPop);
+    }
+
+    /// Opens `home -> covered screen -> dialog`, and hands back the dialog's
+    /// own context, so a test can pop twice and see which route the second
+    /// pop takes.
+    Future<BuildContext> openDialogOverScreen(WidgetTester tester) async {
+      late BuildContext hostContext;
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Builder(
+            builder: (context) {
+              hostContext = context;
+              return const Scaffold(body: Text('home'));
+            },
+          ),
+        ),
+      );
+
+      unawaited(
+        Navigator.of(hostContext).push<void>(
+          MaterialPageRoute<void>(
+            builder: (_) => const Scaffold(body: Text('covered screen')),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      late BuildContext dialogContext;
+      unawaited(
+        showDialog<bool>(
+          context: tester.element(find.text('covered screen')),
+          builder: (context) {
+            dialogContext = context;
+            return const SizedBox.shrink();
+          },
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      return dialogContext;
     }
 
     testWidgets('pops the modal route with the result on a live route', (
@@ -106,6 +150,39 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(dialog.pop, throwsFlutterError);
+    });
+
+    testWidgets('refuses a second pop while the modal is still exiting', (
+      tester,
+    ) async {
+      final dialogContext = await openDialogOverScreen(tester);
+
+      expect(dialogContext.popModalIfMounted(true), isTrue);
+      // A modal stays mounted for the length of its exit transition, so the
+      // mounted check alone lets a second tap in this window through.
+      await tester.pump(const Duration(milliseconds: 20));
+
+      expect(dialogContext.popModalIfMounted(true), isFalse);
+      await tester.pumpAndSettle();
+
+      expect(find.text('covered screen'), findsOneWidget);
+    });
+
+    testWidgets('an unguarded second pop takes the route underneath', (
+      tester,
+    ) async {
+      // Pins what the isCurrent check buys: the same second tap, unguarded,
+      // dismisses the screen the modal was covering.
+      final dialogContext = await openDialogOverScreen(tester);
+
+      expect(dialogContext.popModalIfMounted(true), isTrue);
+      await tester.pump(const Duration(milliseconds: 20));
+
+      Navigator.of(dialogContext).pop(true);
+      await tester.pumpAndSettle();
+
+      expect(find.text('covered screen'), findsNothing);
+      expect(find.text('home'), findsOneWidget);
     });
   });
 }

--- a/mobile/test/screens/settings/nip05_settings_screen_test.dart
+++ b/mobile/test/screens/settings/nip05_settings_screen_test.dart
@@ -150,6 +150,23 @@ void main() {
       expect(find.text(l10n.profileSetupNip05AddressLabel), findsOneWidget);
     });
 
+    testWidgets('confirm dialog cancel leaves NIP-05 on divine mode', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildSubject(profile: createProfile()));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text(l10n.profileSetupUseOwnNip05));
+      await tester.pumpAndSettle();
+      expect(find.text(l10n.profileSetupNip05ConfirmTitle), findsOneWidget);
+
+      await tester.tap(find.text(l10n.profileSetupNip05ConfirmCancel));
+      await tester.pumpAndSettle();
+
+      expect(find.text(l10n.profileSetupNip05ConfirmTitle), findsNothing);
+      expect(find.text(l10n.profileSetupNip05AddressLabel), findsNothing);
+    });
+
     testWidgets(
       'toggle off switches from external NIP-05 back to divine mode',
       (

--- a/mobile/test/widgets/owner_video_delete_confirmation_dialog_test.dart
+++ b/mobile/test/widgets/owner_video_delete_confirmation_dialog_test.dart
@@ -1,0 +1,90 @@
+// ABOUTME: Widget tests for showOwnerVideoDeleteConfirmationDialog.
+// ABOUTME: Pins both answers and the no-op the buttons owe a torn-down route.
+
+import 'dart:async';
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/widgets/owner_video_delete_confirmation_dialog.dart';
+
+void main() {
+  group('showOwnerVideoDeleteConfirmationDialog', () {
+    final l10n = lookupAppLocalizations(const Locale('en'));
+
+    Future<Future<bool>> openDialog(WidgetTester tester) async {
+      late BuildContext hostContext;
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          theme: VineTheme.theme,
+          home: Builder(
+            builder: (context) {
+              hostContext = context;
+              return const Scaffold(body: SizedBox.shrink());
+            },
+          ),
+        ),
+      );
+
+      final confirmed = showOwnerVideoDeleteConfirmationDialog(hostContext);
+      await tester.pumpAndSettle();
+      expect(find.text(l10n.shareMenuDeleteConfirmation), findsOneWidget);
+      return confirmed;
+    }
+
+    testWidgets('resolves true when the delete action is tapped', (
+      tester,
+    ) async {
+      final confirmed = await openDialog(tester);
+
+      await tester.tap(find.text(l10n.shareMenuDelete));
+      await tester.pumpAndSettle();
+
+      await expectLater(confirmed, completion(isTrue));
+    });
+
+    testWidgets('resolves false when the cancel action is tapped', (
+      tester,
+    ) async {
+      final confirmed = await openDialog(tester);
+
+      await tester.tap(find.text(l10n.shareMenuCancel));
+      await tester.pumpAndSettle();
+
+      await expectLater(confirmed, completion(isFalse));
+    });
+
+    testWidgets('both actions no-op once their route is torn down', (
+      tester,
+    ) async {
+      // Opened and then deliberately abandoned: the callbacks are the subject
+      // here, not the dialog's future. Tearing the whole tree down is a blunter
+      // teardown than the route pop the app performs, and when the future
+      // resolves under it is the route's business rather than the guard's.
+      unawaited(await openDialog(tester));
+
+      VoidCallback actionFor(String label) => tester
+          .widget<TextButton>(
+            find.ancestor(
+              of: find.text(label),
+              matching: find.byType(TextButton),
+            ),
+          )
+          .onPressed!;
+
+      final cancel = actionFor(l10n.shareMenuCancel);
+      final delete = actionFor(l10n.shareMenuDelete);
+
+      // Stands in for anything that drops the dialog's route while the tap is
+      // in flight — a rebuild above the modal, a redirect, a deep link.
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pumpAndSettle();
+
+      expect(cancel, returnsNormally);
+      expect(delete, returnsNormally);
+    });
+  });
+}


### PR DESCRIPTION
## Description

A dialog or sheet callback closes over the context its builder was handed. That context's element unmounts the moment the route is torn down, and a route can disappear while a tap is still in flight — a rebuild above the modal, a redirect, a deep link. `Navigator.of` then walks a defunct element and throws: `Looking up a deactivated widget's ancestor is unsafe` in debug, a `_state!` null check in release AOT. Either way the pop never happens and the tap silently does nothing, but `FlutterError.onError` files that no-op in Crashlytics as a fatal, where it competes with real crashes in triage.

There is a second way the same tap goes wrong. `Navigator.pop` takes the navigator's *topmost* route rather than the route the calling context belongs to, and a modal stays mounted for the whole of its exit transition. A second tap landing in that window clears any mounted check and pops whatever is underneath — the screen the modal had been covering. No crash, no report, the user just loses the screen they were on.

#6513 fixed one such site with a file-private helper and left the inventory open. Four competing shapes had accumulated across the tree: unguarded pops, inline `if (ctx.mounted)` checks, that helper, and `share_action_button.dart`'s `_safePop`.

**The decision this issue asked for: yes to a shared helper.** `mobile/lib/extensions/modal_pop_extension.dart` adds `BuildContext.popModalIfMounted<T>([T? result])`, now used by all 17 modal call sites. It returns `bool` so a callback that does more than pop can bail for the same reason:

```dart
onTap: () {
  if (!sheetContext.popModalIfMounted()) return;
  openEditor();
},
```

That return value is load-bearing at three sites, and it only *becomes* load-bearing once the guard exists. The grid's edit and delete follow-ups and profile setup's **Publish** were previously short-circuited by the throw itself — `Navigator.of` blew up before the next line ran, so the follow-up never fired. Removing the throw removes that accidental protection, so without the `bool` a tap the user cannot have made would open a phantom edit dialog, or publish a profile nobody confirmed. The explicit bail replaces an exception that was silently doing the job.

### Two checks, not one

`popModalIfMounted` refuses the pop in both of the cases above:

```dart
if (!mounted) return false;                          // route already gone
if (ModalRoute.isCurrentOf(this) != true) return false;  // route already leaving
```

The second check is what makes the helper do what its name says. Without it the guard is honest only about the first failure, and a double tap still dismisses the screen behind the modal. Skipping is safe either way: the route is closed or closing, so the pop was moot, and every confirmation call site here already reads a `null` result as "not confirmed".

`_safePop` stays local rather than folding into the helper: the share sheet is dismissed from bloc listeners rather than from a button, so it has to survive being reached while GoRouter is out of the tree, and it needs `maybePop` rather than `pop`. It gains the same mounted guard, with a comment saying why it does not use the shared helper.

### Two sheets needed more than a guard

`nip05_settings_screen.dart` and `relay_settings_screen.dart`'s remove-confirmation build their sheet bodies eagerly, so the buttons closed over the **caller's** context rather than the sheet's. Guarding alone would have left them permanently inert once the screen rebuilt underneath the open sheet, rather than fixing anything. Both now resolve the Navigator through a `Builder` inside the sheet's own subtree — the same fix `pooled_age_restricted_retry.dart` already carries for #7291, with the reasoning recorded inline at each site.

### Why not `safePop`

The acceptance criteria ask that any shared helper be clearly distinct from `safe_pop_extension.dart`. It solves the opposite problem: a *live* context whose GoRouter back stack is empty, and it navigates to a fallback route. `popModalIfMounted` never navigates anywhere — when the context is defunct it does nothing at all, because the route it would have popped is already gone. The names, the doc comments, and the return types all keep them apart.

### Sites migrated

Beyond the issue's inventory, walking the modal *builder callbacks* in `lib/` turned up six more sites with the same shape, plus one correction:

- `profile_avatar_section.dart` has no pop of its own — the real site is `profile_setup/widgets/image_url_sheet.dart`, migrated instead.
- Not listed in the issue: `relay_settings_screen.dart`, `add_to_list_dialog.dart`, `composable_video_grid.dart`, `pooled_age_restricted_retry.dart`, `external_link_launcher.dart`, and two where the builder parameter shadows `context` (`inbox_view.dart`, `nostr_connect_screen.dart`). The last two are why a name-based grep alone would have missed them.

**Related Issue:** Closes #6526

## Out of Scope

- **Modal content that lives in its own widget.** This PR covers pops made through a context a modal *builder callback* was handed, or through the `State` of a widget that callback builds directly — that is where "route gone ⇒ pop is moot" holds cleanly. Where a sheet or dialog body was extracted into its own widget, the pop goes through that widget's own `build` context instead: same hazard, different shape, not touched here. 63 files in `lib/` still show a modal and pop unguarded — among them `unfollow_confirmation_sheet.dart`, `badge_delete_confirmation_sheet.dart`, `delete_account_dialog.dart`, `video_editor_main_actions_sheet.dart`, `user_picker_sheet.dart` and `upload_failure_sheet.dart` — out of 127 files that pop unguarded in total.

- **Screen-level and `State`-level pops.** Those fail differently, because the route in question is the screen itself, and are not blanket-guarded here.
- **A ratchet to keep new unguarded modal pops out.** Nothing mechanically prevents the next dialog from reintroducing the shape. Worth considering as a follow-up in the same family as the existing raw-dialog ceiling, but it is a separate piece of work.

## Verification

- `flutter analyze lib test integration_test` — no issues.
- `dart format --set-exit-if-changed` on all 21 touched files — clean.
- All 15 affected suites plus the two new ones — 288 passed, 5 skipped (pre-existing), 0 failed.
- Ratchets run locally: `raw_dialog`, `l10n_delegates`, `test_unit_structure`, `untested_services`, `raw_colors`, `raw_textstyle`, `material_button`, `layer_direction`, `post_close_emit` — all pass.
- New: `test/extensions/modal_pop_extension_test.dart` (6 tests) covers live-route pop with and without a result, the dead-route no-op, the second pop refused mid-exit-transition, and two control tests pinning the failures the guards prevent — unguarded `Navigator.of` *throws* exactly where the mounted check returns `false`, and an unguarded second pop takes the route underneath. The suite fails for the real reason if either guard is removed.
- New: `test/widgets/owner_video_delete_confirmation_dialog_test.dart` gives a previously untested shared dialog both answers plus a dead-route test, in the shape #6513 established.
- Added a cancel-polarity test to `nip05_settings_screen_test.dart`; the Continue path was already covered, so both sides of the `Builder` restructure are now pinned.

The dead-route tests deliberately do not assert the dialog's own future. `pumpWidget(SizedBox.shrink())` tears the tree down harder than the route pop the app performs, and when the future resolves under that is the route's business rather than the guard's — asserting it hangs. #6513's regression test made the same call.

Verified by hand on a real Samsung Galaxy: the curated-list delete dialog, the relay add/remove sheets, and the NIP-05 confirm sheet — the three that carry the structural changes — plus a double tap on a dismissing dialog, which no longer takes the screen behind it with it.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore


