### PR TITLE
fix(video): close the loop seam on both platforms

### DIFF
--- a/mobile/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/mobile/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/app-check.git",
       "state" : {
-        "revision" : "61b85103a1aeed8218f17c794687781505fbbef5",
-        "version" : "11.2.0"
+        "revision" : "3e33dd27dd4c69bd81c7c81fe61d8ccf58846902",
+        "version" : "11.3.1"
       }
     },
     {
@@ -113,8 +113,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleUtilities.git",
       "state" : {
-        "revision" : "60da361632d0de02786f709bdc0c4df340f7613e",
-        "version" : "8.1.0"
+        "revision" : "9f183ae842be978784f2963a343682e0c46d8fb3",
+        "version" : "8.1.2"
       }
     },
     {
@@ -158,8 +158,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/nanopb.git",
       "state" : {
-        "revision" : "b7e1104502eca3a213b46303391ca4d3bc8ddec1",
-        "version" : "2.30910.0"
+        "revision" : "3851d94a41890dea16dc3db34caf60e585cb4163",
+        "version" : "2.30910.1"
       }
     },
     {

--- a/mobile/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/mobile/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/app-check.git",
       "state" : {
-        "revision" : "3e33dd27dd4c69bd81c7c81fe61d8ccf58846902",
-        "version" : "11.3.1"
+        "revision" : "61b85103a1aeed8218f17c794687781505fbbef5",
+        "version" : "11.2.0"
       }
     },
     {
@@ -113,8 +113,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleUtilities.git",
       "state" : {
-        "revision" : "9f183ae842be978784f2963a343682e0c46d8fb3",
-        "version" : "8.1.2"
+        "revision" : "60da361632d0de02786f709bdc0c4df340f7613e",
+        "version" : "8.1.0"
       }
     },
     {
@@ -158,8 +158,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/nanopb.git",
       "state" : {
-        "revision" : "3851d94a41890dea16dc3db34caf60e585cb4163",
-        "version" : "2.30910.1"
+        "revision" : "b7e1104502eca3a213b46303391ca4d3bc8ddec1",
+        "version" : "2.30910.0"
       }
     },
     {

--- a/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/ClipAudioLoopTrack.kt
+++ b/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/ClipAudioLoopTrack.kt
@@ -1,0 +1,324 @@
+package com.divinevideo.divine_video_player
+
+import android.media.AudioAttributes
+import android.media.AudioFormat
+import android.media.AudioTrack
+import android.media.MediaCodec
+import android.media.MediaExtractor
+import android.media.MediaFormat
+import java.io.ByteArrayOutputStream
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+/**
+ * Plays a looping clip's audio outside ExoPlayer, through a static
+ * [AudioTrack] that repeats sample-exact in the audio HAL.
+ *
+ * While the media item carries an audio track, media3 drains and re-anchors
+ * its audio sink at every loop discontinuity, on the same thread that releases
+ * video frames. Measured on an SM-S942B: the same clip with its audio track
+ * stripped loops cleanly, with it the seam is plainly visible. Taking the audio
+ * out of the player and looping it here keeps the sound without paying that.
+ *
+ * Two details decide whether this holds up, both learned the hard way:
+ *
+ *  * The PCM has to be exactly as long as the **video's** loop, not as long as
+ *    whatever end the caller asked for. The feed passes its maximum playback
+ *    duration, which is far past the clip; cutting to that leaves nothing to
+ *    blend with and drifts the two clocks apart every lap.
+ *  * The seam is closed with the material that lies *past* the loop point
+ *    rather than by fading both ends to silence. Fading kills the click but
+ *    leaves an audible restart; blending makes the last sample of the loop and
+ *    its first two consecutive samples of the recording.
+ *
+ * The remaining cost is that video and audio now run on two clocks. They start
+ * together and share a period to the sample, but nothing locks them.
+ */
+internal class ClipAudioLoopTrack private constructor(
+    private val track: AudioTrack,
+    private val sampleRate: Int,
+    private val frameCount: Int,
+) {
+
+    private var released = false
+
+    /**
+     * Starts or resumes the loop at [positionMs] of the clip.
+     *
+     * A static track can only be repositioned while it is not playing, so the
+     * head moves first and playback starts after.
+     */
+    fun play(positionMs: Long, volume: Float) {
+        if (released) return
+        runCatching {
+            track.setVolume(volume)
+            if (track.playState != AudioTrack.PLAYSTATE_PLAYING) {
+                if (frameCount > 0) {
+                    val frame = ((positionMs * sampleRate) / 1000L).toInt()
+                    track.setPlaybackHeadPosition(frame % frameCount)
+                }
+                track.play()
+            }
+        }
+    }
+
+    fun pause() {
+        if (released) return
+        runCatching { track.pause() }
+    }
+
+    fun setVolume(volume: Float) {
+        if (released) return
+        runCatching { track.setVolume(volume) }
+    }
+
+    fun release() {
+        if (released) return
+        released = true
+        runCatching {
+            track.pause()
+            track.flush()
+            track.release()
+        }
+    }
+
+    companion object {
+
+        /** A feed clip is seconds long; this only bounds a pathological file. */
+        private const val MAX_PCM_BYTES = 16 * 1024 * 1024
+
+        private const val DEQUEUE_TIMEOUT_US = 10_000L
+
+        /** Blend length at the seam, taken from beyond the loop point. */
+        private const val CROSSFADE_MS = 100L
+
+        /** Fallback when nothing lies beyond it: enough to kill the click. */
+        private const val RAMP_MS = 5L
+
+        /**
+         * Decodes [uri]'s audio to 16-bit PCM, cut to [loopMs] and blended at
+         * the seam, and wraps it in a looping [AudioTrack].
+         *
+         * [loopMs] must be the duration the player presents, not the media
+         * duration of any track.
+         *
+         * Returns null when there is nothing to play or anything goes wrong;
+         * the caller then leaves the audio with ExoPlayer. Blocks on I/O and on
+         * the decoder, so it must not run on the platform thread.
+         */
+        fun create(
+            uri: String,
+            headers: Map<String, String>,
+            loopMs: Long,
+        ): ClipAudioLoopTrack? {
+            val extractor = MediaExtractor()
+            var codec: MediaCodec? = null
+            try {
+                when {
+                    uri.startsWith("http://") || uri.startsWith("https://") ->
+                        extractor.setDataSource(uri, headers)
+                    uri.startsWith("file://") ->
+                        extractor.setDataSource(uri.removePrefix("file://"))
+                    else -> extractor.setDataSource(uri)
+                }
+
+                var audioIndex = -1
+                for (index in 0 until extractor.trackCount) {
+                    val format = extractor.getTrackFormat(index)
+                    val mime = format.getString(MediaFormat.KEY_MIME) ?: continue
+                    if (mime.startsWith("audio/") && audioIndex < 0) audioIndex = index
+                }
+                if (audioIndex < 0 || loopMs <= 0) return null
+
+                val inputFormat = extractor.getTrackFormat(audioIndex)
+                val mime = inputFormat.getString(MediaFormat.KEY_MIME) ?: return null
+                extractor.selectTrack(audioIndex)
+                // The decoder applies the container's gapless trimming and
+                // hands back exactly the presented length, which leaves nothing
+                // past the loop point to blend with. Dropping those keys is the
+                // equivalent of ffmpeg's -ignore_editlist, which is how the
+                // prototype gets the material for its crossfade.
+                inputFormat.setInteger(MediaFormat.KEY_ENCODER_DELAY, 0)
+                inputFormat.setInteger(MediaFormat.KEY_ENCODER_PADDING, 0)
+                codec = MediaCodec.createDecoderByType(mime).apply {
+                    configure(inputFormat, null, null, 0)
+                    start()
+                }
+
+                val pcm = ByteArrayOutputStream()
+                var sampleRate = inputFormat.getInteger(MediaFormat.KEY_SAMPLE_RATE)
+                var channels = inputFormat.getInteger(MediaFormat.KEY_CHANNEL_COUNT)
+                val info = MediaCodec.BufferInfo()
+                var sawInputEnd = false
+                var sawOutputEnd = false
+
+                while (!sawOutputEnd && pcm.size() < MAX_PCM_BYTES) {
+                    if (!sawInputEnd) {
+                        val inputIndex = codec.dequeueInputBuffer(DEQUEUE_TIMEOUT_US)
+                        if (inputIndex >= 0) {
+                            val buffer = codec.getInputBuffer(inputIndex)!!
+                            val size = extractor.readSampleData(buffer, 0)
+                            if (size < 0) {
+                                codec.queueInputBuffer(
+                                    inputIndex, 0, 0, 0,
+                                    MediaCodec.BUFFER_FLAG_END_OF_STREAM,
+                                )
+                                sawInputEnd = true
+                            } else {
+                                codec.queueInputBuffer(
+                                    inputIndex, 0, size, extractor.sampleTime, 0,
+                                )
+                                extractor.advance()
+                            }
+                        }
+                    }
+                    when (val out = codec.dequeueOutputBuffer(info, DEQUEUE_TIMEOUT_US)) {
+                        MediaCodec.INFO_OUTPUT_FORMAT_CHANGED -> {
+                            val outputFormat = codec.outputFormat
+                            sampleRate = outputFormat.getInteger(MediaFormat.KEY_SAMPLE_RATE)
+                            channels = outputFormat.getInteger(MediaFormat.KEY_CHANNEL_COUNT)
+                        }
+                        MediaCodec.INFO_TRY_AGAIN_LATER -> Unit
+                        else -> if (out >= 0) {
+                            val buffer = codec.getOutputBuffer(out)!!
+                            if (info.size > 0) {
+                                val chunk = ByteArray(info.size)
+                                buffer.position(info.offset)
+                                buffer.get(chunk)
+                                pcm.write(chunk)
+                            }
+                            codec.releaseOutputBuffer(out, false)
+                            if (info.flags and MediaCodec.BUFFER_FLAG_END_OF_STREAM != 0) {
+                                sawOutputEnd = true
+                            }
+                        }
+                    }
+                }
+
+                val raw = pcm.toByteArray()
+                if (raw.isEmpty() || sampleRate <= 0 || channels <= 0) return null
+
+                val samples = ShortArray(raw.size / 2)
+                ByteBuffer.wrap(raw).order(ByteOrder.LITTLE_ENDIAN)
+                    .asShortBuffer().get(samples)
+                val decodedFrames = samples.size / channels
+
+                // [loopMs] is the length the player presents, which is what the
+                // picture loops on. The extractor's track duration is the media
+                // length and ignores the edit list -- for a clip whose edit list
+                // was corrected those differ, and looping on the media length
+                // walks the sound away from the picture every lap.
+                val loopFrames = minOf(
+                    (loopMs * sampleRate / 1000L).toInt(),
+                    decodedFrames,
+                )
+                if (loopFrames <= 0) return null
+
+                // Blend the seam shut. The prototype takes the material that
+                // lies past the loop point, which is the better source: the
+                // wrap then lands on two consecutive samples of the recording.
+                // Android's decoder applies the container's gapless trimming
+                // and hands back exactly the presented length, so there usually
+                // is none -- measured as "0 frames spare" on every fixture. The
+                // loop's own tail is then blended into its head instead, which
+                // is not the same material but closes the same step.
+                // Blend the seam shut with the material that lies past the
+                // loop point: the wrap then lands on two consecutive samples of
+                // the recording, which is what makes the prototype's loop sound
+                // closed rather than restarted.
+                //
+                // Folding the loop's own tail into its head instead was tried
+                // and is worse than doing nothing: the tail has to fade out or
+                // it is heard twice, so the seam becomes a dip to near-silence
+                // followed by material that jumps back. Without spare material
+                // the only honest option is a short ramp, which kills the click
+                // and leaves the restart audible.
+                val spare = decodedFrames - loopFrames
+                val fadeFrames = minOf(
+                    (CROSSFADE_MS * sampleRate / 1000L).toInt(),
+                    spare,
+                )
+                for (i in 0 until fadeFrames) {
+                    val a = i.toFloat() / fadeFrames
+                    for (channel in 0 until channels) {
+                        val head = samples[i * channels + channel].toFloat()
+                        val past = samples[(loopFrames + i) * channels + channel]
+                            .toFloat()
+                        samples[i * channels + channel] =
+                            (past * (1f - a) + head * a)
+                                .coerceIn(-32768f, 32767f).toInt().toShort()
+                    }
+                }
+                if (fadeFrames == 0) {
+                    val rampFrames = minOf(
+                        (RAMP_MS * sampleRate / 1000L).toInt(),
+                        loopFrames / 8,
+                    )
+                    for (i in 0 until rampFrames) {
+                        val gain = i.toFloat() / rampFrames
+                        for (channel in 0 until channels) {
+                            val head = i * channels + channel
+                            val tail = (loopFrames - 1 - i) * channels + channel
+                            samples[head] = (samples[head] * gain).toInt().toShort()
+                            samples[tail] = (samples[tail] * gain).toInt().toShort()
+                        }
+                    }
+                }
+
+                val bytes = ByteArray(loopFrames * channels * 2)
+                ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN)
+                    .asShortBuffer().put(samples, 0, loopFrames * channels)
+
+                val track = AudioTrack.Builder()
+                    .setAudioAttributes(
+                        AudioAttributes.Builder()
+                            .setUsage(AudioAttributes.USAGE_MEDIA)
+                            .setContentType(AudioAttributes.CONTENT_TYPE_MOVIE)
+                            .build(),
+                    )
+                    .setAudioFormat(
+                        AudioFormat.Builder()
+                            .setEncoding(AudioFormat.ENCODING_PCM_16BIT)
+                            .setSampleRate(sampleRate)
+                            .setChannelMask(
+                                if (channels >= 2) {
+                                    AudioFormat.CHANNEL_OUT_STEREO
+                                } else {
+                                    AudioFormat.CHANNEL_OUT_MONO
+                                },
+                            )
+                            .build(),
+                    )
+                    .setBufferSizeInBytes(bytes.size)
+                    .setTransferMode(AudioTrack.MODE_STATIC)
+                    .build()
+
+                if (track.write(bytes, 0, bytes.size) < bytes.size) {
+                    track.release()
+                    return null
+                }
+                // -1 repeats forever. Loop points count frames, not bytes.
+                track.setLoopPoints(0, loopFrames, -1)
+
+                DivineVideoPlayerLog.debug(
+                    "Looping clip audio outside ExoPlayer: ${loopFrames} frames " +
+                        "at ${sampleRate}Hz, ${fadeFrames} frame crossfade " +
+                        "(${if (fadeFrames > 0) "crossfade" else "ramp only"}), " +
+                        "${spare} frames spare",
+                    name = "DivineVideoPlayer.AudioLoop",
+                )
+                return ClipAudioLoopTrack(track, sampleRate, loopFrames)
+            } catch (e: Exception) {
+                DivineVideoPlayerLog.warning(
+                    "Could not build looping audio for $uri: $e",
+                    name = "DivineVideoPlayer.AudioLoop",
+                )
+                return null
+            } finally {
+                runCatching { codec?.stop() }
+                runCatching { codec?.release() }
+                runCatching { extractor.release() }
+            }
+        }
+    }
+}

