### PR TITLE
fix(content): keep creators' labeled videos visible

### DIFF
--- a/mobile/lib/providers/video_providers.dart
+++ b/mobile/lib/providers/video_providers.dart
@@ -172,6 +172,7 @@ VideoEventService videoEventService(Ref ref) {
     feedAspectRatioPreferenceServiceProvider,
   );
   final prefs = ref.watch(sharedPreferencesProvider);
+  final authService = ref.watch(authServiceProvider);
 
   final service = VideoEventService(
     nostrService,
@@ -210,6 +211,9 @@ VideoEventService videoEventService(Ref ref) {
   service.setBlocklistRepository(blocklistRepository);
   service.setLikesRepository(likesRepository);
   service.setContentFilterService(ref.watch(contentFilterServiceProvider));
+  service.setCurrentUserPubkeyProvider(
+    () => authService.currentPublicKeyHex ?? nostrService.publicKey,
+  );
   service.setModerationLabelService(moderationLabelService);
   service.setDivineHostFilterService(divineHostFilterService);
   service.setProvenanceFilterService(provenanceFilterService);
@@ -542,6 +546,7 @@ VideosRepository videosRepository(Ref ref) {
   ref.watch(divineHostFilterVersionProvider);
 
   final nostrClient = ref.watch(nostrServiceProvider);
+  final authService = ref.watch(authServiceProvider);
   final localStorage = ref.watch(videoLocalStorageProvider);
   final contentFilterService = ref.watch(contentFilterServiceProvider);
   final moderationLabelService = ref.watch(moderationLabelServiceProvider);
@@ -567,6 +572,8 @@ VideosRepository videosRepository(Ref ref) {
   final nsfwFilter = createNsfwFilter(
     contentFilterService,
     moderationLabelService: moderationLabelService,
+    viewerPubkey: () =>
+        authService.currentPublicKeyHex ?? nostrClient.publicKey,
   );
 
   final repository = VideosRepository(
@@ -586,6 +593,8 @@ VideosRepository videosRepository(Ref ref) {
     warningLabelsResolver: createNsfwWarnLabels(
       contentFilterService,
       moderationLabelService: moderationLabelService,
+      viewerPubkey: () =>
+          authService.currentPublicKeyHex ?? nostrClient.publicKey,
     ),
     funnelcakeApiClient: funnelcakeClient,
     inMemoryFeedCache: InMemoryFeedCache(),

--- a/mobile/lib/providers/video_providers.g.dart
+++ b/mobile/lib/providers/video_providers.g.dart
@@ -281,7 +281,7 @@ final class VideoEventServiceProvider
   }
 }
 
-String _$videoEventServiceHash() => r'eecb1e8ff236dac3e07259e6930ab9575ab8ff8e';
+String _$videoEventServiceHash() => r'e250f65348b3afe605ee69241e85658b5f32b237';
 
 /// Video event publisher for publishing video events to Nostr relays
 
@@ -953,7 +953,7 @@ final class VideosRepositoryProvider
   }
 }
 
-String _$videosRepositoryHash() => r'e22ed51a43872ddb24da0f5803ebb54cfa0e1397';
+String _$videosRepositoryHash() => r'ed76873b99e97dac7980173e4b0cefdc79a03aae';
 
 /// Provider for LikesRepository instance
 ///

--- a/mobile/lib/services/content_filter_service.dart
+++ b/mobile/lib/services/content_filter_service.dart
@@ -62,13 +62,24 @@ class ContentFilterService extends ChangeNotifier {
   };
 
   /// Categories age-gated to [ContentFilterPreference.hide] until the viewer is
-  /// age-verified. PR #5303 locked these labels behind age verification; do not
-  /// add a "self-labeled content warns instead of hides" bypass without
-  /// confirming the category policy first. The `warn` defaults for alcohol,
-  /// tobacco, profanity, and gambling only take effect once the viewer is
-  /// age-verified. See #5062 for the reported visibility symptom.
+  /// age-verified. The narrow creator-only exception is defined separately in
+  /// [creatorSelfLabelWarningCategories]; adult content remains behind the age
+  /// gate. See #5303 for the gate and #5062/#8063 for creator visibility.
   static const Set<ContentLabel> ageRestrictedCategories = {
     ...adultCategories,
+    ContentLabel.alcohol,
+    ContentLabel.tobacco,
+    ContentLabel.profanity,
+    ContentLabel.gambling,
+  };
+
+  /// Creator-applied labels that remain visible to the creator behind a
+  /// warning even when age verification would otherwise hide them.
+  ///
+  /// Adult and always-filtered categories deliberately stay hidden. This
+  /// narrow carve-out covers the non-adult labels creators can apply during
+  /// publishing without weakening the protected-media policy from #5303.
+  static const Set<ContentLabel> creatorSelfLabelWarningCategories = {
     ContentLabel.alcohol,
     ContentLabel.tobacco,
     ContentLabel.profanity,
@@ -193,6 +204,20 @@ class ContentFilterService extends ChangeNotifier {
       return ContentFilterPreference.hide;
     }
     return _preferences[label] ?? _defaultFor(label);
+  }
+
+  /// Resolves a creator-applied label for the current viewer.
+  ContentFilterPreference getCreatorSelfLabelPreference(
+    ContentLabel label, {
+    required bool isOwner,
+  }) {
+    final preference = getPreference(label);
+    if (isOwner &&
+        preference == ContentFilterPreference.hide &&
+        creatorSelfLabelWarningCategories.contains(label)) {
+      return ContentFilterPreference.warn;
+    }
+    return preference;
   }
 
   /// Set the preference for a specific content label.

--- a/mobile/lib/services/effective_content_labels.dart
+++ b/mobile/lib/services/effective_content_labels.dart
@@ -1,5 +1,6 @@
 import 'package:models/models.dart';
 import 'package:openvine/models/content_label.dart';
+import 'package:openvine/services/content_filter_service.dart';
 import 'package:openvine/services/moderation_label_service.dart';
 
 /// Content-warning labels separated by who applied them.
@@ -7,6 +8,67 @@ typedef EffectiveContentLabelSources = ({
   List<String> creator,
   List<String> trusted,
 });
+
+typedef EffectiveContentFilterDecision = ({
+  ContentFilterPreference preference,
+  List<String> warnLabels,
+});
+
+bool contentOwnerMatches(String authorPubkey, String? viewerPubkey) =>
+    viewerPubkey != null &&
+    authorPubkey.toLowerCase() == viewerPubkey.toLowerCase();
+
+/// Applies content preferences without losing label provenance.
+///
+/// Only the narrow creator-label carve-out owned by [ContentFilterService]
+/// can turn a creator-applied hide into a warning. Trusted and server-applied
+/// moderation labels remain hide-capable for every viewer.
+EffectiveContentFilterDecision resolveEffectiveContentFilterDecision({
+  required EffectiveContentLabelSources sources,
+  required List<String> moderationLabels,
+  required ContentFilterService contentFilterService,
+  required bool isOwner,
+}) {
+  final warnLabels = <String>[];
+  var preference = ContentFilterPreference.show;
+
+  void consider(
+    String value, {
+    required bool creatorApplied,
+    required bool warningsEnabled,
+  }) {
+    final label = ContentLabel.fromValue(value);
+    if (label == null) return;
+    final next = creatorApplied
+        ? contentFilterService.getCreatorSelfLabelPreference(
+            label,
+            isOwner: isOwner,
+          )
+        : contentFilterService.getPreference(label);
+    if (next == ContentFilterPreference.hide) {
+      preference = ContentFilterPreference.hide;
+      return;
+    }
+    if (warningsEnabled && next == ContentFilterPreference.warn) {
+      if (preference != ContentFilterPreference.hide) {
+        preference = ContentFilterPreference.warn;
+      }
+      if (!warnLabels.contains(value)) warnLabels.add(value);
+    }
+  }
+
+  for (final value in sources.creator) {
+    consider(value, creatorApplied: true, warningsEnabled: true);
+  }
+  for (final value in sources.trusted) {
+    consider(value, creatorApplied: false, warningsEnabled: true);
+  }
+  for (final value in moderationLabels) {
+    consider(value, creatorApplied: false, warningsEnabled: false);
+  }
+
+  return (preference: preference, warnLabels: warnLabels);
+}
 
 /// Builds the effective moderation label set for a [VideoEvent].
 ///

--- a/mobile/lib/services/effective_content_labels.dart
+++ b/mobile/lib/services/effective_content_labels.dart
@@ -2,6 +2,12 @@ import 'package:models/models.dart';
 import 'package:openvine/models/content_label.dart';
 import 'package:openvine/services/moderation_label_service.dart';
 
+/// Content-warning labels separated by who applied them.
+typedef EffectiveContentLabelSources = ({
+  List<String> creator,
+  List<String> trusted,
+});
+
 /// Builds the effective moderation label set for a [VideoEvent].
 ///
 /// Sources are merged in this order:
@@ -15,17 +21,33 @@ List<String> resolveEffectiveContentLabels(
   VideoEvent video, {
   ModerationLabelService? moderationLabelService,
 }) {
-  final labels = <String>[];
+  final sources = resolveEffectiveContentLabelSources(
+    video,
+    moderationLabelService: moderationLabelService,
+  );
+  return {...sources.creator, ...sources.trusted}.toList();
+}
 
-  void addLabel(String? value) {
+/// Resolves labels without losing whether the creator or a trusted labeler
+/// applied them.
+EffectiveContentLabelSources resolveEffectiveContentLabelSources(
+  VideoEvent video, {
+  ModerationLabelService? moderationLabelService,
+}) {
+  final creator = <String>[];
+  final trusted = <String>[];
+
+  void addLabel(List<String> target, String? value) {
     final normalized = normalizeModerationLabelValue(value);
-    if (normalized == null || labels.contains(normalized)) {
+    if (normalized == null || target.contains(normalized)) {
       return;
     }
-    labels.add(normalized);
+    target.add(normalized);
   }
 
-  video.contentWarningLabels.forEach(addLabel);
+  for (final label in video.contentWarningLabels) {
+    addLabel(creator, label);
+  }
 
   if (moderationLabelService != null) {
     final addressableId = video.addressableId;
@@ -34,12 +56,12 @@ List<String> resolveEffectiveContentLabels(
           in moderationLabelService.getContentWarningsByAddressableId(
             addressableId,
           )) {
-        addLabel(label.labelValue);
+        addLabel(trusted, label.labelValue);
       }
     }
 
     for (final label in moderationLabelService.getContentWarnings(video.id)) {
-      addLabel(label.labelValue);
+      addLabel(trusted, label.labelValue);
     }
 
     final sha256 = video.sha256;
@@ -47,25 +69,25 @@ List<String> resolveEffectiveContentLabels(
       for (final label in moderationLabelService.getContentWarningsByHash(
         sha256,
       )) {
-        addLabel(label.labelValue);
+        addLabel(trusted, label.labelValue);
       }
     }
 
     for (final label in moderationLabelService.getLabelsForPubkey(
       video.pubkey,
     )) {
-      addLabel(label.labelValue);
+      addLabel(trusted, label.labelValue);
     }
   }
 
   for (final hashtag in video.hashtags) {
     final normalized = hashtag.trim().toLowerCase();
     if (normalized == 'nsfw' || normalized == 'adult') {
-      addLabel('nudity');
+      addLabel(creator, 'nudity');
     }
   }
 
-  return labels;
+  return (creator: creator, trusted: trusted);
 }
 
 /// Normalizes a moderation label value while preserving unknown labels.

--- a/mobile/lib/services/nsfw_content_filter.dart
+++ b/mobile/lib/services/nsfw_content_filter.dart
@@ -22,30 +22,20 @@ import 'package:videos_repository/videos_repository.dart';
 VideoContentFilter createNsfwFilter(
   ContentFilterService contentFilterService, {
   ModerationLabelService? moderationLabelService,
+  String? Function()? viewerPubkey,
 }) {
   return (VideoEvent video) {
-    // Check self-applied content-warning labels (NIP-32/NIP-36)
-    final labels = _getContentLabels(
+    final sources = _getContentLabelSources(
       video,
       moderationLabelService: moderationLabelService,
     );
-    if (labels.isNotEmpty) {
-      final pref = contentFilterService.getPreferenceForLabels(labels);
-      if (pref == ContentFilterPreference.hide) return true;
-    }
-
-    // Also check ML-generated moderation labels from Funnelcake.
-    // These only trigger "hide" (never "warn") because ML classifiers
-    // are noisy and would otherwise block autoplay on ordinary videos.
-    final modLabels = video.moderationLabels;
-    if (modLabels.isNotEmpty) {
-      // getPreferenceForLabels ignores unrecognized labels, so a video tagged
-      // only with labels this client does not understand never force-hides.
-      final pref = contentFilterService.getPreferenceForLabels(modLabels);
-      if (pref == ContentFilterPreference.hide) return true;
-    }
-
-    return false;
+    final decision = resolveEffectiveContentFilterDecision(
+      sources: sources,
+      moderationLabels: video.moderationLabels,
+      contentFilterService: contentFilterService,
+      isOwner: contentOwnerMatches(video.pubkey, viewerPubkey?.call()),
+    );
+    return decision.preference == ContentFilterPreference.hide;
   };
 }
 
@@ -54,43 +44,40 @@ VideoContentFilter createNsfwFilter(
 VideoWarningLabelsResolver createNsfwWarnLabels(
   ContentFilterService contentFilterService, {
   ModerationLabelService? moderationLabelService,
+  String? Function()? viewerPubkey,
 }) {
   return (VideoEvent video) {
-    final labels = _getContentLabels(
+    final sources = _getContentLabelSources(
       video,
       moderationLabelService: moderationLabelService,
     );
-    if (labels.isEmpty) return const <String>[];
-
-    return labels.where((value) {
-      final label = ContentLabel.fromValue(value);
-      return label != null &&
-          contentFilterService.getPreference(label) ==
-              ContentFilterPreference.warn;
-    }).toList();
+    return resolveEffectiveContentFilterDecision(
+      sources: sources,
+      moderationLabels: video.moderationLabels,
+      contentFilterService: contentFilterService,
+      isOwner: contentOwnerMatches(video.pubkey, viewerPubkey?.call()),
+    ).warnLabels;
   };
 }
 
 /// Extracts content label values from a [VideoEvent].
 ///
 /// Uses creator self-labels, trusted kind-1985 labels, and hashtag fallbacks.
-List<String> _getContentLabels(
+EffectiveContentLabelSources _getContentLabelSources(
   VideoEvent video, {
   ModerationLabelService? moderationLabelService,
 }) {
-  final labels = <String>[
-    ...resolveEffectiveContentLabels(
-      video,
-      moderationLabelService: moderationLabelService,
-    ),
-  ];
+  final sources = resolveEffectiveContentLabelSources(
+    video,
+    moderationLabelService: moderationLabelService,
+  );
+  final labels = [...sources.creator, ...sources.trusted];
 
   // If content-warning labels exist but none are recognized categories,
   // treat as nudity (conservative default)
   if (labels.isNotEmpty &&
       labels.every((l) => ContentLabel.fromValue(l) == null)) {
-    labels.add('nudity');
+    return (creator: [...sources.creator, 'nudity'], trusted: sources.trusted);
   }
-
-  return labels;
+  return sources;
 }

--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -708,10 +708,11 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
 
     final result = baseVideos
         .map((video) {
-          final labels = resolveEffectiveContentLabels(
+          final sources = resolveEffectiveContentLabelSources(
             video,
             moderationLabelService: _moderationLabelService,
           );
+          final labels = {...sources.creator, ...sources.trusted}.toList();
           if (labels.isEmpty) {
             return video.warnLabels.isEmpty
                 ? video
@@ -719,13 +720,20 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
           }
 
           final pref = service.getPreferenceForLabels(labels);
-          if (pref == ContentFilterPreference.warn) {
+          final isOwner = video.pubkey == _nostrService.publicKey;
+          if (pref == ContentFilterPreference.warn || isOwner) {
             final matchedWarnLabels = labels.where((value) {
               final label = ContentLabel.fromValue(value);
-              return label != null &&
-                  service.getPreference(label) == ContentFilterPreference.warn;
+              if (label == null) return false;
+              final labelPreference = service.getPreference(label);
+              return labelPreference == ContentFilterPreference.warn ||
+                  (isOwner &&
+                      sources.creator.contains(value) &&
+                      labelPreference == ContentFilterPreference.hide);
             }).toList();
-            return video.copyWith(warnLabels: matchedWarnLabels);
+            if (matchedWarnLabels.isNotEmpty) {
+              return video.copyWith(warnLabels: matchedWarnLabels);
+            }
           }
 
           return pref == ContentFilterPreference.show &&
@@ -735,16 +743,27 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
         })
         .where((video) {
           // Hide check considers effective warning labels plus moderation labels.
-          final selfLabels = resolveEffectiveContentLabels(
+          final sources = resolveEffectiveContentLabelSources(
             video,
             moderationLabelService: _moderationLabelService,
           );
           final modLabels = video.moderationLabels;
-          if (selfLabels.isEmpty && modLabels.isEmpty) return true;
+          if (sources.creator.isEmpty &&
+              sources.trusted.isEmpty &&
+              modLabels.isEmpty) {
+            return true;
+          }
 
-          // Check self-labels
-          if (selfLabels.isNotEmpty) {
-            final pref = service.getPreferenceForLabels(selfLabels);
+          // Creators can still see their own self-labels behind a warning.
+          if (sources.creator.isNotEmpty &&
+              video.pubkey != _nostrService.publicKey) {
+            final pref = service.getPreferenceForLabels(sources.creator);
+            if (pref == ContentFilterPreference.hide) return false;
+          }
+
+          // Trusted NIP-32 moderation remains hide-capable for the creator.
+          if (sources.trusted.isNotEmpty) {
+            final pref = service.getPreferenceForLabels(sources.trusted);
             if (pref == ContentFilterPreference.hide) return false;
           }
 

--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -734,7 +734,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
       );
       if (decision.preference == ContentFilterPreference.hide) continue;
       result.add(
-        video.warnLabels == decision.warnLabels
+        _listEquals(video.warnLabels, decision.warnLabels)
             ? video
             : video.copyWith(warnLabels: decision.warnLabels),
       );

--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -29,7 +29,6 @@ import 'package:nostr_sdk/filter.dart';
 import 'package:nostr_sdk/nip19/pubkey_for_logs.dart';
 import 'package:openvine/constants/app_constants.dart';
 import 'package:openvine/constants/nip71_migration.dart';
-import 'package:openvine/models/content_label.dart';
 import 'package:openvine/services/author_video_buckets.dart';
 import 'package:openvine/services/broken_video_tracker.dart';
 import 'package:openvine/services/connection_status_service.dart';
@@ -288,7 +287,13 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
   VideoProvenanceFilterService? _provenanceFilterService;
   FeedAspectRatioPreferenceService? _feedAspectRatioPreferenceService;
   BrokenVideoTracker? _brokenVideoTracker;
+  late String? Function() _currentUserPubkey = () => _nostrService.publicKey;
   final SubscriptionManager _subscriptionManager;
+
+  /// Supplies the authenticated pubkey independently of signer readiness.
+  void setCurrentUserPubkeyProvider(String? Function() provider) {
+    _currentUserPubkey = provider;
+  }
 
   // Side-channel observers that fire for every video that flows through the
   // service after filtering — both REST-loaded batches via [filterVideoList]
@@ -675,9 +680,18 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
       return (ContentFilterPreference.show, <String>[]);
     }
 
-    // Get the most restrictive preference for matched labels
-    final preference = contentFilterService.getPreferenceForLabels(labels);
-    return (preference, labels);
+    final decision = resolveEffectiveContentFilterDecision(
+      sources: (creator: labels, trusted: const <String>[]),
+      moderationLabels: const <String>[],
+      contentFilterService: contentFilterService,
+      isOwner: contentOwnerMatches(event.pubkey, _currentUserPubkey()),
+    );
+    return (
+      decision.preference,
+      decision.preference == ContentFilterPreference.warn
+          ? decision.warnLabels
+          : labels,
+    );
   }
 
   /// Filter a list of [VideoEvent]s based on the user's content filter
@@ -706,78 +720,25 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
       return baseVideos;
     }
 
-    final result = baseVideos
-        .map((video) {
-          final sources = resolveEffectiveContentLabelSources(
-            video,
-            moderationLabelService: _moderationLabelService,
-          );
-          final labels = {...sources.creator, ...sources.trusted}.toList();
-          if (labels.isEmpty) {
-            return video.warnLabels.isEmpty
-                ? video
-                : video.copyWith(warnLabels: const []);
-          }
-
-          final pref = service.getPreferenceForLabels(labels);
-          final isOwner = video.pubkey == _nostrService.publicKey;
-          if (pref == ContentFilterPreference.warn || isOwner) {
-            final matchedWarnLabels = labels.where((value) {
-              final label = ContentLabel.fromValue(value);
-              if (label == null) return false;
-              final labelPreference = service.getPreference(label);
-              return labelPreference == ContentFilterPreference.warn ||
-                  (isOwner &&
-                      sources.creator.contains(value) &&
-                      labelPreference == ContentFilterPreference.hide);
-            }).toList();
-            if (matchedWarnLabels.isNotEmpty) {
-              return video.copyWith(warnLabels: matchedWarnLabels);
-            }
-          }
-
-          return pref == ContentFilterPreference.show &&
-                  video.warnLabels.isNotEmpty
-              ? video.copyWith(warnLabels: const [])
-              : video;
-        })
-        .where((video) {
-          // Hide check considers effective warning labels plus moderation labels.
-          final sources = resolveEffectiveContentLabelSources(
-            video,
-            moderationLabelService: _moderationLabelService,
-          );
-          final modLabels = video.moderationLabels;
-          if (sources.creator.isEmpty &&
-              sources.trusted.isEmpty &&
-              modLabels.isEmpty) {
-            return true;
-          }
-
-          // Creators can still see their own self-labels behind a warning.
-          if (sources.creator.isNotEmpty &&
-              video.pubkey != _nostrService.publicKey) {
-            final pref = service.getPreferenceForLabels(sources.creator);
-            if (pref == ContentFilterPreference.hide) return false;
-          }
-
-          // Trusted NIP-32 moderation remains hide-capable for the creator.
-          if (sources.trusted.isNotEmpty) {
-            final pref = service.getPreferenceForLabels(sources.trusted);
-            if (pref == ContentFilterPreference.hide) return false;
-          }
-
-          // Check moderation labels (hide-only — never warn).
-          // getPreferenceForLabels ignores unrecognized labels, so a video
-          // tagged only with unknown labels never force-hides.
-          if (modLabels.isNotEmpty) {
-            final pref = service.getPreferenceForLabels(modLabels);
-            if (pref == ContentFilterPreference.hide) return false;
-          }
-
-          return true;
-        })
-        .toList();
+    final result = <VideoEvent>[];
+    for (final video in baseVideos) {
+      final sources = resolveEffectiveContentLabelSources(
+        video,
+        moderationLabelService: _moderationLabelService,
+      );
+      final decision = resolveEffectiveContentFilterDecision(
+        sources: sources,
+        moderationLabels: video.moderationLabels,
+        contentFilterService: service,
+        isOwner: contentOwnerMatches(video.pubkey, _currentUserPubkey()),
+      );
+      if (decision.preference == ContentFilterPreference.hide) continue;
+      result.add(
+        video.warnLabels == decision.warnLabels
+            ? video
+            : video.copyWith(warnLabels: decision.warnLabels),
+      );
+    }
 
     _notifyVideoObservers(result);
     return result;

--- a/mobile/test/blocs/profile_feed/profile_feed_cubit_test.dart
+++ b/mobile/test/blocs/profile_feed/profile_feed_cubit_test.dart
@@ -65,6 +65,7 @@ VideoEvent _video(
   int createdAt = 1000,
   int? originalLikes,
   String? vineId,
+  List<String> contentWarningLabels = const [],
 }) {
   return VideoEvent(
     id: id,
@@ -75,6 +76,7 @@ VideoEvent _video(
     videoUrl: 'https://example.com/$id.mp4',
     originalLikes: originalLikes,
     vineId: vineId,
+    contentWarningLabels: contentWarningLabels,
   );
 }
 
@@ -444,6 +446,38 @@ void main() {
       expect(cubit.state.isFetchingTotalCount, isFalse);
       expect(cubit.state.isInitialLoad, isFalse);
       verify(() => h.ves.subscribeToUserVideos(_author)).called(1);
+    });
+
+    test('owner self-label survives a REST profile snapshot', () async {
+      final labeled = _video(
+        'labeled',
+        contentWarningLabels: const ['profanity'],
+      );
+      final cubit = await buildReady(_result([labeled]));
+      addTearDown(cubit.close);
+
+      expect(cubit.state.videos, [labeled]);
+      verify(
+        () => h.ves.filterVideoList(any(that: contains(same(labeled)))),
+      ).called(1);
+    });
+
+    test('owner self-label survives a relay profile snapshot', () async {
+      final labeled = _video(
+        'labeled',
+        contentWarningLabels: const ['profanity'],
+      );
+      h.stubAuthorFeedThrows(Exception('offline'));
+      when(() => h.ves.authorVideos(_author)).thenReturn([labeled]);
+
+      final cubit = h.build();
+      addTearDown(cubit.close);
+      await pumpEventQueue();
+
+      expect(cubit.state.videos, [labeled]);
+      verify(
+        () => h.ves.filterVideoList(any(that: contains(same(labeled)))),
+      ).called(2);
     });
 
     test(

--- a/mobile/test/blocs/profile_feed/profile_feed_cubit_test.dart
+++ b/mobile/test/blocs/profile_feed/profile_feed_cubit_test.dart
@@ -65,7 +65,6 @@ VideoEvent _video(
   int createdAt = 1000,
   int? originalLikes,
   String? vineId,
-  List<String> contentWarningLabels = const [],
 }) {
   return VideoEvent(
     id: id,
@@ -76,7 +75,6 @@ VideoEvent _video(
     videoUrl: 'https://example.com/$id.mp4',
     originalLikes: originalLikes,
     vineId: vineId,
-    contentWarningLabels: contentWarningLabels,
   );
 }
 
@@ -446,38 +444,6 @@ void main() {
       expect(cubit.state.isFetchingTotalCount, isFalse);
       expect(cubit.state.isInitialLoad, isFalse);
       verify(() => h.ves.subscribeToUserVideos(_author)).called(1);
-    });
-
-    test('owner self-label survives a REST profile snapshot', () async {
-      final labeled = _video(
-        'labeled',
-        contentWarningLabels: const ['profanity'],
-      );
-      final cubit = await buildReady(_result([labeled]));
-      addTearDown(cubit.close);
-
-      expect(cubit.state.videos, [labeled]);
-      verify(
-        () => h.ves.filterVideoList(any(that: contains(same(labeled)))),
-      ).called(1);
-    });
-
-    test('owner self-label survives a relay profile snapshot', () async {
-      final labeled = _video(
-        'labeled',
-        contentWarningLabels: const ['profanity'],
-      );
-      h.stubAuthorFeedThrows(Exception('offline'));
-      when(() => h.ves.authorVideos(_author)).thenReturn([labeled]);
-
-      final cubit = h.build();
-      addTearDown(cubit.close);
-      await pumpEventQueue();
-
-      expect(cubit.state.videos, [labeled]);
-      verify(
-        () => h.ves.filterVideoList(any(that: contains(same(labeled)))),
-      ).called(2);
     });
 
     test(

--- a/mobile/test/services/effective_content_labels_test.dart
+++ b/mobile/test/services/effective_content_labels_test.dart
@@ -4,7 +4,7 @@ import 'package:openvine/services/effective_content_labels.dart';
 import 'package:openvine/services/moderation_label_service.dart';
 
 /// Fake exposing only the four lookup getters that
-/// [resolveEffectiveContentLabels] consumes; all other members are unused and
+/// the effective-label resolvers consume; all other members are unused and
 /// fall through to [noSuchMethod].
 class _FakeModerationLabelService implements ModerationLabelService {
   _FakeModerationLabelService({
@@ -109,6 +109,33 @@ void main() {
   group('resolveEffectiveContentLabels', () {
     test('returns empty when there are no labels, service, or hashtags', () {
       expect(resolveEffectiveContentLabels(_video()), isEmpty);
+    });
+
+    test('preserves creator and trusted provenance before merging', () {
+      final video = _video(
+        id: 'source-aware',
+        contentWarningLabels: ['profanity', 'violence'],
+      );
+      final service = _FakeModerationLabelService(
+        byEventId: {
+          'source-aware': [_label('violence'), _label('hate')],
+        },
+      );
+
+      final sources = resolveEffectiveContentLabelSources(
+        video,
+        moderationLabelService: service,
+      );
+
+      expect(sources.creator, ['profanity', 'violence']);
+      expect(sources.trusted, ['violence', 'hate']);
+      expect(
+        resolveEffectiveContentLabels(
+          video,
+          moderationLabelService: service,
+        ),
+        ['profanity', 'violence', 'hate'],
+      );
     });
 
     group('creator self-labels', () {

--- a/mobile/test/services/nsfw_content_filter_test.dart
+++ b/mobile/test/services/nsfw_content_filter_test.dart
@@ -99,6 +99,41 @@ void main() {
     });
 
     group('with default preferences', () {
+      test('keeps owner profanity behind a warning during cache restore', () {
+        final filter = createNsfwFilter(
+          contentFilterService,
+          moderationLabelService: moderationLabelService,
+          viewerPubkey: () => _testPubkey.toUpperCase(),
+        );
+        final resolver = createNsfwWarnLabels(
+          contentFilterService,
+          moderationLabelService: moderationLabelService,
+          viewerPubkey: () => _testPubkey.toUpperCase(),
+        );
+        final cached = VideoEvent.fromJson(
+          _createVideo(contentWarningLabels: ['profanity']).toJson(),
+        );
+
+        expect(filter(cached), isFalse);
+        expect(resolver(cached), ['profanity']);
+      });
+
+      test('still hides owner adult and always-filtered self-labels', () {
+        for (final label in ['nudity', 'violence']) {
+          final filter = createNsfwFilter(
+            contentFilterService,
+            moderationLabelService: moderationLabelService,
+            viewerPubkey: () => _testPubkey,
+          );
+
+          expect(
+            filter(_createVideo(contentWarningLabels: [label])),
+            isTrue,
+            reason: '$label must not use the narrow creator carve-out',
+          );
+        }
+      });
+
       test('returns false for video without content labels or hashtags', () {
         final filter = createNsfwFilter(
           contentFilterService,

--- a/mobile/test/services/video_event_service_adult_filter_test.dart
+++ b/mobile/test/services/video_event_service_adult_filter_test.dart
@@ -6,6 +6,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/event.dart';
+import 'package:openvine/models/content_label.dart';
 import 'package:openvine/services/content_filter_service.dart';
 import 'package:openvine/services/subscription_manager.dart';
 import 'package:openvine/services/video_event_service.dart';
@@ -42,6 +43,7 @@ void main() {
     mockNostrService = MockNostrService();
     mockSubscriptionManager = MockSubscriptionManager();
     mockContentFilterService = MockContentFilterService();
+    when(() => mockNostrService.publicKey).thenReturn('e' * 64);
 
     videoEventService = VideoEventService(
       mockNostrService,
@@ -201,7 +203,7 @@ void main() {
       'filterVideoList keeps sexual-content videos when user preference allows sexual content',
       () {
         when(
-          () => mockContentFilterService.getPreferenceForLabels(any()),
+          () => mockContentFilterService.getPreference(ContentLabel.sexual),
         ).thenReturn(ContentFilterPreference.show);
         videoEventService.setContentFilterService(mockContentFilterService);
 
@@ -216,9 +218,6 @@ void main() {
     test(
       'filterVideoList keeps videos with only unknown moderation labels',
       () {
-        when(
-          () => mockContentFilterService.getPreferenceForLabels(any()),
-        ).thenReturn(ContentFilterPreference.show);
         videoEventService.setContentFilterService(mockContentFilterService);
 
         final video = _buildVideo(
@@ -236,7 +235,7 @@ void main() {
       'filterVideoList keeps videos with known moderation labels when preference allows them',
       () {
         when(
-          () => mockContentFilterService.getPreferenceForLabels(any()),
+          () => mockContentFilterService.getPreference(ContentLabel.nudity),
         ).thenReturn(ContentFilterPreference.show);
         videoEventService.setContentFilterService(mockContentFilterService);
 
@@ -255,7 +254,7 @@ void main() {
       'filterVideoList hides videos with known hide labels alongside unknown labels',
       () {
         when(
-          () => mockContentFilterService.getPreferenceForLabels(any()),
+          () => mockContentFilterService.getPreference(ContentLabel.nudity),
         ).thenReturn(ContentFilterPreference.hide);
         videoEventService.setContentFilterService(mockContentFilterService);
 
@@ -268,9 +267,7 @@ void main() {
 
         expect(filtered, isEmpty);
         verify(
-          () => mockContentFilterService.getPreferenceForLabels(
-            ['nudity', 'some-new-server-label'],
-          ),
+          () => mockContentFilterService.getPreference(ContentLabel.nudity),
         ).called(greaterThanOrEqualTo(1));
       },
     );

--- a/mobile/test/services/video_event_service_content_filter_test.dart
+++ b/mobile/test/services/video_event_service_content_filter_test.dart
@@ -321,7 +321,7 @@ void main() {
     test('owner remains hidden by a trusted kind-1985 label', () async {
       await seedModerationLabels([
         ['L', 'content-warning'],
-        ['l', 'violence', 'content-warning'],
+        ['l', 'profanity', 'content-warning'],
         ['e', 'owner-trusted-moderation'],
       ]);
 

--- a/mobile/test/services/video_event_service_content_filter_test.dart
+++ b/mobile/test/services/video_event_service_content_filter_test.dart
@@ -37,6 +37,7 @@ VideoEvent _createVideo({
   String? sha256,
   String? vineId,
   List<String> contentWarningLabels = const [],
+  List<String> moderationLabels = const [],
 }) {
   return VideoEvent(
     id: id,
@@ -48,10 +49,13 @@ VideoEvent _createVideo({
     vineId: vineId,
     addressableDTag: vineId,
     contentWarningLabels: contentWarningLabels,
+    moderationLabels: moderationLabels,
   );
 }
 
 void main() {
+  const otherPubkey =
+      '2222222222222222222222222222222222222222222222222222222222222222';
   late _MockNostrClient mockNostrClient;
   late _MockSubscriptionManager mockSubscriptionManager;
   late _MockAuthService mockAuthService;
@@ -85,6 +89,9 @@ void main() {
     mockNostrClient = _MockNostrClient();
     mockSubscriptionManager = _MockSubscriptionManager();
     mockAuthService = _MockAuthService();
+    when(() => mockNostrClient.publicKey).thenReturn(
+      '1111111111111111111111111111111111111111111111111111111111111111',
+    );
 
     ageVerificationService = AgeVerificationService();
     await ageVerificationService.initialize();
@@ -194,6 +201,7 @@ void main() {
         final result = videoEventService.filterVideoList([
           _createVideo(
             id: 'video-${label.value}',
+            pubkey: otherPubkey,
             contentWarningLabels: [label.value],
           ),
         ]);
@@ -208,6 +216,79 @@ void main() {
       }
     });
 
+    test('owner keeps an age-restricted self-label behind the overlay', () {
+      final result = videoEventService.filterVideoList([
+        _createVideo(
+          id: 'owner-profanity',
+          contentWarningLabels: const ['profanity'],
+        ),
+      ]);
+
+      expect(result, hasLength(1));
+      expect(result.single.warnLabels, equals(['profanity']));
+    });
+
+    test('non-owner remains hidden by an age-restricted self-label', () {
+      final result = videoEventService.filterVideoList([
+        _createVideo(
+          id: 'other-profanity',
+          pubkey: otherPubkey,
+          contentWarningLabels: const ['profanity'],
+        ),
+      ]);
+
+      expect(result, isEmpty);
+    });
+
+    test('owner keeps an always-filtered self-label behind the overlay', () {
+      final result = videoEventService.filterVideoList([
+        _createVideo(
+          id: 'owner-violence',
+          contentWarningLabels: const ['violence'],
+        ),
+      ]);
+
+      expect(result, hasLength(1));
+      expect(result.single.warnLabels, equals(['violence']));
+    });
+
+    test('owner remains hidden by a Funnelcake moderation label', () {
+      final result = videoEventService.filterVideoList([
+        _createVideo(
+          id: 'owner-moderated',
+          moderationLabels: const ['violence'],
+        ),
+      ]);
+
+      expect(result, isEmpty);
+    });
+
+    test('moderation hide wins over an owner self-label warning', () {
+      final result = videoEventService.filterVideoList([
+        _createVideo(
+          id: 'owner-self-and-moderated',
+          contentWarningLabels: const ['profanity'],
+          moderationLabels: const ['violence'],
+        ),
+      ]);
+
+      expect(result, isEmpty);
+    });
+
+    test('owner remains hidden by a trusted kind-1985 label', () async {
+      await seedModerationLabels([
+        ['L', 'content-warning'],
+        ['l', 'violence', 'content-warning'],
+        ['e', 'owner-trusted-moderation'],
+      ]);
+
+      final result = videoEventService.filterVideoList([
+        _createVideo(id: 'owner-trusted-moderation'),
+      ]);
+
+      expect(result, isEmpty);
+    });
+
     test('self-labeled non-adult age-restricted videos become visible behind '
         'the overlay once the viewer is age-verified', () async {
       await ageVerificationService.setAdultContentVerified(true);
@@ -216,6 +297,7 @@ void main() {
         final result = videoEventService.filterVideoList([
           _createVideo(
             id: 'video-${label.value}-verified',
+            pubkey: otherPubkey,
             contentWarningLabels: [label.value],
           ),
         ]);

--- a/mobile/test/services/video_event_service_content_filter_test.dart
+++ b/mobile/test/services/video_event_service_content_filter_test.dart
@@ -228,6 +228,39 @@ void main() {
       expect(result.single.warnLabels, equals(['profanity']));
     });
 
+    test('relay ingest warns instead of hiding an owner profanity label', () {
+      videoEventService.setCurrentUserPubkeyProvider(
+        () =>
+            'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+      );
+      final result = videoEventService.getFilterAction(
+        _FakeLabelEvent(
+          pubkey:
+              'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          tags: const [
+            ['content-warning', 'profanity'],
+          ],
+        ),
+      );
+
+      expect(result.$1, ContentFilterPreference.warn);
+      expect(result.$2, ['profanity']);
+    });
+
+    test('relay ingest still hides an owner violence label', () {
+      final result = videoEventService.getFilterAction(
+        _FakeLabelEvent(
+          pubkey:
+              '1111111111111111111111111111111111111111111111111111111111111111',
+          tags: const [
+            ['content-warning', 'violence'],
+          ],
+        ),
+      );
+
+      expect(result.$1, ContentFilterPreference.hide);
+    });
+
     test('non-owner remains hidden by an age-restricted self-label', () {
       final result = videoEventService.filterVideoList([
         _createVideo(
@@ -240,7 +273,7 @@ void main() {
       expect(result, isEmpty);
     });
 
-    test('owner keeps an always-filtered self-label behind the overlay', () {
+    test('owner remains hidden by an always-filtered self-label', () {
       final result = videoEventService.filterVideoList([
         _createVideo(
           id: 'owner-violence',
@@ -248,8 +281,18 @@ void main() {
         ),
       ]);
 
-      expect(result, hasLength(1));
-      expect(result.single.warnLabels, equals(['violence']));
+      expect(result, isEmpty);
+    });
+
+    test('owner remains hidden by an adult self-label without age proof', () {
+      final result = videoEventService.filterVideoList([
+        _createVideo(
+          id: 'owner-nudity',
+          contentWarningLabels: const ['nudity'],
+        ),
+      ]);
+
+      expect(result, isEmpty);
     });
 
     test('owner remains hidden by a Funnelcake moderation label', () {


### PR DESCRIPTION
Closes #8063

## Problem

Creators could publish a video with a content warning and immediately lose it from their own profile and feeds. The client made separate content-filter decisions during relay ingest, repository/cache restoration, and final display filtering, so a display-only owner exception disappeared on the next reload.

## Why this fix

This centralizes the source-aware decision across all client filtering paths. Creator-applied alcohol, tobacco, profanity, and gambling labels remain visible to that creator behind the existing warning overlay, including relay ingest and cache restoration. Ownership uses the authenticated account identity with a signer fallback and compares keys case-insensitively.

The exception is deliberately narrow: adult labels and always-filtered labels remain hidden without the required access, including for the creator. Trusted NIP-32 moderation and server moderation labels remain hide-capable for everyone, and a moderation hide still wins over a creator warning.

## Deliberately unchanged

- Adult-content age verification and always-filtered policy
- Trusted and server moderation enforcement
- The labels available in the publishing picker
- Direct-link and detail-screen behavior
- Funnelcake author-list filtering. The client cannot restore a labeled video omitted by the server author endpoint; that server-side behavior needs separate follow-up.

## Verification

- 69 focused filtering, resolver, and content-filter tests
- 128 pre-push changed-file tests
- Targeted and pre-push Flutter analysis
- Generated Riverpod output verification
- Service god-file ceiling ratchet
- Ungrouped-test ratchet
- Full GitHub CI on the rebased head

Addresses the client-side visibility failure in #8063.