### PR TITLE
fix(invites): keep signup open when invite config fails

### DIFF
--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -4174,7 +4174,7 @@
   "devOptionsInviteAvailabilityServerLoading": "የአገልጋይ እሴት፦ በመጫን ላይ",
   "devOptionsInviteAvailabilityServerEnabled": "የአገልጋይ እሴት፦ በርቷል",
   "devOptionsInviteAvailabilityServerDisabled": "የአገልጋይ እሴት፦ ጠፍቷል",
-  "devOptionsInviteAvailabilityServerUnknown": "የአገልጋይ እሴት፦ አይታወቅም (በነባሪ በርቷል)",
+  "devOptionsInviteAvailabilityServerUnknown": "የአገልጋይ እሴት፦ አይታወቅም",
   "devOptionsInviteAvailabilityOverrideNone": "ሽፋን፦ የአገልጋዩን እሴት ተጠቀም",
   "devOptionsInviteAvailabilityOverrideEnabled": "ሽፋን፦ ማብራት አስገድድ",
   "devOptionsInviteAvailabilityOverrideDisabled": "ሽፋን፦ ማጥፋት አስገድድ",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -4042,7 +4042,7 @@
   "devOptionsInviteAvailabilityServerLoading": "قيمة الخادم: جارٍ التحميل",
   "devOptionsInviteAvailabilityServerEnabled": "قيمة الخادم: مفعّلة",
   "devOptionsInviteAvailabilityServerDisabled": "قيمة الخادم: معطّلة",
-  "devOptionsInviteAvailabilityServerUnknown": "قيمة الخادم: غير معروفة (مفعّلة افتراضيًا)",
+  "devOptionsInviteAvailabilityServerUnknown": "قيمة الخادم: غير معروفة",
   "devOptionsInviteAvailabilityOverrideNone": "تجاوز: استخدم قيمة الخادم",
   "devOptionsInviteAvailabilityOverrideEnabled": "تجاوز: فرض التفعيل",
   "devOptionsInviteAvailabilityOverrideDisabled": "تجاوز: فرض التعطيل",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -4180,7 +4180,7 @@
   "devOptionsInviteAvailabilityServerLoading": "Стойност от сървъра: зарежда се",
   "devOptionsInviteAvailabilityServerEnabled": "Стойност от сървъра: включено",
   "devOptionsInviteAvailabilityServerDisabled": "Стойност от сървъра: изключено",
-  "devOptionsInviteAvailabilityServerUnknown": "Стойност от сървъра: неизвестна (по подразбиране включено)",
+  "devOptionsInviteAvailabilityServerUnknown": "Стойност от сървъра: неизвестна",
   "devOptionsInviteAvailabilityOverrideNone": "Замяна: използвай стойността от сървъра",
   "devOptionsInviteAvailabilityOverrideEnabled": "Замяна: наложено включено",
   "devOptionsInviteAvailabilityOverrideDisabled": "Замяна: наложено изключено",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -4042,7 +4042,7 @@
   "devOptionsInviteAvailabilityServerLoading": "Serverwert: wird geladen",
   "devOptionsInviteAvailabilityServerEnabled": "Serverwert: aktiviert",
   "devOptionsInviteAvailabilityServerDisabled": "Serverwert: deaktiviert",
-  "devOptionsInviteAvailabilityServerUnknown": "Serverwert: unbekannt (standardmäßig aktiviert)",
+  "devOptionsInviteAvailabilityServerUnknown": "Serverwert: unbekannt",
   "devOptionsInviteAvailabilityOverrideNone": "Override: Serverwert verwenden",
   "devOptionsInviteAvailabilityOverrideEnabled": "Override: aktiviert erzwingen",
   "devOptionsInviteAvailabilityOverrideDisabled": "Override: deaktiviert erzwingen",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -6670,7 +6670,7 @@
   "devOptionsInviteAvailabilityServerLoading": "Server value: loading",
   "devOptionsInviteAvailabilityServerEnabled": "Server value: enabled",
   "devOptionsInviteAvailabilityServerDisabled": "Server value: disabled",
-  "devOptionsInviteAvailabilityServerUnknown": "Server value: unknown (defaults enabled)",
+  "devOptionsInviteAvailabilityServerUnknown": "Server value: unknown",
   "devOptionsInviteAvailabilityOverrideNone": "Override: use server value",
   "devOptionsInviteAvailabilityOverrideEnabled": "Override: force enabled",
   "devOptionsInviteAvailabilityOverrideDisabled": "Override: force disabled",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -4042,7 +4042,7 @@
   "devOptionsInviteAvailabilityServerLoading": "Valor del servidor: cargando",
   "devOptionsInviteAvailabilityServerEnabled": "Valor del servidor: activado",
   "devOptionsInviteAvailabilityServerDisabled": "Valor del servidor: desactivado",
-  "devOptionsInviteAvailabilityServerUnknown": "Valor del servidor: desconocido (activado por defecto)",
+  "devOptionsInviteAvailabilityServerUnknown": "Valor del servidor: desconocido",
   "devOptionsInviteAvailabilityOverrideNone": "Anulación: usar el valor del servidor",
   "devOptionsInviteAvailabilityOverrideEnabled": "Anulación: forzar activado",
   "devOptionsInviteAvailabilityOverrideDisabled": "Anulación: forzar desactivado",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -2845,7 +2845,7 @@
   "devOptionsInviteAvailabilityServerLoading": "Server value: nilo-load",
   "devOptionsInviteAvailabilityServerEnabled": "Server value: naka-on",
   "devOptionsInviteAvailabilityServerDisabled": "Server value: naka-off",
-  "devOptionsInviteAvailabilityServerUnknown": "Server value: hindi alam (naka-on bilang default)",
+  "devOptionsInviteAvailabilityServerUnknown": "Server value: hindi alam",
   "devOptionsInviteAvailabilityOverrideNone": "Override: gamitin ang server value",
   "devOptionsInviteAvailabilityOverrideEnabled": "Override: piliting i-on",
   "devOptionsInviteAvailabilityOverrideDisabled": "Override: piliting i-off",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -4042,7 +4042,7 @@
   "devOptionsInviteAvailabilityServerLoading": "Valeur serveur : chargement",
   "devOptionsInviteAvailabilityServerEnabled": "Valeur serveur : activé",
   "devOptionsInviteAvailabilityServerDisabled": "Valeur serveur : désactivé",
-  "devOptionsInviteAvailabilityServerUnknown": "Valeur serveur : inconnue (activé par défaut)",
+  "devOptionsInviteAvailabilityServerUnknown": "Valeur serveur : inconnue",
   "devOptionsInviteAvailabilityOverrideNone": "Surcharge : utiliser la valeur serveur",
   "devOptionsInviteAvailabilityOverrideEnabled": "Surcharge : forcer activé",
   "devOptionsInviteAvailabilityOverrideDisabled": "Surcharge : forcer désactivé",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -4042,7 +4042,7 @@
   "devOptionsInviteAvailabilityServerLoading": "Nilai server: memuat",
   "devOptionsInviteAvailabilityServerEnabled": "Nilai server: aktif",
   "devOptionsInviteAvailabilityServerDisabled": "Nilai server: nonaktif",
