### PR TITLE
fix(feed): stop hashtag pagination dropping every video

### DIFF
--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -2970,29 +2970,13 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
           // For newer versions, _handleReplaceableVideoEvent already removed the old event
 
           // Check hashtag filter if active
-          if (_activeHashtagFilters[subscriptionType] != null &&
-              _activeHashtagFilters[subscriptionType]!.isNotEmpty) {
-            // Check if video has any of the required hashtags (case-insensitive)
-            final requiredHashtagsLower =
-                _activeHashtagFilters[subscriptionType]!
-                    .map((tag) => tag.toLowerCase())
-                    .toList();
-            final videoHashtagsLower = videoEvent.hashtags
-                .map((tag) => tag.toLowerCase())
-                .toList();
-
-            final hasRequiredHashtag = requiredHashtagsLower.any(
-              videoHashtagsLower.contains,
+          if (!_passesHashtagFilter(videoEvent, subscriptionType)) {
+            Log.warning(
+              '⏩ Skipping video without required hashtags: ${_activeHashtagFilters[subscriptionType]}',
+              name: 'VideoEventService',
+              category: LogCategory.video,
             );
-
-            if (!hasRequiredHashtag) {
-              Log.warning(
-                '⏩ Skipping video without required hashtags: ${_activeHashtagFilters[subscriptionType]}',
-                name: 'VideoEventService',
-                category: LogCategory.video,
-              );
-              return;
-            }
+            return;
           }
 
           // Check group filter if active
@@ -3207,19 +3191,13 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
           // For newer versions, _handleReplaceableVideoEvent already removed the old event
 
           // Check hashtag filter if active
-          if (_activeHashtagFilters[subscriptionType] != null &&
-              _activeHashtagFilters[subscriptionType]!.isNotEmpty) {
-            final hasRequiredHashtag = _activeHashtagFilters[subscriptionType]!
-                .any(videoEvent.hashtags.contains);
-
-            if (!hasRequiredHashtag) {
-              Log.warning(
-                '⏩ Skipping historical video without required hashtags: ${_activeHashtagFilters[subscriptionType]}',
-                name: 'VideoEventService',
-                category: LogCategory.video,
-              );
-              return;
-            }
+          if (!_passesHashtagFilter(videoEvent, subscriptionType)) {
+            Log.warning(
+              '⏩ Skipping historical video without required hashtags: ${_activeHashtagFilters[subscriptionType]}',
+              name: 'VideoEventService',
+              category: LogCategory.video,
+            );
+            return;
           }
 
           // Check group filter if active
@@ -3282,7 +3260,14 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
     if (video == null) return;
 
     // Check hashtag filter
-    if (!_passesHashtagFilter(video, subscriptionType)) return;
+    if (!_passesHashtagFilter(video, subscriptionType)) {
+      Log.debug(
+        '⏩ Skipping repost without required hashtags: ${_activeHashtagFilters[subscriptionType]}',
+        name: 'VideoEventService',
+        category: LogCategory.video,
+      );
+      return;
+    }
 
     _addVideoToSubscription(
       video,
@@ -3291,7 +3276,13 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
     );
   }
 
-  /// Check if video passes the active hashtag filter for subscription type
+  /// Whether [video] carries one of the hashtags [subscriptionType] filters on.
+  ///
+  /// The comparison is case-insensitive on both sides. `subscribeToVideoFeed`
+  /// lowercases the tag before putting it in the relay REQ (NIP-24) but stores
+  /// the caller's original casing in [_activeHashtagFilters], so a
+  /// case-sensitive compare here rejects every event the relay returns for a
+  /// capitalised hashtag.
   bool _passesHashtagFilter(
     VideoEvent video,
     SubscriptionType subscriptionType,
@@ -3299,15 +3290,10 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
     final filter = _activeHashtagFilters[subscriptionType];
     if (filter == null || filter.isEmpty) return true;
 
-    final passes = filter.any(video.hashtags.contains);
-    if (!passes) {
-      Log.debug(
-        '⏩ Skipping repost without required hashtags: $filter',
-        name: 'VideoEventService',
-        category: LogCategory.video,
-      );
-    }
-    return passes;
+    final videoHashtags = video.hashtags
+        .map((tag) => tag.toLowerCase())
+        .toSet();
+    return filter.any((tag) => videoHashtags.contains(tag.toLowerCase()));
   }
 
   /// Handle subscription error
@@ -6301,6 +6287,23 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
   @visibleForTesting
   void handleEventForTesting(Event event, SubscriptionType type) {
     _handleNewVideoEvent(event, type);
+  }
+
+  /// Handle a nostr event through the pagination path for testing
+  /// (exposes _handleHistoricalVideoEvent, the `loadMoreEvents` handler).
+  @visibleForTesting
+  void handleHistoricalEventForTesting(Event event, SubscriptionType type) {
+    _handleHistoricalVideoEvent(event, type);
+  }
+
+  /// Seed the active hashtag filter for [type] the way `subscribeToVideoFeed`
+  /// does, so tests can exercise filtering without opening a subscription.
+  @visibleForTesting
+  void setActiveHashtagFilterForTesting(
+    SubscriptionType type,
+    List<String> hashtags,
+  ) {
+    _activeHashtagFilters[type] = hashtags;
   }
 
   /// Flush the pending like-count batch without waiting for the debounce timer.

--- a/mobile/test/services/video_event_service_hashtag_case_test.dart
+++ b/mobile/test/services/video_event_service_hashtag_case_test.dart
@@ -1,46 +1,16 @@
 // ABOUTME: Regression tests for case-insensitive hashtag filtering in VideoEventService
 // ABOUTME: Pins realtime/pagination parity so load-more stops dropping capitalised hashtags
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/event.dart';
 import 'package:openvine/constants/nip71_migration.dart';
 import 'package:openvine/services/subscription_manager.dart';
 import 'package:openvine/services/video_event_service.dart';
 
-class _MinimalNostrClient implements NostrClient {
-  @override
-  bool get isInitialized => true;
+class _MockNostrClient extends Mock implements NostrClient {}
 
-  @override
-  bool get isDisposed => false;
-
-  @override
-  List<String> get connectedRelays => ['wss://localhost:8080'];
-
-  @override
-  int get connectedRelayCount => 1;
-
-  @override
-  int get configuredRelayCount => 1;
-
-  @override
-  List<String> get configuredRelays => ['wss://localhost:8080'];
-
-  @override
-  String get publicKey => '';
-
-  @override
-  bool get hasKeys => false;
-
-  @override
-  Future<void> dispose() async {}
-
-  @override
-  Future<void> initialize({List<String>? customRelays}) async {}
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) => null;
-}
+class _MockSubscriptionManager extends Mock implements SubscriptionManager {}
 
 Event _videoEvent({required String id, required String hashtag}) {
   final event = Event(
@@ -61,23 +31,23 @@ Event _videoEvent({required String id, required String hashtag}) {
 
 void main() {
   group(VideoEventService, () {
-    late _MinimalNostrClient nostrClient;
-    late SubscriptionManager subscriptionManager;
+    late _MockNostrClient nostrClient;
+    late _MockSubscriptionManager subscriptionManager;
     late VideoEventService service;
 
     setUp(() {
-      nostrClient = _MinimalNostrClient();
-      subscriptionManager = SubscriptionManager(nostrClient);
+      nostrClient = _MockNostrClient();
+      subscriptionManager = _MockSubscriptionManager();
+      when(() => nostrClient.isInitialized).thenReturn(true);
+      when(() => nostrClient.isDisposed).thenReturn(false);
+      when(() => nostrClient.connectedRelayCount).thenReturn(1);
       service = VideoEventService(
         nostrClient,
         subscriptionManager: subscriptionManager,
       );
     });
 
-    tearDown(() async {
-      service.dispose();
-      await subscriptionManager.dispose();
-    });
+    tearDown(() => service.dispose());
 
     group('hashtag filter casing', () {
       // `subscribeToVideoFeed` lowercases the tag for the relay REQ (NIP-24)
@@ -98,7 +68,10 @@ void main() {
             SubscriptionType.hashtag,
           );
 
-          expect(service.getVideos(SubscriptionType.hashtag), hasLength(1));
+          expect(
+            service.getVideos(SubscriptionType.hashtag).map((v) => v.id),
+            ['b' * 64],
+          );
         },
       );
 
@@ -117,7 +90,10 @@ void main() {
           SubscriptionType.hashtag,
         );
 
-        expect(service.getVideos(SubscriptionType.hashtag), hasLength(2));
+        expect(
+          service.getVideos(SubscriptionType.hashtag).map((v) => v.id),
+          containsAll(['c' * 64, 'd' * 64]),
+        );
       });
 
       test('a genuinely unrelated hashtag is still rejected on both paths', () {

--- a/mobile/test/services/video_event_service_hashtag_case_test.dart
+++ b/mobile/test/services/video_event_service_hashtag_case_test.dart
@@ -1,0 +1,142 @@
+// ABOUTME: Regression tests for case-insensitive hashtag filtering in VideoEventService
+// ABOUTME: Pins realtime/pagination parity so load-more stops dropping capitalised hashtags
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:openvine/constants/nip71_migration.dart';
+import 'package:openvine/services/subscription_manager.dart';
+import 'package:openvine/services/video_event_service.dart';
+
+class _MinimalNostrClient implements NostrClient {
+  @override
+  bool get isInitialized => true;
+
+  @override
+  bool get isDisposed => false;
+
+  @override
+  List<String> get connectedRelays => ['wss://localhost:8080'];
+
+  @override
+  int get connectedRelayCount => 1;
+
+  @override
+  int get configuredRelayCount => 1;
+
+  @override
+  List<String> get configuredRelays => ['wss://localhost:8080'];
+
+  @override
+  String get publicKey => '';
+
+  @override
+  bool get hasKeys => false;
+
+  @override
+  Future<void> dispose() async {}
+
+  @override
+  Future<void> initialize({List<String>? customRelays}) async {}
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+Event _videoEvent({required String id, required String hashtag}) {
+  final event = Event(
+    'a' * 64,
+    NIP71VideoKinds.addressableShortVideo,
+    [
+      ['d', 'vine_$id'],
+      ['url', 'https://media.divine.video/$id.mp4'],
+      ['m', 'video/mp4'],
+      ['t', hashtag],
+    ],
+    '',
+    createdAt: 1787236269,
+  );
+  event.id = id;
+  return event;
+}
+
+void main() {
+  group(VideoEventService, () {
+    late _MinimalNostrClient nostrClient;
+    late SubscriptionManager subscriptionManager;
+    late VideoEventService service;
+
+    setUp(() {
+      nostrClient = _MinimalNostrClient();
+      subscriptionManager = SubscriptionManager(nostrClient);
+      service = VideoEventService(
+        nostrClient,
+        subscriptionManager: subscriptionManager,
+      );
+    });
+
+    tearDown(() async {
+      service.dispose();
+      await subscriptionManager.dispose();
+    });
+
+    group('hashtag filter casing', () {
+      // `subscribeToVideoFeed` lowercases the tag for the relay REQ (NIP-24)
+      // but stores the caller's original casing in `_activeHashtagFilters`, so
+      // every event the relay returns carries the lowercase form. A
+      // case-sensitive compare on the pagination path therefore rejected 100%
+      // of them whenever the hashtag had any uppercase character.
+      test(
+        'pagination keeps a lowercase-tagged video under a capitalised filter',
+        () {
+          service.setActiveHashtagFilterForTesting(
+            SubscriptionType.hashtag,
+            ['DivineUniversity'],
+          );
+
+          service.handleHistoricalEventForTesting(
+            _videoEvent(id: 'b' * 64, hashtag: 'divineuniversity'),
+            SubscriptionType.hashtag,
+          );
+
+          expect(service.getVideos(SubscriptionType.hashtag), hasLength(1));
+        },
+      );
+
+      test('realtime and pagination agree for the same event and filter', () {
+        service.setActiveHashtagFilterForTesting(
+          SubscriptionType.hashtag,
+          ['DivineUniversity'],
+        );
+
+        service.handleEventForTesting(
+          _videoEvent(id: 'c' * 64, hashtag: 'divineuniversity'),
+          SubscriptionType.hashtag,
+        );
+        service.handleHistoricalEventForTesting(
+          _videoEvent(id: 'd' * 64, hashtag: 'divineuniversity'),
+          SubscriptionType.hashtag,
+        );
+
+        expect(service.getVideos(SubscriptionType.hashtag), hasLength(2));
+      });
+
+      test('a genuinely unrelated hashtag is still rejected on both paths', () {
+        service.setActiveHashtagFilterForTesting(
+          SubscriptionType.hashtag,
+          ['DivineUniversity'],
+        );
+
+        service.handleEventForTesting(
+          _videoEvent(id: 'e' * 64, hashtag: 'cats'),
+          SubscriptionType.hashtag,
+        );
+        service.handleHistoricalEventForTesting(
+          _videoEvent(id: 'f' * 64, hashtag: 'cats'),
+          SubscriptionType.hashtag,
+        );
+
+        expect(service.getVideos(SubscriptionType.hashtag), isEmpty);
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Description

Hashtag pagination dropped **every** video whenever the hashtag had any uppercase character.

`subscribeToVideoFeed` lowercases the tag before putting it in the relay REQ (`:2022`, "converted to lowercase per NIP-24") but stores the caller's original casing in `_activeHashtagFilters` (`:2097`). Every event the relay returns therefore carries the **lowercase** form, while `_handleHistoricalVideoEvent` — the `loadMoreEvents` handler — compared it **case-sensitively** against the stored filter. So load-more rejected 100% of what the relay had just returned.

Caught on device, deep-linking to `/hashtag/DivineUniversity`:

```
- Hashtags: DivineUniversity
Adding hashtag filter to relay query: [divineuniversity] (converted to lowercase per NIP-24)
Filter 0: kinds=[34236], t=[divineuniversity], limit=50
...
🏷️📦 Adding hashtag event to buckets: id=..., hashtags=divineuniversity
```

The realtime path already lowercased both sides, so the first page looked fine — only pagination was broken, which is why this went unnoticed.

Scope: **25.2%** of distinct hashtags seen in the last 30 days of production have at least one non-lowercase form, and entry points preserve case — tapping `#DivineUniversity` on a video routes to `/hashtag/DivineUniversity`.

### The fix

Three copies of this comparison existed and **two were case-sensitive**:

| Site | Before | After |
|---|---|---|
| `_handleNewVideoEvent` (realtime) | case-insensitive, inline | uses the shared predicate |
| `_handleHistoricalVideoEvent` (pagination) | **case-sensitive — the bug** | uses the shared predicate |
| `_passesHashtagFilter` (reposts) | **case-sensitive** | now the shared predicate, case-insensitive |

All three route through `_passesHashtagFilter`, which is case-insensitive on both sides — matching what the realtime path already did, so realtime behaviour is unchanged. The repost caller keeps its own `Log.debug` line, so diagnostics are identical.

**Related Issue:** Relates to #3334 (found while investigating that decomposition; independent of it)

## Out of Scope

- The wider `VideoEventService` decomposition — see #3334.
- **Hashtag case-fragmentation.** `#DivineUniversity` surfaces **5 of 164** videos (exact NIP-45 counts: `DivineUniversity` 157, `divineuniversity` 5, `DIVINEUNIVERSITY` 1, `DivineUniverSity` 1).

  **Correction to an earlier version of this description**, which called that "a funnelcake/normalisation issue, not a client one". It is **a divine-mobile publisher bug**. NIP-24: *"`t`: a hashtag. The value MUST be a lowercase string."* funnelcake storing and matching `t` verbatim is spec-correct; lowercasing the tag for the REQ is spec-correct. We are the ones publishing non-compliant values — `tags_picker_bloc.dart:177-181` dedups hashtags case-insensitively and then stores the raw case, and no hop from there to `video_event_publisher.dart:1352-1357` lowercases. divine-web already complies (`usePublishVideo.ts:63-66`). Tracked separately; it does not change this PR.

## Verification

- `flutter analyze lib/services/video_event_service.dart test/services/video_event_service_hashtag_case_test.dart` — no issues
- `flutter test test/services/video_event_service_hashtag_case_test.dart` — 3/3
- Hashtag suites: `hashtag_duplicate_events_test.dart`, `hashtag_filtering_integration_test.dart`, `hashtag_service_test.dart`, `unit/services/video_event_service_hashtag_dedup_integration_test.dart` — 12 passed
- Adjacent VES suites: repost, event_deduplication, pagination, deduplication, adult_filter, broken_filter — 30 passed
- `check_service_god_file_ceiling.sh`, `check_untested_services_floor.sh`, `check_test_unit_structure.sh` — all OK
- **Confirmed the tests fail without the fix**: reverting only the predicate turns both regression tests red while the negative-control test stays green, so they are not just asserting the new behaviour into existence.

### Note for review

The pagination handler had **no test entry point**, which is a large part of why this divergence survived. This adds two `@visibleForTesting` seams (`handleHistoricalEventForTesting`, `setActiveHashtagFilterForTesting`). That makes the file net **+3 lines** (6,566 → 6,569, ceiling 6,619) — happy to drop them and drive a full subscription instead if reviewers would rather not add surface to this file, but the test would get considerably heavier.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

