### PR TITLE
fix(startup): stop showing account deletion before status is known

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -55,6 +55,7 @@ import 'package:openvine/l10n/current_app_l10n.dart';
 import 'package:openvine/l10n/email_verification_error_l10n.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/l10n/resolve_app_ui_locale.dart';
+import 'package:openvine/models/account_deletion_attempt.dart';
 import 'package:openvine/models/environment_config.dart';
 import 'package:openvine/notifications/routing/notification_tap_target.dart';
 import 'package:openvine/notifications/view/notifications_page.dart';
@@ -1966,6 +1967,9 @@ class _DivineAppState extends ConsumerState<DivineApp>
   bool _backgroundInitDone = false;
   StreamSubscription<void>? _shakeSubscription;
   StreamSubscription<NotificationTapEvent>? _notificationTapSubscription;
+  ProviderSubscription<AsyncValue<AccountDeletionAttempt?>>?
+  _deletionAttemptSubscription;
+  bool _authenticatedDeletionLookupSettled = false;
   QuickActionsCoordinator? _quickActionsCoordinator;
   late final StartupSplashReleaseController _splashReleaseController;
   late final MemoryPressureHandler _memoryPressureHandler;
@@ -2005,6 +2009,13 @@ class _DivineAppState extends ConsumerState<DivineApp>
     // notifies after redirect configuration changes (#5242).
     final router = ref.read(goRouterProvider);
     final authService = ref.read(authServiceProvider);
+    final initialDeletionAttempt = ref.read(
+      currentAccountDeletionAttemptProvider,
+    );
+    _authenticatedDeletionLookupSettled = authenticatedDeletionLookupSettled(
+      authService.authState,
+      initialDeletionAttempt,
+    );
     _splashReleaseController = StartupSplashReleaseController(
       authStateStream: authService.authStateStream,
       currentAuthState: () => authService.authState,
@@ -2016,7 +2027,16 @@ class _DivineAppState extends ConsumerState<DivineApp>
             location,
             hasExpiredOAuthSession: authService.hasExpiredOAuthSession,
             isAnonymous: authService.isAnonymous,
-          ),
+          ) ||
+          !_authenticatedDeletionLookupSettled,
+    );
+    _deletionAttemptSubscription = ref.listenManual(
+      currentAccountDeletionAttemptProvider,
+      (_, next) {
+        _authenticatedDeletionLookupSettled =
+            authenticatedDeletionLookupSettled(authService.authState, next);
+        _splashReleaseController.reevaluate();
+      },
     );
     // Start deferred startup after the first frame so the shell can paint first.
     WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -2037,6 +2057,7 @@ class _DivineAppState extends ConsumerState<DivineApp>
     WidgetsBinding.instance.removeObserver(this);
     _memoryTelemetry.stop();
     _splashReleaseController.dispose();
+    _deletionAttemptSubscription?.close();
     _notificationTapSubscription?.cancel();
     unawaited(_quickActionsCoordinator?.dispose());
     _shakeSubscription?.cancel();

--- a/mobile/lib/router/app_router_redirect.dart
+++ b/mobile/lib/router/app_router_redirect.dart
@@ -15,15 +15,22 @@ bool accountDeletionRecoveryGateActive(
   return attempt.value?.requiresRecoveryScreen ?? false;
 }
 
-/// Whether cold-start navigation is still waiting for the deletion lookup.
+/// Whether the deletion lookup is still in flight for cold-start routing.
 ///
