### PR TITLE
feat(shorebird): bind release provenance to the patch signing key

### DIFF
--- a/.github/scripts/tests/test_shorebird_provenance.py
+++ b/.github/scripts/tests/test_shorebird_provenance.py
@@ -1,3 +1,5 @@
+import hashlib
+import hmac
 import json
 import os
 import subprocess
@@ -8,6 +10,22 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 SCRIPT = REPO_ROOT / "mobile" / "scripts" / "shorebird_provenance.rb"
+
+# Throwaway P-256 public keys, generated for this test. Public halves only,
+# and they sign nothing — they exist so the digest comparison has two
+# genuinely different PEMs to tell apart.
+RELEASE_PUBLIC_KEY = (
+    "-----BEGIN PUBLIC KEY-----\\n"
+    "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEU95v7B64q1r8ca3MXNw/0ytj1mA/\\n"
+    "O5i37b9eVSOyf71BApflNYsMsj2wZDn8z32QJog17hEyHuQe9W3D0fGZvw==\\n"
+    "-----END PUBLIC KEY-----"
+)
+ROTATED_PUBLIC_KEY = (
+    "-----BEGIN PUBLIC KEY-----\\n"
+    "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEaj+mmjSlZGv1yBNP/MjRw9wkTRHV\\n"
+    "4uP7OqE7SPaokof38YYvsZFC1wGShILX89OM5d/O9DFwDCgbpV7x1BNZag==\\n"
+    "-----END PUBLIC KEY-----"
+)
 
 
 class ShorebirdProvenanceTest(unittest.TestCase):
@@ -32,9 +50,14 @@ class ShorebirdProvenanceTest(unittest.TestCase):
             **os.environ,
             "SHOREBIRD_PROVENANCE_HMAC_KEY": "test-only-hmac-key-with-32-bytes-minimum",
             "SHOREBIRD_PROVENANCE_HMAC_KEY_ID": "test-key-v1",
+            "SHOREBIRD_PATCH_PUBLIC_KEY": RELEASE_PUBLIC_KEY,
         }
 
