### PR TITLE
fix(notifications): stop notifications about another creator's video from opening nothing

### DIFF
--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -700,7 +700,6 @@ class NotificationRepository {
                       : _recipientScopedVideoAddressableId(
                           dTag: null,
                           video: video,
-                          rootEventPubkey: null,
                         )),
             );
           }(),
@@ -1605,15 +1604,6 @@ class NotificationRepository {
         eventIds.add(referencedEventId);
       }
 
-      // Ensure rootEventId is prefetched when it might be used as the anchor
-      // (e.g., for comments when referencedEventId is missing). Fixes #6369.
-      final rootEventId = notification.rootEventId;
-      if (rootEventId != null &&
-          rootEventId.isNotEmpty &&
-          _isEventId(rootEventId)) {
-        eventIds.add(rootEventId);
-      }
-
       final kind = _mapNotificationKind(notification);
       if (!_isVideoAnchoredNotification(kind, notification)) continue;
       final anchorEventId = _videoAnchorEventId(kind, notification);
@@ -1735,7 +1725,13 @@ class NotificationRepository {
           : _recipientScopedVideoAddressableId(
               dTag: dTag,
               video: video,
-              rootEventPubkey: group.first.rootEventPubkey,
+              // The payload's root author only describes the anchored video
+              // when the anchor is the thread root itself — not for a
+              // comment/like on the user's own video reply in someone
+              // else's thread.
+              rootEventPubkey: entry.key.eventId == group.first.rootEventId
+                  ? group.first.rootEventPubkey
+                  : null,
             );
       // Normal video rows prefer payload media because it is stable after
       // metadata updates. Video mentions prefer the resolved source video, and
@@ -2046,10 +2042,14 @@ class NotificationRepository {
   /// `referenced_video` block disagreeing with `referenced_event_id` cannot
   /// build a mismatched route.
   ///
-  /// When [rootEventPubkey] is provided from the API response and indicates a
-  /// different owner than the user, avoids synthesizing a recipient-scoped
-  /// coordinate. Fixes #6369 by preventing misattributed routes when ownership
-  /// checks pass but root metadata reveals a different creator.
+  /// [rootEventPubkey] is the payload's root-video author. It is evidence
+  /// about the anchored video only when the anchor IS the thread root — a
+  /// comment with an empty `referenced_event_id`, or a like/repost/list-add
+  /// of the root video itself. Callers pass null otherwise: for a comment on
+  /// the user's own video *reply* inside someone else's thread, the root
+  /// author is the other creator while the anchored reply still belongs to
+  /// the user, and gating on the payload there would kill the legitimate
+  /// stable route (#4730) that #6369 must not regress.
   String? _recipientScopedVideoAddressableId({
     required String? dTag,
     required VideoStats? video,
@@ -2060,9 +2060,13 @@ class NotificationRepository {
     // _groupVideoAnchored (those are reclassified to actor rows, #4920).
     if (video != null && video.pubkey != _userPubkey) return null;
 
-    // If the API response indicates the root event has a different owner than
-    // the user, don't synthesize a recipient-scoped coordinate. Fixes #6369.
-    if (rootEventPubkey != null &&
+    // Payload fallback for #6369: the anchor is the thread root, metadata
+    // could not resolve its owner (transient miss), and the payload's root
+    // author is someone else — minting `<userPubkey>:<d-tag>` would route to
+    // a video that does not exist. Resolved metadata wins over the payload
+    // (#6805), so this only fires on a metadata miss.
+    if (video == null &&
+        rootEventPubkey != null &&
         rootEventPubkey.isNotEmpty &&
         rootEventPubkey != _userPubkey) {
       return null;
@@ -2500,10 +2504,15 @@ class NotificationRepository {
     if (addressableId != null) {
       return addressableId;
     }
+    // The payload's root author only describes the added video when the
+    // anchor is the thread root itself (no distinct `referenced_event_id`).
+    final anchorIsRoot =
+        _nonEmpty(notification.referencedEventId) == null ||
+        notification.referencedEventId == notification.rootEventId;
     return _recipientScopedVideoAddressableId(
       dTag: dTag,
       video: video,
-      rootEventPubkey: notification.rootEventPubkey,
+      rootEventPubkey: anchorIsRoot ? notification.rootEventPubkey : null,
     );
   }
 

--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -1725,13 +1725,10 @@ class NotificationRepository {
           : _recipientScopedVideoAddressableId(
               dTag: dTag,
               video: video,
-              // The payload's root author only describes the anchored video
-              // when the anchor is the thread root itself — not for a
-              // comment/like on the user's own video reply in someone
-              // else's thread.
-              rootEventPubkey: entry.key.eventId == group.first.rootEventId
-                  ? group.first.rootEventPubkey
-                  : null,
+              rootEventPubkey: _groupRootEventPubkey(
+                group,
+                entry.key.eventId,
+              ),
             );
       // Normal video rows prefer payload media because it is stable after
       // metadata updates. Video mentions prefer the resolved source video, and
@@ -2076,6 +2073,35 @@ class NotificationRepository {
     if (resolvedDTag == null) return null;
     return '${NIP71VideoKinds.addressableShortVideo}'
         ':$_userPubkey:$resolvedDTag';
+  }
+
+  /// The payload's root-video author for [anchorEventId], derived across the
+  /// whole group instead of sampled from one member: notifications sharing an
+  /// anchor can disagree — a transient Funnelcake gap can leave the newest
+  /// member's `root_event_pubkey` empty while an older member carries it — and
+  /// a single sampled member would make the #6369 guard order-dependent.
+  ///
+  /// Only a member whose thread root IS the anchor describes the anchored
+  /// video's root author: for a comment on the user's own video *reply*
+  /// inside someone else's thread, the root author is the other creator while
+  /// the anchored reply still belongs to the user, and gating on the payload
+  /// there would kill the legitimate stable route (#4730) that #6369 must not
+  /// regress. A foreign author from any root-anchored member wins over the
+  /// user's own — minting `<userPubkey>:<d-tag>` on contradictory ownership
+  /// evidence is the #6369 failure.
+  String? _groupRootEventPubkey(
+    List<RelayNotification> group,
+    String anchorEventId,
+  ) {
+    String? ownAuthor;
+    for (final n in group) {
+      if (n.rootEventId != anchorEventId) continue;
+      final author = _nonEmpty(n.rootEventPubkey);
+      if (author == null) continue;
+      if (author != _userPubkey) return author;
+      ownAuthor ??= author;
+    }
+    return ownAuthor;
   }
 
   /// Returns the full source-video coordinate for video-sourced mention rows.

--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -700,6 +700,7 @@ class NotificationRepository {
                       : _recipientScopedVideoAddressableId(
                           dTag: null,
                           video: video,
+                          rootEventPubkey: null,
                         )),
             );
           }(),
@@ -1604,6 +1605,15 @@ class NotificationRepository {
         eventIds.add(referencedEventId);
       }
 
+      // Ensure rootEventId is prefetched when it might be used as the anchor
+      // (e.g., for comments when referencedEventId is missing). Fixes #6369.
+      final rootEventId = notification.rootEventId;
+      if (rootEventId != null &&
+          rootEventId.isNotEmpty &&
+          _isEventId(rootEventId)) {
+        eventIds.add(rootEventId);
+      }
+
       final kind = _mapNotificationKind(notification);
       if (!_isVideoAnchoredNotification(kind, notification)) continue;
       final anchorEventId = _videoAnchorEventId(kind, notification);
@@ -1722,7 +1732,11 @@ class NotificationRepository {
           ? trustedRootAddressableId ?? _sourceVideoAddressableId(video: video)
           : isListAdd
           ? _listAddVideoAddressableId(group.first, dTag: dTag, video: video)
-          : _recipientScopedVideoAddressableId(dTag: dTag, video: video);
+          : _recipientScopedVideoAddressableId(
+          dTag: dTag,
+          video: video,
+          rootEventPubkey: group.first.rootEventPubkey,
+        );
       // Normal video rows prefer payload media because it is stable after
       // metadata updates. Video mentions prefer the resolved source video, and
       // only accept payload media when the root coordinate was trusted.
@@ -2031,14 +2045,29 @@ class NotificationRepository {
   /// Prefers the authoritative `VideoStats` d-tag over the payload [dTag] so a
   /// `referenced_video` block disagreeing with `referenced_event_id` cannot
   /// build a mismatched route.
+  ///
+  /// When [rootEventPubkey] is provided from the API response and indicates a
+  /// different owner than the user, avoids synthesizing a recipient-scoped
+  /// coordinate. Fixes #6369 by preventing misattributed routes when ownership
+  /// checks pass but root metadata reveals a different creator.
   String? _recipientScopedVideoAddressableId({
     required String? dTag,
     required VideoStats? video,
+    String? rootEventPubkey,
   }) {
     // Defensive local invariant: metadata that resolves and names a different
     // owner never yields a recipient-scoped route. Unreachable via
     // _groupVideoAnchored (those are reclassified to actor rows, #4920).
     if (video != null && video.pubkey != _userPubkey) return null;
+
+    // If the API response indicates the root event has a different owner than
+    // the user, don't synthesize a recipient-scoped coordinate. Fixes #6369.
+    if (rootEventPubkey != null &&
+        rootEventPubkey.isNotEmpty &&
+        rootEventPubkey != _userPubkey) {
+      return null;
+    }
+
     final resolvedDTag = _nonEmpty(video?.dTag) ?? _nonEmpty(dTag);
     if (resolvedDTag == null) return null;
     return '${NIP71VideoKinds.addressableShortVideo}'
@@ -2471,7 +2500,11 @@ class NotificationRepository {
     if (addressableId != null) {
       return addressableId;
     }
-    return _recipientScopedVideoAddressableId(dTag: dTag, video: video);
+    return _recipientScopedVideoAddressableId(
+      dTag: dTag,
+      video: video,
+      rootEventPubkey: notification.rootEventPubkey,
+    );
   }
 
   String? _trustedListAddRootAddressableId(RelayNotification notification) {

--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -1718,17 +1718,23 @@ class NotificationRepository {
       // creator's video under "mentioned you".
       final trustsRootPayload =
           !isVideoMention || trustedRootAddressableId != null;
+      final groupRootEventPubkey = _groupRootEventPubkey(
+        group,
+        entry.key.eventId,
+      );
       final addressableId = isVideoMention
           ? trustedRootAddressableId ?? _sourceVideoAddressableId(video: video)
           : isListAdd
-          ? _listAddVideoAddressableId(group.first, dTag: dTag, video: video)
+          ? _listAddVideoAddressableId(
+              group.first,
+              dTag: dTag,
+              video: video,
+              rootEventPubkey: groupRootEventPubkey,
+            )
           : _recipientScopedVideoAddressableId(
               dTag: dTag,
               video: video,
-              rootEventPubkey: _groupRootEventPubkey(
-                group,
-                entry.key.eventId,
-              ),
+              rootEventPubkey: groupRootEventPubkey,
             );
       // Normal video rows prefer payload media because it is stable after
       // metadata updates. Video mentions prefer the resolved source video, and
@@ -2521,24 +2527,27 @@ class NotificationRepository {
     return n.referencedEventId;
   }
 
+  /// [rootEventPubkey] is the group-derived root author from
+  /// [_groupRootEventPubkey], which already restricts the evidence to members
+  /// whose thread root IS the anchor. Deriving it across the group rather than
+  /// sampling [notification] matters for the same reason it does for comments:
+  /// a list-add group shares an anchor across several adders, and a transient
+  /// Funnelcake gap can leave the newest member's `root_event_pubkey` empty
+  /// while an older member carries the foreign one.
   String? _listAddVideoAddressableId(
     RelayNotification notification, {
     required String? dTag,
     required VideoStats? video,
+    String? rootEventPubkey,
   }) {
     final addressableId = _trustedListAddRootAddressableId(notification);
     if (addressableId != null) {
       return addressableId;
     }
-    // The payload's root author only describes the added video when the
-    // anchor is the thread root itself (no distinct `referenced_event_id`).
-    final anchorIsRoot =
-        _nonEmpty(notification.referencedEventId) == null ||
-        notification.referencedEventId == notification.rootEventId;
     return _recipientScopedVideoAddressableId(
       dTag: dTag,
       video: video,
-      rootEventPubkey: anchorIsRoot ? notification.rootEventPubkey : null,
+      rootEventPubkey: rootEventPubkey,
     );
   }
 

--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -1733,10 +1733,10 @@ class NotificationRepository {
           : isListAdd
           ? _listAddVideoAddressableId(group.first, dTag: dTag, video: video)
           : _recipientScopedVideoAddressableId(
-          dTag: dTag,
-          video: video,
-          rootEventPubkey: group.first.rootEventPubkey,
-        );
+              dTag: dTag,
+              video: video,
+              rootEventPubkey: group.first.rootEventPubkey,
+            );
       // Normal video rows prefer payload media because it is stable after
       // metadata updates. Video mentions prefer the resolved source video, and
       // only accept payload media when the root coordinate was trusted.

--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -1247,6 +1247,105 @@ void main() {
         verify(() => funnelcakeApiClient.getVideoStats('video_root')).called(1);
       });
 
+      test("comment on another creator's root video leaves the addressable "
+          'id null when metadata misses (#6369)', () async {
+        // Transient metadata miss (default getVideoStats stub throws) plus a
+        // payload root author naming another creator: synthesizing
+        // `userPubkey:<d-tag>` would route to a video that does not exist.
+        stubNotifications([
+          makeNotification(
+            id: 'c-foreign-root',
+            sourcePubkey: 'pub_a',
+            sourceKind: 1111,
+            notificationType: 'comment',
+            referencedEventId: '',
+            rootEventId: 'foreign_root',
+            rootEventPubkey: 'other_creator',
+            referencedDTag: 'foreign-vine',
+            content: 'nice one',
+          ),
+        ]);
+        stubProfiles({'pub_a': makeProfile('pub_a', displayName: 'Alice')});
+
+        final page = await repository.getNotifications();
+
+        expect(page.items, hasLength(1));
+        final item = page.items.single as VideoNotification;
+        expect(item.type, equals(NotificationKind.comment));
+        expect(item.videoAddressableId, isNull);
+        expect(item.videoEventId, equals('foreign_root'));
+      });
+
+      test(
+        "comment on the user's own video reply keeps the recipient-scoped "
+        'route when the thread root belongs to another creator',
+        () async {
+          // The payload root author describes the thread root, not the
+          // anchored reply video — the #6369 guard must not fire here, or
+          // every comment on a video reply loses its stable route (#4730).
+          stubNotifications([
+            makeNotification(
+              id: 'c-own-reply',
+              sourcePubkey: 'pub_a',
+              sourceKind: 1111,
+              notificationType: 'comment',
+              referencedEventId: 'reply_video_event',
+              rootEventId: 'foreign_thread_root',
+              rootEventPubkey: 'other_creator',
+              referencedDTag: 'reply-video-dtag',
+              content: 'great reply',
+            ),
+          ]);
+          stubProfiles({'pub_a': makeProfile('pub_a', displayName: 'Alice')});
+
+          final page = await repository.getNotifications();
+
+          expect(page.items, hasLength(1));
+          final item = page.items.single as VideoNotification;
+          expect(item.type, equals(NotificationKind.comment));
+          expect(
+            item.videoAddressableId,
+            equals(
+              '${NIP71VideoKinds.addressableShortVideo}:'
+              '$userPubkey:reply-video-dtag',
+            ),
+          );
+        },
+      );
+
+      test('resolved metadata wins over a contradictory payload root author '
+          '(#6805)', () async {
+        // Metadata resolves the anchored root video as the user's own; a
+        // stale payload `root_event_pubkey` must not override it.
+        stubNotifications([
+          makeNotification(
+            id: 'c-contradictory',
+            sourcePubkey: 'pub_a',
+            sourceKind: 1111,
+            notificationType: 'comment',
+            referencedEventId: '',
+            rootEventId: 'video_root',
+            rootEventPubkey: 'other_creator',
+            referencedDTag: 'vine-id',
+            content: 'nice one',
+          ),
+        ]);
+        stubProfiles({'pub_a': makeProfile('pub_a', displayName: 'Alice')});
+        stubVideoStats('video_root', makeVideoStats(id: 'video_root'));
+
+        final page = await repository.getNotifications();
+
+        expect(page.items, hasLength(1));
+        final item = page.items.single as VideoNotification;
+        expect(
+          item.videoAddressableId,
+          equals(
+            '${NIP71VideoKinds.addressableShortVideo}:'
+            '$userPubkey:d_video_root',
+          ),
+        );
+      });
+
       test(
         'comment on a video reply anchors to the referenced video, not root',
         () async {
@@ -1798,6 +1897,78 @@ void main() {
           expect(item.listTitle, equals('Literature'));
           expect(item.listCoordinate, equals(listCoordinate));
           verifyNever(() => funnelcakeApiClient.getVideoStats(videoCoordinate));
+        },
+      );
+
+      test(
+        "list_add of another creator's root video leaves the addressable id "
+        'null when metadata misses (#6369)',
+        () async {
+          // Transient metadata miss plus a payload root author naming another
+          // creator: a recipient-scoped coordinate would route to a video
+          // that does not exist.
+          stubNotifications([
+            makeNotification(
+              id: 'list_add_foreign_root',
+              sourceEventId: 'list_evt_foreign_root',
+              sourceKind: 30005,
+              notificationType: 'list_add',
+              referencedEventId: null,
+              rootEventId: 'foreign_root',
+              rootEventPubkey: 'other_creator',
+              referencedDTag: 'foreign-vine',
+              listTitle: 'Literature',
+              listCoordinate: '30005:pubkey_alice:literature',
+            ),
+          ]);
+          stubProfiles({
+            'pubkey_alice': makeProfile('pubkey_alice', displayName: 'Alice'),
+          });
+
+          final page = await repository.getNotifications();
+
+          final item = page.items.single as VideoNotification;
+          expect(item.type, equals(NotificationKind.listAdd));
+          expect(item.videoEventId, equals('foreign_root'));
+          expect(item.videoAddressableId, isNull);
+        },
+      );
+
+      test(
+        "list_add of the user's own video reply keeps the recipient-scoped "
+        'route when the thread root belongs to another creator',
+        () async {
+          // The payload root author describes the thread root, not the added
+          // reply video — the #6369 guard must not fire here.
+          stubNotifications([
+            makeNotification(
+              id: 'list_add_own_reply',
+              sourceEventId: 'list_evt_own_reply',
+              sourceKind: 30005,
+              notificationType: 'list_add',
+              referencedEventId: 'reply_video_event',
+              rootEventId: 'foreign_thread_root',
+              rootEventPubkey: 'other_creator',
+              referencedDTag: 'reply-video-dtag',
+              listTitle: 'Literature',
+              listCoordinate: '30005:pubkey_alice:literature',
+            ),
+          ]);
+          stubProfiles({
+            'pubkey_alice': makeProfile('pubkey_alice', displayName: 'Alice'),
+          });
+
+          final page = await repository.getNotifications();
+
+          final item = page.items.single as VideoNotification;
+          expect(item.type, equals(NotificationKind.listAdd));
+          expect(
+            item.videoAddressableId,
+            equals(
+              '${NIP71VideoKinds.addressableShortVideo}:'
+              '$userPubkey:reply-video-dtag',
+            ),
+          );
         },
       );
 

--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -1277,6 +1277,152 @@ void main() {
       });
 
       test(
+        'comment group stays guarded when the newest member omits '
+        'root_event_pubkey but an older member carries a foreign one (#6369)',
+        () async {
+          // Notifications sharing an anchor can disagree: a transient
+          // Funnelcake gap leaves the newest member's root_event_pubkey empty
+          // while an older member carries it. Sampling only the newest member
+          // would miss the foreign root author and mint the #6369 route.
+          stubNotifications([
+            makeNotification(
+              id: 'c-newest-gap',
+              sourcePubkey: 'pub_a',
+              sourceKind: 1111,
+              notificationType: 'comment',
+              referencedEventId: '',
+              rootEventId: 'foreign_root',
+              rootEventPubkey: '',
+              referencedDTag: 'foreign-vine',
+              content: 'newest',
+              createdAt: DateTime(2025, 1, 2),
+            ),
+            makeNotification(
+              id: 'c-older-evidence',
+              sourcePubkey: 'pub_b',
+              sourceKind: 1111,
+              notificationType: 'comment',
+              referencedEventId: '',
+              rootEventId: 'foreign_root',
+              rootEventPubkey: 'other_creator',
+              referencedDTag: 'foreign-vine',
+              content: 'older',
+              createdAt: DateTime(2025),
+            ),
+          ]);
+          stubProfiles({
+            'pub_a': makeProfile('pub_a', displayName: 'Alice'),
+            'pub_b': makeProfile('pub_b', displayName: 'Bob'),
+          });
+
+          final page = await repository.getNotifications();
+
+          expect(page.items, hasLength(1));
+          final item = page.items.single as VideoNotification;
+          expect(item.type, equals(NotificationKind.comment));
+          expect(item.videoAddressableId, isNull);
+          expect(item.videoEventId, equals('foreign_root'));
+        },
+      );
+
+      test(
+        'comment group stays guarded when the newest member names the user '
+        'but an older member names another creator (#6369)',
+        () async {
+          // Contradictory payloads on a metadata miss: any root-anchored
+          // member carrying a foreign root author suppresses the route —
+          // minting `userPubkey:<d-tag>` on contradictory ownership evidence
+          // is the #6369 failure.
+          stubNotifications([
+            makeNotification(
+              id: 'c-newest-own',
+              sourcePubkey: 'pub_a',
+              sourceKind: 1111,
+              notificationType: 'comment',
+              referencedEventId: '',
+              rootEventId: 'disputed_root',
+              rootEventPubkey: userPubkey,
+              referencedDTag: 'disputed-vine',
+              content: 'newest',
+              createdAt: DateTime(2025, 1, 2),
+            ),
+            makeNotification(
+              id: 'c-older-foreign',
+              sourcePubkey: 'pub_b',
+              sourceKind: 1111,
+              notificationType: 'comment',
+              referencedEventId: '',
+              rootEventId: 'disputed_root',
+              rootEventPubkey: 'other_creator',
+              referencedDTag: 'disputed-vine',
+              content: 'older',
+              createdAt: DateTime(2025),
+            ),
+          ]);
+          stubProfiles({
+            'pub_a': makeProfile('pub_a', displayName: 'Alice'),
+            'pub_b': makeProfile('pub_b', displayName: 'Bob'),
+          });
+
+          final page = await repository.getNotifications();
+
+          expect(page.items, hasLength(1));
+          final item = page.items.single as VideoNotification;
+          expect(item.videoAddressableId, isNull);
+          expect(item.videoEventId, equals('disputed_root'));
+        },
+      );
+
+      test(
+        'comment group without root-author evidence still mints the '
+        'recipient-scoped route (#6369 guard does not over-fire)',
+        () async {
+          // No member carries a root author, so there is no foreign evidence
+          // to act on — the #4730 stable route must survive.
+          stubNotifications([
+            makeNotification(
+              id: 'c-newest-no-evidence',
+              sourcePubkey: 'pub_a',
+              sourceKind: 1111,
+              notificationType: 'comment',
+              referencedEventId: '',
+              rootEventId: 'video_root',
+              referencedDTag: 'vine-id',
+              content: 'newest',
+              createdAt: DateTime(2025, 1, 2),
+            ),
+            makeNotification(
+              id: 'c-older-no-evidence',
+              sourcePubkey: 'pub_b',
+              sourceKind: 1111,
+              notificationType: 'comment',
+              referencedEventId: '',
+              rootEventId: 'video_root',
+              referencedDTag: 'vine-id',
+              content: 'older',
+              createdAt: DateTime(2025),
+            ),
+          ]);
+          stubProfiles({
+            'pub_a': makeProfile('pub_a', displayName: 'Alice'),
+            'pub_b': makeProfile('pub_b', displayName: 'Bob'),
+          });
+
+          final page = await repository.getNotifications();
+
+          expect(page.items, hasLength(1));
+          final item = page.items.single as VideoNotification;
+          expect(
+            item.videoAddressableId,
+            equals(
+              '${NIP71VideoKinds.addressableShortVideo}:'
+              '$userPubkey:vine-id',
+            ),
+          );
+        },
+      );
+
+      test(
         "comment on the user's own video reply keeps the recipient-scoped "
         'route when the thread root belongs to another creator',
         () async {

--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -2081,6 +2081,58 @@ void main() {
       );
 
       test(
+        'list_add group stays guarded when the newest member omits '
+        'root_event_pubkey but an older member carries a foreign one (#6369)',
+        () async {
+          // Same transient Funnelcake gap the comment path guards against:
+          // list_add notifications sharing an anchor can disagree, and the
+          // newest member is the one the row samples. Deriving the root author
+          // across the group is what keeps the guard order-independent.
+          stubNotifications([
+            makeNotification(
+              id: 'list_add_newest_gap',
+              sourcePubkey: 'pub_a',
+              sourceEventId: 'list_evt_newest_gap',
+              sourceKind: 30005,
+              notificationType: 'list_add',
+              referencedEventId: null,
+              rootEventId: 'foreign_root',
+              rootEventPubkey: '',
+              referencedDTag: 'foreign-vine',
+              listTitle: 'Literature',
+              listCoordinate: '30005:pubkey_alice:literature',
+              createdAt: DateTime(2025, 1, 2),
+            ),
+            makeNotification(
+              id: 'list_add_older_evidence',
+              sourcePubkey: 'pub_b',
+              sourceEventId: 'list_evt_older_evidence',
+              sourceKind: 30005,
+              notificationType: 'list_add',
+              referencedEventId: null,
+              rootEventId: 'foreign_root',
+              rootEventPubkey: 'other_creator',
+              referencedDTag: 'foreign-vine',
+              listTitle: 'Literature',
+              listCoordinate: '30005:pubkey_alice:literature',
+              createdAt: DateTime(2025),
+            ),
+          ]);
+          stubProfiles({
+            'pub_a': makeProfile('pub_a', displayName: 'Alice'),
+            'pub_b': makeProfile('pub_b', displayName: 'Bob'),
+          });
+
+          final page = await repository.getNotifications();
+
+          final item = page.items.single as VideoNotification;
+          expect(item.type, equals(NotificationKind.listAdd));
+          expect(item.videoEventId, equals('foreign_root'));
+          expect(item.videoAddressableId, isNull);
+        },
+      );
+
+      test(
         "list_add of the user's own video reply keeps the recipient-scoped "
         'route when the thread root belongs to another creator',
         () async {


### PR DESCRIPTION
## What was broken

A user reported a notification that simply did not work: tapping it opened no video at all, and their own videos showed no comment from the person named in the row. It looked like a phantom notification.

The row is built around a coordinate that means *"this video is yours, and here is which one"*. That coordinate is the right thing to use for a comment on your own video — it keeps working even after the video's metadata is edited. The bug was that we minted it even when the payload said the video belonged to **someone else**, as long as the video's metadata happened to be unavailable at that moment (a timeout or a slow API response). The result was a coordinate that names you as the owner of a video you do not own — an address that resolves to nothing, on any relay. That is the "takes me to no Videos" in the report.

This happens for real: you comment under another creator's video, someone else replies in that thread, and the notification you receive is about *their* video, not yours.

## Why this fix

When metadata resolves, it stays authoritative and decides ownership outright — that behaviour is unchanged. The new guard is a fallback that only runs when metadata could **not** be resolved: if the payload names a different creator as the root video's author, we decline to invent a you-scoped coordinate and leave the row pointing at the raw video id instead. Tapping now opens the actual video rather than nothing.

The evidence is only trustworthy when the video the row points at *is* the thread root. For a comment on your own video **reply** inside someone else's thread, the payload's root author is that other creator while the reply itself is still yours — reading the payload there would destroy a legitimate route (#4730). The guard is scoped to exclude that case, and a test pins it.

The root author is derived across the whole group of notifications sharing a row, not sampled from one member. Members can disagree: a transient gap in the API response can leave the newest member's root author empty while an older member still carries it. Sampling one member would make the guard depend on which notification happened to sort first.

## Added during review

@dcadenas had already spotted that **"added your video to a list"** rows still derive their root author from the newest group member alone, and deferred it as consistent with how the rest of that row is built. Second review (@hm21) went the other way, for two reasons: a test reproduces the bad coordinate on a list-add group with the same transient gap that motivated the comment-path fix, and nothing about that gap is comment-specific — it is a property of the API response, so the same hazard is guarded on one path and open on the other. The list title and list coordinate on these rows are in fact already derived across the group; only the d-tag comes from a single member, and a wrong d-tag is cosmetic where a wrong owner is a dead link.

The fix feeds the group-derived root author into the list-add path too, and retires a duplicated "is this video the thread root?" check that was the same rule written twice. It is a single commit, so it reverts cleanly if @NotThatKindOfDrLiz or @dcadenas prefers the original call.

## What this deliberately does not change

- **The row's wording.** On a transient metadata miss for another creator's video, the row still reads "commented on your video" while the tap now opens the correct (foreign) video. Relabelling a row requires a *confirmed* not-found, not a timeout — that constraint exists so a slow API cannot delete a legitimate notification, and changing it belongs to the #4920 line of work.
- **Rows whose metadata resolves**, rows carrying a trusted root coordinate, and reposts (whose reclassification is destructive and intentionally left alone).
- **No API, schema, or storage change.** Confined to one package; no cache-key bump and no migration.

## Verification

- `notification_repository`: 197/197 tests pass; line coverage 96.60% against the package's 94% gate.
- `dart analyze` and `dart format` clean, plus `flutter analyze lib test` clean at the app level.
- Red/green verified in both directions: the five guard tests fail without their respective fix, each with the exact bad coordinate (`34236:<user>:<foreign-d-tag>`), and the four over-fire tests pin that the guard leaves the legitimate routes alone.

Closes #6369
