### PR TITLE
fix(camera): let iOS record music without the speech cleanup

### DIFF
--- a/mobile/lib/blocs/music_mode/music_mode_cubit.dart
+++ b/mobile/lib/blocs/music_mode/music_mode_cubit.dart
@@ -1,0 +1,32 @@
+// ABOUTME: Cubit backing the Music mode toggle in ContentPreferencesScreen.
+
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:openvine/blocs/close_guard.dart';
+import 'package:openvine/blocs/music_mode/music_mode_state.dart';
+import 'package:openvine/services/music_mode_preference_service.dart';
+
+/// Cubit backing the `_MusicModeToggle` tile in `ContentPreferencesScreen`.
+class MusicModeCubit extends Cubit<MusicModeState>
+    with CloseGuardedEmit<MusicModeState> {
+  MusicModeCubit({required MusicModePreferenceService service})
+    : _service = service,
+      super(const MusicModeState());
+
+  final MusicModePreferenceService _service;
+
+  void load() {
+    emit(
+      state.copyWith(
+        status: MusicModeStatus.ready,
+        isEnabled: _service.isMusicModeEnabled,
+      ),
+    );
+  }
+
+  Future<void> setEnabled(bool value) async {
+    await _service.setMusicModeEnabled(value);
+    // The write crosses an await; leaving the settings screen mid-toggle
+    // closes this cubit before it resumes.
+    emitIfOpen(state.copyWith(isEnabled: _service.isMusicModeEnabled));
+  }
+}

