### PR TITLE
feat(dm): prototype safer message requests and trusted Divine conversations

### DIFF
--- a/mobile/lib/prototypes/dm_inbox_tabs/dm_inbox_classifier.dart
+++ b/mobile/lib/prototypes/dm_inbox_tabs/dm_inbox_classifier.dart
@@ -1,0 +1,510 @@
+// ABOUTME: PROTOTYPE (#8076) — pure four-way DM inbox classifier.
+// ABOUTME: Generalizes DmRepository.classifyPotentialRequests from two buckets
+// ABOUTME: (followed/requests) to four (official/inbox/requests/likelySpam),
+// ABOUTME: and returns a human-readable reason trail for every verdict.
+//
+// Deliberately Flutter-free and dependency-free beyond `models`, so the same
+// function can move into `packages/dm_repository` unchanged if the shape
+// survives the product discussion.
+
+import 'package:models/models.dart';
+
+/// Why a sender is allowed into the cryptographically trusted Official tab.
+enum DivineIdentityKind { operationalAccount, teamMember }
+
+/// A signed-registry identity and the capabilities attached to that role.
+class DivineOfficialIdentity {
+  const DivineOfficialIdentity({required this.kind, required this.label});
+
+  final DivineIdentityKind kind;
+  final String label;
+
+  bool get isBlockable => kind == DivineIdentityKind.teamMember;
+}
+
+/// Where a conversation lands in the four-tab inbox.
+enum DmInboxBucket {
+  /// Authenticated DivineHQ / Divine Support / Trust & Safety.
+  ///
+  /// Never routed to requests, never hidden by a privacy setting, never
+  /// blockable — only reportable.
+  official,
+
+  /// Conversations the user has consented to: they replied, or they follow
+  /// every other participant.
+  inbox,
+
+  /// First contact from someone the user does not follow. Content stays
+  /// concealed until the user affirmatively opens the request.
+  requests,
+
+  /// A request carrying enough independent risk signals to collapse it out
+  /// of the main request stream. Concealed, never auto-deleted.
+  likelySpam,
+}
+
+/// What Divine knows about a sender at classification time.
+///
+/// Every field is a *local or already-synced* fact. Nothing here requires
+/// decrypting message content server-side, and nothing here depends on the
+/// sender using Keycast or having an email on file — those must never affect
+/// spam classification.
+class DmSenderSignals {
+  const DmSenderSignals({
+    this.followsMe = false,
+    this.mutualConnectionCount = 0,
+    this.divineVideoCount = 0,
+    this.daysSinceFirstObserved,
+    this.hasProfileMetadata = false,
+    this.distinctReporterCount = 0,
+    this.recentFirstContactCount = 0,
+    this.hasPriorPublicInteraction = false,
+  });
+
+  /// No usable information about this sender.
+  static const unknown = DmSenderSignals();
+
+  /// The sender follows the current user.
+  final bool followsMe;
+
+  /// How many accounts the current user follows also follow this sender.
+  final int mutualConnectionCount;
+
+  /// Videos this sender has published on Divine.
+  final int divineVideoCount;
+
+  /// Days since Divine first observed any signed event from this sender.
+  ///
+  /// Null when unknown. There is no authoritative npub creation date, so this
+  /// is explicitly "first observed", not "account age".
+  final int? daysSinceFirstObserved;
+
+  /// Sender has both a display name and an avatar.
+  final bool hasProfileMetadata;
+
+  /// Distinct accounts that have reported this sender.
+  final int distinctReporterCount;
+
+  /// First-contact conversations this sender opened in the recent window.
+  final int recentFirstContactCount;
+
+  /// The two accounts have interacted publicly before (like, comment, repost).
+  final bool hasPriorPublicInteraction;
+}
+
+/// Per-conversation facts that do not live on [DmConversation] itself.
+class DmMessageSignals {
+  const DmMessageSignals({
+    this.containsLink = false,
+    this.containsMedia = false,
+  });
+
+  static const none = DmMessageSignals();
+
+  /// The first-contact message contains a URL.
+  final bool containsLink;
+
+  /// The first-contact message carries an attachment or media.
+  final bool containsMedia;
+}
+
+/// One scored signal that fired, with the copy a user would see.
+class DmRiskReason {
+  const DmRiskReason(this.label, this.points);
+
+  /// User-facing phrasing. Deliberately non-specific about thresholds so the
+  /// panel does not double as an evasion recipe.
+  final String label;
+
+  /// Contribution to the risk score. Negative values are mitigating.
+  final int points;
+
+  bool get isMitigating => points < 0;
+}
+
+/// Why one conversation landed where it did.
+class DmVerdict {
+  const DmVerdict({
+    required this.bucket,
+    required this.score,
+    required this.reasons,
+    this.officialIdentity,
+  });
+
+  final DmInboxBucket bucket;
+
+  /// Total risk score. Only meaningful for [DmInboxBucket.requests] and
+  /// [DmInboxBucket.likelySpam]; the other two short-circuit before scoring.
+  final int score;
+
+  final List<DmRiskReason> reasons;
+  final DivineOfficialIdentity? officialIdentity;
+}
+
+/// Tunable weights and thresholds.
+///
+/// Every value here is a product decision, not an engineering one. They are
+/// exposed as a config object precisely so Trust & Safety can own them
+/// without a code change.
+class DmSpamHeuristics {
+  const DmSpamHeuristics({
+    this.spamThreshold = 50,
+    this.newAccountDays = 7,
+    this.establishedAccountDays = 180,
+    this.fanOutThreshold = 20,
+    this.reporterThreshold = 3,
+    this.mutualConnectionCap = 3,
+    this.weightNoDivineVideos = 20,
+    this.weightNewAccount = 25,
+    this.weightNoProfileMetadata = 15,
+    this.weightNoMutualConnections = 15,
+    this.weightContainsLink = 25,
+    this.weightContainsMedia = 10,
+    this.weightHighFanOut = 40,
+    this.weightReportedByOthers = 50,
+    this.weightUnknownGroupInvite = 20,
+    this.weightFollowsMe = -25,
+    this.weightPerMutualConnection = -10,
+    this.weightEstablishedAccount = -15,
+    this.weightHasDivineVideos = -15,
+    this.weightPriorPublicInteraction = -30,
+  });
+
+  /// Score at or above which a request collapses into Likely spam.
+  final int spamThreshold;
+
+  /// Below this many days since first observed counts as a new account.
+  final int newAccountDays;
+
+  /// Above this many days since first observed counts as established.
+  final int establishedAccountDays;
+
+  /// First-contact conversations in the window that count as high fan-out.
+  final int fanOutThreshold;
+
+  /// Distinct reporters that count as a reported sender.
+  final int reporterThreshold;
+
+  /// Mutual connections beyond this stop earning credit.
+  final int mutualConnectionCap;
+
+  final int weightNoDivineVideos;
+  final int weightNewAccount;
+  final int weightNoProfileMetadata;
+  final int weightNoMutualConnections;
+  final int weightContainsLink;
+  final int weightContainsMedia;
+  final int weightHighFanOut;
+  final int weightReportedByOthers;
+  final int weightUnknownGroupInvite;
+  final int weightFollowsMe;
+  final int weightPerMutualConnection;
+  final int weightEstablishedAccount;
+  final int weightHasDivineVideos;
+  final int weightPriorPublicInteraction;
+
+  DmSpamHeuristics copyWith({
+    int? spamThreshold,
+    int? newAccountDays,
+    int? establishedAccountDays,
+    int? fanOutThreshold,
+    int? reporterThreshold,
+    int? mutualConnectionCap,
+    int? weightNoDivineVideos,
+    int? weightNewAccount,
+    int? weightNoProfileMetadata,
+    int? weightNoMutualConnections,
+    int? weightContainsLink,
+    int? weightContainsMedia,
+    int? weightHighFanOut,
+    int? weightReportedByOthers,
+    int? weightUnknownGroupInvite,
+    int? weightFollowsMe,
+    int? weightPerMutualConnection,
+    int? weightEstablishedAccount,
+    int? weightHasDivineVideos,
+    int? weightPriorPublicInteraction,
+  }) {
+    return DmSpamHeuristics(
+      spamThreshold: spamThreshold ?? this.spamThreshold,
+      newAccountDays: newAccountDays ?? this.newAccountDays,
+      establishedAccountDays:
+          establishedAccountDays ?? this.establishedAccountDays,
+      fanOutThreshold: fanOutThreshold ?? this.fanOutThreshold,
+      reporterThreshold: reporterThreshold ?? this.reporterThreshold,
+      mutualConnectionCap: mutualConnectionCap ?? this.mutualConnectionCap,
+      weightNoDivineVideos: weightNoDivineVideos ?? this.weightNoDivineVideos,
+      weightNewAccount: weightNewAccount ?? this.weightNewAccount,
+      weightNoProfileMetadata:
+          weightNoProfileMetadata ?? this.weightNoProfileMetadata,
+      weightNoMutualConnections:
+          weightNoMutualConnections ?? this.weightNoMutualConnections,
+      weightContainsLink: weightContainsLink ?? this.weightContainsLink,
+      weightContainsMedia: weightContainsMedia ?? this.weightContainsMedia,
+      weightHighFanOut: weightHighFanOut ?? this.weightHighFanOut,
+      weightReportedByOthers:
+          weightReportedByOthers ?? this.weightReportedByOthers,
+      weightUnknownGroupInvite:
+          weightUnknownGroupInvite ?? this.weightUnknownGroupInvite,
+      weightFollowsMe: weightFollowsMe ?? this.weightFollowsMe,
+      weightPerMutualConnection:
+          weightPerMutualConnection ?? this.weightPerMutualConnection,
+      weightEstablishedAccount:
+          weightEstablishedAccount ?? this.weightEstablishedAccount,
+      weightHasDivineVideos:
+          weightHasDivineVideos ?? this.weightHasDivineVideos,
+      weightPriorPublicInteraction:
+          weightPriorPublicInteraction ?? this.weightPriorPublicInteraction,
+    );
+  }
+}
+
+/// Result of classifying a whole list.
+class DmInboxClassification {
+  const DmInboxClassification({
+    required this.official,
+    required this.inbox,
+    required this.requests,
+    required this.likelySpam,
+    required this.verdicts,
+  });
+
+  final List<DmConversation> official;
+  final List<DmConversation> inbox;
+  final List<DmConversation> requests;
+  final List<DmConversation> likelySpam;
+
+  /// Conversation id to the reason trail behind its placement.
+  final Map<String, DmVerdict> verdicts;
+
+  List<DmConversation> bucket(DmInboxBucket bucket) => switch (bucket) {
+    DmInboxBucket.official => official,
+    DmInboxBucket.inbox => inbox,
+    DmInboxBucket.requests => requests,
+    DmInboxBucket.likelySpam => likelySpam,
+  };
+}
+
+/// Four-way inbox classifier.
+///
+/// Ordering is deliberate and each step is a hard short-circuit:
+///
+/// 1. **Official** — any participant is a canonical official pubkey. Wins over
+///    everything, including a risk score that would otherwise flag it, because
+///    Divine Support must be able to reach an account about a report.
+/// 2. **Inbox (consented)** — the user has replied, so consent is established.
+/// 3. **Inbox (followed)** — every deduplicated non-self participant is
+///    followed. `every`, not `first`, so a stranger p-tagged into a group
+///    still lands in requests.
+/// 4. **Scored** — everything else is a request; risk score decides whether it
+///    collapses into Likely spam.
+///
+/// Official identity comes only from [officialIdentities], a signed,
+/// release-controlled registry of full pubkeys and role capabilities. Never
+/// from display name, profile metadata, badges, or follow state — all of which
+/// an impersonator controls.
+class DmInboxClassifier {
+  const DmInboxClassifier({
+    required this.officialIdentities,
+    this.heuristics = const DmSpamHeuristics(),
+  });
+
+  final Map<String, DivineOfficialIdentity> officialIdentities;
+  final DmSpamHeuristics heuristics;
+
+  DmInboxClassification classify(
+    List<DmConversation> conversations, {
+    required String userPubkey,
+    required bool Function(String pubkey) isFollowing,
+    required DmSenderSignals Function(String pubkey) signalsFor,
+    DmMessageSignals Function(DmConversation conversation)? messageSignalsFor,
+  }) {
+    final official = <DmConversation>[];
+    final inbox = <DmConversation>[];
+    final requests = <DmConversation>[];
+    final likelySpam = <DmConversation>[];
+    final verdicts = <String, DmVerdict>{};
+
+    for (final conversation in conversations) {
+      final others = conversation.participantPubkeys
+          .where((pk) => pk != userPubkey)
+          .toSet();
+
+      final verdict = _classifyOne(
+        conversation,
+        others: others,
+        isFollowing: isFollowing,
+        signalsFor: signalsFor,
+        messageSignals:
+            messageSignalsFor?.call(conversation) ?? DmMessageSignals.none,
+      );
+
+      verdicts[conversation.id] = verdict;
+      switch (verdict.bucket) {
+        case DmInboxBucket.official:
+          official.add(conversation);
+        case DmInboxBucket.inbox:
+          inbox.add(conversation);
+        case DmInboxBucket.requests:
+          requests.add(conversation);
+        case DmInboxBucket.likelySpam:
+          likelySpam.add(conversation);
+      }
+    }
+
+    return DmInboxClassification(
+      official: official,
+      inbox: inbox,
+      requests: requests,
+      likelySpam: likelySpam,
+      verdicts: verdicts,
+    );
+  }
+
+  DmVerdict _classifyOne(
+    DmConversation conversation, {
+    required Set<String> others,
+    required bool Function(String) isFollowing,
+    required DmSenderSignals Function(String) signalsFor,
+    required DmMessageSignals messageSignals,
+  }) {
+    DivineOfficialIdentity? officialIdentity;
+    for (final pubkey in others) {
+      officialIdentity ??= officialIdentities[pubkey];
+    }
+    if (officialIdentity != null) {
+      return DmVerdict(
+        bucket: DmInboxBucket.official,
+        score: 0,
+        reasons: const [DmRiskReason('Verified Divine identity', 0)],
+        officialIdentity: officialIdentity,
+      );
+    }
+
+    if (conversation.currentUserHasSent) {
+      return const DmVerdict(
+        bucket: DmInboxBucket.inbox,
+        score: 0,
+        reasons: [DmRiskReason('You replied to this conversation', 0)],
+      );
+    }
+
+    // A degenerate row with no counterparty cannot be shown to be safe, so it
+    // fails closed into requests rather than the inbox.
+    if (others.isNotEmpty && others.every(isFollowing)) {
+      return const DmVerdict(
+        bucket: DmInboxBucket.inbox,
+        score: 0,
+        reasons: [DmRiskReason('You follow everyone in this conversation', 0)],
+      );
+    }
+
+    final reasons = _score(
+      conversation,
+      others: others,
+      isFollowing: isFollowing,
+      signalsFor: signalsFor,
+      messageSignals: messageSignals,
+    );
+    final score = reasons.fold(0, (sum, reason) => sum + reason.points);
+
+    return DmVerdict(
+      bucket: score >= heuristics.spamThreshold
+          ? DmInboxBucket.likelySpam
+          : DmInboxBucket.requests,
+      score: score,
+      reasons: reasons,
+    );
+  }
+
+  List<DmRiskReason> _score(
+    DmConversation conversation, {
+    required Set<String> others,
+    required bool Function(String) isFollowing,
+    required DmSenderSignals Function(String) signalsFor,
+    required DmMessageSignals messageSignals,
+  }) {
+    final h = heuristics;
+    final reasons = <DmRiskReason>[];
+
+    // The riskiest unfollowed participant sets the tone for the whole
+    // conversation — a group is only as safe as its least-known member.
+    final unknown = others.where((pk) => !isFollowing(pk)).toList();
+    final signals = unknown
+        .map(signalsFor)
+        .fold<DmSenderSignals?>(null, _riskier);
+    if (signals == null) {
+      return reasons;
+    }
+
+    void add(String label, int points) {
+      if (points != 0) {
+        reasons.add(DmRiskReason(label, points));
+      }
+    }
+
+    if (signals.distinctReporterCount >= h.reporterThreshold) {
+      add('Reported by other people', h.weightReportedByOthers);
+    }
+    if (signals.recentFirstContactCount >= h.fanOutThreshold) {
+      add('Messaged many new people recently', h.weightHighFanOut);
+    }
+
+    final days = signals.daysSinceFirstObserved;
+    if (days != null && days < h.newAccountDays) {
+      add('New account', h.weightNewAccount);
+    } else if (days != null && days > h.establishedAccountDays) {
+      add('Long-standing account', h.weightEstablishedAccount);
+    }
+
+    if (signals.divineVideoCount == 0) {
+      add('Has not posted on Divine', h.weightNoDivineVideos);
+    } else {
+      add('Posts on Divine', h.weightHasDivineVideos);
+    }
+
+    if (!signals.hasProfileMetadata) {
+      add('No profile name or photo', h.weightNoProfileMetadata);
+    }
+
+    if (signals.mutualConnectionCount == 0) {
+      add('No connections in common', h.weightNoMutualConnections);
+    } else {
+      final counted = signals.mutualConnectionCount.clamp(
+        0,
+        h.mutualConnectionCap,
+      );
+      add('Connections in common', counted * h.weightPerMutualConnection);
+    }
+
+    if (signals.followsMe) {
+      add('Follows you', h.weightFollowsMe);
+    }
+    if (signals.hasPriorPublicInteraction) {
+      add('You have interacted before', h.weightPriorPublicInteraction);
+    }
+    if (messageSignals.containsLink) {
+      add('First message contains a link', h.weightContainsLink);
+    }
+    if (messageSignals.containsMedia) {
+      add('First message contains media', h.weightContainsMedia);
+    }
+    if (unknown.length > 1 || (conversation.isGroup && unknown.isNotEmpty)) {
+      add('Added you to a group', h.weightUnknownGroupInvite);
+    }
+
+    return reasons;
+  }
+
+  /// Keeps whichever sender looks worse, so a group inherits its weakest link.
+  static DmSenderSignals _riskier(DmSenderSignals? a, DmSenderSignals b) {
+    if (a == null) return b;
+    int rank(DmSenderSignals s) =>
+        s.distinctReporterCount * 10 +
+        s.recentFirstContactCount -
+        s.mutualConnectionCount -
+        (s.followsMe ? 5 : 0) -
+        (s.divineVideoCount > 0 ? 3 : 0);
+    return rank(b) > rank(a) ? b : a;
+  }
+}

