### PR TITLE
fix(analytics): separate first login identity

### DIFF
--- a/analytics-contract.lock
+++ b/analytics-contract.lock
@@ -1,10 +1,10 @@
 {
   "artifact": "mobile/lib/generated/product_analytics.dart",
-  "artifact_commit": "470a150d767b0c23bea66c37158cdefec6ae9743",
-  "artifact_sha256": "70a236ec0822f272de572669ccb55c5baba905f23df3adc2d572dcbd08b8a778",
-  "contract_commit": "27e21a7a1ea3c6cb998186eda50807e63806efc9",
+  "artifact_commit": "f11951855bc7f83634ff9d70f1d6135b1c4ea2ee",
+  "artifact_sha256": "a17733d368e32ee715952915d5bcf08ce96e1ef1e7ded8cef81639a0eb40af66",
+  "contract_commit": "58ec2aa4090d2f17ca0ef1e30d3602f5bd24f9d6",
   "manifest": "analytics-contract.manifest.json",
-  "manifest_sha256": "027e85ab7098adc866b0b3cd8e827fd48c9645471b13e5a014212c4652765ec5",
+  "manifest_sha256": "6c99268e331c49500f4cb71df153bedd570208b965979bf25fa6b848d578f77f",
   "schema_version": 2,
   "source_artifact": "analytics/generated/product_analytics.dart",
   "source_manifest": "analytics/generated/manifest.json"

--- a/analytics-contract.manifest.json
+++ b/analytics-contract.manifest.json
@@ -2,18 +2,18 @@
   "artifacts": {
     "productAnalytics.ts": {
       "path": "analytics/generated/productAnalytics.ts",
-      "sha256": "1b99c8425e8d7087910debbb5af62c05ba85df545c704d80c7f0c703914595c3"
+      "sha256": "ed72ed97d229d9785de0c7c891481a34a76d6c73a01d5c916e03bf1eac23d75c"
     },
     "product_analytics.dart": {
       "path": "analytics/generated/product_analytics.dart",
-      "sha256": "70a236ec0822f272de572669ccb55c5baba905f23df3adc2d572dcbd08b8a778"
+      "sha256": "a17733d368e32ee715952915d5bcf08ce96e1ef1e7ded8cef81639a0eb40af66"
     },
     "product_analytics.rs": {
       "path": "analytics/generated/product_analytics.rs",
-      "sha256": "83ad6c09c6b8331891b71dc88259cdb878ff56fd96911e83b0603c22008cbe1f"
+      "sha256": "9e444433930ecfbd7ec6ed015b377e40a55692b2ad2270918de8e3799c89273c"
     }
   },
-  "contract_commit": "27e21a7a1ea3c6cb998186eda50807e63806efc9",
+  "contract_commit": "58ec2aa4090d2f17ca0ef1e30d3602f5bd24f9d6",
   "event_id_algorithm": "sha256-rfc8785-v1",
   "schema_version": 2
 }

--- a/mobile/lib/generated/product_analytics.dart
+++ b/mobile/lib/generated/product_analytics.dart
@@ -1,11 +1,22 @@
 // @generated from analytics/event-contract.yaml.
-// Source contract commit: 27e21a7a1ea3c6cb998186eda50807e63806efc9
+// Source contract commit: 58ec2aa4090d2f17ca0ef1e30d3602f5bd24f9d6
 // DO NOT EDIT. Update the contract and run analytics/codegen/generate.py.
 const String productAnalyticsV2ContractCommit =
-    '27e21a7a1ea3c6cb998186eda50807e63806efc9';
+    '58ec2aa4090d2f17ca0ef1e30d3602f5bd24f9d6';
 const int productAnalyticsV2SchemaVersion = 2;
 const String productAnalyticsV2EventIdAlgorithm = 'sha256-rfc8785-v1';
 const bool? productAnalyticsV2ConsentDefaultEnabled = null;
