### PR TITLE
fix(profile): remember secure-account prompt dismissal

### DIFF
--- a/mobile/lib/utils/secure_account_prompt_dismissal.dart
+++ b/mobile/lib/utils/secure_account_prompt_dismissal.dart
@@ -1,0 +1,27 @@
+// ABOUTME: Permanent per-account dismissal state for the secure-account prompt.
+// ABOUTME: Keeps "Maybe later" from resurfacing on profile rebuilds or launches.
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+const _dismissedSecureAccountPromptPrefix = 'dismissed_secure_account_prompt_';
+
+/// Whether one account permanently dismissed the secure-account profile prompt.
+class SecureAccountPromptDismissalStore {
+  const SecureAccountPromptDismissalStore({
+    required SharedPreferences prefs,
+    required String userIdHex,
+  }) : _prefs = prefs,
+       _userIdHex = userIdHex;
+
+  final SharedPreferences _prefs;
+  final String _userIdHex;
+
+  static String keyFor(String userIdHex) =>
+      '$_dismissedSecureAccountPromptPrefix$userIdHex';
+
+  String get key => keyFor(_userIdHex);
+
+  bool isDismissed() => _prefs.get(key) == true;
+
+  Future<void> dismiss() => _prefs.setBool(key, true);
+}

--- a/mobile/lib/utils/secure_account_prompt_dismissal.dart
+++ b/mobile/lib/utils/secure_account_prompt_dismissal.dart
@@ -6,6 +6,15 @@ import 'package:shared_preferences/shared_preferences.dart';
 const _dismissedSecureAccountPromptPrefix = 'dismissed_secure_account_prompt_';
 
 /// Whether one account permanently dismissed the secure-account profile prompt.