-    def emit(self, output: Path | None = None) -> subprocess.CompletedProcess[str]:
+    def emit(
+        self,
+        output: Path | None = None,
+        environment: dict[str, str] | None = None,
+    ) -> subprocess.CompletedProcess[str]:
         return subprocess.run(
             [
                 "ruby",
@@ -60,7 +83,7 @@ class ShorebirdProvenanceTest(unittest.TestCase):
                 str(output or self.record),
             ],
             cwd=REPO_ROOT,
-            env=self.environment,
+            env=environment or self.environment,
             check=False,
             text=True,
             capture_output=True,
@@ -208,6 +231,89 @@ class ShorebirdProvenanceTest(unittest.TestCase):
         self.assertNotIn("STAGING", result.stderr)
         self.assertNotIn("release-secret", result.stderr)
         self.assertNotIn("patch-secret", result.stderr)
+
+    def test_verify_rejects_a_rotated_patch_signing_key(self) -> None:
+        self.assertEqual(0, self.emit().returncode)
+        rotated = self.verify(
+            environment={
+                **self.environment,
+                "SHOREBIRD_PATCH_PUBLIC_KEY": ROTATED_PUBLIC_KEY,
+            }
+        )
+
+        self.assertNotEqual(0, rotated.returncode)
+        self.assertIn("patch signing key does not match", rotated.stderr)
+
+    def test_recorded_key_digest_is_the_plain_digest_of_the_pem(self) -> None:
+        self.assertEqual(0, self.emit().returncode)
+        record = json.loads(self.record.read_text())
+
+        self.assertEqual(
+            hashlib.sha256(
+                RELEASE_PUBLIC_KEY.replace("\\n", "\n").encode()
+            ).hexdigest(),
+            record["patch_public_key_sha256"],
+        )
+
+    def test_emit_rejects_a_public_key_that_is_not_a_pem(self) -> None:
+        result = self.emit(
+            environment={
+                **self.environment,
+                "SHOREBIRD_PATCH_PUBLIC_KEY": "-----BEGIN PRIVATE KEY-----\\nx\\n-----END PRIVATE KEY-----",
+            }
+        )
+
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("not a public-key PEM", result.stderr)
+
+    def test_a_record_predating_key_binding_verifies_with_a_note(self) -> None:
+        self.assertEqual(0, self.emit().returncode)
+        record = json.loads(self.record.read_text())
+        record.pop("patch_public_key_sha256")
+        # The HMAC covers every field but itself, so a record written before
+        # the field existed still authenticates once the field is dropped.
+        record["record_hmac"] = self._recompute_hmac(record)
+        self.record.write_text(json.dumps(record))
+
+        result = self.verify(
+            environment={
+                **self.environment,
+                "SHOREBIRD_PATCH_PUBLIC_KEY": ROTATED_PUBLIC_KEY,
+            }
+        )
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertIn("predates patch-signing-key binding", result.stderr)
+
+    def _recompute_hmac(self, record: dict) -> str:
+        payload = subprocess.run(
+            [
+                "ruby",
+                "-rjson",
+                "-e",
+                """
+                def canonical(value)
+                  case value
+                  when Hash then '{' + value.keys.sort.map { |k|
+                    "#{JSON.generate(k)}:#{canonical(value.fetch(k))}" }.join(',') + '}'
+                  when Array then '[' + value.map { |i| canonical(i) }.join(',') + ']'
+                  else JSON.generate(value)
+                  end
+                end
+                record = JSON.parse($stdin.read)
+                print canonical(record.reject { |name, _| name == 'record_hmac' })
+                """,
+            ],
+            input=json.dumps(record),
+            check=True,
+            text=True,
+            capture_output=True,
+        ).stdout
+        return hmac.new(
+            self.environment["SHOREBIRD_PROVENANCE_HMAC_KEY"].encode(),
+            payload.encode(),
+            hashlib.sha256,
+        ).hexdigest()
 
     def test_unpatchable_historical_record_fails_closed(self) -> None:
         self.assertEqual(0, self.emit().returncode)

--- a/mobile/docs/SHOREBIRD_CODE_PUSH.md
+++ b/mobile/docs/SHOREBIRD_CODE_PUSH.md
@@ -360,6 +360,46 @@ between PEM lines. CI decodes and validates that envelope before invoking
 Shorebird. Release jobs materialize only the public key; patch jobs materialize
 both keys.
 
+### The signing key is bound to the release
+
+Shorebird links the public key into the release binary and the installed app
+verifies every patch signature against *that* key. Sign a patch with a rotated
+private key and the app rejects it — on device, after download, with nothing in
+the build log to explain it.
+
+So provenance records `patch_public_key_sha256`, a plain SHA-256 of the
+normalized public PEM, and the patch workflow aborts when the key it is about
+to sign with is not the key the release was built with:
+
+```
+ERROR: patch signing key does not match the key this release was built with
+```
+
+The digest is deliberately not the keyed HMAC used for `config_fingerprints` —
+the key is public, so a value anyone can recompute is worth more than
+concealment. It covers the PEM with surrounding whitespace stripped, so
+recompute it as:
+
+```
+printf '%s' "$(openssl pkey -pubin -in key.pem)" | shasum -a 256
+```
+
+The `$( )` is load-bearing: it drops the trailing newline `openssl` emits, and
+`shasum` on the file directly returns a different digest.
+
+When that error appears, restore the release's key pair rather than editing the
+record; provenance is create-only.
+
+Releases recorded before this field existed verify with a note on stderr rather
+than an abort. Nothing can be checked for them, which is the reason to prefer
+patching a release cut under the current scheme.
+
+**Rotating the patch-signing pair strands every release built with the old
+one**, exactly as moving the CLI pin does. Rotate immediately after a store
+release, never while a shipped release is the only thing standing between
+production and a hot fix, and retain the retired pair for as long as any
+release signed with it can still be patched.
+
 The `github_credentials` token used by release and patch jobs must have read
 and write access to the private `divinevideo/divine-release-provenance`
 repository. Provenance writes are create-only. Never delete or replace a record

--- a/mobile/scripts/shorebird_provenance.rb
+++ b/mobile/scripts/shorebird_provenance.rb
@@ -36,6 +36,23 @@ def fingerprint_key
   key
 end
 
+PUBLIC_KEY_PEM = /\A-----BEGIN PUBLIC KEY-----\n.+\n-----END PUBLIC KEY-----\z/m
+SHA256_HEX = /\A[0-9a-f]{64}\z/
+
+# Digest of the patch-signing public key baked into the release binary.
+#
+# Shorebird verifies a patch signature on-device against the key linked into
+# the release, so a rotated key produces patches the installed app silently
+# refuses. This is a plain digest, not the keyed fingerprint used for
+# dart-defines: the key is public, and a digest anyone can recompute from the
+# PEM is what makes the mismatch diagnosable.
+def patch_public_key_digest
+  pem = required_env('SHOREBIRD_PATCH_PUBLIC_KEY').gsub('\\n', "\n").strip
+  abort_with('SHOREBIRD_PATCH_PUBLIC_KEY is not a public-key PEM') unless pem.match?(PUBLIC_KEY_PEM)
+
+  OpenSSL::Digest::SHA256.hexdigest(pem)
+end
+
 def fingerprints(defines, key)
   defines.sort.to_h do |name, value|
     abort_with("dart-define #{name} must be a string") unless value.is_a?(String)
@@ -142,6 +159,7 @@ when 'emit'
     'shorebird_cli_revision' => options[:shorebird_cli_revision],
     'config_fingerprint_key_id' => required_env('SHOREBIRD_PROVENANCE_HMAC_KEY_ID'),
     'config_fingerprints' => fingerprints(defines, fingerprint_key),
+    'patch_public_key_sha256' => patch_public_key_digest,
     'patchable' => true,
   }
   record['record_hmac'] = record_hmac(record, fingerprint_key)
