### PR TITLE
feat(experiments): add control-only staging mode

### DIFF
--- a/mobile/lib/features/feature_flags/models/feature_flag.dart
+++ b/mobile/lib/features/feature_flags/models/feature_flag.dart
@@ -80,6 +80,18 @@ enum FeatureFlag {
     'Client Seen-Video Filtering',
     'Demote recently-seen videos in home feeds and drop them from '
         'classics/discovery. Kill-switch for the Aug 2026 campaign load.',
+  ),
+  postPublishConfirmationExperiment(
+    'Post-Publish Confirmation Test',
+    'Enable the 50/50 View and Share confirmation test after publishing. '
+        'Turn off to use the normal control behavior.',
+    audience: FeatureFlagAudience.internal,
+  ),
+  postPublishConfirmationTreatment(
+    'Post-Publish Confirmation Treatment',
+    'Show the View and Share confirmation to its assigned group. Turn off '
+        'while checking that both identical groups measure the same.',
+    audience: FeatureFlagAudience.internal,
   );
 
   const FeatureFlag(

--- a/mobile/lib/features/feature_flags/services/build_configuration.dart
+++ b/mobile/lib/features/feature_flags/services/build_configuration.dart
@@ -60,6 +60,16 @@ class BuildConfiguration {
           'FF_CLIENT_SEEN_FILTERING',
           defaultValue: true,
         );
+      case FeatureFlag.postPublishConfirmationExperiment:
+        return const bool.fromEnvironment(
+          'FF_POST_PUBLISH_CONFIRMATION_EXPERIMENT',
+          defaultValue: true,
+        );
+      case FeatureFlag.postPublishConfirmationTreatment:
+        return const bool.fromEnvironment(
+          'FF_POST_PUBLISH_CONFIRMATION_TREATMENT',
+          defaultValue: true,
+        );
     }
   }
 
@@ -104,6 +114,10 @@ class BuildConfiguration {
         return 'FF_NEW_POST_NOTIFICATIONS';
       case FeatureFlag.clientSeenFiltering:
         return 'FF_CLIENT_SEEN_FILTERING';
+      case FeatureFlag.postPublishConfirmationExperiment:
+        return 'FF_POST_PUBLISH_CONFIRMATION_EXPERIMENT';
+      case FeatureFlag.postPublishConfirmationTreatment:
+        return 'FF_POST_PUBLISH_CONFIRMATION_TREATMENT';
     }
   }
 }

