### PR TITLE
feat(divine_video_player): export audio overlay failures in bug reports

### DIFF
--- a/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/AudioOverlayManager.swift
+++ b/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/AudioOverlayManager.swift
@@ -201,15 +201,24 @@ final class AudioOverlayManager {
             toleranceBefore: .zero,
             toleranceAfter: .zero
         ) { [weak self, weak entry] completed in
-            guard let self, let entry else { return }
-            let message = "Audio overlay track \(entry.trackIndex): " +
-                "\(reason) seek completed=\(completed)"
-            if completed {
-                self.log.debug(message, name: self.logName)
-            } else {
-                self.log.warning(message, name: self.logName)
+            // AVFoundation does not document which queue delivers this, and
+            // AVPlayer is not thread-safe. Every other read and write of
+            // overlay state happens on the main queue, so hop back before
+            // touching the entry's last-reported status fields.
+            DispatchQueue.main.async {
+                guard let self, let entry else { return }
+                let message = "Audio overlay track \(entry.trackIndex): " +
+                    "\(reason) seek completed=\(completed)"
+                if completed {
+                    self.log.debug(message, name: self.logName)
+                } else {
+                    self.log.warning(message, name: self.logName)
+                }
+                self.reportStatusIfChanged(
+                    for: entry,
+                    context: "\(reason) seek"
+                )
             }
-            self.reportStatusIfChanged(for: entry, context: "\(reason) seek")
         }
     }
 

