### PR TITLE
fix(followers): keep follower counts fresh across devices

### DIFF
--- a/mobile/packages/follow_repository/lib/src/follow_repository.dart
+++ b/mobile/packages/follow_repository/lib/src/follow_repository.dart
@@ -25,6 +25,11 @@ import 'package:unified_logger/unified_logger.dart';
 /// API does not expose event timestamps.
 typedef _FollowerRef = ({String pubkey, int? followedAt});
 
+typedef _CachedFollowerStats = ({
+  FollowerStats stats,
+  DateTime cachedAt,
+});
+
 /// Repository for managing follow relationships.
 /// Single source of truth for follow data.
 ///
@@ -48,6 +53,7 @@ class FollowRepository {
     QueryContactListCallback? queryContactList,
     RelayFactory? relayFactory,
     BlockedPubkeysCallback? blockedPubkeys,
+    DateTime Function()? now,
   }) : _nostrClient = nostrClient,
        _blockedPubkeys = blockedPubkeys,
        _isCacheInitialized = isCacheInitialized,
@@ -59,7 +65,8 @@ class FollowRepository {
        _queueOfflineAction = queueOfflineAction,
        _indexerRelayUrls = indexerRelayUrls,
        _queryContactList = queryContactList ?? _defaultQueryContactList,
-       _relayFactory = relayFactory ?? _defaultRelayFactory;
+       _relayFactory = relayFactory ?? _defaultRelayFactory,
+       _now = now ?? DateTime.now;
 
   final NostrClient _nostrClient;
   final IsCacheInitializedCallback? _isCacheInitialized;
@@ -90,6 +97,9 @@ class FollowRepository {
   ///
   /// Null leaves the published contact list unfiltered.
   final BlockedPubkeysCallback? _blockedPubkeys;
+
+  /// Clock used by expiring caches and persisted-stat stabilization.
+  final DateTime Function() _now;
 
   /// Default relay factory — creates a real [RelayBase].
   static RelayBase _defaultRelayFactory(String url, RelayStatus status) =>
@@ -508,6 +518,7 @@ class FollowRepository {
       fetch: fetchMyFollowersSnapshot,
       fromJson: FollowersSnapshot.fromJson,
       toJson: (s) => s.toJson(),
+      ttl: _profileListCacheTtl,
     );
   }
 
@@ -536,6 +547,7 @@ class FollowRepository {
       fetch: () => getOthersFollowing(_nostrClient.publicKey),
       fromJson: FollowingSnapshot.fromJson,
       toJson: (s) => s.toJson(),
+      ttl: _profileListCacheTtl,
     );
   }
 
