### PR TITLE
feat(safety): filter on hosting and provenance, and explain a filtered video

### DIFF
--- a/docs/BLOC_UI_MIGRATION_PRD.md
+++ b/docs/BLOC_UI_MIGRATION_PRD.md
@@ -61,6 +61,7 @@ a UI BLoC would be the wrong layer.
 | `lib/services/content_filter_service.dart` | Adult-content / category filters. |
 | `lib/services/curated_list_service.dart` | NIP-51 curated lists. |
 | `lib/services/divine_host_filter_service.dart` | Divine-hosted-only filter preference. |
+| `lib/services/video_provenance_filter_service.dart` | Capture-verified-only filter preference. |
 | `lib/services/environment_service.dart` | Build environment (dev/staging/prod). |
 | `lib/services/feed_aspect_ratio_preference_service.dart` | Feed aspect-ratio preference. |
 | `lib/services/nip05_verification_service.dart` | NIP-05 verification cache. |

--- a/mobile/lib/blocs/safety_settings/safety_settings_cubit.dart
+++ b/mobile/lib/blocs/safety_settings/safety_settings_cubit.dart
@@ -3,7 +3,6 @@
 // ABOUTME: divine-hosted-only) plus reactive labeler and blocklist lists.
 
 import 'dart:async';
-
 import 'package:content_blocklist_repository/content_blocklist_repository.dart';
 import 'package:content_policy/content_policy.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -15,6 +14,7 @@ import 'package:openvine/services/content_filter_service.dart';
 import 'package:openvine/services/divine_host_filter_service.dart';
 import 'package:openvine/services/moderation_label_service.dart';
 import 'package:openvine/services/video_event_service.dart';
+import 'package:openvine/services/video_provenance_filter_service.dart';
 import 'package:openvine/utils/npub_hex.dart';
 
 /// Cubit backing `SafetySettingsScreen`.
@@ -38,6 +38,7 @@ class SafetySettingsCubit extends Cubit<SafetySettingsState>
     required ContentFilterService contentFilterService,
     required VideoEventService videoEventService,
     required DivineHostFilterService divineHostFilterService,
+    required VideoProvenanceFilterService provenanceFilterService,
     required ModerationLabelService moderationLabelService,
     required FollowRepository followRepository,
     required ContentBlocklistRepository contentBlocklistRepository,
@@ -47,6 +48,7 @@ class SafetySettingsCubit extends Cubit<SafetySettingsState>
        _contentFilterService = contentFilterService,
        _videoEventService = videoEventService,
        _divineHostFilterService = divineHostFilterService,
+       _provenanceFilterService = provenanceFilterService,
        _moderationLabelService = moderationLabelService,
        _followRepository = followRepository,
        _contentBlocklistRepository = contentBlocklistRepository,
@@ -56,6 +58,7 @@ class SafetySettingsCubit extends Cubit<SafetySettingsState>
   final ContentFilterService _contentFilterService;
   final VideoEventService _videoEventService;
   final DivineHostFilterService _divineHostFilterService;
+  final VideoProvenanceFilterService _provenanceFilterService;
   final ModerationLabelService _moderationLabelService;
   final FollowRepository _followRepository;
   final ContentBlocklistRepository _contentBlocklistRepository;
@@ -81,6 +84,7 @@ class SafetySettingsCubit extends Cubit<SafetySettingsState>
         isPeopleIFollowEnabled:
             _moderationLabelService.isFollowingModerationEnabled,
         showDivineHostedOnly: _divineHostFilterService.showDivineHostedOnly,
+        showVerifiedOnly: _provenanceFilterService.showVerifiedOnly,
         customLabelers: _moderationLabelService.customLabelers,
         blockedUsers: _contentBlocklistRepository.runtimeBlockedUsers,
       ),
@@ -133,6 +137,21 @@ class SafetySettingsCubit extends Cubit<SafetySettingsState>
     } catch (e, stackTrace) {
       addError(e, stackTrace);
       emitIfOpen(state.copyWith(showDivineHostedOnly: previous));
+    }
+  }
+
+  /// Toggle "only show camera-verified content".
+  ///
+  /// Independent of the Divine-hosted filter: hosting says who can moderate
+  /// the media, provenance says whether it traces back to a camera.
+  Future<void> setShowVerifiedOnly(bool value) async {
+    final previous = state.showVerifiedOnly;
+    emit(state.copyWith(showVerifiedOnly: value));
+    try {
+      await _provenanceFilterService.setShowVerifiedOnly(value);
+    } catch (e, stackTrace) {
+      addError(e, stackTrace);
+      emitIfOpen(state.copyWith(showVerifiedOnly: previous));
     }
   }
 

--- a/mobile/lib/blocs/safety_settings/safety_settings_state.dart
+++ b/mobile/lib/blocs/safety_settings/safety_settings_state.dart
@@ -23,6 +23,7 @@ class SafetySettingsState extends Equatable {
     this.isAdultContentLocked = false,
     this.isPeopleIFollowEnabled = false,
     this.showDivineHostedOnly = true,
+    this.showVerifiedOnly = false,
     this.customLabelers = const <String>{},
     this.blockedUsers = const <String>{},
   });
@@ -35,6 +36,9 @@ class SafetySettingsState extends Equatable {
   final bool isAdultContentLocked;
   final bool isPeopleIFollowEnabled;
   final bool showDivineHostedOnly;
+
+  /// Whether to hide videos with no capture chain (archive exempt).
+  final bool showVerifiedOnly;
 
   /// Subscribed labeler pubkeys excluding the built-in Divine labeler.
   final Set<String> customLabelers;
@@ -49,6 +53,7 @@ class SafetySettingsState extends Equatable {
     bool? isAdultContentLocked,
     bool? isPeopleIFollowEnabled,
     bool? showDivineHostedOnly,
+    bool? showVerifiedOnly,
     Set<String>? customLabelers,
     Set<String>? blockedUsers,
   }) {
@@ -59,6 +64,7 @@ class SafetySettingsState extends Equatable {
       isPeopleIFollowEnabled:
           isPeopleIFollowEnabled ?? this.isPeopleIFollowEnabled,
       showDivineHostedOnly: showDivineHostedOnly ?? this.showDivineHostedOnly,
+      showVerifiedOnly: showVerifiedOnly ?? this.showVerifiedOnly,
       customLabelers: customLabelers ?? this.customLabelers,
       blockedUsers: blockedUsers ?? this.blockedUsers,
     );
@@ -71,6 +77,7 @@ class SafetySettingsState extends Equatable {
     isAdultContentLocked,
     isPeopleIFollowEnabled,
     showDivineHostedOnly,
+    showVerifiedOnly,
     customLabelers,
     blockedUsers,
   ];

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -1,43 +1,115 @@
 {
   "@@locale": "en",
   "devOptionsClipRecovery": "Clip Recovery",
-  "@devOptionsClipRecovery": {"description": "Header of the Developer Options section that recovers clips the app can no longer show."},
+  "@devOptionsClipRecovery": {
+    "description": "Header of the Developer Options section that recovers clips the app can no longer show."
+  },
   "devOptionsClipRecoveryDescription": "Finds recordings stored under another account and video files no entry references any more.",
-  "@devOptionsClipRecoveryDescription": {"description": "Explains that the tool finds clips hidden under another account plus video files with no database row."},
+  "@devOptionsClipRecoveryDescription": {
+    "description": "Explains that the tool finds clips hidden under another account plus video files with no database row."
+  },
   "devOptionsClipRecoveryScan": "Scan",
-  "@devOptionsClipRecoveryScan": {"description": "Button that starts the clip-recovery scan."},
+  "@devOptionsClipRecoveryScan": {
+    "description": "Button that starts the clip-recovery scan."
+  },
   "devOptionsClipRecoveryFailure": "Clip recovery failed",
-  "@devOptionsClipRecoveryFailure": {"description": "Shown when the clip-recovery scan failed."},
+  "@devOptionsClipRecoveryFailure": {
+    "description": "Shown when the clip-recovery scan failed."
+  },
   "devOptionsClipRecoveryVisible": "Visible now: {clips, plural, =1{{clips} clip} other{{clips} clips}}, {drafts, plural, =1{{drafts} draft} other{{drafts} drafts}}",
-  "@devOptionsClipRecoveryVisible": {"description": "How much of the local library the signed-in account can already see.", "placeholders": {"clips": {"type": "int"}, "drafts": {"type": "int"}}},
+  "@devOptionsClipRecoveryVisible": {
+    "description": "How much of the local library the signed-in account can already see.",
+    "placeholders": {
+      "clips": {
+        "type": "int"
+      },
+      "drafts": {
+        "type": "int"
+      }
+    }
+  },
   "devOptionsClipRecoveryOtherAccounts": "Hidden under other accounts",
-  "@devOptionsClipRecoveryOtherAccounts": {"description": "Subheading above the groups of rows stored under a different account."},
+  "@devOptionsClipRecoveryOtherAccounts": {
+    "description": "Subheading above the groups of rows stored under a different account."
+  },
   "devOptionsClipRecoveryCounts": "{clips, plural, =1{{clips} clip} other{{clips} clips}}, {drafts, plural, =1{{drafts} draft} other{{drafts} drafts}}",
-  "@devOptionsClipRecoveryCounts": {"description": "How many clips and drafts one owner group holds.", "placeholders": {"clips": {"type": "int"}, "drafts": {"type": "int"}}},
+  "@devOptionsClipRecoveryCounts": {
+    "description": "How many clips and drafts one owner group holds.",
+    "placeholders": {
+      "clips": {
+        "type": "int"
+      },
+      "drafts": {
+        "type": "int"
+      }
+    }
+  },
   "devOptionsClipRecoveryClaim": "Move to this account",
-  "@devOptionsClipRecoveryClaim": {"description": "Button that restamps an owner group onto the signed-in account."},
+  "@devOptionsClipRecoveryClaim": {
+    "description": "Button that restamps an owner group onto the signed-in account."
+  },
   "devOptionsClipRecoveryOrphanFiles": "Unreferenced files: {count} ({size})",
-  "@devOptionsClipRecoveryOrphanFiles": {"description": "How many video files on disk no database row references, and their total size.", "placeholders": {"count": {"type": "int"}, "size": {"type": "String"}}},
+  "@devOptionsClipRecoveryOrphanFiles": {
+    "description": "How many video files on disk no database row references, and their total size.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "size": {
+        "type": "String"
+      }
+    }
+  },
   "devOptionsClipRecoveryImport": "Rebuild in library",
-  "@devOptionsClipRecoveryImport": {"description": "Button that rebuilds library entries for the unreferenced video files."},
+  "@devOptionsClipRecoveryImport": {
+    "description": "Button that rebuilds library entries for the unreferenced video files."
+  },
   "devOptionsClipRecoveryEmpty": "Nothing to recover",
-  "@devOptionsClipRecoveryEmpty": {"description": "Shown when a scan found no hidden owners and no unreferenced files."},
+  "@devOptionsClipRecoveryEmpty": {
+    "description": "Shown when a scan found no hidden owners and no unreferenced files."
+  },
   "devOptionsClipRecoveryRecovered": "{count, plural, =1{Recovered {count} clip} other{Recovered {count} clips}}",
