### PR TITLE
fix(dm): drop a conversation's queued reactions when it is removed

### DIFF
--- a/mobile/packages/db_client/lib/src/database/daos/dm_reactions_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/dm_reactions_dao.dart
@@ -476,6 +476,41 @@ class DmReactionsDao extends DatabaseAccessor<AppDatabase>
     return (await query.get()).isNotEmpty;
   }
 
+  /// Delete every reaction row in [conversationId] for [ownerPubkey].
+  ///
+  /// Called from `DmRepository.removeConversation`, inside the same
+  /// transaction as the message/conversation/`outgoing_dms` deletes: a
+  /// removed conversation must leave no queued reaction or kind-5 removal
+  /// behind for the retry sweep to publish into it (#7857). Unlike
+  /// [deleteNonRetryableForOwner] this deletes the retryable rows too —
+  /// removal is an explicit intent to stop sending, not a data-portability
+  /// cleanup.
+  Future<int> deleteForConversation({
+    required String conversationId,
+    required String ownerPubkey,
+  }) {
+    return (delete(dmMessageReactions)..where(
+          (t) =>
+              t.conversationId.equals(conversationId) &
+              t.ownerPubkey.equals(ownerPubkey),
+        ))
+        .go();
+  }
+
+  /// Delete every reaction row in [conversationIds] for [ownerPubkey].
+  /// No-op returning `0` when [conversationIds] is empty.
+  Future<int> deleteForConversations({
+    required Iterable<String> conversationIds,
+    required String ownerPubkey,
+  }) {
+    final ids = conversationIds.toList(growable: false);
+    if (ids.isEmpty) return Future.value(0);
+    return (delete(dmMessageReactions)..where(
+          (t) => t.conversationId.isIn(ids) & t.ownerPubkey.equals(ownerPubkey),
+        ))
+        .go();
+  }
+
   /// Delete everything owned by [ownerPubkey]. Sign-out cleanup.
   Future<int> deleteAllForOwner(String ownerPubkey) async {
     return (delete(

--- a/mobile/packages/db_client/lib/src/database/daos/dm_reactions_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/dm_reactions_dao.dart
@@ -200,15 +200,14 @@ class DmReactionsDao extends DatabaseAccessor<AppDatabase>
     required String id,
     required String ownerPubkey,
   }) async {
-    await (update(dmMessageReactions)..where(
-          (t) => t.id.equals(id) & t.ownerPubkey.equals(ownerPubkey),
-        ))
-        .write(
-          const DmMessageReactionsCompanion(
-            publishStatus: Value(_blockedStatus),
-            rumorEventJson: Value(null),
-          ),
-        );
+    await (update(
+      dmMessageReactions,
+    )..where((t) => t.id.equals(id) & t.ownerPubkey.equals(ownerPubkey))).write(
+      const DmMessageReactionsCompanion(
+        publishStatus: Value(_blockedStatus),
+        rumorEventJson: Value(null),
+      ),
+    );
   }
 
   /// Soft-delete a row (NIP-09 kind 5 deletion received, or own-reaction
@@ -305,9 +304,7 @@ class DmReactionsDao extends DatabaseAccessor<AppDatabase>
           await (update(dmMessageReactions)..where(
                 (t) => t.id.equals(r.id) & t.ownerPubkey.equals(ownerPubkey),
               ))
-              .write(
-                const DmMessageReactionsCompanion(isDeleted: Value(true)),
-              );
+              .write(const DmMessageReactionsCompanion(isDeleted: Value(true)));
         }
       }
       await into(dmMessageReactions).insert(
@@ -385,16 +382,15 @@ class DmReactionsDao extends DatabaseAccessor<AppDatabase>
     required String ownerPubkey,
     required String deletionRumorJson,
   }) async {
-    await (update(dmMessageReactions)..where(
-          (t) => t.id.equals(id) & t.ownerPubkey.equals(ownerPubkey),
-        ))
-        .write(
-          DmMessageReactionsCompanion(
-            isDeleted: const Value(true),
-            publishStatus: const Value(_deletionPendingStatus),
-            rumorEventJson: Value(deletionRumorJson),
-          ),
-        );
+    await (update(
+      dmMessageReactions,
+    )..where((t) => t.id.equals(id) & t.ownerPubkey.equals(ownerPubkey))).write(
+      DmMessageReactionsCompanion(
+        isDeleted: const Value(true),
+        publishStatus: const Value(_deletionPendingStatus),
+        rumorEventJson: Value(deletionRumorJson),
+      ),
+    );
   }
 
   /// Mark a pending own-reaction deletion as delivered: clears the stored
@@ -404,15 +400,14 @@ class DmReactionsDao extends DatabaseAccessor<AppDatabase>
     required String id,
     required String ownerPubkey,
   }) async {
-    await (update(dmMessageReactions)..where(
-          (t) => t.id.equals(id) & t.ownerPubkey.equals(ownerPubkey),
-        ))
-        .write(
-          const DmMessageReactionsCompanion(
-            publishStatus: Value(_deletionSentStatus),
-            rumorEventJson: Value(null),
-          ),
-        );
+    await (update(
+      dmMessageReactions,
+    )..where((t) => t.id.equals(id) & t.ownerPubkey.equals(ownerPubkey))).write(
+      const DmMessageReactionsCompanion(
+        publishStatus: Value(_deletionSentStatus),
+        rumorEventJson: Value(null),
+      ),
+    );
   }
 
   /// Fetch this user's own soft-deleted reactions whose kind-5 deletion still
@@ -476,28 +471,13 @@ class DmReactionsDao extends DatabaseAccessor<AppDatabase>
     return (await query.get()).isNotEmpty;
   }
 
-  /// Delete every reaction row in [conversationId] for [ownerPubkey].
-  ///
-  /// Called from `DmRepository.removeConversation`, inside the same
-  /// transaction as the message/conversation/`outgoing_dms` deletes: a
-  /// removed conversation must leave no queued reaction or kind-5 removal
-  /// behind for the retry sweep to publish into it (#7857). Unlike
-  /// [deleteNonRetryableForOwner] this deletes the retryable rows too —
-  /// removal is an explicit intent to stop sending, not a data-portability
-  /// cleanup.
-  Future<int> deleteForConversation({
-    required String conversationId,
-    required String ownerPubkey,
-  }) {
-    return (delete(dmMessageReactions)..where(
-          (t) =>
-              t.conversationId.equals(conversationId) &
-              t.ownerPubkey.equals(ownerPubkey),
-        ))
-        .go();
-  }
-
   /// Delete every reaction row in [conversationIds] for [ownerPubkey].
