### PR TITLE
fix(profile): open verified accounts on their public profiles

### DIFF
--- a/mobile/lib/widgets/profile/verified_account_chip.dart
+++ b/mobile/lib/widgets/profile/verified_account_chip.dart
@@ -1,5 +1,5 @@
 // ABOUTME: VerifiedAccountChip — single chip for one verified identity claim.
-// ABOUTME: Tapping opens the platform profile in the system browser.
+// ABOUTME: Public profiles are tappable; claims without a URL are informational.
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
@@ -41,15 +41,18 @@ class VerifiedAccountChip extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         spacing: 6,
         children: [
-          DivineIcon(
-            icon: DivineIconName.globe,
-            size: 14,
-            color: context.vineColors.mutedText,
-          ),
+          if (uri != null)
+            DivineIcon(
+              icon: DivineIconName.globe,
+              size: 14,
+              color: context.vineColors.mutedText,
+            ),
           Text(
             '${claim.platform}/${claim.identity}',
             style: VineTheme.labelMediumFont(
-              color: context.vineColors.primaryText,
+              color: uri == null
+                  ? context.vineColors.mutedText
+                  : context.vineColors.primaryText,
             ),
           ),
         ],

--- a/mobile/lib/widgets/profile/verified_account_chip.dart
+++ b/mobile/lib/widgets/profile/verified_account_chip.dart
@@ -4,8 +4,8 @@
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:openvine/l10n/l10n.dart';
-import 'package:profile_repository/profile_repository.dart';
 import 'package:url_launcher/url_launcher.dart';
+import 'package:verifier_client/verifier_client.dart';
 
 /// Pluggable URL launcher for tests.
 typedef ChipUrlLauncher = Future<bool> Function(Uri uri);
@@ -16,8 +16,7 @@ Future<bool> _defaultLauncher(Uri uri) =>
 /// Chip rendering a single verified [IdentityClaim].
 ///
 /// Tapping opens the platform profile via [launchUrl] (override [launcher] in
-/// tests). Platforms without a clean public URL fall through to the verifier
-/// lookup page.
+/// tests). Platforms without a public profile URL are not interactive.
 class VerifiedAccountChip extends StatelessWidget {
   /// Creates a chip for [claim]. [launcher] defaults to the system browser.
   const VerifiedAccountChip({
@@ -35,9 +34,30 @@ class VerifiedAccountChip extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final l10n = context.l10n;
-    final url = _platformUrl(claim);
+    final uri = platformProfileUrl(claim.platform, claim.identity);
+    final content = Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        spacing: 6,
+        children: [
+          DivineIcon(
+            icon: DivineIconName.globe,
+            size: 14,
+            color: context.vineColors.mutedText,
+          ),
+          Text(
+            '${claim.platform}/${claim.identity}',
+            style: VineTheme.labelMediumFont(
+              color: context.vineColors.primaryText,
+            ),
+          ),
+        ],
+      ),
+    );
+
     return Semantics(
-      button: true,
+      button: uri != null,
       label: l10n.verifiedAccountChipSemanticLabel(
         claim.platform,
         claim.identity,
@@ -52,59 +72,14 @@ class VerifiedAccountChip extends StatelessWidget {
                 : VineTheme.neutral10,
           ),
         ),
-        child: InkWell(
-          borderRadius: BorderRadius.circular(16),
-          onTap: () => launcher(Uri.parse(url)),
-          child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              spacing: 6,
-              children: [
-                DivineIcon(
-                  icon: DivineIconName.globe,
-                  size: 14,
-                  color: context.vineColors.mutedText,
-                ),
-                Text(
-                  '${claim.platform}/${claim.identity}',
-                  style: VineTheme.labelMediumFont(
-                    color: context.vineColors.primaryText,
-                  ),
-                ),
-              ],
-            ),
-          ),
-        ),
+        child: uri == null
+            ? content
+            : InkWell(
+                borderRadius: BorderRadius.circular(16),
+                onTap: () => launcher(uri),
+                child: content,
+              ),
       ),
     );
