### PR TITLE
refactor(startup): own app-wide side-effect activation in one place

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -131,6 +131,7 @@ import 'package:openvine/services/video_format_preference.dart';
 import 'package:openvine/services/video_publish/video_publish_service.dart';
 import 'package:openvine/services/video_sharing_service.dart';
 import 'package:openvine/services/zendesk_support_service.dart';
+import 'package:openvine/startup/app_side_effects.dart';
 import 'package:openvine/startup/database_bootstrap_failure_app.dart';
 import 'package:openvine/startup/database_corruption_gate.dart';
 import 'package:openvine/startup/startup_splash_release_controller.dart';
@@ -2176,9 +2177,6 @@ class _DivineAppState extends ConsumerState<DivineApp>
 
   @override
   Widget build(BuildContext context) {
-    // Activate route normalization at app root
-    ref.watch(routeNormalizationProvider);
-
     // Set up deep link listener (must be in build method per Riverpod rules)
     ref.listen<AsyncValue<DeepLink>>(deepLinksProvider, (previous, next) {
       Log.info(
@@ -2853,35 +2851,6 @@ class _DivineAppState extends ConsumerState<DivineApp>
       );
     }
 
-    // Eagerly create the outgoing-DM retry service so its foreground
-    // subscription is wired up at app shell setup. The service has no
-    // UI consumer (it operates on the durable outgoing_dms queue), so
-    // without an explicit read it would never be created. See #4124.
-    ref.watch(outgoingDmRetryServiceProvider);
-
-    // Eagerly create the DM-reaction retry service so its foreground
-    // subscription is wired up at app shell setup. Like the outgoing-DM
-    // retry service it has no UI consumer — it re-drives undelivered
-    // reactions off the dm_message_reactions durable record.
-    ref.watch(dmReactionRetryServiceProvider);
-
-    // Eagerly create the view-event retry service so foreground sweeps
-    // run for the durable pending_view_events queue without a UI consumer.
-    ref.watch(viewEventRetryServiceProvider);
-
-    // Eagerly create the product-event queue so foreground sweeps run for the
-    // durable pending_product_events queue without a UI consumer.
-    ref.watch(productEventQueueProvider);
-
-    // Eagerly create the profile-save retry service so its foreground +
-    // connectivity subscriptions are wired at app shell setup. It re-drives
-    // the durable pending_profile_saves slot with no UI consumer (#3161).
-    ref.watch(profileSaveRetryServiceProvider);
-
-    // Eagerly wire the connectivity → relay force-reconnect bridge so the
-    // relay pool self-heals app-wide the moment the network returns (#3161).
-    ref.watch(connectivityRelayReconnectProvider);
-
     final inviteApiClient = ref.watch(inviteApiClientProvider);
     final inviteAvailabilityRepository = ref.watch(
       inviteAvailabilityRepositoryProvider,
@@ -3089,7 +3058,12 @@ class _DivineAppState extends ConsumerState<DivineApp>
       );
     }
 
-    return wrapped; // ProviderScope now wraps DivineApp from outside
+    // Root-tier app-wide side effects are activated here, above
+    // MaterialApp.router, so they run whether or not the bottom-nav shell is
+    // mounted. See AppRootSideEffects for the membership rule.
+    return AppRootSideEffects(
+      child: wrapped, // ProviderScope now wraps DivineApp from outside
+    );
   }
 }
 

--- a/mobile/lib/providers/auth_providers.dart
+++ b/mobile/lib/providers/auth_providers.dart
@@ -292,8 +292,11 @@ final cawgVerifierClientProvider = Provider<CawgVerifierClient>((ref) {
   return client;
 });
 