-/// The router itself fails open during this state so it never paints the
-/// recovery screen without evidence of an interrupted deletion. The native
-/// startup splash waits on this predicate separately, preventing both a false
-/// recovery screen for ordinary users and a feed flash for recovery users.
+/// The router fails open while this is true so it never paints the recovery
+/// screen without evidence of an interrupted deletion. Separately, the native
+/// startup splash is held (via [authenticatedDeletionLookupSettled]) until this
+/// is false, so an authenticated user sees neither a false recovery screen nor
+/// a feed flash before the lookup resolves.
+///
+/// Any in-flight load counts as pending, including the first post-auth refetch:
+/// that re-run retains the pre-auth `AsyncData(null)`, so it is `isLoading`
+/// while `hasValue` is true. Excluding it would settle against the stale null
+/// and release the splash early (#8058: stay fail-closed until the lookup
+/// resolves).
 bool accountDeletionRecoveryLookupPending(
   AsyncValue<AccountDeletionAttempt?>? attempt,
-) => attempt == null || (attempt.isLoading && !attempt.hasValue);
+) => attempt == null || attempt.isLoading;
 
 bool authenticatedDeletionLookupSettled(
   AuthState authState,

--- a/mobile/lib/router/app_router_redirect.dart
+++ b/mobile/lib/router/app_router_redirect.dart
@@ -11,9 +11,26 @@ bool _suppressNextAuthenticatedAuthRouteRedirect = false;
 bool accountDeletionRecoveryGateActive(
   AsyncValue<AccountDeletionAttempt?>? attempt,
 ) {
-  if (attempt == null || attempt.isLoading || !attempt.hasValue) return true;
+  if (attempt == null || !attempt.hasValue) return false;
   return attempt.value?.requiresRecoveryScreen ?? false;
 }
+
+/// Whether cold-start navigation is still waiting for the deletion lookup.
+///
+/// The router itself fails open during this state so it never paints the
+/// recovery screen without evidence of an interrupted deletion. The native
+/// startup splash waits on this predicate separately, preventing both a false
+/// recovery screen for ordinary users and a feed flash for recovery users.
+bool accountDeletionRecoveryLookupPending(
+  AsyncValue<AccountDeletionAttempt?>? attempt,
+) => attempt == null || (attempt.isLoading && !attempt.hasValue);
+
+bool authenticatedDeletionLookupSettled(
+  AuthState authState,
+  AsyncValue<AccountDeletionAttempt?>? attempt,
+) =>
+    authState == AuthState.authenticated &&
+    !accountDeletionRecoveryLookupPending(attempt);
 
 /// Prevents the next authenticated auth-route redirect from going home.
 ///

--- a/mobile/lib/startup/startup_splash_release_controller.dart
+++ b/mobile/lib/startup/startup_splash_release_controller.dart
@@ -84,6 +84,13 @@ class StartupSplashReleaseController {
     if (settled) _releaseOnce();
   }
 
+  /// Rechecks the release condition after startup state outside auth or
+  /// routing changes.
+  ///
+  /// The account-deletion lookup is one such state: its result can settle
+  /// without changing the current route when no recovery is required.
+  void reevaluate() => _maybeRelease();
+
   void _releaseOnce() {
     if (_released) return;
     _released = true;

--- a/mobile/test/router/minor_account_review_router_test.dart
+++ b/mobile/test/router/minor_account_review_router_test.dart
@@ -79,7 +79,7 @@ void main() {
       );
     });
 
