### PR TITLE
fix(camera): stop iOS countdown recordings from starting quiet and ramping up

### DIFF
--- a/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
+++ b/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
@@ -97,8 +97,12 @@ typedef RecordingStartedCallback = void Function(VideoRecorderMode mode);
 /// AVAudioSession — the camera already owns it in `.playAndRecord`
 /// mode. Interference would trigger `attachAudioToSessionIfNeeded()`
 /// on the native camera controller, restarting the audio capture
-/// pipeline and resetting VPIO/AGC. That manifested as the progressive
-/// mic-volume ramp-up reported in #4539.
+/// pipeline and resetting VPIO/AGC.
+///
+/// #4548 shipped this as a fix for the progressive mic-volume ramp-up in
+/// #4539, but the reports continued: that closed one real interference
+/// path, not the bug. #4539 is still open, and the remaining suspect is
+/// the output route rather than the session category.
 CountdownSoundService defaultCountdownSoundServiceFactory() =>
     CountdownSoundService(
       audioPlayerFactory: () =>

--- a/mobile/packages/divine_camera/ios/Classes/CameraController.swift
+++ b/mobile/packages/divine_camera/ios/Classes/CameraController.swift
@@ -421,6 +421,42 @@ class CameraController: NSObject {
         }
     }
 
+    /// Forces the output route to re-settle immediately before capture.
+    ///
+    /// While audio plays out of the speaker on a `.playAndRecord` session,
+    /// iOS lowers the microphone input level to keep the speaker out of the
+    /// recording, and it restores that level only slowly afterwards. The
+    /// countdown beeps hit exactly that window: capture starts on a damped
+    /// input and the level climbs back over the following seconds, which is
+    /// the progressive volume ramp reported in #4539. Re-asserting the
+    /// output override makes iOS re-establish the route now instead of
+    /// letting the recording ride out the recovery.
+    ///
+    /// Only runs when the built-in speaker is the sole output. With
+    /// headphones or Bluetooth connected the override would drag playback
+    /// off them, and no speaker output reached the microphone in the first
+    /// place.
+    ///
+    /// Must run on `sessionQueue`.
+    private func resettleSpeakerRouteBeforeCapture() {
+        let session = AVAudioSession.sharedInstance()
+        let outputs = session.currentRoute.outputs
+        guard outputs.count == 1, outputs[0].portType == .builtInSpeaker else {
+            return
+        }
+        do {
+            try session.overrideOutputAudioPort(.speaker)
+        } catch {
+            // Non-fatal: the recording still runs, it may just start on the
+            // damped input level the beeps left behind.
+            DivineCameraLog.shared.warning(
+                "Speaker route re-settle before capture failed "
+                    + "(error=\(error.localizedDescription))",
+                name: "DivineCamera.AudioSession"
+            )
+        }
+    }
+
     /// Observe AVAudioSession interruptions (Spotify, phone calls, Siri,
     /// alarms). On `.began` we mark audio as interrupted so any in-flight
     /// recording stops trying to append audio buffers. On `.ended` with
@@ -2214,6 +2250,8 @@ class CameraController: NSObject {
                         + "WITHOUT audio track",
                     name: "DivineCamera.Recording"
                 )
+            } else {
+                self.resettleSpeakerRouteBeforeCapture()
             }
 
             // One state line per recording so a silent clip can be traced

