### PR TITLE
fix(video-editor): insert a duplicated clip next to its source

### DIFF
--- a/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls.dart
@@ -366,10 +366,11 @@ class _TimelineClipControlsState extends State<TimelineClipControls> {
     // build a repeat without dragging the copy back into place.
     final insertIndex = state.currentClipIndex + 1;
     final newClips = [...state.clips]..insert(insertIndex, copy);
-    // Markers on the source and earlier clips keep their positions; markers on
-    // later clips shift right by the copy's duration — the id-based rebase
-    // carries both, and persists them in the same history entry as the clip
-    // change.
+    // Markers strictly inside the source and earlier clips keep their
+    // positions; markers on later clips shift right by the copy's duration,
+    // as does one sitting exactly on the source's trailing seam, which
+    // anchors to the following clip. The id-based rebase carries both, and
+    // persists them in the same history entry as the clip change.
     final rebasedMarkers = rebaseTimelineMarkersForClipState(
       oldClips: state.clips,
       newClips: newClips,

--- a/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls.dart
@@ -361,10 +361,15 @@ class _TimelineClipControlsState extends State<TimelineClipControls> {
           '${DateTime.now().millisecondsSinceEpoch}',
     );
 
-    final newClips = [...state.clips, copy];
-    // The copy is appended at the end, so existing markers keep their
-    // positions; rebase for consistency and to persist markers in the
-    // same history entry as the clip change.
+    // The copy lands directly after its source rather than at the end of the
+    // timeline, matching the stop-motion frame duplicate and letting the user
+    // build a repeat without dragging the copy back into place.
+    final insertIndex = state.currentClipIndex + 1;
+    final newClips = [...state.clips]..insert(insertIndex, copy);
+    // Markers on the source and earlier clips keep their positions; markers on
+    // later clips shift right by the copy's duration — the id-based rebase
+    // carries both, and persists them in the same history entry as the clip
+    // change.
     final rebasedMarkers = rebaseTimelineMarkersForClipState(
       oldClips: state.clips,
       newClips: newClips,
@@ -372,12 +377,12 @@ class _TimelineClipControlsState extends State<TimelineClipControls> {
     );
 
     bloc
-      ..add(ClipEditorClipInserted(index: state.clips.length, clip: copy))
+      ..add(ClipEditorClipInserted(index: insertIndex, clip: copy))
       ..add(const ClipEditorEditingStopped());
 
     overlayBloc.add(TimelineMarkersRebased(rebasedMarkers));
-    // Appending the copy lengthens the composition, so a sound that covered
-    // the old end has to grow with it (#6401).
+    // The copy lengthens the composition, so a sound that covered the old end
+    // has to grow with it (#6401).
     editor.setLengthenedClipState(
       previousClips: state.clips,
       clips: newClips,

--- a/mobile/test/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls_test.dart
@@ -163,6 +163,118 @@ void main() {
       );
     }
 
+    // Stubs an editor whose history writes are captured rather than applied.
+    // [activeMeta] seeds the editor's current history entry, so a test that
+    // needs an existing sound passes its serialized audio key here.
+    void stubEditor({
+      required _MockProImageEditorState editor,
+      required _MockStateManager stateManager,
+      required _MockTimelineOverlayBloc overlayBloc,
+      Map<String, dynamic> activeMeta = const {},
+    }) {
+      when(() => overlayBloc.state).thenReturn(const TimelineOverlayState());
+      when(
+        () => overlayBloc.stream,
+      ).thenAnswer((_) => const Stream<TimelineOverlayState>.empty());
+      when(() => editor.stateManager).thenReturn(stateManager);
+      when(() => stateManager.activeMeta).thenReturn(activeMeta);
+      when(
+        () => editor.addHistory(
+          layers: any(named: 'layers'),
+          filters: any(named: 'filters'),
+          meta: any(named: 'meta'),
+          newLayer: any(named: 'newLayer'),
+          transformConfigs: any(named: 'transformConfigs'),
+          tuneAdjustments: any(named: 'tuneAdjustments'),
+          blur: any(named: 'blur'),
+          heroScreenshotRequired: any(named: 'heroScreenshotRequired'),
+          blockCaptureScreenshot: any(named: 'blockCaptureScreenshot'),
+        ),
+      ).thenAnswer((_) {});
+      when(() => editor.setState(any())).thenAnswer((invocation) {
+        (invocation.positionalArguments.single as VoidCallback)();
+      });
+    }
+
+    // Pumps the controls inside a VideoEditorScope backed by [editor]. Routed
+    // rather than a plain MaterialApp because the speed sheet confirms via
+    // `context.pop`.
+    Future<VideoEditorTimelineControls> pumpWithEditor(
+      WidgetTester tester, {
+      required _MockProImageEditorState editor,
+      required _MockTimelineOverlayBloc overlayBloc,
+      required ClipEditorState state,
+    }) async {
+      when(() => bloc.state).thenReturn(state);
+      await tester.pumpWidget(
+        ProviderScope(
+          child: MaterialApp.router(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            routerConfig: GoRouter(
+              routes: [
+                GoRoute(
+                  path: '/',
+                  builder: (context, routerState) => Scaffold(
+                    body: VideoEditorScope(
+                      editorKey: GlobalKey<ProImageEditorState>(),
+                      editorOverride: editor,
+                      removeAreaKey: GlobalKey(),
+                      originalClipAspectRatio: 9 / 16,
+                      bodySizeNotifier: ValueNotifier(const Size(400, 600)),
+                      zoomMatrixNotifier: ValueNotifier(Matrix4.identity()),
+                      playTimeNotifier: ValueNotifier(Duration.zero),
+                      fromLibrary: false,
+                      onOpenCamera: () {},
+                      onOpenClipsEditor: () {},
+                      onAddStickers: () {},
+                      onOpenMusicLibrary: () {},
+                      onOpenVoiceOver: () {},
+                      onOpenCaptions: () {},
+                      onAddEditTextLayer: ([layer]) async => null,
+                      child: MultiBlocProvider(
+                        providers: [
+                          BlocProvider<ClipEditorBloc>.value(value: bloc),
+                          BlocProvider<TimelineOverlayBloc>.value(
+                            value: overlayBloc,
+                          ),
+                        ],
+                        child: TimelineClipControls(
+                          playheadPosition: ValueNotifier(Duration.zero),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+      return tester.widget<VideoEditorTimelineControls>(
+        find.byType(VideoEditorTimelineControls),
+      );
+    }
+
+    // The meta of the single history entry [editor] was asked to commit.
+    Map<String, dynamic> capturedHistoryMeta(
+      _MockProImageEditorState editor,
+    ) =>
+        verify(
+              () => editor.addHistory(
+                layers: any(named: 'layers'),
+                filters: any(named: 'filters'),
+                meta: captureAny(named: 'meta'),
+                newLayer: any(named: 'newLayer'),
+                transformConfigs: any(named: 'transformConfigs'),
+                tuneAdjustments: any(named: 'tuneAdjustments'),
+                blur: any(named: 'blur'),
+                heroScreenshotRequired: any(named: 'heroScreenshotRequired'),
+                blockCaptureScreenshot: any(named: 'blockCaptureScreenshot'),
+              ),
+            ).captured.single
+            as Map<String, dynamic>;
+
     testWidgets('renders expected labels for single-clip state', (
       tester,
     ) async {
@@ -670,90 +782,31 @@ void main() {
       tester,
     ) async {
       final editor = _MockProImageEditorState();
-      final stateManager = _MockStateManager();
       final overlayBloc = _MockTimelineOverlayBloc();
-
-      when(() => overlayBloc.state).thenReturn(const TimelineOverlayState());
-      when(
-        () => overlayBloc.stream,
-      ).thenAnswer((_) => const Stream<TimelineOverlayState>.empty());
-      when(() => editor.stateManager).thenReturn(stateManager);
       // No audio key in the meta => no sound tracks, so the commit takes the
       // plain clip-state path.
-      when(() => stateManager.activeMeta).thenReturn(<String, dynamic>{});
-      when(
-        () => editor.addHistory(
-          layers: any(named: 'layers'),
-          filters: any(named: 'filters'),
-          meta: any(named: 'meta'),
-          newLayer: any(named: 'newLayer'),
-          transformConfigs: any(named: 'transformConfigs'),
-          tuneAdjustments: any(named: 'tuneAdjustments'),
-          blur: any(named: 'blur'),
-          heroScreenshotRequired: any(named: 'heroScreenshotRequired'),
-          blockCaptureScreenshot: any(named: 'blockCaptureScreenshot'),
-        ),
-      ).thenAnswer((_) {});
-      when(() => editor.setState(any())).thenAnswer((invocation) {
-        (invocation.positionalArguments.single as VoidCallback)();
-      });
+      stubEditor(
+        editor: editor,
+        stateManager: _MockStateManager(),
+        overlayBloc: overlayBloc,
+      );
 
-      when(() => bloc.state).thenReturn(
-        ClipEditorState(
+      final controls = await pumpWithEditor(
+        tester,
+        editor: editor,
+        overlayBloc: overlayBloc,
+        state: ClipEditorState(
           clips: [clip('clip-1'), clip('clip-2'), clip('clip-3')],
           currentClipIndex: 1,
         ),
       );
 
-      await tester.pumpWidget(
-        ProviderScope(
-          child: MaterialApp(
-            localizationsDelegates: AppLocalizations.localizationsDelegates,
-            supportedLocales: AppLocalizations.supportedLocales,
-            home: Scaffold(
-              body: VideoEditorScope(
-                editorKey: GlobalKey<ProImageEditorState>(),
-                editorOverride: editor,
-                removeAreaKey: GlobalKey(),
-                originalClipAspectRatio: 9 / 16,
-                bodySizeNotifier: ValueNotifier(const Size(400, 600)),
-                zoomMatrixNotifier: ValueNotifier(Matrix4.identity()),
-                playTimeNotifier: ValueNotifier(Duration.zero),
-                fromLibrary: false,
-                onOpenCamera: () {},
-                onOpenClipsEditor: () {},
-                onAddStickers: () {},
-                onOpenMusicLibrary: () {},
-                onOpenVoiceOver: () {},
-                onOpenCaptions: () {},
-                onAddEditTextLayer: ([layer]) async => null,
-                child: MultiBlocProvider(
-                  providers: [
-                    BlocProvider<ClipEditorBloc>.value(value: bloc),
-                    BlocProvider<TimelineOverlayBloc>.value(value: overlayBloc),
-                  ],
-                  child: TimelineClipControls(
-                    playheadPosition: ValueNotifier(Duration.zero),
-                  ),
-                ),
-              ),
-            ),
-          ),
-        ),
-      );
-
-      tester
-          .widget<VideoEditorTimelineControls>(
-            find.byType(VideoEditorTimelineControls),
-          )
-          .onDuplicated!();
+      controls.onDuplicated!();
       await tester.pump();
 
       final inserted =
           verify(
-                () => bloc.add(
-                  captureAny(that: isA<ClipEditorClipInserted>()),
-                ),
+                () => bloc.add(captureAny(that: isA<ClipEditorClipInserted>())),
               ).captured.single
               as ClipEditorClipInserted;
       expect(inserted.index, equals(2));
@@ -761,21 +814,7 @@ void main() {
 
       // The editor commit has to agree with the bloc event, or undo/redo and
       // the render would replay a different clip order than the timeline shows.
-      final meta =
-          verify(
-                () => editor.addHistory(
-                  layers: any(named: 'layers'),
-                  filters: any(named: 'filters'),
-                  meta: captureAny(named: 'meta'),
-                  newLayer: any(named: 'newLayer'),
-                  transformConfigs: any(named: 'transformConfigs'),
-                  tuneAdjustments: any(named: 'tuneAdjustments'),
-                  blur: any(named: 'blur'),
-                  heroScreenshotRequired: any(named: 'heroScreenshotRequired'),
-                  blockCaptureScreenshot: any(named: 'blockCaptureScreenshot'),
-                ),
-              ).captured.single
-              as Map<String, dynamic>;
+      final meta = capturedHistoryMeta(editor);
       final committed =
           (meta[VideoEditorConstants.clipsStateHistoryKey] as List<dynamic>)
               .cast<Map<String, dynamic>>()
@@ -791,7 +830,6 @@ void main() {
     // composition, and a sound clamped to the old end has to follow it.
     group('sound follows composition growth', () {
       late _MockProImageEditorState editor;
-      late _MockStateManager stateManager;
       late _MockTimelineOverlayBloc overlayBloc;
 
       final coveringSound = AudioEvent(
@@ -805,115 +843,21 @@ void main() {
 
       setUp(() {
         editor = _MockProImageEditorState();
-        stateManager = _MockStateManager();
         overlayBloc = _MockTimelineOverlayBloc();
-
-        when(() => overlayBloc.state).thenReturn(const TimelineOverlayState());
-        when(
-          () => overlayBloc.stream,
-        ).thenAnswer((_) => const Stream<TimelineOverlayState>.empty());
-        when(() => editor.stateManager).thenReturn(stateManager);
-        when(() => stateManager.activeMeta).thenReturn({
-          VideoEditorConstants.audioStateHistoryKey: [coveringSound.toJson()],
-        });
-        when(
-          () => editor.addHistory(
-            layers: any(named: 'layers'),
-            filters: any(named: 'filters'),
-            meta: any(named: 'meta'),
-            newLayer: any(named: 'newLayer'),
-            transformConfigs: any(named: 'transformConfigs'),
-            tuneAdjustments: any(named: 'tuneAdjustments'),
-            blur: any(named: 'blur'),
-            heroScreenshotRequired: any(named: 'heroScreenshotRequired'),
-            blockCaptureScreenshot: any(named: 'blockCaptureScreenshot'),
-          ),
-        ).thenAnswer((_) {});
-        when(() => editor.setState(any())).thenAnswer((invocation) {
-          (invocation.positionalArguments.single as VoidCallback)();
-        });
+        stubEditor(
+          editor: editor,
+          stateManager: _MockStateManager(),
+          overlayBloc: overlayBloc,
+          activeMeta: {
+            VideoEditorConstants.audioStateHistoryKey: [coveringSound.toJson()],
+          },
+        );
       });
 
-      Future<VideoEditorTimelineControls> pumpWithEditor(
-        WidgetTester tester, {
-        required ClipEditorState state,
-      }) async {
-        when(() => bloc.state).thenReturn(state);
-        // The speed sheet confirms via context.pop, so the harness needs a
-        // GoRouter rather than a plain MaterialApp.
-        await tester.pumpWidget(
-          ProviderScope(
-            child: MaterialApp.router(
-              localizationsDelegates: AppLocalizations.localizationsDelegates,
-              supportedLocales: AppLocalizations.supportedLocales,
-              routerConfig: GoRouter(
-                routes: [
-                  GoRoute(
-                    path: '/',
-                    builder: (context, state) => Scaffold(
-                      body: VideoEditorScope(
-                        editorKey: GlobalKey<ProImageEditorState>(),
-                        editorOverride: editor,
-                        removeAreaKey: GlobalKey(),
-                        originalClipAspectRatio: 9 / 16,
-                        bodySizeNotifier: ValueNotifier(const Size(400, 600)),
-                        zoomMatrixNotifier: ValueNotifier(Matrix4.identity()),
-                        playTimeNotifier: ValueNotifier(Duration.zero),
-                        fromLibrary: false,
-                        onOpenCamera: () {},
-                        onOpenClipsEditor: () {},
-                        onAddStickers: () {},
-                        onOpenMusicLibrary: () {},
-                        onOpenVoiceOver: () {},
-                        onOpenCaptions: () {},
-                        onAddEditTextLayer: ([layer]) async => null,
-                        child: MultiBlocProvider(
-                          providers: [
-                            BlocProvider<ClipEditorBloc>.value(value: bloc),
-                            BlocProvider<TimelineOverlayBloc>.value(
-                              value: overlayBloc,
-                            ),
-                          ],
-                          child: TimelineClipControls(
-                            playheadPosition: ValueNotifier(Duration.zero),
-                          ),
-                        ),
-                      ),
-                    ),
-                  ),
-                ],
-              ),
-            ),
-          ),
-        );
-        return tester.widget<VideoEditorTimelineControls>(
-          find.byType(VideoEditorTimelineControls),
-        );
-      }
-
       List<AudioEvent> capturedAudio() {
-        final meta =
-            verify(
-                  () => editor.addHistory(
-                    layers: any(named: 'layers'),
-                    filters: any(named: 'filters'),
-                    meta: captureAny(named: 'meta'),
-                    newLayer: any(named: 'newLayer'),
-                    transformConfigs: any(named: 'transformConfigs'),
-                    tuneAdjustments: any(named: 'tuneAdjustments'),
-                    blur: any(named: 'blur'),
-                    heroScreenshotRequired: any(
-                      named: 'heroScreenshotRequired',
-                    ),
-                    blockCaptureScreenshot: any(
-                      named: 'blockCaptureScreenshot',
-                    ),
-                  ),
-                ).captured.single
-                as Map<String, dynamic>;
-        final raw =
-            meta[VideoEditorConstants.audioStateHistoryKey] as List<dynamic>;
-        return raw
+        final meta = capturedHistoryMeta(editor);
+        return (meta[VideoEditorConstants.audioStateHistoryKey]
+                as List<dynamic>)
             .cast<Map<String, dynamic>>()
             .map(AudioEvent.fromJson)
             .toList();
@@ -923,6 +867,8 @@ void main() {
           'the copy', (tester) async {
         final controls = await pumpWithEditor(
           tester,
+          editor: editor,
+          overlayBloc: overlayBloc,
           state: ClipEditorState(clips: [clip('clip-1')]),
         );
 
@@ -936,6 +882,8 @@ void main() {
           'composition onto the stretched end', (tester) async {
         final controls = await pumpWithEditor(
           tester,
+          editor: editor,
+          overlayBloc: overlayBloc,
           state: ClipEditorState(clips: [clip('clip-1')]),
         );
 

--- a/mobile/test/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls_test.dart
@@ -663,6 +663,130 @@ void main() {
       },
     );
 
+    // The copy lands next to the clip it was made from, not at the end of the
+    // timeline: repeating a clip is the common case, and appending made the
+    // user drag the copy back past every following clip.
+    testWidgets('inserts the copy directly after the duplicated clip', (
+      tester,
+    ) async {
+      final editor = _MockProImageEditorState();
+      final stateManager = _MockStateManager();
+      final overlayBloc = _MockTimelineOverlayBloc();
+
+      when(() => overlayBloc.state).thenReturn(const TimelineOverlayState());
+      when(
+        () => overlayBloc.stream,
+      ).thenAnswer((_) => const Stream<TimelineOverlayState>.empty());
+      when(() => editor.stateManager).thenReturn(stateManager);
+      // No audio key in the meta => no sound tracks, so the commit takes the
+      // plain clip-state path.
+      when(() => stateManager.activeMeta).thenReturn(<String, dynamic>{});
+      when(
+        () => editor.addHistory(
+          layers: any(named: 'layers'),
+          filters: any(named: 'filters'),
+          meta: any(named: 'meta'),
+          newLayer: any(named: 'newLayer'),
+          transformConfigs: any(named: 'transformConfigs'),
+          tuneAdjustments: any(named: 'tuneAdjustments'),
+          blur: any(named: 'blur'),
+          heroScreenshotRequired: any(named: 'heroScreenshotRequired'),
+          blockCaptureScreenshot: any(named: 'blockCaptureScreenshot'),
+        ),
+      ).thenAnswer((_) {});
+      when(() => editor.setState(any())).thenAnswer((invocation) {
+        (invocation.positionalArguments.single as VoidCallback)();
+      });
+
+      when(() => bloc.state).thenReturn(
+        ClipEditorState(
+          clips: [clip('clip-1'), clip('clip-2'), clip('clip-3')],
+          currentClipIndex: 1,
+        ),
+      );
+
+      await tester.pumpWidget(
+        ProviderScope(
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: VideoEditorScope(
+                editorKey: GlobalKey<ProImageEditorState>(),
+                editorOverride: editor,
+                removeAreaKey: GlobalKey(),
+                originalClipAspectRatio: 9 / 16,
+                bodySizeNotifier: ValueNotifier(const Size(400, 600)),
+                zoomMatrixNotifier: ValueNotifier(Matrix4.identity()),
+                playTimeNotifier: ValueNotifier(Duration.zero),
+                fromLibrary: false,
+                onOpenCamera: () {},
+                onOpenClipsEditor: () {},
+                onAddStickers: () {},
+                onOpenMusicLibrary: () {},
+                onOpenVoiceOver: () {},
+                onOpenCaptions: () {},
+                onAddEditTextLayer: ([layer]) async => null,
+                child: MultiBlocProvider(
+                  providers: [
+                    BlocProvider<ClipEditorBloc>.value(value: bloc),
+                    BlocProvider<TimelineOverlayBloc>.value(value: overlayBloc),
+                  ],
+                  child: TimelineClipControls(
+                    playheadPosition: ValueNotifier(Duration.zero),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      tester
+          .widget<VideoEditorTimelineControls>(
+            find.byType(VideoEditorTimelineControls),
+          )
+          .onDuplicated!();
+      await tester.pump();
+
+      final inserted =
+          verify(
+                () => bloc.add(
+                  captureAny(that: isA<ClipEditorClipInserted>()),
+                ),
+              ).captured.single
+              as ClipEditorClipInserted;
+      expect(inserted.index, equals(2));
+      expect(inserted.clip.id, startsWith('clip-2_copy_'));
+
+      // The editor commit has to agree with the bloc event, or undo/redo and
+      // the render would replay a different clip order than the timeline shows.
+      final meta =
+          verify(
+                () => editor.addHistory(
+                  layers: any(named: 'layers'),
+                  filters: any(named: 'filters'),
+                  meta: captureAny(named: 'meta'),
+                  newLayer: any(named: 'newLayer'),
+                  transformConfigs: any(named: 'transformConfigs'),
+                  tuneAdjustments: any(named: 'tuneAdjustments'),
+                  blur: any(named: 'blur'),
+                  heroScreenshotRequired: any(named: 'heroScreenshotRequired'),
+                  blockCaptureScreenshot: any(named: 'blockCaptureScreenshot'),
+                ),
+              ).captured.single
+              as Map<String, dynamic>;
+      final committed =
+          (meta[VideoEditorConstants.clipsStateHistoryKey] as List<dynamic>)
+              .cast<Map<String, dynamic>>()
+              .map((json) => json['id'] as String)
+              .toList();
+      expect(committed[0], equals('clip-1'));
+      expect(committed[1], equals('clip-2'));
+      expect(committed[2], startsWith('clip-2_copy_'));
+      expect(committed[3], equals('clip-3'));
+    });
+
     // #6401 on the clip-edit paths: duplicate and speed-down lengthen the
     // composition, and a sound clamped to the old end has to follow it.
     group('sound follows composition growth', () {
@@ -796,7 +920,7 @@ void main() {
       }
 
       testWidgets('duplicate grows a sound that covered the composition onto '
-          'the appended copy', (tester) async {
+          'the copy', (tester) async {
         final controls = await pumpWithEditor(
           tester,
           state: ClipEditorState(clips: [clip('clip-1')]),

--- a/mobile/test/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls_test.dart
@@ -168,10 +168,10 @@ void main() {
     // needs an existing sound passes its serialized audio key here.
     void stubEditor({
       required _MockProImageEditorState editor,
-      required _MockStateManager stateManager,
       required _MockTimelineOverlayBloc overlayBloc,
       Map<String, dynamic> activeMeta = const {},
     }) {
+      final stateManager = _MockStateManager();
       when(() => overlayBloc.state).thenReturn(const TimelineOverlayState());
       when(
         () => overlayBloc.stream,
@@ -787,7 +787,6 @@ void main() {
       // plain clip-state path.
       stubEditor(
         editor: editor,
-        stateManager: _MockStateManager(),
         overlayBloc: overlayBloc,
       );
 
@@ -846,7 +845,6 @@ void main() {
         overlayBloc = _MockTimelineOverlayBloc();
         stubEditor(
           editor: editor,
-          stateManager: _MockStateManager(),
           overlayBloc: overlayBloc,
           activeMeta: {
             VideoEditorConstants.audioStateHistoryKey: [coveringSound.toJson()],

--- a/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_geometry_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_geometry_test.dart
@@ -591,6 +591,23 @@ void main() {
       );
     });
 
+    test('shifts later markers right when a copy is inserted mid-timeline', () {
+      // Mirrors the clip-duplication call site: the copy lands directly
+      // after its source, so markers on later clips move right by the
+      // copy's duration while earlier markers stay put.
+      final oldClips = [_clip('a', 3), _clip('b', 5)];
+      final newClips = [_clip('a', 3), _clip('a_copy', 3), _clip('b', 5)];
+
+      expect(
+        rebaseTimelineMarkersForClipState(
+          oldClips: oldClips,
+          newClips: newClips,
+          markers: [const Duration(seconds: 1), const Duration(seconds: 6)],
+        ),
+        equals([const Duration(seconds: 1), const Duration(seconds: 9)]),
+      );
+    });
+
     test('keeps earlier markers in place when a clip is appended', () {
       // Mirrors the clip-duplication call site: the copy is added at the
       // end, so markers on the existing clips must not move.

--- a/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_geometry_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_geometry_test.dart
@@ -609,8 +609,9 @@ void main() {
     });
 
     test('keeps earlier markers in place when a clip is appended', () {
-      // Mirrors the clip-duplication call site: the copy is added at the
-      // end, so markers on the existing clips must not move.
+      // A clip added at the end leaves every existing clip's start time
+      // alone, so markers on them must not move. The duplicate call site
+      // now inserts after the source; see the mid-timeline case above.
       final oldClips = [_clip('a', 3), _clip('b', 5)];
       final newClips = [_clip('a', 3), _clip('b', 5), _clip('a_copy', 3)];
 


### PR DESCRIPTION
Closes #7956

## Description

Duplicating a clip appended the copy to the very end of the timeline. To actually repeat a clip — the reason people hit Duplicate — the user then had to drag the copy back past every clip that followed it. The copy now lands directly after the clip it was made from.

This also makes the two duplicate paths consistent: the stop-motion **frame** duplicate in the same file already inserted the copy next to the selected still, only the clip path appended.

The insert index changes in both the `ClipEditorClipInserted` event and the editor history commit, so undo/redo and the render replay the same order the timeline shows.

Nothing downstream needed adjusting, and the reasons are worth stating because each looked like it might:

- **Markers** — `rebaseTimelineMarkersForClipState` resolves markers through clip *ids*, not absolute time, so markers on the source and earlier clips stay put while markers on later clips shift right by the copy's duration. The stale comment claiming the copy is appended is updated.
- **Sound** — `setLengthenedClipState` compares total composition duration before and after, which is unaffected by *where* the clip lands, so a sound that covered the old end still grows onto the new one (#6401). Anchored audio follows its clip by id.
- **Selection** — inserting *after* the selected index leaves `currentClipIndex` pointing at the original, so there is no index fixup.
- **Transitions** — `DivineVideoClip.transition` is "how this clip transitions into the **next** one", so the original now transitions into its copy and the copy into whatever followed. Duplicating the last clip is unchanged (`index + 1 == length`), which keeps the loop-restart wrap on the end.

A second commit is test-only cleanup: the new insert-position test hand-rolled the mock stubbing, the `VideoEditorScope` pump and the `addHistory` meta capture that the existing "sound follows composition growth" group already had, so the same ~55 lines of scaffolding sat twice in one file. `stubEditor` / `pumpWithEditor` / `capturedHistoryMeta` are now shared by both call sites, and the file is 50 lines smaller than before this PR added to it.

## Out of Scope

Selection stays on the original clip rather than moving to the copy, matching the previous behaviour. Moving it to the copy is a separate UX call.

## Verification

- Manually verified on a real Samsung Galaxy device: duplicating a middle clip puts the copy immediately after it, playback order and sound are correct, and undo restores the original timeline.
- Added a regression test asserting both the dispatched `ClipEditorClipInserted(index: 2)` and the committed clip order (`clip-1, clip-2, clip-2_copy_…, clip-3`) for a 3-clip timeline with the middle clip selected. Re-confirmed after the harness extraction that it still goes red against the old append behaviour.
- `flutter test test/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls_test.dart` — 27/27 pass.
- `flutter test test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart` — 158/158 pass; mid-list insert and index clamping were already covered there.
- `flutter analyze lib test integration_test` — no issues.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
