### PR TITLE
fix(push): deregister outgoing account after account switch

### DIFF
--- a/mobile/lib/providers/container_swap_host.dart
+++ b/mobile/lib/providers/container_swap_host.dart
@@ -46,6 +46,8 @@ class AccountSwitchController {
   ///
   /// [next] must already be built (via `buildAccountContainer`) and signed in
   /// as the target account — the host only mounts it and disposes the old one.
+  /// [beforePreviousContainerDispose] runs after the target mounts and must
+  /// handle its own errors; the previous container is disposed in either case.
   Future<void> swapTo(
     ProviderContainer next, {
     Future<void> Function()? beforePreviousContainerDispose,

--- a/mobile/lib/providers/container_swap_host.dart
+++ b/mobile/lib/providers/container_swap_host.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Hosts the active ProviderContainer and swaps it in place on an
 // ABOUTME: account switch — no widget-tree remount, no welcome-screen bounce.
 
+import 'dart:async';
+
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -13,7 +15,11 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 /// [swapTo] with a freshly-built, already-signed-in container for the target
 /// account.
 class AccountSwitchController {
-  Future<void> Function(ProviderContainer next)? _onSwap;
+  Future<void> Function(
+    ProviderContainer next,
+    Future<void> Function()? beforePreviousContainerDispose,
+  )?
+  _onSwap;
   ProviderContainer? _currentContainer;
   bool _switchInProgress = false;
 
@@ -40,12 +46,15 @@ class AccountSwitchController {
   ///
   /// [next] must already be built (via `buildAccountContainer`) and signed in
   /// as the target account — the host only mounts it and disposes the old one.
-  Future<void> swapTo(ProviderContainer next) {
+  Future<void> swapTo(
+    ProviderContainer next, {
+    Future<void> Function()? beforePreviousContainerDispose,
+  }) {
     final onSwap = _onSwap;
     if (onSwap == null) {
       throw StateError('ContainerSwapHost is not mounted');
     }
-    return onSwap(next);
+    return onSwap(next, beforePreviousContainerDispose);
   }
 }
 
@@ -87,7 +96,10 @@ class _ContainerSwapHostState extends State<ContainerSwapHost> {
     widget.controller._onSwap = _swap;
   }
 
-  Future<void> _swap(ProviderContainer next) async {
+  Future<void> _swap(
+    ProviderContainer next,
+    Future<void> Function()? beforePreviousContainerDispose,
+  ) async {
     if (!mounted) {
       // The host is gone; the caller owns the orphaned container.
       next.dispose();
@@ -103,8 +115,20 @@ class _ContainerSwapHostState extends State<ContainerSwapHost> {
     });
 
     // Dispose the leaving container only after this frame commits, so widgets
-    // still reading it during the unmount don't hit a disposed container.
-    WidgetsBinding.instance.addPostFrameCallback((_) => previous.dispose());
+    // still reading it during the unmount don't hit a disposed container. A
+    // post-commit cleanup may retain account-scoped signers owned by that
+    // container, so keep it alive until the cleanup settles.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      unawaited(
+        (() async {
+          try {
+            await beforePreviousContainerDispose?.call();
+          } finally {
+            previous.dispose();
+          }
+        })(),
+      );
+    });
   }
 
   @override

--- a/mobile/lib/providers/notifications_providers.dart
+++ b/mobile/lib/providers/notifications_providers.dart
@@ -251,6 +251,10 @@ PushNotificationSessionCoordinator? pushNotificationSync(Ref ref) {
 
   final authService = ref.watch(authServiceProvider);
   ref.watch(notificationPreferencesDirtySyncBridgeProvider);
+  final nostrClientFactory = ref.read(nostrClientFactoryProvider);
+  final relayStatisticsService = ref.read(relayStatisticsServiceProvider);
+  final environmentConfig = ref.read(currentEnvironmentProvider);
+  final dbClient = ref.read(appDbClientProvider);
 
   final coordinator = PushNotificationSessionCoordinator(
     authService: authService,
@@ -258,12 +262,11 @@ PushNotificationSessionCoordinator? pushNotificationSync(Ref ref) {
     readReadiness: () => ref.read(nostrSessionProvider),
     readPushService: () => ref.read(pushNotificationServiceProvider),
     createCleanupClient: (identity) {
-      final factory = ref.read(nostrClientFactoryProvider);
-      return factory(
+      return nostrClientFactory(
         signer: identity,
-        statisticsService: ref.read(relayStatisticsServiceProvider),
-        environmentConfig: ref.read(currentEnvironmentProvider),
-        dbClient: ref.read(appDbClientProvider),
+        statisticsService: relayStatisticsService,
+        environmentConfig: environmentConfig,
+        dbClient: dbClient,
       );
     },
   );

--- a/mobile/lib/providers/notifications_providers.dart
+++ b/mobile/lib/providers/notifications_providers.dart
@@ -10,7 +10,6 @@ import 'package:openvine/providers/auth_providers.dart';
 import 'package:openvine/providers/database_provider.dart';
 import 'package:openvine/providers/environment_provider.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
-import 'package:openvine/providers/relay_providers.dart';
 import 'package:openvine/services/app_badge_service.dart';
 import 'package:openvine/services/notification_preferences_service.dart';
 import 'package:openvine/services/notification_service.dart';
@@ -252,8 +251,6 @@ PushNotificationSessionCoordinator? pushNotificationSync(Ref ref) {
   final authService = ref.watch(authServiceProvider);
   ref.watch(notificationPreferencesDirtySyncBridgeProvider);
   final nostrClientFactory = ref.read(nostrClientFactoryProvider);
-  final relayStatisticsService = ref.read(relayStatisticsServiceProvider);
-  final environmentConfig = ref.read(currentEnvironmentProvider);
   final dbClient = ref.read(appDbClientProvider);
 
   final coordinator = PushNotificationSessionCoordinator(
@@ -261,10 +258,10 @@ PushNotificationSessionCoordinator? pushNotificationSync(Ref ref) {
     firebaseMessaging: ref.read(firebaseMessagingProvider),
     readReadiness: () => ref.read(nostrSessionProvider),
     readPushService: () => ref.read(pushNotificationServiceProvider),
-    createCleanupClient: (identity) {
-      return nostrClientFactory(
+    readCleanupClientFactory: () {
+      final environmentConfig = ref.read(currentEnvironmentProvider);
+      return (identity) => nostrClientFactory(
         signer: identity,
-        statisticsService: relayStatisticsService,
         environmentConfig: environmentConfig,
         dbClient: dbClient,
       );

--- a/mobile/lib/providers/notifications_providers.dart
+++ b/mobile/lib/providers/notifications_providers.dart
@@ -239,12 +239,14 @@ final notificationPreferencesServiceProvider =
 ///
 /// Registers FCM token only after the signer-backed Nostr client is ready.
 /// Deregisters the last ready client through AuthService's pre-teardown hook so
-/// outgoing-session cleanup runs before signers and callbacks are cleared.
+/// outgoing-session cleanup runs before signers and callbacks are cleared. The
+/// returned coordinator lets account switching run the same captured-identity
+/// cleanup after the replacement account has committed.
 @Riverpod(keepAlive: true)
-void pushNotificationSync(Ref ref) {
+PushNotificationSessionCoordinator? pushNotificationSync(Ref ref) {
   // Firebase Messaging only supports Android, iOS, macOS, and web.
   if (!isFirebaseSupported) {
-    return;
+    return null;
   }
 
   final authService = ref.watch(authServiceProvider);
@@ -295,4 +297,6 @@ void pushNotificationSync(Ref ref) {
     authStateSubscription.cancel();
     onMessageSubscription.cancel();
   });
+
+  return coordinator;
 }

--- a/mobile/lib/providers/notifications_providers.g.dart
+++ b/mobile/lib/providers/notifications_providers.g.dart
@@ -12,7 +12,9 @@ part of 'notifications_providers.dart';
 ///
 /// Registers FCM token only after the signer-backed Nostr client is ready.
 /// Deregisters the last ready client through AuthService's pre-teardown hook so
-/// outgoing-session cleanup runs before signers and callbacks are cleared.
+/// outgoing-session cleanup runs before signers and callbacks are cleared. The
+/// returned coordinator lets account switching run the same captured-identity
+/// cleanup after the replacement account has committed.
 
 @ProviderFor(pushNotificationSync)
 final pushNotificationSyncProvider = PushNotificationSyncProvider._();
@@ -21,16 +23,25 @@ final pushNotificationSyncProvider = PushNotificationSyncProvider._();
 ///
 /// Registers FCM token only after the signer-backed Nostr client is ready.
 /// Deregisters the last ready client through AuthService's pre-teardown hook so
-/// outgoing-session cleanup runs before signers and callbacks are cleared.
+/// outgoing-session cleanup runs before signers and callbacks are cleared. The
+/// returned coordinator lets account switching run the same captured-identity
+/// cleanup after the replacement account has committed.
 
 final class PushNotificationSyncProvider
-    extends $FunctionalProvider<void, void, void>
-    with $Provider<void> {
+    extends
+        $FunctionalProvider<
+          PushNotificationSessionCoordinator?,
+          PushNotificationSessionCoordinator?,
+          PushNotificationSessionCoordinator?
+        >
+    with $Provider<PushNotificationSessionCoordinator?> {
   /// Bridges Nostr session readiness to push notification registration.
   ///
   /// Registers FCM token only after the signer-backed Nostr client is ready.
   /// Deregisters the last ready client through AuthService's pre-teardown hook so
-  /// outgoing-session cleanup runs before signers and callbacks are cleared.
+  /// outgoing-session cleanup runs before signers and callbacks are cleared. The
+  /// returned coordinator lets account switching run the same captured-identity
+  /// cleanup after the replacement account has committed.
   PushNotificationSyncProvider._()
     : super(
         from: null,
@@ -47,22 +58,25 @@ final class PushNotificationSyncProvider
 
   @$internal
   @override
-  $ProviderElement<void> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(pointer);
+  $ProviderElement<PushNotificationSessionCoordinator?> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
 
   @override
-  void create(Ref ref) {
+  PushNotificationSessionCoordinator? create(Ref ref) {
     return pushNotificationSync(ref);
   }
 
   /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(void value) {
+  Override overrideWithValue(PushNotificationSessionCoordinator? value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $SyncValueProvider<void>(value),
+      providerOverride: $SyncValueProvider<PushNotificationSessionCoordinator?>(
+        value,
+      ),
     );
   }
 }
 
 String _$pushNotificationSyncHash() =>
-    r'bd7c6af23335a355541b7086d8afedf15743369b';
+    r'ec334ed56ef7af263fc6104ae3e0e19db5be44ec';

--- a/mobile/lib/providers/notifications_providers.g.dart
+++ b/mobile/lib/providers/notifications_providers.g.dart
@@ -79,4 +79,4 @@ final class PushNotificationSyncProvider
 }
 
 String _$pushNotificationSyncHash() =>
-    r'6737aee3e63253d4a7b2a50a2e9388ce3b5845ee';
+    r'6cdcb5f909f6463828420979de4373f3c7a3fc3e';

--- a/mobile/lib/providers/notifications_providers.g.dart
+++ b/mobile/lib/providers/notifications_providers.g.dart
@@ -79,4 +79,4 @@ final class PushNotificationSyncProvider
 }
 
 String _$pushNotificationSyncHash() =>
-    r'ec334ed56ef7af263fc6104ae3e0e19db5be44ec';
+    r'6737aee3e63253d4a7b2a50a2e9388ce3b5845ee';

--- a/mobile/lib/providers/swap_account.dart
+++ b/mobile/lib/providers/swap_account.dart
@@ -199,7 +199,18 @@ Future<void> swapAccount({
           })(),
         );
       }
-      await container.read(authServiceProvider).claimLegacyRowsForCurrentUser();
+      try {
+        await container
+            .read(authServiceProvider)
+            .claimLegacyRowsForCurrentUser();
+      } catch (error) {
+        // The target container is already mounted and the outgoing container
+        // has been retired, so this post-commit migration cannot be rolled back.
+        Log.warning(
+          'Claiming legacy user data after account swap failed: $error',
+          name: 'swapAccount',
+        );
+      }
     } catch (_) {
       try {
         await currentAuthService.restoreSignerInfoForCurrentAccount();

--- a/mobile/lib/providers/swap_account.dart
+++ b/mobile/lib/providers/swap_account.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Orchestrates an in-place account switch — build a container, sign it
 // ABOUTME: in as the target account, then swap; roll back on failure.
 
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:nostr_key_manager/nostr_key_manager.dart';
 import 'package:openvine/models/known_account.dart';
@@ -181,17 +183,21 @@ Future<void> swapAccount({
       await signIn(container, account);
       await controller.swapTo(container);
       if (outgoingPushCoordinator != null) {
-        try {
-          await outgoingPushCoordinator
-              .deregisterLastReadyPubkeyAfterAccountSwitch();
-        } catch (error) {
-          // The target account is already live. Push cleanup is best-effort and
-          // must not turn a committed switch into a broken rollback attempt.
-          Log.warning(
-            'Outgoing account push deregistration failed: $error',
-            name: 'swapAccount',
-          );
-        }
+        unawaited(
+          (() async {
+            try {
+              await outgoingPushCoordinator
+                  .deregisterLastReadyPubkeyAfterAccountSwitch();
+            } catch (error) {
+              // The target account is already live. Push cleanup is best-effort
+              // and must not turn a committed switch into a rollback attempt.
+              Log.warning(
+                'Outgoing account push deregistration failed: $error',
+                name: 'swapAccount',
+              );
+            }
+          })(),
+        );
       }
       await container.read(authServiceProvider).claimLegacyRowsForCurrentUser();
     } catch (_) {

--- a/mobile/lib/providers/swap_account.dart
+++ b/mobile/lib/providers/swap_account.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Orchestrates an in-place account switch — build a container, sign it
 // ABOUTME: in as the target account, then swap; roll back on failure.
 
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:nostr_key_manager/nostr_key_manager.dart';
 import 'package:openvine/models/known_account.dart';
@@ -24,6 +26,8 @@ import 'package:unified_logger/unified_logger.dart';
 /// skip the side-effect-free `activate()` refactor (design §8.2 correction).
 typedef AccountSignIn =
     Future<void> Function(ProviderContainer container, KnownAccount account);
+
+const _accountSwitchPushCleanupTimeout = Duration(seconds: 15);
 
 Future<void> _defaultSignIn(
   ProviderContainer container,
@@ -186,7 +190,8 @@ Future<void> swapAccount({
             : () async {
                 try {
                   await outgoingPushCoordinator
-                      .deregisterLastReadyPubkeyAfterAccountSwitch();
+                      .deregisterLastReadyPubkeyAfterAccountSwitch()
+                      .timeout(_accountSwitchPushCleanupTimeout);
                 } catch (error) {
                   // The target account is already live. Push cleanup is
                   // best-effort and must not turn a committed switch into a

--- a/mobile/lib/providers/swap_account.dart
+++ b/mobile/lib/providers/swap_account.dart
@@ -8,6 +8,7 @@ import 'package:openvine/providers/auth_providers.dart';
 import 'package:openvine/providers/container_swap_host.dart';
 import 'package:openvine/providers/device_scope.dart';
 import 'package:openvine/providers/environment_provider.dart';
+import 'package:openvine/providers/notifications_providers.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/router/app_router.dart';
 import 'package:openvine/services/auth_service.dart';
@@ -132,6 +133,12 @@ String? accountSwitchInitialLocation({
 /// intentionally: it only ever copies the leaving account's own credentials
 /// into its own slot.
 ///
+/// Push deregistration follows the same commit boundary. The outgoing
+/// coordinator is captured before sign-in can replace shared signer storage,
+/// but it runs only after [AccountSwitchController.swapTo] succeeds. Its
+/// dedicated cleanup client can then publish for the outgoing identity even as
+/// the old account container is being torn down.
+///
 /// Rolling the container back is not enough on its own: a sign-in that got far
 /// enough to fail has already restored the *target* account's signer keys over
 /// the shared slots and persisted its auth source, which the live container
@@ -151,6 +158,10 @@ Future<void> swapAccount({
   await controller.runExclusive(() async {
     await currentAuthService.archiveCurrentSignerInfo();
     final current = controller.currentContainer;
+    final outgoingPushCoordinator =
+        current != null && current.exists(pushNotificationSyncProvider)
+        ? current.read(pushNotificationSyncProvider)
+        : null;
     final currentLocation = accountSwitchInitialLocation(
       currentLocation: _currentRouterLocation(controller),
       currentPubkeyHex: current?.read(authServiceProvider).currentPublicKeyHex,
@@ -169,6 +180,19 @@ Future<void> swapAccount({
       previousPrimary = await keyStorage.getKeyContainer();
       await signIn(container, account);
       await controller.swapTo(container);
+      if (outgoingPushCoordinator != null) {
+        try {
+          await outgoingPushCoordinator
+              .deregisterLastReadyPubkeyAfterAccountSwitch();
+        } catch (error) {
+          // The target account is already live. Push cleanup is best-effort and
+          // must not turn a committed switch into a broken rollback attempt.
+          Log.warning(
+            'Outgoing account push deregistration failed: $error',
+            name: 'swapAccount',
+          );
+        }
+      }
       await container.read(authServiceProvider).claimLegacyRowsForCurrentUser();
     } catch (_) {
       try {

--- a/mobile/lib/providers/swap_account.dart
+++ b/mobile/lib/providers/swap_account.dart
@@ -1,8 +1,6 @@
 // ABOUTME: Orchestrates an in-place account switch — build a container, sign it
 // ABOUTME: in as the target account, then swap; roll back on failure.
 
-import 'dart:async';
-
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:nostr_key_manager/nostr_key_manager.dart';
 import 'package:openvine/models/known_account.dart';
@@ -137,9 +135,9 @@ String? accountSwitchInitialLocation({
 ///
 /// Push deregistration follows the same commit boundary. The outgoing
 /// coordinator is captured before sign-in can replace shared signer storage,
-/// but it runs only after [AccountSwitchController.swapTo] succeeds. Its
-/// dedicated cleanup client can then publish for the outgoing identity even as
-/// the old account container is being torn down.
+/// but it runs only after [AccountSwitchController.swapTo] commits the target.
+/// The swap host retains the outgoing container until cleanup settles so its
+/// account-scoped signer remains usable throughout deregistration.
 ///
 /// Rolling the container back is not enough on its own: a sign-in that got far
 /// enough to fail has already restored the *target* account's signer keys over
@@ -181,31 +179,32 @@ Future<void> swapAccount({
     try {
       previousPrimary = await keyStorage.getKeyContainer();
       await signIn(container, account);
-      await controller.swapTo(container);
-      if (outgoingPushCoordinator != null) {
-        unawaited(
-          (() async {
-            try {
-              await outgoingPushCoordinator
-                  .deregisterLastReadyPubkeyAfterAccountSwitch();
-            } catch (error) {
-              // The target account is already live. Push cleanup is best-effort
-              // and must not turn a committed switch into a rollback attempt.
-              Log.warning(
-                'Outgoing account push deregistration failed: $error',
-                name: 'swapAccount',
-              );
-            }
-          })(),
-        );
-      }
+      await controller.swapTo(
+        container,
+        beforePreviousContainerDispose: outgoingPushCoordinator == null
+            ? null
+            : () async {
+                try {
+                  await outgoingPushCoordinator
+                      .deregisterLastReadyPubkeyAfterAccountSwitch();
+                } catch (error) {
+                  // The target account is already live. Push cleanup is
+                  // best-effort and must not turn a committed switch into a
+                  // rollback attempt.
+                  Log.warning(
+                    'Outgoing account push deregistration failed: $error',
+                    name: 'swapAccount',
+                  );
+                }
+              },
+      );
       try {
         await container
             .read(authServiceProvider)
             .claimLegacyRowsForCurrentUser();
       } catch (error) {
-        // The target container is already mounted and the outgoing container
-        // has been retired, so this post-commit migration cannot be rolled back.
+        // The target container is already mounted, so this post-commit
+        // migration cannot be rolled back.
         Log.warning(
           'Claiming legacy user data after account swap failed: $error',
           name: 'swapAccount',

--- a/mobile/lib/providers/swap_account.dart
+++ b/mobile/lib/providers/swap_account.dart
@@ -1,8 +1,6 @@
 // ABOUTME: Orchestrates an in-place account switch — build a container, sign it
 // ABOUTME: in as the target account, then swap; roll back on failure.
 
-import 'dart:async';
-
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:nostr_key_manager/nostr_key_manager.dart';
 import 'package:openvine/models/known_account.dart';

--- a/mobile/lib/services/push_notification_session_coordinator.dart
+++ b/mobile/lib/services/push_notification_session_coordinator.dart
@@ -16,6 +16,9 @@ import 'package:unified_logger/unified_logger.dart';
 typedef PushReadinessReader = NostrSessionReadiness Function();
 typedef PushServiceReader = PushNotificationService? Function();
 typedef CleanupClientFactory = NostrClient Function(NostrIdentity identity);
+typedef CleanupClientFactoryReader = CleanupClientFactory Function();
+
+const _pushRegistrationCleanupWaitTimeout = Duration(seconds: 4);
 
 enum _PushRegistrationPhase { beforePushService, mayPublish }
 
@@ -43,18 +46,18 @@ class PushNotificationSessionCoordinator {
     required FirebaseMessaging firebaseMessaging,
     required PushReadinessReader readReadiness,
     required PushServiceReader readPushService,
-    required CleanupClientFactory createCleanupClient,
+    required CleanupClientFactoryReader readCleanupClientFactory,
   }) : _authService = authService,
        _firebaseMessaging = firebaseMessaging,
        _readReadiness = readReadiness,
        _readPushService = readPushService,
-       _createCleanupClient = createCleanupClient;
+       _readCleanupClientFactory = readCleanupClientFactory;
 
   final AuthService _authService;
   final FirebaseMessaging _firebaseMessaging;
   final PushReadinessReader _readReadiness;
   final PushServiceReader _readPushService;
-  final CleanupClientFactory _createCleanupClient;
+  final CleanupClientFactoryReader _readCleanupClientFactory;
 
   final _activeRegistrations = <_PushRegistrationOperation>{};
   StreamSubscription<String>? _tokenRefreshSubscription;
@@ -63,6 +66,7 @@ class PushNotificationSessionCoordinator {
   NostrClient? _lastReadyClient;
   PushNotificationService? _lastReadyPushService;
   NostrIdentity? _lastReadyIdentity;
+  CleanupClientFactory? _lastReadyCleanupClientFactory;
 
   void dispose() {
     _tokenRefreshSubscription?.cancel();
@@ -77,6 +81,7 @@ class PushNotificationSessionCoordinator {
       _lastReadyClient = null;
       _lastReadyPushService = null;
       _lastReadyIdentity = null;
+      _lastReadyCleanupClientFactory = null;
       _invalidateActiveRegistrations();
     }
   }
@@ -92,6 +97,7 @@ class PushNotificationSessionCoordinator {
         _lastReadyClient = null;
         _lastReadyPushService = null;
         _lastReadyIdentity = null;
+        _lastReadyCleanupClientFactory = null;
       }
       return;
     }
@@ -101,6 +107,7 @@ class PushNotificationSessionCoordinator {
       _lastReadyClient = null;
       _lastReadyPushService = null;
       _lastReadyIdentity = null;
+      _lastReadyCleanupClientFactory = null;
       _invalidateActiveRegistrations();
       return;
     }
@@ -113,6 +120,7 @@ class PushNotificationSessionCoordinator {
       _lastReadyClient = null;
       _lastReadyPushService = null;
       _lastReadyIdentity = null;
+      _lastReadyCleanupClientFactory = null;
       _invalidateActiveRegistrations();
       return;
     }
@@ -121,6 +129,7 @@ class PushNotificationSessionCoordinator {
     _lastReadyClient = readiness.client;
     _lastReadyPushService = pushService;
     _lastReadyIdentity = identity;
+    _lastReadyCleanupClientFactory = _readCleanupClientFactory();
     _ensureTokenRefreshSubscription();
     _startRegistrationOperation(
       pubkey: readyPubkey,
@@ -206,11 +215,17 @@ class PushNotificationSessionCoordinator {
     final client = _lastReadyClient;
     final pushService = _lastReadyPushService;
     final identity = _lastReadyIdentity;
+    final createCleanupClient = _lastReadyCleanupClientFactory;
     final operations = List<_PushRegistrationOperation>.of(
       _activeRegistrations,
     );
     _invalidateActiveRegistrations();
-    if (pubkey == null || client == null || pushService == null) return;
+    if (pubkey == null ||
+        client == null ||
+        pushService == null ||
+        createCleanupClient == null) {
+      return;
+    }
     pushService.deactivateRegistration();
 
     Event? deferredCleanupDeregistrationEvent;
@@ -237,7 +252,9 @@ class PushNotificationSessionCoordinator {
         await Future.wait(
           operationsToWait.map(
             (operation) =>
-                operation.future?.timeout(const Duration(seconds: 4)) ??
+                operation.future?.timeout(
+                  _pushRegistrationCleanupWaitTimeout,
+                ) ??
                 Future<void>.value(),
           ),
         );
@@ -276,6 +293,7 @@ class PushNotificationSessionCoordinator {
           deregistrationEvent,
           pushService,
           identity,
+          createCleanupClient,
         );
       } catch (e) {
         Log.warning(
@@ -292,6 +310,7 @@ class PushNotificationSessionCoordinator {
       client,
       pushService,
       identity,
+      createCleanupClient: createCleanupClient,
       requireCurrentSession: requireCurrentSession,
     );
   }
@@ -435,8 +454,9 @@ class PushNotificationSessionCoordinator {
     Event deregistrationEvent,
     PushNotificationService pushService,
     NostrIdentity identity,
+    CleanupClientFactory createCleanupClient,
   ) async {
-    final cleanupClient = _createCleanupClient(identity);
+    final cleanupClient = createCleanupClient(identity);
     try {
       await cleanupClient.initialize();
       await pushService.publishDeregistrationEvent(
@@ -453,6 +473,7 @@ class PushNotificationSessionCoordinator {
     NostrClient client,
     PushNotificationService pushService,
     NostrIdentity identity, {
+    required CleanupClientFactory createCleanupClient,
     required bool requireCurrentSession,
   }) async {
     try {
@@ -468,6 +489,7 @@ class PushNotificationSessionCoordinator {
         deregistrationEvent,
         pushService,
         identity,
+        createCleanupClient,
       );
     } catch (e) {
       Log.warning(
@@ -511,8 +533,10 @@ class PushNotificationSessionCoordinator {
     if (operation.cleanupScheduled) return;
     final registrationFuture = operation.future;
     final deregistrationEvent = operation.deferredCleanupDeregistrationEvent;
+    final createCleanupClient = _lastReadyCleanupClientFactory;
     if (registrationFuture == null) return;
     if (deregistrationEvent == null) return;
+    if (createCleanupClient == null) return;
     operation.cleanupScheduled = true;
     unawaited(
       (() async {
@@ -522,6 +546,7 @@ class PushNotificationSessionCoordinator {
             deregistrationEvent,
             operation.pushService,
             operation.identity,
+            createCleanupClient,
           );
         } catch (e) {
           Log.warning(

--- a/mobile/lib/services/push_notification_session_coordinator.dart
+++ b/mobile/lib/services/push_notification_session_coordinator.dart
@@ -187,7 +187,21 @@ class PushNotificationSessionCoordinator {
     );
   }
 
-  Future<void> deregisterLastReadyPubkey() async {
+  Future<void> deregisterLastReadyPubkey() =>
+      _deregisterLastReadyPubkey(requireCurrentSession: true);
+
+  /// Deregisters the captured outgoing session after an account swap commits.
+  ///
+  /// Unlike sign-out teardown, the old provider container may be disposed while
+  /// this work awaits the cleanup client. The captured pubkey and identity are
+  /// authoritative for this explicit switch, so this path never reads the old
+  /// Riverpod session after the swap.
+  Future<void> deregisterLastReadyPubkeyAfterAccountSwitch() =>
+      _deregisterLastReadyPubkey(requireCurrentSession: false);
+
+  Future<void> _deregisterLastReadyPubkey({
+    required bool requireCurrentSession,
+  }) async {
     final pubkey = _lastReadyPubkey;
     final client = _lastReadyClient;
     final pushService = _lastReadyPushService;
@@ -203,7 +217,10 @@ class PushNotificationSessionCoordinator {
     for (final operation in operations) {
       if (operation.phase == _PushRegistrationPhase.mayPublish) {
         deferredCleanupDeregistrationEvent ??=
-            await _createDeferredCleanupDeregistrationEvent(operation);
+            await _createDeferredCleanupDeregistrationEvent(
+              operation,
+              requireCurrentSession: requireCurrentSession,
+            );
         operation.deferredCleanupDeregistrationEvent ??=
             deferredCleanupDeregistrationEvent;
       }
@@ -235,10 +252,20 @@ class PushNotificationSessionCoordinator {
       }
     }
 
-    if (!_isOutgoingSessionCurrent(pubkey, client, pushService)) return;
+    if (requireCurrentSession &&
+        !_isOutgoingSessionCurrent(pubkey, client, pushService)) {
+      return;
+    }
 
     if (identity == null) {
-      await _deregisterCapturedPubkey(pubkey, client, pushService, null, null);
+      await _deregisterCapturedPubkey(
+        pubkey,
+        client,
+        pushService,
+        null,
+        null,
+        requireCurrentSession: requireCurrentSession,
+      );
       return;
     }
 
@@ -260,7 +287,13 @@ class PushNotificationSessionCoordinator {
       return;
     }
 
-    await _deregisterWithCleanupClient(pubkey, client, pushService, identity);
+    await _deregisterWithCleanupClient(
+      pubkey,
+      client,
+      pushService,
+      identity,
+      requireCurrentSession: requireCurrentSession,
+    );
   }
 
   void _invalidateActiveRegistrations() {
@@ -377,12 +410,13 @@ class PushNotificationSessionCoordinator {
     NostrClient client,
     PushNotificationService pushService,
     NostrIdentity? signingIdentity,
-    NostrClient? publishClient,
-  ) async {
+    NostrClient? publishClient, {
+    required bool requireCurrentSession,
+  }) async {
     try {
       await pushService.deregister(
         pubkey,
-        isCurrent: publishClient == null
+        isCurrent: requireCurrentSession && publishClient == null
             ? () => _isOutgoingSessionCurrent(pubkey, client, pushService)
             : null,
         signingIdentity: signingIdentity,
@@ -418,10 +452,14 @@ class PushNotificationSessionCoordinator {
     String pubkey,
     NostrClient client,
     PushNotificationService pushService,
-    NostrIdentity identity,
-  ) async {
+    NostrIdentity identity, {
+    required bool requireCurrentSession,
+  }) async {
     try {
-      if (!_isOutgoingSessionCurrent(pubkey, client, pushService)) return;
+      if (requireCurrentSession &&
+          !_isOutgoingSessionCurrent(pubkey, client, pushService)) {
+        return;
+      }
       final deregistrationEvent = await pushService
           .createSignedDeregistrationEvent(pubkey, signingIdentity: identity);
       if (deregistrationEvent == null) return;
@@ -441,14 +479,16 @@ class PushNotificationSessionCoordinator {
   }
 
   Future<Event?> _createDeferredCleanupDeregistrationEvent(
-    _PushRegistrationOperation operation,
-  ) async {
+    _PushRegistrationOperation operation, {
+    required bool requireCurrentSession,
+  }) async {
     try {
-      if (!_isOutgoingSessionCurrent(
-        operation.pubkey,
-        operation.client,
-        operation.pushService,
-      )) {
+      if (requireCurrentSession &&
+          !_isOutgoingSessionCurrent(
+            operation.pubkey,
+            operation.client,
+            operation.pushService,
+          )) {
         return null;
       }
       return await operation.pushService.createSignedDeregistrationEvent(

--- a/mobile/lib/services/push_notification_session_coordinator.dart
+++ b/mobile/lib/services/push_notification_session_coordinator.dart
@@ -192,10 +192,10 @@ class PushNotificationSessionCoordinator {
 
   /// Deregisters the captured outgoing session after an account swap commits.
   ///
-  /// Unlike sign-out teardown, the old provider container may be disposed while
-  /// this work awaits the cleanup client. The captured pubkey and identity are
-  /// authoritative for this explicit switch, so this path never reads the old
-  /// Riverpod session after the swap.
+  /// Unlike sign-out teardown, this runs after the target container commits.
+  /// The swap host retains the outgoing provider container until this work
+  /// settles, while the captured pubkey and identity keep cleanup scoped to the
+  /// account being left.
   Future<void> deregisterLastReadyPubkeyAfterAccountSwitch() =>
       _deregisterLastReadyPubkey(requireCurrentSession: false);
 

--- a/mobile/test/providers/container_swap_host_test.dart
+++ b/mobile/test/providers/container_swap_host_test.dart
@@ -68,6 +68,34 @@ void main() {
       expect(() => first.read(_valueProvider), throwsStateError);
     });
 
+    testWidgets('retains the previous container until cleanup settles', (
+      tester,
+    ) async {
+      final controller = AccountSwitchController();
+      final first = containerWith('A');
+      final cleanupCompleter = Completer<void>();
+      await tester.pumpWidget(
+        ContainerSwapHost(
+          initialContainer: first,
+          controller: controller,
+          child: const _ValueText(),
+        ),
+      );
+
+      await controller.swapTo(
+        containerWith('B'),
+        beforePreviousContainerDispose: () => cleanupCompleter.future,
+      );
+      await tester.pump();
+
+      expect(first.read(_valueProvider), 'A');
+
+      cleanupCompleter.complete();
+      await tester.pump();
+
+      expect(() => first.read(_valueProvider), throwsStateError);
+    });
+
     testWidgets('swap remounts container-owned child state', (tester) async {
       final controller = AccountSwitchController();
       var initStateCount = 0;

--- a/mobile/test/providers/push_notification_sync_test.dart
+++ b/mobile/test/providers/push_notification_sync_test.dart
@@ -1542,7 +1542,7 @@ void main() {
     );
 
     test(
-      'direct pre-teardown deregistration uses a captured cleanup client',
+      'account-switch cleanup survives outgoing container disposal',
       () async {
         final tokenRefreshController = StreamController<String>.broadcast();
         addTearDown(tokenRefreshController.close);
@@ -1608,8 +1608,7 @@ void main() {
             ),
           ],
         );
-        addTearDown(container.dispose);
-        container.read(pushNotificationSyncProvider);
+        final coordinator = container.read(pushNotificationSyncProvider)!;
 
         when(() => nostrClient.publicKey).thenReturn(pubkeyA);
         nostrSession.setReadiness(
@@ -1621,7 +1620,8 @@ void main() {
         await Future<void>.delayed(Duration.zero);
         await Future<void>.delayed(Duration.zero);
 
-        final teardownFuture = beforeSessionTeardownCallback!();
+        final teardownFuture = coordinator
+            .deregisterLastReadyPubkeyAfterAccountSwitch();
         await Future<void>.delayed(Duration.zero);
         await Future<void>.delayed(Duration.zero);
 
@@ -1635,6 +1635,7 @@ void main() {
           ),
         );
 
+        container.dispose();
         initializeCompleter.complete();
         await teardownFuture;
 

--- a/mobile/test/providers/push_notification_sync_test.dart
+++ b/mobile/test/providers/push_notification_sync_test.dart
@@ -1570,7 +1570,10 @@ void main() {
         when(
           () => signer.nip44Encrypt(any(), any()),
         ).thenAnswer((_) async => 'encrypted-dereg-token');
-        when(() => messaging.getToken()).thenAnswer((_) async => 'fcm-token');
+        final tokenCompleter = Completer<String?>();
+        when(
+          () => messaging.getToken(),
+        ).thenAnswer((_) => tokenCompleter.future);
         when(
           () => cleanupClient.publishEventAwaitOk(
             event,
@@ -1625,8 +1628,8 @@ void main() {
         await Future<void>.delayed(Duration.zero);
         await Future<void>.delayed(Duration.zero);
 
-        verify(() => signer.signEvent(any())).called(1);
-        verify(cleanupClient.initialize).called(1);
+        verify(() => messaging.getToken()).called(1);
+        verifyNever(cleanupClient.initialize);
         verifyNever(
           () => cleanupClient.publishEventAwaitOk(
             event,
@@ -1636,6 +1639,13 @@ void main() {
         );
 
         container.dispose();
+        tokenCompleter.complete('fcm-token');
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+
+        verify(() => signer.signEvent(any())).called(1);
+        verify(cleanupClient.initialize).called(1);
+
         initializeCompleter.complete();
         await teardownFuture;
 

--- a/mobile/test/providers/push_notification_sync_test.dart
+++ b/mobile/test/providers/push_notification_sync_test.dart
@@ -1542,7 +1542,7 @@ void main() {
     );
 
     test(
-      'account-switch cleanup survives outgoing container disposal',
+      'account-switch cleanup retains provider dependencies after disposal',
       () async {
         final tokenRefreshController = StreamController<String>.broadcast();
         addTearDown(tokenRefreshController.close);

--- a/mobile/test/providers/push_notification_sync_test.dart
+++ b/mobile/test/providers/push_notification_sync_test.dart
@@ -184,6 +184,10 @@ void main() {
     environment: AppEnvironment.test,
     configuredPushServicePubkey: pushServicePubkey,
   );
+  const stagingEnvironment = _ConfiguredEnvironmentConfig(
+    environment: AppEnvironment.staging,
+    configuredPushServicePubkey: pushServicePubkey,
+  );
 
   setUpAll(() {
     registerFallbackValue(const NotificationPreferences());
@@ -1577,11 +1581,11 @@ void main() {
         when(
           () => cleanupClient.publishEventAwaitOk(
             event,
-            targetRelays: [pushEnvironment.relayUrl],
+            targetRelays: [stagingEnvironment.relayUrl],
             timeout: const Duration(seconds: 5),
           ),
         ).thenAnswer(
-          (_) async => _acceptedOutcome(event, pushEnvironment.relayUrl),
+          (_) async => _acceptedOutcome(event, stagingEnvironment.relayUrl),
         );
         final initializeCompleter = Completer<void>();
         when(cleanupClient.initialize).thenAnswer(
@@ -1590,6 +1594,9 @@ void main() {
         // ignore: unnecessary_lambdas
         when(() => cleanupClient.dispose()).thenAnswer((_) async {});
 
+        var currentEnvironment = pushEnvironment;
+        EnvironmentConfig? cleanupEnvironment;
+        Object? cleanupStatisticsService;
         final nostrSession = _TestNostrSession(
           const NostrSessionReadiness.signedOut(),
         );
@@ -1603,17 +1610,31 @@ void main() {
             notificationServiceProvider.overrideWithValue(
               _MockNotificationService(),
             ),
-            currentEnvironmentProvider.overrideWith((_) => pushEnvironment),
+            currentEnvironmentProvider.overrideWith((_) => currentEnvironment),
             nostrSessionProvider.overrideWith(() => nostrSession),
             nostrClientFactoryProvider.overrideWithValue(
-              ({dbClient, environmentConfig, signer, statisticsService}) =>
-                  cleanupClient,
+              ({dbClient, environmentConfig, signer, statisticsService}) {
+                cleanupEnvironment = environmentConfig;
+                cleanupStatisticsService = statisticsService;
+                return cleanupClient;
+              },
             ),
           ],
         );
         final coordinator = container.read(pushNotificationSyncProvider)!;
 
         when(() => nostrClient.publicKey).thenReturn(pubkeyA);
+        nostrSession.setReadiness(
+          NostrSessionReadiness.nostrReady(
+            pubkey: pubkeyA,
+            client: nostrClient,
+          ),
+        );
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+
+        currentEnvironment = stagingEnvironment;
+        container.invalidate(currentEnvironmentProvider);
         nostrSession.setReadiness(
           NostrSessionReadiness.nostrReady(
             pubkey: pubkeyA,
@@ -1633,7 +1654,7 @@ void main() {
         verifyNever(
           () => cleanupClient.publishEventAwaitOk(
             event,
-            targetRelays: [pushEnvironment.relayUrl],
+            targetRelays: [stagingEnvironment.relayUrl],
             timeout: const Duration(seconds: 5),
           ),
         );
@@ -1645,6 +1666,8 @@ void main() {
 
         verify(() => signer.signEvent(any())).called(1);
         verify(cleanupClient.initialize).called(1);
+        expect(cleanupEnvironment, same(stagingEnvironment));
+        expect(cleanupStatisticsService, isNull);
 
         initializeCompleter.complete();
         await teardownFuture;
@@ -1652,7 +1675,7 @@ void main() {
         verify(
           () => cleanupClient.publishEventAwaitOk(
             event,
-            targetRelays: [pushEnvironment.relayUrl],
+            targetRelays: [stagingEnvironment.relayUrl],
             timeout: const Duration(seconds: 5),
           ),
         ).called(1);

--- a/mobile/test/providers/swap_account_test.dart
+++ b/mobile/test/providers/swap_account_test.dart
@@ -487,107 +487,109 @@ void main() {
     expect(events, ['sign in target', 'deregister outgoing']);
   });
 
-  testWidgets('keeps the target account live when push cleanup fails', (
-    tester,
-  ) async {
-    final pushCoordinator = _MockPushNotificationSessionCoordinator();
-    when(
-      pushCoordinator.deregisterLastReadyPubkeyAfterAccountSwitch,
-    ).thenAnswer((_) async => throw Exception('relay unavailable'));
-    final initial = await pumpHost(
+  group('account swap failure boundaries', () {
+    testWidgets('keeps the target account live when push cleanup fails', (
       tester,
-      accountOverrides: [
-        pushNotificationSyncProvider.overrideWithValue(pushCoordinator),
-      ],
-    );
-    initial.read(pushNotificationSyncProvider);
-    ProviderContainer? signedInto;
+    ) async {
+      final pushCoordinator = _MockPushNotificationSessionCoordinator();
+      when(
+        pushCoordinator.deregisterLastReadyPubkeyAfterAccountSwitch,
+      ).thenAnswer((_) async => throw Exception('relay unavailable'));
+      final initial = await pumpHost(
+        tester,
+        accountOverrides: [
+          pushNotificationSyncProvider.overrideWithValue(pushCoordinator),
+        ],
+      );
+      initial.read(pushNotificationSyncProvider);
+      ProviderContainer? signedInto;
 
-    await swapAccount(
-      deviceScope: deviceScope,
-      controller: controller,
-      currentAuthService: currentAuthService,
-      account: account,
-      signIn: (container, _) async => signedInto = container,
-    );
-    await tester.pump();
-
-    expect(controller.currentContainer, same(signedInto));
-    expect(_isDisposed(signedInto!), isFalse);
-    expect(_isDisposed(initial), isTrue);
-    expect(currentAuthService.calls, equals(['archive']));
-  });
-
-  testWidgets('keeps outgoing push registration when target swap fails', (
-    tester,
-  ) async {
-    final pushCoordinator = _MockPushNotificationSessionCoordinator();
-    when(
-      pushCoordinator.deregisterLastReadyPubkeyAfterAccountSwitch,
-    ).thenAnswer((_) async {});
-    final initial = await pumpHost(
-      tester,
-      accountOverrides: [
-        pushNotificationSyncProvider.overrideWithValue(pushCoordinator),
-      ],
-    );
-    initial.read(pushNotificationSyncProvider);
-    ProviderContainer? attempted;
-
-    await expectLater(
-      swapAccount(
+      await swapAccount(
         deviceScope: deviceScope,
         controller: controller,
         currentAuthService: currentAuthService,
         account: account,
-        signIn: (container, _) async {
-          attempted = container;
-          await tester.pumpWidget(const SizedBox());
-        },
-      ),
-      throwsStateError,
-    );
+        signIn: (container, _) async => signedInto = container,
+      );
+      await tester.pump();
 
-    expect(attempted, isNotNull);
-    expect(_isDisposed(attempted!), isTrue);
-    expect(currentAuthService.calls, equals(['archive', 'restore']));
-    verifyNever(pushCoordinator.deregisterLastReadyPubkeyAfterAccountSwitch);
-  });
+      expect(controller.currentContainer, same(signedInto));
+      expect(_isDisposed(signedInto!), isFalse);
+      expect(_isDisposed(initial), isTrue);
+      expect(currentAuthService.calls, equals(['archive']));
+    });
 
-  testWidgets('keeps the target account live when legacy claiming fails', (
-    tester,
-  ) async {
-    final targetAuthService = _MockAuthService();
-    when(
-      targetAuthService.claimLegacyRowsForCurrentUser,
-    ).thenThrow(Exception('database unavailable'));
-    deviceScope = DeviceScope(
-      database: database,
-      sharedPreferences: deviceScope.sharedPreferences,
-      switchController: controller,
-      appVersion: 'test',
-      documentsPath: '/documents',
-      accountOverrides: [
-        secureKeyStorageProvider.overrideWithValue(keyStorage),
-        authServiceProvider.overrideWithValue(targetAuthService),
-      ],
-    );
-    final initial = await pumpHost(tester);
-    ProviderContainer? signedInto;
+    testWidgets('keeps outgoing push registration when target swap fails', (
+      tester,
+    ) async {
+      final pushCoordinator = _MockPushNotificationSessionCoordinator();
+      when(
+        pushCoordinator.deregisterLastReadyPubkeyAfterAccountSwitch,
+      ).thenAnswer((_) async {});
+      final initial = await pumpHost(
+        tester,
+        accountOverrides: [
+          pushNotificationSyncProvider.overrideWithValue(pushCoordinator),
+        ],
+      );
+      initial.read(pushNotificationSyncProvider);
+      ProviderContainer? attempted;
 
-    await swapAccount(
-      deviceScope: deviceScope,
-      controller: controller,
-      currentAuthService: currentAuthService,
-      account: account,
-      signIn: (container, _) async => signedInto = container,
-    );
-    await tester.pump();
+      await expectLater(
+        swapAccount(
+          deviceScope: deviceScope,
+          controller: controller,
+          currentAuthService: currentAuthService,
+          account: account,
+          signIn: (container, _) async {
+            attempted = container;
+            await tester.pumpWidget(const SizedBox());
+          },
+        ),
+        throwsStateError,
+      );
 
-    expect(controller.currentContainer, same(signedInto));
-    expect(_isDisposed(signedInto!), isFalse);
-    expect(_isDisposed(initial), isTrue);
-    expect(currentAuthService.calls, equals(['archive']));
+      expect(attempted, isNotNull);
+      expect(_isDisposed(attempted!), isTrue);
+      expect(currentAuthService.calls, equals(['archive', 'restore']));
+      verifyNever(pushCoordinator.deregisterLastReadyPubkeyAfterAccountSwitch);
+    });
+
+    testWidgets('keeps the target account live when legacy claiming fails', (
+      tester,
+    ) async {
+      final targetAuthService = _MockAuthService();
+      when(
+        targetAuthService.claimLegacyRowsForCurrentUser,
+      ).thenThrow(Exception('database unavailable'));
+      deviceScope = DeviceScope(
+        database: database,
+        sharedPreferences: deviceScope.sharedPreferences,
+        switchController: controller,
+        appVersion: 'test',
+        documentsPath: '/documents',
+        accountOverrides: [
+          secureKeyStorageProvider.overrideWithValue(keyStorage),
+          authServiceProvider.overrideWithValue(targetAuthService),
+        ],
+      );
+      final initial = await pumpHost(tester);
+      ProviderContainer? signedInto;
+
+      await swapAccount(
+        deviceScope: deviceScope,
+        controller: controller,
+        currentAuthService: currentAuthService,
+        account: account,
+        signIn: (container, _) async => signedInto = container,
+      );
+      await tester.pump();
+
+      expect(controller.currentContainer, same(signedInto));
+      expect(_isDisposed(signedInto!), isFalse);
+      expect(_isDisposed(initial), isTrue);
+      expect(currentAuthService.calls, equals(['archive']));
+    });
   });
 
   testWidgets('keeps outgoing push registration when target sign-in fails', (

--- a/mobile/test/providers/swap_account_test.dart
+++ b/mobile/test/providers/swap_account_test.dart
@@ -487,6 +487,73 @@ void main() {
     expect(events, ['sign in target', 'deregister outgoing']);
   });
 
+  testWidgets('keeps the target account live when push cleanup fails', (
+    tester,
+  ) async {
+    final pushCoordinator = _MockPushNotificationSessionCoordinator();
+    when(
+      pushCoordinator.deregisterLastReadyPubkeyAfterAccountSwitch,
+    ).thenThrow(Exception('relay unavailable'));
+    final initial = await pumpHost(
+      tester,
+      accountOverrides: [
+        pushNotificationSyncProvider.overrideWithValue(pushCoordinator),
+      ],
+    );
+    initial.read(pushNotificationSyncProvider);
+    ProviderContainer? signedInto;
+
+    await swapAccount(
+      deviceScope: deviceScope,
+      controller: controller,
+      currentAuthService: currentAuthService,
+      account: account,
+      signIn: (container, _) async => signedInto = container,
+    );
+    await tester.pump();
+
+    expect(controller.currentContainer, same(signedInto));
+    expect(_isDisposed(signedInto!), isFalse);
+    expect(_isDisposed(initial), isTrue);
+    expect(currentAuthService.calls, equals(['archive']));
+  });
+
+  testWidgets('keeps the target account live when legacy claiming fails', (
+    tester,
+  ) async {
+    final targetAuthService = _MockAuthService();
+    when(
+      targetAuthService.claimLegacyRowsForCurrentUser,
+    ).thenThrow(Exception('database unavailable'));
+    deviceScope = DeviceScope(
+      database: database,
+      sharedPreferences: deviceScope.sharedPreferences,
+      switchController: controller,
+      appVersion: 'test',
+      documentsPath: '/documents',
+      accountOverrides: [
+        secureKeyStorageProvider.overrideWithValue(keyStorage),
+        authServiceProvider.overrideWithValue(targetAuthService),
+      ],
+    );
+    final initial = await pumpHost(tester);
+    ProviderContainer? signedInto;
+
+    await swapAccount(
+      deviceScope: deviceScope,
+      controller: controller,
+      currentAuthService: currentAuthService,
+      account: account,
+      signIn: (container, _) async => signedInto = container,
+    );
+    await tester.pump();
+
+    expect(controller.currentContainer, same(signedInto));
+    expect(_isDisposed(signedInto!), isFalse);
+    expect(_isDisposed(initial), isTrue);
+    expect(currentAuthService.calls, equals(['archive']));
+  });
+
   testWidgets('keeps outgoing push registration when target sign-in fails', (
     tester,
   ) async {

--- a/mobile/test/providers/swap_account_test.dart
+++ b/mobile/test/providers/swap_account_test.dart
@@ -529,6 +529,38 @@ void main() {
       expect(currentAuthService.calls, equals(['archive']));
     });
 
+    testWidgets('bounds push cleanup before disposing the outgoing account', (
+      tester,
+    ) async {
+      final cleanupCompleter = Completer<void>();
+      final pushCoordinator = _MockPushNotificationSessionCoordinator();
+      when(
+        pushCoordinator.deregisterLastReadyPubkeyAfterAccountSwitch,
+      ).thenAnswer((_) => cleanupCompleter.future);
+      final initial = await pumpHost(
+        tester,
+        accountOverrides: [
+          pushNotificationSyncProvider.overrideWithValue(pushCoordinator),
+        ],
+      );
+      initial.read(pushNotificationSyncProvider);
+
+      await swapAccount(
+        deviceScope: deviceScope,
+        controller: controller,
+        currentAuthService: currentAuthService,
+        account: account,
+        signIn: (_, _) async {},
+      );
+      await tester.pump();
+
+      expect(_isDisposed(initial), isFalse);
+
+      await tester.pump(const Duration(seconds: 15));
+
+      expect(_isDisposed(initial), isTrue);
+    });
+
     testWidgets('keeps outgoing push registration when target swap fails', (
       tester,
     ) async {

--- a/mobile/test/providers/swap_account_test.dart
+++ b/mobile/test/providers/swap_account_test.dart
@@ -493,7 +493,7 @@ void main() {
     final pushCoordinator = _MockPushNotificationSessionCoordinator();
     when(
       pushCoordinator.deregisterLastReadyPubkeyAfterAccountSwitch,
-    ).thenThrow(Exception('relay unavailable'));
+    ).thenAnswer((_) async => throw Exception('relay unavailable'));
     final initial = await pumpHost(
       tester,
       accountOverrides: [
@@ -516,6 +516,42 @@ void main() {
     expect(_isDisposed(signedInto!), isFalse);
     expect(_isDisposed(initial), isTrue);
     expect(currentAuthService.calls, equals(['archive']));
+  });
+
+  testWidgets('keeps outgoing push registration when target swap fails', (
+    tester,
+  ) async {
+    final pushCoordinator = _MockPushNotificationSessionCoordinator();
+    when(
+      pushCoordinator.deregisterLastReadyPubkeyAfterAccountSwitch,
+    ).thenAnswer((_) async {});
+    final initial = await pumpHost(
+      tester,
+      accountOverrides: [
+        pushNotificationSyncProvider.overrideWithValue(pushCoordinator),
+      ],
+    );
+    initial.read(pushNotificationSyncProvider);
+    ProviderContainer? attempted;
+
+    await expectLater(
+      swapAccount(
+        deviceScope: deviceScope,
+        controller: controller,
+        currentAuthService: currentAuthService,
+        account: account,
+        signIn: (container, _) async {
+          attempted = container;
+          await tester.pumpWidget(const SizedBox());
+        },
+      ),
+      throwsStateError,
+    );
+
+    expect(attempted, isNotNull);
+    expect(_isDisposed(attempted!), isTrue);
+    expect(currentAuthService.calls, equals(['archive', 'restore']));
+    verifyNever(pushCoordinator.deregisterLastReadyPubkeyAfterAccountSwitch);
   });
 
   testWidgets('keeps the target account live when legacy claiming fails', (

--- a/mobile/test/providers/swap_account_test.dart
+++ b/mobile/test/providers/swap_account_test.dart
@@ -14,11 +14,13 @@ import 'package:openvine/models/known_account.dart';
 import 'package:openvine/providers/auth_providers.dart';
 import 'package:openvine/providers/container_swap_host.dart';
 import 'package:openvine/providers/device_scope.dart';
+import 'package:openvine/providers/notifications_providers.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/swap_account.dart';
 import 'package:openvine/router/app_router.dart';
 import 'package:openvine/screens/profile_screen_router.dart';
 import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/push_notification_session_coordinator.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
 // Override lives in riverpod's misc barrel; flutter_riverpod does not
 // re-export the type name even though it accepts List<Override>.
@@ -26,6 +28,9 @@ import 'package:riverpod/misc.dart' show Override;
 import 'package:shared_preferences/shared_preferences.dart';
 
 class _MockAuthService extends Mock implements AuthService {}
+
+class _MockPushNotificationSessionCoordinator extends Mock
+    implements PushNotificationSessionCoordinator {}
 
 bool _isDisposed(ProviderContainer c) {
   try {
@@ -438,9 +443,27 @@ void main() {
     );
   });
 
-  testWidgets('signs in a fresh container and swaps it in', (tester) async {
-    final initial = await pumpHost(tester);
+  testWidgets('deregisters outgoing push after target swap succeeds', (
+    tester,
+  ) async {
     ProviderContainer? signedInto;
+    final events = <String>[];
+    final pushCoordinator = _MockPushNotificationSessionCoordinator();
+    when(
+      pushCoordinator.deregisterLastReadyPubkeyAfterAccountSwitch,
+    ).thenAnswer((
+      _,
+    ) async {
+      expect(controller.currentContainer, same(signedInto));
+      events.add('deregister outgoing');
+    });
+    final initial = await pumpHost(
+      tester,
+      accountOverrides: [
+        pushNotificationSyncProvider.overrideWithValue(pushCoordinator),
+      ],
+    );
+    initial.read(pushNotificationSyncProvider);
 
     await swapAccount(
       deviceScope: deviceScope,
@@ -449,6 +472,7 @@ void main() {
       account: account,
       signIn: (container, acct) async {
         signedInto = container;
+        events.add('sign in target');
         expect(acct, equals(account));
       },
     );
@@ -460,10 +484,23 @@ void main() {
     // The new container is live; the old one was disposed by the swap.
     expect(_isDisposed(signedInto!), isFalse);
     expect(_isDisposed(initial), isTrue);
+    expect(events, ['sign in target', 'deregister outgoing']);
   });
 
-  testWidgets('rolls back when sign-in fails', (tester) async {
-    final initial = await pumpHost(tester);
+  testWidgets('keeps outgoing push registration when target sign-in fails', (
+    tester,
+  ) async {
+    final pushCoordinator = _MockPushNotificationSessionCoordinator();
+    when(
+      pushCoordinator.deregisterLastReadyPubkeyAfterAccountSwitch,
+    ).thenAnswer((_) async {});
+    final initial = await pumpHost(
+      tester,
+      accountOverrides: [
+        pushNotificationSyncProvider.overrideWithValue(pushCoordinator),
+      ],
+    );
+    initial.read(pushNotificationSyncProvider);
     ProviderContainer? attempted;
     keyStorage.primary = _FakeSecureKeyContainer(
       npub: 'npub_previous',
@@ -496,6 +533,7 @@ void main() {
     // its container does not undo that — the leaving account's own keys have
     // to go back, or it reads the wrong signer at the next launch.
     expect(currentAuthService.calls, equals(['archive', 'restore']));
+    verifyNever(pushCoordinator.deregisterLastReadyPubkeyAfterAccountSwitch);
   });
 
   testWidgets('archives the leaving account before signing the new one in', (

--- a/mobile/test/providers/swap_account_test.dart
+++ b/mobile/test/providers/swap_account_test.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Tests swapAccount orchestration — build, sign in, swap; roll back
 // ABOUTME: (dispose the new container, leave the old) when sign-in fails.
 
+import 'dart:async';
+
 import 'package:db_client/db_client.dart';
 import 'package:drift/native.dart';
 import 'package:flutter/material.dart';
@@ -448,6 +450,7 @@ void main() {
   ) async {
     ProviderContainer? signedInto;
     final events = <String>[];
+    final cleanupCompleter = Completer<void>();
     final pushCoordinator = _MockPushNotificationSessionCoordinator();
     when(
       pushCoordinator.deregisterLastReadyPubkeyAfterAccountSwitch,
@@ -456,6 +459,7 @@ void main() {
     ) async {
       expect(controller.currentContainer, same(signedInto));
       events.add('deregister outgoing');
+      await cleanupCompleter.future;
     });
     final initial = await pumpHost(
       tester,
@@ -481,10 +485,16 @@ void main() {
     // Signed into a freshly-built container, not the initial one.
     expect(signedInto, isNotNull);
     expect(signedInto, isNot(same(initial)));
-    // The new container is live; the old one was disposed by the swap.
+    // The target is live, but the old container still owns the signer needed by
+    // the outgoing cleanup and cannot be disposed until that work settles.
     expect(_isDisposed(signedInto!), isFalse);
-    expect(_isDisposed(initial), isTrue);
+    expect(_isDisposed(initial), isFalse);
     expect(events, ['sign in target', 'deregister outgoing']);
+
+    cleanupCompleter.complete();
+    await tester.pump();
+
+    expect(_isDisposed(initial), isTrue);
   });
 
   group('account swap failure boundaries', () {


### PR DESCRIPTION
## Description

Switching accounts could leave the device's push token registered to the outgoing account. This change runs outgoing deregistration only after the target account signs in and mounts successfully. Failed switches preserve the current registration, while successful cleanup is best-effort and bounded to 15 seconds so stale network or signer work cannot hold the outgoing account container forever.

- Captures the outgoing push coordinator before starting the switch.
- Keeps the outgoing account container and signer alive until post-commit cleanup settles or times out.
- Treats cleanup and legacy registration-claim failures as warnings after the new account is already mounted, because the committed switch cannot be rolled back safely at that point.
- Adds regression coverage for successful, failed, and timed-out account switches.

**Related Issue:** Closes #8035

## Out of Scope

This does not persist cleanup across process termination or guarantee deregistration when an interactive remote signer exceeds the 15-second budget. Incoming registration transfers push-token ownership to the new account and provides the service-side backstop.

## Verification

- `dart format --output=none --set-exit-if-changed lib test integration_test tools`
- `flutter analyze lib test integration_test tools`
- Focused account-switch, push-sync, container lifecycle, and startup tests: 91 passed
- CI-equivalent randomized Flutter suite: 18,064 passed, 280 skipped
- Applicable account-switch ratchets, Codex configuration checks, and CI configuration tests

CI-only mergeability, semantic-title, and aggregate workflow checks were not run locally.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
