### PR TITLE
ci(shorebird): keep emergency patches isolated from ongoing development

### DIFF
--- a/.claude/rules/agent_workflow.md
+++ b/.claude/rules/agent_workflow.md
@@ -31,6 +31,24 @@ superseded on the remote.
   rebasing onto fresh `origin/main`.
 - Branching from `main` without `git fetch origin` first.
 
+### Shorebird release-patch exception
+
+The only branch allowed to start somewhere other than `origin/main` is an
+operational Shorebird patch line named
+`shorebird-patch/<platform>/<release-version>`. It starts at the immutable
+`patch_baseline_commit` recorded for that release, after the product fix and
+regression test have merged normally to `main`. Only the reviewed fix is
+cherry-picked onto the linear patch line. If the release already has an active
+patch, extend its existing line so the next patch preserves every prior fix.
+
+This is not a development shortcut: do not implement on the release line, open
+an ordinary product PR from it, merge it back to `main`, add merge commits, or
+mix cleanup with the backport. Keep the remote branch while the release remains
+supported so later cumulative patches are reproducible. Never bypass the
+deletion and non-fast-forward rules protecting `shorebird-patch/**`. The
+complete runbook and approval requirements are in
+`mobile/docs/SHOREBIRD_CODE_PUSH.md`.
+
 One task per worktree. If the current worktree is dirty, commit, stash
 intentionally, or discard intentionally before starting new work
 elsewhere. Do not mix unrelated work into one worktree.
@@ -126,6 +144,12 @@ being true, rebase onto fresh `origin/main`.
 ## 3. Never stack PRs — combine dependent features into one bigger PR
 
 **Every PR targets `main`.** Never `gh pr create --base <other-branch>`.
+
+Shorebird patch lines do not create a second product PR. Their commits are
+mechanical backports of a fix already reviewed and merged through a `main` PR;
+promotion receives a separate operational approval under the Shorebird
+runbook. A backport that needs code adaptation goes back through `main` review
+before it is placed on the patch line.
 
 If features depend on each other, ship them as **one combined PR** on a
 single branch. Use clearly delineated commits and a PR description with

--- a/.github/scripts/tests/test_codemagic_shorebird_config.py
+++ b/.github/scripts/tests/test_codemagic_shorebird_config.py
@@ -276,7 +276,7 @@ class CodemagicShorebirdConfigTest(unittest.TestCase):
         self.assertIn("flutterDebugEmbeddingJar.absolutePath", self.caption_generator_gradle_contents)
 
     def test_shorebird_patch_workflows_block_native_asset_and_dependency_changes(self) -> None:
-        self.assertIn("BLOCKED_ROOTS = %w[android ios macos web assets shaders]", self.patch_source_contents)
+        self.assertIn("BLOCKED_ROOTS = %w[android ios macos web assets scripts shaders]", self.patch_source_contents)
         self.assertIn("pubspec.yaml pubspec.lock shorebird.yaml", self.patch_source_contents)
         self.assertIn("android|assets|shaders|darwin|ios|macos", self.patch_source_contents)
         self.assertIn("cut a normal store release instead of a Shorebird patch", self.patch_source_contents)

--- a/.github/scripts/tests/test_codemagic_shorebird_config.py
+++ b/.github/scripts/tests/test_codemagic_shorebird_config.py
@@ -202,6 +202,16 @@ class CodemagicShorebirdConfigTest(unittest.TestCase):
         self.assertIn('git checkout --detach "refs/remotes/origin/${{ inputs.PATCH_BRANCH }}"', self.contents)
         self.assertIn("*prepare_patch_source", self.contents)
 