+  ///
+  /// Conversation removal calls this inside the same transaction as the
+  /// message/conversation/`outgoing_dms` deletes. Unlike
+  /// [deleteNonRetryableForOwner], this deletes retryable rows too: removal is
+  /// an explicit intent to stop sending, not a data-portability cleanup.
+  ///
   /// No-op returning `0` when [conversationIds] is empty.
   Future<int> deleteForConversations({
     required Iterable<String> conversationIds,

--- a/mobile/packages/db_client/lib/src/database/daos/dm_reactions_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/dm_reactions_dao.dart
@@ -361,7 +361,8 @@ class DmReactionsDao extends DatabaseAccessor<AppDatabase>
                 t.reactorPubkey.equals(ownerPubkey) &
                 t.isDeleted.equals(false) &
                 t.rumorEventJson.isNotNull() &
-                t.publishStatus.isIn(const ['failed', 'pending']),
+                t.publishStatus.isIn(const ['failed', 'pending']) &
+                _notSuppressedByRemoval(t),
           )
           ..orderBy([(t) => OrderingTerm.asc(t.createdAt)]))
         .get();
@@ -423,7 +424,8 @@ class DmReactionsDao extends DatabaseAccessor<AppDatabase>
                 t.reactorPubkey.equals(ownerPubkey) &
                 t.isDeleted.equals(true) &
                 t.rumorEventJson.isNotNull() &
-                t.publishStatus.equals(_deletionPendingStatus),
+                t.publishStatus.equals(_deletionPendingStatus) &
+                _notSuppressedByRemoval(t),
           )
           ..orderBy([(t) => OrderingTerm.asc(t.createdAt)]))
         .get();
@@ -469,6 +471,50 @@ class DmReactionsDao extends DatabaseAccessor<AppDatabase>
       )
       ..limit(1);
     return (await query.get()).isNotEmpty;
+  }
+
+  /// `true` when this reaction is NOT suppressed by a removed-conversation
+  /// tombstone — i.e. no `removed_conversations` marker for the same
+  /// `(conversation_id, owner_pubkey)` covers its `created_at`.
+  ///
+  /// Mirrors the message-suppression rule in `DmRepository`
+  /// (`createdAt <= removedAt` is removed history): a reaction created *after*
+  /// the removal belongs to a conversation the counterparty has since
+  /// recreated, so it must still be delivered. Tombstones outlive the
+  /// `conversations` row on purpose, which is why this keys on them rather
+  /// than on conversation existence — a plain existence check would silently
+  /// drop every queued reaction after an account switch, which clears
+  /// `conversations` wholesale while preserving the retry queue (#6984).
+  Expression<bool> _notSuppressedByRemoval($DmMessageReactionsTable t) {
+    final tombstones = attachedDatabase.removedConversations;
+    return notExistsQuery(
+      selectOnly(tombstones)
+        ..addColumns([tombstones.conversationId])
+        ..where(
+          tombstones.conversationId.equalsExp(t.conversationId) &
+              tombstones.ownerPubkey.equalsExp(t.ownerPubkey) &
+              t.createdAt.isSmallerOrEqual(tombstones.removedAt),
+        ),
+    );
+  }
+
+  /// Delete reaction rows stranded by a conversation removal that predates the
+  /// removal-time cleanup (#7857).
+  ///
+  /// Before that fix, removing a conversation left its `dm_message_reactions`
+  /// rows behind. Those rows are an outgoing queue, so the retry sweep kept
+  /// re-driving them and could publish a gift wrap into a conversation the
+  /// user had removed. Rows written after the tombstone belong to a recreated
+  /// conversation and are kept — same rule as [_notSuppressedByRemoval].
+  ///
+  /// Idempotent: a no-op once the account has none left.
+  Future<int> deleteSuppressedByRemoval({required String ownerPubkey}) {
+    return (delete(dmMessageReactions)..where(
+          (t) =>
+              t.ownerPubkey.equals(ownerPubkey) &
+              _notSuppressedByRemoval(t).not(),
+        ))
+        .go();
   }
 
   /// Delete every reaction row in [conversationIds] for [ownerPubkey].

--- a/mobile/packages/db_client/test/src/database/daos/dm_reactions_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/dm_reactions_dao_test.dart
@@ -28,6 +28,14 @@ const _sentId =
     'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
 const _giftWrapId =
     '1111111111111111111111111111111111111111111111111111111111111111';
+const _otherConversationId =
+    '2222222222222222222222222222222222222222222222222222222222222222';
+const _otherConversationReactionId =
+    '3333333333333333333333333333333333333333333333333333333333333333';
+const _otherOwnerReactionId =
+    '4444444444444444444444444444444444444444444444444444444444444444';
+const _otherTargetMessageId =
+    '5555555555555555555555555555555555555555555555555555555555555555';
 
 void main() {
   late AppDatabase database;
@@ -804,6 +812,156 @@ void main() {
         );
       },
     );
