### PR TITLE
fix(account): keep interrupted deletion recovery safe

### DIFF
--- a/mobile/lib/blocs/account_deletion_recovery/account_deletion_recovery_cubit.dart
+++ b/mobile/lib/blocs/account_deletion_recovery/account_deletion_recovery_cubit.dart
@@ -1,0 +1,404 @@
+// ABOUTME: Owns the interrupted account-deletion recovery state machine.
+// ABOUTME: Coordinates loading, cancellation, polling, cleanup, and sign-out.
+
+import 'dart:async';
+
+import 'package:equatable/equatable.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:nostr_key_manager/nostr_key_manager.dart'
+    show SecureKeyStorageException;
+import 'package:openvine/blocs/close_guard.dart';
+import 'package:openvine/models/account_deletion_attempt.dart';
+import 'package:openvine/repositories/account_deletion_recovery_repository.dart';
+import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/user_data_cleanup_service.dart';
+
+part 'account_deletion_recovery_state.dart';
+
+abstract class AccountDeletionRecoveryPolling {
+  static const schedule = <Duration>[
+    Duration(seconds: 2),
+    Duration(seconds: 3),
+    Duration(seconds: 5),
+    Duration(seconds: 8),
+    Duration(seconds: 13),
+    Duration(seconds: 21),
+  ];
+  static const cap = Duration(seconds: 30);
+  static const sessionBound = Duration(minutes: 15);
+
+  static Duration delayForTick(int tickIndex) =>
+      tickIndex < schedule.length ? schedule[tickIndex] : cap;
+}
+
+typedef RecoveryTimerFactory =
+    Timer Function(Duration duration, void Function() callback);
+
+class AccountDeletionRecoveryCubit extends Cubit<AccountDeletionRecoveryState>
+    with CloseGuardedEmit<AccountDeletionRecoveryState> {
+  AccountDeletionRecoveryCubit({
+    required AccountDeletionRecoveryRepository repository,
+    required AuthService authService,
+    required void Function() onAttemptResolved,
+    RecoveryTimerFactory timerFactory = Timer.new,
+  }) : _repository = repository,
+       _authService = authService,
+       _onAttemptResolved = onAttemptResolved,
+       _timerFactory = timerFactory,
+       super(const AccountDeletionRecoveryState());
+
+  final AccountDeletionRecoveryRepository _repository;
+  final AuthService _authService;
+  final void Function() _onAttemptResolved;
+  final RecoveryTimerFactory _timerFactory;
+
+  Timer? _pollTimer;
+  var _generation = 0;
+  Duration _pollingElapsed = Duration.zero;
+
+  Future<void> load() async {
+    final generation = _beginOperation();
+    emit(
+      const AccountDeletionRecoveryState(
+        status: AccountDeletionRecoveryStatus.loading,
+      ),
+    );
+    try {
+      final attempt = await _repository.fetchCurrent();
+      if (!_isCurrent(generation)) return;
+      await _handleAttempt(attempt, generation: generation);
+    } on Object catch (error, stackTrace) {
+      addError(error, stackTrace);
+      if (!_isCurrent(generation)) return;
+      emitIfOpen(
+        const AccountDeletionRecoveryState(
+          status: AccountDeletionRecoveryStatus.loadFailed,
+          failure: AccountDeletionRecoveryFailure.statusLookup,
+        ),
+      );
+    }
+  }
+
+  Future<void> retry() => load();
+
+  Future<void> cancel() async {
+    final attempt = state.attempt;
+    if (attempt == null ||
+        state.status != AccountDeletionRecoveryStatus.restorable) {
+      return;
+    }
+    final generation = _beginOperation();
+    emit(
+      AccountDeletionRecoveryState(
+        status: AccountDeletionRecoveryStatus.cancelInFlight,
+        attempt: attempt,
+      ),
+    );
+    try {
+      final ready = await _prepareForCancellation(attempt);
+      if (!_isCurrent(generation)) return;
+      final result = await _repository.cancel(attemptId: ready.id);
+      if (!_isCurrent(generation)) return;
+      await _handleAttempt(result, generation: generation);
+    } on AccountDeletionRecoveryException catch (error, stackTrace) {
+      addError(error, stackTrace);
+      if (!_isCurrent(generation)) return;
+      if (_requiresStatusRefresh(error.code)) {
+        await _reloadAfterConflict(generation);
+        return;
+      }
+      emitIfOpen(
+        AccountDeletionRecoveryState(
+          status: AccountDeletionRecoveryStatus.restorable,
+          attempt: attempt,
+          failure: attempt.username == null
+              ? AccountDeletionRecoveryFailure.statusLookup
+              : AccountDeletionRecoveryFailure.usernameRestore,
+        ),
+      );
+    } on Object catch (error, stackTrace) {
+      addError(error, stackTrace);
+      if (!_isCurrent(generation)) return;
+      emitIfOpen(
+        AccountDeletionRecoveryState(
+          status: AccountDeletionRecoveryStatus.restorable,
+          attempt: attempt,
+          failure: attempt.username == null
+              ? AccountDeletionRecoveryFailure.statusLookup
+              : AccountDeletionRecoveryFailure.usernameRestore,
+        ),
+      );
+    }
+  }
+
+  Future<void> completeLocalCleanup() async {
+    final attempt = state.attempt;
+    if (attempt?.status != AccountDeletionAttemptStatus.completed) return;
+    final generation = _beginOperation();
+    emit(
+      AccountDeletionRecoveryState(
+        status: AccountDeletionRecoveryStatus.completingLocally,
+        attempt: attempt,
+      ),
+    );
+    try {
+      await _authService.signOut(deleteKeys: true, deleteLocalUserData: true);
+      if (!_isCurrent(generation)) return;
+      _resolve();
+    } on SecureKeyStorageException catch (error, stackTrace) {
+      addError(error, stackTrace);
+      _emitCleanupFailure(
+        generation,
+        attempt!,
+        AccountDeletionRecoveryFailure.keychainCleanup,
+      );
+    } on UserDataCleanupException catch (error, stackTrace) {
+      addError(error, stackTrace);
+      _emitCleanupFailure(
+        generation,
+        attempt!,
+        AccountDeletionRecoveryFailure.localDataCleanup,
+      );
+    } on Object catch (error, stackTrace) {
+      addError(error, stackTrace);
+      _emitCleanupFailure(
+        generation,
+        attempt!,
+        AccountDeletionRecoveryFailure.localDataCleanup,
+      );
+    }
+  }
+
+  Future<void> signOut() async {
+    if (state.status == AccountDeletionRecoveryStatus.signingOut) return;
+    final attempt = state.attempt;
+    final generation = _beginOperation();
+    emit(
+      AccountDeletionRecoveryState(
+        status: AccountDeletionRecoveryStatus.signingOut,
+        attempt: attempt,
+      ),
+    );
+    try {
+      await _authService.signOut();
+      if (!_isCurrent(generation)) return;
+      _resolve();
+    } on Object catch (error, stackTrace) {
+      addError(error, stackTrace);
+      if (!_isCurrent(generation)) return;
+      emitIfOpen(
+        AccountDeletionRecoveryState(
+          status: AccountDeletionRecoveryStatus.signOutFailed,
+          attempt: attempt,
+          failure: AccountDeletionRecoveryFailure.signOut,
+        ),
+      );
+    }
+  }
+
+  Future<AccountDeletionAttempt> _prepareForCancellation(
+    AccountDeletionAttempt attempt,
+  ) async {
+    if (attempt.status == AccountDeletionAttemptStatus.preparing &&
+        !attempt.isCancellationInFlight &&
+        attempt.username != null) {
+      return _repository.resumePreparation(attempt);
+    }
+    return attempt;
+  }
+
+  Future<void> _reloadAfterConflict(int generation) async {
+    try {
+      final current = await _repository.fetchCurrent();
+      if (!_isCurrent(generation)) return;
+      await _handleAttempt(current, generation: generation);
+    } on Object catch (error, stackTrace) {
+      addError(error, stackTrace);
+      if (!_isCurrent(generation)) return;
+      emitIfOpen(
+        const AccountDeletionRecoveryState(
+          status: AccountDeletionRecoveryStatus.loadFailed,
+          failure: AccountDeletionRecoveryFailure.statusLookup,
+        ),
+      );
+    }
+  }
+
+  bool _requiresStatusRefresh(String? code) => const {
+    'cancellation_after_commit',
+    'illegal_transition',
+    'attempt_not_found',
+  }.contains(code);
+
+  Future<void> _handleAttempt(
+    AccountDeletionAttempt? attempt, {
+    required int generation,
+  }) async {
+    if (!_isCurrent(generation)) return;
+    if (attempt == null ||
+        attempt.status == AccountDeletionAttemptStatus.cancelled) {
+      _resolve();
+      return;
+    }
+    switch (attempt.status) {
+      case AccountDeletionAttemptStatus.preparing:
+        if (attempt.isCancellationInFlight) {
+          _emitPollingState(
+            AccountDeletionRecoveryStatus.cancelInFlight,
+            attempt,
+            generation,
+          );
+        } else {
+          emitIfOpen(
+            AccountDeletionRecoveryState(
+              status: AccountDeletionRecoveryStatus.restorable,
+              attempt: attempt,
+            ),
+          );
+        }
+      case AccountDeletionAttemptStatus.recoverable:
+        emitIfOpen(
+          AccountDeletionRecoveryState(
+            status: AccountDeletionRecoveryStatus.restorable,
+            attempt: attempt,
+          ),
+        );
+      case AccountDeletionAttemptStatus.processing:
+        _emitPollingState(
+          AccountDeletionRecoveryStatus.processing,
+          attempt,
+          generation,
+        );
+      case AccountDeletionAttemptStatus.completed:
+        emitIfOpen(
+          AccountDeletionRecoveryState(
+            status: AccountDeletionRecoveryStatus.completingLocally,
+            attempt: attempt,
+          ),
+        );
+        await completeLocalCleanup();
+      case AccountDeletionAttemptStatus.terminalFailure:
+        emitIfOpen(
+          AccountDeletionRecoveryState(
+            status: AccountDeletionRecoveryStatus.terminalFailure,
+            attempt: attempt,
+          ),
+        );
+      case AccountDeletionAttemptStatus.cancelled:
+        _resolve();
+    }
+  }
+
+  void _emitPollingState(
+    AccountDeletionRecoveryStatus status,
+    AccountDeletionAttempt attempt,
+    int generation,
+  ) {
+    emitIfOpen(
+      AccountDeletionRecoveryState(
+        status: status,
+        attempt: attempt,
+        pollTickIndex: state.pollTickIndex,
+      ),
+    );
+    _schedulePoll(generation);
+  }
+
+  void _schedulePoll(int generation) {
+    _pollTimer?.cancel();
+    final tickIndex = state.pollTickIndex;
+    final delay = AccountDeletionRecoveryPolling.delayForTick(tickIndex);
+    if (_pollingElapsed + delay > AccountDeletionRecoveryPolling.sessionBound) {
+      emitIfOpen(
+        AccountDeletionRecoveryState(
+          status: state.status,
+          attempt: state.attempt,
+          pollTickIndex: tickIndex,
+          pollingPaused: true,
+        ),
+      );
+      return;
+    }
+    _pollingElapsed += delay;
+    _pollTimer = _timerFactory(delay, () => _poll(generation));
+  }
+
+  Future<void> _poll(int generation) async {
+    if (!_isCurrent(generation)) return;
+    final expectedAttemptId = state.attempt?.id;
+    final tickIndex = state.pollTickIndex + 1;
+    try {
+      final current = await _repository.fetchCurrent();
+      if (!_isCurrent(generation)) return;
+      if (current == null || current.id != expectedAttemptId) {
+        emitIfOpen(
+          const AccountDeletionRecoveryState(
+            status: AccountDeletionRecoveryStatus.loadFailed,
+            failure: AccountDeletionRecoveryFailure.statusLookup,
+          ),
+        );
+        return;
+      }
+      emitIfOpen(
+        AccountDeletionRecoveryState(
+          status: state.status,
+          attempt: current,
+          pollTickIndex: tickIndex,
+        ),
+      );
+      await _handleAttempt(current, generation: generation);
+    } on Object catch (error, stackTrace) {
+      addError(error, stackTrace);
+      if (!_isCurrent(generation)) return;
+      emitIfOpen(
+        AccountDeletionRecoveryState(
+          status: state.status,
+          attempt: state.attempt,
+          pollTickIndex: tickIndex,
+        ),
+      );
+      _schedulePoll(generation);
+    }
+  }
+
+  int _beginOperation() {
+    _pollTimer?.cancel();
+    _pollTimer = null;
+    _pollingElapsed = Duration.zero;
+    return ++_generation;
+  }
+
+  bool _isCurrent(int generation) => !isClosed && generation == _generation;
+
+  void _emitCleanupFailure(
+    int generation,
+    AccountDeletionAttempt attempt,
+    AccountDeletionRecoveryFailure failure,
+  ) {
+    if (!_isCurrent(generation)) return;
+    emitIfOpen(
+      AccountDeletionRecoveryState(
+        status: AccountDeletionRecoveryStatus.cleanupFailed,
+        attempt: attempt,
+        failure: failure,
+      ),
+    );
+  }
+
+  void _resolve() {
+    _pollTimer?.cancel();
+    emitIfOpen(
+      const AccountDeletionRecoveryState(
+        status: AccountDeletionRecoveryStatus.resolved,
+      ),
+    );
+    if (!isClosed) _onAttemptResolved();
+  }
+
+  @override
+  Future<void> close() {
+    _generation++;
+    _pollTimer?.cancel();
+    return super.close();
+  }
+}

