### PR TITLE
ci(shorebird): pass both signing keys to the patch commands

### DIFF
--- a/.github/scripts/tests/test_codemagic_shorebird_config.py
+++ b/.github/scripts/tests/test_codemagic_shorebird_config.py
@@ -124,7 +124,10 @@ class CodemagicShorebirdConfigTest(unittest.TestCase):
         self.assertEqual(2, self.contents.count("shorebird_release_preflight.rb"))
         self.assertNotIn("shorebird releases info", self.contents)
         self.assertIn("--build-name=$BUILD_NAME", self.contents)
-        self.assertIn("--public-key-path=build/shorebird/patch_public_key.pem", self.contents)
+        commands = self._shorebird_release_commands()
+        self.assertEqual(2, len(commands))
+        for command in commands:
+            self.assertIn("--public-key-path=build/shorebird/patch_public_key.pem", command)
 
     def test_ios_release_rejects_closed_app_store_version_before_shorebird(self) -> None:
         workflow = self._workflow_block("ios-build")
@@ -404,11 +407,12 @@ class CodemagicShorebirdConfigTest(unittest.TestCase):
             return self.contents[start:]
         return self.contents[start : start + 1 + next_workflow.start()]
 
-    def _shorebird_patch_commands(self) -> list[str]:
+    def _shorebird_commands(self, subcommand: str) -> list[str]:
         commands = []
         lines = self.contents.splitlines()
+        command_pattern = re.compile(rf"^\s+shorebird {re.escape(subcommand)} ")
         for index, line in enumerate(lines):
-            if "shorebird patch " not in line:
+            if command_pattern.match(line) is None:
                 continue
             command_lines = [line]
             cursor = index
@@ -417,6 +421,12 @@ class CodemagicShorebirdConfigTest(unittest.TestCase):
                 command_lines.append(lines[cursor])
             commands.append("\n".join(command_lines))
         return commands
+
+    def _shorebird_patch_commands(self) -> list[str]:
+        return self._shorebird_commands("patch")
+
+    def _shorebird_release_commands(self) -> list[str]:
+        return self._shorebird_commands("release")
 
 
 if __name__ == "__main__":

--- a/.github/scripts/tests/test_codemagic_shorebird_config.py
+++ b/.github/scripts/tests/test_codemagic_shorebird_config.py
@@ -184,8 +184,25 @@ class CodemagicShorebirdConfigTest(unittest.TestCase):
             "shorebird patch ios --release-version=${{ inputs.RELEASE_VERSION }} --track=staging",
             self.contents,
         )
-        self.assertIn("--private-key-path=build/shorebird/patch_private_key.pem", self.contents)
         self.assertNotIn("--track=stable", self.contents)
+        # Per command, not whole-file: the release commands also carry these
+        # flags, so a substring search over the file passes even when a patch
+        # command is missing one. Shipping only --private-key-path is what
+        # made every patch build die with "Both public and private keys must
+        # be provided."
+        commands = self._shorebird_patch_commands()
+        self.assertEqual(2, len(commands))
+        for command in commands:
+            self.assertIn("--public-key-path=build/shorebird/patch_public_key.pem", command)
+            self.assertIn("--private-key-path=build/shorebird/patch_private_key.pem", command)
+
+    def test_patch_workflows_materialize_both_signing_keys(self) -> None:
+        # A key path on the command line is inert unless some step wrote the
+        # file it names.
+        for workflow in ("ios-patch", "android-patch"):
+            block = self._workflow_block(workflow)
+            self.assertIn("*write_shorebird_public_key", block)
+            self.assertIn("*write_shorebird_private_key", block)
 
     def test_shorebird_patch_workflows_use_private_provenance(self) -> None:
         self.assertIn('if [ "$CM_BRANCH" != "main" ]; then', self.contents)

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -33,7 +33,8 @@
 #   - SHOREBIRD_TOKEN (mark as secure) — an API key from the Shorebird
 #     console under Account > API Keys. `shorebird login:ci` is removed;
 #     CI authenticates with API keys only.