+    def test_prepare_patch_source_fails_closed(self) -> None:
+        # Codemagic does not abort a multi-line script when a command fails, so
+        # the step must set -e: a rejected identity check or a failed
+        # fetch/checkout must never leave the build validating and patching the
+        # main checkout it started on.
+        start = self.contents.index("- &prepare_patch_source")
+        end = self.contents.index("- &", start + 1)
+        step = self.contents[start:end]
+        self.assertIn("script: |\n        set -euo pipefail\n", step)
+
     def test_shorebird_workflows_define_every_variable_their_scripts_read(self) -> None:
         resolved = json.loads(
             subprocess.run(

--- a/.github/scripts/tests/test_codemagic_shorebird_config.py
+++ b/.github/scripts/tests/test_codemagic_shorebird_config.py
@@ -20,6 +20,12 @@ PROVENANCE_STORE_PATH = (
     / "scripts"
     / "shorebird_provenance_store.sh"
 )
+PATCH_SOURCE_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "mobile"
+    / "scripts"
+    / "shorebird_patch_source.rb"
+)
 CAPTION_GENERATOR_GRADLE_PATH = (
     Path(__file__).resolve().parents[3]
     / "mobile"
@@ -37,6 +43,7 @@ class CodemagicShorebirdConfigTest(unittest.TestCase):
         self.mise_contents = MISE_PATH.read_text()
         self.shorebird_doc_contents = SHOREBIRD_DOC_PATH.read_text()
         self.provenance_store_contents = PROVENANCE_STORE_PATH.read_text()
+        self.patch_source_contents = PATCH_SOURCE_PATH.read_text()
         self.caption_generator_gradle_contents = CAPTION_GENERATOR_GRADLE_PATH.read_text()
 
     def test_codemagic_yaml_parses_with_aliases(self) -> None:
@@ -182,11 +189,17 @@ class CodemagicShorebirdConfigTest(unittest.TestCase):
 
     def test_shorebird_patch_workflows_use_private_provenance(self) -> None:
         self.assertIn('if [ "$CM_BRANCH" != "main" ]; then', self.contents)
+        self.assertIn("PATCH_BRANCH:", self._workflow_block("ios-patch"))
+        self.assertIn("PATCH_BRANCH:", self._workflow_block("android-patch"))
+        self.assertIn("shorebird-patch/ios/<RELEASE_VERSION>", self.contents)
+        self.assertIn("shorebird-patch/android/<RELEASE_VERSION>", self.contents)
         self.assertIn("RELEASE_COMMIT:", self.contents)
         self.assertIn("*fetch_and_verify_shorebird_provenance", self.contents)
         self.assertIn("shorebird_provenance_store.sh fetch", self.contents)
         self.assertIn("shorebird_provenance.rb verify", self.contents)
-        self.assertIn("git diff --name-only", self.contents)
+        self.assertIn("cp scripts/shorebird_patch_source.rb", self.contents)
+        self.assertIn("--identity-only", self.contents)
+        self.assertIn('git checkout --detach "refs/remotes/origin/${{ inputs.PATCH_BRANCH }}"', self.contents)
         self.assertIn("*prepare_patch_source", self.contents)
 
     def test_shorebird_workflows_define_every_variable_their_scripts_read(self) -> None:
@@ -253,18 +266,12 @@ class CodemagicShorebirdConfigTest(unittest.TestCase):
         self.assertIn("flutterDebugEmbeddingJar.absolutePath", self.caption_generator_gradle_contents)
 
     def test_shorebird_patch_workflows_block_native_asset_and_dependency_changes(self) -> None:
-        self.assertIn("BLOCKED_PATCH_PATHS=$(git diff --name-only", self.contents)
-        self.assertIn("'android/**'", self.contents)
-        self.assertIn("'ios/**'", self.contents)
-        self.assertIn("'assets/**'", self.contents)
-        self.assertIn("'shaders/**'", self.contents)
-        self.assertIn("'pubspec.yaml'", self.contents)
-        self.assertIn("'pubspec.lock'", self.contents)
-        self.assertIn("'packages/**/android/**'", self.contents)
-        self.assertIn("'packages/**/assets/**'", self.contents)
-        self.assertIn("'packages/**/shaders/**'", self.contents)
-        self.assertIn("'packages/**/darwin/**'", self.contents)
-        self.assertIn("Cut a normal store release instead of a Shorebird patch.", self.contents)
+        self.assertIn("BLOCKED_ROOTS = %w[android ios macos web assets shaders]", self.patch_source_contents)
+        self.assertIn("pubspec.yaml pubspec.lock shorebird.yaml", self.patch_source_contents)
+        self.assertIn("android|assets|shaders|darwin|ios|macos", self.patch_source_contents)
+        self.assertIn("cut a normal store release instead of a Shorebird patch", self.patch_source_contents)
+        self.assertIn("no Dart changes found", self.patch_source_contents)
+        self.assertIn("patch source contains merge commits", self.patch_source_contents)
         for command in self._shorebird_patch_commands():
             self.assertNotRegex(command, r"--allow-native-diffs|--allow-asset-diffs")
 

--- a/.github/scripts/tests/test_codemagic_shorebird_config.py
+++ b/.github/scripts/tests/test_codemagic_shorebird_config.py
@@ -293,6 +293,7 @@ class CodemagicShorebirdConfigTest(unittest.TestCase):
         # Swift and podspec sources, so it needs the same blocked surfaces
         # as packages/.
         self.assertIn("(?:packages|overrides)/", self.patch_source_contents)
+        self.assertIn("BLOCKED_ROOT_SCRIPT", self.patch_source_contents)
         self.assertIn("cut a normal store release instead of a Shorebird patch", self.patch_source_contents)
         self.assertIn("no Dart changes found", self.patch_source_contents)
         self.assertIn("patch source contains merge commits", self.patch_source_contents)

--- a/.github/scripts/tests/test_codemagic_shorebird_config.py
+++ b/.github/scripts/tests/test_codemagic_shorebird_config.py
@@ -286,9 +286,13 @@ class CodemagicShorebirdConfigTest(unittest.TestCase):
         self.assertIn("flutterDebugEmbeddingJar.absolutePath", self.caption_generator_gradle_contents)
 
     def test_shorebird_patch_workflows_block_native_asset_and_dependency_changes(self) -> None:
-        self.assertIn("BLOCKED_ROOTS = %w[android ios macos web assets scripts shaders]", self.patch_source_contents)
+        self.assertIn("BLOCKED_ROOTS = %w[android assets ios linux macos scripts shaders web windows]", self.patch_source_contents)
         self.assertIn("pubspec.yaml pubspec.lock shorebird.yaml", self.patch_source_contents)
-        self.assertIn("android|assets|shaders|darwin|ios|macos", self.patch_source_contents)
+        self.assertIn("android|assets|shaders|darwin|ios|linux|macos|windows", self.patch_source_contents)
+        # overrides/ is a live dependency_overrides path root carrying Kotlin,
+        # Swift and podspec sources, so it needs the same blocked surfaces
+        # as packages/.
+        self.assertIn("(?:packages|overrides)/", self.patch_source_contents)
         self.assertIn("cut a normal store release instead of a Shorebird patch", self.patch_source_contents)
         self.assertIn("no Dart changes found", self.patch_source_contents)
         self.assertIn("patch source contains merge commits", self.patch_source_contents)

--- a/.github/scripts/tests/test_codemagic_shorebird_config.py
+++ b/.github/scripts/tests/test_codemagic_shorebird_config.py
@@ -212,6 +212,16 @@ class CodemagicShorebirdConfigTest(unittest.TestCase):
         step = self.contents[start:end]
         self.assertIn("script: |\n        set -euo pipefail\n", step)
 
+    def test_prepare_patch_source_fetches_main_ref_deterministically(self) -> None:
+        # The validator rejects patch sources that contain commits already on
+        # main; that check needs refs/remotes/origin/main to exist at
+        # validation time, so the step fetches it explicitly rather than
+        # relying on the provenance step's opportunistic ref update.
+        start = self.contents.index("- &prepare_patch_source")
+        end = self.contents.index("- &", start + 1)
+        step = self.contents[start:end]
+        self.assertIn('"refs/heads/main:refs/remotes/origin/main"', step)
+
     def test_shorebird_workflows_define_every_variable_their_scripts_read(self) -> None:
         resolved = json.loads(
             subprocess.run(

--- a/.github/scripts/tests/test_shorebird_patch_source.py
+++ b/.github/scripts/tests/test_shorebird_patch_source.py
@@ -187,6 +187,11 @@ class ShorebirdPatchSourceTest(unittest.TestCase):
     def test_accepts_cherry_pick_when_baseline_is_main_tip(self) -> None:
         # Branching at a baseline that is still main's tip is fine: the
         # backport arrives as a cherry-pick, a new object absent from main.
+        # The fixture uses a plain commit rather than a real `git cherry-pick`
+        # on purpose: a cherry-pick can bit-for-bit reproduce the source
+        # commit's SHA when tree, parent, and author/committer identity and
+        # second all coincide, which would (correctly) trip the on-main check
+        # and make this test intermittently red.
         self._commit("lib/fix.dart", "const fixed = true;\n", "fix")
 
         result = self._run()

--- a/.github/scripts/tests/test_shorebird_patch_source.py
+++ b/.github/scripts/tests/test_shorebird_patch_source.py
@@ -140,6 +140,42 @@ class ShorebirdPatchSourceTest(unittest.TestCase):
                 self.assertNotEqual(0, result.returncode)
                 self.assertIn(blocked_path, result.stderr)
 
+    def test_rejects_native_paths_in_a_vendored_dependency_override(self) -> None:
+        # overrides/ holds path-based dependency_overrides forks whose Kotlin,
+        # Swift and podspec sources compile into the app exactly like a
+        # first-party plugin's, but they are not reachable through packages/.
+        blocked_paths = (
+            "overrides/app_device_integrity-1.1.0/ios/Classes/Plugin.swift",
+            "overrides/app_device_integrity-1.1.0/android/build.gradle",
+            "overrides/app_device_integrity-1.1.0/pubspec.yaml",
+        )
+        for index, blocked_path in enumerate(blocked_paths):
+            with self.subTest(path=blocked_path):
+                self._git("reset", "--hard", self.baseline)
+                self._commit(blocked_path, f"blocked {index}\n", "blocked")
+                self._commit("lib/fix.dart", "const fixed = true;\n", "fix")
+
+                result = self._run()
+
+                self.assertNotEqual(0, result.returncode)
+                self.assertIn(blocked_path, result.stderr)
+
+    def test_accepts_dart_only_change_inside_a_vendored_override(self) -> None:
+        # Blocking an override's native surfaces must not block a Dart-only
+        # backport inside the same vendored package.
+        self._commit(
+            "overrides/app_device_integrity-1.1.0/lib/plugin.dart",
+            "const fixed = true;\n",
+            "dart-only override fix",
+        )
+
+        result = self._run()
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertIn(
+            "overrides/app_device_integrity-1.1.0/lib/plugin.dart", result.stdout
+        )
+
     def test_rejects_blocked_paths_under_mobile_directory(self) -> None:
         # Mirrors the real layout and Codemagic's working_directory: the app
         # lives under mobile/, and git diff --name-only still prints

--- a/.github/scripts/tests/test_shorebird_patch_source.py
+++ b/.github/scripts/tests/test_shorebird_patch_source.py
@@ -51,6 +51,7 @@ class ShorebirdPatchSourceTest(unittest.TestCase):
         platform: str = "ios",
         release_version: str = "1.2.3+456",
         branch: str = "shorebird-patch/ios/1.2.3+456",
+        cwd: Path | None = None,
     ) -> subprocess.CompletedProcess[str]:
         return subprocess.run(
             [
@@ -65,7 +66,7 @@ class ShorebirdPatchSourceTest(unittest.TestCase):
                 "--branch",
                 branch,
             ],
-            cwd=self.root,
+            cwd=cwd or self.root,
             check=False,
             text=True,
             capture_output=True,
@@ -103,7 +104,13 @@ class ShorebirdPatchSourceTest(unittest.TestCase):
         self.assertIn("unsafe in a branch name", result.stderr)
 
     def test_rejects_history_not_descended_from_release(self) -> None:
-        unrelated = "0" * 40
+        main_branch = self._git("branch", "--show-current")
+        self._git("checkout", "--orphan", "unrelated-root")
+        self._git("rm", "-rf", "--quiet", ".")
+        self._commit("UNRELATED.md", "unrelated\n", "unrelated root")
+        unrelated = self._git("rev-parse", "HEAD")
+        self._git("checkout", main_branch)
+
         result = self._run(baseline=unrelated)
 
         self.assertNotEqual(0, result.returncode)
@@ -115,6 +122,7 @@ class ShorebirdPatchSourceTest(unittest.TestCase):
             "ios/Runner/AppDelegate.swift",
             "assets/icon.png",
             "pubspec.yaml",
+            "scripts/deploy.sh",
             "packages/divine_ui/ios/plugin.swift",
             "packages/divine_ui/pubspec.yaml",
         )
@@ -128,6 +136,35 @@ class ShorebirdPatchSourceTest(unittest.TestCase):
 
                 self.assertNotEqual(0, result.returncode)
                 self.assertIn(blocked_path, result.stderr)
+
+    def test_rejects_blocked_paths_under_mobile_directory(self) -> None:
+        # Mirrors the real layout and Codemagic's working_directory: the app
+        # lives under mobile/, and git diff --name-only still prints
+        # repository-root-relative paths.
+        mobile = self.root / "mobile"
+        for index, blocked_path in enumerate(
+            ("mobile/ios/Runner/AppDelegate.swift", "mobile/scripts/deploy.sh")
+        ):
+            with self.subTest(path=blocked_path):
+                self._git("reset", "--hard", self.baseline)
+                self._commit(blocked_path, f"blocked {index}\n", "blocked")
+                self._commit("mobile/lib/fix.dart", "const fixed = true;\n", "fix")
+
+                for cwd in (self.root, mobile):
+                    with self.subTest(cwd=cwd):
+                        result = self._run(cwd=cwd)
+                        self.assertNotEqual(0, result.returncode)
+                        self.assertIn(
+                            blocked_path.removeprefix("mobile/"), result.stderr
+                        )
+
+    def test_accepts_dart_fix_from_mobile_working_directory(self) -> None:
+        self._commit("mobile/lib/fix.dart", "const fixed = true;\n", "fix")
+
+        result = self._run(cwd=self.root / "mobile")
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertIn("lib/fix.dart", result.stdout)
 
     def test_rejects_empty_dart_diff(self) -> None:
         self._commit("README.md", "documentation only\n", "docs")

--- a/.github/scripts/tests/test_shorebird_patch_source.py
+++ b/.github/scripts/tests/test_shorebird_patch_source.py
@@ -26,6 +26,9 @@ class ShorebirdPatchSourceTest(unittest.TestCase):
         )
         self._commit("lib/release.dart", "const release = true;\n", "release")
         self.baseline = self._git("rev-parse", "HEAD")
+        # The validator compares the patch range against main's remote-tracking
+        # ref; fixtures start with main sitting exactly on the baseline.
+        self._git("update-ref", "refs/remotes/origin/main", self.baseline)
 
     def _git(self, *arguments: str) -> str:
         return subprocess.run(
@@ -165,6 +168,39 @@ class ShorebirdPatchSourceTest(unittest.TestCase):
 
         self.assertEqual(0, result.returncode, result.stderr)
         self.assertIn("lib/fix.dart", result.stdout)
+
+    def test_rejects_branch_cut_from_advanced_main(self) -> None:
+        # main advances past the baseline...
+        self._commit("lib/advanced.dart", "const advanced = true;\n", "advanced main")
+        self._git(
+            "update-ref", "refs/remotes/origin/main", self._git("rev-parse", "HEAD")
+        )
+        # ...and the operator cuts the patch branch at main's tip instead of
+        # branching from the baseline and cherry-picking.
+        self._commit("lib/fix.dart", "const fixed = true;\n", "fix")
+
+        result = self._run()
+
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("contains commits already on main", result.stderr)
+
+    def test_accepts_cherry_pick_when_baseline_is_main_tip(self) -> None:
+        # Branching at a baseline that is still main's tip is fine: the
+        # backport arrives as a cherry-pick, a new object absent from main.
+        self._commit("lib/fix.dart", "const fixed = true;\n", "fix")
+
+        result = self._run()
+
+        self.assertEqual(0, result.returncode, result.stderr)
+
+    def test_rejects_when_main_ref_is_unavailable(self) -> None:
+        self._git("update-ref", "-d", "refs/remotes/origin/main")
+        self._commit("lib/fix.dart", "const fixed = true;\n", "fix")
+
+        result = self._run()
+
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("fetch main before validating", result.stderr)
 
     def test_rejects_empty_dart_diff(self) -> None:
         self._commit("README.md", "documentation only\n", "docs")

--- a/.github/scripts/tests/test_shorebird_patch_source.py
+++ b/.github/scripts/tests/test_shorebird_patch_source.py
@@ -1,0 +1,164 @@
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = REPO_ROOT / "mobile" / "scripts" / "shorebird_patch_source.rb"
+
+
+class ShorebirdPatchSourceTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.root = Path(self.temp_dir.name)
+        subprocess.run(["git", "init", "-q"], cwd=self.root, check=True)
+        subprocess.run(
+            ["git", "config", "user.email", "shorebird-test@example.invalid"],
+            cwd=self.root,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "Shorebird Test"],
+            cwd=self.root,
+            check=True,
+        )
+        self._commit("lib/release.dart", "const release = true;\n", "release")
+        self.baseline = self._git("rev-parse", "HEAD")
+
+    def _git(self, *arguments: str) -> str:
+        return subprocess.run(
+            ["git", *arguments],
+            cwd=self.root,
+            check=True,
+            text=True,
+            capture_output=True,
+        ).stdout.strip()
+
+    def _commit(self, relative_path: str, contents: str, message: str) -> str:
+        path = self.root / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(contents)
+        self._git("add", relative_path)
+        self._git("commit", "-m", message)
+        return self._git("rev-parse", "HEAD")
+
+    def _run(
+        self,
+        *,
+        baseline: str | None = None,
+        platform: str = "ios",
+        release_version: str = "1.2.3+456",
+        branch: str = "shorebird-patch/ios/1.2.3+456",
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [
+                "ruby",
+                str(SCRIPT),
+                "--baseline",
+                baseline or self.baseline,
+                "--platform",
+                platform,
+                "--release-version",
+                release_version,
+                "--branch",
+                branch,
+            ],
+            cwd=self.root,
+            check=False,
+            text=True,
+            capture_output=True,
+        )
+
+    def test_accepts_matching_release_branch_with_dart_fix(self) -> None:
+        self._commit("lib/fix.dart", "const fixed = true;\n", "fix")
+
+        result = self._run()
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertIn("Verified patch branch", result.stdout)
+        self.assertIn("lib/fix.dart", result.stdout)
+
+    def test_rejects_main_and_another_release_or_platform(self) -> None:
+        self._commit("lib/fix.dart", "const fixed = true;\n", "fix")
+
+        for branch in (
+            "main",
+            "shorebird-patch/ios/1.2.3+457",
+            "shorebird-patch/android/1.2.3+456",
+        ):
+            with self.subTest(branch=branch):
+                result = self._run(branch=branch)
+                self.assertNotEqual(0, result.returncode)
+                self.assertIn("patch branch must be exactly", result.stderr)
+
+    def test_rejects_release_version_that_is_unsafe_in_a_refspec(self) -> None:
+        result = self._run(
+            release_version="1.2.3:malicious",
+            branch="shorebird-patch/ios/1.2.3:malicious",
+        )
+
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("unsafe in a branch name", result.stderr)
+
+    def test_rejects_history_not_descended_from_release(self) -> None:
+        unrelated = "0" * 40
+        result = self._run(baseline=unrelated)
+
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("not an ancestor", result.stderr)
+
+    def test_rejects_blocked_paths(self) -> None:
+        blocked_paths = (
+            "android/app/build.gradle",
+            "ios/Runner/AppDelegate.swift",
+            "assets/icon.png",
+            "pubspec.yaml",
+            "packages/divine_ui/ios/plugin.swift",
+            "packages/divine_ui/pubspec.yaml",
+        )
+        for index, blocked_path in enumerate(blocked_paths):
+            with self.subTest(path=blocked_path):
+                self._git("reset", "--hard", self.baseline)
+                self._commit(blocked_path, f"blocked {index}\n", "blocked")
+                self._commit("lib/fix.dart", "const fixed = true;\n", "fix")
+
+                result = self._run()
+
+                self.assertNotEqual(0, result.returncode)
+                self.assertIn(blocked_path, result.stderr)
+
+    def test_rejects_empty_dart_diff(self) -> None:
+        self._commit("README.md", "documentation only\n", "docs")
+
+        result = self._run()
+
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("no Dart changes", result.stderr)
+
+    def test_rejects_merge_commits(self) -> None:
+        self._git("checkout", "-b", "side")
+        self._commit("lib/side.dart", "const side = true;\n", "side")
+        self._git("checkout", "-b", "patch-line", self.baseline)
+        self._commit("lib/fix.dart", "const fixed = true;\n", "fix")
+        self._git("merge", "--no-ff", "side", "-m", "merge side")
+
+        result = self._run()
+
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("contains merge commits", result.stderr)
+
+    def test_second_patch_reports_both_cumulative_fixes(self) -> None:
+        self._commit("lib/first_fix.dart", "const first = true;\n", "first fix")
+        self._commit("lib/second_fix.dart", "const second = true;\n", "second fix")
+
+        result = self._run()
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertIn("lib/first_fix.dart", result.stdout)
+        self.assertIn("lib/second_fix.dart", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/tests/test_shorebird_patch_source.py
+++ b/.github/scripts/tests/test_shorebird_patch_source.py
@@ -160,6 +160,21 @@ class ShorebirdPatchSourceTest(unittest.TestCase):
                 self.assertNotEqual(0, result.returncode)
                 self.assertIn(blocked_path, result.stderr)
 
+    def test_rejects_app_root_build_scripts(self) -> None:
+        # The Runner scheme runs pre_build_ios.sh as a build pre-action, so an
+        # app-root shell script executes during the signed patch build even
+        # though ios/ itself is blocked and cannot change.
+        for index, blocked_path in enumerate(("pre_build_ios.sh", "build_native.sh")):
+            with self.subTest(path=blocked_path):
+                self._git("reset", "--hard", self.baseline)
+                self._commit(blocked_path, f"echo blocked {index}\n", "blocked")
+                self._commit("lib/fix.dart", "const fixed = true;\n", "fix")
+
+                result = self._run()
+
+                self.assertNotEqual(0, result.returncode)
+                self.assertIn(blocked_path, result.stderr)
+
     def test_accepts_dart_only_change_inside_a_vendored_override(self) -> None:
         # Blocking an override's native surfaces must not block a Dart-only
         # backport inside the same vendored package.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,6 +171,11 @@ If a Divine Brain search or ask tool is available, you may use it for company me
   Shorebird `staging` track first. Validate the staged patch, then promote it
   to `stable`. Rollback exists, but it is emergency recovery rather than a
   substitute for staging and review.
+- Start the manual patch workflow from `main`, but build app code only from the
+  exact `shorebird-patch/<platform>/<release-version>` branch rooted at the
+  provenance-recorded release baseline. Product fixes land on `main` first and
+  are backported onto that linear operational branch. Keep prior patch fixes in
+  every later patch for the release; never patch from an advanced `main` tree.
 - Full detail, including the patch runbook and known gotchas:
   `mobile/docs/SHOREBIRD_CODE_PUSH.md`.
 

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -353,6 +353,8 @@ definitions:
           --identity-only
         git fetch --quiet origin \
           "refs/heads/${{ inputs.PATCH_BRANCH }}:refs/remotes/origin/${{ inputs.PATCH_BRANCH }}"
+        git fetch --quiet origin \
+          "refs/heads/main:refs/remotes/origin/main"
         git checkout --detach "refs/remotes/origin/${{ inputs.PATCH_BRANCH }}"
         ruby build/shorebird/shorebird_patch_source.rb \
           --baseline "$SHOREBIRD_PATCH_BASELINE_COMMIT" \

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -337,6 +337,7 @@ definitions:
     - &prepare_patch_source
       name: Verify patch source
       script: |
+        set -euo pipefail
         if [ "$CM_BRANCH" != "main" ]; then
           echo "Refusing to load the patch workflow from branch '$CM_BRANCH'."
           echo "Start the manual workflow on main; PATCH_BRANCH selects the isolated release source."

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -338,45 +338,26 @@ definitions:
       name: Verify patch source
       script: |
         if [ "$CM_BRANCH" != "main" ]; then
-          echo "Refusing to patch from branch '$CM_BRANCH'."
-          echo "Patch workflows must run from main after the fix has merged."
+          echo "Refusing to load the patch workflow from branch '$CM_BRANCH'."
+          echo "Start the manual workflow on main; PATCH_BRANCH selects the isolated release source."
           exit 1
         fi
         . build/shorebird/patch_source.env
-        BLOCKED_PATCH_PATHS=$(git diff --name-only "$SHOREBIRD_PATCH_BASELINE_COMMIT..HEAD" -- \
-          'android/**' \
-          'ios/**' \
-          'macos/**' \
-          'web/**' \
-          'assets/**' \
-          'shaders/**' \
-          'pubspec.yaml' \
-          'pubspec.lock' \
-          'shorebird.yaml' \
-          'packages/**/android/**' \
-          'packages/**/assets/**' \
-          'packages/**/shaders/**' \
-          'packages/**/darwin/**' \
-          'packages/**/ios/**' \
-          'packages/**/macos/**' \
-          'packages/**/pubspec.yaml')
-        if [ -n "$BLOCKED_PATCH_PATHS" ]; then
-          echo "Refusing to patch: this diff contains native, asset, dependency, or Shorebird config changes."
-          echo
-          echo "$BLOCKED_PATCH_PATHS"
-          echo
-          echo "Cut a normal store release instead of a Shorebird patch."
-          exit 1
-        fi
-        echo "Patch source diff from release commit to current HEAD:"
-        git log --oneline --no-merges "$SHOREBIRD_PATCH_BASELINE_COMMIT..HEAD"
-        if git diff --quiet "$SHOREBIRD_PATCH_BASELINE_COMMIT..HEAD" -- '*.dart'; then
-          echo "No Dart changes found between release commit and HEAD."
-        else
-          echo
-          echo "Dart files changed since the release commit:"
-          git diff --name-only "$SHOREBIRD_PATCH_BASELINE_COMMIT..HEAD" -- '*.dart'
-        fi
+        cp scripts/shorebird_patch_source.rb build/shorebird/shorebird_patch_source.rb
+        ruby build/shorebird/shorebird_patch_source.rb \
+          --baseline "$SHOREBIRD_PATCH_BASELINE_COMMIT" \
+          --platform "$SHOREBIRD_PLATFORM" \
+          --release-version "${{ inputs.RELEASE_VERSION }}" \
+          --branch "${{ inputs.PATCH_BRANCH }}" \
+          --identity-only
+        git fetch --quiet origin \
+          "refs/heads/${{ inputs.PATCH_BRANCH }}:refs/remotes/origin/${{ inputs.PATCH_BRANCH }}"
+        git checkout --detach "refs/remotes/origin/${{ inputs.PATCH_BRANCH }}"
+        ruby build/shorebird/shorebird_patch_source.rb \
+          --baseline "$SHOREBIRD_PATCH_BASELINE_COMMIT" \
+          --platform "$SHOREBIRD_PLATFORM" \
+          --release-version "${{ inputs.RELEASE_VERSION }}" \
+          --branch "${{ inputs.PATCH_BRANCH }}"
     - &preflight_shorebird_android_release
       name: Preflight Android Shorebird release
       script: |
@@ -1116,6 +1097,12 @@ workflows:
           number (e.g. 1.0.9+247). Get it from `shorebird releases list` or the
           Shorebird console — a value with no matching release fails the build.
         type: string
+      PATCH_BRANCH:
+        description: >-
+          Exact remote release-patch branch to build. It must be named
+          shorebird-patch/ios/<RELEASE_VERSION>, start at the recorded release
+          baseline, and contain only the cumulative reviewed Dart backports.
+        type: string
       RELEASE_COMMIT:
         description: >-
           Optional source assertion. When supplied, it must be the recorded
@@ -1199,6 +1186,13 @@ workflows:
           Release to patch, exactly as Shorebird lists it, including the build
           number (e.g. 1.0.9+247). Get it from `shorebird releases list` or the
           Shorebird console — a value with no matching release fails the build.
+        type: string
+      PATCH_BRANCH:
+        description: >-
+          Exact remote release-patch branch to build. It must be named
+          shorebird-patch/android/<RELEASE_VERSION>, start at the recorded
+          release baseline, and contain only the cumulative reviewed Dart
+          backports.
         type: string
       RELEASE_COMMIT:
         description: >-

--- a/mobile/docs/SHOREBIRD_CODE_PUSH.md
+++ b/mobile/docs/SHOREBIRD_CODE_PUSH.md
@@ -239,7 +239,8 @@ test-backed.
    - `DEFAULT_ENV` = **the same value the release was built with**
 1. The workflow authenticates provenance and configuration before fetching the
    exact remote patch branch. It then verifies the branch name, release
-   ancestry, linear history, blocked paths, and non-empty Dart diff. It prints
+   ancestry, linear history, that no patch commit is already on main, blocked
+   paths, and non-empty Dart diff. It prints
    every included commit and Dart file. The incident owner and a mobile
    reviewer must read that complete output before proceeding; the relevant iOS
    or Android platform owner must approve promotion.

--- a/mobile/docs/SHOREBIRD_CODE_PUSH.md
+++ b/mobile/docs/SHOREBIRD_CODE_PUSH.md
@@ -148,30 +148,109 @@ fails, treat the release build as incomplete and do not patch that release.
 
 ## Shipping a patch
 
-1. Land the Dart fix on `main` through the normal PR process. A patch is built
-   from the current checkout, so the fix must be merged first.
-1. Identify the target release: `shorebird patch` needs the version of the
-   build that is actually live. `shorebird releases list`, or the Shorebird
-   console, shows what exists.
-1. The workflow retrieves the private provenance for `RELEASE_VERSION` and
-   derives the patch baseline from it. `RELEASE_COMMIT` is optional; when used
-   as an extra operator assertion, it must be the recorded build commit, the
-   recorded patch baseline, or another commit with the exact recorded tree.
-   The workflow prints every commit and Dart file included after the verified
-   baseline. Read that list before treating the patch as safe: pure Dart merged
-   since the release is exactly what Shorebird can ship.
-   If the diff includes native, asset, dependency, or Shorebird config changes,
-   the workflow refuses to patch and tells you to cut a normal store release.
-1. Run `ios-patch` or `android-patch` in Codemagic with:
+Shorebird is an emergency repair path, not a second feature-delivery channel.
+Do not freeze `main` after a store release and do not build a patch from the
+current `main` tree. Build it from a release-specific patch line rooted at the
+immutable provenance baseline instead. That keeps unrelated work merged after
+the release out of the production payload.
+
+### Patch eligibility
+
+| Situation | Action |
+|---|---|
+| Small, understood Dart-only production regression | Shorebird candidate |
+| Native, Flutter/engine, plugin-native, or bundled-asset change | Store release |
+| Broad refactor, feature, or behavior expansion | Store release |
+| Database or persistent-data migration | Store release unless mobile and platform owners explicitly establish backward compatibility |
+| Fix needs substantial post-release architecture | Backport a smaller fix or cut a store release |
+| Cannot reproduce against the released baseline | Do not patch |
+| Cannot validate the exact release plus patch | Do not promote |
+| Zapstore APK or macOS build | Not patchable in the current setup |
+
+The preflight deliberately rejects every `pubspec.yaml` and `pubspec.lock`
+change even though some pure-Dart dependency changes can be patchable. That is
+a conservative operational boundary, not a claim about Shorebird's technical
+capability. Cut a store release unless this policy is deliberately revised and
+test-backed.
+
+### Prepare the release patch line
+
+1. Confirm the incident meets the eligibility policy and identify the exact
+   live release with `shorebird releases list` or the Shorebird console.
+1. Reproduce the failure against that release or explain why reproduction is
+   impossible. Establish the failing layer before changing code.
+1. Land the minimal fix and its regression test on `main` through the normal PR
+   process. The release line is a backport destination, never the source of a
+   product fix and never something merged back into `main`.
+1. Read the private provenance and create the remote branch at its recorded
+   `patch_baseline_commit`:
+
+   ```text
+   shorebird-patch/<platform>/<release-version>
+   ```
+
+   For example, iOS release `1.2.3+456` uses
+   `shorebird-patch/ios/1.2.3+456`. Create this operational worktree from the
+   recorded baseline, not `origin/main`; this is the sole exception to the
+   normal task-worktree rule. The authenticated record lives at
+   `releases/<platform>/<release-version>.json` in the private
+   `divinevideo/divine-release-provenance` repository. After reading its full
+   40-character baseline, create the line explicitly:
+
+   ```bash
+   git fetch origin
+   git worktree add \
+     .worktrees/shorebird-<platform>-<release-version> \
+     -b shorebird-patch/<platform>/<release-version> \
+     <patch-baseline-commit>
+   ```
+1. Cherry-pick the already-reviewed `main` fix onto the patch line. Do not add
+   cleanup, refactors, features, merge commits, or unrelated generated output.
+   If a backport needs adaptation, revise and review the portable fix on `main`
+   first, then backport it.
+1. If the release already has a patch, start from its existing patch line and
+   add the next fix. A Shorebird patch replaces the release's Dart program and
+   only one patch is active at a time, so every later patch must retain all
+   fixes from the currently active patch. Never recreate a later patch directly
+   from the bare release baseline.
+1. Push the exact patch branch. Its contents were reviewed through the `main`
+   PR; it is not a second product PR and must not be merged to `main`. Keep the
+   branch until the release is no longer supported so cumulative patches remain
+   reproducible. Repository rules prohibit deletion and non-fast-forward
+   updates under `shorebird-patch/**`; never bypass that protection. Before
+   pushing, compare the complete patch line and confirm every commit is an
+   intentional backport:
+
+   ```bash
+   git log --oneline <patch-baseline-commit>..HEAD
+   git diff --stat <patch-baseline-commit>..HEAD
+   git push -u origin shorebird-patch/<platform>/<release-version>
+   ```
+
+### Build, validate, and promote
+
+1. Start `ios-patch` or `android-patch` manually **from `main`** in Codemagic.
+   `main` supplies the current trusted workflow; `PATCH_BRANCH` supplies the
+   isolated app source. Use:
    - `CONFIRM_PATCH` = `YES` (defaults to `NO`; the build aborts otherwise)
    - `RELEASE_VERSION` = the exact release string, e.g. `1.0.9+247`
+   - `PATCH_BRANCH` = `shorebird-patch/<platform>/<RELEASE_VERSION>`
    - `RELEASE_COMMIT` = optional source assertion; normally leave it empty
    - `DEFAULT_ENV` = **the same value the release was built with**
-1. The workflow publishes to Shorebird's `staging` track, not directly to
-   `stable`.
-1. Validate the staged patch with `shorebird preview --track staging
-   --release-version <version>` or the Shorebird console.
-1. Promote the exact patch after validation:
+1. The workflow authenticates provenance and configuration before fetching the
+   exact remote patch branch. It then verifies the branch name, release
+   ancestry, linear history, blocked paths, and non-empty Dart diff. It prints
+   every included commit and Dart file. The incident owner and a mobile
+   reviewer must read that complete output before proceeding; the relevant iOS
+   or Android platform owner must approve promotion.
+1. The workflow publishes to `staging`, never directly to `stable`. Validate
+   the exact release plus staged patch on the affected platform with
+   `shorebird preview --track staging --release-version <version>` or an
+   equivalent installed build. Verify the regression, adjacent behavior,
+   startup, and the current patch number in logs or Crashlytics.
+1. Record the incident owner, mobile reviewer, platform owner, release version,
+   patch number, validation evidence, and rollback decision in the incident or
+   patch issue. Then promote the exact approved patch:
 
    ```
    shorebird patches set-track --release <version> --patch <n> --track stable
@@ -180,7 +259,11 @@ fails, treat the release build as incomplete and do not patch that release.
    `shorebird patches promote --release-version <version> --patch-number <n>`
    is the deprecated legacy shorthand in the pinned CLI. Do not use it in new
    automation.
-1. Both platforms need their own patch run. There is no combined workflow.
+1. Monitor patch installation/failure diagnostics and the original production
+   signal after promotion. If the patch regresses behavior, roll it back first
+   and investigate second; rollback is emergency recovery, not validation.
+1. iOS and Android have independent releases, provenance, patch branches,
+   approvals, and patch runs. Never assume success on one proves the other.
 
 The patch workflow fingerprints the regenerated dart-defines with the same
 key used by the release and fails before compiling when any key differs. It

--- a/mobile/docs/SHOREBIRD_CODE_PUSH.md
+++ b/mobile/docs/SHOREBIRD_CODE_PUSH.md
@@ -207,7 +207,10 @@ test-backed.
 1. Cherry-pick the already-reviewed `main` fix onto the patch line. Do not add
    cleanup, refactors, features, merge commits, or unrelated generated output.
    If a backport needs adaptation, revise and review the portable fix on `main`
-   first, then backport it.
+   first, then backport it. Use plain `git cherry-pick <sha>`, never
+   `--ff` or a fast-forward merge: those put `main`'s own commit object on the
+   line, and the patch-source validator correctly refuses any line containing
+   a commit that is already on `main`.
 1. If the release already has a patch, start from its existing patch line and
    add the next fix. A Shorebird patch replaces the release's Dart program and
    only one patch is active at a time, so every later patch must retain all

--- a/mobile/scripts/shorebird_patch_source.rb
+++ b/mobile/scripts/shorebird_patch_source.rb
@@ -7,10 +7,13 @@ require 'optparse'
 HEX_SHA = /\A[0-9a-f]{40}\z/
 RELEASE_VERSION = /\A[0-9A-Za-z][0-9A-Za-z._+-]*\z/
 PATCHABLE_PLATFORMS = %w[android ios].freeze
-BLOCKED_ROOTS = %w[android ios macos web assets scripts shaders].freeze
+BLOCKED_ROOTS = %w[android assets ios linux macos scripts shaders web windows].freeze
 BLOCKED_FILES = %w[pubspec.yaml pubspec.lock shorebird.yaml].freeze
-BLOCKED_PACKAGE_PATH = %r{\Apackages/[^/]+/(?:android|assets|shaders|darwin|ios|macos)(?:/|\z)}
-BLOCKED_PACKAGE_PUBSPEC = %r{\Apackages/[^/]+/pubspec\.yaml\z}
+# packages/ holds first-party plugins and overrides/ holds vendored
+# dependency_overrides forks. Both compile native code into the app, so both
+# carry the same blocked surfaces.
+BLOCKED_PACKAGE_PATH = %r{\A(?:packages|overrides)/[^/]+/(?:android|assets|shaders|darwin|ios|linux|macos|windows)(?:/|\z)}
+BLOCKED_PACKAGE_PUBSPEC = %r{\A(?:packages|overrides)/[^/]+/pubspec\.(?:yaml|lock)\z}
 
 def abort_with(message)
   warn("ERROR: #{message}")

--- a/mobile/scripts/shorebird_patch_source.rb
+++ b/mobile/scripts/shorebird_patch_source.rb
@@ -9,6 +9,10 @@ RELEASE_VERSION = /\A[0-9A-Za-z][0-9A-Za-z._+-]*\z/
 PATCHABLE_PLATFORMS = %w[android ios].freeze
 BLOCKED_ROOTS = %w[android assets ios linux macos scripts shaders web windows].freeze
 BLOCKED_FILES = %w[pubspec.yaml pubspec.lock shorebird.yaml].freeze
+# Shell scripts at the app root are part of the native build, not the Dart
+# program: the Runner scheme runs pre_build_ios.sh as a build pre-action, so a
+# patch line could otherwise execute new code during a signed release build.
+BLOCKED_ROOT_SCRIPT = %r{\A[^/]+\.sh\z}
 # packages/ holds first-party plugins and overrides/ holds vendored
 # dependency_overrides forks. Both compile native code into the app, so both
 # carry the same blocked surfaces.
@@ -30,6 +34,7 @@ end
 def blocked_path?(path)
   BLOCKED_FILES.include?(path) ||
     BLOCKED_ROOTS.any? { |root| path == root || path.start_with?("#{root}/") } ||
+    path.match?(BLOCKED_ROOT_SCRIPT) ||
     path.match?(BLOCKED_PACKAGE_PATH) ||
     path.match?(BLOCKED_PACKAGE_PUBSPEC)
 end

--- a/mobile/scripts/shorebird_patch_source.rb
+++ b/mobile/scripts/shorebird_patch_source.rb
@@ -68,6 +68,20 @@ range = "#{baseline}..HEAD"
 merge_commits = git('rev-list', '--merges', range).lines(chomp: true)
 abort_with('patch source contains merge commits; use a linear backport history') unless merge_commits.empty?
 
+# The patch line must be rooted at the recorded baseline and carry only
+# backports. Backports are cherry-picks, so every commit in the range is a new
+# object absent from main; a branch cut from main's tip instead contains main's
+# own commits. Ancestry alone cannot tell those apart on a linear main.
+main_ref = 'refs/remotes/origin/main'
+unless system('git', 'rev-parse', '--verify', '--quiet', "#{main_ref}^{commit}", out: File::NULL, err: File::NULL)
+  abort_with("#{main_ref} is unavailable; fetch main before validating the patch source")
+end
+range_commits = git('rev-list', range).lines(chomp: true)
+patch_only_commits = git('rev-list', range, '--not', main_ref).lines(chomp: true)
+unless range_commits.size == patch_only_commits.size
+  abort_with('patch source contains commits already on main; branch from the recorded release baseline and cherry-pick the backported fixes instead')
+end
+
 # git diff --name-only prints repository-root-relative paths regardless of the
 # current directory, while the patch workflows run with working_directory
 # mobile/. Normalize to mobile-relative so the blocked-path checks below match

--- a/mobile/scripts/shorebird_patch_source.rb
+++ b/mobile/scripts/shorebird_patch_source.rb
@@ -7,7 +7,7 @@ require 'optparse'
 HEX_SHA = /\A[0-9a-f]{40}\z/
 RELEASE_VERSION = /\A[0-9A-Za-z][0-9A-Za-z._+-]*\z/
 PATCHABLE_PLATFORMS = %w[android ios].freeze
-BLOCKED_ROOTS = %w[android ios macos web assets shaders].freeze
+BLOCKED_ROOTS = %w[android ios macos web assets scripts shaders].freeze
 BLOCKED_FILES = %w[pubspec.yaml pubspec.lock shorebird.yaml].freeze
 BLOCKED_PACKAGE_PATH = %r{\Apackages/[^/]+/(?:android|assets|shaders|darwin|ios|macos)(?:/|\z)}
 BLOCKED_PACKAGE_PUBSPEC = %r{\Apackages/[^/]+/pubspec\.yaml\z}
@@ -68,10 +68,16 @@ range = "#{baseline}..HEAD"
 merge_commits = git('rev-list', '--merges', range).lines(chomp: true)
 abort_with('patch source contains merge commits; use a linear backport history') unless merge_commits.empty?
 
-changed_paths = git('diff', '--name-only', range).lines(chomp: true)
+# git diff --name-only prints repository-root-relative paths regardless of the
+# current directory, while the patch workflows run with working_directory
+# mobile/. Normalize to mobile-relative so the blocked-path checks below match
+# in both layouts.
+changed_paths = git('diff', '--name-only', range).lines(chomp: true).map do |path|
+  path.sub(%r{\Amobile/}, '')
+end
 blocked_paths = changed_paths.select { |path| blocked_path?(path) }
 unless blocked_paths.empty?
-  warn('ERROR: refusing to patch: this diff contains native, asset, dependency, or Shorebird configuration changes.')
+  warn('ERROR: refusing to patch: this diff contains native, asset, dependency, build script, or Shorebird configuration changes.')
   warn
   blocked_paths.each { |path| warn(path) }
   warn

--- a/mobile/scripts/shorebird_patch_source.rb
+++ b/mobile/scripts/shorebird_patch_source.rb
@@ -1,0 +1,89 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'open3'
+require 'optparse'
+
+HEX_SHA = /\A[0-9a-f]{40}\z/
+RELEASE_VERSION = /\A[0-9A-Za-z][0-9A-Za-z._+-]*\z/
+PATCHABLE_PLATFORMS = %w[android ios].freeze
+BLOCKED_ROOTS = %w[android ios macos web assets shaders].freeze
+BLOCKED_FILES = %w[pubspec.yaml pubspec.lock shorebird.yaml].freeze
+BLOCKED_PACKAGE_PATH = %r{\Apackages/[^/]+/(?:android|assets|shaders|darwin|ios|macos)(?:/|\z)}
+BLOCKED_PACKAGE_PUBSPEC = %r{\Apackages/[^/]+/pubspec\.yaml\z}
+
+def abort_with(message)
+  warn("ERROR: #{message}")
+  exit 1
+end
+
+def git(*arguments)
+  stdout, stderr, status = Open3.capture3('git', *arguments)
+  abort_with("git #{arguments.join(' ')} failed: #{stderr.strip}") unless status.success?
+
+  stdout.strip
+end
+
+def blocked_path?(path)
+  BLOCKED_FILES.include?(path) ||
+    BLOCKED_ROOTS.any? { |root| path == root || path.start_with?("#{root}/") } ||
+    path.match?(BLOCKED_PACKAGE_PATH) ||
+    path.match?(BLOCKED_PACKAGE_PUBSPEC)
+end
+
+options = {}
+OptionParser.new do |parser|
+  parser.on('--baseline VALUE') { |value| options[:baseline] = value }
+  parser.on('--platform VALUE') { |value| options[:platform] = value }
+  parser.on('--release-version VALUE') { |value| options[:release_version] = value }
+  parser.on('--branch VALUE') { |value| options[:branch] = value }
+  parser.on('--identity-only') { options[:identity_only] = true }
+end.parse!
+
+missing = %i[baseline platform release_version branch].select do |name|
+  options.fetch(name, '').empty?
+end
+abort_with("missing option(s): #{missing.map { |name| "--#{name.to_s.tr('_', '-')}" }.join(', ')}") unless missing.empty?
+
+baseline = options[:baseline]
+platform = options[:platform]
+release_version = options[:release_version]
+branch = options[:branch]
+
+abort_with('baseline must be a full lowercase commit SHA') unless baseline.match?(HEX_SHA)
+abort_with('platform must be android or ios') unless PATCHABLE_PLATFORMS.include?(platform)
+abort_with('release version contains characters that are unsafe in a branch name') unless release_version.match?(RELEASE_VERSION)
+
+expected_branch = "shorebird-patch/#{platform}/#{release_version}"
+unless branch == expected_branch
+  abort_with("patch branch must be exactly #{expected_branch.inspect} for this release")
+end
+exit 0 if options[:identity_only]
+
+unless system('git', 'merge-base', '--is-ancestor', baseline, 'HEAD', out: File::NULL, err: File::NULL)
+  abort_with('recorded patch baseline is not an ancestor of the patch source')
+end
+
+range = "#{baseline}..HEAD"
+merge_commits = git('rev-list', '--merges', range).lines(chomp: true)
+abort_with('patch source contains merge commits; use a linear backport history') unless merge_commits.empty?
+
+changed_paths = git('diff', '--name-only', range).lines(chomp: true)
+blocked_paths = changed_paths.select { |path| blocked_path?(path) }
+unless blocked_paths.empty?
+  warn('ERROR: refusing to patch: this diff contains native, asset, dependency, or Shorebird configuration changes.')
+  warn
+  blocked_paths.each { |path| warn(path) }
+  warn
+  abort_with('cut a normal store release instead of a Shorebird patch')
+end
+
+dart_paths = changed_paths.select { |path| path.end_with?('.dart') }
+abort_with('no Dart changes found between the release baseline and patch source') if dart_paths.empty?
+
+puts("Verified patch branch: #{branch}")
+puts("Patch source commits after release baseline #{baseline}:")
+puts(git('log', '--oneline', range))
+puts
+puts('Dart files changed by the complete patch:')
+dart_paths.each { |path| puts(path) }


### PR DESCRIPTION
## Problem

A publicly released app could only be patched from the latest `main` tree. At Divine merge velocity, unrelated native, asset, dependency, and Dart changes quickly made that tree either ineligible or far too broad for an emergency production repair.

## Why this fix

The manual Codemagic workflow now remains anchored on trusted `main` configuration while checking out app code from an exact `shorebird-patch/<platform>/<release-version>` line rooted at the immutable release provenance baseline. A focused validator fails closed on the wrong branch or release, unrelated ancestry, merge commits, commits already on main, blocked native/asset/dependency/build-script paths, and empty Dart changes, then prints the complete patch payload for operator review.

The runbook now defines emergency eligibility, minimal reviewed backports, cumulative later patches, named promotion approvals, staging validation, monitoring, rollback, and branch retirement. Repository rules were also added to prevent deletion or force-pushes under `shorebird-patch/**`, keeping cumulative production patch history append-only.

## Deliberately unchanged

- Store artifacts still use signed `shorebird release` builds.
- Patch publication remains manual, signed, configuration-matched, and staging-first.
- The conservative `pubspec.yaml` and lockfile block remains; pure-Dart dependency exemptions are not introduced.
- Zapstore APKs and macOS remain outside the patch path.
- This PR does not execute a live patch. The staged iOS/Android operational drill remains in #7843 and keeps the parent epic open.

## Verification

- `python3 -m unittest discover -s .github/scripts/tests -p "test_*.py"` (65 tests)
- `.codex/scripts/test-config.sh`
- Ruby syntax and Codemagic YAML parsing
- `git diff --check`
- pre-push merge-conflict and repository hooks

Closes #7842
Refs #7841
Follow-up: #7843