--- a/mobile/lib/blocs/account_deletion_recovery/account_deletion_recovery_state.dart
+++ b/mobile/lib/blocs/account_deletion_recovery/account_deletion_recovery_state.dart
@@ -1,0 +1,49 @@
+part of 'account_deletion_recovery_cubit.dart';
+
+enum AccountDeletionRecoveryStatus {
+  initial,
+  loading,
+  loadFailed,
+  restorable,
+  cancelInFlight,
+  processing,
+  completingLocally,
+  cleanupFailed,
+  terminalFailure,
+  signingOut,
+  signOutFailed,
+  resolved,
+}
+
+enum AccountDeletionRecoveryFailure {
+  statusLookup,
+  usernameRestore,
+  keychainCleanup,
+  localDataCleanup,
+  signOut,
+}
+
+final class AccountDeletionRecoveryState extends Equatable {
+  const AccountDeletionRecoveryState({
+    this.status = AccountDeletionRecoveryStatus.initial,
+    this.attempt,
+    this.failure,
+    this.pollTickIndex = 0,
+    this.pollingPaused = false,
+  });
+
+  final AccountDeletionRecoveryStatus status;
+  final AccountDeletionAttempt? attempt;
+  final AccountDeletionRecoveryFailure? failure;
+  final int pollTickIndex;
+  final bool pollingPaused;
+
+  @override
+  List<Object?> get props => [
+    status,
+    attempt,
+    failure,
+    pollTickIndex,
+    pollingPaused,
+  ];
+}

