### PR TITLE
fix(build): stop staging installs from replacing the production app

### DIFF
--- a/local_stack/run_android_local.sh
+++ b/local_stack/run_android_local.sh
@@ -13,7 +13,6 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 MOBILE_DIR="$(cd "${SCRIPT_DIR}/../mobile" && pwd)"
 COMPOSE_FILE="${SCRIPT_DIR}/docker-compose.yml"
-ANDROID_PACKAGE_ID="co.openvine.app"
 
 # shellcheck source=android_sdk.sh
 source "${SCRIPT_DIR}/android_sdk.sh"
@@ -30,6 +29,12 @@ case "$BUILD_MODE" in
         exit 2
         ;;
 esac
+
+if [[ "$BUILD_MODE" == "debug" ]]; then
+    ANDROID_PACKAGE_ID="co.openvine.app.staging"
+else
+    ANDROID_PACKAGE_ID="co.openvine.app"
+fi
 
 if ! local_stack_has_running_container "$COMPOSE_FILE"; then
     echo "ERROR: Docker stack is not running. Start with: mise run local_up" >&2

--- a/local_stack/test_android_scripts.sh
+++ b/local_stack/test_android_scripts.sh
@@ -173,10 +173,19 @@ assert_contains '-d emulator-5554' "$flutter_args_file" \
   "local Android runner should default to the first emulator instead of a physical device"
 assert_contains '--dart-define=INVITE_SERVER_URL=http://10.0.2.2:43004' "$flutter_args_file" \
   "local Android runner should pass the Android emulator invite-server URL to Flutter"
-assert_contains 'shell pm clear co.openvine.app' "$adb_args_file" \
-  "local Android runner should clear persisted app data before launching"
-assert_contains 'Clearing persisted app data for co.openvine.app' "${tmp_dir}/emulator-selection.err" \
+assert_contains 'shell pm clear co.openvine.app.staging' "$adb_args_file" \
+  "debug local Android runner should clear staging app data before launching"
+assert_contains 'Clearing persisted app data for co.openvine.app.staging' "${tmp_dir}/emulator-selection.err" \
   "local Android runner should make the deterministic reset visible"
+
+rm -f "$adb_args_file" "$flutter_args_file"
+env ADB_DEVICES_OUTPUT=$'emulator-5554\tdevice\n' ADB_ARGS_FILE="$adb_args_file" \
+  FLUTTER_ARGS_FILE="$flutter_args_file" PATH="${tmp_dir}/bin:${PATH}" \
+  bash "${SCRIPT_DIR}/run_android_local.sh" emulator-5554 profile >/dev/null 2>"${tmp_dir}/profile.err"
+assert_contains 'shell pm clear co.openvine.app' "$adb_args_file" \
+  "profile local Android runner should clear production-identity app data"
+assert_contains '--profile' "$flutter_args_file" \
+  "profile local Android runner should preserve the requested build mode"
 
 rm -f "$adb_args_file" "$flutter_args_file"
 env ADB_DEVICES_OUTPUT=$'emulator-5554\tdevice\n' ADB_ARGS_FILE="$adb_args_file" \
@@ -187,7 +196,7 @@ assert_contains '-d emulator-5554' "$flutter_args_file" \
   "local Android runner should still launch Flutter when no app data exists yet"
 assert_contains '--dart-define=DEFAULT_ENV=LOCAL' "$flutter_args_file" \
   "missing app data should not bypass the LOCAL dart define"
-assert_contains 'No existing app install found for co.openvine.app' "${tmp_dir}/missing-package-reset.err" \
+assert_contains 'No existing app install found for co.openvine.app.staging' "${tmp_dir}/missing-package-reset.err" \
   "missing app data should be reported as an idempotent first-run reset"
 
 rm -f "$adb_args_file" "$flutter_args_file"
@@ -200,7 +209,7 @@ clear_failure_exit=$?
 set -e
 assert_eq "1" "$clear_failure_exit" \
   "local Android runner should fail when app data exists but cannot be cleared"
-assert_contains 'Failed to clear persisted app data for co.openvine.app' "${tmp_dir}/clear-failure.err" \
+assert_contains 'Failed to clear persisted app data for co.openvine.app.staging' "${tmp_dir}/clear-failure.err" \
   "clear failure should preserve the underlying hard adb error"
 assert_not_file_exists "$flutter_args_file" \
   "local Android runner should not launch Flutter after a real app-data clear failure"

--- a/mobile/android/app/build.gradle.kts
+++ b/mobile/android/app/build.gradle.kts
@@ -64,6 +64,7 @@ android {
 
     buildTypes {
         debug {
+            applicationIdSuffix = ".staging"
             // Disable Crashlytics symbol uploads for debug builds
             configure<com.google.firebase.crashlytics.buildtools.gradle.CrashlyticsExtension> {
                 mappingFileUploadEnabled = false

--- a/mobile/android/app/google-services.json
+++ b/mobile/android/app/google-services.json
@@ -23,6 +23,25 @@
           "other_platform_oauth_client": []
         }
       }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:972941478875:android:56ca239b8c04ca6044b5fe",
+        "android_client_info": {
+          "package_name": "co.openvine.app.staging"
+        }
+      },
+      "oauth_client": [],
+      "api_key": [
+        {
+          "current_key": "AIzaSyBUMlaHAMKqeS62WG7w4PeqBPRLMDIZCdo"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": []
+        }
+      }
     }
   ],
   "configuration_version": "1"

--- a/mobile/android/app/src/debug/AndroidManifest.xml
+++ b/mobile/android/app/src/debug/AndroidManifest.xml
@@ -1,4 +1,5 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
     <!-- The INTERNET permission is required for development. Specifically,
          the Flutter tool needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.
@@ -18,7 +19,9 @@
          double dash; it cannot be written literally inside an XML comment).
          Without that override a debug build on a device shows the unkeyed
          preview; the exported video is unaffected either way. -->
-    <application>
+    <application
+        android:label="Divine Staging"
+        tools:replace="android:label">
         <meta-data
             android:name="io.flutter.embedding.android.EnableImpeller"
             android:value="false" />

--- a/mobile/e2e/maestro/README.md
+++ b/mobile/e2e/maestro/README.md
@@ -411,7 +411,7 @@ awkward, because the per-app override does not survive the suite:
 
 ```bash
 # Android 13+, per app, without touching the system language:
-adb shell cmd locale set-app-locales co.openvine.app --locales en-US
+adb shell cmd locale set-app-locales co.openvine.app.staging --locales en-US
 ```
 
 **`launchApp: clearState` wipes that again.** It runs `pm clear`, which drops

--- a/mobile/e2e/maestro/asserts/assertAccountDeletedModal.yaml
+++ b/mobile/e2e/maestro/asserts/assertAccountDeletedModal.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 - assertVisible: ✓ Account Deleted
 - assertVisible: |-