@@ -181,6 +199,16 @@ when 'verify'
   abort_with('patch Flutter version does not match release provenance') unless record['flutter_version'] == options[:flutter_version]
   abort_with('patch Shorebird CLI version does not match release provenance') unless record['shorebird_cli_version'] == options[:shorebird_cli_version]
   abort_with('patch Shorebird CLI revision does not match release provenance') unless record['shorebird_cli_revision'] == options[:shorebird_cli_revision]
+
+  recorded_key_digest = record['patch_public_key_sha256']
+  if recorded_key_digest.nil?
+    warn('NOTE: this release predates patch-signing-key binding; the signing key cannot be checked')
+  else
+    abort_with('release provenance patch_public_key_sha256 is invalid') unless recorded_key_digest.is_a?(String) && recorded_key_digest.match?(SHA256_HEX)
+    unless secure_compare(recorded_key_digest, patch_public_key_digest)
+      abort_with('patch signing key does not match the key this release was built with')
+    end
+  end
 
   recorded_fingerprints = record['config_fingerprints']
   abort_with('release provenance config_fingerprints is invalid') unless recorded_fingerprints.is_a?(Hash)


### PR DESCRIPTION
Closes #7941.

## Why

Shorebird links the patch-signing **public** key into the release binary, and the installed app verifies every patch signature against *that* key. Sign a patch with a rotated private key and the app rejects it — on device, after download, with nothing in the build log to explain it. Nothing in the pipeline noticed: provenance already pinned the Flutter version, the CLI version and revision, the source tree, and every dart-define, but not the one key that decides whether the patch installs at all.

## What

`shorebird_provenance.rb` now records `patch_public_key_sha256` on emit, and `verify` aborts when it does not match the key the patch job is about to sign with:

```
ERROR: patch signing key does not match the key this release was built with
```

Three deliberate choices:

- **Plain SHA-256, not the keyed HMAC** used for `config_fingerprints`. That HMAC exists to fingerprint *secret* dart-define values without recording them. A public key needs the opposite property — anyone should be able to recompute the digest from the PEM and see which key a release was built with. The runbook carries the exact command, and it's verified against the script rather than written from memory (`$( )` around `openssl` is load-bearing; `shasum` on the file returns a different digest because of the trailing newline).
- **Schema stays at version 1.** `record_hmac` is computed over the record minus itself, so records written before this field existed still authenticate. Bumping the schema would have made every existing release fail `unsupported release provenance schema` — turning a hardening change into an outage.
- **Legacy records verify with a note, not an abort.** For a release predating the field there is nothing to check. Failing closed there would strand the releases this is meant to protect.

The env var is read directly rather than from `build/shorebird/patch_public_key.pem`, which matters for ordering: in both patch workflows `fetch_and_verify_shorebird_provenance` runs *before* `write_shorebird_public_key`, so the file does not exist yet at verify time.

Also documents that rotating the patch-signing pair strands every release built with the old one — the same shape as moving the CLI pin — so rotation belongs immediately after a store release, never while a shipped release is the only route to a hot fix.

## Testing

Four new tests in `.github/scripts/tests/test_shorebird_provenance.py` (13 total in the file, 74 across the config suite, all green):

- a rotated key is rejected at verify
- the recorded digest equals the plain SHA-256 of the normalized PEM — computed independently in Python, so the test would catch the script switching to a keyed or differently-normalized digest
- emit rejects a value that is not a public-key PEM
- a record with the field removed and its HMAC recomputed still verifies, and says on stderr that the key cannot be checked

Both halves were mutation-tested: making the comparison unconditionally true fails 1 test; dropping the field from the emitted record fails 4.

Test fixtures are two throwaway P-256 **public** keys generated for this test. They sign nothing; they exist so the digest comparison has two genuinely different PEMs to tell apart.

## Manual test plan

Verified locally that the script's digest and the documented `openssl` recompute agree on the same PEM (`fff69cb7…`). The abort path itself exercises on the next `ios-patch` run — provenance for `1.0.21+851` predates the field, so that release takes the legacy note path, and the first release cut after this merges gets the real binding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)