--- a/mobile/packages/divine_camera/test/helpers/native_source.dart
+++ b/mobile/packages/divine_camera/test/helpers/native_source.dart
@@ -1,0 +1,47 @@
+// ABOUTME: Shared readers for the iOS sources the static contract tests pin.
+// ABOUTME: Scopes assertions to one declaration so they cannot match elsewhere.
+
+import 'dart:io';
+
+/// Reads an iOS source file, from the package root or the workspace root.
+///
+/// Which one applies depends on where `flutter test` was invoked, so both
+/// candidates are tried before giving up.
+///
+/// Throws a [StateError] naming [fileName] when neither path exists, rather
+/// than the bare `No element` a plain `firstWhere` would raise.
+String readNativeSource(String fileName) {
+  final candidates = [
+    File('ios/Classes/$fileName'),
+    File('packages/divine_camera/ios/Classes/$fileName'),
+  ];
+  final file = candidates.firstWhere(
+    (file) => file.existsSync(),
+    orElse: () => throw StateError(
+      'No iOS source "$fileName" at '
+      '${candidates.map((file) => file.path).join(' or ')}.',
+    ),
+  );
+
+  return file.readAsStringSync();
+}
+
+/// Returns the Swift declaration starting at [signature] up to its closing
+/// brace, so an assertion cannot match an identical line elsewhere in the
+/// file, nor a line that sits outside the scope being asserted on.
+String declarationAt(String source, String signature) {
+  final start = source.indexOf(signature);
+  if (start < 0) {
+    throw StateError('No declaration starting with "$signature".');
+  }
+
+  var depth = 0;
+  for (var i = source.indexOf('{', start); i < source.length; i++) {
+    if (source[i] == '{') depth++;
+    if (source[i] == '}') {
+      depth--;
+      if (depth == 0) return source.substring(start, i + 1);
+    }
+  }
+  throw StateError('Unbalanced braces after "$signature".');
+}

--- a/mobile/packages/divine_camera/test/ios_audio_processing_contract_test.dart
+++ b/mobile/packages/divine_camera/test/ios_audio_processing_contract_test.dart
@@ -1,38 +1,9 @@
 // ABOUTME: Static guards for the iOS unprocessed-audio capture contract.
 // ABOUTME: Pins the Music mode audio-session mode mapping (#7796).
 
-import 'dart:io';
-
 import 'package:flutter_test/flutter_test.dart';
 