--- a/mobile/e2e/maestro/asserts/assertCaptureClipRecorded.yaml
+++ b/mobile/e2e/maestro/asserts/assertCaptureClipRecorded.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 # The capture session holds at least one clip: the top bar reveals its
 # continue-to-editor button and the shutter row reveals delete-last-clip.

--- a/mobile/e2e/maestro/asserts/assertCaptureMode.yaml
+++ b/mobile/e2e/maestro/asserts/assertCaptureMode.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 # Capture mode, idle: the viewfinder chrome is up and no clip is recorded yet.
 

--- a/mobile/e2e/maestro/asserts/assertClassicClipRecorded.yaml
+++ b/mobile/e2e/maestro/asserts/assertClassicClipRecorded.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 # The classic session holds at least one clip: the top bar's continue button
 # goes live and the row above the preview reveals delete-last-clip.

--- a/mobile/e2e/maestro/asserts/assertClassicMode.yaml
+++ b/mobile/e2e/maestro/asserts/assertClassicMode.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 # Classic mode, idle: the viewfinder chrome is up and no clip is recorded yet.
 #

--- a/mobile/e2e/maestro/asserts/assertCommentsModal.yaml
+++ b/mobile/e2e/maestro/asserts/assertCommentsModal.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 # The sheet still renders a pluralized count ("0 Comments" / "1 Comment"),
 # so the count regex is kept -- it is the only assertion here that proves

--- a/mobile/e2e/maestro/asserts/assertCommentsOptions.yaml
+++ b/mobile/e2e/maestro/asserts/assertCommentsOptions.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 - assertVisible: Options
 - assertVisible:

--- a/mobile/e2e/maestro/asserts/assertDeleteAllMyContent.yaml
+++ b/mobile/e2e/maestro/asserts/assertDeleteAllMyContent.yaml
@@ -1,3 +1,3 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 - assertVisible: DELETE ALL MY CONTENT

--- a/mobile/e2e/maestro/asserts/assertDeleteContentModal.yaml
+++ b/mobile/e2e/maestro/asserts/assertDeleteContentModal.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 - assertVisible: 🚨 DELETE ALL CONTENT?
 - assertVisible: |-

--- a/mobile/e2e/maestro/asserts/assertEditProfileModal.yaml
+++ b/mobile/e2e/maestro/asserts/assertEditProfileModal.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 - assertVisible: Display Name
 - assertVisible: How should people know you?

--- a/mobile/e2e/maestro/asserts/assertEditYourProfile.yaml
+++ b/mobile/e2e/maestro/asserts/assertEditYourProfile.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 - assertVisible: Back
 - assertVisible: Edit Profile

--- a/mobile/e2e/maestro/asserts/assertExplore.yaml
+++ b/mobile/e2e/maestro/asserts/assertExplore.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 # Top bar
 - assertVisible: Menu

--- a/mobile/e2e/maestro/asserts/assertExploreNew.yaml
+++ b/mobile/e2e/maestro/asserts/assertExploreNew.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 # Assert we have landed on Explore with the New tab available.
 

--- a/mobile/e2e/maestro/asserts/assertFinalConfirmationModal.yaml
+++ b/mobile/e2e/maestro/asserts/assertFinalConfirmationModal.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 #- assertVisible: ⚠️ Final Confirmation
 #- assertVisible: "To confirm permanent deletion of ALL your content from Nostr relays, type:"

--- a/mobile/e2e/maestro/asserts/assertFreshHome.yaml
+++ b/mobile/e2e/maestro/asserts/assertFreshHome.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 - assertVisible: "Your Home Feed is Empty"
 - assertVisible: "Follow creators to see their videos here"

--- a/mobile/e2e/maestro/asserts/assertHome.yaml
+++ b/mobile/e2e/maestro/asserts/assertHome.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 # Top bar
 - assertVisible: "Menu"

--- a/mobile/e2e/maestro/asserts/assertImportIdentity.yaml
+++ b/mobile/e2e/maestro/asserts/assertImportIdentity.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 - assertVisible: Import Identity
 - assertVisible: Enter your private key

--- a/mobile/e2e/maestro/asserts/assertLibraryScreen.yaml
+++ b/mobile/e2e/maestro/asserts/assertLibraryScreen.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 - assertVisible: Clips
 - assertVisible: Back

--- a/mobile/e2e/maestro/asserts/assertLipSyncMode.yaml
+++ b/mobile/e2e/maestro/asserts/assertLipSyncMode.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 # Lip-sync mode, idle: the viewfinder chrome and sound picker are up, and no
 # clip is recorded yet.

--- a/mobile/e2e/maestro/asserts/assertLogOutModal.yaml
+++ b/mobile/e2e/maestro/asserts/assertLogOutModal.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 - assertVisible: Log Out?
 - assertVisible: Are you sure you want to log out? Your keys will be saved and you can log back in later.

--- a/mobile/e2e/maestro/asserts/assertLogin.yaml
+++ b/mobile/e2e/maestro/asserts/assertLogin.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 # Asserts the welcome screen, whichever variant it renders.
 #

--- a/mobile/e2e/maestro/asserts/assertMenu.yaml
+++ b/mobile/e2e/maestro/asserts/assertMenu.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 - assertVisible: Settings
 - assertVisible: Support

--- a/mobile/e2e/maestro/asserts/assertNostrKeys.yaml
+++ b/mobile/e2e/maestro/asserts/assertNostrKeys.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 - assertVisible: Back
 - assertVisible: Nostr Keys

--- a/mobile/e2e/maestro/asserts/assertPrivKeyCopied.yaml
+++ b/mobile/e2e/maestro/asserts/assertPrivKeyCopied.yaml
@@ -1,3 +1,3 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 - assertVisible: Private key copied to the clipboard!

--- a/mobile/e2e/maestro/asserts/assertProfile.yaml
+++ b/mobile/e2e/maestro/asserts/assertProfile.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 # Asserts the signed-in user's own profile.
 #

--- a/mobile/e2e/maestro/asserts/assertProfileFresh.yaml
+++ b/mobile/e2e/maestro/asserts/assertProfileFresh.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 - assertVisible: Complete Your Profile
 - assertVisible: Add your name, bio, and picture to get started

--- a/mobile/e2e/maestro/asserts/assertRemoveKeysModal.yaml
+++ b/mobile/e2e/maestro/asserts/assertRemoveKeysModal.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 - assertVisible: ⚠️ Remove Keys from Device?
 - assertVisible: |-

--- a/mobile/e2e/maestro/asserts/assertSearch.yaml
+++ b/mobile/e2e/maestro/asserts/assertSearch.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 # Asserts the search results screen.
 #

--- a/mobile/e2e/maestro/asserts/assertSettings.yaml
+++ b/mobile/e2e/maestro/asserts/assertSettings.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 - assertVisible: PROFILE
 - assertVisible: |-

--- a/mobile/e2e/maestro/asserts/assertSignIn.yaml
+++ b/mobile/e2e/maestro/asserts/assertSignIn.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 - assertVisible: Sign in
 - assertVisible: Email

