### PR TITLE
ci(shorebird): precache Android engine artifacts before Shorebird builds

### DIFF
--- a/.github/scripts/tests/test_codemagic_shorebird_config.py
+++ b/.github/scripts/tests/test_codemagic_shorebird_config.py
@@ -363,14 +363,58 @@ class CodemagicShorebirdConfigTest(unittest.TestCase):
         # shorebird_install rm -rf's ~/.shorebird on any pin change, so every
         # Shorebird Android build has to precache. Without it the Gradle build
         # dies on a missing flutter.jar (#7987).
+        # Scoped to the definition, not the whole file: a whole-file search
+        # passes on any occurrence anywhere, which is how the missing patch-key
+        # wiring survived until #7936.
+        definition = self._definition_block(
+            "precache_shorebird_android_artifacts"
+        )
+
+        # The revision is parsed from the CLI rather than hardcoded, so it
+        # cannot drift from EXPECTED_SHOREBIRD_REVISION.
+        self.assertIn("FLUTTER_REVISION=$(shorebird --version", definition)
+        self.assertNotRegex(
+            definition,
+            r"FLUTTER_REVISION=[\"']?[0-9a-f]{40}",
+            "the Flutter revision must be derived, never a second hardcoded pin",
+        )
+
+        # The parsed revision has to reach a real executable path, and that
+        # executable is what must run precache. Asserting the invocation is the
+        # point: replacing this line with a no-op is the mutation that has to
+        # turn this test red.
+        self.assertIn(
+            'SHOREBIRD_FLUTTER="$HOME/.shorebird/bin/cache/flutter/'
+            '$FLUTTER_REVISION/bin/flutter"',
+            definition,
+        )
+        self.assertIn('"$SHOREBIRD_FLUTTER" precache --android', definition)
+
+        # A missing revision or binary must fail loudly, or Gradle reports the
+        # original confusing "flutter.jar not found" instead.
+        self.assertIn('if [ -z "$FLUTTER_REVISION" ]; then', definition)
+        self.assertIn('if [ ! -x "$SHOREBIRD_FLUTTER" ]; then', definition)
+        self.assertEqual(2, definition.count("exit 1"))
+
+        # Ordering both ways: the CLI has to exist before its Flutter can be
+        # precached, and the precache has to happen before the build that needs
+        # the artifacts.
         for workflow_name, build_step in (
             ("android-build", "- *build_aab"),
             ("android-patch", "- *patch_android"),
         ):
             workflow = self._workflow_block(workflow_name)
-            self.assertIn("- *precache_shorebird_android_artifacts", workflow)
+            install_at = workflow.index("- *shorebird_install")
+            precache_at = workflow.index(
+                "- *precache_shorebird_android_artifacts"
+            )
             self.assertLess(
-                workflow.index("- *precache_shorebird_android_artifacts"),
+                install_at,
+                precache_at,
+                f"{workflow_name} must install Shorebird before precaching it",
+            )
+            self.assertLess(
+                precache_at,
                 workflow.index(build_step),
                 f"{workflow_name} must precache before {build_step}",
             )
@@ -380,13 +424,6 @@ class CodemagicShorebirdConfigTest(unittest.TestCase):
         self.assertNotIn(
             "- *precache_shorebird_android_artifacts",
             self._workflow_block("e2e-smoke-android"),
-        )
-
-        # The revision has to come from the CLI, not a second hardcoded pin
-        # that could drift from EXPECTED_SHOREBIRD_REVISION.
-        self.assertIn(
-            "FLUTTER_REVISION=$(shorebird --version",
-            self.contents,
         )
 
     def test_shorebird_install_runs_before_ios_dependency_resolution(self) -> None:
@@ -430,6 +467,15 @@ class CodemagicShorebirdConfigTest(unittest.TestCase):
         )
         self.assertIn("`shorebird_code_push` is a runtime dependency", self.shorebird_doc_contents)
         self.assertIn("Crashlytics", self.shorebird_doc_contents)
