### PR TITLE
fix(update): send users to working app downloads

### DIFF
--- a/.github/workflows/mobile_ci.yaml
+++ b/.github/workflows/mobile_ci.yaml
@@ -96,6 +96,8 @@ jobs:
           fetch-depth: 0
       - name: Run CI configuration unit tests
         run: python3 -m unittest discover -s .github/scripts/tests
+      - name: 🛍️ Verify update URLs match shipped store identifiers
+        run: bash mobile/scripts/check_store_url_identifiers.sh
 
   generated-files:
     name: Generated Files
@@ -141,8 +143,6 @@ jobs:
         run: bash scripts/check_ios_shipping_versions.sh
       - name: 🌐 Verify backend-host defaults stay on *.divine.video
         run: bash scripts/check_backend_host_defaults.sh
-      - name: 🛍️ Verify update URLs match shipped store identifiers
-        run: bash scripts/check_store_url_identifiers.sh
       - name: 🪵 Verify no raw logging in production code
         run: bash scripts/check_raw_logging.sh
       - name: 🌐 Verify no untagged test mutates HttpOverrides.global

--- a/.github/workflows/mobile_ci.yaml
+++ b/.github/workflows/mobile_ci.yaml
@@ -141,6 +141,8 @@ jobs:
         run: bash scripts/check_ios_shipping_versions.sh
       - name: 🌐 Verify backend-host defaults stay on *.divine.video
         run: bash scripts/check_backend_host_defaults.sh
+      - name: 🛍️ Verify update URLs match shipped store identifiers
+        run: bash scripts/check_store_url_identifiers.sh
       - name: 🪵 Verify no raw logging in production code
         run: bash scripts/check_raw_logging.sh
       - name: 🌐 Verify no untagged test mutates HttpOverrides.global

--- a/mobile/packages/app_update_repository/lib/src/models/install_source.dart
+++ b/mobile/packages/app_update_repository/lib/src/models/install_source.dart
@@ -26,17 +26,16 @@ enum InstallSource {
 abstract class DownloadUrls {
   /// Google Play Store listing.
   static const playStore =
-      'https://play.google.com/store/apps/details?id=com.divinevideo.app';
+      'https://play.google.com/store/apps/details?id=co.openvine.app';
 
   /// Apple App Store listing.
-  static const appStore =
-      'https://apps.apple.com/app/divine-human-video/id6740425428';
+  static const appStore = 'https://apps.apple.com/app/id6747959501';
 
-  /// TestFlight link.
-  static const testFlight = 'https://testflight.apple.com/join/divine';
+  /// Store listing for users running a TestFlight build.
+  static const String testFlight = appStore;
 
   /// Zapstore listing.
-  static const zapstore = 'https://zapstore.dev/app/com.divinevideo.app';
+  static const zapstore = 'https://zapstore.dev/apps/co.openvine.app';
 
   /// GitHub releases page.
   static const github =

--- a/mobile/packages/app_update_repository/test/src/install_source_test.dart
+++ b/mobile/packages/app_update_repository/test/src/install_source_test.dart
@@ -1,0 +1,44 @@
+import 'package:app_update_repository/app_update_repository.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('DownloadUrls', () {
+    test('uses the shipped store listing URLs', () {
+      expect(
+        DownloadUrls.playStore,
+        equals('https://play.google.com/store/apps/details?id=co.openvine.app'),
+      );
+      expect(
+        DownloadUrls.appStore,
+        equals('https://apps.apple.com/app/id6747959501'),
+      );
+      expect(
+        DownloadUrls.testFlight,
+        equals('https://apps.apple.com/app/id6747959501'),
+      );
+      expect(
+        DownloadUrls.zapstore,
+        equals('https://zapstore.dev/apps/co.openvine.app'),
+      );
+      expect(
+        DownloadUrls.github,
+        equals('https://github.com/divinevideo/divine-mobile/releases/latest'),
+      );
+    });
+
+    test('maps every install source to its download URL', () {
+      const expectedUrls = <InstallSource, String>{
+        InstallSource.playStore: DownloadUrls.playStore,
+        InstallSource.appStore: DownloadUrls.appStore,
+        InstallSource.testFlight: DownloadUrls.testFlight,
+        InstallSource.zapstore: DownloadUrls.zapstore,
+        InstallSource.sideload: DownloadUrls.github,
+      };
+
+      expect(expectedUrls.keys, containsAll(InstallSource.values));
+      for (final source in InstallSource.values) {
+        expect(DownloadUrls.forSource(source), expectedUrls[source]);
+      }
+    });
+  });
+}