--- a/mobile/lib/prototypes/dm_inbox_tabs/dm_inbox_fixtures.dart
+++ b/mobile/lib/prototypes/dm_inbox_tabs/dm_inbox_fixtures.dart
@@ -1,0 +1,523 @@
+// ABOUTME: PROTOTYPE (#8076) — fixture conversations for the four-tab inbox.
+// ABOUTME: Deliberately synthetic: no real pubkeys, no real message text, and
+// ABOUTME: nothing derived from a reporter's account. Spans the corners of the
+// ABOUTME: classifier so tuning the weights visibly moves rows between tabs.
+
+import 'package:models/models.dart';
+import 'package:openvine/prototypes/dm_inbox_tabs/dm_inbox_classifier.dart';
+
+/// A fixture sender: display identity plus the signals Divine would know.
+class FixtureSender {
+  const FixtureSender({
+    required this.pubkey,
+    required this.displayName,
+    required this.signals,
+  });
+
+  final String pubkey;
+  final String displayName;
+  final DmSenderSignals signals;
+}
+
+/// One fixture row: the conversation, its participants, and its message hints.
+class FixtureConversation {
+  const FixtureConversation({
+    required this.conversation,
+    required this.messageSignals,
+  });
+
+  final DmConversation conversation;
+  final DmMessageSignals messageSignals;
+}
+
+/// Everything the prototype screen needs to render and classify.
+class DmInboxFixtures {
+  const DmInboxFixtures({
+    required this.userPubkey,
+    required this.officialIdentities,
+    required this.senders,
+    required this.conversations,
+    required this.following,
+    required this.now,
+  });
+
+  /// The instant the fixtures are anchored to, so relative timestamps read
+  /// the same on every launch.
+  final DateTime now;
+
+  final String userPubkey;
+  final Map<String, DivineOfficialIdentity> officialIdentities;
+  final Map<String, FixtureSender> senders;
+  final List<FixtureConversation> conversations;
+  final Set<String> following;
+
+  List<DmConversation> get dmConversations =>
+      conversations.map((f) => f.conversation).toList();
+
+  bool isFollowing(String pubkey) => following.contains(pubkey);
+
+  DmSenderSignals signalsFor(String pubkey) =>
+      senders[pubkey]?.signals ?? DmSenderSignals.unknown;
+
+  String displayNameFor(String pubkey) =>
+      senders[pubkey]?.displayName ?? 'Unknown sender';
+
+  DmMessageSignals messageSignalsFor(DmConversation conversation) {
+    for (final fixture in conversations) {
+      if (fixture.conversation.id == conversation.id) {
+        return fixture.messageSignals;
+      }
+    }
+    return DmMessageSignals.none;
+  }
+
+  /// Name shown on a row: the counterparty, or "A and N others" for a group.
+  String titleFor(DmConversation conversation) {
+    final others = conversation.participantPubkeys
+        .where((pk) => pk != userPubkey)
+        .toList();
+    if (others.isEmpty) return 'Unknown sender';
+    if (others.length == 1) return displayNameFor(others.first);
+    return '${displayNameFor(others.first)} and ${others.length - 1} others';
+  }
+
+  static DmInboxFixtures build() => _build();
+}
+
+// Synthetic 64-char hex. `_pk('a1')` -> 'a1' repeated to full length, so the
+// values look like pubkeys without resembling anyone's real key.
+String _pk(String seed) {
+  final buffer = StringBuffer();
+  while (buffer.length < 64) {
+    buffer.write(seed);
+  }
+  return buffer.toString().substring(0, 64);
+}
+
+const _hqPubkey = 'divinehq';
+const _supportPubkey = 'divinesupport';
+const _trustSafetyPubkey = 'divinetrustsafety';
+const _moderationPubkey = 'divinemoderation';
+const _lizTeamPubkey = 'lizteam';
+const _rabbleTeamPubkey = 'rabbleteam';
+
+int _hoursAgo(int hours) =>
+    _now.subtract(Duration(hours: hours)).millisecondsSinceEpoch ~/ 1000;
+
+// Fixed so the prototype renders identically on every launch.
+final _now = DateTime(2026, 8, 22, 14);
+
+DmInboxFixtures _build() {
+  final senders = <String, FixtureSender>{};
+  void sender(String seed, String name, DmSenderSignals signals) {
+    final pubkey = _pk(seed);
+    senders[pubkey] = FixtureSender(
+      pubkey: pubkey,
+      displayName: name,
+      signals: signals,
+    );
+  }
+
+  // Official senders never reach the scorer, so their signals are unused.
+  sender(_hqPubkey, 'DivineHQ', DmSenderSignals.unknown);
+  sender(_supportPubkey, 'Divine Support', DmSenderSignals.unknown);
+  sender(_trustSafetyPubkey, 'Divine Trust & Safety', DmSenderSignals.unknown);
+  sender(_moderationPubkey, 'Divine Moderation', DmSenderSignals.unknown);
+  sender(_lizTeamPubkey, 'Liz · Divine team', DmSenderSignals.unknown);
+  sender(_rabbleTeamPubkey, 'Rabble · Divine team', DmSenderSignals.unknown);
+
+  // --- Known, trusted people ---------------------------------------------
+  sender(
+    'a1',
+    'Maya Okonkwo',
+    const DmSenderSignals(
+      followsMe: true,
+      mutualConnectionCount: 12,
+      divineVideoCount: 48,
+      daysSinceFirstObserved: 400,
+      hasProfileMetadata: true,
+      hasPriorPublicInteraction: true,
+    ),
+  );
+  sender(
+    'b2',
+    'Deshawn Pierce',
+    const DmSenderSignals(
+      followsMe: true,
+      mutualConnectionCount: 5,
+      divineVideoCount: 9,
+      daysSinceFirstObserved: 260,
+      hasProfileMetadata: true,
+    ),
+  );
+  sender(
+    'c3',
+    'Rin Takahashi',
+    const DmSenderSignals(
+      followsMe: true,
+      mutualConnectionCount: 8,
+      divineVideoCount: 130,
+      daysSinceFirstObserved: 520,
+      hasProfileMetadata: true,
+      hasPriorPublicInteraction: true,
+    ),
+  );
+
+  // --- Plausible first contact (should read as a genuine request) ---------
+  sender(
+    'd4',
+    'Priya Raman',
+    const DmSenderSignals(
+      mutualConnectionCount: 4,
+      divineVideoCount: 22,
+      daysSinceFirstObserved: 300,
+      hasProfileMetadata: true,
+    ),
+  );
+  sender(
+    'e5',
+    'Tobias Lund',
+    const DmSenderSignals(
+      followsMe: true,
+      mutualConnectionCount: 1,
+      divineVideoCount: 3,
+      daysSinceFirstObserved: 95,
+      hasProfileMetadata: true,
+    ),
+  );
+  sender(
+    'f6',
+    'Nadia Broussard',
+    const DmSenderSignals(
+      mutualConnectionCount: 2,
+      divineVideoCount: 1,
+      daysSinceFirstObserved: 45,
+      hasProfileMetadata: true,
+      hasPriorPublicInteraction: true,
+    ),
+  );
+
+  // --- The borderline cases the sliders should move ----------------------
+  // Real creator, brand-new account, no mutuals. Genuine or not depending on
+  // where the new-account weight sits.
+  sender(
+    '07',
+    'Jules Amari',
+    const DmSenderSignals(
+      divineVideoCount: 2,
+      daysSinceFirstObserved: 3,
+      hasProfileMetadata: true,
+      mutualConnectionCount: 1,
+    ),
+  );
+  // Established lurker who has never posted. Punished hard by the
+  // "has not posted on Divine" weight — the false-positive to watch.
+  sender(
+    '18',
+    'Hollis Wray',
+    const DmSenderSignals(
+      daysSinceFirstObserved: 610,
+      hasProfileMetadata: true,
+      mutualConnectionCount: 2,
+    ),
+  );
+  // Fan with a link in the first message. Link weight decides the tab.
+  sender(
+    '29',
+    'Camille Ndiaye',
+    const DmSenderSignals(
+      divineVideoCount: 6,
+      daysSinceFirstObserved: 140,
+      hasProfileMetadata: true,
+      followsMe: true,
+    ),
+  );
+
+  // --- Unambiguous spam ---------------------------------------------------
+  sender(
+    '3a',
+    'crypto_signals_daily',
+    const DmSenderSignals(
+      daysSinceFirstObserved: 1,
+      recentFirstContactCount: 240,
+      distinctReporterCount: 31,
+    ),
+  );
+  sender(
+    '4b',
+    'FREE V-BUCKS GIVEAWAY',
+    const DmSenderSignals(
+      daysSinceFirstObserved: 0,
+      recentFirstContactCount: 88,
+      distinctReporterCount: 12,
+    ),
+  );
+  sender(
+    '5c',
+    'noname',
+    const DmSenderSignals(
+      daysSinceFirstObserved: 2,
+      recentFirstContactCount: 41,
+    ),
+  );
+  // The one that matters most for T&S: harassment, not commerce. Low fan-out,
+  // no links — only "new account + no history + no mutuals" flags it.
+  sender(
+    '6d',
+    'youcanthide',
+    const DmSenderSignals(daysSinceFirstObserved: 0),
+  );
+
+  // --- Group participants -------------------------------------------------
+  sender(
+    '7e',
+    'Sofia Marchetti',
+    const DmSenderSignals(
+      followsMe: true,
+      mutualConnectionCount: 6,
+      divineVideoCount: 15,
+      daysSinceFirstObserved: 310,
+      hasProfileMetadata: true,
+    ),
+  );
+  sender(
+    '8f',
+    'dropship_deals',
+    const DmSenderSignals(
+      daysSinceFirstObserved: 4,
+      recentFirstContactCount: 65,
+      distinctReporterCount: 7,
+    ),
+  );
+
+  final user = _pk('9a');
+  final following = <String>{_pk('a1'), _pk('b2'), _pk('c3'), _pk('7e')};
+
+  var counter = 0;
+  FixtureConversation conversation({
+    required List<String> otherSeeds,
+    required String preview,
+    required int hoursAgo,
+    bool currentUserHasSent = false,
+    bool isRead = true,
+    bool containsLink = false,
+    bool containsMedia = false,
+    String? subject,
+  }) {
+    counter++;
+    final others = otherSeeds.map(_pk).toList();
+    return FixtureConversation(
+      conversation: DmConversation(
+        id: 'fixture-${counter.toString().padLeft(2, '0')}',
+        participantPubkeys: [user, ...others]..sort(),
+        isGroup: others.length > 1,
+        createdAt: _hoursAgo(hoursAgo + 24),
+        lastMessageContent: preview,
+        lastMessageTimestamp: _hoursAgo(hoursAgo),
+        lastMessageSenderPubkey: others.first,
+        subject: subject,
+        isRead: isRead,
+        currentUserHasSent: currentUserHasSent,
+        dmProtocol: 'nip17',
+      ),
+      messageSignals: DmMessageSignals(
+        containsLink: containsLink,
+        containsMedia: containsMedia,
+      ),
+    );
+  }
+
+  final conversations = <FixtureConversation>[
+    // Official — must never be routed to requests, whatever the weights say.
+    conversation(
+      otherSeeds: [_supportPubkey],
+      preview:
+          'We reviewed the report you filed on 19 August. Here is what '
+          'we found and what happens next.',
+      hoursAgo: 2,
+      isRead: false,
+    ),
+    conversation(
+      otherSeeds: [_hqPubkey],
+      preview:
+          'Your account was selected for the creator fund pilot. No '
+          'action needed — details inside.',
+      hoursAgo: 40,
+    ),
+    conversation(
+      otherSeeds: [_trustSafetyPubkey],
+      preview: 'A private safety update is ready for you.',
+      hoursAgo: 18,
+      isRead: false,
+    ),
+    conversation(
+      otherSeeds: [_moderationPubkey],
+      preview: 'We have an update about content you reported.',
+      hoursAgo: 54,
+    ),
+    conversation(
+      otherSeeds: [_lizTeamPubkey],
+      preview: 'Would love your thoughts on the new creator tools.',
+      hoursAgo: 10,
+    ),
+    conversation(
+      otherSeeds: [_rabbleTeamPubkey],
+      preview: 'Thanks for helping us make Divine weirder and safer.',
+      hoursAgo: 70,
+    ),
+
+    // Inbox — replied to, or everyone followed.
+    conversation(
+      otherSeeds: ['a1'],
+      preview: 'ok but the timing on the second loop is unhinged, i love it',
+      hoursAgo: 1,
+      currentUserHasSent: true,
+      isRead: false,
+    ),
+    conversation(
+      otherSeeds: ['b2'],
+      preview: 'sending you the audio tomorrow',
+      hoursAgo: 6,
+      currentUserHasSent: true,
+    ),
+    conversation(
+      otherSeeds: ['c3'],
+      preview: 'did you see what they did with the transition',
+      hoursAgo: 20,
+      currentUserHasSent: true,
+    ),
+    // Followed, never replied to — inbox, not a request.
+    conversation(
+      otherSeeds: ['7e'],
+      preview: 'hey! following up about the collab',
+      hoursAgo: 9,
+      isRead: false,
+    ),
+    // All-followed group.
+    conversation(
+      otherSeeds: ['a1', 'c3', '7e'],
+      preview: 'friday edit jam?',
+      hoursAgo: 30,
+      subject: 'edit jam',
+      currentUserHasSent: true,
+    ),
+
+    // Requests — genuine first contact.
+    conversation(
+      otherSeeds: ['d4'],
+      preview:
+          'Hi! We met at the meetup in Lisbon — are you still doing the '
+          'stop-motion series?',
+      hoursAgo: 3,
+      isRead: false,
+    ),
+    conversation(
+      otherSeeds: ['e5'],
+      preview: 'love your work, quick question about your setup',
+      hoursAgo: 12,
+      isRead: false,
+    ),
+    conversation(
+      otherSeeds: ['f6'],
+      preview:
+          'you commented on my loop last week, thank you!! wanted to say '
+          'hi properly',
+      hoursAgo: 26,
+    ),
+
+    // Borderline — these are the rows the sliders should move.
+    conversation(
+      otherSeeds: ['07'],
+      preview: 'just joined, your stuff is why. any advice for a beginner?',
+      hoursAgo: 5,
+      isRead: false,
+    ),
+    conversation(
+      otherSeeds: ['18'],
+      preview: 'been watching since the vine days. glad you are back.',
+      hoursAgo: 33,
+      isRead: false,
+    ),
+    conversation(
+      otherSeeds: ['29'],
+      preview: 'made a fan edit of your series, here it is',
+      hoursAgo: 15,
+      containsLink: true,
+      isRead: false,
+    ),
+
+    // Likely spam.
+    conversation(
+      otherSeeds: ['3a'],
+      preview:
+          '🚀 100X GAINS GUARANTEED — join the private channel before it '
+          'closes',
+      hoursAgo: 1,
+      containsLink: true,
+      isRead: false,
+    ),
+    conversation(
+      otherSeeds: ['4b'],
+      preview: 'CONGRATULATIONS you have been selected click here to claim',
+      hoursAgo: 4,
+      containsLink: true,
+      isRead: false,
+    ),
+    conversation(
+      otherSeeds: ['5c'],
+      preview: 'hi dear',
+      hoursAgo: 7,
+      containsMedia: true,
+      isRead: false,
+    ),
+    conversation(
+      otherSeeds: ['6d'],
+      preview: 'i know where you posted from',
+      hoursAgo: 2,
+      isRead: false,
+    ),
+    // Mixed group: one followed friend, one spammer. Must not reach the inbox
+    // on the strength of the friend alone.
+    conversation(
+      otherSeeds: ['7e', '8f'],
+      preview: 'added you both, check the link',
+      hoursAgo: 8,
+      containsLink: true,
+      isRead: false,
+    ),
+  ];
+
+  return DmInboxFixtures(
+    now: _now,
+    userPubkey: user,
+    officialIdentities: {
+      _pk(_hqPubkey): const DivineOfficialIdentity(
+        kind: DivineIdentityKind.operationalAccount,
+        label: 'Official account',
+      ),
+      _pk(_supportPubkey): const DivineOfficialIdentity(
+        kind: DivineIdentityKind.operationalAccount,
+        label: 'Official account',
+      ),
+      _pk(_trustSafetyPubkey): const DivineOfficialIdentity(
+        kind: DivineIdentityKind.operationalAccount,
+        label: 'Official account',
+      ),
+      _pk(_moderationPubkey): const DivineOfficialIdentity(
+        kind: DivineIdentityKind.operationalAccount,
+        label: 'Official account',
+      ),
+      _pk(_lizTeamPubkey): const DivineOfficialIdentity(
+        kind: DivineIdentityKind.teamMember,
+        label: 'Divine team',
+      ),
+      _pk(_rabbleTeamPubkey): const DivineOfficialIdentity(
+        kind: DivineIdentityKind.teamMember,
+        label: 'Divine team',
+      ),
+    },
+    senders: senders,
+    conversations: conversations,
+    following: following,
+  );
+}