-    test('opens only after a ready lookup definitively finds no attempt', () {
+    test('stays inactive when a ready lookup finds no attempt', () {
       expect(
         accountDeletionRecoveryGateActive(
           const AsyncData<AccountDeletionAttempt?>(null),

--- a/mobile/test/router/minor_account_review_router_test.dart
+++ b/mobile/test/router/minor_account_review_router_test.dart
@@ -40,16 +40,16 @@ class _MockDeletionRepository extends Mock
 
 void main() {
   group('Account deletion recovery gate', () {
-    test('fails closed while the attempt is loading', () {
+    test('stays inactive while the attempt is loading', () {
       expect(
         accountDeletionRecoveryGateActive(
           const AsyncLoading<AccountDeletionAttempt?>(),
         ),
-        isTrue,
+        isFalse,
       );
     });
 
-    test('fails closed when the coordinator lookup errors', () {
+    test('fails open when the coordinator lookup errors', () {
       expect(
         accountDeletionRecoveryGateActive(
           AsyncError<AccountDeletionAttempt?>(
@@ -57,7 +57,7 @@ void main() {
             StackTrace.empty,
           ),
         ),
-        isTrue,
+        isFalse,
       );
     });
 
@@ -67,6 +67,54 @@ void main() {
           const AsyncData<AccountDeletionAttempt?>(null),
         ),
         isFalse,
+      );
+    });
+
+    test('reports only a cold load without a previous value as pending', () {
+      expect(
+        accountDeletionRecoveryLookupPending(
+          const AsyncLoading<AccountDeletionAttempt?>(),
+        ),
+        isTrue,
+      );
+      expect(
+        accountDeletionRecoveryLookupPending(
+          const AsyncData<AccountDeletionAttempt?>(null),
+        ),
+        isFalse,
+      );
+      expect(
+        accountDeletionRecoveryLookupPending(
+          AsyncError<AccountDeletionAttempt?>(
+            StateError('coordinator unavailable'),
+            StackTrace.empty,
+          ),
+        ),
+        isFalse,
+      );
+    });
+
+    test('settles only a terminal lookup for an authenticated session', () {
+      expect(
+        authenticatedDeletionLookupSettled(
+          AuthState.checking,
+          const AsyncData<AccountDeletionAttempt?>(null),
+        ),
+        isFalse,
+      );
+      expect(
+        authenticatedDeletionLookupSettled(
+          AuthState.authenticated,
+          const AsyncLoading<AccountDeletionAttempt?>(),
+        ),
+        isFalse,
+      );
+      expect(
+        authenticatedDeletionLookupSettled(
+          AuthState.authenticated,
+          const AsyncData<AccountDeletionAttempt?>(null),
+        ),
+        isTrue,
       );
     });
   });

--- a/mobile/test/router/minor_account_review_router_test.dart
+++ b/mobile/test/router/minor_account_review_router_test.dart
@@ -38,6 +38,24 @@ class _NotReadyNostrSession extends NostrSession {
 class _MockDeletionRepository extends Mock
     implements AccountDeletionRecoveryRepository {}
 
+/// The `AsyncLoading` that retains the pre-auth `AsyncData(null)` — the state
+/// `currentAccountDeletionAttemptProvider` enters on its first refetch after
+/// auth settles. Built through a container so it uses only public Riverpod API
+/// (`AsyncValue.copyWithPrevious` is an internal member).
+Future<AsyncValue<AccountDeletionAttempt?>> _retainedNullRefetch() async {
+  var authenticated = false;
+  final lookup = FutureProvider<AccountDeletionAttempt?>((ref) {
+    if (!authenticated) return null;
+    return Completer<AccountDeletionAttempt?>().future;
+  });
+  final container = ProviderContainer();
+  addTearDown(container.dispose);
+  await container.read(lookup.future);
+  authenticated = true;
+  container.invalidate(lookup);
+  return container.read(lookup);
+}
+
 void main() {
   group('Account deletion recovery gate', () {
     test('stays inactive while the attempt is loading', () {
@@ -70,53 +88,78 @@ void main() {
       );
     });
 
-    test('reports only a cold load without a previous value as pending', () {
-      expect(
-        accountDeletionRecoveryLookupPending(
-          const AsyncLoading<AccountDeletionAttempt?>(),
-        ),
-        isTrue,
-      );
-      expect(
-        accountDeletionRecoveryLookupPending(
-          const AsyncData<AccountDeletionAttempt?>(null),
-        ),
-        isFalse,
-      );
-      expect(
-        accountDeletionRecoveryLookupPending(
-          AsyncError<AccountDeletionAttempt?>(
-            StateError('coordinator unavailable'),
-            StackTrace.empty,
+    test(
+      'reports any in-flight lookup as pending, retained value included',
+      () async {
+        expect(
+          accountDeletionRecoveryLookupPending(
+            const AsyncLoading<AccountDeletionAttempt?>(),
           ),
-        ),
-        isFalse,
-      );
-    });
+          isTrue,
+        );
+        // The first post-auth refetch retains the pre-auth AsyncData(null), so
+        // it is isLoading while hasValue is true. It must still count as
+        // pending, or the splash releases against the stale null before the
+        // real attempt is known (#8058).
+        expect(
+          accountDeletionRecoveryLookupPending(await _retainedNullRefetch()),
+          isTrue,
+        );
+        expect(
+          accountDeletionRecoveryLookupPending(
+            const AsyncData<AccountDeletionAttempt?>(null),
+          ),
+          isFalse,
+        );
+        expect(
+          accountDeletionRecoveryLookupPending(
+            AsyncError<AccountDeletionAttempt?>(
+              StateError('coordinator unavailable'),
+              StackTrace.empty,
+            ),
+          ),
+          isFalse,
+        );
+      },
+    );
 
-    test('settles only a terminal lookup for an authenticated session', () {
-      expect(
-        authenticatedDeletionLookupSettled(
-          AuthState.checking,
-          const AsyncData<AccountDeletionAttempt?>(null),
-        ),
-        isFalse,
-      );
-      expect(
-        authenticatedDeletionLookupSettled(
-          AuthState.authenticated,
-          const AsyncLoading<AccountDeletionAttempt?>(),
-        ),
-        isFalse,
-      );
-      expect(
-        authenticatedDeletionLookupSettled(
-          AuthState.authenticated,
-          const AsyncData<AccountDeletionAttempt?>(null),
-        ),
-        isTrue,
-      );
-    });
+    test(
+      'settles only a terminal lookup for an authenticated session',
+      () async {
+        expect(
+          authenticatedDeletionLookupSettled(
+            AuthState.checking,
+            const AsyncData<AccountDeletionAttempt?>(null),
+          ),
+          isFalse,
+        );
+        expect(
+          authenticatedDeletionLookupSettled(
+            AuthState.authenticated,
+            const AsyncLoading<AccountDeletionAttempt?>(),
+          ),
+          isFalse,
+        );
+        // The post-auth refetch that retains the pre-auth null must not settle,
+        // or the splash releases against the stale null and a recovery user
+        // briefly sees the feed (#8058: stay fail-closed until the lookup
+        // resolves).
+        expect(
+          authenticatedDeletionLookupSettled(
+            AuthState.authenticated,
+            await _retainedNullRefetch(),
+          ),
+          isFalse,
+        );
+        expect(
+          authenticatedDeletionLookupSettled(
+            AuthState.authenticated,
+            const AsyncData<AccountDeletionAttempt?>(null),
+          ),
+          isTrue,
+        );
+      },
+    );
   });
 
   group('Minor account review router gating', () {

--- a/mobile/test/startup/startup_splash_release_controller_test.dart
+++ b/mobile/test/startup/startup_splash_release_controller_test.dart
@@ -69,6 +69,35 @@ void main() {
       });
     });
 
+    test('authenticated can recheck a non-routing startup gate', () {
+      fakeAsync((async) {
+        final auth = StreamController<AuthState>.broadcast();
+        final location = ValueNotifier<String>('/home');
+        var deletionLookupPending = true;
+        var releases = 0;
+
+        final controller = StartupSplashReleaseController(
+          authStateStream: auth.stream,
+          currentAuthState: () => AuthState.authenticated,
+          locationListenable: location,
+          currentLocation: () => location.value,
+          authenticatedRedirectPending: (_) => deletionLookupPending,
+          timeout: timeout,
+          release: () => releases++,
+        );
+
+        expect(releases, 0, reason: 'unresolved lookup holds the splash');
+
+        deletionLookupPending = false;
+        controller.reevaluate();
+        expect(releases, 1, reason: 'settled lookup releases the splash');
+
+        controller.dispose();
+        location.dispose();
+        unawaited(auth.close());
+      });
+    });
+
     test(
       'authenticated release follows delegate-style redirect notification',
       () {


### PR DESCRIPTION
## Problem

Authenticated users could see the account-deletion recovery screen on every cold launch, even when they had never requested deletion. The router treated an unresolved coordinator lookup as proof that recovery was required, so the native splash dropped into a misleading full-screen account status route until the request completed.

## Why this fix

The router now requires a confirmed interrupted attempt before entering recovery. During the initial authenticated lookup, the existing native splash remains visible instead of painting either recovery or the feed. A dedicated settled-state latch prevents auth/provider notification ordering from releasing the splash against the pre-auth null value. A resolved lookup error fails open, and the existing startup timeout still prevents an outage from holding the splash indefinitely.

A genuinely interrupted deletion still routes directly from the native splash to recovery. Background refreshes that retain a previous value keep their existing routing behavior.

Refs #8058
Follow-up to #8059

## Verification

- Router redirect, deletion recovery, and startup splash controller tests
- Focused Flutter analysis
- Repository configuration checks
- Pre-push analyzer and changed-file tests
