### PR TITLE
fix(editor): stop imported Vines from ending early with the music still playing

### DIFF
--- a/mobile/lib/services/video_clip_import_service.dart
+++ b/mobile/lib/services/video_clip_import_service.dart
@@ -314,10 +314,12 @@ class VideoClipImportService {
     return const Duration(seconds: 6);
   }
 
-  /// Probes the copied file once for the metadata the import needs.
+  /// Probes the copied file once for the duration and resolution the import
+  /// needs.
   ///
-  /// Returns `null` when the probe fails, leaving callers on the values
-  /// advertised in the Nostr event.
+  /// Returns `null` when the probe fails, leaving both to the event's own
+  /// `duration` and `dim` tags — and to their defaults when it carries
+  /// neither.
   Future<VideoMetadata?> _probeMetadata(File copiedVideo) async {
     try {
       return await _readVideoMetadata(EditorVideo.file(copiedVideo.path));

--- a/mobile/lib/services/video_clip_import_service.dart
+++ b/mobile/lib/services/video_clip_import_service.dart
@@ -128,7 +128,6 @@ class VideoClipImportService {
 
     final importedAt = _now();
     final clipId = _clipIdFor(video, importedAt);
-    final duration = _durationFor(video);
 
     try {
       await Directory(documentsPath).create(recursive: true);
@@ -137,6 +136,9 @@ class VideoClipImportService {
         documentsPath,
         clipId,
       );
+
+      final metadata = await _probeMetadata(copiedVideo);
+      final duration = _durationFor(video, metadata);
 
       final thumbnail = await _extractThumbnail(
         videoPath: copiedVideo.path,
@@ -147,7 +149,7 @@ class VideoClipImportService {
         videoDuration: duration,
       );
 
-      final actualRatio = await _resolveAspectRatio(video, copiedVideo);
+      final actualRatio = _resolveAspectRatio(video, metadata);
 
       final clip = DivineVideoClip(
         id: clipId,
@@ -292,12 +294,41 @@ class VideoClipImportService {
     return '${prefix}_${safeStableId}_${importedAt.microsecondsSinceEpoch}';
   }
 
-  Duration _durationFor(models.VideoEvent video) {
+  /// Resolves the clip's duration, preferring the measured file over the
+  /// event's `duration` tag.
+  ///
+  /// The tag cannot be trusted: every Vine archive import advertises a
+  /// hardcoded `duration 6` regardless of the real length, which measures
+  /// anywhere from 5.201s to 6.548s. The value becomes the export's segment
+  /// end, so a wrong one truncates the clip, and on Android — which has no
+  /// track-end trim — leaves custom audio playing past the last video frame,
+  /// freezing it until the loop restarts (#7920).
+  Duration _durationFor(models.VideoEvent video, VideoMetadata? metadata) {
+    final measured = metadata?.duration;
+    if (measured != null && measured > Duration.zero) return measured;
+
     final seconds = video.duration;
     if (seconds != null && seconds > 0) {
       return Duration(seconds: seconds);
     }
     return const Duration(seconds: 6);
+  }
+
+  /// Probes the copied file once for the metadata the import needs.
+  ///
+  /// Returns `null` when the probe fails, leaving callers on the values
+  /// advertised in the Nostr event.
+  Future<VideoMetadata?> _probeMetadata(File copiedVideo) async {
+    try {
+      return await _readVideoMetadata(EditorVideo.file(copiedVideo.path));
+    } catch (e) {
+      Log.warning(
+        'Failed to read video metadata for ${copiedVideo.path}: $e',
+        name: _logName,
+        category: LogCategory.video,
+      );
+      return null;
+    }
   }
 
   Duration _thumbnailTimestampFor(Duration duration) {
@@ -322,34 +353,22 @@ class VideoClipImportService {
 
   /// Resolves the real aspect ratio of the source video.
   ///
-  /// Prefers the dimensions advertised in the Nostr event. Falls back to
-  /// probing the downloaded file with [ProVideoEditor.getMetadata] when the
-  /// event has no usable `dim` tag (common for own uploads that bypass the
-  /// transcoding pipeline).
-  Future<double?> _resolveAspectRatio(
+  /// Prefers the dimensions advertised in the Nostr event, falling back to the
+  /// probed [metadata] when the event has no usable `dim` tag (common for own
+  /// uploads that bypass the transcoding pipeline).
+  double? _resolveAspectRatio(
     models.VideoEvent video,
-    File copiedVideo,
-  ) async {
+    VideoMetadata? metadata,
+  ) {
     final fromEvent = _aspectRatioFor(video);
     if (fromEvent != null) return fromEvent;
+    if (metadata == null) return null;
 
-    try {
-      final metadata = await _readVideoMetadata(
-        EditorVideo.file(copiedVideo.path),
-      );
-      final width = metadata.resolution.width;
-      final height = metadata.resolution.height;
-      if (width <= 0 || height <= 0) return null;
-      // ProVideoEditor reports display dimensions with rotation applied.
-      return width / height;
-    } catch (e) {
-      Log.warning(
-        'Failed to read video metadata for aspect ratio: $e',
-        name: _logName,
-        category: LogCategory.video,
-      );
-      return null;
-    }
+    final width = metadata.resolution.width;
+    final height = metadata.resolution.height;
+    if (width <= 0 || height <= 0) return null;
+    // ProVideoEditor reports display dimensions with rotation applied.
+    return width / height;
   }
 
   /// Determines the target crop aspect ratio for the editor.

--- a/mobile/test/services/video_clip_import_service_test.dart
+++ b/mobile/test/services/video_clip_import_service_test.dart
@@ -462,12 +462,21 @@ cue text $loneSurrogate here
     expect(success.clip.originalAspectRatio, closeTo(1920 / 1080, 0.001));
   });
 
-  test('uses imeta dimensions before probing file metadata', () async {
+  test('prefers imeta dimensions over the probed resolution', () async {
     var metadataRead = false;
     final service = buildService(
       readVideoMetadata: (video) async {
         metadataRead = true;
-        throw StateError('metadata should not be read');
+        // A resolution that disagrees with the imeta `dim` tag, so the
+        // assertions below can tell which source won.
+        return VideoMetadata(
+          duration: const Duration(seconds: 5),
+          extension: 'mp4',
+          fileSize: 1024,
+          resolution: const Size(720, 720),
+          rotation: 0,
+          bitrate: 1000,
+        );
       },
     );
 
@@ -492,7 +501,9 @@ cue text $loneSurrogate here
     );
 
     final success = result as VideoClipImportSuccess;
-    expect(metadataRead, isFalse);
+    // The file is still probed — the duration needs it — but the ratio comes
+    // from the event.
+    expect(metadataRead, isTrue);
     expect(success.clip.targetAspectRatio, models.AspectRatio.vertical);
     expect(success.clip.originalAspectRatio, closeTo(1080 / 1920, 0.001));
   });
@@ -551,5 +562,96 @@ cue text $loneSurrogate here
       ),
     );
     verifyNever(() => clipLibraryService.saveClip(any()));
+  });
+
+  group('clip duration', () {
+    VideoMetadata metadataWith(Duration duration) => VideoMetadata(
+      duration: duration,
+      extension: 'mp4',
+      fileSize: 1024,
+      resolution: const Size(480, 480),
+      rotation: 0,
+      bitrate: 1000,
+    );
+
+    test(
+      'measures the file instead of trusting the archive duration tag',
+      () async {
+        // Every Vine archive event advertises `duration 6`; the real assets
+        // measure 5.201s-6.548s. Trusting the tag makes the export cut a
+        // full-length Vine short and lets custom audio outlive the video on
+        // Android (#7920).
+        final service = buildService(
+          readVideoMetadata: (video) async =>
+              metadataWith(const Duration(milliseconds: 6548)),
+        );
+
+        final result = await service.importToLibrary(_video());
+
+        final success = result as VideoClipImportSuccess;
+        expect(success.clip.duration, const Duration(milliseconds: 6548));
+      },
+    );
+
+    test('measures a Vine shorter than the advertised tag', () async {
+      final service = buildService(
+        readVideoMetadata: (video) async =>
+            metadataWith(const Duration(milliseconds: 5201)),
+      );
+
+      final result = await service.importToLibrary(_video());
+
+      final success = result as VideoClipImportSuccess;
+      expect(success.clip.duration, const Duration(milliseconds: 5201));
+    });
+
+    test('extracts the ghost frame at the measured duration', () async {
+      Duration? ghostFrameDuration;
+      final service = buildService(
+        readVideoMetadata: (video) async =>
+            metadataWith(const Duration(milliseconds: 5201)),
+        extractLastFrame: ({required videoPath, required videoDuration}) async {
+          ghostFrameDuration = videoDuration;
+          return null;
+        },
+      );
+
+      await service.importToLibrary(_video());
+
+      expect(ghostFrameDuration, const Duration(milliseconds: 5201));
+    });
+
+    test('falls back to the event tag when the probe reports zero', () async {
+      final service = buildService(
+        readVideoMetadata: (video) async => metadataWith(Duration.zero),
+      );
+
+      final result = await service.importToLibrary(_video(duration: 7));
+
+      final success = result as VideoClipImportSuccess;
+      expect(success.clip.duration, const Duration(seconds: 7));
+    });
+
+    test('falls back to the event tag when the probe throws', () async {
+      final service = buildService(
+        readVideoMetadata: (video) async => throw StateError('probe failed'),
+      );
+
+      final result = await service.importToLibrary(_video(duration: 7));
+
+      final success = result as VideoClipImportSuccess;
+      expect(success.clip.duration, const Duration(seconds: 7));
+    });
+
+    test('falls back to six seconds when neither source is usable', () async {
+      final service = buildService(
+        readVideoMetadata: (video) async => metadataWith(Duration.zero),
+      );
+
+      final result = await service.importToLibrary(_video(duration: null));
+
+      final success = result as VideoClipImportSuccess;
+      expect(success.clip.duration, const Duration(seconds: 6));
+    });
   });
 }

--- a/mobile/test/services/video_clip_import_service_test.dart
+++ b/mobile/test/services/video_clip_import_service_test.dart
@@ -593,18 +593,6 @@ cue text $loneSurrogate here
       },
     );
 
-    test('measures a Vine shorter than the advertised tag', () async {
-      final service = buildService(
-        readVideoMetadata: (video) async =>
-            metadataWith(const Duration(milliseconds: 5201)),
-      );
-
-      final result = await service.importToLibrary(_video());
-
-      final success = result as VideoClipImportSuccess;
-      expect(success.clip.duration, const Duration(milliseconds: 5201));
-    });
-
     test('extracts the ghost frame at the measured duration', () async {
       Duration? ghostFrameDuration;
       final service = buildService(


### PR DESCRIPTION
## Description

A user editing an old Vine reported that the end of the clip comes out wrong. Swap the music and change nothing else, and "the tail end will be a still shot until it loops again" — the picture freezes on the last frame while the song keeps going. Full-length Vines also come back visibly shorter than the original.

Both happen at import, before the editor is ever opened.

Every Vine archive event advertises the same hardcoded length — six seconds — in the `imeta` tag that describes the file, no matter how long the file actually is. Measured across four real assets on `media.divine.video`: 5.201s, 6.033s, 6.548s, 6.548s — all four tagged `6`. The import took that number at face value, so the editor believed every classic Vine was exactly 6.000s.

That number becomes the export's segment end, which produces the two failures:

- **The clip gets truncated.** A full-length 6.548s Vine renders at 6.0s — the last ~550ms, including the musical loop point, is cut.
- **Swapped-in music outlives the video.** The window a custom audio track is clamped to comes from the same declared duration. When the declared duration is longer than the real video track, the audio keeps playing past the last frame — which freezes until the loop restarts.

The second one is Android-only, because `pro_video_editor`'s darwin path trims the output to where the shortest track ends (`TrackEndTrimmer`) and the Android path has no equivalent. The reporter was on Android 9.

### Why measuring is the right fix

The file was already probed on import via `ProVideoEditor.getMetadata` — but only for the aspect ratio, and only when the event carried no `dim` tag. Classic Vines always carry `dim 480x480`, so the probe never ran for them. This change probes once, unconditionally, and takes the duration from it, keeping the event tag as the fallback when the probe fails or reports zero. `_resolveAspectRatio` now consumes that same probe result instead of running its own, so an import that previously made one native call still makes exactly one.

**Related Issue:** Closes #7920

## Out of Scope

- **"the vine will either get stuck and not post".** The report's other half did not reproduce in the harness below — every export completed on both platforms. It is plausibly the same wrong end time: the reporter got the post through by "shaving off the end", which is exactly what pulling the segment end back inside the real video does. That is inference, not a measurement, so #7920 is worth reopening if it recurs.
- **~40ms residual audio overhang on Android.** Classic Vine sources have an audio track 31–78ms longer than their video track. Closing that needs the Android equivalent of darwin's `TrackEndTrimmer` in `pro_video_editor`, not an app change.
- **The 6.3s export ceiling, and the editor now showing more than the export keeps.** `VideoEditorConstants.maxDuration` still caps the export, so a 6.548s Vine renders at 6.27s (Android) / 6.3s (iOS) even with a correct duration, while the editor shows the full measured 6.548s. That gap is deliberate. The editor already signposts the cap — the timeline draws max-duration overlays once the composition exceeds it (`video_editor_timeline_body.dart:110`) and the position readout turns `VineTheme.warning` past it (`video_editor_timeline_header.dart:194`) — and keeping the full length is what lets the user choose *which* 6.3s survives by trimming from either end. Clamping the measured value at import would silently pick the first 6.3s and take that choice away. Raising the cap itself is the #6421 product call, not a drive-by change.
- **Already-imported library clips** keep the duration they were saved with. Only new imports are corrected.

## Verification

Measured on a real Samsung SM-S942B and an iPhone 17 simulator, rendering real archive assets through the actual native pipeline. Output MP4 track durations, parsed from the `moov` box:

| Platform | declared duration | video track | audio track | drift |
|---|---|---|---|---|
| iOS | 6.000s (tag) | 5.170s | 5.170s | 0.000s |
| Android | 6.000s (tag) | 5.170s | 6.024s | **+0.854s** |
| Android | 5.201s (measured) | 5.170s | 5.211s | +0.041s |

The third row is the behaviour after this change: the frozen tail drops from 854ms to 41ms.

Truncation, same harness, no music involved:

| source (real) | declared | iOS rendered | Android rendered |
|---|---|---|---|
| 6.548s | 6.000s (tag) | 6.0s | 6.014s |
| 6.548s | 6.548s (measured) | 6.3s | 6.27s |

Also run:

- `flutter analyze lib test integration_test` — clean
- `flutter test test/services/video_clip_import_service_test.dart` — 24/24, including 5 new tests covering measured-wins, fallback on a zero probe, fallback on a throwing probe, the 6s last-resort default, and the ghost frame being extracted at the measured end
- `flutter test test/blocs/share_sheet/share_sheet_bloc_test.dart test/widgets/share_video_menu_comprehensive_test.dart` — 115/115 (the callers of `importToLibrary`)
- Manually verified on a real Samsung Galaxy (SM-S942B): imported a classic Vine, swapped the music, exported — the still frame at the end is gone

One existing test changed meaning. `uses imeta dimensions before probing file metadata` asserted that the probe is skipped when the event carries `dim`. The probe now always runs because the duration needs it, so the test is renamed to `prefers imeta dimensions over the probed resolution` and asserts the ratio still comes from the event while the file is probed.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

