### PR TITLE
docs(shorebird): name the internal TestFlight group and verify delivery

### DIFF
--- a/mobile/docs/SHOREBIRD_CODE_PUSH.md
+++ b/mobile/docs/SHOREBIRD_CODE_PUSH.md
@@ -116,15 +116,33 @@ App Store version train.
 iOS publishing deliberately stops after uploading the Shorebird IPA to App
 Store Connect (`submit_to_testflight: false`, `submit_to_app_store: false`).
 App Store Connect, not Codemagic, provides automatic internal TestFlight
-distribution. This depends on configuration outside this repository: enable
-**Automatic Distribution** on every internal-only tester group that should
-receive each build without Beta App Review. Do not put external testers in
-those groups.
+distribution. This depends on configuration outside this repository.
+
+There is exactly one internal tester group: **Divine Internal**. It must have
+**Automatic Distribution** enabled, and it must contain no external testers —
+adding one turns every build into a Beta App Review submission. Codemagic no
+longer names the group, because it stopped assigning beta groups when
+publishing became upload-only, so nothing in this repository fails if that
+toggle is turned off or the group is renamed. Manage membership in App Store
+Connect; the group is recorded here only so the dependency stays reviewable.
+
+Because it is a single group, it is also a single point of failure: if its
+Automatic Distribution is off, no internal tester receives any build, and
+every Codemagic run still reports success.
 
 A green Codemagic build confirms the IPA upload, not successful App Store
-Connect processing or tester distribution. After each iOS build, confirm the
-build finishes processing and reaches **Ready to Test**, then verify an internal
-tester can see it before treating internal delivery as complete.
+Connect processing or tester distribution. After each iOS build, work through
+this before treating internal delivery as complete:
+
+1. Confirm the build finishes processing in App Store Connect and reaches
+   **Ready to Test**. Codemagic reports success as soon as the upload lands,
+   which is several minutes earlier.
+2. Confirm the build was distributed to **Divine Internal**.
+3. Confirm an internal tester actually sees it in TestFlight.
+
+A build that uploaded but never reached testers looks identical to a healthy
+one from Codemagic alone, which is why this is a checklist rather than a
+closing remark.
 
 After internal testing passes, perform a manual external TestFlight promotion
 of the same build in App Store Connect: add it to the external groups and submit


### PR DESCRIPTION
Closes #7919

Follow-up to #7801 / #7803.

#7801 changed iOS publishing to upload-only and removed the `beta_groups` list from `codemagic.yaml`, making App Store Connect's **Automatic Distribution** the single automatic path to internal testers. That was the right call — Codemagic's publisher was creating a Beta App Review submission and failing the build whenever another build from the same version train was already under review.

The side effect is that the internal-distribution dependency is now entirely invisible from this repository. Nothing here fails if the group loses Automatic Distribution, gets renamed, or gains an external tester, and nothing here even names it any more.

## Changes

**Record the internal group.** The tester groups were cleaned up in App Store Connect on 2026-08-19: the three groups Codemagic used to assign (`AOS`, `GW`, `rabblelabs`) are deleted, and there is now exactly one internal group, **Divine Internal**. Membership stays managed in App Store Connect; the runbook records only which group must have the toggle on.

**Call out the single point of failure.** With one group there is no redundancy left. If its Automatic Distribution is off, no internal tester receives any build — and every Codemagic run still reports success, because the upload genuinely succeeded.

**Turn the post-build check into a numbered checklist.** The prose from #7801 already said to confirm the build reaches Ready to Test and that a tester can see it. Making it three explicit steps — processing completes, the group receives it, a tester confirms — means the middle step gets done.

## Verification

Docs only — no Dart changed, so the pre-push hook skipped analyze and tests.

Group name confirmed against App Store Connect by the maintainer, and recorded here with their approval under the `AGENTS.md` security rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)