### PR TITLE
feat(video-editor): duplicate stop-motion frames and fix their block drag

### DIFF
--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -4225,6 +4225,7 @@
     "videoEditorDeleteSelectedClipsSemanticLabel": "የተመረጡ ቅንጥቦችን ሰርዝ",
     "videoEditorDeleteSelectedFramesSemanticLabel": "የተመረጡ ፍሬሞችን ሰርዝ",
     "videoEditorReverseSelectedFramesSemanticLabel": "የተመረጡ ፍሬሞችን አገላብጥ",
+    "videoEditorDuplicateSelectedFramesSemanticLabel": "የተመረጡ ፍሬሞችን ያባዛ",
     "videoEditorStopMotionTooShortSnackbar": "ቪዲዮው ቢያንስ {seconds} ሰከንድ መሆን አለበት — ጥቂት ተጨማሪ ፍሬሞችን ያንሱ።",
     "videoEditorMergeProgressLabel": "ትንሽ ይቆዩ፣ ቅንጥቦችዎን እያዋሃድን ነው",
     "videoEditorMergeFailed": "ቅንጥቦችን ማዋሃድ አልተቻለም። እባክዎ እንደገና ይሞክሩ።",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -4100,6 +4100,7 @@
     "videoEditorDeleteSelectedClipsSemanticLabel": "حذف المقاطع المحددة",
     "videoEditorDeleteSelectedFramesSemanticLabel": "حذف الإطارات المحددة",
     "videoEditorReverseSelectedFramesSemanticLabel": "عكس الإطارات المحددة",
+    "videoEditorDuplicateSelectedFramesSemanticLabel": "تكرار الإطارات المحددة",
     "videoEditorStopMotionTooShortSnackbar": "يجب أن يكون الفيديو {seconds} ثانية على الأقل — التقط بضعة إطارات إضافية.",
     "videoEditorMergeProgressLabel": "لحظة من فضلك، نقوم بدمج مقاطعك",
     "videoEditorMergeFailed": "تعذّر دمج المقاطع. يُرجى المحاولة مرة أخرى.",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -4231,6 +4231,7 @@
     "videoEditorDeleteSelectedClipsSemanticLabel": "Изтриване на избраните клипове",
     "videoEditorDeleteSelectedFramesSemanticLabel": "Изтриване на избраните кадри",
     "videoEditorReverseSelectedFramesSemanticLabel": "Обръщане на избраните кадри",
+    "videoEditorDuplicateSelectedFramesSemanticLabel": "Дублиране на избраните кадри",
     "videoEditorStopMotionTooShortSnackbar": "Видеото трябва да е поне {seconds}с — заснеми още няколко кадъра.",
     "videoEditorMergeProgressLabel": "Един момент, обединяваме клиповете ти",
     "videoEditorMergeFailed": "Клиповете не могат да бъдат обединени. Опитай отново.",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -4100,6 +4100,7 @@
     "videoEditorDeleteSelectedClipsSemanticLabel": "Ausgewählte Clips löschen",
     "videoEditorDeleteSelectedFramesSemanticLabel": "Ausgewählte Frames löschen",
     "videoEditorReverseSelectedFramesSemanticLabel": "Ausgewählte Frames umkehren",
+    "videoEditorDuplicateSelectedFramesSemanticLabel": "Ausgewählte Frames duplizieren",
     "videoEditorStopMotionTooShortSnackbar": "Dein Video braucht mindestens {seconds}s – nimm noch ein paar Frames auf.",
     "videoEditorMergeProgressLabel": "Einen Moment, wir führen deine Clips zusammen",
     "videoEditorMergeFailed": "Clips konnten nicht zusammengeführt werden. Bitte versuche es erneut.",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -6089,6 +6089,10 @@
   "@videoEditorReverseSelectedFramesSemanticLabel": {
     "description": "Semantic label for the reverse button while stop-motion stills are multi-selected."
   },