--- a/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/ClipAudioLoopTrack.kt
+++ b/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/ClipAudioLoopTrack.kt
@@ -203,71 +203,19 @@ internal class ClipAudioLoopTrack private constructor(
                     .asShortBuffer().get(samples)
                 val decodedFrames = samples.size / channels
 
-                // [loopMs] is the length the player presents, which is what the
-                // picture loops on. The extractor's track duration is the media
-                // length and ignores the edit list -- for a clip whose edit list
-                // was corrected those differ, and looping on the media length
-                // walks the sound away from the picture every lap.
-                val loopFrames = minOf(
-                    (loopMs * sampleRate / 1000L).toInt(),
-                    decodedFrames,
-                )
-                if (loopFrames <= 0) return null
-
-                // Blend the seam shut. The prototype takes the material that
-                // lies past the loop point, which is the better source: the
-                // wrap then lands on two consecutive samples of the recording.
-                // Android's decoder applies the container's gapless trimming
-                // and hands back exactly the presented length, so there usually
-                // is none -- measured as "0 frames spare" on every fixture. The
-                // loop's own tail is then blended into its head instead, which
-                // is not the same material but closes the same step.
-                // Blend the seam shut with the material that lies past the
-                // loop point: the wrap then lands on two consecutive samples of
-                // the recording, which is what makes the prototype's loop sound
-                // closed rather than restarted.
-                //
-                // Folding the loop's own tail into its head instead was tried
-                // and is worse than doing nothing: the tail has to fade out or
-                // it is heard twice, so the seam becomes a dip to near-silence
-                // followed by material that jumps back. Without spare material
-                // the only honest option is a short ramp, which kills the click
-                // and leaves the restart audible.
-                val spare = decodedFrames - loopFrames
-                val fadeFrames = minOf(
-                    (CROSSFADE_MS * sampleRate / 1000L).toInt(),
-                    spare,
-                )
-                for (i in 0 until fadeFrames) {
-                    val a = i.toFloat() / fadeFrames
-                    for (channel in 0 until channels) {
-                        val head = samples[i * channels + channel].toFloat()
-                        val past = samples[(loopFrames + i) * channels + channel]
-                            .toFloat()
-                        samples[i * channels + channel] =
-                            (past * (1f - a) + head * a)
-                                .coerceIn(-32768f, 32767f).toInt().toShort()
-                    }
-                }
-                if (fadeFrames == 0) {
-                    val rampFrames = minOf(
-                        (RAMP_MS * sampleRate / 1000L).toInt(),
-                        loopFrames / 8,
-                    )
-                    for (i in 0 until rampFrames) {
-                        val gain = i.toFloat() / rampFrames
-                        for (channel in 0 until channels) {
-                            val head = i * channels + channel
-                            val tail = (loopFrames - 1 - i) * channels + channel
-                            samples[head] = (samples[head] * gain).toInt().toShort()
-                            samples[tail] = (samples[tail] * gain).toInt().toShort()
-                        }
-                    }
-                }
+                val prepared = LoopPcm.prepare(
+                    samples = samples,
+                    channels = channels,
+                    sampleRate = sampleRate,
+                    loopMs = loopMs,
+                ) ?: return null
+                val loopFrames = prepared.loopFrames
+                val fadeFrames = prepared.fadeFrames
+                val fromPast = prepared.blendedFromPastTheLoop
 
                 val bytes = ByteArray(loopFrames * channels * 2)
                 ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN)
