### PR TITLE
fix(nip46): stop sign-out from leaving the signer connected forever

### DIFF
--- a/mobile/packages/nostr_sdk/lib/nip46/nostr_connect_session.dart
+++ b/mobile/packages/nostr_sdk/lib/nip46/nostr_connect_session.dart
@@ -440,7 +440,12 @@ class NostrConnectSession {
     try {
       relay.disconnect();
       relay.dispose();
-    } catch (_) {}
+    } catch (e) {
+      logger(
+        '[NostrConnectSession] Error shutting down relay '
+        '${relay.relayStatus.addr}: $e',
+      );
+    }
   }
 
   void _setState(NostrConnectState newState) {

--- a/mobile/packages/nostr_sdk/lib/nip46/nostr_connect_session.dart
+++ b/mobile/packages/nostr_sdk/lib/nip46/nostr_connect_session.dart
@@ -247,6 +247,9 @@ class NostrConnectSession {
 
       // Connect to relays and start listening
       await _connectToRelays();
+      // A cancel landing inside that dial has already torn the session down;
+      // announcing `listening` afterwards would undo its terminal state.
+      if (_isClosed) return;
 
       _setState(NostrConnectState.listening);
       logger('[NostrConnectSession] Now listening for bunker response...');
@@ -325,8 +328,14 @@ class NostrConnectSession {
         .toList();
 
     for (final relay in disconnected) {
+      if (_isClosed) return;
       await _reconnectRelay(relay);
     }
+
+    // A cleanup landing inside one of those reconnects has already emptied
+    // `_relays`, which reads here as "all relays lost". Dialing from scratch
+    // then opens sockets for a session that is over (#7962).
+    if (_isClosed) return;
 
     // If all relays were lost, try to reconnect from scratch
     if (_relays.isEmpty) {
@@ -375,7 +384,7 @@ class NostrConnectSession {
     try {
       final relay = await _connectToRelay(relayUrl);
       if (_isClosed) {
-        relay.disconnect();
+        _shutDownRelay(relay);
         _signerSuppliedRelayCount--;
         return;
       }
@@ -415,11 +424,23 @@ class NostrConnectSession {
     _timeoutTimer = null;
 
     for (final relay in _relays) {
-      try {
-        relay.disconnect();
-      } catch (_) {}
+      _shutDownRelay(relay);
     }
     _relays.clear();
+  }
+
+  /// Takes a relay down for good.
+  ///
+  /// [Relay.disconnect] alone leaves the relay connectable: it closes the
+  /// socket but keeps the connection manager, so a reconnect resuming later
+  /// reuses it and opens a fresh socket plus heartbeat. [Relay.dispose] is
+  /// what sets the disposed flag that makes the relay refuse that connect
+  /// (#7962, guard added in #7367).
+  void _shutDownRelay(Relay relay) {
+    try {
+      relay.disconnect();
+      relay.dispose();
+    } catch (_) {}
   }
 
   void _setState(NostrConnectState newState) {
@@ -440,6 +461,15 @@ class NostrConnectSession {
       }
     });
     final results = await Future.wait(futures.toList());
+    // `cancel()` / `dispose()` can land inside that dial. Adopting a relay
+    // after the cleanup has run would put a live socket on a list nothing
+    // will ever walk again, so shut down what finished connecting (#7962).
+    if (_isClosed) {
+      for (final relay in results) {
+        if (relay != null) _shutDownRelay(relay);
+      }
+      return;
+    }
     for (final relay in results) {
       if (relay != null) _relays.add(relay);
     }
@@ -480,13 +510,23 @@ class NostrConnectSession {
     }
   }
 
+  /// Reconnects one dropped relay.
+  ///
+  /// Checks [_isClosed] itself rather than trusting the caller's single
+  /// pre-loop check: every attempt suspends, and a cleanup landing inside one
+  /// of those waits takes the relay off [_relays] — a connect resuming
+  /// afterwards opens a socket and arms a heartbeat that no owner is left to
+  /// close (#7962).
   Future<void> _reconnectRelay(Relay relay) async {
+    if (_isClosed) return;
+
     final addr = relay.relayStatus.addr;
     logger('[NostrConnectSession] Reconnecting to $addr');
 
     try {
       // Re-add the subscription filter so it is sent on connect
       await _addSubscription(relay);
+      if (_isClosed) return;
       final connected = await relay.connect().timeout(_relayConnectTimeout);
       if (connected) {
         logger('[NostrConnectSession] Reconnected to $addr');

--- a/mobile/packages/nostr_sdk/lib/nip46/nostr_remote_signer.dart
+++ b/mobile/packages/nostr_sdk/lib/nip46/nostr_remote_signer.dart
@@ -100,6 +100,15 @@ class NostrRemoteSigner extends NostrSigner {
       }
     });
     final results = await Future.wait(futures.toList());
+    // `close()` can land inside that dial. Adopting a relay after it has run
+    // would put a live socket on a list nothing will ever walk again, so shut
+    // down what finished connecting instead (#7962).
+    if (_isClosed) {
+      for (final relay in results) {
+        if (relay != null) _shutDownRelay(relay);
+      }
+      return null;
+    }
     for (final relay in results) {
       if (relay != null) relays.add(relay);
     }
@@ -259,6 +268,14 @@ class NostrRemoteSigner extends NostrSigner {
     return relay;
   }
 
+  /// Whether a reconnect that has already suspended must drop its connect.
+  ///
+  /// Re-checked after every await in [_reconnectRelay]: [close] landing inside
+  /// one of those waits takes the relay off [relays], so a connect resuming
+  /// afterwards opens a socket and arms a heartbeat that no owner is left to
+  /// close (#7962).
+  bool get _reconnectAbandoned => _isClosed || _isPaused;
+
   /// Attempts to reconnect a relay after disconnection
   /// Uses exponential backoff to avoid hammering the relay
   Future<void> _reconnectRelay(Relay relay) async {
@@ -309,10 +326,21 @@ class NostrRemoteSigner extends NostrSigner {
     );
     await Future<void>.delayed(Duration(milliseconds: backoffMs));
 
+    if (_reconnectAbandoned) {
+      log('[NIP46] _reconnectRelay: abandoned during backoff for $addr');
+      return;
+    }
+
     try {
       // Add subscription query to pending messages before reconnecting
       if (relay.pendingMessages.isEmpty) {
         await addPenddingQueryMsg(relay);
+        if (_reconnectAbandoned) {
+          log(
+            '[NIP46] _reconnectRelay: abandoned while queueing REQ for $addr',
+          );
+          return;
+        }
       }
 
       await relay.connect();
@@ -409,8 +437,14 @@ class NostrRemoteSigner extends NostrSigner {
     NostrRemoteRequest request, {
     int timeout = 60,
   }) async {
-    // Check and reconnect any disconnected relays before sending
-    for (var relay in relays) {
+    // Check and reconnect any disconnected relays before sending.
+    // Iterate a snapshot: `close()` clears `relays`, and landing inside the
+    // connect below would otherwise throw ConcurrentModificationError.
+    for (final relay in List<Relay>.of(relays)) {
+      if (_isClosed) {
+        log('[NIP46] sendAndWaitForResult: signer closed, abandoning request');
+        return null;
+      }
       final status = relay.relayStatus.connected;
       log(
         '[NIP46] sendAndWaitForResult: checking relay ${relay.relayStatus.addr}, status=$status',
@@ -431,6 +465,11 @@ class NostrRemoteSigner extends NostrSigner {
           log('[NIP46] sendAndWaitForResult: failed to reconnect relay: $e');
         }
       }
+    }
+
+    if (_isClosed) {
+      log('[NIP46] sendAndWaitForResult: signer closed, abandoning request');
+      return null;
     }
 
     var senderPubkey = await localNostrSigner.getPublicKey();
@@ -454,6 +493,14 @@ class NostrRemoteSigner extends NostrSigner {
         log(
           '[NIP46] sendAndWaitForResult: sending event id=${event.id} to ${relays.length} relays',
         );
+
+        if (_isClosed) {
+          log(
+            '[NIP46] sendAndWaitForResult: signer closed while signing, '
+            'abandoning request',
+          );
+          return null;
+        }
 
         // set completer to callbacks
         var completer = Completer<String?>();
@@ -594,6 +641,22 @@ class NostrRemoteSigner extends NostrSigner {
   /// Whether the signer is currently paused
   bool get isPaused => _isPaused;
 
+  /// Takes a relay down for good.
+  ///
+  /// [Relay.disconnect] alone leaves the relay connectable: it closes the
+  /// socket but keeps the connection manager, so a reconnect resuming later
+  /// reuses it and opens a fresh socket plus heartbeat. [Relay.dispose] is
+  /// what sets the disposed flag that makes the relay refuse that connect
+  /// (#7962, guard added in #7367).
+  void _shutDownRelay(Relay relay) {
+    try {
+      relay.disconnect();
+      relay.dispose();
+    } catch (e) {
+      log('[NIP46] error shutting down relay ${relay.relayStatus.addr}: $e');
+    }
+  }
+
   @override
   void close() {
     log('[NIP46] close: closing signer and disconnecting all relays');
@@ -601,13 +664,7 @@ class NostrRemoteSigner extends NostrSigner {
 
     // Disconnect all relays to stop reconnection attempts
     for (final relay in relays) {
-      try {
-        relay.disconnect();
-      } catch (e) {
-        log(
-          '[NIP46] close: error disconnecting relay ${relay.relayStatus.addr}: $e',
-        );
-      }
+      _shutDownRelay(relay);
     }
     relays.clear();
 

--- a/mobile/packages/nostr_sdk/test/support/test_relay_server.dart
+++ b/mobile/packages/nostr_sdk/test/support/test_relay_server.dart
@@ -23,15 +23,19 @@ class TestRelayServer {
   /// How many sockets clients have opened over this server's lifetime.
   int connectionCount = 0;
 
-  /// How many of those the client has since closed.
+  /// How many of those have since closed, from either end — a client
+  /// teardown, [dropConnections], or [close].
   int closedConnectionCount = 0;
 
   bool _closed = false;
 
   String get url => 'ws://127.0.0.1:${_server.port}';
 
-  /// Sockets a client opened and never closed — the leak this harness exists
-  /// to catch.
+  /// Sockets that are still open — the leak this harness exists to catch.
+  ///
+  /// A server-side drop counts as closed too, so a test that calls
+  /// [dropConnections] and then sees this climb back is watching the client
+  /// dial a socket nothing is left holding.
   int get openConnectionCount => connectionCount - closedConnectionCount;
 
   static Future<TestRelayServer> start({int? port}) async {

--- a/mobile/packages/nostr_sdk/test/support/test_relay_server.dart
+++ b/mobile/packages/nostr_sdk/test/support/test_relay_server.dart
@@ -1,0 +1,92 @@
+// ABOUTME: In-process WebSocket relay stand-in for nostr_sdk NIP-46 tests.
+// ABOUTME: Counts sockets opened and closed so leaks are directly observable.
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+/// A loopback WebSocket server that stands in for a relay.
+///
+/// [connectionCount] is the point of the harness: a socket opened by a
+/// reconnect that should never have run shows up here even though nothing in
+/// the app holds a reference to it any more.
+class TestRelayServer {
+  TestRelayServer._(this._server) {
+    _requests = _server.listen(_handleRequest);
+  }
+
+  final HttpServer _server;
+  final _sockets = <WebSocket>[];
+  final receivedMessages = <List<dynamic>>[];
+  late final StreamSubscription<HttpRequest> _requests;
+
+  /// How many sockets clients have opened over this server's lifetime.
+  int connectionCount = 0;
+
+  /// How many of those the client has since closed.
+  int closedConnectionCount = 0;
+
+  bool _closed = false;
+
+  String get url => 'ws://127.0.0.1:${_server.port}';
+
+  /// Sockets a client opened and never closed — the leak this harness exists
+  /// to catch.
+  int get openConnectionCount => connectionCount - closedConnectionCount;
+
+  static Future<TestRelayServer> start({int? port}) async {
+    final server = await HttpServer.bind(
+      InternetAddress.loopbackIPv4,
+      port ?? 0,
+    );
+    return TestRelayServer._(server);
+  }
+
+  /// Sends a relay message (e.g. `['EVENT', subId, eventJson]`) to every
+  /// connected client. Callers ignore the subscription id, so any value works.
+  void push(Object message) {
+    final text = jsonEncode(message);
+    for (final socket in _sockets) {
+      socket.add(text);
+    }
+  }
+
+  /// Drops every live socket while the server keeps listening, so a client
+  /// sees its connection die and can dial back in.
+  Future<void> dropConnections() async {
+    final live = List<WebSocket>.of(_sockets);
+    _sockets.clear();
+    for (final socket in live) {
+      await socket.close();
+    }
+  }
+
+  Future<void> _handleRequest(HttpRequest request) async {
+    if (!WebSocketTransformer.isUpgradeRequest(request)) {
+      request.response.statusCode = HttpStatus.badRequest;
+      await request.response.close();
+      return;
+    }
+
+    final socket = await WebSocketTransformer.upgrade(request);
+    _sockets.add(socket);
+    connectionCount += 1;
+    socket.listen(
+      (message) {
+        receivedMessages.add(jsonDecode(message as String) as List<dynamic>);
+      },
+      onDone: () => closedConnectionCount += 1,
+      onError: (Object _) {},
+    );
+  }
+
+  Future<void> close() async {
+    if (_closed) return;
+    _closed = true;
+    for (final socket in _sockets) {
+      await socket.close();
+    }
+    await _requests.cancel();
+    await _server.close(force: true);
+  }
+}

--- a/mobile/packages/nostr_sdk/test/unit/nostr_connect_session_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/nostr_connect_session_test.dart
@@ -9,6 +9,8 @@ import 'package:nostr_sdk/nip46/nostr_remote_response.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
 import 'package:test/test.dart';
 
+import '../support/test_relay_server.dart';
+
 void main() {
   group('NostrRemoteSignerInfo nostrconnect:// support', () {
     test('isNostrConnectUrl returns true for nostrconnect:// URLs', () {
@@ -289,8 +291,8 @@ void main() {
     });
 
     test('addRelay dedupes configured and connected relays', () async {
-      final primaryRelay = await _TestRelayServer.start();
-      final callbackRelay = await _TestRelayServer.start();
+      final primaryRelay = await TestRelayServer.start();
+      final callbackRelay = await TestRelayServer.start();
       addTearDown(primaryRelay.close);
       addTearDown(callbackRelay.close);
 
@@ -319,7 +321,7 @@ void main() {
     });
 
     test('addRelay stops admitting signer relays at the cap', () async {
-      final primaryRelay = await _TestRelayServer.start();
+      final primaryRelay = await TestRelayServer.start();
       addTearDown(primaryRelay.close);
 
       final session = NostrConnectSession(relays: [primaryRelay.url]);
@@ -327,9 +329,9 @@ void main() {
 
       await session.start();
 
-      final callbackRelays = <_TestRelayServer>[];
+      final callbackRelays = <TestRelayServer>[];
       for (var i = 0; i <= RelayListCaps.nip46Callback; i++) {
-        final relay = await _TestRelayServer.start();
+        final relay = await TestRelayServer.start();
         addTearDown(relay.close);
         callbackRelays.add(relay);
         await session.addRelay(relay.url);
@@ -346,7 +348,7 @@ void main() {
     });
 
     test('addRelay does not spend the cap on a relay that failed', () async {
-      final primaryRelay = await _TestRelayServer.start();
+      final primaryRelay = await TestRelayServer.start();
       final failedPort = await _unusedLoopbackPort();
       addTearDown(primaryRelay.close);
 
@@ -359,7 +361,7 @@ void main() {
         await session.addRelay('ws://127.0.0.1:$failedPort');
       }
 
-      final callbackRelay = await _TestRelayServer.start();
+      final callbackRelay = await TestRelayServer.start();
       addTearDown(callbackRelay.close);
 
       await session.addRelay(callbackRelay.url);
@@ -371,7 +373,7 @@ void main() {
     });
 
     test('addRelay holds the cap when callbacks arrive together', () async {
-      final primaryRelay = await _TestRelayServer.start();
+      final primaryRelay = await TestRelayServer.start();
       addTearDown(primaryRelay.close);
 
       final session = NostrConnectSession(relays: [primaryRelay.url]);
@@ -379,9 +381,9 @@ void main() {
 
       await session.start();
 
-      final callbackRelays = <_TestRelayServer>[];
+      final callbackRelays = <TestRelayServer>[];
       for (var i = 0; i < RelayListCaps.nip46Callback + 3; i++) {
-        final relay = await _TestRelayServer.start();
+        final relay = await TestRelayServer.start();
         addTearDown(relay.close);
         callbackRelays.add(relay);
       }
@@ -400,7 +402,7 @@ void main() {
     });
 
     test('addRelay dials a repeated callback relay once', () async {
-      final primaryRelay = await _TestRelayServer.start();
+      final primaryRelay = await TestRelayServer.start();
       addTearDown(primaryRelay.close);
 
       final session = NostrConnectSession(relays: [primaryRelay.url]);
@@ -408,7 +410,7 @@ void main() {
 
       await session.start();
 
-      final callbackRelay = await _TestRelayServer.start();
+      final callbackRelay = await TestRelayServer.start();
       addTearDown(callbackRelay.close);
 
       await Future.wait([
@@ -424,7 +426,7 @@ void main() {
     });
 
     test('addRelay treats a trailing slash as the same relay', () async {
-      final primaryRelay = await _TestRelayServer.start();
+      final primaryRelay = await TestRelayServer.start();
       addTearDown(primaryRelay.close);
 
       final session = NostrConnectSession(relays: [primaryRelay.url]);
@@ -432,7 +434,7 @@ void main() {
 
       await session.start();
 
-      final callbackRelay = await _TestRelayServer.start();
+      final callbackRelay = await TestRelayServer.start();
       addTearDown(callbackRelay.close);
 
       await session.addRelay(callbackRelay.url);
@@ -446,7 +448,7 @@ void main() {
     });
 
     test('addRelay is a no-op unless the session is listening', () async {
-      final callbackRelay = await _TestRelayServer.start();
+      final callbackRelay = await TestRelayServer.start();
       addTearDown(callbackRelay.close);
 
       final idleSession = NostrConnectSession(relays: ['ws://127.0.0.1:9']);
@@ -461,7 +463,7 @@ void main() {
     });
 
     test('addRelay excludes relays whose connect returns false', () async {
-      final primaryRelay = await _TestRelayServer.start();
+      final primaryRelay = await TestRelayServer.start();
       final failedPort = await _unusedLoopbackPort();
       final callbackUrl = 'ws://127.0.0.1:$failedPort';
       addTearDown(primaryRelay.close);
@@ -472,7 +474,7 @@ void main() {
       await session.start();
       await session.addRelay(callbackUrl);
 
-      final callbackRelay = await _TestRelayServer.start(port: failedPort);
+      final callbackRelay = await TestRelayServer.start(port: failedPort);
       addTearDown(callbackRelay.close);
 
       await session.addRelay(callbackUrl);
@@ -486,7 +488,7 @@ void main() {
     test(
       'addRelay excludes relays whose connect times out',
       () async {
-        final primaryRelay = await _TestRelayServer.start();
+        final primaryRelay = await TestRelayServer.start();
         final blackhole = await _BlackholeServer.start();
         final callbackUrl = blackhole.url;
         addTearDown(primaryRelay.close);
@@ -500,7 +502,7 @@ void main() {
 
         final failedPort = blackhole.port;
         await blackhole.close();
-        final callbackRelay = await _TestRelayServer.start(port: failedPort);
+        final callbackRelay = await TestRelayServer.start(port: failedPort);
         addTearDown(callbackRelay.close);
 
         await session.addRelay(callbackUrl);
@@ -516,7 +518,7 @@ void main() {
     test(
       'addRelay disconnects a relay that connects after the session timeout',
       () async {
-        final primaryRelay = await _TestRelayServer.start();
+        final primaryRelay = await TestRelayServer.start();
         final delayedRelay = await _DelayedUpgradeRelayServer.start(
           delay: const Duration(seconds: 9),
         );
@@ -544,6 +546,76 @@ void main() {
       },
       timeout: const Timeout(Duration(seconds: 20)),
     );
+  });
+
+  group('relay lifecycle after cancel (#7962)', () {
+    test('a reconnect in flight when the session is cancelled opens no '
+        'socket', () async {
+      final server = await TestRelayServer.start();
+      addTearDown(server.close);
+
+      final logs = <String>[];
+      final session = NostrConnectSession(
+        relays: [server.url],
+        logger: logs.add,
+      );
+      addTearDown(session.dispose);
+
+      await session.start();
+      expect(server.connectionCount, equals(1));
+
+      // Drop the relay the way a flaky network would, then let the session
+      // notice before asking it to recover.
+      await server.dropConnections();
+      await _waitForSockets(server, open: 0);
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+
+      unawaited(session.ensureConnected());
+      session.cancel();
+
+      await Future<void>.delayed(const Duration(milliseconds: 300));
+
+      expect(
+        logs.where((line) => line.contains('Reconnecting to')),
+        isNotEmpty,
+        reason:
+            'the session never attempted a reconnect, so this test would '
+            'pass without exercising anything',
+      );
+      expect(
+        server.connectionCount,
+        equals(1),
+        reason:
+            'a reconnect resuming after cancel() opens a socket and arms '
+            'a heartbeat that nothing is left holding',
+      );
+      expect(server.openConnectionCount, isZero);
+    });
+
+    test('a relay that finishes dialing after cancel is shut down', () async {
+      final server = await TestRelayServer.start();
+      addTearDown(server.close);
+
+      final session = NostrConnectSession(relays: [server.url]);
+      addTearDown(session.dispose);
+
+      // start() suspends inside the dial, so the cancel lands while the relay
+      // is still connecting and the socket opens after the cleanup has run.
+      final starting = session.start();
+      session.cancel();
+      await starting;
+
+      await _waitForSockets(server, open: 0);
+
+      expect(
+        server.openConnectionCount,
+        isZero,
+        reason:
+            'a relay adopted after _cleanup() is a live socket on a list '
+            'nothing will ever walk again',
+      );
+      expect(session.state, equals(NostrConnectState.cancelled));
+    });
   });
 
   group('NostrConnectState enum', () {
@@ -743,7 +815,7 @@ void main() {
     test(
       'never logs the matched secret while handling a successful response',
       () async {
-        final relay = await _TestRelayServer.start();
+        final relay = await TestRelayServer.start();
         addTearDown(relay.close);
 
         final logs = <String>[];
@@ -800,7 +872,7 @@ void main() {
     test(
       'logs neither the response result nor the expected secret on a mismatch',
       () async {
-        final relay = await _TestRelayServer.start();
+        final relay = await TestRelayServer.start();
         addTearDown(relay.close);
 
         final logs = <String>[];
@@ -850,7 +922,7 @@ void main() {
 
     test('keeps listening through an injected error response and still binds '
         'on the real secret (pairing-DoS regression, #5683)', () async {
-      final relay = await _TestRelayServer.start();
+      final relay = await TestRelayServer.start();
       addTearDown(relay.close);
 
       final session = NostrConnectSession(relays: [relay.url]);
@@ -920,7 +992,7 @@ void main() {
 
     test('keeps listening through an auth_url challenge, dedupes relay '
         'replays of the same id, and still binds on the real secret', () async {
-      final relay = await _TestRelayServer.start();
+      final relay = await TestRelayServer.start();
       addTearDown(relay.close);
 
       final logs = <String>[];
@@ -998,7 +1070,7 @@ void main() {
     test(
       'restarts the wait window exactly once across multiple challenges',
       () async {
-        final relay = await _TestRelayServer.start();
+        final relay = await TestRelayServer.start();
         addTearDown(relay.close);
 
         final logs = <String>[];
@@ -1050,7 +1122,7 @@ void main() {
 
     test('extends the deadline once: a challenge mid-wait moves the timeout '
         'to a full window from the challenge, then still times out', () async {
-      final relay = await _TestRelayServer.start();
+      final relay = await TestRelayServer.start();
       addTearDown(relay.close);
 
       final logs = <String>[];
@@ -1103,7 +1175,7 @@ void main() {
 
     test('ignores a secret match that arrives after the wait timed out — '
         'the session must not flip to connected with nobody waiting', () async {
-      final relay = await _TestRelayServer.start();
+      final relay = await TestRelayServer.start();
       addTearDown(relay.close);
 
       final logs = <String>[];
@@ -1139,7 +1211,7 @@ void main() {
     });
 
     test('never logs the challenge URL (#3760 redaction contract)', () async {
-      final relay = await _TestRelayServer.start();
+      final relay = await TestRelayServer.start();
       addTearDown(relay.close);
 
       final logs = <String>[];
@@ -1188,7 +1260,7 @@ void main() {
   group('event id integrity (#6151)', () {
     test('drops a tampered relay copy that reuses the real response id, so the '
         'genuine secret still binds instead of being deduped away', () async {
-      final relay = await _TestRelayServer.start();
+      final relay = await TestRelayServer.start();
       addTearDown(relay.close);
 
       final logs = <String>[];
@@ -1290,64 +1362,6 @@ Future<int> _unusedLoopbackPort() async {
   return port;
 }
 
-class _TestRelayServer {
-  _TestRelayServer._(this._server) {
-    _requests = _server.listen(_handleRequest);
-  }
-
-  final HttpServer _server;
-  final _sockets = <WebSocket>[];
-  final receivedMessages = <List<dynamic>>[];
-  late final StreamSubscription<HttpRequest> _requests;
-  int connectionCount = 0;
-  bool _closed = false;
-
-  String get url => 'ws://127.0.0.1:${_server.port}';
-
-  /// Sends a relay message (e.g. `['EVENT', subId, eventJson]`) to every
-  /// connected client. The session ignores the subscription id, so any value
-  /// works.
-  void push(Object message) {
-    final text = jsonEncode(message);
-    for (final socket in _sockets) {
-      socket.add(text);
-    }
-  }
-
-  static Future<_TestRelayServer> start({int? port}) async {
-    final server = await HttpServer.bind(
-      InternetAddress.loopbackIPv4,
-      port ?? 0,
-    );
-    return _TestRelayServer._(server);
-  }
-
-  Future<void> _handleRequest(HttpRequest request) async {
-    if (!WebSocketTransformer.isUpgradeRequest(request)) {
-      request.response.statusCode = HttpStatus.badRequest;
-      await request.response.close();
-      return;
-    }
-
-    final socket = await WebSocketTransformer.upgrade(request);
-    _sockets.add(socket);
-    connectionCount += 1;
-    socket.listen((message) {
-      receivedMessages.add(jsonDecode(message as String) as List<dynamic>);
-    });
-  }
-
-  Future<void> close() async {
-    if (_closed) return;
-    _closed = true;
-    for (final socket in _sockets) {
-      await socket.close();
-    }
-    await _requests.cancel();
-    await _server.close(force: true);
-  }
-}
-
 bool _isReqMessage(List<dynamic> message) =>
     message.isNotEmpty && message.first == 'REQ';
 
@@ -1432,5 +1446,20 @@ class _BlackholeServer {
     }
     await _requests.cancel();
     await _server.close();
+  }
+}
+
+/// Waits until the server holds exactly [open] client sockets.
+///
+/// A socket the client closes takes a turn or two to register server-side, so
+/// asserting straight after a teardown reads the pre-close count.
+Future<void> _waitForSockets(
+  TestRelayServer server, {
+  required int open,
+}) async {
+  final deadline = DateTime.now().add(const Duration(seconds: 2));
+  while (server.openConnectionCount != open &&
+      DateTime.now().isBefore(deadline)) {
+    await Future<void>.delayed(const Duration(milliseconds: 10));
   }
 }

--- a/mobile/packages/nostr_sdk/test/unit/nostr_connect_session_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/nostr_connect_session_test.dart
@@ -1453,13 +1453,22 @@ class _BlackholeServer {
 ///
 /// A socket the client closes takes a turn or two to register server-side, so
 /// asserting straight after a teardown reads the pre-close count.
+///
+/// Throws rather than returning on timeout: callers use this to establish a
+/// precondition, and giving up quietly would let the scenario be set up wrong
+/// and the test pass without exercising anything.
 Future<void> _waitForSockets(
   TestRelayServer server, {
   required int open,
 }) async {
   final deadline = DateTime.now().add(const Duration(seconds: 2));
-  while (server.openConnectionCount != open &&
-      DateTime.now().isBefore(deadline)) {
+  while (server.openConnectionCount != open) {
+    if (DateTime.now().isAfter(deadline)) {
+      throw StateError(
+        'server still holds ${server.openConnectionCount} open sockets, '
+        'expected $open',
+      );
+    }
     await Future<void>.delayed(const Duration(milliseconds: 10));
   }
 }

--- a/mobile/packages/nostr_sdk/test/unit/nostr_remote_signer_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/nostr_remote_signer_test.dart
@@ -3,10 +3,17 @@
 
 import 'dart:async';
 
+import 'package:nostr_sdk/nip46/nostr_remote_request.dart';
 import 'package:nostr_sdk/nip46/nostr_remote_signer.dart';
 import 'package:nostr_sdk/nip46/nostr_remote_signer_info.dart';
+import 'package:nostr_sdk/relay/client_connected.dart';
 import 'package:nostr_sdk/relay/relay_mode.dart';
 import 'package:test/test.dart';
+
+import '../support/test_relay_server.dart';
+
+const _remoteSignerPubkey =
+    'deadbeef1234567890abcdef1234567890abcdef1234567890abcdef12345678';
 
 void main() {
   group('NostrRemoteSigner', () {
@@ -138,6 +145,115 @@ void main() {
     });
   });
 
+  group('relay lifecycle after close (#7962)', () {
+    Future<NostrRemoteSigner> connectedSigner(
+      List<TestRelayServer> servers,
+    ) async {
+      final relayParams = servers.map((s) => 'relay=${s.url}').join('&');
+      final signer = NostrRemoteSigner(
+        RelayMode.baseMode,
+        NostrRemoteSignerInfo.parseBunkerUrl(
+          'bunker://$_remoteSignerPubkey?$relayParams&secret=testsecret',
+        ),
+      );
+      addTearDown(signer.close);
+      await signer.connect(sendConnectRequest: false);
+      return signer;
+    }
+
+    test('a reconnect parked in backoff opens no socket after close', () async {
+      final server = await TestRelayServer.start();
+      addTearDown(server.close);
+
+      final signer = await connectedSigner([server]);
+      expect(server.connectionCount, equals(1));
+
+      // Pause first so the signer's own reconnect-on-disconnect does not race
+      // the setup, then drop the relay the way a flaky network would.
+      signer.pause();
+      await signer.relays.single.disconnect();
+      await _settleDisconnected(signer);
+
+      // resume() re-dials every disconnected relay, suspending on the backoff
+      // wait before it connects. That wait is the window sign-out lands in.
+      signer.resume();
+      signer.close();
+
+      // Longer than the first backoff step (100ms), so a reconnect that
+      // ignored the close has finished dialing by the time we assert.
+      await Future<void>.delayed(const Duration(milliseconds: 400));
+
+      expect(
+        server.connectionCount,
+        equals(1),
+        reason:
+            'a reconnect resuming after close() opens a socket and arms a '
+            'heartbeat that nothing is left holding',
+      );
+      expect(server.openConnectionCount, isZero);
+    });
+
+    test('close disposes each relay, so a later connect is refused', () async {
+      final server = await TestRelayServer.start();
+      addTearDown(server.close);
+
+      final signer = await connectedSigner([server]);
+      final relay = signer.relays.single;
+
+      signer.close();
+
+      expect(
+        await relay.connect(),
+        isFalse,
+        reason:
+            'close() only disconnected the relay, so the disposed guard '
+            'added in #7367 never engages and the relay reconnects',
+      );
+      expect(server.connectionCount, equals(1));
+    });
+
+    test('close during a request does not trip the relay iterator', () async {
+      final first = await TestRelayServer.start();
+      final second = await TestRelayServer.start();
+      addTearDown(first.close);
+      addTearDown(second.close);
+
+      final signer = await connectedSigner([first, second]);
+      expect(signer.relays, hasLength(2));
+
+      // Both disconnected, so the request suspends on the first relay's
+      // reconnect and close() lands with the loop still walking `relays`.
+      // Pausing keeps the signer's own reconnect from racing the setup.
+      signer.pause();
+      for (final relay in signer.relays) {
+        await relay.disconnect();
+      }
+      await _settleDisconnected(signer);
+
+      final pending = signer.sendAndWaitForResult(
+        NostrRemoteRequest('get_public_key', []),
+        timeout: 1,
+      );
+      signer.close();
+
+      await expectLater(
+        pending,
+        completion(isNull),
+        reason:
+            'close() clears `relays` mid-iteration, so walking the live '
+            'list throws ConcurrentModificationError',
+      );
+
+      // The re-dial of the first relay began before close(), so it may well
+      // have opened a socket — what matters is that nothing outlives the
+      // close, including the relays the loop never reached.
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+      expect(first.openConnectionCount, isZero);
+      expect(second.openConnectionCount, isZero);
+      expect(second.connectionCount, equals(1));
+    });
+  });
+
   group('NostrRemoteSigner reconnection logic', () {
     // These tests document the expected reconnection behavior.
     // Full integration tests would require mocking WebSocket connections.
@@ -156,4 +272,25 @@ void main() {
       },
     );
   });
+}
+
+/// Waits for every relay to actually report disconnected.
+///
+/// [Relay.disconnect] flips the status synchronously, but the connection
+/// manager's earlier `connected` state event is still queued behind it and
+/// lands afterwards — so the status reads connected again for a turn or two
+/// before settling. A test that reads it too early sees a connected relay and
+/// silently sets up the wrong scenario.
+Future<void> _settleDisconnected(NostrRemoteSigner signer) async {
+  bool allDown() => signer.relays.every(
+    (relay) => relay.relayStatus.connected == ClientConnected.disconnect,
+  );
+
+  final deadline = DateTime.now().add(const Duration(seconds: 2));
+  while (!allDown()) {
+    if (DateTime.now().isAfter(deadline)) {
+      throw StateError('relays never settled into a disconnected state');
+    }
+    await Future<void>.delayed(const Duration(milliseconds: 5));
+  }
 }


### PR DESCRIPTION
## Summary

Signing out could leave the app holding an open WebSocket to the remote signer, plus a heartbeat `Timer.periodic` on it, for the rest of the process. Both belonged to a relay the signer had already dropped from its list, so nothing was left that could close either one.

This is the defect #7367 fixed for the main relay pool, in a subsystem that fix does not reach — the NIP-46 path has its own relays and its own reconnect logic.

Closes #7962

## The two causes the issue named

**The closed flag was checked before the wait, not after.** `NostrRemoteSigner._reconnectRelay` returned early on `_isClosed`, then waited out a backoff of up to 1600ms, then connected with no second check. `NostrConnectSession._reconnectRelay` had the same shape, relying on its caller's single pre-loop check. Both now re-check after every suspension point.

**Neither ever disposed its relays, so the `RelayBase` guard could not engage.** That guard keys off the relay having been *disposed*; `close()` and `_cleanup()` only ever *disconnected*. Disconnecting closes the socket but keeps the connection manager, so a resuming reconnect reused it and opened a fresh socket with a fresh heartbeat. Both now dispose alongside the disconnect, via a shared `_shutDownRelay`.

## Four more windows the tests found

All the same shape — a connect already in flight when the teardown runs:

- `NostrRemoteSigner.connect()` and `NostrConnectSession._connectToRelays()` adopted relays that finished dialing *after* the teardown, putting live sockets onto a list nothing would ever walk again.
- `NostrConnectSession.ensureConnected()` was the worst of them: after the (now guarded) reconnect it reads the list the cleanup just emptied as "all relays lost" and dials the whole set again from scratch. Pre-fix this opened **three** sockets after `cancel()`.
- `start()` announced `listening` after a `cancel()` had already put the session in its terminal state.

## ConcurrentModificationError

The issue flagged this as unverified — it is real, and reproduced in a test. `sendAndWaitForResult` walked the live `relays` list across an awaited `connect()`, and `close()` clears that list. It now iterates a snapshot and abandons the request once the signer is closed, rather than registering a completer into a map `close()` has already drained (which would have hung until the request timeout).

## Test plan

New regression tests, each verified to fail on the pre-fix code with the symptom it names:

| Test | Pre-fix failure |
|---|---|
| a reconnect parked in backoff opens no socket after close | `Expected: <1> Actual: <2>` |
| close disposes each relay, so a later connect is refused | `Expected: false Actual: <true>` |
| close during a request does not trip the relay iterator | `Concurrent modification during iteration` |
| a reconnect in flight when the session is cancelled opens no socket | `Expected: <1> Actual: <3>` |
| a relay that finishes dialing after cancel is shut down | `Expected: <0> Actual: <1>` |

Two notes on how these are written, because both bit during development:

- **The relay status needs to settle before the scenario is set up.** `Relay.disconnect()` flips the status synchronously, but the connection manager's earlier `connected` state event is still queued behind it and lands afterwards. A test that reads the status too early sees a *connected* relay, skips the reconnect entirely, and passes green while exercising nothing. That is exactly what the first version of the signer test did. Both files now wait for the status to settle.
- **The session reconnect test asserts its own precondition.** It requires a `Reconnecting to` log line before asserting on the socket count, so it cannot pass by never having attempted a reconnect.

`_TestRelayServer` moves from a private class in the session test to `test/support/test_relay_server.dart` so both files can use it, and gains `openConnectionCount` — a socket the client opened and never closed is the leak, so it is worth asserting directly rather than inferring.

Verified locally:

- `flutter test` in `mobile/packages/nostr_sdk` — 580 passing
- `flutter test` in `mobile/packages/nostr_key_manager` — 71 passing (it owns the only production `NostrRemoteSigner` construction)
- The six app-side suites that touch the signer or the connect session — 78 passing
- `flutter analyze lib test integration_test` and `dart format` clean

