### PR TITLE
fix(camera): honour Music mode when Android picks an audio source

### DIFF
--- a/mobile/lib/screens/settings/content_preferences_screen.dart
+++ b/mobile/lib/screens/settings/content_preferences_screen.dart
@@ -44,7 +44,9 @@ class ContentPreferencesScreen extends ConsumerWidget {
               const _ContentFiltersTile(),
               const AccountContentLabelsTile(),
               const _AudioSharingToggle(),
-              if (!kIsWeb && defaultTargetPlatform == TargetPlatform.iOS)
+              if (!kIsWeb &&
+                  (defaultTargetPlatform == TargetPlatform.iOS ||
+                      defaultTargetPlatform == TargetPlatform.android))
                 const _MusicModeToggle(),
               if (!kIsWeb && defaultTargetPlatform != TargetPlatform.linux)
                 const _AudioDeviceSelector(),

--- a/mobile/lib/services/music_mode_preference_service.dart
+++ b/mobile/lib/services/music_mode_preference_service.dart
@@ -1,4 +1,4 @@
-// ABOUTME: Service for the Music mode recording preference (iOS)
+// ABOUTME: Service for the Music mode recording preference (iOS/Android)
 // ABOUTME: Controls whether the mic is captured without speech-tuned cleanup
 
 import 'package:shared_preferences/shared_preferences.dart';
@@ -11,7 +11,8 @@ import 'package:unified_logger/unified_logger.dart';
 /// instrument as noise and gates it away (#7796). Off by default: the
 /// processing is what keeps ordinary talking clips clean.
 ///
-/// iOS is the only platform that acts on this today — see
+/// iOS swaps the capture session's audio mode; Android picks a recording
+/// audio source that skips the processing — see
 /// `DivineCamera.initialize(preferUnprocessedAudio:)`.
 class MusicModePreferenceService {
   MusicModePreferenceService(this._prefs)

--- a/mobile/lib/services/video_recorder/camera/camera_base_service.dart
+++ b/mobile/lib/services/video_recorder/camera/camera_base_service.dart
@@ -53,7 +53,8 @@ abstract class CameraService {
   /// level (default: true).
   /// [preferUnprocessedAudio] captures the microphone without the platform's
   /// speech-tuned noise suppression, so instruments survive at their real
-  /// level (default: false). iOS only — see `MusicModePreferenceService`.
+  /// level (default: false). iOS and Android — see
+  /// `MusicModePreferenceService`.
   Future<void> initialize({
     DivineVideoQuality videoQuality = DivineVideoQuality.fhd,
     DivineCameraLens initialLens = DivineCameraLens.front,

--- a/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/AudioInputSource.kt
+++ b/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/AudioInputSource.kt
@@ -8,6 +8,29 @@ import android.media.MediaRecorder
 import androidx.camera.video.AudioSpec
 
 /**
+ * The order AOSP picks an input device in for every source this file can
+ * choose — `MIC`, `VOICE_RECOGNITION` and `UNPROCESSED`.
+ *
+ * `Engine::getDeviceForInputSource` keeps two separate `case` blocks, one for
+ * `MIC`/`DEFAULT` and one shared by `VOICE_RECOGNITION`/`UNPROCESSED`, but
+ * hands both the same list, and has since Android 13. So switching *between*
+ * these three sources changes the processing and never the device — which is
+ * what makes Music mode composable with the external-mic fix below.
+ *
+ * `CAMCORDER`, which [AudioSpec.SOURCE_AUTO] resolves to, is the odd one out:
+ * `BACK_MIC, BUILTIN_MIC, USB_DEVICE`. It is the only source that will not
+ * route to a wired headset or to Bluetooth, and the only one that prefers the
+ * rear mic.
+ */
+private val MIC_FAMILY_DEVICE_PRIORITY = intArrayOf(
+    AudioDeviceInfo.TYPE_WIRED_HEADSET,
+    AudioDeviceInfo.TYPE_USB_HEADSET,
+    AudioDeviceInfo.TYPE_USB_DEVICE,
+    AudioDeviceInfo.TYPE_BLE_HEADSET,
+    AudioDeviceInfo.TYPE_BUILTIN_MIC
+)
+
+/**
  * Input device types that mean the user attached something to record with.
  *
  * Only devices reported by `AudioManager.GET_DEVICES_INPUTS` are ever tested
@@ -28,11 +51,6 @@ import androidx.camera.video.AudioSpec
  * counts, and the output-device list matches both. So USB is treated as
  * intent to record — plugging a USB peripheral into a phone you are filming
  * on is a deliberate act.
- *
- * The 3.5mm jack is left out for the opposite reason. `TYPE_WIRED_HEADSET`
- * is overwhelmingly earbuds, CAMCORDER does not select it today, and adding
- * it would change recording for people who plugged in only to listen.
- * Bluetooth is left out for the same reason.
  */
 private val EXTERNAL_MIC_TYPES = setOf(
     AudioDeviceInfo.TYPE_USB_DEVICE,
@@ -40,29 +58,79 @@ private val EXTERNAL_MIC_TYPES = setOf(
 )
 
 /**
+ * Input types someone is wearing to listen, not holding to record.
+ *
+ * Both outrank the built-in mic in [MIC_FAMILY_DEVICE_PRIORITY], and neither
+ * appears in `CAMCORDER`'s list at all. So whenever one of these would be the
+ * captured device, leaving the source alone is the only way to keep the
+ * recording off the user's earbuds — see [audioSourceForInputDeviceTypes].
+ */
+private val LISTENING_ONLY_TYPES = setOf(
+    AudioDeviceInfo.TYPE_WIRED_HEADSET,
+    AudioDeviceInfo.TYPE_BLE_HEADSET
+)
+
+/**
  * The audio source a new Recorder should capture from, given the connected
- * input device [types].
+ * input device [types], whether the user turned on Music mode
+ * ([preferUnprocessedAudio]) and whether this device reports support for the
+ * unprocessed source ([unprocessedSourceSupported]).
  *
  * CameraX leaves the source at [AudioSpec.SOURCE_AUTO], which resolves to
- * `MediaRecorder.AudioSource.CAMCORDER`. AOSP's audio policy ranks input
- * devices per source, and for CAMCORDER the order is back mic, built-in mic,
- * then USB — USB is reachable only on a device with no built-in mic, so on a
- * phone an attached USB microphone is never selected (#6171). MIC ranks USB
- * ahead of the built-in mic, which is what someone who just plugged in a
- * microphone expects.
+ * `MediaRecorder.AudioSource.CAMCORDER`. Two independent things can pull us
+ * off that default, and they compose because every source we can move to
+ * shares one device ordering (see [MIC_FAMILY_DEVICE_PRIORITY]):
  *
- * Returns [AudioSpec.SOURCE_AUTO] unless USB is attached without a wired
- * headset. MIC ranks a wired headset ahead of USB, so switching with both
- * attached would capture from the headset rather than the USB device that
- * triggered the switch.
+ *  - **An attached USB microphone (#6171).** `CAMCORDER` ranks USB behind the
+ *    built-in mic, so it is reachable only on a device with no built-in mic —
+ *    on a phone, never. The MIC-family ordering puts USB ahead of the built-in
+ *    mic, which is what someone who just plugged a microphone in expects.
+ *  - **Music mode (#7796, #8079).** The CDD requires `UNPROCESSED` to carry
+ *    no gain control, filtering or echo cancellation (§5.11 [C-1-8]) — that
+ *    processing is what flattens a sustained instrument. Support is opt-in per
+ *    device, and where it is missing the constant is documented to "behave
+ *    like DEFAULT", i.e. silently give back the processing we were escaping.
+ *    So an unsupported device falls to `VOICE_RECOGNITION`, Android's own
+ *    recommended substitute, which the CDD separately requires to disable
+ *    automatic gain control and noise reduction (§5.4.2 [C-1-2], [C-1-3]).
+ *
+ * The one thing that stops both is a device the user is only listening on.
+ * `CAMCORDER` is the sole source that will not route to a wired headset or to
+ * Bluetooth, so if either would win the device race, *any* switch moves the
+ * recording onto their earbud mic — worse than the processing or the built-in
+ * mic we were trying to escape. Those cases keep [AudioSpec.SOURCE_AUTO] and
+ * give up on both goals deliberately.
+ *
+ * Music mode with nothing attached still switches. It is a request about
+ * processing rather than about devices, and the only device it can cost is
+ * `BACK_MIC`, which `CAMCORDER` prefers and the MIC family does not list —
+ * an accepted trade on the phones that declare one, since a gated instrument
+ * is the louder complaint than a front-facing mic.
+ *
+ * Two limits worth knowing, neither of them reachable from here. On Android 12
+ * only, `BLE_HEADSET` is prepended to the shared ordering, so earbuds outrank
+ * a USB mic there and the last case above picks the wrong device; Android 13
+ * onward ranks USB first, and there is no runtime handle on the ordering to
+ * branch off. And while the phone is in a telephony *or VoIP* call, AOSP
+ * rewrites every source here to `VOICE_COMMUNICATION` before selecting a
+ * device, so none of this applies for the duration of the call.
  */
-internal fun audioSourceForInputDeviceTypes(types: IntArray): Int {
-    val hasWiredHeadset = AudioDeviceInfo.TYPE_WIRED_HEADSET in types
-    val hasUsbInput = types.any { it in EXTERNAL_MIC_TYPES }
-    return if (hasUsbInput && !hasWiredHeadset) {
-        MediaRecorder.AudioSource.MIC
-    } else {
-        AudioSpec.SOURCE_AUTO
+internal fun audioSourceForInputDeviceTypes(
+    types: IntArray,
+    preferUnprocessedAudio: Boolean = false,
+    unprocessedSourceSupported: Boolean = false
+): Int {
+    val captured = MIC_FAMILY_DEVICE_PRIORITY.firstOrNull { it in types }
+    if (captured != null && captured in LISTENING_ONLY_TYPES) {
+        return AudioSpec.SOURCE_AUTO
+    }
+    return when {
+        preferUnprocessedAudio && unprocessedSourceSupported ->
+            MediaRecorder.AudioSource.UNPROCESSED
+        preferUnprocessedAudio -> MediaRecorder.AudioSource.VOICE_RECOGNITION
+        captured != null && captured in EXTERNAL_MIC_TYPES ->
+            MediaRecorder.AudioSource.MIC
+        else -> AudioSpec.SOURCE_AUTO
     }
 }
 
@@ -85,4 +153,18 @@ internal fun audioInputTypeName(type: Int): String = when (type) {
     AudioDeviceInfo.TYPE_TELEPHONY -> "TELEPHONY"
     AudioDeviceInfo.TYPE_REMOTE_SUBMIX -> "REMOTE_SUBMIX"
     else -> "TYPE_$type"
+}
+
+/**
+ * Short readable name for a resolved audio [source], for the same diagnostic.
+ *
+ * A report that Music mode or an external mic did nothing is only actionable
+ * if the log says which source was actually chosen.
+ */
+internal fun audioSourceName(source: Int): String = when (source) {
+    AudioSpec.SOURCE_AUTO -> "camera default"
+    MediaRecorder.AudioSource.MIC -> "MIC"
+    MediaRecorder.AudioSource.VOICE_RECOGNITION -> "VOICE_RECOGNITION"
+    MediaRecorder.AudioSource.UNPROCESSED -> "UNPROCESSED"
+    else -> "SOURCE_$source"
 }

--- a/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/CameraController.kt
+++ b/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/CameraController.kt
@@ -93,6 +93,11 @@ class CameraController(
     // continuously). Reset to the sentinel on each recording Start.
     private var lastAudioState: Int = Int.MIN_VALUE
 
+    // Whether the user asked for capture without the platform's speech-tuned
+    // processing (Music mode, #7796). Set per initialize like every other
+    // session flag, and read when a Recorder picks its audio source.
+    private var prefersUnprocessedAudio: Boolean = false
+
     // Callback for startRecording - called when recording truly starts or is aborted
     private var startRecordingCallback: ((String?) -> Unit)? = null
     private var isPaused: Boolean = false
@@ -365,13 +370,15 @@ class CameraController(
         enableScreenFlash: Boolean = true,
         mirrorFrontCameraOutput: Boolean = true,
         enableAutoLensSwitch: Boolean = true,
+        preferUnprocessedAudio: Boolean = false,
         callback: (Map<String, Any?>?, String?) -> Unit
     ) {
-        DivineCameraLog.d(TAG, "Initializing camera with lens: $lens, quality: $quality, enableScreenFlash: $enableScreenFlash, mirrorFrontCameraOutput: $mirrorFrontCameraOutput, autoLensSwitch: $enableAutoLensSwitch (portrait mode 1080x1920)")
+        DivineCameraLog.d(TAG, "Initializing camera with lens: $lens, quality: $quality, enableScreenFlash: $enableScreenFlash, mirrorFrontCameraOutput: $mirrorFrontCameraOutput, autoLensSwitch: $enableAutoLensSwitch, unprocessedAudio: $preferUnprocessedAudio (portrait mode 1080x1920)")
 
         screenFlashFeatureEnabled = enableScreenFlash
         this.mirrorFrontCameraOutput = mirrorFrontCameraOutput
         this.autoLensSwitchRequested = enableAutoLensSwitch
+        this.prefersUnprocessedAudio = preferUnprocessedAudio
 
         // Map lens string to lens type and facing
         currentLensType = lens
@@ -905,10 +912,16 @@ class CameraController(
      * up a microphone attached since the last build; a mic plugged in while the
      * camera stays bound is picked up on the next switch or re-entry.
      *
-     * Logs the decision and the inputs it was made from either way. A report
-     * that the external mic was still ignored is only actionable if it says
-     * which inputs the device reported, and a device naming its mic something
-     * we do not route on leaves no other trace (#6171).
+     * Also honours the user's Music mode preference (#8079), which asks for
+     * capture without the platform's speech-tuned processing. iOS answers that
+     * with an audio-session mode; the audio source is Android's equivalent
+     * lever, and this is the only place Android picks one.
+     *
+     * Logs the decision, both inputs to it, and the inputs the device
+     * reported. A report that the external mic or Music mode was ignored is
+     * only actionable if it says which source was chosen and from what, and a
+     * device naming its mic something we do not route on leaves no other
+     * trace (#6171).
      */
     private fun resolveAudioSource(): Int {
         val audioManager =
@@ -924,16 +937,26 @@ class CameraController(
             .getDevices(AudioManager.GET_DEVICES_INPUTS)
             .map { it.type }
             .toIntArray()
-        val source = audioSourceForInputDeviceTypes(types)
+        // Only the exact string "true" means supported. The CDD requires an
+        // unsupporting device to return null (§5.11 [C-2-1]) while AOSP's own
+        // getProperty returns String.valueOf(false) and never null, so both
+        // answers are in the field and both must read as unsupported.
+        val unprocessedSupported = audioManager
+            .getProperty(AudioManager.PROPERTY_SUPPORT_AUDIO_SOURCE_UNPROCESSED)
+            .toBoolean()
+        val source = audioSourceForInputDeviceTypes(
+            types,
+            preferUnprocessedAudio = prefersUnprocessedAudio,
+            unprocessedSourceSupported = unprocessedSupported
+        )
         val inputs = types
             .joinToString(", ") { audioInputTypeName(it) }
             .ifEmpty { "none" }
         DivineCameraLog.info(
-            if (source == AudioSpec.SOURCE_AUTO) {
-                "Audio source: camera default (inputs: $inputs)"
-            } else {
-                "Audio source: MIC, external input attached (inputs: $inputs)"
-            },
+            "Audio source: ${audioSourceName(source)} " +
+                "(music mode: $prefersUnprocessedAudio, " +
+                "unprocessed supported: $unprocessedSupported, " +
+                "inputs: $inputs)",
             name = "DivineCamera.Audio"
         )
         return source

--- a/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/DivineCameraPlugin.kt
+++ b/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/DivineCameraPlugin.kt
@@ -117,7 +117,8 @@ class DivineCameraPlugin :
                 val enableScreenFlash = call.argument<Boolean>("enableScreenFlash") ?: true
                 val mirrorFrontCameraOutput = call.argument<Boolean>("mirrorFrontCameraOutput") ?: true
                 val enableAutoLensSwitch = call.argument<Boolean>("enableAutoLensSwitch") ?: true
-                initializeCamera(lens, videoQuality, enableScreenFlash, mirrorFrontCameraOutput, enableAutoLensSwitch, oneShotResult)
+                val preferUnprocessedAudio = call.argument<Boolean>("preferUnprocessedAudio") ?: false
+                initializeCamera(lens, videoQuality, enableScreenFlash, mirrorFrontCameraOutput, enableAutoLensSwitch, preferUnprocessedAudio, oneShotResult)
             }
 
             "disposeCamera" -> {
@@ -209,7 +210,7 @@ class DivineCameraPlugin :
         }
     }
 
-    private fun initializeCamera(lens: String, videoQuality: String, enableScreenFlash: Boolean, mirrorFrontCameraOutput: Boolean, enableAutoLensSwitch: Boolean, result: Result) {
+    private fun initializeCamera(lens: String, videoQuality: String, enableScreenFlash: Boolean, mirrorFrontCameraOutput: Boolean, enableAutoLensSwitch: Boolean, preferUnprocessedAudio: Boolean, result: Result) {
         val currentActivity = activity
         if (currentActivity == null) {
             result.error("NO_ACTIVITY", "Activity not available", null)
@@ -229,7 +230,7 @@ class DivineCameraPlugin :
                 channel.invokeMethod("onRecordingAutoStopped", recordingResult)
             }
 
-            cameraController?.initialize(lens, videoQuality, enableScreenFlash, mirrorFrontCameraOutput, enableAutoLensSwitch) { state, error ->
+            cameraController?.initialize(lens, videoQuality, enableScreenFlash, mirrorFrontCameraOutput, enableAutoLensSwitch, preferUnprocessedAudio) { state, error ->
                 if (error != null) {
                     result.error("INIT_ERROR", error, null)
                 } else {

--- a/mobile/packages/divine_camera/android/src/test/kotlin/co/openvine/divine_camera/AudioInputSourceTest.kt
+++ b/mobile/packages/divine_camera/android/src/test/kotlin/co/openvine/divine_camera/AudioInputSourceTest.kt
@@ -170,6 +170,169 @@ internal class AudioInputSourceTest {
     }
 
     @Test
+    fun musicMode_capturesWithoutProcessingWhereSupported() {
+        // The whole point of the preference: UNPROCESSED is the source Android
+        // documents for capture with no AGC and no noise suppression.
+        assertEquals(
+            MediaRecorder.AudioSource.UNPROCESSED,
+            audioSourceForInputDeviceTypes(
+                intArrayOf(AudioDeviceInfo.TYPE_BUILTIN_MIC),
+                preferUnprocessedAudio = true,
+                unprocessedSourceSupported = true
+            )
+        )
+    }
+
+    @Test
+    fun musicMode_fallsBackToVoiceRecognitionWhereUnprocessedIsUnsupported() {
+        // Not every device supports UNPROCESSED. VOICE_RECOGNITION is
+        // Android's own documented fallback, and drops AGC and noise
+        // suppression — less than UNPROCESSED promises, more than doing
+        // nothing, which is what Android did before #8079.
+        assertEquals(
+            MediaRecorder.AudioSource.VOICE_RECOGNITION,
+            audioSourceForInputDeviceTypes(
+                intArrayOf(AudioDeviceInfo.TYPE_BUILTIN_MIC),
+                preferUnprocessedAudio = true,
+                unprocessedSourceSupported = false
+            )
+        )
+    }
+
+    @Test
+    fun musicMode_alongsideAUsbMicKeepsBoth() {
+        // A musician with an external mic wants the mic AND the processing
+        // gone. AOSP hands MIC, VOICE_RECOGNITION and UNPROCESSED the same
+        // device list, so moving to UNPROCESSED for the processing does not
+        // cost the USB device that #6171 was about.
+        assertEquals(
+            MediaRecorder.AudioSource.UNPROCESSED,
+            audioSourceForInputDeviceTypes(
+                intArrayOf(
+                    AudioDeviceInfo.TYPE_BUILTIN_MIC,
+                    AudioDeviceInfo.TYPE_USB_DEVICE
+                ),
+                preferUnprocessedAudio = true,
+                unprocessedSourceSupported = true
+            )
+        )
+    }
+
+    @Test
+    fun musicMode_withAWiredHeadsetKeepsCameraXDefault() {
+        // A wired headset outranks everything under the unprocessed sources
+        // just as it does under MIC, and CAMCORDER will not route to it at
+        // all — so honouring Music mode here would move the recording onto
+        // the earbud mic. Giving up on the processing is the smaller loss.
+        assertEquals(
+            AudioSpec.SOURCE_AUTO,
+            audioSourceForInputDeviceTypes(
+                intArrayOf(
+                    AudioDeviceInfo.TYPE_BUILTIN_MIC,
+                    AudioDeviceInfo.TYPE_WIRED_HEADSET
+                ),
+                preferUnprocessedAudio = true,
+                unprocessedSourceSupported = true
+            )
+        )
+    }
+
+    @Test
+    fun musicMode_withBluetoothEarbudsKeepsCameraXDefault() {
+        // Same rule over the air. BLUETOOTH_BLE sits above the built-in mic
+        // in the shared ordering but is absent from CAMCORDER's, so a switch
+        // made purely for the processing would silently hand the recording to
+        // the user's earbuds. That is the trade #7652 already refused.
+        assertEquals(
+            AudioSpec.SOURCE_AUTO,
+            audioSourceForInputDeviceTypes(
+                intArrayOf(
+                    AudioDeviceInfo.TYPE_BUILTIN_MIC,
+                    AudioDeviceInfo.TYPE_BLE_HEADSET
+                ),
+                preferUnprocessedAudio = true,
+                unprocessedSourceSupported = true
+            )
+        )
+    }
+
+    @Test
+    fun musicMode_withEarbudsAndAPluggedInMicStillSwitches() {
+        // Monitoring on earbuds while an external mic records is the setup
+        // Music mode exists for. USB outranks BLUETOOTH_BLE, so the mic wins
+        // the device race and the switch is safe to make.
+        assertEquals(
+            MediaRecorder.AudioSource.UNPROCESSED,
+            audioSourceForInputDeviceTypes(
+                intArrayOf(
+                    AudioDeviceInfo.TYPE_BUILTIN_MIC,
+                    AudioDeviceInfo.TYPE_BLE_HEADSET,
+                    AudioDeviceInfo.TYPE_USB_DEVICE
+                ),
+                preferUnprocessedAudio = true,
+                unprocessedSourceSupported = true
+            )
+        )
+    }
+
+    @Test
+    fun musicMode_offLeavesTheSupportPropertyIrrelevant() {
+        // A device that supports UNPROCESSED must not drift off the
+        // camera-tuned path for users who never asked for Music mode.
+        assertEquals(
+            AudioSpec.SOURCE_AUTO,
+            audioSourceForInputDeviceTypes(
+                intArrayOf(AudioDeviceInfo.TYPE_BUILTIN_MIC),
+                preferUnprocessedAudio = false,
+                unprocessedSourceSupported = true
+            )
+        )
+        assertEquals(
+            MediaRecorder.AudioSource.MIC,
+            audioSourceForInputDeviceTypes(
+                intArrayOf(
+                    AudioDeviceInfo.TYPE_BUILTIN_MIC,
+                    AudioDeviceInfo.TYPE_USB_DEVICE
+                ),
+                preferUnprocessedAudio = false,
+                unprocessedSourceSupported = true
+            )
+        )
+    }
+
+    @Test
+    fun musicMode_withNoReportedInputsStillSwitches() {
+        // Music mode is a request about processing, not about devices, and an
+        // empty input list is not evidence of earbuds. Nothing is captured
+        // either way here, so the honest reading is to honour the setting.
+        assertEquals(
+            MediaRecorder.AudioSource.UNPROCESSED,
+            audioSourceForInputDeviceTypes(
+                intArrayOf(),
+                preferUnprocessedAudio = true,
+                unprocessedSourceSupported = true
+            )
+        )
+    }
+
+    @Test
+    fun sourceNames_stayReadableAndKeepUnmappedSourcesVisible() {
+        // These land in bug reports next to the input list; "Music mode did
+        // nothing" is only diagnosable if the chosen source is named.
+        assertEquals("camera default", audioSourceName(AudioSpec.SOURCE_AUTO))
+        assertEquals("MIC", audioSourceName(MediaRecorder.AudioSource.MIC))
+        assertEquals(
+            "UNPROCESSED",
+            audioSourceName(MediaRecorder.AudioSource.UNPROCESSED)
+        )
+        assertEquals(
+            "VOICE_RECOGNITION",
+            audioSourceName(MediaRecorder.AudioSource.VOICE_RECOGNITION)
+        )
+        assertEquals("SOURCE_9999", audioSourceName(9999))
+    }
+
+    @Test
     fun inputTypeNames_stayReadableAndKeepUnmappedTypesVisible() {
         // The names land in user bug reports, and an unmapped type is the case
         // worth reading: a device that calls its external mic something we do
@@ -189,14 +352,25 @@ internal class AudioInputSourceTest {
      */
     @SuppressLint("RestrictedApi")
     @Test
-    fun recorderRetainsTheConfiguredAudioSource() {
-        assertEquals(
-            MediaRecorder.AudioSource.MIC,
-            Recorder.Builder()
-                .setAudioSource(MediaRecorder.AudioSource.MIC)
-                .build()
-                .audioSource
+    fun recorderRetainsEveryAudioSourceWeCanResolve() {
+        // Every one of these is outside AudioSpec's declared domain
+        // (SOURCE_AUTO and SOURCE_CAMCORDER), so all three depend on the
+        // setter passing the value through unvalidated.
+        val sources = mapOf(
+            "MIC" to MediaRecorder.AudioSource.MIC,
+            "VOICE_RECOGNITION" to MediaRecorder.AudioSource.VOICE_RECOGNITION,
+            "UNPROCESSED" to MediaRecorder.AudioSource.UNPROCESSED
         )
+        for ((name, source) in sources) {
+            assertEquals(
+                source,
+                Recorder.Builder()
+                    .setAudioSource(source)
+                    .build()
+                    .audioSource,
+                "$name should survive into the built Recorder"
+            )
+        }
     }
 
     @SuppressLint("RestrictedApi")

--- a/mobile/packages/divine_camera/lib/divine_camera.dart
+++ b/mobile/packages/divine_camera/lib/divine_camera.dart
@@ -107,8 +107,8 @@ class DivineCamera {
   /// The preview is always mirrored.
   /// [preferUnprocessedAudio] captures the microphone without the
   /// speech-tuned noise suppression the platform applies by default, so
-  /// instruments and music survive at their real level. iOS only — every
-  /// other platform ignores it.
+  /// instruments and music survive at their real level. iOS and Android
+  /// act on it; every other platform ignores it.
   ///
   /// Returns the initialized camera state.
   Future<CameraState> initialize({

--- a/mobile/packages/divine_camera/lib/divine_camera_platform_interface.dart
+++ b/mobile/packages/divine_camera/lib/divine_camera_platform_interface.dart
@@ -42,8 +42,8 @@ abstract class DivineCameraPlatform extends PlatformInterface {
   /// Initializes the camera with the specified lens.
   ///
   /// [preferUnprocessedAudio] asks the platform to capture the microphone
-  /// without the speech-tuned processing it applies by default. iOS only —
-  /// other platforms ignore it.
+  /// without the speech-tuned processing it applies by default. iOS and
+  /// Android act on it; other platforms ignore it.
   ///
   /// Returns the initial camera state.
   Future<CameraState> initializeCamera({

--- a/mobile/packages/divine_camera/test/android_audio_processing_contract_test.dart
+++ b/mobile/packages/divine_camera/test/android_audio_processing_contract_test.dart
@@ -1,0 +1,118 @@
+// ABOUTME: Static guards for the Android unprocessed-audio capture contract.
+// ABOUTME: Pins that Music mode reaches the recording audio source (#8079).
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+String _readNativeSource(String fileName) {
+  const packagePath = 'android/src/main/kotlin/co/openvine/divine_camera';
+  final file = [
+    File('$packagePath/$fileName'),
+    File('packages/divine_camera/$packagePath/$fileName'),
+  ].firstWhere((file) => file.existsSync());
+
+  return file.readAsStringSync();
+}
+
+/// Returns the Kotlin declaration starting at [signature] up to its closing
+/// brace, so an assertion cannot match an identical line elsewhere in the
+/// file, nor a line that sits outside the scope being asserted on.
+String _declarationAt(String source, String signature) {
+  final start = source.indexOf(signature);
+  if (start < 0) {
+    throw StateError('No declaration starting with "$signature".');
+  }
+
+  var depth = 0;
+  for (var i = source.indexOf('{', start); i < source.length; i++) {
+    if (source[i] == '{') depth++;
+    if (source[i] == '}') {
+      depth--;
+      if (depth == 0) return source.substring(start, i + 1);
+    }
+  }
+  throw StateError('Unbalanced braces after "$signature".');
+}
+
+void main() {
+  group('Android unprocessed audio contract', () {
+    late final String pluginSource;
+    late final String controllerSource;
+    late final String resolveAudioSource;
+
+    setUpAll(() {
+      pluginSource = _readNativeSource('DivineCameraPlugin.kt');
+      controllerSource = _readNativeSource('CameraController.kt');
+      resolveAudioSource = _declarationAt(
+        controllerSource,
+        'private fun resolveAudioSource(',
+      );
+    });
+
+    test('the plugin reads the Music mode argument off the channel', () {
+      // The defect this closes: five of the six initialize arguments were
+      // read and this one was dropped by MethodCall.argument without an
+      // error, so the setting could not reach Android at all.
+      expect(
+        pluginSource,
+        contains(
+          'call.argument<Boolean>("preferUnprocessedAudio") ?: false',
+        ),
+      );
+    });
+
+    test('the plugin forwards it to the controller', () {
+      expect(
+        _declarationAt(pluginSource, 'private fun initializeCamera('),
+        contains('enableAutoLensSwitch, preferUnprocessedAudio)'),
+      );
+    });
+
+    test('the controller keeps it for the life of the session', () {
+      // Stored per initialize like every other session flag, because the
+      // Recorder that consumes it is built later, on bind and on lens switch.
+      expect(
+        controllerSource,
+        contains('private var prefersUnprocessedAudio: Boolean = false'),
+      );
+      expect(
+        _declarationAt(controllerSource, '    fun initialize('),
+        contains('this.prefersUnprocessedAudio = preferUnprocessedAudio'),
+      );
+    });
+
+    test('resolving a source consults the preference', () {
+      expect(
+        resolveAudioSource,
+        contains('preferUnprocessedAudio = prefersUnprocessedAudio'),
+      );
+    });
+
+    test('unprocessed support is probed, and only "true" counts', () {
+      // The CDD tells an unsupporting device to return null while AOSP
+      // returns "false", so the check has to reject both rather than test
+      // for null. toBoolean() is what makes an unexpected value read as
+      // unsupported instead of silently claiming support.
+      expect(
+        resolveAudioSource,
+        contains('AudioManager.PROPERTY_SUPPORT_AUDIO_SOURCE_UNPROCESSED'),
+      );
+      expect(resolveAudioSource, contains('.toBoolean()'));
+    });
+
+    test('the resolved source is named in the diagnostic', () {
+      // A "Music mode did nothing" report is only actionable if the log says
+      // which source was chosen and whether the device claimed support.
+      expect(resolveAudioSource, contains(r'${audioSourceName(source)}'));
+      expect(
+        resolveAudioSource,
+        contains(r'music mode: $prefersUnprocessedAudio'),
+      );
+      expect(
+        resolveAudioSource,
+        contains(r'unprocessed supported: $unprocessedSupported'),
+      );
+    });
+  });
+}

--- a/mobile/packages/divine_camera/test/divine_camera_method_channel_test.dart
+++ b/mobile/packages/divine_camera/test/divine_camera_method_channel_test.dart
@@ -149,8 +149,9 @@ void main() {
     );
 
     test('initializeCamera forwards the unprocessed-audio request', () async {
-      // iOS reads this key to pick the recording audio-session mode (#7796);
-      // dropping it here silently strands the Music mode setting.
+      // iOS reads this key to pick the recording audio-session mode (#7796)
+      // and Android to pick the recording audio source (#8079); dropping it
+      // here silently strands the Music mode setting.
       await platform.initializeCamera(preferUnprocessedAudio: true);
 
       expect(lastInitializeArgs?['preferUnprocessedAudio'], isTrue);

--- a/mobile/test/screens/settings/content_preferences_music_mode_test.dart
+++ b/mobile/test/screens/settings/content_preferences_music_mode_test.dart
@@ -1,5 +1,5 @@
 // ABOUTME: Tests the Music mode toggle in content preferences (#7796).
-// ABOUTME: Covers the iOS-only gate and that a tap reaches the preference.
+// ABOUTME: Covers the iOS/Android gate and that a tap reaches the preference.
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/foundation.dart';
@@ -116,10 +116,24 @@ void main() {
       await disposeTree(tester);
     });
 
-    testWidgets('hides the toggle where nothing acts on it', (tester) async {
-      // Android resolves its recording audio source separately (#7652), so a
-      // switch there would be a control that does nothing.
+    testWidgets('shows the toggle on Android too', (tester) async {
+      // Android honours the preference when it resolves the recording audio
+      // source (#8079), so the switch has to be reachable there as well —
+      // until it was, the setting could not be turned on at all on Android.
       debugDefaultTargetPlatformOverride = TargetPlatform.android;
+
+      await tester.pumpWidget(createTestWidget());
+      await tester.pumpAndSettle();
+
+      expect(musicModeTile(), findsOneWidget);
+
+      await disposeTree(tester);
+    });
+
+    testWidgets('hides the toggle where nothing acts on it', (tester) async {
+      // macOS captures through its own controller, which never reads the
+      // flag, so a switch there would be a control that does nothing.
+      debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
 
       await tester.pumpWidget(createTestWidget());
       await tester.pumpAndSettle();


### PR DESCRIPTION
## Description

Music mode asks the camera to capture without the platform's speech-tuned processing, because that processing treats a sustained instrument as noise and gates it away (#7796). Android did nothing with it, in two independent ways that each made the other invisible:

1. **The flag never arrived.** Dart has always sent `preferUnprocessedAudio` over the method channel. `DivineCameraPlugin.kt` read five of the six `initializeCamera` arguments and dropped this one — and `MethodCall.argument` returns `null` for a key nobody asks for, so there was no error and no log.
2. **The switch was never reachable.** `content_preferences_screen.dart` rendered the toggle only on iOS, so an Android user could not turn the preference on to begin with. Fixing either half alone leaves the feature unreachable.

`resolveAudioSource()` — added by #7652, and still the only place Android picks an audio source — now honours it.

**`UNPROCESSED` where the device supports it, `VOICE_RECOGNITION` where it does not.** The CDD requires `UNPROCESSED` to carry no gain control, filtering or echo cancellation (§5.11 [C-1-8]), but support is opt-in per device and the constant is documented to *"behave like `DEFAULT`"* where it is missing — which would silently hand back the processing we were escaping. `VOICE_RECOGNITION` is Android's own recommended substitute and the CDD separately requires it to disable AGC and noise reduction (§5.4.2 [C-1-2], [C-1-3]). Only the exact string `"true"` counts as support: the CDD tells an unsupporting device to return `null` (§5.11 [C-2-1]) while AOSP's `getProperty` returns `String.valueOf(false)` and never `null`, so both answers are in the field.

**This composes with the external-mic fix instead of fighting it.** The risk worth checking was that moving off `MIC` would undo #6171. It does not: `Engine::getDeviceForInputSource` keeps `MIC`/`DEFAULT` and `VOICE_RECOGNITION`/`UNPROCESSED` in separate `case` blocks but hands both the same ordered list — `WIRED_HEADSET, USB_HEADSET, USB_DEVICE, BLUETOOTH_BLE, BUILTIN_MIC` — and has since Android 13. Switching between those three sources changes the processing and never the device, so a musician with a USB mic gets the mic **and** loses the processing.

**One veto covers both goals, and replaces the ad-hoc one.** `CAMCORDER` is the only source that will not route to a wired headset or to Bluetooth. So whenever either would win the device race, *any* switch moves the recording onto the user's earbud mic. #7652 handled the wired-headset half as a special case (`hasUsbInput && !hasWiredHeadset`); expressing it as "what device would this source actually capture from, and did the user attach it to record?" keeps every one of that PR's 13 tests green unchanged and closes the case the special case never covered — Music mode with earbuds on and no USB mic attached, which would otherwise have recorded through the earbuds.

Music mode with nothing attached still switches. It is a request about processing, not devices, and the only device it can cost is `BACK_MIC`, which `CAMCORDER` prefers and the MIC family does not list — an accepted trade on the phones that declare one.

The diagnostic now names the chosen source, whether Music mode was on, and whether the device claimed `UNPROCESSED` support, so "Music mode did nothing" says which of those was responsible.

**Related Issue:** Closes #8079

## Out of Scope

- **Hot-plugging while the camera stays bound.** Unchanged from #7652 — the source is resolved per Recorder build, so it is picked up on entry and on either lens switch, not mid-session. Closing it needs an `AudioDeviceCallback` plus a rebind that tears down the preview.
- **Telling the user when the veto fires.** With earbuds attached, Music mode silently does nothing. Surfacing that needs new copy in 22 locales and a decision about how loudly to say it; the log line covers diagnosability in the meantime.
- **Android 12's ordering.** That version alone prepends `BLE_HEADSET` to the shared list, so earbuds outrank a USB mic there. There is no runtime handle on the ordering to branch off, and the veto already covers the earbuds-only case; only earbuds-plus-USB is affected, and identically to how #7652 already behaves.
- **Choosing a specific input device.** Still impossible — CameraX 1.5.3 cannot bind a Recorder to a particular `AudioDeviceInfo` at any restriction level. Tracked in #7654.

## Verification

- `gradle :divine_camera:testDebugUnitTest` — 54 green, 22 of them `AudioInputSourceTest` (13 pre-existing, unchanged).
- Mutation-checked rather than assumed, three ways: removing the listening-device veto fails exactly the two earbud tests; ignoring the support property fails exactly the `VOICE_RECOGNITION` fallback test; and restoring the original defect (plugin stops reading the channel argument) fails the contract test.
- `flutter analyze lib test integration_test` and `flutter analyze lib test` in `packages/divine_camera` — No issues found.
- `flutter test --coverage` in `packages/divine_camera` — 392 green, coverage still 100.00% (778/778).
- Targeted Dart: the Music mode widget, cubit, service and `VideoRecorderBloc` suites.
- AOSP claims read from downloaded `Engine.cpp` across android11 → main rather than inferred; the shared list is byte-identical android13 → main. Constant values (`UNPROCESSED = 9`, `VOICE_RECOGNITION = 6`) read from `android.jar`. CameraX passing an out-of-domain source through unvalidated re-confirmed against 1.5.3 bytecode.
- **Not hardware-verified.** No Android device or USB-C mic here, so the audible result is unconfirmed — the same caveat #7652 shipped with. The test that closes this is: turn Music mode on, record a sustained instrument, confirm it is not gated.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
