### PR TITLE
docs: trim video series v1 design

### DIFF
--- a/docs/superpowers/specs/2026-08-22-video-series-design.md
+++ b/docs/superpowers/specs/2026-08-22-video-series-design.md
@@ -1,0 +1,214 @@
+# Video Series — Design
+
+Date: 2026-08-22
+Status: Approved design, pending implementation plan
+
+## Problem
+
+A creator has a story that doesn't fit in one 6-second loop. Today they post
+part 1, part 2, and part 3 as three unrelated videos. A viewer who meets part 3
+in the feed has no way to know parts 1 and 2 exist, and no way to watch them in
+order.
+
+Series makes that ordering explicit: a viewer sees "Part 3 of 10", can jump to
+the start, and can walk forward and back through the parts.
+
+## Non-goals
+
+- Series containing other people's videos. Curating other creators' work is the
+  existing curated-list feature and stays there.
+- A dedicated Discover surface for series, series cards on profile, or
+  "start from part 1" entry points. Deferred until series exist in the wild.
+- Any new Nostr event kind.
+
+## Data model
+
+A series is a **kind 30005 curated video list** with `playorder=manual`. The
+existing `curated_list_repository` package already models, converts, publishes,
+and deep-links these lists; series reuse all of it.
+
+Two additions:
+
+**On the list event (kind 30005):**
+
+```
+["series", "true"]
+```
+
+Marks the list as a series so ordinary curated lists stay ordinary in Discover
+and in list UI. Part order is the existing `a`-tag order under
+`playorder=manual` — no separate order field on the list.
+
+**On each part (kind 34236, the creator's own video):**
+
+```
+["a", "30005:<owner_pubkey>:<series_d_tag>"]
+["part", "3"]
+```
+
+`part` is the 1-based position. It exists so a video can render its own chip
+without first fetching the list. **The list is authoritative for order.** If the
+two disagree — the owner reordered parts after publishing — the list wins and
+the chip renders from list position.
+
+### Why tags on the video
+
+Tagging the video gives reverse lookup for free: a video met anywhere (main
+feed, profile, hashtag, deep link) already names its series, so the chip needs
+one addressable fetch of the list, cached, and no `#a` scan or server index.
+
+The alternative considered — prev/next tags chaining videos with no list object
+— was rejected: linking part N to part N+1 requires republishing part N *after*
+N+1 exists, which is one edit per link, and a single failed edit breaks the
+chain with no object holding the truth.
+
+### Membership
+
+Own videos only. A creator can only sign their own events, so a series built
+from someone else's videos would have untagged parts and no chip. Series is a
+creator's own multi-part story; curating others stays the curated-list feature.
+
+### Edit path
+
+Assigning an already-published video to a series republishes its kind 34236
+event. The repo has a known bug where `published_at` goes null on edit and the
+publication date is permanently rewritten. That path must preserve every
+original tag verbatim, `published_at` included. This is a hard blocker for the
+feature, covered by a regression test — not worked around.
+
+## Components
+
+### Package: `curated_list_repository`
+
+- `isSeries` on `CuratedList`, round-tripped through the converter's tag
+  read/write.
+- `createSeries()`.
+- `reorderParts(listId, from, to)` — rewrites `a`-tag order and republishes the
+  30005 event. No video edits.
+- `seriesForVideo(videoCoordinate)` — resolves a video's series `a` tag to the
+  list, cached.
+
+### Publish path
+
+The existing publish/metadata flow gains a series field. The picked series
+coordinate and computed part index are written into the kind 34236 tags at sign
+time, so first-publish assignment never involves an edit.
+
+### BLoC: `mobile/lib/features/series/bloc/`
+
+- `SeriesBloc` — loads a series and its ordered parts, owns `currentIndex`,
+  exposes `hasPrev` / `hasNext`. Drives both the series screen and the player
+  chrome.
+- `VideoSeriesChipCubit` — per video: resolves the series `a` tag to a name and
+  a part position. Emits nothing when the video carries no series tag, so the
+  chip never renders on ordinary videos.
+
+### UI
+
+- `SeriesChip` — renders `Part 3 of 10 · Series name`, tappable, opens the
+  series. App-level (not `divine_ui`) because it needs l10n; built from
+  `divine_ui` primitives.
+- Prev / next `DivineIconButton`s beside the chip in the fullscreen overlay,
+  shown only while a series is active.
+- Series screen — the existing `CuratedListFeedScreen` in a series mode:
+  numbered parts, drag-to-reorder for the owner, viewer-only for everyone else.
+- "Add to series" in the existing video menu; series picker in the publish
+  metadata screen.
+
+### Reused as-is
+
+Playback stays `PooledFullscreenVideoFeedScreen`, fed a series-ordered video
+list. Auto-advance inherits the user's existing feed setting — no new toggle,
+no new policy. Sharing, deep links, and list CRUD already exist.
+
+## User flows
+
+**Publish, series doesn't exist yet.** Metadata screen → "Part of a series" →
+picker lists your series plus "New series…" → name it → the 30005 list is
+created and the video is tagged part 1, in one submit.
+
+**Publish, series exists.** Pick the series; the video is tagged with the next
+part number (highest existing part + 1).
+
+**Retroactive.** Two ways into the same sheet: the video's own menu
+("Add to series"), or "Add videos" from inside a series — a grid of the
+creator's own videos, multi-select, ordered by pick order. This is the edit
+path described above.
+
+**Reorder / remove.** Owner sees numbered parts with drag handles on the series
+screen. Reordering republishes only the 30005 list. Videos' `part` tags go
+stale, which is expected: the list is authoritative and the chip renders from
+list position. Removing a part never blocks — a video pointing at a series that
+no longer lists it simply shows no chip.
+
+**Viewer.** Meets part 3 in the feed → chip reads `Part 3 of 10 · Name`. Tap
+the chip for the series screen numbered from part 1, or use prev/next to walk
+the series without leaving the player.
+
+**Someone else's series.** Chip, prev/next, series screen, share. No add, no
+reorder.
+
+## Long-record → series
+
+The strongest entry point, and new capability rather than a wire-up.
+
+Record or import a long clip → the editor offers "Split into a series" → cut
+points default to roughly every 6 seconds and are draggable → name the series →
+export N segments → publish N videos, each tagged with the series coordinate
+and its part index, in order.
+
+What this requires that does not exist today:
+
+- The editor accepting a source longer than `VideoEditorConstants.maxDuration`
+  (6.3s) in series mode. That cap is a hard invariant today; series mode carves
+  an explicit exception.
+- N sequential exports through `VideoEditorRenderService`, with progress UI.
+- Batch publish with partial-failure handling. The series list publishes first;
+  each part publishes independently; failures fall into the existing
+  background-upload retry path. A series with gaps renders the parts that
+  exist and never blocks.
+- Segment preview and adjustment before committing.
+
+`VideoEditorSplitService` is not reusable directly — it splits within a single
+video's timeline (trim-based, both halves stay one post). Its split-position
+validation math is reusable; the segment-to-separate-post pipeline is new.
+
+This is roughly as much work as the rest of the design combined. It ships in
+v1 by decision.
+
+## Failure handling
+
+| Failure | Behavior |
+|---|---|
+| Part published, list republish fails | Video carries the series tag, list lacks the part. Chip resolves the list, finds no part, renders nothing. Retried on next series open. |
+| List published, parts fail to upload | Series exists with gaps. Landed parts render; failed parts sit in the existing background-upload retry queue. |
+| Retro-assign edit drops `published_at` | Hard blocker. Republish preserves all original tags verbatim; regression test asserts `published_at` survives. |
+| Part deleted (kind 5) | Remaining parts render, renumbered from list position. |
+| Series list deleted, videos still tagged | Chip resolves nothing and renders nothing. Never an error state. |
+| Segment export fails mid-batch | Already-exported segments keep their queued uploads; the failed segment retries without redoing the others. |
+
+## Testing
+
+- **Package** (`curated_list_repository`, 100% coverage gate): converter
+  round-trip for the `series` tag, `orderedVideoIds` under manual order,
+  reorder republish, `seriesForVideo` resolution and caching.
+- **BLoC**: `SeriesBloc` load, prev/next, boundary behavior;
+  `VideoSeriesChipCubit` emits nothing for untagged videos; list position wins
+  over a stale `part` tag.
+- **Widget**: chip renders `Part 3 of 10`; prev disabled at part 1; next
+  disabled at the last part; no chip on ordinary videos; l10n delegates wired.
+- **Publish**: tags written on first publish; retro-assign preserves
+  `published_at` and every prior tag.
+- **Editor**: split-point math, N-segment export, partial-failure recovery.
+- **Golden**: chip in the fullscreen overlay.
+
+All new copy goes through `context.l10n`, with keys mirrored into every
+`app_*.arb` locale or recorded as known untranslated debt.
+
+## Delivery note
+
+Series core and the editor split flow are dependent, so they either combine
+into one PR or the core merges to `main` first and the split flow follows as a
+second PR branched from fresh `main`. The second form is not stacking and keeps
+review tractable. This is a plan-level decision, resolved in the
+implementation plan rather than here.

--- a/docs/superpowers/specs/2026-08-22-video-series-design.md
+++ b/docs/superpowers/specs/2026-08-22-video-series-design.md
@@ -110,8 +110,40 @@ larger Riverpod-to-repository migration is unrelated scope.
 Add one exact-coordinate fetch to `CuratedListRepository`, backed by its
 existing `NostrClient`: query kind 30005 by author and `d` tag, apply
 replaceable-event ordering, validate `isSeries`, and cache the result by full
-coordinate for the session. This supports videos encountered anywhere without
-a broad `#a` scan.
+coordinate. This supports videos encountered anywhere without a broad `#a`
+scan.
+
+#### Cache freshness contract
+
+A series list is a replaceable event, so a session-long cache would freeze it.
+A viewer who cached parts 1-3 would keep reading `of 3` for the rest of the
+session, and a newly published part 4 would fail membership validation and show
+no series UI at all — the feature silently disappearing on exactly the video
+that motivated it. The cache is therefore bounded:
+
+- **Entries carry a fetch timestamp and a 60-second TTL.** A read older than
+  that refetches before answering. 60 seconds is chosen so a creator publishing
+  consecutive parts sees the count move without a restart, while a viewer
+  scrolling a feed of one series' parts still gets one fetch, not one per video.
+- **A negative membership result is never served from cache.** If the cached
+  list does not contain the video's coordinate, refetch once before concluding
+  the video is not a member. Only a fresh miss suppresses the series UI. This is
+  the rule that keeps a just-published part from rendering as an ordinary video;
+  everything else here is an optimization, this one is correctness.
+- **Local mutation invalidates immediately.** `createSeries` and the append path
+  in `CuratedListService` evict the affected coordinate synchronously, before
+  their futures complete, so the publishing creator never reads their own stale
+  list.
+- **A newer replaceable event wins on arrival.** If any live subscription
+  delivers a kind-30005 event for a cached coordinate with a higher `created_at`
+  (ties broken by lower event id, matching the replaceable-event ordering
+  already applied on fetch), it replaces the entry rather than waiting for the
+  TTL.
+
+Staleness that survives all four is bounded to 60 seconds on the total, and to
+zero on membership. `Part 3 of 9` briefly reading `of 8` is acceptable; `no
+series UI` for a valid part is not, which is why only the count is allowed to
+lag.
 
 `VideoSeriesCubit` is the only new state-management unit. Given a `VideoEvent`,
 it:
@@ -133,9 +165,26 @@ so retries do not lose it.
 
 At publish time:
 
-1. If a new series was requested, create its empty kind-30005 event first. A
-   creation failure keeps the user on the metadata screen with retry and cancel
-   actions.
+1. If a new series was requested, create its empty kind-30005 event first, and
+   do not begin the video publish until a relay has accepted it. A creation
+   failure keeps the user on the metadata screen with retry and cancel actions.
+
+   The existing `CuratedListService.createList()` already provides this proof
+   and needs no new API. For a public list by an authenticated user it calls
+   `_publishListToNostr(newList, confirmed: true)`, which awaits
+   `publishEventAwaitOk` and treats `outcome.acceptedByAny` as the bar; on
+   failure it removes the local list, re-saves, and returns `null`
+   (`mobile/lib/services/curated_list_service.dart:273-280`, `1135-1148`). The
+   publication result is not discarded — a non-null return **is** the
+   relay-acceptance proof.
+
+   Two conditions are load-bearing, and `createSeries` must enforce both rather
+   than inherit them by luck: the list must be `isPublic: true`, and the user
+   must be authenticated. When either is false the publish is skipped entirely
+   and a local-only list is returned — which for a series would mean a creator
+   builds parts against a list no viewer can resolve. `createSeries` therefore
+   fixes `isPublic: true` and fails closed when unauthenticated, and the publish
+   flow treats a `null` return as the creation failure above.
 2. Sign and publish the video with the marked series `a` tag.
 3. After the video publish succeeds, append its stable kind-34236 coordinate to
    the list through `CuratedListService`.
@@ -159,13 +208,45 @@ Part 3 of 10 · Series name
 ```
 
 Tapping it opens the existing author/list route and starts
-`CuratedListFeedScreen` playback at index 0. The series mode of that screen adds
+`CuratedListFeedScreen` playback at index 0. That screen cannot do this today,
+so version 1 extends it — see [Playback entry contract](#playback-entry-contract). The series mode of that screen adds
 part numbers to grid items; playback remains
 `PooledFullscreenVideoFeedScreen` with the list's existing order. Swipe and
 auto-advance behavior remain unchanged.
 
+#### Playback entry contract
+
+`CuratedListFeedScreen` currently opens in grid mode and has no way to start in
+playback: its constructor takes `listId`, `listName`, `videoIds` and
+`authorPubkey` only, and `_activeVideoIndex` is initialized to `null`, which is
+exactly what selects the grid
+(`mobile/lib/screens/curated_list_feed_screen.dart:59-64`, `82`, `95`). The
+acceptance criterion "tapping the chip starts the ordered series at part 1"
+therefore requires a screen change, not just navigation.
+
+Version 1 adds:
+
+- **`final int? initialVideoIndex;`** to `CuratedListFeedScreen`, defaulting to
+  `null` so every existing call site keeps today's grid-first behavior
+  unchanged.
+- **`initState` seeds `_activeVideoIndex` from it.** The field stays mutable and
+  every existing transition — selecting a grid item, backing out to the grid —
+  is untouched, so back from playback still lands on the grid rather than
+  leaving the screen.
+- **An out-of-range or negative value falls back to the grid** rather than
+  throwing. The existing guard at line 265 already discards an index past the
+  loaded video count; the constructor value goes through the same path, which
+  matters because the list can name a part whose video fails to load.
+- **`CuratedListByAuthorScreen` forwards it** from an optional `play` query
+  parameter on `/list/:pubkey/:listId`, parsed with `int.tryParse` so a
+  malformed value degrades to the grid instead of failing the route. This keeps
+  the entry point a plain deep link, so a shared series URL can also open at a
+  part.
+- **`SeriesChip` navigates to** `CuratedListByAuthorScreen.pathFor(...)` with
+  `play=0`.
+
 The existing list route, deep link, sharing, loading, and missing-video behavior
-are reused. Version 1 adds no previous/next overlay buttons and no new series
+are otherwise reused. Version 1 adds no previous/next overlay buttons and no new series
 screen. Existing list discovery may show a series as a normal public list; no
 special discovery treatment is added.
 
@@ -193,7 +274,7 @@ part 1; the viewer swipes or auto-advances through the remaining parts.
 
 | Failure | Behavior |
 |---|---|
-| Series creation fails | Do not start the video publish. Keep the metadata state and offer retry or cancel. |
+| Series creation fails (`createSeries` returns `null`, i.e. no relay accepted the list, or the user is unauthenticated) | Do not start the video publish. Keep the metadata state and offer retry or cancel. |
 | Video publish fails | Do not append the part. The background retry retains the selected series coordinate. |
 | Video succeeds but list relay publish fails | Keep the locally appended part and the existing pending-republish state; remote viewers see no chip until the list update reaches a relay. |
 | Series list is missing or deleted | Render no chip. The video remains an ordinary playable video. |
@@ -205,16 +286,25 @@ part 1; the viewer swipes or auto-advances through the remaining parts.
 - `models`: `CuratedList.isSeries` and `VideoEvent.seriesCoordinate` JSON,
   `copyWith`, equality, tag parsing, and marked-versus-unmarked `a` tags.
 - `curated_list_repository`: series marker round-trip, exact-coordinate fetch,
-  replaceable-event winner selection, validation, and caching.
+  replaceable-event winner selection, validation, and caching. Cache freshness
+  specifically: a read inside the TTL does not refetch, a read past it does, a
+  cached negative membership refetches before suppressing the UI, a local
+  mutation evicts synchronously, and a higher-`created_at` event arriving on a
+  subscription replaces the entry.
 - `CuratedListService`: `createSeries` invariants and append behavior using a
-  full kind-34236 coordinate.
+  full kind-34236 coordinate, including that it forces `isPublic: true`, fails
+  closed when unauthenticated, and returns `null` when no relay accepts the
+  list.
 - Publish: selected series is retained in the draft, the marked tag is signed,
   append happens only after successful video publication, and failed list
   publication retains retry state.
 - `VideoSeriesCubit`: absent/malformed coordinate, missing list, wrong owner,
   missing membership, and valid index.
 - Widget: chip copy, no chip for ordinary or invalid videos, numbered series
-  grid, and chip navigation starts playback at part 1.
+  grid, and chip navigation starts playback at part 1. Also that
+  `initialVideoIndex: null` still opens the grid, that an out-of-range value
+  falls back to the grid, and that backing out of seeded playback lands on the
+  grid.
 - Localization: mirror new keys into every `app_*.arb` locale or record known
   untranslated debt, then run the ARB consistency test.
 - Visual verification: run the existing golden verification workflow and

--- a/docs/superpowers/specs/2026-08-22-video-series-design.md
+++ b/docs/superpowers/specs/2026-08-22-video-series-design.md
@@ -1,255 +1,233 @@
 # Video Series — Design
 
 Date: 2026-08-22
-Status: Approved design, pending implementation plan
+Status: Revised design, pending review
 
 ## Problem
 
-A creator has a story that doesn't fit in one 6-second loop. Today they post
-part 1, part 2, and part 3 as three unrelated videos. A viewer who meets part 3
-in the feed has no way to know parts 1 and 2 exist, and no way to watch them in
-order.
+A creator has a story that does not fit in one 6-second loop. Today they post
+part 1, part 2, and part 3 as unrelated videos. A viewer who meets part 3 in a
+feed cannot tell that earlier parts exist or watch the story in order.
 
-Series makes that ordering explicit: a viewer sees "Part 3 of 10", can jump to
-the start, and can walk forward and back through the parts.
+The first release needs one complete loop: a creator publishes a new video into
+a named series, and a viewer can identify the part and start the series from
+part 1.
 
-## Non-goals
+## Scope
 
-- Series containing other people's videos. Curating other creators' work is the
-  existing curated-list feature and stays there.
-- A dedicated Discover surface for series, series cards on profile, or
-  "start from part 1" entry points. Deferred until series exist in the wild.
-- Any new Nostr event kind.
+Version 1 includes:
 
-## Data model
+- Creating or selecting one of the creator's series while publishing a video.
+- Appending each successfully published video to that series.
+- Showing `Part 3 of 10 · Series name` on a series video.
+- Opening the existing curated-list feed at part 1 from that label.
+- Showing part numbers in the existing curated-list grid.
+- Swiping through the ordered parts with the existing fullscreen list player.
 
-A series is a **kind 30005 curated video list** with `playorder=manual`. The
-existing `curated_list_repository` package already models, converts, publishes,
-and deep-links these lists; series reuse all of it.
+Version 1 does not include:
 
-Two additions:
+- Assigning already-published videos to a series.
+- Removing or reordering parts.
+- Splitting a long recording into several posts or batch publishing.
+- Encoding series order as a NIP-22 reply chain.
+- A dedicated series discovery surface, profile section, or series card.
+- Collaborative series or series containing another creator's videos.
+- A new Nostr event kind.
 
-**On the list event (kind 30005):**
+These are separate product problems. They should be reconsidered after the
+publish-and-watch loop has real usage rather than built speculatively.
 
-```
+## Protocol and data model
+
+### Series list
+
+A series is a public kind-30005 curated video list with manual play order. It
+uses the existing list fields and adds one marker:
+
+```text
 ["series", "true"]
 ```
 
-Marks the list as a series so ordinary curated lists stay ordinary in Discover
-and in list UI. Part order is the existing `a`-tag order under
-`playorder=manual` — no separate order field on the list.
+Each part is an existing ordered `a` tag containing the part's kind-34236
+coordinate. The list order is the only source of truth for part number and
+total count.
 
-**On each part (kind 34236, the creator's own video):**
+Series created by Divine are non-collaborative and public. When reading a
+series, the app only accepts kind-34236 coordinates whose embedded author
+matches the list author. Malformed or foreign-author entries are ignored.
 
+### Video reference
+
+Each newly published series video carries a marked reference to the list:
+
+```text
+["a", "30005:<creator_pubkey>:<series_d_tag>", "", "series"]
 ```
-["a", "30005:<owner_pubkey>:<series_d_tag>"]
-["part", "3"]
+
+The `series` marker distinguishes this reference from inspired-by, reply, and
+other `a` tags already used on video events. The creator pubkey in the
+coordinate must match the video author.
+
+There is deliberately no `part` tag. Rendering `Part 3 of 10` already requires
+the list for its name and total, so a second copy of the index only creates
+stale state. There are also no reply tags: a reply chain would duplicate order,
+change comment semantics, and require filtering work unrelated to the core
+feature.
+
+If the referenced list is missing, is not marked as a series, does not contain
+the video's addressable coordinate, or has a different owner, the video is
+treated as an ordinary video and no series UI is shown.
+
+## Architecture
+
+### Models and conversion
+
+- Add `isSeries` to `CuratedList` and persist it through JSON serialization,
+  `copyWith`, equality, and `CuratedListConverter` event conversion.
+- Add a nullable `seriesCoordinate` to `VideoEvent`. Parse only an `a` tag with
+  the `series` marker and persist the value through JSON serialization and
+  `copyWith` so cached REST and relay videos behave the same.
+- Preserve the full coordinate everywhere. Nostr identifiers are never
+  truncated.
+
+### Existing list mutation path
+
+Keep kind-30005 writes in `CuratedListService`, where list creation, local
+persistence, serialized mutation, relay publication, and retry state already
+live. Version 1 adds only:
+
+- `createSeries(name)`, which creates a public, non-collaborative manual list
+  with the series marker.
+- Appending a published video's addressable coordinate through the existing
+  list-mutation path.
+
+Do not move all list CRUD into `curated_list_repository` as part of this
+feature. That package is currently a read-oriented bridge, and completing the
+larger Riverpod-to-repository migration is unrelated scope.
+
+### Series lookup
+
+Add one exact-coordinate fetch to `CuratedListRepository`, backed by its
+existing `NostrClient`: query kind 30005 by author and `d` tag, apply
+replaceable-event ordering, validate `isSeries`, and cache the result by full
+coordinate for the session. This supports videos encountered anywhere without
+a broad `#a` scan.
+
+`VideoSeriesCubit` is the only new state-management unit. Given a `VideoEvent`,
+it:
+
+1. Returns no series state when `seriesCoordinate` is absent or malformed.
+2. Loads the exact list through `CuratedListRepository`.
+3. Validates matching ownership and membership.
+4. Exposes the list and the video's zero-based index.
+
+There is no separate `SeriesBloc`; the existing curated-list providers and
+fullscreen player already own list loading and playback.
+
+### Publish flow
+
+The metadata screen adds an optional series picker containing the creator's
+series and `New series…`. Creating a series asks only for a name. The selected
+full series coordinate is stored in the publish draft/background-upload state
+so retries do not lose it.
+
+At publish time:
+
+1. If a new series was requested, create its empty kind-30005 event first. A
+   creation failure keeps the user on the metadata screen with retry and cancel
+   actions.
+2. Sign and publish the video with the marked series `a` tag.
+3. After the video publish succeeds, append its stable kind-34236 coordinate to
+   the list through `CuratedListService`.
+
+The operations are intentionally not described as atomic; Nostr cannot provide
+that guarantee. The existing list mutation path persists a failed relay update
+locally and marks it for republish. A failed video publish does not append a
+part, and its background retry retains the series selection.
+
+Generic `Add to list` UI excludes series in version 1 because adding a video to
+only the list would not add the required marked tag to an already-published
+video.
+
+### UI and routing
+
+`SeriesChip` is app-level UI built from `divine_ui` primitives because its copy
+is localized. It renders only from a loaded `VideoSeriesCubit` state and reads:
+
+```text
+Part 3 of 10 · Series name
 ```
 
-`part` is the 1-based position. It exists so a video can render its own chip
-without first fetching the list. **The list is authoritative for order.** If the
-two disagree — the owner reordered parts after publishing — the list wins and
-the chip renders from list position.
+Tapping it opens the existing author/list route and starts
+`CuratedListFeedScreen` playback at index 0. The series mode of that screen adds
+part numbers to grid items; playback remains
+`PooledFullscreenVideoFeedScreen` with the list's existing order. Swipe and
+auto-advance behavior remain unchanged.
 
-**Parts also chain as video replies.** Every part after the first publishes as a
-NIP-22 video reply, root (`E`/`A`/`K`) pointing at part 1 and parent
-(`e`/`a`/`k`) at part N-1 — the same tag shape `comments_repository` already
-builds for video replies. This is free continuity: the chain renders as a thread
-in any Nostr client, and `VideoReplyParentLink` already shows the parent link in
-this app with no new work.
-
-The chain is a second, redundant expression of the order. The list stays
-authoritative: it survives a deleted part, supports reorder without re-parenting
-videos, and answers "of 10" in one fetch, none of which a chain does. When the
-two disagree, the list wins.
-
-### Series parts are not comments
-
-Because parts reply to part 1, they would otherwise appear as comments on it — a
-10-part series reading as 9 comments. The comments list filters out a video
-reply when it is authored by the root video's author *and* carries the root's
-series coordinate. Those are series parts, surfaced by the series UI, not the
-comment thread. Video replies from anyone else, and the author's own video
-replies that are not series parts, are unaffected.
-
-### Why tags on the video
-
-Tagging the video gives reverse lookup for free: a video met anywhere (main
-feed, profile, hashtag, deep link) already names its series, so the chip needs
-one addressable fetch of the list, cached, and no `#a` scan or server index.
-
-Two alternatives were considered and folded in or rejected:
-
-- **Prev/next tags with no list object** — rejected. Linking part N to part N+1
-  means republishing part N *after* N+1 exists: one edit per link, and a single
-  failed edit breaks the chain with nothing holding the truth.
-- **Reply chain only** (part N is a video reply to part N-1, no list) — folded
-  in as the redundant layer rather than adopted alone. It costs nothing and
-  reads natively as a thread, but on its own it can't answer "of 10" without
-  walking every hop, branches ambiguously if the author posts two video replies
-  to one part, snaps when a middle part is deleted, and needs re-parenting edits
-  to reorder.
-
-### Membership
-
-Own videos only. A creator can only sign their own events, so a series built
-from someone else's videos would have untagged parts and no chip. Series is a
-creator's own multi-part story; curating others stays the curated-list feature.
-
-### Edit path
-
-Assigning an already-published video to a series republishes its kind 34236
-event. The repo has a known bug where `published_at` goes null on edit and the
-publication date is permanently rewritten. That path must preserve every
-original tag verbatim, `published_at` included. This is a hard blocker for the
-feature, covered by a regression test — not worked around.
-
-## Components
-
-### Package: `curated_list_repository`
-
-- `isSeries` on `CuratedList`, round-tripped through the converter's tag
-  read/write.
-- `createSeries()`.
-- `reorderParts(listId, from, to)` — rewrites `a`-tag order and republishes the
-  30005 event. No video edits.
-- `seriesForVideo(videoCoordinate)` — resolves a video's series `a` tag to the
-  list, cached.
-
-### Publish path
-
-The existing publish/metadata flow gains a series field. The picked series
-coordinate and computed part index are written into the kind 34236 tags at sign
-time, so first-publish assignment never involves an edit. When the series
-already has parts, the same sign step adds the NIP-22 root and parent tags,
-reusing the tag builder in `comments_repository`.
-
-### Comments list
-
-`comments_list_bloc` drops video replies that are authored by the root video's
-author and carry the root's series coordinate, so series parts stay out of the
-comment thread. Everything else about comments is untouched.
-
-### BLoC: `mobile/lib/features/series/bloc/`
-
-- `SeriesBloc` — loads a series and its ordered parts, owns `currentIndex`,
-  exposes `hasPrev` / `hasNext`. Drives both the series screen and the player
-  chrome.
-- `VideoSeriesChipCubit` — per video: resolves the series `a` tag to a name and
-  a part position. Emits nothing when the video carries no series tag, so the
-  chip never renders on ordinary videos.
-
-### UI
-
-- `SeriesChip` — renders `Part 3 of 10 · Series name`, tappable, opens the
-  series. App-level (not `divine_ui`) because it needs l10n; built from
-  `divine_ui` primitives.
-- Prev / next `DivineIconButton`s beside the chip in the fullscreen overlay,
-  shown only while a series is active.
-- Series screen — the existing `CuratedListFeedScreen` in a series mode:
-  numbered parts, drag-to-reorder for the owner, viewer-only for everyone else.
-- "Add to series" in the existing video menu; series picker in the publish
-  metadata screen.
-
-### Reused as-is
-
-Playback stays `PooledFullscreenVideoFeedScreen`, fed a series-ordered video
-list. Auto-advance inherits the user's existing feed setting — no new toggle,
-no new policy. Sharing, deep links, and list CRUD already exist.
+The existing list route, deep link, sharing, loading, and missing-video behavior
+are reused. Version 1 adds no previous/next overlay buttons and no new series
+screen. Existing list discovery may show a series as a normal public list; no
+special discovery treatment is added.
 
 ## User flows
 
-**Publish, series doesn't exist yet.** Metadata screen → "Part of a series" →
-picker lists your series plus "New series…" → name it → the 30005 list is
-created and the video is tagged part 1, in one submit.
+### Publish into a new series
 
-**Publish, series exists.** Pick the series; the video is tagged with the next
-part number (highest existing part + 1).
+Metadata → `Part of a series` → `New series…` → enter a name → publish. The app
+creates the empty series, publishes the tagged video, then appends the video's
+coordinate as part 1.
 
-**Retroactive.** Two ways into the same sheet: the video's own menu
-("Add to series"), or "Add videos" from inside a series — a grid of the
-creator's own videos, multi-select, ordered by pick order. This is the edit
-path described above.
+### Publish the next part
 
-**Reorder / remove.** Owner sees numbered parts with drag handles on the series
-screen. Reordering republishes only the 30005 list. Videos' `part` tags go
-stale, which is expected: the list is authoritative and the chip renders from
-list position. Removing a part never blocks — a video pointing at a series that
-no longer lists it simply shows no chip.
+Metadata → `Part of a series` → choose an existing series → publish. After the
+video succeeds, its coordinate is appended and its position is derived from the
+updated list.
 
-**Viewer.** Meets part 3 in the feed → chip reads `Part 3 of 10 · Name`. Tap
-the chip for the series screen numbered from part 1, or use prev/next to walk
-the series without leaving the player.
+### Watch
 
-**Someone else's series.** Chip, prev/next, series screen, share. No add, no
-reorder.
-
-## Long-record → series
-
-The strongest entry point, and new capability rather than a wire-up.
-
-Record or import a long clip → the editor offers "Split into a series" → cut
-points default to roughly every 6 seconds and are draggable → name the series →
-export N segments → publish N videos, each tagged with the series coordinate
-and its part index, in order.
-
-What this requires that does not exist today:
-
-- The editor accepting a source longer than `VideoEditorConstants.maxDuration`
-  (6.3s) in series mode. That cap is a hard invariant today; series mode carves
-  an explicit exception.
-- N sequential exports through `VideoEditorRenderService`, with progress UI.
-- Batch publish with partial-failure handling. The series list publishes first;
-  each part publishes independently; failures fall into the existing
-  background-upload retry path. A series with gaps renders the parts that
-  exist and never blocks.
-- Segment preview and adjustment before committing.
-
-`VideoEditorSplitService` is not reusable directly — it splits within a single
-video's timeline (trim-based, both halves stay one post). Its split-position
-validation math is reusable; the segment-to-separate-post pipeline is new.
-
-This is roughly as much work as the rest of the design combined. It ships in
-v1 by decision.
+A viewer meets part 3 in any feed. Once the referenced list resolves, the chip
+reads `Part 3 of 10 · Series name`. Tapping it starts the existing list player at
+part 1; the viewer swipes or auto-advances through the remaining parts.
 
 ## Failure handling
 
 | Failure | Behavior |
 |---|---|
-| Part published, list republish fails | Video carries the series tag, list lacks the part. Chip resolves the list, finds no part, renders nothing. Retried on next series open. |
-| List published, parts fail to upload | Series exists with gaps. Landed parts render; failed parts sit in the existing background-upload retry queue. |
-| Retro-assign edit drops `published_at` | Hard blocker. Republish preserves all original tags verbatim; regression test asserts `published_at` survives. |
-| Part deleted (kind 5) | Remaining parts render, renumbered from list position. |
-| Series list deleted, videos still tagged | Chip resolves nothing and renders nothing. Never an error state. |
-| Middle part deleted, breaking the reply chain | List renumbers and playback continues; the chain is redundant, so a snapped link is cosmetic. Later parts keep pointing at a deleted parent and their parent link renders nothing. |
-| Retro-assigned part has no reply tags | Expected. Videos assigned after publish keep their original threading; only the list places them. The chain is best-effort, the list is complete. |
-| Segment export fails mid-batch | Already-exported segments keep their queued uploads; the failed segment retries without redoing the others. |
+| Series creation fails | Do not start the video publish. Keep the metadata state and offer retry or cancel. |
+| Video publish fails | Do not append the part. The background retry retains the selected series coordinate. |
+| Video succeeds but list relay publish fails | Keep the locally appended part and the existing pending-republish state; remote viewers see no chip until the list update reaches a relay. |
+| Series list is missing or deleted | Render no chip. The video remains an ordinary playable video. |
+| Video tag and list membership disagree | The list wins. Render no chip until the list contains the video's coordinate. |
+| A listed video cannot be loaded | Omit it from the grid/player without rewriting the list. Part numbers still come from the authoritative list order and may contain a gap. |
 
 ## Testing
 
-- **Package** (`curated_list_repository`, 100% coverage gate): converter
-  round-trip for the `series` tag, `orderedVideoIds` under manual order,
-  reorder republish, `seriesForVideo` resolution and caching.
-- **BLoC**: `SeriesBloc` load, prev/next, boundary behavior;
-  `VideoSeriesChipCubit` emits nothing for untagged videos; list position wins
-  over a stale `part` tag.
-- **Widget**: chip renders `Part 3 of 10`; prev disabled at part 1; next
-  disabled at the last part; no chip on ordinary videos; l10n delegates wired.
-- **Publish**: tags written on first publish; part N carries NIP-22 root at
-  part 1 and parent at part N-1; retro-assign preserves `published_at` and
-  every prior tag and adds no reply tags.
-- **Comments**: a series part does not appear in the root video's comment
-  thread; a non-series video reply from the same author still does.
-- **Editor**: split-point math, N-segment export, partial-failure recovery.
-- **Golden**: chip in the fullscreen overlay.
+- `models`: `CuratedList.isSeries` and `VideoEvent.seriesCoordinate` JSON,
+  `copyWith`, equality, tag parsing, and marked-versus-unmarked `a` tags.
+- `curated_list_repository`: series marker round-trip, exact-coordinate fetch,
+  replaceable-event winner selection, validation, and caching.
+- `CuratedListService`: `createSeries` invariants and append behavior using a
+  full kind-34236 coordinate.
+- Publish: selected series is retained in the draft, the marked tag is signed,
+  append happens only after successful video publication, and failed list
+  publication retains retry state.
+- `VideoSeriesCubit`: absent/malformed coordinate, missing list, wrong owner,
+  missing membership, and valid index.
+- Widget: chip copy, no chip for ordinary or invalid videos, numbered series
+  grid, and chip navigation starts playback at part 1.
+- Localization: mirror new keys into every `app_*.arb` locale or record known
+  untranslated debt, then run the ARB consistency test.
+- Visual verification: run the existing golden verification workflow and
+  update only goldens affected by the chip or numbered grid.
 
-All new copy goes through `context.l10n`, with keys mirrored into every
-`app_*.arb` locale or recorded as known untranslated debt.
+## Acceptance criteria
 
-## Delivery note
-
-Series core and the editor split flow are dependent, so they either combine
-into one PR or the core merges to `main` first and the split flow follows as a
-second PR branched from fresh `main`. The second form is not stacking and keeps
-review tractable. This is a plan-level decision, resolved in the
-implementation plan rather than here.
+- A creator can create or select a series while publishing a new video.
+- A successfully published part appears once at the end of the series list.
+- A series video encountered outside the series resolves to the correct name,
+  position, and total without scanning all lists.
+- Tapping the chip starts the ordered series at part 1.
+- Ordinary videos and inconsistent or unavailable series data show no series
+  UI and continue to play normally.
+- No reply/comment behavior, existing-video republish flow, editor duration
+  rules, or batch uploader is changed by version 1.

--- a/docs/superpowers/specs/2026-08-22-video-series-design.md
+++ b/docs/superpowers/specs/2026-08-22-video-series-design.md
@@ -115,35 +115,42 @@ scan.
 
 #### Cache freshness contract
 
-A series list is a replaceable event, so a session-long cache would freeze it.
+A series list is remote-derived cacheable data, so the exact-coordinate lookup
+uses the existing `cache_sync` package rather than introducing a feature-local
+cache. A session-long entry would freeze a replaceable event.
 A viewer who cached parts 1-3 would keep reading `of 3` for the rest of the
 session, and a newly published part 4 would fail membership validation and show
 no series UI at all — the feature silently disappearing on exactly the video
 that motivated it. The cache is therefore bounded:
 
-- **Entries carry a fetch timestamp and a 60-second TTL.** A read older than
-  that refetches before answering. 60 seconds is chosen so a creator publishing
-  consecutive parts sees the count move without a restart, while a viewer
-  scrolling a feed of one series' parts still gets one fetch, not one per video.
+- **`cache_sync` entries use a 60-second TTL.** The stable cache key contains
+  the full list owner pubkey and d-tag. A read older than the TTL refetches
+  before answering. 60 seconds is chosen so a creator publishing consecutive
+  parts sees the count move without a restart, while a viewer scrolling a feed
+  of one series' parts still gets one fetch, not one per video.
 - **A negative membership result is never served from cache.** If the cached
-  list does not contain the video's coordinate, refetch once before concluding
-  the video is not a member. Only a fresh miss suppresses the series UI. This is
-  the rule that keeps a just-published part from rendering as an ordinary video;
-  everything else here is an optimization, this one is correctness.
-- **Local mutation invalidates immediately.** `createSeries` and the append path
-  in `CuratedListService` evict the affected coordinate synchronously, before
-  their futures complete, so the publishing creator never reads their own stale
-  list.
-- **A newer replaceable event wins on arrival.** If any live subscription
-  delivers a kind-30005 event for a cached coordinate with a higher `created_at`
-  (ties broken by lower event id, matching the replaceable-event ordering
-  already applied on fetch), it replaces the entry rather than waiting for the
-  TTL.
+  list does not contain the video's coordinate, the repository awaits
+  `CacheSync.invalidate(key)` and performs one exact-coordinate relay fetch
+  before concluding that the video is not a member. Only that fresh miss
+  suppresses the series UI. This is the rule that keeps a just-published part
+  from rendering as an ordinary video; everything else here is an optimization,
+  this one is correctness.
+- **Local mutation invalidation is awaited.** After `createSeries` or the append
+  path commits a local mutation, it awaits `CacheSync.invalidate(key)` before
+  its future completes. Callers therefore cannot observe the old entry after an
+  awaited mutation. `CacheSync.invalidate` is Drift-backed and asynchronous;
+  read-your-write ordering, not a literally synchronous eviction API, is the
+  required guarantee.
 
-Staleness that survives all four is bounded to 60 seconds on the total, and to
-zero on membership. `Part 3 of 9` briefly reading `of 8` is acceptable; `no
-series UI` for a valid part is not, which is why only the count is allowed to
-lag.
+Version 1 deliberately adds no second live kind-30005 subscription. The
+existing subscription is owned by `CuratedListService` and covers the signed-in
+user's lists; coupling it into the read-oriented repository, or adding another
+subscription there, would create ownership and lifecycle work that the TTL,
+awaited local invalidation, and fresh-on-negative rule do not require.
+
+Remote total-count staleness is bounded to 60 seconds and membership staleness
+to one forced relay fetch. `Part 3 of 9` briefly reading `of 8` is acceptable;
+`no series UI` for a valid part after a successful fresh fetch is not.
 
 `VideoSeriesCubit` is the only new state-management unit. Given a `VideoEvent`,
 it:
@@ -151,7 +158,7 @@ it:
 1. Returns no series state when `seriesCoordinate` is absent or malformed.
 2. Loads the exact list through `CuratedListRepository`.
 3. Validates matching ownership and membership.
-4. Exposes the list and the video's zero-based index.
+4. Exposes the list and the video's zero-based authoritative list position.
 
 There is no separate `SeriesBloc`; the existing curated-list providers and
 fullscreen player already own list loading and playback.
@@ -169,22 +176,22 @@ At publish time:
    do not begin the video publish until a relay has accepted it. A creation
    failure keeps the user on the metadata screen with retry and cancel actions.
 
-   The existing `CuratedListService.createList()` already provides this proof
-   and needs no new API. For a public list by an authenticated user it calls
-   `_publishListToNostr(newList, confirmed: true)`, which awaits
-   `publishEventAwaitOk` and treats `outcome.acceptedByAny` as the bar; on
-   failure it removes the local list, re-saves, and returns `null`
-   (`mobile/lib/services/curated_list_service.dart:273-280`, `1135-1148`). The
-   publication result is not discarded — a non-null return **is** the
-   relay-acceptance proof.
+   Generic `CuratedListService.createList()` does **not** provide this proof and
+   its offline behavior must remain unchanged. It deliberately keeps a local
+   list when no relay is reachable: `_createList` awaits
+   `_publishListToNostr(current, confirmed: true)` but discards the returned
+   boolean, then returns the retained list. Private lists publish too, with
+   sealed items; `isPublic` is a series visibility requirement, not a condition
+   that makes publication happen.
 
-   Two conditions are load-bearing, and `createSeries` must enforce both rather
-   than inherit them by luck: the list must be `isPublic: true`, and the user
-   must be authenticated. When either is false the publish is skipped entirely
-   and a local-only list is returned — which for a series would mean a creator
-   builds parts against a list no viewer can resolve. `createSeries` therefore
-   fixes `isPublic: true` and fails closed when unauthenticated, and the publish
-   flow treats a `null` return as the creation failure above.
+   `createSeries` therefore has a series-specific confirmed-creation contract.
+   It returns an explicit result with `success(list)`, `unauthenticated`, and
+   `relayRejected` outcomes. It creates a public, non-collaborative manual list,
+   awaits the confirmed publish result, and returns `success` only when
+   `acceptedByAny` is true. On signing failure or relay rejection it removes the
+   provisional local list and persists that removal before returning
+   `relayRejected`. The publish flow continues to step 2 only for `success`;
+   both failure outcomes keep the metadata state and offer retry or cancel.
 2. Sign and publish the video with the marked series `a` tag.
 3. After the video publish succeeds, append its stable kind-34236 coordinate to
    the list through `CuratedListService`.
@@ -209,10 +216,30 @@ Part 3 of 10 · Series name
 
 Tapping it opens the existing author/list route and starts
 `CuratedListFeedScreen` playback at index 0. That screen cannot do this today,
-so version 1 extends it — see [Playback entry contract](#playback-entry-contract). The series mode of that screen adds
-part numbers to grid items; playback remains
-`PooledFullscreenVideoFeedScreen` with the list's existing order. Swipe and
-auto-advance behavior remain unchanged.
+so version 1 extends it — see [Playback entry contract](#playback-entry-contract).
+The series mode of that screen adds part numbers to grid items; playback remains
+`PooledFullscreenVideoFeedScreen`. Swipe and auto-advance behavior remain
+unchanged after the resolved videos have been restored to authoritative list
+order.
+
+#### Ordered resolution contract
+
+`videoEventsByIdsProvider` does not preserve its input order today: it appends
+cached event ids, then cached addressable coordinates, then relay results in
+arrival order, yielding again as each event arrives. The grid and fullscreen
+player render that emitted order verbatim. Reusing it without an ordering step
+would make `play=0`, displayed part numbers, and swipe order depend on cache and
+relay timing rather than the series list.
+
+Every provider emission used for a curated list must therefore be projected
+back into the order of the requested `videoIds`. Matching uses the full event id
+for ordinary events and the full `34236:<pubkey>:<d-tag>` coordinate for
+addressable videos. Missing or blocked videos are omitted without collapsing
+the authoritative position: UI part numbers come from the matched coordinate's
+zero-based position in `videoIds`, plus one, while the total remains the count
+of valid same-author coordinates in the series list. The grid and player receive
+the same ordered resolved list, so a late arrival inserts at its list position
+rather than at the end.
 
 #### Playback entry contract
 
@@ -226,24 +253,30 @@ therefore requires a screen change, not just navigation.
 
 Version 1 adds:
 
-- **`final int? initialVideoIndex;`** to `CuratedListFeedScreen`, defaulting to
+- **`final int? initialListIndex;`** to `CuratedListFeedScreen`, defaulting to
   `null` so every existing call site keeps today's grid-first behavior
   unchanged.
-- **`initState` seeds `_activeVideoIndex` from it.** The field stays mutable and
-  every existing transition — selecting a grid item, backing out to the grid —
-  is untouched, so back from playback still lands on the grid rather than
-  leaving the screen.
-- **An out-of-range or negative value falls back to the grid** rather than
-  throwing. The existing guard at line 265 already discards an index past the
-  loaded video count; the constructor value goes through the same path, which
-  matters because the list can name a part whose video fails to load.
-- **`CuratedListByAuthorScreen` forwards it** from an optional `play` query
-  parameter on `/list/:pubkey/:listId`, parsed with `int.tryParse` so a
-  malformed value degrades to the grid instead of failing the route. This keeps
-  the entry point a plain deep link, so a shared series URL can also open at a
-  part.
-- **`SeriesChip` navigates to** `CuratedListByAuthorScreen.pathFor(...)` with
-  `play=0`.
+- **The requested authoritative position stays pending while videos load.** It
+  is not copied directly into `_activeVideoIndex`, because missing videos make
+  an index in the resolved player list different from a position in the source
+  list. Once the video at `videoIds[initialListIndex]` resolves, the screen maps
+  its full id or coordinate to the corresponding index in the ordered resolved
+  list and enters playback there. If that particular video cannot be loaded,
+  the screen stays on the grid rather than silently starting a later part.
+  Loading and error states keep the normal app bar and route-level back
+  affordance. The active-player field stays mutable, so backing out of playback
+  still lands on the grid rather than leaving the screen.
+- **A malformed, negative, or out-of-range value stays on the grid.** The
+  existing player guard is not reused: today it renders a chrome-less
+  `curatedListVideoNotAvailable` dead end for a high index and does not reject a
+  negative index. Version 1 validates before entering video mode instead.
+- **`RoutePaths` owns the query parameter.** Its author/list path builder gains
+  an optional `play` argument and emits the query parameter. The router parses
+  it with `int.tryParse`, and `CuratedListByAuthorScreen` only forwards the
+  nullable parsed value; screen `pathFor` methods remain thin `RoutePaths`
+  delegates.
+- **`SeriesChip` navigates through `RoutePaths` with `play: 0`.** This keeps the
+  entry point a plain deep link, so a shared series URL can also open at a part.
 
 The existing list route, deep link, sharing, loading, and missing-video behavior
 are otherwise reused. Version 1 adds no previous/next overlay buttons and no new series
@@ -274,7 +307,7 @@ part 1; the viewer swipes or auto-advances through the remaining parts.
 
 | Failure | Behavior |
 |---|---|
-| Series creation fails (`createSeries` returns `null`, i.e. no relay accepted the list, or the user is unauthenticated) | Do not start the video publish. Keep the metadata state and offer retry or cancel. |
+| Series creation is unauthenticated or no relay accepts it | `createSeries` returns the corresponding non-success result. Remove any provisional list, do not start the video publish, keep the metadata state, and offer retry or cancel. |
 | Video publish fails | Do not append the part. The background retry retains the selected series coordinate. |
 | Video succeeds but list relay publish fails | Keep the locally appended part and the existing pending-republish state; remote viewers see no chip until the list update reaches a relay. |
 | Series list is missing or deleted | Render no chip. The video remains an ordinary playable video. |
@@ -286,25 +319,28 @@ part 1; the viewer swipes or auto-advances through the remaining parts.
 - `models`: `CuratedList.isSeries` and `VideoEvent.seriesCoordinate` JSON,
   `copyWith`, equality, tag parsing, and marked-versus-unmarked `a` tags.
 - `curated_list_repository`: series marker round-trip, exact-coordinate fetch,
-  replaceable-event winner selection, validation, and caching. Cache freshness
-  specifically: a read inside the TTL does not refetch, a read past it does, a
-  cached negative membership refetches before suppressing the UI, a local
-  mutation evicts synchronously, and a higher-`created_at` event arriving on a
-  subscription replaces the entry.
+  replaceable-event winner selection, validation, and `cache_sync` caching.
+  Cache freshness specifically: a read inside the TTL does not refetch, a read
+  past it does, a cached negative membership invalidates and refetches before
+  suppressing the UI, and an awaited local mutation does not complete until
+  invalidation completes.
 - `CuratedListService`: `createSeries` invariants and append behavior using a
-  full kind-34236 coordinate, including that it forces `isPublic: true`, fails
-  closed when unauthenticated, and returns `null` when no relay accepts the
-  list.
+  full kind-34236 coordinate, including its explicit success,
+  unauthenticated, and relay-rejected outcomes, provisional-list rollback, and
+  the fact that generic `createList` retains its existing offline semantics.
 - Publish: selected series is retained in the draft, the marked tag is signed,
   append happens only after successful video publication, and failed list
   publication retains retry state.
 - `VideoSeriesCubit`: absent/malformed coordinate, missing list, wrong owner,
   missing membership, and valid index.
 - Widget: chip copy, no chip for ordinary or invalid videos, numbered series
-  grid, and chip navigation starts playback at part 1. Also that
-  `initialVideoIndex: null` still opens the grid, that an out-of-range value
-  falls back to the grid, and that backing out of seeded playback lands on the
-  grid.
+  grid, and chip navigation starts playback at part 1. Cover mixed cache/relay
+  arrival, late insertion, and missing-video gaps to prove that grid numbering,
+  playback start, and swipe order follow `videoIds`; also cover that
+  `initialListIndex: null` still opens the grid, malformed/negative/out-of-range
+  values stay on the grid, an unavailable requested part does not substitute a
+  later part, loading retains a back affordance, and backing out of seeded
+  playback lands on the grid.
 - Localization: mirror new keys into every `app_*.arb` locale or record known
   untranslated debt, then run the ARB consistency test.
 - Visual verification: run the existing golden verification workflow and

--- a/docs/superpowers/specs/2026-08-22-video-series-design.md
+++ b/docs/superpowers/specs/2026-08-22-video-series-design.md
@@ -51,16 +51,44 @@ without first fetching the list. **The list is authoritative for order.** If the
 two disagree — the owner reordered parts after publishing — the list wins and
 the chip renders from list position.
 
+**Parts also chain as video replies.** Every part after the first publishes as a
+NIP-22 video reply, root (`E`/`A`/`K`) pointing at part 1 and parent
+(`e`/`a`/`k`) at part N-1 — the same tag shape `comments_repository` already
+builds for video replies. This is free continuity: the chain renders as a thread
+in any Nostr client, and `VideoReplyParentLink` already shows the parent link in
+this app with no new work.
+
+The chain is a second, redundant expression of the order. The list stays
+authoritative: it survives a deleted part, supports reorder without re-parenting
+videos, and answers "of 10" in one fetch, none of which a chain does. When the
+two disagree, the list wins.
+
+### Series parts are not comments
+
+Because parts reply to part 1, they would otherwise appear as comments on it — a
+10-part series reading as 9 comments. The comments list filters out a video
+reply when it is authored by the root video's author *and* carries the root's
+series coordinate. Those are series parts, surfaced by the series UI, not the
+comment thread. Video replies from anyone else, and the author's own video
+replies that are not series parts, are unaffected.
+
 ### Why tags on the video
 
 Tagging the video gives reverse lookup for free: a video met anywhere (main
 feed, profile, hashtag, deep link) already names its series, so the chip needs
 one addressable fetch of the list, cached, and no `#a` scan or server index.
 
-The alternative considered — prev/next tags chaining videos with no list object
-— was rejected: linking part N to part N+1 requires republishing part N *after*
-N+1 exists, which is one edit per link, and a single failed edit breaks the
-chain with no object holding the truth.
+Two alternatives were considered and folded in or rejected:
+
+- **Prev/next tags with no list object** — rejected. Linking part N to part N+1
+  means republishing part N *after* N+1 exists: one edit per link, and a single
+  failed edit breaks the chain with nothing holding the truth.
+- **Reply chain only** (part N is a video reply to part N-1, no list) — folded
+  in as the redundant layer rather than adopted alone. It costs nothing and
+  reads natively as a thread, but on its own it can't answer "of 10" without
+  walking every hop, branches ambiguously if the author posts two video replies
+  to one part, snaps when a middle part is deleted, and needs re-parenting edits
+  to reorder.
 
 ### Membership
 
@@ -92,7 +120,15 @@ feature, covered by a regression test — not worked around.
 
 The existing publish/metadata flow gains a series field. The picked series
 coordinate and computed part index are written into the kind 34236 tags at sign
-time, so first-publish assignment never involves an edit.
+time, so first-publish assignment never involves an edit. When the series
+already has parts, the same sign step adds the NIP-22 root and parent tags,
+reusing the tag builder in `comments_repository`.
+
+### Comments list
+
+`comments_list_bloc` drops video replies that are authored by the root video's
+author and carry the root's series coordinate, so series parts stay out of the
+comment thread. Everything else about comments is untouched.
 
 ### BLoC: `mobile/lib/features/series/bloc/`
 
@@ -185,6 +221,8 @@ v1 by decision.
 | Retro-assign edit drops `published_at` | Hard blocker. Republish preserves all original tags verbatim; regression test asserts `published_at` survives. |
 | Part deleted (kind 5) | Remaining parts render, renumbered from list position. |
 | Series list deleted, videos still tagged | Chip resolves nothing and renders nothing. Never an error state. |
+| Middle part deleted, breaking the reply chain | List renumbers and playback continues; the chain is redundant, so a snapped link is cosmetic. Later parts keep pointing at a deleted parent and their parent link renders nothing. |
+| Retro-assigned part has no reply tags | Expected. Videos assigned after publish keep their original threading; only the list places them. The chain is best-effort, the list is complete. |
 | Segment export fails mid-batch | Already-exported segments keep their queued uploads; the failed segment retries without redoing the others. |
 
 ## Testing
@@ -197,8 +235,11 @@ v1 by decision.
   over a stale `part` tag.
 - **Widget**: chip renders `Part 3 of 10`; prev disabled at part 1; next
   disabled at the last part; no chip on ordinary videos; l10n delegates wired.
-- **Publish**: tags written on first publish; retro-assign preserves
-  `published_at` and every prior tag.
+- **Publish**: tags written on first publish; part N carries NIP-22 root at
+  part 1 and parent at part N-1; retro-assign preserves `published_at` and
+  every prior tag and adds no reply tags.
+- **Comments**: a series part does not appear in the root video's comment
+  thread; a non-series video reply from the same author still does.
 - **Editor**: split-point math, N-segment export, partial-failure recovery.
 - **Golden**: chip in the fullscreen overlay.
 


### PR DESCRIPTION
Closes #8056

## Problem

Creators currently publish multi-part stories as unrelated videos, so viewers who encounter a later part cannot identify the earlier parts or watch them in order.

## Why this design

- reuse one public kind-30005 curated list as the authoritative order
- put a marked series coordinate on each new video for exact reverse lookup
- require explicit relay acceptance before publishing the first video
- use cache_sync with a 60-second TTL, awaited local invalidation, and a fresh fetch before treating membership as missing
- restore resolved videos to list order before numbering, playback, or auto-advance
- treat deep-link play positions as authoritative list positions and enter playback only when that exact part resolves

## Deliberately unchanged

Version one does not add reply threading, retroactive assignment, reordering, long-video splitting, batch publishing, collaborative series, a new event kind, or a new playback screen.

## Verification

- git diff --check
- repository pre-push checks (no Dart files changed)
- full design review against current origin/main list creation, cache, provider-ordering, and routing behavior
