### PR TITLE
fix(auth): route Secure account key conflict to recovery, not a dead end

### DIFF
--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -2085,6 +2085,10 @@
   "authUnableToAccessKeys": "Unable to access your keys. Please try again.",
   "authRegistrationFailed": "Registration failed",
   "authRegistrationComplete": "Registration complete. Please check your email.",
+  "authSecureAccountAlreadyRegistered": "You already have an account. Sign in or reset your password to get back in.",
+  "@authSecureAccountAlreadyRegistered": {
+    "description": "Shown when Secure account fails because the key already has an account (server CONFLICT). The user is routed to sign-in / forgot-password to recover."
+  },
   "authFailedToSendResetEmail": "Failed to send reset email.",
   "authSending": "Sending...",
   "authSignInButton": "Sign in",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -2085,9 +2085,9 @@
   "authUnableToAccessKeys": "Unable to access your keys. Please try again.",
   "authRegistrationFailed": "Registration failed",
   "authRegistrationComplete": "Registration complete. Please check your email.",
-  "authSecureAccountAlreadyRegistered": "Looks like an account already exists. Sign in or reset your password to continue.",
+  "authSecureAccountAlreadyRegistered": "Looks like an account already exists. Sign in to it, or contact support if you can't get back in.",
   "@authSecureAccountAlreadyRegistered": {
-    "description": "Shown when Secure account fails with a server CONFLICT, which covers both the key already being registered and the entered email already being taken. Deliberately does not assert the user owns the account, since the email case may belong to a different account. The user is routed to sign-in / forgot-password to continue."
+    "description": "Shown in place on the Secure account screen when registration fails with a server CONFLICT, which covers both the key already being registered and the entered email already being taken. Deliberately does not assert the user owns the account, since the email case may belong to a different account. The screen offers Sign in and Contact support choices."
   },
   "authFailedToSendResetEmail": "Failed to send reset email.",
   "authSending": "Sending...",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -2085,9 +2085,9 @@
   "authUnableToAccessKeys": "Unable to access your keys. Please try again.",
   "authRegistrationFailed": "Registration failed",
   "authRegistrationComplete": "Registration complete. Please check your email.",
-  "authSecureAccountAlreadyRegistered": "You already have an account. Sign in or reset your password to get back in.",
+  "authSecureAccountAlreadyRegistered": "Looks like an account already exists. Sign in or reset your password to continue.",
   "@authSecureAccountAlreadyRegistered": {
-    "description": "Shown when Secure account fails because the key already has an account (server CONFLICT). The user is routed to sign-in / forgot-password to recover."
+    "description": "Shown when Secure account fails with a server CONFLICT, which covers both the key already being registered and the entered email already being taken. Deliberately does not assert the user owns the account, since the email case may belong to a different account. The user is routed to sign-in / forgot-password to continue."
   },
   "authFailedToSendResetEmail": "Failed to send reset email.",
   "authSending": "Sending...",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -2085,9 +2085,9 @@
   "authUnableToAccessKeys": "Unable to access your keys. Please try again.",
   "authRegistrationFailed": "Registration failed",
   "authRegistrationComplete": "Registration complete. Please check your email.",
