### PR TITLE
test(auth): clean up services after each test

### DIFF
--- a/mobile/test/services/auth_service_local_first_startup_test.dart
+++ b/mobile/test/services/auth_service_local_first_startup_test.dart
@@ -142,12 +142,14 @@ void main() {
       final keyStorage = SecureKeyStorage(
         securityConfig: const SecurityConfig(requireHardwareBacked: false),
       );
-      return AuthService(
+      final authService = AuthService(
         userDataCleanupService: mockCleanupService,
         keyStorage: keyStorage,
         oauthClient: mockOAuthClient,
         startupNetworkOperationTimeout: startupNetworkOperationTimeout,
       );
+      addTearDown(authService.dispose);
+      return authService;
     }
 
     test('divineOAuth local restore starts in upgrading state '
@@ -562,7 +564,6 @@ void main() {
 
       expect(authService.authState, equals(AuthState.unauthenticated));
       expect(authService.hasExpiredOAuthSession, isTrue);
-      await authService.dispose();
     });
 
     test('no local key + hanging refresh reaches unauthenticated', () async {
@@ -593,7 +594,6 @@ void main() {
 
       expect(authService.authState, equals(AuthState.unauthenticated));
       expect(authService.hasExpiredOAuthSession, isTrue);
-      await authService.dispose();
     });
 
     test(
@@ -636,7 +636,6 @@ void main() {
 
         refreshCompleter.complete(null);
         expect(await retry, isFalse);
-        await authService.dispose();
       },
     );
   });

--- a/mobile/test/services/auth_service_signout_cleanup_test.dart
+++ b/mobile/test/services/auth_service_signout_cleanup_test.dart
@@ -102,6 +102,7 @@ void main() {
         userDataCleanupService: mockCleanupService,
         keyStorage: mockKeyStorage,
       );
+      addTearDown(authService.dispose);
 
       // Setup mock behaviors
       when(


### PR DESCRIPTION
## What was wrong

A test about app background/foreground handling started failing at random on pull requests that had nothing to do with authentication. The failure was always the same: `A Timer is still pending even after the widget tree was disposed`, in `badge clear failure does not break resume handling`.

The cause was authentication tests leaving real `AuthService` objects behind. Those objects register themselves with a process-wide background manager the first time they start up, and nothing ever removed them again. Because CI runs the whole suite inside one shared isolate, a later, unrelated test that simulated the app returning to the foreground woke every leftover object up, and each one started a 35-second login-refresh timer that outlived the test that triggered it.

The new analytics test in #7938 did not create this problem. It only changed which tests share a run, which made an existing problem show up consistently.

## What this fixes

Each authentication test now shuts down the services it created, so nothing is left registered when the next test runs.

Two suites needed it:

- **Local-first startup** (`auth_service_local_first_startup_test.dart`) — the suite that produced the timers behind the observed failure. Its builder now registers the shutdown, which also replaces three hand-written shutdown calls that only covered three of thirteen tests.
- **Sign-out cleanup** (`auth_service_signout_cleanup_test.dart`) — added during review. It leaked the same way in five tests. It happens to be harmless today only because that suite passes no login client, which makes the resume path return immediately, so the next edit to that file could have brought the flake straight back.

Every other authentication suite already shut its services down; these were the two that did not.

## What this does not change

Nothing in the app. This is test cleanup only — no authentication behaviour, no production code, no user-visible change.

## Tests

Passed:

- code formatting and Dart analysis on both changed files
- all 13 local-first startup tests, all 23 sign-out cleanup tests, and all 4 app background/foreground tests
- the full `test/services/` directory plus the lifecycle test: 4,329 passed, 46 skipped
- the repository checks that run before a push

Relates to #6880.
Unblocks #7938.

Closes #none