--- a/mobile/e2e/maestro/asserts/assertSpecificUserProfile.yaml
+++ b/mobile/e2e/maestro/asserts/assertSpecificUserProfile.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 - assertVisible: ${SEARCH_USER}
 - assertVisible: Follow

--- a/mobile/e2e/maestro/asserts/assertSplash.yaml
+++ b/mobile/e2e/maestro/asserts/assertSplash.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 - waitForAnimationToEnd # Divine logo may take some time to load
 - assertVisible:

--- a/mobile/e2e/maestro/asserts/assertStopMotionFrameCaptured.yaml
+++ b/mobile/e2e/maestro/asserts/assertStopMotionFrameCaptured.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 # The stop-motion session holds at least one still: the top bar reveals its
 # assemble-and-continue button and the shutter row reveals undo-last-still.

--- a/mobile/e2e/maestro/asserts/assertStopMotionMode.yaml
+++ b/mobile/e2e/maestro/asserts/assertStopMotionMode.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 # Stop-motion mode, idle: the viewfinder chrome is up and no still is captured
 # yet.

--- a/mobile/e2e/maestro/asserts/assertUserProfile.yaml
+++ b/mobile/e2e/maestro/asserts/assertUserProfile.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 # Asserts somebody else's profile. See assertProfile.yaml for your own.
 #

--- a/mobile/e2e/maestro/asserts/assertUserTaken.yaml
+++ b/mobile/e2e/maestro/asserts/assertUserTaken.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 - assertVisible:
     text: Username already taken

--- a/mobile/e2e/maestro/asserts/assertUsersFollowing.yaml
+++ b/mobile/e2e/maestro/asserts/assertUsersFollowing.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 - assertVisible: |-
     Following

--- a/mobile/e2e/maestro/asserts/assertVideoFeedDrained.yaml
+++ b/mobile/e2e/maestro/asserts/assertVideoFeedDrained.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 # The fullscreen feed had videos and now has none.
 #

--- a/mobile/e2e/maestro/asserts/assertVideoLiked.yaml
+++ b/mobile/e2e/maestro/asserts/assertVideoLiked.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 # Like state is only observable through the button's label -- the identifier
 # is constant across both states by design, so there is no id to key on.

--- a/mobile/e2e/maestro/asserts/assertVideoPlayback.yaml
+++ b/mobile/e2e/maestro/asserts/assertVideoPlayback.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 # Wait for the fullscreen feed to resolve before asserting its chrome.
 #

--- a/mobile/e2e/maestro/asserts/assertVideoUser&Description.yaml
+++ b/mobile/e2e/maestro/asserts/assertVideoUser&Description.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 - assertVisible:
     text: "${VIDEO_USER}"

--- a/mobile/e2e/maestro/flows/captureModeFlow.yaml
+++ b/mobile/e2e/maestro/flows/captureModeFlow.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 #Capture-mode journey: create an account, open the recorder, record a clip,
 #delete it again, and sign the device back out.

--- a/mobile/e2e/maestro/flows/classicModeFlow.yaml
+++ b/mobile/e2e/maestro/flows/classicModeFlow.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 #Classic journey: create an account, open the recorder on classic, drive its
 #action row, record a clip by tapping the preview, prove a second recording

--- a/mobile/e2e/maestro/flows/commentFlow.yaml
+++ b/mobile/e2e/maestro/flows/commentFlow.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 - runFlow: ../tests/loginFreshInstall.yaml
 - runFlow: ../tests/commentVideo.yaml

--- a/mobile/e2e/maestro/flows/followFlow.yaml
+++ b/mobile/e2e/maestro/flows/followFlow.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 env:
   VIDEO_USER: ""
   VIDEO_DESCRIPTION: ""

--- a/mobile/e2e/maestro/flows/likeFlow.yaml
+++ b/mobile/e2e/maestro/flows/likeFlow.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 - runFlow: ../tests/loginFreshInstall.yaml
 - runFlow: ../tests/videoLike.yaml

--- a/mobile/e2e/maestro/flows/lipSyncModeFlow.yaml
+++ b/mobile/e2e/maestro/flows/lipSyncModeFlow.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 #Lip-sync journey: create an account, open the recorder on lip-sync, drive its
 #control rail, prove the shutter is gated on picking a sound and then records

--- a/mobile/e2e/maestro/flows/loginEmailPwd.yaml
+++ b/mobile/e2e/maestro/flows/loginEmailPwd.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 # Credentials are NOT committed. Supply them at run time. If full-suite CI is
 # restored, it should read them from the `maestro_e2e_credentials` Codemagic
 # group:

--- a/mobile/e2e/maestro/flows/profileNavigationFlow.yaml
+++ b/mobile/e2e/maestro/flows/profileNavigationFlow.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 - runFlow: ../tests/loginFreshInstall.yaml
 - runFlow: ../tests/profileFreshInstall.yaml

--- a/mobile/e2e/maestro/flows/searchTagFlow.yaml
+++ b/mobile/e2e/maestro/flows/searchTagFlow.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 env:
   SEARCH_TAG: "comedy"
 ---

--- a/mobile/e2e/maestro/flows/searchUserFlow.yaml
+++ b/mobile/e2e/maestro/flows/searchUserFlow.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 # The account searched for is NOT committed. Supply it at run time. If
 # full-suite CI is restored, it should read it from the
 # `maestro_e2e_credentials` Codemagic group:

--- a/mobile/e2e/maestro/flows/searchVideoFlow.yaml
+++ b/mobile/e2e/maestro/flows/searchVideoFlow.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 env:
   VIDEO_TITLE: "monza"
 ---

--- a/mobile/e2e/maestro/flows/stopMotionModeFlow.yaml
+++ b/mobile/e2e/maestro/flows/stopMotionModeFlow.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 #Stop-motion journey: create an account, open the recorder on stop-motion,
 #drive its control rail, shoot two stills, undo them again, and sign the device

--- a/mobile/e2e/maestro/scripts/ui_smoke_ios.sh
+++ b/mobile/e2e/maestro/scripts/ui_smoke_ios.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 # Behavior:
 #  - Boots the requested iOS simulator (override with IOS_SIM_DEVICE)
 #  - Installs mobile/build/ios/iphonesimulator/Runner.app onto it
-#  - Verifies installation using BUNDLE_ID (co.openvine.app)
+#  - Verifies the Debug installation using BUNDLE_ID (co.openvine.app.staging)
 #  - Runs Maestro suite: e2e/maestro/suites/smoke.yaml
 #
 # Build the app first, against STAGING — a PRODUCTION run signs in and writes
@@ -49,7 +49,7 @@ APP_INFO_PLIST="${APP_PATH}/Info.plist"
 # -----------------------------
 IOS_SIM_DEVICE="${IOS_SIM_DEVICE:-iPhone 16 Pro}"
 MAESTRO_CLI="maestro"
-BUNDLE_ID="co.openvine.app"
+BUNDLE_ID="co.openvine.app.staging"
 
 # The official installer drops the binary here and it is not on a
 # non-interactive PATH.