--- a/mobile/lib/prototypes/dm_inbox_tabs/dm_inbox_tabs_prototype_screen.dart
+++ b/mobile/lib/prototypes/dm_inbox_tabs/dm_inbox_tabs_prototype_screen.dart
@@ -1,0 +1,962 @@
+// ABOUTME: PROTOTYPE (#8076) — four-tab DM inbox on fixture data.
+// ABOUTME: Not wired to the real DM pipeline; it exists to make the
+// ABOUTME: classification and its tuning visible before the product decision.
+// ABOUTME: Copy is hardcoded English on purpose — see the note in the header.
+//
+// Strings here deliberately bypass `context.l10n`. Adding ARB keys for copy
+// that is still being designed would ship them to 21 locales and orphan them
+// the moment the wording changes. l10n happens when the shape is decided.
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:models/models.dart';
+import 'package:openvine/mixins/reduced_motion_tab_controller_mixin.dart';
+import 'package:openvine/prototypes/dm_inbox_tabs/dm_inbox_classifier.dart';
+import 'package:openvine/prototypes/dm_inbox_tabs/dm_inbox_fixtures.dart';
+import 'package:openvine/prototypes/dm_inbox_tabs/dm_inbox_tuning_view.dart';
+import 'package:openvine/router/route_paths.dart';
+
+/// Where the Official bucket is rendered.
+enum OfficialPlacement {
+  /// Official gets its own tab. Findable and impersonation-resistant, but it
+  /// is a fifth place to look — a support message about a report lands
+  /// somewhere the user is not looking by default.
+  ownTab,
+
+  /// Official is pinned to the top of Inbox. Matches "official messages go
+  /// directly to the inbox" literally, still visually distinct, still
+  /// unblockable.
+  pinnedInInbox,
+}
+
+/// Four-tab DM inbox prototype.
+class DmInboxTabsPrototypeScreen extends StatefulWidget {
+  const DmInboxTabsPrototypeScreen({super.key});
+
+  static const routeName = 'dm-inbox-tabs-prototype';
+  static const String path = RoutePaths.dmInboxTabsPrototype;
+
+  @override
+  State<DmInboxTabsPrototypeScreen> createState() =>
+      _DmInboxTabsPrototypeScreenState();
+}
+
+class _DmInboxTabsPrototypeScreenState extends State<DmInboxTabsPrototypeScreen>
+    with TickerProviderStateMixin, ReducedMotionTabControllerMixin {
+  final DmInboxFixtures _fixtures = DmInboxFixtures.build();
+
+  DmSpamHeuristics _heuristics = const DmSpamHeuristics();
+  OfficialPlacement _placement = OfficialPlacement.ownTab;
+
+  /// Conversations the user has affirmatively opened. Until then the preview
+  /// text stays concealed — that is the whole point of the requests bucket.
+  final _revealed = <String>{};
+
+  /// Rows whose scoring breakdown is expanded.
+  final _explained = <String>{};
+
+  @override
+  int get tabCount => _placement == OfficialPlacement.ownTab ? 4 : 3;
+
+  @override
+  void onTabChanged() => setState(() {});
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    syncTabController();
+  }
+
+  DmInboxClassification get _classification =>
+      DmInboxClassifier(
+        officialIdentities: _fixtures.officialIdentities,
+        heuristics: _heuristics,
+      ).classify(
+        _fixtures.dmConversations,
+        userPubkey: _fixtures.userPubkey,
+        isFollowing: _fixtures.isFollowing,
+        signalsFor: _fixtures.signalsFor,
+        messageSignalsFor: _fixtures.messageSignalsFor,
+      );
+
+  List<DmInboxBucket> get _tabs => _placement == OfficialPlacement.ownTab
+      ? const [
+          DmInboxBucket.inbox,
+          DmInboxBucket.official,
+          DmInboxBucket.requests,
+          DmInboxBucket.likelySpam,
+        ]
+      : const [
+          DmInboxBucket.inbox,
+          DmInboxBucket.requests,
+          DmInboxBucket.likelySpam,
+        ];
+
+  Future<void> _openTuning() async {
+    final updated = await Navigator.of(context).push<DmSpamHeuristics>(
+      MaterialPageRoute<DmSpamHeuristics>(
+        builder: (_) => DmInboxTuningView(
+          heuristics: _heuristics,
+          placement: _placement,
+          onPlacementChanged: (placement) {
+            setState(() {
+              _placement = placement;
+              syncTabController(index: 0);
+            });
+          },
+        ),
+      ),
+    );
+    if (updated != null && mounted) {
+      setState(() => _heuristics = updated);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.vineColors;
+    final classification = _classification;
+
+    return Scaffold(
+      backgroundColor: colors.background,
+      appBar: AppBar(
+        backgroundColor: colors.background,
+        elevation: 0,
+        scrolledUnderElevation: 0,
+        titleSpacing: 20,
+        title: Text(
+          'Inbox',
+          style: VineTheme.headlineSmallFont(color: colors.primaryText),
+        ),
+        actions: [
+          DivineIconButton(
+            icon: DivineIconName.faders,
+            tooltip: 'Tune classification',
+            semanticLabel: 'Tune classification',
+            onPressed: _openTuning,
+          ),
+          const SizedBox(width: 12),
+        ],
+      ),
+      body: Column(
+        children: [
+          _PrototypeStrip(
+            spamCount: classification.likelySpam.length,
+            total: _fixtures.conversations.length,
+            onTune: _openTuning,
+          ),
+          _InboxTabBar(
+            controller: tabController,
+            tabs: _tabs,
+            classification: classification,
+          ),
+          Divider(height: 1, thickness: 1, color: colors.outlineDisabled),
+          Expanded(
+            child: TabBarView(
+              controller: tabController,
+              children: [
+                for (final bucket in _tabs)
+                  _BucketList(
+                    bucket: bucket,
+                    conversations: _sorted(classification.bucket(bucket)),
+                    classification: classification,
+                    fixtures: _fixtures,
+                    revealed: _revealed,
+                    explained: _explained,
+                    threshold: _heuristics.spamThreshold,
+                    pinnedOfficial:
+                        bucket == DmInboxBucket.inbox &&
+                            _placement == OfficialPlacement.pinnedInInbox
+                        ? _sorted(classification.official)
+                        : const [],
+                    onReveal: (id) => setState(() => _revealed.add(id)),
+                    onToggleExplain: (id) => setState(() {
+                      if (!_explained.remove(id)) _explained.add(id);
+                    }),
+                  ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  List<DmConversation> _sorted(List<DmConversation> conversations) =>
+      [...conversations]
+        ..sort((a, b) => b.effectiveTimestamp.compareTo(a.effectiveTimestamp));
+}
+
+class _PrototypeStrip extends StatelessWidget {
+  const _PrototypeStrip({
+    required this.spamCount,
+    required this.total,
+    required this.onTune,
+  });
+
+  final int spamCount;
+  final int total;
+  final VoidCallback onTune;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.vineColors;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(20, 0, 20, 14),
+      child: Semantics(
+        button: true,
+        label: 'Prototype using fixture data. Tap to tune classification.',
+        child: InkWell(
+          onTap: onTune,
+          borderRadius: const BorderRadius.all(Radius.circular(12)),
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+            decoration: BoxDecoration(
+              color: colors.surfaceContainer,
+              borderRadius: const BorderRadius.all(Radius.circular(12)),
+              border: Border.all(color: colors.outlineDisabled),
+            ),
+            child: Row(
+              spacing: 10,
+              children: [
+                DivineIcon(
+                  icon: DivineIconName.sparkle,
+                  color: colors.onSurfaceMuted,
+                  size: 15,
+                ),
+                Expanded(
+                  child: Text(
+                    'Prototype · $spamCount of $total filtered as likely spam',
+                    style: VineTheme.bodySmallFont(
+                      color: colors.onSurfaceVariant,
+                    ),
+                  ),
+                ),
+                Text(
+                  'Tune',
+                  style: VineTheme.labelMediumFont(color: VineTheme.primary),
+                ),
+                const DivineIcon(
+                  icon: DivineIconName.arrowRight,
+                  color: VineTheme.primary,
+                  size: 13,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _InboxTabBar extends StatelessWidget {
+  const _InboxTabBar({
+    required this.controller,
+    required this.tabs,
+    required this.classification,
+  });
+
+  final TabController controller;
+  final List<DmInboxBucket> tabs;
+  final DmInboxClassification classification;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.vineColors;
+    // Material is required for the TabBar ink splash.
+    return Material(
+      color: VineTheme.transparent,
+      child: TabBar(
+        controller: controller,
+        isScrollable: true,
+        tabAlignment: TabAlignment.start,
+        padding: const EdgeInsetsDirectional.only(start: 12),
+        indicatorColor: VineTheme.tabIndicatorGreen,
+        indicatorWeight: 3,
+        indicatorSize: TabBarIndicatorSize.label,
+        dividerColor: VineTheme.transparent,
+        labelColor: colors.primaryText,
+        unselectedLabelColor: colors.onSurfaceMuted,
+        labelPadding: const EdgeInsets.symmetric(horizontal: 12),
+        overlayColor: WidgetStateProperty.all(VineTheme.transparent),
+        labelStyle: VineTheme.titleSmallFont(color: colors.primaryText),
+        unselectedLabelStyle: VineTheme.titleSmallFont(
+          color: colors.onSurfaceMuted,
+        ),
+        tabs: [
+          for (final bucket in tabs)
+            Tab(
+              height: 46,
+              child: _TabLabel(
+                label: bucket.label,
+                // Likely spam deliberately does not contribute an unread
+                // count — a badge on it would reward the spammer with the
+                // attention the bucket exists to withhold.
+                unread: bucket == DmInboxBucket.likelySpam
+                    ? 0
+                    : classification
+                          .bucket(bucket)
+                          .where((c) => !c.isRead)
+                          .length,
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _TabLabel extends StatelessWidget {
+  const _TabLabel({required this.label, required this.unread});
+
+  final String label;
+  final int unread;
+
+  @override
+  Widget build(BuildContext context) {
+    if (unread == 0) return Text(label);
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      spacing: 7,
+      children: [
+        Text(label),
+        _CountBadge(count: unread),
+      ],
+    );
+  }
+}
+
+class _CountBadge extends StatelessWidget {
+  const _CountBadge({required this.count});
+
+  final int count;
+
+  @override
+  Widget build(BuildContext context) {
+    return MediaQuery.withNoTextScaling(
+      child: Container(
+        constraints: const BoxConstraints(minWidth: 18, minHeight: 18),
+        padding: const EdgeInsets.symmetric(horizontal: 5),
+        decoration: const BoxDecoration(
+          color: VineTheme.primary,
+          borderRadius: BorderRadius.all(Radius.circular(1000)),
+        ),
+        alignment: Alignment.center,
+        child: Text(
+          count > 99 ? '99+' : '$count',
+          style: VineTheme.labelSmallFont(color: VineTheme.onPrimary),
+        ),
+      ),
+    );
+  }
+}
+
+class _BucketList extends StatelessWidget {
+  const _BucketList({
+    required this.bucket,
+    required this.conversations,
+    required this.classification,
+    required this.fixtures,
+    required this.revealed,
+    required this.explained,
+    required this.threshold,
+    required this.pinnedOfficial,
+    required this.onReveal,
+    required this.onToggleExplain,
+  });
+
+  final DmInboxBucket bucket;
+  final List<DmConversation> conversations;
+  final DmInboxClassification classification;
+  final DmInboxFixtures fixtures;
+  final Set<String> revealed;
+  final Set<String> explained;
+  final int threshold;
+  final List<DmConversation> pinnedOfficial;
+  final ValueChanged<String> onReveal;
+  final ValueChanged<String> onToggleExplain;
+
+  @override
+  Widget build(BuildContext context) {
+    final rows = [...pinnedOfficial, ...conversations];
+
+    if (rows.isEmpty) {
+      return _EmptyBucket(bucket: bucket);
+    }
+
+    return ListView.builder(
+      padding: const EdgeInsets.only(bottom: 32),
+      itemCount: rows.length + 1,
+      itemBuilder: (context, index) {
+        if (index == 0) return _BucketHeader(bucket: bucket);
+        final conversation = rows[index - 1];
+        final isPinned = pinnedOfficial.contains(conversation);
+        return _ConversationRow(
+          conversation: conversation,
+          fixtures: fixtures,
+          verdict: classification.verdicts[conversation.id],
+          threshold: threshold,
+          // A pinned official row keeps official semantics inside Inbox.
+          bucket: isPinned ? DmInboxBucket.official : bucket,
+          revealed: revealed.contains(conversation.id),
+          explained: explained.contains(conversation.id),
+          onReveal: () => onReveal(conversation.id),
+          onToggleExplain: () => onToggleExplain(conversation.id),
+        );
+      },
+    );
+  }
+}
+
+class _EmptyBucket extends StatelessWidget {
+  const _EmptyBucket({required this.bucket});
+
+  final DmInboxBucket bucket;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.vineColors;
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(40),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          spacing: 14,
+          children: [
+            DivineIcon(
+              icon: bucket.icon,
+              color: colors.onSurfaceMuted.withValues(alpha: 0.5),
+              size: 34,
+            ),
+            Text(
+              bucket.emptyCopy,
+              textAlign: TextAlign.center,
+              style: VineTheme.bodyMediumFont(color: colors.onSurfaceMuted),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _BucketHeader extends StatelessWidget {
+  const _BucketHeader({required this.bucket});
+
+  final DmInboxBucket bucket;
+
+  @override
+  Widget build(BuildContext context) {
+    final copy = bucket.headerCopy;
+    if (copy == null) return const SizedBox(height: 8);
+    final colors = context.vineColors;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(20, 16, 20, 8),
+      child: Container(
+        padding: const EdgeInsets.all(14),
+        decoration: BoxDecoration(
+          color: colors.surfaceContainer.withValues(alpha: 0.6),
+          borderRadius: const BorderRadius.all(Radius.circular(14)),
+        ),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          spacing: 12,
+          children: [
+            DivineIcon(
+              icon: bucket.icon,
+              color: bucket.accent(context),
+              size: 17,
+            ),
+            Expanded(
+              child: Text(
+                copy,
+                style: VineTheme.bodySmallFont(
+                  color: colors.onSurfaceVariant,
+                ).copyWith(height: 1.45),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ConversationRow extends StatelessWidget {
+  const _ConversationRow({
+    required this.conversation,
+    required this.fixtures,
+    required this.verdict,
+    required this.threshold,
+    required this.bucket,
+    required this.revealed,
+    required this.explained,
+    required this.onReveal,
+    required this.onToggleExplain,
+  });
+
+  final DmConversation conversation;
+  final DmInboxFixtures fixtures;
+  final DmVerdict? verdict;
+  final int threshold;
+  final DmInboxBucket bucket;
+  final bool revealed;
+  final bool explained;
+  final VoidCallback onReveal;
+  final VoidCallback onToggleExplain;
+
+  bool get _isOfficial => bucket == DmInboxBucket.official;
+
+  bool get _isScored =>
+      bucket == DmInboxBucket.requests || bucket == DmInboxBucket.likelySpam;
+
+  bool get _concealed => !revealed && _isScored;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.vineColors;
+    final title = fixtures.titleFor(conversation);
+    final unread = !conversation.isRead;
+
+    return Semantics(
+      button: _concealed,
+      label: _concealed
+          ? 'Message request from $title, content hidden. Tap to open.'
+          : 'Conversation with $title',
+      child: InkWell(
+        onTap: _concealed ? onReveal : null,
+        child: Container(
+          padding: const EdgeInsets.fromLTRB(20, 14, 20, 14),
+          decoration: BoxDecoration(
+            border: Border(
+              bottom: BorderSide(color: colors.outlineDisabled, width: 0.5),
+            ),
+          ),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            spacing: 14,
+            children: [
+              _Avatar(
+                title: title,
+                isOfficial: _isOfficial,
+                concealed: _concealed,
+              ),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  spacing: 3,
+                  children: [
+                    _TitleRow(
+                      title: title,
+                      unread: unread,
+                      isOfficial: _isOfficial,
+                      timestamp: _relativeTime(),
+                    ),
+                    _PreviewText(
+                      conversation: conversation,
+                      concealed: _concealed,
+                      unread: unread,
+                    ),
+                    if (_isOfficial && verdict?.officialIdentity != null)
+                      _OfficialFooter(identity: verdict!.officialIdentity!),
+                    if (_isScored && verdict != null)
+                      _RiskFooter(
+                        verdict: verdict!,
+                        threshold: threshold,
+                        expanded: explained,
+                        onToggle: onToggleExplain,
+                      ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  String _relativeTime() {
+    final at = DateTime.fromMillisecondsSinceEpoch(
+      conversation.effectiveTimestamp * 1000,
+    );
+    final elapsed = fixtures.now.difference(at);
+    if (elapsed.inMinutes < 60) return '${elapsed.inMinutes}m';
+    if (elapsed.inHours < 24) return '${elapsed.inHours}h';
+    return '${elapsed.inDays}d';
+  }
+}
+
+class _TitleRow extends StatelessWidget {
+  const _TitleRow({
+    required this.title,
+    required this.unread,
+    required this.isOfficial,
+    required this.timestamp,
+  });
+
+  final String title;
+  final bool unread;
+  final bool isOfficial;
+  final String timestamp;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.vineColors;
+    return Row(
+      spacing: 6,
+      children: [
+        Flexible(
+          child: Text(
+            title,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: unread
+                ? VineTheme.titleSmallFont(color: colors.primaryText)
+                : VineTheme.bodyLargeFont(color: colors.primaryText),
+          ),
+        ),
+        if (isOfficial)
+          const DivineIcon(
+            icon: DivineIconName.sealCheckFill,
+            color: VineTheme.primary,
+            size: 15,
+          ),
+        const Spacer(),
+        Text(
+          timestamp,
+          style: VineTheme.bodySmallFont(color: colors.onSurfaceMuted),
+        ),
+        if (unread) const _UnreadDot(),
+      ],
+    );
+  }
+}
+
+class _Avatar extends StatelessWidget {
+  const _Avatar({
+    required this.title,
+    required this.isOfficial,
+    required this.concealed,
+  });
+
+  final String title;
+  final bool isOfficial;
+  final bool concealed;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.vineColors;
+    return Container(
+      width: 44,
+      height: 44,
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        color: isOfficial
+            ? colors.iconButton
+            : colors.surfaceContainer.withValues(alpha: concealed ? 0.6 : 1),
+        border: isOfficial
+            ? Border.all(color: VineTheme.primary.withValues(alpha: 0.45))
+            : null,
+      ),
+      alignment: Alignment.center,
+      child: concealed
+          ? DivineIcon(
+              icon: DivineIconName.lockSimple,
+              color: colors.onSurfaceMuted,
+              size: 17,
+            )
+          : Text(
+              title.characters.first.toUpperCase(),
+              style: VineTheme.titleMediumFont(
+                color: isOfficial ? colors.onIconButton : colors.onSurface,
+              ),
+            ),
+    );
+  }
+}
+
+class _OfficialFooter extends StatelessWidget {
+  const _OfficialFooter({required this.identity});
+
+  final DivineOfficialIdentity identity;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.vineColors;
+    return Padding(
+      padding: const EdgeInsets.only(top: 6),
+      child: Row(
+        spacing: 8,
+        children: [
+          Text(
+            identity.label,
+            style: VineTheme.labelSmallFont(color: VineTheme.primary),
+          ),
+          Flexible(
+            child: Text(
+              identity.isBlockable
+                  ? 'Reportable · blockable'
+                  : 'Reportable · cannot be blocked',
+              style: VineTheme.labelSmallFont(color: colors.onSurfaceMuted),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _UnreadDot extends StatelessWidget {
+  const _UnreadDot();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 8,
+      height: 8,
+      decoration: const BoxDecoration(
+        shape: BoxShape.circle,
+        color: VineTheme.primary,
+      ),
+    );
+  }
+}
+
+class _PreviewText extends StatelessWidget {
+  const _PreviewText({
+    required this.conversation,
+    required this.concealed,
+    required this.unread,
+  });
+
+  final DmConversation conversation;
+  final bool concealed;
+  final bool unread;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.vineColors;
+    if (concealed) {
+      return Text(
+        'Message hidden until you open it',
+        style: VineTheme.bodyMediumFont(
+          color: colors.onSurfaceMuted,
+        ).copyWith(fontStyle: FontStyle.italic),
+      );
+    }
+    return Text(
+      conversation.lastMessageContent ?? '',
+      maxLines: 2,
+      overflow: TextOverflow.ellipsis,
+      style: VineTheme.bodyMediumFont(
+        color: unread ? colors.onSurface : colors.onSurfaceMuted,
+      ).copyWith(height: 1.35),
+    );
+  }
+}
+
+/// The "Why is this here?" affordance.
+///
+/// Collapsed it is one quiet line; expanded it lists the signals that fired.
+/// A real build would not show the numeric score or the threshold — that is
+/// an evasion recipe — but this is the tuning surface, so it does.
+class _RiskFooter extends StatelessWidget {
+  const _RiskFooter({
+    required this.verdict,
+    required this.threshold,
+    required this.expanded,
+    required this.onToggle,
+  });
+
+  final DmVerdict verdict;
+  final int threshold;
+  final bool expanded;
+  final VoidCallback onToggle;
+
+  @override
+  Widget build(BuildContext context) {
+    if (verdict.reasons.isEmpty) return const SizedBox.shrink();
+    final colors = context.vineColors;
+    final isSpam = verdict.bucket == DmInboxBucket.likelySpam;
+    final accent = isSpam ? VineTheme.error : colors.onSurfaceMuted;
+
+    return Padding(
+      padding: const EdgeInsets.only(top: 9),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        spacing: 8,
+        children: [
+          Semantics(
+            button: true,
+            label: expanded ? 'Hide reasons' : 'Why is this here?',
+            child: InkWell(
+              onTap: onToggle,
+              borderRadius: const BorderRadius.all(Radius.circular(8)),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                spacing: 7,
+                children: [
+                  _ScorePill(score: verdict.score, isSpam: isSpam),
+                  Text(
+                    expanded ? 'Hide reasons' : 'Why is this here?',
+                    style: VineTheme.labelSmallFont(color: accent),
+                  ),
+                  DivineIcon(
+                    icon: expanded
+                        ? DivineIconName.arrowUp
+                        : DivineIconName.arrowDown,
+                    color: accent,
+                    size: 11,
+                  ),
+                ],
+              ),
+            ),
+          ),
+          if (expanded) _ReasonList(verdict: verdict, threshold: threshold),
+        ],
+      ),
+    );
+  }
+}
+
+class _ScorePill extends StatelessWidget {
+  const _ScorePill({required this.score, required this.isSpam});
+
+  final int score;
+  final bool isSpam;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.vineColors;
+    return MediaQuery.withNoTextScaling(
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 2),
+        decoration: BoxDecoration(
+          color: isSpam
+              ? VineTheme.error.withValues(alpha: 0.16)
+              : colors.surfaceContainer,
+          borderRadius: const BorderRadius.all(Radius.circular(6)),
+        ),
+        child: Text(
+          'risk $score',
+          style: VineTheme.labelSmallFont(
+            color: isSpam ? VineTheme.error : colors.onSurfaceMuted,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ReasonList extends StatelessWidget {
+  const _ReasonList({required this.verdict, required this.threshold});
+
+  final DmVerdict verdict;
+  final int threshold;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.vineColors;
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: colors.surfaceContainer.withValues(alpha: 0.55),
+        borderRadius: const BorderRadius.all(Radius.circular(10)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        spacing: 6,
+        children: [
+          for (final reason in verdict.reasons) _ReasonRow(reason: reason),
+          Padding(
+            padding: const EdgeInsets.only(top: 2),
+            child: Text(
+              'Total ${verdict.score} · filtered at $threshold or above',
+              style: VineTheme.labelSmallFont(color: colors.onSurfaceMuted),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ReasonRow extends StatelessWidget {
+  const _ReasonRow({required this.reason});
+
+  final DmRiskReason reason;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.vineColors;
+    final tint = reason.isMitigating ? colors.accentPositive : VineTheme.error;
+    return Row(
+      spacing: 8,
+      children: [
+        DivineIcon(
+          icon: reason.isMitigating
+              ? DivineIconName.arrowDown
+              : DivineIconName.arrowUp,
+          color: tint,
+          size: 11,
+        ),
+        Expanded(
+          child: Text(
+            reason.label,
+            style: VineTheme.bodySmallFont(color: colors.onSurfaceVariant),
+          ),
+        ),
+        Text(
+          '${reason.points > 0 ? '+' : ''}${reason.points}',
+          style: VineTheme.labelMediumFont(color: tint),
+        ),
+      ],
+    );
+  }
+}
+
+extension on DmInboxBucket {
+  String get label => switch (this) {
+    DmInboxBucket.official => 'Official',
+    DmInboxBucket.inbox => 'Inbox',
+    DmInboxBucket.requests => 'Requests',
+    DmInboxBucket.likelySpam => 'Likely spam',
+  };
+
+  DivineIconName get icon => switch (this) {
+    DmInboxBucket.official => DivineIconName.sealCheckFill,
+    DmInboxBucket.inbox => DivineIconName.chatCircle,
+    DmInboxBucket.requests => DivineIconName.envelopeSimple,
+    DmInboxBucket.likelySpam => DivineIconName.prohibit,
+  };
+
+  Color accent(BuildContext context) => switch (this) {
+    DmInboxBucket.official => VineTheme.primary,
+    DmInboxBucket.inbox => context.vineColors.onSurfaceMuted,
+    DmInboxBucket.requests => context.vineColors.onSurfaceMuted,
+    DmInboxBucket.likelySpam => VineTheme.error,
+  };
+
+  String? get headerCopy => switch (this) {
+    DmInboxBucket.official =>
+      'Messages from Divine about your account, reports, and safety. These '
+          'always arrive here and cannot be blocked.',
+    DmInboxBucket.inbox => null,
+    DmInboxBucket.requests =>
+      'People you have not replied to. Open one to read it — nothing here is '
+          'marked as seen until you do.',
+    DmInboxBucket.likelySpam =>
+      'Filtered out of your requests. Nothing is deleted; open anything to '
+          'read it or move it back.',
+  };
+
+  String get emptyCopy => switch (this) {
+    DmInboxBucket.official => 'No messages from Divine.',
+    DmInboxBucket.inbox => 'No conversations yet.',
+    DmInboxBucket.requests => 'No message requests.',
+    DmInboxBucket.likelySpam => 'Nothing filtered.',
+  };
+}

--- a/mobile/lib/prototypes/dm_inbox_tabs/dm_inbox_tuning_view.dart
+++ b/mobile/lib/prototypes/dm_inbox_tabs/dm_inbox_tuning_view.dart
@@ -1,0 +1,632 @@
+// ABOUTME: PROTOTYPE (#8076) — live tuning panel for the inbox classifier.
+// ABOUTME: Every value here is a Trust & Safety product decision, surfaced as
+// ABOUTME: a slider so the tradeoffs can be argued about concretely rather
+// ABOUTME: than in the abstract.
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:openvine/prototypes/dm_inbox_tabs/dm_inbox_classifier.dart';
+import 'package:openvine/prototypes/dm_inbox_tabs/dm_inbox_tabs_prototype_screen.dart';
+
+/// Full-screen tuning panel. Pops the edited heuristics back to the caller.
+class DmInboxTuningView extends StatefulWidget {
+  const DmInboxTuningView({
+    required this.heuristics,
+    required this.placement,
+    required this.onPlacementChanged,
+    super.key,
+  });
+
+  final DmSpamHeuristics heuristics;
+  final OfficialPlacement placement;
+  final ValueChanged<OfficialPlacement> onPlacementChanged;
+
+  @override
+  State<DmInboxTuningView> createState() => _DmInboxTuningViewState();
+}
+
+class _DmInboxTuningViewState extends State<DmInboxTuningView> {
+  late DmSpamHeuristics _heuristics = widget.heuristics;
+  late OfficialPlacement _placement = widget.placement;
+
+  void _update(DmSpamHeuristics next) => setState(() => _heuristics = next);
+
+  void _applyRecipe(String name, DmSpamHeuristics recipe) {
+    _update(recipe);
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text('$name applied. Review the sliders before saving.'),
+      ),
+    );
+  }
+
+  void _shareRecipe() {
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(
+        content: Text(
+          'Share preview: settings only — never messages, contacts, or account data.',
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.vineColors;
+    final h = _heuristics;
+
+    return PopScope(
+      canPop: false,
+      onPopInvokedWithResult: (didPop, _) {
+        if (!didPop) Navigator.of(context).pop(_heuristics);
+      },
+      child: Scaffold(
+        backgroundColor: colors.background,
+        appBar: AppBar(
+          backgroundColor: colors.background,
+          elevation: 0,
+          scrolledUnderElevation: 0,
+          titleSpacing: 4,
+          title: Text(
+            'My request filter',
+            style: VineTheme.titleLargeFont(color: colors.primaryText),
+          ),
+          actions: [
+            DivineIconButton(
+              icon: DivineIconName.share,
+              tooltip: 'Share filter recipe',
+              semanticLabel: 'Share filter recipe',
+              onPressed: _shareRecipe,
+            ),
+            DivineIconButton(
+              icon: DivineIconName.arrowCounterClockwise,
+              tooltip: 'Reset to defaults',
+              semanticLabel: 'Reset to defaults',
+              onPressed: () => _update(const DmSpamHeuristics()),
+            ),
+            const SizedBox(width: 12),
+          ],
+        ),
+        body: ListView(
+          padding: const EdgeInsets.fromLTRB(20, 4, 20, 48),
+          children: [
+            _FilterHero(onShare: _shareRecipe),
+            const SizedBox(height: 20),
+            _Section(
+              title: 'Remix a community filter',
+              icon: DivineIconName.users,
+              blurb:
+                  'Start with settings someone else shared, then make them '
+                  'yours. Recipes never include messages, contacts, or '
+                  'account data.',
+              children: [
+                _RecipeTile(
+                  title: 'Quiet Porch',
+                  author: 'Liz',
+                  description:
+                      'Strict on bursts and links; generous to creators.',
+                  onApply: () => _applyRecipe(
+                    'Quiet Porch',
+                    const DmSpamHeuristics(
+                      spamThreshold: 42,
+                      weightHighFanOut: 70,
+                      weightContainsLink: 45,
+                      weightReportedByOthers: 75,
+                      weightHasDivineVideos: -25,
+                      weightPriorPublicInteraction: -40,
+                    ),
+                  ),
+                ),
+                _RecipeTile(
+                  title: 'Creator Open Door',
+                  author: 'Community Safety',
+                  description:
+                      'Welcomes established creators and trusted mutuals.',
+                  onApply: () => _applyRecipe(
+                    'Creator Open Door',
+                    const DmSpamHeuristics(
+                      spamThreshold: 65,
+                      weightHighFanOut: 65,
+                      weightReportedByOthers: 80,
+                      weightPerMutualConnection: -18,
+                      weightHasDivineVideos: -30,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            _Section(
+              title: 'Layout',
+              icon: DivineIconName.sealCheckFill,
+              children: [
+                _PlacementPicker(
+                  placement: _placement,
+                  onChanged: (value) {
+                    setState(() => _placement = value);
+                    widget.onPlacementChanged(value);
+                  },
+                ),
+              ],
+            ),
+            _Section(
+              title: 'Threshold',
+              icon: DivineIconName.prohibit,
+              blurb:
+                  'A request collapses into Likely spam once its risk score '
+                  'reaches this. Lower catches more spam, and more innocent '
+                  'people with it.',
+              children: [
+                _Slider(
+                  label: 'Likely-spam threshold',
+                  value: h.spamThreshold,
+                  min: 10,
+                  max: 150,
+                  onChanged: (v) => _update(h.copyWith(spamThreshold: v)),
+                ),
+              ],
+            ),
+            _Section(
+              title: 'Risk signals',
+              icon: DivineIconName.warning,
+              accent: VineTheme.error,
+              blurb:
+                  'Added to the score when the signal fires. The strongest '
+                  'two are behavioural — what the sender did to other people '
+                  '— rather than anything about who they are.',
+              children: [
+                _Slider(
+                  label: 'Reported by other people',
+                  value: h.weightReportedByOthers,
+                  min: 0,
+                  max: 100,
+                  onChanged: (v) =>
+                      _update(h.copyWith(weightReportedByOthers: v)),
+                ),
+                _Slider(
+                  label: 'Messaged many new people recently',
+                  value: h.weightHighFanOut,
+                  min: 0,
+                  max: 100,
+                  onChanged: (v) => _update(h.copyWith(weightHighFanOut: v)),
+                ),
+                _Slider(
+                  label: 'New account',
+                  value: h.weightNewAccount,
+                  min: 0,
+                  max: 100,
+                  onChanged: (v) => _update(h.copyWith(weightNewAccount: v)),
+                ),
+                _Slider(
+                  label: 'Has not posted on Divine',
+                  value: h.weightNoDivineVideos,
+                  min: 0,
+                  max: 100,
+                  onChanged: (v) =>
+                      _update(h.copyWith(weightNoDivineVideos: v)),
+                ),
+                _Slider(
+                  label: 'No profile name or photo',
+                  value: h.weightNoProfileMetadata,
+                  min: 0,
+                  max: 100,
+                  onChanged: (v) =>
+                      _update(h.copyWith(weightNoProfileMetadata: v)),
+                ),
+                _Slider(
+                  label: 'No connections in common',
+                  value: h.weightNoMutualConnections,
+                  min: 0,
+                  max: 100,
+                  onChanged: (v) =>
+                      _update(h.copyWith(weightNoMutualConnections: v)),
+                ),
+                _Slider(
+                  label: 'First message contains a link',
+                  value: h.weightContainsLink,
+                  min: 0,
+                  max: 100,
+                  onChanged: (v) => _update(h.copyWith(weightContainsLink: v)),
+                ),
+                _Slider(
+                  label: 'First message contains media',
+                  value: h.weightContainsMedia,
+                  min: 0,
+                  max: 100,
+                  onChanged: (v) => _update(h.copyWith(weightContainsMedia: v)),
+                ),
+                _Slider(
+                  label: 'Added you to a group',
+                  value: h.weightUnknownGroupInvite,
+                  min: 0,
+                  max: 100,
+                  onChanged: (v) =>
+                      _update(h.copyWith(weightUnknownGroupInvite: v)),
+                ),
+              ],
+            ),
+            _Section(
+              title: 'Mitigating signals',
+              icon: DivineIconName.shieldCheck,
+              accent: VineTheme.primary,
+              blurb:
+                  'Subtracted from the score. These are what keep a real '
+                  'person with an unusual profile out of the spam bucket.',
+              children: [
+                _Slider(
+                  label: 'You have interacted before',
+                  value: -h.weightPriorPublicInteraction,
+                  min: 0,
+                  max: 100,
+                  onChanged: (v) =>
+                      _update(h.copyWith(weightPriorPublicInteraction: -v)),
+                ),
+                _Slider(
+                  label: 'Follows you',
+                  value: -h.weightFollowsMe,
+                  min: 0,
+                  max: 100,
+                  onChanged: (v) => _update(h.copyWith(weightFollowsMe: -v)),
+                ),
+                _Slider(
+                  label: 'Per connection in common',
+                  value: -h.weightPerMutualConnection,
+                  min: 0,
+                  max: 50,
+                  onChanged: (v) =>
+                      _update(h.copyWith(weightPerMutualConnection: -v)),
+                ),
+                _Slider(
+                  label: 'Posts on Divine',
+                  value: -h.weightHasDivineVideos,
+                  min: 0,
+                  max: 100,
+                  onChanged: (v) =>
+                      _update(h.copyWith(weightHasDivineVideos: -v)),
+                ),
+                _Slider(
+                  label: 'Long-standing account',
+                  value: -h.weightEstablishedAccount,
+                  min: 0,
+                  max: 100,
+                  onChanged: (v) =>
+                      _update(h.copyWith(weightEstablishedAccount: -v)),
+                ),
+              ],
+            ),
+            _Section(
+              title: 'Signal definitions',
+              icon: DivineIconName.info,
+              blurb:
+                  'There is no authoritative npub creation date, so account '
+                  'age means "days since Divine first observed a signed '
+                  'event".',
+              children: [
+                _Slider(
+                  label: 'New account is under',
+                  unit: 'days',
+                  value: h.newAccountDays,
+                  min: 1,
+                  max: 90,
+                  onChanged: (v) => _update(h.copyWith(newAccountDays: v)),
+                ),
+                _Slider(
+                  label: 'Long-standing account is over',
+                  unit: 'days',
+                  value: h.establishedAccountDays,
+                  min: 30,
+                  max: 730,
+                  onChanged: (v) =>
+                      _update(h.copyWith(establishedAccountDays: v)),
+                ),
+                _Slider(
+                  label: 'High fan-out is',
+                  unit: 'new chats',
+                  value: h.fanOutThreshold,
+                  min: 1,
+                  max: 100,
+                  onChanged: (v) => _update(h.copyWith(fanOutThreshold: v)),
+                ),
+                _Slider(
+                  label: 'Reported is',
+                  unit: 'reporters',
+                  value: h.reporterThreshold,
+                  min: 1,
+                  max: 25,
+                  onChanged: (v) => _update(h.copyWith(reporterThreshold: v)),
+                ),
+                _Slider(
+                  label: 'Connections stop counting after',
+                  value: h.mutualConnectionCap,
+                  min: 1,
+                  max: 20,
+                  onChanged: (v) => _update(h.copyWith(mutualConnectionCap: v)),
+                ),
+              ],
+            ),
+            DivineButton(
+              label: 'Save filter',
+              expanded: true,
+              onPressed: () => Navigator.of(context).pop(_heuristics),
+            ),
+            const SizedBox(height: 10),
+            DivineButton(
+              label: 'Share as a filter recipe',
+              leadingIcon: DivineIconName.shareNetwork,
+              expanded: true,
+              type: DivineButtonType.secondary,
+              onPressed: _shareRecipe,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _FilterHero extends StatelessWidget {
+  const _FilterHero({required this.onShare});
+
+  final VoidCallback onShare;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.vineColors;
+    return Container(
+      padding: const EdgeInsets.all(18),
+      decoration: BoxDecoration(
+        color: colors.surfaceContainer,
+        borderRadius: const BorderRadius.all(Radius.circular(18)),
+        border: Border.all(color: VineTheme.primary.withValues(alpha: 0.35)),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        spacing: 14,
+        children: [
+          const DivineIcon(
+            icon: DivineIconName.shieldCheck,
+            color: VineTheme.primary,
+            size: 28,
+          ),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              spacing: 6,
+              children: [
+                Text(
+                  'Shield: Balanced',
+                  style: VineTheme.titleLargeFont(color: colors.primaryText),
+                ),
+                Text(
+                  'Decide what reaches Requests and what waits in Likely spam. '
+                  'Official Divine identities and existing chats are never filtered.',
+                  style: VineTheme.bodyMediumFont(
+                    color: colors.onSurfaceVariant,
+                  ).copyWith(height: 1.4),
+                ),
+                DivineButton(
+                  label: 'Share this setup',
+                  leadingIcon: DivineIconName.share,
+                  type: DivineButtonType.link,
+                  onPressed: onShare,
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _RecipeTile extends StatelessWidget {
+  const _RecipeTile({
+    required this.title,
+    required this.author,
+    required this.description,
+    required this.onApply,
+  });
+
+  final String title;
+  final String author;
+  final String description;
+  final VoidCallback onApply;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.vineColors;
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      child: Row(
+        spacing: 12,
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              spacing: 2,
+              children: [
+                Text(
+                  title,
+                  style: VineTheme.titleSmallFont(color: colors.primaryText),
+                ),
+                Text(
+                  'by $author · $description',
+                  style: VineTheme.bodySmallFont(color: colors.onSurfaceMuted),
+                ),
+              ],
+            ),
+          ),
+          DivineButton(
+            label: 'Remix',
+            type: DivineButtonType.secondary,
+            size: DivineButtonSize.small,
+            onPressed: onApply,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _Section extends StatelessWidget {
+  const _Section({
+    required this.title,
+    required this.icon,
+    required this.children,
+    this.blurb,
+    this.accent,
+  });
+
+  final String title;
+  final DivineIconName icon;
+  final String? blurb;
+  final Color? accent;
+  final List<Widget> children;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.vineColors;
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 20),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        spacing: 10,
+        children: [
+          Row(
+            spacing: 9,
+            children: [
+              DivineIcon(
+                icon: icon,
+                color: accent ?? colors.onSurfaceMuted,
+                size: 15,
+              ),
+              Text(
+                title,
+                style: VineTheme.titleSmallFont(color: colors.primaryText),
+              ),
+            ],
+          ),
+          if (blurb != null)
+            Text(
+              blurb!,
+              style: VineTheme.bodySmallFont(
+                color: colors.onSurfaceMuted,
+              ).copyWith(height: 1.45),
+            ),
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 6),
+            decoration: BoxDecoration(
+              color: colors.surfaceContainer.withValues(alpha: 0.55),
+              borderRadius: const BorderRadius.all(Radius.circular(16)),
+            ),
+            child: Column(children: children),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _PlacementPicker extends StatelessWidget {
+  const _PlacementPicker({required this.placement, required this.onChanged});
+
+  final OfficialPlacement placement;
+  final ValueChanged<OfficialPlacement> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final isOwnTab = placement == OfficialPlacement.ownTab;
+    return DivineSwitchTile(
+      title: 'Official gets its own tab',
+      subtitle: isOwnTab
+          ? 'Four tabs. Findable and hard to impersonate, but it is a fifth '
+                'place to look.'
+          : 'Three tabs. Official pins to the top of Inbox, matching '
+                '"official messages go directly to the inbox".',
+      value: isOwnTab,
+      onChanged: (value) => onChanged(
+        value ? OfficialPlacement.ownTab : OfficialPlacement.pinnedInInbox,
+      ),
+    );
+  }
+}
+
+class _Slider extends StatelessWidget {
+  const _Slider({
+    required this.label,
+    required this.value,
+    required this.min,
+    required this.max,
+    required this.onChanged,
+    this.unit,
+  });
+
+  final String label;
+  final String? unit;
+  final int value;
+  final int min;
+  final int max;
+  final ValueChanged<int> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.vineColors;
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        spacing: 2,
+        children: [
+          Row(
+            spacing: 12,
+            children: [
+              Expanded(
+                child: Text(
+                  label,
+                  style: VineTheme.bodyMediumFont(color: colors.primaryText),
+                ),
+              ),
+              _ValueChip(value: value, unit: unit),
+            ],
+          ),
+          DivineSlider(
+            value: value.toDouble().clamp(min.toDouble(), max.toDouble()),
+            min: min.toDouble(),
+            max: max.toDouble(),
+            divisions: max - min,
+            trackHeight: 5,
+            thumbHeight: 24,
+            semanticLabel: label,
+            onChanged: (v) => onChanged(v.round()),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ValueChip extends StatelessWidget {
+  const _ValueChip({required this.value, this.unit});
+
+  final int value;
+  final String? unit;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.vineColors;
+    return MediaQuery.withNoTextScaling(
+      child: Container(
+        constraints: const BoxConstraints(minWidth: 34),
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+        decoration: BoxDecoration(
+          color: colors.containerLow,
+          borderRadius: const BorderRadius.all(Radius.circular(7)),
+        ),
+        alignment: Alignment.center,
+        child: Text(
+          unit == null ? '$value' : '$value $unit',
+          style: VineTheme.labelMediumFont(color: colors.primaryText),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/router/route_paths.dart
+++ b/mobile/lib/router/route_paths.dart
@@ -28,6 +28,9 @@ abstract final class RoutePaths {
   static const curatedListFeedBase = '/list';
   static const developerOptions = '/developer-options';
   static const discoverLists = '/discover-lists';
+
+  /// PROTOTYPE (#8076). Remove with the prototype.
+  static const dmInboxTabsPrototype = '/developer-options/dm-inbox-tabs';
   static const emailVerification = '/verify-email';
   static const explore = '/explore';
   static const followersBase = '/followers';

--- a/mobile/lib/router/routes/settings_routes.dart
+++ b/mobile/lib/router/routes/settings_routes.dart
@@ -9,10 +9,12 @@ import 'package:openvine/features/feature_flags/models/feature_flag.dart';
 import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
 import 'package:openvine/features/feature_flags/screens/feature_flag_screen.dart';
 import 'package:openvine/models/authentication_source.dart';
+import 'package:openvine/prototypes/dm_inbox_tabs/dm_inbox_tabs_prototype_screen.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/invite_availability_providers.dart';
 import 'package:openvine/router/go_router_page_name.dart';
 import 'package:openvine/router/invite_availability_redirects.dart';
+import 'package:openvine/router/navigator_keys.dart';
 import 'package:openvine/screens/badges/badge_award_screen.dart';
 import 'package:openvine/screens/badges/badge_detail_screen.dart';
 import 'package:openvine/screens/badges/badge_editor_screen.dart';
@@ -247,6 +249,13 @@ List<RouteBase> settingsRoutes(Ref ref) {
       path: ClipRecoveryScreen.path,
       name: ClipRecoveryScreen.routeName,
       builder: (_, _) => const ClipRecoveryScreen(),
+    ),
+    // PROTOTYPE (#8076): four-tab DM inbox on fixture data. Remove with it.
+    GoRoute(
+      path: DmInboxTabsPrototypeScreen.path,
+      name: DmInboxTabsPrototypeScreen.routeName,
+      parentNavigatorKey: NavigatorKeys.root,
+      builder: (_, _) => const DmInboxTabsPrototypeScreen(),
     ),
     GoRoute(
       path: DeveloperOptionsScreen.path,

--- a/mobile/lib/router/routes/settings_routes.dart
+++ b/mobile/lib/router/routes/settings_routes.dart
@@ -254,7 +254,6 @@ List<RouteBase> settingsRoutes(Ref ref) {
     GoRoute(
       path: DmInboxTabsPrototypeScreen.path,
       name: DmInboxTabsPrototypeScreen.routeName,
-      parentNavigatorKey: NavigatorKeys.root,
       builder: (_, _) => const DmInboxTabsPrototypeScreen(),
     ),
     GoRoute(

--- a/mobile/lib/screens/developer_options_screen.dart
+++ b/mobile/lib/screens/developer_options_screen.dart
@@ -18,6 +18,7 @@ import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/models/environment_config.dart';
 import 'package:openvine/models/invite_availability.dart';
 import 'package:openvine/models/minor_account_review_status.dart';
+import 'package:openvine/prototypes/dm_inbox_tabs/dm_inbox_tabs_prototype_screen.dart';
 import 'package:openvine/providers/analytics_providers.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/environment_provider.dart';
@@ -410,6 +411,25 @@ class _DeveloperOptionsScreenState
                     style: VineTheme.bodyMediumFont(
                       color: context.vineColors.secondaryText,
                     ),
+                  ),
+                ),
+                // PROTOTYPE (#8076). Remove with the prototype.
+                ListTile(
+                  title: Text(
+                    'DM inbox: 4-tab prototype',
+                    style: VineTheme.titleMediumFont(
+                      color: context.vineColors.primaryText,
+                    ),
+                  ),
+                  subtitle: Text(
+                    'Official / Inbox / Requests / Likely spam on fixture '
+                    'data, with live-tunable weights.',
+                    style: VineTheme.bodyMediumFont(
+                      color: context.vineColors.secondaryText,
+                    ),
+                  ),
+                  onTap: () => context.pushNamed(
+                    DmInboxTabsPrototypeScreen.routeName,
                   ),
                 ),
                 ListTile(

--- a/mobile/macos/Runner.xcodeproj/project.pbxproj
+++ b/mobile/macos/Runner.xcodeproj/project.pbxproj
@@ -258,7 +258,6 @@
 				51BD49356784271F7E3B2B6C /* [CP] Embed Pods Frameworks */,
 				9AD7FD721DF2C6A84F6A1FC3 /* Codesign media_kit frameworks */,
 				BBC532B406767D40236ED3DB /* FlutterFire: "flutterfire upload-crashlytics-symbols" */,
-				31C85F115DFB287174C4FF54 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -369,23 +368,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		31C85F115DFB287174C4FF54 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		3399D490228B24CF009A79C7 /* ShellScript */ = {

--- a/mobile/test/prototypes/dm_inbox_tabs/dm_inbox_classifier_test.dart
+++ b/mobile/test/prototypes/dm_inbox_tabs/dm_inbox_classifier_test.dart
@@ -1,0 +1,193 @@
+// ABOUTME: PROTOTYPE (#8076) — pins the four-way classifier's invariants.
+// ABOUTME: The official-account rules are product requirements, not
+// ABOUTME: implementation details, so they get named tests.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/prototypes/dm_inbox_tabs/dm_inbox_classifier.dart';
+import 'package:openvine/prototypes/dm_inbox_tabs/dm_inbox_fixtures.dart';
+
+void main() {
+  group(DmInboxClassifier, () {
+    late DmInboxFixtures fixtures;
+
+    setUp(() => fixtures = DmInboxFixtures.build());
+
+    DmInboxClassification classify({DmSpamHeuristics? heuristics}) {
+      return DmInboxClassifier(
+        officialIdentities: fixtures.officialIdentities,
+        heuristics: heuristics ?? const DmSpamHeuristics(),
+      ).classify(
+        fixtures.dmConversations,
+        userPubkey: fixtures.userPubkey,
+        isFollowing: fixtures.isFollowing,
+        signalsFor: fixtures.signalsFor,
+        messageSignalsFor: fixtures.messageSignalsFor,
+      );
+    }
+
+    group('official', () {
+      test('routes every canonical Divine account to the official bucket', () {
+        final result = classify();
+
+        expect(result.official, hasLength(6));
+        expect(
+          result.official.map(fixtures.titleFor),
+          containsAll(<String>[
+            'DivineHQ',
+            'Divine Support',
+            'Divine Trust & Safety',
+            'Divine Moderation',
+            'Liz · Divine team',
+            'Rabble · Divine team',
+          ]),
+        );
+      });
+
+      test('operational accounts are unblockable and team members are not', () {
+        final result = classify();
+        final identities = <String, DivineOfficialIdentity>{
+          for (final conversation in result.official)
+            fixtures.titleFor(conversation):
+                result.verdicts[conversation.id]!.officialIdentity!,
+        };
+
+        expect(identities['DivineHQ']!.isBlockable, isFalse);
+        expect(identities['Divine Support']!.isBlockable, isFalse);
+        expect(identities['Liz · Divine team']!.isBlockable, isTrue);
+        expect(identities['Rabble · Divine team']!.isBlockable, isTrue);
+      });
+
+      test('never routes an official account to requests or likely spam', () {
+        // The strictest possible config: everything is maximally suspicious
+        // and the threshold is at the floor. Official must still not move.
+        final result = classify(
+          heuristics: const DmSpamHeuristics(
+            spamThreshold: 1,
+            weightNoDivineVideos: 100,
+            weightNewAccount: 100,
+            weightNoProfileMetadata: 100,
+            weightNoMutualConnections: 100,
+            weightFollowsMe: 0,
+            weightPerMutualConnection: 0,
+            weightEstablishedAccount: 0,
+            weightHasDivineVideos: 0,
+            weightPriorPublicInteraction: 0,
+          ),
+        );
+
+        final officialTitles = result.official.map(fixtures.titleFor);
+        expect(officialTitles, containsAll(['DivineHQ', 'Divine Support']));
+        for (final conversation in [...result.requests, ...result.likelySpam]) {
+          expect(
+            fixtures.titleFor(conversation),
+            isNot(anyOf('DivineHQ', 'Divine Support')),
+          );
+        }
+      });
+    });
+
+    group('inbox', () {
+      test('includes conversations the user has replied to', () {
+        final result = classify();
+        expect(
+          result.inbox.every(
+            (c) => c.currentUserHasSent || _allFollowed(fixtures, c),
+          ),
+          isTrue,
+        );
+      });
+
+      test('includes a followed sender the user has never replied to', () {
+        final result = classify();
+        final titles = result.inbox.map(fixtures.titleFor);
+        expect(titles, contains('Sofia Marchetti'));
+      });
+
+      test('keeps a group containing one unfollowed spammer out of inbox', () {
+        final result = classify();
+        final mixedGroup = fixtures.dmConversations.firstWhere(
+          (c) => fixtures.titleFor(c).contains('and 1 others'),
+        );
+        expect(result.inbox, isNot(contains(mixedGroup)));
+        expect(
+          [...result.requests, ...result.likelySpam],
+          contains(mixedGroup),
+        );
+      });
+    });
+
+    group('likelySpam', () {
+      test('catches the unambiguous spam senders at default weights', () {
+        final result = classify();
+        final titles = result.likelySpam.map(fixtures.titleFor).toList();
+
+        expect(
+          titles,
+          containsAll(<String>[
+            'crypto_signals_daily',
+            'FREE V-BUCKS GIVEAWAY',
+            'noname',
+          ]),
+        );
+      });
+
+      test('leaves plausible first contact in requests at default weights', () {
+        final result = classify();
+        final requestTitles = result.requests.map(fixtures.titleFor).toList();
+
+        expect(
+          requestTitles,
+          containsAll(<String>[
+            'Priya Raman',
+            'Tobias Lund',
+            'Nadia Broussard',
+          ]),
+        );
+      });
+
+      test('empties as the threshold rises past every score', () {
+        final result = classify(
+          heuristics: const DmSpamHeuristics(spamThreshold: 1000),
+        );
+        expect(result.likelySpam, isEmpty);
+      });
+
+      test('swallows every request as the threshold drops to zero', () {
+        final result = classify(
+          heuristics: const DmSpamHeuristics(spamThreshold: -1000),
+        );
+        expect(result.requests, isEmpty);
+        expect(result.likelySpam, isNotEmpty);
+      });
+    });
+
+    group('verdicts', () {
+      test('explains every conversation it classified', () {
+        final result = classify();
+        expect(
+          result.verdicts.keys.toSet(),
+          equals(fixtures.dmConversations.map((c) => c.id).toSet()),
+        );
+      });
+
+      test('partitions without dropping or duplicating a conversation', () {
+        final result = classify();
+        final all = [
+          ...result.official,
+          ...result.inbox,
+          ...result.requests,
+          ...result.likelySpam,
+        ];
+        expect(all, hasLength(fixtures.dmConversations.length));
+        expect(all.map((c) => c.id).toSet(), hasLength(all.length));
+      });
+    });
+  });
+}
+
+bool _allFollowed(DmInboxFixtures fixtures, conversation) {
+  final others = (conversation.participantPubkeys as List<String>)
+      .where((pk) => pk != fixtures.userPubkey)
+      .toSet();
+  return others.isNotEmpty && others.every(fixtures.isFollowing);
+}

--- a/mobile/test/prototypes/dm_inbox_tabs/dm_inbox_tabs_prototype_screen_test.dart
+++ b/mobile/test/prototypes/dm_inbox_tabs/dm_inbox_tabs_prototype_screen_test.dart
@@ -1,0 +1,74 @@
+// ABOUTME: PROTOTYPE (#8076) — proves the four-tab screen renders and that
+// ABOUTME: request content stays concealed until the user opens it.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/prototypes/dm_inbox_tabs/dm_inbox_tabs_prototype_screen.dart';
+
+import '../../helpers/test_provider_overrides.dart';
+
+void main() {
+  group(DmInboxTabsPrototypeScreen, () {
+    Future<void> pumpScreen(WidgetTester tester) async {
+      await tester.pumpWidget(
+        testMaterialApp(home: const DmInboxTabsPrototypeScreen()),
+      );
+      await tester.pumpAndSettle();
+    }
+
+    group('renders', () {
+      testWidgets('shows all four tabs', (tester) async {
+        await pumpScreen(tester);
+
+        expect(find.text('Inbox'), findsWidgets);
+        expect(find.text('Official'), findsOneWidget);
+        expect(find.text('Requests'), findsOneWidget);
+        expect(find.text('Likely spam'), findsOneWidget);
+      });
+
+      testWidgets('opens on Inbox with consented conversations', (
+        tester,
+      ) async {
+        await pumpScreen(tester);
+
+        expect(find.text('Maya Okonkwo'), findsOneWidget);
+        expect(find.text('crypto_signals_daily'), findsNothing);
+      });
+    });
+
+    group('interactions', () {
+      testWidgets('conceals request content until the row is opened', (
+        tester,
+      ) async {
+        await pumpScreen(tester);
+        await tester.tap(find.text('Requests'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Priya Raman'), findsOneWidget);
+        expect(find.textContaining('Lisbon'), findsNothing);
+        expect(find.text('Message hidden until you open it'), findsWidgets);
+
+        await tester.tap(find.text('Priya Raman'));
+        await tester.pumpAndSettle();
+
+        expect(find.textContaining('Lisbon'), findsOneWidget);
+      });
+
+      testWidgets('shows official messages unconcealed and unblockable', (
+        tester,
+      ) async {
+        await pumpScreen(tester);
+        await tester.tap(find.text('Official'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Divine Support'), findsOneWidget);
+        expect(find.textContaining('report you filed'), findsOneWidget);
+        expect(
+          find.textContaining('cannot be blocked'),
+          findsWidgets,
+        );
+        expect(find.text('Liz · Divine team'), findsOneWidget);
+        expect(find.text('Reportable · blockable'), findsWidgets);
+      });
+    });
+  });
+}


### PR DESCRIPTION
Closes #8076

## Problem

The current DM redesign needs a concrete cross-functional discussion surface before production behavior changes. Unsolicited message content must remain concealed until consent, people need an unmistakable way to identify real Divine communications, and spam controls need to be understandable rather than a black box.

## Why this prototype

This adds a fixture-only, native Flutter prototype under Developer Options. It separates existing chats, verified Divine identities, ordinary requests, and likely spam; exposes the scoring tradeoffs live; and makes the trust boundary explicit:

- operational Divine accounts are reportable but cannot be blocked
- verified Divine team members are reportable and blockable
- request content stays concealed until the user chooses to reveal it
- a deterministic, locally explainable score routes requests without inspecting message content server-side
- advanced users can tune the score, remix community recipes, and preview settings-only sharing

All identities, keys, conversations, and signals in the prototype are synthetic.

## Deliberately unchanged

This does not touch the production DM repository, inbox classification, storage, badges, routing guards, block behavior, or Nostr event formats. Sharing is a prototype interaction only and does not publish a recipe. It is intended for Product, Trust & Safety, Support, Engineering, Marketing, and user-research discussion—not production rollout.

## Try it

On macOS, open Developer Options and choose **DM inbox: 4-tab prototype**. Use the faders control to open **My request filter**, change weights, apply a community recipe, and return to see conversations move between Requests and Likely spam.

## Verification

- Focused prototype and routing/widget tests: 29 passed in the pre-push suite
- Focused Flutter analysis: no issues
- Native macOS debug build completed successfully

Closes no issue; #8076 remains a product-discussion input rather than an implementation-ready specification.