-#   - SHOREBIRD_PATCH_PUBLIC_KEY (public PEM used by `shorebird release`)
+#   - SHOREBIRD_PATCH_PUBLIC_KEY (public PEM used by `shorebird release` and
+#     `shorebird patch`)
 #   - SHOREBIRD_PATCH_PRIVATE_KEY (secure private PEM used by `shorebird patch`)
 #   - SHOREBIRD_PROVENANCE_HMAC_KEY (secure random value used only to compare
 #     release and patch configuration without storing or logging its values)
@@ -514,10 +515,13 @@ definitions:
         # behaviour beyond the code fix. Shorebird refuses to patch when it
         # detects native or asset diffs; do NOT add --allow-native-diffs or
         # --allow-asset-diffs to force past that — cut a new release instead.
-        # Signing needs both halves: the private key signs the patch and the
-        # public key validates that signature against the one baked into the
-        # release. Passing only one fails with "Both public and private keys
-        # must be provided."
+        # Signing needs both halves. The private key signs the patch; the
+        # public key goes into the build env as SHOREBIRD_PUBLIC_KEY, the
+        # same way `shorebird release` passes it, and verifies the signature
+        # just produced against itself. Nothing here checks it against the
+        # release's own key, so a rotated key builds green and the patch is
+        # rejected at boot on device. Passing only one fails with "Both
+        # public and private keys must be provided."
         shorebird patch android --release-version=${{ inputs.RELEASE_VERSION }} --track=staging \
           --dart-define-from-file=build/shorebird/dart_defines.json \
           --public-key-path=build/shorebird/patch_public_key.pem \

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -514,8 +514,13 @@ definitions:
         # behaviour beyond the code fix. Shorebird refuses to patch when it
         # detects native or asset diffs; do NOT add --allow-native-diffs or
         # --allow-asset-diffs to force past that — cut a new release instead.
+        # Signing needs both halves: the private key signs the patch and the
+        # public key validates that signature against the one baked into the
+        # release. Passing only one fails with "Both public and private keys
+        # must be provided."
         shorebird patch android --release-version=${{ inputs.RELEASE_VERSION }} --track=staging \
           --dart-define-from-file=build/shorebird/dart_defines.json \
+          --public-key-path=build/shorebird/patch_public_key.pem \
           --private-key-path=build/shorebird/patch_private_key.pem
     - &build_macos
       name: Build macOS app
@@ -606,8 +611,10 @@ definitions:
       script: |
         # See the Android patch step for why there is no --flutter-version and
         # why the dart-defines must match the release's.
+        # See the Android patch step for why both key halves are required.
         shorebird patch ios --release-version=${{ inputs.RELEASE_VERSION }} --track=staging \
           --dart-define-from-file=build/shorebird/dart_defines.json \
+          --public-key-path=build/shorebird/patch_public_key.pem \
           --private-key-path=build/shorebird/patch_private_key.pem \
           --export-options-plist=/Users/builder/export_options.plist
     - &upload_dsyms_to_crashlytics
@@ -1160,6 +1167,7 @@ workflows:
       - *fetch_and_verify_shorebird_provenance
       - *prepare_patch_source
       - *check_ios_extension_signing_contract
+      - *write_shorebird_public_key
       - *write_shorebird_private_key
       - *setup_code_signing_xcode
       - *clean_ios_workspace_state
@@ -1246,6 +1254,7 @@ workflows:
       - *prepare_patch_source
       - *setup_local_properties
       - *configure_gradle_memory
+      - *write_shorebird_public_key
       - *write_shorebird_private_key
       - *patch_android
 

--- a/mobile/docs/SHOREBIRD_CODE_PUSH.md
+++ b/mobile/docs/SHOREBIRD_CODE_PUSH.md
@@ -348,7 +348,8 @@ longer exists.
 
 The same group holds patch-signing key material:
 
