### PR TITLE
chore(camera): record why a clip's audio starts where it does

### DIFF
--- a/mobile/packages/divine_camera/ios/Classes/CameraController.swift
+++ b/mobile/packages/divine_camera/ios/Classes/CameraController.swift
@@ -2802,7 +2802,7 @@ class CameraController: NSObject {
                 + "attachMs=\(String(format: "%.0f", self.lastAudioAttachMs)), "
                 + "attachPath=\(self.recordingAudioAttachPath), "
                 + "entry=[\(self.recordingAudioEntryRoute)], "
-                + "stabilization=\(Self.stabilizationString(from: self.requestedStabilizationMode))",
+                + "stabilization=\(self.reportedStabilizationString())",
             name: "DivineCamera.Recording"
         )
     }

--- a/mobile/packages/divine_camera/ios/Classes/CameraController.swift
+++ b/mobile/packages/divine_camera/ios/Classes/CameraController.swift
@@ -108,9 +108,12 @@ class CameraController: NSObject {
     /// same loose cross-queue convention as `lastVideoFrameEndPTS`.
     private var writerAnchorPTS: CMTime?
     private var firstAppendedAudioPTS: CMTime?
-    /// PTS of the first audio buffer seen by the delegate for this recording,
-    /// including ones dropped before the writer session existed. Separates
-    /// "mic delivered nothing" from "the writer gate dropped it".
+    /// PTS of the first audio buffer the delegate saw for this recording,
+    /// recorded before every gate that can drop it — the writer session not
+    /// being open yet, an interruption in progress, or no audio writer input
+    /// at all. Inside those gates a clip whose mic never delivered and a clip
+    /// whose buffers were all discarded report the same nothing, which is the
+    /// one distinction this field exists to make.
     private var firstSeenAudioPTS: CMTime?
     /// Wall-clock instant the record request entered the native layer, and how
     /// long `attachAudioToSessionIfNeeded()` blocked. A slow attach delays the
@@ -132,8 +135,10 @@ class CameraController: NSObject {
     /// The pair above as it stood for *this* recording, snapshotted at the
     /// record tap next to `lastAudioAttachMs`. Reading the live values at
     /// stop time would print one attach's path beside another attach's
-    /// duration — a fast record tap on a cold camera is enough, because the
-    /// 1s pre-warm fires while the tap's own attach is still blocking.
+    /// duration: `sessionQueue` is serial, so the deferred pre-warm cannot
+    /// overlap the tap's attach — it becomes ready at its deadline and runs
+    /// straight after it, mid-recording, overwriting the pair while
+    /// `lastAudioAttachMs` still holds the tap's own cost.
     private var recordingAudioAttachPath = "unknown"
     private var recordingAudioEntryRoute = "unknown"
     /// Wall clock at which the writer session was anchored, i.e. when capture
@@ -1178,8 +1183,9 @@ class CameraController: NSObject {
         // the new `audioReady` contract honest — the recording proceeds
         // without an audio track instead of producing a silent AAC track.
         let entrySession = AVAudioSession.sharedInstance()
+        let entryRunning = self.audioCaptureSession?.isRunning ?? false
         self.lastAudioEntryRoute = "category=\(entrySession.category.rawValue)"
-            + ",mode=\(entrySession.mode.rawValue),running=false"
+            + ",mode=\(entrySession.mode.rawValue),running=\(entryRunning)"
         self.lastAudioAttachPath = "build"
         if !configureAudioSessionForRecording() {
             return false
@@ -3004,13 +3010,18 @@ extension CameraController: AVCaptureVideoDataOutputSampleBufferDelegate {
         }
         // Handle audio output
         else if output == audioOutput {
+            // Note the mic's first buffer ahead of every gate below. Inside
+            // them a recording that never got an audio writer input, one
+            // dropped by an interruption, and one whose mic delivered nothing
+            // all log micLeadInMs=n/a — and telling those apart is the whole
+            // point of the field.
+            if isRecording, firstSeenAudioPTS == nil {
+                firstSeenAudioPTS = CMSampleBufferGetPresentationTimeStamp(sampleBuffer)
+            }
             // Skip appending while interrupted — iOS keeps delivering
             // (silent) buffers after the session is deactivated, which
             // would produce a valid AAC track with no sound.
             if isRecording, !audioInterrupted, let writer = assetWriter, let audioInput = audioWriterInput {
-                if firstSeenAudioPTS == nil {
-                    firstSeenAudioPTS = CMSampleBufferGetPresentationTimeStamp(sampleBuffer)
-                }
                 // Only append audio after session has started
                 if isWriterSessionStarted && writer.status == .writing && audioInput.isReadyForMoreMediaData {
                     audioInput.append(sampleBuffer)

--- a/mobile/packages/divine_camera/ios/Classes/CameraController.swift
+++ b/mobile/packages/divine_camera/ios/Classes/CameraController.swift
@@ -119,12 +119,23 @@ class CameraController: NSObject {
     /// leading silence is the point of measuring both.
     private var recordRequestTime: Date?
     private var lastAudioAttachMs: Double = 0
-    /// Which branch of `attachAudioToSessionIfNeeded()` this recording took,
-    /// and what the shared session looked like on entry. A drifted category
-    /// forces the slow deactivate/reconfigure/activate cycle inline on the
-    /// record tap, which delays the whole recording rather than just audio.
+    /// Which branch the most recent `attachAudioToSessionIfNeeded()` took, and
+    /// what the shared session looked like on entry. A drifted category forces
+    /// the slow deactivate/reconfigure/activate cycle inline on the record tap,
+    /// which delays the whole recording rather than just audio.
+    ///
+    /// Process-wide, not per recording: the deferred pre-warm, the
+    /// interruption-ended handler and `resumePreview()` all attach again and
+    /// can land mid-recording.
     private var lastAudioAttachPath = "unknown"
     private var lastAudioEntryRoute = "unknown"
+    /// The pair above as it stood for *this* recording, snapshotted at the
+    /// record tap next to `lastAudioAttachMs`. Reading the live values at
+    /// stop time would print one attach's path beside another attach's
+    /// duration — a fast record tap on a cold camera is enough, because the
+    /// 1s pre-warm fires while the tap's own attach is still blocking.
+    private var recordingAudioAttachPath = "unknown"
+    private var recordingAudioEntryRoute = "unknown"
     /// Wall clock at which the writer session was anchored, i.e. when capture
     /// actually began. Against `recordRequestTime` this is the tap-to-capture
     /// delay the user experiences as lost leading content.
@@ -2253,6 +2264,8 @@ class CameraController: NSObject {
             let attachStart = Date()
             let audioAttached = self.attachAudioToSessionIfNeeded()
             self.lastAudioAttachMs = Date().timeIntervalSince(attachStart) * 1000
+            self.recordingAudioAttachPath = self.lastAudioAttachPath
+            self.recordingAudioEntryRoute = self.lastAudioEntryRoute
             if audioAttached && self.audioInterrupted {
                 self.audioInterrupted = false
                 DivineCameraLog.shared.info(
@@ -2787,8 +2800,8 @@ class CameraController: NSObject {
                 + "audioTrackStartMs=\(trackStartMs), "
                 + "tapToCaptureMs=\(startDelayMs), "
                 + "attachMs=\(String(format: "%.0f", self.lastAudioAttachMs)), "
-                + "attachPath=\(self.lastAudioAttachPath), "
-                + "entry=[\(self.lastAudioEntryRoute)], "
+                + "attachPath=\(self.recordingAudioAttachPath), "
+                + "entry=[\(self.recordingAudioEntryRoute)], "
                 + "stabilization=\(Self.stabilizationString(from: self.requestedStabilizationMode))",
             name: "DivineCamera.Recording"
         )

--- a/mobile/packages/divine_camera/ios/Classes/CameraController.swift
+++ b/mobile/packages/divine_camera/ios/Classes/CameraController.swift
@@ -89,6 +89,46 @@ class CameraController: NSObject {
     /// cross-queue convention as `lastVideoFrameEndPTS`.
     private var appendedAudioBufferCount = 0
     private var maxAudioPeakDb: Float = -160
+
+    /// Audio-alignment diagnostics (#7888). "Recording starts, but the first
+    /// couple of seconds have no sound" is not reproducible in-house — five
+    /// captures on an M4 iPad all put the audio track at 0ms — so the finished
+    /// clip has to carry its own evidence, or every such report costs another
+    /// blind investigation.
+    ///
+    /// Nothing in the capture path couples the two tracks: the writer session
+    /// is anchored on the first video frame, while audio comes from a separate
+    /// AVCaptureSession whose first buffer can land either side of that anchor
+    /// (measured -66ms to +35ms). A device whose mic takes longer to deliver
+    /// pushes that gap into audible territory, and only the numbers below can
+    /// tell that apart from the alternatives — a slow attach on the record
+    /// tap, or a mic that delivered nothing at all.
+    ///
+    /// Written on `videoOutputQueue`, read once after the writer finished —
+    /// same loose cross-queue convention as `lastVideoFrameEndPTS`.
+    private var writerAnchorPTS: CMTime?
+    private var firstAppendedAudioPTS: CMTime?
+    /// PTS of the first audio buffer seen by the delegate for this recording,
+    /// including ones dropped before the writer session existed. Separates
+    /// "mic delivered nothing" from "the writer gate dropped it".
+    private var firstSeenAudioPTS: CMTime?
+    /// Wall-clock instant the record request entered the native layer, and how
+    /// long `attachAudioToSessionIfNeeded()` blocked. A slow attach delays the
+    /// *whole* recording — video included — so it loses leading content
+    /// without shifting audio against video. Distinguishing that from real
+    /// leading silence is the point of measuring both.
+    private var recordRequestTime: Date?
+    private var lastAudioAttachMs: Double = 0
+    /// Which branch of `attachAudioToSessionIfNeeded()` this recording took,
+    /// and what the shared session looked like on entry. A drifted category
+    /// forces the slow deactivate/reconfigure/activate cycle inline on the
+    /// record tap, which delays the whole recording rather than just audio.
+    private var lastAudioAttachPath = "unknown"
+    private var lastAudioEntryRoute = "unknown"
+    /// Wall clock at which the writer session was anchored, i.e. when capture
+    /// actually began. Against `recordRequestTime` this is the tap-to-capture
+    /// delay the user experiences as lost leading content.
+    private var writerSessionStartedAt: Date?
     
     private var textureRegistry: FlutterTextureRegistry
 
@@ -1064,6 +1104,11 @@ class CameraController: NSObject {
             // though the user asked for unprocessed capture (#7796).
             let needsReconfigure = session.category != .playAndRecord
                 || session.mode != desiredAudioSessionMode
+            self.lastAudioEntryRoute = "category=\(session.category.rawValue)"
+                + ",mode=\(session.mode.rawValue)"
+                + ",running=\(existing.isRunning)"
+            self.lastAudioAttachPath = needsReconfigure
+                ? "reconfigure" : (existing.isRunning ? "warm" : "restart")
             if needsReconfigure {
                 // CRITICAL: stop the audio AVCaptureSession before the
                 // setActive(false)/setActive(true) cycle inside
@@ -1121,6 +1166,10 @@ class CameraController: NSObject {
         // captured buffers would be silent. Returning false here keeps
         // the new `audioReady` contract honest — the recording proceeds
         // without an audio track instead of producing a silent AAC track.
+        let entrySession = AVAudioSession.sharedInstance()
+        self.lastAudioEntryRoute = "category=\(entrySession.category.rawValue)"
+            + ",mode=\(entrySession.mode.rawValue),running=false"
+        self.lastAudioAttachPath = "build"
         if !configureAudioSessionForRecording() {
             return false
         }
@@ -2183,7 +2232,8 @@ class CameraController: NSObject {
         }
         
         self.maxDurationMs = maxDurationMs
-        
+        let recordRequestedAt = Date()
+
         // Build and start the dedicated audio capture session on first record.
         // The audio session was pre-built in the background ~1s after the
         // first preview frame (see completeInitializationIfNeeded), so this
@@ -2199,7 +2249,10 @@ class CameraController: NSObject {
             // (!audioInterrupted) limits the damage; full protection would
             // require a writer-level lock that is not worth the added
             // complexity here.
+            self.recordRequestTime = recordRequestedAt
+            let attachStart = Date()
             let audioAttached = self.attachAudioToSessionIfNeeded()
+            self.lastAudioAttachMs = Date().timeIntervalSince(attachStart) * 1000
             if audioAttached && self.audioInterrupted {
                 self.audioInterrupted = false
                 DivineCameraLog.shared.info(
@@ -2364,6 +2417,10 @@ class CameraController: NSObject {
             self.isRecording = true
             self.isWriterSessionStarted = false  // Will be set to true when first frame is received
             self.lastVideoFrameEndPTS = nil
+            self.writerAnchorPTS = nil
+            self.writerSessionStartedAt = nil
+            self.firstAppendedAudioPTS = nil
+            self.firstSeenAudioPTS = nil
             self.recordingStartTime = Date()
             self.appendedAudioBufferCount = 0
             self.maxAudioPeakDb = -160
@@ -2504,6 +2561,8 @@ class CameraController: NSObject {
                         let hasAudioTrack = !asset.tracks(withMediaType: .audio).isEmpty
                         let audioStats = "audioBuffers=\(self.appendedAudioBufferCount), "
                             + "maxPeakDb=\(String(format: "%.1f", self.maxAudioPeakDb))"
+
+                        self.logAudioAlignmentDiagnostics(asset: asset)
                         if hasAudioTrack {
                             DivineCameraLog.shared.info(
                                 "Recording completed with audio track (durationMs=\(duration), \(audioStats))",
@@ -2698,6 +2757,43 @@ class CameraController: NSObject {
         }
     }
 
+    /// Emits the #7888 audio-alignment breadcrumb for a finished recording:
+    /// how far the first encoded audio sample sits behind the writer anchor,
+    /// how much of that gap predates any mic buffer at all, and which audio
+    /// attach path this recording took.
+    private func logAudioAlignmentDiagnostics(asset: AVAsset) {
+        func ms(_ later: CMTime?, _ earlier: CMTime?) -> String {
+            guard let later, let earlier,
+                  later.isNumeric, earlier.isNumeric else { return "n/a" }
+            return String(format: "%.0f", (later - earlier).seconds * 1000)
+        }
+
+        var startDelayMs = "n/a"
+        if let requested = self.recordRequestTime, let anchored = self.writerSessionStartedAt {
+            startDelayMs = String(format: "%.0f", anchored.timeIntervalSince(requested) * 1000)
+        }
+
+        var trackStartMs = "n/a"
+        if let audioTrack = asset.tracks(withMediaType: .audio).first {
+            let start = audioTrack.timeRange.start
+            if start.isNumeric {
+                trackStartMs = String(format: "%.0f", start.seconds * 1000)
+            }
+        }
+
+        DivineCameraLog.shared.info(
+            "Audio alignment: appendLeadInMs=\(ms(self.firstAppendedAudioPTS, self.writerAnchorPTS)), "
+                + "micLeadInMs=\(ms(self.firstSeenAudioPTS, self.writerAnchorPTS)), "
+                + "audioTrackStartMs=\(trackStartMs), "
+                + "tapToCaptureMs=\(startDelayMs), "
+                + "attachMs=\(String(format: "%.0f", self.lastAudioAttachMs)), "
+                + "attachPath=\(self.lastAudioAttachPath), "
+                + "entry=[\(self.lastAudioEntryRoute)], "
+                + "stabilization=\(Self.stabilizationString(from: self.requestedStabilizationMode))",
+            name: "DivineCamera.Recording"
+        )
+    }
+
     private func photoFlashMode(for output: AVCapturePhotoOutput) -> AVCaptureDevice.FlashMode {
         let requestedMode = currentFlashMode
         let supportedModes = output.supportedFlashModes
@@ -2864,6 +2960,8 @@ extension CameraController: AVCaptureVideoDataOutputSampleBufferDelegate {
                 if !isWriterSessionStarted && writer.status == .writing {
                     writer.startSession(atSourceTime: timestamp)
                     isWriterSessionStarted = true
+                    writerAnchorPTS = timestamp
+                    writerSessionStartedAt = Date()
                     // Native-only event (sample-buffer delegate, no method
                     // call): reclaim the UI engine's diagnostics sink first.
                     reclaimLogSink?()
@@ -2897,9 +2995,15 @@ extension CameraController: AVCaptureVideoDataOutputSampleBufferDelegate {
             // (silent) buffers after the session is deactivated, which
             // would produce a valid AAC track with no sound.
             if isRecording, !audioInterrupted, let writer = assetWriter, let audioInput = audioWriterInput {
+                if firstSeenAudioPTS == nil {
+                    firstSeenAudioPTS = CMSampleBufferGetPresentationTimeStamp(sampleBuffer)
+                }
                 // Only append audio after session has started
                 if isWriterSessionStarted && writer.status == .writing && audioInput.isReadyForMoreMediaData {
                     audioInput.append(sampleBuffer)
+                    if firstAppendedAudioPTS == nil {
+                        firstAppendedAudioPTS = CMSampleBufferGetPresentationTimeStamp(sampleBuffer)
+                    }
                     appendedAudioBufferCount += 1
                     for channel in connection.audioChannels {
                         maxAudioPeakDb = max(maxAudioPeakDb, channel.peakHoldLevel)

--- a/mobile/packages/divine_camera/test/ios_audio_alignment_diagnostics_contract_test.dart
+++ b/mobile/packages/divine_camera/test/ios_audio_alignment_diagnostics_contract_test.dart
@@ -1,0 +1,163 @@
+// ABOUTME: Static guards for the iOS recording audio-alignment breadcrumb.
+// ABOUTME: A finished clip must carry why its audio started where it did.
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+String _readNativeSource(String fileName) {
+  final file = [
+    File('ios/Classes/$fileName'),
+    File('packages/divine_camera/ios/Classes/$fileName'),
+  ].firstWhere((file) => file.existsSync());
+
+  return file.readAsStringSync();
+}
+
+/// Returns the Swift declaration or block starting at [signature] up to its
+/// closing brace, so an assertion cannot match an identical line elsewhere in
+/// the file, nor a line that sits outside the scope being asserted on.
+String _declarationAt(String source, String signature) {
+  final start = source.indexOf(signature);
+  if (start < 0) {
+    throw StateError('No declaration starting with "$signature".');
+  }
+
+  var depth = 0;
+  for (var i = source.indexOf('{', start); i < source.length; i++) {
+    if (source[i] == '{') depth++;
+    if (source[i] == '}') {
+      depth--;
+      if (depth == 0) return source.substring(start, i + 1);
+    }
+  }
+  throw StateError('Unbalanced braces after "$signature".');
+}
+
+void main() {
+  group('iOS recording audio-alignment diagnostics', () {
+    late final String source;
+    late final String diagnostics;
+
+    setUpAll(() {
+      source = _readNativeSource('CameraController.swift');
+      diagnostics = _declarationAt(
+        source,
+        'private func logAudioAlignmentDiagnostics(',
+      );
+    });
+
+    test('reports every field a leading-silence report needs', () {
+      // #7888 was reported as "the first two seconds have no audio" and could
+      // not be reproduced in-house, so the clip itself has to say which of the
+      // candidate causes applied. Each key below discriminates between them:
+      // appendLeadIn vs micLeadIn separates a late mic from the writer gate
+      // dropping buffers, tapToCapture catches a slow start that loses leading
+      // content without shifting audio at all, and the attach path plus the
+      // session state on entry say whether the record tap paid for a
+      // reconfigure. Drop one and the next report is unactionable again.
+      for (final key in const [
+        'appendLeadInMs=',
+        'micLeadInMs=',
+        'audioTrackStartMs=',
+        'tapToCaptureMs=',
+        'attachMs=',
+        'attachPath=',
+        'entry=[',
+        'stabilization=',
+      ]) {
+        expect(diagnostics, contains(key), reason: 'missing $key');
+      }
+    });
+
+    test('reads the audio track start from the finished asset', () {
+      // The in-flight PTS values say what the writer was handed; only the
+      // finished file says what a player will actually do with it.
+      expect(diagnostics, contains('asset.tracks(withMediaType: .audio)'));
+      expect(diagnostics, contains('timeRange.start'));
+    });
+
+    test('runs for recordings that ended up without an audio track', () {
+      // A clip with no audio at all is the loudest version of this bug, so the
+      // breadcrumb must not sit behind the hasAudioTrack branch that only
+      // covers the good case.
+      final stop = _declarationAt(source, 'func stopRecording(');
+      final call = stop.indexOf('self.logAudioAlignmentDiagnostics(asset:');
+      final branch = stop.indexOf('if hasAudioTrack {');
+      expect(call, greaterThan(-1));
+      expect(branch, greaterThan(-1));
+      expect(call, lessThan(branch));
+    });
+
+    test('captures the writer anchor where the session is started', () {
+      // The anchor is every lead-in measurement's zero point. Recording it
+      // anywhere but at startSession would measure a different instant than
+      // the one the audio gate compares against.
+      final delegate = _declarationAt(
+        source,
+        'func captureOutput(_ output: AVCaptureOutput,',
+      );
+      final anchor = delegate.indexOf('writer.startSession(atSourceTime:');
+      expect(anchor, greaterThan(-1));
+      expect(
+        delegate.indexOf('writerAnchorPTS = timestamp'),
+        greaterThan(anchor),
+      );
+    });
+
+    test('records the first mic buffer before the writer gate', () {
+      // firstSeenAudioPTS exists to answer "did the mic deliver anything at
+      // all". Assigned inside the isWriterSessionStarted branch it would only
+      // ever equal firstAppendedAudioPTS and answer nothing.
+      final audioBranch = _declarationAt(
+        source,
+        'if isRecording, !audioInterrupted, let writer = assetWriter,',
+      );
+      final seen = audioBranch.indexOf('firstSeenAudioPTS =');
+      final gate = audioBranch.indexOf('if isWriterSessionStarted &&');
+      expect(seen, greaterThan(-1));
+      expect(gate, greaterThan(-1));
+      expect(seen, lessThan(gate));
+    });
+
+    test('samples the audio session state before it is repaired', () {
+      // attachAudioToSessionIfNeeded() fixes a drifted category on the spot.
+      // Sampling after that repair would report .playAndRecord every time and
+      // hide the drift the record tap actually paid for. Both entry paths --
+      // the reuse branch and the first-time build -- have their own repair
+      // call, so both are pinned; the call text is matched rather than the
+      // bare function name, which also appears in the surrounding comments.
+      final attach = _declarationAt(
+        source,
+        'private func attachAudioToSessionIfNeeded()',
+      );
+
+      final reuseEntry = attach.indexOf('self.lastAudioEntryRoute =');
+      final reuseRepair = attach.indexOf(
+        'let configured = configureAudioSessionForRecording()',
+      );
+      expect(reuseEntry, greaterThan(-1));
+      expect(reuseRepair, greaterThan(-1));
+      expect(reuseEntry, lessThan(reuseRepair));
+
+      final buildEntry = attach.indexOf('self.lastAudioAttachPath = "build"');
+      final buildRepair = attach.indexOf(
+        'if !configureAudioSessionForRecording() {',
+      );
+      expect(buildEntry, greaterThan(-1));
+      expect(buildRepair, greaterThan(-1));
+      expect(buildEntry, lessThan(buildRepair));
+    });
+
+    test('measures the attach around the call, not inside it', () {
+      // The cost that matters is what the record tap waits for, which includes
+      // every branch attach can take -- including the ones that return early.
+      final start = _declarationAt(source, 'func startRecording(');
+      expect(start, contains('let attachStart = Date()'));
+      expect(
+        start.indexOf('lastAudioAttachMs = Date().timeIntervalSince'),
+        greaterThan(start.indexOf('self.attachAudioToSessionIfNeeded()')),
+      );
+    });
+  });
+}

--- a/mobile/packages/divine_camera/test/ios_audio_alignment_diagnostics_contract_test.dart
+++ b/mobile/packages/divine_camera/test/ios_audio_alignment_diagnostics_contract_test.dart
@@ -105,19 +105,27 @@ void main() {
       );
     });
 
-    test('records the first mic buffer before the writer gate', () {
+    test('records the first mic buffer before every gate that drops it', () {
       // firstSeenAudioPTS exists to answer "did the mic deliver anything at
-      // all". Assigned inside the isWriterSessionStarted branch it would only
-      // ever equal firstAppendedAudioPTS and answer nothing.
+      // all". Three gates sit between the buffer and the writer: no audio
+      // writer input (attach failed), an interruption in progress, and the
+      // writer session not being open yet. Behind any of them a clip whose
+      // mic never delivered and a clip whose buffers were all discarded both
+      // report n/a -- the one distinction the field is here to make.
       final audioBranch = _declarationAt(
         source,
-        'if isRecording, !audioInterrupted, let writer = assetWriter,',
+        'else if output == audioOutput {',
       );
       final seen = audioBranch.indexOf('firstSeenAudioPTS =');
-      final gate = audioBranch.indexOf('if isWriterSessionStarted &&');
+      final appendGate = audioBranch.indexOf(
+        'if isRecording, !audioInterrupted, let writer = assetWriter,',
+      );
+      final sessionGate = audioBranch.indexOf('if isWriterSessionStarted &&');
       expect(seen, greaterThan(-1));
-      expect(gate, greaterThan(-1));
-      expect(seen, lessThan(gate));
+      expect(appendGate, greaterThan(-1));
+      expect(sessionGate, greaterThan(-1));
+      expect(seen, lessThan(appendGate));
+      expect(seen, lessThan(sessionGate));
     });
 
     test('samples the audio session state before it is repaired', () {
@@ -165,8 +173,9 @@ void main() {
       // pre-warm, the interruption-ended handler and resumePreview(), and
       // none of the three is gated on isRecording. Reading the process-wide
       // lastAudio* pair at stop time would print one attach's path beside
-      // another attach's duration -- a record tap on a cold camera is enough,
-      // because the pre-warm fires while the tap's own attach still blocks.
+      // another attach's duration -- sessionQueue is serial, so the pre-warm
+      // cannot overlap the tap's attach, but it becomes ready at its deadline
+      // and runs straight after it, mid-recording.
       final start = _declarationAt(source, 'func startRecording(');
       final snapshot = start.indexOf(
         'self.recordingAudioAttachPath = self.lastAudioAttachPath',

--- a/mobile/packages/divine_camera/test/ios_audio_alignment_diagnostics_contract_test.dart
+++ b/mobile/packages/divine_camera/test/ios_audio_alignment_diagnostics_contract_test.dart
@@ -159,5 +159,31 @@ void main() {
         greaterThan(start.indexOf('self.attachAudioToSessionIfNeeded()')),
       );
     });
+
+    test("pairs attachMs with this recording's own attach path", () {
+      // attachAudioToSessionIfNeeded() also runs from the deferred 1s
+      // pre-warm, the interruption-ended handler and resumePreview(), and
+      // none of the three is gated on isRecording. Reading the process-wide
+      // lastAudio* pair at stop time would print one attach's path beside
+      // another attach's duration -- a record tap on a cold camera is enough,
+      // because the pre-warm fires while the tap's own attach still blocks.
+      final start = _declarationAt(source, 'func startRecording(');
+      final snapshot = start.indexOf(
+        'self.recordingAudioAttachPath = self.lastAudioAttachPath',
+      );
+      final measured = start.indexOf(
+        'lastAudioAttachMs = Date().timeIntervalSince',
+      );
+      expect(snapshot, greaterThan(-1));
+      expect(snapshot, greaterThan(measured));
+      expect(
+        diagnostics,
+        contains(r'attachPath=\(self.recordingAudioAttachPath)'),
+      );
+      expect(
+        diagnostics,
+        contains(r'entry=[\(self.recordingAudioEntryRoute)]'),
+      );
+    });
   });
 }

--- a/mobile/packages/divine_camera/test/ios_audio_alignment_diagnostics_contract_test.dart
+++ b/mobile/packages/divine_camera/test/ios_audio_alignment_diagnostics_contract_test.dart
@@ -185,5 +185,19 @@ void main() {
         contains(r'entry=[\(self.recordingAudioEntryRoute)]'),
       );
     });
+
+    test('reports the stabilization the recorder actually used', () {
+      // requestedStabilizationMode is reverted only when the mode is rejected
+      // at set time. A camera switch re-applies it, discards the result and
+      // leaves the stored value naming a mode the recording never had. Since
+      // a look-ahead mode is the one thing in the capture path that can move
+      // the writer anchor by hundreds of ms, this field has to be the mode
+      // the connection carried, not the one that was asked for.
+      expect(diagnostics, contains('self.reportedStabilizationString()'));
+      expect(
+        diagnostics,
+        isNot(contains('from: self.requestedStabilizationMode')),
+      );
+    });
   });
 }


### PR DESCRIPTION
## Description

#7888 reports that a recording's first couple of seconds have no sound. I instrumented the native capture path and took five recordings on a physical iPad Air 11-inch (M4), iOS 26.5.2. The suspected cause from the triage handoff — the writer session anchored to the first video frame while audio is still warming, turning that interval into leading silence — **does not reproduce**: the audio track starts at 0 ms in every run, including three forced onto the cold path.

| # | Path | tapToCaptureMs | attachMs | appendLeadInMs | audioTrackStartMs |
|---|---|---|---|---|---|
| 1 | warm | – | 1 | −52 | 0 |
| 2 | warm | 31 | 1 | −43 | 0 |
| 3 | cold, entry category `.playback`/`.moviePlayback` | 199 | 89 | +35 | 0 |
| 4 | cold, entry category `.playback`/`.default` | 185 | 76 | +6 | 0 |
| 5 | cold, session stopped | 206 | 93 | +20 | 0 |
| 6 | warm (verification build) | 23 | 2 | −33 | 0 |

So the report cannot currently be acted on, and nothing in a bug report says what happened on the reporter's device instead. **Three different faults produce that same complaint**, and the finished-clip log could not tell them apart:

- a mic that delivers its first buffer late — audio shifted against video,
- a record tap that pays for an inline audio-session reconfigure and starts the *whole* recording late — leading content lost, but audio and video still aligned,
- a mic that delivered nothing at all.

This PR logs the numbers that separate them, once per finished recording:

```
Audio alignment: appendLeadInMs=…, micLeadInMs=…, audioTrackStartMs=…,
tapToCaptureMs=…, attachMs=…, attachPath=…,
entry=[category=…,mode=…,running=…], stabilization=…
```

`appendLeadIn` vs `micLeadIn` separates a late mic from the writer gate dropping buffers. `audioTrackStartMs` is read from the finished asset, because the in-flight PTS values only say what the writer was handed, not what a player will do with it. `tapToCaptureMs` catches the late-start case. `attachPath` plus the shared session's category and mode **as found on entry** — sampled before `attachAudioToSessionIfNeeded()` repairs a drifted one, or it would report `.playAndRecord` every time and hide the drift the tap actually paid for.

**Why measurement and not a fix:** the runs show the two tracks are genuinely uncoupled — `appendLeadInMs` ranged from −66 ms to +35 ms, with nothing in the capture path constraining which side of the anchor the first audio buffer lands on. The mechanism the handoff describes is real; an M4 just compresses it to milliseconds. Changing writer semantics on that observation alone, with no reproduction to verify against, would be speculative. Capture behaviour is unchanged here.

Two things the investigation also ruled out, recorded so nobody re-walks them:

- **Category drift is real but cheap.** Runs 3 and 4 did enter attach with the shared session on `.playback` — the feed's player does steal it — but the inline reconfigure cost 76–93 ms, not seconds, and it delays video too.
- **The editor playback path cannot produce this.** Recorded clips are not played through a separate audio player, `audio_timing` applies only to a selected sound, and `commonTrackEnd` can only shorten a clip — none of them can shift audio later within one.

**Related Issue:** Closes #none — Relates to #7888. Instrumentation only; the reported bug is not fixed here, and #7888 stays open ([investigation comment](https://github.com/divinevideo/divine-mobile/issues/7888#issuecomment-5369951824)).

Two answers came back while this was in review, and they narrow the report to a single candidate. The reporter had no stabilization selected, and only the **audio** start is missing — the video's beginning is intact. A slow record tap delays the whole recording, video included, so that one is out; the writer gate dropping buffers needs delayed video frames, which without a look-ahead stabilization mode cannot happen. What is left is the mic delivering its first buffer late, and `micLeadInMs` is the single field that confirms it. That is the argument for shipping this rather than continuing to guess.

## Out of Scope

- **A fix for #7888.** Not reproducible in-house; see above.
- **`maxPeakDb` is dead and stays dead in this diff.** It came back as exactly −120.0 in all six recordings, on clips whose audio is fine. Since it is not −160 the metering loop ran, so `peakHoldLevel` is returning a floor constant — leaving the field with two reachable states ("some audio buffer arrived" / "none did"), which `audioBuffers=N` already tells you. Its documented purpose is unreachable by construction: "a populated track whose peak stayed near −160" cannot happen, because populating the track pins the value to −120. Nothing in Dart reads it and no test covers it, which is why it went unnoticed. Deliberately left alone here — it needs its own issue and its own fix (compute the peak from the sample buffer's PCM, or drop the field).

## Verification

- `flutter analyze packages/divine_camera` — clean.
- `flutter test` in `packages/divine_camera` — 386/386 pass, including 9 new contract tests.
- `flutter build ios --profile` — compiles.
- **On-device:** six recordings on a physical iPad Air 11-inch (M4), iOS 26.5.2, listed in the table above. Runs 3–5 were forced onto the cold path by temporarily disabling the deferred audio pre-warm (reverted before commit; on this hardware the pre-warm otherwise always beats a record tap). Run 6 was taken against the first commit's build to confirm the log line survives the cleanup pass. The three review commits below landed after those runs; they were verified by suite, analyzer, `flutter build ios --profile`, and by mutation-checking each new assertion, not by a further device recording.
- Not verified on Android: the change is iOS-only Swift, and the macOS `CameraController` is untouched.

The contract test pins the field set and, more importantly, the ordering the diagnostics depend on — anchor taken at `startSession`, first-seen mic PTS recorded before the writer gate, session state sampled before attach repairs it. Move any of those and a field keeps its name while silently measuring something else. That is not hypothetical: while writing the test it first matched `configureAudioSessionForRecording()` in a *comment* rather than the call, and passed a check that proved nothing until anchored to the call text.

## Review follow-ups

Three corrections after review, each with a test that fails if the fix is reverted. None of them changes capture behaviour; all three fix the log line describing something other than what the finished clip did.

- `762e4d2` — `attachPath` and `entry` were read from process-wide fields, so they could name a different attach than the `attachMs` printed beside them. The deferred pre-warm, the interruption-ended handler and `resumePreview()` all re-attach with no `isRecording` guard, and `sessionQueue` being serial means the pre-warm runs straight after the tap's own attach rather than during it — mid-recording either way. Snapshotted at the record tap now.
- `1e5b1e1` — `stabilization=` named the requested mode. `applyVideoStabilization()`'s result is discarded at the session-build and camera-switch sites, so a mode rejected by the new format leaves the stored value naming one the recording never had. Reads `reportedStabilizationString()` now, the same value `getCameraState()` reports.
- `2fbc7d9` — `micLeadInMs` could not make its own distinction: the first-seen PTS sat inside the guard that also requires an audio writer input and no active interruption, so a failed attach, an interruption and a silent mic all read `n/a`. Taken ahead of every gate now. Same commit stops the build path hardcoding `running=false` in the entry route.

## Type of Change

- [x] 🗑️ Chore