-  "devOptionsInviteAvailabilityServerUnknown": "Nilai server: tidak diketahui (bawaan aktif)",
+  "devOptionsInviteAvailabilityServerUnknown": "Nilai server: tidak diketahui",
   "devOptionsInviteAvailabilityOverrideNone": "Penggantian: pakai nilai server",
   "devOptionsInviteAvailabilityOverrideEnabled": "Penggantian: paksa aktif",
   "devOptionsInviteAvailabilityOverrideDisabled": "Penggantian: paksa nonaktif",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -4042,7 +4042,7 @@
   "devOptionsInviteAvailabilityServerLoading": "Valore del server: caricamento",
   "devOptionsInviteAvailabilityServerEnabled": "Valore del server: attivo",
   "devOptionsInviteAvailabilityServerDisabled": "Valore del server: disattivo",
-  "devOptionsInviteAvailabilityServerUnknown": "Valore del server: sconosciuto (attivo per impostazione predefinita)",
+  "devOptionsInviteAvailabilityServerUnknown": "Valore del server: sconosciuto",
   "devOptionsInviteAvailabilityOverrideNone": "Forzatura: usa il valore del server",
   "devOptionsInviteAvailabilityOverrideEnabled": "Forzatura: imponi attivo",
   "devOptionsInviteAvailabilityOverrideDisabled": "Forzatura: imponi disattivo",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -4042,7 +4042,7 @@
   "devOptionsInviteAvailabilityServerLoading": "サーバー値: 読み込み中",
   "devOptionsInviteAvailabilityServerEnabled": "サーバー値: 有効",
   "devOptionsInviteAvailabilityServerDisabled": "サーバー値: 無効",
-  "devOptionsInviteAvailabilityServerUnknown": "サーバー値: 不明（既定で有効）",
+  "devOptionsInviteAvailabilityServerUnknown": "サーバー値: 不明",
   "devOptionsInviteAvailabilityOverrideNone": "上書き: サーバー値を使う",
   "devOptionsInviteAvailabilityOverrideEnabled": "上書き: 有効を強制",
   "devOptionsInviteAvailabilityOverrideDisabled": "上書き: 無効を強制",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -3510,7 +3510,7 @@
   "devOptionsInviteAvailabilityServerLoading": "서버 값: 불러오는 중",
   "devOptionsInviteAvailabilityServerEnabled": "서버 값: 켜짐",
   "devOptionsInviteAvailabilityServerDisabled": "서버 값: 꺼짐",
-  "devOptionsInviteAvailabilityServerUnknown": "서버 값: 알 수 없음 (기본값 켜짐)",
+  "devOptionsInviteAvailabilityServerUnknown": "서버 값: 알 수 없음",
   "devOptionsInviteAvailabilityOverrideNone": "재정의: 서버 값 사용",
   "devOptionsInviteAvailabilityOverrideEnabled": "재정의: 켜기 강제",
   "devOptionsInviteAvailabilityOverrideDisabled": "재정의: 끄기 강제",

--- a/mobile/lib/l10n/app_ms.arb
+++ b/mobile/lib/l10n/app_ms.arb
@@ -5805,7 +5805,7 @@
   "devOptionsInviteAvailabilityServerLoading": "Nilai pelayan: sedang dimuatkan",
   "devOptionsInviteAvailabilityServerEnabled": "Nilai pelayan: dihidupkan",
   "devOptionsInviteAvailabilityServerDisabled": "Nilai pelayan: dimatikan",
-  "devOptionsInviteAvailabilityServerUnknown": "Nilai pelayan: tidak diketahui (lalai dihidupkan)",
+  "devOptionsInviteAvailabilityServerUnknown": "Nilai pelayan: tidak diketahui",
   "devOptionsInviteAvailabilityOverrideNone": "Tulis ganti: guna nilai pelayan",
   "devOptionsInviteAvailabilityOverrideEnabled": "Tulis ganti: paksa hidup",
   "devOptionsInviteAvailabilityOverrideDisabled": "Tulis ganti: paksa mati",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -4042,7 +4042,7 @@
   "devOptionsInviteAvailabilityServerLoading": "Serverwaarde: laden",
   "devOptionsInviteAvailabilityServerEnabled": "Serverwaarde: aan",
   "devOptionsInviteAvailabilityServerDisabled": "Serverwaarde: uit",
-  "devOptionsInviteAvailabilityServerUnknown": "Serverwaarde: onbekend (standaard aan)",
+  "devOptionsInviteAvailabilityServerUnknown": "Serverwaarde: onbekend",
   "devOptionsInviteAvailabilityOverrideNone": "Overschrijving: serverwaarde gebruiken",
   "devOptionsInviteAvailabilityOverrideEnabled": "Overschrijving: aan afdwingen",
   "devOptionsInviteAvailabilityOverrideDisabled": "Overschrijving: uit afdwingen",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -4042,7 +4042,7 @@
   "devOptionsInviteAvailabilityServerLoading": "Wartość serwera: wczytywanie",
   "devOptionsInviteAvailabilityServerEnabled": "Wartość serwera: włączone",
   "devOptionsInviteAvailabilityServerDisabled": "Wartość serwera: wyłączone",
-  "devOptionsInviteAvailabilityServerUnknown": "Wartość serwera: nieznana (domyślnie włączone)",
+  "devOptionsInviteAvailabilityServerUnknown": "Wartość serwera: nieznana",
   "devOptionsInviteAvailabilityOverrideNone": "Nadpisanie: użyj wartości serwera",
   "devOptionsInviteAvailabilityOverrideEnabled": "Nadpisanie: wymuś włączenie",
   "devOptionsInviteAvailabilityOverrideDisabled": "Nadpisanie: wymuś wyłączenie",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -4042,7 +4042,7 @@
   "devOptionsInviteAvailabilityServerLoading": "Valor do servidor: carregando",
   "devOptionsInviteAvailabilityServerEnabled": "Valor do servidor: ativado",
   "devOptionsInviteAvailabilityServerDisabled": "Valor do servidor: desativado",
-  "devOptionsInviteAvailabilityServerUnknown": "Valor do servidor: desconhecido (ativado por padrão)",
+  "devOptionsInviteAvailabilityServerUnknown": "Valor do servidor: desconhecido",
   "devOptionsInviteAvailabilityOverrideNone": "Substituição: usar o valor do servidor",
   "devOptionsInviteAvailabilityOverrideEnabled": "Substituição: forçar ativado",
   "devOptionsInviteAvailabilityOverrideDisabled": "Substituição: forçar desativado",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -4042,7 +4042,7 @@
   "devOptionsInviteAvailabilityServerLoading": "Valoare server: se încarcă",
   "devOptionsInviteAvailabilityServerEnabled": "Valoare server: activat",
   "devOptionsInviteAvailabilityServerDisabled": "Valoare server: dezactivat",