-  "@devOptionsClipRecoveryRecovered": {"description": "Confirmation of how many clips the last claim or rebuild recovered.", "placeholders": {"count": {"type": "int"}}},
+  "@devOptionsClipRecoveryRecovered": {
+    "description": "Confirmation of how many clips the last claim or rebuild recovered.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "devOptionsClipRecoveryCopied": "Recovery report copied",
-  "@devOptionsClipRecoveryCopied": {"description": "Confirmation shown after the recovery report is copied to the clipboard."},
+  "@devOptionsClipRecoveryCopied": {
+    "description": "Confirmation shown after the recovery report is copied to the clipboard."
+  },
   "devOptionsStorageFootprint": "Storage Footprint",
-  "@devOptionsStorageFootprint": {"description": "Header of the Developer Options section that measures the app's on-disk footprint."},
+  "@devOptionsStorageFootprint": {
+    "description": "Header of the Developer Options section that measures the app's on-disk footprint."
+  },
   "devOptionsStorageFootprintDescription": "Every directory the app writes to. Clearing caches only reclaims part of this.",
-  "@devOptionsStorageFootprintDescription": {"description": "Explains that the footprint covers more than the caches the Storage screen can clear."},
+  "@devOptionsStorageFootprintDescription": {
+    "description": "Explains that the footprint covers more than the caches the Storage screen can clear."
+  },
   "devOptionsStorageFootprintMeasure": "Measure",
-  "@devOptionsStorageFootprintMeasure": {"description": "Button that starts walking every directory the app writes to."},
+  "@devOptionsStorageFootprintMeasure": {
+    "description": "Button that starts walking every directory the app writes to."
+  },
   "devOptionsStorageFootprintTotal": "Total: {size}",
-  "@devOptionsStorageFootprintTotal": {"description": "Total bytes across every measured directory.", "placeholders": {"size": {"type": "String"}}},
+  "@devOptionsStorageFootprintTotal": {
+    "description": "Total bytes across every measured directory.",
+    "placeholders": {
+      "size": {
+        "type": "String"
+      }
+    }
+  },
   "devOptionsStorageFootprintCopied": "Storage report copied",
-  "@devOptionsStorageFootprintCopied": {"description": "Confirmation shown after the footprint report is copied to the clipboard."},
+  "@devOptionsStorageFootprintCopied": {
+    "description": "Confirmation shown after the footprint report is copied to the clipboard."
+  },
   "devOptionsStorageFootprintFailure": "Could not measure storage",
-  "@devOptionsStorageFootprintFailure": {"description": "Shown when the footprint measurement failed."},
+  "@devOptionsStorageFootprintFailure": {
+    "description": "Shown when the footprint measurement failed."
+  },
   "feedTuningMoreLabel": "More like this",
   "@feedTuningMoreLabel": {
     "description": "Indicator and snackbar text when the user swipes right to get more videos like the current one."
@@ -470,7 +542,7 @@
   "profileMessageLabel": "Message",
   "profileDeletedAccountName": "Deleted account",
   "@profileDeletedAccountName": {
-    "description": "Stands in for the display name of an account that requested deletion. A noun phrase used where a person's name would normally appear \u2014 the inbox row, the conversation header, and the following bar."
+    "description": "Stands in for the display name of an account that requested deletion. A noun phrase used where a person's name would normally appear — the inbox row, the conversation header, and the following bar."
   },
   "inboxConversationDeletedAccountSubtitle": "This account was deleted",
   "@inboxConversationDeletedAccountSubtitle": {
@@ -662,7 +734,7 @@
   "videoGridDeletingContent": "Deleting content...",
   "exploreTabFeatured": "Featured",
   "@exploreTabFeatured": {
-    "description": "Name of the Explore tab that shows a server-curated collection. The collection's own name is not this string \u2014 it rides beside it in a pill."
+    "description": "Name of the Explore tab that shows a server-curated collection. The collection's own name is not this string — it rides beside it in a pill."
   },
   "exploreTabClassics": "Classics",
   "exploreTabNew": "New",
@@ -922,7 +994,16 @@
     "description": "Neutral label shown when a video references a shared sound event that cannot currently be fetched. Must not imply the video author's original sound."
   },
   "videoInspiredByAttributionMultiple": "Inspired by @{creatorName} +{additionalCreatorCount}",
-  "@videoInspiredByAttributionMultiple": {"placeholders": {"creatorName": {"type": "String"}, "additionalCreatorCount": {"type": "int"}}},
+  "@videoInspiredByAttributionMultiple": {
+    "placeholders": {
+      "creatorName": {
+        "type": "String"
+      },
+      "additionalCreatorCount": {
+        "type": "int"
+      }
+    }
+  },
   "videoInspiredByAttribution": "Inspired by @{creatorName}",
   "@videoInspiredByAttribution": {
     "placeholders": {
@@ -1985,7 +2066,9 @@
   "@authVerificationResendCooldown": {
     "description": "Disabled-state label for the resend button during its cooldown. {time} is a preformatted m:ss countdown (e.g. 4:59).",
     "placeholders": {
-      "time": { "type": "String" }
+      "time": {
+        "type": "String"
+      }
     }
   },
   "authVerificationResendFailed": "We couldn't resend the email. Try again.",
@@ -2173,7 +2256,11 @@
   "crosspostViewPost": "View post",
   "crosspostReconnectPrompt": "Reconnect {platform} in crossposting settings to keep posting.",
   "@crosspostReconnectPrompt": {
-    "placeholders": { "platform": { "type": "String" } }
+    "placeholders": {
+      "platform": {
+        "type": "String"
+      }
+    }
   },
   "crosspostReconnect": "Reconnect",
   "crosspostErrorNotOwner": "Only your own videos can be crossposted.",
@@ -2319,7 +2406,9 @@
   "shareMenuDeleteFailedCouldNotSign": "Couldn't sign the delete request. Try again.",
   "shareMenuDeleteFailedRelayRejected": "The relay wouldn't accept this delete request. Try again in a moment.",
   "shareMenuDeleteFailedAccountRestricted": "Your account is restricted, so this delete request couldn't be sent. Contact support for help deleting it.",
-  "@shareMenuDeleteFailedAccountRestricted": {"description": "Shown when every responding relay explicitly rejects an owner's content-deletion request because the publishing account is suspended or banned."},
+  "@shareMenuDeleteFailedAccountRestricted": {
+    "description": "Shown when every responding relay explicitly rejects an owner's content-deletion request because the publishing account is suspended or banned."
+  },
   "shareMenuDeleteFailedRelayNoResponse": "Couldn't reach the relay. Check your connection and try again.",
   "shareMenuDeletePartiallyConfirmed": "Deleted. Not every relay confirmed, so it may still show up in other apps.",
   "shareMenuDeleteFailedGeneric": "Couldn't delete this video. Try again.",
@@ -2867,14 +2956,20 @@
   "listShareText": "Check out {name} on Divine: {url}",
   "@listShareText": {
     "placeholders": {
-      "name": { "type": "String" },
-      "url": { "type": "String" }
+      "name": {
+        "type": "String"
+      },
+      "url": {
+        "type": "String"
+      }
     }
   },
   "listShareSubject": "{name} on Divine",
   "@listShareSubject": {
     "placeholders": {
-      "name": { "type": "String" }
+      "name": {
+        "type": "String"
+      }
     }
   },
   "listCancel": "Cancel",
@@ -3420,13 +3515,12 @@
     }
   },
   "dmSendNoRecipientMessage": "We couldn't tell who this thread is with. Open it again from your inbox.",
-  "@dmSendNoRecipientMessage": {"description": "SnackBar text shown when a send is dispatched with no recipient (#7335). Unlike every other send failure there is no queue row and so no red \"Not delivered\" bubble to carry the news, which is why this one outcome gets a toast. Reachable only by opening the conversation route without participants, e.g. a hand-crafted deep link."},
+  "@dmSendNoRecipientMessage": {
+    "description": "SnackBar text shown when a send is dispatched with no recipient (#7335). Unlike every other send failure there is no queue row and so no red \"Not delivered\" bubble to carry the news, which is why this one outcome gets a toast. Reachable only by opening the conversation route without participants, e.g. a hand-crafted deep link."
+  },
   "dmSendBlockedMessage": "You can only message official Divine accounts",
-
   "@dmSendBlockedMessage": {
-
     "description": "SnackBar text shown when a protected minor (13-15) tries to DM a non-approved account (#176). Neutral, no retry action."
-
   },
   "dmSendBlockedRetiredMessage": "Nobody is reading this conversation. Message Divine Moderation instead.",
   "@dmSendBlockedRetiredMessage": {
@@ -4097,7 +4191,13 @@
   "commentsInputSemanticLabelEdit": "Edit input",
   "commentsInputSemanticLabelReply": "Reply input",
   "classicVinersViewProfileSemanticLabel": "View profile for {displayName}",
-  "@classicVinersViewProfileSemanticLabel": {"placeholders": {"displayName": {"type": "String"}}},
+  "@classicVinersViewProfileSemanticLabel": {
+    "placeholders": {
+      "displayName": {
+        "type": "String"
+      }
+    }
+  },
   "classicsEmptyDescription": "The Classics archive is being loaded",
   "classicsEmptyTitle": "No Classics Found",
   "classicsErrorTitle": "Failed to load Classics",
@@ -4106,10 +4206,22 @@
   "classicsUnavailableTitle": "Classics Unavailable",
   "hashtagFeedEmptySubtitle": "Be the first to post a video with this hashtag!",
   "hashtagFeedEmptyTitle": "No videos found for #{hashtag}",
-  "@hashtagFeedEmptyTitle": {"placeholders": {"hashtag": {"type": "String"}}},
+  "@hashtagFeedEmptyTitle": {
+    "placeholders": {
+      "hashtag": {
+        "type": "String"
+      }
+    }
+  },
   "hashtagFeedLoadingSubtitle": "This may take a few moments",
   "hashtagFeedLoadingTitle": "Loading videos about #{hashtag}...",
-  "@hashtagFeedLoadingTitle": {"placeholders": {"hashtag": {"type": "String"}}},
+  "@hashtagFeedLoadingTitle": {
+    "placeholders": {
+      "hashtag": {
+        "type": "String"
+      }
+    }
+  },
   "hashtagInputHint": "Add hashtags... #vine #nostr",
   "newVideosTabEmptySubtitle": "Check back later for new content",
   "newVideosTabEmptyTitle": "No videos in New Videos",
@@ -4120,11 +4232,29 @@
   "popularVideosFeedSourceLabel": "Popular feed source",
   "trendingHashtagsLoading": "Loading hashtags...",
   "trendingHashtagsViewVideosTagged": "View videos tagged {hashtag}",
-  "@trendingHashtagsViewVideosTagged": {"placeholders": {"hashtag": {"type": "String"}}},
+  "@trendingHashtagsViewVideosTagged": {
+    "placeholders": {
+      "hashtag": {
+        "type": "String"
+      }
+    }
+  },
   "videoGridAuthorSemanticLabel": "Video author: {name}",
-  "@videoGridAuthorSemanticLabel": {"placeholders": {"name": {"type": "String"}}},
+  "@videoGridAuthorSemanticLabel": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
   "videoGridDescriptionSemanticLabel": "Video description: {description}",
-  "@videoGridDescriptionSemanticLabel": {"placeholders": {"description": {"type": "String"}}},
+  "@videoGridDescriptionSemanticLabel": {
+    "placeholders": {
+      "description": {
+        "type": "String"
+      }
+    }
+  },
   "forYouAlgorithmChoiceBody": "Divine's vision is to give you true algorithmic choice. Instead of being locked into a single black-box algorithm, you'll be able to choose from multiple recommendation approaches:",
   "forYouAlgorithmChoiceChronological": "Chronological timeline from creators you follow",
   "forYouAlgorithmChoiceClosing": "This puts you in control of your attention rather than leaving it up to the platform. You should know how your feed is curated and have the power to change it whenever you want.",
@@ -4132,21 +4262,21 @@
   "forYouAlgorithmChoicePersonalizedFeed": "Personalized \"For You\" feed",
   "forYouAlgorithmChoiceTitle": "Your Algorithm, Your Choice",
   "forYouAlgorithmChoiceTrending": "Trending and popular content",
-  "forYouAlgorithmCommentsDescription": "Strong signal \u2014 you were engaged enough to respond",
+  "forYouAlgorithmCommentsDescription": "Strong signal — you were engaged enough to respond",
   "forYouAlgorithmHowItWorksBody": "Divine pays attention to how you interact with content to understand what you enjoy. Every time you watch a video, give it a reaction, leave a comment, or repost it, the system takes note.",
   "forYouAlgorithmHowItWorksTitle": "How It Works",
   "forYouAlgorithmInteractionsIntro": "Different actions signal different levels of interest:",
   "forYouAlgorithmNewToDivineBody1": "If you haven't built up a viewing history yet, we show a mix of what's currently popular and trending alongside recent uploads. This gives you a great starting point to explore.",
   "forYouAlgorithmNewToDivineBody2": "As you watch, like, and engage with content, recommendations gradually become more personalized. Over time, your For You feed surfaces videos from creators you might never have discovered on your own.",
   "forYouAlgorithmNewToDivineTitle": "New to Divine?",
-  "forYouAlgorithmOpenSourceBody": "We're building an open system where developers can implement their own algorithms, and you can choose which ones to use \u2014 or opt out entirely.",
+  "forYouAlgorithmOpenSourceBody": "We're building an open system where developers can implement their own algorithms, and you can choose which ones to use — or opt out entirely.",
   "forYouAlgorithmOpenSourceTitle": "Open Source & Transparent",
-  "forYouAlgorithmReactionsDescription": "Medium signal \u2014 a quick way to show appreciation",
+  "forYouAlgorithmReactionsDescription": "Medium signal — a quick way to show appreciation",
   "forYouAlgorithmReactionsTitle": "Reactions",
-  "forYouAlgorithmRepostsDescription": "Strongest signal \u2014 sharing with your followers is a powerful endorsement",
+  "forYouAlgorithmRepostsDescription": "Strongest signal — sharing with your followers is a powerful endorsement",
   "forYouAlgorithmSubtitle": "Powered by Gorse, an open-source recommendation engine",
   "forYouAlgorithmTitle": "The Divine Algorithm",
-  "forYouAlgorithmViewsDescription": "Light signal \u2014 indicates basic interest",
+  "forYouAlgorithmViewsDescription": "Light signal — indicates basic interest",
   "forYouEmptyDescription": "Watch and like some videos to get personalized recommendations.",
   "forYouEmptyTitle": "No Recommendations Yet",
   "forYouErrorTitle": "Failed to load recommendations",
@@ -4156,79 +4286,189 @@
   "inboxConversationViewProfileButton": "View profile",
   "inboxMessageRequestsEmpty": "No message requests",
   "inboxMessageRequestsSemanticLabel": "Message requests, {requestCount} pending",
-  "@inboxMessageRequestsSemanticLabel": {"placeholders": {"requestCount": {"type": "int"}}},
+  "@inboxMessageRequestsSemanticLabel": {
+    "placeholders": {
+      "requestCount": {
+        "type": "int"
+      }
+    }
+  },
   "inboxMessageRequestsTitle": "Message requests",
   "inboxMessagesTab": "Messages",
   "inboxRequestTileLabel": "{displayName} message request",
-  "@inboxRequestTileLabel": {"placeholders": {"displayName": {"type": "String"}}},
+  "@inboxRequestTileLabel": {
+    "placeholders": {
+      "displayName": {
+        "type": "String"
+      }
+    }
+  },
   "inboxRequestTileSubtitle": "Sent a message request",
   "inboxRequestsMarkAllRead": "Mark all requests as read",
   "inboxRequestsRemoveAll": "Remove all requests",
   "messageRequestDeclineAndRemoveButton": "Decline and remove",
   "messageRequestBlockButton": "Block",
   "messageRequestDeclinedSnackbar": "Declined {displayName}'s request",
-  "@messageRequestDeclinedSnackbar": {"placeholders": {"displayName": {"type": "String"}}},
+  "@messageRequestDeclinedSnackbar": {
+    "placeholders": {
+      "displayName": {
+        "type": "String"
+      }
+    }
+  },
   "messageRequestBlockConfirmBody": "This clears the request and keeps their messages out of your inbox. Anything they send is still readable under Blocked.",
-  "@messageRequestBlockConfirmBody": {"description": "Body of the confirmation shown before blocking the sender of a message request (#7881). The title reuses profileBlockTitle. Blocking does not stop the sender from sending — their messages are still received and retained, the inbox filter just hides them — so this copy must promise inbox hiding, not delivery prevention, and must say the messages stay readable under the Blocked filter (#7026)."},
+  "@messageRequestBlockConfirmBody": {
+    "description": "Body of the confirmation shown before blocking the sender of a message request (#7881). The title reuses profileBlockTitle. Blocking does not stop the sender from sending — their messages are still received and retained, the inbox filter just hides them — so this copy must promise inbox hiding, not delivery prevention, and must say the messages stay readable under the Blocked filter (#7026)."
+  },
   "messageRequestLoadFailed": "Couldn't load this request.",
-  "@messageRequestLoadFailed": {"description": "Shown in place of the request preview when its database read fails (#7335), next to a `commonRetry` button. The screen previously fell through to the loaded layout, so a failed read rendered a generated placeholder name, a count of 0, and live accept/decline buttons over an unknown sender."},
+  "@messageRequestLoadFailed": {
+    "description": "Shown in place of the request preview when its database read fails (#7335), next to a `commonRetry` button. The screen previously fell through to the loaded layout, so a failed read rendered a generated placeholder name, a count of 0, and live accept/decline buttons over an unknown sender."
+  },
   "messageRequestFollowersCount": "{countValue, plural, =1{{count} Follower} other{{count} Followers}}",
-  "@messageRequestFollowersCount": {"placeholders": {"countValue": {"type": "int"}, "count": {"type": "String"}}},
+  "@messageRequestFollowersCount": {
+    "placeholders": {
+      "countValue": {
+        "type": "int"
+      },
+      "count": {
+        "type": "String"
+      }
+    }
+  },
   "messageRequestVideosCount": "{countValue, plural, =1{{count} video} other{{count} videos}}",
-  "@messageRequestVideosCount": {"placeholders": {"countValue": {"type": "int"}, "count": {"type": "String"}}},
+  "@messageRequestVideosCount": {
+    "placeholders": {
+      "countValue": {
+        "type": "int"
+      },
+      "count": {
+        "type": "String"
+      }
+    }
+  },
   "messageRequestMessageCount": "{count, plural, =1{1 message} other{{count} messages}}",
-  "@messageRequestMessageCount": {"placeholders": {"count": {"type": "int"}}},
+  "@messageRequestMessageCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "messageRequestViewMessagesButton": "View messages",
   "messageRequestViewProfileButton": "View profile",
   "messageRequestWantsToMessageYou": "{displayName} wants to message you, they've sent {messageText}.",
-  "@messageRequestWantsToMessageYou": {"placeholders": {"displayName": {"type": "String"}, "messageText": {"type": "String"}}},
+  "@messageRequestWantsToMessageYou": {
+    "placeholders": {
+      "displayName": {
+        "type": "String"
+      },
+      "messageText": {
+        "type": "String"
+      }
+    }
+  },
   "deleteAccountAccountChanged": "You switched accounts, so nothing was deleted. Reopen delete for the account you want to remove.",
-  "@deleteAccountAccountChanged": {"description": "Error shown when the signed-in account changed between confirming a deletion and executing it; nothing was deleted."},
+  "@deleteAccountAccountChanged": {
+    "description": "Error shown when the signed-in account changed between confirming a deletion and executing it; nothing was deleted."
+  },
   "deleteAccountAccountChangedAfterDeletion": "Some deletion requests were accepted, but cleanup stopped because you switched accounts. Sign back into the original account to finish.",
-  "@deleteAccountAccountChangedAfterDeletion": {"description": "Error shown when a relay accepted at least one account or content deletion request but the signed-in account changed before cleanup could finish."},
+  "@deleteAccountAccountChangedAfterDeletion": {
+    "description": "Error shown when a relay accepted at least one account or content deletion request but the signed-in account changed before cleanup could finish."
+  },
   "deleteAccountBurnUsernameFailed": "Couldn't release your username. Your account was not deleted. Try again, or uncheck the option.",
-  "@deleteAccountBurnUsernameFailed": {"description": "Error shown when the opt-in @divine.video username burn fails during account deletion; the account is not deleted."},
+  "@deleteAccountBurnUsernameFailed": {
+    "description": "Error shown when the opt-in @divine.video username burn fails during account deletion; the account is not deleted."
+  },
   "deleteAccountBurnUsernameReleased": "Your username {username} has been permanently released, but we couldn't finish deleting your account. Tap Delete again to finish.",
-  "@deleteAccountBurnUsernameReleased": {"description": "Shown when the opt-in @divine.video username burn committed but the account could not be fully deleted (a later step failed). The burn is never rolled back. {username} is like @alice.divine.video.", "placeholders": {"username": {"type": "String"}}},
+  "@deleteAccountBurnUsernameReleased": {
+    "description": "Shown when the opt-in @divine.video username burn committed but the account could not be fully deleted (a later step failed). The burn is never rolled back. {username} is like @alice.divine.video.",
+    "placeholders": {
+      "username": {
+        "type": "String"
+      }
+    }
+  },
   "deleteAccountBurnUsernameToggle": "Also permanently give up {username}",
-  "@deleteAccountBurnUsernameToggle": {"description": "Opt-in checkbox in the delete-account dialog to permanently burn the user's @divine.video handle. {username} is the handle like @alice.divine.video.", "placeholders": {"username": {"type": "String"}}},
+  "@deleteAccountBurnUsernameToggle": {
+    "description": "Opt-in checkbox in the delete-account dialog to permanently burn the user's @divine.video handle. {username} is the handle like @alice.divine.video.",
+    "placeholders": {
+      "username": {
+        "type": "String"
+      }
+    }
+  },
   "deleteAccountConfirmDeletePrompt": "To confirm, type:",
-  "@deleteAccountConfirmDeletePrompt": {"description": "Prompt above the confirmation field when the account has no username; the user types the word DELETE."},
+  "@deleteAccountConfirmDeletePrompt": {
+    "description": "Prompt above the confirmation field when the account has no username; the user types the word DELETE."
+  },
   "deleteAccountConfirmUsernamePrompt": "To confirm, type your username:",
-  "@deleteAccountConfirmUsernamePrompt": {"description": "Prompt above the confirmation field when the account has a username; the user re-types their username to confirm deletion."},
+  "@deleteAccountConfirmUsernamePrompt": {
+    "description": "Prompt above the confirmation field when the account has a username; the user re-types their username to confirm deletion."
+  },
   "deleteAccountConfirmationHint": "Type DELETE",
-  "@deleteAccountConfirmationHint": {"description": "Label on the delete-confirmation field when the user must type the DELETE token. Shown inside the field when empty and floating above it once focused, so it stays visible while typing."},
+  "@deleteAccountConfirmationHint": {
+    "description": "Label on the delete-confirmation field when the user must type the DELETE token. Shown inside the field when empty and floating above it once focused, so it stays visible while typing."
+  },
   "deleteAccountConfirmationHintUsername": "Type your username",
-  "@deleteAccountConfirmationHintUsername": {"description": "Label on the delete-confirmation field when the user must type their username. Shown inside the field when empty and floating above it once focused, so it stays visible while typing."},
+  "@deleteAccountConfirmationHintUsername": {
+    "description": "Label on the delete-confirmation field when the user must type their username. Shown inside the field when empty and floating above it once focused, so it stays visible while typing."
+  },
   "deleteAccountContentDeletionFailed": "Failed to delete content from relays",
   "deleteAccountRelayConfirmationFailed": "We couldn't confirm account deletion with a relay. Check your connection and try again.",
   "deleteAccountAccountRestricted": "Your account is restricted, so deletion couldn't continue. Contact support for help deleting your account.",
-  "@deleteAccountAccountRestricted": {"description": "Shown when every responding relay explicitly rejects the NIP-62 account-deletion request because the publishing account is suspended or banned."},
-  "@deleteAccountRelayConfirmationFailed": {"description": "Error shown when the NIP-62 account deletion request could not be confirmed by any relay after bounded retries; account deletion could not proceed to server cleanup or sign-out."},
+  "@deleteAccountAccountRestricted": {
+    "description": "Shown when every responding relay explicitly rejects the NIP-62 account-deletion request because the publishing account is suspended or banned."
+  },
+  "@deleteAccountRelayConfirmationFailed": {
+    "description": "Error shown when the NIP-62 account deletion request could not be confirmed by any relay after bounded retries; account deletion could not proceed to server cleanup or sign-out."
+  },
   "deleteAccountDeleteAllContentButton": "Delete All Content",
   "deleteAccountDeletionIncomplete": "We couldn't finish deleting your account. Try again.",
-  "@deleteAccountDeletionIncomplete": {"description": "Neutral error when account deletion could not complete and the username-burn state is uncertain (an unresolved network timeout). Makes no claim about the username; retrying resolves it."},
-  "deleteAccountFinalConfirmationTitle": "\u26a0\ufe0f Final Confirmation",
-  "deleteAccountKeyDeletionWarning": "Deletion requests sent, but your keys may not have been fully removed from this device. Go to Settings \u2192 Nostr Keys \u2192 Remove Keys to retry.",
+  "@deleteAccountDeletionIncomplete": {
+    "description": "Neutral error when account deletion could not complete and the username-burn state is uncertain (an unresolved network timeout). Makes no claim about the username; retrying resolves it."
+  },
+  "deleteAccountFinalConfirmationTitle": "⚠️ Final Confirmation",
+  "deleteAccountKeyDeletionWarning": "Deletion requests sent, but your keys may not have been fully removed from this device. Go to Settings → Nostr Keys → Remove Keys to retry.",
   "deleteAccountLocalDataDeletionFailed": "Deletion requests sent and you're signed out, but some local data could not be removed from this device.",
   "deleteAccountPreparingDeletion": "Preparing deletion...",
   "deleteAccountProgressEvents": "{current} / {total} events",
-  "@deleteAccountProgressEvents": {"placeholders": {"current": {"type": "int"}, "total": {"type": "int"}}},
+  "@deleteAccountProgressEvents": {
+    "placeholders": {
+      "current": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
   "deleteAccountRemoveKeysBody": "This removes the local login for this account from this device. It won't delete your Divine account or Nostr identity.\n\nYour drafts and clips stay saved on this device for this account. If this is your last local account, you'll return to the login screen.",
   "deleteAccountRemoveKeysConfirm": "Remove from device",
   "deleteAccountRemoveKeysTitle": "Remove this account from this device?",
   "deleteAccountReauthRequired": "Sign in again to delete your account. Nothing has been deleted yet.",
-  "@deleteAccountReauthRequired": {"description": "Shown when account deletion is blocked before anything is published because the session cannot authorize the server-side account deletion. Tells the user to sign in again and makes clear nothing was deleted."},
+  "@deleteAccountReauthRequired": {
+    "description": "Shown when account deletion is blocked before anything is published because the session cannot authorize the server-side account deletion. Tells the user to sign in again and makes clear nothing was deleted."
+  },
   "deleteAccountServerDeletionFailed": "Deletion requests sent for your posts, but we couldn't finish deleting your account. Try again in a bit.",
-  "@deleteAccountServerDeletionFailed": {"description": "Snackbar shown when the Nostr deletion requests were already published but the server-side Divine account deletion failed for a reason a fresh sign-in cannot clear (5xx, 404, or an unreachable server). Must not claim that nothing was deleted, because the vanish request has already reached relays, and must not tell the user to sign in again, which does not clear a server failure."},
+  "@deleteAccountServerDeletionFailed": {
+    "description": "Snackbar shown when the Nostr deletion requests were already published but the server-side Divine account deletion failed for a reason a fresh sign-in cannot clear (5xx, 404, or an unreachable server). Must not claim that nothing was deleted, because the vanish request has already reached relays, and must not tell the user to sign in again, which does not clear a server failure."
+  },
   "deleteAccountServerDeletionRequiresReauth": "Deletion requests sent for your posts, but we couldn't finish deleting your account. Sign in again to finish.",
-  "@deleteAccountServerDeletionRequiresReauth": {"description": "Snackbar shown when the Nostr deletion requests were already published but the server-side Divine account deletion was refused for a credential reason only a fresh sign-in can clear. Must not claim that nothing was deleted, because the vanish request has already reached relays."},
+  "@deleteAccountServerDeletionRequiresReauth": {
+    "description": "Snackbar shown when the Nostr deletion requests were already published but the server-side Divine account deletion was refused for a credential reason only a fresh sign-in can clear. Must not claim that nothing was deleted, because the vanish request has already reached relays."
+  },
   "deleteAccountSuccess": "Deletion requests sent. You're signed out on this device.",
-  "@deleteAccountSuccess": {"description": "Snackbar after the account deletion flow publishes Nostr deletion requests, deletes the Divine account when applicable, and signs out locally. Do not imply guaranteed deletion from every relay, client, cache, search index, or other signed-in device."},
+  "@deleteAccountSuccess": {
+    "description": "Snackbar after the account deletion flow publishes Nostr deletion requests, deletes the Divine account when applicable, and signs out locally. Do not imply guaranteed deletion from every relay, client, cache, search index, or other signed-in device."
+  },
   "deleteAccountSuccessContentUnverified": "Account deletion requested. Some existing posts could not be individually confirmed for deletion.",
-  "@deleteAccountSuccessContentUnverified": {"description": "Snackbar when the account-wide vanish request was published but the relay query failed or at least one per-item deletion request was not confirmed. Must not imply every existing post was individually requested or confirmed for deletion."},
+  "@deleteAccountSuccessContentUnverified": {
+    "description": "Snackbar when the account-wide vanish request was published but the relay query failed or at least one per-item deletion request was not confirmed. Must not imply every existing post was individually requested or confirmed for deletion."
+  },
   "deleteAccountWarningBody": "This sends deletion requests for your account and content, deletes your Divine account when possible, and signs you out on this device. Some relays, clients, and search indexes may keep copies. Other signed-in devices stay active until you remove the keys there.",
-  "@deleteAccountWarningBody": {"description": "Warning body in the delete-account confirmation dialog, shown above the type-to-confirm field. Be clear that Nostr deletion is request-based, not a guarantee that every relay, client, cache, search index, or other signed-in device will forget the account."},
+  "@deleteAccountWarningBody": {
+    "description": "Warning body in the delete-account confirmation dialog, shown above the type-to-confirm field. Be clear that Nostr deletion is request-based, not a guarantee that every relay, client, cache, search index, or other signed-in device will forget the account."
+  },
   "findPeopleAnonymousUser": "Anonymous",
   "findPeopleNoContacts": "No contacts found.\nStart following people to see them here.",
   "geoBlockedCityLabel": "City",
@@ -4240,7 +4480,7 @@
   "likedVideosEmpty": "No liked videos",
   "likedVideosInvalidRoute": "Invalid route",
   "likedVideosTitle": "Liked Videos",
-  "uploadFailureSheetRetryingSnackbar": "Retrying upload\u2026",
+  "uploadFailureSheetRetryingSnackbar": "Retrying upload…",
   "uploadFailureSheetSaveToDraftsButton": "Save to Drafts",
   "uploadFailureSheetSavedToDraftsSnackbar": "Saved to drafts",
   "uploadFailureSheetTitle": "Upload Failed",
@@ -4255,12 +4495,33 @@
   "publishErrorTimeout": "The upload timed out. Try a stronger connection or a smaller video.",
   "publishErrorTls": "Secure connection failed. Check your network — public Wi-Fi can block uploads.",
   "publishErrorServerNotFound": "The media server ({serverName}) is not available. You can choose another in your settings.",
-  "@publishErrorServerNotFound": {"description": "Shown when the media (Blossom) server returns 404. {serverName} is the server host.", "placeholders": {"serverName": {"type": "String"}}},
+  "@publishErrorServerNotFound": {
+    "description": "Shown when the media (Blossom) server returns 404. {serverName} is the server host.",
+    "placeholders": {
+      "serverName": {
+        "type": "String"
+      }
+    }
+  },
   "publishErrorFileTooLarge": "The video file is too large for the server. Try trimming it or lowering the quality.",
   "publishErrorServerInternalError": "The media server ({serverName}) had an internal error. You can choose another in your settings.",
-  "@publishErrorServerInternalError": {"description": "Shown when the media (Blossom) server returns 500. {serverName} is the server host.", "placeholders": {"serverName": {"type": "String"}}},
+  "@publishErrorServerInternalError": {
+    "description": "Shown when the media (Blossom) server returns 500. {serverName} is the server host.",
+    "placeholders": {
+      "serverName": {
+        "type": "String"
+      }
+    }
+  },
   "publishErrorServerDown": "The media server ({serverName}) is temporarily down. Try again shortly or choose another in your settings.",
-  "@publishErrorServerDown": {"description": "Shown when the media (Blossom) server returns 502/503. {serverName} is the server host.", "placeholders": {"serverName": {"type": "String"}}},
+  "@publishErrorServerDown": {
+    "description": "Shown when the media (Blossom) server returns 502/503. {serverName} is the server host.",
+    "placeholders": {
+      "serverName": {
+        "type": "String"
+      }
+    }
+  },
   "publishErrorForbidden": "You don’t have permission to upload to this server.",
   "publishErrorFileNotFound": "The video file could not be found. It may have been deleted. Re-record and try again.",
   "publishErrorLowStorage": "Not enough storage on your device. Free up some space and try again.",
@@ -4277,26 +4538,86 @@
   "publishErrorOverlaysUnavailable": "The text and stickers on this draft couldn’t be prepared. Open it in the editor, then post again.",
   "publishErrorUnknownServer": "Unknown server",
   "searchFilterPillSemanticLabel": "Filter: {filter}",
-  "@searchFilterPillSemanticLabel": {"placeholders": {"filter": {"type": "String"}}},
+  "@searchFilterPillSemanticLabel": {
+    "placeholders": {
+      "filter": {
+        "type": "String"
+      }
+    }
+  },
   "searchNoResultsFound": "No results found for \"{query}\"",
-  "@searchNoResultsFound": {"placeholders": {"query": {"type": "String"}}},
+  "@searchNoResultsFound": {
+    "placeholders": {
+      "query": {
+        "type": "String"
+      }
+    }
+  },
   "searchTagChipViewVideosTaggedLabel": "View videos tagged {tag}",
-  "@searchTagChipViewVideosTaggedLabel": {"placeholders": {"tag": {"type": "String"}}},
+  "@searchTagChipViewVideosTaggedLabel": {
+    "placeholders": {
+      "tag": {
+        "type": "String"
+      }
+    }
+  },
   "audioAttributionRowSemanticLabel": "Sound: {soundName} by {creatorName}. Tap to view sound details.",
-  "@audioAttributionRowSemanticLabel": {"placeholders": {"soundName": {"type": "String"}, "creatorName": {"type": "String"}}},
+  "@audioAttributionRowSemanticLabel": {
+    "placeholders": {
+      "soundName": {
+        "type": "String"
+      },
+      "creatorName": {
+        "type": "String"
+      }
+    }
+  },
   "metadataSoundsOriginalSoundSemantics": "Original sound by {creatorName}. Tap to use this sound.",
-  "@metadataSoundsOriginalSoundSemantics": {"placeholders": {"creatorName": {"type": "String"}}},
+  "@metadataSoundsOriginalSoundSemantics": {
+    "placeholders": {
+      "creatorName": {
+        "type": "String"
+      }
+    }
+  },
   "metadataSoundsSharedSoundSemantics": "Sound: {soundName} by {creatorName}. Tap to view details.",
-  "@metadataSoundsSharedSoundSemantics": {"placeholders": {"soundName": {"type": "String"}, "creatorName": {"type": "String"}}},
+  "@metadataSoundsSharedSoundSemantics": {
+    "placeholders": {
+      "soundName": {
+        "type": "String"
+      },
+      "creatorName": {
+        "type": "String"
+      }
+    }
+  },
   "soundDetailLoadError": "Failed to load sound: {error}",
-  "@soundDetailLoadError": {"placeholders": {"error": {"type": "String"}}},
+  "@soundDetailLoadError": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
   "soundDetailNotFoundMessage": "This sound could not be found",
   "soundDetailNotFoundTitle": "Sound Not Found",
-  "videoFeedLoopCountLabel": "{count, plural, =1{\ud83d\udd01 {count} loop} other{\ud83d\udd01 {count} loops}}",
-  "@videoFeedLoopCountLabel": {"placeholders": {"count": {"type": "int"}}},
+  "videoFeedLoopCountLabel": "{count, plural, =1{🔁 {count} loop} other{🔁 {count} loops}}",
+  "@videoFeedLoopCountLabel": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "originalSoundUnavailableBody": "Audio from this video is not available separately.",
   "originalSoundByCreator": "Original sound - {creatorName}",
-  "@originalSoundByCreator": {"placeholders": {"creatorName": {"type": "String"}}},
+  "@originalSoundByCreator": {
+    "placeholders": {
+      "creatorName": {
+        "type": "String"
+      }
+    }
+  },
   "ogVinerBadgeLabel": "OG Viner",
   "profileBadgeOgVinerBody": "This person posted an original Vine that Divine found in the archive. It is not an account verification badge.",
   "@profileBadgeOgVinerBody": {
@@ -4313,12 +4634,33 @@
   "unfollowConfirmButton": "Unfollow",
   "videoClipSaveFailed": "Failed to save clip",
   "videoClipSaveTo": "Save to {destination}",
-  "@videoClipSaveTo": {"placeholders": {"destination": {"type": "String"}}},
+  "@videoClipSaveTo": {
+    "placeholders": {
+      "destination": {
+        "type": "String"
+      }
+    }
+  },
   "videoClipDelete": "Delete clip",
   "inspiredByAttributionMultipleSemanticLabel": "Inspired by {creatorName} +{additionalCreatorCount}. Tap to view their profile.",
-  "@inspiredByAttributionMultipleSemanticLabel": {"placeholders": {"creatorName": {"type": "String"}, "additionalCreatorCount": {"type": "int"}}},
+  "@inspiredByAttributionMultipleSemanticLabel": {
+    "placeholders": {
+      "creatorName": {
+        "type": "String"
+      },
+      "additionalCreatorCount": {
+        "type": "int"
+      }
+    }
+  },
   "inspiredByAttributionSemanticLabel": "Inspired by {creatorName}. Tap to view their profile.",
-  "@inspiredByAttributionSemanticLabel": {"placeholders": {"creatorName": {"type": "String"}}},
+  "@inspiredByAttributionSemanticLabel": {
+    "placeholders": {
+      "creatorName": {
+        "type": "String"
+      }
+    }
+  },
   "bugReportSendReport": "Send Report",
   "supportSubjectRequiredLabel": "Subject *",
   "supportPublicSubmissionTitle": "Public GitHub post",
@@ -4453,12 +4795,18 @@
   "blueskyEnabledSubtitle": "Your videos will be published to Bluesky",
   "blueskyDisabledSubtitle": "Your videos will not be published to Bluesky",
   "blueskyBackfillDisclosureTitle": "Your past videos will post too",
-  "@blueskyBackfillDisclosureTitle": {"description": "Title for the Bluesky publishing disclosure explaining historical videos are backfilled when crossposting is enabled."},
+  "@blueskyBackfillDisclosureTitle": {
+    "description": "Title for the Bluesky publishing disclosure explaining historical videos are backfilled when crossposting is enabled."
+  },
   "blueskyBackfillDisclosureSubtitle": "When you turn this on, Divine will start sending your older videos to Bluesky, oldest first, without rushing the daily limit.",
-  "@blueskyBackfillDisclosureSubtitle": {"description": "Body text for the Bluesky publishing disclosure explaining that enabling crossposting starts a historical video backfill."},
+  "@blueskyBackfillDisclosureSubtitle": {
+    "description": "Body text for the Bluesky publishing disclosure explaining that enabling crossposting starts a historical video backfill."
+  },
   "blueskyHandle": "Bluesky Handle",
   "blueskyDid": "Bluesky DID",
-  "@blueskyDid": {"description": "Label for the ATProto DID shown when a Bluesky account is provisioned."},
+  "@blueskyDid": {
+    "description": "Label for the ATProto DID shown when a Bluesky account is provisioned."
+  },
   "blueskyStatus": "Status",
   "blueskyStatusReady": "Account provisioned and ready",
   "blueskyStatusPending": "Account provisioning in progress...",
@@ -5243,7 +5591,9 @@
   "@videoEditorVoiceOverTakeName": {
     "description": "Title for a single recorded voice-over take, numbered by capture position.",
     "placeholders": {
-      "number": { "type": "int" }
+      "number": {
+        "type": "int"
+      }
     }
   },
   "videoEditorOpenVoiceOverSemanticLabel": "Record a voice over",
@@ -5254,7 +5604,9 @@
   "@videoEditorVoiceOverRecordingsCount": {
     "description": "Counts the voice-over takes recorded so far in the recorder screen.",
     "placeholders": {
-      "count": { "type": "int" }
+      "count": {
+        "type": "int"
+      }
     }
   },
   "videoEditorVoiceOverDeleteLast": "Delete last recording",
@@ -5336,7 +5688,9 @@
   "@videoEditorStopMotionFramesCount": {
     "description": "Short frames-per-image value shown on the stop-motion preview badge and action button (e.g. '2 frames').",
     "placeholders": {
-      "count": { "type": "int" }
+      "count": {
+        "type": "int"
+      }
     }
   },
   "videoEditorStopMotionFramesPerImageButtonLabel": "Frames",
@@ -5347,15 +5701,21 @@
   "@videoEditorStopMotionFramesPerImageValueSemanticLabel": {
     "description": "Accessibility value announcing the current stop-motion hold length, in output frames per still.",
     "placeholders": {
-      "count": { "type": "int" }
+      "count": {
+        "type": "int"
+      }
     }
   },
   "videoEditorStopMotionFrameSemanticLabel": "Stop-motion frame {position} of {total}",
   "@videoEditorStopMotionFrameSemanticLabel": {
     "description": "Accessibility label for a single still tile in the stop-motion timeline strip.",
     "placeholders": {
-      "position": { "type": "int" },
-      "total": { "type": "int" }
+      "position": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
     }
   },
   "videoEditorEditLabel": "Edit",
@@ -5543,7 +5903,9 @@
   "@videoEditorTransitionCurveOptionSemanticLabel": {
     "description": "Accessibility label for an easing-curve option in the transition picker, identified by its position. The curve shape is shown visually as a glyph; screen readers announce the option number instead.",
     "placeholders": {
-      "number": { "type": "int" }
+      "number": {
+        "type": "int"
+      }
     }
   },
   "videoEditorLayerAnimationLabel": "Animation",
@@ -5819,7 +6181,7 @@
   },
   "videoMetadataSaveToDraftsWithoutGalleryHint": "Save video to drafts. No rendered video yet, so no copy is added to {destination}.",
   "@videoMetadataSaveToDraftsWithoutGalleryHint": {
-    "description": "Accessibility hint on the Save-for-later button while no rendered video file exists yet \u2014 the render is still running, or it failed. The button stays enabled, since a draft needs no rendered file, but the gallery copy is made from that file and is therefore skipped.",
+    "description": "Accessibility hint on the Save-for-later button while no rendered video file exists yet — the render is still running, or it failed. The button stays enabled, since a draft needs no rendered file, but the gallery copy is made from that file and is therefore skipped.",
     "placeholders": {
       "destination": {
         "type": "String"
@@ -5945,11 +6307,32 @@
   "badgeDetailBlockClaimantsEmptyTitle": "No one claims this badge right now",
   "badgeDetailBlockClaimantsEmptyBody": "We did not find any current claimants to block.",
   "badgeDetailBlockClaimantsHeading": "{count, plural, =1{Block 1 claimant?} other{Block {count} claimants?}}",
-  "@badgeDetailBlockClaimantsHeading": {"description": "Full-screen confirmation heading before blocking everyone who currently claims a badge.", "placeholders": {"count": {"type": "int"}}},
+  "@badgeDetailBlockClaimantsHeading": {
+    "description": "Full-screen confirmation heading before blocking everyone who currently claims a badge.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "badgeDetailBlockClaimantsBody": "{count, plural, =1{This blocks the account currently claiming this badge. Their posts will leave your feeds, and they will not be notified.} other{This blocks the {count} accounts currently claiming this badge. Their posts will leave your feeds, and they will not be notified.}}",
-  "@badgeDetailBlockClaimantsBody": {"description": "Full-screen confirmation body explaining the effect of blocking everyone who currently claims a badge.", "placeholders": {"count": {"type": "int"}}},
+  "@badgeDetailBlockClaimantsBody": {
+    "description": "Full-screen confirmation body explaining the effect of blocking everyone who currently claims a badge.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "badgeDetailBlockClaimantsConfirm": "{count, plural, =1{Block 1 account} other{Block {count} accounts}}",
-  "@badgeDetailBlockClaimantsConfirm": {"description": "Destructive confirmation button for blocking everyone who currently claims a badge.", "placeholders": {"count": {"type": "int"}}},
+  "@badgeDetailBlockClaimantsConfirm": {
+    "description": "Destructive confirmation button for blocking everyone who currently claims a badge.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "badgeDetailBlockClaimantsSuccess": "Badge claimants blocked",
   "badgeDetailBlockClaimantsFailure": "Could not block badge claimants",
   "badgeDetailLoadError": "Could not load this badge",
@@ -6169,7 +6552,7 @@
   "devOptionsProtectedMinorCurrentStateLabel": "Current state",
   "devOptionsProtectedMinorStateProtected": "Protected minor (13-15)",
   "devOptionsProtectedMinorStateNotProtected": "Not protected",
-  "devOptionsProtectedMinorStateLoading": "Loading\u2026",
+  "devOptionsProtectedMinorStateLoading": "Loading…",
   "devOptionsProtectedMinorStateError": "Error reading state",
   "devOptionsProtectedMinorOverrideNone": "No override (real account state)",
   "devOptionsProtectedMinorOverrideProtected": "Override: forced protected",
@@ -6304,373 +6687,648 @@
     "description": "Inline green call-to-action on the welcome screen that opens the family-guidance flow for under-16 users."
   },
   "minorAccountReviewUnder13WhyTitle": "Here's why",
-    "generalSettingsHoldToRecord": "Hold to record",
-    "generalSettingsHoldToRecordSubtitle": "Start recording when you press and hold, then stop when you release",
-    "uploadPublishedCountMessage": "{count, plural, =1{Video published to your profile} other{{count} videos published to your profile}}",
-    "@uploadPublishedCountMessage": {
-        "description": "Snackbar shown after one or more background uploads succeed, e.g. after a re-auth redirect during which uploads completed.",
-        "placeholders": {
-            "count": {
-                "type": "int",
-                "example": "2"
-            }
-        }
-    },
-    "dmMessageSendLabel": "Send message",
-    "@dmMessageSendLabel": {
-        "description": "Screen-reader label for the send button at the bottom of a DM conversation."
-    },
-    "emojiPickerSearchHint": "Search",
-    "@emojiPickerSearchHint": {
-        "description": "Hint text in the search field of the full emoji picker opened from the DM reaction '+' button."
-    },
-    "emojiCategoryRecent": "Recent",
-    "@emojiCategoryRecent": {
-        "description": "Title for the 'Recent' category in the full emoji picker."
-    },
-    "emojiCategorySmileys": "Smileys & People",
-    "@emojiCategorySmileys": {
-        "description": "Title for the 'Smileys & People' category in the full emoji picker."
-    },
-    "emojiCategoryAnimals": "Animals & Nature",
-    "@emojiCategoryAnimals": {
-        "description": "Title for the 'Animals & Nature' category in the full emoji picker."
-    },
-    "emojiCategoryFood": "Food & Drink",
-    "@emojiCategoryFood": {
-        "description": "Title for the 'Food & Drink' category in the full emoji picker."
-    },
-    "emojiCategoryActivities": "Activities",
-    "@emojiCategoryActivities": {
-        "description": "Title for the 'Activities' category in the full emoji picker."
-    },
-    "emojiCategoryTravel": "Travel & Places",
-    "@emojiCategoryTravel": {
-        "description": "Title for the 'Travel & Places' category in the full emoji picker."
-    },
-    "emojiCategoryObjects": "Objects",
-    "@emojiCategoryObjects": {
-        "description": "Title for the 'Objects' category in the full emoji picker."
-    },
-    "emojiCategorySymbols": "Symbols",
-    "@emojiCategorySymbols": {
-        "description": "Title for the 'Symbols' category in the full emoji picker."
-    },
-    "emojiCategoryFlags": "Flags",
-    "@emojiCategoryFlags": {
-        "description": "Title for the 'Flags' category in the full emoji picker."
-    },
-    "videoEditorMarkerLabel": "Marker",
-    "videoEditorAddTimelineMarkerSemanticLabel": "Add timeline marker",
-    "videoEditorRemoveTimelineMarkerSemanticLabel": "Remove timeline marker",
-    "videoEditorRemoveTimelineMarkerAtPlayheadSemanticLabel": "Remove marker at playhead",
-    "@videoEditorRemoveTimelineMarkerAtPlayheadSemanticLabel": {
-        "description": "Semantic label for the marker-mode bottom-bar delete button, which immediately removes the marker at the current playhead position. Distinct from videoEditorRemoveTimelineMarkerSemanticLabel (the per-marker dot, which asks for confirmation) so screen-reader users can tell the two delete controls apart."
-    },
-    "videoEditorDeleteTimelineMarkerTitle": "Delete marker?",
-    "videoEditorDeleteTimelineMarkerSubtitle": "This removes the marker from the timeline. Your edit stays intact.",
-    "videoEditorVolumeLongPressHint": "Mute or unmute all tracks",
-    "@videoEditorVolumeLongPressHint": {
-        "description": "Semantic long-press hint for a volume arc control. Screen readers announce this as the long-press affordance, which mutes or unmutes all timeline tracks at once."
-    },
-    "videoEditorSplitFailed": "Split failed. Please try again.",
-    "videoEditEditSubtitles": "Edit subtitles",
-    "subtitleEditorTitle": "Edit subtitles",
-    "subtitleEditorSave": "Save",
-    "subtitleEditorProcessing": "Subtitles are still being generated. Check back in a moment.",
-    "subtitleEditorNoSpeech": "No speech was detected in this video, so there's nothing to caption.",
-    "subtitleEditorWriteOwn": "Write them yourself",
-    "subtitleEditorAddCue": "Add a line",
-    "subtitleEditorRemoveCue": "Remove this line",
-    "subtitleEditorPreviewUnavailable": "The video can't be played right now, but you can still fix the captions.",
-    "@subtitleEditorPreviewUnavailable": {
-        "description": "Shown in place of the subtitle editor's video preview when the video cannot be played, so the creator knows the captions are still editable."
-    },
-    "subtitleEditorPlayPreview": "Play the video",
-    "@subtitleEditorPlayPreview": {
-        "description": "Screen-reader label for the subtitle editor's video preview while it is paused; tapping it starts playback."
-    },
-    "subtitleEditorPausePreview": "Pause the video",
-    "@subtitleEditorPausePreview": {
-        "description": "Screen-reader label for the subtitle editor's video preview while it is playing; tapping it pauses playback."
-    },
-    "subtitleEditorInvalidHint": "Every line needs text and an end after its start.",
-    "subtitleEditorLoadError": "Couldn't load subtitles. Try again.",
-    "subtitleEditorSaveSuccess": "Subtitles updated",
-    "subtitleEditorSaveError": "Couldn't save subtitles. Try again.",
-    "subtitleEditorRetry": "Retry",
-    "subtitleEditorCueHint": "Caption text",
-    "imageCropEditorRotateLabel": "Rotate",
-    "@imageCropEditorRotateLabel": {
-        "description": "Bottom-bar action in the image crop editor that rotates the image 90 degrees."
-    },
-    "imageCropEditorFlipLabel": "Flip",
-    "@imageCropEditorFlipLabel": {
-        "description": "Bottom-bar action in the image crop editor that mirrors the image horizontally."
-    },
-    "imageCropEditorResetLabel": "Reset",
-    "@imageCropEditorResetLabel": {
-        "description": "Bottom-bar action in the image crop editor that reverts all crop, rotate and flip changes."
-    },
-    "imageCropEditorCloseSemanticLabel": "Cancel cropping",
-    "@imageCropEditorCloseSemanticLabel": {
-        "description": "Accessibility label for the close button in the image crop editor that discards changes and returns without uploading."
-    },
-    "imageCropEditorDoneSemanticLabel": "Apply crop",
-    "@imageCropEditorDoneSemanticLabel": {
-        "description": "Accessibility label for the done button in the image crop editor that confirms the crop and proceeds with the upload."
-    },
-    "imageCropEditorProcessing": "Applying crop…",
-    "@imageCropEditorProcessing": {
-        "description": "Loading message shown while the image crop editor generates the final cropped image after the user taps done."
-    },
-    "backgroundUploadNotificationTitle": "Uploading video",
-    "@backgroundUploadNotificationTitle": {
-        "description": "Title of the Android foreground-service notification shown while a video uploads in the background so the transfer survives app suspension."
-    },
-    "monetizationSettingsTitle": "Creator Support",
-    "@monetizationSettingsTitle": {"description": "Title for the settings screen where creators configure outbound support links."},
-    "monetizationSettingsSubtitle": "Add tip and subscription links",
-    "@monetizationSettingsSubtitle": {"description": "Subtitle for the settings row that opens creator support link settings."},
-    "monetizationSettingsIntroTitle": "Outbound links only",
-    "@monetizationSettingsIntroTitle": {"description": "Heading explaining monetization links do not create in-app payments."},
-    "monetizationSettingsIntroBody": "Add creator-controlled destinations. Divine never handles the payment or unlocks in-app content from these links.",
-    "@monetizationSettingsIntroBody": {"description": "Body copy explaining profile monetization links are external only."},
-    "monetizationSettingsConfiguredCount": "{count, plural, =1{{count} active link on your profile} other{{count} active links on your profile}}",
-    "@monetizationSettingsConfiguredCount": {"description": "Summary of active monetization links configured on the profile.", "placeholders": {"count": {"type": "int"}}},
-    "monetizationSettingsTipSection": "Send a tip",
-    "@monetizationSettingsTipSection": {"description": "Section header for one-time tip link providers."},
-    "monetizationSettingsSubscriptionSection": "Subscribe / support",
-    "@monetizationSettingsSubscriptionSection": {"description": "Section header for recurring or creator-support link providers."},
-    "monetizationSettingsSave": "Save support links",
-    "@monetizationSettingsSave": {"description": "Button label to save profile monetization links."},
-    "monetizationSettingsSaving": "Saving...",
-    "@monetizationSettingsSaving": {"description": "Button label while profile monetization links are saving."},
-    "monetizationSettingsSaved": "Support links updated",
-    "@monetizationSettingsSaved": {"description": "Snackbar shown after monetization links are saved."},
-    "monetizationSettingsSaveFailed": "Could not save support links. Check your connection and try again.",
-    "@monetizationSettingsSaveFailed": {"description": "Snackbar shown when profile monetization links fail to save."},
-    "monetizationSettingsErrorEmpty": "Add a handle or URL.",
-    "@monetizationSettingsErrorEmpty": {"description": "Validation error for an empty monetization link input."},
-    "monetizationSettingsErrorInvalid": "That link does not look right.",
-    "@monetizationSettingsErrorInvalid": {"description": "Validation error for a malformed monetization link input."},
-    "monetizationSettingsErrorWrongProvider": "Use a link for this provider.",
-    "@monetizationSettingsErrorWrongProvider": {"description": "Validation error when a monetization link uses the wrong provider domain."},
-    "monetizationSettingsHintCashApp": "$cashtag or cash.app link",
-    "@monetizationSettingsHintCashApp": {"description": "Input hint for Cash App monetization link."},
-    "monetizationSettingsHintPayPal": "PayPal.me handle or link",
-    "@monetizationSettingsHintPayPal": {"description": "Input hint for PayPal monetization link."},
-    "monetizationSettingsHintVenmo": "Venmo handle or link",
-    "@monetizationSettingsHintVenmo": {"description": "Input hint for Venmo monetization link."},
-    "monetizationSettingsHintPatreon": "Patreon handle or link",
-    "@monetizationSettingsHintPatreon": {"description": "Input hint for Patreon monetization link."},
-    "monetizationSettingsHintSubstack": "Substack domain or link",
-    "@monetizationSettingsHintSubstack": {"description": "Input hint for Substack monetization link."},
-    "monetizationSettingsHintMedium": "Medium handle or link",
-    "@monetizationSettingsHintMedium": {"description": "Input hint for Medium monetization link."},
-    "monetizationSettingsHintOpenCollective": "Open Collective slug or link",
-    "@monetizationSettingsHintOpenCollective": {"description": "Input hint for Open Collective monetization link."},
-    "profileSupportSheetTitle": "Support this creator",
-    "@profileSupportSheetTitle": {"description": "Title for the profile support links bottom sheet."},
-    "profileSupportSheetBody": "These links open outside Divine. Nothing here unlocks content in the app.",
-    "@profileSupportSheetBody": {"description": "Policy copy in the profile support links bottom sheet."},
-    "profileSupportTipSection": "Send a tip",
-    "@profileSupportTipSection": {"description": "Section header for tip links in the profile support sheet."},
-    "profileSupportSubscriptionSection": "Subscribe / support",
-    "@profileSupportSubscriptionSection": {"description": "Section header for subscription links in the profile support sheet."},
-    "profileSupportButtonLabel": "Support",
-    "@profileSupportButtonLabel": {"description": "Compact button label on a profile that opens creator support links."},
-    "monetizationTipsSettingsTitle": "Tips",
-    "@monetizationTipsSettingsTitle": {"description": "App Store-safe title for the settings screen where creators configure optional tip links."},
-    "monetizationTipsSettingsSubtitle": "Add optional tip links",
-    "@monetizationTipsSettingsSubtitle": {"description": "App Store-safe subtitle for the settings row that opens optional tip link settings."},
-    "monetizationTipsSettingsIntroTitle": "Optional tips only",
-    "@monetizationTipsSettingsIntroTitle": {"description": "App Store-safe heading explaining tip links are optional user-to-user gifts."},
-    "monetizationTipsSettingsIntroBody": "Tips are optional user-to-user gifts. They do not unlock content, subscriptions, features, ranking, visibility, or access in Divine.",
-    "@monetizationTipsSettingsIntroBody": {"description": "App Store-safe body copy explaining tips do not unlock digital content or services."},
-    "monetizationTipsSettingsConfiguredCount": "{count, plural, =1{{count} active tip link on your profile} other{{count} active tip links on your profile}}",
-    "@monetizationTipsSettingsConfiguredCount": {"description": "App Store-safe summary of active tip links configured on the profile.", "placeholders": {"count": {"type": "int"}}},
-    "monetizationTipsSettingsSave": "Save tip links",
-    "@monetizationTipsSettingsSave": {"description": "App Store-safe button label to save optional tip links."},
-    "monetizationTipsSettingsSaved": "Tip links updated",
-    "@monetizationTipsSettingsSaved": {"description": "App Store-safe snackbar shown after optional tip links are saved."},
-    "profileTipButtonLabel": "Tip",
-    "@profileTipButtonLabel": {"description": "App Store-safe compact button label on a profile that opens optional creator tip links."},
-    "profileTipSheetTitle": "Tip this creator",
-    "@profileTipSheetTitle": {"description": "App Store-safe title for the profile tip links bottom sheet."},
-    "profileTipSheetBody": "Tips open outside Divine. They are optional and do not unlock content, subscriptions, features, or access in Divine.",
-    "@profileTipSheetBody": {"description": "App Store-safe policy copy in the profile tip links bottom sheet."},
+  "generalSettingsHoldToRecord": "Hold to record",
+  "generalSettingsHoldToRecordSubtitle": "Start recording when you press and hold, then stop when you release",
+  "uploadPublishedCountMessage": "{count, plural, =1{Video published to your profile} other{{count} videos published to your profile}}",
+  "@uploadPublishedCountMessage": {
+    "description": "Snackbar shown after one or more background uploads succeed, e.g. after a re-auth redirect during which uploads completed.",
+    "placeholders": {
+      "count": {
+        "type": "int",
+        "example": "2"
+      }
+    }
+  },
+  "dmMessageSendLabel": "Send message",
+  "@dmMessageSendLabel": {
+    "description": "Screen-reader label for the send button at the bottom of a DM conversation."
+  },
+  "emojiPickerSearchHint": "Search",
+  "@emojiPickerSearchHint": {
+    "description": "Hint text in the search field of the full emoji picker opened from the DM reaction '+' button."
+  },
+  "emojiCategoryRecent": "Recent",
+  "@emojiCategoryRecent": {
+    "description": "Title for the 'Recent' category in the full emoji picker."
+  },
+  "emojiCategorySmileys": "Smileys & People",
+  "@emojiCategorySmileys": {
+    "description": "Title for the 'Smileys & People' category in the full emoji picker."
+  },
+  "emojiCategoryAnimals": "Animals & Nature",
+  "@emojiCategoryAnimals": {
+    "description": "Title for the 'Animals & Nature' category in the full emoji picker."
+  },
+  "emojiCategoryFood": "Food & Drink",
+  "@emojiCategoryFood": {
+    "description": "Title for the 'Food & Drink' category in the full emoji picker."
+  },
+  "emojiCategoryActivities": "Activities",
+  "@emojiCategoryActivities": {
+    "description": "Title for the 'Activities' category in the full emoji picker."
+  },
+  "emojiCategoryTravel": "Travel & Places",
+  "@emojiCategoryTravel": {
+    "description": "Title for the 'Travel & Places' category in the full emoji picker."
+  },
+  "emojiCategoryObjects": "Objects",
+  "@emojiCategoryObjects": {
+    "description": "Title for the 'Objects' category in the full emoji picker."
+  },
+  "emojiCategorySymbols": "Symbols",
+  "@emojiCategorySymbols": {
+    "description": "Title for the 'Symbols' category in the full emoji picker."
+  },
+  "emojiCategoryFlags": "Flags",
+  "@emojiCategoryFlags": {
+    "description": "Title for the 'Flags' category in the full emoji picker."
+  },
+  "videoEditorMarkerLabel": "Marker",
+  "videoEditorAddTimelineMarkerSemanticLabel": "Add timeline marker",
+  "videoEditorRemoveTimelineMarkerSemanticLabel": "Remove timeline marker",
+  "videoEditorRemoveTimelineMarkerAtPlayheadSemanticLabel": "Remove marker at playhead",
+  "@videoEditorRemoveTimelineMarkerAtPlayheadSemanticLabel": {
+    "description": "Semantic label for the marker-mode bottom-bar delete button, which immediately removes the marker at the current playhead position. Distinct from videoEditorRemoveTimelineMarkerSemanticLabel (the per-marker dot, which asks for confirmation) so screen-reader users can tell the two delete controls apart."
+  },
+  "videoEditorDeleteTimelineMarkerTitle": "Delete marker?",
+  "videoEditorDeleteTimelineMarkerSubtitle": "This removes the marker from the timeline. Your edit stays intact.",
+  "videoEditorVolumeLongPressHint": "Mute or unmute all tracks",
+  "@videoEditorVolumeLongPressHint": {
+    "description": "Semantic long-press hint for a volume arc control. Screen readers announce this as the long-press affordance, which mutes or unmutes all timeline tracks at once."
+  },
+  "videoEditorSplitFailed": "Split failed. Please try again.",
+  "videoEditEditSubtitles": "Edit subtitles",
+  "subtitleEditorTitle": "Edit subtitles",
+  "subtitleEditorSave": "Save",
+  "subtitleEditorProcessing": "Subtitles are still being generated. Check back in a moment.",
+  "subtitleEditorNoSpeech": "No speech was detected in this video, so there's nothing to caption.",
+  "subtitleEditorWriteOwn": "Write them yourself",
+  "subtitleEditorAddCue": "Add a line",
+  "subtitleEditorRemoveCue": "Remove this line",
+  "subtitleEditorPreviewUnavailable": "The video can't be played right now, but you can still fix the captions.",
+  "@subtitleEditorPreviewUnavailable": {
+    "description": "Shown in place of the subtitle editor's video preview when the video cannot be played, so the creator knows the captions are still editable."
+  },
+  "subtitleEditorPlayPreview": "Play the video",
+  "@subtitleEditorPlayPreview": {
+    "description": "Screen-reader label for the subtitle editor's video preview while it is paused; tapping it starts playback."
+  },
+  "subtitleEditorPausePreview": "Pause the video",
+  "@subtitleEditorPausePreview": {
+    "description": "Screen-reader label for the subtitle editor's video preview while it is playing; tapping it pauses playback."
+  },
+  "subtitleEditorInvalidHint": "Every line needs text and an end after its start.",
+  "subtitleEditorLoadError": "Couldn't load subtitles. Try again.",
+  "subtitleEditorSaveSuccess": "Subtitles updated",
+  "subtitleEditorSaveError": "Couldn't save subtitles. Try again.",
+  "subtitleEditorRetry": "Retry",
+  "subtitleEditorCueHint": "Caption text",
+  "imageCropEditorRotateLabel": "Rotate",
+  "@imageCropEditorRotateLabel": {
+    "description": "Bottom-bar action in the image crop editor that rotates the image 90 degrees."
+  },
+  "imageCropEditorFlipLabel": "Flip",
+  "@imageCropEditorFlipLabel": {
+    "description": "Bottom-bar action in the image crop editor that mirrors the image horizontally."
+  },
+  "imageCropEditorResetLabel": "Reset",
+  "@imageCropEditorResetLabel": {
+    "description": "Bottom-bar action in the image crop editor that reverts all crop, rotate and flip changes."
+  },
+  "imageCropEditorCloseSemanticLabel": "Cancel cropping",
+  "@imageCropEditorCloseSemanticLabel": {
+    "description": "Accessibility label for the close button in the image crop editor that discards changes and returns without uploading."
+  },
+  "imageCropEditorDoneSemanticLabel": "Apply crop",
+  "@imageCropEditorDoneSemanticLabel": {
+    "description": "Accessibility label for the done button in the image crop editor that confirms the crop and proceeds with the upload."
+  },
+  "imageCropEditorProcessing": "Applying crop…",
+  "@imageCropEditorProcessing": {
+    "description": "Loading message shown while the image crop editor generates the final cropped image after the user taps done."
+  },
+  "backgroundUploadNotificationTitle": "Uploading video",
+  "@backgroundUploadNotificationTitle": {
+    "description": "Title of the Android foreground-service notification shown while a video uploads in the background so the transfer survives app suspension."
+  },
+  "monetizationSettingsTitle": "Creator Support",
+  "@monetizationSettingsTitle": {
+    "description": "Title for the settings screen where creators configure outbound support links."
+  },
+  "monetizationSettingsSubtitle": "Add tip and subscription links",
+  "@monetizationSettingsSubtitle": {
+    "description": "Subtitle for the settings row that opens creator support link settings."
+  },
+  "monetizationSettingsIntroTitle": "Outbound links only",
+  "@monetizationSettingsIntroTitle": {
+    "description": "Heading explaining monetization links do not create in-app payments."
+  },
+  "monetizationSettingsIntroBody": "Add creator-controlled destinations. Divine never handles the payment or unlocks in-app content from these links.",
+  "@monetizationSettingsIntroBody": {
+    "description": "Body copy explaining profile monetization links are external only."
+  },
+  "monetizationSettingsConfiguredCount": "{count, plural, =1{{count} active link on your profile} other{{count} active links on your profile}}",
+  "@monetizationSettingsConfiguredCount": {
+    "description": "Summary of active monetization links configured on the profile.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "monetizationSettingsTipSection": "Send a tip",
+  "@monetizationSettingsTipSection": {
+    "description": "Section header for one-time tip link providers."
+  },
+  "monetizationSettingsSubscriptionSection": "Subscribe / support",
+  "@monetizationSettingsSubscriptionSection": {
+    "description": "Section header for recurring or creator-support link providers."
+  },
+  "monetizationSettingsSave": "Save support links",
+  "@monetizationSettingsSave": {
+    "description": "Button label to save profile monetization links."
+  },
+  "monetizationSettingsSaving": "Saving...",
+  "@monetizationSettingsSaving": {
+    "description": "Button label while profile monetization links are saving."
+  },
+  "monetizationSettingsSaved": "Support links updated",
+  "@monetizationSettingsSaved": {
+    "description": "Snackbar shown after monetization links are saved."
+  },
+  "monetizationSettingsSaveFailed": "Could not save support links. Check your connection and try again.",
+  "@monetizationSettingsSaveFailed": {
+    "description": "Snackbar shown when profile monetization links fail to save."
+  },
+  "monetizationSettingsErrorEmpty": "Add a handle or URL.",
+  "@monetizationSettingsErrorEmpty": {
+    "description": "Validation error for an empty monetization link input."
+  },
+  "monetizationSettingsErrorInvalid": "That link does not look right.",
+  "@monetizationSettingsErrorInvalid": {
+    "description": "Validation error for a malformed monetization link input."
+  },
+  "monetizationSettingsErrorWrongProvider": "Use a link for this provider.",
+  "@monetizationSettingsErrorWrongProvider": {
+    "description": "Validation error when a monetization link uses the wrong provider domain."
+  },
+  "monetizationSettingsHintCashApp": "$cashtag or cash.app link",
+  "@monetizationSettingsHintCashApp": {
+    "description": "Input hint for Cash App monetization link."
+  },
+  "monetizationSettingsHintPayPal": "PayPal.me handle or link",
+  "@monetizationSettingsHintPayPal": {
+    "description": "Input hint for PayPal monetization link."
+  },
+  "monetizationSettingsHintVenmo": "Venmo handle or link",
+  "@monetizationSettingsHintVenmo": {
+    "description": "Input hint for Venmo monetization link."
+  },
+  "monetizationSettingsHintPatreon": "Patreon handle or link",
+  "@monetizationSettingsHintPatreon": {
+    "description": "Input hint for Patreon monetization link."
+  },
+  "monetizationSettingsHintSubstack": "Substack domain or link",
+  "@monetizationSettingsHintSubstack": {
+    "description": "Input hint for Substack monetization link."
+  },
+  "monetizationSettingsHintMedium": "Medium handle or link",
+  "@monetizationSettingsHintMedium": {
+    "description": "Input hint for Medium monetization link."
+  },
+  "monetizationSettingsHintOpenCollective": "Open Collective slug or link",
+  "@monetizationSettingsHintOpenCollective": {
+    "description": "Input hint for Open Collective monetization link."
+  },
+  "profileSupportSheetTitle": "Support this creator",
+  "@profileSupportSheetTitle": {
+    "description": "Title for the profile support links bottom sheet."
+  },
+  "profileSupportSheetBody": "These links open outside Divine. Nothing here unlocks content in the app.",
+  "@profileSupportSheetBody": {
+    "description": "Policy copy in the profile support links bottom sheet."
+  },
+  "profileSupportTipSection": "Send a tip",
+  "@profileSupportTipSection": {
+    "description": "Section header for tip links in the profile support sheet."
+  },
+  "profileSupportSubscriptionSection": "Subscribe / support",
+  "@profileSupportSubscriptionSection": {
+    "description": "Section header for subscription links in the profile support sheet."
+  },
+  "profileSupportButtonLabel": "Support",
+  "@profileSupportButtonLabel": {
+    "description": "Compact button label on a profile that opens creator support links."
+  },
+  "monetizationTipsSettingsTitle": "Tips",
+  "@monetizationTipsSettingsTitle": {
+    "description": "App Store-safe title for the settings screen where creators configure optional tip links."
+  },
+  "monetizationTipsSettingsSubtitle": "Add optional tip links",
+  "@monetizationTipsSettingsSubtitle": {
+    "description": "App Store-safe subtitle for the settings row that opens optional tip link settings."
+  },
+  "monetizationTipsSettingsIntroTitle": "Optional tips only",
+  "@monetizationTipsSettingsIntroTitle": {
+    "description": "App Store-safe heading explaining tip links are optional user-to-user gifts."
+  },
+  "monetizationTipsSettingsIntroBody": "Tips are optional user-to-user gifts. They do not unlock content, subscriptions, features, ranking, visibility, or access in Divine.",
+  "@monetizationTipsSettingsIntroBody": {
+    "description": "App Store-safe body copy explaining tips do not unlock digital content or services."
+  },
+  "monetizationTipsSettingsConfiguredCount": "{count, plural, =1{{count} active tip link on your profile} other{{count} active tip links on your profile}}",
+  "@monetizationTipsSettingsConfiguredCount": {
+    "description": "App Store-safe summary of active tip links configured on the profile.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "monetizationTipsSettingsSave": "Save tip links",
+  "@monetizationTipsSettingsSave": {
+    "description": "App Store-safe button label to save optional tip links."
+  },
+  "monetizationTipsSettingsSaved": "Tip links updated",
+  "@monetizationTipsSettingsSaved": {
+    "description": "App Store-safe snackbar shown after optional tip links are saved."
+  },
+  "profileTipButtonLabel": "Tip",
+  "@profileTipButtonLabel": {
+    "description": "App Store-safe compact button label on a profile that opens optional creator tip links."
+  },
+  "profileTipSheetTitle": "Tip this creator",
+  "@profileTipSheetTitle": {
+    "description": "App Store-safe title for the profile tip links bottom sheet."
+  },
+  "profileTipSheetBody": "Tips open outside Divine. They are optional and do not unlock content, subscriptions, features, or access in Divine.",
+  "@profileTipSheetBody": {
+    "description": "App Store-safe policy copy in the profile tip links bottom sheet."
+  },
   "settingsStorageTitle": "Storage",
-  "@settingsStorageTitle": {"description": "Title of the Storage settings screen and its entry in the settings list."},
+  "@settingsStorageTitle": {
+    "description": "Title of the Storage settings screen and its entry in the settings list."
+  },
   "settingsStorageCacheSectionTitle": "Cached media",
-  "@settingsStorageCacheSectionTitle": {"description": "Section header for the clearable media caches on the Storage screen."},
+  "@settingsStorageCacheSectionTitle": {
+    "description": "Section header for the clearable media caches on the Storage screen."
+  },
   "settingsStorageCacheDescription": "Cached feed videos, thumbnails and temporary renders. Clearing them is safe — they're re-downloaded or regenerated when needed.",
-  "@settingsStorageCacheDescription": {"description": "Explains what the cached-media section clears and that it is safe."},
+  "@settingsStorageCacheDescription": {
+    "description": "Explains what the cached-media section clears and that it is safe."
+  },
   "settingsStorageMeasuring": "Measuring…",
-  "@settingsStorageMeasuring": {"description": "Placeholder shown while the cache size is being computed."},
+  "@settingsStorageMeasuring": {
+    "description": "Placeholder shown while the cache size is being computed."
+  },
   "settingsStorageCacheInUse": "{size} in use",
-  "@settingsStorageCacheInUse": {"description": "Shows how much disk the caches currently use.", "placeholders": {"size": {"type": "String"}}},
+  "@settingsStorageCacheInUse": {
+    "description": "Shows how much disk the caches currently use.",
+    "placeholders": {
+      "size": {
+        "type": "String"
+      }
+    }
+  },
   "settingsStorageClearButton": "Clear cache",
-  "@settingsStorageClearButton": {"description": "Button that clears the media caches."},
+  "@settingsStorageClearButton": {
+    "description": "Button that clears the media caches."
+  },
   "settingsStorageClearConfirmTitle": "Clear cached media?",
-  "@settingsStorageClearConfirmTitle": {"description": "Title of the confirmation sheet before clearing caches."},
+  "@settingsStorageClearConfirmTitle": {
+    "description": "Title of the confirmation sheet before clearing caches."
+  },
   "settingsStorageClearConfirmMessage": "This frees up {size}. Your clip library is not affected.",
-  "@settingsStorageClearConfirmMessage": {"description": "Body of the clear-cache confirmation sheet.", "placeholders": {"size": {"type": "String"}}},
+  "@settingsStorageClearConfirmMessage": {
+    "description": "Body of the clear-cache confirmation sheet.",
+    "placeholders": {
+      "size": {
+        "type": "String"
+      }
+    }
+  },
   "settingsStorageClearConfirmAction": "Clear",
-  "@settingsStorageClearConfirmAction": {"description": "Confirm button that performs the cache clear."},
+  "@settingsStorageClearConfirmAction": {
+    "description": "Confirm button that performs the cache clear."
+  },
   "settingsStorageCleared": "Cache cleared",
-  "@settingsStorageCleared": {"description": "Accessibility announcement after the cache is cleared."},
+  "@settingsStorageCleared": {
+    "description": "Accessibility announcement after the cache is cleared."
+  },
   "settingsStorageLibrarySectionTitle": "Clip library",
-  "@settingsStorageLibrarySectionTitle": {"description": "Section header for the clip-library audit on the Storage screen."},
+  "@settingsStorageLibrarySectionTitle": {
+    "description": "Section header for the clip-library audit on the Storage screen."
+  },
   "settingsStorageLibraryDescription": "Check for broken clips whose video file is missing.",
-  "@settingsStorageLibraryDescription": {"description": "Explains what the clip-library check does."},
+  "@settingsStorageLibraryDescription": {
+    "description": "Explains what the clip-library check does."
+  },
   "settingsStorageScanButton": "Check library",
-  "@settingsStorageScanButton": {"description": "Button that scans the clip library for broken clips."},
+  "@settingsStorageScanButton": {
+    "description": "Button that scans the clip library for broken clips."
+  },
   "settingsStorageLibraryHealthy": "No broken clips found",
-  "@settingsStorageLibraryHealthy": {"description": "Shown when the library scan finds no broken clips."},
+  "@settingsStorageLibraryHealthy": {
+    "description": "Shown when the library scan finds no broken clips."
+  },
   "settingsStorageBrokenClipsFound": "Broken clips found: {count}",
-  "@settingsStorageBrokenClipsFound": {"description": "Shows how many broken clips the scan found.", "placeholders": {"count": {"type": "int"}}},
+  "@settingsStorageBrokenClipsFound": {
+    "description": "Shows how many broken clips the scan found.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "settingsStorageRemoveBrokenButton": "Remove broken clips",
-  "@settingsStorageRemoveBrokenButton": {"description": "Button that removes the broken clips found by the scan."},
+  "@settingsStorageRemoveBrokenButton": {
+    "description": "Button that removes the broken clips found by the scan."
+  },
   "settingsStorageBrokenClipsRemoved": "Broken clips removed",
-  "@settingsStorageBrokenClipsRemoved": {"description": "Accessibility announcement after broken clips are removed."},
+  "@settingsStorageBrokenClipsRemoved": {
+    "description": "Accessibility announcement after broken clips are removed."
+  },
   "settingsStorageError": "Something went wrong",
-  "@settingsStorageError": {"description": "Generic error shown when a storage operation fails."},
+  "@settingsStorageError": {
+    "description": "Generic error shown when a storage operation fails."
+  },
   "settingsStorageMaxVideoCacheLabel": "Maximum video cache",
-  "@settingsStorageMaxVideoCacheLabel": {"description": "Label above the slider that sets the maximum video-cache size."},
+  "@settingsStorageMaxVideoCacheLabel": {
+    "description": "Label above the slider that sets the maximum video-cache size."
+  },
   "settingsStorageApproxVideos": "{count, plural, =1{≈ {count} video} other{≈ {count} videos}}",
-  "@settingsStorageApproxVideos": {"description": "Approximate number of videos that fit in the chosen cache size.", "placeholders": {"count": {"type": "int"}}},
+  "@settingsStorageApproxVideos": {
+    "description": "Approximate number of videos that fit in the chosen cache size.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "settingsStorageRemoveBrokenConfirmTitle": "Remove broken clips?",
-  "@settingsStorageRemoveBrokenConfirmTitle": {"description": "Title of the confirmation sheet before permanently removing broken clips whose video file is gone."},
+  "@settingsStorageRemoveBrokenConfirmTitle": {
+    "description": "Title of the confirmation sheet before permanently removing broken clips whose video file is gone."
+  },
   "settingsStorageRepairSectionTitle": "Repair install",
-  "@settingsStorageRepairSectionTitle": {"description": "Section header for the last-resort local-data reset on the Storage screen."},
+  "@settingsStorageRepairSectionTitle": {
+    "description": "Section header for the last-resort local-data reset on the Storage screen."
+  },
   "settingsStorageRepairDescription": "If the app keeps crashing or acting strange, resetting its local data usually fixes it. Your clips and drafts stay.",
-  "@settingsStorageRepairDescription": {"description": "Explains when to reach for the repair reset and what survives it."},
+  "@settingsStorageRepairDescription": {
+    "description": "Explains when to reach for the repair reset and what survives it."
+  },
   "settingsStorageRepairButton": "Reset app data",
-  "@settingsStorageRepairButton": {"description": "Button that wipes local app data to recover from a broken install."},
+  "@settingsStorageRepairButton": {
+    "description": "Button that wipes local app data to recover from a broken install."
+  },
   "settingsStorageRepairConfirmTitle": "Reset app data?",
-  "@settingsStorageRepairConfirmTitle": {"description": "Title of the confirmation sheet before the repair reset."},
+  "@settingsStorageRepairConfirmTitle": {
+    "description": "Title of the confirmation sheet before the repair reset."
+  },
   "settingsStorageRepairConfirmMessage": "This clears cached feed data and temporary files. Your clips, drafts, settings and sign-in stay, but you'll need to restart the app afterwards.",
-  "@settingsStorageRepairConfirmMessage": {"description": "Body of the repair confirmation sheet: what is removed, what survives, and that a restart is needed."},
+  "@settingsStorageRepairConfirmMessage": {
+    "description": "Body of the repair confirmation sheet: what is removed, what survives, and that a restart is needed."
+  },
   "settingsStorageRepairFootprint": "{size} will be removed",
-  "@settingsStorageRepairFootprint": {"description": "Shows how much disk the repair reset frees, inside the confirmation sheet.", "placeholders": {"size": {"type": "String"}}},
+  "@settingsStorageRepairFootprint": {
+    "description": "Shows how much disk the repair reset frees, inside the confirmation sheet.",
+    "placeholders": {
+      "size": {
+        "type": "String"
+      }
+    }
+  },
   "settingsStorageRepairConfirmAction": "Reset",
-  "@settingsStorageRepairConfirmAction": {"description": "Confirm button that performs the repair reset."},
+  "@settingsStorageRepairConfirmAction": {
+    "description": "Confirm button that performs the repair reset."
+  },
   "settingsStorageRepairInProgress": "Resetting…",
-  "@settingsStorageRepairInProgress": {"description": "Shown while the repair reset is running."},
+  "@settingsStorageRepairInProgress": {
+    "description": "Shown while the repair reset is running."
+  },
   "settingsStorageRepairSuccess": "Done — restart the app to finish.",
-  "@settingsStorageRepairSuccess": {"description": "Shown and announced after a successful repair reset."},
+  "@settingsStorageRepairSuccess": {
+    "description": "Shown and announced after a successful repair reset."
+  },
   "settingsStorageRepairFailure": "Couldn't reset everything. Try again after a restart.",
-  "@settingsStorageRepairFailure": {"description": "Shown and announced when the repair reset could not complete."},
+  "@settingsStorageRepairFailure": {
+    "description": "Shown and announced when the repair reset could not complete."
+  },
   "nostrSettingsSignatureVerification": "Signature verification",
-  "@nostrSettingsSignatureVerification": {"description": "Title for the Nostr relay signature verification setting."},
+  "@nostrSettingsSignatureVerification": {
+    "description": "Title for the Nostr relay signature verification setting."
+  },
   "nostrSettingsSignatureVerificationIntro": "Choose when Divine checks relay event signatures. Event IDs are always validated first.",
-  "@nostrSettingsSignatureVerificationIntro": {"description": "Intro copy for the Nostr relay signature verification setting screen."},
+  "@nostrSettingsSignatureVerificationIntro": {
+    "description": "Intro copy for the Nostr relay signature verification setting screen."
+  },
   "nostrSettingsSignatureVerificationAll": "All relays",
-  "@nostrSettingsSignatureVerificationAll": {"description": "Option label to verify event signatures from all Nostr relays."},
+  "@nostrSettingsSignatureVerificationAll": {
+    "description": "Option label to verify event signatures from all Nostr relays."
+  },
   "nostrSettingsSignatureVerificationAllSubtitle": "Safest. Verify every relay event signature.",
-  "@nostrSettingsSignatureVerificationAllSubtitle": {"description": "Option subtitle for verifying every Nostr relay event signature."},
+  "@nostrSettingsSignatureVerificationAllSubtitle": {
+    "description": "Option subtitle for verifying every Nostr relay event signature."
+  },
   "nostrSettingsSignatureVerificationUntrusted": "Untrusted relays",
-  "@nostrSettingsSignatureVerificationUntrusted": {"description": "Option label to verify event signatures only from untrusted Nostr relays."},
+  "@nostrSettingsSignatureVerificationUntrusted": {
+    "description": "Option label to verify event signatures only from untrusted Nostr relays."
+  },
   "nostrSettingsSignatureVerificationUntrustedSubtitle": "Skip checks for relays already in your configured pool.",
-  "@nostrSettingsSignatureVerificationUntrustedSubtitle": {"description": "Option subtitle for skipping signature checks on configured relays."},
+  "@nostrSettingsSignatureVerificationUntrustedSubtitle": {
+    "description": "Option subtitle for skipping signature checks on configured relays."
+  },
   "nostrSettingsSignatureVerificationNonDivine": "Non-Divine relays",
-  "@nostrSettingsSignatureVerificationNonDivine": {"description": "Option label to verify event signatures only from non-Divine Nostr relays."},
+  "@nostrSettingsSignatureVerificationNonDivine": {
+    "description": "Option label to verify event signatures only from non-Divine Nostr relays."
+  },
   "nostrSettingsSignatureVerificationNonDivineSubtitle": "Trust Divine relays, verify the rest.",
-  "@nostrSettingsSignatureVerificationNonDivineSubtitle": {"description": "Option subtitle for trusting Divine-hosted relays while verifying other relay signatures."},
+  "@nostrSettingsSignatureVerificationNonDivineSubtitle": {
+    "description": "Option subtitle for trusting Divine-hosted relays while verifying other relay signatures."
+  },
   "settingsCrosspostingTitle": "Crossposting",
-  "@settingsCrosspostingTitle": {"description": "Settings row and screen title for crossposting videos to external platforms."},
+  "@settingsCrosspostingTitle": {
+    "description": "Settings row and screen title for crossposting videos to external platforms."
+  },
   "settingsCrosspostingSubtitle": "Share your videos to other platforms",
-  "@settingsCrosspostingSubtitle": {"description": "Settings row subtitle for the crossposting screen."},
+  "@settingsCrosspostingSubtitle": {
+    "description": "Settings row subtitle for the crossposting screen."
+  },
   "crosspostingSignInRequired": "Sign in with Divine to manage crossposting",
-  "@crosspostingSignInRequired": {"description": "Shown on the crossposting screen when the user is signed out."},
+  "@crosspostingSignInRequired": {
+    "description": "Shown on the crossposting screen when the user is signed out."
+  },
   "crosspostingLoadFailed": "Couldn't load your crossposting settings",
-  "@crosspostingLoadFailed": {"description": "Error shown when the crossposting settings fail to load."},
+  "@crosspostingLoadFailed": {
+    "description": "Error shown when the crossposting settings fail to load."
+  },
   "crosspostingNoPlatforms": "No crossposting platforms are available right now",
-  "@crosspostingNoPlatforms": {"description": "Empty state when the service has no enabled crossposting platforms."},
+  "@crosspostingNoPlatforms": {
+    "description": "Empty state when the service has no enabled crossposting platforms."
+  },
   "crosspostingRetry": "Retry",
-  "@crosspostingRetry": {"description": "Button label to retry loading crossposting settings."},
+  "@crosspostingRetry": {
+    "description": "Button label to retry loading crossposting settings."
+  },
   "crosspostingNotConnected": "Not connected",
-  "@crosspostingNotConnected": {"description": "Status line for a platform without a linked account."},
+  "@crosspostingNotConnected": {
+    "description": "Status line for a platform without a linked account."
+  },
   "crosspostingConnected": "Connected",
-  "@crosspostingConnected": {"description": "Status line for a connected platform whose account name and external ID are unavailable."},
+  "@crosspostingConnected": {
+    "description": "Status line for a connected platform whose account name and external ID are unavailable."
+  },
   "crosspostingNeedsReconnect": "Needs reconnecting",
-  "@crosspostingNeedsReconnect": {"description": "Status line for a platform whose account link expired."},
+  "@crosspostingNeedsReconnect": {
+    "description": "Status line for a platform whose account link expired."
+  },
   "crosspostingConnect": "Connect",
-  "@crosspostingConnect": {"description": "Button label to link an external platform account."},
+  "@crosspostingConnect": {
+    "description": "Button label to link an external platform account."
+  },
   "crosspostingReconnect": "Reconnect",
-  "@crosspostingReconnect": {"description": "Button label to re-link a platform account that needs re-authorization."},
+  "@crosspostingReconnect": {
+    "description": "Button label to re-link a platform account that needs re-authorization."
+  },
   "crosspostingDisconnect": "Disconnect",
-  "@crosspostingDisconnect": {"description": "Button label to unlink an external platform account."},
+  "@crosspostingDisconnect": {
+    "description": "Button label to unlink an external platform account."
+  },
   "crosspostingModeOff": "Off",
-  "@crosspostingModeOff": {"description": "Posting-mode option: never crosspost to this platform."},
+  "@crosspostingModeOff": {
+    "description": "Posting-mode option: never crosspost to this platform."
+  },
   "crosspostingModeManual": "Manual",
-  "@crosspostingModeManual": {"description": "Posting-mode option: user picks per video."},
+  "@crosspostingModeManual": {
+    "description": "Posting-mode option: user picks per video."
+  },
   "crosspostingModeManualSubtitle": "You choose per video",
-  "@crosspostingModeManualSubtitle": {"description": "Explains the manual posting mode."},
+  "@crosspostingModeManualSubtitle": {
+    "description": "Explains the manual posting mode."
+  },
   "crosspostingModeAutomatic": "Automatic",
-  "@crosspostingModeAutomatic": {"description": "Posting-mode option: every future video is crossposted."},
+  "@crosspostingModeAutomatic": {
+    "description": "Posting-mode option: every future video is crossposted."
+  },
   "crosspostingModeAutomaticSubtitle": "Future videos post automatically — only videos published after you turn this on",
-  "@crosspostingModeAutomaticSubtitle": {"description": "Explains the automatic posting mode and that it is not retroactive."},
+  "@crosspostingModeAutomaticSubtitle": {
+    "description": "Explains the automatic posting mode and that it is not retroactive."
+  },
   "crosspostingNotConnectedError": "Connect this platform first to change how it posts.",
-  "@crosspostingNotConnectedError": {"description": "Error shown when a posting mode is set on a platform that isn't connected."},
+  "@crosspostingNotConnectedError": {
+    "description": "Error shown when a posting mode is set on a platform that isn't connected."
+  },
   "crosspostingGenericError": "Something went wrong. Try again.",
-  "@crosspostingGenericError": {"description": "Generic error for failed crossposting actions."},
+  "@crosspostingGenericError": {
+    "description": "Generic error for failed crossposting actions."
+  },
   "crosspostingCallbackTimeoutError": "We never heard back from the sign-in page. If you finished connecting there, refresh — your account may already be linked.",
-  "@crosspostingCallbackTimeoutError": {"description": "Error shown when the crossposting OAuth browser session ends without a validated callback (for example when Android app-link verification fails)."},
+  "@crosspostingCallbackTimeoutError": {
+    "description": "Error shown when the crossposting OAuth browser session ends without a validated callback (for example when Android app-link verification fails)."
+  },
   "crosspostingConnectionSuccess": "{platform} connected",
   "@crosspostingConnectionSuccess": {
     "description": "Snackbar after returning from a successful platform connection.",
-    "placeholders": {"platform": {"type": "String"}}
+    "placeholders": {
+      "platform": {
+        "type": "String"
+      }
+    }
   },
   "crosspostingConnectionFailed": "Couldn't connect {platform}",
   "@crosspostingConnectionFailed": {
     "description": "Snackbar after returning from a failed platform connection.",
-    "placeholders": {"platform": {"type": "String"}}
+    "placeholders": {
+      "platform": {
+        "type": "String"
+      }
+    }
   },
   "crosspostingConnectionDenied": "Connection was canceled on {platform}",
   "@crosspostingConnectionDenied": {
     "description": "Snackbar when the user denied the connection on the provider's page.",
-    "placeholders": {"platform": {"type": "String"}}
+    "placeholders": {
+      "platform": {
+        "type": "String"
+      }
+    }
   },
   "supporterTitle": "Divine Supporters",
-  "@supporterTitle": {"description": "Title of the supporter subscription settings screen and its settings tile."},
+  "@supporterTitle": {
+    "description": "Title of the supporter subscription settings screen and its settings tile."
+  },
   "supporterTileSubtitle": "Support Divine with an optional monthly subscription.",
-  "@supporterTileSubtitle": {"description": "Subtitle of the supporter subscription settings tile."},
+  "@supporterTileSubtitle": {
+    "description": "Subtitle of the supporter subscription settings tile."
+  },
   "supporterHeroTitle": "Keep Divine running",
-  "@supporterHeroTitle": {"description": "Headline at the top of the supporter subscription screen."},
+  "@supporterHeroTitle": {
+    "description": "Headline at the top of the supporter subscription screen."
+  },
   "supporterHeroBody": "Divine is free and always will be. If you want to help us keep the loops going, become a monthly supporter. Nothing is locked — it just keeps the lights on and earns our thanks.",
-  "@supporterHeroBody": {"description": "Introductory copy on the supporter subscription screen explaining the optional monthly support."},
+  "@supporterHeroBody": {
+    "description": "Introductory copy on the supporter subscription screen explaining the optional monthly support."
+  },
   "supporterActiveBadge": "You're a Divine Supporter. Thank you for keeping this going.",
-  "@supporterActiveBadge": {"description": "Confirmation shown to users with an active supporter subscription."},
+  "@supporterActiveBadge": {
+    "description": "Confirmation shown to users with an active supporter subscription."
+  },
   "supporterPurchasePending": "Your purchase is pending approval.",
-  "@supporterPurchasePending": {"description": "Status note shown while a supporter purchase awaits store approval."},
+  "@supporterPurchasePending": {
+    "description": "Status note shown while a supporter purchase awaits store approval."
+  },
   "supporterPurchaseConfirming": "Confirming your support…",
-  "@supporterPurchaseConfirming": {"description": "Status note shown while the server verifies a supporter purchase."},
+  "@supporterPurchaseConfirming": {
+    "description": "Status note shown while the server verifies a supporter purchase."
+  },
   "supporterStoreChecking": "Checking the store…",
-  "@supporterStoreChecking": {"description": "Loading note shown while supporter subscription tiers are fetched from the store."},
+  "@supporterStoreChecking": {
+    "description": "Loading note shown while supporter subscription tiers are fetched from the store."
+  },
   "supporterUnavailable": "Supporter subscriptions are not available here right now.",
-  "@supporterUnavailable": {"description": "Note shown when no supporter subscription tiers are available on this device or storefront."},
+  "@supporterUnavailable": {
+    "description": "Note shown when no supporter subscription tiers are available on this device or storefront."
+  },
   "supporterRestorePurchases": "Restore purchases",
-  "@supporterRestorePurchases": {"description": "Button label that re-checks the store for an existing supporter subscription."},
+  "@supporterRestorePurchases": {
+    "description": "Button label that re-checks the store for an existing supporter subscription."
+  },
   "supporterDismissError": "Dismiss error",
-  "@supporterDismissError": {"description": "Accessibility label for the button that dismisses the supporter error banner."},
+  "@supporterDismissError": {
+    "description": "Accessibility label for the button that dismisses the supporter error banner."
+  },
   "supporterErrorStoreUnavailable": "The store is unavailable on this device.",
-  "@supporterErrorStoreUnavailable": {"description": "Error shown when the device cannot reach the app store billing client."},
+  "@supporterErrorStoreUnavailable": {
+    "description": "Error shown when the device cannot reach the app store billing client."
+  },
   "supporterErrorPurchaseFailed": "The purchase did not complete. You were not charged.",
-  "@supporterErrorPurchaseFailed": {"description": "Error shown when a supporter purchase fails or is cancelled."},
+  "@supporterErrorPurchaseFailed": {
+    "description": "Error shown when a supporter purchase fails or is cancelled."
+  },
   "supporterErrorPurchasePending": "Your purchase is pending approval.",
-  "@supporterErrorPurchasePending": {"description": "Error-banner variant shown when a supporter purchase is left in a pending state."},
+  "@supporterErrorPurchasePending": {
+    "description": "Error-banner variant shown when a supporter purchase is left in a pending state."
+  },
   "supporterErrorRestoreFailed": "No supporter subscription was found to restore.",
-  "@supporterErrorRestoreFailed": {"description": "Error shown when restoring purchases finds no supporter subscription."},
+  "@supporterErrorRestoreFailed": {
+    "description": "Error shown when restoring purchases finds no supporter subscription."
+  },
   "supporterErrorOwnershipConflict": "This purchase belongs to another Divine account.",
-  "@supporterErrorOwnershipConflict": {"description": "Error shown when the store purchase is already claimed by a different Divine account."},
+  "@supporterErrorOwnershipConflict": {
+    "description": "Error shown when the store purchase is already claimed by a different Divine account."
+  },
   "supporterErrorVerificationUnavailable": "Divine could not confirm supporter status right now.",
-  "@supporterErrorVerificationUnavailable": {"description": "Error shown when the server-side verification of a supporter purchase is temporarily unavailable."},
+  "@supporterErrorVerificationUnavailable": {
+    "description": "Error shown when the server-side verification of a supporter purchase is temporarily unavailable."
+  },
   "supporterErrorUnknown": "Something went wrong. Please try again.",
-  "@supporterErrorUnknown": {"description": "Generic supporter flow error shown when no more specific message applies."},
+  "@supporterErrorUnknown": {
+    "description": "Generic supporter flow error shown when no more specific message applies."
+  },
   "supporterDisclaimer": "Divine confirms supporter status after the store verifies your purchase. Recognition is optional, and the halo is not verification.",
-  "@supporterDisclaimer": {"description": "Footnote on the supporter screen explaining server-side confirmation and that recognition is optional."},
+  "@supporterDisclaimer": {
+    "description": "Footnote on the supporter screen explaining server-side confirmation and that recognition is optional."
+  },
   "profileNotifyBellOff": "Get notified about new vines",
   "@profileNotifyBellOff": {
     "description": "Accessibility label on the profile bell when the viewer is not subscribed. Describes the action the tap performs, not the current state."
@@ -6701,13 +7359,17 @@
   "soundCreatorBy": "By {creator}",
   "@soundCreatorBy": {
     "placeholders": {
-      "creator": {"type": "String"}
+      "creator": {
+        "type": "String"
+      }
     }
   },
   "soundSharedBy": "Shared by {publisher}",
   "@soundSharedBy": {
     "placeholders": {
-      "publisher": {"type": "String"}
+      "publisher": {
+        "type": "String"
+      }
     }
   },
   "soundRemixingAllowed": "Remixing allowed",
@@ -6728,29 +7390,54 @@
   "videoEditorDiscardToolChangesSemanticLabel": "Discard changes in {tool}",
   "@videoEditorDiscardToolChangesSemanticLabel": {
     "description": "Accessibility label for closing a named video-editor tool without applying its changes.",
-    "placeholders": {"tool": {"type": "String", "example": "Draw"}}
+    "placeholders": {
+      "tool": {
+        "type": "String",
+        "example": "Draw"
+      }
+    }
   },
   "videoEditorApplyToolChangesSemanticLabel": "Apply changes in {tool}",
   "@videoEditorApplyToolChangesSemanticLabel": {
     "description": "Accessibility label for applying changes made in a named video-editor tool.",
-    "placeholders": {"tool": {"type": "String", "example": "Draw"}}
+    "placeholders": {
+      "tool": {
+        "type": "String",
+        "example": "Draw"
+      }
+    }
   },
   "videoEditorRemoveAudioSemanticLabel": "Remove audio",
   "rgbColorSemanticLabel": "RGB {red}, {green}, {blue}",
   "@rgbColorSemanticLabel": {
     "description": "Accessibility label announcing a color swatch as its RGB triplet, used when the color has no human-readable name.",
     "placeholders": {
-      "red": {"type": "int", "example": "255"},
-      "green": {"type": "int", "example": "0"},
-      "blue": {"type": "int", "example": "0"}
+      "red": {
+        "type": "int",
+        "example": "255"
+      },
+      "green": {
+        "type": "int",
+        "example": "0"
+      },
+      "blue": {
+        "type": "int",
+        "example": "0"
+      }
     }
   },
   "videoEditorColorPickerSwatchSemanticLabel": "{picker}, {color}",
   "@videoEditorColorPickerSwatchSemanticLabel": {
     "description": "Joins the custom color swatch's picker role and its color description into one accessibility label. Translate the separator, not the placeholders: locales that do not list with a Latin comma should use their own (for example '、' or '، '), matching rgbColorSemanticLabel.",
     "placeholders": {
-      "picker": {"type": "String", "example": "Color picker"},
-      "color": {"type": "String", "example": "RGB 100, 20, 20"}
+      "picker": {
+        "type": "String",
+        "example": "Color picker"
+      },
+      "color": {
+        "type": "String",
+        "example": "RGB 100, 20, 20"
+      }
     }
   },
   "verifyTitle": "Verified accounts",
@@ -6801,22 +7488,34 @@
   "@verifyUnlinkSemanticLabel": {
     "description": "Screen reader label for the button that removes a linked account.",
     "placeholders": {
-      "platform": {"type": "String", "example": "GitHub"},
-      "identity": {"type": "String", "example": "octocat"}
+      "platform": {
+        "type": "String",
+        "example": "GitHub"
+      },
+      "identity": {
+        "type": "String",
+        "example": "octocat"
+      }
     }
   },
   "verifyUnlinkConfirmTitle": "Unlink {platform}?",
   "@verifyUnlinkConfirmTitle": {
     "description": "Title of the sheet confirming an account unlink. {platform} is the platform's display name.",
     "placeholders": {
-      "platform": {"type": "String", "example": "GitHub"}
+      "platform": {
+        "type": "String",
+        "example": "GitHub"
+      }
     }
   },
   "verifyUnlinkConfirmSubtitle": "{identity} stops showing on your profile. You can link it again later, but you will have to sign in or post a new proof.",
   "@verifyUnlinkConfirmSubtitle": {
     "description": "Body of the sheet confirming an account unlink. {identity} is the handle being unlinked.",
     "placeholders": {
-      "identity": {"type": "String", "example": "octocat"}
+      "identity": {
+        "type": "String",
+        "example": "octocat"
+      }
     }
   },
   "verifyUnlinkConfirmCta": "Unlink",
@@ -6827,7 +7526,10 @@
   "@verifyLinkSemanticLabel": {
     "description": "Screen reader label for a row that opens the flow for linking one platform.",
     "placeholders": {
-      "platform": {"type": "String", "example": "GitHub"}
+      "platform": {
+        "type": "String",
+        "example": "GitHub"
+      }
     }
   },
   "verifyOneTapBadge": "One tap",
@@ -6838,14 +7540,20 @@
   "@verifyConnectOauthExplainer": {
     "description": "Explains the sign-in route for linking a platform. Reassures that nothing is posted to the account.",
     "placeholders": {
-      "platform": {"type": "String", "example": "Twitter / X"}
+      "platform": {
+        "type": "String",
+        "example": "Twitter / X"
+      }
     }
   },
   "verifyConnectOauthCta": "Continue with {platform}",
   "@verifyConnectOauthCta": {
     "description": "Button that opens the platform's sign-in page to link the account.",
     "placeholders": {
-      "platform": {"type": "String", "example": "Twitter / X"}
+      "platform": {
+        "type": "String",
+        "example": "Twitter / X"
+      }
     }
   },
   "verifyConnectProofTitle": "Or post a proof",
@@ -6940,7 +7648,10 @@
   "@verifyLinkedConfirmation": {
     "description": "Confirmation shown on the verify screen right after an account was linked and published. {platform} is the platform's display name.",
     "placeholders": {
-      "platform": {"type": "String", "example": "GitHub"}
+      "platform": {
+        "type": "String",
+        "example": "GitHub"
+      }
     }
   },
   "verifyErrorTelegramNotPublic": "That's a private channel or an invite. Give the channel a public link, then paste the message link.",
@@ -7169,18 +7880,18 @@
   },
   "changeEmailSentExpiry": "The links stop working after 24 hours.",
   "changeEmailSentDone": "Got it",
-    "searchUserVideoCount": "{count, plural, =1{{formattedCount} video} other{{formattedCount} videos}}",
-    "@searchUserVideoCount": {
-        "description": "Secondary line on a people-search result row: how many videos this user has published.",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            },
-            "formattedCount": {
-                "type": "String"
-            }
-        }
-    },
+  "searchUserVideoCount": "{count, plural, =1{{formattedCount} video} other{{formattedCount} videos}}",
+  "@searchUserVideoCount": {
+    "description": "Secondary line on a people-search result row: how many videos this user has published.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "formattedCount": {
+        "type": "String"
+      }
+    }
+  },
   "socialProofMutual": "Mutual",
   "@socialProofMutual": {
     "description": "Secondary line on a user row: the viewer and this account follow each other. Shown in place of a truncated npub, which cannot tell two same-named people apart."
@@ -7214,49 +7925,134 @@
     "description": "Shown on the video feed when the device has no network, or when even the status page (on a different CDN) is unreachable."
   },
   "dbFailureTitle": "couldn't unlock your local database",
-  "@dbFailureTitle": {"description": "Title of the fail-closed startup screen shown when the encrypted local database cannot be opened."},
+  "@dbFailureTitle": {
+    "description": "Title of the fail-closed startup screen shown when the encrypted local database cannot be opened."
+  },
   "dbFailureAdviceResettable": "A restart won't fix this one. Resetting the local database below gives Divine a clean start — your account stays.",
-  "@dbFailureAdviceResettable": {"description": "Advice on the database-failure screen when a reset is offered, because the database is provably unusable."},
+  "@dbFailureAdviceResettable": {
+    "description": "Advice on the database-failure screen when a reset is offered, because the database is provably unusable."
+  },
   "dbFailureAdviceRestart": "Restart Divine after unlocking your device. If this keeps happening, update the app or contact support.",
-  "@dbFailureAdviceRestart": {"description": "Advice on the database-failure screen when no reset is offered, because the database is intact and only its keystore was unreachable."},
+  "@dbFailureAdviceRestart": {
+    "description": "Advice on the database-failure screen when no reset is offered, because the database is intact and only its keystore was unreachable."
+  },
   "dbFailureDiagnostic": "Diagnostic: {code}",
-  "@dbFailureDiagnostic": {"description": "Short diagnostic code rendered on the database-failure screen so a support report can name the cause without a stack trace.", "placeholders": {"code": {"type": "String"}}},
+  "@dbFailureDiagnostic": {
+    "description": "Short diagnostic code rendered on the database-failure screen so a support report can name the cause without a stack trace.",
+    "placeholders": {
+      "code": {
+        "type": "String"
+      }
+    }
+  },
   "dbFailureCloseApp": "close Divine",
-  "@dbFailureCloseApp": {"description": "Button that quits the app from the database-failure screen."},
+  "@dbFailureCloseApp": {
+    "description": "Button that quits the app from the database-failure screen."
+  },
   "dbFailureResetAction": "reset local database",
-  "@dbFailureResetAction": {"description": "Button that opens the confirmation step for the destructive local-database reset."},
+  "@dbFailureResetAction": {
+    "description": "Button that opens the confirmation step for the destructive local-database reset."
+  },
   "dbFailureConfirmTitle": "reset your local database?",
-  "@dbFailureConfirmTitle": {"description": "Title of the confirmation step before the local database is reset."},
+  "@dbFailureConfirmTitle": {
+    "description": "Title of the confirmation step before the local database is reset."
+  },
   "dbFailureConfirmBody": "Your account stays. Drafts and clips saved on this device are deleted — messages and feeds come back from the network.",
-  "@dbFailureConfirmBody": {"description": "Body of the confirmation step explaining what a local-database reset deletes and what survives."},
+  "@dbFailureConfirmBody": {
+    "description": "Body of the confirmation step explaining what a local-database reset deletes and what survives."
+  },
   "dbFailureResetConfirm": "reset and close",
-  "@dbFailureResetConfirm": {"description": "Button that performs the local-database reset and then closes the app."},
+  "@dbFailureResetConfirm": {
+    "description": "Button that performs the local-database reset and then closes the app."
+  },
   "dbFailureCancel": "cancel",
-  "@dbFailureCancel": {"description": "Button that returns from the reset confirmation to the failure screen."},
+  "@dbFailureCancel": {
+    "description": "Button that returns from the reset confirmation to the failure screen."
+  },
   "dbFailureResetFailed": "That didn't work. Close Divine and try again.",
-  "@dbFailureResetFailed": {"description": "Message shown when the local-database reset itself failed or timed out."},
+  "@dbFailureResetFailed": {
+    "description": "Message shown when the local-database reset itself failed or timed out."
+  },
   "dbFailureResetDoneTitle": "local database reset",
-  "@dbFailureResetDoneTitle": {"description": "Title of the terminal step after a successful local-database reset."},
+  "@dbFailureResetDoneTitle": {
+    "description": "Title of the terminal step after a successful local-database reset."
+  },
   "dbFailureResetDoneBody": "Close Divine and open it again — the next launch builds a fresh local database.",
-  "@dbFailureResetDoneBody": {"description": "Body of the terminal step after a successful reset, telling the user to relaunch."},
+  "@dbFailureResetDoneBody": {
+    "description": "Body of the terminal step after a successful reset, telling the user to relaunch."
+  },
   "authSignInOptionsInfo": "About sign-in options",
-  "@authSignInOptionsInfo": {"description": "Screen-reader label for the info button on the sign-in options screen, which opens a sheet explaining each sign-in method."},
+  "@authSignInOptionsInfo": {
+    "description": "Screen-reader label for the info button on the sign-in options screen, which opens a sheet explaining each sign-in method."
+  },
   "authShowPassword": "Show password",
-  "@authShowPassword": {"description": "Screen-reader label for the control that reveals the typed password."},
+  "@authShowPassword": {
+    "description": "Screen-reader label for the control that reveals the typed password."
+  },
   "authHidePassword": "Hide password",
-  "@authHidePassword": {"description": "Screen-reader label for the control that re-masks the typed password."},
+  "@authHidePassword": {
+    "description": "Screen-reader label for the control that re-masks the typed password."
+  },
   "followUserSemanticLabel": "Follow user",
-  "@followUserSemanticLabel": {"description": "Screen-reader label for the follow button on a user row."},
+  "@followUserSemanticLabel": {
+    "description": "Screen-reader label for the follow button on a user row."
+  },
   "unfollowUserSemanticLabel": "Unfollow user",
-  "@unfollowUserSemanticLabel": {"description": "Screen-reader label for the unfollow button on a user row."},
+  "@unfollowUserSemanticLabel": {
+    "description": "Screen-reader label for the unfollow button on a user row."
+  },
   "commentsLoadingSemanticLabel": "Loading comments",
-  "@commentsLoadingSemanticLabel": {"description": "Screen-reader label announced while the comment list is still loading."},
+  "@commentsLoadingSemanticLabel": {
+    "description": "Screen-reader label announced while the comment list is still loading."
+  },
   "analyticsWindowAll": "All",
-  "@analyticsWindowAll": {"description": "Creator-analytics time window covering all time, shown next to 7D / 28D / 90D."},
+  "@analyticsWindowAll": {
+    "description": "Creator-analytics time window covering all time, shown next to 7D / 28D / 90D."
+  },
   "followUserIndexedSemanticLabel": "Follow user {index}",
-  "@followUserIndexedSemanticLabel": {"description": "Screen-reader label for the follow button on a user row inside a list, carrying the row position so end-to-end flows can target a specific row.", "placeholders": {"index": {"type": "String"}}},
+  "@followUserIndexedSemanticLabel": {
+    "description": "Screen-reader label for the follow button on a user row inside a list, carrying the row position so end-to-end flows can target a specific row.",
+    "placeholders": {
+      "index": {
+        "type": "String"
+      }
+    }
+  },
   "unfollowUserIndexedSemanticLabel": "Unfollow user {index}",
-  "@unfollowUserIndexedSemanticLabel": {"description": "Screen-reader label for the unfollow button on a user row inside a list, carrying the row position so end-to-end flows can target a specific row.", "placeholders": {"index": {"type": "String"}}},
+  "@unfollowUserIndexedSemanticLabel": {
+    "description": "Screen-reader label for the unfollow button on a user row inside a list, carrying the row position so end-to-end flows can target a specific row.",
+    "placeholders": {
+      "index": {
+        "type": "String"
+      }
+    }
+  },
   "supporterTierMonthlyLabel": "{title} — {price} / month",
-  "@supporterTierMonthlyLabel": {"description": "Label on a supporter subscription button: the tier name, its price, and the monthly billing period.", "placeholders": {"title": {"type": "String"}, "price": {"type": "String"}}}
+  "@supporterTierMonthlyLabel": {
+    "description": "Label on a supporter subscription button: the tier name, its price, and the monthly billing period.",
+    "placeholders": {
+      "title": {
+        "type": "String"
+      },
+      "price": {
+        "type": "String"
+      }
+    }
+  },
+  "videoDetailHiddenBySettingsTitle": "Hidden by your settings",
+  "videoDetailHiddenByHostFilterBody": "This one's hosted on {host}, and you're set to only show Divine-hosted videos.",
+  "@videoDetailHiddenByHostFilterBody": {
+    "description": "Shown when a video is hidden because its media host is not a Divine host and the 'only show Divine-hosted videos' safety setting is on.",
+    "placeholders": {
+      "host": {
+        "type": "String"
+      }
+    }
+  },
+  "videoDetailHiddenByContentFilterBody": "Your content filters are hiding this one.",
+  "videoDetailHiddenByProvenanceFilterBody": "This one has no capture chain back to a camera, and you're set to only show camera-verified videos.",
+  "videoDetailHiddenShowAnyway": "Show it anyway",
+  "videoDetailHiddenOpenSettings": "Change setting",
+  "safetySettingsShowVerifiedOnly": "Only show camera-verified videos",
+  "safetySettingsShowVerifiedOnlySubtitle": "Hide videos without a capture chain back to a camera. Vine archive videos are always shown."
 }

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -19425,6 +19425,54 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'{title} — {price} / month'**
   String supporterTierMonthlyLabel(String title, String price);
+
+  /// No description provided for @videoDetailHiddenBySettingsTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Hidden by your settings'**
+  String get videoDetailHiddenBySettingsTitle;
+
+  /// Shown when a video is hidden because its media host is not a Divine host and the 'only show Divine-hosted videos' safety setting is on.
+  ///
+  /// In en, this message translates to:
+  /// **'This one\'s hosted on {host}, and you\'re set to only show Divine-hosted videos.'**
+  String videoDetailHiddenByHostFilterBody(String host);
+
+  /// No description provided for @videoDetailHiddenByContentFilterBody.
+  ///
+  /// In en, this message translates to:
+  /// **'Your content filters are hiding this one.'**
+  String get videoDetailHiddenByContentFilterBody;
+
+  /// No description provided for @videoDetailHiddenByProvenanceFilterBody.
+  ///
+  /// In en, this message translates to:
+  /// **'This one has no capture chain back to a camera, and you\'re set to only show camera-verified videos.'**
+  String get videoDetailHiddenByProvenanceFilterBody;
+
+  /// No description provided for @videoDetailHiddenShowAnyway.
+  ///
+  /// In en, this message translates to:
+  /// **'Show it anyway'**
+  String get videoDetailHiddenShowAnyway;
+
+  /// No description provided for @videoDetailHiddenOpenSettings.
+  ///
+  /// In en, this message translates to:
+  /// **'Change setting'**
+  String get videoDetailHiddenOpenSettings;
+
+  /// No description provided for @safetySettingsShowVerifiedOnly.
+  ///
+  /// In en, this message translates to:
+  /// **'Only show camera-verified videos'**
+  String get safetySettingsShowVerifiedOnly;
+
+  /// No description provided for @safetySettingsShowVerifiedOnlySubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Hide videos without a capture chain back to a camera. Vine archive videos are always shown.'**
+  String get safetySettingsShowVerifiedOnlySubtitle;
 }
 
 class _AppLocalizationsDelegate

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -11186,4 +11186,34 @@ class AppLocalizationsAm extends AppLocalizations {
   String supporterTierMonthlyLabel(String title, String price) {
     return '$title — $price / በወር';
   }
+
+  @override
+  String get videoDetailHiddenBySettingsTitle => 'Hidden by your settings';
+
+  @override
+  String videoDetailHiddenByHostFilterBody(String host) {
+    return 'This one\'s hosted on $host, and you\'re set to only show Divine-hosted videos.';
+  }
+
+  @override
+  String get videoDetailHiddenByContentFilterBody =>
+      'Your content filters are hiding this one.';
+
+  @override
+  String get videoDetailHiddenByProvenanceFilterBody =>
+      'This one has no capture chain back to a camera, and you\'re set to only show camera-verified videos.';
+
+  @override
+  String get videoDetailHiddenShowAnyway => 'Show it anyway';
+
+  @override
+  String get videoDetailHiddenOpenSettings => 'Change setting';
+
+  @override
+  String get safetySettingsShowVerifiedOnly =>
+      'Only show camera-verified videos';
+
+  @override
+  String get safetySettingsShowVerifiedOnlySubtitle =>
+      'Hide videos without a capture chain back to a camera. Vine archive videos are always shown.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -11398,4 +11398,34 @@ class AppLocalizationsAr extends AppLocalizations {
   String supporterTierMonthlyLabel(String title, String price) {
     return '$title — $price / شهريًا';
   }
+
+  @override
+  String get videoDetailHiddenBySettingsTitle => 'Hidden by your settings';
+
+  @override
+  String videoDetailHiddenByHostFilterBody(String host) {
+    return 'This one\'s hosted on $host, and you\'re set to only show Divine-hosted videos.';
+  }
+
+  @override
+  String get videoDetailHiddenByContentFilterBody =>
+      'Your content filters are hiding this one.';
+
+  @override
+  String get videoDetailHiddenByProvenanceFilterBody =>
+      'This one has no capture chain back to a camera, and you\'re set to only show camera-verified videos.';
+
+  @override
+  String get videoDetailHiddenShowAnyway => 'Show it anyway';
+
+  @override
+  String get videoDetailHiddenOpenSettings => 'Change setting';
+
+  @override
+  String get safetySettingsShowVerifiedOnly =>
+      'Only show camera-verified videos';
+
+  @override
+  String get safetySettingsShowVerifiedOnlySubtitle =>
+      'Hide videos without a capture chain back to a camera. Vine archive videos are always shown.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -11603,4 +11603,34 @@ class AppLocalizationsBg extends AppLocalizations {
   String supporterTierMonthlyLabel(String title, String price) {
     return '$title — $price / месец';
   }
+
+  @override
+  String get videoDetailHiddenBySettingsTitle => 'Hidden by your settings';
+
+  @override
+  String videoDetailHiddenByHostFilterBody(String host) {
+    return 'This one\'s hosted on $host, and you\'re set to only show Divine-hosted videos.';
+  }
+
+  @override
+  String get videoDetailHiddenByContentFilterBody =>
+      'Your content filters are hiding this one.';
+
+  @override
+  String get videoDetailHiddenByProvenanceFilterBody =>
+      'This one has no capture chain back to a camera, and you\'re set to only show camera-verified videos.';
+
+  @override
+  String get videoDetailHiddenShowAnyway => 'Show it anyway';
+
+  @override
+  String get videoDetailHiddenOpenSettings => 'Change setting';
+
+  @override
+  String get safetySettingsShowVerifiedOnly =>
+      'Only show camera-verified videos';
+
+  @override
+  String get safetySettingsShowVerifiedOnlySubtitle =>
+      'Hide videos without a capture chain back to a camera. Vine archive videos are always shown.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -11628,4 +11628,34 @@ class AppLocalizationsDe extends AppLocalizations {
   String supporterTierMonthlyLabel(String title, String price) {
     return '$title — $price / Monat';
   }
+
+  @override
+  String get videoDetailHiddenBySettingsTitle => 'Hidden by your settings';
+
+  @override
+  String videoDetailHiddenByHostFilterBody(String host) {
+    return 'This one\'s hosted on $host, and you\'re set to only show Divine-hosted videos.';
+  }
+
+  @override
+  String get videoDetailHiddenByContentFilterBody =>
+      'Your content filters are hiding this one.';
+
+  @override
+  String get videoDetailHiddenByProvenanceFilterBody =>
+      'This one has no capture chain back to a camera, and you\'re set to only show camera-verified videos.';
+
+  @override
+  String get videoDetailHiddenShowAnyway => 'Show it anyway';
+
+  @override
+  String get videoDetailHiddenOpenSettings => 'Change setting';
+
+  @override
+  String get safetySettingsShowVerifiedOnly =>
+      'Only show camera-verified videos';
+
+  @override
+  String get safetySettingsShowVerifiedOnlySubtitle =>
+      'Hide videos without a capture chain back to a camera. Vine archive videos are always shown.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -11589,4 +11589,34 @@ class AppLocalizationsEn extends AppLocalizations {
   String supporterTierMonthlyLabel(String title, String price) {
     return '$title — $price / month';
   }
+
+  @override
+  String get videoDetailHiddenBySettingsTitle => 'Hidden by your settings';
+
+  @override
+  String videoDetailHiddenByHostFilterBody(String host) {
+    return 'This one\'s hosted on $host, and you\'re set to only show Divine-hosted videos.';
+  }
+
+  @override
+  String get videoDetailHiddenByContentFilterBody =>
+      'Your content filters are hiding this one.';
+
+  @override
+  String get videoDetailHiddenByProvenanceFilterBody =>
+      'This one has no capture chain back to a camera, and you\'re set to only show camera-verified videos.';
+
+  @override
+  String get videoDetailHiddenShowAnyway => 'Show it anyway';
+
+  @override
+  String get videoDetailHiddenOpenSettings => 'Change setting';
+
+  @override
+  String get safetySettingsShowVerifiedOnly =>
+      'Only show camera-verified videos';
+
+  @override
+  String get safetySettingsShowVerifiedOnlySubtitle =>
+      'Hide videos without a capture chain back to a camera. Vine archive videos are always shown.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -11610,4 +11610,34 @@ class AppLocalizationsEs extends AppLocalizations {
   String supporterTierMonthlyLabel(String title, String price) {
     return '$title — $price / mes';
   }
+
+  @override
+  String get videoDetailHiddenBySettingsTitle => 'Hidden by your settings';
+
+  @override
+  String videoDetailHiddenByHostFilterBody(String host) {
+    return 'This one\'s hosted on $host, and you\'re set to only show Divine-hosted videos.';
+  }
+
+  @override
+  String get videoDetailHiddenByContentFilterBody =>
+      'Your content filters are hiding this one.';
+
+  @override
+  String get videoDetailHiddenByProvenanceFilterBody =>
+      'This one has no capture chain back to a camera, and you\'re set to only show camera-verified videos.';
+
+  @override
+  String get videoDetailHiddenShowAnyway => 'Show it anyway';
+
+  @override
+  String get videoDetailHiddenOpenSettings => 'Change setting';
+
+  @override
+  String get safetySettingsShowVerifiedOnly =>
+      'Only show camera-verified videos';
+
+  @override
+  String get safetySettingsShowVerifiedOnlySubtitle =>
+      'Hide videos without a capture chain back to a camera. Vine archive videos are always shown.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -11594,4 +11594,34 @@ class AppLocalizationsFil extends AppLocalizations {
   String supporterTierMonthlyLabel(String title, String price) {
     return '$title — $price / buwan';
   }
+
+  @override
+  String get videoDetailHiddenBySettingsTitle => 'Hidden by your settings';
+
+  @override
+  String videoDetailHiddenByHostFilterBody(String host) {
+    return 'This one\'s hosted on $host, and you\'re set to only show Divine-hosted videos.';
+  }
+
+  @override
+  String get videoDetailHiddenByContentFilterBody =>
+      'Your content filters are hiding this one.';
+
+  @override
+  String get videoDetailHiddenByProvenanceFilterBody =>
+      'This one has no capture chain back to a camera, and you\'re set to only show camera-verified videos.';
+
+  @override
+  String get videoDetailHiddenShowAnyway => 'Show it anyway';
+
+  @override
+  String get videoDetailHiddenOpenSettings => 'Change setting';
+
+  @override
+  String get safetySettingsShowVerifiedOnly =>
+      'Only show camera-verified videos';
+
+  @override
+  String get safetySettingsShowVerifiedOnlySubtitle =>
+      'Hide videos without a capture chain back to a camera. Vine archive videos are always shown.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -11658,4 +11658,34 @@ class AppLocalizationsFr extends AppLocalizations {
   String supporterTierMonthlyLabel(String title, String price) {
     return '$title — $price / mois';
   }
+
+  @override
+  String get videoDetailHiddenBySettingsTitle => 'Hidden by your settings';
+
+  @override
+  String videoDetailHiddenByHostFilterBody(String host) {
+    return 'This one\'s hosted on $host, and you\'re set to only show Divine-hosted videos.';
+  }
+
+  @override
+  String get videoDetailHiddenByContentFilterBody =>
+      'Your content filters are hiding this one.';
+
+  @override
+  String get videoDetailHiddenByProvenanceFilterBody =>
+      'This one has no capture chain back to a camera, and you\'re set to only show camera-verified videos.';
+
+  @override
+  String get videoDetailHiddenShowAnyway => 'Show it anyway';
+
+  @override
+  String get videoDetailHiddenOpenSettings => 'Change setting';
+
+  @override
+  String get safetySettingsShowVerifiedOnly =>
+      'Only show camera-verified videos';
+
+  @override
+  String get safetySettingsShowVerifiedOnlySubtitle =>
+      'Hide videos without a capture chain back to a camera. Vine archive videos are always shown.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -11401,4 +11401,34 @@ class AppLocalizationsId extends AppLocalizations {
   String supporterTierMonthlyLabel(String title, String price) {
     return '$title — $price / bulan';
   }
+
+  @override
+  String get videoDetailHiddenBySettingsTitle => 'Hidden by your settings';
+
+  @override
+  String videoDetailHiddenByHostFilterBody(String host) {
+    return 'This one\'s hosted on $host, and you\'re set to only show Divine-hosted videos.';
+  }
+
+  @override
+  String get videoDetailHiddenByContentFilterBody =>
+      'Your content filters are hiding this one.';
+
+  @override
+  String get videoDetailHiddenByProvenanceFilterBody =>
+      'This one has no capture chain back to a camera, and you\'re set to only show camera-verified videos.';
+
+  @override
+  String get videoDetailHiddenShowAnyway => 'Show it anyway';
+
+  @override
+  String get videoDetailHiddenOpenSettings => 'Change setting';
+
+  @override
+  String get safetySettingsShowVerifiedOnly =>
+      'Only show camera-verified videos';
+
+  @override
+  String get safetySettingsShowVerifiedOnlySubtitle =>
+      'Hide videos without a capture chain back to a camera. Vine archive videos are always shown.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -11622,4 +11622,34 @@ class AppLocalizationsIt extends AppLocalizations {
   String supporterTierMonthlyLabel(String title, String price) {
     return '$title — $price / mese';
   }
+
+  @override
+  String get videoDetailHiddenBySettingsTitle => 'Hidden by your settings';
+
+  @override
+  String videoDetailHiddenByHostFilterBody(String host) {
+    return 'This one\'s hosted on $host, and you\'re set to only show Divine-hosted videos.';
+  }
+
+  @override
+  String get videoDetailHiddenByContentFilterBody =>
+      'Your content filters are hiding this one.';
+
+  @override
+  String get videoDetailHiddenByProvenanceFilterBody =>
+      'This one has no capture chain back to a camera, and you\'re set to only show camera-verified videos.';
+
+  @override
+  String get videoDetailHiddenShowAnyway => 'Show it anyway';
+
+  @override
+  String get videoDetailHiddenOpenSettings => 'Change setting';
+
+  @override
+  String get safetySettingsShowVerifiedOnly =>
+      'Only show camera-verified videos';
+
+  @override
+  String get safetySettingsShowVerifiedOnlySubtitle =>
+      'Hide videos without a capture chain back to a camera. Vine archive videos are always shown.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -10911,4 +10911,34 @@ class AppLocalizationsJa extends AppLocalizations {
   String supporterTierMonthlyLabel(String title, String price) {
     return '$title — $price / 月';
   }
+
+  @override
+  String get videoDetailHiddenBySettingsTitle => 'Hidden by your settings';
+
+  @override
+  String videoDetailHiddenByHostFilterBody(String host) {
+    return 'This one\'s hosted on $host, and you\'re set to only show Divine-hosted videos.';
+  }
+
+  @override
+  String get videoDetailHiddenByContentFilterBody =>
+      'Your content filters are hiding this one.';
+
+  @override
+  String get videoDetailHiddenByProvenanceFilterBody =>
+      'This one has no capture chain back to a camera, and you\'re set to only show camera-verified videos.';
+
+  @override
+  String get videoDetailHiddenShowAnyway => 'Show it anyway';
+
+  @override
+  String get videoDetailHiddenOpenSettings => 'Change setting';
+
+  @override
+  String get safetySettingsShowVerifiedOnly =>
+      'Only show camera-verified videos';
+
+  @override
+  String get safetySettingsShowVerifiedOnlySubtitle =>
+      'Hide videos without a capture chain back to a camera. Vine archive videos are always shown.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -10925,4 +10925,34 @@ class AppLocalizationsKo extends AppLocalizations {
   String supporterTierMonthlyLabel(String title, String price) {
     return '$title — $price / 월';
   }
+
+  @override
+  String get videoDetailHiddenBySettingsTitle => 'Hidden by your settings';
+
+  @override
+  String videoDetailHiddenByHostFilterBody(String host) {
+    return 'This one\'s hosted on $host, and you\'re set to only show Divine-hosted videos.';
+  }
+
+  @override
+  String get videoDetailHiddenByContentFilterBody =>
+      'Your content filters are hiding this one.';
+
+  @override
+  String get videoDetailHiddenByProvenanceFilterBody =>
+      'This one has no capture chain back to a camera, and you\'re set to only show camera-verified videos.';
+
+  @override
+  String get videoDetailHiddenShowAnyway => 'Show it anyway';
+
+  @override
+  String get videoDetailHiddenOpenSettings => 'Change setting';
+
+  @override
+  String get safetySettingsShowVerifiedOnly =>
+      'Only show camera-verified videos';
+
+  @override
+  String get safetySettingsShowVerifiedOnlySubtitle =>
+      'Hide videos without a capture chain back to a camera. Vine archive videos are always shown.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -11494,4 +11494,34 @@ class AppLocalizationsMs extends AppLocalizations {
   String supporterTierMonthlyLabel(String title, String price) {
     return '$title — $price / bulan';
   }
+
+  @override
+  String get videoDetailHiddenBySettingsTitle => 'Hidden by your settings';
+
+  @override
+  String videoDetailHiddenByHostFilterBody(String host) {
+    return 'This one\'s hosted on $host, and you\'re set to only show Divine-hosted videos.';
+  }
+
+  @override
+  String get videoDetailHiddenByContentFilterBody =>
+      'Your content filters are hiding this one.';
+
+  @override
+  String get videoDetailHiddenByProvenanceFilterBody =>
+      'This one has no capture chain back to a camera, and you\'re set to only show camera-verified videos.';
+
+  @override
+  String get videoDetailHiddenShowAnyway => 'Show it anyway';
+
+  @override
+  String get videoDetailHiddenOpenSettings => 'Change setting';
+
+  @override
+  String get safetySettingsShowVerifiedOnly =>
+      'Only show camera-verified videos';
+
+  @override
+  String get safetySettingsShowVerifiedOnlySubtitle =>
+      'Hide videos without a capture chain back to a camera. Vine archive videos are always shown.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -11545,4 +11545,34 @@ class AppLocalizationsNl extends AppLocalizations {
   String supporterTierMonthlyLabel(String title, String price) {
     return '$title — $price / maand';
   }
+
+  @override
+  String get videoDetailHiddenBySettingsTitle => 'Hidden by your settings';
+
+  @override
+  String videoDetailHiddenByHostFilterBody(String host) {
+    return 'This one\'s hosted on $host, and you\'re set to only show Divine-hosted videos.';
+  }
+
+  @override
+  String get videoDetailHiddenByContentFilterBody =>
+      'Your content filters are hiding this one.';
+
+  @override
+  String get videoDetailHiddenByProvenanceFilterBody =>
+      'This one has no capture chain back to a camera, and you\'re set to only show camera-verified videos.';
+
+  @override
+  String get videoDetailHiddenShowAnyway => 'Show it anyway';
+
+  @override
+  String get videoDetailHiddenOpenSettings => 'Change setting';
+
+  @override
+  String get safetySettingsShowVerifiedOnly =>
+      'Only show camera-verified videos';
+
+  @override
+  String get safetySettingsShowVerifiedOnlySubtitle =>
+      'Hide videos without a capture chain back to a camera. Vine archive videos are always shown.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -11715,4 +11715,34 @@ class AppLocalizationsPl extends AppLocalizations {
   String supporterTierMonthlyLabel(String title, String price) {
     return '$title — $price / miesiąc';
   }
+
+  @override
+  String get videoDetailHiddenBySettingsTitle => 'Hidden by your settings';
+
+  @override
+  String videoDetailHiddenByHostFilterBody(String host) {
+    return 'This one\'s hosted on $host, and you\'re set to only show Divine-hosted videos.';
+  }
+
+  @override
+  String get videoDetailHiddenByContentFilterBody =>
+      'Your content filters are hiding this one.';
+
+  @override
+  String get videoDetailHiddenByProvenanceFilterBody =>
+      'This one has no capture chain back to a camera, and you\'re set to only show camera-verified videos.';
+
+  @override
+  String get videoDetailHiddenShowAnyway => 'Show it anyway';
+
+  @override
+  String get videoDetailHiddenOpenSettings => 'Change setting';
+
+  @override
+  String get safetySettingsShowVerifiedOnly =>
+      'Only show camera-verified videos';
+
+  @override
+  String get safetySettingsShowVerifiedOnlySubtitle =>
+      'Hide videos without a capture chain back to a camera. Vine archive videos are always shown.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -11573,4 +11573,34 @@ class AppLocalizationsPt extends AppLocalizations {
   String supporterTierMonthlyLabel(String title, String price) {
     return '$title — $price / mês';
   }
+
+  @override
+  String get videoDetailHiddenBySettingsTitle => 'Hidden by your settings';
+
+  @override
+  String videoDetailHiddenByHostFilterBody(String host) {
+    return 'This one\'s hosted on $host, and you\'re set to only show Divine-hosted videos.';
+  }
+
+  @override
+  String get videoDetailHiddenByContentFilterBody =>
+      'Your content filters are hiding this one.';
+
+  @override
+  String get videoDetailHiddenByProvenanceFilterBody =>
+      'This one has no capture chain back to a camera, and you\'re set to only show camera-verified videos.';
+
+  @override
+  String get videoDetailHiddenShowAnyway => 'Show it anyway';
+
+  @override
+  String get videoDetailHiddenOpenSettings => 'Change setting';
+
+  @override
+  String get safetySettingsShowVerifiedOnly =>
+      'Only show camera-verified videos';
+
+  @override
+  String get safetySettingsShowVerifiedOnlySubtitle =>
+      'Hide videos without a capture chain back to a camera. Vine archive videos are always shown.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -11733,4 +11733,34 @@ class AppLocalizationsRo extends AppLocalizations {
   String supporterTierMonthlyLabel(String title, String price) {
     return '$title — $price / lună';
   }
+
+  @override
+  String get videoDetailHiddenBySettingsTitle => 'Hidden by your settings';
+
+  @override
+  String videoDetailHiddenByHostFilterBody(String host) {
+    return 'This one\'s hosted on $host, and you\'re set to only show Divine-hosted videos.';
+  }
+
+  @override
+  String get videoDetailHiddenByContentFilterBody =>
+      'Your content filters are hiding this one.';
+
+  @override
+  String get videoDetailHiddenByProvenanceFilterBody =>
+      'This one has no capture chain back to a camera, and you\'re set to only show camera-verified videos.';
+
+  @override
+  String get videoDetailHiddenShowAnyway => 'Show it anyway';
+
+  @override
+  String get videoDetailHiddenOpenSettings => 'Change setting';
+
+  @override
+  String get safetySettingsShowVerifiedOnly =>
+      'Only show camera-verified videos';
+
+  @override
+  String get safetySettingsShowVerifiedOnlySubtitle =>
+      'Hide videos without a capture chain back to a camera. Vine archive videos are always shown.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -11486,4 +11486,34 @@ class AppLocalizationsSv extends AppLocalizations {
   String supporterTierMonthlyLabel(String title, String price) {
     return '$title — $price / månad';
   }
+
+  @override
+  String get videoDetailHiddenBySettingsTitle => 'Hidden by your settings';
+
+  @override
+  String videoDetailHiddenByHostFilterBody(String host) {
+    return 'This one\'s hosted on $host, and you\'re set to only show Divine-hosted videos.';
+  }
+
+  @override
+  String get videoDetailHiddenByContentFilterBody =>
+      'Your content filters are hiding this one.';
+
+  @override
+  String get videoDetailHiddenByProvenanceFilterBody =>
+      'This one has no capture chain back to a camera, and you\'re set to only show camera-verified videos.';
+
+  @override
+  String get videoDetailHiddenShowAnyway => 'Show it anyway';
+
+  @override
+  String get videoDetailHiddenOpenSettings => 'Change setting';
+
+  @override
+  String get safetySettingsShowVerifiedOnly =>
+      'Only show camera-verified videos';
+
+  @override
+  String get safetySettingsShowVerifiedOnlySubtitle =>
+      'Hide videos without a capture chain back to a camera. Vine archive videos are always shown.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -11415,4 +11415,34 @@ class AppLocalizationsTr extends AppLocalizations {
   String supporterTierMonthlyLabel(String title, String price) {
     return '$title — $price / ay';
   }
+
+  @override
+  String get videoDetailHiddenBySettingsTitle => 'Hidden by your settings';
+
+  @override
+  String videoDetailHiddenByHostFilterBody(String host) {
+    return 'This one\'s hosted on $host, and you\'re set to only show Divine-hosted videos.';
+  }
+
+  @override
+  String get videoDetailHiddenByContentFilterBody =>
+      'Your content filters are hiding this one.';
+
+  @override
+  String get videoDetailHiddenByProvenanceFilterBody =>
+      'This one has no capture chain back to a camera, and you\'re set to only show camera-verified videos.';
+
+  @override
+  String get videoDetailHiddenShowAnyway => 'Show it anyway';
+
+  @override
+  String get videoDetailHiddenOpenSettings => 'Change setting';
+
+  @override
+  String get safetySettingsShowVerifiedOnly =>
+      'Only show camera-verified videos';
+
+  @override
+  String get safetySettingsShowVerifiedOnlySubtitle =>
+      'Hide videos without a capture chain back to a camera. Vine archive videos are always shown.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -11475,4 +11475,34 @@ class AppLocalizationsUr extends AppLocalizations {
   String supporterTierMonthlyLabel(String title, String price) {
     return '$title — $price / ماہ';
   }
+
+  @override
+  String get videoDetailHiddenBySettingsTitle => 'Hidden by your settings';
+
+  @override
+  String videoDetailHiddenByHostFilterBody(String host) {
+    return 'This one\'s hosted on $host, and you\'re set to only show Divine-hosted videos.';
+  }
+
+  @override
+  String get videoDetailHiddenByContentFilterBody =>
+      'Your content filters are hiding this one.';
+
+  @override
+  String get videoDetailHiddenByProvenanceFilterBody =>
+      'This one has no capture chain back to a camera, and you\'re set to only show camera-verified videos.';
+
+  @override
+  String get videoDetailHiddenShowAnyway => 'Show it anyway';
+
+  @override
+  String get videoDetailHiddenOpenSettings => 'Change setting';
+
+  @override
+  String get safetySettingsShowVerifiedOnly =>
+      'Only show camera-verified videos';
+
+  @override
+  String get safetySettingsShowVerifiedOnlySubtitle =>
+      'Hide videos without a capture chain back to a camera. Vine archive videos are always shown.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -11436,4 +11436,34 @@ class AppLocalizationsVi extends AppLocalizations {
   String supporterTierMonthlyLabel(String title, String price) {
     return '$title — $price / tháng';
   }
+
+  @override
+  String get videoDetailHiddenBySettingsTitle => 'Hidden by your settings';
+
+  @override
+  String videoDetailHiddenByHostFilterBody(String host) {
+    return 'This one\'s hosted on $host, and you\'re set to only show Divine-hosted videos.';
+  }
+
+  @override
+  String get videoDetailHiddenByContentFilterBody =>
+      'Your content filters are hiding this one.';
+
+  @override
+  String get videoDetailHiddenByProvenanceFilterBody =>
+      'This one has no capture chain back to a camera, and you\'re set to only show camera-verified videos.';
+
+  @override
+  String get videoDetailHiddenShowAnyway => 'Show it anyway';
+
+  @override
+  String get videoDetailHiddenOpenSettings => 'Change setting';
+
+  @override
+  String get safetySettingsShowVerifiedOnly =>
+      'Only show camera-verified videos';
+
+  @override
+  String get safetySettingsShowVerifiedOnlySubtitle =>
+      'Hide videos without a capture chain back to a camera. Vine archive videos are always shown.';
 }

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -10804,4 +10804,34 @@ class AppLocalizationsZh extends AppLocalizations {
   String supporterTierMonthlyLabel(String title, String price) {
     return '$title — $price / 月';
   }
+
+  @override
+  String get videoDetailHiddenBySettingsTitle => 'Hidden by your settings';
+
+  @override
+  String videoDetailHiddenByHostFilterBody(String host) {
+    return 'This one\'s hosted on $host, and you\'re set to only show Divine-hosted videos.';
+  }
+
+  @override
+  String get videoDetailHiddenByContentFilterBody =>
+      'Your content filters are hiding this one.';
+
+  @override
+  String get videoDetailHiddenByProvenanceFilterBody =>
+      'This one has no capture chain back to a camera, and you\'re set to only show camera-verified videos.';
+
+  @override
+  String get videoDetailHiddenShowAnyway => 'Show it anyway';
+
+  @override
+  String get videoDetailHiddenOpenSettings => 'Change setting';
+
+  @override
+  String get safetySettingsShowVerifiedOnly =>
+      'Only show camera-verified videos';
+
+  @override
+  String get safetySettingsShowVerifiedOnlySubtitle =>
+      'Hide videos without a capture chain back to a camera. Vine archive videos are always shown.';
 }

--- a/mobile/lib/providers/moderation_providers.dart
+++ b/mobile/lib/providers/moderation_providers.dart
@@ -2,7 +2,6 @@
 // ABOUTME: Policy engine, host/age/content filters, NIP-32 labels, blocklist + sync bridge
 
 import 'dart:async';
-
 import 'package:content_blocklist_repository/content_blocklist_repository.dart';
 import 'package:content_policy/content_policy.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -18,6 +17,7 @@ import 'package:openvine/services/blocklist_content_filter.dart';
 import 'package:openvine/services/content_filter_service.dart';
 import 'package:openvine/services/divine_host_filter_service.dart';
 import 'package:openvine/services/moderation_label_service.dart';
+import 'package:openvine/services/video_provenance_filter_service.dart';
 import 'package:openvine/utils/open_vine_image_cache.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:unified_logger/unified_logger.dart';
@@ -68,6 +68,37 @@ class DivineHostFilterVersion extends Notifier<int> {
   @override
   int build() {
     final service = ref.watch(divineHostFilterServiceProvider);
+    service.addListener(increment);
+    ref.onDispose(() => service.removeListener(increment));
+    return 0;
+  }
+
+  void increment() => state++;
+}
+
+/// Capture-verified-only filter preference service.
+///
+/// Separate axis from [divineHostFilterServiceProvider]: hosting says who
+/// can moderate the media, provenance says whether it traces to a camera.
+final videoProvenanceFilterServiceProvider =
+    Provider<VideoProvenanceFilterService>((ref) {
+      final prefs = ref.watch(sharedPreferencesProvider);
+      final service = VideoProvenanceFilterService(prefs);
+      ref.onDispose(service.dispose);
+      return service;
+    });
+
+/// Rebuild trigger for consumers that need to react to provenance-filter
+/// preference changes.
+final videoProvenanceFilterVersionProvider =
+    NotifierProvider<VideoProvenanceFilterVersion, int>(
+      VideoProvenanceFilterVersion.new,
+    );
+
+class VideoProvenanceFilterVersion extends Notifier<int> {
+  @override
+  int build() {
+    final service = ref.watch(videoProvenanceFilterServiceProvider);
     service.addListener(increment);
     ref.onDispose(() => service.removeListener(increment));
     return 0;

--- a/mobile/lib/providers/video_providers.dart
+++ b/mobile/lib/providers/video_providers.dart
@@ -2,11 +2,9 @@
 // ABOUTME: VideoEventService keystone + filters, publishers, repositories, sharing
 
 import 'dart:async';
-
 import 'package:db_client/db_client.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart' show Provider;
 import 'package:likes_repository/likes_repository.dart';
-import 'package:openvine/extensions/video_event_extensions.dart';
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
 import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
 import 'package:openvine/l10n/current_app_l10n.dart';
@@ -52,6 +50,7 @@ import 'package:openvine/services/video_filter_builder.dart';
 import 'package:openvine/services/video_metadata_update_service.dart';
 import 'package:openvine/services/video_moderation_status_service.dart';
 import 'package:openvine/services/video_sharing_service.dart';
+import 'package:openvine/services/video_source_visibility_policy.dart';
 import 'package:openvine/services/view_event_publisher.dart';
 import 'package:reposts_repository/reposts_repository.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -166,6 +165,9 @@ VideoEventService videoEventService(Ref ref) {
   final likesRepository = ref.watch(likesRepositoryProvider);
   final moderationLabelService = ref.watch(moderationLabelServiceProvider);
   final divineHostFilterService = ref.read(divineHostFilterServiceProvider);
+  final provenanceFilterService = ref.read(
+    videoProvenanceFilterServiceProvider,
+  );
   final feedAspectRatioPreference = ref.watch(
     feedAspectRatioPreferenceServiceProvider,
   );
@@ -210,6 +212,7 @@ VideoEventService videoEventService(Ref ref) {
   service.setContentFilterService(ref.watch(contentFilterServiceProvider));
   service.setModerationLabelService(moderationLabelService);
   service.setDivineHostFilterService(divineHostFilterService);
+  service.setProvenanceFilterService(provenanceFilterService);
   service.setFeedAspectRatioPreferenceService(feedAspectRatioPreference);
 
   // Attach the scoped broken-video tracker so videos confirmed unavailable stay
@@ -553,6 +556,9 @@ VideosRepository videosRepository(Ref ref) {
     }
   }();
   final divineHostFilterService = ref.read(divineHostFilterServiceProvider);
+  final provenanceFilterService = ref.read(
+    videoProvenanceFilterServiceProvider,
+  );
   final feedAspectRatioPreference = ref.watch(
     feedAspectRatioPreferenceServiceProvider,
   );
@@ -571,8 +577,11 @@ VideosRepository videosRepository(Ref ref) {
     removedVideoIds: videoEventService.removedVideoIds,
     contentFilter: (video) =>
         nsfwFilter(video) ||
-        (divineHostFilterService.showDivineHostedOnly &&
-            !video.isFromDivineServer) ||
+        VideoSourceVisibilityPolicy.isHiddenBySourcePreferences(
+          video,
+          divineHostedOnly: divineHostFilterService.showDivineHostedOnly,
+          verifiedOnly: provenanceFilterService.showVerifiedOnly,
+        ) ||
         feedAspectRatioPreference.shouldHideVideo(video),
     warningLabelsResolver: createNsfwWarnLabels(
       contentFilterService,

--- a/mobile/lib/providers/video_providers.g.dart
+++ b/mobile/lib/providers/video_providers.g.dart
@@ -281,7 +281,7 @@ final class VideoEventServiceProvider
   }
 }
 
-String _$videoEventServiceHash() => r'058ce434fa5549b725a62b3199decdb496e18e53';
+String _$videoEventServiceHash() => r'eecb1e8ff236dac3e07259e6930ab9575ab8ff8e';
 
 /// Video event publisher for publishing video events to Nostr relays
 
@@ -953,7 +953,7 @@ final class VideosRepositoryProvider
   }
 }
 
-String _$videosRepositoryHash() => r'44fb1b8a6951fbad33b2b95047ec9e7edbb65c54';
+String _$videosRepositoryHash() => r'e22ed51a43872ddb24da0f5803ebb54cfa0e1397';
 
 /// Provider for LikesRepository instance
 ///

--- a/mobile/lib/screens/safety_settings_screen.dart
+++ b/mobile/lib/screens/safety_settings_screen.dart
@@ -42,6 +42,9 @@ class SafetySettingsScreen extends ConsumerWidget {
     final contentBlocklistRepository = ref.watch(
       contentBlocklistRepositoryProvider,
     );
+    final provenanceFilterService = ref.watch(
+      videoProvenanceFilterServiceProvider,
+    );
     final isAdultContentLocked = ref.watch(isProtectedMinorProvider);
     return BlocProvider(
       // Auth-flippable services are re-keyed so the Cubit reloads with the
@@ -51,6 +54,7 @@ class SafetySettingsScreen extends ConsumerWidget {
         contentFilterService,
         videoEventService,
         divineHostFilterService,
+        provenanceFilterService,
         moderationLabelService,
         followRepository,
         contentBlocklistRepository,
@@ -61,6 +65,7 @@ class SafetySettingsScreen extends ConsumerWidget {
         contentFilterService: contentFilterService,
         videoEventService: videoEventService,
         divineHostFilterService: divineHostFilterService,
+        provenanceFilterService: provenanceFilterService,
         moderationLabelService: moderationLabelService,
         followRepository: followRepository,
         contentBlocklistRepository: contentBlocklistRepository,
@@ -104,6 +109,7 @@ class SafetySettingsView extends StatelessWidget {
                   const _AgeVerificationTile(),
                   const SizedBox(height: 8),
                   const _DivineHostedOnlyTile(),
+                  const _VerifiedOnlyTile(),
                   DivineSectionHeader(context.l10n.safetySettingsModeration),
                   const _DivineProviderTile(),
                   const _PeopleIFollowProviderTile(),
@@ -193,6 +199,25 @@ class _DivineHostedOnlyTile extends StatelessWidget {
       value: showDivineHostedOnly,
       onChanged: (value) =>
           context.read<SafetySettingsCubit>().setShowDivineHostedOnly(value),
+    );
+  }
+}
+
+class _VerifiedOnlyTile extends StatelessWidget {
+  const _VerifiedOnlyTile();
+
+  @override
+  Widget build(BuildContext context) {
+    final showVerifiedOnly = context.select(
+      (SafetySettingsCubit cubit) => cubit.state.showVerifiedOnly,
+    );
+    return DivineSwitchTile(
+      leadingIcon: DivineIconName.sealCheck,
+      title: context.l10n.safetySettingsShowVerifiedOnly,
+      subtitle: context.l10n.safetySettingsShowVerifiedOnlySubtitle,
+      value: showVerifiedOnly,
+      onChanged: (value) =>
+          context.read<SafetySettingsCubit>().setShowVerifiedOnly(value),
     );
   }
 }

--- a/mobile/lib/screens/video_detail_screen.dart
+++ b/mobile/lib/screens/video_detail_screen.dart
@@ -261,6 +261,24 @@ class _VideoDetailScreenState extends ConsumerState<VideoDetailScreen> {
     }
   }
 
+  /// Which source preference is responsible, so the panel names the setting
+  /// the viewer actually has to change rather than guessing.
+  ///
+  /// Both can apply at once; hosting is reported first because it is on by
+  /// default and is therefore the likelier surprise.
+  _HiddenReason _hiddenReason(VideoEvent video) {
+    if (!video.isFromDivineServer &&
+        ref.read(divineHostFilterServiceProvider).showDivineHostedOnly) {
+      return _HiddenReason.divineHostedOnly;
+    }
+    if (!video.hasProofMode &&
+        !video.isOriginalVine &&
+        ref.read(videoProvenanceFilterServiceProvider).showVerifiedOnly) {
+      return _HiddenReason.verifiedOnly;
+    }
+    return _HiddenReason.otherContentFilter;
+  }
+
   /// Renders the filtered video for this screen only.
   ///
   /// The lookup already parsed it, so the override is a state change rather
@@ -331,9 +349,7 @@ class _VideoDetailScreenState extends ConsumerState<VideoDetailScreen> {
         ),
         _VideoDetailError.hiddenBySettings => _HiddenBySettingsScreen(
           video: _hiddenVideo!,
-          isHostFilter:
-              !_hiddenVideo!.isFromDivineServer &&
-              ref.read(divineHostFilterServiceProvider).showDivineHostedOnly,
+          reason: _hiddenReason(_hiddenVideo!),
           onShowAnyway: _showHiddenVideoAnyway,
           onClose: () => _handleExit(context),
         ),
@@ -453,20 +469,22 @@ enum _VideoDetailError { notFound, loadFailed, hiddenBySettings }
 /// Explains that a content filter — not a missing video — is why nothing
 /// played, and offers both ways out: change the setting, or override it for
 /// this one video.
+/// Which source preference hid the video.
+enum _HiddenReason { divineHostedOnly, verifiedOnly, otherContentFilter }
+
 class _HiddenBySettingsScreen extends StatelessWidget {
   const _HiddenBySettingsScreen({
     required this.video,
-    required this.isHostFilter,
+    required this.reason,
     required this.onShowAnyway,
     required this.onClose,
   });
 
   final VideoEvent video;
 
-  /// Whether the "only show Divine-hosted videos" setting is responsible, as
-  /// opposed to some other content filter. Drives which explanation is shown
-  /// so the copy never names a setting that is not the cause.
-  final bool isHostFilter;
+  /// Drives which explanation is shown, so the copy never names a setting
+  /// that is not the cause.
+  final _HiddenReason reason;
 
   final VoidCallback onShowAnyway;
   final VoidCallback onClose;
@@ -482,9 +500,14 @@ class _HiddenBySettingsScreen extends StatelessWidget {
     return TvStaticMessageScreen(
       sticker: .alert,
       title: context.l10n.videoDetailHiddenBySettingsTitle,
-      description: isHostFilter
-          ? context.l10n.videoDetailHiddenByHostFilterBody(_host())
-          : context.l10n.videoDetailHiddenByContentFilterBody,
+      description: switch (reason) {
+        _HiddenReason.divineHostedOnly =>
+          context.l10n.videoDetailHiddenByHostFilterBody(_host()),
+        _HiddenReason.verifiedOnly =>
+          context.l10n.videoDetailHiddenByProvenanceFilterBody,
+        _HiddenReason.otherContentFilter =>
+          context.l10n.videoDetailHiddenByContentFilterBody,
+      },
       actionLabel: context.l10n.videoDetailHiddenShowAnyway,
       onAction: onShowAnyway,
       onClose: onClose,

--- a/mobile/lib/screens/video_detail_screen.dart
+++ b/mobile/lib/screens/video_detail_screen.dart
@@ -2,16 +2,17 @@
 // ABOUTME: Fetches video from Nostr and displays it in full-screen player
 
 import 'dart:async';
-
 import 'package:divine_ui/divine_ui.dart';
 import 'package:feed_repository/feed_repository.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:models/models.dart' hide LogCategory;
 import 'package:nostr_client/nostr_client.dart' show NostrClient;
 import 'package:openvine/constants/semantic_ids.dart';
 import 'package:openvine/extensions/safe_pop_extension.dart';
+import 'package:openvine/extensions/video_event_extensions.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/models/view_traffic_source.dart';
 import 'package:openvine/providers/analytics_providers.dart';
@@ -20,10 +21,12 @@ import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/router/route_paths.dart';
 import 'package:openvine/screens/feed/dm_reply_context.dart';
 import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
+import 'package:openvine/screens/safety_settings_screen.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/takeover_close_button.dart';
 import 'package:openvine/widgets/tv_static_message_screen.dart';
 import 'package:unified_logger/unified_logger.dart';
+import 'package:videos_repository/videos_repository.dart';
 
 class VideoDetailRouteExtra {
   const VideoDetailRouteExtra({
@@ -86,6 +89,10 @@ class _VideoDetailScreenState extends ConsumerState<VideoDetailScreen> {
   VideoEvent? _video;
   bool _isLoading = true;
   _VideoDetailError? _error;
+
+  /// The video a content filter removed, kept so the viewer can override
+  /// the filter for this one video without another round trip (#7892).
+  VideoEvent? _hiddenVideo;
   StreamSubscription? _relayReadySubscription;
   bool _retryScheduled = false;
   bool _hasRetriedAfterRelayReady = false;
@@ -153,12 +160,31 @@ class _VideoDetailScreenState extends ConsumerState<VideoDetailScreen> {
       // fetchVideoWithStats handles cache→relay lookup and bulk-stats
       // hydration in one call, matching what feed providers do.
       final videosRepository = ref.read(videosRepositoryProvider);
-      final video = widget.fallbackVideoIds.isEmpty
-          ? await videosRepository.fetchVideoWithStatsForRouteId(widget.videoId)
-          : await videosRepository.fetchVideoWithStatsForRouteId(
-              widget.videoId,
-              fallbackRouteIds: widget.fallbackVideoIds,
-            );
+      final lookup = await videosRepository.lookupVideoForRouteId(
+        widget.videoId,
+        fallbackRouteIds: widget.fallbackVideoIds,
+      );
+
+      // A filtered video is not a missing one: it resolved and plays, and
+      // reporting it as "not found" leaves the viewer with no way to act
+      // on a setting they may never have chosen (#7892).
+      if (lookup case VideoRouteHiddenByFilter(:final video)) {
+        Log.info(
+          'Video hidden by content filters: ${widget.videoId}',
+          name: 'VideoDetailScreen',
+          category: LogCategory.video,
+        );
+        if (mounted) {
+          setState(() {
+            _hiddenVideo = video;
+            _error = _VideoDetailError.hiddenBySettings;
+            _isLoading = false;
+          });
+        }
+        return;
+      }
+
+      final video = lookup is VideoRouteFound ? lookup.video : null;
 
       if (video != null) {
         Log.info(
@@ -235,6 +261,21 @@ class _VideoDetailScreenState extends ConsumerState<VideoDetailScreen> {
     }
   }
 
+  /// Renders the filtered video for this screen only.
+  ///
+  /// The lookup already parsed it, so the override is a state change rather
+  /// than a refetch, and it deliberately does not touch the stored setting —
+  /// overriding one video is not the same as turning the filter off.
+  void _showHiddenVideoAnyway() {
+    final video = _hiddenVideo;
+    if (video == null) return;
+    setState(() {
+      _video = video;
+      _error = null;
+      _isLoading = false;
+    });
+  }
+
   bool _scheduleRelayReadyRetry(NostrClient nostrClient) {
     if (_retryScheduled || _hasRetriedAfterRelayReady) {
       return false;
@@ -286,6 +327,14 @@ class _VideoDetailScreenState extends ConsumerState<VideoDetailScreen> {
     if (_error case final error?) {
       return switch (error) {
         _VideoDetailError.notFound => _NotFoundScreen(
+          onClose: () => _handleExit(context),
+        ),
+        _VideoDetailError.hiddenBySettings => _HiddenBySettingsScreen(
+          video: _hiddenVideo!,
+          isHostFilter:
+              !_hiddenVideo!.isFromDivineServer &&
+              ref.read(divineHostFilterServiceProvider).showDivineHostedOnly,
+          onShowAnyway: _showHiddenVideoAnyway,
           onClose: () => _handleExit(context),
         ),
         _VideoDetailError.loadFailed => TvStaticMessageScreen(
@@ -399,4 +448,52 @@ class _NotFoundScreen extends StatelessWidget {
   }
 }
 
-enum _VideoDetailError { notFound, loadFailed }
+enum _VideoDetailError { notFound, loadFailed, hiddenBySettings }
+
+/// Explains that a content filter — not a missing video — is why nothing
+/// played, and offers both ways out: change the setting, or override it for
+/// this one video.
+class _HiddenBySettingsScreen extends StatelessWidget {
+  const _HiddenBySettingsScreen({
+    required this.video,
+    required this.isHostFilter,
+    required this.onShowAnyway,
+    required this.onClose,
+  });
+
+  final VideoEvent video;
+
+  /// Whether the "only show Divine-hosted videos" setting is responsible, as
+  /// opposed to some other content filter. Drives which explanation is shown
+  /// so the copy never names a setting that is not the cause.
+  final bool isHostFilter;
+
+  final VoidCallback onShowAnyway;
+  final VoidCallback onClose;
+
+  String _host() {
+    final url = video.videoUrl;
+    if (url == null || url.isEmpty) return '';
+    return Uri.tryParse(url)?.host ?? '';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return TvStaticMessageScreen(
+      sticker: .alert,
+      title: context.l10n.videoDetailHiddenBySettingsTitle,
+      description: isHostFilter
+          ? context.l10n.videoDetailHiddenByHostFilterBody(_host())
+          : context.l10n.videoDetailHiddenByContentFilterBody,
+      actionLabel: context.l10n.videoDetailHiddenShowAnyway,
+      onAction: onShowAnyway,
+      onClose: onClose,
+      closeSemanticLabel: context.l10n.videoDetailCloseSemanticLabel,
+      footer: DivineButton(
+        label: context.l10n.videoDetailHiddenOpenSettings,
+        type: DivineButtonType.secondary,
+        onPressed: () => context.push(SafetySettingsScreen.path),
+      ),
+    );
+  }
+}

--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -18,7 +18,6 @@
 library;
 
 import 'dart:async';
-
 import 'package:content_blocklist_repository/content_blocklist_repository.dart';
 import 'package:flutter/widgets.dart';
 import 'package:likes_repository/likes_repository.dart';
@@ -29,7 +28,6 @@ import 'package:nostr_sdk/event.dart';
 import 'package:nostr_sdk/filter.dart';
 import 'package:openvine/constants/app_constants.dart';
 import 'package:openvine/constants/nip71_migration.dart';
-import 'package:openvine/extensions/video_event_extensions.dart';
 import 'package:openvine/models/content_label.dart';
 import 'package:openvine/services/author_video_buckets.dart';
 import 'package:openvine/services/broken_video_tracker.dart';
@@ -48,6 +46,8 @@ import 'package:openvine/services/repost_resolver.dart';
 import 'package:openvine/services/subscription_manager.dart';
 import 'package:openvine/services/video_block_policy.dart';
 import 'package:openvine/services/video_filter_builder.dart';
+import 'package:openvine/services/video_provenance_filter_service.dart';
+import 'package:openvine/services/video_source_visibility_policy.dart';
 import 'package:openvine/utils/log_tag_sanitizer.dart';
 import 'package:profile_repository/profile_repository.dart';
 import 'package:unified_logger/unified_logger.dart';
@@ -284,6 +284,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
   ContentFilterService? _contentFilterService;
   ModerationLabelService? _moderationLabelService;
   DivineHostFilterService? _divineHostFilterService;
+  VideoProvenanceFilterService? _provenanceFilterService;
   FeedAspectRatioPreferenceService? _feedAspectRatioPreferenceService;
   BrokenVideoTracker? _brokenVideoTracker;
   final SubscriptionManager _subscriptionManager;
@@ -507,6 +508,11 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
     );
   }
 
+  /// Set the capture-verified-only filter service.
+  void setProvenanceFilterService(VideoProvenanceFilterService service) {
+    _provenanceFilterService = service;
+  }
+
   /// Set the feed aspect-ratio preference service.
   void setFeedAspectRatioPreferenceService(
     FeedAspectRatioPreferenceService service,
@@ -535,12 +541,19 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
   bool get shouldFilterNonDivineVideos =>
       _divineHostFilterService?.showDivineHostedOnly ?? false;
 
+  bool get _shouldFilterUnverifiedVideos =>
+      _provenanceFilterService?.showVerifiedOnly ?? false;
+
   /// Returns true when shared feed policy hides this video.
   bool shouldHideVideo(VideoEvent video) {
     if (VideoBlockPolicy.isHiddenByBlocklist(video, _blocklistRepository)) {
       return true;
     }
-    if (shouldFilterNonDivineVideos && !video.isFromDivineServer) {
+    if (VideoSourceVisibilityPolicy.isHiddenBySourcePreferences(
+      video,
+      divineHostedOnly: shouldFilterNonDivineVideos,
+      verifiedOnly: _shouldFilterUnverifiedVideos,
+    )) {
       return true;
     }
     return false;

--- a/mobile/lib/services/video_provenance_filter_service.dart
+++ b/mobile/lib/services/video_provenance_filter_service.dart
@@ -1,0 +1,41 @@
+// ABOUTME: Persists the viewer's "only show capture-verified videos" choice.
+// ABOUTME: Independent of the Divine-hosted filter; both can apply at once.
+
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Persists the user's preference for only showing capture-verified videos.
+///
+/// This is the provenance axis, and it is deliberately separate from
+/// [DivineHostFilterService]'s hosting axis. Where a video is served from
+/// says who can moderate or take it down; whether it carries a capture
+/// chain (C2PA / ProofMode) says whether it can be traced back to a camera.
+/// A creator can publish verified media on their own host, and unverified
+/// media can sit on ours, so neither answers the other's question.
+///
+/// Defaults to `false`. Enabling it by default would hide every upload
+/// without a capture chain from users who never chose it — roughly an
+/// eighth of modern uploads at the time of writing.
+///
+/// Archive content is exempt at the filter site, not here: original Vine
+/// videos predate content credentials by a decade and can never satisfy a
+/// provenance check.
+class VideoProvenanceFilterService extends ChangeNotifier {
+  VideoProvenanceFilterService(this._prefs)
+    : _showVerifiedOnly = _prefs.getBool(_prefsKey) ?? false;
+
+  static const String _prefsKey = 'show_verified_only';
+
+  final SharedPreferences _prefs;
+  bool _showVerifiedOnly;
+
+  bool get showVerifiedOnly => _showVerifiedOnly;
+
+  Future<void> setShowVerifiedOnly(bool value) async {
+    if (_showVerifiedOnly == value) return;
+
+    await _prefs.setBool(_prefsKey, value);
+    _showVerifiedOnly = value;
+    notifyListeners();
+  }
+}

--- a/mobile/lib/services/video_source_visibility_policy.dart
+++ b/mobile/lib/services/video_source_visibility_policy.dart
@@ -1,0 +1,44 @@
+// ABOUTME: Shared predicate for the viewer's two video-source preferences.
+// ABOUTME: Hosting and provenance are independent axes; neither implies the other.
+
+import 'package:models/models.dart';
+import 'package:openvine/extensions/video_event_extensions.dart';
+
+/// Decides whether the viewer's source preferences hide a video.
+///
+/// Lives outside `VideoEventService` so the feed policy and the repository
+/// content filter share one definition. They previously each spelled the
+/// hosting rule out separately, which is how they came to disagree with the
+/// "Not Divine" badge about the same video.
+class VideoSourceVisibilityPolicy {
+  const VideoSourceVisibilityPolicy._();
+
+  /// Whether [video] is hidden by the viewer's source preferences.
+  ///
+  /// The two axes answer different questions and are deliberately not
+  /// collapsed into one rule:
+  ///
+  /// * [divineHostedOnly] — hosting. Whether we serve the media and can
+  ///   therefore moderate or take it down.
+  /// * [verifiedOnly] — provenance. Whether the media carries a capture
+  ///   chain (C2PA / ProofMode) tracing it back to a camera.
+  ///
+  /// A creator can publish verified media on their own host, and unverified
+  /// media can sit on ours, so satisfying one axis says nothing about the
+  /// other.
+  ///
+  /// Original Vine archive videos are exempt from [verifiedOnly]: they
+  /// predate content credentials by a decade, and without the exemption the
+  /// preference would hide ~97% of the catalogue.
+  static bool isHiddenBySourcePreferences(
+    VideoEvent video, {
+    required bool divineHostedOnly,
+    required bool verifiedOnly,
+  }) {
+    if (divineHostedOnly && !video.isFromDivineServer) return true;
+    if (verifiedOnly && !video.hasProofMode && !video.isOriginalVine) {
+      return true;
+    }
+    return false;
+  }
+}

--- a/mobile/packages/videos_repository/lib/src/video_route_lookup_result.dart
+++ b/mobile/packages/videos_repository/lib/src/video_route_lookup_result.dart
@@ -1,0 +1,40 @@
+// ABOUTME: Outcome of resolving a /video/<route-id> deep link.
+// ABOUTME: Separates "no source had it" from "a source had it, filters hid it".
+
+import 'package:models/models.dart';
+
+/// Result of a route-id video lookup.
+///
+/// A plain `VideoEvent?` cannot express the difference between a video that
+/// no source could supply and one that every source supplied but the
+/// viewer's content filters removed. Both render as "video not found",
+/// which is a lie for the second case and leaves the viewer with no way to
+/// act — the video exists, plays, and is often their own.
+sealed class VideoRouteLookupResult {
+  const VideoRouteLookupResult();
+}
+
+/// A playable video the viewer is allowed to see.
+final class VideoRouteFound extends VideoRouteLookupResult {
+  const VideoRouteFound(this.video);
+
+  final VideoEvent video;
+}
+
+/// A video that resolved and parsed, then was removed by the viewer's
+/// content preferences.
+///
+/// Carries [video] so the presentation layer can explain *which* preference
+/// is responsible (for example by checking the media host against the
+/// "only show Divine-hosted videos" setting) without this package having to
+/// know what the app's filters mean.
+final class VideoRouteHiddenByFilter extends VideoRouteLookupResult {
+  const VideoRouteHiddenByFilter(this.video);
+
+  final VideoEvent video;
+}
+
+/// No source supplied the video.
+final class VideoRouteMissing extends VideoRouteLookupResult {
+  const VideoRouteMissing();
+}

--- a/mobile/packages/videos_repository/lib/src/video_route_lookup_result.dart
+++ b/mobile/packages/videos_repository/lib/src/video_route_lookup_result.dart
@@ -16,8 +16,10 @@ sealed class VideoRouteLookupResult {
 
 /// A playable video the viewer is allowed to see.
 final class VideoRouteFound extends VideoRouteLookupResult {
+  /// Creates a result carrying the playable [video].
   const VideoRouteFound(this.video);
 
+  /// The resolved, hydrated video.
   final VideoEvent video;
 }
 
@@ -29,12 +31,15 @@ final class VideoRouteFound extends VideoRouteLookupResult {
 /// "only show Divine-hosted videos" setting) without this package having to
 /// know what the app's filters mean.
 final class VideoRouteHiddenByFilter extends VideoRouteLookupResult {
+  /// Creates a result carrying the [video] a content filter removed.
   const VideoRouteHiddenByFilter(this.video);
 
+  /// The parsed video, so callers can explain which preference hid it.
   final VideoEvent video;
 }
 
 /// No source supplied the video.
 final class VideoRouteMissing extends VideoRouteLookupResult {
+  /// Creates a result meaning no source supplied the video.
   const VideoRouteMissing();
 }

--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -23,6 +23,7 @@ import 'package:videos_repository/src/seen_video_lookup.dart';
 import 'package:videos_repository/src/video_content_filter.dart';
 import 'package:videos_repository/src/video_event_filter.dart';
 import 'package:videos_repository/src/video_local_storage.dart';
+import 'package:videos_repository/src/video_route_lookup_result.dart';
 import 'package:videos_repository/src/video_search_sort.dart';
 
 export 'package:models/src/nip71_video_kinds.dart' show NIP71VideoKinds;
@@ -1696,6 +1697,7 @@ class VideosRepository {
     Event event, {
     bool permissive = false,
     bool ignoreBlockFilter = false,
+    void Function(VideoEvent video)? onContentFiltered,
   }) {
     // Skip events that aren't valid video kinds
     final isSupported = permissive
@@ -1723,7 +1725,9 @@ class VideosRepository {
     // Skip expired videos (NIP-40)
     if (video.isExpired) return null;
 
-    return _applyContentPreferences(video);
+    final permitted = _applyContentPreferences(video);
+    if (permitted == null) onContentFiltered?.call(video);
+    return permitted;
   }
 
   bool _isReplyOnlyVideoEvent(Event event) {
@@ -2662,16 +2666,41 @@ class VideosRepository {
     String routeId, {
     List<String> fallbackRouteIds = const [],
   }) async {
+    final result = await lookupVideoForRouteId(
+      routeId,
+      fallbackRouteIds: fallbackRouteIds,
+    );
+    return result is VideoRouteFound ? result.video : null;
+  }
+
+  /// Resolves a `/video/<route-id>` reference, distinguishing a video no
+  /// source could supply from one the viewer's content filters removed.
+  ///
+  /// Both collapsed to null before, so a video that exists and plays —
+  /// often the viewer's own — rendered as a permanent "video not found"
+  /// with nothing naming the setting responsible and no way to act on it
+  /// (#7892). Callers that only need the video keep using
+  /// [fetchVideoWithStatsForRouteId].
+  Future<VideoRouteLookupResult> lookupVideoForRouteId(
+    String routeId, {
+    List<String> fallbackRouteIds = const [],
+  }) async {
     FunnelcakeException? apiFailure;
     final attempted = <String>{};
+
+    // Any source may parse the video and then have it filtered; keep the
+    // first so the caller can explain the outcome instead of guessing.
+    VideoEvent? filtered;
+    void onContentFiltered(VideoEvent video) => filtered ??= video;
 
     for (final candidateRouteId in [routeId, ...fallbackRouteIds]) {
       if (!attempted.add(candidateRouteId)) continue;
       try {
         final video = await _fetchVideoWithStatsForSingleRouteId(
           candidateRouteId,
+          onContentFiltered: onContentFiltered,
         );
-        if (video != null) return video;
+        if (video != null) return VideoRouteFound(video);
       } on FunnelcakeException catch (e) {
         // Keep going: a fallback route is a different query shape (an
         // author-scoped addressable resolves against relays alone) and can
@@ -2692,12 +2721,16 @@ class VideosRepository {
     final failure = apiFailure;
     if (failure != null) throw failure;
 
-    return null;
+    final hidden = filtered;
+    if (hidden != null) return VideoRouteHiddenByFilter(hidden);
+
+    return const VideoRouteMissing();
   }
 
   Future<VideoEvent?> _fetchVideoWithStatsForSingleRouteId(
-    String routeId,
-  ) async {
+    String routeId, {
+    void Function(VideoEvent video)? onContentFiltered,
+  }) async {
     final candidate = _VideoRouteCandidate.parse(routeId);
     if (candidate == null) {
       Log.warning(
@@ -2724,7 +2757,10 @@ class VideosRepository {
       return video;
     }
 
-    final cached = await _fetchRouteVideoFromLocalCache(candidate);
+    final cached = await _fetchRouteVideoFromLocalCache(
+      candidate,
+      onContentFiltered: onContentFiltered,
+    );
     if (cached != null) return resolved('localCache', cached);
     missed.add('localCache');
 
@@ -2736,6 +2772,7 @@ class VideosRepository {
           funnelcakeRouteId,
           expectedPubkey: candidate.addressablePubkey,
           permissive: true,
+          onContentFiltered: onContentFiltered,
         );
         if (byFunnelcake != null) {
           return resolved('funnelcake', byFunnelcake);
@@ -2757,6 +2794,7 @@ class VideosRepository {
     if (candidate.eventId != null) {
       final byEventId = await _fetchRouteVideoByEventIdFromRelay(
         candidate.eventId!,
+        onContentFiltered: onContentFiltered,
       );
       if (byEventId != null) return resolved('relayEventId', byEventId);
       missed.add('relayEventId');
@@ -2765,6 +2803,7 @@ class VideosRepository {
     if (candidate.addressableId != null) {
       final byAddressable = await _fetchAddressableVideoFromRelay(
         candidate.addressableId!,
+        onContentFiltered: onContentFiltered,
       );
       if (byAddressable != null) {
         return resolved('relayAddressable', byAddressable);
@@ -2775,6 +2814,7 @@ class VideosRepository {
     if (candidate.stableId != null) {
       final byStableId = await _fetchVideoByStableIdFromRelay(
         candidate.stableId!,
+        onContentFiltered: onContentFiltered,
       );
       if (byStableId != null) return resolved('relayStableId', byStableId);
       missed.add('relayStableId');
@@ -3141,8 +3181,9 @@ class VideosRepository {
   /// a same-d-tag cache hit from another creator must fall through to the
   /// author-filtered relay lookup instead of satisfying the route.
   Future<VideoEvent?> _fetchRouteVideoFromLocalCache(
-    _VideoRouteCandidate candidate,
-  ) async {
+    _VideoRouteCandidate candidate, {
+    void Function(VideoEvent video)? onContentFiltered,
+  }) async {
     if (_localStorage == null) return null;
 
     final candidates = <Event>[];
@@ -3168,10 +3209,16 @@ class VideosRepository {
     }
 
     if (candidates.isEmpty) return null;
-    return _parseAndHydrateFirstRouteVideo(candidates);
+    return _parseAndHydrateFirstRouteVideo(
+      candidates,
+      onContentFiltered: onContentFiltered,
+    );
   }
 
-  Future<VideoEvent?> _fetchRouteVideoByEventIdFromRelay(String eventId) async {
+  Future<VideoEvent?> _fetchRouteVideoByEventIdFromRelay(
+    String eventId, {
+    void Function(VideoEvent video)? onContentFiltered,
+  }) async {
     if (eventId.isEmpty) return null;
 
     final events = await _nostrClient
@@ -3182,10 +3229,16 @@ class VideosRepository {
           ),
         ])
         .timeout(_routeRelayTimeout, onTimeout: () => const <Event>[]);
-    return _parseAndHydrateFirstRouteVideo(events);
+    return _parseAndHydrateFirstRouteVideo(
+      events,
+      onContentFiltered: onContentFiltered,
+    );
   }
 
-  Future<VideoEvent?> _fetchVideoByStableIdFromRelay(String stableId) async {
+  Future<VideoEvent?> _fetchVideoByStableIdFromRelay(
+    String stableId, {
+    void Function(VideoEvent video)? onContentFiltered,
+  }) async {
     final events = await _nostrClient
         .queryEvents([
           Filter(
@@ -3197,7 +3250,10 @@ class VideosRepository {
           ),
         ])
         .timeout(_routeRelayTimeout, onTimeout: () => const <Event>[]);
-    return _parseAndHydrateFirstRouteVideo(events);
+    return _parseAndHydrateFirstRouteVideo(
+      events,
+      onContentFiltered: onContentFiltered,
+    );
   }
 
   /// Fetches a video by addressable id (`kind:pubkey:d-tag`) from relay only.
@@ -3222,8 +3278,9 @@ class VideosRepository {
   /// kinds (e.g. 21, 22, 34235) reach this branch via naddr1 references and
   /// must resolve the same way they do via raw event id or bare d-tag.
   Future<VideoEvent?> _fetchAddressableVideoFromRelay(
-    String addressableId,
-  ) async {
+    String addressableId, {
+    void Function(VideoEvent video)? onContentFiltered,
+  }) async {
     final parsed = AId.fromString(addressableId);
     if (parsed == null || !NIP71VideoKinds.isAcceptableVideoKind(parsed.kind)) {
       return null;
@@ -3238,13 +3295,17 @@ class VideosRepository {
           ),
         ])
         .timeout(_routeRelayTimeout, onTimeout: () => const <Event>[]);
-    return _parseAndHydrateFirstRouteVideo(events);
+    return _parseAndHydrateFirstRouteVideo(
+      events,
+      onContentFiltered: onContentFiltered,
+    );
   }
 
   Future<VideoEvent?> _fetchVideoFromRouteApi(
     String routeId, {
     String? expectedPubkey,
     bool permissive = false,
+    void Function(VideoEvent video)? onContentFiltered,
   }) async {
     if (_funnelcakeApiClient == null || !_funnelcakeApiClient.isAvailable) {
       return null;
@@ -3257,6 +3318,7 @@ class VideosRepository {
       event,
       permissive: permissive,
       ignoreBlockFilter: true,
+      onContentFiltered: onContentFiltered,
     );
     if (video == null) return null;
     if (expectedPubkey != null && video.pubkey != expectedPubkey) return null;
@@ -3265,8 +3327,9 @@ class VideosRepository {
   }
 
   Future<VideoEvent?> _parseAndHydrateFirstRouteVideo(
-    List<Event> events,
-  ) async {
+    List<Event> events, {
+    void Function(VideoEvent video)? onContentFiltered,
+  }) async {
     if (events.isEmpty) return null;
 
     events.sort((a, b) => b.createdAt.compareTo(a.createdAt));
@@ -3276,6 +3339,7 @@ class VideosRepository {
         event,
         permissive: true,
         ignoreBlockFilter: true,
+        onContentFiltered: onContentFiltered,
       );
       if (video != null) {
         videos.add(video);

--- a/mobile/packages/videos_repository/lib/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/videos_repository.dart
@@ -17,7 +17,7 @@ export 'src/seen_video_lookup.dart';
 export 'src/video_content_filter.dart';
 export 'src/video_event_filter.dart';
 export 'src/video_local_storage.dart';
-export 'src/video_route_lookup_result.dart';
 export 'src/video_merge_helpers.dart';
+export 'src/video_route_lookup_result.dart';
 export 'src/video_search_sort.dart';
 export 'src/videos_repository.dart';

--- a/mobile/packages/videos_repository/lib/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/videos_repository.dart
@@ -17,6 +17,7 @@ export 'src/seen_video_lookup.dart';
 export 'src/video_content_filter.dart';
 export 'src/video_event_filter.dart';
 export 'src/video_local_storage.dart';
+export 'src/video_route_lookup_result.dart';
 export 'src/video_merge_helpers.dart';
 export 'src/video_search_sort.dart';
 export 'src/videos_repository.dart';

--- a/mobile/packages/videos_repository/test/src/videos_repository_route_hidden_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_route_hidden_test.dart
@@ -70,7 +70,7 @@ void main() {
       // Stands in for the app's "only show Divine-hosted videos" filter.
       final repo = build(
         contentFilter: (video) =>
-            !(Uri.parse(video.videoUrl ?? '').host.endsWith('.divine.video')),
+            !Uri.parse(video.videoUrl ?? '').host.endsWith('.divine.video'),
       );
 
       final result = await repo.lookupVideoForRouteId('34236:$_pubkey:$_dTag');

--- a/mobile/packages/videos_repository/test/src/videos_repository_route_hidden_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_route_hidden_test.dart
@@ -1,0 +1,125 @@
+// ABOUTME: Pins that a filtered video is reported as hidden, not as missing.
+// ABOUTME: Collapsing both to null renders "not found" for a playable video.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:funnelcake_api_client/funnelcake_api_client.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/nostr_sdk.dart';
+import 'package:videos_repository/videos_repository.dart';
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _MockFunnelcakeApiClient extends Mock implements FunnelcakeApiClient {}
+
+const _pubkey =
+    'd95aa8fc0eff8e488952495b8064991d27fb96ed8652f12cdedc5a4e8b5ae540';
+const _dTag =
+    '7465a9b8a671506e748391248e6ce7538608f0d430458daa5a0b38aa3a01c180';
+const _eventId =
+    '72440ed755f6a4ccabf91adaa28e90a3940fdabd2537110ad945f8d41b2e22e1';
+
+/// Mirrors the real event behind #7892: media on a non-Divine host.
+Event _offHostVideo() => Event.fromJson({
+  'id': _eventId,
+  'pubkey': _pubkey,
+  'created_at': 1765250795,
+  'kind': 34236,
+  'content': '',
+  'sig': 'a' * 128,
+  'tags': [
+    ['d', _dTag],
+    [
+      'imeta',
+      'url https://separately-robust-roughy.edgecompute.app/$_dTag',
+      'm video/mp4',
+    ],
+    ['title', 'unsteady shot of the water'],
+  ],
+});
+
+void main() {
+  setUpAll(() => registerFallbackValue(<Filter>[]));
+
+  group('lookupVideoForRouteId', () {
+    late _MockNostrClient nostr;
+    late _MockFunnelcakeApiClient funnelcake;
+
+    setUp(() {
+      nostr = _MockNostrClient();
+      funnelcake = _MockFunnelcakeApiClient();
+      when(() => funnelcake.isAvailable).thenReturn(false);
+      when(() => nostr.queryEvents(any())).thenAnswer((_) async => []);
+    });
+
+    VideosRepository build({VideoContentFilter? contentFilter}) =>
+        VideosRepository(
+          nostrClient: nostr,
+          funnelcakeApiClient: funnelcake,
+          contentFilter: contentFilter,
+        );
+
+    test('reports a content-filtered video as hidden, not missing', () async {
+      when(
+        () => nostr.queryEvents(any()),
+      ).thenAnswer((_) async => [_offHostVideo()]);
+      when(
+        () => funnelcake.getBulkVideoStats(any()),
+      ).thenThrow(const FunnelcakeException('no stats'));
+
+      // Stands in for the app's "only show Divine-hosted videos" filter.
+      final repo = build(
+        contentFilter: (video) =>
+            !(Uri.parse(video.videoUrl ?? '').host.endsWith('.divine.video')),
+      );
+
+      final result = await repo.lookupVideoForRouteId('34236:$_pubkey:$_dTag');
+
+      expect(result, isA<VideoRouteHiddenByFilter>());
+      expect((result as VideoRouteHiddenByFilter).video.id, equals(_eventId));
+    });
+
+    test('reports a genuinely absent video as missing', () async {
+      final repo = build();
+
+      final result = await repo.lookupVideoForRouteId('34236:$_pubkey:$_dTag');
+
+      expect(result, isA<VideoRouteMissing>());
+    });
+
+    test('reports an allowed video as found', () async {
+      when(
+        () => nostr.queryEvents(any()),
+      ).thenAnswer((_) async => [_offHostVideo()]);
+      when(
+        () => funnelcake.getBulkVideoStats(any()),
+      ).thenThrow(const FunnelcakeException('no stats'));
+
+      final repo = build();
+
+      final result = await repo.lookupVideoForRouteId('34236:$_pubkey:$_dTag');
+
+      expect(result, isA<VideoRouteFound>());
+    });
+
+    test(
+      'fetchVideoWithStatsForRouteId still returns null when hidden',
+      () async {
+        when(
+          () => nostr.queryEvents(any()),
+        ).thenAnswer((_) async => [_offHostVideo()]);
+        when(
+          () => funnelcake.getBulkVideoStats(any()),
+        ).thenThrow(const FunnelcakeException('no stats'));
+
+        final repo = build(contentFilter: (_) => true);
+
+        // Existing callers keep their contract.
+        expect(
+          await repo.fetchVideoWithStatsForRouteId('34236:$_pubkey:$_dTag'),
+          isNull,
+        );
+      },
+    );
+  });
+}

--- a/mobile/scripts/check_changenotifier_boundary.sh
+++ b/mobile/scripts/check_changenotifier_boundary.sh
@@ -55,6 +55,7 @@ ALLOWLIST=(
   "services/content_filter_service.dart"
   "services/curated_list_service.dart"
   "services/divine_host_filter_service.dart"
+  "services/video_provenance_filter_service.dart"
   "services/environment_service.dart"
   "services/feed_aspect_ratio_preference_service.dart"
   "services/nip05_verification_service.dart"

--- a/mobile/test/blocs/safety_settings/safety_settings_cubit_test.dart
+++ b/mobile/test/blocs/safety_settings/safety_settings_cubit_test.dart
@@ -17,6 +17,7 @@ import 'package:openvine/services/content_filter_service.dart';
 import 'package:openvine/services/divine_host_filter_service.dart';
 import 'package:openvine/services/moderation_label_service.dart';
 import 'package:openvine/services/video_event_service.dart';
+import 'package:openvine/services/video_provenance_filter_service.dart';
 
 class _MockAgeVerificationService extends Mock
     implements AgeVerificationService {}
@@ -27,6 +28,9 @@ class _MockVideoEventService extends Mock implements VideoEventService {}
 
 class _MockDivineHostFilterService extends Mock
     implements DivineHostFilterService {}
+
+class _MockVideoProvenanceFilterService extends Mock
+    implements VideoProvenanceFilterService {}
 
 class _MockModerationLabelService extends Mock
     implements ModerationLabelService {}
@@ -42,6 +46,7 @@ void main() {
     late _MockContentFilterService filterService;
     late _MockVideoEventService videoEventService;
     late _MockDivineHostFilterService divineHostFilterService;
+    late _MockVideoProvenanceFilterService provenanceFilterService;
     late _MockModerationLabelService moderationLabelService;
     late _MockFollowRepository followRepository;
     late _MockContentBlocklistRepository blocklistRepository;
@@ -52,6 +57,8 @@ void main() {
       filterService = _MockContentFilterService();
       videoEventService = _MockVideoEventService();
       divineHostFilterService = _MockDivineHostFilterService();
+      provenanceFilterService = _MockVideoProvenanceFilterService();
+      when(() => provenanceFilterService.showVerifiedOnly).thenReturn(false);
       moderationLabelService = _MockModerationLabelService();
       followRepository = _MockFollowRepository();
       blocklistRepository = _MockContentBlocklistRepository();
@@ -119,6 +126,7 @@ void main() {
           contentFilterService: filterService,
           videoEventService: videoEventService,
           divineHostFilterService: divineHostFilterService,
+          provenanceFilterService: provenanceFilterService,
           moderationLabelService: moderationLabelService,
           followRepository: followRepository,
           contentBlocklistRepository: blocklistRepository,

--- a/mobile/test/l10n/arb_consistency_test.dart
+++ b/mobile/test/l10n/arb_consistency_test.dart
@@ -474,6 +474,13 @@ void main() {
 // Keys intentionally allowed to fall back to English until a translation pass.
 // Keep this list small and reviewable so new translation gaps stay visible.
 const _knownUntranslatedDebt = <String>{
+  // #7892: safety-filter explanation on the video detail screen. Translation
+  // deferred to the next l10n pass.
+  'videoDetailHiddenBySettingsTitle',
+  'videoDetailHiddenByHostFilterBody',
+  'videoDetailHiddenByContentFilterBody',
+  'videoDetailHiddenShowAnyway',
+  'videoDetailHiddenOpenSettings',
   // Restricted-account deletion guidance tracked in #7879.
   'shareMenuDeleteFailedAccountRestricted',
   'deleteAccountAccountRestricted',

--- a/mobile/test/l10n/arb_consistency_test.dart
+++ b/mobile/test/l10n/arb_consistency_test.dart
@@ -481,6 +481,9 @@ const _knownUntranslatedDebt = <String>{
   'videoDetailHiddenByContentFilterBody',
   'videoDetailHiddenShowAnyway',
   'videoDetailHiddenOpenSettings',
+  'videoDetailHiddenByProvenanceFilterBody',
+  'safetySettingsShowVerifiedOnly',
+  'safetySettingsShowVerifiedOnlySubtitle',
   // Restricted-account deletion guidance tracked in #7879.
   'shareMenuDeleteFailedAccountRestricted',
   'deleteAccountAccountRestricted',

--- a/mobile/test/screens/safety_settings_screen_test.dart
+++ b/mobile/test/screens/safety_settings_screen_test.dart
@@ -23,9 +23,9 @@ import 'package:openvine/services/content_reporting_service.dart';
 import 'package:openvine/services/divine_host_filter_service.dart';
 import 'package:openvine/services/moderation_label_service.dart';
 import 'package:openvine/services/video_event_service.dart';
+import 'package:openvine/services/video_provenance_filter_service.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:openvine/services/video_provenance_filter_service.dart';
 
 class _MockContentBlocklistRepository extends Mock
     implements ContentBlocklistRepository {

--- a/mobile/test/screens/safety_settings_screen_test.dart
+++ b/mobile/test/screens/safety_settings_screen_test.dart
@@ -25,6 +25,7 @@ import 'package:openvine/services/moderation_label_service.dart';
 import 'package:openvine/services/video_event_service.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:openvine/services/video_provenance_filter_service.dart';
 
 class _MockContentBlocklistRepository extends Mock
     implements ContentBlocklistRepository {
@@ -110,6 +111,7 @@ void main() {
     late _MockContentFilterService mockContentFilterService;
     late _MockVideoEventService mockVideoEventService;
     late DivineHostFilterService divineHostFilterService;
+    late VideoProvenanceFilterService provenanceFilterService;
     const blockedPubkey =
         'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
     const labelerPubkey =
@@ -127,6 +129,7 @@ void main() {
       mockContentFilterService = _MockContentFilterService();
       mockVideoEventService = _MockVideoEventService();
       divineHostFilterService = DivineHostFilterService(prefs);
+      provenanceFilterService = VideoProvenanceFilterService(prefs);
 
       when(
         () => mockModerationLabelService.ensureLoaded(),
@@ -194,6 +197,9 @@ void main() {
           videoEventServiceProvider.overrideWithValue(mockVideoEventService),
           divineHostFilterServiceProvider.overrideWithValue(
             divineHostFilterService,
+          ),
+          videoProvenanceFilterServiceProvider.overrideWithValue(
+            provenanceFilterService,
           ),
           isProtectedMinorProvider.overrideWithValue(isProtectedMinor),
           userProfileReactiveProvider.overrideWith(

--- a/mobile/test/screens/video_detail_screen_test.dart
+++ b/mobile/test/screens/video_detail_screen_test.dart
@@ -21,6 +21,7 @@ import 'package:openvine/screens/video_detail_screen.dart';
 import 'package:openvine/services/video_event_service.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:videos_repository/videos_repository.dart';
+import 'package:openvine/services/video_provenance_filter_service.dart';
 
 import '../helpers/test_provider_overrides.dart';
 import '../test_data/video_test_data.dart';
@@ -35,6 +36,9 @@ class _MockContentBlocklistRepository extends Mock
     implements ContentBlocklistRepository {}
 
 class _MockVideosRepository extends Mock implements VideosRepository {}
+
+class _MockVideoProvenanceFilterService extends Mock
+    implements VideoProvenanceFilterService {}
 
 Finder _divineSticker(DivineStickerName name) =>
     find.byWidgetPredicate((w) => w is DivineSticker && w.sticker == name);
@@ -102,6 +106,7 @@ void main() {
     Widget buildSubject({
       String videoId = 'test_video_id',
       List<String> fallbackVideoIds = const [],
+      List<dynamic> extraOverrides = const <dynamic>[],
     }) {
       return testMaterialApp(
         mockNostrService: mockNostrClient,
@@ -112,6 +117,7 @@ void main() {
             mockBlocklistRepository,
           ),
           videosRepositoryProvider.overrideWithValue(mockVideosRepository),
+          ...extraOverrides,
         ],
         home: VideoDetailScreen(
           videoId: videoId,
@@ -400,6 +406,44 @@ void main() {
             ),
           ),
           findsOneWidget,
+        );
+      });
+
+      testWidgets('names the provenance setting when that is the cause', (
+        tester,
+      ) async {
+        // Divine-hosted, so the hosting axis is satisfied — only the
+        // capture-chain preference can be responsible.
+        stubHidden(
+          createTestVideoEvent(
+            id: 'unverified_video',
+            videoUrl: 'https://cdn.divine.video/abc.mp4',
+          ),
+        );
+        final provenanceFilter = _MockVideoProvenanceFilterService();
+        when(() => provenanceFilter.showVerifiedOnly).thenReturn(true);
+
+        await tester.pumpWidget(
+          buildSubject(
+            extraOverrides: [
+              videoProvenanceFilterServiceProvider.overrideWithValue(
+                provenanceFilter,
+              ),
+            ],
+          ),
+        );
+        await tester.pump();
+
+        expect(
+          find.text(l10n.videoDetailHiddenByProvenanceFilterBody),
+          findsOneWidget,
+        );
+        // Must not blame the hosting setting for a Divine-hosted video.
+        expect(
+          find.text(
+            l10n.videoDetailHiddenByHostFilterBody('cdn.divine.video'),
+          ),
+          findsNothing,
         );
       });
 

--- a/mobile/test/screens/video_detail_screen_test.dart
+++ b/mobile/test/screens/video_detail_screen_test.dart
@@ -19,9 +19,9 @@ import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/screens/feed/video_feed_page.dart';
 import 'package:openvine/screens/video_detail_screen.dart';
 import 'package:openvine/services/video_event_service.dart';
+import 'package:openvine/services/video_provenance_filter_service.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:videos_repository/videos_repository.dart';
-import 'package:openvine/services/video_provenance_filter_service.dart';
 
 import '../helpers/test_provider_overrides.dart';
 import '../test_data/video_test_data.dart';

--- a/mobile/test/screens/video_detail_screen_test.dart
+++ b/mobile/test/screens/video_detail_screen_test.dart
@@ -127,9 +127,9 @@ void main() {
         tester,
       ) async {
         // fetchVideoWithStatsForRouteId stays pending
-        final completer = Completer<VideoEvent?>();
+        final completer = Completer<VideoRouteLookupResult>();
         when(
-          () => mockVideosRepository.fetchVideoWithStatsForRouteId(any()),
+          () => mockVideosRepository.lookupVideoForRouteId(any()),
         ).thenAnswer((_) => completer.future);
 
         await tester.pumpWidget(buildSubject());
@@ -143,11 +143,11 @@ void main() {
         (tester) async {
           // A lookup that never resolves — cold start before the relays are
           // queryable — used to strand the user on the spinner with no exit.
-          final completer = Completer<VideoEvent?>();
+          final completer = Completer<VideoRouteLookupResult>();
           when(
-            () => mockVideosRepository.fetchVideoWithStatsForRouteId(any()),
+            () => mockVideosRepository.lookupVideoForRouteId(any()),
           ).thenAnswer((_) => completer.future);
-          addTearDown(() => completer.complete(null));
+          addTearDown(() => completer.complete(const VideoRouteMissing()));
 
           final router = GoRouter(
             routes: [
@@ -214,11 +214,11 @@ void main() {
       testWidgets('exit lands on the feed when there is nothing to pop', (
         tester,
       ) async {
-        final completer = Completer<VideoEvent?>();
+        final completer = Completer<VideoRouteLookupResult>();
         when(
-          () => mockVideosRepository.fetchVideoWithStatsForRouteId(any()),
+          () => mockVideosRepository.lookupVideoForRouteId(any()),
         ).thenAnswer((_) => completer.future);
-        addTearDown(() => completer.complete(null));
+        addTearDown(() => completer.complete(const VideoRouteMissing()));
 
         final router = GoRouter(
           initialLocation: VideoDetailScreen.pathForId('test_video_id'),
@@ -282,10 +282,10 @@ void main() {
           when(() => mockNostrClient.connectedRelayCount).thenReturn(0);
           var attempts = 0;
           when(
-            () => mockVideosRepository.fetchVideoWithStatsForRouteId(any()),
+            () => mockVideosRepository.lookupVideoForRouteId(any()),
           ).thenAnswer((_) async {
             attempts++;
-            return null;
+            return const VideoRouteMissing();
           });
 
           final router = GoRouter(
@@ -354,6 +354,93 @@ void main() {
       );
     });
 
+    group('hidden by a content filter', () {
+      VideoEvent offHostVideo() => createTestVideoEvent(
+        id: 'off_host_video',
+        videoUrl: 'https://separately-robust-roughy.edgecompute.app/abc123',
+      );
+
+      void stubHidden(VideoEvent video) {
+        when(
+          () => mockVideosRepository.lookupVideoForRouteId(
+            any(),
+            fallbackRouteIds: any(named: 'fallbackRouteIds'),
+          ),
+        ).thenAnswer((_) async => VideoRouteHiddenByFilter(video));
+      }
+
+      testWidgets('explains the filter instead of claiming "not found"', (
+        tester,
+      ) async {
+        stubHidden(offHostVideo());
+
+        await tester.pumpWidget(buildSubject());
+        await tester.pump();
+
+        expect(
+          find.text(l10n.videoDetailHiddenBySettingsTitle),
+          findsOneWidget,
+        );
+        // The old behaviour — the lie this exists to stop.
+        expect(find.text(l10n.videoErrorNotFound), findsNothing);
+      });
+
+      testWidgets('names the media host that triggered the host filter', (
+        tester,
+      ) async {
+        stubHidden(offHostVideo());
+
+        await tester.pumpWidget(buildSubject());
+        await tester.pump();
+
+        expect(
+          find.text(
+            l10n.videoDetailHiddenByHostFilterBody(
+              'separately-robust-roughy.edgecompute.app',
+            ),
+          ),
+          findsOneWidget,
+        );
+      });
+
+      testWidgets('offers both a settings route and a per-video override', (
+        tester,
+      ) async {
+        stubHidden(offHostVideo());
+
+        await tester.pumpWidget(buildSubject());
+        await tester.pump();
+
+        expect(find.text(l10n.videoDetailHiddenShowAnyway), findsOneWidget);
+        expect(find.text(l10n.videoDetailHiddenOpenSettings), findsOneWidget);
+      });
+
+      testWidgets('"show it anyway" plays the video without a refetch', (
+        tester,
+      ) async {
+        stubHidden(offHostVideo());
+
+        await tester.pumpWidget(buildSubject());
+        await tester.pump();
+
+        await tester.tap(find.text(l10n.videoDetailHiddenShowAnyway));
+        await tester.pump();
+
+        expect(find.byKey(const Key('video-feed-placeholder')), findsOneWidget);
+        expect(
+          find.text(l10n.videoDetailHiddenBySettingsTitle),
+          findsNothing,
+        );
+        // The lookup already carried the video; overriding must not refetch.
+        verify(
+          () => mockVideosRepository.lookupVideoForRouteId(
+            any(),
+            fallbackRouteIds: any(named: 'fallbackRouteIds'),
+          ),
+        ).called(1);
+      });
+    });
+
     group('video found', () {
       testWidgets('renders supplied route video without fetching it again', (
         tester,
@@ -395,7 +482,7 @@ void main() {
         expect(find.byKey(const Key('video-feed-placeholder')), findsOneWidget);
         expect(capturedVideo, same(initialVideo));
         verifyNever(
-          () => mockVideosRepository.fetchVideoWithStatsForRouteId(any()),
+          () => mockVideosRepository.lookupVideoForRouteId(any()),
         );
       });
 
@@ -409,10 +496,10 @@ void main() {
           );
 
           when(
-            () => mockVideosRepository.fetchVideoWithStatsForRouteId(
+            () => mockVideosRepository.lookupVideoForRouteId(
               'test_video_id',
             ),
-          ).thenAnswer((_) async => video);
+          ).thenAnswer((_) async => VideoRouteFound(video));
 
           await tester.pumpWidget(buildSubject());
           await tester.pump();
@@ -434,11 +521,11 @@ void main() {
           );
 
           when(
-            () => mockVideosRepository.fetchVideoWithStatsForRouteId(
+            () => mockVideosRepository.lookupVideoForRouteId(
               '34236:test_pubkey:stable_id',
               fallbackRouteIds: const ['raw_video_id'],
             ),
-          ).thenAnswer((_) async => video);
+          ).thenAnswer((_) async => VideoRouteFound(video));
 
           await tester.pumpWidget(
             buildSubject(
@@ -453,7 +540,7 @@ void main() {
             findsOneWidget,
           );
           verify(
-            () => mockVideosRepository.fetchVideoWithStatsForRouteId(
+            () => mockVideosRepository.lookupVideoForRouteId(
               '34236:test_pubkey:stable_id',
               fallbackRouteIds: const ['raw_video_id'],
             ),
@@ -478,10 +565,10 @@ void main() {
 
           VideoEvent? capturedVideo;
           when(
-            () => mockVideosRepository.fetchVideoWithStatsForRouteId(
+            () => mockVideosRepository.lookupVideoForRouteId(
               'test_video_id',
             ),
-          ).thenAnswer((_) async => videoWithStats);
+          ).thenAnswer((_) async => VideoRouteFound(videoWithStats));
 
           await tester.pumpWidget(
             testMaterialApp(
@@ -532,15 +619,15 @@ void main() {
         );
 
         when(
-          () => mockVideosRepository.fetchVideoWithStatsForRouteId(
+          () => mockVideosRepository.lookupVideoForRouteId(
             'first_video_id',
           ),
-        ).thenAnswer((_) async => firstVideo);
+        ).thenAnswer((_) async => VideoRouteFound(firstVideo));
         when(
-          () => mockVideosRepository.fetchVideoWithStatsForRouteId(
+          () => mockVideosRepository.lookupVideoForRouteId(
             'second_video_id',
           ),
-        ).thenAnswer((_) async => secondVideo);
+        ).thenAnswer((_) async => VideoRouteFound(secondVideo));
 
         VideoEvent? capturedVideo;
 
@@ -603,8 +690,8 @@ void main() {
         'renders error when fetchVideoWithStatsForRouteId returns null',
         (tester) async {
           when(
-            () => mockVideosRepository.fetchVideoWithStatsForRouteId(any()),
-          ).thenAnswer((_) async => null);
+            () => mockVideosRepository.lookupVideoForRouteId(any()),
+          ).thenAnswer((_) async => const VideoRouteMissing());
 
           await tester.pumpWidget(buildSubject());
           await tester.pump();
@@ -640,9 +727,8 @@ void main() {
           // contract.
           const coordinate = '34236:owner_pubkey_hex:my-vine-id';
           when(
-            () =>
-                mockVideosRepository.fetchVideoWithStatsForRouteId(coordinate),
-          ).thenAnswer((_) async => null);
+            () => mockVideosRepository.lookupVideoForRouteId(coordinate),
+          ).thenAnswer((_) async => const VideoRouteMissing());
 
           await tester.pumpWidget(buildSubject(videoId: coordinate));
           await tester.pump();
@@ -676,14 +762,14 @@ void main() {
           );
 
           when(
-            () => mockVideosRepository.fetchVideoWithStatsForRouteId(
+            () => mockVideosRepository.lookupVideoForRouteId(
               'cold_start_video',
             ),
           ).thenAnswer((_) async {
             if (!isInitialized || connectedRelayCount == 0) {
-              return null;
+              return const VideoRouteMissing();
             }
-            return video;
+            return VideoRouteFound(video);
           });
 
           await tester.pumpWidget(buildSubject(videoId: 'cold_start_video'));
@@ -730,16 +816,16 @@ void main() {
 
         var attempts = 0;
         when(
-          () => mockVideosRepository.fetchVideoWithStatsForRouteId(
+          () => mockVideosRepository.lookupVideoForRouteId(
             'dropped_relay_video',
           ),
         ).thenAnswer((_) async {
           attempts++;
           if (attempts == 1) {
             connectedRelayCount = 0;
-            return null;
+            return const VideoRouteMissing();
           }
-          return video;
+          return VideoRouteFound(video);
         });
 
         await tester.pumpWidget(buildSubject(videoId: 'dropped_relay_video'));
@@ -768,7 +854,7 @@ void main() {
         'renders error message when fetchVideoWithStatsForRouteId throws',
         (tester) async {
           when(
-            () => mockVideosRepository.fetchVideoWithStatsForRouteId(any()),
+            () => mockVideosRepository.lookupVideoForRouteId(any()),
           ).thenAnswer((_) => Future.error(Exception('Network error')));
 
           await tester.pumpWidget(buildSubject());
@@ -789,7 +875,7 @@ void main() {
         // message, so a corrupt local database showed the user the raw
         // SqliteException — SQL, parameters and all.
         when(
-          () => mockVideosRepository.fetchVideoWithStatsForRouteId(any()),
+          () => mockVideosRepository.lookupVideoForRouteId(any()),
         ).thenAnswer(
           (_) => Future.error(
             Exception(
@@ -816,12 +902,12 @@ void main() {
         );
         var attempts = 0;
         when(
-          () => mockVideosRepository.fetchVideoWithStatsForRouteId(any()),
+          () => mockVideosRepository.lookupVideoForRouteId(any()),
         ).thenAnswer((_) {
           attempts++;
           return attempts == 1
-              ? Future<VideoEvent?>.error(Exception('Network error'))
-              : Future<VideoEvent?>.value(video);
+              ? Future<VideoRouteLookupResult>.error(Exception('Network error'))
+              : Future<VideoRouteLookupResult>.value(VideoRouteFound(video));
         });
 
         await tester.pumpWidget(buildSubject());
@@ -840,17 +926,17 @@ void main() {
       testWidgets('shows the loading state while the retry is in flight', (
         tester,
       ) async {
-        final refetch = Completer<VideoEvent?>();
+        final refetch = Completer<VideoRouteLookupResult>();
         var attempts = 0;
         when(
-          () => mockVideosRepository.fetchVideoWithStatsForRouteId(any()),
+          () => mockVideosRepository.lookupVideoForRouteId(any()),
         ).thenAnswer((_) {
           attempts++;
           return attempts == 1
-              ? Future<VideoEvent?>.error(Exception('Network error'))
+              ? Future<VideoRouteLookupResult>.error(Exception('Network error'))
               : refetch.future;
         });
-        addTearDown(() => refetch.complete(null));
+        addTearDown(() => refetch.complete(const VideoRouteMissing()));
 
         await tester.pumpWidget(buildSubject());
         await tester.pump();
@@ -873,10 +959,12 @@ void main() {
           // the user on an unbounded spinner with no way back to Retry.
           var attempts = 0;
           when(
-            () => mockVideosRepository.fetchVideoWithStatsForRouteId(any()),
+            () => mockVideosRepository.lookupVideoForRouteId(any()),
           ).thenAnswer((_) {
             attempts++;
-            return Future<VideoEvent?>.error(Exception('Network error'));
+            return Future<VideoRouteLookupResult>.error(
+              Exception('Network error'),
+            );
           });
 
           await tester.pumpWidget(buildSubject());
@@ -911,10 +999,10 @@ void main() {
         );
 
         when(
-          () => mockVideosRepository.fetchVideoWithStatsForRouteId(
+          () => mockVideosRepository.lookupVideoForRouteId(
             'blocked_video_id',
           ),
-        ).thenAnswer((_) async => video);
+        ).thenAnswer((_) async => VideoRouteFound(video));
         when(
           () => mockBlocklistRepository.shouldFilterFromFeeds('blocked_pubkey'),
         ).thenReturn(true);
@@ -935,10 +1023,10 @@ void main() {
         );
 
         when(
-          () => mockVideosRepository.fetchVideoWithStatsForRouteId(
+          () => mockVideosRepository.lookupVideoForRouteId(
             'blocked_video_id',
           ),
-        ).thenAnswer((_) async => video);
+        ).thenAnswer((_) async => VideoRouteFound(video));
         when(
           () => mockBlocklistRepository.hasBlockedUs('blocked_pubkey'),
         ).thenReturn(true);
@@ -960,10 +1048,10 @@ void main() {
         );
 
         when(
-          () => mockVideosRepository.fetchVideoWithStatsForRouteId(
+          () => mockVideosRepository.lookupVideoForRouteId(
             'hidden_video_id',
           ),
-        ).thenAnswer((_) async => video);
+        ).thenAnswer((_) async => VideoRouteFound(video));
         when(
           () => mockVideoEventService.shouldHideVideo(video),
         ).thenReturn(true);
@@ -988,10 +1076,10 @@ void main() {
         );
 
         when(
-          () => mockVideosRepository.fetchVideoWithStatsForRouteId(
+          () => mockVideosRepository.lookupVideoForRouteId(
             'deleted_video_id',
           ),
-        ).thenAnswer((_) async => video);
+        ).thenAnswer((_) async => VideoRouteFound(video));
         when(
           () => mockVideoEventService.isVideoEventKnownDeleted(video),
         ).thenReturn(true);
@@ -1020,10 +1108,10 @@ void main() {
         );
 
         when(
-          () => mockVideosRepository.fetchVideoWithStatsForRouteId(
+          () => mockVideosRepository.lookupVideoForRouteId(
             'unblocked_video_id',
           ),
-        ).thenAnswer((_) async => video);
+        ).thenAnswer((_) async => VideoRouteFound(video));
         when(
           () => mockVideoEventService.shouldHideVideo(video),
         ).thenReturn(true);

--- a/mobile/test/services/video_provenance_filter_service_test.dart
+++ b/mobile/test/services/video_provenance_filter_service_test.dart
@@ -1,0 +1,53 @@
+// ABOUTME: Pins the capture-verified-only preference and its default.
+// ABOUTME: Defaulting this on would hide 13% of modern uploads on upgrade.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/services/video_provenance_filter_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  group('VideoProvenanceFilterService', () {
+    test('defaults to disabled when no preference is stored', () async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+
+      final service = VideoProvenanceFilterService(prefs);
+
+      // Opt-in: enabling it by default would silently hide every upload
+      // without a capture chain from users who never chose it.
+      expect(service.showVerifiedOnly, isFalse);
+    });
+
+    test('respects an explicitly enabled preference', () async {
+      SharedPreferences.setMockInitialValues({'show_verified_only': true});
+      final prefs = await SharedPreferences.getInstance();
+
+      final service = VideoProvenanceFilterService(prefs);
+
+      expect(service.showVerifiedOnly, isTrue);
+    });
+
+    test('persists enabled state across reloads', () async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      final service = VideoProvenanceFilterService(prefs);
+
+      await service.setShowVerifiedOnly(true);
+
+      expect(VideoProvenanceFilterService(prefs).showVerifiedOnly, isTrue);
+    });
+
+    test('notifies listeners when the preference changes', () async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      final service = VideoProvenanceFilterService(prefs);
+      var notifications = 0;
+      service.addListener(() => notifications++);
+
+      await service.setShowVerifiedOnly(true);
+      await service.setShowVerifiedOnly(true); // no-op, same value
+
+      expect(notifications, equals(1));
+    });
+  });
+}

--- a/mobile/test/services/video_source_visibility_policy_test.dart
+++ b/mobile/test/services/video_source_visibility_policy_test.dart
@@ -1,0 +1,55 @@
+// ABOUTME: Pins the two independent source axes: hosting and provenance.
+// ABOUTME: One shared predicate so feeds and route lookups cannot diverge.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart';
+import 'package:openvine/services/video_source_visibility_policy.dart';
+
+import '../test_data/video_test_data.dart';
+
+void main() {
+  group('VideoSourceVisibilityPolicy.isHiddenBySourcePreferences', () {
+    final divineHosted = createTestVideoEvent(
+      id: 'divine',
+      videoUrl: 'https://cdn.divine.video/abc.mp4',
+    );
+    final offHost = createTestVideoEvent(
+      id: 'offhost',
+      videoUrl: 'https://someone.blossom.band/abc',
+    );
+
+    bool hidden(
+      VideoEvent video, {
+      bool divineHostedOnly = false,
+      bool verifiedOnly = false,
+    }) => VideoSourceVisibilityPolicy.isHiddenBySourcePreferences(
+      video,
+      divineHostedOnly: divineHostedOnly,
+      verifiedOnly: verifiedOnly,
+    );
+
+    test('hides nothing when both preferences are off', () {
+      expect(hidden(offHost), isFalse);
+      expect(hidden(divineHosted), isFalse);
+    });
+
+    test('hosting axis hides off-host media', () {
+      expect(hidden(offHost, divineHostedOnly: true), isTrue);
+      expect(hidden(divineHosted, divineHostedOnly: true), isFalse);
+    });
+
+    test('provenance axis hides media with no capture chain', () {
+      // Divine-hosted but unverified: the hosting axis alone would let this
+      // through, which is why the two axes are independent.
+      expect(hidden(divineHosted, verifiedOnly: true), isTrue);
+    });
+
+    test('axes are independent, not a single relaxed rule', () {
+      // Off-host is hidden by hosting even though provenance is off...
+      expect(hidden(offHost, divineHostedOnly: true), isTrue);
+      // ...and Divine-hosted is hidden by provenance even though hosting
+      // is satisfied. Neither axis can substitute for the other.
+      expect(hidden(divineHosted, verifiedOnly: true), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
Fixes #7892.

Two related changes: a second, independent source filter, and a video-detail panel that explains whichever filter hid a video instead of claiming it doesn't exist.

## 1. Two independent source axes

Hosting and provenance answer different questions:

- **Hosting** — where the media is served from, i.e. who can moderate or take it down.
- **Provenance** — whether it carries a capture chain (C2PA / ProofMode) tracing back to a camera.

A creator can publish verified media on their own host, and unverified media can sit on ours, so **neither axis implies the other** and one toggle cannot express both. Today only the hosting axis exists, which means a C2PA-verified clip on a third-party Blossom server is invisible to every user on defaults — the opposite of what the provenance pipeline is for.

Adds `VideoProvenanceFilterService` and a second Safety settings toggle, **"Only show camera-verified videos"**, default **off**.

The predicate moves into `VideoSourceVisibilityPolicy`, shared by the feed policy (`VideoEventService.shouldHideVideo`) and the repository content filter. They previously each spelled the hosting rule out separately, which is how the filter came to disagree with the **"Not Divine" badge** — `shouldShowNotDivineBadge` already treats ProofMode and Vine-archive content as distinct from plain off-host media, and the filter didn't.

### Numbers behind the design

| | count | share |
|---|---|---|
| Vine archive (`platform=vine`) | 2,159,653 | 97.6% of catalogue |
| Modern, C2PA-tagged | 39,152 | **86.8% of modern** |
| Modern, unverified | 5,961 | 13.2% of modern |

Two consequences:

- **Archive is exempt from the provenance axis.** Original Vines predate content credentials by a decade; without the exemption the preference would hide 97.6% of the catalogue. This is the same exemption `shouldShowNotDivineBadge` already carries.
- **Default off.** Enabling it by default would hide ~13% of modern uploads from users who never chose it.

`platform='vine'` and the NIP-32 label `l=vine-archive` agree on exactly 2,159,650 events with **zero divergence either way**, so `isOriginalVine` is a safe discriminator today. (`divine-context` `ARCHITECTURE.md:108` names the label as the canonical one; worth revisiting if they ever drift.)

## 2. Explain the filter instead of reporting "not found"

A video removed by a content filter and a video no source could supply both resolved to `null`, and `null` renders **"video not found"** — a dead end naming no cause, for a video that exists and plays.

`lookupVideoForRouteId` now returns found / hidden-by-filter / missing. `fetchVideoWithStatsForRouteId` delegates and keeps its `VideoEvent?` contract, so its three other callers are untouched.

The panel names **whichever axis is responsible** — hosting, provenance, or another content filter — so "Change setting" points at the setting that actually hid it, and never blames the wrong one. It also offers "Show it anyway", which reuses the video the lookup already carried (no refetch) and deliberately does **not** change the stored setting.

## Verification

- 43 tests in `video_detail_screen_test` (23 pre-existing migrated, since the screen now calls `lookupVideoForRouteId`), 15 in `safety_settings_screen_test`, plus new suites for both services and the shared policy.
- `videos_repository`: 498 tests, **100.00% line coverage (1260/1260)**.
- `flutter analyze lib test` clean.
- Ratchets pass: `orphaned_arb_key_floor`, `service_god_file_ceiling`, `untested_services_floor`, `l10n_delegates_ceiling`.

## Things worth a reviewer's attention

- **Copy for the new toggle is my wording, not product's.** `hasProofMode` covers ProofMode manifests, PGP fingerprints, device attestation *and* C2PA, so "camera-verified" may over- or under-claim.
- **`video_event_service.dart` grew 14 lines** (6566 → 6580, ceiling 6619). The predicate was extracted, but the field/setter/imports still cost lines in a frozen god-file. Under the ceiling, but it spends headroom rather than shrinking.
- **`video_proof_verification_summary` in ClickHouse is empty (0 rows).** The share figures above come from raw `c2pa_manifest_id` / `proofmode` tags on events, which is tag-*present*, not tag-*validated*. The client's `hasUsableC2paManifest` requires `c2pa_manifest_present && c2pa_manifest_valid != false`, so if that table is meant to be populated and isn't, the strict predicate could behave differently from these counts.
- **The `?? true` default on the hosting filter is unchanged.** Whether host filtering should be on by default is a product call this PR deliberately doesn't make.
- **This PR's scope grew** from the original messaging fix. The commits are separated so the two halves can be read independently.

## Not verified

I rendered the panel and looked at it (dark mode only) but have not run the app. No golden is committed — references have to be generated on the Ubuntu runner via `update_goldens`. Light mode is unchecked.
