### PR TITLE
fix(nostr): release subscription slots after bounded reads

### DIFF
--- a/mobile/integration_test/helpers/test_nostr_service.dart
+++ b/mobile/integration_test/helpers/test_nostr_service.dart
@@ -145,6 +145,7 @@ class TestNostrService implements NostrClient {
     List<int> relayTypes = const [],
     bool sendAfterAuth = false,
     void Function()? onEose,
+    bool closeOnEose = false,
   }) {
     final subId =
         subscriptionId ?? 'test_sub_${DateTime.now().millisecondsSinceEpoch}';

--- a/mobile/lib/constants/app_constants.dart
+++ b/mobile/lib/constants/app_constants.dart
@@ -160,9 +160,6 @@ class AppConstants {
   /// Connection timeout for relay connections
   static const Duration relayConnectionTimeout = Duration(seconds: 30);
 
-  /// Maximum subscription limit per relay
-  static const int maxSubscriptionsPerRelay = 100;
-
   // ============================================================================
   // UI CONFIGURATION
   // ============================================================================

--- a/mobile/lib/providers/list_providers.dart
+++ b/mobile/lib/providers/list_providers.dart
@@ -4,7 +4,8 @@
 import 'dart:async';
 
 import 'package:models/models.dart' hide LogCategory;
-import 'package:nostr_client/nostr_client.dart' show NostrClient;
+import 'package:nostr_client/nostr_client.dart'
+    show NostrClient, RelaySubscriptionRefusedException;
 import 'package:nostr_sdk/filter.dart';
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
 import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
@@ -246,9 +247,18 @@ Stream<List<CuratedList>> publicListsContainingVideo(
   // Yield an initial value to avoid hanging if the stream is empty
   yield const <CuratedList>[];
 
-  // Stream events from Nostr relays, accumulating as they arrive
+  // Stream events from Nostr relays, accumulating as they arrive. A refusal
+  // from every relay ends the read; keep what already arrived.
   await for (final CuratedList list
-      in curatedListStream ?? const Stream.empty()) {
+      in curatedListStream?.handleError(
+            (Object error) => Log.warning(
+              '📋 Relay refused public list stream: $error',
+              name: 'PublicListsContainingVideo',
+              category: LogCategory.video,
+            ),
+            test: (error) => error is RelaySubscriptionRefusedException,
+          ) ??
+          const Stream.empty()) {
     if (!seenIds.contains(list.id)) {
       seenIds.add(list.id);
       accumulated.add(list);
@@ -481,7 +491,18 @@ Stream<List<VideoEvent>> _curatedListVideoEvents({
     if (nostrClient == null) return;
 
     if (filters.isNotEmpty) {
-      final eventStream = nostrClient.subscribe(filters, closeOnEose: true);
+      // A refusal from every relay closes the read early. Log it and keep the
+      // videos already resolved rather than failing the whole provider.
+      final eventStream = nostrClient
+          .subscribe(filters, closeOnEose: true)
+          .handleError(
+            (Object error) => Log.warning(
+              '📋 Relay refused video fetch: $error',
+              name: 'CuratedListVideoEvents',
+              category: LogCategory.video,
+            ),
+            test: (error) => error is RelaySubscriptionRefusedException,
+          );
       final seenIds = foundVideos.map((v) => v.id.toLowerCase()).toSet();
 
       await for (final event in eventStream) {
@@ -704,7 +725,18 @@ Stream<List<VideoEvent>> _videoEventsByIds({
     if (nostrClient == null) return;
 
     if (filters.isNotEmpty) {
-      final eventStream = nostrClient.subscribe(filters, closeOnEose: true);
+      // A refusal from every relay closes the read early. Log it and keep the
+      // videos already resolved rather than failing the whole provider.
+      final eventStream = nostrClient
+          .subscribe(filters, closeOnEose: true)
+          .handleError(
+            (Object error) => Log.warning(
+              '📋 Relay refused video fetch: $error',
+              name: 'VideoEventsByIds',
+              category: LogCategory.video,
+            ),
+            test: (error) => error is RelaySubscriptionRefusedException,
+          );
       final seenIds = foundVideos.map((v) => v.id.toLowerCase()).toSet();
 
       await for (final event in eventStream) {

--- a/mobile/lib/providers/list_providers.dart
+++ b/mobile/lib/providers/list_providers.dart
@@ -481,7 +481,7 @@ Stream<List<VideoEvent>> _curatedListVideoEvents({
     if (nostrClient == null) return;
 
     if (filters.isNotEmpty) {
-      final eventStream = nostrClient.subscribe(filters);
+      final eventStream = nostrClient.subscribe(filters, closeOnEose: true);
       final seenIds = foundVideos.map((v) => v.id.toLowerCase()).toSet();
 
       await for (final event in eventStream) {
@@ -704,7 +704,7 @@ Stream<List<VideoEvent>> _videoEventsByIds({
     if (nostrClient == null) return;
 
     if (filters.isNotEmpty) {
-      final eventStream = nostrClient.subscribe(filters);
+      final eventStream = nostrClient.subscribe(filters, closeOnEose: true);
       final seenIds = foundVideos.map((v) => v.id.toLowerCase()).toSet();
 
       await for (final event in eventStream) {

--- a/mobile/lib/providers/list_providers.g.dart
+++ b/mobile/lib/providers/list_providers.g.dart
@@ -489,7 +489,7 @@ final class PublicListsContainingVideoProvider
 }
 
 String _$publicListsContainingVideoHash() =>
-    r'904b7d295bc60b70f320aeaf59b2d56d88522306';
+    r'b8c596353975f2448715a57f63e10f048a273fd3';
 
 /// Provider that streams public lists containing a specific video
 /// Accumulates results as they arrive from Nostr relays, yielding updated list

--- a/mobile/lib/services/curated_list_relay_gateway.dart
+++ b/mobile/lib/services/curated_list_relay_gateway.dart
@@ -263,6 +263,7 @@ class CuratedListRelayGateway {
         try {
           final subscription = _nostrService.subscribe(
             [filter],
+            closeOnEose: true,
             onEose: () {
               Log.info(
                 '📋 EOSE received for public curated lists: '
@@ -402,7 +403,10 @@ class CuratedListRelayGateway {
       );
 
       // Subscribe to matching events
-      final subscription = _nostrService.subscribe([filter]);
+      final subscription = _nostrService.subscribe(
+        [filter],
+        closeOnEose: true,
+      );
 
       // Set a timeout for the subscription
       timeoutTimer = Timer(const Duration(seconds: 10), () {
@@ -522,7 +526,7 @@ class CuratedListRelayGateway {
 
     // Subscribe and transform events to CuratedList objects
     return _nostrService
-        .subscribe([filter])
+        .subscribe([filter], closeOnEose: true)
         .map((event) {
           final dTag = CuratedListConverter.extractDTag(event);
           if (dTag == null) return null;

--- a/mobile/lib/services/subscribed_list_video_cache.dart
+++ b/mobile/lib/services/subscribed_list_video_cache.dart
@@ -318,6 +318,16 @@ class SubscribedListVideoCache extends ChangeNotifier {
         name: 'SubscribedListVideoCache',
         category: LogCategory.video,
       );
+    } on RelaySubscriptionRefusedException catch (e) {
+      // Every relay refused the REQ. Keep whatever arrived before that; the
+      // caller runs from an unawaited microtask, so rethrowing here would
+      // reach the zone as an uncaught async error.
+      Log.warning(
+        'Relay refused list video fetch (${e.reason}) - '
+        'processed ${seenIds.length} events',
+        name: 'SubscribedListVideoCache',
+        category: LogCategory.video,
+      );
     }
   }
 }

--- a/mobile/lib/services/subscribed_list_video_cache.dart
+++ b/mobile/lib/services/subscribed_list_video_cache.dart
@@ -282,7 +282,7 @@ class SubscribedListVideoCache extends ChangeNotifier {
 
     if (filters.isEmpty) return;
 
-    final eventStream = _nostrService.subscribe(filters);
+    final eventStream = _nostrService.subscribe(filters, closeOnEose: true);
     final seenIds = <String>{};
 
     // Use 3 second timeout for relay fetches (faster initial load)

--- a/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
+++ b/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
@@ -1187,8 +1187,19 @@ class ContentBlocklistRepository {
       _mutualMuteSubscriptionId =
           'mutual-mute-${DateTime.now().millisecondsSinceEpoch}';
 
-      // Listen to the stream
-      subscription.listen(_handleMuteListEvent);
+      // Listen to the stream. A relay that refuses the REQ surfaces a stream
+      // error; without onError it would escape to the zone as an uncaught
+      // async error, because the try/catch here only covers the setup.
+      subscription.listen(
+        _handleMuteListEvent,
+        onError: (Object error) {
+          Log.warning(
+            'Mutual mute subscription ended: $error',
+            name: 'ContentBlocklistRepository',
+            category: LogCategory.system,
+          );
+        },
+      );
 
       Log.info(
         'Mutual mute subscription created: $_mutualMuteSubscriptionId',
@@ -1262,7 +1273,18 @@ class ContentBlocklistRepository {
       // Others' block lists that include our pubkey.
       final othersFilter = Filter(kinds: const [30000])..p = [ourPubkey];
 
-      nostrService.subscribe([othersFilter]).listen(_handleBlockListEvent);
+      nostrService
+          .subscribe([othersFilter])
+          .listen(
+            _handleBlockListEvent,
+            onError: (Object error) {
+              Log.warning(
+                'Block list subscription ended: $error',
+                name: 'ContentBlocklistRepository',
+                category: LogCategory.system,
+              );
+            },
+          );
 
       _blockListSyncStarted = true;
       _blockListSyncClient = nostrService;

--- a/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
+++ b/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
@@ -1783,7 +1783,19 @@ class _AuthorListWatch {
           .subscribe([
             Filter(authors: _authors.toList(), kinds: [_kind]),
           ], subscriptionId: id)
-          .listen(onEvent);
+          .listen(
+            onEvent,
+            // A relay that refuses this REQ surfaces a stream error, and the
+            // try/catch here only covers the setup. Without onError it would
+            // escape to the zone as an uncaught async error.
+            onError: (Object error) {
+              Log.warning(
+                '$_label author watch ended: $error',
+                name: 'ContentBlocklistRepository',
+                category: LogCategory.system,
+              );
+            },
+          );
 
       Log.info(
         'Watching ${_authors.length} $_label author(s) by author id',

--- a/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
+++ b/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
@@ -2154,6 +2154,37 @@ void main() {
       expect(service.blockedPubkeysForAccount(ourPubkey), isEmpty);
     });
 
+    test(
+      'a refused relay subscription does not become an uncaught error',
+      () async {
+        SharedPreferences.setMockInitialValues(<String, Object>{});
+        final prefs = await SharedPreferences.getInstance();
+        final service = ContentBlocklistRepository(prefs: prefs);
+        final mockClient = _MockNostrClient();
+        when(() => mockClient.subscribe(any())).thenAnswer(
+          (_) => Stream<Event>.error(
+            const RelaySubscriptionRefusedException(
+              'error: too many subscriptions',
+            ),
+          ),
+        );
+
+        // Both syncs listen without awaiting. Without an onError handler the
+        // stream error reaches the zone and is reported as a crash.
+        await service.syncMuteListsInBackground(mockClient, ourPubkey);
+        final mockSigner = _MockBlockListSigner();
+        when(() => mockSigner.isAuthenticated).thenReturn(false);
+        await service.syncBlockListsInBackground(
+          mockClient,
+          mockSigner,
+          ourPubkey,
+        );
+        await pumpEventQueue();
+
+        expect(service.blockedPubkeysForAccount(ourPubkey), isEmpty);
+      },
+    );
+
     test('is empty for the empty pubkey', () async {
       SharedPreferences.setMockInitialValues(<String, Object>{});
       final prefs = await SharedPreferences.getInstance();

--- a/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
+++ b/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
@@ -3760,6 +3760,52 @@ void main() {
       ..sig = 'signature';
 
     test(
+      'a refused by-author watch does not become an uncaught error',
+      () async {
+        // The by-author watch is a long-lived REQ. A relay that runs out of
+        // subscription slots ends it with CLOSED, which reaches the stream as
+        // an error; without an onError handler it escapes to the zone.
+        when(
+          () => mockNostrService.subscribe(
+            any(),
+            subscriptionId: any(
+              named: 'subscriptionId',
+              that: contains('author-watch'),
+            ),
+          ),
+        ).thenAnswer(
+          (_) => Stream<Event>.error(
+            const RelaySubscriptionRefusedException(
+              'error: too many subscriptions',
+            ),
+          ),
+        );
+
+        final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+        relay.publish(
+          listEvent(
+            30000,
+            [
+              ['d', 'block'],
+              ['p', ourPubkey],
+            ],
+            createdAt: now,
+            id: 'block-event',
+          ),
+        );
+
+        await service.syncBlockListsInBackground(
+          mockNostrService,
+          mockSigner,
+          ourPubkey,
+        );
+        await pumpEventQueue();
+
+        expect(service.hasBlockedUs(blockerPubkey), isTrue);
+      },
+    );
+
+    test(
       'hasBlockedUs clears when the blocker republishes a kind-30000 list '
       'that no longer tags us',
       () async {

--- a/mobile/packages/nostr_client/lib/src/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/src/nostr_client.dart
@@ -13,6 +13,18 @@ import 'package:nostr_sdk/nostr_sdk.dart';
 import 'package:nostr_sdk/utils/hash_util.dart';
 import 'package:pool/pool.dart';
 
+/// The relay ended a live subscription before the client unsubscribed.
+class RelaySubscriptionRefusedException implements Exception {
+  /// Creates an exception preserving the relay-provided [reason].
+  const RelaySubscriptionRefusedException(this.reason);
+
+  /// The reason supplied by the relay's `CLOSED` frame.
+  final String reason;
+
+  @override
+  String toString() => 'RelaySubscriptionRefusedException: $reason';
+}
+
 /// Observer for NostrClient activity statistics.
 ///
 /// Implement this interface and set it via [NostrClient.statisticsObserver]
@@ -1172,6 +1184,12 @@ class NostrClient {
   /// re-enter safely after a previous listener was canceled. The returned
   /// stream is closed when its last listener cancels; call [subscribe] again
   /// instead of retaining and re-listening to the old stream.
+  ///
+  /// Set [closeOnEose] for bounded reads. Their stream closes after every
+  /// serving relay reports EOSE, and the relay subscription is released.
+  ///
+  /// The stream emits a [RelaySubscriptionRefusedException] if every serving
+  /// relay ends the REQ with `CLOSED`.
   Stream<Event> subscribe(
     List<Filter> filters, {
     String? subscriptionId,
@@ -1180,6 +1198,7 @@ class NostrClient {
     List<int> relayTypes = RelayType.all,
     bool sendAfterAuth = false,
     void Function()? onEose,
+    bool closeOnEose = false,
   }) {
     final effectiveTempRelays = _allowedRelays(tempRelays);
     final effectiveTargetRelays = _allowedRelays(targetRelays);
@@ -1250,7 +1269,16 @@ class NostrClient {
       targetRelays: effectiveTargetRelays,
       relayTypes: relayTypes,
       sendAfterAuth: sendAfterAuth,
-      onEose: onEose,
+      onEose: () {
+        onEose?.call();
+        if (closeOnEose) cleanupSubscription();
+      },
+      onClosed: (reason) {
+        if (!controller.isClosed) {
+          controller.addError(RelaySubscriptionRefusedException(reason));
+        }
+        cleanupSubscription();
+      },
     );
 
     // If nostr_sdk generated a different ID, update our mapping

--- a/mobile/packages/nostr_client/test/src/nostr_client_test.dart
+++ b/mobile/packages/nostr_client/test/src/nostr_client_test.dart
@@ -1831,6 +1831,7 @@ void main() {
             relayTypes: any(named: 'relayTypes'),
             sendAfterAuth: any(named: 'sendAfterAuth'),
             onEose: any(named: 'onEose'),
+            onClosed: any(named: 'onClosed'),
           ),
         ).thenReturn('test-sub-id');
 
@@ -1848,6 +1849,7 @@ void main() {
             relayTypes: any(named: 'relayTypes'),
             sendAfterAuth: any(named: 'sendAfterAuth'),
             onEose: any(named: 'onEose'),
+            onClosed: any(named: 'onClosed'),
           ),
         ).captured.single;
         return captured as void Function(Event);
@@ -2110,6 +2112,7 @@ void main() {
             relayTypes: any(named: 'relayTypes'),
             sendAfterAuth: any(named: 'sendAfterAuth'),
             onEose: any(named: 'onEose'),
+            onClosed: any(named: 'onClosed'),
           ),
         ).thenReturn('test-sub-id');
 
@@ -2126,8 +2129,129 @@ void main() {
             relayTypes: any(named: 'relayTypes'),
             sendAfterAuth: any(named: 'sendAfterAuth'),
             onEose: any(named: 'onEose'),
+            onClosed: any(named: 'onClosed'),
           ),
         ).called(1);
+      });
+
+      test(
+        'closeOnEose releases the relay subscription and closes the stream',
+        () async {
+          void Function()? onEose;
+          when(
+            () => mockNostr.subscribe(
+              any(),
+              any(),
+              id: any(named: 'id'),
+              tempRelays: any(named: 'tempRelays'),
+              targetRelays: any(named: 'targetRelays'),
+              relayTypes: any(named: 'relayTypes'),
+              sendAfterAuth: any(named: 'sendAfterAuth'),
+              onEose: any(named: 'onEose'),
+              onClosed: any(named: 'onClosed'),
+            ),
+          ).thenAnswer((invocation) {
+            onEose = invocation.namedArguments[#onEose] as void Function()?;
+            return invocation.namedArguments[#id] as String;
+          });
+          when(() => mockNostr.unsubscribe(any())).thenReturn(null);
+
+          final stream = client.subscribe(
+            [
+              Filter(kinds: [EventKind.textNote]),
+            ],
+            closeOnEose: true,
+          );
+          final done = expectLater(stream, emitsDone);
+
+          onEose!();
+
+          await done;
+          verify(() => mockNostr.unsubscribe(any())).called(1);
+          expect(client.activeSubscriptionCount, 0);
+        },
+      );
+
+      test('EOSE preserves long-lived subscriptions by default', () async {
+        void Function()? onEose;
+        when(
+          () => mockNostr.subscribe(
+            any(),
+            any(),
+            id: any(named: 'id'),
+            tempRelays: any(named: 'tempRelays'),
+            targetRelays: any(named: 'targetRelays'),
+            relayTypes: any(named: 'relayTypes'),
+            sendAfterAuth: any(named: 'sendAfterAuth'),
+            onEose: any(named: 'onEose'),
+            onClosed: any(named: 'onClosed'),
+          ),
+        ).thenAnswer((invocation) {
+          onEose = invocation.namedArguments[#onEose] as void Function()?;
+          return invocation.namedArguments[#id] as String;
+        });
+        when(() => mockNostr.unsubscribe(any())).thenReturn(null);
+
+        var done = false;
+        final subscription = client
+            .subscribe([
+              Filter(kinds: [EventKind.textNote]),
+            ])
+            .listen((_) {}, onDone: () => done = true);
+
+        onEose!();
+        await pumpEventQueue();
+
+        expect(done, isFalse);
+        expect(client.activeSubscriptionCount, 1);
+        verifyNever(() => mockNostr.unsubscribe(any()));
+        await subscription.cancel();
+      });
+
+      test('CLOSED surfaces its reason as a typed stream error', () async {
+        void Function(String reason)? onClosed;
+        when(
+          () => mockNostr.subscribe(
+            any(),
+            any(),
+            id: any(named: 'id'),
+            tempRelays: any(named: 'tempRelays'),
+            targetRelays: any(named: 'targetRelays'),
+            relayTypes: any(named: 'relayTypes'),
+            sendAfterAuth: any(named: 'sendAfterAuth'),
+            onEose: any(named: 'onEose'),
+            onClosed: any(named: 'onClosed'),
+          ),
+        ).thenAnswer((invocation) {
+          onClosed =
+              invocation.namedArguments[#onClosed]
+                  as void Function(String reason)?;
+          return invocation.namedArguments[#id] as String;
+        });
+        when(() => mockNostr.unsubscribe(any())).thenReturn(null);
+
+        final stream = client.subscribe([
+          Filter(kinds: [EventKind.textNote]),
+        ]);
+        final expectation = expectLater(
+          stream,
+          emitsInOrder([
+            emitsError(
+              isA<RelaySubscriptionRefusedException>().having(
+                (error) => error.reason,
+                'reason',
+                'error: too many subscriptions',
+              ),
+            ),
+            emitsDone,
+          ]),
+        );
+
+        onClosed!('error: too many subscriptions');
+
+        await expectation;
+        verify(() => mockNostr.unsubscribe(any())).called(1);
+        expect(client.activeSubscriptionCount, 0);
       });
 
       test('creates new subscription for different filters', () {
@@ -2148,6 +2272,7 @@ void main() {
             relayTypes: any(named: 'relayTypes'),
             sendAfterAuth: any(named: 'sendAfterAuth'),
             onEose: any(named: 'onEose'),
+            onClosed: any(named: 'onClosed'),
           ),
         ).thenReturn('test-sub-id');
 
@@ -2166,6 +2291,7 @@ void main() {
             relayTypes: any(named: 'relayTypes'),
             sendAfterAuth: any(named: 'sendAfterAuth'),
             onEose: any(named: 'onEose'),
+            onClosed: any(named: 'onClosed'),
           ),
         ).called(2);
       });
@@ -2186,6 +2312,7 @@ void main() {
             relayTypes: any(named: 'relayTypes'),
             sendAfterAuth: any(named: 'sendAfterAuth'),
             onEose: any(named: 'onEose'),
+            onClosed: any(named: 'onClosed'),
           ),
         ).thenAnswer((invocation) {
           final id = invocation.namedArguments[#id] as String;
@@ -2209,6 +2336,7 @@ void main() {
             relayTypes: any(named: 'relayTypes'),
             sendAfterAuth: any(named: 'sendAfterAuth'),
             onEose: any(named: 'onEose'),
+            onClosed: any(named: 'onClosed'),
           ),
         ).called(2);
       });
@@ -2230,6 +2358,7 @@ void main() {
               relayTypes: any(named: 'relayTypes'),
               sendAfterAuth: any(named: 'sendAfterAuth'),
               onEose: any(named: 'onEose'),
+              onClosed: any(named: 'onClosed'),
             ),
           ).thenAnswer(
             (invocation) => invocation.namedArguments[#id] as String,
@@ -2261,6 +2390,7 @@ void main() {
             relayTypes: any(named: 'relayTypes'),
             sendAfterAuth: any(named: 'sendAfterAuth'),
             onEose: any(named: 'onEose'),
+            onClosed: any(named: 'onClosed'),
           ),
         ).thenAnswer(
           (invocation) => invocation.namedArguments[#id] as String,
@@ -2291,6 +2421,7 @@ void main() {
             relayTypes: any(named: 'relayTypes'),
             sendAfterAuth: any(named: 'sendAfterAuth'),
             onEose: any(named: 'onEose'),
+            onClosed: any(named: 'onClosed'),
           ),
         ).thenReturn(customId);
 
@@ -2306,6 +2437,7 @@ void main() {
             relayTypes: any(named: 'relayTypes'),
             sendAfterAuth: any(named: 'sendAfterAuth'),
             onEose: any(named: 'onEose'),
+            onClosed: any(named: 'onClosed'),
           ),
         ).called(1);
       });
@@ -2327,6 +2459,7 @@ void main() {
             relayTypes: any(named: 'relayTypes'),
             sendAfterAuth: any(named: 'sendAfterAuth'),
             onEose: any(named: 'onEose'),
+            onClosed: any(named: 'onClosed'),
           ),
         ).thenReturn('test-sub-id');
 
@@ -2349,6 +2482,7 @@ void main() {
             relayTypes: [RelayType.normal],
             sendAfterAuth: true,
             onEose: any(named: 'onEose'),
+            onClosed: any(named: 'onClosed'),
           ),
         ).called(1);
       });
@@ -2369,6 +2503,7 @@ void main() {
             relayTypes: any(named: 'relayTypes'),
             sendAfterAuth: any(named: 'sendAfterAuth'),
             onEose: any(named: 'onEose'),
+            onClosed: any(named: 'onClosed'),
           ),
         ).thenReturn('nostr-generated-id');
 
@@ -2395,6 +2530,7 @@ void main() {
             relayTypes: any(named: 'relayTypes'),
             sendAfterAuth: any(named: 'sendAfterAuth'),
             onEose: any(named: 'onEose'),
+            onClosed: any(named: 'onClosed'),
           ),
         ).thenReturn(subscriptionId);
         when(() => mockNostr.unsubscribe(any())).thenReturn(null);
@@ -2435,6 +2571,7 @@ void main() {
             relayTypes: any(named: 'relayTypes'),
             sendAfterAuth: any(named: 'sendAfterAuth'),
             onEose: any(named: 'onEose'),
+            onClosed: any(named: 'onClosed'),
           ),
         ).thenAnswer((_) => 'sub-${callCount++}');
         when(() => mockNostr.unsubscribe(any())).thenReturn(null);
@@ -3768,6 +3905,7 @@ void main() {
             relayTypes: any(named: 'relayTypes'),
             sendAfterAuth: any(named: 'sendAfterAuth'),
             onEose: any(named: 'onEose'),
+            onClosed: any(named: 'onClosed'),
           ),
         ).thenReturn('test-sub-id');
         when(() => mockNostr.unsubscribe(any())).thenReturn(null);
@@ -3855,6 +3993,8 @@ void main() {
               targetRelays: any(named: 'targetRelays'),
               relayTypes: any(named: 'relayTypes'),
               sendAfterAuth: any(named: 'sendAfterAuth'),
+              onEose: any(named: 'onEose'),
+              onClosed: any(named: 'onClosed'),
             ),
           ).thenAnswer((invocation) {
             capturedCallback =
@@ -3900,6 +4040,8 @@ void main() {
               targetRelays: any(named: 'targetRelays'),
               relayTypes: any(named: 'relayTypes'),
               sendAfterAuth: any(named: 'sendAfterAuth'),
+              onEose: any(named: 'onEose'),
+              onClosed: any(named: 'onClosed'),
             ),
           ).thenAnswer((invocation) {
             capturedCallback =
@@ -3937,6 +4079,8 @@ void main() {
               targetRelays: any(named: 'targetRelays'),
               relayTypes: any(named: 'relayTypes'),
               sendAfterAuth: any(named: 'sendAfterAuth'),
+              onEose: any(named: 'onEose'),
+              onClosed: any(named: 'onClosed'),
             ),
           ).thenAnswer((invocation) {
             capturedCallback =
@@ -4471,6 +4615,7 @@ void main() {
             relayTypes: any(named: 'relayTypes'),
             sendAfterAuth: any(named: 'sendAfterAuth'),
             onEose: any(named: 'onEose'),
+            onClosed: any(named: 'onClosed'),
           ),
         ).thenAnswer((invocation) {
           // Get the callback and call it with test event
@@ -4503,6 +4648,7 @@ void main() {
             relayTypes: any(named: 'relayTypes'),
             sendAfterAuth: any(named: 'sendAfterAuth'),
             onEose: any(named: 'onEose'),
+            onClosed: any(named: 'onClosed'),
           ),
         ).thenReturn('search-sub-id');
 
@@ -4519,6 +4665,7 @@ void main() {
             relayTypes: any(named: 'relayTypes'),
             sendAfterAuth: any(named: 'sendAfterAuth'),
             onEose: any(named: 'onEose'),
+            onClosed: any(named: 'onClosed'),
           ),
         ).captured;
 
@@ -4547,6 +4694,7 @@ void main() {
             relayTypes: any(named: 'relayTypes'),
             sendAfterAuth: any(named: 'sendAfterAuth'),
             onEose: any(named: 'onEose'),
+            onClosed: any(named: 'onClosed'),
           ),
         ).thenAnswer((invocation) {
           final callback =
@@ -4575,6 +4723,7 @@ void main() {
             relayTypes: any(named: 'relayTypes'),
             sendAfterAuth: any(named: 'sendAfterAuth'),
             onEose: any(named: 'onEose'),
+            onClosed: any(named: 'onClosed'),
           ),
         ).thenReturn('search-sub-id');
 
@@ -4590,6 +4739,7 @@ void main() {
             relayTypes: any(named: 'relayTypes'),
             sendAfterAuth: any(named: 'sendAfterAuth'),
             onEose: any(named: 'onEose'),
+            onClosed: any(named: 'onClosed'),
           ),
         ).captured;
 

--- a/mobile/packages/nostr_sdk/lib/nostr.dart
+++ b/mobile/packages/nostr_sdk/lib/nostr.dart
@@ -315,6 +315,7 @@ class Nostr {
     bool sendAfterAuth =
         false, // if relay not connected, it will send after auth
     void Function()? onEose,
+    void Function(String reason)? onClosed,
   }) {
     return _pool.subscribe(
       filters,
@@ -325,6 +326,7 @@ class Nostr {
       relayTypes: relayTypes,
       sendAfterAuth: sendAfterAuth,
       onEose: onEose,
+      onClosed: onClosed,
     );
   }
 

--- a/mobile/packages/nostr_sdk/lib/relay/relay.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay.dart
@@ -309,6 +309,13 @@ abstract class Relay {
   /// forgotten. Returns whether [id] named a pending query.
   bool discardQuery(String id) => _queries.remove(id) != null;
 
+  /// Drops a live subscription without sending `CLOSE`.
+  ///
+  /// Used when the relay itself closed the subscription (a `CLOSED` frame), so
+  /// echoing a `CLOSE` back would name a subscription the relay has already
+  /// forgotten. Returns whether [id] named a live subscription.
+  bool discardSubscription(String id) => _subscriptions.remove(id) != null;
+
   bool checkQuery(String id) {
     return _queries[id] != null;
   }

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -1777,6 +1777,11 @@ class RelayPool {
           subscription.onClosed?.call(reason);
         } else if (subscription != null && subscription.onEose != null) {
           final eoseRelays = _subscriptionEoseRelays[subscriptionId];
+          // A relay that reported EOSE and then refused the REQ leaves the
+          // tally with it. Left in, its EOSE would stand in for a relay that
+          // is still streaming stored events, and a bounded read would close
+          // on a partial result.
+          eoseRelays?.remove(relay.url);
           if (eoseRelays != null && eoseRelays.length >= activeRelays.length) {
             subscription.onEose!();
             _subscriptionEoseRelays.remove(subscriptionId);

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -1765,15 +1765,22 @@ class RelayPool {
       // immediately so reconnect cannot replay a subscription the relay has
       // already refused. Other relays may still be serving the same logical
       // subscription; only fail that subscription once none remain.
-      if (relay.discardSubscription(subscriptionId)) {
+      if (!_shouldReplayQueryAfterAuth(relay, reason) &&
+          relay.discardSubscription(subscriptionId)) {
         final subscription = _subscriptions[subscriptionId];
-        if (subscription != null &&
-            _getRelaysWithSubscription(subscriptionId).isEmpty) {
+        final activeRelays = _getRelaysWithSubscription(subscriptionId);
+        if (subscription != null && activeRelays.isEmpty) {
           _subscriptionSilenceProbes.remove(subscriptionId)?.cancel();
           _subscriptions.remove(subscriptionId);
           _subscriptionEoseRelays.remove(subscriptionId);
           _subscriptionSentAt.remove(subscriptionId);
           subscription.onClosed?.call(reason);
+        } else if (subscription != null && subscription.onEose != null) {
+          final eoseRelays = _subscriptionEoseRelays[subscriptionId];
+          if (eoseRelays != null && eoseRelays.length >= activeRelays.length) {
+            subscription.onEose!();
+            _subscriptionEoseRelays.remove(subscriptionId);
+          }
         }
         return;
       }

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -1761,6 +1761,23 @@ class RelayPool {
         relay.failCountQuery(subscriptionId, reason);
       }
 
+      // CLOSED terminates this relay's copy of a live REQ. Forget it locally
+      // immediately so reconnect cannot replay a subscription the relay has
+      // already refused. Other relays may still be serving the same logical
+      // subscription; only fail that subscription once none remain.
+      if (relay.discardSubscription(subscriptionId)) {
+        final subscription = _subscriptions[subscriptionId];
+        if (subscription != null &&
+            _getRelaysWithSubscription(subscriptionId).isEmpty) {
+          _subscriptionSilenceProbes.remove(subscriptionId)?.cancel();
+          _subscriptions.remove(subscriptionId);
+          _subscriptionEoseRelays.remove(subscriptionId);
+          _subscriptionSentAt.remove(subscriptionId);
+          subscription.onClosed?.call(reason);
+        }
+        return;
+      }
+
       // A refused/abandoned REQ is terminal unless it is the pre-AUTH probe
       // that must stay saved for replay after NIP-42 succeeds.
       if (_shouldReplayQueryAfterAuth(relay, reason)) {
@@ -1812,6 +1829,7 @@ class RelayPool {
     bool sendAfterAuth =
         false, // if relay not connected, it will send after auth
     void Function()? onEose,
+    void Function(String reason)? onClosed,
   }) {
     if (filters.isEmpty) {
       throw ArgumentError("No filters given", "filters");
@@ -1825,6 +1843,7 @@ class RelayPool {
       onEvent,
       id: id,
       onEose: onEose,
+      onClosed: onClosed,
     );
     _subscriptions[subscription.id] = subscription;
     _subscriptionSentAt[subscription.id] = DateTime.now();

--- a/mobile/packages/nostr_sdk/lib/subscription.dart
+++ b/mobile/packages/nostr_sdk/lib/subscription.dart
@@ -12,6 +12,10 @@ class Subscription {
   /// relays for this subscription.
   void Function()? onEose;
 
+  /// Callback invoked when every relay serving this subscription has ended
+  /// its REQ with a `CLOSED` frame.
+  void Function(String reason)? onClosed;
+
   /// [filters] parsed once at construction.
   ///
   /// [matchesEvent] runs on every inbound frame, and `Filter.fromJson` copies
@@ -24,9 +28,14 @@ class Subscription {
   /// Subscription ID
   String get id => _id;
 
-  Subscription(this.filters, this.onEvent, {String? id, this.onEose})
-    : _id = id ?? StringUtil.rndNameStr(16),
-      _parsedFilters = [for (final filter in filters) Filter.fromJson(filter)];
+  Subscription(
+    this.filters,
+    this.onEvent, {
+    String? id,
+    this.onEose,
+    this.onClosed,
+  }) : _id = id ?? StringUtil.rndNameStr(16),
+       _parsedFilters = [for (final filter in filters) Filter.fromJson(filter)];
 
   /// Whether [event] satisfies at least one filter in this subscription.
   ///

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_closed_frame_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_closed_frame_test.dart
@@ -238,6 +238,64 @@ void main() {
       },
     );
 
+    test('CLOSED lets EOSE from every remaining relay complete', () async {
+      final signer = LocalNostrSigner(
+        '5ee1c8000ab28edd64d74a7d951ac2dd559814887b1b9e1ac7c5f89e96125c12',
+      );
+      final nostr = Nostr(signer, [], dummyTempRelay);
+      final completedRelay = _ControlledQueryRelay('wss://completed.example');
+      final refusedRelay = _ControlledQueryRelay('wss://refused-after.example');
+      expect(await nostr.relayPool.add(completedRelay), isTrue);
+      expect(await nostr.relayPool.add(refusedRelay), isTrue);
+
+      var eoseCount = 0;
+      nostr.subscribe(
+        [
+          {
+            'kinds': [1],
+          },
+        ],
+        (_) {},
+        onEose: () => eoseCount++,
+      );
+
+      final subId = await completedRelay.awaitPendingSubscription();
+      expect(await refusedRelay.awaitPendingSubscription(), subId);
+      await completedRelay.deliver(['EOSE', subId]);
+      expect(eoseCount, 0);
+
+      await refusedRelay.deliver(['CLOSED', subId, 'error: refused']);
+
+      expect(eoseCount, 1);
+    });
+
+    test('auth-required CLOSED keeps a live subscription for replay', () async {
+      final signer = LocalNostrSigner(
+        '5ee1c8000ab28edd64d74a7d951ac2dd559814887b1b9e1ac7c5f89e96125c12',
+      );
+      final nostr = Nostr(signer, [], dummyTempRelay);
+      final relay = _ControlledQueryRelay('wss://auth-live.example');
+      expect(await nostr.relayPool.add(relay), isTrue);
+
+      var closed = false;
+      nostr.subscribe(
+        [
+          {
+            'kinds': [1],
+          },
+        ],
+        (_) {},
+        sendAfterAuth: true,
+        onClosed: (_) => closed = true,
+      );
+
+      final subId = await relay.awaitPendingSubscription();
+      await relay.deliver(['CLOSED', subId, 'auth-required: sign in']);
+
+      expect(closed, isFalse);
+      expect(relay.hasSubscriptionById(subId), isTrue);
+    });
+
     test('auth-required CLOSED keeps the query for post-AUTH replay', () async {
       final signer = LocalNostrSigner(
         '5ee1c8000ab28edd64d74a7d951ac2dd559814887b1b9e1ac7c5f89e96125c12',

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_closed_frame_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_closed_frame_test.dart
@@ -68,6 +68,15 @@ class _ControlledQueryRelay extends Relay {
     fail('RelayPool never registered a pending query for the REQ');
   }
 
+  Future<String> awaitPendingSubscription() async {
+    for (var i = 0; i < 1000; i++) {
+      final subId = capturedSubId;
+      if (subId != null && hasSubscriptionById(subId)) return subId;
+      await Future<void>.delayed(Duration.zero);
+    }
+    fail('RelayPool never registered a live subscription for the REQ');
+  }
+
   Future<void> awaitReqCount(int count) async {
     for (var i = 0; i < 1000; i++) {
       final reqCount = sentMessages.where((m) => m.first == 'REQ').length;
@@ -143,6 +152,91 @@ void main() {
       expect(result.timedOut, isFalse);
       expect(result.events, isEmpty);
     });
+
+    test(
+      'CLOSED releases the last live subscription and prevents replay',
+      () async {
+        final signer = LocalNostrSigner(
+          '5ee1c8000ab28edd64d74a7d951ac2dd559814887b1b9e1ac7c5f89e96125c12',
+        );
+        final nostr = Nostr(signer, [], dummyTempRelay);
+        final refusedRelay = _ControlledQueryRelay(
+          'wss://refused-live.example',
+        );
+        expect(await nostr.relayPool.add(refusedRelay), isTrue);
+
+        String? closedReason;
+        nostr.subscribe(
+          [
+            {
+              'kinds': [1],
+            },
+          ],
+          (_) {},
+          onClosed: (reason) => closedReason = reason,
+        );
+
+        final subId = await refusedRelay.awaitPendingSubscription();
+        await refusedRelay.deliver([
+          'CLOSED',
+          subId,
+          'error: too many subscriptions',
+        ]);
+
+        expect(closedReason, 'error: too many subscriptions');
+        expect(refusedRelay.hasSubscriptionById(subId), isFalse);
+
+        final replacementRelay = _ControlledQueryRelay(
+          'wss://replacement.example',
+        );
+        expect(
+          await nostr.relayPool.add(replacementRelay, autoSubscribe: true),
+          isTrue,
+        );
+        expect(
+          replacementRelay.sentMessages.where((m) => m.first == 'REQ'),
+          isEmpty,
+          reason: 'a refused subscription must not replay on a new socket',
+        );
+      },
+    );
+
+    test(
+      'CLOSED from one relay preserves a subscription served by another',
+      () async {
+        final signer = LocalNostrSigner(
+          '5ee1c8000ab28edd64d74a7d951ac2dd559814887b1b9e1ac7c5f89e96125c12',
+        );
+        final nostr = Nostr(signer, [], dummyTempRelay);
+        final refusedRelay = _ControlledQueryRelay(
+          'wss://refused-peer.example',
+        );
+        final servingRelay = _ControlledQueryRelay(
+          'wss://serving-peer.example',
+        );
+        expect(await nostr.relayPool.add(refusedRelay), isTrue);
+        expect(await nostr.relayPool.add(servingRelay), isTrue);
+
+        var closed = false;
+        nostr.subscribe(
+          [
+            {
+              'kinds': [1],
+            },
+          ],
+          (_) {},
+          onClosed: (_) => closed = true,
+        );
+
+        final subId = await refusedRelay.awaitPendingSubscription();
+        expect(await servingRelay.awaitPendingSubscription(), subId);
+        await refusedRelay.deliver(['CLOSED', subId, 'error: refused']);
+
+        expect(closed, isFalse);
+        expect(refusedRelay.hasSubscriptionById(subId), isFalse);
+        expect(servingRelay.hasSubscriptionById(subId), isTrue);
+      },
+    );
 
     test('auth-required CLOSED keeps the query for post-AUTH replay', () async {
       final signer = LocalNostrSigner(

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_closed_frame_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_closed_frame_test.dart
@@ -269,6 +269,42 @@ void main() {
       expect(eoseCount, 1);
     });
 
+    test(
+      'EOSE then CLOSED from one relay does not complete the rest',
+      () async {
+        final signer = LocalNostrSigner(
+          '5ee1c8000ab28edd64d74a7d951ac2dd559814887b1b9e1ac7c5f89e96125c12',
+        );
+        final nostr = Nostr(signer, [], dummyTempRelay);
+        final earlyRelay = _ControlledQueryRelay('wss://early.example');
+        final slowRelay = _ControlledQueryRelay('wss://slow.example');
+        expect(await nostr.relayPool.add(earlyRelay), isTrue);
+        expect(await nostr.relayPool.add(slowRelay), isTrue);
+
+        var eoseCount = 0;
+        nostr.subscribe(
+          [
+            {
+              'kinds': [1],
+            },
+          ],
+          (_) {},
+          onEose: () => eoseCount++,
+        );
+
+        final subId = await earlyRelay.awaitPendingSubscription();
+        expect(await slowRelay.awaitPendingSubscription(), subId);
+
+        await earlyRelay.deliver(['EOSE', subId]);
+        await earlyRelay.deliver(['CLOSED', subId, 'error: refused']);
+
+        expect(eoseCount, 0, reason: 'slow.example has not reported EOSE yet');
+
+        await slowRelay.deliver(['EOSE', subId]);
+        expect(eoseCount, 1);
+      },
+    );
+
     test('auth-required CLOSED keeps a live subscription for replay', () async {
       final signer = LocalNostrSigner(
         '5ee1c8000ab28edd64d74a7d951ac2dd559814887b1b9e1ac7c5f89e96125c12',

--- a/mobile/test/helpers/test_nostr_service.dart
+++ b/mobile/test/helpers/test_nostr_service.dart
@@ -145,6 +145,7 @@ class TestNostrService implements NostrClient {
     List<int> relayTypes = const [],
     bool sendAfterAuth = false,
     void Function()? onEose,
+    bool closeOnEose = false,
   }) {
     final subId =
         subscriptionId ?? 'test_sub_${DateTime.now().millisecondsSinceEpoch}';

--- a/mobile/test/providers/list_providers_test.dart
+++ b/mobile/test/providers/list_providers_test.dart
@@ -9,6 +9,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/event.dart';
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
 import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
 import 'package:openvine/providers/app_providers.dart';
@@ -330,6 +331,59 @@ void main() {
       verify(
         () => nostrClient.subscribe(any(), closeOnEose: true),
       ).called(1);
+    });
+
+    test('keeps cached videos when every relay refuses the read', () async {
+      final cachedVideo = _video(id: _allowedVideoId, pubkey: _ownerA);
+      final videoEventService = _MockVideoEventService();
+      final nostrClient = _MockNostrClient();
+      when(() => videoEventService.discoveryVideos).thenReturn(const []);
+      when(() => videoEventService.homeFeedVideos).thenReturn(const []);
+      when(() => videoEventService.profileVideos).thenReturn(const []);
+      when(
+        () => videoEventService.getVideoById(_allowedVideoId),
+      ).thenReturn(cachedVideo);
+      when(
+        () => videoEventService.getVideoById(_blockedVideoId),
+      ).thenReturn(null);
+      when(
+        () => videoEventService.shouldHideVideo(cachedVideo),
+      ).thenReturn(false);
+      when(() => nostrClient.subscribe(any(), closeOnEose: true)).thenAnswer(
+        (_) => Stream<Event>.error(
+          const RelaySubscriptionRefusedException(
+            'error: too many subscriptions',
+          ),
+        ),
+      );
+
+      final container = ProviderContainer(
+        overrides: [
+          videoEventServiceProvider.overrideWithValue(videoEventService),
+          nostrServiceProvider.overrideWithValue(nostrClient),
+        ],
+      );
+      addTearDown(container.dispose);
+      final provider = videoEventsByIdsProvider([
+        _allowedVideoId,
+        _blockedVideoId,
+      ]);
+      final states = <AsyncValue<List<VideoEvent>>>[];
+      final subscription = container.listen(
+        provider,
+        (_, next) => states.add(next),
+      );
+      addTearDown(subscription.close);
+
+      await container.read(provider.future);
+      await pumpEventQueue();
+
+      expect(
+        states.where((state) => state.hasError),
+        isEmpty,
+        reason: 'a refused relay read must not fail the provider',
+      );
+      expect(states.last.value?.map((v) => v.id), [_allowedVideoId]);
     });
 
     test(

--- a/mobile/test/providers/list_providers_test.dart
+++ b/mobile/test/providers/list_providers_test.dart
@@ -8,10 +8,12 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
+import 'package:nostr_client/nostr_client.dart';
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
 import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/list_providers.dart';
+import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/curated_list_service.dart';
 import 'package:openvine/services/video_event_service.dart';
@@ -23,6 +25,8 @@ class _MockPeopleListsRepository extends Mock
     implements PeopleListsRepository {}
 
 class _MockVideoEventService extends Mock implements VideoEventService {}
+
+class _MockNostrClient extends Mock implements NostrClient {}
 
 // Full-length 64-char Nostr pubkeys — never truncate.
 const String _ownerA =
@@ -298,6 +302,36 @@ void main() {
   });
 
   group(videoEventsByIdsProvider, () {
+    test('uses an EOSE-bounded relay read for missing videos', () async {
+      final videoEventService = _MockVideoEventService();
+      final nostrClient = _MockNostrClient();
+      when(() => videoEventService.discoveryVideos).thenReturn(const []);
+      when(() => videoEventService.homeFeedVideos).thenReturn(const []);
+      when(() => videoEventService.profileVideos).thenReturn(const []);
+      when(
+        () => videoEventService.getVideoById(_allowedVideoId),
+      ).thenReturn(null);
+      when(
+        () => nostrClient.subscribe(any(), closeOnEose: true),
+      ).thenAnswer((_) => const Stream.empty());
+
+      final container = ProviderContainer(
+        overrides: [
+          videoEventServiceProvider.overrideWithValue(videoEventService),
+          nostrServiceProvider.overrideWithValue(nostrClient),
+        ],
+      );
+      addTearDown(container.dispose);
+      final provider = videoEventsByIdsProvider([_allowedVideoId]);
+      final subscription = container.listen(provider, (_, _) {});
+      addTearDown(subscription.close);
+
+      await expectLater(container.read(provider.future), completion(isEmpty));
+      verify(
+        () => nostrClient.subscribe(any(), closeOnEose: true),
+      ).called(1);
+    });
+
     test(
       'filters hidden addressable videos found in the local cache',
       () async {
@@ -415,6 +449,40 @@ void main() {
   });
 
   group(curatedListVideoEventsProvider, () {
+    test('uses an EOSE-bounded relay read for missing videos', () async {
+      const listId = 'relay-list';
+      final videoEventService = _MockVideoEventService();
+      final nostrClient = _MockNostrClient();
+      when(() => videoEventService.discoveryVideos).thenReturn(const []);
+      when(() => videoEventService.homeFeedVideos).thenReturn(const []);
+      when(() => videoEventService.profileVideos).thenReturn(const []);
+      when(
+        () => videoEventService.getVideoById(_allowedVideoId),
+      ).thenReturn(null);
+      when(
+        () => nostrClient.subscribe(any(), closeOnEose: true),
+      ).thenAnswer((_) => const Stream.empty());
+
+      final container = ProviderContainer(
+        overrides: [
+          videoEventServiceProvider.overrideWithValue(videoEventService),
+          nostrServiceProvider.overrideWithValue(nostrClient),
+          curatedListVideosProvider(
+            listId,
+          ).overrideWith((ref) => [_allowedVideoId]),
+        ],
+      );
+      addTearDown(container.dispose);
+      final provider = curatedListVideoEventsProvider(listId);
+      final subscription = container.listen(provider, (_, _) {});
+      addTearDown(subscription.close);
+
+      await expectLater(container.read(provider.future), completion(isEmpty));
+      verify(
+        () => nostrClient.subscribe(any(), closeOnEose: true),
+      ).called(1);
+    });
+
     test(
       'filters hidden videos found by plain event id in the local cache',
       () async {

--- a/mobile/test/services/cache_first_query_test.dart
+++ b/mobile/test/services/cache_first_query_test.dart
@@ -41,6 +41,7 @@ class MockNostrServiceWithDelay implements NostrClient {
     List<int> relayTypes = const [],
     bool sendAfterAuth = false,
     void Function()? onEose,
+    bool closeOnEose = false,
   }) {
     // Simulate relay delay: call onEose after 100ms. Tracked as a cancellable
     // Timer so dispose() stops it firing onEose on a torn-down service.

--- a/mobile/test/services/curated_list_service_query_test.dart
+++ b/mobile/test/services/curated_list_service_query_test.dart
@@ -80,6 +80,13 @@ void main() {
 
       // Mock subscribeToEvents for relay sync
       when(
+        () => mockNostr.subscribe(
+          any(),
+          onEose: any(named: 'onEose'),
+          closeOnEose: true,
+        ),
+      ).thenAnswer((_) => const Stream.empty());
+      when(
         () => mockNostr.subscribe(any(), onEose: any(named: 'onEose')),
       ).thenAnswer((_) => const Stream.empty());
 
@@ -343,7 +350,11 @@ void main() {
 
         // Setup mock to return empty stream
         when(
-          () => mockNostr.subscribe(any(), onEose: any(named: 'onEose')),
+          () => mockNostr.subscribe(
+            any(),
+            onEose: any(named: 'onEose'),
+            closeOnEose: true,
+          ),
         ).thenAnswer((_) => const Stream.empty());
 
         // Act
@@ -368,7 +379,7 @@ void main() {
             );
 
             when(
-              () => mockNostr.subscribe(any()),
+              () => mockNostr.subscribe(any(), closeOnEose: true),
             ).thenAnswer((_) => controller.stream);
 
             List<CuratedList>? lists;
@@ -424,7 +435,11 @@ void main() {
 
         // Setup mock to return events progressively
         when(
-          () => mockNostr.subscribe(any(), onEose: any(named: 'onEose')),
+          () => mockNostr.subscribe(
+            any(),
+            onEose: any(named: 'onEose'),
+            closeOnEose: true,
+          ),
         ).thenAnswer(
           (_) => Stream.fromIterable([mockListEvent1, mockListEvent2]),
         );
@@ -518,6 +533,32 @@ void main() {
     });
 
     group('streamPublicListsFromRelays()', () {
+      test('finishes and releases the source subscription on EOSE', () async {
+        void Function()? onEose;
+        var canceled = false;
+        final source = StreamController<Event>(
+          onCancel: () => canceled = true,
+        );
+        addTearDown(source.close);
+        when(
+          () => mockNostr.subscribe(
+            any(),
+            onEose: any(named: 'onEose'),
+            closeOnEose: true,
+          ),
+        ).thenAnswer((invocation) {
+          onEose = invocation.namedArguments[#onEose] as void Function()?;
+          return source.stream;
+        });
+
+        final result = service.streamPublicListsFromRelays().toList();
+        await Future<void>.delayed(Duration.zero);
+        onEose!();
+
+        expect(await result, isEmpty);
+        expect(canceled, isTrue);
+      });
+
       test('streams lists immediately as they arrive', () async {
         // Setup: Mock events arriving one at a time
         final event1 = Event.fromJson({
@@ -558,7 +599,11 @@ void main() {
 
         // Mock subscribe to return events as a stream
         when(
-          () => mockNostr.subscribe(any(), onEose: any(named: 'onEose')),
+          () => mockNostr.subscribe(
+            any(),
+            onEose: any(named: 'onEose'),
+            closeOnEose: true,
+          ),
         ).thenAnswer((_) => Stream.fromIterable([event1, event2]));
 
         // Act: Collect streamed results
@@ -617,7 +662,11 @@ void main() {
 
         // Send older first, then newer
         when(
-          () => mockNostr.subscribe(any(), onEose: any(named: 'onEose')),
+          () => mockNostr.subscribe(
+            any(),
+            onEose: any(named: 'onEose'),
+            closeOnEose: true,
+          ),
         ).thenAnswer((_) => Stream.fromIterable([olderEvent, newerEvent]));
 
         List<CuratedList>? finalLists;
@@ -671,7 +720,11 @@ void main() {
         });
 
         when(
-          () => mockNostr.subscribe(any(), onEose: any(named: 'onEose')),
+          () => mockNostr.subscribe(
+            any(),
+            onEose: any(named: 'onEose'),
+            closeOnEose: true,
+          ),
         ).thenAnswer((_) => Stream.fromIterable([emptyList, nonEmptyList]));
 
         List<CuratedList>? finalLists;
@@ -701,7 +754,11 @@ void main() {
         });
 
         when(
-          () => mockNostr.subscribe(any(), onEose: any(named: 'onEose')),
+          () => mockNostr.subscribe(
+            any(),
+            onEose: any(named: 'onEose'),
+            closeOnEose: true,
+          ),
         ).thenAnswer((_) => Stream.value(malformedList));
 
         final updates = await service.streamPublicListsFromRelays().toList();
@@ -729,7 +786,11 @@ void main() {
         });
 
         when(
-          () => mockNostr.subscribe(any(), onEose: any(named: 'onEose')),
+          () => mockNostr.subscribe(
+            any(),
+            onEose: any(named: 'onEose'),
+            closeOnEose: true,
+          ),
         ).thenAnswer((_) => Stream.fromIterable([oldEvent]));
 
         // Act: Request with until date
@@ -744,7 +805,11 @@ void main() {
 
         // Verify subscribe was called (filter construction is internal)
         verify(
-          () => mockNostr.subscribe(any(), onEose: any(named: 'onEose')),
+          () => mockNostr.subscribe(
+            any(),
+            onEose: any(named: 'onEose'),
+            closeOnEose: true,
+          ),
         ).called(1);
         expect(results?.isNotEmpty, true);
       });

--- a/mobile/test/services/curated_list_service_stream_test.dart
+++ b/mobile/test/services/curated_list_service_stream_test.dart
@@ -100,7 +100,11 @@ void main() {
 
       // Mock subscribe to return our controlled stream
       when(
-        () => mockNostr.subscribe(any(), onEose: any(named: 'onEose')),
+        () => mockNostr.subscribe(
+          any(),
+          onEose: any(named: 'onEose'),
+          closeOnEose: true,
+        ),
       ).thenAnswer((_) => eventController.stream);
 
       service = CuratedListService(
@@ -339,7 +343,11 @@ void main() {
         // Capture the filter passed to subscribe
         Filter? capturedFilter;
         when(
-          () => mockNostr.subscribe(any(), onEose: any(named: 'onEose')),
+          () => mockNostr.subscribe(
+            any(),
+            onEose: any(named: 'onEose'),
+            closeOnEose: true,
+          ),
         ).thenAnswer((invocation) {
           final filters = invocation.positionalArguments[0] as List<Filter>;
           capturedFilter = filters.first;
@@ -420,7 +428,11 @@ void main() {
       test('completes empty when relays EOSE without events', () async {
         void Function()? onEose;
         when(
-          () => mockNostr.subscribe(any(), onEose: any(named: 'onEose')),
+          () => mockNostr.subscribe(
+            any(),
+            onEose: any(named: 'onEose'),
+            closeOnEose: true,
+          ),
         ).thenAnswer((invocation) {
           onEose = invocation.namedArguments[#onEose] as void Function()?;
           return eventController.stream;
@@ -446,7 +458,11 @@ void main() {
       test('completes with received events when relays EOSE', () async {
         void Function()? onEose;
         when(
-          () => mockNostr.subscribe(any(), onEose: any(named: 'onEose')),
+          () => mockNostr.subscribe(
+            any(),
+            onEose: any(named: 'onEose'),
+            closeOnEose: true,
+          ),
         ).thenAnswer((invocation) {
           onEose = invocation.namedArguments[#onEose] as void Function()?;
           return eventController.stream;
@@ -487,7 +503,11 @@ void main() {
             },
           );
           when(
-            () => mockNostr.subscribe(any(), onEose: any(named: 'onEose')),
+            () => mockNostr.subscribe(
+              any(),
+              onEose: any(named: 'onEose'),
+              closeOnEose: true,
+            ),
           ).thenAnswer((_) => eventController.stream);
 
           Object? receivedError;
@@ -519,7 +539,11 @@ void main() {
           },
         );
         when(
-          () => mockNostr.subscribe(any(), onEose: any(named: 'onEose')),
+          () => mockNostr.subscribe(
+            any(),
+            onEose: any(named: 'onEose'),
+            closeOnEose: true,
+          ),
         ).thenAnswer((_) => eventController.stream);
 
         final subscription = service.streamPublicListsFromRelays().listen(

--- a/mobile/test/services/subscribed_list_video_cache_test.dart
+++ b/mobile/test/services/subscribed_list_video_cache_test.dart
@@ -218,6 +218,29 @@ void main() {
         ).called(1);
       });
 
+      test('a refused relay read does not escape syncList', () async {
+        when(() => mockVideoEventService.getVideoById(any())).thenReturn(null);
+        when(
+          () => mockNostrService.subscribe(any(), closeOnEose: true),
+        ).thenAnswer(
+          (_) => Stream<Event>.error(
+            const RelaySubscriptionRefusedException(
+              'error: too many subscriptions',
+            ),
+          ),
+        );
+
+        const missingVideoId =
+            'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
+
+        // syncAllSubscribedLists runs from an unawaited microtask, so an
+        // escaping error would land in the zone as an uncaught async error.
+        await expectLater(
+          cache.syncList('list1', [missingVideoId]),
+          completes,
+        );
+      });
+
       test('separates event IDs from addressable coordinates', () async {
         when(() => mockVideoEventService.getVideoById(any())).thenReturn(null);
         when(

--- a/mobile/test/services/subscribed_list_video_cache_test.dart
+++ b/mobile/test/services/subscribed_list_video_cache_test.dart
@@ -92,7 +92,7 @@ void main() {
 
         // Mock Nostr service to not need relay fetch (all cached)
         when(
-          () => mockNostrService.subscribe(any()),
+          () => mockNostrService.subscribe(any(), closeOnEose: true),
         ).thenAnswer((_) => const Stream<Event>.empty());
 
         // Sync list with these video IDs
@@ -124,7 +124,7 @@ void main() {
           () => mockVideoEventService.getVideoById(video1Id),
         ).thenReturn(video1);
         when(
-          () => mockNostrService.subscribe(any()),
+          () => mockNostrService.subscribe(any(), closeOnEose: true),
         ).thenAnswer((_) => const Stream<Event>.empty());
 
         // Add video to two different lists
@@ -157,7 +157,7 @@ void main() {
 
           // Subscribe should still be called but for empty list
           when(
-            () => mockNostrService.subscribe(any()),
+            () => mockNostrService.subscribe(any(), closeOnEose: true),
           ).thenAnswer((_) => const Stream<Event>.empty());
 
           await cache.syncList('list1', [cachedVideoId]);
@@ -199,7 +199,9 @@ void main() {
 
         // Setup stream to emit the event
         final controller = StreamController<Event>();
-        when(() => mockNostrService.subscribe(any())).thenAnswer((_) {
+        when(
+          () => mockNostrService.subscribe(any(), closeOnEose: true),
+        ).thenAnswer((_) {
           // Emit event and close after a delay
           Future.delayed(const Duration(milliseconds: 10), () {
             controller.add(mockEvent);
@@ -211,13 +213,15 @@ void main() {
         await cache.syncList('list1', [missingVideoId]);
 
         // Verify subscribe was called
-        verify(() => mockNostrService.subscribe(any())).called(1);
+        verify(
+          () => mockNostrService.subscribe(any(), closeOnEose: true),
+        ).called(1);
       });
 
       test('separates event IDs from addressable coordinates', () async {
         when(() => mockVideoEventService.getVideoById(any())).thenReturn(null);
         when(
-          () => mockNostrService.subscribe(any()),
+          () => mockNostrService.subscribe(any(), closeOnEose: true),
         ).thenAnswer((_) => const Stream<Event>.empty());
 
         const eventId =
@@ -227,7 +231,9 @@ void main() {
         await cache.syncList('list1', [eventId, addressableCoord]);
 
         // Verify subscribe was called - should handle both types
-        verify(() => mockNostrService.subscribe(any())).called(1);
+        verify(
+          () => mockNostrService.subscribe(any(), closeOnEose: true),
+        ).called(1);
       });
 
       test('notifies listeners after sync', () async {
@@ -243,7 +249,7 @@ void main() {
           () => mockVideoEventService.getVideoById(videoId),
         ).thenReturn(video);
         when(
-          () => mockNostrService.subscribe(any()),
+          () => mockNostrService.subscribe(any(), closeOnEose: true),
         ).thenAnswer((_) => const Stream<Event>.empty());
 
         var notified = false;
@@ -294,7 +300,7 @@ void main() {
           () => mockVideoEventService.getVideoById(video2Id),
         ).thenReturn(video2);
         when(
-          () => mockNostrService.subscribe(any()),
+          () => mockNostrService.subscribe(any(), closeOnEose: true),
         ).thenAnswer((_) => const Stream<Event>.empty());
 
         await cache.syncAllSubscribedLists();
@@ -328,7 +334,7 @@ void main() {
           () => mockVideoEventService.getVideoById(video2Id),
         ).thenReturn(video2);
         when(
-          () => mockNostrService.subscribe(any()),
+          () => mockNostrService.subscribe(any(), closeOnEose: true),
         ).thenAnswer((_) => const Stream<Event>.empty());
 
         // Sync two lists
@@ -364,7 +370,7 @@ void main() {
             () => mockVideoEventService.getVideoById(videoId),
           ).thenReturn(video1);
           when(
-            () => mockNostrService.subscribe(any()),
+            () => mockNostrService.subscribe(any(), closeOnEose: true),
           ).thenAnswer((_) => const Stream<Event>.empty());
 
           // Add video1 to both lists
@@ -392,7 +398,7 @@ void main() {
           () => mockVideoEventService.getVideoById(videoId),
         ).thenReturn(video);
         when(
-          () => mockNostrService.subscribe(any()),
+          () => mockNostrService.subscribe(any(), closeOnEose: true),
         ).thenAnswer((_) => const Stream<Event>.empty());
 
         await cache.syncList('list1', [videoId]);
@@ -422,7 +428,7 @@ void main() {
           () => mockVideoEventService.getVideoById(sharedVideoId),
         ).thenReturn(video1);
         when(
-          () => mockNostrService.subscribe(any()),
+          () => mockNostrService.subscribe(any(), closeOnEose: true),
         ).thenAnswer((_) => const Stream<Event>.empty());
 
         // Add same video to three lists

--- a/mobile/test/services/video_event_service_deleted_event_purge_test.dart
+++ b/mobile/test/services/video_event_service_deleted_event_purge_test.dart
@@ -34,6 +34,7 @@ class _StreamingNostrService implements NostrClient {
     List<int> relayTypes = const [],
     bool sendAfterAuth = false,
     void Function()? onEose,
+    bool closeOnEose = false,
   }) {
     if (onEose != null) {
       Future.microtask(onEose);

--- a/mobile/test/services/video_event_service_with_event_router_test.dart
+++ b/mobile/test/services/video_event_service_with_event_router_test.dart
@@ -36,6 +36,7 @@ class MockNostrService implements NostrClient {
     List<int> relayTypes = const [],
     bool sendAfterAuth = false,
     void Function()? onEose,
+    bool closeOnEose = false,
   }) {
     _subscriptionFilters.addAll(filters);
 


### PR DESCRIPTION
## Summary

After roughly ten minutes of normal use on a single-relay account, screens that read from relays go silent: Discover Lists shows "The relay did not return lists in time", and list videos stop resolving. Nothing is actually slow — the relay never received the request at all.

Every completed read left its Nostr subscription registered on the relay connection instead of closing it. `relay.divine.video` caps a connection at 100 concurrent subscriptions, so once that many had accumulated the relay refused every new request with a `CLOSED` frame. The client had no handler for `CLOSED` on a live subscription, so the refusal was dropped and the caller waited out its timeout with no events, no end-of-stored-events signal, and no error.

This change fixes both halves:

- Bounded reads (a "fetch these videos and stop" query, as opposed to a live feed) now opt into `closeOnEose` on `NostrClient.subscribe`, which releases the relay subscription as soon as every serving relay has delivered its stored events. Long-lived subscriptions keep the previous behaviour.
- A non-auth `CLOSED` is now terminal for that relay: the client forgets its copy of the subscription so a reconnect cannot replay a request the relay already refused, and once no relay is left serving it the caller gets a typed `RelaySubscriptionRefusedException` on the stream instead of silence.
- NIP-42 auth replay is unaffected — an `auth-required` refusal still parks the subscription for replay after the handshake — and a refusal from one relay leaves healthy peers serving the same subscription untouched.
- Removes `AppConstants.maxSubscriptionsPerRelay`, a client-side limit nothing read.

### Blast radius: `subscribe()` streams can now carry an error

This is the part worth a second look. Before this change a `NostrClient.subscribe` stream only ever produced events; now it can emit `RelaySubscriptionRefusedException`, and a call site that listens without an `onError` turns that into an uncaught async error. Every one of the ~28 call sites was checked; the four that had no place for the error to land are handled here:

- the mutual-mute and block-list syncs, and the by-author block/mute watch, listen without awaiting — each now logs the refusal
- the subscribed-list video cache runs from an unawaited microtask, so an escaping error would reach the zone — it now keeps the events that already arrived
- the curated-list and by-id video providers would have aborted mid-generator and dropped videos already resolved from cache — they now log and keep them

## Testing

- `flutter test test/unit/relay_pool_closed_frame_test.dart` in `packages/nostr_sdk` (9 tests, covering the single-relay, multi-relay, EOSE-then-CLOSED, and auth-required cases)
- full `packages/nostr_sdk` test suite
- `flutter test test/src/nostr_client_test.dart` in `packages/nostr_client`
- full `packages/content_blocklist_repository` suite (128 tests, 100% line coverage held)
- affected app provider/service suites
- pre-push selected suite (431 tests)
- `flutter analyze`

Closes #8006
Refs #7805
