### PR TITLE
feat(share): let people send Divine to friends from Settings

### DIFF
--- a/mobile/integration_test/auth/invite_availability_e2e_test.dart
+++ b/mobile/integration_test/auth/invite_availability_e2e_test.dart
@@ -68,7 +68,7 @@ void main() {
       router.go(SettingsScreen.path);
       await pumpUntilSettled(tester, maxSeconds: 10);
 
-      expect(find.text(_en.settingsInvites), findsNothing);
+      expect(find.text(_en.settingsShareDivine), findsOneWidget);
       expect(
         inviteState(tester).status,
         InviteStatusLoadingStatus.initial,
@@ -140,11 +140,11 @@ void main() {
       router.go(SettingsScreen.path);
       await pumpUntilSettled(tester, maxSeconds: 10);
 
-      expect(find.text(_en.settingsInvites), findsOneWidget);
+      expect(find.text(_en.settingsShareDivine), findsOneWidget);
 
       final granted = await waitForLoadedInviteStatus(tester);
       expect(granted.inviteStatus, isNotNull);
-      await tester.tap(find.text(_en.settingsInvites));
+      router.go(InvitesScreen.path);
       await pumpUntilSettled(tester, maxSeconds: 10);
       expect(find.byType(InvitesView), findsOneWidget);
 

--- a/mobile/integration_test/auth/repro_log1_test.dart
+++ b/mobile/integration_test/auth/repro_log1_test.dart
@@ -112,42 +112,33 @@ void main() {
           'codes=${grantedStatus.codes.length}',
         );
 
-        // ── Settings shows the Invites entry ──
+        // ── Settings shows the share action independently of invites ──
         // The router comes from the provider container: InheritedGoRouter
         // lives below MaterialApp, so GoRouter.of cannot see it from here.
         final router = container.read(goRouterProvider);
         router.go(SettingsScreen.path);
         await pumpUntilSettled(tester, maxSeconds: 10);
 
-        final invitesEntry = find.ancestor(
-          of: find.text(_en.settingsInvites),
+        final shareEntry = find.ancestor(
+          of: find.text(_en.settingsShareDivine),
           matching: find.byWidgetPredicate(
             (widget) =>
                 widget is Semantics &&
-                widget.properties.label == _en.settingsInvites,
+                widget.properties.label == _en.settingsShareDivine,
           ),
         );
         expect(
-          invitesEntry,
+          shareEntry,
           findsOneWidget,
           reason:
-              'Settings should offer the Invites entry for an identity that '
-              'holds ${grantedStatus.remaining} invites and zero codes',
-        );
-        // The badge count is whatever the server returned, not a literal the
-        // app carries around.
-        expect(
-          find.descendant(
-            of: invitesEntry,
-            matching: find.text('${grantedStatus.remaining}'),
-          ),
-          findsOneWidget,
+              'Settings should offer the Divine share action independently '
+              'of invite allocation',
         );
 
-        logPhase('Phase 1b: Settings shows the Invites entry');
+        logPhase('Phase 1b: Settings shows the Divine share action');
 
         // ── The invites screen reports the server's allocation ──
-        await tester.tap(find.text(_en.settingsInvites));
+        router.go(InvitesScreen.path);
         await pumpUntilSettled(tester, maxSeconds: 10);
 
         expect(find.byType(InvitesView), findsOneWidget);

--- a/mobile/lib/blocs/invite_status/invite_status_state.dart
+++ b/mobile/lib/blocs/invite_status/invite_status_state.dart
@@ -39,10 +39,6 @@ class InviteStatusState extends Equatable {
   /// Whether the user has remaining invite capacity.
   bool get hasAvailableInvites => availableInviteCount > 0;
 
-  /// Whether the user has any invite activity (codes or remaining capacity).
-  bool get hasInviteActivity =>
-      hasAvailableInvites || (inviteStatus?.codes.isNotEmpty ?? false);
-
   /// Number of invites the user still has to share.
   ///
   /// Not what they can still *generate* — see [InviteStatus.mintableCount] for

--- a/mobile/lib/constants/app_constants.dart
+++ b/mobile/lib/constants/app_constants.dart
@@ -44,6 +44,9 @@ class AppConstants {
   /// Divine-hosted account portability flow.
   static const String accountPortabilityUrl = 'https://divine.video/exit';
 
+  /// Divine download page that selects stores for the visitor's platform.
+  static const String downloadUrl = 'https://divine.video/download';
+
   // ============================================================================
   // FEED CONFIGURATION
   // ============================================================================

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -103,7 +103,7 @@
             }
         }
     },
-    "settingsInvites": "ግብዣዎች",
+  "settingsShareDivine": "Divineን ከጓደኞችዎ ጋር ያጋሩ",
     "settingsSwitchAccount": "መለያ ቀይር",
     "settingsAddAnotherAccount": "ሌላ መለያ ያክሉ",
   "settingsAccountSwitchFailed": "መለያዎችን መቀየር አልተቻለም። እባክዎ እንደገና ይሞክሩ።",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -103,7 +103,7 @@
             }
         }
     },
-  "settingsShareDivine": "شارك Divine مع أصدقائك",
+  "settingsShareDivine": "مشاركة Divine مع الأصدقاء",
     "settingsSwitchAccount": "تبديل الحساب",
     "settingsAddAnotherAccount": "إضافة حساب آخر",
   "settingsAccountSwitchFailed": "تعذر تبديل الحسابات. يُرجى المحاولة مرة أخرى.",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -103,7 +103,7 @@
             }
         }
     },
-    "settingsInvites": "الدعوات",
+  "settingsShareDivine": "شارك Divine مع أصدقائك",
     "settingsSwitchAccount": "تبديل الحساب",
     "settingsAddAnotherAccount": "إضافة حساب آخر",
   "settingsAccountSwitchFailed": "تعذر تبديل الحسابات. يُرجى المحاولة مرة أخرى.",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -103,7 +103,7 @@
             }
         }
     },
-    "settingsInvites": "Покани",
+  "settingsShareDivine": "Сподели Divine с приятелите си",
     "settingsSwitchAccount": "Смени акаунта",
     "settingsAddAnotherAccount": "Добави друг акаунт",
   "settingsAccountSwitchFailed": "Не можахме да превключим акаунтите. Опитайте отново.",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -103,7 +103,7 @@
             }
         }
     },
-    "settingsInvites": "Einladungen",
+  "settingsShareDivine": "Teile Divine mit deinen Freunden",
     "settingsSwitchAccount": "Konto wechseln",
     "settingsAddAnotherAccount": "Weiteres Konto hinzufügen",
   "settingsAccountSwitchFailed": "Konten konnten nicht gewechselt werden. Bitte versuch es erneut.",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -181,7 +181,10 @@
       }
     }
   },
