### PR TITLE
fix(drafts): keep draft audio playable after an iOS app update

### DIFF
--- a/mobile/lib/blocs/video_editor/clip_editor/clip_editor_bloc.dart
+++ b/mobile/lib/blocs/video_editor/clip_editor/clip_editor_bloc.dart
@@ -1889,7 +1889,10 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
     );
 
     try {
-      final result = await _audioExtractionService.extractAudio(
+      // Draft-owned rather than temporary: this track is written into the
+      // editor history the draft persists, so it has to outlive both the
+      // session and the next app update.
+      final result = await _audioExtractionService.extractAudioForDraft(
         videoPath: videoPath,
         speed: extractionSpeed,
       );
@@ -1952,7 +1955,9 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
       }
 
       final audioEvent = AudioEvent(
-        id: 'local_extracted_${DateTime.now().microsecondsSinceEpoch}',
+        id:
+            '${AudioEvent.localExtractedMarker}_'
+            '${DateTime.now().microsecondsSinceEpoch}',
         pubkey: '',
         createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
         url: result.audioFilePath,

--- a/mobile/lib/blocs/video_editor/voice_over/voice_over_cubit.dart
+++ b/mobile/lib/blocs/video_editor/voice_over/voice_over_cubit.dart
@@ -10,6 +10,7 @@ import 'package:models/models.dart' show AudioEvent;
 import 'package:openvine/blocs/close_guard.dart';
 import 'package:openvine/services/haptic_service.dart';
 import 'package:openvine/services/video_editor/voice_over_recorder_service.dart';
+import 'package:openvine/utils/draft_audio_path_resolver.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 import 'package:permissions_service/permissions_service.dart';
@@ -372,6 +373,6 @@ class VoiceOverCubit extends Cubit<VoiceOverState>
 
   static Future<Directory> _defaultStorageDirectory() async {
     final documents = await getApplicationDocumentsDirectory();
-    return Directory(p.join(documents.path, 'voice_over_recordings'));
+    return Directory(p.join(documents.path, voiceOverRecordingsDirName));
   }
 }

--- a/mobile/lib/extensions/draft_local_audio_extensions.dart
+++ b/mobile/lib/extensions/draft_local_audio_extensions.dart
@@ -7,18 +7,19 @@ extension DraftLocalAudioPaths on DivineVideoDraft {
   /// Absolute file paths of draft-local audio referenced by this draft.
   ///
   /// Covers imported audio created by `LocalAudioImportService` (stored under
-  /// `draft_audio_imports/<draftId>`) and committed voice-over recordings, both
-  /// persisted as draft-local [AudioEvent]s. Sweeps every history entry's audio
-  /// metadata in [DivineVideoDraft.editorStateHistory] plus the legacy
+  /// `draft_audio_imports/<draftId>`), committed voice-over recordings, and
+  /// audio extracted from the draft's own clips — all persisted as draft-local
+  /// [AudioEvent]s. Sweeps every history entry's audio metadata in
+  /// [DivineVideoDraft.editorStateHistory] plus the legacy
   /// [DivineVideoDraft.selectedSound], collecting [AudioEvent.localFilePath] for
-  /// each [AudioEvent.isLocalImport] track. Used by draft deletion to remove
+  /// each [AudioEvent.isDraftLocalAudio] track. Used by draft deletion to remove
   /// audio files that would otherwise persist after the draft is gone.
   Set<String> get localAudioFilePaths {
     final paths = <String>{};
 
     void addIfLocal(AudioEvent event) {
-      // localFilePath is non-null only for a local import with a non-empty
-      // url, so the null check alone covers the import and emptiness guards.
+      // localFilePath is non-null only for draft-local audio with a non-empty
+      // url, so the null check alone covers the locality and emptiness guards.
       final path = event.localFilePath;
       if (path != null) {
         paths.add(path);

--- a/mobile/lib/models/divine_video_draft.dart
+++ b/mobile/lib/models/divine_video_draft.dart
@@ -16,6 +16,7 @@ import 'package:openvine/models/audio_share_attribution.dart';
 import 'package:openvine/models/content_label.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/video_reply_context.dart';
+import 'package:openvine/utils/draft_audio_path_resolver.dart';
 import 'package:openvine/utils/path_resolver.dart';
 import 'package:path/path.dart' as p;
 import 'package:pro_image_editor/pro_image_editor.dart';
@@ -178,11 +179,16 @@ class DivineVideoDraft {
       publishAttempts: json['publishAttempts'] as int? ?? 0,
       sourceDraftId: json['sourceDraftId'] as String?,
       proofManifestJson: json['proofManifestJson'] as String?,
-      editorStateHistory:
-          (json['editorStateHistory'] as Map<String, dynamic>?) ?? const {},
-      editorEditingParameters:
-          (json['editorEditingParameters'] as Map<String, dynamic>?) ??
-          const {},
+      editorStateHistory: resolveAudioPaths(
+        (json['editorStateHistory'] as Map<String, dynamic>?) ?? const {},
+        documentsPath,
+        useOriginalPath: useOriginalPath,
+      ),
+      editorEditingParameters: resolveAudioPaths(
+        (json['editorEditingParameters'] as Map<String, dynamic>?) ?? const {},
+        documentsPath,
+        useOriginalPath: useOriginalPath,
+      ),
       finalRenderedClip: json['finalRenderedClip'] != null
           ? DivineVideoClip.fromJson(
               json['finalRenderedClip'] as Map<String, dynamic>,
@@ -206,7 +212,13 @@ class DivineVideoDraft {
       // Old format (selectedAudioEventId/selectedAudioRelay) is ignored -
       // user must re-select sound if loading old draft
       selectedSound: json['selectedSound'] != null
-          ? AudioEvent.fromJson(json['selectedSound'] as Map<String, dynamic>)
+          ? AudioEvent.fromJson(
+              resolveAudioPaths(
+                json['selectedSound'] as Map<String, dynamic>,
+                documentsPath,
+                useOriginalPath: useOriginalPath,
+              ),
+            )
           : null,
       audioShareAttribution: json['audioShareAttribution'] is Map
           ? AudioShareAttribution.fromJson(
@@ -497,9 +509,10 @@ class DivineVideoDraft {
     if (sourceDraftId != null) 'sourceDraftId': sourceDraftId,
     'publishAttempts': publishAttempts,
     'proofManifestJson': proofManifestJson,
-    if (editorStateHistory.isNotEmpty) 'editorStateHistory': editorStateHistory,
+    if (editorStateHistory.isNotEmpty)
+      'editorStateHistory': toPortableAudioPaths(editorStateHistory),
     if (editorEditingParameters.isNotEmpty)
-      'editorEditingParameters': editorEditingParameters,
+      'editorEditingParameters': toPortableAudioPaths(editorEditingParameters),
     if (finalRenderedClip != null)
       'finalRenderedClip': finalRenderedClip!.toJson(),
     if (collaboratorPubkeys.isNotEmpty)
@@ -510,7 +523,8 @@ class DivineVideoDraft {
       'clipSourceCredits': clipSourceCredits
           .map((credit) => credit.toJson())
           .toList(),
-    if (selectedSound != null) 'selectedSound': selectedSound!.toJson(),
+    if (selectedSound != null)
+      'selectedSound': toPortableAudioPaths(selectedSound!.toJson()),
     if (audioShareAttribution != null)
       'audioShareAttribution': audioShareAttribution!.toJson(),
     if (contentWarning != null) 'contentWarning': contentWarning,

--- a/mobile/lib/services/audio_extraction_service.dart
+++ b/mobile/lib/services/audio_extraction_service.dart
@@ -4,6 +4,9 @@
 import 'dart:io';
 
 import 'package:blossom_upload_service/blossom_upload_service.dart';
+import 'package:models/models.dart' show AudioEvent;
+import 'package:openvine/utils/draft_audio_path_resolver.dart';
+import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
 import 'package:unified_logger/unified_logger.dart';
@@ -103,6 +106,10 @@ class AudioExtractionService {
   ///
   /// [videoPath] - Path to the source video file.
   /// [speed] - Optional playback speed to apply to the extracted audio.
+  /// [outputDirectory] - Where to write the file. Defaults to the temporary
+  /// directory, which suits one-shot consumers that read the audio and drop
+  /// it. Pass a persistent directory when the result outlives the session —
+  /// see [extractAudioForDraft].
   ///
   /// Returns an [AudioExtractionResult] containing the path to the extracted
   /// audio file and metadata (duration, file size, SHA-256 hash, MIME type).
@@ -114,6 +121,7 @@ class AudioExtractionService {
   Future<AudioExtractionResult> extractAudio({
     required String videoPath,
     double? speed,
+    Directory? outputDirectory,
   }) async {
     final effectiveSpeed = speed != null && speed > 0 ? speed : 1.0;
 
@@ -159,9 +167,11 @@ class AudioExtractionService {
     }
 
     // Generate output path — extension must match AudioFormat.wav
-    final tempDir = await getTemporaryDirectory();
+    final isTemporary = outputDirectory == null;
+    final directory = outputDirectory ?? await getTemporaryDirectory();
+    await directory.create(recursive: true);
     final timestamp = DateTime.now().millisecondsSinceEpoch;
-    final outputPath = '${tempDir.path}/extracted_audio_$timestamp.wav';
+    final outputPath = '${directory.path}/extracted_audio_$timestamp.wav';
 
     Log.debug(
       'Extracting audio to: $outputPath',
@@ -199,8 +209,11 @@ class AudioExtractionService {
       throw const AudioExtractionException('Audio file was not created');
     }
 
-    // Track this file for potential cleanup
-    _temporaryFiles.add(outputPath);
+    // Track this file for potential cleanup. A caller-owned directory is not
+    // tracked: `cleanupTemporaryFiles()` with no argument sweeps the whole
+    // list, and a draft-owned track must not be reachable that way. Deleting
+    // one by explicit path still works — see [cleanupAudioFile].
+    if (isTemporary) _temporaryFiles.add(outputPath);
 
     // Calculate hash and get file size using streaming (memory efficient)
     Log.debug(
@@ -311,6 +324,28 @@ class AudioExtractionService {
       );
       throw AudioExtractionException('Failed to merge audio', cause: e);
     }
+  }
+
+  /// Extracts audio that will be attached to a draft's timeline.
+  ///
+  /// Same contract as [extractAudio], except the file is written where it can
+  /// survive: an extracted track is persisted into the draft's editor history,
+  /// and the temporary directory is both replaced on an app update and
+  /// purgeable by iOS at any time, so a track left there goes silent without
+  /// warning. The caller owns the file from here — draft deletion reclaims it
+  /// through [AudioEvent.localFilePath].
+  Future<AudioExtractionResult> extractAudioForDraft({
+    required String videoPath,
+    double? speed,
+  }) async => extractAudio(
+    videoPath: videoPath,
+    speed: speed,
+    outputDirectory: await _draftAudioDirectory(),
+  );
+
+  static Future<Directory> _draftAudioDirectory() async {
+    final docs = await getApplicationDocumentsDirectory();
+    return Directory(p.join(docs.path, extractedClipAudioDirName));
   }
 
   /// Cleans up temporary audio files created by this service.

--- a/mobile/lib/services/local_audio_import_service.dart
+++ b/mobile/lib/services/local_audio_import_service.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:models/models.dart' show AudioEvent;
+import 'package:openvine/utils/draft_audio_path_resolver.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
@@ -72,7 +73,7 @@ class LocalAudioImportService {
 
   static Future<Directory> _defaultStorageRoot() async {
     final docs = await getApplicationDocumentsDirectory();
-    return Directory(p.join(docs.path, 'draft_audio_imports'));
+    return Directory(p.join(docs.path, draftAudioImportsDirName));
   }
 
   static Future<Duration?> _defaultDurationResolver(File file) async {

--- a/mobile/lib/utils/draft_audio_path_resolver.dart
+++ b/mobile/lib/utils/draft_audio_path_resolver.dart
@@ -1,0 +1,124 @@
+// ABOUTME: Keeps draft-local audio paths valid across iOS container changes
+// ABOUTME: by persisting them relative to the app documents directory
+
+import 'package:models/models.dart' show AudioEvent;
+import 'package:path/path.dart' as p;
+
+/// Documents-relative directory holding audio files imported into a draft.
+const String draftAudioImportsDirName = 'draft_audio_imports';
+
+/// Documents-relative directory holding committed voice-over recordings.
+const String voiceOverRecordingsDirName = 'voice_over_recordings';
+
+const Set<String> _audioRootDirNames = {
+  draftAudioImportsDirName,
+  voiceOverRecordingsDirName,
+};
+
+/// Documents-relative form of an absolute draft-local audio [path].
+///
+/// iOS rewrites the app container path on every app update, so an absolute
+/// audio path baked into a saved draft dangles from then on: the video still
+/// plays — clip paths are persisted as basenames and rejoined on load — while
+/// every sound goes silent. Audio lives in per-draft subdirectories, so unlike
+/// a clip it keeps the whole subpath below the documents directory instead of
+/// just the basename. Paths outside a known audio directory are returned
+/// unchanged.
+String toPortableAudioPath(String path) => _belowAudioRoot(path) ?? path;
+
+/// Absolute path for a persisted audio [path], rooted at [documentsPath].
+///
+/// Accepts the portable form as well as an absolute path from a previous
+/// container, so drafts written before the portable form existed heal the
+/// first time they are loaded.
+String resolveAudioPath(String path, String documentsPath) {
+  final relative = _belowAudioRoot(path);
+  return relative == null ? path : p.join(documentsPath, relative);
+}
+
+/// [json] with every draft-local audio path rewritten to its portable form.
+Map<String, dynamic> toPortableAudioPaths(Map<String, dynamic> json) =>
+    _rewriteAudioUrls(json, toPortableAudioPath)! as Map<String, dynamic>;
+
+/// [json] with every draft-local audio path resolved against [documentsPath].
+///
+/// When [useOriginalPath] is true the stored paths are returned unchanged,
+/// mirroring `resolvePath`.
+Map<String, dynamic> resolveAudioPaths(
+  Map<String, dynamic> json,
+  String documentsPath, {
+  bool useOriginalPath = false,
+}) {
+  if (useOriginalPath) return json;
+  return _rewriteAudioUrls(
+        json,
+        (path) => resolveAudioPath(path, documentsPath),
+      )!
+      as Map<String, dynamic>;
+}
+
+/// The `<audio-root>/…` tail of [path], or `null` when it has no audio root.
+String? _belowAudioRoot(String path) {
+  if (path.isEmpty) return null;
+  final segments = p.split(path);
+  // Stop at the second-to-last segment: a match needs a file below the root.
+  for (var i = segments.length - 2; i >= 0; i--) {
+    if (_audioRootDirNames.contains(segments[i])) {
+      return p.joinAll(segments.sublist(i));
+    }
+  }
+  return null;
+}
+
+/// Applies [transform] to the `url` of every draft-local [AudioEvent] map
+/// nested anywhere inside [node], returning [node] itself when nothing moved.
+///
+/// The editor persists audio in three unrelated shapes — the selected sound,
+/// `editorStateHistory.history[].meta.audio[]`, and
+/// `editorEditingParameters.meta.audio[]` — so this walks the whole tree
+/// instead of hardcoding those routes.
+Object? _rewriteAudioUrls(
+  Object? node,
+  String Function(String path) transform,
+) {
+  if (node is List) {
+    List<Object?>? copy;
+    for (var i = 0; i < node.length; i++) {
+      final rewritten = _rewriteAudioUrls(node[i], transform);
+      if (identical(rewritten, node[i])) continue;
+      (copy ??= List<Object?>.of(node))[i] = rewritten;
+    }
+    return copy ?? node;
+  }
+  if (node is! Map) return node;
+
+  final url = _localImportAudioUrl(node);
+  if (url != null) {
+    final rewritten = transform(url);
+    if (rewritten == url) return node;
+    return <String, dynamic>{
+      ...Map<String, dynamic>.from(node),
+      'url': rewritten,
+    };
+  }
+
+  Map<String, dynamic>? copy;
+  for (final entry in node.entries) {
+    final key = entry.key;
+    if (key is! String) continue;
+    final rewritten = _rewriteAudioUrls(entry.value, transform);
+    if (identical(rewritten, entry.value)) continue;
+    (copy ??= Map<String, dynamic>.from(node))[key] = rewritten;
+  }
+  return copy ?? node;
+}
+
+/// The on-disk url of [node] when it is a draft-local audio event, else `null`.
+String? _localImportAudioUrl(Map<Object?, Object?> node) {
+  final id = node['id'];
+  if (id is! String || !id.startsWith('${AudioEvent.localImportMarker}_')) {
+    return null;
+  }
+  final url = node['url'];
+  return url is String && url.isNotEmpty ? url : null;
+}

--- a/mobile/lib/utils/draft_audio_path_resolver.dart
+++ b/mobile/lib/utils/draft_audio_path_resolver.dart
@@ -10,9 +10,24 @@ const String draftAudioImportsDirName = 'draft_audio_imports';
 /// Documents-relative directory holding committed voice-over recordings.
 const String voiceOverRecordingsDirName = 'voice_over_recordings';
 
+/// Documents-relative directory holding audio extracted from a draft's clips.
+///
+/// Extraction writes to the temporary directory for one-shot consumers such as
+/// caption generation, but a track the user drops on the timeline is persisted
+/// into the draft — and the temporary directory is both container-scoped and
+/// purgeable by iOS at any moment, so that copy has to live here instead.
+const String extractedClipAudioDirName = 'extracted_clip_audio';
+
 const Set<String> _audioRootDirNames = {
   draftAudioImportsDirName,
   voiceOverRecordingsDirName,
+  extractedClipAudioDirName,
+};
+
+/// Id prefixes of audio backed by a file this device wrote for a draft.
+const Set<String> _draftLocalMarkers = {
+  AudioEvent.localImportMarker,
+  AudioEvent.localExtractedMarker,
 };
 
 /// Documents-relative form of an absolute draft-local audio [path].
@@ -20,10 +35,10 @@ const Set<String> _audioRootDirNames = {
 /// iOS rewrites the app container path on every app update, so an absolute
 /// audio path baked into a saved draft dangles from then on: the video still
 /// plays — clip paths are persisted as basenames and rejoined on load — while
-/// every sound goes silent. Audio lives in per-draft subdirectories, so unlike
-/// a clip it keeps the whole subpath below the documents directory instead of
-/// just the basename. Paths outside a known audio directory are returned
-/// unchanged.
+/// every sound goes silent. Imported audio lives in per-draft subdirectories,
+/// so unlike a clip it keeps the whole subpath below the documents directory
+/// instead of just the basename. Paths outside a known audio directory are
+/// returned unchanged.
 String toPortableAudioPath(String path) => _belowAudioRoot(path) ?? path;
 
 /// Absolute path for a persisted audio [path], rooted at [documentsPath].
@@ -62,7 +77,7 @@ Map<String, dynamic> resolveAudioPaths(
 /// Matches on the segment name alone, not on whether [path] sits under the
 /// documents directory, so a file placed in a `voice_over_recordings/` folder
 /// anywhere else would also be rebased onto documents on load. Nothing writes
-/// those two names outside the documents directory today.
+/// any of the three names outside the documents directory today.
 String? _belowAudioRoot(String path) {
   if (path.isEmpty) return null;
   final segments = p.split(path);
@@ -97,7 +112,7 @@ Object? _rewriteAudioUrls(
   }
   if (node is! Map) return node;
 
-  final url = _localImportAudioUrl(node);
+  final url = _draftLocalAudioUrl(node);
   if (url != null) {
     final rewritten = transform(url);
     if (rewritten == url) return node;
@@ -120,12 +135,13 @@ Object? _rewriteAudioUrls(
 
 /// The on-disk url of [node] when it is a draft-local audio event, else `null`.
 ///
-/// Mirrors [AudioEvent.isLocalImport] and [AudioEvent.localFilePath] against a
-/// raw map: the persisted tree is walked without deserializing, so a malformed
-/// audio entry is skipped rather than throwing. Keep the predicate in step.
-String? _localImportAudioUrl(Map<Object?, Object?> node) {
+/// Mirrors [AudioEvent.isDraftLocalAudio] and [AudioEvent.localFilePath]
+/// against a raw map: the persisted tree is walked without deserializing, so a
+/// malformed audio entry is skipped rather than throwing. Keep the predicate in
+/// step.
+String? _draftLocalAudioUrl(Map<Object?, Object?> node) {
   final id = node['id'];
-  if (id is! String || !id.startsWith('${AudioEvent.localImportMarker}_')) {
+  if (id is! String || !_draftLocalMarkers.any((m) => id.startsWith('${m}_'))) {
     return null;
   }
   final url = node['url'];

--- a/mobile/lib/utils/draft_audio_path_resolver.dart
+++ b/mobile/lib/utils/draft_audio_path_resolver.dart
@@ -58,6 +58,11 @@ Map<String, dynamic> resolveAudioPaths(
 }
 
 /// The `<audio-root>/…` tail of [path], or `null` when it has no audio root.
+///
+/// Matches on the segment name alone, not on whether [path] sits under the
+/// documents directory, so a file placed in a `voice_over_recordings/` folder
+/// anywhere else would also be rebased onto documents on load. Nothing writes
+/// those two names outside the documents directory today.
 String? _belowAudioRoot(String path) {
   if (path.isEmpty) return null;
   final segments = p.split(path);
@@ -114,6 +119,10 @@ Object? _rewriteAudioUrls(
 }
 
 /// The on-disk url of [node] when it is a draft-local audio event, else `null`.
+///
+/// Mirrors [AudioEvent.isLocalImport] and [AudioEvent.localFilePath] against a
+/// raw map: the persisted tree is walked without deserializing, so a malformed
+/// audio entry is skipped rather than throwing. Keep the predicate in step.
 String? _localImportAudioUrl(Map<Object?, Object?> node) {
   final id = node['id'];
   if (id is! String || !id.startsWith('${AudioEvent.localImportMarker}_')) {

--- a/mobile/lib/utils/path_resolver.dart
+++ b/mobile/lib/utils/path_resolver.dart
@@ -1,5 +1,9 @@
 // ABOUTME: Utility for resolving file paths for iOS compatibility
-// ABOUTME: iOS changes container paths on app updates, so we store only filenames
+// ABOUTME: iOS changes container paths on app updates, so we store basenames
+//
+// Draft-local audio is the exception: it lives in per-draft subdirectories
+// and keeps its whole documents-relative subpath. See
+// `utils/draft_audio_path_resolver.dart`.
 
 import 'package:flutter/foundation.dart';
 import 'package:path/path.dart' as p;

--- a/mobile/packages/models/lib/src/audio_event.dart
+++ b/mobile/packages/models/lib/src/audio_event.dart
@@ -336,6 +336,15 @@ class AudioEvent {
   /// Marker for draft-local imported audio.
   static const localImportMarker = 'local_import';
 
+  /// Marker for audio the editor extracted from one of a draft's own clips.
+  ///
+  /// Deliberately not [localImportMarker]: an extracted track is the video's
+  /// own sound rather than material the user brought in, so it must stay out
+  /// of the reuse-consent and attribution paths that key on
+  /// [isLocalImport]. It is still a draft-local file, which [localFilePath]
+  /// and [isDraftLocalAudio] cover.
+  static const localExtractedMarker = 'local_extracted';
+
   /// Marker for sounds resolved from server-side external provider search.
   static const externalProviderMarker = 'external_provider';
 
@@ -388,11 +397,22 @@ class AudioEvent {
   /// Whether this audio is a draft-local imported file.
   bool get isLocalImport => id.startsWith('${localImportMarker}_');
 
-  /// Local file path for imported audio.
+  /// Whether this audio was extracted from one of the draft's own clips.
+  bool get isLocalExtracted => id.startsWith('${localExtractedMarker}_');
+
+  /// Whether this audio is backed by a file this device wrote for a draft.
+  ///
+  /// Covers imported audio, voice-over takes (both [isLocalImport]) and
+  /// extracted clip audio. Distinct from [isLocalImport], which additionally
+  /// means "material the user brought in" and so gates reuse consent and
+  /// attribution.
+  bool get isDraftLocalAudio => isLocalImport || isLocalExtracted;
+
+  /// Local file path for draft-local audio.
   ///
   /// Returns null for bundled and published Nostr audio.
   String? get localFilePath {
-    if (!isLocalImport || url == null || url!.isEmpty) return null;
+    if (!isDraftLocalAudio || url == null || url!.isEmpty) return null;
     return url;
   }
 

--- a/mobile/packages/models/test/src/audio_event_test.dart
+++ b/mobile/packages/models/test/src/audio_event_test.dart
@@ -582,6 +582,38 @@ void main() {
       });
     });
 
+    group('extracted clip audio', () {
+      AudioEvent extracted({String id = 'local_extracted_1', String? url}) =>
+          AudioEvent(
+            id: id,
+            pubkey: '',
+            createdAt: 1700000000,
+            url: url ?? '/docs/extracted_clip_audio/extracted_audio_1.wav',
+          );
+
+      test('is draft-local audio with a usable file path', () {
+        final event = extracted();
+
+        expect(event.isLocalExtracted, isTrue);
+        expect(event.isDraftLocalAudio, isTrue);
+        expect(
+          event.localFilePath,
+          equals('/docs/extracted_clip_audio/extracted_audio_1.wav'),
+        );
+      });
+
+      test('is not a local import, so reuse and attribution skip it', () {
+        // An extracted track is the video's own sound. Treating it as
+        // imported material would push it into the reuse-consent and
+        // attribution paths, which key on isLocalImport.
+        expect(extracted().isLocalImport, isFalse);
+      });
+
+      test('has no file path without a url', () {
+        expect(extracted(url: '').localFilePath, isNull);
+      });
+    });
+
     group('fromLocalImport', () {
       test('creates draft-local audio event', () {
         final event = AudioEvent.fromLocalImport(

--- a/mobile/test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart
+++ b/mobile/test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart
@@ -3339,7 +3339,7 @@ void main() {
         'emits isExtractingAudio then success with muted clip and correct endTime',
         build: () {
           when(
-            () => mockService.extractAudio(
+            () => mockService.extractAudioForDraft(
               videoPath: any(named: 'videoPath'),
               speed: any(named: 'speed'),
             ),
@@ -3392,7 +3392,7 @@ void main() {
           expect(result.audioEvent.anchorClipId, equals(clip.id));
           expect(result.audioEvent.isAnchored, isTrue);
           verify(
-            () => mockService.extractAudio(
+            () => mockService.extractAudioForDraft(
               videoPath: '/path/clip-local.mp4',
               speed: any(named: 'speed'),
             ),
@@ -3406,7 +3406,7 @@ void main() {
         'extracts audio from the clip named by the event, not the selection',
         build: () {
           when(
-            () => mockService.extractAudio(
+            () => mockService.extractAudioForDraft(
               videoPath: any(named: 'videoPath'),
               speed: any(named: 'speed'),
             ),
@@ -3440,7 +3440,7 @@ void main() {
           expect(clips.firstWhere((c) => c.id == 'b').volume, equals(0));
           expect(clips.firstWhere((c) => c.id == 'a').volume, equals(1.0));
           verify(
-            () => mockService.extractAudio(
+            () => mockService.extractAudioForDraft(
               videoPath: '/path/b.mp4',
               speed: any(named: 'speed'),
             ),
@@ -3456,7 +3456,7 @@ void main() {
         'dedupes a queued re-extraction of an already-extracted clip',
         build: () {
           when(
-            () => mockService.extractAudio(
+            () => mockService.extractAudioForDraft(
               videoPath: any(named: 'videoPath'),
               speed: any(named: 'speed'),
             ),
@@ -3491,7 +3491,7 @@ void main() {
           expect(bloc.state.extractedAudioClipIds, contains('b'));
           // Extraction ran exactly once despite two queued requests.
           verify(
-            () => mockService.extractAudio(
+            () => mockService.extractAudioForDraft(
               videoPath: any(named: 'videoPath'),
               speed: any(named: 'speed'),
             ),
@@ -3505,7 +3505,7 @@ void main() {
         're-extracts after the clip is manually un-muted',
         build: () {
           when(
-            () => mockService.extractAudio(
+            () => mockService.extractAudioForDraft(
               videoPath: any(named: 'videoPath'),
               speed: any(named: 'speed'),
             ),
@@ -3536,7 +3536,7 @@ void main() {
           // even though it is already in extractedAudioClipIds.
           expect(bloc.state.clips.single.volume, equals(0));
           verify(
-            () => mockService.extractAudio(
+            () => mockService.extractAudioForDraft(
               videoPath: any(named: 'videoPath'),
               speed: any(named: 'speed'),
             ),
@@ -3548,7 +3548,7 @@ void main() {
         'uses playback duration and forwards speed for extracted source clip',
         build: () {
           when(
-            () => mockService.extractAudio(
+            () => mockService.extractAudioForDraft(
               videoPath: any(named: 'videoPath'),
               speed: any(named: 'speed'),
             ),
@@ -3584,7 +3584,7 @@ void main() {
             equals(clip.playbackDuration),
           );
           verify(
-            () => mockService.extractAudio(
+            () => mockService.extractAudioForDraft(
               videoPath: '/path/clip-local.mp4',
               speed: 2.0,
             ),
@@ -3596,7 +3596,7 @@ void main() {
         'uses playback-time offsets when an extracted clip follows a slowed clip',
         build: () {
           when(
-            () => mockService.extractAudio(
+            () => mockService.extractAudioForDraft(
               videoPath: any(named: 'videoPath'),
               speed: any(named: 'speed'),
             ),
@@ -3648,7 +3648,7 @@ void main() {
           'in-flight extraction', () async {
         final completer = Completer<AudioExtractionResult>();
         when(
-          () => mockService.extractAudio(
+          () => mockService.extractAudioForDraft(
             videoPath: any(named: 'videoPath'),
             speed: any(named: 'speed'),
           ),
@@ -3690,7 +3690,7 @@ void main() {
           isA<ClipAudioExtractionDiscarded>(),
         );
         verify(
-          () => mockService.extractAudio(
+          () => mockService.extractAudioForDraft(
             videoPath: '/path/clip-local.mp4',
             speed: 2.0,
           ),
@@ -3706,7 +3706,7 @@ void main() {
         'emits isExtractingAudio then ClipAudioExtractionFailure on AudioExtractionException',
         build: () {
           when(
-            () => mockService.extractAudio(
+            () => mockService.extractAudioForDraft(
               videoPath: any(named: 'videoPath'),
               speed: any(named: 'speed'),
             ),
@@ -3738,7 +3738,7 @@ void main() {
         'wraps unexpected extraction errors in Reportable with context',
         build: () {
           when(
-            () => mockService.extractAudio(
+            () => mockService.extractAudioForDraft(
               videoPath: any(named: 'videoPath'),
               speed: any(named: 'speed'),
             ),
@@ -3780,7 +3780,7 @@ void main() {
           'when source clip is removed during in-flight extraction', () async {
         final completer = Completer<AudioExtractionResult>();
         when(
-          () => mockService.extractAudio(
+          () => mockService.extractAudioForDraft(
             videoPath: any(named: 'videoPath'),
             speed: any(named: 'speed'),
           ),

--- a/mobile/test/models/divine_video_draft_audio_path_test.dart
+++ b/mobile/test/models/divine_video_draft_audio_path_test.dart
@@ -139,6 +139,27 @@ void main() {
       ]);
     });
 
+    test('leaves audio in portable form when useOriginalPath is set', () {
+      final restored = DivineVideoDraft.fromJson(
+        _draft().toJson(),
+        _newDocs,
+        useOriginalPath: true,
+      );
+
+      expect(_historyAudioUrls(restored), [
+        'draft_audio_imports/draft_1/song.m4a',
+        'voice_over_recordings/take_1.m4a',
+      ]);
+      expect(
+        _parametersAudioUrl(restored),
+        'draft_audio_imports/draft_1/song.m4a',
+      );
+      expect(
+        restored.selectedSound?.url,
+        'draft_audio_imports/draft_1/song.m4a',
+      );
+    });
+
     test('reports rebased paths for draft-delete cleanup', () {
       final restored = DivineVideoDraft.fromJson(_draft().toJson(), _newDocs);
 

--- a/mobile/test/models/divine_video_draft_audio_path_test.dart
+++ b/mobile/test/models/divine_video_draft_audio_path_test.dart
@@ -1,0 +1,168 @@
+// ABOUTME: Regression tests for draft-local audio surviving iOS container moves
+// ABOUTME: Covers state history, editing parameters and the selected sound
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart';
+import 'package:openvine/extensions/draft_local_audio_extensions.dart';
+import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/divine_video_draft.dart';
+import 'package:pro_video_editor/pro_video_editor.dart';
+
+const _oldDocs = '/var/mobile/Containers/Data/Application/OLD-UUID/Documents';
+const _newDocs = '/var/mobile/Containers/Data/Application/NEW-UUID/Documents';
+
+const _importedPath = '$_oldDocs/draft_audio_imports/draft_1/song.m4a';
+const _voiceOverPath = '$_oldDocs/voice_over_recordings/take_1.m4a';
+
+AudioEvent _localAudio(String id, String path) => AudioEvent.fromLocalImport(
+  id: id,
+  filePath: path,
+  createdAt: 1700000000,
+  title: 'Local audio',
+  mimeType: 'audio/mp4',
+  duration: 4,
+);
+
+DivineVideoDraft _draft() => DivineVideoDraft(
+  id: 'draft_1',
+  clips: [
+    DivineVideoClip(
+      id: 'clip_1',
+      video: EditorVideo.file('$_oldDocs/clip.mp4'),
+      duration: const Duration(seconds: 6),
+      recordedAt: DateTime(2025),
+      originalAspectRatio: 9 / 16,
+      targetAspectRatio: .vertical,
+    ),
+  ],
+  title: 'Test Draft',
+  description: '',
+  hashtags: const {},
+  selectedApproach: 'camera',
+  createdAt: DateTime(2025),
+  lastModified: DateTime(2025),
+  publishStatus: PublishStatus.draft,
+  publishAttempts: 0,
+  selectedSound: _localAudio('local_import_selected', _importedPath),
+  editorStateHistory: {
+    'version': '1.0.0',
+    'history': [
+      {
+        'meta': {
+          'audio': [
+            _localAudio('local_import_1', _importedPath).toJson(),
+            _localAudio('local_import_2', _voiceOverPath).toJson(),
+          ],
+        },
+      },
+    ],
+  },
+  editorEditingParameters: {
+    'meta': {
+      'audio': [_localAudio('local_import_1', _importedPath).toJson()],
+    },
+  },
+);
+
+List<String> _historyAudioUrls(DivineVideoDraft draft) {
+  final entry = (draft.editorStateHistory['history']! as List).first as Map;
+  final audio = (entry['meta']! as Map)['audio']! as List;
+  return audio.map((e) => (e as Map)['url'] as String).toList();
+}
+
+String _parametersAudioUrl(DivineVideoDraft draft) {
+  final audio =
+      (draft.editorEditingParameters['meta']! as Map)['audio']! as List;
+  return (audio.first as Map)['url'] as String;
+}
+
+void main() {
+  group(DivineVideoDraft, () {
+    test('persists draft-local audio relative to the documents directory', () {
+      final json = _draft().toJson();
+
+      final entry =
+          (json['editorStateHistory']! as Map<String, dynamic>)['history']!
+              as List;
+      final audio = ((entry.first as Map)['meta']! as Map)['audio']! as List;
+      expect(
+        audio.map((e) => (e as Map)['url']),
+        [
+          'draft_audio_imports/draft_1/song.m4a',
+          'voice_over_recordings/take_1.m4a',
+        ],
+      );
+      expect(
+        (json['selectedSound']! as Map<String, dynamic>)['url'],
+        'draft_audio_imports/draft_1/song.m4a',
+      );
+    });
+
+    test('rebases draft-local audio onto the current container on load', () {
+      final restored = DivineVideoDraft.fromJson(_draft().toJson(), _newDocs);
+
+      expect(_historyAudioUrls(restored), [
+        '$_newDocs/draft_audio_imports/draft_1/song.m4a',
+        '$_newDocs/voice_over_recordings/take_1.m4a',
+      ]);
+      expect(
+        _parametersAudioUrl(restored),
+        '$_newDocs/draft_audio_imports/draft_1/song.m4a',
+      );
+      expect(
+        restored.selectedSound?.localFilePath,
+        '$_newDocs/draft_audio_imports/draft_1/song.m4a',
+      );
+    });
+
+    test('heals a draft saved with a previous container path', () {
+      // Drafts written before audio paths became portable stored the absolute
+      // path of the container they were created in.
+      final legacyJson = _draft().toJson()
+        ..['editorStateHistory'] = {
+          'version': '1.0.0',
+          'history': [
+            {
+              'meta': {
+                'audio': [
+                  _localAudio('local_import_1', _importedPath).toJson(),
+                ],
+              },
+            },
+          ],
+        };
+
+      final restored = DivineVideoDraft.fromJson(legacyJson, _newDocs);
+
+      expect(_historyAudioUrls(restored), [
+        '$_newDocs/draft_audio_imports/draft_1/song.m4a',
+      ]);
+    });
+
+    test('reports rebased paths for draft-delete cleanup', () {
+      final restored = DivineVideoDraft.fromJson(_draft().toJson(), _newDocs);
+
+      expect(restored.localAudioFilePaths, {
+        '$_newDocs/draft_audio_imports/draft_1/song.m4a',
+        '$_newDocs/voice_over_recordings/take_1.m4a',
+      });
+    });
+
+    test('leaves published sounds untouched', () {
+      final draft = _draft().copyWith(
+        selectedSound: AudioEvent(
+          id: 'sound-id-1234567890123456789012345678901234567890123456789012',
+          pubkey:
+              'abc123def456789012345678901234567890123456789012345678901234abcd',
+          createdAt: 1700000000,
+          url: 'https://blossom.example/audio.aac',
+        ),
+        skipUpdateLastModified: true,
+      );
+
+      final restored = DivineVideoDraft.fromJson(draft.toJson(), _newDocs);
+
+      expect(restored.selectedSound?.url, 'https://blossom.example/audio.aac');
+    });
+  });
+}

--- a/mobile/test/models/divine_video_draft_audio_path_test.dart
+++ b/mobile/test/models/divine_video_draft_audio_path_test.dart
@@ -13,6 +13,7 @@ const _newDocs = '/var/mobile/Containers/Data/Application/NEW-UUID/Documents';
 
 const _importedPath = '$_oldDocs/draft_audio_imports/draft_1/song.m4a';
 const _voiceOverPath = '$_oldDocs/voice_over_recordings/take_1.m4a';
+const _extractedPath = '$_oldDocs/extracted_clip_audio/extracted_audio_1.wav';
 
 AudioEvent _localAudio(String id, String path) => AudioEvent.fromLocalImport(
   id: id,
@@ -20,6 +21,18 @@ AudioEvent _localAudio(String id, String path) => AudioEvent.fromLocalImport(
   createdAt: 1700000000,
   title: 'Local audio',
   mimeType: 'audio/mp4',
+  duration: 4,
+);
+
+/// Audio the editor pulled off one of the draft's own clips. Not a local
+/// import: the id marker differs, which is what keeps it out of the reuse and
+/// attribution paths.
+AudioEvent _extractedAudio() => AudioEvent(
+  id: 'local_extracted_1',
+  pubkey: '',
+  createdAt: 1700000000,
+  url: _extractedPath,
+  mimeType: 'audio/wav',
   duration: 4,
 );
 
@@ -52,6 +65,7 @@ DivineVideoDraft _draft() => DivineVideoDraft(
           'audio': [
             _localAudio('local_import_1', _importedPath).toJson(),
             _localAudio('local_import_2', _voiceOverPath).toJson(),
+            _extractedAudio().toJson(),
           ],
         },
       },
@@ -90,6 +104,7 @@ void main() {
         [
           'draft_audio_imports/draft_1/song.m4a',
           'voice_over_recordings/take_1.m4a',
+          'extracted_clip_audio/extracted_audio_1.wav',
         ],
       );
       expect(
@@ -104,6 +119,7 @@ void main() {
       expect(_historyAudioUrls(restored), [
         '$_newDocs/draft_audio_imports/draft_1/song.m4a',
         '$_newDocs/voice_over_recordings/take_1.m4a',
+        '$_newDocs/extracted_clip_audio/extracted_audio_1.wav',
       ]);
       expect(
         _parametersAudioUrl(restored),
@@ -149,6 +165,7 @@ void main() {
       expect(_historyAudioUrls(restored), [
         'draft_audio_imports/draft_1/song.m4a',
         'voice_over_recordings/take_1.m4a',
+        'extracted_clip_audio/extracted_audio_1.wav',
       ]);
       expect(
         _parametersAudioUrl(restored),
@@ -166,6 +183,7 @@ void main() {
       expect(restored.localAudioFilePaths, {
         '$_newDocs/draft_audio_imports/draft_1/song.m4a',
         '$_newDocs/voice_over_recordings/take_1.m4a',
+        '$_newDocs/extracted_clip_audio/extracted_audio_1.wav',
       });
     });
 

--- a/mobile/test/services/audio_extraction_service_test.dart
+++ b/mobile/test/services/audio_extraction_service_test.dart
@@ -326,6 +326,58 @@ void main() {
       }
     });
 
+    test('extractAudio writes into a caller-owned directory', () async {
+      final directory = await Directory.systemTemp.createTemp('draft_audio');
+      addTearDown(() => directory.delete(recursive: true));
+
+      final result = await service.extractAudio(
+        videoPath: fakeVideoFile.path,
+        outputDirectory: directory,
+      );
+
+      expect(result.audioFilePath, startsWith(directory.path));
+      expect(File(result.audioFilePath).existsSync(), isTrue);
+    });
+
+    test('extractAudio leaves a caller-owned file out of the sweep', () async {
+      // A draft-owned track lives for as long as the draft does. If it were
+      // tracked as temporary, the no-argument sweep would delete a file the
+      // draft still points at.
+      final directory = await Directory.systemTemp.createTemp('draft_audio');
+      addTearDown(() => directory.delete(recursive: true));
+
+      final result = await service.extractAudio(
+        videoPath: fakeVideoFile.path,
+        outputDirectory: directory,
+      );
+      await service.cleanupTemporaryFiles();
+
+      expect(File(result.audioFilePath).existsSync(), isTrue);
+    });
+
+    test('cleanupAudioFile deletes a caller-owned file', () async {
+      // The discard path is the only thing reclaiming a draft-owned track the
+      // editor decided not to attach. Untracked no longer means undeletable.
+      final directory = await Directory.systemTemp.createTemp('draft_audio');
+      addTearDown(() => directory.delete(recursive: true));
+
+      final result = await service.extractAudio(
+        videoPath: fakeVideoFile.path,
+        outputDirectory: directory,
+      );
+      await service.cleanupAudioFile(result.audioFilePath);
+
+      expect(File(result.audioFilePath).existsSync(), isFalse);
+    });
+
+    test('extractAudio still sweeps its own temporary output', () async {
+      final result = await service.extractAudio(videoPath: fakeVideoFile.path);
+
+      await service.cleanupTemporaryFiles();
+
+      expect(File(result.audioFilePath).existsSync(), isFalse);
+    });
+
     test('extractAudio throws when video has no audio track', () async {
       mockEditor.hasAudio = false;
 

--- a/mobile/test/utils/draft_audio_path_resolver_test.dart
+++ b/mobile/test/utils/draft_audio_path_resolver_test.dart
@@ -14,6 +14,9 @@ Map<String, dynamic> _audioJson(String url, {String id = 'local_import_1'}) => {
   'url': url,
 };
 
+String _singleAudioUrl(Map<String, dynamic> json) =>
+    (((json['meta']! as Map)['audio']! as List).single as Map)['url'] as String;
+
 void main() {
   group('toPortableAudioPath', () {
     test('strips the container prefix from an imported audio path', () {
@@ -150,6 +153,22 @@ void main() {
       };
       expect(identical(toPortableAudioPaths(json), json), isTrue);
       expect(identical(resolveAudioPaths(json, _newDocs), json), isTrue);
+    });
+
+    test('leaves a remote sound whose url contains an audio root', () {
+      // The id gate is the only thing protecting this: the url carries a
+      // voice_over_recordings segment, so without the local-import check it
+      // would be truncated on save and rebased under the documents directory
+      // on load, turning a remote url into a dangling local path.
+      const remoteUrl = 'https://cdn.example/voice_over_recordings/take.m4a';
+      final json = <String, dynamic>{
+        'meta': {
+          'audio': [_audioJson(remoteUrl, id: 'nostr-event-id')],
+        },
+      };
+
+      expect(_singleAudioUrl(toPortableAudioPaths(json)), remoteUrl);
+      expect(_singleAudioUrl(resolveAudioPaths(json, _newDocs)), remoteUrl);
     });
 
     test('returns the same instance when nothing needs rewriting', () {

--- a/mobile/test/utils/draft_audio_path_resolver_test.dart
+++ b/mobile/test/utils/draft_audio_path_resolver_test.dart
@@ -1,0 +1,186 @@
+// ABOUTME: Tests documents-relative persistence of draft-local audio paths
+// ABOUTME: Covers portable rewrite, resolution, and healing of stale paths
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/utils/draft_audio_path_resolver.dart';
+
+const _oldDocs = '/var/mobile/Containers/Data/Application/OLD-UUID/Documents';
+const _newDocs = '/var/mobile/Containers/Data/Application/NEW-UUID/Documents';
+
+Map<String, dynamic> _audioJson(String url, {String id = 'local_import_1'}) => {
+  'id': id,
+  'pubkey': 'local_import',
+  'createdAt': 1700000000,
+  'url': url,
+};
+
+void main() {
+  group('toPortableAudioPath', () {
+    test('strips the container prefix from an imported audio path', () {
+      expect(
+        toPortableAudioPath('$_oldDocs/draft_audio_imports/draft_1/song.m4a'),
+        'draft_audio_imports/draft_1/song.m4a',
+      );
+    });
+
+    test('strips the container prefix from a voice-over recording', () {
+      expect(
+        toPortableAudioPath('$_oldDocs/voice_over_recordings/take_3.m4a'),
+        'voice_over_recordings/take_3.m4a',
+      );
+    });
+
+    test('leaves an already portable path untouched', () {
+      expect(
+        toPortableAudioPath('draft_audio_imports/draft_1/song.m4a'),
+        'draft_audio_imports/draft_1/song.m4a',
+      );
+    });
+
+    test('leaves a path outside a known audio directory untouched', () {
+      expect(toPortableAudioPath('$_oldDocs/clip.mp4'), '$_oldDocs/clip.mp4');
+      expect(toPortableAudioPath(''), '');
+    });
+
+    test('ignores a bare audio directory with no file below it', () {
+      expect(
+        toPortableAudioPath('$_oldDocs/draft_audio_imports'),
+        '$_oldDocs/draft_audio_imports',
+      );
+    });
+  });
+
+  group('resolveAudioPath', () {
+    test('roots a portable path at the current documents directory', () {
+      expect(
+        resolveAudioPath('draft_audio_imports/draft_1/song.m4a', _newDocs),
+        '$_newDocs/draft_audio_imports/draft_1/song.m4a',
+      );
+    });
+
+    test('heals an absolute path from a previous container', () {
+      expect(
+        resolveAudioPath(
+          '$_oldDocs/voice_over_recordings/take_3.m4a',
+          _newDocs,
+        ),
+        '$_newDocs/voice_over_recordings/take_3.m4a',
+      );
+    });
+
+    test('leaves a path outside a known audio directory untouched', () {
+      expect(
+        resolveAudioPath('https://blossom.example/audio.aac', _newDocs),
+        'https://blossom.example/audio.aac',
+      );
+    });
+  });
+
+  group('audio path rewriting in persisted maps', () {
+    test('rewrites audio nested in editor state history', () {
+      final history = <String, dynamic>{
+        'version': '1.0.0',
+        'history': [
+          {
+            'meta': {
+              'audio': [
+                _audioJson('$_oldDocs/draft_audio_imports/d1/song.m4a'),
+                _audioJson(
+                  '$_oldDocs/voice_over_recordings/take.m4a',
+                  id: 'local_import_2',
+                ),
+              ],
+            },
+          },
+        ],
+      };
+
+      final portable = toPortableAudioPaths(history);
+      final audio =
+          ((portable['history'] as List).first as Map)['meta']
+              as Map<String, dynamic>;
+      expect(
+        (audio['audio'] as List).map((e) => (e as Map)['url']),
+        ['draft_audio_imports/d1/song.m4a', 'voice_over_recordings/take.m4a'],
+      );
+
+      final resolved = resolveAudioPaths(portable, _newDocs);
+      final resolvedAudio =
+          ((resolved['history'] as List).first as Map)['meta']
+              as Map<String, dynamic>;
+      expect(
+        (resolvedAudio['audio'] as List).map((e) => (e as Map)['url']),
+        [
+          '$_newDocs/draft_audio_imports/d1/song.m4a',
+          '$_newDocs/voice_over_recordings/take.m4a',
+        ],
+      );
+    });
+
+    test('rewrites audio nested in editor editing parameters', () {
+      final parameters = <String, dynamic>{
+        'meta': {
+          'audio': [_audioJson('$_oldDocs/draft_audio_imports/d1/song.m4a')],
+        },
+      };
+
+      final resolved = resolveAudioPaths(
+        toPortableAudioPaths(parameters),
+        _newDocs,
+      );
+      final audio = ((resolved['meta'] as Map)['audio'] as List).first as Map;
+      expect(audio['url'], '$_newDocs/draft_audio_imports/d1/song.m4a');
+    });
+
+    test('rewrites a bare audio event map', () {
+      final portable = toPortableAudioPaths(
+        _audioJson('$_oldDocs/draft_audio_imports/d1/song.m4a'),
+      );
+      expect(portable['url'], 'draft_audio_imports/d1/song.m4a');
+    });
+
+    test('leaves published and bundled sounds untouched', () {
+      final json = <String, dynamic>{
+        'meta': {
+          'audio': [
+            _audioJson('https://blossom.example/a.aac', id: 'nostr-event-id'),
+            _audioJson('asset://sounds/beat.mp3', id: 'bundled_beat'),
+          ],
+        },
+      };
+      expect(identical(toPortableAudioPaths(json), json), isTrue);
+      expect(identical(resolveAudioPaths(json, _newDocs), json), isTrue);
+    });
+
+    test('returns the same instance when nothing needs rewriting', () {
+      final json = <String, dynamic>{
+        'meta': {
+          'audio': [_audioJson('draft_audio_imports/d1/song.m4a')],
+        },
+      };
+      expect(identical(toPortableAudioPaths(json), json), isTrue);
+    });
+
+    test('honors useOriginalPath', () {
+      final json = _audioJson('draft_audio_imports/d1/song.m4a');
+      expect(
+        resolveAudioPaths(json, _newDocs, useOriginalPath: true)['url'],
+        'draft_audio_imports/d1/song.m4a',
+      );
+    });
+
+    test('skips malformed audio entries without throwing', () {
+      final json = <String, dynamic>{
+        'meta': {
+          'audio': [
+            {'id': 'local_import_1'},
+            {'id': 'local_import_2', 'url': 42},
+            'not-a-map',
+          ],
+        },
+      };
+      expect(() => toPortableAudioPaths(json), returnsNormally);
+      expect(identical(toPortableAudioPaths(json), json), isTrue);
+    });
+  });
+}

--- a/mobile/test/utils/draft_audio_path_resolver_test.dart
+++ b/mobile/test/utils/draft_audio_path_resolver_test.dart
@@ -40,6 +40,13 @@ void main() {
       );
     });
 
+    test('strips the container prefix from extracted clip audio', () {
+      expect(
+        toPortableAudioPath('$_oldDocs/extracted_clip_audio/take.wav'),
+        'extracted_clip_audio/take.wav',
+      );
+    });
+
     test('leaves a path outside a known audio directory untouched', () {
       expect(toPortableAudioPath('$_oldDocs/clip.mp4'), '$_oldDocs/clip.mp4');
       expect(toPortableAudioPath(''), '');
@@ -169,6 +176,33 @@ void main() {
 
       expect(_singleAudioUrl(toPortableAudioPaths(json)), remoteUrl);
       expect(_singleAudioUrl(resolveAudioPaths(json, _newDocs)), remoteUrl);
+    });
+
+    test("rewrites audio extracted from one of the draft's own clips", () {
+      // Extracted audio carries its own id marker rather than the import one,
+      // so it is only reached if the gate covers both. Its file used to live
+      // in the temporary directory, where an app update or an iOS purge takes
+      // it regardless of how the path is stored.
+      final json = <String, dynamic>{
+        'meta': {
+          'audio': [
+            _audioJson(
+              '$_oldDocs/extracted_clip_audio/extracted_audio_1.wav',
+              id: 'local_extracted_1',
+            ),
+          ],
+        },
+      };
+
+      final portable = toPortableAudioPaths(json);
+      expect(
+        _singleAudioUrl(portable),
+        'extracted_clip_audio/extracted_audio_1.wav',
+      );
+      expect(
+        _singleAudioUrl(resolveAudioPaths(portable, _newDocs)),
+        '$_newDocs/extracted_clip_audio/extracted_audio_1.wav',
+      );
     });
 
     test('returns the same instance when nothing needs rewriting', () {


### PR DESCRIPTION
Closes #7971

## Description

A user reported that voiceovers and imported sound in a draft are gone the next time they open it: *"saving it as a draft and then going back to it the day after or a few days after and all of the audio is muted."*

Every file reference inside a saved draft is persisted as a **basename** and rejoined with the current documents directory on load — clips, thumbnails, ghost frames, chroma-key backgrounds, stop-motion frames. `path_resolver.dart` says why in its first line: *"iOS changes container paths on app updates, so we store only filenames."*

Audio was the exception, in all three of the places a draft can hold it. Imported tracks (`LocalAudioImportService`) and committed voice-over takes (`VoiceOverCubit`) both live under the app documents directory and are persisted as `AudioEvent`s whose `url` is the raw absolute path, in three places that were written and read verbatim:

- `editorStateHistory.history[].meta.audio[]`
- `editorEditingParameters.meta.audio[]`
- `selectedSound`

So after any iOS app update the container UUID changes and every one of those paths dangles. The video still plays because its paths are rebased, while all sound goes silent — and it fails completely silently: there is no existence check anywhere before the path reaches ffmpeg in `_resolveRenderAudioSource` (`video_editor_audio_render.dart`). The delay in the report isn't time-based, it's the app update that happened in between.

The fix persists draft-local audio relative to the documents directory and resolves it back on load. Two details worth calling out:

- **Not a basename.** Audio lives in per-draft subdirectories (`draft_audio_imports/<draftId>/…`, `voice_over_recordings/…`), so `resolvePath`'s basename approach would flatten it into the wrong location. The new resolver keeps the whole subpath below Documents.
- **Existing broken drafts heal themselves.** Resolution also accepts an absolute path from a previous container, so a draft saved before this change gets its audio back the first time it is loaded — the files themselves were never deleted, iOS carries them into the new container, only the path prefix moved.

**One consequence to know before merging:** extracted audio moves from self-cleaning storage into reference-counted storage, and into the backup set with it. iOS excludes `Library/Caches` from iCloud and iTunes backup automatically, `Documents` is not excluded, and nothing in the repo sets `NSURLIsExcludedFromBackupKey`. Imports and voice-overs already live there so the direction is consistent, but extraction writes uncompressed WAV — measured at 566 KB for a 6.5s clip, about 88 KB/s — which makes it the largest of the three per second of audio, carried in every backup until the draft is deleted. Excluding it from backup was not done here: draft audio is the user's own work, and dropping it on a device restore is a product call rather than a cleanup. Raised by @realmeylisdev.

**Extracted clip audio needed a different fix from the other two.** Audio the editor pulls off a clip was written to the temporary directory, and iOS replaces that on an app update and purges it whenever it likes — so rebasing its path would have resolved onto an empty directory. It now lands under documents alongside imports and voice-overs, which is what makes a portable path meaningful for it. It also carries its own `local_extracted_` id marker, deliberately not the import one: reuse consent and publish attribution key on `isLocalImport`, and an extracted track is the video's own sound rather than material the user brought in.

The walk is structural rather than route-specific: it rewrites the `url` of any local-import `AudioEvent` map found anywhere in the persisted tree. The editor stores audio in three unrelated shapes and `editorStateHistory` is an opaque `pro_image_editor` export blob, so hardcoding those routes would silently miss a track the day that export format shifts. Non-local sounds (Nostr, bundled, external) are never touched, and unchanged subtrees return the same instance rather than being rebuilt — `CompleteParameters.toMap()` inlines a full raw frame as a `List<int>`, so a naive deep copy would clone that on every save and every load.

## Out of Scope

- The missing existence check before audio reaches ffmpeg. A dangling audio path still fails silently; this PR removes the cause rather than adding a diagnostic. Worth a follow-up if we want the editor to surface "this sound is missing" instead of just playing nothing.
- Saved sounds in **My Sounds** have the same bug in a second store, filed as #7977. It needs plumbing this PR does not have — `loadSavedSounds()` is synchronous and there is no synchronous documents path in the app today — so it is a follow-up rather than two more lines here.
- Draft-delete cleanup still walks `selectedSound` and `editorStateHistory` only, never `editorEditingParameters`. Pre-existing, and neither reviewer could show the app reaching a parameters-only state; widening that sweep makes file deletion more aggressive, which does not belong in this PR.
- Android is unaffected by this bug — `app_flutter` is stable across updates — but the change is platform-agnostic and a no-op there.

## Verification

- `flutter analyze lib test integration_test` — clean
- `flutter test test/models/ test/extensions/ test/utils/ test/services/draft_storage_service_test.dart test/services/local_audio_import_service_test.dart test/services/upload_manager_from_draft_test.dart test/services/auto_draft_complete_flow_test.dart test/blocs/video_editor/voice_over/ test/blocs/drafts_library/` — 1388 passed
- New regression tests confirmed to **fail** against the pre-fix model (4 of 5 red when `divine_video_draft.dart` is reverted), so they can actually catch this coming back.

Verified on the iOS Simulator (iPhone 17, iOS 26.3) by putting the app through a real container change rather than simulating one in a string. A draft carrying a voice-over is saved in one app container, the app is reinstalled into a fresh container, the documents directory is carried across the way iOS carries it on an app update, and the draft is reopened.

- **Pre-fix the bug reproduces.** The reopened draft still points into the container the draft was written in — `…/4F4898D5-C8C6-46F1-9B8A-39BE341B034B/Documents/voice_over_recordings/voice_over_swap.m4a` — while the app is now running out of `…/068531CB-242A-45AD-A0BA-5100A3F525DA/`. Nothing exists at that path any more. That is the report: the video plays, the sound is gone.
- **Post-fix the same swap resolves onto the new container** and the file is readable.
- **The persisted blob on device carries no container prefix at all** — the stored url is `voice_over_recordings/voice_over_swap.m4a`, so there is nothing left for a future update to invalidate.
- The unit tests were re-run against the pre-fix model on device too: the portable-persist and heal-a-legacy-draft cases go red, the round-trip case stays green as expected.

Drafts that already went silent were checked as their own journey on device, because that is the part of this change users actually feel: a draft is created on the broken build, silenced by a container change, then **opened and re-saved by the broken build** — the state a user who already hit this is in — and then carried through a further container change onto a build with the fix. The sound comes back. The broken build's re-save is harmless because it writes the stale path through verbatim, and nothing in the app deletes or drops the audio in the meantime: `deleteDraftAudioFiles` only ever deletes paths it was handed, `storage_management_service` sweeps caches and seams but never `voice_over_recordings` or `draft_audio_imports`, and no code path removes an audio track because its file failed to load. The one case healing cannot reach is a real uninstall, which takes the documents directory with it.

The harness that drives the two halves of the swap is not committed — it needs a manual reinstall between phases, so it is a verification tool rather than a CI test, and the committed unit tests already pin the same behaviour.

The services that actually produce these paths were driven on device rather than stood in for, because a resolver that knows the wrong two directory names would pass every hand-written test in this PR and still ship the bug. `LocalAudioImportService` imported a real bundled sound — native duration probe included, so it was a decodable audio file and not a stub — and `VoiceOverCubit` recorded a take onto its own default storage directory. Both landed under the directories the resolver recognises. Their draft was then persisted through `DraftStorageService` into a real on-disk Drift database, and that database was carried into a new container along with the documents directory: both tracks come back resolved onto the new container with their files readable. Reverting the model makes this go red on the stored blob still carrying a container path.

Extracted clip audio was verified the same way, with the real native extraction rather than a stand-in: a bundled seed video with a real audio track is run through `extractAudioForDraft`, the file lands under `<Documents>/extracted_clip_audio/`, the draft persists `extracted_clip_audio/extracted_audio_….wav` with no container prefix, and after a reinstall into a fresh container it resolves back onto the live container, is readable, and is picked up by draft-delete cleanup. Four mutations were checked individually — removing the new audio root, removing the id marker from the gate, reverting `localFilePath`, and tracking a caller-owned output as temporary — and each one turns tests red.

Not driven through the editor UI — the camera and editor sit behind the signed-out redirect, so the checks above enter at the service layer instead of record → voice-over → save → reopen. What that leaves unexercised is the button wiring, not the path handling this PR changes.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)





