### PR TITLE
fix(divine_ui): drop the text listener when DivineAuthTextField disposes

### DIFF
--- a/mobile/packages/divine_ui/lib/src/text_field/divine_auth_text_field.dart
+++ b/mobile/packages/divine_ui/lib/src/text_field/divine_auth_text_field.dart
@@ -199,6 +199,9 @@ class _DivineAuthTextFieldState extends State<DivineAuthTextField> {
   @override
   void dispose() {
     _focusNode.removeListener(_handleFocusChange);
+    // The caller's controller outlives this State, so the listener has to come
+    // off here — otherwise a later notification hits setState on a dead State.
+    _controller.removeListener(_handleTextChange);
     if (widget.focusNode == null) {
       _focusNode.dispose();
     }

--- a/mobile/packages/divine_ui/test/src/text_field/divine_auth_text_field_test.dart
+++ b/mobile/packages/divine_ui/test/src/text_field/divine_auth_text_field_test.dart
@@ -847,6 +847,23 @@ void main() {
       });
     });
 
+    group('dispose', () {
+      testWidgets('stops listening to a caller-owned controller', (
+        tester,
+      ) async {
+        final controller = TextEditingController();
+        addTearDown(controller.dispose);
+
+        await tester.pumpWidget(buildTestWidget(controller: controller));
+
+        // The caller keeps the controller; only the field leaves the tree.
+        await tester.pumpWidget(const MaterialApp(home: Scaffold()));
+        controller.text = 'typed after the field was disposed';
+
+        expect(tester.takeException(), isNull);
+      });
+    });
+
     testWidgets('renders a prefix affix inside the field', (tester) async {
       await tester.pumpWidget(
         const MaterialApp(


### PR DESCRIPTION
Closes #7949

## Description

Crashlytics has been recording `Null check operator used on a null value` as a
**fatal** on Android 1.0.20 (727):

```
at State.setState(framework.dart:1219)
at _DivineAuthTextFieldState._handleTextChange(divine_auth_text_field.dart:220)
at ChangeNotifier.notifyListeners(change_notifier.dart:435)
at TextEditingController.value=(editable_text.dart:292)
at EditableTextState.userUpdateTextEditingValue(editable_text.dart:5066)
at RenderEditable.selectPositionAt(editable.dart:2137)   // a plain tap
```

`framework.dart:1219` is `_element!.markNeedsBuild()`, so the `!` is on a
`State` whose element has already been unmounted — `setState` after `dispose`.

Root cause: `_DivineAuthTextFieldState.dispose()` removed the **focus**
listener but never the **controller** one. Every call site owns its
`TextEditingController` in the parent `State`, so the controller outlives the
field. The disposed `State` stayed subscribed, and the next notification ran
`setState` on it.

The teardown that arms it is ordinary: any time the element is destroyed while
the controller survives and a new element takes over the same controller. From
then on the dead listener throws on every later keystroke or tap on the live
field, and each teardown adds one more.

**Corrected after review** — hm21 pointed out my original mechanism was wrong,
and verifying it turned up a second trigger, so this section is rewritten.

No index shift is needed at all. The simple case is a field that sits *inside*
a conditional branch: toggling the condition removes the whole subtree, the
field unmounts, and a controller owned further up survives it. Two screens do
exactly that, and both are reachable in normal use:

**Settings → Nostr → NIP-05** (hm21's find). `_externalController` is created
once at `nip05_settings_screen.dart:93` and disposed only with the screen
(:112), while its field renders solely under
`if (editorState.nip05Mode == Nip05Mode.external_)` (:171). Every toggle away
unmounts the field and strands a listener; every toggle back mounts a new one
on the same controller. It does not even need a tap to fire — `:339` assigns
`_externalController.text`, and a `.text` setter notifies.

**Key import.** `_passwordController` is a `State` field at
`key_import_screen.dart:33`, and the password field renders only under
`if (_isEncryptedKey)` (:129). That flag is recomputed inside `setState` from
the *key* field's own `onChanged` (:116-125,
`Nip49.isEncryptedKey(value.trim())`). So it flips on ordinary typing — paste
an `ncryptsec1…` key and the field appears, correct or clear the paste and it
vanishes, stranding a listener each cycle. No deliberate toggle required.

For the record, what I got wrong: I scanned for a conditional *sibling before*
the field and concluded `create_account_screen.dart`'s `headerWidget` was the
only candidate. That heuristic cannot see a field nested inside the
conditional itself, which is the actual shape here. The `headerWidget` theory
was unproven and is dropped.

The other two gated sites are inert, and worth recording so nobody re-opens
them: `auth_form_scaffold.dart:194`'s `if (confirmPasswordController != null)`
never toggles because both callers always pass one, and
`reset_password.dart:195`'s `_hasEmail` derives from a route parameter.

It never hard-crashes the app: `ChangeNotifier.notifyListeners` catches per
listener and forwards to `FlutterError.onError`, which
`crash_reporting_service.dart:50` wires to `recordFlutterFatalError`. So each
throw lands in the dashboard as a fatal, one per event, and the leak compounds
with every teardown.

The fix is the missing `removeListener`, restoring the symmetry the focus node
already had. The regression test drops the field out of the tree while the
caller keeps the controller, then writes to it — it reproduced the crash before
the fix (`setState() called after dispose()`, the debug form of the same null
check) and passes after.

**Related Issue:** Relates to Crashlytics `ce1d327e3ce6f30c7593953c7138add4`

## Out of Scope

- `didUpdateWidget` drops the internally created `FocusNode` /
  `TextEditingController` on the floor when a caller starts supplying one, so
  those instances leak. Flutter's own `TextField` disposes the local controller
  at that point. No call site currently swaps either from null to non-null, and
  the safe shape for the focus node is a larger restructure, so it is left
  alone here rather than bundled into a crash fix.

## Verification

- `flutter test test/src/text_field/divine_auth_text_field_test.dart` — 44 pass
  (new test fails on `main`, passes here)
- `flutter test --coverage` in `packages/divine_ui` — 940 pass, 2288/2288 lines
  (100%, gate held)
- `flutter analyze lib test` in `packages/divine_ui` — clean
- `flutter test test/screens/auth/ test/widgets/auth/ test/screens/settings/account/` — 201 pass
- `dart format --set-exit-if-changed` — clean

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

