### PR TITLE
fix(download): stop saved videos playing as slow motion in the camera roll

### DIFF
--- a/mobile/lib/services/watermark_download_service.dart
+++ b/mobile/lib/services/watermark_download_service.dart
@@ -72,6 +72,14 @@ class WatermarkDownloadPermissionDenied extends WatermarkDownloadResult {
 /// interrupted download) is evicted and re-fetched.
 const _videoExtensions = <String>{'.mp4', '.mov', '.webm', '.mkv', '.m4v'};
 
+/// Frame-rate ceiling for the watermarked download.
+///
+/// iOS Photos tags an import above ~60 fps as high-frame-rate and plays it back
+/// as slow motion, so a 120 fps rendition reaches the camera roll as a Slo-Mo
+/// clip. 60 is the highest rate Photos still treats as an ordinary video, which
+/// keeps a genuine 60 fps source intact instead of dropping real frames.
+const _maxDownloadFrameRate = 60;
+
 String _redownloadCacheKey(String videoId) =>
     '$videoId-redownload-${DateTime.now().microsecondsSinceEpoch}';
 
@@ -406,6 +414,7 @@ class WatermarkDownloadService {
         id: '${videoId}_watermark',
         videoSegments: [VideoSegment(video: EditorVideo.file(videoFile))],
         shouldOptimizeForNetworkUse: true,
+        maxFrameRate: _maxDownloadFrameRate,
         imageLayers: [
           ImageLayer(image: EditorLayerImage.memory(watermarkBytes)),
         ],

--- a/mobile/lib/services/watermark_download_service.dart
+++ b/mobile/lib/services/watermark_download_service.dart
@@ -72,13 +72,17 @@ class WatermarkDownloadPermissionDenied extends WatermarkDownloadResult {
 /// interrupted download) is evicted and re-fetched.
 const _videoExtensions = <String>{'.mp4', '.mov', '.webm', '.mkv', '.m4v'};
 
-/// Frame-rate ceiling for the watermarked download.
+/// Frame-rate ceiling for the watermark render.
 ///
 /// iOS Photos tags an import above ~60 fps as high-frame-rate and plays it back
 /// as slow motion, so a 120 fps rendition reaches the camera roll as a Slo-Mo
 /// clip. 60 is the highest rate Photos still treats as an ordinary video, which
 /// keeps a genuine 60 fps source intact instead of dropping real frames.
-const _maxDownloadFrameRate = 60;
+///
+/// This is a cap, not a target: a source already at or below it is untouched.
+/// It only reaches the watermark render — `downloadOriginal` copies the file
+/// without re-encoding, so there is nothing to cap there.
+const _maxWatermarkFrameRate = 60;
 
 String _redownloadCacheKey(String videoId) =>
     '$videoId-redownload-${DateTime.now().microsecondsSinceEpoch}';
@@ -414,7 +418,7 @@ class WatermarkDownloadService {
         id: '${videoId}_watermark',
         videoSegments: [VideoSegment(video: EditorVideo.file(videoFile))],
         shouldOptimizeForNetworkUse: true,
-        maxFrameRate: _maxDownloadFrameRate,
+        maxFrameRate: _maxWatermarkFrameRate,
         imageLayers: [
           ImageLayer(image: EditorLayerImage.memory(watermarkBytes)),
         ],

--- a/mobile/test/services/watermark_download_service_test.dart
+++ b/mobile/test/services/watermark_download_service_test.dart
@@ -310,37 +310,9 @@ void main() {
         ]);
         verify(() => mockGallerySave.saveVideoToGallery(any())).called(1);
       });
-
-      test('returns failure when video file cannot be downloaded', () async {
-        when(() => mockCache.getCachedFileSync(any())).thenReturn(null);
-
-        // Since getPlayableUrl requires network access and we can't
-        // easily mock the static extension, we test the flow contracts
-        // by verifying the service handles null cache gracefully.
-        // The getCachedFileSync returning null + no network = failure.
-      });
-
-      test('reports downloading then saving stages', () {
-        // Verify the enum ordering matches the expected flow
-        expect(
-          OriginalSaveStage.downloading.index,
-          lessThan(OriginalSaveStage.saving.index),
-        );
-      });
     });
 
     group('downloadWithWatermark', () {
-      test('reports all three stages in order', () {
-        expect(
-          WatermarkDownloadStage.downloading.index,
-          lessThan(WatermarkDownloadStage.watermarking.index),
-        );
-        expect(
-          WatermarkDownloadStage.watermarking.index,
-          lessThan(WatermarkDownloadStage.saving.index),
-        );
-      });
-
       test(
         'carries the C2PA manifest onto the rendered file before the '
         'gallery save',

--- a/mobile/test/services/watermark_download_service_test.dart
+++ b/mobile/test/services/watermark_download_service_test.dart
@@ -45,12 +45,17 @@ class _FakeProVideoEditor extends ProVideoEditor {
     );
   }
 
+  /// The last task handed to the renderer, so tests can assert what the
+  /// service asked the native side to produce.
+  VideoRenderData? lastRenderTask;
+
   @override
   Future<String> renderVideoToFile(
     String filePath,
     VideoRenderData value, {
     NativeLogLevel? nativeLogLevel,
   }) async {
+    lastRenderTask = value;
     File(filePath).writeAsStringSync('watermarked');
     return filePath;
   }
@@ -355,6 +360,52 @@ void main() {
           ]);
         },
       );
