### PR TITLE
fix(video): preserve provenance when editing REST-loaded videos

### DIFF
--- a/mobile/lib/blocs/profile_feed/profile_feed_enrichment_merge.dart
+++ b/mobile/lib/blocs/profile_feed/profile_feed_enrichment_merge.dart
@@ -47,86 +47,78 @@ VideoEvent _mergeEnrichmentIntoCurrent(
   VideoEvent current,
   VideoEvent enriched,
 ) {
-  return current.copyWith(
+  final enrichedIsNewer =
+      current.eventCreatedAt != null &&
+      enriched.eventCreatedAt != null &&
+      enriched.eventCreatedAt! > current.eventCreatedAt!;
+  final primary = enrichedIsNewer ? enriched : current;
+  final secondary = enrichedIsNewer ? current : enriched;
+
+  return primary.copyWith(
     publishedAt:
-        (current.publishedAt != null && current.publishedAt!.isNotEmpty)
-        ? current.publishedAt
-        : enriched.publishedAt,
-    rawTags: mergeVideoRawTagsPrimaryWins(current.rawTags, enriched.rawTags),
-    contentWarningLabels: current.contentWarningLabels.isNotEmpty
-        ? current.contentWarningLabels
-        : enriched.contentWarningLabels,
-    title: current.title ?? enriched.title,
-    videoUrl: current.videoUrl ?? enriched.videoUrl,
-    thumbnailUrl: current.thumbnailUrl ?? enriched.thumbnailUrl,
-    duration: current.duration ?? enriched.duration,
-    dimensions: current.dimensions ?? enriched.dimensions,
-    mimeType: current.mimeType ?? enriched.mimeType,
-    sha256: current.sha256 ?? enriched.sha256,
-    fileSize: current.fileSize ?? enriched.fileSize,
-    hashtags: current.hashtags.isNotEmpty
-        ? current.hashtags
-        : enriched.hashtags,
-    vineId: current.vineId ?? enriched.vineId,
-    addressableDTag: current.addressableDTag ?? enriched.addressableDTag,
-    group: current.group ?? enriched.group,
-    altText: current.altText ?? enriched.altText,
-    blurhash: current.blurhash ?? enriched.blurhash,
+        (primary.publishedAt != null && primary.publishedAt!.isNotEmpty)
+        ? primary.publishedAt
+        : secondary.publishedAt,
+    rawTags: mergeVideoRawTagsPrimaryWins(primary.rawTags, secondary.rawTags),
+    contentWarningLabels: primary.contentWarningLabels.isNotEmpty
+        ? primary.contentWarningLabels
+        : secondary.contentWarningLabels,
+    title: primary.title ?? secondary.title,
+    videoUrl: primary.videoUrl ?? secondary.videoUrl,
+    thumbnailUrl: primary.thumbnailUrl ?? secondary.thumbnailUrl,
+    duration: primary.duration ?? secondary.duration,
+    dimensions: primary.dimensions ?? secondary.dimensions,
+    mimeType: primary.mimeType ?? secondary.mimeType,
+    sha256: primary.sha256 ?? secondary.sha256,
+    fileSize: primary.fileSize ?? secondary.fileSize,
+    hashtags: primary.hashtags.isNotEmpty
+        ? primary.hashtags
+        : secondary.hashtags,
+    vineId: primary.vineId ?? secondary.vineId,
+    addressableDTag: primary.addressableDTag ?? secondary.addressableDTag,
+    group: primary.group ?? secondary.group,
+    altText: primary.altText ?? secondary.altText,
+    blurhash: primary.blurhash ?? secondary.blurhash,
     originalLoops: mergeNullableEngagementMax(
-      current.originalLoops,
-      enriched.originalLoops,
+      primary.originalLoops,
+      secondary.originalLoops,
     ),
     originalLikes: mergeNullableEngagementMax(
-      current.originalLikes,
-      enriched.originalLikes,
+      primary.originalLikes,
+      secondary.originalLikes,
     ),
     originalComments: mergeNullableEngagementMax(
-      current.originalComments,
-      enriched.originalComments,
+      primary.originalComments,
+      secondary.originalComments,
     ),
     originalReposts: mergeNullableEngagementMax(
-      current.originalReposts,
-      enriched.originalReposts,
+      primary.originalReposts,
+      secondary.originalReposts,
     ),
-    audioEventId: current.audioEventId ?? enriched.audioEventId,
-    audioEventRelay: current.audioEventRelay ?? enriched.audioEventRelay,
-    collaboratorPubkeys: current.collaboratorPubkeys.isNotEmpty
-        ? current.collaboratorPubkeys
-        : enriched.collaboratorPubkeys,
-    inspiredByVideo: current.inspiredByVideo ?? enriched.inspiredByVideo,
-    textTrackRef: current.textTrackRef ?? enriched.textTrackRef,
-    textTrackRefs: current.textTrackRefs.isNotEmpty
-        ? current.textTrackRefs
-        : enriched.textTrackRefs,
+    audioEventId: primary.audioEventId ?? secondary.audioEventId,
+    audioEventRelay: primary.audioEventRelay ?? secondary.audioEventRelay,
+    collaboratorPubkeys: primary.collaboratorPubkeys.isNotEmpty
+        ? primary.collaboratorPubkeys
+        : secondary.collaboratorPubkeys,
+    inspiredByVideo: primary.inspiredByVideo ?? secondary.inspiredByVideo,
+    textTrackRef: primary.textTrackRef ?? secondary.textTrackRef,
+    textTrackRefs: primary.textTrackRefs.isNotEmpty
+        ? primary.textTrackRefs
+        : secondary.textTrackRefs,
     textTrackContent:
-        current.textTrackContent ??
-        ((current.textTrackRef?.isNotEmpty ?? false) ||
-                current.textTrackRefs.isNotEmpty
+        primary.textTrackContent ??
+        ((primary.textTrackRef?.isNotEmpty ?? false) ||
+                primary.textTrackRefs.isNotEmpty
             ? null
-            : enriched.textTrackContent),
-    nostrEventTags: _newerNostrEventTags(current, enriched),
-    authorName: current.authorName ?? enriched.authorName,
-    authorAvatar: current.authorAvatar ?? enriched.authorAvatar,
+            : secondary.textTrackContent),
+    nostrEventTags: primary.nostrEventTags.isNotEmpty
+        ? primary.nostrEventTags
+        : secondary.nostrEventTags,
+    authorName: primary.authorName ?? secondary.authorName,
+    authorAvatar: primary.authorAvatar ?? secondary.authorAvatar,
     nostrLikeCount: mergeNullableEngagementMax(
-      current.nostrLikeCount,
-      enriched.nostrLikeCount,
+      primary.nostrLikeCount,
+      secondary.nostrLikeCount,
     ),
   );
-}
-
-List<List<String>> _newerNostrEventTags(
-  VideoEvent current,
-  VideoEvent enriched,
-) {
-  final currentCreatedAt = current.eventCreatedAt;
-  final enrichedCreatedAt = enriched.eventCreatedAt;
-  if (enriched.nostrEventTags.isNotEmpty &&
-      currentCreatedAt != null &&
-      enrichedCreatedAt != null &&
-      enrichedCreatedAt > currentCreatedAt) {
-    return enriched.nostrEventTags;
-  }
-  return current.nostrEventTags.isNotEmpty
-      ? current.nostrEventTags
-      : enriched.nostrEventTags;
 }

--- a/mobile/lib/blocs/profile_feed/profile_feed_enrichment_merge.dart
+++ b/mobile/lib/blocs/profile_feed/profile_feed_enrichment_merge.dart
@@ -1,13 +1,12 @@
 // ABOUTME: Nostr-enrichment merge policy for the profile/author feed (#3705).
-// ABOUTME: Fills missing fields on the current videos from their enriched Nostr
-// ABOUTME: copies without clobbering relay updates that arrived meanwhile.
+// ABOUTME: Merges REST and Nostr metadata without clobbering newer relay events.
 
 import 'package:models/models.dart';
 import 'package:videos_repository/videos_repository.dart';
 
-/// Merges enriched copies over [sourceKeys] against [current], filling missing
-/// fields without clobbering relay updates that arrived during the enrichment
-/// window (#3705).
+/// Merges enriched copies over [sourceKeys] against [current]. A strictly newer
+/// raw Nostr event supplies edit-sensitive metadata; otherwise current state
+/// remains primary so relay updates that arrived during enrichment survive.
 ///
 /// [removeTombstones] drops NIP-09-deleted events; it is injected because
 /// tombstone state is a session-scoped, `VideoEventService`-owned concern that
@@ -63,6 +62,13 @@ VideoEvent _mergeEnrichmentIntoCurrent(
     contentWarningLabels: primary.contentWarningLabels.isNotEmpty
         ? primary.contentWarningLabels
         : secondary.contentWarningLabels,
+    categories: primary.categories.isNotEmpty
+        ? primary.categories
+        : secondary.categories,
+    moderationLabels: primary.moderationLabels.isNotEmpty
+        ? primary.moderationLabels
+        : secondary.moderationLabels,
+    proofSummary: primary.proofSummary ?? secondary.proofSummary,
     title: primary.title ?? secondary.title,
     videoUrl: primary.videoUrl ?? secondary.videoUrl,
     thumbnailUrl: primary.thumbnailUrl ?? secondary.thumbnailUrl,
@@ -119,6 +125,14 @@ VideoEvent _mergeEnrichmentIntoCurrent(
     nostrLikeCount: mergeNullableEngagementMax(
       primary.nostrLikeCount,
       secondary.nostrLikeCount,
+    ),
+    nostrCommentCount: mergeNullableEngagementMax(
+      primary.nostrCommentCount,
+      secondary.nostrCommentCount,
+    ),
+    nostrRepostCount: mergeNullableEngagementMax(
+      primary.nostrRepostCount,
+      secondary.nostrRepostCount,
     ),
   );
 }

--- a/mobile/lib/blocs/profile_feed/profile_feed_enrichment_merge.dart
+++ b/mobile/lib/blocs/profile_feed/profile_feed_enrichment_merge.dart
@@ -104,9 +104,7 @@ VideoEvent _mergeEnrichmentIntoCurrent(
                 current.textTrackRefs.isNotEmpty
             ? null
             : enriched.textTrackContent),
-    nostrEventTags: current.nostrEventTags.isNotEmpty
-        ? current.nostrEventTags
-        : enriched.nostrEventTags,
+    nostrEventTags: _newerNostrEventTags(current, enriched),
     authorName: current.authorName ?? enriched.authorName,
     authorAvatar: current.authorAvatar ?? enriched.authorAvatar,
     nostrLikeCount: mergeNullableEngagementMax(
@@ -114,4 +112,21 @@ VideoEvent _mergeEnrichmentIntoCurrent(
       enriched.nostrLikeCount,
     ),
   );
+}
+
+List<List<String>> _newerNostrEventTags(
+  VideoEvent current,
+  VideoEvent enriched,
+) {
+  final currentCreatedAt = current.eventCreatedAt;
+  final enrichedCreatedAt = enriched.eventCreatedAt;
+  if (enriched.nostrEventTags.isNotEmpty &&
+      currentCreatedAt != null &&
+      enrichedCreatedAt != null &&
+      enrichedCreatedAt > currentCreatedAt) {
+    return enriched.nostrEventTags;
+  }
+  return current.nostrEventTags.isNotEmpty
+      ? current.nostrEventTags
+      : enriched.nostrEventTags;
 }

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -2462,6 +2462,10 @@
       }
     }
   },