-  "settingsInvites": "Invites",
+  "settingsShareDivine": "Share Divine with your friends",
+  "@settingsShareDivine": {
+    "description": "Button that opens the share sheet with Divine's download link"
+  },
   "settingsSwitchAccount": "Switch account",
   "settingsAddAnotherAccount": "Add another account",
   "settingsAccountSwitchFailed": "Couldn't switch accounts. Please try again.",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -103,7 +103,7 @@
             }
         }
     },
-    "settingsInvites": "Invitaciones",
+  "settingsShareDivine": "Compartí Divine con tus amigos",
     "settingsSwitchAccount": "Cambiar de cuenta",
     "settingsAddAnotherAccount": "Agregar otra cuenta",
   "settingsAccountSwitchFailed": "No se pudieron cambiar las cuentas. Inténtalo de nuevo.",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -79,7 +79,7 @@
     "settingsDeveloperModeAlreadyEnabled": "Naka-enable na ang developer mode",
     "settingsDeveloperModeEnabled": "Na-enable ang developer mode!",
     "settingsDeveloperModeTapsRemaining": "{count} pang tap para ma-enable ang developer mode",
-    "settingsInvites": "Mga Invite",
+  "settingsShareDivine": "I-share ang Divine sa mga kaibigan mo",
     "settingsSwitchAccount": "Magpalit ng account",
     "settingsAddAnotherAccount": "Magdagdag ng isa pang account",
   "settingsAccountSwitchFailed": "Hindi mailipat ang mga account. Pakisubukan ulit.",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -103,7 +103,7 @@
             }
         }
     },
-    "settingsInvites": "Invitations",
+  "settingsShareDivine": "Partage Divine avec tes amis",
     "settingsSwitchAccount": "Changer de compte",
     "settingsAddAnotherAccount": "Ajouter un autre compte",
   "settingsAccountSwitchFailed": "Impossible de changer de compte. Réessaie.",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -103,7 +103,7 @@
             }
         }
     },
-    "settingsInvites": "Undangan",
+  "settingsShareDivine": "Bagikan Divine dengan teman-temanmu",
     "settingsSwitchAccount": "Ganti akun",
     "settingsAddAnotherAccount": "Tambah akun lain",
   "settingsAccountSwitchFailed": "Tidak dapat beralih akun. Coba lagi.",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -103,7 +103,7 @@
             }
         }
     },
-    "settingsInvites": "Inviti",
+  "settingsShareDivine": "Condividi Divine con i tuoi amici",
     "settingsSwitchAccount": "Cambia account",
     "settingsAddAnotherAccount": "Aggiungi un altro account",
   "settingsAccountSwitchFailed": "Impossibile cambiare account. Riprova.",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -103,7 +103,7 @@
             }
         }
     },
-    "settingsInvites": "招待",
+  "settingsShareDivine": "Divineを友だちと共有",
     "settingsSwitchAccount": "アカウントを切り替え",
     "settingsAddAnotherAccount": "別のアカウントを追加",
   "settingsAccountSwitchFailed": "アカウントを切り替えられませんでした。もう一度お試しください。",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -79,7 +79,7 @@
     "settingsDeveloperModeAlreadyEnabled": "개발자 모드가 이미 켜져 있어요",
     "settingsDeveloperModeEnabled": "개발자 모드가 켜졌어요!",
     "settingsDeveloperModeTapsRemaining": "개발자 모드를 켜려면 {count}번 더 탭해주세요",
-    "settingsInvites": "초대장",
+  "settingsShareDivine": "친구들과 Divine을 공유해요",
     "settingsSwitchAccount": "계정 전환",
     "settingsAddAnotherAccount": "다른 계정 추가",
   "settingsAccountSwitchFailed": "계정을 전환할 수 없었어요. 다시 시도해 주세요.",

--- a/mobile/lib/l10n/app_ms.arb
+++ b/mobile/lib/l10n/app_ms.arb
@@ -82,7 +82,7 @@
       }
     }
   },
-  "settingsInvites": "Jemputan",
+  "settingsShareDivine": "Kongsi Divine dengan rakan anda",
   "settingsSwitchAccount": "Tukar akaun",
   "settingsAddAnotherAccount": "Tambah akaun lain",
   "settingsAccountSwitchFailed": "Tidak dapat menukar akaun. Sila cuba lagi.",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -103,7 +103,7 @@
             }
         }
     },
-    "settingsInvites": "Uitnodigingen",
+  "settingsShareDivine": "Deel Divine met je vrienden",
     "settingsSwitchAccount": "Wissel van account",
     "settingsAddAnotherAccount": "Nog een account toevoegen",
   "settingsAccountSwitchFailed": "Kan niet van account wisselen. Probeer het opnieuw.",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -103,7 +103,7 @@
             }
         }
     },
-    "settingsInvites": "Zaproszenia",
+  "settingsShareDivine": "Udostępnij Divine znajomym",
     "settingsSwitchAccount": "Przełącz konto",
     "settingsAddAnotherAccount": "Dodaj kolejne konto",
   "settingsAccountSwitchFailed": "Nie udało się przełączyć kont. Spróbuj ponownie.",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -103,7 +103,7 @@
             }
         }
     },
-    "settingsInvites": "Convites",
+  "settingsShareDivine": "Compartilhe Divine com seus amigos",
     "settingsSwitchAccount": "Trocar de conta",
     "settingsAddAnotherAccount": "Adicionar outra conta",
   "settingsAccountSwitchFailed": "Não foi possível trocar de conta. Tente novamente.",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -103,7 +103,7 @@
             }
         }
     },
-    "settingsInvites": "Invitații",
+  "settingsShareDivine": "Distribuie Divine prietenilor tăi",
     "settingsSwitchAccount": "Schimbă contul",
     "settingsAddAnotherAccount": "Adaugă alt cont",
   "settingsAccountSwitchFailed": "Nu s-a putut schimba contul. Încearcă din nou.",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -103,7 +103,7 @@
             }
         }
     },
-    "settingsInvites": "Inbjudningar",
+  "settingsShareDivine": "Dela Divine med dina vänner",
     "settingsSwitchAccount": "Byt konto",
     "settingsAddAnotherAccount": "Lägg till ett till konto",
   "settingsAccountSwitchFailed": "Det gick inte att byta konto. Försök igen.",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -103,7 +103,7 @@
             }
         }
     },
-    "settingsInvites": "Davetler",
+  "settingsShareDivine": "Divine'ı arkadaşlarınla paylaş",
     "settingsSwitchAccount": "Hesap değiştir",
     "settingsAddAnotherAccount": "Başka hesap ekle",
   "settingsAccountSwitchFailed": "Hesaplar değiştirilemedi. Lütfen tekrar dene.",

--- a/mobile/lib/l10n/app_ur.arb
+++ b/mobile/lib/l10n/app_ur.arb
@@ -82,7 +82,7 @@
       }
     }
   },
