### PR TITLE
fix(safety): fetch real profiles for blocked users

### DIFF
--- a/mobile/lib/providers/user_profile_providers.dart
+++ b/mobile/lib/providers/user_profile_providers.dart
@@ -94,6 +94,36 @@ Stream<UserProfile?> _watchUserProfile(
   yield* repo.watchProfile(pubkey: pubkey);
 }
 
+/// Reactive profile provider for a pubkey the viewer has blocked.
+///
+/// [userProfileReactive] cannot serve this: the repository's block filter
+/// short-circuits `fetchFreshProfile` for a blocked pubkey, so a blocked
+/// account the viewer never saw in a feed has nothing cached and renders as a
+/// generated fallback name forever. Reviewing a block needs the real name and
+/// avatar, so this path fetches with the filter bypassed. It is *about* the
+/// account rather than a surface for its content.
+@riverpod
+Stream<UserProfile?> blockedUserProfile(Ref ref, String pubkey) {
+  final repo = ref.watch(profileReadRepositoryProvider);
+  if (repo == null) return Stream<UserProfile?>.value(null);
+
+  return _watchBlockedUserProfile(repo, pubkey);
+}
+
+Stream<UserProfile?> _watchBlockedUserProfile(
+  ProfileReader repo,
+  String pubkey,
+) async* {
+  final cached = await repo.getCachedProfile(pubkey: pubkey);
+  if (cached == null) {
+    unawaited(
+      repo.fetchFreshProfile(pubkey: pubkey, ignoreBlockFilter: true),
+    );
+  }
+
+  yield* repo.watchProfile(pubkey: pubkey);
+}
+
 /// One-shot provider: returns cached profile or fetches fresh.
 ///
 /// Use this when you need a single read (e.g., building a share sheet)

--- a/mobile/lib/providers/user_profile_providers.dart
+++ b/mobile/lib/providers/user_profile_providers.dart
@@ -122,6 +122,18 @@ Future<Map<String, UserProfile>> blockedUserProfiles(
   return profiles;
 }
 
+/// Watches a blocked account's cached profile without starting another fetch.
+///
+/// [blockedUserProfiles] hydrates the cache in bounded batches; this provider
+/// keeps each tile reactive to that hydration and later profile updates.
+@riverpod
+Stream<UserProfile?> blockedUserProfile(Ref ref, String pubkey) {
+  final repo = ref.watch(profileReadRepositoryProvider);
+  if (repo == null) return Stream.value(null);
+
+  return repo.watchProfile(pubkey: pubkey);
+}
+
 /// One-shot provider: returns cached profile or fetches fresh.
 ///
 /// Use this when you need a single read (e.g., building a share sheet)

--- a/mobile/lib/providers/user_profile_providers.dart
+++ b/mobile/lib/providers/user_profile_providers.dart
@@ -12,6 +12,8 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'user_profile_providers.g.dart';
 
