### PR TITLE
feat(explore): keep sponsorship visible in fullscreen feeds

### DIFF
--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -749,7 +749,7 @@
   "exploreTabIntegratedApps": "Integrated Apps",
   "exploreFeaturedSponsoredBy": "Sponsored by {sponsor}",
   "@exploreFeaturedSponsoredBy": {
-    "description": "Commercial disclosure pinned above a sponsored featured collection's grid. This is a disclosure, not marketing copy: translate it so it clearly communicates commercial sponsorship rather than an editorial credit. Many languages may render this more naturally as a noun label than a prepositional phrase, or may need the brand name to lead. {sponsor} is a brand name supplied by the server and must not be translated.",
+    "description": "Commercial disclosure shown with a sponsored featured collection in grid and fullscreen views. This is a disclosure, not marketing copy: translate it so it clearly communicates commercial sponsorship rather than an editorial credit. Many languages may render this more naturally as a noun label than a prepositional phrase, or may need the brand name to lead. {sponsor} is a brand name supplied by the server and must not be translated.",
     "placeholders": {
       "sponsor": {
         "type": "String",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -2130,7 +2130,7 @@ abstract class AppLocalizations {
   /// **'Integrated Apps'**
   String get exploreTabIntegratedApps;
 
-  /// Commercial disclosure pinned above a sponsored featured collection's grid. This is a disclosure, not marketing copy: translate it so it clearly communicates commercial sponsorship rather than an editorial credit. Many languages may render this more naturally as a noun label than a prepositional phrase, or may need the brand name to lead. {sponsor} is a brand name supplied by the server and must not be translated.
+  /// Commercial disclosure shown with a sponsored featured collection in grid and fullscreen views. This is a disclosure, not marketing copy: translate it so it clearly communicates commercial sponsorship rather than an editorial credit. Many languages may render this more naturally as a noun label than a prepositional phrase, or may need the brand name to lead. {sponsor} is a brand name supplied by the server and must not be translated.
   ///
   /// In en, this message translates to:
   /// **'Sponsored by {sponsor}'**

--- a/mobile/lib/router/pooled_fullscreen_feed_route.dart
+++ b/mobile/lib/router/pooled_fullscreen_feed_route.dart
@@ -16,10 +16,7 @@ import 'package:openvine/widgets/profile/profile_video_feed_view.dart';
 /// discarded on page reload or mobile lifecycle restoration. When that
 /// happens, recover the selected video through its durable URL identity.
 /// Falls back to the home feed only for legacy URLs with no video identity.
-String? fullscreenFeedRedirect(
-  Object? extra, {
-  String? fallbackVideoId,
-}) {
+String? fullscreenFeedRedirect(Object? extra, {String? fallbackVideoId}) {
   if (extra is PooledFullscreenVideoFeedArgs ||
       extra is ProfilePooledFullscreenVideoFeedArgs) {
     return null;
@@ -43,6 +40,7 @@ Widget buildPooledFullscreenFeed(BuildContext context, GoRouterState state) {
       initialVideoId: extra.initialVideoId,
       initialStableId: extra.initialStableId,
       contextTitle: extra.contextTitle,
+      sponsorName: extra.sponsorName,
       trafficSource: extra.trafficSource,
       sourceDetail: extra.sourceDetail,
       autoOpenComments: extra.autoOpenComments,

--- a/mobile/lib/screens/explore/tabs/featured_videos_tab.dart
+++ b/mobile/lib/screens/explore/tabs/featured_videos_tab.dart
@@ -94,13 +94,22 @@ class _FeaturedVideosView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final sponsorName = featuredTabSponsorName(
+      config,
+      context.l10n.localeName,
+    );
     // The disclosure is pinned rather than scrolled into the grid, and sits
     // outside the videos state so it survives an empty or failed page: it
     // describes the tab's commercial arrangement, not its contents.
     return Column(
       children: [
-        _FeaturedPartnershipLine(config: config),
-        Expanded(child: _FeaturedVideosContent(config: config)),
+        _FeaturedPartnershipLine(sponsorName: sponsorName),
+        Expanded(
+          child: _FeaturedVideosContent(
+            config: config,
+            sponsorName: sponsorName,
+          ),
+        ),
       ],
     );
   }
@@ -110,15 +119,15 @@ class _FeaturedVideosView extends StatelessWidget {
 ///
 /// Renders nothing when the collection has no sponsor.
 class _FeaturedPartnershipLine extends StatelessWidget {
-  const _FeaturedPartnershipLine({required this.config});
+  const _FeaturedPartnershipLine({required this.sponsorName});
 
-  final FeaturedTabConfig config;
+  final String? sponsorName;
 
   @override
   Widget build(BuildContext context) {
-    final l10n = context.l10n;
-    final sponsor = featuredTabSponsorName(config, l10n.localeName);
+    final sponsor = sponsorName;
     if (sponsor == null) return const SizedBox.shrink();
+    final l10n = context.l10n;
 
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
@@ -138,9 +147,13 @@ class _FeaturedPartnershipLine extends StatelessWidget {
 }
 
 class _FeaturedVideosContent extends StatelessWidget {
-  const _FeaturedVideosContent({required this.config});
+  const _FeaturedVideosContent({
+    required this.config,
+    required this.sponsorName,
+  });
 
   final FeaturedTabConfig config;
+  final String? sponsorName;
 
   @override
   Widget build(BuildContext context) {
@@ -159,7 +172,11 @@ class _FeaturedVideosContent extends StatelessWidget {
       },
       builder: (context, state) {
         if (state.videos.isNotEmpty) {
-          return _FeaturedGrid(config: config, state: state);
+          return _FeaturedGrid(
+            config: config,
+            state: state,
+            sponsorName: sponsorName,
+          );
         }
 
         return switch (state.status) {
@@ -169,6 +186,7 @@ class _FeaturedVideosContent extends StatelessWidget {
           FeaturedTabVideosStatus.ready => _FeaturedGrid(
             config: config,
             state: state,
+            sponsorName: sponsorName,
           ),
         };
       },
@@ -177,10 +195,15 @@ class _FeaturedVideosContent extends StatelessWidget {
 }
 
 class _FeaturedGrid extends ConsumerWidget {
-  const _FeaturedGrid({required this.config, required this.state});
+  const _FeaturedGrid({
+    required this.config,
+    required this.state,
+    required this.sponsorName,
+  });
 
   final FeaturedTabConfig config;
   final FeaturedTabVideosState state;
+  final String? sponsorName;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -199,6 +222,7 @@ class _FeaturedGrid extends ConsumerWidget {
           feedRepository: ref.read(feedRepositoryProvider),
           initialIndex: index,
           initialVideoId: videos[index].id,
+          sponsorName: sponsorName,
           trafficSource: ViewTrafficSource.discoveryFeatured,
           sourceDetail: config.id,
         ),

--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -41,6 +41,7 @@ import 'package:openvine/widgets/feed_tuning/feed_tuning_swipe_overlay.dart';
 import 'package:openvine/widgets/nav_rounded_shell.dart';
 import 'package:openvine/widgets/video_feed_item/feed_immersive_chrome.dart';
 import 'package:openvine/widgets/video_feed_item/feed_videos.dart';
+import 'package:openvine/widgets/video_feed_item/fullscreen_sponsor_disclosure.dart';
 import 'package:openvine/widgets/video_feed_item/inline_comment_composer_bar.dart';
 import 'package:openvine/widgets/video_feed_item/reaction_overlay.dart';
 import 'package:openvine/widgets/video_feed_item/reel_dm_reply_bar.dart';
@@ -73,6 +74,7 @@ class PooledFullscreenVideoFeedArgs {
     this.initialVideoId,
     this.initialStableId,
     this.contextTitle,
+    this.sponsorName,
     this.trafficSource = ViewTrafficSource.unknown,
     this.sourceDetail,
     this.autoOpenComments = false,
@@ -98,6 +100,9 @@ class PooledFullscreenVideoFeedArgs {
 
   /// Optional title for context display.
   final String? contextTitle;
+
+  /// Already sanitized and clamped sponsor; null for non-sponsored feeds.
+  final String? sponsorName;
 
   /// Traffic source for view event analytics.
   final ViewTrafficSource trafficSource;
@@ -176,6 +181,7 @@ class PooledFullscreenVideoFeedScreen extends ConsumerWidget {
     this.initialVideoId,
     this.initialStableId,
     this.contextTitle,
+    this.sponsorName,
     this.trafficSource = ViewTrafficSource.unknown,
     this.sourceDetail,
     this.autoOpenComments = false,
@@ -194,6 +200,9 @@ class PooledFullscreenVideoFeedScreen extends ConsumerWidget {
   final String? initialVideoId;
   final String? initialStableId;
   final String? contextTitle;
+
+  /// Already sanitized and clamped sponsor; null for non-sponsored feeds.
+  final String? sponsorName;
   final ViewTrafficSource trafficSource;
   final String? sourceDetail;
 
@@ -338,6 +347,7 @@ class PooledFullscreenVideoFeedScreen extends ConsumerWidget {
       ],
       child: FullscreenFeedContent(
         contextTitle: contextTitle,
+        sponsorName: sponsorName,
         trafficSource: trafficSource,
         sourceDetail: sourceDetail,
         autoOpenComments: autoOpenComments,
@@ -359,6 +369,7 @@ class FullscreenFeedContent extends ConsumerStatefulWidget {
   @visibleForTesting
   const FullscreenFeedContent({
     this.contextTitle,
+    this.sponsorName,
     this.trafficSource = ViewTrafficSource.unknown,
     this.sourceDetail,
     this.autoOpenComments = false,
@@ -370,6 +381,9 @@ class FullscreenFeedContent extends ConsumerStatefulWidget {
 
   /// Optional title for context display.
   final String? contextTitle;
+
+  /// Already sanitized and clamped sponsor; null for non-sponsored feeds.
+  final String? sponsorName;
 
   /// Traffic source for view event analytics.
   final ViewTrafficSource trafficSource;
@@ -1013,6 +1027,22 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
                           ),
                       ],
                     ),
+                    if (widget.sponsorName case final sponsorName?)
+                      PositionedDirectional(
+                        top:
+                            MediaQuery.paddingOf(context).top +
+                            appBar.preferredSize.height +
+                            8,
+                        start: 16,
+                        end: 16,
+                        child: FeedImmersiveChrome(
+                          child: TextFieldTapRegion(
+                            child: FullscreenSponsorDisclosure(
+                              sponsorName: sponsorName,
+                            ),
+                          ),
+                        ),
+                      ),
                     // Full-screen TikTok/IG-style reaction pop, centered over
                     // the reel.
                     if (_reactionEmoji != null)

--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -60,6 +60,24 @@ Alignment fullscreenVideoMediaAlignment({required bool isPortrait}) {
   return Alignment.center;
 }
 
+/// Leading inset that clears the app bar's back button.
+///
+/// The disclosure sits on the app bar's own row, to the right of the back
+/// button, so it starts past that button's tap target.
+const double _sponsorDisclosureStartInset = 64;
+
+/// Trailing inset that clears the app bar's overflow button.
+const double _sponsorDisclosureEndInset = 64;
+
+/// Height of a single-line disclosure: [VineTheme.bodyTinyFont]'s 14pt line
+/// box, plus 6pt of padding above and below.
+///
+/// Used only to centre the first line against the back button. The disclosure
+/// is deliberately not height-constrained to the bar — a long sponsor name, or
+/// a large system text size, wraps downward over the video rather than clip,
+/// because a clipped disclosure has stopped disclosing.
+const double _sponsorDisclosureLineHeight = 26;
+
 /// Arguments for navigating to PooledFullscreenVideoFeedScreen.
 ///
 /// The feed is described by a [source] and resolved through a
@@ -1037,10 +1055,11 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
                       PositionedDirectional(
                         top:
                             MediaQuery.paddingOf(context).top +
-                            appBar.preferredSize.height +
-                            8,
-                        start: 16,
-                        end: 16,
+                            (appBar.preferredSize.height -
+                                    _sponsorDisclosureLineHeight) /
+                                2,
+                        start: _sponsorDisclosureStartInset,
+                        end: _sponsorDisclosureEndInset,
                         child: TextFieldTapRegion(
                           child: FullscreenSponsorDisclosure(
                             sponsorName: sponsorName,

--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -1027,6 +1027,12 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
                           ),
                       ],
                     ),
+                    // Deliberately not wrapped in [FeedImmersiveChrome]: every
+                    // other chrome layer fades while the viewer holds the
+                    // video, but a commercial disclosure has to stay up for
+                    // the whole reel. It keeps the app bar's slot height as
+                    // its offset even once that bar has faded, so the pill
+                    // does not jump when immersive mode toggles.
                     if (widget.sponsorName case final sponsorName?)
                       PositionedDirectional(
                         top:
@@ -1035,11 +1041,9 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
                             8,
                         start: 16,
                         end: 16,
-                        child: FeedImmersiveChrome(
-                          child: TextFieldTapRegion(
-                            child: FullscreenSponsorDisclosure(
-                              sponsorName: sponsorName,
-                            ),
+                        child: TextFieldTapRegion(
+                          child: FullscreenSponsorDisclosure(
+                            sponsorName: sponsorName,
                           ),
                         ),
                       ),

--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -3,12 +3,14 @@
 // ABOUTME: Uses FullscreenFeedBloc for state management
 
 import 'dart:async';
+import 'dart:math' as math;
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:feed_repository/feed_repository.dart';
 import 'package:feed_tuning_repository/feed_tuning_repository.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart' show OrdinalSortKey;
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:models/models.dart';
@@ -60,23 +62,20 @@ Alignment fullscreenVideoMediaAlignment({required bool isPortrait}) {
   return Alignment.center;
 }
 
-/// Leading inset that clears the app bar's back button.
-///
-/// The disclosure sits on the app bar's own row, to the right of the back
-/// button, so it starts past that button's tap target.
-const double _sponsorDisclosureStartInset = 64;
+/// Clears both the expanded leading slot and the scaled back-button target.
+double _sponsorDisclosureStartInset(
+  BuildContext context,
+  DiVineAppBarStyle style,
+) => math.max(
+  style.leadingWidth,
+  style.horizontalPadding + DivineIcon.scaleSize(context, 48),
+);
 
-/// Trailing inset that clears the app bar's overflow button.
-const double _sponsorDisclosureEndInset = 64;
-
-/// Height of a single-line disclosure: [VineTheme.bodyTinyFont]'s 14pt line
-/// box, plus 6pt of padding above and below.
-///
-/// Used only to centre the first line against the back button. The disclosure
-/// is deliberately not height-constrained to the bar — a long sponsor name, or
-/// a large system text size, wraps downward over the video rather than clip,
-/// because a clipped disclosure has stopped disclosing.
-const double _sponsorDisclosureLineHeight = 26;
+/// Clears the scaled trailing action target plus its app-bar edge padding.
+double _sponsorDisclosureEndInset(
+  BuildContext context,
+  DiVineAppBarStyle style,
+) => style.horizontalPadding + DivineIcon.scaleSize(context, 48);
 
 /// Arguments for navigating to PooledFullscreenVideoFeedScreen.
 ///
@@ -845,6 +844,21 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
                   currentUserPubkey != null &&
                   state.currentVideo != null;
 
+              final appBarStyle = DiVineAppBarStyle.overMediaStyle.copyWith(
+                horizontalPadding: 12,
+                // With the default 48 px icon button and 12 px
+                // [horizontalPadding], a 72 px leading slot leaves
+                // 12 px between the back button's right edge and
+                // the title text (72 − 12 − 48 = 12).
+                leadingWidth: 72,
+                // Figma `title/medium` token (Bricolage Grotesque
+                // 800, 16 / 24 / 0.15) — overrides the default
+                // [VineTheme.titleLargeFont] (22) used by the
+                // shared app bar.
+                titleStyle: VineTheme.titleMediumFont(
+                  color: VineTheme.whiteText,
+                ),
+              );
               final appBar = DiVineAppBar(
                 title: widget.contextTitle ?? '',
                 showBackButton: true,
@@ -860,21 +874,7 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
                 // video so a small icon hit-target is easy to miss.
                 expandLeadingHitArea: true,
                 customActions: [FeedSettingsMenu(video: state.currentVideo)],
-                style: DiVineAppBarStyle.overMediaStyle.copyWith(
-                  horizontalPadding: 12,
-                  // With the default 48 px icon button and 12 px
-                  // [horizontalPadding], a 72 px leading slot leaves
-                  // 12 px between the back button's right edge and
-                  // the title text (72 − 12 − 48 = 12).
-                  leadingWidth: 72,
-                  // Figma `title/medium` token (Bricolage Grotesque
-                  // 800, 16 / 24 / 0.15) — overrides the default
-                  // [VineTheme.titleLargeFont] (22) used by the
-                  // shared app bar.
-                  titleStyle: VineTheme.titleMediumFont(
-                    color: VineTheme.whiteText,
-                  ),
-                ),
+                style: appBarStyle,
               );
 
               return Scaffold(
@@ -925,125 +925,134 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
                 // already-`extendBodyBehindAppBar` body expects.
                 appBar: PreferredSize(
                   preferredSize: appBar.preferredSize,
-                  child: FeedImmersiveChrome(
-                    child: TextFieldTapRegion(child: appBar),
+                  child: Semantics(
+                    sortKey: const OrdinalSortKey(0),
+                    child: FeedImmersiveChrome(
+                      child: TextFieldTapRegion(child: appBar),
+                    ),
                   ),
                 ),
                 body: Stack(
                   children: [
-                    Column(
-                      children: [
-                        Expanded(
-                          // Match the home feed: when the comment bar is on
-                          // screen, the video carries the same rounded
-                          // bottom corners as `video_feed_page.dart`, so
-                          // the corners reveal the semantic nav surface (the
-                          // outer color [NavRoundedShell] paints). It
-                          // shares its hex (`#00150D`) with the comment
-                          // bar's [VineTheme.surfaceBackground], so the
-                          // rounded cutouts seam continuously into the bar.
-                          child: Stack(
-                            children: [
-                              FeedTuningSwipeGate(
-                                enabled: feedTuningEnabled,
-                                onTuned: _onTuned,
-                                child: VideoTapShield(
-                                  child: _MaybeRoundFeedBottom(
-                                    roundCorners: showCommentBar,
-                                    child: MediaQuery.removePadding(
-                                      context: context,
-                                      removeBottom: true,
-                                      child: FeedVideos(
-                                        key: _feedVideosKey,
-                                        // Pause the reel while the DM reply composer
-                                        // is focused so it doesn't play under the
-                                        // keyboard.
-                                        isActive: !_replyComposerFocused,
-                                        videos: state.videos,
-                                        contextTitle: widget.contextTitle,
-                                        currentIndex: state.currentIndex,
-                                        hasMore: state.canLoadMore,
-                                        isLoadingMore: state.isLoadingMore,
-                                        trafficSource: widget.trafficSource,
-                                        sourceDetail: widget.sourceDetail,
-                                        onActiveVideoChanged: (video, index) {
-                                          ref
-                                              .read(
-                                                foregroundFeedActivityGateProvider,
-                                              )
-                                              .markActive();
-                                          _resumeAutoAdvanceAfterSwipe();
-                                          ref
-                                              .read(
-                                                feedPerformanceTrackerProvider,
-                                              )
-                                              .startVideoSwipeTracking(
-                                                video.id,
-                                              );
-                                          context
-                                              .read<FullscreenFeedBloc>()
-                                              .add(
-                                                FullscreenFeedIndexChanged(
-                                                  index,
-                                                ),
-                                              );
-                                          widget.onPageChanged?.call(index);
-                                        },
-                                        onNearEnd: () {
-                                          if (state.canLoadMore) {
-                                            _triggerLoadMore();
-                                          }
-                                        },
+                    Semantics(
+                      sortKey: const OrdinalSortKey(2),
+                      child: Column(
+                        children: [
+                          Expanded(
+                            // Match the home feed: when the comment bar is on
+                            // screen, the video carries the same rounded
+                            // bottom corners as `video_feed_page.dart`, so
+                            // the corners reveal the semantic nav surface (the
+                            // outer color [NavRoundedShell] paints). It
+                            // shares its hex (`#00150D`) with the comment
+                            // bar's [VineTheme.surfaceBackground], so the
+                            // rounded cutouts seam continuously into the bar.
+                            child: Stack(
+                              children: [
+                                FeedTuningSwipeGate(
+                                  enabled: feedTuningEnabled,
+                                  onTuned: _onTuned,
+                                  child: VideoTapShield(
+                                    child: _MaybeRoundFeedBottom(
+                                      roundCorners: showCommentBar,
+                                      child: MediaQuery.removePadding(
+                                        context: context,
+                                        removeBottom: true,
+                                        child: FeedVideos(
+                                          key: _feedVideosKey,
+                                          // Pause the reel while the DM reply composer
+                                          // is focused so it doesn't play under the
+                                          // keyboard.
+                                          isActive: !_replyComposerFocused,
+                                          videos: state.videos,
+                                          contextTitle: widget.contextTitle,
+                                          currentIndex: state.currentIndex,
+                                          hasMore: state.canLoadMore,
+                                          isLoadingMore: state.isLoadingMore,
+                                          trafficSource: widget.trafficSource,
+                                          sourceDetail: widget.sourceDetail,
+                                          onActiveVideoChanged: (video, index) {
+                                            ref
+                                                .read(
+                                                  foregroundFeedActivityGateProvider,
+                                                )
+                                                .markActive();
+                                            _resumeAutoAdvanceAfterSwipe();
+                                            ref
+                                                .read(
+                                                  feedPerformanceTrackerProvider,
+                                                )
+                                                .startVideoSwipeTracking(
+                                                  video.id,
+                                                );
+                                            context
+                                                .read<FullscreenFeedBloc>()
+                                                .add(
+                                                  FullscreenFeedIndexChanged(
+                                                    index,
+                                                  ),
+                                                );
+                                            widget.onPageChanged?.call(index);
+                                          },
+                                          onNearEnd: () {
+                                            if (state.canLoadMore) {
+                                              _triggerLoadMore();
+                                            }
+                                          },
+                                        ),
                                       ),
                                     ),
                                   ),
                                 ),
-                              ),
-                              Positioned(
-                                left: 0,
-                                right: 0,
-                                bottom: 16,
-                                child: LoadingMorePill(
-                                  isVisible:
-                                      state.isLoadingMore &&
-                                      state.currentIndex >=
-                                          state.videos.length - 1,
+                                Positioned(
+                                  left: 0,
+                                  right: 0,
+                                  bottom: 16,
+                                  child: LoadingMorePill(
+                                    isVisible:
+                                        state.isLoadingMore &&
+                                        state.currentIndex >=
+                                            state.videos.length - 1,
+                                  ),
                                 ),
-                              ),
-                            ],
-                          ),
-                        ),
-                        if (showCommentBar)
-                          InlineCommentComposerBar(
-                            onFocusChanged: (focused) {
-                              if (mounted &&
-                                  focused != _inlineComposerFocused) {
-                                setState(
-                                  () => _inlineComposerFocused = focused,
-                                );
-                              }
-                            },
-                          ),
-                        if (showDmReplyBar)
-                          ReelReplyBridge(
-                            setComposerFocused: (focused) {
-                              if (mounted && focused != _replyComposerFocused) {
-                                setState(() => _replyComposerFocused = focused);
-                              }
-                            },
-                            playReaction: (emoji) {
-                              if (mounted) {
-                                setState(() {
-                                  _reactionEmoji = emoji;
-                                  _reactionNonce++;
-                                });
-                              }
-                            },
-                            child: ReelDmReplyBarHost(
-                              dmReplyContext: widget.dmReplyContext!,
+                              ],
                             ),
                           ),
-                      ],
+                          if (showCommentBar)
+                            InlineCommentComposerBar(
+                              onFocusChanged: (focused) {
+                                if (mounted &&
+                                    focused != _inlineComposerFocused) {
+                                  setState(
+                                    () => _inlineComposerFocused = focused,
+                                  );
+                                }
+                              },
+                            ),
+                          if (showDmReplyBar)
+                            ReelReplyBridge(
+                              setComposerFocused: (focused) {
+                                if (mounted &&
+                                    focused != _replyComposerFocused) {
+                                  setState(
+                                    () => _replyComposerFocused = focused,
+                                  );
+                                }
+                              },
+                              playReaction: (emoji) {
+                                if (mounted) {
+                                  setState(() {
+                                    _reactionEmoji = emoji;
+                                    _reactionNonce++;
+                                  });
+                                }
+                              },
+                              child: ReelDmReplyBarHost(
+                                dmReplyContext: widget.dmReplyContext!,
+                              ),
+                            ),
+                        ],
+                      ),
                     ),
                     // Deliberately not wrapped in [FeedImmersiveChrome]: every
                     // other chrome layer fades while the viewer holds the
@@ -1056,13 +1065,21 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
                         top:
                             MediaQuery.paddingOf(context).top +
                             (appBar.preferredSize.height -
-                                    _sponsorDisclosureLineHeight) /
+                                    FullscreenSponsorDisclosure.singleLineHeight(
+                                      context,
+                                    )) /
                                 2,
-                        start: _sponsorDisclosureStartInset,
-                        end: _sponsorDisclosureEndInset,
-                        child: TextFieldTapRegion(
-                          child: FullscreenSponsorDisclosure(
-                            sponsorName: sponsorName,
+                        start: _sponsorDisclosureStartInset(
+                          context,
+                          appBarStyle,
+                        ),
+                        end: _sponsorDisclosureEndInset(context, appBarStyle),
+                        child: IgnorePointer(
+                          child: Semantics(
+                            sortKey: const OrdinalSortKey(1),
+                            child: FullscreenSponsorDisclosure(
+                              sponsorName: sponsorName,
+                            ),
                           ),
                         ),
                       ),

--- a/mobile/lib/widgets/video_feed_item/fullscreen_sponsor_disclosure.dart
+++ b/mobile/lib/widgets/video_feed_item/fullscreen_sponsor_disclosure.dart
@@ -11,11 +11,19 @@ import 'package:openvine/l10n/l10n.dart';
 /// surface. The text deliberately has no line ceiling so the disclosure stays
 /// complete at large system text sizes.
 ///
-/// The scrim is sized for the worst frame rather than the average one: a
-/// disclosure has to stay readable over a blown-out white shot, not just over
-/// the dark footage most reels open on. At [VineTheme.scrim80] white text
-/// clears 12.6:1 against a pure-white frame; the 50% scrim this started at
-/// was 4.0:1, under the 4.5:1 bar for 12px text.
+/// The scrim matches the app bar's own icon buttons ([VineTheme.scrim15], the
+/// `0x26000000` those buttons use in transparent mode) so the disclosure reads
+/// as part of the top chrome rather than as something dropped on the video.
+///
+/// That fill was chosen for an icon, and an icon is a thick shape that carries
+/// itself; text is thin strokes. At 15% the scrim measures 1.4:1 against a
+/// pure-white shot, so it is [_glyphShadows], not the box, that keeps this
+/// readable over a bright frame.
+///
+/// It is deliberately small and quiet rather than sized like a control. This
+/// is the one chrome layer that survives immersive viewing, so it is the only
+/// thing on screen while the viewer holds the video — heavy enough to read on
+/// any frame, light enough not to become the subject.
 class FullscreenSponsorDisclosure extends StatelessWidget {
   const FullscreenSponsorDisclosure({required this.sponsorName, super.key});
 
@@ -27,17 +35,34 @@ class FullscreenSponsorDisclosure extends StatelessWidget {
       alignment: AlignmentDirectional.centerStart,
       child: DecoratedBox(
         decoration: BoxDecoration(
-          color: VineTheme.scrim80,
-          borderRadius: BorderRadius.circular(16),
+          color: VineTheme.scrim15,
+          borderRadius: BorderRadius.circular(12),
         ),
         child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
           child: Text(
             context.l10n.exploreFeaturedSponsoredBy(sponsorName),
-            style: VineTheme.labelMediumFont(color: VineTheme.whiteText),
+            style: VineTheme.bodyTinyFont(
+              color: VineTheme.whiteText,
+            ).copyWith(shadows: _glyphShadows),
           ),
         ),
       ),
     );
   }
 }
+
+/// Carries the legibility the chrome-matched scrim does not provide on its own.
+///
+/// Contrast against a scrim is one number for the whole box; a shadow works at
+/// the glyph edge instead, which is where reading actually happens. The tight
+/// shadow separates the letters from whatever sits directly behind them and
+/// the wider one lifts the whole word off a bright frame.
+///
+/// Deliberately heavier than the single `shadow25` blur that `caption_pill`
+/// uses over the same video. A caption that loses a word to a bright frame is
+/// a cosmetic problem; a disclosure that does has stopped disclosing.
+const _glyphShadows = <Shadow>[
+  Shadow(color: VineTheme.scrim80, blurRadius: 4, offset: Offset(0, 1)),
+  Shadow(color: VineTheme.scrim50, blurRadius: 12),
+];

--- a/mobile/lib/widgets/video_feed_item/fullscreen_sponsor_disclosure.dart
+++ b/mobile/lib/widgets/video_feed_item/fullscreen_sponsor_disclosure.dart
@@ -11,14 +11,9 @@ import 'package:openvine/l10n/l10n.dart';
 /// surface. The text deliberately has no line ceiling so the disclosure stays
 /// complete at large system text sizes.
 ///
-/// The scrim matches the app bar's own icon buttons ([VineTheme.scrim15], the
-/// `0x26000000` those buttons use in transparent mode) so the disclosure reads
-/// as part of the top chrome rather than as something dropped on the video.
-///
-/// That fill was chosen for an icon, and an icon is a thick shape that carries
-/// itself; text is thin strokes. At 15% the scrim measures 1.4:1 against a
-/// pure-white shot, so it is [_glyphShadows], not the box, that keeps this
-/// readable over a bright frame.
+/// The scrim is sized for the brightest frame rather than the average one.
+/// At [VineTheme.scrim65], white text clears 7:1 against a pure-white shot,
+/// while remaining quieter than the 80% media-chrome treatment.
 ///
 /// It is deliberately small and quiet rather than sized like a control. This
 /// is the one chrome layer that survives immersive viewing, so it is the only
@@ -27,7 +22,25 @@ import 'package:openvine/l10n/l10n.dart';
 class FullscreenSponsorDisclosure extends StatelessWidget {
   const FullscreenSponsorDisclosure({required this.sponsorName, super.key});
 
+  /// Horizontal padding around the localized disclosure text.
+  static const horizontalPadding = 10.0;
+
+  /// Vertical padding around the localized disclosure text.
+  static const verticalPadding = 6.0;
+
   final String sponsorName;
+
+  /// Height of one line plus its vertical padding at the current text scale.
+  ///
+  /// The fullscreen feed uses this only to center the first line in the app
+  /// bar row; wrapped lines continue downward over the video without clipping.
+  static double singleLineHeight(BuildContext context) {
+    final style = VineTheme.bodyTinyFont();
+    final scaledFontSize = MediaQuery.textScalerOf(
+      context,
+    ).scale(style.fontSize!);
+    return scaledFontSize * style.height! + verticalPadding * 2;
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -35,11 +48,14 @@ class FullscreenSponsorDisclosure extends StatelessWidget {
       alignment: AlignmentDirectional.centerStart,
       child: DecoratedBox(
         decoration: BoxDecoration(
-          color: VineTheme.scrim15,
+          color: VineTheme.scrim65,
           borderRadius: BorderRadius.circular(12),
         ),
         child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+          padding: const EdgeInsets.symmetric(
+            horizontal: horizontalPadding,
+            vertical: verticalPadding,
+          ),
           child: Text(
             context.l10n.exploreFeaturedSponsoredBy(sponsorName),
             style: VineTheme.bodyTinyFont(
@@ -52,12 +68,11 @@ class FullscreenSponsorDisclosure extends StatelessWidget {
   }
 }
 
-/// Carries the legibility the chrome-matched scrim does not provide on its own.
+/// Adds local edge separation on top of the contrast-compliant scrim.
 ///
-/// Contrast against a scrim is one number for the whole box; a shadow works at
-/// the glyph edge instead, which is where reading actually happens. The tight
-/// shadow separates the letters from whatever sits directly behind them and
-/// the wider one lifts the whole word off a bright frame.
+/// The scrim carries the required contrast. The tight shadow separates the
+/// letters from detail immediately behind them and the wider one lifts the
+/// whole word off visually busy footage.
 ///
 /// Deliberately heavier than the single `shadow25` blur that `caption_pill`
 /// uses over the same video. A caption that loses a word to a bright frame is

--- a/mobile/lib/widgets/video_feed_item/fullscreen_sponsor_disclosure.dart
+++ b/mobile/lib/widgets/video_feed_item/fullscreen_sponsor_disclosure.dart
@@ -1,0 +1,37 @@
+// ABOUTME: Readable sponsorship disclosure for fullscreen video feeds.
+// ABOUTME: Uses fixed over-video chrome and allows text to wrap without clipping.
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:openvine/l10n/l10n.dart';
+
+/// A scrim-backed sponsorship label rendered over fullscreen video.
+///
+/// [sponsorName] must already be sanitized and clamped by the launching
+/// surface. The text deliberately has no line ceiling so the disclosure stays
+/// complete at large system text sizes.
+class FullscreenSponsorDisclosure extends StatelessWidget {
+  const FullscreenSponsorDisclosure({required this.sponsorName, super.key});
+
+  final String sponsorName;
+
+  @override
+  Widget build(BuildContext context) {
+    return Align(
+      alignment: AlignmentDirectional.centerStart,
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: VineTheme.scrim50,
+          borderRadius: BorderRadius.circular(16),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+          child: Text(
+            context.l10n.exploreFeaturedSponsoredBy(sponsorName),
+            style: VineTheme.labelMediumFont(color: VineTheme.whiteText),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/widgets/video_feed_item/fullscreen_sponsor_disclosure.dart
+++ b/mobile/lib/widgets/video_feed_item/fullscreen_sponsor_disclosure.dart
@@ -35,7 +35,7 @@ class FullscreenSponsorDisclosure extends StatelessWidget {
   /// The fullscreen feed uses this only to center the first line in the app
   /// bar row; wrapped lines continue downward over the video without clipping.
   static double singleLineHeight(BuildContext context) {
-    final style = VineTheme.bodyTinyFont();
+    final style = VineTheme.bodyTinyFont(color: VineTheme.whiteText);
     final scaledFontSize = MediaQuery.textScalerOf(
       context,
     ).scale(style.fontSize!);

--- a/mobile/lib/widgets/video_feed_item/fullscreen_sponsor_disclosure.dart
+++ b/mobile/lib/widgets/video_feed_item/fullscreen_sponsor_disclosure.dart
@@ -10,6 +10,12 @@ import 'package:openvine/l10n/l10n.dart';
 /// [sponsorName] must already be sanitized and clamped by the launching
 /// surface. The text deliberately has no line ceiling so the disclosure stays
 /// complete at large system text sizes.
+///
+/// The scrim is sized for the worst frame rather than the average one: a
+/// disclosure has to stay readable over a blown-out white shot, not just over
+/// the dark footage most reels open on. At [VineTheme.scrim80] white text
+/// clears 12.6:1 against a pure-white frame; the 50% scrim this started at
+/// was 4.0:1, under the 4.5:1 bar for 12px text.
 class FullscreenSponsorDisclosure extends StatelessWidget {
   const FullscreenSponsorDisclosure({required this.sponsorName, super.key});
 
@@ -21,7 +27,7 @@ class FullscreenSponsorDisclosure extends StatelessWidget {
       alignment: AlignmentDirectional.centerStart,
       child: DecoratedBox(
         decoration: BoxDecoration(
-          color: VineTheme.scrim50,
+          color: VineTheme.scrim80,
           borderRadius: BorderRadius.circular(16),
         ),
         child: Padding(

--- a/mobile/packages/divine_ui/lib/src/theme/vine_theme.dart
+++ b/mobile/packages/divine_ui/lib/src/theme/vine_theme.dart
@@ -779,6 +779,20 @@ class VineTheme {
     fontFeatures: fontFeatures,
   );
 
+  /// Body tiny: Inter 400 10/14/0.4
+  ///
+  /// The smallest type the design system offers, for supporting text that has
+  /// to be present without competing — a commercial disclosure over video, for
+  /// example. Regular weight by design: at this size the 600 of the `label`
+  /// family reads as shouting.
+  static TextStyle bodyTinyFont({Color? color}) => GoogleFonts.inter(
+    fontSize: 10,
+    fontWeight: FontWeight.w400,
+    height: 14 / 10,
+    letterSpacing: 0.4,
+    color: color,
+  );
+
   // --------------------------------------------------------------------------
   // Label styles (Inter, weight 600)
   // --------------------------------------------------------------------------

--- a/mobile/packages/divine_ui/test/src/divine_ui_test.dart
+++ b/mobile/packages/divine_ui/test/src/divine_ui_test.dart
@@ -601,6 +601,21 @@ void main() {
         expect(style.fontSize, 12);
         expect(style.fontWeight, FontWeight.w400);
       });
+
+      testWidgets('bodyTinyFont returns correct style', (tester) async {
+        final style = VineTheme.bodyTinyFont();
+        expect(style.fontSize, 10);
+        expect(style.fontWeight, FontWeight.w400);
+        expect(style.height, 14 / 10);
+        expect(style.letterSpacing, 0.4);
+      });
+
+      testWidgets('bodyTinyFont is the smallest body size', (tester) async {
+        expect(
+          VineTheme.bodyTinyFont().fontSize,
+          lessThan(VineTheme.bodySmallFont().fontSize!),
+        );
+      });
     });
 
     group('typography - label fonts', () {

--- a/mobile/test/router/fullscreen_feed_redirect_test.dart
+++ b/mobile/test/router/fullscreen_feed_redirect_test.dart
@@ -22,15 +22,23 @@ VideoEvent _video(String id) => VideoEvent(
 
 class _RestoredPooledFeedState extends Fake implements GoRouterState {
   _RestoredPooledFeedState(String videoId)
-    : uri = Uri.parse(
-        PooledFullscreenVideoFeedScreen.pathForVideoId(videoId),
-      );
+    : uri = Uri.parse(PooledFullscreenVideoFeedScreen.pathForVideoId(videoId));
 
   @override
   final Uri uri;
 
   @override
   Object? get extra => null;
+}
+
+class _PooledFeedState extends Fake implements GoRouterState {
+  _PooledFeedState(this.extra);
+
+  @override
+  final Object? extra;
+
+  @override
+  Uri get uri => Uri.parse(PooledFullscreenVideoFeedScreen.path);
 }
 
 void main() {
@@ -87,11 +95,38 @@ void main() {
       );
     });
 
+    testWidgets('builder forwards the sponsor disclosure', (tester) async {
+      late Widget built;
+      final args = PooledFullscreenVideoFeedArgs(
+        source: SingleVideoViewSource(_video('1')),
+        feedRepository: StaticFeedRepository(),
+        initialIndex: 0,
+        sponsorName: 'Acme Bikes',
+      );
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) {
+              built = buildPooledFullscreenFeed(
+                context,
+                _PooledFeedState(args),
+              );
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+
+      expect(built, isA<PooledFullscreenVideoFeedScreen>());
+      expect(
+        (built as PooledFullscreenVideoFeedScreen).sponsorName,
+        'Acme Bikes',
+      );
+    });
+
     testWidgets(
       'builder recovers directly if extra disappears after redirect',
-      (
-        tester,
-      ) async {
+      (tester) async {
         late Widget recovered;
         await tester.pumpWidget(
           MaterialApp(

--- a/mobile/test/router/fullscreen_feed_redirect_test.dart
+++ b/mobile/test/router/fullscreen_feed_redirect_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:models/models.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/router/pooled_fullscreen_feed_route.dart'
     show buildPooledFullscreenFeed, fullscreenFeedRedirect;
 import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
@@ -105,6 +106,8 @@ void main() {
       );
       await tester.pumpWidget(
         MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
           home: Builder(
             builder: (context) {
               built = buildPooledFullscreenFeed(

--- a/mobile/test/screens/explore/tabs/featured_videos_tab_test.dart
+++ b/mobile/test/screens/explore/tabs/featured_videos_tab_test.dart
@@ -100,9 +100,8 @@ void main() {
           cursor: any(named: 'cursor'),
         ),
       ).thenAnswer(
-        (_) async => FeaturedTabVideosPage(
-          videos: [_video('first'), _video('second')],
-        ),
+        (_) async =>
+            FeaturedTabVideosPage(videos: [_video('first'), _video('second')]),
       );
       when(
         () => router.push<Object?>(any(), extra: any(named: 'extra')),
@@ -136,22 +135,62 @@ void main() {
       await tester.pump();
 
       final captured = verify(
-        () => router.push<Object?>(
-          any(),
-          extra: captureAny(named: 'extra'),
-        ),
+        () => router.push<Object?>(any(), extra: captureAny(named: 'extra')),
       ).captured.single;
       final args = captured as PooledFullscreenVideoFeedArgs;
 
       expect(args.source, isA<VideoListViewSource>());
       expect(args.initialIndex, 0);
       expect(args.initialVideoId, 'first');
+      expect(args.sponsorName, isNull);
       expect(args.trafficSource, ViewTrafficSource.discoveryFeatured);
       expect(args.sourceDetail, 'ft_a1b2c3d4');
       expect(args.feedRepository, same(feedRepository));
 
       final source = args.source as VideoListViewSource;
       expect(source.videos.map((video) => video.id), ['first', 'second']);
+    });
+
+    testWidgets('carries the resolved sponsor into the fullscreen feed', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildSubject(config: _sponsoredConfig()));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byType(VideoThumbnailWidget).first);
+      await tester.pump();
+
+      final captured = verify(
+        () => router.push<Object?>(any(), extra: captureAny(named: 'extra')),
+      ).captured.single;
+      final args = captured as PooledFullscreenVideoFeedArgs;
+
+      expect(args.sponsorName, 'Acme Bikes');
+    });
+
+    testWidgets('carries the sanitized sponsor into the fullscreen feed', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        buildSubject(
+          config: _config(
+            disclosureLabel: const {
+              'default': '\u0000Acme Bikes and Accessories Beyond Limit',
+            },
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byType(VideoThumbnailWidget).first);
+      await tester.pump();
+
+      final captured = verify(
+        () => router.push<Object?>(any(), extra: captureAny(named: 'extra')),
+      ).captured.single;
+      final args = captured as PooledFullscreenVideoFeedArgs;
+
+      expect(args.sponsorName, 'Acme Bikes and Accessor…');
     });
 
     testWidgets('refetches an empty page when a config poll lands', (
@@ -194,9 +233,7 @@ void main() {
       await featuredTabsCubit.refresh();
       await tester.pumpAndSettle();
 
-      verifyNever(
-        () => featuredRepository.loadVideos(tabId: 'ft_a1b2c3d4'),
-      );
+      verifyNever(() => featuredRepository.loadVideos(tabId: 'ft_a1b2c3d4'));
     });
 
     testWidgets('reloads when the configuration is retargeted in place', (
@@ -260,9 +297,7 @@ void main() {
         // appear as a line naming somebody else's locale either.
         await tester.pumpWidget(
           buildSubject(
-            config: _config(
-              disclosureLabel: const {'pt': 'Acme Bicicletas'},
-            ),
+            config: _config(disclosureLabel: const {'pt': 'Acme Bicicletas'}),
           ),
         );
         await tester.pumpAndSettle();

--- a/mobile/test/screens/feed/pooled_fullscreen_video_feed_args_test.dart
+++ b/mobile/test/screens/feed/pooled_fullscreen_video_feed_args_test.dart
@@ -36,11 +36,13 @@ void main() {
         feedRepository: StaticFeedRepository(),
         initialIndex: 2,
         contextTitle: 'For You',
+        sponsorName: 'Acme Bikes',
         trafficSource: ViewTrafficSource.discoveryForYou,
         autoOpenComments: true,
       );
 
       expect(args.contextTitle, 'For You');
+      expect(args.sponsorName, 'Acme Bikes');
       expect(args.trafficSource, ViewTrafficSource.discoveryForYou);
       expect(args.autoOpenComments, isTrue);
     });

--- a/mobile/test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart
+++ b/mobile/test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart
@@ -40,6 +40,7 @@ import 'package:openvine/screens/feed/video_feed_page.dart';
 import 'package:openvine/services/media_auth_interceptor.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/video_feed_item/actions/actions.dart';
+import 'package:openvine/widgets/video_feed_item/feed_immersive_chrome.dart';
 import 'package:openvine/widgets/video_feed_item/feed_videos.dart';
 import 'package:openvine/widgets/video_feed_item/fullscreen_sponsor_disclosure.dart';
 import 'package:openvine/widgets/video_feed_item/inline_comment_composer_bar.dart';
@@ -357,21 +358,57 @@ void main() {
 
         expect(find.text(expected), findsOneWidget);
         expect(find.byType(FullscreenSponsorDisclosure), findsOneWidget);
+      });
 
-        final disclosureContext = tester.element(
-          find.byType(FullscreenSponsorDisclosure),
+      testWidgets('keeps the disclosure up while the viewer holds the video', (
+        tester,
+      ) async {
+        final nativePlayer = _NativePlayerHarness(tester)..install();
+        addTearDown(nativePlayer.dispose);
+        final expected = lookupAppLocalizations(
+          const Locale('en'),
+        ).exploreFeaturedSponsoredBy('Acme Bikes');
+
+        await tester.pumpWidget(
+          buildSubject(
+            state: FullscreenFeedState(
+              status: FullscreenFeedStatus.ready,
+              videos: createTestVideos(count: 1),
+            ),
+            sponsorName: 'Acme Bikes',
+          ),
         );
-        disclosureContext.read<FeedImmersiveCubit>().enter();
         await tester.pump();
-        await tester.pump(const Duration(milliseconds: 180));
 
-        final opacity = tester.widget<AnimatedOpacity>(
+        tester
+            .element(find.byType(FullscreenSponsorDisclosure))
+            .read<FeedImmersiveCubit>()
+            .enter();
+        await tester.pump();
+        await tester.pump(kFeedImmersiveFadeDuration);
+
+        // The app bar fading proves immersive mode actually engaged, so the
+        // disclosure assertion below cannot pass by never entering it.
+        final appBarFade = tester.widget<AnimatedOpacity>(
           find.ancestor(
-            of: find.byType(FullscreenSponsorDisclosure),
+            of: find.byType(DiVineAppBar),
             matching: find.byType(AnimatedOpacity),
           ),
         );
-        expect(opacity.opacity, 0);
+        expect(appBarFade.opacity, isZero);
+
+        expect(find.text(expected), findsOneWidget);
+        expect(
+          tester
+              .widgetList<AnimatedOpacity>(
+                find.ancestor(
+                  of: find.byType(FullscreenSponsorDisclosure),
+                  matching: find.byType(AnimatedOpacity),
+                ),
+              )
+              .every((fade) => fade.opacity == 1.0),
+          isTrue,
+        );
       });
 
       testWidgets('omits the disclosure for an unsponsored feed', (

--- a/mobile/test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart
+++ b/mobile/test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart
@@ -33,6 +33,7 @@ import 'package:openvine/models/viewer_auth_result.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/screens/feed/feed_auto_advance_cubit.dart';
+import 'package:openvine/screens/feed/feed_immersive_cubit.dart';
 import 'package:openvine/screens/feed/feed_settings_menu.dart';
 import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
 import 'package:openvine/screens/feed/video_feed_page.dart';
@@ -40,6 +41,7 @@ import 'package:openvine/services/media_auth_interceptor.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/video_feed_item/actions/actions.dart';
 import 'package:openvine/widgets/video_feed_item/feed_videos.dart';
+import 'package:openvine/widgets/video_feed_item/fullscreen_sponsor_disclosure.dart';
 import 'package:openvine/widgets/video_feed_item/inline_comment_composer_bar.dart';
 import 'package:openvine/widgets/video_feed_item/moderated_content_overlay.dart';
 
@@ -253,6 +255,7 @@ void main() {
 
     Widget buildContent({
       String? contextTitle,
+      String? sponsorName,
       ViewTrafficSource trafficSource = ViewTrafficSource.unknown,
       String? sourceDetail,
       VoidCallback? onBack,
@@ -267,6 +270,7 @@ void main() {
         ],
         child: FullscreenFeedContent(
           contextTitle: contextTitle,
+          sponsorName: sponsorName,
           trafficSource: trafficSource,
           sourceDetail: sourceDetail,
           onBack: onBack,
@@ -279,6 +283,7 @@ void main() {
       List<dynamic>? additionalOverrides,
       MockAuthService? mockAuthService,
       String? contextTitle,
+      String? sponsorName,
       ViewTrafficSource trafficSource = ViewTrafficSource.unknown,
       String? sourceDetail,
       VoidCallback? onBack,
@@ -293,6 +298,7 @@ void main() {
         mockNip05VerificationService: mockNip05VerificationService,
         home: buildContent(
           contextTitle: contextTitle,
+          sponsorName: sponsorName,
           trafficSource: trafficSource,
           sourceDetail: sourceDetail,
           onBack: onBack,
@@ -331,6 +337,62 @@ void main() {
     });
 
     group('state rendering', () {
+      testWidgets('shows a sponsored collection disclosure', (tester) async {
+        final nativePlayer = _NativePlayerHarness(tester)..install();
+        addTearDown(nativePlayer.dispose);
+        final expected = lookupAppLocalizations(
+          const Locale('en'),
+        ).exploreFeaturedSponsoredBy('Acme Bikes');
+
+        await tester.pumpWidget(
+          buildSubject(
+            state: FullscreenFeedState(
+              status: FullscreenFeedStatus.ready,
+              videos: createTestVideos(count: 1),
+            ),
+            sponsorName: 'Acme Bikes',
+          ),
+        );
+        await tester.pump();
+
+        expect(find.text(expected), findsOneWidget);
+        expect(find.byType(FullscreenSponsorDisclosure), findsOneWidget);
+
+        final disclosureContext = tester.element(
+          find.byType(FullscreenSponsorDisclosure),
+        );
+        disclosureContext.read<FeedImmersiveCubit>().enter();
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 180));
+
+        final opacity = tester.widget<AnimatedOpacity>(
+          find.ancestor(
+            of: find.byType(FullscreenSponsorDisclosure),
+            matching: find.byType(AnimatedOpacity),
+          ),
+        );
+        expect(opacity.opacity, 0);
+      });
+
+      testWidgets('omits the disclosure for an unsponsored feed', (
+        tester,
+      ) async {
+        final nativePlayer = _NativePlayerHarness(tester)..install();
+        addTearDown(nativePlayer.dispose);
+
+        await tester.pumpWidget(
+          buildSubject(
+            state: FullscreenFeedState(
+              status: FullscreenFeedStatus.ready,
+              videos: createTestVideos(count: 1),
+            ),
+          ),
+        );
+        await tester.pump();
+
+        expect(find.byType(FullscreenSponsorDisclosure), findsNothing);
+      });
+
       testWidgets('shows loading indicator when status is initial', (
         tester,
       ) async {

--- a/mobile/test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart
+++ b/mobile/test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart
@@ -13,6 +13,7 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:divine_video_player/divine_video_player.dart'
     show DivineVideoPlayerController;
 import 'package:feed_tuning_repository/feed_tuning_repository.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -285,6 +286,7 @@ void main() {
       MockAuthService? mockAuthService,
       String? contextTitle,
       String? sponsorName,
+      MediaQueryData? mediaQueryData,
       ViewTrafficSource trafficSource = ViewTrafficSource.unknown,
       String? sourceDetail,
       VoidCallback? onBack,
@@ -292,18 +294,21 @@ void main() {
       final effectiveState = state ?? const FullscreenFeedState();
       when(() => mockBloc.state).thenReturn(effectiveState);
 
+      final content = buildContent(
+        contextTitle: contextTitle,
+        sponsorName: sponsorName,
+        trafficSource: trafficSource,
+        sourceDetail: sourceDetail,
+        onBack: onBack,
+      );
       return testMaterialApp(
         additionalOverrides: additionalOverrides,
         mockAuthService: mockAuthService,
         mockProfileRepository: mockProfileRepository,
         mockNip05VerificationService: mockNip05VerificationService,
-        home: buildContent(
-          contextTitle: contextTitle,
-          sponsorName: sponsorName,
-          trafficSource: trafficSource,
-          sourceDetail: sourceDetail,
-          onBack: onBack,
-        ),
+        home: mediaQueryData == null
+            ? content
+            : MediaQuery(data: mediaQueryData, child: content),
       );
     }
 
@@ -399,16 +404,160 @@ void main() {
 
         expect(find.text(expected), findsOneWidget);
         expect(
-          tester
-              .widgetList<AnimatedOpacity>(
-                find.ancestor(
-                  of: find.byType(FullscreenSponsorDisclosure),
-                  matching: find.byType(AnimatedOpacity),
-                ),
-              )
-              .every((fade) => fade.opacity == 1.0),
-          isTrue,
+          find.ancestor(
+            of: find.byType(FullscreenSponsorDisclosure),
+            matching: find.byType(AnimatedOpacity),
+          ),
+          findsNothing,
         );
+      });
+
+      testWidgets('holding the disclosure enters immersive viewing', (
+        tester,
+      ) async {
+        final nativePlayer = _NativePlayerHarness(tester)..install();
+        addTearDown(nativePlayer.dispose);
+
+        await tester.pumpWidget(
+          buildSubject(
+            state: FullscreenFeedState(
+              status: FullscreenFeedStatus.ready,
+              videos: createTestVideos(count: 1),
+            ),
+            sponsorName: 'Acme Bikes',
+          ),
+        );
+        await tester.pump();
+
+        final disclosureText = find.descendant(
+          of: find.byType(FullscreenSponsorDisclosure),
+          matching: find.byType(Text),
+        );
+        final immersiveCubit = tester
+            .element(disclosureText)
+            .read<FeedImmersiveCubit>();
+        final gesture = await tester.startGesture(
+          tester.getCenter(disclosureText),
+        );
+        await tester.pump(kLongPressTimeout + const Duration(milliseconds: 1));
+
+        expect(immersiveCubit.state.isImmersive, isTrue);
+
+        await gesture.up();
+        await tester.pump();
+        expect(immersiveCubit.state.isImmersive, isFalse);
+      });
+
+      testWidgets('positions the disclosure inside the safe app-bar row', (
+        tester,
+      ) async {
+        final nativePlayer = _NativePlayerHarness(tester)..install();
+        addTearDown(nativePlayer.dispose);
+        const topPadding = 48.0;
+
+        await tester.pumpWidget(
+          buildSubject(
+            state: FullscreenFeedState(
+              status: FullscreenFeedStatus.ready,
+              videos: createTestVideos(count: 1),
+            ),
+            sponsorName: 'Acme Bikes',
+            mediaQueryData: const MediaQueryData(
+              padding: EdgeInsets.only(top: topPadding),
+            ),
+          ),
+        );
+        await tester.pump();
+
+        final disclosureRect = tester.getRect(
+          find.byType(FullscreenSponsorDisclosure),
+        );
+        final appBarRect = tester.getRect(find.byType(DiVineAppBar));
+
+        expect(disclosureRect.top, greaterThanOrEqualTo(topPadding));
+        expect(disclosureRect.center.dy, closeTo(topPadding + 36, 0.01));
+        expect(disclosureRect.bottom, lessThanOrEqualTo(appBarRect.bottom));
+      });
+
+      for (final textScale in <double>[1, 2, 3]) {
+        testWidgets(
+          'keeps the disclosure clear of app-bar controls at ${textScale}x',
+          (tester) async {
+            final nativePlayer = _NativePlayerHarness(tester)..install();
+            addTearDown(nativePlayer.dispose);
+
+            await tester.pumpWidget(
+              buildSubject(
+                state: FullscreenFeedState(
+                  status: FullscreenFeedStatus.ready,
+                  videos: createTestVideos(count: 1),
+                ),
+                sponsorName: 'A long sponsor name',
+                mediaQueryData: MediaQueryData(
+                  textScaler: TextScaler.linear(textScale),
+                ),
+              ),
+            );
+            await tester.pump();
+
+            final disclosureRect = tester.getRect(
+              find.byType(FullscreenSponsorDisclosure),
+            );
+            final backButtonRect = tester.getRect(
+              find.bySemanticsIdentifier(
+                DiVineAppBarLeading.backButtonSemanticId,
+              ),
+            );
+            final settingsRect = tester.getRect(find.byType(FeedSettingsMenu));
+
+            expect(
+              disclosureRect.left,
+              greaterThanOrEqualTo(backButtonRect.right),
+            );
+            expect(disclosureRect.right, lessThanOrEqualTo(settingsRect.left));
+            expect(tester.takeException(), isNull);
+          },
+        );
+      }
+
+      testWidgets('announces sponsorship before video controls', (
+        tester,
+      ) async {
+        final semanticsHandle = tester.ensureSemantics();
+        final nativePlayer = _NativePlayerHarness(tester)..install();
+        addTearDown(nativePlayer.dispose);
+        final disclosureLabel = lookupAppLocalizations(
+          const Locale('en'),
+        ).exploreFeaturedSponsoredBy('Acme Bikes');
+
+        try {
+          await tester.pumpWidget(
+            buildSubject(
+              state: FullscreenFeedState(
+                status: FullscreenFeedStatus.ready,
+                videos: createTestVideos(count: 1),
+              ),
+              sponsorName: 'Acme Bikes',
+            ),
+          );
+          await tester.pump();
+
+          final traversal = tester.semantics
+              .simulatedAccessibilityTraversal()
+              .map((node) => node.getSemanticsData().label)
+              .toList();
+          final backIndex = traversal.indexOf('Back');
+          final disclosureIndex = traversal.indexOf(disclosureLabel);
+          final firstVideoControlIndex = traversal.indexWhere(
+            (label) => label.contains('Like'),
+          );
+
+          expect(backIndex, isNonNegative);
+          expect(disclosureIndex, greaterThan(backIndex));
+          expect(firstVideoControlIndex, greaterThan(disclosureIndex));
+        } finally {
+          semanticsHandle.dispose();
+        }
       });
 
       testWidgets('omits the disclosure for an unsponsored feed', (

--- a/mobile/test/widgets/video_feed_item/fullscreen_sponsor_disclosure_test.dart
+++ b/mobile/test/widgets/video_feed_item/fullscreen_sponsor_disclosure_test.dart
@@ -1,0 +1,96 @@
+// ABOUTME: Widget tests for the fullscreen sponsorship disclosure.
+// ABOUTME: Guards contrast, semantics, and large-text wrapping over video.
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/widgets/video_feed_item/fullscreen_sponsor_disclosure.dart';
+
+import '../../helpers/test_provider_overrides.dart';
+
+void main() {
+  group(FullscreenSponsorDisclosure, () {
+    Widget buildSubject({double textScale = 1}) {
+      return testMaterialApp(
+        home: MediaQuery(
+          data: MediaQueryData(textScaler: TextScaler.linear(textScale)),
+          child: const Scaffold(
+            body: Align(
+              alignment: Alignment.topLeft,
+              child: SizedBox(
+                width: 180,
+                child: FullscreenSponsorDisclosure(
+                  sponsorName: 'Acme Bikes',
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    testWidgets('maintains normal-text contrast over a bright frame', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildSubject());
+
+      final decoration =
+          tester
+                  .widget<DecoratedBox>(
+                    find.descendant(
+                      of: find.byType(FullscreenSponsorDisclosure),
+                      matching: find.byType(DecoratedBox),
+                    ),
+                  )
+                  .decoration
+              as BoxDecoration;
+      final background = Color.alphaBlend(
+        decoration.color!,
+        VineTheme.whiteText,
+      );
+      final contrast = _contrastRatio(VineTheme.whiteText, background);
+
+      expect(contrast, greaterThanOrEqualTo(4.5));
+    });
+
+    testWidgets('wraps the complete label at large text sizes', (tester) async {
+      await tester.pumpWidget(buildSubject(textScale: 3));
+
+      final text = tester.widget<Text>(
+        find.descendant(
+          of: find.byType(FullscreenSponsorDisclosure),
+          matching: find.byType(Text),
+        ),
+      );
+      final disclosureRect = tester.getRect(
+        find.byType(FullscreenSponsorDisclosure),
+      );
+
+      expect(text.maxLines, isNull);
+      expect(text.overflow, isNull);
+      expect(disclosureRect.height, greaterThan(54));
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('announces the complete localized disclosure', (tester) async {
+      final semanticsHandle = tester.ensureSemantics();
+      try {
+        await tester.pumpWidget(buildSubject());
+        final expected = lookupAppLocalizations(
+          const Locale('en'),
+        ).exploreFeaturedSponsoredBy('Acme Bikes');
+
+        expect(find.bySemanticsLabel(expected), findsOneWidget);
+      } finally {
+        semanticsHandle.dispose();
+      }
+    });
+  });
+}
+
+double _contrastRatio(Color foreground, Color background) {
+  final lighter = foreground.computeLuminance();
+  final darker = background.computeLuminance();
+  return (lighter + 0.05) / (darker + 0.05);
+}


### PR DESCRIPTION
## Problem

Sponsored featured collections disclose their sponsor above the Explore grid, but that disclosure disappeared when a viewer opened the collection fullscreen—where most viewing happens.

## Why this fix

The featured surface resolves and sanitizes the sponsor name once, then carries that presentation value through the fullscreen route without overloading the analytics-facing context title.

Fullscreen playback renders the localized disclosure beside the back button and keeps it present during press-and-hold immersive viewing. The pill is pointer-transparent, so tap-to-pause, double-tap-to-like, and press-and-hold still reach the video even when the gesture starts on its text.

The treatment uses `scrim65`, which gives white normal-size text at least 7:1 contrast over a pure-white frame. Glyph shadows add local separation over detailed footage without being relied on for WCAG contrast. This is quieter than the 80% media-chrome treatment while still clearing the repository's 4.5:1 accessibility floor.

Placement derives from the app bar's leading slot, scaled action target, current safe-area inset, and resolved text metrics. Long sponsor names and large system text can wrap downward over the video without colliding with the back or settings controls. Screen-reader traversal announces the app-bar controls and sponsorship before the video's metadata and actions.

Unlike every other chrome layer, the disclosure does **not** fade during press-and-hold immersive viewing. The app bar, per-item overlay, action rail, and comment bar still fade. A viewer choosing to hide controls is asking for a clean frame; a commercial disclosure they can dismiss is a different thing, so this one stays up for the whole reel.

This also adds `VineTheme.bodyTinyFont` (Inter 400 10/14/0.4) rather than overriding size and weight at the call site.

## Deliberately unchanged

If lifecycle restoration or a cold URL entry loses the in-memory route arguments, the existing redirect still recovers the selected video as a single-video detail route, with no sponsorship disclosure. What is sponsored is the placement in the featured feed, not the video everywhere it appears.

The fullscreen route uses `StaticFeedRepository`, whose feed is a frozen snapshot of exactly the collection's videos. Swiping cannot leave the sponsored placement while the disclosure remains on screen.

A featured collection with no sponsor renders neither the grid disclosure nor the fullscreen pill. No localization copy changed; only the English metadata description covers both grid and fullscreen use.

## Verification

- Red-to-green regression coverage for gesture passthrough, safe-area geometry, 1×/2×/3× text scaling, control clearance, semantics traversal, bright-frame contrast, complete semantics, and large-text wrapping
- 84 focused PR tests
- 132 changed-file pre-push tests
- `flutter analyze`
- Localization consistency plus raw typography, color, Material button, dialog, implicit font color, test-structure, and layer-direction ratchets

Closes #7672
