### PR TITLE
feat(inbox): surface pending badge awards as a Badges tab

### DIFF
--- a/mobile/lib/blocs/badges/badges_state.dart
+++ b/mobile/lib/blocs/badges/badges_state.dart
@@ -66,6 +66,14 @@ class BadgesState extends Equatable {
   /// Awards the user dismissed on this device, kept so they can be restored.
   final List<BadgeAwardViewData> hidden;
 
+  /// Awards waiting on a decision — offered, not yet accepted or dismissed.
+  ///
+  /// [hidden] is a separate list, so an award is pending purely on not having
+  /// been accepted. Badge awards arrive rarely and a user holds a handful, so
+  /// the filter stays a getter rather than another stored field.
+  List<BadgeAwardViewData> get pending =>
+      awarded.where((award) => !award.isAccepted).toList();
+
   /// Whether [actionStatus] is a finished outcome a reload should clear.
   ///
   /// The in-flight values gate the action buttons, so a pull to refresh

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -2652,13 +2652,9 @@
       }
     }
   },
-  "notificationsTabBadges": "Badges",
+  "notificationsTabBadges": "{count, plural, =0{Badges} other{Badges ({count})}}",
   "@notificationsTabBadges": {
-    "description": "Inbox tab listing badge awards that still need an accept or reject."
-  },
-  "notificationsTabBadgesWithCount": "Badges ({count})",
-  "@notificationsTabBadgesWithCount": {
-    "description": "Badges inbox tab label when awards are waiting on a decision.",
+    "description": "Inbox tab listing badge awards that still need an accept or reject, counting those waiting.",
     "placeholders": {
       "count": {
         "type": "int"

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -2652,6 +2652,32 @@
       }
     }
   },
