### PR TITLE
fix(auth): keep email verification usable with the keyboard up

### DIFF
--- a/mobile/lib/screens/auth/email_verification_screen.dart
+++ b/mobile/lib/screens/auth/email_verification_screen.dart
@@ -1015,14 +1015,18 @@ class _ResendRow extends StatelessWidget {
               button: true,
               enabled: !disabled,
               label: label,
-              child: ExcludeSemantics(
-                child: GestureDetector(
-                  behavior: HitTestBehavior.opaque,
-                  onTap: disabled
-                      ? null
-                      : () => context
-                            .read<EmailVerificationCubit>()
-                            .resendVerification(),
+              // `ExcludeSemantics` sits inside the detector, not around it:
+              // wrapping the detector drops its own `SemanticsAction.tap`
+              // along with the subtree, leaving a node that announces a
+              // button VoiceOver cannot activate.
+              child: GestureDetector(
+                behavior: HitTestBehavior.opaque,
+                onTap: disabled
+                    ? null
+                    : () => context
+                          .read<EmailVerificationCubit>()
+                          .resendVerification(),
+                child: ExcludeSemantics(
                   child: ConstrainedBox(
                     constraints: const BoxConstraints(
                       minWidth: 48,

--- a/mobile/lib/screens/auth/email_verification_screen.dart
+++ b/mobile/lib/screens/auth/email_verification_screen.dart
@@ -80,6 +80,10 @@ class EmailVerificationScreen extends ConsumerStatefulWidget {
 
 class _EmailVerificationScreenState
     extends ConsumerState<EmailVerificationScreen> {
+  /// Clears the floating close button: its 16px offset plus the 48px box a
+  /// [DivineIconButton] occupies at either size.
+  static const double _contentTopPadding = 64;
+
   bool _isTokenMode = false;
   StreamSubscription<AuthState>? _authSubscription;
   late final EmailVerificationCubit _cubit;
@@ -531,111 +535,100 @@ class _EmailVerificationScreenState
                   state.status != EmailVerificationStatus.success;
               final startsOver =
                   state.status == EmailVerificationStatus.failure;
-              return Column(
+              return Stack(
                 children: [
-                  // Close button (hidden on success)
-                  if (showCloseButton)
-                    Padding(
-                      padding: const EdgeInsets.all(16),
-                      child: Align(
-                        alignment: AlignmentDirectional.centerStart,
-                        child: _CloseButton(
-                          onPressed: startsOver
-                              ? _handleStartOver
-                              : _handleCancel,
-                          label: startsOver
-                              ? context.l10n.authStartOver
-                              : context.l10n.commonClose,
-                        ),
-                      ),
-                    )
-                  else
-                    const SizedBox(height: 76),
-
-                  // Main content
-                  Expanded(
-                    child: Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 24),
-                      child: switch (state.status) {
-                        EmailVerificationStatus.initial => _PollingContent(
-                          email: null,
-                          isPollingMode: widget.isPollingMode || !_isTokenMode,
-                        ),
-                        EmailVerificationStatus.polling => _PollingContent(
-                          email: state.pendingEmail,
-                          isPollingMode: widget.isPollingMode || !_isTokenMode,
-                        ),
-                        EmailVerificationStatus.pollingTimedOut =>
-                          _PollingContent(
-                            email: state.pendingEmail,
-                            isPollingMode:
-                                widget.isPollingMode || !_isTokenMode,
-                            isActivelyPolling: false,
+                  // Main content. The keyboard is not resized away
+                  // (`resizeToAvoidBottomInset: false`), so shrink the scroll
+                  // viewport by the inset instead: PIN entry and its submit
+                  // button stay reachable while the keyboard is up.
+                  Padding(
+                    padding: EdgeInsets.only(
+                      bottom: MediaQuery.viewInsetsOf(context).bottom,
+                    ),
+                    child: CustomScrollView(
+                      slivers: [
+                        // Fills the viewport so the content's `Spacer`s can
+                        // center it, and scrolls once it no longer fits.
+                        SliverFillRemaining(
+                          hasScrollBody: false,
+                          child: Padding(
+                            padding: const EdgeInsets.fromLTRB(
+                              24,
+                              _contentTopPadding,
+                              24,
+                              32,
+                            ),
+                            child: switch (state.status) {
+                              EmailVerificationStatus.initial =>
+                                _PollingContent(
+                                  email: null,
+                                  isPollingMode:
+                                      widget.isPollingMode || !_isTokenMode,
+                                ),
+                              EmailVerificationStatus.polling =>
+                                _PollingContent(
+                                  email: state.pendingEmail,
+                                  isPollingMode:
+                                      widget.isPollingMode || !_isTokenMode,
+                                ),
+                              EmailVerificationStatus.pollingTimedOut =>
+                                _PollingContent(
+                                  email: state.pendingEmail,
+                                  isPollingMode:
+                                      widget.isPollingMode || !_isTokenMode,
+                                  isActivelyPolling: false,
+                                ),
+                              EmailVerificationStatus.success =>
+                                const _SuccessContent(),
+                              EmailVerificationStatus.failure => _ErrorContent(
+                                errorCode: state.errorCode,
+                                onStartOver: _handleStartOver,
+                                onSignInInstead:
+                                    state.errorCode ==
+                                        EmailVerificationError
+                                            .emailAlreadyRegistered
+                                    ? () => _handleSignInRecovery(
+                                        state.pendingEmail,
+                                        state.errorCode!,
+                                      )
+                                    : null,
+                                onReturnToInviteGate:
+                                    state.showInviteGateRecovery &&
+                                        state.inviteRecoveryCode != null
+                                    ? () => _handleInviteRecovery(
+                                        state.inviteRecoveryCode!,
+                                        state.errorCode,
+                                      )
+                                    : null,
+                              ),
+                            },
                           ),
-                        EmailVerificationStatus.success =>
-                          const _SuccessContent(),
-                        EmailVerificationStatus.failure => _ErrorContent(
-                          errorCode: state.errorCode,
-                          onStartOver: _handleStartOver,
-                          onSignInInstead:
-                              state.errorCode ==
-                                  EmailVerificationError.emailAlreadyRegistered
-                              ? () => _handleSignInRecovery(
-                                  state.pendingEmail,
-                                  state.errorCode!,
-                                )
-                              : null,
-                          onReturnToInviteGate:
-                              state.showInviteGateRecovery &&
-                                  state.inviteRecoveryCode != null
-                              ? () => _handleInviteRecovery(
-                                  state.inviteRecoveryCode!,
-                                  state.errorCode,
-                                )
-                              : null,
                         ),
-                      },
+                      ],
                     ),
                   ),
+
+                  // Close affordance (hidden on success), floating above the
+                  // scrolling content so it never shifts with it.
+                  if (showCloseButton)
+                    PositionedDirectional(
+                      top: 16,
+                      start: 16,
+                      child: DivineIconButton(
+                        type: .secondary,
+                        onPressed: startsOver
+                            ? _handleStartOver
+                            : _handleCancel,
+                        size: .small,
+                        icon: .x,
+                        semanticLabel: startsOver
+                            ? context.l10n.authStartOver
+                            : context.l10n.commonClose,
+                      ),
+                    ),
                 ],
               );
             },
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-/// Close button (X) for the verification screen.
-class _CloseButton extends StatelessWidget {
-  const _CloseButton({required this.onPressed, required this.label});
-
-  final VoidCallback onPressed;
-
-  /// Names the action, which differs by state: this is the only exit from the
-  /// polling screen, and the expired-resend copy tells the user to start again
-  /// without an icon-only X being able to say so.
-  final String label;
-
-  @override
-  Widget build(BuildContext context) {
-    return Semantics(
-      button: true,
-      label: label,
-      child: GestureDetector(
-        onTap: onPressed,
-        child: Container(
-          width: 36,
-          height: 36,
-          decoration: BoxDecoration(
-            color: context.vineColors.surfaceContainer,
-            shape: BoxShape.circle,
-          ),
-          child: DivineIcon(
-            icon: DivineIconName.x,
-            color: context.vineColors.onIconButton,
-            size: 20,
           ),
         ),
       ),
@@ -766,126 +759,113 @@ class _PollingContent extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // Scroll-safe so the added PIN entry never overflows on short screens,
-    // while still vertically centering the content on tall ones.
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        return SingleChildScrollView(
-          child: ConstrainedBox(
-            constraints: BoxConstraints(minHeight: constraints.maxHeight),
-            child: IntrinsicHeight(
-              child: Column(
-                children: [
-                  const Spacer(),
+    return Column(
+      children: [
+        const Spacer(),
 
-                  // Email sticker
-                  Transform.rotate(
-                    angle: -8 * pi / 180,
-                    child: const DivineSticker(
-                      sticker: DivineStickerName.email,
-                      size: 120,
-                    ),
-                  ),
-                  const SizedBox(height: 32),
-
-                  // Title
-                  Text(
-                    isPollingMode
-                        ? context.l10n.authCompleteRegistration
-                        : context.l10n.authVerifying,
-                    style: TextStyle(
-                      fontFamily: VineTheme.fontFamilyBricolage,
-                      fontSize: 28,
-                      fontWeight: FontWeight.w700,
-                      color: context.vineColors.primaryText,
-                    ),
-                    textAlign: TextAlign.center,
-                  ),
-                  const SizedBox(height: 16),
-
-                  if (isPollingMode && email != null && email!.isNotEmpty) ...[
-                    Text(
-                      context.l10n.authVerificationLinkSent,
-                      style: TextStyle(
-                        fontSize: 16,
-                        color: context.vineColors.secondaryText,
-                        height: 1.4,
-                      ),
-                      textAlign: TextAlign.center,
-                    ),
-                    const SizedBox(height: 4),
-                    Text(
-                      email!,
-                      style: TextStyle(
-                        fontSize: 16,
-                        fontWeight: FontWeight.w700,
-                        color: context.vineColors.primaryText,
-                      ),
-                      textAlign: TextAlign.center,
-                    ),
-                    const SizedBox(height: 8),
-                    Text(
-                      context.l10n.authClickVerificationLink,
-                      style: TextStyle(
-                        fontSize: 14,
-                        color: context.vineColors.secondaryText,
-                        height: 1.4,
-                      ),
-                      textAlign: TextAlign.center,
-                    ),
-                  ] else ...[
-                    Text(
-                      context.l10n.authPleaseWaitVerifying,
-                      style: TextStyle(
-                        fontSize: 16,
-                        color: context.vineColors.secondaryText,
-                        height: 1.4,
-                      ),
-                      textAlign: TextAlign.center,
-                    ),
-                  ],
-
-                  const Spacer(),
-
-                  // Status + action buttons at bottom
-                  Padding(
-                    padding: const EdgeInsets.only(top: 32, bottom: 32),
-                    child: Column(
-                      children: [
-                        if (isPollingMode) ...[
-                          const _PinEntrySection(),
-                          const SizedBox(height: 20),
-                        ],
-                        if (isActivelyPolling)
-                          _StatusButton(
-                            label: context.l10n.authWaitingForVerification,
-                          )
-                        else
-                          Text(
-                            context.l10n.authVerificationPollingStopped,
-                            style: VineTheme.bodySmallFont(
-                              color: context.vineColors.secondaryText,
-                            ),
-                            textAlign: TextAlign.center,
-                          ),
-                        if (isPollingMode) ...[
-                          const SizedBox(height: 20),
-                          DivineButton(
-                            expanded: true,
-                            type: DivineButtonType.secondary,
-                            label: context.l10n.authOpenEmailApp,
-                            onPressed: _openEmailApp,
-                          ),
-                        ],
-                      ],
-                    ),
-                  ),
-                ],
-              ),
-            ),
+        // Email sticker
+        Transform.rotate(
+          angle: -8 * pi / 180,
+          child: const DivineSticker(
+            sticker: DivineStickerName.email,
+            size: 120,
           ),
-        );
-      },
+        ),
+        const SizedBox(height: 32),
+
+        // Title
+        Text(
+          isPollingMode
+              ? context.l10n.authCompleteRegistration
+              : context.l10n.authVerifying,
+          style: TextStyle(
+            fontFamily: VineTheme.fontFamilyBricolage,
+            fontSize: 28,
+            fontWeight: FontWeight.w700,
+            color: context.vineColors.primaryText,
+          ),
+          textAlign: TextAlign.center,
+        ),
+        const SizedBox(height: 16),
+
+        if (isPollingMode && email != null && email!.isNotEmpty) ...[
+          Text(
+            context.l10n.authVerificationLinkSent,
+            style: TextStyle(
+              fontSize: 16,
+              color: context.vineColors.secondaryText,
+              height: 1.4,
+            ),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 4),
+          Text(
+            email!,
+            style: TextStyle(
+              fontSize: 16,
+              fontWeight: FontWeight.w700,
+              color: context.vineColors.primaryText,
+            ),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 8),
+          Text(
+            context.l10n.authClickVerificationLink,
+            style: TextStyle(
+              fontSize: 14,
+              color: context.vineColors.secondaryText,
+              height: 1.4,
+            ),
+            textAlign: TextAlign.center,
+          ),
+        ] else ...[
+          Text(
+            context.l10n.authPleaseWaitVerifying,
+            style: TextStyle(
+              fontSize: 16,
+              color: context.vineColors.secondaryText,
+              height: 1.4,
+            ),
+            textAlign: TextAlign.center,
+          ),
+        ],
+
+        const Spacer(),
+
+        // Status + action buttons at bottom
+        Padding(
+          padding: const EdgeInsets.only(top: 32),
+          child: Column(
+            children: [
+              if (isPollingMode) ...[
+                const _PinEntrySection(),
+                const SizedBox(height: 20),
+              ],
+              if (isActivelyPolling)
+                _StatusButton(
+                  label: context.l10n.authWaitingForVerification,
+                )
+              else
+                Text(
+                  context.l10n.authVerificationPollingStopped,
+                  style: VineTheme.bodySmallFont(
+                    color: context.vineColors.secondaryText,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+              if (isPollingMode) ...[
+                const SizedBox(height: 20),
+                DivineButton(
+                  expanded: true,
+                  type: DivineButtonType.secondary,
+                  label: context.l10n.authOpenEmailApp,
+                  onPressed: _openEmailApp,
+                ),
+              ],
+            ],
+          ),
+        ),
+      ],
     );
   }
 }
@@ -1127,10 +1107,7 @@ class _SuccessContent extends StatelessWidget {
         const Spacer(),
 
         // Signing you in status button
-        Padding(
-          padding: const EdgeInsets.only(bottom: 32),
-          child: _StatusButton(label: context.l10n.authSigningYouIn),
-        ),
+        _StatusButton(label: context.l10n.authSigningYouIn),
       ],
     );
   }
@@ -1188,17 +1165,14 @@ class _ErrorContent extends StatelessWidget {
         const Spacer(),
 
         // Start over button
-        Padding(
-          padding: const EdgeInsets.only(bottom: 32),
-          child: DivineButton(
-            expanded: true,
-            label: onSignInInstead != null
-                ? l10n.authSignInButton
-                : onReturnToInviteGate == null
-                ? l10n.authStartOver
-                : l10n.authBackToInviteCode,
-            onPressed: onSignInInstead ?? onReturnToInviteGate ?? onStartOver,
-          ),
+        DivineButton(
+          expanded: true,
+          label: onSignInInstead != null
+              ? l10n.authSignInButton
+              : onReturnToInviteGate == null
+              ? l10n.authStartOver
+              : l10n.authBackToInviteCode,
+          onPressed: onSignInInstead ?? onReturnToInviteGate ?? onStartOver,
         ),
       ],
     );

--- a/mobile/lib/screens/auth/email_verification_screen.dart
+++ b/mobile/lib/screens/auth/email_verification_screen.dart
@@ -80,9 +80,15 @@ class EmailVerificationScreen extends ConsumerStatefulWidget {
 
 class _EmailVerificationScreenState
     extends ConsumerState<EmailVerificationScreen> {
-  /// Clears the floating close button: its 16px offset plus the 48px box a
-  /// [DivineIconButton] occupies at either size.
-  static const double _contentTopPadding = 64;
+  /// Offset of the floating close button from the top-start corner.
+  static const double _closeButtonInset = 16;
+
+  /// Clears the floating close button: its inset plus the box a small
+  /// [DivineIconButton] occupies. That box is `scaleSize(48)`, so it grows
+  /// with the icon text scale and a fixed 64 would let the button sit on the
+  /// content at large accessibility sizes.
+  double _contentTopPadding(BuildContext context) =>
+      _closeButtonInset + DivineIcon.scaleSize(context, 48);
 
   bool _isTokenMode = false;
   StreamSubscription<AuthState>? _authSubscription;
@@ -552,9 +558,9 @@ class _EmailVerificationScreenState
                         SliverFillRemaining(
                           hasScrollBody: false,
                           child: Padding(
-                            padding: const EdgeInsets.fromLTRB(
+                            padding: EdgeInsets.fromLTRB(
                               24,
-                              _contentTopPadding,
+                              _contentTopPadding(context),
                               24,
                               32,
                             ),
@@ -612,8 +618,8 @@ class _EmailVerificationScreenState
                   // scrolling content so it never shifts with it.
                   if (showCloseButton)
                     PositionedDirectional(
-                      top: 16,
-                      start: 16,
+                      top: _closeButtonInset,
+                      start: _closeButtonInset,
                       child: DivineIconButton(
                         type: .secondary,
                         onPressed: startsOver

--- a/mobile/test/screens/auth/email_verification_screen_test.dart
+++ b/mobile/test/screens/auth/email_verification_screen_test.dart
@@ -1675,6 +1675,39 @@ void main() {
       );
     });
 
+    // The floating close button clears the content by a padding derived from
+    // the button's own box, which follows the icon text scale. A fixed value
+    // lets the button sit on the content once the scale grows.
+    testWidgets('keeps the close button clear of the content at large text', (
+      tester,
+    ) async {
+      tester.view.devicePixelRatio = 1;
+      tester.view.physicalSize = const Size(360, 560);
+      addTearDown(tester.view.reset);
+
+      await tester.pumpWidget(
+        MediaQuery(
+          data: const MediaQueryData(textScaler: TextScaler.linear(1.6)),
+          child: createTestWidget(
+            deviceCode: 'test-device-code',
+            verifier: 'test-verifier',
+            email: 'user@example.com',
+            initialState: const EmailVerificationState(
+              status: EmailVerificationStatus.polling,
+              pendingEmail: 'user@example.com',
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(
+        tester.getRect(find.byType(DivineIconButton)).bottom,
+        lessThanOrEqualTo(tester.getRect(find.byType(DivineSticker)).top),
+        reason: 'the close button must not overlap the content it floats over',
+      );
+    });
+
     // Success and error are `Spacer`-centred columns. Before the screen owned
     // the scrolling they had no scroll view at all, so a short viewport at a
     // large text scale overflowed instead of scrolling.

--- a/mobile/test/screens/auth/email_verification_screen_test.dart
+++ b/mobile/test/screens/auth/email_verification_screen_test.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'package:bloc_test/bloc_test.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -1767,6 +1768,72 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text(l10n.authVerificationPollingStopped), findsOneWidget);
+    });
+  });
+
+  group('resend affordance', () {
+    // `Semantics(button: true)` wrapping `ExcludeSemantics(child:
+    // GestureDetector(onTap: ...))` drops the detector's own
+    // `SemanticsAction.tap` along with the subtree, so the node announces a
+    // button VoiceOver cannot activate. `tester.tap` does not catch it — a
+    // real touch still reaches the handler — so assert the action itself.
+    testWidgets('exposes a tap action to assistive tech', (tester) async {
+      final handle = tester.ensureSemantics();
+      final l10n = lookupAppLocalizations(const Locale('en'));
+
+      await pumpVerificationScreen(
+        tester,
+        deviceCode: 'device-code',
+        verifier: 'verifier',
+        email: 'someone@example.test',
+        initialState: const EmailVerificationState(
+          status: EmailVerificationStatus.polling,
+          pendingEmail: 'someone@example.test',
+        ),
+      );
+      await tester.pump();
+
+      final resend = tester.getSemantics(
+        find.bySemanticsLabel(l10n.authVerificationResend),
+      );
+      expect(
+        resend.getSemanticsData().hasAction(SemanticsAction.tap),
+        isTrue,
+        reason:
+            'the resend link announces itself as a button, so it has to carry '
+            'the tap action that activating it depends on',
+      );
+      handle.dispose();
+    });
+
+    // The cooldown state deliberately drops the action: the node stays
+    // labelled and flagged disabled rather than silently tappable.
+    testWidgets('drops the tap action while cooling down', (tester) async {
+      final handle = tester.ensureSemantics();
+      final l10n = lookupAppLocalizations(const Locale('en'));
+
+      await pumpVerificationScreen(
+        tester,
+        deviceCode: 'device-code',
+        verifier: 'verifier',
+        email: 'someone@example.test',
+        initialState: const EmailVerificationState(
+          status: EmailVerificationStatus.polling,
+          pendingEmail: 'someone@example.test',
+          resendStatus: ResendStatus.cooldown,
+          resendCooldownSeconds: 120,
+        ),
+      );
+      await tester.pump();
+
+      final resend = tester.getSemantics(
+        find.bySemanticsLabel(l10n.authVerificationResendCooldown('2:00')),
+      );
+      expect(
+        resend.getSemanticsData().hasAction(SemanticsAction.tap),
+        isFalse,
+      );
+      handle.dispose();
     });
   });
 }

--- a/mobile/test/screens/auth/email_verification_screen_test.dart
+++ b/mobile/test/screens/auth/email_verification_screen_test.dart
@@ -1588,8 +1588,8 @@ void main() {
         ),
         findsOneWidget,
         reason:
-            'the X is a bare GestureDetector; without a Semantics wrapper a '
-            'screen reader reaches an unlabeled tap target',
+            'an icon-only X carries no meaning on its own; without '
+            '`semanticLabel` a screen reader reaches an unnamed tap target',
       );
       handle.dispose();
     });
@@ -1622,6 +1622,86 @@ void main() {
         findsOneWidget,
       );
       handle.dispose();
+    });
+  });
+
+  group('keyboard reachability', () {
+    // The screen sets `resizeToAvoidBottomInset: false`, so the layout does
+    // not shrink when the keyboard opens. Unless the scroll view owns the
+    // inset itself, the PIN field's submit button sits under the keyboard
+    // with no gesture that can reach it.
+    testWidgets('scrolls the PIN submit button clear of the keyboard', (
+      tester,
+    ) async {
+      const viewport = Size(390, 760);
+      const keyboardExtent = 300.0;
+      final l10n = lookupAppLocalizations(const Locale('en'));
+
+      tester.view.devicePixelRatio = 1;
+      tester.view.physicalSize = viewport;
+      tester.view.viewInsets = const FakeViewPadding(bottom: keyboardExtent);
+      addTearDown(tester.view.reset);
+
+      await tester.pumpWidget(
+        createTestWidget(
+          deviceCode: 'test-device-code',
+          verifier: 'test-verifier',
+          email: 'user@example.com',
+          initialState: const EmailVerificationState(
+            status: EmailVerificationStatus.polling,
+            pendingEmail: 'user@example.com',
+          ),
+        ),
+      );
+      await tester.pump();
+
+      final submit = find.widgetWithText(
+        DivineButton,
+        l10n.authVerificationPinSubmit,
+      );
+      expect(submit, findsOneWidget);
+
+      await tester.dragUntilVisible(
+        submit,
+        find.byType(CustomScrollView),
+        const Offset(0, -80),
+      );
+      await tester.pump();
+
+      expect(
+        tester.getRect(submit).bottom,
+        lessThanOrEqualTo(viewport.height - keyboardExtent),
+        reason: 'the submit button must come to rest above the keyboard',
+      );
+    });
+
+    // Success and error are `Spacer`-centred columns. Before the screen owned
+    // the scrolling they had no scroll view at all, so a short viewport at a
+    // large text scale overflowed instead of scrolling.
+    testWidgets('scrolls the failure state instead of overflowing', (
+      tester,
+    ) async {
+      tester.view.devicePixelRatio = 1;
+      tester.view.physicalSize = const Size(320, 480);
+      addTearDown(tester.view.reset);
+
+      await tester.pumpWidget(
+        MediaQuery(
+          data: const MediaQueryData(textScaler: TextScaler.linear(1.6)),
+          child: createTestWidget(
+            deviceCode: 'test-device-code',
+            verifier: 'test-verifier',
+            initialState: const EmailVerificationState(
+              status: EmailVerificationStatus.failure,
+              errorCode: EmailVerificationError.pollFailed,
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(tester.takeException(), isNull);
+      expect(find.byType(CustomScrollView), findsOneWidget);
     });
   });
 


### PR DESCRIPTION
Closes #7866

## Summary

Someone finishing registration by typing the emailed PIN cannot submit it. The keyboard covers the PIN field, its submit button and the resend link, and the screen does not scroll — so nothing brings them back into view and the flow dead-ends unless the user goes back to their inbox and taps the link instead.

Two causes. The screen sets `resizeToAvoidBottomInset: false`, so the layout never shrinks when the keyboard opens. And the one scroll view it had lived inside the polling content, constrained to exactly the viewport height (`ConstrainedBox(minHeight: constraints.maxHeight)` + `IntrinsicHeight`), so its content could never exceed the viewport and it never had anything to scroll.

The success and error states had no scroll safety at all — both are `Column`s with `Spacer`s inside an `Expanded`. A 320×480 viewport at 1.6× text overflows them by 54 pixels today.

## What changed

- Scroll ownership moves up to the screen: a single `CustomScrollView` + `SliverFillRemaining(hasScrollBody: false)`, the same pattern `invite_gate_screen.dart` already uses. It still fills the viewport so the `Spacer`-based centering works on tall screens, and scrolls once the content outgrows it — for all three states, not just polling.
- The scroll viewport shrinks by `MediaQuery.viewInsetsOf(context).bottom`, so the focused PIN field scrolls into view above the keyboard instead of hiding underneath it.
- The close affordance floats over the content via `PositionedDirectional` instead of occupying a row in the column. That removes the `SizedBox(height: 76)` placeholder the success state needed, so the content no longer shifts when the button disappears.
- The hand-rolled `_CloseButton` is replaced by `DivineIconButton(type: .secondary, size: .small, icon: .x)`. **This changes how the button looks**: a 36px circle with a 20px pale-mint (`onIconButton`) icon becomes a 40px rounded square with a 2px `outlineMuted` border, a drop shadow, and a 24px brand-green (`accentBrand`) icon. The outer box grows from 36px to the 48px tap target the old one was missing. Contrast is fine in both appearances (7.6:1 in dark, higher in light).
- The content's top padding is derived from the button's own box (`DivineIcon.scaleSize(context, 48)`) rather than a fixed 64. The button's box follows the icon text scale, so a fixed value let it come to rest on the content at large accessibility text sizes.
- Page padding is owned by the screen now, so the per-state `EdgeInsets.only(bottom: 32)` wrappers are gone. Rendered spacing is unchanged.

## Why this shape

`Spacer` needs a bounded height, which is why the naive fix — wrapping the states in a `SingleChildScrollView` — fails outright with `RenderFlex children have non-zero flex but incoming height constraints are unbounded`. `SliverFillRemaining(hasScrollBody: false)` lays its child out at `max(remaining viewport extent, child intrinsic height)`, which is bounded and tight, so centering and scrolling both work without an `IntrinsicHeight` wrapper per state.

## What this deliberately does not change

The invite gate's back button is still the app-level `RoundedIconButton` — also a rounded square with a 2px border and shadow, but 48px with an `onIconButton` icon. So the two adjacent auth screens now use slightly different greens for the same kind of affordance. The outer footprint already matches at 48px; unifying the icon colour means retiring `RoundedIconButton` in favour of the design-system component everywhere, which is its own migration rather than something to smuggle into a scroll fix.

The close button stays put while the content scrolls under it. That is the point of floating it — it is the only exit from the polling screen, so it should be reachable at any scroll offset.

## Test plan

- Three new regression tests in `test/screens/auth/email_verification_screen_test.dart`, each verified red on `origin/main` and green here:
  - the PIN submit button scrolls clear of a 300px keyboard on a 390×760 viewport (before: it rests 9px underneath it);
  - the close button does not overlap the content at 1.6× text (before, against a fixed 64: overlapping by 5.5px);
  - the failure state scrolls instead of overflowing on 320×480 at 1.6× text (before: `A RenderFlex overflowed by 54 pixels on the bottom`).
- `flutter test test/screens/auth/email_verification_screen_test.dart` — 51/51 green.
- `flutter analyze lib test integration_test` — clean.
- Ratchets re-run locally: raw TextStyle, raw colors, Material button, raw dialog, layer direction, post-close emit, l10n delegates, test/unit structure, untested services — all pass.