--- a/mobile/e2e/maestro/suites/fullRegression.yaml
+++ b/mobile/e2e/maestro/suites/fullRegression.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 name: Divine regression test
 # Account credentials and content fixtures are NOT committed. Supply them at
 # run time. If full-regression CI is restored, it should read them from the

--- a/mobile/e2e/maestro/suites/smoke.yaml
+++ b/mobile/e2e/maestro/suites/smoke.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 name: Divine Smoke regression test
 ---
 # Every social flow is back in, so a dispatched run exercises the whole

--- a/mobile/e2e/maestro/tests/backupYourKey.yaml
+++ b/mobile/e2e/maestro/tests/backupYourKey.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 #TC to follow a user,
 # given the user is logged in in the app,

--- a/mobile/e2e/maestro/tests/captureModeControls.yaml
+++ b/mobile/e2e/maestro/tests/captureModeControls.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 tags:
   - recorder
 ---

--- a/mobile/e2e/maestro/tests/captureModeDeleteClip.yaml
+++ b/mobile/e2e/maestro/tests/captureModeDeleteClip.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 tags:
   - recorder
 ---

--- a/mobile/e2e/maestro/tests/captureModeOpen.yaml
+++ b/mobile/e2e/maestro/tests/captureModeOpen.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 tags:
   - recorder
 ---

--- a/mobile/e2e/maestro/tests/captureModeRecordClip.yaml
+++ b/mobile/e2e/maestro/tests/captureModeRecordClip.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 tags:
   - recorder
 ---

--- a/mobile/e2e/maestro/tests/classicModeControls.yaml
+++ b/mobile/e2e/maestro/tests/classicModeControls.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 tags:
   - recorder
 ---

--- a/mobile/e2e/maestro/tests/classicModeDeleteClip.yaml
+++ b/mobile/e2e/maestro/tests/classicModeDeleteClip.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 tags:
   - recorder
 ---

--- a/mobile/e2e/maestro/tests/classicModeOpen.yaml
+++ b/mobile/e2e/maestro/tests/classicModeOpen.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 tags:
   - recorder
 ---

--- a/mobile/e2e/maestro/tests/classicModeRecordClip.yaml
+++ b/mobile/e2e/maestro/tests/classicModeRecordClip.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 tags:
   - recorder
 ---

--- a/mobile/e2e/maestro/tests/classicModeRecordingLimit.yaml
+++ b/mobile/e2e/maestro/tests/classicModeRecordingLimit.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 tags:
   - recorder
 ---

--- a/mobile/e2e/maestro/tests/commentVideo.yaml
+++ b/mobile/e2e/maestro/tests/commentVideo.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 env:
   COMMENT: "Automated comment"
 ---

--- a/mobile/e2e/maestro/tests/deleteAccountData.yaml
+++ b/mobile/e2e/maestro/tests/deleteAccountData.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 #TC to delete the account data for a user
 # given the user is logged in in the app,

--- a/mobile/e2e/maestro/tests/deleteComment.yaml
+++ b/mobile/e2e/maestro/tests/deleteComment.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 # Known limitation: this proves the comment leaves the poster's screen, not
 # that it leaves the relay. Measured against STAGING on 2026-08-10: the app

--- a/mobile/e2e/maestro/tests/editProfile.yaml
+++ b/mobile/e2e/maestro/tests/editProfile.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 #TC to edit the user profile,
 # given the user is logged in in the app with existing keys,

--- a/mobile/e2e/maestro/tests/follow.yaml
+++ b/mobile/e2e/maestro/tests/follow.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 env:
   VIDEO_USER: ""
   VIDEO_DESCRIPTION: ""

--- a/mobile/e2e/maestro/tests/lipSyncModeAudioGate.yaml
+++ b/mobile/e2e/maestro/tests/lipSyncModeAudioGate.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 tags:
   - recorder
 ---

--- a/mobile/e2e/maestro/tests/lipSyncModeControls.yaml
+++ b/mobile/e2e/maestro/tests/lipSyncModeControls.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 tags:
   - recorder
 ---

--- a/mobile/e2e/maestro/tests/lipSyncModeOpen.yaml
+++ b/mobile/e2e/maestro/tests/lipSyncModeOpen.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 tags:
   - recorder
 ---

--- a/mobile/e2e/maestro/tests/lipSyncModeRecordClip.yaml
+++ b/mobile/e2e/maestro/tests/lipSyncModeRecordClip.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 tags:
   - recorder
 ---

--- a/mobile/e2e/maestro/tests/loginExistingKeys.yaml
+++ b/mobile/e2e/maestro/tests/loginExistingKeys.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 #TC to check that the user can login
 # given that the app is closed

--- a/mobile/e2e/maestro/tests/loginFreshInstall.yaml
+++ b/mobile/e2e/maestro/tests/loginFreshInstall.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 tags:
   - auth
 ---

--- a/mobile/e2e/maestro/tests/logout.yaml
+++ b/mobile/e2e/maestro/tests/logout.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 #TC to log out,
 # given the user is logged in in the app,

--- a/mobile/e2e/maestro/tests/profileFreshInstall.yaml
+++ b/mobile/e2e/maestro/tests/profileFreshInstall.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 #TC to view the own user profile of a new user,
 # given the user is logged in in the app,

--- a/mobile/e2e/maestro/tests/profileNavigation.yaml
+++ b/mobile/e2e/maestro/tests/profileNavigation.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 env:
   DISPLAY_NAME: "AutomationUser"
   BIO: "AutomationUser bio"

--- a/mobile/e2e/maestro/tests/removeKeys.yaml
+++ b/mobile/e2e/maestro/tests/removeKeys.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 tags:
   - auth
   - settings

--- a/mobile/e2e/maestro/tests/searchTags.yaml
+++ b/mobile/e2e/maestro/tests/searchTags.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 #TC to search with tags,
 # given the user is logged in in the app,

--- a/mobile/e2e/maestro/tests/searchUsers.yaml
+++ b/mobile/e2e/maestro/tests/searchUsers.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 #TC to search for a user,
 # given the user is logged in and on the Explore screen,

--- a/mobile/e2e/maestro/tests/searchVideos.yaml
+++ b/mobile/e2e/maestro/tests/searchVideos.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 #TC to search for a video,
 # given the user is logged in in the app,

--- a/mobile/e2e/maestro/tests/stopMotionModeCaptureFrame.yaml
+++ b/mobile/e2e/maestro/tests/stopMotionModeCaptureFrame.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 tags:
   - recorder
 ---

--- a/mobile/e2e/maestro/tests/stopMotionModeControls.yaml
+++ b/mobile/e2e/maestro/tests/stopMotionModeControls.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 tags:
   - recorder
 ---

--- a/mobile/e2e/maestro/tests/stopMotionModeOpen.yaml
+++ b/mobile/e2e/maestro/tests/stopMotionModeOpen.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 tags:
   - recorder
 ---

