### PR TITLE
fix(recorder): stop countdown beeps from clamping the iOS mic gain

### DIFF
--- a/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
+++ b/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
@@ -793,11 +793,11 @@ class VideoRecorderBloc
         emit(state.copyWith(countdownValue: i));
 
         unawaited(_countdownSoundService!.playShortBeep());
+        // The last tick is shortened by exactly as long as the "go" beep
+        // takes to play out, so recording still starts on the second.
         final delay = i > 1
             ? const Duration(seconds: 1)
-            : const Duration(seconds: 1) -
-                  CountdownSoundService.longBeepDuration -
-                  CountdownSoundService.postPlaybackBuffer;
+            : _countdownSoundService!.finalTickLeadIn;
         await Future<void>.delayed(delay);
       }
 

--- a/mobile/packages/sound_service/lib/src/countdown_sound_service.dart
+++ b/mobile/packages/sound_service/lib/src/countdown_sound_service.dart
@@ -26,7 +26,9 @@ typedef AudioPlayerFactory = SimpleAudioPlayer Function();
 ///
 /// for (var i = 3; i > 0; i--) {
 ///   await service.playShortBeep();
-///   await Future.delayed(Duration(seconds: 1));
+///   await Future.delayed(
+///     i > 1 ? const Duration(seconds: 1) : service.finalTickLeadIn,
+///   );
 /// }
 ///
 /// await service.playLongBeepAndWait();