+
+const int productAnalyticsV2ContentImpressionRecordedPositionMinimum = 0;
+const int productAnalyticsV2ContentImpressionRecordedPositionMaximum = 10000;
+const int productAnalyticsV2ContentImpressionRecordedVisibleMsMinimum = 1000;
+const int productAnalyticsV2ContentImpressionRecordedVisibleMsMaximum = 3600000;
+const int productAnalyticsV2PlaybackSessionRecordedDurationMsMinimum = 0;
+const int productAnalyticsV2PlaybackSessionRecordedDurationMsMaximum = 86400000;
+const int productAnalyticsV2PlaybackSessionRecordedWatchedMsMinimum = 0;
+const int productAnalyticsV2PlaybackSessionRecordedWatchedMsMaximum = 86400000;
+const int productAnalyticsV2PlaybackSessionRecordedLoopCountMinimum = 0;
+const int productAnalyticsV2PlaybackSessionRecordedLoopCountMaximum = 1000;
 
 enum ProductAnalyticsV2Source {
   mobile('mobile'),

--- a/mobile/lib/providers/social_providers.dart
+++ b/mobile/lib/providers/social_providers.dart
@@ -621,16 +621,23 @@ AnalyticsService analyticsService(Ref ref) {
   var lastPubkey = authService.currentPublicKeyHex;
   final unregisterBeforeTeardown = authService
       .registerBeforeSessionTeardownCallback(() async {
-        final outgoingPubkey = authService.currentPublicKeyHex ?? lastPubkey;
-        await service.handleIdentityChange(outgoingPubkey);
+        await service.handleIdentityChange();
         lastPubkey = null;
       });
   final authStateSubscription = authService.authStateStream.listen((_) {
     final nextPubkey = authService.currentPublicKeyHex;
     final previousPubkey = lastPubkey;
     lastPubkey = nextPubkey;
-    if (previousPubkey != null && previousPubkey != nextPubkey) {
-      unawaited(service.handleIdentityChange(previousPubkey));
+    if (previousPubkey != nextPubkey) {
+      unawaited(
+        service.handleIdentityChange().catchError((Object error) {
+          Log.warning(
+            'Failed to apply product analytics identity boundary: $error',
+            name: 'SocialProviders',
+            category: LogCategory.system,
+          );
+        }),
+      );
     }
   });
 

--- a/mobile/lib/providers/social_providers.g.dart
+++ b/mobile/lib/providers/social_providers.g.dart
@@ -400,7 +400,7 @@ final class AnalyticsServiceProvider
   }
 }
 
-String _$analyticsServiceHash() => r'4de91a3c8ab9880b5f3c042d73ff5caa16092bd9';
+String _$analyticsServiceHash() => r'd6a3557f076970d357d94e47baa85545ffd556dc';
 
 /// Hashtag cache service for persistent hashtag storage
 

--- a/mobile/lib/services/analytics_service.dart
+++ b/mobile/lib/services/analytics_service.dart
@@ -255,20 +255,17 @@ class AnalyticsService implements BackgroundAwareService {
     }
   }
 
-  /// Clears queued events owned by the outgoing account before logout/switch.
+  /// Clears queued events before any login, logout, or account switch.
   ///