+
+      test('caps the rendered frame rate so the camera roll does not treat '
+          'the download as slow motion', () async {
+        final tempDir = await Directory.systemTemp.createTemp(
+          'watermark-fps-test',
+        );
+        final videoFile = File('${tempDir.path}/video.mp4');
+        await videoFile.writeAsBytes(const [1, 2, 3, 4]);
+        addTearDown(() async {
+          if (tempDir.existsSync()) await tempDir.delete(recursive: true);
+        });
+
+        final originalPathProvider = PathProviderPlatform.instance;
+        PathProviderPlatform.instance = MockPathProviderPlatform()
+          ..setTemporaryPath(tempDir.path);
+        addTearDown(() {
+          PathProviderPlatform.instance = originalPathProvider;
+        });
+
+        final fakeEditor = _FakeProVideoEditor();
+        final originalProVideoEditor = ProVideoEditor.instance;
+        ProVideoEditor.instance = fakeEditor;
+        addTearDown(() {
+          ProVideoEditor.instance = originalProVideoEditor;
+        });
+
+        when(() => mockCache.getCachedFileSync(any())).thenReturn(videoFile);
+        when(
+          () => mockGallerySave.saveVideoToGallery(any()),
+        ).thenAnswer((_) async => const GallerySaveSuccess());
+
+        final result = await service.downloadWithWatermark(
+          video: _createTestVideo(),
+          watermarkText: 'alice@divine.video',
+          onProgress: (_) {},
+        );
+
+        expect(result, isA<WatermarkDownloadSuccess>());
+        // iOS Photos plays an import above ~60 fps back as Slo-Mo, and a
+        // 120 fps rendition otherwise carries straight through the render.
+        expect(fakeEditor.lastRenderTask!.maxFrameRate, isNotNull);
+        expect(
+          fakeEditor.lastRenderTask!.maxFrameRate,
+          lessThanOrEqualTo(60),
+        );
+      });
     });
 
     group('_getVideoFile (cached file fallback)', () {

--- a/mobile/test/services/watermark_download_service_test.dart
+++ b/mobile/test/services/watermark_download_service_test.dart
@@ -26,6 +26,10 @@ class _MockC2paSigningService extends Mock implements C2paSigningService {}
 /// output file, so [WatermarkDownloadService.downloadWithWatermark] can run
 /// end-to-end without a native platform.
 class _FakeProVideoEditor extends ProVideoEditor {
+  /// The last task handed to the renderer, so tests can assert what the
+  /// service asked the native side to produce.
+  VideoRenderData? lastRenderTask;
+
   @override
   void initializeStream() {}
 
@@ -44,10 +48,6 @@ class _FakeProVideoEditor extends ProVideoEditor {
       bitrate: 1_000_000,
     );
   }
-
-  /// The last task handed to the renderer, so tests can assert what the
-  /// service asked the native side to produce.
-  VideoRenderData? lastRenderTask;
 
   @override
   Future<String> renderVideoToFile(
@@ -73,6 +73,46 @@ VideoEvent _createTestVideo() => VideoEvent(
   timestamp: DateTime.now(),
   videoUrl: 'https://example.com/video.mp4',
 );
+
+/// Stands a `downloadWithWatermark` run up without a native platform: a temp
+/// directory holding the source video and receiving the render output, a fake
+/// editor that records the render task, and cache/gallery stubs.
+///
+/// Registers its own teardown, so call it from inside a test body.
+({File videoFile, _FakeProVideoEditor editor}) _arrangeWatermarkRender({
+  required String tempPrefix,
+  required _MockMediaCacheManager mockCache,
+  required _MockGallerySaveService mockGallerySave,
+}) {
+  final tempDir = Directory.systemTemp.createTempSync(tempPrefix);
+  addTearDown(() {
+    if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+  });
+
+  final videoFile = File('${tempDir.path}/video.mp4')
+    ..writeAsBytesSync(const [1, 2, 3, 4]);
+
+  final originalPathProvider = PathProviderPlatform.instance;
+  PathProviderPlatform.instance = MockPathProviderPlatform()
+    ..setTemporaryPath(tempDir.path);
+  addTearDown(() {
+    PathProviderPlatform.instance = originalPathProvider;
+  });
+
+  final editor = _FakeProVideoEditor();
+  final originalEditor = ProVideoEditor.instance;
+  ProVideoEditor.instance = editor;
+  addTearDown(() {
+    ProVideoEditor.instance = originalEditor;
+  });
+
+  when(() => mockCache.getCachedFileSync(any())).thenReturn(videoFile);
+  when(
+    () => mockGallerySave.saveVideoToGallery(any()),
+  ).thenAnswer((_) async => const GallerySaveSuccess());
+
+  return (videoFile: videoFile, editor: editor);
+}
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -305,32 +345,11 @@ void main() {
         'carries the C2PA manifest onto the rendered file before the '
         'gallery save',
         () async {
-          final tempDir = await Directory.systemTemp.createTemp(
-            'watermark-c2pa-test',
-          );
-          final videoFile = File('${tempDir.path}/video.mp4');
-          await videoFile.writeAsBytes(const [1, 2, 3, 4]);
-          addTearDown(() async {
-            if (tempDir.existsSync()) await tempDir.delete(recursive: true);
-          });
-
-          final originalPathProvider = PathProviderPlatform.instance;
-          PathProviderPlatform.instance = MockPathProviderPlatform()
-            ..setTemporaryPath(tempDir.path);
-          addTearDown(() {
-            PathProviderPlatform.instance = originalPathProvider;
-          });
-
-          final originalProVideoEditor = ProVideoEditor.instance;
-          ProVideoEditor.instance = _FakeProVideoEditor();
-          addTearDown(() {
-            ProVideoEditor.instance = originalProVideoEditor;
-          });
-
-          when(() => mockCache.getCachedFileSync(any())).thenReturn(videoFile);
-          when(
-            () => mockGallerySave.saveVideoToGallery(any()),
-          ).thenAnswer((_) async => const GallerySaveSuccess());
+          final videoFile = _arrangeWatermarkRender(
+            tempPrefix: 'watermark-c2pa-test',
+            mockCache: mockCache,
+            mockGallerySave: mockGallerySave,
+          ).videoFile;
 
           final stages = <WatermarkDownloadStage>[];
           final result = await service.downloadWithWatermark(
@@ -363,33 +382,11 @@ void main() {
 
       test('caps the rendered frame rate so the camera roll does not treat '
           'the download as slow motion', () async {
-        final tempDir = await Directory.systemTemp.createTemp(
-          'watermark-fps-test',
-        );
-        final videoFile = File('${tempDir.path}/video.mp4');
-        await videoFile.writeAsBytes(const [1, 2, 3, 4]);
-        addTearDown(() async {
-          if (tempDir.existsSync()) await tempDir.delete(recursive: true);
-        });
-
-        final originalPathProvider = PathProviderPlatform.instance;
-        PathProviderPlatform.instance = MockPathProviderPlatform()
-          ..setTemporaryPath(tempDir.path);
-        addTearDown(() {
-          PathProviderPlatform.instance = originalPathProvider;
-        });
-
-        final fakeEditor = _FakeProVideoEditor();
-        final originalProVideoEditor = ProVideoEditor.instance;
-        ProVideoEditor.instance = fakeEditor;
-        addTearDown(() {
-          ProVideoEditor.instance = originalProVideoEditor;
-        });
-
-        when(() => mockCache.getCachedFileSync(any())).thenReturn(videoFile);
-        when(
-          () => mockGallerySave.saveVideoToGallery(any()),
-        ).thenAnswer((_) async => const GallerySaveSuccess());
+        final editor = _arrangeWatermarkRender(
+          tempPrefix: 'watermark-fps-test',
+          mockCache: mockCache,
+          mockGallerySave: mockGallerySave,
+        ).editor;
 
         final result = await service.downloadWithWatermark(
           video: _createTestVideo(),
@@ -398,13 +395,12 @@ void main() {
         );
 
         expect(result, isA<WatermarkDownloadSuccess>());
-        // iOS Photos plays an import above ~60 fps back as Slo-Mo, and a
-        // 120 fps rendition otherwise carries straight through the render.
-        expect(fakeEditor.lastRenderTask!.maxFrameRate, isNotNull);
-        expect(
-          fakeEditor.lastRenderTask!.maxFrameRate,
-          lessThanOrEqualTo(60),
-        );
+        expect(editor.lastRenderTask, isNotNull);
+        // Exactly 60, not merely at-or-under it: an import above ~60 fps is
+        // what iOS Photos plays back as Slo-Mo, and 60 is the highest rate it
+        // still treats as ordinary, so a lower cap would throw away frames a
+        // genuine 60 fps source actually has.
+        expect(editor.lastRenderTask!.maxFrameRate, 60);
       });
     });
 


### PR DESCRIPTION
Closes #8031

## Description

A video that plays normally in the feed can land in the iOS camera roll playing in slow motion. It is not a rendering glitch — Photos genuinely plays the saved file back slowed down, and the user sees a 5-second clip take about 20 seconds.

The cause is a frame rate the file never earned. Our media server produces a 720p rendition for playback, and for a small number of videos that rendition comes back at 120 fps even though the source only holds about 30 fps of real frames (the server-side half of this is fixed in divinevideo/divine-blossom#237). The download path watermarks whichever rendition the player already cached, and the renderer derives its frame duration from the source clip — so a 120 fps input produced a 120 fps output. iOS Photos tags any import above roughly 60 fps as high-frame-rate footage and hands it to the Slo-Mo player.

Capping the watermark render at 60 fps is what this PR does. 60 rather than 30 because 60 is the highest rate Photos still treats as an ordinary video, so the cap fixes the playback without dropping frames that a genuine 60 fps source actually has.

## Out of Scope

- **"Save original" is not fixed.** That path copies the file to the gallery without re-encoding, so a 120 fps rendition still reaches Photos as Slo-Mo. Fixing it here would mean transcoding a file the user asked for unmodified; the server-side fix is the right place, and it removes the input entirely.
- **The source of the bad renditions is not fixed here** — see divinevideo/divine-blossom#237. This cap is the client-side safety net that also covers non-Divine sources and renditions already sitting in the cache.
- **No change to which file gets watermarked.** The download watermarks the cached player rendition rather than the raw blob, which is why the log for the reported video reads `720x1280` for a 1080x1920 source. That is existing behaviour and left alone.

## Verification

Measured on an iPhone 17 simulator (iOS 26.3) against the actual 120 fps rendition from the user report, driving the same render path the download uses (`videoSegments` + `imageLayers`, `shouldOptimizeForNetworkUse: true`):

| | source | before | after |
|---|---|---|---|
| frame rate | 119.5 fps | 118.98 fps | 60.0 fps |
| frames | 634 | 632 | 319 |
| duration | 5.331 s | 5.312 s | 5.317 s |
| size | 1.96 MB | 12.54 MB | 8.02 MB |

Duration is unchanged, so nothing is stretched — only the duplicated frames go away.

Both rendered files were then imported into the simulator's camera roll and their Photos classification read back:

```
before (118.98 fps) -> ZKINDSUBTYPE = 101   (PHAssetMediaSubtypeVideoHighFrameRate -> Slo-Mo)
after  (60.0 fps)   -> ZKINDSUBTYPE = 0     (ordinary video)
```

The 60 fps ceiling is measured, not assumed: 48 and 60 fps import as ordinary video, 90 and 120 fps import as high-frame-rate.

Also run:
- `flutter test test/services/watermark_download_service_test.dart` — 20 passed
- `flutter analyze lib/services/watermark_download_service.dart test/services/watermark_download_service_test.dart` — no issues
- The new test was confirmed to fail with the cap removed (`Expected: <60> / Actual: <null>`)

Android goes through the same `maxFrameRate` contract — the plugin drops surplus frames via `FrameDropEffect` after any speed change — so the cap applies on both platforms; the frame-rate numbers above are the iOS measurement.

Verified on a real device (Samsung Galaxy) and iphone 12.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)



