### PR TITLE
test(profile): pin the single isOwnProfile flag behind the followers stat

### DIFF
--- a/mobile/test/widgets/profile/profile_followers_stat_test.dart
+++ b/mobile/test/widgets/profile/profile_followers_stat_test.dart
@@ -1,0 +1,91 @@
+// ABOUTME: Tests for ProfileFollowersStat, the profile header's followers column
+// ABOUTME: Pins the single isOwnProfile flag that gates the OthersFollowersBloc read
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/blocs/others_followers/others_followers_bloc.dart';
+import 'package:openvine/widgets/profile/profile_followers_stat.dart';
+
+import '../../helpers/test_provider_overrides.dart';
+
+class _MockOthersFollowersBloc
+    extends MockBloc<OthersFollowersEvent, OthersFollowersState>
+    implements OthersFollowersBloc {}
+
+const _targetPubkey =
+    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+void main() {
+  group(ProfileFollowersStat, () {
+    late _MockOthersFollowersBloc othersFollowersBloc;
+
+    setUp(() {
+      othersFollowersBloc = _MockOthersFollowersBloc();
+      when(() => othersFollowersBloc.state).thenReturn(
+        const OthersFollowersState(
+          status: OthersFollowersStatus.success,
+          followersPubkeys: ['a', 'b', 'c'],
+          rawFollowersPubkeys: ['a', 'b', 'c'],
+          authoritativeFollowerCount: 42,
+          targetPubkey: _targetPubkey,
+        ),
+      );
+    });
+
+    /// Mirrors [ProfileGridView]: the ancestor `OthersFollowersBloc` exists
+    /// only for other people's profiles, and the same flag is handed down to
+    /// the stat. Both must be driven by one value — see below.
+    Widget buildSubject({required bool isOwnProfile}) {
+      final stat = ProfileFollowersStat(
+        pubkey: _targetPubkey,
+        displayName: 'Target',
+        isOwnProfile: isOwnProfile,
+        initialCount: 7,
+      );
+
+      return testMaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            width: 120,
+            child: isOwnProfile
+                ? stat
+                : BlocProvider<OthersFollowersBloc>.value(
+                    value: othersFollowersBloc,
+                    child: stat,
+                  ),
+          ),
+        ),
+      );
+    }
+
+    testWidgets('shows the ancestor bloc count on another profile', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildSubject(isOwnProfile: false));
+      await tester.pump();
+
+      expect(find.text('42'), findsOneWidget);
+    });
+
+    // Regression guard for #1695 (Crashlytics `Provider<OthersFollowersBloc>
+    // not found for BlocBuilder<OthersFollowersBloc, OthersFollowersState>`,
+    // #6527). The stat used to decide "is this me?" from
+    // `nostrServiceProvider.publicKey` while ProfileGridView gated the
+    // provider on `authService.currentPublicKeyHex`. During startup the two
+    // disagreed, so an own profile got no provider but still built the
+    // other-profile view. Any second source of truth reintroduces that crash
+    // here, because this tree deliberately has no OthersFollowersBloc.
+    testWidgets('never reads OthersFollowersBloc on the own profile', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildSubject(isOwnProfile: true));
+      await tester.pump();
+
+      expect(tester.takeException(), isNull);
+      expect(find.byType(ProfileFollowersStat), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
Closes #7874

## Description

Investigating #6527 turned up no live defect to fix — the crash it asks about was fixed in 1.0.7 — but the contract that fixes it had no test, so this PR adds one.

Crashlytics issue `a8c821212ea690bd4ecf96e4a9d696c9` carries a sample reading `Provider<OthersFollowersBloc> not found for BlocBuilder<OthersFollowersBloc, OthersFollowersState>`. Only two such `BlocBuilder`s exist. The one in `others_followers_screen.dart` sits directly under its own `MultiBlocProvider`, so the reachable one is `_OthersFollowersStatView` in `mobile/lib/widgets/profile/profile_followers_stat.dart`, whose provider comes from an ancestor: `ProfileGridView` mounts `BlocProvider<OthersFollowersBloc>` only when `!isOwnProfile`.

At 1.0.4 — the version the Crashlytics issue was first seen on — the two ends disagreed. `ProfileGridView` gated the provider on `authService.currentPublicKeyHex`, while `ProfileFollowersStat` ran its own check, `pubkey == ref.watch(nostrServiceProvider).publicKey`. Those resolve at different times during startup, so an own profile could be "mine" to the grid (no provider) and "not mine" to the stat (other-profile view, unguarded `BlocBuilder`) in the same frame. #2150 replaced the second check with an `isOwnProfile` flag passed down from the parent and shipped in 1.0.7; no `OthersFollowersBloc` event has been recorded since.

`profile_followers_stat.dart` has never had a test file, so nothing stops a second source of truth from coming back. The two tests added here render the widget with, and without, an ancestor `OthersFollowersBloc`:

- other profile, provider present → the ancestor bloc's count renders;
- own profile, **no provider anywhere in the tree** → nothing looks the bloc up.

Reintroducing the pre-#2150 check (verified locally by restoring `ref.watch(nostrServiceProvider).publicKey == pubkey` alongside the flag) turns the second test red with the exact production exception: `ProviderNotFoundException: Could not find the correct Provider<OthersFollowersBloc>`.

**Related Issue:**  — #6527 is closed by the investigation write-up posted on it; this PR only adds the missing guard.

## Out of Scope

- No production code changes. The wiring bug is already fixed; this PR only pins it.
- #6528 proposes deleting `profile_followers_stat.dart` as dead code. It is not dead — `ProfileHeaderWidget` renders it via `_ProfileStatsRow` at `profile_header_media.dart:355`, which is a `part` of `profile_header_widget.dart` and therefore invisible to an import-based search. Correction posted on that issue; not changed here.

## Verification

Run from `mobile/`:

- `flutter test test/widgets/profile/profile_followers_stat_test.dart` — 2 passed
- `flutter test test/widgets/profile/` — 336 passed
- `flutter analyze lib test integration_test` — No issues found
- `dart format` — 1 file checked, 0 changed
- Failure check: with the pre-#2150 second check restored in `lib/`, `never reads OthersFollowersBloc on the own profile` fails with `ProviderNotFoundException`; `lib/` was restored afterwards and is untouched in this diff.

No device pass and no screenshots: the diff is a test file, and no runtime code is touched.

## Type of Change

- [x] 🗑️ Chore