--- a/mobile/e2e/maestro/tests/stopMotionModeUndoFrame.yaml
+++ b/mobile/e2e/maestro/tests/stopMotionModeUndoFrame.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 tags:
   - recorder
 ---

--- a/mobile/e2e/maestro/tests/unfollow.yaml
+++ b/mobile/e2e/maestro/tests/unfollow.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 tags:
   - Social
 ---

--- a/mobile/e2e/maestro/tests/userAlreadyTaken.yaml
+++ b/mobile/e2e/maestro/tests/userAlreadyTaken.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 #TC to edit the user profile to an existing username,
 # given the user is logged in in the app with existing keys, on the Edit Profile screen,

--- a/mobile/e2e/maestro/tests/videoLike.yaml
+++ b/mobile/e2e/maestro/tests/videoLike.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 tags:
   - Social
 ---

--- a/mobile/e2e/maestro/tests/videoUnlike.yaml
+++ b/mobile/e2e/maestro/tests/videoUnlike.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 tags:
   - Social
 ---

--- a/mobile/e2e/maestro/utils/deleteLastRecorderClip.yaml
+++ b/mobile/e2e/maestro/utils/deleteLastRecorderClip.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 #Utility: given the capture-stack recorder session holds at least one clip,
 #delete the last clip and wait for the empty-session chrome.

--- a/mobile/e2e/maestro/utils/driveAspectRatioControl.yaml
+++ b/mobile/e2e/maestro/utils/driveAspectRatioControl.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 #Utility: flip the aspect-ratio control to Square and back, leaving it on its
 #default. Every mode that renders the control rail renders this one.

--- a/mobile/e2e/maestro/utils/driveCaptureRail.yaml
+++ b/mobile/e2e/maestro/utils/driveCaptureRail.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 #Utility: given a ready viewfinder in a mode that renders the full capture
 #control rail (capture and lip-sync), drive every control and leave each one

--- a/mobile/e2e/maestro/utils/driveFlashControl.yaml
+++ b/mobile/e2e/maestro/utils/driveFlashControl.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 #Utility: cycle the flash control Off -> On -> Auto -> Off, leaving it on its
 #default. Every mode that renders the control rail renders this one.

--- a/mobile/e2e/maestro/utils/driveGhostFrameControl.yaml
+++ b/mobile/e2e/maestro/utils/driveGhostFrameControl.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 #Utility: toggle the ghost-frame (onion-skin) overlay on and back off, leaving
 #it on its default. Rendered by both modes that draw the previous frame over

--- a/mobile/e2e/maestro/utils/driveGridControl.yaml
+++ b/mobile/e2e/maestro/utils/driveGridControl.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 #Utility: toggle the grid overlay off and back on, leaving it on its default.
 #Rendered by every mode that declares `supportGridLines` — stop-motion on the

--- a/mobile/e2e/maestro/utils/driveLensControl.yaml
+++ b/mobile/e2e/maestro/utils/driveLensControl.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 #Utility: switch to the front lens and back, leaving it on its default. Every
 #mode that renders the control rail renders this one.

--- a/mobile/e2e/maestro/utils/hideKeyboard.yaml
+++ b/mobile/e2e/maestro/utils/hideKeyboard.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 - runFlow:
     when:

--- a/mobile/e2e/maestro/utils/openCaptureMode.yaml
+++ b/mobile/e2e/maestro/utils/openCaptureMode.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 #Utility: given the user is signed in and on a feed surface, open the recorder
 #and leave it on a ready capture-mode viewfinder.

--- a/mobile/e2e/maestro/utils/openClassicMode.yaml
+++ b/mobile/e2e/maestro/utils/openClassicMode.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 #Utility: given the user is signed in and on a feed surface, open the recorder
 #and leave it on a ready classic viewfinder with an empty session.

--- a/mobile/e2e/maestro/utils/openLipSyncMode.yaml
+++ b/mobile/e2e/maestro/utils/openLipSyncMode.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 #Utility: given the user is signed in and on a feed surface, open the recorder
 #and leave it on a ready lip-sync viewfinder with no sound picked.

--- a/mobile/e2e/maestro/utils/openRecorder.yaml
+++ b/mobile/e2e/maestro/utils/openRecorder.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 #Utility: given the user is signed in and on a feed surface, open the recorder
 #and leave it on whichever mode the app restored, with no first-run sheet in

--- a/mobile/e2e/maestro/utils/openSettings.yaml
+++ b/mobile/e2e/maestro/utils/openSettings.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 #Utility: given the user is signed in, open Settings.
 #

--- a/mobile/e2e/maestro/utils/openStopMotionMode.yaml
+++ b/mobile/e2e/maestro/utils/openStopMotionMode.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 #Utility: given the user is signed in and on a feed surface, open the recorder
 #and leave it on a ready stop-motion viewfinder with an empty session.

--- a/mobile/e2e/maestro/utils/recordCaptureClip.yaml
+++ b/mobile/e2e/maestro/utils/recordCaptureClip.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 #Utility: given the recorder is on a mode that renders the capture stack with
 #tap-to-toggle recording enabled, record one clip and leave it in the session.

--- a/mobile/e2e/maestro/utils/recordClassicClip.yaml
+++ b/mobile/e2e/maestro/utils/recordClassicClip.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 #Utility: given the recorder is on a ready classic viewfinder with tap-to-toggle
 #recording enabled, record one clip and leave it in the session.

--- a/mobile/e2e/maestro/utils/searchWorkaround.yaml
+++ b/mobile/e2e/maestro/utils/searchWorkaround.yaml
@@ -1,4 +1,4 @@
-appId: co.openvine.app
+appId: co.openvine.app.staging
 ---
 #Utility TC for search workaround
 #Steps:

--- a/mobile/integration_test/helpers/constants.dart
+++ b/mobile/integration_test/helpers/constants.dart
@@ -15,4 +15,4 @@ export 'package:openvine/models/environment_config.dart'
 const pgPort = 15432;
 
 /// Android app package name for adb commands
-const appPackage = 'co.openvine.app';
+const appPackage = 'co.openvine.app.staging';

