### PR TITLE
fix(supporters): recover paid purchases on app launch

### DIFF
--- a/mobile/lib/providers/supporter_providers.dart
+++ b/mobile/lib/providers/supporter_providers.dart
@@ -74,7 +74,7 @@ EntitlementValidator entitlementValidator(Ref ref) {
 }
 
 /// The account-scoped [SupporterRepository] that owns the cached entitlement.
-@riverpod
+@Riverpod(keepAlive: true)
 SupporterRepository supporterRepository(Ref ref) {
   ref.watch(currentAuthStateProvider);
   final pubkey = ref.watch(authServiceProvider).currentPublicKeyHex;

--- a/mobile/lib/providers/supporter_providers.dart
+++ b/mobile/lib/providers/supporter_providers.dart
@@ -2,8 +2,6 @@
 // ABOUTME: Selects the store-backed EntitlementValidator on iOS/Android and a
 // ABOUTME: stub elsewhere, owned by an account-scoped SupporterRepository.
 
-import 'dart:async';
-
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:iap_repository/iap_repository.dart';
@@ -31,9 +29,7 @@ bool get hasInAppPurchaseStore =>
 ///
 /// Keeping this empty by default prevents the flag-gated client foundation
 /// from sending requests to an invented or undeployed endpoint.
-const supporterApiBaseUrl = String.fromEnvironment(
-  'SUPPORTERS_API_BASE_URL',
-);
+const supporterApiBaseUrl = String.fromEnvironment('SUPPORTERS_API_BASE_URL');
 
 /// The NIP-98 authenticated supporter Worker client, when configured.
 @riverpod
@@ -50,7 +46,11 @@ SupporterApiClient? supporterApiClient(Ref ref) {
         method: method,
         payload: payload,
       );
-      return token?.authorizationHeader;
+      if (token == null) return null;
+      return (
+        authorizationHeader: token.authorizationHeader,
+        pubkey: token.signedEvent.pubkey,
+      );
     },
   );
   ref.onDispose(client.dispose);
