### PR TITLE
fix(inbox): keep the filter-chips header from blanking the Messages pane

### DIFF
--- a/mobile/lib/screens/inbox/inbox_view.dart
+++ b/mobile/lib/screens/inbox/inbox_view.dart
@@ -1207,12 +1207,25 @@ class _FilterChipsHeaderDelegate extends SliverPersistentHeaderDelegate {
 
   @override
   Widget build(BuildContext context, double shrinkOffset, bool overlaps) {
-    return ColoredBox(
-      color: context.vineColors.surfaceContainerHigh,
-      child: InboxFilterChips(
-        selected: selected,
-        hasBlocked: hasBlocked,
-        onChanged: onChanged,
+    // Pin the child to exactly [extent]. A persistent header lays its child
+    // out under LOOSE constraints, so the chips settle at whatever height
+    // their own text layout produces — which is not always [extent], because
+    // that value is a formula over `textScaler.scale(...)` while the real
+    // height comes from font metrics that snap to whole pixels. When the two
+    // diverge the sliver reports paintExtent (child) < layoutExtent (extent),
+    // which violates the SliverGeometry contract, throws out of the
+    // viewport's performLayout, and leaves every sliver below it — the
+    // support row, the requests banner, the whole conversation list — with
+    // null geometry, rendering the Messages pane blank.
+    return SizedBox(
+      height: extent,
+      child: ColoredBox(
+        color: context.vineColors.surfaceContainerHigh,
+        child: InboxFilterChips(
+          selected: selected,
+          hasBlocked: hasBlocked,
+          onChanged: onChanged,
+        ),
       ),
     );
   }

--- a/mobile/lib/screens/inbox/inbox_view.dart
+++ b/mobile/lib/screens/inbox/inbox_view.dart
@@ -1150,7 +1150,7 @@ class _FilteredEmptyContent extends StatelessWidget {
   }
 }
 
-/// Pinned header carrying [UnreadFilterChips].
+/// Pinned header carrying [InboxFilterChips].
 ///
 /// Pinned rather than scrolled away so the user can always drop back to All
 /// after narrowing to Unread without hunting for the chip. Opaque, because the

--- a/mobile/lib/screens/inbox/inbox_view.dart
+++ b/mobile/lib/screens/inbox/inbox_view.dart
@@ -521,29 +521,6 @@ class _PinnedSupportRow extends StatelessWidget {
   }
 }
 
-/// Vertical padding [UnreadFilterChips] puts above and below its chip row.
-const double _kFilterChipsVerticalPadding = 8;
-
-/// Inner vertical padding of a [DivineButtonSize.tiny] chip. Fixed per size.
-const double _kTinyChipVerticalPadding = 6;
-
-/// Line box of a tiny chip's `titleSmallFont` label (14/20) — the only part of
-/// the chip's height that grows with the text scaler.
-const double _kTinyChipLineHeight = 20;
-
-/// Height [UnreadFilterChips] needs at the current text scale.
-///
-/// A pinned sliver declares its extent before its child is laid out, so this
-/// reproduces the child's height rather than measuring it. Under-declaring
-/// silently clips the label — a Row overflowing on its cross axis does not
-/// throw. Duplicating the arithmetic is safe only because a widget test pins
-/// it against the chips' real intrinsic height at two scales, so a moved
-/// `divine_ui` token fails there instead of on a phone.
-double _filterChipsExtent(BuildContext context) =>
-    _kFilterChipsVerticalPadding * 2 +
-    _kTinyChipVerticalPadding * 2 +
-    MediaQuery.textScalerOf(context).scale(_kTinyChipLineHeight);
-
 /// The whole Messages pane as a single scroll view.
 ///
 /// Every piece of chrome — following bar, search field, filter chips — used to
@@ -797,12 +774,10 @@ class _MessagesScrollViewState extends ConsumerState<_MessagesScrollView>
           ),
         ),
       ),
-      SliverPersistentHeader(
-        pinned: true,
-        delegate: _FilterChipsHeaderDelegate(
+      PinnedHeaderSliver(
+        child: _FilterChipsHeader(
           selected: filter,
           hasBlocked: hasBlocked,
-          extent: _filterChipsExtent(context),
           onChanged: (value) => context.read<ConversationListBloc>().add(
             ConversationListFilterChanged(value),
           ),
@@ -1180,60 +1155,38 @@ class _FilteredEmptyContent extends StatelessWidget {
 /// Pinned rather than scrolled away so the user can always drop back to All
 /// after narrowing to Unread without hunting for the chip. Opaque, because the
 /// conversation list scrolls underneath it.
-class _FilterChipsHeaderDelegate extends SliverPersistentHeaderDelegate {
-  const _FilterChipsHeaderDelegate({
+///
+/// Rendered through [PinnedHeaderSliver] rather than a
+/// [SliverPersistentHeaderDelegate] on purpose, the same way
+/// `sound_detail_screen.dart` does: a delegate has to declare its extent
+/// before its child is laid out, and a header that ends up shorter than that
+/// extent makes `layoutExtent` exceed `paintExtent`. The sliver then fails
+/// layout, every sliver after it keeps a null geometry, and paint reports it
+/// as "Null check operator used on a null value" against the enclosing
+/// [CustomScrollView] — a blank Messages pane. The chips' height comes from
+/// font metrics that snap to whole pixels, while any declared extent is
+/// arithmetic over `textScaler.scale(...)`, so the two diverged at eleven of
+/// iOS's twelve Dynamic Type sizes: six blanked the pane and five clipped the
+/// chips, leaving only the default correct (#7854). [PinnedHeaderSliver]
+/// measures the child, so there is nothing to keep in sync.
+class _FilterChipsHeader extends StatelessWidget {
+  const _FilterChipsHeader({
     required this.selected,
     required this.hasBlocked,
     required this.onChanged,
-    required this.extent,
   });
 
   final InboxFilter selected;
   final bool hasBlocked;
   final ValueChanged<InboxFilter> onChanged;
 
-  /// Height the chips need at the caller's text scale. Passed in rather than
-  /// read here: [SliverPersistentHeaderDelegate]'s extent getters take no
-  /// [BuildContext], so the MediaQuery lookup has to happen in the widget
-  /// that builds the delegate. Same shape as the `topInset` pattern in
-  /// `.claude/rules/ui_theming.md`.
-  final double extent;
-
   @override
-  double get minExtent => extent;
-
-  @override
-  double get maxExtent => extent;
-
-  @override
-  Widget build(BuildContext context, double shrinkOffset, bool overlaps) {
-    // Pin the child to exactly [extent]. A persistent header lays its child
-    // out under LOOSE constraints, so the chips settle at whatever height
-    // their own text layout produces — which is not always [extent], because
-    // that value is a formula over `textScaler.scale(...)` while the real
-    // height comes from font metrics that snap to whole pixels. When the two
-    // diverge the sliver reports paintExtent (child) < layoutExtent (extent),
-    // which violates the SliverGeometry contract, throws out of the
-    // viewport's performLayout, and leaves every sliver below it — the
-    // support row, the requests banner, the whole conversation list — with
-    // null geometry, rendering the Messages pane blank.
-    return SizedBox(
-      height: extent,
-      child: ColoredBox(
-        color: context.vineColors.surfaceContainerHigh,
-        child: InboxFilterChips(
-          selected: selected,
-          hasBlocked: hasBlocked,
-          onChanged: onChanged,
-        ),
-      ),
-    );
-  }
-
-  @override
-  bool shouldRebuild(_FilterChipsHeaderDelegate oldDelegate) =>
-      oldDelegate.selected != selected ||
-      oldDelegate.hasBlocked != hasBlocked ||
-      oldDelegate.onChanged != onChanged ||
-      oldDelegate.extent != extent;
+  Widget build(BuildContext context) => ColoredBox(
+    color: context.vineColors.surfaceContainerHigh,
+    child: InboxFilterChips(
+      selected: selected,
+      hasBlocked: hasBlocked,
+      onChanged: onChanged,
+    ),
+  );
 }

--- a/mobile/lib/screens/inbox/widgets/inbox_filter_chips.dart
+++ b/mobile/lib/screens/inbox/widgets/inbox_filter_chips.dart
@@ -35,7 +35,8 @@ class InboxFilterChips extends StatelessWidget {
   Widget build(BuildContext context) {
     // Deliberately no MediaQuery.withNoTextScaling: these are controls to read
     // and tap, not fixed overlay badges. The pinned header hosting this row
-    // declares a text-scale-aware extent so the row has room to grow into.
+    // measures it rather than declaring an extent, so the row is free to grow
+    // with the text scale (#7854).
     // Horizontally scrollable because the chips size to their intrinsic
     // width: `DivineButton`'s internal `Flexible` sits inside its own
     // MainAxisSize.min Row, so it can never yield width to a sibling, and a

--- a/mobile/test/screens/inbox/inbox_view_test.dart
+++ b/mobile/test/screens/inbox/inbox_view_test.dart
@@ -1517,15 +1517,13 @@ void main() {
         );
       });
 
-      // A pinned SliverPersistentHeader lays its child out with a TIGHT height
-      // equal to maxExtent, so `getSize(...).height` only ever reports the
-      // extent the delegate declared — asserting it equals a constant measures
-      // that constant against itself and cannot catch an under-declared header.
-      // What can: the chips' own intrinsic height, which is computed from the
-      // content and is independent of the constraint it was laid out under. If
-      // the header declares less than that, the label is silently clipped
-      // (cross-axis overflow in a Row does not throw), which is the failure
-      // these two tests exist to catch.
+      // `laidOut` is the height the chips actually got; `needed` is their
+      // intrinsic height, computed from the content and independent of the
+      // constraint they were laid out under. Comparing the two is what catches
+      // a clipped label, since a Row overflowing on its cross axis does not
+      // throw. Both matter: a header shorter than `needed` clips the chips,
+      // and a header taller than what its child lays out to used to blank the
+      // whole pane — see the Dynamic Type sweep below.
       Future<({double laidOut, double needed})> pumpChips(
         WidgetTester tester, {
         required TextScaler textScaler,
@@ -1544,8 +1542,12 @@ void main() {
         );
         await openMessages(tester);
 
+        // skipOffstage:false so this helper still reports sizes when the
+        // viewport is broken: the onstage element walk itself null-crashes on
+        // a sliver left unlaid-out, and swallowing that here would hide which
+        // assertion below actually failed.
         final box = tester.renderObject<RenderBox>(
-          find.byType(InboxFilterChips),
+          find.byType(InboxFilterChips, skipOffstage: false),
         );
         return (
           laidOut: box.size.height,
@@ -1553,37 +1555,63 @@ void main() {
         );
       }
 
-      // A text scale whose extent formula lands on a fraction the chips' own
-      // text layout does not reproduce: `_filterChipsExtent` computes
-      // 8*2 + 6*2 + scale(20), so 1.12 declares 50.4 while the chips lay out
-      // at 50.0. The header then reports paintExtent 50.0 against layoutExtent
-      // 50.4, which fails SliverGeometry's contract inside the viewport's
-      // performLayout and blanks every sliver below — the whole conversation
-      // list. Integer-extent scales (1.0, 1.15, 1.2, 1.5, 2.0) never diverge,
-      // which is why the two scales already covered here did not catch it.
-      for (final scale in <double>[1.06, 1.12]) {
-        testWidgets(
-          'the pinned header keeps a valid sliver geometry at text scale '
-          '$scale',
-          (tester) async {
-            final size = await pumpChips(
-              tester,
-              textScaler: TextScaler.linear(scale),
-            );
+      // Every Dynamic Type size iOS can hand us, as the ratio of that
+      // category's body point size to the 17pt default — the mapping the
+      // engine uses to turn `preferredContentSizeCategory` into a text scale.
+      //
+      // The header used to declare its own extent as arithmetic over
+      // `textScaler.scale(20)` while its child settled on whatever the font
+      // metrics produced, and those snap to whole pixels. Eleven of these
+      // twelve diverged. Six declared MORE than the child laid out to —
+      // extraSmall, extraLarge (one notch above the default), XXXL, and
+      // AX3/AX4/AX5 — leaving paintExtent below layoutExtent, which fails
+      // SliverGeometry's contract inside the viewport's performLayout, aborts
+      // the child layout sequence, and leaves the conversation list with a
+      // null geometry: a blank pane. The other five declared LESS than the
+      // chips need — small, medium, XXL, AX1, AX2 — silently clipping them.
+      // Only the default was correct (#7854). The scale this file covered
+      // before, 2.0, lands on a whole pixel and never diverged, which is why
+      // it did not catch either half.
+      const iosDynamicTypeScales = <String, double>{
+        'extraSmall': 14 / 17,
+        'small': 15 / 17,
+        'medium': 16 / 17,
+        'large (default)': 1,
+        'extraLarge': 19 / 17,
+        'extraExtraLarge': 21 / 17,
+        'extraExtraExtraLarge': 23 / 17,
+        'AX1': 28 / 17,
+        'AX2': 33 / 17,
+        'AX3': 40 / 17,
+        'AX4': 47 / 17,
+        'AX5': 53 / 17,
+      };
 
-            expect(
-              tester.takeException(),
-              isNull,
-              reason: 'a fractional header extent must not throw out of layout',
-            );
-            expect(
-              size.laidOut,
-              8 * 2 + 6 * 2 + TextScaler.linear(scale).scale(20),
-              reason: 'the chips must fill the extent the header declares',
-            );
-            expect(find.byType(ConversationTile), findsWidgets);
-          },
-        );
+      for (final MapEntry(key: category, value: scale)
+          in iosDynamicTypeScales.entries) {
+        testWidgets('renders the conversation list at iOS $category', (
+          tester,
+        ) async {
+          final size = await pumpChips(
+            tester,
+            textScaler: TextScaler.linear(scale),
+          );
+
+          expect(
+            tester.takeException(),
+            isNull,
+            reason: 'the header must not break the SliverGeometry contract',
+          );
+          expect(
+            size.laidOut,
+            greaterThanOrEqualTo(size.needed),
+            reason: 'the header must not clip the chips',
+          );
+          // The canary: this finder walks the onstage element tree, which is
+          // exactly what null-crashes when a sliver was left unlaid-out. It
+          // failing IS the blank pane.
+          expect(find.byType(ConversationTile), findsWidgets);
+        });
       }
 
       testWidgets('the pinned header fits the chips at the default text scale', (

--- a/mobile/test/screens/inbox/inbox_view_test.dart
+++ b/mobile/test/screens/inbox/inbox_view_test.dart
@@ -1560,14 +1560,20 @@ void main() {
       // engine uses to turn `preferredContentSizeCategory` into
       // `textScaleFactor`.
       //
-      // `TextScaler.linear` is a stand-in for the real thing: on device
-      // `MediaQuery.textScalerOf` is a `SystemTextScaler`, whose `scale()`
-      // defers to `PlatformDispatcher.scaleFontSize` — an engine-defined
-      // curve, not a multiplication. Measured on an iPhone at extraLarge, a
-      // 14pt/1.4x paragraph lays out at 22.0 either way, so the ladder is
-      // faithful where it has been checked. That the real curve cannot be
-      // reproduced by arithmetic at all is the point: measuring the child is
-      // immune to it, and any declared extent is not.
+      // `TextScaler.linear` is a stand-in: on device `MediaQuery.textScalerOf`
+      // is a `SystemTextScaler`, whose `scale()` defers to
+      // `PlatformDispatcher.scaleFontSize`. That falls back to
+      // `size * textScaleFactor` only while the platform sends no
+      // `configurationId` — otherwise it asks the engine for a per-size curve,
+      // which is the Android 14+ non-linear path. Measured on an iPhone at
+      // extraLarge, a 14pt/1.4x paragraph lays out at 22.0, matching the
+      // linear form, so the ladder is faithful where it has been checked.
+      //
+      // Neither form is what a declared extent has to match, though: the
+      // child's height comes from a laid-out line box that snaps to whole
+      // pixels, and no arithmetic over `scale()` reproduces that rounding.
+      // Measuring the child is immune to all of it; a declared extent is not,
+      // on either platform.
       //
       // The header used to declare its own extent as arithmetic over
       // `textScaler.scale(20)` while its child settled on whatever the font
@@ -1626,10 +1632,11 @@ void main() {
           // that is a different geometry path — scrollOffset above zero,
           // layoutExtent shrinking toward zero — than the initial layout.
           // `PinnedHeaderSliver` derives paintExtent as
-          // `remainingPaintExtent - overlap` with no lower clamp, which is
-          // safe here only because nothing pinned sits above this header and
-          // `overlap` stays at zero. Adding one would put paintExtent back
-          // under layoutExtent and blank the pane again, so pin it.
+          // `min(childExtent, remainingPaintExtent - overlap)`. That second
+          // term has no lower clamp, so it is safe here only because nothing
+          // pinned sits above this header and `overlap` stays at zero. Adding
+          // one would put paintExtent back under layoutExtent and blank the
+          // pane again, so pin it.
           await tester.drag(
             find.byType(CustomScrollView),
             const Offset(0, -400),

--- a/mobile/test/screens/inbox/inbox_view_test.dart
+++ b/mobile/test/screens/inbox/inbox_view_test.dart
@@ -1553,6 +1553,39 @@ void main() {
         );
       }
 
+      // A text scale whose extent formula lands on a fraction the chips' own
+      // text layout does not reproduce: `_filterChipsExtent` computes
+      // 8*2 + 6*2 + scale(20), so 1.12 declares 50.4 while the chips lay out
+      // at 50.0. The header then reports paintExtent 50.0 against layoutExtent
+      // 50.4, which fails SliverGeometry's contract inside the viewport's
+      // performLayout and blanks every sliver below — the whole conversation
+      // list. Integer-extent scales (1.0, 1.15, 1.2, 1.5, 2.0) never diverge,
+      // which is why the two scales already covered here did not catch it.
+      for (final scale in <double>[1.06, 1.12]) {
+        testWidgets(
+          'the pinned header keeps a valid sliver geometry at text scale '
+          '$scale',
+          (tester) async {
+            final size = await pumpChips(
+              tester,
+              textScaler: TextScaler.linear(scale),
+            );
+
+            expect(
+              tester.takeException(),
+              isNull,
+              reason: 'a fractional header extent must not throw out of layout',
+            );
+            expect(
+              size.laidOut,
+              8 * 2 + 6 * 2 + TextScaler.linear(scale).scale(20),
+              reason: 'the chips must fill the extent the header declares',
+            );
+            expect(find.byType(ConversationTile), findsWidgets);
+          },
+        );
+      }
+
       testWidgets('the pinned header fits the chips at the default text scale', (
         tester,
       ) async {

--- a/mobile/test/screens/inbox/inbox_view_test.dart
+++ b/mobile/test/screens/inbox/inbox_view_test.dart
@@ -1557,7 +1557,17 @@ void main() {
 
       // Every Dynamic Type size iOS can hand us, as the ratio of that
       // category's body point size to the 17pt default — the mapping the
-      // engine uses to turn `preferredContentSizeCategory` into a text scale.
+      // engine uses to turn `preferredContentSizeCategory` into
+      // `textScaleFactor`.
+      //
+      // `TextScaler.linear` is a stand-in for the real thing: on device
+      // `MediaQuery.textScalerOf` is a `SystemTextScaler`, whose `scale()`
+      // defers to `PlatformDispatcher.scaleFontSize` — an engine-defined
+      // curve, not a multiplication. Measured on an iPhone at extraLarge, a
+      // 14pt/1.4x paragraph lays out at 22.0 either way, so the ladder is
+      // faithful where it has been checked. That the real curve cannot be
+      // reproduced by arithmetic at all is the point: measuring the child is
+      // immune to it, and any declared extent is not.
       //
       // The header used to declare its own extent as arithmetic over
       // `textScaler.scale(20)` while its child settled on whatever the font
@@ -1610,6 +1620,27 @@ void main() {
           // The canary: this finder walks the onstage element tree, which is
           // exactly what null-crashes when a sliver was left unlaid-out. It
           // failing IS the blank pane.
+          expect(find.byType(ConversationTile), findsWidgets);
+
+          // Pinning only engages once there is something to pin against, and
+          // that is a different geometry path — scrollOffset above zero,
+          // layoutExtent shrinking toward zero — than the initial layout.
+          // `PinnedHeaderSliver` derives paintExtent as
+          // `remainingPaintExtent - overlap` with no lower clamp, which is
+          // safe here only because nothing pinned sits above this header and
+          // `overlap` stays at zero. Adding one would put paintExtent back
+          // under layoutExtent and blank the pane again, so pin it.
+          await tester.drag(
+            find.byType(CustomScrollView),
+            const Offset(0, -400),
+          );
+          await tester.pump();
+
+          expect(
+            tester.takeException(),
+            isNull,
+            reason: 'the header must survive scrolling to its pinned edge',
+          );
           expect(find.byType(ConversationTile), findsWidgets);
         });
       }


### PR DESCRIPTION
## Description

The Messages tab lost its entire conversation list at most system text sizes, with the conversations sitting in the database and in `ConversationListState.visibleConversations` the whole time. The chrome laid out *before* the pinned filter chips — the following bar, the search field, the chips themselves — kept rendering, so the pane read as "you have no messages" rather than as a crash.

The filter-chips row was a `SliverPersistentHeader` whose delegate declared `minExtent`/`maxExtent` from a formula — `8*2 + 6*2 + textScaler.scale(20)` — reproducing its child's height rather than measuring it. A persistent header lays its child out under **loose** constraints (`asBoxConstraints(maxExtent:)` leaves `minHeight` at 0), so the chips settled at whatever their own text layout produced. The formula and the real height agreed at exactly one of iOS's twelve Dynamic Type sizes.

Where the formula declared **more** than the child laid out to, the sliver reported `paintExtent` below `layoutExtent`:

```
SliverGeometry is not valid: The "layoutExtent" exceeds the "paintExtent".
The paintExtent is 50.0, but the layoutExtent is 50.4.
  creator: _SliverPinnedPersistentHeader ← SliverPersistentHeader ← Viewport
```

That assertion has two throw sites and only one of them matters. The one in `RenderObject.layout` (`object.dart:2910`) sits inside the `try`/`catch` at 2906–2915 and is caught harmlessly. The one that does the damage is `viewport.dart:843` — `assert(childLayoutGeometry.debugAssertIsValid())` inside `RenderViewport.performLayout`, where nothing catches it. It aborts the child layout sequence, so the pinned support row, the requests banner and the conversation `SliverList` are all left with `geometry == null`, and `viewport.dart:998` (`child.geometry!.visible`) then null-crashes during paint.

Measured against `main` at every scale iOS can produce:

| Dynamic Type | declared | chips need | result |
|---|---|---|---|
| extraSmall | 44.47 | 44.0 | **list gone** |
| small | 45.65 | 46.0 | chips clipped |
| medium | 46.82 | 47.0 | chips clipped |
| **large (default)** | **48.0** | **48.0** | **ok** |
| extraLarge | 50.35 | 50.0 | **list gone** |
| extraExtraLarge | 52.71 | 53.0 | chips clipped |
| extraExtraExtraLarge | 55.06 | 55.0 | **list gone** |
| AX1 | 60.94 | 61.0 | chips clipped |
| AX2 | 66.82 | 67.0 | chips clipped |
| AX3 | 75.06 | 75.0 | **list gone** |
| AX4 | 83.29 | 83.0 | **list gone** |
| AX5 | 90.35 | 90.0 | **list gone** |

Only the default size was correct.

The fix drops the declared extent entirely and renders the row through `PinnedHeaderSliver`, which sizes itself to the measured child. That is the same call `sound_detail_screen.dart` already made, for the same reason, with the same failure written up in its doc comment (#7235). It deletes `_filterChipsExtent`, the three constants feeding it, and `_FilterChipsHeaderDelegate`, so there is no arithmetic left to keep in sync with `divine_ui`'s tiny-chip tokens — which is what drifted here.

### Confirmed on a real engine

Reproduced and fixed on an iOS simulator against the same signed-in account, switching sizes with `xcrun simctl ui <udid> content_size`:

- At **extraLarge** on `main`: the geometry assertion fires and the conversation list is simply absent — following bar, search field and chips still painted.
- At **extraLarge** on this branch: the support row, the requests banner and every conversation tile all render.
- Across all twelve sizes on this branch: every one renders, zero `SliverGeometry` errors.
- On `main` the assertion fires at exactly the six sizes the table marks, and at none of the other six — matching the widget sweep.

Two things worth knowing beyond the layout itself:

- **The semantics tree lies while this is happening.** Reading the accessibility tree during the failure still reports all seven conversations, because semantics updates are themselves failing (`!semantics.parentDataDirty`, `!childSemantics.renderObject._needsLayout`). VoiceOver would announce rows that are not on screen. Screenshots, not the a11y tree, are ground truth here.
- **`scale()` is engine-defined.** `MediaQuery.textScalerOf` is a `SystemTextScaler`, whose `scale()` defers to `PlatformDispatcher.scaleFontSize` — a platform curve, not a multiplication. The widget sweep uses `TextScaler.linear` as a stand-in; measured on an iPhone at extraLarge a 14pt/1.4x paragraph lays out at 22.0 under both, so it is faithful where it has been checked. That the real curve cannot be reproduced by arithmetic at all is the argument for measuring the child: no declared extent can be right by construction. It also means I can't claim Android is unaffected from its nominal scale values alone — it routes through the same engine call.

### Scope

`SliverGeometry.debugAssertIsValid` runs inside an `assert`, so the missing list is debug-only; profile and release builds strip both throw sites, lay out with the inconsistent geometry, and offset the content below the header by the difference (≤0.5px). The clipping half is **not** debug-only — it ships. So: a hard blocker in debug/QA for anyone off the default text size, and a latent contract violation plus sub-pixel clipping in production.

**Related Issue:** Closes #7854

## Out of Scope

None. The first revision of this PR pinned the child to the declared extent with a `SizedBox`, which fixed the missing list but left the five clipping sizes alone and kept the formula alive. Measuring the child fixes both halves, so nothing is deferred.

## Verification

- `flutter analyze lib test integration_test` — no issues
- `dart format --set-exit-if-changed` on both changed files — clean
- `flutter test test/screens/inbox/` — 446 passed
- The sweep replacing the two synthetic scales walks all twelve iOS Dynamic Type sizes, at rest and scrolled to the pinned edge. Against `main` it fails 11 of 12 — six on the `SliverGeometry` contract, five on clipping — and passes 12/12 here. (The `SizedBox` approach scores 7/12.)
- `check_raw_colors_ceiling`, `check_raw_textstyle_ceiling`, `check_material_button_ceiling`, `check_raw_dialog_ceiling` — pass
- Real-engine A/B on the iOS simulator across all twelve Dynamic Type sizes, plus a physical iPhone run (which sits at extraLarge) showing no render errors on this branch

Before/after captures exist for all twelve sizes but are deliberately **not** attached, and should not be: this repository is public and the captures are of a signed-in account, showing real conversation names, avatars and message bodies. If a visual is wanted here, say so and I will produce redacted ones against throwaway data.

Staying in draft until it has been confirmed on someone else's device at a non-default text size.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