--- a/mobile/lib/models/account_deletion_attempt.dart
+++ b/mobile/lib/models/account_deletion_attempt.dart
@@ -47,15 +47,24 @@ class AccountDeletionAttempt {
 
   factory AccountDeletionAttempt.fromJson(Map<String, dynamic> json) {
     final id = json['id'] as String?;
-    final status = json['status'] as String?;
-    final operation = json['operation'] as String?;
-    if (id == null || id.isEmpty || status == null || operation == null) {
+    final statusValue = json['status'] as String?;
+    final operationValue = json['operation'] as String?;
+    if (id == null ||
+        id.isEmpty ||
+        statusValue == null ||
+        operationValue == null) {
       throw const FormatException('Invalid deletion attempt response');
+    }
+    final status = AccountDeletionAttemptStatus.fromJson(statusValue);
+    final operation = AccountDeletionAttemptOperation.fromJson(operationValue);
+    if (operation == AccountDeletionAttemptOperation.cancelling &&
+        status != AccountDeletionAttemptStatus.preparing) {
+      throw const FormatException('Invalid deletion attempt state');
     }
     return AccountDeletionAttempt(
       id: id,
-      status: AccountDeletionAttemptStatus.fromJson(status),
-      operation: AccountDeletionAttemptOperation.fromJson(operation),
+      status: status,
+      operation: operation,
       username: json['username'] as String?,
       usernameExpiresAt: (json['username_expires_at'] as num?)?.toInt(),
       failureCode: json['failure_code'] as String?,

--- a/mobile/lib/models/account_deletion_attempt.dart
+++ b/mobile/lib/models/account_deletion_attempt.dart
@@ -84,10 +84,6 @@ class AccountDeletionAttempt {
       status == AccountDeletionAttemptStatus.preparing &&
       operation == AccountDeletionAttemptOperation.cancelling;
 
-  bool get needsPolling =>
-      status == AccountDeletionAttemptStatus.processing ||
-      isCancellationInFlight;
-
   /// Whether this state must hold the user on the full-screen recovery gate.
   ///
   /// Terminal failures stay on the recovery screen because it renders the

--- a/mobile/lib/providers/account_deletion_recovery_providers.dart
+++ b/mobile/lib/providers/account_deletion_recovery_providers.dart
@@ -41,16 +41,3 @@ final currentAccountDeletionAttemptProvider =
           .watch(accountDeletionRecoveryRepositoryProvider)
           .fetchCurrent();
     });
-
-final pollingAccountDeletionAttemptProvider =
-    StreamProvider<AccountDeletionAttempt?>((ref) {
-      if (ref.watch(currentAuthStateProvider) != AuthState.authenticated) {
-        return Stream.value(null);
-      }
-      if (!ref.watch(nostrSessionProvider).isReadyForActiveClient) {
-        return Stream.value(null);
-      }
-      return ref
-          .watch(accountDeletionRecoveryRepositoryProvider)
-          .watchCurrent();
-    });

--- a/mobile/lib/providers/account_deletion_recovery_providers.dart
+++ b/mobile/lib/providers/account_deletion_recovery_providers.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Riverpod wiring for resumable server-side account deletion.
 // ABOUTME: Fetches current attempt after authentication for launch routing.
 
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/models/account_deletion_attempt.dart';
 import 'package:openvine/providers/auth_providers.dart';
@@ -31,7 +33,9 @@ final currentAccountDeletionAttemptProvider =
         return null;
       }
       if (!ref.watch(nostrSessionProvider).isReadyForActiveClient) {
-        return null;
+        final waitingForReadiness = Completer<AccountDeletionAttempt?>();
+        ref.onDispose(waitingForReadiness.complete);
+        return waitingForReadiness.future;
       }
       return ref
           .watch(accountDeletionRecoveryRepositoryProvider)

--- a/mobile/lib/repositories/account_deletion_recovery_repository.dart
+++ b/mobile/lib/repositories/account_deletion_recovery_repository.dart
@@ -175,18 +175,6 @@ class AccountDeletionRecoveryRepository {
     }
   }
 
-  Stream<AccountDeletionAttempt?> watchCurrent({
-    Duration pollInterval = _pollInterval,
-  }) async* {
-    var attempt = await fetchCurrent();
-    yield attempt;
-    while (attempt?.needsPolling ?? false) {
-      await _delay(pollInterval);
-      attempt = await fetchCurrent();
-      yield attempt;
-    }
-  }
-
   Future<AccountDeletionAttempt> submit({
     required String attemptId,
     required String vanishEventId,

--- a/mobile/lib/router/app_router.dart
+++ b/mobile/lib/router/app_router.dart
@@ -11,6 +11,7 @@ import 'package:go_router/go_router.dart';
 import 'package:openvine/blocs/invite_availability/invite_availability_cubit.dart';
 import 'package:openvine/config/screenshot_mode.dart';
 import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/models/account_deletion_attempt.dart';
 import 'package:openvine/models/invite_availability.dart';
 import 'package:openvine/models/minor_account_review_status.dart';
 import 'package:openvine/providers/analytics_providers.dart';
@@ -126,8 +127,8 @@ final goRouterProvider = Provider<GoRouter>((ref) {
     refreshListenable.refresh();
   });
   ref.listen(currentAccountDeletionAttemptProvider, (previous, next) {
-    final before = previous?.value?.requiresRecoveryScreen ?? false;
-    final after = next.value?.requiresRecoveryScreen ?? false;
+    final before = accountDeletionRecoveryGateActive(previous);
+    final after = accountDeletionRecoveryGateActive(next);
     if (before != after) refreshListenable.refresh();
   });
   ref.onDispose(refreshListenable.dispose);

--- a/mobile/lib/router/app_router_redirect.dart
+++ b/mobile/lib/router/app_router_redirect.dart
@@ -11,7 +11,7 @@ bool _suppressNextAuthenticatedAuthRouteRedirect = false;
 bool accountDeletionRecoveryGateActive(
   AsyncValue<AccountDeletionAttempt?>? attempt,
 ) {
-  if (attempt == null || !attempt.hasValue) return true;
+  if (attempt == null || attempt.isLoading || !attempt.hasValue) return true;
   return attempt.value?.requiresRecoveryScreen ?? false;
 }
 

--- a/mobile/lib/router/app_router_redirect.dart
+++ b/mobile/lib/router/app_router_redirect.dart
@@ -7,6 +7,14 @@ part of 'app_router.dart';
 bool _hasNavigated = false;
 bool _suppressNextAuthenticatedAuthRouteRedirect = false;
 
+@visibleForTesting
+bool accountDeletionRecoveryGateActive(
+  AsyncValue<AccountDeletionAttempt?>? attempt,
+) {
+  if (attempt == null || !attempt.hasValue) return true;
+  return attempt.value?.requiresRecoveryScreen ?? false;
+}
+
 /// Prevents the next authenticated auth-route redirect from going home.
 ///
 /// Used when a cold-start quick action already opened a protected route before
@@ -306,7 +314,10 @@ String? appRouterRedirect(Ref ref, GoRouterState state) {
   }
 
   final reviewStatusAsync = ref.read(currentMinorAccountReviewStatusProvider);
-  final deletionAttempt = ref.read(currentAccountDeletionAttemptProvider).value;
+  final deletionAttemptAsync = ref.read(currentAccountDeletionAttemptProvider);
+  final deletionRecoveryGateActive = accountDeletionRecoveryGateActive(
+    deletionAttemptAsync,
+  );
   final reviewStatus = reviewStatusAsync.value;
   final moderationConversationId = _moderationConversationId(
     authService,
@@ -345,13 +356,13 @@ String? appRouterRedirect(Ref ref, GoRouterState state) {
   final isAuthRoute = _isAuthEntryLocation(location);
 
   if (authState == AuthState.authenticated &&
-      deletionAttempt?.requiresRecoveryScreen == true &&
+      deletionRecoveryGateActive &&
       !isDeletionRecoveryRoute &&
       !isSupportRoute) {
     return AccountDeletionRecoveryScreen.path;
   }
   if (authState == AuthState.authenticated &&
-      deletionAttempt?.requiresRecoveryScreen != true &&
+      !deletionRecoveryGateActive &&
       isDeletionRecoveryRoute) {
     return VideoFeedPage.pathForIndex(0);
   }

--- a/mobile/lib/screens/account_deletion_recovery_screen.dart
+++ b/mobile/lib/screens/account_deletion_recovery_screen.dart
@@ -34,7 +34,6 @@ class AccountDeletionRecoveryScreen extends ConsumerWidget {
           authService: authService,
           onAttemptResolved: () {
             ref.invalidate(currentAccountDeletionAttemptProvider);
-            ref.invalidate(pollingAccountDeletionAttemptProvider);
           },
         );
         if (isReady) cubit.load();
@@ -92,15 +91,17 @@ class _RecoveryStateContent extends StatelessWidget {
       AccountDeletionRecoveryStatus.resolved => const Center(
         child: CircularProgressIndicator(),
       ),
-      AccountDeletionRecoveryStatus.loadFailed ||
-      AccountDeletionRecoveryStatus.signOutFailed => _RecoveryContent(
+      AccountDeletionRecoveryStatus.loadFailed => _RecoveryContent(
         body: context.l10n.accountDeletionRecoveryStatusFailed,
         actionLabel: context.l10n.commonRetry,
-        onPressed: state.status == AccountDeletionRecoveryStatus.signOutFailed
-            ? cubit.signOut
-            : cubit.retry,
+        onPressed: cubit.retry,
         secondaryActionLabel: context.l10n.accountDeletionSignOut,
         onSecondaryPressed: cubit.signOut,
+      ),
+      AccountDeletionRecoveryStatus.signOutFailed => _RecoveryContent(
+        body: context.l10n.authUnexpectedError,
+        actionLabel: context.l10n.accountDeletionSignOut,
+        onPressed: cubit.signOut,
       ),
       AccountDeletionRecoveryStatus.restorable => _RestorableContent(
         state: state,

--- a/mobile/lib/screens/account_deletion_recovery_screen.dart
+++ b/mobile/lib/screens/account_deletion_recovery_screen.dart
@@ -1,229 +1,73 @@
 // ABOUTME: Full-screen recovery gate for interrupted account deletion.
-// ABOUTME: Lets users restore a pending username or resume server processing.
+// ABOUTME: Bridges app dependencies into the recovery Cubit and renders state.
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-import 'package:nostr_key_manager/nostr_key_manager.dart'
-    show SecureKeyStorageException;
+import 'package:openvine/blocs/account_deletion_recovery/account_deletion_recovery_cubit.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/models/account_deletion_attempt.dart';
 import 'package:openvine/providers/account_deletion_recovery_providers.dart';
 import 'package:openvine/providers/auth_providers.dart';
-import 'package:openvine/repositories/account_deletion_recovery_repository.dart';
+import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/router/route_paths.dart';
 
-class AccountDeletionRecoveryScreen extends ConsumerStatefulWidget {
+class AccountDeletionRecoveryScreen extends ConsumerWidget {
   const AccountDeletionRecoveryScreen({super.key});
 
   static const String path = RoutePaths.accountDeletionRecovery;
   static const String routeName = 'account-deletion-recovery';
 
   @override
-  ConsumerState<AccountDeletionRecoveryScreen> createState() =>
-      _AccountDeletionRecoveryScreenState();
+  Widget build(BuildContext context, WidgetRef ref) {
+    final repository = ref.watch(accountDeletionRecoveryRepositoryProvider);
+    final authService = ref.watch(authServiceProvider);
+    final isReady = ref.watch(nostrSessionProvider).isReadyForActiveClient;
+
+    return BlocProvider<AccountDeletionRecoveryCubit>(
+      key: ValueKey((repository, authService, isReady)),
+      create: (_) {
+        final cubit = AccountDeletionRecoveryCubit(
+          repository: repository,
+          authService: authService,
+          onAttemptResolved: () {
+            ref.invalidate(currentAccountDeletionAttemptProvider);
+            ref.invalidate(pollingAccountDeletionAttemptProvider);
+          },
+        );
+        if (isReady) cubit.load();
+        return cubit;
+      },
+      child: const AccountDeletionRecoveryView(),
+    );
+  }
 }
 
-class _AccountDeletionRecoveryScreenState
-    extends ConsumerState<AccountDeletionRecoveryScreen> {
-  var _isCancelling = false;
-  var _isSigningOut = false;
-  String? _error;
-
-  Future<void> _finishDeletion() async {
-    if (_isSigningOut) return;
-    _isSigningOut = true;
-    try {
-      await ref
-          .read(authServiceProvider)
-          .signOut(deleteKeys: true, deleteLocalUserData: true);
-    } on SecureKeyStorageException {
-      if (!mounted) return;
-      setState(() {
-        _isSigningOut = false;
-        _error = context.l10n.deleteAccountKeyDeletionWarning;
-      });
-    } on Object {
-      if (!mounted) return;
-      setState(() {
-        _isSigningOut = false;
-        _error = context.l10n.deleteAccountLocalDataDeletionFailed;
-      });
-    }
-  }
-
-  Future<void> _signOut() async {
-    if (_isSigningOut) return;
-    setState(() => _isSigningOut = true);
-    try {
-      await ref.read(authServiceProvider).signOut();
-    } on Object {
-      if (!mounted) return;
-      setState(() {
-        _isSigningOut = false;
-        _error = context.l10n.accountDeletionRecoveryStatusFailed;
-      });
-    }
-  }
-
-  Future<void> _restore(AccountDeletionAttempt attempt) async {
-    setState(() {
-      _isCancelling = true;
-      _error = null;
-    });
-    try {
-      final repository = ref.read(accountDeletionRecoveryRepositoryProvider);
-      final ready =
-          attempt.status == AccountDeletionAttemptStatus.preparing &&
-              !attempt.isCancellationInFlight &&
-              attempt.username != null
-          ? await repository.resumePreparation(attempt)
-          : attempt;
-      final canCancelPreparingAttempt =
-          ready.status == AccountDeletionAttemptStatus.preparing &&
-          ready.username == null;
-      if (ready.status != AccountDeletionAttemptStatus.recoverable &&
-          !canCancelPreparingAttempt) {
-        throw const AccountDeletionRecoveryException(
-          'Username preparation did not become recoverable',
-        );
-      }
-      final restored = await repository.cancelAndWait(attemptId: ready.id);
-      if (!mounted) return;
-      if (restored.status != AccountDeletionAttemptStatus.cancelled) {
-        throw const AccountDeletionRecoveryException(
-          'Server did not confirm username restoration',
-        );
-      }
-      ref.invalidate(currentAccountDeletionAttemptProvider);
-      ref.invalidate(pollingAccountDeletionAttemptProvider);
-      context.go(RoutePaths.videoFeedForIndex(0));
-    } on AccountDeletionRecoveryException catch (error) {
-      if (!mounted) return;
-      if (const {
-        'cancellation_after_commit',
-        'illegal_transition',
-        'attempt_not_found',
-      }.contains(error.code)) {
-        ref.invalidate(currentAccountDeletionAttemptProvider);
-        ref.invalidate(pollingAccountDeletionAttemptProvider);
-      } else {
-        setState(
-          () => _error = attempt.username == null
-              ? context.l10n.accountDeletionRecoveryStatusFailed
-              : context.l10n.accountDeletionRecoveryFailed,
-        );
-      }
-    } on Object {
-      if (!mounted) return;
-      setState(
-        () => _error = attempt.username == null
-            ? context.l10n.accountDeletionRecoveryStatusFailed
-            : context.l10n.accountDeletionRecoveryFailed,
-      );
-    } finally {
-      if (mounted) setState(() => _isCancelling = false);
-    }
-  }
-
-  void _refresh() {
-    setState(() => _error = null);
-    ref.invalidate(currentAccountDeletionAttemptProvider);
-    ref.invalidate(pollingAccountDeletionAttemptProvider);
-  }
+class AccountDeletionRecoveryView extends StatelessWidget {
+  @visibleForTesting
+  const AccountDeletionRecoveryView({super.key});
 
   @override
   Widget build(BuildContext context) {
-    final attempt = ref.watch(pollingAccountDeletionAttemptProvider);
-    return Scaffold(
-      appBar: AppBar(
-        automaticallyImplyLeading: false,
-        title: Text(context.l10n.accountDeletionRecoveryTitle),
-      ),
-      body: SafeArea(
-        child: Padding(
-          padding: const EdgeInsets.all(24),
-          child: attempt.when(
-            loading: () => const Center(child: CircularProgressIndicator()),
-            error: (_, _) => _RecoveryContent(
-              body: context.l10n.accountDeletionRecoveryStatusFailed,
-              actionLabel: context.l10n.commonRetry,
-              onPressed: _refresh,
-            ),
-            data: (value) {
-              if (value == null ||
-                  value.status == AccountDeletionAttemptStatus.cancelled) {
-                WidgetsBinding.instance.addPostFrameCallback((_) {
-                  if (mounted) context.go(RoutePaths.videoFeedForIndex(0));
-                });
-                return const Center(child: CircularProgressIndicator());
-              }
-              final error = _error;
-              if (value.status == AccountDeletionAttemptStatus.completed) {
-                if (!_isSigningOut && error == null) {
-                  WidgetsBinding.instance.addPostFrameCallback(
-                    (_) => _finishDeletion(),
-                  );
-                }
-                return error == null
-                    ? const Center(child: CircularProgressIndicator())
-                    : _RecoveryContent(
-                        body: error,
-                        actionLabel: context.l10n.commonRetry,
-                        onPressed: _finishDeletion,
-                      );
-              }
-              if (value.status ==
-                  AccountDeletionAttemptStatus.terminalFailure) {
-                return _RecoveryContent(
-                  body: error ?? _failureBody(context, value.failureCode),
-                  actionLabel: context.l10n.supportContactSupport,
-                  onPressed: () => context.push(RoutePaths.supportCenter),
-                  secondaryActionLabel: context.l10n.accountDeletionSignOut,
-                  onSecondaryPressed: _isSigningOut ? null : _signOut,
-                );
-              }
-              if (value.status == AccountDeletionAttemptStatus.recoverable ||
-                  (value.status == AccountDeletionAttemptStatus.preparing &&
-                      !value.isCancellationInFlight)) {
-                final expiresAt = value.usernameExpiresAt;
-                final usernameRecoveryBody = expiresAt == null
-                    ? context.l10n.accountDeletionRecoveryBody
-                    : context.l10n.accountDeletionRecoveryBodyWithExpiry(
-                        MaterialLocalizations.of(context).formatFullDate(
-                          DateTime.fromMillisecondsSinceEpoch(
-                            expiresAt * Duration.millisecondsPerSecond,
-                          ).toLocal(),
-                        ),
-                      );
-                return _RecoveryContent(
-                  body:
-                      error ??
-                      (value.username == null
-                          ? context.l10n.accountDeletionCancelAttemptBody
-                          : usernameRecoveryBody),
-                  actionLabel: value.username == null
-                      ? context.l10n.accountDeletionCancelAttempt
-                      : context.l10n.accountDeletionRestoreUsername,
-                  onPressed: _isCancelling ? null : () => _restore(value),
-                  showProgress: _isCancelling,
-                );
-              }
-              // A cancelling attempt and a processing one are both waiting on
-              // the coordinator, but they are waiting on opposite outcomes:
-              // saying deletion is still running while the server is putting
-              // the account back reads as the cancel having failed.
-              return _RecoveryContent(
-                body:
-                    error ??
-                    (value.isCancellationInFlight
-                        ? context.l10n.accountDeletionCancellingBody
-                        : context.l10n.accountDeletionFinishingBody),
-                actionLabel: context.l10n.commonRetry,
-                onPressed: _refresh,
-              );
-            },
+    return BlocListener<
+      AccountDeletionRecoveryCubit,
+      AccountDeletionRecoveryState
+    >(
+      listenWhen: (previous, current) =>
+          previous.status != AccountDeletionRecoveryStatus.resolved &&
+          current.status == AccountDeletionRecoveryStatus.resolved,
+      listener: (context, _) => context.go(RoutePaths.videoFeedForIndex(0)),
+      child: Scaffold(
+        appBar: AppBar(
+          automaticallyImplyLeading: false,
+          title: Text(context.l10n.accountDeletionRecoveryTitle),
+        ),
+        body: const SafeArea(
+          child: Padding(
+            padding: EdgeInsets.all(24),
+            child: _RecoveryStateContent(),
           ),
         ),
       ),
@@ -231,14 +75,129 @@ class _AccountDeletionRecoveryScreenState
   }
 }
 
-/// Localized copy for a terminal-failure attempt's stable `failure_code`.
-///
-/// The coordinator sets one of `username_attempt_expired`,
-/// `keycast_deletion_failed`, `relay_erasure_unconfirmed`, or
-/// `deletion_deadline_exceeded`. Only the first two have copy that says
-/// something the generic terminal message does not; the rest — and any code a
-/// later coordinator adds — fall back to it rather than rendering server
-/// English.
+class _RecoveryStateContent extends StatelessWidget {
+  const _RecoveryStateContent();
+
+  @override
+  Widget build(BuildContext context) {
+    final state = context.watch<AccountDeletionRecoveryCubit>().state;
+    final cubit = context.read<AccountDeletionRecoveryCubit>();
+    return switch (state.status) {
+      AccountDeletionRecoveryStatus.initial ||
+      AccountDeletionRecoveryStatus.loading => _LoadingRecoveryContent(
+        onSignOut: cubit.signOut,
+      ),
+      AccountDeletionRecoveryStatus.completingLocally ||
+      AccountDeletionRecoveryStatus.signingOut ||
+      AccountDeletionRecoveryStatus.resolved => const Center(
+        child: CircularProgressIndicator(),
+      ),
+      AccountDeletionRecoveryStatus.loadFailed ||
+      AccountDeletionRecoveryStatus.signOutFailed => _RecoveryContent(
+        body: context.l10n.accountDeletionRecoveryStatusFailed,
+        actionLabel: context.l10n.commonRetry,
+        onPressed: state.status == AccountDeletionRecoveryStatus.signOutFailed
+            ? cubit.signOut
+            : cubit.retry,
+        secondaryActionLabel: context.l10n.accountDeletionSignOut,
+        onSecondaryPressed: cubit.signOut,
+      ),
+      AccountDeletionRecoveryStatus.restorable => _RestorableContent(
+        state: state,
+      ),
+      AccountDeletionRecoveryStatus.cancelInFlight => _RecoveryContent(
+        body: context.l10n.accountDeletionCancellingBody,
+        actionLabel: context.l10n.commonRetry,
+        onPressed: cubit.retry,
+      ),
+      AccountDeletionRecoveryStatus.processing => _RecoveryContent(
+        body: context.l10n.accountDeletionFinishingBody,
+        actionLabel: context.l10n.commonRetry,
+        onPressed: cubit.retry,
+      ),
+      AccountDeletionRecoveryStatus.cleanupFailed => _RecoveryContent(
+        body: state.failure == AccountDeletionRecoveryFailure.keychainCleanup
+            ? context.l10n.deleteAccountKeyDeletionWarning
+            : context.l10n.deleteAccountLocalDataDeletionFailed,
+        actionLabel: context.l10n.commonRetry,
+        onPressed: cubit.completeLocalCleanup,
+      ),
+      AccountDeletionRecoveryStatus.terminalFailure => _RecoveryContent(
+        body: _failureBody(context, state.attempt?.failureCode),
+        actionLabel: context.l10n.supportContactSupport,
+        onPressed: () => context.push(RoutePaths.supportCenter),
+        secondaryActionLabel: context.l10n.accountDeletionSignOut,
+        onSecondaryPressed: cubit.signOut,
+      ),
+    };
+  }
+}
+
+class _LoadingRecoveryContent extends StatelessWidget {
+  const _LoadingRecoveryContent({required this.onSignOut});
+
+  final VoidCallback onSignOut;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      spacing: 24,
+      children: [
+        const Center(child: CircularProgressIndicator()),
+        DivineButton(
+          label: context.l10n.accountDeletionSignOut,
+          type: DivineButtonType.secondary,
+          onPressed: onSignOut,
+        ),
+      ],
+    );
+  }
+}
+
+class _RestorableContent extends StatelessWidget {
+  const _RestorableContent({required this.state});
+
+  final AccountDeletionRecoveryState state;
+
+  @override
+  Widget build(BuildContext context) {
+    final attempt = state.attempt!;
+    final hasUsername = attempt.username != null;
+    return _RecoveryContent(
+      body: switch (state.failure) {
+        AccountDeletionRecoveryFailure.usernameRestore =>
+          context.l10n.accountDeletionRecoveryFailed,
+        AccountDeletionRecoveryFailure.statusLookup =>
+          context.l10n.accountDeletionRecoveryStatusFailed,
+        _ =>
+          hasUsername
+              ? _usernameRecoveryBody(context, attempt)
+              : context.l10n.accountDeletionCancelAttemptBody,
+      },
+      actionLabel: hasUsername
+          ? context.l10n.accountDeletionRestoreUsername
+          : context.l10n.accountDeletionCancelAttempt,
+      onPressed: context.read<AccountDeletionRecoveryCubit>().cancel,
+    );
+  }
+}
+
+String _usernameRecoveryBody(
+  BuildContext context,
+  AccountDeletionAttempt attempt,
+) {
+  final expiresAt = attempt.usernameExpiresAt;
+  if (expiresAt == null) return context.l10n.accountDeletionRecoveryBody;
+  final expiryDate = MaterialLocalizations.of(context).formatFullDate(
+    DateTime.fromMillisecondsSinceEpoch(
+      expiresAt * Duration.millisecondsPerSecond,
+    ).toLocal(),
+  );
+  return context.l10n.accountDeletionRecoveryBodyWithExpiry(expiryDate);
+}
+
 String _failureBody(
   BuildContext context,
   String? failureCode,
@@ -253,7 +212,6 @@ class _RecoveryContent extends StatelessWidget {
     required this.body,
     required this.actionLabel,
     required this.onPressed,
-    this.showProgress = false,
     this.secondaryActionLabel,
     this.onSecondaryPressed,
   });
@@ -261,7 +219,6 @@ class _RecoveryContent extends StatelessWidget {
   final String body;
   final String actionLabel;
   final VoidCallback? onPressed;
-  final bool showProgress;
   final String? secondaryActionLabel;
   final VoidCallback? onSecondaryPressed;
 
@@ -282,7 +239,6 @@ class _RecoveryContent extends StatelessWidget {
           label: actionLabel,
           onPressed: onPressed,
           leadingIcon: DivineIconName.arrowCounterClockwise,
-          isLoading: showProgress,
         ),
         if (secondaryActionLabel != null)
           DivineButton(

--- a/mobile/test/blocs/account_deletion_recovery/account_deletion_recovery_cubit_test.dart
+++ b/mobile/test/blocs/account_deletion_recovery/account_deletion_recovery_cubit_test.dart
@@ -1,0 +1,400 @@
+// ABOUTME: State-machine tests for interrupted account-deletion recovery.
+// ABOUTME: Pins coordinator transitions, polling, cleanup, and close safety.
+
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_key_manager/nostr_key_manager.dart';
+import 'package:openvine/blocs/account_deletion_recovery/account_deletion_recovery_cubit.dart';
+import 'package:openvine/models/account_deletion_attempt.dart';
+import 'package:openvine/repositories/account_deletion_recovery_repository.dart';
+import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/user_data_cleanup_service.dart';
+
+class _MockRepository extends Mock
+    implements AccountDeletionRecoveryRepository {}
+
+class _MockAuthService extends Mock implements AuthService {}
+
+class _ManualTimer implements Timer {
+  _ManualTimer(this._callback);
+
+  final void Function() _callback;
+  var _active = true;
+
+  void fire() {
+    if (!_active) return;
+    _active = false;
+    _callback();
+  }
+
+  @override
+  void cancel() => _active = false;
+
+  @override
+  bool get isActive => _active;
+
+  @override
+  int get tick => _active ? 0 : 1;
+}
+
+class _ManualTimers {
+  final timers = <_ManualTimer>[];
+
+  Timer create(Duration _, void Function() callback) {
+    final timer = _ManualTimer(callback);
+    timers.add(timer);
+    return timer;
+  }
+
+  Future<void> fireNext() async {
+    timers.firstWhere((timer) => timer.isActive).fire();
+    await Future<void>.delayed(Duration.zero);
+  }
+}
+
+const _preparing = AccountDeletionAttempt(
+  id: 'attempt-id',
+  status: AccountDeletionAttemptStatus.preparing,
+  username: 'alice',
+);
+const _recoverable = AccountDeletionAttempt(
+  id: 'attempt-id',
+  status: AccountDeletionAttemptStatus.recoverable,
+  username: 'alice',
+);
+const _cancelling = AccountDeletionAttempt(
+  id: 'attempt-id',
+  status: AccountDeletionAttemptStatus.preparing,
+  operation: AccountDeletionAttemptOperation.cancelling,
+  username: 'alice',
+);
+const _processing = AccountDeletionAttempt(
+  id: 'attempt-id',
+  status: AccountDeletionAttemptStatus.processing,
+);
+const _completed = AccountDeletionAttempt(
+  id: 'attempt-id',
+  status: AccountDeletionAttemptStatus.completed,
+);
+const _cancelled = AccountDeletionAttempt(
+  id: 'attempt-id',
+  status: AccountDeletionAttemptStatus.cancelled,
+);
+
+void main() {
+  late _MockRepository repository;
+  late _MockAuthService authService;
+  late _ManualTimers timers;
+  late int resolvedCalls;
+
+  AccountDeletionRecoveryCubit buildCubit() => AccountDeletionRecoveryCubit(
+    repository: repository,
+    authService: authService,
+    onAttemptResolved: () => resolvedCalls++,
+    timerFactory: timers.create,
+  );
+
+  setUpAll(() {
+    registerFallbackValue(_preparing);
+  });
+
+  setUp(() {
+    repository = _MockRepository();
+    authService = _MockAuthService();
+    timers = _ManualTimers();
+    resolvedCalls = 0;
+  });
+
+  group('load', () {
+    final cases = <(AccountDeletionAttempt, AccountDeletionRecoveryStatus)>[
+      (_preparing, AccountDeletionRecoveryStatus.restorable),
+      (_recoverable, AccountDeletionRecoveryStatus.restorable),
+      (_cancelling, AccountDeletionRecoveryStatus.cancelInFlight),
+      (_processing, AccountDeletionRecoveryStatus.processing),
+      (
+        const AccountDeletionAttempt(
+          id: 'attempt-id',
+          status: AccountDeletionAttemptStatus.terminalFailure,
+        ),
+        AccountDeletionRecoveryStatus.terminalFailure,
+      ),
+    ];
+
+    for (final (attempt, expectedStatus) in cases) {
+      test('${attempt.status.name} + ${attempt.operation.name}', () async {
+        when(repository.fetchCurrent).thenAnswer((_) async => attempt);
+        final cubit = buildCubit();
+
+        await cubit.load();
+
+        expect(cubit.state.status, expectedStatus);
+        expect(cubit.state.attempt, same(attempt));
+        await cubit.close();
+      });
+    }
+
+    test(
+      'completed deletes local credentials only after server completion',
+      () async {
+        when(repository.fetchCurrent).thenAnswer((_) async => _completed);
+        when(
+          () => authService.signOut(
+            deleteKeys: true,
+            deleteLocalUserData: true,
+          ),
+        ).thenAnswer((_) async {});
+        final cubit = buildCubit();
+
+        await cubit.load();
+
+        expect(cubit.state.status, AccountDeletionRecoveryStatus.resolved);
+        verify(
+          () => authService.signOut(
+            deleteKeys: true,
+            deleteLocalUserData: true,
+          ),
+        ).called(1);
+        expect(resolvedCalls, 1);
+        await cubit.close();
+      },
+    );
+
+    test(
+      'absent and cancelled attempts resolve without local deletion',
+      () async {
+        when(repository.fetchCurrent).thenAnswer((_) async => null);
+        final absentCubit = buildCubit();
+        await absentCubit.load();
+        expect(
+          absentCubit.state.status,
+          AccountDeletionRecoveryStatus.resolved,
+        );
+        await absentCubit.close();
+
+        when(repository.fetchCurrent).thenAnswer((_) async => _cancelled);
+        final cancelledCubit = buildCubit();
+        await cancelledCubit.load();
+        expect(
+          cancelledCubit.state.status,
+          AccountDeletionRecoveryStatus.resolved,
+        );
+        verifyNever(
+          () => authService.signOut(
+            deleteKeys: any(named: 'deleteKeys'),
+            deleteLocalUserData: any(named: 'deleteLocalUserData'),
+          ),
+        );
+        await cancelledCubit.close();
+      },
+    );
+
+    test('lookup error fails closed without carrying an exception', () async {
+      when(repository.fetchCurrent).thenThrow(const FormatException('bad'));
+      final cubit = buildCubit();
+
+      await cubit.load();
+
+      expect(cubit.state.status, AccountDeletionRecoveryStatus.loadFailed);
+      expect(
+        cubit.state.failure,
+        AccountDeletionRecoveryFailure.statusLookup,
+      );
+      await cubit.close();
+    });
+  });
+
+  group('cancel', () {
+    test(
+      'preparing username completes handshake before 200 cancellation',
+      () async {
+        when(repository.fetchCurrent).thenAnswer((_) async => _preparing);
+        when(
+          () => repository.resumePreparation(_preparing),
+        ).thenAnswer((_) async => _recoverable);
+        when(
+          () => repository.cancel(attemptId: 'attempt-id'),
+        ).thenAnswer((_) async => _cancelled);
+        final cubit = buildCubit();
+        await cubit.load();
+
+        await cubit.cancel();
+
+        verify(() => repository.resumePreparation(_preparing)).called(1);
+        expect(cubit.state.status, AccountDeletionRecoveryStatus.resolved);
+        await cubit.close();
+      },
+    );
+
+    test(
+      '202 cancellation enters polling and repeated cancel is ignored',
+      () async {
+        when(repository.fetchCurrent).thenAnswer((_) async => _recoverable);
+        when(
+          () => repository.cancel(attemptId: 'attempt-id'),
+        ).thenAnswer((_) async => _cancelling);
+        final cubit = buildCubit();
+        await cubit.load();
+
+        await cubit.cancel();
+        await cubit.cancel();
+
+        expect(
+          cubit.state.status,
+          AccountDeletionRecoveryStatus.cancelInFlight,
+        );
+        verify(() => repository.cancel(attemptId: 'attempt-id')).called(1);
+        verifyNever(() => repository.resumePreparation(any()));
+        await cubit.close();
+      },
+    );
+
+    test('cancellation after commit reloads processing state', () async {
+      var fetches = 0;
+      when(repository.fetchCurrent).thenAnswer((_) async {
+        fetches++;
+        return fetches == 1 ? _recoverable : _processing;
+      });
+      when(
+        () => repository.cancel(attemptId: 'attempt-id'),
+      ).thenThrow(
+        const AccountDeletionRecoveryException(
+          'conflict',
+          code: 'cancellation_after_commit',
+        ),
+      );
+      final cubit = buildCubit();
+      await cubit.load();
+
+      await cubit.cancel();
+
+      expect(cubit.state.status, AccountDeletionRecoveryStatus.processing);
+      await cubit.close();
+    });
+  });
+
+  test('polling retries transient failure and completes cleanup', () async {
+    var fetches = 0;
+    when(repository.fetchCurrent).thenAnswer((_) async {
+      fetches++;
+      if (fetches == 1) return _processing;
+      if (fetches == 2) {
+        throw const AccountDeletionRecoveryException('offline');
+      }
+      return _completed;
+    });
+    when(
+      () => authService.signOut(
+        deleteKeys: true,
+        deleteLocalUserData: true,
+      ),
+    ).thenAnswer((_) async {});
+    final cubit = buildCubit();
+    await cubit.load();
+
+    await timers.fireNext();
+    expect(cubit.state.status, AccountDeletionRecoveryStatus.processing);
+    expect(cubit.state.pollTickIndex, 1);
+    await timers.fireNext();
+
+    expect(cubit.state.status, AccountDeletionRecoveryStatus.resolved);
+    expect(fetches, 3);
+    await cubit.close();
+  });
+
+  test('polling fails closed when the attempt identity changes', () async {
+    var fetches = 0;
+    when(repository.fetchCurrent).thenAnswer((_) async {
+      fetches++;
+      return fetches == 1
+          ? _processing
+          : const AccountDeletionAttempt(
+              id: 'different-attempt-id',
+              status: AccountDeletionAttemptStatus.processing,
+            );
+    });
+    final cubit = buildCubit();
+    await cubit.load();
+
+    await timers.fireNext();
+
+    expect(cubit.state.status, AccountDeletionRecoveryStatus.loadFailed);
+    expect(timers.timers.where((timer) => timer.isActive), isEmpty);
+    await cubit.close();
+  });
+
+  test('polling pauses at the session bound and keeps manual retry', () async {
+    when(repository.fetchCurrent).thenAnswer((_) async => _processing);
+    final cubit = buildCubit();
+    await cubit.load();
+
+    while (timers.timers.any((timer) => timer.isActive)) {
+      await timers.fireNext();
+    }
+
+    expect(cubit.state.status, AccountDeletionRecoveryStatus.processing);
+    expect(cubit.state.pollingPaused, isTrue);
+    final fetchesBeforeRetry = cubit.state.pollTickIndex + 1;
+    await cubit.retry();
+    verify(repository.fetchCurrent).called(fetchesBeforeRetry + 1);
+    expect(cubit.state.pollingPaused, isFalse);
+    await cubit.close();
+  });
+
+  test(
+    'cleanup failure records a typed reason and remains retryable',
+    () async {
+      when(repository.fetchCurrent).thenAnswer((_) async => _completed);
+      when(
+        () => authService.signOut(
+          deleteKeys: true,
+          deleteLocalUserData: true,
+        ),
+      ).thenThrow(const SecureKeyStorageException('locked'));
+      final cubit = buildCubit();
+
+      await cubit.load();
+
+      expect(cubit.state.status, AccountDeletionRecoveryStatus.cleanupFailed);
+      expect(
+        cubit.state.failure,
+        AccountDeletionRecoveryFailure.keychainCleanup,
+      );
+      await cubit.close();
+    },
+  );
+
+  test('local data cleanup failure has a distinct typed reason', () async {
+    when(repository.fetchCurrent).thenAnswer((_) async => _completed);
+    when(
+      () => authService.signOut(
+        deleteKeys: true,
+        deleteLocalUserData: true,
+      ),
+    ).thenThrow(const UserDataCleanupException('failed'));
+    final cubit = buildCubit();
+
+    await cubit.load();
+
+    expect(
+      cubit.state.failure,
+      AccountDeletionRecoveryFailure.localDataCleanup,
+    );
+    await cubit.close();
+  });
+
+  test('close during an in-flight request drops the resumed emit', () async {
+    final completer = Completer<AccountDeletionAttempt?>();
+    when(repository.fetchCurrent).thenAnswer((_) => completer.future);
+    final cubit = buildCubit();
+    final load = cubit.load();
+    expect(cubit.state.status, AccountDeletionRecoveryStatus.loading);
+
+    await cubit.close();
+    completer.complete(_recoverable);
+    await load;
+
+    expect(cubit.state.status, AccountDeletionRecoveryStatus.loading);
+  });
+}

--- a/mobile/test/providers/account_deletion_recovery_providers_test.dart
+++ b/mobile/test/providers/account_deletion_recovery_providers_test.dart
@@ -1,0 +1,69 @@
+// ABOUTME: Tests the account-deletion recovery providers used by routing.
+// ABOUTME: Verifies lookup readiness remains fail-closed until signing works.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:openvine/providers/account_deletion_recovery_providers.dart';
+import 'package:openvine/providers/auth_providers.dart';
+import 'package:openvine/providers/nostr_client_provider.dart';
+import 'package:openvine/repositories/account_deletion_recovery_repository.dart';
+import 'package:openvine/services/auth_service.dart';
+
+class _MockDeletionRepository extends Mock
+    implements AccountDeletionRecoveryRepository {}
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _TestNostrSession extends NostrSession {
+  @override
+  NostrSessionReadiness build() =>
+      const NostrSessionReadiness.identityKnown(pubkey: 'user-pubkey');
+
+  void markReady() {
+    final client = _MockNostrClient();
+    when(() => client.hasKeys).thenReturn(true);
+    when(() => client.publicKey).thenReturn('user-pubkey');
+    state = NostrSessionReadiness.nostrReady(
+      pubkey: 'user-pubkey',
+      client: client,
+    );
+  }
+}
+
+void main() {
+  test('lookup stays loading until the active client is ready', () async {
+    final repository = _MockDeletionRepository();
+    when(repository.fetchCurrent).thenAnswer((_) async => null);
+    final container = ProviderContainer(
+      overrides: [
+        currentAuthStateProvider.overrideWithValue(AuthState.authenticated),
+        nostrSessionProvider.overrideWith(_TestNostrSession.new),
+        accountDeletionRecoveryRepositoryProvider.overrideWithValue(repository),
+      ],
+    );
+    addTearDown(container.dispose);
+    final subscription = container.listen(
+      currentAccountDeletionAttemptProvider,
+      (_, _) {},
+      fireImmediately: true,
+    );
+    addTearDown(subscription.close);
+
+    await Future<void>.delayed(Duration.zero);
+
+    expect(
+      container.read(currentAccountDeletionAttemptProvider).isLoading,
+      true,
+    );
+    verifyNever(repository.fetchCurrent);
+
+    (container.read(nostrSessionProvider.notifier) as _TestNostrSession)
+        .markReady();
+    await container.read(currentAccountDeletionAttemptProvider.future);
+
+    expect(container.read(currentAccountDeletionAttemptProvider).value, isNull);
+    verify(repository.fetchCurrent).called(1);
+  });
+}

--- a/mobile/test/repositories/account_deletion_recovery_repository_test.dart
+++ b/mobile/test/repositories/account_deletion_recovery_repository_test.dart
@@ -278,6 +278,31 @@ void main() {
     );
   });
 
+  for (final status in [
+    'recoverable',
+    'processing',
+    'cancelled',
+    'completed',
+    'terminal_failure',
+  ]) {
+    test('$status + cancelling fails closed', () async {
+      final result = repository(
+        MockClient(
+          (_) async => http.Response(
+            jsonEncode({
+              'id': 'attempt-1',
+              'status': status,
+              'operation': 'cancelling',
+            }),
+            200,
+          ),
+        ),
+      );
+
+      await expectLater(result.fetchCurrent(), throwsFormatException);
+    });
+  }
+
   test('202 cancel returns a cancellation-in-flight attempt', () async {
     final result = await repository(
       MockClient(
@@ -410,59 +435,6 @@ void main() {
       Duration(milliseconds: 10),
       Duration(milliseconds: 20),
     ]);
-  });
-
-  test(
-    'watchCurrent polls processing until the attempt is completed',
-    () async {
-      var calls = 0;
-      final states = await repository(
-        MockClient((_) async {
-          calls++;
-          return http.Response(
-            jsonEncode({
-              'id': 'attempt-1',
-              'status': calls == 1 ? 'processing' : 'completed',
-              'operation': 'none',
-            }),
-            200,
-          );
-        }),
-        delay: (_) async {},
-      ).watchCurrent().toList();
-
-      expect(states.map((attempt) => attempt?.status), [
-        AccountDeletionAttemptStatus.processing,
-        AccountDeletionAttemptStatus.completed,
-      ]);
-    },
-  );
-
-  test('watchCurrent stops when the active account changes', () async {
-    var pubkey =
-        '385c3a6ec0b9d57a4330dbd6284989be5bd00e41c535f9ca39b6ae7c521b81cd';
-    final stream = repository(
-      MockClient(
-        (_) async => http.Response(
-          jsonEncode({
-            'id': 'attempt-1',
-            'status': 'processing',
-            'operation': 'none',
-          }),
-          200,
-        ),
-      ),
-      currentPubkey: () => pubkey,
-      delay: (_) async => pubkey = _otherPubkey,
-    ).watchCurrent();
-
-    await expectLater(
-      stream,
-      emitsInOrder([
-        isA<AccountDeletionAttempt>(),
-        emitsError(isA<AccountDeletionRecoveryException>()),
-      ]),
-    );
   });
 
   test('a stalled Name Server keeps the repository failure type', () async {

--- a/mobile/test/router/app_router_divine_scheme_gating_test.dart
+++ b/mobile/test/router/app_router_divine_scheme_gating_test.dart
@@ -64,6 +64,7 @@ void main() {
         // navigation; the empty-following bounce is not what these tests are
         // about.
         hasFollowingInCacheProvider.overrideWithValue(true),
+        currentAccountDeletionAttemptProvider.overrideWith((ref) async => null),
         currentMinorAccountReviewStatusProvider.overrideWith(
           (ref) async => restricted
               ? const MinorAccountReviewStatus(
@@ -77,6 +78,7 @@ void main() {
     addTearDown(container.dispose);
     // Settle the status so the redirect sees a value rather than AsyncLoading,
     // which has its own loading-screen bounce.
+    await container.read(currentAccountDeletionAttemptProvider.future);
     await container.read(currentMinorAccountReviewStatusProvider.future);
 
     final ref = container.read(_refProvider);

--- a/mobile/test/router/app_router_redirect_test.dart
+++ b/mobile/test/router/app_router_redirect_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/models/minor_account_review_status.dart';
+import 'package:openvine/providers/account_deletion_recovery_providers.dart';
 import 'package:openvine/providers/auth_providers.dart';
 import 'package:openvine/providers/minor_account_review_providers.dart';
 import 'package:openvine/router/app_router.dart';
@@ -217,6 +218,9 @@ void main() {
       final container = ProviderContainer(
         overrides: [
           authServiceProvider.overrideWithValue(authService),
+          currentAccountDeletionAttemptProvider.overrideWith(
+            (ref) async => null,
+          ),
           currentMinorAccountReviewStatusProvider.overrideWith(
             (ref) async => status,
           ),
@@ -226,6 +230,7 @@ void main() {
         ],
       );
       addTearDown(container.dispose);
+      await container.read(currentAccountDeletionAttemptProvider.future);
       await container.read(currentMinorAccountReviewStatusProvider.future);
       return container;
     }

--- a/mobile/test/router/app_router_test.dart
+++ b/mobile/test/router/app_router_test.dart
@@ -687,6 +687,9 @@ void main() {
           currentMinorAccountReviewStatusProvider.overrideWith(
             (ref) async => MinorAccountReviewStatus.active(),
           ),
+          currentAccountDeletionAttemptProvider.overrideWith(
+            (ref) async => null,
+          ),
           // These navigations model an adult with a confirmed not-protected
           // verdict; the #176 guard otherwise fails closed and bounces.
           isDmRestrictedProvider.overrideWithValue(false),
@@ -737,6 +740,9 @@ void main() {
           ...getStandardTestOverrides(mockAuthService: mockAuthService),
           currentMinorAccountReviewStatusProvider.overrideWith(
             (ref) async => MinorAccountReviewStatus.active(),
+          ),
+          currentAccountDeletionAttemptProvider.overrideWith(
+            (ref) async => null,
           ),
           // These navigations model an adult with a confirmed not-protected
           // verdict; the #176 guard otherwise fails closed and bounces.

--- a/mobile/test/router/app_router_universal_link_gating_test.dart
+++ b/mobile/test/router/app_router_universal_link_gating_test.dart
@@ -62,6 +62,7 @@ void main() {
         // navigation; the empty-following bounce is not what these tests are
         // about.
         hasFollowingInCacheProvider.overrideWithValue(true),
+        currentAccountDeletionAttemptProvider.overrideWith((ref) async => null),
         currentMinorAccountReviewStatusProvider.overrideWith((ref) async {
           if (reviewStatusPending) {
             // Never completes, so the redirect sees AsyncLoading with no value
@@ -85,6 +86,7 @@ void main() {
       // AsyncLoading, which has its own loading-screen bounce.
       await container.read(currentMinorAccountReviewStatusProvider.future);
     }
+    await container.read(currentAccountDeletionAttemptProvider.future);
 
     final ref = container.read(_refProvider);
     final router = GoRouter(

--- a/mobile/test/router/apps_sandbox_route_test.dart
+++ b/mobile/test/router/apps_sandbox_route_test.dart
@@ -58,6 +58,7 @@ void main() {
         currentMinorAccountReviewStatusProvider.overrideWith(
           (ref) async => MinorAccountReviewStatus.active(),
         ),
+        currentAccountDeletionAttemptProvider.overrideWith((ref) async => null),
       ],
     );
     addTearDown(container.dispose);
@@ -117,6 +118,9 @@ void main() {
           currentMinorAccountReviewStatusProvider.overrideWith(
             (ref) async => MinorAccountReviewStatus.active(),
           ),
+          currentAccountDeletionAttemptProvider.overrideWith(
+            (ref) async => null,
+          ),
           nostrAppDirectoryServiceProvider.overrideWithValue(
             mockDirectoryService,
           ),
@@ -175,6 +179,9 @@ void main() {
           ),
           currentMinorAccountReviewStatusProvider.overrideWith(
             (ref) async => MinorAccountReviewStatus.active(),
+          ),
+          currentAccountDeletionAttemptProvider.overrideWith(
+            (ref) async => null,
           ),
           nostrAppDirectoryServiceProvider.overrideWithValue(
             mockDirectoryService,
@@ -283,6 +290,7 @@ Future<void> _pumpRouterAt(
       currentMinorAccountReviewStatusProvider.overrideWith(
         (ref) async => MinorAccountReviewStatus.active(),
       ),
+      currentAccountDeletionAttemptProvider.overrideWith((ref) async => null),
       nostrAppDirectoryServiceProvider.overrideWithValue(mockDirectoryService),
     ],
   );

--- a/mobile/test/router/minor_account_review_error_redirect_test.dart
+++ b/mobile/test/router/minor_account_review_error_redirect_test.dart
@@ -81,6 +81,9 @@ void main() {
             currentMinorAccountReviewStatusProvider.overrideWith(
               (ref) async => throw StateError('review status unavailable'),
             ),
+            currentAccountDeletionAttemptProvider.overrideWith(
+              (ref) async => null,
+            ),
           ],
         );
         registerContainerTearDown(tester, container);
@@ -115,6 +118,9 @@ void main() {
             currentMinorAccountReviewStatusProvider.overrideWith(
               (ref) async => throw StateError('review status unavailable'),
             ),
+            currentAccountDeletionAttemptProvider.overrideWith(
+              (ref) async => null,
+            ),
           ],
         );
         registerContainerTearDown(tester, container);
@@ -146,6 +152,9 @@ void main() {
             nostrSessionProvider.overrideWith(_NotReadyNostrSession.new),
             currentMinorAccountReviewStatusProvider.overrideWith(
               (ref) async => throw StateError('review status unavailable'),
+            ),
+            currentAccountDeletionAttemptProvider.overrideWith(
+              (ref) async => null,
             ),
           ],
         );

--- a/mobile/test/router/minor_account_review_router_test.dart
+++ b/mobile/test/router/minor_account_review_router_test.dart
@@ -74,6 +74,18 @@ void main() {
   group('Minor account review router gating', () {
     late MockAuthService mockAuthService;
 
+    List<dynamic> routerOverrides({
+      AccountDeletionAttempt? deletionAttempt,
+    }) => [
+      ...getStandardTestOverrides(mockAuthService: mockAuthService),
+      currentAccountDeletionAttemptProvider.overrideWith(
+        (_) async => deletionAttempt,
+      ),
+      pollingAccountDeletionAttemptProvider.overrideWith(
+        (_) => Stream.value(deletionAttempt),
+      ),
+    ];
+
     setUp(() {
       resetNavigationState();
       mockAuthService = createMockAuthService();
@@ -152,7 +164,7 @@ void main() {
     ) async {
       final container = ProviderContainer(
         overrides: [
-          ...getStandardTestOverrides(mockAuthService: mockAuthService),
+          ...routerOverrides(),
           nostrSessionProvider.overrideWith(_NotReadyNostrSession.new),
           currentMinorAccountReviewStatusProvider.overrideWith(
             (ref) async => restrictedStatus(),
@@ -178,26 +190,16 @@ void main() {
       (tester) async {
         final container = ProviderContainer(
           overrides: [
-            ...getStandardTestOverrides(mockAuthService: mockAuthService),
-            nostrSessionProvider.overrideWith(_NotReadyNostrSession.new),
-            currentMinorAccountReviewStatusProvider.overrideWith(
-              (_) async => MinorAccountReviewStatus.active(),
-            ),
-            currentAccountDeletionAttemptProvider.overrideWith(
-              (_) async => const AccountDeletionAttempt(
+            ...routerOverrides(
+              deletionAttempt: const AccountDeletionAttempt(
                 id: 'attempt-id',
                 status: AccountDeletionAttemptStatus.recoverable,
                 username: 'alice',
               ),
             ),
-            pollingAccountDeletionAttemptProvider.overrideWith(
-              (_) => Stream.value(
-                const AccountDeletionAttempt(
-                  id: 'attempt-id',
-                  status: AccountDeletionAttemptStatus.recoverable,
-                  username: 'alice',
-                ),
-              ),
+            nostrSessionProvider.overrideWith(_NotReadyNostrSession.new),
+            currentMinorAccountReviewStatusProvider.overrideWith(
+              (_) async => MinorAccountReviewStatus.active(),
             ),
             accountDeletionRecoveryRepositoryProvider.overrideWithValue(
               _MockDeletionRepository(),
@@ -225,24 +227,15 @@ void main() {
     ) async {
       final container = ProviderContainer(
         overrides: [
-          ...getStandardTestOverrides(mockAuthService: mockAuthService),
-          nostrSessionProvider.overrideWith(_NotReadyNostrSession.new),
-          currentMinorAccountReviewStatusProvider.overrideWith(
-            (_) async => MinorAccountReviewStatus.active(),
-          ),
-          currentAccountDeletionAttemptProvider.overrideWith(
-            (_) async => const AccountDeletionAttempt(
+          ...routerOverrides(
+            deletionAttempt: const AccountDeletionAttempt(
               id: 'attempt-id',
               status: AccountDeletionAttemptStatus.terminalFailure,
             ),
           ),
-          pollingAccountDeletionAttemptProvider.overrideWith(
-            (_) => Stream.value(
-              const AccountDeletionAttempt(
-                id: 'attempt-id',
-                status: AccountDeletionAttemptStatus.terminalFailure,
-              ),
-            ),
+          nostrSessionProvider.overrideWith(_NotReadyNostrSession.new),
+          currentMinorAccountReviewStatusProvider.overrideWith(
+            (_) async => MinorAccountReviewStatus.active(),
           ),
           accountDeletionRecoveryRepositoryProvider.overrideWithValue(
             _MockDeletionRepository(),
@@ -267,7 +260,7 @@ void main() {
     testWidgets('allows parent contact route while restricted', (tester) async {
       final container = ProviderContainer(
         overrides: [
-          ...getStandardTestOverrides(mockAuthService: mockAuthService),
+          ...routerOverrides(),
           nostrSessionProvider.overrideWith(_NotReadyNostrSession.new),
           currentMinorAccountReviewStatusProvider.overrideWith(
             (ref) async => restrictedStatus(),
@@ -293,7 +286,7 @@ void main() {
     ) async {
       final container = ProviderContainer(
         overrides: [
-          ...getStandardTestOverrides(mockAuthService: mockAuthService),
+          ...routerOverrides(),
           nostrSessionProvider.overrideWith(_NotReadyNostrSession.new),
           currentMinorAccountReviewStatusProvider.overrideWith(
             (ref) async => restrictedStatus(
@@ -323,7 +316,7 @@ void main() {
     ) async {
       final container = ProviderContainer(
         overrides: [
-          ...getStandardTestOverrides(mockAuthService: mockAuthService),
+          ...routerOverrides(),
           nostrSessionProvider.overrideWith(_NotReadyNostrSession.new),
           currentMinorAccountReviewStatusProvider.overrideWith(
             (ref) async => restrictedStatus(),
@@ -350,7 +343,7 @@ void main() {
     testWidgets('allows support center route while restricted', (tester) async {
       final container = ProviderContainer(
         overrides: [
-          ...getStandardTestOverrides(mockAuthService: mockAuthService),
+          ...routerOverrides(),
           bugReportServiceProvider.overrideWith((ref) => BugReportService()),
           nostrSessionProvider.overrideWith(_NotReadyNostrSession.new),
           currentMinorAccountReviewStatusProvider.overrideWith(
@@ -377,7 +370,7 @@ void main() {
     ) async {
       final container = ProviderContainer(
         overrides: [
-          ...getStandardTestOverrides(mockAuthService: mockAuthService),
+          ...routerOverrides(),
           nostrSessionProvider.overrideWith(_NotReadyNostrSession.new),
           currentMinorAccountReviewStatusProvider.overrideWith(
             (ref) async => restrictedStatus(
@@ -407,7 +400,7 @@ void main() {
     ) async {
       final container = ProviderContainer(
         overrides: [
-          ...getStandardTestOverrides(mockAuthService: mockAuthService),
+          ...routerOverrides(),
           nostrSessionProvider.overrideWith(_NotReadyNostrSession.new),
           currentMinorAccountReviewStatusProvider.overrideWith(
             (ref) async => restrictedStatus(
@@ -441,7 +434,7 @@ void main() {
       final allowedConversationId = ConversationPage.pathForId('mod-conv-123');
       final container = ProviderContainer(
         overrides: [
-          ...getStandardTestOverrides(mockAuthService: mockAuthService),
+          ...routerOverrides(),
           nostrSessionProvider.overrideWith(_NotReadyNostrSession.new),
           currentMinorAccountReviewStatusProvider.overrideWith(
             (ref) async =>
@@ -467,7 +460,7 @@ void main() {
     ) async {
       final container = ProviderContainer(
         overrides: [
-          ...getStandardTestOverrides(mockAuthService: mockAuthService),
+          ...routerOverrides(),
           nostrSessionProvider.overrideWith(_NotReadyNostrSession.new),
           currentMinorAccountReviewStatusProvider.overrideWith(
             (ref) async =>
@@ -495,7 +488,7 @@ void main() {
       final completer = Completer<MinorAccountReviewStatus>();
       final container = ProviderContainer(
         overrides: [
-          ...getStandardTestOverrides(mockAuthService: mockAuthService),
+          ...routerOverrides(),
           nostrSessionProvider.overrideWith(_NotReadyNostrSession.new),
           currentMinorAccountReviewStatusProvider.overrideWith(
             (ref) => completer.future,
@@ -532,7 +525,7 @@ void main() {
         final pendingRefetch = Completer<MinorAccountReviewStatus>();
         final container = ProviderContainer(
           overrides: [
-            ...getStandardTestOverrides(mockAuthService: mockAuthService),
+            ...routerOverrides(),
             bugReportServiceProvider.overrideWith((ref) => BugReportService()),
             nostrSessionProvider.overrideWith(_NotReadyNostrSession.new),
             currentMinorAccountReviewStatusProvider.overrideWith((ref) {
@@ -592,7 +585,7 @@ void main() {
       final pendingRefetch = Completer<MinorAccountReviewStatus>();
       final container = ProviderContainer(
         overrides: [
-          ...getStandardTestOverrides(mockAuthService: mockAuthService),
+          ...routerOverrides(),
           nostrSessionProvider.overrideWith(_NotReadyNostrSession.new),
           currentMinorAccountReviewStatusProvider.overrideWith((ref) {
             loadCount++;

--- a/mobile/test/router/minor_account_review_router_test.dart
+++ b/mobile/test/router/minor_account_review_router_test.dart
@@ -81,9 +81,6 @@ void main() {
       currentAccountDeletionAttemptProvider.overrideWith(
         (_) async => deletionAttempt,
       ),
-      pollingAccountDeletionAttemptProvider.overrideWith(
-        (_) => Stream.value(deletionAttempt),
-      ),
     ];
 
     setUp(() {

--- a/mobile/test/router/minor_account_review_router_test.dart
+++ b/mobile/test/router/minor_account_review_router_test.dart
@@ -10,6 +10,7 @@ import 'package:openvine/models/account_deletion_attempt.dart';
 import 'package:openvine/models/minor_account_review_status.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
+import 'package:openvine/repositories/account_deletion_recovery_repository.dart';
 import 'package:openvine/router/app_router.dart';
 import 'package:openvine/router/providers/route_normalization_provider.dart';
 import 'package:openvine/screens/account_deletion_recovery_screen.dart';
@@ -34,7 +35,42 @@ class _NotReadyNostrSession extends NostrSession {
       const NostrSessionReadiness.identityKnown(pubkey: 'user-pubkey');
 }
 
+class _MockDeletionRepository extends Mock
+    implements AccountDeletionRecoveryRepository {}
+
 void main() {
+  group('Account deletion recovery gate', () {
+    test('fails closed while the attempt is loading', () {
+      expect(
+        accountDeletionRecoveryGateActive(
+          const AsyncLoading<AccountDeletionAttempt?>(),
+        ),
+        isTrue,
+      );
+    });
+
+    test('fails closed when the coordinator lookup errors', () {
+      expect(
+        accountDeletionRecoveryGateActive(
+          AsyncError<AccountDeletionAttempt?>(
+            StateError('coordinator unavailable'),
+            StackTrace.empty,
+          ),
+        ),
+        isTrue,
+      );
+    });
+
+    test('opens only after a ready lookup definitively finds no attempt', () {
+      expect(
+        accountDeletionRecoveryGateActive(
+          const AsyncData<AccountDeletionAttempt?>(null),
+        ),
+        isFalse,
+      );
+    });
+  });
+
   group('Minor account review router gating', () {
     late MockAuthService mockAuthService;
 
@@ -53,6 +89,7 @@ void main() {
       WidgetTester tester,
       ProviderContainer container, {
       bool activateRouteNormalizer = false,
+      bool settle = true,
     }) async {
       if (activateRouteNormalizer) {
         container.read(routeNormalizationProvider);
@@ -67,7 +104,11 @@ void main() {
           ),
         ),
       );
-      await tester.pumpAndSettle();
+      if (settle) {
+        await tester.pumpAndSettle();
+      } else {
+        await tester.pump();
+      }
     }
 
     void registerContainerTearDown(
@@ -158,16 +199,19 @@ void main() {
                 ),
               ),
             ),
+            accountDeletionRecoveryRepositoryProvider.overrideWithValue(
+              _MockDeletionRepository(),
+            ),
           ],
         );
         registerContainerTearDown(tester, container);
         await container.read(currentMinorAccountReviewStatusProvider.future);
         await container.read(currentAccountDeletionAttemptProvider.future);
-        await pumpRouter(tester, container);
+        await pumpRouter(tester, container, settle: false);
 
         final router = container.read(goRouterProvider);
         router.go(VideoFeedPage.pathForIndex(0));
-        await tester.pumpAndSettle();
+        await tester.pump();
 
         expect(
           router.routeInformationProvider.value.uri.toString(),
@@ -200,12 +244,15 @@ void main() {
               ),
             ),
           ),
+          accountDeletionRecoveryRepositoryProvider.overrideWithValue(
+            _MockDeletionRepository(),
+          ),
         ],
       );
       registerContainerTearDown(tester, container);
       await container.read(currentMinorAccountReviewStatusProvider.future);
       await container.read(currentAccountDeletionAttemptProvider.future);
-      await pumpRouter(tester, container);
+      await pumpRouter(tester, container, settle: false);
 
       final router = container.read(goRouterProvider);
       router.go(SupportCenterScreen.path);

--- a/mobile/test/router/nip05_settings_navigation_test.dart
+++ b/mobile/test/router/nip05_settings_navigation_test.dart
@@ -123,6 +123,9 @@ void main() {
           currentMinorAccountReviewStatusProvider.overrideWith(
             (ref) async => MinorAccountReviewStatus.active(),
           ),
+          currentAccountDeletionAttemptProvider.overrideWith(
+            (ref) async => null,
+          ),
           profileRepositoryProvider.overrideWithValue(profileRepository),
           profileReadRepositoryProvider.overrideWithValue(profileRepository),
           blossomUploadServiceProvider.overrideWithValue(blossomUploadService),

--- a/mobile/test/router/route_error_routing_test.dart
+++ b/mobile/test/router/route_error_routing_test.dart
@@ -42,6 +42,7 @@ void main() {
         currentMinorAccountReviewStatusProvider.overrideWith(
           (ref) async => MinorAccountReviewStatus.active(),
         ),
+        currentAccountDeletionAttemptProvider.overrideWith((ref) async => null),
       ],
     );
     addTearDown(container.dispose);

--- a/mobile/test/router/router_refresh_gate_coupling_test.dart
+++ b/mobile/test/router/router_refresh_gate_coupling_test.dart
@@ -99,6 +99,9 @@ void main() {
           currentMinorAccountReviewStatusProvider.overrideWith(
             (ref) async => status,
           ),
+          currentAccountDeletionAttemptProvider.overrideWith(
+            (ref) async => null,
+          ),
         ],
       );
       // Route normalization is required for the parent-contact fallbacks.

--- a/mobile/test/router/saved_videos_route_test.dart
+++ b/mobile/test/router/saved_videos_route_test.dart
@@ -40,6 +40,7 @@ void main() {
         currentMinorAccountReviewStatusProvider.overrideWith(
           (ref) async => MinorAccountReviewStatus.active(),
         ),
+        currentAccountDeletionAttemptProvider.overrideWith((ref) async => null),
         videoEventServiceProvider.overrideWithValue(
           createMockVideoEventService(),
         ),

--- a/mobile/test/screens/account_deletion_recovery_screen_test.dart
+++ b/mobile/test/screens/account_deletion_recovery_screen_test.dart
@@ -216,6 +216,32 @@ void main() {
     );
   });
 
+  testWidgets('sign-out failure offers one sign-out retry with generic copy', (
+    tester,
+  ) async {
+    when(() => cubit.state).thenReturn(
+      const AccountDeletionRecoveryState(
+        status: AccountDeletionRecoveryStatus.signOutFailed,
+      ),
+    );
+    await tester.pumpWidget(_app(cubit));
+
+    final l10n = lookupAppLocalizations(const Locale('en'));
+    expect(find.text(l10n.authUnexpectedError), findsOneWidget);
+    expect(
+      find.widgetWithText(DivineButton, l10n.accountDeletionSignOut),
+      findsOneWidget,
+    );
+    expect(
+      find.widgetWithText(DivineButton, l10n.commonRetry),
+      findsNothing,
+    );
+    await tester.tap(
+      find.widgetWithText(DivineButton, l10n.accountDeletionSignOut),
+    );
+    verify(cubit.signOut).called(1);
+  });
+
   testWidgets('fail-closed loading keeps sign out reachable', (tester) async {
     when(() => cubit.state).thenReturn(
       const AccountDeletionRecoveryState(

--- a/mobile/test/screens/account_deletion_recovery_screen_test.dart
+++ b/mobile/test/screens/account_deletion_recovery_screen_test.dart
@@ -1,27 +1,20 @@
-// ABOUTME: Widget tests for interrupted account-deletion recovery states.
-// ABOUTME: Pins rollback, processing, and completed-deletion local cleanup.
+// ABOUTME: Widget tests for the account-deletion recovery Cubit view.
+// ABOUTME: Pins localized copy and valid actions for every recovery state.
 
+import 'package:bloc_test/bloc_test.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:nostr_key_manager/nostr_key_manager.dart'
-    show SecureKeyStorageException;
+import 'package:openvine/blocs/account_deletion_recovery/account_deletion_recovery_cubit.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/account_deletion_attempt.dart';
-import 'package:openvine/providers/account_deletion_recovery_providers.dart';
-import 'package:openvine/providers/auth_providers.dart';
-import 'package:openvine/repositories/account_deletion_recovery_repository.dart';
 import 'package:openvine/screens/account_deletion_recovery_screen.dart';
-import 'package:openvine/services/auth_service.dart';
-import 'package:openvine/services/user_data_cleanup_service.dart';
 
-class _MockRecoveryRepository extends Mock
-    implements AccountDeletionRecoveryRepository {}
-
-class _MockAuthService extends Mock implements AuthService {}
+class _MockRecoveryCubit extends MockCubit<AccountDeletionRecoveryState>
+    implements AccountDeletionRecoveryCubit {}
 
 const _recoverable = AccountDeletionAttempt(
   id: 'attempt-id',
@@ -30,19 +23,20 @@ const _recoverable = AccountDeletionAttempt(
   usernameExpiresAt: 1787450400,
 );
 
-Widget _app({
-  required AccountDeletionAttempt attempt,
-  required AccountDeletionRecoveryRepository repository,
-  AuthService? authService,
-  Stream<AccountDeletionAttempt?>? attempts,
-  Stream<AccountDeletionAttempt?> Function()? attemptsBuilder,
+Widget _app(
+  AccountDeletionRecoveryCubit cubit, {
+  Stream<AccountDeletionRecoveryState>? states,
 }) {
+  if (states != null) whenListen(cubit, states);
   final router = GoRouter(
     initialLocation: AccountDeletionRecoveryScreen.path,
     routes: [
       GoRoute(
         path: AccountDeletionRecoveryScreen.path,
-        builder: (_, _) => const AccountDeletionRecoveryScreen(),
+        builder: (_, _) => BlocProvider.value(
+          value: cubit,
+          child: const AccountDeletionRecoveryView(),
+        ),
       ),
       GoRoute(
         path: '/home/0',
@@ -50,386 +44,206 @@ Widget _app({
       ),
     ],
   );
-  return ProviderScope(
-    overrides: [
-      pollingAccountDeletionAttemptProvider.overrideWith(
-        (_) => attemptsBuilder?.call() ?? attempts ?? Stream.value(attempt),
-      ),
-      accountDeletionRecoveryRepositoryProvider.overrideWithValue(repository),
-      if (authService != null)
-        authServiceProvider.overrideWithValue(authService),
-    ],
-    child: MaterialApp.router(
-      localizationsDelegates: AppLocalizations.localizationsDelegates,
-      supportedLocales: AppLocalizations.supportedLocales,
-      routerConfig: router,
-    ),
+  return MaterialApp.router(
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    routerConfig: router,
   );
 }
 
 void main() {
-  setUpAll(() {
-    registerFallbackValue(_recoverable);
+  late _MockRecoveryCubit cubit;
+
+  setUp(() {
+    cubit = _MockRecoveryCubit();
+    when(cubit.cancel).thenAnswer((_) async {});
+    when(cubit.retry).thenAnswer((_) async {});
+    when(cubit.signOut).thenAnswer((_) async {});
+    when(cubit.completeLocalCleanup).thenAnswer((_) async {});
   });
 
-  testWidgets('recoverable attempt restores username and returns home', (
-    tester,
-  ) async {
-    final repository = _MockRecoveryRepository();
-    when(() => repository.cancelAndWait(attemptId: 'attempt-id')).thenAnswer(
-      (_) async => const AccountDeletionAttempt(
-        id: 'attempt-id',
-        status: AccountDeletionAttemptStatus.cancelled,
-        username: 'alice',
+  testWidgets('recoverable username offers only restore', (tester) async {
+    when(() => cubit.state).thenReturn(
+      const AccountDeletionRecoveryState(
+        status: AccountDeletionRecoveryStatus.restorable,
+        attempt: _recoverable,
       ),
     );
-    await tester.pumpWidget(
-      _app(attempt: _recoverable, repository: repository),
-    );
-    await tester.pumpAndSettle();
+    await tester.pumpWidget(_app(cubit));
 
     final l10n = lookupAppLocalizations(const Locale('en'));
     expect(find.textContaining('reserved for you until'), findsOneWidget);
     await tester.tap(
       find.widgetWithText(DivineButton, l10n.accountDeletionRestoreUsername),
     );
-    await tester.pumpAndSettle();
 
-    verify(() => repository.cancelAndWait(attemptId: 'attempt-id')).called(1);
-    expect(find.text('Home'), findsOneWidget);
+    verify(cubit.cancel).called(1);
+    expect(
+      find.widgetWithText(DivineButton, l10n.accountDeletionCancelAttempt),
+      findsNothing,
+    );
   });
 
-  testWidgets('preparing attempt finishes its handshake before rollback', (
+  testWidgets('preparing attempt without username offers cancellation', (
     tester,
   ) async {
-    final repository = _MockRecoveryRepository();
-    when(
-      () => repository.resumePreparation(any()),
-    ).thenAnswer((_) async => _recoverable);
-    when(() => repository.cancelAndWait(attemptId: 'attempt-id')).thenAnswer(
-      (_) async => const AccountDeletionAttempt(
-        id: 'attempt-id',
-        status: AccountDeletionAttemptStatus.cancelled,
-        username: 'alice',
-      ),
-    );
-    await tester.pumpWidget(
-      _app(
-        attempt: const AccountDeletionAttempt(
+    when(() => cubit.state).thenReturn(
+      const AccountDeletionRecoveryState(
+        status: AccountDeletionRecoveryStatus.restorable,
+        attempt: AccountDeletionAttempt(
           id: 'attempt-id',
           status: AccountDeletionAttemptStatus.preparing,
-          username: 'alice',
         ),
-        repository: repository,
       ),
     );
-    await tester.pumpAndSettle();
+    await tester.pumpWidget(_app(cubit));
 
     final l10n = lookupAppLocalizations(const Locale('en'));
-    await tester.tap(
-      find.widgetWithText(DivineButton, l10n.accountDeletionRestoreUsername),
+    expect(find.text(l10n.accountDeletionCancelAttemptBody), findsOneWidget);
+    expect(
+      find.widgetWithText(DivineButton, l10n.accountDeletionCancelAttempt),
+      findsOneWidget,
     );
-    await tester.pumpAndSettle();
-
-    verify(
-      () => repository.resumePreparation(
-        const AccountDeletionAttempt(
-          id: 'attempt-id',
-          status: AccountDeletionAttemptStatus.preparing,
-          username: 'alice',
-        ),
-      ),
-    ).called(1);
-    verify(() => repository.cancelAndWait(attemptId: 'attempt-id')).called(1);
-    expect(find.text('Home'), findsOneWidget);
   });
 
-  testWidgets('cancelling attempt polls without re-preparing username', (
+  testWidgets('cancelling attempt has no conflicting restore action', (
     tester,
   ) async {
-    final repository = _MockRecoveryRepository();
-    await tester.pumpWidget(
-      _app(
-        attempt: const AccountDeletionAttempt(
+    when(() => cubit.state).thenReturn(
+      const AccountDeletionRecoveryState(
+        status: AccountDeletionRecoveryStatus.cancelInFlight,
+        attempt: AccountDeletionAttempt(
           id: 'attempt-id',
           status: AccountDeletionAttemptStatus.preparing,
           operation: AccountDeletionAttemptOperation.cancelling,
           username: 'alice',
         ),
-        repository: repository,
       ),
     );
-    await tester.pumpAndSettle();
+    await tester.pumpWidget(_app(cubit));
 
     final l10n = lookupAppLocalizations(const Locale('en'));
     expect(find.text(l10n.accountDeletionCancellingBody), findsOneWidget);
-    expect(find.text(l10n.accountDeletionFinishingBody), findsNothing);
     expect(
       find.widgetWithText(DivineButton, l10n.accountDeletionRestoreUsername),
       findsNothing,
     );
+  });
+
+  testWidgets('processing remains non-cancellable', (tester) async {
+    when(() => cubit.state).thenReturn(
+      const AccountDeletionRecoveryState(
+        status: AccountDeletionRecoveryStatus.processing,
+        attempt: AccountDeletionAttempt(
+          id: 'attempt-id',
+          status: AccountDeletionAttemptStatus.processing,
+        ),
+      ),
+    );
+    await tester.pumpWidget(_app(cubit));
+
+    final l10n = lookupAppLocalizations(const Locale('en'));
+    expect(find.text(l10n.accountDeletionFinishingBody), findsOneWidget);
+    expect(
+      find.widgetWithText(DivineButton, l10n.accountDeletionRestoreUsername),
+      findsNothing,
+    );
+  });
+
+  testWidgets('cleanup failures distinguish keychain from local data', (
+    tester,
+  ) async {
+    when(() => cubit.state).thenReturn(
+      const AccountDeletionRecoveryState(
+        status: AccountDeletionRecoveryStatus.cleanupFailed,
+        attempt: AccountDeletionAttempt(
+          id: 'attempt-id',
+          status: AccountDeletionAttemptStatus.completed,
+        ),
+        failure: AccountDeletionRecoveryFailure.keychainCleanup,
+      ),
+    );
+    await tester.pumpWidget(_app(cubit));
+
+    final l10n = lookupAppLocalizations(const Locale('en'));
+    expect(find.text(l10n.deleteAccountKeyDeletionWarning), findsOneWidget);
+    expect(
+      find.text(l10n.deleteAccountLocalDataDeletionFailed),
+      findsNothing,
+    );
+  });
+
+  testWidgets('terminal failure offers support and sign out', (tester) async {
+    when(() => cubit.state).thenReturn(
+      const AccountDeletionRecoveryState(
+        status: AccountDeletionRecoveryStatus.terminalFailure,
+        attempt: AccountDeletionAttempt(
+          id: 'attempt-id',
+          status: AccountDeletionAttemptStatus.terminalFailure,
+          failureMessage: 'Server English must not be shown.',
+        ),
+      ),
+    );
+    await tester.pumpWidget(_app(cubit));
+
+    final l10n = lookupAppLocalizations(const Locale('en'));
+    expect(find.textContaining('Server English'), findsNothing);
+    await tester.tap(
+      find.widgetWithText(DivineButton, l10n.accountDeletionSignOut),
+    );
+    verify(cubit.signOut).called(1);
+  });
+
+  testWidgets('fail-closed load error keeps retry and sign out reachable', (
+    tester,
+  ) async {
+    when(() => cubit.state).thenReturn(
+      const AccountDeletionRecoveryState(
+        status: AccountDeletionRecoveryStatus.loadFailed,
+        failure: AccountDeletionRecoveryFailure.statusLookup,
+      ),
+    );
+    await tester.pumpWidget(_app(cubit));
+
+    final l10n = lookupAppLocalizations(const Locale('en'));
     expect(
       find.widgetWithText(DivineButton, l10n.commonRetry),
       findsOneWidget,
     );
-    verifyNever(() => repository.resumePreparation(any()));
-  });
-
-  testWidgets('cancellation-after-commit refreshes into processing', (
-    tester,
-  ) async {
-    final repository = _MockRecoveryRepository();
-    when(
-      () => repository.cancelAndWait(attemptId: 'attempt-id'),
-    ).thenThrow(
-      const AccountDeletionRecoveryException(
-        'server text',
-        code: 'cancellation_after_commit',
-      ),
-    );
-    var providerBuilds = 0;
-    await tester.pumpWidget(
-      _app(
-        attempt: _recoverable,
-        attemptsBuilder: () {
-          providerBuilds++;
-          return Stream.value(
-            providerBuilds == 1
-                ? _recoverable
-                : const AccountDeletionAttempt(
-                    id: 'attempt-id',
-                    status: AccountDeletionAttemptStatus.processing,
-                  ),
-          );
-        },
-        repository: repository,
-      ),
-    );
-    await tester.pumpAndSettle();
-
-    final l10n = lookupAppLocalizations(const Locale('en'));
-    await tester.tap(
-      find.widgetWithText(DivineButton, l10n.accountDeletionRestoreUsername),
-    );
-    await tester.pump();
-    await tester.pump();
-
-    expect(find.text(l10n.accountDeletionFinishingBody), findsOneWidget);
-    expect(find.textContaining('server text'), findsNothing);
-  });
-
-  testWidgets('processing attempt cannot be rolled back from the screen', (
-    tester,
-  ) async {
-    final repository = _MockRecoveryRepository();
-    await tester.pumpWidget(
-      _app(
-        attempt: const AccountDeletionAttempt(
-          id: 'attempt-id',
-          status: AccountDeletionAttemptStatus.processing,
-        ),
-        repository: repository,
-      ),
-    );
-    await tester.pumpAndSettle();
-
-    final l10n = lookupAppLocalizations(const Locale('en'));
-    expect(find.text(l10n.accountDeletionFinishingBody), findsOneWidget);
     expect(
-      find.widgetWithText(DivineButton, l10n.accountDeletionRestoreUsername),
-      findsNothing,
-    );
-  });
-
-  testWidgets('processing attempt auto-advances to completed cleanup', (
-    tester,
-  ) async {
-    final repository = _MockRecoveryRepository();
-    final authService = _MockAuthService();
-    when(
-      () => authService.signOut(deleteKeys: true, deleteLocalUserData: true),
-    ).thenAnswer((_) async {});
-    await tester.pumpWidget(
-      _app(
-        attempt: const AccountDeletionAttempt(
-          id: 'attempt-id',
-          status: AccountDeletionAttemptStatus.processing,
-        ),
-        attempts: Stream.fromIterable(const [
-          AccountDeletionAttempt(
-            id: 'attempt-id',
-            status: AccountDeletionAttemptStatus.processing,
-          ),
-          AccountDeletionAttempt(
-            id: 'attempt-id',
-            status: AccountDeletionAttemptStatus.completed,
-          ),
-        ]),
-        repository: repository,
-        authService: authService,
-      ),
-    );
-    await tester.pump();
-    await tester.pump();
-
-    verify(
-      () => authService.signOut(deleteKeys: true, deleteLocalUserData: true),
-    ).called(1);
-  });
-
-  testWidgets(
-    'failed local cleanup after a completed deletion says what actually failed',
-    (tester) async {
-      final repository = _MockRecoveryRepository();
-      final authService = _MockAuthService();
-      when(
-        () => authService.signOut(deleteKeys: true, deleteLocalUserData: true),
-      ).thenThrow(const SecureKeyStorageException('keychain locked'));
-      await tester.pumpWidget(
-        _app(
-          attempt: const AccountDeletionAttempt(
-            id: 'attempt-id',
-            status: AccountDeletionAttemptStatus.completed,
-            username: 'alice',
-          ),
-          repository: repository,
-          authService: authService,
-        ),
-      );
-      // Not pumpAndSettle: the completed branch shows a progress indicator,
-      // which never settles.
-      await tester.pump();
-      await tester.pump();
-
-      // The server already deleted the account, so nothing here may offer to
-      // restore a username or imply the account survived.
-      final l10n = lookupAppLocalizations(const Locale('en'));
-      expect(find.text(l10n.accountDeletionRecoveryFailed), findsNothing);
-      expect(find.text(l10n.deleteAccountKeyDeletionWarning), findsOneWidget);
-    },
-  );
-
-  testWidgets('completed deletion removes local credentials', (tester) async {
-    final repository = _MockRecoveryRepository();
-    final authService = _MockAuthService();
-    when(
-      () => authService.signOut(deleteKeys: true, deleteLocalUserData: true),
-    ).thenAnswer((_) async {});
-    await tester.pumpWidget(
-      _app(
-        attempt: const AccountDeletionAttempt(
-          id: 'attempt-id',
-          status: AccountDeletionAttemptStatus.completed,
-        ),
-        repository: repository,
-        authService: authService,
-      ),
-    );
-    await tester.pump();
-
-    verify(
-      () => authService.signOut(deleteKeys: true, deleteLocalUserData: true),
-    ).called(1);
-  });
-
-  testWidgets('preparing attempt without username cancels by existing id', (
-    tester,
-  ) async {
-    final repository = _MockRecoveryRepository();
-    when(() => repository.cancelAndWait(attemptId: 'attempt-id')).thenAnswer(
-      (_) async => const AccountDeletionAttempt(
-        id: 'attempt-id',
-        status: AccountDeletionAttemptStatus.cancelled,
-      ),
-    );
-    await tester.pumpWidget(
-      _app(
-        attempt: const AccountDeletionAttempt(
-          id: 'attempt-id',
-          status: AccountDeletionAttemptStatus.preparing,
-        ),
-        repository: repository,
-      ),
-    );
-    await tester.pumpAndSettle();
-
-    final l10n = lookupAppLocalizations(const Locale('en'));
-    expect(find.text(l10n.accountDeletionCancelAttemptBody), findsOneWidget);
-    await tester.tap(
-      find.widgetWithText(DivineButton, l10n.accountDeletionCancelAttempt),
-    );
-    await tester.pumpAndSettle();
-
-    verifyNever(() => repository.prepare(username: any(named: 'username')));
-    verifyNever(() => repository.resumePreparation(any()));
-    verify(() => repository.cancelAndWait(attemptId: 'attempt-id')).called(1);
-    expect(find.text('Home'), findsOneWidget);
-  });
-
-  testWidgets('terminal failure offers support and non-destructive sign out', (
-    tester,
-  ) async {
-    final repository = _MockRecoveryRepository();
-    final authService = _MockAuthService();
-    when(authService.signOut).thenAnswer((_) async {});
-    await tester.pumpWidget(
-      _app(
-        attempt: const AccountDeletionAttempt(
-          id: 'attempt-id',
-          status: AccountDeletionAttemptStatus.terminalFailure,
-          failureCode: 'coordinator_failed',
-          failureMessage: 'Deletion could not be completed safely.',
-        ),
-        repository: repository,
-        authService: authService,
-      ),
-    );
-    await tester.pumpAndSettle();
-
-    final l10n = lookupAppLocalizations(const Locale('en'));
-    expect(
-      find.textContaining('Deletion could not be completed safely.'),
-      findsNothing,
-    );
-    expect(find.textContaining('coordinator_failed'), findsNothing);
-    expect(find.text(l10n.accountDeletionTerminalFailureBody), findsOneWidget);
-    expect(
-      find.widgetWithText(DivineButton, l10n.supportContactSupport),
+      find.widgetWithText(DivineButton, l10n.accountDeletionSignOut),
       findsOneWidget,
     );
+  });
+
+  testWidgets('fail-closed loading keeps sign out reachable', (tester) async {
+    when(() => cubit.state).thenReturn(
+      const AccountDeletionRecoveryState(
+        status: AccountDeletionRecoveryStatus.loading,
+      ),
+    );
+    await tester.pumpWidget(_app(cubit));
+
+    final l10n = lookupAppLocalizations(const Locale('en'));
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
     await tester.tap(
       find.widgetWithText(DivineButton, l10n.accountDeletionSignOut),
     );
-    await tester.pump();
-
-    verify(authService.signOut).called(1);
+    verify(cubit.signOut).called(1);
   });
 
-  testWidgets('completed cleanup failure says deletion already happened', (
-    tester,
-  ) async {
-    final repository = _MockRecoveryRepository();
-    final authService = _MockAuthService();
-    when(
-      () => authService.signOut(deleteKeys: true, deleteLocalUserData: true),
-    ).thenThrow(const UserDataCleanupException('cleanup failed'));
-    await tester.pumpWidget(
-      _app(
-        attempt: const AccountDeletionAttempt(
-          id: 'attempt-id',
-          status: AccountDeletionAttemptStatus.completed,
-        ),
-        repository: repository,
-        authService: authService,
-      ),
+  testWidgets('resolved state returns to the feed', (tester) async {
+    const initial = AccountDeletionRecoveryState(
+      status: AccountDeletionRecoveryStatus.restorable,
+      attempt: _recoverable,
     );
+    const resolved = AccountDeletionRecoveryState(
+      status: AccountDeletionRecoveryStatus.resolved,
+    );
+    when(() => cubit.state).thenReturn(initial);
+    await tester.pumpWidget(_app(cubit, states: Stream.value(resolved)));
     await tester.pumpAndSettle();
 
-    final l10n = lookupAppLocalizations(const Locale('en'));
-    expect(
-      find.text(l10n.deleteAccountLocalDataDeletionFailed),
-      findsOneWidget,
-    );
-    expect(find.text(l10n.accountDeletionRecoveryFailed), findsNothing);
+    expect(find.text('Home'), findsOneWidget);
   });
 }

--- a/mobile/test/screens/profile_screen_router_test.dart
+++ b/mobile/test/screens/profile_screen_router_test.dart
@@ -272,12 +272,18 @@ void main() {
       final bloc = await pumpProfileAt(tester, 0);
 
       expect(bloc.state.currentVideo?.id, mockVideos[0].id);
+
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump(const Duration(seconds: 3));
     });
 
     testWidgets('index 1 in the URL opens the second video', (tester) async {
       final bloc = await pumpProfileAt(tester, 1);
 
       expect(bloc.state.currentVideo?.id, mockVideos[1].id);
+
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump(const Duration(seconds: 3));
     });
   });
 


### PR DESCRIPTION
People recovering an interrupted account deletion could be told that an accepted cancellation failed, or be routed away while the coordinator state was still loading. Processing attempts also depended on a screen-local retry button instead of continuing safely in the background.

The recovery workflow now has one lifecycle-owned Cubit that models the coordinator state, owns cancellation and bounded polling, and performs local cleanup only after the server confirms completion. The screen is split into dependency-wiring and presentation layers, with typed failure states and a reachable sign-out escape. Router gating now remains closed while the deletion lookup is loading or has failed, and opens only after a definitive no-attempt result.

This deliberately keeps the current-attempt Riverpod provider as app/router compatibility glue; the obsolete polling provider was removed after the Cubit took ownership. It also preserves the deployed coordinator contract and repository behavior added in #8027, including the operation field, HTTP 202 cancellation handling, and typed conflict codes; this PR consumes that contract rather than replacing it.

Verification:

- Focused account-deletion and affected router suites: 67 tests passed
- Full optimized non-golden suite: 17,996 tests passed with 280 repository-declared skips
- `flutter analyze lib test integration_test tools`
- ARB consistency test
- Post-close emit, orphaned localization, layer-direction, raw-color, raw-TextStyle, and Material-button ratchets
- Pre-push analyzer and changed-file test selection

Closes #8039