+  "shareMenuOriginalVideoUnavailable": "Couldn't load the original video. Try again in a moment.",
+  "@shareMenuOriginalVideoUnavailable": {
+    "description": "Snackbar shown when an edit is stopped because the original video's complete metadata could not be loaded safely."
+  },
   "shareMenuDeleteVideoQuestion": "Delete Video?",
   "shareMenuVideoDeletionRequested": "Video deleted",
   "authSessionExpired": "Your session has expired. Please sign in again.",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -6713,6 +6713,12 @@ abstract class AppLocalizations {
   /// **'Failed to update video: {error}'**
   String shareMenuFailedToUpdateVideo(String error);
 
+  /// Snackbar shown when an edit is stopped because the original video's complete metadata could not be loaded safely.
+  ///
+  /// In en, this message translates to:
+  /// **'Couldn\'t load the original video. Try again in a moment.'**
+  String get shareMenuOriginalVideoUnavailable;
+
   /// No description provided for @shareMenuDeleteVideoQuestion.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -3842,6 +3842,10 @@ class AppLocalizationsAm extends AppLocalizations {
   }
 
   @override
+  String get shareMenuOriginalVideoUnavailable =>
+      'Couldn\'t load the original video. Try again in a moment.';
+
+  @override
   String get shareMenuDeleteVideoQuestion => 'ቪዲዮ ይሰረዝ?';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -3895,6 +3895,10 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
+  String get shareMenuOriginalVideoUnavailable =>
+      'Couldn\'t load the original video. Try again in a moment.';
+
+  @override
   String get shareMenuDeleteVideoQuestion => 'حذف الفيديو؟';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -3978,6 +3978,10 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
+  String get shareMenuOriginalVideoUnavailable =>
+      'Couldn\'t load the original video. Try again in a moment.';
+
+  @override
   String get shareMenuDeleteVideoQuestion => 'Да изтрием видеото?';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -3978,6 +3978,10 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String get shareMenuOriginalVideoUnavailable =>
+      'Couldn\'t load the original video. Try again in a moment.';
+
+  @override
   String get shareMenuDeleteVideoQuestion => 'Video löschen?';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -4009,6 +4009,10 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get shareMenuOriginalVideoUnavailable =>
+      'Couldn\'t load the original video. Try again in a moment.';
+
+  @override
   String get shareMenuDeleteVideoQuestion => 'Delete Video?';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -3971,6 +3971,10 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String get shareMenuOriginalVideoUnavailable =>
+      'Couldn\'t load the original video. Try again in a moment.';
+
+  @override
   String get shareMenuDeleteVideoQuestion => '¿Eliminar video?';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -3953,6 +3953,10 @@ class AppLocalizationsFil extends AppLocalizations {
   }
 
   @override
+  String get shareMenuOriginalVideoUnavailable =>
+      'Couldn\'t load the original video. Try again in a moment.';
+
+  @override
   String get shareMenuDeleteVideoQuestion => 'Burahin ang Video?';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -3989,6 +3989,10 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String get shareMenuOriginalVideoUnavailable =>
+      'Couldn\'t load the original video. Try again in a moment.';
+
+  @override
   String get shareMenuDeleteVideoQuestion => 'Supprimer la vidéo ?';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -3859,6 +3859,10 @@ class AppLocalizationsId extends AppLocalizations {
   }
 
   @override
+  String get shareMenuOriginalVideoUnavailable =>
+      'Couldn\'t load the original video. Try again in a moment.';
+
+  @override
   String get shareMenuDeleteVideoQuestion => 'Hapus Video?';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -3974,6 +3974,10 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String get shareMenuOriginalVideoUnavailable =>
+      'Couldn\'t load the original video. Try again in a moment.';
+
+  @override
   String get shareMenuDeleteVideoQuestion => 'Eliminare il video?';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -3686,6 +3686,10 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
+  String get shareMenuOriginalVideoUnavailable =>
+      'Couldn\'t load the original video. Try again in a moment.';
+
+  @override
   String get shareMenuDeleteVideoQuestion => '動画を削除する?';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -3702,6 +3702,10 @@ class AppLocalizationsKo extends AppLocalizations {
   }
 
   @override
+  String get shareMenuOriginalVideoUnavailable =>
+      'Couldn\'t load the original video. Try again in a moment.';
+
+  @override
   String get shareMenuDeleteVideoQuestion => '영상을 삭제할까요?';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -3925,6 +3925,10 @@ class AppLocalizationsMs extends AppLocalizations {
   }
 
   @override
+  String get shareMenuOriginalVideoUnavailable =>
+      'Couldn\'t load the original video. Try again in a moment.';
+
+  @override
   String get shareMenuDeleteVideoQuestion => 'Padam Video?';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -3942,6 +3942,10 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
