### PR TITLE
fix(lists): stop a deleted list returning on the next relay sync

### DIFF
--- a/mobile/lib/services/curated_list_service.dart
+++ b/mobile/lib/services/curated_list_service.dart
@@ -753,16 +753,13 @@ class CuratedListService extends ChangeNotifier {
         }
       }
 
-      await _removeListAndSubscription(listId);
       // Recorded whatever the local event id says. A null id does not mean no
       // relay holds this coordinate — another device can have published the
       // same stable d-tag independently, which is the case the unpublished
-      // merge in [_processListEvent] exists to handle.
-      final ownerPubkey =
-          list.pubkey ?? _relayGateway.currentAuthenticatedPubkey();
-      if (ownerPubkey != null) {
-        await _recordListDeletion(ownerPubkey, listId);
-      }
+      // merge in [_processListEvent] exists to handle. Record before removing
+      // the local list so relay sync never sees an unprotected absence.
+      await _recordListDeletion(list.pubkey!, listId);
+      await _removeListAndSubscription(listId);
       if (listId == defaultListId) {
         await _prefs.setBool(defaultListDeletedStorageKey, true);
       }

--- a/mobile/lib/services/curated_list_service.dart
+++ b/mobile/lib/services/curated_list_service.dart
@@ -82,6 +82,8 @@ class CuratedListService extends ChangeNotifier {
 
   static const String listsStorageKey = 'curated_lists';
   static const String subscribedListsStorageKey = 'subscribed_list_ids';
+  static const String deletedListCoordinatesStorageKey =
+      'deleted_curated_list_coordinates';
   static const String defaultListDeletedStorageKey =
       'curated_lists_default_deleted';
   static const String defaultListId = 'my_vine_list';
@@ -219,6 +221,45 @@ class CuratedListService extends ChangeNotifier {
     return _prefs.getBool(defaultListDeletedStorageKey) ?? false;
   }
 
+  /// The `<pubkey>:<d-tag>` form of a kind 30005 coordinate.
+  ///
+  /// A `d` tag is only unique per author, so a deletion has to be remembered
+  /// against its owner. Keying on the identifier alone would suppress a list
+  /// that merely shares it — another account on this device, or someone
+  /// else's list arriving from a relay.
+  String _listCoordinate(String ownerPubkey, String listId) =>
+      '$ownerPubkey:$listId';
+
+  /// Coordinates this install has deleted.
+  ///
+  /// NIP-09 is advisory: a relay may never see the deletion request, or may
+  /// decline it, and keep replaying the original event. Without a local record
+  /// the next sync adds the list straight back. The set is not pruned — an
+  /// entry is a few dozen bytes, deletions are rare, and there is no point at
+  /// which every relay is known to have honoured the request.
+  Set<String> _deletedListCoordinates() =>
+      (_prefs.getStringList(deletedListCoordinatesStorageKey) ?? const [])
+          .toSet();
+
+  Future<void> _recordListDeletion(String ownerPubkey, String listId) async {
+    final coordinates = _deletedListCoordinates()
+      ..add(_listCoordinate(ownerPubkey, listId));
+    await _prefs.setStringList(
+      deletedListCoordinatesStorageKey,
+      coordinates.toList(growable: false),
+    );
+  }
+
+  /// Lifts the tombstone so a re-created list can sync again.
+  Future<void> _forgetListDeletion(String ownerPubkey, String listId) async {
+    final coordinates = _deletedListCoordinates();
+    if (!coordinates.remove(_listCoordinate(ownerPubkey, listId))) return;
+    await _prefs.setStringList(
+      deletedListCoordinatesStorageKey,
+      coordinates.toList(growable: false),
+    );
+  }
+
   /// Get the default "My List" for quick adding
   CuratedList? getDefaultList() {
     try {
@@ -316,6 +357,13 @@ class CuratedListService extends ChangeNotifier {
         thumbnailEventId: thumbnailEventId,
         playOrder: playOrder,
       );
+
+      // Re-using a deleted identifier has to lift its tombstone, or the new
+      // list's own relay events would be discarded for the life of the install
+      // and it would never reach another device.
+      if (ownerPubkey != null) {
+        await _forgetListDeletion(ownerPubkey, listId);
+      }
 
       _lists.add(newList);
       await _saveLists();
@@ -706,6 +754,15 @@ class CuratedListService extends ChangeNotifier {
       }
 
       await _removeListAndSubscription(listId);
+      // Recorded whatever the local event id says. A null id does not mean no
+      // relay holds this coordinate — another device can have published the
+      // same stable d-tag independently, which is the case the unpublished
+      // merge in [_processListEvent] exists to handle.
+      final ownerPubkey =
+          list.pubkey ?? _relayGateway.currentAuthenticatedPubkey();
+      if (ownerPubkey != null) {
+        await _recordListDeletion(ownerPubkey, listId);
+      }
       if (listId == defaultListId) {
         await _prefs.setBool(defaultListDeletedStorageKey, true);
       }
@@ -1714,6 +1771,20 @@ class CuratedListService extends ChangeNotifier {
           );
         }
       } else {
+        // Checked here rather than earlier so the tombstone only ever blocks a
+        // resurrection. A list still present locally keeps syncing normally,
+        // which is what should happen if a delete failed after recording it.
+        if (_deletedListCoordinates().contains(
+          _listCoordinate(event.pubkey, dTag),
+        )) {
+          Log.debug(
+            'Skipping deleted list event from relay: $dTag',
+            name: 'CuratedListService',
+            category: LogCategory.system,
+          );
+          return;
+        }
+
         // Add new list from relay
         Log.debug(
           'Adding new list from relay: ${curatedList.name}',

--- a/mobile/test/services/curated_list_service_crud_test.dart
+++ b/mobile/test/services/curated_list_service_crud_test.dart
@@ -36,7 +36,6 @@ const _ownerPubkey =
 const _otherPubkey =
     'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789';
 
-/// An outcome one relay accepted — what [PublishOutcome.acceptedByAny] gates on.
 /// A kind 30005 curated-list event as a relay would replay it.
 Event _listEvent(String listId, String title, [String pubkey = _ownerPubkey]) =>
     Event.fromJson({
@@ -52,6 +51,7 @@ Event _listEvent(String listId, String title, [String pubkey = _ownerPubkey]) =>
       'sig': 'test_signature',
     });
 
+/// An outcome one relay accepted — what [PublishOutcome.acceptedByAny] gates on.
 PublishOutcome _accepted(Event event) => PublishOutcome(
   eventId: event.id,
   acceptedBy: const ['wss://relay.test'],
@@ -2099,6 +2099,30 @@ void main() {
           expect(service.getListById(listId), isNull);
         },
       );
+
+      test('records the tombstone before exposing local removal', () async {
+        final list = await service.createList(name: 'Doomed List');
+        final listId = list!.id;
+        reset(mockNostr);
+        when(() => mockNostr.publishEventAwaitOk(any())).thenAnswer(
+          (invocation) async =>
+              _accepted(invocation.positionalArguments[0] as Event),
+        );
+
+        var removalWasProtected = false;
+        service.setOnListUnsubscribed((removedListId) {
+          final tombstones = prefs.getStringList(
+            CuratedListService.deletedListCoordinatesStorageKey,
+          );
+          removalWasProtected =
+              service.getListById(removedListId) == null &&
+              (tombstones?.contains('$_ownerPubkey:$removedListId') ?? false);
+        });
+
+        expect(await service.deleteOwnedList(listId), isTrue);
+
+        expect(removalWasProtected, isTrue);
+      });
 
       test(
         'the deletion survives a new service over the same storage',

--- a/mobile/test/services/curated_list_service_crud_test.dart
+++ b/mobile/test/services/curated_list_service_crud_test.dart
@@ -37,6 +37,21 @@ const _otherPubkey =
     'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789';
 
 /// An outcome one relay accepted — what [PublishOutcome.acceptedByAny] gates on.
+/// A kind 30005 curated-list event as a relay would replay it.
+Event _listEvent(String listId, String title, [String pubkey = _ownerPubkey]) =>
+    Event.fromJson({
+      'id': 'relay_event_for_$listId',
+      'pubkey': pubkey,
+      'created_at': DateTime.now().millisecondsSinceEpoch ~/ 1000,
+      'kind': 30005,
+      'tags': [
+        ['d', listId],
+        ['title', title],
+      ],
+      'content': '',
+      'sig': 'test_signature',
+    });
+
 PublishOutcome _accepted(Event event) => PublishOutcome(
   eventId: event.id,
   acceptedBy: const ['wss://relay.test'],
@@ -2057,6 +2072,122 @@ void main() {
         );
         expect(published.tags, contains(equals(['k', '30005'])));
       });
+
+      test(
+        'a deleted list is not resurrected by a later relay event',
+        () async {
+          final list = await service.createList(name: 'Doomed List');
+          final listId = list!.id;
+          reset(mockNostr);
+          when(() => mockNostr.signer).thenReturn(mockSigner);
+          when(() => mockNostr.publishEventAwaitOk(any())).thenAnswer(
+            (invocation) async =>
+                _accepted(invocation.positionalArguments[0] as Event),
+          );
+
+          expect(await service.deleteOwnedList(listId), isTrue);
+          expect(service.getListById(listId), isNull);
+
+          // NIP-09 is advisory. A relay that never saw the deletion, or chose
+          // not to honour it, keeps serving the original kind 30005 event.
+          when(
+            () => mockNostr.subscribe(any()),
+          ).thenAnswer((_) => Stream.value(_listEvent(listId, 'Doomed List')));
+
+          await service.fetchUserListsFromRelays(force: true);
+
+          expect(service.getListById(listId), isNull);
+        },
+      );
+
+      test(
+        'the deletion survives a new service over the same storage',
+        () async {
+          final list = await service.createList(name: 'Doomed List');
+          final listId = list!.id;
+          reset(mockNostr);
+          when(() => mockNostr.signer).thenReturn(mockSigner);
+          when(() => mockNostr.publishEventAwaitOk(any())).thenAnswer(
+            (invocation) async =>
+                _accepted(invocation.positionalArguments[0] as Event),
+          );
+          expect(await service.deleteOwnedList(listId), isTrue);
+
+          when(
+            () => mockNostr.subscribe(any()),
+          ).thenAnswer((_) => Stream.value(_listEvent(listId, 'Doomed List')));
+
+          final relaunched = CuratedListService(
+            nostrService: mockNostr,
+            authService: mockAuth,
+            prefs: prefs,
+          );
+          await relaunched.fetchUserListsFromRelays(force: true);
+
+          expect(relaunched.getListById(listId), isNull);
+        },
+      );
+
+      test(
+        'a re-created default list is not blocked by its own tombstone',
+        () async {
+          // The tombstone and the default-deleted flag are two separate pref
+          // writes, so a launch killed between them leaves the tombstone set and
+          // the flag clear. initialize() then re-creates "My List" on the same
+          // coordinate, and without lifting the tombstone the new list's own
+          // relay events would be discarded for the life of the install.
+          SharedPreferences.setMockInitialValues({
+            CuratedListService.deletedListCoordinatesStorageKey: <String>[
+              '$_ownerPubkey:${CuratedListService.defaultListId}',
+            ],
+          });
+          final relaunched = CuratedListService(
+            nostrService: mockNostr,
+            authService: mockAuth,
+            prefs: await SharedPreferences.getInstance(),
+          );
+          await relaunched.initialize();
+          final defaultList = relaunched.getDefaultList();
+          expect(defaultList, isNotNull);
+
+          when(() => mockNostr.subscribe(any())).thenAnswer(
+            (_) => Stream.value(_listEvent(defaultList!.id, 'My List')),
+          );
+          await relaunched.fetchUserListsFromRelays(force: true);
+
+          expect(relaunched.getDefaultList(), isNotNull);
+        },
+      );
+
+      test(
+        "deleting one list does not suppress another owner's same id",
+        () async {
+          final list = await service.createList(name: 'Doomed List');
+          final listId = list!.id;
+          reset(mockNostr);
+          when(() => mockNostr.signer).thenReturn(mockSigner);
+          when(() => mockNostr.publishEventAwaitOk(any())).thenAnswer(
+            (invocation) async =>
+                _accepted(invocation.positionalArguments[0] as Event),
+          );
+          expect(await service.deleteOwnedList(listId), isTrue);
+
+          // A `d` tag is only unique per pubkey, so the tombstone has to be
+          // keyed by owner. Someone else's list that happens to share the
+          // identifier is a different coordinate entirely.
+          when(() => mockAuth.currentPublicKeyHex).thenReturn(_otherPubkey);
+          when(mockSigner.getPublicKey).thenAnswer((_) async => _otherPubkey);
+          when(() => mockNostr.subscribe(any())).thenAnswer(
+            (_) =>
+                Stream.value(_listEvent(listId, 'Someone Else', _otherPubkey)),
+          );
+
+          await service.fetchUserListsFromRelays(force: true);
+
+          expect(service.getListById(listId), isNotNull);
+          expect(service.getListById(listId)!.pubkey, _otherPubkey);
+        },
+      );
 
       test('keeps local list when publish fails', () async {
         final list = await service.createList(name: 'Owned Public List');


### PR DESCRIPTION
Closes #7723.

## Why

Delete a curated list you own and it can come back on the next relay sync.

`deleteOwnedList` asks relays to drop the coordinate with a NIP-09 kind 5, then removes the list locally. NIP-09 is a *request*: a relay may never receive it, may not implement it, or may decline. Any relay that still holds the kind 30005 event replays it on the next sync, `_processListEvent` finds no local list for that `d` tag, and the `else` branch calls `_lists.add(curatedList)` unconditionally. The list is back, with its items.

`_wasDefaultListDeleted()` was the only deletion tombstone in the file, and it covers exactly one coordinate — `my_vine_list`. Every other list a user deletes had nothing recording that the deletion happened.

Because NIP-09 is advisory, a client-side tombstone is the only thing that can actually hold a deletion.

## Correcting the issue's diagnosis

#7723 attributes this to the union merge and the `nostrEventId == null` predicate being overloaded. That is not the mechanism. The merge branch only runs when a local list already exists (`existingListIndex != -1`), and a deleted list is gone from `_lists`, so the event never reaches it. The resurrection is the unconditional add in the `else` branch, and the missing piece is a general tombstone rather than a disambiguated event id.

Same audit pass filed five siblings that no longer describe live code, all verified against this head:

- **#7728** — already fixed. `_backfillUnpublishedLists` re-reads `currentOwner` inside the loop body and returns when it differs from the captured `owner`.
- **#7724** — not reproducible. The merge sets `isPublic: (…) || isCollaborative`, so a collaborative result is forced public; there is no separate `isPrivate` field for it to contradict.
- **#7725** — already fixed. `deleteOwnedList` is a wrapper around `_serializeListOperation`.
- **#7727** — no such method. There is no dead `deleteList`.
- **#7726** — docstring only; deliberately left out of this PR to keep the diff to the defect.

Their cited line numbers (2019, 2155) do not exist — the file is 1763 lines. Worth closing them rather than leaving three `critical` labels on an unclaimed pile.

## What changed

A `(pubkey, d-tag)` keyed tombstone in `SharedPreferences`, under a new `deletedListCoordinatesStorageKey`.

**Keyed by owner, not by identifier.** A `d` tag is only unique per author. `defaultListId` is a shared constant across every user, so a tombstone keyed on the identifier alone would suppress relay events for anyone's list sharing it — another account on the same device after a switch, or someone else's list arriving from a relay. The stored form matches the coordinate `publishListDeletion` already deletes against, `30005:<pubkey>:<d-tag>`. Full hex pubkeys, no truncation.

**Recorded regardless of the local event id.** A null `nostrEventId` does not mean no relay holds the coordinate — another device can have published the same stable `d` tag independently, which is the case the unpublished merge in this same method exists to handle.

**Checked in the add-new branch, not early.** The tombstone can only ever block a resurrection. A list still present locally keeps syncing normally, which is the right behaviour if a delete died after recording but before removing.

**Lifted on re-creation.** `_recordListDeletion` and the `defaultListDeleted` flag are two separate pref writes, so a launch killed between them leaves the tombstone set and the flag clear. `initialize()` then re-creates "My List" on a tombstoned coordinate, and without lifting it the new list's own relay events would be discarded for the life of the install and it would never reach another device.

Every insertion site was checked: create (tombstone lifted), `subscribeToList` (different author, no conflict), relay sync (guarded). The two `_lists[index] =` sites update a list already present locally and cannot resurrect.

The set is not pruned. An entry is a few dozen bytes, deletions are rare, and there is no point at which every relay is known to have honoured the request.

## Tests

Four regression cases in `deleteOwnedList()`:

- a deleted list is not re-added when a relay replays its event
- the tombstone survives a new service instance over the same storage
- a re-created default list is not blocked by its own tombstone
- deleting one list does not suppress another owner's list with the same identifier

**Mutation check:** removing only the guard from `_processListEvent`, leaving the rest of the change in place, fails the resurrection cases. Reverting the whole service file instead only produces a compile error, which proves nothing — so the guard was mutated in isolation.

## Verification

- `flutter analyze lib test integration_test`
- the full `curated_list_service_*` and `curated_list_relay_gateway` suites
- `dart format`

## Out of scope, worth a follow-up

`_deleteOwnedList` only publishes the kind 5 when `nostrEventId != null`, but `publishListDeletion` deletes by the `a` coordinate rather than by event id. A list published from another device has a null local event id and still exists on relays, so that gate can skip a deletion request that would have succeeded. The tombstone in this PR makes it a local-only inconsistency rather than a resurrection, so it is not urgent — but the gate is questionable on its own terms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
