### PR TITLE
fix(dm): bound a NIP-04 DM's created_at so it cannot freeze the unread badge

### DIFF
--- a/mobile/packages/dm_repository/lib/src/dm_clock.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_clock.dart
@@ -1,0 +1,38 @@
+// ABOUTME: Snapshots the local clock and bounds self-asserted DM `created_at`
+// ABOUTME: values against it, so one forged or badly-skewed timestamp cannot
+// ABOUTME: poison local ordering, cursors, or read state.
+
+/// A snapshot of the local clock, used to bound self-asserted DM timestamps.
+///
+/// Nothing on either DM ingest path binds a message's `created_at` to real
+/// time. A NIP-59 rumor is unsigned — only the seal and wrap are bound — so its
+/// timestamp is chosen freely by whoever sent the wrap, and a kind-4's
+/// `created_at`, while signed, is signed by its own author. So both are bounded
+/// to local time before they reach any store.
+///
+/// Left unbounded, a single future-dated message pins its conversation above
+/// every honest one and, because the conversation upsert only follows the
+/// newest timestamp, permanently stops the thread's unread badge from flipping
+/// back. See #7343 (NIP-17) and #8001 (NIP-04).
+///
+/// The bound is one-sided: an implausibly *old* timestamp is handled separately
+/// by `DmSyncState.minPlausibleCreatedAt`, which defends a different failure (a
+/// truncated history drain) and must not interact with this one.
+class DmClock {
+  /// Creates a clock pinned to [nowSeconds] (unix seconds).
+  DmClock(this.nowSeconds);
+
+  /// Creates a clock pinned to the current local time.
+  DmClock.now() : nowSeconds = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+
+  /// The pinned local time, in unix seconds.
+  ///
+  /// Snapshotted once so every timestamp derived from one ingested event —
+  /// message row, conversation row, cursor — agrees, and so a loop over many
+  /// entries does not re-read the clock per iteration.
+  final int nowSeconds;
+
+  /// Returns [createdAt] bounded above by [nowSeconds].
+  int atMostNow(int createdAt) =>
+      createdAt > nowSeconds ? nowSeconds : createdAt;
+}

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -2513,6 +2513,27 @@ class DmRepository {
         return;
       }
 
