### PR TITLE
fix(explore): say sponsored by on featured collections

### DIFF
--- a/mobile/docs/LOCALIZATION_STYLE_GUIDE.md
+++ b/mobile/docs/LOCALIZATION_STYLE_GUIDE.md
@@ -338,9 +338,10 @@ affected locales is tracked in
 **Never soften a load-bearing word.** Safety, consent, money, deletion and age
 copy carry meaning that a friendlier synonym destroys. The repo already treats
 this as a first-class reason to *defer* rather than approximate — see the
-comment on `exploreFeaturedPaidPartnership` in
+comment on `exploreFeaturedSponsoredBy` in
 `mobile/test/l10n/arb_consistency_test.dart`, held out of machine translation
-because "paid" is load-bearing and a softened rendering discloses nothing.
+because it must remain an unmistakable commercial disclosure rather than
+soften into an editorial credit.
 
 **Match the source's energy, not its punctuation.** Exclamation marks and
 ALL CAPS are one language's way of spelling emphasis, and copying the marks

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -671,9 +671,9 @@
   "exploreTabForYou": "For You",
   "exploreTabLists": "Lists",
   "exploreTabIntegratedApps": "Integrated Apps",
-  "exploreFeaturedPaidPartnership": "In paid partnership with {sponsor}",
-  "@exploreFeaturedPaidPartnership": {
-    "description": "Commercial disclosure pinned above a sponsored featured collection's grid. The wording is a legal disclosure, not marketing copy: translate it as the closest local equivalent of a paid commercial partnership, and keep the word for 'paid'. {sponsor} is a brand name supplied by the server and must not be translated.",
+  "exploreFeaturedSponsoredBy": "Sponsored by {sponsor}",
+  "@exploreFeaturedSponsoredBy": {
+    "description": "Commercial disclosure pinned above a sponsored featured collection's grid. This is a disclosure, not marketing copy: translate it so it clearly communicates commercial sponsorship rather than an editorial credit. Many languages may render this more naturally as a noun label than a prepositional phrase, or may need the brand name to lead. {sponsor} is a brand name supplied by the server and must not be translated.",
     "placeholders": {
       "sponsor": {
         "type": "String",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -2124,11 +2124,11 @@ abstract class AppLocalizations {
   /// **'Integrated Apps'**
   String get exploreTabIntegratedApps;
 
-  /// Commercial disclosure pinned above a sponsored featured collection's grid. The wording is a legal disclosure, not marketing copy: translate it as the closest local equivalent of a paid commercial partnership, and keep the word for 'paid'. {sponsor} is a brand name supplied by the server and must not be translated.
+  /// Commercial disclosure pinned above a sponsored featured collection's grid. This is a disclosure, not marketing copy: translate it so it clearly communicates commercial sponsorship rather than an editorial credit. Many languages may render this more naturally as a noun label than a prepositional phrase, or may need the brand name to lead. {sponsor} is a brand name supplied by the server and must not be translated.
   ///
   /// In en, this message translates to:
-  /// **'In paid partnership with {sponsor}'**
-  String exploreFeaturedPaidPartnership(String sponsor);
+  /// **'Sponsored by {sponsor}'**
+  String exploreFeaturedSponsoredBy(String sponsor);
 
   /// Spoken label for the featured tab's collection pill when the collection is sponsored. The pill's pink colour conveys this visually; this carries the same state to screen readers. {name} is the collection name supplied by the server.
   ///

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -1202,8 +1202,8 @@ class AppLocalizationsAm extends AppLocalizations {
   String get exploreTabIntegratedApps => 'የተዋሃዱ መተግበሪያዎች';
 
   @override
-  String exploreFeaturedPaidPartnership(String sponsor) {
-    return 'In paid partnership with $sponsor';
+  String exploreFeaturedSponsoredBy(String sponsor) {
+    return 'Sponsored by $sponsor';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -1206,8 +1206,8 @@ class AppLocalizationsAr extends AppLocalizations {
   String get exploreTabIntegratedApps => 'التطبيقات المدمجة';
 
   @override
-  String exploreFeaturedPaidPartnership(String sponsor) {
-    return 'In paid partnership with $sponsor';
+  String exploreFeaturedSponsoredBy(String sponsor) {
+    return 'Sponsored by $sponsor';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -1241,8 +1241,8 @@ class AppLocalizationsBg extends AppLocalizations {
   String get exploreTabIntegratedApps => 'Интегрирани приложения';
 
   @override
-  String exploreFeaturedPaidPartnership(String sponsor) {
-    return 'In paid partnership with $sponsor';
+  String exploreFeaturedSponsoredBy(String sponsor) {
+    return 'Sponsored by $sponsor';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -1241,8 +1241,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get exploreTabIntegratedApps => 'Integrierte Apps';
 
   @override
-  String exploreFeaturedPaidPartnership(String sponsor) {
-    return 'In paid partnership with $sponsor';
+  String exploreFeaturedSponsoredBy(String sponsor) {
+    return 'Sponsored by $sponsor';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -1238,8 +1238,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get exploreTabIntegratedApps => 'Integrated Apps';
 
   @override
-  String exploreFeaturedPaidPartnership(String sponsor) {
-    return 'In paid partnership with $sponsor';
+  String exploreFeaturedSponsoredBy(String sponsor) {
+    return 'Sponsored by $sponsor';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -1240,8 +1240,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get exploreTabIntegratedApps => 'Apps integradas';
 
   @override
-  String exploreFeaturedPaidPartnership(String sponsor) {
-    return 'In paid partnership with $sponsor';
+  String exploreFeaturedSponsoredBy(String sponsor) {
+    return 'Sponsored by $sponsor';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -1213,8 +1213,8 @@ class AppLocalizationsFil extends AppLocalizations {
   String get exploreTabIntegratedApps => 'Mga Integrated App';
 
   @override
-  String exploreFeaturedPaidPartnership(String sponsor) {
-    return 'In paid partnership with $sponsor';
+  String exploreFeaturedSponsoredBy(String sponsor) {
+    return 'Sponsored by $sponsor';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -1254,8 +1254,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get exploreTabIntegratedApps => 'Apps intégrées';
 
   @override
-  String exploreFeaturedPaidPartnership(String sponsor) {
-    return 'In paid partnership with $sponsor';
+  String exploreFeaturedSponsoredBy(String sponsor) {
+    return 'Sponsored by $sponsor';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -1169,8 +1169,8 @@ class AppLocalizationsId extends AppLocalizations {
   String get exploreTabIntegratedApps => 'Aplikasi Terintegrasi';
 
   @override
-  String exploreFeaturedPaidPartnership(String sponsor) {
-    return 'In paid partnership with $sponsor';
+  String exploreFeaturedSponsoredBy(String sponsor) {
+    return 'Sponsored by $sponsor';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -1242,8 +1242,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get exploreTabIntegratedApps => 'App integrate';
 
   @override
-  String exploreFeaturedPaidPartnership(String sponsor) {
-    return 'In paid partnership with $sponsor';
+  String exploreFeaturedSponsoredBy(String sponsor) {
+    return 'Sponsored by $sponsor';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -1114,8 +1114,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get exploreTabIntegratedApps => '連携アプリ';
 
   @override
-  String exploreFeaturedPaidPartnership(String sponsor) {
-    return 'In paid partnership with $sponsor';
+  String exploreFeaturedSponsoredBy(String sponsor) {
+    return 'Sponsored by $sponsor';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -1118,8 +1118,8 @@ class AppLocalizationsKo extends AppLocalizations {
   String get exploreTabIntegratedApps => '연동된 앱';
 
   @override
-  String exploreFeaturedPaidPartnership(String sponsor) {
-    return 'In paid partnership with $sponsor';
+  String exploreFeaturedSponsoredBy(String sponsor) {
+    return 'Sponsored by $sponsor';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -1200,8 +1200,8 @@ class AppLocalizationsMs extends AppLocalizations {
   String get exploreTabIntegratedApps => 'Apl Bersepadu';
 
   @override
-  String exploreFeaturedPaidPartnership(String sponsor) {
-    return 'In paid partnership with $sponsor';
+  String exploreFeaturedSponsoredBy(String sponsor) {
+    return 'Sponsored by $sponsor';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -1232,8 +1232,8 @@ class AppLocalizationsNl extends AppLocalizations {
   String get exploreTabIntegratedApps => 'Geïntegreerde apps';
 
   @override
-  String exploreFeaturedPaidPartnership(String sponsor) {
-    return 'In paid partnership with $sponsor';
+  String exploreFeaturedSponsoredBy(String sponsor) {
+    return 'Sponsored by $sponsor';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -1254,8 +1254,8 @@ class AppLocalizationsPl extends AppLocalizations {
   String get exploreTabIntegratedApps => 'Zintegrowane aplikacje';
 
   @override
-  String exploreFeaturedPaidPartnership(String sponsor) {
-    return 'In paid partnership with $sponsor';
+  String exploreFeaturedSponsoredBy(String sponsor) {
+    return 'Sponsored by $sponsor';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -1239,8 +1239,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get exploreTabIntegratedApps => 'Apps integrados';
 
   @override
-  String exploreFeaturedPaidPartnership(String sponsor) {
-    return 'In paid partnership with $sponsor';
+  String exploreFeaturedSponsoredBy(String sponsor) {
+    return 'Sponsored by $sponsor';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -1267,8 +1267,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get exploreTabIntegratedApps => 'Aplicații integrate';
 
   @override
-  String exploreFeaturedPaidPartnership(String sponsor) {
-    return 'In paid partnership with $sponsor';
+  String exploreFeaturedSponsoredBy(String sponsor) {
+    return 'Sponsored by $sponsor';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -1217,8 +1217,8 @@ class AppLocalizationsSv extends AppLocalizations {
   String get exploreTabIntegratedApps => 'Integrerade appar';
 
   @override
-  String exploreFeaturedPaidPartnership(String sponsor) {
-    return 'In paid partnership with $sponsor';
+  String exploreFeaturedSponsoredBy(String sponsor) {
+    return 'Sponsored by $sponsor';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -1168,8 +1168,8 @@ class AppLocalizationsTr extends AppLocalizations {
   String get exploreTabIntegratedApps => 'Entegre Uygulamalar';
 
   @override
-  String exploreFeaturedPaidPartnership(String sponsor) {
-    return 'In paid partnership with $sponsor';
+  String exploreFeaturedSponsoredBy(String sponsor) {
+    return 'Sponsored by $sponsor';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -1230,8 +1230,8 @@ class AppLocalizationsUr extends AppLocalizations {
   String get exploreTabIntegratedApps => 'مربوط ایپس';
 
   @override
-  String exploreFeaturedPaidPartnership(String sponsor) {
-    return 'In paid partnership with $sponsor';
+  String exploreFeaturedSponsoredBy(String sponsor) {
+    return 'Sponsored by $sponsor';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -1200,8 +1200,8 @@ class AppLocalizationsVi extends AppLocalizations {
   String get exploreTabIntegratedApps => 'Ứng dụng tích hợp';
 
   @override
-  String exploreFeaturedPaidPartnership(String sponsor) {
-    return 'In paid partnership with $sponsor';
+  String exploreFeaturedSponsoredBy(String sponsor) {
+    return 'Sponsored by $sponsor';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -1128,8 +1128,8 @@ class AppLocalizationsZh extends AppLocalizations {
   String get exploreTabIntegratedApps => '集成应用';
 
   @override
-  String exploreFeaturedPaidPartnership(String sponsor) {
-    return 'In paid partnership with $sponsor';
+  String exploreFeaturedSponsoredBy(String sponsor) {
+    return 'Sponsored by $sponsor';
   }
 
   @override

--- a/mobile/lib/screens/explore/tabs/featured_videos_tab.dart
+++ b/mobile/lib/screens/explore/tabs/featured_videos_tab.dart
@@ -125,7 +125,7 @@ class _FeaturedPartnershipLine extends StatelessWidget {
       child: Align(
         alignment: AlignmentDirectional.centerStart,
         child: Text(
-          l10n.exploreFeaturedPaidPartnership(sponsor),
+          l10n.exploreFeaturedSponsoredBy(sponsor),
           // Wraps with no line ceiling: a clipped disclosure has stopped
           // disclosing, and the grid below yields whatever the line needs.
           style: VineTheme.labelMediumFont(

--- a/mobile/test/l10n/arb_consistency_test.dart
+++ b/mobile/test/l10n/arb_consistency_test.dart
@@ -38,6 +38,16 @@ void main() {
       }
     });
 
+    test('known untranslated debt only names template messages', () {
+      final template = _readArb(File('lib/l10n/app_en.arb'));
+
+      expect(
+        _knownUntranslatedDebt.difference(_messageKeys(template)),
+        isEmpty,
+        reason: 'stale untranslated-debt entries must be removed',
+      );
+    });
+
     test('owner delete copy keeps Divine and Nostr disclosure', () {
       final l10nDir = Directory('lib/l10n');
       final arbFiles =
@@ -485,10 +495,10 @@ const _knownUntranslatedDebt = <String>{
   'authAccountRestoreFailed',
   'settingsAccountRestoreFailed',
   'settingsAccountRestoreFailedSwitchMessage',
-  // Commercial disclosure copy, deliberately not machine-translated: "paid"
-  // is load-bearing and a softened rendering discloses nothing. Translation
-  // pass tracked in #7673, and required before any non-English campaign.
-  'exploreFeaturedPaidPartnership',
+  // Commercial disclosure copy, deliberately not machine-translated: a
+  // softened rendering discloses nothing. Translation pass tracked in #7673,
+  // and required before any non-English campaign.
+  'exploreFeaturedSponsoredBy',
   'exploreFeaturedSponsoredPillSemanticLabel',
   // Secure-account key-conflict recovery copy is new; translation pass
   // tracked in #7984.

--- a/mobile/test/screens/explore/tabs/featured_videos_tab_test.dart
+++ b/mobile/test/screens/explore/tabs/featured_videos_tab_test.dart
@@ -45,9 +45,9 @@ FeaturedTabConfig _config({Map<String, String> disclosureLabel = const {}}) {
 FeaturedTabConfig _sponsoredConfig() =>
     _config(disclosureLabel: const {'default': 'Acme Bikes'});
 
-String _partnershipLine(String sponsor) => lookupAppLocalizations(
+String _sponsoredLine(String sponsor) => lookupAppLocalizations(
   const Locale('en'),
-).exploreFeaturedPaidPartnership(sponsor);
+).exploreFeaturedSponsoredBy(sponsor);
 
 VideoEvent _video(String id) {
   return VideoEvent(
@@ -227,7 +227,7 @@ void main() {
       await tester.pumpWidget(buildSubject(config: _sponsoredConfig()));
       await tester.pumpAndSettle();
 
-      final line = find.text(_partnershipLine('Acme Bikes'));
+      final line = find.text(_sponsoredLine('Acme Bikes'));
       expect(line, findsOneWidget);
       // Pinned above the grid rather than scrolled into it.
       expect(
@@ -242,7 +242,7 @@ void main() {
       await tester.pumpWidget(buildSubject());
       await tester.pumpAndSettle();
 
-      expect(find.textContaining('paid partnership'), findsNothing);
+      expect(find.text(_sponsoredLine('Acme Bikes')), findsNothing);
     });
 
     testWidgets(
@@ -259,7 +259,7 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        expect(find.textContaining('paid partnership'), findsNothing);
+        expect(find.text(_sponsoredLine('Acme Bicicletas')), findsNothing);
       },
     );
 
@@ -276,7 +276,7 @@ void main() {
       await tester.pumpWidget(buildSubject(config: _sponsoredConfig()));
       await tester.pumpAndSettle();
 
-      expect(find.text(_partnershipLine('Acme Bikes')), findsOneWidget);
+      expect(find.text(_sponsoredLine('Acme Bikes')), findsOneWidget);
     });
 
     testWidgets('keeps the disclosure when the videos request fails', (
@@ -292,7 +292,7 @@ void main() {
       await tester.pumpWidget(buildSubject(config: _sponsoredConfig()));
       await tester.pumpAndSettle();
       // It describes the tab's commercial arrangement, not its contents.
-      expect(find.text(_partnershipLine('Acme Bikes')), findsOneWidget);
+      expect(find.text(_sponsoredLine('Acme Bikes')), findsOneWidget);
     });
   });
 }

--- a/mobile/test/screens/explore/tabs/featured_videos_tab_test.dart
+++ b/mobile/test/screens/explore/tabs/featured_videos_tab_test.dart
@@ -49,6 +49,14 @@ String _sponsoredLine(String sponsor) => lookupAppLocalizations(
   const Locale('en'),
 ).exploreFeaturedSponsoredBy(sponsor);
 
+/// The disclosure's own wording, with the brand taken out.
+///
+/// Negative assertions match on this rather than on one brand string. A line
+/// that renders with the wrong sponsor — or with none at all — is still a
+/// commercial disclosure on a collection that has no sponsor, and a matcher
+/// naming a brand the widget was never given cannot fail on either.
+String _disclosureWording() => _sponsoredLine('').trim();
+
 VideoEvent _video(String id) {
   return VideoEvent(
     id: id,
@@ -242,7 +250,7 @@ void main() {
       await tester.pumpWidget(buildSubject());
       await tester.pumpAndSettle();
 
-      expect(find.text(_sponsoredLine('Acme Bikes')), findsNothing);
+      expect(find.textContaining(_disclosureWording()), findsNothing);
     });
 
     testWidgets(
@@ -259,7 +267,7 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        expect(find.text(_sponsoredLine('Acme Bicicletas')), findsNothing);
+        expect(find.textContaining(_disclosureWording()), findsNothing);
       },
     );
 


### PR DESCRIPTION
Featured collections currently describe sponsorship as an “In paid partnership with” relationship. This changes the disclosure to the approved, clearer “Sponsored by {sponsor}” wording while keeping the sponsor name supplied by the server.

The localization key and generated APIs are renamed to match the new construction. Translator guidance now preserves the important distinction between a commercial disclosure and an editorial credit, without requiring an unnatural prepositional phrase in every language. The English fallback remains intentional until the translation pass tracked in #7673.

This also updates the localization style-guide example and adds a consistency assertion so stale entries cannot remain in the untranslated-debt allowlist after future key renames. It does not change featured-collection loading, sponsor resolution, layout, or backend behavior.

Verification:
- flutter gen-l10n
- flutter test test/l10n/
- flutter test test/screens/explore/tabs/featured_videos_tab_test.dart
- flutter analyze
- check-l10n hardcoded-string scan
- pre-push checks

Closes #7993