--- a/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/AudioOverlayManager.swift
+++ b/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/AudioOverlayManager.swift
@@ -94,6 +94,10 @@ final class AudioOverlayManager {
     func pauseAndDeactivateAll() {
         for entry in overlays {
             entry.player.pause()
+            // Report the deactivation, not the call: pause arrives on every
+            // stop and every pause tap, and re-logging already-idle tracks
+            // spends bug-report capacity on a non-event.
+            guard entry.isActive else { continue }
             entry.isActive = false
             log.info(
                 "Audio overlay track \(entry.trackIndex): paused and deactivated",

--- a/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/AudioOverlayManager.swift
+++ b/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/AudioOverlayManager.swift
@@ -92,7 +92,6 @@ final class AudioOverlayManager {
     /// the video position falls within that track's active range.
     func update(videoPositionSec: Double, isPlaying: Bool, speed: Double) {
         logger.debug("update: position \(videoPositionSec)")
-        logger.debug("update called")
         for entry in overlays {
             let inRange = videoPositionSec >= entry.videoStartSec &&
                 (entry.videoEndSec == nil || videoPositionSec < entry.videoEndSec!)

--- a/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/AudioOverlayManager.swift
+++ b/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/AudioOverlayManager.swift
@@ -52,7 +52,11 @@ final class AudioOverlayManager {
 
     /// Sets volume for the overlay at `index`.
     func setTrackVolume(at index: Int, volume: Float) {
-        guard index >= 0, index < overlays.count else { return }
+        guard index >= 0, index < overlays.count else { 
+            logger.warning("setTrackVolume: index out of bounds")
+            return 
+        }
+        logger.debug("setTrackVolume: index \(index) volume \(volume)")
         overlays[index].player.volume = volume
     }
 
@@ -69,14 +73,14 @@ final class AudioOverlayManager {
     func pauseAndDeactivateAll() {
         for entry in overlays {
             entry.player.pause()
-            entry.player.pause()
             entry.isActive = false
-                        entry.logger.info("pausing track")
+            entry.logger.info("pausing track")
         }
     }
 
     /// Updates playback speed on currently active overlay players.
     func setSpeed(_ speed: Double) {
+        logger.debug("setSpeed: \(speed)")
         for entry in overlays where entry.isActive {
             entry.player.rate = Float(speed)
         }
@@ -87,6 +91,7 @@ final class AudioOverlayManager {
     /// Starts, pauses, or drift-corrects each overlay based on whether
     /// the video position falls within that track's active range.
     func update(videoPositionSec: Double, isPlaying: Bool, speed: Double) {
+        logger.debug("update: position \(videoPositionSec)")
         logger.debug("update called")
         for entry in overlays {
             let inRange = videoPositionSec >= entry.videoStartSec &&
@@ -100,7 +105,6 @@ final class AudioOverlayManager {
                 if let trackEnd = entry.trackEndSec, expectedAudioSec >= trackEnd {
                     if entry.isActive {
                         entry.player.pause()
-                        entry.player.pause()
                         entry.isActive = false
                         entry.logger.info("pausing track")
                     }
@@ -109,6 +113,7 @@ final class AudioOverlayManager {
 
                 if !entry.isActive {
                     let audioTime = CMTime(seconds: expectedAudioSec, preferredTimescale: 600)
+                    logger.info("update: starting playback")
                     entry.player.seek(to: audioTime, toleranceBefore: .zero, toleranceAfter: .zero)
                     entry.player.play()
                     entry.player.rate = Float(speed)
@@ -118,6 +123,7 @@ final class AudioOverlayManager {
                     let actualSec = CMTimeGetSeconds(entry.player.currentTime())
                     let drift = abs(expectedAudioSec - actualSec)
                     if drift > driftThreshold {
+                        logger.debug("update: drift correction \(drift)")
                         let audioTime = CMTime(seconds: expectedAudioSec, preferredTimescale: 600)
                         entry.player.seek(to: audioTime, toleranceBefore: .zero, toleranceAfter: .zero)
                     }
@@ -125,9 +131,8 @@ final class AudioOverlayManager {
             } else {
                 if entry.isActive {
                     entry.player.pause()
-                    entry.player.pause()
                     entry.isActive = false
-                        entry.logger.info("pausing track")
+                    entry.logger.info("pausing track")
                 }
             }
         }
@@ -167,5 +172,7 @@ final class AudioOverlayEntry {
         self.videoEndSec = videoEndSec
         self.trackStartSec = trackStartSec
         self.trackEndSec = trackEndSec
+        self.trackIndex = 0
+        self.logger = Logger(subsystem: "divine_video_player", category: "AudioOverlayEntry")
     }
 }

--- a/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/AudioOverlayManager.swift
+++ b/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/AudioOverlayManager.swift
@@ -52,9 +52,9 @@ final class AudioOverlayManager {
 
     /// Sets volume for the overlay at `index`.
     func setTrackVolume(at index: Int, volume: Float) {
-        guard index >= 0, index < overlays.count else { 
+        guard index >= 0, index < overlays.count else {
             logger.warning("setTrackVolume: index out of bounds")
-            return 
+            return
         }
         logger.debug("setTrackVolume: index \(index) volume \(volume)")
         overlays[index].player.volume = volume

--- a/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/AudioOverlayManager.swift
+++ b/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/AudioOverlayManager.swift
@@ -114,9 +114,14 @@ final class AudioOverlayManager {
     /// Starts, pauses, or drift-corrects each overlay based on whether
     /// the video position falls within that track's active range.
     func update(videoPositionSec: Double, isPlaying: Bool, speed: Double) {
-        // This runs every 0.2 seconds. Keep it out of UnifiedLogger so user
-        // bug reports retain capacity for state transitions and failures.
+        guard !overlays.isEmpty else { return }
+        // Runs every 0.2 seconds on the main queue for every player instance.
+        // Console-only so user bug reports retain capacity for state
+        // transitions and failures, and debug-only because a console trace
+        // never reaches a bug report in the first place.
+        #if DEBUG
         print("[AudioOverlay] update: position \(videoPositionSec)")
+        #endif
         for entry in overlays {
             reportStatusIfChanged(for: entry, context: "update")
             let inRange = videoPositionSec >= entry.videoStartSec &&
@@ -156,10 +161,12 @@ final class AudioOverlayManager {
                     let actualSec = CMTimeGetSeconds(entry.player.currentTime())
                     let drift = abs(expectedAudioSec - actualSec)
                     if drift > driftThreshold {
+                        #if DEBUG
                         print(
                             "[AudioOverlay] track \(entry.trackIndex): " +
                                 "drift correction \(drift)s"
                         )
+                        #endif
                         let audioTime = CMTime(seconds: expectedAudioSec, preferredTimescale: 600)
                         seek(entry, to: audioTime, reason: "drift correction")
                     }

--- a/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/AudioOverlayManager.swift
+++ b/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/AudioOverlayManager.swift
@@ -1,4 +1,5 @@
 import AVFoundation
+import os
 
 /// Manages audio overlay tracks that play alongside the main video.
 ///
@@ -7,15 +8,20 @@ import AVFoundation
 /// aligned within ``driftThreshold``.
 final class AudioOverlayManager {
 
+    private let logger = Logger(subsystem: "divine_video_player", category: "AudioOverlay")
     private var overlays: [AudioOverlayEntry] = []
     private let driftThreshold: Double = 0.25
 
     /// Replaces all audio overlays with the given track definitions.
     func setTracks(from tracksRaw: [[String: Any]]) {
+        logger.debug("setTracks: replacing overlays")
         disposeAll()
 
-        for map in tracksRaw {
-            guard let uri = map["uri"] as? String else { continue }
+        for (index, map) in tracksRaw.enumerated() {
+            guard let uri = map["uri"] as? String else {
+                logger.warning("setTracks: skipping track - no uri")
+                continue
+            }
             let vol = (map["volume"] as? NSNumber)?.floatValue ?? 1.0
             let videoStartMs = (map["videoStartMs"] as? NSNumber)?.doubleValue ?? 0
             let videoEndMs = (map["videoEndMs"] as? NSNumber)?.doubleValue
@@ -53,6 +59,7 @@ final class AudioOverlayManager {
     /// Resumes playback of currently active overlays at the given speed.
     func resumeActive(speed: Double) {
         for entry in overlays where entry.isActive {
+            entry.logger.debug("playing track")
             entry.player.play()
             entry.player.rate = Float(speed)
         }
@@ -62,7 +69,9 @@ final class AudioOverlayManager {
     func pauseAndDeactivateAll() {
         for entry in overlays {
             entry.player.pause()
+            entry.player.pause()
             entry.isActive = false
+                        entry.logger.info("pausing track")
         }
     }
 
@@ -78,6 +87,7 @@ final class AudioOverlayManager {
     /// Starts, pauses, or drift-corrects each overlay based on whether
     /// the video position falls within that track's active range.
     func update(videoPositionSec: Double, isPlaying: Bool, speed: Double) {
+        logger.debug("update called")
         for entry in overlays {
             let inRange = videoPositionSec >= entry.videoStartSec &&
                 (entry.videoEndSec == nil || videoPositionSec < entry.videoEndSec!)
@@ -90,7 +100,9 @@ final class AudioOverlayManager {
                 if let trackEnd = entry.trackEndSec, expectedAudioSec >= trackEnd {
                     if entry.isActive {
                         entry.player.pause()
+                        entry.player.pause()
                         entry.isActive = false
+                        entry.logger.info("pausing track")
                     }
                     continue
                 }
@@ -113,7 +125,9 @@ final class AudioOverlayManager {
             } else {
                 if entry.isActive {
                     entry.player.pause()
+                    entry.player.pause()
                     entry.isActive = false
+                        entry.logger.info("pausing track")
                 }
             }
         }
@@ -121,6 +135,7 @@ final class AudioOverlayManager {
 
     /// Releases all overlay players and clears the list.
     func disposeAll() {
+        logger.debug("disposeAll called")
         for entry in overlays {
             entry.player.pause()
             entry.player.replaceCurrentItem(with: nil)
@@ -137,6 +152,8 @@ final class AudioOverlayEntry {
     let trackStartSec: Double
     let trackEndSec: Double?
     var isActive: Bool = false
+    let trackIndex: Int
+    let logger: Logger
 
     init(
         player: AVPlayer,

--- a/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/AudioOverlayManager.swift
+++ b/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/AudioOverlayManager.swift
@@ -1,5 +1,4 @@
 import AVFoundation
-import os
 
 /// Manages audio overlay tracks that play alongside the main video.
 ///
@@ -8,18 +7,25 @@ import os
 /// aligned within ``driftThreshold``.
 final class AudioOverlayManager {
 
-    private let logger = Logger(subsystem: "divine_video_player", category: "AudioOverlay")
+    private let log = DivineVideoPlayerLog.shared
     private var overlays: [AudioOverlayEntry] = []
     private let driftThreshold: Double = 0.25
+    private let logName = "AudioOverlayManager"
 
     /// Replaces all audio overlays with the given track definitions.
     func setTracks(from tracksRaw: [[String: Any]]) {
-        logger.debug("setTracks: replacing overlays")
+        log.info(
+            "Replacing audio overlays with \(tracksRaw.count) track(s)",
+            name: logName
+        )
         disposeAll()
 
         for (index, map) in tracksRaw.enumerated() {
             guard let uri = map["uri"] as? String else {
-                logger.warning("setTracks: skipping track - no uri")
+                log.warning(
+                    "Audio overlay track \(index): skipping track with no uri",
+                    name: logName
+                )
                 continue
             }
             let vol = (map["volume"] as? NSNumber)?.floatValue ?? 1.0
@@ -34,6 +40,10 @@ final class AudioOverlayManager {
             } else if let parsed = URL(string: uri) {
                 url = parsed
             } else {
+                log.warning(
+                    "Audio overlay track \(index): skipping invalid uri",
+                    name: logName
+                )
                 continue
             }
 
@@ -45,7 +55,8 @@ final class AudioOverlayManager {
                 videoStartSec: videoStartMs / 1000.0,
                 videoEndSec: videoEndMs.map { $0 / 1000.0 },
                 trackStartSec: trackStartMs / 1000.0,
-                trackEndSec: trackEndMs.map { $0 / 1000.0 }
+                trackEndSec: trackEndMs.map { $0 / 1000.0 },
+                trackIndex: index
             ))
         }
     }
@@ -53,19 +64,29 @@ final class AudioOverlayManager {
     /// Sets volume for the overlay at `index`.
     func setTrackVolume(at index: Int, volume: Float) {
         guard index >= 0, index < overlays.count else {
-            logger.warning("setTrackVolume: index out of bounds")
+            log.warning(
+                "Audio overlay index \(index): volume update out of bounds",
+                name: logName
+            )
             return
         }
-        logger.debug("setTrackVolume: index \(index) volume \(volume)")
+        log.debug(
+            "Audio overlay track \(overlays[index].trackIndex): volume set to \(volume)",
+            name: logName
+        )
         overlays[index].player.volume = volume
     }
 
     /// Resumes playback of currently active overlays at the given speed.
     func resumeActive(speed: Double) {
         for entry in overlays where entry.isActive {
-            entry.logger.debug("playing track")
+            log.info(
+                "Audio overlay track \(entry.trackIndex): resuming at speed \(speed)",
+                name: logName
+            )
             entry.player.play()
             entry.player.rate = Float(speed)
+            reportStatusIfChanged(for: entry, context: "resume")
         }
     }
 
@@ -74,13 +95,15 @@ final class AudioOverlayManager {
         for entry in overlays {
             entry.player.pause()
             entry.isActive = false
-            entry.logger.info("pausing track")
+            log.info(
+                "Audio overlay track \(entry.trackIndex): paused and deactivated",
+                name: logName
+            )
         }
     }
 
     /// Updates playback speed on currently active overlay players.
     func setSpeed(_ speed: Double) {
-        logger.debug("setSpeed: \(speed)")
         for entry in overlays where entry.isActive {
             entry.player.rate = Float(speed)
         }
@@ -91,8 +114,11 @@ final class AudioOverlayManager {
     /// Starts, pauses, or drift-corrects each overlay based on whether
     /// the video position falls within that track's active range.
     func update(videoPositionSec: Double, isPlaying: Bool, speed: Double) {
-        logger.debug("update: position \(videoPositionSec)")
+        // This runs every 0.2 seconds. Keep it out of UnifiedLogger so user
+        // bug reports retain capacity for state transitions and failures.
+        print("[AudioOverlay] update: position \(videoPositionSec)")
         for entry in overlays {
+            reportStatusIfChanged(for: entry, context: "update")
             let inRange = videoPositionSec >= entry.videoStartSec &&
                 (entry.videoEndSec == nil || videoPositionSec < entry.videoEndSec!)
 
@@ -105,33 +131,47 @@ final class AudioOverlayManager {
                     if entry.isActive {
                         entry.player.pause()
                         entry.isActive = false
-                        entry.logger.info("pausing track")
+                        log.info(
+                            "Audio overlay track \(entry.trackIndex): reached track end",
+                            name: logName
+                        )
                     }
                     continue
                 }
 
                 if !entry.isActive {
                     let audioTime = CMTime(seconds: expectedAudioSec, preferredTimescale: 600)
-                    logger.info("update: starting playback")
-                    entry.player.seek(to: audioTime, toleranceBefore: .zero, toleranceAfter: .zero)
+                    log.info(
+                        "Audio overlay track \(entry.trackIndex): starting playback " +
+                            "at \(expectedAudioSec)s, speed \(speed)",
+                        name: logName
+                    )
+                    seek(entry, to: audioTime, reason: "playback start")
                     entry.player.play()
                     entry.player.rate = Float(speed)
                     entry.isActive = true
+                    reportStatusIfChanged(for: entry, context: "playback start")
                 } else {
                     // Correct drift.
                     let actualSec = CMTimeGetSeconds(entry.player.currentTime())
                     let drift = abs(expectedAudioSec - actualSec)
                     if drift > driftThreshold {
-                        logger.debug("update: drift correction \(drift)")
+                        print(
+                            "[AudioOverlay] track \(entry.trackIndex): " +
+                                "drift correction \(drift)s"
+                        )
                         let audioTime = CMTime(seconds: expectedAudioSec, preferredTimescale: 600)
-                        entry.player.seek(to: audioTime, toleranceBefore: .zero, toleranceAfter: .zero)
+                        seek(entry, to: audioTime, reason: "drift correction")
                     }
                 }
             } else {
                 if entry.isActive {
                     entry.player.pause()
                     entry.isActive = false
-                    entry.logger.info("pausing track")
+                    log.info(
+                        "Audio overlay track \(entry.trackIndex): paused outside active range",
+                        name: logName
+                    )
                 }
             }
         }
@@ -139,12 +179,66 @@ final class AudioOverlayManager {
 
     /// Releases all overlay players and clears the list.
     func disposeAll() {
-        logger.debug("disposeAll called")
+        guard !overlays.isEmpty else { return }
+        log.debug("Disposing \(overlays.count) audio overlay(s)", name: logName)
         for entry in overlays {
             entry.player.pause()
             entry.player.replaceCurrentItem(with: nil)
         }
         overlays.removeAll()
+    }
+
+    private func seek(_ entry: AudioOverlayEntry, to time: CMTime, reason: String) {
+        entry.player.seek(
+            to: time,
+            toleranceBefore: .zero,
+            toleranceAfter: .zero
+        ) { [weak self, weak entry] completed in
+            guard let self, let entry else { return }
+            let message = "Audio overlay track \(entry.trackIndex): " +
+                "\(reason) seek completed=\(completed)"
+            if completed {
+                self.log.debug(message, name: self.logName)
+            } else {
+                self.log.warning(message, name: self.logName)
+            }
+            self.reportStatusIfChanged(for: entry, context: "\(reason) seek")
+        }
+    }
+
+    private func reportStatusIfChanged(
+        for entry: AudioOverlayEntry,
+        context: String
+    ) {
+        let playerStatus = entry.player.status
+        let itemStatus = entry.player.currentItem?.status
+        let itemError = entry.player.currentItem?.error
+        let itemErrorDescription = itemError.map { error in
+            let nsError = error as NSError
+            return "\(nsError.domain)(\(nsError.code)): \(nsError.localizedDescription)"
+        }
+
+        guard playerStatus != entry.lastPlayerStatus ||
+            itemStatus != entry.lastItemStatus ||
+            itemErrorDescription != entry.lastItemErrorDescription
+        else {
+            return
+        }
+
+        entry.lastPlayerStatus = playerStatus
+        entry.lastItemStatus = itemStatus
+        entry.lastItemErrorDescription = itemErrorDescription
+
+        let errorDescription = itemErrorDescription ?? "none"
+        let message = "Audio overlay track \(entry.trackIndex): \(context), " +
+            "player.status=\(String(describing: playerStatus)), " +
+            "currentItem.status=\(String(describing: itemStatus)), " +
+            "currentItem.error=\(errorDescription)"
+        if playerStatus == .failed || itemStatus == .failed || itemError != nil {
+            log.error(message, name: logName)
+        } else {
+            log.info(message, name: logName)
+        }
     }
 }
 
@@ -157,21 +251,23 @@ final class AudioOverlayEntry {
     let trackEndSec: Double?
     var isActive: Bool = false
     let trackIndex: Int
-    let logger: Logger
+    var lastPlayerStatus: AVPlayer.Status?
+    var lastItemStatus: AVPlayerItem.Status?
+    var lastItemErrorDescription: String?
 
     init(
         player: AVPlayer,
         videoStartSec: Double,
         videoEndSec: Double?,
         trackStartSec: Double,
-        trackEndSec: Double?
+        trackEndSec: Double?,
+        trackIndex: Int
     ) {
         self.player = player
         self.videoStartSec = videoStartSec
         self.videoEndSec = videoEndSec
         self.trackStartSec = trackStartSec
         self.trackEndSec = trackEndSec
-        self.trackIndex = 0
-        self.logger = Logger(subsystem: "divine_video_player", category: "AudioOverlayEntry")
+        self.trackIndex = trackIndex
     }
 }

--- a/mobile/packages/divine_video_player/test/src/media_processing_log_contract_test.dart
+++ b/mobile/packages/divine_video_player/test/src/media_processing_log_contract_test.dart
@@ -90,6 +90,26 @@ void main() {
       );
     });
   });
+
+  group('Apple audio-overlay diagnostic contract', () {
+    test('exports curated outcomes without forwarding periodic ticks', () {
+      final source = _appleAudioOverlaySourceFile().readAsStringSync();
+
+      expect(source, isNot(contains('import os')));
+      expect(source, contains('DivineVideoPlayerLog.shared'));
+      expect(source, contains('trackIndex: index'));
+      expect(source, contains('player.currentItem?.status'));
+      expect(source, contains('player.currentItem?.error'));
+      expect(source, contains('player.status'));
+      expect(source, contains('seek completed='));
+      expect(source, contains('skipping invalid uri'));
+      expect(
+        source,
+        contains('print("[AudioOverlay] update: position'),
+        reason: 'The 5 Hz position trace must stay out of bug-report logs.',
+      );
+    });
+  });
 }
 
 File _androidSourceFile() {
@@ -121,5 +141,21 @@ File _appleSourceFile() {
     'packages/divine_video_player/'
     'darwin/divine_video_player/Sources/divine_video_player/'
     'DivineVideoPlayerInstance.swift',
+  );
+}
+
+File _appleAudioOverlaySourceFile() {
+  final packageRelative = File(
+    'darwin/divine_video_player/Sources/divine_video_player/'
+    'AudioOverlayManager.swift',
+  );
+  if (packageRelative.existsSync()) {
+    return packageRelative;
+  }
+
+  return File(
+    'packages/divine_video_player/'
+    'darwin/divine_video_player/Sources/divine_video_player/'
+    'AudioOverlayManager.swift',
   );
 }

--- a/mobile/packages/divine_video_player/test/src/media_processing_log_contract_test.dart
+++ b/mobile/packages/divine_video_player/test/src/media_processing_log_contract_test.dart
@@ -106,10 +106,60 @@ void main() {
       expect(
         source,
         contains('print("[AudioOverlay] update: position'),
-        reason: 'The 5 Hz position trace must stay out of bug-report logs.',
+        reason:
+            'The position trace stays on the console instead of the log '
+            'bridge, so it cannot crowd state transitions and failures out '
+            'of an exported bug report.',
+      );
+    });
+
+    test('keeps console traces out of release builds', () {
+      final source = _appleAudioOverlaySourceFile().readAsStringSync();
+
+      expect(
+        _printsOutsideDebugGuards(source),
+        isEmpty,
+        reason:
+            'update() runs five times a second on the main queue for every '
+            'player, and a console trace never reaches a bug report, so '
+            'these traces must not ship in release builds.',
       );
     });
   });
+}
+
+/// Returns every `print(` in [source] that is not inside a `#if DEBUG` block.
+List<String> _printsOutsideDebugGuards(String source) {
+  final offenders = <String>[];
+  final enclosingDebugGuards = <bool>[];
+  final lines = source.split('\n');
+
+  for (var i = 0; i < lines.length; i++) {
+    final line = lines[i].trim();
+
+    if (line.startsWith('#if')) {
+      enclosingDebugGuards.add(line == '#if DEBUG');
+      continue;
+    }
+    if (line.startsWith('#else') || line.startsWith('#elseif')) {
+      if (enclosingDebugGuards.isNotEmpty) {
+        enclosingDebugGuards[enclosingDebugGuards.length - 1] = false;
+      }
+      continue;
+    }
+    if (line.startsWith('#endif')) {
+      if (enclosingDebugGuards.isNotEmpty) {
+        enclosingDebugGuards.removeLast();
+      }
+      continue;
+    }
+
+    if (line.startsWith('//') || !line.contains('print(')) continue;
+    if (enclosingDebugGuards.contains(true)) continue;
+    offenders.add('line ${i + 1}: $line');
+  }
+
+  return offenders;
 }
 
 File _androidSourceFile() {

--- a/mobile/packages/divine_video_player/test/src/media_processing_log_contract_test.dart
+++ b/mobile/packages/divine_video_player/test/src/media_processing_log_contract_test.dart
@@ -113,6 +113,28 @@ void main() {
       );
     });
 
+    test('mutates overlay state on the main queue after a seek', () {
+      final source = _appleAudioOverlaySourceFile().readAsStringSync();
+
+      final seekCompletion = source.indexOf('] completed in');
+      final mainHop = source.indexOf(
+        'DispatchQueue.main.async',
+        seekCompletion,
+      );
+      final statusReport = source.indexOf('reportStatusIfChanged', mainHop);
+
+      expect(seekCompletion, greaterThanOrEqualTo(0));
+      expect(mainHop, greaterThan(seekCompletion));
+      expect(
+        statusReport,
+        greaterThan(mainHop),
+        reason:
+            'AVFoundation does not document which queue delivers a seek '
+            'completion, so the handler must hop to main before it touches '
+            'the entry state that the 0.2s update also writes.',
+      );
+    });
+
     test('keeps console traces out of release builds', () {
       final source = _appleAudioOverlaySourceFile().readAsStringSync();
 


### PR DESCRIPTION
Closes #7743

## Problem

A remote iOS report says an added audio track does not play in the video editor. Existing Dart logs show whether the audio-track bridge call throws, but they cannot show whether the native AVPlayer item loads, whether a seek completes, or whether playback enters a failed state.

## Why this approach

Audio-overlay lifecycle and failure diagnostics now use the existing DivineVideoPlayerLog bridge, so curated native events reach UnifiedLogger and are included in user-submitted bug reports. Each message identifies the original track index.

The manager records seek completion and reports changes to AVPlayer.status, AVPlayerItem.status, and AVPlayerItem.error. Invalid or missing track URIs are reported instead of being silently dropped. Statuses are emitted only when they change, and pause is logged only on a real state edge, so pausing an already-idle player does not spend buffer capacity on a non-event.

The 0.2-second position trace and the drift detail stay on the console rather than the log bridge, and are compiled out of release builds: a console trace cannot reach a bug report, so on a remote user's device it would be cost without evidence.

## Deliberate scope

This is permanent diagnostic instrumentation and does not change audio playback behavior. It gathers evidence for the missing-audio symptom only. It does not diagnose or fix the separately reported play/pause-button glitch or waveform-extraction error.

## Review fixes pushed by @hm21

- `7f243d5` — the position trace was a bare `print`, which Swift keeps in release builds. It ran five times a second on the main queue for every player instance, and sat before the overlay loop, so it also ran for videos that had no audio overlay at all. Both console traces are now `#if DEBUG`, and `update()` returns early when there are no overlays.
- `2f1399d` — the seek completion handler wrote the same per-entry status fields that `update()` writes on the main queue, on a queue AVFoundation does not document. The handler body now hops to main.
- `8b1c7a9` — `pauseAndDeactivateAll` logged one line per track on every call; it now logs only a real deactivation.

## Verification

- swiftc type-check of AudioOverlayManager.swift and DivineVideoPlayerLog.swift, in both the DEBUG and the release configuration
- flutter analyze in mobile/packages/divine_video_player
- flutter test in mobile/packages/divine_video_player (292 tests)
- regression contract verifies the exported status/error fields, track attribution, invalid-URI warning, the console-only periodic trace, that no console trace ships outside a `#if DEBUG` guard, and that the seek handler hops to main before touching entry state
- all PR checks green on `8b1c7a9`

A standalone swift build was also attempted. It exposed and helped correct a Swift syntax error, then stopped at the existing unresolved FlutterMacOS module dependency; the two affected Swift files were subsequently type-checked directly against AVFoundation.
