### PR TITLE
chore(release): open the 1.0.22 version train

### DIFF
--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.21+820
+version: 1.0.22+820
 
 environment:
   sdk: ^3.12.0


### PR DESCRIPTION
> **Correction (2026-08-22):** this description originally said `1.0.21+849` was "approved and live in the App Store" and called it "live production". That is wrong and has been fixed inline below. **The build users actually download from the App Store is `1.0.20`.** Everything after it — `1.0.21+849/850/851` and the Android `1.0.22+739` — has been TestFlight / Android-internal only, cut to exercise the Shorebird implementation, and never released to users. The version-train reasoning in this PR is unaffected: the preflight compares against the latest **approved** version, not the released one, so an approved-but-unreleased `849` still closes the `1.0.21` train.

Prerequisite for #7980. Part of #7841.

## Why

`1.0.21` was **approved** by App Review as build `849`, which closes that train. Approved is the state that matters here — `849` was never released to users, but `mobile/scripts/ios_store_version_preflight.rb` requires the candidate marketing version to be **strictly greater** than the latest approved one:

```ruby
unless (candidate_parts <=> approved_parts) == 1
  abort("ERROR: candidate version #{candidate_version} must be newer than approved App Store version ...")
```

A higher build number cannot reopen a closed train, so every `ios-build` at `1.0.21+N` now fails the preflight before Shorebird runs. This is also why `1.0.21+850` and `+851` were permitted — they were built before `849` was approved.

## Scope

One line. Only the marketing version matters: CI takes the build number from `PROJECT_BUILD_NUMBER`, so the `+820` suffix is inert and deliberately left alone rather than invented anew.

## Verification

- 69/69 `.github/scripts/tests` pass.
- Checked that nothing pins the app's version: the only `1.0.21` elsewhere is a fixture default in `test_ios_store_version_preflight.py`, unrelated to `pubspec.yaml`.

## What this unblocks

The next iOS store release, which is the one that must also carry the staging-validation affordance (#7979). The live App Store build (`1.0.20`) is not patchable, so Divine cannot hot-fix production today; that capability starts with the first release cut from this train.

Android is not gated by this preflight, but sharing the train keeps both platforms on one version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