--- a/mobile/lib/features/post_publish/post_publish_experiment.dart
+++ b/mobile/lib/features/post_publish/post_publish_experiment.dart
@@ -34,13 +34,19 @@ class PostPublishConfirmationOffer {
 class PostPublishExperiment {
   PostPublishExperiment({
     required AnalyticsEventSink analytics,
+    bool Function()? isEnabled,
+    bool Function()? isTreatmentEnabled,
     RecordPostPublishExposure? recordExposure,
     DateTime Function()? now,
   }) : _analytics = analytics,
+       _isEnabled = isEnabled ?? _alwaysEnabled,
+       _isTreatmentEnabled = isTreatmentEnabled ?? _alwaysEnabled,
        _recordExposure = recordExposure,
        _now = now ?? DateTime.now;
 
   final AnalyticsEventSink _analytics;
+  final bool Function() _isEnabled;
+  final bool Function() _isTreatmentEnabled;
   final RecordPostPublishExposure? _recordExposure;
   final DateTime Function() _now;
 
@@ -52,9 +58,10 @@ class PostPublishExperiment {
   final Map<String, PostPublishVariant> _publishVariants = {};
 
   static const _maxPendingVariants = 32;
+  static bool _alwaysEnabled() => true;
 
   PostPublishVariant variantForUser(String? pubkeyHex) {
-    if (pubkeyHex == null) return PostPublishVariant.control;
+    if (!_isEnabled() || pubkeyHex == null) return PostPublishVariant.control;
     // Lowercased so a signer that returns uppercase hex cannot move the same
     // account between buckets.
     final assignmentByte = sha256
@@ -72,15 +79,17 @@ class PostPublishExperiment {
     required PostPublishVariant variant,
     bool isExperimentExposure = false,
   }) async {
+    final enabled = _isEnabled();
+    final activeVariant = enabled ? variant : PostPublishVariant.control;
     _publishVariants
       ..remove(publishId)
-      ..[publishId] = variant;
+      ..[publishId] = activeVariant;
     while (_publishVariants.length > _maxPendingVariants) {
       _publishVariants.remove(_publishVariants.keys.first);
     }
-    if (isExperimentExposure && _recordExposure != null) {
+    if (enabled && isExperimentExposure && _recordExposure != null) {
       try {
-        await _recordExposure(variant);
+        await _recordExposure(activeVariant);
       } catch (error) {
         Log.warning(
           'Post-publish experiment exposure failed: $error',
@@ -93,18 +102,20 @@ class PostPublishExperiment {
       name: 'post_publish_screen_shown',
       parameters: {
         'destination': destination,
-        'variant': variant.analyticsName,
+        'variant': activeVariant.analyticsName,
       },
     );
   }
 
   PostPublishConfirmationOffer? completed(Set<String> publishIds) {
-    var showConfirmation = false;
+    var assignedToTreatment = false;
     for (final publishId in publishIds) {
-      showConfirmation =
-          _publishVariants.remove(publishId) == PostPublishVariant.viewShare ||
-          showConfirmation;
+      final assignedVariant = _publishVariants.remove(publishId);
+      assignedToTreatment =
+          assignedVariant == PostPublishVariant.viewShare ||
+          assignedToTreatment;
     }
+    final showConfirmation = assignedToTreatment && _isTreatmentEnabled();
     return showConfirmation
         ? PostPublishConfirmationOffer(publishedAt: _now())
         : null;

--- a/mobile/lib/features/post_publish/post_publish_experiment.dart
+++ b/mobile/lib/features/post_publish/post_publish_experiment.dart
@@ -115,7 +115,10 @@ class PostPublishExperiment {
           assignedVariant == PostPublishVariant.viewShare ||
           assignedToTreatment;
     }
-    final showConfirmation = assignedToTreatment && _isTreatmentEnabled();
+    // The master switch is re-read here, not just at assignment time, so
+    // flipping it off also drops a publish that was already in flight.
+    final showConfirmation =
+        assignedToTreatment && _isEnabled() && _isTreatmentEnabled();
     return showConfirmation
         ? PostPublishConfirmationOffer(publishedAt: _now())
         : null;

--- a/mobile/lib/providers/post_publish_providers.dart
+++ b/mobile/lib/providers/post_publish_providers.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Riverpod wiring for the post-publish create-again experiment.
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:openvine/features/feature_flags/models/feature_flag.dart';
+import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
 import 'package:openvine/features/post_publish/post_publish_experiment.dart';
 import 'package:openvine/generated/product_analytics.dart';
 import 'package:openvine/providers/analytics_providers.dart';
@@ -9,6 +11,12 @@ import 'package:openvine/providers/social_providers.dart';
 final postPublishExperimentProvider = Provider<PostPublishExperiment>((ref) {
   return PostPublishExperiment(
     analytics: ref.watch(analyticsEventSinkProvider),
+    isEnabled: () => ref.read(
+      isFeatureEnabledProvider(FeatureFlag.postPublishConfirmationExperiment),
+    ),
+    isTreatmentEnabled: () => ref.read(
+      isFeatureEnabledProvider(FeatureFlag.postPublishConfirmationTreatment),
+    ),
     recordExposure: (variant) async {
       await ref
           .read(analyticsServiceProvider)

--- a/mobile/test/core/feature_flag_test.dart
+++ b/mobile/test/core/feature_flag_test.dart
@@ -69,7 +69,11 @@ void main() {
       );
       expect(FeatureFlag.feedTuning.audience, FeatureFlagAudience.internal);
       expect(
-        FeatureFlag.communityContentWarnings.audience,
+        FeatureFlag.postPublishConfirmationExperiment.audience,
+        FeatureFlagAudience.internal,
+      );
+      expect(
+        FeatureFlag.postPublishConfirmationTreatment.audience,
         FeatureFlagAudience.internal,
       );
     });

--- a/mobile/test/features/post_publish/post_publish_experiment_test.dart
+++ b/mobile/test/features/post_publish/post_publish_experiment_test.dart
@@ -286,6 +286,27 @@ void main() {
     );
 
     test(
+      'turning the experiment off drops a confirmation already assigned',
+      () async {
+        var enabled = true;
+        final killSwitchExperiment = PostPublishExperiment(
+          analytics: analytics,
+          isEnabled: () => enabled,
+        );
+        final treatmentUser = _pubkeyForVariant(PostPublishVariant.viewShare);
+
+        await killSwitchExperiment.screenShown(
+          publishId: 'publish-1',
+          destination: 'profile',
+          variant: killSwitchExperiment.variantForUser(treatmentUser),
+        );
+        enabled = false;
+
+        expect(killSwitchExperiment.completed({'publish-1'}), isNull);
+      },
+    );
+
+    test(
       'an exposure recording failure does not affect the publish flow',
       () async {
         final experimentWithFailure = PostPublishExperiment(

--- a/mobile/test/features/post_publish/post_publish_experiment_test.dart
+++ b/mobile/test/features/post_publish/post_publish_experiment_test.dart
@@ -234,6 +234,58 @@ void main() {
     );
 
     test(
+      'disabled experiment stays in control and records no exposure',
+      () async {
+        final exposures = <PostPublishVariant>[];
+        final disabledExperiment = PostPublishExperiment(
+          analytics: analytics,
+          isEnabled: () => false,
+          recordExposure: (variant) async => exposures.add(variant),
+        );
+        final treatmentUser = _pubkeyForVariant(PostPublishVariant.viewShare);
+        final variant = disabledExperiment.variantForUser(treatmentUser);
+
+        await disabledExperiment.screenShown(
+          publishId: 'publish-1',
+          destination: 'profile',
+          variant: variant,
+          isExperimentExposure: true,
+        );
+
+        expect(variant, PostPublishVariant.control);
+        expect(disabledExperiment.completed({'publish-1'}), isNull);
+        expect(exposures, isEmpty);
+        expect(analytics.events.single.parameters['variant'], 'control');
+      },
+    );
+
+    test(
+      'A/A mode records assignments but gives both groups control',
+      () async {
+        final exposures = <PostPublishVariant>[];
+        final aaExperiment = PostPublishExperiment(
+          analytics: analytics,
+          isTreatmentEnabled: () => false,
+          recordExposure: (variant) async => exposures.add(variant),
+        );
+        final treatmentUser = _pubkeyForVariant(PostPublishVariant.viewShare);
+        final variant = aaExperiment.variantForUser(treatmentUser);
+
+        await aaExperiment.screenShown(
+          publishId: 'publish-1',
+          destination: 'profile',
+          variant: variant,
+          isExperimentExposure: true,
+        );
+
+        expect(variant, PostPublishVariant.viewShare);
+        expect(exposures, [PostPublishVariant.viewShare]);
+        expect(aaExperiment.completed({'publish-1'}), isNull);
+        expect(analytics.events.single.parameters['variant'], 'view_share');
+      },
+    );
+
+    test(
       'an exposure recording failure does not affect the publish flow',
       () async {
         final experimentWithFailure = PostPublishExperiment(

--- a/mobile/test/providers/post_publish_providers_test.dart
+++ b/mobile/test/providers/post_publish_providers_test.dart
@@ -1,0 +1,96 @@
+// ABOUTME: Proves the post-publish experiment reads the existing feature flag.
+// ABOUTME: Keeps the disabled path on normal control behavior.
+
+import 'package:analytics/analytics.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/features/feature_flags/models/feature_flag.dart';
+import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
+import 'package:openvine/features/post_publish/post_publish_experiment.dart';
+import 'package:openvine/providers/analytics_providers.dart';
+import 'package:openvine/providers/post_publish_providers.dart';
+
+class _NoopAnalytics implements AnalyticsEventSink {
+  @override
+  Future<void> logEvent({
+    required String name,
+    required Map<String, Object> parameters,
+  }) async {}
+
+  @override
+  Future<void> logScreenView({
+    required String screenName,
+    String? screenClass,
+    Map<String, Object>? parameters,
+  }) async {}
+
+  @override
+  Future<void> setUserId(String? userId) async {}
+
+  @override
+  Future<void> setUserProperty({
+    required String name,
+    required String? value,
+  }) async {}
+}
+
+void main() {
+  String treatmentUser() {
+    final reference = PostPublishExperiment(analytics: _NoopAnalytics());
+    return List.generate(
+      1000,
+      (index) => index.toRadixString(16).padLeft(64, '0'),
+    ).firstWhere(
+      (pubkey) =>
+          reference.variantForUser(pubkey) == PostPublishVariant.viewShare,
+    );
+  }
+
+  test('off switch forces the post-publish experiment into control', () {
+    final container = ProviderContainer(
+      overrides: [
+        analyticsEventSinkProvider.overrideWithValue(_NoopAnalytics()),
+        isFeatureEnabledProvider(
+          FeatureFlag.postPublishConfirmationExperiment,
+        ).overrideWithValue(false),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final configured = container.read(postPublishExperimentProvider);
+
+    expect(
+      configured.variantForUser(treatmentUser()),
+      PostPublishVariant.control,
+    );
+  });
+
+  test(
+    'A/A switch keeps assignments but suppresses treatment behavior',
+    () async {
+      final container = ProviderContainer(
+        overrides: [
+          analyticsEventSinkProvider.overrideWithValue(_NoopAnalytics()),
+          isFeatureEnabledProvider(
+            FeatureFlag.postPublishConfirmationExperiment,
+          ).overrideWithValue(true),
+          isFeatureEnabledProvider(
+            FeatureFlag.postPublishConfirmationTreatment,
+          ).overrideWithValue(false),
+        ],
+      );
+      addTearDown(container.dispose);
+      final configured = container.read(postPublishExperimentProvider);
+      final variant = configured.variantForUser(treatmentUser());
+
+      await configured.screenShown(
+        publishId: 'publish-1',
+        destination: 'profile',
+        variant: variant,
+      );
+
+      expect(variant, PostPublishVariant.viewShare);
+      expect(configured.completed({'publish-1'}), isNull);
+    },
+  );
+}

--- a/mobile/test/services/build_config_test.dart
+++ b/mobile/test/services/build_config_test.dart
@@ -98,6 +98,37 @@ void main() {
       expect(config.getDefault(FeatureFlag.curatedLists), isTrue);
     });
 
+    test('post-publish experiment has a build-time off switch', () {
+      const config = BuildConfiguration();
+
+      expect(
+        config.getDefault(FeatureFlag.postPublishConfirmationExperiment),
+        const bool.fromEnvironment(
+          'FF_POST_PUBLISH_CONFIRMATION_EXPERIMENT',
+          defaultValue: true,
+        ),
+      );
+      expect(
+        config.getEnvironmentKey(
+          FeatureFlag.postPublishConfirmationExperiment,
+        ),
+        'FF_POST_PUBLISH_CONFIRMATION_EXPERIMENT',
+      );
+      expect(
+        config.getDefault(FeatureFlag.postPublishConfirmationTreatment),
+        const bool.fromEnvironment(
+          'FF_POST_PUBLISH_CONFIRMATION_TREATMENT',
+          defaultValue: true,
+        ),
+      );
+      expect(
+        config.getEnvironmentKey(
+          FeatureFlag.postPublishConfirmationTreatment,
+        ),
+        'FF_POST_PUBLISH_CONFIRMATION_TREATMENT',
+      );
+    });
+
     test('integratedApps should map to FF_INTEGRATED_APPS env var', () {
       const config = BuildConfiguration();
 


### PR DESCRIPTION
Closes #7961

## What this changes

Adds two internal build switches to the existing post-publish phone test. They use the app's current feature-flag system; there is no new service.

- Experiment off: everyone gets the normal behavior and no assignment event is recorded.
- Assignment-only check: people are still split into two groups and those assignments are recorded, but everyone gets the same normal behavior.
- Treatment check: the assigned treatment group gets the View and Share confirmation.

Both switches default to on, so the current app behavior does not change unless a staging or release build explicitly changes them.

The off switch is checked again when a publish finishes. If a developer turns it off while an upload is in progress, that publish returns to the normal behavior too.

## Why

We need to prove that the measurement path does not invent a difference before anyone interprets a real treatment. Assignment-only mode gives both groups identical behavior while the private dashboard checks that assignments arrive and stay close to a 50/50 split.

This does not choose a product outcome or interpret results. That remains human decision 2 in the analytics plan. Until that decision names an outcome and the action it can trigger, this work checks assignment health only and creates no results dashboard.

This is stacked on #7938 and depends on the private assignment check in divinevideo/divine-iac-coreconfig#1827.

Linked issue: divinevideo/divine-funnelcake#1090.

## Current staging state

- The server path and exact 30-day assignment count are live in staging.
- The private dashboard is live with no public route. Low-volume staging data remains `WAIT`, which means there is not enough data to judge the split.
- A fresh Android emulator install of the exact labelled staging build recorded and published a virtual-camera video in control-only mode. The app returned to the publisher profile without showing the View and Share confirmation.
- The matching Android assignment reached the restricted recent-exposure view and the current-day 30-day assignment count. This proves the real app path is connected; it is not assignment-health or product-result evidence.
- The temporary staging settings were removed afterward, and a second valid request confirmed collection was disabled again.
- The iOS and treatment checks remain. Production remains off.

The complete Android record is in divinevideo/divine-context#92.

## Validation

On current commit `acf8316`:

- The full local pre-push check passed.
- The Flutter analyzer found no issues.
- Generated-file, formatting, merge-conflict, and repository checks passed.
- All 268 tests selected by the pre-push check passed.
- Two independent reviewers approved the current commit. One reviewer also proved that the new regression test fails when the fix is removed and passes when it is restored.
- The exact full GitHub Mobile CI run passed: https://github.com/divinevideo/divine-mobile/actions/runs/32375411288
- The exact GitHub service integration run passed: https://github.com/divinevideo/divine-mobile/actions/runs/32375411285

There is no visual change with the default settings.

## Staging test

Build the app with assignment recording on and the treatment screen off:

```text
--dart-define=FF_POST_PUBLISH_CONFIRMATION_EXPERIMENT=true
--dart-define=FF_POST_PUBLISH_CONFIRMATION_TREATMENT=false
```

Use a fresh staging install. If the device has a stored opt-out or internal flag override, clear the app data or reinstall first. Complete one non-reply publish and remain on your own profile until it finishes.

Every account must keep the normal success behavior while the private assignment table receives both assigned groups. A low-volume staging run will usually say `WAIT`; that means there is not enough data to judge the split. It is still enough to prove that a real phone assignment reached the private count.

While the table says `WAIT`, one manual staging build may turn treatment on solely to prove that the View and Share screen appears for the assigned treatment group. Do not call that a result, compare outcomes, or make a product decision from it.

Record the exact UTC time whenever assignment-only mode or treatment mode changes. Any result that crosses an unrecorded mode change is unusable.

Do not run or interpret a real experiment when the table says `WAIT` or `STOP`. A real test also requires decision 2 to name the outcome and the action the team may take.
