### PR TITLE
fix(relay): stop sign-out from leaving a relay connection open forever

### DIFF
--- a/mobile/packages/nostr_client/lib/src/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/src/nostr_client.dart
@@ -1800,6 +1800,11 @@ class NostrClient {
   /// must check [isDisposed] (or their own ownership signal) before using
   /// the client.
   Future<void> dispose() async {
+    // Before the first await: every await below is a window in which an armed
+    // relay repair can fire and open a socket that the teardown at the end has
+    // already walked past, leaving a live WebSocket and heartbeat timer nothing
+    // can reach (#7367).
+    _nostr.beginClose();
     await closeAllSubscriptions();
     await _relayManager.dispose();
     await _queryPool.close();

--- a/mobile/packages/nostr_client/test/src/nostr_client_test.dart
+++ b/mobile/packages/nostr_client/test/src/nostr_client_test.dart
@@ -139,6 +139,7 @@ void main() {
 
       // Set up default mock behavior
       when(() => mockNostr.publicKey).thenReturn(testPublicKey);
+      when(() => mockNostr.beginClose()).thenReturn(null);
       when(() => mockNostr.close()).thenReturn(null);
       when(() => mockRelayManager.dispose()).thenAnswer((_) async {});
       // Default to having connected relays (tests can override if needed)
@@ -3775,6 +3776,22 @@ void main() {
         await client.dispose();
 
         verify(() => mockNostr.unsubscribe(any())).called(1);
+        verify(() => mockNostr.close()).called(1);
+      });
+
+      test('marks the relay pool as closing before its first await', () async {
+        when(() => mockNostr.unsubscribe(any())).thenReturn(null);
+
+        final disposing = client.dispose();
+
+        // Asserted before awaiting, so it pins the ordering rather than just
+        // the call: every await below this point in dispose() is a window in
+        // which an armed relay repair could open a socket that the teardown
+        // at the end has already walked past (#7367).
+        verify(() => mockNostr.beginClose()).called(1);
+        verifyNever(() => mockNostr.close());
+
+        await disposing;
         verify(() => mockNostr.close()).called(1);
       });
     });

--- a/mobile/packages/nostr_sdk/lib/nostr.dart
+++ b/mobile/packages/nostr_sdk/lib/nostr.dart
@@ -275,7 +275,19 @@ class Nostr {
     return null;
   }
 
+  /// Marks the relay pool as closing so nothing opens another socket while
+  /// the owner works its way through the rest of its teardown.
+  ///
+  /// [close] is the real teardown; this only has to run first, before the
+  /// owner's first await. See [RelayPool.beginClose].
+  void beginClose() {
+    _pool.beginClose();
+  }
+
   void close() {
+    // Idempotent, and already done by an owner that called [beginClose] first;
+    // repeated here so a direct [close] closes the same window.
+    _pool.beginClose();
     _pool.removeAll();
     nostrSigner.close();
   }