+  String get shareMenuOriginalVideoUnavailable =>
+      'Couldn\'t load the original video. Try again in a moment.';
+
+  @override
   String get shareMenuDeleteVideoQuestion => 'Video verwijderen?';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -4035,6 +4035,10 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
+  String get shareMenuOriginalVideoUnavailable =>
+      'Couldn\'t load the original video. Try again in a moment.';
+
+  @override
   String get shareMenuDeleteVideoQuestion => 'Usunąć film?';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -3955,6 +3955,10 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String get shareMenuOriginalVideoUnavailable =>
+      'Couldn\'t load the original video. Try again in a moment.';
+
+  @override
   String get shareMenuDeleteVideoQuestion => 'Excluir vídeo?';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -4051,6 +4051,10 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
+  String get shareMenuOriginalVideoUnavailable =>
+      'Couldn\'t load the original video. Try again in a moment.';
+
+  @override
   String get shareMenuDeleteVideoQuestion => 'Ștergi videoclipul?';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -3926,6 +3926,10 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
+  String get shareMenuOriginalVideoUnavailable =>
+      'Couldn\'t load the original video. Try again in a moment.';
+
+  @override
   String get shareMenuDeleteVideoQuestion => 'Ta bort video?';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -3868,6 +3868,10 @@ class AppLocalizationsTr extends AppLocalizations {
   }
 
   @override
+  String get shareMenuOriginalVideoUnavailable =>
+      'Couldn\'t load the original video. Try again in a moment.';
+
+  @override
   String get shareMenuDeleteVideoQuestion => 'Video Silinsin mi?';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -3930,6 +3930,10 @@ class AppLocalizationsUr extends AppLocalizations {
   }
 
   @override
+  String get shareMenuOriginalVideoUnavailable =>
+      'Couldn\'t load the original video. Try again in a moment.';
+
+  @override
   String get shareMenuDeleteVideoQuestion => 'ویڈیو حذف کریں؟';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -3900,6 +3900,10 @@ class AppLocalizationsVi extends AppLocalizations {
   }
 
   @override
+  String get shareMenuOriginalVideoUnavailable =>
+      'Couldn\'t load the original video. Try again in a moment.';
+
+  @override
   String get shareMenuDeleteVideoQuestion => 'Xóa video?';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -3681,6 +3681,10 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
+  String get shareMenuOriginalVideoUnavailable =>
+      'Couldn\'t load the original video. Try again in a moment.';
+
+  @override
   String get shareMenuDeleteVideoQuestion => '删除视频？';
 
   @override

--- a/mobile/lib/screens/subtitle_editor/subtitle_editor_screen.dart
+++ b/mobile/lib/screens/subtitle_editor/subtitle_editor_screen.dart
@@ -27,7 +27,8 @@ import 'package:openvine/widgets/subtitle_editor/subtitle_editor_stage.dart';
 ///
 /// The screen is keyed on [videoId] so it can be rebuilt from the route alone.
 /// A [prefetched] video may be passed as a fast path when navigating from a