@@ -39,11 +41,25 @@ class CountdownSoundService {
   CountdownSoundService({AudioPlayerFactory? audioPlayerFactory})
     : _audioPlayerFactory = audioPlayerFactory ?? JustAudioSimplePlayer.new;
 
-  /// Duration of the short countdown tick beep.
-  static const shortBeepDuration = Duration(milliseconds: 15);
+  /// Playback volume applied to both countdown beeps.
+  ///
+  /// The beeps leave the speaker while the camera microphone is already
+  /// capturing, and on iPhone the bottom speaker sits centimetres from the
+  /// bottom mic. Both assets peak at -7.4 dBFS, so at full level the "go"
+  /// beep drives the input near clipping and the automatic gain control
+  /// that `AVAudioSessionMode.videoRecording` leaves enabled clamps the mic
+  /// gain moments before capture starts. Its release curve runs for
+  /// seconds — that is the progressive volume ramp reported in #4539.
+  /// Attenuating by ~10 dB puts the beep peak near -18 dBFS while keeping
+  /// it clearly audible.
+  static const beepVolume = 0.3;
 
-  /// Duration of the long "go" beep played after countdown reaches zero.
-  static const longBeepDuration = Duration(milliseconds: 60);
+  /// Play-out duration assumed for the long "go" beep before [preload] has
+  /// measured the asset.
+  ///
+  /// Matches `countdown_beep_long.wav`; [longBeepDuration] reports the real
+  /// value once the player has loaded it.
+  static const longBeepFallbackDuration = Duration(milliseconds: 600);
 
   /// Buffer added after long beep playback to ensure audio fully completes.
   ///
@@ -63,26 +79,53 @@ class CountdownSoundService {
   final AudioPlayerFactory _audioPlayerFactory;
   SimpleAudioPlayer? _shortBeepPlayer;
   SimpleAudioPlayer? _longBeepPlayer;
+  Duration _longBeepDuration = longBeepFallbackDuration;
   bool _isDisposed = false;
+
+  /// Play-out duration of the long "go" beep, as reported by the player
+  /// during [preload].
+  Duration get longBeepDuration => _longBeepDuration;
+
+  /// How long to hold the final countdown tick before starting the "go"
+  /// beep, so that beep plus [postPlaybackBuffer] lands exactly one second
+  /// after the tick appeared.
+  ///
+  /// Clamped at [Duration.zero] for assets longer than that second.
+  Duration get finalTickLeadIn {
+    final leadIn =
+        const Duration(seconds: 1) - _longBeepDuration - postPlaybackBuffer;
+    return leadIn.isNegative ? Duration.zero : leadIn;
+  }
 
   /// Pre-loads both countdown sound assets for instant playback.
   ///
-  /// Call this once before the countdown loop begins.
+  /// Call this once before the countdown loop begins. Players left over
+  /// from an earlier countdown are released first.
   ///
   /// Throws [Exception] if assets fail to load (caller should handle
   /// gracefully — countdown sounds are best-effort).
   Future<void> preload() async {
+    await _disposePlayers();
+
     try {
       _shortBeepPlayer = _audioPlayerFactory();
       _longBeepPlayer = _audioPlayerFactory();
 
-      await Future.wait([
+      final durations = await Future.wait([
         _shortBeepPlayer!.setAsset(shortBeepAsset),
         _longBeepPlayer!.setAsset(longBeepAsset),
       ]);
 
+      await Future.wait([
+        _shortBeepPlayer!.setVolume(beepVolume),
+        _longBeepPlayer!.setVolume(beepVolume),
+      ]);
+
+      _longBeepDuration = durations.last ?? longBeepFallbackDuration;
+
       Log.debug(
-        'Countdown sounds preloaded',
+        'Countdown sounds preloaded '
+        '(long beep ${_longBeepDuration.inMilliseconds}ms)',
         name: 'CountdownSoundService',
         category: LogCategory.video,
       );
@@ -143,6 +186,10 @@ class CountdownSoundService {
   /// Releases audio player resources.
   Future<void> dispose() async {
     _isDisposed = true;
+    await _disposePlayers();
+  }
+
+  Future<void> _disposePlayers() async {
     await _shortBeepPlayer?.dispose();
     await _longBeepPlayer?.dispose();
     _shortBeepPlayer = null;

--- a/mobile/packages/sound_service/lib/src/simple_audio_player.dart
+++ b/mobile/packages/sound_service/lib/src/simple_audio_player.dart
@@ -13,6 +13,10 @@ abstract interface class SimpleAudioPlayer {
   /// Loads an asset at [assetPath] and returns the audio duration.
   Future<Duration?> setAsset(String assetPath);
 
+  /// Sets the playback volume, where `0.0` is silent and `1.0` plays the
+  /// asset at its own level.
+  Future<void> setVolume(double volume);
+
   /// Seeks to the given [position].
   Future<void> seek(Duration position);
 
@@ -58,6 +62,9 @@ class JustAudioSimplePlayer implements SimpleAudioPlayer {
 
   @override
   Future<Duration?> setAsset(String assetPath) => _player.setAsset(assetPath);
+
+  @override
+  Future<void> setVolume(double volume) => _player.setVolume(volume);
 
   @override
   Future<void> seek(Duration position) => _player.seek(position);

--- a/mobile/packages/sound_service/test/src/countdown_sound_service_test.dart
+++ b/mobile/packages/sound_service/test/src/countdown_sound_service_test.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Tests for CountdownSoundService - countdown beep playback.
-// ABOUTME: Covers preload, playShortBeep, playLongBeepAndWait, dispose,
-// ABOUTME: and error/edge-case handling using mocktail SimpleAudioPlayer mocks.
+// ABOUTME: Covers preload, beep attenuation, tick timing, playShortBeep,
+// ABOUTME: playLongBeepAndWait, dispose, and error/edge-case handling using
+// ABOUTME: mocktail SimpleAudioPlayer mocks.
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -31,6 +32,12 @@ void main() {
           return factoryCallCount == 1 ? mockShortPlayer : mockLongPlayer;
         },
       );
+
+      for (final player in [mockShortPlayer, mockLongPlayer]) {
+        when(
+          () => player.setVolume(CountdownSoundService.beepVolume),
+        ).thenAnswer((_) async {});
+      }
     });
 
     group('preload', () {
@@ -51,6 +58,80 @@ void main() {
         verify(
           () => mockLongPlayer.setAsset(CountdownSoundService.longBeepAsset),
         ).called(1);
+      });
+
+      test('attenuates both beeps so they cannot clamp the mic AGC', () async {
+        when(
+          () => mockShortPlayer.setAsset(any()),
+        ).thenAnswer((_) async => .zero);
+        when(
+          () => mockLongPlayer.setAsset(any()),
+        ).thenAnswer((_) async => .zero);
+
+        await service.preload();
+
+        verify(
+          () => mockShortPlayer.setVolume(CountdownSoundService.beepVolume),
+        ).called(1);
+        verify(
+          () => mockLongPlayer.setVolume(CountdownSoundService.beepVolume),
+        ).called(1);
+        expect(CountdownSoundService.beepVolume, lessThan(1.0));
+      });
+
+      test('records the long beep duration reported by the player', () async {
+        when(
+          () => mockShortPlayer.setAsset(any()),
+        ).thenAnswer((_) async => const Duration(milliseconds: 120));
+        when(
+          () => mockLongPlayer.setAsset(any()),
+        ).thenAnswer((_) async => const Duration(milliseconds: 600));
+
+        await service.preload();
+
+        expect(
+          service.longBeepDuration,
+          equals(const Duration(milliseconds: 600)),
+        );
+      });
+
+      test('falls back when the player reports no duration', () async {
+        when(
+          () => mockShortPlayer.setAsset(any()),
+        ).thenAnswer((_) async => null);
+        when(
+          () => mockLongPlayer.setAsset(any()),
+        ).thenAnswer((_) async => null);
+
+        await service.preload();
+
+        expect(
+          service.longBeepDuration,
+          equals(CountdownSoundService.longBeepFallbackDuration),
+        );
+      });
+
+      test('releases the players created by an earlier preload', () async {
+        final players = List.generate(4, (_) => _MockSimpleAudioPlayer());
+        var index = 0;
+        for (final player in players) {
+          when(() => player.setAsset(any())).thenAnswer((_) async => .zero);
+          when(
+            () => player.setVolume(CountdownSoundService.beepVolume),
+          ).thenAnswer((_) async {});
+          when(player.dispose).thenAnswer((_) async {});
+        }
+        final reused = CountdownSoundService(
+          audioPlayerFactory: () => players[index++],
+        );
+
+        await reused.preload();
+        await reused.preload();
+
+        verify(players[0].dispose).called(1);
+        verify(players[1].dispose).called(1);
+        verifyNever(players[2].dispose);
+        verifyNever(players[3].dispose);
       });
 
       test('disposes players and rethrows when setAsset fails', () async {
@@ -174,6 +255,48 @@ void main() {
         await service.dispose();
         // Second dispose should not throw (players are null).
         await expectLater(service.dispose(), completes);
+      });
+    });
+
+    group('finalTickLeadIn', () {
+      test('defaults to the declared asset duration before preload', () {
+        expect(
+          service.finalTickLeadIn,
+          equals(
+            const Duration(seconds: 1) -
+                CountdownSoundService.longBeepFallbackDuration -
+                CountdownSoundService.postPlaybackBuffer,
+          ),
+        );
+      });
+
+      test('shortens the final tick by the measured go beep', () async {
+        when(
+          () => mockShortPlayer.setAsset(any()),
+        ).thenAnswer((_) async => .zero);
+        when(
+          () => mockLongPlayer.setAsset(any()),
+        ).thenAnswer((_) async => const Duration(milliseconds: 400));
+
+        await service.preload();
+
+        expect(
+          service.finalTickLeadIn,
+          equals(const Duration(milliseconds: 450)),
+        );
+      });
+
+      test('clamps to zero for a go beep longer than the tick', () async {
+        when(
+          () => mockShortPlayer.setAsset(any()),
+        ).thenAnswer((_) async => .zero);
+        when(
+          () => mockLongPlayer.setAsset(any()),
+        ).thenAnswer((_) async => const Duration(seconds: 2));
+
+        await service.preload();
+
+        expect(service.finalTickLeadIn, equals(Duration.zero));
       });
     });
 


### PR DESCRIPTION
## Description

Recordings started with the countdown timer ramp up in volume on iOS: with steady speech, a 6s clip ends audibly louder than it starts. #4539 was closed by #4548, which removed a real but different interference path — just_audio reconfiguring the camera-owned `AVAudioSession` — and the reports continued.

The remaining path is acoustic rather than session-level:

- The camera's dedicated audio `AVCaptureSession` is pre-built and started about a second after the first preview frame (`CameraController.attachAudioToSessionIfNeeded`), so the microphone is live for the whole countdown, not just from the record tap.
- That session runs `.playAndRecord` with mode `.videoRecording`, which leaves the system's automatic gain control enabled.
- The beeps go out of the speaker, which on iPhone sits centimetres from the bottom mic. Both assets peak at -7.4 dBFS and the "go" beep carries 488ms of tone, so at full level it drives the input close to clipping.
- `playLongBeepAndWait()` returns 150ms after the beep finishes and recording starts immediately after. The AGC release curve runs for seconds, so capture begins with the mic gain at its floor and recovers across the entire clip.

Changes:

- Attenuate both countdown beeps to `0.3` (~-10 dB, peak near -18 dBFS). They stay clearly audible but no longer push the AGC. `SimpleAudioPlayer` gains a `setVolume` method for this.
- Derive the final tick's lead-in from the duration the player reports for the asset instead of a hardcoded 60ms. `countdown_beep_long.wav` is 600ms, so the old constant stretched the last countdown second to roughly 1.43s. `finalTickLeadIn` lives on `CountdownSoundService` because that is the only place that knows the beep's real length, and it is clamped at zero.
- Drop the unused `shortBeepDuration` constant — it declared 15ms against an 88ms tone and was referenced nowhere.

**Related Issue:** Closes #4539

## Out of Scope

Not requested by the report, called out separately: `preload()` runs once per countdown and replaced both players without disposing the previous pair, leaking two just_audio players per recording. Fixed here because it sits in the same method the volume change touches.

If device testing shows the ramp survives at `0.3`, the next lever is `AVAudioSessionMode.measurement` on the camera's session, which disables AGC outright. That is a much larger behavioural change — it also removes system noise suppression and lowers the overall input level — so it is deliberately not in this PR.

## Verification

- `flutter analyze lib test integration_test` — no issues.
- `flutter test` in `mobile/packages/sound_service` — 122 passed, line coverage 333/333 (100%, which is that package's CI gate).
- `flutter test test/blocs/video_recorder test/widgets/video_recorder` — 403 passed.
- Asset levels measured with `ffmpeg volumedetect` / `silencedetect`: both beeps peak at -7.4 dBFS; tone spans 12-100ms (short) and 12-500ms (long), against the 15ms / 60ms the code declared.

Still open, which is why this is a draft: **the fix is not yet confirmed on a device, and one attempt to confirm the mechanism came back negative.** Recording with the countdown on unmodified code at maximum media volume produced no ramp on an iPhone 12. That device has never reproduced the bug in any configuration, so the result is an unaffected baseline rather than a refutation — the loud/quiet A/B only discriminates on hardware that shows the ramp reliably. Treat the mechanism below as the leading hypothesis, not an established cause.

For context on how it was derived: The root cause is inferred from the code path and the measured asset levels, and the ramp does not reproduce on an iPhone 12 or iPad — consistent with the effect scaling with media volume, speaker-to-mic geometry, and whether headphones are connected. The normal Samsung Galaxy pass does not apply; this is an iOS-only path.

Two checks worth running on an affected device before this leaves draft:

1. Record with the countdown at full media volume, then again with media volume at zero or with headphones plugged in. If the ramp only appears in the first case, the acoustic mechanism is confirmed.
2. Compare a countdown recording before and after this change with `ffmpeg -i clip.mp4 -af ebur128=framelog=verbose -f null -` and check that momentary loudness stays flat.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