+      // A kind-4's `created_at` is signed, but by its own author — nothing
+      // binds it to real time. Bound it once here, before any store sees it,
+      // the same way the NIP-17 rumor path does (#7343): the conversation
+      // upsert only follows the newest timestamp, so a future-dated value pins
+      // the thread to the top and stops its unread badge from ever flipping
+      // back. Every use below reads this local, never the raw event, so a
+      // later write site cannot reintroduce the gap. Placed after the replay
+      // check so a replayed event does not re-log the warning. #8001.
+      final clock = DmClock.now();
+      final persistedCreatedAt = clock.atMostNow(nip04Event.createdAt);
+      if (nip04Event.createdAt >
+          clock.nowSeconds + DmSyncState.maxFutureSkewSeconds) {
+        Log.warning(
+          'Clamped DM (kind ${EventKind.directMessage}) from '
+          '${nip04Event.pubkey}: event created_at ${nip04Event.createdAt} is '
+          'beyond the expected skew of ${DmSyncState.maxFutureSkewSeconds}s '
+          '(now ${clock.nowSeconds})',
+          category: LogCategory.system,
+        );
+      }
+
       // Extract recipient from p tag
       String? recipientPubkey;
       for (final tag in nip04Event.tags) {
@@ -2564,7 +2585,7 @@ class DmRepository {
         conversationId: conversationId,
         senderPubkey: senderPubkey,
         content: plaintext,
-        createdAt: nip04Event.createdAt,
+        createdAt: persistedCreatedAt,
         ownerPubkey: _userPubkey,
       );
       if (isDuplicate) {
@@ -2597,7 +2618,7 @@ class DmRepository {
           conversationId: conversationId,
           ownerPubkey: ownerPubkey,
         );
-        if (removedAt != null && nip04Event.createdAt <= removedAt!) {
+        if (removedAt != null && persistedCreatedAt <= removedAt!) {
           suppressedByRemovedConversation = true;
           return;
         }
@@ -2607,7 +2628,7 @@ class DmRepository {
           conversationId: conversationId,
           senderPubkey: senderPubkey,
           content: plaintext,
-          createdAt: nip04Event.createdAt,
+          createdAt: persistedCreatedAt,
           giftWrapId: nip04Event.id,
           messageKind: EventKind.directMessage,
           ownerPubkey: ownerPubkey,
@@ -2623,9 +2644,9 @@ class DmRepository {
           id: conversationId,
           participantPubkeys: jsonEncode(participants),
           isGroup: false,
-          createdAt: existing?.createdAt ?? nip04Event.createdAt,
+          createdAt: existing?.createdAt ?? persistedCreatedAt,
           lastMessageContent: plaintext,
-          lastMessageTimestamp: nip04Event.createdAt,
+          lastMessageTimestamp: persistedCreatedAt,
           lastMessageSenderPubkey: senderPubkey,
           isRead: isSentByMe,
           currentUserHasSent:
@@ -2655,7 +2676,7 @@ class DmRepository {
         await _recordProcessedWrap(nip04Event.id);
         Log.debug(
           'Suppressed NIP-04 DM ${nip04Event.id} in removed conversation '
-          '$conversationId: createdAt ${nip04Event.createdAt} is at or '
+          '$conversationId: createdAt $persistedCreatedAt is at or '
           'before removal at $removedAt',
           category: LogCategory.system,
         );
@@ -2676,17 +2697,18 @@ class DmRepository {
       }
 
       // NIP-04 created_at values are not randomized (unlike NIP-17 gift
-      // wraps) so the event timestamp is safe to use directly.
+      // wraps), so this bounded timestamp is a real send time and safe to
+      // record as a cursor.
       await _syncState?.recordSeen(
         _userPubkey,
-        createdAt: nip04Event.createdAt,
+        createdAt: persistedCreatedAt,
       );
 
       Log.debug(
         'Persisted NIP-04 DM ${nip04Event.id} '
         '(kind ${EventKind.directMessage}) in conversation '
         '$conversationId from $senderPubkey '
-        'createdAt=${nip04Event.createdAt}',
+        'createdAt=$persistedCreatedAt',
         category: LogCategory.system,
       );
     } on Object catch (e, stackTrace) {

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -15,6 +15,7 @@ import 'package:dm_repository/src/build_mode.dart';
 import 'package:dm_repository/src/collaborator_invite_recovery.dart';
 import 'package:dm_repository/src/compute.dart';
 import 'package:dm_repository/src/dm_batch_send_budget.dart';
+import 'package:dm_repository/src/dm_clock.dart';
 import 'package:dm_repository/src/dm_decrypt_isolate.dart';
 import 'package:dm_repository/src/dm_decryption_worker.dart';
 import 'package:dm_repository/src/dm_reactions_repository.dart';
@@ -1804,15 +1805,14 @@ class DmRepository {
       // sender. Keep the message, but clamp the timestamp used for local
       // ordering/cursors so a bad clock cannot blackhole future subscriptions
       // or pin the thread above honest messages forever.
-      final nowSec = DateTime.now().millisecondsSinceEpoch ~/ 1000;
-      final persistedCreatedAt = rumor.createdAt > nowSec
-          ? nowSec
-          : rumor.createdAt;
-      if (rumor.createdAt > nowSec + DmSyncState.maxFutureSkewSeconds) {
+      final clock = DmClock.now();
+      final persistedCreatedAt = clock.atMostNow(rumor.createdAt);
+      if (rumor.createdAt >
+          clock.nowSeconds + DmSyncState.maxFutureSkewSeconds) {
         Log.warning(
           'Clamped DM (kind ${rumor.kind}) from ${rumor.pubkey}: rumor '
           'created_at ${rumor.createdAt} is beyond the expected skew of '
-          '${DmSyncState.maxFutureSkewSeconds}s (now $nowSec)',
+          '${DmSyncState.maxFutureSkewSeconds}s (now ${clock.nowSeconds})',
           category: LogCategory.system,
         );
       }
@@ -5632,12 +5632,12 @@ class DmRepository {
     // undone: one marker published by a device with a corrupt clock would pin
     // every conversation read for good. Clamp to the local clock, the same way
     // an incoming rumor's own created_at is clamped for ordering. #7343.
-    final nowSec = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+    final clock = DmClock.now();
     for (final entry in read.entries) {
       final tupleKey = entry.key;
       final ts = entry.value;
       if (tupleKey is! String || ts is! int) continue;
-      final cursor = ts > nowSec ? nowSec : ts;
+      final cursor = clock.atMostNow(ts);
       final pubkeys = tupleKey.split(',');
       if (pubkeys.length < 2) continue;
       final conversationId = computeConversationId(pubkeys);

--- a/mobile/packages/dm_repository/test/src/dm_clock_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_clock_test.dart
@@ -1,0 +1,47 @@
+// ABOUTME: Unit coverage for DmClock, the one-sided bound applied to
+// ABOUTME: self-asserted DM `created_at` values on both ingest paths.
+
+import 'package:dm_repository/src/dm_clock.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group(DmClock, () {
+    const nowSeconds = 1700000000;
+
+    group('atMostNow', () {
+      test('passes an honestly-dated timestamp through unchanged', () {
+        expect(
+          DmClock(nowSeconds).atMostNow(nowSeconds - 3600),
+          equals(nowSeconds - 3600),
+        );
+      });
+
+      test('passes a timestamp equal to now through unchanged', () {
+        expect(DmClock(nowSeconds).atMostNow(nowSeconds), nowSeconds);
+      });
+
+      test('bounds a timestamp one second into the future', () {
+        expect(DmClock(nowSeconds).atMostNow(nowSeconds + 1), nowSeconds);
+      });
+
+      test('bounds a far-future timestamp to now', () {
+        // Year 2100.
+        expect(DmClock(nowSeconds).atMostNow(4102444800), nowSeconds);
+      });
+
+      test('does not raise an implausibly old timestamp', () {
+        // The bound is one-sided: the history-drain floor is a separate
+        // defence and must not be applied here.
+        expect(DmClock(nowSeconds).atMostNow(1), equals(1));
+      });
+    });
+
+    test('now() pins to the local wall clock', () {
+      final before = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+      final clock = DmClock.now();
+      final after = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+
+      expect(clock.nowSeconds, inInclusiveRange(before, after));
+    });
+  });
+}

--- a/mobile/packages/dm_repository/test/src/dm_future_dated_created_at_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_future_dated_created_at_test.dart
@@ -1,0 +1,177 @@
+// ABOUTME: Regression coverage for #8001 — a future-dated NIP-04 DM must not
+// ABOUTME: raise the conversation's last_message_timestamp above now, because
+// ABOUTME: the upsert's read gate would then never flip it unread again.
+
+import 'dart:async';
+
+import 'package:db_client/db_client.dart';
+import 'package:dm_repository/dm_repository.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:nostr_sdk/event_kind.dart';
+import 'package:nostr_sdk/signer/local_nostr_signer.dart';
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+const _owner =
+    'a4f5c1b2d3e4f5061728394a5b6c7d8e9f0a1b2c3d4e5f60718293a4b5c6d7e8';
+const _peer =
+    'b1c2d3e4f5061728394a5b6c7d8e9f0a1b2c3d4e5f60718293a4b5c6d7e8f9a0';
+const _privateKey =
+    '5426e5b8b4b0e2a1f5e8d3c7a9b2f4e6d8c0a2b4f6e8d0c2a4b6f8e0d2c4a6b8';
+
+// Year 2100 — unconditionally beyond any plausible clock skew.
+const _year2100 = 4102444800;
+
+void main() {
+  group('a future-dated NIP-04 DM cannot freeze the unread badge', () {
+    late AppDatabase db;
+    late ConversationsDao conversationsDao;
+    late DirectMessagesDao messagesDao;
+    late _MockNostrClient nostrClient;
+    late StreamController<Event> relay;
+    late DmRepository repository;
+
+    setUp(() async {
+      db = AppDatabase.test(NativeDatabase.memory());
+      conversationsDao = ConversationsDao(db);
+      messagesDao = DirectMessagesDao(db);
+      nostrClient = _MockNostrClient();
+      relay = StreamController<Event>();
+
+      when(() => nostrClient.connectedRelayCount).thenReturn(1);
+      when(() => nostrClient.configuredRelayCount).thenReturn(1);
+      when(
+        () => nostrClient.queryEvents(
+          any(),
+          subscriptionId: any(named: 'subscriptionId'),
+          useCache: any(named: 'useCache'),
+        ),
+      ).thenAnswer((_) async => const <Event>[]);
+      when(() => nostrClient.unsubscribe(any())).thenAnswer((_) async {});
+      when(
+        () => nostrClient.subscribe(
+          any(),
+          subscriptionId: any(named: 'subscriptionId'),
+          tempRelays: any(named: 'tempRelays'),
+          targetRelays: any(named: 'targetRelays'),
+        ),
+      ).thenAnswer((_) => relay.stream);
+
+      repository = DmRepository(
+        nostrClient: nostrClient,
+        directMessagesDao: messagesDao,
+        conversationsDao: conversationsDao,
+        userPubkey: _owner,
+        signer: LocalNostrSigner(_privateKey),
+        // Every kind 4 in this group decrypts to its own ciphertext, so the
+        // cross-protocol dedup window never collapses two distinct messages.
+        nip04Decryptor: (_, ciphertext) async => ciphertext,
+      );
+      await repository.startListening();
+    });
+
+    tearDown(() async {
+      // stopListening() before closing the stream: onDone would otherwise arm
+      // a reconnect timer that outlives this test.
+      await repository.stopListening();
+      await relay.close();
+      await db.close();
+    });
+
+    /// Feeds one kind 4 addressed to the owner through the live subscription
+    /// and waits for the serialized ingest to drain.
+    Future<void> deliver({required String id, required int createdAt}) async {
+      relay.add(
+        Event.fromJson({
+          'id': id,
+          'pubkey': _peer,
+          'created_at': createdAt,
+          'kind': EventKind.directMessage,
+          'tags': [
+            ['p', _owner],
+          ],
+          'content': 'ciphertext-$id',
+          'sig': '',
+        }),
+      );
+      for (var i = 0; i < 8; i++) {
+        await Future<void>.delayed(Duration.zero);
+      }
+    }
+
+    /// Waits until the local clock crosses into the next second.
+    ///
+    /// Nostr timestamps are second-resolution and the DAO's read gate is a
+    /// strict `>`, so a bounded forged message and an honest one delivered in
+    /// the same second are indistinguishable to it. Bounded by one second.
+    Future<void> nextSecond() async {
+      final start = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+      while (DateTime.now().millisecondsSinceEpoch ~/ 1000 == start) {
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+      }
+    }
+
+    final conversationId = DmRepository.computeConversationId([_owner, _peer]);
+
+    Future<ConversationRow> conversation() async {
+      final row = await conversationsDao.getConversation(
+        conversationId,
+        ownerPubkey: _owner,
+      );
+      return row!;
+    }
+
+    test('its timestamp is bounded to now on the conversation row', () async {
+      await deliver(id: 'a' * 64, createdAt: _year2100);
+
+      final nowSec = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+      final row = await conversation();
+      expect(row.lastMessageTimestamp, closeTo(nowSec, 5));
+      expect(row.createdAt, closeTo(nowSec, 5));
+    });
+
+    test(
+      'a later genuine message still flips the thread back to unread',
+      () async {
+        // The user-visible failure: once last_message_timestamp holds a forged
+        // future value, `incomingIsNewer` is false for every honest message
+        // that follows, so is_read is never cleared and the preview freezes.
+        await deliver(id: 'a' * 64, createdAt: _year2100);
+        await conversationsDao.markAsRead(conversationId, ownerPubkey: _owner);
+        expect((await conversation()).isRead, isTrue);
+
+        await nextSecond();
+        await deliver(
+          id: 'b' * 64,
+          createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+        );
+
+        final row = await conversation();
+        expect(row.isRead, isFalse);
+        expect(row.lastMessageContent, 'ciphertext-${'b' * 64}');
+      },
+    );
+
+    test('the read cursor is not dragged into the future', () async {
+      await deliver(id: 'a' * 64, createdAt: _year2100);
+      await conversationsDao.markAsRead(conversationId, ownerPubkey: _owner);
+
+      final nowSec = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+      expect((await conversation()).lastReadTimestamp, closeTo(nowSec, 5));
+    });
+
+    test('an honestly-dated message keeps its own timestamp', () async {
+      const sentAt = 1700000000;
+      await deliver(id: 'c' * 64, createdAt: sentAt);
+
+      final row = await conversation();
+      expect(row.lastMessageTimestamp, sentAt);
+      final message = await messagesDao.getMessageById('c' * 64);
+      expect(message!.createdAt, sentAt);
+    });
+  });
+}


### PR DESCRIPTION
## Description

`#7343` bounded the timestamp a NIP-59 rumor contributes to local ordering, because a rumor is unsigned and its `created_at` is chosen freely by whoever sent the wrap. A kind 4's `created_at` **is** signed — but by its own author, which binds it to real time no more than an unsigned rumor does. `_handleNip04Event` had no bound at all and wrote the raw value into the message row, both conversation timestamps, the removed-conversation tombstone comparison, and the sync cursor.

The conversation row is the one that hurts. `upsertConversation` only follows the newest message:

```dart
// conversations_dao.dart:118
isRead: excl.isRead.iif(incomingIsNewer, old.isRead),
```

so once `last_message_timestamp` holds a far-future value, every later genuine message — NIP-17 or NIP-04 — fails `incomingIsNewer`. The thread stops flipping to unread, its preview and last-message sender freeze, and it sorts to the top permanently. Opening it once also drags the `#4977` cross-device read cursor up to the forged time, so the damage outlives the local row.

**Two commits:**

1. **`refactor(dm)`** — extract the bound into `DmClock`. Three sites had reimplemented `x > nowSec ? nowSec : x` inline (NIP-17 ingest, read-cursor reconcile) or lacked it entirely (NIP-04 ingest). `DmClock` snapshots now once and exposes both `nowSeconds` (for the skew warning) and `atMostNow`. No behavior change; kept out of the package barrel since nothing above the repository needs it.

2. **`fix(dm)`** — apply it on the NIP-04 path. The bounded value is bound to one local right after the replay check, and every use below reads that local rather than the raw event, so a write site added to this handler later cannot reintroduce the gap. The skew warning now matches the NIP-17 path, which otherwise left this defence completely silent.

**Exploitability, stated so this is not over-triaged:** not reachable through `relay.divine.video` today — funnelcake rejects a `created_at` more than `max_created_at_drift_seconds` (default 60) ahead, and a kind 4's outer `created_at` is the one it checks. The remaining vector is a DM inbox relay from the user's own kind-10050 that is more permissive. Defence in depth, but the asymmetry between the two ingest paths was real, and the guarded path already documents exactly why the guard is needed.

**Behavior is unchanged** for honest timestamps, and for the tombstone comparison: a removal time is always in the past, so a future-dated event counts as newer than the removal whether or not it is bounded.

**Related Issue:** Closes #8001

## Out of Scope

- `DmSyncState.recordSeen` and `repairPoisonedBoundaries` already clamp, so the *subscription blackhole* half of this hazard was covered on both protocols. Untouched.
- `#7643` is the same root shape (an unbounded relay-supplied `created_at`) on the replaceable-event **publish** side. Different code paths; the shared-helper idea is worth landing there consistently, but not here.

## Verification

From `mobile/packages/dm_repository`:

- `flutter analyze lib test` — clean
- `flutter test` — 640 passing
- `flutter test --coverage` — 93.93%, above this package's `min_coverage: 93` gate; `dm_clock.dart` at 4/4 lines
- `dart format --output=none --set-exit-if-changed lib test` — clean

From `mobile`:

- `flutter analyze lib test integration_test` — clean
- `bash scripts/check_nostr_id_log_truncation.sh` — still frozen at 0

**The regression test was proven to fail without the fix.** With commit 2's `lib` change reverted, three of its four cases go red for the right reasons:

| Case | Without the fix |
|---|---|
| bounded on the conversation row | `Expected: within <5> of <1787290614>` / `Actual: <4102444800>` |
| a later genuine message re-flips unread | `Expected: false` / `Actual: <true>` |
| read cursor not dragged into the future | `Expected: within <5> of <1787290615>` / `Actual: <4102444800>` |
| an honest timestamp is kept as-is | passes both ways — the over-clamp guard |

It drives real Drift DAOs (`AppDatabase.test(NativeDatabase.memory())`) rather than mocks, so the assertion is the user-visible outcome — the badge flips — not that a particular argument reached a mock.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] 🧹 Code refactor