+  "notificationsTabBadges": "Badges",
+  "@notificationsTabBadges": {
+    "description": "Inbox tab listing badge awards that still need an accept or reject."
+  },
+  "notificationsTabBadgesWithCount": "Badges ({count})",
+  "@notificationsTabBadgesWithCount": {
+    "description": "Badges inbox tab label when awards are waiting on a decision.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "notificationsPendingBadges": "{count, plural, =1{A badge is waiting for you to accept it} other{{count} badges are waiting for you to accept them}}",
+  "@notificationsPendingBadges": {
+    "description": "Banner on the All inbox tab pointing at undecided badge awards.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "notificationsBadgesEmpty": "No badges waiting. When someone awards you one, it lands here.",
+  "@notificationsBadgesEmpty": {
+    "description": "Empty state for the Badges inbox tab."
+  },
   "notificationsVideoUnavailable": "Video unavailable",
   "feedFailedToLoadVideos": "Failed to load videos",
   "feedRetry": "Retry",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -7115,17 +7115,11 @@ abstract class AppLocalizations {
   /// **'{count, plural, =1{You have {count} invite to share with friends!} other{You have {count} invites to share with friends!}}'**
   String notificationsInvitePlural(int count);
 
-  /// Inbox tab listing badge awards that still need an accept or reject.
+  /// Inbox tab listing badge awards that still need an accept or reject, counting those waiting.
   ///
   /// In en, this message translates to:
-  /// **'Badges'**
-  String get notificationsTabBadges;
-
-  /// Badges inbox tab label when awards are waiting on a decision.
-  ///
-  /// In en, this message translates to:
-  /// **'Badges ({count})'**
-  String notificationsTabBadgesWithCount(int count);
+  /// **'{count, plural, =0{Badges} other{Badges ({count})}}'**
+  String notificationsTabBadges(int count);
 
   /// Banner on the All inbox tab pointing at undecided badge awards.
   ///

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -7115,6 +7115,30 @@ abstract class AppLocalizations {
   /// **'{count, plural, =1{You have {count} invite to share with friends!} other{You have {count} invites to share with friends!}}'**
   String notificationsInvitePlural(int count);
 
+  /// Inbox tab listing badge awards that still need an accept or reject.
+  ///
+  /// In en, this message translates to:
+  /// **'Badges'**
+  String get notificationsTabBadges;
+
+  /// Badges inbox tab label when awards are waiting on a decision.
+  ///
+  /// In en, this message translates to:
+  /// **'Badges ({count})'**
+  String notificationsTabBadgesWithCount(int count);
+
+  /// Banner on the All inbox tab pointing at undecided badge awards.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{A badge is waiting for you to accept it} other{{count} badges are waiting for you to accept them}}'**
+  String notificationsPendingBadges(int count);
+
+  /// Empty state for the Badges inbox tab.
+  ///
+  /// In en, this message translates to:
+  /// **'No badges waiting. When someone awards you one, it lands here.'**
+  String get notificationsBadgesEmpty;
+
   /// No description provided for @notificationsVideoUnavailable.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -4075,11 +4075,14 @@ class AppLocalizationsAm extends AppLocalizations {
   }
 
   @override
-  String get notificationsTabBadges => 'Badges';
-
-  @override
-  String notificationsTabBadgesWithCount(int count) {
-    return 'Badges ($count)';
+  String notificationsTabBadges(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Badges ($count)',
+      zero: 'Badges',
+    );
+    return '$_temp0';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -4075,6 +4075,29 @@ class AppLocalizationsAm extends AppLocalizations {
   }
 
   @override
+  String get notificationsTabBadges => 'Badges';
+
+  @override
+  String notificationsTabBadgesWithCount(int count) {
+    return 'Badges ($count)';
+  }
+
+  @override
+  String notificationsPendingBadges(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count badges are waiting for you to accept them',
+      one: 'A badge is waiting for you to accept it',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get notificationsBadgesEmpty =>
+      'No badges waiting. When someone awards you one, it lands here.';
+
+  @override
   String get notificationsVideoUnavailable => 'ቪዲዮ አይገኝም';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -4133,11 +4133,14 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
-  String get notificationsTabBadges => 'Badges';
-
-  @override
-  String notificationsTabBadgesWithCount(int count) {
-    return 'Badges ($count)';
+  String notificationsTabBadges(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Badges ($count)',
+      zero: 'Badges',
+    );
+    return '$_temp0';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -4133,6 +4133,29 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
+  String get notificationsTabBadges => 'Badges';
+
+  @override
+  String notificationsTabBadgesWithCount(int count) {
+    return 'Badges ($count)';
+  }
+
+  @override
+  String notificationsPendingBadges(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count badges are waiting for you to accept them',
+      one: 'A badge is waiting for you to accept it',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get notificationsBadgesEmpty =>
+      'No badges waiting. When someone awards you one, it lands here.';
+
+  @override
   String get notificationsVideoUnavailable => 'الفيديو غير متاح';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -4216,6 +4216,29 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
+  String get notificationsTabBadges => 'Badges';
+
+  @override
+  String notificationsTabBadgesWithCount(int count) {
+    return 'Badges ($count)';
+  }
+
+  @override
+  String notificationsPendingBadges(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count badges are waiting for you to accept them',
+      one: 'A badge is waiting for you to accept it',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get notificationsBadgesEmpty =>
+      'No badges waiting. When someone awards you one, it lands here.';
+
+  @override
   String get notificationsVideoUnavailable => 'Видеото е недостъпно';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -4216,11 +4216,14 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
-  String get notificationsTabBadges => 'Badges';
-
-  @override
-  String notificationsTabBadgesWithCount(int count) {
-    return 'Badges ($count)';
+  String notificationsTabBadges(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Badges ($count)',
+      zero: 'Badges',
+    );
+    return '$_temp0';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -4221,11 +4221,14 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get notificationsTabBadges => 'Badges';
-
-  @override
-  String notificationsTabBadgesWithCount(int count) {
-    return 'Badges ($count)';
+  String notificationsTabBadges(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Badges ($count)',
+      zero: 'Badges',
+    );
+    return '$_temp0';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -4221,6 +4221,29 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String get notificationsTabBadges => 'Badges';
+
+  @override
+  String notificationsTabBadgesWithCount(int count) {
+    return 'Badges ($count)';
+  }
+
+  @override
+  String notificationsPendingBadges(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count badges are waiting for you to accept them',
+      one: 'A badge is waiting for you to accept it',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get notificationsBadgesEmpty =>
+      'No badges waiting. When someone awards you one, it lands here.';
+
+  @override
   String get notificationsVideoUnavailable => 'Video nicht verfügbar';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -4253,11 +4253,14 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get notificationsTabBadges => 'Badges';
-
-  @override
-  String notificationsTabBadgesWithCount(int count) {
-    return 'Badges ($count)';
+  String notificationsTabBadges(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Badges ($count)',
+      zero: 'Badges',
+    );
+    return '$_temp0';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -4253,6 +4253,29 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get notificationsTabBadges => 'Badges';
+
+  @override
+  String notificationsTabBadgesWithCount(int count) {
+    return 'Badges ($count)';
+  }
+
+  @override
+  String notificationsPendingBadges(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count badges are waiting for you to accept them',
+      one: 'A badge is waiting for you to accept it',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get notificationsBadgesEmpty =>
+      'No badges waiting. When someone awards you one, it lands here.';
+
+  @override
   String get notificationsVideoUnavailable => 'Video unavailable';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -4212,11 +4212,14 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get notificationsTabBadges => 'Badges';
-
-  @override
-  String notificationsTabBadgesWithCount(int count) {
-    return 'Badges ($count)';
+  String notificationsTabBadges(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Badges ($count)',
+      zero: 'Badges',
+    );
+    return '$_temp0';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -4212,6 +4212,29 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String get notificationsTabBadges => 'Badges';
+
+  @override
+  String notificationsTabBadgesWithCount(int count) {
+    return 'Badges ($count)';
+  }
+
+  @override
+  String notificationsPendingBadges(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count badges are waiting for you to accept them',
+      one: 'A badge is waiting for you to accept it',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get notificationsBadgesEmpty =>
+      'No badges waiting. When someone awards you one, it lands here.';
+
+  @override
   String get notificationsVideoUnavailable => 'Video no disponible';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -4194,11 +4194,14 @@ class AppLocalizationsFil extends AppLocalizations {
   }
 
   @override
-  String get notificationsTabBadges => 'Badges';
-
-  @override
-  String notificationsTabBadgesWithCount(int count) {
-    return 'Badges ($count)';
+  String notificationsTabBadges(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Badges ($count)',
+      zero: 'Badges',
+    );
+    return '$_temp0';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -4194,6 +4194,29 @@ class AppLocalizationsFil extends AppLocalizations {
   }
 
   @override
+  String get notificationsTabBadges => 'Badges';
+
+  @override
+  String notificationsTabBadgesWithCount(int count) {
+    return 'Badges ($count)';
+  }
+
+  @override
+  String notificationsPendingBadges(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count badges are waiting for you to accept them',
+      one: 'A badge is waiting for you to accept it',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get notificationsBadgesEmpty =>
+      'No badges waiting. When someone awards you one, it lands here.';
+
+  @override
   String get notificationsVideoUnavailable => 'Hindi available ang video';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -4229,6 +4229,29 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String get notificationsTabBadges => 'Badges';
+
+  @override
+  String notificationsTabBadgesWithCount(int count) {
+    return 'Badges ($count)';
+  }
+
+  @override
+  String notificationsPendingBadges(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count badges are waiting for you to accept them',
+      one: 'A badge is waiting for you to accept it',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get notificationsBadgesEmpty =>
+      'No badges waiting. When someone awards you one, it lands here.';
+
+  @override
   String get notificationsVideoUnavailable => 'Vidéo indisponible';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -4229,11 +4229,14 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get notificationsTabBadges => 'Badges';
-
-  @override
-  String notificationsTabBadgesWithCount(int count) {
-    return 'Badges ($count)';
+  String notificationsTabBadges(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Badges ($count)',
+      zero: 'Badges',
+    );
+    return '$_temp0';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -4096,11 +4096,14 @@ class AppLocalizationsId extends AppLocalizations {
   }
 
   @override
-  String get notificationsTabBadges => 'Badges';
-
-  @override
-  String notificationsTabBadgesWithCount(int count) {
-    return 'Badges ($count)';
+  String notificationsTabBadges(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Badges ($count)',
+      zero: 'Badges',
+    );
+    return '$_temp0';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -4096,6 +4096,29 @@ class AppLocalizationsId extends AppLocalizations {
   }
 
   @override
+  String get notificationsTabBadges => 'Badges';
+
+  @override
+  String notificationsTabBadgesWithCount(int count) {
+    return 'Badges ($count)';
+  }
+
+  @override
+  String notificationsPendingBadges(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count badges are waiting for you to accept them',
+      one: 'A badge is waiting for you to accept it',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get notificationsBadgesEmpty =>
+      'No badges waiting. When someone awards you one, it lands here.';
+
+  @override
   String get notificationsVideoUnavailable => 'Video tidak tersedia';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -4215,11 +4215,14 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String get notificationsTabBadges => 'Badges';
-
-  @override
-  String notificationsTabBadgesWithCount(int count) {
-    return 'Badges ($count)';
+  String notificationsTabBadges(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Badges ($count)',
+      zero: 'Badges',
+    );
+    return '$_temp0';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -4215,6 +4215,29 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String get notificationsTabBadges => 'Badges';
+
+  @override
+  String notificationsTabBadgesWithCount(int count) {
+    return 'Badges ($count)';
+  }
+
+  @override
+  String notificationsPendingBadges(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count badges are waiting for you to accept them',
+      one: 'A badge is waiting for you to accept it',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get notificationsBadgesEmpty =>
+      'No badges waiting. When someone awards you one, it lands here.';
+
+  @override
   String get notificationsVideoUnavailable => 'Video non disponibile';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -3915,11 +3915,14 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
-  String get notificationsTabBadges => 'Badges';
-
-  @override
-  String notificationsTabBadgesWithCount(int count) {
-    return 'Badges ($count)';
+  String notificationsTabBadges(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Badges ($count)',
+      zero: 'Badges',
+    );
+    return '$_temp0';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -3915,6 +3915,29 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
+  String get notificationsTabBadges => 'Badges';
+
+  @override
+  String notificationsTabBadgesWithCount(int count) {
+    return 'Badges ($count)';
+  }
+
+  @override
+  String notificationsPendingBadges(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count badges are waiting for you to accept them',
+      one: 'A badge is waiting for you to accept it',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get notificationsBadgesEmpty =>
+      'No badges waiting. When someone awards you one, it lands here.';
+
+  @override
   String get notificationsVideoUnavailable => '動画を見れないよ';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -3931,11 +3931,14 @@ class AppLocalizationsKo extends AppLocalizations {
   }
 
   @override
-  String get notificationsTabBadges => 'Badges';
-
-  @override
-  String notificationsTabBadgesWithCount(int count) {
-    return 'Badges ($count)';
+  String notificationsTabBadges(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Badges ($count)',
+      zero: 'Badges',
+    );
+    return '$_temp0';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -3931,6 +3931,29 @@ class AppLocalizationsKo extends AppLocalizations {
   }
 
   @override
+  String get notificationsTabBadges => 'Badges';
+
+  @override
+  String notificationsTabBadgesWithCount(int count) {
+    return 'Badges ($count)';
+  }
+
+  @override
+  String notificationsPendingBadges(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count badges are waiting for you to accept them',
+      one: 'A badge is waiting for you to accept it',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get notificationsBadgesEmpty =>
+      'No badges waiting. When someone awards you one, it lands here.';
+
+  @override
   String get notificationsVideoUnavailable => '영상을 사용할 수 없어요';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -4163,6 +4163,29 @@ class AppLocalizationsMs extends AppLocalizations {
   }
 
   @override
+  String get notificationsTabBadges => 'Badges';
+
+  @override
+  String notificationsTabBadgesWithCount(int count) {
+    return 'Badges ($count)';
+  }
+
+  @override
+  String notificationsPendingBadges(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count badges are waiting for you to accept them',
+      one: 'A badge is waiting for you to accept it',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get notificationsBadgesEmpty =>
+      'No badges waiting. When someone awards you one, it lands here.';
+
+  @override
   String get notificationsVideoUnavailable => 'Video tidak tersedia';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -4163,11 +4163,14 @@ class AppLocalizationsMs extends AppLocalizations {
   }
 
   @override
-  String get notificationsTabBadges => 'Badges';
-
-  @override
-  String notificationsTabBadgesWithCount(int count) {
-    return 'Badges ($count)';
+  String notificationsTabBadges(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Badges ($count)',
+      zero: 'Badges',
+    );
+    return '$_temp0';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -4181,11 +4181,14 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
-  String get notificationsTabBadges => 'Badges';
-
-  @override
-  String notificationsTabBadgesWithCount(int count) {
-    return 'Badges ($count)';
+  String notificationsTabBadges(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Badges ($count)',
+      zero: 'Badges',
+    );
+    return '$_temp0';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -4181,6 +4181,29 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
+  String get notificationsTabBadges => 'Badges';
+
+  @override
+  String notificationsTabBadgesWithCount(int count) {
+    return 'Badges ($count)';
+  }
+
+  @override
+  String notificationsPendingBadges(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count badges are waiting for you to accept them',
+      one: 'A badge is waiting for you to accept it',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get notificationsBadgesEmpty =>
+      'No badges waiting. When someone awards you one, it lands here.';
+
+  @override
   String get notificationsVideoUnavailable => 'Video niet beschikbaar';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -4284,11 +4284,14 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
-  String get notificationsTabBadges => 'Badges';
-
-  @override
-  String notificationsTabBadgesWithCount(int count) {
-    return 'Badges ($count)';
+  String notificationsTabBadges(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Badges ($count)',
+      zero: 'Badges',
+    );
+    return '$_temp0';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -4284,6 +4284,29 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
+  String get notificationsTabBadges => 'Badges';
+
+  @override
+  String notificationsTabBadgesWithCount(int count) {
+    return 'Badges ($count)';
+  }
+
+  @override
+  String notificationsPendingBadges(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count badges are waiting for you to accept them',
+      one: 'A badge is waiting for you to accept it',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get notificationsBadgesEmpty =>
+      'No badges waiting. When someone awards you one, it lands here.';
+
+  @override
   String get notificationsVideoUnavailable => 'Film niedostępny';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -4194,6 +4194,29 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String get notificationsTabBadges => 'Badges';
+
+  @override
+  String notificationsTabBadgesWithCount(int count) {
+    return 'Badges ($count)';
+  }
+
+  @override
+  String notificationsPendingBadges(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count badges are waiting for you to accept them',
+      one: 'A badge is waiting for you to accept it',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get notificationsBadgesEmpty =>
+      'No badges waiting. When someone awards you one, it lands here.';
+
+  @override
   String get notificationsVideoUnavailable => 'Vídeo indisponível';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -4194,11 +4194,14 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String get notificationsTabBadges => 'Badges';
-
-  @override
-  String notificationsTabBadgesWithCount(int count) {
-    return 'Badges ($count)';
+  String notificationsTabBadges(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Badges ($count)',
+      zero: 'Badges',
+    );
+    return '$_temp0';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -4300,11 +4300,14 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String get notificationsTabBadges => 'Badges';
-
-  @override
-  String notificationsTabBadgesWithCount(int count) {
-    return 'Badges ($count)';
+  String notificationsTabBadges(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Badges ($count)',
+      zero: 'Badges',
+    );
+    return '$_temp0';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -4300,6 +4300,29 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
+  String get notificationsTabBadges => 'Badges';
+
+  @override
+  String notificationsTabBadgesWithCount(int count) {
+    return 'Badges ($count)';
+  }
+
+  @override
+  String notificationsPendingBadges(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count badges are waiting for you to accept them',
+      one: 'A badge is waiting for you to accept it',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get notificationsBadgesEmpty =>
+      'No badges waiting. When someone awards you one, it lands here.';
+
+  @override
   String get notificationsVideoUnavailable => 'Videoclip indisponibil';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -4164,6 +4164,29 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
+  String get notificationsTabBadges => 'Badges';
+
+  @override
+  String notificationsTabBadgesWithCount(int count) {
+    return 'Badges ($count)';
+  }
+
+  @override
+  String notificationsPendingBadges(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count badges are waiting for you to accept them',
+      one: 'A badge is waiting for you to accept it',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get notificationsBadgesEmpty =>
+      'No badges waiting. When someone awards you one, it lands here.';
+
+  @override
   String get notificationsVideoUnavailable => 'Videon är otillgänglig';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -4164,11 +4164,14 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
-  String get notificationsTabBadges => 'Badges';
-
-  @override
-  String notificationsTabBadgesWithCount(int count) {
-    return 'Badges ($count)';
+  String notificationsTabBadges(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Badges ($count)',
+      zero: 'Badges',
+    );
+    return '$_temp0';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -4106,6 +4106,29 @@ class AppLocalizationsTr extends AppLocalizations {
   }
 
   @override
+  String get notificationsTabBadges => 'Badges';
+
+  @override
+  String notificationsTabBadgesWithCount(int count) {
+    return 'Badges ($count)';
+  }
+
+  @override
+  String notificationsPendingBadges(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count badges are waiting for you to accept them',
+      one: 'A badge is waiting for you to accept it',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get notificationsBadgesEmpty =>
+      'No badges waiting. When someone awards you one, it lands here.';
+
+  @override
   String get notificationsVideoUnavailable => 'Video kullanılamıyor';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -4106,11 +4106,14 @@ class AppLocalizationsTr extends AppLocalizations {
   }
 
   @override
-  String get notificationsTabBadges => 'Badges';
-
-  @override
-  String notificationsTabBadgesWithCount(int count) {
-    return 'Badges ($count)';
+  String notificationsTabBadges(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Badges ($count)',
+      zero: 'Badges',
+    );
+    return '$_temp0';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -4172,11 +4172,14 @@ class AppLocalizationsUr extends AppLocalizations {
   }
 
   @override
-  String get notificationsTabBadges => 'Badges';
-
-  @override
-  String notificationsTabBadgesWithCount(int count) {
-    return 'Badges ($count)';
+  String notificationsTabBadges(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Badges ($count)',
+      zero: 'Badges',
+    );
+    return '$_temp0';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -4172,6 +4172,29 @@ class AppLocalizationsUr extends AppLocalizations {
   }
 
   @override
+  String get notificationsTabBadges => 'Badges';
+
+  @override
+  String notificationsTabBadgesWithCount(int count) {
+    return 'Badges ($count)';
+  }
+
+  @override
+  String notificationsPendingBadges(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count badges are waiting for you to accept them',
+      one: 'A badge is waiting for you to accept it',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get notificationsBadgesEmpty =>
+      'No badges waiting. When someone awards you one, it lands here.';
+
+  @override
   String get notificationsVideoUnavailable => 'ویڈیو دستیاب نہیں';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -4137,11 +4137,14 @@ class AppLocalizationsVi extends AppLocalizations {
   }
 
   @override
-  String get notificationsTabBadges => 'Badges';
-
-  @override
-  String notificationsTabBadgesWithCount(int count) {
-    return 'Badges ($count)';
+  String notificationsTabBadges(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Badges ($count)',
+      zero: 'Badges',
+    );
+    return '$_temp0';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -4137,6 +4137,29 @@ class AppLocalizationsVi extends AppLocalizations {
   }
 
   @override
+  String get notificationsTabBadges => 'Badges';
+
+  @override
+  String notificationsTabBadgesWithCount(int count) {
+    return 'Badges ($count)';
+  }
+
+  @override
+  String notificationsPendingBadges(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count badges are waiting for you to accept them',
+      one: 'A badge is waiting for you to accept it',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get notificationsBadgesEmpty =>
+      'No badges waiting. When someone awards you one, it lands here.';
+
+  @override
   String get notificationsVideoUnavailable => 'Video không khả dụng';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -3908,11 +3908,14 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
-  String get notificationsTabBadges => 'Badges';
-
-  @override
-  String notificationsTabBadgesWithCount(int count) {
-    return 'Badges ($count)';
+  String notificationsTabBadges(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Badges ($count)',
+      zero: 'Badges',
+    );
+    return '$_temp0';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -3908,6 +3908,29 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
+  String get notificationsTabBadges => 'Badges';
+
+  @override
+  String notificationsTabBadgesWithCount(int count) {
+    return 'Badges ($count)';
+  }
+
+  @override
+  String notificationsPendingBadges(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count badges are waiting for you to accept them',
+      one: 'A badge is waiting for you to accept it',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get notificationsBadgesEmpty =>
+      'No badges waiting. When someone awards you one, it lands here.';
+
+  @override
   String get notificationsVideoUnavailable => '视频不可用';
 
   @override

--- a/mobile/lib/notifications/view/inbox_notifications_page.dart
+++ b/mobile/lib/notifications/view/inbox_notifications_page.dart
@@ -105,9 +105,14 @@ class _InboxNotificationsScaffoldState
     super.didUpdateWidget(oldWidget);
     if (widget.badgeRepository == oldWidget.badgeRepository) return;
     // A new repository is bound to a different signer, so in-flight accepts
-    // belong to the previous one and are dropped with the cubit.
-    _badgesCubit.close();
-    _badgesCubit = BadgesCubit(repository: widget.badgeRepository)..load();
+    // belong to the previous one and are dropped with the cubit. The old one
+    // is closed after the frame: descendants are still subscribed to it until
+    // this rebuild swaps them onto the new instance.
+    final previous = _badgesCubit;
+    WidgetsBinding.instance.addPostFrameCallback((_) => previous.close());
+    setState(() {
+      _badgesCubit = BadgesCubit(repository: widget.badgeRepository)..load();
+    });
   }
 
   @override
@@ -137,36 +142,7 @@ class _InboxNotificationsScaffoldState
           child: Column(
             children: [
               const SizedBox(height: 12),
-              Material(
-                type: MaterialType.transparency,
-                child: TabBar(
-                  controller: tabController,
-                  isScrollable: true,
-                  tabAlignment: TabAlignment.start,
-                  padding: const EdgeInsetsDirectional.only(start: 16),
-                  indicatorColor: VineTheme.tabIndicatorGreen,
-                  indicatorWeight: 4,
-                  indicatorSize: TabBarIndicatorSize.tab,
-                  dividerColor: VineTheme.transparent,
-                  labelColor: context.vineColors.primaryText,
-                  unselectedLabelColor: context.vineColors.onSurfaceMuted,
-                  labelPadding: const EdgeInsets.symmetric(horizontal: 14),
-                  labelStyle: VineTheme.titleMediumFont(
-                    color: context.vineColors.primaryText,
-                  ),
-                  unselectedLabelStyle: VineTheme.titleMediumFont(
-                    color: context.vineColors.onSurfaceMuted,
-                  ),
-                  tabs: [
-                    Tab(text: context.l10n.notificationsTabAll),
-                    Tab(text: context.l10n.notificationsTabLikes),
-                    Tab(text: context.l10n.notificationsTabComments),
-                    Tab(text: context.l10n.notificationsTabFollows),
-                    Tab(text: context.l10n.notificationsTabReposts),
-                    const _BadgesTab(),
-                  ],
-                ),
-              ),
+              _InboxTabBar(controller: tabController),
               Expanded(
                 child: TabBarView(
                   controller: tabController,
@@ -312,22 +288,48 @@ class _NotificationVisibilityDispatcherState
   }
 }
 
-/// Tab label for pending badge awards, carrying their count.
-///
-/// The count is the point of the tab: a badge award is an offer waiting on a
-/// decision, and nothing else in the app says one is waiting.
-class _BadgesTab extends StatelessWidget {
-  const _BadgesTab();
+/// Inbox filter tabs, built inside the badges cubit's subtree so the Badges
+/// label can carry its pending count.
+class _InboxTabBar extends StatelessWidget {
+  const _InboxTabBar({required this.controller});
+
+  final TabController controller;
 
   @override
   Widget build(BuildContext context) {
-    final pendingCount = context.select(
+    final pendingBadges = context.select(
       (BadgesCubit cubit) => cubit.state.pending.length,
     );
-    return Tab(
-      text: pendingCount == 0
-          ? context.l10n.notificationsTabBadges
-          : context.l10n.notificationsTabBadgesWithCount(pendingCount),
+    // Material is required for the TabBar ink splash.
+    return Material(
+      type: MaterialType.transparency,
+      child: TabBar(
+        controller: controller,
+        isScrollable: true,
+        tabAlignment: TabAlignment.start,
+        padding: const EdgeInsetsDirectional.only(start: 16),
+        indicatorColor: VineTheme.tabIndicatorGreen,
+        indicatorWeight: 4,
+        indicatorSize: TabBarIndicatorSize.tab,
+        dividerColor: VineTheme.transparent,
+        labelColor: context.vineColors.primaryText,
+        unselectedLabelColor: context.vineColors.onSurfaceMuted,
+        labelPadding: const EdgeInsets.symmetric(horizontal: 14),
+        labelStyle: VineTheme.titleMediumFont(
+          color: context.vineColors.primaryText,
+        ),
+        unselectedLabelStyle: VineTheme.titleMediumFont(
+          color: context.vineColors.onSurfaceMuted,
+        ),
+        tabs: [
+          Tab(text: context.l10n.notificationsTabAll),
+          Tab(text: context.l10n.notificationsTabLikes),
+          Tab(text: context.l10n.notificationsTabComments),
+          Tab(text: context.l10n.notificationsTabFollows),
+          Tab(text: context.l10n.notificationsTabReposts),
+          Tab(text: context.l10n.notificationsTabBadges(pendingBadges)),
+        ],
+      ),
     );
   }
 }
@@ -345,37 +347,42 @@ class _PendingBadgesBanner extends StatelessWidget {
     );
     if (pendingCount == 0) return const SizedBox.shrink();
 
-    return InkWell(
-      onTap: onViewPending,
-      child: Semantics(
-        button: true,
-        child: Container(
-          padding: const EdgeInsets.all(16),
-          color: context.vineColors.card,
-          child: Row(
-            spacing: 12,
-            children: [
-              Container(
-                width: 48,
-                height: 48,
-                decoration: const BoxDecoration(
-                  color: VineTheme.vineGreen,
-                  shape: BoxShape.circle,
-                ),
-                child: DivineIcon(
-                  icon: DivineIconName.sealCheck,
-                  color: context.vineColors.background,
-                ),
-              ),
-              Expanded(
-                child: Text(
-                  context.l10n.notificationsPendingBadges(pendingCount),
-                  style: VineTheme.bodyMediumFont(
-                    color: context.vineColors.primaryText,
+    // Its own Material: the banner sits in a plain Column, so the ink splash
+    // cannot rely on an ancestor sheet being there.
+    return Material(
+      type: MaterialType.transparency,
+      child: InkWell(
+        onTap: onViewPending,
+        child: Semantics(
+          button: true,
+          child: Container(
+            padding: const EdgeInsets.all(16),
+            color: context.vineColors.card,
+            child: Row(
+              spacing: 12,
+              children: [
+                Container(
+                  width: 48,
+                  height: 48,
+                  decoration: const BoxDecoration(
+                    color: VineTheme.vineGreen,
+                    shape: BoxShape.circle,
+                  ),
+                  child: DivineIcon(
+                    icon: DivineIconName.sealCheck,
+                    color: context.vineColors.background,
                   ),
                 ),
-              ),
-            ],
+                Expanded(
+                  child: Text(
+                    context.l10n.notificationsPendingBadges(pendingCount),
+                    style: VineTheme.bodyMediumFont(
+                      color: context.vineColors.primaryText,
+                    ),
+                  ),
+                ),
+              ],
+            ),
           ),
         ),
       ),

--- a/mobile/lib/notifications/view/inbox_notifications_page.dart
+++ b/mobile/lib/notifications/view/inbox_notifications_page.dart
@@ -1,6 +1,5 @@
-// ABOUTME: Inbox notifications scaffold — TabBar (All/Likes/Comments/
-// ABOUTME: Follows/Reposts) + invites banner wrapping the BLoC-driven
-// ABOUTME: NotificationsView.
+// ABOUTME: Inbox notifications scaffold — six filter tabs plus actionable
+// ABOUTME: invite and pending-badge banners wrapping NotificationsView.
 
 import 'package:badge_repository/badge_repository.dart';
 import 'package:divine_ui/divine_ui.dart';
@@ -25,9 +24,9 @@ import 'package:openvine/widgets/signup_invites_availability_builder.dart';
 
 /// Inbox notifications page — owns the BLoC and tab scaffold.
 ///
-/// Wraps [NotificationsView] with the existing 5-tab UI (All / Likes /
-/// Comments / Follows / Reposts) and the invites banner shown on the All
-/// tab. Each tab owns a feed BLoC with independent server-side pagination.
+/// Wraps [NotificationsView] with the six-tab UI (All / Likes / Comments /
+/// Follows / Reposts / Badges) and actionable banners shown on the All tab.
+/// Each notification tab owns a feed BLoC with independent pagination.
 class InboxNotificationsPage extends ConsumerWidget {
   /// Creates an [InboxNotificationsPage].
   const InboxNotificationsPage({this.isVisible = true, super.key});
@@ -58,8 +57,10 @@ class InboxNotificationsPage extends ConsumerWidget {
   }
 }
 
+const int _inboxTabCount = 6;
+
 /// Position of the Badges tab, last after the reaction filters.
-const _badgesTabIndex = 5;
+const int _badgesTabIndex = _inboxTabCount - 1;
 
 class _InboxNotificationsScaffold extends StatefulWidget {
   const _InboxNotificationsScaffold({
@@ -83,7 +84,7 @@ class _InboxNotificationsScaffoldState
     extends State<_InboxNotificationsScaffold>
     with TickerProviderStateMixin, ReducedMotionTabControllerMixin {
   @override
-  int get tabCount => 6;
+  int get tabCount => _inboxTabCount;
 
   /// Owned here rather than by a keyed `BlocProvider` so a repository swap
   /// rebuilds the badge subtree only. Keying a provider above the tabs would
@@ -103,16 +104,24 @@ class _InboxNotificationsScaffoldState
   @override
   void didUpdateWidget(_InboxNotificationsScaffold oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (widget.badgeRepository == oldWidget.badgeRepository) return;
-    // A new repository is bound to a different signer, so in-flight accepts
-    // belong to the previous one and are dropped with the cubit. The old one
-    // is closed after the frame: descendants are still subscribed to it until
-    // this rebuild swaps them onto the new instance.
-    final previous = _badgesCubit;
-    WidgetsBinding.instance.addPostFrameCallback((_) => previous.close());
-    setState(() {
-      _badgesCubit = BadgesCubit(repository: widget.badgeRepository)..load();
-    });
+    if (widget.badgeRepository != oldWidget.badgeRepository) {
+      // Keep the old cubit alive through the rebuild while descendants rebind.
+      // See PR #8046.
+      final previous = _badgesCubit;
+      WidgetsBinding.instance.addPostFrameCallback((_) => previous.close());
+      setState(() {
+        _badgesCubit = BadgesCubit(repository: widget.badgeRepository)..load();
+      });
+      return;
+    }
+
+    if (!oldWidget.isVisible && widget.isVisible) {
+      final cubit = _badgesCubit;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted || !identical(_badgesCubit, cubit)) return;
+        cubit.refresh();
+      });
+    }
   }
 
   @override
@@ -347,45 +356,10 @@ class _PendingBadgesBanner extends StatelessWidget {
     );
     if (pendingCount == 0) return const SizedBox.shrink();
 
-    // Its own Material: the banner sits in a plain Column, so the ink splash
-    // cannot rely on an ancestor sheet being there.
-    return Material(
-      type: MaterialType.transparency,
-      child: InkWell(
-        onTap: onViewPending,
-        child: Semantics(
-          button: true,
-          child: Container(
-            padding: const EdgeInsets.all(16),
-            color: context.vineColors.card,
-            child: Row(
-              spacing: 12,
-              children: [
-                Container(
-                  width: 48,
-                  height: 48,
-                  decoration: const BoxDecoration(
-                    color: VineTheme.vineGreen,
-                    shape: BoxShape.circle,
-                  ),
-                  child: DivineIcon(
-                    icon: DivineIconName.sealCheck,
-                    color: context.vineColors.background,
-                  ),
-                ),
-                Expanded(
-                  child: Text(
-                    context.l10n.notificationsPendingBadges(pendingCount),
-                    style: VineTheme.bodyMediumFont(
-                      color: context.vineColors.primaryText,
-                    ),
-                  ),
-                ),
-              ],
-            ),
-          ),
-        ),
-      ),
+    return _InboxBanner(
+      icon: DivineIconName.sealCheck,
+      label: context.l10n.notificationsPendingBadges(pendingCount),
+      onTap: onViewPending,
     );
   }
 }
@@ -419,39 +393,64 @@ class _InviteNotificationCard extends StatelessWidget {
     final label = count == 1
         ? context.l10n.notificationsInviteSingular
         : context.l10n.notificationsInvitePlural(count);
-    return InkWell(
+    return _InboxBanner(
+      icon: DivineIconName.shareNetwork,
+      label: label,
       onTap: () => context.push(InvitesScreen.path),
-      child: Container(
-        padding: const EdgeInsets.all(16),
-        color: context.vineColors.card,
-        child: Row(
-          spacing: 12,
-          children: [
-            Container(
-              width: 48,
-              height: 48,
-              decoration: const BoxDecoration(
-                color: VineTheme.vineGreen,
-                shape: BoxShape.circle,
-              ),
-              child: DivineIcon(
-                icon: DivineIconName.shareNetwork,
-                color: context.vineColors.background,
-              ),
-            ),
-            Expanded(
-              child: Text(
-                label,
-                style: VineTheme.bodyMediumFont(
-                  color: context.vineColors.primaryText,
+    );
+  }
+}
+
+/// Shared actionable banner chrome for the All tab.
+class _InboxBanner extends StatelessWidget {
+  const _InboxBanner({
+    required this.icon,
+    required this.label,
+    required this.onTap,
+  });
+
+  final DivineIconName icon;
+  final String label;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    // The card color belongs to Material so the InkWell splash paints above it.
+    return Material(
+      color: context.vineColors.card,
+      child: InkWell(
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Row(
+            spacing: 12,
+            children: [
+              Container(
+                width: 48,
+                height: 48,
+                decoration: const BoxDecoration(
+                  color: VineTheme.vineGreen,
+                  shape: BoxShape.circle,
+                ),
+                child: DivineIcon(
+                  icon: icon,
+                  color: context.vineColors.background,
                 ),
               ),
-            ),
-            DivineIcon(
-              icon: DivineIconName.caretRight,
-              color: context.vineColors.mutedText,
-            ),
-          ],
+              Expanded(
+                child: Text(
+                  label,
+                  style: VineTheme.bodyMediumFont(
+                    color: context.vineColors.primaryText,
+                  ),
+                ),
+              ),
+              DivineIcon(
+                icon: DivineIconName.caretRight,
+                color: context.vineColors.mutedText,
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/mobile/lib/notifications/view/inbox_notifications_page.dart
+++ b/mobile/lib/notifications/view/inbox_notifications_page.dart
@@ -2,6 +2,7 @@
 // ABOUTME: Follows/Reposts) + invites banner wrapping the BLoC-driven
 // ABOUTME: NotificationsView.
 
+import 'package:badge_repository/badge_repository.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -10,12 +11,14 @@ import 'package:follow_repository/follow_repository.dart';
 import 'package:go_router/go_router.dart';
 import 'package:models/models.dart';
 import 'package:notification_repository/notification_repository.dart';
+import 'package:openvine/blocs/badges/badges_cubit.dart';
 import 'package:openvine/blocs/invite_status/invite_status_cubit.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/mixins/reduced_motion_tab_controller_mixin.dart';
 import 'package:openvine/notifications/bloc/notification_feed_bloc.dart';
 import 'package:openvine/notifications/providers/notification_repository_provider.dart';
 import 'package:openvine/notifications/view/notifications_view.dart';
+import 'package:openvine/notifications/view/pending_badge_awards_view.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/screens/settings/invites_screen.dart';
 import 'package:openvine/widgets/signup_invites_availability_builder.dart';
@@ -44,24 +47,31 @@ class InboxNotificationsPage extends ConsumerWidget {
       );
     }
     final followRepository = ref.watch(followRepositoryProvider);
+    final badgeRepository = ref.watch(badgeRepositoryProvider);
 
     return _InboxNotificationsScaffold(
       notificationRepository: notificationRepository,
       followRepository: followRepository,
+      badgeRepository: badgeRepository,
       isVisible: isVisible,
     );
   }
 }
 
+/// Position of the Badges tab, last after the reaction filters.
+const _badgesTabIndex = 5;
+
 class _InboxNotificationsScaffold extends StatefulWidget {
   const _InboxNotificationsScaffold({
     required this.notificationRepository,
     required this.followRepository,
+    required this.badgeRepository,
     required this.isVisible,
   });
 
   final NotificationRepository notificationRepository;
   final FollowRepository followRepository;
+  final BadgeRepository badgeRepository;
   final bool isVisible;
 
   @override
@@ -73,15 +83,37 @@ class _InboxNotificationsScaffoldState
     extends State<_InboxNotificationsScaffold>
     with TickerProviderStateMixin, ReducedMotionTabControllerMixin {
   @override
-  int get tabCount => 5;
+  int get tabCount => 6;
+
+  /// Owned here rather than by a keyed `BlocProvider` so a repository swap
+  /// rebuilds the badge subtree only. Keying a provider above the tabs would
+  /// also tear down every notification feed and reset the open tab.
+  late BadgesCubit _badgesCubit;
 
   @override
   void initState() {
     super.initState();
+    _badgesCubit = BadgesCubit(repository: widget.badgeRepository)..load();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
       context.read<InviteStatusCubit>().load();
     });
+  }
+
+  @override
+  void didUpdateWidget(_InboxNotificationsScaffold oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.badgeRepository == oldWidget.badgeRepository) return;
+    // A new repository is bound to a different signer, so in-flight accepts
+    // belong to the previous one and are dropped with the cubit.
+    _badgesCubit.close();
+    _badgesCubit = BadgesCubit(repository: widget.badgeRepository)..load();
+  }
+
+  @override
+  void dispose() {
+    _badgesCubit.close();
+    super.dispose();
   }
 
   @override
@@ -98,81 +130,92 @@ class _InboxNotificationsScaffoldState
       ),
       child: ColoredBox(
         color: context.vineColors.surfaceContainerHigh,
-        child: Column(
-          children: [
-            const SizedBox(height: 12),
-            Material(
-              type: MaterialType.transparency,
-              child: TabBar(
-                controller: tabController,
-                isScrollable: true,
-                tabAlignment: TabAlignment.start,
-                padding: const EdgeInsetsDirectional.only(start: 16),
-                indicatorColor: VineTheme.tabIndicatorGreen,
-                indicatorWeight: 4,
-                indicatorSize: TabBarIndicatorSize.tab,
-                dividerColor: VineTheme.transparent,
-                labelColor: context.vineColors.primaryText,
-                unselectedLabelColor: context.vineColors.onSurfaceMuted,
-                labelPadding: const EdgeInsets.symmetric(horizontal: 14),
-                labelStyle: VineTheme.titleMediumFont(
-                  color: context.vineColors.primaryText,
+        // One cubit for the tab label's pending count, the All-tab banner, and
+        // the Badges tab body, so accepting an award updates all three.
+        child: BlocProvider<BadgesCubit>.value(
+          value: _badgesCubit,
+          child: Column(
+            children: [
+              const SizedBox(height: 12),
+              Material(
+                type: MaterialType.transparency,
+                child: TabBar(
+                  controller: tabController,
+                  isScrollable: true,
+                  tabAlignment: TabAlignment.start,
+                  padding: const EdgeInsetsDirectional.only(start: 16),
+                  indicatorColor: VineTheme.tabIndicatorGreen,
+                  indicatorWeight: 4,
+                  indicatorSize: TabBarIndicatorSize.tab,
+                  dividerColor: VineTheme.transparent,
+                  labelColor: context.vineColors.primaryText,
+                  unselectedLabelColor: context.vineColors.onSurfaceMuted,
+                  labelPadding: const EdgeInsets.symmetric(horizontal: 14),
+                  labelStyle: VineTheme.titleMediumFont(
+                    color: context.vineColors.primaryText,
+                  ),
+                  unselectedLabelStyle: VineTheme.titleMediumFont(
+                    color: context.vineColors.onSurfaceMuted,
+                  ),
+                  tabs: [
+                    Tab(text: context.l10n.notificationsTabAll),
+                    Tab(text: context.l10n.notificationsTabLikes),
+                    Tab(text: context.l10n.notificationsTabComments),
+                    Tab(text: context.l10n.notificationsTabFollows),
+                    Tab(text: context.l10n.notificationsTabReposts),
+                    const _BadgesTab(),
+                  ],
                 ),
-                unselectedLabelStyle: VineTheme.titleMediumFont(
-                  color: context.vineColors.onSurfaceMuted,
-                ),
-                tabs: [
-                  Tab(text: context.l10n.notificationsTabAll),
-                  Tab(text: context.l10n.notificationsTabLikes),
-                  Tab(text: context.l10n.notificationsTabComments),
-                  Tab(text: context.l10n.notificationsTabFollows),
-                  Tab(text: context.l10n.notificationsTabReposts),
-                ],
               ),
-            ),
-            Expanded(
-              child: TabBarView(
-                controller: tabController,
-                children: [
-                  _NotificationTab(
-                    notificationRepository: widget.notificationRepository,
-                    followRepository: widget.followRepository,
-                    isVisible: widget.isVisible,
-                    child: const Column(
-                      children: [
-                        _InvitesBanner(),
-                        Expanded(child: NotificationsView()),
-                      ],
+              Expanded(
+                child: TabBarView(
+                  controller: tabController,
+                  children: [
+                    _NotificationTab(
+                      notificationRepository: widget.notificationRepository,
+                      followRepository: widget.followRepository,
+                      isVisible: widget.isVisible,
+                      child: Column(
+                        children: [
+                          const _InvitesBanner(),
+                          _PendingBadgesBanner(
+                            onViewPending: () =>
+                                tabController.animateTo(_badgesTabIndex),
+                          ),
+                          const Expanded(child: NotificationsView()),
+                        ],
+                      ),
                     ),
-                  ),
-                  _NotificationTab(
-                    notificationRepository: widget.notificationRepository,
-                    followRepository: widget.followRepository,
-                    isVisible: widget.isVisible,
-                    filter: NotificationKind.like,
-                  ),
-                  _NotificationTab(
-                    notificationRepository: widget.notificationRepository,
-                    followRepository: widget.followRepository,
-                    isVisible: widget.isVisible,
-                    filter: NotificationKind.comment,
-                  ),
-                  _NotificationTab(
-                    notificationRepository: widget.notificationRepository,
-                    followRepository: widget.followRepository,
-                    isVisible: widget.isVisible,
-                    filter: NotificationKind.follow,
-                  ),
-                  _NotificationTab(
-                    notificationRepository: widget.notificationRepository,
-                    followRepository: widget.followRepository,
-                    isVisible: widget.isVisible,
-                    filter: NotificationKind.repost,
-                  ),
-                ],
+                    _NotificationTab(
+                      notificationRepository: widget.notificationRepository,
+                      followRepository: widget.followRepository,
+                      isVisible: widget.isVisible,
+                      filter: NotificationKind.like,
+                    ),
+                    _NotificationTab(
+                      notificationRepository: widget.notificationRepository,
+                      followRepository: widget.followRepository,
+                      isVisible: widget.isVisible,
+                      filter: NotificationKind.comment,
+                    ),
+                    _NotificationTab(
+                      notificationRepository: widget.notificationRepository,
+                      followRepository: widget.followRepository,
+                      isVisible: widget.isVisible,
+                      filter: NotificationKind.follow,
+                    ),
+                    _NotificationTab(
+                      notificationRepository: widget.notificationRepository,
+                      followRepository: widget.followRepository,
+                      isVisible: widget.isVisible,
+                      filter: NotificationKind.repost,
+                    ),
+                    const PendingBadgeAwardsView(),
+                  ],
+                ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );
@@ -266,6 +309,77 @@ class _NotificationVisibilityDispatcherState
   Widget build(BuildContext context) {
     _observeVisibility();
     return widget.child;
+  }
+}
+
+/// Tab label for pending badge awards, carrying their count.
+///
+/// The count is the point of the tab: a badge award is an offer waiting on a
+/// decision, and nothing else in the app says one is waiting.
+class _BadgesTab extends StatelessWidget {
+  const _BadgesTab();
+
+  @override
+  Widget build(BuildContext context) {
+    final pendingCount = context.select(
+      (BadgesCubit cubit) => cubit.state.pending.length,
+    );
+    return Tab(
+      text: pendingCount == 0
+          ? context.l10n.notificationsTabBadges
+          : context.l10n.notificationsTabBadgesWithCount(pendingCount),
+    );
+  }
+}
+
+/// Points at waiting badge awards from the All tab.
+class _PendingBadgesBanner extends StatelessWidget {
+  const _PendingBadgesBanner({required this.onViewPending});
+
+  final VoidCallback onViewPending;
+
+  @override
+  Widget build(BuildContext context) {
+    final pendingCount = context.select(
+      (BadgesCubit cubit) => cubit.state.pending.length,
+    );
+    if (pendingCount == 0) return const SizedBox.shrink();
+
+    return InkWell(
+      onTap: onViewPending,
+      child: Semantics(
+        button: true,
+        child: Container(
+          padding: const EdgeInsets.all(16),
+          color: context.vineColors.card,
+          child: Row(
+            spacing: 12,
+            children: [
+              Container(
+                width: 48,
+                height: 48,
+                decoration: const BoxDecoration(
+                  color: VineTheme.vineGreen,
+                  shape: BoxShape.circle,
+                ),
+                child: DivineIcon(
+                  icon: DivineIconName.sealCheck,
+                  color: context.vineColors.background,
+                ),
+              ),
+              Expanded(
+                child: Text(
+                  context.l10n.notificationsPendingBadges(pendingCount),
+                  style: VineTheme.bodyMediumFont(
+                    color: context.vineColors.primaryText,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
   }
 }
 

--- a/mobile/lib/notifications/view/pending_badge_awards_view.dart
+++ b/mobile/lib/notifications/view/pending_badge_awards_view.dart
@@ -1,0 +1,96 @@
+// ABOUTME: Inbox Badges tab — badge awards waiting on an accept or reject,
+// ABOUTME: rendered from the BadgesCubit provided above the tab bar.
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:openvine/blocs/badges/badges_cubit.dart';
+import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/widgets/badges/awarded_badge_card.dart';
+import 'package:openvine/widgets/branded_loading_indicator.dart';
+
+/// Badge awards addressed to the user that still need a decision.
+///
+/// Accepted and dismissed awards drop out, so the tab is a queue rather than
+/// a second badge dashboard — Settings → Badges stays the place to review
+/// everything, including what was already accepted.
+class PendingBadgeAwardsView extends StatelessWidget {
+  /// Creates the pending badge awards view.
+  const PendingBadgeAwardsView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<BadgesCubit, BadgesState>(
+      builder: (context, state) {
+        return RefreshIndicator(
+          color: VineTheme.onPrimary,
+          backgroundColor: VineTheme.vineGreen,
+          onRefresh: () => context.read<BadgesCubit>().refresh(),
+          child: Center(
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 640),
+              child: _PendingBody(state: state),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _PendingBody extends StatelessWidget {
+  const _PendingBody({required this.state});
+
+  final BadgesState state;
+
+  @override
+  Widget build(BuildContext context) {
+    if (state.status == BadgesStatus.loading) {
+      return const Center(child: BrandedLoadingIndicator());
+    }
+
+    final pending = state.pending;
+    if (pending.isEmpty) {
+      return _EmptyPending(
+        message: state.status == BadgesStatus.error
+            ? context.l10n.badgesLoadError
+            : context.l10n.notificationsBadgesEmpty,
+      );
+    }
+
+    return ListView.builder(
+      padding: const EdgeInsets.fromLTRB(16, 16, 16, 32),
+      itemCount: pending.length,
+      itemBuilder: (context, index) => Padding(
+        padding: const EdgeInsets.only(bottom: 12),
+        child: AwardedBadgeCard(
+          award: pending[index],
+          actionStatus: state.actionStatus,
+        ),
+      ),
+    );
+  }
+}
+
+/// Empty and error copy, kept scrollable so pull to refresh still works.
+class _EmptyPending extends StatelessWidget {
+  const _EmptyPending({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView(
+      padding: const EdgeInsets.fromLTRB(16, 48, 16, 32),
+      children: [
+        Text(
+          message,
+          textAlign: TextAlign.center,
+          style: VineTheme.bodyMediumFont(
+            color: context.vineColors.onSurfaceVariant,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/mobile/lib/screens/badges/badges_screen.dart
+++ b/mobile/lib/screens/badges/badges_screen.dart
@@ -6,7 +6,6 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 import 'package:openvine/blocs/badges/badges_cubit.dart';
 import 'package:openvine/extensions/safe_pop_extension.dart';
 import 'package:openvine/l10n/l10n.dart';
@@ -16,9 +15,8 @@ import 'package:openvine/router/route_paths.dart';
 import 'package:openvine/screens/badges/badge_detail_screen.dart';
 import 'package:openvine/screens/badges/badge_editor_screen.dart';
 import 'package:openvine/screens/badges/widgets/badge_recipient_row.dart';
-import 'package:openvine/screens/badges/widgets/badge_status_pill.dart';
+import 'package:openvine/widgets/badges/awarded_badge_card.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
-import 'package:openvine/widgets/vine_cached_image.dart';
 
 /// Shows the current user's Nostr badge dashboard.
 class BadgesScreen extends ConsumerWidget {
@@ -76,10 +74,8 @@ class _BadgesViewState extends State<BadgesView>
             icon: SvgIconSource(DivineIconName.plus.assetPath),
             tooltip: l10n.badgesCreateAction,
             semanticLabel: l10n.badgesCreateAction,
-            onPressed: () => _openAndRefresh(
-              context,
-              BadgeEditorScreen.createPath,
-            ),
+            onPressed: () =>
+                openBadgeAndRefresh(context, BadgeEditorScreen.createPath),
           ),
         ],
       ),
@@ -90,30 +86,13 @@ class _BadgesViewState extends State<BadgesView>
           Expanded(
             child: TabBarView(
               controller: tabController,
-              children: const [
-                _AwardedTab(),
-                _CreatedTab(),
-                _IssuedTab(),
-              ],
+              children: const [_AwardedTab(), _CreatedTab(), _IssuedTab()],
             ),
           ),
         ],
       ),
     );
   }
-}
-
-/// Pushes [path] and reloads the dashboard once it pops.
-///
-/// Creating, editing, and awarding all change what the tabs show, and none of
-/// them run through this screen's cubit.
-Future<void> _openAndRefresh(BuildContext context, String path) async {
-  final cubit = context.read<BadgesCubit>();
-  await context.push<bool>(path);
-  // The dashboard can be gone by the time the pushed route pops — a deep link
-  // out of it, or a sign-out rebuilding the repository.
-  if (cubit.isClosed) return;
-  await cubit.refresh();
 }
 
 class _BadgesTabBar extends StatelessWidget {
@@ -244,7 +223,7 @@ class _AwardedTab extends StatelessWidget {
         else
           _BadgeCardList(
             itemCount: state.awarded.length,
-            itemBuilder: (context, index) => _AwardedBadgeCard(
+            itemBuilder: (context, index) => AwardedBadgeCard(
               award: state.awarded[index],
               actionStatus: state.actionStatus,
             ),
@@ -339,139 +318,6 @@ class _IssuedTabState extends State<_IssuedTab> {
   }
 }
 
-class _AwardedBadgeCard extends StatelessWidget {
-  const _AwardedBadgeCard({required this.award, required this.actionStatus});
-
-  final BadgeAwardViewData award;
-  final BadgeActionStatus actionStatus;
-
-  bool get _isBusy =>
-      actionStatus == BadgeActionStatus.accepting ||
-      actionStatus == BadgeActionStatus.removing ||
-      actionStatus == BadgeActionStatus.hiding;
-
-  @override
-  Widget build(BuildContext context) {
-    final cubit = context.read<BadgesCubit>();
-    final coordinate = BadgeCoordinate.parse(award.definitionCoordinate);
-    return _Panel(
-      onTap: coordinate == null
-          ? null
-          : () => _openAndRefresh(
-              context,
-              BadgeDetailScreen.pathFor(coordinate),
-            ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              _BadgeMedallion(imageUrl: award.imageUrl),
-              const SizedBox(width: 14),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      award.displayName,
-                      style: VineTheme.titleMediumFont(
-                        color: context.vineColors.onSurface,
-                      ),
-                    ),
-                    const SizedBox(height: 6),
-                    BadgeStatusPill(
-                      label: award.isAccepted
-                          ? context.l10n.badgesStatusAccepted
-                          : context.l10n.badgesStatusNotAccepted,
-                      accepted: award.isAccepted,
-                    ),
-                  ],
-                ),
-              ),
-            ],
-          ),
-          if (award.definition?.description?.isNotEmpty ?? false) ...[
-            const SizedBox(height: 12),
-            Text(
-              award.definition!.description!,
-              style: VineTheme.bodySmallFont(
-                color: context.vineColors.onSurfaceVariant,
-              ),
-            ),
-          ],
-          const SizedBox(height: 14),
-          Wrap(
-            spacing: 10,
-            runSpacing: 8,
-            children: [
-              if (award.isAccepted)
-                DivineButton(
-                  label: context.l10n.badgesActionRemove,
-                  type: DivineButtonType.secondary,
-                  size: DivineButtonSize.small,
-                  isLoading: actionStatus == BadgeActionStatus.removing,
-                  onPressed: _isBusy ? null : () => cubit.removeAward(award),
-                )
-              else
-                DivineButton(
-                  label: context.l10n.badgesActionAccept,
-                  size: DivineButtonSize.small,
-                  isLoading: actionStatus == BadgeActionStatus.accepting,
-                  onPressed: _isBusy ? null : () => cubit.acceptAward(award),
-                ),
-              // Offered for an accepted badge too: removing only unpins it,
-              // and the badge stays on the list until it is also rejected.
-              // Withheld when the award event is gone — the badge is pinned
-              // and unremovable anywhere else, so dismissing the row is the
-              // one thing that must not be possible.
-              if (award.hasAwardEvent)
-                DivineButton(
-                  label: context.l10n.badgesActionReject,
-                  type: DivineButtonType.secondary,
-                  size: DivineButtonSize.small,
-                  isLoading: actionStatus == BadgeActionStatus.hiding,
-                  onPressed: _isBusy
-                      ? null
-                      : () => _hideWithUndo(context, award),
-                ),
-            ],
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-/// Rejects [award] and offers an immediate way back.
-///
-/// Without an undo a mistap would strand the badge in the hidden section,
-/// so the way back is offered right where the mistake happened.
-Future<void> _hideWithUndo(
-  BuildContext context,
-  BadgeAwardViewData award,
-) async {
-  final cubit = context.read<BadgesCubit>();
-  final messenger = ScaffoldMessenger.of(context);
-  final l10n = context.l10n;
-
-  await cubit.rejectAward(award);
-  if (cubit.state.actionStatus != BadgeActionStatus.completed) return;
-
-  messenger.showSnackBar(
-    DivineSnackbarContainer.snackBar(
-      l10n.badgesHiddenSnackbar,
-      actionLabel: l10n.badgesHiddenSnackbarUndo,
-      // The snackbar lives on the app-level messenger, so it outlives this
-      // route; undoing into a closed cubit would throw.
-      onActionPressed: () {
-        if (!cubit.isClosed) cubit.unhideAward(award);
-      },
-    ),
-  );
-}
-
-/// Collapsible list of awards the user dismissed, each restorable.
 class _HiddenAwardsSection extends StatefulWidget {
   const _HiddenAwardsSection({required this.hidden});
 
@@ -534,11 +380,11 @@ class _HiddenAwardCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return _Panel(
+    return BadgePanel(
       child: Row(
         spacing: 14,
         children: [
-          _BadgeMedallion(imageUrl: award.imageUrl),
+          BadgeMedallion(imageUrl: award.imageUrl),
           Expanded(
             child: Text(
               award.displayName,
@@ -567,17 +413,17 @@ class _CreatedBadgeCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final coordinate = BadgeCoordinate.parse(badge.coordinate);
-    return _Panel(
+    return BadgePanel(
       onTap: coordinate == null
           ? null
-          : () => _openAndRefresh(
+          : () => openBadgeAndRefresh(
               context,
               BadgeDetailScreen.pathFor(coordinate),
             ),
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          _BadgeMedallion(imageUrl: badge.imageUrl),
+          BadgeMedallion(imageUrl: badge.imageUrl),
           const SizedBox(width: 14),
           Expanded(
             child: Column(
@@ -621,7 +467,7 @@ class _IssuedBadgeCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final hasRecipients = badge.recipients.isNotEmpty;
-    return _Panel(
+    return BadgePanel(
       onTap: hasRecipients ? onToggle : null,
       child: Row(
         spacing: 12,
@@ -662,31 +508,6 @@ class _IssuedBadgeCard extends StatelessWidget {
   }
 }
 
-class _Panel extends StatelessWidget {
-  const _Panel({required this.child, this.onTap});
-
-  final Widget child;
-  final VoidCallback? onTap;
-
-  @override
-  Widget build(BuildContext context) {
-    final panel = DecoratedBox(
-      decoration: BoxDecoration(
-        color: context.vineColors.card,
-        borderRadius: BorderRadius.circular(8),
-        border: Border.all(color: context.vineColors.outlineMuted),
-      ),
-      child: Padding(padding: const EdgeInsets.all(16), child: child),
-    );
-    if (onTap == null) return panel;
-
-    return Semantics(
-      button: true,
-      child: GestureDetector(onTap: onTap, child: panel),
-    );
-  }
-}
-
 class _EmptyPanel extends StatelessWidget {
   const _EmptyPanel({required this.title, required this.subtitle});
 
@@ -695,7 +516,7 @@ class _EmptyPanel extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return _Panel(
+    return BadgePanel(
       child: Column(
         spacing: 6,
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -740,7 +561,7 @@ class _BadgesLoadingCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const _Panel(
+    return const BadgePanel(
       child: Center(child: BrandedLoadingIndicator(size: 60)),
     );
   }
@@ -751,7 +572,7 @@ class _BadgesErrorCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return _Panel(
+    return BadgePanel(
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -768,41 +589,6 @@ class _BadgesErrorCard extends StatelessWidget {
           ),
         ],
       ),
-    );
-  }
-}
-
-class _BadgeMedallion extends StatelessWidget {
-  const _BadgeMedallion({required this.imageUrl});
-
-  final String? imageUrl;
-
-  @override
-  Widget build(BuildContext context) {
-    final fallback = DecoratedBox(
-      decoration: const BoxDecoration(
-        shape: BoxShape.circle,
-        color: VineTheme.vineGreen,
-      ),
-      child: Center(
-        child: Text(
-          'B',
-          style: VineTheme.titleMediumFont(color: VineTheme.primaryDarkGreen),
-        ),
-      ),
-    );
-
-    return SizedBox(
-      width: 56,
-      height: 56,
-      child: imageUrl == null || imageUrl!.isEmpty
-          ? fallback
-          : ClipOval(
-              child: VineCachedImage(
-                imageUrl: imageUrl!,
-                errorWidget: (_, _, _) => fallback,
-              ),
-            ),
     );
   }
 }

--- a/mobile/lib/widgets/badges/awarded_badge_card.dart
+++ b/mobile/lib/widgets/badges/awarded_badge_card.dart
@@ -1,0 +1,238 @@
+// ABOUTME: Shared card for one NIP-58 badge award addressed to the user,
+// ABOUTME: with its accept / remove / reject actions and panel chrome.
+
+import 'package:badge_repository/badge_repository.dart';
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
+import 'package:openvine/blocs/badges/badges_cubit.dart';
+import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/screens/badges/badge_detail_screen.dart';
+import 'package:openvine/screens/badges/widgets/badge_status_pill.dart';
+import 'package:openvine/widgets/vine_cached_image.dart';
+
+/// Pushes [path] and reloads the badge dashboard once it pops.
+///
+/// Creating, editing, and awarding all change what the badge surfaces show,
+/// and none of them run through the cubit that renders them.
+Future<void> openBadgeAndRefresh(BuildContext context, String path) async {
+  final cubit = context.read<BadgesCubit>();
+  await context.push<bool>(path);
+  // The surface can be gone by the time the pushed route pops — a deep link
+  // out of it, or a sign-out rebuilding the repository.
+  if (cubit.isClosed) return;
+  await cubit.refresh();
+}
+
+/// Rejects [award] and offers an immediate way back.
+///
+/// Without an undo a mistap would strand the badge in the hidden section,
+/// so the way back is offered right where the mistake happened.
+Future<void> hideAwardWithUndo(
+  BuildContext context,
+  BadgeAwardViewData award,
+) async {
+  final cubit = context.read<BadgesCubit>();
+  final messenger = ScaffoldMessenger.of(context);
+  final l10n = context.l10n;
+
+  await cubit.rejectAward(award);
+  if (cubit.state.actionStatus != BadgeActionStatus.completed) return;
+
+  messenger.showSnackBar(
+    DivineSnackbarContainer.snackBar(
+      l10n.badgesHiddenSnackbar,
+      actionLabel: l10n.badgesHiddenSnackbarUndo,
+      // The snackbar lives on the app-level messenger, so it outlives this
+      // route; undoing into a closed cubit would throw.
+      onActionPressed: () {
+        if (!cubit.isClosed) cubit.unhideAward(award);
+      },
+    ),
+  );
+}
+
+/// Bordered surface shared by every badge card.
+class BadgePanel extends StatelessWidget {
+  /// Creates a badge panel wrapping [child].
+  const BadgePanel({required this.child, this.onTap, super.key});
+
+  /// Panel content.
+  final Widget child;
+
+  /// Invoked when the panel is tapped, when it is tappable.
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final panel = DecoratedBox(
+      decoration: BoxDecoration(
+        color: context.vineColors.card,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: context.vineColors.outlineMuted),
+      ),
+      child: Padding(padding: const EdgeInsets.all(16), child: child),
+    );
+    if (onTap == null) return panel;
+
+    return Semantics(
+      button: true,
+      child: GestureDetector(onTap: onTap, child: panel),
+    );
+  }
+}
+
+/// Circular badge artwork, falling back to a lettermark.
+class BadgeMedallion extends StatelessWidget {
+  /// Creates a medallion for [imageUrl].
+  const BadgeMedallion({required this.imageUrl, super.key});
+
+  /// Badge image, or null when the definition carries none.
+  final String? imageUrl;
+
+  @override
+  Widget build(BuildContext context) {
+    final fallback = DecoratedBox(
+      decoration: const BoxDecoration(
+        shape: BoxShape.circle,
+        color: VineTheme.vineGreen,
+      ),
+      child: Center(
+        child: Text(
+          'B',
+          style: VineTheme.titleMediumFont(color: VineTheme.primaryDarkGreen),
+        ),
+      ),
+    );
+
+    return SizedBox(
+      width: 56,
+      height: 56,
+      child: imageUrl == null || imageUrl!.isEmpty
+          ? fallback
+          : ClipOval(
+              child: VineCachedImage(
+                imageUrl: imageUrl!,
+                errorWidget: (_, _, _) => fallback,
+              ),
+            ),
+    );
+  }
+}
+
+/// One badge award addressed to the current user.
+///
+/// Rendered both on the badge dashboard and in the inbox's Badges tab, so
+/// accepting or rejecting an award works the same wherever it is surfaced.
+class AwardedBadgeCard extends StatelessWidget {
+  /// Creates a card for [award].
+  const AwardedBadgeCard({
+    required this.award,
+    required this.actionStatus,
+    super.key,
+  });
+
+  /// The award being offered to the user.
+  final BadgeAwardViewData award;
+
+  /// Current mutation status, used to disable actions while one publishes.
+  final BadgeActionStatus actionStatus;
+
+  bool get _isBusy =>
+      actionStatus == BadgeActionStatus.accepting ||
+      actionStatus == BadgeActionStatus.removing ||
+      actionStatus == BadgeActionStatus.hiding;
+
+  @override
+  Widget build(BuildContext context) {
+    final cubit = context.read<BadgesCubit>();
+    final coordinate = BadgeCoordinate.parse(award.definitionCoordinate);
+    return BadgePanel(
+      onTap: coordinate == null
+          ? null
+          : () => openBadgeAndRefresh(
+              context,
+              BadgeDetailScreen.pathFor(coordinate),
+            ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              BadgeMedallion(imageUrl: award.imageUrl),
+              const SizedBox(width: 14),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      award.displayName,
+                      style: VineTheme.titleMediumFont(
+                        color: context.vineColors.onSurface,
+                      ),
+                    ),
+                    const SizedBox(height: 6),
+                    BadgeStatusPill(
+                      label: award.isAccepted
+                          ? context.l10n.badgesStatusAccepted
+                          : context.l10n.badgesStatusNotAccepted,
+                      accepted: award.isAccepted,
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          if (award.definition?.description?.isNotEmpty ?? false) ...[
+            const SizedBox(height: 12),
+            Text(
+              award.definition!.description!,
+              style: VineTheme.bodySmallFont(
+                color: context.vineColors.onSurfaceVariant,
+              ),
+            ),
+          ],
+          const SizedBox(height: 14),
+          Wrap(
+            spacing: 10,
+            runSpacing: 8,
+            children: [
+              if (award.isAccepted)
+                DivineButton(
+                  label: context.l10n.badgesActionRemove,
+                  type: DivineButtonType.secondary,
+                  size: DivineButtonSize.small,
+                  isLoading: actionStatus == BadgeActionStatus.removing,
+                  onPressed: _isBusy ? null : () => cubit.removeAward(award),
+                )
+              else
+                DivineButton(
+                  label: context.l10n.badgesActionAccept,
+                  size: DivineButtonSize.small,
+                  isLoading: actionStatus == BadgeActionStatus.accepting,
+                  onPressed: _isBusy ? null : () => cubit.acceptAward(award),
+                ),
+              // Offered for an accepted badge too: removing only unpins it,
+              // and the badge stays on the list until it is also rejected.
+              // Withheld when the award event is gone — the badge is pinned
+              // and unremovable anywhere else, so dismissing the row is the
+              // one thing that must not be possible.
+              if (award.hasAwardEvent)
+                DivineButton(
+                  label: context.l10n.badgesActionReject,
+                  type: DivineButtonType.secondary,
+                  size: DivineButtonSize.small,
+                  isLoading: actionStatus == BadgeActionStatus.hiding,
+                  onPressed: _isBusy
+                      ? null
+                      : () => hideAwardWithUndo(context, award),
+                ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/test/helpers/badge_fixtures.dart
+++ b/mobile/test/helpers/badge_fixtures.dart
@@ -1,0 +1,69 @@
+// ABOUTME: Shared NIP-58 badge award fixtures for widget tests that render
+// ABOUTME: the badge dashboard or the inbox Badges tab.
+
+import 'package:badge_repository/badge_repository.dart';
+import 'package:nostr_sdk/nostr_sdk.dart';
+
+/// Builds a badge award addressed to the test user.
+///
+/// [isAccepted] drives whether the award still counts as pending.
+BadgeAwardViewData badgeAwardFixture({
+  required bool isAccepted,
+  String name = 'Diviner of the Day',
+  String dTag = 'daily-diviner',
+  int seed = 1,
+}) {
+  final issuerPubkey = badgeTestPubkey(2);
+  final definitionCoordinate = '30009:$issuerPubkey:$dTag';
+  return BadgeAwardViewData(
+    award: Nip58BadgeAward(
+      event: _event(
+        id: badgeTestEventId(seed),
+        pubkey: issuerPubkey,
+        kind: EventKind.badgeAward,
+        tags: [
+          ['a', definitionCoordinate],
+          ['p', badgeTestPubkey(1)],
+        ],
+      ),
+      definitionCoordinate: definitionCoordinate,
+      recipientPubkeys: [badgeTestPubkey(1)],
+    ),
+    definition: Nip58BadgeDefinition(
+      event: _event(
+        id: badgeTestEventId(seed + 100),
+        pubkey: issuerPubkey,
+        kind: EventKind.badgeDefinition,
+      ),
+      coordinate: definitionCoordinate,
+      dTag: dTag,
+      name: name,
+      description: 'Awarded for showing up with a good eye.',
+    ),
+    isAccepted: isAccepted,
+  );
+}
+
+/// Deterministic 64-character event id for [seed].
+String badgeTestEventId(int seed) => seed.toRadixString(16).padLeft(64, '0');
+
+/// Deterministic 64-character pubkey for [seed].
+String badgeTestPubkey(int seed) =>
+    (seed + 100).toRadixString(16).padLeft(64, '0');
+
+Event _event({
+  required String id,
+  required String pubkey,
+  int kind = 1,
+  List<List<String>> tags = const [],
+}) {
+  return Event.fromJson({
+    'id': id,
+    'pubkey': pubkey,
+    'created_at': 1000,
+    'kind': kind,
+    'tags': tags,
+    'content': '',
+    'sig': '',
+  });
+}

--- a/mobile/test/helpers/badge_fixtures.dart
+++ b/mobile/test/helpers/badge_fixtures.dart
@@ -11,13 +11,14 @@ BadgeAwardViewData badgeAwardFixture({
   required bool isAccepted,
   String name = 'Diviner of the Day',
   String dTag = 'daily-diviner',
+  String description = 'Awarded for showing up with a good eye.',
   int seed = 1,
 }) {
   final issuerPubkey = badgeTestPubkey(2);
   final definitionCoordinate = '30009:$issuerPubkey:$dTag';
   return BadgeAwardViewData(
     award: Nip58BadgeAward(
-      event: _event(
+      event: badgeTestEvent(
         id: badgeTestEventId(seed),
         pubkey: issuerPubkey,
         kind: EventKind.badgeAward,
@@ -30,7 +31,7 @@ BadgeAwardViewData badgeAwardFixture({
       recipientPubkeys: [badgeTestPubkey(1)],
     ),
     definition: Nip58BadgeDefinition(
-      event: _event(
+      event: badgeTestEvent(
         id: badgeTestEventId(seed + 100),
         pubkey: issuerPubkey,
         kind: EventKind.badgeDefinition,
@@ -38,7 +39,7 @@ BadgeAwardViewData badgeAwardFixture({
       coordinate: definitionCoordinate,
       dTag: dTag,
       name: name,
-      description: 'Awarded for showing up with a good eye.',
+      description: description,
     ),
     isAccepted: isAccepted,
   );
@@ -51,19 +52,22 @@ String badgeTestEventId(int seed) => seed.toRadixString(16).padLeft(64, '0');
 String badgeTestPubkey(int seed) =>
     (seed + 100).toRadixString(16).padLeft(64, '0');
 
-Event _event({
+/// Builds a deterministic synthetic Nostr event for badge fixtures.
+Event badgeTestEvent({
   required String id,
   required String pubkey,
   int kind = 1,
   List<List<String>> tags = const [],
+  int createdAt = 1000,
+  String content = '',
 }) {
   return Event.fromJson({
     'id': id,
     'pubkey': pubkey,
-    'created_at': 1000,
+    'created_at': createdAt,
     'kind': kind,
     'tags': tags,
-    'content': '',
+    'content': content,
     'sig': '',
   });
 }

--- a/mobile/test/l10n/arb_consistency_test.dart
+++ b/mobile/test/l10n/arb_consistency_test.dart
@@ -487,7 +487,6 @@ const _knownUntranslatedDebt = <String>{
   // Inbox Badges tab and its All-tab banner. Translation deferred to the next
   // l10n pass.
   'notificationsTabBadges',
-  'notificationsTabBadgesWithCount',
   'notificationsPendingBadges',
   'notificationsBadgesEmpty',
   // #7892: safety-filter explanation on the video detail screen. Translation

--- a/mobile/test/l10n/arb_consistency_test.dart
+++ b/mobile/test/l10n/arb_consistency_test.dart
@@ -484,6 +484,12 @@ void main() {
 // Keys intentionally allowed to fall back to English until a translation pass.
 // Keep this list small and reviewable so new translation gaps stay visible.
 const _knownUntranslatedDebt = <String>{
+  // Inbox Badges tab and its All-tab banner. Translation deferred to the next
+  // l10n pass.
+  'notificationsTabBadges',
+  'notificationsTabBadgesWithCount',
+  'notificationsPendingBadges',
+  'notificationsBadgesEmpty',
   // #7892: safety-filter explanation on the video detail screen. Translation
   // deferred to the next l10n pass.
   'videoDetailHiddenBySettingsTitle',

--- a/mobile/test/notifications/view/inbox_notifications_page_test.dart
+++ b/mobile/test/notifications/view/inbox_notifications_page_test.dart
@@ -4,6 +4,7 @@
 
 // ignore_for_file: prefer_const_constructors
 
+import 'package:badge_repository/badge_repository.dart';
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -18,7 +19,10 @@ import 'package:openvine/blocs/invite_status/invite_status_cubit.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/notifications/providers/notification_repository_provider.dart';
 import 'package:openvine/notifications/view/inbox_notifications_page.dart';
+import 'package:openvine/notifications/view/pending_badge_awards_view.dart';
+import 'package:openvine/providers/app_providers.dart';
 
+import '../../helpers/badge_fixtures.dart';
 import '../../helpers/invite_availability_harness.dart';
 import '../../helpers/test_provider_overrides.dart';
 
@@ -26,6 +30,8 @@ class _MockNotificationRepository extends Mock
     implements NotificationRepository {}
 
 class _MockFollowRepository extends Mock implements FollowRepository {}
+
+class _MockBadgeRepository extends Mock implements BadgeRepository {}
 
 class _MockInviteStatusCubit extends MockCubit<InviteStatusState>
     implements InviteStatusCubit {}
@@ -35,11 +41,21 @@ void main() {
     late _MockNotificationRepository mockNotificationRepo;
     late _MockFollowRepository mockFollowRepo;
     late _MockInviteStatusCubit mockInviteCubit;
+    late _MockBadgeRepository mockBadgeRepo;
 
     setUp(() {
       mockNotificationRepo = _MockNotificationRepository();
       mockFollowRepo = _MockFollowRepository();
       mockInviteCubit = _MockInviteStatusCubit();
+      mockBadgeRepo = _MockBadgeRepository();
+
+      when(mockBadgeRepo.loadDashboard).thenAnswer(
+        (_) async => const BadgeDashboardData(
+          awarded: [],
+          issued: [],
+          created: [],
+        ),
+      );
 
       when(
         () => mockNotificationRepo.watchSnapshot(filter: any(named: 'filter')),
@@ -64,6 +80,7 @@ void main() {
           notificationRepositoryProvider.overrideWithValue(
             mockNotificationRepo,
           ),
+          badgeRepositoryProvider.overrideWithValue(mockBadgeRepo),
         ],
         home: Builder(
           builder: (context) => MediaQuery(
@@ -250,6 +267,74 @@ void main() {
 
         expect(controller(tester).index, equals(2));
         expect(controller(tester).animationDuration, equals(Duration.zero));
+      });
+    });
+
+    group('badges tab', () {
+      final l10n = lookupAppLocalizations(const Locale('en'));
+
+      void stubPending(int count) {
+        when(mockBadgeRepo.loadDashboard).thenAnswer(
+          (_) async => BadgeDashboardData(
+            awarded: [
+              for (var i = 0; i < count; i++)
+                badgeAwardFixture(
+                  isAccepted: false,
+                  name: 'Badge $i',
+                  dTag: 'badge-$i',
+                  seed: i + 1,
+                ),
+            ],
+            issued: const [],
+            created: const [],
+          ),
+        );
+      }
+
+      testWidgets('counts awards waiting on a decision in the tab label', (
+        tester,
+      ) async {
+        stubPending(2);
+
+        await tester.pumpWidget(buildSubject());
+        await tester.pumpAndSettle();
+
+        expect(
+          find.text(l10n.notificationsTabBadgesWithCount(2)),
+          findsOneWidget,
+        );
+      });
+
+      testWidgets('drops the count once nothing is waiting', (tester) async {
+        await tester.pumpWidget(buildSubject());
+        await tester.pumpAndSettle();
+
+        expect(find.text(l10n.notificationsTabBadges), findsOneWidget);
+        expect(find.textContaining('Badges ('), findsNothing);
+      });
+
+      testWidgets('banner on the All tab opens the badges queue', (
+        tester,
+      ) async {
+        stubPending(1);
+
+        await tester.pumpWidget(buildSubject());
+        await tester.pumpAndSettle();
+
+        expect(find.text(l10n.notificationsPendingBadges(1)), findsOneWidget);
+
+        await tester.tap(find.text(l10n.notificationsPendingBadges(1)));
+        await tester.pumpAndSettle();
+
+        expect(find.byType(PendingBadgeAwardsView), findsOneWidget);
+        expect(find.text('Badge 0'), findsOneWidget);
+      });
+
+      testWidgets('hides the banner when no award is waiting', (tester) async {
+        await tester.pumpWidget(buildSubject());
+        await tester.pumpAndSettle();
+
+        expect(find.text(l10n.notificationsPendingBadges(1)), findsNothing);
       });
     });
 

--- a/mobile/test/notifications/view/inbox_notifications_page_test.dart
+++ b/mobile/test/notifications/view/inbox_notifications_page_test.dart
@@ -50,11 +50,8 @@ void main() {
       mockBadgeRepo = _MockBadgeRepository();
 
       when(mockBadgeRepo.loadDashboard).thenAnswer(
-        (_) async => const BadgeDashboardData(
-          awarded: [],
-          issued: [],
-          created: [],
-        ),
+        (_) async =>
+            const BadgeDashboardData(awarded: [], issued: [], created: []),
       );
 
       when(
@@ -299,10 +296,7 @@ void main() {
         await tester.pumpWidget(buildSubject());
         await tester.pumpAndSettle();
 
-        expect(
-          find.text(l10n.notificationsTabBadges(2)),
-          findsOneWidget,
-        );
+        expect(find.text(l10n.notificationsTabBadges(2)), findsOneWidget);
       });
 
       testWidgets('drops the count once nothing is waiting', (tester) async {
@@ -335,6 +329,22 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(find.text(l10n.notificationsPendingBadges(1)), findsNothing);
+      });
+
+      testWidgets('reloads pending awards when the inbox becomes visible', (
+        tester,
+      ) async {
+        await tester.pumpWidget(buildSubject(isVisible: false));
+        await tester.pumpAndSettle();
+
+        verify(mockBadgeRepo.loadDashboard).called(1);
+        clearInteractions(mockBadgeRepo);
+
+        await tester.pumpWidget(buildSubject());
+        await tester.pump();
+        await tester.pump();
+
+        verify(mockBadgeRepo.loadDashboard).called(1);
       });
     });
 

--- a/mobile/test/notifications/view/inbox_notifications_page_test.dart
+++ b/mobile/test/notifications/view/inbox_notifications_page_test.dart
@@ -300,7 +300,7 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(
-          find.text(l10n.notificationsTabBadgesWithCount(2)),
+          find.text(l10n.notificationsTabBadges(2)),
           findsOneWidget,
         );
       });
@@ -309,7 +309,7 @@ void main() {
         await tester.pumpWidget(buildSubject());
         await tester.pumpAndSettle();
 
-        expect(find.text(l10n.notificationsTabBadges), findsOneWidget);
+        expect(find.text(l10n.notificationsTabBadges(0)), findsOneWidget);
         expect(find.textContaining('Badges ('), findsNothing);
       });
 

--- a/mobile/test/notifications/view/notification_pages_repo_swap_test.dart
+++ b/mobile/test/notifications/view/notification_pages_repo_swap_test.dart
@@ -12,6 +12,7 @@
 // the BlocProvider element persists across rebuilds and the bloc stays
 // bound to stale repositories.
 
+import 'package:badge_repository/badge_repository.dart';
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -35,6 +36,19 @@ class _MockNotificationRepository extends Mock
     implements NotificationRepository {}
 
 class _MockFollowRepository extends Mock implements FollowRepository {}
+
+/// The inbox page reads the badge repository for its Badges tab. These tests
+/// only swap the notification and follow repositories, so a stub keeps the
+/// real one — and its SharedPreferences dependency — out of the scope.
+class _MockBadgeRepository extends Mock implements BadgeRepository {}
+
+_MockBadgeRepository _stubBadgeRepository() {
+  final repository = _MockBadgeRepository();
+  when(repository.loadDashboard).thenAnswer(
+    (_) async => const BadgeDashboardData(awarded: [], issued: [], created: []),
+  );
+  return repository;
+}
 
 class _MockInviteStatusCubit extends MockCubit<InviteStatusState>
     implements InviteStatusCubit {}
@@ -76,6 +90,7 @@ void main() {
       (tester) async {
         final container = ProviderContainer(
           overrides: [
+            badgeRepositoryProvider.overrideWithValue(_stubBadgeRepository()),
             notificationRepositoryProvider.overrideWith((ref) {
               final v = ref.watch(_notificationRepoSwap);
               return v == 0 ? mockNotificationRepoA : mockNotificationRepoB;
@@ -114,6 +129,7 @@ void main() {
       (tester) async {
         final container = ProviderContainer(
           overrides: [
+            badgeRepositoryProvider.overrideWithValue(_stubBadgeRepository()),
             notificationRepositoryProvider.overrideWithValue(
               mockNotificationRepoA,
             ),
@@ -155,6 +171,7 @@ void main() {
         final rebuildKey = GlobalKey<_RebuildHostState>();
         final container = ProviderContainer(
           overrides: [
+            badgeRepositoryProvider.overrideWithValue(_stubBadgeRepository()),
             notificationRepositoryProvider.overrideWithValue(
               mockNotificationRepoA,
             ),
@@ -196,6 +213,7 @@ void main() {
       (tester) async {
         final container = ProviderContainer(
           overrides: [
+            badgeRepositoryProvider.overrideWithValue(_stubBadgeRepository()),
             notificationRepositoryProvider.overrideWith((ref) {
               final v = ref.watch(_notificationRepoSwap);
               return v == 0 ? mockNotificationRepoA : mockNotificationRepoB;
@@ -297,6 +315,7 @@ void main() {
       (tester) async {
         final container = ProviderContainer(
           overrides: [
+            badgeRepositoryProvider.overrideWithValue(_stubBadgeRepository()),
             notificationRepositoryProvider.overrideWith((ref) {
               final v = ref.watch(_notificationRepoSwap);
               return v == 0 ? mockNotificationRepoA : mockNotificationRepoB;
@@ -341,6 +360,7 @@ void main() {
       (tester) async {
         final container = ProviderContainer(
           overrides: [
+            badgeRepositoryProvider.overrideWithValue(_stubBadgeRepository()),
             notificationRepositoryProvider.overrideWithValue(
               mockNotificationRepoA,
             ),
@@ -388,6 +408,7 @@ void main() {
         final rebuildKey = GlobalKey<_RebuildHostState>();
         final container = ProviderContainer(
           overrides: [
+            badgeRepositoryProvider.overrideWithValue(_stubBadgeRepository()),
             notificationRepositoryProvider.overrideWithValue(
               mockNotificationRepoA,
             ),
@@ -426,6 +447,7 @@ void main() {
       (tester) async {
         final container = ProviderContainer(
           overrides: [
+            badgeRepositoryProvider.overrideWithValue(_stubBadgeRepository()),
             notificationRepositoryProvider.overrideWith((ref) {
               final v = ref.watch(_notificationRepoSwap);
               return v == 0 ? mockNotificationRepoA : mockNotificationRepoB;

--- a/mobile/test/notifications/view/notification_pages_repo_swap_test.dart
+++ b/mobile/test/notifications/view/notification_pages_repo_swap_test.dart
@@ -32,6 +32,8 @@ import 'package:openvine/notifications/view/notifications_page.dart';
 import 'package:openvine/notifications/view/notifications_view.dart';
 import 'package:openvine/providers/app_providers.dart';
 
+import '../../helpers/badge_fixtures.dart';
+
 class _MockNotificationRepository extends Mock
     implements NotificationRepository {}
 
@@ -42,10 +44,22 @@ class _MockFollowRepository extends Mock implements FollowRepository {}
 /// real one — and its SharedPreferences dependency — out of the scope.
 class _MockBadgeRepository extends Mock implements BadgeRepository {}
 
-_MockBadgeRepository _stubBadgeRepository() {
+_MockBadgeRepository _stubBadgeRepository({int pendingAwards = 0}) {
   final repository = _MockBadgeRepository();
   when(repository.loadDashboard).thenAnswer(
-    (_) async => const BadgeDashboardData(awarded: [], issued: [], created: []),
+    (_) async => BadgeDashboardData(
+      awarded: [
+        for (var i = 0; i < pendingAwards; i++)
+          badgeAwardFixture(
+            isAccepted: false,
+            name: 'Badge $i',
+            dTag: 'badge-$i',
+            seed: i + 1,
+          ),
+      ],
+      issued: const [],
+      created: const [],
+    ),
   );
   return repository;
 }
@@ -55,6 +69,7 @@ class _MockInviteStatusCubit extends MockCubit<InviteStatusState>
 
 final _notificationRepoSwap = StateProvider<int>((ref) => 0);
 final _followRepoSwap = StateProvider<int>((ref) => 0);
+final _badgeRepoSwap = StateProvider<int>((ref) => 0);
 
 void main() {
   group('NotificationsPage — BlocProvider repo-swap', () {
@@ -491,6 +506,53 @@ void main() {
         expect(blocAfter.state.unreadCount, equals(0));
         expect(blocAfter.state.hasMore, isTrue);
         expect(blocAfter.state.refreshError, isFalse);
+      },
+    );
+
+    testWidgets(
+      'rebinds the badges cubit when badgeRepositoryProvider rebuilds with a '
+      'new repository instance',
+      (tester) async {
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        final badgeRepoA = _stubBadgeRepository();
+        final badgeRepoB = _stubBadgeRepository(pendingAwards: 2);
+
+        final container = ProviderContainer(
+          overrides: [
+            badgeRepositoryProvider.overrideWith((ref) {
+              final v = ref.watch(_badgeRepoSwap);
+              return v == 0 ? badgeRepoA : badgeRepoB;
+            }),
+            notificationRepositoryProvider.overrideWithValue(
+              mockNotificationRepoA,
+            ),
+            followRepositoryProvider.overrideWithValue(mockFollowRepoA),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        await tester.pumpWidget(
+          _TestApp(
+            container: container,
+            home: BlocProvider<InviteStatusCubit>.value(
+              value: mockInviteCubit,
+              child: const Scaffold(body: InboxNotificationsPage()),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text(l10n.notificationsTabBadges(0)), findsOneWidget);
+
+        final feedBefore = _notificationFeedBlocFor(tester);
+
+        container.read(_badgeRepoSwap.notifier).state = 1;
+        await tester.pumpAndSettle();
+
+        // The new repository's awards drive the label...
+        expect(find.text(l10n.notificationsTabBadges(2)), findsOneWidget);
+        // ...and the notification feeds are untouched by a badge-only swap.
+        expect(_notificationFeedBlocFor(tester), same(feedBefore));
       },
     );
   });

--- a/mobile/test/notifications/view/pending_badge_awards_view_test.dart
+++ b/mobile/test/notifications/view/pending_badge_awards_view_test.dart
@@ -1,0 +1,107 @@
+// ABOUTME: Widget tests for the inbox Badges tab — only undecided awards are
+// ABOUTME: listed, and accepting one publishes through the repository.
+
+import 'package:badge_repository/badge_repository.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/blocs/badges/badges_cubit.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/notifications/view/pending_badge_awards_view.dart';
+
+import '../../helpers/badge_fixtures.dart';
+import '../../helpers/test_provider_overrides.dart';
+
+class _MockBadgeRepository extends Mock implements BadgeRepository {}
+
+void main() {
+  group(PendingBadgeAwardsView, () {
+    late _MockBadgeRepository repository;
+    final l10n = lookupAppLocalizations(const Locale('en'));
+
+    setUpAll(() {
+      registerFallbackValue(badgeAwardFixture(isAccepted: false));
+    });
+
+    setUp(() {
+      repository = _MockBadgeRepository();
+    });
+
+    void stubDashboard(List<BadgeAwardViewData> awarded) {
+      when(repository.loadDashboard).thenAnswer(
+        (_) async => BadgeDashboardData(
+          awarded: awarded,
+          issued: const [],
+          created: const [],
+        ),
+      );
+    }
+
+    Widget buildSubject() {
+      return testMaterialApp(
+        home: BlocProvider(
+          create: (_) => BadgesCubit(repository: repository)..load(),
+          child: const PendingBadgeAwardsView(),
+        ),
+      );
+    }
+
+    testWidgets('lists an award that is waiting on a decision', (tester) async {
+      stubDashboard([badgeAwardFixture(isAccepted: false)]);
+
+      await tester.pumpWidget(buildSubject());
+      await tester.pumpAndSettle();
+
+      expect(find.text('Diviner of the Day'), findsOneWidget);
+      expect(find.text(l10n.badgesActionAccept), findsOneWidget);
+    });
+
+    testWidgets('leaves an already-accepted award out of the queue', (
+      tester,
+    ) async {
+      stubDashboard([
+        badgeAwardFixture(isAccepted: true, name: 'Already Mine'),
+        badgeAwardFixture(
+          isAccepted: false,
+          name: 'Still Waiting',
+          dTag: 'weekly-diviner',
+          seed: 2,
+        ),
+      ]);
+
+      await tester.pumpWidget(buildSubject());
+      await tester.pumpAndSettle();
+
+      expect(find.text('Still Waiting'), findsOneWidget);
+      expect(find.text('Already Mine'), findsNothing);
+    });
+
+    testWidgets('shows the empty message when nothing is waiting', (
+      tester,
+    ) async {
+      stubDashboard([badgeAwardFixture(isAccepted: true)]);
+
+      await tester.pumpWidget(buildSubject());
+      await tester.pumpAndSettle();
+
+      expect(find.text(l10n.notificationsBadgesEmpty), findsOneWidget);
+    });
+
+    testWidgets('accepting an award publishes through the repository', (
+      tester,
+    ) async {
+      final award = badgeAwardFixture(isAccepted: false);
+      stubDashboard([award]);
+      when(() => repository.acceptAward(any())).thenAnswer((_) async {});
+
+      await tester.pumpWidget(buildSubject());
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text(l10n.badgesActionAccept));
+      await tester.pumpAndSettle();
+
+      verify(() => repository.acceptAward(award)).called(1);
+    });
+  });
+}

--- a/mobile/test/screens/badges/badges_screen_test.dart
+++ b/mobile/test/screens/badges/badges_screen_test.dart
@@ -9,6 +9,7 @@ import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/screens/badges/badges_screen.dart';
 import 'package:openvine/widgets/user_profile_tile.dart';
 
+import '../../helpers/badge_fixtures.dart';
 import '../../helpers/test_provider_overrides.dart';
 
 class _MockBadgeRepository extends Mock implements BadgeRepository {}
@@ -22,12 +23,12 @@ void main() {
     final l10n = lookupAppLocalizations(const Locale('en'));
 
     setUpAll(() {
-      registerFallbackValue(_awardViewData(isAccepted: false));
+      registerFallbackValue(badgeAwardFixture(isAccepted: false));
     });
 
     setUp(() {
       repository = _MockBadgeRepository();
-      awardedBadge = _awardViewData(isAccepted: false);
+      awardedBadge = badgeAwardFixture(isAccepted: false);
       issuedBadge = _issuedViewData(recipientAccepted: true);
       createdBadge = _createdViewData();
     });
@@ -73,7 +74,7 @@ void main() {
       // which parses back as '' rather than null.
       when(repository.loadDashboard).thenAnswer(
         (_) async => BadgeDashboardData(
-          awarded: [_awardViewData(isAccepted: false, description: '')],
+          awarded: [badgeAwardFixture(isAccepted: false, description: '')],
           issued: [issuedBadge],
           created: [createdBadge],
         ),
@@ -137,7 +138,7 @@ void main() {
       expect(find.text(l10n.badgesRecipientAcceptedStatus), findsOneWidget);
       // Recipients render as people, not as raw keys.
       expect(find.byType(UserProfileTile), findsOneWidget);
-      expect(find.text(_pubkey(3)), findsNothing);
+      expect(find.text(badgeTestPubkey(3)), findsNothing);
     });
 
     testWidgets('created tab shows its own empty state', (tester) async {
@@ -190,7 +191,7 @@ void main() {
     testWidgets('an accepted award can be rejected, not only removed', (
       tester,
     ) async {
-      final accepted = _awardViewData(isAccepted: true);
+      final accepted = badgeAwardFixture(isAccepted: true);
       when(repository.loadDashboard).thenAnswer(
         (_) async => BadgeDashboardData(
           awarded: [accepted],
@@ -300,47 +301,12 @@ void main() {
   });
 }
 
-BadgeAwardViewData _awardViewData({
-  required bool isAccepted,
-  String description = 'Awarded for showing up with a good eye.',
-}) {
-  final issuerPubkey = _pubkey(2);
-  final definitionCoordinate = '30009:$issuerPubkey:daily-diviner';
-  return BadgeAwardViewData(
-    award: Nip58BadgeAward(
-      event: _event(
-        id: _eventId(1),
-        pubkey: issuerPubkey,
-        kind: EventKind.badgeAward,
-        tags: [
-          ['a', definitionCoordinate],
-          ['p', _pubkey(1)],
-        ],
-      ),
-      definitionCoordinate: definitionCoordinate,
-      recipientPubkeys: [_pubkey(1)],
-    ),
-    definition: Nip58BadgeDefinition(
-      event: _event(
-        id: _eventId(2),
-        pubkey: issuerPubkey,
-        kind: EventKind.badgeDefinition,
-      ),
-      coordinate: definitionCoordinate,
-      dTag: 'daily-diviner',
-      name: 'Diviner of the Day',
-      description: description,
-    ),
-    isAccepted: isAccepted,
-  );
-}
-
 CreatedBadgeViewData _createdViewData() {
-  final issuerPubkey = _pubkey(1);
+  final issuerPubkey = badgeTestPubkey(1);
   return CreatedBadgeViewData(
     definition: Nip58BadgeDefinition(
-      event: _event(
-        id: _eventId(5),
+      event: badgeTestEvent(
+        id: badgeTestEventId(5),
         pubkey: issuerPubkey,
         kind: EventKind.badgeDefinition,
       ),
@@ -354,15 +320,15 @@ CreatedBadgeViewData _createdViewData() {
 }
 
 IssuedBadgeViewData _issuedViewData({required bool recipientAccepted}) {
-  final issuerPubkey = _pubkey(1);
-  final recipientPubkey = _pubkey(3);
+  final issuerPubkey = badgeTestPubkey(1);
+  final recipientPubkey = badgeTestPubkey(3);
   final definitionCoordinate = '30009:$issuerPubkey:weekly-diviner';
   return IssuedBadgeViewData(
     coordinate: definitionCoordinate,
     latestAwardedAt: 1000,
     definition: Nip58BadgeDefinition(
-      event: _event(
-        id: _eventId(4),
+      event: badgeTestEvent(
+        id: badgeTestEventId(4),
         pubkey: issuerPubkey,
         kind: EventKind.badgeDefinition,
       ),
@@ -378,26 +344,3 @@ IssuedBadgeViewData _issuedViewData({required bool recipientAccepted}) {
     ],
   );
 }
-
-Event _event({
-  required String id,
-  required String pubkey,
-  int kind = 1,
-  List<List<String>> tags = const [],
-  int createdAt = 1000,
-  String content = '',
-}) {
-  return Event.fromJson({
-    'id': id,
-    'pubkey': pubkey,
-    'created_at': createdAt,
-    'kind': kind,
-    'tags': tags,
-    'content': content,
-    'sig': '',
-  });
-}
-
-String _eventId(int seed) => seed.toRadixString(16).padLeft(64, '0');
-
-String _pubkey(int seed) => (seed + 100).toRadixString(16).padLeft(64, '0');


### PR DESCRIPTION
Closes #8047

## What

Adds a **Badges** tab to the inbox listing NIP-58 badge awards that are waiting on a decision, with the pending count on the tab label and a banner on the All tab pointing at the queue.

## Why

Badge awards already work end to end — accept, reject, hide, issued-status — but the only way to find one was Settings → Badges. Nothing anywhere told you an award had arrived, so an award nobody thought to go looking for was never answered. "I don't know which ones have been offered to me" is the whole bug.

The tab is a **queue, not a dashboard**: accepted and dismissed awards drop out, so what's listed is exactly what needs you. Settings → Badges stays the place to review everything, including what you already accepted.

## How

- `BadgesState.pending` — awarded minus accepted (`hidden` is already a separate list).
- `PendingBadgeAwardsView` renders the queue; empty and error states stay scrollable so pull-to-refresh keeps working.
- The accept / remove / reject card moves out of `BadgesScreen` into `lib/widgets/badges/awarded_badge_card.dart`, so both surfaces publish through one path rather than duplicating the kind-30008 republish.
- One `BadgesCubit` feeds the tab label, the banner, and the tab body, owned by the inbox scaffold `State`. A keyed `BlocProvider` above the tabs was the obvious wiring and is wrong: it tears down every notification feed and resets the open tab whenever the badge repository identity flips. `didUpdateWidget` reassigns in `setState`, closes the previous cubit after the frame, and refreshes pending awards when the kept-alive inbox becomes visible again.
- The invites and pending-badges banners share one tappable card shell, so both expose the same chevron and visible ink response.

## Not in this PR: badge rows in the All feed

Badge awards can't appear as ordinary rows in All from the client side. Funnelcake's notification inbox materializes only kinds `(1, 3, 6, 7, 16, 1111, 9735, 30023)` plus curated-list sources — `database/migrations/000138_notifications_inbox_read_model.up.sql:24` and `000188_curated_list_notification_sources.up.sql:21`. Kind 8 is not ingested, so there is nothing for the client to render. That needs a divine-funnelcake migration first; the banner covers the same need in the meantime, and interleaved rows become a small follow-up here once the server emits the type.

## Testing

- `pending_badge_awards_view_test` — pending awards listed, accepted ones excluded, empty state, accept publishes through the repository.
- `inbox_notifications_page_test` — count on the tab label, no count at zero, banner opens the queue, banner hidden when nothing waits, and returning to the inbox refreshes the badge queue.
- `notification_pages_repo_swap_test` — swapping `badgeRepositoryProvider` rebinds the cubit **and** leaves the `NotificationFeedBloc` instances alone.
- Full `test/notifications`, `test/screens/badges`, `test/blocs/badges`, `test/l10n`: 470 passing. `flutter analyze lib test integration_test` clean. Design-system, orphaned-ARB, and l10n-delegate ratchets all green.

New ARB keys are in `_knownUntranslatedDebt` pending the next translation pass.