### PR TITLE
fix(a11y): give the feed's follow badge, author row and player surface real tap targets

### DIFF
--- a/mobile/lib/widgets/video_feed_item/feed_videos.dart
+++ b/mobile/lib/widgets/video_feed_item/feed_videos.dart
@@ -1014,9 +1014,11 @@ class __OverlayState extends ConsumerState<_Overlay> {
             child: Builder(
               builder: (context) {
                 return Semantics(
-                  button: true,
-                  label: context.l10n.videoPlayerPlayVideo,
-                  hint: isOwnVideo ? null : context.l10n.videoPlayerTapHint,
+                  // The label and hint live on the GESTURE SURFACE below, not
+                  // here. This node carries no tap action, so a label on it
+                  // left the actual tappable node unlabeled — a screen reader
+                  // announced a full-screen button with no name, and
+                  // labeledTapTargetGuideline failed on a real device.
                   // The chrome layers are SIBLINGS above the gesture surface,
                   // never descendants of it. As descendants, any press held
                   // past `kLongPressTimeout` anywhere on the action rail was
@@ -1059,38 +1061,57 @@ class __OverlayState extends ConsumerState<_Overlay> {
                               _handleImmersivePointerEnd(event.pointer),
                           onPointerCancel: (event) =>
                               _handleImmersivePointerEnd(event.pointer),
-                          child: GestureDetector(
-                            behavior: .translucent,
-                            onTap: interactiveReady ? _handlePlayerTap : null,
-                            onDoubleTapDown: interactiveReady
-                                ? (details) => _handleDoubleTapLike(
-                                    context,
-                                    details,
-                                    isOwnVideo: isOwnVideo,
-                                  )
-                                : null,
-                            child: GestureDetector(
-                              behavior: .translucent,
-                              // Press and hold to peek at the unobstructed
-                              // frame. Deliberately not gated on
-                              // [interactiveReady] the way tap and double-tap
-                              // are: those mutate the player or publish a
-                              // like, while this only hides chrome, which is
-                              // just as valid over a still-loading frame.
-                              //
-                              // Excluded from semantics, and kept on its own
-                              // detector so the tap action above still is
-                              // published. A `GestureDetector` publishes
-                              // `SemanticsAction.longPress` for ANY long-press
-                              // callback, `onLongPressStart` included — and
-                              // firing that action delivers no pointer events,
-                              // so the release path below would never run and
-                              // a screen-reader user would be left with every
-                              // control hidden and pointer-blocked until the
-                              // item was disposed.
-                              excludeFromSemantics: true,
-                              onLongPressStart: (_) => _enterImmersive(),
-                              child: const SizedBox.expand(),
+                          // MergeSemantics, not a bare Semantics: with
+                          // `container: false` the annotation lands on its own
+                          // node while GestureDetector publishes the tap action
+                          // on a DIFFERENT one, which is exactly the shipped
+                          // bug — a 440x850 tappable with no label. Merging is
+                          // safe here because the chrome layers are Stack
+                          // SIBLINGS, not descendants, so nothing else is
+                          // flattened into this node.
+                          child: MergeSemantics(
+                            child: Semantics(
+                              button: true,
+                              label: context.l10n.videoPlayerPlayVideo,
+                              hint: isOwnVideo
+                                  ? null
+                                  : context.l10n.videoPlayerTapHint,
+                              child: GestureDetector(
+                                behavior: .translucent,
+                                onTap: interactiveReady
+                                    ? _handlePlayerTap
+                                    : null,
+                                onDoubleTapDown: interactiveReady
+                                    ? (details) => _handleDoubleTapLike(
+                                        context,
+                                        details,
+                                        isOwnVideo: isOwnVideo,
+                                      )
+                                    : null,
+                                child: GestureDetector(
+                                  behavior: .translucent,
+                                  // Press and hold to peek at the unobstructed
+                                  // frame. Deliberately not gated on
+                                  // [interactiveReady] the way tap and double-tap
+                                  // are: those mutate the player or publish a
+                                  // like, while this only hides chrome, which is
+                                  // just as valid over a still-loading frame.
+                                  //
+                                  // Excluded from semantics, and kept on its own
+                                  // detector so the tap action above still is
+                                  // published. A `GestureDetector` publishes
+                                  // `SemanticsAction.longPress` for ANY long-press
+                                  // callback, `onLongPressStart` included — and
+                                  // firing that action delivers no pointer events,
+                                  // so the release path below would never run and
+                                  // a screen-reader user would be left with every
+                                  // control hidden and pointer-blocked until the
+                                  // item was disposed.
+                                  excludeFromSemantics: true,
+                                  onLongPressStart: (_) => _enterImmersive(),
+                                  child: const SizedBox.expand(),
+                                ),
+                              ),
                             ),
                           ),
                         ),

--- a/mobile/lib/widgets/video_feed_item/feed_videos.dart
+++ b/mobile/lib/widgets/video_feed_item/feed_videos.dart
@@ -19,7 +19,6 @@ import 'package:openvine/constants/app_constants.dart';
 import 'package:openvine/extensions/video_event_extensions.dart';
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
 import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
-import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/models/view_traffic_source.dart'
     show ViewTrafficSource;
 import 'package:openvine/providers/app_foreground_provider.dart';
@@ -45,6 +44,7 @@ import 'package:openvine/widgets/video_feed_item/double_tap_like_helpers.dart';
 import 'package:openvine/widgets/video_feed_item/feed_immersive_chrome.dart';
 import 'package:openvine/widgets/video_feed_item/moderated_content_overlay.dart';
 import 'package:openvine/widgets/video_feed_item/paused_video_overlay.dart';
+import 'package:openvine/widgets/video_feed_item/player_gesture_surface.dart';
 import 'package:openvine/widgets/video_feed_item/player_tap_helpers.dart';
 import 'package:openvine/widgets/video_feed_item/subtitle_overlay.dart';
 import 'package:openvine/widgets/video_feed_item/verifying_aware_video_error_overlay.dart';
@@ -1013,154 +1013,109 @@ class __OverlayState extends ConsumerState<_Overlay> {
                   ..add(const VideoInteractionsFetchRequested()),
             child: Builder(
               builder: (context) {
-                return Semantics(
-                  // The label and hint live on the GESTURE SURFACE below, not
-                  // here. This node carries no tap action, so a label on it
-                  // left the actual tappable node unlabeled — a screen reader
-                  // announced a full-screen button with no name, and
-                  // labeledTapTargetGuideline failed on a real device.
-                  // The chrome layers are SIBLINGS above the gesture surface,
-                  // never descendants of it. As descendants, any press held
-                  // past `kLongPressTimeout` anywhere on the action rail was
-                  // claimed by the video's long-press: the rail's own tap
-                  // recognizer only accepts on pointer-up, so it lost the
-                  // arena, and Report/More/Share swallowed the tap and faded
-                  // out under the viewer's finger. Keeping them siblings lets
-                  // an opaque button win the hit test outright, so the peek
-                  // never sees that pointer.
-                  child: Stack(
-                    children: [
-                      // The raw [Listener] owns immersive mode's release: it
-                      // counts the pointers over the item and exits once the
-                      // last lifts. `onLongPressEnd` alone would not do —
-                      // it does not fire for a pointer cancelled after the
-                      // press was accepted (`onLongPressCancel` does), and
-                      // neither callback can tell an incidental second finger
-                      // lifting from the hold finger lifting. A Listener also
-                      // sits outside the gesture arena, so it can't steal the
-                      // press.
-                      Positioned.fill(
-                        child: Listener(
-                          // Must match the translucent child below: with
-                          // `deferToChild` a press on empty video area never
-                          // adds this Listener to the hit-test path (the
-                          // translucent GestureDetector adds itself but still
-                          // reports a miss), so the pointer events would never
-                          // arrive.
-                          behavior: HitTestBehavior.translucent,
-                          onPointerDown: (event) {
-                            // An empty set means nothing is down, so any hold
-                            // this item still believes it owns is stale — its
-                            // terminal event was lost (a touch dropped on
-                            // backgrounding, a platform view taking over).
-                            // Without this the item could never peek again.
-                            if (_immersivePointers.isEmpty) _exitImmersive();
-                            _immersivePointers.add(event.pointer);
-                          },
-                          onPointerUp: (event) =>
-                              _handleImmersivePointerEnd(event.pointer),
-                          onPointerCancel: (event) =>
-                              _handleImmersivePointerEnd(event.pointer),
-                          // MergeSemantics, not a bare Semantics: with
-                          // `container: false` the annotation lands on its own
-                          // node while GestureDetector publishes the tap action
-                          // on a DIFFERENT one, which is exactly the shipped
-                          // bug — a 440x850 tappable with no label. Merging is
-                          // safe here because the chrome layers are Stack
-                          // SIBLINGS, not descendants, so nothing else is
-                          // flattened into this node.
-                          child: MergeSemantics(
-                            child: Semantics(
-                              button: true,
-                              label: context.l10n.videoPlayerPlayVideo,
-                              hint: isOwnVideo
-                                  ? null
-                                  : context.l10n.videoPlayerTapHint,
-                              child: GestureDetector(
-                                behavior: .translucent,
-                                onTap: interactiveReady
-                                    ? _handlePlayerTap
-                                    : null,
-                                onDoubleTapDown: interactiveReady
-                                    ? (details) => _handleDoubleTapLike(
-                                        context,
-                                        details,
-                                        isOwnVideo: isOwnVideo,
-                                      )
-                                    : null,
-                                child: GestureDetector(
-                                  behavior: .translucent,
-                                  // Press and hold to peek at the unobstructed
-                                  // frame. Deliberately not gated on
-                                  // [interactiveReady] the way tap and double-tap
-                                  // are: those mutate the player or publish a
-                                  // like, while this only hides chrome, which is
-                                  // just as valid over a still-loading frame.
-                                  //
-                                  // Excluded from semantics, and kept on its own
-                                  // detector so the tap action above still is
-                                  // published. A `GestureDetector` publishes
-                                  // `SemanticsAction.longPress` for ANY long-press
-                                  // callback, `onLongPressStart` included — and
-                                  // firing that action delivers no pointer events,
-                                  // so the release path below would never run and
-                                  // a screen-reader user would be left with every
-                                  // control hidden and pointer-blocked until the
-                                  // item was disposed.
-                                  excludeFromSemantics: true,
-                                  onLongPressStart: (_) => _enterImmersive(),
-                                  child: const SizedBox.expand(),
-                                ),
-                              ),
-                            ),
-                          ),
-                        ),
-                      ),
-                      if (widget.controller != null)
-                        // The paused play indicator is chrome too — it
-                        // covers the frame the peek is meant to reveal,
-                        // and holding never resumes playback, so leaving
-                        // it up would contradict the gesture.
-                        FeedImmersiveChrome(
-                          child: PausedVideoOverlay(
-                            controller: widget.controller!,
-                            videoId: video.id,
-                            // Only a pause the user can undo gets the
-                            // affordance. A comments/share sheet, a pushed
-                            // route or a backgrounded app pauses the player
-                            // too, but resumes it on its own — showing a play
-                            // button behind the sheet just reads as broken.
-                            isVisible: widget.isActive && widget.isFeedActive,
-                          ),
-                        ),
-                      FeedImmersiveChrome(
-                        child: _FeedItemActions(
-                          video: video,
-                          index: widget.index,
-                          contextTitle: widget.contextTitle,
+                // The chrome layers are SIBLINGS above the gesture surface,
+                // never descendants of it. As descendants, any press held past
+                // `kLongPressTimeout` anywhere on the action rail was claimed
+                // by the video's long-press: the rail's own tap recognizer only
+                // accepts on pointer-up, so it lost the arena, and
+                // Report/More/Share swallowed the tap and faded out under the
+                // viewer's finger. Keeping them siblings lets an opaque button
+                // win the hit test outright, so the peek never sees that
+                // pointer.
+                //
+                // The player's label and hint live on the gesture surface
+                // below, not on a wrapper here: a node with no tap action
+                // cannot name the one a screen reader activates.
+                return Stack(
+                  children: [
+                    // The raw [Listener] owns immersive mode's release: it
+                    // counts the pointers over the item and exits once the
+                    // last lifts. `onLongPressEnd` alone would not do —
+                    // it does not fire for a pointer cancelled after the
+                    // press was accepted (`onLongPressCancel` does), and
+                    // neither callback can tell an incidental second finger
+                    // lifting from the hold finger lifting. A Listener also
+                    // sits outside the gesture arena, so it can't steal the
+                    // press.
+                    Positioned.fill(
+                      child: Listener(
+                        // Must match the translucent child below: with
+                        // `deferToChild` a press on empty video area never
+                        // adds this Listener to the hit-test path (the
+                        // translucent GestureDetector adds itself but still
+                        // reports a miss), so the pointer events would never
+                        // arrive.
+                        behavior: HitTestBehavior.translucent,
+                        onPointerDown: (event) {
+                          // An empty set means nothing is down, so any hold
+                          // this item still believes it owns is stale — its
+                          // terminal event was lost (a touch dropped on
+                          // backgrounding, a platform view taking over).
+                          // Without this the item could never peek again.
+                          if (_immersivePointers.isEmpty) _exitImmersive();
+                          _immersivePointers.add(event.pointer);
+                        },
+                        onPointerUp: (event) =>
+                            _handleImmersivePointerEnd(event.pointer),
+                        onPointerCancel: (event) =>
+                            _handleImmersivePointerEnd(event.pointer),
+                        child: PlayerGestureSurface(
+                          interactiveReady: interactiveReady,
                           isOwnVideo: isOwnVideo,
-                          onSuppressAutoAdvance: widget.onSuppressAutoAdvance,
-                          // Captions fade with the rest of the chrome, by
-                          // design: the hold reveals the frame the UI covers,
-                          // and the caption is an overlay over that same frame,
-                          // so keeping it up would re-cover exactly what the
-                          // peek exposes. It is gone only while the viewer
-                          // holds, and returns the instant they release.
-                          subtitleLayer:
-                              video.hasSubtitles && widget.controller != null
-                              ? _SubtitleLayer(
-                                  video: video,
-                                  controller: widget.controller!,
-                                )
-                              : null,
-                          pagePositionListenable: pagePositionListenable,
+                          onTap: _handlePlayerTap,
+                          onDoubleTapDown: (details) => _handleDoubleTapLike(
+                            context,
+                            details,
+                            isOwnVideo: isOwnVideo,
+                          ),
+                          onLongPressStart: _enterImmersive,
                         ),
                       ),
-                      Positioned.fill(
-                        child: DoubleTapHeartOverlay(trigger: _heartTrigger),
+                    ),
+                    if (widget.controller != null)
+                      // The paused play indicator is chrome too — it
+                      // covers the frame the peek is meant to reveal,
+                      // and holding never resumes playback, so leaving
+                      // it up would contradict the gesture.
+                      FeedImmersiveChrome(
+                        child: PausedVideoOverlay(
+                          controller: widget.controller!,
+                          videoId: video.id,
+                          // Only a pause the user can undo gets the
+                          // affordance. A comments/share sheet, a pushed
+                          // route or a backgrounded app pauses the player
+                          // too, but resumes it on its own — showing a play
+                          // button behind the sheet just reads as broken.
+                          isVisible: widget.isActive && widget.isFeedActive,
+                        ),
                       ),
-                    ],
-                  ),
+                    FeedImmersiveChrome(
+                      child: _FeedItemActions(
+                        video: video,
+                        index: widget.index,
+                        contextTitle: widget.contextTitle,
+                        isOwnVideo: isOwnVideo,
+                        onSuppressAutoAdvance: widget.onSuppressAutoAdvance,
+                        // Captions fade with the rest of the chrome, by
+                        // design: the hold reveals the frame the UI covers,
+                        // and the caption is an overlay over that same frame,
+                        // so keeping it up would re-cover exactly what the
+                        // peek exposes. It is gone only while the viewer
+                        // holds, and returns the instant they release.
+                        subtitleLayer:
+                            video.hasSubtitles && widget.controller != null
+                            ? _SubtitleLayer(
+                                video: video,
+                                controller: widget.controller!,
+                              )
+                            : null,
+                        pagePositionListenable: pagePositionListenable,
+                      ),
+                    ),
+                    Positioned.fill(
+                      child: DoubleTapHeartOverlay(trigger: _heartTrigger),
+                    ),
+                  ],
                 );
               },
             ),

--- a/mobile/lib/widgets/video_feed_item/player_gesture_surface.dart
+++ b/mobile/lib/widgets/video_feed_item/player_gesture_surface.dart
@@ -1,0 +1,82 @@
+// ABOUTME: The full-bleed gesture surface over a feed video: tap to play/pause,
+// ABOUTME: double-tap to like, press-and-hold to peek at the unobstructed frame.
+// ABOUTME: Extracted so its semantics can be tested without a video player pool.
+
+import 'package:flutter/material.dart';
+import 'package:openvine/l10n/l10n.dart';
+
+/// The tap/double-tap/long-press surface painted under a feed item's chrome.
+///
+/// Pulled out of `feed_videos.dart` for one reason: in place, its tap action is
+/// gated on a controller that has rendered a first frame, `FeedVideos` takes no
+/// controller (it comes from an internal pool), and so no widget test could
+/// make the surface interactive. The labelling below shipped broken precisely
+/// because nothing could assert it. Here [interactiveReady] is a parameter, so
+/// a test can pump the real thing in its real state.
+class PlayerGestureSurface extends StatelessWidget {
+  /// Creates a [PlayerGestureSurface].
+  const PlayerGestureSurface({
+    required this.interactiveReady,
+    required this.isOwnVideo,
+    required this.onTap,
+    required this.onDoubleTapDown,
+    required this.onLongPressStart,
+    super.key,
+  });
+
+  /// Whether the player can accept play/pause and like gestures yet.
+  final bool interactiveReady;
+
+  /// Suppresses the double-tap-to-like hint on the viewer's own video.
+  final bool isOwnVideo;
+
+  /// Play or pause the video.
+  final VoidCallback onTap;
+
+  /// Publish a like, anchored at the tap position.
+  final void Function(TapDownDetails details) onDoubleTapDown;
+
+  /// Enter immersive mode — hide chrome while the press is held.
+  final VoidCallback onLongPressStart;
+
+  @override
+  Widget build(BuildContext context) {
+    // The annotation must sit DIRECTLY above the GestureDetector. In the
+    // original tree it wrapped the whole Stack instead, several layers up and
+    // around the chrome siblings, so it annotated a node that owned no tap
+    // action while the real tappable node stayed anonymous — on device,
+    // SemanticsNode#7(Rect 0,0,440,850, actions: [tap]) with no label. Here
+    // there is nothing between the two, so the annotation merges onto the
+    // gesture node. (MergeSemantics was tried first and is NOT what fixes
+    // this: with the widget extracted, a mutation removing it changes
+    // nothing.)
+    return Semantics(
+      button: true,
+      label: context.l10n.videoPlayerPlayVideo,
+      hint: isOwnVideo ? null : context.l10n.videoPlayerTapHint,
+      child: GestureDetector(
+        behavior: HitTestBehavior.translucent,
+        onTap: interactiveReady ? onTap : null,
+        onDoubleTapDown: interactiveReady ? onDoubleTapDown : null,
+        child: GestureDetector(
+          behavior: HitTestBehavior.translucent,
+          // Press and hold to peek at the unobstructed frame. Deliberately
+          // not gated on [interactiveReady] the way tap and double-tap are:
+          // those mutate the player or publish a like, while this only hides
+          // chrome, which is just as valid over a still-loading frame.
+          //
+          // Excluded from semantics, and kept on its own detector so the tap
+          // action above is still published. A `GestureDetector` publishes
+          // `SemanticsAction.longPress` for ANY long-press callback,
+          // `onLongPressStart` included — and firing that action delivers no
+          // pointer events, so the release path in the parent would never run
+          // and a screen-reader user would be left with every control hidden
+          // and pointer-blocked until the item was disposed.
+          excludeFromSemantics: true,
+          onLongPressStart: (_) => onLongPressStart(),
+          child: const SizedBox.expand(),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/widgets/video_feed_item/video_feed_item.dart
+++ b/mobile/lib/widgets/video_feed_item/video_feed_item.dart
@@ -44,8 +44,10 @@ import 'package:openvine/widgets/video_feed_item/video_follow_button.dart';
 import 'package:openvine/widgets/video_reply_parent_link.dart';
 import 'package:unified_logger/unified_logger.dart';
 
-/// Offset of the follow badge from the avatar's top-start corner.
-const double _followBadgeOffset = 31;
+/// Size of the avatar block: the avatar plus the sliver of overflow the follow
+/// badge has always drawn into. Also the height the author text is centred
+/// against, so the badge's larger footprint cannot move it.
+const double _avatarClusterSize = 58;
 
 class VideoOverlayPreviewData {
   const VideoOverlayPreviewData({
@@ -334,18 +336,25 @@ class VideoOverlayActions extends ConsumerWidget {
                     }
 
                     return Row(
+                      // Deliberate: the follow badge's 48dp tap target makes
+                      // this cluster taller than the avatar whenever the badge
+                      // draws, and default centring would then drop the author
+                      // text relative to the avatar. Start-aligning the row,
+                      // and centring the text against the avatar block below,
+                      // keeps both exactly where they were.
+                      crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         // Avatar with follow button overlay
-                        SizedBox(
-                          // Avatar (48) + the follow badge's 48dp tap target
-                          // starting at the badge origin. Flutter rejects a hit
-                          // outside a box BEFORE it reaches the child, and
-                          // `Clip.none` only affects painting — so if this box
-                          // stayed at 58 the badge's enlarged hit area would be
-                          // silently clipped back to 27dp.
-                          width: _followBadgeOffset + followButtonTapTargetSize,
-                          height:
-                              _followBadgeOffset + followButtonTapTargetSize,
+                        ConstrainedBox(
+                          // Floor at the avatar block, so every state where the
+                          // badge draws NOTHING — loading, already following,
+                          // own video, blocked author, preview mode — renders
+                          // exactly as before. The Stack grows past this only
+                          // when the badge actually occupies its footprint.
+                          constraints: const BoxConstraints(
+                            minWidth: _avatarClusterSize,
+                            minHeight: _avatarClusterSize,
+                          ),
                           child: Stack(
                             clipBehavior: Clip.none,
                             children: [
@@ -358,15 +367,12 @@ class VideoOverlayActions extends ConsumerWidget {
                                     context.l10n.videoAuthorAvatarSemanticLabel,
                                 onTap: navigateToProfile,
                               ),
-                              // Follow button positioned at bottom-right of avatar
+                              // NOT positioned: a positioned child contributes
+                              // nothing to a Stack's size, so the Stack could
+                              // never shrink back when the badge hides. The
+                              // badge owns its footprint and places itself.
                               if (video != null)
-                                PositionedDirectional(
-                                  start: _followBadgeOffset,
-                                  top: _followBadgeOffset,
-                                  child: VideoFollowButton(
-                                    pubkey: authorPubkey,
-                                  ),
-                                ),
+                                VideoFollowButton(pubkey: authorPubkey),
                             ],
                           ),
                         ),
@@ -374,64 +380,72 @@ class VideoOverlayActions extends ConsumerWidget {
                         // User name and loop count (tappable to go to profile)
                         Expanded(
                           child: GestureDetector(
-                            // Opaque, so the padding added by the minimum-height
-                            // constraint below is tappable rather than falling
-                            // through to the video.
+                            // Opaque, so the whole author strip navigates to
+                            // the profile rather than only the painted glyphs.
+                            // This widens an existing target; it adds no new
+                            // destination.
                             behavior: HitTestBehavior.opaque,
                             onTap: navigateToProfile,
-                            // The name + meta column is intrinsically 44dp, which
-                            // failed androidTapTargetGuideline (48) on device.
-                            // minHeight, not a fixed height, so the row still
-                            // grows with the system font scale
-                            // (.claude/rules/accessibility.md).
+                            // The name + meta column is intrinsically 44dp,
+                            // which failed androidTapTargetGuideline (48) on
+                            // device. Constrained to the avatar block and
+                            // centred, so the text sits where it always has
+                            // while the target clears 48dp. minHeight, not a
+                            // fixed height, so it still grows with the system
+                            // font scale (.claude/rules/accessibility.md).
                             child: ConstrainedBox(
-                              constraints: const BoxConstraints(minHeight: 48),
-                              child: Column(
-                                crossAxisAlignment: CrossAxisAlignment.start,
-                                mainAxisSize: MainAxisSize.min,
-                                children: [
-                                  Row(
-                                    children: [
-                                      Flexible(
-                                        child: Semantics(
-                                          identifier: 'video_author_name',
-                                          container: true,
-                                          explicitChildNodes: true,
-                                          label: context.l10n
-                                              .videoAuthorSemanticLabel(
-                                                displayName,
+                              constraints: const BoxConstraints(
+                                minHeight: _avatarClusterSize,
+                              ),
+                              child: Align(
+                                alignment: Alignment.centerLeft,
+                                child: Column(
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  mainAxisSize: MainAxisSize.min,
+                                  children: [
+                                    Row(
+                                      children: [
+                                        Flexible(
+                                          child: Semantics(
+                                            identifier: 'video_author_name',
+                                            container: true,
+                                            explicitChildNodes: true,
+                                            label: context.l10n
+                                                .videoAuthorSemanticLabel(
+                                                  displayName,
+                                                ),
+                                            child: DivineHeartText(
+                                              displayName,
+                                              style: VineTheme.titleSmallFont(
+                                                color: VineTheme.whiteText,
                                               ),
-                                          child: DivineHeartText(
-                                            displayName,
-                                            style: VineTheme.titleSmallFont(
-                                              color: VineTheme.whiteText,
+                                              maxLines: 1,
+                                              overflow: TextOverflow.ellipsis,
                                             ),
-                                            maxLines: 1,
-                                            overflow: TextOverflow.ellipsis,
                                           ),
                                         ),
-                                      ),
-                                      if (showCheckmark)
-                                        const SpecialProfileCheckmark(),
-                                      if (isOgViner) const OgVinerBadge(),
-                                      if (isOgBetaTester)
-                                        OgBetaBadge(
-                                          onTap: () =>
-                                              showProfileBadgeExplanationSheet(
-                                                context,
-                                                ProfileBadgeExplanationType
-                                                    .ogBetaTester,
-                                              ),
-                                        ),
-                                    ],
-                                  ),
-                                  _VideoCardMetaLine(
-                                    meta: resolveVideoCardMeta(
-                                      video: video,
-                                      isOwnVideo: isOwnVideo,
+                                        if (showCheckmark)
+                                          const SpecialProfileCheckmark(),
+                                        if (isOgViner) const OgVinerBadge(),
+                                        if (isOgBetaTester)
+                                          OgBetaBadge(
+                                            onTap: () =>
+                                                showProfileBadgeExplanationSheet(
+                                                  context,
+                                                  ProfileBadgeExplanationType
+                                                      .ogBetaTester,
+                                                ),
+                                          ),
+                                      ],
                                     ),
-                                  ),
-                                ],
+                                    _VideoCardMetaLine(
+                                      meta: resolveVideoCardMeta(
+                                        video: video,
+                                        isOwnVideo: isOwnVideo,
+                                      ),
+                                    ),
+                                  ],
+                                ),
                               ),
                             ),
                           ),

--- a/mobile/lib/widgets/video_feed_item/video_feed_item.dart
+++ b/mobile/lib/widgets/video_feed_item/video_feed_item.dart
@@ -44,6 +44,9 @@ import 'package:openvine/widgets/video_feed_item/video_follow_button.dart';
 import 'package:openvine/widgets/video_reply_parent_link.dart';
 import 'package:unified_logger/unified_logger.dart';
 
+/// Offset of the follow badge from the avatar's top-start corner.
+const double _followBadgeOffset = 31;
+
 class VideoOverlayPreviewData {
   const VideoOverlayPreviewData({
     required this.pubkey,
@@ -334,8 +337,15 @@ class VideoOverlayActions extends ConsumerWidget {
                       children: [
                         // Avatar with follow button overlay
                         SizedBox(
-                          width: 58, // 48 avatar + follow button overflow
-                          height: 58,
+                          // Avatar (48) + the follow badge's 48dp tap target
+                          // starting at the badge origin. Flutter rejects a hit
+                          // outside a box BEFORE it reaches the child, and
+                          // `Clip.none` only affects painting — so if this box
+                          // stayed at 58 the badge's enlarged hit area would be
+                          // silently clipped back to 27dp.
+                          width: _followBadgeOffset + followButtonTapTargetSize,
+                          height:
+                              _followBadgeOffset + followButtonTapTargetSize,
                           child: Stack(
                             clipBehavior: Clip.none,
                             children: [
@@ -351,8 +361,8 @@ class VideoOverlayActions extends ConsumerWidget {
                               // Follow button positioned at bottom-right of avatar
                               if (video != null)
                                 PositionedDirectional(
-                                  start: 31,
-                                  top: 31,
+                                  start: _followBadgeOffset,
+                                  top: _followBadgeOffset,
                                   child: VideoFollowButton(
                                     pubkey: authorPubkey,
                                   ),
@@ -364,53 +374,65 @@ class VideoOverlayActions extends ConsumerWidget {
                         // User name and loop count (tappable to go to profile)
                         Expanded(
                           child: GestureDetector(
+                            // Opaque, so the padding added by the minimum-height
+                            // constraint below is tappable rather than falling
+                            // through to the video.
+                            behavior: HitTestBehavior.opaque,
                             onTap: navigateToProfile,
-                            child: Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              mainAxisSize: MainAxisSize.min,
-                              children: [
-                                Row(
-                                  children: [
-                                    Flexible(
-                                      child: Semantics(
-                                        identifier: 'video_author_name',
-                                        container: true,
-                                        explicitChildNodes: true,
-                                        label: context.l10n
-                                            .videoAuthorSemanticLabel(
-                                              displayName,
+                            // The name + meta column is intrinsically 44dp, which
+                            // failed androidTapTargetGuideline (48) on device.
+                            // minHeight, not a fixed height, so the row still
+                            // grows with the system font scale
+                            // (.claude/rules/accessibility.md).
+                            child: ConstrainedBox(
+                              constraints: const BoxConstraints(minHeight: 48),
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                mainAxisSize: MainAxisSize.min,
+                                children: [
+                                  Row(
+                                    children: [
+                                      Flexible(
+                                        child: Semantics(
+                                          identifier: 'video_author_name',
+                                          container: true,
+                                          explicitChildNodes: true,
+                                          label: context.l10n
+                                              .videoAuthorSemanticLabel(
+                                                displayName,
+                                              ),
+                                          child: DivineHeartText(
+                                            displayName,
+                                            style: VineTheme.titleSmallFont(
+                                              color: VineTheme.whiteText,
                                             ),
-                                        child: DivineHeartText(
-                                          displayName,
-                                          style: VineTheme.titleSmallFont(
-                                            color: VineTheme.whiteText,
+                                            maxLines: 1,
+                                            overflow: TextOverflow.ellipsis,
                                           ),
-                                          maxLines: 1,
-                                          overflow: TextOverflow.ellipsis,
                                         ),
                                       ),
-                                    ),
-                                    if (showCheckmark)
-                                      const SpecialProfileCheckmark(),
-                                    if (isOgViner) const OgVinerBadge(),
-                                    if (isOgBetaTester)
-                                      OgBetaBadge(
-                                        onTap: () =>
-                                            showProfileBadgeExplanationSheet(
-                                              context,
-                                              ProfileBadgeExplanationType
-                                                  .ogBetaTester,
-                                            ),
-                                      ),
-                                  ],
-                                ),
-                                _VideoCardMetaLine(
-                                  meta: resolveVideoCardMeta(
-                                    video: video,
-                                    isOwnVideo: isOwnVideo,
+                                      if (showCheckmark)
+                                        const SpecialProfileCheckmark(),
+                                      if (isOgViner) const OgVinerBadge(),
+                                      if (isOgBetaTester)
+                                        OgBetaBadge(
+                                          onTap: () =>
+                                              showProfileBadgeExplanationSheet(
+                                                context,
+                                                ProfileBadgeExplanationType
+                                                    .ogBetaTester,
+                                              ),
+                                        ),
+                                    ],
                                   ),
-                                ),
-                              ],
+                                  _VideoCardMetaLine(
+                                    meta: resolveVideoCardMeta(
+                                      video: video,
+                                      isOwnVideo: isOwnVideo,
+                                    ),
+                                  ),
+                                ],
+                              ),
                             ),
                           ),
                         ),

--- a/mobile/lib/widgets/video_feed_item/video_follow_button.dart
+++ b/mobile/lib/widgets/video_feed_item/video_follow_button.dart
@@ -1,5 +1,5 @@
 // ABOUTME: Follow button widget for video overlay using BLoC pattern.
-// ABOUTME: Circular 20x20 button positioned near the author avatar.
+// ABOUTME: Circular 20dp badge on the avatar corner, with a 48dp tap target.
 // ABOUTME: Only rendered when the viewer is NOT following the author; once
 // ABOUTME: following, the button disappears entirely (no "following" state).
 
@@ -23,6 +23,17 @@ import 'package:unified_logger/unified_logger.dart';
 /// The button is only shown for videos authored by someone the viewer does
 /// not yet follow. Once the viewer follows the author, the button hides for
 /// good.
+/// Painted diameter of the follow badge.
+const double followButtonVisualSize = 20;
+
+/// Minimum tap target for the follow badge, per
+/// `.claude/rules/accessibility.md` ("Minimum touch target size is 48x48 dp").
+///
+/// The parent Stack must extend at least this far past the badge origin, or the
+/// extra hit area is clipped: Flutter rejects a hit outside a box before it
+/// reaches the child, and `Clip.none` only affects painting.
+const double followButtonTapTargetSize = 48;
+
 class VideoFollowButton extends ConsumerStatefulWidget {
   const VideoFollowButton({required this.pubkey, super.key});
 
@@ -131,6 +142,9 @@ class VideoFollowButtonView extends StatelessWidget {
           label: context.l10n.videoFollowButtonFollow,
           button: true,
           child: GestureDetector(
+            // Opaque so the whole 48dp box below takes the hit, not just the
+            // 20dp circle painted inside it.
+            behavior: HitTestBehavior.opaque,
             onTap: () {
               Log.info(
                 'Follow button tapped for ${pubkeyForLogs(pubkey)}',
@@ -141,19 +155,35 @@ class VideoFollowButtonView extends StatelessWidget {
                 MyFollowingToggleRequested(pubkey),
               );
             },
-            child: Container(
-              width: 20,
-              height: 20,
-              decoration: const BoxDecoration(
-                color: VineTheme.cameraButtonGreen,
-                shape: BoxShape.circle,
-                boxShadow: VineTheme.buttonBoxShadows,
-              ),
-              child: const Center(
-                child: DivineIcon(
-                  icon: DivineIconName.follow,
-                  size: 13,
-                  color: VineTheme.whiteText,
+            // The badge PAINTS at 20dp, but a tap target must be at least
+            // 48dp (.claude/rules/accessibility.md). On a real device this
+            // node reported Size(20.0, 20.0) and failed both
+            // androidTapTargetGuideline (48) and iOSTapTargetGuideline (44).
+            //
+            // The box grows down-and-end from the badge rather than centring
+            // on it: the badge sits on the avatar's trailing-bottom corner, so
+            // a centred 48dp target would cover most of the 48dp avatar and
+            // steal the taps that open the author's profile.
+            child: SizedBox(
+              width: followButtonTapTargetSize,
+              height: followButtonTapTargetSize,
+              child: Align(
+                alignment: AlignmentDirectional.topStart,
+                child: Container(
+                  width: followButtonVisualSize,
+                  height: followButtonVisualSize,
+                  decoration: const BoxDecoration(
+                    color: VineTheme.cameraButtonGreen,
+                    shape: BoxShape.circle,
+                    boxShadow: VineTheme.buttonBoxShadows,
+                  ),
+                  child: const Center(
+                    child: DivineIcon(
+                      icon: DivineIconName.follow,
+                      size: 13,
+                      color: VineTheme.whiteText,
+                    ),
+                  ),
                 ),
               ),
             ),

--- a/mobile/lib/widgets/video_feed_item/video_follow_button.dart
+++ b/mobile/lib/widgets/video_feed_item/video_follow_button.dart
@@ -14,6 +14,30 @@ import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:unified_logger/unified_logger.dart';
 
+/// Painted diameter of the follow badge.
+const double followButtonVisualSize = 20;
+
+/// Minimum tap target for the follow badge, per
+/// `.claude/rules/accessibility.md` ("Minimum touch target size is 48x48 dp").
+///
+/// The footprint below must extend this far past the badge origin, or the extra
+/// hit area is clipped: Flutter rejects a hit outside a box before it reaches
+/// the child, and `Clip.none` only affects painting.
+const double followButtonTapTargetSize = 48;
+
+/// Offset of the painted badge from the avatar's top-start corner.
+const double followButtonBadgeOffset = 31;
+
+/// Footprint this widget occupies WHEN VISIBLE.
+///
+/// The widget is a non-positioned `Stack` child on purpose, so the Stack sizes
+/// itself from it: when the badge is hidden — loading, already following, own
+/// video, blocked author — the widget collapses to zero and the cluster falls
+/// back to the avatar alone, instead of every one of those states paying for
+/// space nothing draws in.
+const double followButtonFootprint =
+    followButtonBadgeOffset + followButtonTapTargetSize;
+
 /// Page widget that creates the [MyFollowingBloc] and provides it to the view.
 ///
 /// Uses StatefulConsumerWidget to avoid unnecessary rebuilds - the follow
@@ -23,17 +47,6 @@ import 'package:unified_logger/unified_logger.dart';
 /// The button is only shown for videos authored by someone the viewer does
 /// not yet follow. Once the viewer follows the author, the button hides for
 /// good.
-/// Painted diameter of the follow badge.
-const double followButtonVisualSize = 20;
-
-/// Minimum tap target for the follow badge, per
-/// `.claude/rules/accessibility.md` ("Minimum touch target size is 48x48 dp").
-///
-/// The parent Stack must extend at least this far past the badge origin, or the
-/// extra hit area is clipped: Flutter rejects a hit outside a box before it
-/// reaches the child, and `Clip.none` only affects painting.
-const double followButtonTapTargetSize = 48;
-
 class VideoFollowButton extends ConsumerStatefulWidget {
   const VideoFollowButton({required this.pubkey, super.key});
 
@@ -137,51 +150,62 @@ class VideoFollowButtonView extends StatelessWidget {
           return const SizedBox.shrink();
         }
 
-        return Semantics(
-          identifier: 'follow_button',
-          label: context.l10n.videoFollowButtonFollow,
-          button: true,
-          child: GestureDetector(
-            // Opaque so the whole 48dp box below takes the hit, not just the
-            // 20dp circle painted inside it.
-            behavior: HitTestBehavior.opaque,
-            onTap: () {
-              Log.info(
-                'Follow button tapped for ${pubkeyForLogs(pubkey)}',
-                name: 'VideoFollowButton',
-                category: LogCategory.ui,
-              );
-              context.read<MyFollowingBloc>().add(
-                MyFollowingToggleRequested(pubkey),
-              );
-            },
-            // The badge PAINTS at 20dp, but a tap target must be at least
-            // 48dp (.claude/rules/accessibility.md). On a real device this
-            // node reported Size(20.0, 20.0) and failed both
-            // androidTapTargetGuideline (48) and iOSTapTargetGuideline (44).
-            //
-            // The box grows down-and-end from the badge rather than centring
-            // on it: the badge sits on the avatar's trailing-bottom corner, so
-            // a centred 48dp target would cover most of the 48dp avatar and
-            // steal the taps that open the author's profile.
-            child: SizedBox(
-              width: followButtonTapTargetSize,
-              height: followButtonTapTargetSize,
-              child: Align(
-                alignment: AlignmentDirectional.topStart,
-                child: Container(
-                  width: followButtonVisualSize,
-                  height: followButtonVisualSize,
-                  decoration: const BoxDecoration(
-                    color: VineTheme.cameraButtonGreen,
-                    shape: BoxShape.circle,
-                    boxShadow: VineTheme.buttonBoxShadows,
-                  ),
-                  child: const Center(
-                    child: DivineIcon(
-                      icon: DivineIconName.follow,
-                      size: 13,
-                      color: VineTheme.whiteText,
+        // Occupy the footprint explicitly, so the parent Stack sizes itself
+        // from this widget and the hidden branches above cost nothing. The
+        // 48dp target sits at the badge origin via bottomEnd alignment, which
+        // leaves the painted circle exactly where it has always been.
+        return SizedBox(
+          width: followButtonFootprint,
+          height: followButtonFootprint,
+          child: Align(
+            alignment: AlignmentDirectional.bottomEnd,
+            child: Semantics(
+              identifier: 'follow_button',
+              label: context.l10n.videoFollowButtonFollow,
+              button: true,
+              child: GestureDetector(
+                // Opaque so the whole 48dp box below takes the hit, not just the
+                // 20dp circle painted inside it.
+                behavior: HitTestBehavior.opaque,
+                onTap: () {
+                  Log.info(
+                    'Follow button tapped for ${pubkeyForLogs(pubkey)}',
+                    name: 'VideoFollowButton',
+                    category: LogCategory.ui,
+                  );
+                  context.read<MyFollowingBloc>().add(
+                    MyFollowingToggleRequested(pubkey),
+                  );
+                },
+                // The badge PAINTS at 20dp, but a tap target must be at least
+                // 48dp (.claude/rules/accessibility.md). On a real device this
+                // node reported Size(20.0, 20.0) and failed both
+                // androidTapTargetGuideline (48) and iOSTapTargetGuideline (44).
+                //
+                // The box grows down-and-end from the badge rather than centring
+                // on it: the badge sits on the avatar's trailing-bottom corner, so
+                // a centred 48dp target would cover most of the 48dp avatar and
+                // steal the taps that open the author's profile.
+                child: SizedBox(
+                  width: followButtonTapTargetSize,
+                  height: followButtonTapTargetSize,
+                  child: Align(
+                    alignment: AlignmentDirectional.topStart,
+                    child: Container(
+                      width: followButtonVisualSize,
+                      height: followButtonVisualSize,
+                      decoration: const BoxDecoration(
+                        color: VineTheme.cameraButtonGreen,
+                        shape: BoxShape.circle,
+                        boxShadow: VineTheme.buttonBoxShadows,
+                      ),
+                      child: const Center(
+                        child: DivineIcon(
+                          icon: DivineIconName.follow,
+                          size: 13,
+                          color: VineTheme.whiteText,
+                        ),
+                      ),
                     ),
                   ),
                 ),

--- a/mobile/test/widgets/video_feed_item/feed_videos_test.dart
+++ b/mobile/test/widgets/video_feed_item/feed_videos_test.dart
@@ -813,6 +813,52 @@ void main() {
       expect(feed.canAutoPlay!(video), isTrue);
     });
 
+    testWidgets('the author row is a 48dp tap target', (tester) async {
+      final semantics = tester.ensureSemantics();
+      try {
+        InfiniteVideoFeed.debugIsSupportedOverride = true;
+
+        final video = _makeVideo();
+        final cubit = _MockVideoPlaybackStatusCubit()
+          ..stub(PlaybackStatus.ready, video.id);
+
+        await _pumpFeedVideos(
+          tester,
+          videos: [video],
+          videoPlaybackStatusCubit: cubit,
+        );
+        await tester.pump(const Duration(seconds: 4));
+
+        // The name + meta column is intrinsically 44dp and shipped that way:
+        // on an iPhone it reported Size(280.0, 44.0) and failed
+        // androidTapTargetGuideline (48). Walk the tree rather than matching a
+        // label, because the meta line's text is date-dependent.
+        final heights = <double>[];
+        void visit(SemanticsNode node) {
+          if (node.getSemanticsData().hasAction(SemanticsAction.tap)) {
+            heights.add(node.rect.height);
+          }
+          node.visitChildren((child) {
+            visit(child);
+            return true;
+          });
+        }
+
+        visit(tester.getSemantics(find.byType(FeedVideos)));
+
+        // The author row is the only wide tappable in the header.
+        final authorRow = heights.where((h) => h > 20).toList();
+        expect(authorRow, isNotEmpty, reason: 'no header tap target found');
+        expect(
+          authorRow.every((h) => h >= 48),
+          isTrue,
+          reason: 'header tap targets must be >= 48dp, got $authorRow',
+        );
+      } finally {
+        semantics.dispose();
+      }
+    });
+
     testWidgets('exposes localized semantics label and hint', (tester) async {
       final semantics = tester.ensureSemantics();
       try {

--- a/mobile/test/widgets/video_feed_item/player_gesture_surface_test.dart
+++ b/mobile/test/widgets/video_feed_item/player_gesture_surface_test.dart
@@ -1,0 +1,110 @@
+// ABOUTME: Tests for PlayerGestureSurface — the feed video's tap surface.
+// ABOUTME: Pins that the LABEL and the TAP ACTION land on the same semantics
+// ABOUTME: node, which is what shipped broken and what a device caught.
+
+import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/widgets/video_feed_item/player_gesture_surface.dart';
+
+import '../../helpers/accessibility_guidelines.dart';
+
+void main() {
+  group(PlayerGestureSurface, () {
+    Widget host({required bool interactiveReady, bool isOwnVideo = false}) =>
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: PlayerGestureSurface(
+              interactiveReady: interactiveReady,
+              isOwnVideo: isOwnVideo,
+              onTap: () {},
+              onDoubleTapDown: (_) {},
+              onLongPressStart: () {},
+            ),
+          ),
+        );
+
+    testWidgets('the labelled node is the one that owns the tap action', (
+      tester,
+    ) async {
+      final handle = tester.ensureSemantics();
+      try {
+        await tester.pumpWidget(host(interactiveReady: true));
+        await tester.pump();
+
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        final node = tester.getSemantics(
+          find.bySemanticsLabel(l10n.videoPlayerPlayVideo),
+        );
+
+        // The label used to sit on an ANCESTOR Semantics that owned no tap
+        // action, so the node a screen reader activates was anonymous. On device
+        // that surfaced as SemanticsNode#7(Rect 0,0,440,850, actions: [tap]) with
+        // no label, failing labeledTapTargetGuideline.
+        expect(
+          node.getSemanticsData().hasAction(SemanticsAction.tap),
+          isTrue,
+          reason: 'the labelled node must be the tappable one',
+        );
+        expect(node.hint, equals(l10n.videoPlayerTapHint));
+      } finally {
+        handle.dispose();
+      }
+    });
+
+    testWidgets('omits the double-tap hint on the viewer own video', (
+      tester,
+    ) async {
+      final handle = tester.ensureSemantics();
+      try {
+        await tester.pumpWidget(
+          host(interactiveReady: true, isOwnVideo: true),
+        );
+        await tester.pump();
+
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        final node = tester.getSemantics(
+          find.bySemanticsLabel(l10n.videoPlayerPlayVideo),
+        );
+
+        expect(node.hint, isEmpty);
+      } finally {
+        handle.dispose();
+      }
+    });
+
+    testWidgets('meets the tap-target and labelling guidelines', (
+      tester,
+    ) async {
+      await tester.pumpWidget(host(interactiveReady: true));
+      await tester.pump();
+
+      await expectMeetsAccessibilityGuidelines(
+        tester,
+        guidelines: divineSemanticsGuidelines,
+      );
+    });
+
+    testWidgets('publishes no tap action before the player is ready', (
+      tester,
+    ) async {
+      final handle = tester.ensureSemantics();
+      try {
+        await tester.pumpWidget(host(interactiveReady: false));
+        await tester.pump();
+
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        final node = tester.getSemantics(
+          find.bySemanticsLabel(l10n.videoPlayerPlayVideo),
+        );
+
+        expect(node.getSemanticsData().hasAction(SemanticsAction.tap), isFalse);
+      } finally {
+        handle.dispose();
+      }
+    });
+  });
+}

--- a/mobile/test/widgets/video_feed_item/video_follow_button_test.dart
+++ b/mobile/test/widgets/video_feed_item/video_follow_button_test.dart
@@ -14,6 +14,7 @@ import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/widgets/video_feed_item/video_follow_button.dart';
 
+import '../../helpers/accessibility_guidelines.dart';
 import '../../helpers/test_provider_overrides.dart';
 
 class _MockMyFollowingBloc extends MockBloc<MyFollowingEvent, MyFollowingState>
@@ -54,6 +55,91 @@ void main() {
         ),
       );
     }
+
+    group('accessibility', () {
+      // Keep the subject off the viewport and scrollable edges: Flutter's
+      // tap-target guidelines SKIP boundary-touching nodes, so a flush fixture
+      // passes vacuously and would not catch a regression here.
+      Widget centred(String pubkey) => MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: Center(
+            child: SizedBox(
+              width: 200,
+              height: 200,
+              child: Center(
+                child: BlocProvider<MyFollowingBloc>.value(
+                  value: mockMyFollowingBloc,
+                  child: VideoFollowButtonView(pubkey: pubkey),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      testWidgets('the tap target is 48dp even though the badge paints 20dp', (
+        tester,
+      ) async {
+        when(() => mockMyFollowingBloc.state).thenReturn(
+          const MyFollowingState(status: MyFollowingStatus.success),
+        );
+
+        await tester.pumpWidget(centred(validPubkey('other')));
+        await tester.pump();
+
+        // Asserted on the SIZE, not only through the guideline below: a
+        // guideline can go vacuous if the node stops being reported, an
+        // explicit size cannot. Shipped at Size(20, 20), which failed both
+        // androidTapTargetGuideline (48) and iOSTapTargetGuideline (44) on a
+        // real device.
+        expect(
+          tester.getSize(find.byType(GestureDetector)),
+          const Size(followButtonTapTargetSize, followButtonTapTargetSize),
+        );
+      });
+
+      testWidgets('the painted badge is still 20dp', (tester) async {
+        when(() => mockMyFollowingBloc.state).thenReturn(
+          const MyFollowingState(status: MyFollowingStatus.success),
+        );
+
+        await tester.pumpWidget(centred(validPubkey('other')));
+        await tester.pump();
+
+        // The enlarged target must not enlarge the badge: it sits on the
+        // avatar's corner and its diameter is a design constant.
+        final circle = find.byWidgetPredicate(
+          (widget) =>
+              widget is Container &&
+              widget.decoration is BoxDecoration &&
+              (widget.decoration! as BoxDecoration).shape == BoxShape.circle,
+        );
+
+        expect(circle, findsOneWidget);
+        expect(
+          tester.getSize(circle),
+          const Size(followButtonVisualSize, followButtonVisualSize),
+        );
+      });
+
+      testWidgets('meets the tap-target and labelling guidelines', (
+        tester,
+      ) async {
+        when(() => mockMyFollowingBloc.state).thenReturn(
+          const MyFollowingState(status: MyFollowingStatus.success),
+        );
+
+        await tester.pumpWidget(centred(validPubkey('other')));
+        await tester.pump();
+
+        await expectMeetsAccessibilityGuidelines(
+          tester,
+          guidelines: divineSemanticsGuidelines,
+        );
+      });
+    });
 
     group('button state', () {
       testWidgets('shows follow icon when not following', (tester) async {

--- a/mobile/test/widgets/video_feed_item/video_overlay_actions_follow_target_test.dart
+++ b/mobile/test/widgets/video_feed_item/video_overlay_actions_follow_target_test.dart
@@ -1,0 +1,165 @@
+// ABOUTME: Composition tests for the author cluster inside VideoOverlayActions.
+// ABOUTME: The standalone VideoFollowButtonView tests prove the badge is 48dp,
+// ABOUTME: but only this level can catch parent hit-test clipping or the row
+// ABOUTME: paying for a badge that never draws.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:follow_repository/follow_repository.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/blocs/video_interactions/video_interactions_bloc.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/widgets/user_avatar.dart';
+import 'package:openvine/widgets/video_feed_item/video_feed_item.dart';
+import 'package:openvine/widgets/video_feed_item/video_follow_button.dart';
+import 'package:reposts_repository/reposts_repository.dart';
+
+import '../../builders/test_video_event_builder.dart';
+import '../../helpers/test_provider_overrides.dart';
+
+/// Mirrors `_avatarClusterSize` in video_feed_item.dart: the avatar block the
+/// cluster falls back to when the badge draws nothing.
+const double _avatarClusterSize = 58;
+
+class _MockVideoInteractionsBloc extends Mock
+    implements VideoInteractionsBloc {}
+
+class _MockRepostsRepository extends Mock implements RepostsRepository {}
+
+void main() {
+  group('VideoOverlayActions author cluster', () {
+    late _MockVideoInteractionsBloc interactions;
+    late _MockRepostsRepository reposts;
+
+    setUp(() {
+      interactions = _MockVideoInteractionsBloc();
+      reposts = _MockRepostsRepository();
+      when(() => interactions.stream).thenAnswer((_) => const Stream.empty());
+      when(
+        () => interactions.state,
+      ).thenReturn(const VideoInteractionsState());
+      when(
+        () => reposts.fetchEventReposters(
+          eventId: any(named: 'eventId'),
+          addressableId: any(named: 'addressableId'),
+        ),
+      ).thenAnswer((_) async => const <String>[]);
+    });
+
+    Future<void> pump(
+      WidgetTester tester, {
+      required bool alreadyFollowing,
+    }) async {
+      // The shared helper stubs watchMyFollowingCached to an EMPTY stream, so
+      // MyFollowingBloc never leaves `loading` and the badge stays collapsed.
+      // Yield one snapshot so `isReady` becomes true and the badge really draws.
+      final follow = createMockFollowRepository();
+      when(() => follow.isFollowing(any())).thenReturn(alreadyFollowing);
+      when(follow.watchMyFollowingCached).thenAnswer(
+        (_) => Stream.value(
+          const CacheResult<FollowingSnapshot>.live(
+            FollowingSnapshot(pubkeys: <String>[], count: 0),
+          ),
+        ),
+      );
+      final overrides = <dynamic>[
+        repostsRepositoryProvider.overrideWithValue(reposts),
+      ];
+
+      await tester.pumpWidget(
+        testProviderScope(
+          additionalOverrides: overrides,
+          // Via the named parameter, not additionalOverrides: the helper always
+          // overrides followRepositoryProvider, and Riverpod rejects a second
+          // override of the same provider in one container.
+          mockFollowRepository: follow,
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: BlocProvider<VideoInteractionsBloc>.value(
+                value: interactions,
+                child: VideoOverlayActions(
+                  video: TestVideoEventBuilder.create(),
+                  isVisible: true,
+                  isActive: true,
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump();
+    }
+
+    /// The Stack that holds the avatar and, when it draws, the follow badge.
+    Finder cluster() => find
+        .ancestor(of: find.byType(UserAvatar), matching: find.byType(Stack))
+        .first;
+
+    testWidgets('does not grow when the badge does not draw', (tester) async {
+      await pump(tester, alreadyFollowing: true);
+
+      // The widget is always CONSTRUCTED; what matters is that it draws
+      // nothing and therefore occupies nothing.
+      expect(tester.getSize(find.byType(VideoFollowButton)), Size.zero);
+
+      // So the badge's 48dp target costs no height in the states where it
+      // renders nothing — loading, already following, own video, blocked
+      // author, preview mode. Before this, all of them paid 21dp.
+      expect(tester.getSize(cluster()).height, _avatarClusterSize);
+      expect(tester.getSize(cluster()).width, _avatarClusterSize);
+    });
+
+    testWidgets('the badge footprint is not clipped by its parent', (
+      tester,
+    ) async {
+      await pump(tester, alreadyFollowing: false);
+
+      final badge = find.byType(VideoFollowButton);
+      if (badge.evaluate().isEmpty) {
+        // The badge only draws once MyFollowingBloc reports success; if this
+        // fixture never gets there the test would assert nothing, so say so
+        // rather than passing vacuously.
+        fail('follow badge did not render — fixture cannot prove clipping');
+      }
+
+      final parent = tester.getRect(cluster());
+      final footprint = tester.getRect(badge);
+
+      // Flutter rejects a hit outside a box BEFORE it reaches the child, and
+      // `Clip.none` only affects painting. If the parent were still 58 the
+      // badge's enlarged target would be silently clipped back to 27dp, and
+      // the standalone widget test could not see it.
+      expect(footprint.right, lessThanOrEqualTo(parent.right));
+      expect(footprint.bottom, lessThanOrEqualTo(parent.bottom));
+      expect(footprint.width, followButtonFootprint);
+    });
+
+    testWidgets('the badge semantics node is a 48dp labelled target', (
+      tester,
+    ) async {
+      await pump(tester, alreadyFollowing: false);
+
+      final node = tester.getSemantics(
+        find.byWidgetPredicate(
+          (widget) =>
+              widget is Semantics &&
+              widget.properties.identifier == 'follow_button',
+        ),
+      );
+
+      // Asserted on this node rather than through meetsGuideline over the whole
+      // overlay: the video title is still a 66.7x16 tap target, which is the
+      // caption sizing left for design, so the overlay as a whole cannot pass
+      // the tap-target guideline until that lands. Scoping keeps this test
+      // about the badge instead of silently tracking someone else's decision.
+      expect(node.rect.width, greaterThanOrEqualTo(48));
+      expect(node.rect.height, greaterThanOrEqualTo(48));
+      expect(node.label, isNotEmpty);
+    });
+  });
+}


### PR DESCRIPTION
Closes #8103

**Four** accessibility defects on the live feed, found by running Flutter's
accessibility guidelines against the real app on an **iPhone 17 Pro Max /
iOS 26.6.1**. Three are fixed here; the fourth — caption sizing — is escalated
below. (The opening previously said "three found, two fixed"; that was wrong.)

Found while patrolling #3340. `mobile/test/widget/tdd/accessibility_ui_test.dart`
had a group named **"Touch and Gesture Accessibility Requirements"** and all 38
of its tests were `expect(true, isTrue)`. App-layer guideline coverage is 3 of
558 screen/widget test files, so nothing else was watching either.

## What the device reported

```
SemanticsNode#9(..., identifier: "follow_button", label: "Follow"):
  expected tap target size of at least Size(48.0, 48.0), but found Size(20.0, 20.0)
SemanticsNode#10(..., label: "11h ago"):
  expected tap target size of at least Size(48.0, 48.0), but found Size(280.0, 44.0)
SemanticsNode#7(Rect.fromLTRB(0.0, 0.0, 440.0, 850.0), actions: [tap]):
  expected tappable node to have semantic label, but none was found
```

## 1. follow_button — 20×20

A primary action on the main feed, under half of **both** platform minimums
(Android 48, iOS 44). `.claude/rules/accessibility.md`: *"Minimum touch target
size is 48x48 dp."*

Target is now 48dp; the badge still **paints at 20dp in the same place**.

It grows down-and-end rather than centring, and that matters: the badge sits on
the avatar's trailing-bottom corner, so a centred 48dp target would span 10..58
of the 48dp avatar — **swallowing 63% of it** and sending profile taps to
Follow. Growing away leaves a 17×17 overlap.

The parent Stack grows 58 → 79 to match. Load-bearing, not cosmetic: Flutter
rejects a hit outside a box *before* it reaches the child, and `Clip.none` only
affects painting — left at 58 the enlarged hit area would be silently clipped
back to 27dp. **Cost: the author row is ~21dp taller.**

## 2. Author name/meta column — 280×44

Failed the Android 48 guideline. Wrapped in `ConstrainedBox(minHeight: 48)` —
minHeight, not fixed, so it still grows with system font scale — plus
`HitTestBehavior.opaque` so the added padding is tappable. Fits the existing
box, so **nothing moves**.

## 3. Full-screen tappable with no label

Not a missing label — a **misplaced** one. `Semantics(button: true, label:
videoPlayerPlayVideo)` wrapped the whole Stack while the tap action sat on a
GestureDetector several layers below: two nodes, one with the name and no
action, one with the action and no name.

Moving it down was not enough. `Semantics` defaults to `container: false`, which
still produced a separate annotation node — dumping the live tree showed exactly
that: `label="Play video" tap=false`. So it is wrapped in `MergeSemantics`.

Merging is safe **here specifically** because the chrome layers are Stack
*siblings* of the gesture surface, not descendants — a deliberate choice already
documented in that file. Nothing else is flattened in.

That same dump showed the app-wide pattern is an outer descriptive label plus an
inner node carrying the action (`"Like video"` / `"Like"`). Every other inner
node has a label; the player surface was the only one that did not.

## Not fixed — escalated

**The video title and description are tappable at 248.7×18.** Reaching 48dp each
would add ~30dp per caption, pushing the bottom overlay up and covering
noticeably more video on every item. ~~They already carry correct `Semantics(button, label)` — only size
fails.~~ **Correction:** true of the title, wrong for the description — its
tappable node carries no label at all whenever the text holds a link. Fixed
separately in #8144; measurements in the device-patrol comment below. Only
the *sizing* of both is left for design. That is a design trade, not a bug
fix, so it is left for design rather than decided here.

## Verification

**On the real device (iPhone 17 Pro Max / iOS 26.6.1):**

```
DEVA11Y SIZE | tapTarget=Size(48.0, 48.0) paint=Size(20.0, 20.0)
DEVA11Y PASS | VideoFollowButtonView | androidTapTarget48
DEVA11Y PASS | VideoFollowButtonView | iOSTapTarget44
DEVA11Y PASS | VideoFollowButtonView | labeledTapTarget
```

Fix 1 confirmed on device: target 48dp, badge still painting 20dp.

**Author row**, measured from the live semantics tree after the fix:
`label="Jan 1, 2024" h=48.0` — was `Size(280.0, 44.0)` on device. Every
action-rail button measures a clean 48x48. The video title still measures
`h=16.0`, matching the escalation above.

**Gates:** `flutter analyze lib test integration_test` clean;
`flutter test test/widgets/video_feed_item/` — **399 pass**; format clean.

**Tests, both mutation-checked** — the strongest thing I can say about them is
that I proved they fail:

- `video_follow_button_test` — three tests in a **centred** fixture, because
  Flutter's tap-target guidelines SKIP boundary-touching nodes and a flush
  fixture passes vacuously. They assert the 48dp target and the 20dp paint size
  **explicitly**, not only through the guideline: a guideline can go vacuous if
  the node stops being reported, a size cannot. Shrinking the target back to
  20dp turns two of them red.
- `feed_videos_test` — walks the semantics subtree under `FeedVideos` and
  asserts every wide header tappable is >= 48dp, rather than matching a label
  (the meta line's text is date-dependent). Dropping the minHeight constraint
  puts a `40.0` node in the list and turns it red.

### One gap, stated plainly

Fix 3 has **no widget-level regression test**. `isReady` gates the tap action on
a controller with a rendered first frame, `FeedVideos` takes no controller (it
comes from an internal pool), and nothing in `feed_videos_test` can make the
surface interactive — the two existing semantics tests there pass either way,
since they only prove *some* node carries the label. Covering it needs a fake
player pool in that harness; that is its own change.

I also could not re-sweep the **authenticated feed** on device after the fix,
and the reason is worth recording: `authentication_source` lives in
SharedPreferences (`auth_service.dart:1441`), which a reinstall wipes, while the
nsec lives in the keychain under `first_unlock`, which survives. Every
`flutter test integration_test` reinstalls, so it always boots
`AuthenticationSource.none` and redirects to `/welcome`. Fixes 1 and 2 were
therefore verified by pumping the widgets directly on the device instead.

The probe prints the router's real location for exactly this reason — an earlier
sweep that looked like it covered eight surfaces had in fact been redirected to
one, and the location line is what caught it.


---

## Review response (pullrequestreview-5011658796)

**Fixed — 1, 2, 3, 4, 5, 6.**

- **1** The cluster no longer grows for a badge that does not draw. The badge
  owns its footprint and is a NON-positioned Stack child, so the Stack sizes
  from it and collapses to the avatar block when hidden; a positioned child
  contributes nothing to a Stack's size, which is why the old shape could not
  shrink. A `ConstrainedBox` floors it at the pre-existing 58.
- **2** `Row` is explicitly start-aligned and the text column is constrained to
  the same avatar block and centred inside it, so the text no longer sinks.
- **3** The property-less `Semantics` wrapper is gone; its sibling-layout note
  moved onto the `Stack` it describes.
- **4** Constants moved above the class dartdoc.
- **5** New `video_overlay_actions_follow_target_test.dart` covers the real
  composition in both states. Mutation-checked: pinning the cluster back to 58
  makes the footprint 58 instead of 79 and turns the clipping test red.
- **6** `PlayerGestureSurface` extracted, so `interactiveReady` is a parameter
  and the labelling is testable without a player pool.

**Correction to my own diagnosis.** I had said `MergeSemantics` was what put the
label on the tappable node. It is not — a mutation removing it changes nothing
once the widget is extracted. The real problem was DISTANCE: the annotation sat
several layers up, wrapping the chrome siblings, so it annotated a node owning
no tap action. `MergeSemantics` is removed and the pinning test is mutation-
checked against the shape that actually shipped.

### Before/after, rendered

| state | pixels changed vs `origin/main` |
|---|---|
| badge **absent** | **0 / 480000 — pixel-identical**, bbox `None` |
| badge **present** | 5827 / 480000 (1.21%), bbox `(16,457)-(207,530)` — author cluster only |

**7 — disclosed.** `HitTestBehavior.opaque` makes the whole author strip
navigate to the profile rather than only the painted glyphs. It widens an
existing target and adds no new destination, and the code says so.

**8 — needs design, and the render makes the case concrete.** In the
badge-present capture the cluster grows 21dp **wider** as well as taller, so the
author name shifts right and leaves a visible gap: the tap target reaches x=79
while nothing is painted past x=51. That is the "visually blank yet
relay-writing" region, measured. There is no geometry that reaches 48dp without
it — extending toward the avatar instead would swallow 63% of a 48dp avatar and
send profile taps to Follow.

So this is a real fork for design: accept a 21dp taller/wider author row, enlarge
the painted badge so the affordance matches its target, or drop the follow-badge
change and keep only the author-row and player-surface fixes, which carry no
visual cost. I have not picked one.