-/// feed or metadata screen, but route state is not required for correctness.
+/// feed or metadata screen. It is used only when its complete raw tag array is
+/// available for the video replacement published after subtitle changes.
 class SubtitleEditorScreen extends ConsumerStatefulWidget {
   /// Creates the subtitle editor page for [videoId].
   const SubtitleEditorScreen({
@@ -49,7 +50,7 @@ class SubtitleEditorScreen extends ConsumerStatefulWidget {
   /// The event id of the video whose subtitles are being edited.
   final String videoId;
 
-  /// Optional prefetched video used to avoid an async resolve on push.
+  /// Optional complete prefetched video used to avoid an async resolve.
   final VideoEvent? prefetched;
 
   @override
@@ -71,7 +72,9 @@ class _SubtitleEditorScreenState extends ConsumerState<SubtitleEditorScreen>
   @override
   void initState() {
     super.initState();
-    if (widget.prefetched != null && widget.prefetched!.id == widget.videoId) {
+    if (widget.prefetched != null &&
+        widget.prefetched!.id == widget.videoId &&
+        widget.prefetched!.nostrEventTags.isNotEmpty) {
       _resolved = widget.prefetched;
     } else {
       _resolve();
@@ -83,6 +86,7 @@ class _SubtitleEditorScreenState extends ConsumerState<SubtitleEditorScreen>
     final video = await resolver.resolveById(
       widget.videoId,
       allowOwnContentBypass: true,
+      requireRawTags: true,
     );
     if (!mounted) return;
     setState(() {

--- a/mobile/lib/screens/video_metadata/video_metadata_edit_screen.dart
+++ b/mobile/lib/screens/video_metadata/video_metadata_edit_screen.dart
@@ -15,8 +15,9 @@ import 'package:openvine/widgets/video_metadata/modes/edit/video_metadata_edit_s
 ///
 /// The screen is keyed on a [videoId] so the route is deep-linkable. When a
 /// [prefetched] [VideoEvent] is available (e.g. from a feed-side tap), it is
-/// used immediately as a fast path; otherwise the screen resolves the id via
-/// the [videoEventResolverProvider] (in-memory → personal cache → relay).
+/// used immediately only when it carries the complete raw tag array required
+/// for safe republishing; otherwise the screen resolves the id via the
+/// [videoEventResolverProvider] (in-memory → personal cache → relay).
 ///
 /// Navigate to this screen with [pathFor]:
 /// ```dart
@@ -55,7 +56,9 @@ class _VideoMetadataEditScreenState
   @override
   void initState() {
     super.initState();
-    if (widget.prefetched != null && widget.prefetched!.id == widget.videoId) {
+    if (widget.prefetched != null &&
+        widget.prefetched!.id == widget.videoId &&
+        widget.prefetched!.nostrEventTags.isNotEmpty) {
       _resolved = widget.prefetched;
     } else {
       _resolve();
@@ -67,6 +70,7 @@ class _VideoMetadataEditScreenState
     final video = await resolver.resolveById(
       widget.videoId,
       allowOwnContentBypass: true,
+      requireRawTags: true,
     );
     if (!mounted) return;
     setState(() {

--- a/mobile/lib/services/video_event_resolver.dart
+++ b/mobile/lib/services/video_event_resolver.dart
@@ -49,13 +49,16 @@ class VideoEventResolver {
   Future<VideoEvent?> resolveById(
     String eventId, {
     bool allowOwnContentBypass = false,
+    bool requireRawTags = false,
     Duration timeout = const Duration(seconds: 10),
   }) async {
     if (eventId.isEmpty) return null;
 
     // 1) In-memory feeds.
     final cached = _videoEventService.getVideoEventById(eventId);
-    if (cached != null && _passesFilter(cached, allowOwnContentBypass)) {
+    if (cached != null &&
+        _hasRequiredRawTags(cached, requireRawTags) &&
+        _passesFilter(cached, allowOwnContentBypass)) {
       return cached;
     }
 
@@ -63,7 +66,9 @@ class VideoEventResolver {
     final cachedEvent = _personalEventCache.getEventById(eventId);
     if (cachedEvent != null) {
       final parsed = _tryParse(cachedEvent);
-      if (parsed != null && _passesFilter(parsed, allowOwnContentBypass)) {
+      if (parsed != null &&
+          _hasRequiredRawTags(parsed, requireRawTags) &&
+          _passesFilter(parsed, allowOwnContentBypass)) {
         return parsed;
       }
     }
@@ -71,7 +76,9 @@ class VideoEventResolver {
     // 3) Relay fetch.
     try {
       final fetched = await _fetchFromRelay(eventId, timeout);
-      if (fetched != null && _passesFilter(fetched, allowOwnContentBypass)) {
+      if (fetched != null &&
+          _hasRequiredRawTags(fetched, requireRawTags) &&
+          _passesFilter(fetched, allowOwnContentBypass)) {
         return fetched;
       }
     } catch (e, st) {
@@ -86,6 +93,9 @@ class VideoEventResolver {
 
     return null;
   }
+
+  bool _hasRequiredRawTags(VideoEvent video, bool requireRawTags) =>
+      !requireRawTags || video.nostrEventTags.isNotEmpty;
 
   bool _passesFilter(VideoEvent video, bool allowOwnContentBypass) {
     if (allowOwnContentBypass) {

--- a/mobile/lib/services/video_metadata_update_service.dart
+++ b/mobile/lib/services/video_metadata_update_service.dart
@@ -43,6 +43,12 @@ class VideoUpdateFailure extends VideoUpdateResult {
   final Object error;
 }
 
+/// The original event could not be loaded with the raw tags required for a
+/// lossless addressable-event replacement.
+class VideoUpdateOriginalUnavailable extends VideoUpdateResult {
+  const VideoUpdateOriginalUnavailable();
+}
+
 /// Tag names the metadata-edit flow always rebuilds from the editor state
 /// or re-derives from the original event's parsed fields.
 const _editRebuiltTagNames = {
@@ -62,8 +68,8 @@ const _editRebuiltTagNames = {
 /// Every other tag on the original event — audio-attribution `e` tags,
 /// engagement counts, expiration, client, relay hints, ProofMode/C2PA
 /// provenance, reply threading, subtitle text-tracks, … — is preserved
-/// unchanged so a metadata edit does not drop data it does not own,
-/// provided the raw tags are available (see [_sourceOriginalTags]).
+/// unchanged so a metadata edit does not drop data it does not own. Publishing
+/// is refused unless the raw tags are available (see [_sourceOriginalTags]).
 ///
 /// [isVideoReply] gates the inspired-by a-tag: the edit flow only rebuilds
 /// that tag for non-reply videos (see the rebuild block in `updateVideo`),
@@ -242,6 +248,11 @@ class VideoMetadataUpdateService {
         throw Exception('User not authenticated');
       }
 
+      final originalTags = _sourceOriginalTags(originalVideo);
+      if (originalTags.isEmpty) {
+        return const VideoUpdateOriginalUnavailable();
+      }
+
       // A pubkey promoted from a plain mention to a collaborator in this
       // edit changes role: drop its stale 'mention' p-tag so it is not
       // double-listed alongside the rebuilt 'collaborator' p-tag.
@@ -257,7 +268,7 @@ class VideoMetadataUpdateService {
       // Preserve every tag the edit flow does not own; the owned ones are
       // rebuilt from the editor state below.
       final isVideoReply = originalVideo.isVideoReply;
-      final preservedTags = _sourceOriginalTags(originalVideo)
+      final preservedTags = originalTags
           .where(
             (tag) =>
                 !_isEditRebuiltTag(tag, isVideoReply: isVideoReply) &&
@@ -458,7 +469,7 @@ class VideoMetadataUpdateService {
   /// rehydrated from a JSON cache that omits raw tags (the own-profile grid
   /// and cold-start feed do this). In that case, recover the raw event from
   /// the personal cache so preservation is not silently defeated; if it is
-  /// not cached, fall back to an empty list (the pre-existing behavior).
+  /// not cached, return an empty list so [updateVideo] can refuse to publish.
   List<List<String>> _sourceOriginalTags(VideoEvent video) {
     return sourceOriginalVideoTags(
       video: video,

--- a/mobile/lib/widgets/video_metadata/modes/edit/video_metadata_edit_bottom_bar.dart
+++ b/mobile/lib/widgets/video_metadata/modes/edit/video_metadata_edit_bottom_bar.dart
@@ -89,12 +89,25 @@ class _VideoMetadataEditBottomBarState
           context.pop();
           messenger.showSnackBar(snackBar);
         }
+      } else if (result is VideoUpdateOriginalUnavailable) {
+        _reportOriginalVideoUnavailable();
       } else if (result is VideoUpdateFailure) {
         _reportUpdateFailure(result.error);
       }
     } catch (e) {
       _reportUpdateFailure(e);
     }
+  }
+
+  void _reportOriginalVideoUnavailable() {
+    if (!mounted) return;
+    setState(() => _isUpdating = false);
+    ScaffoldMessenger.of(context).showSnackBar(
+      DivineSnackbarContainer.snackBar(
+        context.l10n.shareMenuOriginalVideoUnavailable,
+        error: true,
+      ),
+    );
   }
 
   void _reportUpdateFailure(Object error) {

--- a/mobile/packages/models/lib/src/video_stats.dart
+++ b/mobile/packages/models/lib/src/video_stats.dart
@@ -43,6 +43,7 @@ class VideoStats {
     this.embeddedLikes,
     this.embeddedComments,
     this.embeddedReposts,
+    this.eventTags = const [],
     this.rawTags = const {},
     this.contentWarningLabels = const [],
     this.textTrackRef,
@@ -225,15 +226,20 @@ class VideoStats {
     String? summaryFromTag;
     int? publishedAt;
     final rawTags = <String, String>{};
+    final eventTags = <List<String>>[];
     final contentWarningLabels = <String>[];
     final collaboratorPubkeys = <String>[];
 
     if (eventData['tags'] is List) {
       final tags = eventData['tags'] as List<dynamic>;
       for (final tag in tags) {
-        if (tag is List && tag.length >= 2) {
-          final tagName = tag[0].toString();
-          final tagValue = tag[1].toString();
+        if (tag is List) {
+          final normalizedTag = tag.map((value) => value.toString()).toList();
+          if (normalizedTag.isEmpty) continue;
+          eventTags.add(normalizedTag);
+          if (normalizedTag.length < 2) continue;
+          final tagName = normalizedTag[0];
+          final tagValue = normalizedTag[1];
 
           // Store every tag in rawTags for downstream consumers
           rawTags[tagName] = tagValue;
@@ -423,6 +429,7 @@ class VideoStats {
       embeddedLikes: embeddedLikes,
       embeddedComments: embeddedComments,
       embeddedReposts: embeddedReposts,
+      eventTags: eventTags,
       rawTags: rawTags,
       categories: categories,
       contentWarningLabels: contentWarningLabels,
@@ -521,6 +528,12 @@ class VideoStats {
   /// Empty until the API includes a `categories` field in video responses.
   final List<String> categories;
 
+  /// Complete ordered Nostr tag array from the REST event payload.
+  ///
+  /// Unlike [rawTags], this preserves repeated tag names and every component
+  /// of structured tags so an addressable event can be republished safely.
+  final List<List<String>> eventTags;
+
   /// All Nostr event tags as a flat map, preserving tags (like ProofMode,
   /// C2PA, verification) that don't have dedicated fields on this model.
   final Map<String, String> rawTags;
@@ -585,6 +598,11 @@ class VideoStats {
         embeddedComments ?? int.tryParse(rawTags['comments'] ?? '');
     final originalReposts =
         embeddedReposts ?? int.tryParse(rawTags['reposts'] ?? '');
+    final hashtags = eventTags
+        .where((tag) => tag.length >= 2 && tag.first == 't')
+        .map((tag) => tag[1])
+        .where((tag) => tag.isNotEmpty)
+        .toList();
     return VideoEvent(
       id: id,
       pubkey: pubkey,
@@ -614,6 +632,9 @@ class VideoStats {
       nostrCommentCount: comments,
       nostrRepostCount: reposts,
       originalLoops: loops,
+      hashtags: hashtags,
+      altText: rawTags['alt'],
+      duration: int.tryParse(rawTags['duration'] ?? ''),
       textTrackRef: textTrackRef,
       textTrackContent: textTrackContent,
       categories: categories,
@@ -621,6 +642,7 @@ class VideoStats {
       collaboratorPubkeys: collaboratorPubkeys,
       moderationLabels: moderationLabels,
       proofSummary: proofSummary,
+      nostrEventTags: eventTags,
       rawTags: {
         ...rawTags,
         // Note: Do NOT inject engagement `loops` here — rawTags['loops']

--- a/mobile/packages/models/lib/src/video_stats.dart
+++ b/mobile/packages/models/lib/src/video_stats.dart
@@ -625,6 +625,7 @@ class VideoStats {
       authorAvatar: authorAvatar,
       blurhash: blurhash,
       dimensions: dimensions,
+      fileSize: _fileSizeFromEventTags(eventTags),
       originalLikes: originalLikes,
       nostrLikeCount: reactions,
       originalComments: originalComments,
@@ -666,6 +667,21 @@ class VideoStats {
 
   @override
   String toString() => 'VideoStats(id: $id, title: $title)';
+}
+
+int? _fileSizeFromEventTags(List<List<String>> eventTags) {
+  int? fileSize;
+  for (final tag in eventTags) {
+    if (tag.isEmpty) continue;
+    if (tag.first == 'size' && tag.length >= 2) {
+      fileSize = int.tryParse(tag[1]);
+    } else if (tag.first == 'imeta') {
+      parseImetaTag(tag, (key, value) {
+        if (key == 'size') fileSize ??= int.tryParse(value);
+      });
+    }
+  }
+  return fileSize;
 }
 
 List<String> _parseModerationLabels(dynamic value) {

--- a/mobile/packages/models/test/src/video_stats_test.dart
+++ b/mobile/packages/models/test/src/video_stats_test.dart
@@ -177,6 +177,34 @@ void main() {
         );
       });
 
+      test('preserves file size from imeta for metadata editing', () {
+        final video = VideoStats.fromJson(const {
+          'event': {
+            'id': 'event-id',
+            'pubkey': 'event-pubkey',
+            'created_at': 1700000000,
+            'kind': 34236,
+            'content': 'Description',
+            'tags': [
+              ['d', 'video-1'],
+              [
+                'imeta',
+                'url https://example.com/video.mp4',
+                'size 480000',
+              ],
+            ],
+          },
+          'stats': {
+            'reactions': 0,
+            'comments': 0,
+            'reposts': 0,
+            'engagement_score': 0,
+          },
+        }).toVideoEvent();
+
+        expect(video.fileSize, 480000);
+      });
+
       test(
         'parses explicit addressable d tag fields from compact REST JSON',
         () {

--- a/mobile/packages/models/test/src/video_stats_test.dart
+++ b/mobile/packages/models/test/src/video_stats_test.dart
@@ -123,6 +123,60 @@ void main() {
         expect(stats.trendingScore, equals(0.75));
       });
 
+      test('preserves repeated and provenance tags for editing', () {
+        final stats = VideoStats.fromJson(const {
+          'event': {
+            'id': 'event-id',
+            'pubkey': 'event-pubkey',
+            'created_at': 1700000000,
+            'kind': 34236,
+            'content': 'Description',
+            'tags': [
+              ['d', 'video-1'],
+              ['imeta', 'url https://example.com/video.mp4'],
+              ['t', 'first'],
+              ['t', 'second'],
+              ['alt', 'Accessible description'],
+              ['duration', '6'],
+              ['proofmode', 'proof-manifest'],
+              ['c2pa_manifest_id', 'urn:c2pa:test'],
+              ['verification', 'verified_mobile'],
+              ['device_attestation', 'attestation'],
+            ],
+          },
+          'stats': {
+            'reactions': 0,
+            'comments': 0,
+            'reposts': 0,
+            'engagement_score': 0,
+          },
+        });
+
+        final video = stats.toVideoEvent();
+
+        expect(stats.eventTags, hasLength(10));
+        expect(video.nostrEventTags, equals(stats.eventTags));
+        expect(video.hashtags, equals(['first', 'second']));
+        expect(video.altText, equals('Accessible description'));
+        expect(video.duration, equals(6));
+        expect(
+          video.nostrEventTags,
+          contains(equals(['proofmode', 'proof-manifest'])),
+        );
+        expect(
+          video.nostrEventTags,
+          contains(equals(['c2pa_manifest_id', 'urn:c2pa:test'])),
+        );
+        expect(
+          video.nostrEventTags,
+          contains(equals(['verification', 'verified_mobile'])),
+        );
+        expect(
+          video.nostrEventTags,
+          contains(equals(['device_attestation', 'attestation'])),
+        );
+      });
+
       test(
         'parses explicit addressable d tag fields from compact REST JSON',
         () {

--- a/mobile/packages/models/test/src/video_stats_test.dart
+++ b/mobile/packages/models/test/src/video_stats_test.dart
@@ -177,7 +177,7 @@ void main() {
         );
       });
 
-      test('preserves file size from imeta for metadata editing', () {
+      test('standalone file size overrides imeta for metadata editing', () {
         final video = VideoStats.fromJson(const {
           'event': {
             'id': 'event-id',
@@ -192,6 +192,7 @@ void main() {
                 'url https://example.com/video.mp4',
                 'size 480000',
               ],
+              ['size', '640000'],
             ],
           },
           'stats': {
@@ -202,7 +203,7 @@ void main() {
           },
         }).toVideoEvent();
 
-        expect(video.fileSize, 480000);
+        expect(video.fileSize, 640000);
       });
 
       test(

--- a/mobile/test/blocs/profile_feed/profile_feed_enrichment_merge_test.dart
+++ b/mobile/test/blocs/profile_feed/profile_feed_enrichment_merge_test.dart
@@ -16,6 +16,8 @@ VideoEvent _video({
   String? textTrackContent,
   int? eventCreatedAt,
   List<List<String>> nostrEventTags = const [],
+  List<String> hashtags = const [],
+  String? title,
 }) {
   return VideoEvent(
     id: id,
@@ -30,6 +32,8 @@ VideoEvent _video({
     textTrackContent: textTrackContent,
     eventCreatedAt: eventCreatedAt,
     nostrEventTags: nostrEventTags,
+    hashtags: hashtags,
+    title: title,
   );
 }
 
@@ -135,6 +139,8 @@ void main() {
           ['d', 'video-d-tag'],
           ['t', 'stale'],
         ],
+        hashtags: const ['stale'],
+        title: 'Stale title',
       );
       final enriched = _video(
         id: 'nostr',
@@ -144,6 +150,8 @@ void main() {
           ['d', 'video-d-tag'],
           ['t', 'current'],
         ],
+        hashtags: const ['current'],
+        title: 'Current title',
       );
 
       final merged = mergeProfileFeedEnrichment(
@@ -154,6 +162,9 @@ void main() {
       );
 
       expect(merged.single.nostrEventTags, enriched.nostrEventTags);
+      expect(merged.single.hashtags, enriched.hashtags);
+      expect(merged.single.title, enriched.title);
+      expect(merged.single.id, enriched.id);
     });
 
     test('keeps raw tags from a newer current event', () {
@@ -184,6 +195,7 @@ void main() {
       );
 
       expect(merged.single.nostrEventTags, current.nostrEventTags);
+      expect(merged.single.id, current.id);
     });
   });
 }

--- a/mobile/test/blocs/profile_feed/profile_feed_enrichment_merge_test.dart
+++ b/mobile/test/blocs/profile_feed/profile_feed_enrichment_merge_test.dart
@@ -18,6 +18,12 @@ VideoEvent _video({
   List<List<String>> nostrEventTags = const [],
   List<String> hashtags = const [],
   String? title,
+  int? nostrLikeCount,
+  int? nostrCommentCount,
+  int? nostrRepostCount,
+  List<String> categories = const [],
+  List<String> moderationLabels = const [],
+  ProofVerificationSummary? proofSummary,
 }) {
   return VideoEvent(
     id: id,
@@ -34,6 +40,12 @@ VideoEvent _video({
     nostrEventTags: nostrEventTags,
     hashtags: hashtags,
     title: title,
+    nostrLikeCount: nostrLikeCount,
+    nostrCommentCount: nostrCommentCount,
+    nostrRepostCount: nostrRepostCount,
+    categories: categories,
+    moderationLabels: moderationLabels,
+    proofSummary: proofSummary,
   );
 }
 
@@ -141,6 +153,17 @@ void main() {
         ],
         hashtags: const ['stale'],
         title: 'Stale title',
+        nostrLikeCount: 11,
+        nostrCommentCount: 7,
+        nostrRepostCount: 3,
+        categories: const ['comedy'],
+        moderationLabels: const ['label'],
+        proofSummary: const ProofVerificationSummary(
+          status: 'present',
+          level: 'basic_proof',
+          version: 1,
+          checks: {'proofmode_present': true},
+        ),
       );
       final enriched = _video(
         id: 'nostr',
@@ -165,6 +188,12 @@ void main() {
       expect(merged.single.hashtags, enriched.hashtags);
       expect(merged.single.title, enriched.title);
       expect(merged.single.id, enriched.id);
+      expect(merged.single.nostrLikeCount, 11);
+      expect(merged.single.nostrCommentCount, 7);
+      expect(merged.single.nostrRepostCount, 3);
+      expect(merged.single.categories, ['comedy']);
+      expect(merged.single.moderationLabels, ['label']);
+      expect(merged.single.proofSummary, current.proofSummary);
     });
 
     test('keeps raw tags from a newer current event', () {

--- a/mobile/test/blocs/profile_feed/profile_feed_enrichment_merge_test.dart
+++ b/mobile/test/blocs/profile_feed/profile_feed_enrichment_merge_test.dart
@@ -14,6 +14,8 @@ VideoEvent _video({
   String? textTrackRef,
   List<String> textTrackRefs = const [],
   String? textTrackContent,
+  int? eventCreatedAt,
+  List<List<String>> nostrEventTags = const [],
 }) {
   return VideoEvent(
     id: id,
@@ -26,6 +28,8 @@ VideoEvent _video({
     textTrackRef: textTrackRef,
     textTrackRefs: textTrackRefs,
     textTrackContent: textTrackContent,
+    eventCreatedAt: eventCreatedAt,
+    nostrEventTags: nostrEventTags,
   );
 }
 
@@ -120,6 +124,66 @@ void main() {
       );
 
       expect(merged, [current]);
+    });
+
+    test('uses raw tags from a strictly newer enriched event', () {
+      final current = _video(
+        id: 'rest',
+        vineId: 'video-d-tag',
+        eventCreatedAt: 100,
+        nostrEventTags: const [
+          ['d', 'video-d-tag'],
+          ['t', 'stale'],
+        ],
+      );
+      final enriched = _video(
+        id: 'nostr',
+        vineId: 'video-d-tag',
+        eventCreatedAt: 101,
+        nostrEventTags: const [
+          ['d', 'video-d-tag'],
+          ['t', 'current'],
+        ],
+      );
+
+      final merged = mergeProfileFeedEnrichment(
+        current: [current],
+        sourceKeys: {canonicalProfileFeedVideoKey(current)},
+        incoming: [enriched],
+        removeTombstones: (videos) => videos,
+      );
+
+      expect(merged.single.nostrEventTags, enriched.nostrEventTags);
+    });
+
+    test('keeps raw tags from a newer current event', () {
+      final current = _video(
+        id: 'nostr-current',
+        vineId: 'video-d-tag',
+        eventCreatedAt: 102,
+        nostrEventTags: const [
+          ['d', 'video-d-tag'],
+          ['t', 'current'],
+        ],
+      );
+      final enriched = _video(
+        id: 'stale-enrichment',
+        vineId: 'video-d-tag',
+        eventCreatedAt: 101,
+        nostrEventTags: const [
+          ['d', 'video-d-tag'],
+          ['t', 'stale'],
+        ],
+      );
+
+      final merged = mergeProfileFeedEnrichment(
+        current: [current],
+        sourceKeys: {canonicalProfileFeedVideoKey(current)},
+        incoming: [enriched],
+        removeTombstones: (videos) => videos,
+      );
+
+      expect(merged.single.nostrEventTags, current.nostrEventTags);
     });
   });
 }

--- a/mobile/test/l10n/arb_consistency_test.dart
+++ b/mobile/test/l10n/arb_consistency_test.dart
@@ -489,6 +489,9 @@ const _knownUntranslatedDebt = <String>{
   'notificationsTabBadges',
   'notificationsPendingBadges',
   'notificationsBadgesEmpty',
+  // Critical metadata-loss prevention copy added in #8014. Translation is
+  // deferred to the next l10n pass.
+  'shareMenuOriginalVideoUnavailable',
   // #7892: safety-filter explanation on the video detail screen. Translation
   // deferred to the next l10n pass.
   'videoDetailHiddenBySettingsTitle',

--- a/mobile/test/screens/subtitle_editor/subtitle_editor_screen_test.dart
+++ b/mobile/test/screens/subtitle_editor/subtitle_editor_screen_test.dart
@@ -36,15 +36,18 @@ class _FakeVideoEventResolver implements VideoEventResolver {
   final VideoEvent? video;
   final resolvedIds = <String>[];
   final allowOwnContentBypassValues = <bool>[];
+  final requireRawTagsValues = <bool>[];
 
   @override
   Future<VideoEvent?> resolveById(
     String eventId, {
     bool allowOwnContentBypass = false,
+    bool requireRawTags = false,
     Duration timeout = const Duration(seconds: 10),
   }) async {
     resolvedIds.add(eventId);
     allowOwnContentBypassValues.add(allowOwnContentBypass);
+    requireRawTagsValues.add(requireRawTags);
     return video;
   }
 }
@@ -653,6 +656,7 @@ void main() {
 
       expect(resolver.resolvedIds, [video.id]);
       expect(resolver.allowOwnContentBypassValues, [isTrue]);
+      expect(resolver.requireRawTagsValues, [isTrue]);
       expect(cueTextInList('hello'), findsOneWidget);
       verify(() => repository.loadCues(video)).called(1);
     });

--- a/mobile/test/screens/video_metadata_edit_screen_test.dart
+++ b/mobile/test/screens/video_metadata_edit_screen_test.dart
@@ -1,0 +1,69 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/providers/video_providers.dart';
+import 'package:openvine/screens/video_metadata/video_metadata_edit_screen.dart';
+import 'package:openvine/services/video_event_resolver.dart';
+
+class _MockVideoEventResolver extends Mock implements VideoEventResolver {}
+
+void main() {
+  testWidgets('raw-tagless prefetch resolves a complete event before editing', (
+    tester,
+  ) async {
+    final resolver = _MockVideoEventResolver();
+    final pending = Completer<VideoEvent?>();
+    when(
+      () => resolver.resolveById(
+        'event-id',
+        allowOwnContentBypass: true,
+        requireRawTags: true,
+      ),
+    ).thenAnswer((_) => pending.future);
+
+    final incomplete = VideoEvent(
+      id: 'event-id',
+      pubkey: 'author-pubkey',
+      createdAt: 1700000000,
+      content: 'Description',
+      timestamp: DateTime.fromMillisecondsSinceEpoch(
+        1700000000 * 1000,
+        isUtc: true,
+      ),
+      videoUrl: 'https://example.com/video.mp4',
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          videoEventResolverProvider.overrideWithValue(resolver),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: VideoMetadataEditScreen(
+            videoId: incomplete.id,
+            prefetched: incomplete,
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    verify(
+      () => resolver.resolveById(
+        'event-id',
+        allowOwnContentBypass: true,
+        requireRawTags: true,
+      ),
+    ).called(1);
+
+    pending.complete();
+    await tester.pump();
+  });
+}

--- a/mobile/test/screens/video_metadata_edit_screen_test.dart
+++ b/mobile/test/screens/video_metadata_edit_screen_test.dart
@@ -13,57 +13,62 @@ import 'package:openvine/services/video_event_resolver.dart';
 class _MockVideoEventResolver extends Mock implements VideoEventResolver {}
 
 void main() {
-  testWidgets('raw-tagless prefetch resolves a complete event before editing', (
-    tester,
-  ) async {
-    final resolver = _MockVideoEventResolver();
-    final pending = Completer<VideoEvent?>();
-    when(
-      () => resolver.resolveById(
-        'event-id',
-        allowOwnContentBypass: true,
-        requireRawTags: true,
-      ),
-    ).thenAnswer((_) => pending.future);
-
-    final incomplete = VideoEvent(
-      id: 'event-id',
-      pubkey: 'author-pubkey',
-      createdAt: 1700000000,
-      content: 'Description',
-      timestamp: DateTime.fromMillisecondsSinceEpoch(
-        1700000000 * 1000,
-        isUtc: true,
-      ),
-      videoUrl: 'https://example.com/video.mp4',
-    );
-
-    await tester.pumpWidget(
-      ProviderScope(
-        overrides: [
-          videoEventResolverProvider.overrideWithValue(resolver),
-        ],
-        child: MaterialApp(
-          localizationsDelegates: AppLocalizations.localizationsDelegates,
-          supportedLocales: AppLocalizations.supportedLocales,
-          home: VideoMetadataEditScreen(
-            videoId: incomplete.id,
-            prefetched: incomplete,
+  group(VideoMetadataEditScreen, () {
+    testWidgets(
+      'raw-tagless prefetch resolves a complete event before editing',
+      (
+        tester,
+      ) async {
+        final resolver = _MockVideoEventResolver();
+        final pending = Completer<VideoEvent?>();
+        when(
+          () => resolver.resolveById(
+            'event-id',
+            allowOwnContentBypass: true,
+            requireRawTags: true,
           ),
-        ),
-      ),
+        ).thenAnswer((_) => pending.future);
+
+        final incomplete = VideoEvent(
+          id: 'event-id',
+          pubkey: 'author-pubkey',
+          createdAt: 1700000000,
+          content: 'Description',
+          timestamp: DateTime.fromMillisecondsSinceEpoch(
+            1700000000 * 1000,
+            isUtc: true,
+          ),
+          videoUrl: 'https://example.com/video.mp4',
+        );
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              videoEventResolverProvider.overrideWithValue(resolver),
+            ],
+            child: MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: VideoMetadataEditScreen(
+                videoId: incomplete.id,
+                prefetched: incomplete,
+              ),
+            ),
+          ),
+        );
+
+        expect(find.byType(CircularProgressIndicator), findsOneWidget);
+        verify(
+          () => resolver.resolveById(
+            'event-id',
+            allowOwnContentBypass: true,
+            requireRawTags: true,
+          ),
+        ).called(1);
+
+        pending.complete();
+        await tester.pump();
+      },
     );
-
-    expect(find.byType(CircularProgressIndicator), findsOneWidget);
-    verify(
-      () => resolver.resolveById(
-        'event-id',
-        allowOwnContentBypass: true,
-        requireRawTags: true,
-      ),
-    ).called(1);
-
-    pending.complete();
-    await tester.pump();
   });
 }

--- a/mobile/test/services/seed_media_preload_service_test.dart
+++ b/mobile/test/services/seed_media_preload_service_test.dart
@@ -144,9 +144,9 @@ void main() {
             return null;
           });
 
-      expect(
-        () async => SeedMediaPreloadService.loadSeedMediaIfNeeded(),
-        returnsNormally,
+      await expectLater(
+        SeedMediaPreloadService.loadSeedMediaIfNeeded(),
+        completes,
         reason: 'Missing manifest should be non-critical',
       );
     });
@@ -161,9 +161,9 @@ void main() {
               return ByteData.sublistView(bytes);
             });
 
-        expect(
-          () async => SeedMediaPreloadService.loadSeedMediaIfNeeded(),
-          returnsNormally,
+        await expectLater(
+          SeedMediaPreloadService.loadSeedMediaIfNeeded(),
+          completes,
           reason: 'Corrupted manifest should be non-critical',
         );
       },

--- a/mobile/test/services/video_event_resolver_test.dart
+++ b/mobile/test/services/video_event_resolver_test.dart
@@ -72,6 +72,28 @@ void main() {
       verifyNever(() => cache.getEventById(any()));
     });
 
+    test('requireRawTags skips incomplete in-memory and cache hits', () async {
+      final incomplete = _videoEvent(id: eventId, pubkey: otherPubkey);
+      final incompleteCached = _kind34236Event(
+        id: eventId,
+        pubkey: otherPubkey,
+        tags: const [],
+      );
+      final completeRelay = _kind34236Event(id: eventId, pubkey: otherPubkey);
+      when(
+        () => videoService.getVideoEventById(eventId),
+      ).thenReturn(incomplete);
+      when(() => cache.getEventById(eventId)).thenReturn(incompleteCached);
+
+      final resolver = build();
+      final future = resolver.resolveById(eventId, requireRawTags: true);
+      relayController.add(completeRelay);
+
+      final result = await future;
+      expect(result, isNotNull);
+      expect(result!.nostrEventTags, isNotEmpty);
+    });
+
     test('returns personal cache hit when in-memory misses', () async {
       final event = _kind34236Event(id: eventId, pubkey: otherPubkey);
       when(() => cache.getEventById(eventId)).thenReturn(event);
@@ -177,16 +199,22 @@ VideoEvent _videoEvent({required String id, required String pubkey}) {
   );
 }
 
-Event _kind34236Event({required String id, required String pubkey}) {
+Event _kind34236Event({
+  required String id,
+  required String pubkey,
+  List<List<String>>? tags,
+}) {
   return Event.fromJson({
     'id': id,
     'pubkey': pubkey,
     'created_at': 1700000000,
     'kind': 34236,
-    'tags': [
-      ['d', 'd-tag-$id'],
-      ['url', 'https://example.com/video.mp4'],
-    ],
+    'tags':
+        tags ??
+        [
+          ['d', 'd-tag-$id'],
+          ['url', 'https://example.com/video.mp4'],
+        ],
     'content': 'content',
     'sig': 'signature',
   });

--- a/mobile/test/services/video_metadata_update_service_test.dart
+++ b/mobile/test/services/video_metadata_update_service_test.dart
@@ -3,6 +3,7 @@
 // ABOUTME: edited-field replacement, replacement created_at, successful publish,
 // ABOUTME: publish failure, and invite failure via inviteFailureCount.
 
+import 'dart:io';
 import 'dart:ui' show Locale;
 
 import 'package:blossom_upload_service/blossom_upload_service.dart';
@@ -74,6 +75,7 @@ void main() {
   setUpAll(() {
     registerFallbackValue(_FakeEvent());
     registerFallbackValue(_FakeVideoEvent());
+    registerFallbackValue(File('/tmp/fallback-thumbnail.jpg'));
   });
 
   setUp(() {
@@ -580,38 +582,112 @@ void main() {
         expect(capturedTags, contains(equals(['expiration', '1799999999'])));
       });
 
-      test('rebuilds imeta from videoUrl when nostrEventTags is empty and the '
-          'event is not cached', () async {
-        final video = VideoEvent(
-          id: 'uncached-event-id',
-          pubkey: _ownerPubkey,
-          createdAt: 1757385263,
-          content: 'Test video content',
-          timestamp: DateTime.fromMillisecondsSinceEpoch(1757385263 * 1000),
-          videoUrl: 'https://cdn.example.com/video.mp4',
-          title: 'Test Video Title',
-          vineId: 'video-d-tag',
-        );
-        when(
-          () => mockPersonalEventCacheService.getEventById('uncached-event-id'),
-        ).thenReturn(null);
+      test(
+        'refuses to publish when original raw tags are unavailable',
+        () async {
+          final video = VideoEvent(
+            id: 'uncached-event-id',
+            pubkey: _ownerPubkey,
+            createdAt: 1757385263,
+            content: 'Test video content',
+            timestamp: DateTime.fromMillisecondsSinceEpoch(1757385263 * 1000),
+            videoUrl: 'https://cdn.example.com/video.mp4',
+            title: 'Test Video Title',
+            vineId: 'video-d-tag',
+          );
+          when(
+            () =>
+                mockPersonalEventCacheService.getEventById('uncached-event-id'),
+          ).thenReturn(null);
 
-        final result = await service.updateVideo(
-          originalVideo: video,
-          editorState: VideoEditorProviderState(),
-          initialCollaboratorPubkeys: const {},
-        );
+          final result = await service.updateVideo(
+            originalVideo: video,
+            editorState: VideoEditorProviderState(),
+            initialCollaboratorPubkeys: const {},
+            newThumbnailFile: File('/tmp/unused-thumbnail.jpg'),
+          );
 
-        expect(result, isA<VideoUpdateSuccess>());
-        final imetaTags = capturedTags
-            .where((t) => t.isNotEmpty && t.first == 'imeta')
-            .toList();
-        expect(imetaTags, hasLength(1));
-        expect(
-          imetaTags.single,
-          contains('url https://cdn.example.com/video.mp4'),
-        );
-      });
+          expect(result, isA<VideoUpdateOriginalUnavailable>());
+          verifyNever(
+            () => mockBlossomUploadService.uploadImage(
+              imageFile: any(named: 'imageFile'),
+              nostrPubkey: any(named: 'nostrPubkey'),
+            ),
+          );
+          verifyNever(
+            () => mockAuthService.createAndSignEvent(
+              kind: any(named: 'kind'),
+              content: any(named: 'content'),
+              tags: any(named: 'tags'),
+              createdAt: any(named: 'createdAt'),
+            ),
+          );
+          verifyNever(() => mockNostrService.publishEvent(any()));
+        },
+      );
+
+      test(
+        'REST-sourced edit preserves hashtags and provenance tags',
+        () async {
+          final video = VideoStats.fromJson(const {
+            'event': {
+              'id': 'rest-event-id',
+              'pubkey': _ownerPubkey,
+              'created_at': 1757385263,
+              'kind': 34236,
+              'content': 'Test video content',
+              'tags': [
+                ['d', 'video-d-tag'],
+                [
+                  'imeta',
+                  'url https://cdn.example.com/video.mp4',
+                  'm video/mp4',
+                ],
+                ['t', 'first'],
+                ['t', 'second'],
+                ['alt', 'Accessible description'],
+                ['duration', '6'],
+                ['proofmode', 'proof-manifest'],
+                ['c2pa_manifest_id', 'urn:c2pa:test'],
+                ['verification', 'verified_mobile'],
+                ['device_attestation', 'attestation'],
+                ['text-track', '39307:author:subtitles:video-d-tag'],
+              ],
+            },
+            'stats': {
+              'reactions': 0,
+              'comments': 0,
+              'reposts': 0,
+              'engagement_score': 0,
+            },
+          }).toVideoEvent();
+
+          final result = await service.updateVideo(
+            originalVideo: video,
+            editorState: VideoEditorProviderState(
+              title: video.title ?? '',
+              description: video.content,
+              tags: video.hashtags.toSet(),
+            ),
+            initialCollaboratorPubkeys: const {},
+          );
+
+          expect(result, isA<VideoUpdateSuccess>());
+          for (final tag in const [
+            ['t', 'first'],
+            ['t', 'second'],
+            ['alt', 'Accessible description'],
+            ['duration', '6'],
+            ['proofmode', 'proof-manifest'],
+            ['c2pa_manifest_id', 'urn:c2pa:test'],
+            ['verification', 'verified_mobile'],
+            ['device_attestation', 'attestation'],
+            ['text-track', '39307:author:subtitles:video-d-tag'],
+          ]) {
+            expect(capturedTags, contains(equals(tag)));
+          }
+        },
+      );
     });
 
     group('edited field replacement', () {
@@ -652,6 +728,28 @@ void main() {
           expect(capturedTags, isNot(contains(equals(['t', 'oldtag']))));
         },
       );
+
+      test('allows the user to clear hashtags from a complete event', () async {
+        final video = _testVideo(
+          extraTags: const [
+            ['t', 'oldtag'],
+            ['proofmode', 'proof-manifest'],
+          ],
+        );
+
+        final result = await service.updateVideo(
+          originalVideo: video,
+          editorState: VideoEditorProviderState(),
+          initialCollaboratorPubkeys: const {},
+        );
+
+        expect(result, isA<VideoUpdateSuccess>());
+        expect(capturedTags.where((tag) => tag.first == 't'), isEmpty);
+        expect(
+          capturedTags,
+          contains(equals(['proofmode', 'proof-manifest'])),
+        );
+      });
 
       test(
         'removes the content-warning group when warnings are cleared',

--- a/mobile/test/services/video_metadata_update_service_test.dart
+++ b/mobile/test/services/video_metadata_update_service_test.dart
@@ -642,6 +642,7 @@ void main() {
                   'imeta',
                   'url https://cdn.example.com/video.mp4',
                   'm video/mp4',
+                  'size 480000',
                 ],
                 ['t', 'first'],
                 ['t', 'second'],
@@ -686,6 +687,10 @@ void main() {
           ]) {
             expect(capturedTags, contains(equals(tag)));
           }
+          expect(
+            capturedTags.singleWhere((tag) => tag.first == 'imeta'),
+            contains('size 480000'),
+          );
         },
       );
     });

--- a/mobile/test/widgets/video_metadata/modes/edit/video_metadata_edit_bottom_bar_test.dart
+++ b/mobile/test/widgets/video_metadata/modes/edit/video_metadata_edit_bottom_bar_test.dart
@@ -5,11 +5,23 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart' show VideoEvent;
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/models/video_editor/video_editor_provider_state.dart';
+import 'package:openvine/providers/video_editor_provider.dart';
+import 'package:openvine/providers/video_providers.dart';
 import 'package:openvine/screens/subtitle_editor/subtitle_editor_screen.dart';
+import 'package:openvine/services/video_metadata_update_service.dart';
 import 'package:openvine/widgets/video_metadata/modes/edit/video_metadata_edit_bottom_bar.dart';
 
 import '../../../../helpers/go_router.dart';
 import '../../../../helpers/test_helpers.dart';
+
+class _MockVideoMetadataUpdateService extends Mock
+    implements VideoMetadataUpdateService {}
+
+class _MockVideoEditorNotifier extends VideoEditorNotifier {
+  @override
+  VideoEditorProviderState build() => VideoEditorProviderState();
+}
 
 void main() {
   group(VideoMetadataEditBottomBar, () {
@@ -18,6 +30,8 @@ void main() {
 
     setUpAll(() {
       registerFallbackValue(TestHelpers.createVideoEvent(id: 'fallback'));
+      registerFallbackValue(VideoEditorProviderState());
+      registerFallbackValue(<String>{});
     });
 
     setUp(() {
@@ -29,8 +43,16 @@ void main() {
     Widget buildSubject(
       MockGoRouter goRouter, {
       ValueChanged<VideoEvent>? onVideoUpdated,
+      VideoMetadataUpdateService? updateService,
     }) {
       return ProviderScope(
+        overrides: [
+          videoEditorProvider.overrideWith(_MockVideoEditorNotifier.new),
+          if (updateService != null)
+            videoMetadataUpdateServiceProvider.overrideWithValue(
+              updateService,
+            ),
+        ],
         child: MaterialApp(
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
@@ -107,6 +129,37 @@ void main() {
         ),
         findsOneWidget,
       );
+    });
+
+    testWidgets('explains when complete original metadata is unavailable', (
+      tester,
+    ) async {
+      final mockGoRouter = MockGoRouter();
+      final updateService = _MockVideoMetadataUpdateService();
+      when(
+        () => updateService.updateVideo(
+          originalVideo: any(named: 'originalVideo'),
+          editorState: any(named: 'editorState'),
+          initialCollaboratorPubkeys: any(
+            named: 'initialCollaboratorPubkeys',
+          ),
+          newThumbnailFile: any(named: 'newThumbnailFile'),
+        ),
+      ).thenAnswer((_) async => const VideoUpdateOriginalUnavailable());
+
+      await tester.pumpWidget(
+        buildSubject(mockGoRouter, updateService: updateService),
+      );
+
+      await tester.tap(find.text(l10n.shareMenuUpdate));
+      await tester.pump();
+
+      expect(find.byType(SnackBar), findsOneWidget);
+      final snackbar = tester.widget<DivineSnackbarContainer>(
+        find.byType(DivineSnackbarContainer),
+      );
+      expect(snackbar.label, l10n.shareMenuOriginalVideoUnavailable);
+      expect(snackbar.error, isTrue);
     });
   });
 }


### PR DESCRIPTION
## What this fixes

Editing a video loaded from the REST/profile path could republish an incomplete addressable event. That removed hashtags and raw provenance tags such as ProofMode, C2PA, verification, and device-attestation metadata.

## What changed

- retain the complete ordered Nostr tag array when converting REST `VideoStats` into a `VideoEvent`, including repeated hashtags
- require complete raw tags when resolving videos for metadata and subtitle editing
- refuse to publish an edit when the original tag set is unavailable, before uploads, signing, publishing, or cache mutation
- surface that refusal as localized, actionable UI copy
- preserve all original provenance and auxiliary tags while still allowing a creator to intentionally clear hashtags

## Verification

- `flutter analyze`
- 183 focused model, service, resolver, screen, widget, and localization tests
- localization consistency and orphan-key checks
- layer-direction, service-size, post-close emit, and Nostr logging ratchets
- repository pre-push checks

## Deliberately unchanged

This prevents new destructive republishes. It does not reconstruct provenance already removed from relay events or change the separate snapshot-cache serialization policy.

Closes #8014