-  /// Also rotates the anonymous and session identifiers: the queue purge
-  /// establishes that data must not cross an account boundary, and keeping the
-  /// old identifiers would let the backend join the next account's batches to
-  /// the outgoing account's rows. The anonymous-to-first-login boundary
-  /// (null previous pubkey) deliberately keeps the identifiers so acquisition
-  /// events stay attributable to the signup they produced.
-  Future<void> handleIdentityChange(String? previousPubkey) async {
+  /// The first login is an identity boundary too. Rotating both identifiers
+  /// prevents pre-login activity from being joined to the authenticated
+  /// account, while clearing the whole queue prevents older anonymous or
+  /// account-owned rows from crossing the boundary later.
+  Future<void> handleIdentityChange(String? _) async {
     _productAnalyticsUtm.clear();
-    if (previousPubkey == null || previousPubkey.isEmpty) return;
-    await _productEventQueue?.clearOwner(previousPubkey);
     if (_anonymousIdOverride == null) _anonymousId = _uuid.v4();
     if (_sessionIdOverride == null) _sessionId = _uuid.v4();
+    await _productEventQueue?.clear();
   }
 
   Future<String?> recordContentImpression({

--- a/mobile/lib/services/analytics_service.dart
+++ b/mobile/lib/services/analytics_service.dart
@@ -86,8 +86,8 @@ class AnalyticsService implements BackgroundAwareService {
 
   bool _analyticsEnabled = true; // Default to enabled
   bool _isInitialized = false;
-  // Not final: rotated when an account session is torn down so a later
-  // account's events cannot be joined to the previous account's rows.
+  // Not final: rotated at every identity or consent boundary so activity from
+  // separate privacy contexts cannot be joined.
   late String _anonymousId = _uuid.v4();
   late String _sessionId = _uuid.v4();
   final Map<String, String> _productAnalyticsUtm = {};
@@ -192,6 +192,7 @@ class AnalyticsService implements BackgroundAwareService {
 
     if (!enabled) {
       _productAnalyticsUtm.clear();
+      _rotateProductAnalyticsIdentity();
       try {
         await _productEventQueue?.clear();
       } catch (error) {
@@ -261,11 +262,15 @@ class AnalyticsService implements BackgroundAwareService {
   /// prevents pre-login activity from being joined to the authenticated
   /// account, while clearing the whole queue prevents older anonymous or
   /// account-owned rows from crossing the boundary later.
-  Future<void> handleIdentityChange(String? _) async {
+  Future<void> handleIdentityChange() async {
     _productAnalyticsUtm.clear();
+    _rotateProductAnalyticsIdentity();
+    await _productEventQueue?.clear();
+  }
+
+  void _rotateProductAnalyticsIdentity() {
     if (_anonymousIdOverride == null) _anonymousId = _uuid.v4();
     if (_sessionIdOverride == null) _sessionId = _uuid.v4();
-    await _productEventQueue?.clear();
   }
 
   Future<String?> recordContentImpression({

--- a/mobile/lib/services/product_event_queue.dart
+++ b/mobile/lib/services/product_event_queue.dart
@@ -85,9 +85,6 @@ class ProductEventQueue {
 
   Future<void> clear() => _dao.deleteAll();
 
-  Future<void> clearOwner(String ownerPubkey) =>
-      _dao.deleteForOwner(ownerPubkey);
-
   Future<void> flush() async {
     if (!_sendingEnabled || _isFlushing) return;
     _isFlushing = true;

--- a/mobile/packages/db_client/lib/src/database/daos/pending_product_events_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/pending_product_events_dao.dart
@@ -207,12 +207,6 @@ class PendingProductEventsDao extends DatabaseAccessor<AppDatabase>
     )..where((table) => table.id.equals(id))).go();
   }
 
-  Future<int> deleteForOwner(String ownerPubkey) {
-    return (delete(
-      pendingProductEvents,
-    )..where((table) => table.ownerPubkey.equals(ownerPubkey))).go();
-  }
-
   Future<int> deleteAll() => delete(pendingProductEvents).go();
 
   /// Removes expired rows, then trims the oldest survivors to [maxRecords].

--- a/mobile/packages/db_client/test/src/database/daos/pending_product_events_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/pending_product_events_dao_test.dart
@@ -208,18 +208,6 @@ void main() {
           expect(retryable.map((event) => event.id).toSet(), {'legacy'});
         },
       );
-
-      test('deleteForOwner removes only that account', () async {
-        await dao.enqueue(makeEvent(id: 'for-a', ownerPubkey: ownerA));
-        await dao.enqueue(makeEvent(id: 'for-b', ownerPubkey: ownerB));
-        await dao.enqueue(makeEvent(id: 'anonymous'));
-
-        expect(await dao.deleteForOwner(ownerA), 1);
-
-        expect(await dao.getById('for-a'), isNull);
-        expect(await dao.getById('for-b'), isNotNull);
-        expect(await dao.getById('anonymous'), isNotNull);
-      });
     });
 
     test('deleteAll removes signed and anonymous rows', () async {

--- a/mobile/test/providers/product_analytics_release_provider_test.dart
+++ b/mobile/test/providers/product_analytics_release_provider_test.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Proves product analytics uses the running app version.
 // ABOUTME: Prevents release coverage from collapsing into the old 1.0.0 constant.
 
+import 'dart:async';
+
 import 'package:db_client/db_client.dart';
 import 'package:drift/native.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -90,4 +92,65 @@ void main() {
       '2026.8.21-dogfood',
     );
   });
+
+  test(
+    'first login applies an identity boundary and logout does not repeat it',
+    () async {
+      SharedPreferences.setMockInitialValues({});
+      final database = AppDatabase.test(NativeDatabase.memory());
+      final authService = _MockAuthService();
+      final queue = _MockProductEventQueue();
+      final viewPublisher = _MockViewEventPublisher();
+      final authStates = StreamController<AuthState>();
+      Future<void> Function()? beforeTeardown;
+      String? currentPubkey;
+
+      when(
+        () => authService.currentPublicKeyHex,
+      ).thenAnswer((_) => currentPubkey);
+      when(
+        () => authService.authStateStream,
+      ).thenAnswer((_) => authStates.stream);
+      when(
+        () => authService.registerBeforeSessionTeardownCallback(any()),
+      ).thenAnswer((invocation) {
+        beforeTeardown =
+            invocation.positionalArguments.single as Future<void> Function();
+        return () {};
+      });
+      when(queue.clear).thenAnswer((_) async {});
+      when(queue.recoverPublishingAndFlush).thenAnswer((_) async {});
+
+      final container = ProviderContainer(
+        overrides: [
+          appVersionProvider.overrideWithValue('2026.8.21-dogfood'),
+          databaseProvider.overrideWithValue(database),
+          authServiceProvider.overrideWithValue(authService),
+          productEventQueueProvider.overrideWithValue(queue),
+          viewEventPublisherProvider.overrideWithValue(viewPublisher),
+          viewEventRetryServiceProvider.overrideWithValue(null),
+        ],
+      );
+      addTearDown(() async {
+        container.dispose();
+        await authStates.close();
+        await database.close();
+      });
+
+      final analytics = container.read(analyticsServiceProvider);
+      await analytics.initialize();
+      currentPubkey = 'a' * 64;
+      authStates.add(AuthState.authenticated);
+      await pumpEventQueue();
+
+      verify(queue.clear).called(1);
+
+      await beforeTeardown!();
+      currentPubkey = null;
+      authStates.add(AuthState.unauthenticated);
+      await pumpEventQueue();
+
+      verify(queue.clear).called(1);
+    },
+  );
 }

--- a/mobile/test/services/analytics_service_test.dart
+++ b/mobile/test/services/analytics_service_test.dart
@@ -355,10 +355,25 @@ void main() {
     });
 
     test(
-      'consent withdrawal clears queued events and acquisition data',
+      'consent withdrawal rotates identifiers and clears queued data',
       () async {
         final queue = _MockProductEventQueue();
+        final recordedEvents = <ProductAnalyticsV2Event>[];
+        when(
+          () => queue.enqueue(any(), ownerPubkey: any(named: 'ownerPubkey')),
+        ).thenAnswer((invocation) async {
+          recordedEvents.add(
+            invocation.positionalArguments.single as ProductAnalyticsV2Event,
+          );
+        });
+        when(() => queue.enqueue(any())).thenAnswer((invocation) async {
+          recordedEvents.add(
+            invocation.positionalArguments.single as ProductAnalyticsV2Event,
+          );
+        });
         when(queue.clear).thenAnswer((_) async {});
+        when(queue.flush).thenAnswer((_) async {});
+        when(queue.recoverPublishingAndFlush).thenAnswer((_) async {});
         analyticsService.dispose();
         analyticsService = AnalyticsService(
           productEventQueue: queue,
@@ -368,11 +383,24 @@ void main() {
         analyticsService.captureProductAnalyticsUtm({
           'utm_source': 'newsletter',
         });
+        await analyticsService.recordRegistrationStarted(
+          entryPoint: ProductAnalyticsV2RegistrationEntryPoint.landing,
+        );
 
         await analyticsService.setAnalyticsEnabled(false);
+        await analyticsService.setAnalyticsEnabled(true);
+        await analyticsService.recordRegistrationStarted(
+          entryPoint: ProductAnalyticsV2RegistrationEntryPoint.invite,
+        );
 
         verify(queue.clear).called(1);
         expect(analyticsService.productAnalyticsUtm, isEmpty);
+        final envelopes = recordedEvents
+            .map((event) => event.envelope)
+            .toList();
+        expect(envelopes, hasLength(2));
+        expect(envelopes[1].anonymousId, isNot(envelopes[0].anonymousId));
+        expect(envelopes[1].sessionId, isNot(envelopes[0].sessionId));
       },
     );
 
@@ -391,7 +419,7 @@ void main() {
           'utm_source': 'newsletter',
         });
 
-        await analyticsService.handleIdentityChange('a' * 64);
+        await analyticsService.handleIdentityChange();
 
         verify(queue.clear).called(1);
         expect(analyticsService.productAnalyticsUtm, isEmpty);
@@ -483,7 +511,7 @@ void main() {
           position: 0,
           visibleMs: 1000,
         );
-        await analyticsService.handleIdentityChange('a' * 64);
+        await analyticsService.handleIdentityChange();
         await analyticsService.recordContentImpression(
           contentId: 'c' * 64,
           surface: ProductAnalyticsV2Surface.feed,
@@ -530,7 +558,7 @@ void main() {
         );
         // First login is still an identity boundary. Pre-login activity must
         // not be joinable to the newly authenticated account.
-        await analyticsService.handleIdentityChange(null);
+        await analyticsService.handleIdentityChange();
         await analyticsService.recordRegistrationStarted(
           entryPoint: ProductAnalyticsV2RegistrationEntryPoint.invite,
         );

--- a/mobile/test/services/analytics_service_test.dart
+++ b/mobile/test/services/analytics_service_test.dart
@@ -377,10 +377,10 @@ void main() {
     );
 
     test(
-      'account changes purge the previous owner and acquisition data',
+      'account changes purge every queued row and acquisition data',
       () async {
         final queue = _MockProductEventQueue();
-        when(() => queue.clearOwner(any())).thenAnswer((_) async {});
+        when(queue.clear).thenAnswer((_) async {});
         analyticsService.dispose();
         analyticsService = AnalyticsService(
           productEventQueue: queue,
@@ -393,7 +393,7 @@ void main() {
 
         await analyticsService.handleIdentityChange('a' * 64);
 
-        verify(() => queue.clearOwner('a' * 64)).called(1);
+        verify(queue.clear).called(1);
         expect(analyticsService.productAnalyticsUtm, isEmpty);
       },
     );
@@ -467,7 +467,7 @@ void main() {
           () => queue.enqueue(any(), ownerPubkey: any(named: 'ownerPubkey')),
         ).thenAnswer((_) async {});
         when(queue.flush).thenAnswer((_) async {});
-        when(() => queue.clearOwner(any())).thenAnswer((_) async {});
+        when(queue.clear).thenAnswer((_) async {});
         when(queue.recoverPublishingAndFlush).thenAnswer((_) async {});
         analyticsService.dispose();
         analyticsService = AnalyticsService(
@@ -508,12 +508,13 @@ void main() {
     );
 
     test(
-      'keeps identifiers across the anonymous-to-first-login boundary',
+      'rotates identifiers across the anonymous-to-first-login boundary',
       () async {
         final queue = _MockProductEventQueue();
         when(
           () => queue.enqueue(any(), ownerPubkey: any(named: 'ownerPubkey')),
         ).thenAnswer((_) async {});
+        when(queue.clear).thenAnswer((_) async {});
         when(queue.flush).thenAnswer((_) async {});
         when(queue.recoverPublishingAndFlush).thenAnswer((_) async {});
         analyticsService.dispose();
@@ -527,8 +528,8 @@ void main() {
         await analyticsService.recordRegistrationStarted(
           entryPoint: ProductAnalyticsV2RegistrationEntryPoint.landing,
         );
-        // First login has no outgoing account: the acquisition funnel join
-        // must survive.
+        // First login is still an identity boundary. Pre-login activity must
+        // not be joinable to the newly authenticated account.
         await analyticsService.handleIdentityChange(null);
         await analyticsService.recordRegistrationStarted(
           entryPoint: ProductAnalyticsV2RegistrationEntryPoint.invite,
@@ -545,8 +546,9 @@ void main() {
                 .map((event) => event.envelope)
                 .toList();
         expect(envelopes, hasLength(2));
-        expect(envelopes[1].anonymousId, envelopes[0].anonymousId);
-        expect(envelopes[1].sessionId, envelopes[0].sessionId);
+        expect(envelopes[1].anonymousId, isNot(envelopes[0].anonymousId));
+        expect(envelopes[1].sessionId, isNot(envelopes[0].sessionId));
+        verify(queue.clear).called(1);
       },
     );
 

--- a/mobile/test/services/product_event_queue_test.dart
+++ b/mobile/test/services/product_event_queue_test.dart
@@ -296,15 +296,12 @@ void main() {
       verify(() => dao.markDeadLetter('event-a', 'schema rejected')).called(1);
     });
 
-    test('clear and clearOwner purge private queued data', () async {
+    test('clear purges all private queued data', () async {
       when(() => dao.deleteAll()).thenAnswer((_) async => 2);
-      when(() => dao.deleteForOwner(owner)).thenAnswer((_) async => 1);
 
       await queue.clear();
-      await queue.clearOwner(owner);
 
       verify(() => dao.deleteAll()).called(1);
-      verify(() => dao.deleteForOwner(owner)).called(1);
     });
   });
 }


### PR DESCRIPTION
## Summary

- Rotate the anonymous and session analytics identifiers on first login, logout, account switches, and analytics-consent withdrawal.
- Clear every queued analytics row at those privacy boundaries, including anonymous rows.
- Pin the generated mobile event definitions to the merged privacy contract.
- Remove the obsolete owner-specific queue purge path.

## Why

The first mobile analytics change deliberately kept pre-login identifiers after signup so acquisition activity could be joined to the new account. The approved privacy decision in divinevideo/divine-context#94 forbids that join and also requires fresh identifiers after consent withdrawal.

The service-level first-login change was not enough by itself: the app's auth listener skipped anonymous-to-authenticated transitions. The listener now applies the boundary whenever the observed pubkey changes, while the ordered logout teardown prevents duplicate rotation. Clearing the whole queue makes the boundary unambiguous because anonymous rows cannot survive alongside account-owned rows.

Part of #7978. Related to #7938 and divinevideo/divine-context#94.

## Validation

- Provider regression coverage for anonymous-to-first-login wiring and single logout rotation.
- Analytics service regression coverage for fresh identifiers after consent withdrawal and re-consent.
- Focused analytics, provider, queue, and pending-event DAO tests: 53 passed in the pre-push gate.
- Full `db_client` package suite: 994 passed.
- `flutter analyze`: no issues.
- Generated-file verification and `dart run tools/check_product_analytics_contract.dart`.
- All GitHub checks green, including four test shards, service integration tests, generated files, analysis, formatting, goldens, DB Client CI, and web preview.

The first-login provider and consent-withdrawal regressions both failed before their respective fixes.

## User-visible change

None. Product analytics collection remains off.
