### PR TITLE
fix(account): send the bearer token first when deleting the Keycast account

### DIFF
--- a/mobile/lib/services/account_deletion_proof_signer.dart
+++ b/mobile/lib/services/account_deletion_proof_signer.dart
@@ -61,7 +61,19 @@ class AccountDeletionProofSigner {
         method: HttpMethod.delete,
       );
 
-      // The check that carries the weight: the one above only proves the
+      // Ordered before the account check so a signer that produced nothing is
+      // not reported as a proof being discarded.
+      if (token == null) {
+        Log.warning(
+          'Could not sign NIP-98 proof for account deletion; '
+          'the refused bearer attempt stands',
+          name: 'AccountDeletionProofSigner',
+          category: LogCategory.auth,
+        );
+        return null;
+      }
+
+      // The check that carries the weight: the entry check only proves the
       // accounts matched before a call that can take seconds.
       if (_activePubkey() != tokenOwnerPubkey) {
         Log.warning(
@@ -73,15 +85,8 @@ class AccountDeletionProofSigner {
         );
         return null;
       }
-      if (token == null) {
-        Log.warning(
-          'Could not sign NIP-98 proof for account deletion; '
-          'the refused bearer attempt stands',
-          name: 'AccountDeletionProofSigner',
-          category: LogCategory.auth,
-        );
-      }
-      return token?.token;
+
+      return token.token;
     } catch (e) {
       Log.warning(
         'NIP-98 proof signing threw for account deletion: $e',

--- a/mobile/lib/services/account_deletion_proof_signer.dart
+++ b/mobile/lib/services/account_deletion_proof_signer.dart
@@ -1,0 +1,99 @@
+// ABOUTME: Signs the NIP-98 proof-of-key for the Keycast account-deletion retry
+// ABOUTME: Pins the proof to the account whose bearer token is being spent
+
+import 'package:openvine/services/nip98_auth_service.dart';
+import 'package:unified_logger/unified_logger.dart';
+
+/// Signs the NIP-98 proof-of-key that backs the account-deletion retry.
+///
+/// Keycast's `DELETE /user/account` is authorized by the bearer token; this
+/// proof is only offered after that token comes back 403. Lives outside
+/// `AuthService` so the account pin below is unit-testable on its own, and so
+/// deletion work stops accreting into an already-oversized service (#4338).
+class AccountDeletionProofSigner {
+  AccountDeletionProofSigner({
+    required Nip98AuthService Function() buildNip98Auth,
+    required String? Function() activePubkey,
+  }) : _buildNip98Auth = buildNip98Auth,
+       _activePubkey = activePubkey;
+
+  /// Builds the NIP-98 service on first use.
+  ///
+  /// Reuses the audited kind-27235 construction in [Nip98AuthService] rather
+  /// than hand-rolling a second one for a single call site. Deferred rather
+  /// than eager so [dispose] does not construct one — and start its
+  /// cache-cleanup timer — purely in order to tear it down.
+  final Nip98AuthService Function() _buildNip98Auth;
+
+  /// The pubkey signed in right now, sampled at each call rather than held.
+  final String? Function() _activePubkey;
+
+  Nip98AuthService? _nip98Auth;
+
+  /// The base64 event body for a `DELETE` of [url], or null when no proof
+  /// should be sent — in which case the refusal the bearer attempt earned
+  /// stands.
+  ///
+  /// Never throws: failing to sign must not turn a refused deletion into a
+  /// reported network error.
+  ///
+  /// Refuses unless the signer still belongs to [tokenOwnerPubkey], the
+  /// account the bearer token was minted for. Signing is a remote RPC for a
+  /// Keycast identity, so an account switch can land mid-flight — and pairing
+  /// one account's token with another's proof on an irreversible delete is not
+  /// a mistake worth leaving to whether the server happens to reject it.
+  Future<String?> sign(String url, {required String? tokenOwnerPubkey}) async {
+    try {
+      if (tokenOwnerPubkey == null || _activePubkey() != tokenOwnerPubkey) {
+        Log.warning(
+          'Refusing to sign a deletion proof for a different account than the '
+          'token was minted for: token owner '
+          '${tokenOwnerPubkey ?? "unknown"}, signed-in account '
+          '${_activePubkey() ?? "none"}',
+          name: 'AccountDeletionProofSigner',
+          category: LogCategory.auth,
+        );
+        return null;
+      }
+
+      final token = await (_nip98Auth ??= _buildNip98Auth()).createAuthToken(
+        url: url,
+        method: HttpMethod.delete,
+      );
+
+      // The check that carries the weight: the one above only proves the
+      // accounts matched before a call that can take seconds.
+      if (_activePubkey() != tokenOwnerPubkey) {
+        Log.warning(
+          'Discarding a deletion proof signed for $tokenOwnerPubkey: the '
+          'signed-in account changed to ${_activePubkey() ?? "none"} while it '
+          'was being signed',
+          name: 'AccountDeletionProofSigner',
+          category: LogCategory.auth,
+        );
+        return null;
+      }
+      if (token == null) {
+        Log.warning(
+          'Could not sign NIP-98 proof for account deletion; '
+          'the refused bearer attempt stands',
+          name: 'AccountDeletionProofSigner',
+          category: LogCategory.auth,
+        );
+      }
+      return token?.token;
+    } catch (e) {
+      Log.warning(
+        'NIP-98 proof signing threw for account deletion: $e',
+        name: 'AccountDeletionProofSigner',
+        category: LogCategory.auth,
+      );
+      return null;
+    }
+  }
+
+  void dispose() {
+    _nip98Auth?.dispose();
+    _nip98Auth = null;
+  }
+}

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -3177,13 +3177,13 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
         );
       }
 