-  "authSecureAccountAlreadyRegistered": "Looks like an account already exists. Sign in to it, or contact support if you can't get back in.",
+  "authSecureAccountAlreadyRegistered": "Looks like an account already exists. Try a different email, or sign in to the existing account with this email address. If neither works, contact support.",
   "@authSecureAccountAlreadyRegistered": {
-    "description": "Shown in place on the Secure account screen when registration fails with a server CONFLICT, which covers both the key already being registered and the entered email already being taken. Deliberately does not assert the user owns the account, since the email case may belong to a different account. The screen offers Sign in and Contact support choices."
+    "description": "Shown in place on the Secure account screen when registration fails with a server CONFLICT, which covers both the key already being registered and the entered email already being taken. Deliberately does not assert the user owns the account, since the email case may belong to a different account. Presents two primary actions (retry with a different email, or sign in to the existing account) with Contact support as a fallback, not an equal option."
   },
   "authFailedToSendResetEmail": "Failed to send reset email.",
   "authSending": "Sending...",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -5759,6 +5759,12 @@ abstract class AppLocalizations {
   /// **'Registration complete. Please check your email.'**
   String get authRegistrationComplete;
 
+  /// Shown when Secure account fails because the key already has an account (server CONFLICT). The user is routed to sign-in / forgot-password to recover.
+  ///
+  /// In en, this message translates to:
+  /// **'You already have an account. Sign in or reset your password to get back in.'**
+  String get authSecureAccountAlreadyRegistered;
+
   /// No description provided for @authFailedToSendResetEmail.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -5759,10 +5759,10 @@ abstract class AppLocalizations {
   /// **'Registration complete. Please check your email.'**
   String get authRegistrationComplete;
 
-  /// Shown when Secure account fails because the key already has an account (server CONFLICT). The user is routed to sign-in / forgot-password to recover.
+  /// Shown when Secure account fails with a server CONFLICT, which covers both the key already being registered and the entered email already being taken. Deliberately does not assert the user owns the account, since the email case may belong to a different account. The user is routed to sign-in / forgot-password to continue.
   ///
   /// In en, this message translates to:
-  /// **'You already have an account. Sign in or reset your password to get back in.'**
+  /// **'Looks like an account already exists. Sign in or reset your password to continue.'**
   String get authSecureAccountAlreadyRegistered;
 
   /// No description provided for @authFailedToSendResetEmail.

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -5759,10 +5759,10 @@ abstract class AppLocalizations {
   /// **'Registration complete. Please check your email.'**
   String get authRegistrationComplete;
 
-  /// Shown when Secure account fails with a server CONFLICT, which covers both the key already being registered and the entered email already being taken. Deliberately does not assert the user owns the account, since the email case may belong to a different account. The user is routed to sign-in / forgot-password to continue.
+  /// Shown in place on the Secure account screen when registration fails with a server CONFLICT, which covers both the key already being registered and the entered email already being taken. Deliberately does not assert the user owns the account, since the email case may belong to a different account. The screen offers Sign in and Contact support choices.
   ///
   /// In en, this message translates to:
-  /// **'Looks like an account already exists. Sign in or reset your password to continue.'**
+  /// **'Looks like an account already exists. Sign in to it, or contact support if you can\'t get back in.'**
   String get authSecureAccountAlreadyRegistered;
 
   /// No description provided for @authFailedToSendResetEmail.

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -5759,10 +5759,10 @@ abstract class AppLocalizations {
   /// **'Registration complete. Please check your email.'**
   String get authRegistrationComplete;
 
-  /// Shown in place on the Secure account screen when registration fails with a server CONFLICT, which covers both the key already being registered and the entered email already being taken. Deliberately does not assert the user owns the account, since the email case may belong to a different account. The screen offers Sign in and Contact support choices.
+  /// Shown in place on the Secure account screen when registration fails with a server CONFLICT, which covers both the key already being registered and the entered email already being taken. Deliberately does not assert the user owns the account, since the email case may belong to a different account. Presents two primary actions (retry with a different email, or sign in to the existing account) with Contact support as a fallback, not an equal option.
   ///
   /// In en, this message translates to:
-  /// **'Looks like an account already exists. Sign in to it, or contact support if you can\'t get back in.'**
+  /// **'Looks like an account already exists. Try a different email, or sign in to the existing account with this email address. If neither works, contact support.'**
   String get authSecureAccountAlreadyRegistered;
 
   /// No description provided for @authFailedToSendResetEmail.

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -3292,7 +3292,7 @@ class AppLocalizationsAm extends AppLocalizations {
 
   @override
   String get authSecureAccountAlreadyRegistered =>
-      'You already have an account. Sign in or reset your password to get back in.';
+      'Looks like an account already exists. Sign in or reset your password to continue.';
 
   @override
   String get authFailedToSendResetEmail => 'ዳግም ማስጀመር ኢሜይል መላክ አልተሳካም።';

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -3292,7 +3292,7 @@ class AppLocalizationsAm extends AppLocalizations {
 
   @override
   String get authSecureAccountAlreadyRegistered =>
-      'Looks like an account already exists. Sign in to it, or contact support if you can\'t get back in.';
+      'Looks like an account already exists. Try a different email, or sign in to the existing account with this email address. If neither works, contact support.';
 
   @override
   String get authFailedToSendResetEmail => 'ዳግም ማስጀመር ኢሜይል መላክ አልተሳካም።';

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -3291,6 +3291,10 @@ class AppLocalizationsAm extends AppLocalizations {
   String get authRegistrationComplete => 'ምዝገባው ተጠናቅቋል። እባክህ ኢሜልህን አረጋግጥ።';
 
   @override
+  String get authSecureAccountAlreadyRegistered =>
+      'You already have an account. Sign in or reset your password to get back in.';
+
+  @override
   String get authFailedToSendResetEmail => 'ዳግም ማስጀመር ኢሜይል መላክ አልተሳካም።';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -3292,7 +3292,7 @@ class AppLocalizationsAm extends AppLocalizations {
 
   @override
   String get authSecureAccountAlreadyRegistered =>
-      'Looks like an account already exists. Sign in or reset your password to continue.';
+      'Looks like an account already exists. Sign in to it, or contact support if you can\'t get back in.';
 
   @override
   String get authFailedToSendResetEmail => 'ዳግም ማስጀመር ኢሜይል መላክ አልተሳካም።';

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -3325,6 +3325,10 @@ class AppLocalizationsAr extends AppLocalizations {
       'تم التسجيل. يرجى تفقّد بريدك الإلكتروني.';
 
   @override
+  String get authSecureAccountAlreadyRegistered =>
+      'You already have an account. Sign in or reset your password to get back in.';
+
+  @override
   String get authFailedToSendResetEmail => 'فشل إرسال بريد إعادة التعيين.';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -3326,7 +3326,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get authSecureAccountAlreadyRegistered =>
-      'You already have an account. Sign in or reset your password to get back in.';
+      'Looks like an account already exists. Sign in or reset your password to continue.';
 
   @override
   String get authFailedToSendResetEmail => 'فشل إرسال بريد إعادة التعيين.';

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -3326,7 +3326,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get authSecureAccountAlreadyRegistered =>
-      'Looks like an account already exists. Sign in or reset your password to continue.';
+      'Looks like an account already exists. Sign in to it, or contact support if you can\'t get back in.';
 
   @override
   String get authFailedToSendResetEmail => 'فشل إرسال بريد إعادة التعيين.';

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -3326,7 +3326,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get authSecureAccountAlreadyRegistered =>
-      'Looks like an account already exists. Sign in to it, or contact support if you can\'t get back in.';
+      'Looks like an account already exists. Try a different email, or sign in to the existing account with this email address. If neither works, contact support.';
 
   @override
   String get authFailedToSendResetEmail => 'فشل إرسال بريد إعادة التعيين.';

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -3405,6 +3405,10 @@ class AppLocalizationsBg extends AppLocalizations {
       'Регистрацията е готова. Провери имейла си.';
 
   @override
+  String get authSecureAccountAlreadyRegistered =>
+      'You already have an account. Sign in or reset your password to get back in.';
+
+  @override
   String get authFailedToSendResetEmail =>
       'Не успяхме да изпратим имейл за нулиране.';
 

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -3406,7 +3406,7 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get authSecureAccountAlreadyRegistered =>
-      'Looks like an account already exists. Sign in or reset your password to continue.';
+      'Looks like an account already exists. Sign in to it, or contact support if you can\'t get back in.';
 
   @override
   String get authFailedToSendResetEmail =>

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -3406,7 +3406,7 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get authSecureAccountAlreadyRegistered =>
-      'You already have an account. Sign in or reset your password to get back in.';
+      'Looks like an account already exists. Sign in or reset your password to continue.';
 
   @override
   String get authFailedToSendResetEmail =>

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -3406,7 +3406,7 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get authSecureAccountAlreadyRegistered =>
-      'Looks like an account already exists. Sign in to it, or contact support if you can\'t get back in.';
+      'Looks like an account already exists. Try a different email, or sign in to the existing account with this email address. If neither works, contact support.';
 
   @override
   String get authFailedToSendResetEmail =>

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -3400,7 +3400,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get authSecureAccountAlreadyRegistered =>
-      'Looks like an account already exists. Sign in to it, or contact support if you can\'t get back in.';
+      'Looks like an account already exists. Try a different email, or sign in to the existing account with this email address. If neither works, contact support.';
 
   @override
   String get authFailedToSendResetEmail =>

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -3400,7 +3400,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get authSecureAccountAlreadyRegistered =>
-      'You already have an account. Sign in or reset your password to get back in.';
+      'Looks like an account already exists. Sign in or reset your password to continue.';
 
   @override
   String get authFailedToSendResetEmail =>

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -3399,6 +3399,10 @@ class AppLocalizationsDe extends AppLocalizations {
       'Registrierung abgeschlossen. Bitte prüf deine E-Mails.';
 
   @override
+  String get authSecureAccountAlreadyRegistered =>
+      'You already have an account. Sign in or reset your password to get back in.';
+
+  @override
   String get authFailedToSendResetEmail =>
       'Reset-E-Mail konnte nicht gesendet werden.';
 

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -3400,7 +3400,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get authSecureAccountAlreadyRegistered =>
-      'Looks like an account already exists. Sign in or reset your password to continue.';
+      'Looks like an account already exists. Sign in to it, or contact support if you can\'t get back in.';
 
   @override
   String get authFailedToSendResetEmail =>

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -3430,7 +3430,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get authSecureAccountAlreadyRegistered =>
-      'You already have an account. Sign in or reset your password to get back in.';
+      'Looks like an account already exists. Sign in or reset your password to continue.';
 
   @override
   String get authFailedToSendResetEmail => 'Failed to send reset email.';

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -3429,6 +3429,10 @@ class AppLocalizationsEn extends AppLocalizations {
       'Registration complete. Please check your email.';
 
   @override
+  String get authSecureAccountAlreadyRegistered =>
+      'You already have an account. Sign in or reset your password to get back in.';
+
+  @override
   String get authFailedToSendResetEmail => 'Failed to send reset email.';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -3430,7 +3430,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get authSecureAccountAlreadyRegistered =>
-      'Looks like an account already exists. Sign in or reset your password to continue.';
+      'Looks like an account already exists. Sign in to it, or contact support if you can\'t get back in.';
 
   @override
   String get authFailedToSendResetEmail => 'Failed to send reset email.';

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -3430,7 +3430,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get authSecureAccountAlreadyRegistered =>
-      'Looks like an account already exists. Sign in to it, or contact support if you can\'t get back in.';
+      'Looks like an account already exists. Try a different email, or sign in to the existing account with this email address. If neither works, contact support.';
 
   @override
   String get authFailedToSendResetEmail => 'Failed to send reset email.';

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -3397,7 +3397,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get authSecureAccountAlreadyRegistered =>
-      'Looks like an account already exists. Sign in or reset your password to continue.';
+      'Looks like an account already exists. Sign in to it, or contact support if you can\'t get back in.';
 
   @override
   String get authFailedToSendResetEmail =>

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -3397,7 +3397,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get authSecureAccountAlreadyRegistered =>
-      'Looks like an account already exists. Sign in to it, or contact support if you can\'t get back in.';
+      'Looks like an account already exists. Try a different email, or sign in to the existing account with this email address. If neither works, contact support.';
 
   @override
   String get authFailedToSendResetEmail =>

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -3397,7 +3397,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get authSecureAccountAlreadyRegistered =>
-      'You already have an account. Sign in or reset your password to get back in.';
+      'Looks like an account already exists. Sign in or reset your password to continue.';
 
   @override
   String get authFailedToSendResetEmail =>

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -3396,6 +3396,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get authRegistrationComplete => 'Registro completo. Revisá tu email.';
 
   @override
+  String get authSecureAccountAlreadyRegistered =>
+      'You already have an account. Sign in or reset your password to get back in.';
+
+  @override
   String get authFailedToSendResetEmail =>
       'No se pudo enviar el email de restablecimiento.';
 

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -3378,7 +3378,7 @@ class AppLocalizationsFil extends AppLocalizations {
 
   @override
   String get authSecureAccountAlreadyRegistered =>
-      'Looks like an account already exists. Sign in or reset your password to continue.';
+      'Looks like an account already exists. Sign in to it, or contact support if you can\'t get back in.';
 
   @override
   String get authFailedToSendResetEmail => 'Hindi naipadala ang reset email.';

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -3378,7 +3378,7 @@ class AppLocalizationsFil extends AppLocalizations {
 
   @override
   String get authSecureAccountAlreadyRegistered =>
-      'Looks like an account already exists. Sign in to it, or contact support if you can\'t get back in.';
+      'Looks like an account already exists. Try a different email, or sign in to the existing account with this email address. If neither works, contact support.';
 
   @override
   String get authFailedToSendResetEmail => 'Hindi naipadala ang reset email.';

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -3378,7 +3378,7 @@ class AppLocalizationsFil extends AppLocalizations {
 
   @override
   String get authSecureAccountAlreadyRegistered =>
-      'You already have an account. Sign in or reset your password to get back in.';
+      'Looks like an account already exists. Sign in or reset your password to continue.';
 
   @override
   String get authFailedToSendResetEmail => 'Hindi naipadala ang reset email.';

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -3377,6 +3377,10 @@ class AppLocalizationsFil extends AppLocalizations {
       'Kumpleto na ang registration. Pakitsek ang iyong email.';
 
   @override
+  String get authSecureAccountAlreadyRegistered =>
+      'You already have an account. Sign in or reset your password to get back in.';
+
+  @override
   String get authFailedToSendResetEmail => 'Hindi naipadala ang reset email.';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -3411,7 +3411,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get authSecureAccountAlreadyRegistered =>
-      'Looks like an account already exists. Sign in to it, or contact support if you can\'t get back in.';
+      'Looks like an account already exists. Try a different email, or sign in to the existing account with this email address. If neither works, contact support.';
 
   @override
   String get authFailedToSendResetEmail =>

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -3411,7 +3411,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get authSecureAccountAlreadyRegistered =>
-      'Looks like an account already exists. Sign in or reset your password to continue.';
+      'Looks like an account already exists. Sign in to it, or contact support if you can\'t get back in.';
 
   @override
   String get authFailedToSendResetEmail =>

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -3410,6 +3410,10 @@ class AppLocalizationsFr extends AppLocalizations {
       'Inscription terminée. Vérifie ton e-mail.';
 
   @override
+  String get authSecureAccountAlreadyRegistered =>
+      'You already have an account. Sign in or reset your password to get back in.';
+
+  @override
   String get authFailedToSendResetEmail =>
       'Échec de l\'envoi de l\'e-mail de réinitialisation.';
 

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -3411,7 +3411,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get authSecureAccountAlreadyRegistered =>
-      'You already have an account. Sign in or reset your password to get back in.';
+      'Looks like an account already exists. Sign in or reset your password to continue.';
 
   @override
   String get authFailedToSendResetEmail =>

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -3291,6 +3291,10 @@ class AppLocalizationsId extends AppLocalizations {
       'Pendaftaran selesai. Silakan cek emailmu.';
 
   @override
+  String get authSecureAccountAlreadyRegistered =>
+      'You already have an account. Sign in or reset your password to get back in.';
+
+  @override
   String get authFailedToSendResetEmail => 'Gagal mengirim email reset.';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -3292,7 +3292,7 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get authSecureAccountAlreadyRegistered =>
-      'Looks like an account already exists. Sign in to it, or contact support if you can\'t get back in.';
+      'Looks like an account already exists. Try a different email, or sign in to the existing account with this email address. If neither works, contact support.';
 
   @override
   String get authFailedToSendResetEmail => 'Gagal mengirim email reset.';

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -3292,7 +3292,7 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get authSecureAccountAlreadyRegistered =>
-      'You already have an account. Sign in or reset your password to get back in.';
+      'Looks like an account already exists. Sign in or reset your password to continue.';
 
   @override
   String get authFailedToSendResetEmail => 'Gagal mengirim email reset.';

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -3292,7 +3292,7 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get authSecureAccountAlreadyRegistered =>
-      'Looks like an account already exists. Sign in or reset your password to continue.';
+      'Looks like an account already exists. Sign in to it, or contact support if you can\'t get back in.';
 
   @override
   String get authFailedToSendResetEmail => 'Gagal mengirim email reset.';

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -3402,7 +3402,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get authSecureAccountAlreadyRegistered =>
-      'You already have an account. Sign in or reset your password to get back in.';
+      'Looks like an account already exists. Sign in or reset your password to continue.';
 
   @override
   String get authFailedToSendResetEmail =>

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -3402,7 +3402,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get authSecureAccountAlreadyRegistered =>
-      'Looks like an account already exists. Sign in or reset your password to continue.';
+      'Looks like an account already exists. Sign in to it, or contact support if you can\'t get back in.';
 
   @override
   String get authFailedToSendResetEmail =>

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -3401,6 +3401,10 @@ class AppLocalizationsIt extends AppLocalizations {
       'Registrazione completata. Controlla la tua email.';
 
   @override
+  String get authSecureAccountAlreadyRegistered =>
+      'You already have an account. Sign in or reset your password to get back in.';
+
+  @override
   String get authFailedToSendResetEmail =>
       'Impossibile inviare l\'email di reimpostazione.';
 

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -3402,7 +3402,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get authSecureAccountAlreadyRegistered =>
-      'Looks like an account already exists. Sign in to it, or contact support if you can\'t get back in.';
+      'Looks like an account already exists. Try a different email, or sign in to the existing account with this email address. If neither works, contact support.';
 
   @override
   String get authFailedToSendResetEmail =>

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -3147,6 +3147,10 @@ class AppLocalizationsJa extends AppLocalizations {
   String get authRegistrationComplete => '登録完了。メールを確認してね。';
 
   @override
+  String get authSecureAccountAlreadyRegistered =>
+      'You already have an account. Sign in or reset your password to get back in.';
+
+  @override
   String get authFailedToSendResetEmail => 'リセットメールの送信がうまくいかなかった。';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -3148,7 +3148,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get authSecureAccountAlreadyRegistered =>
-      'Looks like an account already exists. Sign in or reset your password to continue.';
+      'Looks like an account already exists. Sign in to it, or contact support if you can\'t get back in.';
 
   @override
   String get authFailedToSendResetEmail => 'リセットメールの送信がうまくいかなかった。';

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -3148,7 +3148,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get authSecureAccountAlreadyRegistered =>
-      'You already have an account. Sign in or reset your password to get back in.';
+      'Looks like an account already exists. Sign in or reset your password to continue.';
 
   @override
   String get authFailedToSendResetEmail => 'リセットメールの送信がうまくいかなかった。';

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -3148,7 +3148,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get authSecureAccountAlreadyRegistered =>
-      'Looks like an account already exists. Sign in to it, or contact support if you can\'t get back in.';
+      'Looks like an account already exists. Try a different email, or sign in to the existing account with this email address. If neither works, contact support.';
 
   @override
   String get authFailedToSendResetEmail => 'リセットメールの送信がうまくいかなかった。';

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -3164,7 +3164,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get authSecureAccountAlreadyRegistered =>
-      'Looks like an account already exists. Sign in to it, or contact support if you can\'t get back in.';
+      'Looks like an account already exists. Try a different email, or sign in to the existing account with this email address. If neither works, contact support.';
 
   @override
   String get authFailedToSendResetEmail => '재설정 이메일을 보내지 못했어요.';

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -3164,7 +3164,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get authSecureAccountAlreadyRegistered =>
-      'Looks like an account already exists. Sign in or reset your password to continue.';
+      'Looks like an account already exists. Sign in to it, or contact support if you can\'t get back in.';
 
   @override
   String get authFailedToSendResetEmail => '재설정 이메일을 보내지 못했어요.';

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -3163,6 +3163,10 @@ class AppLocalizationsKo extends AppLocalizations {
   String get authRegistrationComplete => '가입이 완료됐어요. 이메일을 확인해주세요.';
 
   @override
+  String get authSecureAccountAlreadyRegistered =>
+      'You already have an account. Sign in or reset your password to get back in.';
+
+  @override
   String get authFailedToSendResetEmail => '재설정 이메일을 보내지 못했어요.';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -3164,7 +3164,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get authSecureAccountAlreadyRegistered =>
-      'You already have an account. Sign in or reset your password to get back in.';
+      'Looks like an account already exists. Sign in or reset your password to continue.';
 
   @override
   String get authFailedToSendResetEmail => '재설정 이메일을 보내지 못했어요.';

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -3354,7 +3354,7 @@ class AppLocalizationsMs extends AppLocalizations {
 
   @override
   String get authSecureAccountAlreadyRegistered =>
-      'You already have an account. Sign in or reset your password to get back in.';
+      'Looks like an account already exists. Sign in or reset your password to continue.';
 
   @override
   String get authFailedToSendResetEmail =>

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -3354,7 +3354,7 @@ class AppLocalizationsMs extends AppLocalizations {
 
   @override
   String get authSecureAccountAlreadyRegistered =>
-      'Looks like an account already exists. Sign in or reset your password to continue.';
+      'Looks like an account already exists. Sign in to it, or contact support if you can\'t get back in.';
 
   @override
   String get authFailedToSendResetEmail =>

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -3354,7 +3354,7 @@ class AppLocalizationsMs extends AppLocalizations {
 
   @override
   String get authSecureAccountAlreadyRegistered =>
-      'Looks like an account already exists. Sign in to it, or contact support if you can\'t get back in.';
+      'Looks like an account already exists. Try a different email, or sign in to the existing account with this email address. If neither works, contact support.';
 
   @override
   String get authFailedToSendResetEmail =>

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -3353,6 +3353,10 @@ class AppLocalizationsMs extends AppLocalizations {
       'Pendaftaran lengkap. Sila semak e-mel anda.';
 
   @override
+  String get authSecureAccountAlreadyRegistered =>
+      'You already have an account. Sign in or reset your password to get back in.';
+
+  @override
   String get authFailedToSendResetEmail =>
       'Gagal menghantar e-mel tetapan semula.';
 

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -3372,7 +3372,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get authSecureAccountAlreadyRegistered =>
-      'Looks like an account already exists. Sign in to it, or contact support if you can\'t get back in.';
+      'Looks like an account already exists. Try a different email, or sign in to the existing account with this email address. If neither works, contact support.';
 
   @override
   String get authFailedToSendResetEmail => 'Resetmail versturen mislukt.';

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -3372,7 +3372,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get authSecureAccountAlreadyRegistered =>
-      'You already have an account. Sign in or reset your password to get back in.';
+      'Looks like an account already exists. Sign in or reset your password to continue.';
 
   @override
   String get authFailedToSendResetEmail => 'Resetmail versturen mislukt.';

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -3372,7 +3372,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get authSecureAccountAlreadyRegistered =>
-      'Looks like an account already exists. Sign in or reset your password to continue.';
+      'Looks like an account already exists. Sign in to it, or contact support if you can\'t get back in.';
 
   @override
   String get authFailedToSendResetEmail => 'Resetmail versturen mislukt.';

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -3371,6 +3371,10 @@ class AppLocalizationsNl extends AppLocalizations {
       'Registratie voltooid. Check je e-mail.';
 
   @override
+  String get authSecureAccountAlreadyRegistered =>
+      'You already have an account. Sign in or reset your password to get back in.';
+
+  @override
   String get authFailedToSendResetEmail => 'Resetmail versturen mislukt.';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -3447,7 +3447,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get authSecureAccountAlreadyRegistered =>
-      'Looks like an account already exists. Sign in to it, or contact support if you can\'t get back in.';
+      'Looks like an account already exists. Try a different email, or sign in to the existing account with this email address. If neither works, contact support.';
 
   @override
   String get authFailedToSendResetEmail =>

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -3447,7 +3447,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get authSecureAccountAlreadyRegistered =>
-      'Looks like an account already exists. Sign in or reset your password to continue.';
+      'Looks like an account already exists. Sign in to it, or contact support if you can\'t get back in.';
 
   @override
   String get authFailedToSendResetEmail =>

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -3447,7 +3447,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get authSecureAccountAlreadyRegistered =>
-      'You already have an account. Sign in or reset your password to get back in.';
+      'Looks like an account already exists. Sign in or reset your password to continue.';
 
   @override
   String get authFailedToSendResetEmail =>

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -3446,6 +3446,10 @@ class AppLocalizationsPl extends AppLocalizations {
       'Rejestracja ukończona. Sprawdź e-mail.';
 
   @override
+  String get authSecureAccountAlreadyRegistered =>
+      'You already have an account. Sign in or reset your password to get back in.';
+
+  @override
   String get authFailedToSendResetEmail =>
       'Nie udało się wysłać e-maila z resetem.';
 

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -3383,7 +3383,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get authSecureAccountAlreadyRegistered =>
-      'You already have an account. Sign in or reset your password to get back in.';
+      'Looks like an account already exists. Sign in or reset your password to continue.';
 
   @override
   String get authFailedToSendResetEmail =>

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -3382,6 +3382,10 @@ class AppLocalizationsPt extends AppLocalizations {
       'Registro completo. Verifique seu e-mail.';
 
   @override
+  String get authSecureAccountAlreadyRegistered =>
+      'You already have an account. Sign in or reset your password to get back in.';
+
+  @override
   String get authFailedToSendResetEmail =>
       'Falha ao enviar o e-mail de redefinição.';
 

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -3383,7 +3383,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get authSecureAccountAlreadyRegistered =>
-      'Looks like an account already exists. Sign in or reset your password to continue.';
+      'Looks like an account already exists. Sign in to it, or contact support if you can\'t get back in.';
 
   @override
   String get authFailedToSendResetEmail =>

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -3383,7 +3383,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get authSecureAccountAlreadyRegistered =>
-      'Looks like an account already exists. Sign in to it, or contact support if you can\'t get back in.';
+      'Looks like an account already exists. Try a different email, or sign in to the existing account with this email address. If neither works, contact support.';
 
   @override
   String get authFailedToSendResetEmail =>

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -3462,7 +3462,7 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get authSecureAccountAlreadyRegistered =>
-      'Looks like an account already exists. Sign in to it, or contact support if you can\'t get back in.';
+      'Looks like an account already exists. Try a different email, or sign in to the existing account with this email address. If neither works, contact support.';
 
   @override
   String get authFailedToSendResetEmail =>

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -3462,7 +3462,7 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get authSecureAccountAlreadyRegistered =>
-      'You already have an account. Sign in or reset your password to get back in.';
+      'Looks like an account already exists. Sign in or reset your password to continue.';
 
   @override
   String get authFailedToSendResetEmail =>

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -3462,7 +3462,7 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get authSecureAccountAlreadyRegistered =>
-      'Looks like an account already exists. Sign in or reset your password to continue.';
+      'Looks like an account already exists. Sign in to it, or contact support if you can\'t get back in.';
 
   @override
   String get authFailedToSendResetEmail =>

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -3461,6 +3461,10 @@ class AppLocalizationsRo extends AppLocalizations {
       'Înscriere finalizată. Verifică-ți emailul.';
 
   @override
+  String get authSecureAccountAlreadyRegistered =>
+      'You already have an account. Sign in or reset your password to get back in.';
+
+  @override
   String get authFailedToSendResetEmail =>
       'N-am putut trimite emailul de resetare.';
 

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -3353,7 +3353,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get authSecureAccountAlreadyRegistered =>
-      'Looks like an account already exists. Sign in or reset your password to continue.';
+      'Looks like an account already exists. Sign in to it, or contact support if you can\'t get back in.';
 
   @override
   String get authFailedToSendResetEmail =>

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -3353,7 +3353,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get authSecureAccountAlreadyRegistered =>
-      'Looks like an account already exists. Sign in to it, or contact support if you can\'t get back in.';
+      'Looks like an account already exists. Try a different email, or sign in to the existing account with this email address. If neither works, contact support.';
 
   @override
   String get authFailedToSendResetEmail =>

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -3352,6 +3352,10 @@ class AppLocalizationsSv extends AppLocalizations {
   String get authRegistrationComplete => 'Registrering klar. Kolla din e-post.';
 
   @override
+  String get authSecureAccountAlreadyRegistered =>
+      'You already have an account. Sign in or reset your password to get back in.';
+
+  @override
   String get authFailedToSendResetEmail =>
       'Kunde inte skicka återställningsmejl.';
 

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -3353,7 +3353,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get authSecureAccountAlreadyRegistered =>
-      'You already have an account. Sign in or reset your password to get back in.';
+      'Looks like an account already exists. Sign in or reset your password to continue.';
 
   @override
   String get authFailedToSendResetEmail =>

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -3299,7 +3299,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get authSecureAccountAlreadyRegistered =>
-      'Looks like an account already exists. Sign in to it, or contact support if you can\'t get back in.';
+      'Looks like an account already exists. Try a different email, or sign in to the existing account with this email address. If neither works, contact support.';
 
   @override
   String get authFailedToSendResetEmail => 'Sıfırlama e-postası gönderilemedi.';

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -3299,7 +3299,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get authSecureAccountAlreadyRegistered =>
-      'Looks like an account already exists. Sign in or reset your password to continue.';
+      'Looks like an account already exists. Sign in to it, or contact support if you can\'t get back in.';
 
   @override
   String get authFailedToSendResetEmail => 'Sıfırlama e-postası gönderilemedi.';

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -3298,6 +3298,10 @@ class AppLocalizationsTr extends AppLocalizations {
       'Kayıt tamamlandı. Lütfen e-postanı kontrol et.';
 
   @override
+  String get authSecureAccountAlreadyRegistered =>
+      'You already have an account. Sign in or reset your password to get back in.';
+
+  @override
   String get authFailedToSendResetEmail => 'Sıfırlama e-postası gönderilemedi.';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -3299,7 +3299,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get authSecureAccountAlreadyRegistered =>
-      'You already have an account. Sign in or reset your password to get back in.';
+      'Looks like an account already exists. Sign in or reset your password to continue.';
 
   @override
   String get authFailedToSendResetEmail => 'Sıfırlama e-postası gönderilemedi.';

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -3359,7 +3359,7 @@ class AppLocalizationsUr extends AppLocalizations {
 
   @override
   String get authSecureAccountAlreadyRegistered =>
-      'Looks like an account already exists. Sign in or reset your password to continue.';
+      'Looks like an account already exists. Sign in to it, or contact support if you can\'t get back in.';
 
   @override
   String get authFailedToSendResetEmail => 'ری سیٹ ای میل نہیں بھیجی جا سکی۔';

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -3358,6 +3358,10 @@ class AppLocalizationsUr extends AppLocalizations {
       'رجسٹریشن مکمل۔ براہ کرم اپنی ای میل چیک کریں۔';
 
   @override
+  String get authSecureAccountAlreadyRegistered =>
+      'You already have an account. Sign in or reset your password to get back in.';
+
+  @override
   String get authFailedToSendResetEmail => 'ری سیٹ ای میل نہیں بھیجی جا سکی۔';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -3359,7 +3359,7 @@ class AppLocalizationsUr extends AppLocalizations {
 
   @override
   String get authSecureAccountAlreadyRegistered =>
-      'Looks like an account already exists. Sign in to it, or contact support if you can\'t get back in.';
+      'Looks like an account already exists. Try a different email, or sign in to the existing account with this email address. If neither works, contact support.';
 
   @override
   String get authFailedToSendResetEmail => 'ری سیٹ ای میل نہیں بھیجی جا سکی۔';

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -3359,7 +3359,7 @@ class AppLocalizationsUr extends AppLocalizations {
 
   @override
   String get authSecureAccountAlreadyRegistered =>
-      'You already have an account. Sign in or reset your password to get back in.';
+      'Looks like an account already exists. Sign in or reset your password to continue.';
 
   @override
   String get authFailedToSendResetEmail => 'ری سیٹ ای میل نہیں بھیجی جا سکی۔';

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -3332,6 +3332,10 @@ class AppLocalizationsVi extends AppLocalizations {
       'Đăng ký hoàn tất. Vui lòng kiểm tra email của bạn.';
 
   @override
+  String get authSecureAccountAlreadyRegistered =>
+      'You already have an account. Sign in or reset your password to get back in.';
+
+  @override
   String get authFailedToSendResetEmail => 'Không gửi được email đặt lại.';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -3333,7 +3333,7 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get authSecureAccountAlreadyRegistered =>
-      'Looks like an account already exists. Sign in to it, or contact support if you can\'t get back in.';
+      'Looks like an account already exists. Try a different email, or sign in to the existing account with this email address. If neither works, contact support.';
 
   @override
   String get authFailedToSendResetEmail => 'Không gửi được email đặt lại.';

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -3333,7 +3333,7 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get authSecureAccountAlreadyRegistered =>
-      'Looks like an account already exists. Sign in or reset your password to continue.';
+      'Looks like an account already exists. Sign in to it, or contact support if you can\'t get back in.';
 
   @override
   String get authFailedToSendResetEmail => 'Không gửi được email đặt lại.';

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -3333,7 +3333,7 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get authSecureAccountAlreadyRegistered =>
-      'You already have an account. Sign in or reset your password to get back in.';
+      'Looks like an account already exists. Sign in or reset your password to continue.';
 
   @override
   String get authFailedToSendResetEmail => 'Không gửi được email đặt lại.';

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -3161,7 +3161,7 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get authSecureAccountAlreadyRegistered =>
-      'Looks like an account already exists. Sign in to it, or contact support if you can\'t get back in.';
+      'Looks like an account already exists. Try a different email, or sign in to the existing account with this email address. If neither works, contact support.';
 
   @override
   String get authFailedToSendResetEmail => '重置邮件发送失败。';

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -3161,7 +3161,7 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get authSecureAccountAlreadyRegistered =>
-      'You already have an account. Sign in or reset your password to get back in.';
+      'Looks like an account already exists. Sign in or reset your password to continue.';
 
   @override
   String get authFailedToSendResetEmail => '重置邮件发送失败。';

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -3161,7 +3161,7 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get authSecureAccountAlreadyRegistered =>
-      'Looks like an account already exists. Sign in or reset your password to continue.';
+      'Looks like an account already exists. Sign in to it, or contact support if you can\'t get back in.';
 
   @override
   String get authFailedToSendResetEmail => '重置邮件发送失败。';

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -3160,6 +3160,10 @@ class AppLocalizationsZh extends AppLocalizations {
   String get authRegistrationComplete => '注册完成。请查收你的邮箱。';
 
   @override
+  String get authSecureAccountAlreadyRegistered =>
+      'You already have an account. Sign in or reset your password to get back in.';
+
+  @override
   String get authFailedToSendResetEmail => '重置邮件发送失败。';
 
   @override

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -1921,11 +1921,12 @@ class _DivineAppState extends ConsumerState<DivineApp>
       currentAuthState: () => authService.authState,
       locationListenable: router.routerDelegate,
       currentLocation: () =>
-          router.routerDelegate.currentConfiguration.uri.path,
+          router.routerDelegate.currentConfiguration.uri.toString(),
       authenticatedRedirectPending: (location) =>
           authenticatedRedirectsFromAuthEntry(
             location,
             hasExpiredOAuthSession: authService.hasExpiredOAuthSession,
+            isAnonymous: authService.isAnonymous,
           ),
     );
     // Start deferred startup after the first frame so the shell can paint first.

--- a/mobile/lib/router/app_router_redirect.dart
+++ b/mobile/lib/router/app_router_redirect.dart
@@ -428,6 +428,16 @@ String? appRouterRedirect(Ref ref, GoRouterState state) {
         location == WelcomeScreen.loginOptionsPath) {
       return deepLinkRewrite;
     }
+    // Allow an anonymously-authenticated user through to login options when
+    // they arrive from the Secure account key-conflict recovery flow, which
+    // deep-links here with a prefilled `email` param. Without this they would
+    // be bounced to the feed and the "sign in to the existing account"
+    // recovery affordance would dead-end.
+    if (authService.isAnonymous &&
+        location == WelcomeScreen.loginOptionsPath &&
+        state.uri.queryParameters.containsKey('email')) {
+      return deepLinkRewrite;
+    }
     if (_suppressNextAuthenticatedAuthRouteRedirect) {
       _suppressNextAuthenticatedAuthRouteRedirect = false;
       Log.info(

--- a/mobile/lib/router/auth_entry_redirect.dart
+++ b/mobile/lib/router/auth_entry_redirect.dart
@@ -7,9 +7,8 @@ import 'package:openvine/screens/auth/welcome_screen.dart';
 /// Mirrors that redirect in `goRouterProvider` (`app_router.dart`): an
 /// authenticated user is only redirected home from the sign-in entry points
 /// (`/welcome`, `/nostr-connect`, `/welcome/invite`, `/welcome/create-account`,
-/// `/welcome/login-options`), with the same expired-session exception for login
-/// options (an expired-session user must reach login options to re-authenticate
-/// rather than be bounced home).
+/// `/welcome/login-options`), with the same expired-session and anonymous
+/// recovery exceptions for login options.
 ///
 /// It is deliberately narrower than `app_router.dart`'s broad auth-entry check:
 /// auth-entry routes an authenticated user is intentionally left on —
@@ -26,13 +25,21 @@ import 'package:openvine/screens/auth/welcome_screen.dart';
 bool authenticatedRedirectsFromAuthEntry(
   String location, {
   required bool hasExpiredOAuthSession,
+  required bool isAnonymous,
 }) {
-  if (hasExpiredOAuthSession && location == WelcomeScreen.loginOptionsPath) {
+  final uri = Uri.parse(location);
+  final path = uri.path;
+  if (hasExpiredOAuthSession && path == WelcomeScreen.loginOptionsPath) {
     return false;
   }
-  return location == WelcomeScreen.path ||
-      location == NostrConnectScreen.path ||
-      location == WelcomeScreen.inviteGatePath ||
-      location == WelcomeScreen.createAccountPath ||
-      location == WelcomeScreen.loginOptionsPath;
+  if (isAnonymous &&
+      path == WelcomeScreen.loginOptionsPath &&
+      uri.queryParameters.containsKey('email')) {
+    return false;
+  }
+  return path == WelcomeScreen.path ||
+      path == NostrConnectScreen.path ||
+      path == WelcomeScreen.inviteGatePath ||
+      path == WelcomeScreen.createAccountPath ||
+      path == WelcomeScreen.loginOptionsPath;
 }

--- a/mobile/lib/screens/auth/secure_account_screen.dart
+++ b/mobile/lib/screens/auth/secure_account_screen.dart
@@ -142,9 +142,10 @@ class _SecureAccountScreenState extends ConsumerState<SecureAccountScreen> {
     );
 
     if (!result.success) {
-      // CONFLICT means this key already has an account (the app fell back to
-      // anonymous while the registered key stayed on device). Route to the
-      // recovery hub instead of dead-ending on the raw server text.
+      // CONFLICT means the key or the entered email already has an account
+      // (the common case is a registered key the app forgot after falling back
+      // to anonymous). Route to the recovery hub instead of dead-ending on the
+      // raw server text.
       if (result.errorCode == 'CONFLICT') {
         if (!mounted) return;
         context.go(

--- a/mobile/lib/screens/auth/secure_account_screen.dart
+++ b/mobile/lib/screens/auth/secure_account_screen.dart
@@ -11,6 +11,7 @@ import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/router/route_paths.dart';
 import 'package:openvine/router/routes/router_guards.dart';
+import 'package:openvine/screens/auth/welcome_screen.dart';
 import 'package:openvine/utils/validators.dart';
 import 'package:openvine/widgets/auth/auth_error_box.dart';
 import 'package:openvine/widgets/auth/auth_form_scaffold.dart';
@@ -141,6 +142,19 @@ class _SecureAccountScreenState extends ConsumerState<SecureAccountScreen> {
     );
 
     if (!result.success) {
+      // CONFLICT means this key already has an account (the app fell back to
+      // anonymous while the registered key stayed on device). Route to the
+      // recovery hub instead of dead-ending on the raw server text.
+      if (result.errorCode == 'CONFLICT') {
+        if (!mounted) return;
+        context.go(
+          WelcomeScreen.loginOptionsPathWithRecovery(
+            email: email,
+            error: context.l10n.authSecureAccountAlreadyRegistered,
+          ),
+        );
+        return;
+      }
       _setGeneralError(
         result.errorDescription ?? context.l10n.authRegistrationFailed,
       );

--- a/mobile/lib/screens/auth/secure_account_screen.dart
+++ b/mobile/lib/screens/auth/secure_account_screen.dart
@@ -12,6 +12,7 @@ import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/router/route_paths.dart';
 import 'package:openvine/router/routes/router_guards.dart';
 import 'package:openvine/screens/auth/welcome_screen.dart';
+import 'package:openvine/screens/settings/support_center_screen.dart';
 import 'package:openvine/utils/validators.dart';
 import 'package:openvine/widgets/auth/auth_error_box.dart';
 import 'package:openvine/widgets/auth/auth_form_scaffold.dart';
@@ -36,6 +37,7 @@ class _SecureAccountScreenState extends ConsumerState<SecureAccountScreen> {
   final _passwordController = TextEditingController();
   final _confirmPasswordController = TextEditingController();
   bool _isLoading = false;
+  bool _hasConflict = false;
   String? _emailError;
   String? _passwordError;
   String? _confirmPasswordError;
@@ -45,6 +47,20 @@ class _SecureAccountScreenState extends ConsumerState<SecureAccountScreen> {
     if (mounted) {
       setState(() => _generalError = message);
     }
+  }
+
+  void _onConflictSignIn() {
+    // Push (not go) so a failed sign-in pops back here, where the
+    // "Contact support" fallback is still available.
+    context.push(
+      WelcomeScreen.loginOptionsPathWithRecovery(
+        email: _emailController.text.trim(),
+      ),
+    );
+  }
+
+  void _onConflictContactSupport() {
+    context.push(SupportCenterScreen.path);
   }
 
   @override
@@ -144,16 +160,16 @@ class _SecureAccountScreenState extends ConsumerState<SecureAccountScreen> {
     if (!result.success) {
       // CONFLICT means the key or the entered email already has an account
       // (the common case is a registered key the app forgot after falling back
-      // to anonymous). Route to the recovery hub instead of dead-ending on the
-      // raw server text.
+      // to anonymous). Show recovery choices in place instead of dead-ending on
+      // the raw server text: sign in for the recoverable case, contact support
+      // for the ones we can't resolve in-app (duplicate or credential-less
+      // accounts).
       if (result.errorCode == 'CONFLICT') {
         if (!mounted) return;
-        context.go(
-          WelcomeScreen.loginOptionsPathWithRecovery(
-            email: email,
-            error: context.l10n.authSecureAccountAlreadyRegistered,
-          ),
-        );
+        setState(() {
+          _hasConflict = true;
+          _generalError = context.l10n.authSecureAccountAlreadyRegistered;
+        });
         return;
       }
       _setGeneralError(
@@ -194,7 +210,7 @@ class _SecureAccountScreenState extends ConsumerState<SecureAccountScreen> {
       emailError: _emailError,
       passwordError: _passwordError,
       confirmPasswordError: _confirmPasswordError,
-      enabled: !_isLoading,
+      enabled: !_isLoading && !_hasConflict,
       onEmailChanged: (_) {
         if (_emailError != null) setState(() => _emailError = null);
       },
@@ -214,12 +230,26 @@ class _SecureAccountScreenState extends ConsumerState<SecureAccountScreen> {
       errorWidget: _generalError != null
           ? AuthErrorBox(message: _generalError!)
           : null,
-      primaryButton: DivineButton(
-        expanded: true,
-        label: context.l10n.authSecureAccountTitle,
-        isLoading: _isLoading,
-        onPressed: _handleSubmit,
-      ),
+      primaryButton: _hasConflict
+          ? DivineButton(
+              expanded: true,
+              label: context.l10n.authSignInButton,
+              onPressed: _onConflictSignIn,
+            )
+          : DivineButton(
+              expanded: true,
+              label: context.l10n.authSecureAccountTitle,
+              isLoading: _isLoading,
+              onPressed: _handleSubmit,
+            ),
+      secondaryButton: _hasConflict
+          ? DivineButton(
+              expanded: true,
+              type: .secondary,
+              label: context.l10n.authContactSupport,
+              onPressed: _onConflictContactSupport,
+            )
+          : null,
     );
   }
 }

--- a/mobile/lib/screens/auth/secure_account_screen.dart
+++ b/mobile/lib/screens/auth/secure_account_screen.dart
@@ -105,6 +105,7 @@ class _SecureAccountScreenState extends ConsumerState<SecureAccountScreen> {
       _passwordError = null;
       _confirmPasswordError = null;
       _generalError = null;
+      _hasConflict = false;
     });
 
     final l10n = context.l10n;
@@ -171,8 +172,8 @@ class _SecureAccountScreenState extends ConsumerState<SecureAccountScreen> {
           _hasConflict = true;
           _generalError = context.l10n.authSecureAccountAlreadyRegistered;
         });
-        // The state change disables the form and swaps the buttons; announce it
-        // so a screen-reader user knows registration hit a recoverable conflict.
+        // Announce the new recovery state so a screen-reader user knows
+        // registration hit a recoverable conflict.
         SemanticsService.sendAnnouncement(
           View.of(context),
           context.l10n.authSecureAccountAlreadyRegistered,

--- a/mobile/lib/screens/auth/secure_account_screen.dart
+++ b/mobile/lib/screens/auth/secure_account_screen.dart
@@ -3,6 +3,7 @@
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -170,6 +171,13 @@ class _SecureAccountScreenState extends ConsumerState<SecureAccountScreen> {
           _hasConflict = true;
           _generalError = context.l10n.authSecureAccountAlreadyRegistered;
         });
+        // The state change disables the form and swaps the buttons; announce it
+        // so a screen-reader user knows registration hit a recoverable conflict.
+        SemanticsService.sendAnnouncement(
+          View.of(context),
+          context.l10n.authSecureAccountAlreadyRegistered,
+          Directionality.of(context),
+        );
         return;
       }
       _setGeneralError(

--- a/mobile/lib/screens/auth/secure_account_screen.dart
+++ b/mobile/lib/screens/auth/secure_account_screen.dart
@@ -218,9 +218,18 @@ class _SecureAccountScreenState extends ConsumerState<SecureAccountScreen> {
       emailError: _emailError,
       passwordError: _passwordError,
       confirmPasswordError: _confirmPasswordError,
-      enabled: !_isLoading && !_hasConflict,
+      enabled: !_isLoading,
       onEmailChanged: (_) {
-        if (_emailError != null) setState(() => _emailError = null);
+        if (_emailError == null && !_hasConflict) return;
+        setState(() {
+          _emailError = null;
+          // Editing the email clears the conflict so a different address can
+          // be retried in place (the email-already-registered case).
+          if (_hasConflict) {
+            _hasConflict = false;
+            _generalError = null;
+          }
+        });
       },
       onPasswordChanged: (_) {
         if (_passwordError != null || _confirmPasswordError != null) {
@@ -235,29 +244,60 @@ class _SecureAccountScreenState extends ConsumerState<SecureAccountScreen> {
           setState(() => _confirmPasswordError = null);
         }
       },
-      errorWidget: _generalError != null
+      // The conflict message rides at the top (above the fields) so it stays
+      // in view alongside the recovery choices; transient errors stay inline.
+      headerWidget: _hasConflict && _generalError != null
           ? AuthErrorBox(message: _generalError!)
           : null,
-      primaryButton: _hasConflict
-          ? DivineButton(
-              expanded: true,
-              label: context.l10n.authSignInButton,
-              onPressed: _onConflictSignIn,
-            )
-          : DivineButton(
-              expanded: true,
-              label: context.l10n.authSecureAccountTitle,
-              isLoading: _isLoading,
-              onPressed: _handleSubmit,
-            ),
+      errorWidget: !_hasConflict && _generalError != null
+          ? AuthErrorBox(message: _generalError!)
+          : null,
+      primaryButton: DivineButton(
+        expanded: true,
+        label: context.l10n.authSecureAccountTitle,
+        isLoading: _isLoading,
+        onPressed: _handleSubmit,
+      ),
       secondaryButton: _hasConflict
-          ? DivineButton(
-              expanded: true,
-              type: .secondary,
-              label: context.l10n.authContactSupport,
-              onPressed: _onConflictContactSupport,
+          ? _ConflictActions(
+              onSignIn: _onConflictSignIn,
+              onContactSupport: _onConflictContactSupport,
             )
           : null,
+    );
+  }
+}
+
+/// The sign-in and contact-support recovery actions shown below the retry
+/// button when Secure account hits an already-registered conflict.
+class _ConflictActions extends StatelessWidget {
+  const _ConflictActions({
+    required this.onSignIn,
+    required this.onContactSupport,
+  });
+
+  final VoidCallback onSignIn;
+  final VoidCallback onContactSupport;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      spacing: 12,
+      children: [
+        DivineButton(
+          expanded: true,
+          type: .secondary,
+          label: context.l10n.authSignInButton,
+          onPressed: onSignIn,
+        ),
+        DivineButton(
+          expanded: true,
+          type: .link,
+          label: context.l10n.authContactSupport,
+          onPressed: onContactSupport,
+        ),
+      ],
     );
   }
 }

--- a/mobile/test/l10n/arb_consistency_test.dart
+++ b/mobile/test/l10n/arb_consistency_test.dart
@@ -491,7 +491,7 @@ const _knownUntranslatedDebt = <String>{
   'exploreFeaturedPaidPartnership',
   'exploreFeaturedSponsoredPillSemanticLabel',
   // Secure-account key-conflict recovery copy is new; translation pass
-  // tracked in #7782.
+  // tracked in #7984.
   'authSecureAccountAlreadyRegistered',
   // The four social-proof keys and searchUserVideoCount left this list when
   // this branch translated them into every locale.

--- a/mobile/test/l10n/arb_consistency_test.dart
+++ b/mobile/test/l10n/arb_consistency_test.dart
@@ -490,6 +490,9 @@ const _knownUntranslatedDebt = <String>{
   // pass tracked in #7673, and required before any non-English campaign.
   'exploreFeaturedPaidPartnership',
   'exploreFeaturedSponsoredPillSemanticLabel',
+  // Secure-account key-conflict recovery copy is new; translation pass
+  // tracked in #7782.
+  'authSecureAccountAlreadyRegistered',
   // The four social-proof keys and searchUserVideoCount left this list when
   // this branch translated them into every locale.
 };

--- a/mobile/test/router/app_router_redirect_test.dart
+++ b/mobile/test/router/app_router_redirect_test.dart
@@ -1,11 +1,27 @@
 // ABOUTME: Unit tests for the router-refresh gate that keeps a resume/background
-// ABOUTME: review-status refetch from tearing down a reel pushed on top mid-init.
+// ABOUTME: review-status refetch from tearing down a reel pushed on top mid-init,
+// ABOUTME: plus the anonymous Secure-account conflict recovery redirect exception.
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_riverpod/legacy.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:openvine/models/minor_account_review_status.dart';
+import 'package:openvine/providers/auth_providers.dart';
+import 'package:openvine/providers/minor_account_review_providers.dart';
 import 'package:openvine/router/app_router.dart';
+import 'package:openvine/router/providers/redirect_provider.dart';
+import 'package:openvine/screens/feed/video_feed_page.dart';
+import 'package:openvine/services/auth_service.dart';
+
+class _MockAuthService extends Mock implements AuthService {}
+
+class _MockGoRouterState extends Mock implements GoRouterState {}
+
+/// Exposes the container's [Ref] so tests can invoke [appRouterRedirect],
+/// which reads providers off the ref GoRouter hands it in production.
+final _refProbeProvider = Provider<Ref>((ref) => ref);
 
 /// The retained-value loading emission a `ref.watch`-driven reload produces for
 /// a provider currently holding [value]: an `AsyncLoading` that still carries
@@ -177,5 +193,77 @@ void main() {
         isTrue,
       );
     });
+  });
+
+  group('anonymous Secure-account conflict recovery redirect', () {
+    late _MockAuthService authService;
+
+    setUp(() {
+      resetNavigationState();
+      authService = _MockAuthService();
+      when(() => authService.authState).thenReturn(AuthState.authenticated);
+      when(() => authService.isAnonymous).thenReturn(true);
+      when(() => authService.hasExpiredOAuthSession).thenReturn(false);
+    });
+
+    // A resolved active status so the minor-account-review gates fall through
+    // to the authenticated auth-route handling this group exercises.
+    Future<ProviderContainer> buildContainer() async {
+      final container = ProviderContainer(
+        overrides: [
+          authServiceProvider.overrideWithValue(authService),
+          currentMinorAccountReviewStatusProvider.overrideWith(
+            (ref) async => MinorAccountReviewStatus.active(),
+          ),
+          checkEmptyFollowingRedirectProvider.overrideWith(
+            (ref, location) => null,
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      await container.read(currentMinorAccountReviewStatusProvider.future);
+      return container;
+    }
+
+    GoRouterState stateFor(String location) {
+      final uri = Uri.parse(location);
+      final state = _MockGoRouterState();
+      when(() => state.uri).thenReturn(uri);
+      when(() => state.matchedLocation).thenReturn(uri.path);
+      return state;
+    }
+
+    test(
+      'lets an anonymous authenticated user reach login options when arriving '
+      'from conflict recovery (email param present)',
+      () async {
+        final container = await buildContainer();
+        final ref = container.read(_refProbeProvider);
+
+        final result = appRouterRedirect(
+          ref,
+          stateFor('/welcome/login-options?email=user%40example.com'),
+        );
+
+        // Null: no redirect, the recovery sign-in destination stays visible.
+        expect(result, isNull);
+      },
+    );
+
+    test(
+      'still bounces an anonymous authenticated user to the feed on plain '
+      'login options with no recovery param',
+      () async {
+        final container = await buildContainer();
+        final ref = container.read(_refProbeProvider);
+
+        final result = appRouterRedirect(
+          ref,
+          stateFor('/welcome/login-options'),
+        );
+
+        expect(result, VideoFeedPage.pathForIndex(0));
+      },
+    );
   });
 }

--- a/mobile/test/router/app_router_redirect_test.dart
+++ b/mobile/test/router/app_router_redirect_test.dart
@@ -13,6 +13,7 @@ import 'package:openvine/providers/minor_account_review_providers.dart';
 import 'package:openvine/router/app_router.dart';
 import 'package:openvine/router/providers/redirect_provider.dart';
 import 'package:openvine/screens/feed/video_feed_page.dart';
+import 'package:openvine/screens/minor_account_review_screen.dart';
 import 'package:openvine/services/auth_service.dart';
 
 class _MockAuthService extends Mock implements AuthService {}
@@ -206,14 +207,18 @@ void main() {
       when(() => authService.hasExpiredOAuthSession).thenReturn(false);
     });
 
-    // A resolved active status so the minor-account-review gates fall through
-    // to the authenticated auth-route handling this group exercises.
-    Future<ProviderContainer> buildContainer() async {
+    // Defaults to a resolved active status so the minor-account-review gates
+    // fall through to the authenticated auth-route handling this group
+    // exercises; pass a restricted status to assert the gate ordering holds.
+    Future<ProviderContainer> buildContainer({
+      MinorAccountReviewStatus? reviewStatus,
+    }) async {
+      final status = reviewStatus ?? MinorAccountReviewStatus.active();
       final container = ProviderContainer(
         overrides: [
           authServiceProvider.overrideWithValue(authService),
           currentMinorAccountReviewStatusProvider.overrideWith(
-            (ref) async => MinorAccountReviewStatus.active(),
+            (ref) async => status,
           ),
           checkEmptyFollowingRedirectProvider.overrideWith(
             (ref, location) => null,
@@ -263,6 +268,27 @@ void main() {
         );
 
         expect(result, VideoFeedPage.pathForIndex(0));
+      },
+    );
+
+    test(
+      'still routes a restricted-minor anonymous user to review even with the '
+      'recovery email param — the recovery exception must not outrank the '
+      'load-bearing minor-review gate',
+      () async {
+        final container = await buildContainer(
+          reviewStatus: const MinorAccountReviewStatus(
+            restrictionStatus: AccountRestrictionStatus.restrictedMinorReview,
+          ),
+        );
+        final ref = container.read(_refProbeProvider);
+
+        final result = appRouterRedirect(
+          ref,
+          stateFor('/welcome/login-options?email=user%40example.com'),
+        );
+
+        expect(result, MinorAccountReviewScreen.path);
       },
     );
   });

--- a/mobile/test/router/login_flow_redirect_test.dart
+++ b/mobile/test/router/login_flow_redirect_test.dart
@@ -18,14 +18,15 @@ import 'package:openvine/services/auth_service.dart';
 /// dependencies.
 ///
 /// The authenticated auth-route decision (rule 1, including the expired-session
-/// login-options exception) delegates to the real
+/// and anonymous recovery exceptions) delegates to the real
 /// [authenticatedRedirectsFromAuthEntry] helper, so that branch cannot drift
 /// from the router. Only the unauthenticated `isAuthRoute` mirror (rule 2)
 /// remains a local copy — keep it in sync when adding a new auth route.
 ///
 /// The actual redirect logic is:
 /// 1. If authenticated AND on top-level auth entry routes -> redirect to /home/0
-///    (EXCEPT expired-session users navigating to loginOptionsPath)
+///    (EXCEPT expired-session users and anonymous email-recovery users
+///    navigating to loginOptionsPath)
 ///    (EXCEPT import-key, which doubles as an authenticated account-switch route)
 /// 2. If NOT on auth route AND unauthenticated -> redirect to /welcome
 /// 3. Otherwise -> null (no redirect)
@@ -33,6 +34,7 @@ String? testRedirectLogic({
   required String location,
   required AuthState authState,
   bool hasExpiredOAuthSession = false,
+  bool isAnonymous = false,
 }) {
   // Auth routes that should be accessible without authentication.
   // Mirrors the isAuthRoute check in app_router.dart.
@@ -52,6 +54,7 @@ String? testRedirectLogic({
       authenticatedRedirectsFromAuthEntry(
         location,
         hasExpiredOAuthSession: hasExpiredOAuthSession,
+        isAnonymous: isAnonymous,
       )) {
     return VideoFeedPage.pathForIndex(0);
   }
@@ -486,6 +489,28 @@ void main() {
   });
 
   group('authenticatedRedirectsFromAuthEntry', () {
+    test('anonymous email recovery has no pending home redirect', () {
+      expect(
+        authenticatedRedirectsFromAuthEntry(
+          '${WelcomeScreen.loginOptionsPath}?email=existing%40example.com',
+          hasExpiredOAuthSession: false,
+          isAnonymous: true,
+        ),
+        isFalse,
+      );
+    });
+
+    test('registered users with an email query still redirect home', () {
+      expect(
+        authenticatedRedirectsFromAuthEntry(
+          '${WelcomeScreen.loginOptionsPath}?email=existing%40example.com',
+          hasExpiredOAuthSession: false,
+          isAnonymous: false,
+        ),
+        isTrue,
+      );
+    });
+
     group('redirects an authenticated user home from', () {
       for (final location in <String>[
         WelcomeScreen.path,
@@ -499,6 +524,7 @@ void main() {
             authenticatedRedirectsFromAuthEntry(
               location,
               hasExpiredOAuthSession: false,
+              isAnonymous: false,
             ),
             isTrue,
             reason: '$location is a sign-in entry point — bounce home',
@@ -521,6 +547,7 @@ void main() {
             authenticatedRedirectsFromAuthEntry(
               location,
               hasExpiredOAuthSession: false,
+              isAnonymous: false,
             ),
             isFalse,
             reason: '$location is a route the router leaves the user on',
@@ -534,6 +561,7 @@ void main() {
         authenticatedRedirectsFromAuthEntry(
           WelcomeScreen.loginOptionsPath,
           hasExpiredOAuthSession: true,
+          isAnonymous: false,
         ),
         isFalse,
         reason: 'expired-session users must reach login options to re-auth',
@@ -545,6 +573,7 @@ void main() {
         authenticatedRedirectsFromAuthEntry(
           WelcomeScreen.path,
           hasExpiredOAuthSession: true,
+          isAnonymous: false,
         ),
         isTrue,
         reason: 'the expired-session exception only applies to login options',

--- a/mobile/test/screens/auth/secure_account_screen_test.dart
+++ b/mobile/test/screens/auth/secure_account_screen_test.dart
@@ -685,101 +685,146 @@ void main() {
     });
 
     group('Key conflict recovery', () {
-      testWidgets(
-        'routes to login options with a localized message when the key is '
-        'already registered',
-        (tester) async {
-          when(
-            () => mockOAuth.headlessRegister(
-              email: any(named: 'email'),
-              password: any(named: 'password'),
-              nsec: any(named: 'nsec'),
-              scope: any(named: 'scope'),
+      Future<GoRouter> pumpConflict(WidgetTester tester) async {
+        await setRegistrationTestSurface(tester);
+        when(
+          () => mockOAuth.headlessRegister(
+            email: any(named: 'email'),
+            password: any(named: 'password'),
+            nsec: any(named: 'nsec'),
+            scope: any(named: 'scope'),
+          ),
+        ).thenAnswer(
+          (_) async => (
+            HeadlessRegisterResult.error(
+              'This Nostr key is already registered. '
+              'Please log in instead or use a different key.',
+              code: 'CONFLICT',
             ),
-          ).thenAnswer(
-            (_) async => (
-              HeadlessRegisterResult.error(
-                'This Nostr key is already registered. '
-                'Please log in instead or use a different key.',
-                code: 'CONFLICT',
-              ),
-              'test-verifier',
-            ),
-          );
+            'test-verifier',
+          ),
+        );
 
-          final router = GoRouter(
-            initialLocation: '/welcome',
-            routes: [
-              GoRoute(
-                path: '/welcome',
-                builder: (_, _) => const SecureAccountScreen(),
-              ),
-              GoRoute(
-                path: '/welcome/login-options',
-                builder: (_, _) => const SizedBox.shrink(),
-              ),
+        final router = GoRouter(
+          initialLocation: '/welcome',
+          routes: [
+            GoRoute(
+              path: '/welcome',
+              builder: (_, _) => const SecureAccountScreen(),
+            ),
+            GoRoute(
+              path: '/welcome/login-options',
+              builder: (_, state) =>
+                  Text('login-options:${state.uri.queryParameters['email']}'),
+            ),
+            GoRoute(
+              path: '/support-center',
+              builder: (_, _) => const Text('support-center-stub'),
+            ),
+          ],
+        );
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              ...getStandardTestOverrides(),
+              oauthClientProvider.overrideWithValue(mockOAuth),
+              authServiceProvider.overrideWithValue(mockAuthService),
             ],
-          );
-
-          await tester.pumpWidget(
-            ProviderScope(
-              overrides: [
-                ...getStandardTestOverrides(),
-                oauthClientProvider.overrideWithValue(mockOAuth),
-                authServiceProvider.overrideWithValue(mockAuthService),
-              ],
-              child: MaterialApp.router(
-                localizationsDelegates: AppLocalizations.localizationsDelegates,
-                supportedLocales: AppLocalizations.supportedLocales,
-                routerConfig: router,
-              ),
+            child: MaterialApp.router(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              routerConfig: router,
             ),
-          );
-          await tester.pumpAndSettle();
+          ),
+        );
+        await tester.pumpAndSettle();
 
-          await tester.enterText(
-            find.descendant(
-              of: find.widgetWithText(DivineAuthTextField, 'Email'),
-              matching: find.byType(TextField),
-            ),
-            'existing@example.com',
-          );
-          await tester.enterText(
-            find.descendant(
-              of: find.widgetWithText(DivineAuthTextField, 'Password'),
-              matching: find.byType(TextField),
-            ),
-            'SecurePass123!',
-          );
-          await tester.enterText(
-            find.descendant(
-              of: find.widgetWithText(DivineAuthTextField, 'Confirm password'),
-              matching: find.byType(TextField),
-            ),
-            'SecurePass123!',
-          );
+        await tester.enterText(
+          find.descendant(
+            of: find.widgetWithText(DivineAuthTextField, 'Email'),
+            matching: find.byType(TextField),
+          ),
+          'existing@example.com',
+        );
+        await tester.enterText(
+          find.descendant(
+            of: find.widgetWithText(DivineAuthTextField, 'Password'),
+            matching: find.byType(TextField),
+          ),
+          'SecurePass123!',
+        );
+        await tester.enterText(
+          find.descendant(
+            of: find.widgetWithText(DivineAuthTextField, 'Confirm password'),
+            matching: find.byType(TextField),
+          ),
+          'SecurePass123!',
+        );
 
-          await tester.tap(
-            find.widgetWithText(DivineButton, 'Secure account'),
-          );
-          // Let the exportNsec microtask, the headlessRegister future, and the
-          // resulting context.go settle without pumpAndSettle (avoids a hang).
-          await tester.pump();
-          await tester.pump(const Duration(milliseconds: 100));
+        await tester.tap(find.widgetWithText(DivineButton, 'Secure account'));
+        // Settle the exportNsec microtask + headlessRegister future without
+        // pumpAndSettle (avoids a hang on the loading spinner).
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 100));
 
-          final uri = router.routeInformationProvider.value.uri;
-          final l10n = lookupAppLocalizations(const Locale('en'));
+        return router;
+      }
 
-          // Routes to the recovery hub with the localized message (not the raw
-          // server sentence), carrying the entered email.
-          expect(uri.path, '/welcome/login-options');
-          expect(
-            uri.queryParameters['error'],
-            l10n.authSecureAccountAlreadyRegistered,
-          );
-          expect(uri.queryParameters['email'], 'existing@example.com');
-        },
-      );
+      testWidgets('shows in-place recovery choices instead of navigating away', (
+        tester,
+      ) async {
+        final router = await pumpConflict(tester);
+        final l10n = lookupAppLocalizations(const Locale('en'));
+
+        // Stays on the screen and offers both doors rather than auto-bouncing.
+        expect(router.routeInformationProvider.value.uri.path, '/welcome');
+        expect(
+          find.text(l10n.authSecureAccountAlreadyRegistered),
+          findsOneWidget,
+        );
+        expect(
+          find.widgetWithText(DivineButton, l10n.authSignInButton),
+          findsOneWidget,
+        );
+        expect(
+          find.widgetWithText(DivineButton, l10n.authContactSupport),
+          findsOneWidget,
+        );
+        // The raw server sentence never reaches the user.
+        expect(find.textContaining('Nostr key'), findsNothing);
+      });
+
+      testWidgets('Sign in routes to the recovery hub with the email', (
+        tester,
+      ) async {
+        await pumpConflict(tester);
+        final l10n = lookupAppLocalizations(const Locale('en'));
+
+        await tester.tap(
+          find.widgetWithText(DivineButton, l10n.authSignInButton),
+        );
+        await tester.pumpAndSettle();
+
+        expect(
+          find.text('login-options:existing@example.com'),
+          findsOneWidget,
+        );
+      });
+
+      testWidgets('Contact support routes to the support center', (
+        tester,
+      ) async {
+        await pumpConflict(tester);
+        final l10n = lookupAppLocalizations(const Locale('en'));
+
+        await tester.tap(
+          find.widgetWithText(DivineButton, l10n.authContactSupport),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text('support-center-stub'), findsOneWidget);
+      });
     });
   });
 }

--- a/mobile/test/screens/auth/secure_account_screen_test.dart
+++ b/mobile/test/screens/auth/secure_account_screen_test.dart
@@ -762,19 +762,21 @@ void main() {
           await tester.tap(
             find.widgetWithText(DivineButton, 'Secure account'),
           );
+          // Let the exportNsec microtask, the headlessRegister future, and the
+          // resulting context.go settle without pumpAndSettle (avoids a hang).
           await tester.pump();
           await tester.pump(const Duration(milliseconds: 100));
 
           final uri = router.routeInformationProvider.value.uri;
           final l10n = lookupAppLocalizations(const Locale('en'));
 
+          // Routes to the recovery hub with the localized message (not the raw
+          // server sentence), carrying the entered email.
           expect(uri.path, '/welcome/login-options');
           expect(
             uri.queryParameters['error'],
             l10n.authSecureAccountAlreadyRegistered,
           );
-          // The raw server sentence must not leak through to the user.
-          expect(uri.queryParameters['error'], isNot(contains('Nostr key')));
           expect(uri.queryParameters['email'], 'existing@example.com');
         },
       );

--- a/mobile/test/screens/auth/secure_account_screen_test.dart
+++ b/mobile/test/screens/auth/secure_account_screen_test.dart
@@ -762,7 +762,12 @@ void main() {
           'SecurePass123!',
         );
 
-        await tester.tap(find.widgetWithText(DivineButton, 'Secure account'));
+        await tester.tap(
+          find.widgetWithText(
+            DivineButton,
+            lookupAppLocalizations(const Locale('en')).authSecureAccountTitle,
+          ),
+        );
         // Settle the exportNsec microtask + headlessRegister future without
         // pumpAndSettle (avoids a hang on the loading spinner).
         await tester.pump();
@@ -791,6 +796,19 @@ void main() {
           find.widgetWithText(DivineButton, l10n.authContactSupport),
           findsOneWidget,
         );
+        // The submit is replaced by the recovery choices, not shown alongside.
+        expect(
+          find.widgetWithText(DivineButton, l10n.authSecureAccountTitle),
+          findsNothing,
+        );
+        // The form is disabled so the two choices are the only path forward.
+        final emailField = tester.widget<TextField>(
+          find.descendant(
+            of: find.widgetWithText(DivineAuthTextField, 'Email'),
+            matching: find.byType(TextField),
+          ),
+        );
+        expect(emailField.enabled, isFalse);
         // The raw server sentence never reaches the user.
         expect(find.textContaining('Nostr key'), findsNothing);
       });

--- a/mobile/test/screens/auth/secure_account_screen_test.dart
+++ b/mobile/test/screens/auth/secure_account_screen_test.dart
@@ -683,5 +683,101 @@ void main() {
         );
       });
     });
+
+    group('Key conflict recovery', () {
+      testWidgets(
+        'routes to login options with a localized message when the key is '
+        'already registered',
+        (tester) async {
+          when(
+            () => mockOAuth.headlessRegister(
+              email: any(named: 'email'),
+              password: any(named: 'password'),
+              nsec: any(named: 'nsec'),
+              scope: any(named: 'scope'),
+            ),
+          ).thenAnswer(
+            (_) async => (
+              HeadlessRegisterResult.error(
+                'This Nostr key is already registered. '
+                'Please log in instead or use a different key.',
+                code: 'CONFLICT',
+              ),
+              'test-verifier',
+            ),
+          );
+
+          final router = GoRouter(
+            initialLocation: '/welcome',
+            routes: [
+              GoRoute(
+                path: '/welcome',
+                builder: (_, _) => const SecureAccountScreen(),
+              ),
+              GoRoute(
+                path: '/welcome/login-options',
+                builder: (_, _) => const SizedBox.shrink(),
+              ),
+            ],
+          );
+
+          await tester.pumpWidget(
+            ProviderScope(
+              overrides: [
+                ...getStandardTestOverrides(),
+                oauthClientProvider.overrideWithValue(mockOAuth),
+                authServiceProvider.overrideWithValue(mockAuthService),
+              ],
+              child: MaterialApp.router(
+                localizationsDelegates: AppLocalizations.localizationsDelegates,
+                supportedLocales: AppLocalizations.supportedLocales,
+                routerConfig: router,
+              ),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          await tester.enterText(
+            find.descendant(
+              of: find.widgetWithText(DivineAuthTextField, 'Email'),
+              matching: find.byType(TextField),
+            ),
+            'existing@example.com',
+          );
+          await tester.enterText(
+            find.descendant(
+              of: find.widgetWithText(DivineAuthTextField, 'Password'),
+              matching: find.byType(TextField),
+            ),
+            'SecurePass123!',
+          );
+          await tester.enterText(
+            find.descendant(
+              of: find.widgetWithText(DivineAuthTextField, 'Confirm password'),
+              matching: find.byType(TextField),
+            ),
+            'SecurePass123!',
+          );
+
+          await tester.tap(
+            find.widgetWithText(DivineButton, 'Secure account'),
+          );
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 100));
+
+          final uri = router.routeInformationProvider.value.uri;
+          final l10n = lookupAppLocalizations(const Locale('en'));
+
+          expect(uri.path, '/welcome/login-options');
+          expect(
+            uri.queryParameters['error'],
+            l10n.authSecureAccountAlreadyRegistered,
+          );
+          // The raw server sentence must not leak through to the user.
+          expect(uri.queryParameters['error'], isNot(contains('Nostr key')));
+          expect(uri.queryParameters['email'], 'existing@example.com');
+        },
+      );
+    });
   });
 }

--- a/mobile/test/screens/auth/secure_account_screen_test.dart
+++ b/mobile/test/screens/auth/secure_account_screen_test.dart
@@ -459,9 +459,7 @@ void main() {
             'SecurePass123!',
           );
 
-          await tester.tap(
-            find.widgetWithText(DivineButton, 'Secure account'),
-          );
+          await tester.tap(find.widgetWithText(DivineButton, 'Secure account'));
           await tester.pump();
           await tester.pump(const Duration(milliseconds: 500));
 
@@ -778,9 +776,7 @@ void main() {
 
       testWidgets(
         'shows in-place recovery choices instead of navigating away',
-        (
-          tester,
-        ) async {
+        (tester) async {
           final router = await pumpConflict(tester);
           final l10n = lookupAppLocalizations(const Locale('en'));
 
@@ -849,6 +845,63 @@ void main() {
         );
       });
 
+      testWidgets(
+        'resubmitting clears stale recovery actions and renders the new result',
+        (tester) async {
+          await pumpConflict(tester);
+          final l10n = lookupAppLocalizations(const Locale('en'));
+          final retry = Completer<(HeadlessRegisterResult, String)>();
+          when(
+            () => mockOAuth.headlessRegister(
+              email: any(named: 'email'),
+              password: any(named: 'password'),
+              nsec: any(named: 'nsec'),
+              scope: any(named: 'scope'),
+            ),
+          ).thenAnswer((_) => retry.future);
+
+          await tester.tap(
+            find.widgetWithText(DivineButton, l10n.authSecureAccountTitle),
+          );
+          await tester.pump();
+
+          expect(
+            find.text(l10n.authSecureAccountAlreadyRegistered),
+            findsNothing,
+          );
+          expect(
+            find.widgetWithText(DivineButton, l10n.authSignInButton),
+            findsNothing,
+          );
+          expect(
+            find.widgetWithText(DivineButton, l10n.authContactSupport),
+            findsNothing,
+          );
+
+          retry.complete((
+            HeadlessRegisterResult(
+              success: true,
+              pubkey: 'test-pubkey',
+              verificationRequired: false,
+              email: 'existing@example.com',
+            ),
+            'test-verifier',
+          ));
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 100));
+
+          expect(find.text(l10n.authRegistrationComplete), findsOneWidget);
+          expect(
+            find.widgetWithText(DivineButton, l10n.authSignInButton),
+            findsNothing,
+          );
+          expect(
+            find.widgetWithText(DivineButton, l10n.authContactSupport),
+            findsNothing,
+          );
+        },
+      );
+
       testWidgets('Sign in routes to the recovery hub with the email', (
         tester,
       ) async {
@@ -860,10 +913,7 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        expect(
-          find.text('login-options:existing@example.com'),
-          findsOneWidget,
-        );
+        expect(find.text('login-options:existing@example.com'), findsOneWidget);
       });
 
       testWidgets('Contact support routes to the support center', (

--- a/mobile/test/screens/auth/secure_account_screen_test.dart
+++ b/mobile/test/screens/auth/secure_account_screen_test.dart
@@ -776,41 +776,77 @@ void main() {
         return router;
       }
 
-      testWidgets('shows in-place recovery choices instead of navigating away', (
+      testWidgets(
+        'shows in-place recovery choices instead of navigating away',
+        (
+          tester,
+        ) async {
+          final router = await pumpConflict(tester);
+          final l10n = lookupAppLocalizations(const Locale('en'));
+
+          // Stays on the screen and offers recovery choices rather than
+          // auto-bouncing.
+          expect(router.routeInformationProvider.value.uri.path, '/welcome');
+          expect(
+            find.text(l10n.authSecureAccountAlreadyRegistered),
+            findsOneWidget,
+          );
+          // Retry stays available (form is not locked) alongside the
+          // sign-in and contact-support doors.
+          expect(
+            find.widgetWithText(DivineButton, l10n.authSecureAccountTitle),
+            findsOneWidget,
+          );
+          expect(
+            find.widgetWithText(DivineButton, l10n.authSignInButton),
+            findsOneWidget,
+          );
+          expect(
+            find.widgetWithText(DivineButton, l10n.authContactSupport),
+            findsOneWidget,
+          );
+          // The form stays editable so a different email can be tried in place.
+          final emailField = tester.widget<TextField>(
+            find.descendant(
+              of: find.widgetWithText(DivineAuthTextField, 'Email'),
+              matching: find.byType(TextField),
+            ),
+          );
+          expect(emailField.enabled, isTrue);
+          // The raw server sentence never reaches the user.
+          expect(find.textContaining('Nostr key'), findsNothing);
+        },
+      );
+
+      testWidgets('editing the email clears the conflict for a fresh retry', (
         tester,
       ) async {
-        final router = await pumpConflict(tester);
+        await pumpConflict(tester);
         final l10n = lookupAppLocalizations(const Locale('en'));
 
-        // Stays on the screen and offers both doors rather than auto-bouncing.
-        expect(router.routeInformationProvider.value.uri.path, '/welcome');
         expect(
           find.text(l10n.authSecureAccountAlreadyRegistered),
           findsOneWidget,
         );
-        expect(
-          find.widgetWithText(DivineButton, l10n.authSignInButton),
-          findsOneWidget,
-        );
-        expect(
-          find.widgetWithText(DivineButton, l10n.authContactSupport),
-          findsOneWidget,
-        );
-        // The submit is replaced by the recovery choices, not shown alongside.
-        expect(
-          find.widgetWithText(DivineButton, l10n.authSecureAccountTitle),
-          findsNothing,
-        );
-        // The form is disabled so the two choices are the only path forward.
-        final emailField = tester.widget<TextField>(
+
+        await tester.enterText(
           find.descendant(
             of: find.widgetWithText(DivineAuthTextField, 'Email'),
             matching: find.byType(TextField),
           ),
+          'different@example.com',
         );
-        expect(emailField.enabled, isFalse);
-        // The raw server sentence never reaches the user.
-        expect(find.textContaining('Nostr key'), findsNothing);
+        await tester.pump();
+
+        // The conflict message and its recovery doors clear on edit.
+        expect(
+          find.text(l10n.authSecureAccountAlreadyRegistered),
+          findsNothing,
+        );
+        expect(
+          find.widgetWithText(DivineButton, l10n.authContactSupport),
+          findsNothing,
+        );
       });
 
       testWidgets('Sign in routes to the recovery hub with the email', (

--- a/mobile/test/startup/startup_splash_release_controller_test.dart
+++ b/mobile/test/startup/startup_splash_release_controller_test.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:fake_async/fake_async.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/router/auth_entry_redirect.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/startup/startup_splash_release_controller.dart';
 
@@ -246,6 +247,49 @@ void main() {
           // No lingering timer to fire later.
           async.elapse(timeout * 2);
           expect(releases, 1);
+
+          controller.dispose();
+          location.dispose();
+          unawaited(auth.close());
+        });
+      },
+    );
+
+    test(
+      'anonymous login recovery releases without waiting for the timeout',
+      () {
+        fakeAsync((async) {
+          final auth = StreamController<AuthState>.broadcast();
+          final location = ValueNotifier<String>(
+            '/welcome/login-options?email=existing%40example.com',
+          );
+          var state = AuthState.checking;
+          var releases = 0;
+
+          final controller = StartupSplashReleaseController(
+            authStateStream: auth.stream,
+            currentAuthState: () => state,
+            locationListenable: location,
+            currentLocation: () => location.value,
+            authenticatedRedirectPending: (currentLocation) =>
+                authenticatedRedirectsFromAuthEntry(
+                  currentLocation,
+                  hasExpiredOAuthSession: false,
+                  isAnonymous: true,
+                ),
+            timeout: timeout,
+            release: () => releases++,
+          );
+
+          state = AuthState.authenticated;
+          auth.add(AuthState.authenticated);
+          async.flushMicrotasks();
+
+          expect(
+            releases,
+            1,
+            reason: 'the router leaves anonymous recovery on login options',
+          );
 
           controller.dispose();
           location.dispose();


### PR DESCRIPTION
## Description

A user whose account has no email and password yet can tap "Secure account" to add them. Sometimes the server responds that an account already exists — either because their account is already registered, or because the email they entered belongs to a different account. The app used to show that raw server message in English and leave the user with no way to continue.

Now the user sees a short message and three clear options on the same screen:

- **Try a different email.** The form stays editable, so if the email they entered is the problem, they can change it and tap "Secure account" again.
- **Sign in to the existing account** with that email.
- **Contact support**, if the first two don't work.

The message sits at the top of the screen so it stays visible next to the options. The order reflects what's most likely to help: retry and sign-in first, support last.

The app can't tell which of the two situations caused the message — the server sends the same response for both — so it offers a path for each, plus support as the fallback.

**Related Issue:** Closes #7782

## Out of Scope

- The root cause — a person ending up with more than one account for themselves — is a server-side problem, being handled separately by the platform team. This change improves how the app responds; it does not stop the duplicate accounts from being created.
- Translating the new recovery copy and mapping remaining server errors to localized client copy are tracked in #7984.
- Replacing the Secure account entry after the app learns that the key is registered is tracked in #7985.
- A user whose existing account has no email on file can't finish this recovery, because there's no address to send a reset to. That case is rare and needs server-side support.

## Verification

- Automated tests cover the conflict message and recovery actions, editing the email, retrying after a conflict, sign-in/support navigation, and the real authenticated redirect policy.
- Redirect and splash-release tests verify that anonymous email recovery reaches login options without waiting for the startup timeout, while the restricted-minor gate still wins.
- Ran the screen on the iOS simulator to confirm the layout, wording, and flow.
- The analysis, formatting, and test checks pass.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