@@ -96,12 +96,18 @@ SupporterRepository supporterRepository(Ref ref) {
 /// must be able to claim it as soon as an authenticated build with the Worker
 /// URL opens. The repository coalesces overlapping calls and retains failed
 /// store proofs for a later foreground retry.
-final supporterRecoveryProvider = Provider<void>((ref) {
+final supporterRecoveryProvider = Provider<Future<void>?>((ref) {
+  final authService = ref.watch(authServiceProvider);
   final authState = ref.watch(currentAuthStateProvider);
+  ref.watch(currentAuthRpcCapabilityProvider);
   final isForeground = ref.watch(appForegroundProvider);
-  if (authState != AuthState.authenticated || !isForeground) return;
+  if (authState != AuthState.authenticated ||
+      !authService.canPublishNostrWritesNow ||
+      !isForeground) {
+    return null;
+  }
 
   final repository = ref.watch(supporterRepositoryProvider);
-  if (!repository.hasServerClient) return;
-  unawaited(repository.recoverPurchases());
+  if (!repository.hasServerClient) return null;
+  return repository.recoverPurchases();
 });

--- a/mobile/lib/providers/supporter_providers.dart
+++ b/mobile/lib/providers/supporter_providers.dart
@@ -94,8 +94,8 @@ SupporterRepository supporterRepository(Ref ref) {
 /// This deliberately does not depend on the Supporter screen or the feature
 /// flag: anyone whose store purchase succeeded before the Worker was wired
 /// must be able to claim it as soon as an authenticated build with the Worker
-/// URL opens. The repository coalesces overlapping calls and retains failed
-/// store proofs for a later foreground retry.
+/// URL opens. The repository first checks canonical state, coalesces overlapping
+/// calls, and retries failures on a later foreground edge.
 final supporterRecoveryProvider = Provider<Future<void>?>((ref) {
   final authService = ref.watch(authServiceProvider);
   final authState = ref.watch(currentAuthStateProvider);

--- a/mobile/lib/providers/supporter_providers.dart
+++ b/mobile/lib/providers/supporter_providers.dart
@@ -2,11 +2,16 @@
 // ABOUTME: Selects the store-backed EntitlementValidator on iOS/Android and a
 // ABOUTME: stub elsewhere, owned by an account-scoped SupporterRepository.
 
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:iap_repository/iap_repository.dart';
+import 'package:openvine/providers/app_foreground_provider.dart';
 import 'package:openvine/providers/auth_providers.dart';
 import 'package:openvine/providers/service_providers.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
+import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/supporter_api_client.dart';
 import 'package:openvine/services/supporter_repository.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -82,3 +87,21 @@ SupporterRepository supporterRepository(Ref ref) {
   ref.onDispose(repository.dispose);
   return repository;
 }
+
+/// Repairs store purchases automatically after a signed-in app enters the
+/// foreground.
+///
+/// This deliberately does not depend on the Supporter screen or the feature
+/// flag: anyone whose store purchase succeeded before the Worker was wired
+/// must be able to claim it as soon as an authenticated build with the Worker
+/// URL opens. The repository coalesces overlapping calls and retains failed
+/// store proofs for a later foreground retry.
+final supporterRecoveryProvider = Provider<void>((ref) {
+  final authState = ref.watch(currentAuthStateProvider);
+  final isForeground = ref.watch(appForegroundProvider);
+  if (authState != AuthState.authenticated || !isForeground) return;
+
+  final repository = ref.watch(supporterRepositoryProvider);
+  if (!repository.hasServerClient) return;
+  unawaited(repository.recoverPurchases());
+});

--- a/mobile/lib/providers/supporter_providers.g.dart
+++ b/mobile/lib/providers/supporter_providers.g.dart
@@ -59,7 +59,7 @@ final class SupporterApiClientProvider
 }
 
 String _$supporterApiClientHash() =>
-    r'715fac50da56c5849e3451b87c5fad149e223d1b';
+    r'b2fccc742b9187925bc86a96aab4bba3294894de';
 
 /// The store-backed [EntitlementValidator] for the current platform.
 ///

--- a/mobile/lib/providers/supporter_providers.g.dart
+++ b/mobile/lib/providers/supporter_providers.g.dart
@@ -148,7 +148,7 @@ final class SupporterRepositoryProvider
         argument: null,
         retry: null,
         name: r'supporterRepositoryProvider',
-        isAutoDispose: true,
+        isAutoDispose: false,
         dependencies: null,
         $allTransitiveDependencies: null,
       );
@@ -177,4 +177,4 @@ final class SupporterRepositoryProvider
 }
 
 String _$supporterRepositoryHash() =>
-    r'5064f725ec5fa201ef693a5eee13a95602360834';
+    r'3e2f3f1fa5ec502364222a5bf658af9ffee4f48b';

--- a/mobile/lib/services/supporter_api_client.dart
+++ b/mobile/lib/services/supporter_api_client.dart
@@ -208,8 +208,14 @@ class SupporterApiClient {
   final Duration _timeout;
 
   /// Fetches canonical private state for the authenticated Divine account.
-  Future<SupporterAccountSnapshot> fetchMe() async {
-    final response = await _send(HttpMethod.get, '/v1/me');
+  Future<SupporterAccountSnapshot> fetchMe({
+    required String expectedPubkey,
+  }) async {
+    final response = await _send(
+      HttpMethod.get,
+      '/v1/me',
+      expectedPubkey: expectedPubkey,
+    );
     return _decodeSnapshot(response);
   }
 
@@ -230,6 +236,7 @@ class SupporterApiClient {
 
   /// Updates recognition preferences without changing payment state.
   Future<SupporterAccountSnapshot> updateRecognition({
+    required String expectedPubkey,
     required bool haloVisible,
     required bool discoveryVisible,
     required bool foundingHistoryVisible,
@@ -243,6 +250,7 @@ class SupporterApiClient {
       HttpMethod.patch,
       '/v1/me/recognition',
       body: body,
+      expectedPubkey: expectedPubkey,
     );
     return _decodeSnapshot(response);
   }

--- a/mobile/lib/services/supporter_api_client.dart
+++ b/mobile/lib/services/supporter_api_client.dart
@@ -332,10 +332,20 @@ class SupporterApiClient {
   }
 
   SupporterApiException _exceptionForStatus(int statusCode, String body) {
-    final kind = switch (statusCode) {
-      401 || 403 => SupporterApiFailureKind.unauthorized,
-      409 => SupporterApiFailureKind.ownershipConflict,
-      408 || 429 || >= 500 => SupporterApiFailureKind.unavailable,
+    String? errorCode;
+    try {
+      final decoded = jsonDecode(body);
+      if (decoded is Map<String, dynamic>) {
+        final error = decoded['error'];
+        if (error is Map<String, dynamic>) errorCode = error['code'] as String?;
+      }
+    } on FormatException {
+      // Error classification still falls back to the HTTP status.
+    }
+    final kind = switch ((statusCode, errorCode)) {
+      (_, 'ownership_conflict') => SupporterApiFailureKind.ownershipConflict,
+      (401 || 403, _) => SupporterApiFailureKind.unauthorized,
+      (408 || 409 || 429 || >= 500, _) => SupporterApiFailureKind.unavailable,
       _ => SupporterApiFailureKind.requestFailed,
     };
     final message = switch (kind) {

--- a/mobile/lib/services/supporter_api_client.dart
+++ b/mobile/lib/services/supporter_api_client.dart
@@ -29,11 +29,7 @@ enum SupporterApiFailureKind {
 /// Exception raised by the supporter Worker API client.
 class SupporterApiException implements Exception {
   /// Creates a typed supporter API failure.
-  const SupporterApiException(
-    this.kind,
-    this.message, {
-    this.statusCode,
-  });
+  const SupporterApiException(this.kind, this.message, {this.statusCode});
 
   /// The stable category used by repository and Cubit state mapping.
   final SupporterApiFailureKind kind;
@@ -182,9 +178,12 @@ class SupporterPurchaseClaim {
   };
 }
 
-/// Provides a NIP-98 Authorization header for an exact request.
+/// A NIP-98 Authorization header and the pubkey that signed it.
+typedef SupporterAuthHeader = ({String authorizationHeader, String pubkey});
+
+/// Provides NIP-98 authentication for an exact request.
 typedef SupporterAuthHeaderProvider =
-    Future<String?> Function({
+    Future<SupporterAuthHeader?> Function({
       required String url,
       required HttpMethod method,
       String? payload,
@@ -216,10 +215,16 @@ class SupporterApiClient {
 
   /// Claims a store purchase for the pubkey represented by the NIP-98 signer.
   Future<SupporterAccountSnapshot> claimPurchase(
-    SupporterPurchaseClaim claim,
-  ) async {
+    SupporterPurchaseClaim claim, {
+    required String expectedPubkey,
+  }) async {
     final body = jsonEncode(claim.toJson());
-    final response = await _send(HttpMethod.post, '/v1/purchases/claim', body);
+    final response = await _send(
+      HttpMethod.post,
+      '/v1/purchases/claim',
+      body: body,
+      expectedPubkey: expectedPubkey,
+    );
     return _decodeSnapshot(response);
   }
 
@@ -237,7 +242,7 @@ class SupporterApiClient {
     final response = await _send(
       HttpMethod.patch,
       '/v1/me/recognition',
-      body,
+      body: body,
     );
     return _decodeSnapshot(response);
   }
@@ -247,16 +252,18 @@ class SupporterApiClient {
 
   Future<http.Response> _send(
     HttpMethod method,
-    String path, [
+    String path, {
     String? body,
-  ]) async {
+    String? expectedPubkey,
+  }) async {
     final uri = _baseUri.resolve(path.substring(1));
     final auth = await _authHeaderProvider(
       url: uri.toString(),
       method: method,
       payload: body,
     );
-    if (auth == null) {
+    if (auth == null ||
+        (expectedPubkey != null && auth.pubkey != expectedPubkey)) {
       throw const SupporterApiException(
         SupporterApiFailureKind.unauthorized,
         'Sign in to manage supporter status.',
@@ -265,18 +272,14 @@ class SupporterApiClient {
 
     final headers = <String, String>{
       'Accept': 'application/json',
-      'Authorization': auth,
+      'Authorization': auth.authorizationHeader,
     };
     if (body != null) headers['Content-Type'] = 'application/json';
 
     try {
       final response = await (switch (method) {
         HttpMethod.get => _httpClient.get(uri, headers: headers),
-        HttpMethod.post => _httpClient.post(
-          uri,
-          headers: headers,
-          body: body,
-        ),
+        HttpMethod.post => _httpClient.post(uri, headers: headers, body: body),
         HttpMethod.patch => _httpClient.patch(
           uri,
           headers: headers,

--- a/mobile/lib/services/supporter_repository.dart
+++ b/mobile/lib/services/supporter_repository.dart
@@ -157,7 +157,7 @@ class SupporterRepository {
         'Supporter verification is not configured.',
       );
     }
-    final snapshot = await client.claimPurchase(claim);
+    final snapshot = await client.claimPurchase(claim, expectedPubkey: _pubkey);
     _handleChange(snapshot.entitlement);
     return snapshot;
   }
@@ -244,6 +244,7 @@ class SupporterRepository {
           idempotencyKey: proof.attemptId,
           proof: proof.toJson(),
         ),
+        expectedPubkey: _pubkey,
       );
       _handleChange(snapshot.entitlement);
       await _validator.completePurchase(proof);

--- a/mobile/lib/services/supporter_repository.dart
+++ b/mobile/lib/services/supporter_repository.dart
@@ -260,11 +260,17 @@ class SupporterRepository {
       _handleChange(snapshot.entitlement);
       await _validator.completePurchase(proof);
     } on Object catch (error, stackTrace) {
-      _recoveryCompleted = false;
+      _recoveryCompleted = _isTerminalClaimFailure(error);
       if (!proof.silent) _handleValidatorError(error, stackTrace);
       // Keep the purchase unacknowledged so the store can redeliver it after
       // the Worker or signer becomes available.
     }
+  }
+
+  bool _isTerminalClaimFailure(Object error) {
+    return error is SupporterApiException &&
+        (error.kind == SupporterApiFailureKind.ownershipConflict ||
+            error.statusCode == 400);
   }
 
   /// Mark the entitlement inactive locally (e.g. after a confirmed expiry or

--- a/mobile/lib/services/supporter_repository.dart
+++ b/mobile/lib/services/supporter_repository.dart
@@ -60,6 +60,7 @@ class SupporterRepository {
   StreamSubscription<SupporterEntitlement>? _subscription;
   StreamSubscription<SupporterPurchaseProof>? _proofSubscription;
   Future<void>? _recoveryInFlight;
+  bool _recoveryCompleted = false;
   final StreamController<SupporterEntitlement> _controller =
       StreamController<SupporterEntitlement>.broadcast();
 
@@ -104,7 +105,7 @@ class SupporterRepository {
   /// while a restore is already underway share the same work; a later
   /// foreground activation can retry after a store or network failure.
   Future<void> recoverPurchases() {
-    if (!hasServerClient) return Future<void>.value();
+    if (!hasServerClient || _recoveryCompleted) return Future<void>.value();
 
     final inFlight = _recoveryInFlight;
     if (inFlight != null) return inFlight;
@@ -121,11 +122,20 @@ class SupporterRepository {
 
   Future<void> _recoverPurchases() async {
     try {
-      await restorePurchases();
-    } on Object catch (error, stackTrace) {
-      // Recovery is a background repair. Do not make app startup depend on a
-      // reachable store; retain the unacknowledged purchase for the next retry.
-      _handleValidatorError(error, stackTrace);
+      final snapshot = await refreshFromServer();
+      if (snapshot.entitlement.isSupporter) {
+        _recoveryCompleted = true;
+        return;
+      }
+      await _validator.restorePurchases(
+        capturedPubkey: _pubkey,
+        attemptId:
+            'supporter-recovery-${DateTime.now().microsecondsSinceEpoch}',
+        silent: true,
+      );
+      _recoveryCompleted = true;
+    } on Object {
+      // Background repair stays silent. A later foreground edge retries.
     }
   }
 
@@ -141,7 +151,7 @@ class SupporterRepository {
         'Supporter verification is not configured.',
       );
     }
-    final snapshot = await client.fetchMe();
+    final snapshot = await client.fetchMe(expectedPubkey: _pubkey);
     _handleChange(snapshot.entitlement);
     return snapshot;
   }
@@ -176,6 +186,7 @@ class SupporterRepository {
       );
     }
     final snapshot = await client.updateRecognition(
+      expectedPubkey: _pubkey,
       haloVisible: haloVisible,
       discoveryVisible: discoveryVisible,
       foundingHistoryVisible: foundingHistoryVisible,
@@ -249,7 +260,8 @@ class SupporterRepository {
       _handleChange(snapshot.entitlement);
       await _validator.completePurchase(proof);
     } on Object catch (error, stackTrace) {
-      _handleValidatorError(error, stackTrace);
+      _recoveryCompleted = false;
+      if (!proof.silent) _handleValidatorError(error, stackTrace);
       // Keep the purchase unacknowledged so the store can redeliver it after
       // the Worker or signer becomes available.
     }

--- a/mobile/lib/services/supporter_repository.dart
+++ b/mobile/lib/services/supporter_repository.dart
@@ -59,6 +59,7 @@ class SupporterRepository {
   late SupporterEntitlement _current;
   StreamSubscription<SupporterEntitlement>? _subscription;
   StreamSubscription<SupporterPurchaseProof>? _proofSubscription;
+  Future<void>? _recoveryInFlight;
   final StreamController<SupporterEntitlement> _controller =
       StreamController<SupporterEntitlement>.broadcast();
 
@@ -93,6 +94,39 @@ class SupporterRepository {
       capturedPubkey: _pubkey,
       attemptId: 'supporter-restore-${DateTime.now().microsecondsSinceEpoch}',
     );
+  }
+
+  /// Starts a non-blocking restore for purchases that predate the canonical
+  /// entitlement service.
+  ///
+  /// The store redelivers the resulting proofs through [purchaseProofChanges],
+  /// where they are claimed with this account's NIP-98 identity. Calls made
+  /// while a restore is already underway share the same work; a later
+  /// foreground activation can retry after a store or network failure.
+  Future<void> recoverPurchases() {
+    if (!hasServerClient) return Future<void>.value();
+
+    final inFlight = _recoveryInFlight;
+    if (inFlight != null) return inFlight;
+
+    late final Future<void> recovery;
+    recovery = _recoverPurchases().whenComplete(() {
+      if (identical(_recoveryInFlight, recovery)) {
+        _recoveryInFlight = null;
+      }
+    });
+    _recoveryInFlight = recovery;
+    return recovery;
+  }
+
+  Future<void> _recoverPurchases() async {
+    try {
+      await restorePurchases();
+    } on Object catch (error, stackTrace) {
+      // Recovery is a background repair. Do not make app startup depend on a
+      // reachable store; retain the unacknowledged purchase for the next retry.
+      _handleValidatorError(error, stackTrace);
+    }
   }
 
   /// Whether canonical Worker requests are configured for this build.

--- a/mobile/lib/startup/app_side_effects.dart
+++ b/mobile/lib/startup/app_side_effects.dart
@@ -54,7 +54,8 @@ class AppRootSideEffects extends ConsumerWidget {
 
     // Reclaims store purchases made before canonical entitlement recording was
     // available. It runs only for an authenticated account with the Worker
-    // configured, and retries when the app returns to the foreground.
+    // configured. Canonical state avoids repeated work after success; failures
+    // retry when the app returns to the foreground.
     ref.watch(supporterRecoveryProvider);
 
     // Durable-queue drivers. Each owns a foreground (and, for profile saves,

--- a/mobile/lib/startup/app_side_effects.dart
+++ b/mobile/lib/startup/app_side_effects.dart
@@ -9,6 +9,7 @@ import 'package:openvine/providers/notifications_providers.dart';
 import 'package:openvine/providers/relay_list_repository_provider.dart';
 import 'package:openvine/providers/relay_providers.dart';
 import 'package:openvine/providers/social_providers.dart';
+import 'package:openvine/providers/supporter_providers.dart';
 import 'package:openvine/router/providers/route_normalization_provider.dart';
 
 /// App-wide side effects that must run for the whole life of the process.
@@ -50,6 +51,11 @@ class AppRootSideEffects extends ConsumerWidget {
     // branch.
     ref.watch(zendeskIdentitySyncProvider);
     ref.watch(analyticsIdentitySyncProvider);
+
+    // Reclaims store purchases made before canonical entitlement recording was
+    // available. It runs only for an authenticated account with the Worker
+    // configured, and retries when the app returns to the foreground.
+    ref.watch(supporterRecoveryProvider);
 
     // Durable-queue drivers. Each owns a foreground (and, for profile saves,
     // connectivity) subscription that re-drives a Drift-backed queue, and none

--- a/mobile/packages/iap_repository/lib/src/entitlement_validator.dart
+++ b/mobile/packages/iap_repository/lib/src/entitlement_validator.dart
@@ -26,6 +26,7 @@ class SupporterPurchaseProof {
     required this.localVerificationData,
     this.transactionId,
     this.capturedPubkey,
+    this.silent = false,
   });
 
   /// Stable client retry key for this purchase attempt.
@@ -48,6 +49,9 @@ class SupporterPurchaseProof {
 
   /// Divine pubkey captured when the purchase or restore was initiated.
   final String? capturedPubkey;
+
+  /// Whether this proof came from background repair rather than user action.
+  final bool silent;
 
   /// The minimum opaque payload sent to the private supporter Worker.
   Map<String, dynamic> toJson() => {
@@ -101,6 +105,7 @@ abstract class EntitlementValidator {
   Future<SupporterEntitlement> restorePurchases({
     String? capturedPubkey,
     String? attemptId,
+    bool silent = false,
   });
 
   /// Emits store evidence after a terminal purchase result. This stream does

--- a/mobile/packages/iap_repository/lib/src/in_app_purchase_validator.dart
+++ b/mobile/packages/iap_repository/lib/src/in_app_purchase_validator.dart
@@ -244,7 +244,11 @@ class InAppPurchaseValidator implements EntitlementValidator {
           attemptId ?? 'restore-${DateTime.now().microsecondsSinceEpoch}',
       silent: silent,
     );
-    await _store.restorePurchases();
+    try {
+      await _store.restorePurchases();
+    } finally {
+      _restoreContext = null;
+    }
 
     // Restored purchases are delivered on the purchase stream. We resolve to
     // inactive synchronously and rely on the stream + repository cache to

--- a/mobile/packages/iap_repository/lib/src/in_app_purchase_validator.dart
+++ b/mobile/packages/iap_repository/lib/src/in_app_purchase_validator.dart
@@ -2,7 +2,9 @@
 // ABOUTME: plugin (StoreKit on iOS, Google Play Billing on Android).
 
 import 'dart:async';
+import 'dart:convert';
 
+import 'package:crypto/crypto.dart';
 import 'package:flutter/foundation.dart';
 import 'package:iap_repository/src/entitlement_validator.dart';
 import 'package:iap_repository/src/exceptions.dart';
@@ -85,16 +87,19 @@ class InAppPurchaseValidator implements EntitlementValidator {
 
   Future<void> _processPurchase(PurchaseDetails purchase) async {
     final pending = _pendingPurchases.remove(purchase.productID);
+    final context = pending == null && _restoreContext != null
+        ? _PurchaseContext(
+            capturedPubkey: _restoreContext!.capturedPubkey,
+            attemptId: _restoreContext!.attemptId,
+            silent: _restoreContext!.silent,
+          )
+        : pending;
     switch (purchase.status) {
       case PurchaseStatus.purchased:
       case PurchaseStatus.restored:
-        _lifecycleController.add(EntitlementLifecycle.confirming);
-        final context = pending == null && _restoreContext != null
-            ? _PurchaseContext(
-                capturedPubkey: _restoreContext!.capturedPubkey,
-                attemptId: _restoreContext!.attemptId,
-              )
-            : pending;
+        if (context?.silent != true) {
+          _lifecycleController.add(EntitlementLifecycle.confirming);
+        }
         final proof = _proofFromPurchase(purchase, context);
         _unacknowledgedPurchases[proof.attemptId] = purchase;
         _proofController.add(proof);
@@ -107,7 +112,9 @@ class InAppPurchaseValidator implements EntitlementValidator {
           purchase.error?.message ?? 'Purchase failed.',
         );
         pending?.completer?.completeError(exception);
-        _entitlementController.addError(exception);
+        if (context?.silent != true) {
+          _entitlementController.addError(exception);
+        }
       case PurchaseStatus.canceled:
         const exception = PurchaseFailedException(
           null,
@@ -120,7 +127,9 @@ class InAppPurchaseValidator implements EntitlementValidator {
         if (pending != null) {
           _pendingPurchases[purchase.productID] = pending;
         }
-        _lifecycleController.add(EntitlementLifecycle.pending);
+        if (context?.silent != true) {
+          _lifecycleController.add(EntitlementLifecycle.pending);
+        }
     }
   }
 
@@ -129,10 +138,11 @@ class InAppPurchaseValidator implements EntitlementValidator {
     _PurchaseContext? context,
   ) {
     final transactionId = purchase.purchaseID;
-    final contextId = context?.attemptId ?? 'store-${purchase.productID}';
-    final attemptId = transactionId == null || transactionId.isEmpty
-        ? contextId
-        : '$contextId:$transactionId';
+    final proofIdentity = transactionId == null || transactionId.isEmpty
+        ? purchase.verificationData.serverVerificationData
+        : transactionId;
+    final proofDigest = sha256.convert(utf8.encode(proofIdentity));
+    final attemptId = 'store-${purchase.productID}:$proofDigest';
     return SupporterPurchaseProof(
       attemptId: attemptId,
       store: defaultTargetPlatform == TargetPlatform.iOS ? 'apple' : 'google',
@@ -141,6 +151,7 @@ class InAppPurchaseValidator implements EntitlementValidator {
       localVerificationData: purchase.verificationData.localVerificationData,
       transactionId: transactionId,
       capturedPubkey: context?.capturedPubkey,
+      silent: context?.silent ?? false,
     );
   }
 
@@ -221,6 +232,7 @@ class InAppPurchaseValidator implements EntitlementValidator {
   Future<SupporterEntitlement> restorePurchases({
     String? capturedPubkey,
     String? attemptId,
+    bool silent = false,
   }) async {
     if (!await _store.isAvailable()) {
       throw const StoreUnavailableException();
@@ -230,6 +242,7 @@ class InAppPurchaseValidator implements EntitlementValidator {
       capturedPubkey: capturedPubkey,
       attemptId:
           attemptId ?? 'restore-${DateTime.now().microsecondsSinceEpoch}',
+      silent: silent,
     );
     await _store.restorePurchases();
 
@@ -275,11 +288,13 @@ class _PurchaseContext {
     required this.capturedPubkey,
     required this.attemptId,
     this.completer,
+    this.silent = false,
   });
 
   final Completer<SupporterEntitlement>? completer;
   final String? capturedPubkey;
   final String attemptId;
+  final bool silent;
 }
 
 typedef _PendingPurchase = _PurchaseContext;
@@ -288,8 +303,10 @@ class _RestoreContext {
   const _RestoreContext({
     required this.capturedPubkey,
     required this.attemptId,
+    required this.silent,
   });
 
   final String? capturedPubkey;
   final String attemptId;
+  final bool silent;
 }

--- a/mobile/packages/iap_repository/lib/src/stub_entitlement_validator.dart
+++ b/mobile/packages/iap_repository/lib/src/stub_entitlement_validator.dart
@@ -36,6 +36,7 @@ class StubEntitlementValidator implements EntitlementValidator {
   Future<SupporterEntitlement> restorePurchases({
     String? capturedPubkey,
     String? attemptId,
+    bool silent = false,
   }) => Future.value(SupporterEntitlement.inactive);
 
   @override

--- a/mobile/packages/iap_repository/pubspec.yaml
+++ b/mobile/packages/iap_repository/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 resolution: workspace
 
 dependencies:
+  crypto: ^3.0.7
   flutter:
     sdk: flutter
   in_app_purchase: ^3.2.0

--- a/mobile/packages/iap_repository/test/in_app_purchase_validator_test.dart
+++ b/mobile/packages/iap_repository/test/in_app_purchase_validator_test.dart
@@ -366,18 +366,19 @@ void main() {
       test(
         'restored delivery after restore uses the restore context',
         () async {
-          when(() => store.restorePurchases()).thenAnswer((_) async {});
+          when(() => store.restorePurchases()).thenAnswer((_) async {
+            streamController.add([
+              _purchase(
+                'divine.supporter.monthly',
+                status: PurchaseStatus.restored,
+              ),
+            ]);
+          });
           final proofFuture = validator.purchaseProofChanges.first;
           await validator.restorePurchases(
             capturedPubkey: 'captured-pubkey',
             attemptId: 'restore-1',
           );
-          streamController.add([
-            _purchase(
-              'divine.supporter.monthly',
-              status: PurchaseStatus.restored,
-            ),
-          ]);
           final proof = await proofFuture.timeout(
             const Duration(seconds: 1),
           );
@@ -420,22 +421,41 @@ void main() {
       test(
         'silent restore does not emit interactive lifecycle state',
         () async {
-          when(() => store.restorePurchases()).thenAnswer((_) async {});
+          when(() => store.restorePurchases()).thenAnswer((_) async {
+            streamController.add([
+              _purchase(
+                'divine.supporter.monthly',
+                status: PurchaseStatus.restored,
+              ),
+            ]);
+          });
           final lifecycle = <EntitlementLifecycle>[];
           validator.lifecycleChanges.listen(lifecycle.add);
 
-          await validator.restorePurchases(silent: true);
           final proofFuture = validator.purchaseProofChanges.first;
-          streamController.add([
-            _purchase(
-              'divine.supporter.monthly',
-              status: PurchaseStatus.restored,
-            ),
-          ]);
+          await validator.restorePurchases(silent: true);
           final proof = await proofFuture;
 
           expect(proof.silent, isTrue);
           expect(lifecycle, isEmpty);
+        },
+      );
+
+      test(
+        'silent restore context does not affect later store errors',
+        () async {
+          when(() => store.restorePurchases()).thenAnswer((_) async {});
+          await validator.restorePurchases(silent: true);
+          final errorFuture = expectLater(
+            validator.entitlementChanges,
+            emitsError(isA<PurchaseFailedException>()),
+          );
+
+          streamController.add([
+            _purchase('divine.supporter.monthly', status: PurchaseStatus.error),
+          ]);
+
+          await errorFuture;
         },
       );
 

--- a/mobile/packages/iap_repository/test/in_app_purchase_validator_test.dart
+++ b/mobile/packages/iap_repository/test/in_app_purchase_validator_test.dart
@@ -356,7 +356,10 @@ void main() {
           ]);
           await future.timeout(const Duration(seconds: 1));
           final proof = await proofFuture;
-          expect(proof.attemptId, 'attempt-1:tx-1');
+          expect(
+            proof.attemptId,
+            startsWith('store-divine.supporter.monthly:'),
+          );
         },
       );
 
@@ -378,8 +381,61 @@ void main() {
           final proof = await proofFuture.timeout(
             const Duration(seconds: 1),
           );
-          expect(proof.attemptId, 'restore-1');
+          expect(
+            proof.attemptId,
+            startsWith('store-divine.supporter.monthly:'),
+          );
           expect(proof.capturedPubkey, 'captured-pubkey');
+        },
+      );
+
+      test(
+        'repeated delivery without a transaction id uses a stable proof key',
+        () async {
+          when(() => store.restorePurchases()).thenAnswer((_) async {});
+
+          await validator.restorePurchases(attemptId: 'restore-1');
+          final firstProof = validator.purchaseProofChanges.first;
+          streamController.add([
+            _purchase(
+              'divine.supporter.monthly',
+              status: PurchaseStatus.restored,
+            ),
+          ]);
+          final firstAttemptId = (await firstProof).attemptId;
+
+          await validator.restorePurchases(attemptId: 'restore-2');
+          final secondProof = validator.purchaseProofChanges.first;
+          streamController.add([
+            _purchase(
+              'divine.supporter.monthly',
+              status: PurchaseStatus.restored,
+            ),
+          ]);
+
+          expect(firstAttemptId, (await secondProof).attemptId);
+        },
+      );
+
+      test(
+        'silent restore does not emit interactive lifecycle state',
+        () async {
+          when(() => store.restorePurchases()).thenAnswer((_) async {});
+          final lifecycle = <EntitlementLifecycle>[];
+          validator.lifecycleChanges.listen(lifecycle.add);
+
+          await validator.restorePurchases(silent: true);
+          final proofFuture = validator.purchaseProofChanges.first;
+          streamController.add([
+            _purchase(
+              'divine.supporter.monthly',
+              status: PurchaseStatus.restored,
+            ),
+          ]);
+          final proof = await proofFuture;
+
+          expect(proof.silent, isTrue);
+          expect(lifecycle, isEmpty);
         },
       );
 

--- a/mobile/test/blocs/supporter/supporter_cubit_test.dart
+++ b/mobile/test/blocs/supporter/supporter_cubit_test.dart
@@ -73,6 +73,7 @@ class _FakeValidator extends Fake implements EntitlementValidator {
   Future<SupporterEntitlement> restorePurchases({
     String? capturedPubkey,
     String? attemptId,
+    bool silent = false,
   }) async {
     if (restoreError != null) throw restoreError!;
     return SupporterEntitlement.inactive;

--- a/mobile/test/providers/supporter_providers_test.dart
+++ b/mobile/test/providers/supporter_providers_test.dart
@@ -1,0 +1,68 @@
+// ABOUTME: Tests account and signer gates for automatic supporter recovery.
+// ABOUTME: Ensures recovery waits for NIP-98 signing capability.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/models/auth_rpc_capability.dart';
+import 'package:openvine/providers/app_foreground_provider.dart';
+import 'package:openvine/providers/auth_providers.dart';
+import 'package:openvine/providers/supporter_providers.dart';
+import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/supporter_repository.dart';
+
+class _MockAuthService extends Mock implements AuthService {}
+
+class _MockSupporterRepository extends Mock implements SupporterRepository {}
+
+void main() {
+  group('supporterRecoveryProvider', () {
+    late _MockAuthService authService;
+    late _MockSupporterRepository repository;
+
+    setUp(() {
+      authService = _MockAuthService();
+      repository = _MockSupporterRepository();
+
+      when(() => authService.canPublishNostrWritesNow).thenReturn(false);
+      when(() => repository.hasServerClient).thenReturn(true);
+      when(() => repository.recoverPurchases()).thenAnswer((_) async {});
+    });
+
+    test('waits for signer capability before restoring purchases', () async {
+      final unavailableContainer = ProviderContainer(
+        overrides: [
+          authServiceProvider.overrideWithValue(authService),
+          currentAuthStateProvider.overrideWithValue(AuthState.authenticated),
+          currentAuthRpcCapabilityProvider.overrideWithValue(
+            AuthRpcCapability.upgrading,
+          ),
+          appForegroundProvider.overrideWith(AppForeground.new),
+          supporterRepositoryProvider.overrideWithValue(repository),
+        ],
+      );
+      expect(unavailableContainer.read(supporterRecoveryProvider), isNull);
+      verifyNever(() => repository.recoverPurchases());
+      unavailableContainer.dispose();
+
+      when(() => authService.canPublishNostrWritesNow).thenReturn(true);
+      final readyContainer = ProviderContainer(
+        overrides: [
+          authServiceProvider.overrideWithValue(authService),
+          currentAuthStateProvider.overrideWithValue(AuthState.authenticated),
+          currentAuthRpcCapabilityProvider.overrideWithValue(
+            AuthRpcCapability.rpcReady,
+          ),
+          appForegroundProvider.overrideWith(AppForeground.new),
+          supporterRepositoryProvider.overrideWithValue(repository),
+        ],
+      );
+      addTearDown(readyContainer.dispose);
+      final recovery = readyContainer.read(supporterRecoveryProvider);
+      expect(recovery, isNotNull);
+      await recovery;
+
+      verify(() => repository.recoverPurchases()).called(1);
+    });
+  });
+}

--- a/mobile/test/providers/supporter_providers_test.dart
+++ b/mobile/test/providers/supporter_providers_test.dart
@@ -15,6 +15,11 @@ class _MockAuthService extends Mock implements AuthService {}
 
 class _MockSupporterRepository extends Mock implements SupporterRepository {}
 
+class _BackgroundAppForeground extends AppForeground {
+  @override
+  bool build() => false;
+}
+
 void main() {
   group('supporterRecoveryProvider', () {
     late _MockAuthService authService;
@@ -61,6 +66,52 @@ void main() {
       final recovery = readyContainer.read(supporterRecoveryProvider);
       expect(recovery, isNotNull);
       await recovery;
+
+      verify(() => repository.recoverPurchases()).called(1);
+    });
+
+    test('does not restore while the app is backgrounded', () {
+      when(() => authService.canPublishNostrWritesNow).thenReturn(true);
+      final container = ProviderContainer(
+        overrides: [
+          authServiceProvider.overrideWithValue(authService),
+          currentAuthStateProvider.overrideWithValue(AuthState.authenticated),
+          currentAuthRpcCapabilityProvider.overrideWithValue(
+            AuthRpcCapability.rpcReady,
+          ),
+          appForegroundProvider.overrideWith(_BackgroundAppForeground.new),
+          supporterRepositoryProvider.overrideWithValue(repository),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      expect(container.read(supporterRecoveryProvider), isNull);
+      verifyNever(() => repository.recoverPurchases());
+    });
+
+    test('restores on a background to foreground transition', () async {
+      when(() => authService.canPublishNostrWritesNow).thenReturn(true);
+      final container = ProviderContainer(
+        overrides: [
+          authServiceProvider.overrideWithValue(authService),
+          currentAuthStateProvider.overrideWithValue(AuthState.authenticated),
+          currentAuthRpcCapabilityProvider.overrideWithValue(
+            AuthRpcCapability.rpcReady,
+          ),
+          appForegroundProvider.overrideWith(_BackgroundAppForeground.new),
+          supporterRepositoryProvider.overrideWithValue(repository),
+        ],
+      );
+      addTearDown(container.dispose);
+      container.listen(
+        supporterRecoveryProvider,
+        (_, _) {},
+        fireImmediately: true,
+      );
+      verifyNever(() => repository.recoverPurchases());
+
+      container.read(appForegroundProvider.notifier).setForeground(true);
+      await Future<void>.delayed(Duration.zero);
 
       verify(() => repository.recoverPurchases()).called(1);
     });

--- a/mobile/test/screens/settings/supporter_screen_test.dart
+++ b/mobile/test/screens/settings/supporter_screen_test.dart
@@ -67,6 +67,7 @@ class _EmptyValidator extends Fake implements EntitlementValidator {
   Future<SupporterEntitlement> restorePurchases({
     String? capturedPubkey,
     String? attemptId,
+    bool silent = false,
   }) async => SupporterEntitlement.inactive;
 
   @override

--- a/mobile/test/services/supporter_api_client_test.dart
+++ b/mobile/test/services/supporter_api_client_test.dart
@@ -67,7 +67,10 @@ void main() {
       ),
     );
 
-    final snapshot = await buildClient().fetchMe();
+    final snapshot = await buildClient().fetchMe(
+      expectedPubkey:
+          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    );
 
     expect(snapshot.status, SupporterServerStatus.grace);
     expect(snapshot.entitlement.productId, 'divine.supporter.annual');
@@ -161,6 +164,42 @@ void main() {
     );
     verifyNever(
       () => httpClient.post(
+        any(),
+        headers: any(named: 'headers'),
+        body: any(named: 'body'),
+      ),
+    );
+  });
+
+  test('rejects reads and preference writes signed by another account', () async {
+    final client = SupporterApiClient(
+      baseUri: Uri.parse('https://supporters.test'),
+      httpClient: httpClient,
+      authHeaderProvider: ({required url, required method, payload}) async => (
+        authorizationHeader: 'Nostr stale-token',
+        pubkey:
+            'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+      ),
+    );
+    const expectedPubkey =
+        'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+    await expectLater(
+      client.fetchMe(expectedPubkey: expectedPubkey),
+      throwsA(isA<SupporterApiException>()),
+    );
+    await expectLater(
+      client.updateRecognition(
+        expectedPubkey: expectedPubkey,
+        haloVisible: true,
+        discoveryVisible: false,
+        foundingHistoryVisible: false,
+      ),
+      throwsA(isA<SupporterApiException>()),
+    );
+    verifyNever(() => httpClient.get(any(), headers: any(named: 'headers')));
+    verifyNever(
+      () => httpClient.patch(
         any(),
         headers: any(named: 'headers'),
         body: any(named: 'body'),

--- a/mobile/test/services/supporter_api_client_test.dart
+++ b/mobile/test/services/supporter_api_client_test.dart
@@ -214,7 +214,14 @@ void main() {
         headers: any(named: 'headers'),
         body: any(named: 'body'),
       ),
-    ).thenAnswer((_) async => http.Response('{}', 409));
+    ).thenAnswer(
+      (_) async => http.Response(
+        jsonEncode({
+          'error': {'code': 'ownership_conflict'},
+        }),
+        409,
+      ),
+    );
 
     await expectLater(
       buildClient().claimPurchase(
@@ -232,6 +239,43 @@ void main() {
           (error) => error.kind,
           'kind',
           SupporterApiFailureKind.ownershipConflict,
+        ),
+      ),
+    );
+  });
+
+  test('treats a claim already in progress as retryable', () async {
+    when(
+      () => httpClient.post(
+        any(),
+        headers: any(named: 'headers'),
+        body: any(named: 'body'),
+      ),
+    ).thenAnswer(
+      (_) async => http.Response(
+        jsonEncode({
+          'error': {'code': 'claim_in_progress'},
+        }),
+        409,
+      ),
+    );
+
+    await expectLater(
+      buildClient().claimPurchase(
+        const SupporterPurchaseClaim(
+          store: 'apple',
+          productId: 'divine.supporter.monthly',
+          idempotencyKey: 'attempt-1234567890',
+          proof: {'signed_payload': 'opaque-proof-material'},
+        ),
+        expectedPubkey:
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      ),
+      throwsA(
+        isA<SupporterApiException>().having(
+          (error) => error.kind,
+          'kind',
+          SupporterApiFailureKind.unavailable,
         ),
       ),
     );

--- a/mobile/test/services/supporter_api_client_test.dart
+++ b/mobile/test/services/supporter_api_client_test.dart
@@ -20,7 +20,11 @@ void main() {
     httpClient: httpClient,
     authHeaderProvider: ({required url, required method, payload}) async {
       authCalls.add((url: url, method: method, payload: payload));
-      return 'Nostr test-token';
+      return (
+        authorizationHeader: 'Nostr test-token',
+        pubkey:
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      );
     },
   );
 
@@ -110,6 +114,8 @@ void main() {
           idempotencyKey: 'attempt-1234567890',
           proof: proof,
         ),
+        expectedPubkey:
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
       );
 
       expect(jsonDecode(requestBody), {
@@ -122,6 +128,45 @@ void main() {
       expect(authCalls.single.payload, requestBody);
     },
   );
+
+  test('rejects a claim signed by a different account', () async {
+    final client = SupporterApiClient(
+      baseUri: Uri.parse('https://supporters.test'),
+      httpClient: httpClient,
+      authHeaderProvider: ({required url, required method, payload}) async => (
+        authorizationHeader: 'Nostr stale-token',
+        pubkey:
+            'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+      ),
+    );
+
+    await expectLater(
+      client.claimPurchase(
+        const SupporterPurchaseClaim(
+          store: 'apple',
+          productId: 'divine.supporter.monthly',
+          idempotencyKey: 'attempt-1234567890',
+          proof: {'signed_payload': 'opaque-proof-material'},
+        ),
+        expectedPubkey:
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      ),
+      throwsA(
+        isA<SupporterApiException>().having(
+          (error) => error.kind,
+          'kind',
+          SupporterApiFailureKind.unauthorized,
+        ),
+      ),
+    );
+    verifyNever(
+      () => httpClient.post(
+        any(),
+        headers: any(named: 'headers'),
+        body: any(named: 'body'),
+      ),
+    );
+  });
 
   test('maps ownership conflict to a typed API failure', () async {
     when(
@@ -140,6 +185,8 @@ void main() {
           idempotencyKey: 'attempt-1234567890',
           proof: {'purchase_token': 'opaque'},
         ),
+        expectedPubkey:
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
       ),
       throwsA(
         isA<SupporterApiException>().having(

--- a/mobile/test/services/supporter_repository_test.dart
+++ b/mobile/test/services/supporter_repository_test.dart
@@ -5,6 +5,8 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
 import 'package:iap_repository/iap_repository.dart';
 import 'package:models/models.dart';
 import 'package:openvine/services/supporter_api_client.dart';
@@ -22,6 +24,8 @@ class _FakeValidator implements EntitlementValidator {
   SupporterEntitlement purchaseResult = SupporterEntitlement.inactive;
   int restoreCallCount = 0;
   String? restoredPubkey;
+  bool? restoredSilently;
+  Object? restoreError;
   Completer<void>? restoreCompleter;
 
   @override
@@ -44,9 +48,12 @@ class _FakeValidator implements EntitlementValidator {
   Future<SupporterEntitlement> restorePurchases({
     String? capturedPubkey,
     String? attemptId,
+    bool silent = false,
   }) async {
     restoreCallCount++;
     restoredPubkey = capturedPubkey;
+    restoredSilently = silent;
+    if (restoreError != null) throw restoreError!;
     await restoreCompleter?.future;
     return purchaseResult;
   }
@@ -80,6 +87,31 @@ void main() {
       'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
   const pubkeyB =
       'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+  SupporterApiClient buildApiClient({bool active = false}) {
+    return SupporterApiClient(
+      baseUri: Uri.parse('https://supporters.test'),
+      httpClient: MockClient((request) async {
+        return http.Response(
+          jsonEncode({
+            'status': active ? 'active' : 'inactive',
+            'entitlement': {
+              if (active) 'productId': 'divine.supporter.monthly',
+              'source': 'server',
+              'isActive': active,
+            },
+            'recognition': <String, dynamic>{},
+          }),
+          200,
+        );
+      }),
+      authHeaderProvider: ({required url, required method, payload}) async => (
+        authorizationHeader: 'Nostr test-token',
+        pubkey: pubkeyA,
+      ),
+    );
+  }
+
   SharedPreferences.setMockInitialValues({});
 
   group(SupporterRepository, () {
@@ -270,14 +302,7 @@ void main() {
       'silently restores configured purchases for the signed-in account',
       () async {
         final prefs = await SharedPreferences.getInstance();
-        final apiClient = SupporterApiClient(
-          baseUri: Uri.parse('https://supporters.test'),
-          authHeaderProvider:
-              ({required url, required method, payload}) async => (
-                authorizationHeader: 'Nostr test-token',
-                pubkey: pubkeyA,
-              ),
-        );
+        final apiClient = buildApiClient();
         final repo = SupporterRepository(
           pubkey: pubkeyA,
           validator: validator,
@@ -291,19 +316,13 @@ void main() {
 
         expect(validator.restoreCallCount, 1);
         expect(validator.restoredPubkey, pubkeyA);
+        expect(validator.restoredSilently, isTrue);
       },
     );
 
     test('coalesces concurrent automatic recovery attempts', () async {
       final prefs = await SharedPreferences.getInstance();
-      final apiClient = SupporterApiClient(
-        baseUri: Uri.parse('https://supporters.test'),
-        authHeaderProvider: ({required url, required method, payload}) async =>
-            (
-              authorizationHeader: 'Nostr test-token',
-              pubkey: pubkeyA,
-            ),
-      );
+      final apiClient = buildApiClient();
       final repo = SupporterRepository(
         pubkey: pubkeyA,
         validator: validator,
@@ -322,5 +341,84 @@ void main() {
       validator.restoreCompleter!.complete();
       await Future.wait([first, second]);
     });
+
+    test(
+      'skips automatic recovery when no Worker client is configured',
+      () async {
+        final prefs = await SharedPreferences.getInstance();
+        final repo = SupporterRepository(
+          pubkey: pubkeyA,
+          validator: validator,
+          prefs: prefs,
+        );
+        addTearDown(repo.dispose);
+
+        await repo.recoverPurchases();
+
+        expect(validator.restoreCallCount, 0);
+      },
+    );
+
+    test('skips store restore when canonical entitlement is active', () async {
+      final prefs = await SharedPreferences.getInstance();
+      final apiClient = buildApiClient(active: true);
+      final repo = SupporterRepository(
+        pubkey: pubkeyA,
+        validator: validator,
+        prefs: prefs,
+        apiClient: apiClient,
+      );
+      addTearDown(repo.dispose);
+      addTearDown(apiClient.dispose);
+
+      await repo.recoverPurchases();
+      await repo.recoverPurchases();
+
+      expect(repo.isSupporter, isTrue);
+      expect(validator.restoreCallCount, 0);
+    });
+
+    test('does not repeat a successful recovery in the same process', () async {
+      final prefs = await SharedPreferences.getInstance();
+      final apiClient = buildApiClient();
+      final repo = SupporterRepository(
+        pubkey: pubkeyA,
+        validator: validator,
+        prefs: prefs,
+        apiClient: apiClient,
+      );
+      addTearDown(repo.dispose);
+      addTearDown(apiClient.dispose);
+
+      await repo.recoverPurchases();
+      await repo.recoverPurchases();
+
+      expect(validator.restoreCallCount, 1);
+    });
+
+    test(
+      'retries a failed background restore without surfacing its error',
+      () async {
+        final prefs = await SharedPreferences.getInstance();
+        final apiClient = buildApiClient();
+        final repo = SupporterRepository(
+          pubkey: pubkeyA,
+          validator: validator,
+          prefs: prefs,
+          apiClient: apiClient,
+        );
+        addTearDown(repo.dispose);
+        addTearDown(apiClient.dispose);
+        validator.restoreError = const StoreUnavailableException();
+        final errors = <Object>[];
+        repo.changes.listen((_) {}, onError: errors.add);
+
+        await repo.recoverPurchases();
+        await repo.recoverPurchases();
+
+        expect(validator.restoreCallCount, 2);
+        expect(errors, isEmpty);
+      },
+    );
   });
 }

--- a/mobile/test/services/supporter_repository_test.dart
+++ b/mobile/test/services/supporter_repository_test.dart
@@ -7,6 +7,7 @@ import 'dart:convert';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:iap_repository/iap_repository.dart';
 import 'package:models/models.dart';
+import 'package:openvine/services/supporter_api_client.dart';
 import 'package:openvine/services/supporter_repository.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -19,6 +20,9 @@ class _FakeValidator implements EntitlementValidator {
       StreamController<SupporterPurchaseProof>.broadcast();
   List<SupporterTier> products = const [];
   SupporterEntitlement purchaseResult = SupporterEntitlement.inactive;
+  int restoreCallCount = 0;
+  String? restoredPubkey;
+  Completer<void>? restoreCompleter;
 
   @override
   void startListening() {}
@@ -40,7 +44,12 @@ class _FakeValidator implements EntitlementValidator {
   Future<SupporterEntitlement> restorePurchases({
     String? capturedPubkey,
     String? attemptId,
-  }) async => purchaseResult;
+  }) async {
+    restoreCallCount++;
+    restoredPubkey = capturedPubkey;
+    await restoreCompleter?.future;
+    return purchaseResult;
+  }
 
   @override
   Stream<SupporterEntitlement> get entitlementChanges => _controller.stream;
@@ -258,6 +267,58 @@ void main() {
       addTearDown(repo.dispose);
 
       expect(repo.isSupporter, isFalse);
+    });
+
+    test(
+      'silently restores configured purchases for the signed-in account',
+      () async {
+        final prefs = await SharedPreferences.getInstance();
+        final apiClient = SupporterApiClient(
+          baseUri: Uri.parse('https://supporters.test'),
+          authHeaderProvider:
+              ({required url, required method, payload}) async =>
+                  'Nostr test-token',
+        );
+        final repo = SupporterRepository(
+          pubkey: pubkeyA,
+          validator: validator,
+          prefs: prefs,
+          apiClient: apiClient,
+        );
+        addTearDown(repo.dispose);
+        addTearDown(apiClient.dispose);
+
+        await repo.recoverPurchases();
+
+        expect(validator.restoreCallCount, 1);
+        expect(validator.restoredPubkey, pubkeyA);
+      },
+    );
+
+    test('coalesces concurrent automatic recovery attempts', () async {
+      final prefs = await SharedPreferences.getInstance();
+      final apiClient = SupporterApiClient(
+        baseUri: Uri.parse('https://supporters.test'),
+        authHeaderProvider: ({required url, required method, payload}) async =>
+            'Nostr test-token',
+      );
+      final repo = SupporterRepository(
+        pubkey: pubkeyA,
+        validator: validator,
+        prefs: prefs,
+        apiClient: apiClient,
+      );
+      addTearDown(repo.dispose);
+      addTearDown(apiClient.dispose);
+      validator.restoreCompleter = Completer<void>();
+
+      final first = repo.recoverPurchases();
+      final second = repo.recoverPurchases();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(validator.restoreCallCount, 1);
+      validator.restoreCompleter!.complete();
+      await Future.wait([first, second]);
     });
   });
 }

--- a/mobile/test/services/supporter_repository_test.dart
+++ b/mobile/test/services/supporter_repository_test.dart
@@ -67,10 +67,7 @@ class _FakeValidator implements EntitlementValidator {
   void emit(SupporterEntitlement e) => _controller.add(e);
 
   void emitError(Object error, [StackTrace? stackTrace]) =>
-      _controller.addError(
-        error,
-        stackTrace,
-      );
+      _controller.addError(error, stackTrace);
 
   @override
   void dispose() {
@@ -276,8 +273,10 @@ void main() {
         final apiClient = SupporterApiClient(
           baseUri: Uri.parse('https://supporters.test'),
           authHeaderProvider:
-              ({required url, required method, payload}) async =>
-                  'Nostr test-token',
+              ({required url, required method, payload}) async => (
+                authorizationHeader: 'Nostr test-token',
+                pubkey: pubkeyA,
+              ),
         );
         final repo = SupporterRepository(
           pubkey: pubkeyA,
@@ -300,7 +299,10 @@ void main() {
       final apiClient = SupporterApiClient(
         baseUri: Uri.parse('https://supporters.test'),
         authHeaderProvider: ({required url, required method, payload}) async =>
-            'Nostr test-token',
+            (
+              authorizationHeader: 'Nostr test-token',
+              pubkey: pubkeyA,
+            ),
       );
       final repo = SupporterRepository(
         pubkey: pubkeyA,

--- a/mobile/test/services/supporter_repository_test.dart
+++ b/mobile/test/services/supporter_repository_test.dart
@@ -88,10 +88,24 @@ void main() {
   const pubkeyB =
       'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
 
-  SupporterApiClient buildApiClient({bool active = false}) {
+  SupporterApiClient buildApiClient({
+    bool active = false,
+    int? claimStatus,
+    String? claimErrorCode,
+    Completer<void>? claimObserved,
+  }) {
     return SupporterApiClient(
       baseUri: Uri.parse('https://supporters.test'),
       httpClient: MockClient((request) async {
+        if (request.method == 'POST' && claimStatus != null) {
+          claimObserved?.complete();
+          return http.Response(
+            jsonEncode({
+              'error': {'code': claimErrorCode},
+            }),
+            claimStatus,
+          );
+        }
         return http.Response(
           jsonEncode({
             'status': active ? 'active' : 'inactive',
@@ -420,5 +434,41 @@ void main() {
         expect(errors, isEmpty);
       },
     );
+
+    test('does not retry a purchase owned by another account', () async {
+      final prefs = await SharedPreferences.getInstance();
+      final claimObserved = Completer<void>();
+      final apiClient = buildApiClient(
+        claimStatus: 409,
+        claimErrorCode: 'ownership_conflict',
+        claimObserved: claimObserved,
+      );
+      final repo = SupporterRepository(
+        pubkey: pubkeyA,
+        validator: validator,
+        prefs: prefs,
+        apiClient: apiClient,
+      );
+      addTearDown(repo.dispose);
+      addTearDown(apiClient.dispose);
+
+      await repo.recoverPurchases();
+      validator.proofController.add(
+        const SupporterPurchaseProof(
+          attemptId: 'stable-attempt-1234',
+          store: 'apple',
+          productId: 'divine.supporter.monthly',
+          serverVerificationData: 'opaque-proof',
+          localVerificationData: '',
+          capturedPubkey: pubkeyA,
+          silent: true,
+        ),
+      );
+      await claimObserved.future;
+      await Future<void>.delayed(Duration.zero);
+      await repo.recoverPurchases();
+
+      expect(validator.restoreCallCount, 1);
+    });
   });
 }

--- a/mobile/test/startup/app_side_effects_test.dart
+++ b/mobile/test/startup/app_side_effects_test.dart
@@ -16,6 +16,7 @@ import 'package:openvine/providers/notifications_providers.dart';
 import 'package:openvine/providers/relay_list_repository_provider.dart';
 import 'package:openvine/providers/relay_providers.dart';
 import 'package:openvine/providers/social_providers.dart';
+import 'package:openvine/providers/supporter_providers.dart';
 import 'package:openvine/router/providers/route_normalization_provider.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/product_event_queue.dart';
@@ -105,6 +106,7 @@ void main() {
     productEventQueueProvider.overrideWithValue(_MockProductEventQueue()),
     profileSaveRetryServiceProvider.overrideWithValue(null),
     zendeskIdentitySyncProvider.overrideWithValue(null),
+    supporterRecoveryProvider.overrideWithValue(null),
     // Shell tier. The three that construct real services record instead.
     relayStatisticsBridgeProvider.overrideWith(
       (ref) => onRelayStatisticsBuilt?.call(),
@@ -276,6 +278,7 @@ void main() {
       'profileSaveRetryServiceProvider',
       'zendeskIdentitySyncProvider',
       'analyticsIdentitySyncProvider',
+      'supporterRecoveryProvider',
       'relayStatisticsBridgeProvider',
       'relaySetChangeBridgeProvider',
       'relayListDirtyPublishBridgeProvider',


### PR DESCRIPTION
Closes #8044

## Summary
- automatically repair store purchases after a signed-in app reaches the foreground
- check canonical supporter state first and skip repeated work after a successful repair
- bind every Worker request to the active Nostr signer and use stable per-purchase claim keys
- keep background recovery silent while retrying transient failures on a later foreground edge

## Verification
- `flutter analyze lib test integration_test tools`
- `flutter test packages/iap_repository/test/in_app_purchase_validator_test.dart test/services/supporter_api_client_test.dart test/services/supporter_repository_test.dart test/providers/supporter_providers_test.dart test/startup/app_side_effects_test.dart`
- full `iap_repository` analyze and test suite
- dependency, package-boundary, coverage, architecture, logging, localization, and test-structure ratchets
