### PR TITLE
fix(feed): keep the New feed chronological

### DIFF
--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -731,6 +731,20 @@ class VideosRepository {
   /// more behind it.
   ///
   /// Returns an empty result if no videos are found or on error.
+  /// Fetches the newest videos, newest first.
+  ///
+  /// Deliberately does not apply seen-freshness reordering. This feed is
+  /// surfaced as "New", and that label is a chronological promise: a video
+  /// watched in the last 24 hours keeps its position rather than sinking
+  /// below older ones. Because reordering ran after pagination it also
+  /// partitioned each page on its own, so timestamps descended, jumped
+  /// backwards at the page's recently-seen block, then descended again from
+  /// the next page's top — the feed read as unsorted rather than merely
+  /// re-prioritised.
+  ///
+  /// Discovery surfaces that do want the bias keep it: [getHomeFeedVideos]
+  /// still demotes via [prioritizeNotRecentlySeenVideos], and classics drop
+  /// recently-seen entirely via [filterOutRecentlySeenVideos].
   Future<HomeFeedResult> getNewVideos({
     int limit = _defaultLimit,
     int? until,
@@ -740,9 +754,8 @@ class VideosRepository {
     if (!skipCache && until == null) {
       final cached = _inMemoryFeedCache?.get('latest');
       if (cached != null) {
-        final ordered = await _orderBySeenFreshness(cached.videos);
         return HomeFeedResult(
-          videos: ordered,
+          videos: cached.videos,
           hasMore: cached.hasMore,
           paginationCursor: cached.paginationCursor,
         );
@@ -764,9 +777,8 @@ class VideosRepository {
             : page.videos;
         // Hydrate views/loops — list endpoint omits them for some rows.
         final hydrated = await _hydrateVideosWithBulkStats(mergedVideos);
-        final ordered = await _orderBySeenFreshness(hydrated);
         return _recentVideosResult(
-          ordered,
+          hydrated,
           limit: limit,
           until: until,
           serverHasMore: page.serverHasMore,
@@ -782,8 +794,7 @@ class VideosRepository {
       until: until,
     );
     final hydrated = await _hydrateVideosWithBulkStats(videos);
-    final ordered = await _orderBySeenFreshness(hydrated);
-    return _recentVideosResult(ordered, limit: limit, until: until);
+    return _recentVideosResult(hydrated, limit: limit, until: until);
   }
 
   /// Wraps a latest-feed page, recording whether more sits behind it so

--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -710,6 +710,19 @@ class VideosRepository {
   /// This is the "New" feed mode - shows all public videos sorted by
   /// creation time.
   ///
+  /// Deliberately does not apply seen-freshness reordering. This feed is
+  /// surfaced as "New", and that label is a chronological promise: a video
+  /// watched in the last 24 hours keeps its position rather than sinking
+  /// below older ones. Because reordering ran after pagination it also
+  /// partitioned each page on its own, so timestamps descended, jumped
+  /// backwards at the page's recently-seen block, then descended again from
+  /// the next page's top — the feed read as unsorted rather than merely
+  /// re-prioritised.
+  ///
+  /// Discovery surfaces that do want the bias keep it: [getHomeFeedVideos]
+  /// still demotes via [prioritizeNotRecentlySeenVideos], and classics drop
+  /// recently-seen entirely via [filterOutRecentlySeenVideos].
+  ///
   /// Strategy:
   /// 1. If Funnelcake API is available, tries the REST API first (faster)
   /// 2. Falls back to Nostr relay query
@@ -731,20 +744,6 @@ class VideosRepository {
   /// more behind it.
   ///
   /// Returns an empty result if no videos are found or on error.
-  /// Fetches the newest videos, newest first.
-  ///
-  /// Deliberately does not apply seen-freshness reordering. This feed is
-  /// surfaced as "New", and that label is a chronological promise: a video
-  /// watched in the last 24 hours keeps its position rather than sinking
-  /// below older ones. Because reordering ran after pagination it also
-  /// partitioned each page on its own, so timestamps descended, jumped
-  /// backwards at the page's recently-seen block, then descended again from
-  /// the next page's top — the feed read as unsorted rather than merely
-  /// re-prioritised.
-  ///
-  /// Discovery surfaces that do want the bias keep it: [getHomeFeedVideos]
-  /// still demotes via [prioritizeNotRecentlySeenVideos], and classics drop
-  /// recently-seen entirely via [filterOutRecentlySeenVideos].
   Future<HomeFeedResult> getNewVideos({
     int limit = _defaultLimit,
     int? until,

--- a/mobile/packages/videos_repository/test/src/videos_repository_seen_filtering_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_seen_filtering_test.dart
@@ -127,7 +127,13 @@ void main() {
       expect(result.videos.map((v) => v.id).toList(), [unseenId, seenId]);
     });
 
-    test('getNewVideos demotes recently seen', () async {
+    // The New feed is chronological by contract: the label promises recency,
+    // so a recently-seen video keeps its place instead of sinking. Demotion
+    // partitioned each page independently, which produced a sawtooth —
+    // timestamps descended, jumped back at the page's seen block, then
+    // descended again from the next page's top. Discovery surfaces that do
+    // want the bias still use the shared helper (see getHomeFeedVideos above).
+    test('getNewVideos preserves source order for recently seen', () async {
       final seen = _stats('seen-new');
       final unseen = _stats('unseen-new');
       when(
@@ -156,8 +162,44 @@ void main() {
 
       final result = await repo.getNewVideos();
       expect(result.videos.map((v) => v.id).toList(), [
-        'unseen-new',
         'seen-new',
+        'unseen-new',
+      ]);
+    });
+
+    test('getNewVideos preserves source order on a paginated page', () async {
+      final seen = _stats('seen-page2');
+      final unseen = _stats('unseen-page2');
+      when(
+        () => mockFunnelcake.getRecentVideosPage(
+          limit: any(named: 'limit'),
+          before: any(named: 'before'),
+        ),
+      ).thenAnswer(
+        (_) async => RecentVideosResponse(
+          videos: [seen, unseen],
+          serverItemCount: 2,
+        ),
+      );
+      when(
+        () => mockFunnelcake.getBulkVideoStats(any()),
+      ).thenAnswer((_) async => const BulkVideoStatsResponse(stats: {}));
+
+      final repo = VideosRepository(
+        nostrClient: mockNostr,
+        funnelcakeApiClient: mockFunnelcake,
+        seenVideoLookup: SeenVideoLookup(
+          wasSeenRecently: (id, {within = const Duration(hours: 24)}) =>
+              id == 'seen-page2',
+        ),
+      );
+
+      // Page 2 must not re-partition: independent per-page partitioning is
+      // what made the feed read as unsorted across page boundaries.
+      final result = await repo.getNewVideos(until: 1704067200);
+      expect(result.videos.map((v) => v.id).toList(), [
+        'seen-page2',
+        'unseen-page2',
       ]);
     });
 

--- a/mobile/packages/videos_repository/test/src/videos_repository_seen_filtering_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_seen_filtering_test.dart
@@ -1,5 +1,6 @@
 // TDD: client-side seen-video filtering across feeds
-// Covers: home (following) demotes, new demotes, classic drops + deep-fetch,
+// Covers: home (following) demotes, new stays chronological (including cache
+// hits, relay fallback, and page boundaries), classic drops + deep-fetch,
 // profile untouched, deep-fetch triggers when filtering removes most of page.
 
 import 'dart:math';
@@ -167,9 +168,68 @@ void main() {
       ]);
     });
 
-    test('getNewVideos preserves source order on a paginated page', () async {
-      final seen = _stats('seen-page2');
-      final unseen = _stats('unseen-page2');
+    // Cross-page, not per-page: the seen heads of both pages must keep their
+    // places, so the concatenation descends monotonically across the
+    // boundary. Per-page partitioning is what made the feed read as unsorted
+    // — timestamps descended, jumped back at the page's seen block, then
+    // descended again from the next page's top.
+    test('getNewVideos does not re-partition across page boundaries', () async {
+      when(
+        () => mockFunnelcake.getRecentVideosPage(
+          limit: any(named: 'limit'),
+          before: any(named: 'before'),
+        ),
+      ).thenAnswer((invocation) async {
+        final before = invocation.namedArguments[#before] as int?;
+        if (before == null) {
+          return RecentVideosResponse(
+            videos: [
+              _stats('p1-seen-newest', createdAt: 1000),
+              _stats('p1-mid', createdAt: 900),
+              _stats('p1-tail', createdAt: 800),
+            ],
+            serverItemCount: 3,
+          );
+        }
+        return RecentVideosResponse(
+          videos: [
+            _stats('p2-seen-head', createdAt: 700),
+            _stats('p2-older', createdAt: 600),
+          ],
+          serverItemCount: 2,
+        );
+      });
+      when(
+        () => mockFunnelcake.getBulkVideoStats(any()),
+      ).thenAnswer((_) async => const BulkVideoStatsResponse(stats: {}));
+
+      final repo = VideosRepository(
+        nostrClient: mockNostr,
+        funnelcakeApiClient: mockFunnelcake,
+        seenVideoLookup: SeenVideoLookup(
+          wasSeenRecently: (id, {within = const Duration(hours: 24)}) =>
+              id == 'p1-seen-newest' || id == 'p2-seen-head',
+        ),
+      );
+
+      final page1 = await repo.getNewVideos(limit: 3);
+      final page2 = await repo.getNewVideos(limit: 3, until: 800);
+      final all = [...page1.videos, ...page2.videos];
+      expect(all.map((v) => v.id).toList(), [
+        'p1-seen-newest',
+        'p1-mid',
+        'p1-tail',
+        'p2-seen-head',
+        'p2-older',
+      ]);
+    });
+
+    // Reopening Explore within a day of browsing is a same-session cache
+    // hit — the PR's named worst case. The cached page must come back in
+    // its recorded order, not re-demoted on the way out.
+    test('getNewVideos cache hit returns the cached order unchanged', () async {
+      final seen = _stats('cache-seen');
+      final unseen = _stats('cache-unseen');
       when(
         () => mockFunnelcake.getRecentVideosPage(
           limit: any(named: 'limit'),
@@ -188,18 +248,64 @@ void main() {
       final repo = VideosRepository(
         nostrClient: mockNostr,
         funnelcakeApiClient: mockFunnelcake,
+        inMemoryFeedCache: InMemoryFeedCache(),
         seenVideoLookup: SeenVideoLookup(
           wasSeenRecently: (id, {within = const Duration(hours: 24)}) =>
-              id == 'seen-page2',
+              id == 'cache-seen',
         ),
       );
 
-      // Page 2 must not re-partition: independent per-page partitioning is
-      // what made the feed read as unsorted across page boundaries.
-      final result = await repo.getNewVideos(until: 1704067200);
+      final first = await repo.getNewVideos();
+      final second = await repo.getNewVideos();
+      expect(first.videos.map((v) => v.id).toList(), [
+        'cache-seen',
+        'cache-unseen',
+      ]);
+      expect(second.videos.map((v) => v.id).toList(), [
+        'cache-seen',
+        'cache-unseen',
+      ]);
+      verify(
+        () => mockFunnelcake.getRecentVideosPage(
+          limit: any(named: 'limit'),
+          before: any(named: 'before'),
+        ),
+      ).called(1);
+    });
+
+    // With Funnelcake down, the relay path must still be chronological: the
+    // newest event is recently seen, but must not sink.
+    test('getNewVideos relay fallback stays chronological for seen', () async {
+      final newestSeen = _event('relay-seen-newest', createdAt: 1704067300);
+      final middle = _event('relay-mid', createdAt: 1704067250);
+      final oldest = _event('relay-oldest');
+      when(
+        () => mockFunnelcake.getRecentVideosPage(
+          limit: any(named: 'limit'),
+          before: any(named: 'before'),
+        ),
+      ).thenThrow(const FunnelcakeException('stats API down'));
+      when(
+        () => mockFunnelcake.getBulkVideoStats(any()),
+      ).thenAnswer((_) async => const BulkVideoStatsResponse(stats: {}));
+      when(
+        () => mockNostr.queryEvents(any()),
+      ).thenAnswer((_) async => [middle, oldest, newestSeen]);
+
+      final repo = VideosRepository(
+        nostrClient: mockNostr,
+        funnelcakeApiClient: mockFunnelcake,
+        seenVideoLookup: SeenVideoLookup(
+          wasSeenRecently: (id, {within = const Duration(hours: 24)}) =>
+              id == 'relay-seen-newest',
+        ),
+      );
+
+      final result = await repo.getNewVideos(limit: 10);
       expect(result.videos.map((v) => v.id).toList(), [
-        'seen-page2',
-        'unseen-page2',
+        'relay-seen-newest',
+        'relay-mid',
+        'relay-oldest',
       ]);
     });
 


### PR DESCRIPTION
Closes #7860

## Symptom

The Explore → **New** tab is not sorted chronologically.

## Cause

`VideosRepository.getNewVideos` ran **every** return path — in-memory cache hit, Funnelcake, and the relay fallback — through `_orderBySeenFreshness`. That calls `prioritizeNotRecentlySeenVideos`, which partitions the page and concatenates:

```dart
return [...notRecentlySeen, ...recentlySeen];
```

Anything watched in the last 24 hours (`defaultRecentlySeenVideoWindow`) sinks to the bottom of the page.

The server is not involved. `GET /api/videos?sort=recent&limit=25` returns strictly descending `created_at` with zero out-of-order pairs, and `_mergeRecentApiVideosWithRelayRefresh` already sorts `b.createdAt.compareTo(a.createdAt)`. The reordering was entirely client-side and entirely inside this one method.

## Why it read as "unsorted" rather than "re-prioritised"

The partition ran **after** pagination, so each page was partitioned independently:

```
page 1: [newest unseen … oldest unseen][newest seen … oldest seen]
page 2: [newest unseen … oldest unseen][newest seen … oldest seen]
```

Timestamps descend, jump backwards at each page's seen block, then descend again from the next page's top — a sawtooth, repeating per page. It's worst on the pattern that surfaces it most: reopening Explore within a day of browsing, when the genuinely-newest videos are the ones already watched, so they sink and the top of "New" looks *older* than it did earlier.

Both `new_videos_feed_provider.dart` and `new_videos_tab.dart` already document themselves as *"sorted by creation time"* / *"sorted by time"*. The documented contract was chronological; the implementation had drifted from it.

## Change

Remove the three `_orderBySeenFreshness` calls inside `getNewVideos`, and document the chronological contract on the method.

**Scoped to this feed only.** The shared helpers are untouched:

- `getHomeFeedVideos` still demotes via `prioritizeNotRecentlySeenVideos`
- classics still drop entirely via `filterOutRecentlySeenVideos`
- the other four `_orderBySeenFreshness` call sites in the repository are unchanged

`getNewVideos` has no callers besides the two New surfaces (`new_videos_feed_provider.dart` and `VideoFeedSourceType.newVideos` in `video_feed_bloc.dart`), so the blast radius is the New-labelled surfaces: the Explore → New tab and the main feed's New mode via the feed-mode switch. Nothing downstream re-sorts — `_filterVideos` only filters, and the bloc passes the result through.

## ⚠️ Behavior change — please read

**A heavy viewer will now see videos they already watched at the top of New**, where previously those were demoted for 24 hours. That is the intended trade: "New" makes a chronological promise, and de-duplicating recent viewing is a discovery-surface concern rather than a recency-feed one.

If product would rather keep the freshness bias, the alternative is to apply the partition **before** pagination instead of per page. That kills the sawtooth while retaining demotion, and I'm happy to switch this PR to that shape instead — it's a bigger change, since ordering would have to move to the paging layer.

**This inverts an existing test.** `getNewVideos demotes recently seen` asserted the old behavior and is replaced by tests asserting source order is preserved. That inversion is the deliberate core of the PR, not an incidental fixup — flagging it explicitly so it gets scrutiny rather than being skimmed as a rename.

## Testing

- `getNewVideos preserves source order for recently seen` (replaces the inverted test)
- `getNewVideos does not re-partition across page boundaries` — new, asserts the concatenation stays monotonically descending across a page boundary, the property the sawtooth broke
- `getNewVideos cache hit returns the cached order unchanged` and `getNewVideos relay fallback stays chronological for seen` — pin the cache-hit and relay-fallback return paths (review follow-up)
- The existing `getHomeFeedVideos demotes recently seen` and `getClassicVideos drops recently seen` tests are untouched and still pass, which is what pins the scoping
- **491 tests pass, line coverage 100.00% (1224/1224)** — this package's VeryGood workflow sets no `min_coverage`, so it enforces the 100% default
- `flutter analyze lib test` clean in both app and package

## Not verified

I have not run the app to confirm the tab visually. The evidence here is the call-path trace, the server-ordering check, and the tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