--- a/mobile/packages/nostr_sdk/lib/relay/relay_base.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_base.dart
@@ -28,6 +28,15 @@ class RelayBase extends Relay {
   /// Tracks whether doConnect is in progress to avoid duplicate onConnected calls
   bool _isConnecting = false;
 
+  /// Whether [dispose] has run.
+  ///
+  /// [doConnect] creates the connection manager lazily, so without this a
+  /// connect on a disposed relay would mint a *fresh* manager — one the
+  /// manager's own disposed guard cannot catch, because that guard lives on
+  /// the instance [dispose] threw away. The socket and heartbeat timer it
+  /// opened would then belong to a relay nothing references (#7367).
+  bool _disposed = false;
+
   bool _connectionIsFresh = true;
 
   @override
@@ -35,6 +44,11 @@ class RelayBase extends Relay {
 
   @override
   Future<bool> doConnect() async {
+    if (_disposed) {
+      log("connect refused: $url - relay is disposed");
+      return false;
+    }
+
     // If already connected, return true
     if (_connectionManager != null && _connectionManager!.isConnected) {
       log("connect break: $url - already connected");
@@ -260,6 +274,7 @@ class RelayBase extends Relay {
 
   @override
   void dispose() {
+    _disposed = true;
     _stateSubscription?.cancel();
     _messageSubscription?.cancel();
     _errorSubscription?.cancel();

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -599,6 +599,7 @@ class RelayPool {
 
   /// Whether the pool is closing or closed, and therefore must not open any
   /// further sockets.
+  @visibleForTesting
   bool get isClosed => _closed;
 
   /// Marks the pool as closing without tearing anything down yet.

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -192,6 +192,9 @@ class RelayPool {
   /// Armed silence probes, keyed by subscription id.
   final Map<String, Timer> _subscriptionSilenceProbes = {};
 
+  /// Whether teardown has begun. See [beginClose].
+  bool _closed = false;
+
   /// One-shot queries at least one relay has already answered.
   ///
   /// Sticky for the query's lifetime rather than a property of the call that
@@ -534,6 +537,7 @@ class RelayPool {
     bool init = false,
     int relayType = RelayType.normal,
   }) async {
+    if (_closed) return false;
     if (relayType == RelayType.normal) {
       if (_relays.containsKey(relay.url)) {
         return true;
@@ -593,6 +597,38 @@ class RelayPool {
     return list;
   }
 
+  /// Whether the pool is closing or closed, and therefore must not open any
+  /// further sockets.
+  bool get isClosed => _closed;
+
+  /// Marks the pool as closing without tearing anything down yet.
+  ///
+  /// [removeAll] is what actually disposes the relays, but an owner reaches it
+  /// only after a sequence of awaits (see `NostrClient.dispose`). Every one of
+  /// those awaits is a window in which an armed repair can fire and call
+  /// `connect()`; the socket and heartbeat timer it opens then outlive the
+  /// [removeAll] that was supposed to close them, because the relay holding
+  /// them is disposed a moment later and nothing can reach them again (#7367).
+  /// Calling this first closes that window: the probes are disarmed and every
+  /// path that could start a connection turns into a no-op.
+  void beginClose() {
+    if (_closed) return;
+    _closed = true;
+    _cancelSilenceProbes();
+  }
+
+  void _cancelSilenceProbes() {
+    for (final probe in _subscriptionSilenceProbes.values) {
+      probe.cancel();
+    }
+    _subscriptionSilenceProbes.clear();
+  }
+
+  /// Removes every relay from the pool.
+  ///
+  /// This is teardown when reached through [Nostr.close], but it is also a
+  /// legitimate "start over with a different relay set" — so it deliberately
+  /// does not mark the pool closed. [beginClose] is what does that.
   void removeAll() {
     final keys = _relayKeysSnapshot();
     for (var url in keys) {
@@ -608,10 +644,7 @@ class RelayPool {
     _tempRelaySweepTimer = null;
     // Nothing left to repair, and a probe outliving the pool would fire into
     // an empty relay set on every armed subscription.
-    for (final probe in _subscriptionSilenceProbes.values) {
-      probe.cancel();
-    }
-    _subscriptionSilenceProbes.clear();
+    _cancelSilenceProbes();
   }
 
   /// Drops the pool-side state keyed by [url] so a relay that comes back is
@@ -1229,6 +1262,7 @@ class RelayPool {
   ///   relay that is already connected or connecting.
   void _probeSubscriptionSilence(String subId) {
     _subscriptionSilenceProbes.remove(subId);
+    if (_closed) return;
     if (!_subscriptions.containsKey(subId)) return;
     final sentAt = _subscriptionSentAt[subId];
     if (sentAt == null) return;
@@ -1259,6 +1293,7 @@ class RelayPool {
   }
 
   Future<void> _reconnectDroppedRelay(Relay relay) async {
+    if (_closed) return;
     try {
       await relay.connect();
     } catch (e) {
@@ -1835,10 +1870,12 @@ class RelayPool {
     }
 
     _subscriptionSilenceProbes[subscription.id]?.cancel();
-    _subscriptionSilenceProbes[subscription.id] = Timer(
-      subscriptionSilenceProbe,
-      () => _probeSubscriptionSilence(subscription.id),
-    );
+    if (!_closed) {
+      _subscriptionSilenceProbes[subscription.id] = Timer(
+        subscriptionSilenceProbe,
+        () => _probeSubscriptionSilence(subscription.id),
+      );
+    }
 
     return subscription.id;
   }
@@ -2546,6 +2583,7 @@ class RelayPool {
   /// connection so the next attempt runs on a live socket; the reconnect
   /// re-issues the relay's saved REQs (see [Relay.onConnected]).
   void _repairSilentRelays(List<String> silentRelayUrls, DateTime sentAt) {
+    if (_closed) return;
     final now = DateTime.now();
     for (final url in silentRelayUrls) {
       final relay = _relays[url] ?? _cacheRelays[url] ?? _tempRelays[url];
@@ -2574,6 +2612,7 @@ class RelayPool {
   /// subscriptions and pending one-shot queries on the fresh connection, so an
   /// in-flight REQ that the closed socket swallowed still runs.
   Future<void> _reconnectSilentRelay(RelayBase relay) async {
+    if (_closed) return;
     try {
       await relay.forceReconnect();
     } catch (e) {
@@ -2582,6 +2621,7 @@ class RelayPool {
   }
 
   void reconnect() {
+    if (_closed) return;
     for (final relay in _relaysSnapshot()) {
       relay.connect();
     }
@@ -2604,7 +2644,7 @@ class RelayPool {
       // Temp relays serve one-shot queries like any other relay, so they need
       // the same drop-releases-the-query sweep [add] wires up.
       _observeRelayStatus(tempRelay);
-      tempRelay.connect();
+      if (!_closed) tempRelay.connect();
       _tempRelays[addr] = tempRelay;
       _ensureTempRelaySweepScheduled();
     }
@@ -2613,6 +2653,7 @@ class RelayPool {
   }
 
   void _ensureTempRelaySweepScheduled() {
+    if (_closed) return;
     if (_tempRelaySweepTimer != null) return;
     _tempRelaySweepTimer = Timer.periodic(
       tempRelaySweepInterval,

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -1294,6 +1294,11 @@ class RelayPool {
     }
   }
 
+  /// Connects [relay] so a REQ queued while it was down is actually written.
+  ///
+  /// As with [_reconnectSilentRelay], the closed-check cannot be reached on
+  /// its own — [_probeSubscriptionSilence] is the only caller and it already
+  /// refuses on a closed pool — and is kept for a future caller's benefit.
   Future<void> _reconnectDroppedRelay(Relay relay) async {
     if (_closed) return;
     try {
@@ -2613,6 +2618,12 @@ class RelayPool {
   /// Force-cycles [relay]'s socket. [Relay.onConnected] re-issues the saved
   /// subscriptions and pending one-shot queries on the fresh connection, so an
   /// in-flight REQ that the closed socket swallowed still runs.
+  ///
+  /// The closed-check is belt and braces, not a second line of defence that
+  /// can be reached on its own: [_repairSilentRelays] is the only caller and
+  /// it checks the same flag with no suspension point in between. It is kept
+  /// so a future second caller inherits the refusal rather than having to
+  /// remember it.
   Future<void> _reconnectSilentRelay(RelayBase relay) async {
     if (_closed) return;
     try {
@@ -2653,6 +2664,12 @@ class RelayPool {
 
     return tempRelay;
   }
+
+  /// Whether the idle-temp-relay sweep is armed. Tests assert on this to
+  /// prove teardown leaves no `Timer.periodic` behind, which is the shape
+  /// that strands into an unrelated later suite under a merged isolate.
+  @visibleForTesting
+  bool get hasTempRelaySweepScheduled => _tempRelaySweepTimer != null;
 
   void _ensureTempRelaySweepScheduled() {
     if (_closed) return;

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -627,9 +627,10 @@ class RelayPool {
 
   /// Removes every relay from the pool.
   ///
-  /// This is teardown when reached through [Nostr.close], but it is also a
-  /// legitimate "start over with a different relay set" — so it deliberately
-  /// does not mark the pool closed. [beginClose] is what does that.
+  /// This on its own does not mark the pool closed, so a direct caller can
+  /// use it to start over with a different relay set. Reaching it through
+  /// [Nostr.close] is terminal instead, because that calls [beginClose]
+  /// first and nothing reopens a closed pool.
   void removeAll() {
     final keys = _relayKeysSnapshot();
     for (var url in keys) {

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -1869,7 +1869,7 @@ class RelayPool {
       }
     }
 
-    _subscriptionSilenceProbes[subscription.id]?.cancel();
+    _subscriptionSilenceProbes.remove(subscription.id)?.cancel();
     if (!_closed) {
       _subscriptionSilenceProbes[subscription.id] = Timer(
         subscriptionSilenceProbe,

--- a/mobile/packages/nostr_sdk/lib/relay/web_socket_connection_manager.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/web_socket_connection_manager.dart
@@ -141,13 +141,6 @@ class WebSocketConnectionManager {
   /// Whether currently connected
   bool get isConnected => _state == ConnectionState.connected;
 
-  /// Whether [dispose] has been called.
-  ///
-  /// A disposed manager never opens another socket: its streams are closed
-  /// and the relay that owned it has already dropped its reference, so
-  /// anything it connected would be unreachable and therefore uncloseable.
-  bool get isDisposed => _disposed;
-
   /// Number of reconnection attempts made
   int get reconnectAttempts => _reconnectAttempts;
 
@@ -314,9 +307,7 @@ class WebSocketConnectionManager {
 
   void _onStreamError(dynamic error) {
     log('Stream error: $error');
-    if (!_errorController.isClosed) {
-      _errorController.add('Stream error: $error');
-    }
+    _emitError('Stream error: $error');
     _handleDisconnect();
   }
 
@@ -429,7 +420,7 @@ class WebSocketConnectionManager {
       return true;
     } catch (e) {
       log('Send error: $e');
-      _errorController.add('Send error: $e');
+      _emitError('Send error: $e');
       _handleDisconnect();
       return false;
     }
@@ -448,7 +439,7 @@ class WebSocketConnectionManager {
       encoded = jsonEncode(data);
     } catch (e) {
       log('JSON encode error: $e');
-      _errorController.add('JSON encode error: $e');
+      _emitError('JSON encode error: $e');
       return false;
     }
 
@@ -467,7 +458,7 @@ class WebSocketConnectionManager {
       if (_deadlineExpired(deadline)) return false;
       if (_reconnectAttempts >= config.maxReconnectAttempts) {
         log('Max reconnect attempts reached for $url');
-        _errorController.add('Max reconnect attempts reached');
+        _emitError('Max reconnect attempts reached');
         return false;
       }
 

--- a/mobile/packages/nostr_sdk/lib/relay/web_socket_connection_manager.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/web_socket_connection_manager.dart
@@ -115,7 +115,6 @@ class WebSocketConnectionManager {
   bool _disposed = false;
 
   // Timers
-  Timer? _reconnectTimer;
   Timer? _heartbeatTimer;
 
   // Activity tracking for idle detection
@@ -235,8 +234,6 @@ class WebSocketConnectionManager {
 
       _setState(ConnectionState.connected);
       _reconnectAttempts = 0;
-      _reconnectTimer?.cancel();
-      _reconnectTimer = null;
 
       // Track connection time as initial activity
       _lastActivityAt = DateTime.now();
@@ -334,8 +331,6 @@ class WebSocketConnectionManager {
   /// Disconnect from the WebSocket server
   Future<void> disconnect() async {
     _shouldReconnect = false;
-    _reconnectTimer?.cancel();
-    _reconnectTimer = null;
     _stopHeartbeat();
 
     await _closeChannel();
@@ -545,8 +540,6 @@ class WebSocketConnectionManager {
   /// Reset reconnection state, allowing fresh attempts
   void resetReconnection() {
     _reconnectAttempts = 0;
-    _reconnectTimer?.cancel();
-    _reconnectTimer = null;
   }
 
   /// Force immediate reconnection, resetting backoff

--- a/mobile/packages/nostr_sdk/lib/relay/web_socket_connection_manager.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/web_socket_connection_manager.dart
@@ -558,6 +558,11 @@ class WebSocketConnectionManager {
 
     resetReconnection();
     _shouldReconnect = true;
+    // Neither resetReconnection nor _closeChannel touches the heartbeat, so
+    // without this a reconnect that fails leaves the previous connection's
+    // Timer.periodic running with nothing to beat on. disconnect() and
+    // _handleDisconnect both stop it; this is the sibling that did not.
+    _stopHeartbeat();
     await _closeChannel();
     _setState(ConnectionState.disconnected);
     return _doConnect();

--- a/mobile/packages/nostr_sdk/lib/relay/web_socket_connection_manager.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/web_socket_connection_manager.dart
@@ -171,7 +171,7 @@ class WebSocketConnectionManager {
   /// Connect to the WebSocket server
   Future<bool> connect() async {
     if (_disposed) {
-      log('Connect refused: $url manager is disposed');
+      log('Connect refused: $url - manager is disposed');
       return false;
     }
 
@@ -191,7 +191,7 @@ class WebSocketConnectionManager {
 
   Future<bool> _doConnect() async {
     if (_disposed) {
-      log('Connect refused: $url manager is disposed');
+      log('Connect refused: $url - manager is disposed');
       return false;
     }
 
@@ -545,7 +545,7 @@ class WebSocketConnectionManager {
   /// Force immediate reconnection, resetting backoff
   Future<bool> reconnect() async {
     if (_disposed) {
-      log('Reconnect refused: $url manager is disposed');
+      log('Reconnect refused: $url - manager is disposed');
       return false;
     }
 

--- a/mobile/packages/nostr_sdk/lib/relay/web_socket_connection_manager.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/web_socket_connection_manager.dart
@@ -110,6 +110,10 @@ class WebSocketConnectionManager {
   int _reconnectAttempts = 0;
   bool _shouldReconnect = true;
 
+  /// Set by [dispose] before its first await, so a connect that is already
+  /// in flight can tell that its owner is gone by the time it resumes.
+  bool _disposed = false;
+
   // Timers
   Timer? _reconnectTimer;
   Timer? _heartbeatTimer;
@@ -136,6 +140,13 @@ class WebSocketConnectionManager {
 
   /// Whether currently connected
   bool get isConnected => _state == ConnectionState.connected;
+
+  /// Whether [dispose] has been called.
+  ///
+  /// A disposed manager never opens another socket: its streams are closed
+  /// and the relay that owned it has already dropped its reference, so
+  /// anything it connected would be unreachable and therefore uncloseable.
+  bool get isDisposed => _disposed;
 
   /// Number of reconnection attempts made
   int get reconnectAttempts => _reconnectAttempts;
@@ -167,6 +178,11 @@ class WebSocketConnectionManager {
 
   /// Connect to the WebSocket server
   Future<bool> connect() async {
+    if (_disposed) {
+      log('Connect refused: $url manager is disposed');
+      return false;
+    }
+
     if (_state == ConnectionState.connected) {
       log('Already connected to $url');
       return true;
@@ -182,8 +198,14 @@ class WebSocketConnectionManager {
   }
 
   Future<bool> _doConnect() async {
+    if (_disposed) {
+      log('Connect refused: $url manager is disposed');
+      return false;
+    }
+
     _setState(ConnectionState.connecting);
 
+    WebSocketChannel? channel;
     try {
       final uri = Uri.parse(url);
       if (uri.scheme != 'ws' && uri.scheme != 'wss') {
@@ -191,16 +213,27 @@ class WebSocketConnectionManager {
       }
 
       log('Connecting to $url');
-      _channel = _channelFactory.create(uri);
+      channel = _channelFactory.create(uri);
+      _channel = channel;
 
       // Wait for the WebSocket handshake to complete. Without this,
       // IOWebSocketChannel.connect() returns immediately and DNS/TLS
       // failures surface as unhandled async errors in the zone instead
       // of being caught here.
-      await _channel!.ready.timeout(config.connectionTimeout);
+      await channel.ready.timeout(config.connectionTimeout);
+
+      // A dispose, a disconnect, or a newer connect can all run inside the
+      // handshake window, and each of them detaches this channel. Adopting it
+      // anyway would arm a heartbeat `Timer.periodic` and hold a live socket
+      // that no owner can reach — so nothing could ever close either (#7367).
+      if (_disposed || !identical(_channel, channel)) {
+        log('Discarding socket for $url: its owner went away mid-handshake');
+        await _closeOrphanedChannel(channel);
+        return false;
+      }
 
       // Set up message listener
-      _channelSubscription = _channel!.stream.listen(
+      _channelSubscription = channel.stream.listen(
         _onMessage,
         onError: _onStreamError,
         onDone: _onStreamDone,
@@ -223,27 +256,50 @@ class WebSocketConnectionManager {
       return true;
     } on WebSocketChannelException catch (e) {
       log('Connection failed (WebSocket): $e');
-      _errorController.add('Connection failed: $e');
-      _channel = null;
+      _emitError('Connection failed: $e');
+      _detachChannel(channel);
       _setState(ConnectionState.disconnected);
       return false;
     } on TimeoutException {
       log('Connection timed out after ${config.connectionTimeout}');
-      _errorController.add('Connection timed out');
+      _emitError('Connection timed out');
       // Clean up the channel that never finished connecting
-      try {
-        await _channel?.sink.close();
-      } catch (_) {}
-      _channel = null;
+      await _closeOrphanedChannel(channel);
+      _detachChannel(channel);
       _setState(ConnectionState.disconnected);
       return false;
     } catch (e) {
       log('Connection failed: $e');
-      _errorController.add('Connection failed: $e');
-      _channel = null;
+      _emitError('Connection failed: $e');
+      _detachChannel(channel);
       _setState(ConnectionState.disconnected);
       return false;
     }
+  }
+
+  /// Clears [_channel] unless something else already installed a different
+  /// one, so a failing connect cannot null out a channel it does not own.
+  ///
+  /// A null [channel] means creation itself failed and there is no attempt
+  /// left to keep — the field is cleared, as it always was.
+  void _detachChannel(WebSocketChannel? channel) {
+    if (channel == null || identical(_channel, channel)) _channel = null;
+  }
+
+  /// Closes a socket that no longer has an owner.
+  Future<void> _closeOrphanedChannel(WebSocketChannel? channel) async {
+    if (channel == null) return;
+    try {
+      await channel.sink.close();
+    } catch (e) {
+      log('Error closing orphaned channel: $e');
+    }
+  }
+
+  /// Publishes to [errorStream] unless teardown already closed it.
+  void _emitError(String message) {
+    if (_errorController.isClosed) return;
+    _errorController.add(message);
   }
 
   void _onMessage(dynamic message) {
@@ -504,6 +560,11 @@ class WebSocketConnectionManager {
 
   /// Force immediate reconnection, resetting backoff
   Future<bool> reconnect() async {
+    if (_disposed) {
+      log('Reconnect refused: $url manager is disposed');
+      return false;
+    }
+
     resetReconnection();
     _shouldReconnect = true;
     await _closeChannel();
@@ -569,7 +630,11 @@ class WebSocketConnectionManager {
   }
 
   /// Dispose of resources
+  ///
+  /// [_disposed] is set before the first await so a connect that is already
+  /// in flight sees it the moment it resumes.
   Future<void> dispose() async {
+    _disposed = true;
     await disconnect();
     await _stateController.close();
     await _messageController.close();

--- a/mobile/packages/nostr_sdk/test/support/fake_web_socket.dart
+++ b/mobile/packages/nostr_sdk/test/support/fake_web_socket.dart
@@ -74,6 +74,10 @@ class FakeWebSocketChannel implements WebSocketChannel {
   void simulateMessage(dynamic message) => _streamController.add(message);
 
   List<dynamic> get sentMessages => _sink.messages;
+
+  /// Whether the sink was closed — i.e. whether the socket this channel
+  /// stands for was actually shut down rather than left open.
+  bool get isClosed => _sink.closed;
 }
 
 class FakeWebSocketChannelFactory implements WebSocketChannelFactory {

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_teardown_race_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_teardown_race_test.dart
@@ -16,12 +16,18 @@ void main() {
 
     late Nostr nostr;
     late FakeWebSocketChannelFactory factory;
+    late FakeWebSocketChannelFactory tempFactory;
 
     Future<void> setUpPool({Object? initialConnectError}) async {
       final signer = LocalNostrSigner(
         '5ee1c8000ab28edd64d74a7d951ac2dd559814887b1b9e1ac7c5f89e96125c12',
       );
-      nostr = Nostr(signer, [], (url) => RelayBase(url, RelayStatus(url)));
+      tempFactory = FakeWebSocketChannelFactory();
+      nostr = Nostr(
+        signer,
+        [],
+        (url) => RelayBase(url, RelayStatus(url), channelFactory: tempFactory),
+      );
       await nostr.refreshPublicKey();
       factory = FakeWebSocketChannelFactory(readyError: initialConnectError);
       await nostr.relayPool.add(
@@ -60,24 +66,60 @@ void main() {
       );
     });
 
-    test('the whole teardown window leaves no socket open', () async {
+    // The probes are the repair trigger that `beginClose` disarms outright,
+    // so nothing timer-driven survives into the window. This one does: it is
+    // reached straight off `unsubscribe`, which is what the first await of
+    // `NostrClient.dispose()` — `closeAllSubscriptions()` — spends its time
+    // doing. Without the flag the pool force-reconnects the relay it is in
+    // the middle of tearing down.
+    test('closing subscriptions inside the window repairs nothing', () async {
+      await setUpPool();
+      // The relay answered nothing since the REQ, which is what marks it as a
+      // half-open zombie worth force-cycling.
+      nostr.relayPool.minSubscriptionAgeBeforeRepair = Duration.zero;
+      final subId = subscribeToFeed();
+      await Future<void>.delayed(Duration.zero);
+
+      nostr.relayPool.beginClose();
+      nostr.unsubscribe(subId);
+      await Future<void>.delayed(afterProbe);
+
+      expect(
+        factory.createdChannels,
+        hasLength(1),
+        reason:
+            'the repair would force-reconnect a relay that removeAll() is '
+            'about to dispose, stranding the fresh socket and its heartbeat',
+      );
+    });
+
+    // A query that lands during teardown routes through a temp relay, which
+    // both dials the address and arms the pool-wide idle sweep.
+    test('a temp relay minted inside the window connects nothing', () async {
+      await setUpPool();
+      nostr.relayPool.beginClose();
+
+      nostr.relayPool.checkAndGenTempRelay(otherUrl);
+      await Future<void>.delayed(afterProbe);
+
+      expect(tempFactory.createdChannels, isEmpty);
+      expect(
+        nostr.relayPool.hasTempRelaySweepScheduled,
+        isFalse,
+        reason: 'a periodic sweep armed here outlives the pool that armed it',
+      );
+    });
+
+    test('teardown leaves no live socket behind', () async {
       await setUpPool();
       subscribeToFeed();
       await Future<void>.delayed(Duration.zero);
 
-      // dispose(): beginClose() before the first await, then the awaits, then
-      // the teardown that actually disposes the relays.
       nostr.relayPool.beginClose();
-      await Future<void>.delayed(afterProbe);
       nostr.relayPool.removeAll();
       await Future<void>.delayed(afterProbe);
 
-      expect(factory.createdChannels, hasLength(1));
-      expect(
-        factory.createdChannels.single.isClosed,
-        isTrue,
-        reason: 'dispose must leave no live socket behind',
-      );
+      expect(factory.createdChannels.single.isClosed, isTrue);
     });
 
     test('a subscription issued after teardown began arms no probe', () async {

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_teardown_race_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_teardown_race_test.dart
@@ -134,6 +134,28 @@ void main() {
       );
     });
 
+    test('Nostr.close() leaves the pool closed to new connections', () async {
+      await setUpPool();
+
+      nostr.close();
+
+      expect(nostr.relayPool.isClosed, isTrue);
+
+      final lateFactory = FakeWebSocketChannelFactory();
+      final added = await nostr.relayPool.add(
+        RelayBase(otherUrl, RelayStatus(otherUrl), channelFactory: lateFactory),
+      );
+
+      expect(added, isFalse);
+      expect(
+        lateFactory.createdChannels,
+        isEmpty,
+        reason:
+            'close() is what marks the pool terminally closed, so a '
+            'relay added afterwards must not open a socket',
+      );
+    });
+
     test('add() after teardown began does not connect the relay', () async {
       await setUpPool();
       nostr.relayPool.beginClose();

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_teardown_race_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_teardown_race_test.dart
@@ -110,14 +110,14 @@ void main() {
     // `Relay` reference — `checkAndGenTempRelay` and `getRelay` both hand one
     // out — must not be able to bring a dead relay back to life.
     test('a disposed relay opens no further socket', () async {
-      final factory = FakeWebSocketChannelFactory();
+      final relayFactory = FakeWebSocketChannelFactory();
       final relay = RelayBase(
         relayUrl,
         RelayStatus(relayUrl),
-        channelFactory: factory,
+        channelFactory: relayFactory,
       );
       expect(await relay.connect(), isTrue);
-      expect(factory.createdChannels, hasLength(1));
+      expect(relayFactory.createdChannels, hasLength(1));
 
       relay.dispose();
 
@@ -126,7 +126,7 @@ void main() {
       expect(await relay.forceReconnect(), isFalse);
       expect(await relay.connect(), isFalse);
       expect(
-        factory.createdChannels,
+        relayFactory.createdChannels,
         hasLength(1),
         reason:
             'a socket opened by a disposed relay has no owner left to '

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_teardown_race_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_teardown_race_test.dart
@@ -105,6 +105,35 @@ void main() {
       expect(factory.createdChannels, hasLength(1));
     });
 
+    // The pool drops a relay from every map at the moment it disposes it, so
+    // this is the belt to the pool flag's braces: a caller that still holds a
+    // `Relay` reference — `checkAndGenTempRelay` and `getRelay` both hand one
+    // out — must not be able to bring a dead relay back to life.
+    test('a disposed relay opens no further socket', () async {
+      final factory = FakeWebSocketChannelFactory();
+      final relay = RelayBase(
+        relayUrl,
+        RelayStatus(relayUrl),
+        channelFactory: factory,
+      );
+      expect(await relay.connect(), isTrue);
+      expect(factory.createdChannels, hasLength(1));
+
+      relay.dispose();
+
+      // forceReconnect falls through to connect() once dispose has dropped
+      // the connection manager, and connect() used to create a brand new one.
+      expect(await relay.forceReconnect(), isFalse);
+      expect(await relay.connect(), isFalse);
+      expect(
+        factory.createdChannels,
+        hasLength(1),
+        reason:
+            'a socket opened by a disposed relay has no owner left to '
+            'close it, and neither has the heartbeat timer it arms',
+      );
+    });
+
     test('add() after teardown began does not connect the relay', () async {
       await setUpPool();
       nostr.relayPool.beginClose();

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_teardown_race_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_teardown_race_test.dart
@@ -1,0 +1,121 @@
+// ABOUTME: Regression tests for repairs that race the pool's teardown and used
+// ABOUTME: to leave an orphaned socket plus heartbeat timer behind (#7367).
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nostr_sdk/nostr_sdk.dart';
+
+import '../support/fake_web_socket.dart';
+
+void main() {
+  group('RelayPool teardown race', () {
+    const relayUrl = 'wss://relay.divine.video';
+    const otherUrl = 'wss://other.divine.video';
+    const probe = Duration(milliseconds: 20);
+    // Comfortably past [probe] plus the reconnect's own async hops.
+    const afterProbe = Duration(milliseconds: 80);
+
+    late Nostr nostr;
+    late FakeWebSocketChannelFactory factory;
+
+    Future<void> setUpPool({Object? initialConnectError}) async {
+      final signer = LocalNostrSigner(
+        '5ee1c8000ab28edd64d74a7d951ac2dd559814887b1b9e1ac7c5f89e96125c12',
+      );
+      nostr = Nostr(signer, [], (url) => RelayBase(url, RelayStatus(url)));
+      await nostr.refreshPublicKey();
+      factory = FakeWebSocketChannelFactory(readyError: initialConnectError);
+      await nostr.relayPool.add(
+        RelayBase(relayUrl, RelayStatus(relayUrl), channelFactory: factory),
+      );
+      nostr.relayPool.subscriptionSilenceProbe = probe;
+    }
+
+    String subscribeToFeed() => nostr.subscribe([
+      {
+        'kinds': [34236],
+      },
+    ], (_) {});
+
+    test('a probe armed before teardown is disarmed and opens no '
+        'socket', () async {
+      await setUpPool();
+      final subId = subscribeToFeed();
+      await Future<void>.delayed(Duration.zero);
+      expect(nostr.relayPool.armedSilenceProbeSubscriptionIds, [subId]);
+
+      // The owner's dispose() has begun. removeAll() is several awaits away,
+      // and the probe would otherwise fire inside that window.
+      nostr.relayPool.beginClose();
+
+      expect(nostr.relayPool.isClosed, isTrue);
+      expect(nostr.relayPool.armedSilenceProbeSubscriptionIds, isEmpty);
+
+      await Future<void>.delayed(afterProbe);
+      expect(
+        factory.createdChannels,
+        hasLength(1),
+        reason:
+            'a socket opened inside the teardown window outlives the '
+            'removeAll() that was supposed to close it',
+      );
+    });
+
+    test('the whole teardown window leaves no socket open', () async {
+      await setUpPool();
+      subscribeToFeed();
+      await Future<void>.delayed(Duration.zero);
+
+      // dispose(): beginClose() before the first await, then the awaits, then
+      // the teardown that actually disposes the relays.
+      nostr.relayPool.beginClose();
+      await Future<void>.delayed(afterProbe);
+      nostr.relayPool.removeAll();
+      await Future<void>.delayed(afterProbe);
+
+      expect(factory.createdChannels, hasLength(1));
+      expect(
+        factory.createdChannels.single.isClosed,
+        isTrue,
+        reason: 'dispose must leave no live socket behind',
+      );
+    });
+
+    test('a subscription issued after teardown began arms no probe', () async {
+      await setUpPool();
+      nostr.relayPool.beginClose();
+
+      subscribeToFeed();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(nostr.relayPool.armedSilenceProbeSubscriptionIds, isEmpty);
+      await Future<void>.delayed(afterProbe);
+      expect(factory.createdChannels, hasLength(1));
+    });
+
+    test('reconnect() after teardown began opens no socket', () async {
+      // The relay never connected, so a reconnect would open a fresh socket.
+      await setUpPool(initialConnectError: Exception('connect failed'));
+      expect(factory.createdChannels, hasLength(1));
+      factory.readyError = null;
+
+      nostr.relayPool.beginClose();
+      nostr.relayPool.reconnect();
+      await Future<void>.delayed(afterProbe);
+
+      expect(factory.createdChannels, hasLength(1));
+    });
+
+    test('add() after teardown began does not connect the relay', () async {
+      await setUpPool();
+      nostr.relayPool.beginClose();
+
+      final lateFactory = FakeWebSocketChannelFactory();
+      final added = await nostr.relayPool.add(
+        RelayBase(otherUrl, RelayStatus(otherUrl), channelFactory: lateFactory),
+      );
+
+      expect(added, isFalse);
+      expect(lateFactory.createdChannels, isEmpty);
+    });
+  });
+}

--- a/mobile/packages/nostr_sdk/test/unit/web_socket_connection_manager_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/web_socket_connection_manager_test.dart
@@ -662,7 +662,7 @@ void main() {
           );
 
           expect(await reconnecting.connect(), isTrue);
-          expect(armed(), 1, reason: 'the connect arms the heartbeat');
+          expect(armed(), equals(1), reason: 'the connect arms the heartbeat');
 
           // A relay that has gone quiet gets force-reconnected, and on a bad
           // network that reconnect is the one most likely to fail.
@@ -766,40 +766,42 @@ void main() {
         expect(manager.state, equals(ConnectionState.disconnected));
       });
 
-      test('a handshake superseded by a newer connect closes its own '
-          'socket', () async {
-        final gate = Completer<void>();
-        mockFactory.readyGate = gate;
+      test(
+        'a handshake superseded by a newer connect is not adopted',
+        () async {
+          final gate = Completer<void>();
+          mockFactory.readyGate = gate;
 
-        final superseded = manager.connect();
-        await Future<void>.delayed(Duration.zero);
-        final supersededChannel = mockFactory.lastChannel!;
+          final superseded = manager.connect();
+          await Future<void>.delayed(Duration.zero);
+          final supersededChannel = mockFactory.lastChannel!;
 
-        // A newer connect lands while the first handshake is still parked,
-        // and takes ownership of the manager.
-        mockFactory.readyGate = null;
-        expect(await manager.reconnect(), isTrue);
-        expect(mockFactory.createdChannels, hasLength(2));
-        final owner = mockFactory.lastChannel!;
+          // A newer connect lands while the first handshake is still parked,
+          // and takes ownership of the manager.
+          mockFactory.readyGate = null;
+          expect(await manager.reconnect(), isTrue);
+          expect(mockFactory.createdChannels, hasLength(2));
+          final owner = mockFactory.lastChannel!;
 
-        gate.complete();
+          gate.complete();
 
-        expect(
-          await superseded,
-          isFalse,
-          reason: 'the newer connect owns the manager now',
-        );
+          expect(
+            await superseded,
+            isFalse,
+            reason: 'the newer connect owns the manager now',
+          );
 
-        // Adopting the stale channel would repoint the message subscription
-        // at a socket nobody is writing to.
-        final received = <dynamic>[];
-        manager.messageStream.listen(received.add);
-        owner.simulateMessage('still listening to the live socket');
-        await Future<void>.delayed(Duration.zero);
+          // Adopting the stale channel would repoint the message subscription
+          // at a socket nobody is writing to.
+          final received = <dynamic>[];
+          manager.messageStream.listen(received.add);
+          owner.simulateMessage('still listening to the live socket');
+          await Future<void>.delayed(Duration.zero);
 
-        expect(received, equals(['still listening to the live socket']));
-        expect(supersededChannel.isClosed, isTrue);
-      });
+          expect(received, equals(['still listening to the live socket']));
+          expect(supersededChannel.isClosed, isTrue);
+        },
+      );
 
       test('a handshake that completes after dispose closes its own '
           'socket', () async {

--- a/mobile/packages/nostr_sdk/test/unit/web_socket_connection_manager_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/web_socket_connection_manager_test.dart
@@ -128,6 +128,10 @@ class MockWebSocketChannelFactory implements WebSocketChannelFactory {
   /// instead of succeeding. Simulates DNS/TLS handshake failures.
   Object? readyError;
 
+  /// When set, the channel's `ready` stays pending until this completes.
+  /// A real handshake is a network round trip that other work can run inside.
+  Completer<void>? readyGate;
+
   @override
   WebSocketChannel create(Uri uri) {
     if (shouldFail) {
@@ -136,7 +140,7 @@ class MockWebSocketChannelFactory implements WebSocketChannelFactory {
     final channel = MockWebSocketChannel(
       readyFuture: readyError != null
           ? Future.error(readyError!)
-          : Future.value(),
+          : (readyGate?.future ?? Future.value()),
     );
     createdChannels.add(channel);
     return channel;
@@ -150,6 +154,7 @@ class MockWebSocketChannelFactory implements WebSocketChannelFactory {
     shouldFail = false;
     failureMessage = null;
     readyError = null;
+    readyGate = null;
   }
 }
 
@@ -656,6 +661,61 @@ void main() {
         await Future.delayed(Duration.zero);
 
         expect(stateStreamClosed, isTrue);
+      });
+
+      // A connect that is already in flight when dispose runs would otherwise
+      // finish onto a manager nobody holds a reference to any more, arming a
+      // heartbeat `Timer.periodic` on a socket nothing can ever close (#7367).
+      test('a reconnect that resumes after dispose opens no socket', () async {
+        await manager.connect();
+        final closeGate = mockFactory.lastChannel!.blockClose();
+
+        // Parks inside reconnect's own close of the old channel.
+        final reconnecting = manager.reconnect();
+        await Future<void>.delayed(Duration.zero);
+
+        // The owner tears the manager down while the reconnect is parked.
+        await manager.dispose();
+        closeGate.complete();
+
+        expect(await reconnecting, isFalse);
+        expect(
+          mockFactory.createdChannels,
+          hasLength(1),
+          reason: 'a disposed manager must not open another socket',
+        );
+        expect(manager.state, equals(ConnectionState.disconnected));
+      });
+
+      test('a handshake that completes after dispose closes its own '
+          'socket', () async {
+        final factory = MockWebSocketChannelFactory();
+        final gate = Completer<void>();
+        factory.readyGate = gate;
+        final racing = WebSocketConnectionManager(
+          url: 'wss://test.relay.com',
+          channelFactory: factory,
+          logger: logMessages.add,
+        );
+
+        final connecting = racing.connect();
+        await Future<void>.delayed(Duration.zero);
+        final orphan = factory.lastChannel!;
+
+        await racing.dispose();
+        gate.complete();
+
+        expect(
+          await connecting,
+          isFalse,
+          reason: 'the handshake has no owner left to hand the socket to',
+        );
+        expect(orphan.isClosed, isTrue);
+        expect(
+          racing.state,
+          isNot(equals(ConnectionState.connected)),
+          reason: 'reaching connected is what arms the heartbeat timer',
+        );
       });
     });
   });

--- a/mobile/packages/nostr_sdk/test/unit/web_socket_connection_manager_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/web_socket_connection_manager_test.dart
@@ -158,6 +158,56 @@ class MockWebSocketChannelFactory implements WebSocketChannelFactory {
   }
 }
 
+/// Runs [body] in a zone that counts the periodic timers currently armed.
+///
+/// The heartbeat is a `Timer.periodic` with no accessor, and it does nothing
+/// observable while the connection is down, so counting the timers the zone
+/// hands out is the only way to see one survive a failed reconnect.
+Future<void> countingPeriodicTimers(
+  Future<void> Function(int Function() armed) body,
+) {
+  var armed = 0;
+  return runZoned(
+    () => body(() => armed),
+    zoneSpecification: ZoneSpecification(
+      createPeriodicTimer: (self, parent, zone, period, callback) {
+        armed++;
+        late final _CountingTimer wrapper;
+        final inner = parent.createPeriodicTimer(
+          zone,
+          period,
+          (_) => callback(wrapper),
+        );
+        wrapper = _CountingTimer(inner, () => armed--);
+        return wrapper;
+      },
+    ),
+  );
+}
+
+class _CountingTimer implements Timer {
+  _CountingTimer(this._inner, this._onCancel);
+
+  final Timer _inner;
+  final void Function() _onCancel;
+  bool _cancelled = false;
+
+  @override
+  void cancel() {
+    if (!_cancelled) {
+      _cancelled = true;
+      _onCancel();
+    }
+    _inner.cancel();
+  }
+
+  @override
+  bool get isActive => _inner.isActive;
+
+  @override
+  int get tick => _inner.tick;
+}
+
 void main() {
   group('WebSocketConnectionManager', () {
     late MockWebSocketChannelFactory mockFactory;
@@ -600,6 +650,33 @@ void main() {
         expect(mockFactory.createdChannels.length, equals(2));
         expect(mockFactory.lastChannel, isNot(equals(firstChannel)));
         expect(manager.isConnected, isTrue);
+      });
+
+      test('a failed reconnect does not leave the heartbeat armed', () async {
+        await countingPeriodicTimers((armed) async {
+          final factory = MockWebSocketChannelFactory();
+          final reconnecting = WebSocketConnectionManager(
+            url: 'wss://test.relay.com',
+            channelFactory: factory,
+            logger: logMessages.add,
+          );
+
+          expect(await reconnecting.connect(), isTrue);
+          expect(armed(), 1, reason: 'the connect arms the heartbeat');
+
+          // A relay that has gone quiet gets force-reconnected, and on a bad
+          // network that reconnect is the one most likely to fail.
+          factory.shouldFail = true;
+          expect(await reconnecting.reconnect(), isFalse);
+
+          expect(
+            armed(),
+            isZero,
+            reason: 'the old heartbeat has no connection left to beat on',
+          );
+
+          await reconnecting.dispose();
+        });
       });
 
       test('does not reconnect after explicit disconnect', () async {

--- a/mobile/packages/nostr_sdk/test/unit/web_socket_connection_manager_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/web_socket_connection_manager_test.dart
@@ -743,7 +743,9 @@ void main() {
       // A connect that is already in flight when dispose runs would otherwise
       // finish onto a manager nobody holds a reference to any more, arming a
       // heartbeat `Timer.periodic` on a socket nothing can ever close (#7367).
-      test('a reconnect that resumes after dispose opens no socket', () async {
+      // The reconnect here is only how the connect gets parked; what refuses
+      // on resume is _doConnect's own guard, not reconnect's entry guard.
+      test('a connect in flight when dispose runs opens no socket', () async {
         await manager.connect();
         final closeGate = mockFactory.lastChannel!.blockClose();
 

--- a/mobile/packages/nostr_sdk/test/unit/web_socket_connection_manager_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/web_socket_connection_manager_test.dart
@@ -764,6 +764,41 @@ void main() {
         expect(manager.state, equals(ConnectionState.disconnected));
       });
 
+      test('a handshake superseded by a newer connect closes its own '
+          'socket', () async {
+        final gate = Completer<void>();
+        mockFactory.readyGate = gate;
+
+        final superseded = manager.connect();
+        await Future<void>.delayed(Duration.zero);
+        final supersededChannel = mockFactory.lastChannel!;
+
+        // A newer connect lands while the first handshake is still parked,
+        // and takes ownership of the manager.
+        mockFactory.readyGate = null;
+        expect(await manager.reconnect(), isTrue);
+        expect(mockFactory.createdChannels, hasLength(2));
+        final owner = mockFactory.lastChannel!;
+
+        gate.complete();
+
+        expect(
+          await superseded,
+          isFalse,
+          reason: 'the newer connect owns the manager now',
+        );
+
+        // Adopting the stale channel would repoint the message subscription
+        // at a socket nobody is writing to.
+        final received = <dynamic>[];
+        manager.messageStream.listen(received.add);
+        owner.simulateMessage('still listening to the live socket');
+        await Future<void>.delayed(Duration.zero);
+
+        expect(received, equals(['still listening to the live socket']));
+        expect(supersededChannel.isClosed, isTrue);
+      });
+
       test('a handshake that completes after dispose closes its own '
           'socket', () async {
         final factory = MockWebSocketChannelFactory();


### PR DESCRIPTION
## Description

Signing out, switching accounts, or otherwise tearing down the app's Nostr stack could leave a live network connection to a relay open for the rest of the process, together with a repeating timer ticking against it. By the time either existed, nothing owned them any more — so nothing could ever close them. The user had left that relay behind; the phone kept talking to it and kept waking up for it. In the test suite the same leak shows up as a stranded timer that fails an unrelated later suite, because CI runs every untagged mobile test inside one shared isolate.

The cause is a gap in teardown. Shutting the client down is a sequence of steps, and only the last of them actually closes relays. Everything before it is a window in which the relay pool's own self-repair machinery — the watchdogs that reconnect a relay that has gone quiet — could still fire and open a fresh connection. The step meant to close that connection had already run, so the socket and its heartbeat timer were orphaned the instant the connect finished.

Concretely: `NostrClient.dispose()` reaches `RelayPool.removeAll()` only after three awaits (`closeAllSubscriptions()`, `_relayManager.dispose()`, `_queryPool.close()`), and `RelayPool` armed nothing against that gap. A silence probe or a silent-relay repair firing inside it called `connect()`; `removeAll()` then disposed the relay a moment later, and the connect still in flight finished onto a manager nothing held a reference to any more — arming a heartbeat `Timer.periodic` on a live WebSocket that no owner could ever close.

## Why this shape of fix

**Pool-level flag, not a per-callsite guard.** `RelayPool` gets `_closed`, set by a new `beginClose()` that `NostrClient.dispose()` calls **before its first await** — a flag set at `removeAll()` would still leave the window it is meant to close wide open. Every path that can initiate a connection checks it: the silence-probe callback, `_repairSilentRelays`, `_reconnectSilentRelay` (the `forceReconnect` caller), `_reconnectDroppedRelay`, `reconnect()`, `add()`, the temp-relay connect, and the temp-relay sweep timer. New probes are no longer armed once the pool is closing.

`removeAll()` deliberately does **not** set the flag. It is also a legitimate "start over with a different relay set" — `relay_pool_publish_targets_test.dart` uses it exactly that way — so `Nostr.close()` is what marks the pool terminally closed, and `removeAll()` keeps its old meaning.

**A second net in `WebSocketConnectionManager`,** because a check at repair-start is necessary but not sufficient: a `connect()` that began legitimately just before the flag was set still completes after it. `dispose()` now sets `_disposed` synchronously before its own first await, and `connect()` / `reconnect()` / `_doConnect()` refuse afterwards. Critically, `_doConnect()` re-checks after the handshake whether it still owns the channel it opened (`_disposed || !identical(_channel, channel)`) and closes that socket instead of adopting it — so `_setState(connected)` and `_startHeartbeat()` are never reached for an orphan. The channel handle now travels through a local variable, so a failing connect can no longer null out the channel a later connect already installed.

**A third net in `RelayBase`,** which closes the one hole the first two cannot see. `RelayBase.doConnect()` creates its connection manager lazily (`_connectionManager ??= …`) and `dispose()` drops that reference, so a connect on a *disposed* relay used to mint a **brand-new** manager — one whose `_disposed` flag is false, because the flag lives on the instance `dispose()` threw away. `RelayBase.forceReconnect()` reaches it directly: with no manager left it falls through to `connect()`. `RelayBase` now records its own `_disposed` and refuses in `doConnect()`. The pool flag hides this today because `removeAll()` drops a relay from every map at the moment it disposes it, but `Relay` is a public SDK type that callers hold — `checkAndGenTempRelay` and `getRelay` both hand one out — so the invariant "a disposed relay never opens a socket" is worth making total rather than incidental.

`RelayManager.forceReconnectAll()` needs no separate guard: it funnels through `_connectToRelay` → `RelayPool.add`, which the flag already covers.

Tidying in the same file: every publish to the connection manager's error stream now goes through the `_emitError` close guard. Six call sites still added to the controller raw, which throws if teardown closed it first.

## Out of Scope

`checkAndGenTempRelay` still registers the temp-relay entry after `beginClose()`; it just does not connect it. No socket, no timer — only a dead map entry, collected by the `removeAll()` at the end of the same `dispose()`. Leaving it that way keeps the method's non-nullable `Relay` return contract intact.

**Related Issue:** Closes #7367

## Verification

- New `mobile/packages/nostr_sdk/test/unit/relay_pool_teardown_race_test.dart` (6 tests): a probe armed before teardown is disarmed and opens no socket; the full teardown window leaves no socket open; a subscription issued after teardown arms no probe; `reconnect()` and `add()` after teardown open nothing; a disposed relay opens no further socket.
- Two new tests in `web_socket_connection_manager_test.dart`: a reconnect parked on its own channel close and resuming after `dispose()` opens no socket; a handshake completing after `dispose()` closes its own socket and never reaches `connected` (which is the only path that arms the heartbeat).
- One new test in `nostr_client_test.dart` asserting `beginClose()` ran *before* `dispose()`'s first await — `verify` is called on the un-awaited future, so it pins the ordering rather than just the call.
- Every test was confirmed red with the guard it names neutralised, and the pool guards are pinned one at a time rather than by removing `beginClose()` wholesale:
  - `add()` and `reconnect()` each fail their own test alone.
  - The repair path reached from `unsubscribe()` fails once **both** its checks are removed — `_repairSilentRelays` and `_reconnectSilentRelay` sit on one call chain with no suspension point between them, so either alone still refuses. The run records a second socket to a relay `removeAll()` is about to dispose.
  - The temp-relay connect and the idle-sweep timer each fail alone.
  - `_probeSubscriptionSilence` and `_reconnectDroppedRelay` are **not** pinned. `beginClose()` cancels the probe timers synchronously, so on a closed pool neither line is reachable; both are kept for a future caller and say so in a comment.
- Removing `_disposed` fails the in-flight-connect test; removing the post-handshake ownership check makes `connect()` return `true`, i.e. reproduces the adopted orphan socket; removing the `RelayBase` guard makes `forceReconnect()` on a disposed relay return `true`, i.e. reproduces the freshly minted orphan manager.
- `flutter test packages/nostr_sdk/test packages/nostr_client/test` — 911 passing.
- `flutter analyze packages/nostr_sdk packages/nostr_client` and `flutter analyze lib test integration_test` — clean.
- `dart format --set-exit-if-changed` over both packages — clean.
- Ratchet guards run locally: `check_file_size_ceiling`, `check_empty_catch_ceiling`, `check_raw_logging`, `check_todos`, `check_skip_ceiling`, `check_future_delayed_ceiling`, `check_future_delayed_production_ceiling`, `check_test_unit_structure`, `check_package_flutter_boundary`, `check_package_coverage_floor`, `check_package_ci_floor`, `check_service_sentinel_ceiling`, `check_process_global_mutations` — all green.

Not device-verified on the Samsung Galaxy: this is a Dart-level lifecycle race with no user-visible surface, and the leak it fixes is only observable as a stranded timer/socket.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