+
+    group('removed-conversation tombstone suppression', () {
+      /// The `createdAt` [insertPending] uses by default.
+      const reactionAt = 1_700_000_000;
+
+      Future<void> recordTombstone({
+        required int removedAt,
+        String conversationId = _conversationId,
+        String ownerPubkey = _ownerA,
+      }) {
+        return database.removedConversationsDao.record(
+          conversationId: conversationId,
+          ownerPubkey: ownerPubkey,
+          removedAt: removedAt,
+        );
+      }
+
+      test(
+        'a reaction stranded by an older removal is not retryable',
+        () async {
+          await insertPending();
+          await recordTombstone(removedAt: reactionAt);
+
+          expect(
+            await dao.getRetryableOwnReactions(ownerPubkey: _ownerA),
+            isEmpty,
+            reason:
+                'a removal at or after the reaction must take it out of the '
+                'sweep, so it can never be published into the removed thread',
+          );
+        },
+      );
+
+      test('a reaction created after the removal stays retryable', () async {
+        await insertPending(createdAt: reactionAt + 500);
+        await recordTombstone(removedAt: reactionAt);
+
+        expect(
+          await dao.getRetryableOwnReactions(ownerPubkey: _ownerA),
+          hasLength(1),
+          reason:
+              'the counterparty recreated the conversation after the removal; '
+              'that reaction is still owed delivery',
+        );
+      });
+
+      test("another owner's tombstone does not suppress this owner", () async {
+        await insertPending();
+        await recordTombstone(removedAt: reactionAt, ownerPubkey: _ownerB);
+
+        expect(
+          await dao.getRetryableOwnReactions(ownerPubkey: _ownerA),
+          hasLength(1),
+        );
+      });
+
+      test(
+        "another conversation's tombstone does not suppress this one",
+        () async {
+          await insertPending();
+          await recordTombstone(
+            removedAt: reactionAt,
+            conversationId: _otherConversationId,
+          );
+
+          expect(
+            await dao.getRetryableOwnReactions(ownerPubkey: _ownerA),
+            hasLength(1),
+          );
+        },
+      );
+
+      test('a pending kind-5 removal is suppressed the same way', () async {
+        await insertPending();
+        await dao.markOwnDeletionPending(
+          id: _pendingId,
+          ownerPubkey: _ownerA,
+          deletionRumorJson: '{"kind":5}',
+        );
+        expect(
+          await dao.getRetryableOwnDeletions(ownerPubkey: _ownerA),
+          hasLength(1),
+        );
+
+        await recordTombstone(removedAt: reactionAt);
+
+        expect(
+          await dao.getRetryableOwnDeletions(ownerPubkey: _ownerA),
+          isEmpty,
+        );
+      });
+
+      test('deleteSuppressedByRemoval purges only stranded rows', () async {
+        await insertPending();
+        await insertPending(
+          id: _otherConversationReactionId,
+          conversationId: _otherConversationId,
+          targetMessageId: _otherTargetMessageId,
+        );
+        await recordTombstone(removedAt: reactionAt);
+
+        final purged = await dao.deleteSuppressedByRemoval(
+          ownerPubkey: _ownerA,
+        );
+
+        expect(purged, equals(1));
+        expect(await dao.getById(id: _pendingId, ownerPubkey: _ownerA), isNull);
+        expect(
+          await dao.getById(
+            id: _otherConversationReactionId,
+            ownerPubkey: _ownerA,
+          ),
+          isNotNull,
+        );
+      });
+
+      test('deleteSuppressedByRemoval keeps post-removal rows', () async {
+        await insertPending(createdAt: reactionAt + 500);
+        await recordTombstone(removedAt: reactionAt);
+
+        expect(
+          await dao.deleteSuppressedByRemoval(ownerPubkey: _ownerA),
+          isZero,
+        );
+        expect(
+          await dao.getById(id: _pendingId, ownerPubkey: _ownerA),
+          isNotNull,
+        );
+      });
+
+      test('deleteSuppressedByRemoval is owner-scoped', () async {
+        await insertPending();
+        await insertPending(
+          id: _otherOwnerReactionId,
+          ownerPubkey: _ownerB,
+          reactorPubkey: _ownerB,
+        );
+        await recordTombstone(removedAt: reactionAt);
+        await recordTombstone(removedAt: reactionAt, ownerPubkey: _ownerB);
+
+        expect(
+          await dao.deleteSuppressedByRemoval(ownerPubkey: _ownerA),
+          equals(1),
+        );
+        expect(
+          await dao.getById(id: _otherOwnerReactionId, ownerPubkey: _ownerB),
+          isNotNull,
+        );
+      });
+    });
 
     test('deleteForConversations is a no-op for an empty id list', () async {
       await insertPending();

--- a/mobile/packages/db_client/test/src/database/daos/dm_reactions_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/dm_reactions_dao_test.dart
@@ -57,6 +57,7 @@ void main() {
   group('DmReactionsDao', () {
     Future<List<String>> insertPending({
       String id = _pendingId,
+      String conversationId = _conversationId,
       String ownerPubkey = _ownerA,
       String reactorPubkey = _reactorA,
       String emoji = '🔥',
@@ -65,7 +66,7 @@ void main() {
     }) {
       return dao.insertOwnReactionSuperseding(
         placeholderId: id,
-        conversationId: _conversationId,
+        conversationId: conversationId,
         targetMessageId: targetMessageId,
         targetMessageAuthor: _targetAuthor,
         reactorPubkey: reactorPubkey,
@@ -757,6 +758,66 @@ void main() {
       expect(deleted, equals(1));
       expect(await dao.getById(id: _pendingId, ownerPubkey: _ownerA), isNull);
       expect(await dao.getById(id: _sentId, ownerPubkey: _ownerB), isNotNull);
+    });
+
+    test(
+      'deleteForConversations clears only selected conversations for owner',
+      () async {
+        const otherConversationId =
+            '2222222222222222222222222222222222222222222222222222222222222222';
+        const otherConversationReactionId =
+            '3333333333333333333333333333333333333333333333333333333333333333';
+        const otherOwnerReactionId =
+            '4444444444444444444444444444444444444444444444444444444444444444';
+        const otherTargetMessageId =
+            '5555555555555555555555555555555555555555555555555555555555555555';
+
+        await insertPending();
+        await insertPending(
+          id: otherConversationReactionId,
+          conversationId: otherConversationId,
+          targetMessageId: otherTargetMessageId,
+        );
+        await insertPending(
+          id: otherOwnerReactionId,
+          ownerPubkey: _ownerB,
+          reactorPubkey: _ownerB,
+        );
+
+        final deleted = await dao.deleteForConversations(
+          conversationIds: [_conversationId],
+          ownerPubkey: _ownerA,
+        );
+
+        expect(deleted, equals(1));
+        expect(await dao.getById(id: _pendingId, ownerPubkey: _ownerA), isNull);
+        expect(
+          await dao.getById(
+            id: otherConversationReactionId,
+            ownerPubkey: _ownerA,
+          ),
+          isNotNull,
+        );
+        expect(
+          await dao.getById(id: otherOwnerReactionId, ownerPubkey: _ownerB),
+          isNotNull,
+        );
+      },
+    );
+
+    test('deleteForConversations is a no-op for an empty id list', () async {
+      await insertPending();
+
+      final deleted = await dao.deleteForConversations(
+        conversationIds: const [],
+        ownerPubkey: _ownerA,
+      );
+
+      expect(deleted, equals(0));
+      expect(
+        await dao.getById(id: _pendingId, ownerPubkey: _ownerA),
+        isNotNull,
+      );
     });
 
     test(

--- a/mobile/packages/dm_repository/lib/src/dm_reactions_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_reactions_repository.dart
@@ -163,6 +163,27 @@ class DmReactionsRepository {
     _messageService = null;
   }
 
+  /// Drop every reaction row this account holds for [conversationIds].
+  ///
+  /// Called by `DmRepository.removeConversation` from inside its removal
+  /// transaction, so a removed conversation leaves no queued reaction or
+  /// pending kind-5 removal behind (#7857). Without this the retry sweep
+  /// keeps re-driving those rows and publishes a gift wrap into a
+  /// conversation the user removed — [retryableReactions] and
+  /// [retryableDeletions] are owner-scoped only, and
+  /// [_resolveWrapRecipients] falls back to the target message's author
+  /// once the conversation row is gone.
+  ///
+  /// No-op when uninitialized (no owner to scope the delete to) or when
+  /// [conversationIds] is empty.
+  Future<void> deleteForConversations(Iterable<String> conversationIds) async {
+    if (_userPubkey.isEmpty) return;
+    await _reactionsDao.deleteForConversations(
+      conversationIds: conversationIds,
+      ownerPubkey: _userPubkey,
+    );
+  }
+
   /// Reactive stream of every live reaction in [conversationId] for the
   /// current account, collapsed to at most one reaction per reactor per
   /// target message (the cap-at-one invariant — see [_collapsePerReactor]).

--- a/mobile/packages/dm_repository/lib/src/dm_reactions_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_reactions_repository.dart
@@ -174,13 +174,18 @@ class DmReactionsRepository {
   /// [_resolveWrapRecipients] falls back to the target message's author
   /// once the conversation row is gone.
   ///
-  /// No-op when uninitialized (no owner to scope the delete to) or when
-  /// [conversationIds] is empty.
-  Future<void> deleteForConversations(Iterable<String> conversationIds) async {
-    if (_userPubkey.isEmpty) return;
+  /// [ownerPubkey] is supplied by the caller rather than read from this
+  /// repository's mutable credentials so an account transition cannot change
+  /// the owner midway through the enclosing removal transaction.
+  ///
+  /// No-op when [conversationIds] is empty.
+  Future<void> deleteForConversations(
+    Iterable<String> conversationIds, {
+    required String ownerPubkey,
+  }) async {
     await _reactionsDao.deleteForConversations(
       conversationIds: conversationIds,
-      ownerPubkey: _userPubkey,
+      ownerPubkey: ownerPubkey,
     );
   }
 

--- a/mobile/packages/dm_repository/lib/src/dm_reactions_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_reactions_repository.dart
@@ -189,6 +189,24 @@ class DmReactionsRepository {
     );
   }
 
+  /// Purge reaction rows stranded by a conversation removal that happened
+  /// before removal started dropping them (#7857).
+  ///
+  /// [deleteForConversations] only closes the leak going forward. An install
+  /// that removed a conversation on an older build still holds that
+  /// conversation's rows, and because the retry sweep selects by owner alone
+  /// they stay in the outgoing queue — the sweep's in-memory attempt budget
+  /// resets on every cold start, so they never age out on their own.
+  ///
+  /// Rows created after the removal marker are kept: they belong to a
+  /// conversation the counterparty has since recreated and are still owed
+  /// delivery.
+  ///
+  /// Idempotent — a no-op once the account has none left.
+  Future<int> purgeStrandedByRemoval({required String ownerPubkey}) {
+    return _reactionsDao.deleteSuppressedByRemoval(ownerPubkey: ownerPubkey);
+  }
+
   /// Reactive stream of every live reaction in [conversationId] for the
   /// current account, collapsed to at most one reaction per reactor per
   /// target message (the cap-at-one invariant — see [_collapsePerReactor]).

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -6013,6 +6013,43 @@ class DmRepository {
     await _cleanupSelfConversations();
     await _backfillCurrentUserHasSent();
     await _backfillConversationPreviews();
+    await _purgeReactionsStrandedByRemoval();
+  }
+
+  /// Drops reaction rows left behind by a conversation removal on a build that
+  /// predates the removal-time cleanup (#7857).
+  ///
+  /// Those rows are an outgoing queue, not a render cache, so the retry sweep
+  /// keeps re-driving them and can publish a gift wrap into a conversation the
+  /// user removed. The sweep's attempt budget is in memory, so it resets on
+  /// every cold start and they never age out.
+  ///
+  /// The read side is guarded independently — the retry queries exclude
+  /// tombstoned rows — so a sweep that fires before this finishes still cannot
+  /// publish one. This reclaims the rows.
+  ///
+  /// Idempotent — a no-op once the account has none left.
+  Future<void> _purgeReactionsStrandedByRemoval() async {
+    final owner = _ownerPubkey;
+    if (owner == null) return;
+    try {
+      final purged = await _reactionsRepository?.purgeStrandedByRemoval(
+        ownerPubkey: owner,
+      );
+      if (purged != null && purged > 0) {
+        Log.info(
+          'Purged $purged DM reaction rows stranded by a removed conversation',
+          category: LogCategory.system,
+        );
+      }
+    } on Object catch (e, stackTrace) {
+      Log.error(
+        'Failed to purge reactions stranded by removed conversations: $e',
+        category: LogCategory.system,
+        error: e,
+        stackTrace: stackTrace,
+      );
+    }
   }
 
   /// Backfills `currentUserHasSent` for conversations where the column

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -5734,7 +5734,10 @@ class DmRepository {
         conversationId: conversationId,
         ownerPubkey: owner,
       );
-      await _reactionsRepository?.deleteForConversations([conversationId]);
+      await _reactionsRepository?.deleteForConversations(
+        [conversationId],
+        ownerPubkey: owner,
+      );
     });
   }
 
@@ -5773,7 +5776,10 @@ class DmRepository {
         conversationIds: conversationIds,
         ownerPubkey: owner,
       );
-      await _reactionsRepository?.deleteForConversations(conversationIds);
+      await _reactionsRepository?.deleteForConversations(
+        conversationIds,
+        ownerPubkey: owner,
+      );
     });
   }
 

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -5693,12 +5693,19 @@ class DmRepository {
     }
   }
 
-  /// Remove a conversation, its messages, and queued sends atomically.
+  /// Remove a conversation, its messages, its queued sends, and its queued
+  /// reactions atomically.
   ///
   /// Records an owner-scoped tombstone first so relay replay cannot restore
   /// history at or before the removal time. The marker is kept for the
   /// account's lifetime: a newer message recreates the conversation while
   /// earlier history stays suppressed.
+  ///
+  /// The `dm_message_reactions` delete is not housekeeping. Those rows are
+  /// the durable outgoing queue for unpublished reactions and pending kind-5
+  /// removals, and the retry sweep selects them by owner alone. Left behind,
+  /// the sweep publishes a gift wrap into a conversation the user removed
+  /// (#7857) — the reaction counterpart of the `outgoing_dms` delete above.
   ///
   /// Throws:
   ///
@@ -5727,10 +5734,13 @@ class DmRepository {
         conversationId: conversationId,
         ownerPubkey: owner,
       );
+      await _reactionsRepository?.deleteForConversations([conversationId]);
     });
   }
 