-/// Provider that sets Zendesk user identity when auth state changes
-/// Watch this provider at app startup to keep Zendesk identity in sync with auth
+/// Provider that sets Zendesk user identity when auth state changes.
+///
+/// Activated by `AppRootSideEffects`, above `MaterialApp.router`, so the
+/// identity is mirrored for the whole process rather than from the moment the
+/// bottom-nav shell mounts.
 @Riverpod(keepAlive: true)
 void zendeskIdentitySync(Ref ref) {
   final authService = ref.watch(authServiceProvider);
@@ -333,8 +336,12 @@ void zendeskIdentitySync(Ref ref) {
 ///
 /// Deliberately independent of [zendeskIdentitySync]: campaign attribution
 /// joins BigQuery `user_id` against the ClickHouse pubkey, so it must not be
-/// coupled to the lifetime of the support-desk integration. Watch this
-/// provider at app startup to keep the analytics identity in sync with auth.
+/// coupled to the lifetime of the support-desk integration.
+///
+/// Activated by `AppRootSideEffects`. It used to be activated from
+/// `AppShell.build()`, which left every crash report and analytics event
+/// before the first bottom-nav tab — splash, auth restore, sign-up, e-mail
+/// verification, onboarding — without a `user_id`.
 @Riverpod(keepAlive: true)
 void analyticsIdentitySync(Ref ref) {
   final authService = ref.watch(authServiceProvider);

--- a/mobile/lib/providers/auth_providers.g.dart
+++ b/mobile/lib/providers/auth_providers.g.dart
@@ -544,20 +544,29 @@ final class KnownAccountsProvider
 
 String _$knownAccountsHash() => r'8e9753265420cf092af04aa07686c98cdaa8eb1e';
 
-/// Provider that sets Zendesk user identity when auth state changes
-/// Watch this provider at app startup to keep Zendesk identity in sync with auth
+/// Provider that sets Zendesk user identity when auth state changes.
+///
+/// Activated by `AppRootSideEffects`, above `MaterialApp.router`, so the
+/// identity is mirrored for the whole process rather than from the moment the
+/// bottom-nav shell mounts.
 
 @ProviderFor(zendeskIdentitySync)
 final zendeskIdentitySyncProvider = ZendeskIdentitySyncProvider._();
 
-/// Provider that sets Zendesk user identity when auth state changes
-/// Watch this provider at app startup to keep Zendesk identity in sync with auth
+/// Provider that sets Zendesk user identity when auth state changes.
+///
+/// Activated by `AppRootSideEffects`, above `MaterialApp.router`, so the
+/// identity is mirrored for the whole process rather than from the moment the
+/// bottom-nav shell mounts.
 
 final class ZendeskIdentitySyncProvider
     extends $FunctionalProvider<void, void, void>
     with $Provider<void> {
-  /// Provider that sets Zendesk user identity when auth state changes
-  /// Watch this provider at app startup to keep Zendesk identity in sync with auth
+  /// Provider that sets Zendesk user identity when auth state changes.
+  ///
+  /// Activated by `AppRootSideEffects`, above `MaterialApp.router`, so the
+  /// identity is mirrored for the whole process rather than from the moment the
+  /// bottom-nav shell mounts.
   ZendeskIdentitySyncProvider._()
     : super(
         from: null,
@@ -599,8 +608,12 @@ String _$zendeskIdentitySyncHash() =>
 ///
 /// Deliberately independent of [zendeskIdentitySync]: campaign attribution
 /// joins BigQuery `user_id` against the ClickHouse pubkey, so it must not be
-/// coupled to the lifetime of the support-desk integration. Watch this
-/// provider at app startup to keep the analytics identity in sync with auth.
+/// coupled to the lifetime of the support-desk integration.
+///
+/// Activated by `AppRootSideEffects`. It used to be activated from
+/// `AppShell.build()`, which left every crash report and analytics event
+/// before the first bottom-nav tab — splash, auth restore, sign-up, e-mail
+/// verification, onboarding — without a `user_id`.
 
 @ProviderFor(analyticsIdentitySync)
 final analyticsIdentitySyncProvider = AnalyticsIdentitySyncProvider._();
@@ -610,8 +623,12 @@ final analyticsIdentitySyncProvider = AnalyticsIdentitySyncProvider._();
 ///
 /// Deliberately independent of [zendeskIdentitySync]: campaign attribution
 /// joins BigQuery `user_id` against the ClickHouse pubkey, so it must not be
-/// coupled to the lifetime of the support-desk integration. Watch this
-/// provider at app startup to keep the analytics identity in sync with auth.
+/// coupled to the lifetime of the support-desk integration.
+///
+/// Activated by `AppRootSideEffects`. It used to be activated from
+/// `AppShell.build()`, which left every crash report and analytics event
+/// before the first bottom-nav tab — splash, auth restore, sign-up, e-mail
+/// verification, onboarding — without a `user_id`.
 
 final class AnalyticsIdentitySyncProvider
     extends $FunctionalProvider<void, void, void>
@@ -621,8 +638,12 @@ final class AnalyticsIdentitySyncProvider
   ///
   /// Deliberately independent of [zendeskIdentitySync]: campaign attribution
   /// joins BigQuery `user_id` against the ClickHouse pubkey, so it must not be
-  /// coupled to the lifetime of the support-desk integration. Watch this
-  /// provider at app startup to keep the analytics identity in sync with auth.
+  /// coupled to the lifetime of the support-desk integration.
+  ///
+  /// Activated by `AppRootSideEffects`. It used to be activated from
+  /// `AppShell.build()`, which left every crash report and analytics event
+  /// before the first bottom-nav tab — splash, auth restore, sign-up, e-mail
+  /// verification, onboarding — without a `user_id`.
   AnalyticsIdentitySyncProvider._()
     : super(
         from: null,

--- a/mobile/lib/providers/moderation_providers.dart
+++ b/mobile/lib/providers/moderation_providers.dart
@@ -247,7 +247,7 @@ class BlocklistVersion extends _$BlocklistVersion {
 
 /// Bridge that starts blocklist sync when the Nostr session becomes ready.
 ///
-/// Watch this at app shell level. It listens to [nostrSessionProvider] and
+/// Activated by `AppShellSideEffects`. It listens to [nostrSessionProvider] and
 /// triggers [syncMuteListsInBackground] + [syncBlockListsInBackground]
 /// the first time the signer-backed Nostr client is initialized. This covers:
 /// - Already-authenticated startup (iOS keychain persists across reinstalls)
@@ -325,7 +325,7 @@ void blocklistSyncBridge(Ref ref) {
 /// missing — the #6109 class of loss, on the write side where no merge
 /// guard can catch it.
 ///
-/// Watch this at app shell level.
+/// Activated by `AppShellSideEffects`.
 @Riverpod(keepAlive: true)
 void blockedFollowReconciler(Ref ref) {
   final blocklistRepository = ref.watch(contentBlocklistRepositoryProvider);

--- a/mobile/lib/providers/moderation_providers.g.dart
+++ b/mobile/lib/providers/moderation_providers.g.dart
@@ -556,7 +556,7 @@ abstract class _$BlocklistVersion extends $Notifier<int> {
 
 /// Bridge that starts blocklist sync when the Nostr session becomes ready.
 ///
-/// Watch this at app shell level. It listens to [nostrSessionProvider] and
+/// Activated by `AppShellSideEffects`. It listens to [nostrSessionProvider] and
 /// triggers [syncMuteListsInBackground] + [syncBlockListsInBackground]
 /// the first time the signer-backed Nostr client is initialized. This covers:
 /// - Already-authenticated startup (iOS keychain persists across reinstalls)
@@ -570,7 +570,7 @@ final blocklistSyncBridgeProvider = BlocklistSyncBridgeProvider._();
 
 /// Bridge that starts blocklist sync when the Nostr session becomes ready.
 ///
-/// Watch this at app shell level. It listens to [nostrSessionProvider] and
+/// Activated by `AppShellSideEffects`. It listens to [nostrSessionProvider] and
 /// triggers [syncMuteListsInBackground] + [syncBlockListsInBackground]
 /// the first time the signer-backed Nostr client is initialized. This covers:
 /// - Already-authenticated startup (iOS keychain persists across reinstalls)
@@ -584,7 +584,7 @@ final class BlocklistSyncBridgeProvider
     with $Provider<void> {
   /// Bridge that starts blocklist sync when the Nostr session becomes ready.
   ///
-  /// Watch this at app shell level. It listens to [nostrSessionProvider] and
+  /// Activated by `AppShellSideEffects`. It listens to [nostrSessionProvider] and
   /// triggers [syncMuteListsInBackground] + [syncBlockListsInBackground]
   /// the first time the signer-backed Nostr client is initialized. This covers:
   /// - Already-authenticated startup (iOS keychain persists across reinstalls)
@@ -652,7 +652,7 @@ String _$blocklistSyncBridgeHash() =>
 /// missing — the #6109 class of loss, on the write side where no merge
 /// guard can catch it.
 ///
-/// Watch this at app shell level.
+/// Activated by `AppShellSideEffects`.
 
 @ProviderFor(blockedFollowReconciler)
 final blockedFollowReconcilerProvider = BlockedFollowReconcilerProvider._();
@@ -681,7 +681,7 @@ final blockedFollowReconcilerProvider = BlockedFollowReconcilerProvider._();
 /// missing — the #6109 class of loss, on the write side where no merge
 /// guard can catch it.
 ///
-/// Watch this at app shell level.
+/// Activated by `AppShellSideEffects`.
 
 final class BlockedFollowReconcilerProvider
     extends $FunctionalProvider<void, void, void>
@@ -710,7 +710,7 @@ final class BlockedFollowReconcilerProvider
   /// missing — the #6109 class of loss, on the write side where no merge
   /// guard can catch it.
   ///
-  /// Watch this at app shell level.
+  /// Activated by `AppShellSideEffects`.
   BlockedFollowReconcilerProvider._()
     : super(
         from: null,

--- a/mobile/lib/providers/relay_list_repository_provider.dart
+++ b/mobile/lib/providers/relay_list_repository_provider.dart
@@ -1,5 +1,5 @@
 // ABOUTME: Riverpod wiring for NIP-65 relay-list publishing and dirty retry.
-// ABOUTME: Activated from app shell alongside other relay side-effect bridges.
+// ABOUTME: Activated by AppShellSideEffects with the other relay bridges.
 
 import 'dart:async';
 

--- a/mobile/lib/providers/relay_providers.dart
+++ b/mobile/lib/providers/relay_providers.dart
@@ -555,7 +555,8 @@ Stream<Map<String, RelayStatistics>> relayStatisticsStream(Ref ref) async* {
 /// periodically syncs per-relay SDK counters (events received, queries sent,
 /// errors) so each relay displays its own real statistics.
 ///
-/// Must be watched at app level to activate the bridge.
+/// Activated by `AppShellSideEffects` — the 3s counter timer is recurring
+/// work a signed-out user should not pay for.
 @Riverpod(keepAlive: true)
 void relayStatisticsBridge(Ref ref) {
   final nostrService = ref.watch(nostrServiceProvider);
@@ -704,8 +705,9 @@ bool _setsEqual<T>(Set<T> a, Set<T> b) {
 /// network returning, so a pool that collapsed to zero connections during an
 /// offline window self-heals app-wide — not only on an app-foreground
 /// transition (#3161). Debounced so a burst of connectivity events collapses
-/// into one reconnect. keepAlive with no UI consumer: read eagerly at app
-/// shell startup so the subscription is wired.
+/// into one reconnect. keepAlive with no UI consumer: activated by
+/// `AppRootSideEffects` so the pool also self-heals on routes outside the
+/// bottom-nav shell.
 final connectivityRelayReconnectProvider = Provider<void>((ref) {
   final nostrService = ref.watch(nostrServiceProvider);
   Timer? debounce;

--- a/mobile/lib/providers/relay_providers.g.dart
+++ b/mobile/lib/providers/relay_providers.g.dart
@@ -224,7 +224,8 @@ String _$relayStatisticsStreamHash() =>
 /// periodically syncs per-relay SDK counters (events received, queries sent,
 /// errors) so each relay displays its own real statistics.
 ///
-/// Must be watched at app level to activate the bridge.
+/// Activated by `AppShellSideEffects` — the 3s counter timer is recurring
+/// work a signed-out user should not pay for.
 
 @ProviderFor(relayStatisticsBridge)
 final relayStatisticsBridgeProvider = RelayStatisticsBridgeProvider._();
@@ -236,7 +237,8 @@ final relayStatisticsBridgeProvider = RelayStatisticsBridgeProvider._();
 /// periodically syncs per-relay SDK counters (events received, queries sent,
 /// errors) so each relay displays its own real statistics.
 ///
-/// Must be watched at app level to activate the bridge.
+/// Activated by `AppShellSideEffects` — the 3s counter timer is recurring
+/// work a signed-out user should not pay for.
 
 final class RelayStatisticsBridgeProvider
     extends $FunctionalProvider<void, void, void>
@@ -248,7 +250,8 @@ final class RelayStatisticsBridgeProvider
   /// periodically syncs per-relay SDK counters (events received, queries sent,
   /// errors) so each relay displays its own real statistics.
   ///
-  /// Must be watched at app level to activate the bridge.
+  /// Activated by `AppShellSideEffects` — the 3s counter timer is recurring
+  /// work a signed-out user should not pay for.
   RelayStatisticsBridgeProvider._()
     : super(
         from: null,

--- a/mobile/lib/router/app_shell.dart
+++ b/mobile/lib/router/app_shell.dart
@@ -12,7 +12,6 @@ import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/notifications/view/notifications_page.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/overlay_visibility_provider.dart';
-import 'package:openvine/providers/relay_list_repository_provider.dart';
 import 'package:openvine/providers/route_feed_providers.dart';
 import 'package:openvine/providers/shell_obscured_provider.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
@@ -319,32 +318,6 @@ class _AppShellState extends ConsumerState<AppShell> with RouteAware {
       final notifier = ref.read(activeBranchIndexProvider.notifier);
       if (notifier.state != activeIndex) notifier.state = activeIndex;
     });
-
-    // Transitional scaffold: records relay connection events for analytics.
-    // TODO(#4338): remove when relay management moves to a dedicated cubit/service.
-    ref.watch(relayStatisticsBridgeProvider);
-
-    // Transitional scaffold: refreshes feeds when the relay set changes.
-    // TODO(#4338): remove when feed refresh is driven by a relay event stream in a cubit.
-    ref.watch(relaySetChangeBridgeProvider);
-
-    ref.watch(relayListDirtyPublishBridgeProvider);
-
-    // Initialize Zendesk identity sync to keep user identity in sync with auth
-    ref.watch(zendeskIdentitySyncProvider);
-
-    // Mirrors the authenticated pubkey into Firebase Analytics + Crashlytics.
-    ref.watch(analyticsIdentitySyncProvider);
-
-    // Transitional scaffold: syncs notification preferences on auth change.
-    // TODO(#4338): remove when NotificationPreferencesCubit owns this lifecycle.
-    ref.watch(notificationPreferencesDirtySyncBridgeProvider);
-    ref.watch(pushNotificationSyncProvider);
-
-    // Transitional scaffold: syncs block/mute list after login.
-    // TODO(#4338): remove when BlocklistCubit owns post-login sync.
-    ref.watch(blocklistSyncBridgeProvider);
-    ref.watch(blockedFollowReconcilerProvider);
 
     // The shell chrome (app bar) mirrors the *active tab's* route. While a
     // full-screen route is pushed above the whole shell (camera, editor,

--- a/mobile/lib/router/routes/shell.dart
+++ b/mobile/lib/router/routes/shell.dart
@@ -16,6 +16,7 @@ import 'package:openvine/screens/feed/video_feed_page.dart';
 import 'package:openvine/screens/inbox/inbox_page.dart';
 import 'package:openvine/screens/liked_videos_screen_router.dart';
 import 'package:openvine/screens/profile_screen_router.dart';
+import 'package:openvine/startup/app_side_effects.dart';
 
 List<RouteBase> shellRoutes() {
   return [
@@ -43,15 +44,20 @@ List<RouteBase> shellRoutes() {
           ...state.uri.queryParameters,
         },
         restorationId: state.pageKey.value,
-        // Provided above AppShell so both consumers can reach the same
-        // instance: VineBottomNav (inside AppShell) signals a home-tab retap
-        // and renders the refresh spinner; VideoFeedView (inside the home
-        // branch) listens and performs the refresh.
-        child: BlocProvider<HomeFeedRetapCubit>(
-          create: (_) => HomeFeedRetapCubit(),
-          child: AppShell(
-            currentIndex: navigationShell.currentIndex,
-            child: navigationShell,
+        // The shell-tier app-wide side effects are activated here rather than
+        // inside AppShell so the shell widget stays pure chrome — see
+        // AppShellSideEffects for the membership rule.
+        child: AppShellSideEffects(
+          // Provided above AppShell so both consumers can reach the same
+          // instance: VineBottomNav (inside AppShell) signals a home-tab retap
+          // and renders the refresh spinner; VideoFeedView (inside the home
+          // branch) listens and performs the refresh.
+          child: BlocProvider<HomeFeedRetapCubit>(
+            create: (_) => HomeFeedRetapCubit(),
+            child: AppShell(
+              currentIndex: navigationShell.currentIndex,
+              child: navigationShell,
+            ),
           ),
         ),
       ),

--- a/mobile/lib/startup/app_side_effects.dart
+++ b/mobile/lib/startup/app_side_effects.dart
@@ -15,7 +15,7 @@ import 'package:openvine/router/providers/route_normalization_provider.dart';
 ///
 /// Mounted once, at the app root, above `MaterialApp.router`. Membership rule:
 /// a provider belongs here when activating it costs no more than the
-/// already-initialized `authServiceProvider`, **or** when its whole point is to
+/// already-constructed `authServiceProvider`, **or** when its whole point is to
 /// keep working while the bottom-nav shell is not mounted.
 ///
 /// The identity mirrors are the reason this host exists. They were previously
@@ -38,8 +38,16 @@ class AppRootSideEffects extends ConsumerWidget {
     ref.watch(routeNormalizationProvider);
 
     // Mirrors the authenticated pubkey into Zendesk, and into Firebase
-    // Analytics + Crashlytics. Both only need `authServiceProvider`, which
-    // startup has already built, so activating them here is free.
+    // Analytics + Crashlytics. Cheap to activate: `authServiceProvider` is
+    // already constructed, and the extra `profileRepositoryProvider` /
+    // `nostrSessionProvider` reads the Zendesk mirror makes are notifier reads
+    // that build nothing.
+    //
+    // Activation here happens during the first frame, before
+    // `AuthService.initialize()` — that runs in the post-frame `essential`
+    // startup phase — so auth still reports `checking` and a restored identity
+    // arrives on `authStateStream` rather than through either provider's eager
+    // branch.
     ref.watch(zendeskIdentitySyncProvider);
     ref.watch(analyticsIdentitySyncProvider);
 

--- a/mobile/lib/startup/app_side_effects.dart
+++ b/mobile/lib/startup/app_side_effects.dart
@@ -1,0 +1,121 @@
+// ABOUTME: The one place app-wide side-effect providers are activated.
+// ABOUTME: Two hosts, split by what activating each provider costs at startup.
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:openvine/providers/auth_providers.dart';
+import 'package:openvine/providers/moderation_providers.dart';
+import 'package:openvine/providers/notifications_providers.dart';
+import 'package:openvine/providers/relay_list_repository_provider.dart';
+import 'package:openvine/providers/relay_providers.dart';
+import 'package:openvine/providers/social_providers.dart';
+import 'package:openvine/router/providers/route_normalization_provider.dart';
+
+/// App-wide side effects that must run for the whole life of the process.
+///
+/// Mounted once, at the app root, above `MaterialApp.router`. Membership rule:
+/// a provider belongs here when activating it costs no more than the
+/// already-initialized `authServiceProvider`, **or** when its whole point is to
+/// keep working while the bottom-nav shell is not mounted.
+///
+/// The identity mirrors are the reason this host exists. They were previously
+/// activated from `AppShell.build()`, which does not run until the user lands
+/// on a bottom-nav tab — so for the whole pre-shell window (splash, auth
+/// restore, sign-up, e-mail verification, onboarding) Crashlytics reports and
+/// Firebase Analytics events carried no `user_id`, even for an already
+/// authenticated user restored from the keychain. Both providers' own dartdoc
+/// said "watch this provider at app startup"; this host is what makes that
+/// true.
+class AppRootSideEffects extends ConsumerWidget {
+  const AppRootSideEffects({required this.child, super.key});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    // Redirects the router to canonical URLs. Router plumbing, not a service:
+    // it only reads `goRouterProvider` and attaches a listener.
+    ref.watch(routeNormalizationProvider);
+
+    // Mirrors the authenticated pubkey into Zendesk, and into Firebase
+    // Analytics + Crashlytics. Both only need `authServiceProvider`, which
+    // startup has already built, so activating them here is free.
+    ref.watch(zendeskIdentitySyncProvider);
+    ref.watch(analyticsIdentitySyncProvider);
+
+    // Durable-queue drivers. Each owns a foreground (and, for profile saves,
+    // connectivity) subscription that re-drives a Drift-backed queue, and none
+    // has a UI consumer — without an activation here they would never be
+    // constructed at all (#4124, #3161).
+    ref.watch(outgoingDmRetryServiceProvider);
+    ref.watch(dmReactionRetryServiceProvider);
+    ref.watch(viewEventRetryServiceProvider);
+    ref.watch(productEventQueueProvider);
+    ref.watch(profileSaveRetryServiceProvider);
+
+    // Force-reconnects the relay pool when connectivity returns (#3161).
+    // The one root-tier member that watches `nostrServiceProvider`: the pool
+    // has to self-heal app-wide, including on routes outside the shell, so it
+    // cannot be deferred to [AppShellSideEffects]. `NostrService.build()` only
+    // dials relays when an identity is present, so a signed-out launch still
+    // pays construction only.
+    ref.watch(connectivityRelayReconnectProvider);
+
+    return child;
+  }
+}
+
+/// App-wide side effects deferred until the bottom-nav shell mounts.
+///
+/// Mounted by the bottom-nav `StatefulShellRoute` (see `routes/shell.dart`),
+/// above `AppShell` rather than inside it, so the shell widget stays pure
+/// chrome. Membership rule: activating the provider builds a feed/follow
+/// service or starts recurring work that a signed-out user idling on
+/// `/welcome` should not pay for.
+///
+/// The deferral moves *construction*, not correctness: each member either
+/// gates its own work on `nostrSessionProvider` readiness, or — as
+/// [relayStatisticsBridgeProvider] does — reads the current relay state on
+/// activation, which is empty until a session dials relays anyway.
+///
+/// These are all `keepAlive`, so they are started once and are not torn down
+/// when the shell is covered by a pushed full-screen route.
+class AppShellSideEffects extends ConsumerWidget {
+  const AppShellSideEffects({required this.child, super.key});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    // Records relay connection events for analytics, and runs a 3s timer
+    // syncing per-relay SDK counters — recurring work, so it waits for a
+    // signed-in session.
+    // TODO(#4338): remove when relay management moves to a dedicated
+    // cubit/service.
+    ref.watch(relayStatisticsBridgeProvider);
+
+    // Refreshes feeds when the relay set changes. Builds
+    // `videoEventServiceProvider`.
+    // TODO(#4338): remove when feed refresh is driven by a relay event stream
+    // in a cubit.
+    ref.watch(relaySetChangeBridgeProvider);
+
+    // Retries a dirty kind:10002 relay-list publish once the session is ready.
+    ref.watch(relayListDirtyPublishBridgeProvider);
+
+    // Drains notification preferences marked dirty while offline, then
+    // registers the FCM token for the ready signer.
+    // TODO(#4338): remove when NotificationPreferencesCubit owns this
+    // lifecycle.
+    ref.watch(notificationPreferencesDirtySyncBridgeProvider);
+    ref.watch(pushNotificationSyncProvider);
+
+    // Syncs block/mute lists after login, then reconciles follows that
+    // contradict a block. The reconciler builds `followRepositoryProvider`.
+    // TODO(#4338): remove when BlocklistCubit owns post-login sync.
+    ref.watch(blocklistSyncBridgeProvider);
+    ref.watch(blockedFollowReconcilerProvider);
+
+    return child;
+  }
+}

--- a/mobile/test/router/app_shell_chrome_freeze_test.dart
+++ b/mobile/test/router/app_shell_chrome_freeze_test.dart
@@ -41,13 +41,6 @@ List<Override> _overrides({
   required Stream<RouteContext> contextStream,
 }) => [
   pageContextProvider.overrideWith((ref) => contextStream),
-  relayStatisticsBridgeProvider.overrideWithValue(null),
-  relaySetChangeBridgeProvider.overrideWithValue(null),
-  zendeskIdentitySyncProvider.overrideWithValue(null),
-  analyticsIdentitySyncProvider.overrideWithValue(null),
-  pushNotificationSyncProvider.overrideWithValue(null),
-  blocklistSyncBridgeProvider.overrideWithValue(null),
-  blockedFollowReconcilerProvider.overrideWithValue(null),
   authServiceProvider.overrideWithValue(mockAuthService),
   sharedPreferencesProvider.overrideWithValue(sharedPreferences),
   currentEnvironmentProvider.overrideWithValue(EnvironmentConfig.production),

--- a/mobile/test/router/app_shell_notification_badge_test.dart
+++ b/mobile/test/router/app_shell_notification_badge_test.dart
@@ -59,13 +59,6 @@ Widget _buildSubject({
         pageContextProvider.overrideWith(
           (ref) => Stream.value(const RouteContext(type: RouteType.home)),
         ),
-        relayStatisticsBridgeProvider.overrideWithValue(null),
-        relaySetChangeBridgeProvider.overrideWithValue(null),
-        zendeskIdentitySyncProvider.overrideWithValue(null),
-        analyticsIdentitySyncProvider.overrideWithValue(null),
-        pushNotificationSyncProvider.overrideWithValue(null),
-        blocklistSyncBridgeProvider.overrideWithValue(null),
-        blockedFollowReconcilerProvider.overrideWithValue(null),
         authServiceProvider.overrideWithValue(mockAuthService),
         sharedPreferencesProvider.overrideWithValue(sharedPreferences),
         currentEnvironmentProvider.overrideWithValue(

--- a/mobile/test/router/app_shell_obscured_test.dart
+++ b/mobile/test/router/app_shell_obscured_test.dart
@@ -45,13 +45,6 @@ List<Override> _overrides({
   pageContextProvider.overrideWith(
     (ref) => Stream.value(const RouteContext(type: RouteType.home)),
   ),
-  relayStatisticsBridgeProvider.overrideWithValue(null),
-  relaySetChangeBridgeProvider.overrideWithValue(null),
-  zendeskIdentitySyncProvider.overrideWithValue(null),
-  analyticsIdentitySyncProvider.overrideWithValue(null),
-  pushNotificationSyncProvider.overrideWithValue(null),
-  blocklistSyncBridgeProvider.overrideWithValue(null),
-  blockedFollowReconcilerProvider.overrideWithValue(null),
   authServiceProvider.overrideWithValue(mockAuthService),
   sharedPreferencesProvider.overrideWithValue(sharedPreferences),
   currentEnvironmentProvider.overrideWithValue(EnvironmentConfig.production),

--- a/mobile/test/router/app_shell_own_profile_encoding_test.dart
+++ b/mobile/test/router/app_shell_own_profile_encoding_test.dart
@@ -41,13 +41,6 @@ List<Override> _overrides({
   required RouteContext routeContext,
 }) => [
   pageContextProvider.overrideWith((ref) => Stream.value(routeContext)),
-  relayStatisticsBridgeProvider.overrideWithValue(null),
-  relaySetChangeBridgeProvider.overrideWithValue(null),
-  zendeskIdentitySyncProvider.overrideWithValue(null),
-  analyticsIdentitySyncProvider.overrideWithValue(null),
-  pushNotificationSyncProvider.overrideWithValue(null),
-  blocklistSyncBridgeProvider.overrideWithValue(null),
-  blockedFollowReconcilerProvider.overrideWithValue(null),
   authServiceProvider.overrideWithValue(mockAuthService),
   sharedPreferencesProvider.overrideWithValue(sharedPreferences),
   currentEnvironmentProvider.overrideWithValue(EnvironmentConfig.production),

--- a/mobile/test/router/shell_transition_test.dart
+++ b/mobile/test/router/shell_transition_test.dart
@@ -10,6 +10,7 @@ import 'package:openvine/router/router.dart';
 import 'package:openvine/router/routes/shell.dart';
 import 'package:openvine/screens/feed/home_feed_retap_cubit.dart';
 import 'package:openvine/screens/feed/video_feed_page.dart';
+import 'package:openvine/startup/app_side_effects.dart';
 
 class _FakeGoRouterState extends Fake implements GoRouterState {
   @override
@@ -85,11 +86,15 @@ void main() {
         'tab': 'feed',
         'source': 'startup',
       });
+      // The shell-tier app-wide side effects are activated above the page's
+      // content so AppShell itself stays pure chrome (see app_side_effects.dart).
+      expect(transitionPage.child, isA<AppShellSideEffects>());
+      final sideEffects = transitionPage.child as AppShellSideEffects;
       // The retap cubit wraps AppShell so the bottom nav and the home
       // branch's feed share one instance (see shell.dart).
-      expect(transitionPage.child, isA<BlocProvider<HomeFeedRetapCubit>>());
+      expect(sideEffects.child, isA<BlocProvider<HomeFeedRetapCubit>>());
       final retapProvider =
-          transitionPage.child as BlocProvider<HomeFeedRetapCubit>;
+          sideEffects.child as BlocProvider<HomeFeedRetapCubit>;
       expect(retapProvider.child, isA<AppShell>());
     });
   });

--- a/mobile/test/startup/app_side_effects_test.dart
+++ b/mobile/test/startup/app_side_effects_test.dart
@@ -1,0 +1,274 @@
+// ABOUTME: Pins the two app-wide side-effect activation hosts and their split.
+// ABOUTME: Root tier runs without the shell; shell tier stays deferred.
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:analytics/analytics.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/providers/analytics_providers.dart';
+import 'package:openvine/providers/auth_providers.dart';
+import 'package:openvine/providers/moderation_providers.dart';
+import 'package:openvine/providers/notifications_providers.dart';
+import 'package:openvine/providers/relay_list_repository_provider.dart';
+import 'package:openvine/providers/relay_providers.dart';
+import 'package:openvine/providers/social_providers.dart';
+import 'package:openvine/router/providers/route_normalization_provider.dart';
+import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/product_event_queue.dart';
+import 'package:openvine/startup/app_side_effects.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+class _MockAuthService extends Mock implements AuthService {}
+
+class _MockProductEventQueue extends Mock implements ProductEventQueue {}
+
+class _RecordingAnalytics implements AnalyticsEventSink {
+  final userIds = <String?>[];
+
+  @override
+  Future<void> setUserId(String? userId) async => userIds.add(userId);
+
+  @override
+  Future<void> setUserProperty({
+    required String name,
+    required String? value,
+  }) async {}
+
+  @override
+  Future<void> logEvent({
+    required String name,
+    required Map<String, Object> parameters,
+  }) async {}
+
+  @override
+  Future<void> logScreenView({
+    required String screenName,
+    String? screenClass,
+    Map<String, Object>? parameters,
+  }) async {}
+}
+
+// Full-length Nostr pubkey — never truncated.
+const String _pubkey =
+    '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+
+void main() {
+  late _MockAuthService authService;
+  late StreamController<AuthState> authStates;
+  late _RecordingAnalytics analytics;
+  late List<String?> crashUserIds;
+
+  setUp(() {
+    authStates = StreamController<AuthState>.broadcast();
+    addTearDown(authStates.close);
+
+    authService = _MockAuthService();
+    when(() => authService.isAuthenticated).thenReturn(true);
+    when(() => authService.currentPublicKeyHex).thenReturn(_pubkey);
+    when(
+      () => authService.authStateStream,
+    ).thenAnswer((_) => authStates.stream);
+
+    analytics = _RecordingAnalytics();
+    crashUserIds = <String?>[];
+  });
+
+  /// Overrides that neutralize everything except the identity mirrors, so a
+  /// test observes activation rather than the services behind it.
+  List<Override> baseOverrides({
+    void Function()? onRelayStatisticsBuilt,
+    void Function()? onRelaySetChangeBuilt,
+    void Function()? onBlockedFollowReconcilerBuilt,
+  }) => [
+    authServiceProvider.overrideWithValue(authService),
+    analyticsIdentityCoordinatorProvider.overrideWithValue(
+      AnalyticsIdentityCoordinator(
+        analytics: analytics,
+        setCrashUserId: (userId) async => crashUserIds.add(userId),
+      ),
+    ),
+    // Root tier, stubbed: neither reaches the identity mirrors under test.
+    routeNormalizationProvider.overrideWithValue(null),
+    connectivityRelayReconnectProvider.overrideWithValue(null),
+    outgoingDmRetryServiceProvider.overrideWithValue(null),
+    dmReactionRetryServiceProvider.overrideWithValue(null),
+    viewEventRetryServiceProvider.overrideWithValue(null),
+    productEventQueueProvider.overrideWithValue(_MockProductEventQueue()),
+    profileSaveRetryServiceProvider.overrideWithValue(null),
+    zendeskIdentitySyncProvider.overrideWithValue(null),
+    // Shell tier. The three that construct real services record instead.
+    relayStatisticsBridgeProvider.overrideWith(
+      (ref) => onRelayStatisticsBuilt?.call(),
+    ),
+    relaySetChangeBridgeProvider.overrideWith(
+      (ref) => onRelaySetChangeBuilt?.call(),
+    ),
+    blockedFollowReconcilerProvider.overrideWith(
+      (ref) => onBlockedFollowReconcilerBuilt?.call(),
+    ),
+    relayListDirtyPublishBridgeProvider.overrideWithValue(null),
+    notificationPreferencesDirtySyncBridgeProvider.overrideWithValue((_) {}),
+    pushNotificationSyncProvider.overrideWithValue(null),
+    blocklistSyncBridgeProvider.overrideWithValue(null),
+  ];
+
+  group(AppRootSideEffects, () {
+    testWidgets(
+      'mirrors the restored identity without the bottom-nav shell mounted',
+      (tester) async {
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: baseOverrides(),
+            child: const AppRootSideEffects(child: SizedBox.shrink()),
+          ),
+        );
+        await tester.pump();
+
+        // The regression this host exists for: before it, both mirrors were
+        // activated from AppShell.build(), so every pre-shell crash report and
+        // analytics event was anonymous even for a restored identity.
+        expect(analytics.userIds, [_pubkey]);
+        expect(crashUserIds, [_pubkey]);
+      },
+    );
+
+    testWidgets('clears the identity on logout', (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: baseOverrides(),
+          child: const AppRootSideEffects(child: SizedBox.shrink()),
+        ),
+      );
+      await tester.pump();
+
+      when(() => authService.currentPublicKeyHex).thenReturn(null);
+      authStates.add(AuthState.unauthenticated);
+      await tester.pump();
+
+      expect(analytics.userIds, [_pubkey, null]);
+      expect(crashUserIds, [_pubkey, null]);
+    });
+
+    testWidgets('does not construct the deferred shell-tier services', (
+      tester,
+    ) async {
+      var relayStatistics = false;
+      var relaySetChange = false;
+      var blockedFollowReconciler = false;
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: baseOverrides(
+            onRelayStatisticsBuilt: () => relayStatistics = true,
+            onRelaySetChangeBuilt: () => relaySetChange = true,
+            onBlockedFollowReconcilerBuilt: () =>
+                blockedFollowReconciler = true,
+          ),
+          child: const AppRootSideEffects(child: SizedBox.shrink()),
+        ),
+      );
+      await tester.pump();
+
+      // A signed-out launch sits on /welcome with no shell. Activating these
+      // there would build videoEventService / followRepository and start a 3s
+      // relay-counter timer for a user who has no session yet.
+      expect(relayStatistics, isFalse);
+      expect(relaySetChange, isFalse);
+      expect(blockedFollowReconciler, isFalse);
+    });
+  });
+
+  group(AppShellSideEffects, () {
+    testWidgets('activates the deferred shell-tier services', (tester) async {
+      var relayStatistics = false;
+      var relaySetChange = false;
+      var blockedFollowReconciler = false;
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: baseOverrides(
+            onRelayStatisticsBuilt: () => relayStatistics = true,
+            onRelaySetChangeBuilt: () => relaySetChange = true,
+            onBlockedFollowReconcilerBuilt: () =>
+                blockedFollowReconciler = true,
+          ),
+          child: const AppShellSideEffects(child: SizedBox.shrink()),
+        ),
+      );
+      await tester.pump();
+
+      expect(relayStatistics, isTrue);
+      expect(relaySetChange, isTrue);
+      expect(blockedFollowReconciler, isTrue);
+    });
+
+    testWidgets('does not own the identity mirrors', (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: baseOverrides(),
+          child: const AppShellSideEffects(child: SizedBox.shrink()),
+        ),
+      );
+      await tester.pump();
+
+      // The mirrors belong to the root tier alone. Re-adding them here would
+      // reintroduce the shell-mount dependency this split removed.
+      expect(analytics.userIds, isEmpty);
+      expect(crashUserIds, isEmpty);
+    });
+  });
+
+  group('activation ownership', () {
+    // Activating an app-wide side effect from a screen or from the app root
+    // directly is what this file replaced: sixteen `ref.watch` calls spread
+    // across main.dart and app_shell.dart, each its own undocumented decision
+    // about when the effect starts. New ones belong in a host above, where the
+    // tier rule is written down and the split is covered by tests.
+    const hosts = {'lib/startup/app_side_effects.dart'};
+    const activationOnlyProviders = <String>[
+      'routeNormalizationProvider',
+      'connectivityRelayReconnectProvider',
+      'outgoingDmRetryServiceProvider',
+      'dmReactionRetryServiceProvider',
+      'viewEventRetryServiceProvider',
+      'productEventQueueProvider',
+      'profileSaveRetryServiceProvider',
+      'zendeskIdentitySyncProvider',
+      'analyticsIdentitySyncProvider',
+      'relayStatisticsBridgeProvider',
+      'relaySetChangeBridgeProvider',
+      'relayListDirtyPublishBridgeProvider',
+      'notificationPreferencesDirtySyncBridgeProvider',
+      'pushNotificationSyncProvider',
+      'blocklistSyncBridgeProvider',
+      'blockedFollowReconcilerProvider',
+    ];
+
+    for (final path in const [
+      'lib/main.dart',
+      'lib/router/app_shell.dart',
+      'lib/router/routes/shell.dart',
+    ]) {
+      test('$path activates no app-wide side effect of its own', () {
+        assert(!hosts.contains(path), 'a host cannot guard itself');
+        final source = File(path).readAsStringSync();
+
+        for (final provider in activationOnlyProviders) {
+          expect(
+            source,
+            isNot(contains('ref.watch($provider)')),
+            reason:
+                '$path activates $provider directly. App-wide side effects '
+                'are activated from AppRootSideEffects or AppShellSideEffects '
+                'in ${hosts.single}, which documents why each one starts when '
+                'it does.',
+          );
+        }
+      });
+    }
+  });
+}

--- a/mobile/test/startup/app_side_effects_test.dart
+++ b/mobile/test/startup/app_side_effects_test.dart
@@ -62,6 +62,11 @@ void main() {
   late _RecordingAnalytics analytics;
   late List<String?> crashUserIds;
 
+  // AnalyticsIdentityCoordinator keeps the last applied user ID in a static,
+  // and the VGV merged isolate shares it with every other suite in the bundle.
+  setUp(AnalyticsIdentityCoordinator.resetLastAppliedUserId);
+  tearDown(AnalyticsIdentityCoordinator.resetLastAppliedUserId);
+
   setUp(() {
     authStates = StreamController<AuthState>.broadcast();
     addTearDown(authStates.close);
@@ -151,6 +156,38 @@ void main() {
 
       expect(analytics.userIds, [_pubkey, null]);
       expect(crashUserIds, [_pubkey, null]);
+    });
+
+    testWidgets('mirrors an identity restored after the first frame', (
+      tester,
+    ) async {
+      // The path the fix actually runs on at the root. This host builds during
+      // the first frame, while AuthService.initialize() runs in the post-frame
+      // essential startup phase — so auth still reports `checking` here and the
+      // restored pubkey arrives on authStateStream, not through the provider's
+      // eager branch. The test above covers that eager branch, which is what
+      // used to run at shell-mount time.
+      when(() => authService.isAuthenticated).thenReturn(false);
+      when(() => authService.currentPublicKeyHex).thenReturn(null);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: baseOverrides(),
+          child: const AppRootSideEffects(child: SizedBox.shrink()),
+        ),
+      );
+      await tester.pump();
+
+      expect(analytics.userIds, isEmpty);
+      expect(crashUserIds, isEmpty);
+
+      when(() => authService.isAuthenticated).thenReturn(true);
+      when(() => authService.currentPublicKeyHex).thenReturn(_pubkey);
+      authStates.add(AuthState.authenticated);
+      await tester.pump();
+
+      expect(analytics.userIds, [_pubkey]);
+      expect(crashUserIds, [_pubkey]);
     });
 
     testWidgets('does not construct the deferred shell-tier services', (
@@ -254,7 +291,6 @@ void main() {
       'lib/router/routes/shell.dart',
     ]) {
       test('$path activates no app-wide side effect of its own', () {
-        assert(!hosts.contains(path), 'a host cannot guard itself');
         final source = File(path).readAsStringSync();
 
         for (final provider in activationOnlyProviders) {


### PR DESCRIPTION
## Description

Most of #3336 is already fixed on `main` — see the audit at the bottom. What was left is its last acceptance criterion, *"bridge providers are converted to named coordinator services or activated from one documented bootstrap location"*, and a real bug hiding behind it.

**Sixteen bare `ref.watch` calls** activated app-wide side effects: eleven in `_DivineAppState.build()`, five in `AppShell.build()`. Nothing recorded why any of them lived where it did, and several dartdocs disagreed with their own call site — `zendeskIdentitySync` and `analyticsIdentitySync` both said *"watch this provider at app startup"* while only the bottom-nav shell watched them.

### The bug that fell out of it

`analyticsIdentitySync` is the **only** production path that sets the Crashlytics user identifier and the Firebase Analytics `user_id` (`auth_providers.dart` → `AnalyticsIdentityCoordinator` → `CrashReportingService.instance.setUserId`). `zendeskIdentitySync` is the only one that sets the support-desk identity. Both were activated from `AppShell.build()`, which does not run until the user lands on a bottom-nav tab.

So for the whole pre-shell window — splash, auth restore, sign-up, e-mail verification, onboarding, the database-corruption gate — **crash reports and analytics events carried no `user_id`**, including for an identity already restored from the keychain. Startup crashes, the ones most worth attributing, were exactly the ones reported anonymously.

### The change

Two hosts in a new `lib/startup/app_side_effects.dart`, each carrying the membership rule that decides which tier a provider joins:

- **`AppRootSideEffects`** — above `MaterialApp.router`. For effects that must run for the whole process. The two identity mirrors move here; that is the fix.
- **`AppShellSideEffects`** — mounted by the shell *route*, above `AppShell` rather than inside it, so the shell widget goes back to being pure chrome. For effects whose activation builds a feed/follow service or starts recurring work a signed-out user idling on `/welcome` should not pay for.

Timing is unchanged for every provider except the two identity mirrors. `ZendeskSupportService.setUserIdentity` is local-only and its channel-backed siblings already `await _awaitInitialization()`, so neither minds being activated earlier.

**Why not one host?** Because `relayStatisticsBridge` starts a 3s timer and `relaySetChangeBridge` / `blockedFollowReconciler` construct `videoEventService` / `followRepository`. Activating those at the root would make a signed-out launch pay for all of it. The split is the honest answer, and the tier rule is written down rather than implied.

**Related Issue:** Relates to #3336, #4338

## Out of Scope

- Four more root-safe providers (`relayListDirtyPublishBridge`, `notificationPreferencesDirtySyncBridge`, `pushNotificationSync`, `blocklistSyncBridge`) could also move to the root tier — none forces `NostrService` construction. Left alone here: each changes push/blocklist timing, and none has a proven bug behind it. Now a one-line move per provider if we want it.
- The `TODO(#4338)` markers on the shell-tier bridges stay. They are still transitional scaffolding; this PR gives them an owner, it does not retire them.
- `notificationServiceProvider` still does `unawaited(service.initialize())` during construction — the last live instance of #3336's *"provider construction does not start non-trivial async work"* criterion. Representing it as explicit async state is a behavior change, not a move, so it is not in this diff.

## Verification

- `flutter analyze lib test integration_test` — clean
- `flutter test test/startup/ test/router/ test/providers/ test/main_app_shell_repository_sync_test.dart test/features/app/startup/` — **1228 passed**, 81 skipped
- All 34 `scripts/check_*.sh` ratchets pass (`check_ios_extension_signing_contract.sh` fails identically on a clean tree — it needs a CI-provided env var)
- `dart run build_runner build --delete-conflicting-outputs` re-run; generated dartdoc propagation committed, no provider hashes changed
- Rebased onto `origin/main` at `b4dd2e1f4e` and re-verified afterwards

**Every new assertion was checked against a deliberate mutation of the host**, so none of them is coverage theatre:

| Mutation | Expected failure | Result |
|---|---|---|
| Root host drops `analyticsIdentitySync` | 2 identity tests | ✅ both red |
| Shell host re-acquires `analyticsIdentitySync` | "does not own the identity mirrors" | ✅ red |
| `relayStatisticsBridge` promoted to root tier | "does not construct the deferred shell-tier services" | ✅ red |
| Bridge re-scattered into `app_shell.dart` | source guard | ✅ red, with the fix in the message |

The source guard fails if `main.dart`, `app_shell.dart` or `shell.dart` ever activates one of the sixteen directly again, so the centralization cannot silently unwind.

## Issue audit — what #3336 already got, on `main`

The issue was filed in April 2026 against `33f6e026a`. Its evidence all points at `app_providers.dart` lines 260–1758; that file is now an **18-line barrel** (split by #4506), so every line reference is dead. Verified by name against current `main`:

| Acceptance criterion | State |
|---|---|
| `isNostrReadyProvider` no longer uses `Timer.periodic` polling | **Done.** The provider no longer exists in `lib/`. `nostrSessionProvider` / `NostrSessionReadiness` replaced it with an explicit four-phase contract driven by `authStateStream` and `ref.listen` — no polling anywhere. |
| Provider construction does not start non-trivial async work | **Mostly done.** The `Future.delayed` + web-timer notification retry is gone, replaced by `PushNotificationSessionCoordinator` + readiness listeners. `notificationServiceProvider`'s `unawaited(initialize())` is the remaining case (see Out of Scope). |
| Bridges are named coordinators, or activated from one documented location | **This PR.** Several already had named coordinators (`PushNotificationSessionCoordinator`, `_relaySetChangeCoordinator`); activation was the part still scattered. |
| Startup/readiness has focused tests | **This PR** adds them. |
| Notification, blocklist, relay statistics, Zendesk, push sync stay covered | Held — 1228 tests green, and the shell tier is now pinned by name. |

One incidental find worth recording: `main.dart:1583` documents that `NostrService` is *"initialized lazily in AuthService when user actually authenticates, to avoid blocking startup for unauthenticated users"* — but `connectivityRelayReconnectProvider` `ref.watch`es it from the app root, so it is constructed on every launch regardless. Not a regression and not changed here (`NostrService.build()` only dials relays when an identity is present, so a signed-out launch pays construction only), but the comment overstates the laziness.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] 🧹 Code refactor