-  }
-}
-
-/// Builds an external URL for [claim].
-///
-/// Platforms with a stable public profile URL (`github`, `twitter`, `bluesky`,
-/// `youtube`, `tiktok`) get a direct link. Everything else (mastodon, discord,
-/// telegram, unknown) routes through the verifier lookup page so the
-/// verifier itself can resolve the canonical URL.
-String _platformUrl(IdentityClaim claim) {
-  switch (claim.platform.toLowerCase()) {
-    case 'github':
-      return 'https://github.com/${claim.identity}';
-    case 'twitter':
-      return 'https://twitter.com/${claim.identity}';
-    case 'bluesky':
-      return 'https://bsky.app/profile/${claim.identity}';
-    case 'youtube':
-      return 'https://youtube.com/@${claim.identity}';
-    case 'tiktok':
-      return 'https://tiktok.com/@${claim.identity}';
-    case 'mastodon':
-    case 'discord':
-    case 'telegram':
-    default:
-      return 'https://verifier.divine.video/u'
-          '?platform=${claim.platform}'
-          '&identity=${Uri.encodeComponent(claim.identity)}';
   }
 }

--- a/mobile/packages/verifier_client/lib/src/platform_profile_url.dart
+++ b/mobile/packages/verifier_client/lib/src/platform_profile_url.dart
@@ -10,9 +10,14 @@ Uri? platformProfileUrl(String platform, String identity) {
   if (normalizedIdentity.isEmpty) return null;
 
   return switch (platform.trim().toLowerCase()) {
-    'github' => _httpsUri('github.com', [normalizedIdentity]),
+    'github' => _httpsUri('github.com', [
+      _withoutLeadingAt(normalizedIdentity),
+    ]),
     'twitter' => _handleUri('x.com', normalizedIdentity),
-    'bluesky' => _httpsUri('bsky.app', ['profile', normalizedIdentity]),
+    'bluesky' => _httpsUri('bsky.app', [
+      'profile',
+      _withoutLeadingAt(normalizedIdentity),
+    ]),
     'tiktok' => _handleUri(
       'www.tiktok.com',
       normalizedIdentity,
@@ -20,7 +25,7 @@ Uri? platformProfileUrl(String platform, String identity) {
     ),
     'telegram' => _handleUri('t.me', normalizedIdentity),
     'youtube' =>
-      normalizedIdentity.startsWith('UC')
+      _youtubeChannelId.hasMatch(normalizedIdentity)
           ? _httpsUri('www.youtube.com', ['channel', normalizedIdentity])
           : _handleUri(
               'www.youtube.com',
@@ -57,7 +62,7 @@ Uri? _mastodonUri(String identity) {
       origin.path.isNotEmpty ||
       origin.hasQuery ||
       origin.hasFragment ||
-      origin.authority != instance) {
+      origin.authority != instance.toLowerCase()) {
     return null;
   }
 
@@ -66,3 +71,8 @@ Uri? _mastodonUri(String identity) {
 
 Uri _httpsUri(String host, List<String> pathSegments) =>
     Uri(scheme: 'https', host: host, pathSegments: pathSegments);
+
+String _withoutLeadingAt(String identity) =>
+    identity.startsWith('@') ? identity.substring(1) : identity;
+
+final _youtubeChannelId = RegExp(r'^UC[A-Za-z0-9_-]{22}$');

--- a/mobile/packages/verifier_client/lib/src/platform_profile_url.dart
+++ b/mobile/packages/verifier_client/lib/src/platform_profile_url.dart
@@ -1,0 +1,68 @@
+// ABOUTME: Builds public profile URLs for verified identity platforms.
+// ABOUTME: Returns null when a platform has no stable public profile URL.
+
+/// Builds the public profile URI for a verified platform [identity].
+///
+/// Returns `null` when the identity is malformed or the platform does not
+/// expose a stable public profile URL.
+Uri? platformProfileUrl(String platform, String identity) {
+  final normalizedIdentity = identity.trim();
+  if (normalizedIdentity.isEmpty) return null;
+
+  return switch (platform.trim().toLowerCase()) {
+    'github' => _httpsUri('github.com', [normalizedIdentity]),
+    'twitter' => _handleUri('x.com', normalizedIdentity),
+    'bluesky' => _httpsUri('bsky.app', ['profile', normalizedIdentity]),
+    'tiktok' => _handleUri(
+      'www.tiktok.com',
+      normalizedIdentity,
+      prefix: '@',
+    ),
+    'telegram' => _handleUri('t.me', normalizedIdentity),
+    'youtube' =>
+      normalizedIdentity.startsWith('UC')
+          ? _httpsUri('www.youtube.com', ['channel', normalizedIdentity])
+          : _handleUri(
+              'www.youtube.com',
+              normalizedIdentity,
+              prefix: '@',
+            ),
+    'mastodon' => _mastodonUri(normalizedIdentity),
+    _ => null,
+  };
+}
+
+Uri? _handleUri(String host, String identity, {String prefix = ''}) {
+  final handle = identity.startsWith('@') ? identity.substring(1) : identity;
+  if (handle.isEmpty || handle.contains('/')) return null;
+  return _httpsUri(host, ['$prefix$handle']);
+}
+
+Uri? _mastodonUri(String identity) {
+  final separator = identity.indexOf('/');
+  if (separator <= 0 || separator == identity.length - 1) return null;
+
+  final instance = identity.substring(0, separator);
+  final rawUsername = identity.substring(separator + 1);
+  final username = rawUsername.startsWith('@')
+      ? rawUsername.substring(1)
+      : rawUsername;
+  if (username.isEmpty || username.contains('/')) return null;
+
+  final origin = Uri.tryParse('https://$instance');
+  if (origin == null ||
+      origin.scheme != 'https' ||
+      origin.host.isEmpty ||
+      origin.userInfo.isNotEmpty ||
+      origin.path.isNotEmpty ||
+      origin.hasQuery ||
+      origin.hasFragment ||
+      origin.authority != instance) {
+    return null;
+  }
+
+  return origin.replace(pathSegments: ['@$username']);
+}
+
+Uri _httpsUri(String host, List<String> pathSegments) =>
+    Uri(scheme: 'https', host: host, pathSegments: pathSegments);

--- a/mobile/packages/verifier_client/lib/verifier_client.dart
+++ b/mobile/packages/verifier_client/lib/verifier_client.dart
@@ -5,4 +5,5 @@ export 'src/exceptions.dart';
 export 'src/models/identity_claim.dart';
 export 'src/models/verification_result.dart';
 export 'src/models/verifier_platform.dart';
+export 'src/platform_profile_url.dart';
 export 'src/verifier_client.dart';

--- a/mobile/packages/verifier_client/test/src/platform_profile_url_test.dart
+++ b/mobile/packages/verifier_client/test/src/platform_profile_url_test.dart
@@ -1,0 +1,100 @@
+// ABOUTME: Tests public profile URL construction for verified identity claims.
+// ABOUTME: Covers platform-specific forms and identities without public URLs.
+
+import 'package:test/test.dart';
+import 'package:verifier_client/verifier_client.dart';
+
+void main() {
+  group(platformProfileUrl, () {
+    test('builds a GitHub profile URL', () {
+      expect(
+        platformProfileUrl('github', 'octocat'),
+        Uri.parse('https://github.com/octocat'),
+      );
+    });
+
+    test('builds an X profile URL', () {
+      expect(
+        platformProfileUrl(' Twitter ', ' jack '),
+        Uri.parse('https://x.com/jack'),
+      );
+    });
+
+    test('builds a Bluesky profile URL', () {
+      expect(
+        platformProfileUrl('bluesky', 'alice.bsky.social'),
+        Uri.parse('https://bsky.app/profile/alice.bsky.social'),
+      );
+    });
+
+    test('builds TikTok profile URLs for bare and prefixed handles', () {
+      expect(
+        platformProfileUrl('tiktok', 'alice'),
+        Uri.parse('https://www.tiktok.com/@alice'),
+      );
+      expect(
+        platformProfileUrl('tiktok', '@alice'),
+        Uri.parse('https://www.tiktok.com/@alice'),
+      );
+    });
+
+    test('builds Telegram profile URLs for bare and prefixed handles', () {
+      expect(
+        platformProfileUrl('telegram', 'alice'),
+        Uri.parse('https://t.me/alice'),
+      );
+      expect(
+        platformProfileUrl('telegram', '@alice'),
+        Uri.parse('https://t.me/alice'),
+      );
+    });
+
+    test('builds a YouTube channel URL for a channel ID', () {
+      expect(
+        platformProfileUrl('youtube', 'UC_x5XG1OV2P6uZZ5FSM9Ttw'),
+        Uri.parse('https://www.youtube.com/channel/UC_x5XG1OV2P6uZZ5FSM9Ttw'),
+      );
+    });
+
+    test('builds YouTube handle URLs without duplicating at signs', () {
+      expect(
+        platformProfileUrl('youtube', 'alice'),
+        Uri.parse('https://www.youtube.com/@alice'),
+      );
+      expect(
+        platformProfileUrl('youtube', '@alice'),
+        Uri.parse('https://www.youtube.com/@alice'),
+      );
+    });
+
+    test('builds a Mastodon URL from an at-prefixed username', () {
+      expect(
+        platformProfileUrl('mastodon', 'fosstodon.org/@alice'),
+        Uri.parse('https://fosstodon.org/@alice'),
+      );
+    });
+
+    test('adds the Mastodon username at sign when omitted', () {
+      expect(
+        platformProfileUrl('mastodon', 'fosstodon.org/alice'),
+        Uri.parse('https://fosstodon.org/@alice'),
+      );
+    });
+
+    test('rejects malformed Mastodon identities', () {
+      expect(platformProfileUrl('mastodon', 'alice'), isNull);
+      expect(platformProfileUrl('mastodon', '/@alice'), isNull);
+      expect(
+        platformProfileUrl('mastodon', 'https://example.com/@alice'),
+        isNull,
+      );
+      expect(platformProfileUrl('mastodon', 'example.com/'), isNull);
+    });
+
+    test('returns null for identities without a public profile URL', () {
+      expect(platformProfileUrl('discord', 'alice'), isNull);
+      expect(platformProfileUrl('unknown', 'alice'), isNull);
+      expect(platformProfileUrl('github', '  '), isNull);
+    });
+  });
+}

--- a/mobile/packages/verifier_client/test/src/platform_profile_url_test.dart
+++ b/mobile/packages/verifier_client/test/src/platform_profile_url_test.dart
@@ -11,6 +11,10 @@ void main() {
         platformProfileUrl('github', 'octocat'),
         Uri.parse('https://github.com/octocat'),
       );
+      expect(
+        platformProfileUrl('github', '@octocat'),
+        Uri.parse('https://github.com/octocat'),
+      );
     });
 
     test('builds an X profile URL', () {
@@ -23,6 +27,10 @@ void main() {
     test('builds a Bluesky profile URL', () {
       expect(
         platformProfileUrl('bluesky', 'alice.bsky.social'),
+        Uri.parse('https://bsky.app/profile/alice.bsky.social'),
+      );
+      expect(
+        platformProfileUrl('bluesky', '@alice.bsky.social'),
         Uri.parse('https://bsky.app/profile/alice.bsky.social'),
       );
     });
@@ -65,6 +73,10 @@ void main() {
         platformProfileUrl('youtube', '@alice'),
         Uri.parse('https://www.youtube.com/@alice'),
       );
+      expect(
+        platformProfileUrl('youtube', 'UCLA'),
+        Uri.parse('https://www.youtube.com/@UCLA'),
+      );
     });
 
     test('builds a Mastodon URL from an at-prefixed username', () {
@@ -78,6 +90,13 @@ void main() {
       expect(
         platformProfileUrl('mastodon', 'fosstodon.org/alice'),
         Uri.parse('https://fosstodon.org/@alice'),
+      );
+    });
+
+    test('accepts a mixed-case Mastodon instance', () {
+      expect(
+        platformProfileUrl('mastodon', 'Mastodon.Social/@alice'),
+        Uri.parse('https://mastodon.social/@alice'),
       );
     });
 

--- a/mobile/test/widgets/profile/verified_account_chip_test.dart
+++ b/mobile/test/widgets/profile/verified_account_chip_test.dart
@@ -1,5 +1,6 @@
-// ABOUTME: Widget tests for VerifiedAccountChip — render + tap launches URL.
+// ABOUTME: Widget tests for interactive and informational verified-account chips.
 
+import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/semantics.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -140,6 +141,7 @@ void main() {
 
       expect(find.textContaining('discord'), findsOneWidget);
       expect(find.byType(InkWell), findsNothing);
+      expect(find.byType(DivineIcon), findsNothing);
 
       final semantics = tester.getSemantics(find.byType(VerifiedAccountChip));
       expect(

--- a/mobile/test/widgets/profile/verified_account_chip_test.dart
+++ b/mobile/test/widgets/profile/verified_account_chip_test.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Widget tests for VerifiedAccountChip — render + tap launches URL.
 
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/widgets/profile/verified_account_chip.dart';
@@ -60,7 +61,7 @@ void main() {
       expect(launched.toString(), equals('https://github.com/octocat'));
     });
 
-    testWidgets('mastodon claims route through verifier lookup', (
+    testWidgets('mastodon claims launch the public profile', (
       tester,
     ) async {
       Uri? launched;
@@ -83,13 +84,69 @@ void main() {
       await tester.pump();
       await tester.tap(find.byType(InkWell));
       await tester.pumpAndSettle();
-      expect(launched, isNotNull);
-      expect(launched!.host, equals('verifier.divine.video'));
-      expect(launched!.queryParameters['platform'], equals('mastodon'));
-      expect(
-        launched!.queryParameters['identity'],
-        equals('fosstodon.org/@alice'),
+      expect(launched, Uri.parse('https://fosstodon.org/@alice'));
+    });
+
+    testWidgets('youtube channel claims launch the channel profile', (
+      tester,
+    ) async {
+      Uri? launched;
+      await tester.pumpWidget(
+        _wrap(
+          VerifiedAccountChip(
+            claim: const IdentityClaim(
+              pubkey: _hex64,
+              platform: 'youtube',
+              identity: 'UC_x5XG1OV2P6uZZ5FSM9Ttw',
+              proof: 'abc',
+            ),
+            launcher: (uri) async {
+              launched = uri;
+              return true;
+            },
+          ),
+        ),
       );
+      await tester.tap(find.byType(InkWell));
+      await tester.pumpAndSettle();
+      expect(
+        launched,
+        Uri.parse(
+          'https://www.youtube.com/channel/UC_x5XG1OV2P6uZZ5FSM9Ttw',
+        ),
+      );
+    });
+
+    testWidgets('discord claims are visible but not interactive', (
+      tester,
+    ) async {
+      var launches = 0;
+      await tester.pumpWidget(
+        _wrap(
+          VerifiedAccountChip(
+            claim: const IdentityClaim(
+              pubkey: _hex64,
+              platform: 'discord',
+              identity: 'alice',
+              proof: 'abc',
+            ),
+            launcher: (_) async {
+              launches++;
+              return true;
+            },
+          ),
+        ),
+      );
+
+      expect(find.textContaining('discord'), findsOneWidget);
+      expect(find.byType(InkWell), findsNothing);
+
+      final semantics = tester.getSemantics(find.byType(VerifiedAccountChip));
+      expect(
+        semantics.getSemanticsData().hasAction(SemanticsAction.tap),
+        isFalse,
+      );
+      expect(launches, isZero);
     });
   });
 }


### PR DESCRIPTION
Verified account chips could send people to a verifier lookup page that does not exist, so Mastodon, Telegram, Discord, and unknown claims opened a 404 instead of the linked account. YouTube identities also produced invalid URLs when they were channel IDs or already-prefixed handles.

This change centralizes platform profile URI construction in `verifier_client`, sends supported claims directly to their public profiles, and leaves claims such as Discord visible but non-interactive when no stable public profile URL exists. It also validates malformed Mastodon identities instead of constructing an unsafe or misleading destination.

This deliberately does not change verification, proof lookup, claim storage, or the linked-account display text.

Verification:
- `flutter analyze --no-pub lib/widgets/profile/verified_account_chip.dart test/widgets/profile/verified_account_chip_test.dart packages/verifier_client/lib packages/verifier_client/test`
- `flutter test --no-pub test/widgets/profile/verified_account_chip_test.dart`
- `flutter test --no-pub packages/verifier_client/test`
- Full `verifier_client` coverage: 89.2% (floor: 76%)

Fixes #7810