### PR TITLE
fix(age-gate): stop verified viewers being prompted again at startup

### DIFF
--- a/mobile/lib/blocs/video_playback_status/video_playback_status_cubit.dart
+++ b/mobile/lib/blocs/video_playback_status/video_playback_status_cubit.dart
@@ -14,7 +14,7 @@ class VideoPlaybackStatusCubit extends Cubit<VideoPlaybackStatusState> {
   /// to the [VideoPlaybackStatusState] default when null.
   VideoPlaybackStatusCubit({
     int? maxEntries,
-    bool Function()? canAutoAuthorizeAgeRestrictedMedia,
+    Future<bool> Function()? canAutoAuthorizeAgeRestrictedMedia,
   }) : _canAutoAuthorizeAgeRestrictedMedia = canAutoAuthorizeAgeRestrictedMedia,
        super(
          maxEntries == null
@@ -22,7 +22,7 @@ class VideoPlaybackStatusCubit extends Cubit<VideoPlaybackStatusState> {
              : VideoPlaybackStatusState(maxEntries: maxEntries),
        );
 
-  final bool Function()? _canAutoAuthorizeAgeRestrictedMedia;
+  final Future<bool> Function()? _canAutoAuthorizeAgeRestrictedMedia;
 
   /// Reports [status] for the video with [eventId].
   ///
@@ -71,14 +71,20 @@ class VideoPlaybackStatusCubit extends Cubit<VideoPlaybackStatusState> {
   /// This keeps the retry/fallback decision in the cubit rather than in the
   /// error overlay. The caller still owns invoking the UI callback after this
   /// method grants the attempt.
-  bool consumeAgeRestrictedAutoRetryIfEligible(
+  Future<bool> consumeAgeRestrictedAutoRetryIfEligible(
     String eventId, {
     required bool isAgeRestricted,
     required bool hasVerifyAction,
-  }) {
+  }) async {
     if (!isAgeRestricted || !hasVerifyAction) return false;
     if (state.isVerifying(eventId)) return false;
-    if (!(_canAutoAuthorizeAgeRestrictedMedia?.call() ?? false)) return false;
+    final canAutoAuthorize =
+        await (_canAutoAuthorizeAgeRestrictedMedia?.call() ??
+            Future<bool>.value(false));
+    if (!canAutoAuthorize) {
+      return false;
+    }
+    if (isClosed || state.isVerifying(eventId)) return false;
     return consumeAutoRetryAttempt(eventId);
   }
 

--- a/mobile/lib/blocs/video_playback_status/video_playback_status_cubit.dart
+++ b/mobile/lib/blocs/video_playback_status/video_playback_status_cubit.dart
@@ -75,6 +75,7 @@ class VideoPlaybackStatusCubit extends Cubit<VideoPlaybackStatusState> {
     String eventId, {
     required bool isAgeRestricted,
     required bool hasVerifyAction,
+    bool Function()? isConsumerActive,
   }) async {
     if (!isAgeRestricted || !hasVerifyAction) return false;
     if (state.isVerifying(eventId)) return false;
@@ -84,7 +85,11 @@ class VideoPlaybackStatusCubit extends Cubit<VideoPlaybackStatusState> {
     if (!canAutoAuthorize) {
       return false;
     }
-    if (isClosed || state.isVerifying(eventId)) return false;
+    if (isClosed ||
+        !(isConsumerActive?.call() ?? true) ||
+        state.isVerifying(eventId)) {
+      return false;
+    }
     return consumeAutoRetryAttempt(eventId);
   }
 

--- a/mobile/lib/screens/feed/pooled_age_restricted_retry.dart
+++ b/mobile/lib/screens/feed/pooled_age_restricted_retry.dart
@@ -156,7 +156,8 @@ Future<void> autoRetryAgeRestrictedPooledVideo({
   required PooledRetryPlayback retryPlayback,
 }) async {
   final mediaAuthInterceptor = ref.read(mediaAuthInterceptorProvider);
-  if (!mediaAuthInterceptor.canAutoAuthorizeAdultMedia) return;
+  if (!await mediaAuthInterceptor.canAutoAuthorizeAdultMedia()) return;
+  if (!context.mounted) return;
 
   final retryInput = _resolveRetryInput(video, resolveSha256);
   if (retryInput == null || retryInput.sha256 == null) return;

--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -332,7 +332,7 @@ class PooledFullscreenVideoFeedScreen extends ConsumerWidget {
           create: (_) => VideoPlaybackStatusCubit(
             canAutoAuthorizeAgeRestrictedMedia: () => ref
                 .read(mediaAuthInterceptorProvider)
-                .shouldAutoAuthorizeAgeRestrictedMedia,
+                .canAutoAuthorizeAdultMedia(),
           ),
         ),
       ],

--- a/mobile/lib/screens/feed/video_feed_page.dart
+++ b/mobile/lib/screens/feed/video_feed_page.dart
@@ -111,7 +111,7 @@ class VideoFeedPage extends ConsumerWidget {
           create: (_) => VideoPlaybackStatusCubit(
             canAutoAuthorizeAgeRestrictedMedia: () => ref
                 .read(mediaAuthInterceptorProvider)
-                .shouldAutoAuthorizeAgeRestrictedMedia,
+                .canAutoAuthorizeAdultMedia(),
           ),
         ),
       ],

--- a/mobile/lib/services/media_auth_interceptor.dart
+++ b/mobile/lib/services/media_auth_interceptor.dart
@@ -22,16 +22,20 @@ class MediaAuthInterceptor {
   final ContentFilterService _contentFilterService;
   final MediaViewerAuthService _mediaViewerAuthService;
 
+  /// Awaits the persisted verification and content-filter state so gate
+  /// decisions read loaded values rather than cold-start in-memory defaults.
+  Future<void> _awaitModerationServicesReady() => Future.wait([
+    _ageVerificationService.initialized,
+    _contentFilterService.initialized,
+  ]);
+
   /// Whether an age-restricted media surface can retry with viewer auth without
   /// asking the user to verify again.
   ///
   /// `hide` remains a hard block. Verified users with `warn` or `show`
   /// preferences can reuse their existing verification for playback auth.
   Future<bool> canAutoAuthorizeAdultMedia() async {
-    await Future.wait([
-      _ageVerificationService.initialized,
-      _contentFilterService.initialized,
-    ]);
+    await _awaitModerationServicesReady();
     return _mediaViewerAuthService.canCreateHeaders &&
         _ageVerificationService.isAdultContentVerified &&
         _contentFilterService.adultPlaybackPreference !=
@@ -49,10 +53,7 @@ class MediaAuthInterceptor {
     String? serverUrl,
   }) async {
     try {
-      await Future.wait([
-        _ageVerificationService.initialized,
-        _contentFilterService.initialized,
-      ]);
+      await _awaitModerationServicesReady();
 
       if (!_mediaViewerAuthService.canCreatePassiveHeaders ||
           !_ageVerificationService.isAdultContentVerified ||
@@ -138,10 +139,7 @@ class MediaAuthInterceptor {
         category: LogCategory.system,
       );
 
-      await Future.wait([
-        _ageVerificationService.initialized,
-        _contentFilterService.initialized,
-      ]);
+      await _awaitModerationServicesReady();
 
       final playbackPreference = _contentFilterService.adultPlaybackPreference;
 

--- a/mobile/lib/services/media_auth_interceptor.dart
+++ b/mobile/lib/services/media_auth_interceptor.dart
@@ -27,13 +27,16 @@ class MediaAuthInterceptor {
   ///
   /// `hide` remains a hard block. Verified users with `warn` or `show`
   /// preferences can reuse their existing verification for playback auth.
-  bool get shouldAutoAuthorizeAgeRestrictedMedia =>
-      _mediaViewerAuthService.canCreateHeaders &&
-      _ageVerificationService.isAdultContentVerified &&
-      _contentFilterService.adultPlaybackPreference !=
-          ContentFilterPreference.hide;
-
-  bool get canAutoAuthorizeAdultMedia => shouldAutoAuthorizeAgeRestrictedMedia;
+  Future<bool> canAutoAuthorizeAdultMedia() async {
+    await Future.wait([
+      _ageVerificationService.initialized,
+      _contentFilterService.initialized,
+    ]);
+    return _mediaViewerAuthService.canCreateHeaders &&
+        _ageVerificationService.isAdultContentVerified &&
+        _contentFilterService.adultPlaybackPreference !=
+            ContentFilterPreference.hide;
+  }
 
   /// Creates viewer-auth headers for passive thumbnail/background image loads.
   ///
@@ -90,7 +93,7 @@ class MediaAuthInterceptor {
     String? serverUrl,
   }) async {
     try {
-      if (!canAutoAuthorizeAdultMedia) {
+      if (!await canAutoAuthorizeAdultMedia()) {
         return const ViewerAuthUnavailable();
       }
 
@@ -134,6 +137,11 @@ class MediaAuthInterceptor {
         name: 'MediaAuthInterceptor',
         category: LogCategory.system,
       );
+
+      await Future.wait([
+        _ageVerificationService.initialized,
+        _contentFilterService.initialized,
+      ]);
 
       final playbackPreference = _contentFilterService.adultPlaybackPreference;
 

--- a/mobile/lib/widgets/video_feed_item/pooled_video_error_overlay.dart
+++ b/mobile/lib/widgets/video_feed_item/pooled_video_error_overlay.dart
@@ -91,10 +91,10 @@ class _PooledVideoErrorOverlayState
         widget.video.id,
         isAgeRestricted: showVerifyAge,
         hasVerifyAction: widget.onVerifyAge != null,
+        isConsumerActive: () => mounted,
       )) {
         return;
       }
-      if (!mounted) return;
       widget.onVerifyAge?.call();
     });
   }

--- a/mobile/lib/widgets/video_feed_item/pooled_video_error_overlay.dart
+++ b/mobile/lib/widgets/video_feed_item/pooled_video_error_overlay.dart
@@ -84,16 +84,17 @@ class _PooledVideoErrorOverlayState
       return;
     }
 
-    WidgetsBinding.instance.addPostFrameCallback((_) {
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
       if (!mounted) return;
       final playbackStatusCubit = context.read<VideoPlaybackStatusCubit>();
-      if (!playbackStatusCubit.consumeAgeRestrictedAutoRetryIfEligible(
+      if (!await playbackStatusCubit.consumeAgeRestrictedAutoRetryIfEligible(
         widget.video.id,
         isAgeRestricted: showVerifyAge,
         hasVerifyAction: widget.onVerifyAge != null,
       )) {
         return;
       }
+      if (!mounted) return;
       widget.onVerifyAge?.call();
     });
   }

--- a/mobile/test/blocs/video_playback_status/video_playback_status_cubit_test.dart
+++ b/mobile/test/blocs/video_playback_status/video_playback_status_cubit_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:infinite_video_feed/infinite_video_feed.dart'
@@ -178,13 +180,13 @@ void main() {
 
       test(
         'auto retry eligibility requires age restriction and verify action',
-        () {
+        () async {
           final cubit = VideoPlaybackStatusCubit(
-            canAutoAuthorizeAgeRestrictedMedia: () => true,
+            canAutoAuthorizeAgeRestrictedMedia: () async => true,
           );
 
           expect(
-            cubit.consumeAgeRestrictedAutoRetryIfEligible(
+            await cubit.consumeAgeRestrictedAutoRetryIfEligible(
               id1,
               isAgeRestricted: false,
               hasVerifyAction: true,
@@ -192,7 +194,7 @@ void main() {
             isFalse,
           );
           expect(
-            cubit.consumeAgeRestrictedAutoRetryIfEligible(
+            await cubit.consumeAgeRestrictedAutoRetryIfEligible(
               id1,
               isAgeRestricted: true,
               hasVerifyAction: false,
@@ -203,30 +205,33 @@ void main() {
         },
       );
 
-      test('auto retry eligibility requires an auto-authorized viewer', () {
-        final cubit = VideoPlaybackStatusCubit(
-          canAutoAuthorizeAgeRestrictedMedia: () => false,
-        );
+      test(
+        'auto retry eligibility requires an auto-authorized viewer',
+        () async {
+          final cubit = VideoPlaybackStatusCubit(
+            canAutoAuthorizeAgeRestrictedMedia: () async => false,
+          );
 
-        expect(
-          cubit.consumeAgeRestrictedAutoRetryIfEligible(
-            id1,
-            isAgeRestricted: true,
-            hasVerifyAction: true,
-          ),
-          isFalse,
-        );
-        expect(cubit.state.hasAutoRetryAttempted(id1), isFalse);
-      });
+          expect(
+            await cubit.consumeAgeRestrictedAutoRetryIfEligible(
+              id1,
+              isAgeRestricted: true,
+              hasVerifyAction: true,
+            ),
+            isFalse,
+          );
+          expect(cubit.state.hasAutoRetryAttempted(id1), isFalse);
+        },
+      );
 
-      test('auto retry eligibility is blocked while verifying', () {
+      test('auto retry eligibility is blocked while verifying', () async {
         final cubit = VideoPlaybackStatusCubit(
-          canAutoAuthorizeAgeRestrictedMedia: () => true,
+          canAutoAuthorizeAgeRestrictedMedia: () async => true,
         );
         cubit.markVerifying(id1);
 
         expect(
-          cubit.consumeAgeRestrictedAutoRetryIfEligible(
+          await cubit.consumeAgeRestrictedAutoRetryIfEligible(
             id1,
             isAgeRestricted: true,
             hasVerifyAction: true,
@@ -236,13 +241,13 @@ void main() {
         expect(cubit.state.hasAutoRetryAttempted(id1), isFalse);
       });
 
-      test('auto retry eligibility spends the per-video budget once', () {
+      test('auto retry eligibility spends the per-video budget once', () async {
         final cubit = VideoPlaybackStatusCubit(
-          canAutoAuthorizeAgeRestrictedMedia: () => true,
+          canAutoAuthorizeAgeRestrictedMedia: () async => true,
         );
 
         expect(
-          cubit.consumeAgeRestrictedAutoRetryIfEligible(
+          await cubit.consumeAgeRestrictedAutoRetryIfEligible(
             id1,
             isAgeRestricted: true,
             hasVerifyAction: true,
@@ -251,7 +256,7 @@ void main() {
         );
         expect(cubit.state.hasAutoRetryAttempted(id1), isTrue);
         expect(
-          cubit.consumeAgeRestrictedAutoRetryIfEligible(
+          await cubit.consumeAgeRestrictedAutoRetryIfEligible(
             id1,
             isAgeRestricted: true,
             hasVerifyAction: true,
@@ -259,6 +264,30 @@ void main() {
           isFalse,
         );
       });
+
+      test(
+        'waits for async eligibility before spending the retry budget',
+        () async {
+          final eligibility = Completer<bool>();
+          final cubit = VideoPlaybackStatusCubit(
+            canAutoAuthorizeAgeRestrictedMedia: () => eligibility.future,
+          );
+
+          final resultFuture = cubit.consumeAgeRestrictedAutoRetryIfEligible(
+            id1,
+            isAgeRestricted: true,
+            hasVerifyAction: true,
+          );
+          await Future<void>.value();
+
+          expect(cubit.state.hasAutoRetryAttempted(id1), isFalse);
+
+          eligibility.complete(true);
+
+          expect(await resultFuture, isTrue);
+          expect(cubit.state.hasAutoRetryAttempted(id1), isTrue);
+        },
+      );
     });
 
     group('authenticated retry exhaustion', () {

--- a/mobile/test/blocs/video_playback_status/video_playback_status_cubit_test.dart
+++ b/mobile/test/blocs/video_playback_status/video_playback_status_cubit_test.dart
@@ -288,6 +288,26 @@ void main() {
           expect(cubit.state.hasAutoRetryAttempted(id1), isTrue);
         },
       );
+
+      test('does not emit when closed while eligibility is pending', () async {
+        final eligibility = Completer<bool>();
+        final cubit = VideoPlaybackStatusCubit(
+          canAutoAuthorizeAgeRestrictedMedia: () => eligibility.future,
+        );
+
+        final resultFuture = cubit.consumeAgeRestrictedAutoRetryIfEligible(
+          id1,
+          isAgeRestricted: true,
+          hasVerifyAction: true,
+        );
+        await Future<void>.value();
+        await cubit.close();
+
+        eligibility.complete(true);
+
+        expect(await resultFuture, isFalse);
+        expect(cubit.state.hasAutoRetryAttempted(id1), isFalse);
+      });
     });
 
     group('authenticated retry exhaustion', () {

--- a/mobile/test/screens/feed/pooled_age_restricted_retry_test.dart
+++ b/mobile/test/screens/feed/pooled_age_restricted_retry_test.dart
@@ -807,6 +807,52 @@ void main() {
   });
 
   group('autoRetryAgeRestrictedPooledVideo', () {
+    testWidgets('stops when the caller unmounts during eligibility', (
+      tester,
+    ) async {
+      final eligibility = Completer<bool>();
+      final hostVisible = ValueNotifier<bool>(true);
+      final mediaAuthInterceptor = _MockMediaAuthInterceptor();
+      final playbackStatusCubit = VideoPlaybackStatusCubit();
+      var retryCount = 0;
+      addTearDown(hostVisible.dispose);
+      addTearDown(playbackStatusCubit.close);
+
+      when(
+        mediaAuthInterceptor.canAutoAuthorizeAdultMedia,
+      ).thenAnswer((_) => eligibility.future);
+
+      await tester.pumpWidget(
+        _AutoRetryHarness(
+          mediaAuthInterceptor: mediaAuthInterceptor,
+          playbackStatusCubit: playbackStatusCubit,
+          retryPlayback: (_) {
+            retryCount++;
+            return _retryRecovered;
+          },
+          hostVisible: hostVisible,
+        ),
+      );
+
+      await tester.tap(find.text('Auto retry'));
+      await tester.pump();
+      hostVisible.value = false;
+      await tester.pump();
+
+      eligibility.complete(true);
+      await tester.pump();
+
+      expect(retryCount, 0);
+      expect(playbackStatusCubit.state.isVerifying(_videoId), isFalse);
+      verifyNever(
+        () => mediaAuthInterceptor.createAutoAuthHeadersForAdultMedia(
+          sha256Hash: any(named: 'sha256Hash'),
+          url: any(named: 'url'),
+          serverUrl: any(named: 'serverUrl'),
+        ),
+      );
+    });
+
     testWidgets('marks authenticated retry exhausted silently when playback '
         'still fails', (tester) async {
       final mediaAuthInterceptor = _MockMediaAuthInterceptor();
@@ -1019,11 +1065,13 @@ class _AutoRetryHarness extends StatelessWidget {
     required this.mediaAuthInterceptor,
     required this.playbackStatusCubit,
     required this.retryPlayback,
+    this.hostVisible,
   });
 
   final MediaAuthInterceptor mediaAuthInterceptor;
   final VideoPlaybackStatusCubit playbackStatusCubit;
   final PooledRetryPlayback retryPlayback;
+  final ValueListenable<bool>? hostVisible;
 
   @override
   Widget build(BuildContext context) {
@@ -1037,18 +1085,25 @@ class _AutoRetryHarness extends StatelessWidget {
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
           home: Scaffold(
-            body: Consumer(
-              builder: (context, ref, _) {
-                return TextButton(
-                  onPressed: () => autoRetryAgeRestrictedPooledVideo(
-                    context: context,
-                    ref: ref,
-                    video: _video,
-                    index: 0,
-                    resolveSha256: _resolveSha256,
-                    retryPlayback: retryPlayback,
-                  ),
-                  child: const Text('Auto retry'),
+            body: ValueListenableBuilder<bool>(
+              valueListenable:
+                  hostVisible ?? const AlwaysStoppedAnimation<bool>(true),
+              builder: (_, hostVisible, _) {
+                if (!hostVisible) return const SizedBox.shrink();
+                return Consumer(
+                  builder: (context, ref, _) {
+                    return TextButton(
+                      onPressed: () => autoRetryAgeRestrictedPooledVideo(
+                        context: context,
+                        ref: ref,
+                        video: _video,
+                        index: 0,
+                        resolveSha256: _resolveSha256,
+                        retryPlayback: retryPlayback,
+                      ),
+                      child: const Text('Auto retry'),
+                    );
+                  },
                 );
               },
             ),

--- a/mobile/test/screens/feed/pooled_age_restricted_retry_test.dart
+++ b/mobile/test/screens/feed/pooled_age_restricted_retry_test.dart
@@ -815,8 +815,8 @@ void main() {
       addTearDown(playbackStatusCubit.close);
 
       when(
-        () => mediaAuthInterceptor.canAutoAuthorizeAdultMedia,
-      ).thenReturn(true);
+        mediaAuthInterceptor.canAutoAuthorizeAdultMedia,
+      ).thenAnswer((_) async => true);
       when(
         () => mediaAuthInterceptor.createAutoAuthHeadersForAdultMedia(
           sha256Hash: _sha256,
@@ -863,8 +863,8 @@ void main() {
       addTearDown(playbackStatusCubit.close);
 
       when(
-        () => mediaAuthInterceptor.canAutoAuthorizeAdultMedia,
-      ).thenReturn(true);
+        mediaAuthInterceptor.canAutoAuthorizeAdultMedia,
+      ).thenAnswer((_) async => true);
       when(
         () => mediaAuthInterceptor.createAutoAuthHeadersForAdultMedia(
           sha256Hash: _sha256,

--- a/mobile/test/services/media_auth_interceptor_preference_test.dart
+++ b/mobile/test/services/media_auth_interceptor_preference_test.dart
@@ -45,6 +45,8 @@ void main() {
       contentFilterService: mockContentFilterService,
       mediaViewerAuthService: mockMediaViewerAuthService,
     );
+    when(() => mockAgeVerificationService.initialized).thenAnswer((_) async {});
+    when(() => mockContentFilterService.initialized).thenAnswer((_) async {});
   });
 
   group('MediaAuthInterceptor - preference handling', () {
@@ -81,7 +83,7 @@ void main() {
           realContentFilterService.adultPlaybackPreference,
           ContentFilterPreference.hide,
         );
-        expect(interceptor.shouldAutoAuthorizeAgeRestrictedMedia, isFalse);
+        expect(await interceptor.canAutoAuthorizeAdultMedia(), isFalse);
 
         final result = await interceptor.handleUnauthorizedMedia(
           context: mockContext,
@@ -133,7 +135,7 @@ void main() {
           realContentFilterService.adultPlaybackPreference,
           ContentFilterPreference.hide,
         );
-        expect(interceptor.shouldAutoAuthorizeAgeRestrictedMedia, isFalse);
+        expect(await interceptor.canAutoAuthorizeAdultMedia(), isFalse);
 
         final result = await interceptor.handleUnauthorizedMedia(
           context: mockContext,
@@ -202,7 +204,7 @@ void main() {
           realContentFilterService.adultPlaybackPreference,
           ContentFilterPreference.warn,
         );
-        expect(interceptor.shouldAutoAuthorizeAgeRestrictedMedia, isTrue);
+        expect(await interceptor.canAutoAuthorizeAdultMedia(), isTrue);
 
         final result = await interceptor.handleUnauthorizedMedia(
           context: mockContext,
@@ -240,7 +242,7 @@ void main() {
           () => mockMediaViewerAuthService.canCreateHeaders,
         ).thenReturn(true);
 
-        expect(interceptor.shouldAutoAuthorizeAgeRestrictedMedia, isFalse);
+        expect(await interceptor.canAutoAuthorizeAdultMedia(), isFalse);
 
         final result = await interceptor.handleUnauthorizedMedia(
           context: mockContext,
@@ -335,7 +337,7 @@ void main() {
         );
 
         // Assert - auto auth header created, no dialog shown
-        expect(interceptor.shouldAutoAuthorizeAgeRestrictedMedia, isTrue);
+        expect(await interceptor.canAutoAuthorizeAdultMedia(), isTrue);
         expect(result, isA<ViewerAuthAuthorized>());
         expect(
           result.headersOrNull,
@@ -470,7 +472,7 @@ void main() {
         );
 
         // Assert - auth header created without re-verification
-        expect(interceptor.shouldAutoAuthorizeAgeRestrictedMedia, isTrue);
+        expect(await interceptor.canAutoAuthorizeAdultMedia(), isTrue);
         expect(result, isA<ViewerAuthAuthorized>());
         expect(
           result.headersOrNull,

--- a/mobile/test/services/media_auth_interceptor_test.dart
+++ b/mobile/test/services/media_auth_interceptor_test.dart
@@ -321,6 +321,97 @@ void main() {
   });
 
   group('MediaAuthInterceptor - helper methods', () {
+    test(
+      'waits for moderation readiness before auto-auth gate checks',
+      () async {
+        final ageReady = Completer<void>();
+        final filterReady = Completer<void>();
+        when(
+          () => mockAgeVerificationService.initialized,
+        ).thenAnswer((_) => ageReady.future);
+        when(
+          () => mockContentFilterService.initialized,
+        ).thenAnswer((_) => filterReady.future);
+        when(
+          () => mockMediaViewerAuthService.canCreateHeaders,
+        ).thenReturn(true);
+        when(
+          () => mockAgeVerificationService.isAdultContentVerified,
+        ).thenReturn(true);
+        when(
+          () => mockContentFilterService.adultPlaybackPreference,
+        ).thenReturn(ContentFilterPreference.show);
+        when(
+          () => mockMediaViewerAuthService.createAuthHeaders(
+            sha256Hash: any(named: 'sha256Hash'),
+            url: any(named: 'url'),
+            serverUrl: any(named: 'serverUrl'),
+          ),
+        ).thenAnswer(
+          (_) async =>
+              const ViewerAuthAuthorized({'Authorization': 'Nostr token'}),
+        );
+
+        final resultFuture = interceptor.createAutoAuthHeadersForAdultMedia(
+          sha256Hash: 'abc123',
+        );
+        await Future<void>.value();
+
+        verifyNever(
+          () => mockMediaViewerAuthService.createAuthHeaders(
+            sha256Hash: any(named: 'sha256Hash'),
+            url: any(named: 'url'),
+            serverUrl: any(named: 'serverUrl'),
+          ),
+        );
+
+        ageReady.complete();
+        filterReady.complete();
+        final result = await resultFuture;
+
+        expect(result, isA<ViewerAuthAuthorized>());
+      },
+    );
+
+    test(
+      'waits for readiness before returning verified hide preference',
+      () async {
+        final ageReady = Completer<void>();
+        final filterReady = Completer<void>();
+        when(
+          () => mockAgeVerificationService.initialized,
+        ).thenAnswer((_) => ageReady.future);
+        when(
+          () => mockContentFilterService.initialized,
+        ).thenAnswer((_) => filterReady.future);
+        when(
+          () => mockAgeVerificationService.isAdultContentVerified,
+        ).thenReturn(true);
+        when(
+          () => mockContentFilterService.adultPlaybackPreference,
+        ).thenReturn(ContentFilterPreference.hide);
+
+        final resultFuture = interceptor.handleUnauthorizedMedia(
+          context: mockContext,
+          sha256Hash: 'abc123',
+        );
+        await Future<void>.value();
+
+        verifyNever(
+          () => mockAgeVerificationService.verifyAdultContentAccess(any()),
+        );
+
+        ageReady.complete();
+        filterReady.complete();
+        final result = await resultFuture;
+
+        expect(result, isA<ViewerAuthBlockedByPreference>());
+        verifyNever(
+          () => mockAgeVerificationService.verifyAdultContentAccess(any()),
+        );
+      },
+    );
+
     test('canCreateAuthHeaders delegates to MediaViewerAuthService', () {
       // Arrange
       when(() => mockMediaViewerAuthService.canCreateHeaders).thenReturn(true);

--- a/mobile/test/services/media_auth_interceptor_test.dart
+++ b/mobile/test/services/media_auth_interceptor_test.dart
@@ -378,6 +378,11 @@ void main() {
       () async {
         final ageReady = Completer<void>();
         final filterReady = Completer<void>();
+        // Persisted verification is only available once the services finish
+        // initializing. Before then the in-memory default reads as unverified,
+        // which would route to the verify-dialog path. Reading the gate before
+        // awaiting readiness is exactly the cold-start bug this guards.
+        var loaded = false;
         when(
           () => mockAgeVerificationService.initialized,
         ).thenAnswer((_) => ageReady.future);
@@ -386,10 +391,14 @@ void main() {
         ).thenAnswer((_) => filterReady.future);
         when(
           () => mockAgeVerificationService.isAdultContentVerified,
-        ).thenReturn(true);
+        ).thenAnswer((_) => loaded);
         when(
           () => mockContentFilterService.adultPlaybackPreference,
         ).thenReturn(ContentFilterPreference.hide);
+        when(() => mockContext.mounted).thenReturn(true);
+        when(
+          () => mockAgeVerificationService.verifyAdultContentAccess(any()),
+        ).thenAnswer((_) async => false);
 
         final resultFuture = interceptor.handleUnauthorizedMedia(
           context: mockContext,
@@ -397,10 +406,13 @@ void main() {
         );
         await Future<void>.value();
 
+        // Until initialization completes the gate must not fall through to the
+        // verify-dialog path on the pre-load unverified default.
         verifyNever(
           () => mockAgeVerificationService.verifyAdultContentAccess(any()),
         );
 
+        loaded = true;
         ageReady.complete();
         filterReady.complete();
         final result = await resultFuture;

--- a/mobile/test/widgets/pooled_video_error_overlay_test.dart
+++ b/mobile/test/widgets/pooled_video_error_overlay_test.dart
@@ -268,7 +268,7 @@ void main() {
         tester,
       ) async {
         final playbackStatusCubit = VideoPlaybackStatusCubit(
-          canAutoAuthorizeAgeRestrictedMedia: () => true,
+          canAutoAuthorizeAgeRestrictedMedia: () async => true,
         );
 
         await tester.pumpWidget(
@@ -288,7 +288,7 @@ void main() {
         'auto-runs Verify age only once across overlay teardown and rebuild',
         (tester) async {
           final playbackStatusCubit = VideoPlaybackStatusCubit(
-            canAutoAuthorizeAgeRestrictedMedia: () => true,
+            canAutoAuthorizeAgeRestrictedMedia: () async => true,
           );
           var verifyAgeCalls = 0;
 
@@ -520,7 +520,7 @@ void main() {
         'auto-runs verify action for moderation age restriction when already authorized',
         (tester) async {
           final playbackStatusCubit = VideoPlaybackStatusCubit(
-            canAutoAuthorizeAgeRestrictedMedia: () => true,
+            canAutoAuthorizeAgeRestrictedMedia: () async => true,
           );
 
           await tester.pumpWidget(

--- a/mobile/test/widgets/pooled_video_error_overlay_test.dart
+++ b/mobile/test/widgets/pooled_video_error_overlay_test.dart
@@ -322,6 +322,54 @@ void main() {
         },
       );
 
+      testWidgets(
+        'preserves auto retry when the overlay unmounts during eligibility',
+        (tester) async {
+          final eligibility = Completer<bool>();
+          final playbackStatusCubit = VideoPlaybackStatusCubit(
+            canAutoAuthorizeAgeRestrictedMedia: () => eligibility.future,
+          );
+          var verifyAgeCalls = 0;
+
+          await tester.pumpWidget(
+            buildWidget(
+              errorType: VideoErrorType.ageRestricted,
+              onVerifyAge: () => verifyAgeCalls++,
+              playbackStatusCubit: playbackStatusCubit,
+            ),
+          );
+          await tester.pump();
+
+          await tester.pumpWidget(const SizedBox.shrink());
+          eligibility.complete(true);
+          await tester.pump();
+
+          expect(verifyAgeCalls, 0);
+          expect(
+            playbackStatusCubit.state.hasAutoRetryAttempted(divineVideo.id),
+            isFalse,
+          );
+
+          await tester.pumpWidget(
+            buildWidget(
+              errorType: VideoErrorType.ageRestricted,
+              onVerifyAge: () => verifyAgeCalls++,
+              playbackStatusCubit: playbackStatusCubit,
+            ),
+          );
+          await tester.pump();
+
+          expect(verifyAgeCalls, 1);
+          expect(
+            playbackStatusCubit.state.hasAutoRetryAttempted(divineVideo.id),
+            isTrue,
+          );
+
+          await tester.pumpWidget(const SizedBox.shrink());
+          await playbackStatusCubit.close();
+        },
+      );
+
       testWidgets('does not auto-run Verify age when adult content is hidden', (
         tester,
       ) async {

--- a/mobile/test/widgets/video_feed_item/feed_videos_test.dart
+++ b/mobile/test/widgets/video_feed_item/feed_videos_test.dart
@@ -202,6 +202,7 @@ extension _PlaybackCubitStub on _MockVideoPlaybackStatusCubit {
         any(),
         isAgeRestricted: any(named: 'isAgeRestricted'),
         hasVerifyAction: any(named: 'hasVerifyAction'),
+        isConsumerActive: any(named: 'isConsumerActive'),
       ),
     ).thenAnswer((_) async => false);
     whenListen(this, const Stream<VideoPlaybackStatusState>.empty());

--- a/mobile/test/widgets/video_feed_item/feed_videos_test.dart
+++ b/mobile/test/widgets/video_feed_item/feed_videos_test.dart
@@ -203,7 +203,7 @@ extension _PlaybackCubitStub on _MockVideoPlaybackStatusCubit {
         isAgeRestricted: any(named: 'isAgeRestricted'),
         hasVerifyAction: any(named: 'hasVerifyAction'),
       ),
-    ).thenReturn(false);
+    ).thenAnswer((_) async => false);
     whenListen(this, const Stream<VideoPlaybackStatusState>.empty());
   }
 }
@@ -508,8 +508,8 @@ void main() {
         );
         final mediaAuthInterceptor = _MockMediaAuthInterceptor();
         when(
-          () => mediaAuthInterceptor.canAutoAuthorizeAdultMedia,
-        ).thenReturn(true);
+          mediaAuthInterceptor.canAutoAuthorizeAdultMedia,
+        ).thenAnswer((_) async => true);
         when(
           () => mediaAuthInterceptor.createAutoAuthHeadersForAdultMedia(
             sha256Hash: any(named: 'sha256Hash'),
@@ -563,8 +563,8 @@ void main() {
         );
         final mediaAuthInterceptor = _MockMediaAuthInterceptor();
         when(
-          () => mediaAuthInterceptor.canAutoAuthorizeAdultMedia,
-        ).thenReturn(false);
+          mediaAuthInterceptor.canAutoAuthorizeAdultMedia,
+        ).thenAnswer((_) async => false);
         final playbackStatusCubit = _MockVideoPlaybackStatusCubit()
           ..stub(PlaybackStatus.ready, video.id);
 

--- a/mobile/test/widgets/video_feed_item/verifying_aware_video_error_overlay_test.dart
+++ b/mobile/test/widgets/video_feed_item/verifying_aware_video_error_overlay_test.dart
@@ -63,8 +63,8 @@ void main() {
     }) {
       final authInterceptor = interceptor ?? _MockMediaAuthInterceptor();
       when(
-        () => authInterceptor.shouldAutoAuthorizeAgeRestrictedMedia,
-      ).thenReturn(false);
+        authInterceptor.canAutoAuthorizeAdultMedia,
+      ).thenAnswer((_) async => false);
       return tester.pumpWidget(
         ProviderScope(
           overrides: [


### PR DESCRIPTION
## Description

Viewers who had already completed adult-content verification could still see the verification prompt when restricted media loaded during app startup. The retry paths read default in-memory values before persisted verification and content-filter settings finished loading, then had no reliable signal to reconsider that decision.

This change makes automatic authorization and manual unauthorized-media handling wait for both services to initialize. It carries that asynchronous decision through both feed retry entry points and spends the once-per-video retry budget only after eligibility has settled.

This does not change which content-filter preferences allow playback, the verification UX, persistence/account scoping, or localization. Account-scoped verification remains tracked in #7816.

**Related Issue:** Closes #7812

## Verification

- Added pending-initialization regression coverage for media authorization and retry-budget behavior
- Full randomized non-golden mobile test suite
- Focused affected suite after rebasing: 145 tests
- `flutter analyze`
- Pre-push analyzer and 218 changed-file tests
- Post-close emit, layer-direction, untested-service, and Codex configuration guards

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [ ] Build configuration change
- [ ] Documentation
- [ ] Chore