--- a/mobile/lib/blocs/music_mode/music_mode_cubit.dart
+++ b/mobile/lib/blocs/music_mode/music_mode_cubit.dart
@@ -15,12 +15,7 @@ class MusicModeCubit extends Cubit<MusicModeState>
   final MusicModePreferenceService _service;
 
   void load() {
-    emit(
-      state.copyWith(
-        status: MusicModeStatus.ready,
-        isEnabled: _service.isMusicModeEnabled,
-      ),
-    );
+    emit(state.copyWith(isEnabled: _service.isMusicModeEnabled));
   }
 
   Future<void> setEnabled(bool value) async {

--- a/mobile/lib/blocs/music_mode/music_mode_state.dart
+++ b/mobile/lib/blocs/music_mode/music_mode_state.dart
@@ -2,29 +2,16 @@
 
 import 'package:equatable/equatable.dart';
 
-/// Load lifecycle of the Music mode tile.
-enum MusicModeStatus { loading, ready }
-
 /// State for `MusicModeCubit`.
 class MusicModeState extends Equatable {
-  const MusicModeState({
-    this.status = MusicModeStatus.loading,
-    this.isEnabled = false,
-  });
+  const MusicModeState({this.isEnabled = false});
 
-  final MusicModeStatus status;
   final bool isEnabled;
 
-  MusicModeState copyWith({
-    MusicModeStatus? status,
-    bool? isEnabled,
-  }) {
-    return MusicModeState(
-      status: status ?? this.status,
-      isEnabled: isEnabled ?? this.isEnabled,
-    );
+  MusicModeState copyWith({bool? isEnabled}) {
+    return MusicModeState(isEnabled: isEnabled ?? this.isEnabled);
   }
 
   @override
-  List<Object?> get props => [status, isEnabled];
+  List<Object?> get props => [isEnabled];
 }

--- a/mobile/lib/blocs/music_mode/music_mode_state.dart
+++ b/mobile/lib/blocs/music_mode/music_mode_state.dart
@@ -1,0 +1,30 @@
+// ABOUTME: State for MusicModeCubit — the Music mode recording preference.
+
+import 'package:equatable/equatable.dart';
+
+/// Load lifecycle of the Music mode tile.
+enum MusicModeStatus { loading, ready }
+
+/// State for `MusicModeCubit`.
+class MusicModeState extends Equatable {
+  const MusicModeState({
+    this.status = MusicModeStatus.loading,
+    this.isEnabled = false,
+  });
+
+  final MusicModeStatus status;
+  final bool isEnabled;
+
+  MusicModeState copyWith({
+    MusicModeStatus? status,
+    bool? isEnabled,
+  }) {
+    return MusicModeState(
+      status: status ?? this.status,
+      isEnabled: isEnabled ?? this.isEnabled,
+    );
+  }
+
+  @override
+  List<Object?> get props => [status, isEnabled];
+}

--- a/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
+++ b/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
@@ -33,6 +33,7 @@ import 'package:openvine/models/video_recorder/video_recorder_timer_duration.dar
 import 'package:openvine/providers/clip_manager_provider.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
 import 'package:openvine/services/haptic_service.dart';
+import 'package:openvine/services/music_mode_preference_service.dart';
 import 'package:openvine/services/performance_monitoring_service.dart';
 import 'package:openvine/services/video_editor/clip_media_duration.dart';
 import 'package:openvine/services/video_recorder/camera/camera_base_service.dart';
@@ -369,6 +370,10 @@ class VideoRecorderBloc
         videoQuality: event.videoQuality,
         initialLens: initialLens,
         enableAutoLensSwitch: true,
+        // Read at init because the audio-session mode is chosen once per
+        // capture session; flipping the setting applies to the next open.
+        preferUnprocessedAudio:
+            prefs.getBool(MusicModePreferenceService.prefsKey) ?? false,
       );
     } catch (e) {
       initError = e;

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -176,6 +176,8 @@
     "contentPreferencesUseDeviceLanguage": "የመሣሪያውን ቋንቋ ተጠቀም (ነባሪ)",
     "contentPreferencesAudioSharing": "የእኔን ኦዲዮ ለእንደገና ጥቅም ላይ እንዲውል አድርግ",
     "contentPreferencesAudioSharingSubtitle": "ሲነቃ ሌሎች ከቪዲዮዎችዎ ኦዲዮን መጠቀም ይችላሉ።",
+    "contentPreferencesMusicMode": "የሙዚቃ ሁነታ",
+    "contentPreferencesMusicModeSubtitle": "የሙዚቃ መሣሪያዎችን የሚያደበዝዘውን የድምፅ ማጽጃ ያጠፋል። ለሙዚቃ የተሻለ፣ ለድምፅ ግን ትንሽ ሻካራ።",
     "contentPreferencesAccountLabels": "መለያ መለያዎች",
     "contentPreferencesAccountLabelsEmpty": "ይዘትዎን በራስ-ይሰይሙ",
     "contentPreferencesAccountContentLabels": "የመለያ ይዘት መለያዎች",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -159,6 +159,8 @@
     "contentPreferencesUseDeviceLanguage": "استخدام لغة الجهاز (افتراضي)",
     "contentPreferencesAudioSharing": "إتاحة صوتي للاستخدام",
     "contentPreferencesAudioSharingSubtitle": "عند التفعيل، يمكن للآخرين استخدام الصوت من فيديوهاتك",
+    "contentPreferencesMusicMode": "وضع الموسيقى",
+    "contentPreferencesMusicModeSubtitle": "يوقف تنقية الضوضاء التي تُخفّت صوت الآلات الموسيقية. أفضل للموسيقى، وأقسى على الأصوات.",
     "contentPreferencesAccountLabels": "وسوم الحساب",
     "contentPreferencesAccountLabelsEmpty": "ضع وسومًا لمحتواك",
     "contentPreferencesAccountContentLabels": "وسوم محتوى الحساب",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -159,6 +159,8 @@
     "contentPreferencesUseDeviceLanguage": "Използвай езика на устройството (по подразбиране)",
     "contentPreferencesAudioSharing": "Позволи моето аудио да се използва отново",
     "contentPreferencesAudioSharingSubtitle": "Когато е включено, други могат да използват аудио от твоите видеа",
+    "contentPreferencesMusicMode": "Музикален режим",
+    "contentPreferencesMusicModeSubtitle": "Изключва шумопотискането, което задушава инструментите. По-добре за музика, по-грубо за глас.",
     "contentPreferencesAccountLabels": "Етикети на акаунта",
     "contentPreferencesAccountLabelsEmpty": "Сам избираш етикетите за съдържанието си",
     "contentPreferencesAccountContentLabels": "Етикети за съдържанието на акаунта",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -159,6 +159,8 @@
     "contentPreferencesUseDeviceLanguage": "Gerätesprache verwenden (Standard)",
     "contentPreferencesAudioSharing": "Mein Audio zur Wiederverwendung freigeben",
     "contentPreferencesAudioSharingSubtitle": "Wenn aktiviert, können andere Audio aus deinen Videos verwenden",
+    "contentPreferencesMusicMode": "Musikmodus",
+    "contentPreferencesMusicModeSubtitle": "Schaltet die Rauschunterdrückung ab, die Instrumente plattmacht. Besser für Musik, rauer für Stimmen.",
     "contentPreferencesAccountLabels": "Konto-Labels",
     "contentPreferencesAccountLabelsEmpty": "Kennzeichne deine Inhalte selbst",
     "contentPreferencesAccountContentLabels": "Konto-Inhalts-Labels",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -194,6 +194,11 @@
   "contentPreferencesUseDeviceLanguage": "Use device language (default)",
   "contentPreferencesAudioSharing": "Make my audio available for reuse",
   "contentPreferencesAudioSharingSubtitle": "When enabled, others can use audio from your videos",
+  "contentPreferencesMusicMode": "Music mode",
+  "contentPreferencesMusicModeSubtitle": "Skips the noise cleanup that flattens instruments. Better for music, rougher on voices.",
+  "@contentPreferencesMusicModeSubtitle": {
+    "description": "Explains the trade-off behind the Music mode switch in Settings -> Content Preferences. Enabling it drops the platform's speech-tuned noise suppression, so instruments keep their real level but spoken audio loses the cleanup that flatters it."
+  },
   "contentPreferencesAccountLabels": "Account Labels",
   "contentPreferencesAccountLabelsEmpty": "Self-label your content",
   "contentPreferencesAccountContentLabels": "Account Content Labels",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -159,6 +159,8 @@
     "contentPreferencesUseDeviceLanguage": "Usar el idioma del dispositivo (predeterminado)",
     "contentPreferencesAudioSharing": "Permitir que reutilicen mi audio",
     "contentPreferencesAudioSharingSubtitle": "Si lo activás, otros pueden usar el audio de tus videos",
+    "contentPreferencesMusicMode": "Modo música",
+    "contentPreferencesMusicModeSubtitle": "Desactiva la limpieza de ruido que aplasta los instrumentos. Mejor para la música, más áspero para las voces.",
     "contentPreferencesAccountLabels": "Etiquetas de la cuenta",
     "contentPreferencesAccountLabelsEmpty": "Auto-etiquetá tu contenido",
     "contentPreferencesAccountContentLabels": "Etiquetas de contenido de la cuenta",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -107,6 +107,8 @@
     "contentPreferencesUseDeviceLanguage": "Gamitin ang wika ng device (default)",
     "contentPreferencesAudioSharing": "Gawing magagamit ng iba ang audio ko",
     "contentPreferencesAudioSharingSubtitle": "Kapag naka-enable, magagamit ng iba ang audio mula sa mga video mo",
+    "contentPreferencesMusicMode": "Music mode",
+    "contentPreferencesMusicModeSubtitle": "Ini-skip ang noise cleanup na pumipipi sa mga instrumento. Mas maganda sa musika, mas magaspang sa boses.",
     "contentPreferencesAccountLabels": "Mga Account Label",
     "contentPreferencesAccountLabelsEmpty": "I-label mo ang sarili mong content",
     "contentPreferencesAccountContentLabels": "Mga Account Content Label",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -159,6 +159,8 @@
     "contentPreferencesUseDeviceLanguage": "Utiliser la langue de l'appareil (par défaut)",
     "contentPreferencesAudioSharing": "Rendre mon audio réutilisable",
     "contentPreferencesAudioSharingSubtitle": "Quand c'est activé, les autres peuvent utiliser l'audio de tes vidéos",
+    "contentPreferencesMusicMode": "Mode musique",
+    "contentPreferencesMusicModeSubtitle": "Désactive le nettoyage du bruit qui écrase les instruments. Mieux pour la musique, plus rugueux pour les voix.",
     "contentPreferencesAccountLabels": "Étiquettes de compte",
     "contentPreferencesAccountLabelsEmpty": "Auto-étiquette ton contenu",
     "contentPreferencesAccountContentLabels": "Étiquettes de contenu du compte",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -159,6 +159,8 @@
     "contentPreferencesUseDeviceLanguage": "Pakai bahasa perangkat (bawaan)",
     "contentPreferencesAudioSharing": "Jadikan audioku bisa dipakai ulang",
     "contentPreferencesAudioSharingSubtitle": "Saat aktif, orang lain bisa memakai audio dari videomu",
+    "contentPreferencesMusicMode": "Mode musik",
+    "contentPreferencesMusicModeSubtitle": "Melewati pembersihan derau yang meredam alat musik. Lebih bagus untuk musik, lebih kasar untuk suara.",
     "contentPreferencesAccountLabels": "Label Akun",
     "contentPreferencesAccountLabelsEmpty": "Beri label sendiri pada kontenmu",
     "contentPreferencesAccountContentLabels": "Label Konten Akun",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -159,6 +159,8 @@
     "contentPreferencesUseDeviceLanguage": "Usa la lingua del dispositivo (predefinita)",
     "contentPreferencesAudioSharing": "Rendi disponibile il mio audio per il riutilizzo",
     "contentPreferencesAudioSharingSubtitle": "Quando attivo, altri possono usare l'audio dei tuoi video",
+    "contentPreferencesMusicMode": "Modalità musica",
+    "contentPreferencesMusicModeSubtitle": "Disattiva la pulizia del rumore che schiaccia gli strumenti. Meglio per la musica, più ruvido sulle voci.",
     "contentPreferencesAccountLabels": "Etichette account",
     "contentPreferencesAccountLabelsEmpty": "Auto-etichetta i tuoi contenuti",
     "contentPreferencesAccountContentLabels": "Etichette contenuti dell'account",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -159,6 +159,8 @@
     "contentPreferencesUseDeviceLanguage": "デバイスの言語を使う (既定)",
     "contentPreferencesAudioSharing": "自分の音声を再利用可能にする",
     "contentPreferencesAudioSharingSubtitle": "オンにすると、他の人があなたの動画の音声を使えるよ",
+    "contentPreferencesMusicMode": "音楽モード",
+    "contentPreferencesMusicModeSubtitle": "楽器の音を潰してしまうノイズ除去をオフにします。音楽向きですが、声には少し粗くなります。",
     "contentPreferencesAccountLabels": "アカウントラベル",
     "contentPreferencesAccountLabelsEmpty": "自分のコンテンツにラベルを付けよう",
     "contentPreferencesAccountContentLabels": "アカウントのコンテンツラベル",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -107,6 +107,8 @@
     "contentPreferencesUseDeviceLanguage": "기기 언어 사용 (기본값)",
     "contentPreferencesAudioSharing": "내 오디오 재사용 허용",
     "contentPreferencesAudioSharingSubtitle": "켜면 다른 사람들이 내 영상의 오디오를 쓸 수 있어요",
+    "contentPreferencesMusicMode": "음악 모드",
+    "contentPreferencesMusicModeSubtitle": "악기 소리를 뭉개는 노이즈 제거를 꺼요. 음악에는 좋고, 목소리에는 조금 거칠어요.",
     "contentPreferencesAccountLabels": "계정 라벨",
     "contentPreferencesAccountLabelsEmpty": "내 콘텐츠에 스스로 라벨 달기",
     "contentPreferencesAccountContentLabels": "계정 콘텐츠 라벨",

--- a/mobile/lib/l10n/app_ms.arb
+++ b/mobile/lib/l10n/app_ms.arb
@@ -156,6 +156,8 @@
   "contentPreferencesUseDeviceLanguage": "Guna bahasa peranti (lalai)",
   "contentPreferencesAudioSharing": "Benarkan audio saya digunakan semula",
   "contentPreferencesAudioSharingSubtitle": "Apabila didayakan, orang lain boleh menggunakan audio daripada video anda",
+  "contentPreferencesMusicMode": "Mod muzik",
+  "contentPreferencesMusicModeSubtitle": "Melangkau pembersihan hingar yang memampatkan bunyi alat muzik. Lebih baik untuk muzik, lebih kasar untuk suara.",
   "contentPreferencesAccountLabels": "Label Akaun",
   "contentPreferencesAccountLabelsEmpty": "Labelkan kandungan anda sendiri",
   "contentPreferencesAccountContentLabels": "Label Kandungan Akaun",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -159,6 +159,8 @@
     "contentPreferencesUseDeviceLanguage": "Gebruik apparaattaal (standaard)",
     "contentPreferencesAudioSharing": "Maak mijn audio beschikbaar voor hergebruik",
     "contentPreferencesAudioSharingSubtitle": "Als dit aanstaat kunnen anderen audio uit je video's gebruiken",
+    "contentPreferencesMusicMode": "Muziekmodus",
+    "contentPreferencesMusicModeSubtitle": "Zet de ruisonderdrukking uit die instrumenten platslaat. Beter voor muziek, ruwer voor stemmen.",
     "contentPreferencesAccountLabels": "Accountlabels",
     "contentPreferencesAccountLabelsEmpty": "Label je eigen inhoud",
     "contentPreferencesAccountContentLabels": "Inhoudslabels voor account",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -159,6 +159,8 @@
     "contentPreferencesUseDeviceLanguage": "Użyj języka urządzenia (domyślnie)",
     "contentPreferencesAudioSharing": "Udostępniaj moje audio do ponownego użycia",
     "contentPreferencesAudioSharingSubtitle": "Gdy włączone, inni mogą używać dźwięku z twoich filmów",
+    "contentPreferencesMusicMode": "Tryb muzyczny",
+    "contentPreferencesMusicModeSubtitle": "Wyłącza redukcję szumów, która spłaszcza instrumenty. Lepiej dla muzyki, gorzej dla głosu.",
     "contentPreferencesAccountLabels": "Etykiety konta",
     "contentPreferencesAccountLabelsEmpty": "Oznacz swoje treści",
     "contentPreferencesAccountContentLabels": "Etykiety treści konta",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -159,6 +159,8 @@
     "contentPreferencesUseDeviceLanguage": "Usar idioma do dispositivo (padrão)",
     "contentPreferencesAudioSharing": "Liberar meu áudio para reutilização",
     "contentPreferencesAudioSharingSubtitle": "Quando ativado, outras pessoas podem usar o áudio dos seus vídeos",
+    "contentPreferencesMusicMode": "Modo música",
+    "contentPreferencesMusicModeSubtitle": "Desliga a limpeza de ruído que achata os instrumentos. Melhor para música, mais bruto nas vozes.",
     "contentPreferencesAccountLabels": "Rótulos da conta",
     "contentPreferencesAccountLabelsEmpty": "Rótulos próprios para seu conteúdo",
     "contentPreferencesAccountContentLabels": "Rótulos de conteúdo da conta",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -159,6 +159,8 @@
     "contentPreferencesUseDeviceLanguage": "Folosește limba dispozitivului (implicit)",
     "contentPreferencesAudioSharing": "Fă audio-ul meu disponibil pentru refolosire",
     "contentPreferencesAudioSharingSubtitle": "Când e activat, alții pot folosi audio din videoclipurile tale",
+    "contentPreferencesMusicMode": "Mod muzică",
+    "contentPreferencesMusicModeSubtitle": "Dezactivează reducerea zgomotului care turtește instrumentele. Mai bine pentru muzică, mai aspru pentru voci.",
     "contentPreferencesAccountLabels": "Etichete de cont",
     "contentPreferencesAccountLabelsEmpty": "Auto-etichetează-ți conținutul",
     "contentPreferencesAccountContentLabels": "Etichete de conținut pentru cont",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -159,6 +159,8 @@
     "contentPreferencesUseDeviceLanguage": "Använd enhetens språk (standard)",
     "contentPreferencesAudioSharing": "Gör mitt ljud tillgängligt för återanvändning",
     "contentPreferencesAudioSharingSubtitle": "När aktiverat kan andra använda ljud från dina videor",
+    "contentPreferencesMusicMode": "Musikläge",
+    "contentPreferencesMusicModeSubtitle": "Stänger av brusreduceringen som plattar till instrument. Bättre för musik, råare för röster.",
     "contentPreferencesAccountLabels": "Kontoetiketter",
     "contentPreferencesAccountLabelsEmpty": "Självmärk ditt innehåll",
     "contentPreferencesAccountContentLabels": "Etiketter för kontoinnehåll",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -159,6 +159,8 @@
     "contentPreferencesUseDeviceLanguage": "Cihaz dilini kullan (varsayılan)",
     "contentPreferencesAudioSharing": "Sesimi yeniden kullanıma aç",
     "contentPreferencesAudioSharingSubtitle": "Etkinleştirildiğinde başkaları videolarındaki sesi kullanabilir",
+    "contentPreferencesMusicMode": "Müzik modu",
+    "contentPreferencesMusicModeSubtitle": "Enstrümanları ezen gürültü temizlemesini kapatır. Müzik için daha iyi, sesler için daha ham.",
     "contentPreferencesAccountLabels": "Hesap Etiketleri",
     "contentPreferencesAccountLabelsEmpty": "İçeriğini kendin etiketle",
     "contentPreferencesAccountContentLabels": "Hesap İçerik Etiketleri",

--- a/mobile/lib/l10n/app_ur.arb
+++ b/mobile/lib/l10n/app_ur.arb
@@ -156,6 +156,8 @@
   "contentPreferencesUseDeviceLanguage": "ڈیوائس کی زبان استعمال کریں (ڈیفالٹ)",
   "contentPreferencesAudioSharing": "میری آڈیو دوبارہ استعمال کے لیے دستیاب کریں",
   "contentPreferencesAudioSharingSubtitle": "فعال ہونے پر دوسرے لوگ آپ کی ویڈیوز کی آڈیو استعمال کر سکتے ہیں",
+  "contentPreferencesMusicMode": "موسیقی موڈ",
+  "contentPreferencesMusicModeSubtitle": "شور کی وہ صفائی بند کر دیتا ہے جو سازوں کو دبا دیتی ہے۔ موسیقی کے لیے بہتر، آوازوں کے لیے کچھ کھردرا۔",
   "contentPreferencesAccountLabels": "اکاؤنٹ لیبلز",
   "contentPreferencesAccountLabelsEmpty": "اپنے مواد کو خود لیبل کریں",
   "contentPreferencesAccountContentLabels": "اکاؤنٹ مواد لیبلز",

--- a/mobile/lib/l10n/app_vi.arb
+++ b/mobile/lib/l10n/app_vi.arb
@@ -156,6 +156,8 @@
   "contentPreferencesUseDeviceLanguage": "Dùng ngôn ngữ thiết bị (mặc định)",
   "contentPreferencesAudioSharing": "Cho phép dùng lại âm thanh của tôi",
   "contentPreferencesAudioSharingSubtitle": "Khi bật, người khác có thể sử dụng âm thanh từ video của bạn",
+  "contentPreferencesMusicMode": "Chế độ âm nhạc",
+  "contentPreferencesMusicModeSubtitle": "Tắt bộ lọc tiếng ồn vốn làm bẹp tiếng nhạc cụ. Hợp với âm nhạc, thô hơn với giọng nói.",
   "contentPreferencesAccountLabels": "Nhãn tài khoản",
   "contentPreferencesAccountLabelsEmpty": "Tự gắn nhãn nội dung của bạn",
   "contentPreferencesAccountContentLabels": "Nhãn nội dung tài khoản",

--- a/mobile/lib/l10n/app_zh.arb
+++ b/mobile/lib/l10n/app_zh.arb
@@ -156,6 +156,8 @@
   "contentPreferencesUseDeviceLanguage": "跟随系统语言（默认）",
   "contentPreferencesAudioSharing": "允许他人二次使用我的音频",
   "contentPreferencesAudioSharingSubtitle": "开启后，其他人可以使用你视频中的音频",
+  "contentPreferencesMusicMode": "音乐模式",
+  "contentPreferencesMusicModeSubtitle": "关掉会压扁乐器声的降噪处理。更适合音乐，人声会糙一点。",
   "contentPreferencesAccountLabels": "账号标签",
   "contentPreferencesAccountLabelsEmpty": "为自己的内容打标签",
   "contentPreferencesAccountContentLabels": "账号内容标签",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -684,6 +684,18 @@ abstract class AppLocalizations {
   /// **'When enabled, others can use audio from your videos'**
   String get contentPreferencesAudioSharingSubtitle;
 
+  /// No description provided for @contentPreferencesMusicMode.
+  ///
+  /// In en, this message translates to:
+  /// **'Music mode'**
+  String get contentPreferencesMusicMode;
+
+  /// Explains the trade-off behind the Music mode switch in Settings -> Content Preferences. Enabling it drops the platform's speech-tuned noise suppression, so instruments keep their real level but spoken audio loses the cleanup that flatters it.
+  ///
+  /// In en, this message translates to:
+  /// **'Skips the noise cleanup that flattens instruments. Better for music, rougher on voices.'**
+  String get contentPreferencesMusicModeSubtitle;
+
   /// No description provided for @contentPreferencesAccountLabels.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -384,6 +384,13 @@ class AppLocalizationsAm extends AppLocalizations {
       'ሲነቃ ሌሎች ከቪዲዮዎችዎ ኦዲዮን መጠቀም ይችላሉ።';
 
   @override
+  String get contentPreferencesMusicMode => 'የሙዚቃ ሁነታ';
+
+  @override
+  String get contentPreferencesMusicModeSubtitle =>
+      'የሙዚቃ መሣሪያዎችን የሚያደበዝዘውን የድምፅ ማጽጃ ያጠፋል። ለሙዚቃ የተሻለ፣ ለድምፅ ግን ትንሽ ሻካራ።';
+
+  @override
   String get contentPreferencesAccountLabels => 'መለያ መለያዎች';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -370,6 +370,13 @@ class AppLocalizationsAr extends AppLocalizations {
       'عند التفعيل، يمكن للآخرين استخدام الصوت من فيديوهاتك';
 
   @override
+  String get contentPreferencesMusicMode => 'وضع الموسيقى';
+
+  @override
+  String get contentPreferencesMusicModeSubtitle =>
+      'يوقف تنقية الضوضاء التي تُخفّت صوت الآلات الموسيقية. أفضل للموسيقى، وأقسى على الأصوات.';
+
+  @override
   String get contentPreferencesAccountLabels => 'وسوم الحساب';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -389,6 +389,13 @@ class AppLocalizationsBg extends AppLocalizations {
       'Когато е включено, други могат да използват аудио от твоите видеа';
 
   @override
+  String get contentPreferencesMusicMode => 'Музикален режим';
+
+  @override
+  String get contentPreferencesMusicModeSubtitle =>
+      'Изключва шумопотискането, което задушава инструментите. По-добре за музика, по-грубо за глас.';
+
+  @override
   String get contentPreferencesAccountLabels => 'Етикети на акаунта';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -388,6 +388,13 @@ class AppLocalizationsDe extends AppLocalizations {
       'Wenn aktiviert, können andere Audio aus deinen Videos verwenden';
 
   @override
+  String get contentPreferencesMusicMode => 'Musikmodus';
+
+  @override
+  String get contentPreferencesMusicModeSubtitle =>
+      'Schaltet die Rauschunterdrückung ab, die Instrumente plattmacht. Besser für Musik, rauer für Stimmen.';
+
+  @override
   String get contentPreferencesAccountLabels => 'Konto-Labels';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -391,6 +391,13 @@ class AppLocalizationsEn extends AppLocalizations {
       'When enabled, others can use audio from your videos';
 
   @override
+  String get contentPreferencesMusicMode => 'Music mode';
+
+  @override
+  String get contentPreferencesMusicModeSubtitle =>
+      'Skips the noise cleanup that flattens instruments. Better for music, rougher on voices.';
+
+  @override
   String get contentPreferencesAccountLabels => 'Account Labels';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -387,6 +387,13 @@ class AppLocalizationsEs extends AppLocalizations {
       'Si lo activás, otros pueden usar el audio de tus videos';
 
   @override
+  String get contentPreferencesMusicMode => 'Modo música';
+
+  @override
+  String get contentPreferencesMusicModeSubtitle =>
+      'Desactiva la limpieza de ruido que aplasta los instrumentos. Mejor para la música, más áspero para las voces.';
+
+  @override
   String get contentPreferencesAccountLabels => 'Etiquetas de la cuenta';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -355,6 +355,13 @@ class AppLocalizationsFil extends AppLocalizations {
       'Kapag naka-enable, magagamit ng iba ang audio mula sa mga video mo';
 
   @override
+  String get contentPreferencesMusicMode => 'Music mode';
+
+  @override
+  String get contentPreferencesMusicModeSubtitle =>
+      'Ini-skip ang noise cleanup na pumipipi sa mga instrumento. Mas maganda sa musika, mas magaspang sa boses.';
+
+  @override
   String get contentPreferencesAccountLabels => 'Mga Account Label';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -394,6 +394,13 @@ class AppLocalizationsFr extends AppLocalizations {
       'Quand c\'est activé, les autres peuvent utiliser l\'audio de tes vidéos';
 
   @override
+  String get contentPreferencesMusicMode => 'Mode musique';
+
+  @override
+  String get contentPreferencesMusicModeSubtitle =>
+      'Désactive le nettoyage du bruit qui écrase les instruments. Mieux pour la musique, plus rugueux pour les voix.';
+
+  @override
   String get contentPreferencesAccountLabels => 'Étiquettes de compte';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -325,6 +325,13 @@ class AppLocalizationsId extends AppLocalizations {
       'Saat aktif, orang lain bisa memakai audio dari videomu';
 
   @override
+  String get contentPreferencesMusicMode => 'Mode musik';
+
+  @override
+  String get contentPreferencesMusicModeSubtitle =>
+      'Melewati pembersihan derau yang meredam alat musik. Lebih bagus untuk musik, lebih kasar untuk suara.';
+
+  @override
   String get contentPreferencesAccountLabels => 'Label Akun';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -389,6 +389,13 @@ class AppLocalizationsIt extends AppLocalizations {
       'Quando attivo, altri possono usare l\'audio dei tuoi video';
 
   @override
+  String get contentPreferencesMusicMode => 'Modalità musica';
+
+  @override
+  String get contentPreferencesMusicModeSubtitle =>
+      'Disattiva la pulizia del rumore che schiaccia gli strumenti. Meglio per la musica, più ruvido sulle voci.';
+
+  @override
   String get contentPreferencesAccountLabels => 'Etichette account';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -311,6 +311,13 @@ class AppLocalizationsJa extends AppLocalizations {
       'オンにすると、他の人があなたの動画の音声を使えるよ';
 
   @override
+  String get contentPreferencesMusicMode => '音楽モード';
+
+  @override
+  String get contentPreferencesMusicModeSubtitle =>
+      '楽器の音を潰してしまうノイズ除去をオフにします。音楽向きですが、声には少し粗くなります。';
+
+  @override
   String get contentPreferencesAccountLabels => 'アカウントラベル';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -312,6 +312,13 @@ class AppLocalizationsKo extends AppLocalizations {
       '켜면 다른 사람들이 내 영상의 오디오를 쓸 수 있어요';
 
   @override
+  String get contentPreferencesMusicMode => '음악 모드';
+
+  @override
+  String get contentPreferencesMusicModeSubtitle =>
+      '악기 소리를 뭉개는 노이즈 제거를 꺼요. 음악에는 좋고, 목소리에는 조금 거칠어요.';
+
+  @override
   String get contentPreferencesAccountLabels => '계정 라벨';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -354,6 +354,13 @@ class AppLocalizationsMs extends AppLocalizations {
       'Apabila didayakan, orang lain boleh menggunakan audio daripada video anda';
 
   @override
+  String get contentPreferencesMusicMode => 'Mod muzik';
+
+  @override
+  String get contentPreferencesMusicModeSubtitle =>
+      'Melangkau pembersihan hingar yang memampatkan bunyi alat muzik. Lebih baik untuk muzik, lebih kasar untuk suara.';
+
+  @override
   String get contentPreferencesAccountLabels => 'Label Akaun';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -385,6 +385,13 @@ class AppLocalizationsNl extends AppLocalizations {
       'Als dit aanstaat kunnen anderen audio uit je video\'s gebruiken';
 
   @override
+  String get contentPreferencesMusicMode => 'Muziekmodus';
+
+  @override
+  String get contentPreferencesMusicModeSubtitle =>
+      'Zet de ruisonderdrukking uit die instrumenten platslaat. Beter voor muziek, ruwer voor stemmen.';
+
+  @override
   String get contentPreferencesAccountLabels => 'Accountlabels';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -395,6 +395,13 @@ class AppLocalizationsPl extends AppLocalizations {
       'Gdy włączone, inni mogą używać dźwięku z twoich filmów';
 
   @override
+  String get contentPreferencesMusicMode => 'Tryb muzyczny';
+
+  @override
+  String get contentPreferencesMusicModeSubtitle =>
+      'Wyłącza redukcję szumów, która spłaszcza instrumenty. Lepiej dla muzyki, gorzej dla głosu.';
+
+  @override
   String get contentPreferencesAccountLabels => 'Etykiety konta';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -387,6 +387,13 @@ class AppLocalizationsPt extends AppLocalizations {
       'Quando ativado, outras pessoas podem usar o áudio dos seus vídeos';
 
   @override
+  String get contentPreferencesMusicMode => 'Modo música';
+
+  @override
+  String get contentPreferencesMusicModeSubtitle =>
+      'Desliga a limpeza de ruído que achata os instrumentos. Melhor para música, mais bruto nas vozes.';
+
+  @override
   String get contentPreferencesAccountLabels => 'Rótulos da conta';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -406,6 +406,13 @@ class AppLocalizationsRo extends AppLocalizations {
       'Când e activat, alții pot folosi audio din videoclipurile tale';
 
   @override
+  String get contentPreferencesMusicMode => 'Mod muzică';
+
+  @override
+  String get contentPreferencesMusicModeSubtitle =>
+      'Dezactivează reducerea zgomotului care turtește instrumentele. Mai bine pentru muzică, mai aspru pentru voci.';
+
+  @override
   String get contentPreferencesAccountLabels => 'Etichete de cont';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -373,6 +373,13 @@ class AppLocalizationsSv extends AppLocalizations {
       'När aktiverat kan andra använda ljud från dina videor';
 
   @override
+  String get contentPreferencesMusicMode => 'Musikläge';
+
+  @override
+  String get contentPreferencesMusicModeSubtitle =>
+      'Stänger av brusreduceringen som plattar till instrument. Bättre för musik, råare för röster.';
+
+  @override
   String get contentPreferencesAccountLabels => 'Kontoetiketter';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -323,6 +323,13 @@ class AppLocalizationsTr extends AppLocalizations {
       'Etkinleştirildiğinde başkaları videolarındaki sesi kullanabilir';
 
   @override
+  String get contentPreferencesMusicMode => 'Müzik modu';
+
+  @override
+  String get contentPreferencesMusicModeSubtitle =>
+      'Enstrümanları ezen gürültü temizlemesini kapatır. Müzik için daha iyi, sesler için daha ham.';
+
+  @override
   String get contentPreferencesAccountLabels => 'Hesap Etiketleri';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -386,6 +386,13 @@ class AppLocalizationsUr extends AppLocalizations {
       'فعال ہونے پر دوسرے لوگ آپ کی ویڈیوز کی آڈیو استعمال کر سکتے ہیں';
 
   @override
+  String get contentPreferencesMusicMode => 'موسیقی موڈ';
+
+  @override
+  String get contentPreferencesMusicModeSubtitle =>
+      'شور کی وہ صفائی بند کر دیتا ہے جو سازوں کو دبا دیتی ہے۔ موسیقی کے لیے بہتر، آوازوں کے لیے کچھ کھردرا۔';
+
+  @override
   String get contentPreferencesAccountLabels => 'اکاؤنٹ لیبلز';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -356,6 +356,13 @@ class AppLocalizationsVi extends AppLocalizations {
       'Khi bật, người khác có thể sử dụng âm thanh từ video của bạn';
 
   @override
+  String get contentPreferencesMusicMode => 'Chế độ âm nhạc';
+
+  @override
+  String get contentPreferencesMusicModeSubtitle =>
+      'Tắt bộ lọc tiếng ồn vốn làm bẹp tiếng nhạc cụ. Hợp với âm nhạc, thô hơn với giọng nói.';
+
+  @override
   String get contentPreferencesAccountLabels => 'Nhãn tài khoản';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -338,6 +338,13 @@ class AppLocalizationsZh extends AppLocalizations {
   String get contentPreferencesAudioSharingSubtitle => '开启后，其他人可以使用你视频中的音频';
 
   @override
+  String get contentPreferencesMusicMode => '音乐模式';
+
+  @override
+  String get contentPreferencesMusicModeSubtitle =>
+      '关掉会压扁乐器声的降噪处理。更适合音乐，人声会糙一点。';
+
+  @override
   String get contentPreferencesAccountLabels => '账号标签';
 
   @override

--- a/mobile/lib/providers/preferences_providers.dart
+++ b/mobile/lib/providers/preferences_providers.dart
@@ -9,6 +9,7 @@ import 'package:openvine/services/audio_sharing_preference_service.dart';
 import 'package:openvine/services/feed_aspect_ratio_preference_service.dart';
 import 'package:openvine/services/hold_to_record_preference_service.dart';
 import 'package:openvine/services/language_preference_service.dart';
+import 'package:openvine/services/music_mode_preference_service.dart';
 import 'package:openvine/services/nostr_signature_verification_preference_service.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -33,6 +34,16 @@ final holdToRecordPreferenceServiceProvider =
       final prefs = ref.watch(sharedPreferencesProvider);
       return HoldToRecordPreferenceService(prefs);
     });
+
+/// Music mode preference service: whether recordings capture the microphone
+/// without the platform's speech-tuned cleanup. Non-autoDispose so the
+/// setting outlives the settings screen that wrote it.
+final musicModePreferenceServiceProvider = Provider<MusicModePreferenceService>(
+  (ref) {
+    final prefs = ref.watch(sharedPreferencesProvider);
+    return MusicModePreferenceService(prefs);
+  },
+);
 
 final nostrSignatureVerificationPreferenceServiceProvider =
     Provider<NostrSignatureVerificationPreferenceService>((ref) {

--- a/mobile/lib/screens/settings/content_preferences_screen.dart
+++ b/mobile/lib/screens/settings/content_preferences_screen.dart
@@ -11,6 +11,7 @@ import 'package:go_router/go_router.dart';
 import 'package:openvine/blocs/audio_device/audio_device_cubit.dart';
 import 'package:openvine/blocs/audio_sharing/audio_sharing_cubit.dart';
 import 'package:openvine/blocs/language_setting/language_setting_cubit.dart';
+import 'package:openvine/blocs/music_mode/music_mode_cubit.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/router/route_paths.dart';
@@ -43,6 +44,8 @@ class ContentPreferencesScreen extends ConsumerWidget {
               const _ContentFiltersTile(),
               const AccountContentLabelsTile(),
               const _AudioSharingToggle(),
+              if (!kIsWeb && defaultTargetPlatform == TargetPlatform.iOS)
+                const _MusicModeToggle(),
               if (!kIsWeb && defaultTargetPlatform != TargetPlatform.linux)
                 const _AudioDeviceSelector(),
             ],
@@ -252,6 +255,42 @@ class _AudioSharingToggleTile extends StatelessWidget {
       subtitle: context.l10n.contentPreferencesAudioSharingSubtitle,
       value: isEnabled,
       onChanged: (value) => context.read<AudioSharingCubit>().setEnabled(value),
+    );
+  }
+}
+
+/// Opt-in unprocessed microphone capture.
+///
+/// iOS-only for now: it maps to the recording audio-session mode, and no
+/// other platform acts on the preference yet (#7796).
+class _MusicModeToggle extends ConsumerWidget {
+  const _MusicModeToggle();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final service = ref.watch(musicModePreferenceServiceProvider);
+    return BlocProvider(
+      key: ValueKey(service),
+      create: (_) => MusicModeCubit(service: service)..load(),
+      child: const _MusicModeToggleTile(),
+    );
+  }
+}
+
+class _MusicModeToggleTile extends StatelessWidget {
+  const _MusicModeToggleTile();
+
+  @override
+  Widget build(BuildContext context) {
+    final isEnabled = context.select(
+      (MusicModeCubit cubit) => cubit.state.isEnabled,
+    );
+    return DivineSwitchTile(
+      leadingIcon: DivineIconName.waveform,
+      title: context.l10n.contentPreferencesMusicMode,
+      subtitle: context.l10n.contentPreferencesMusicModeSubtitle,
+      value: isEnabled,
+      onChanged: (value) => context.read<MusicModeCubit>().setEnabled(value),
     );
   }
 }

--- a/mobile/lib/services/music_mode_preference_service.dart
+++ b/mobile/lib/services/music_mode_preference_service.dart
@@ -1,0 +1,51 @@
+// ABOUTME: Service for the Music mode recording preference (iOS)
+// ABOUTME: Controls whether the mic is captured without speech-tuned cleanup
+
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:unified_logger/unified_logger.dart';
+
+/// Service for the user's "Music mode" recording preference.
+///
+/// When enabled, the camera captures the microphone without the platform's
+/// speech-tuned noise suppression, which otherwise treats a sustained
+/// instrument as noise and gates it away (#7796). Off by default: the
+/// processing is what keeps ordinary talking clips clean.
+///
+/// iOS is the only platform that acts on this today — see
+/// `DivineCamera.initialize(preferUnprocessedAudio:)`.
+class MusicModePreferenceService {
+  MusicModePreferenceService(this._prefs)
+    : _isMusicModeEnabled = _prefs.getBool(prefsKey) ?? false;
+
+  /// SharedPreferences key for the Music mode preference.
+  static const String prefsKey = 'music_mode_enabled';
+
+  final SharedPreferences _prefs;
+  bool _isMusicModeEnabled;
+
+  /// Whether the user has opted into unprocessed audio capture.
+  bool get isMusicModeEnabled => _isMusicModeEnabled;
+
+  /// Set the Music mode preference.
+  ///
+  /// Takes effect the next time the camera is initialized — the audio session
+  /// mode is chosen once per capture session.
+  Future<void> setMusicModeEnabled(bool enabled) async {
+    try {
+      await _prefs.setBool(prefsKey, enabled);
+      _isMusicModeEnabled = enabled;
+
+      Log.debug(
+        'Music mode preference set to: $enabled',
+        name: 'MusicModePreferenceService',
+        category: LogCategory.system,
+      );
+    } catch (e) {
+      Log.error(
+        'Error saving music mode preference: $e',
+        name: 'MusicModePreferenceService',
+        category: LogCategory.system,
+      );
+    }
+  }
+}

--- a/mobile/lib/services/video_recorder/camera/camera_base_service.dart
+++ b/mobile/lib/services/video_recorder/camera/camera_base_service.dart
@@ -51,10 +51,14 @@ abstract class CameraService {
   /// (default: front).
   /// [enableAutoLensSwitch] enables automatic lens switching based on zoom
   /// level (default: true).
+  /// [preferUnprocessedAudio] captures the microphone without the platform's
+  /// speech-tuned noise suppression, so instruments survive at their real
+  /// level (default: false). iOS only — see `MusicModePreferenceService`.
   Future<void> initialize({
     DivineVideoQuality videoQuality = DivineVideoQuality.fhd,
     DivineCameraLens initialLens = DivineCameraLens.front,
     bool enableAutoLensSwitch = false,
+    bool preferUnprocessedAudio = false,
   });
 
   /// Releases camera resources and cleans up.

--- a/mobile/lib/services/video_recorder/camera/camera_linux_service.dart
+++ b/mobile/lib/services/video_recorder/camera/camera_linux_service.dart
@@ -87,6 +87,7 @@ class CameraLinuxService extends CameraService {
     DivineVideoQuality videoQuality = DivineVideoQuality.fhd,
     DivineCameraLens initialLens = DivineCameraLens.front,
     bool enableAutoLensSwitch = false,
+    bool preferUnprocessedAudio = false,
   }) async {
     Log.info(
       'Camera is not available on Linux - showing placeholder',

--- a/mobile/lib/services/video_recorder/camera/camera_mobile_service.dart
+++ b/mobile/lib/services/video_recorder/camera/camera_mobile_service.dart
@@ -28,6 +28,7 @@ class CameraMobileService extends CameraService {
     DivineVideoQuality videoQuality = DivineVideoQuality.fhd,
     DivineCameraLens initialLens = DivineCameraLens.front,
     bool enableAutoLensSwitch = false,
+    bool preferUnprocessedAudio = false,
   }) async {
     // Clear any previous error
     _initializationError = null;
@@ -43,6 +44,7 @@ class CameraMobileService extends CameraService {
         lens: initialLens,
         videoQuality: videoQuality,
         enableAutoLensSwitch: enableAutoLensSwitch,
+        preferUnprocessedAudio: preferUnprocessedAudio,
       );
       _camera.onRecordingAutoStopped = (result) {
         onAutoStopped(EditorVideo.file(result.filePath));

--- a/mobile/packages/divine_camera/ios/Classes/CameraController.swift
+++ b/mobile/packages/divine_camera/ios/Classes/CameraController.swift
@@ -396,6 +396,14 @@ class CameraController: NSObject {
                     mode: mode,
                     options: [.defaultToSpeaker, .allowBluetoothA2DP]
                 )
+                // Stop asking for a mode this device refuses. Left set, the
+                // reuse path in attachAudioToSessionIfNeeded() would read a
+                // permanent mode mismatch and tear the audio capture session
+                // down and back up before every recording, and its cheap
+                // setActive(true) interruption recovery would never run
+                // again. initialize() re-arms the preference, so the refusal
+                // only latches for this capture session.
+                prefersUnprocessedAudio = false
             }
             try audioSession.setActive(true)
             DivineCameraLog.shared.info(

--- a/mobile/packages/divine_camera/ios/Classes/CameraController.swift
+++ b/mobile/packages/divine_camera/ios/Classes/CameraController.swift
@@ -45,6 +45,18 @@ class CameraController: NSObject {
     private var audioWriterInput: AVAssetWriterInput?
     private var pixelBufferAdaptor: AVAssetWriterInputPixelBufferAdaptor?
 
+    /// When true the shared AVAudioSession is configured with
+    /// `.measurement`, the mode Apple documents as minimising system-supplied
+    /// signal processing on the input signal. The default `.videoRecording`
+    /// mode runs speech-tuned noise suppression that gates instruments away
+    /// (#7796). Set once per session from `initialize(preferUnprocessedAudio:)`.
+    private var prefersUnprocessedAudio = false
+
+    /// The AVAudioSession mode this controller wants for capture.
+    private var desiredAudioSessionMode: AVAudioSession.Mode {
+        prefersUnprocessedAudio ? .measurement : .videoRecording
+    }
+
     /// Set by the AVAudioSession interruption observer. While true the
     /// audio capture path is known to be silent and we skip appending
     /// audio buffers to the asset writer.
@@ -349,17 +361,46 @@ class CameraController: NSObject {
             // can fail or the mic gets no samples because the session
             // transitions while still active.
             try? audioSession.setActive(false, options: .notifyOthersOnDeactivation)
-            // .videoRecording mode enables system-level noise suppression and
-            // echo cancellation tuned for direct capture (vs .default which is
-            // tuned for VoIP). This gives better mic quality without extra work.
-            try audioSession.setCategory(
-                .playAndRecord,
-                mode: .videoRecording,
-                options: [.defaultToSpeaker, .allowBluetoothA2DP]
-            )
+            // Mode picks the input processing:
+            // - .videoRecording (default) applies system-level noise
+            //   suppression tuned for direct capture, which keeps speech
+            //   clean but treats sustained non-speech as noise and gates it
+            //   away — that is what eats an instrument (#7796).
+            // - .measurement is the mode Apple documents as minimising
+            //   system-supplied signal processing, so music survives at its
+            //   real level. It costs the camera-adjacent mic selection and
+            //   level normalisation .videoRecording does for speech, which is
+            //   why it is opt-in rather than the default.
+            var mode = desiredAudioSessionMode
+            do {
+                try audioSession.setCategory(
+                    .playAndRecord,
+                    mode: mode,
+                    options: [.defaultToSpeaker, .allowBluetoothA2DP]
+                )
+            } catch {
+                // A device that refuses .measurement must still record: the
+                // outer catch returns false, and a false here means the clip
+                // ships with no audio track at all — a far worse outcome than
+                // the processing the user opted out of.
+                guard mode != .videoRecording else { throw error }
+                DivineCameraLog.shared.warning(
+                    "Audio session rejected mode=\(mode.rawValue) "
+                        + "(\(error.localizedDescription)) — falling back to "
+                        + "videoRecording",
+                    name: "DivineCamera.AudioSession"
+                )
+                mode = .videoRecording
+                try audioSession.setCategory(
+                    .playAndRecord,
+                    mode: mode,
+                    options: [.defaultToSpeaker, .allowBluetoothA2DP]
+                )
+            }
             try audioSession.setActive(true)
             DivineCameraLog.shared.info(
-                "Audio session configured: A2DP playback, built-in mic for recording",
+                "Audio session configured: A2DP playback, built-in mic for "
+                    + "recording, mode=\(mode.rawValue)",
                 name: "DivineCamera.AudioSession"
             )
             return true
@@ -654,8 +695,9 @@ class CameraController: NSObject {
     private var videoEncodingBitRate = 8_000_000
 
     /// Initializes the camera with the specified lens and video quality.
-    func initialize(lens: String, videoQuality: String, enableScreenFlash: Bool = true, mirrorFrontCameraOutput: Bool = true, enableAutoLensSwitch: Bool = true, completion: @escaping ([String: Any]?, String?) -> Void) {
+    func initialize(lens: String, videoQuality: String, enableScreenFlash: Bool = true, mirrorFrontCameraOutput: Bool = true, enableAutoLensSwitch: Bool = true, preferUnprocessedAudio: Bool = false, completion: @escaping ([String: Any]?, String?) -> Void) {
         self.autoLensSwitchRequested = enableAutoLensSwitch
+        self.prefersUnprocessedAudio = preferUnprocessedAudio
         currentLensType = lens
         currentLens = getPositionForLensType(lens)
         screenFlashFeatureEnabled = enableScreenFlash
@@ -1009,7 +1051,11 @@ class CameraController: NSObject {
            self.audioInput != nil,
            self.audioOutput != nil {
             let session = AVAudioSession.sharedInstance()
+            // Mode is part of the contract, not just category: a session left
+            // on .videoRecording would keep gating instruments away even
+            // though the user asked for unprocessed capture (#7796).
             let needsReconfigure = session.category != .playAndRecord
+                || session.mode != desiredAudioSessionMode
             if needsReconfigure {
                 // CRITICAL: stop the audio AVCaptureSession before the
                 // setActive(false)/setActive(true) cycle inside
@@ -2178,6 +2224,7 @@ class CameraController: NSObject {
             DivineCameraLog.shared.info(
                 "Recording audio state: ready=\(audioReady), "
                     + "category=\(session.category.rawValue), "
+                    + "mode=\(session.mode.rawValue), "
                     + "inputs=[\(inputs)], outputs=[\(outputs)], "
                     + "inputMuted=\(inputMuted)",
                 name: "DivineCamera.Recording"
@@ -2660,7 +2707,7 @@ class CameraController: NSObject {
     /// after disposing the camera, and iOS rejects that `setCategory` with
     /// `InsufficientPriority` (OSStatus 561017449) while an audio capture
     /// session is still running. The editor then plays the clip back through
-    /// the recorder's `.playAndRecord` / `.videoRecording` configuration.
+    /// the recorder's `.playAndRecord` capture configuration.
     func release(completion: (() -> Void)? = nil) {
         // Restore screen brightness if screen flash was enabled
         disableScreenFlash()

--- a/mobile/packages/divine_camera/ios/Classes/DivineCameraPlugin.swift
+++ b/mobile/packages/divine_camera/ios/Classes/DivineCameraPlugin.swift
@@ -57,12 +57,15 @@ public class DivineCameraPlugin: NSObject, FlutterPlugin {
             // 1. AudioToolbox + AVAudioSession + mediaserverd XPC roundtrip.
             let audioSession = AVAudioSession.sharedInstance()
             do {
-                // Use the same mode as the real recording path
+                // Warm the mode the real recording path defaults to
                 // (CameraController.configureAudioSessionForRecording).
-                // Pre-warming with a different mode means the warmed audio
-                // route doesn't match what we actually use at record time,
-                // so the first recording still pays the mode-switch cost
-                // and the warmed behaviour drifts from the real one.
+                // Pre-warming a mode we don't record in leaves the warmed
+                // route mismatched, so the first recording still pays the
+                // mode-switch cost and the warmed behaviour drifts from the
+                // real one. This runs at plugin registration, long before
+                // Dart can report the user's unprocessed-audio preference
+                // (#7796), so it can only warm the default — the few users
+                // who opt in pay that switch once, on their first recording.
                 try audioSession.setCategory(
                     .playAndRecord,
                     mode: .videoRecording,
@@ -178,7 +181,8 @@ public class DivineCameraPlugin: NSObject, FlutterPlugin {
             let enableScreenFlash = args["enableScreenFlash"] as? Bool ?? true
             let mirrorFrontCameraOutput = args["mirrorFrontCameraOutput"] as? Bool ?? true
             let enableAutoLensSwitch = args["enableAutoLensSwitch"] as? Bool ?? true
-            initializeCamera(lens: lens, videoQuality: videoQuality, enableScreenFlash: enableScreenFlash, mirrorFrontCameraOutput: mirrorFrontCameraOutput, enableAutoLensSwitch: enableAutoLensSwitch, result: result)
+            let preferUnprocessedAudio = args["preferUnprocessedAudio"] as? Bool ?? false
+            initializeCamera(lens: lens, videoQuality: videoQuality, enableScreenFlash: enableScreenFlash, mirrorFrontCameraOutput: mirrorFrontCameraOutput, enableAutoLensSwitch: enableAutoLensSwitch, preferUnprocessedAudio: preferUnprocessedAudio, result: result)
             
         case "disposeCamera":
             disposeCamera(result: result)
@@ -273,7 +277,7 @@ public class DivineCameraPlugin: NSObject, FlutterPlugin {
         return FlutterError(code: code, message: message, details: nil)
     }
 
-    private func initializeCamera(lens: String, videoQuality: String, enableScreenFlash: Bool, mirrorFrontCameraOutput: Bool, enableAutoLensSwitch: Bool, result: @escaping FlutterResult) {
+    private func initializeCamera(lens: String, videoQuality: String, enableScreenFlash: Bool, mirrorFrontCameraOutput: Bool, enableAutoLensSwitch: Bool, preferUnprocessedAudio: Bool, result: @escaping FlutterResult) {
         guard let registry = textureRegistry else {
             result(Self.cameraError("NO_REGISTRY", "Texture registry not available"))
             return
@@ -285,7 +289,7 @@ public class DivineCameraPlugin: NSObject, FlutterPlugin {
             reclaimLogSink: { [weak self] in self?.installLogSink() }
         )
 
-        cameraController?.initialize(lens: lens, videoQuality: videoQuality, enableScreenFlash: enableScreenFlash, mirrorFrontCameraOutput: mirrorFrontCameraOutput, enableAutoLensSwitch: enableAutoLensSwitch) { [weak self] state, error in
+        cameraController?.initialize(lens: lens, videoQuality: videoQuality, enableScreenFlash: enableScreenFlash, mirrorFrontCameraOutput: mirrorFrontCameraOutput, enableAutoLensSwitch: enableAutoLensSwitch, preferUnprocessedAudio: preferUnprocessedAudio) { [weak self] state, error in
             DispatchQueue.main.async {
                 if let error = error {
                     result(Self.cameraError("INIT_ERROR", error))

--- a/mobile/packages/divine_camera/ios/Classes/DivineCameraPlugin.swift
+++ b/mobile/packages/divine_camera/ios/Classes/DivineCameraPlugin.swift
@@ -64,8 +64,11 @@ public class DivineCameraPlugin: NSObject, FlutterPlugin {
                 // mode-switch cost and the warmed behaviour drifts from the
                 // real one. This runs at plugin registration, long before
                 // Dart can report the user's unprocessed-audio preference
-                // (#7796), so it can only warm the default — the few users
-                // who opt in pay that switch once, on their first recording.
+                // (#7796), so it can only warm the default. Music mode then
+                // switches the session once, from the deferred audio
+                // pre-build a second after the first preview frame — not
+                // from the record tap, which is what that pre-build exists
+                // to keep clear.
                 try audioSession.setCategory(
                     .playAndRecord,
                     mode: .videoRecording,

--- a/mobile/packages/divine_camera/lib/divine_camera.dart
+++ b/mobile/packages/divine_camera/lib/divine_camera.dart
@@ -105,6 +105,10 @@ class DivineCamera {
   /// as a mirror image (like the preview).
   /// When `false`, the video shows the real-world orientation (non-mirrored).
   /// The preview is always mirrored.
+  /// [preferUnprocessedAudio] captures the microphone without the
+  /// speech-tuned noise suppression the platform applies by default, so
+  /// instruments and music survive at their real level. iOS only — every
+  /// other platform ignores it.
   ///
   /// Returns the initialized camera state.
   Future<CameraState> initialize({
@@ -113,6 +117,7 @@ class DivineCamera {
     bool enableScreenFlash = true,
     bool mirrorFrontCameraOutput = false,
     bool enableAutoLensSwitch = true,
+    bool preferUnprocessedAudio = false,
   }) async {
     // Register auto-stop callback with platform
     _platform.onRecordingAutoStopped = _handleAutoStop;
@@ -129,6 +134,7 @@ class DivineCamera {
       enableScreenFlash: enableScreenFlash,
       mirrorFrontCameraOutput: mirrorFrontCameraOutput,
       enableAutoLensSwitch: enableAutoLensSwitch,
+      preferUnprocessedAudio: preferUnprocessedAudio,
     );
     _notifyStateChanged();
     return _state;

--- a/mobile/packages/divine_camera/lib/divine_camera_method_channel.dart
+++ b/mobile/packages/divine_camera/lib/divine_camera_method_channel.dart
@@ -125,6 +125,7 @@ class MethodChannelDivineCamera extends DivineCameraPlatform {
     bool enableScreenFlash = true,
     bool mirrorFrontCameraOutput = true,
     bool enableAutoLensSwitch = true,
+    bool preferUnprocessedAudio = false,
   }) async {
     final result = await methodChannel.invokeMapMethod<dynamic, dynamic>(
       'initializeCamera',
@@ -134,6 +135,7 @@ class MethodChannelDivineCamera extends DivineCameraPlatform {
         'enableScreenFlash': enableScreenFlash,
         'mirrorFrontCameraOutput': mirrorFrontCameraOutput,
         'enableAutoLensSwitch': enableAutoLensSwitch,
+        'preferUnprocessedAudio': preferUnprocessedAudio,
       },
     );
     if (result == null) {

--- a/mobile/packages/divine_camera/lib/divine_camera_platform_interface.dart
+++ b/mobile/packages/divine_camera/lib/divine_camera_platform_interface.dart
@@ -40,6 +40,11 @@ abstract class DivineCameraPlatform extends PlatformInterface {
   }
 
   /// Initializes the camera with the specified lens.
+  ///
+  /// [preferUnprocessedAudio] asks the platform to capture the microphone
+  /// without the speech-tuned processing it applies by default. iOS only —
+  /// other platforms ignore it.
+  ///
   /// Returns the initial camera state.
   Future<CameraState> initializeCamera({
     DivineCameraLens lens = DivineCameraLens.back,
@@ -47,6 +52,7 @@ abstract class DivineCameraPlatform extends PlatformInterface {
     bool enableScreenFlash = true,
     bool mirrorFrontCameraOutput = true,
     bool enableAutoLensSwitch = true,
+    bool preferUnprocessedAudio = false,
   }) {
     throw UnimplementedError('initializeCamera() has not been implemented.');
   }

--- a/mobile/packages/divine_camera/test/divine_camera_method_channel_test.dart
+++ b/mobile/packages/divine_camera/test/divine_camera_method_channel_test.dart
@@ -9,10 +9,12 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   late MethodChannelDivineCamera platform;
+  Map<dynamic, dynamic>? lastInitializeArgs;
   const channel = MethodChannel('divine_camera');
 
   setUp(() {
     platform = MethodChannelDivineCamera();
+    lastInitializeArgs = null;
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(channel, (methodCall) async {
           final args = methodCall.arguments as Map<dynamic, dynamic>?;
@@ -20,6 +22,7 @@ void main() {
             case 'getPlatformVersion':
               return 'Android 14';
             case 'initializeCamera':
+              lastInitializeArgs = args;
               return {
                 'isInitialized': true,
                 'isRecording': false,
@@ -134,6 +137,23 @@ void main() {
       expect(state.hasFrontCamera, isTrue);
       expect(state.hasBackCamera, isTrue);
       expect(state.textureId, 1);
+    });
+
+    test(
+      'initializeCamera defaults to the platform audio processing',
+      () async {
+        await platform.initializeCamera();
+
+        expect(lastInitializeArgs?['preferUnprocessedAudio'], isFalse);
+      },
+    );
+
+    test('initializeCamera forwards the unprocessed-audio request', () async {
+      // iOS reads this key to pick the recording audio-session mode (#7796);
+      // dropping it here silently strands the Music mode setting.
+      await platform.initializeCamera(preferUnprocessedAudio: true);
+
+      expect(lastInitializeArgs?['preferUnprocessedAudio'], isTrue);
     });
 
     test('initializeCamera with front lens', () async {

--- a/mobile/packages/divine_camera/test/divine_camera_platform_interface_test.dart
+++ b/mobile/packages/divine_camera/test/divine_camera_platform_interface_test.dart
@@ -17,6 +17,7 @@ class TestDivineCameraPlatform extends DivineCameraPlatform
     bool enableScreenFlash = true,
     bool mirrorFrontCameraOutput = false,
     bool enableAutoLensSwitch = false,
+    bool preferUnprocessedAudio = false,
   }) async => const CameraState(isInitialized: true);
 
   @override

--- a/mobile/packages/divine_camera/test/divine_camera_test.dart
+++ b/mobile/packages/divine_camera/test/divine_camera_test.dart
@@ -71,6 +71,7 @@ class MockDivineCameraPlatform
     bool enableScreenFlash = true,
     bool mirrorFrontCameraOutput = false,
     bool enableAutoLensSwitch = false,
+    bool preferUnprocessedAudio = false,
   }) async {
     return _state = CameraState(
       isInitialized: true,
@@ -1975,6 +1976,7 @@ class _RotatedFocusMock extends MockDivineCameraPlatform {
     bool enableScreenFlash = true,
     bool mirrorFrontCameraOutput = false,
     bool enableAutoLensSwitch = false,
+    bool preferUnprocessedAudio = false,
   }) async {
     return CameraState(
       isInitialized: true,
@@ -1994,6 +1996,7 @@ class _NoFocusSupportMock extends MockDivineCameraPlatform {
     bool enableScreenFlash = true,
     bool mirrorFrontCameraOutput = false,
     bool enableAutoLensSwitch = false,
+    bool preferUnprocessedAudio = false,
   }) async {
     return const CameraState(
       isInitialized: true,
@@ -2011,6 +2014,7 @@ class _NoExposureSupportMock extends MockDivineCameraPlatform {
     bool enableScreenFlash = true,
     bool mirrorFrontCameraOutput = false,
     bool enableAutoLensSwitch = false,
+    bool preferUnprocessedAudio = false,
   }) async {
     return const CameraState(isInitialized: true, isFocusPointSupported: true);
   }
@@ -2025,6 +2029,7 @@ class _SingleCameraMock extends MockDivineCameraPlatform {
     bool enableScreenFlash = true,
     bool mirrorFrontCameraOutput = false,
     bool enableAutoLensSwitch = false,
+    bool preferUnprocessedAudio = false,
   }) async {
     return const CameraState(isInitialized: true, hasBackCamera: true);
   }

--- a/mobile/packages/divine_camera/test/ios_audio_processing_contract_test.dart
+++ b/mobile/packages/divine_camera/test/ios_audio_processing_contract_test.dart
@@ -1,4 +1,5 @@
-// ABOUTME: Static guards for the iOS unprocessed-audio capture contract (#7796).
+// ABOUTME: Static guards for the iOS unprocessed-audio capture contract.
+// ABOUTME: Pins the Music mode audio-session mode mapping (#7796).
 
 import 'dart:io';
 

--- a/mobile/packages/divine_camera/test/ios_audio_processing_contract_test.dart
+++ b/mobile/packages/divine_camera/test/ios_audio_processing_contract_test.dart
@@ -1,0 +1,85 @@
+// ABOUTME: Static guards for the iOS unprocessed-audio capture contract (#7796).
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('iOS unprocessed audio contract', () {
+    late final String controllerSource;
+    late final String pluginSource;
+
+    String read(String relativePath) {
+      final file = [
+        File('ios/Classes/$relativePath'),
+        File('packages/divine_camera/ios/Classes/$relativePath'),
+      ].firstWhere((file) => file.existsSync());
+      return file.readAsStringSync();
+    }
+
+    setUpAll(() {
+      controllerSource = read('CameraController.swift');
+      pluginSource = read('DivineCameraPlugin.swift');
+    });
+
+    test('keeps the speech-tuned mode as the default', () {
+      // Off by default is the whole reason this ships as an opt-in: the
+      // processing is what keeps ordinary talking clips clean.
+      expect(
+        controllerSource,
+        contains('private var prefersUnprocessedAudio = false'),
+      );
+      expect(
+        pluginSource,
+        contains('args["preferUnprocessedAudio"] as? Bool ?? false'),
+      );
+    });
+
+    test('maps the preference onto .measurement', () {
+      // .measurement is the mode Apple documents as minimising
+      // system-supplied input processing — the escape hatch from the noise
+      // suppression that gates an instrument away.
+      expect(
+        controllerSource,
+        contains('prefersUnprocessedAudio ? .measurement : .videoRecording'),
+      );
+    });
+
+    test('configures the session from the resolved mode, not a literal', () {
+      // A hardcoded `mode: .videoRecording` here would silently ignore the
+      // preference while every other layer reported it as applied.
+      expect(controllerSource, contains('var mode = desiredAudioSessionMode'));
+      expect(controllerSource, contains('mode: mode,'));
+      expect(controllerSource, isNot(contains('mode: .videoRecording,')));
+    });
+
+    test('falls back to the default mode rather than losing the audio', () {
+      // A device that rejects .measurement must still get an audio track:
+      // returning false here ships a clip with no audio at all, which is
+      // worse than the processing the user opted out of.
+      expect(
+        controllerSource,
+        contains('guard mode != .videoRecording else { throw error }'),
+      );
+      expect(controllerSource, contains('falling back to '));
+    });
+
+    test(
+      'treats a live session on the wrong mode as needing a reconfigure',
+      () {
+        // The reuse path returns early when the category already matches, so
+        // without the mode check a warm session keeps the old processing.
+        expect(
+          controllerSource,
+          contains('|| session.mode != desiredAudioSessionMode'),
+        );
+      },
+    );
+
+    test('logs the active mode with the per-recording audio state', () {
+      // A "music sounds gated" bug report has to be answerable from the
+      // captured log alone.
+      expect(controllerSource, contains(r'mode=\(session.mode.rawValue)'));
+    });
+  });
+}

--- a/mobile/packages/divine_camera/test/ios_audio_processing_contract_test.dart
+++ b/mobile/packages/divine_camera/test/ios_audio_processing_contract_test.dart
@@ -5,22 +5,53 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
+String _readNativeSource(String fileName) {
+  final file = [
+    File('ios/Classes/$fileName'),
+    File('packages/divine_camera/ios/Classes/$fileName'),
+  ].firstWhere((file) => file.existsSync());
+
+  return file.readAsStringSync();
+}
+
+/// Returns the Swift declaration starting at [signature] up to its closing
+/// brace, so an assertion cannot match an identical line elsewhere in the
+/// file, nor a line that sits outside the scope being asserted on.
+String _declarationAt(String source, String signature) {
+  final start = source.indexOf(signature);
+  if (start < 0) {
+    throw StateError('No declaration starting with "$signature".');
+  }
+
+  var depth = 0;
+  for (var i = source.indexOf('{', start); i < source.length; i++) {
+    if (source[i] == '{') depth++;
+    if (source[i] == '}') {
+      depth--;
+      if (depth == 0) return source.substring(start, i + 1);
+    }
+  }
+  throw StateError('Unbalanced braces after "$signature".');
+}
+
 void main() {
   group('iOS unprocessed audio contract', () {
     late final String controllerSource;
     late final String pluginSource;
-
-    String read(String relativePath) {
-      final file = [
-        File('ios/Classes/$relativePath'),
-        File('packages/divine_camera/ios/Classes/$relativePath'),
-      ].firstWhere((file) => file.existsSync());
-      return file.readAsStringSync();
-    }
+    late final String configureAudioSession;
+    late final String attachAudioToSession;
 
     setUpAll(() {
-      controllerSource = read('CameraController.swift');
-      pluginSource = read('DivineCameraPlugin.swift');
+      controllerSource = _readNativeSource('CameraController.swift');
+      pluginSource = _readNativeSource('DivineCameraPlugin.swift');
+      configureAudioSession = _declarationAt(
+        controllerSource,
+        'private func configureAudioSessionForRecording(',
+      );
+      attachAudioToSession = _declarationAt(
+        controllerSource,
+        'private func attachAudioToSessionIfNeeded(',
+      );
     });
 
     test('keeps the speech-tuned mode as the default', () {
@@ -49,9 +80,12 @@ void main() {
     test('configures the session from the resolved mode, not a literal', () {
       // A hardcoded `mode: .videoRecording` here would silently ignore the
       // preference while every other layer reported it as applied.
-      expect(controllerSource, contains('var mode = desiredAudioSessionMode'));
-      expect(controllerSource, contains('mode: mode,'));
-      expect(controllerSource, isNot(contains('mode: .videoRecording,')));
+      expect(
+        configureAudioSession,
+        contains('var mode = desiredAudioSessionMode'),
+      );
+      expect(configureAudioSession, contains('mode: mode,'));
+      expect(configureAudioSession, isNot(contains('mode: .videoRecording,')));
     });
 
     test('falls back to the default mode rather than losing the audio', () {
@@ -59,10 +93,21 @@ void main() {
       // returning false here ships a clip with no audio at all, which is
       // worse than the processing the user opted out of.
       expect(
-        controllerSource,
+        configureAudioSession,
         contains('guard mode != .videoRecording else { throw error }'),
       );
-      expect(controllerSource, contains('falling back to '));
+      expect(configureAudioSession, contains('falling back to '));
+    });
+
+    test('latches a refused mode so the reuse path stops churning', () {
+      // Without this the preference stays set after the fallback, so the
+      // reuse path below reads a permanent mode mismatch and tears the audio
+      // capture session down and back up before every recording — and its
+      // cheap setActive(true) interruption recovery never runs again.
+      expect(
+        configureAudioSession,
+        contains('prefersUnprocessedAudio = false'),
+      );
     });
 
     test(
@@ -71,7 +116,7 @@ void main() {
         // The reuse path returns early when the category already matches, so
         // without the mode check a warm session keeps the old processing.
         expect(
-          controllerSource,
+          attachAudioToSession,
           contains('|| session.mode != desiredAudioSessionMode'),
         );
       },

--- a/mobile/packages/divine_camera/test/widgets/camera_preview_widget_test.dart
+++ b/mobile/packages/divine_camera/test/widgets/camera_preview_widget_test.dart
@@ -53,6 +53,7 @@ class MockDivineCameraPlatform
     bool enableScreenFlash = true,
     bool mirrorFrontCameraOutput = false,
     bool enableAutoLensSwitch = false,
+    bool preferUnprocessedAudio = false,
   }) async {
     return _state = CameraState(
       isInitialized: true,
@@ -144,6 +145,7 @@ class _WideAspectRatioMock extends MockDivineCameraPlatform {
     bool enableScreenFlash = true,
     bool mirrorFrontCameraOutput = false,
     bool enableAutoLensSwitch = false,
+    bool preferUnprocessedAudio = false,
   }) async {
     return const CameraState(
       isInitialized: true,
@@ -162,6 +164,7 @@ class _RotatedPreviewMock extends MockDivineCameraPlatform {
     bool enableScreenFlash = true,
     bool mirrorFrontCameraOutput = false,
     bool enableAutoLensSwitch = false,
+    bool preferUnprocessedAudio = false,
   }) async {
     return const CameraState(
       isInitialized: true,

--- a/mobile/test/blocs/music_mode/music_mode_cubit_test.dart
+++ b/mobile/test/blocs/music_mode/music_mode_cubit_test.dart
@@ -1,0 +1,53 @@
+// ABOUTME: Unit tests for MusicModeCubit — load + toggle.
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/blocs/music_mode/music_mode_cubit.dart';
+import 'package:openvine/blocs/music_mode/music_mode_state.dart';
+import 'package:openvine/services/music_mode_preference_service.dart';
+
+class _MockMusicModePreferenceService extends Mock
+    implements MusicModePreferenceService {}
+
+void main() {
+  group(MusicModeCubit, () {
+    late _MockMusicModePreferenceService service;
+
+    setUp(() {
+      service = _MockMusicModePreferenceService();
+      when(() => service.isMusicModeEnabled).thenReturn(false);
+      when(() => service.setMusicModeEnabled(any())).thenAnswer((_) async {});
+    });
+
+    MusicModeCubit buildCubit() => MusicModeCubit(service: service);
+
+    blocTest<MusicModeCubit, MusicModeState>(
+      'load snapshots service state',
+      setUp: () {
+        when(() => service.isMusicModeEnabled).thenReturn(true);
+      },
+      build: buildCubit,
+      act: (cubit) => cubit.load(),
+      expect: () => [
+        const MusicModeState(status: MusicModeStatus.ready, isEnabled: true),
+      ],
+    );
+
+    blocTest<MusicModeCubit, MusicModeState>(
+      'setEnabled delegates to service and emits re-read snapshot',
+      seed: () => const MusicModeState(status: MusicModeStatus.ready),
+      setUp: () {
+        when(() => service.isMusicModeEnabled).thenReturn(true);
+      },
+      build: buildCubit,
+      act: (cubit) => cubit.setEnabled(true),
+      expect: () => [
+        const MusicModeState(status: MusicModeStatus.ready, isEnabled: true),
+      ],
+      verify: (_) {
+        verify(() => service.setMusicModeEnabled(true)).called(1);
+      },
+    );
+  });
+}

--- a/mobile/test/blocs/music_mode/music_mode_cubit_test.dart
+++ b/mobile/test/blocs/music_mode/music_mode_cubit_test.dart
@@ -29,22 +29,17 @@ void main() {
       },
       build: buildCubit,
       act: (cubit) => cubit.load(),
-      expect: () => [
-        const MusicModeState(status: MusicModeStatus.ready, isEnabled: true),
-      ],
+      expect: () => [const MusicModeState(isEnabled: true)],
     );
 
     blocTest<MusicModeCubit, MusicModeState>(
       'setEnabled delegates to service and emits re-read snapshot',
-      seed: () => const MusicModeState(status: MusicModeStatus.ready),
       setUp: () {
         when(() => service.isMusicModeEnabled).thenReturn(true);
       },
       build: buildCubit,
       act: (cubit) => cubit.setEnabled(true),
-      expect: () => [
-        const MusicModeState(status: MusicModeStatus.ready, isEnabled: true),
-      ],
+      expect: () => [const MusicModeState(isEnabled: true)],
       verify: (_) {
         verify(() => service.setMusicModeEnabled(true)).called(1);
       },

--- a/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
+++ b/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
@@ -21,6 +21,7 @@ import 'package:openvine/models/video_recorder/video_recorder_state.dart';
 import 'package:openvine/models/video_recorder/video_recorder_timer_duration.dart';
 import 'package:openvine/providers/clip_manager_provider.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
+import 'package:openvine/services/music_mode_preference_service.dart';
 import 'package:openvine/services/performance_monitoring_service.dart';
 import 'package:openvine/services/video_recorder/camera/camera_base_service.dart';
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
@@ -2225,6 +2226,7 @@ void main() {
             videoQuality: any(named: 'videoQuality'),
             initialLens: any(named: 'initialLens'),
             enableAutoLensSwitch: any(named: 'enableAutoLensSwitch'),
+            preferUnprocessedAudio: any(named: 'preferUnprocessedAudio'),
           ),
         ).thenAnswer((_) async {});
         when(
@@ -2283,6 +2285,7 @@ void main() {
               videoQuality: any(named: 'videoQuality'),
               initialLens: any(named: 'initialLens'),
               enableAutoLensSwitch: any(named: 'enableAutoLensSwitch'),
+              preferUnprocessedAudio: any(named: 'preferUnprocessedAudio'),
             ),
           ).thenThrow(Exception('camera boom')),
           build: buildTraced,
@@ -2303,6 +2306,28 @@ void main() {
               videoQuality: any(named: 'videoQuality'),
               initialLens: any(named: 'initialLens'),
               enableAutoLensSwitch: true,
+              preferUnprocessedAudio: any(named: 'preferUnprocessedAudio'),
+            ),
+          ).called(1);
+        },
+      );
+
+      blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
+        'asks for unprocessed capture when Music mode is on',
+        setUp: () {
+          when(
+            () => prefs.getBool(MusicModePreferenceService.prefsKey),
+          ).thenReturn(true);
+        },
+        build: buildBloc,
+        act: (bloc) => bloc.add(const VideoRecorderInitializeRequested()),
+        verify: (_) {
+          verify(
+            () => cameraService.initialize(
+              videoQuality: any(named: 'videoQuality'),
+              initialLens: any(named: 'initialLens'),
+              enableAutoLensSwitch: any(named: 'enableAutoLensSwitch'),
+              preferUnprocessedAudio: true,
             ),
           ).called(1);
         },
@@ -2657,6 +2682,7 @@ void main() {
               videoQuality: any(named: 'videoQuality'),
               initialLens: any(named: 'initialLens'),
               enableAutoLensSwitch: any(named: 'enableAutoLensSwitch'),
+              preferUnprocessedAudio: any(named: 'preferUnprocessedAudio'),
             ),
           ).thenAnswer((_) async {});
           when(

--- a/mobile/test/mocks/mock_camera_service.dart
+++ b/mobile/test/mocks/mock_camera_service.dart
@@ -34,6 +34,7 @@ class MockCameraService extends CameraService {
     DivineVideoQuality videoQuality = DivineVideoQuality.fhd,
     DivineCameraLens initialLens = DivineCameraLens.front,
     bool enableAutoLensSwitch = false,
+    bool preferUnprocessedAudio = false,
   }) async {
     _currentLens = initialLens;
     _isInitialized = true;

--- a/mobile/test/screens/settings/content_preferences_music_mode_test.dart
+++ b/mobile/test/screens/settings/content_preferences_music_mode_test.dart
@@ -1,0 +1,159 @@
+// ABOUTME: Tests the Music mode toggle in content preferences (#7796).
+// ABOUTME: Covers the iOS-only gate and that a tap reaches the preference.
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
+import 'package:openvine/screens/settings/content_preferences_screen.dart';
+import 'package:openvine/services/account_label_service.dart';
+import 'package:openvine/services/audio_sharing_preference_service.dart';
+import 'package:openvine/services/language_preference_service.dart';
+import 'package:openvine/services/music_mode_preference_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockAudioSharingPreferenceService extends Mock
+    implements AudioSharingPreferenceService {}
+
+class _MockLanguagePreferenceService extends Mock
+    implements LanguagePreferenceService {}
+
+class _MockAccountLabelService extends Mock implements AccountLabelService {}
+
+class _MockMusicModePreferenceService extends Mock
+    implements MusicModePreferenceService {}
+
+void main() {
+  group('ContentPreferencesScreen Music mode toggle', () {
+    final l10n = lookupAppLocalizations(const Locale('en'));
+    late _MockAudioSharingPreferenceService audioSharingService;
+    late _MockLanguagePreferenceService languageService;
+    late _MockAccountLabelService accountLabelService;
+    late _MockMusicModePreferenceService musicModeService;
+    late SharedPreferences sharedPreferences;
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      sharedPreferences = await SharedPreferences.getInstance();
+      audioSharingService = _MockAudioSharingPreferenceService();
+      languageService = _MockLanguagePreferenceService();
+      accountLabelService = _MockAccountLabelService();
+      musicModeService = _MockMusicModePreferenceService();
+
+      when(() => audioSharingService.isAudioSharingEnabled).thenReturn(false);
+      when(
+        () => audioSharingService.setAudioSharingEnabled(any()),
+      ).thenAnswer((_) async {});
+      when(() => languageService.initialize()).thenAnswer((_) async {});
+      when(() => languageService.contentLanguage).thenReturn('en');
+      when(() => languageService.isCustomLanguageSet).thenReturn(false);
+      when(() => accountLabelService.accountLabels).thenReturn({});
+      when(() => accountLabelService.initialized).thenAnswer((_) async {});
+      when(() => musicModeService.isMusicModeEnabled).thenReturn(false);
+      when(
+        () => musicModeService.setMusicModeEnabled(any()),
+      ).thenAnswer((_) async {});
+    });
+
+    // testWidgets asserts every foundation debug var is unset when the body
+    // returns, before tearDown runs — hence the in-body reset in `disposeTree`.
+    // This tearDown only catches bodies that threw before reaching it.
+    tearDown(() => debugDefaultTargetPlatformOverride = null);
+
+    Widget createTestWidget() {
+      return ProviderScope(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(sharedPreferences),
+          audioSharingPreferenceServiceProvider.overrideWithValue(
+            audioSharingService,
+          ),
+          languagePreferenceServiceProvider.overrideWithValue(languageService),
+          accountLabelServiceProvider.overrideWithValue(accountLabelService),
+          musicModePreferenceServiceProvider.overrideWithValue(
+            musicModeService,
+          ),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          theme: VineTheme.theme,
+          home: const ContentPreferencesScreen(),
+        ),
+      );
+    }
+
+    Future<void> disposeTree(WidgetTester tester) async {
+      await tester.pumpWidget(const SizedBox());
+      await tester.pump();
+      debugDefaultTargetPlatformOverride = null;
+    }
+
+    Finder musicModeTile() => find.byWidgetPredicate(
+      (widget) =>
+          widget is DivineSwitchTile &&
+          widget.title == l10n.contentPreferencesMusicMode,
+    );
+
+    testWidgets('shows the toggle on iOS with its trade-off subtitle', (
+      tester,
+    ) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+
+      await tester.pumpWidget(createTestWidget());
+      await tester.pumpAndSettle();
+
+      expect(musicModeTile(), findsOneWidget);
+      expect(
+        find.text(l10n.contentPreferencesMusicModeSubtitle),
+        findsOneWidget,
+      );
+
+      await disposeTree(tester);
+    });
+
+    testWidgets('hides the toggle where nothing acts on it', (tester) async {
+      // Android resolves its recording audio source separately (#7652), so a
+      // switch there would be a control that does nothing.
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+
+      await tester.pumpWidget(createTestWidget());
+      await tester.pumpAndSettle();
+
+      expect(musicModeTile(), findsNothing);
+
+      await disposeTree(tester);
+    });
+
+    testWidgets('reflects the persisted preference', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      when(() => musicModeService.isMusicModeEnabled).thenReturn(true);
+
+      await tester.pumpWidget(createTestWidget());
+      await tester.pumpAndSettle();
+
+      final tile = tester.widget<DivineSwitchTile>(musicModeTile());
+      expect(tile.value, isTrue);
+
+      await disposeTree(tester);
+    });
+
+    testWidgets('tapping the toggle writes the preference', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+
+      await tester.pumpWidget(createTestWidget());
+      await tester.pumpAndSettle();
+
+      await tester.tap(musicModeTile());
+      await tester.pumpAndSettle();
+
+      verify(() => musicModeService.setMusicModeEnabled(true)).called(1);
+
+      await disposeTree(tester);
+    });
+  });
+}

--- a/mobile/test/services/music_mode_preference_service_test.dart
+++ b/mobile/test/services/music_mode_preference_service_test.dart
@@ -1,3 +1,6 @@
+// ABOUTME: Unit tests for MusicModePreferenceService — the Music mode flag.
+// ABOUTME: Pins the default-off behaviour and the persisted key (#7796).
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/services/music_mode_preference_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';

--- a/mobile/test/services/music_mode_preference_service_test.dart
+++ b/mobile/test/services/music_mode_preference_service_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/services/music_mode_preference_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  group(MusicModePreferenceService, () {
+    late SharedPreferences prefs;
+    late MusicModePreferenceService service;
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      prefs = await SharedPreferences.getInstance();
+      service = MusicModePreferenceService(prefs);
+    });
+
+    test('defaults to disabled so speech capture keeps its cleanup', () {
+      expect(service.isMusicModeEnabled, isFalse);
+    });
+
+    test('persists enabled preference', () async {
+      await service.setMusicModeEnabled(true);
+
+      final reloaded = MusicModePreferenceService(prefs);
+
+      expect(reloaded.isMusicModeEnabled, isTrue);
+    });
+
+    test('persists disabled preference', () async {
+      await service.setMusicModeEnabled(true);
+      await service.setMusicModeEnabled(false);
+
+      final reloaded = MusicModePreferenceService(prefs);
+
+      expect(reloaded.isMusicModeEnabled, isFalse);
+    });
+
+    test('uses the key VideoRecorderBloc reads at camera init', () {
+      // The bloc reads this key straight off SharedPreferences, so a rename
+      // here silently strands the setting.
+      expect(MusicModePreferenceService.prefsKey, 'music_mode_enabled');
+    });
+  });
+}

--- a/mobile/test/widgets/video_recorder/preview/video_recorder_mobile_preview_test.dart
+++ b/mobile/test/widgets/video_recorder/preview/video_recorder_mobile_preview_test.dart
@@ -32,6 +32,7 @@ class _FakeCameraPlatform extends DivineCameraPlatform {
     bool enableScreenFlash = true,
     bool mirrorFrontCameraOutput = true,
     bool enableAutoLensSwitch = false,
+    bool preferUnprocessedAudio = false,
   }) async {
     return const CameraState(isInitialized: true, textureId: 1);
   }


### PR DESCRIPTION
## Description

Recording with the in-app camera flattened instruments. The audio session was pinned to `.videoRecording`, whose system-level noise suppression is tuned for speech and treats a sustained instrument as noise to gate away — which is why the clip sounded like Voice Isolation was on even with the mic mode set to Standard. Nothing exposed a way out, so a guitar clip was unrecoverable.

This ships the escape hatch rather than flipping the default: a new **Music mode** switch in Settings → Content Preferences, off by default. When on, iOS configures the recording session with `.measurement`, the mode Apple documents as minimising system-supplied input processing.

**Why opt-in and not global.** The issue leaves this open as a product call, and the trade-off is real in both directions: the processing is exactly what keeps ordinary talking clips clean, and `.measurement` also gives up the camera-adjacent mic selection and level normalisation that speech benefits from. A blanket switch trades one complaint for another, so the default is unchanged and only people recording music pay the cost.

**One consequence worth naming: level, not just texture.** Apple documents `.measurement` as minimising signal processing on **input and output**, and #7872 wrote the input half down explicitly — it disables automatic gain control and lowers the overall input level. For a loud instrument that is the point: no AGC means no pumping and no gating. For a quiet source it means no boost either, so a music-mode clip can simply come out quieter. The output half lands on the same session the recorder plays through, so the countdown beep and the audio-playback service can be quieter too. Nobody has measured the size of either drop — @realmeylisdev's device pass confirmed the mode, not the gain — so it sits on the device-test list below rather than being stated as a number. The tile's subtitle deliberately still warns about texture ("rougher on voices") and not about level: putting an unmeasured "quieter" into 22 locales is a claim of its own, and the string has not shipped, so it stays cheap to revise once someone has actually heard how big the drop is.

**Three things in the native path worth a reviewer's eye.**

- `attachAudioToSessionIfNeeded()` reused a warm session whenever the *category* still matched, so a session left on `.videoRecording` would have kept gating instruments away while every layer above reported the preference as applied. It now compares the mode too, and reconfigures through the existing stop → configure → restart path.
- A device that rejects `.measurement` falls back to `.videoRecording` instead of failing the configure. The failure path here returns `false`, and a `false` means the clip ships with **no audio track at all** — strictly worse than the processing the user opted out of.
- That fallback also **latches** the refusal for the rest of the capture session. Without it the two points above fight each other: the reuse path would compare the live session against a mode the device will never accept, so every recording start would tear the audio capture session down and rebuild it, and the cheap `setActive(true)` interruption recovery — the branch that exists precisely because the full reconfigure is the risky one — would never run again. The next camera open re-arms the preference and tries `.measurement` once more.

The per-recording diagnostic line now logs the active mode alongside the category, so a future "music sounds gated" report is answerable from the captured log.

**Scope: iOS only.** Android resolves its recording audio source separately in #7652, and per [@realmeylisdev's note on #7796](https://github.com/divinevideo/divine-mobile/issues/7796#issuecomment-5330442272), `Recorder.Builder.setAudioSource(int)` takes one value — so an Android change here would silently overwrite that routing decision and belongs in the same resolver, not in this PR. The switch is hidden on Android rather than sitting inert, and the tile is covered by a test that pins that gate.

**Related Issue:** Closes #7796

## Out of Scope

- The Android side of the same class of problem (#7652, #6171) — needs the single audio-source resolver those issues describe, not a second independent decision.
- The inert audio-input-device picker (#7654).
- Pre-warm still warms `.videoRecording`. It runs at plugin registration, long before Dart can report the preference, so it can only warm the default. The switch to `.measurement` then happens once, from the deferred audio pre-build a second after the first preview frame — not from the record tap, which is exactly what that pre-build exists to keep clear. @realmeylisdev's device pass confirms it: one `mode=AVAudioSessionModeMeasurement` configure line, before the first tap, and none after.

## Verification

- `flutter analyze lib test` — clean, both at the app level and inside `packages/divine_camera`. The app-level pass does not reach package test sources, so the package needs its own run.
- `flutter build ios --simulator --debug` — succeeds, so the Swift type-checks (the simulator has no camera, so it is a compile check, not a behaviour check).
- New tests: `packages/divine_camera/test/ios_audio_processing_contract_test.dart` (static guards on the Swift contract: default off, `.measurement` mapping, mode-aware reconfigure, the fallback, the latch, the log line — each assertion scoped to the declaration under test, the way the sibling handoff contract test does), `test/screens/settings/content_preferences_music_mode_test.dart` (renders on iOS, hidden on Android, reflects and writes the preference), `test/services/music_mode_preference_service_test.dart`, `test/blocs/music_mode/music_mode_cubit_test.dart`, plus a `VideoRecorderBloc` case pinning that the preference reaches `CameraService.initialize`.
- Updated suites green: `video_recorder_bloc_test.dart`, `divine_camera_method_channel_test.dart`, `video_recorder_mobile_preview_test.dart`, `test/l10n/`.
- Ratchets run locally: every `mobile/scripts/check_*.sh` guard except the ones needing Codemagic/network env — all pass.
- l10n: both keys added to all 22 locales, `flutter gen-l10n` output committed. Register follows the per-locale table in `LOCALIZATION_STYLE_GUIDE.md`.

**Still needs a device pass before merge.** The behaviour this fixes only shows up on real hardware with a real instrument, and the simulator has no camera, so the capture path never runs there. The project's usual manual pass runs on a Samsung Galaxy, which an iOS-only change cannot exercise at all. What is left: on an iPhone, record a clip with music with the switch off, then on, and compare — does the guitar survive, how much quieter is the clip, and is the countdown beep noticeably softer. Everything listed here is static and automated verification; treat the audio result itself as unconfirmed until someone runs that.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
