### PR TITLE
fix(dm): avoid retrying terminal NIP-04 duplicates

### DIFF
--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -2521,6 +2521,8 @@ class DmRepository {
           break;
         }
       }
+      // A missing recipient is rejected before decryption, so recording it in
+      // the processed ledger would not avoid cryptographic work on replay.
       if (recipientPubkey == null) return;
 
       // Determine sender and the other party's pubkey for decryption
@@ -2530,6 +2532,8 @@ class DmRepository {
 
       // Decrypt using injected decryptor or signer fallback
       final signer = _signer;
+      // Keep missing-decryptor events retryable: signer availability can
+      // change without the relay event changing.
       if (signer == null && _nip04Decryptor == null) return;
       final decryptor =
           _nip04Decryptor ??
@@ -2537,6 +2541,7 @@ class DmRepository {
               signer!.decrypt(pubkey, ciphertext);
       final plaintext = await decryptor(peerPubkey, nip04Event.content);
       if (plaintext == null) {
+        // Keep failed decryptions retryable; a later attempt may succeed.
         Log.debug(
           'Failed to decrypt NIP-04 event ${nip04Event.id}',
           category: LogCategory.system,
@@ -2657,6 +2662,11 @@ class DmRepository {
         return;
       }
       if (!inserted) {
+        // Terminal: local uniqueness constraints already represent this
+        // event in the message store. Record it even though hasGiftWrap will
+        // normally catch the same row, preserving the terminal outcome if
+        // the conflicting constraint was the message id instead.
+        await _recordProcessedWrap(nip04Event.id);
         Log.debug(
           'Skipped duplicate NIP-04 event ${nip04Event.id}: insert was '
           'ignored by local dedup constraints',

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -8994,6 +8994,87 @@ void main() {
         },
       );
 
+      test(
+        'a NIP-04 event ignored by database dedup is recorded so redelivery '
+        'skips decrypt',
+        () async {
+          final nip04Event = createNip04Event();
+          final ledger = _InMemoryProcessedGiftWrapsDao();
+          var decryptCalls = 0;
+          when(
+            () => mockDirectMessagesDao.hasGiftWrap(_rumorEventId),
+          ).thenAnswer((_) async => false);
+          when(
+            () => mockDirectMessagesDao.hasMatchingMessage(
+              conversationId: any(named: 'conversationId'),
+              senderPubkey: any(named: 'senderPubkey'),
+              content: any(named: 'content'),
+              createdAt: any(named: 'createdAt'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          ).thenAnswer((_) async => false);
+          when(
+            () => mockDirectMessagesDao.insertMessage(
+              id: any(named: 'id'),
+              conversationId: any(named: 'conversationId'),
+              senderPubkey: any(named: 'senderPubkey'),
+              content: any(named: 'content'),
+              createdAt: any(named: 'createdAt'),
+              giftWrapId: any(named: 'giftWrapId'),
+              messageKind: any(named: 'messageKind'),
+              replyToId: any(named: 'replyToId'),
+              subject: any(named: 'subject'),
+              fileType: any(named: 'fileType'),
+              encryptionAlgorithm: any(named: 'encryptionAlgorithm'),
+              decryptionKey: any(named: 'decryptionKey'),
+              decryptionNonce: any(named: 'decryptionNonce'),
+              fileHash: any(named: 'fileHash'),
+              originalFileHash: any(named: 'originalFileHash'),
+              fileSize: any(named: 'fileSize'),
+              dimensions: any(named: 'dimensions'),
+              blurhash: any(named: 'blurhash'),
+              thumbnailUrl: any(named: 'thumbnailUrl'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+              tagsJson: any(named: 'tagsJson'),
+              sendBatchId: any(named: 'sendBatchId'),
+            ),
+          ).thenAnswer((_) async => false);
+
+          final controller = StreamController<Event>();
+          when(
+            () => mockNostrClient.subscribe(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+            ),
+          ).thenAnswer((_) => controller.stream);
+
+          final repository = createRepository(
+            processedGiftWrapsDao: ledger,
+            nip04Decryptor: (_, _) async {
+              decryptCalls++;
+              return 'Decrypted NIP-04 text';
+            },
+          );
+          await repository.startListening();
+
+          controller.add(nip04Event);
+          await Future<void>.delayed(Duration.zero);
+          await Future<void>.delayed(Duration.zero);
+
+          expect(decryptCalls, 1);
+          expect(ledger.recorded, contains(_rumorEventId));
+
+          controller.add(nip04Event);
+          await Future<void>.delayed(Duration.zero);
+          await Future<void>.delayed(Duration.zero);
+
+          expect(decryptCalls, 1);
+
+          await controller.close();
+          await repository.stopListening();
+        },
+      );
+
       test('decrypts and persists a NIP-04 message', () async {
         final nip04Event = createNip04Event();
 
@@ -9395,8 +9476,10 @@ void main() {
         await repository.stopListening();
       });
 
-      test('skips NIP-04 events when decryption fails', () async {
+      test('failed NIP-04 decrypt stays retryable on redelivery', () async {
         final nip04Event = createNip04Event();
+        final ledger = _InMemoryProcessedGiftWrapsDao();
+        var decryptCalls = 0;
 
         when(
           () => mockDirectMessagesDao.hasGiftWrap(_rumorEventId),
@@ -9411,12 +9494,24 @@ void main() {
         ).thenAnswer((_) => controller.stream);
 
         final repository = createRepository(
-          nip04Decryptor: (_, _) async => null,
+          processedGiftWrapsDao: ledger,
+          nip04Decryptor: (_, _) async {
+            decryptCalls++;
+            return null;
+          },
         );
 
         await repository.startListening();
         controller.add(nip04Event);
         await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+
+        controller.add(nip04Event);
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(decryptCalls, 2);
+        expect(ledger.recorded, isEmpty);
 
         verifyNever(
           () => mockDirectMessagesDao.insertMessage(


### PR DESCRIPTION
Relay replays can deliver the same encrypted direct-message event after the local database has already rejected it as a duplicate. That terminal outcome was not written to the processed-event ledger, unlike the equivalent NIP-17 path, so the handler could repeat work instead of remembering the decision.

This records NIP-04 events when the message insert is rejected by local uniqueness constraints. It also documents why malformed pre-decrypt events and unavailable or failed decryption remain retryable.

This deliberately does not change cross-protocol content matching. Whether those matches should become durable remains tied to the separate policy decision in #7324.

Verification:
- `flutter test test/src/dm_repository_test.dart`
- `flutter test --coverage` (94.00% line coverage; 620 tests)
- `flutter analyze lib test integration_test`
- pre-push changed-file checks
- regression test confirmed red with the ledger write removed, then green after restoration

Closes #7882