-- `SHOREBIRD_PATCH_PUBLIC_KEY` — public PEM passed to `shorebird release`
+- `SHOREBIRD_PATCH_PUBLIC_KEY` — public PEM passed to `shorebird release` and
+  `shorebird patch`
 - `SHOREBIRD_PATCH_PRIVATE_KEY` — secure private PEM passed to `shorebird patch`
 - `SHOREBIRD_PROVENANCE_HMAC_KEY` — secure random key for dart-define
   fingerprints
@@ -356,8 +357,8 @@ The same group holds patch-signing key material:
 
 Store both patch-signing keys as single-line values with literal `\n` sequences
 between PEM lines. CI decodes and validates that envelope before invoking
-Shorebird. Release jobs only materialize the public key; patch jobs only
-materialize the private key.
+Shorebird. Release jobs materialize only the public key; patch jobs materialize
+both keys.
 
 The `github_credentials` token used by release and patch jobs must have read
 and write access to the private `divinevideo/divine-release-provenance`


### PR DESCRIPTION
Fixes #7937.

Found by the first real patch attempt — the iOS half of the #7843 drill (epic #7841). Full defect analysis, reproduction, and evidence are in #7937; this description covers the change.

## The bug

`ios-patch` failed at step 19, `Patch iOS (Shorebird)`, exit 64:

```
Both public and private keys must be provided.
```

`shorebird patch` needs both halves to sign. The private key signs the patch. The public key enters the rebuild environment as `SHOREBIRD_PUBLIC_KEY`, following the same path as `shorebird release`, and Shorebird verifies the newly produced signature against that supplied key. It does not compare the supplied key with the target release during the patch command. Both patch commands passed only the private key, and neither patch workflow ran `*write_shorebird_public_key`, so the public key was missing from the command line and from disk.

Not a regression from #7844 — broken since code push was wired up in #7202. Nothing caught it because **no patch had ever actually been built**. Every guard in the workflow passed on this run; it just could never reach a successful signing step behind them. `ios-patch` and `android-patch` were affected identically.

## Changes

- `--public-key-path=build/shorebird/patch_public_key.pem` on both `patch_ios` and `patch_android`.
- `*write_shorebird_public_key` added to both patch workflows' script lists, so the file the flag names actually exists.
- Config tests rewritten from whole-file to per-command and per-workflow scope for both patch and release commands.
- Signing-key documentation updated to reflect that patch jobs materialize both keys.

## Why the tests passed before

```python
self.assertIn("--public-key-path=build/shorebird/patch_public_key.pem", self.contents)
```

Whole-file substring. The *release* commands carried that flag, so the assertion matched on their strength while neither *patch* command had it. Once patch commands gained the flag, that same assertion could no longer prove either release command retained it.

The replacement extracts complete command invocations from anchored command lines and asserts the required key paths per command. A second test asserts per workflow block that both key-writing steps are present, since a key path is inert unless some step wrote the file it names.

## Verification

- 28/28 `test_codemagic_shorebird_config.py`
- 69/69 across `.github/scripts/tests/`
- Patch tests confirmed **red** against the pre-fix `codemagic.yaml`.
- The release regression assertion confirmed **red** when both release commands were stripped of `--public-key-path`.

The real proof is the next `ios-patch` run reaching the signing step. That is the drill's next action and will be recorded on #7843.

## Signing-key provenance follow-up

Nothing in the patch command compares its public key with the key embedded in the target release. A rotated keypair can therefore build and publish successfully while devices reject the patch at boot. #7941 tracks adding a compatibility-aware public-key fingerprint to release provenance.

## Note

`SHOREBIRD_PATCH_PUBLIC_KEY` is already in the `shorebird_credentials` variable group, which both patch workflows already include, so no Codemagic configuration change is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