-                    .asShortBuffer().put(samples, 0, loopFrames * channels)
+                    .asShortBuffer().put(prepared.samples, 0, loopFrames * channels)
 
                 val track = AudioTrack.Builder()
                     .setAudioAttributes(
@@ -302,9 +250,8 @@ internal class ClipAudioLoopTrack private constructor(
 
                 DivineVideoPlayerLog.debug(
                     "Looping clip audio outside ExoPlayer: ${loopFrames} frames " +
-                        "at ${sampleRate}Hz, ${fadeFrames} frame crossfade " +
-                        "(${if (fadeFrames > 0) "crossfade" else "ramp only"}), " +
-                        "${spare} frames spare",
+                        "at ${sampleRate}Hz, ${fadeFrames} frame " +
+                        "${if (fromPast) "crossfade" else "ramp"}",
                     name = "DivineVideoPlayer.AudioLoop",
                 )
                 return ClipAudioLoopTrack(track, sampleRate, loopFrames)

--- a/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/ClipAudioLoopTrack.kt
+++ b/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/ClipAudioLoopTrack.kt
@@ -53,13 +53,35 @@ internal class ClipAudioLoopTrack private constructor(
         runCatching {
             track.setVolume(volume)
             if (track.playState != AudioTrack.PLAYSTATE_PLAYING) {
-                if (frameCount > 0) {
-                    val frame = ((positionMs * sampleRate) / 1000L).toInt()
-                    track.setPlaybackHeadPosition(frame % frameCount)
-                }
+                moveHead(positionMs)
                 track.play()
             }
         }
+    }
+
+    /**
+     * Moves the loop to [positionMs] of the clip.
+     *
+     * The player's own seek only moves the picture; without this the sound
+     * keeps running from wherever it had got to and the two stay apart for the
+     * rest of the visit. A static track can only be repositioned while it is
+     * not playing, so a running loop is paused across the move.
+     */
+    fun seekTo(positionMs: Long) {
+        if (released) return
+        runCatching {
+            val wasPlaying = track.playState == AudioTrack.PLAYSTATE_PLAYING
+            if (wasPlaying) track.pause()
+            moveHead(positionMs)
+            if (wasPlaying) track.play()
+        }
+    }
+
+    /** Puts the playback head at [positionMs], wrapped into the loop. */
+    private fun moveHead(positionMs: Long) {
+        if (frameCount <= 0) return
+        val frame = ((positionMs * sampleRate) / 1000L).toInt()
+        track.setPlaybackHeadPosition(frame.mod(frameCount))
     }
 
     fun pause() {
@@ -88,12 +110,6 @@ internal class ClipAudioLoopTrack private constructor(
         private const val MAX_PCM_BYTES = 16 * 1024 * 1024
 
         private const val DEQUEUE_TIMEOUT_US = 10_000L
-
-        /** Blend length at the seam, taken from beyond the loop point. */
-        private const val CROSSFADE_MS = 100L
-
-        /** Fallback when nothing lies beyond it: enough to kill the click. */
-        private const val RAMP_MS = 5L
 
         /**
          * Decodes [uri]'s audio to 16-bit PCM, cut to [loopMs] and blended at
@@ -196,12 +212,14 @@ internal class ClipAudioLoopTrack private constructor(
                 }
 
                 val raw = pcm.toByteArray()
-                if (raw.isEmpty() || sampleRate <= 0 || channels <= 0) return null
+                // A wider decode would be written to a stereo track as it
+                // stands and played as interleaved nonsense, so it stays with
+                // ExoPlayer.
+                if (raw.isEmpty() || sampleRate <= 0 || channels !in 1..2) return null
 
                 val samples = ShortArray(raw.size / 2)
                 ByteBuffer.wrap(raw).order(ByteOrder.LITTLE_ENDIAN)
                     .asShortBuffer().get(samples)
-                val decodedFrames = samples.size / channels
 
                 val prepared = LoopPcm.prepare(
                     samples = samples,
@@ -229,7 +247,7 @@ internal class ClipAudioLoopTrack private constructor(
                             .setEncoding(AudioFormat.ENCODING_PCM_16BIT)
                             .setSampleRate(sampleRate)
                             .setChannelMask(
-                                if (channels >= 2) {
+                                if (channels == 2) {
                                     AudioFormat.CHANNEL_OUT_STEREO
                                 } else {
                                     AudioFormat.CHANNEL_OUT_MONO

--- a/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
+++ b/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
@@ -635,8 +635,8 @@ internal class DivineVideoPlayerInstance(
      * player has looped.
      *
      * Runs from [Player.Listener.onPositionDiscontinuity] on an automatic
-     * transition, which for the feed's single-clip `REPEAT_MODE_ALL` player is
-     * the loop restart itself.
+     * transition, which for the feed's single repeating clip is the loop
+     * restart itself.
      */
     private fun applyPendingCommonTrackEndClamp() {
         val pending = pendingCommonTrackEndClamp ?: return
@@ -760,13 +760,6 @@ internal class DivineVideoPlayerInstance(
                 null
             }
             val effectiveEndMs = listOfNotNull(endMs, commonEndMs).minOrNull()
-            if (trimToCommonTrackEnd) {
-                DivineVideoPlayerLog.debug(
-                    "Player $playerId clip end requested=${endMs}ms " +
-                        "common=${commonEndMs}ms effective=${effectiveEndMs}ms for $uri",
-                    name = "DivineVideoPlayer.Load",
-                )
-            }
             val clipVol = (map["volume"] as? Number)?.toFloat() ?: 1.0f
             val clipSpeed = ((map["playbackSpeed"] as? Number)?.toFloat() ?: 1.0f)
                 .coerceAtLeast(MIN_PLAYBACK_SPEED)
@@ -823,6 +816,12 @@ internal class DivineVideoPlayerInstance(
             }
         }
 
+        lastClipsRaw = clipsRaw
+        // The repeat mode depends on how many clips are loaded, so a clip list
+        // that arrives without a following `setLooping` has to reapply it here.
+        applyRepeatMode()
+        startClipAudioLoop(clipsRaw, clipCount, awaitTimeline = true)
+
         // Fade the video's edges only when the whole video is one clip, which
         // is what the feed loops. On a multi-clip timeline a stream is one clip
         // rather than the whole video, so fading every stream would notch the
@@ -830,8 +829,6 @@ internal class DivineVideoPlayerInstance(
         //
         // Published before the playlist swap below, because that swap disables
         // the audio renderer and flushes the pipeline on the playback thread.
-        lastClipsRaw = clipsRaw
-        startClipAudioLoop(clipsRaw, clipCount)
         declickProcessor.enabled = clipCount == 1
         declickProcessor.videoDurationUs = LoopDeclickAudioProcessor.DURATION_UNKNOWN
         declickProcessor.nextStreamStartUs = startLocalMs * 1000L
@@ -883,9 +880,9 @@ internal class DivineVideoPlayerInstance(
      *
      * A clipping configuration is not free: media3 wraps the source in a
      * `ClippingMediaSource`, and a looping player then repeats the wrapper
-     * rather than the source. The Apple side had the same shape -- every clip
+     * rather than the source. The Apple side had the same shape — every clip
      * was copied into an `AVMutableComposition` even when there was nothing to
-     * compose -- and there it cost the loop seam; playing the asset itself
+     * compose — and there it cost the loop seam; playing the asset itself
      * closed it.
      *
      * The feed always passes an end (its maximum playback duration), so
@@ -1028,11 +1025,6 @@ internal class DivineVideoPlayerInstance(
             if (videoUs <= 0 || audioUs <= 0) {
                 NO_TRACK_PAIR
             } else {
-                DivineVideoPlayerLog.debug(
-                    "Player $playerId read track ends video=${videoUs / 1000}ms " +
-                        "audio=${audioUs / 1000}ms for $uri",
-                    name = "DivineVideoPlayer.Load",
-                )
                 longArrayOf(videoUs, audioUs)
             }
         } catch (e: Exception) {
@@ -1089,32 +1081,43 @@ internal class DivineVideoPlayerInstance(
      * [ClipAudioLoopTrack].
      *
      * Only for the case that has the seam: one clip, repeating. Multi-clip
-     * timelines keep the player's audio -- there is no repeat of the same media
-     * period there, so nothing to avoid.
+     * timelines keep the player's audio — there is no repeat of the same
+     * media period there, so nothing to avoid.
      *
      * Decoding blocks, so it runs on [metadataExecutor]; the picture is already
      * playing by the time the sound joins, which is the right way round.
+     *
+     * [awaitTimeline] is for a caller that still has its playlist swap ahead of
+     * it. The player's duration describes whatever is loaded *now*, so on a
+     * reused player that is the outgoing video, and cutting the loop to it
+     * would play the new video's sound at the previous one's length.
      */
-    private fun startClipAudioLoop(clipsRaw: List<Map<String, Any?>>, clipCount: Int) {
+    private fun startClipAudioLoop(
+        clipsRaw: List<Map<String, Any?>>,
+        clipCount: Int,
+        awaitTimeline: Boolean = false,
+    ) {
         releaseClipAudioLoop()
         val generation = ++clipAudioGeneration
         if (clipCount != 1 || !isLooping) return
         val map = clipsRaw.firstOrNull() ?: return
         val uri = map["uri"] as? String ?: return
-        if ((map["startMs"] as? Number)?.toLong() ?: 0L != 0L) return
+        if (((map["startMs"] as? Number)?.toLong() ?: 0L) != 0L) return
+        // A static track plays the recording at its own rate and has no
+        // stretcher to follow a speed change with, so an off-speed player keeps
+        // ExoPlayer's audio rather than drifting away from its own picture.
+        if (speed != 1.0) return
+        if (((map["playbackSpeed"] as? Number)?.toFloat() ?: 1.0f) != 1.0f) return
         val headers = httpHeadersOf(map)
 
         // The renderer must not see the audio at all, or it pays the sink
         // rebuild at the seam regardless of who is making the sound.
         val exoPlayer = ensurePlayer()
-        exoPlayer.trackSelectionParameters = exoPlayer.trackSelectionParameters
-            .buildUpon()
-            .setTrackTypeDisabled(C.TRACK_TYPE_AUDIO, true)
-            .build()
+        setExoPlayerAudioEnabled(false)
 
         // The presented length is only known once the timeline is populated;
         // [onPlaybackStateChanged] calls back in when it is.
-        val loopMs = exoPlayer.duration
+        val loopMs = if (awaitTimeline) C.TIME_UNSET else exoPlayer.duration
         if (loopMs == C.TIME_UNSET || loopMs <= 0) {
             clipAudioPending = true
             return
@@ -1126,8 +1129,15 @@ internal class DivineVideoPlayerInstance(
             metadataExecutor.execute {
                 val loop = ClipAudioLoopTrack.create(uri, headers, loopMs)
                 mainHandler.post {
-                    if (generation != clipAudioGeneration || loop == null) {
+                    if (generation != clipAudioGeneration) {
                         loop?.release()
+                        return@post
+                    }
+                    if (loop == null) {
+                        // Nothing decoded — a clip with no audio, an
+                        // unreachable source, a codec that refused. Hand the
+                        // audio back or the video plays silent for good.
+                        setExoPlayerAudioEnabled(true)
                         return@post
                     }
                     clipAudioLoop = loop
@@ -1142,14 +1152,19 @@ internal class DivineVideoPlayerInstance(
     /** Releases the private audio path and lets ExoPlayer see audio again. */
     private fun releaseClipAudioLoop() {
         clipAudioGeneration++
+        clipAudioPending = false
         clipAudioLoop?.release()
         clipAudioLoop = null
-        player?.let { exoPlayer ->
-            exoPlayer.trackSelectionParameters = exoPlayer.trackSelectionParameters
-                .buildUpon()
-                .setTrackTypeDisabled(C.TRACK_TYPE_AUDIO, false)
-                .build()
-        }
+        setExoPlayerAudioEnabled(true)
+    }
+
+    /** Selects or deselects the player's own audio renderer. */
+    private fun setExoPlayerAudioEnabled(enabled: Boolean) {
+        val exoPlayer = player ?: return
+        exoPlayer.trackSelectionParameters = exoPlayer.trackSelectionParameters
+            .buildUpon()
+            .setTrackTypeDisabled(C.TRACK_TYPE_AUDIO, !enabled)
+            .build()
     }
 
     private fun updateDeclickDuration() {
@@ -1187,6 +1202,8 @@ internal class DivineVideoPlayerInstance(
         // and not the start of the video, so the fade out stays on the join.
         declickProcessor.nextStreamStartUs = resolved.second * 1000L
         exoPlayer.seekTo(targetIndex, resolved.second)
+        // The loop track is outside the player and does not hear the seek.
+        clipAudioLoop?.seekTo(resolved.second)
 
         // Apply the target clip's per-clip speed and volume immediately.
         // ExoPlayer does not fire onPositionDiscontinuity / onMediaItemTransition
@@ -1251,9 +1268,15 @@ internal class DivineVideoPlayerInstance(
     }
 
     private fun handleSetPlaybackSpeed(call: MethodCall, result: MethodChannel.Result) {
+        val wasNormalSpeed = speed == 1.0
         speed = (call.argument<Number>("speed"))?.toDouble() ?: 1.0
         player?.setPlaybackSpeed(speed.toFloat())
         audioOverlayManager.setPlaybackSpeed(speed.toFloat())
+        // The loop track cannot be stretched, so leaving normal speed hands the
+        // audio back to the player and returning to it takes the audio again.
+        if (wasNormalSpeed != (speed == 1.0)) {
+            startClipAudioLoop(lastClipsRaw, clipCount)
+        }
         result.success(null)
     }
 
@@ -1267,16 +1290,29 @@ internal class DivineVideoPlayerInstance(
                 releaseClipAudioLoop()
             }
         }
-        // A single repeating clip is what REPEAT_MODE_ONE is for: it repeats the
-        // media period in place instead of walking a one-item playlist round.
-        // The perfect_loop prototype loops this way and closes the seam; this
-        // is the last structural difference left between the two players.
+        applyRepeatMode()
+        result.success(null)
+    }
+
+    /**
+     * Puts the player in the repeat mode its current clip list calls for.
+     *
+     * A single repeating clip is what `REPEAT_MODE_ONE` is for: it repeats the
+     * media period in place instead of walking a one-item playlist round. The
+     * perfect_loop prototype loops this way and closes the seam; this was the
+     * last structural difference left between the two players.
+     *
+     * Because the mode depends on the clip count, both `setLooping` and
+     * `setClips` have to apply it. The editor replaces its clip list without
+     * calling `setLooping` again, so a timeline split in two while
+     * `REPEAT_MODE_ONE` was set would otherwise repeat its first clip forever.
+     */
+    private fun applyRepeatMode() {
         player?.repeatMode = when {
             !isLooping -> Player.REPEAT_MODE_OFF
             clipCount == 1 -> Player.REPEAT_MODE_ONE
             else -> Player.REPEAT_MODE_ALL
         }
-        result.success(null)
     }
 
     private fun handleJumpToClip(call: MethodCall, result: MethodChannel.Result) {
@@ -1314,6 +1350,9 @@ internal class DivineVideoPlayerInstance(
         // Stop and clear media so the surface goes blank.
         exoPlayer.stop()
         exoPlayer.clearMediaItems()
+        // The loop track plays outside the player, so stopping the player does
+        // not stop it — the sound would keep looping over a blank surface.
+        releaseClipAudioLoop()
         clipOffsets = listOf()
         clipVolumes = listOf()
         clipSpeeds = listOf()
@@ -1598,9 +1637,9 @@ internal class DivineVideoPlayerInstance(
         ) {
             // The loop restart is the free moment to install a track-end clamp
             // that resolved while this player was already playing. Deliberately
-            // outside the mediaItemIndex guard below: a single-clip
-            // REPEAT_MODE_ALL loop reports index 0 on both sides, and that loop
-            // is the case the clamp exists for.
+            // outside the mediaItemIndex guard below: a single repeating clip
+            // reports index 0 on both sides, and that loop is the case the
+            // clamp exists for.
             if (reason == Player.DISCONTINUITY_REASON_AUTO_TRANSITION) {
                 applyPendingCommonTrackEndClamp()
             }
@@ -1612,9 +1651,9 @@ internal class DivineVideoPlayerInstance(
             // speeds differ. Position discontinuity fires at the moment the
             // playback position jumps to the new media item, so resetting
             // here closes that window.
-            // The mediaItemIndex guard also makes this a no-op for single-clip
-            // loops (REPEAT_MODE_ALL with one item): both indices are 0, so the
-            // block is skipped entirely → seamless loop regardless of speed.
+            // The mediaItemIndex guard also makes this a no-op for a single
+            // repeating clip: both indices are 0, so the block is skipped
+            // entirely → seamless loop regardless of speed.
             if (reason == Player.DISCONTINUITY_REASON_AUTO_TRANSITION &&
                 newPosition.mediaItemIndex != oldPosition.mediaItemIndex
             ) {
@@ -1653,11 +1692,11 @@ internal class DivineVideoPlayerInstance(
             }
             // Apply per-clip volume and speed for the clip that just started.
             // [onPositionDiscontinuity] already handles the speed/volume switch
-            // (including the Sonic-flush seekTo) for every automatic transition,
-            // including REPEAT_MODE_ALL loops. This block is therefore a
-            // safety-net only: it covers any edge case where
-            // onPositionDiscontinuity did not fire (e.g. a single-item repeat
-            // in REPEAT_MODE_ONE where mediaItemIndex does not change).
+            // (including the Sonic-flush seekTo) for every automatic transition
+            // between clips. This block is therefore a safety-net only: it
+            // covers any edge case where onPositionDiscontinuity did not fire
+            // (e.g. a single-item repeat, where mediaItemIndex does not
+            // change).
             // The seekTo flush is intentionally NOT repeated here — a second
             // seekTo on the same frame causes a double-stutter at the loop
             // restart point without any audio benefit.

--- a/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
+++ b/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
@@ -134,6 +134,23 @@ internal class DivineVideoPlayerInstance(
     /** Per-clip playback speed multipliers (1.0 = normal). Never zero. */
     private var clipSpeeds = listOf<Float>()
     private var clipCount = 0
+    /** The clip's audio, played outside ExoPlayer. See [ClipAudioLoopTrack]. */
+    private var clipAudioLoop: ClipAudioLoopTrack? = null
+
+    /** Guards a decode that finishes after its clips were replaced. */
+    private var clipAudioGeneration = 0
+
+    /** Set when the audio loop is waiting for a readable duration. */
+    private var clipAudioPending = false
+
+    /**
+     * The clips last handed over.
+     *
+     * Dart sends `setLooping` as its own call *after* `setClips`, so whether
+     * this player loops is not yet known while the clips are applied.
+     */
+    private var lastClipsRaw: List<Map<String, Any?>> = emptyList()
+
     private var isLooping = false
     private var volume = 1.0
     private var speed = 1.0
@@ -813,6 +830,8 @@ internal class DivineVideoPlayerInstance(
         //
         // Published before the playlist swap below, because that swap disables
         // the audio renderer and flushes the pipeline on the playback thread.
+        lastClipsRaw = clipsRaw
+        startClipAudioLoop(clipsRaw, clipCount)
         declickProcessor.enabled = clipCount == 1
         declickProcessor.videoDurationUs = LoopDeclickAudioProcessor.DURATION_UNKNOWN
         declickProcessor.nextStreamStartUs = startLocalMs * 1000L
@@ -858,12 +877,31 @@ internal class DivineVideoPlayerInstance(
         mainHandler.postDelayed(setClipsTimeoutRunnable, SET_CLIPS_TIMEOUT_MS)
     }
 
+    /**
+     * Wraps [uri] in a media item, clipping it only when that really cuts
+     * something.
+     *
+     * A clipping configuration is not free: media3 wraps the source in a
+     * `ClippingMediaSource`, and a looping player then repeats the wrapper
+     * rather than the source. The Apple side had the same shape -- every clip
+     * was copied into an `AVMutableComposition` even when there was nothing to
+     * compose -- and there it cost the loop seam; playing the asset itself
+     * closed it.
+     *
+     * The feed always passes an end (its maximum playback duration), so
+     * without this test every feed video was wrapped, whether or not the end
+     * fell inside the clip. Track lengths come from [trackDurationsCache],
+     * which is already filled by then; when they are unknown the wrapper stays,
+     * because guessing wrong here would silently play past a trim.
+     */
     private fun buildMediaItem(
         uri: String,
         startMs: Long,
         endMs: Long?,
-    ): MediaItem =
-        MediaItem.Builder().setUri(uri)
+    ): MediaItem {
+        val builder = MediaItem.Builder().setUri(uri)
+        if (clipsNothing(uri, startMs, endMs)) return builder.build()
+        return builder
             .setClippingConfiguration(
                 MediaItem.ClippingConfiguration.Builder()
                     .setStartPositionMs(startMs)
@@ -873,6 +911,17 @@ internal class DivineVideoPlayerInstance(
                     .build(),
             )
             .build()
+    }
+
+    /** Whether clipping [uri] to [startMs]..[endMs] would leave it untouched. */
+    private fun clipsNothing(uri: String, startMs: Long, endMs: Long?): Boolean {
+        if (startMs != 0L) return false
+        if (endMs == null) return true
+        val durations = trackDurationsCache[uri]
+        if (durations == null || durations.contentEquals(NO_TRACK_PAIR)) return false
+        val containerEndMs = (durations.maxOrNull() ?: return false) / 1000
+        return endMs >= containerEndMs
+    }
 
     /**
      * The point up to which *every* track of [uri] still has content, in
@@ -1035,6 +1084,74 @@ internal class DivineVideoPlayerInstance(
      * fade out sits is not derived from this — the processor holds the last
      * few milliseconds back and releases them at the real end of the stream.
      */
+    /**
+     * Moves a looping single clip's audio out of ExoPlayer and into its own
+     * [ClipAudioLoopTrack].
+     *
+     * Only for the case that has the seam: one clip, repeating. Multi-clip
+     * timelines keep the player's audio -- there is no repeat of the same media
+     * period there, so nothing to avoid.
+     *
+     * Decoding blocks, so it runs on [metadataExecutor]; the picture is already
+     * playing by the time the sound joins, which is the right way round.
+     */
+    private fun startClipAudioLoop(clipsRaw: List<Map<String, Any?>>, clipCount: Int) {
+        releaseClipAudioLoop()
+        val generation = ++clipAudioGeneration
+        if (clipCount != 1 || !isLooping) return
+        val map = clipsRaw.firstOrNull() ?: return
+        val uri = map["uri"] as? String ?: return
+        if ((map["startMs"] as? Number)?.toLong() ?: 0L != 0L) return
+        val headers = httpHeadersOf(map)
+
+        // The renderer must not see the audio at all, or it pays the sink
+        // rebuild at the seam regardless of who is making the sound.
+        val exoPlayer = ensurePlayer()
+        exoPlayer.trackSelectionParameters = exoPlayer.trackSelectionParameters
+            .buildUpon()
+            .setTrackTypeDisabled(C.TRACK_TYPE_AUDIO, true)
+            .build()
+
+        // The presented length is only known once the timeline is populated;
+        // [onPlaybackStateChanged] calls back in when it is.
+        val loopMs = exoPlayer.duration
+        if (loopMs == C.TIME_UNSET || loopMs <= 0) {
+            clipAudioPending = true
+            return
+        }
+        clipAudioPending = false
+
+        if (metadataExecutor.isShutdown) return
+        runCatching {
+            metadataExecutor.execute {
+                val loop = ClipAudioLoopTrack.create(uri, headers, loopMs)
+                mainHandler.post {
+                    if (generation != clipAudioGeneration || loop == null) {
+                        loop?.release()
+                        return@post
+                    }
+                    clipAudioLoop = loop
+                    if (player?.isPlaying == true) {
+                        loop.play(player?.currentPosition ?: 0L, volume.toFloat())
+                    }
+                }
+            }
+        }
+    }
+
+    /** Releases the private audio path and lets ExoPlayer see audio again. */
+    private fun releaseClipAudioLoop() {
+        clipAudioGeneration++
+        clipAudioLoop?.release()
+        clipAudioLoop = null
+        player?.let { exoPlayer ->
+            exoPlayer.trackSelectionParameters = exoPlayer.trackSelectionParameters
+                .buildUpon()
+                .setTrackTypeDisabled(C.TRACK_TYPE_AUDIO, false)
+                .build()
+        }
+    }
+
     private fun updateDeclickDuration() {
         val durationMs = player?.duration ?: C.TIME_UNSET
         declickProcessor.videoDurationUs = if (durationMs == C.TIME_UNSET) {
@@ -1127,6 +1244,9 @@ internal class DivineVideoPlayerInstance(
         volume = (call.argument<Number>("volume"))?.toDouble() ?: 1.0
         val currentIndex = player?.currentMediaItemIndex ?: 0
         player?.volume = (clipVolumes.getOrElse(currentIndex) { 1.0f }) * volume.toFloat()
+        clipAudioLoop?.setVolume(
+            (clipVolumes.getOrElse(currentIndex) { 1.0f }) * volume.toFloat(),
+        )
         result.success(null)
     }
 
@@ -1138,8 +1258,24 @@ internal class DivineVideoPlayerInstance(
     }
 
     private fun handleSetLooping(call: MethodCall, result: MethodChannel.Result) {
+        val wasLooping = isLooping
         isLooping = call.argument<Boolean>("looping") ?: false
-        player?.repeatMode = if (isLooping) Player.REPEAT_MODE_ALL else Player.REPEAT_MODE_OFF
+        if (isLooping != wasLooping && lastClipsRaw.isNotEmpty()) {
+            if (isLooping) {
+                startClipAudioLoop(lastClipsRaw, lastClipsRaw.size)
+            } else {
+                releaseClipAudioLoop()
+            }
+        }
+        // A single repeating clip is what REPEAT_MODE_ONE is for: it repeats the
+        // media period in place instead of walking a one-item playlist round.
+        // The perfect_loop prototype loops this way and closes the seam; this
+        // is the last structural difference left between the two players.
+        player?.repeatMode = when {
+            !isLooping -> Player.REPEAT_MODE_OFF
+            clipCount == 1 -> Player.REPEAT_MODE_ONE
+            else -> Player.REPEAT_MODE_ALL
+        }
         result.success(null)
     }
 
@@ -1157,12 +1293,14 @@ internal class DivineVideoPlayerInstance(
 
     private fun handlePlay(result: MethodChannel.Result) {
         ensurePlayer().play()
+        clipAudioLoop?.play(player?.currentPosition ?: 0L, volume.toFloat())
         audioOverlayManager.resumeActive()
         result.success(null)
     }
 
     private fun handlePause(result: MethodChannel.Result) {
         ensurePlayer().pause()
+        clipAudioLoop?.pause()
         audioOverlayManager.pauseAll()
         result.success(null)
     }
@@ -1432,6 +1570,7 @@ internal class DivineVideoPlayerInstance(
                 // The video's length is only readable once the timeline is
                 // populated, and it bounds how long the fade may be.
                 updateDeclickDuration()
+                if (clipAudioPending) startClipAudioLoop(lastClipsRaw, lastClipsRaw.size)
                 // Seek complete — switch from reporting target to actual position.
                 pendingGlobalStartMs = 0L
                 completeSeekIfPending()
@@ -1739,6 +1878,7 @@ internal class DivineVideoPlayerInstance(
         // rather than left waiting on a continuation that will not apply.
         setClipsGeneration++
         deferredSetClips?.let { settleDeferredSetClips(it, apply = false) }
+        releaseClipAudioLoop()
         metadataExecutor.shutdownNow()
         seekCompletionResult?.success(null)
         seekCompletionResult = null
@@ -1800,6 +1940,7 @@ internal class DivineVideoPlayerInstance(
     )
 
     companion object {
+
         private const val POSITION_UPDATE_INTERVAL_MS = 200L
         private const val SET_CLIPS_TIMEOUT_MS = 10_000L
 

--- a/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
+++ b/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
@@ -182,6 +182,17 @@ internal class DivineVideoPlayerInstance(
     private var deferredSetClips: DeferredSetClips? = null
 
     /**
+     * A resolved track-end clamp waiting for a loop restart to be applied.
+     *
+     * Held when the read lands on a player that is already playing, where
+     * swapping the item outright would jump the video back to its start. At
+     * the loop boundary the position is already back at zero, so the swap
+     * costs nothing there. Superseded by the generation check like every other
+     * piece of late background work.
+     */
+    private var pendingCommonTrackEndClamp: PendingCommonTrackEndClamp? = null
+
+    /**
      * Gives up waiting for the track lengths and starts the player unclamped.
      *
      * The read has to be bounded. `MediaExtractor` fetches a remote source
@@ -466,6 +477,7 @@ internal class DivineVideoPlayerInstance(
 
         // Any newer call supersedes a resolution still in flight.
         val generation = ++setClipsGeneration
+        pendingCommonTrackEndClamp = null
         deferredSetClips?.let { settleDeferredSetClips(it, apply = false) }
 
         val unresolved = if (trackDurationProbingDisabled) {
@@ -565,7 +577,7 @@ internal class DivineVideoPlayerInstance(
 
     /**
      * Tightens the loaded playlist to the track ends a background read just
-     * resolved, while doing so is still free.
+     * resolved, at the first moment doing so is free.
      *
      * A clamp lives in the item's `ClippingConfiguration`, and
      * `ClippingMediaSource.canUpdateMediaItem` compares that configuration, so
@@ -574,10 +586,16 @@ internal class DivineVideoPlayerInstance(
      * the position to the *default* position of the one that takes its place.
      * On a player that has not started that is invisible — a preloaded tile
      * sits paused at frame zero, and the feed preloads a window around the
-     * current index. On one that is already playing it is the video jumping
-     * back to its start mid-watch, which is a worse artifact than the seam it
-     * removes, so that load keeps the seam and the cached lengths clamp the
-     * next `setClips` for the source instead.
+     * current index.
+     *
+     * On one that is already playing, swapping *now* would be the video
+     * jumping back to its start mid-watch. Waiting for the source's next
+     * `setClips` is not a fix either: for a remote source the read never lands
+     * before the tile the viewer is on starts playing, so the video they are
+     * actually watching keeps the seam for its whole visit. Instead the clamp
+     * is parked and applied at the next loop restart, where the position has
+     * already returned to zero and resolving to the default position is where
+     * playback is anyway.
      */
     private fun applyResolvedCommonTrackEnds(
         generation: Long,
@@ -586,8 +604,37 @@ internal class DivineVideoPlayerInstance(
         if (generation != setClipsGeneration) return
         val exoPlayer = player ?: return
         if (exoPlayer.mediaItemCount != clipsRaw.size) return
-        if (exoPlayer.playWhenReady || exoPlayer.currentPosition > 0L) return
+        if (exoPlayer.playWhenReady || exoPlayer.currentPosition > 0L) {
+            pendingCommonTrackEndClamp =
+                PendingCommonTrackEndClamp(generation, clipsRaw)
+            return
+        }
+        pendingCommonTrackEndClamp = null
+        clampLoadedClipsToResolvedTrackEnds(exoPlayer, clipsRaw)
+    }
 
+    /**
+     * Applies a clamp parked by [applyResolvedCommonTrackEnds] now that the
+     * player has looped.
+     *
+     * Runs from [Player.Listener.onPositionDiscontinuity] on an automatic
+     * transition, which for the feed's single-clip `REPEAT_MODE_ALL` player is
+     * the loop restart itself.
+     */
+    private fun applyPendingCommonTrackEndClamp() {
+        val pending = pendingCommonTrackEndClamp ?: return
+        pendingCommonTrackEndClamp = null
+        if (pending.generation != setClipsGeneration) return
+        val exoPlayer = player ?: return
+        if (exoPlayer.mediaItemCount != pending.clipsRaw.size) return
+        clampLoadedClipsToResolvedTrackEnds(exoPlayer, pending.clipsRaw)
+    }
+
+    /** Rebuilds every loaded item whose resolved clamp differs from its own. */
+    private fun clampLoadedClipsToResolvedTrackEnds(
+        exoPlayer: ExoPlayer,
+        clipsRaw: List<Map<String, Any?>>,
+    ) {
         var changed = false
         clipsRaw.forEachIndexed loop@{ index, map ->
             val uri = map["uri"] as? String ?: return@loop
@@ -696,6 +743,13 @@ internal class DivineVideoPlayerInstance(
                 null
             }
             val effectiveEndMs = listOfNotNull(endMs, commonEndMs).minOrNull()
+            if (trimToCommonTrackEnd) {
+                DivineVideoPlayerLog.debug(
+                    "Player $playerId clip end requested=${endMs}ms " +
+                        "common=${commonEndMs}ms effective=${effectiveEndMs}ms for $uri",
+                    name = "DivineVideoPlayer.Load",
+                )
+            }
             val clipVol = (map["volume"] as? Number)?.toFloat() ?: 1.0f
             val clipSpeed = ((map["playbackSpeed"] as? Number)?.toFloat() ?: 1.0f)
                 .coerceAtLeast(MIN_PLAYBACK_SPEED)
@@ -925,6 +979,11 @@ internal class DivineVideoPlayerInstance(
             if (videoUs <= 0 || audioUs <= 0) {
                 NO_TRACK_PAIR
             } else {
+                DivineVideoPlayerLog.debug(
+                    "Player $playerId read track ends video=${videoUs / 1000}ms " +
+                        "audio=${audioUs / 1000}ms for $uri",
+                    name = "DivineVideoPlayer.Load",
+                )
                 longArrayOf(videoUs, audioUs)
             }
         } catch (e: Exception) {
@@ -1398,6 +1457,14 @@ internal class DivineVideoPlayerInstance(
             newPosition: Player.PositionInfo,
             reason: Int,
         ) {
+            // The loop restart is the free moment to install a track-end clamp
+            // that resolved while this player was already playing. Deliberately
+            // outside the mediaItemIndex guard below: a single-clip
+            // REPEAT_MODE_ALL loop reports index 0 on both sides, and that loop
+            // is the case the clamp exists for.
+            if (reason == Player.DISCONTINUITY_REASON_AUTO_TRANSITION) {
+                applyPendingCommonTrackEndClamp()
+            }
             // Apply per-clip speed/volume as early as possible on auto-transition.
             // [onMediaItemTransition] fires later in the pipeline, after a few
             // frames of the new clip have already rendered with the previous
@@ -1696,6 +1763,7 @@ internal class DivineVideoPlayerInstance(
         legacyEntry?.release()
         legacyEntry = null
         audioOverlayManager.releaseAll()
+        pendingCommonTrackEndClamp = null
         eventSink = null
     }
 
@@ -1718,6 +1786,18 @@ internal class DivineVideoPlayerInstance(
          */
         var settled: Boolean = false
     }
+
+    /**
+     * A resolved track-end clamp waiting for the loop restart that makes
+     * installing it free.
+     *
+     * [generation] is the `setClips` the clamp was resolved for, so a newer one
+     * discards it rather than clamping the wrong playlist.
+     */
+    private class PendingCommonTrackEndClamp(
+        val generation: Long,
+        val clipsRaw: List<Map<String, Any?>>,
+    )
 
     companion object {
         private const val POSITION_UPDATE_INTERVAL_MS = 200L

--- a/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/LoopPcm.kt
+++ b/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/LoopPcm.kt
@@ -1,0 +1,104 @@
+package com.divinevideo.divine_video_player
+
+/**
+ * Cuts decoded PCM to a loop and closes its seam.
+ *
+ * Split out of [ClipAudioLoopTrack] because everything here is arithmetic on a
+ * sample array, and every one of these rules was got wrong at least once while
+ * the seam was being chased: the loop was cut to the caller's requested end
+ * instead of the player's duration, the blend ran against material that was not
+ * there, and a fallback blend made the seam worse than leaving it alone.
+ */
+internal object LoopPcm {
+
+    /** Blend length at the seam, when there is material to blend with. */
+    const val CROSSFADE_MS = 100L
+
+    /** Fallback when there is not: long enough to kill the click, no more. */
+    const val RAMP_MS = 5L
+
+    /**
+     * The loop, and how its seam was closed.
+     *
+     * [samples] holds the loop in its first `loopFrames * channels` entries;
+     * anything past that was only needed for the blend.
+     */
+    data class Prepared(
+        val samples: ShortArray,
+        val loopFrames: Int,
+        val fadeFrames: Int,
+        val blendedFromPastTheLoop: Boolean,
+    ) {
+        override fun equals(other: Any?): Boolean =
+            this === other ||
+                (other is Prepared &&
+                    samples.contentEquals(other.samples) &&
+                    loopFrames == other.loopFrames &&
+                    fadeFrames == other.fadeFrames &&
+                    blendedFromPastTheLoop == other.blendedFromPastTheLoop)
+
+        override fun hashCode(): Int =
+            samples.contentHashCode() * 31 + loopFrames
+    }
+
+    /**
+     * Prepares [samples] as a loop of [loopMs], blending its seam.
+     *
+     * [loopMs] must be the duration the *player* presents. A track's media
+     * duration ignores the edit list, and on a clip whose edit list was
+     * corrected the two differ — looping the sound on the media length walks it
+     * away from the picture a little every lap.
+     *
+     * The seam is closed with the material that lies past the loop point, so
+     * the loop's last sample and its first become two consecutive samples of
+     * the recording. Where the decode ends at the loop, both ends are ramped
+     * instead: that removes the click and leaves the restart audible, which is
+     * worse but honest. Folding the loop's own tail into its head was tried and
+     * is worse than either — the tail has to fade or it is heard twice, so the
+     * seam becomes a dip to near-silence followed by material that jumps back.
+     *
+     * Returns null when there is no loop to build.
+     */
+    fun prepare(
+        samples: ShortArray,
+        channels: Int,
+        sampleRate: Int,
+        loopMs: Long,
+    ): Prepared? {
+        if (channels <= 0 || sampleRate <= 0 || loopMs <= 0) return null
+        val decodedFrames = samples.size / channels
+        val loopFrames = minOf((loopMs * sampleRate / 1000L).toInt(), decodedFrames)
+        if (loopFrames <= 0) return null
+
+        val spare = decodedFrames - loopFrames
+        val wanted = (CROSSFADE_MS * sampleRate / 1000L).toInt()
+        val fadeFrames = minOf(wanted, spare)
+        val out = samples.copyOf()
+
+        if (fadeFrames > 0) {
+            for (i in 0 until fadeFrames) {
+                val a = i.toFloat() / fadeFrames
+                for (channel in 0 until channels) {
+                    val head = samples[i * channels + channel].toFloat()
+                    val past = samples[(loopFrames + i) * channels + channel].toFloat()
+                    out[i * channels + channel] =
+                        (past * (1f - a) + head * a)
+                            .coerceIn(-32768f, 32767f).toInt().toShort()
+                }
+            }
+            return Prepared(out, loopFrames, fadeFrames, blendedFromPastTheLoop = true)
+        }
+
+        val rampFrames = minOf((RAMP_MS * sampleRate / 1000L).toInt(), loopFrames / 8)
+        for (i in 0 until rampFrames) {
+            val gain = i.toFloat() / rampFrames
+            for (channel in 0 until channels) {
+                val head = i * channels + channel
+                val tail = (loopFrames - 1 - i) * channels + channel
+                out[head] = (out[head] * gain).toInt().toShort()
+                out[tail] = (out[tail] * gain).toInt().toShort()
+            }
+        }
+        return Prepared(out, loopFrames, rampFrames, blendedFromPastTheLoop = false)
+    }
+}

--- a/mobile/packages/divine_video_player/android/src/test/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstanceTest.kt
+++ b/mobile/packages/divine_video_player/android/src/test/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstanceTest.kt
@@ -7,6 +7,7 @@ import android.net.Uri
 import android.os.Handler
 import android.os.SystemClock
 import android.view.Surface
+import androidx.media3.common.C
 import androidx.media3.common.MediaItem
 import androidx.media3.common.PlaybackException
 import androidx.media3.common.PlaybackParameters
@@ -992,8 +993,22 @@ class DivineVideoPlayerInstanceTest {
         assertEquals(6_000L, replaced.captured.clippingConfiguration.endPositionMs)
     }
 
+    /** A [Player.PositionInfo] carrying only the field the listener reads. */
+    private fun positionInfo(mediaItemIndex: Int): Player.PositionInfo =
+        Player.PositionInfo(
+            /* windowUid = */ null,
+            /* mediaItemIndex = */ mediaItemIndex,
+            /* mediaItem = */ null,
+            /* periodUid = */ null,
+            /* periodIndex = */ mediaItemIndex,
+            /* positionMs = */ 0L,
+            /* contentPositionMs = */ 0L,
+            /* adGroupIndex = */ C.INDEX_UNSET,
+            /* adIndexInAdGroup = */ C.INDEX_UNSET,
+        )
+
     @Test
-    fun `a resolved clamp is not applied over a playlist already playing`() {
+    fun `a resolved clamp is parked rather than applied mid-watch`() {
         every { mockPlayer.mediaItemCount } returns 1
         every { mockPlayer.getMediaItemAt(0) } returns MediaItem.Builder().build()
         every { mockPlayer.playWhenReady } returns true
@@ -1006,9 +1021,98 @@ class DivineVideoPlayerInstanceTest {
             capturePostedRunnables().forEach { it.run() }
         }
 
-        // A clipping configuration cannot be updated in place, so this would
-        // remove and re-insert the period being played and restart the video
-        // from zero mid-watch — worse than the seam it removes.
+        // A clipping configuration cannot be updated in place, so applying it
+        // here would remove and re-insert the period being played and restart
+        // the video from zero mid-watch — worse than the seam it removes.
+        verify(exactly = 0) { mockPlayer.replaceMediaItem(any(), any()) }
+    }
+
+    @Test
+    fun `a parked clamp is applied at the loop restart`() {
+        every { mockPlayer.mediaItemCount } returns 1
+        every { mockPlayer.getMediaItemAt(0) } returns MediaItem.Builder().build()
+        every { mockPlayer.playWhenReady } returns true
+        val listenerSlot = slot<Player.Listener>()
+        every { mockPlayer.addListener(capture(listenerSlot)) } just runs
+
+        withTrackDurations(videoUs = 6_000_000L, audioUs = 6_040_000L) {
+            instance.onMethodCall(
+                trimmingSetClipsCall("https://cdn.example/playing.mp4"),
+                mockk(relaxed = true),
+            )
+            capturePostedRunnables().forEach { it.run() }
+        }
+        verify(exactly = 0) { mockPlayer.replaceMediaItem(any(), any()) }
+
+        // A single-clip REPEAT_MODE_ALL loop reports the same media item index
+        // on both sides of the restart, which is why the clamp hook sits
+        // outside the index guard the speed/volume block uses.
+        listenerSlot.captured.onPositionDiscontinuity(
+            positionInfo(mediaItemIndex = 0),
+            positionInfo(mediaItemIndex = 0),
+            Player.DISCONTINUITY_REASON_AUTO_TRANSITION,
+        )
+
+        val replaced = slot<MediaItem>()
+        verify { mockPlayer.replaceMediaItem(0, capture(replaced)) }
+        assertEquals(6_000L, replaced.captured.clippingConfiguration.endPositionMs)
+    }
+
+    @Test
+    fun `a parked clamp is applied only once`() {
+        every { mockPlayer.mediaItemCount } returns 1
+        every { mockPlayer.getMediaItemAt(0) } returns MediaItem.Builder().build()
+        every { mockPlayer.playWhenReady } returns true
+        val listenerSlot = slot<Player.Listener>()
+        every { mockPlayer.addListener(capture(listenerSlot)) } just runs
+
+        withTrackDurations(videoUs = 6_000_000L, audioUs = 6_040_000L) {
+            instance.onMethodCall(
+                trimmingSetClipsCall("https://cdn.example/playing.mp4"),
+                mockk(relaxed = true),
+            )
+            capturePostedRunnables().forEach { it.run() }
+        }
+
+        repeat(3) {
+            listenerSlot.captured.onPositionDiscontinuity(
+                positionInfo(mediaItemIndex = 0),
+                positionInfo(mediaItemIndex = 0),
+                Player.DISCONTINUITY_REASON_AUTO_TRANSITION,
+            )
+        }
+
+        // Every later lap must cost nothing: re-installing the same clipping
+        // configuration would rebuild the period at each loop, which is the
+        // stutter the clamp exists to remove.
+        verify(exactly = 1) { mockPlayer.replaceMediaItem(0, any()) }
+    }
+
+    @Test
+    fun `a parked clamp is not applied on a seek`() {
+        every { mockPlayer.mediaItemCount } returns 1
+        every { mockPlayer.getMediaItemAt(0) } returns MediaItem.Builder().build()
+        every { mockPlayer.playWhenReady } returns true
+        val listenerSlot = slot<Player.Listener>()
+        every { mockPlayer.addListener(capture(listenerSlot)) } just runs
+
+        withTrackDurations(videoUs = 6_000_000L, audioUs = 6_040_000L) {
+            instance.onMethodCall(
+                trimmingSetClipsCall("https://cdn.example/playing.mp4"),
+                mockk(relaxed = true),
+            )
+            capturePostedRunnables().forEach { it.run() }
+        }
+
+        // A seek lands anywhere, so the remove-and-insert would drop playback
+        // back to the default position — the mid-watch restart the parking
+        // exists to avoid.
+        listenerSlot.captured.onPositionDiscontinuity(
+            positionInfo(mediaItemIndex = 0),
+            positionInfo(mediaItemIndex = 0),
+            Player.DISCONTINUITY_REASON_SEEK,
+        )
+
         verify(exactly = 0) { mockPlayer.replaceMediaItem(any(), any()) }
     }
 

--- a/mobile/packages/divine_video_player/android/src/test/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstanceTest.kt
+++ b/mobile/packages/divine_video_player/android/src/test/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstanceTest.kt
@@ -12,6 +12,7 @@ import androidx.media3.common.MediaItem
 import androidx.media3.common.PlaybackException
 import androidx.media3.common.PlaybackParameters
 import androidx.media3.common.Player
+import androidx.media3.common.TrackSelectionParameters
 import androidx.media3.datasource.DataSpec
 import androidx.media3.datasource.HttpDataSource
 import androidx.media3.exoplayer.ExoPlayer
@@ -24,10 +25,12 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkConstructor
+import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.runs
 import io.mockk.slot
 import io.mockk.unmockkConstructor
+import io.mockk.unmockkObject
 import io.mockk.unmockkStatic
 import io.mockk.verify
 import io.mockk.verifyOrder
@@ -809,6 +812,128 @@ class DivineVideoPlayerInstanceTest {
 
     // -- common-track-end clamp resolution --
 
+    private fun loopingCall(looping: Boolean): MethodCall =
+        MethodCall("setLooping", mapOf("looping" to looping))
+
+    private fun twoClipSetClipsCall(): MethodCall =
+        MethodCall(
+            "setClips",
+            mapOf(
+                "clips" to listOf(
+                    mapOf("uri" to "file:///tmp/a.mp4", "startMs" to 0, "endMs" to 1000),
+                    mapOf("uri" to "file:///tmp/b.mp4", "startMs" to 0, "endMs" to 1000),
+                ),
+            ),
+        )
+
+    @Test
+    fun `a clip list that grows leaves single-clip repeat behind`() {
+        instance.onMethodCall(setClipsCall(), mockk(relaxed = true))
+        instance.onMethodCall(loopingCall(looping = true), mockk(relaxed = true))
+
+        verify { mockPlayer.repeatMode = Player.REPEAT_MODE_ONE }
+
+        // The editor swaps its clip list without calling setLooping again — a
+        // split turns one clip into two. A repeat mode left on the single-clip
+        // setting would repeat the first clip forever instead of walking the
+        // timeline.
+        instance.onMethodCall(twoClipSetClipsCall(), mockk(relaxed = true))
+
+        verify { mockPlayer.repeatMode = Player.REPEAT_MODE_ALL }
+    }
+
+    /**
+     * Records the audio-renderer selections the instance makes, newest last.
+     *
+     * `true` means the player's own audio was switched off in favour of the
+     * private loop track.
+     */
+    private fun captureAudioTrackDisables(): List<Boolean> {
+        val params = mockk<TrackSelectionParameters>(relaxed = true)
+        val builder = mockk<TrackSelectionParameters.Builder>(relaxed = true)
+        val disabled = mutableListOf<Boolean>()
+        every { mockPlayer.trackSelectionParameters } returns params
+        every { params.buildUpon() } returns builder
+        every { builder.build() } returns params
+        every {
+            builder.setTrackTypeDisabled(C.TRACK_TYPE_AUDIO, capture(disabled))
+        } returns builder
+        return disabled
+    }
+
+    @Test
+    fun `a clip whose audio will not decode gets the player's audio back`() {
+        mockkObject(ClipAudioLoopTrack.Companion)
+        try {
+            every { ClipAudioLoopTrack.create(any(), any(), any()) } returns null
+            every { mockPlayer.duration } returns 3_000L
+            val disabled = captureAudioTrackDisables()
+
+            instance.onMethodCall(setClipsCall(), mockk(relaxed = true))
+            instance.onMethodCall(loopingCall(looping = true), mockk(relaxed = true))
+            capturePostedRunnables().forEach { it.run() }
+
+            // The renderer is switched off before the decode is attempted, so a
+            // decode that yields nothing has to switch it back on. Leaving it
+            // off plays the video silent for the rest of its life.
+            assertEquals(true, disabled.contains(true))
+            assertEquals(false, disabled.last())
+        } finally {
+            unmockkObject(ClipAudioLoopTrack.Companion)
+        }
+    }
+
+    @Test
+    fun `a fresh clip list waits for its own timeline before cutting the audio`() {
+        mockkObject(ClipAudioLoopTrack.Companion)
+        try {
+            every { ClipAudioLoopTrack.create(any(), any(), any()) } returns null
+            // A reused player still holds the outgoing item while the new clips
+            // are applied, so its duration describes that one.
+            every { mockPlayer.duration } returns 3_000L
+            captureAudioTrackDisables()
+            val listener = capturePlayerListener()
+
+            instance.onMethodCall(loopingCall(looping = true), mockk(relaxed = true))
+            instance.onMethodCall(setClipsCall(), mockk(relaxed = true))
+
+            // Cutting to that duration here would loop the incoming video's
+            // sound at the previous video's length, drifting a little further
+            // from the picture every lap.
+            verify(exactly = 0) { ClipAudioLoopTrack.create(any(), any(), any()) }
+
+            listener.onPlaybackStateChanged(Player.STATE_READY)
+
+            verify(exactly = 1) { ClipAudioLoopTrack.create(any(), any(), any()) }
+        } finally {
+            unmockkObject(ClipAudioLoopTrack.Companion)
+        }
+    }
+
+    @Test
+    fun `an off-speed player keeps its own audio`() {
+        mockkObject(ClipAudioLoopTrack.Companion)
+        try {
+            every { ClipAudioLoopTrack.create(any(), any(), any()) } returns null
+            every { mockPlayer.duration } returns 3_000L
+            val disabled = captureAudioTrackDisables()
+
+            instance.onMethodCall(
+                MethodCall("setPlaybackSpeed", mapOf("speed" to 2.0)),
+                mockk(relaxed = true),
+            )
+            instance.onMethodCall(setClipsCall(), mockk(relaxed = true))
+            instance.onMethodCall(loopingCall(looping = true), mockk(relaxed = true))
+
+            // A static track plays the recording at its own rate, so it would
+            // drift away from a picture running at twice the speed.
+            verify(exactly = 0) { ClipAudioLoopTrack.create(any(), any(), any()) }
+            assertEquals(false, disabled.contains(true))
+        } finally {
+            unmockkObject(ClipAudioLoopTrack.Companion)
+        }
+    }
+
     private fun trimmingSetClipsCall(uri: String): MethodCall =
         MethodCall(
             "setClips",
@@ -1044,9 +1169,9 @@ class DivineVideoPlayerInstanceTest {
         }
         verify(exactly = 0) { mockPlayer.replaceMediaItem(any(), any()) }
 
-        // A single-clip REPEAT_MODE_ALL loop reports the same media item index
-        // on both sides of the restart, which is why the clamp hook sits
-        // outside the index guard the speed/volume block uses.
+        // A single repeating clip reports the same media item index on both
+        // sides of the restart, which is why the clamp hook sits outside the
+        // index guard the speed/volume block uses.
         listenerSlot.captured.onPositionDiscontinuity(
             positionInfo(mediaItemIndex = 0),
             positionInfo(mediaItemIndex = 0),

--- a/mobile/packages/divine_video_player/android/src/test/kotlin/com/divinevideo/divine_video_player/LoopPcmTest.kt
+++ b/mobile/packages/divine_video_player/android/src/test/kotlin/com/divinevideo/divine_video_player/LoopPcmTest.kt
@@ -1,0 +1,153 @@
+package com.divinevideo.divine_video_player
+
+import kotlin.math.abs
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins the arithmetic behind the Android loop's audio.
+ *
+ * Every rule here was got wrong at least once while the loop seam was being
+ * chased, and each time the mistake was audible rather than visible in a log:
+ * the loop cut to the wrong length, a blend that ran against material that was
+ * not there, and a fallback that made the seam worse than leaving it alone.
+ */
+class LoopPcmTest {
+
+    private val sampleRate = 44100
+
+    /** A tone with a deliberate step at [loopFrames], so a seam is measurable. */
+    private fun tone(frames: Int, channels: Int = 1, offset: Int = 0): ShortArray =
+        ShortArray(frames * channels) { index ->
+            val frame = index / channels
+            val channel = index % channels
+            (((frame + offset) % 200 - 100) * 100 + channel * 7).toShort()
+        }
+
+    private fun seamStep(prepared: LoopPcm.Prepared, channels: Int): Int {
+        val last = (prepared.loopFrames - 1) * channels
+        return abs(prepared.samples[last] - prepared.samples[0])
+    }
+
+    @Test
+    fun `cuts the loop to the duration the player presents`() {
+        // 3.1s of audio, but the player presents 3.0s: the loop is the shorter.
+        val prepared = LoopPcm.prepare(
+            samples = tone(frames = (3.1 * sampleRate).toInt()),
+            channels = 1,
+            sampleRate = sampleRate,
+            loopMs = 3000,
+        )!!
+
+        assertEquals(3000 * sampleRate / 1000, prepared.loopFrames)
+    }
+
+    @Test
+    fun `never cuts past what was decoded`() {
+        // The feed asks for its playback cap, far past any clip. Reading that
+        // as the loop length would run the track off the end of its own buffer.
+        val decoded = sampleRate // one second
+        val prepared = LoopPcm.prepare(
+            samples = tone(frames = decoded),
+            channels = 1,
+            sampleRate = sampleRate,
+            loopMs = 7000,
+        )!!
+
+        assertEquals(decoded, prepared.loopFrames)
+    }
+
+    @Test
+    fun `blends the seam with the material past the loop point`() {
+        val loopFrames = sampleRate
+        val prepared = LoopPcm.prepare(
+            // A quarter second of material beyond the loop to blend with.
+            samples = tone(frames = loopFrames + sampleRate / 4),
+            channels = 1,
+            sampleRate = sampleRate,
+            loopMs = 1000,
+        )!!
+
+        assertTrue(prepared.blendedFromPastTheLoop)
+        assertEquals((LoopPcm.CROSSFADE_MS * sampleRate / 1000).toInt(), prepared.fadeFrames)
+    }
+
+    @Test
+    fun `the blend shrinks the step at the wrap`() {
+        val loopFrames = sampleRate
+        val samples = tone(frames = loopFrames + sampleRate / 4)
+        val prepared = LoopPcm.prepare(samples, 1, sampleRate, loopMs = 1000)!!
+
+        val before = abs(samples[loopFrames - 1] - samples[0])
+        assertTrue(
+            "seam step should fall, was $before now ${seamStep(prepared, 1)}",
+            seamStep(prepared, 1) < before,
+        )
+    }
+
+    @Test
+    fun `ramps both ends when nothing lies past the loop point`() {
+        // Android's decoder applies the container's gapless trimming and hands
+        // back exactly the presented length, which is this case.
+        val loopFrames = sampleRate
+        val prepared = LoopPcm.prepare(
+            samples = tone(frames = loopFrames),
+            channels = 1,
+            sampleRate = sampleRate,
+            loopMs = 1000,
+        )!!
+
+        assertEquals(false, prepared.blendedFromPastTheLoop)
+        assertEquals((LoopPcm.RAMP_MS * sampleRate / 1000).toInt(), prepared.fadeFrames)
+        // Both edges reach zero, so the wrap is silence to silence.
+        assertEquals(0, prepared.samples[0].toInt())
+        assertEquals(0, prepared.samples[(prepared.loopFrames - 1)].toInt())
+    }
+
+    @Test
+    fun `keeps stereo channels in their own lanes`() {
+        // A byte offset that misses a frame boundary swaps the channels for the
+        // rest of the loop, which is silent in a log and obvious in a room.
+        val channels = 2
+        val loopFrames = sampleRate
+        val prepared = LoopPcm.prepare(
+            samples = tone(frames = loopFrames + sampleRate / 4, channels = channels),
+            channels = channels,
+            sampleRate = sampleRate,
+            loopMs = 1000,
+        )!!
+
+        // Channel 1 carries a +7 marker the blend has to preserve.
+        for (frame in listOf(0, 1, prepared.fadeFrames + 10, prepared.loopFrames - 1)) {
+            val left = prepared.samples[frame * channels]
+            val right = prepared.samples[frame * channels + 1]
+            assertNotEquals("channels collapsed at frame $frame", left, right)
+        }
+    }
+
+    @Test
+    fun `refuses input it cannot make a loop from`() {
+        assertNull(LoopPcm.prepare(tone(frames = 100), channels = 1, sampleRate, loopMs = 0))
+        assertNull(LoopPcm.prepare(ShortArray(0), channels = 1, sampleRate, loopMs = 1000))
+        assertNull(LoopPcm.prepare(tone(frames = 100), channels = 0, sampleRate, loopMs = 1000))
+        assertNull(LoopPcm.prepare(tone(frames = 100), channels = 1, 0, loopMs = 1000))
+    }
+
+    @Test
+    fun `leaves the material outside the blend untouched`() {
+        val loopFrames = sampleRate
+        val samples = tone(frames = loopFrames + sampleRate / 4)
+        val prepared = LoopPcm.prepare(samples, 1, sampleRate, loopMs = 1000)!!
+
+        for (frame in prepared.fadeFrames until loopFrames) {
+            assertEquals(
+                "frame $frame was altered outside the blend",
+                samples[frame],
+                prepared.samples[frame],
+            )
+        }
+    }
+}

--- a/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/DivineVideoPlayerInstance.swift
+++ b/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/DivineVideoPlayerInstance.swift
@@ -21,6 +21,15 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
     private var eventSink: FlutterEventSink?
     private var timeObserver: Any?
     private var currentItemObservation: NSKeyValueObservation?
+
+    /// The edge-declick mix built for the loaded composition, kept so it can be
+    /// re-applied to every item `AVPlayerLooper` makes.
+    ///
+    /// The looper does not replay the template item — it builds its own copies,
+    /// and a copy does not carry the template's `audioMix`. Setting it once at
+    /// load time therefore declicks the first lap and no other, which is
+    /// exactly the lap nobody is listening for.
+    private var loopAudioMix: AVAudioMix?
     private var statusObservation: NSKeyValueObservation?
     private var bufferingObservation: NSKeyValueObservation?
     private var likelyToKeepUpObservation: NSKeyValueObservation?
@@ -446,6 +455,7 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
             }
             playerItem.videoComposition = videoComposition
         }
+        loopAudioMix = audioMix
         if let audioMix { playerItem.audioMix = audioMix }
         return (playerItem, offsets, durations)
     }
@@ -943,6 +953,7 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
         } else {
             player.insert(item, after: nil)
         }
+        prewarmLoopingOutputs()
         attachCurrentItemOutputs()
     }
 
@@ -1103,8 +1114,24 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
         attachCurrentItemOutputs()
     }
 
+    /// Hands the looper's queued items to the texture output so each one
+    /// carries a video output before it becomes current.
+    ///
+    /// `AVPlayerLooper` builds its copies asynchronously, so the set can still
+    /// be empty right after the looper is created and fills in later; running
+    /// this again on every current-item change picks up whatever it has by
+    /// then. It is idempotent — an item already warmed is skipped.
+    private func prewarmLoopingOutputs() {
+        guard let looper = playerLooper else { return }
+        textureOutput?.prewarm(items: looper.loopingPlayerItems)
+    }
+
     private func attachCurrentItemOutputs() {
         guard let item = player?.currentItem else { return }
+        prewarmLoopingOutputs()
+        if let loopAudioMix, item.audioMix !== loopAudioMix {
+            item.audioMix = loopAudioMix
+        }
         textureOutput?.attach(to: item)
         observeStatus(for: item)
         observeBuffering(for: item)

--- a/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/DivineVideoPlayerInstance.swift
+++ b/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/DivineVideoPlayerInstance.swift
@@ -17,6 +17,17 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
 
     private var player: AVQueuePlayer?
     private var playerLooper: AVPlayerLooper?
+
+    /// Bereich, den [AVPlayerLooper] wiederholen soll, wenn er kuerzer ist als
+    /// das Item.
+    ///
+    /// Der Direktpfad spielt das Asset unveraendert, kann den gemeinsamen
+    /// Spurenschluss also nicht wie die Composition in eine Zeitspanne
+    /// schneiden. Ohne diesen Bereich laeuft der Loop bis zum Container-Ende
+    /// weiter, und ueber die Strecke, auf der die kuerzere Spur schon
+    /// ausgelaufen ist, steht das Bild -- auf dem Simulator gemessen als 86ms
+    /// Standbild je Runde.
+    private var loopTimeRange: CMTimeRange?
     private var templateItem: AVPlayerItem?
     private var eventSink: FlutterEventSink?
     private var timeObserver: Any?
@@ -247,9 +258,24 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
                 let playerItem: AVPlayerItem
                 let offsets: [Double]
                 let durations: [Double]
-                if let hlsClip = Self.soleHlsClip(in: clipsRaw) {
-                    (playerItem, offsets, durations) =
-                        try await self.makeHlsPlayerItem(from: hlsClip)
+                // Der Direktpfad ist die bessere Wahl, kann aber nicht jeden
+                // Clip darstellen -- ein gedrehtes Video braucht die
+                // Layer-Instruction der Composition. Er meldet das selbst.
+                var direct: (AVPlayerItem, [Double], [Double])?
+                if let clip = Self.soleHlsClip(in: clipsRaw) {
+                    do {
+                        direct = try await self.makeHlsPlayerItem(from: clip)
+                    } catch CompositionError.directItemNotApplicable {
+                        direct = nil
+                        DivineVideoPlayerLog.shared.warning(
+                            "Player \(self.playerId) uses the composition: "
+                                + "clip needs rotation",
+                            name: "DivineVideoPlayer.Load"
+                        )
+                    }
+                }
+                if let direct {
+                    (playerItem, offsets, durations) = direct
                 } else {
                     (playerItem, offsets, durations) =
                         try await self.makeCompositionPlayerItem(from: clipsRaw)
@@ -378,12 +404,52 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
     /// do today rather than playing something subtly wrong. Multi-clip
     /// timelines likewise still need a composition to stitch — the editor's
     /// multi-clip sources are local files, never HLS.
+    /// Whether [uri] may skip the composition and be played from the asset.
+    ///
+    /// A single unchanged clip has nothing to compose, and `AVPlayerLooper`
+    /// only closes the seam over the asset itself -- over a composition of the
+    /// same file it does not. Remote URLs stay on the composition path, which
+    /// owns the buffering and header handling for them.
+    ///
+    /// Rotation is decided later, against the loaded asset, in
+    /// [directItemSuitsRotation] -- it cannot be read from the URL.
+    /// Whether a clip may skip the composition once its asset is loaded.
+    ///
+    /// The composition rights a rotated track with a layer instruction.
+    /// `AVPlayerItemVideoOutput` hands the pixel buffer over as decoded and
+    /// applies no `preferredTransform`, and the Apple side -- unlike Android --
+    /// sends Dart no rotation to compensate with. HLS is exempt: its renditions
+    /// are upright, and an HLS asset exposes no tracks to inspect anyway.
+    private static func directItemSuitsRotation(
+        _ asset: AVURLAsset,
+        isHls: Bool
+    ) async -> Bool {
+        if isHls { return true }
+        do {
+            guard
+                let track = try await asset.loadTracks(withMediaType: .video).first
+            else { return false }
+            let (naturalSize, transform) = try await track.load(
+                .naturalSize, .preferredTransform
+            )
+            return transform.standardized(for: naturalSize).isEffectivelyIdentity
+        } catch {
+            // Unreadable is not upright; let the composition handle it.
+            return false
+        }
+    }
+
+    private static func takesDirectItemPath(_ uri: String) -> Bool {
+        if URL(string: uri)?.pathExtension.lowercased() == "m3u8" { return true }
+        return !uri.hasPrefix("http")
+    }
+
     private static func soleHlsClip(
         in clipsRaw: [[String: Any]]
     ) -> [String: Any]? {
         guard clipsRaw.count == 1, let clip = clipsRaw.first,
             let uri = clip["uri"] as? String,
-            URL(string: uri)?.pathExtension.lowercased() == "m3u8",
+            Self.takesDirectItemPath(uri),
             (clip["startMs"] as? NSNumber)?.int64Value ?? 0 == 0,
             (clip["volume"] as? NSNumber)?.doubleValue ?? 1.0 == 1.0,
             (clip["playbackSpeed"] as? NSNumber)?.doubleValue ?? 1.0 == 1.0
@@ -404,7 +470,19 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
     private func makeHlsPlayerItem(
         from clipMap: [String: Any]
     ) async throws -> (AVPlayerItem, [Double], [Double]) {
-        guard let uri = clipMap["uri"] as? String, let url = URL(string: uri) else {
+        guard let uri = clipMap["uri"] as? String else {
+            throw CompositionError.noPlayableVideoTracks
+        }
+        // Ein blosser Dateipfad ist keine URL mit Schema; URL(string:) liefert
+        // dafuer etwas, das AVURLAsset nicht laden kann. Der Composition-Pfad
+        // unterscheidet hier schon, dieser hat es nie gebraucht, weil er bis
+        // jetzt nur HLS-URLs sah.
+        let url: URL
+        if uri.hasPrefix("/") {
+            url = URL(fileURLWithPath: uri)
+        } else if let parsed = URL(string: uri) {
+            url = parsed
+        } else {
             throw CompositionError.noPlayableVideoTracks
         }
         let httpHeaders = clipMap["httpHeaders"] as? [String: String]
@@ -412,6 +490,10 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
             [Self.avURLAssetHTTPHeaderFieldsKey: $0]
         }
         let asset = AVURLAsset(url: url, options: assetOptions)
+        let isHls = url.pathExtension.lowercased() == "m3u8"
+        guard await Self.directItemSuitsRotation(asset, isHls: isHls) else {
+            throw CompositionError.directItemNotApplicable
+        }
         let assetDuration = try await asset.load(.duration)
 
         // soleHlsClip guarantees startMs == 0, so the item's timeline is
@@ -424,11 +506,48 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
             throw CompositionError.noPlayableVideoTracks
         }
 
+        // Denselben Schnitt wie die Composition: die Wiedergabe endet dort, wo
+        // die kuerzere der beiden Spuren ausgeht, nicht am Container-Ende.
+        // Hier kann er nicht in eine Zeitspanne geschnitten werden -- das Asset
+        // bleibt unveraendert -- also bekommt ihn der Looper als Bereich.
+        var loopEnd = endTime
+        let trimToCommonTrackEnd =
+            (clipMap["trimToCommonTrackEnd"] as? NSNumber)?.boolValue ?? false
+        if trimToCommonTrackEnd {
+            let videoTracks = try await asset.loadTracks(withMediaType: .video)
+            let audioTracks = try await asset.loadTracks(withMediaType: .audio)
+            if let videoTrack = videoTracks.first, let audioTrack = audioTracks.first {
+                do {
+                    let videoRange = try await videoTrack.load(.timeRange)
+                    let audioRange = try await audioTrack.load(.timeRange)
+                    if let commonEnd = boundedCommonTrackEnd(
+                        startTime: .zero,
+                        requestedEnd: endTime,
+                        videoEnd: videoRange.end,
+                        audioEnd: audioRange.end
+                    ) {
+                        loopEnd = CMTimeMinimum(loopEnd, commonEnd)
+                    }
+                } catch {
+                    DivineVideoPlayerLog.shared.warning(
+                        "Player \(playerId) could not read track durations: "
+                            + "\(error.localizedDescription)",
+                        name: "DivineVideoPlayer.Load"
+                    )
+                }
+            }
+        }
+
         let playerItem = AVPlayerItem(asset: asset)
-        if CMTimeCompare(endTime, assetDuration) < 0 {
+        // forwardPlaybackEndTime und der Looper beschreiben dieselbe Grenze auf
+        // zwei Wegen; nur der Looper-Bereich wird beim Wiederholen beachtet.
+        loopTimeRange = CMTimeCompare(loopEnd, assetDuration) < 0
+            ? CMTimeRange(start: .zero, end: loopEnd)
+            : nil
+        if loopTimeRange == nil, CMTimeCompare(endTime, assetDuration) < 0 {
             playerItem.forwardPlaybackEndTime = endTime
         }
-        return (playerItem, [0], [endTime.seconds])
+        return (playerItem, [0], [loopEnd.seconds])
     }
 
     /// Builds a player item backed by an AVMutableComposition of every clip.
@@ -438,6 +557,7 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
         let (composition, videoComposition, offsets, durations, audioMix) =
             try await buildComposition(from: clipsRaw)
 
+        loopTimeRange = nil
         let playerItem = AVPlayerItem(asset: composition)
         // Validate BEFORE assigning. -[AVPlayerItem setVideoComposition:]
         // throws an Objective-C NSInvalidArgumentException on an invalid
@@ -949,7 +1069,15 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
         playerLooper = nil
         player.removeAllItems()
         if isLooping {
-            playerLooper = AVPlayerLooper(player: player, templateItem: item)
+            if let range = loopTimeRange {
+                playerLooper = AVPlayerLooper(
+                    player: player,
+                    templateItem: item,
+                    timeRange: range
+                )
+            } else {
+                playerLooper = AVPlayerLooper(player: player, templateItem: item)
+            }
         } else {
             player.insert(item, after: nil)
         }
@@ -1583,6 +1711,7 @@ private enum CompositionError: Error, LocalizedError {
     case noPlayableVideoTracks
     case invalidRenderSize
     case invalidFrameDuration
+    case directItemNotApplicable
 
     var errorDescription: String? {
         switch self {
@@ -1594,6 +1723,8 @@ private enum CompositionError: Error, LocalizedError {
             return "Video composition has an invalid render size."
         case .invalidFrameDuration:
             return "Video composition has an invalid frame duration."
+        case .directItemNotApplicable:
+            return "Clip needs the composition path."
         }
     }
 }

--- a/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/DivineVideoPlayerInstance.swift
+++ b/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/DivineVideoPlayerInstance.swift
@@ -18,15 +18,13 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
     private var player: AVQueuePlayer?
     private var playerLooper: AVPlayerLooper?
 
-    /// Bereich, den [AVPlayerLooper] wiederholen soll, wenn er kuerzer ist als
-    /// das Item.
+    /// The range `AVPlayerLooper` repeats, when that is shorter than the item.
     ///
-    /// Der Direktpfad spielt das Asset unveraendert, kann den gemeinsamen
-    /// Spurenschluss also nicht wie die Composition in eine Zeitspanne
-    /// schneiden. Ohne diesen Bereich laeuft der Loop bis zum Container-Ende
-    /// weiter, und ueber die Strecke, auf der die kuerzere Spur schon
-    /// ausgelaufen ist, steht das Bild -- auf dem Simulator gemessen als 86ms
-    /// Standbild je Runde.
+    /// The direct path plays the asset untouched, so unlike the composition it
+    /// cannot cut the common track end into a time range. Without this range
+    /// the loop runs on to the end of the container, and over the stretch where
+    /// the shorter track has already run out the picture stands still —
+    /// measured on the simulator as 86 ms of held frame per lap.
     private var loopTimeRange: CMTimeRange?
     private var templateItem: AVPlayerItem?
     private var eventSink: FlutterEventSink?
@@ -258,13 +256,13 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
                 let playerItem: AVPlayerItem
                 let offsets: [Double]
                 let durations: [Double]
-                // Der Direktpfad ist die bessere Wahl, kann aber nicht jeden
-                // Clip darstellen -- ein gedrehtes Video braucht die
-                // Layer-Instruction der Composition. Er meldet das selbst.
+                // The direct path is the better one, but it cannot represent
+                // every clip — a rotated video needs the composition's layer
+                // instruction. It reports that itself.
                 var direct: (AVPlayerItem, [Double], [Double])?
-                if let clip = Self.soleHlsClip(in: clipsRaw) {
+                if let clip = Self.soleDirectItemClip(in: clipsRaw) {
                     do {
-                        direct = try await self.makeHlsPlayerItem(from: clip)
+                        direct = try await self.makeDirectPlayerItem(from: clip)
                     } catch CompositionError.directItemNotApplicable {
                         direct = nil
                         DivineVideoPlayerLog.shared.warning(
@@ -388,36 +386,11 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
         }
     }
 
-    /// The single clip of [clipsRaw] when it is an HLS source the direct-item
-    /// path can represent exactly, otherwise nil.
-    ///
-    /// An HLS `AVURLAsset` exposes **no** tracks — `loadTracks` returns an
-    /// empty array — so a composition built from one always ends in
-    /// [CompositionError.noPlayableVideoTracks] and can never play. Such
-    /// clips take the direct-item path in [makeHlsPlayerItem] instead.
-    ///
-    /// The diversion is deliberately narrow. A composition can start a clip
-    /// part-way in and rescale it; an `AVPlayerItem` carries the whole asset
-    /// from zero, so a non-zero `startMs` or an off-speed clip has no exact
-    /// representation here and would report a timeline that does not match
-    /// what plays. Those keep failing on the composition path exactly as they
-    /// do today rather than playing something subtly wrong. Multi-clip
-    /// timelines likewise still need a composition to stitch — the editor's
-    /// multi-clip sources are local files, never HLS.
-    /// Whether [uri] may skip the composition and be played from the asset.
-    ///
-    /// A single unchanged clip has nothing to compose, and `AVPlayerLooper`
-    /// only closes the seam over the asset itself -- over a composition of the
-    /// same file it does not. Remote URLs stay on the composition path, which
-    /// owns the buffering and header handling for them.
-    ///
-    /// Rotation is decided later, against the loaded asset, in
-    /// [directItemSuitsRotation] -- it cannot be read from the URL.
     /// Whether a clip may skip the composition once its asset is loaded.
     ///
     /// The composition rights a rotated track with a layer instruction.
     /// `AVPlayerItemVideoOutput` hands the pixel buffer over as decoded and
-    /// applies no `preferredTransform`, and the Apple side -- unlike Android --
+    /// applies no `preferredTransform`, and the Apple side — unlike Android —
     /// sends Dart no rotation to compensate with. HLS is exempt: its renditions
     /// are upright, and an HLS asset exposes no tracks to inspect anyway.
     private static func directItemSuitsRotation(
@@ -439,12 +412,39 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
         }
     }
 
+    /// Whether [uri] may skip the composition and be played from the asset.
+    ///
+    /// A single unchanged clip has nothing to compose, and `AVPlayerLooper`
+    /// only closes the seam over the asset itself — over a composition of the
+    /// same file it does not. Remote URLs stay on the composition path, which
+    /// owns the buffering and header handling for them.
+    ///
+    /// Rotation is decided later, against the loaded asset, in
+    /// [directItemSuitsRotation] — it cannot be read from the URL.
     private static func takesDirectItemPath(_ uri: String) -> Bool {
         if URL(string: uri)?.pathExtension.lowercased() == "m3u8" { return true }
         return !uri.hasPrefix("http")
     }
 
-    private static func soleHlsClip(
+    /// The single clip of [clipsRaw] the direct-item path can represent
+    /// exactly, otherwise nil.
+    ///
+    /// Two sources qualify, for different reasons. An HLS `AVURLAsset` exposes
+    /// **no** tracks — `loadTracks` returns an empty array — so a composition
+    /// built from one always ends in
+    /// [CompositionError.noPlayableVideoTracks] and can never play. A local
+    /// file qualifies because there is nothing to compose: `AVPlayerLooper`
+    /// closes the seam over the asset itself and does not over a composition
+    /// of the same file.
+    ///
+    /// The diversion is deliberately narrow. A composition can start a clip
+    /// part-way in and rescale it; an `AVPlayerItem` carries the whole asset
+    /// from zero, so a non-zero `startMs` or an off-speed clip has no exact
+    /// representation here and would report a timeline that does not match
+    /// what plays. Those keep taking the composition path exactly as they do
+    /// today rather than playing something subtly wrong. Multi-clip timelines
+    /// likewise still need a composition to stitch.
+    private static func soleDirectItemClip(
         in clipsRaw: [[String: Any]]
     ) -> [String: Any]? {
         guard clipsRaw.count == 1, let clip = clipsRaw.first,
@@ -457,26 +457,36 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
         return clip
     }
 
-    /// Builds a player item straight from an HLS asset, bypassing the
+    /// Builds a player item straight from the asset, bypassing the
     /// composition.
     ///
-    /// Trimming is applied with `forwardPlaybackEndTime` rather than a
-    /// composition time range. Orientation needs no video composition because
-    /// HLS renditions are already upright. Per-clip volume changes stay on the
-    /// composition path because a direct item has no audio mix. The cost is that
-    /// the audio-mix edge de-click fades do not apply, so an HLS loop seam can
-    /// click; HLS is only ever reached as a last-resort fallback source, which
-    /// does not justify rebuilding those ramps here.
-    private func makeHlsPlayerItem(
+    /// This is the path every unchanged single clip takes, HLS and local file
+    /// alike, because `AVPlayerLooper` only closes the loop seam over an asset
+    /// and not over a composition of the same file.
+    ///
+    /// Trimming has no composition time range to live in, so it is applied
+    /// twice over: as `forwardPlaybackEndTime`, which bounds playback, and —
+    /// when the trim is what decides the loop — as the looper's own range,
+    /// which is the only one honoured when it wraps.
+    ///
+    /// A rotated clip cannot come here at all; [directItemSuitsRotation] sends
+    /// it back to the composition, which rights it with a layer instruction.
+    /// Per-clip volume changes likewise stay on the composition path, because a
+    /// direct item has no audio mix. The cost is that the audio-mix edge
+    /// de-click fades do not apply, so the loop seam can click.
+    ///
+    /// Throws [CompositionError.directItemNotApplicable] when the loaded asset
+    /// turns out to need the composition after all.
+    private func makeDirectPlayerItem(
         from clipMap: [String: Any]
     ) async throws -> (AVPlayerItem, [Double], [Double]) {
         guard let uri = clipMap["uri"] as? String else {
             throw CompositionError.noPlayableVideoTracks
         }
-        // Ein blosser Dateipfad ist keine URL mit Schema; URL(string:) liefert
-        // dafuer etwas, das AVURLAsset nicht laden kann. Der Composition-Pfad
-        // unterscheidet hier schon, dieser hat es nie gebraucht, weil er bis
-        // jetzt nur HLS-URLs sah.
+        // A bare file path is not a URL with a scheme, and URL(string:) turns
+        // one into something AVURLAsset cannot load. The composition path
+        // already draws this distinction; this one never needed to, because
+        // until now it only ever saw HLS URLs.
         let url: URL
         if uri.hasPrefix("/") {
             url = URL(fileURLWithPath: uri)
@@ -496,7 +506,7 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
         }
         let assetDuration = try await asset.load(.duration)
 
-        // soleHlsClip guarantees startMs == 0, so the item's timeline is
+        // soleDirectItemClip guarantees startMs == 0, so the item's timeline is
         // [0, endTime] and the reported duration is endTime itself.
         let endTime = Self.clampedEndTime(
             requestedEndMs: clipMap["endMs"] as? NSNumber,
@@ -506,10 +516,10 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
             throw CompositionError.noPlayableVideoTracks
         }
 
-        // Denselben Schnitt wie die Composition: die Wiedergabe endet dort, wo
-        // die kuerzere der beiden Spuren ausgeht, nicht am Container-Ende.
-        // Hier kann er nicht in eine Zeitspanne geschnitten werden -- das Asset
-        // bleibt unveraendert -- also bekommt ihn der Looper als Bereich.
+        // The same cut the composition makes: playback ends where the shorter
+        // of the two tracks runs out, not at the end of the container. Here it
+        // cannot be cut into a time range — the asset stays untouched — so the
+        // looper is given it as its range instead.
         var loopEnd = endTime
         let trimToCommonTrackEnd =
             (clipMap["trimToCommonTrackEnd"] as? NSNumber)?.boolValue ?? false
@@ -539,8 +549,12 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
         }
 
         let playerItem = AVPlayerItem(asset: asset)
-        // forwardPlaybackEndTime und der Looper beschreiben dieselbe Grenze auf
-        // zwei Wegen; nur der Looper-Bereich wird beim Wiederholen beachtet.
+        // A direct item has no audio mix, so anything the last composition left
+        // behind has to go — otherwise every item the looper builds is handed a
+        // mix whose input parameters address a different asset's tracks.
+        loopAudioMix = nil
+        // forwardPlaybackEndTime and the looper describe the same boundary two
+        // ways; only the looper's range is honoured when it wraps.
         loopTimeRange = CMTimeCompare(loopEnd, assetDuration) < 0
             ? CMTimeRange(start: .zero, end: loopEnd)
             : nil

--- a/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/VideoTextureOutput.swift
+++ b/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/VideoTextureOutput.swift
@@ -32,6 +32,21 @@ final class VideoTextureOutput: NSObject, FlutterTexture, AVPlayerItemOutputPull
     private weak var player: AVPlayer?
     /// Item the output is currently attached to, so we can detach cleanly.
     private weak var attachedItem: AVPlayerItem?
+
+    /// Every item that already carries one of our outputs, newest last.
+    ///
+    /// `AVPlayerLooper` does not replay one item — it cycles a small set of
+    /// copies, so the current item changes at every loop restart. Building the
+    /// output at that moment means `item.add` and the decoder's first frame
+    /// both land on the seam, and until one arrives `copyPixelBuffer` keeps
+    /// returning the previous lap's last frame: a visible freeze, once per
+    /// loop, on any asset. Adding the output to each queued item ahead of time
+    /// leaves nothing to do at the switch but adopt it.
+    ///
+    /// Items are held strongly, which is safe because the set only ever holds
+    /// what [prewarm] was given — the looper's own items, which it retains for
+    /// as long as it exists — and is dropped wholesale on [dispose].
+    private var warmOutputs: [(item: AVPlayerItem, output: AVPlayerItemVideoOutput)] = []
     /// One-shot observation that triggers the initial frame pull as soon
     /// as the freshly attached item reports `.readyToPlay`. Without this,
     /// the first `copyPixelBuffer(forItemTime:)` can race the decoder
@@ -129,22 +144,15 @@ final class VideoTextureOutput: NSObject, FlutterTexture, AVPlayerItemOutputPull
 
     // MARK: - Public API
 
-    /// Attaches the video output to a player item so frames can be
-    /// pulled from it.
-    func attach(to item: AVPlayerItem) {
-        // Remove the old output from the item it was actually added to.
-        if let old = videoOutput, let prev = attachedItem {
-            prev.remove(old)
-        }
-        itemStatusObservation?.invalidate()
-        itemStatusObservation = nil
-
-        // Request 32BGRA: Flutter's external-texture upload path expects
-        // a BGRA `CVPixelBuffer` and renders garbage / black on YpCbCr
-        // buffers. AVFoundation will color-convert 10-bit / HDR sources
-        // into BGRA for us — at the cost of HDR range, but that's the
-        // same tradeoff the official video_player plugin makes when it
-        // doesn't pass an explicit Metal renderer.
+    /// Builds an output configured for Flutter's external-texture path.
+    ///
+    /// Request 32BGRA: Flutter's external-texture upload path expects a BGRA
+    /// `CVPixelBuffer` and renders garbage / black on YpCbCr buffers.
+    /// AVFoundation will color-convert 10-bit / HDR sources into BGRA for us —
+    /// at the cost of HDR range, but that's the same tradeoff the official
+    /// video_player plugin makes when it doesn't pass an explicit Metal
+    /// renderer.
+    private func makeVideoOutput() -> AVPlayerItemVideoOutput {
         let attrs: [String: Any] = [
             kCVPixelBufferPixelFormatTypeKey as String:
                 kCVPixelFormatType_32BGRA,
@@ -152,10 +160,68 @@ final class VideoTextureOutput: NSObject, FlutterTexture, AVPlayerItemOutputPull
             // the GPU as a Flutter texture without an extra copy.
             kCVPixelBufferIOSurfacePropertiesKey as String: [:],
         ]
-        let output = AVPlayerItemVideoOutput(
-            pixelBufferAttributes: attrs
-        )
+        let output = AVPlayerItemVideoOutput(pixelBufferAttributes: attrs)
         output.setDelegate(self, queue: .main)
+        return output
+    }
+
+    /// Gives every item in [items] an output before it becomes current.
+    ///
+    /// Pass `AVPlayerLooper.loopingPlayerItems`. The looper cycles that same
+    /// small set, so after the first pass every lap finds its output already
+    /// attached and [attach] has nothing to build at the seam. Items the
+    /// looper no longer owns are dropped, so rebuilding the queue cannot pin
+    /// an old item's decoder for the life of the player.
+    func prewarm(items: [AVPlayerItem]) {
+        for entry in warmOutputs
+        where !items.contains(where: { $0 === entry.item }) && entry.item !== attachedItem {
+            entry.item.remove(entry.output)
+        }
+        warmOutputs.removeAll { entry in
+            !items.contains(where: { $0 === entry.item })
+        }
+
+        for item in items where !warmOutputs.contains(where: { $0.item === item }) {
+            // The current item already has one; adopt it rather than adding a
+            // second output to the same item.
+            if item === attachedItem, let existing = videoOutput {
+                warmOutputs.append((item: item, output: existing))
+                continue
+            }
+            let output = makeVideoOutput()
+            item.add(output)
+            warmOutputs.append((item: item, output: output))
+        }
+    }
+
+    /// Attaches the video output to a player item so frames can be
+    /// pulled from it.
+    func attach(to item: AVPlayerItem) {
+        itemStatusObservation?.invalidate()
+        itemStatusObservation = nil
+
+        // Already warmed by [prewarm] — adopt it. Nothing is torn down: the
+        // outgoing item keeps its own output so it is warm again when the
+        // looper comes back around to it.
+        if let warm = warmOutputs.first(where: { $0.item === item })?.output {
+            videoOutput = warm
+            attachedItem = item
+            pendingSeekTime = .invalid
+            mediaDataRearmCount = 0
+            lastDeliveredItemTime = .invalid
+            nextStallRecoveryTime = 0
+            warm.requestNotificationOfMediaDataChange(withAdvanceInterval: 0)
+            return
+        }
+
+        // Remove the old output from the item it was actually added to.
+        if let old = videoOutput,
+           let prev = attachedItem,
+           !warmOutputs.contains(where: { $0.item === prev }) {
+            prev.remove(old)
+        }
+
+        let output = makeVideoOutput()
         item.add(output)
         videoOutput = output
         attachedItem = item
@@ -315,6 +381,7 @@ final class VideoTextureOutput: NSObject, FlutterTexture, AVPlayerItemOutputPull
         itemStatusObservation?.invalidate()
         itemStatusObservation = nil
         registry.unregisterTexture(textureId)
+        warmOutputs.removeAll()
         videoOutput = nil
         latestPixelBuffer = nil
         onFirstFrame = nil

--- a/mobile/packages/divine_video_player/test/src/apple_direct_item_contract_test.dart
+++ b/mobile/packages/divine_video_player/test/src/apple_direct_item_contract_test.dart
@@ -2,27 +2,30 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
-/// An HLS `AVURLAsset` exposes no tracks — `loadTracks(withMediaType:)` returns
-/// an empty array — so an `AVMutableComposition` built from one always ends in
-/// `CompositionError.noPlayableVideoTracks` and can never play. A single HLS
-/// clip therefore has to bypass the composition entirely and be handed to
-/// `AVPlayerItem` directly.
+/// A single unchanged clip is handed to `AVPlayerItem` directly instead of
+/// being copied into an `AVMutableComposition`, for two separate reasons. An
+/// HLS `AVURLAsset` exposes no tracks — `loadTracks(withMediaType:)` returns an
+/// empty array — so a composition built from one always ends in
+/// `CompositionError.noPlayableVideoTracks` and can never play. A local file
+/// has nothing to compose, and `AVPlayerLooper` closes the loop seam over an
+/// asset while it does not over a composition of the same file.
 ///
 /// None of this has a Dart runtime surface, and the package has no Swift test
 /// harness, so the invariants are pinned as a source contract the same way the
-/// composition guards are: a refactor that routes HLS back through
+/// composition guards are: a refactor that routes these sources back through
 /// `buildComposition` keeps every runtime test green while restoring
-/// "No playable video tracks found." for every HLS source.
+/// "No playable video tracks found." for every HLS source and the loop seam
+/// for every local one.
 void main() {
-  group('Apple native HLS direct-item contract', () {
-    test('a single m3u8 clip is diverted away from the composition', () {
+  group('Apple native direct-item contract', () {
+    test('a single unchanged clip is diverted away from the composition', () {
       final source = _appleSourceFile().readAsStringSync();
 
       expect(
         source,
-        contains('soleHlsClip'),
+        contains('soleDirectItemClip'),
         reason:
-            'The HLS detection helper is what keeps an HLS source out of '
+            'The eligibility helper is what keeps a divertable source out of '
             'buildComposition.',
       );
       expect(
@@ -30,14 +33,22 @@ void main() {
         contains('pathExtension.lowercased() == "m3u8"'),
         reason:
             'Every app-constructed HLS URL ends in .m3u8, so the path '
-            'extension is the cheap deterministic signal for which builder '
-            'runs - no extra load to discover the asset has no tracks.',
+            'extension is the cheap deterministic signal that admits one - no '
+            'extra load to discover the asset has no tracks.',
+      );
+      expect(
+        source,
+        contains('return !uri.hasPrefix("http")'),
+        reason:
+            'A remote non-HLS URL keeps taking the composition, which owns the '
+            'buffering and header handling for it; only a local file joins HLS '
+            'on the direct path.',
       );
       expect(
         source,
         contains('clipsRaw.count == 1'),
         reason:
-            'Only a whole-timeline HLS source may skip the composition — a '
+            'Only a whole-timeline source may skip the composition — a '
             'multi-clip timeline still needs one to stitch.',
       );
       expect(
@@ -66,7 +77,7 @@ void main() {
             'so a clip with custom volume must keep taking that path.',
       );
 
-      final dispatch = source.indexOf('Self.soleHlsClip(in: clipsRaw)');
+      final dispatch = source.indexOf('Self.soleDirectItemClip(in: clipsRaw)');
       final compositionCall = source.indexOf(
         'makeCompositionPlayerItem(from: clipsRaw)',
       );
@@ -76,22 +87,22 @@ void main() {
         dispatch,
         lessThan(compositionCall),
         reason:
-            'The HLS check must gate the composition call, not follow it — '
-            'otherwise the composition is built first and throws.',
+            'The eligibility check must gate the composition call, not follow '
+            'it — otherwise the composition is built first and throws.',
       );
     });
 
-    test('the HLS builder never asks the asset for tracks', () {
+    test('the direct builder never demands tracks an HLS asset lacks', () {
       final body = _functionBody(
         _appleSourceFile().readAsStringSync(),
-        'private func makeHlsPlayerItem(',
+        'private func makeDirectPlayerItem(',
       );
 
-      // The path is no longer HLS-only: a single unchanged local file takes
-      // it too, and that one does need its tracks, both to decide rotation and
-      // to clamp the loop to the shorter track. HLS must survive that
-      // unchanged, and it can only do so if every track read is optional --
-      // loadTracks hands back an empty array for it.
+      // The path is not HLS-only: a single unchanged local file takes it too,
+      // and that one does need its tracks, both to decide rotation and to
+      // clamp the loop to the shorter track. HLS must survive that unchanged,
+      // and it can only do so if every track read is optional — loadTracks
+      // hands back an empty array for it.
       expect(
         body,
         isNot(
@@ -147,6 +158,14 @@ void main() {
         reason:
             'Gated HLS playback authenticates with a viewer-auth header, which '
             'is lost if the asset is built without the header options.',
+      );
+      expect(
+        body,
+        contains('loopAudioMix = nil'),
+        reason:
+            'A direct item has no audio mix, so a mix left behind by an '
+            'earlier composition would be re-applied to every item the looper '
+            'builds - with input parameters addressing another asset.',
       );
     });
   });

--- a/mobile/packages/divine_video_player/test/src/apple_hls_direct_item_contract_test.dart
+++ b/mobile/packages/divine_video_player/test/src/apple_hls_direct_item_contract_test.dart
@@ -87,17 +87,52 @@ void main() {
         'private func makeHlsPlayerItem(',
       );
 
+      // The path is no longer HLS-only: a single unchanged local file takes
+      // it too, and that one does need its tracks, both to decide rotation and
+      // to clamp the loop to the shorter track. HLS must survive that
+      // unchanged, and it can only do so if every track read is optional --
+      // loadTracks hands back an empty array for it.
       expect(
         body,
-        isNot(contains('loadTracks')),
+        isNot(
+          contains('let videoTrack = try await asset.loadTracks'),
+        ),
         reason:
-            'loadTracks returns an empty array for HLS. Reintroducing it here '
-            'is exactly the failure this path exists to avoid.',
+            'A non-optional track read would crash or throw for HLS, which '
+            'exposes none.',
+      );
+      expect(
+        body,
+        contains(
+          'if let videoTrack = videoTracks.first, '
+          'let audioTrack = audioTracks.first {',
+        ),
+        reason:
+            'The clamp may only run when both tracks are really there, so an '
+            'HLS source falls through it untouched.',
+      );
+      expect(
+        _functionBody(
+          _appleSourceFile().readAsStringSync(),
+          'private static func directItemSuitsRotation(',
+        ),
+        contains('if isHls { return true }'),
+        reason:
+            'The rotation check must short-circuit before it asks an HLS '
+            'asset for tracks it does not have.',
       );
       expect(
         body,
         contains('AVPlayerItem(asset: asset)'),
         reason: 'The item must come straight from the AVURLAsset.',
+      );
+      expect(
+        body,
+        contains('loopTimeRange'),
+        reason:
+            'AVPlayerLooper ignores forwardPlaybackEndTime when it wraps, so '
+            'a clip whose container outlives its picture needs the trim as the '
+            'looper range instead.',
       );
       expect(
         body,


### PR DESCRIPTION
Closes #8022

## Summary

Closes the loop seam a feed clip shows once per lap. Four separate causes sat behind that one symptom, each hiding the next, and they are split across the two platforms.


| Before | After (once backend fix is published) |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/eaf8c308-cffc-4736-9bf2-ec57aea25d65"></video> | <video src="https://github.com/user-attachments/assets/57f2e573-41b5-48b0-a7cd-446987228e8d"></video> |





**Apple**

- A single unchanged clip was copied into an `AVMutableComposition`, because the direct-item path only accepted `.m3u8`. `AVPlayerLooper` does not close the seam over a composition and does over the asset itself. Nothing was being composed — one clip, no trim, no speed or volume change.
- That path then ignored `trimToCommonTrackEnd`, which it had never needed while it only saw HLS. A clip whose container outlives its video track held its last frame across the gap: **86 ms per lap**, measured. The asset stays untouched here, so the trim goes to the looper as its loop range — `forwardPlaybackEndTime` bounds playback but the looper ignores it when it wraps.
- A rotated clip now falls back to the composition. `AVPlayerItemVideoOutput` applies no `preferredTransform`, and the Apple side sends Dart no rotation to compensate with, unlike Android — without the guard a portrait clip would arrive on its side.
- The direct path builds its URL with `URL(fileURLWithPath:)` for a bare path. `URL(string:)` yields a scheme-less URL `AVURLAsset` cannot load, which never showed while that path saw only HLS URLs.
- A trimmed direct clip sets `forwardPlaybackEndTime` as well as the looper's range. The looper owns the wrap, but a player that is not looping — or stops looping later — has only `forwardPlaybackEndTime` to end the item where Dart was told it ends; without it the whole asset played.
- The texture output's delegate callbacks act only for the output that is attached. Prewarming gives every looper item an output with the same delegate, so a queued item's flush reset the current output's bookkeeping and its media-data notification copied the next lap's first frame at the player's time, before the current lap had ended. The warm set is also pruned when looping is switched off, instead of holding the old looper's items and decoders until dispose.
- Adopting a prewarmed output re-arms the first-frame signal. A new clip set on a reused looping player finds its items already warm, and without the reset `onFirstFrame` never fired for the second video — on the texture path that callback is the only thing that flips `firstFrameRendered`, so Flutter kept its loader over a video that was decoding and playing normally.

**Android**

- While the media item carries an audio track, media3 drains and re-anchors its audio sink at every loop discontinuity, on the thread that also releases video frames. The same clip with its audio stripped loops cleanly. The audio now leaves the player: decoded once, repeated by a static `AudioTrack`, which wraps inside the HAL.
- The clipping configuration is skipped when it would cut nothing, so a clip needing no trim is not wrapped in a `ClippingMediaSource` for it.
- The loop track follows the player's actual playing state in `onIsPlayingChanged`, not only the play and pause Dart asks for. Backgrounding, a buffering stall and an Activity detach all pause the player by itself, and each left the track sounding over a still picture; on return the two had drifted apart. It takes the player's volume, which already folds in the clip's gain and is deliberately zero during the foreground frame flush. `stopForActivityDetach` releases the track outright.
- A single repeating clip uses `REPEAT_MODE_ONE`. Because that choice depends on how many clips are loaded, both `setLooping` and `setClips` apply it — the editor swaps its clip list without calling `setLooping` again, so a split would otherwise leave the player repeating its first clip forever.
- A loop the `AudioTrack` rejects is handed back to ExoPlayer. `setLoopPoints` reports failure in its return value, which was discarded; the renderer's own audio has already been taken away by then, so the clip would have played its sound once and gone silent for every later lap with nothing in the log to say why.
- A decode shorter than the picture is padded with silence to the presented length rather than cut back to what decoded. The picture loops at the presented duration whatever the sound does, and the track repeats in the HAL on its own clock, so a shorter audio loop separated from the picture by the difference every lap — on a feed clip whose audio track ends 1.7 s before its video track, a mismatch `trimToCommonTrackEnd` deliberately leaves alone as the creator's own, the sound restarted mid-picture from the first lap. The presented duration can be trusted for this because `ClippingTimeline` clips it to the source's own length; it is never a cap past the clip.
- The loop audio is cut again when the common-track-end clamp lands. On a feed player that clamp arrives from a background read and is parked until the next loop restart, and applying it replaced the media item without touching the audio — the picture shortened to the common track end, the sound kept the pre-clamp length, and the two looped at different periods from that lap on.
- The decoded PCM is placed where its first timestamp says, not at zero. A track whose sound starts after its picture — an initial empty edit, an audio `start_time` past zero in ffprobe — ran ahead by that offset every lap; and the AAC priming the extractor stamps before zero, 1024 frames on every feed clip, put the loop's audio 23 ms behind the picture. Leading silence for the one, a cut for the other — the same cut the player makes with gapless trimming on.
- The renderer gets its audio back on a one-second deadline when the loop decode has not landed. The decode shares the single metadata thread with the track-length reads, and a stalled remote read there left every clip behind it playing over silence with nothing to end it. A loop that lands after the deadline takes over at the next loop restart, or at once while nothing is playing. On an SM-S942B the decode lands in 190–390 ms, so the deadline is for the stall, not the common case.

## How the causes were separated

Each was ruled in or out on its own against a reference clip that loops flawlessly in a standalone prototype on the same devices, bundled and substituted for the feed's own videos so both sides played identical bytes (SHA-256 `796b82f0…`).

The decisive step was running the prototype's player inside this app, on a bare screen: it was clean, which cleared the app — the feed, the overlays, the memory pressure — and left our own player. Ours on the same bare screen still stalled, and stopped once the audio left it.

Ruled out along the way, each with its own run: the file, the clipping configuration, the repeat mode, the declick processor, the container's `mvhd` overhang, and the media clock — the audio position advances 1:1 with the frame gap at every wrap, so the picture was never waiting on it.

## Loop audio, and what it costs

The PCM is cut to the duration the **player** presents, read from ExoPlayer once its timeline is populated. A track's media duration ignores the edit list, and on a clip whose edit list was corrected the two differ — looping the sound on the media length walks it away from the picture a little every lap.

The seam is blended with the material past the loop point, which needs the decoder's gapless trimming switched off; that is the equivalent of ffmpeg's `-ignore_editlist`, and without it the decoder hands back exactly the presented length and leaves nothing to blend with. On the reference clip the sample step at the wrap drops from **1530 to 223**, below the clip's own median step of 1028. What looked like 22–34 ms past the loop on real CDN clips was the AAC priming the extractor stamps before zero, not material; placed by its timestamp it is cut, as the player cuts it. Whether a feed clip blends or ramps now depends on whether its audio track outlives the presented loop, and both occur in the feed.

Where a decode ends at the loop, or short of it, both ends ramp over 5 ms instead — the tail at the last decoded sample, with silence from there to the loop point. That kills the click and leaves the restart audible — worse, but honest. Folding the loop's own tail into its head was tried and is worse than either: the tail has to fade or it is heard twice, so the seam becomes a dip to near-silence followed by material that jumps back.

Taking the audio out of the player means the player's own lifecycle no longer moves it, so each point where it could drift had to be closed by hand. The loop length is read from the timeline it belongs to and not from the outgoing item a reused player still holds — every feed tile is a reused player, and reading it early cut the incoming video's sound to the previous video's length — and read again when the track-end clamp changes that timeline. A seek moves the track with the picture. Stop releases it rather than leaving it looping over a blank surface. An off-speed player keeps ExoPlayer's audio, because a static track has no stretcher; the Apple side already declined those clips. A decode that yields nothing hands the audio back rather than leaving the renderer switched off and the video silent for good, and a decode wider than stereo is declined rather than written to a stereo track as it stands.

Known and deliberate:

- **Each live player now allocates its own `AudioTrack`.** The feed keeps up to three. Memory and audio focus under that are untested.
- **The 30 ms declick fades no longer apply to single-clip loops**, since the audio leaves the ExoPlayer path they live on. Multi-clip timelines are unchanged.
- **Video and audio run on two clocks.** They start together, share a period by construction, and are re-anchored together on a seek, but nothing locks them between those points; this was not listened to over a long session.
- **Why a rotated clip rendered upright on Apple without the guard is unexplained.** The guard is right regardless — the mechanism that made it look unnecessary is not understood, so it was not relied on.

## Tests

`LoopPcmTest`, ten cases over the sample arithmetic — including the pad to the picture's period and the tail ramp at the decode's end — split out of `ClipAudioLoopTrack` so it could be reached at all. Each pins a rule that was got wrong at least once during this work, and every one of those mistakes was audible rather than visible in a log.

The Apple source contract was retargeted: that path is no longer HLS-only, so it may read tracks, but every read must stay optional and the rotation check must short-circuit before asking an HLS asset for tracks it has none of.

Seven further Kotlin tests cover the lifecycle points above: the loop length waiting for its own timeline, the loop audio cut again once a clamp has shortened the picture, the audio handed back when nothing decodes, the off-speed player keeping ExoPlayer's, the repeat mode following a clip list that grows, a self-pause pausing and resuming the loop track, and an Activity detach releasing it. Each was verified red with its fix reverted. Six more pin the review fixes: the PCM opening with silence for a late audio start, the priming cut for a start stamped before zero, a start past the loop refused, a decode held behind a stalled read handing the audio back on the deadline and taking over at the next restart, a late loop taking over at once while paused, and a loop that lands in time keeping the audio. Each red against a mutant of its fix.

Two source contracts pin the Apple side: the trimmed direct item sets `forwardPlaybackEndTime` and the looper range as one block, and the texture output ignores outputs that are not current and prunes its warm set without a looper. The direct-item contract's negative guard matched `videoTrack` where the source reads `videoTracks` and could never fail; it now pins the array read and rejects a forced unwrap or index into it. A third contract pins the first-frame reset to the warm-adopt branch of `attach(to:)` specifically, so the cold path's existing reset cannot satisfy it.

The three parked-clamp tests run on a feed-profile player. Since #9067 a full-profile player reads a remote source's track lengths before the load, so on the default instance nothing is parked and those tests had stopped describing anything.

116 Kotlin tests and 315 package tests green; `flutter analyze` clean; Android and iOS both build. The Apple sources typecheck for iOS and macOS through `darwin/test_diagnostics.sh` with the same three Swift 6 concurrency warnings `main` carries.

## Test plan

Verified on an iPhone 17 simulator and a physical Samsung SM-S942B, against the prototype side by side:

- reference clip, both platforms — seam closed, picture and sound
- real feed videos with every fix active — clean
- a fixture differing only by a 90° display matrix — upright, and the seam returns, which is the composition fallback firing
- a fixture with its audio track stripped — isolated the Android cause before the fix
- Samsung SM-S942B, a feed clip whose audio track ends 1.7 s before its video track (`202752` frames decoded against `6324 ms` presented): the sound stops where the file's does and restarts with the picture. Before, it restarted 1.7 s ahead of it, from the first lap.
- Samsung SM-S942B, feed playing, read through `dumpsys audio`: the loop track goes `started` → `paused` on Home and back to `started` on return, with the loop seam still closed by ear
- iPhone 17 Pro simulator (iOS 26.5), after rebasing onto `main` with #9153: the For You feed keeps the direct path and its loops run alongside the new native diagnostics — `disposedPlayers 0` and `pendingLoads 0` on every sample through seven swipes (`players`/`textures` steady at 3, each outgoing player `disposed`), a 90 s backgrounding (`playingPlayers` 1 → 0 → 1, `framesDelivered` frozen meanwhile) and the resume; no `native_player_resources_after_dispose`
- Samsung SM-S942B, feed with the review fixes: every feed clip decodes `from -23219 us` (a 48 kHz clip `-21333 us`) and drops its priming; a generated clip with its audio starting at 0.955 s decodes `from 955442 us` and opens with that much silence; no `handed audio back` warning across the session, `prepared → loop audio` 190–390 ms against the 1000 ms deadline; seam and sync verified by ear

## Not fixed here

Two transcoder defects remain in the files themselves and cannot be addressed in the client: divinevideo/divine-blossom#235, with a fix in flight at divinevideo/divine-blossom#236.





