### PR TITLE
feat(video-player): log why playback stops

### DIFF
--- a/mobile/lib/screens/comments/widgets/video_comment_player.dart
+++ b/mobile/lib/screens/comments/widgets/video_comment_player.dart
@@ -90,7 +90,10 @@ class _VideoCommentPlayerState extends State<VideoCommentPlayer>
     }
 
     setState(() => _isInitializing = true);
-    final controller = DivineVideoPlayerController(useTexture: true);
+    final controller = DivineVideoPlayerController(
+      useTexture: true,
+      debugLabel: 'comments',
+    );
     try {
       await controller.initialize();
       await controller.setSource(VideoClip.network(widget.videoUrl));

--- a/mobile/lib/screens/video_editor/video_clip_chroma_key_screen.dart
+++ b/mobile/lib/screens/video_editor/video_clip_chroma_key_screen.dart
@@ -117,7 +117,10 @@ class _VideoClipChromaKeyScreenState extends State<VideoClipChromaKeyScreen> {
 
     // Re-check `mounted` after every await and tear the controller down when
     // this screen went away mid-load, rather than leaking it.
-    final player = DivineVideoPlayerController(useTexture: true);
+    final player = DivineVideoPlayerController(
+      useTexture: true,
+      debugLabel: 'editor_chroma_key',
+    );
     try {
       await player.initialize();
       if (!mounted) return await player.dispose();

--- a/mobile/lib/screens/video_editor/video_clip_transform_screen.dart
+++ b/mobile/lib/screens/video_editor/video_clip_transform_screen.dart
@@ -64,7 +64,10 @@ class _VideoClipTransformScreenState extends State<VideoClipTransformScreen> {
         widget.clip.requireVideo,
       );
 
-      final player = DivineVideoPlayerController(useTexture: true);
+      final player = DivineVideoPlayerController(
+        useTexture: true,
+        debugLabel: 'editor_transform',
+      );
       await player.initialize();
       await player.setSource(
         VideoClip(

--- a/mobile/lib/screens/video_editor/video_editor_screen.dart
+++ b/mobile/lib/screens/video_editor/video_editor_screen.dart
@@ -344,6 +344,7 @@ class _VideoEditorScreenState extends ConsumerState<VideoEditorScreen>
     final result = await Navigator.push<bool>(
       context,
       PageRouteBuilder<bool>(
+        settings: const RouteSettings(name: 'video_recorder'),
         opaque: false,
         barrierDismissible: true,
         barrierColor: VineTheme.transparent,
@@ -585,6 +586,7 @@ class _VideoEditorScreenState extends ConsumerState<VideoEditorScreen>
     final result = await Navigator.push<TextLayer>(
       context,
       PageRouteBuilder<TextLayer>(
+        settings: const RouteSettings(name: 'video_text_editor'),
         opaque: false,
         barrierDismissible: true,
         barrierColor: VineTheme.transparent,
@@ -762,6 +764,7 @@ class _VideoEditorScreenState extends ConsumerState<VideoEditorScreen>
     mainBloc.add(const VideoEditorExternalPauseRequested(isPaused: true));
     final takes = await Navigator.of(context).push<List<AudioEvent>>(
       PageRouteBuilder<List<AudioEvent>>(
+        settings: const RouteSettings(name: 'voice_over_recorder'),
         pageBuilder: (_, _, _) => VoiceOverRecorderScreen(
           availableDuration: availableDuration,
           priorTakeCount: priorTakeCount,

--- a/mobile/lib/screens/video_metadata/video_metadata_cover_screen.dart
+++ b/mobile/lib/screens/video_metadata/video_metadata_cover_screen.dart
@@ -105,7 +105,10 @@ class _VideoMetadataCoverScreenState
     if (!mounted) return;
     _videoDuration = metadata.duration;
 
-    final controller = DivineVideoPlayerController(useTexture: true);
+    final controller = DivineVideoPlayerController(
+      useTexture: true,
+      debugLabel: 'metadata_cover',
+    );
     try {
       await controller.initialize();
       if (!mounted) {

--- a/mobile/lib/screens/video_metadata/video_metadata_preview_screen.dart
+++ b/mobile/lib/screens/video_metadata/video_metadata_preview_screen.dart
@@ -91,7 +91,10 @@ class _VideoMetadataPreviewScreenState
     final video = widget.clip.video;
     if (video == null) return;
 
-    final controller = DivineVideoPlayerController(useTexture: true);
+    final controller = DivineVideoPlayerController(
+      useTexture: true,
+      debugLabel: 'metadata_preview',
+    );
     try {
       await controller.initialize();
       if (!mounted) {

--- a/mobile/lib/widgets/subtitle_editor/subtitle_editor_stage.dart
+++ b/mobile/lib/widgets/subtitle_editor/subtitle_editor_stage.dart
@@ -210,7 +210,10 @@ class _SubtitleEditorStageState extends State<SubtitleEditorStage>
       return;
     }
 
-    final controller = DivineVideoPlayerController(useTexture: true);
+    final controller = DivineVideoPlayerController(
+      useTexture: true,
+      debugLabel: 'subtitle_editor',
+    );
     try {
       await controller.initialize();
       await controller.setSource(VideoClip.network(url));

--- a/mobile/lib/widgets/video_clip/video_clip_preview.dart
+++ b/mobile/lib/widgets/video_clip/video_clip_preview.dart
@@ -74,7 +74,10 @@ class _VideoClipPreviewSheetState extends ConsumerState<VideoClipPreview> {
       return;
     }
 
-    final controller = DivineVideoPlayerController(useTexture: true);
+    final controller = DivineVideoPlayerController(
+      useTexture: true,
+      debugLabel: 'clip_preview',
+    );
     try {
       await controller.initialize();
       if (!mounted) {

--- a/mobile/lib/widgets/video_editor/audio_editor/audio_selection_bottom_sheet.dart
+++ b/mobile/lib/widgets/video_editor/audio_editor/audio_selection_bottom_sheet.dart
@@ -367,6 +367,7 @@ class _AudioSelectionBottomSheetState
             (VideoEditorConstants.maxDuration.inMilliseconds / 1000.0)) {
       final timingResult = await Navigator.of(context).push<AudioTimingResult>(
         PageRouteBuilder(
+          settings: const RouteSettings(name: 'audio_timing'),
           opaque: false,
           barrierColor: VineTheme.transparent,
           transitionsBuilder: (_, animation, _, child) =>

--- a/mobile/lib/widgets/video_editor/audio_editor/video_editor_audio_chip.dart
+++ b/mobile/lib/widgets/video_editor/audio_editor/video_editor_audio_chip.dart
@@ -66,6 +66,7 @@ class VideoEditorAudioChip extends StatelessWidget {
       // screen so the user can adjust the start offset or remove the sound.
       final timingResult = await Navigator.of(context).push<AudioTimingResult>(
         PageRouteBuilder(
+          settings: const RouteSettings(name: 'audio_timing'),
           opaque: false,
           barrierColor: VineTheme.transparent,
           pageBuilder: (_, _, _) =>

--- a/mobile/lib/widgets/video_editor/chroma_key/chroma_key_backdrop.dart
+++ b/mobile/lib/widgets/video_editor/chroma_key/chroma_key_backdrop.dart
@@ -185,6 +185,7 @@ class _VideoBackdropState extends State<_VideoBackdrop> {
     final controller = DivineVideoPlayerController(
       useTexture: true,
       exclusivePlayback: false,
+      debugLabel: 'editor_chroma_backdrop',
     );
     bool superseded() => !mounted || generation != _loadGeneration;
     try {

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
@@ -1493,7 +1493,10 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
     // fast Done-tap (release) or a newer init can replace/null `_videoPlayer`
     // mid-flight. Whoever supersedes us owns disposing this controller, so we
     // just abandon it rather than resurrecting a released player.
-    final player = DivineVideoPlayerController(useTexture: true);
+    final player = DivineVideoPlayerController(
+      useTexture: true,
+      debugLabel: 'editor_canvas',
+    );
     _videoPlayer = player;
 
     await player.initialize();

--- a/mobile/lib/widgets/video_editor/stop_motion/stop_motion_frame_commands.dart
+++ b/mobile/lib/widgets/video_editor/stop_motion/stop_motion_frame_commands.dart
@@ -105,6 +105,7 @@ Future<void> transformStopMotionFrame(
 
   final bytes = await Navigator.of(context).push<Uint8List>(
     PageRouteBuilder<Uint8List>(
+      settings: const RouteSettings(name: 'stop_motion_frame_transform'),
       opaque: false,
       barrierColor: context.vineColors.surfaceContainerHigh,
       pageBuilder: (_, _, _) => StopMotionFrameTransformScreen(

--- a/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls.dart
@@ -139,6 +139,7 @@ class _TimelineClipControlsState extends State<TimelineClipControls> {
 
     final transform = await Navigator.of(context).push<ExportTransform>(
       PageRouteBuilder<ExportTransform>(
+        settings: const RouteSettings(name: 'video_clip_transform'),
         opaque: false,
         barrierColor: context.vineColors.surfaceContainerHigh,
         pageBuilder: (_, _, _) => VideoClipTransformScreen(clip: clip),
@@ -171,6 +172,7 @@ class _TimelineClipControlsState extends State<TimelineClipControls> {
     // and would not otherwise find it. Nothing comes back through the pop.
     await Navigator.of(context).push<void>(
       PageRouteBuilder<void>(
+        settings: const RouteSettings(name: 'video_clip_chroma_key'),
         opaque: false,
         barrierColor: VineTheme.backgroundCamera,
         pageBuilder: (_, _, _) => BlocProvider<ClipEditorBloc>.value(

--- a/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_overlay_controls.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_overlay_controls.dart
@@ -429,6 +429,7 @@ class _SoundOverlayControls extends StatelessWidget {
 
     final timingResult = await Navigator.of(context).push<AudioTimingResult>(
       PageRouteBuilder(
+        settings: const RouteSettings(name: 'audio_timing'),
         opaque: false,
         barrierColor: VineTheme.transparent,
         transitionsBuilder: (_, animation, _, child) =>

--- a/mobile/lib/widgets/video_metadata/modes/capture/video_metadata_capture_app_bar.dart
+++ b/mobile/lib/widgets/video_metadata/modes/capture/video_metadata_capture_app_bar.dart
@@ -27,6 +27,7 @@ class VideoMetadataCaptureAppBar extends ConsumerWidget
     await Navigator.push(
       context,
       PageRouteBuilder<void>(
+        settings: const RouteSettings(name: 'video_metadata_preview'),
         pageBuilder: (_, _, _) => VideoMetadataPreviewScreen(clip: clip),
         transitionsBuilder: (_, animation, _, child) {
           return FadeTransition(opacity: animation, child: child);

--- a/mobile/lib/widgets/video_metadata/modes/capture/video_metadata_capture_clip_preview.dart
+++ b/mobile/lib/widgets/video_metadata/modes/capture/video_metadata_capture_clip_preview.dart
@@ -32,6 +32,7 @@ class VideoMetadataCaptureClipPreview extends ConsumerWidget {
     await Navigator.push(
       context,
       PageRouteBuilder<void>(
+        settings: const RouteSettings(name: 'video_metadata_cover'),
         transitionDuration: duration,
         reverseTransitionDuration: duration,
         pageBuilder: (_, _, _) => VideoMetadataCoverScreen(clip: clip),

--- a/mobile/lib/widgets/video_metadata/modes/classic/video_metadata_classic_preview_thumbnail.dart
+++ b/mobile/lib/widgets/video_metadata/modes/classic/video_metadata_classic_preview_thumbnail.dart
@@ -78,7 +78,10 @@ class _VideoMetadataClassicPreviewThumbnailState
     // Avoid re-initializing for the same source.
     if (_controller != null) return;
 
-    final controller = DivineVideoPlayerController(useTexture: true);
+    final controller = DivineVideoPlayerController(
+      useTexture: true,
+      debugLabel: 'metadata_classic_thumbnail',
+    );
     try {
       await controller.initialize();
       if (!mounted) {

--- a/mobile/lib/widgets/video_metadata/modes/edit/video_metadata_edit_stack.dart
+++ b/mobile/lib/widgets/video_metadata/modes/edit/video_metadata_edit_stack.dart
@@ -116,6 +116,7 @@ class _VideoMetadataEditStackContentState
     final path = await Navigator.push<String?>(
       context,
       PageRouteBuilder<String?>(
+        settings: const RouteSettings(name: 'video_metadata_cover'),
         transitionDuration: duration,
         reverseTransitionDuration: duration,
         pageBuilder: (_, _, _) => VideoMetadataCoverScreen(

--- a/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
+++ b/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
@@ -41,6 +41,8 @@ internal class DivineVideoPlayerInstance(
     messenger: BinaryMessenger,
     private val context: Context,
     private val playerId: Int,
+    /** Names the screen that owns this player, as sent by the Dart side. */
+    private val debugLabel: String? = null,
     private val playerFactory: ((Context) -> ExoPlayer)? = null,
     private val bufferProfile: BufferProfile = BufferProfile.FULL,
     private val mainHandler: Handler = Handler(Looper.getMainLooper()),
@@ -135,6 +137,16 @@ internal class DivineVideoPlayerInstance(
     private var clipSpeeds = listOf<Float>()
     private var clipCount = 0
     private var isLooping = false
+
+    /**
+     * Identifies this player in diagnostic logs.
+     *
+     * Mirrors the Dart side's `_logTarget` so a `Player 665404 (feed[0])`
+     * line reads the same whichever half of the channel emitted it.
+     */
+    private val logTarget: String =
+        if (debugLabel == null) "Player $playerId" else "Player $playerId ($debugLabel)"
+
     private var volume = 1.0
     private var speed = 1.0
     private var firstFrameRendered = false
@@ -196,7 +208,7 @@ internal class DivineVideoPlayerInstance(
         deferredSetClips?.let { deferred ->
             trackDurationProbingDisabled = true
             DivineVideoPlayerLog.warning(
-                "Player $playerId applied clips unclamped: track lengths not " +
+                "$logTarget applied clips unclamped: track lengths not " +
                     "read within ${TRACK_DURATION_RESOLVE_TIMEOUT_MS}ms; " +
                     "metadata probing disabled for this instance",
                 name = "DivineVideoPlayer.Load",
@@ -247,7 +259,7 @@ internal class DivineVideoPlayerInstance(
     private val setClipsTimeoutRunnable = Runnable {
         if (pendingSetClipsResult != null) {
             DivineVideoPlayerLog.warning(
-                "Player $playerId load froze: never reached ready within " +
+                "$logTarget load froze: never reached ready within " +
                     "${SET_CLIPS_TIMEOUT_MS}ms",
                 name = "DivineVideoPlayer.Freeze",
             )
@@ -270,7 +282,7 @@ internal class DivineVideoPlayerInstance(
     private val bufferingWatchdogRunnable = Runnable {
         bufferingStallReported = true
         DivineVideoPlayerLog.warning(
-            "Player $playerId appears frozen: still buffering after " +
+            "$logTarget appears frozen: still buffering after " +
                 "${BUFFERING_STALL_MS}ms",
             name = "DivineVideoPlayer.Freeze",
         )
@@ -529,7 +541,7 @@ internal class DivineVideoPlayerInstance(
         } catch (e: RejectedExecutionException) {
             // Disposed while a call was in flight; nothing left to play into.
             DivineVideoPlayerLog.warning(
-                "Player $playerId dropped setClips after dispose: $e",
+                "$logTarget dropped setClips after dispose: $e",
                 name = "DivineVideoPlayer.Load",
             )
             if (claimDeferredSetClips(deferred)) {
@@ -557,7 +569,7 @@ internal class DivineVideoPlayerInstance(
             }
         } catch (e: RejectedExecutionException) {
             DivineVideoPlayerLog.warning(
-                "Player $playerId dropped background track-duration read: $e",
+                "$logTarget dropped background track-duration read: $e",
                 name = "DivineVideoPlayer.Load",
             )
         }
@@ -611,7 +623,7 @@ internal class DivineVideoPlayerInstance(
         if (changed) {
             refreshClipOffsets(exoPlayer)
             DivineVideoPlayerLog.info(
-                "Player $playerId applied resolved track-end clamp",
+                "$logTarget applied resolved track-end clamp",
                 name = "DivineVideoPlayer.Load",
             )
         }
@@ -677,7 +689,7 @@ internal class DivineVideoPlayerInstance(
             val uri = map["uri"] as? String
             if (uri == null) {
                 DivineVideoPlayerLog.warning(
-                    "Player $playerId skipped a clip: missing uri",
+                    "$logTarget skipped a clip: missing uri",
                     name = "DivineVideoPlayer.Load",
                 )
                 continue
@@ -774,7 +786,7 @@ internal class DivineVideoPlayerInstance(
         exoPlayer.prepare()
         isResettingPlayer = false
         DivineVideoPlayerLog.info(
-            "Player $playerId prepared $clipCount clip(s)",
+            "$logTarget prepared $clipCount clip(s)",
             name = "DivineVideoPlayer.Load",
         )
         // Apply the starting clip's per-clip volume immediately so the correct
@@ -929,7 +941,7 @@ internal class DivineVideoPlayerInstance(
             }
         } catch (e: Exception) {
             DivineVideoPlayerLog.warning(
-                "Player $playerId could not read track durations: $e",
+                "$logTarget could not read track durations: $e",
                 name = "DivineVideoPlayer.Load",
             )
             return
@@ -1136,7 +1148,7 @@ internal class DivineVideoPlayerInstance(
         }
         audioOverlayManager.setTracks(tracksRaw, speed.toFloat())
         DivineVideoPlayerLog.info(
-            "Player $playerId set ${tracksRaw.size} audio overlay track(s)",
+            "$logTarget set ${tracksRaw.size} audio overlay track(s)",
             name = "DivineVideoPlayer.Audio",
         )
         syncAudioOverlays()
@@ -1413,9 +1425,41 @@ internal class DivineVideoPlayerInstance(
          */
         override fun onPlayWhenReadyChanged(playWhenReady: Boolean, reason: Int) {
             val message =
-                "Player $playerId playWhenReady=$playWhenReady " +
+                "$logTarget playWhenReady=$playWhenReady " +
                     "(${playWhenReadyReasonName(reason)})"
             if (playWhenReady) {
+                DivineVideoPlayerLog.debug(message, name = "DivineVideoPlayer.Playback")
+            } else {
+                DivineVideoPlayerLog.info(message, name = "DivineVideoPlayer.Playback")
+            }
+        }
+
+        /**
+         * Reports a stop that nobody asked for.
+         *
+         * `playWhenReady` still true means this player was not paused — it
+         * stopped on its own. The buffering watchdog only fires after 8s, so
+         * a shorter stall would otherwise leave no trace at all.
+         *
+         * Two routine transitions reach the same callback and are not
+         * anomalies: a seek drives the player through `STATE_BUFFERING` on
+         * its way to the new position, and a non-looping clip reaching its
+         * end lands in `STATE_ENDED`. Both are reported at debug so the info
+         * line keeps meaning "stopped for no reason we asked for".
+         */
+        private fun reportUnrequestedStop() {
+            val exoPlayer = player ?: return
+            if (!exoPlayer.playWhenReady) return
+
+            val state = exoPlayer.playbackState
+            val expected =
+                seekCompletionResult != null || state == Player.STATE_ENDED
+            val message =
+                "$logTarget stopped playing while still requested to play " +
+                    "(state=${playbackStateName(state)}" +
+                    (if (seekCompletionResult != null) ", seeking" else "") +
+                    ")"
+            if (expected) {
                 DivineVideoPlayerLog.debug(message, name = "DivineVideoPlayer.Playback")
             } else {
                 DivineVideoPlayerLog.info(message, name = "DivineVideoPlayer.Playback")
@@ -1427,17 +1471,7 @@ internal class DivineVideoPlayerInstance(
                 syncAudioOverlays()
             } else {
                 audioOverlayManager.pauseAndDeactivateAll()
-                // Still asked to play, yet no longer playing: nobody paused
-                // this one, it stalled or ran out of media by itself. The
-                // buffering watchdog only fires after 8s, so a shorter stall
-                // would otherwise leave no trace at all.
-                if (player?.playWhenReady == true) {
-                    DivineVideoPlayerLog.info(
-                        "Player $playerId stopped playing while still requested to " +
-                            "play (state=${playbackStateName(player?.playbackState)})",
-                        name = "DivineVideoPlayer.Playback",
-                    )
-                }
+                reportUnrequestedStop()
             }
             sendStateUpdate()
         }
@@ -1520,7 +1554,7 @@ internal class DivineVideoPlayerInstance(
             val currentUri = player?.currentMediaItem?.localConfiguration?.uri
             val nativeErrorCode = errorCodeFor(error)
             val message =
-                "Player $playerId playback error [${error.errorCodeName}]: " +
+                "$logTarget playback error [${error.errorCodeName}]: " +
                     "source=${currentUri ?: "unknown"} " +
                     (error.message ?: "unknown")
             if (nativeErrorCode == "media_processing") {
@@ -1605,7 +1639,7 @@ internal class DivineVideoPlayerInstance(
         val recoveringPlayer = player ?: return false
         decoderRetryCount++
         DivineVideoPlayerLog.warning(
-            "Player $playerId decoder error [${error.errorCodeName}] — " +
+            "$logTarget decoder error [${error.errorCodeName}] — " +
                 "retry $decoderRetryCount/$MAX_DECODER_RETRIES " +
                 "in ${DECODER_RETRY_DELAY_MS}ms",
             name = "DivineVideoPlayer.Playback",

--- a/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
+++ b/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
@@ -1441,11 +1441,14 @@ internal class DivineVideoPlayerInstance(
          * stopped on its own. The buffering watchdog only fires after 8s, so
          * a shorter stall would otherwise leave no trace at all.
          *
-         * Two routine transitions reach the same callback and are not
+         * Three routine transitions reach the same callback and are not
          * anomalies: a seek drives the player through `STATE_BUFFERING` on
-         * its way to the new position, and a non-looping clip reaching its
-         * end lands in `STATE_ENDED`. Both are reported at debug so the info
-         * line keeps meaning "stopped for no reason we asked for".
+         * its way to the new position, a non-looping clip reaching its end
+         * lands in `STATE_ENDED`, and a requested `stop()` lands in
+         * `STATE_IDLE`. The last covers Dart's `stop()`, Activity detach, and
+         * a fatal error — none of which clear `playWhenReady`, and the error
+         * is already reported by [onPlayerError]. All are reported at debug so
+         * the info line keeps meaning "stopped for no reason we asked for".
          */
         private fun reportUnrequestedStop() {
             val exoPlayer = player ?: return
@@ -1453,7 +1456,9 @@ internal class DivineVideoPlayerInstance(
 
             val state = exoPlayer.playbackState
             val expected =
-                seekCompletionResult != null || state == Player.STATE_ENDED
+                seekCompletionResult != null ||
+                    state == Player.STATE_ENDED ||
+                    state == Player.STATE_IDLE
             val message =
                 "$logTarget stopped playing while still requested to play " +
                     "(state=${playbackStateName(state)}" +

--- a/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
+++ b/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
@@ -1222,6 +1222,27 @@ internal class DivineVideoPlayerInstance(
         sink.success(map)
     }
 
+    /** Human-readable name for a media3 `PLAY_WHEN_READY_CHANGE_REASON_*`. */
+    private fun playWhenReadyReasonName(reason: Int): String =
+        when (reason) {
+            Player.PLAY_WHEN_READY_CHANGE_REASON_USER_REQUEST -> "user_request"
+            Player.PLAY_WHEN_READY_CHANGE_REASON_AUDIO_FOCUS_LOSS -> "audio_focus_loss"
+            Player.PLAY_WHEN_READY_CHANGE_REASON_AUDIO_BECOMING_NOISY -> "audio_becoming_noisy"
+            Player.PLAY_WHEN_READY_CHANGE_REASON_REMOTE -> "remote"
+            Player.PLAY_WHEN_READY_CHANGE_REASON_END_OF_MEDIA_ITEM -> "end_of_media_item"
+            else -> "unknown($reason)"
+        }
+
+    /** Human-readable name for a media3 `Player.STATE_*`. */
+    private fun playbackStateName(state: Int?): String =
+        when (state) {
+            Player.STATE_IDLE -> "idle"
+            Player.STATE_BUFFERING -> "buffering"
+            Player.STATE_READY -> "ready"
+            Player.STATE_ENDED -> "ended"
+            else -> "unknown($state)"
+        }
+
     private fun errorCodeFor(error: PlaybackException): String =
         when (error.errorCode) {
             PlaybackException.ERROR_CODE_IO_BAD_HTTP_STATUS -> {
@@ -1384,11 +1405,39 @@ internal class DivineVideoPlayerInstance(
             sendStateUpdate()
         }
 
+        /**
+         * The decisive signal when a video stops with no user action: media3
+         * names *why* `playWhenReady` flipped, which separates our own
+         * `pause()` (`USER_REQUEST`) from the platform taking playback away
+         * (`AUDIO_FOCUS_LOSS`, `AUDIO_BECOMING_NOISY`, `REMOTE`).
+         */
+        override fun onPlayWhenReadyChanged(playWhenReady: Boolean, reason: Int) {
+            val message =
+                "Player $playerId playWhenReady=$playWhenReady " +
+                    "(${playWhenReadyReasonName(reason)})"
+            if (playWhenReady) {
+                DivineVideoPlayerLog.debug(message, name = "DivineVideoPlayer.Playback")
+            } else {
+                DivineVideoPlayerLog.info(message, name = "DivineVideoPlayer.Playback")
+            }
+        }
+
         override fun onIsPlayingChanged(isPlaying: Boolean) {
             if (isPlaying) {
                 syncAudioOverlays()
             } else {
                 audioOverlayManager.pauseAndDeactivateAll()
+                // Still asked to play, yet no longer playing: nobody paused
+                // this one, it stalled or ran out of media by itself. The
+                // buffering watchdog only fires after 8s, so a shorter stall
+                // would otherwise leave no trace at all.
+                if (player?.playWhenReady == true) {
+                    DivineVideoPlayerLog.info(
+                        "Player $playerId stopped playing while still requested to " +
+                            "play (state=${playbackStateName(player?.playbackState)})",
+                        name = "DivineVideoPlayer.Playback",
+                    )
+                }
             }
             sendStateUpdate()
         }

--- a/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerPlugin.kt
+++ b/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerPlugin.kt
@@ -140,17 +140,21 @@ class DivineVideoPlayerPlugin : FlutterPlugin, MethodChannel.MethodCallHandler, 
                 val bufferProfile = BufferProfile.fromWireValue(
                     call.argument<String>("bufferProfile"),
                 )
+                val debugLabel = call.argument<String>("debugLabel")
                 val instance = DivineVideoPlayerInstance(
                     binding.binaryMessenger,
                     binding.applicationContext,
                     id,
+                    debugLabel = debugLabel,
                     bufferProfile = bufferProfile,
                 )
                 PlayerRegistry.put(id, instance)
 
                 val useTexture = call.argument<Boolean>("useTexture") ?: false
+                val logTarget =
+                    if (debugLabel == null) "Player $id" else "Player $id ($debugLabel)"
                 DivineVideoPlayerLog.info(
-                    "Player $id created " +
+                    "$logTarget created " +
                         "(useTexture=$useTexture, bufferProfile=$bufferProfile)",
                     name = "DivineVideoPlayer.Lifecycle",
                 )

--- a/mobile/packages/divine_video_player/android/src/test/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstanceTest.kt
+++ b/mobile/packages/divine_video_player/android/src/test/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstanceTest.kt
@@ -469,6 +469,50 @@ class DivineVideoPlayerInstanceTest {
         verify(exactly = 0) { result.success(any()) }
     }
 
+    /**
+     * Installs a [DivineVideoPlayerLog] sink around [action] and returns the
+     * `(level, message)` of the unrequested-stop line it emitted, or null.
+     */
+    private fun captureUnrequestedStopLog(action: () -> Unit): Pair<String, String>? {
+        val entries = mutableListOf<Pair<String, String>>()
+        DivineVideoPlayerLog.sink = { level, message, _ -> entries.add(level to message) }
+        try {
+            action()
+        } finally {
+            DivineVideoPlayerLog.sink = null
+        }
+        return entries.lastOrNull {
+            it.second.contains("stopped playing while still requested to play")
+        }
+    }
+
+    @Test
+    fun `reportUnrequestedStop stays at debug for a requested stop (STATE_IDLE)`() {
+        val listener = capturePlayerListener()
+        every { mockPlayer.playWhenReady } returns true
+        every { mockPlayer.playbackState } returns Player.STATE_IDLE
+
+        val entry = captureUnrequestedStopLog { listener.onIsPlayingChanged(false) }
+
+        // A requested stop() (Dart, Activity detach, or a fatal error) lands
+        // in STATE_IDLE with playWhenReady still set — not the "stopped for no
+        // reason we asked for" the info line is reserved for.
+        assertEquals("debug", entry?.first)
+    }
+
+    @Test
+    fun `reportUnrequestedStop reports a genuine mid-play stall at info`() {
+        val listener = capturePlayerListener()
+        every { mockPlayer.playWhenReady } returns true
+        every { mockPlayer.playbackState } returns Player.STATE_BUFFERING
+
+        val entry = captureUnrequestedStopLog { listener.onIsPlayingChanged(false) }
+
+        // Buffering with no seek in flight is the anomaly the info line exists
+        // to surface — the STATE_IDLE guard must not silence this.
+        assertEquals("info", entry?.first)
+    }
+
     @Test
     fun `onPlayerError completes pending setClips result with error`() {
         val listener = capturePlayerListener()

--- a/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/DivineVideoPlayerInstance.swift
+++ b/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/DivineVideoPlayerInstance.swift
@@ -12,6 +12,11 @@ import FlutterMacOS
 final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
 
     private let playerId: Int
+    /// Identifies this player in diagnostic logs.
+    ///
+    /// Mirrors the Dart side's `_logTarget` so a `Player 665404 (feed[0])`
+    /// line reads the same whichever half of the channel emitted it.
+    private let logTarget: String
     private let methodChannel: FlutterMethodChannel
     private let eventChannel: FlutterEventChannel
 
@@ -128,8 +133,14 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
     /// Audio overlay manager for synchronized audio tracks.
     private let audioOverlayManager = AudioOverlayManager()
 
-    init(messenger: FlutterBinaryMessenger, playerId: Int) {
+    init(
+        messenger: FlutterBinaryMessenger,
+        playerId: Int,
+        debugLabel: String? = nil
+    ) {
         self.playerId = playerId
+        logTarget = debugLabel.map { "Player \(playerId) (\($0))" }
+            ?? "Player \(playerId)"
 
         methodChannel = FlutterMethodChannel(
             name: "divine_video_player/player_\(playerId)",
@@ -500,7 +511,7 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
         for clipMap in clipsRaw {
             guard let uri = clipMap["uri"] as? String else {
                 DivineVideoPlayerLog.shared.warning(
-                    "Player \(playerId) skipped a clip: missing uri",
+                    "\(logTarget) skipped a clip: missing uri",
                     name: "DivineVideoPlayer.Load"
                 )
                 continue
@@ -520,7 +531,7 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
                 url = parsed
             } else {
                 DivineVideoPlayerLog.shared.warning(
-                    "Player \(playerId) skipped a clip: unparseable uri",
+                    "\(logTarget) skipped a clip: unparseable uri",
                     name: "DivineVideoPlayer.Load"
                 )
                 continue
@@ -538,7 +549,7 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
 
             guard let sourceVideoTrack = assetVideoTracks.first else {
                 DivineVideoPlayerLog.shared.warning(
-                    "Player \(playerId) skipped a clip: no video track",
+                    "\(logTarget) skipped a clip: no video track",
                     name: "DivineVideoPlayer.Load"
                 )
                 continue
@@ -549,7 +560,7 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
             let displaySize = naturalSize.applying(transform).absoluteSize
             guard displaySize.isPositive else {
                 DivineVideoPlayerLog.shared.warning(
-                    "Player \(playerId) skipped a clip: non-positive display size",
+                    "\(logTarget) skipped a clip: non-positive display size",
                     name: "DivineVideoPlayer.Load"
                 )
                 continue
@@ -579,7 +590,7 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
                     }
                 } catch {
                     DivineVideoPlayerLog.shared.warning(
-                        "Player \(playerId) could not read track durations: "
+                        "\(logTarget) could not read track durations: "
                             + "\(error.localizedDescription)",
                         name: "DivineVideoPlayer.Load"
                     )
@@ -589,7 +600,7 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
             let clipDuration = CMTimeSubtract(endTime, startTime)
             guard CMTimeCompare(clipDuration, .zero) > 0 else {
                 DivineVideoPlayerLog.shared.warning(
-                    "Player \(playerId) skipped a clip: non-positive duration",
+                    "\(logTarget) skipped a clip: non-positive duration",
                     name: "DivineVideoPlayer.Load"
                 )
                 continue
@@ -884,7 +895,7 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
         }
         audioOverlayManager.setTracks(from: tracksRaw)
         DivineVideoPlayerLog.shared.info(
-            "Player \(playerId) set \(tracksRaw.count) audio overlay track(s)",
+            "\(logTarget) set \(tracksRaw.count) audio overlay track(s)",
             name: "DivineVideoPlayer.Audio"
         )
         syncAudioOverlays()

--- a/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/DivineVideoPlayerPlugin.swift
+++ b/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/DivineVideoPlayerPlugin.swift
@@ -174,9 +174,11 @@ public class DivineVideoPlayerPlugin: NSObject, FlutterPlugin {
             PlayerRegistry.shared.remove(id)?.dispose()
 
             let messenger = Self.messenger(for: registrar)
+            let debugLabel = args["debugLabel"] as? String
             let instance = DivineVideoPlayerInstance(
                 messenger: messenger,
-                playerId: id
+                playerId: id,
+                debugLabel: debugLabel
             )
             // Record the owning engine by its binary messenger. The plugin
             // instance whose global channel received this `create` is the
@@ -186,8 +188,10 @@ public class DivineVideoPlayerPlugin: NSObject, FlutterPlugin {
             PlayerRegistry.shared.set(instance, for: id, engine: messenger)
 
             let useTexture = args["useTexture"] as? Bool ?? false
+            let logTarget = debugLabel.map { "Player \(id) (\($0))" }
+                ?? "Player \(id)"
             DivineVideoPlayerLog.shared.info(
-                "Player \(id) created (useTexture=\(useTexture))",
+                "\(logTarget) created (useTexture=\(useTexture))",
                 name: "DivineVideoPlayer.Lifecycle"
             )
             if useTexture {

--- a/mobile/packages/divine_video_player/lib/src/divine_video_player_controller.dart
+++ b/mobile/packages/divine_video_player/lib/src/divine_video_player_controller.dart
@@ -15,6 +15,12 @@ import 'package:unified_logger/unified_logger.dart';
 /// Default maximum cache size on disk (500 MB).
 const int kDefaultCacheMaxSizeBytes = 500 * 1024 * 1024;
 
+/// Logger name for the Dart half of the player.
+///
+/// Native diagnostics arrive under their own `DivineVideoPlayer.*` names, so
+/// this one marks the lines that come from a Dart-side call.
+const _logName = 'DivineVideoPlayerController';
+
 /// Controls a native multi-clip video player that treats multiple clips
 /// as a single continuous timeline.
 ///
@@ -61,11 +67,17 @@ class DivineVideoPlayerController {
   /// part of another player's picture rather than a video of its own, such as
   /// the chroma-key backdrop composited behind a keyed clip. See
   /// [_pauseOtherLiveControllers].
+  ///
+  /// [debugLabel] names the surface that owns this player in diagnostic logs.
+  /// Player IDs are wall-clock seeded and identical on both sides of the
+  /// channel, so a `Player 665404` line in a bug report is only traceable
+  /// back to a screen if that screen labelled itself here.
   DivineVideoPlayerController({
     this.useTexture = false,
     this.useLegacySurface = false,
     this.bufferProfile = VideoBufferProfile.full,
     this.exclusivePlayback = true,
+    this.debugLabel,
   }) {
     _ensureNativeLogHandler();
   }
@@ -135,6 +147,11 @@ class DivineVideoPlayerController {
   /// Whether this player takes part in the one-video-at-a-time rule.
   /// See the constructor docs and [_pauseOtherLiveControllers].
   final bool exclusivePlayback;
+
+  /// Names the surface that owns this player in diagnostic logs.
+  ///
+  /// See the constructor docs. `null` when the owner did not label itself.
+  final String? debugLabel;
 
   static const _globalChannel = MethodChannel('divine_video_player');
 
@@ -457,6 +474,11 @@ class DivineVideoPlayerController {
   /// Starts or resumes playback.
   Future<void> play() async {
     _ensureInitialized();
+    Log.debug(
+      '$_logTarget: play() requested',
+      name: _logName,
+      category: LogCategory.video,
+    );
     if (exclusivePlayback) await _pauseOtherLiveControllers();
     if (_isWebBackend) return _webBackend!.play();
     if (_isLinuxBackend) return _linuxBackend!.play();
@@ -466,6 +488,11 @@ class DivineVideoPlayerController {
   /// Pauses playback.
   Future<void> pause() async {
     _ensureInitialized();
+    Log.debug(
+      '$_logTarget: pause() requested',
+      name: _logName,
+      category: LogCategory.video,
+    );
     if (_isWebBackend) return _webBackend!.pause();
     if (_isLinuxBackend) return _linuxBackend!.pause();
     await _methodChannel.invokeMethod<void>('pause');
@@ -478,6 +505,11 @@ class DivineVideoPlayerController {
   /// be reused by calling [setSource] or [setClips] again.
   Future<void> stop() async {
     _ensureInitialized();
+    Log.debug(
+      '$_logTarget: stop() requested',
+      name: _logName,
+      category: LogCategory.video,
+    );
     if (_isWebBackend) return _webBackend!.stop();
     if (_isLinuxBackend) return _linuxBackend!.stop();
     await _methodChannel.invokeMethod<void>('stop');
@@ -616,6 +648,18 @@ class DivineVideoPlayerController {
               !controller._disposed,
         )
         .toList(growable: false);
+    if (otherControllers.isEmpty) return;
+
+    // The only record that a player was stopped by *someone else* rather than
+    // by its own screen. Without it a pause from this rule is indistinguishable
+    // from the user pressing pause.
+    Log.info(
+      '$_logTarget: exclusive playback pausing ${otherControllers.length} '
+      'sibling player(s): '
+      '${otherControllers.map((c) => c._logTarget).join(', ')}',
+      name: _logName,
+      category: LogCategory.video,
+    );
 
     await Future.wait<void>(
       otherControllers.map((controller) async {
@@ -624,13 +668,20 @@ class DivineVideoPlayerController {
         } on Object catch (error) {
           Log.warning(
             'Failed to pause sibling player before starting playback: $error',
-            name: 'DivineVideoPlayerController',
+            name: _logName,
             category: LogCategory.video,
           );
         }
       }),
     );
   }
+
+  /// Identifies this player in diagnostic logs.
+  ///
+  /// Reads [_playerId], so it is only safe after [initialize] has run.
+  String get _logTarget => debugLabel == null
+      ? 'Player $_playerId'
+      : 'Player $_playerId ($debugLabel)';
 
   void _ensureInitialized() {
     if (!_initialized) {

--- a/mobile/packages/divine_video_player/lib/src/divine_video_player_controller.dart
+++ b/mobile/packages/divine_video_player/lib/src/divine_video_player_controller.dart
@@ -71,7 +71,8 @@ class DivineVideoPlayerController {
   /// [debugLabel] names the surface that owns this player in diagnostic logs.
   /// Player IDs are wall-clock seeded and identical on both sides of the
   /// channel, so a `Player 665404` line in a bug report is only traceable
-  /// back to a screen if that screen labelled itself here.
+  /// back to a screen if that screen labelled itself here. The label is
+  /// forwarded to the native player, so its lines carry it too.
   DivineVideoPlayerController({
     this.useTexture = false,
     this.useLegacySurface = false,
@@ -150,7 +151,8 @@ class DivineVideoPlayerController {
 
   /// Names the surface that owns this player in diagnostic logs.
   ///
-  /// See the constructor docs. `null` when the owner did not label itself.
+  /// See the constructor docs. `null` when the owner did not label itself,
+  /// which leaves both halves logging a bare `Player <id>`.
   final String? debugLabel;
 
   static const _globalChannel = MethodChannel('divine_video_player');
@@ -409,6 +411,7 @@ class DivineVideoPlayerController {
           'useTexture': useTexture,
           'useLegacySurface': useLegacySurface,
           'bufferProfile': bufferProfile.wireValue,
+          'debugLabel': debugLabel,
         },
       );
       if (useTexture && result != null) {
@@ -667,7 +670,8 @@ class DivineVideoPlayerController {
           await controller.pause();
         } on Object catch (error) {
           Log.warning(
-            'Failed to pause sibling player before starting playback: $error',
+            '$_logTarget: failed to pause sibling player '
+            '${controller._logTarget} before starting playback: $error',
             name: _logName,
             category: LogCategory.video,
           );

--- a/mobile/packages/divine_video_player/test/src/divine_video_player_controller_test.dart
+++ b/mobile/packages/divine_video_player/test/src/divine_video_player_controller_test.dart
@@ -52,6 +52,14 @@ void main() {
     return matches.isEmpty ? null : matches.last;
   }
 
+  /// The most recent log line emitted when pausing a sibling threw.
+  LogEntry? latestSiblingPauseFailureLog() {
+    final matches = LogCaptureService().getRecentLogs().where(
+      (entry) => entry.message.contains('failed to pause sibling player'),
+    );
+    return matches.isEmpty ? null : matches.last;
+  }
+
   /// Registers platform channel mocks and initializes the controller.
   ///
   /// The event channel mock is set up inside the 'create' handler so that
@@ -197,6 +205,19 @@ void main() {
         expect(
           globalCalls.first.arguments,
           containsPair('id', isA<int>()),
+        );
+      });
+
+      test('passes debugLabel through create', () async {
+        controller = DivineVideoPlayerController(debugLabel: 'cover');
+
+        await initController();
+
+        // The native half builds its own log prefix from this, so its lines
+        // name the same screen the Dart lines do.
+        expect(
+          globalCalls.first.arguments,
+          containsPair('debugLabel', 'cover'),
         );
       });
 
@@ -381,6 +402,33 @@ void main() {
         expect(playerCalls, hasLength(2));
         expect(playerCalls.first.method, equals('pause'));
         expect(playerCalls.last.method, equals('play'));
+      });
+
+      test('names both players when pausing a sibling fails', () async {
+        final other = DivineVideoPlayerController(debugLabel: 'editor');
+        addTearDown(other.dispose);
+        await other.initialize();
+
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(
+              MethodChannel(
+                'divine_video_player/player_${controller.playerId}',
+              ),
+              (call) async {
+                if (call.method == 'pause') {
+                  throw PlatformException(code: 'pause_failed');
+                }
+                return null;
+              },
+            );
+
+        await other.play();
+
+        final entry = latestSiblingPauseFailureLog();
+        expect(entry, isNotNull);
+        // Both halves matter: who tried to pause, and which player refused.
+        expect(entry!.message, contains('Player ${other.playerId} (editor)'));
+        expect(entry.message, contains('Player ${controller.playerId}'));
       });
 
       test('play leaves others alone when not exclusive', () async {

--- a/mobile/packages/divine_video_player/test/src/divine_video_player_controller_test.dart
+++ b/mobile/packages/divine_video_player/test/src/divine_video_player_controller_test.dart
@@ -7,6 +7,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:unified_logger/unified_logger.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -42,6 +43,14 @@ void main() {
         createDefaultWebVideoPlayerBackend;
     await eventController.close();
   });
+
+  /// The most recent log line emitted by the exclusive-playback rule.
+  LogEntry? latestExclusivePauseLog() {
+    final matches = LogCaptureService().getRecentLogs().where(
+      (entry) => entry.message.contains('exclusive playback pausing'),
+    );
+    return matches.isEmpty ? null : matches.last;
+  }
 
   /// Registers platform channel mocks and initializes the controller.
   ///
@@ -396,6 +405,36 @@ void main() {
         await controller.play();
 
         expect(playerCalls.map((call) => call.method), equals(['play']));
+      });
+
+      test('play names the siblings the exclusive rule paused', () async {
+        final editor = DivineVideoPlayerController(debugLabel: 'cover');
+        addTearDown(editor.dispose);
+        await editor.initialize();
+
+        await editor.play();
+
+        final entry = latestExclusivePauseLog();
+        expect(entry, isNotNull);
+        // The victim is identified so a stopped player in a bug report can be
+        // traced back to the screen that stopped it.
+        expect(entry!.message, contains('Player ${controller.playerId}'));
+        expect(
+          entry.message,
+          contains('Player ${editor.playerId} (cover)'),
+        );
+      });
+
+      test('play logs no sibling pause when it is the only player', () async {
+        await controller.dispose();
+        final solo = DivineVideoPlayerController(debugLabel: 'solo');
+        addTearDown(solo.dispose);
+        await solo.initialize();
+        await LogCaptureService().clearAllLogs();
+
+        await solo.play();
+
+        expect(latestExclusivePauseLog(), isNull);
       });
 
       test('pause invokes native method', () async {

--- a/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
@@ -1105,6 +1105,7 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
       // read-ahead buffer so short-form playback doesn't OOM on low-RAM
       // Android devices (#3419).
       bufferProfile: VideoBufferProfile.feed,
+      debugLabel: 'feed[$index]',
     );
     _controllers[index] = controller;
 


### PR DESCRIPTION
Closes #7864

## Description

A user reported the video player stopping mid-playback inside the video editor. The exported logs could not answer why, and that is the actual problem this PR fixes: the player logs `created` / `prepared 1 clip(s)` / `disposed` and nothing else. `play`, `pause` and every playback-state transition are invisible, so an 8-second editor session shows up as complete silence between `prepared` and the thumbnail extraction on save.

The absence was informative in one direction — the watchdogs that *do* log (`DivineVideoPlayer.Freeze` after an 8s buffering stall, `DivineVideoPlayer.Playback` on any `PlaybackException`) all stayed silent, which rules out a decoder error, a load timeout and a long stall. But it leaves no positive signal about what did happen.

Three gaps, closed:

**1. `playWhenReady` transitions, with media3's own reason** (`DivineVideoPlayerInstance.kt`). This is the decisive one: media3 already knows *why* the flag flipped, and reporting it separates our own `pause()` (`user_request`) from the platform taking playback away (`audio_focus_loss`, `audio_becoming_noisy`, `remote`) and from the clip simply ending (`end_of_media_item`). Logged at info when it goes false, debug when it goes true — a stop is the interesting direction.

**2. A stall nobody asked for.** `isPlaying` going false while `playWhenReady` is still true means the player stopped on its own rather than being paused. The existing buffering watchdog only fires after 8s, so anything shorter left no trace whatsoever.

**3. The silent sibling pause.** `_pauseOtherLiveControllers()` enforces the app-wide "one video at a time" rule by pausing *every* other live controller on any `play()`, and it logged nothing on the success path — only on failure. A player stopped this way was indistinguishable in the logs from the user pressing pause, and it is a plausible mechanism here: the editor is pushed on top of a feed whose three players stay alive underneath. It now emits one line naming the initiator and every player it paused.

`debugLabel` is what makes those lines readable. Player IDs are wall-clock seeded (`665404`), identical on both sides of the channel, and otherwise untraceable back to a screen — so every one of the 11 creation sites now labels itself, and the feed labels per index (`feed[3]`).

The route naming is the same problem one layer up: all nine `PageRouteBuilder` pushes in the editor and metadata flows omitted `RouteSettings`, so `PageLoadObserver` recorded the entire cover-screen session as `unknown_route` and measured its duration against the wrong pop.

Sample of what a future export will show:

```
Player 665404 (editor_canvas): play() requested
Player 665404 (editor_canvas): exclusive playback pausing 1 sibling player(s): Player 665396 (feed[0])
Player 665396 (feed[0]) playWhenReady=false (user_request)
Player 665404 (editor_canvas) playWhenReady=false (audio_focus_loss)
```

**Related Issue:** 

## Out of Scope

- **iOS/macOS parity for the two native logs.** AVPlayer has no `playWhenReady`-with-reason; the equivalent would be KVO on `timeControlStatus` + `reasonForWaitingToPlay`, which the Swift side does not observe at all today. The reproduction is on Android, so this was not built speculatively. Everything else works on every platform: point 3 and the route names are pure Dart, and `debugLabel` is forwarded across the channel so Android and Apple both prefix their existing log lines with it.
- **A leaked native player.** In the report's logs, player `665396` is created in the home feed and never disposed — `vc_native=1` in every `MemoryTelemetry` sample for the following 2m45s confirms it outlives the screen. That is a real bug rather than a logging gap and belongs in its own PR.
- **No behaviour change.** The one non-log edit is an early `return` when `_pauseOtherLiveControllers()` finds no siblings, which skips a `Future.wait` over an empty list.

## Review Follow-up

A review pass over the first two commits found three things worth correcting, fixed in `bc2e15c`:

- The exclusive-playback rule named every sibling it paused on the success path but not on the failure path, which is the one worth reading. It now names both the initiator and the sibling that refused.
- The unrequested-stop line fired on two routine transitions — a seek drives the player through `STATE_BUFFERING` on its way to the new position, and a non-looping clip reaching its end lands in `STATE_ENDED`. Every scrub of the editor timeline therefore logged a "stall" at info. Both now log at debug, so the info line keeps meaning "stopped for no reason we asked for".
- `debugLabel` never crossed the channel, so native lines read `Player 665404` while Dart lines read `Player 665404 (editor_canvas)`. It now travels with `create`, and both native halves build the same prefix — applied to every existing native log line rather than only the new ones, since being traceable back to a screen is the whole point.

The two routes that share the name `video_metadata_cover` were deliberately left alone: `PageLoadObserver` pairs `startScreenLoad` / `endScreen` by name, so the same screen should resolve to one surface.

## Verification

- `flutter analyze lib test integration_test` — no issues
- `mobile/packages/divine_video_player`: 289 tests pass; coverage on the touched controller is 244/244 lines (package total unchanged at 99.50%, the four uncovered lines are pre-existing in `audio_track.dart` / `video_clip.dart`)
- `gradlew :divine_video_player:testDebugUnitTest` — BUILD SUCCESSFUL (the Kotlin change compiles and the existing instance tests still pass)
- 124 tests across the 11 mirrored app test files for the touched screens and widgets
- Four new controller tests, all mutation-checked: deleting the `Log.info` reddens the sibling-naming test, deleting the empty-siblings early return reddens the solo-player test, dropping the sibling name from the failure warning reddens the third, and removing `debugLabel` from the `create` arguments reddens the fourth
- Confirmed `Log.debug` still reaches the bug-report buffer at the production log level (`warning`): `UnifiedLogger._log` captures to memory unconditionally, level filtering only gates console output


## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