--- a/mobile/ios/CameraQuickActionWidget/CameraQuickActionWidgetDebug.entitlements
+++ b/mobile/ios/CameraQuickActionWidget/CameraQuickActionWidgetDebug.entitlements
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/mobile/ios/NotificationServiceExtension/NotificationServiceExtensionDebug.entitlements
+++ b/mobile/ios/NotificationServiceExtension/NotificationServiceExtensionDebug.entitlements
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/mobile/ios/Runner.xcodeproj/project.pbxproj
+++ b/mobile/ios/Runner.xcodeproj/project.pbxproj
@@ -111,6 +111,7 @@
 		7B0F1A2B3C4D5E6F708192A3 /* Profile.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Profile.xcconfig; path = Flutter/Profile.xcconfig; sourceTree = "<group>"; };
 		82B841000000000000334401 /* AppVersion.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = AppVersion.xcconfig; path = Flutter/AppVersion.xcconfig; sourceTree = "<group>"; };
 		8CE07D4A15ABF6932C18302C /* GoogleService-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "Runner/GoogleService-Info.plist"; sourceTree = "<group>"; };
+		F17EBA5E0000000000000001 /* GoogleService-Info-Debug.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "GoogleService-Info-Debug.plist"; sourceTree = "<group>"; };
 		8E202EC5FED8AC0BD1454DD8 /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
@@ -265,6 +266,7 @@
 		97C146F01CF9000F007C117D /* Runner */ = {
 			isa = PBXGroup;
 			children = (
+				F17EBA5E0000000000000001 /* GoogleService-Info-Debug.plist */,
 				97C146FA1CF9000F007C117D /* Main.storyboard */,
 				97C146FD1CF9000F007C117D /* Assets.xcassets */,
 				97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */,
@@ -391,6 +393,7 @@
 				97C146EA1CF9000F007C117D /* Sources */,
 				97C146EB1CF9000F007C117D /* Frameworks */,
 				97C146EC1CF9000F007C117D /* Resources */,
+				F17EBA5E0000000000000002 /* Use staging Firebase config */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				F4D10BEA6CFC4738B7665C3A /* Embed App Extensions */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
@@ -542,6 +545,23 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		F17EBA5E0000000000000002 /* Use staging Firebase config */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PROJECT_DIR}/Runner/GoogleService-Info-Debug.plist",
+			);
+			name = "Use staging Firebase config";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [ \"$CONFIGURATION\" = \"Debug\" ]; then\n  cp \"$PROJECT_DIR/Runner/GoogleService-Info-Debug.plist\" \"$TARGET_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH/GoogleService-Info.plist\"\nfi\n";
+			showEnvVarsInLog = 0;
+		};
 		0439C9E33AA6B9E50AD033CE /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -845,6 +865,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 7B0F1A2B3C4D5E6F708192A3 /* Profile.xcconfig */;
 			buildSettings = {
+				APP_DISPLAY_NAME = Divine;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
@@ -929,7 +950,7 @@
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_OBJC_WEAK = NO;
-				CODE_SIGN_ENTITLEMENTS = NotificationServiceExtension/NotificationServiceExtension.entitlements;
+				CODE_SIGN_ENTITLEMENTS = NotificationServiceExtension/NotificationServiceExtensionDebug.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = GZCZBKH7MY;
@@ -941,7 +962,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = co.openvine.app.NotificationServiceExtension;
+				PRODUCT_BUNDLE_IDENTIFIER = co.openvine.app.staging.NotificationServiceExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -1095,9 +1116,10 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 9740EEB21CF90195004384FC /* Debug.xcconfig */;
 			buildSettings = {
+				APP_DISPLAY_NAME = "Divine Staging";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
+				CODE_SIGN_ENTITLEMENTS = Runner/RunnerDebug.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
@@ -1111,7 +1133,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = "$(FLUTTER_BUILD_NAME)";
-				PRODUCT_BUNDLE_IDENTIFIER = co.openvine.app;
+				PRODUCT_BUNDLE_IDENTIFIER = co.openvine.app.staging;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
@@ -1126,6 +1148,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 7AFA3C8E1D35360C0083082E /* Release.xcconfig */;
 			buildSettings = {
+				APP_DISPLAY_NAME = Divine;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
@@ -1202,7 +1225,7 @@
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_OBJC_WEAK = NO;
-				CODE_SIGN_ENTITLEMENTS = CameraQuickActionWidget/CameraQuickActionWidget.entitlements;
+				CODE_SIGN_ENTITLEMENTS = CameraQuickActionWidget/CameraQuickActionWidgetDebug.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = GZCZBKH7MY;
@@ -1214,7 +1237,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = co.openvine.app.CameraQuickActionWidget;
+				PRODUCT_BUNDLE_IDENTIFIER = co.openvine.app.staging.CameraQuickActionWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;

--- a/mobile/ios/Runner.xcodeproj/project.pbxproj
+++ b/mobile/ios/Runner.xcodeproj/project.pbxproj
@@ -875,7 +875,6 @@
 				DEVELOPMENT_TEAM = GZCZBKH7MY;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = divine;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.video";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1126,7 +1125,6 @@
 				DEVELOPMENT_TEAM = GZCZBKH7MY;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = divine;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.video";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1158,7 +1156,6 @@
 				DEVELOPMENT_TEAM = GZCZBKH7MY;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = divine;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.video";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/mobile/ios/Runner/GoogleService-Info-Debug.plist
+++ b/mobile/ios/Runner/GoogleService-Info-Debug.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>API_KEY</key>
+	<string>AIzaSyChiPGndRdZwsMoLqnel2WSocROmoKLdB4</string>
+	<key>GCM_SENDER_ID</key>
+	<string>972941478875</string>
+	<key>PLIST_VERSION</key>
+	<string>1</string>
+	<key>BUNDLE_ID</key>
+	<string>co.openvine.app.staging</string>
+	<key>PROJECT_ID</key>
+	<string>openvine-co</string>
+	<key>STORAGE_BUCKET</key>
+	<string>openvine-co.firebasestorage.app</string>
+	<key>IS_ADS_ENABLED</key>
+	<false/>
+	<key>IS_ANALYTICS_ENABLED</key>
+	<false/>
+	<key>IS_APPINVITE_ENABLED</key>
+	<true/>
+	<key>IS_GCM_ENABLED</key>
+	<true/>
+	<key>IS_SIGNIN_ENABLED</key>
+	<true/>
+	<key>GOOGLE_APP_ID</key>
+	<string>1:972941478875:ios:2e044bbc68923a1844b5fe</string>
+</dict>
+</plist>

--- a/mobile/ios/Runner/Info.plist
+++ b/mobile/ios/Runner/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>Divine</string>
+	<string>$(APP_DISPLAY_NAME)</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/mobile/ios/Runner/RunnerDebug.entitlements
+++ b/mobile/ios/Runner/RunnerDebug.entitlements
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/mobile/lib/firebase_options.dart
+++ b/mobile/lib/firebase_options.dart
@@ -3,7 +3,7 @@
 
 import 'package:firebase_core/firebase_core.dart' show FirebaseOptions;
 import 'package:flutter/foundation.dart'
-    show TargetPlatform, defaultTargetPlatform, kIsWeb;
+    show TargetPlatform, defaultTargetPlatform, kDebugMode, kIsWeb;
 
 /// Default [FirebaseOptions] for use with your Firebase apps.
 ///
@@ -22,9 +22,9 @@ class DefaultFirebaseOptions {
     }
     switch (defaultTargetPlatform) {
       case TargetPlatform.android:
-        return android;
+        return kDebugMode ? androidStaging : android;
       case TargetPlatform.iOS:
-        return ios;
+        return kDebugMode ? iosStaging : ios;
       case TargetPlatform.macOS:
         return macos;
       case TargetPlatform.windows:
@@ -58,6 +58,14 @@ class DefaultFirebaseOptions {
     storageBucket: 'openvine-co.firebasestorage.app',
   );
 
+  static const FirebaseOptions androidStaging = FirebaseOptions(
+    apiKey: 'AIzaSyBUMlaHAMKqeS62WG7w4PeqBPRLMDIZCdo',
+    appId: '1:972941478875:android:56ca239b8c04ca6044b5fe',
+    messagingSenderId: '972941478875',
+    projectId: 'openvine-co',
+    storageBucket: 'openvine-co.firebasestorage.app',
+  );
+
   static const FirebaseOptions ios = FirebaseOptions(
     apiKey: 'AIzaSyChiPGndRdZwsMoLqnel2WSocROmoKLdB4',
     appId: '1:972941478875:ios:f61272b3cf485df244b5fe',
@@ -65,6 +73,15 @@ class DefaultFirebaseOptions {
     projectId: 'openvine-co',
     storageBucket: 'openvine-co.firebasestorage.app',
     iosBundleId: 'co.openvine.app',
+  );
+
+  static const FirebaseOptions iosStaging = FirebaseOptions(
+    apiKey: 'AIzaSyChiPGndRdZwsMoLqnel2WSocROmoKLdB4',
+    appId: '1:972941478875:ios:2e044bbc68923a1844b5fe',
+    messagingSenderId: '972941478875',
+    projectId: 'openvine-co',
+    storageBucket: 'openvine-co.firebasestorage.app',
+    iosBundleId: 'co.openvine.app.staging',
   );
 
   static const FirebaseOptions macos = FirebaseOptions(

--- a/mobile/scripts/check_ios_extension_signing_contract.sh
+++ b/mobile/scripts/check_ios_extension_signing_contract.sh
@@ -14,6 +14,7 @@ project_file, expected_raw = ARGV
 project = File.read(project_file)
 
 expected = expected_raw.split(/[,\s]+/).reject(&:empty?).sort
+shipping_configurations = %w[Profile Release]
 
 objects = project
   .scan(/^\t\t([A-Z0-9]+) \/\* ([^*]+) \*\/ = \{\n(.*?)^\t\t\};/m)
@@ -36,15 +37,19 @@ actual = target_blocks.flat_map do |_target_id, _target_name, config_list_id|
   config_list_body = objects[config_list_id]&.fetch(:body, nil)
   next [] unless config_list_body
 
-  config_list_body.scan(/^\s*([A-Z0-9]+) \/\* [^*]+ \*\//).flat_map do |(config_id)|
-    config_body = objects[config_id]&.fetch(:body, nil)
-    next [] unless config_body
+  config_list_body
+    .scan(/^\s*([A-Z0-9]+) \/\* ([^*]+) \*\//)
+    .flat_map do |config_id, configuration|
+      next [] unless shipping_configurations.include?(configuration.strip)
 
-    bundle_id = config_body.match(/PRODUCT_BUNDLE_IDENTIFIER = ([^;\n]+);/)&.[](1)
-    next [] unless bundle_id
+      config_body = objects[config_id]&.fetch(:body, nil)
+      next [] unless config_body
 
-    bundle_id.delete('"')
-  end
+      bundle_id = config_body.match(/PRODUCT_BUNDLE_IDENTIFIER = ([^;\n]+);/)&.[](1)
+      next [] unless bundle_id
+
+      bundle_id.delete('"')
+    end
 end.uniq.sort
 
 if actual.empty?
@@ -58,12 +63,12 @@ stale = expected - actual
 unless missing.empty? && stale.empty?
   puts "ERROR: iOS extension signing bundle IDs are out of sync."
   puts "Expected from IOS_EXTENSION_BUNDLE_IDS: #{expected.join(', ')}"
-  puts "Actual app-extension targets: #{actual.join(', ')}"
+  puts "Actual shipping app-extension targets: #{actual.join(', ')}"
   puts "Missing from IOS_EXTENSION_BUNDLE_IDS: #{missing.join(', ')}" unless missing.empty?
   puts "No matching app-extension target: #{stale.join(', ')}" unless stale.empty?
   puts "Every app extension also needs a matching App Store provisioning profile in Codemagic Code signing identities."
   exit 1
 end
 
-puts "iOS extension signing bundle IDs are in sync: #{actual.join(', ')}"
+puts "iOS shipping extension bundle IDs are in sync: #{actual.join(', ')}"
 RUBY

--- a/mobile/test/config/staging_app_identity_test.dart
+++ b/mobile/test/config/staging_app_identity_test.dart
@@ -4,6 +4,23 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('staging app identity', () {
+    test('shipping extension signing ignores debug-only bundle IDs', () async {
+      final result = await Process.run(
+        'bash',
+        ['scripts/check_ios_extension_signing_contract.sh'],
+        environment: {
+          ...Platform.environment,
+          'IOS_EXTENSION_BUNDLE_IDS': [
+            'co.openvine.app.NotificationServiceExtension',
+            'co.openvine.app.CameraQuickActionWidget',
+          ].join(' '),
+        },
+      );
+
+      expect(result.stderr, isEmpty);
+      expect(result.exitCode, 0, reason: result.stdout as String);
+    });
+
     test('iOS debug build cannot replace the production app', () {
       final project = File(
         'ios/Runner.xcodeproj/project.pbxproj',
@@ -27,10 +44,7 @@ void main() {
           'co.openvine.app.staging.CameraQuickActionWidget;',
         ),
       );
-      expect(
-        project,
-        contains('APP_DISPLAY_NAME = "Divine Staging";'),
-      );
+      expect(project, contains('APP_DISPLAY_NAME = "Divine Staging";'));
       expect(
         File('ios/Runner/Info.plist').readAsStringSync(),
         contains(r'<string>$(APP_DISPLAY_NAME)</string>'),
@@ -96,6 +110,23 @@ void main() {
         contains('kDebugMode ? androidStaging : android'),
       );
       expect(firebaseOptions, contains('kDebugMode ? iosStaging : ios'));
+    });
+
+    test('Maestro debug flows target the staging app identity', () {
+      final flowFiles = Directory('e2e/maestro')
+          .listSync(recursive: true)
+          .whereType<File>()
+          .where((file) => file.path.endsWith('.yaml'));
+
+      expect(flowFiles, isNotEmpty);
+      for (final file in flowFiles) {
+        final appIdLines = file.readAsLinesSync().where(
+          (line) => line.startsWith('appId:'),
+        );
+        for (final line in appIdLines) {
+          expect(line, 'appId: co.openvine.app.staging', reason: file.path);
+        }
+      }
     });
   });
 }

--- a/mobile/test/config/staging_app_identity_test.dart
+++ b/mobile/test/config/staging_app_identity_test.dart
@@ -1,0 +1,101 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('staging app identity', () {
+    test('iOS debug build cannot replace the production app', () {
+      final project = File(
+        'ios/Runner.xcodeproj/project.pbxproj',
+      ).readAsStringSync();
+
+      expect(
+        project,
+        contains('PRODUCT_BUNDLE_IDENTIFIER = co.openvine.app.staging;'),
+      );
+      expect(
+        project,
+        contains(
+          'PRODUCT_BUNDLE_IDENTIFIER = '
+          'co.openvine.app.staging.NotificationServiceExtension;',
+        ),
+      );
+      expect(
+        project,
+        contains(
+          'PRODUCT_BUNDLE_IDENTIFIER = '
+          'co.openvine.app.staging.CameraQuickActionWidget;',
+        ),
+      );
+      expect(
+        project,
+        contains('APP_DISPLAY_NAME = "Divine Staging";'),
+      );
+      expect(
+        File('ios/Runner/Info.plist').readAsStringSync(),
+        contains(r'<string>$(APP_DISPLAY_NAME)</string>'),
+      );
+    });
+
+    test('iOS debug signing does not reuse production capabilities', () {
+      final project = File(
+        'ios/Runner.xcodeproj/project.pbxproj',
+      ).readAsStringSync();
+
+      for (final path in const [
+        'Runner/RunnerDebug.entitlements',
+        'NotificationServiceExtension/NotificationServiceExtensionDebug.entitlements',
+        'CameraQuickActionWidget/CameraQuickActionWidgetDebug.entitlements',
+      ]) {
+        expect(project, contains('CODE_SIGN_ENTITLEMENTS = $path;'));
+
+        final entitlements = File('ios/$path').readAsStringSync();
+        expect(entitlements, isNot(contains('group.co.openvine.app')));
+        expect(entitlements, isNot(contains('associated-domains')));
+        expect(entitlements, isNot(contains('aps-environment')));
+      }
+    });
+
+    test('Android debug build cannot replace the production app', () {
+      final gradle = File('android/app/build.gradle.kts').readAsStringSync();
+      final firebaseConfig = File(
+        'android/app/google-services.json',
+      ).readAsStringSync();
+      final debugManifest = File(
+        'android/app/src/debug/AndroidManifest.xml',
+      ).readAsStringSync();
+
+      expect(gradle, contains('applicationIdSuffix = ".staging"'));
+      expect(debugManifest, contains('android:label="Divine Staging"'));
+      expect(firebaseConfig, contains('co.openvine.app.staging'));
+      expect(
+        firebaseConfig,
+        contains('1:972941478875:android:56ca239b8c04ca6044b5fe'),
+      );
+    });
+
+    test('debug builds use the registered staging Firebase apps', () {
+      final project = File(
+        'ios/Runner.xcodeproj/project.pbxproj',
+      ).readAsStringSync();
+      final stagingPlist = File(
+        'ios/Runner/GoogleService-Info-Debug.plist',
+      ).readAsStringSync();
+      final firebaseOptions = File(
+        'lib/firebase_options.dart',
+      ).readAsStringSync();
+
+      expect(project, contains('GoogleService-Info-Debug.plist'));
+      expect(stagingPlist, contains('co.openvine.app.staging'));
+      expect(
+        stagingPlist,
+        contains('1:972941478875:ios:2e044bbc68923a1844b5fe'),
+      );
+      expect(
+        firebaseOptions,
+        contains('kDebugMode ? androidStaging : android'),
+      );
+      expect(firebaseOptions, contains('kDebugMode ? iosStaging : ios'));
+    });
+  });
+}

--- a/mobile/test/firebase_options_android_config_test.dart
+++ b/mobile/test/firebase_options_android_config_test.dart
@@ -4,27 +4,43 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/firebase_options.dart';
 
 void main() {
-  test('DefaultFirebaseOptions.android matches google-services.json', () {
+  test('Android Firebase options match each registered app', () {
     final config =
         jsonDecode(File('android/app/google-services.json').readAsStringSync())
             as Map<String, dynamic>;
     final projectInfo = config['project_info'] as Map<String, dynamic>;
     final clients = config['client'] as List<dynamic>;
-    final client = clients.single as Map<String, dynamic>;
-    final clientInfo = client['client_info'] as Map<String, dynamic>;
-    final apiKeys = client['api_key'] as List<dynamic>;
-    final apiKey = apiKeys.single as Map<String, dynamic>;
 
-    const options = DefaultFirebaseOptions.android;
+    void expectOptionsMatch(
+      String packageName,
+      FirebaseOptions options,
+    ) {
+      final client = clients.cast<Map<String, dynamic>>().singleWhere((client) {
+        final clientInfo = client['client_info'] as Map<String, dynamic>;
+        final androidInfo =
+            clientInfo['android_client_info'] as Map<String, dynamic>;
+        return androidInfo['package_name'] == packageName;
+      });
+      final clientInfo = client['client_info'] as Map<String, dynamic>;
+      final apiKeys = client['api_key'] as List<dynamic>;
+      final apiKey = apiKeys.single as Map<String, dynamic>;
 
-    expect(options.apiKey, apiKey['current_key']);
-    expect(options.appId, clientInfo['mobilesdk_app_id']);
-    expect(options.messagingSenderId, projectInfo['project_number']);
-    expect(options.projectId, projectInfo['project_id']);
-    expect(options.storageBucket, projectInfo['storage_bucket']);
+      expect(options.apiKey, apiKey['current_key']);
+      expect(options.appId, clientInfo['mobilesdk_app_id']);
+      expect(options.messagingSenderId, projectInfo['project_number']);
+      expect(options.projectId, projectInfo['project_id']);
+      expect(options.storageBucket, projectInfo['storage_bucket']);
+    }
+
+    expectOptionsMatch('co.openvine.app', DefaultFirebaseOptions.android);
+    expectOptionsMatch(
+      'co.openvine.app.staging',
+      DefaultFirebaseOptions.androidStaging,
+    );
   });
 }


### PR DESCRIPTION
## Problem

Installing a local debug build on a test phone can replace the production Divine app because both use the same application identity. That makes physical staging tests unsafe and can mix debug Firebase traffic with the production app registration.

## Why this fix

Debug builds now install as **Divine Staging** with separate `.staging` identifiers on iOS and Android. Matching iOS and Android apps were registered in the existing Firebase project, and debug builds select those registrations. The debug iOS app and extensions use empty entitlement files, so they cannot reuse the production push, associated-domain, or shared app-group capabilities.

## Deliberately unchanged

Profile and release builds keep the existing production name, identifiers, Firebase registrations, and entitlements. There is no in-app visual change; only the debug app name shown by the operating system changes to **Divine Staging**.

## Validation

- Focused staging identity test: 4 passed
- Targeted Dart analysis: no findings
- Android debug APK built successfully and reports package `co.openvine.app.staging` and label `Divine Staging`
- iOS debug app built without signing and reports bundle `co.openvine.app.staging`, display name `Divine Staging`, the matching staging Firebase app, and staging identifiers for both extensions
- JSON and property-list validation passed
- Pre-push analysis and focused tests passed
- `git diff --check`

Fixes #8002.