@@ -743,8 +755,8 @@ class FollowRepository {
   /// to dominate individual follow/unfollow events.
   static const _hysteresisMinimumCount = 20;
 
-  /// In-memory cache for follower/following counts.
-  final Map<String, FollowerStats> _followerStatsCache = {};
+  /// Short-lived in-memory cache for follower/following counts.
+  final Map<String, _CachedFollowerStats> _followerStatsCache = {};
 
   /// Load persisted follower stats from the Drift database.
   ///
@@ -790,7 +802,7 @@ class FollowRepository {
     if (persistedCount < _hysteresisMinimumCount) return freshCount;
 
     // Persisted count is stale → accept the fresh count
-    if (DateTime.now().difference(persistedTimestamp) > _staleDuration) {
+    if (_now().difference(persistedTimestamp) > _staleDuration) {
       return freshCount;
     }
 
@@ -859,14 +871,16 @@ class FollowRepository {
     try {
       // Check in-memory cache first
       final cachedStats = _followerStatsCache[pubkey];
-      if (cachedStats != null) {
+      if (cachedStats != null &&
+          _now().difference(cachedStats.cachedAt) < _profileListCacheTtl) {
         Log.debug(
-          'Using cached follower stats: $cachedStats',
+          'Using cached follower stats: ${cachedStats.stats}',
           name: 'FollowRepository',
           category: LogCategory.system,
         );
-        return cachedStats;
+        return cachedStats.stats;
       }
+      _followerStatsCache.remove(pubkey);
 
       // Fetch from network
       final freshStats = await _fetchFollowerStats(pubkey);
@@ -881,7 +895,7 @@ class FollowRepository {
             followers: persisted.followers,
             following: persisted.following,
           );
-          _followerStatsCache[pubkey] = fallback;
+          _cacheFollowerStats(pubkey, fallback);
           return fallback;
         }
         return freshStats;
@@ -893,14 +907,15 @@ class FollowRepository {
       final stats = _stabilizeStats(pubkey, freshStats, persisted: persisted);
 
       // Cache in memory.
-      _followerStatsCache[pubkey] = stats;
+      _cacheFollowerStats(pubkey, stats);
 
       // Only re-persist when the value actually changed. When hysteresis
       // keeps the old persisted count, skipping the write preserves the
       // original timestamp so the stale check can eventually trigger.
-      if (persisted == null ||
-          stats.followers != persisted.followers ||
-          stats.following != persisted.following) {
+      if (pubkey != _nostrClient.publicKey &&
+          (persisted == null ||
+              stats.followers != persisted.followers ||
+              stats.following != persisted.following)) {
         await _persistFollowerStats(pubkey, stats);
       }
 
@@ -925,12 +940,16 @@ class FollowRepository {
           followers: persisted.followers,
           following: persisted.following,
         );
-        _followerStatsCache[pubkey] = fallback;
+        _cacheFollowerStats(pubkey, fallback);
         return fallback;
       }
 
       return FollowerStats.zero;
     }
+  }
+
+  void _cacheFollowerStats(String pubkey, FollowerStats stats) {
+    _followerStatsCache[pubkey] = (stats: stats, cachedAt: _now());
   }
 
   /// Fetch follower stats from the network.

--- a/mobile/packages/follow_repository/test/src/follow_repository_cached_test.dart
+++ b/mobile/packages/follow_repository/test/src/follow_repository_cached_test.dart
@@ -14,6 +14,20 @@ import '../../../cache_sync/test/fake_cache_dao.dart';
 
 class _MockNostrClient extends Mock implements NostrClient {}
 
+class _RecordingCacheDao extends FakeCacheDao {
+  Duration? lastTtl;
+
+  @override
+  Future<void> write({
+    required String key,
+    required String payload,
+    Duration? ttl,
+  }) async {
+    lastTtl = ttl;
+    await super.write(key: key, payload: payload, ttl: ttl);
+  }
+}
+
 /// Subclass that overrides the data-source methods wrapped by the cached
 /// watchers, so tests can drive deterministic input without standing up a
 /// full Nostr stack.
@@ -109,17 +123,32 @@ class _TestableFollowRepository extends FollowRepository {
 }
 
 void main() {
-  late FakeCacheDao dao;
+  late _RecordingCacheDao dao;
   late _MockNostrClient mockNostrClient;
 
   setUp(() async {
-    dao = FakeCacheDao();
+    dao = _RecordingCacheDao();
     await CacheSync.init(dao: dao);
     mockNostrClient = _MockNostrClient();
     when(() => mockNostrClient.publicKey).thenReturn('current-user');
   });
 
   group('FollowRepository.watchMyFollowersCached', () {
+    test('writes the cache with the profile-list TTL', () async {
+      final repo = _TestableFollowRepository(
+        nostrClient: mockNostrClient,
+        myFollowersResult: const ['a'],
+        myFollowerCountResult: 1,
+        myFollowingStream: const Stream.empty(),
+        othersFollowersResult: const [],
+        othersFollowingResult: const FollowingSnapshot(pubkeys: [], count: 0),
+      );
+
+      await repo.watchMyFollowersCached().drain<void>();
+
+      expect(dao.lastTtl, const Duration(seconds: 30));
+    });
+
     test('emits live result when cache is empty', () async {
       final repo = _TestableFollowRepository(
         nostrClient: mockNostrClient,
@@ -246,6 +275,22 @@ void main() {
   });
 
   group('FollowRepository.watchMyFollowingCached', () {
+    test('writes the cache with the profile-list TTL', () async {
+      final repo = _TestableFollowRepository(
+        nostrClient: mockNostrClient,
+        myFollowingStream: const Stream.empty(),
+        othersFollowersResult: const [],
+        othersFollowingResult: const FollowingSnapshot(
+          pubkeys: ['network'],
+          count: 1,
+        ),
+      );
+
+      await repo.watchMyFollowingCached().drain<void>();
+
+      expect(dao.lastTtl, const Duration(seconds: 30));
+    });
+
     test('emits live result from a fresh getOthersFollowing fetch, '
         'NOT from the watchMyFollowing BehaviorSubject replay', () async {
       final repo = _TestableFollowRepository(

--- a/mobile/packages/follow_repository/test/src/follow_repository_test.dart
+++ b/mobile/packages/follow_repository/test/src/follow_repository_test.dart
@@ -4545,6 +4545,53 @@ void main() {
       );
 
       test(
+        'refetches stats after the in-memory cache TTL expires',
+        () async {
+          final mockFunnelcakeClient = _MockFunnelcakeApiClient();
+          var now = DateTime.utc(2026, 8, 22, 12);
+          var followerCount = 100;
+          when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+          when(
+            () => mockFunnelcakeClient.getSocialCounts(testTargetPubkey),
+          ).thenAnswer(
+            (_) async => SocialCounts(
+              pubkey: testTargetPubkey,
+              followerCount: followerCount,
+              followingCount: 50,
+            ),
+          );
+
+          repository = FollowRepository(
+            nostrClient: mockNostrClient,
+            isCacheInitialized: () => cacheIsInitialized,
+            getCachedEventsByKind: (kind) => getCachedEventsByKind(kind),
+            cacheUserEvent: cachedUserEvents.add,
+            funnelcakeApiClient: mockFunnelcakeClient,
+            indexerRelayUrls: const [],
+            now: () => now,
+          );
+
+          final first = await repository.getFollowerStats(testTargetPubkey);
+          followerCount = 101;
+          now = now.add(const Duration(seconds: 29));
+          final beforeExpiry = await repository.getFollowerStats(
+            testTargetPubkey,
+          );
+          now = now.add(const Duration(seconds: 2));
+          final afterExpiry = await repository.getFollowerStats(
+            testTargetPubkey,
+          );
+
+          expect(first.followers, 100);
+          expect(beforeExpiry.followers, 100);
+          expect(afterExpiry.followers, 101);
+          verify(
+            () => mockFunnelcakeClient.getSocialCounts(testTargetPubkey),
+          ).called(2);
+        },
+      );
+
+      test(
         'falls back to WebSocket when REST API is unavailable',
         () async {
           // No funnelcake client, use nostr client subscribe for
@@ -5277,6 +5324,47 @@ void main() {
     });
 
     group('getFollowerStats - persistence', () {
+      test(
+        'does not persist raw stats for the signed-in user',
+        () async {
+          final mockStatsDao = _MockProfileStatsDao();
+          final mockFunnelcakeClient = _MockFunnelcakeApiClient();
+          when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+          when(
+            () => mockFunnelcakeClient.getSocialCounts(testCurrentUserPubkey),
+          ).thenAnswer(
+            (_) async => const SocialCounts(
+              pubkey: testCurrentUserPubkey,
+              followerCount: 200,
+              followingCount: 100,
+            ),
+          );
+          when(
+            () => mockStatsDao.getStatsRaw(testCurrentUserPubkey),
+          ).thenAnswer((_) async => null);
+
+          repository = FollowRepository(
+            nostrClient: mockNostrClient,
+            isCacheInitialized: () => cacheIsInitialized,
+            getCachedEventsByKind: (kind) => getCachedEventsByKind(kind),
+            cacheUserEvent: cachedUserEvents.add,
+            funnelcakeApiClient: mockFunnelcakeClient,
+            profileStatsDao: mockStatsDao,
+            indexerRelayUrls: const [],
+          );
+
+          await repository.getFollowerStats(testCurrentUserPubkey);
+
+          verifyNever(
+            () => mockStatsDao.upsertStats(
+              pubkey: any(named: 'pubkey'),
+              followerCount: any(named: 'followerCount'),
+              followingCount: any(named: 'followingCount'),
+            ),
+          );
+        },
+      );
+
       test(
         'persists when stats differ from persisted values',
         () async {

--- a/mobile/test/repositories/follow_repository_follower_stats_test.dart
+++ b/mobile/test/repositories/follow_repository_follower_stats_test.dart
@@ -36,6 +36,10 @@ FollowRepository _createRepository({
 }) {
   final nostrClient = _MockNostrClient();
 
+  // These cases fetch another profile. Keep the signed-in account distinct so
+  // repository-owned persistence remains part of the scenario under test.
+  when(() => nostrClient.publicKey).thenReturn('current-user');
+
   // Mock NostrClient.subscribe to return an empty stream (no WS data).
   when(
     () => nostrClient.subscribe(any()),


### PR DESCRIPTION
Follower and following counts could stay different between devices long after the network had newer data. The signed-in user's cached lists never expired, profile statistics stayed frozen in memory for the whole app session, and raw repository counts could overwrite the blocklist-aware value owned by the followers BLoC.

This change gives the signed-in user's list caches the same 30-second lifetime already used for other profiles, expires the in-memory statistics cache after that interval, and leaves persistence for the signed-in account exclusively with the BLoC. Other-profile statistics continue to be persisted normally.

The existing 24-hour persisted-count hysteresis is deliberately unchanged. Corroborating disagreements between REST and relay/indexer sources remains separately owned by #6954.

Verification:

- `flutter test test/src/follow_repository_cached_test.dart test/src/follow_repository_test.dart` (239 tests)
- `flutter test` in `mobile/packages/follow_repository` (291 tests)
- `flutter analyze` in `mobile/packages/follow_repository`
- `flutter analyze` in `mobile`
- `.codex/scripts/test-config.sh`

Closes #7472
Refs #8072
Refs #6954