+  "videoEditorDuplicateSelectedFramesSemanticLabel": "Duplicate selected frames",
+  "@videoEditorDuplicateSelectedFramesSemanticLabel": {
+    "description": "Semantic label for the duplicate button while stop-motion stills are multi-selected."
+  },
   "videoEditorStopMotionTooShortSnackbar": "Your video needs at least {seconds}s — capture a few more frames.",
   "@videoEditorStopMotionTooShortSnackbar": {
     "description": "Snackbar shown when Done is pressed on a stop-motion composition shorter than the minimum output duration.",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -4100,6 +4100,7 @@
     "videoEditorDeleteSelectedClipsSemanticLabel": "Eliminar clips seleccionados",
     "videoEditorDeleteSelectedFramesSemanticLabel": "Eliminar fotogramas seleccionados",
     "videoEditorReverseSelectedFramesSemanticLabel": "Invertir fotogramas seleccionados",
+    "videoEditorDuplicateSelectedFramesSemanticLabel": "Duplicar fotogramas seleccionados",
     "videoEditorStopMotionTooShortSnackbar": "Tu video necesita al menos {seconds}s: captura algunos fotogramas más.",
     "videoEditorMergeProgressLabel": "Un momento, estamos combinando tus clips",
     "videoEditorMergeFailed": "No se pudieron combinar los clips. Inténtalo de nuevo.",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -2896,6 +2896,7 @@
     "videoEditorDeleteSelectedClipsSemanticLabel": "Tanggalin ang mga napiling clip",
     "videoEditorDeleteSelectedFramesSemanticLabel": "Tanggalin ang mga napiling frame",
     "videoEditorReverseSelectedFramesSemanticLabel": "Baligtarin ang mga napiling frame",
+    "videoEditorDuplicateSelectedFramesSemanticLabel": "I-duplicate ang mga napiling frame",
     "videoEditorStopMotionTooShortSnackbar": "Kailangang hindi bababa sa {seconds} segundo ang video mo — kumuha pa ng ilang frame.",
     "videoEditorMergeProgressLabel": "Sandali lang, pinagsasama namin ang iyong mga clip",
     "videoEditorMergeFailed": "Hindi mapagsama ang mga clip. Pakisubukang muli.",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -4100,6 +4100,7 @@
     "videoEditorDeleteSelectedClipsSemanticLabel": "Supprimer les clips sélectionnés",
     "videoEditorDeleteSelectedFramesSemanticLabel": "Supprimer les images sélectionnées",
     "videoEditorReverseSelectedFramesSemanticLabel": "Inverser les images sélectionnées",
+    "videoEditorDuplicateSelectedFramesSemanticLabel": "Dupliquer les images sélectionnées",
     "videoEditorStopMotionTooShortSnackbar": "Ta vidéo doit durer au moins {seconds}s — capture encore quelques images.",
     "videoEditorMergeProgressLabel": "Un instant, nous fusionnons vos clips",
     "videoEditorMergeFailed": "Impossible de fusionner les clips. Veuillez réessayer.",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -4100,6 +4100,7 @@
     "videoEditorDeleteSelectedClipsSemanticLabel": "Hapus klip yang dipilih",
     "videoEditorDeleteSelectedFramesSemanticLabel": "Hapus bingkai yang dipilih",
     "videoEditorReverseSelectedFramesSemanticLabel": "Balikkan bingkai yang dipilih",
+    "videoEditorDuplicateSelectedFramesSemanticLabel": "Duplikat bingkai yang dipilih",
     "videoEditorStopMotionTooShortSnackbar": "Videomu harus minimal {seconds} detik — ambil beberapa bingkai lagi.",
     "videoEditorMergeProgressLabel": "Sebentar, kami sedang menggabungkan klipmu",
     "videoEditorMergeFailed": "Tidak dapat menggabungkan klip. Silakan coba lagi.",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -4100,6 +4100,7 @@
     "videoEditorDeleteSelectedClipsSemanticLabel": "Elimina le clip selezionate",
     "videoEditorDeleteSelectedFramesSemanticLabel": "Elimina i fotogrammi selezionati",
     "videoEditorReverseSelectedFramesSemanticLabel": "Inverti i fotogrammi selezionati",
+    "videoEditorDuplicateSelectedFramesSemanticLabel": "Duplica i fotogrammi selezionati",
     "videoEditorStopMotionTooShortSnackbar": "Il tuo video deve durare almeno {seconds}s: scatta ancora qualche fotogramma.",
     "videoEditorMergeProgressLabel": "Un momento, stiamo unendo le tue clip",
     "videoEditorMergeFailed": "Impossibile unire le clip. Riprova.",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -4100,6 +4100,7 @@
     "videoEditorDeleteSelectedClipsSemanticLabel": "選択したクリップを削除",
     "videoEditorDeleteSelectedFramesSemanticLabel": "選択したフレームを削除",
     "videoEditorReverseSelectedFramesSemanticLabel": "選択したフレームを逆順にする",
+    "videoEditorDuplicateSelectedFramesSemanticLabel": "選択したフレームを複製",
     "videoEditorStopMotionTooShortSnackbar": "動画は{seconds}秒以上必要です。もう少しフレームを撮影してください。",
     "videoEditorMergeProgressLabel": "少々お待ちください。クリップを結合しています",
     "videoEditorMergeFailed": "クリップを結合できませんでした。もう一度お試しください。",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -3561,6 +3561,7 @@
     "videoEditorDeleteSelectedClipsSemanticLabel": "선택한 클립 삭제",
     "videoEditorDeleteSelectedFramesSemanticLabel": "선택한 프레임 삭제",
     "videoEditorReverseSelectedFramesSemanticLabel": "선택한 프레임 순서 뒤집기",
+    "videoEditorDuplicateSelectedFramesSemanticLabel": "선택한 프레임 복제",
     "videoEditorStopMotionTooShortSnackbar": "영상은 최소 {seconds}초여야 해요. 프레임을 몇 장 더 찍어 주세요.",
     "videoEditorMergeProgressLabel": "잠시만요, 클립을 병합하고 있어요",
     "videoEditorMergeFailed": "클립을 병합할 수 없습니다. 다시 시도해 주세요.",

--- a/mobile/lib/l10n/app_ms.arb
+++ b/mobile/lib/l10n/app_ms.arb
@@ -5355,6 +5355,10 @@
   "@videoEditorReverseSelectedFramesSemanticLabel": {
     "description": "Semantic label for the reverse button while stop-motion stills are multi-selected."
   },
+  "videoEditorDuplicateSelectedFramesSemanticLabel": "Duplikasi bingkai dipilih",
+  "@videoEditorDuplicateSelectedFramesSemanticLabel": {
+    "description": "Semantic label for the duplicate button while stop-motion stills are multi-selected."
+  },
   "videoEditorStopMotionTooShortSnackbar": "Video anda memerlukan sekurang-kurangnya {seconds}s — rakam beberapa bingkai lagi.",
   "@videoEditorStopMotionTooShortSnackbar": {
     "description": "Snackbar shown when Done is pressed on a stop-motion composition shorter than the minimum output duration.",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -4100,6 +4100,7 @@
     "videoEditorDeleteSelectedClipsSemanticLabel": "Geselecteerde clips verwijderen",
     "videoEditorDeleteSelectedFramesSemanticLabel": "Geselecteerde frames verwijderen",
     "videoEditorReverseSelectedFramesSemanticLabel": "Geselecteerde frames omkeren",
+    "videoEditorDuplicateSelectedFramesSemanticLabel": "Geselecteerde frames dupliceren",
     "videoEditorStopMotionTooShortSnackbar": "Je video moet minstens {seconds}s duren – leg nog een paar frames vast.",
     "videoEditorMergeProgressLabel": "Een moment, we voegen je clips samen",
     "videoEditorMergeFailed": "Kan clips niet samenvoegen. Probeer het opnieuw.",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -4100,6 +4100,7 @@
     "videoEditorDeleteSelectedClipsSemanticLabel": "Usuń zaznaczone klipy",
     "videoEditorDeleteSelectedFramesSemanticLabel": "Usuń zaznaczone klatki",
     "videoEditorReverseSelectedFramesSemanticLabel": "Odwróć zaznaczone klatki",
+    "videoEditorDuplicateSelectedFramesSemanticLabel": "Duplikuj zaznaczone klatki",
     "videoEditorStopMotionTooShortSnackbar": "Twój film musi trwać co najmniej {seconds}s – dodaj jeszcze kilka klatek.",
     "videoEditorMergeProgressLabel": "Chwila, scalamy Twoje klipy",
     "videoEditorMergeFailed": "Nie udało się scalić klipów. Spróbuj ponownie.",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -4100,6 +4100,7 @@
     "videoEditorDeleteSelectedClipsSemanticLabel": "Excluir clipes selecionados",
     "videoEditorDeleteSelectedFramesSemanticLabel": "Excluir quadros selecionados",
     "videoEditorReverseSelectedFramesSemanticLabel": "Inverter quadros selecionados",
+    "videoEditorDuplicateSelectedFramesSemanticLabel": "Duplicar quadros selecionados",
     "videoEditorStopMotionTooShortSnackbar": "Seu vídeo precisa de pelo menos {seconds}s — capture mais alguns quadros.",
     "videoEditorMergeProgressLabel": "Um momento, estamos mesclando seus clipes",
     "videoEditorMergeFailed": "Não foi possível mesclar os clipes. Tente novamente.",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -4100,6 +4100,7 @@
     "videoEditorDeleteSelectedClipsSemanticLabel": "Șterge clipurile selectate",
     "videoEditorDeleteSelectedFramesSemanticLabel": "Șterge cadrele selectate",
     "videoEditorReverseSelectedFramesSemanticLabel": "Inversează cadrele selectate",
+    "videoEditorDuplicateSelectedFramesSemanticLabel": "Duplichează cadrele selectate",
     "videoEditorStopMotionTooShortSnackbar": "Videoclipul tău trebuie să dureze cel puțin {seconds}s — capturează încă câteva cadre.",
     "videoEditorMergeProgressLabel": "Un moment, îți îmbinăm clipurile",
     "videoEditorMergeFailed": "Clipurile nu au putut fi îmbinate. Încearcă din nou.",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -4100,6 +4100,7 @@
     "videoEditorDeleteSelectedClipsSemanticLabel": "Ta bort markerade klipp",
     "videoEditorDeleteSelectedFramesSemanticLabel": "Ta bort markerade bildrutor",
     "videoEditorReverseSelectedFramesSemanticLabel": "Vänd markerade bildrutor",
+    "videoEditorDuplicateSelectedFramesSemanticLabel": "Duplicera markerade bildrutor",
     "videoEditorStopMotionTooShortSnackbar": "Din video måste vara minst {seconds}s – ta några bildrutor till.",
     "videoEditorMergeProgressLabel": "Ett ögonblick, vi slår samman dina klipp",
     "videoEditorMergeFailed": "Det gick inte att slå samman klippen. Försök igen.",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -4100,6 +4100,7 @@
     "videoEditorDeleteSelectedClipsSemanticLabel": "Seçili klipleri sil",
     "videoEditorDeleteSelectedFramesSemanticLabel": "Seçili kareleri sil",
     "videoEditorReverseSelectedFramesSemanticLabel": "Seçili kareleri ters çevir",
+    "videoEditorDuplicateSelectedFramesSemanticLabel": "Seçili kareleri çoğalt",
     "videoEditorStopMotionTooShortSnackbar": "Videon en az {seconds}sn olmalı — birkaç kare daha çek.",
     "videoEditorMergeProgressLabel": "Bir saniye, kliplerini birleştiriyoruz",
     "videoEditorMergeFailed": "Klipler birleştirilemedi. Lütfen tekrar dene.",

--- a/mobile/lib/l10n/app_ur.arb
+++ b/mobile/lib/l10n/app_ur.arb
@@ -5355,6 +5355,10 @@
   "@videoEditorReverseSelectedFramesSemanticLabel": {
     "description": "Semantic label for the reverse button while stop-motion stills are multi-selected."
   },
+  "videoEditorDuplicateSelectedFramesSemanticLabel": "منتخب فریم کی نقل کریں",
+  "@videoEditorDuplicateSelectedFramesSemanticLabel": {
+    "description": "Semantic label for the duplicate button while stop-motion stills are multi-selected."
+  },
   "videoEditorStopMotionTooShortSnackbar": "آپ کی ویڈیو کو کم از کم {seconds}s چاہیے — کچھ اور فریم پکڑیں۔",
   "@videoEditorStopMotionTooShortSnackbar": {
     "description": "Snackbar shown when Done is pressed on a stop-motion composition shorter than the minimum output duration.",

--- a/mobile/lib/l10n/app_vi.arb
+++ b/mobile/lib/l10n/app_vi.arb
@@ -5355,6 +5355,10 @@
   "@videoEditorReverseSelectedFramesSemanticLabel": {
     "description": "Semantic label for the reverse button while stop-motion stills are multi-selected."
   },
+  "videoEditorDuplicateSelectedFramesSemanticLabel": "Nhân bản các khung hình đã chọn",
+  "@videoEditorDuplicateSelectedFramesSemanticLabel": {
+    "description": "Semantic label for the duplicate button while stop-motion stills are multi-selected."
+  },
   "videoEditorStopMotionTooShortSnackbar": "Video của bạn cần ít nhất {seconds}s — hãy chụp thêm vài khung hình.",
   "@videoEditorStopMotionTooShortSnackbar": {
     "description": "Snackbar shown when Done is pressed on a stop-motion composition shorter than the minimum output duration.",

--- a/mobile/lib/l10n/app_zh.arb
+++ b/mobile/lib/l10n/app_zh.arb
@@ -5355,6 +5355,10 @@
   "@videoEditorReverseSelectedFramesSemanticLabel": {
     "description": "Semantic label for the reverse button while stop-motion stills are multi-selected."
   },
+  "videoEditorDuplicateSelectedFramesSemanticLabel": "复制选中帧",
+  "@videoEditorDuplicateSelectedFramesSemanticLabel": {
+    "description": "Semantic label for the duplicate button while stop-motion stills are multi-selected."
+  },
   "videoEditorStopMotionTooShortSnackbar": "视频至少需要 {seconds} 秒——再多拍几帧吧。",
   "@videoEditorStopMotionTooShortSnackbar": {
     "description": "Snackbar shown when Done is pressed on a stop-motion composition shorter than the minimum output duration.",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -15460,6 +15460,12 @@ abstract class AppLocalizations {
   /// **'Reverse selected frames'**
   String get videoEditorReverseSelectedFramesSemanticLabel;
 
+  /// Semantic label for the duplicate button while stop-motion stills are multi-selected.
+  ///
+  /// In en, this message translates to:
+  /// **'Duplicate selected frames'**
+  String get videoEditorDuplicateSelectedFramesSemanticLabel;
+
   /// Snackbar shown when Done is pressed on a stop-motion composition shorter than the minimum output duration.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -8845,6 +8845,10 @@ class AppLocalizationsAm extends AppLocalizations {
       'የተመረጡ ፍሬሞችን አገላብጥ';
 
   @override
+  String get videoEditorDuplicateSelectedFramesSemanticLabel =>
+      'የተመረጡ ፍሬሞችን ያባዛ';
+
+  @override
   String videoEditorStopMotionTooShortSnackbar(int seconds) {
     return 'ቪዲዮው ቢያንስ $seconds ሰከንድ መሆን አለበት — ጥቂት ተጨማሪ ፍሬሞችን ያንሱ።';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -8997,6 +8997,10 @@ class AppLocalizationsAr extends AppLocalizations {
       'عكس الإطارات المحددة';
 
   @override
+  String get videoEditorDuplicateSelectedFramesSemanticLabel =>
+      'تكرار الإطارات المحددة';
+
+  @override
   String videoEditorStopMotionTooShortSnackbar(int seconds) {
     return 'يجب أن يكون الفيديو $seconds ثانية على الأقل — التقط بضعة إطارات إضافية.';
   }

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -9140,6 +9140,10 @@ class AppLocalizationsBg extends AppLocalizations {
       'Обръщане на избраните кадри';
 
   @override
+  String get videoEditorDuplicateSelectedFramesSemanticLabel =>
+      'Дублиране на избраните кадри';
+
+  @override
   String videoEditorStopMotionTooShortSnackbar(int seconds) {
     return 'Видеото трябва да е поне $secondsс — заснеми още няколко кадъра.';
   }

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -9167,6 +9167,10 @@ class AppLocalizationsDe extends AppLocalizations {
       'Ausgewählte Frames umkehren';
 
   @override
+  String get videoEditorDuplicateSelectedFramesSemanticLabel =>
+      'Ausgewählte Frames duplizieren';
+
+  @override
   String videoEditorStopMotionTooShortSnackbar(int seconds) {
     return 'Dein Video braucht mindestens ${seconds}s – nimm noch ein paar Frames auf.';
   }

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -9163,6 +9163,10 @@ class AppLocalizationsEn extends AppLocalizations {
       'Reverse selected frames';
 
   @override
+  String get videoEditorDuplicateSelectedFramesSemanticLabel =>
+      'Duplicate selected frames';
+
+  @override
   String videoEditorStopMotionTooShortSnackbar(int seconds) {
     return 'Your video needs at least ${seconds}s — capture a few more frames.';
   }

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -9142,6 +9142,10 @@ class AppLocalizationsEs extends AppLocalizations {
       'Invertir fotogramas seleccionados';
 
   @override
+  String get videoEditorDuplicateSelectedFramesSemanticLabel =>
+      'Duplicar fotogramas seleccionados';
+
+  @override
   String videoEditorStopMotionTooShortSnackbar(int seconds) {
     return 'Tu video necesita al menos ${seconds}s: captura algunos fotogramas más.';
   }

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -9127,6 +9127,10 @@ class AppLocalizationsFil extends AppLocalizations {
       'Baligtarin ang mga napiling frame';
 
   @override
+  String get videoEditorDuplicateSelectedFramesSemanticLabel =>
+      'I-duplicate ang mga napiling frame';
+
+  @override
   String videoEditorStopMotionTooShortSnackbar(int seconds) {
     return 'Kailangang hindi bababa sa $seconds segundo ang video mo — kumuha pa ng ilang frame.';
   }

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -9188,6 +9188,10 @@ class AppLocalizationsFr extends AppLocalizations {
       'Inverser les images sélectionnées';
 
   @override
+  String get videoEditorDuplicateSelectedFramesSemanticLabel =>
+      'Dupliquer les images sélectionnées';
+
+  @override
   String videoEditorStopMotionTooShortSnackbar(int seconds) {
     return 'Ta vidéo doit durer au moins ${seconds}s — capture encore quelques images.';
   }

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -8976,6 +8976,10 @@ class AppLocalizationsId extends AppLocalizations {
       'Balikkan bingkai yang dipilih';
 
   @override
+  String get videoEditorDuplicateSelectedFramesSemanticLabel =>
+      'Duplikat bingkai yang dipilih';
+
+  @override
   String videoEditorStopMotionTooShortSnackbar(int seconds) {
     return 'Videomu harus minimal $seconds detik — ambil beberapa bingkai lagi.';
   }

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -9157,6 +9157,10 @@ class AppLocalizationsIt extends AppLocalizations {
       'Inverti i fotogrammi selezionati';
 
   @override
+  String get videoEditorDuplicateSelectedFramesSemanticLabel =>
+      'Duplica i fotogrammi selezionati';
+
+  @override
   String videoEditorStopMotionTooShortSnackbar(int seconds) {
     return 'Il tuo video deve durare almeno ${seconds}s: scatta ancora qualche fotogramma.';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -8615,6 +8615,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get videoEditorReverseSelectedFramesSemanticLabel => '選択したフレームを逆順にする';
 
   @override
+  String get videoEditorDuplicateSelectedFramesSemanticLabel => '選択したフレームを複製';
+
+  @override
   String videoEditorStopMotionTooShortSnackbar(int seconds) {
     return '動画は$seconds秒以上必要です。もう少しフレームを撮影してください。';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -8633,6 +8633,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get videoEditorReverseSelectedFramesSemanticLabel => '선택한 프레임 순서 뒤집기';
 
   @override
+  String get videoEditorDuplicateSelectedFramesSemanticLabel => '선택한 프레임 복제';
+
+  @override
   String videoEditorStopMotionTooShortSnackbar(int seconds) {
     return '영상은 최소 $seconds초여야 해요. 프레임을 몇 장 더 찍어 주세요.';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -9067,6 +9067,10 @@ class AppLocalizationsMs extends AppLocalizations {
       'Songsangkan bingkai dipilih';
 
   @override
+  String get videoEditorDuplicateSelectedFramesSemanticLabel =>
+      'Duplikasi bingkai dipilih';
+
+  @override
   String videoEditorStopMotionTooShortSnackbar(int seconds) {
     return 'Video anda memerlukan sekurang-kurangnya ${seconds}s — rakam beberapa bingkai lagi.';
   }

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -9095,6 +9095,10 @@ class AppLocalizationsNl extends AppLocalizations {
       'Geselecteerde frames omkeren';
 
   @override
+  String get videoEditorDuplicateSelectedFramesSemanticLabel =>
+      'Geselecteerde frames dupliceren';
+
+  @override
   String videoEditorStopMotionTooShortSnackbar(int seconds) {
     return 'Je video moet minstens ${seconds}s duren – leg nog een paar frames vast.';
   }

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -9238,6 +9238,10 @@ class AppLocalizationsPl extends AppLocalizations {
       'Odwróć zaznaczone klatki';
 
   @override
+  String get videoEditorDuplicateSelectedFramesSemanticLabel =>
+      'Duplikuj zaznaczone klatki';
+
+  @override
   String videoEditorStopMotionTooShortSnackbar(int seconds) {
     return 'Twój film musi trwać co najmniej ${seconds}s – dodaj jeszcze kilka klatek.';
   }

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -9120,6 +9120,10 @@ class AppLocalizationsPt extends AppLocalizations {
       'Inverter quadros selecionados';
 
   @override
+  String get videoEditorDuplicateSelectedFramesSemanticLabel =>
+      'Duplicar quadros selecionados';
+
+  @override
   String videoEditorStopMotionTooShortSnackbar(int seconds) {
     return 'Seu vídeo precisa de pelo menos ${seconds}s — capture mais alguns quadros.';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -9259,6 +9259,10 @@ class AppLocalizationsRo extends AppLocalizations {
       'Inversează cadrele selectate';
 
   @override
+  String get videoEditorDuplicateSelectedFramesSemanticLabel =>
+      'Duplichează cadrele selectate';
+
+  @override
   String videoEditorStopMotionTooShortSnackbar(int seconds) {
     return 'Videoclipul tău trebuie să dureze cel puțin ${seconds}s — capturează încă câteva cadre.';
   }

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -9053,6 +9053,10 @@ class AppLocalizationsSv extends AppLocalizations {
       'Vänd markerade bildrutor';
 
   @override
+  String get videoEditorDuplicateSelectedFramesSemanticLabel =>
+      'Duplicera markerade bildrutor';
+
+  @override
   String videoEditorStopMotionTooShortSnackbar(int seconds) {
     return 'Din video måste vara minst ${seconds}s – ta några bildrutor till.';
   }

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -8973,6 +8973,10 @@ class AppLocalizationsTr extends AppLocalizations {
       'Seçili kareleri ters çevir';
 
   @override
+  String get videoEditorDuplicateSelectedFramesSemanticLabel =>
+      'Seçili kareleri çoğalt';
+
+  @override
   String videoEditorStopMotionTooShortSnackbar(int seconds) {
     return 'Videon en az ${seconds}sn olmalı — birkaç kare daha çek.';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -9050,6 +9050,10 @@ class AppLocalizationsUr extends AppLocalizations {
       'منتخب فریم الٹائیں';
 
   @override
+  String get videoEditorDuplicateSelectedFramesSemanticLabel =>
+      'منتخب فریم کی نقل کریں';
+
+  @override
   String videoEditorStopMotionTooShortSnackbar(int seconds) {
     return 'آپ کی ویڈیو کو کم از کم ${seconds}s چاہیے — کچھ اور فریم پکڑیں۔';
   }

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -9017,6 +9017,10 @@ class AppLocalizationsVi extends AppLocalizations {
       'Đảo ngược các khung hình đã chọn';
 
   @override
+  String get videoEditorDuplicateSelectedFramesSemanticLabel =>
+      'Nhân bản các khung hình đã chọn';
+
+  @override
   String videoEditorStopMotionTooShortSnackbar(int seconds) {
     return 'Video của bạn cần ít nhất ${seconds}s — hãy chụp thêm vài khung hình.';
   }

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -8555,6 +8555,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get videoEditorReverseSelectedFramesSemanticLabel => '倒放选中帧';
 
   @override
+  String get videoEditorDuplicateSelectedFramesSemanticLabel => '复制选中帧';
+
+  @override
   String videoEditorStopMotionTooShortSnackbar(int seconds) {
     return '视频至少需要 $seconds 秒——再多拍几帧吧。';
   }

--- a/mobile/lib/models/stop_motion/stop_motion_frame_ops.dart
+++ b/mobile/lib/models/stop_motion/stop_motion_frame_ops.dart
@@ -363,7 +363,7 @@ abstract class StopMotionFrameOps {
         indexes.any((index) => index < 0 || index >= frames.length)) {
       return frames;
     }
-    final at = indexes.reduce((a, b) => a > b ? a : b) + 1;
+    final at = duplicateInsertIndex(indexes);
     return [
       ...frames.sublist(0, at),
       for (var i = 0; i < frames.length; i++)
@@ -371,6 +371,12 @@ abstract class StopMotionFrameOps {
       ...frames.sublist(at),
     ];
   }
+
+  /// Index the block of copies [duplicateFrames] inserts at, so the caller can
+  /// move the selection onto them (`at .. at + indexes.length - 1`) without
+  /// re-deriving where they landed. [indexes] must not be empty.
+  static int duplicateInsertIndex(Set<int> indexes) =>
+      indexes.reduce((a, b) => a > b ? a : b) + 1;
 
   /// [frames] with every still at [indexes] held for [framesPerImage] output
   /// frames, each marked as an individual override (see [setFrameHold]).

--- a/mobile/lib/models/stop_motion/stop_motion_frame_ops.dart
+++ b/mobile/lib/models/stop_motion/stop_motion_frame_ops.dart
@@ -341,6 +341,37 @@ abstract class StopMotionFrameOps {
     return frames;
   }
 
+  /// [frames] with a copy of every still at [indexes] — in their current
+  /// relative order — inserted as one block directly after the last selected
+  /// still (frame multi-select "duplicate").
+  ///
+  /// The copies land together rather than each beside its own source, so a
+  /// selected run duplicates into a repeat of itself — the point of the action
+  /// in a stop-motion sequence. A single selected still therefore behaves
+  /// exactly like the per-still duplicate in the clip controls: the copy
+  /// follows its source.
+  ///
+  /// Copies share the source still's image file and hold; nothing about a
+  /// still is per-instance, so the frames are reused rather than cloned.
+  /// Returns the list unchanged when the selection is empty or contains an
+  /// out-of-range index.
+  static List<StopMotionClipFrame> duplicateFrames(
+    List<StopMotionClipFrame> frames,
+    Set<int> indexes,
+  ) {
+    if (indexes.isEmpty ||
+        indexes.any((index) => index < 0 || index >= frames.length)) {
+      return frames;
+    }
+    final at = indexes.reduce((a, b) => a > b ? a : b) + 1;
+    return [
+      ...frames.sublist(0, at),
+      for (var i = 0; i < frames.length; i++)
+        if (indexes.contains(i)) frames[i],
+      ...frames.sublist(at),
+    ];
+  }
+
   /// [frames] with every still at [indexes] held for [framesPerImage] output
   /// frames, each marked as an individual override (see [setFrameHold]).
   /// Out-of-range indexes are ignored.

--- a/mobile/lib/widgets/video_editor/stop_motion/stop_motion_frame_commands.dart
+++ b/mobile/lib/widgets/video_editor/stop_motion/stop_motion_frame_commands.dart
@@ -27,11 +27,12 @@ import 'package:openvine/widgets/video_editor/timeline_editor/video_editor_timel
 /// (the frame-ops helpers return the source list unchanged) is skipped so it
 /// never records an empty history entry.
 ///
-/// Bails when the [ProImageEditorState] is gone — a tap can resolve after the
+/// Returns whether the edit was committed. Bails with `false` when the
+/// [ProImageEditorState] is gone — a tap can resolve after the
 /// editor route is popped, and force-unwrapping it there is a release-mode
 /// crash (#5799). Bailing before the bloc dispatch keeps the frame list and
 /// the editor history from diverging.
-void commitStopMotionFrames(
+bool commitStopMotionFrames(
   BuildContext context, {
   required String clipId,
   required List<StopMotionClipFrame> frames,
@@ -39,19 +40,17 @@ void commitStopMotionFrames(
   final bloc = context.read<ClipEditorBloc>();
   final overlayBloc = context.read<TimelineOverlayBloc>();
   final editor = VideoEditorScope.of(context).editor;
-  if (editor == null) return;
+  if (editor == null) return false;
 
   final state = bloc.state;
   final index = state.clips.indexWhere((clip) => clip.id == clipId);
-  if (index == -1) return;
+  if (index == -1) return false;
 
   final clip = state.clips[index];
-  if (identical(frames, clip.stopMotionFrames)) return;
+  if (identical(frames, clip.stopMotionFrames)) return false;
 
   final updated = StopMotionFrameOps.clipWithFrames(clip, frames);
-  final newClips = [
-    for (final c in state.clips) c.id == clipId ? updated : c,
-  ];
+  final newClips = [for (final c in state.clips) c.id == clipId ? updated : c];
   final rebasedMarkers = rebaseTimelineMarkersForClipState(
     oldClips: state.clips,
     newClips: newClips,
@@ -67,6 +66,7 @@ void commitStopMotionFrames(
     clips: newClips,
     timelineMarkers: rebasedMarkers,
   );
+  return true;
 }
 
 DivineVideoClip? _clip(BuildContext context, String clipId) {

--- a/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls.dart
@@ -300,10 +300,7 @@ class _TimelineClipControlsState extends State<TimelineClipControls> {
     bloc.add(
       // Bind the request to this clip so the render still targets the intended
       // clip even if the selection changes while it runs.
-      ClipEditorSaveClipToLibraryRequested(
-        clipId: clipId,
-        overlays: overlays,
-      ),
+      ClipEditorSaveClipToLibraryRequested(clipId: clipId, overlays: overlays),
     );
   }
 
@@ -468,11 +465,7 @@ class _StopMotionClipControls extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final ({
-      String clipId,
-      List<StopMotionClipFrame> frames,
-      int? selected,
-    })?
+    final ({String clipId, List<StopMotionClipFrame> frames, int? selected})?
     data = context.select((ClipEditorBloc b) {
       final state = b.state;
       final index = state.currentClipIndex;
@@ -506,11 +499,7 @@ class _StopMotionClipControls extends StatelessWidget {
           ? () => commitStopMotionFrames(
               context,
               clipId: data.clipId,
-              frames: [
-                ...frames.sublist(0, selected + 1),
-                frames[selected],
-                ...frames.sublist(selected + 1),
-              ],
+              frames: StopMotionFrameOps.duplicateFrames(frames, {selected}),
             )
           : null,
       // Crop / rotate / flip the selected still. A stop-motion still is an

--- a/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_multi_select_controls.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_multi_select_controls.dart
@@ -69,9 +69,7 @@ class TimelineMultiSelectControls extends StatelessWidget {
   void _delete(BuildContext context) {
     // The bloc owns the clip-list mutation; the scaffold's removed-result
     // listener rebases markers and commits the new list to editor history.
-    context.read<ClipEditorBloc>().add(
-      const ClipEditorSelectedClipsRemoved(),
-    );
+    context.read<ClipEditorBloc>().add(const ClipEditorSelectedClipsRemoved());
   }
 }
 
@@ -238,7 +236,12 @@ class TimelineFrameMultiSelectControls extends StatelessWidget {
     final duplicated = StopMotionFrameOps.duplicateFrames(frames, selection);
     if (identical(duplicated, frames)) return;
 
-    commitStopMotionFrames(context, clipId: clip.id, frames: duplicated);
+    final committed = commitStopMotionFrames(
+      context,
+      clipId: clip.id,
+      frames: duplicated,
+    );
+    if (!committed) return;
 
     final firstCopy = StopMotionFrameOps.duplicateInsertIndex(selection);
     bloc.add(

--- a/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_multi_select_controls.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_multi_select_controls.dart
@@ -76,8 +76,9 @@ class TimelineMultiSelectControls extends StatelessWidget {
 }
 
 /// Action bar shown while a stop-motion composition is in frame multi-select
-/// mode: selection count plus hold / Delete / Done actions on the selected
-/// stills. Delete is gated so at least one still always remains.
+/// mode: selection count plus hold / Reverse / Duplicate / Delete / Done
+/// actions on the selected stills. Delete is gated so at least one still
+/// always remains.
 class TimelineFrameMultiSelectControls extends StatelessWidget {
   const TimelineFrameMultiSelectControls({super.key});
 
@@ -98,8 +99,8 @@ class TimelineFrameMultiSelectControls extends StatelessWidget {
     if (data == null) return const SizedBox.shrink();
 
     final selectedCount = data.selected.length;
-    final canDelete = selectedCount >= 1 && selectedCount < data.frameCount;
-    final canSetHold = selectedCount >= 1;
+    final hasSelection = selectedCount >= 1;
+    final canDelete = hasSelection && selectedCount < data.frameCount;
     final canReverse = selectedCount >= 2;
 
     return DecoratedBox(
@@ -145,7 +146,7 @@ class TimelineFrameMultiSelectControls extends StatelessWidget {
                         semanticLabel: context
                             .l10n
                             .videoEditorStopMotionFramesPerImageLabel,
-                        onPressed: canSetHold
+                        onPressed: hasSelection
                             ? () => editStopMotionFramesHold(
                                 context,
                                 clipId: data.clipId,
@@ -161,6 +162,16 @@ class TimelineFrameMultiSelectControls extends StatelessWidget {
                             .l10n
                             .videoEditorReverseSelectedFramesSemanticLabel,
                         onPressed: canReverse ? () => _reverse(context) : null,
+                      ),
+                      _ControlButton(
+                        icon: .copy,
+                        label: context.l10n.videoEditorDuplicateLabel,
+                        semanticLabel: context
+                            .l10n
+                            .videoEditorDuplicateSelectedFramesSemanticLabel,
+                        onPressed: hasSelection
+                            ? () => _duplicate(context)
+                            : null,
                       ),
                       _ControlButton(
                         icon: .trash,
@@ -209,6 +220,31 @@ class TimelineFrameMultiSelectControls extends StatelessWidget {
         frames,
         state.selectedFrameIndexes,
       ),
+    );
+  }
+
+  /// Repeats the selected stills right after the last of them, then moves the
+  /// selection onto the copies — so the highlight shows what was just created
+  /// and a follow-up drag or hold change acts on the new stills, not the
+  /// originals.
+  void _duplicate(BuildContext context) {
+    final bloc = context.read<ClipEditorBloc>();
+    final state = bloc.state;
+    if (!isStopMotionComposition(state.clips)) return;
+    final clip = state.clips.first;
+    final frames = clip.stopMotionFrames ?? const [];
+    final selection = state.selectedFrameIndexes;
+
+    final duplicated = StopMotionFrameOps.duplicateFrames(frames, selection);
+    if (identical(duplicated, frames)) return;
+
+    commitStopMotionFrames(context, clipId: clip.id, frames: duplicated);
+
+    final firstCopy = selection.reduce((a, b) => a > b ? a : b) + 1;
+    bloc.add(
+      ClipEditorFrameMultiSelectionSet({
+        for (var i = 0; i < selection.length; i++) firstCopy + i,
+      }),
     );
   }
 

--- a/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_multi_select_controls.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_multi_select_controls.dart
@@ -240,7 +240,7 @@ class TimelineFrameMultiSelectControls extends StatelessWidget {
 
     commitStopMotionFrames(context, clipId: clip.id, frames: duplicated);
 
-    final firstCopy = selection.reduce((a, b) => a > b ? a : b) + 1;
+    final firstCopy = StopMotionFrameOps.duplicateInsertIndex(selection);
     bloc.add(
       ClipEditorFrameMultiSelectionSet({
         for (var i = 0; i < selection.length; i++) firstCopy + i,

--- a/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_stop_motion_frame_strip.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_stop_motion_frame_strip.dart
@@ -95,8 +95,9 @@ class _VideoEditorStopMotionFrameStripState
   int _dragStartIndex = 0;
 
   /// Whether the active drag moves the multi-select block instead of a single
-  /// tile. While set, [_orderedFrames] holds only the *unselected* stills and
-  /// [_blockSlot] is the insertion slot among them.
+  /// tile. While set, every still keeps its slot in [_orderedFrames] — the
+  /// selected ones are only dimmed — and [_blockSlot] is the insertion slot in
+  /// that full layout.
   bool _isBlockDrag = false;
 
   /// The selected stills being block-dragged, in their current order.
@@ -106,12 +107,6 @@ class _VideoEditorStopMotionFrameStripState
   /// (`0.._orderedFrames.length`).
   int _blockSlot = 0;
 
-  /// Maps the pickup finger x (measured in the full N-tile layout) into the
-  /// post-removal (N-1 tile) layout. Without it, a zero-distance block drag
-  /// resolves the finger against the shifted widths and jumps by one tile —
-  /// releasing without dragging would silently reorder. See
-  /// [_onBlockDragStart].
-  double _blockDragOffsetX = 0;
   double _dragTargetOffsetX = 0;
 
   // Finger tracking (global X is the source of truth so auto-scroll and the
@@ -204,6 +199,21 @@ class _VideoEditorStopMotionFrameStripState
     return slot;
   }
 
+  /// Translates a block-drag insertion slot in the full N-tile layout into the
+  /// slot [StopMotionFrameOps.moveFrames] expects — an index among the
+  /// *unselected* stills, which is simply how many of them sit left of it.
+  ///
+  /// A slot anywhere inside a contiguous selected run maps back to that run's
+  /// own home, which is what makes releasing without leaving the block a no-op.
+  int _remainingSlotFor(int fullSlot) {
+    final selection = widget.selectedFrameIndexes;
+    var slot = 0;
+    for (var i = 0; i < fullSlot && i < widget.frames.length; i++) {
+      if (!selection.contains(i)) slot++;
+    }
+    return slot;
+  }
+
   void _onLongPressStart(LongPressStartDetails details) {
     if (widget.frames.length <= 1) return;
     if (widget.isMultiSelectMode) {
@@ -239,6 +249,14 @@ class _VideoEditorStopMotionFrameStripState
   /// Starts dragging the whole multi-select block. Only a long-press on a
   /// *selected* tile picks the block up; there must be at least one
   /// unselected still left to move past.
+  ///
+  /// Unlike the single-tile drag, the selected stills are *not* lifted out of
+  /// the layout — they stay in their slots, dimmed. Collapsing a ten-still
+  /// block out of the strip would shift every remaining tile left by the
+  /// block's width mid-gesture, so the insertion slot could only be tracked
+  /// relative to the block's old home — the marker trailed the finger by the
+  /// whole block, dropping the stills back where the first one used to sit.
+  /// Against a layout that does not move, the slot is the one under the finger.
   void _onBlockDragStart(LongPressStartDetails details) {
     final selection = widget.selectedFrameIndexes;
     if (widget.onBlockMove == null ||
@@ -258,24 +276,10 @@ class _VideoEditorStopMotionFrameStripState
         ? ((fingerX - tileLeft) / tileWidth).clamp(0.0, 1.0)
         : 0.5;
 
-    final blockFrames = <StopMotionClipFrame>[];
-    final remaining = <StopMotionClipFrame>[];
-    for (var i = 0; i < widget.frames.length; i++) {
-      (selection.contains(i) ? blockFrames : remaining).add(widget.frames[i]);
-    }
-
-    // Home slot = the block's leftmost original position among the remaining
-    // stills (all frames before it are unselected, so their count is exactly
-    // the smallest selected index). Anchoring the pickup here — instead of
-    // mapping the raw finger x against the shifted post-removal widths — keeps
-    // a no-drag release a no-op for a contiguous block and drives the offset
-    // that makes dragging land on the right slot.
-    final remainingWidths = [for (final frame in remaining) _tileWidth(frame)];
-    final homeSlot = selection.reduce((a, b) => a < b ? a : b);
-    var homeX = 0.0;
-    for (var i = 0; i < homeSlot; i++) {
-      homeX += remainingWidths[i];
-    }
+    final blockFrames = [
+      for (var i = 0; i < widget.frames.length; i++)
+        if (selection.contains(i)) widget.frames[i],
+    ];
 
     HapticFeedback.mediumImpact();
     widget.onReorderChanged?.call(true);
@@ -283,9 +287,7 @@ class _VideoEditorStopMotionFrameStripState
       _isReordering = true;
       _isBlockDrag = true;
       _blockFrames = blockFrames;
-      _orderedFrames = remaining;
-      _blockSlot = homeSlot;
-      _blockDragOffsetX = fingerX - homeX;
+      _blockSlot = _slotAtX(fingerX, layout.widths);
       _dragGlobalX = details.globalPosition.dx;
       _dragStartGlobalX = details.globalPosition.dx;
       _dragStartLocalX = fingerX;
@@ -307,7 +309,7 @@ class _VideoEditorStopMotionFrameStripState
   void _applyDragTarget() {
     final widths = _computeLayout().widths;
     if (_isBlockDrag) {
-      final slot = _slotAtX(_effectiveLocalX - _blockDragOffsetX, widths);
+      final slot = _slotAtX(_effectiveLocalX, widths);
       if (slot != _blockSlot) {
         HapticFeedback.selectionClick();
         _blockSlot = slot;
@@ -376,7 +378,7 @@ class _VideoEditorStopMotionFrameStripState
     widget.onReorderChanged?.call(false);
 
     if (_isBlockDrag) {
-      final slot = _blockSlot;
+      final slot = _remainingSlotFor(_blockSlot);
       final moved = (_effectiveLocalX - _dragStartLocalX).abs() > 0.5;
       setState(() {
         _isReordering = false;
@@ -445,10 +447,15 @@ class _VideoEditorStopMotionFrameStripState
                     index: i,
                     total: _orderedFrames.length,
                     isSelected:
-                        !_isReordering &&
+                        (_isBlockDrag || !_isReordering) &&
                         (widget.isMultiSelectMode
                             ? widget.selectedFrameIndexes.contains(i)
                             : i == widget.selectedFrameIndex),
+                    // A block member stays in its slot but reads as lifted, so
+                    // the strip shows what is travelling with the finger
+                    // without collapsing under it.
+                    isLifted:
+                        _isBlockDrag && widget.selectedFrameIndexes.contains(i),
                     onTap: _isReordering ? null : () => widget.onFrameTapped(i),
                   ),
                 ),
@@ -546,6 +553,7 @@ class _FrameTile extends StatelessWidget {
     required this.isSelected,
     this.onTap,
     this.isDragging = false,
+    this.isLifted = false,
   });
 
   final StopMotionClipFrame frame;
@@ -554,6 +562,11 @@ class _FrameTile extends StatelessWidget {
   final bool isSelected;
   final VoidCallback? onTap;
   final bool isDragging;
+
+  /// Whether this still is part of the block currently travelling with the
+  /// finger. It keeps its slot so the strip's geometry stays stable, and fades
+  /// to read as picked up rather than left behind.
+  final bool isLifted;
 
   @override
   Widget build(BuildContext context) {
@@ -575,7 +588,11 @@ class _FrameTile extends StatelessWidget {
         onTap: onTap,
         behavior: HitTestBehavior.opaque,
         child: Opacity(
-          opacity: isDragging ? 0.85 : 1,
+          opacity: isLifted
+              ? 0.35
+              : isDragging
+              ? 0.85
+              : 1,
           child: DecoratedBox(
             // Foreground: the image fills the same box, so a background
             // decoration would be painted underneath it and never show.

--- a/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_body.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_body.dart
@@ -291,7 +291,12 @@ class _StopMotionFrameStrip extends StatelessWidget {
         // No-op moves return the same instance; skip commit and selection
         // shuffle so the history stays clean.
         if (identical(moved, frames)) return;
-        commitStopMotionFrames(context, clipId: clip.id, frames: moved);
+        final committed = commitStopMotionFrames(
+          context,
+          clipId: clip.id,
+          frames: moved,
+        );
+        if (!committed) return;
         // The block now occupies slot..slot+n-1 — keep it selected.
         bloc.add(
           ClipEditorFrameMultiSelectionSet({

--- a/mobile/test/models/stop_motion/stop_motion_frame_ops_test.dart
+++ b/mobile/test/models/stop_motion/stop_motion_frame_ops_test.dart
@@ -351,6 +351,61 @@ void main() {
     });
   });
 
+  group('duplicateFrames', () {
+    test('repeats the selected run right after its last still', () {
+      final result = StopMotionFrameOps.duplicateFrames(
+        framesOf([1, 1, 1, 1]),
+        {1, 2},
+      );
+      expect(result.map((f) => f.path), [
+        'f0.jpg',
+        'f1.jpg',
+        'f2.jpg',
+        'f1.jpg',
+        'f2.jpg',
+        'f3.jpg',
+      ]);
+    });
+
+    test('gathers a non-contiguous selection into one copied block', () {
+      final result = StopMotionFrameOps.duplicateFrames(
+        framesOf([1, 1, 1, 1]),
+        {0, 2},
+      );
+      expect(result.map((f) => f.path), [
+        'f0.jpg',
+        'f1.jpg',
+        'f2.jpg',
+        'f0.jpg',
+        'f2.jpg',
+        'f3.jpg',
+      ]);
+    });
+
+    test("carries each copied still's hold", () {
+      final result = StopMotionFrameOps.duplicateFrames(framesOf([1, 7]), {1});
+      expect(
+        result.map(
+          (f) => StopMotionFrameOps.durationToFramesPerImage(f.duration),
+        ),
+        [1, 7, 7],
+      );
+    });
+
+    test('returns the list unchanged for an empty selection', () {
+      final frames = framesOf([1, 1]);
+      expect(
+        StopMotionFrameOps.duplicateFrames(frames, const {}),
+        same(frames),
+      );
+    });
+
+    test('returns the list unchanged for out-of-range indexes', () {
+      final frames = framesOf([1, 1]);
+      expect(StopMotionFrameOps.duplicateFrames(frames, {0, 5}), same(frames));
+    });
+  });
+
   group('moveFrames', () {
     test('moves the selected stills as one block to the slot', () {
       // Select f0 + f1, insert at slot 2 of the remaining [f2, f3].

--- a/mobile/test/models/stop_motion/stop_motion_frame_ops_test.dart
+++ b/mobile/test/models/stop_motion/stop_motion_frame_ops_test.dart
@@ -404,6 +404,24 @@ void main() {
       final frames = framesOf([1, 1]);
       expect(StopMotionFrameOps.duplicateFrames(frames, {0, 5}), same(frames));
     });
+
+    // The action bar moves the selection onto the copies using
+    // `duplicateInsertIndex`; if it ever stopped agreeing with where
+    // `duplicateFrames` actually puts them, the highlight would silently land
+    // on the wrong stills and every follow-up edit would act on them.
+    test('duplicateInsertIndex points at the block the copies land in', () {
+      const selection = {1, 2};
+      final result = StopMotionFrameOps.duplicateFrames(
+        framesOf([1, 1, 1, 1]),
+        selection,
+      );
+      final at = StopMotionFrameOps.duplicateInsertIndex(selection);
+
+      expect(
+        result.sublist(at, at + selection.length).map((f) => f.path),
+        ['f1.jpg', 'f2.jpg'],
+      );
+    });
   });
 
   group('moveFrames', () {

--- a/mobile/test/widgets/video_editor/timeline_editor/controls/video_editor_timeline_multi_select_controls_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/controls/video_editor_timeline_multi_select_controls_test.dart
@@ -9,14 +9,29 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart' as model;
 import 'package:openvine/blocs/video_editor/clip_editor/clip_editor_bloc.dart';
+import 'package:openvine/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/stop_motion_clip_frame.dart';
+import 'package:openvine/widgets/video_editor/main_editor/video_editor_scope.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/controls/video_editor_timeline_multi_select_controls.dart';
+import 'package:pro_image_editor/pro_image_editor.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
 
 class _MockClipEditorBloc extends MockBloc<ClipEditorEvent, ClipEditorState>
     implements ClipEditorBloc {}
+
+class _MockTimelineOverlayBloc
+    extends MockBloc<TimelineOverlayEvent, TimelineOverlayState>
+    implements TimelineOverlayBloc {}
+
+class _MockProImageEditorState extends Mock implements ProImageEditorState {
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) =>
+      '_MockProImageEditorState';
+}
+
+class _MockStateManager extends Mock implements StateManager {}
 
 DivineVideoClip _stopMotionClip(String id, int frameCount) {
   return DivineVideoClip(
@@ -302,6 +317,178 @@ void main() {
         ).onPressed,
         isNull,
       );
+    });
+
+    // Duplicate goes through `commitStopMotionFrames`, which bails without a
+    // live editor — so the behaviour tests below need one mounted in scope.
+    group('Duplicate', () {
+      late _MockTimelineOverlayBloc overlayBloc;
+      late _MockProImageEditorState editor;
+
+      setUpAll(() {
+        registerFallbackValue(const ClipEditorEditingStopped());
+      });
+
+      setUp(() {
+        overlayBloc = _MockTimelineOverlayBloc();
+        when(() => overlayBloc.state).thenReturn(const TimelineOverlayState());
+        when(
+          () => overlayBloc.stream,
+        ).thenAnswer((_) => const Stream<TimelineOverlayState>.empty());
+
+        editor = _MockProImageEditorState();
+        final stateManager = _MockStateManager();
+        when(() => editor.stateManager).thenReturn(stateManager);
+        when(() => stateManager.activeMeta).thenReturn(<String, dynamic>{});
+        when(
+          () => editor.addHistory(
+            layers: any(named: 'layers'),
+            filters: any(named: 'filters'),
+            meta: any(named: 'meta'),
+            newLayer: any(named: 'newLayer'),
+            transformConfigs: any(named: 'transformConfigs'),
+            tuneAdjustments: any(named: 'tuneAdjustments'),
+            blur: any(named: 'blur'),
+            heroScreenshotRequired: any(named: 'heroScreenshotRequired'),
+            blockCaptureScreenshot: any(named: 'blockCaptureScreenshot'),
+          ),
+        ).thenAnswer((_) {});
+        when(() => editor.setState(any())).thenAnswer((invocation) {
+          (invocation.positionalArguments.single as VoidCallback)();
+        });
+      });
+
+      Future<void> pressDuplicate(
+        WidgetTester tester, {
+        required Set<int> selected,
+        int frameCount = 4,
+      }) async {
+        when(() => bloc.state).thenReturn(
+          ClipEditorState(
+            clips: [_stopMotionClip('a', frameCount)],
+            isMultiSelectMode: true,
+            selectedFrameIndexes: selected,
+          ),
+        );
+
+        await tester.pumpWidget(
+          MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: VideoEditorScope(
+                editorKey: GlobalKey<ProImageEditorState>(),
+                editorOverride: editor,
+                removeAreaKey: GlobalKey(),
+                originalClipAspectRatio: 9 / 16,
+                bodySizeNotifier: ValueNotifier(const Size(400, 600)),
+                zoomMatrixNotifier: ValueNotifier(Matrix4.identity()),
+                playTimeNotifier: ValueNotifier(Duration.zero),
+                fromLibrary: false,
+                onOpenCamera: () {},
+                onOpenClipsEditor: () {},
+                onAddStickers: () {},
+                onOpenMusicLibrary: () {},
+                onOpenVoiceOver: () {},
+                onOpenCaptions: () {},
+                onAddEditTextLayer: ([layer]) async => null,
+                child: MultiBlocProvider(
+                  providers: [
+                    BlocProvider<ClipEditorBloc>.value(value: bloc),
+                    BlocProvider<TimelineOverlayBloc>.value(value: overlayBloc),
+                  ],
+                  child: const TimelineFrameMultiSelectControls(),
+                ),
+              ),
+            ),
+          ),
+        );
+
+        buttonWithLabel(
+          tester,
+          l10n.videoEditorDuplicateSelectedFramesSemanticLabel,
+        ).onPressed!();
+        await tester.pump();
+      }
+
+      List<String> committedFramePaths() {
+        final updated =
+            verify(
+                  () =>
+                      bloc.add(captureAny(that: isA<ClipEditorClipUpdated>())),
+                ).captured.single
+                as ClipEditorClipUpdated;
+        return [
+          for (final frame in updated.clip.stopMotionFrames!) frame.path,
+        ];
+      }
+
+      Set<int> reselected() {
+        final event =
+            verify(
+                  () => bloc.add(
+                    captureAny(that: isA<ClipEditorFrameMultiSelectionSet>()),
+                  ),
+                ).captured.single
+                as ClipEditorFrameMultiSelectionSet;
+        return event.frameIndexes;
+      }
+
+      testWidgets('repeats the selected run right after its last still', (
+        tester,
+      ) async {
+        await pressDuplicate(tester, selected: const {1, 2});
+
+        expect(committedFramePaths(), [
+          '/tmp/a-0.png',
+          '/tmp/a-1.png',
+          '/tmp/a-2.png',
+          '/tmp/a-1.png',
+          '/tmp/a-2.png',
+          '/tmp/a-3.png',
+        ]);
+      });
+
+      // The highlight has to show what was just created: a follow-up hold
+      // change or block drag acts on the selection, and leaving it on the
+      // sources would silently edit the originals instead.
+      testWidgets('moves the selection onto the copies', (tester) async {
+        await pressDuplicate(tester, selected: const {1, 2});
+
+        expect(reselected(), {3, 4});
+      });
+
+      testWidgets('a single still duplicates in place, like the per-still '
+          'action', (tester) async {
+        await pressDuplicate(tester, selected: const {1});
+
+        expect(committedFramePaths(), [
+          '/tmp/a-0.png',
+          '/tmp/a-1.png',
+          '/tmp/a-1.png',
+          '/tmp/a-2.png',
+          '/tmp/a-3.png',
+        ]);
+        expect(reselected(), {2});
+      });
+
+      // Gaps collapse: the copies land as one repeat, not each beside its own
+      // source, so the selection that follows them is contiguous too.
+      testWidgets('gathers a non-contiguous selection into one block', (
+        tester,
+      ) async {
+        await pressDuplicate(tester, selected: const {0, 2});
+
+        expect(committedFramePaths(), [
+          '/tmp/a-0.png',
+          '/tmp/a-1.png',
+          '/tmp/a-2.png',
+          '/tmp/a-0.png',
+          '/tmp/a-2.png',
+          '/tmp/a-3.png',
+        ]);
+        expect(reselected(), {3, 4});
+      });
     });
   });
 }

--- a/mobile/test/widgets/video_editor/timeline_editor/controls/video_editor_timeline_multi_select_controls_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/controls/video_editor_timeline_multi_select_controls_test.dart
@@ -221,9 +221,7 @@ void main() {
       );
       await tester.pump();
 
-      verify(
-        () => bloc.add(const ClipEditorMultiSelectCancelled()),
-      ).called(1);
+      verify(() => bloc.add(const ClipEditorMultiSelectCancelled())).called(1);
     });
 
     testWidgets('Delete dispatches a remove event when enabled', (
@@ -244,9 +242,7 @@ void main() {
       );
       await tester.pump();
 
-      verify(
-        () => bloc.add(const ClipEditorSelectedClipsRemoved()),
-      ).called(1);
+      verify(() => bloc.add(const ClipEditorSelectedClipsRemoved())).called(1);
     });
   });
 
@@ -362,6 +358,7 @@ void main() {
         WidgetTester tester, {
         required Set<int> selected,
         int frameCount = 4,
+        bool hasEditor = true,
       }) async {
         when(() => bloc.state).thenReturn(
           ClipEditorState(
@@ -378,7 +375,7 @@ void main() {
             home: Scaffold(
               body: VideoEditorScope(
                 editorKey: GlobalKey<ProImageEditorState>(),
-                editorOverride: editor,
+                editorOverride: hasEditor ? editor : null,
                 removeAreaKey: GlobalKey(),
                 originalClipAspectRatio: 9 / 16,
                 bodySizeNotifier: ValueNotifier(const Size(400, 600)),
@@ -418,9 +415,7 @@ void main() {
                       bloc.add(captureAny(that: isA<ClipEditorClipUpdated>())),
                 ).captured.single
                 as ClipEditorClipUpdated;
-        return [
-          for (final frame in updated.clip.stopMotionFrames!) frame.path,
-        ];
+        return [for (final frame in updated.clip.stopMotionFrames!) frame.path];
       }
 
       Set<int> reselected() {
@@ -488,6 +483,17 @@ void main() {
           '/tmp/a-3.png',
         ]);
         expect(reselected(), {3, 4});
+      });
+
+      testWidgets('does not move the selection when the editor is gone', (
+        tester,
+      ) async {
+        await pressDuplicate(tester, selected: const {0}, hasEditor: false);
+
+        verifyNever(() => bloc.add(any(that: isA<ClipEditorClipUpdated>())));
+        verifyNever(
+          () => bloc.add(any(that: isA<ClipEditorFrameMultiSelectionSet>())),
+        );
       });
     });
   });

--- a/mobile/test/widgets/video_editor/timeline_editor/controls/video_editor_timeline_multi_select_controls_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/controls/video_editor_timeline_multi_select_controls_test.dart
@@ -1,5 +1,5 @@
-// ABOUTME: Widget tests for TimelineMultiSelectControls.
-// ABOUTME: Verifies the count label, merge/delete gating, and event dispatch.
+// ABOUTME: Widget tests for the clip and stop-motion-frame multi-select bars.
+// ABOUTME: Verifies the count label, action gating, and event dispatch.
 
 import 'package:bloc_test/bloc_test.dart';
 import 'package:divine_ui/divine_ui.dart';
@@ -11,11 +11,29 @@ import 'package:models/models.dart' as model;
 import 'package:openvine/blocs/video_editor/clip_editor/clip_editor_bloc.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/stop_motion_clip_frame.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/controls/video_editor_timeline_multi_select_controls.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
 
 class _MockClipEditorBloc extends MockBloc<ClipEditorEvent, ClipEditorState>
     implements ClipEditorBloc {}
+
+DivineVideoClip _stopMotionClip(String id, int frameCount) {
+  return DivineVideoClip(
+    id: id,
+    duration: Duration(milliseconds: 500 * frameCount),
+    recordedAt: DateTime(2025),
+    targetAspectRatio: model.AspectRatio.vertical,
+    originalAspectRatio: 9 / 16,
+    stopMotionFrames: [
+      for (var i = 0; i < frameCount; i++)
+        StopMotionClipFrame(
+          path: '/tmp/$id-$i.png',
+          duration: const Duration(milliseconds: 500),
+        ),
+    ],
+  );
+}
 
 DivineVideoClip _clip(String id) {
   return DivineVideoClip(
@@ -214,6 +232,76 @@ void main() {
       verify(
         () => bloc.add(const ClipEditorSelectedClipsRemoved()),
       ).called(1);
+    });
+  });
+
+  group(TimelineFrameMultiSelectControls, () {
+    late _MockClipEditorBloc bloc;
+    final l10n = lookupAppLocalizations(const Locale('en'));
+
+    setUp(() {
+      bloc = _MockClipEditorBloc();
+      when(
+        () => bloc.stream,
+      ).thenAnswer((_) => const Stream<ClipEditorState>.empty());
+    });
+
+    Widget build() {
+      return MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: BlocProvider<ClipEditorBloc>.value(
+            value: bloc,
+            child: const TimelineFrameMultiSelectControls(),
+          ),
+        ),
+      );
+    }
+
+    DivineIconButton buttonWithLabel(WidgetTester tester, String label) {
+      return tester
+          .widgetList<DivineIconButton>(find.byType(DivineIconButton))
+          .firstWhere((b) => b.semanticLabel == label);
+    }
+
+    testWidgets('offers Duplicate on the selected stills', (tester) async {
+      when(() => bloc.state).thenReturn(
+        ClipEditorState(
+          clips: [_stopMotionClip('a', 4)],
+          isMultiSelectMode: true,
+          selectedFrameIndexes: const {1, 2},
+        ),
+      );
+
+      await tester.pumpWidget(build());
+
+      expect(
+        buttonWithLabel(
+          tester,
+          l10n.videoEditorDuplicateSelectedFramesSemanticLabel,
+        ).onPressed,
+        isNotNull,
+      );
+    });
+
+    testWidgets('disables Duplicate with nothing selected', (tester) async {
+      when(() => bloc.state).thenReturn(
+        ClipEditorState(
+          clips: [_stopMotionClip('a', 4)],
+          isMultiSelectMode: true,
+        ),
+      );
+
+      await tester.pumpWidget(build());
+
+      expect(
+        buttonWithLabel(
+          tester,
+          l10n.videoEditorDuplicateSelectedFramesSemanticLabel,
+        ).onPressed,
+        isNull,
+      );
     });
   });
 }

--- a/mobile/test/widgets/video_editor/timeline_editor/strips/video_editor_stop_motion_frame_strip_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/strips/video_editor_stop_motion_frame_strip_test.dart
@@ -383,6 +383,35 @@ void main() {
     await tester.pumpAndSettle();
   });
 
+  testWidgets('selected stills stay in place and dim during block drag', (
+    tester,
+  ) async {
+    frames = makeFrames(5);
+    await pump(
+      tester,
+      onFrameTapped: (_) {},
+      isMultiSelectMode: true,
+      selectedFrameIndexes: {1, 2, 3},
+      onBlockMove: (_) {},
+    );
+
+    final gesture = await tester.startGesture(
+      tester.getCenter(find.byType(Image).at(2)),
+    );
+    await tester.pump(kLongPressTimeout + const Duration(milliseconds: 50));
+    await tester.pump();
+
+    expect(
+      find.byWidgetPredicate(
+        (widget) => widget is Opacity && widget.opacity == 0.35,
+      ),
+      findsNWidgets(3),
+    );
+
+    await gesture.up();
+    await tester.pumpAndSettle();
+  });
+
   testWidgets('block drag does not start on an unselected tile', (
     tester,
   ) async {

--- a/mobile/test/widgets/video_editor/timeline_editor/strips/video_editor_stop_motion_frame_strip_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/strips/video_editor_stop_motion_frame_strip_test.dart
@@ -35,6 +35,17 @@ void main() {
 
   tearDown(() => tempDir.deleteSync(recursive: true));
 
+  /// [count] stills of 0.5s each — 50px-wide tiles at the test's 100 pps.
+  List<StopMotionClipFrame> makeFrames(int count) => [
+    for (var i = 0; i < count; i++)
+      StopMotionClipFrame(
+        path: (File(
+          '${tempDir.path}/f$i.png',
+        )..writeAsBytesSync(pngBytes)).path,
+        duration: const Duration(milliseconds: 500),
+      ),
+  ];
+
   Future<void> pump(
     WidgetTester tester, {
     required ValueChanged<int> onFrameTapped,
@@ -274,6 +285,69 @@ void main() {
       expect(movedToSlot, isNull);
     },
   );
+
+  testWidgets('block drag drops the selection under the finger', (
+    tester,
+  ) async {
+    int? movedToSlot;
+    frames = makeFrames(8);
+    await pump(
+      tester,
+      onFrameTapped: (_) {},
+      isMultiSelectMode: true,
+      selectedFrameIndexes: {0, 1, 2, 3},
+      onBlockMove: (slot) => movedToSlot = slot,
+    );
+
+    // Pick the block up by its LAST still (centre x=175) and release over the
+    // 7th still (x=310). The drop follows the finger — the block lands after
+    // the two unselected stills it was dragged past (slot 2), not three tiles
+    // short of the finger where its own first still used to sit.
+    final gesture = await tester.startGesture(
+      tester.getCenter(find.byType(Image).at(3)),
+    );
+    await tester.pump(kLongPressTimeout + const Duration(milliseconds: 50));
+    await tester.pump();
+    await gesture.moveBy(const Offset(135, 0));
+    await tester.pump();
+    await gesture.up();
+    await tester.pumpAndSettle();
+
+    expect(movedToSlot, 2);
+  });
+
+  testWidgets('insertion marker follows the finger during a block drag', (
+    tester,
+  ) async {
+    frames = makeFrames(8);
+    await pump(
+      tester,
+      onFrameTapped: (_) {},
+      isMultiSelectMode: true,
+      selectedFrameIndexes: {0, 1, 2, 3},
+      onBlockMove: (_) {},
+    );
+
+    final gesture = await tester.startGesture(
+      tester.getCenter(find.byType(Image).at(3)),
+    );
+    await tester.pump(kLongPressTimeout + const Duration(milliseconds: 50));
+    await tester.pump();
+    await gesture.moveBy(const Offset(135, 0));
+    await tester.pump();
+
+    final marker = find.byWidgetPredicate(
+      (w) => w is ColoredBox && w.color == VineTheme.accentYellow,
+    );
+    expect(
+      tester.getTopLeft(marker).dx,
+      closeTo(310, 30),
+      reason: 'marker sits at the finger, not a block-width behind it',
+    );
+
+    await gesture.up();
+    await tester.pumpAndSettle();
+  });
 
   testWidgets('block drag does not start on an unselected tile', (
     tester,

--- a/mobile/test/widgets/video_editor/timeline_editor/strips/video_editor_stop_motion_frame_strip_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/strips/video_editor_stop_motion_frame_strip_test.dart
@@ -316,6 +316,40 @@ void main() {
     expect(movedToSlot, 2);
   });
 
+  // The slot the finger is over is expressed in the full N-tile layout, but
+  // `moveFrames` counts insertion slots among the *unselected* stills only. A
+  // drag that stays inside the block therefore has to translate back to the
+  // block's own home — otherwise the raw full-layout slot (4 here) is clamped
+  // to the end of the remaining list and a nudge silently reorders the strip.
+  testWidgets('a drag that stays inside the block reports its home slot', (
+    tester,
+  ) async {
+    int? movedToSlot;
+    frames = makeFrames(5);
+    await pump(
+      tester,
+      onFrameTapped: (_) {},
+      isMultiSelectMode: true,
+      selectedFrameIndexes: {1, 2, 3},
+      onBlockMove: (slot) => movedToSlot = slot,
+    );
+
+    // Pick up the block's last still (centre x=175) and nudge it 15px right —
+    // far enough to count as a drag, still over the block's own stills.
+    final gesture = await tester.startGesture(
+      tester.getCenter(find.byType(Image).at(3)),
+    );
+    await tester.pump(kLongPressTimeout + const Duration(milliseconds: 50));
+    await tester.pump();
+    await gesture.moveBy(const Offset(15, 0));
+    await tester.pump();
+    await gesture.up();
+    await tester.pumpAndSettle();
+
+    // Home = one unselected still (f0) sits left of the block.
+    expect(movedToSlot, 1);
+  });
+
   testWidgets('insertion marker follows the finger during a block drag', (
     tester,
   ) async {


### PR DESCRIPTION
Closes #8010

Two changes to stop-motion frame multi-select, shipped together because both land in the same action bar and the same frame-list ops.

## Dragging a selection drops it at the finger

Picking a multi-select block up lifted the selected stills out of the layout, so the remaining tiles collapsed left by the whole block width mid-gesture. From there the insertion slot could only be tracked *relative* to the block's old home (`_blockDragOffsetX = fingerX - homeX`), which left the insertion marker trailing the finger by that same width. Dragging ten stills dropped them roughly where the first one used to sit, and placing them anywhere on purpose meant overshooting by ten tiles.

The selected stills now keep their slots and are only dimmed, so the strip geometry does not move under the finger and the insertion slot is simply the one the finger is over. The slot is expressed in the full N-tile layout and translated into the "index among the unselected stills" that `moveFrames` expects on release.

Why that translation keeps the old no-op guarantee: a slot anywhere inside a contiguous selected run maps back to that run's own home, so picking a block up and releasing it without moving still changes nothing — previously that property came from the home-anchored offset, which is exactly what had to go.

## Duplicate on a frame selection

Frame multi-select could set the hold, reverse and delete stills, but repeating a run meant duplicating one still at a time from the single-frame bar. `StopMotionFrameOps.duplicateFrames` adds the action to the multi-select bar.

The copies land as one block right after the last selected still rather than each beside its own source, so a selected run duplicates into a repeat of itself — the reason to reach for the action in a stop-motion sequence. A single selected still therefore behaves exactly like the per-still duplicate it mirrors. Copies reuse the source frame instances: nothing about a still is per-instance, and the strip already disambiguates shared paths for its tile keys.

The selection moves onto the copies afterwards, so the highlight shows what was created and a follow-up drag or hold change acts on the new stills rather than silently on the originals.

New l10n key `videoEditorDuplicateSelectedFramesSemanticLabel`, translated in all 22 locales.

## Test plan

Manually verified on a real Samsung Galaxy device:

- Multi-select ~10 stills, pick the block up by its **last** tile and drop it mid-strip — the marker sits under the finger and the stills land there.
- Pick a block up and release without moving — nothing changes.
- Duplicate a selected run, confirm the repeat lands directly after it and the highlight follows the copies.
- Undo/redo across both actions.

Automated:

- `flutter analyze lib test integration_test` clean.
- `flutter test test/models/stop_motion test/widgets/video_editor/timeline_editor test/l10n/arb_consistency_test.dart` — 546 passing.
- Every new test was confirmed red against the behaviour it pins before the fix landed: the drag tests against the previous trailing-offset behaviour, the home-slot test against the raw full-layout slot, and the duplicate tests against a selection left sitting on the sources.