+
+    def _definition_block(self, anchor_name: str) -> str:
+        start = self.contents.index(f"    - &{anchor_name}\n")
+        next_definition = re.search(
+            r"^    - &", self.contents[start + 1 :], re.MULTILINE
+        )
+        if next_definition is None:
+            return self.contents[start:]
+        return self.contents[start : start + 1 + next_definition.start()]
 
     def _workflow_block(self, workflow_name: str) -> str:
         start = self.contents.index(f"  {workflow_name}:")

--- a/.github/scripts/tests/test_codemagic_shorebird_config.py
+++ b/.github/scripts/tests/test_codemagic_shorebird_config.py
@@ -358,6 +358,37 @@ class CodemagicShorebirdConfigTest(unittest.TestCase):
         for workflow in ("ios-build", "android-build", "ios-patch", "android-patch"):
             self.assertIn("- $HOME/.shorebird", self._workflow_block(workflow))
 
+    def test_android_shorebird_builds_precache_android_engine_artifacts(self) -> None:
+        # Shorebird's bundled Flutter precaches only host artifacts, and
+        # shorebird_install rm -rf's ~/.shorebird on any pin change, so every
+        # Shorebird Android build has to precache. Without it the Gradle build
+        # dies on a missing flutter.jar (#7987).
+        for workflow_name, build_step in (
+            ("android-build", "- *build_aab"),
+            ("android-patch", "- *patch_android"),
+        ):
+            workflow = self._workflow_block(workflow_name)
+            self.assertIn("- *precache_shorebird_android_artifacts", workflow)
+            self.assertLess(
+                workflow.index("- *precache_shorebird_android_artifacts"),
+                workflow.index(build_step),
+                f"{workflow_name} must precache before {build_step}",
+            )
+
+        # The e2e workflow builds with Codemagic's own Flutter, not
+        # Shorebird's, so it neither needs nor should pay for the download.
+        self.assertNotIn(
+            "- *precache_shorebird_android_artifacts",
+            self._workflow_block("e2e-smoke-android"),
+        )
+
+        # The revision has to come from the CLI, not a second hardcoded pin
+        # that could drift from EXPECTED_SHOREBIRD_REVISION.
+        self.assertIn(
+            "FLUTTER_REVISION=$(shorebird --version",
+            self.contents,
+        )
+
     def test_shorebird_install_runs_before_ios_dependency_resolution(self) -> None:
         for workflow_name in ("ios-build", "ios-patch"):
             workflow = self._workflow_block(workflow_name)

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -146,6 +146,29 @@ definitions:
     - &pod_install
       name: Run pod install
       script: find . -name "Podfile" -execdir pod install \;
+    - &precache_shorebird_android_artifacts
+      name: Precache Shorebird Android engine artifacts
+      script: |
+        set -euo pipefail
+        # Shorebird ships its own Flutter and precaches only what the host
+        # needs, which on a macOS runner is iOS and desktop. Both Android
+        # workflows build through that Flutter, so without this they fail with
+        # "Flutter debug embedding JAR not found ... Run 'flutter precache
+        # --android'". shorebird_install also rm -rf's ~/.shorebird on any pin
+        # change, discarding whatever an earlier run precached, so this cannot
+        # be a one-time setup step. See #7987.
+        FLUTTER_REVISION=$(shorebird --version 2>/dev/null \
+          | sed -n 's/^Flutter .* revision \([0-9a-f]\{40\}\).*/\1/p')
+        if [ -z "$FLUTTER_REVISION" ]; then
+          echo "ERROR: could not read the Shorebird Flutter revision from 'shorebird --version'."
+          exit 1
+        fi
+        SHOREBIRD_FLUTTER="$HOME/.shorebird/bin/cache/flutter/$FLUTTER_REVISION/bin/flutter"
+        if [ ! -x "$SHOREBIRD_FLUTTER" ]; then
+          echo "ERROR: Shorebird Flutter not found at $SHOREBIRD_FLUTTER"
+          exit 1
+        fi
+        "$SHOREBIRD_FLUTTER" precache --android
     - &setup_local_properties
       name: Set up local.properties
       script: echo "flutter.sdk=$FLUTTER_ROOT" > "$CM_BUILD_DIR/mobile/android/local.properties"
@@ -1060,6 +1083,7 @@ workflows:
       - *preflight_shorebird_android_release
       - *write_shorebird_dart_defines
       - *build_apk