-  "settingsInvites": "دعوت نامے",
+  "settingsShareDivine": "Divine کو اپنے دوستوں کے ساتھ شیئر کریں",
   "settingsSwitchAccount": "اکاؤنٹ تبدیل کریں",
   "settingsAddAnotherAccount": "ایک اور اکاؤنٹ شامل کریں",
   "settingsAccountSwitchFailed": "اکاؤنٹ تبدیل نہیں ہو سکا۔ براہ کرم دوبارہ کوشش کریں۔",

--- a/mobile/lib/l10n/app_vi.arb
+++ b/mobile/lib/l10n/app_vi.arb
@@ -82,7 +82,7 @@
       }
     }
   },
-  "settingsInvites": "Lời mời",
+  "settingsShareDivine": "Chia sẻ Divine với bạn bè",
   "settingsSwitchAccount": "Chuyển tài khoản",
   "settingsAddAnotherAccount": "Thêm tài khoản khác",
   "settingsAccountSwitchFailed": "Không thể chuyển tài khoản. Vui lòng thử lại.",

--- a/mobile/lib/l10n/app_zh.arb
+++ b/mobile/lib/l10n/app_zh.arb
@@ -82,7 +82,7 @@
       }
     }
   },
-  "settingsInvites": "邀请",
+  "settingsShareDivine": "与朋友分享 Divine",
   "settingsSwitchAccount": "切换账号",
   "settingsAddAnotherAccount": "添加其他账号",
   "settingsAccountSwitchFailed": "切换账号失败，请重试。",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -426,11 +426,11 @@ abstract class AppLocalizations {
   /// **'{count, plural, =1{{count} more tap to enable developer mode} other{{count} more taps to enable developer mode}}'**
   String settingsDeveloperModeTapsRemaining(int count);
 
-  /// No description provided for @settingsInvites.
+  /// Button that opens the share sheet with Divine's download link
   ///
   /// In en, this message translates to:
-  /// **'Invites'**
-  String get settingsInvites;
+  /// **'Share Divine with your friends'**
+  String get settingsShareDivine;
 
   /// No description provided for @settingsSwitchAccount.
   ///

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -203,7 +203,7 @@ class AppLocalizationsAm extends AppLocalizations {
   }
 
   @override
-  String get settingsInvites => 'ግብዣዎች';
+  String get settingsShareDivine => 'Divineን ከጓደኞችዎ ጋር ያጋሩ';
 
   @override
   String get settingsSwitchAccount => 'መለያ ቀይር';

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -205,7 +205,7 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
-  String get settingsInvites => 'الدعوات';
+  String get settingsShareDivine => 'شارك Divine مع أصدقائك';
 
   @override
   String get settingsSwitchAccount => 'تبديل الحساب';

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -205,7 +205,7 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
-  String get settingsShareDivine => 'شارك Divine مع أصدقائك';
+  String get settingsShareDivine => 'مشاركة Divine مع الأصدقاء';
 
   @override
   String get settingsSwitchAccount => 'تبديل الحساب';

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -210,7 +210,7 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
-  String get settingsInvites => 'Покани';
+  String get settingsShareDivine => 'Сподели Divine с приятелите си';
 
   @override
   String get settingsSwitchAccount => 'Смени акаунта';

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -210,7 +210,7 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get settingsInvites => 'Einladungen';
+  String get settingsShareDivine => 'Teile Divine mit deinen Freunden';
 
   @override
   String get settingsSwitchAccount => 'Konto wechseln';

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -213,7 +213,7 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get settingsInvites => 'Invites';
+  String get settingsShareDivine => 'Share Divine with your friends';
 
   @override
   String get settingsSwitchAccount => 'Switch account';

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -208,7 +208,7 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get settingsInvites => 'Invitaciones';
+  String get settingsShareDivine => 'Compartí Divine con tus amigos';
 
   @override
   String get settingsSwitchAccount => 'Cambiar de cuenta';

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -176,7 +176,7 @@ class AppLocalizationsFil extends AppLocalizations {
   }
 
   @override
-  String get settingsInvites => 'Mga Invite';
+  String get settingsShareDivine => 'I-share ang Divine sa mga kaibigan mo';
 
   @override
   String get settingsSwitchAccount => 'Magpalit ng account';

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -210,7 +210,7 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get settingsInvites => 'Invitations';
+  String get settingsShareDivine => 'Partage Divine avec tes amis';
 
   @override
   String get settingsSwitchAccount => 'Changer de compte';

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -177,7 +177,7 @@ class AppLocalizationsId extends AppLocalizations {
   }
 
   @override
-  String get settingsInvites => 'Undangan';
+  String get settingsShareDivine => 'Bagikan Divine dengan teman-temanmu';
 
   @override
   String get settingsSwitchAccount => 'Ganti akun';

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -210,7 +210,7 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String get settingsInvites => 'Inviti';
+  String get settingsShareDivine => 'Condividi Divine con i tuoi amici';
 
   @override
   String get settingsSwitchAccount => 'Cambia account';

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -170,7 +170,7 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
-  String get settingsInvites => '招待';
+  String get settingsShareDivine => 'Divineを友だちと共有';
 
   @override
   String get settingsSwitchAccount => 'アカウントを切り替え';

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -171,7 +171,7 @@ class AppLocalizationsKo extends AppLocalizations {
   }
 
   @override
-  String get settingsInvites => '초대장';
+  String get settingsShareDivine => '친구들과 Divine을 공유해요';
 
   @override
   String get settingsSwitchAccount => '계정 전환';

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -177,7 +177,7 @@ class AppLocalizationsMs extends AppLocalizations {
   }
 
   @override
-  String get settingsInvites => 'Jemputan';
+  String get settingsShareDivine => 'Kongsi Divine dengan rakan anda';
 
   @override
   String get settingsSwitchAccount => 'Tukar akaun';

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -207,7 +207,7 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
-  String get settingsInvites => 'Uitnodigingen';
+  String get settingsShareDivine => 'Deel Divine met je vrienden';
 
   @override
   String get settingsSwitchAccount => 'Wissel van account';

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -221,7 +221,7 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
-  String get settingsInvites => 'Zaproszenia';
+  String get settingsShareDivine => 'Udostępnij Divine znajomym';
 
   @override
   String get settingsSwitchAccount => 'Przełącz konto';

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -208,7 +208,7 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String get settingsInvites => 'Convites';
+  String get settingsShareDivine => 'Compartilhe Divine com seus amigos';
 
   @override
   String get settingsSwitchAccount => 'Trocar de conta';

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -220,7 +220,7 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String get settingsInvites => 'Invitații';
+  String get settingsShareDivine => 'Distribuie Divine prietenilor tăi';
 
   @override
   String get settingsSwitchAccount => 'Schimbă contul';

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -207,7 +207,7 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
-  String get settingsInvites => 'Inbjudningar';
+  String get settingsShareDivine => 'Dela Divine med dina vänner';
 
   @override
   String get settingsSwitchAccount => 'Byt konto';

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -177,7 +177,7 @@ class AppLocalizationsTr extends AppLocalizations {
   }
 
   @override
-  String get settingsInvites => 'Davetler';
+  String get settingsShareDivine => 'Divine\'ı arkadaşlarınla paylaş';
 
   @override
   String get settingsSwitchAccount => 'Hesap değiştir';

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -208,7 +208,7 @@ class AppLocalizationsUr extends AppLocalizations {
   }
 
   @override
-  String get settingsInvites => 'دعوت نامے';
+  String get settingsShareDivine => 'Divine کو اپنے دوستوں کے ساتھ شیئر کریں';
 
   @override
   String get settingsSwitchAccount => 'اکاؤنٹ تبدیل کریں';

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -177,7 +177,7 @@ class AppLocalizationsVi extends AppLocalizations {
   }
 
   @override
-  String get settingsInvites => 'Lời mời';
+  String get settingsShareDivine => 'Chia sẻ Divine với bạn bè';
 
   @override
   String get settingsSwitchAccount => 'Chuyển tài khoản';

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -170,7 +170,7 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
-  String get settingsInvites => '邀请';
+  String get settingsShareDivine => '与朋友分享 Divine';
 
   @override
   String get settingsSwitchAccount => '切换账号';

--- a/mobile/lib/screens/settings/settings_screen.dart
+++ b/mobile/lib/screens/settings/settings_screen.dart
@@ -589,36 +589,39 @@ class _ShareDivineButton extends StatelessWidget {
           ShareParams(text: AppConstants.downloadUrl),
         ),
         borderRadius: BorderRadius.circular(16),
-        child: Container(
-          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-          decoration: BoxDecoration(
-            color: context.vineColors.surfaceContainer,
-            borderRadius: BorderRadius.circular(16),
-            border: Border.all(
-              color: context.vineColors.outlineMuted,
-              width: 2,
-            ),
-          ),
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            spacing: 8,
-            children: [
-              DivineIcon(
-                icon: DivineIconName.shareNetwork,
-                color: context.vineColors.accentPositive,
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(minHeight: 48),
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            decoration: BoxDecoration(
+              color: context.vineColors.surfaceContainer,
+              borderRadius: BorderRadius.circular(16),
+              border: Border.all(
+                color: context.vineColors.outlineMuted,
+                width: 2,
               ),
-              // A sentence-length label, unlike the single word this slot
-              // used to hold: it has to wrap rather than overflow the pill
-              // on a narrow phone or at a large text scale.
-              Flexible(
-                child: Text(
-                  label,
-                  style: VineTheme.titleMediumFont(
-                    color: context.vineColors.accentPositive,
+            ),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              spacing: 8,
+              children: [
+                DivineIcon(
+                  icon: DivineIconName.shareNetwork,
+                  color: context.vineColors.accentPositive,
+                ),
+                // A sentence-length label, unlike the single word this slot
+                // used to hold: it has to wrap rather than overflow the pill
+                // on a narrow phone or at a large text scale.
+                Flexible(
+                  child: Text(
+                    label,
+                    style: VineTheme.titleMediumFont(
+                      color: context.vineColors.accentPositive,
+                    ),
                   ),
                 ),
-              ),
-            ],
+              ],
+            ),
           ),
         ),
       ),

--- a/mobile/lib/screens/settings/settings_screen.dart
+++ b/mobile/lib/screens/settings/settings_screen.dart
@@ -607,10 +607,15 @@ class _ShareDivineButton extends StatelessWidget {
                 icon: DivineIconName.shareNetwork,
                 color: context.vineColors.accentPositive,
               ),
-              Text(
-                label,
-                style: VineTheme.titleMediumFont(
-                  color: context.vineColors.accentPositive,
+              // A sentence-length label, unlike the single word this slot
+              // used to hold: it has to wrap rather than overflow the pill
+              // on a narrow phone or at a large text scale.
+              Flexible(
+                child: Text(
+                  label,
+                  style: VineTheme.titleMediumFont(
+                    color: context.vineColors.accentPositive,
+                  ),
                 ),
               ),
             ],

--- a/mobile/lib/screens/settings/settings_screen.dart
+++ b/mobile/lib/screens/settings/settings_screen.dart
@@ -12,8 +12,8 @@ import 'package:keycast_flutter/keycast_flutter.dart'
     show SessionExpiredException;
 import 'package:models/models.dart';
 import 'package:openvine/blocs/background_publish/background_publish_bloc.dart';
-import 'package:openvine/blocs/invite_status/invite_status_cubit.dart';
 import 'package:openvine/blocs/settings_account/settings_account_cubit.dart';
+import 'package:openvine/constants/app_constants.dart';
 import 'package:openvine/constants/semantic_ids.dart';
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
 import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
@@ -38,7 +38,6 @@ import 'package:openvine/screens/developer_options_screen.dart';
 import 'package:openvine/screens/notification_settings_screen.dart';
 import 'package:openvine/screens/safety_settings_screen.dart';
 import 'package:openvine/screens/settings/general_settings_screen.dart';
-import 'package:openvine/screens/settings/invites_screen.dart';
 import 'package:openvine/screens/settings/legal_screen.dart';
 import 'package:openvine/screens/settings/monetization_links_settings_screen.dart';
 import 'package:openvine/screens/settings/nostr_settings_screen.dart';
@@ -48,8 +47,8 @@ import 'package:openvine/services/auth_service.dart' hide UserProfile;
 import 'package:openvine/utils/deferred_login_options_navigator.dart';
 import 'package:openvine/utils/nostr_apps_platform_support.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
+import 'package:openvine/utils/share_sheet.dart';
 import 'package:openvine/utils/user_identifier_line_resolver.dart';
-import 'package:openvine/widgets/signup_invites_availability_builder.dart';
 import 'package:openvine/widgets/user_avatar.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:unified_logger/unified_logger.dart';
@@ -73,7 +72,6 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
   void initState() {
     super.initState();
     unawaited(_loadAppVersion());
-    unawaited(context.read<InviteStatusCubit?>()?.load());
     _accountCubit = SettingsAccountCubit(
       authService: ref.read(authServiceProvider),
       draftStorageService: ref.read(draftStorageServiceProvider),
@@ -522,75 +520,7 @@ class _AccountHeader extends StatelessWidget {
             spacing: 16,
             children: [
               _AccountHeaderProfile(pubkey: pubkey),
-              SignupInvitesAvailabilityBuilder(
-                builder: (context, availability) {
-                  if (!availability.isEnabled) {
-                    return const SizedBox.shrink();
-                  }
-                  return BlocBuilder<InviteStatusCubit, InviteStatusState>(
-                    builder: (context, inviteState) {
-                      if (!inviteState.hasInviteActivity) {
-                        return const SizedBox.shrink();
-                      }
-                      return Semantics(
-                        button: true,
-                        label: context.l10n.settingsInvites,
-                        child: InkWell(
-                          onTap: () => context.push(InvitesScreen.path),
-                          borderRadius: BorderRadius.circular(16),
-                          child: Container(
-                            padding: const EdgeInsets.symmetric(
-                              horizontal: 16,
-                              vertical: 8,
-                            ),
-                            decoration: BoxDecoration(
-                              color: context.vineColors.surfaceContainer,
-                              borderRadius: BorderRadius.circular(16),
-                              border: Border.all(
-                                color: context.vineColors.outlineMuted,
-                                width: 2,
-                              ),
-                            ),
-                            child: Row(
-                              mainAxisSize: MainAxisSize.min,
-                              spacing: 8,
-                              children: [
-                                DivineIcon(
-                                  icon: DivineIconName.shareNetwork,
-                                  color: context.vineColors.accentPositive,
-                                ),
-                                Text(
-                                  context.l10n.settingsInvites,
-                                  style: VineTheme.titleMediumFont(
-                                    color: context.vineColors.accentPositive,
-                                  ),
-                                ),
-                                if (inviteState.hasAvailableInvites)
-                                  Container(
-                                    padding: const EdgeInsets.symmetric(
-                                      horizontal: 8,
-                                      vertical: 2,
-                                    ),
-                                    decoration: BoxDecoration(
-                                      color: VineTheme.vineGreen,
-                                      borderRadius: BorderRadius.circular(12),
-                                    ),
-                                    child: Text(
-                                      '${inviteState.availableInviteCount}',
-                                      style: VineTheme.labelSmallFont(
-                                        color: VineTheme.onPrimary,
-                                      ),
-                                    ),
-                                  ),
-                              ],
-                            ),
-                          ),
-                        ),
-                      );
-                    },
-                  );
-                },
-              ),
+              const _ShareDivineButton(),
               if (accountSwitchingEnabled)
                 Semantics(
                   button: true,
@@ -640,6 +570,53 @@ class _AccountHeader extends StatelessWidget {
           ),
         );
       },
+    );
+  }
+}
+
+class _ShareDivineButton extends StatelessWidget {
+  const _ShareDivineButton();
+
+  @override
+  Widget build(BuildContext context) {
+    final label = context.l10n.settingsShareDivine;
+    return Semantics(
+      button: true,
+      label: label,
+      child: InkWell(
+        onTap: () => showShareSheet(
+          context,
+          ShareParams(text: AppConstants.downloadUrl),
+        ),
+        borderRadius: BorderRadius.circular(16),
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          decoration: BoxDecoration(
+            color: context.vineColors.surfaceContainer,
+            borderRadius: BorderRadius.circular(16),
+            border: Border.all(
+              color: context.vineColors.outlineMuted,
+              width: 2,
+            ),
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            spacing: 8,
+            children: [
+              DivineIcon(
+                icon: DivineIconName.shareNetwork,
+                color: context.vineColors.accentPositive,
+              ),
+              Text(
+                label,
+                style: VineTheme.titleMediumFont(
+                  color: context.vineColors.accentPositive,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
     );
   }
 }

--- a/mobile/test/screens/settings/settings_share_divine_test.dart
+++ b/mobile/test/screens/settings/settings_share_divine_test.dart
@@ -171,7 +171,11 @@ void main() {
         .setMockMethodCallHandler(_shareChannel, null);
   });
 
-  Widget wrap({required OnboardingMode onboardingMode}) {
+  Widget wrap({
+    required OnboardingMode onboardingMode,
+    Locale locale = const Locale('en'),
+    double textScaleFactor = 1,
+  }) {
     final divineHostFilterService = DivineHostFilterService(sharedPreferences);
     final availabilityCubit = seededInviteAvailabilityCubit(
       serverMode: onboardingMode,
@@ -216,7 +220,13 @@ void main() {
       child: MaterialApp(
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
+        locale: locale,
         theme: VineTheme.theme,
+        builder: (context, child) => MediaQuery.withClampedTextScaling(
+          minScaleFactor: textScaleFactor,
+          maxScaleFactor: textScaleFactor,
+          child: child!,
+        ),
         home: MultiBlocProvider(
           providers: [
             BlocProvider<LocaleCubit>.value(value: localeCubit),
@@ -250,5 +260,41 @@ void main() {
       expect(shareCalls.single['originWidth'], isNotNull);
       expect(shareCalls.single['originHeight'], isNotNull);
     });
+  }
+
+  // The slot used to hold one word ("Invites"); the label is now a sentence,
+  // so the pill has to survive a narrow phone, the longest translation, and
+  // an accessibility text scale. Every case below overflowed before the
+  // label was allowed to wrap.
+  const layoutProbes = <({double width, Locale locale, double textScale})>[
+    (width: 320, locale: Locale('fil'), textScale: 1),
+    (width: 360, locale: Locale('fil'), textScale: 1),
+    (width: 360, locale: Locale('en'), textScale: 1.3),
+    (width: 412, locale: Locale('en'), textScale: 2),
+  ];
+
+  for (final probe in layoutProbes) {
+    testWidgets(
+      'share action fits ${probe.width}dp in ${probe.locale.languageCode} '
+      'at text scale ${probe.textScale}',
+      (tester) async {
+        await tester.binding.setSurfaceSize(Size(probe.width, 1600));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+
+        await tester.pumpWidget(
+          wrap(
+            onboardingMode: OnboardingMode.open,
+            locale: probe.locale,
+            textScaleFactor: probe.textScale,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(
+          find.text(lookupAppLocalizations(probe.locale).settingsShareDivine),
+          findsOneWidget,
+        );
+      },
+    );
   }
 }

--- a/mobile/test/screens/settings/settings_share_divine_test.dart
+++ b/mobile/test/screens/settings/settings_share_divine_test.dart
@@ -251,6 +251,11 @@ void main() {
         const Locale('en'),
       ).settingsShareDivine;
       expect(find.text(label), findsOneWidget);
+      final shareAction = find.ancestor(
+        of: find.text(label),
+        matching: find.byType(InkWell),
+      );
+      expect(tester.getSize(shareAction).height, greaterThanOrEqualTo(48));
 
       await tester.tap(find.text(label));
       await tester.pumpAndSettle();

--- a/mobile/test/screens/settings/settings_share_divine_test.dart
+++ b/mobile/test/screens/settings/settings_share_divine_test.dart
@@ -237,9 +237,12 @@ void main() {
       await tester.pumpWidget(wrap(onboardingMode: onboardingMode));
       await tester.pumpAndSettle();
 
-      expect(find.text('Share Divine with your friends'), findsOneWidget);
+      final label = lookupAppLocalizations(
+        const Locale('en'),
+      ).settingsShareDivine;
+      expect(find.text(label), findsOneWidget);
 
-      await tester.tap(find.text('Share Divine with your friends'));
+      await tester.tap(find.text(label));
       await tester.pumpAndSettle();
 
       expect(shareCalls, hasLength(1));

--- a/mobile/test/screens/settings/settings_share_divine_test.dart
+++ b/mobile/test/screens/settings/settings_share_divine_test.dart
@@ -1,0 +1,251 @@
+// ABOUTME: Widget tests for sharing Divine from the Settings account header.
+// ABOUTME: Verifies invite availability cannot hide the anchored share action.
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:content_blocklist_repository/content_blocklist_repository.dart';
+import 'package:content_policy/content_policy.dart';
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:follow_repository/follow_repository.dart';
+import 'package:invite_api_client/invite_api_client.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/blocs/locale/locale_cubit.dart';
+import 'package:openvine/constants/app_constants.dart';
+import 'package:openvine/features/feature_flags/models/feature_flag.dart';
+import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/models/content_label.dart';
+import 'package:openvine/models/known_account.dart';
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
+import 'package:openvine/screens/settings/settings_screen.dart';
+import 'package:openvine/services/account_label_service.dart';
+import 'package:openvine/services/age_verification_service.dart';
+import 'package:openvine/services/audio_sharing_preference_service.dart';
+import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/content_filter_service.dart';
+import 'package:openvine/services/divine_host_filter_service.dart';
+import 'package:openvine/services/draft_storage_service.dart';
+import 'package:openvine/services/feed_aspect_ratio_preference_service.dart';
+import 'package:openvine/services/language_preference_service.dart';
+import 'package:openvine/services/moderation_label_service.dart';
+import 'package:openvine/services/video_event_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../helpers/invite_availability_harness.dart';
+
+const _shareChannel = MethodChannel('dev.fluttercommunity.plus/share');
+
+class _MockAuthService extends Mock implements AuthService {}
+
+class _MockLocaleCubit extends MockCubit<LocaleState> implements LocaleCubit {}
+
+class _MockDraftStorageService extends Mock implements DraftStorageService {}
+
+class _MockAudioSharingPreferenceService extends Mock
+    implements AudioSharingPreferenceService {}
+
+class _MockLanguagePreferenceService extends Mock
+    implements LanguagePreferenceService {}
+
+class _MockAccountLabelService extends Mock implements AccountLabelService {}
+
+class _MockAgeVerificationService extends Mock
+    implements AgeVerificationService {}
+
+class _MockContentFilterService extends Mock implements ContentFilterService {}
+
+class _MockModerationLabelService extends Mock
+    implements ModerationLabelService {}
+
+class _MockFollowRepository extends Mock implements FollowRepository {}
+
+class _MockContentBlocklistRepository extends Mock
+    implements ContentBlocklistRepository {
+  @override
+  Set<String> get runtimeBlockedUsers => const {};
+
+  @override
+  Stream<ContentPolicyState> get stateStream =>
+      const Stream<ContentPolicyState>.empty();
+}
+
+class _MockVideoEventService extends Mock implements VideoEventService {
+  @override
+  int filterAdultContentFromExistingVideos() => 0;
+}
+
+void main() {
+  const currentPubkey =
+      'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2';
+
+  late List<Map<Object?, Object?>> shareCalls;
+  late SharedPreferences sharedPreferences;
+  late _MockAuthService authService;
+  late _MockLocaleCubit localeCubit;
+  late _MockDraftStorageService draftStorageService;
+  late _MockAudioSharingPreferenceService audioSharingService;
+  late _MockLanguagePreferenceService languageService;
+  late _MockAccountLabelService accountLabelService;
+  late _MockAgeVerificationService ageVerificationService;
+  late _MockContentFilterService contentFilterService;
+  late _MockModerationLabelService moderationLabelService;
+  late _MockFollowRepository followRepository;
+  late _MockContentBlocklistRepository blocklistRepository;
+  late _MockVideoEventService videoEventService;
+
+  setUp(() async {
+    shareCalls = <Map<Object?, Object?>>[];
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(_shareChannel, (call) async {
+          if (call.method == 'share') {
+            shareCalls.add(call.arguments as Map<Object?, Object?>);
+          }
+          return 'com.apple.UIKit.activity.CopyToPasteboard';
+        });
+
+    SharedPreferences.setMockInitialValues({});
+    sharedPreferences = await SharedPreferences.getInstance();
+    authService = _MockAuthService();
+    localeCubit = _MockLocaleCubit();
+    draftStorageService = _MockDraftStorageService();
+    audioSharingService = _MockAudioSharingPreferenceService();
+    languageService = _MockLanguagePreferenceService();
+    accountLabelService = _MockAccountLabelService();
+    ageVerificationService = _MockAgeVerificationService();
+    contentFilterService = _MockContentFilterService();
+    moderationLabelService = _MockModerationLabelService();
+    followRepository = _MockFollowRepository();
+    blocklistRepository = _MockContentBlocklistRepository();
+    videoEventService = _MockVideoEventService();
+
+    when(() => localeCubit.state).thenReturn(const LocaleState());
+    when(() => authService.isAuthenticated).thenReturn(true);
+    when(() => authService.isAnonymous).thenReturn(false);
+    when(() => authService.hasExpiredOAuthSession).thenReturn(false);
+    when(() => authService.currentPublicKeyHex).thenReturn(currentPubkey);
+    when(() => authService.getKnownAccounts()).thenAnswer(
+      (_) async => [
+        KnownAccount(
+          pubkeyHex: currentPubkey,
+          authSource: AuthenticationSource.importedKeys,
+          addedAt: DateTime(2026),
+          lastUsedAt: DateTime(2026),
+        ),
+      ],
+    );
+    when(() => draftStorageService.getDraftCount()).thenAnswer((_) async => 0);
+    when(() => audioSharingService.isAudioSharingEnabled).thenReturn(false);
+    when(() => languageService.contentLanguage).thenReturn('en');
+    when(() => languageService.isCustomLanguageSet).thenReturn(false);
+    when(() => accountLabelService.accountLabels).thenReturn(<ContentLabel>{});
+    when(() => accountLabelService.initialized).thenAnswer((_) async {});
+    when(() => ageVerificationService.initialize()).thenAnswer((_) async {});
+    when(() => ageVerificationService.isAdultContentVerified).thenReturn(false);
+    when(() => contentFilterService.initialize()).thenAnswer((_) async {});
+    for (final label in ContentLabel.values) {
+      when(
+        () => contentFilterService.getPreference(label),
+      ).thenReturn(ContentFilterPreference.warn);
+    }
+    when(
+      () => moderationLabelService.isDivineLabelerSubscribed,
+    ).thenReturn(true);
+    when(() => moderationLabelService.ensureLoaded()).thenAnswer((_) async {});
+    when(
+      () => moderationLabelService.isFollowingModerationEnabled,
+    ).thenReturn(false);
+    when(() => moderationLabelService.customLabelers).thenReturn(<String>{});
+    when(() => followRepository.followingPubkeys).thenReturn(<String>[]);
+    when(
+      () => followRepository.followingStream,
+    ).thenAnswer((_) => const Stream<List<String>>.empty());
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(_shareChannel, null);
+  });
+
+  Widget wrap({required OnboardingMode onboardingMode}) {
+    final divineHostFilterService = DivineHostFilterService(sharedPreferences);
+    final availabilityCubit = seededInviteAvailabilityCubit(
+      serverMode: onboardingMode,
+    );
+    addTearDown(availabilityCubit.close);
+
+    return ProviderScope(
+      overrides: [
+        sharedPreferencesProvider.overrideWithValue(sharedPreferences),
+        authServiceProvider.overrideWithValue(authService),
+        currentAuthStateProvider.overrideWithValue(AuthState.authenticated),
+        profileRepositoryProvider.overrideWithValue(null),
+        profileReadRepositoryProvider.overrideWithValue(null),
+        draftStorageServiceProvider.overrideWithValue(draftStorageService),
+        isFeatureEnabledProvider(
+          FeatureFlag.accountSwitching,
+        ).overrideWithValue(false),
+        audioSharingPreferenceServiceProvider.overrideWithValue(
+          audioSharingService,
+        ),
+        languagePreferenceServiceProvider.overrideWithValue(languageService),
+        accountLabelServiceProvider.overrideWithValue(accountLabelService),
+        ageVerificationServiceProvider.overrideWithValue(
+          ageVerificationService,
+        ),
+        contentFilterServiceProvider.overrideWithValue(contentFilterService),
+        moderationLabelServiceProvider.overrideWithValue(
+          moderationLabelService,
+        ),
+        followRepositoryProvider.overrideWithValue(followRepository),
+        contentBlocklistRepositoryProvider.overrideWithValue(
+          blocklistRepository,
+        ),
+        videoEventServiceProvider.overrideWithValue(videoEventService),
+        divineHostFilterServiceProvider.overrideWithValue(
+          divineHostFilterService,
+        ),
+        feedAspectRatioPreferenceServiceProvider.overrideWithValue(
+          FeedAspectRatioPreferenceService(sharedPreferences),
+        ),
+      ],
+      child: MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        theme: VineTheme.theme,
+        home: MultiBlocProvider(
+          providers: [
+            BlocProvider<LocaleCubit>.value(value: localeCubit),
+            BlocProvider.value(value: availabilityCubit),
+          ],
+          child: const SettingsScreen(),
+        ),
+      ),
+    );
+  }
+
+  for (final onboardingMode in OnboardingMode.values) {
+    testWidgets('shares Divine when onboarding mode is $onboardingMode', (
+      tester,
+    ) async {
+      await tester.binding.setSurfaceSize(const Size(800, 1600));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+      await tester.pumpWidget(wrap(onboardingMode: onboardingMode));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Share Divine with your friends'), findsOneWidget);
+
+      await tester.tap(find.text('Share Divine with your friends'));
+      await tester.pumpAndSettle();
+
+      expect(shareCalls, hasLength(1));
+      expect(shareCalls.single['text'], AppConstants.downloadUrl);
+      expect(shareCalls.single['originWidth'], isNotNull);
+      expect(shareCalls.single['originHeight'], isNotNull);
+    });
+  }
+}

--- a/mobile/test/widgets/settings_screen_test.dart
+++ b/mobile/test/widgets/settings_screen_test.dart
@@ -21,7 +21,7 @@ import 'package:openvine/features/feature_flags/screens/feature_flag_screen.dart
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/divine_video_draft.dart';
 import 'package:openvine/models/invite_availability.dart';
-import 'package:openvine/models/invite_models.dart';
+import 'package:openvine/models/invite_models.dart' show OnboardingMode;
 import 'package:openvine/models/known_account.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/environment_provider.dart';
@@ -297,7 +297,7 @@ void main() {
       await tester.pump();
     });
 
-    testWidgets('loads invite status so profile can show invite access', (
+    testWidgets('does not load invite status for the share action', (
       tester,
     ) async {
       final mockInviteCubit = _createMockInviteCubit();
@@ -305,28 +305,16 @@ void main() {
       await tester.pumpWidget(buildSubject(inviteCubit: mockInviteCubit));
       await tester.pumpAndSettle();
 
-      verify(mockInviteCubit.load).called(1);
+      verifyNever(mockInviteCubit.load);
+      expect(find.text(l10n.settingsShareDivine), findsOneWidget);
 
       await tester.pumpWidget(const SizedBox());
       await tester.pump();
     });
 
-    testWidgets('hides invite shortcut when signup invites are disabled', (
+    testWidgets('shows share action when signup invites are disabled', (
       tester,
     ) async {
-      final mockInviteCubit = _MockInviteStatusCubit();
-      when(mockInviteCubit.load).thenAnswer((_) async {});
-      when(() => mockInviteCubit.state).thenReturn(
-        const InviteStatusState(
-          status: InviteStatusLoadingStatus.loaded,
-          inviteStatus: InviteStatus(
-            canInvite: true,
-            remaining: 5,
-            total: 5,
-            codes: [],
-          ),
-        ),
-      );
       final availabilityCubit = seededInviteAvailabilityCubit(
         serverMode: OnboardingMode.open,
       );
@@ -334,145 +322,58 @@ void main() {
 
       await tester.pumpWidget(
         buildSubject(
-          inviteCubit: mockInviteCubit,
           availabilityCubit: availabilityCubit,
         ),
       );
       await tester.pumpAndSettle();
 
-      expect(find.text('Invites'), findsNothing);
+      expect(find.text(l10n.settingsShareDivine), findsOneWidget);
 
       await tester.pumpWidget(const SizedBox());
       await tester.pump();
     });
 
     testWidgets(
-      'hides invite shortcut immediately when override forces disabled',
+      'keeps share action when invite override forces disabled',
       (tester) async {
-        final mockInviteCubit = _MockInviteStatusCubit();
-        when(mockInviteCubit.load).thenAnswer((_) async {});
-        when(() => mockInviteCubit.state).thenReturn(
-          const InviteStatusState(
-            status: InviteStatusLoadingStatus.loaded,
-            inviteStatus: InviteStatus(
-              canInvite: true,
-              remaining: 5,
-              total: 5,
-              codes: [],
-            ),
-          ),
-        );
         final availabilityCubit = seededInviteAvailabilityCubit();
         addTearDown(availabilityCubit.close);
 
         await tester.pumpWidget(
           buildSubject(
-            inviteCubit: mockInviteCubit,
             availabilityCubit: availabilityCubit,
           ),
         );
         await tester.pumpAndSettle();
-        expect(find.text('Invites'), findsOneWidget);
+        expect(find.text(l10n.settingsShareDivine), findsOneWidget);
 
         availabilityCubit.setOverride(InviteAvailabilityOverride.forceDisabled);
         expect(availabilityCubit.state.isEnabled, isFalse);
         await tester.pumpAndSettle();
 
-        expect(find.text('Invites'), findsNothing);
+        expect(find.text(l10n.settingsShareDivine), findsOneWidget);
 
         await tester.pumpWidget(const SizedBox());
         await tester.pump();
       },
     );
 
-    testWidgets('renders invite shortcut when unclaimed invites exist', (
-      tester,
-    ) async {
-      final mockInviteCubit = _MockInviteStatusCubit();
-      when(mockInviteCubit.load).thenAnswer((_) async {});
-      when(() => mockInviteCubit.state).thenReturn(
-        const InviteStatusState(
-          status: InviteStatusLoadingStatus.loaded,
-          inviteStatus: InviteStatus(
-            canInvite: true,
-            remaining: 0,
-            total: 1,
-            codes: [InviteCode(code: 'AB23-EF7K', claimed: false)],
-          ),
-        ),
-      );
-
-      await tester.pumpWidget(buildSubject(inviteCubit: mockInviteCubit));
-      await tester.pumpAndSettle();
-
-      expect(find.text('Invites'), findsOneWidget);
-      expect(find.text('1'), findsNothing);
-
-      await tester.pumpWidget(const SizedBox());
-      await tester.pump();
-    });
-
-    testWidgets('renders invite shortcut when invite capacity exists', (
-      tester,
-    ) async {
-      final mockInviteCubit = _MockInviteStatusCubit();
-      when(mockInviteCubit.load).thenAnswer((_) async {});
-      when(() => mockInviteCubit.state).thenReturn(
-        const InviteStatusState(
-          status: InviteStatusLoadingStatus.loaded,
-          inviteStatus: InviteStatus(
-            canInvite: true,
-            remaining: 5,
-            total: 5,
-            codes: [],
-          ),
-        ),
-      );
-
-      await tester.pumpWidget(buildSubject(inviteCubit: mockInviteCubit));
-      await tester.pumpAndSettle();
-
-      expect(find.text('Invites'), findsOneWidget);
-      expect(find.text('5'), findsOneWidget);
-
-      await tester.pumpWidget(const SizedBox());
-      await tester.pump();
-    });
-
     testWidgets(
-      'reveals invite shortcut immediately when lazy allocation arrives',
-      (tester) async {
+      'share action does not show an invite activity badge',
+      (
+        tester,
+      ) async {
         final mockInviteCubit = _MockInviteStatusCubit();
-        when(mockInviteCubit.load).thenAnswer((_) async {});
-        final states = StreamController<InviteStatusState>();
-        addTearDown(states.close);
-        whenListen(
-          mockInviteCubit,
-          states.stream,
-          initialState: const InviteStatusState(
-            status: InviteStatusLoadingStatus.loading,
-          ),
+        when(() => mockInviteCubit.state).thenReturn(
+          const InviteStatusState(status: InviteStatusLoadingStatus.error),
         );
 
         await tester.pumpWidget(buildSubject(inviteCubit: mockInviteCubit));
         await tester.pumpAndSettle();
-        expect(find.text('Invites'), findsNothing);
 
-        states.add(
-          const InviteStatusState(
-            status: InviteStatusLoadingStatus.loaded,
-            inviteStatus: InviteStatus(
-              canInvite: true,
-              remaining: 5,
-              total: 5,
-              codes: [],
-            ),
-          ),
-        );
-        await tester.pumpAndSettle();
-
-        expect(find.text('Invites'), findsOneWidget);
-        expect(find.text('5'), findsOneWidget);
+        expect(find.text(l10n.settingsShareDivine), findsOneWidget);
+        expect(find.text('1'), findsNothing);
+        expect(find.text('5'), findsNothing);
 
         await tester.pumpWidget(const SizedBox());
         await tester.pump();

--- a/mobile/test/widgets/settings_screen_test.dart
+++ b/mobile/test/widgets/settings_screen_test.dart
@@ -9,6 +9,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:invite_api_client/invite_api_client.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart' show UserProfile;
 import 'package:openvine/blocs/background_publish/background_publish_bloc.dart';
@@ -21,7 +22,6 @@ import 'package:openvine/features/feature_flags/screens/feature_flag_screen.dart
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/divine_video_draft.dart';
 import 'package:openvine/models/invite_availability.dart';
-import 'package:openvine/models/invite_models.dart' show OnboardingMode;
 import 'package:openvine/models/known_account.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/environment_provider.dart';
@@ -365,14 +365,21 @@ void main() {
       ) async {
         final mockInviteCubit = _MockInviteStatusCubit();
         when(() => mockInviteCubit.state).thenReturn(
-          const InviteStatusState(status: InviteStatusLoadingStatus.error),
+          const InviteStatusState(
+            status: InviteStatusLoadingStatus.loaded,
+            inviteStatus: InviteStatus(
+              canInvite: true,
+              remaining: 5,
+              total: 5,
+              codes: [],
+            ),
+          ),
         );
 
         await tester.pumpWidget(buildSubject(inviteCubit: mockInviteCubit));
         await tester.pumpAndSettle();
 
         expect(find.text(l10n.settingsShareDivine), findsOneWidget);
-        expect(find.text('1'), findsNothing);
         expect(find.text('5'), findsNothing);
 
         await tester.pumpWidget(const SizedBox());


### PR DESCRIPTION
## Problem

Invite codes are no longer part of open onboarding, so the conditional Invites chip disappeared from the Settings account header and left no in-app way to send Divine to a friend.

## Why this fix

Settings now always shows a localized **Share Divine with your friends** action in that slot. It opens the native share sheet with only `https://divine.video/download`; the recipient-facing page selects the appropriate stores for their device. The existing share wrapper supplies the popover anchor required on iPad.

The obsolete Settings invite-state warm-up, dead `hasInviteActivity` getter, invite badge, and orphaned `settingsInvites` localization are removed. The replacement label is translated in all 22 locales, and generated localization APIs and integration expectations are updated.

## Deliberately unchanged

The Invites screen and inbox invite banner remain available when invite onboarding is enabled.

This PR must remain unmerged until divinevideo/divine-web#641 is merged, deployed, and `https://divine.video/download` is manually confirmed to render the real download page. The current SPA fallback returns HTTP 200 even when that route renders an error, so a status check alone is insufficient.

## Verification

- `flutter analyze lib test integration_test`
- 69 focused settings, invite-status, inbox, share-entry-point, and localization tests
- `bash scripts/check_orphaned_arb_key_floor.sh`
- `python3 .agents/skills/check-l10n/scan_strings.py`
- pre-commit and pre-push hooks

Closes #7998