### PR TITLE
fix(auth): make signed-out support reachable

### DIFF
--- a/mobile/lib/router/app_router_redirect.dart
+++ b/mobile/lib/router/app_router_redirect.dart
@@ -364,6 +364,7 @@ String? appRouterRedirect(Ref ref, GoRouterState state) {
       location == SupportCenterScreen.path ||
       location == BugReportScreen.path ||
       location == FeatureRequestScreen.path;
+  final isPublicSupportRoute = location == SupportCenterScreen.path;
   final isModerationConversationRoute =
       moderationConversationId != null &&
       location == ConversationPage.pathForId(moderationConversationId);
@@ -521,6 +522,7 @@ String? appRouterRedirect(Ref ref, GoRouterState state) {
   // awaitingTosAcceptance has no dedicated screen, so treat it like
   // unauthenticated.
   if (!isAuthRoute &&
+      !isPublicSupportRoute &&
       !_isPublicRecorderLocation(location) &&
       (authState == AuthState.unauthenticated ||
           authState == AuthState.awaitingTosAcceptance)) {

--- a/mobile/lib/screens/auth/login_options_screen.dart
+++ b/mobile/lib/screens/auth/login_options_screen.dart
@@ -21,6 +21,7 @@ import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/screens/auth/email_verification_screen.dart';
 import 'package:openvine/screens/auth/nostr_connect_screen.dart';
 import 'package:openvine/screens/key_import_screen.dart';
+import 'package:openvine/screens/settings/support_center_screen.dart';
 import 'package:openvine/utils/validators.dart';
 import 'package:openvine/widgets/auth/auth_error_box.dart';
 import 'package:openvine/widgets/auth/forgot_password_dialog.dart';
@@ -482,7 +483,17 @@ class _SignInContentState extends ConsumerState<_SignInContent> {
                     ),
                   ),
                 ),
-                const SizedBox(height: 32),
+                const SizedBox(height: 8),
+                Center(
+                  child: DivineButton(
+                    type: .link,
+                    label: context.l10n.authContactSupport,
+                    onPressed: isDisabled
+                        ? null
+                        : () => context.push(SupportCenterScreen.path),
+                  ),
+                ),
+                const SizedBox(height: 24),
 
                 // Push alternative methods to bottom
                 const Spacer(),

--- a/mobile/lib/screens/settings/support_center_screen.dart
+++ b/mobile/lib/screens/settings/support_center_screen.dart
@@ -13,6 +13,7 @@ import 'package:openvine/router/route_paths.dart';
 import 'package:openvine/screens/auth/welcome_screen.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/bug_report_service.dart';
+import 'package:openvine/services/support_email_composer.dart';
 import 'package:openvine/services/zendesk_support_service.dart';
 import 'package:openvine/utils/share_position_origin.dart';
 import 'package:openvine/widgets/bug_report_dialog.dart';
@@ -24,7 +25,9 @@ class SupportCenterScreen extends ConsumerWidget {
   static const routeName = 'support-center';
   static const String path = RoutePaths.supportCenter;
 
-  const SupportCenterScreen({super.key});
+  const SupportCenterScreen({this.composeEmail, super.key});
+
+  final SupportEmailCompose? composeEmail;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -48,13 +51,12 @@ class SupportCenterScreen extends ConsumerWidget {
           constraints: const BoxConstraints(maxWidth: 600),
           child: ListView(
             children: [
-              if (ZendeskSupportService.isAvailable)
-                _SupportTile(
-                  icon: DivineIconName.chat,
-                  title: l10n.supportContactSupport,
-                  subtitle: l10n.supportContactSupportSubtitle,
-                  onTap: () => _viewSupportMessages(context),
-                ),
+              _SupportTile(
+                icon: DivineIconName.chat,
+                title: l10n.supportContactSupport,
+                subtitle: l10n.supportContactSupportSubtitle,
+                onTap: () => _contactSupport(context),
+              ),
               if (isAuthenticated)
                 _SupportTile(
                   icon: DivineIconName.warningCircle,
@@ -241,6 +243,21 @@ class SupportCenterScreen extends ConsumerWidget {
         ),
       );
     }
+  }
+
+  Future<void> _contactSupport(BuildContext context) async {
+    if (ZendeskSupportService.isAvailable) {
+      await _viewSupportMessages(context);
+      return;
+    }
+
+    final sharePositionOrigin = shareAnchorForContext(context);
+    await (composeEmail ?? SupportEmailComposer().compose)(
+      toEmail: AppConstants.supportEmail,
+      subject: context.l10n.supportContactSupport,
+      body: '',
+      sharePositionOrigin: sharePositionOrigin,
+    );
   }
 
   Future<void> _launchUrl(

--- a/mobile/lib/screens/settings/support_center_screen.dart
+++ b/mobile/lib/screens/settings/support_center_screen.dart
@@ -6,9 +6,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:openvine/constants/app_constants.dart';
+import 'package:openvine/extensions/safe_pop_extension.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/router/route_paths.dart';
+import 'package:openvine/screens/auth/welcome_screen.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/bug_report_service.dart';
 import 'package:openvine/services/zendesk_support_service.dart';
@@ -37,7 +39,7 @@ class SupportCenterScreen extends ConsumerWidget {
       appBar: DiVineAppBar(
         title: l10n.supportTitle,
         showBackButton: true,
-        onBackPressed: context.pop,
+        onBackPressed: () => context.safePop(fallback: WelcomeScreen.path),
       ),
       backgroundColor: context.vineColors.background,
       body: Align(
@@ -60,12 +62,13 @@ class SupportCenterScreen extends ConsumerWidget {
                 onTap: () =>
                     _showBugReport(context, bugReportService, userPubkey),
               ),
-              _SupportTile(
-                icon: DivineIconName.sparkle,
-                title: l10n.supportRequestFeature,
-                subtitle: l10n.supportRequestFeatureSubtitle,
-                onTap: () => _showFeatureRequest(context),
-              ),
+              if (isAuthenticated)
+                _SupportTile(
+                  icon: DivineIconName.sparkle,
+                  title: l10n.supportRequestFeature,
+                  subtitle: l10n.supportRequestFeatureSubtitle,
+                  onTap: () => _showFeatureRequest(context),
+                ),
               _SupportTile(
                 icon: DivineIconName.save,
                 title: l10n.supportSaveLogs,

--- a/mobile/lib/screens/settings/support_center_screen.dart
+++ b/mobile/lib/screens/settings/support_center_screen.dart
@@ -25,9 +25,14 @@ class SupportCenterScreen extends ConsumerWidget {
   static const routeName = 'support-center';
   static const String path = RoutePaths.supportCenter;
 
-  const SupportCenterScreen({this.composeEmail, super.key});
+  const SupportCenterScreen({
+    this.composeEmail,
+    this.openZendeskSupport,
+    super.key,
+  });
 
   final SupportEmailCompose? composeEmail;
+  final Future<bool> Function()? openZendeskSupport;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -222,42 +227,42 @@ class SupportCenterScreen extends ConsumerWidget {
     }
   }
 
-  Future<void> _viewSupportMessages(BuildContext context) async {
-    if (!ZendeskSupportService.isAvailable) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        DivineSnackbarContainer.snackBar(
-          context.l10n.supportChatNotAvailable,
-          error: true,
-        ),
-      );
-      return;
-    }
-
+  Future<bool> _viewSupportMessages() async {
     // JWT refresh is handled internally by showTicketListScreen via _ensureFreshJwt
-    final shown = await ZendeskSupportService.showTicketListScreen();
-    if (!shown && context.mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        DivineSnackbarContainer.snackBar(
-          context.l10n.supportCouldNotOpenMessages,
-          error: true,
-        ),
-      );
-    }
+    return ZendeskSupportService.showTicketListScreen();
   }
 
   Future<void> _contactSupport(BuildContext context) async {
-    if (ZendeskSupportService.isAvailable) {
-      await _viewSupportMessages(context);
-      return;
+    final l10n = context.l10n;
+    var emailBody = l10n.supportContactSupportSubtitle;
+    final openZendesk =
+        openZendeskSupport ??
+        (ZendeskSupportService.isAvailable ? _viewSupportMessages : null);
+    if (openZendesk != null) {
+      if (await openZendesk()) return;
+      emailBody = '${l10n.supportCouldNotOpenMessages}\n\n$emailBody';
+    } else {
+      emailBody = '${l10n.supportChatNotAvailable}\n\n$emailBody';
     }
+    if (!context.mounted) return;
 
     final sharePositionOrigin = shareAnchorForContext(context);
-    await (composeEmail ?? SupportEmailComposer().compose)(
-      toEmail: AppConstants.supportEmail,
-      subject: context.l10n.supportContactSupport,
-      body: '',
-      sharePositionOrigin: sharePositionOrigin,
-    );
+    try {
+      await (composeEmail ?? SupportEmailComposer().compose)(
+        toEmail: AppConstants.supportEmail,
+        subject: l10n.supportContactSupport,
+        body: emailBody,
+        sharePositionOrigin: sharePositionOrigin,
+      );
+    } catch (_) {
+      if (!context.mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        DivineSnackbarContainer.snackBar(
+          l10n.authCouldNotOpenEmail(AppConstants.supportEmail),
+          error: true,
+        ),
+      );
+    }
   }
 
   Future<void> _launchUrl(

--- a/mobile/lib/screens/settings/support_center_screen.dart
+++ b/mobile/lib/screens/settings/support_center_screen.dart
@@ -55,13 +55,14 @@ class SupportCenterScreen extends ConsumerWidget {
                   subtitle: l10n.supportContactSupportSubtitle,
                   onTap: () => _viewSupportMessages(context),
                 ),
-              _SupportTile(
-                icon: DivineIconName.warningCircle,
-                title: l10n.supportReportBug,
-                subtitle: l10n.supportReportBugSubtitle,
-                onTap: () =>
-                    _showBugReport(context, bugReportService, userPubkey),
-              ),
+              if (isAuthenticated)
+                _SupportTile(
+                  icon: DivineIconName.warningCircle,
+                  title: l10n.supportReportBug,
+                  subtitle: l10n.supportReportBugSubtitle,
+                  onTap: () =>
+                      _showBugReport(context, bugReportService, userPubkey),
+                ),
               if (isAuthenticated)
                 _SupportTile(
                   icon: DivineIconName.sparkle,

--- a/mobile/lib/services/support_email_composer.dart
+++ b/mobile/lib/services/support_email_composer.dart
@@ -15,6 +15,14 @@ typedef ShareTextLauncher =
       Rect? sharePositionOrigin,
     });
 
+typedef SupportEmailCompose =
+    Future<void> Function({
+      required String toEmail,
+      required String subject,
+      required String body,
+      Rect? sharePositionOrigin,
+    });
+
 String _buildFallbackShareText({
   required String toEmail,
   required String subject,

--- a/mobile/lib/services/zendesk_support_service.dart
+++ b/mobile/lib/services/zendesk_support_service.dart
@@ -235,7 +235,9 @@ class ZendeskSupportService {
     await _awaitInitialization();
 
     if (!_initialized) return false;
-    if (_userName == null || _userEmail == null) return false;
+    if (_userName == null || _userEmail == null) {
+      return setAnonymousIdentity();
+    }
 
     try {
       await _channel.invokeMethod('setUserIdentity', {
@@ -279,20 +281,21 @@ class ZendeskSupportService {
   ///
   /// Sets a plain anonymous identity without name/email so Zendesk widget works.
   /// Should be called before showing ticket screens if user is not logged in.
-  static Future<void> setAnonymousIdentity() async {
-    if (_initialized) {
-      try {
-        await _channel.invokeMethod('setAnonymousIdentity');
-        Log.info(
-          'Zendesk anonymous identity set',
-          category: LogCategory.system,
-        );
-      } catch (e) {
-        Log.warning(
-          'Error setting Zendesk anonymous identity: $e',
-          category: LogCategory.system,
-        );
-      }
+  static Future<bool> setAnonymousIdentity() async {
+    if (!_initialized) return false;
+    try {
+      await _channel.invokeMethod('setAnonymousIdentity');
+      Log.info(
+        'Zendesk anonymous identity set',
+        category: LogCategory.system,
+      );
+      return true;
+    } catch (e) {
+      Log.warning(
+        'Error setting Zendesk anonymous identity: $e',
+        category: LogCategory.system,
+      );
+      return false;
     }
   }
 

--- a/mobile/lib/services/zendesk_support_service.dart
+++ b/mobile/lib/services/zendesk_support_service.dart
@@ -298,6 +298,7 @@ class ZendeskSupportService {
     }
   }
 
+  // Ticket history may open signed out; ticket creation still needs requester info.
   static Future<bool> _setAvailableAnonymousIdentity() {
     if (_userName != null && _userEmail != null) {
       return setAnonymousIdentityWithUserInfo();

--- a/mobile/lib/services/zendesk_support_service.dart
+++ b/mobile/lib/services/zendesk_support_service.dart
@@ -235,9 +235,7 @@ class ZendeskSupportService {
     await _awaitInitialization();
 
     if (!_initialized) return false;
-    if (_userName == null || _userEmail == null) {
-      return setAnonymousIdentity();
-    }
+    if (_userName == null || _userEmail == null) return false;
 
     try {
       await _channel.invokeMethod('setUserIdentity', {
@@ -282,6 +280,7 @@ class ZendeskSupportService {
   /// Sets a plain anonymous identity without name/email so Zendesk widget works.
   /// Should be called before showing ticket screens if user is not logged in.
   static Future<bool> setAnonymousIdentity() async {
+    await _awaitInitialization();
     if (!_initialized) return false;
     try {
       await _channel.invokeMethod('setAnonymousIdentity');
@@ -297,6 +296,13 @@ class ZendeskSupportService {
       );
       return false;
     }
+  }
+
+  static Future<bool> _setAvailableAnonymousIdentity() {
+    if (_userName != null && _userEmail != null) {
+      return setAnonymousIdentityWithUserInfo();
+    }
+    return setAnonymousIdentity();
   }
 
   // ==========================================================================
@@ -567,7 +573,7 @@ class ZendeskSupportService {
 
     final jwtReady = await _ensureFreshJwt();
     if (!jwtReady) {
-      await setAnonymousIdentityWithUserInfo();
+      await _setAvailableAnonymousIdentity();
     }
 
     try {
@@ -587,7 +593,7 @@ class ZendeskSupportService {
           'Retrying ticket list with anonymous identity fallback',
           category: LogCategory.system,
         );
-        final identitySet = await setAnonymousIdentityWithUserInfo();
+        final identitySet = await _setAvailableAnonymousIdentity();
         if (identitySet) {
           try {
             await _channel.invokeMethod('showTicketList');

--- a/mobile/scripts/baseline/unsafe_back_pops.txt
+++ b/mobile/scripts/baseline/unsafe_back_pops.txt
@@ -38,6 +38,5 @@ lib/screens/settings/nip05_settings_screen.dart	2
 lib/screens/settings/nostr_settings_screen.dart	1
 lib/screens/settings/settings_screen.dart	1
 lib/screens/settings/storage/storage_management_page.dart	1
-lib/screens/settings/support_center_screen.dart	1
 lib/screens/user_list_people_screen.dart	2
 lib/screens/video_engagement/video_engagement_list_view.dart	1

--- a/mobile/test/router/app_router_redirect_test.dart
+++ b/mobile/test/router/app_router_redirect_test.dart
@@ -17,6 +17,7 @@ import 'package:openvine/screens/feed/video_feed_page.dart';
 import 'package:openvine/screens/minor_account_review_screen.dart';
 import 'package:openvine/screens/settings/support_center_screen.dart';
 import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/widgets/feature_request_dialog.dart';
 
 class _MockAuthService extends Mock implements AuthService {}
 
@@ -300,10 +301,13 @@ void main() {
   });
 
   group('signed-out support access', () {
-    test('keeps the Support Center reachable while unauthenticated', () async {
+    Future<String?> redirectFor({
+      required AuthState authState,
+      required String location,
+    }) async {
       resetNavigationState();
       final authService = _MockAuthService();
-      when(() => authService.authState).thenReturn(AuthState.unauthenticated);
+      when(() => authService.authState).thenReturn(authState);
 
       final container = ProviderContainer(
         overrides: [
@@ -321,13 +325,40 @@ void main() {
       await container.read(currentMinorAccountReviewStatusProvider.future);
 
       final state = _MockGoRouterState();
-      final uri = Uri.parse(SupportCenterScreen.path);
+      final uri = Uri.parse(location);
       when(() => state.uri).thenReturn(uri);
       when(() => state.matchedLocation).thenReturn(uri.path);
 
+      return appRouterRedirect(container.read(_refProbeProvider), state);
+    }
+
+    test('keeps the Support Center reachable while unauthenticated', () async {
       expect(
-        appRouterRedirect(container.read(_refProbeProvider), state),
+        await redirectFor(
+          authState: AuthState.unauthenticated,
+          location: SupportCenterScreen.path,
+        ),
         isNull,
+      );
+    });
+
+    test('keeps the Support Center reachable while awaiting TOS', () async {
+      expect(
+        await redirectFor(
+          authState: AuthState.awaitingTosAcceptance,
+          location: SupportCenterScreen.path,
+        ),
+        isNull,
+      );
+    });
+
+    test('keeps signed-out feature requests behind the auth gate', () async {
+      expect(
+        await redirectFor(
+          authState: AuthState.unauthenticated,
+          location: FeatureRequestScreen.path,
+        ),
+        '/welcome',
       );
     });
   });

--- a/mobile/test/router/app_router_redirect_test.dart
+++ b/mobile/test/router/app_router_redirect_test.dart
@@ -13,6 +13,7 @@ import 'package:openvine/providers/auth_providers.dart';
 import 'package:openvine/providers/minor_account_review_providers.dart';
 import 'package:openvine/router/app_router.dart';
 import 'package:openvine/router/providers/redirect_provider.dart';
+import 'package:openvine/screens/auth/welcome_screen.dart';
 import 'package:openvine/screens/feed/video_feed_page.dart';
 import 'package:openvine/screens/minor_account_review_screen.dart';
 import 'package:openvine/screens/settings/support_center_screen.dart';
@@ -359,7 +360,7 @@ void main() {
           authState: AuthState.unauthenticated,
           location: FeatureRequestScreen.path,
         ),
-        '/welcome',
+        WelcomeScreen.path,
       );
     });
 
@@ -369,7 +370,7 @@ void main() {
           authState: AuthState.unauthenticated,
           location: BugReportScreen.path,
         ),
-        '/welcome',
+        WelcomeScreen.path,
       );
     });
   });

--- a/mobile/test/router/app_router_redirect_test.dart
+++ b/mobile/test/router/app_router_redirect_test.dart
@@ -17,6 +17,7 @@ import 'package:openvine/screens/feed/video_feed_page.dart';
 import 'package:openvine/screens/minor_account_review_screen.dart';
 import 'package:openvine/screens/settings/support_center_screen.dart';
 import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/widgets/bug_report_dialog.dart';
 import 'package:openvine/widgets/feature_request_dialog.dart';
 
 class _MockAuthService extends Mock implements AuthService {}
@@ -357,6 +358,16 @@ void main() {
         await redirectFor(
           authState: AuthState.unauthenticated,
           location: FeatureRequestScreen.path,
+        ),
+        '/welcome',
+      );
+    });
+
+    test('keeps signed-out bug reports behind the auth gate', () async {
+      expect(
+        await redirectFor(
+          authState: AuthState.unauthenticated,
+          location: BugReportScreen.path,
         ),
         '/welcome',
       );

--- a/mobile/test/router/app_router_redirect_test.dart
+++ b/mobile/test/router/app_router_redirect_test.dart
@@ -15,6 +15,7 @@ import 'package:openvine/router/app_router.dart';
 import 'package:openvine/router/providers/redirect_provider.dart';
 import 'package:openvine/screens/feed/video_feed_page.dart';
 import 'package:openvine/screens/minor_account_review_screen.dart';
+import 'package:openvine/screens/settings/support_center_screen.dart';
 import 'package:openvine/services/auth_service.dart';
 
 class _MockAuthService extends Mock implements AuthService {}
@@ -296,5 +297,38 @@ void main() {
         expect(result, MinorAccountReviewScreen.path);
       },
     );
+  });
+
+  group('signed-out support access', () {
+    test('keeps the Support Center reachable while unauthenticated', () async {
+      resetNavigationState();
+      final authService = _MockAuthService();
+      when(() => authService.authState).thenReturn(AuthState.unauthenticated);
+
+      final container = ProviderContainer(
+        overrides: [
+          authServiceProvider.overrideWithValue(authService),
+          currentAccountDeletionAttemptProvider.overrideWith(
+            (ref) async => null,
+          ),
+          currentMinorAccountReviewStatusProvider.overrideWith(
+            (ref) async => MinorAccountReviewStatus.active(),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      await container.read(currentAccountDeletionAttemptProvider.future);
+      await container.read(currentMinorAccountReviewStatusProvider.future);
+
+      final state = _MockGoRouterState();
+      final uri = Uri.parse(SupportCenterScreen.path);
+      when(() => state.uri).thenReturn(uri);
+      when(() => state.matchedLocation).thenReturn(uri.path);
+
+      expect(
+        appRouterRedirect(container.read(_refProbeProvider), state),
+        isNull,
+      );
+    });
   });
 }

--- a/mobile/test/screens/auth/login_options_screen_test.dart
+++ b/mobile/test/screens/auth/login_options_screen_test.dart
@@ -15,6 +15,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/screens/auth/login_options_screen.dart';
+import 'package:openvine/screens/settings/support_center_screen.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/pending_verification_service.dart';
 import 'package:openvine/widgets/auth_back_button.dart';
@@ -88,6 +89,10 @@ void main() {
               path: '/verify-email',
               builder: (_, _) =>
                   const Scaffold(body: Text('Email Verification')),
+            ),
+            GoRoute(
+              path: SupportCenterScreen.path,
+              builder: (_, _) => const Scaffold(body: Text('Support Center')),
             ),
           ],
         ),
@@ -209,6 +214,16 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(find.text('Forgot password?'), findsOneWidget);
+      });
+
+      testWidgets('displays contact support link', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        expect(
+          find.widgetWithText(DivineButton, 'Contact support'),
+          findsOneWidget,
+        );
       });
 
       testWidgets('displays Import Nostr key button', (tester) async {
@@ -352,6 +367,18 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(find.text('Reset Password'), findsOneWidget);
+      });
+
+      testWidgets('tapping contact support opens the Support Center', (
+        tester,
+      ) async {
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.widgetWithText(DivineButton, 'Contact support'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Support Center'), findsOneWidget);
       });
 
       testWidgets('failed password reset keeps dialog open without success', (

--- a/mobile/test/screens/settings/support_center_screen_test.dart
+++ b/mobile/test/screens/settings/support_center_screen_test.dart
@@ -12,6 +12,7 @@ import 'package:openvine/screens/settings/support_center_screen.dart';
 import 'package:openvine/services/account_deletion_service.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/bug_report_service.dart';
+import 'package:openvine/services/support_email_composer.dart';
 import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
 
 import '../../helpers/url_launcher_test_double.dart';
@@ -44,6 +45,7 @@ void main() {
       WidgetTester tester, {
       AuthState authState = AuthState.authenticated,
       Locale locale = const Locale('en'),
+      SupportEmailCompose? composeEmail,
     }) async {
       await tester.pumpWidget(
         ProviderScope(
@@ -64,7 +66,7 @@ void main() {
             locale: locale,
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,
-            home: const SupportCenterScreen(),
+            home: SupportCenterScreen(composeEmail: composeEmail),
           ),
         ),
       );
@@ -143,6 +145,33 @@ void main() {
 
       expect(find.text(en.supportReportBug), findsNothing);
       expect(find.text(en.supportRequestFeature), findsNothing);
+    });
+
+    testWidgets('opens email support when Zendesk is unavailable', (
+      tester,
+    ) async {
+      String? capturedToEmail;
+      String? capturedSubject;
+      await pump(
+        tester,
+        authState: AuthState.unauthenticated,
+        composeEmail:
+            ({
+              required String toEmail,
+              required String subject,
+              required String body,
+              Rect? sharePositionOrigin,
+            }) async {
+              capturedToEmail = toEmail;
+              capturedSubject = subject;
+            },
+      );
+
+      await tester.tap(find.text(en.supportContactSupport));
+      await tester.pumpAndSettle();
+
+      expect(capturedToEmail, AppConstants.supportEmail);
+      expect(capturedSubject, en.supportContactSupport);
     });
 
     // The row existing is not the feature; reaching the confirmation gate is.

--- a/mobile/test/screens/settings/support_center_screen_test.dart
+++ b/mobile/test/screens/settings/support_center_screen_test.dart
@@ -13,6 +13,7 @@ import 'package:openvine/services/account_deletion_service.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/bug_report_service.dart';
 import 'package:openvine/services/support_email_composer.dart';
+import 'package:openvine/services/zendesk_support_service.dart';
 import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
 
 import '../../helpers/url_launcher_test_double.dart';
@@ -35,17 +36,21 @@ void main() {
     final en = lookupAppLocalizations(const Locale('en'));
 
     setUp(() {
+      ZendeskSupportService.resetForTesting();
       authService = _MockAuthService();
       bugReportService = _MockBugReportService();
       accountDeletionService = _MockAccountDeletionService();
       when(() => authService.currentPublicKeyHex).thenReturn(_pubkeyHex);
     });
 
+    tearDown(ZendeskSupportService.resetForTesting);
+
     Future<void> pump(
       WidgetTester tester, {
       AuthState authState = AuthState.authenticated,
       Locale locale = const Locale('en'),
       SupportEmailCompose? composeEmail,
+      Future<bool> Function()? openZendeskSupport,
     }) async {
       await tester.pumpWidget(
         ProviderScope(
@@ -66,7 +71,10 @@ void main() {
             locale: locale,
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,
-            home: SupportCenterScreen(composeEmail: composeEmail),
+            home: SupportCenterScreen(
+              composeEmail: composeEmail,
+              openZendeskSupport: openZendeskSupport,
+            ),
           ),
         ),
       );
@@ -152,6 +160,7 @@ void main() {
     ) async {
       String? capturedToEmail;
       String? capturedSubject;
+      String? capturedBody;
       await pump(
         tester,
         authState: AuthState.unauthenticated,
@@ -164,6 +173,7 @@ void main() {
             }) async {
               capturedToEmail = toEmail;
               capturedSubject = subject;
+              capturedBody = body;
             },
       );
 
@@ -172,6 +182,57 @@ void main() {
 
       expect(capturedToEmail, AppConstants.supportEmail);
       expect(capturedSubject, en.supportContactSupport);
+      expect(capturedBody, contains(en.supportChatNotAvailable));
+      expect(capturedBody, contains(en.supportContactSupportSubtitle));
+    });
+
+    testWidgets('falls back to email when Zendesk cannot open messages', (
+      tester,
+    ) async {
+      var composed = false;
+      await pump(
+        tester,
+        authState: AuthState.unauthenticated,
+        openZendeskSupport: () async => false,
+        composeEmail:
+            ({
+              required String toEmail,
+              required String subject,
+              required String body,
+              Rect? sharePositionOrigin,
+            }) async {
+              composed = true;
+            },
+      );
+
+      await tester.tap(find.text(en.supportContactSupport));
+      await tester.pumpAndSettle();
+
+      expect(composed, true);
+    });
+
+    testWidgets('shows an error when email support cannot open', (
+      tester,
+    ) async {
+      await pump(
+        tester,
+        authState: AuthState.unauthenticated,
+        composeEmail:
+            ({
+              required String toEmail,
+              required String subject,
+              required String body,
+              Rect? sharePositionOrigin,
+            }) async => throw Exception('compose failed'),
+      );
+
+      await tester.tap(find.text(en.supportContactSupport));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text(en.authCouldNotOpenEmail(AppConstants.supportEmail)),
+        findsOneWidget,
+      );
     });
 
     // The row existing is not the feature; reaching the confirmation gate is.

--- a/mobile/test/screens/settings/support_center_screen_test.dart
+++ b/mobile/test/screens/settings/support_center_screen_test.dart
@@ -132,13 +132,16 @@ void main() {
       expect(find.text(en.nostrSettingsDeleteAccount), findsNothing);
       // The screen itself still renders, so the assertion above is about the
       // auth gate rather than a failed pump.
-      expect(find.text(en.supportReportBug), findsOneWidget);
+      expect(find.text(en.supportTitle), findsOneWidget);
     });
 
-    testWidgets('hides feature requests when signed out', (tester) async {
+    testWidgets('hides authenticated support forms when signed out', (
+      tester,
+    ) async {
       await pump(tester, authState: AuthState.unauthenticated);
       await scrollToBottom(tester);
 
+      expect(find.text(en.supportReportBug), findsNothing);
       expect(find.text(en.supportRequestFeature), findsNothing);
     });
 

--- a/mobile/test/screens/settings/support_center_screen_test.dart
+++ b/mobile/test/screens/settings/support_center_screen_test.dart
@@ -135,6 +135,13 @@ void main() {
       expect(find.text(en.supportReportBug), findsOneWidget);
     });
 
+    testWidgets('hides feature requests when signed out', (tester) async {
+      await pump(tester, authState: AuthState.unauthenticated);
+      await scrollToBottom(tester);
+
+      expect(find.text(en.supportRequestFeature), findsNothing);
+    });
+
     // The row existing is not the feature; reaching the confirmation gate is.
     testWidgets('opens the deletion confirmation gate when tapped', (
       tester,

--- a/mobile/test/services/zendesk_support_service_test.dart
+++ b/mobile/test/services/zendesk_support_service_test.dart
@@ -182,6 +182,37 @@ void main() {
         expect(userIdentityCalls, 1);
       },
     );
+
+    test(
+      'setAnonymousIdentity waits for an in-flight initialization',
+      () async {
+        var anonymousIdentityCalls = 0;
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(channel, (MethodCall call) async {
+              if (call.method == 'initialize') {
+                await Future<void>.delayed(const Duration(milliseconds: 20));
+                return true;
+              }
+              if (call.method == 'setAnonymousIdentity') {
+                anonymousIdentityCalls++;
+                return true;
+              }
+              return null;
+            });
+
+        final initialization = ZendeskSupportService.initialize(
+          appId: 'test',
+          clientId: 'test',
+          zendeskUrl: 'https://test.zendesk.com',
+        );
+
+        final identitySet = await ZendeskSupportService.setAnonymousIdentity();
+        await initialization;
+
+        expect(identitySet, true);
+        expect(anonymousIdentityCalls, 1);
+      },
+    );
   });
 
   group('ZendeskSupportService.showNewTicketScreen', () {

--- a/mobile/test/services/zendesk_support_service_test.dart
+++ b/mobile/test/services/zendesk_support_service_test.dart
@@ -350,6 +350,31 @@ void main() {
       expect(showTicketListCalled, true);
     });
 
+    test('sets a plain anonymous identity without cached user info', () async {
+      final calls = <String>[];
+
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (MethodCall call) async {
+            calls.add(call.method);
+            if (call.method == 'initialize') return true;
+            return null;
+          });
+
+      await ZendeskSupportService.initialize(
+        appId: 'test',
+        clientId: 'test',
+        zendeskUrl: 'https://test.zendesk.com',
+      );
+
+      final result = await ZendeskSupportService.showTicketListScreen();
+
+      expect(result, isTrue);
+      expect(
+        calls,
+        containsAllInOrder(['setAnonymousIdentity', 'showTicketList']),
+      );
+    });
+
     test('retries with anonymous identity when NO_IDENTITY error', () async {
       var showTicketListCallCount = 0;
       var setUserIdentityCalled = false;
@@ -1422,30 +1447,33 @@ void main() {
       expect(methodCalls, ['showNewTicket']);
     });
 
-    test('showTicketListScreen without auth context skips refresh', () async {
-      final methodCalls = <String>[];
+    test(
+      'showTicketListScreen without auth context sets anonymous identity',
+      () async {
+        final methodCalls = <String>[];
 
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockMethodCallHandler(channel, (MethodCall call) async {
-            methodCalls.add(call.method);
-            if (call.method == 'initialize') return true;
-            if (call.method == 'showTicketList') return true;
-            return null;
-          });
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(channel, (MethodCall call) async {
+              methodCalls.add(call.method);
+              if (call.method == 'initialize') return true;
+              if (call.method == 'showTicketList') return true;
+              return null;
+            });
 
-      await ZendeskSupportService.initialize(
-        appId: 'test',
-        clientId: 'test',
-        zendeskUrl: 'https://test.zendesk.com',
-      );
+        await ZendeskSupportService.initialize(
+          appId: 'test',
+          clientId: 'test',
+          zendeskUrl: 'https://test.zendesk.com',
+        );
 
-      methodCalls.clear();
+        methodCalls.clear();
 
-      final result = await ZendeskSupportService.showTicketListScreen();
+        final result = await ZendeskSupportService.showTicketListScreen();
 
-      expect(result, true);
-      expect(methodCalls, ['showTicketList']);
-    });
+        expect(result, true);
+        expect(methodCalls, ['setAnonymousIdentity', 'showTicketList']);
+      },
+    );
 
     test(
       'showTicketListScreen falls back to anonymous identity when JWT refresh fails',
@@ -1621,7 +1649,7 @@ void main() {
 
         expect(result, isTrue);
         expect(refreshCallCount, 0);
-        expect(methodCalls, ['showTicketList']);
+        expect(methodCalls, ['setAnonymousIdentity', 'showTicketList']);
       },
     );
   });


### PR DESCRIPTION
## Description

People who cannot sign in had password recovery options but no way to contact support from the sign-in flow.
This change adds a Contact support action and keeps the Support Center landing page reachable while signed out.
Ticket history can use an anonymous identity, while authenticated-only forms remain protected.
If in-app support is unavailable or fails to open, the action falls back to the existing support email flow.

**Related Issue:** Closes #7346

## Out of Scope

This does not change sign-in, password recovery, authenticated bug reports, or feature-request behavior.

## Verification

- `flutter test test/screens/settings/support_center_screen_test.dart test/services/zendesk_support_service_test.dart test/router/app_router_redirect_test.dart test/screens/auth/login_options_screen_test.dart test/services/support_email_composer_test.dart` (124 passed)
- `flutter test --exclude-tags integration` (18,136 passed, 280 skipped)
- `flutter analyze lib test integration_test tools`
- `dart format --output=none --set-exit-if-changed lib test integration_test tools`
- Relevant configuration and generated-file ratchets, including Maestro copy drift, localization, service, test-structure, package-boundary, and log-encoding checks
- `repo-validate` pack `984dc6d` covered the `mobile` root and reported 18 locally non-runnable CI-owned gaps for reusable workflows, aggregate status, VGV tag gates, and semantic checks.
- The declared aggregate `very_good test` command was not run because `very_good` is not installed in this environment.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