--- a/mobile/scripts/check_store_url_identifiers.sh
+++ b/mobile/scripts/check_store_url_identifiers.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+ruby - \
+  "$REPO_ROOT/mobile/android/app/build.gradle.kts" \
+  "$REPO_ROOT/codemagic.yaml" \
+  "$REPO_ROOT/mobile/packages/app_update_repository/lib/src/models/install_source.dart" <<'RUBY'
+android_config_path, codemagic_path, download_urls_path = ARGV
+
+android_config = File.read(android_config_path)
+codemagic = File.read(codemagic_path)
+download_urls = File.read(download_urls_path)
+
+application_id = android_config.match(/^\s*applicationId\s*=\s*"([^"]+)"\s*$/)&.[](1)
+app_store_id = codemagic.match(/^\s*APP_STORE_APP_ID=(\d+)\b/)&.[](1)
+url_constants = download_urls
+  .scan(/static const(?: String)?\s+(\w+)\s*=\s*'([^']+)'\s*;/m)
+  .to_h
+
+failures = []
+failures << "#{android_config_path} must define applicationId." if application_id.nil?
+failures << "#{codemagic_path} must define APP_STORE_APP_ID." if app_store_id.nil?
+
+if application_id
+  expected_play_store =
+    "https://play.google.com/store/apps/details?id=#{application_id}"
+  expected_zapstore = "https://zapstore.dev/apps/#{application_id}"
+
+  unless url_constants['playStore'] == expected_play_store
+    failures << "DownloadUrls.playStore must use Android applicationId #{application_id}."
+  end
+  unless url_constants['zapstore'] == expected_zapstore
+    failures << "DownloadUrls.zapstore must use Android applicationId #{application_id}."
+  end
+end
+
+if app_store_id
+  expected_app_store = "https://apps.apple.com/app/id#{app_store_id}"
+  unless url_constants['appStore'] == expected_app_store
+    failures << "DownloadUrls.appStore must use App Store id #{app_store_id}."
+  end
+end
+
+if failures.any?
+  puts 'ERROR: update download URLs drifted from the shipped app identifiers.'
+  failures.each { |failure| puts "  - #{failure}" }
+  exit 1
+end
+
+puts 'Update download URLs match the shipped app identifiers.'
+RUBY

--- a/mobile/test/services/build_provenance_service_test.dart
+++ b/mobile/test/services/build_provenance_service_test.dart
@@ -108,7 +108,7 @@ BuildProvenanceService _service({
   return BuildProvenanceService(
     packageInfo: PackageInfo(
       appName: 'Divine',
-      packageName: 'com.divinevideo.app',
+      packageName: 'co.openvine.app',
       version: '1.0.20',
       buildNumber: '837',
     ),


### PR DESCRIPTION
Users tapping the in-app update prompt currently land on missing Play Store, App Store, TestFlight, or Zapstore pages. The hardcoded URLs used identifiers that never matched the shipped app, and the TestFlight join link is no longer valid.

This updates each download destination to the shipped Android package and App Store identifiers. TestFlight builds now use the working App Store listing, matching the existing server response. It also removes the same obsolete package identifier from the adjacent provenance fixture.

This deliberately keeps the destinations compile-time constants: the client config does not provide a complete set of store links, and fetching it would add a network dependency to update routing.

CI impact: Generated Files now checks the Play Store and Zapstore URLs against the Android application ID and the App Store URL against the release automation app ID. This is a parity check with no live network request.

Verification:
- `very_good test --coverage --min-coverage 89` in `mobile/packages/app_update_repository` (36 tests)
- `flutter test test/services/build_provenance_service_test.dart`
- `flutter analyze`
- `bash scripts/check_store_url_identifiers.sh`
- `actionlint .github/workflows/mobile_ci.yaml`

Closes #7999