-  "devOptionsInviteAvailabilityServerUnknown": "Valoare server: necunoscută (implicit activat)",
+  "devOptionsInviteAvailabilityServerUnknown": "Valoare server: necunoscută",
   "devOptionsInviteAvailabilityOverrideNone": "Suprascriere: folosește valoarea serverului",
   "devOptionsInviteAvailabilityOverrideEnabled": "Suprascriere: forțează activarea",
   "devOptionsInviteAvailabilityOverrideDisabled": "Suprascriere: forțează dezactivarea",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -4042,7 +4042,7 @@
   "devOptionsInviteAvailabilityServerLoading": "Servervärde: läser in",
   "devOptionsInviteAvailabilityServerEnabled": "Servervärde: på",
   "devOptionsInviteAvailabilityServerDisabled": "Servervärde: av",
-  "devOptionsInviteAvailabilityServerUnknown": "Servervärde: okänt (på som standard)",
+  "devOptionsInviteAvailabilityServerUnknown": "Servervärde: okänt",
   "devOptionsInviteAvailabilityOverrideNone": "Överstyrning: använd servervärdet",
   "devOptionsInviteAvailabilityOverrideEnabled": "Överstyrning: tvinga på",
   "devOptionsInviteAvailabilityOverrideDisabled": "Överstyrning: tvinga av",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -4042,7 +4042,7 @@
   "devOptionsInviteAvailabilityServerLoading": "Sunucu değeri: yükleniyor",
   "devOptionsInviteAvailabilityServerEnabled": "Sunucu değeri: açık",
   "devOptionsInviteAvailabilityServerDisabled": "Sunucu değeri: kapalı",
-  "devOptionsInviteAvailabilityServerUnknown": "Sunucu değeri: bilinmiyor (varsayılan açık)",
+  "devOptionsInviteAvailabilityServerUnknown": "Sunucu değeri: bilinmiyor",
   "devOptionsInviteAvailabilityOverrideNone": "Geçersiz kılma: sunucu değerini kullan",
   "devOptionsInviteAvailabilityOverrideEnabled": "Geçersiz kılma: açık olarak zorla",
   "devOptionsInviteAvailabilityOverrideDisabled": "Geçersiz kılma: kapalı olarak zorla",

--- a/mobile/lib/l10n/app_ur.arb
+++ b/mobile/lib/l10n/app_ur.arb
@@ -5805,7 +5805,7 @@
   "devOptionsInviteAvailabilityServerLoading": "سرور ویلیو: لوڈ ہو رہی ہے",
   "devOptionsInviteAvailabilityServerEnabled": "سرور ویلیو: فعال",
   "devOptionsInviteAvailabilityServerDisabled": "سرور ویلیو: غیر فعال",
-  "devOptionsInviteAvailabilityServerUnknown": "سرور ویلیو: نامعلوم (بطور ڈیفالٹ فعال)",
+  "devOptionsInviteAvailabilityServerUnknown": "سرور ویلیو: نامعلوم",
   "devOptionsInviteAvailabilityOverrideNone": "اوور رائیڈ: سرور ویلیو استعمال کریں",
   "devOptionsInviteAvailabilityOverrideEnabled": "اوور رائیڈ: زبردستی فعال",
   "devOptionsInviteAvailabilityOverrideDisabled": "اوور رائیڈ: زبردستی غیر فعال",

--- a/mobile/lib/l10n/app_vi.arb
+++ b/mobile/lib/l10n/app_vi.arb
@@ -5805,7 +5805,7 @@
   "devOptionsInviteAvailabilityServerLoading": "Giá trị máy chủ: đang tải",
   "devOptionsInviteAvailabilityServerEnabled": "Giá trị máy chủ: đã bật",
   "devOptionsInviteAvailabilityServerDisabled": "Giá trị máy chủ: đã tắt",
-  "devOptionsInviteAvailabilityServerUnknown": "Giá trị máy chủ: không rõ (mặc định bật)",
+  "devOptionsInviteAvailabilityServerUnknown": "Giá trị máy chủ: không rõ",
   "devOptionsInviteAvailabilityOverrideNone": "Ghi đè: dùng giá trị máy chủ",
   "devOptionsInviteAvailabilityOverrideEnabled": "Ghi đè: buộc bật",
   "devOptionsInviteAvailabilityOverrideDisabled": "Ghi đè: buộc tắt",

--- a/mobile/lib/l10n/app_zh.arb
+++ b/mobile/lib/l10n/app_zh.arb
@@ -5805,7 +5805,7 @@
   "devOptionsInviteAvailabilityServerLoading": "服务器值：加载中",
   "devOptionsInviteAvailabilityServerEnabled": "服务器值：已启用",
   "devOptionsInviteAvailabilityServerDisabled": "服务器值：已禁用",
-  "devOptionsInviteAvailabilityServerUnknown": "服务器值：未知（默认启用）",
+  "devOptionsInviteAvailabilityServerUnknown": "服务器值：未知",
   "devOptionsInviteAvailabilityOverrideNone": "覆盖：使用服务器值",
   "devOptionsInviteAvailabilityOverrideEnabled": "覆盖：强制启用",
   "devOptionsInviteAvailabilityOverrideDisabled": "覆盖：强制禁用",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -17455,7 +17455,7 @@ abstract class AppLocalizations {
   /// No description provided for @devOptionsInviteAvailabilityServerUnknown.
   ///
   /// In en, this message translates to:
-  /// **'Server value: unknown (defaults enabled)'**
+  /// **'Server value: unknown'**
   String get devOptionsInviteAvailabilityServerUnknown;
 
   /// No description provided for @devOptionsInviteAvailabilityOverrideNone.

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -10026,8 +10026,7 @@ class AppLocalizationsAm extends AppLocalizations {
   String get devOptionsInviteAvailabilityServerDisabled => 'የአገልጋይ እሴት፦ ጠፍቷል';
 
   @override
-  String get devOptionsInviteAvailabilityServerUnknown =>
-      'የአገልጋይ እሴት፦ አይታወቅም (በነባሪ በርቷል)';
+  String get devOptionsInviteAvailabilityServerUnknown => 'የአገልጋይ እሴት፦ አይታወቅም';
 
   @override
   String get devOptionsInviteAvailabilityOverrideNone =>

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -10214,7 +10214,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get devOptionsInviteAvailabilityServerUnknown =>
-      'قيمة الخادم: غير معروفة (مفعّلة افتراضيًا)';
+      'قيمة الخادم: غير معروفة';
 
   @override
   String get devOptionsInviteAvailabilityOverrideNone =>

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -10393,7 +10393,7 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get devOptionsInviteAvailabilityServerUnknown =>
-      'Стойност от сървъра: неизвестна (по подразбиране включено)';
+      'Стойност от сървъра: неизвестна';
 
   @override
   String get devOptionsInviteAvailabilityOverrideNone =>

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -10416,7 +10416,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get devOptionsInviteAvailabilityServerUnknown =>
-      'Serverwert: unbekannt (standardmäßig aktiviert)';
+      'Serverwert: unbekannt';
 
   @override
   String get devOptionsInviteAvailabilityOverrideNone =>

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -10395,7 +10395,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get devOptionsInviteAvailabilityServerUnknown =>
-      'Server value: unknown (defaults enabled)';
+      'Server value: unknown';
 
   @override
   String get devOptionsInviteAvailabilityOverrideNone =>

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -10400,7 +10400,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get devOptionsInviteAvailabilityServerUnknown =>
-      'Valor del servidor: desconocido (activado por defecto)';
+      'Valor del servidor: desconocido';
 
   @override
   String get devOptionsInviteAvailabilityOverrideNone =>

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -10388,7 +10388,7 @@ class AppLocalizationsFil extends AppLocalizations {
 
   @override
   String get devOptionsInviteAvailabilityServerUnknown =>
-      'Server value: hindi alam (naka-on bilang default)';
+      'Server value: hindi alam';
 
   @override
   String get devOptionsInviteAvailabilityOverrideNone =>

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -10447,7 +10447,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get devOptionsInviteAvailabilityServerUnknown =>
-      'Valeur serveur : inconnue (activé par défaut)';
+      'Valeur serveur : inconnue';
 
   @override
   String get devOptionsInviteAvailabilityOverrideNone =>

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -10214,7 +10214,7 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get devOptionsInviteAvailabilityServerUnknown =>
-      'Nilai server: tidak diketahui (bawaan aktif)';
+      'Nilai server: tidak diketahui';
 
   @override
   String get devOptionsInviteAvailabilityOverrideNone =>

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -10418,7 +10418,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get devOptionsInviteAvailabilityServerUnknown =>
-      'Valore del server: sconosciuto (attivo per impostazione predefinita)';
+      'Valore del server: sconosciuto';
 
   @override
   String get devOptionsInviteAvailabilityOverrideNone =>

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -9778,7 +9778,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get devOptionsInviteAvailabilityServerDisabled => 'サーバー値: 無効';
 
   @override
-  String get devOptionsInviteAvailabilityServerUnknown => 'サーバー値: 不明（既定で有効）';
+  String get devOptionsInviteAvailabilityServerUnknown => 'サーバー値: 不明';
 
   @override
   String get devOptionsInviteAvailabilityOverrideNone => '上書き: サーバー値を使う';

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -9795,8 +9795,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get devOptionsInviteAvailabilityServerDisabled => '서버 값: 꺼짐';
 
   @override
-  String get devOptionsInviteAvailabilityServerUnknown =>
-      '서버 값: 알 수 없음 (기본값 켜짐)';
+  String get devOptionsInviteAvailabilityServerUnknown => '서버 값: 알 수 없음';
 
   @override
   String get devOptionsInviteAvailabilityOverrideNone => '재정의: 서버 값 사용';

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -10311,7 +10311,7 @@ class AppLocalizationsMs extends AppLocalizations {
 
   @override
   String get devOptionsInviteAvailabilityServerUnknown =>
-      'Nilai pelayan: tidak diketahui (lalai dihidupkan)';
+      'Nilai pelayan: tidak diketahui';
 
   @override
   String get devOptionsInviteAvailabilityOverrideNone =>

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -10346,7 +10346,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get devOptionsInviteAvailabilityServerUnknown =>
-      'Serverwaarde: onbekend (standaard aan)';
+      'Serverwaarde: onbekend';
 
   @override
   String get devOptionsInviteAvailabilityOverrideNone =>

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -10491,7 +10491,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get devOptionsInviteAvailabilityServerUnknown =>
-      'Wartość serwera: nieznana (domyślnie włączone)';
+      'Wartość serwera: nieznana';
 
   @override
   String get devOptionsInviteAvailabilityOverrideNone =>

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -10367,7 +10367,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get devOptionsInviteAvailabilityServerUnknown =>
-      'Valor do servidor: desconhecido (ativado por padrão)';
+      'Valor do servidor: desconhecido';
 
   @override
   String get devOptionsInviteAvailabilityOverrideNone =>

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -10518,7 +10518,7 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get devOptionsInviteAvailabilityServerUnknown =>
-      'Valoare server: necunoscută (implicit activat)';
+      'Valoare server: necunoscută';
 
   @override
   String get devOptionsInviteAvailabilityOverrideNone =>

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -10293,8 +10293,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get devOptionsInviteAvailabilityServerDisabled => 'Servervärde: av';
 
   @override
-  String get devOptionsInviteAvailabilityServerUnknown =>
-      'Servervärde: okänt (på som standard)';
+  String get devOptionsInviteAvailabilityServerUnknown => 'Servervärde: okänt';
 
   @override
   String get devOptionsInviteAvailabilityOverrideNone =>

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -10215,7 +10215,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get devOptionsInviteAvailabilityServerUnknown =>
-      'Sunucu değeri: bilinmiyor (varsayılan açık)';
+      'Sunucu değeri: bilinmiyor';
 
   @override
   String get devOptionsInviteAvailabilityOverrideNone =>

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -10287,8 +10287,7 @@ class AppLocalizationsUr extends AppLocalizations {
       'سرور ویلیو: غیر فعال';
 
   @override
-  String get devOptionsInviteAvailabilityServerUnknown =>
-      'سرور ویلیو: نامعلوم (بطور ڈیفالٹ فعال)';
+  String get devOptionsInviteAvailabilityServerUnknown => 'سرور ویلیو: نامعلوم';
 
   @override
   String get devOptionsInviteAvailabilityOverrideNone =>

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -10257,7 +10257,7 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get devOptionsInviteAvailabilityServerUnknown =>
-      'Giá trị máy chủ: không rõ (mặc định bật)';
+      'Giá trị máy chủ: không rõ';
 
   @override
   String get devOptionsInviteAvailabilityOverrideNone =>

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -9689,7 +9689,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get devOptionsInviteAvailabilityServerDisabled => '服务器值：已禁用';
 
   @override
-  String get devOptionsInviteAvailabilityServerUnknown => '服务器值：未知（默认启用）';
+  String get devOptionsInviteAvailabilityServerUnknown => '服务器值：未知';
 
   @override
   String get devOptionsInviteAvailabilityOverrideNone => '覆盖：使用服务器值';

--- a/mobile/lib/models/invite_availability.dart
+++ b/mobile/lib/models/invite_availability.dart
@@ -28,8 +28,8 @@ class InviteAvailabilityState extends Equatable {
 
   /// Whether signup/access invitations should be shown and enforced.
   ///
-  /// `open` is the only disabled server value. Missing, unavailable, or
-  /// unknown configuration defaults to enabled.
+  /// Only an explicit `inviteCodeRequired` server value enables invitations.
+  /// Missing, unavailable, or unknown configuration defaults to disabled.
   bool get isEnabled {
     switch (developerOverride) {
       case InviteAvailabilityOverride.forceEnabled:
@@ -37,14 +37,14 @@ class InviteAvailabilityState extends Equatable {
       case InviteAvailabilityOverride.forceDisabled:
         return false;
       case InviteAvailabilityOverride.useServer:
-        return serverMode != OnboardingMode.open;
+        return serverMode == OnboardingMode.inviteCodeRequired;
     }
   }
 
   InviteClientConfig get resolvedConfig {
     return config ??
         InviteClientConfig(
-          mode: serverMode ?? OnboardingMode.inviteCodeRequired,
+          mode: serverMode ?? OnboardingMode.open,
           supportEmail: AppConstants.supportEmail,
         );
   }

--- a/mobile/lib/repositories/invite_availability_repository.dart
+++ b/mobile/lib/repositories/invite_availability_repository.dart
@@ -53,7 +53,7 @@ class InviteAvailabilityRepository {
       );
     } on Object catch (error) {
       Log.warning(
-        'Invite client config unavailable; defaulting signup invites on: $error',
+        'Invite client config unavailable; defaulting signup invites off: $error',
         name: 'InviteAvailabilityRepository',
         category: LogCategory.auth,
       );

--- a/mobile/lib/router/routes/auth_routes.dart
+++ b/mobile/lib/router/routes/auth_routes.dart
@@ -52,7 +52,11 @@ List<RouteBase> authRoutes(Ref ref) {
           name: CreateAccountScreen.routeName,
           builder: (_, state) {
             _captureProductAnalyticsUtm(ref, state);
-            return const InviteProtectedCreateAccountScreen();
+            return InviteProtectedCreateAccountScreen(
+              initialCode: state.uri.queryParameters['code'],
+              initialError: state.uri.queryParameters['error'],
+              initialSourceSlug: state.uri.queryParameters['sourceSlug'],
+            );
           },
         ),
         GoRoute(

--- a/mobile/lib/screens/auth/invite_gate_screen.dart
+++ b/mobile/lib/screens/auth/invite_gate_screen.dart
@@ -121,7 +121,20 @@ class _InviteGateScreenState extends State<InviteGateScreen> {
   void _redirectToCreateAccount() {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted && !context.read<InviteAvailabilityCubit>().state.isEnabled) {
-        context.go(WelcomeScreen.createAccountPath);
+        final queryParameters = <String, String>{
+          if (widget.initialCode?.isNotEmpty ?? false)
+            'code': widget.initialCode!,
+          if (widget.initialError?.isNotEmpty ?? false)
+            'error': widget.initialError!,
+          if (widget.initialSourceSlug?.isNotEmpty ?? false)
+            'sourceSlug': widget.initialSourceSlug!,
+        };
+        context.go(
+          Uri(
+            path: WelcomeScreen.createAccountPath,
+            queryParameters: queryParameters.isEmpty ? null : queryParameters,
+          ).toString(),
+        );
       }
     });
   }

--- a/mobile/lib/screens/auth/invite_gate_screen.dart
+++ b/mobile/lib/screens/auth/invite_gate_screen.dart
@@ -120,7 +120,7 @@ class _InviteGateScreenState extends State<InviteGateScreen> {
 
   void _redirectToCreateAccount() {
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (mounted) {
+      if (mounted && !context.read<InviteAvailabilityCubit>().state.isEnabled) {
         context.go(WelcomeScreen.createAccountPath);
       }
     });
@@ -156,11 +156,11 @@ class _InviteGateScreenState extends State<InviteGateScreen> {
 
     return BlocBuilder<InviteAvailabilityCubit, InviteAvailabilityState>(
       builder: (context, availability) {
-        if (!availability.hasResolved) {
-          return const _InviteLoadingPage();
-        }
         if (!availability.isEnabled) {
           _redirectToCreateAccount();
+          return const _InviteLoadingPage();
+        }
+        if (!availability.hasResolved) {
           return const _InviteLoadingPage();
         }
 

--- a/mobile/lib/screens/auth/invite_protected_create_account_screen.dart
+++ b/mobile/lib/screens/auth/invite_protected_create_account_screen.dart
@@ -16,7 +16,16 @@ import 'package:openvine/screens/auth/welcome_screen.dart';
 import 'package:openvine/services/auth_service.dart';
 
 class InviteProtectedCreateAccountScreen extends ConsumerStatefulWidget {
-  const InviteProtectedCreateAccountScreen({super.key});
+  const InviteProtectedCreateAccountScreen({
+    this.initialCode,
+    this.initialError,
+    this.initialSourceSlug,
+    super.key,
+  });
+
+  final String? initialCode;
+  final String? initialError;
+  final String? initialSourceSlug;
 
   @override
   ConsumerState<InviteProtectedCreateAccountScreen> createState() =>
@@ -28,7 +37,16 @@ class _InviteProtectedCreateAccountScreenState
   void _redirectToInvite(BuildContext context) {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (context.mounted) {
-        context.go(WelcomeScreen.inviteGatePath);
+        final code = widget.initialCode;
+        context.go(
+          code == null || code.isEmpty
+              ? WelcomeScreen.inviteGatePath
+              : WelcomeScreen.inviteGatePathWithCode(
+                  code,
+                  error: widget.initialError,
+                  sourceSlug: widget.initialSourceSlug,
+                ),
+        );
       }
     });
   }

--- a/mobile/lib/screens/auth/invite_protected_create_account_screen.dart
+++ b/mobile/lib/screens/auth/invite_protected_create_account_screen.dart
@@ -48,12 +48,12 @@ class _InviteProtectedCreateAccountScreenState
               });
             }
 
-            if (!availability.hasResolved) {
-              return const _InviteGuardLoadingPage();
-            }
-
             if (!availability.isEnabled || state.hasAccessGrant) {
               return const CreateAccountScreen();
+            }
+
+            if (!availability.hasResolved) {
+              return const _InviteGuardLoadingPage();
             }
 
             _redirectToInvite(context);

--- a/mobile/lib/screens/auth/welcome_screen.dart
+++ b/mobile/lib/screens/auth/welcome_screen.dart
@@ -148,7 +148,7 @@ class _WelcomeView extends StatelessWidget {
           case WelcomeStatus.navigatingToCreateAccount:
             final invitesEnabled =
                 context.read<InviteAvailabilityCubit?>()?.state.isEnabled ??
-                true;
+                false;
             context.push(
               invitesEnabled
                   ? WelcomeScreen.inviteGatePath

--- a/mobile/packages/invite_api_client/lib/src/invite_models.dart
+++ b/mobile/packages/invite_api_client/lib/src/invite_models.dart
@@ -12,8 +12,8 @@ OnboardingMode parseOnboardingMode(String? rawValue) {
     case 'invite_code_required':
       return OnboardingMode.inviteCodeRequired;
     default:
-      // Missing or unknown values keep signup invites enabled.
-      return OnboardingMode.inviteCodeRequired;
+      // Missing or unknown values must not block account creation.
+      return OnboardingMode.open;
   }
 }
 

--- a/mobile/packages/invite_api_client/test/src/invite_models_test.dart
+++ b/mobile/packages/invite_api_client/test/src/invite_models_test.dart
@@ -22,14 +22,11 @@ void main() {
       expect(parseOnboardingMode('open'), OnboardingMode.open);
     });
 
-    test('defaults missing and unknown values to inviteCodeRequired', () {
-      expect(parseOnboardingMode(null), OnboardingMode.inviteCodeRequired);
-      expect(parseOnboardingMode(''), OnboardingMode.inviteCodeRequired);
-      expect(
-        parseOnboardingMode('unavailable'),
-        OnboardingMode.inviteCodeRequired,
-      );
-      expect(parseOnboardingMode('mystery'), OnboardingMode.inviteCodeRequired);
+    test('defaults missing and unknown values to open', () {
+      expect(parseOnboardingMode(null), OnboardingMode.open);
+      expect(parseOnboardingMode(''), OnboardingMode.open);
+      expect(parseOnboardingMode('unavailable'), OnboardingMode.open);
+      expect(parseOnboardingMode('mystery'), OnboardingMode.open);
     });
   });
 

--- a/mobile/test/blocs/invite_availability/invite_availability_cubit_test.dart
+++ b/mobile/test/blocs/invite_availability/invite_availability_cubit_test.dart
@@ -67,7 +67,7 @@ void main() {
     );
 
     blocTest<InviteAvailabilityCubit, InviteAvailabilityState>(
-      'defaults to enabled when configuration is unavailable',
+      'defaults to disabled when configuration is unavailable',
       setUp: () {
         when(
           () => client.getClientConfig(),
@@ -78,7 +78,7 @@ void main() {
       expect: () => [
         isA<InviteAvailabilityState>()
             .having((s) => s.hasResolved, 'hasResolved', isTrue)
-            .having((s) => s.isEnabled, 'isEnabled', isTrue)
+            .having((s) => s.isEnabled, 'isEnabled', isFalse)
             .having((s) => s.serverMode, 'serverMode', isNull),
       ],
     );

--- a/mobile/test/models/invite_availability_test.dart
+++ b/mobile/test/models/invite_availability_test.dart
@@ -4,10 +4,10 @@ import 'package:openvine/models/invite_availability.dart';
 
 void main() {
   group(InviteAvailabilityState, () {
-    test('defaults to enabled before the server value resolves', () {
+    test('defaults to disabled before the server value resolves', () {
       const state = InviteAvailabilityState();
       expect(state.hasResolved, isFalse);
-      expect(state.isEnabled, isTrue);
+      expect(state.isEnabled, isFalse);
     });
 
     test('enables invites for invite_code_required', () {
@@ -26,9 +26,14 @@ void main() {
       expect(state.isEnabled, isFalse);
     });
 
-    test('defaults unknown or missing server values to enabled', () {
+    test('defaults unknown or missing server values to disabled', () {
       const unknown = InviteAvailabilityState(hasResolved: true);
-      expect(unknown.isEnabled, isTrue);
+      expect(unknown.isEnabled, isFalse);
+    });
+
+    test('defaults resolved config to open when server mode is missing', () {
+      const state = InviteAvailabilityState(hasResolved: true);
+      expect(state.resolvedConfig.mode, OnboardingMode.open);
     });
 
     test('force enabled wins over a disabled server value', () {

--- a/mobile/test/notifications/view/inbox_notifications_page_test.dart
+++ b/mobile/test/notifications/view/inbox_notifications_page_test.dart
@@ -372,8 +372,12 @@ void main() {
             ),
           ),
         );
+        final availabilityCubit = seededInviteAvailabilityCubit();
+        addTearDown(availabilityCubit.close);
 
-        await tester.pumpWidget(buildSubject());
+        await tester.pumpWidget(
+          buildSubject(availabilityCubit: availabilityCubit),
+        );
         await tester.pumpAndSettle();
 
         expect(find.text(l10n.notificationsInvitePlural(2)), findsOneWidget);
@@ -393,8 +397,12 @@ void main() {
               ),
             ),
           );
+          final availabilityCubit = seededInviteAvailabilityCubit();
+          addTearDown(availabilityCubit.close);
 
-          await tester.pumpWidget(buildSubject());
+          await tester.pumpWidget(
+            buildSubject(availabilityCubit: availabilityCubit),
+          );
           await tester.pumpAndSettle();
 
           expect(find.text(l10n.notificationsInviteSingular), findsOneWidget);

--- a/mobile/test/repositories/invite_availability_repository_test.dart
+++ b/mobile/test/repositories/invite_availability_repository_test.dart
@@ -52,7 +52,7 @@ void main() {
       expect(state.isEnabled, isFalse);
     });
 
-    test('defaults to enabled when client config fails', () async {
+    test('defaults to disabled when client config fails', () async {
       when(
         () => client.getClientConfig(),
       ).thenThrow(const InviteApiException('unavailable'));
@@ -63,7 +63,7 @@ void main() {
       final state = await repository.loadOnce();
       expect(state.hasResolved, isTrue);
       expect(state.serverMode, isNull);
-      expect(state.isEnabled, isTrue);
+      expect(state.isEnabled, isFalse);
     });
 
     test('does not refetch after a failed load', () async {

--- a/mobile/test/screens/auth/invite_gate_screen_test.dart
+++ b/mobile/test/screens/auth/invite_gate_screen_test.dart
@@ -49,6 +49,7 @@ void main() {
   Widget createTestWidget({
     InviteApiClient? inviteApiClient,
     InviteAvailabilityState? availabilitySeed = _resolvedInviteRequired,
+    String initialLocation = WelcomeScreen.inviteGatePath,
   }) {
     final client = inviteApiClient ?? mockInviteApiClient;
 
@@ -71,7 +72,7 @@ void main() {
           supportedLocales: AppLocalizations.supportedLocales,
           theme: VineTheme.theme,
           routerConfig: GoRouter(
-            initialLocation: WelcomeScreen.inviteGatePath,
+            initialLocation: initialLocation,
             routes: [
               GoRoute(
                 path: WelcomeScreen.path,
@@ -89,8 +90,22 @@ void main() {
                   ),
                   GoRoute(
                     path: 'create-account',
-                    builder: (context, state) =>
-                        const Scaffold(body: Text('Create Account')),
+                    builder: (context, state) => Scaffold(
+                      body: Column(
+                        children: [
+                          const Text('Create Account'),
+                          if (state.uri.queryParameters['code']
+                              case final code?)
+                            Text('Code: $code'),
+                          if (state.uri.queryParameters['error']
+                              case final error?)
+                            Text('Error: $error'),
+                          if (state.uri.queryParameters['sourceSlug']
+                              case final sourceSlug?)
+                            Text('Source: $sourceSlug'),
+                        ],
+                      ),
+                    ),
                   ),
                 ],
               ),
@@ -152,11 +167,21 @@ void main() {
         () => mockInviteApiClient.getClientConfig(),
       ).thenAnswer((_) => pendingConfig.future);
 
-      await tester.pumpWidget(createTestWidget(availabilitySeed: null));
+      await tester.pumpWidget(
+        createTestWidget(
+          availabilitySeed: null,
+          initialLocation:
+              '${WelcomeScreen.inviteGatePath}?code=AB12-EF34'
+              '&error=Invite%20problem&sourceSlug=creator',
+        ),
+      );
       await tester.pump();
       await tester.pump();
 
       expect(find.text('Create Account'), findsOneWidget);
+      expect(find.text('Code: AB12-EF34'), findsOneWidget);
+      expect(find.text('Error: Invite problem'), findsOneWidget);
+      expect(find.text('Source: creator'), findsOneWidget);
       expect(find.text('Add your invite code'), findsNothing);
     });
 

--- a/mobile/test/screens/auth/invite_gate_screen_test.dart
+++ b/mobile/test/screens/auth/invite_gate_screen_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:divine_ui/divine_ui.dart';
@@ -12,6 +13,7 @@ import 'package:openvine/blocs/invite_availability/invite_availability_cubit.dar
 import 'package:openvine/blocs/invite_gate/invite_gate_bloc.dart';
 import 'package:openvine/constants/semantic_ids.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/models/invite_availability.dart';
 import 'package:openvine/repositories/invite_availability_repository.dart';
 import 'package:openvine/screens/auth/invite_gate_screen.dart';
 import 'package:openvine/screens/auth/welcome_screen.dart';
@@ -21,6 +23,15 @@ class _MockInviteApiClient extends Mock implements InviteApiClient {}
 class _MockHttpClient extends Mock implements http.Client {}
 
 class _MockResponse extends Mock implements http.Response {}
+
+const _resolvedInviteRequired = InviteAvailabilityState(
+  hasResolved: true,
+  serverMode: OnboardingMode.inviteCodeRequired,
+  config: InviteClientConfig(
+    mode: OnboardingMode.inviteCodeRequired,
+    supportEmail: 'support@divine.video',
+  ),
+);
 
 void main() {
   late _MockInviteApiClient mockInviteApiClient;
@@ -35,7 +46,10 @@ void main() {
     mockInviteApiClient = _MockInviteApiClient();
   });
 
-  Widget createTestWidget({InviteApiClient? inviteApiClient}) {
+  Widget createTestWidget({
+    InviteApiClient? inviteApiClient,
+    InviteAvailabilityState? availabilitySeed = _resolvedInviteRequired,
+  }) {
     final client = inviteApiClient ?? mockInviteApiClient;
 
     return RepositoryProvider<InviteApiClient>.value(
@@ -44,7 +58,10 @@ void main() {
         providers: [
           BlocProvider(
             create: (_) => InviteAvailabilityCubit(
-              repository: InviteAvailabilityRepository(client: client),
+              repository: InviteAvailabilityRepository(
+                client: client,
+                seed: availabilitySeed,
+              ),
             )..load(),
           ),
           BlocProvider(create: (_) => InviteGateBloc(inviteApiClient: client)),
@@ -95,7 +112,18 @@ void main() {
         ),
       );
 
-      await tester.pumpWidget(createTestWidget());
+      await tester.pumpWidget(
+        createTestWidget(
+          availabilitySeed: InviteAvailabilityState(
+            hasResolved: true,
+            serverMode: parseOnboardingMode('waitlist_only'),
+            config: InviteClientConfig(
+              mode: parseOnboardingMode('waitlist_only'),
+              supportEmail: 'support@divine.video',
+            ),
+          ),
+        ),
+      );
       await tester.pumpAndSettle();
 
       expect(find.text('Add your invite code'), findsOneWidget);
@@ -109,8 +137,24 @@ void main() {
         () => mockInviteApiClient.getClientConfig(),
       ).thenThrow(const InviteApiException('unavailable'));
 
-      await tester.pumpWidget(createTestWidget());
+      await tester.pumpWidget(createTestWidget(availabilitySeed: null));
       await tester.pumpAndSettle();
+
+      expect(find.text('Create Account'), findsOneWidget);
+      expect(find.text('Add your invite code'), findsNothing);
+    });
+
+    testWidgets('bypasses the gate while client config is unresolved', (
+      tester,
+    ) async {
+      final pendingConfig = Completer<InviteClientConfig>();
+      when(
+        () => mockInviteApiClient.getClientConfig(),
+      ).thenAnswer((_) => pendingConfig.future);
+
+      await tester.pumpWidget(createTestWidget(availabilitySeed: null));
+      await tester.pump();
+      await tester.pump();
 
       expect(find.text('Create Account'), findsOneWidget);
       expect(find.text('Add your invite code'), findsNothing);
@@ -126,7 +170,7 @@ void main() {
         ),
       );
 
-      await tester.pumpWidget(createTestWidget());
+      await tester.pumpWidget(createTestWidget(availabilitySeed: null));
       await tester.pumpAndSettle();
 
       expect(find.text('Create Account'), findsOneWidget);
@@ -156,7 +200,10 @@ void main() {
         );
 
         await tester.pumpWidget(
-          createTestWidget(inviteApiClient: previewInviteApiClient),
+          createTestWidget(
+            inviteApiClient: previewInviteApiClient,
+            availabilitySeed: null,
+          ),
         );
         await tester.pumpAndSettle();
 
@@ -255,6 +302,7 @@ void main() {
                 create: (_) => InviteAvailabilityCubit(
                   repository: InviteAvailabilityRepository(
                     client: mockInviteApiClient,
+                    seed: _resolvedInviteRequired,
                   ),
                 )..load(),
               ),
@@ -330,6 +378,7 @@ void main() {
                 create: (_) => InviteAvailabilityCubit(
                   repository: InviteAvailabilityRepository(
                     client: mockInviteApiClient,
+                    seed: _resolvedInviteRequired,
                   ),
                 )..load(),
               ),
@@ -417,6 +466,7 @@ void main() {
                 create: (_) => InviteAvailabilityCubit(
                   repository: InviteAvailabilityRepository(
                     client: mockInviteApiClient,
+                    seed: _resolvedInviteRequired,
                   ),
                 )..load(),
               ),

--- a/mobile/test/screens/auth/invite_gate_screen_test.dart
+++ b/mobile/test/screens/auth/invite_gate_screen_test.dart
@@ -102,7 +102,7 @@ void main() {
       expect(find.text('Join waitlist'), findsOneWidget);
     });
 
-    testWidgets('keeps the invite form when client config is unavailable', (
+    testWidgets('bypasses the gate when client config is unavailable', (
       tester,
     ) async {
       when(
@@ -112,7 +112,8 @@ void main() {
       await tester.pumpWidget(createTestWidget());
       await tester.pumpAndSettle();
 
-      expect(find.text('Add your invite code'), findsOneWidget);
+      expect(find.text('Create Account'), findsOneWidget);
+      expect(find.text('Add your invite code'), findsNothing);
     });
 
     testWidgets('bypasses the gate when server onboarding mode is open', (

--- a/mobile/test/screens/auth/invite_protected_create_account_screen_test.dart
+++ b/mobile/test/screens/auth/invite_protected_create_account_screen_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:divine_ui/divine_ui.dart';
@@ -160,6 +161,20 @@ void main() {
 
       await tester.pumpWidget(createTestWidget());
       await tester.pumpAndSettle();
+
+      expect(find.widgetWithText(DivineAuthTextField, 'Email'), findsOneWidget);
+    });
+
+    testWidgets('allows create-account while client config is unresolved', (
+      tester,
+    ) async {
+      final pendingConfig = Completer<InviteClientConfig>();
+      when(
+        () => mockInviteApiClient.getClientConfig(),
+      ).thenAnswer((_) => pendingConfig.future);
+
+      await tester.pumpWidget(createTestWidget());
+      await tester.pump();
 
       expect(find.widgetWithText(DivineAuthTextField, 'Email'), findsOneWidget);
     });

--- a/mobile/test/screens/auth/invite_protected_create_account_screen_test.dart
+++ b/mobile/test/screens/auth/invite_protected_create_account_screen_test.dart
@@ -63,6 +63,7 @@ void main() {
   Widget createTestWidget({
     bool hasAccessGrant = false,
     InviteApiClient? inviteApiClient,
+    String initialLocation = WelcomeScreen.createAccountPath,
   }) {
     final container = ProviderContainer(
       overrides: [
@@ -105,7 +106,7 @@ void main() {
             supportedLocales: AppLocalizations.supportedLocales,
             theme: VineTheme.theme,
             routerConfig: GoRouter(
-              initialLocation: WelcomeScreen.createAccountPath,
+              initialLocation: initialLocation,
               routes: [
                 GoRoute(
                   path: WelcomeScreen.path,
@@ -114,13 +115,32 @@ void main() {
                   routes: [
                     GoRoute(
                       path: 'invite',
-                      builder: (context, state) =>
-                          const Scaffold(body: Text('Invite Gate')),
+                      builder: (context, state) => Scaffold(
+                        body: Column(
+                          children: [
+                            const Text('Invite Gate'),
+                            if (state.uri.queryParameters['code']
+                                case final code?)
+                              Text('Code: $code'),
+                            if (state.uri.queryParameters['error']
+                                case final error?)
+                              Text('Error: $error'),
+                            if (state.uri.queryParameters['sourceSlug']
+                                case final sourceSlug?)
+                              Text('Source: $sourceSlug'),
+                          ],
+                        ),
+                      ),
                     ),
                     GoRoute(
                       path: 'create-account',
                       builder: (context, state) =>
-                          const InviteProtectedCreateAccountScreen(),
+                          InviteProtectedCreateAccountScreen(
+                            initialCode: state.uri.queryParameters['code'],
+                            initialError: state.uri.queryParameters['error'],
+                            initialSourceSlug:
+                                state.uri.queryParameters['sourceSlug'],
+                          ),
                     ),
                   ],
                 ),
@@ -147,6 +167,31 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('Invite Gate'), findsOneWidget);
+    });
+
+    testWidgets('preserves a deep-linked code when invites become required', (
+      tester,
+    ) async {
+      when(() => mockInviteApiClient.getClientConfig()).thenAnswer(
+        (_) async => const InviteClientConfig(
+          mode: OnboardingMode.inviteCodeRequired,
+          supportEmail: 'support@divine.video',
+        ),
+      );
+
+      await tester.pumpWidget(
+        createTestWidget(
+          initialLocation:
+              '${WelcomeScreen.createAccountPath}?code=AB12-EF34'
+              '&error=Invite%20problem&sourceSlug=creator',
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Invite Gate'), findsOneWidget);
+      expect(find.text('Code: AB12-EF34'), findsOneWidget);
+      expect(find.text('Error: Invite problem'), findsOneWidget);
+      expect(find.text('Source: creator'), findsOneWidget);
     });
 
     testWidgets('allows create-account when server onboarding mode is open', (

--- a/mobile/test/screens/welcome_screen_test.dart
+++ b/mobile/test/screens/welcome_screen_test.dart
@@ -297,19 +297,44 @@ void main() {
         },
       );
 
-      testWidgets('tapping create account calls acceptTerms and navigates', (
-        tester,
-      ) async {
-        await useTallSurface(tester);
-        await tester.pumpWidget(createTestWidget());
-        await tester.pumpAndSettle();
+      testWidgets(
+        'tapping create account defaults to skipping the invite gate',
+        (tester) async {
+          await useTallSurface(tester);
+          await tester.pumpWidget(createTestWidget());
+          await tester.pumpAndSettle();
 
-        await tester.tap(find.text('Create a new Divine account'));
-        await tester.pumpAndSettle();
+          await tester.tap(find.text('Create a new Divine account'));
+          await tester.pumpAndSettle();
 
-        verify(() => mockAuthService.acceptTerms()).called(1);
-        expect(find.text('Invite Gate'), findsOneWidget);
-      });
+          verify(() => mockAuthService.acceptTerms()).called(1);
+          expect(find.text('Create Account'), findsOneWidget);
+          expect(find.text('Invite Gate'), findsNothing);
+        },
+      );
+
+      testWidgets(
+        'tapping create account skips the invite gate while config resolves',
+        (tester) async {
+          await useTallSurface(tester);
+          final availabilityCubit = seededInviteAvailabilityCubit(
+            serverMode: null,
+            hasResolved: false,
+          );
+          addTearDown(availabilityCubit.close);
+
+          await tester.pumpWidget(
+            createTestWidget(availabilityCubit: availabilityCubit),
+          );
+          await tester.pumpAndSettle();
+
+          await tester.tap(find.text('Create a new Divine account'));
+          await tester.pumpAndSettle();
+
+          expect(find.text('Create Account'), findsOneWidget);
+          expect(find.text('Invite Gate'), findsNothing);
+        },
+      );
 
       testWidgets(
         'tapping create account skips the invite gate when invites are disabled',
@@ -726,7 +751,7 @@ void main() {
       });
 
       testWidgets(
-        'tapping "Create new account" calls acceptTerms and navigates',
+        'tapping "Create new account" defaults to skipping the invite gate',
         (tester) async {
           await tester.binding.setSurfaceSize(const Size(800, 1200));
           addTearDown(() => tester.binding.setSurfaceSize(null));
@@ -737,7 +762,8 @@ void main() {
           await tester.pumpAndSettle();
 
           verify(() => mockAuthService.acceptTerms()).called(1);
-          expect(find.text('Invite Gate'), findsOneWidget);
+          expect(find.text('Create Account'), findsOneWidget);
+          expect(find.text('Invite Gate'), findsNothing);
         },
       );
 


### PR DESCRIPTION
A failed or slow invite-configuration request can currently send a new user into an invite-code wall even though signup codes are no longer accepted. That makes account creation a dead end on common first-launch network failures.

The invite defaults now require an explicit `invite_code_required` response before enabling the gate. Missing, unknown, unresolved, failed, and absent-provider states all keep account creation open, while an explicit invite-required response and developer overrides retain their existing behavior. The fallback configuration and warning log use the same safe default.

This deliberately does not remove the remaining invite machinery; that broader deletion stays as Step 2 of #8000 after this emergency behavior fix ships.

Verification:
- `flutter test test/models/invite_availability_test.dart test/repositories/invite_availability_repository_test.dart test/screens/welcome_screen_test.dart packages/invite_api_client/test/src/invite_models_test.dart`
- `flutter analyze`
- `flutter test --coverage` in `packages/invite_api_client` — 91.35% (floor: 89%)
- `bash scripts/check_package_coverage_floor.sh`
- pre-push analyzer and changed-file tests

Refs #8000