+      - *precache_shorebird_android_artifacts
       - *build_aab
       - *emit_shorebird_provenance
       - *publish_github_release
@@ -1260,6 +1284,7 @@ workflows:
       - *configure_gradle_memory
       - *write_shorebird_public_key
       - *write_shorebird_private_key
+      - *precache_shorebird_android_artifacts
       - *patch_android
 
   macos-build:


### PR DESCRIPTION
Fixes #7987. Unblocks the Android half of #7843 (epic #7841).

## The failure

`Android Build` step 16, `Build Android AAB (Shorebird release)`, exit 70:

```
Flutter debug embedding JAR not found at
/Users/builder/.shorebird/bin/cache/flutter/0cae2fc0a4b0c190d9f9090ad731b28cc6fb85df/bin/cache/artifacts/engine/android-arm64/flutter.jar.
Run 'flutter precache --android' for the FLUTTER_ROOT toolchain.
```

`build_apk` passes just before it because that is a plain `flutter build` on Codemagic's own precached Flutter. `build_aab` runs `shorebird release android`, which builds through **Shorebird's** bundled Flutter — and that copy has no Android engine artifacts.

Reproduced on a local install of the same pinned version, so it is Shorebird's default on a macOS host rather than a CI fluke:

```
$ ls ~/.shorebird/bin/cache/flutter/0cae2fc0a4b0c190d9f9090ad731b28cc6fb85df/bin/cache/artifacts/engine/
common  darwin-x64  ios  ios-profile  ios-release
```

## Why it worked before and doesn't now

Android releases `1.0.20+714`, `+716` and `+719` exist, so this path used to work. `shorebird_install` — from the pinned-revision hardening in #7202 — wipes the cache whenever the pin does not match:

```bash
if ! printf '%s\n' "$SHOREBIRD_VERSION_OUTPUT" | grep -Fq "$EXPECTED_SHOREBIRD_VERSION" || \
   [ "$SHOREBIRD_REVISION" != "$EXPECTED_SHOREBIRD_REVISION" ]; then
  rm -rf "$HOME/.shorebird"
```

That discards `bin/cache/flutter/*/bin/cache/artifacts` along with everything else, and nothing recreates it — `grep -c precache codemagic.yaml` returned `0`. Because `$HOME/.shorebird` is also in `cache_paths`, the failure looks intermittent across runs, which is worse to diagnose under incident pressure.

## Changes

A `precache_shorebird_android_artifacts` step in both Shorebird Android workflows.

**Placed after each workflow's gates**, so a build rejected by the release preflight or by provenance/patch-source verification does not pay for a multi-hundred-MB download first: after `build_apk` in `android-build`, after `write_shorebird_private_key` in `android-patch`.

**Not** in `e2e-smoke-android` — it builds with Codemagic's Flutter and neither needs the artifacts nor should pay for them.

**The revision is derived, not hardcoded.** `shorebird flutter` exposes only `config` and `versions`, so there is no CLI proxy for precache and the Flutter binary inside Shorebird's cache has to be invoked directly. Parsing it from `shorebird --version` avoids a second pin that could silently drift from `EXPECTED_SHOREBIRD_REVISION`. The step fails loudly if either the revision or the binary is missing, rather than skipping quietly and letting Gradle produce the original confusing error.

`android-patch` is fixed too. It runs `shorebird patch android` through the same bundled Flutter and would hit the identical wall the moment a patchable Android release exists.

## Verification

- 70/70 `.github/scripts/tests` pass, including the new `test_android_shorebird_builds_precache_android_engine_artifacts`.
- New test confirmed **red** against pre-fix `codemagic.yaml`: `'- *precache_shorebird_android_artifacts' not found in ' android-build: …'`.
- `codemagic.yaml` still parses with aliases; all 8 workflows resolve.

The test asserts per workflow that the step exists *and* precedes the actual build step, asserts `e2e-smoke-android` does not get it, and pins that the revision comes from `shorebird --version`.

Real proof is the next `Android Build` reaching `shorebird release android` — which is also the first provenance-recorded Android release Divine will have, since `divinevideo/divine-release-provenance` currently has no `releases/android/` directory at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)