-String _readNativeSource(String fileName) {
-  final file = [
-    File('ios/Classes/$fileName'),
-    File('packages/divine_camera/ios/Classes/$fileName'),
-  ].firstWhere((file) => file.existsSync());
-
-  return file.readAsStringSync();
-}
-
-/// Returns the Swift declaration starting at [signature] up to its closing
-/// brace, so an assertion cannot match an identical line elsewhere in the
-/// file, nor a line that sits outside the scope being asserted on.
-String _declarationAt(String source, String signature) {
-  final start = source.indexOf(signature);
-  if (start < 0) {
-    throw StateError('No declaration starting with "$signature".');
-  }
-
-  var depth = 0;
-  for (var i = source.indexOf('{', start); i < source.length; i++) {
-    if (source[i] == '{') depth++;
-    if (source[i] == '}') {
-      depth--;
-      if (depth == 0) return source.substring(start, i + 1);
-    }
-  }
-  throw StateError('Unbalanced braces after "$signature".');
-}
+import 'helpers/native_source.dart';
 
 void main() {
   group('iOS unprocessed audio contract', () {
@@ -42,13 +13,13 @@ void main() {
     late final String attachAudioToSession;
 
     setUpAll(() {
-      controllerSource = _readNativeSource('CameraController.swift');
-      pluginSource = _readNativeSource('DivineCameraPlugin.swift');
-      configureAudioSession = _declarationAt(
+      controllerSource = readNativeSource('CameraController.swift');
+      pluginSource = readNativeSource('DivineCameraPlugin.swift');
+      configureAudioSession = declarationAt(
         controllerSource,
         'private func configureAudioSessionForRecording(',
       );
-      attachAudioToSession = _declarationAt(
+      attachAudioToSession = declarationAt(
         controllerSource,
         'private func attachAudioToSessionIfNeeded(',
       );

--- a/mobile/packages/divine_camera/test/ios_audio_session_handoff_contract_test.dart
+++ b/mobile/packages/divine_camera/test/ios_audio_session_handoff_contract_test.dart
@@ -1,38 +1,9 @@
 // ABOUTME: Static guards for the iOS recorder-to-editor audio-session handoff.
 // ABOUTME: disposeCamera must not resolve before the capture sessions stop.
 
-import 'dart:io';
-
 import 'package:flutter_test/flutter_test.dart';
 
-String _readNativeSource(String fileName) {
-  final file = [
-    File('ios/Classes/$fileName'),
-    File('packages/divine_camera/ios/Classes/$fileName'),
-  ].firstWhere((file) => file.existsSync());
-
-  return file.readAsStringSync();
-}
-
-/// Returns the Swift declaration or block starting at [signature] up to its
-/// closing brace, so an assertion cannot match an identical line elsewhere in
-/// the file, nor a line that sits outside the scope being asserted on.
-String _declarationAt(String source, String signature) {
-  final start = source.indexOf(signature);
-  if (start < 0) {
-    throw StateError('No declaration starting with "$signature".');
-  }
-
-  var depth = 0;
-  for (var i = source.indexOf('{', start); i < source.length; i++) {
-    if (source[i] == '{') depth++;
-    if (source[i] == '}') {
-      depth--;
-      if (depth == 0) return source.substring(start, i + 1);
-    }
-  }
-  throw StateError('Unbalanced braces after "$signature".');
-}
+import 'helpers/native_source.dart';
 
 void main() {
   group('iOS camera dispose audio-session handoff', () {
@@ -40,12 +11,12 @@ void main() {
     late final String release;
 
     setUpAll(() {
-      disposeCamera = _declarationAt(
-        _readNativeSource('DivineCameraPlugin.swift'),
+      disposeCamera = declarationAt(
+        readNativeSource('DivineCameraPlugin.swift'),
         'private func disposeCamera(',
       );
-      release = _declarationAt(
-        _readNativeSource('CameraController.swift'),
+      release = declarationAt(
+        readNativeSource('CameraController.swift'),
         'func release(',
       );
     });
@@ -79,7 +50,7 @@ void main() {
       // passes when the dispatch is hoisted out of the block, or moved to its
       // top -- and either of those fires the completion before the capture
       // sessions are stopped, which is the bug this file guards.
-      final teardown = _declarationAt(release, 'sessionQueue.async {');
+      final teardown = declarationAt(release, 'sessionQueue.async {');
       expect(teardown, contains('self.audioCaptureSession?.stopRunning()'));
       expect(
         teardown,

--- a/mobile/packages/divine_camera/test/ios_capture_input_level_contract_test.dart
+++ b/mobile/packages/divine_camera/test/ios_capture_input_level_contract_test.dart
@@ -1,0 +1,67 @@
+// ABOUTME: Static guards for the iOS mic-level re-settle before capture.
+// ABOUTME: The override must stay scoped to a speaker-only output route.
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+String _readNativeSource(String fileName) {
+  final file = [
+    File('ios/Classes/$fileName'),
+    File('packages/divine_camera/ios/Classes/$fileName'),
+  ].firstWhere((file) => file.existsSync());
+
+  return file.readAsStringSync();
+}
+
+void main() {
+  group('iOS capture input level re-settle', () {
+    late final String controllerSource;
+
+    setUpAll(() {
+      controllerSource = _readNativeSource('CameraController.swift');
+    });
+
+    test('record start re-settles the route once audio is ready', () {
+      // iOS damps the mic input while the countdown beeps play out of the
+      // speaker and restores it only slowly, so capture would otherwise
+      // start on a damped input and climb back over several seconds.
+      expect(
+        controllerSource,
+        contains('self.resettleSpeakerRouteBeforeCapture()'),
+      );
+      expect(
+        controllerSource,
+        contains('private func resettleSpeakerRouteBeforeCapture() {'),
+      );
+      expect(
+        controllerSource,
+        contains('try session.overrideOutputAudioPort(.speaker)'),
+      );
+    });
+
+    test('the override stays scoped to a speaker-only route', () {
+      // Overriding while headphones or Bluetooth are connected would drag
+      // playback off them, and no speaker output reached the mic anyway.
+      expect(
+        controllerSource,
+        contains(
+          'guard outputs.count == 1, outputs[0].portType == .builtInSpeaker',
+        ),
+      );
+    });
+
+    test('a failed override does not abort the recording', () {
+      final helperStart = controllerSource.indexOf(
+        'private func resettleSpeakerRouteBeforeCapture() {',
+      );
+      final helper = controllerSource.substring(
+        helperStart,
+        controllerSource.indexOf('\n    }\n', helperStart),
+      );
+      expect(helper, contains('catch'));
+      expect(helper, isNot(contains('return false')));
+      expect(helper, isNot(contains('throw')));
+    });
+  });
+}

--- a/mobile/packages/divine_camera/test/ios_capture_input_level_contract_test.dart
+++ b/mobile/packages/divine_camera/test/ios_capture_input_level_contract_test.dart
@@ -1,41 +1,54 @@
 // ABOUTME: Static guards for the iOS mic-level re-settle before capture.
 // ABOUTME: The override must stay scoped to a speaker-only output route.
 
-import 'dart:io';
-
 import 'package:flutter_test/flutter_test.dart';
 
-String _readNativeSource(String fileName) {
-  final file = [
-    File('ios/Classes/$fileName'),
-    File('packages/divine_camera/ios/Classes/$fileName'),
-  ].firstWhere((file) => file.existsSync());
+import 'helpers/native_source.dart';
 
-  return file.readAsStringSync();
+/// Returns the `else` block belonging to the `if` that starts at [signature].
+///
+/// Pins which branch a call sits in: an assertion scoped to the declaration
+/// alone would stay green if the call moved into the other branch.
+String _elseBlockOf(String source, String signature) {
+  final ifBlock = declarationAt(source, signature);
+  final afterIf = source.substring(
+    source.indexOf(ifBlock) + ifBlock.length,
+  );
+
+  return declarationAt(afterIf, ' else {');
 }
 
 void main() {
   group('iOS capture input level re-settle', () {
-    late final String controllerSource;
+    late final String startRecording;
+    late final String audioReadyBranch;
+    late final String resettleHelper;
 
     setUpAll(() {
-      controllerSource = _readNativeSource('CameraController.swift');
+      final controllerSource = readNativeSource('CameraController.swift');
+      startRecording = declarationAt(
+        controllerSource,
+        'func startRecording(maxDurationMs:',
+      );
+      audioReadyBranch = _elseBlockOf(startRecording, 'if !audioReady {');
+      resettleHelper = declarationAt(
+        controllerSource,
+        'private func resettleSpeakerRouteBeforeCapture(',
+      );
     });
 
     test('record start re-settles the route once audio is ready', () {
       // iOS damps the mic input while the countdown beeps play out of the
       // speaker and restores it only slowly, so capture would otherwise
-      // start on a damped input and climb back over several seconds.
+      // start on a damped input and climb back over several seconds. The
+      // branch matters: on the !audioReady side there is no audio track to
+      // rescue, and the call would only move the route for nothing.
       expect(
-        controllerSource,
+        audioReadyBranch,
         contains('self.resettleSpeakerRouteBeforeCapture()'),
       );
       expect(
-        controllerSource,
-        contains('private func resettleSpeakerRouteBeforeCapture() {'),
-      );
-      expect(
-        controllerSource,
+        resettleHelper,
         contains('try session.overrideOutputAudioPort(.speaker)'),
       );
     });
@@ -44,10 +57,10 @@ void main() {
       // "Before capture" is the contract: once the writer is running, an
       // override no longer rescues the damped input the beeps left behind,
       // it only changes the route mid-clip.
-      final resettleCall = controllerSource.indexOf(
+      final resettleCall = startRecording.indexOf(
         'self.resettleSpeakerRouteBeforeCapture()',
       );
-      final writerStart = controllerSource.indexOf(
+      final writerStart = startRecording.indexOf(
         'self.startRecordingAfterAudioReady(',
       );
       expect(resettleCall, isNonNegative);
@@ -58,24 +71,19 @@ void main() {
     test('the override stays scoped to a speaker-only route', () {
       // Overriding while headphones or Bluetooth are connected would drag
       // playback off them, and no speaker output reached the mic anyway.
-      expect(
-        controllerSource,
-        contains(
-          'guard outputs.count == 1, outputs[0].portType == .builtInSpeaker',
-        ),
+      final guard = resettleHelper.indexOf(
+        'guard outputs.count == 1, outputs[0].portType == .builtInSpeaker',
       );
+      final override = resettleHelper.indexOf(
+        'try session.overrideOutputAudioPort(.speaker)',
+      );
+      expect(guard, isNonNegative);
+      expect(override, greaterThan(guard));
     });
 
     test('a failed override does not abort the recording', () {
-      final helperStart = controllerSource.indexOf(
-        'private func resettleSpeakerRouteBeforeCapture() {',
-      );
-      final helper = controllerSource.substring(
-        helperStart,
-        controllerSource.indexOf('\n    }\n', helperStart),
-      );
-      expect(helper, contains('catch'));
-      expect(helper, isNot(contains('throw')));
+      expect(resettleHelper, contains('catch'));
+      expect(resettleHelper, isNot(contains('throw')));
     });
   });
 }

--- a/mobile/packages/divine_camera/test/ios_capture_input_level_contract_test.dart
+++ b/mobile/packages/divine_camera/test/ios_capture_input_level_contract_test.dart
@@ -40,6 +40,21 @@ void main() {
       );
     });
 
+    test('the re-settle runs before the writer starts', () {
+      // "Before capture" is the contract: once the writer is running, an
+      // override no longer rescues the damped input the beeps left behind,
+      // it only changes the route mid-clip.
+      final resettleCall = controllerSource.indexOf(
+        'self.resettleSpeakerRouteBeforeCapture()',
+      );
+      final writerStart = controllerSource.indexOf(
+        'self.startRecordingAfterAudioReady(',
+      );
+      expect(resettleCall, isNonNegative);
+      expect(writerStart, isNonNegative);
+      expect(resettleCall, lessThan(writerStart));
+    });
+
     test('the override stays scoped to a speaker-only route', () {
       // Overriding while headphones or Bluetooth are connected would drag
       // playback off them, and no speaker output reached the mic anyway.
@@ -60,7 +75,6 @@ void main() {
         controllerSource.indexOf('\n    }\n', helperStart),
       );
       expect(helper, contains('catch'));
-      expect(helper, isNot(contains('return false')));
       expect(helper, isNot(contains('throw')));
     });
   });

--- a/mobile/packages/divine_camera/test/ios_stabilization_contract_test.dart
+++ b/mobile/packages/divine_camera/test/ios_stabilization_contract_test.dart
@@ -1,20 +1,15 @@
 // ABOUTME: Static guards for iOS video stabilization recorder constraints.
 
-import 'dart:io';
-
 import 'package:flutter_test/flutter_test.dart';
+
+import 'helpers/native_source.dart';
 
 void main() {
   group('iOS stabilization recorder contract', () {
     late final String controllerSource;
 
     setUpAll(() {
-      final controllerFile = [
-        File('ios/Classes/CameraController.swift'),
-        File('packages/divine_camera/ios/Classes/CameraController.swift'),
-      ].firstWhere((file) => file.existsSync());
-
-      controllerSource = controllerFile.readAsStringSync();
+      controllerSource = readNativeSource('CameraController.swift');
     });
 
     test('does not advertise previewOptimized for full-resolution output', () {


### PR DESCRIPTION
## Description

Recordings started with the countdown timer ramp up in volume on iOS. A clip from an affected device (iPhone 15 Pro, iOS 26.6) measures the ramp directly — speech RMS climbs from -50.8 dB to -24.7 dB across five seconds while the noise floor stays flat at about -65 dB:

| second | noise floor | speech |
|---|---|---|
| 0 | -65.6 dB | -50.8 dB |
| 1 | -66.3 dB | -42.3 dB |
| 2 | -64.9 dB | -36.4 dB |
| 3 | -66.8 dB | -34.9 dB |
| 4 | -59.3 dB | -30.5 dB |
| 5 | -61.1 dB | -24.7 dB |

The same scene recorded on the same device without the countdown is flat, so the countdown is the trigger. A flat floor under rising speech rules out a plain gain multiplier on the whole signal and points at input gain rising while the noise suppression that `.videoRecording` mode enables holds the floor down.

#4539 has two earlier attempts and neither theory explains this measurement. #4548 (merged May 2026, present in the build measured above) removed a real session-level interference path — just_audio reconfiguring the camera-owned `AVAudioSession` — and the reports continued. #7872 (closed, not merged) blamed the beep loudness clamping the input gain acoustically, and was withdrawn because the ramp did not reproduce on an iPhone 12 with or without the countdown, at any volume or distance. Note that the doc comment on `defaultCountdownSoundServiceFactory` in `video_recorder_bloc.dart` still describes #4539 in terms of the #4548 mechanism, so a reader landing there finds the older explanation.

The behaviour is documented and not specific to this app: while audio plays out of the speaker on a `.playAndRecord` session, iOS damps the microphone input to keep the speaker out of the recording, and restores that level only slowly afterwards. Apple's own forums carry the sibling report ([thread 694742](https://developer.apple.com/forums/thread/694742) — capture level drops dramatically as soon as an `AVPlayer` starts, filed with Apple, no reply). The countdown beeps land in exactly that window: the last one ends 150ms before the writer starts, so capture begins on a damped input and climbs back over the following seconds.

The change re-asserts the output override once audio is ready and before the writer starts, so iOS re-establishes the route immediately instead of letting the recording ride out the recovery. That is the workaround developers report for the sibling case ([thread 721535](https://developer.apple.com/forums/thread/721535)).

It is scoped to a speaker-only output route. With headphones or Bluetooth connected the override would drag playback off them, and no speaker output reached the microphone in the first place. A failed override is logged and does not abort the recording.

**Related Issue:** Relates to #4539

## Out of Scope

Deliberately not attempted, with reasons, since each was considered and rejected:

- **Attenuating the beeps.** `setVolume` is relative to the media volume, so at full volume it only shifts a threshold the user controls. And the measured recovery runs longer than five seconds, so trimming a beep to buy one second of headroom cannot close the gap either.
- **`AudioServicesPlaySystemSound`.** It genuinely bypasses the audio session — it is how Apple's Camera plays the shutter during capture — but system sounds follow the ringer volume and the silent switch. The countdown would go quiet for anyone recording in silent mode, which is the propped-up-phone case the feature exists for.
- **`AVAudioSessionMode.measurement`.** The only mechanism-independent fix, and the only public lever for input processing at all — `inputGain` is not settable on the built-in mic from iPhone 6s onward, and `preferredMicrophoneMode` is read-only. But it minimizes system processing on *every* recording, and developer reports consistently describe the level dropping to barely audible. For a phone two metres away that likely trades "starts quiet, gets loud" for "stays quiet".

No diagnostics are bundled here.

## Verification

- `flutter test` in `mobile/packages/divine_camera` — 381 passed, including four new static contract guards over the native source (the package has no Swift test target; `ios_stabilization_contract_test.dart` established the pattern).
- `flutter analyze lib test integration_test` — no issues.
- Full iOS release build for device, signed and installed on an iPad Air 11-inch (M4, iOS 26.5.2). Confirmed the shipped `Runner` binary actually contains `resettleSpeakerRouteBeforeCapture`.
- Android is untouched, so the usual Samsung Galaxy pass does not apply.

Still open, which is why this is a draft:

1. **The fix is unproven.** The iPad used for the build has never reproduced the ramp in any configuration, so it can show absence of regression but not effect. Confirmation needs an affected device.
2. **The on-device functional checks are pending** — most importantly that a countdown recording with headphones or Bluetooth connected keeps playing the beeps there and does not jump the route to the speaker when recording starts. That path is exactly what the guard protects and is the real regression risk of this change.

3. **The re-settle may only reach the first clip of a session.** `overrideOutputAudioPort` is a latched state rather than a command — it stays in effect until the route changes or it is set back to `.none` — and nothing clears it between clips. `attachAudioToSessionIfNeeded()` deliberately skips `configureAudioSessionForRecording()` (and therefore `setCategory`) once category and mode are already right, and `setActive(false)` only runs when the app pauses. With #4548 keeping the countdown player off the category, that warm path is the normal path, so on the second and later clips this call re-asserts a value that is already set. Whether iOS re-evaluates the route on a redundant write is undocumented. Device confirmation therefore needs **two countdown clips back to back**, not one — and if only the first is flat, the fix needs a forced `.none` -> `.speaker` transition instead of a re-assert.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore


