### PR TITLE
fix(sounds): keep saved My Sounds audio playable after an iOS app update

### DIFF
--- a/mobile/integration_test/account_swap_integration_test.dart
+++ b/mobile/integration_test/account_swap_integration_test.dart
@@ -73,6 +73,7 @@ void main() {
       sharedPreferences: prefs,
       switchController: controller,
       appVersion: 'test',
+      documentsPath: '/documents',
     );
 
     // Create two real local-key identities in a setup container. Guarded

--- a/mobile/lib/extensions/draft_local_audio_extensions.dart
+++ b/mobile/lib/extensions/draft_local_audio_extensions.dart
@@ -10,10 +10,11 @@ extension DraftLocalAudioPaths on DivineVideoDraft {
   /// `draft_audio_imports/<draftId>`), committed voice-over recordings, and
   /// audio extracted from the draft's own clips — all persisted as draft-local
   /// [AudioEvent]s. Sweeps every history entry's audio metadata in
-  /// [DivineVideoDraft.editorStateHistory] plus the legacy
-  /// [DivineVideoDraft.selectedSound], collecting [AudioEvent.localFilePath] for
-  /// each [AudioEvent.isDraftLocalAudio] track. Used by draft deletion to remove
-  /// audio files that would otherwise persist after the draft is gone.
+  /// [DivineVideoDraft.editorStateHistory], the completed-editor snapshot in
+  /// [DivineVideoDraft.editorEditingParameters], plus the legacy
+  /// [DivineVideoDraft.selectedSound], collecting [AudioEvent.localFilePath]
+  /// for each [AudioEvent.isDraftLocalAudio] track. Used by draft deletion to
+  /// remove audio files that would otherwise persist after the draft is gone.
   Set<String> get localAudioFilePaths {
     final paths = <String>{};
 
@@ -26,18 +27,10 @@ extension DraftLocalAudioPaths on DivineVideoDraft {
       }
     }
 
-    final selected = selectedSound;
-    if (selected != null) addIfLocal(selected);
-
-    final history = editorStateHistory['history'];
-    if (history is! Iterable) return paths;
-
-    for (final item in history) {
-      if (item is! Map) continue;
-      final meta = item['meta'];
-      if (meta is! Map) continue;
-      final audio = meta[VideoEditorConstants.audioStateHistoryKey];
-      if (audio is! Iterable) continue;
+    void addFromMeta(Object? rawMeta) {
+      if (rawMeta is! Map) return;
+      final audio = rawMeta[VideoEditorConstants.audioStateHistoryKey];
+      if (audio is! Iterable) return;
       for (final raw in audio) {
         if (raw is! Map) continue;
         try {
@@ -45,6 +38,19 @@ extension DraftLocalAudioPaths on DivineVideoDraft {
         } catch (_) {
           // Skip malformed audio entries; cleanup must never throw.
         }
+      }
+    }
+
+    final selected = selectedSound;
+    if (selected != null) addIfLocal(selected);
+
+    addFromMeta(editorEditingParameters['meta']);
+
+    final history = editorStateHistory['history'];
+    if (history is Iterable) {
+      for (final item in history) {
+        if (item is! Map) continue;
+        addFromMeta(item['meta']);
       }
     }
 

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -139,6 +139,7 @@ import 'package:openvine/utils/app_uptime.dart';
 import 'package:openvine/utils/expected_network_error.dart';
 import 'package:openvine/utils/log_message_batcher.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
+import 'package:openvine/utils/path_resolver.dart';
 import 'package:openvine/utils/platform_support.dart';
 import 'package:openvine/utils/recoverable_flutter_error.dart';
 import 'package:openvine/utils/sensitive_uri_for_logs.dart';
@@ -1394,6 +1395,11 @@ Future<void> _startOpenVineApp() async {
   // in-app review gate reads. Both are best-effort and fall back to safe
   // defaults on web/desktop/unsupported native shells (#6296).
   final installSource = await const InstallSourceService().resolve();
+
+  // Resolved once here so synchronous readers can rebase persisted absolute
+  // paths without awaiting: iOS rewrites the container path on every app
+  // update, and the plugin lookup behind it is a Future.
+  final documentsPath = await getDocumentsPath();
   await AppEngagementStore(
     sharedPreferences: sharedPreferences,
   ).recordSession();
@@ -1403,6 +1409,7 @@ Future<void> _startOpenVineApp() async {
     sharedPreferences: sharedPreferences,
     switchController: accountSwitchController,
     appVersion: packageInfo.version,
+    documentsPath: documentsPath,
     dbCipherKey: dbCipherKey,
     databaseCorruptionService: databaseCorruptionService,
     installSource: installSource,

--- a/mobile/lib/providers/device_scope.dart
+++ b/mobile/lib/providers/device_scope.dart
@@ -9,6 +9,7 @@ import 'package:openvine/providers/container_swap_host.dart';
 import 'package:openvine/providers/database_corruption_provider.dart';
 import 'package:openvine/providers/database_provider.dart';
 import 'package:openvine/providers/db_cipher_key_provider.dart';
+import 'package:openvine/providers/documents_path_provider.dart';
 import 'package:openvine/providers/install_source_provider.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/services/database_corruption_service.dart';
@@ -47,6 +48,7 @@ class DeviceScope {
     required this.sharedPreferences,
     required this.switchController,
     required this.appVersion,
+    required this.documentsPath,
     this.dbCipherKey,
     this.databaseCorruptionService,
     this.installSource = InstallSource.sideload,
@@ -66,6 +68,14 @@ class DeviceScope {
 
   /// App version resolved once from `PackageInfo` during bootstrap.
   final String appVersion;
+
+  /// Application documents directory, resolved once during bootstrap.
+  ///
+  /// iOS rewrites the container path on every app update, so persisted
+  /// absolute paths are rebased against this on read. It lives here rather
+  /// than behind an async lookup because synchronous readers — saved sounds
+  /// load straight out of SharedPreferences — cannot await one. Empty on web.
+  final String documentsPath;
 
   /// The app-lifetime handle the UI calls to switch accounts. Device-scoped so
   /// it outlives — and drives — every container swap.
@@ -97,6 +107,7 @@ class DeviceScope {
     databaseProvider.overrideWithValue(database),
     sharedPreferencesProvider.overrideWithValue(sharedPreferences),
     appVersionProvider.overrideWithValue(appVersion),
+    documentsPathProvider.overrideWithValue(documentsPath),
     dbCipherKeyProvider.overrideWithValue(dbCipherKey),
     databaseCorruptionServiceProvider.overrideWithValue(
       databaseCorruptionService,

--- a/mobile/lib/providers/documents_path_provider.dart
+++ b/mobile/lib/providers/documents_path_provider.dart
@@ -1,0 +1,23 @@
+// ABOUTME: Riverpod provider for the app documents directory path.
+// ABOUTME: Resolved once at startup and overridden in DeviceScope so every
+// ABOUTME: account container shares the same synchronous value.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Absolute path of the application documents directory, resolved once during
+/// startup (see `main.dart`) and injected into every account container via
+/// [DeviceScope.overrides].
+///
+/// iOS rewrites the app container path on every app update, so a persisted
+/// absolute path has to be rebased against the *current* documents directory
+/// on read. `getDocumentsPath()` is a `Future`, which synchronous readers such
+/// as `SavedSoundsService.loadSavedSounds` cannot await, so the value is
+/// resolved once at bootstrap and carried device-wide instead.
+///
+/// Throws by default; `main.dart` overrides it before `runApp`. Reading it
+/// without that override is a wiring error, not a runtime condition to handle.
+/// Empty string is a legitimate value on web, where there is no documents
+/// directory (see `getDocumentsPath`).
+final documentsPathProvider = Provider<String>(
+  (_) => throw StateError('documentsPathProvider must be overridden'),
+);

--- a/mobile/lib/providers/saved_sounds_provider.dart
+++ b/mobile/lib/providers/saved_sounds_provider.dart
@@ -3,6 +3,7 @@
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/providers/auth_providers.dart';
+import 'package:openvine/providers/documents_path_provider.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/services/saved_sounds_service.dart';
 
@@ -14,5 +15,8 @@ final savedSoundsServiceProvider = Provider<SavedSoundsService>((ref) {
   return SavedSoundsService(
     ref.watch(sharedPreferencesProvider),
     pubkeyHex: pubkeyHex,
+    // Draft-local audio is stored relative to the documents directory; iOS
+    // rewrites that path on every app update, so it is rebased on load.
+    documentsPath: ref.watch(documentsPathProvider),
   );
 });

--- a/mobile/lib/providers/social_providers.dart
+++ b/mobile/lib/providers/social_providers.dart
@@ -684,6 +684,9 @@ DraftStorageService draftStorageService(Ref ref) {
     draftsDao: db.draftsDao,
     clipsDao: db.clipsDao,
     ownerPubkey: ownerPubkey,
+    // Deleting a draft reclaims its audio files; My Sounds can point at one of
+    // them, so cleanup has to be able to see the saved sound buckets.
+    preferences: ref.watch(sharedPreferencesProvider),
   );
 }
 

--- a/mobile/lib/providers/social_providers.g.dart
+++ b/mobile/lib/providers/social_providers.g.dart
@@ -506,7 +506,7 @@ final class DraftStorageServiceProvider
 }
 
 String _$draftStorageServiceHash() =>
-    r'49c37c22a23ecd1ba90b4a51b782abebf40fb1dd';
+    r'0c8954ff051734798a78c463aa2b6c1a311f94d8';
 
 /// Clip library service for persisting individual video clips
 

--- a/mobile/lib/services/creator_sync/saved_sounds_local_store.dart
+++ b/mobile/lib/services/creator_sync/saved_sounds_local_store.dart
@@ -17,7 +17,10 @@ class SavedSoundsLocalStore implements LocalSoundStore {
     // loadSavedSounds() first: it is what kicks off the legacy-bucket
     // migration, and an account whose bucket that migration has not written
     // yet reads as absent rather than unreadable.
-    final sounds = _service.loadSavedSounds();
+    // Stored paths, not resolved ones: a body carrying this device's current
+    // container path would hash differently after every iOS app update and
+    // republish itself to the relay for no change the user made.
+    final sounds = _service.loadSavedSounds(resolveLocalPaths: false);
     if (_service.isLibraryUnreadable) {
       throw LocalStoreUnreadableException(
         'saved sound library is present but not decodable by this build',

--- a/mobile/lib/services/draft_storage_service.dart
+++ b/mobile/lib/services/draft_storage_service.dart
@@ -10,6 +10,7 @@ import 'package:openvine/models/divine_video_draft.dart';
 import 'package:openvine/models/stop_motion/stop_motion_frame_ops.dart';
 import 'package:openvine/services/crash_reporting_service.dart';
 import 'package:openvine/services/file_cleanup_service.dart';
+import 'package:openvine/services/saved_sounds_service.dart';
 import 'package:openvine/utils/path_resolver.dart';
 import 'package:path/path.dart' as p;
 import 'package:shared_preferences/shared_preferences.dart';
@@ -20,11 +21,19 @@ class DraftStorageService {
     required DraftsDao draftsDao,
     required ClipsDao clipsDao,
     this.ownerPubkey,
+    SharedPreferences? preferences,
   }) : _draftsDao = draftsDao,
-       _clipsDao = clipsDao;
+       _clipsDao = clipsDao,
+       _preferences = preferences;
 
   final DraftsDao _draftsDao;
   final ClipsDao _clipsDao;
+
+  /// Where saved sounds live, consulted before deleting a draft's audio files.
+  ///
+  /// Nullable so tests that never delete a draft need not wire it; a null
+  /// instance simply cannot see My Sounds references.
+  final SharedPreferences? _preferences;
 
   /// Hex pubkey of the current account. When set, new drafts are tagged
   /// with this owner and queries filter by it (plus legacy NULL rows).
@@ -645,8 +654,8 @@ class DraftStorageService {
     }
   }
 
-  /// Basenames of draft-local audio files referenced by any surviving draft,
-  /// across all accounts.
+  /// Basenames of draft-local audio files referenced by any surviving draft or
+  /// saved sound, across all accounts.
   ///
   /// The same local audio file can be shared by a draft and its publish copy —
   /// `copyWith` carries [DivineVideoDraft.editorStateHistory] and
@@ -655,12 +664,17 @@ class DraftStorageService {
   /// directly (audio paths live there, not in an indexed column) and never
   /// throws: a corrupt blob is logged and skipped.
   ///
+  /// My Sounds is scanned too. Audio imported from the Library is written
+  /// under whichever draft was open at the time, so deleting that draft would
+  /// otherwise reclaim a file a saved sound still points at — and unlike a
+  /// stale path, a deleted file cannot be healed on load (#7977).
+  ///
   /// Callers run this *after* deleting the draft they are cleaning up, so
   /// every row it sees is a survivor and there is nothing to exclude.
   Future<Set<String>> _referencedLocalAudioFilenames() async {
     final rows = await _draftsDao.getAllDrafts();
     final documentsPath = await getDocumentsPath();
-    final filenames = <String>{};
+    final filenames = <String>{..._savedSoundAudioFilenames()};
 
     for (final row in rows) {
       final DivineVideoDraft draft;
@@ -683,6 +697,15 @@ class DraftStorageService {
     }
 
     return filenames;
+  }
+
+  /// Basenames of draft-local audio files a saved sound points at, or empty
+  /// when this instance was built without access to storage.
+  Set<String> _savedSoundAudioFilenames() {
+    final preferences = _preferences;
+    return preferences == null
+        ? const {}
+        : SavedSoundsService.referencedLocalAudioFilenames(preferences);
   }
 
   /// Basenames of clip ghost-frame files referenced by any surviving clip,
@@ -778,11 +801,13 @@ class DraftStorageService {
       draftsDao: _draftsDao,
       clipsDao: _clipsDao,
     );
-    // No drafts survive a clear-all, so nothing can still reference the audio.
+    // No draft survives a clear-all, but My Sounds does — and a saved sound
+    // can point at a file the cleared drafts owned (#7977).
     await FileCleanupService.deleteDraftAudioFiles(
       allAudioPaths,
       draftsDao: _draftsDao,
       clipsDao: _clipsDao,
+      referencedAudioFilenames: _savedSoundAudioFilenames(),
     );
   }
 }

--- a/mobile/lib/services/saved_sounds_service.dart
+++ b/mobile/lib/services/saved_sounds_service.dart
@@ -7,13 +7,19 @@ import 'dart:convert';
 import 'package:meta/meta.dart';
 import 'package:models/models.dart' show AudioEvent;
 import 'package:openvine/models/saved_sound.dart';
+import 'package:openvine/utils/draft_audio_path_resolver.dart';
+import 'package:path/path.dart' as p;
 import 'package:shared_preferences/shared_preferences.dart';
 
 enum SavedSoundSaveResult { saved, alreadySaved }
 
 class SavedSoundsService {
-  SavedSoundsService(this._preferences, {String? pubkeyHex})
-    : _pubkeyHex = pubkeyHex;
+  SavedSoundsService(
+    this._preferences, {
+    String? pubkeyHex,
+    String documentsPath = '',
+  }) : _pubkeyHex = pubkeyHex,
+       _documentsPath = documentsPath;
 
   /// Prefix for the per-account storage keys.
   static const _keyPrefix = 'saved_reusable_sounds';
@@ -41,6 +47,10 @@ class SavedSoundsService {
   /// Signed-in pubkey (hex) whose saved sounds this instance manages, or
   /// `null` when signed out.
   final String? _pubkeyHex;
+
+  /// Application documents directory that draft-local audio paths are stored
+  /// relative to. Empty on web, and in tests that never persist a local file.
+  final String _documentsPath;
 
   /// SharedPreferences key for a specific account's saved sounds.
   ///
@@ -82,25 +92,37 @@ class SavedSoundsService {
     }
   }
 
-  List<SavedSound> loadSavedSounds() {
+  /// The account's saved sounds, newest first.
+  ///
+  /// Draft-local audio is stored relative to the documents directory, so its
+  /// path is rebased onto [_documentsPath] on the way out — that is what keeps
+  /// an imported sound playable after an iOS app update rewrites the container
+  /// path. Pass [resolveLocalPaths] as `false` to get the stored form instead,
+  /// which is what cross-device sync publishes: a body carrying this device's
+  /// container path would change hash on every app update and republish itself.
+  List<SavedSound> loadSavedSounds({bool resolveLocalPaths = true}) {
     _migrateLegacyBucketIfNeeded();
     final rawSounds = _preferences.getString(storageKey);
     if (rawSounds == null || rawSounds.isEmpty) {
       return [];
     }
 
+    final List<SavedSound> sounds;
     try {
       final decoded = jsonDecode(rawSounds);
       if (decoded is List) {
-        return _readLegacySounds(decoded);
+        sounds = _readLegacySounds(decoded);
+      } else if (decoded is Map) {
+        sounds = _readVersionedSounds(Map<String, dynamic>.from(decoded));
+      } else {
+        return [];
       }
-      if (decoded is Map) {
-        return _readVersionedSounds(Map<String, dynamic>.from(decoded));
-      }
-      return [];
     } catch (_) {
       return [];
     }
+
+    if (!resolveLocalPaths) return sounds;
+    return sounds.map(_resolvedRecord).toList();
   }
 
   Future<SavedSoundSaveResult> saveSound(AudioEvent sound) async {
@@ -187,6 +209,64 @@ class SavedSoundsService {
     return sounds;
   }
 
+  /// Basenames of draft-local audio files a saved sound points at, across
+  /// *every* account bucket on this device.
+  ///
+  /// Audio imported from the Library still lands under the draft that was open
+  /// at the time (`draft_audio_imports/<draftId>/`), so a file a My Sounds
+  /// entry depends on can be owned by a draft the user later deletes. Draft
+  /// cleanup consults this and keeps such a file: a dangling path heals on the
+  /// next load, a deleted file does not (#7977).
+  ///
+  /// All accounts, not just the signed-in one — draft cleanup already scans
+  /// drafts device-wide, and a saved sound outlives the account switch that
+  /// hides it. Never throws: an undecodable bucket contributes nothing.
+  static Set<String> referencedLocalAudioFilenames(
+    SharedPreferences preferences,
+  ) {
+    final filenames = <String>{};
+    for (final key in preferences.getKeys()) {
+      if (!key.startsWith(_keyPrefix)) continue;
+      final raw = preferences.getString(key);
+      if (raw == null || raw.isEmpty) continue;
+      for (final audioJson in _storedAudioJson(raw)) {
+        try {
+          final path = AudioEvent.fromJson(audioJson).localFilePath;
+          if (path != null && path.isNotEmpty) {
+            filenames.add(p.basename(path));
+          }
+        } catch (_) {
+          continue;
+        }
+      }
+    }
+    return filenames;
+  }
+
+  /// The `AudioEvent` json of every entry in a stored bucket [raw], in either
+  /// the legacy list shape or the versioned `{schemaVersion, sounds}` shape.
+  static Iterable<Map<String, dynamic>> _storedAudioJson(String raw) sync* {
+    final Object? decoded;
+    try {
+      decoded = jsonDecode(raw);
+    } catch (_) {
+      return;
+    }
+    final List<dynamic> entries;
+    if (decoded is List) {
+      entries = decoded;
+    } else if (decoded is Map && decoded['sounds'] is List) {
+      entries = decoded['sounds'] as List<dynamic>;
+    } else {
+      return;
+    }
+    for (final entry in entries.whereType<Map>()) {
+      // Legacy entries are the AudioEvent itself; versioned ones nest it.
+      final audio = entry['audio'];
+      yield Map<String, dynamic>.from(audio is Map ? audio : entry);
+    }
+  }
+
   static bool _isNewerSchema(Map<String, dynamic> decoded) {
     final version = decoded['schemaVersion'];
     return version is int &&
@@ -229,10 +309,45 @@ class SavedSoundsService {
     return sound.copyWith(audio: _persistableSound(sound.audio));
   }
 
+  /// [sound] in the form that is written to disk.
+  ///
+  /// Strips the editor's clip anchor, and stores a draft-local audio file
+  /// relative to the documents directory rather than by absolute path — iOS
+  /// rewrites the container path on every app update, so an absolute path
+  /// dangles from then on and the saved sound plays nothing (#7977).
   AudioEvent _persistableSound(AudioEvent sound) {
-    return sound.anchorClipId == null
+    final unanchored = sound.anchorClipId == null
         ? sound
         : sound.copyWith(clearAnchorClipId: true);
+    return _mapLocalAudioPath(unanchored, toPortableAudioPath);
+  }
+
+  SavedSound _resolvedRecord(SavedSound sound) =>
+      sound.copyWith(audio: _resolvedSound(sound.audio));
+
+  /// [sound] with its stored draft-local path rebased onto [_documentsPath].
+  ///
+  /// [resolveAudioPath] also accepts an absolute path from a previous
+  /// container, so a sound saved before the portable form existed heals the
+  /// first time it is loaded.
+  AudioEvent _resolvedSound(AudioEvent sound) => _mapLocalAudioPath(
+    sound,
+    (path) => resolveAudioPath(path, _documentsPath),
+  );
+
+  /// Applies [transform] to [sound]'s file path when it is draft-local audio.
+  ///
+  /// [AudioEvent.localFilePath] is the gate: a published or bundled sound's
+  /// `url` is a remote address, and rewriting one would turn a playable url
+  /// into a dangling local path.
+  static AudioEvent _mapLocalAudioPath(
+    AudioEvent sound,
+    String Function(String path) transform,
+  ) {
+    final path = sound.localFilePath;
+    if (path == null) return sound;
+    final mapped = transform(path);
+    return mapped == path ? sound : sound.copyWith(url: mapped);
   }
 
   /// One-time upgrade migration: adopt the pre-namespacing device-wide list

--- a/mobile/test/extensions/draft_local_audio_extensions_test.dart
+++ b/mobile/test/extensions/draft_local_audio_extensions_test.dart
@@ -23,6 +23,7 @@ DivineVideoClip _createTestClip() => DivineVideoClip(
 
 DivineVideoDraft _draft({
   Map<String, dynamic> editorStateHistory = const {},
+  Map<String, dynamic> editorEditingParameters = const {},
   AudioEvent? selectedSound,
 }) => DivineVideoDraft(
   id: 'draft_1',
@@ -36,6 +37,7 @@ DivineVideoDraft _draft({
   publishStatus: PublishStatus.draft,
   publishAttempts: 0,
   editorStateHistory: editorStateHistory,
+  editorEditingParameters: editorEditingParameters,
   selectedSound: selectedSound,
 );
 
@@ -94,6 +96,66 @@ void main() {
 
       expect(draft.localAudioFilePaths, {path});
     });
+
+    test('collects local audio held only in completed-editor parameters', () {
+      const path = '/docs/draft_audio_imports/draft_1/completed.m4a';
+      final draft = _draft(
+        editorEditingParameters: {
+          'meta': {
+            VideoEditorConstants.audioStateHistoryKey: [
+              _localImport('local_import_completed', path).toJson(),
+            ],
+          },
+        },
+      );
+
+      expect(draft.localAudioFilePaths, {path});
+    });
+
+    test('deduplicates completed-editor audio against history', () {
+      const path = '/docs/draft_audio_imports/draft_1/shared.m4a';
+      final track = _localImport('local_import_shared', path);
+      final draft = _draft(
+        editorStateHistory: _historyWithAudio([track]),
+        editorEditingParameters: {
+          'meta': {
+            VideoEditorConstants.audioStateHistoryKey: [track.toJson()],
+          },
+        },
+      );
+
+      expect(draft.localAudioFilePaths, {path});
+    });
+
+    test('ignores malformed completed-editor parameter shapes', () {
+      final draft = _draft(
+        editorEditingParameters: const {
+          'meta': {
+            VideoEditorConstants.audioStateHistoryKey: [
+              'not-a-map',
+              <String, dynamic>{},
+            ],
+          },
+        },
+      );
+
+      expect(draft.localAudioFilePaths, isEmpty);
+    });
+
+    test(
+      'keeps history paths when completed-editor parameters are malformed',
+      () {
+        const path = '/docs/voice_over_recordings/history.m4a';
+        final draft = _draft(
+          editorStateHistory: _historyWithAudio([
+            _localImport('local_import_history', path),
+          ]),
+          editorEditingParameters: const {'meta': 'not-a-map'},
+        );
+
+        expect(draft.localAudioFilePaths, {path});
+      },
+    );
 
     test('ignores non-local audio (bundled, network, original sound)', () {
       final draft = _draft(

--- a/mobile/test/helpers/test_provider_overrides.dart
+++ b/mobile/test/helpers/test_provider_overrides.dart
@@ -17,6 +17,7 @@ import 'package:openvine/features/feature_flags/models/feature_flag.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/app_version_provider.dart';
+import 'package:openvine/providers/documents_path_provider.dart';
 import 'package:openvine/providers/nip05_verification_provider.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
@@ -394,8 +395,9 @@ List<dynamic> getStandardTestOverrides({
   final mockFollow = mockFollowRepository ?? createMockFollowRepository();
 
   return [
-    // Mirror DeviceScope's required bootstrap override for test containers.
+    // Mirror DeviceScope's required bootstrap overrides for test containers.
     appVersionProvider.overrideWithValue('test'),
+    documentsPathProvider.overrideWithValue('/documents'),
     // Analytics has its own focused tests. Other widget tests must not create
     // its transport, timers, or session listeners as an incidental side effect.
     analyticsServiceProvider.overrideWithValue(

--- a/mobile/test/providers/device_scope_test.dart
+++ b/mobile/test/providers/device_scope_test.dart
@@ -9,6 +9,7 @@ import 'package:openvine/providers/app_version_provider.dart';
 import 'package:openvine/providers/container_swap_host.dart';
 import 'package:openvine/providers/database_provider.dart';
 import 'package:openvine/providers/device_scope.dart';
+import 'package:openvine/providers/documents_path_provider.dart';
 import 'package:openvine/providers/install_source_provider.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -29,6 +30,7 @@ void main() {
       sharedPreferences: prefs,
       switchController: AccountSwitchController(),
       appVersion: '1.2.3',
+      documentsPath: '/documents',
       installSource: InstallSource.playStore,
     );
   });
@@ -65,6 +67,16 @@ void main() {
 
     expect(a.read(installSourceProvider), InstallSource.playStore);
     expect(b.read(installSourceProvider), InstallSource.playStore);
+  });
+
+  test('every container reads the same documents path override', () {
+    final a = buildAccountContainer(deviceScope);
+    addTearDown(a.dispose);
+    final b = buildAccountContainer(deviceScope);
+    addTearDown(b.dispose);
+
+    expect(a.read(documentsPathProvider), '/documents');
+    expect(b.read(documentsPathProvider), '/documents');
   });
 
   test('every container reads the same app version override', () {

--- a/mobile/test/providers/saved_sounds_provider_test.dart
+++ b/mobile/test/providers/saved_sounds_provider_test.dart
@@ -1,0 +1,82 @@
+// ABOUTME: Tests the wiring of savedSoundsServiceProvider.
+// ABOUTME: Pins the account bucket and the documents path the service reads.
+
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart' show AudioEvent;
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/documents_path_provider.dart';
+import 'package:openvine/providers/saved_sounds_provider.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
+import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/saved_sounds_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockAuthService extends Mock implements AuthService {}
+
+void main() {
+  group(savedSoundsServiceProvider, () {
+    const pubkeyHex =
+        'a1b2c3d4e5f6789012345678901234567890abcdef1234567890123456789012';
+    const oldContainer = '/var/mobile/Containers/Data/Application/OLD';
+    const newContainer = '/var/mobile/Containers/Data/Application/NEW';
+    const relativePath = 'draft_audio_imports/draft_autosave/imported.m4a';
+
+    late SharedPreferences preferences;
+    late _MockAuthService authService;
+
+    setUp(() async {
+      SavedSoundsService.resetLegacyMigrationClaimForTesting();
+      SharedPreferences.setMockInitialValues({});
+      preferences = await SharedPreferences.getInstance();
+      authService = _MockAuthService();
+      when(() => authService.currentPublicKeyHex).thenReturn(pubkeyHex);
+      when(() => authService.authState).thenReturn(AuthState.authenticated);
+      when(
+        () => authService.authStateStream,
+      ).thenAnswer((_) => const Stream<AuthState>.empty());
+    });
+
+    ProviderContainer createContainer(String documentsPath) {
+      final container = ProviderContainer(
+        overrides: [
+          authServiceProvider.overrideWithValue(authService),
+          sharedPreferencesProvider.overrideWithValue(preferences),
+          documentsPathProvider.overrideWithValue(documentsPath),
+        ],
+      );
+      addTearDown(container.dispose);
+      return container;
+    }
+
+    test('hands the service the container-relative documents path', () async {
+      // Save on one launch...
+      await createContainer(oldContainer)
+          .read(savedSoundsServiceProvider)
+          .saveSound(
+            AudioEvent.fromLocalImport(
+              id: 'local_import_1',
+              filePath: '$oldContainer/$relativePath',
+              createdAt: 1700000000,
+              title: 'Imported sound',
+              mimeType: 'audio/mp4',
+            ),
+          );
+
+      // ...read it back on the launch after an iOS app update rewrote the
+      // container path. Without the documents path the provider hands over,
+      // the sound loads with a dangling url and plays nothing (#7977).
+      final afterUpdate = createContainer(
+        newContainer,
+      ).read(savedSoundsServiceProvider);
+
+      expect(
+        afterUpdate.loadSounds().single.url,
+        '$newContainer/$relativePath',
+      );
+    });
+  });
+}

--- a/mobile/test/providers/swap_account_test.dart
+++ b/mobile/test/providers/swap_account_test.dart
@@ -83,6 +83,7 @@ void main() {
       sharedPreferences: prefs,
       switchController: controller,
       appVersion: 'test',
+      documentsPath: '/documents',
       accountOverrides: [
         secureKeyStorageProvider.overrideWithValue(keyStorage),
       ],

--- a/mobile/test/services/creator_sync/saved_sounds_local_store_test.dart
+++ b/mobile/test/services/creator_sync/saved_sounds_local_store_test.dart
@@ -3,6 +3,7 @@
 
 import 'package:creator_sync/creator_sync.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart' show AudioEvent;
 import 'package:openvine/services/creator_sync/saved_sounds_local_store.dart';
 import 'package:openvine/services/saved_sounds_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -33,6 +34,37 @@ void main() {
     test('readAll is empty for a fresh account', () async {
       expect(await store.readAll(), isEmpty);
     });
+
+    test(
+      'readAll publishes the stored audio path, not the resolved one',
+      () async {
+        const container = '/var/mobile/Containers/Data/Application/OLD';
+        const relativePath = 'draft_audio_imports/draft_autosave/imported.m4a';
+        final imported = SavedSoundsService(
+          await SharedPreferences.getInstance(),
+          pubkeyHex: pubkey,
+          documentsPath: container,
+        );
+        await imported.saveSound(
+          AudioEvent.fromLocalImport(
+            id: 'local_import_1',
+            filePath: '$container/$relativePath',
+            createdAt: 1700000000,
+            title: 'Imported sound',
+            mimeType: 'audio/mp4',
+          ),
+        );
+
+        final body = (await SavedSoundsLocalStore(imported).readAll().then(
+          (all) => all['local_import_1'],
+        ))!;
+
+        // The reconciler hashes this body to decide whether to republish. iOS
+        // rewrites the container path on every app update, so a resolved path
+        // here would republish the sound after every update for no user edit.
+        expect((body['audio']! as Map)['url'], relativePath);
+      },
+    );
 
     test('readAll keys sounds by their full untruncated id', () async {
       final sound = buildSavedSound(id: 'c' * 64);

--- a/mobile/test/services/draft_storage_service_test.dart
+++ b/mobile/test/services/draft_storage_service_test.dart
@@ -15,6 +15,7 @@ import 'package:openvine/models/stop_motion_clip_frame.dart';
 import 'package:openvine/models/video_editor/clip_chroma_key.dart';
 import 'package:openvine/services/clip_library_service.dart';
 import 'package:openvine/services/draft_storage_service.dart';
+import 'package:openvine/services/saved_sounds_service.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
@@ -2160,6 +2161,121 @@ void main() {
           reason: 'a corrupt sibling draft must not block audio cleanup',
         );
       });
+
+      test('keeps audio a saved sound still points at', () async {
+        // Importing audio from the Library still writes it under whichever
+        // draft was open (`draft_audio_imports/<draftId>/`), so deleting that
+        // draft would otherwise reclaim a file My Sounds depends on. Unlike a
+        // stale path, a deleted file cannot be healed on load (#7977).
+        final audio = writeAudio(
+          p.join('draft_audio_imports', 'draft_autosave', 'imported.m4a'),
+        );
+        SavedSoundsService.resetLegacyMigrationClaimForTesting();
+        SharedPreferences.setMockInitialValues({});
+        final preferences = await SharedPreferences.getInstance();
+        await SavedSoundsService(
+          preferences,
+          documentsPath: documentsPath,
+        ).saveSound(
+          AudioEvent.fromLocalImport(
+            id: 'local_import_saved',
+            filePath: audio.path,
+            createdAt: 1700000000,
+            title: 'Saved sound',
+            mimeType: 'audio/mp4',
+          ),
+        );
+        final guardedService = DraftStorageService(
+          draftsDao: database.draftsDao,
+          clipsDao: database.clipsDao,
+          preferences: preferences,
+        );
+        final draft = draftWithAudio(
+          id: 'draft_autosave',
+          audioPath: audio.path,
+          audioId: 'local_import_saved',
+        );
+        await guardedService.saveDraft(draft);
+
+        await guardedService.deleteDraft(draft.id);
+
+        expect(
+          audio.existsSync(),
+          isTrue,
+          reason: 'a file My Sounds still references must survive the delete',
+        );
+      });
+
+      test('deletes audio no saved sound points at', () async {
+        final audio = writeAudio(
+          p.join('draft_audio_imports', 'draft_unsaved', 'imported.m4a'),
+        );
+        SavedSoundsService.resetLegacyMigrationClaimForTesting();
+        SharedPreferences.setMockInitialValues({});
+        final guardedService = DraftStorageService(
+          draftsDao: database.draftsDao,
+          clipsDao: database.clipsDao,
+          preferences: await SharedPreferences.getInstance(),
+        );
+        final draft = draftWithAudio(
+          id: 'draft_unsaved',
+          audioPath: audio.path,
+          audioId: 'local_import_unsaved',
+        );
+        await guardedService.saveDraft(draft);
+
+        await guardedService.deleteDraft(draft.id);
+
+        expect(
+          audio.existsSync(),
+          isFalse,
+          reason: 'the saved-sound guard must not keep every audio file alive',
+        );
+      });
+
+      test(
+        'keeps audio a saved sound points at when all drafts are cleared',
+        () async {
+          final audio = writeAudio(
+            p.join('draft_audio_imports', 'draft_cleared', 'imported.m4a'),
+          );
+          SavedSoundsService.resetLegacyMigrationClaimForTesting();
+          SharedPreferences.setMockInitialValues({});
+          final preferences = await SharedPreferences.getInstance();
+          await SavedSoundsService(
+            preferences,
+            documentsPath: documentsPath,
+          ).saveSound(
+            AudioEvent.fromLocalImport(
+              id: 'local_import_saved_clear',
+              filePath: audio.path,
+              createdAt: 1700000000,
+              title: 'Saved sound',
+              mimeType: 'audio/mp4',
+            ),
+          );
+          final guardedService = DraftStorageService(
+            draftsDao: database.draftsDao,
+            clipsDao: database.clipsDao,
+            preferences: preferences,
+          );
+          await guardedService.saveDraft(
+            draftWithAudio(
+              id: 'draft_cleared',
+              audioPath: audio.path,
+              audioId: 'local_import_saved_clear',
+            ),
+          );
+
+          await guardedService.clearAllDrafts();
+
+          expect(
+            audio.existsSync(),
+            isTrue,
+            reason: 'My Sounds survives a clear-all, so its audio must too',
+          );
+        },
+      );
 
       test('deletes audio files when all drafts are cleared', () async {
         final audio = writeAudio(

--- a/mobile/test/services/draft_storage_service_test.dart
+++ b/mobile/test/services/draft_storage_service_test.dart
@@ -2126,6 +2126,62 @@ void main() {
         );
       });
 
+      test(
+        'keeps audio held only in a surviving completed-editor snapshot',
+        () async {
+          final audio = writeAudio(
+            p.join('voice_over_recordings', 'completed_shared.m4a'),
+          );
+          final track = AudioEvent.fromLocalImport(
+            id: 'local_import_completed_shared',
+            filePath: audio.path,
+            createdAt: 1700000000,
+            title: 'Local audio',
+            mimeType: 'audio/mp4',
+          );
+          final owner = draftWithAudio(
+            id: 'draft_snapshot_owner',
+            audioPath: audio.path,
+            audioId: track.id,
+          );
+          final survivor = DivineVideoDraft.create(
+            id: 'draft_snapshot_survivor',
+            clips: [
+              DivineVideoClip(
+                id: 'clip_snapshot_survivor',
+                video: EditorVideo.file('/path/to/video.mp4'),
+                duration: const Duration(seconds: 6),
+                recordedAt: DateTime(2025),
+                targetAspectRatio: AspectRatio.square,
+                originalAspectRatio: 9 / 16,
+              ),
+            ],
+            title: 'Snapshot survivor',
+            description: '',
+            hashtags: const {},
+            selectedApproach: 'video',
+            editorEditingParameters: {
+              'meta': {
+                VideoEditorConstants.audioStateHistoryKey: [track.toJson()],
+              },
+            },
+          );
+
+          await service.saveDraft(owner);
+          await service.saveDraft(survivor);
+
+          await service.deleteDraft(owner.id);
+
+          expect(
+            audio.existsSync(),
+            isTrue,
+            reason:
+                'audio in a surviving completed-editor snapshot must outlive '
+                'the deleted draft that shared it',
+          );
+        },
+      );
+
       test('still deletes the target audio when a sibling draft has a corrupt '
           'data blob', () async {
         final audio = writeAudio(

--- a/mobile/test/services/saved_sounds_service_test.dart
+++ b/mobile/test/services/saved_sounds_service_test.dart
@@ -35,6 +35,17 @@ AudioEvent _sound({
   );
 }
 
+AudioEvent _importedSound({
+  required String id,
+  required String filePath,
+}) => AudioEvent.fromLocalImport(
+  id: id,
+  filePath: filePath,
+  createdAt: 1700000000,
+  title: 'Imported sound',
+  mimeType: 'audio/mp4',
+);
+
 void main() {
   group(SavedSoundsService, () {
     late SharedPreferences sharedPreferences;
@@ -464,6 +475,235 @@ void main() {
           );
         },
       );
+    });
+
+    group('draft-local audio paths', () {
+      // The container UUID iOS rewrites on every app update.
+      const oldContainer = '/var/mobile/Containers/Data/Application/OLD';
+      const newContainer = '/var/mobile/Containers/Data/Application/NEW';
+      const relativePath = 'draft_audio_imports/draft_autosave/imported.m4a';
+
+      test(
+        'persists an imported sound relative to the documents directory',
+        () async {
+          final service = SavedSoundsService(
+            sharedPreferences,
+            documentsPath: oldContainer,
+          );
+
+          await service.saveSound(
+            _importedSound(
+              id: 'local_import_1',
+              filePath: '$oldContainer/$relativePath',
+            ),
+          );
+
+          expect(
+            sharedPreferences.getString('saved_reusable_sounds_anon'),
+            contains(relativePath),
+            reason: 'the stored path must survive a container rewrite',
+          );
+          expect(
+            sharedPreferences.getString('saved_reusable_sounds_anon'),
+            isNot(contains(oldContainer)),
+          );
+        },
+      );
+
+      test(
+        'plays back from the current container after an app update',
+        () async {
+          await SavedSoundsService(
+            sharedPreferences,
+            documentsPath: oldContainer,
+          ).saveSound(
+            _importedSound(
+              id: 'local_import_1',
+              filePath: '$oldContainer/$relativePath',
+            ),
+          );
+
+          // The next launch resolves a different documents directory.
+          final afterUpdate = SavedSoundsService(
+            sharedPreferences,
+            documentsPath: newContainer,
+          );
+
+          expect(
+            afterUpdate.loadSounds().single.url,
+            '$newContainer/$relativePath',
+          );
+        },
+      );
+
+      test('heals a sound saved before paths were stored portably', () async {
+        // Written by a build that persisted the absolute path verbatim.
+        sharedPreferences.setString(
+          'saved_reusable_sounds_anon',
+          jsonEncode([
+            _importedSound(
+              id: 'local_import_1',
+              filePath: '$oldContainer/$relativePath',
+            ).toJson(),
+          ]),
+        );
+
+        final service = SavedSoundsService(
+          sharedPreferences,
+          documentsPath: newContainer,
+        );
+
+        expect(service.loadSounds().single.url, '$newContainer/$relativePath');
+      });
+
+      test('leaves a published sound url alone', () async {
+        // A remote url that happens to carry an audio-root segment: without
+        // the draft-local gate it would be truncated on save and rebased
+        // under the documents directory on load, turning a playable url into
+        // a dangling path.
+        const remoteUrl =
+            'https://cdn.example.com/voice_over_recordings/take.m4a';
+        final published = _sound(id: 'published').copyWith(url: remoteUrl);
+
+        final service = SavedSoundsService(
+          sharedPreferences,
+          documentsPath: newContainer,
+        );
+        await service.saveSound(published);
+
+        expect(service.loadSounds().single.url, remoteUrl);
+        expect(
+          sharedPreferences.getString('saved_reusable_sounds_anon'),
+          contains(remoteUrl),
+        );
+      });
+
+      test(
+        'hands the stored path to callers that opt out of resolving',
+        () async {
+          final service = SavedSoundsService(
+            sharedPreferences,
+            documentsPath: oldContainer,
+          );
+          await service.saveSound(
+            _importedSound(
+              id: 'local_import_1',
+              filePath: '$oldContainer/$relativePath',
+            ),
+          );
+
+          expect(
+            service.loadSavedSounds(resolveLocalPaths: false).single.audio.url,
+            relativePath,
+          );
+        },
+      );
+
+      test('keeps the stored path stable across a container rewrite', () async {
+        await SavedSoundsService(
+          sharedPreferences,
+          documentsPath: oldContainer,
+        ).saveSound(
+          _importedSound(
+            id: 'local_import_1',
+            filePath: '$oldContainer/$relativePath',
+          ),
+        );
+        final before = sharedPreferences.getString(
+          'saved_reusable_sounds_anon',
+        );
+
+        // Loading and rewriting on a later launch must not bake the new
+        // container into storage — cross-device sync hashes this body, and a
+        // path that moves every app update republishes itself forever.
+        final afterUpdate = SavedSoundsService(
+          sharedPreferences,
+          documentsPath: newContainer,
+        );
+        await afterUpdate.saveSound(_sound(id: 'other'));
+
+        expect(
+          sharedPreferences.getString('saved_reusable_sounds_anon'),
+          contains(relativePath),
+        );
+        expect(
+          sharedPreferences.getString('saved_reusable_sounds_anon'),
+          isNot(contains(newContainer)),
+        );
+        expect(before, isNot(contains(newContainer)));
+      });
+    });
+
+    group('referencedLocalAudioFilenames', () {
+      final pubkey = 'f' * 64;
+
+      test(
+        'collects local audio basenames from every account bucket',
+        () async {
+          await SavedSoundsService(
+            sharedPreferences,
+            documentsPath: '/documents',
+          ).saveSound(
+            _importedSound(
+              id: 'local_import_anon',
+              filePath: '/documents/draft_audio_imports/d1/anon.m4a',
+            ),
+          );
+          await SavedSoundsService(
+            sharedPreferences,
+            pubkeyHex: pubkey,
+            documentsPath: '/documents',
+          ).saveSound(
+            _importedSound(
+              id: 'local_import_account',
+              filePath: '/documents/draft_audio_imports/d2/account.m4a',
+            ),
+          );
+
+          expect(
+            SavedSoundsService.referencedLocalAudioFilenames(sharedPreferences),
+            {'anon.m4a', 'account.m4a'},
+          );
+        },
+      );
+
+      test('reads the pre-namespacing legacy bucket too', () {
+        sharedPreferences.setString(
+          'saved_reusable_sounds',
+          jsonEncode([
+            _importedSound(
+              id: 'local_import_legacy',
+              filePath: 'draft_audio_imports/d3/legacy.m4a',
+            ).toJson(),
+          ]),
+        );
+
+        expect(
+          SavedSoundsService.referencedLocalAudioFilenames(sharedPreferences),
+          {'legacy.m4a'},
+        );
+      });
+
+      test('ignores published sounds and unrelated keys', () async {
+        await SavedSoundsService(sharedPreferences).saveSound(
+          _sound(id: 'published'),
+        );
+        await sharedPreferences.setString('vine_drafts', 'not a sound bucket');
+
+        expect(
+          SavedSoundsService.referencedLocalAudioFilenames(sharedPreferences),
+          isEmpty,
+        );
+      });
+
+      test('skips a bucket this build cannot decode', () {
+        sharedPreferences.setString('saved_reusable_sounds_anon', 'not json');
+
+        expect(
+          SavedSoundsService.referencedLocalAudioFilenames(sharedPreferences),
+          isEmpty,
+        );
+      });
     });
   });
 }

--- a/mobile/test/widgets/library/sounds_tab_test.dart
+++ b/mobile/test/widgets/library/sounds_tab_test.dart
@@ -18,6 +18,7 @@ import 'package:openvine/blocs/saved_sounds/saved_sounds_scope.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/saved_sound.dart';
 import 'package:openvine/providers/creator_sync_provider.dart';
+import 'package:openvine/providers/documents_path_provider.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/upload_media_providers.dart';
@@ -143,6 +144,7 @@ void main() {
         ProviderScope(
           overrides: [
             sharedPreferencesProvider.overrideWithValue(sharedPreferences),
+            documentsPathProvider.overrideWithValue('/documents'),
             if (audioService != null)
               audioPlaybackServiceProvider.overrideWithValue(audioService),
           ],
@@ -544,6 +546,7 @@ void main() {
           ProviderScope(
             overrides: [
               sharedPreferencesProvider.overrideWithValue(sharedPreferences),
+              documentsPathProvider.overrideWithValue('/documents'),
               soundSyncAvailabilityProvider.overrideWith(
                 (ref) async => SoundSyncAvailable(syncRepository),
               ),
@@ -663,6 +666,7 @@ void main() {
                 sharedPreferencesProvider.overrideWithValue(
                   sharedPreferences,
                 ),
+                documentsPathProvider.overrideWithValue('/documents'),
                 nostrSessionProvider.overrideWith(
                   () => _TestNostrSession(
                     NostrSessionReadiness.nostrReady(


### PR DESCRIPTION
## Description

A sound the user imports and saves to **My Sounds** goes silent after an iOS app update. The entry stays in the list, so it looks intact — it just has no audio.

Same mechanism #7970 fixed for drafts, in a second store that PR deliberately left alone. iOS rewrites the app container path on every app update, and `SavedSoundsService` persisted the `AudioEvent` verbatim, so the absolute `<Documents>/draft_audio_imports/<draftId>/<file>` path a local import carries dangles from then on. Nothing existence-checks it before playback, so it fails silently rather than surfacing an error.

**Three defects, all fixed here.** The issue flagged the second as a "worth confirming" — it is reachable, and the path fix alone would not have made the sound play. The third surfaced while reviewing the fix: the same audio-goes-missing failure, in the draft cleanup scan this PR extends.

### 1. The dangling path

Draft-local audio is now persisted relative to the documents directory, reusing the helpers #7970 shipped in `utils/draft_audio_path_resolver.dart`. `resolveAudioPath` also accepts an absolute path from a previous container, so entries already broken on users' devices heal the first time they are loaded.

The gate is `AudioEvent.localFilePath`, not a raw `url` rewrite: a published sound's `url` is a remote address, and a remote url that happens to carry a `voice_over_recordings/` segment would otherwise be truncated on save and rebased under Documents on load — turning a playable url into a dangling local path. A test pins that.

**Why `DeviceScope` and not an edit inside the service:** the read side needs a documents path and there was no synchronous source for one. `loadSavedSounds()` is sync and so are its callers, `savedSoundsServiceProvider` is a plain `Provider`, and `getDocumentsPath()` is a `Future`. Drafts do not hit this because `DivineVideoDraft.fromJson` is already handed a `documentsPath` by an async caller; saved sounds have no such seam. So it is resolved once at bootstrap and carried device-wide on `DeviceScope`, next to `sharedPreferences` and `installSource` — every account container reads the same value, and it survives an account switch.

**Why cross-device sync reads the stored form:** `SoundSyncRepository` hashes the body `SavedSoundsLocalStore.readAll()` returns to decide whether to republish. Handing it a *resolved* path would make that hash change after every app update, republishing every imported sound to the relay for no edit the user made — a regression this PR would otherwise have introduced, since today's stale absolute path at least stays constant. `readAll` therefore passes `resolveLocalPaths: false`.

### 2. The deleted file

`LocalAudioImportService` writes the file under whichever draft was open — `draft_audio_imports/<draftId>/` — even when the picker was opened from the Library tab, where `videoEditorProvider.draftId` is the autosave draft. Draft cleanup only ever scanned drafts (`_referencedLocalAudioFilenames`), and the backstop underneath it (`FileCleanupService.deleteFileIfUnreferenced`) consults `draftsDao` and `clipsDao` and nothing else. So deleting the originating draft reclaimed a file a My Sounds entry still pointed at.

That failure is a missing file, not a dangling path, and no amount of rebasing recovers it. Draft deletion now unions in `SavedSoundsService.referencedLocalAudioFilenames(prefs)`, which scans every account bucket — cleanup already runs device-wide, and a saved sound outlives the account switch that hides it.

`clearAllDrafts()` carried the same bug behind a comment asserting the opposite ("No drafts survive a clear-all, so nothing can still reference the audio"). My Sounds survives a clear-all, so it is guarded too.

### 3. The audio the cleanup scan could not see

*Not part of the original fix — found while reviewing it, and left in because it is the same failure, one layer down.*

The editor keeps audio in three unrelated places: the legacy `selectedSound`, every entry of the undo/redo history, and `editorEditingParameters` — the snapshot a completed editor session writes. `DraftLocalAudioPaths.localAudioFilePaths` swept only the first two.

That list is used in **both** directions. Draft deletion reads it to reclaim the deleted draft's audio, and `_referencedLocalAudioFilenames()` reads it again to work out which files a *surviving* draft still needs. So a track that lived only in the completed-editor snapshot was invisible twice over: deleting the draft that owned the file left it behind forever, and — the part that costs a user something — deleting any *other* draft that shared it reclaimed a file a surviving draft still renders and plays. That is #7977's failure again, reached through drafts instead of My Sounds.

The snapshot is a real carrier, not a theoretical one: `DivineVideoDraft` already rebases audio paths inside it (#7970), and `DraftRenderParametersService.buildForDraft` reads its tracks to render and publish. It is written from a different state field than the history, so the two can disagree.

**How far the evidence goes:** the gap itself is established — a draft carrying audio only in that snapshot returns an empty path set, and the two new tests fail without the sweep. What is *not* established is the user-facing sequence that lands a draft in that state; the two carriers are written from separate state fields and can disagree, but no concrete repro was found. The fix is cheap and strictly widening in both directions (more files protected, more reclaimed), so it is worth taking on that basis alone — but it should not be read as a fix for an observed report.

**Related Issue:** Closes #7977

## Out of Scope

- **A saved sound whose file is already gone still plays nothing, silently.** Users hit by defect 2 before this ships cannot be recovered by rebasing, and nothing existence-checks the path before playback. Surfacing that in the Sounds tab is a UI change of its own.
- **The import destination itself.** Audio picked from the Library still lands under the autosave draft rather than a library-owned directory. The reference guard makes that safe; moving it is a migration.
- **Deleting a saved sound never reclaims its audio file.** This is a consequence of the fix rather than a pre-existing gap: a file now kept alive by a My Sounds reference becomes a permanent orphan if the user later deletes that entry. `removeSound` has no file-deletion path and no DAO access to prove the file is otherwise unreferenced, and there is no audio sweeper to fall back on. Giving it one means moving that cleanup up a layer, which is its own change.

## Verification

- `flutter analyze lib test integration_test` — clean.
- Full suite (`flutter test test/ --exclude-tags "integration || golden"`): 17863 passed, 0 failed, 280 skipped.
- All 44 `mobile/scripts/check_*.sh` ratchets run locally, not only the ones this diff looked likely to touch. The single failure, `check_ios_extension_signing_contract.sh`, reproduces unchanged on a clean `origin/main` worktree — it needs CI environment values, and is not from this diff.
- `dart run build_runner build --delete-conflicting-outputs`; the regenerated `social_providers.g.dart` hash is committed.
- Every load-bearing behaviour was mutation-checked: dropping the draft-local gate, skipping the resolve on read, dropping the saved-sound guard, and reverting the completed-editor-snapshot sweep each turn the suite red on their own.

New tests: `saved_sounds_service_test` (portable write, rebase on read, healing a stale absolute path, published-url pass-through, stored-form opt-out, storage stability, plus four for `referencedLocalAudioFilenames`), `saved_sounds_provider_test` (the provider actually hands over the documents path), `saved_sounds_local_store_test` (sync body carries the stored path), `draft_storage_service_test` (delete and clear-all both keep a saved sound's file; a file nothing saved is still reclaimed), `device_scope_test` (every container reads the same documents path). For defect 3: `draft_local_audio_extensions_test` (audio held only in the completed-editor snapshot is collected, deduplicated against the history, survives malformed shapes, and does not cost the history its own paths) and `draft_storage_service_test` (a file a surviving draft names only in that snapshot outlives the deleted draft that shared it).

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