-  /// Remove multiple conversations, messages, and queued sends atomically.
+  /// Remove multiple conversations, their messages, their queued sends, and
+  /// their queued reactions atomically. See [removeConversation] for why the
+  /// reaction rows go with them.
   ///
   /// No-op when [conversationIds] is empty.
   ///
@@ -5763,6 +5773,7 @@ class DmRepository {
         conversationIds: conversationIds,
         ownerPubkey: owner,
       );
+      await _reactionsRepository?.deleteForConversations(conversationIds);
     });
   }
 

--- a/mobile/packages/dm_repository/pubspec.yaml
+++ b/mobile/packages/dm_repository/pubspec.yaml
@@ -24,6 +24,7 @@ dependencies:
     path: ../unified_logger
 
 dev_dependencies:
+  drift: ^2.34.0
   fake_async: ^1.3.3
   flutter_test:
     sdk: flutter

--- a/mobile/packages/dm_repository/test/src/dm_removal_reaction_queue_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_removal_reaction_queue_test.dart
@@ -1,0 +1,301 @@
+// ABOUTME: Regression coverage for #7857 — removing a conversation must drop
+// ABOUTME: its queued DM reactions and pending kind-5 removals, so the retry
+// ABOUTME: sweep can never publish a gift wrap into a removed conversation.
+
+import 'package:db_client/db_client.dart';
+import 'package:dm_repository/dm_repository.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/event.dart';
+
+class _MockNip17MessageService extends Mock implements NIP17MessageService {}
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _FakeEvent extends Fake implements Event {}
+
+const _owner =
+    '1111111111111111111111111111111111111111111111111111111111111111';
+const _peer =
+    '2222222222222222222222222222222222222222222222222222222222222222';
+const _peer2 =
+    '3333333333333333333333333333333333333333333333333333333333333333';
+const _targetMessageId =
+    '4444444444444444444444444444444444444444444444444444444444444444';
+
+void main() {
+  setUpAll(() => registerFallbackValue(_FakeEvent()));
+
+  group('removeConversation drops the reaction queue', () {
+    late AppDatabase db;
+    late DmReactionsDao reactionsDao;
+    late ConversationsDao conversationsDao;
+    late DirectMessagesDao messagesDao;
+    late _MockNip17MessageService messageService;
+    late DmReactionsRepository reactions;
+
+    setUp(() {
+      db = AppDatabase.test(NativeDatabase.memory());
+      reactionsDao = DmReactionsDao(db);
+      conversationsDao = ConversationsDao(db);
+      messagesDao = DirectMessagesDao(db);
+      messageService = _MockNip17MessageService();
+
+      when(
+        () => messageService.buildRumor(
+          recipientPubkey: any(named: 'recipientPubkey'),
+          content: any(named: 'content'),
+          eventKind: any(named: 'eventKind'),
+          additionalTags: any(named: 'additionalTags'),
+          createdAt: any(named: 'createdAt'),
+        ),
+      ).thenAnswer((invocation) {
+        final tags = <List<String>>[
+          ['p', invocation.namedArguments[#recipientPubkey] as String],
+          ...invocation.namedArguments[#additionalTags] as List<List<String>>,
+        ];
+        return Event(
+          _owner,
+          invocation.namedArguments[#eventKind] as int,
+          tags,
+          invocation.namedArguments[#content] as String,
+        );
+      });
+
+      reactions =
+          DmReactionsRepository(
+            reactionsDao: reactionsDao,
+            conversationsDao: conversationsDao,
+            directMessagesDao: messagesDao,
+          )..setCredentials(
+            userPubkey: _owner,
+            messageService: messageService,
+          );
+    });
+
+    tearDown(() => db.close());
+
+    /// Wire layer that never confirms, so a publish leaves a durable
+    /// retryable row behind — the offline case the sweep exists for.
+    void stubOfflineWire() {
+      when(
+        () => messageService.sendRumor(
+          rumorEvent: any(named: 'rumorEvent'),
+          recipientPubkey: any(named: 'recipientPubkey'),
+          targetRelays: any(named: 'targetRelays'),
+          awaitRecipientOk: any(named: 'awaitRecipientOk'),
+          selfWrapOnSoftUnconfirmed: any(named: 'selfWrapOnSoftUnconfirmed'),
+          recipientWrapBuildTimeout: any(named: 'recipientWrapBuildTimeout'),
+          selfWrapBuildTimeout: any(named: 'selfWrapBuildTimeout'),
+        ),
+      ).thenAnswer((_) async => const NIP17SendResult.failure('offline'));
+    }
+
+    void stubLandingWire() {
+      when(
+        () => messageService.sendRumor(
+          rumorEvent: any(named: 'rumorEvent'),
+          recipientPubkey: any(named: 'recipientPubkey'),
+          targetRelays: any(named: 'targetRelays'),
+          awaitRecipientOk: any(named: 'awaitRecipientOk'),
+          selfWrapOnSoftUnconfirmed: any(named: 'selfWrapOnSoftUnconfirmed'),
+          recipientWrapBuildTimeout: any(named: 'recipientWrapBuildTimeout'),
+          selfWrapBuildTimeout: any(named: 'selfWrapBuildTimeout'),
+        ),
+      ).thenAnswer((invocation) async {
+        final rumor = invocation.namedArguments[#rumorEvent] as Event;
+        return NIP17SendResult.success(
+          rumorEventId: rumor.id,
+          messageEventId: 'wrap-${rumor.id}',
+          recipientPubkey:
+              invocation.namedArguments[#recipientPubkey] as String,
+        );
+      });
+    }
+
+    Future<String> seedConversation(List<String> participants) async {
+      final conversationId = DmRepository.computeConversationId(participants);
+      await conversationsDao.upsertConversation(
+        id: conversationId,
+        participantPubkeys: '["${participants.join('","')}"]',
+        isGroup: participants.length > 2,
+        createdAt: 1700000000,
+        ownerPubkey: _owner,
+      );
+      return conversationId;
+    }
+
+    DmRepository buildDmRepository() => DmRepository(
+      nostrClient: _MockNostrClient(),
+      directMessagesDao: messagesDao,
+      conversationsDao: conversationsDao,
+      userPubkey: _owner,
+      reactionsRepository: reactions,
+    );
+
+    test('a queued reaction is not retryable after removal', () async {
+      stubOfflineWire();
+      final conversationId = await seedConversation([_owner, _peer]);
+      final result = await reactions.publish(
+        conversationId: conversationId,
+        targetMessageId: _targetMessageId,
+        targetMessageAuthor: _peer,
+        emoji: '🔥',
+      );
+      expect(result.success, isFalse);
+      expect(
+        await reactionsDao.getRetryableOwnReactions(ownerPubkey: _owner),
+        hasLength(1),
+        reason: 'the offline publish must leave a durable retryable row',
+      );
+
+      await buildDmRepository().removeConversation(conversationId);
+
+      expect(
+        await reactionsDao.getRetryableOwnReactions(ownerPubkey: _owner),
+        isEmpty,
+        reason:
+            'the sweep must find nothing to publish into a removed '
+            'conversation',
+      );
+    });
+
+    test('a pending kind-5 removal is not retryable after removal', () async {
+      stubLandingWire();
+      final conversationId = await seedConversation([_owner, _peer]);
+      final result = await reactions.publish(
+        conversationId: conversationId,
+        targetMessageId: _targetMessageId,
+        targetMessageAuthor: _peer,
+        emoji: '🔥',
+      );
+      expect(result.success, isTrue);
+
+      stubOfflineWire();
+      await reactions.removeOwn(
+        rumorId: result.rumorId,
+        targetMessageAuthor: _peer,
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      expect(
+        await reactionsDao.getRetryableOwnDeletions(ownerPubkey: _owner),
+        hasLength(1),
+      );
+
+      await buildDmRepository().removeConversation(conversationId);
+
+      expect(
+        await reactionsDao.getRetryableOwnDeletions(ownerPubkey: _owner),
+        isEmpty,
+      );
+    });
+
+    test(
+      'removal drops received reactions too, not just own queued ones',
+      () async {
+        stubOfflineWire();
+        final conversationId = await seedConversation([_owner, _peer]);
+        await reactionsDao.upsertIncoming(
+          id: '5' * 64,
+          conversationId: conversationId,
+          targetMessageId: _targetMessageId,
+          targetMessageAuthor: _owner,
+          reactorPubkey: _peer,
+          emoji: '👍',
+          createdAt: 1700000001,
+          ownerPubkey: _owner,
+          giftWrapId: '6' * 64,
+        );
+
+        await buildDmRepository().removeConversation(conversationId);
+
+        expect(
+          await reactionsDao.getById(id: '5' * 64, ownerPubkey: _owner),
+          isNull,
+        );
+      },
+    );
+
+    test("removal leaves another conversation's queue untouched", () async {
+      stubOfflineWire();
+      final removed = await seedConversation([_owner, _peer]);
+      final kept = await seedConversation([_owner, _peer2]);
+      await reactions.publish(
+        conversationId: removed,
+        targetMessageId: _targetMessageId,
+        targetMessageAuthor: _peer,
+        emoji: '🔥',
+      );
+      await reactions.publish(
+        conversationId: kept,
+        targetMessageId: '7' * 64,
+        targetMessageAuthor: _peer2,
+        emoji: '🎉',
+      );
+      expect(
+        await reactionsDao.getRetryableOwnReactions(ownerPubkey: _owner),
+        hasLength(2),
+      );
+
+      await buildDmRepository().removeConversation(removed);
+
+      final survivors = await reactionsDao.getRetryableOwnReactions(
+        ownerPubkey: _owner,
+      );
+      expect(survivors, hasLength(1));
+      expect(survivors.single.conversationId, kept);
+    });
+
+    test('removeConversations drops the queue for every id', () async {
+      stubOfflineWire();
+      final first = await seedConversation([_owner, _peer]);
+      final second = await seedConversation([_owner, _peer2]);
+      await reactions.publish(
+        conversationId: first,
+        targetMessageId: _targetMessageId,
+        targetMessageAuthor: _peer,
+        emoji: '🔥',
+      );
+      await reactions.publish(
+        conversationId: second,
+        targetMessageId: '7' * 64,
+        targetMessageAuthor: _peer2,
+        emoji: '🎉',
+      );
+
+      await buildDmRepository().removeConversations([first, second]);
+
+      expect(
+        await reactionsDao.getRetryableOwnReactions(ownerPubkey: _owner),
+        isEmpty,
+      );
+    });
+
+    test("another account's reactions survive this owner's removal", () async {
+      stubOfflineWire();
+      final conversationId = await seedConversation([_owner, _peer]);
+      await reactionsDao.upsertIncoming(
+        id: '8' * 64,
+        conversationId: conversationId,
+        targetMessageId: _targetMessageId,
+        targetMessageAuthor: _peer,
+        reactorPubkey: _peer,
+        emoji: '👍',
+        createdAt: 1700000002,
+        ownerPubkey: _peer,
+        giftWrapId: '9' * 64,
+      );
+
+      await buildDmRepository().removeConversation(conversationId);
+
+      expect(
+        await reactionsDao.getById(id: '8' * 64, ownerPubkey: _peer),
+        isNotNull,
+        reason: 'the delete is owner-scoped',
+      );
+    });
+  });
+}

--- a/mobile/packages/dm_repository/test/src/dm_removal_reaction_queue_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_removal_reaction_queue_test.dart
@@ -179,7 +179,6 @@ void main() {
         rumorId: result.rumorId,
         targetMessageAuthor: _peer,
       );
-      await Future<void>.delayed(const Duration(milliseconds: 50));
       expect(
         await reactionsDao.getRetryableOwnDeletions(ownerPubkey: _owner),
         hasLength(1),
@@ -189,6 +188,29 @@ void main() {
 
       expect(
         await reactionsDao.getRetryableOwnDeletions(ownerPubkey: _owner),
+        isEmpty,
+      );
+    });
+
+    test('removal keeps its owner snapshot when credentials clear', () async {
+      stubOfflineWire();
+      final conversationId = await seedConversation([_owner, _peer]);
+      await reactions.publish(
+        conversationId: conversationId,
+        targetMessageId: _targetMessageId,
+        targetMessageAuthor: _peer,
+        emoji: '🔥',
+      );
+      expect(
+        await reactionsDao.getRetryableOwnReactions(ownerPubkey: _owner),
+        hasLength(1),
+      );
+
+      reactions.clearCredentials();
+      await buildDmRepository().removeConversation(conversationId);
+
+      expect(
+        await reactionsDao.getRetryableOwnReactions(ownerPubkey: _owner),
         isEmpty,
       );
     });

--- a/mobile/packages/dm_repository/test/src/dm_removal_reaction_queue_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_removal_reaction_queue_test.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Regression coverage for #7857 — removing a conversation must drop
 // ABOUTME: its queued DM reactions and pending kind-5 removals, so the retry
 // ABOUTME: sweep can never publish a gift wrap into a removed conversation.
+// ABOUTME: Also covers rows stranded by a removal on an older build.
 
 import 'package:db_client/db_client.dart';
 import 'package:dm_repository/dm_repository.dart';
@@ -132,8 +133,124 @@ void main() {
       nostrClient: _MockNostrClient(),
       directMessagesDao: messagesDao,
       conversationsDao: conversationsDao,
+      removedConversationsDao: db.removedConversationsDao,
       userPubkey: _owner,
       reactionsRepository: reactions,
+    );
+
+    /// Reproduce the on-disk state an older build left behind: the
+    /// conversation and its messages are gone and the tombstone is recorded,
+    /// but the reaction rows were never touched.
+    Future<void> removeTheWayOldBuildsDid(
+      String conversationId, {
+      Duration ago = Duration.zero,
+    }) async {
+      final removedAt =
+          (DateTime.now().millisecondsSinceEpoch ~/ 1000) - ago.inSeconds;
+      await db.removedConversationsDao.record(
+        conversationId: conversationId,
+        ownerPubkey: _owner,
+        removedAt: removedAt,
+      );
+      await messagesDao.deleteConversationMessages(
+        conversationId,
+        ownerPubkey: _owner,
+      );
+      await conversationsDao.deleteConversation(
+        conversationId,
+        ownerPubkey: _owner,
+      );
+    }
+
+    test(
+      'a reaction stranded by an older build is never swept up again',
+      () async {
+        stubOfflineWire();
+        final conversationId = await seedConversation([_owner, _peer]);
+        await reactions.publish(
+          conversationId: conversationId,
+          targetMessageId: _targetMessageId,
+          targetMessageAuthor: _peer,
+          emoji: '🔥',
+        );
+        expect(await reactions.retryableReactions(), hasLength(1));
+
+        await removeTheWayOldBuildsDid(conversationId);
+
+        expect(
+          await reactions.retryableReactions(),
+          isEmpty,
+          reason:
+              'the sweep re-derives the recipient from the reaction row, so a '
+              'stranded row would publish to the counterparty of a '
+              'conversation the user removed',
+        );
+      },
+    );
+
+    test('post-auth maintenance reclaims the stranded rows', () async {
+      stubOfflineWire();
+      final conversationId = await seedConversation([_owner, _peer]);
+      await reactions.publish(
+        conversationId: conversationId,
+        targetMessageId: _targetMessageId,
+        targetMessageAuthor: _peer,
+        emoji: '🔥',
+      );
+      final stranded = (await reactionsDao.getRetryableOwnReactions(
+        ownerPubkey: _owner,
+      )).single.id;
+      await removeTheWayOldBuildsDid(conversationId);
+      expect(
+        await reactionsDao.getById(id: stranded, ownerPubkey: _owner),
+        isNotNull,
+        reason: 'the older build left the row on disk',
+      );
+
+      final purged = await reactions.purgeStrandedByRemoval(
+        ownerPubkey: _owner,
+      );
+
+      expect(purged, equals(1));
+      expect(
+        await reactionsDao.getById(id: stranded, ownerPubkey: _owner),
+        isNull,
+      );
+    });
+
+    test(
+      'a reaction in a conversation recreated after removal still sends',
+      () async {
+        stubOfflineWire();
+        final conversationId = await seedConversation([_owner, _peer]);
+        // Removed a while back, so the new reaction is unambiguously later —
+        // `removed_at` has second granularity and the rule suppresses ties.
+        await removeTheWayOldBuildsDid(
+          conversationId,
+          ago: const Duration(minutes: 1),
+        );
+
+        // The counterparty writes again, so the thread comes back.
+        await seedConversation([_owner, _peer]);
+        await reactions.publish(
+          conversationId: conversationId,
+          targetMessageId: _targetMessageId,
+          targetMessageAuthor: _peer,
+          emoji: '🔥',
+        );
+
+        expect(
+          await reactions.retryableReactions(),
+          hasLength(1),
+          reason:
+              'the tombstone outlives the conversation row on purpose; only '
+              'reactions from the removed era are suppressed',
+        );
+        expect(
+          await reactions.purgeStrandedByRemoval(ownerPubkey: _owner),
+          isZero,
+        );
+      },
     );
 
     test('a queued reaction is not retryable after removal', () async {


### PR DESCRIPTION
Closes #7857.

## What

`DmRepository.removeConversation` deleted the conversation's messages and its `conversations` row, but never touched `dm_message_reactions`. That table is not just a render cache — it is also an outgoing queue. A reaction or a kind-5 un-react that has not landed keeps its rumor JSON there, and `DmReactionRetryService` selects those rows by owner alone, with no conversation predicate:

```dart
// dm_reactions_dao.dart — getRetryableOwnReactions / getRetryableOwnDeletions
t.ownerPubkey.equals(ownerPubkey) &
t.reactorPubkey.equals(ownerPubkey) & ...
```

So the sweep kept re-driving those rows after removal, and `_resolveWrapRecipients` still found a recipient: with the conversation row gone it falls back to the reacted message's author. The result is a kind-7 (or kind-5) gift wrap published to the counterparty of a conversation the user removed.

The retry budget does not bound this. `DmReactionRetryConfig` keeps attempt accounting in memory rather than on the `dm_message_reactions` row — its own doc says "the budget resets on a cold start" — and the sweep is armed at app-shell setup with `fireImmediately: true` (`social_providers.dart:493`). Every launch therefore spends a fresh five attempts on the same row.

Removal now drops the conversation's reaction rows in the same transaction as the message and conversation deletes.

## Why delete rather than filter

The issue offered a second option — add a conversation-existence predicate to the two retry queries. That silences the leak but breaks a deliberate behaviour: on a plain account switch `conversations` is cleared wholesale while the retryable reaction subset is preserved on purpose (#6984). A conversation-existence filter would drop every queued reaction after any account switch. Deleting on removal is the narrower change and mirrors what #7811 does for `outgoing_dms`.

## Installs that already removed a conversation

Deleting at removal time only closes the leak going forward. Anyone who removed a conversation on an earlier build still has that conversation's reaction rows on disk, and the retry sweep selects them by owner alone, so it keeps re-driving them — `_resolveWrapRecipients` falls back to the reacted message's author, which is still the counterparty of the removed thread. Because the attempt budget lives in memory, those rows never age out; every launch spends a fresh five attempts. Reproduced by rebuilding that on-disk state (conversation and messages gone, tombstone recorded, reaction rows untouched) and watching the sweep address the counterparty.

Both retry queries now exclude rows covered by a removal tombstone, and post-auth maintenance reclaims them.

The predicate keys on `removed_conversations` rather than on whether the conversation row still exists, which is what makes it safe where the rejected filter above is not: tombstones survive a non-destructive account switch (pinned by `social_providers_cleanup_test.dart`) while `conversations` is cleared wholesale. It compares `created_at <= removed_at` — the same rule `DmRepository` already applies to messages — so a conversation the counterparty recreates keeps delivering its newer reactions.

Both layers are deliberate. The sweep is armed with `fireImmediately: true` and post-auth maintenance runs unawaited, so a purge on its own would race the sweep and lose. The query guard is the correctness fix; the purge reclaims the rows.

## Verification

New `dm_removal_reaction_queue_test.dart` runs the real `DmRepository`, real `DmReactionsRepository` and real DAOs against a real in-memory Drift database — no DAO mocks — and covers:

- a queued reaction is no longer retryable after removal
- a pending kind-5 removal is no longer retryable after removal
- removal keeps its owner snapshot when credentials clear mid-flight
- received reactions go too, not just own queued ones
- another conversation's queue is untouched
- `removeConversations` clears every id
- another account's rows survive (the delete is owner-scoped)
- a reaction stranded by an older build is never swept up again
- post-auth maintenance reclaims those stranded rows
- a reaction in a conversation recreated after removal still sends

Six of the first seven fail on `main` without the removal-time delete; the three stranded-row tests fail without the tombstone guard and the purge respectively. Atomicity was verified separately: the reaction delete is visible inside the transaction and rolls back with it, so it is genuinely atomic with the message and conversation deletes.

`packages/db_client` gains eight DAO tests for the tombstone predicate, covering the boundary (`created_at` equal to `removed_at` is suppressed, later is kept) and both scoping axes.

`packages/dm_repository` 629/629, `packages/db_client` 992/992, and the app-layer DM/provider suites all pass. `drift` is added to `dm_repository`'s **dev**\_dependencies only — the regression needs a real database, and no lockfile changed.

## Note on #7811

#7811 merged while this was in review. The branch has been rebased onto it and the conflict resolved: both `removeConversation` and `removeConversations` now carry #7811's tombstone + `outgoing_dms` delete **and** the reaction delete, with a merged doc comment. Only the doc comments conflicted — the transaction bodies auto-merged. Re-verified on the new base, and the new tests still fail without the production change.

## Out of scope, reported separately

Two adjacent defects share the same root cause — the reaction queue outlives the `conversations` table it derives its recipients from — but are not fixed here because they fire on the account-switch path, independent of conversation removal:

- **#7880** — a queued **group** reaction narrows to the target message's author alone. That one-element fan-out then has no failures, so it reports *success*: the row flips to `sent` and `swapPlaceholderId` nulls `rumor_event_json`. The other members never receive it, and the rumor needed to re-send is gone — re-tapping mints a new reaction with a new rumor id, it does not repair that row. `outgoing_dms` avoids this by keeping `recipient_pubkey` on the queue row instead of re-deriving it from `conversations`.
- a queued reaction on your **own** message resolves to zero recipients and never terminates, for the same in-memory-budget reason as above