+///
+/// Scoped to a single account at construction, so a call site cannot pair the
+/// key with the wrong pubkey.
+///
+/// [isDismissed] is synchronous, and a [dismiss] is visible through it before
+/// the returned future completes — `setBool` updates the in-memory
+/// [SharedPreferences] cache synchronously. The profile header rebuilds
+/// without awaiting the write and depends on that ordering, so keep both
+/// methods free of any debounce or extra async hop.
 class SecureAccountPromptDismissalStore {
   const SecureAccountPromptDismissalStore({
     required SharedPreferences prefs,
@@ -16,12 +25,18 @@ class SecureAccountPromptDismissalStore {
   final SharedPreferences _prefs;
   final String _userIdHex;
 
+  /// Preference holding the dismissal flag for [userIdHex].
   static String keyFor(String userIdHex) =>
       '$_dismissedSecureAccountPromptPrefix$userIdHex';
 
+  /// Preference holding this store's dismissal flag.
   String get key => keyFor(_userIdHex);
 
+  /// Whether this account stored a dismissal. A missing or non-boolean value
+  /// reads as "not dismissed".
   bool isDismissed() => _prefs.get(key) == true;
 
+  /// Hides the prompt for this account. There is no expiry and no undo: the
+  /// action stops appearing on its own once the account is no longer anonymous.
   Future<void> dismiss() => _prefs.setBool(key, true);
 }

--- a/mobile/lib/widgets/profile/profile_actions_sheet/profile_actions_sheet_content.dart
+++ b/mobile/lib/widgets/profile/profile_actions_sheet/profile_actions_sheet_content.dart
@@ -21,12 +21,18 @@ class ProfileActionsSheetContent extends StatefulWidget {
   /// Creates a [ProfileActionsSheetContent].
   ///
   /// [actions] must contain at least one element.
-  const ProfileActionsSheetContent({required this.actions, super.key})
-    : assert(actions.length > 0, 'actions must not be empty');
+  const ProfileActionsSheetContent({
+    required this.actions,
+    this.onMaybeLater,
+    super.key,
+  }) : assert(actions.length > 0, 'actions must not be empty');
 
   /// Ordered list of actions to present. The first action is shown
   /// immediately; subsequent ones appear after "Maybe Later".
   final List<ProfileActionType> actions;
+
+  /// Called with the action the user dismissed before the sheet advances.
+  final void Function(ProfileActionType action)? onMaybeLater;
 
   @override
   State<ProfileActionsSheetContent> createState() =>
@@ -38,6 +44,7 @@ class _ProfileActionsSheetContentState
   int _currentIndex = 0;
 
   void _onMaybeLater() {
+    widget.onMaybeLater?.call(widget.actions[_currentIndex]);
     final nextIndex = _currentIndex + 1;
     if (nextIndex >= widget.actions.length) {
       Navigator.of(context).pop();

--- a/mobile/lib/widgets/profile/profile_header_media.dart
+++ b/mobile/lib/widgets/profile/profile_header_media.dart
@@ -559,11 +559,11 @@ class _ProfileActionLabel extends StatelessWidget {
     final (icon, label) = switch (action) {
       ProfileActionType.secureAccount => (
         DivineIconName.lockSimple,
-        'Secure your account',
+        context.l10n.profileSecureYourAccount,
       ),
       ProfileActionType.completeProfile => (
         DivineIconName.pencilSimple,
-        'Complete your profile',
+        context.l10n.profileCompleteYourProfile,
       ),
     };
 

--- a/mobile/lib/widgets/profile/profile_header_media.dart
+++ b/mobile/lib/widgets/profile/profile_header_media.dart
@@ -568,11 +568,13 @@ class _ProfileActionLabel extends StatelessWidget {
     };
 
     final chip = context.vineColors.accentChipYellow;
+    final maxWidth = MediaQuery.sizeOf(context).width - 32;
 
     return Stack(
       clipBehavior: Clip.none,
       children: [
         Container(
+          constraints: BoxConstraints(maxWidth: maxWidth),
           padding: const EdgeInsets.fromLTRB(12, 8, 16, 8),
           decoration: BoxDecoration(
             color: chip.container,
@@ -595,9 +597,13 @@ class _ProfileActionLabel extends StatelessWidget {
             spacing: 8,
             children: [
               DivineIcon(icon: icon, size: 16, color: chip.onContainer),
-              Text(
-                label,
-                style: VineTheme.titleSmallFont(color: chip.onContainer),
+              Flexible(
+                child: Text(
+                  label,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: VineTheme.titleSmallFont(color: chip.onContainer),
+                ),
               ),
             ],
           ),

--- a/mobile/lib/widgets/profile/profile_header_widget.dart
+++ b/mobile/lib/widgets/profile/profile_header_widget.dart
@@ -39,6 +39,7 @@ import 'package:openvine/utils/clipboard_utils.dart';
 import 'package:openvine/utils/deferred_login_options_navigator.dart';
 import 'package:openvine/utils/divine_login_banner_dismissal.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
+import 'package:openvine/utils/secure_account_prompt_dismissal.dart';
 import 'package:openvine/utils/user_profile_utils.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/linkified_text/linkified_text_widgets.dart';
@@ -294,11 +295,19 @@ class _ProfileHeaderWidgetState extends ConsumerState<ProfileHeaderWidget> {
         !isDivineLoginBannerHidden;
 
     // Compute pending profile actions for the avatar badge
-    final pendingActions = ProfileActionType.pending(
-      isOwnProfile: widget.isOwnProfile,
-      isAnonymous: isAnonymous,
-      hasAnyProfileInfo: hasAnyProfileInfo,
+    final secureAccountPromptDismissal = SecureAccountPromptDismissalStore(
+      prefs: prefs,
+      userIdHex: widget.userIdHex,
     );
+    final pendingActions =
+        ProfileActionType.pending(
+          isOwnProfile: widget.isOwnProfile,
+          isAnonymous: isAnonymous,
+          hasAnyProfileInfo: hasAnyProfileInfo,
+        ).where((action) {
+          return action != ProfileActionType.secureAccount ||
+              !secureAccountPromptDismissal.isDismissed();
+        }).toList();
 
     // Banner is rendered separately by ProfileBannerLayer in profile_grid.dart
     // so it can be placed behind the safe area. This widget only renders the
@@ -388,7 +397,11 @@ class _ProfileHeaderWidgetState extends ConsumerState<ProfileHeaderWidget> {
                     profileColor: profileColor,
                     pendingActions: pendingActions,
                     onActionTap: pendingActions.isNotEmpty
-                        ? () => _showActionsSheet(context, pendingActions)
+                        ? () => _showActionsSheet(
+                            context,
+                            pendingActions,
+                            secureAccountPromptDismissal,
+                          )
                         : null,
                   ),
                 ),
@@ -538,12 +551,20 @@ class _ProfileHeaderWidgetState extends ConsumerState<ProfileHeaderWidget> {
   void _showActionsSheet(
     BuildContext context,
     List<ProfileActionType> actions,
+    SecureAccountPromptDismissalStore secureAccountPromptDismissal,
   ) {
     VineBottomSheet.show<void>(
       context: context,
       scrollable: false,
       showHeaderDivider: false,
-      body: ProfileActionsSheetContent(actions: actions),
+      body: ProfileActionsSheetContent(
+        actions: actions,
+        onMaybeLater: (action) {
+          if (action != ProfileActionType.secureAccount) return;
+          unawaited(secureAccountPromptDismissal.dismiss());
+          if (mounted) setState(() {});
+        },
+      ),
     );
   }
 }

--- a/mobile/lib/widgets/profile/profile_header_widget.dart
+++ b/mobile/lib/widgets/profile/profile_header_widget.dart
@@ -561,6 +561,9 @@ class _ProfileHeaderWidgetState extends ConsumerState<ProfileHeaderWidget> {
         actions: actions,
         onMaybeLater: (action) {
           if (action != ProfileActionType.secureAccount) return;
+          // The write lands in the in-memory SharedPreferences cache before
+          // the future completes, so an empty setState is enough to drop the
+          // action from the next build.
           unawaited(secureAccountPromptDismissal.dismiss());
           if (mounted) setState(() {});
         },

--- a/mobile/test/utils/secure_account_prompt_dismissal_test.dart
+++ b/mobile/test/utils/secure_account_prompt_dismissal_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/utils/secure_account_prompt_dismissal.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  group(SecureAccountPromptDismissalStore, () {
+    setUp(() => SharedPreferences.setMockInitialValues({}));
+
+    Future<SecureAccountPromptDismissalStore> storeFor(String pubkey) async =>
+        SecureAccountPromptDismissalStore(
+          prefs: await SharedPreferences.getInstance(),
+          userIdHex: pubkey,
+        );
+
+    test('persists a dismissal without an expiry', () async {
+      final store = await storeFor('account-a');
+
+      await store.dismiss();
+
+      expect((await storeFor('account-a')).isDismissed(), isTrue);
+    });
+
+    test('keeps dismissals scoped to one account', () async {
+      await (await storeFor('account-a')).dismiss();
+
+      expect((await storeFor('account-b')).isDismissed(), isFalse);
+    });
+
+    test('treats missing and malformed values as not dismissed', () async {
+      SharedPreferences.setMockInitialValues({
+        SecureAccountPromptDismissalStore.keyFor('malformed'): 'true',
+      });
+
+      expect((await storeFor('missing')).isDismissed(), isFalse);
+      expect((await storeFor('malformed')).isDismissed(), isFalse);
+    });
+  });
+}

--- a/mobile/test/widgets/profile/profile_actions_sheet/profile_actions_sheet_content_test.dart
+++ b/mobile/test/widgets/profile/profile_actions_sheet/profile_actions_sheet_content_test.dart
@@ -9,7 +9,10 @@ import 'package:openvine/widgets/profile/profile_actions_sheet/profile_actions_s
 
 void main() {
   group(ProfileActionsSheetContent, () {
-    Widget buildApp({required List<ProfileActionType> actions}) {
+    Widget buildApp({
+      required List<ProfileActionType> actions,
+      void Function(ProfileActionType action)? onMaybeLater,
+    }) {
       return MaterialApp(
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
@@ -22,7 +25,10 @@ void main() {
                     context: context,
                     scrollable: false,
                     showHeaderDivider: false,
-                    body: ProfileActionsSheetContent(actions: actions),
+                    body: ProfileActionsSheetContent(
+                      actions: actions,
+                      onMaybeLater: onMaybeLater,
+                    ),
                   );
                 },
                 child: const Text('Open'),
@@ -55,8 +61,12 @@ void main() {
       testWidgets('Maybe Later dismisses sheet when only action', (
         tester,
       ) async {
+        final dismissed = <ProfileActionType>[];
         await tester.pumpWidget(
-          buildApp(actions: [ProfileActionType.secureAccount]),
+          buildApp(
+            actions: [ProfileActionType.secureAccount],
+            onMaybeLater: dismissed.add,
+          ),
         );
         await tester.tap(find.text('Open'));
         await tester.pumpAndSettle();
@@ -66,6 +76,7 @@ void main() {
 
         // Sheet should be dismissed
         expect(find.text('Secure Your Account'), findsNothing);
+        expect(dismissed, [ProfileActionType.secureAccount]);
       });
     });
 

--- a/mobile/test/widgets/profile/profile_header_widget_test.dart
+++ b/mobile/test/widgets/profile/profile_header_widget_test.dart
@@ -43,6 +43,7 @@ import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/og_beta_badge.dart';
 import 'package:openvine/widgets/og_viner_badge.dart';
 import 'package:openvine/widgets/profile/profile_action_buttons_widget.dart';
+import 'package:openvine/widgets/profile/profile_actions_sheet/profile_actions_sheet.dart';
 import 'package:openvine/widgets/profile/profile_header_widget.dart';
 import 'package:openvine/widgets/profile/profile_stats_row_widget.dart';
 import 'package:openvine/widgets/profile/profile_website_row.dart';
@@ -321,6 +322,8 @@ void main() {
     setUpAll(() async {
       SharedPreferences.setMockInitialValues({});
     });
+
+    final enL10n = lookupAppLocalizations(const Locale('en'));
 
     Widget buildTestWidget({
       required String userIdHex,
@@ -1832,7 +1835,7 @@ void main() {
     });
 
     testWidgets(
-      'shows Complete your profile label for own profile without custom name',
+      'shows Complete Your Profile label for own profile without custom name',
       (tester) async {
         final profileWithDefaultName = createTestProfile();
 
@@ -1845,7 +1848,7 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        expect(find.text('Complete Your Profile'), findsOneWidget);
+        expect(find.text(enL10n.profileCompleteYourProfile), findsOneWidget);
       },
     );
 
@@ -1864,7 +1867,7 @@ void main() {
 
       // Action label is replaced with SizedBox.shrink() during the loading
       // window so the prompt doesn't flicker between states (#4183 review).
-      expect(find.text('Complete Your Profile'), findsNothing);
+      expect(find.text(enL10n.profileCompleteYourProfile), findsNothing);
     });
 
     testWidgets('hides action label when profile has custom name', (
@@ -1881,7 +1884,7 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      expect(find.text('Complete Your Profile'), findsNothing);
+      expect(find.text(enL10n.profileCompleteYourProfile), findsNothing);
     });
 
     testWidgets('hides action label for other profiles', (tester) async {
@@ -1896,7 +1899,7 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      expect(find.text('Complete Your Profile'), findsNothing);
+      expect(find.text(enL10n.profileCompleteYourProfile), findsNothing);
     });
 
     testWidgets('renders PeopleListMembershipIndicator for other users', (
@@ -2140,7 +2143,7 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        expect(find.text('Secure Your Account'), findsOneWidget);
+        expect(find.text(enL10n.profileSecureYourAccount), findsOneWidget);
         // 1 action — badge shows "1"
         expect(find.text('1'), findsOneWidget);
       });
@@ -2161,7 +2164,7 @@ void main() {
           await tester.pumpAndSettle();
 
           // Secure takes precedence
-          expect(find.text('Secure Your Account'), findsOneWidget);
+          expect(find.text(enL10n.profileSecureYourAccount), findsOneWidget);
           // 2 actions — red badge with "2"
           expect(find.text('2'), findsOneWidget);
         },
@@ -2181,8 +2184,8 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        expect(find.text('Secure Your Account'), findsNothing);
-        expect(find.text('Complete Your Profile'), findsNothing);
+        expect(find.text(enL10n.profileSecureYourAccount), findsNothing);
+        expect(find.text(enL10n.profileCompleteYourProfile), findsNothing);
       });
 
       testWidgets('hides label for other profiles even when anonymous', (
@@ -2200,7 +2203,7 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        expect(find.text('Secure Your Account'), findsNothing);
+        expect(find.text(enL10n.profileSecureYourAccount), findsNothing);
       });
 
       testWidgets('tapping label opens actions bottom sheet', (tester) async {
@@ -2217,13 +2220,20 @@ void main() {
         await tester.pumpAndSettle();
 
         // Tap on the action label
-        await tester.tap(find.text('Secure Your Account'));
+        await tester.tap(find.text(enL10n.profileSecureYourAccount));
         await tester.pumpAndSettle();
 
-        // The bottom sheet should show the first action
-        expect(find.text('Secure Your Account'), findsNWidgets(2));
-        expect(find.text('Add Email & Password'), findsOneWidget);
-        expect(find.text('Maybe Later'), findsOneWidget);
+        // The pill and the sheet title share one ARB key, so scope the
+        // title to the sheet rather than counting matches.
+        expect(
+          find.descendant(
+            of: find.byType(ProfileActionsSheetContent),
+            matching: find.text(enL10n.profileSecureYourAccount),
+          ),
+          findsOneWidget,
+        );
+        expect(find.text(enL10n.profileSecurePrimaryButton), findsOneWidget);
+        expect(find.text(enL10n.profileMaybeLaterLabel), findsOneWidget);
       });
 
       testWidgets('Maybe Later permanently hides the secure-account action', (
@@ -2243,18 +2253,18 @@ void main() {
 
         await tester.pumpWidget(buildHeader());
         await tester.pumpAndSettle();
-        await tester.tap(find.text('Secure Your Account'));
+        await tester.tap(find.text(enL10n.profileSecureYourAccount));
         await tester.pumpAndSettle();
-        await tester.tap(find.text('Maybe Later'));
+        await tester.tap(find.text(enL10n.profileMaybeLaterLabel));
         await tester.pumpAndSettle();
 
-        expect(find.text('Secure Your Account'), findsNothing);
+        expect(find.text(enL10n.profileSecureYourAccount), findsNothing);
 
         await tester.pumpWidget(const SizedBox.shrink());
         await tester.pumpWidget(buildHeader());
         await tester.pumpAndSettle();
 
-        expect(find.text('Secure Your Account'), findsNothing);
+        expect(find.text(enL10n.profileSecureYourAccount), findsNothing);
       });
     });
 
@@ -2456,7 +2466,7 @@ void main() {
 
           // Anonymous users see the action label pill, not session expired
           final l10n = lookupAppLocalizations(const Locale('en'));
-          expect(find.text('Secure Your Account'), findsOneWidget);
+          expect(find.text(enL10n.profileSecureYourAccount), findsOneWidget);
           expect(find.text(l10n.profileSessionExpired), findsNothing);
         },
       );

--- a/mobile/test/widgets/profile/profile_header_widget_test.dart
+++ b/mobile/test/widgets/profile/profile_header_widget_test.dart
@@ -2266,6 +2266,40 @@ void main() {
 
         expect(find.text(enL10n.profileSecureYourAccount), findsNothing);
       });
+
+      testWidgets('Maybe Later leaves the complete-profile action pending', (
+        tester,
+      ) async {
+        SharedPreferences.setMockInitialValues({});
+        final prefs = await SharedPreferences.getInstance();
+
+        await tester.pumpWidget(
+          buildTestWidget(
+            userIdHex: testUserHex,
+            isOwnProfile: true,
+            // Default name and no picture/bio/NIP-05, so both actions pend.
+            profile: createTestProfile(),
+            isAnonymous: true,
+            sharedPreferences: prefs,
+          ),
+        );
+        await tester.pumpAndSettle();
+        expect(find.text('2'), findsOneWidget);
+
+        await tester.tap(find.text(enL10n.profileSecureYourAccount));
+        await tester.pumpAndSettle();
+
+        // Dismiss secure-account, then the complete-profile prompt behind it.
+        await tester.tap(find.text(enL10n.profileMaybeLaterLabel));
+        await tester.pump(const Duration(milliseconds: 700));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text(enL10n.profileMaybeLaterLabel));
+        await tester.pumpAndSettle();
+
+        expect(find.text(enL10n.profileSecureYourAccount), findsNothing);
+        expect(find.text(enL10n.profileCompleteYourProfile), findsOneWidget);
+        expect(find.text('1'), findsOneWidget);
+      });
     });
 
     group('Session Expired', () {

--- a/mobile/test/widgets/profile/profile_header_widget_test.dart
+++ b/mobile/test/widgets/profile/profile_header_widget_test.dart
@@ -643,9 +643,7 @@ void main() {
       // so this is the default state for Divine team accounts rather than an
       // edge case. Without the guard the header renders two explainer
       // buttons side by side.
-      final dualPubkey = kDivineTeamPubkeys.firstWhere(
-        isOgBetaTesterPubkey,
-      );
+      final dualPubkey = kDivineTeamPubkeys.firstWhere(isOgBetaTesterPubkey);
 
       await tester.pumpWidget(
         buildTestWidget(
@@ -1847,7 +1845,7 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        expect(find.text('Complete your profile'), findsOneWidget);
+        expect(find.text('Complete Your Profile'), findsOneWidget);
       },
     );
 
@@ -1866,7 +1864,7 @@ void main() {
 
       // Action label is replaced with SizedBox.shrink() during the loading
       // window so the prompt doesn't flicker between states (#4183 review).
-      expect(find.text('Complete your profile'), findsNothing);
+      expect(find.text('Complete Your Profile'), findsNothing);
     });
 
     testWidgets('hides action label when profile has custom name', (
@@ -1883,7 +1881,7 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      expect(find.text('Complete your profile'), findsNothing);
+      expect(find.text('Complete Your Profile'), findsNothing);
     });
 
     testWidgets('hides action label for other profiles', (tester) async {
@@ -1898,7 +1896,7 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      expect(find.text('Complete your profile'), findsNothing);
+      expect(find.text('Complete Your Profile'), findsNothing);
     });
 
     testWidgets('renders PeopleListMembershipIndicator for other users', (
@@ -2142,7 +2140,7 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        expect(find.text('Secure your account'), findsOneWidget);
+        expect(find.text('Secure Your Account'), findsOneWidget);
         // 1 action — badge shows "1"
         expect(find.text('1'), findsOneWidget);
       });
@@ -2163,7 +2161,7 @@ void main() {
           await tester.pumpAndSettle();
 
           // Secure takes precedence
-          expect(find.text('Secure your account'), findsOneWidget);
+          expect(find.text('Secure Your Account'), findsOneWidget);
           // 2 actions — red badge with "2"
           expect(find.text('2'), findsOneWidget);
         },
@@ -2183,8 +2181,8 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        expect(find.text('Secure your account'), findsNothing);
-        expect(find.text('Complete your profile'), findsNothing);
+        expect(find.text('Secure Your Account'), findsNothing);
+        expect(find.text('Complete Your Profile'), findsNothing);
       });
 
       testWidgets('hides label for other profiles even when anonymous', (
@@ -2202,7 +2200,7 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        expect(find.text('Secure your account'), findsNothing);
+        expect(find.text('Secure Your Account'), findsNothing);
       });
 
       testWidgets('tapping label opens actions bottom sheet', (tester) async {
@@ -2219,13 +2217,44 @@ void main() {
         await tester.pumpAndSettle();
 
         // Tap on the action label
-        await tester.tap(find.text('Secure your account'));
+        await tester.tap(find.text('Secure Your Account'));
         await tester.pumpAndSettle();
 
         // The bottom sheet should show the first action
-        expect(find.text('Secure Your Account'), findsOneWidget);
+        expect(find.text('Secure Your Account'), findsNWidgets(2));
         expect(find.text('Add Email & Password'), findsOneWidget);
         expect(find.text('Maybe Later'), findsOneWidget);
+      });
+
+      testWidgets('Maybe Later permanently hides the secure-account action', (
+        tester,
+      ) async {
+        SharedPreferences.setMockInitialValues({});
+        final prefs = await SharedPreferences.getInstance();
+        final testProfile = createTestProfile(displayName: 'Test User');
+
+        Widget buildHeader() => buildTestWidget(
+          userIdHex: testUserHex,
+          isOwnProfile: true,
+          profile: testProfile,
+          isAnonymous: true,
+          sharedPreferences: prefs,
+        );
+
+        await tester.pumpWidget(buildHeader());
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('Secure Your Account'));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('Maybe Later'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Secure Your Account'), findsNothing);
+
+        await tester.pumpWidget(const SizedBox.shrink());
+        await tester.pumpWidget(buildHeader());
+        await tester.pumpAndSettle();
+
+        expect(find.text('Secure Your Account'), findsNothing);
       });
     });
 
@@ -2427,7 +2456,7 @@ void main() {
 
           // Anonymous users see the action label pill, not session expired
           final l10n = lookupAppLocalizations(const Locale('en'));
-          expect(find.text('Secure your account'), findsOneWidget);
+          expect(find.text('Secure Your Account'), findsOneWidget);
           expect(find.text(l10n.profileSessionExpired), findsNothing);
         },
       );

--- a/mobile/test/widgets/profile/profile_header_widget_test.dart
+++ b/mobile/test/widgets/profile/profile_header_widget_test.dart
@@ -2499,9 +2499,8 @@ void main() {
           await tester.pumpAndSettle();
 
           // Anonymous users see the action label pill, not session expired
-          final l10n = lookupAppLocalizations(const Locale('en'));
           expect(find.text(enL10n.profileSecureYourAccount), findsOneWidget);
-          expect(find.text(l10n.profileSessionExpired), findsNothing);
+          expect(find.text(enL10n.profileSessionExpired), findsNothing);
         },
       );
 

--- a/mobile/test/widgets/profile/profile_header_widget_test.dart
+++ b/mobile/test/widgets/profile/profile_header_widget_test.dart
@@ -352,6 +352,7 @@ void main() {
       ThemeData? theme,
       bool disableAnimations = false,
       TextScaler? textScaler,
+      Locale locale = const Locale('en'),
       bool renderHeader = true,
       MockAuthService? authService,
       bool isVanished = false,
@@ -477,6 +478,7 @@ void main() {
         child: MaterialApp(
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
+          locale: locale,
           theme: theme,
           home: Builder(
             builder: (context) => MediaQuery(
@@ -2128,6 +2130,36 @@ void main() {
     });
 
     group('Action Label', () {
+      testWidgets('keeps localized label inside a narrow scaled viewport', (
+        tester,
+      ) async {
+        tester.view.physicalSize = const Size(320, 800);
+        tester.view.devicePixelRatio = 1;
+        addTearDown(tester.view.reset);
+        const locale = Locale('it');
+        final l10n = lookupAppLocalizations(locale);
+
+        await tester.pumpWidget(
+          buildTestWidget(
+            userIdHex: testUserHex,
+            isOwnProfile: true,
+            profile: createTestProfile(displayName: 'Test User'),
+            isAnonymous: true,
+            textScaler: const TextScaler.linear(2),
+            locale: locale,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final label = find.text(l10n.profileSecureYourAccount);
+        final labelRect = tester.getRect(label);
+        expect(labelRect.left, greaterThanOrEqualTo(0));
+        expect(
+          labelRect.right,
+          lessThanOrEqualTo(tester.view.physicalSize.width),
+        );
+      });
+
       testWidgets('shows Secure label when anonymous with custom name', (
         tester,
       ) async {


### PR DESCRIPTION
## Problem

Tapping **Maybe Later** on **Secure Your Account** only closed the current sheet. The profile rebuilt the action from authentication state, so the prompt returned immediately and on later launches. The profile pill also bypassed localization even though the sheet already had translated strings.

## Why this fix

The dismissal is now stored permanently in SharedPreferences, scoped to the full account pubkey, and applied before pending profile actions reach either the pill or sheet. Only the secure-account action is suppressed; **Complete Your Profile** remains independent. The pill now reuses the existing localized action strings and stays within the viewport with large text or longer translations.

Closes #8073

## Verification

- Profile dismissal store, action sheet, and full profile-header widget suites
- Focused Flutter analysis
- Narrow viewport and 2x text-scale coverage for localized pill copy
- ARB consistency test across every locale
- Hardcoded user-visible string scan
- Repository configuration checks
- Pre-push analyzer and changed-file tests
