### PR TITLE
fix(ci): always descend past a variable declaration, and drop safeSubstring

### DIFF
--- a/mobile/lib/utils/string_utils.dart
+++ b/mobile/lib/utils/string_utils.dart
@@ -1,10 +1,10 @@
-// ABOUTME: String utility functions for safe operations and formatting
+// ABOUTME: String utility functions for formatting and sanitization
 // ABOUTME: Provides compact-number formatting and UTF-16 sanitization
 
 import 'package:count_formatter/count_formatter.dart';
 import 'package:text_sanitizer/text_sanitizer.dart' as text_sanitizer;
 
-/// Utility functions for safe string operations
+/// Utility functions for string formatting and sanitization.
 class StringUtils {
   /// Format a number to a compact, locale-aware string.
   ///

--- a/mobile/lib/utils/string_utils.dart
+++ b/mobile/lib/utils/string_utils.dart
@@ -1,22 +1,11 @@
 // ABOUTME: String utility functions for safe operations and formatting
-// ABOUTME: Provides safe substring, compact-number and UTF-16 helpers
+// ABOUTME: Provides compact-number formatting and UTF-16 sanitization
 
 import 'package:count_formatter/count_formatter.dart';
 import 'package:text_sanitizer/text_sanitizer.dart' as text_sanitizer;
 
 /// Utility functions for safe string operations
 class StringUtils {
-  /// Safe substring operation that won't throw RangeError
-  /// Returns substring from [start] to [end], handling bounds automatically
-  static String safeSubstring(String str, int start, [int? end]) {
-    if (str.isEmpty) return '';
-
-    final clampedStart = start.clamp(0, str.length);
-    final clampedEnd = (end ?? str.length).clamp(clampedStart, str.length);
-
-    return str.substring(clampedStart, clampedEnd);
-  }
-
   /// Format a number to a compact, locale-aware string.
   ///
   /// Delegates to [CountFormatter.formatCompact] for consistent,

--- a/mobile/scripts/lib/nostr_id_log_truncation_detector.dart
+++ b/mobile/scripts/lib/nostr_id_log_truncation_detector.dart
@@ -729,11 +729,20 @@ class _ShortenedLocalCollector extends RecursiveAstVisitor<void> {
 
   @override
   void visitVariableDeclaration(VariableDeclaration node) {
-    if (!_isVisible(node)) return;
+    // Every path falls through to super: a visitor that conditionally skips it
+    // stops descending into the initializer, so anything nested there — a
+    // closure with its own declarations — silently stops being collected. That
+    // is invisible from outside, because a detector that looks at less just
+    // reports fewer sites.
+    if (_isVisible(node)) _record(node);
+    super.visitVariableDeclaration(node);
+  }
+
+  void _record(VariableDeclaration node) {
     final initializer = node.initializer;
     // A secret aliased to a differently-named local and then logged —
     // `final backup = nsec;` — otherwise launders past the secret rule, which
-    // only ever sees the local's own name.
+    // only ever sees the local's own name. One hop only; see the header.
     final aliased = _rootIdentifierName(initializer);
     if (aliased != null && isSecretName(aliased)) {
       locals[node.name.lexeme] = _Hit(
@@ -765,7 +774,6 @@ class _ShortenedLocalCollector extends RecursiveAstVisitor<void> {
     } else {
       locals.remove(node.name.lexeme);
     }
-    super.visitVariableDeclaration(node);
   }
 }
 


### PR DESCRIPTION
## Description

Follow-up to #7965, which merged at 02:09:43Z. A re-review landed on it at 02:11:52Z — two minutes later — so five findings arrived against a tree that no longer existed. Three were already satisfied at the merged head; two were not, and are fixed here.

**Verified against `main` before doing anything**, since the same review reported a critical finding that its own earlier commit had already closed:

| Finding | Verdict |
|---|---|
| A — compound secret names (`privateKeyHex`, `senderPrivateKeyHex`, `signingKeyHex`) bypass the guard, marked CRITICAL | **Already fixed** at the merged head by `9c30a93c44`. All three flag today; confirmed by probe. |
| B — the ellipsis rule also matches progress messages | **Not reproducible.** `'Calling $method...'` and `'Loading more for $subscriptionType...'` are both ignored, because neither `method` nor `subscriptionType` is an identifier name — and the header comment already says exactly that. |
| C — the alias comment overstates the limit | **Already accurate.** The header says "a one-hop alias", and `AGENTS.md` says "aliased through one local". (Cited line 104 is `'id',`, a lexicon entry.) |
| D — early returns skip `super` in `visitVariableDeclaration` | **Real — fixed here.** |
| E — `StringUtils.safeSubstring` is dead | **Real — fixed here.** |

### D — always descend

Two early returns (the visibility check, and the alias branch added in #7965) skipped `super.visitVariableDeclaration`. A visitor that conditionally stops descending stops collecting whatever is nested below it, and the symptom is *fewer reported sites* — indistinguishable from a clean tree. The recording logic moves into a helper so every path falls through to `super`.

**I could not construct a case where this changes a verdict, and so did not add a test.** Locals are collected from the nearest enclosing `FunctionBody` of the log call, and the only declarations reachable below a declaration live inside a closure — which is its own `FunctionBody` and gets collected when a log call sits in it. So this is fragility removed, not a bug fixed; a test asserting it would pass equally before and after, which `testing.md` rules out. Detector output is byte-identical across the change, checked on the probe matrix and on the tree.

### E — drop `safeSubstring`

Zero call sites, including tests. I scoped this out during #7965 as unrelated rot, which was defensible when it stood alone — but that same class already lost `formatIdForLogging` and `safeTruncate` in that PR, so leaving the third dead helper is just an inconsistency for the next reader.

**Related Issue:** Relates to #3372

## Out of Scope

- Findings A, B and C — verified already satisfied at the merged head rather than re-fixed. Detail above so the re-review can be closed against evidence.
- Widening alias tracking beyond one hop. `final a = nsec; final b = a; Log.info('$b')` is still not caught, which is consistent with the detector's other stated limits. It is a lint, not a sandbox, and saying so plainly beats implying otherwise.

## Verification

- `flutter analyze lib test integration_test scripts` — clean
- 57 tests pass (46 detector + 11 `string_utils`)
- Guard: zero sites across `lib` / `packages` / `test` / `integration_test`
- Probe matrix unchanged across the D fix: the four suffixed-secret shapes, `nsec` / `rawPrivateKey` / `clientNsec`, and the one-hop alias all still flag; `canExportLocalNsec`, `hasPrivateKey`, `usesSigningKey`, `account.nsec != null` and `consecutive` all still pass
- Branched from `origin/main` at `5080f27b71`

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] 🧹 Code refactor
