### PR TITLE
fix(lists): keep private lists private during relay sync

### DIFF
--- a/mobile/lib/services/curated_list_service.dart
+++ b/mobile/lib/services/curated_list_service.dart
@@ -18,6 +18,7 @@ import 'package:nostr_sdk/event.dart';
 import 'package:nostr_sdk/filter.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/curated_list_relay_gateway.dart';
+import 'package:openvine/utils/curated_list_privacy.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:unified_logger/unified_logger.dart';
 
@@ -327,7 +328,7 @@ class CuratedListService extends ChangeNotifier {
     PlayOrder playOrder = PlayOrder.chronological,
   }) async {
     try {
-      if (!isPublic && isCollaborative) {
+      if (!hasValidCuratedListVisibility(isPublic, isCollaborative)) {
         Log.warning(
           'Cannot create a private collaborative list - private items are '
           'encrypted to the owner only',
@@ -635,7 +636,10 @@ class CuratedListService extends ChangeNotifier {
         playOrder: playOrder ?? list.playOrder,
         updatedAt: DateTime.now(),
       );
-      if (!updatedList.isPublic && updatedList.isCollaborative) {
+      if (!hasValidCuratedListVisibility(
+        updatedList.isPublic,
+        updatedList.isCollaborative,
+      )) {
         Log.warning(
           'Cannot make a collaborative list private - private items are '
           'encrypted to the owner only',
@@ -1727,17 +1731,28 @@ class CuratedListService extends ChangeNotifier {
             ...existingList.allowedCollaborators,
             ...curatedList.allowedCollaborators,
           }.toList(growable: false);
+          final isPublic = existingList.isPublic && curatedList.isPublic;
+          final hasPrivacyConflict = !hasValidCuratedListVisibility(
+            isPublic,
+            isCollaborative,
+          );
+          if (hasPrivacyConflict) {
+            Log.warning(
+              'Keeping list $dTag private and dropping collaboration during '
+              'relay merge',
+              name: 'CuratedListService',
+              category: LogCategory.system,
+            );
+          }
 
           _lists[existingListIndex] = preferred.copyWith(
             pubkey: event.pubkey,
             videoEventIds: mergedVideoIds,
             createdAt: existingList.createdAt,
             updatedAt: DateTime.now(),
-            isCollaborative: isCollaborative,
-            allowedCollaborators: collaborators,
-            isPublic:
-                (existingList.isPublic && curatedList.isPublic) ||
-                isCollaborative,
+            isCollaborative: isCollaborative && !hasPrivacyConflict,
+            allowedCollaborators: hasPrivacyConflict ? const [] : collaborators,
+            isPublic: isPublic,
             clearNostrEventId: true,
             pendingRepublish: false,
           );

--- a/mobile/lib/utils/curated_list_privacy.dart
+++ b/mobile/lib/utils/curated_list_privacy.dart
@@ -1,0 +1,6 @@
+// ABOUTME: Defines the visibility invariant for curated lists.
+// ABOUTME: Keeps private lists owner-only by forbidding collaboration.
+
+/// Whether a curated list's visibility and collaboration settings can coexist.
+bool hasValidCuratedListVisibility(bool isPublic, bool isCollaborative) =>
+    isPublic || !isCollaborative;

--- a/mobile/test/services/curated_list_service_crud_test.dart
+++ b/mobile/test/services/curated_list_service_crud_test.dart
@@ -18,6 +18,7 @@ import 'package:nostr_sdk/signer/nostr_signer.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/curated_list_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:unified_logger/unified_logger.dart';
 
 import '../helpers/curated_list_publish_stubs.dart';
 
@@ -683,7 +684,7 @@ void main() {
         },
       );
 
-      test('merge keeps collaborative lists public', () async {
+      test('merge repairs a legacy private collaborative list', () async {
         SharedPreferences.setMockInitialValues({
           CuratedListService.listsStorageKey: jsonEncode([
             CuratedList(
@@ -725,9 +726,87 @@ void main() {
         await upgraded.fetchUserListsFromRelays();
 
         final merged = upgraded.getListById('collaborative-local')!;
-        expect(merged.isCollaborative, isTrue);
-        expect(merged.isPublic, isTrue);
+        expect(merged.isCollaborative, isFalse);
+        expect(merged.allowedCollaborators, isEmpty);
+        expect(merged.isPublic, isFalse);
       });
+
+      test(
+        'private list wins a collaborative relay conflict and republishes sealed',
+        () async {
+          await LogCaptureService().clearAllLogs();
+          SharedPreferences.setMockInitialValues({
+            CuratedListService.listsStorageKey: jsonEncode([
+              CuratedList(
+                id: 'private-local',
+                name: 'Private Local',
+                videoEventIds: const ['local_video'],
+                createdAt: DateTime(2025),
+                updatedAt: DateTime(2025),
+                isPublic: false,
+                pubkey: _ownerPubkey,
+              ).toJson(),
+            ]),
+          });
+          when(() => mockNostr.subscribe(any())).thenAnswer(
+            (_) => Stream.value(
+              Event.fromJson({
+                'id': 'relay_collaborative_event',
+                'pubkey': _ownerPubkey,
+                'created_at': DateTime.now().millisecondsSinceEpoch ~/ 1000,
+                'kind': 30005,
+                'tags': [
+                  ['d', 'private-local'],
+                  ['title', 'Collaborative Relay'],
+                  ['e', 'relay_video'],
+                  ['collaborative', 'true'],
+                  ['collaborator', _otherPubkey],
+                ],
+                'content': 'Collaborative Relay',
+                'sig': 'test_signature',
+              }),
+            ),
+          );
+          final upgraded = CuratedListService(
+            nostrService: mockNostr,
+            authService: mockAuth,
+            prefs: await SharedPreferences.getInstance(),
+          );
+
+          await upgraded.fetchUserListsFromRelays();
+
+          final merged = upgraded.getListById('private-local')!;
+          expect(merged.isPublic, isFalse);
+          expect(merged.isCollaborative, isFalse);
+          expect(merged.allowedCollaborators, isEmpty);
+          expect(merged.videoEventIds, ['relay_video', 'local_video']);
+
+          final warning = LogCaptureService()
+              .getRecentLogs()
+              .where(
+                (entry) =>
+                    entry.level == LogLevel.warning &&
+                    entry.message.contains('private-local'),
+              )
+              .single;
+          expect(warning.level, LogLevel.warning);
+
+          final republished =
+              verify(
+                    () => mockNostr.publishEventAwaitOk(captureAny()),
+                  ).captured.last
+                  as Event;
+          expect(
+            republished.tags,
+            isNot(contains(equals(['e', 'local_video']))),
+          );
+          expect(
+            republished.tags,
+            isNot(contains(equals(['e', 'relay_video']))),
+          );
+          expect(_unseal(republished.content), isNotNull);
+        },
+      );
 
       test(
         'backs up null-pubkey local lists as the authenticated owner',


### PR DESCRIPTION
A private list could become public when relay sync merged it with a collaborative copy of the same list. The merge combined collaboration first, then used that result to override the user's private visibility choice.

This change makes privacy the restrictive merge result: conflicting collaboration metadata and collaborators are dropped, while items from both copies are preserved. The same named visibility invariant now governs create, update, and relay-merge paths. Legacy private-and-collaborative state is repaired with the same policy.

This does not add or expose collaborative-list controls in the app.

Verification:
- `flutter test test/services/curated_list_service_crud_test.dart` (92 tests)
- `flutter analyze lib test integration_test`
- `bash scripts/check_service_god_file_ceiling.sh`

Closes #7724