### PR TITLE
fix(camera): stop the iOS editor from playing clips with the recorder's audio settings

### DIFF
--- a/mobile/packages/divine_camera/ios/Classes/CameraController.swift
+++ b/mobile/packages/divine_camera/ios/Classes/CameraController.swift
@@ -2672,9 +2672,8 @@ class CameraController: NSObject {
         initializationTimeoutTimer = nil
         initializationCompletion = nil
         
-        // Strong capture on purpose: the plugin drops its reference as soon
-        // as this returns, so a weak capture could deallocate the controller
-        // before the queued teardown ever runs.
+        // Strong capture on purpose: a `guard let self else { return }` here
+        // would drop `completion` and hang the caller awaiting the teardown.
         sessionQueue.async {
             // Stop recording if in progress
             if self.isRecording {

--- a/mobile/packages/divine_camera/ios/Classes/CameraController.swift
+++ b/mobile/packages/divine_camera/ios/Classes/CameraController.swift
@@ -2653,7 +2653,15 @@ class CameraController: NSObject {
     }
 
     /// Releases all camera resources.
-    func release() {
+    ///
+    /// `completion` fires on the main queue once the teardown has actually
+    /// run on `sessionQueue`. The recorder -> editor handoff needs that
+    /// signal: it switches the shared AVAudioSession to `.playback` right
+    /// after disposing the camera, and iOS rejects that `setCategory` with
+    /// `InsufficientPriority` (OSStatus 561017449) while an audio capture
+    /// session is still running. The editor then plays the clip back through
+    /// the recorder's `.playAndRecord` / `.videoRecording` configuration.
+    func release(completion: (() -> Void)? = nil) {
         // Restore screen brightness if screen flash was enabled
         disableScreenFlash()
         // Disable auto-flash if it was enabled
@@ -2664,9 +2672,10 @@ class CameraController: NSObject {
         initializationTimeoutTimer = nil
         initializationCompletion = nil
         
-        sessionQueue.async { [weak self] in
-            guard let self = self else { return }
-            
+        // Strong capture on purpose: the plugin drops its reference as soon
+        // as this returns, so a weak capture could deallocate the controller
+        // before the queued teardown ever runs.
+        sessionQueue.async {
             // Stop recording if in progress
             if self.isRecording {
                 self.isRecording = false
@@ -2706,6 +2715,10 @@ class CameraController: NSObject {
             self.latestSampleBuffer = nil
             self.pixelBufferRef = nil
             self.pixelBufferLock.unlock()
+
+            if let completion {
+                DispatchQueue.main.async(execute: completion)
+            }
         }
     }
 }

--- a/mobile/packages/divine_camera/ios/Classes/DivineCameraPlugin.swift
+++ b/mobile/packages/divine_camera/ios/Classes/DivineCameraPlugin.swift
@@ -308,9 +308,21 @@ public class DivineCameraPlugin: NSObject, FlutterPlugin {
     private func disposeCamera(result: @escaping FlutterResult) {
         volumeKeyHandler?.release()
         volumeKeyHandler = nil
-        cameraController?.release()
+
+        guard let controller = cameraController else {
+            result(nil)
+            return
+        }
         cameraController = nil
-        result(nil)
+        // Return only once the capture sessions are actually stopped. The
+        // caller switches the shared AVAudioSession to playback immediately
+        // after this future resolves, and iOS refuses that category change
+        // with InsufficientPriority while the audio capture session is still
+        // running -- which left the editor playing back through the
+        // recorder's session configuration.
+        controller.release {
+            result(nil)
+        }
     }
     
     private func setRemoteRecordControlEnabled(enabled: Bool, result: @escaping FlutterResult) {

--- a/mobile/packages/divine_camera/test/ios_audio_session_handoff_contract_test.dart
+++ b/mobile/packages/divine_camera/test/ios_audio_session_handoff_contract_test.dart
@@ -14,8 +14,9 @@ String _readNativeSource(String fileName) {
   return file.readAsStringSync();
 }
 
-/// Returns the Swift declaration starting at [signature] up to its closing
-/// brace, so an assertion cannot match an identical line elsewhere in the file.
+/// Returns the Swift declaration or block starting at [signature] up to its
+/// closing brace, so an assertion cannot match an identical line elsewhere in
+/// the file, nor a line that sits outside the scope being asserted on.
 String _declarationAt(String source, String signature) {
   final start = source.indexOf(signature);
   if (start < 0) {
@@ -72,9 +73,23 @@ void main() {
         release,
         startsWith('func release(completion: (() -> Void)? = nil) {'),
       );
+
+      // Pin the dispatch inside the queued teardown and after the capture
+      // sessions stop. Asserting `contains` over the whole declaration still
+      // passes when the dispatch is hoisted out of the block, or moved to its
+      // top -- and either of those fires the completion before the capture
+      // sessions are stopped, which is the bug this file guards.
+      final teardown = _declarationAt(release, 'sessionQueue.async {');
+      expect(teardown, contains('self.audioCaptureSession?.stopRunning()'));
       expect(
-        release,
+        teardown,
         contains('DispatchQueue.main.async(execute: completion)'),
+      );
+      expect(
+        teardown.indexOf('DispatchQueue.main.async(execute: completion)'),
+        greaterThan(
+          teardown.indexOf('self.audioCaptureSession?.stopRunning()'),
+        ),
       );
     });
 

--- a/mobile/packages/divine_camera/test/ios_audio_session_handoff_contract_test.dart
+++ b/mobile/packages/divine_camera/test/ios_audio_session_handoff_contract_test.dart
@@ -1,0 +1,68 @@
+// ABOUTME: Static guards for the iOS recorder-to-editor audio-session handoff.
+// ABOUTME: disposeCamera must not resolve before the capture sessions stop.
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+String _readNativeSource(String fileName) {
+  final file = [
+    File('ios/Classes/$fileName'),
+    File('packages/divine_camera/ios/Classes/$fileName'),
+  ].firstWhere((file) => file.existsSync());
+
+  return file.readAsStringSync();
+}
+
+void main() {
+  group('iOS camera dispose audio-session handoff', () {
+    late final String pluginSource;
+    late final String controllerSource;
+
+    setUpAll(() {
+      pluginSource = _readNativeSource('DivineCameraPlugin.swift');
+      controllerSource = _readNativeSource('CameraController.swift');
+    });
+
+    test('disposeCamera resolves through the teardown completion', () {
+      // Resolving before CameraController.release() has stopped the capture
+      // sessions makes the caller's setCategory(.playback) fail with
+      // InsufficientPriority (OSStatus 561017449), which leaves the editor
+      // playing back through the recorder's .playAndRecord session.
+      expect(pluginSource, contains('controller.release {'));
+      expect(
+        pluginSource,
+        isNot(
+          contains(
+            'cameraController?.release()\n'
+            '        cameraController = nil\n'
+            '        result(nil)',
+          ),
+        ),
+      );
+    });
+
+    test('release exposes a completion and fires it after teardown', () {
+      expect(
+        controllerSource,
+        contains('func release(completion: (() -> Void)? = nil) {'),
+      );
+      expect(
+        controllerSource,
+        contains('DispatchQueue.main.async(execute: completion)'),
+      );
+    });
+
+    test('release retains the controller for its queued teardown', () {
+      // The plugin drops its reference as soon as release() returns, so a
+      // weak capture here could deallocate the controller before the
+      // teardown — and therefore the completion — ever ran.
+      expect(
+        controllerSource,
+        contains(
+          'sessionQueue.async {\n            // Stop recording if in progress',
+        ),
+      );
+    });
+  });
+}

--- a/mobile/packages/divine_camera/test/ios_audio_session_handoff_contract_test.dart
+++ b/mobile/packages/divine_camera/test/ios_audio_session_handoff_contract_test.dart
@@ -14,14 +14,39 @@ String _readNativeSource(String fileName) {
   return file.readAsStringSync();
 }
 
+/// Returns the Swift declaration starting at [signature] up to its closing
+/// brace, so an assertion cannot match an identical line elsewhere in the file.
+String _declarationAt(String source, String signature) {
+  final start = source.indexOf(signature);
+  if (start < 0) {
+    throw StateError('No declaration starting with "$signature".');
+  }
+
+  var depth = 0;
+  for (var i = source.indexOf('{', start); i < source.length; i++) {
+    if (source[i] == '{') depth++;
+    if (source[i] == '}') {
+      depth--;
+      if (depth == 0) return source.substring(start, i + 1);
+    }
+  }
+  throw StateError('Unbalanced braces after "$signature".');
+}
+
 void main() {
   group('iOS camera dispose audio-session handoff', () {
-    late final String pluginSource;
-    late final String controllerSource;
+    late final String disposeCamera;
+    late final String release;
 
     setUpAll(() {
-      pluginSource = _readNativeSource('DivineCameraPlugin.swift');
-      controllerSource = _readNativeSource('CameraController.swift');
+      disposeCamera = _declarationAt(
+        _readNativeSource('DivineCameraPlugin.swift'),
+        'private func disposeCamera(',
+      );
+      release = _declarationAt(
+        _readNativeSource('CameraController.swift'),
+        'func release(',
+      );
     });
 
     test('disposeCamera resolves through the teardown completion', () {
@@ -29,40 +54,34 @@ void main() {
       // sessions makes the caller's setCategory(.playback) fail with
       // InsufficientPriority (OSStatus 561017449), which leaves the editor
       // playing back through the recorder's .playAndRecord session.
-      expect(pluginSource, contains('controller.release {'));
+      expect(disposeCamera, contains('controller.release {'));
+      expect(disposeCamera, isNot(contains('cameraController?.release()')));
+    });
+
+    test('disposeCamera still answers when there is no camera', () {
+      // The completion is the only remaining path to `result`, so the
+      // no-controller case needs its own early return or Dart waits forever.
       expect(
-        pluginSource,
-        isNot(
-          contains(
-            'cameraController?.release()\n'
-            '        cameraController = nil\n'
-            '        result(nil)',
-          ),
-        ),
+        disposeCamera,
+        contains('guard let controller = cameraController'),
       );
     });
 
-    test('release exposes a completion and fires it after teardown', () {
+    test('release takes a completion and fires it after the teardown', () {
       expect(
-        controllerSource,
-        contains('func release(completion: (() -> Void)? = nil) {'),
+        release,
+        startsWith('func release(completion: (() -> Void)? = nil) {'),
       );
       expect(
-        controllerSource,
+        release,
         contains('DispatchQueue.main.async(execute: completion)'),
       );
     });
 
-    test('release retains the controller for its queued teardown', () {
-      // The plugin drops its reference as soon as release() returns, so a
-      // weak capture here could deallocate the controller before the
-      // teardown — and therefore the completion — ever ran.
-      expect(
-        controllerSource,
-        contains(
-          'sessionQueue.async {\n            // Stop recording if in progress',
-        ),
-      );
+    test('release retains the controller so the completion always fires', () {
+      // A `guard let self else { return }` inside the queued teardown would
+      // drop the completion and hang the Dart caller awaiting disposeCamera.
+      expect(release, isNot(contains('[weak self]')));
     });
   });
 }


### PR DESCRIPTION
## Description

On iPhone, opening the editor straight after recording left the clip playing back with the recorder's audio setup still in force, instead of a normal playback setup. The app does try to switch to playback the moment the recorder hands off, but iOS refused the switch — and that refusal is deliberately swallowed so playback keeps working at all, so nothing retried and the recorder's configuration stayed in force for the rest of the editor session.

A user log from an affected device (iPhone 15 Pro, iOS 26.6, 1.0.20+848) catches it 4ms after the camera was released:

```
06:47:30.616  → disposeCamera
06:47:30.620  [WARNING] Failed to configure audio session for mixed playback:
              PlatformException(561017449, …)
```

`561017449` is `'!pri'` — `AVAudioSessionErrorCodeInsufficientPriority`. iOS rejects a switch to `.playback` while an audio capture session is still running, and no further audio-session configuration appears anywhere in the remaining log.

### Why this is the right fix

Releasing the camera never waited for anything. The native `release()` queued the whole teardown — stopping the video and audio capture sessions, releasing inputs and outputs — onto a background queue and returned immediately, and the plugin answered Dart on the very next line. So `await cameraService.dispose()` resolved while the microphone capture session was still running, and the switch to playback landed on a session iOS was not willing to hand over.

`release()` now takes a completion that fires once the teardown has actually run, and `disposeCamera` answers Dart through it. The caller's `await` spans the real teardown, so the capture sessions are stopped by the time it asks for playback.

The queued teardown also captures `self` strongly instead of weakly. That is required by the new contract rather than a separate bug fix: a `guard let self else { return }` inside the queued block would drop the completion, and the Dart caller awaiting `disposeCamera` would wait forever. For an initialized camera the controller was already held alive by the Flutter texture registry (`textureRegistry.register(self)`, released only by the `unregisterTexture` inside that same block), so the weak capture was not silently skipping teardown today — it only left the narrow window before the texture is registered exposed.

**Related Issue:** Relates to #4539

## Out of Scope

This does not claim to fix the progressive volume ramp in #4539, and that issue stays open. It fixes a real defect found while investigating it, in the exact path users describe ("gets louder when I play it back in the editor"). Whether the ramp is in the recorded file or introduced during playback is still unknown — the recorder only logs `maxPeakDb` over the whole clip, which cannot distinguish the two. A per-second level log is the obvious next diagnostic and is deliberately not bundled here.

`disposeCamera` now resolves later than it used to: its latency is bounded by the camera's session queue instead of returning immediately. That is the point of the change, and the cost is contained — the caller awaits it after the editor push transition has already run, so it delays the audio switch, not the navigation. There is no `sync` dispatch onto that queue anywhere in the controller, so the completion cannot deadlock behind it.

Re-initializing the camera still releases the previous controller without waiting. That path is followed by camera setup rather than playback, so it never had this problem, and making it await would reorder camera startup for no established benefit.

The failure is still swallowed with a warning if iOS refuses the category change for some other reason. Left as-is: that warning is what made this diagnosable, and turning it into a hard failure would risk breaking editor audio for a case we have not seen.

## Verification

- `xcrun swiftc -parse` on both changed Swift files — clean.
- `flutter test` in `mobile/packages/divine_camera` — 368 passed, including four new static contract guards over the native sources (the package has no Swift test target; `ios_stabilization_contract_test.dart` established this pattern). The guards slice the `disposeCamera` and `release` declarations by brace matching and assert on those, so they cannot be satisfied by an identical line elsewhere in the file and do not depend on indentation.
- Those four guards were mutation-checked: reverting both Swift changes turns all four red.
- `flutter analyze` and `dart format` — clean.
- Not verified on a device. The change is an ordering fix in native teardown, and confirming it needs an affected iPhone: the `Failed to configure audio session for mixed playback` warning should disappear from the log after recording and entering the editor. The usual Samsung Galaxy pass does not apply — this is iOS-only code.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