+const _blockedProfileFetchChunkSize = 50;
+
 final _vanishedProfilePubkeysProvider = StreamProvider<Set<String>>((ref) {
   return ref
       .watch(databaseProvider)
@@ -94,34 +96,30 @@ Stream<UserProfile?> _watchUserProfile(
   yield* repo.watchProfile(pubkey: pubkey);
 }
 
-/// Reactive profile provider for a pubkey the viewer has blocked.
+/// Resolves profiles for the accounts the viewer has blocked.
 ///
-/// [userProfileReactive] cannot serve this: the repository's block filter
-/// short-circuits `fetchFreshProfile` for a blocked pubkey, so a blocked
-/// account the viewer never saw in a feed has nothing cached and renders as a
-/// generated fallback name forever. Reviewing a block needs the real name and
-/// avatar, so this path fetches with the filter bypassed. It is *about* the
-/// account rather than a surface for its content.
+/// Fetching the set in bounded batches avoids starting a REST request plus two
+/// relay queries for every uncached row when a synced mute list is large.
 @riverpod
-Stream<UserProfile?> blockedUserProfile(Ref ref, String pubkey) {
+Future<Map<String, UserProfile>> blockedUserProfiles(
+  Ref ref,
+  Set<String> pubkeys,
+) async {
   final repo = ref.watch(profileReadRepositoryProvider);
-  if (repo == null) return Stream<UserProfile?>.value(null);
+  if (repo == null || pubkeys.isEmpty) return const {};
 
-  return _watchBlockedUserProfile(repo, pubkey);
-}
-
-Stream<UserProfile?> _watchBlockedUserProfile(
-  ProfileReader repo,
-  String pubkey,
-) async* {
-  final cached = await repo.getCachedProfile(pubkey: pubkey);
-  if (cached == null) {
-    unawaited(
-      repo.fetchFreshProfile(pubkey: pubkey, ignoreBlockFilter: true),
+  final profiles = <String, UserProfile>{};
+  final pending = pubkeys.toList();
+  for (var i = 0; i < pending.length; i += _blockedProfileFetchChunkSize) {
+    final chunk = pending.skip(i).take(_blockedProfileFetchChunkSize).toList();
+    profiles.addAll(
+      await repo.fetchBatchProfiles(
+        pubkeys: chunk,
+        ignoreBlockFilter: true,
+      ),
     );
   }
-
-  yield* repo.watchProfile(pubkey: pubkey);
+  return profiles;
 }
 
 /// One-shot provider: returns cached profile or fetches fresh.

--- a/mobile/lib/providers/user_profile_providers.g.dart
+++ b/mobile/lib/providers/user_profile_providers.g.dart
@@ -264,6 +264,106 @@ final class BlockedUserProfilesFamily extends $Family
   String toString() => r'blockedUserProfilesProvider';
 }
 
+/// Watches a blocked account's cached profile without starting another fetch.
+///
+/// [blockedUserProfiles] hydrates the cache in bounded batches; this provider
+/// keeps each tile reactive to that hydration and later profile updates.
+
+@ProviderFor(blockedUserProfile)
+final blockedUserProfileProvider = BlockedUserProfileFamily._();
+
+/// Watches a blocked account's cached profile without starting another fetch.
+///
+/// [blockedUserProfiles] hydrates the cache in bounded batches; this provider
+/// keeps each tile reactive to that hydration and later profile updates.
+
+final class BlockedUserProfileProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<UserProfile?>,
+          UserProfile?,
+          Stream<UserProfile?>
+        >
+    with $FutureModifier<UserProfile?>, $StreamProvider<UserProfile?> {
+  /// Watches a blocked account's cached profile without starting another fetch.
+  ///
+  /// [blockedUserProfiles] hydrates the cache in bounded batches; this provider
+  /// keeps each tile reactive to that hydration and later profile updates.
+  BlockedUserProfileProvider._({
+    required BlockedUserProfileFamily super.from,
+    required String super.argument,
+  }) : super(
+         retry: null,
+         name: r'blockedUserProfileProvider',
+         isAutoDispose: true,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$blockedUserProfileHash();
+
+  @override
+  String toString() {
+    return r'blockedUserProfileProvider'
+        ''
+        '($argument)';
+  }
+
+  @$internal
+  @override
+  $StreamProviderElement<UserProfile?> $createElement(
+    $ProviderPointer pointer,
+  ) => $StreamProviderElement(pointer);
+
+  @override
+  Stream<UserProfile?> create(Ref ref) {
+    final argument = this.argument as String;
+    return blockedUserProfile(ref, argument);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is BlockedUserProfileProvider && other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$blockedUserProfileHash() =>
+    r'939f57fd466b49999d7e73e97937c0660e1e1d77';
+
+/// Watches a blocked account's cached profile without starting another fetch.
+///
+/// [blockedUserProfiles] hydrates the cache in bounded batches; this provider
+/// keeps each tile reactive to that hydration and later profile updates.
+
+final class BlockedUserProfileFamily extends $Family
+    with $FunctionalFamilyOverride<Stream<UserProfile?>, String> {
+  BlockedUserProfileFamily._()
+    : super(
+        retry: null,
+        name: r'blockedUserProfileProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: true,
+      );
+
+  /// Watches a blocked account's cached profile without starting another fetch.
+  ///
+  /// [blockedUserProfiles] hydrates the cache in bounded batches; this provider
+  /// keeps each tile reactive to that hydration and later profile updates.
+
+  BlockedUserProfileProvider call(String pubkey) =>
+      BlockedUserProfileProvider._(argument: pubkey, from: this);
+
+  @override
+  String toString() => r'blockedUserProfileProvider';
+}
+
 /// One-shot provider: returns cached profile or fetches fresh.
 ///
 /// Use this when you need a single read (e.g., building a share sheet)

--- a/mobile/lib/providers/user_profile_providers.g.dart
+++ b/mobile/lib/providers/user_profile_providers.g.dart
@@ -158,79 +158,69 @@ final class UserProfileReactiveFamily extends $Family
   String toString() => r'userProfileReactiveProvider';
 }
 
-/// Reactive profile provider for a pubkey the viewer has blocked.
+/// Resolves profiles for the accounts the viewer has blocked.
 ///
-/// [userProfileReactive] cannot serve this: the repository's block filter
-/// short-circuits `fetchFreshProfile` for a blocked pubkey, so a blocked
-/// account the viewer never saw in a feed has nothing cached and renders as a
-/// generated fallback name forever. Reviewing a block needs the real name and
-/// avatar, so this path fetches with the filter bypassed. It is *about* the
-/// account rather than a surface for its content.
+/// Fetching the set in bounded batches avoids starting a REST request plus two
+/// relay queries for every uncached row when a synced mute list is large.
 
-@ProviderFor(blockedUserProfile)
-final blockedUserProfileProvider = BlockedUserProfileFamily._();
+@ProviderFor(blockedUserProfiles)
+final blockedUserProfilesProvider = BlockedUserProfilesFamily._();
 
-/// Reactive profile provider for a pubkey the viewer has blocked.
+/// Resolves profiles for the accounts the viewer has blocked.
 ///
-/// [userProfileReactive] cannot serve this: the repository's block filter
-/// short-circuits `fetchFreshProfile` for a blocked pubkey, so a blocked
-/// account the viewer never saw in a feed has nothing cached and renders as a
-/// generated fallback name forever. Reviewing a block needs the real name and
-/// avatar, so this path fetches with the filter bypassed. It is *about* the
-/// account rather than a surface for its content.
+/// Fetching the set in bounded batches avoids starting a REST request plus two
+/// relay queries for every uncached row when a synced mute list is large.
 
-final class BlockedUserProfileProvider
+final class BlockedUserProfilesProvider
     extends
         $FunctionalProvider<
-          AsyncValue<UserProfile?>,
-          UserProfile?,
-          Stream<UserProfile?>
+          AsyncValue<Map<String, UserProfile>>,
+          Map<String, UserProfile>,
+          FutureOr<Map<String, UserProfile>>
         >
-    with $FutureModifier<UserProfile?>, $StreamProvider<UserProfile?> {
-  /// Reactive profile provider for a pubkey the viewer has blocked.
+    with
+        $FutureModifier<Map<String, UserProfile>>,
+        $FutureProvider<Map<String, UserProfile>> {
+  /// Resolves profiles for the accounts the viewer has blocked.
   ///
-  /// [userProfileReactive] cannot serve this: the repository's block filter
-  /// short-circuits `fetchFreshProfile` for a blocked pubkey, so a blocked
-  /// account the viewer never saw in a feed has nothing cached and renders as a
-  /// generated fallback name forever. Reviewing a block needs the real name and
-  /// avatar, so this path fetches with the filter bypassed. It is *about* the
-  /// account rather than a surface for its content.
-  BlockedUserProfileProvider._({
-    required BlockedUserProfileFamily super.from,
-    required String super.argument,
+  /// Fetching the set in bounded batches avoids starting a REST request plus two
+  /// relay queries for every uncached row when a synced mute list is large.
+  BlockedUserProfilesProvider._({
+    required BlockedUserProfilesFamily super.from,
+    required Set<String> super.argument,
   }) : super(
          retry: null,
-         name: r'blockedUserProfileProvider',
+         name: r'blockedUserProfilesProvider',
          isAutoDispose: true,
          dependencies: null,
          $allTransitiveDependencies: null,
        );
 
   @override
-  String debugGetCreateSourceHash() => _$blockedUserProfileHash();
+  String debugGetCreateSourceHash() => _$blockedUserProfilesHash();
 
   @override
   String toString() {
-    return r'blockedUserProfileProvider'
+    return r'blockedUserProfilesProvider'
         ''
         '($argument)';
   }
 
   @$internal
   @override
-  $StreamProviderElement<UserProfile?> $createElement(
+  $FutureProviderElement<Map<String, UserProfile>> $createElement(
     $ProviderPointer pointer,
-  ) => $StreamProviderElement(pointer);
+  ) => $FutureProviderElement(pointer);
 
   @override
-  Stream<UserProfile?> create(Ref ref) {
-    final argument = this.argument as String;
-    return blockedUserProfile(ref, argument);
+  FutureOr<Map<String, UserProfile>> create(Ref ref) {
+    final argument = this.argument as Set<String>;
+    return blockedUserProfiles(ref, argument);
   }
 
   @override
   bool operator ==(Object other) {
-    return other is BlockedUserProfileProvider && other.argument == argument;
+    return other is BlockedUserProfilesProvider && other.argument == argument;
   }
 
   @override
@@ -239,43 +229,39 @@ final class BlockedUserProfileProvider
   }
 }
 
-String _$blockedUserProfileHash() =>
-    r'99591a8116981c4015ffdae9d6f3dce3db3b6bd7';
+String _$blockedUserProfilesHash() =>
+    r'85f3707aa089783ffa55e4854d874a4a7bd3b68f';
 
-/// Reactive profile provider for a pubkey the viewer has blocked.
+/// Resolves profiles for the accounts the viewer has blocked.
 ///
-/// [userProfileReactive] cannot serve this: the repository's block filter
-/// short-circuits `fetchFreshProfile` for a blocked pubkey, so a blocked
-/// account the viewer never saw in a feed has nothing cached and renders as a
-/// generated fallback name forever. Reviewing a block needs the real name and
-/// avatar, so this path fetches with the filter bypassed. It is *about* the
-/// account rather than a surface for its content.
+/// Fetching the set in bounded batches avoids starting a REST request plus two
+/// relay queries for every uncached row when a synced mute list is large.
 
-final class BlockedUserProfileFamily extends $Family
-    with $FunctionalFamilyOverride<Stream<UserProfile?>, String> {
-  BlockedUserProfileFamily._()
+final class BlockedUserProfilesFamily extends $Family
+    with
+        $FunctionalFamilyOverride<
+          FutureOr<Map<String, UserProfile>>,
+          Set<String>
+        > {
+  BlockedUserProfilesFamily._()
     : super(
         retry: null,
-        name: r'blockedUserProfileProvider',
+        name: r'blockedUserProfilesProvider',
         dependencies: null,
         $allTransitiveDependencies: null,
         isAutoDispose: true,
       );
 
-  /// Reactive profile provider for a pubkey the viewer has blocked.
+  /// Resolves profiles for the accounts the viewer has blocked.
   ///
-  /// [userProfileReactive] cannot serve this: the repository's block filter
-  /// short-circuits `fetchFreshProfile` for a blocked pubkey, so a blocked
-  /// account the viewer never saw in a feed has nothing cached and renders as a
-  /// generated fallback name forever. Reviewing a block needs the real name and
-  /// avatar, so this path fetches with the filter bypassed. It is *about* the
-  /// account rather than a surface for its content.
+  /// Fetching the set in bounded batches avoids starting a REST request plus two
+  /// relay queries for every uncached row when a synced mute list is large.
 
-  BlockedUserProfileProvider call(String pubkey) =>
-      BlockedUserProfileProvider._(argument: pubkey, from: this);
+  BlockedUserProfilesProvider call(Set<String> pubkeys) =>
+      BlockedUserProfilesProvider._(argument: pubkeys, from: this);
 
   @override
-  String toString() => r'blockedUserProfileProvider';
+  String toString() => r'blockedUserProfilesProvider';
 }
 
 /// One-shot provider: returns cached profile or fetches fresh.

--- a/mobile/lib/providers/user_profile_providers.g.dart
+++ b/mobile/lib/providers/user_profile_providers.g.dart
@@ -158,6 +158,126 @@ final class UserProfileReactiveFamily extends $Family
   String toString() => r'userProfileReactiveProvider';
 }
 
+/// Reactive profile provider for a pubkey the viewer has blocked.
+///
+/// [userProfileReactive] cannot serve this: the repository's block filter
+/// short-circuits `fetchFreshProfile` for a blocked pubkey, so a blocked
+/// account the viewer never saw in a feed has nothing cached and renders as a
+/// generated fallback name forever. Reviewing a block needs the real name and
+/// avatar, so this path fetches with the filter bypassed. It is *about* the
+/// account rather than a surface for its content.
+
+@ProviderFor(blockedUserProfile)
+final blockedUserProfileProvider = BlockedUserProfileFamily._();
+
+/// Reactive profile provider for a pubkey the viewer has blocked.
+///
+/// [userProfileReactive] cannot serve this: the repository's block filter
+/// short-circuits `fetchFreshProfile` for a blocked pubkey, so a blocked
+/// account the viewer never saw in a feed has nothing cached and renders as a
+/// generated fallback name forever. Reviewing a block needs the real name and
+/// avatar, so this path fetches with the filter bypassed. It is *about* the
+/// account rather than a surface for its content.
+
+final class BlockedUserProfileProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<UserProfile?>,
+          UserProfile?,
+          Stream<UserProfile?>
+        >
+    with $FutureModifier<UserProfile?>, $StreamProvider<UserProfile?> {
+  /// Reactive profile provider for a pubkey the viewer has blocked.
+  ///
+  /// [userProfileReactive] cannot serve this: the repository's block filter
+  /// short-circuits `fetchFreshProfile` for a blocked pubkey, so a blocked
+  /// account the viewer never saw in a feed has nothing cached and renders as a
+  /// generated fallback name forever. Reviewing a block needs the real name and
+  /// avatar, so this path fetches with the filter bypassed. It is *about* the
+  /// account rather than a surface for its content.
+  BlockedUserProfileProvider._({
+    required BlockedUserProfileFamily super.from,
+    required String super.argument,
+  }) : super(
+         retry: null,
+         name: r'blockedUserProfileProvider',
+         isAutoDispose: true,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$blockedUserProfileHash();
+
+  @override
+  String toString() {
+    return r'blockedUserProfileProvider'
+        ''
+        '($argument)';
+  }
+
+  @$internal
+  @override
+  $StreamProviderElement<UserProfile?> $createElement(
+    $ProviderPointer pointer,
+  ) => $StreamProviderElement(pointer);
+
+  @override
+  Stream<UserProfile?> create(Ref ref) {
+    final argument = this.argument as String;
+    return blockedUserProfile(ref, argument);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is BlockedUserProfileProvider && other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$blockedUserProfileHash() =>
+    r'99591a8116981c4015ffdae9d6f3dce3db3b6bd7';
+
+/// Reactive profile provider for a pubkey the viewer has blocked.
+///
+/// [userProfileReactive] cannot serve this: the repository's block filter
+/// short-circuits `fetchFreshProfile` for a blocked pubkey, so a blocked
+/// account the viewer never saw in a feed has nothing cached and renders as a
+/// generated fallback name forever. Reviewing a block needs the real name and
+/// avatar, so this path fetches with the filter bypassed. It is *about* the
+/// account rather than a surface for its content.
+
+final class BlockedUserProfileFamily extends $Family
+    with $FunctionalFamilyOverride<Stream<UserProfile?>, String> {
+  BlockedUserProfileFamily._()
+    : super(
+        retry: null,
+        name: r'blockedUserProfileProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: true,
+      );
+
+  /// Reactive profile provider for a pubkey the viewer has blocked.
+  ///
+  /// [userProfileReactive] cannot serve this: the repository's block filter
+  /// short-circuits `fetchFreshProfile` for a blocked pubkey, so a blocked
+  /// account the viewer never saw in a feed has nothing cached and renders as a
+  /// generated fallback name forever. Reviewing a block needs the real name and
+  /// avatar, so this path fetches with the filter bypassed. It is *about* the
+  /// account rather than a surface for its content.
+
+  BlockedUserProfileProvider call(String pubkey) =>
+      BlockedUserProfileProvider._(argument: pubkey, from: this);
+
+  @override
+  String toString() => r'blockedUserProfileProvider';
+}
+
 /// One-shot provider: returns cached profile or fetches fresh.
 ///
 /// Use this when you need a single read (e.g., building a share sheet)

--- a/mobile/lib/screens/safety_settings_screen.dart
+++ b/mobile/lib/screens/safety_settings_screen.dart
@@ -435,13 +435,12 @@ class _BlockedUsersSection extends ConsumerWidget {
         ),
       );
     }
-    final profiles = ref.watch(blockedUserProfilesProvider(blockedUsers)).value;
+    ref.watch(blockedUserProfilesProvider(blockedUsers));
     return Column(
       children: blockedUsers
           .map(
             (pubkey) => _BlockedUserTile(
               pubkey: pubkey,
-              profile: profiles?[pubkey],
               onUnblock: () => _unblockUser(context, pubkey),
             ),
           )
@@ -464,20 +463,18 @@ class _BlockedUsersSection extends ConsumerWidget {
 }
 
 /// Tile widget for displaying a blocked user with unblock option.
-class _BlockedUserTile extends StatelessWidget {
+class _BlockedUserTile extends ConsumerWidget {
   const _BlockedUserTile({
     required this.pubkey,
-    required this.profile,
     required this.onUnblock,
   });
 
   final String pubkey;
-  final UserProfile? profile;
   final VoidCallback onUnblock;
 
   @override
-  Widget build(BuildContext context) {
-    final profile = this.profile;
+  Widget build(BuildContext context, WidgetRef ref) {
+    final profile = ref.watch(blockedUserProfileProvider(pubkey)).value;
     final displayName =
         profile?.bestDisplayName ?? UserProfile.defaultDisplayNameFor(pubkey);
     // No relationship line here: "You follow" under an account you have

--- a/mobile/lib/screens/safety_settings_screen.dart
+++ b/mobile/lib/screens/safety_settings_screen.dart
@@ -470,7 +470,7 @@ class _BlockedUserTile extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final profileAsync = ref.watch(userProfileReactiveProvider(pubkey));
+    final profileAsync = ref.watch(blockedUserProfileProvider(pubkey));
     final profile = profileAsync.value;
     final displayName =
         profile?.bestDisplayName ?? UserProfile.defaultDisplayNameFor(pubkey);

--- a/mobile/lib/screens/safety_settings_screen.dart
+++ b/mobile/lib/screens/safety_settings_screen.dart
@@ -416,11 +416,11 @@ class _AddLabelerSheetState extends State<_AddLabelerSheet> {
   }
 }
 
-class _BlockedUsersSection extends StatelessWidget {
+class _BlockedUsersSection extends ConsumerWidget {
   const _BlockedUsersSection();
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final blockedUsers = context.select(
       (SafetySettingsCubit cubit) => cubit.state.blockedUsers,
     );
@@ -435,11 +435,13 @@ class _BlockedUsersSection extends StatelessWidget {
         ),
       );
     }
+    final profiles = ref.watch(blockedUserProfilesProvider(blockedUsers)).value;
     return Column(
       children: blockedUsers
           .map(
             (pubkey) => _BlockedUserTile(
               pubkey: pubkey,
+              profile: profiles?[pubkey],
               onUnblock: () => _unblockUser(context, pubkey),
             ),
           )
@@ -462,16 +464,20 @@ class _BlockedUsersSection extends StatelessWidget {
 }
 
 /// Tile widget for displaying a blocked user with unblock option.
-class _BlockedUserTile extends ConsumerWidget {
-  const _BlockedUserTile({required this.pubkey, required this.onUnblock});
+class _BlockedUserTile extends StatelessWidget {
+  const _BlockedUserTile({
+    required this.pubkey,
+    required this.profile,
+    required this.onUnblock,
+  });
 
   final String pubkey;
+  final UserProfile? profile;
   final VoidCallback onUnblock;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final profileAsync = ref.watch(blockedUserProfileProvider(pubkey));
-    final profile = profileAsync.value;
+  Widget build(BuildContext context) {
+    final profile = this.profile;
     final displayName =
         profile?.bestDisplayName ?? UserProfile.defaultDisplayNameFor(pubkey);
     // No relationship line here: "You follow" under an account you have

--- a/mobile/packages/profile_repository/lib/src/profile_reader.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_reader.dart
@@ -62,22 +62,19 @@ abstract interface class ProfileReader {
   ///
   /// Reads only — the relay query and the funnelcake REST fallback are both
   /// unauthenticated. Returns `null` when no profile exists anywhere.
-  ///
-  /// Set [ignoreBlockFilter] when the caller is *about* the blocked account
-  /// rather than showing its content — the blocked-users list in Safety
-  /// Settings needs a name and avatar to be reviewable at all.
   Future<UserProfile?> fetchFreshProfile({
     required String pubkey,
     bool requireRawKind0,
     List<Duration> rawKind0RetryDelays,
-    bool ignoreBlockFilter,
   });
 
   /// Resolves many profiles at once, preferring the Drift cache.
   ///
   /// Partial results are returned rather than throwing.
+  /// Set [ignoreBlockFilter] only for a surface that manages blocked accounts.
   Future<Map<String, UserProfile>> fetchBatchProfiles({
     required List<String> pubkeys,
+    bool ignoreBlockFilter,
   });
 
   /// Returns the cached NIP-39 `i` tag list for [pubkey] from local storage.

--- a/mobile/packages/profile_repository/lib/src/profile_reader.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_reader.dart
@@ -47,9 +47,7 @@ abstract interface class ProfileReader {
   /// guards. Pubkeys without a cached profile, or profiles filtered by the
   /// repository's block policy, are absent from the result, which is not
   /// order-aligned with [pubkeys].
-  Future<List<UserProfile>> getCachedProfiles({
-    required List<String> pubkeys,
-  });
+  Future<List<UserProfile>> getCachedProfiles({required List<String> pubkeys});
 
   /// Watches the cached profile for [pubkey], emitting on every cache write.
   Stream<UserProfile?> watchProfile({required String pubkey});
@@ -64,10 +62,15 @@ abstract interface class ProfileReader {
   ///
   /// Reads only — the relay query and the funnelcake REST fallback are both
   /// unauthenticated. Returns `null` when no profile exists anywhere.
+  ///
+  /// Set [ignoreBlockFilter] when the caller is *about* the blocked account
+  /// rather than showing its content — the blocked-users list in Safety
+  /// Settings needs a name and avatar to be reviewable at all.
   Future<UserProfile?> fetchFreshProfile({
     required String pubkey,
     bool requireRawKind0,
     List<Duration> rawKind0RetryDelays,
+    bool ignoreBlockFilter,
   });
 
   /// Resolves many profiles at once, preferring the Drift cache.

--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -765,7 +765,6 @@ class ProfileRepository implements ProfileReader {
     required String pubkey,
     bool requireRawKind0 = false,
     List<Duration> rawKind0RetryDelays = const [],
-    bool ignoreBlockFilter = false,
   }) {
     if (_vanished.contains(pubkey)) {
       revalidateVanishOnce(pubkey);
@@ -776,7 +775,6 @@ class ProfileRepository implements ProfileReader {
       pubkey: pubkey,
       requireRawKind0: requireRawKind0,
       rawKind0RetryDelays: rawKind0RetryDelays,
-      ignoreBlockFilter: ignoreBlockFilter,
     );
   }
 
@@ -788,7 +786,6 @@ class ProfileRepository implements ProfileReader {
     required String pubkey,
     bool requireRawKind0 = false,
     List<Duration> rawKind0RetryDelays = const [],
-    bool ignoreBlockFilter = false,
   }) {
     if (requireRawKind0 && _rawKind0ConfirmedMissing.contains(pubkey)) {
       return Future<UserProfile?>.value();
@@ -800,13 +797,9 @@ class ProfileRepository implements ProfileReader {
     _confirmedMissing.remove(pubkey);
 
     // Deduplicate: return existing in-flight future if present.
-    final rawKind0Suffix = requireRawKind0
-        ? '#raw-kind0#retry-${rawKind0RetryDelays.length}'
-        : '';
-    // A bypassing call must not dedupe onto a filtered one and inherit its
-    // null.
-    final blockFilterSuffix = ignoreBlockFilter ? '#no-block-filter' : '';
-    final fetchKey = '$pubkey$rawKind0Suffix$blockFilterSuffix';
+    final fetchKey = requireRawKind0
+        ? '$pubkey#raw-kind0#retry-${rawKind0RetryDelays.length}'
+        : pubkey;
     final existing = _inFlightFetches[fetchKey];
     if (existing != null) return existing;
 
@@ -814,7 +807,6 @@ class ProfileRepository implements ProfileReader {
       pubkey,
       requireRawKind0: requireRawKind0,
       rawKind0RetryDelays: rawKind0RetryDelays,
-      ignoreBlockFilter: ignoreBlockFilter,
     );
     _inFlightFetches[fetchKey] = future;
 
@@ -825,12 +817,10 @@ class ProfileRepository implements ProfileReader {
     String pubkey, {
     required bool requireRawKind0,
     required List<Duration> rawKind0RetryDelays,
-    bool ignoreBlockFilter = false,
   }) async {
     final first = await _doFetchFreshProfile(
       pubkey,
       requireRawKind0: requireRawKind0,
-      ignoreBlockFilter: ignoreBlockFilter,
     );
     if (!requireRawKind0 || first != null) return first;
 
@@ -841,7 +831,6 @@ class ProfileRepository implements ProfileReader {
       final retry = await _doFetchFreshProfile(
         pubkey,
         requireRawKind0: true,
-        ignoreBlockFilter: ignoreBlockFilter,
       );
       if (retry != null) return retry;
     }
@@ -853,11 +842,8 @@ class ProfileRepository implements ProfileReader {
   Future<UserProfile?> _doFetchFreshProfile(
     String pubkey, {
     required bool requireRawKind0,
-    bool ignoreBlockFilter = false,
   }) async {
-    if (!ignoreBlockFilter && (_blockFilter?.call(pubkey) ?? false)) {
-      return null;
-    }
+    if (_blockFilter?.call(pubkey) ?? false) return null;
 
     // Step 1: Try Funnelcake REST API (fast, broad coverage).
     if (_funnelcakeApiClient?.isAvailable ?? false) {
@@ -2455,6 +2441,7 @@ class ProfileRepository implements ProfileReader {
   @override
   Future<Map<String, UserProfile>> fetchBatchProfiles({
     required List<String> pubkeys,
+    bool ignoreBlockFilter = false,
   }) async {
     if (pubkeys.isEmpty) return {};
 
@@ -2463,7 +2450,7 @@ class ProfileRepository implements ProfileReader {
 
     Map<String, UserProfile> filteredResults() {
       final blockFilter = _blockFilter;
-      if (blockFilter != null) {
+      if (!ignoreBlockFilter && blockFilter != null) {
         results.removeWhere((pubkey, _) => blockFilter(pubkey));
       }
       return results;

--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -646,12 +646,9 @@ class ProfileRepository implements ProfileReader {
   /// Returns `null` when no event is found or the query fails.
   Future<Event?> _fetchIdentityEvent(String pubkey) async {
     try {
-      final events = await _nostrClient.queryEvents(
-        [
-          Filter(kinds: const [identityEventKind], authors: [pubkey], limit: 5),
-        ],
-        useCache: false,
-      );
+      final events = await _nostrClient.queryEvents([
+        Filter(kinds: const [identityEventKind], authors: [pubkey], limit: 5),
+      ], useCache: false);
       return newestIdentityEvent(
         events.where((e) => e.kind == identityEventKind).toList(),
       );
@@ -768,6 +765,7 @@ class ProfileRepository implements ProfileReader {
     required String pubkey,
     bool requireRawKind0 = false,
     List<Duration> rawKind0RetryDelays = const [],
+    bool ignoreBlockFilter = false,
   }) {
     if (_vanished.contains(pubkey)) {
       revalidateVanishOnce(pubkey);
@@ -778,6 +776,7 @@ class ProfileRepository implements ProfileReader {
       pubkey: pubkey,
       requireRawKind0: requireRawKind0,
       rawKind0RetryDelays: rawKind0RetryDelays,
+      ignoreBlockFilter: ignoreBlockFilter,
     );
   }
 
@@ -789,6 +788,7 @@ class ProfileRepository implements ProfileReader {
     required String pubkey,
     bool requireRawKind0 = false,
     List<Duration> rawKind0RetryDelays = const [],
+    bool ignoreBlockFilter = false,
   }) {
     if (requireRawKind0 && _rawKind0ConfirmedMissing.contains(pubkey)) {
       return Future<UserProfile?>.value();
@@ -800,9 +800,13 @@ class ProfileRepository implements ProfileReader {
     _confirmedMissing.remove(pubkey);
 
     // Deduplicate: return existing in-flight future if present.
-    final fetchKey = requireRawKind0
-        ? '$pubkey#raw-kind0#retry-${rawKind0RetryDelays.length}'
-        : pubkey;
+    final rawKind0Suffix = requireRawKind0
+        ? '#raw-kind0#retry-${rawKind0RetryDelays.length}'
+        : '';
+    // A bypassing call must not dedupe onto a filtered one and inherit its
+    // null.
+    final blockFilterSuffix = ignoreBlockFilter ? '#no-block-filter' : '';
+    final fetchKey = '$pubkey$rawKind0Suffix$blockFilterSuffix';
     final existing = _inFlightFetches[fetchKey];
     if (existing != null) return existing;
 
@@ -810,6 +814,7 @@ class ProfileRepository implements ProfileReader {
       pubkey,
       requireRawKind0: requireRawKind0,
       rawKind0RetryDelays: rawKind0RetryDelays,
+      ignoreBlockFilter: ignoreBlockFilter,
     );
     _inFlightFetches[fetchKey] = future;
 
@@ -820,10 +825,12 @@ class ProfileRepository implements ProfileReader {
     String pubkey, {
     required bool requireRawKind0,
     required List<Duration> rawKind0RetryDelays,
+    bool ignoreBlockFilter = false,
   }) async {
     final first = await _doFetchFreshProfile(
       pubkey,
       requireRawKind0: requireRawKind0,
+      ignoreBlockFilter: ignoreBlockFilter,
     );
     if (!requireRawKind0 || first != null) return first;
 
@@ -831,7 +838,11 @@ class ProfileRepository implements ProfileReader {
       if (delay > Duration.zero) {
         await Future<void>.delayed(delay);
       }
-      final retry = await _doFetchFreshProfile(pubkey, requireRawKind0: true);
+      final retry = await _doFetchFreshProfile(
+        pubkey,
+        requireRawKind0: true,
+        ignoreBlockFilter: ignoreBlockFilter,
+      );
       if (retry != null) return retry;
     }
 
@@ -842,8 +853,11 @@ class ProfileRepository implements ProfileReader {
   Future<UserProfile?> _doFetchFreshProfile(
     String pubkey, {
     required bool requireRawKind0,
+    bool ignoreBlockFilter = false,
   }) async {
-    if (_blockFilter?.call(pubkey) ?? false) return null;
+    if (!ignoreBlockFilter && (_blockFilter?.call(pubkey) ?? false)) {
+      return null;
+    }
 
     // Step 1: Try Funnelcake REST API (fast, broad coverage).
     if (_funnelcakeApiClient?.isAvailable ?? false) {

--- a/mobile/packages/profile_repository/test/src/profile_reader_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_reader_test.dart
@@ -51,6 +51,7 @@ class _ExhaustiveReader implements ProfileReader {
     required String pubkey,
     bool requireRawKind0 = false,
     List<Duration> rawKind0RetryDelays = const [],
+    bool ignoreBlockFilter = false,
   }) async => null;
 
   @override

--- a/mobile/packages/profile_repository/test/src/profile_reader_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_reader_test.dart
@@ -51,12 +51,12 @@ class _ExhaustiveReader implements ProfileReader {
     required String pubkey,
     bool requireRawKind0 = false,
     List<Duration> rawKind0RetryDelays = const [],
-    bool ignoreBlockFilter = false,
   }) async => null;
 
   @override
   Future<Map<String, UserProfile>> fetchBatchProfiles({
     required List<String> pubkeys,
+    bool ignoreBlockFilter = false,
   }) async => {};
 
   @override

--- a/mobile/packages/profile_repository/test/src/profile_repository_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_test.dart
@@ -635,6 +635,42 @@ void main() {
         },
       );
 
+      test('fetches a blocked pubkey when ignoreBlockFilter is set', () async {
+        final blockingRepository = ProfileRepository(
+          nostrClient: mockNostrClient,
+          userProfilesDao: mockUserProfilesDao,
+          httpClient: mockHttpClient,
+          blockFilter: (pubkey) => pubkey == testPubkey,
+        );
+
+        final result = await blockingRepository.fetchFreshProfile(
+          pubkey: testPubkey,
+          ignoreBlockFilter: true,
+        );
+
+        expect(result?.displayName, equals('Test User'));
+      });
+
+      test('bypassing fetch does not dedupe onto a filtered one', () async {
+        final blockingRepository = ProfileRepository(
+          nostrClient: mockNostrClient,
+          userProfilesDao: mockUserProfilesDao,
+          httpClient: mockHttpClient,
+          blockFilter: (pubkey) => pubkey == testPubkey,
+        );
+
+        final results = await Future.wait([
+          blockingRepository.fetchFreshProfile(pubkey: testPubkey),
+          blockingRepository.fetchFreshProfile(
+            pubkey: testPubkey,
+            ignoreBlockFilter: true,
+          ),
+        ]);
+
+        expect(results.first, isNull);
+        expect(results.last?.displayName, equals('Test User'));
+      });
+
       test('deduplicates concurrent calls for the same pubkey', () async {
         final results = await Future.wait([
           profileRepository.fetchFreshProfile(pubkey: testPubkey),
@@ -5728,34 +5764,31 @@ void main() {
       // timeout does, on a fully keyed account. Nothing between here and the
       // signer catches, and this method's own handler is `on Exception`, so
       // without local containment the throw left claimUsername entirely.
-      test(
-        'returns UsernameClaimError when the signer throws',
-        () async {
-          when(
-            () => mockNostrClient.createNip98AuthHeader(
-              url: any(named: 'url'),
-              method: any(named: 'method'),
-              payload: any(named: 'payload'),
-            ),
-          ).thenThrow(StateError('no signer'));
+      test('returns UsernameClaimError when the signer throws', () async {
+        when(
+          () => mockNostrClient.createNip98AuthHeader(
+            url: any(named: 'url'),
+            method: any(named: 'method'),
+            payload: any(named: 'payload'),
+          ),
+        ).thenThrow(StateError('no signer'));
 
-          final usernameClaimResult = await profileRepository.claimUsername(
-            username: 'username',
-          );
+        final usernameClaimResult = await profileRepository.claimUsername(
+          username: 'username',
+        );
 
-          expect(
-            usernameClaimResult,
-            isA<UsernameClaimError>().having(
-              (e) => e.message,
-              'message',
-              'Signing failed',
-            ),
-          );
+        expect(
+          usernameClaimResult,
+          isA<UsernameClaimError>().having(
+            (e) => e.message,
+            'message',
+            'Signing failed',
+          ),
+        );
 
-          // The request never left the device, so no name was claimed.
-          verifyNever(() => mockHttpClient.post(any()));
-        },
-      );
+        // The request never left the device, so no name was claimed.
+        verifyNever(() => mockHttpClient.post(any()));
+      });
 
       test(
         'sends lowercase username in payload for mixed-case input',
@@ -5952,9 +5985,7 @@ void main() {
       }) {
         when(
           () => mockHttpClient.get(
-            Uri.parse(
-              '$_testNameServer/api/username/check/$username',
-            ),
+            Uri.parse('$_testNameServer/api/username/check/$username'),
           ),
         ).thenAnswer(
           (_) async => Response(
@@ -6353,9 +6384,7 @@ void main() {
         fakeAsync((async) {
           when(
             () => mockHttpClient.get(
-              Uri.parse(
-                '$_testNameServer/api/username/check/testuser',
-              ),
+              Uri.parse('$_testNameServer/api/username/check/testuser'),
             ),
           ).thenAnswer((_) async {
             // Simulates an unresponsive name server: never resolves within

--- a/mobile/packages/profile_repository/test/src/profile_repository_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_test.dart
@@ -635,42 +635,6 @@ void main() {
         },
       );
 
-      test('fetches a blocked pubkey when ignoreBlockFilter is set', () async {
-        final blockingRepository = ProfileRepository(
-          nostrClient: mockNostrClient,
-          userProfilesDao: mockUserProfilesDao,
-          httpClient: mockHttpClient,
-          blockFilter: (pubkey) => pubkey == testPubkey,
-        );
-
-        final result = await blockingRepository.fetchFreshProfile(
-          pubkey: testPubkey,
-          ignoreBlockFilter: true,
-        );
-
-        expect(result?.displayName, equals('Test User'));
-      });
-
-      test('bypassing fetch does not dedupe onto a filtered one', () async {
-        final blockingRepository = ProfileRepository(
-          nostrClient: mockNostrClient,
-          userProfilesDao: mockUserProfilesDao,
-          httpClient: mockHttpClient,
-          blockFilter: (pubkey) => pubkey == testPubkey,
-        );
-
-        final results = await Future.wait([
-          blockingRepository.fetchFreshProfile(pubkey: testPubkey),
-          blockingRepository.fetchFreshProfile(
-            pubkey: testPubkey,
-            ignoreBlockFilter: true,
-          ),
-        ]);
-
-        expect(results.first, isNull);
-        expect(results.last?.displayName, equals('Test User'));
-      });
-
       test('deduplicates concurrent calls for the same pubkey', () async {
         final results = await Future.wait([
           profileRepository.fetchFreshProfile(pubkey: testPubkey),
@@ -6833,6 +6797,48 @@ void main() {
         expect(result[testPubkey2]?.displayName, equals('Allowed Cached'));
         verifyNever(() => mockNostrClient.fetchProfile(any()));
       });
+
+      test(
+        'returns uncached blocked profiles when the block filter is bypassed',
+        () async {
+          when(
+            () => mockUserProfilesDao.getProfilesByPubkeys([testPubkey]),
+          ).thenAnswer((_) async => []);
+          when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+          when(
+            () => mockFunnelcakeClient.getBulkProfiles([testPubkey]),
+          ).thenAnswer(
+            (_) async => BulkProfilesResponse(
+              profiles: {
+                testPubkey: UserProfileFound(
+                  profile: UserProfileData.fromJson(testPubkey, const {
+                    'display_name': 'Blocked API User',
+                  }),
+                ),
+              },
+            ),
+          );
+          when(
+            () => mockUserProfilesDao.upsertProfiles(any()),
+          ).thenAnswer((_) async {});
+
+          final repoWithBlockFilter = ProfileRepository(
+            nostrClient: mockNostrClient,
+            userProfilesDao: mockUserProfilesDao,
+            httpClient: mockHttpClient,
+            funnelcakeApiClient: mockFunnelcakeClient,
+            blockFilter: (pubkey) => pubkey == testPubkey,
+          );
+
+          final result = await repoWithBlockFilter.fetchBatchProfiles(
+            pubkeys: [testPubkey],
+            ignoreBlockFilter: true,
+          );
+
+          expect(result[testPubkey]?.displayName, equals('Blocked API User'));
+          verifyNever(() => mockNostrClient.fetchProfile(any()));
+        },
+      );
 
       test('fetches uncached from Funnelcake API', () async {
         when(

--- a/mobile/test/providers/user_profile_providers_test.dart
+++ b/mobile/test/providers/user_profile_providers_test.dart
@@ -219,7 +219,7 @@ void main() {
     );
   });
 
-  group('blockedUserProfileProvider', () {
+  group('blockedUserProfilesProvider', () {
     late _MockProfileRepository profileRepository;
     late ProviderContainer container;
 
@@ -233,74 +233,48 @@ void main() {
       addTearDown(container.dispose);
     });
 
-    test('fetches a blocked pubkey with the block filter bypassed', () async {
-      final liveController = StreamController<UserProfile?>();
-      addTearDown(liveController.close);
-
+    test('fetches blocked pubkeys in one filter-bypassing batch', () async {
+      final blockedProfile = _profile(pubkey, name: 'blocked');
       when(
-        () => profileRepository.getCachedProfile(pubkey: pubkey),
-      ).thenAnswer((_) async => null);
-      when(
-        () => profileRepository.fetchFreshProfile(
-          pubkey: pubkey,
+        () => profileRepository.fetchBatchProfiles(
+          pubkeys: [pubkey],
           ignoreBlockFilter: true,
         ),
-      ).thenAnswer((_) async => null);
-      when(
-        () => profileRepository.watchProfile(pubkey: pubkey),
-      ).thenAnswer((_) => liveController.stream);
+      ).thenAnswer((_) async => {pubkey: blockedProfile});
 
-      final sub = container.listen(
-        blockedUserProfileProvider(pubkey),
-        (_, _) {},
-        fireImmediately: true,
+      final result = await container.read(
+        blockedUserProfilesProvider({pubkey}).future,
       );
-      addTearDown(sub.close);
 
-      await Future<void>.delayed(Duration.zero);
-
+      expect(result, {pubkey: blockedProfile});
       verify(
-        () => profileRepository.fetchFreshProfile(
-          pubkey: pubkey,
+        () => profileRepository.fetchBatchProfiles(
+          pubkeys: [pubkey],
           ignoreBlockFilter: true,
         ),
       ).called(1);
     });
 
-    test('emits the cached profile without fetching', () async {
-      final liveController = StreamController<UserProfile?>();
-      addTearDown(liveController.close);
-      final cachedProfile = _profile(pubkey, name: 'blocked');
-
+    test('chunks large blocklists into bounded batch requests', () async {
+      final pubkeys = {
+        for (var i = 0; i < 51; i++) i.toString().padLeft(64, '0'),
+      };
       when(
-        () => profileRepository.getCachedProfile(pubkey: pubkey),
-      ).thenAnswer((_) async => cachedProfile);
-      when(
-        () => profileRepository.watchProfile(pubkey: pubkey),
-      ).thenAnswer((_) => liveController.stream);
-
-      final emitted = <AsyncValue<UserProfile?>>[];
-      final sub = container.listen(
-        blockedUserProfileProvider(pubkey),
-        (_, next) => emitted.add(next),
-        fireImmediately: true,
-      );
-      addTearDown(sub.close);
-
-      await untilCalled(() => profileRepository.watchProfile(pubkey: pubkey));
-      liveController.add(cachedProfile);
-      await Future<void>.delayed(Duration.zero);
-
-      expect(
-        emitted.where((value) => value.hasValue).map((v) => v.value),
-        [cachedProfile],
-      );
-      verifyNever(
-        () => profileRepository.fetchFreshProfile(
-          pubkey: pubkey,
+        () => profileRepository.fetchBatchProfiles(
+          pubkeys: any(named: 'pubkeys'),
           ignoreBlockFilter: true,
         ),
-      );
+      ).thenAnswer((_) async => {});
+
+      await container.read(blockedUserProfilesProvider(pubkeys).future);
+
+      final captured = verify(
+        () => profileRepository.fetchBatchProfiles(
+          pubkeys: captureAny(named: 'pubkeys'),
+          ignoreBlockFilter: true,
+        ),
+      ).captured.cast<List<String>>();
+      expect(captured.map((chunk) => chunk.length), [50, 1]);
     });
   });
 

--- a/mobile/test/providers/user_profile_providers_test.dart
+++ b/mobile/test/providers/user_profile_providers_test.dart
@@ -278,6 +278,45 @@ void main() {
     });
   });
 
+  group('blockedUserProfileProvider', () {
+    test('streams cache updates without starting a per-user fetch', () async {
+      final profileRepository = _MockProfileRepository();
+      final updates = StreamController<UserProfile?>();
+      addTearDown(updates.close);
+      when(
+        () => profileRepository.watchProfile(pubkey: pubkey),
+      ).thenAnswer((_) => updates.stream);
+      final container = ProviderContainer(
+        overrides: [
+          profileReadRepositoryProvider.overrideWithValue(profileRepository),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final emitted = <UserProfile?>[];
+      final subscription = container.listen(
+        blockedUserProfileProvider(pubkey),
+        (_, next) {
+          if (next.hasValue) emitted.add(next.value);
+        },
+        fireImmediately: true,
+      );
+      addTearDown(subscription.close);
+      final cachedProfile = _profile(pubkey, name: 'updated');
+
+      updates.add(cachedProfile);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(emitted, [cachedProfile]);
+      verify(
+        () => profileRepository.watchProfile(pubkey: pubkey),
+      ).called(1);
+      verifyNever(
+        () => profileRepository.fetchFreshProfile(pubkey: any(named: 'pubkey')),
+      );
+    });
+  });
+
   group('fetchUserProfileProvider', () {
     late _MockProfileRepository profileRepository;
     late ProviderContainer container;

--- a/mobile/test/providers/user_profile_providers_test.dart
+++ b/mobile/test/providers/user_profile_providers_test.dart
@@ -219,6 +219,91 @@ void main() {
     );
   });
 
+  group('blockedUserProfileProvider', () {
+    late _MockProfileRepository profileRepository;
+    late ProviderContainer container;
+
+    setUp(() {
+      profileRepository = _MockProfileRepository();
+      container = ProviderContainer(
+        overrides: [
+          profileReadRepositoryProvider.overrideWithValue(profileRepository),
+        ],
+      );
+      addTearDown(container.dispose);
+    });
+
+    test('fetches a blocked pubkey with the block filter bypassed', () async {
+      final liveController = StreamController<UserProfile?>();
+      addTearDown(liveController.close);
+
+      when(
+        () => profileRepository.getCachedProfile(pubkey: pubkey),
+      ).thenAnswer((_) async => null);
+      when(
+        () => profileRepository.fetchFreshProfile(
+          pubkey: pubkey,
+          ignoreBlockFilter: true,
+        ),
+      ).thenAnswer((_) async => null);
+      when(
+        () => profileRepository.watchProfile(pubkey: pubkey),
+      ).thenAnswer((_) => liveController.stream);
+
+      final sub = container.listen(
+        blockedUserProfileProvider(pubkey),
+        (_, _) {},
+        fireImmediately: true,
+      );
+      addTearDown(sub.close);
+
+      await Future<void>.delayed(Duration.zero);
+
+      verify(
+        () => profileRepository.fetchFreshProfile(
+          pubkey: pubkey,
+          ignoreBlockFilter: true,
+        ),
+      ).called(1);
+    });
+
+    test('emits the cached profile without fetching', () async {
+      final liveController = StreamController<UserProfile?>();
+      addTearDown(liveController.close);
+      final cachedProfile = _profile(pubkey, name: 'blocked');
+
+      when(
+        () => profileRepository.getCachedProfile(pubkey: pubkey),
+      ).thenAnswer((_) async => cachedProfile);
+      when(
+        () => profileRepository.watchProfile(pubkey: pubkey),
+      ).thenAnswer((_) => liveController.stream);
+
+      final emitted = <AsyncValue<UserProfile?>>[];
+      final sub = container.listen(
+        blockedUserProfileProvider(pubkey),
+        (_, next) => emitted.add(next),
+        fireImmediately: true,
+      );
+      addTearDown(sub.close);
+
+      await untilCalled(() => profileRepository.watchProfile(pubkey: pubkey));
+      liveController.add(cachedProfile);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(
+        emitted.where((value) => value.hasValue).map((v) => v.value),
+        [cachedProfile],
+      );
+      verifyNever(
+        () => profileRepository.fetchFreshProfile(
+          pubkey: pubkey,
+          ignoreBlockFilter: true,
+        ),
+      );
+    });
+  });
+
   group('fetchUserProfileProvider', () {
     late _MockProfileRepository profileRepository;
     late ProviderContainer container;

--- a/mobile/test/screens/safety_settings_screen_test.dart
+++ b/mobile/test/screens/safety_settings_screen_test.dart
@@ -205,8 +205,10 @@ void main() {
           userProfileReactiveProvider.overrideWith(
             (ref, pubkey) => Stream.value(profiles[pubkey]),
           ),
-          blockedUserProfileProvider.overrideWith(
-            (ref, pubkey) => Stream.value(profiles[pubkey]),
+          blockedUserProfilesProvider.overrideWith(
+            (ref, pubkeys) async => {
+              for (final pubkey in pubkeys) pubkey: ?profiles[pubkey],
+            },
           ),
         ],
       );

--- a/mobile/test/screens/safety_settings_screen_test.dart
+++ b/mobile/test/screens/safety_settings_screen_test.dart
@@ -205,6 +205,9 @@ void main() {
           userProfileReactiveProvider.overrideWith(
             (ref, pubkey) => Stream.value(profiles[pubkey]),
           ),
+          blockedUserProfileProvider.overrideWith(
+            (ref, pubkey) => Stream.value(profiles[pubkey]),
+          ),
           blockedUserProfilesProvider.overrideWith(
             (ref, pubkeys) async => {
               for (final pubkey in pubkeys) pubkey: ?profiles[pubkey],

--- a/mobile/test/screens/safety_settings_screen_test.dart
+++ b/mobile/test/screens/safety_settings_screen_test.dart
@@ -205,6 +205,9 @@ void main() {
           userProfileReactiveProvider.overrideWith(
             (ref, pubkey) => Stream.value(profiles[pubkey]),
           ),
+          blockedUserProfileProvider.overrideWith(
+            (ref, pubkey) => Stream.value(profiles[pubkey]),
+          ),
         ],
       );
 
@@ -258,6 +261,37 @@ void main() {
         findsOneWidget,
       );
       expect(find.text(npub), findsOneWidget);
+    });
+
+    testWidgets('blocked users show their real name and nip05', (
+      tester,
+    ) async {
+      await mockBlocklistRepository.blockUser(blockedPubkey);
+
+      await tester.pumpWidget(
+        createTestWidget(
+          profiles: {
+            blockedPubkey: UserProfile(
+              pubkey: blockedPubkey,
+              displayName: 'Loud Neighbour',
+              nip05: '_@loud.divine.video',
+              rawData: const {},
+              createdAt: DateTime.utc(2026),
+              eventId: 'blocked-profile-event',
+            ),
+          },
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.scrollUntilVisible(find.text('Loud Neighbour'), 200);
+
+      expect(find.text('Loud Neighbour'), findsOneWidget);
+      expect(find.text('@loud'), findsOneWidget);
+      expect(
+        find.text(UserProfile.defaultDisplayNameFor(blockedPubkey)),
+        findsNothing,
+      );
     });
 
     testWidgets(


### PR DESCRIPTION
## What

The blocked-users list in Content & Safety showed generated `Adjective Animal NN` fallback names and default avatars instead of the real profile, so there was no way to tell who you had blocked.

## Why

`ProfileRepository._doFetchFreshProfile` returns `null` immediately when the pubkey passes the injected block filter. That is right for content surfaces, but it also means a blocked account's kind-0 can never be fetched. An account blocked via a mute list synced from a relay — never encountered in a feed, so never cached — has no profile row at all, and the tile falls back to `UserProfile.defaultDisplayNameFor`, which reads like a real name and isn't one.

The cache read path (`getCachedProfile` / `watchProfile`) is unfiltered and `blockUser` does not purge the cache, so the fetch gate was the whole cause.

## How

- `fetchBatchProfiles` takes `ignoreBlockFilter` (default `false`) so the blocked-users surface can hydrate real profiles without relaxing filtering for existing callers.
- `blockedUserProfilesProvider` hydrates the cache in sequential chunks of 50, bounding REST and relay work for large synced mute lists.
- Each tile watches its pubkey's Drift cache without starting another network fetch, so batch results and later profile updates appear reactively.

Reviewing a block is *about* the account, not a surface for its content, which is why the bypass is scoped to this one provider rather than relaxing the filter.

## Testing

- `profile_repository`: an uncached blocked profile is returned only when the batch filter is explicitly bypassed. Full suite: 447 tests passed, `--coverage` 100% (0 uncovered lines).
- `user_profile_providers_test`: covers filter-bypassing batch hydration, bounded chunking, and reactive cache updates without a per-user fetch.
- `safety_settings_screen_test`: a blocked user with a profile renders the real name and nip05, and *not* the generated fallback.
- `flutter analyze`: clean.
- `mise run test`: 17,972 passed, 280 skipped.


Closes #8050
