### PR TITLE
ci(ios): let every Shorebird build reach internal testers without entering review

### DIFF
--- a/.github/scripts/tests/test_codemagic_shorebird_config.py
+++ b/.github/scripts/tests/test_codemagic_shorebird_config.py
@@ -276,6 +276,27 @@ class CodemagicShorebirdConfigTest(unittest.TestCase):
         self.assertNotRegex(self.contents, r"(?m)^\s+flutter build appbundle ")
         self.assertNotRegex(self.contents, r"(?m)^\s+flutter build ipa ")
 
+    def test_ios_release_uploads_without_automatic_review_submission(self) -> None:
+        workflow = self._workflow_block("ios-build")
+
+        self.assertIn("app_store_connect:", workflow)
+        self.assertIn("submit_to_testflight: false", workflow)
+        self.assertIn("submit_to_app_store: false", workflow)
+        self.assertNotIn("beta_groups:", workflow)
+
+        self.assertRegex(
+            self.shorebird_doc_contents,
+            r"automatic internal TestFlight\s+distribution",
+        )
+        self.assertRegex(
+            self.shorebird_doc_contents,
+            r"manual external TestFlight promotion",
+        )
+        self.assertRegex(
+            self.shorebird_doc_contents,
+            r"manual\s+App Store promotion",
+        )
+
     def test_release_jobs_never_materialize_patch_private_key(self) -> None:
         self.assertIn("*write_shorebird_public_key", self._workflow_block("ios-build"))
         self.assertIn("*write_shorebird_public_key", self._workflow_block("android-build"))

--- a/.github/scripts/tests/test_codemagic_shorebird_config.py
+++ b/.github/scripts/tests/test_codemagic_shorebird_config.py
@@ -282,7 +282,6 @@ class CodemagicShorebirdConfigTest(unittest.TestCase):
         self.assertIn("app_store_connect:", workflow)
         self.assertIn("submit_to_testflight: false", workflow)
         self.assertIn("submit_to_app_store: false", workflow)
-        self.assertNotIn("beta_groups:", workflow)
 
         self.assertRegex(
             self.shorebird_doc_contents,

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Signed store builds run on Codemagic (`codemagic.yaml`); GitHub Actions (`.githu
 
 Codemagic workflows and their publishing targets:
 
-- iOS build — `flutter build ipa --release`, published to App Store Connect (TestFlight / App Store); dSYMs uploaded to Firebase Crashlytics.
+- iOS build — `shorebird release ios`, uploaded to App Store Connect without automatic review submission; dSYMs uploaded to Firebase Crashlytics.
 - Android build — `flutter build appbundle --release` (and split-per-ABI APKs), published to Google Play.
 - macOS build — packaged as a DMG and published to a GitHub Release.
 - E2E smoke tests — Maestro flows on iOS Simulator and Android emulator.

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -963,13 +963,9 @@ workflows:
     publishing:
       app_store_connect:
         auth: integration
-        submit_to_testflight: true
+        # Upload only; App Store Connect owns internal distribution and review gates.
+        submit_to_testflight: false
         submit_to_app_store: false
-        # Auto-distribute internal builds to assignable TestFlight groups.
-        beta_groups:
-          - "AOS"
-          - "GW"
-          - "rabblelabs"
 
   ios-simulator-build:
     name: iOS Simulator Build

--- a/mobile/docs/SHOREBIRD_CODE_PUSH.md
+++ b/mobile/docs/SHOREBIRD_CODE_PUSH.md
@@ -116,9 +116,15 @@ App Store version train.
 iOS publishing deliberately stops after uploading the Shorebird IPA to App
 Store Connect (`submit_to_testflight: false`, `submit_to_app_store: false`).
 App Store Connect, not Codemagic, provides automatic internal TestFlight
-distribution: enable **Automatic Distribution** on an internal-only tester
-group so every processed build is available there without Beta App Review.
-Do not put external testers in that group.
+distribution. This depends on configuration outside this repository: enable
+**Automatic Distribution** on every internal-only tester group that should
+receive each build without Beta App Review. Do not put external testers in
+those groups.
+
+A green Codemagic build confirms the IPA upload, not successful App Store
+Connect processing or tester distribution. After each iOS build, confirm the
+build finishes processing and reaches **Ready to Test**, then verify an internal
+tester can see it before treating internal delivery as complete.
 
 After internal testing passes, perform a manual external TestFlight promotion
 of the same build in App Store Connect: add it to the external groups and submit

--- a/mobile/docs/SHOREBIRD_CODE_PUSH.md
+++ b/mobile/docs/SHOREBIRD_CODE_PUSH.md
@@ -113,9 +113,21 @@ version and refuses a candidate that is equal or lower before Shorebird builds
 or records a release. Increasing only the build number cannot reopen a closed
 App Store version train.
 
-Publishing behaviour is unchanged: iOS stops at TestFlight
-(`submit_to_app_store: false`, internal groups), Android uploads to Play as a
-draft. Promotion to production stays manual in both stores.
+iOS publishing deliberately stops after uploading the Shorebird IPA to App
+Store Connect (`submit_to_testflight: false`, `submit_to_app_store: false`).
+App Store Connect, not Codemagic, provides automatic internal TestFlight
+distribution: enable **Automatic Distribution** on an internal-only tester
+group so every processed build is available there without Beta App Review.
+Do not put external testers in that group.
+
+After internal testing passes, perform a manual external TestFlight promotion
+of the same build in App Store Connect: add it to the external groups and submit
+it for Beta App Review. After the full external cohort passes, perform a manual
+App Store promotion by selecting that exact build for the marketing version and
+submitting it for App Store Review. Do not rebuild between those gates; the
+binary reviewed for public release must be the Shorebird binary exercised by
+both tester cohorts. Android continues to upload to Play as a draft, with
+promotion to production remaining manual.
 
 Release commands pass `--public-key-path`, so every new store binary only
 accepts signed Shorebird patches. A release built without the public key cannot


### PR DESCRIPTION
Closes #7803

Every iOS candidate should reach internal TestFlight testers automatically, while external TestFlight and public App Store promotion remain deliberate gates. The current Codemagic publisher automatically creates a Beta App Review submission, so a build is marked failed whenever another build from the same version train is already under review—even though its Shorebird release, provenance, upload, processing, and group assignment succeeded.

This changes App Store Connect publishing to upload-only: both automatic TestFlight review submission and automatic App Store submission are disabled, and Codemagic no longer assigns beta groups. App Store Connect Automatic Distribution on the internal-only groups becomes the single automatic internal path. After internal validation, an operator promotes the same binary to external TestFlight and, after the external cohort passes, selects that exact binary for public App Store review.

This does not change the build artifact: every store-bound IPA is still produced by `shorebird release ios`, signed for patches, and recorded in private provenance. It does not submit anything publicly, change Android publishing, or alter patch promotion.

Operational requirements:

- Enable Automatic Distribution on every internal-only TestFlight group that should receive each build; external testers must remain in separate groups.
- After each green `ios-build`, confirm the build finishes processing, reaches Ready to Test, and is visible to an internal tester. Codemagic's upload result alone does not verify App Store Connect processing or distribution.

Verification:

- 25 focused Shorebird/Codemagic configuration tests
- 50 complete CI configuration tests
- Codemagic variable-group guard
- Codex configuration checks
- YAML parse regression coverage
- Pre-push conflict guard