-      // Prefer a NIP-98 proof-of-key over the bearer token.
-      // [activeAccountKeycastToken] above may have just minted a refreshed
-      // token, and a refreshed token no longer carries the server's first-party
-      // fact — so the bearer path is exactly the one that gets refused, after
-      // the irreversible NIP-62 vanish has already been published. Signing
-      // proves key control instead. Falls back to the bearer token when signing
-      // is unavailable, so this can ship before the server accepts proofs.
+      // The bearer token authorizes this; the signer is only a 403 retry.
+      // Keycast's delete route parses `Bearer ` and rejects every other
+      // scheme, so leading with a NIP-98 proof gets a 401 back before the
+      // proof is read at all — after the irreversible NIP-62 vanish has
+      // already been published. keycast#331 closed keycast#323 by preserving
+      // the first-party fact across refresh rotation instead of accepting
+      // proofs here, which is what makes the refreshed bearer token usable.
       // See #5756 / #4881 / keycast#323.
       final result = await _oauthClient.deleteAccount(
         accessToken,
@@ -3236,16 +3236,14 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
 
   /// Sign a NIP-98 proof-of-key for the account-deletion request at [url].
   ///
-  /// Returns the base64 event body, or null when a proof cannot be produced —
-  /// in which case the caller falls back to the bearer token. Never throws:
-  /// failing to sign must not abort a deletion that the bearer path could still
-  /// complete.
+  /// Only reached once the bearer attempt came back 403. Returns the base64
+  /// event body, or null when a proof cannot be produced — in which case the
+  /// 403 stands. Never throws: failing to sign must not turn a refused
+  /// deletion into a reported network error.
   ///
   /// The signer must still be alive here. It is: the flow signs and publishes
   /// the kind-62 vanish moments earlier, so a working signer is a precondition
-  /// of reaching this point at all. If that ordering ever changes, this returns
-  /// null and the call silently degrades to the bearer token — which is the
-  /// behavior this exists to avoid, so keep the ordering.
+  /// of reaching this point at all.
   Future<String?> _signAccountDeletionProof(String url) async {
     try {
       final token = await _nip98Auth.createAuthToken(

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -3253,7 +3253,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
       if (token == null) {
         Log.warning(
           'Could not sign NIP-98 proof for account deletion; '
-          'falling back to bearer token',
+          'the refused bearer attempt stands',
           name: 'AuthService',
           category: LogCategory.auth,
         );

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -19,6 +19,7 @@ import 'package:openvine/models/auth_result.dart';
 import 'package:openvine/models/auth_rpc_capability.dart';
 import 'package:openvine/models/authentication_source.dart';
 import 'package:openvine/models/known_account.dart';
+import 'package:openvine/services/account_deletion_proof_signer.dart';
 import 'package:openvine/services/auth/known_accounts_registry.dart';
 import 'package:openvine/services/auth/nostr_connect_coordinator.dart';
 import 'package:openvine/services/auth/nostr_identity.dart';
@@ -3195,7 +3196,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
       final result = await _oauthClient.deleteAccount(
         accessToken,
         nip98Signer: (url) =>
-            _signAccountDeletionProof(url, tokenOwnerPubkey: tokenOwnerPubkey),
+            _deletionProof.sign(url, tokenOwnerPubkey: tokenOwnerPubkey),
       );
 
       if (result.success) {
@@ -3231,85 +3232,18 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
     }
   }
 
-  /// NIP-98 signer, built on first use against this instance.
+  /// Signs the proof-of-key the deletion retry offers after a 403.
   ///
-  /// Reuses the audited token construction in [Nip98AuthService] rather than
-  /// hand-rolling a second kind-27235 code path for one call site. Deliberately
-  /// nullable rather than `late final`, so [dispose] does not construct one (and
-  /// start its cache-cleanup timer) purely in order to tear it down.
-  Nip98AuthService? _nip98AuthService;
+  /// Deferred rather than eager so [dispose] does not build one purely to tear
+  /// it down. Lives in its own class so deletion work stops accreting into
+  /// this already-oversized service (#4338).
+  AccountDeletionProofSigner? _deletionProofSigner;
 
-  Nip98AuthService get _nip98Auth =>
-      _nip98AuthService ??= Nip98AuthService(authService: this);
-
-  /// Sign a NIP-98 proof-of-key for the account-deletion request at [url].
-  ///
-  /// Only reached once the bearer attempt came back 403. Returns the base64
-  /// event body, or null when a proof cannot be produced — in which case the
-  /// 403 stands. Never throws: failing to sign must not turn a refused
-  /// deletion into a reported network error.
-  ///
-  /// The signer must still be alive here. It is: the flow signs and publishes
-  /// the kind-62 vanish moments earlier, so a working signer is a precondition
-  /// of reaching this point at all.
-  ///
-  /// Refuses unless the signer still belongs to [tokenOwnerPubkey], the
-  /// account the bearer token was minted for. Signing is a remote RPC for a
-  /// Keycast identity, so an account switch can land mid-flight — and pairing
-  /// one account's token with another's proof on an irreversible delete is not
-  /// a mistake worth leaving to whether the server happens to reject it.
-  Future<String?> _signAccountDeletionProof(
-    String url, {
-    required String? tokenOwnerPubkey,
-  }) async {
-    try {
-      if (tokenOwnerPubkey == null || currentPublicKeyHex != tokenOwnerPubkey) {
-        Log.warning(
-          'Refusing to sign a deletion proof for a different account than the '
-          'token was minted for: token owner '
-          '${tokenOwnerPubkey ?? "unknown"}, signed-in account '
-          '${currentPublicKeyHex ?? "none"}',
-          name: 'AuthService',
-          category: LogCategory.auth,
-        );
-        return null;
-      }
-
-      final token = await _nip98Auth.createAuthToken(
-        url: url,
-        method: HttpMethod.delete,
+  AccountDeletionProofSigner get _deletionProof =>
+      _deletionProofSigner ??= AccountDeletionProofSigner(
+        buildNip98Auth: () => Nip98AuthService(authService: this),
+        activePubkey: () => currentPublicKeyHex,
       );
-
-      // The check that carries the weight: the one above only proves the
-      // accounts matched before a call that can take seconds.
-      if (currentPublicKeyHex != tokenOwnerPubkey) {
-        Log.warning(
-          'Discarding a deletion proof signed for $tokenOwnerPubkey: the '
-          'signed-in account changed to ${currentPublicKeyHex ?? "none"} '
-          'while it was being signed',
-          name: 'AuthService',
-          category: LogCategory.auth,
-        );
-        return null;
-      }
-      if (token == null) {
-        Log.warning(
-          'Could not sign NIP-98 proof for account deletion; '
-          'the refused bearer attempt stands',
-          name: 'AuthService',
-          category: LogCategory.auth,
-        );
-      }
-      return token?.token;
-    } catch (e) {
-      Log.warning(
-        'NIP-98 proof signing threw for account deletion: $e',
-        name: 'AuthService',
-        category: LogCategory.auth,
-      );
-      return null;
-    }
-  }
 
   /// Sign out the current user.
   ///
@@ -4780,8 +4714,8 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
     _bunkerSigner = null;
 
     // Cancels the NIP-98 token cache's periodic cleanup timer, if one was built.
-    _nip98AuthService?.dispose();
-    _nip98AuthService = null;
+    _deletionProofSigner?.dispose();
+    _deletionProofSigner = null;
 
     // Close Amber signer if active
     _amberSigner?.close();

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -3162,6 +3162,13 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
       // runs before this call, and refuses a session the signed-in account
       // cannot claim — deletion is irreversible, so the account it lands on
       // has to be the one that asked for it.
+      //
+      // Sampled before minting, not after: [activeAccountKeycastToken] reads
+      // the same getter on entry, so this names the account it validates the
+      // session against. Sampling afterwards would name the *new* account if
+      // a switch landed in between, and the pin below would then approve the
+      // very mismatch it exists to catch.
+      final tokenOwnerPubkey = currentPublicKeyHex;
       final accessToken = await activeAccountKeycastToken();
       if (accessToken == null) {
         Log.warning(
@@ -3187,7 +3194,8 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
       // See #5756 / #4881 / keycast#323.
       final result = await _oauthClient.deleteAccount(
         accessToken,
-        nip98Signer: _signAccountDeletionProof,
+        nip98Signer: (url) =>
+            _signAccountDeletionProof(url, tokenOwnerPubkey: tokenOwnerPubkey),
       );
 
       if (result.success) {
@@ -3244,12 +3252,46 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   /// The signer must still be alive here. It is: the flow signs and publishes
   /// the kind-62 vanish moments earlier, so a working signer is a precondition
   /// of reaching this point at all.
-  Future<String?> _signAccountDeletionProof(String url) async {
+  ///
+  /// Refuses unless the signer still belongs to [tokenOwnerPubkey], the
+  /// account the bearer token was minted for. Signing is a remote RPC for a
+  /// Keycast identity, so an account switch can land mid-flight — and pairing
+  /// one account's token with another's proof on an irreversible delete is not
+  /// a mistake worth leaving to whether the server happens to reject it.
+  Future<String?> _signAccountDeletionProof(
+    String url, {
+    required String? tokenOwnerPubkey,
+  }) async {
     try {
+      if (tokenOwnerPubkey == null || currentPublicKeyHex != tokenOwnerPubkey) {
+        Log.warning(
+          'Refusing to sign a deletion proof for a different account than the '
+          'token was minted for: token owner '
+          '${tokenOwnerPubkey ?? "unknown"}, signed-in account '
+          '${currentPublicKeyHex ?? "none"}',
+          name: 'AuthService',
+          category: LogCategory.auth,
+        );
+        return null;
+      }
+
       final token = await _nip98Auth.createAuthToken(
         url: url,
         method: HttpMethod.delete,
       );
+
+      // The check that carries the weight: the one above only proves the
+      // accounts matched before a call that can take seconds.
+      if (currentPublicKeyHex != tokenOwnerPubkey) {
+        Log.warning(
+          'Discarding a deletion proof signed for $tokenOwnerPubkey: the '
+          'signed-in account changed to ${currentPublicKeyHex ?? "none"} '
+          'while it was being signed',
+          name: 'AuthService',
+          category: LogCategory.auth,
+        );
+        return null;
+      }
       if (token == null) {
         Log.warning(
           'Could not sign NIP-98 proof for account deletion; '

--- a/mobile/packages/keycast_flutter/lib/src/oauth/oauth_client.dart
+++ b/mobile/packages/keycast_flutter/lib/src/oauth/oauth_client.dart
@@ -1032,7 +1032,8 @@ class KeycastOAuth {
   /// divergence makes the server reject the proof. Keycast closed keycast#323
   /// by preserving the first-party fact across refresh rotation instead of
   /// accepting proofs on this route, so until that changes the retry cannot
-  /// succeed — which is why only a 200 from it supersedes the original 403.
+  /// succeed — which is why neither its status nor a throw out of it may
+  /// displace the refusal the bearer attempt already earned.
   ///
   /// Returns [DeleteAccountResult] with success status.
   Future<DeleteAccountResult> deleteAccount(
@@ -1047,13 +1048,19 @@ class KeycastOAuth {
       if (response.statusCode == 403 && nip98Signer != null) {
         final proof = await _signDeletionProof(nip98Signer, url);
         if (proof != null) {
-          final retry = await _sendAccountDeletion(url, 'Nostr $proof');
-          // Only a success supersedes the 403. Today the route answers the
-          // `Nostr ` scheme 401, so adopting the retry unconditionally would
-          // replace an accurate "not authorized to delete" with "invalid or
-          // expired token" — the misdiagnosis this whole path exists to end.
-          if (retry.statusCode == 200) {
-            response = retry;
+          // Best-effort, in both directions. Only a 200 supersedes the 403,
+          // and a timeout or dropped socket on the retry must not escape to
+          // the network-error handler below: either would discard the refusal
+          // the server actually sent, and `requiresReauthentication` is the
+          // only thing the UI branches on — so the user would be told to check
+          // their connection after the irreversible vanish had gone out.
+          try {
+            final retry = await _sendAccountDeletion(url, 'Nostr $proof');
+            if (retry.statusCode == 200) {
+              response = retry;
+            }
+          } catch (_) {
+            // Keep the refusal the bearer attempt already earned.
           }
         }
       }
@@ -1078,8 +1085,9 @@ class KeycastOAuth {
         // The credential was read and refused: neither user-signed nor
         // carrying the server's first-party fact. The proof-of-key retry above
         // has already had its turn, so re-authenticating is what is left — this
-        // must never be reported as a connectivity problem, and the server's
-        // own prose here is the only thing that says which of the two it was.
+        // must never be reported as a connectivity problem. The server's prose
+        // is what separates the two refusals, in the log; the UI reads only
+        // `requiresReauthentication`, which 401 and 403 both set.
         return DeleteAccountResult.error(
           _errorMessageFrom(response) ??
               'Account deletion requires signing in again',

--- a/mobile/packages/keycast_flutter/lib/src/oauth/oauth_client.dart
+++ b/mobile/packages/keycast_flutter/lib/src/oauth/oauth_client.dart
@@ -1032,7 +1032,7 @@ class KeycastOAuth {
   /// divergence makes the server reject the proof. Keycast closed keycast#323
   /// by preserving the first-party fact across refresh rotation instead of
   /// accepting proofs on this route, so until that changes the retry cannot
-  /// succeed and the original 403 is returned.
+  /// succeed — which is why only a 200 from it supersedes the original 403.
   ///
   /// Returns [DeleteAccountResult] with success status.
   Future<DeleteAccountResult> deleteAccount(
@@ -1047,7 +1047,14 @@ class KeycastOAuth {
       if (response.statusCode == 403 && nip98Signer != null) {
         final proof = await _signDeletionProof(nip98Signer, url);
         if (proof != null) {
-          response = await _sendAccountDeletion(url, 'Nostr $proof');
+          final retry = await _sendAccountDeletion(url, 'Nostr $proof');
+          // Only a success supersedes the 403. Today the route answers the
+          // `Nostr ` scheme 401, so adopting the retry unconditionally would
+          // replace an accurate "not authorized to delete" with "invalid or
+          // expired token" — the misdiagnosis this whole path exists to end.
+          if (retry.statusCode == 200) {
+            response = retry;
+          }
         }
       }
 
@@ -1071,7 +1078,8 @@ class KeycastOAuth {
         // The credential was read and refused: neither user-signed nor
         // carrying the server's first-party fact. The proof-of-key retry above
         // has already had its turn, so re-authenticating is what is left — this
-        // must never be reported as a connectivity problem.
+        // must never be reported as a connectivity problem, and the server's
+        // own prose here is the only thing that says which of the two it was.
         return DeleteAccountResult.error(
           _errorMessageFrom(response) ??
               'Account deletion requires signing in again',

--- a/mobile/packages/keycast_flutter/lib/src/oauth/oauth_client.dart
+++ b/mobile/packages/keycast_flutter/lib/src/oauth/oauth_client.dart
@@ -983,20 +983,56 @@ class KeycastOAuth {
     }
   }
 
+  /// One `DELETE /api/user/account` attempt carrying [authorization].
+  Future<http.Response> _sendAccountDeletion(
+    String url,
+    String authorization,
+  ) {
+    return _client
+        .delete(
+          Uri.parse(url),
+          headers: {
+            'Authorization': authorization,
+            'Content-Type': 'application/json',
+          },
+        )
+        .timeout(requestTimeout);
+  }
+
+  /// The NIP-98 proof for [url], or null when [signer] cannot produce one.
+  ///
+  /// Swallows a throwing signer so the 403 that triggered the retry stays the
+  /// response the caller sees, rather than a misleading network error.
+  static Future<String?> _signDeletionProof(
+    Future<String?> Function(String url) signer,
+    String url,
+  ) async {
+    try {
+      return await signer(url);
+    } catch (_) {
+      return null;
+    }
+  }
+
   /// Delete the user's account permanently from Keycast
   ///
   /// This is a destructive action that cannot be undone.
   ///
-  /// Authorization prefers a **NIP-98 proof-of-key** when [nip98Signer] is
-  /// supplied and succeeds, falling back to the bearer [token] otherwise.
-  /// The proof matters because a bearer token minted by a *refresh* no longer
-  /// carries the server's first-party fact, so it is refused — while a
-  /// signature proves key control regardless of how old the session is.
+  /// Authorization uses the bearer [token]. Keycast's `DELETE /user/account`
+  /// hands the header straight to UCAN validation, which strips a `Bearer `
+  /// prefix and rejects every other scheme — so a NIP-98 proof is answered
+  /// with 401 before it is ever read.
   ///
-  /// [nip98Signer] receives the exact request URL and returns the base64 event
-  /// body (without the `Nostr ` scheme), or null if it cannot sign. The URL is
-  /// passed in rather than rebuilt by the caller because NIP-98 binds the
-  /// signature to it: any divergence makes the server reject the proof.
+  /// [nip98Signer] is therefore a **retry** credential, used only after a
+  /// **403**: that is the code the server returns once it has read and refused
+  /// a credential, which is the case a proof-of-key would cure. It receives
+  /// the exact request URL and returns the base64 event body (without the
+  /// `Nostr ` scheme), or null if it cannot sign. The URL is passed in rather
+  /// than rebuilt by the caller because NIP-98 binds the signature to it: any
+  /// divergence makes the server reject the proof. Keycast closed keycast#323
+  /// by preserving the first-party fact across refresh rotation instead of
+  /// accepting proofs on this route, so until that changes the retry cannot
+  /// succeed and the original 403 is returned.
   ///
   /// Returns [DeleteAccountResult] with success status.
   Future<DeleteAccountResult> deleteAccount(
@@ -1005,19 +1041,15 @@ class KeycastOAuth {
   }) async {
     try {
       final url = '${config.serverUrl}/api/user/account';
-      final nip98Token = nip98Signer == null ? null : await nip98Signer(url);
 
-      final response = await _client
-          .delete(
-            Uri.parse(url),
-            headers: {
-              'Authorization': nip98Token != null
-                  ? 'Nostr $nip98Token'
-                  : 'Bearer $token',
-              'Content-Type': 'application/json',
-            },
-          )
-          .timeout(requestTimeout);
+      var response = await _sendAccountDeletion(url, 'Bearer $token');
+
+      if (response.statusCode == 403 && nip98Signer != null) {
+        final proof = await _signDeletionProof(nip98Signer, url);
+        if (proof != null) {
+          response = await _sendAccountDeletion(url, 'Nostr $proof');
+        }
+      }
 
       if (response.statusCode == 200) {
         final json = jsonDecode(response.body) as Map<String, dynamic>;
@@ -1036,10 +1068,10 @@ class KeycastOAuth {
       }
 
       if (response.statusCode == 403) {
-        // The credential is valid but not authorized to delete — currently
-        // because a refreshed access token no longer carries the server's
-        // first-party fact. Re-authenticating fixes it, so this must never be
-        // reported as a connectivity problem or retried unchanged.
+        // The credential was read and refused: neither user-signed nor
+        // carrying the server's first-party fact. The proof-of-key retry above
+        // has already had its turn, so re-authenticating is what is left — this
+        // must never be reported as a connectivity problem.
         return DeleteAccountResult.error(
           _errorMessageFrom(response) ??
               'Account deletion requires signing in again',

--- a/mobile/packages/keycast_flutter/test/oauth_client_test.dart
+++ b/mobile/packages/keycast_flutter/test/oauth_client_test.dart
@@ -1682,6 +1682,61 @@ void main() {
         expect(result.requiresReauthentication, isTrue);
       });
 
+      test('keeps the 403 when the proof retry cannot be sent', () async {
+        // A dropped socket on the retry must not escape to the network-error
+        // handler: that clears `requiresReauthentication`, which is the only
+        // thing the UI branches on, so the user would be told to check their
+        // connection after the irreversible vanish had already published.
+        final mockClient = MockClient((request) async {
+          if (request.headers['Authorization']!.startsWith('Bearer ')) {
+            return http.Response(
+              jsonEncode({'message': 'Account deletion requires the app'}),
+              403,
+            );
+          }
+          throw const SocketException('connection reset');
+        });
+
+        final oauth = KeycastOAuth(config: config, httpClient: mockClient);
+        final result = await oauth.deleteAccount(
+          'refreshed_token',
+          nip98Signer: (_) async => 'BASE64EVENT',
+        );
+
+        expect(result.error, 'Account deletion requires the app');
+        expect(result.requiresReauthentication, isTrue);
+      });
+
+      test('keeps the 403 when the proof retry hangs', () async {
+        // Same contract for the timeout path, which is the likelier one: the
+        // signer sits between the two requests, so the connection can idle
+        // long enough for the retry to open on a dead one.
+        final mockClient = MockClient((request) {
+          if (request.headers['Authorization']!.startsWith('Bearer ')) {
+            return Future.value(
+              http.Response(
+                jsonEncode({'message': 'Account deletion requires the app'}),
+                403,
+              ),
+            );
+          }
+          return Completer<http.Response>().future;
+        });
+
+        final oauth = KeycastOAuth(
+          config: config,
+          httpClient: mockClient,
+          requestTimeout: const Duration(milliseconds: 50),
+        );
+        final result = await oauth.deleteAccount(
+          'refreshed_token',
+          nip98Signer: (_) async => 'BASE64EVENT',
+        );
+
+        expect(result.error, 'Account deletion requires the app');
+        expect(result.requiresReauthentication, isTrue);
+      });
+
       test('does not retry a 401 with a proof', () async {
         // 401 is what keycast answers when it cannot parse the credential.
         // Re-sending an unparseable scheme would only repeat the failure.

--- a/mobile/packages/keycast_flutter/test/oauth_client_test.dart
+++ b/mobile/packages/keycast_flutter/test/oauth_client_test.dart
@@ -1649,6 +1649,39 @@ void main() {
         ]);
       });
 
+      test('keeps the 403 when the proof retry is refused', () async {
+        // Keycast strips a `Bearer ` prefix and answers every other scheme
+        // 401, so the retry this route allows is exactly the one it rejects.
+        // Adopting that 401 would replace the accurate "not authorized to
+        // delete" — plus the server's own prose — with "invalid or expired
+        // token", which is the misdiagnosis #4881 is about.
+        final sentAuthorizations = <String?>[];
+        final mockClient = MockClient((request) async {
+          sentAuthorizations.add(request.headers['Authorization']);
+          if (sentAuthorizations.length == 1) {
+            return http.Response(
+              jsonEncode({'message': 'Account deletion requires the app'}),
+              403,
+            );
+          }
+          return http.Response('Invalid or expired token', 401);
+        });
+
+        final oauth = KeycastOAuth(config: config, httpClient: mockClient);
+        final result = await oauth.deleteAccount(
+          'refreshed_token',
+          nip98Signer: (_) async => 'BASE64EVENT',
+        );
+
+        expect(sentAuthorizations, [
+          'Bearer refreshed_token',
+          'Nostr BASE64EVENT',
+        ]);
+        expect(result.success, isFalse);
+        expect(result.error, 'Account deletion requires the app');
+        expect(result.requiresReauthentication, isTrue);
+      });
+
       test('does not retry a 401 with a proof', () async {
         // 401 is what keycast answers when it cannot parse the credential.
         // Re-sending an unparseable scheme would only repeat the failure.

--- a/mobile/packages/keycast_flutter/test/oauth_client_test.dart
+++ b/mobile/packages/keycast_flutter/test/oauth_client_test.dart
@@ -1592,39 +1592,15 @@ void main() {
         expect(result.requiresReauthentication, isTrue);
       });
 
-      test(
-        'sends a NIP-98 proof instead of the bearer token when signed',
-        () async {
-          // The bearer token is exactly the credential that gets refused once it
-          // has been refreshed, so a proof must take precedence over it.
-          String? sentAuthorization;
-          final mockClient = MockClient((request) async {
-            sentAuthorization = request.headers['Authorization'];
-            return http.Response(
-              jsonEncode({'success': true, 'message': 'Account deleted'}),
-              200,
-            );
-          });
-
-          final oauth = KeycastOAuth(config: config, httpClient: mockClient);
-          final result = await oauth.deleteAccount(
-            'refreshed_token',
-            nip98Signer: (_) async => 'BASE64EVENT',
-          );
-
-          expect(result.success, isTrue);
-          expect(sentAuthorization, 'Nostr BASE64EVENT');
-          expect(sentAuthorization, isNot(contains('Bearer')));
-        },
-      );
-
-      test('signs the proof over the exact URL the request is sent to', () async {
-        // NIP-98 binds the signature to the `u` tag; if the signer is handed a
-        // different URL than the request uses, the server rejects every proof.
-        String? signedUrl;
-        Uri? requestedUri;
+      test('sends the bearer token even when a signer is available', () async {
+        // keycast's delete route strips a `Bearer ` prefix and rejects every
+        // other scheme, so leading with a `Nostr` proof is answered 401 before
+        // the proof is read — after the irreversible NIP-62 vanish has already
+        // been published. Leading with the bearer token is the whole fix.
+        final sentAuthorizations = <String?>[];
+        var signerCalls = 0;
         final mockClient = MockClient((request) async {
-          requestedUri = request.url;
+          sentAuthorizations.add(request.headers['Authorization']);
           return http.Response(
             jsonEncode({'success': true, 'message': 'Account deleted'}),
             200,
@@ -1632,26 +1608,84 @@ void main() {
         });
 
         final oauth = KeycastOAuth(config: config, httpClient: mockClient);
-        await oauth.deleteAccount(
-          'token',
-          nip98Signer: (url) async {
-            signedUrl = url;
-            return 'PROOF';
+        final result = await oauth.deleteAccount(
+          'refreshed_token',
+          nip98Signer: (_) async {
+            signerCalls++;
+            return 'BASE64EVENT';
           },
         );
 
-        expect(signedUrl, isNotNull);
-        expect(signedUrl, requestedUri.toString());
+        expect(result.success, isTrue);
+        expect(sentAuthorizations, ['Bearer refreshed_token']);
+        expect(signerCalls, isZero);
+      });
+
+      test('retries with a NIP-98 proof after a 403', () async {
+        // A 403 means the credential was read and refused, which is the case a
+        // proof-of-key would cure. A 401 means it could not be read at all.
+        final sentAuthorizations = <String?>[];
+        final mockClient = MockClient((request) async {
+          sentAuthorizations.add(request.headers['Authorization']);
+          if (sentAuthorizations.length == 1) {
+            return http.Response('Forbidden', 403);
+          }
+          return http.Response(
+            jsonEncode({'success': true, 'message': 'Account deleted'}),
+            200,
+          );
+        });
+
+        final oauth = KeycastOAuth(config: config, httpClient: mockClient);
+        final result = await oauth.deleteAccount(
+          'refreshed_token',
+          nip98Signer: (_) async => 'BASE64EVENT',
+        );
+
+        expect(result.success, isTrue);
+        expect(sentAuthorizations, [
+          'Bearer refreshed_token',
+          'Nostr BASE64EVENT',
+        ]);
+      });
+
+      test('does not retry a 401 with a proof', () async {
+        // 401 is what keycast answers when it cannot parse the credential.
+        // Re-sending an unparseable scheme would only repeat the failure.
+        var requests = 0;
+        var signerCalls = 0;
+        final mockClient = MockClient((request) async {
+          requests++;
+          return http.Response('Unauthorized', 401);
+        });
+
+        final oauth = KeycastOAuth(config: config, httpClient: mockClient);
+        final result = await oauth.deleteAccount(
+          'expired_token',
+          nip98Signer: (_) async {
+            signerCalls++;
+            return 'BASE64EVENT';
+          },
+        );
+
+        expect(result.success, isFalse);
+        expect(result.requiresReauthentication, isTrue);
+        expect(requests, 1);
+        expect(signerCalls, isZero);
       });
 
       test(
-        'falls back to the bearer token when the signer returns null',
+        'signs the retry proof over the exact URL the request is sent to',
         () async {
-          // Lets the client ship before the server accepts proofs, and keeps
-          // deletion working for anyone whose signer is unavailable.
-          String? sentAuthorization;
+          // NIP-98 binds the signature to the `u` tag; if the signer is handed a
+          // different URL than the request uses, the server rejects every proof.
+          String? signedUrl;
+          Uri? requestedUri;
+          var requests = 0;
           final mockClient = MockClient((request) async {
-            sentAuthorization = request.headers['Authorization'];
+            requestedUri = request.url;
+            requests++;
+            if (requests == 1) return http.Response('Forbidden', 403);
             return http.Response(
               jsonEncode({'success': true, 'message': 'Account deleted'}),
               200,
@@ -1659,15 +1693,55 @@ void main() {
           });
 
           final oauth = KeycastOAuth(config: config, httpClient: mockClient);
-          final result = await oauth.deleteAccount(
-            'test_token',
-            nip98Signer: (_) async => null,
+          await oauth.deleteAccount(
+            'token',
+            nip98Signer: (url) async {
+              signedUrl = url;
+              return 'PROOF';
+            },
           );
 
-          expect(result.success, isTrue);
-          expect(sentAuthorization, 'Bearer test_token');
+          expect(signedUrl, isNotNull);
+          expect(signedUrl, requestedUri.toString());
         },
       );
+
+      test('keeps the 403 when the signer returns null', () async {
+        var requests = 0;
+        final mockClient = MockClient((request) async {
+          requests++;
+          return http.Response('Forbidden', 403);
+        });
+
+        final oauth = KeycastOAuth(config: config, httpClient: mockClient);
+        final result = await oauth.deleteAccount(
+          'test_token',
+          nip98Signer: (_) async => null,
+        );
+
+        expect(result.success, isFalse);
+        expect(result.error, contains('requires signing in again'));
+        expect(result.requiresReauthentication, isTrue);
+        expect(requests, 1);
+      });
+
+      test('keeps the 403 when the signer throws', () async {
+        // A throwing signer must not surface as a network error: that would
+        // tell the user to check their connection for a refused credential.
+        final mockClient = MockClient((request) async {
+          return http.Response('Forbidden', 403);
+        });
+
+        final oauth = KeycastOAuth(config: config, httpClient: mockClient);
+        final result = await oauth.deleteAccount(
+          'test_token',
+          nip98Signer: (_) async => throw StateError('signer gone'),
+        );
+
+        expect(result.success, isFalse);
+        expect(result.error, contains('requires signing in again'));
+        expect(result.requiresReauthentication, isTrue);
+      });
 
       test('uses the bearer token when no signer is supplied', () async {
         // Pins the default: existing callers keep their current behavior.

--- a/mobile/scripts/baseline/service_god_file_sizes.txt
+++ b/mobile/scripts/baseline/service_god_file_sizes.txt
@@ -6,7 +6,7 @@
 # This hard service baseline is authoritative over the advisory file_sizes.txt
 # baseline for service god-file ceilings.
 # Regenerate after shrinking/removing: UPDATE_BASELINE=1 bash scripts/check_service_god_file_ceiling.sh
-lib/services/auth_service.dart	4780
+lib/services/auth_service.dart	4735
 lib/services/curated_list_service.dart	1848
 lib/services/upload_manager.dart	2317
 lib/services/video_editor/video_editor_render_service.dart	1539

--- a/mobile/test/services/account_deletion_proof_signer_test.dart
+++ b/mobile/test/services/account_deletion_proof_signer_test.dart
@@ -1,0 +1,144 @@
+// ABOUTME: Tests for AccountDeletionProofSigner - the 403 retry credential
+// ABOUTME: Verifies the proof is pinned to the account whose token is spent
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/services/account_deletion_proof_signer.dart';
+import 'package:openvine/services/nip98_auth_service.dart';
+
+class _MockNip98AuthService extends Mock implements Nip98AuthService {}
+
+class _FakeNip98Token extends Fake implements Nip98Token {
+  @override
+  String get token => 'BASE64EVENT';
+}
+
+void main() {
+  group(AccountDeletionProofSigner, () {
+    final tokenOwner = 'a' * 64;
+    final otherAccount = 'b' * 64;
+    const url = 'https://login.divine.video/api/user/account';
+
+    late _MockNip98AuthService nip98Auth;
+    late int builds;
+
+    setUp(() {
+      nip98Auth = _MockNip98AuthService();
+      builds = 0;
+      registerFallbackValue(HttpMethod.delete);
+    });
+
+    /// A signer whose active account is whatever [activePubkey] returns.
+    AccountDeletionProofSigner signerFor(String? Function() activePubkey) {
+      return AccountDeletionProofSigner(
+        buildNip98Auth: () {
+          builds++;
+          return nip98Auth;
+        },
+        activePubkey: activePubkey,
+      );
+    }
+
+    void stubSigning({Nip98Token? returns}) {
+      when(
+        () => nip98Auth.createAuthToken(
+          url: any(named: 'url'),
+          method: any(named: 'method'),
+        ),
+      ).thenAnswer((_) async => returns);
+    }
+
+    test('signs when the account still owns the token', () async {
+      stubSigning(returns: _FakeNip98Token());
+
+      final proof = await signerFor(
+        () => tokenOwner,
+      ).sign(url, tokenOwnerPubkey: tokenOwner);
+
+      expect(proof, 'BASE64EVENT');
+    });
+
+    test(
+      'refuses, without signing, when the account already differs',
+      () async {
+        stubSigning(returns: _FakeNip98Token());
+
+        final proof = await signerFor(
+          () => otherAccount,
+        ).sign(url, tokenOwnerPubkey: tokenOwner);
+
+        expect(proof, isNull);
+        verifyNever(
+          () => nip98Auth.createAuthToken(
+            url: any(named: 'url'),
+            method: any(named: 'method'),
+          ),
+        );
+        expect(
+          builds,
+          isZero,
+          reason: 'a refused pin must not build the NIP-98 service',
+        );
+      },
+    );
+
+    // The check that carries the weight. Signing is a remote RPC for a Keycast
+    // identity, so the switch can land after the entry check has passed —
+    // pairing one account's bearer token with another's proof on a delete that
+    // cannot be undone.
+    test('discards a proof signed while the account changed', () async {
+      var active = tokenOwner;
+      when(
+        () => nip98Auth.createAuthToken(
+          url: any(named: 'url'),
+          method: any(named: 'method'),
+        ),
+      ).thenAnswer((_) async {
+        active = otherAccount;
+        return _FakeNip98Token();
+      });
+
+      final proof = await signerFor(
+        () => active,
+      ).sign(url, tokenOwnerPubkey: tokenOwner);
+
+      expect(proof, isNull);
+    });
+
+    test('returns null rather than throwing when signing fails', () async {
+      when(
+        () => nip98Auth.createAuthToken(
+          url: any(named: 'url'),
+          method: any(named: 'method'),
+        ),
+      ).thenThrow(StateError('signer gone'));
+
+      final proof = await signerFor(
+        () => tokenOwner,
+      ).sign(url, tokenOwnerPubkey: tokenOwner);
+
+      expect(proof, isNull);
+    });
+
+    test('signs over the exact URL it is handed', () async {
+      stubSigning(returns: _FakeNip98Token());
+
+      await signerFor(() => tokenOwner).sign(url, tokenOwnerPubkey: tokenOwner);
+
+      verify(
+        () => nip98Auth.createAuthToken(url: url, method: HttpMethod.delete),
+      ).called(1);
+    });
+
+    test('disposes the NIP-98 service it built', () async {
+      stubSigning(returns: _FakeNip98Token());
+      when(() => nip98Auth.dispose()).thenReturn(null);
+
+      final signer = signerFor(() => tokenOwner);
+      await signer.sign(url, tokenOwnerPubkey: tokenOwner);
+      signer.dispose();
+
+      verify(() => nip98Auth.dispose()).called(1);
+    });
+  });
+}

--- a/mobile/test/services/auth_service_delete_keycast_account_test.dart
+++ b/mobile/test/services/auth_service_delete_keycast_account_test.dart
@@ -291,14 +291,47 @@ void main() {
     // recourse if keycast ever refuses it with a 403 again (#4881) — which
     // lands after the irreversible NIP-62 vanish has already been published.
     // Dropping it would leave that path with nothing to retry.
+    test('supplies a NIP-98 signer as the 403 retry credential', () async {
+      final (authService, pubkeyHex) = await signedInAuthService();
+      when(() => mockOAuthClient.getSession()).thenAnswer((_) async => null);
+      when(
+        () => mockOAuthClient.refreshSession(userPubkey: pubkeyHex),
+      ).thenAnswer(
+        (_) async => session(owner: pubkeyHex, token: testAccessToken),
+      );
+
+      Future<String?> Function(String)? capturedSigner;
+      when(
+        () => mockOAuthClient.deleteAccount(
+          testAccessToken,
+          nip98Signer: any(named: 'nip98Signer'),
+        ),
+      ).thenAnswer((invocation) async {
+        capturedSigner =
+            invocation.namedArguments[#nip98Signer]
+                as Future<String?> Function(String)?;
+        return DeleteAccountResult(success: true, message: 'deleted');
+      });
+
+      await authService.deleteKeycastAccount();
+
+      expect(
+        capturedSigner,
+        isNotNull,
+        reason: 'deleteKeycastAccount must offer a proof-of-key signer',
+      );
+    });
+
+    // The token is minted for one account and the proof is signed by whoever
+    // is live at signing time — a remote RPC for a Keycast identity, so an
+    // account switch can land in between. Pairing account A's token with
+    // account B's proof on an irreversible delete must not depend on the
+    // server happening to reject it.
     test(
-      'supplies a NIP-98 signer as the 403 retry credential',
+      'refuses to sign a proof once the signed-in account changes',
       () async {
         final (authService, pubkeyHex) = await signedInAuthService();
-        when(() => mockOAuthClient.getSession()).thenAnswer((_) async => null);
-        when(
-          () => mockOAuthClient.refreshSession(userPubkey: pubkeyHex),
-        ).thenAnswer(
+        when(() => mockOAuthClient.getSession()).thenAnswer(
           (_) async => session(owner: pubkeyHex, token: testAccessToken),
         );
 
@@ -316,11 +349,19 @@ void main() {
         });
 
         await authService.deleteKeycastAccount();
+        expect(capturedSigner, isNotNull);
+
+        // Stand in for the switch the real flow can hit mid-signing.
+        await ignoringDiscoveryErrors(
+          () => authService.importFromNsec(
+            Nip19.encodePrivateKey(generatePrivateKey()),
+          ),
+        );
+        expect(authService.currentPublicKeyHex, isNot(pubkeyHex));
 
         expect(
-          capturedSigner,
-          isNotNull,
-          reason: 'deleteKeycastAccount must offer a proof-of-key signer',
+          await capturedSigner!('https://keycast.test/api/user/account'),
+          isNull,
         );
       },
     );

--- a/mobile/test/services/auth_service_delete_keycast_account_test.dart
+++ b/mobile/test/services/auth_service_delete_keycast_account_test.dart
@@ -287,13 +287,12 @@ void main() {
       },
     );
 
-    // Without a proof-of-key the request falls back to the bearer token, and a
-    // refreshed bearer token is exactly what keycast refuses (#4881) — after
-    // the irreversible NIP-62 vanish has already been published. If this
-    // regresses, deletion silently goes back to failing for every returning
-    // user.
+    // The bearer token authorizes the delete; the signer is the client's only
+    // recourse if keycast ever refuses it with a 403 again (#4881) — which
+    // lands after the irreversible NIP-62 vanish has already been published.
+    // Dropping it would leave that path with nothing to retry.
     test(
-      'supplies a NIP-98 signer so a refreshed session can still delete',
+      'supplies a NIP-98 signer as the 403 retry credential',
       () async {
         final (authService, pubkeyHex) = await signedInAuthService();
         when(() => mockOAuthClient.getSession()).thenAnswer((_) async => null);


### PR DESCRIPTION
## Description

Account deletion failed for every OAuth user, and it failed at the worst possible moment: after the irreversible NIP-62 request to vanish and the kind-5 sweeps had already been published. Content broadcast for deletion, account still alive, user still signed in and told to check their internet connection.

Keycast's `DELETE /user/account` hands the Authorization header straight to UCAN validation, whose first act is `strip_prefix("Bearer ")` — every other scheme is rejected before the credential is looked at. Since #6563 the client led with a NIP-98 proof (`Authorization: Nostr <base64>`), so the request came back 401 and the client reported "Unauthorized: invalid or expired token" for a perfectly valid token. The bearer fallback never ran: it only triggers when the *signer* fails, not when the server refuses the scheme, and signing worked fine.

The proof was added for a real reason — a refreshed bearer token no longer carried the server's `first_party` fact, so it was refused with 403 (keycast#323). But keycast closed that issue with PR #331, which preserves the fact across refresh rotation instead of accepting proofs on this route. Server-side NIP-98 is still wired into exactly one endpoint, the admin login. So the bearer token is once again the credential that works, and this PR leads with it.

The signer stays wired up as a **403-only retry**, for the day that route does accept a proof. The status split is deliberate: 403 is what the server returns once it has read a credential and refused it, which is the case a proof-of-key would cure. 401 means it could not read the header at all, and re-sending the same unreadable scheme cannot help — so a 401 is never retried. A signer that throws is swallowed too, so a refused deletion is not reported to the user as a network error. And only a **200** from the retry supersedes the first response: the retry necessarily carries the `Nostr ` scheme, which is the one thing that route answers 401, so adopting it unconditionally would overwrite an accurate 403 — and the server's own prose with it — with the very "invalid or expired token" this PR is about. That matters today rather than someday: keycast#331 leaves authorizations created before its migration at `is_first_party = false` with no safe backfill, so the 403 cohort is live.

**Related Issue:** Closes #4881

## Out of Scope

`checkAccountDeletionReadiness` still blocks deletion outright when `session.grantType != authorization_code`, and `refreshSession` sets exactly that grant type. The gate exists only because of the pre-#331 server behaviour, so today it sends users to a re-login they no longer need. It is fail-safe — it blocks *before* anything irreversible is published, and re-login clears it — so it is friction rather than the failure this PR fixes. Left alone here; happy to file it separately.

Leading with the bearer token also makes a genuine server failure reachable where a 401 used to pre-empt it, and a 500 / 503 / 404 lands on copy that reads as though nothing was deleted. Raised by @mbradley in review and filed as #7875 rather than fixed here: it is a copy/state question that predates this PR, and the flag the dialog branches on answers "can a fresh sign-in clear this" rather than "how much already happened".

## Verification

- Manually verified on a real Samsung Galaxy: signed in as an OAuth user and deleted the account end to end. The Keycast call now returns 200 where it previously returned 401 after the vanish had already gone out.
- New regression test `sends the bearer token even when a signer is available` fails on the old code.
- New coverage for the retry contract: retries after 403, does **not** retry after 401, signs the retry proof over the exact request URL, keeps the 403 when the signer returns null or throws, and keeps the 403 plus the server's message when the retry itself comes back refused, drops its socket, or hangs past the timeout.
- `flutter test` in `mobile/packages/keycast_flutter` — 298/298.
- `flutter test test/services/` — 4322/4322. Both account-pin guards are individually mutation-checked: removing either one alone turns a distinct test in `account_deletion_proof_signer_test.dart` red.
- The retry proof is pinned to the account its bearer token was minted for, sampled before the token is minted and rechecked after signing. Signing moved out of `auth_service.dart` into `AccountDeletionProofSigner` so that pin is unit-testable on its own and deletion work stops accreting into a frozen god-file (#4338); `auth_service.dart` drops 4801 -> 4735 and its ceiling is relocked. The pin is — an account switch during that window would otherwise pair one account's token with another's proof on an irreversible delete. Inert against today's server, which is the server's accident rather than this client's guarantee. Raised by @mbradley in review.
- `flutter test test/services/auth_service_delete_keycast_account_test.dart test/services/account_deletion_service_test.dart test/services/account_deletion_proof_signer_test.dart test/widgets/delete_account_dialog_test.dart` — 120/120.
- `flutter analyze lib test` clean in both `mobile/` and `mobile/packages/keycast_flutter/`.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
