### PR TITLE
fix(account): stop implying deletion during startup

### DIFF
--- a/mobile/lib/providers/account_deletion_recovery_providers.dart
+++ b/mobile/lib/providers/account_deletion_recovery_providers.dart
@@ -7,7 +7,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/models/account_deletion_attempt.dart';
 import 'package:openvine/providers/auth_providers.dart';
 import 'package:openvine/providers/environment_provider.dart';
-import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/providers/service_providers.dart';
 import 'package:openvine/repositories/account_deletion_recovery_repository.dart';
 import 'package:openvine/services/auth_service.dart';
@@ -32,7 +31,9 @@ final currentAccountDeletionAttemptProvider =
       if (ref.watch(currentAuthStateProvider) != AuthState.authenticated) {
         return null;
       }
-      if (!ref.watch(nostrSessionProvider).isReadyForActiveClient) {
+      final authService = ref.watch(authServiceProvider);
+      ref.watch(currentAuthRpcCapabilityProvider);
+      if (!authService.canPublishNostrWritesNow) {
         final waitingForReadiness = Completer<AccountDeletionAttempt?>();
         ref.onDispose(waitingForReadiness.complete);
         return waitingForReadiness.future;

--- a/mobile/lib/screens/account_deletion_recovery_screen.dart
+++ b/mobile/lib/screens/account_deletion_recovery_screen.dart
@@ -50,6 +50,9 @@ class AccountDeletionRecoveryView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final hasConfirmedDeletionAttempt = context.select(
+      (AccountDeletionRecoveryCubit cubit) => cubit.state.attempt != null,
+    );
     return BlocListener<
       AccountDeletionRecoveryCubit,
       AccountDeletionRecoveryState
@@ -61,7 +64,11 @@ class AccountDeletionRecoveryView extends StatelessWidget {
       child: Scaffold(
         appBar: AppBar(
           automaticallyImplyLeading: false,
-          title: Text(context.l10n.accountDeletionRecoveryTitle),
+          title: Text(
+            hasConfirmedDeletionAttempt
+                ? context.l10n.accountDeletionRecoveryTitle
+                : context.l10n.minorAccountReviewCheckingStatusTitle,
+          ),
         ),
         body: const SafeArea(
           child: Padding(
@@ -92,7 +99,7 @@ class _RecoveryStateContent extends StatelessWidget {
         child: CircularProgressIndicator(),
       ),
       AccountDeletionRecoveryStatus.loadFailed => _RecoveryContent(
-        body: context.l10n.accountDeletionRecoveryStatusFailed,
+        body: context.l10n.authUnexpectedError,
         actionLabel: context.l10n.commonRetry,
         onPressed: cubit.retry,
         secondaryActionLabel: context.l10n.accountDeletionSignOut,

--- a/mobile/test/providers/account_deletion_recovery_providers_test.dart
+++ b/mobile/test/providers/account_deletion_recovery_providers_test.dart
@@ -4,7 +4,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:nostr_client/nostr_client.dart';
+import 'package:openvine/models/auth_rpc_capability.dart';
 import 'package:openvine/providers/account_deletion_recovery_providers.dart';
 import 'package:openvine/providers/auth_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
@@ -14,46 +14,78 @@ import 'package:openvine/services/auth_service.dart';
 class _MockDeletionRepository extends Mock
     implements AccountDeletionRecoveryRepository {}
 
-class _MockNostrClient extends Mock implements NostrClient {}
+class _MockAuthService extends Mock implements AuthService {}
 
 class _TestNostrSession extends NostrSession {
   @override
   NostrSessionReadiness build() =>
       const NostrSessionReadiness.identityKnown(pubkey: 'user-pubkey');
-
-  void markReady() {
-    final client = _MockNostrClient();
-    when(() => client.hasKeys).thenReturn(true);
-    when(() => client.publicKey).thenReturn('user-pubkey');
-    state = NostrSessionReadiness.nostrReady(
-      pubkey: 'user-pubkey',
-      client: client,
-    );
-  }
 }
 
 void main() {
   group('currentAccountDeletionAttemptProvider', () {
-    test('lookup stays loading until the active client is ready', () async {
+    test(
+      'lookup starts when signing is ready without waiting for relays',
+      () async {
+        final repository = _MockDeletionRepository();
+        final authService = _MockAuthService();
+        when(repository.fetchCurrent).thenAnswer((_) async => null);
+        when(() => authService.canPublishNostrWritesNow).thenReturn(true);
+        final container = ProviderContainer(
+          overrides: [
+            authServiceProvider.overrideWithValue(authService),
+            currentAuthStateProvider.overrideWithValue(AuthState.authenticated),
+            currentAuthRpcCapabilityProvider.overrideWithValue(
+              AuthRpcCapability.unavailable,
+            ),
+            nostrSessionProvider.overrideWith(_TestNostrSession.new),
+            accountDeletionRecoveryRepositoryProvider.overrideWithValue(
+              repository,
+            ),
+          ],
+        );
+        addTearDown(container.dispose);
+        final subscription = container.listen(
+          currentAccountDeletionAttemptProvider,
+          (_, _) {},
+          fireImmediately: true,
+        );
+        addTearDown(subscription.close);
+
+        await container.read(currentAccountDeletionAttemptProvider.future);
+
+        expect(
+          container.read(currentAccountDeletionAttemptProvider).value,
+          isNull,
+        );
+        verify(repository.fetchCurrent).called(1);
+      },
+    );
+
+    test('lookup stays fail-closed while signing is unavailable', () async {
       final repository = _MockDeletionRepository();
-      when(repository.fetchCurrent).thenAnswer((_) async => null);
+      final authService = _MockAuthService();
+      when(() => authService.canPublishNostrWritesNow).thenReturn(false);
       final container = ProviderContainer(
         overrides: [
+          authServiceProvider.overrideWithValue(authService),
           currentAuthStateProvider.overrideWithValue(AuthState.authenticated),
-          nostrSessionProvider.overrideWith(_TestNostrSession.new),
+          currentAuthRpcCapabilityProvider.overrideWithValue(
+            AuthRpcCapability.upgrading,
+          ),
           accountDeletionRecoveryRepositoryProvider.overrideWithValue(
             repository,
           ),
         ],
       );
       addTearDown(container.dispose);
+
       final subscription = container.listen(
         currentAccountDeletionAttemptProvider,
         (_, _) {},
         fireImmediately: true,
       );
       addTearDown(subscription.close);
-
       await Future<void>.delayed(Duration.zero);
 
       expect(
@@ -61,16 +93,6 @@ void main() {
         true,
       );
       verifyNever(repository.fetchCurrent);
-
-      (container.read(nostrSessionProvider.notifier) as _TestNostrSession)
-          .markReady();
-      await container.read(currentAccountDeletionAttemptProvider.future);
-
-      expect(
-        container.read(currentAccountDeletionAttemptProvider).value,
-        isNull,
-      );
-      verify(repository.fetchCurrent).called(1);
     });
   });
 }

--- a/mobile/test/screens/account_deletion_recovery_screen_test.dart
+++ b/mobile/test/screens/account_deletion_recovery_screen_test.dart
@@ -73,6 +73,7 @@ void main() {
       await tester.pumpWidget(_app(cubit));
 
       final l10n = lookupAppLocalizations(const Locale('en'));
+      expect(find.text(l10n.accountDeletionRecoveryTitle), findsOneWidget);
       expect(find.textContaining('reserved for you until'), findsOneWidget);
       await tester.tap(
         find.widgetWithText(DivineButton, l10n.accountDeletionRestoreUsername),
@@ -208,6 +209,15 @@ void main() {
 
       final l10n = lookupAppLocalizations(const Locale('en'));
       expect(
+        find.text(l10n.minorAccountReviewCheckingStatusTitle),
+        findsOneWidget,
+      );
+      expect(
+        find.textContaining(RegExp('delet', caseSensitive: false)),
+        findsNothing,
+      );
+      expect(find.text(l10n.authUnexpectedError), findsOneWidget);
+      expect(
         find.widgetWithText(DivineButton, l10n.commonRetry),
         findsOneWidget,
       );
@@ -219,9 +229,7 @@ void main() {
 
     testWidgets(
       'sign-out failure offers one sign-out retry with generic copy',
-      (
-        tester,
-      ) async {
+      (tester) async {
         when(() => cubit.state).thenReturn(
           const AccountDeletionRecoveryState(
             status: AccountDeletionRecoveryStatus.signOutFailed,
@@ -255,6 +263,14 @@ void main() {
       await tester.pumpWidget(_app(cubit));
 
       final l10n = lookupAppLocalizations(const Locale('en'));
+      expect(
+        find.text(l10n.minorAccountReviewCheckingStatusTitle),
+        findsOneWidget,
+      );
+      expect(
+        find.textContaining(RegExp('delet', caseSensitive: false)),
+        findsNothing,
+      );
       expect(find.byType(CircularProgressIndicator), findsOneWidget);
       await tester.tap(
         find.widgetWithText(DivineButton, l10n.accountDeletionSignOut),


### PR DESCRIPTION
## What changed

Authenticated cold launches could briefly say “Finish deleting your account” even when the user had never requested deletion, and normal startup was blocked for roughly four seconds while relay initialization completed.

Two independent causes are fixed:

- Unconfirmed loading and lookup-error states now use neutral, already-localized account-status and generic error copy. Deletion language appears only after the server returns an actual deletion attempt.
- The read-only deletion-status request now begins as soon as the authenticated signer is usable. It no longer waits for relay connections that the HTTP request does not use. Remote-signing accounts still remain fail-closed until their signer capability is ready.

The deletion recovery actions, status API, destructive operations, and fail-closed safety policy are unchanged.

Fixes #8058
Blocks #7980

## Verification

- Focused account-deletion screen, Cubit, provider, router, and repository tests
- Full `flutter analyze`
- ARB consistency test
- Hardcoded user-visible string scan
- Pre-push analyzer and changed-file tests
- Regression coverage proves loading/error states contain no deletion language
- Regression coverage proves local signing starts the lookup without relay readiness and unavailable signers remain fail-closed