### PR TITLE
fix(account): confirm a successful account deletion instead of crashing

### DIFF
--- a/mobile/lib/widgets/delete_account_dialog.dart
+++ b/mobile/lib/widgets/delete_account_dialog.dart
@@ -958,7 +958,6 @@ Future<void> executeAccountDeletion({
         final showSupportAction =
             result.failureReason ==
             DeleteAccountFailureReason.accountRestricted;
-        final messenger = ScaffoldMessenger.of(context);
         messenger.showSnackBar(
           DivineSnackbarContainer.snackBar(
             text,

--- a/mobile/lib/widgets/delete_account_dialog.dart
+++ b/mobile/lib/widgets/delete_account_dialog.dart
@@ -452,6 +452,25 @@ Future<void> executeAccountDeletion({
 
   // Show progress sheet with BlocProvider
   if (!context.mounted) return;
+
+  // Signing out flips auth state to unauthenticated, which makes the global
+  // redirect replace the whole stack with /welcome — tearing down the route
+  // this was called from. Everything needed to report the outcome afterwards
+  // is therefore captured here: the messenger and the view sit above the
+  // Navigator and outlive the redirect, so the confirmation lands on the
+  // destination instead of vanishing with the caller (#6450).
+  final messenger = ScaffoldMessenger.of(context);
+  final view = View.of(context);
+  final textDirection = Directionality.of(context);
+  // The navigator the sheet is pushed onto, resolved while the caller is
+  // still mounted. `context.pop()` would resolve to the innermost navigator
+  // instead, which for a shell-nested caller is not the one holding it.
+  final rootNavigator = Navigator.of(context, rootNavigator: true);
+
+  // The sheet's own route, captured so dismissal can target exactly this
+  // sheet: `VineBottomSheet.show` hands back the result future, not the route.
+  ModalRoute<void>? progressSheetRoute;
+
   unawaited(
     VineBottomSheet.show<void>(
       context: context,
@@ -468,8 +487,10 @@ Future<void> executeAccountDeletion({
       // leaving the bottom nav tappable mid-deletion.
       useRootNavigator: true,
       body: const _DeletionProgressSheetContent(),
-      contentWrapper: (_, child) =>
-          BlocProvider.value(value: cubit, child: child),
+      contentWrapper: (sheetContext, child) {
+        progressSheetRoute = ModalRoute.of<void>(sheetContext);
+        return BlocProvider.value(value: cubit, child: child);
+      },
     ),
   );
 
@@ -477,24 +498,32 @@ Future<void> executeAccountDeletion({
   var progressSheetDismissed = false;
 
   void dismissProgressSheet() {
-    if (!progressSheetDismissed && context.mounted) {
-      progressSheetDismissed = true;
-      // Targets the navigator the sheet was pushed onto. `context.pop()` would
-      // resolve to the innermost navigator instead, which for a shell-nested
-      // caller is not the one holding this sheet.
-      Navigator.of(context, rootNavigator: true).pop();
+    if (progressSheetDismissed || !rootNavigator.mounted) return;
+    progressSheetDismissed = true;
+    final route = progressSheetRoute;
+    if (route == null) {
+      // The sheet has not had its first build yet, so no frame has run since
+      // it was pushed and nothing can have moved it: it is still on top.
+      rootNavigator.pop();
+      return;
+    }
+    // Once built, dismiss by identity rather than popping whatever sits on
+    // top. The sign-out redirect takes this sheet down together with the
+    // route it was pushed over, and a blind pop then removes the page the
+    // redirect just installed — for /welcome, the last one on the stack, so
+    // the app is left with no page at all (#6450).
+    if (!route.isActive) return;
+    if (route.isCurrent) {
+      rootNavigator.pop();
+    } else {
+      rootNavigator.removeRoute(route);
     }
   }
 
   // Speak each delete outcome so screen-reader users hear the result the
   // snackbar shows visually. Mirrors the snackbar text at every outcome site.
   void announceOutcome(String message) {
-    if (!context.mounted) return;
-    SemanticsService.sendAnnouncement(
-      View.of(context),
-      message,
-      Directionality.of(context),
-    );
+    SemanticsService.sendAnnouncement(view, message, textDirection);
   }
 
   // Captured before the first await so the post-sign-out catch can localize
@@ -520,6 +549,9 @@ Future<void> executeAccountDeletion({
   final attemptCancelledText = context.l10n.accountDeletionAttemptCancelled;
   final recoveryFailedText = context.l10n.accountDeletionRecoveryFailed;
   final finishingDeletionText = context.l10n.accountDeletionFinishingBody;
+  final deletionSuccessText = context.l10n.deleteAccountSuccess;
+  final deletionSuccessUnverifiedText =
+      context.l10n.deleteAccountSuccessContentUnverified;
 
   AccountDeletionAttempt? deletionAttempt;
   var attemptPrepared = false;
@@ -864,30 +896,32 @@ Future<void> executeAccountDeletion({
         localDataDeletionFailure = localDataDeletionFailedText;
       }
 
-      // Close loading indicator and show result snackbar
-      // Router will automatically redirect to /welcome after sign out
+      // Close loading indicator and show result snackbar. Sign-out has already
+      // redirected to /welcome and taken the calling route with it, so the
+      // outcome is reported through the messenger captured up front — gating
+      // this on `context.mounted` left a completed deletion silent (#6450).
       dismissProgressSheet();
-      if (context.mounted) {
-        // When the relay query that enumerates existing content failed, no
-        // per-item deletion request was sent for anything the user had already
-        // posted. When a kind-5 batch was not confirmed, some per-item requests
-        // also did not land. Saying "deletion requests sent" would overstate
-        // either outcome.
-        final snackbarText =
-            keyDeletionWarning ??
-            localDataDeletionFailure ??
-            (result.contentQueryFailed || result.contentDeletionIncomplete
-                ? context.l10n.deleteAccountSuccessContentUnverified
-                : context.l10n.deleteAccountSuccess);
-        ScaffoldMessenger.of(context).showSnackBar(
+      // When the relay query that enumerates existing content failed, no
+      // per-item deletion request was sent for anything the user had already
+      // posted. When a kind-5 batch was not confirmed, some per-item requests
+      // also did not land. Saying "deletion requests sent" would overstate
+      // either outcome.
+      final snackbarText =
+          keyDeletionWarning ??
+          localDataDeletionFailure ??
+          (result.contentQueryFailed || result.contentDeletionIncomplete
+              ? deletionSuccessUnverifiedText
+              : deletionSuccessText);
+      if (messenger.mounted) {
+        messenger.showSnackBar(
           DivineSnackbarContainer.snackBar(
             snackbarText,
             error:
                 keyDeletionWarning != null || localDataDeletionFailure != null,
           ),
         );
-        announceOutcome(snackbarText);
       }
+      announceOutcome(snackbarText);
     } else {
       // Content deletion (NIP-62) failed.
       if (attemptPrepared) {

--- a/mobile/lib/widgets/delete_account_dialog.dart
+++ b/mobile/lib/widgets/delete_account_dialog.dart
@@ -447,11 +447,11 @@ Future<void> executeAccountDeletion({
   String? confirmedPubkey,
   String screenName = 'AccountDeletion',
 }) async {
-  // Create cubit for tracking progress
-  final cubit = AccountDeletionProgressCubit();
-
-  // Show progress sheet with BlocProvider
   if (!context.mounted) return;
+
+  // Created after the mounted gate: returning above it would leave this cubit
+  // open, since only the `finally` below ever closes one.
+  final cubit = AccountDeletionProgressCubit();
 
   // Signing out flips auth state to unauthenticated, which makes the global
   // redirect replace the whole stack with /welcome — tearing down the route

--- a/mobile/lib/widgets/delete_account_dialog.dart
+++ b/mobile/lib/widgets/delete_account_dialog.dart
@@ -470,6 +470,10 @@ Future<void> executeAccountDeletion({
   // The sheet's own route, captured so dismissal can target exactly this
   // sheet: `VineBottomSheet.show` hands back the result future, not the route.
   ModalRoute<void>? progressSheetRoute;
+  // Set once the sheet has left the navigator, whoever took it down. Before
+  // the sheet's first build there is no route to target, and this is then the
+  // only way to tell "not shown yet" from "already gone".
+  var progressSheetClosed = false;
 
   unawaited(
     VineBottomSheet.show<void>(
@@ -491,7 +495,7 @@ Future<void> executeAccountDeletion({
         progressSheetRoute = ModalRoute.of<void>(sheetContext);
         return BlocProvider.value(value: cubit, child: child);
       },
-    ),
+    ).whenComplete(() => progressSheetClosed = true),
   );
 
   // Track if the progress sheet was dismissed to avoid double-popping.
@@ -503,8 +507,11 @@ Future<void> executeAccountDeletion({
     final route = progressSheetRoute;
     if (route == null) {
       // The sheet has not had its first build yet, so no frame has run since
-      // it was pushed and nothing can have moved it: it is still on top.
-      rootNavigator.pop();
+      // it was pushed and nothing can have moved it: it is still on top —
+      // unless it never made it onto the navigator, or left again before it
+      // could build. Popping blindly then removes someone else's route, which
+      // is the failure this whole function exists to avoid.
+      if (!progressSheetClosed) rootNavigator.pop();
       return;
     }
     // Once built, dismiss by identity rather than popping whatever sits on

--- a/mobile/packages/divine_ui/test/src/bottom_sheet/vine_bottom_sheet_test.dart
+++ b/mobile/packages/divine_ui/test/src/bottom_sheet/vine_bottom_sheet_test.dart
@@ -964,22 +964,30 @@ void main() {
       testWidgets(
         'contentWrapper is applied around the sheet inside the modal route',
         (tester) async {
+          ModalRoute<dynamic>? callerRoute;
+          ModalRoute<void>? wrapperRoute;
+
           await tester.pumpWidget(
             MaterialApp(
               home: Scaffold(
                 body: Builder(
-                  builder: (context) => ElevatedButton(
-                    onPressed: () async {
-                      await VineBottomSheet.show<void>(
-                        context: context,
-                        title: const Text('Wrapped'),
-                        children: const [Text('Body')],
-                        contentWrapper: (wrapperContext, child) =>
-                            _WrapperMarker(child: child),
-                      );
-                    },
-                    child: const Text('Open'),
-                  ),
+                  builder: (context) {
+                    callerRoute = ModalRoute.of(context);
+                    return ElevatedButton(
+                      onPressed: () async {
+                        await VineBottomSheet.show<void>(
+                          context: context,
+                          title: const Text('Wrapped'),
+                          children: const [Text('Body')],
+                          contentWrapper: (wrapperContext, child) {
+                            wrapperRoute = ModalRoute.of<void>(wrapperContext);
+                            return _WrapperMarker(child: child);
+                          },
+                        );
+                      },
+                      child: const Text('Open'),
+                    );
+                  },
                 ),
               ),
             ),
@@ -991,6 +999,14 @@ void main() {
           // Wrapper wraps the real sheet content.
           expect(find.byType(_WrapperMarker), findsOneWidget);
           expect(find.text('Body'), findsOneWidget);
+          // The wrapper's context resolves to the sheet's OWN route, not the
+          // route it was opened from. Callers dismiss a sheet by identity from
+          // here (`ModalRoute.of(wrapperContext)`); applying the wrapper above
+          // the modal route instead would hand them the caller's page route,
+          // and removing that takes the user's screen down with it.
+          expect(wrapperRoute, isA<ModalBottomSheetRoute<void>>());
+          expect(callerRoute, isNotNull);
+          expect(wrapperRoute, isNot(same(callerRoute)));
         },
       );
 
@@ -1084,23 +1100,31 @@ void main() {
       testWidgets(
         'contentWrapper is applied in fixed (non-scrollable) mode too',
         (tester) async {
+          ModalRoute<dynamic>? callerRoute;
+          ModalRoute<void>? wrapperRoute;
+
           await tester.pumpWidget(
             MaterialApp(
               home: Scaffold(
                 body: Builder(
-                  builder: (context) => ElevatedButton(
-                    onPressed: () async {
-                      await VineBottomSheet.show<void>(
-                        context: context,
-                        scrollable: false,
-                        title: const Text('Wrapped Fixed'),
-                        children: const [Text('Fixed Body')],
-                        contentWrapper: (wrapperContext, child) =>
-                            _WrapperMarker(child: child),
-                      );
-                    },
-                    child: const Text('Open Fixed'),
-                  ),
+                  builder: (context) {
+                    callerRoute = ModalRoute.of(context);
+                    return ElevatedButton(
+                      onPressed: () async {
+                        await VineBottomSheet.show<void>(
+                          context: context,
+                          scrollable: false,
+                          title: const Text('Wrapped Fixed'),
+                          children: const [Text('Fixed Body')],
+                          contentWrapper: (wrapperContext, child) {
+                            wrapperRoute = ModalRoute.of<void>(wrapperContext);
+                            return _WrapperMarker(child: child);
+                          },
+                        );
+                      },
+                      child: const Text('Open Fixed'),
+                    );
+                  },
                 ),
               ),
             ),
@@ -1111,6 +1135,10 @@ void main() {
 
           expect(find.byType(_WrapperMarker), findsOneWidget);
           expect(find.text('Fixed Body'), findsOneWidget);
+          // Same route-identity contract as the scrollable path above.
+          expect(wrapperRoute, isA<ModalBottomSheetRoute<void>>());
+          expect(callerRoute, isNotNull);
+          expect(wrapperRoute, isNot(same(callerRoute)));
         },
       );
 

--- a/mobile/test/widgets/delete_account_dialog_test.dart
+++ b/mobile/test/widgets/delete_account_dialog_test.dart
@@ -174,6 +174,12 @@ Future<BuildContext> _pumpSignOutRedirectApp(
       ),
     ],
   );
+  // Ordered so the router drops its refreshListenable subscription before the
+  // notifier it listens to is torn down: addTearDown runs last-registered
+  // first. Without this the router outlives the test inside the merged VGV
+  // isolate, still listening.
+  addTearDown(redirect.dispose);
+  addTearDown(router.dispose);
   await tester.pumpWidget(
     MaterialApp.router(
       localizationsDelegates: AppLocalizations.localizationsDelegates,

--- a/mobile/test/widgets/delete_account_dialog_test.dart
+++ b/mobile/test/widgets/delete_account_dialog_test.dart
@@ -1043,6 +1043,66 @@ void main() {
       },
     );
 
+    testWidgets(
+      'keeps the caller screen when the sheet is closed by system back',
+      (tester) async {
+        final deletionService = _MockAccountDeletionService();
+        final authService = _MockAuthService();
+        when(
+          authService.checkAccountDeletionReadiness,
+        ).thenAnswer((_) async => AccountDeletionReadiness.ready);
+        final deletionGate = Completer<DeleteAccountResult>();
+        when(
+          () => deletionService.deleteAccount(
+            onProgress: any(named: 'onProgress'),
+            expectedPubkey: any(named: 'expectedPubkey'),
+          ),
+        ).thenAnswer((_) => deletionGate.future);
+
+        late BuildContext capturedContext;
+        await tester.pumpWidget(
+          _wrapWithRouter(
+            Builder(
+              builder: (context) {
+                capturedContext = context;
+                return const Scaffold(body: Text(_callerScreenMarker));
+              },
+            ),
+          ),
+        );
+
+        final deletion = executeAccountDeletion(
+          context: capturedContext,
+          deletionService: deletionService,
+          authService: authService,
+        );
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 400));
+        expect(find.byType(VineBottomSheet), findsOneWidget);
+
+        // Nothing stops an Android back press from closing the progress
+        // sheet: it carries no PopScope, and isDismissible/enableDrag only
+        // govern the barrier and the drag.
+        await tester.binding.handlePopRoute();
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 400));
+        expect(find.byType(VineBottomSheet), findsNothing);
+
+        deletionGate.complete(
+          DeleteAccountResult.failure(
+            DeleteAccountFailureReason.vanishNotConfirmed,
+          ),
+        );
+        await deletion;
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 400));
+
+        // The sheet is already gone, so there is nothing left to dismiss.
+        expect(find.text(_callerScreenMarker), findsOneWidget);
+        expect(tester.takeException(), isNull);
+      },
+    );
+
     testWidgets('opted-in burn aborts when recovery is unavailable', (
       tester,
     ) async {

--- a/mobile/test/widgets/delete_account_dialog_test.dart
+++ b/mobile/test/widgets/delete_account_dialog_test.dart
@@ -78,6 +78,10 @@ Widget _wrapWithRouter(Widget child) {
       ),
     ],
   );
+  // Same reason the sign-out redirect router is disposed below: an
+  // undisposed GoRouter keeps listening past the end of the test inside the
+  // merged VGV isolate. Most tests in this file go through this helper.
+  addTearDown(router.dispose);
   return MaterialApp.router(
     localizationsDelegates: AppLocalizations.localizationsDelegates,
     supportedLocales: AppLocalizations.supportedLocales,

--- a/mobile/test/widgets/delete_account_dialog_test.dart
+++ b/mobile/test/widgets/delete_account_dialog_test.dart
@@ -144,6 +144,7 @@ class _SignOutRedirectNotifier extends ChangeNotifier {
   }
 }
 
+const _callerScreenMarker = 'Caller screen';
 const _welcomeLocation = '/welcome';
 const _welcomeMarker = 'Welcome destination';
 
@@ -977,6 +978,66 @@ void main() {
         expect(find.text(_welcomeMarker), findsOneWidget);
         expect(
           find.text(_englishL10n().deleteAccountSuccess),
+          findsOneWidget,
+        );
+      },
+    );
+
+    testWidgets(
+      'takes down its own sheet and leaves the screen under it standing',
+      (tester) async {
+        final deletionService = _MockAccountDeletionService();
+        final authService = _MockAuthService();
+        when(
+          authService.checkAccountDeletionReadiness,
+        ).thenAnswer((_) async => AccountDeletionReadiness.ready);
+        // Held open so a frame can run while the sheet is up. Every other
+        // test here finishes the deletion inside one microtask turn, so the
+        // sheet is dismissed before it has ever built — and the dismissal
+        // never reaches the route it captured.
+        final deletionGate = Completer<DeleteAccountResult>();
+        when(
+          () => deletionService.deleteAccount(
+            onProgress: any(named: 'onProgress'),
+            expectedPubkey: any(named: 'expectedPubkey'),
+          ),
+        ).thenAnswer((_) => deletionGate.future);
+
+        late BuildContext capturedContext;
+        await tester.pumpWidget(
+          _wrapWithRouter(
+            Builder(
+              builder: (context) {
+                capturedContext = context;
+                return const Scaffold(body: Text(_callerScreenMarker));
+              },
+            ),
+          ),
+        );
+
+        final deletion = executeAccountDeletion(
+          context: capturedContext,
+          deletionService: deletionService,
+          authService: authService,
+        );
+        // Not pumpAndSettle: the sheet's progress indicator never goes quiet.
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 400));
+        expect(find.byType(VineBottomSheet), findsOneWidget);
+
+        deletionGate.complete(
+          DeleteAccountResult.failure(
+            DeleteAccountFailureReason.vanishNotConfirmed,
+          ),
+        );
+        await deletion;
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 400));
+
+        expect(find.byType(VineBottomSheet), findsNothing);
+        expect(find.text(_callerScreenMarker), findsOneWidget);
+        expect(
+          find.text(_englishL10n().deleteAccountRelayConfirmationFailed),
           findsOneWidget,
         );
       },

--- a/mobile/test/widgets/delete_account_dialog_test.dart
+++ b/mobile/test/widgets/delete_account_dialog_test.dart
@@ -132,6 +132,98 @@ Finder _deleteAllContentButton() => find.widgetWithText(
 Finder _deleteSheetCancelButton() =>
     find.widgetWithText(DivineButton, _englishL10n().commonCancel);
 
+/// Mirrors production's global auth redirect: once the account is signed out
+/// every route resolves to /welcome, so the route deletion was started from —
+/// and its context — is torn down while the flow is still running.
+class _SignOutRedirectNotifier extends ChangeNotifier {
+  bool signedOut = false;
+
+  void signOut() {
+    signedOut = true;
+    notifyListeners();
+  }
+}
+
+const _welcomeLocation = '/welcome';
+const _welcomeMarker = 'Welcome destination';
+
+Future<BuildContext> _pumpSignOutRedirectApp(
+  WidgetTester tester,
+  _SignOutRedirectNotifier redirect,
+) async {
+  late BuildContext capturedContext;
+  final router = GoRouter(
+    refreshListenable: redirect,
+    redirect: (_, state) =>
+        redirect.signedOut && state.matchedLocation != _welcomeLocation
+        ? _welcomeLocation
+        : null,
+    routes: [
+      GoRoute(
+        path: '/',
+        builder: (_, _) => Builder(
+          builder: (context) {
+            capturedContext = context;
+            return const Scaffold(body: SizedBox.shrink());
+          },
+        ),
+      ),
+      GoRoute(
+        path: _welcomeLocation,
+        builder: (_, _) => const Scaffold(body: Text(_welcomeMarker)),
+      ),
+    ],
+  );
+  await tester.pumpWidget(
+    MaterialApp.router(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      routerConfig: router,
+    ),
+  );
+  return capturedContext;
+}
+
+void _stubSuccessfulDeletion(
+  _MockAccountDeletionService deletionService,
+  _MockAuthService authService,
+) {
+  when(
+    authService.checkAccountDeletionReadiness,
+  ).thenAnswer((_) async => AccountDeletionReadiness.ready);
+  when(
+    () => deletionService.deleteAccount(
+      onProgress: any(named: 'onProgress'),
+      expectedPubkey: any(named: 'expectedPubkey'),
+    ),
+  ).thenAnswer((_) async => DeleteAccountResult.createSuccess('event-id'));
+  when(authService.deleteKeycastAccount).thenAnswer(
+    (_) async => (success: true, error: null, requiresReauthentication: false),
+  );
+}
+
+/// Collects what the deletion flow hands to screen readers.
+List<Object?> _captureAnnouncements(WidgetTester tester) {
+  final announced = <Object?>[];
+  tester.binding.defaultBinaryMessenger.setMockDecodedMessageHandler<Object?>(
+    SystemChannels.accessibility,
+    (message) async {
+      if (message is Map && message['type'] == 'announce') {
+        announced.add((message['data'] as Map?)?['message']);
+      }
+      return null;
+    },
+  );
+  addTearDown(
+    () => tester.binding.defaultBinaryMessenger
+        .setMockDecodedMessageHandler<Object?>(
+          SystemChannels.accessibility,
+          null,
+        ),
+  );
+  return announced;
+}
+
 Future<void> _tapBurnUsernameCheckbox(WidgetTester tester) async {
   final tile = find.byType(DivineRowCheckbox);
   await tester.ensureVisible(tile);
@@ -794,6 +886,95 @@ void main() {
       );
       expect(find.text(l10n.deleteAccountSuccess), findsNothing);
     });
+
+    testWidgets(
+      'confirms a successful deletion on the screen the redirect lands on',
+      (tester) async {
+        final deletionService = _MockAccountDeletionService();
+        final authService = _MockAuthService();
+        final redirect = _SignOutRedirectNotifier();
+        _stubSuccessfulDeletion(deletionService, authService);
+        // Holds sign-out open while the redirect runs, so the route deletion
+        // was started from is gone before signOut returns — the device
+        // timeline in #6450.
+        final signOutGate = Completer<void>();
+        when(
+          () =>
+              authService.signOut(deleteKeys: true, deleteLocalUserData: true),
+        ).thenAnswer((_) async {
+          redirect.signOut();
+          await signOutGate.future;
+        });
+        final announced = _captureAnnouncements(tester);
+
+        final capturedContext = await _pumpSignOutRedirectApp(tester, redirect);
+        final deletion = executeAccountDeletion(
+          context: capturedContext,
+          deletionService: deletionService,
+          authService: authService,
+        );
+        await tester.pumpAndSettle();
+        expect(find.text(_welcomeMarker), findsOneWidget);
+
+        signOutGate.complete();
+        await deletion;
+        await tester.pumpAndSettle();
+
+        final l10n = _englishL10n();
+        expect(find.text(l10n.deleteAccountSuccess), findsOneWidget);
+        expect(announced, contains(l10n.deleteAccountSuccess));
+      },
+    );
+
+    testWidgets(
+      'leaves the redirect destination standing when the sheet is already gone',
+      (tester) async {
+        final deletionService = _MockAccountDeletionService();
+        final authService = _MockAuthService();
+        final redirect = _SignOutRedirectNotifier();
+        _stubSuccessfulDeletion(deletionService, authService);
+        final signOutGate = Completer<void>();
+        when(
+          () =>
+              authService.signOut(deleteKeys: true, deleteLocalUserData: true),
+        ).thenAnswer((_) async {
+          redirect.signOut();
+          await signOutGate.future;
+        });
+
+        final capturedContext = await _pumpSignOutRedirectApp(tester, redirect);
+        final deletion = executeAccountDeletion(
+          context: capturedContext,
+          deletionService: deletionService,
+          authService: authService,
+        );
+        // Stop one frame past the redirect, with the outgoing route still
+        // animating away: the caller context is then still mounted when
+        // sign-out returns, which is what a device reaches whenever the
+        // sign-out work blocks frames. Dismissing the progress sheet by
+        // popping the navigator took the freshly installed /welcome page
+        // with it, leaving the app with no page at all.
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 16));
+        expect(
+          capturedContext.mounted,
+          isTrue,
+          reason:
+              'the scenario needs the caller still mounted after the '
+              'redirect',
+        );
+
+        signOutGate.complete();
+        await deletion;
+        await tester.pumpAndSettle();
+
+        expect(find.text(_welcomeMarker), findsOneWidget);
+        expect(
+          find.text(_englishL10n().deleteAccountSuccess),
+          findsOneWidget,
+        );
+      },
+    );
 
     testWidgets('opted-in burn aborts when recovery is unavailable', (
       tester,


### PR DESCRIPTION
## Description

A **successful** account deletion left the user with no confirmation at all, and filed an error on every run.

Signing out at the end of the flow flips auth state to `unauthenticated`, so the global redirect replaces the whole stack with `/welcome` and tears down the route the deletion was started from. Everything after `await signOut(...)` still went through that route's `context`, which failed two different ways depending on whether the outgoing route had finished animating out by then:

- **Context already unmounted** — `dismissProgressSheet()` and the success snackbar are both behind `if (context.mounted)`, so the completed deletion was reported nowhere: no snackbar, no screen-reader announcement.
- **Context still mounted** (what a device reaches, because the sign-out work blocks frames) — the progress sheet had already been removed together with the route it was pushed over, so `Navigator.of(context, rootNavigator: true).pop()` removed the `/welcome` page the redirect had just installed: `You have popped the last page off of the stack, there are no pages left to show`. That is the same root cause as the `GoError: There is nothing to pop` in the issue, made worse rather than fixed by the switch from `context.pop()` to a root-navigator pop.

Both were reproduced as widget tests before changing anything, driving the real `GoRouter` redirect from a `refreshListenable` and holding `signOut` open with a completer while it runs — the device timeline from the issue.

### The fix

**Report the outcome through objects that outlive the redirect.** `ScaffoldMessenger`, `FlutterView` and `Directionality` are captured before the deletion starts. The messenger sits above the `Navigator`, so the confirmation lands on `/welcome` instead of vanishing with the caller, and the `context.mounted` gate on the success path is gone. The two success strings are now localized up front like the rest of the flow's copy already was. Reporting *before* `signOut` was the other option in the issue and is not usable here: `signOut` is what produces `keyDeletionWarning` / `localDataDeletionFailure`, which decide the message.

**Dismiss the progress sheet by identity, not by popping whatever is on top.** The sheet's own `ModalRoute` is captured from the sheet's context, and dismissal pops only while that route `isCurrent`, uses `removeRoute` while it is active but covered, and does nothing once the redirect has already taken it down. Before its first build there is no route to target yet — but no frame has run since the push either, so nothing can have moved it and the plain pop stays correct; that is the path the early-abort branches take.

`announceOutcome` now speaks through the captured view, so it can no longer be silently skipped either. It stays paired with a snackbar at every call site.

**Related Issue:** Closes #6450

## Review Follow-ups

A self-review over the fix above turned up five things, each pushed as its own commit.

**The contract the dismissal rests on was unpinned.** Dismissing by identity reads the sheet's route out of `contentWrapper` via `ModalRoute.of(sheetContext)`, which is only correct because `VineBottomSheet` applies the wrapper *inside* the modal route. The divine_ui test named for that ("contentWrapper is applied around the sheet inside the modal route") asserted only that the wrapper wraps the sheet body — which stays true either way. Mutating `VineBottomSheet.show` to pass the caller's context instead kept that test green *and* kept all 52 delete-account tests green, while turning `removeRoute(progressSheetRoute)` into a call that removes the page the user was on. Both contentWrapper tests now assert the route identity, and both fail under that mutation.

**The null-route fallback could still pop a foreign route.** `dismissProgressSheet` falls back to a blind `rootNavigator.pop()` while `progressSheetRoute` is null, justified by "no frame has run since the push". That holds for the synchronous abort path, but the same branch is reached when the sheet never made it onto the navigator (an assertion inside `VineBottomSheet.show`) or left again before its first build — and the blind pop then removes whatever is on top, which is the #6450 failure itself. The sheet's own future now reports that case, so "not shown yet" is distinguishable from "already gone" without a frame-timing argument.

**A shadowed `messenger`.** The content-deletion failure branch declared its own `messenger` local over the one captured before the deletion starts. Nothing in `lib` nests a `ScaffoldMessenger`, so both names referred to the same instance — removed the redundant lookup.

**A leaked cubit.** `AccountDeletionProgressCubit()` was constructed one line above the `context.mounted` gate, and only the `finally` closes one, so returning at that gate left it open. Constructed after the gate now. Pre-existing, not introduced by this PR.

**Leaked test router.** `_pumpSignOutRedirectApp` disposed neither the `GoRouter` nor the notifier it refreshes from, so the router kept listening past the end of the test inside the merged VGV isolate.

## Out of Scope

The failure branches keep their `context.mounted` gates. None of them crosses a sign-out, so the calling route is still standing when they report — and they legitimately need a live context for `context.l10n` reads and the support-center `context.push`.

## Verification

- Two regression tests added in `delete_account_dialog_test.dart`, both verified to fail against the unfixed code with exactly the two symptoms above: `confirms a successful deletion on the screen the redirect lands on` (asserts the snackbar, the screen-reader announcement, and that nothing throws) and `leaves the redirect destination standing when the sheet is already gone` (pins the mid-transition case).
- Both contentWrapper route-identity assertions verified to fail against a `VineBottomSheet` mutated to apply the wrapper outside the modal route — the regression they exist to catch, which nothing else in the repo catches.
- `flutter test test/widgets/delete_account_dialog_test.dart` — 52 passed.
- Wider affected scope green: delete-account widgets, `account_deletion_*` services, settings screens, `pause_aware_modals` — 277 passed, 2 skipped.
- `mobile/packages/divine_ui` — 969 passed; line coverage unchanged (the change is test-only).
- `flutter analyze lib test integration_test` — no issues, and `flutter analyze lib test` inside `packages/divine_ui`, which the app-level analyze does not cover. `dart format` clean.
- 20 ratchets checked locally, including `unsafe_back_pop`, `l10n_delegates`, `raw_dialog`, `process_global_mutations`, `shared_channel_overrides`, `layer_direction`, `package_flutter_boundary`, `post_close_emit` — all green.
- **Device verification on a real Samsung Galaxy is still outstanding** — that is why this is a draft.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

