### PR TITLE
fix(observability): report which source resolved a video route id

### DIFF
--- a/mobile/lib/services/notification_target_resolver.dart
+++ b/mobile/lib/services/notification_target_resolver.dart
@@ -1,6 +1,7 @@
 import 'package:models/models.dart' show NIP71VideoKinds;
 import 'package:nostr_client/nostr_client.dart';
 import 'package:openvine/services/video_event_service.dart';
+import 'package:unified_logger/unified_logger.dart';
 
 class NotificationTargetResolver {
   NotificationTargetResolver({
@@ -15,25 +16,50 @@ class NotificationTargetResolver {
   Future<String?> resolveVideoEventIdFromNotificationTarget(
     String targetId,
   ) async {
+    final (:videoId, :source) = await _resolveTarget(targetId);
+
+    // A tap that resolves to nothing silently falls back to the actor's
+    // profile, so without this the walk is invisible in a bug report.
+    if (videoId == null) {
+      Log.warning(
+        'Notification target $targetId did not resolve to a video '
+        '(stopped at: $source)',
+        name: 'NotificationTargetResolver',
+        category: LogCategory.video,
+      );
+      return null;
+    }
+
+    Log.info(
+      'Notification target $targetId resolved to $videoId via $source',
+      name: 'NotificationTargetResolver',
+      category: LogCategory.video,
+    );
+    return videoId;
+  }
+
+  Future<({String? videoId, String source})> _resolveTarget(
+    String targetId,
+  ) async {
     final directVideo = _videoEventService.getVideoById(targetId);
     if (directVideo != null) {
-      return targetId;
+      return (videoId: targetId, source: 'localCache');
     }
 
     final event = await _nostrService.fetchEventById(targetId);
     if (event == null) {
-      return null;
+      return (videoId: null, source: 'targetEventNotFound');
     }
 
     if (NIP71VideoKinds.isAcceptableVideoKind(event.kind)) {
-      return targetId;
+      return (videoId: targetId, source: 'targetIsVideoEvent');
     }
 
     // NIP-22: uppercase A tag = root addressable scope. Prefer this when
     // available because it remains valid across NIP-33 video replacements.
     for (final tag in event.tags) {
       if (tag.length >= 2 && tag[0] == 'A' && _isVideoAddressableId(tag[1])) {
-        return tag[1];
+        return (videoId: tag[1], source: 'nip22RootAddressable');
       }
     }
 
@@ -41,14 +67,14 @@ class NotificationTargetResolver {
     // supports anchorless actor-like rows whose target is the reaction event.
     for (final tag in event.tags) {
       if (tag.length >= 2 && tag[0] == 'a' && _isVideoAddressableId(tag[1])) {
-        return tag[1];
+        return (videoId: tag[1], source: 'nip25Addressable');
       }
     }
 
     // NIP-22: uppercase E tag = root scope, points to root video event.
     for (final tag in event.tags) {
       if (tag.length >= 2 && tag[0] == 'E' && tag[1].isNotEmpty) {
-        return tag[1];
+        return (videoId: tag[1], source: 'nip22RootEvent');
       }
     }
 
@@ -67,7 +93,7 @@ class NotificationTargetResolver {
 
       final marker = tag.length > 3 ? tag[3] : '';
       if (marker == 'root') {
-        return candidateId;
+        return (videoId: candidateId, source: 'nip10RootMarker');
       }
       if (marker.isEmpty) {
         legacyCandidates.add(candidateId);
@@ -76,11 +102,11 @@ class NotificationTargetResolver {
 
     for (final candidateId in legacyCandidates) {
       if (await _isResolvableVideoEvent(candidateId)) {
-        return candidateId;
+        return (videoId: candidateId, source: 'legacyUnmarkedETag');
       }
     }
 
-    return null;
+    return (videoId: null, source: 'noUsableRootTag');
   }
 
   bool _isVideoAddressableId(String value) {

--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -2672,6 +2672,15 @@ class VideosRepository {
       }
     }
 
+    // Every candidate is exhausted here and nowhere else: the per-candidate
+    // helper cannot tell a miss that a later fallback rescues from a net
+    // failure, so it reports at INFO and this is the only WARNING.
+    Log.warning(
+      'Route lookup failed for every candidate: ${attempted.join(', ')}',
+      name: 'VideosRepository',
+      category: LogCategory.video,
+    );
+
     final failure = apiFailure;
     if (failure != null) throw failure;
 
@@ -2763,7 +2772,7 @@ class VideosRepository {
       missed.add('relayStableId');
     }
 
-    Log.warning(
+    Log.info(
       'Route lookup exhausted every source for $routeId '
       '(eventId=${candidate.eventId}, '
       'addressableId=${candidate.addressableId}, '

--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -2682,10 +2682,34 @@ class VideosRepository {
     String routeId,
   ) async {
     final candidate = _VideoRouteCandidate.parse(routeId);
-    if (candidate == null) return null;
+    if (candidate == null) {
+      Log.warning(
+        'Route lookup could not parse route id: $routeId',
+        name: 'VideosRepository',
+        category: LogCategory.video,
+      );
+      return null;
+    }
+
+    // Sources that answered "no", in the order they were tried. A null from
+    // this method renders a permanent "video not found", so the misses are
+    // reported alongside whichever source finally answered — otherwise the
+    // failure is indistinguishable from the video genuinely not existing.
+    final missed = <String>[];
+
+    VideoEvent resolved(String source, VideoEvent video) {
+      Log.info(
+        'Route lookup resolved $routeId via $source'
+        '${missed.isEmpty ? '' : ' (missed: ${missed.join(', ')})'}',
+        name: 'VideosRepository',
+        category: LogCategory.video,
+      );
+      return video;
+    }
 
     final cached = await _fetchRouteVideoFromLocalCache(candidate);
-    if (cached != null) return cached;
+    if (cached != null) return resolved('localCache', cached);
+    missed.add('localCache');
 
     FunnelcakeException? apiFailure;
     final funnelcakeRouteId = candidate.stableId ?? candidate.eventId;
@@ -2696,7 +2720,10 @@ class VideosRepository {
           expectedPubkey: candidate.addressablePubkey,
           permissive: true,
         );
-        if (byFunnelcake != null) return byFunnelcake;
+        if (byFunnelcake != null) {
+          return resolved('funnelcake', byFunnelcake);
+        }
+        missed.add('funnelcake');
       } on FunnelcakeException catch (e, stackTrace) {
         Log.error(
           'Funnelcake route lookup failed; falling back to relay',
@@ -2705,6 +2732,7 @@ class VideosRepository {
           error: e,
           stackTrace: stackTrace,
         );
+        missed.add('funnelcake=error');
         apiFailure = e;
       }
     }
@@ -2713,22 +2741,36 @@ class VideosRepository {
       final byEventId = await _fetchRouteVideoByEventIdFromRelay(
         candidate.eventId!,
       );
-      if (byEventId != null) return byEventId;
+      if (byEventId != null) return resolved('relayEventId', byEventId);
+      missed.add('relayEventId');
     }
 
     if (candidate.addressableId != null) {
       final byAddressable = await _fetchAddressableVideoFromRelay(
         candidate.addressableId!,
       );
-      if (byAddressable != null) return byAddressable;
+      if (byAddressable != null) {
+        return resolved('relayAddressable', byAddressable);
+      }
+      missed.add('relayAddressable');
     }
 
     if (candidate.stableId != null) {
       final byStableId = await _fetchVideoByStableIdFromRelay(
         candidate.stableId!,
       );
-      if (byStableId != null) return byStableId;
+      if (byStableId != null) return resolved('relayStableId', byStableId);
+      missed.add('relayStableId');
     }
+
+    Log.warning(
+      'Route lookup exhausted every source for $routeId '
+      '(eventId=${candidate.eventId}, '
+      'addressableId=${candidate.addressableId}, '
+      'stableId=${candidate.stableId}); missed: ${missed.join(', ')}',
+      name: 'VideosRepository',
+      category: LogCategory.video,
+    );
 
     // Nothing answered. When the API was unreachable we cannot claim the video
     // is missing: null renders a permanent "could be gone, out of reach, or

--- a/mobile/packages/videos_repository/test/src/videos_repository_route_lookup_logging_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_route_lookup_logging_test.dart
@@ -1,5 +1,5 @@
 // ABOUTME: Pins the per-step diagnostics emitted by the route-id video lookup.
-// ABOUTME: A silent null here is undiagnosable in production (see #7806).
+// ABOUTME: A silent null here is undiagnosable in production (see #7892).
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:funnelcake_api_client/funnelcake_api_client.dart';

--- a/mobile/packages/videos_repository/test/src/videos_repository_route_lookup_logging_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_route_lookup_logging_test.dart
@@ -38,6 +38,13 @@ List<String> _logsMentioning(String routeId) => LogCaptureService()
     .map((e) => e.message)
     .toList();
 
+/// WARNING-level messages captured for this test's unique route id.
+List<String> _warningsMentioning(String routeId) => LogCaptureService()
+    .getRecentLogs()
+    .where((e) => e.level == LogLevel.warning && e.message.contains(routeId))
+    .map((e) => e.message)
+    .toList();
+
 void main() {
   setUpAll(() => registerFallbackValue(<Filter>[]));
 
@@ -133,6 +140,69 @@ void main() {
         parseFailures,
         isNotEmpty,
         reason: 'an unparseable route id must not fail silently',
+      );
+    });
+
+    test('does not warn when a fallback route id rescues the lookup', () async {
+      const missingId =
+          '5555555555555555555555555555555555555555555555555555555555555555';
+      const dTag =
+          '6666666666666666666666666666666666666666666666666666666666666666';
+      const fallbackRouteId = '34236:$_pubkey:$dTag';
+
+      // Only the fallback's d-tag resolves; the primary misses every source.
+      when(() => nostr.queryEvents(any())).thenAnswer((invocation) async {
+        final filters = invocation.positionalArguments.first as List<Filter>;
+        final matches = filters.any((f) => f.d?.contains(dTag) ?? false);
+        return matches ? [_videoEvent(id: missingId, dTag: dTag)] : <Event>[];
+      });
+
+      final result = await build().fetchVideoWithStatsForRouteId(
+        missingId,
+        fallbackRouteIds: const [fallbackRouteId],
+      );
+
+      expect(result, isNotNull, reason: 'the fallback must rescue the lookup');
+      expect(
+        _warningsMentioning(missingId),
+        isEmpty,
+        reason: 'a net-successful lookup must not log a warning',
+      );
+      expect(
+        _logsMentioning(missingId).join('\n'),
+        contains('exhausted every source'),
+        reason: 'the primary miss stays diagnosable below warning level',
+      );
+    });
+
+    test('warns once when every candidate fails', () async {
+      const missingId =
+          '7777777777777777777777777777777777777777777777777777777777777777';
+      const dTag =
+          '8888888888888888888888888888888888888888888888888888888888888888';
+      const fallbackRouteId = '34236:$_pubkey:$dTag';
+
+      final result = await build().fetchVideoWithStatsForRouteId(
+        missingId,
+        fallbackRouteIds: const [fallbackRouteId],
+      );
+
+      expect(result, isNull);
+      // Deduped across both candidates: reporting per candidate would leave
+      // two distinct warnings for one failed lookup.
+      final warnings = {
+        ..._warningsMentioning(missingId),
+        ..._warningsMentioning(dTag),
+      };
+      expect(
+        warnings,
+        hasLength(1),
+        reason: 'exhaustion is reported once, after every candidate failed',
+      );
+      expect(
+        warnings.single,
+        contains(fallbackRouteId),
+        reason: 'the warning must name every candidate it tried',
       );
     });
   });

--- a/mobile/packages/videos_repository/test/src/videos_repository_route_lookup_logging_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_route_lookup_logging_test.dart
@@ -1,0 +1,139 @@
+// ABOUTME: Pins the per-step diagnostics emitted by the route-id video lookup.
+// ABOUTME: A silent null here is undiagnosable in production (see #7806).
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:funnelcake_api_client/funnelcake_api_client.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/nostr_sdk.dart';
+import 'package:unified_logger/unified_logger.dart';
+import 'package:videos_repository/videos_repository.dart';
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _MockFunnelcakeApiClient extends Mock implements FunnelcakeApiClient {}
+
+const _pubkey =
+    'd95aa8fc0eff8e488952495b8064991d27fb96ed8652f12cdedc5a4e8b5ae540';
+
+Event _videoEvent({required String id, required String dTag}) =>
+    Event.fromJson({
+      'id': id,
+      'pubkey': _pubkey,
+      'created_at': 1765250795,
+      'kind': 34236,
+      'content': '',
+      'sig': 'a' * 128,
+      'tags': [
+        ['d', dTag],
+        ['imeta', 'url https://cdn.divine.video/$dTag.mp4', 'm video/mp4'],
+        ['title', 'route lookup fixture'],
+      ],
+    });
+
+/// Messages captured for this test's unique route id.
+List<String> _logsMentioning(String routeId) => LogCaptureService()
+    .getRecentLogs()
+    .where((e) => e.message.contains(routeId))
+    .map((e) => e.message)
+    .toList();
+
+void main() {
+  setUpAll(() => registerFallbackValue(<Filter>[]));
+
+  group('route-id lookup diagnostics', () {
+    late _MockNostrClient nostr;
+    late _MockFunnelcakeApiClient funnelcake;
+
+    setUp(() {
+      nostr = _MockNostrClient();
+      funnelcake = _MockFunnelcakeApiClient();
+      when(() => nostr.queryEvents(any())).thenAnswer((_) async => []);
+      when(() => funnelcake.isAvailable).thenReturn(false);
+    });
+
+    VideosRepository build() =>
+        VideosRepository(nostrClient: nostr, funnelcakeApiClient: funnelcake);
+
+    test(
+      'names every missed source when the route id resolves nowhere',
+      () async {
+        const dTag =
+            '1111111111111111111111111111111111111111111111111111111111111111';
+        const routeId = '34236:$_pubkey:$dTag';
+
+        final result = await build().fetchVideoWithStatsForRouteId(routeId);
+
+        expect(result, isNull);
+        final logs = _logsMentioning(routeId);
+        expect(logs, isNotEmpty, reason: 'lookup failure must be logged');
+        final combined = logs.join('\n');
+        for (final step in [
+          'localCache',
+          'relayAddressable',
+          'relayStableId',
+        ]) {
+          expect(
+            combined,
+            contains(step),
+            reason: 'failure log must name the $step step',
+          );
+        }
+      },
+    );
+
+    test('names the source that resolved the route id', () async {
+      const dTag =
+          '2222222222222222222222222222222222222222222222222222222222222222';
+      const eventId =
+          '3333333333333333333333333333333333333333333333333333333333333333';
+      const routeId = '34236:$_pubkey:$dTag';
+
+      when(() => funnelcake.isAvailable).thenReturn(true);
+      when(
+        () => funnelcake.getVideoEvent(any()),
+      ).thenAnswer((_) async => _videoEvent(id: eventId, dTag: dTag));
+      when(
+        () => funnelcake.getBulkVideoStats(any()),
+      ).thenThrow(const FunnelcakeException('no stats'));
+
+      final result = await build().fetchVideoWithStatsForRouteId(routeId);
+
+      expect(result, isNotNull);
+      final combined = _logsMentioning(routeId).join('\n');
+      expect(
+        combined,
+        contains('funnelcake'),
+        reason: 'success log must name the resolving step',
+      );
+    });
+
+    test('logs the full route id without truncating it', () async {
+      const dTag =
+          '4444444444444444444444444444444444444444444444444444444444444444';
+      const routeId = '34236:$_pubkey:$dTag';
+
+      await build().fetchVideoWithStatsForRouteId(routeId);
+
+      // Nostr ids are never truncated in logs (repo-wide rule).
+      expect(_logsMentioning(routeId).join('\n'), contains(dTag));
+    });
+
+    test('logs a route id it cannot parse', () async {
+      // parse() only rejects blank input; every other string is treated as a
+      // bare d-tag, so blank is the one shape that reaches this branch.
+      final result = await build().fetchVideoWithStatsForRouteId('   ');
+
+      expect(result, isNull);
+      final parseFailures = LogCaptureService()
+          .getRecentLogs()
+          .where((e) => e.message.contains('could not parse route id'))
+          .toList();
+      expect(
+        parseFailures,
+        isNotEmpty,
+        reason: 'an unparseable route id must not fail silently',
+      );
+    });
+  });
+}

--- a/mobile/test/services/notification_target_resolver_test.dart
+++ b/mobile/test/services/notification_target_resolver_test.dart
@@ -4,6 +4,7 @@ import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/event.dart';
 import 'package:openvine/services/notification_target_resolver.dart';
 import 'package:openvine/services/video_event_service.dart';
+import 'package:unified_logger/unified_logger.dart';
 
 class _MockVideoEventService extends Mock implements VideoEventService {}
 
@@ -294,6 +295,63 @@ void main() {
       );
 
       expect(resolved, isNull);
+    });
+
+    group('diagnostics', () {
+      List<String> logsMentioning(String targetId) => LogCaptureService()
+          .getRecentLogs()
+          .where((e) => e.message.contains(targetId))
+          .map((e) => e.message)
+          .toList();
+
+      test('logs the tag that resolved the target', () async {
+        const targetId = 'comment_logged_resolved';
+        const rootId = 'root_video_logged';
+        when(() => videoEventService.getVideoById(targetId)).thenReturn(null);
+        when(() => nostrClient.fetchEventById(targetId)).thenAnswer(
+          (_) async => Event('a' * 64, 1111, const [
+            ['E', rootId],
+          ], 'comment'),
+        );
+
+        await resolver.resolveVideoEventIdFromNotificationTarget(targetId);
+
+        expect(
+          logsMentioning(targetId).join('\n'),
+          contains('nip22RootEvent'),
+          reason: 'a successful walk must name the tag it used',
+        );
+      });
+
+      test('logs where the walk stopped when nothing resolves', () async {
+        const targetId = 'comment_logged_unresolvable';
+        when(() => videoEventService.getVideoById(targetId)).thenReturn(null);
+        when(
+          () => nostrClient.fetchEventById(targetId),
+        ).thenAnswer((_) async => null);
+
+        final resolved = await resolver
+            .resolveVideoEventIdFromNotificationTarget(targetId);
+
+        expect(resolved, isNull);
+        expect(
+          logsMentioning(targetId).join('\n'),
+          contains('targetEventNotFound'),
+          reason: 'a silent fallback to the profile must leave a trace',
+        );
+      });
+
+      test('logs the full target id without truncating it', () async {
+        final targetId = 'f' * 64;
+        when(() => videoEventService.getVideoById(targetId)).thenReturn(null);
+        when(
+          () => nostrClient.fetchEventById(targetId),
+        ).thenAnswer((_) async => null);
+
+        await resolver.resolveVideoEventIdFromNotificationTarget(targetId);
+
+        expect(logsMentioning(targetId).join('\n'), contains(targetId));
+      });
     });
   });
 }


### PR DESCRIPTION
## What

A deep link to `/video/<route-id>` (notification tap, share link, push) walks five sources in order and takes the first hit:

1. local cache
2. Funnelcake REST
3. relay by event id
4. relay by addressable id
5. relay by d-tag

Every one of them returns `null` silently. The entire path carries **one** log line (`videos_repository.dart`, the Funnelcake `catch`), and it only fires on an exception — not on a clean miss. So an exhausted lookup renders a permanent "video not found" that is indistinguishable from the video genuinely not existing.

`NotificationTargetResolver` had **no logging at all**, so a tap that fails to resolve silently falls back to the actor's profile with no trace.

This PR adds:

- the source that resolved a route id, plus the sources that missed
- a summary line when every source is exhausted, including the parsed `eventId` / `addressableId` / `stableId`
- a warning when a route id cannot be parsed
- resolver logging: which tag the walk used, or where it stopped

Nostr ids are logged in full, per the repo-wide no-truncation rule.

## Why

Investigating a report of a notification tap landing on "video not found". Everything checked out individually — the event was present on the relay by both event id and addressable id, `GET /api/videos/<d-tag>` and `<event-id>` both returned 200 on `api.divine.video`, `VideoEvent.fromNostrEvent` produced `hasVideo=true` with a playable https URL, there was no NIP-09 deletion, no filtering label, and an offline harness driving the real `fetchVideoWithStatsForRouteId` with the actual event JSON resolved it correctly in all four Funnelcake-available/unavailable permutations.

The composed thing still failed on device, and there was no way to tell which step declined. **This PR does not fix that bug** — it makes the next reproduction diagnosable. Root cause is still open.

## Behavior change

None. Logging only; no control flow was altered. The `else { missed.add('…=skipped') }` branches were deliberately left out rather than covered with contrived tests — the exhaustion log prints which candidate fields were populated, so a skipped step is derivable.

## Testing

- New `videos_repository_route_lookup_logging_test.dart` (4 tests): names missed sources on exhaustion, names the resolving source, logs the full untruncated route id, logs an unparseable route id.
- 3 tests added to `notification_target_resolver_test.dart` for the resolver diagnostics.
- `videos_repository`: **492 tests pass, line coverage 100.00% (1247/1247)** — the package's VeryGood workflow specifies no `min_coverage`, so it enforces the 100% default. First draft left 4 uncovered lines; that is fixed.
- `flutter analyze lib test` clean in both the app and the package.

One thing worth flagging for review: my first version of the "unparseable route id" test passed for the wrong reason. `_VideoRouteCandidate.parse` only returns null for blank input — every other unrecognized string becomes a bare `stableId` — so the test was exercising the exhaustion path, not the parse-failure path. It now uses blank input and asserts on the parse-failure message specifically.

## Not verified

I have not reproduced the original failure with this instrumentation in place; that needs a build and a device repro. The claim here is only that the path becomes diagnosable, not that the bug is understood.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Relates to #7892

