### PR TITLE
fix(observability): stop reporting aborted media downloads as fatal

### DIFF
--- a/mobile/lib/utils/platform_io_web.dart
+++ b/mobile/lib/utils/platform_io_web.dart
@@ -125,6 +125,27 @@ class SocketException implements Exception {
   String toString() => 'SocketException: $message';
 }
 
+// HttpException stub for web platform. Web has no dart:io HTTP client, so this
+// is never thrown or instantiated — it exists so `is HttpException` checks
+// compile for web and correctly evaluate to false. `toString()` mirrors
+// `dart:io`'s, which appends the uri only when one was supplied.
+class HttpException implements Exception {
+  const HttpException(this.message, {this.uri});
+
+  final String message;
+  final Uri? uri;
+
+  @override
+  String toString() {
+    final buffer = StringBuffer('HttpException: ')..write(message);
+    final uri = this.uri;
+    if (uri != null) {
+      buffer.write(', uri = $uri');
+    }
+    return buffer.toString();
+  }
+}
+
 // Process stub for web platform
 class Process {
   static Future<ProcessResult> run(

--- a/mobile/lib/utils/recoverable_flutter_error.dart
+++ b/mobile/lib/utils/recoverable_flutter_error.dart
@@ -86,7 +86,10 @@ RecoverableFlutterError? classifyRecoverableFlutterError(
   // kills the socket), so gate on the HttpException type rather than
   // enumerating messages that keep arriving one Crashlytics issue at a time.
   // The string arm stays because a codec-wrapped load arrives already
-  // stringified, with the typed exception no longer reachable.
+  // stringified, with the typed exception no longer reachable. Being an `is`
+  // check it also takes flutter_cache_manager's HttpExceptionWithStatus, so a
+  // non-2xx CachedNetworkImage thumbnail ('Invalid statusCode: 404', which no
+  // string arm matches) is recoverable here rather than fatal.
   final isInterruptedMediaDownload =
       hasRecoverableMediaHost &&
       (details.exception is io.HttpException ||

--- a/mobile/lib/utils/recoverable_flutter_error.dart
+++ b/mobile/lib/utils/recoverable_flutter_error.dart
@@ -1,3 +1,7 @@
+import 'dart:io'
+    if (dart.library.js_interop) 'package:openvine/utils/platform_io_web.dart'
+    as io;
+
 import 'package:flutter/material.dart';
 import 'package:media_cache/media_cache.dart';
 import 'package:openvine/utils/expected_network_error.dart';
@@ -75,9 +79,18 @@ RecoverableFlutterError? classifyRecoverableFlutterError(
   final isMediaHostLookup =
       error.contains('SocketException') && hasRecoverableMediaHost;
 
+  // A media download the transport tears down mid-flight is recoverable — the
+  // widget falls back to a placeholder. dart:io words these differently per
+  // platform and per abort point ('Connection closed while receiving data'
+  // when the parser runs dry, 'Software caused connection abort' when the OS
+  // kills the socket), so gate on the HttpException type rather than
+  // enumerating messages that keep arriving one Crashlytics issue at a time.
+  // The string arm stays because a codec-wrapped load arrives already
+  // stringified, with the typed exception no longer reachable.
   final isInterruptedMediaDownload =
-      error.contains('Connection closed while receiving data') &&
-      hasRecoverableMediaHost;
+      hasRecoverableMediaHost &&
+      (details.exception is io.HttpException ||
+          error.contains('Connection closed while receiving data'));
 
   final isMissingHttpHost =
       library == 'dart:_http' && error.contains('No host specified in URI');

--- a/mobile/lib/utils/recoverable_flutter_error.dart
+++ b/mobile/lib/utils/recoverable_flutter_error.dart
@@ -91,8 +91,8 @@ RecoverableFlutterError? classifyRecoverableFlutterError(
   // non-2xx CachedNetworkImage thumbnail ('Invalid statusCode: 404', which no
   // string arm matches) is recoverable here rather than fatal.
   final isInterruptedMediaDownload =
-      hasRecoverableMediaHost &&
-      (details.exception is io.HttpException ||
+      _isRecoverableMediaHttpException(details.exception) ||
+      (hasRecoverableMediaHost &&
           error.contains('Connection closed while receiving data'));
 
   final isMissingHttpHost =
@@ -119,9 +119,15 @@ RecoverableFlutterError? classifyRecoverableFlutterError(
     return (reason: _recoverableMediaLoadReason, report: false);
   }
 
+  // Interrupted downloads and non-2xx responses are expected network/IO
+  // failures. Keep them out of Crashlytics while still presenting the image
+  // fallback and recording the local warning.
+  if (isInterruptedMediaDownload) {
+    return (reason: _recoverableMediaLoadReason, report: false);
+  }
+
   if (isImageHttpFailure ||
       isMediaHostLookup ||
-      isInterruptedMediaDownload ||
       isMissingHttpHost ||
       isInvalidImageData) {
     return (reason: _recoverableMediaLoadReason, report: true);
@@ -143,6 +149,13 @@ RecoverableFlutterError? classifyRecoverableFlutterError(
   }
 
   return null;
+}
+
+bool _isRecoverableMediaHttpException(Object exception) {
+  if (exception is! io.HttpException) return false;
+
+  final host = exception.uri?.host;
+  return host != null && _recoverableMediaHosts.contains(host);
 }
 
 bool _containsRecoverableMediaHost(String value) {

--- a/mobile/test/utils/recoverable_flutter_error_test.dart
+++ b/mobile/test/utils/recoverable_flutter_error_test.dart
@@ -134,6 +134,40 @@ void main() {
       ));
     });
 
+    // The abort message dart:io uses when the OS kills the socket mid-download
+    // rather than the parser running dry. It reached Crashlytics as a FATAL
+    // (issue 198b20e41b65c26f4d7dcbd83993a011, 1.0.20) because the branch
+    // matched only the parser's wording, even though the failure is the same
+    // recoverable thumbnail load.
+    test('classifies aborted Divine media downloads as recoverable', () {
+      final details = FlutterErrorDetails(
+        exception: HttpException(
+          'Software caused connection abort',
+          uri: Uri.parse('https://media.divine.video/hash'),
+        ),
+        library: 'dart:_http',
+      );
+
+      expect(classifyRecoverableFlutterError(details), (
+        reason: 'Recoverable media load failure',
+        report: true,
+      ));
+    });
+
+    // The type arm must not swallow an HttpException from anywhere else — a
+    // failing app API call is not a placeholder-recoverable thumbnail.
+    test('keeps aborted downloads from other hosts fatal', () {
+      final details = FlutterErrorDetails(
+        exception: HttpException(
+          'Software caused connection abort',
+          uri: Uri.parse('https://api.example.com/thing'),
+        ),
+        library: 'dart:_http',
+      );
+
+      expect(classifyRecoverableFlutterError(details), isNull);
+    });
+
     test('classifies dart:_http missing-host URI failures as recoverable', () {
       final details = FlutterErrorDetails(
         exception: ArgumentError('No host specified in URI https:///thumb.jpg'),

--- a/mobile/test/utils/recoverable_flutter_error_test.dart
+++ b/mobile/test/utils/recoverable_flutter_error_test.dart
@@ -1,6 +1,8 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_cache_manager/flutter_cache_manager.dart'
+    show HttpExceptionWithStatus;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:media_cache/media_cache.dart';
 import 'package:openvine/utils/recoverable_flutter_error.dart';
@@ -166,6 +168,47 @@ void main() {
       );
 
       expect(classifyRecoverableFlutterError(details), isNull);
+    });
+
+    // Pins the string arm, which the type arm cannot stand in for: a
+    // codec-wrapped load arrives already stringified as a plain Exception, so
+    // `is HttpException` is false. Every other interrupted-download test now
+    // passes through the type arm, and without this one the string arm can be
+    // deleted with the suite still green.
+    test('keeps stringified interrupted media downloads recoverable', () {
+      final details = FlutterErrorDetails(
+        exception: Exception(
+          'HttpException: Connection closed while receiving data, '
+          'uri = https://media.divine.video/hash',
+        ),
+        library: 'dart:_http',
+      );
+
+      expect(classifyRecoverableFlutterError(details), (
+        reason: 'Recoverable media load failure',
+        report: true,
+      ));
+    });
+
+    // flutter_cache_manager reports every non-2xx as HttpExceptionWithStatus,
+    // a dart:io HttpException subclass whose 'Invalid statusCode' wording no
+    // string arm matches — so a dead CachedNetworkImage thumbnail was fatal
+    // before the type arm and is recoverable after it. Pins the arm as a
+    // subtype check rather than an exact-type one.
+    test('classifies cached-image non-2xx failures as recoverable', () {
+      final details = FlutterErrorDetails(
+        exception: HttpExceptionWithStatus(
+          404,
+          'Invalid statusCode: 404',
+          uri: Uri.parse('https://media.divine.video/hash'),
+        ),
+        library: 'dart:_http',
+      );
+
+      expect(classifyRecoverableFlutterError(details), (
+        reason: 'Recoverable media load failure',
+        report: true,
+      ));
     });
 
     test('classifies dart:_http missing-host URI failures as recoverable', () {

--- a/mobile/test/utils/recoverable_flutter_error_test.dart
+++ b/mobile/test/utils/recoverable_flutter_error_test.dart
@@ -132,7 +132,7 @@ void main() {
 
       expect(classifyRecoverableFlutterError(details), (
         reason: 'Recoverable media load failure',
-        report: true,
+        report: false,
       ));
     });
 
@@ -152,7 +152,7 @@ void main() {
 
       expect(classifyRecoverableFlutterError(details), (
         reason: 'Recoverable media load failure',
-        report: true,
+        report: false,
       ));
     });
 
@@ -163,6 +163,18 @@ void main() {
         exception: HttpException(
           'Software caused connection abort',
           uri: Uri.parse('https://api.example.com/thing'),
+        ),
+        library: 'dart:_http',
+      );
+
+      expect(classifyRecoverableFlutterError(details), isNull);
+    });
+
+    test('keeps aborted downloads from Divine non-media hosts fatal', () {
+      final details = FlutterErrorDetails(
+        exception: HttpException(
+          'Software caused connection abort',
+          uri: Uri.parse('https://api.divine.video/thing'),
         ),
         library: 'dart:_http',
       );
@@ -186,7 +198,7 @@ void main() {
 
       expect(classifyRecoverableFlutterError(details), (
         reason: 'Recoverable media load failure',
-        report: true,
+        report: false,
       ));
     });
 
@@ -207,7 +219,7 @@ void main() {
 
       expect(classifyRecoverableFlutterError(details), (
         reason: 'Recoverable media load failure',
-        report: true,
+        report: false,
       ));
     });
 


### PR DESCRIPTION
Closes #7871

## What

A thumbnail load that the transport tears down mid-flight was reaching Crashlytics as a **FATAL** crash, even though nothing crashed. Downgrade it to the same recoverable path its sibling failure already takes.

Found while triaging Crashlytics: [`198b20e41b65c26f4d7dcbd83993a011`](https://console.firebase.google.com/v1/appid/project/openvine-co/crashlytics/app/1:972941478875:android:c716006682f92d9444b5fe/issues/198b20e41b65c26f4d7dcbd83993a011) — fresh on 1.0.20, 4 events / 3 users.

```
io.flutter.plugins.firebase.crashlytics.FlutterError:
HttpException: Software caused connection abort, uri = https://media.divine.video/<hash>
  at FirebaseCrashlytics.recordFlutterFatalError
  at CrashReportingService.initialize.<fn>          (crash_reporting_service.dart:50)
  at _startOpenVineApp.<fn>                          (main.dart:1220)
  at FlutterError.reportError
  at ImageStreamCompleter.reportError
  at new MultiFrameImageStreamCompleter.<fn>
```

The stack is a plain image-load failure: `MultiFrameImageStreamCompleter` reports a failed download through `FlutterError.onError`, which forwards to `recordFlutterFatalError`. The sample event has `processState: BACKGROUND` and the report runs on the Firebase background thread — the app was alive and the widget fell back to a placeholder. The only real damage is a polluted dashboard and a crash-free-users rate that understates reality.

`.claude/rules/error_handling.md` puts "Network / IO (timeout, dropped connection, DNS)" in the not-reportable row, so this was never meant to be fatal.

## Why the fix is a type check rather than another string

`classifyRecoverableFlutterError` already downgrades this exact failure — same host, same image path — when dart:io words it `Connection closed while receiving data`. That is what the HTTP parser says when it runs dry. `Software caused connection abort` is what you get when the OS kills the socket instead. Same class of failure, different abort point, different wording, and the branch matched only the first one.

Adding the second string would have worked until the third wording arrives as its own Crashlytics issue. Both are `dart:io` `HttpException`s, so the branch now gates on the type. Two things keep that from over-matching:

- Typed exceptions are scoped by their URI host to the configured media hosts, so aborted calls to unrelated endpoints — including non-media Divine subdomains — stay fatal. Tests pin both cases.
- Expected interrupted downloads are logged locally but stay out of Crashlytics entirely, matching the repository reporting policy.
- The string arm stays, because a codec-wrapped load arrives already stringified with the typed exception no longer reachable — dropping it would have narrowed coverage.

Being an `is` check rather than an exact-type one, the arm also takes `flutter_cache_manager`'s `HttpExceptionWithStatus`, which subclasses `dart:io`'s. That means a non-2xx `CachedNetworkImage` thumbnail — worded `Invalid statusCode: 404`, which no string arm matches and which `isImageHttpFailure` misses because that branch keys on Flutter's own `HTTP request failed, statusCode: ` wording — moves from fatal to recoverable too. That is the same class of dead-thumbnail failure and wanted, but it is a real second behaviour change rather than a side note, so it is pinned by its own test and called out at the branch.

The web IO shim gains an `HttpException` stub for the same reason it already carries a `SocketException` one: the `is` check has to compile on web, where it is always false.

## Test plan

- `flutter analyze lib test` — no issues
- `flutter test test/utils/recoverable_flutter_error_test.dart` — 25/25, including five new cases: the real crash string classifies as recoverable, the same abort from an unrelated host stays fatal, the same abort from a Divine non-media host stays fatal, a stringified interrupted download still matches the string arm, and a cached-image non-2xx matches the type arm by subtype
- `flutter build web --release` — compiles clean locally; the refreshed `Build Flutter Web Preview` CI job also passed on the takeover head.
- Confirmed each new test **fails** for its own reason, one at a time:
  - reverting the classifier reddens `classifies aborted Divine media downloads as recoverable`
  - deleting the string arm reddens `keeps stringified interrupted media downloads recoverable` and nothing else — before that test existed the arm could be deleted with the whole suite still green
  - narrowing the type arm to `runtimeType ==` reddens `classifies cached-image non-2xx failures as recoverable` and nothing else

### On a real Samsung Galaxy (SM-S942B)

The failure turned out to be trivially forcible, contrary to an earlier note here: a debug build, a scroll burst through the Explore grid, then `svc wifi disable; svc data disable` mid-transfer. That produced, **in the same burst**, both wordings from `media.divine.video`:

```
HttpException: Software caused connection abort, uri = https://media.divine.video/d47fbf57…
HttpException: Connection closed while receiving data, uri = https://media.divine.video/39852abe…
```

That is direct field evidence for this PR's premise — one failure, two wordings separated only by where the transport gave up — and is why the branch gates on the type instead of collecting messages.

What the run did **not** show is the classifier running: no `Recoverable media load failure (non-fatal)` line appeared. That is expected rather than a miss. Flutter routes an image error to `FlutterError` only when the stream carries no error listener, and `Image` attaches one only when an `errorBuilder` is set — every thumbnail surface reachable in that flow sets one, so the widget consumed the errors itself (`[Image.network] Thumbnail load failed …` in logcat). The absence is a real signal and not a logging artifact: the handler logs at warning level with no category, and a sibling warning printed in the same session.

Two things follow. It explains the issue's small volume — 4 events / 3 users — against an exception this easy to reproduce: nearly every surface is already guarded, so only a rare unguarded one reaches `FlutterError`. And it is the argument for fixing at the classifier rather than per widget, since the classifier covers whatever unguarded surface exists without anyone having to enumerate them first.




