### PR TITLE
fix(followers): keep incomplete sources from lowering totals

### DIFF
--- a/mobile/packages/follow_repository/lib/src/follow_repository.dart
+++ b/mobile/packages/follow_repository/lib/src/follow_repository.dart
@@ -33,6 +33,7 @@ typedef _CachedFollowerStats = ({
 typedef _FollowerCountObservation = ({
   int count,
   bool isComplete,
+  bool isRestBaseline,
   String source,
 });
 
@@ -978,7 +979,12 @@ class FollowRepository {
     final wsResult = results[1]! as _WebSocketFollowerStats;
     final followerCounts = [
       if (restResult != null)
-        (count: restResult.followers, isComplete: false, source: 'REST'),
+        (
+          count: restResult.followers,
+          isComplete: false,
+          isRestBaseline: true,
+          source: 'REST',
+        ),
       ...wsResult.followerCounts,
     ];
     final followers = _corroborateFollowerCount(followerCounts);
@@ -1005,14 +1011,14 @@ class FollowRepository {
     return FollowerStats(followers: followers, following: following);
   }
 
-  /// Selects a follower count from the highest-confidence usable observations.
+  /// Selects a follower count using REST as the stable baseline.
   ///
-  /// Complete observations establish that an indexer finished answering, but
-  /// EOSE only covers that relay's own holdings. Positive complete observations
-  /// form the preferred confidence tier and partial lower bounds never cap
-  /// them. Conflicts within a tier use the second-highest value so a lone high
-  /// source cannot win. Zero observations are ignored when any source found
-  /// followers because an empty index is not evidence against positive data.
+  /// One indexer cannot override REST because neither EOSE nor a timeout proves
+  /// that relay's holdings are complete. Two or more indexers can raise the
+  /// baseline using their second-highest count, which rejects a lone high
+  /// outlier without letting a low partial result drag REST down. Without REST,
+  /// the same second-highest fallback applies across indexers; a single indexer
+  /// is used only when it is the sole available evidence.
   static int _corroborateFollowerCount(
     List<_FollowerCountObservation> observations,
   ) {
@@ -1027,21 +1033,25 @@ class FollowRepository {
     final usable = hasPositiveCount
         ? observations.where((result) => result.count > 0)
         : observations;
-    final completeCounts = usable
-        .where((result) => result.isComplete)
+    final restCounts = usable
+        .where((result) => result.isRestBaseline)
         .map((result) => result.count)
         .toList();
-    if (completeCounts.length >= 2) return secondHighest(completeCounts);
-    if (completeCounts.length == 1) return completeCounts.single;
-
-    final partialCounts = usable
-        .where((result) => !result.isComplete)
+    final indexerCounts = usable
+        .where((result) => !result.isRestBaseline)
         .map((result) => result.count)
         .toList();
+    final restBaseline = restCounts.isEmpty ? null : restCounts.reduce(max);
 
-    return partialCounts.length == 1
-        ? partialCounts.single
-        : secondHighest(partialCounts);
+    if (indexerCounts.length >= 2) {
+      final corroboratedIndexerCount = secondHighest(indexerCounts);
+      return restBaseline == null
+          ? corroboratedIndexerCount
+          : max(restBaseline, corroboratedIndexerCount);
+    }
+
+    if (restBaseline != null) return restBaseline;
+    return indexerCounts.single;
   }
 
   /// Try fetching follower stats via the Funnelcake REST API.
@@ -1210,7 +1220,12 @@ class FollowRepository {
         name: 'FollowRepository',
         category: LogCategory.system,
       );
-      return (count: result, isComplete: isComplete, source: indexerUrl);
+      return (
+        count: result,
+        isComplete: isComplete,
+        isRestBaseline: false,
+        source: indexerUrl,
+      );
     } catch (e) {
       Log.warning(
         'Error querying $indexerUrl for followers: $e',
@@ -1222,6 +1237,7 @@ class FollowRepository {
           : (
               count: followerPubkeys.length,
               isComplete: isComplete,
+              isRestBaseline: false,
               source: indexerUrl,
             );
     } finally {

--- a/mobile/packages/follow_repository/lib/src/follow_repository.dart
+++ b/mobile/packages/follow_repository/lib/src/follow_repository.dart
@@ -30,6 +30,17 @@ typedef _CachedFollowerStats = ({
   DateTime cachedAt,
 });
 
+typedef _FollowerCountObservation = ({
+  int count,
+  bool isComplete,
+  String source,
+});
+
+typedef _WebSocketFollowerStats = ({
+  int following,
+  List<_FollowerCountObservation> followerCounts,
+});
+
 /// Repository for managing follow relationships.
 /// Single source of truth for follow data.
 ///
@@ -954,8 +965,8 @@ class FollowRepository {
 
   /// Fetch follower stats from the network.
   ///
-  /// Runs REST API and WebSocket queries in parallel, then uses the
-  /// higher count from each source.
+  /// Runs REST API and WebSocket queries in parallel, then corroborates the
+  /// follower count across the usable source observations.
   Future<FollowerStats> _fetchFollowerStats(String pubkey) async {
     // Run REST and WebSocket queries in parallel for best coverage
     final results = await Future.wait([
@@ -963,33 +974,73 @@ class FollowRepository {
       _fetchFollowerStatsViaWebSocket(pubkey),
     ]);
 
-    final restResult = results[0];
-    final wsResult = results[1]!;
+    final restResult = results[0] as FollowerStats?;
+    final wsResult = results[1]! as _WebSocketFollowerStats;
+    final followerCounts = [
+      if (restResult != null)
+        (count: restResult.followers, isComplete: true, source: 'REST'),
+      ...wsResult.followerCounts,
+    ];
+    final followers = _corroborateFollowerCount(followerCounts);
+    final following = restResult == null
+        ? wsResult.following
+        : max(restResult.following, wsResult.following);
+    final observationSummary = followerCounts.isEmpty
+        ? 'none'
+        : followerCounts
+              .map(
+                (result) =>
+                    '${result.source}=${result.count}'
+                    '${result.isComplete ? '(complete)' : '(partial)'}',
+              )
+              .join(', ');
 
-    if (restResult == null) {
-      return wsResult;
-    }
-
-    // Use the higher count from each source
-    final followers = restResult.followers > wsResult.followers
-        ? restResult.followers
-        : wsResult.followers;
-    final following = restResult.following > wsResult.following
-        ? restResult.following
-        : wsResult.following;
-
-    if (followers != restResult.followers ||
-        following != restResult.following) {
-      Log.info(
-        'Follower stats merged: REST=${restResult.followers}/'
-        '${restResult.following}, WS=${wsResult.followers}/'
-        '${wsResult.following} → using $followers/$following',
-        name: 'FollowRepository',
-        category: LogCategory.system,
-      );
-    }
+    Log.info(
+      'Follower count observations: $observationSummary, '
+      'using $followers for ${pubkeyForLogs(pubkey)}',
+      name: 'FollowRepository',
+      category: LogCategory.system,
+    );
 
     return FollowerStats(followers: followers, following: following);
+  }
+
+  /// Selects the highest follower count corroborated by another observation.
+  ///
+  /// Complete observations establish that a source finished answering, but
+  /// EOSE only covers that relay's own holdings. Two complete observations use
+  /// their second-highest count. A single complete observation is capped by the
+  /// best partial lower bound, while an all-partial result also uses its
+  /// second-highest count. A lone high value therefore cannot win any
+  /// multi-source result.
+  static int _corroborateFollowerCount(
+    List<_FollowerCountObservation> observations,
+  ) {
+    if (observations.isEmpty) return 0;
+
+    int secondHighest(List<int> counts) {
+      counts.sort();
+      return counts[counts.length - 2];
+    }
+
+    final completeCounts = observations
+        .where((result) => result.isComplete)
+        .map((result) => result.count)
+        .toList();
+    if (completeCounts.length >= 2) return secondHighest(completeCounts);
+
+    final partialCounts = observations
+        .where((result) => !result.isComplete)
+        .map((result) => result.count)
+        .toList();
+    if (completeCounts.length == 1) {
+      if (partialCounts.isEmpty) return completeCounts.single;
+      return min(completeCounts.single, partialCounts.reduce(max));
+    }
+
+    return partialCounts.length == 1
+        ? partialCounts.single
+        : secondHighest(partialCounts);
   }
 
   /// Try fetching follower stats via the Funnelcake REST API.
@@ -1029,21 +1080,29 @@ class FollowRepository {
   }
 
   /// Fetch follower stats via WebSocket queries (parallel).
-  Future<FollowerStats> _fetchFollowerStatsViaWebSocket(String pubkey) async {
+  Future<_WebSocketFollowerStats> _fetchFollowerStatsViaWebSocket(
+    String pubkey,
+  ) async {
     try {
       final results = await Future.wait([
         _fetchFollowingCountViaWebSocket(pubkey),
         _fetchFollowersCountViaIndexers(pubkey),
       ]);
 
-      return FollowerStats(following: results[0], followers: results[1]);
+      return (
+        following: results[0] as int,
+        followerCounts: results[1] as List<_FollowerCountObservation>,
+      );
     } catch (e) {
       Log.error(
         'Error fetching follower stats via WebSocket: $e',
         name: 'FollowRepository',
         category: LogCategory.system,
       );
-      return FollowerStats.zero;
+      return (
+        following: 0,
+        followerCounts: const <_FollowerCountObservation>[],
+      );
     }
   }
 
@@ -1074,7 +1133,9 @@ class FollowRepository {
   }
 
   /// Get followers count by querying indexer relays directly.
-  Future<int> _fetchFollowersCountViaIndexers(String pubkey) async {
+  Future<List<_FollowerCountObservation>> _fetchFollowersCountViaIndexers(
+    String pubkey,
+  ) async {
     final results = await Future.wait(
       _indexerRelayUrls.map(
         (url) =>
@@ -1085,29 +1146,16 @@ class FollowRepository {
                 name: 'FollowRepository',
                 category: LogCategory.system,
               );
-              return 0;
+              return null;
             }),
       ),
     );
 
-    // Use the highest count from any indexer
-    var best = 0;
-    for (final count in results) {
-      if (count > best) best = count;
-    }
-
-    Log.info(
-      'Indexer followers counts: $results, '
-      'using $best for ${pubkeyForLogs(pubkey)}',
-      name: 'FollowRepository',
-      category: LogCategory.system,
-    );
-
-    return best;
+    return results.whereType<_FollowerCountObservation>().toList();
   }
 
   /// Query a single indexer relay for kind 3 events mentioning pubkey.
-  Future<int> _queryIndexerForFollowerCount(
+  Future<_FollowerCountObservation?> _queryIndexerForFollowerCount(
     String indexerUrl,
     String pubkey,
   ) async {
@@ -1116,6 +1164,7 @@ class FollowRepository {
     final completer = Completer<int>();
     final followerPubkeys = <String>{};
     final subscriptionId = 'fc_${DateTime.now().millisecondsSinceEpoch}';
+    var isComplete = false;
 
     relay.onMessage = (relay, jsonMsg) async {
       if (jsonMsg.isEmpty) return;
@@ -1130,6 +1179,7 @@ class FollowRepository {
         }
       } else if (messageType == 'EOSE') {
         if (!completer.isCompleted) {
+          isComplete = true;
           completer.complete(followerPubkeys.length);
         }
       }
@@ -1144,7 +1194,7 @@ class FollowRepository {
 
       final connected = await relay.connect();
       if (!connected) {
-        return 0;
+        return null;
       }
 
       final result = await completer.future.timeout(
@@ -1159,14 +1209,20 @@ class FollowRepository {
         name: 'FollowRepository',
         category: LogCategory.system,
       );
-      return result;
+      return (count: result, isComplete: isComplete, source: indexerUrl);
     } catch (e) {
       Log.warning(
         'Error querying $indexerUrl for followers: $e',
         name: 'FollowRepository',
         category: LogCategory.system,
       );
-      return followerPubkeys.length;
+      return followerPubkeys.isEmpty
+          ? null
+          : (
+              count: followerPubkeys.length,
+              isComplete: isComplete,
+              source: indexerUrl,
+            );
     } finally {
       try {
         await relay.disconnect();

--- a/mobile/packages/follow_repository/lib/src/follow_repository.dart
+++ b/mobile/packages/follow_repository/lib/src/follow_repository.dart
@@ -33,7 +33,6 @@ typedef _CachedFollowerStats = ({
 typedef _FollowerCountObservation = ({
   int count,
   bool isComplete,
-  bool isRestBaseline,
   String source,
 });
 
@@ -979,12 +978,7 @@ class FollowRepository {
     final wsResult = results[1]! as _WebSocketFollowerStats;
     final followerCounts = [
       if (restResult != null)
-        (
-          count: restResult.followers,
-          isComplete: false,
-          isRestBaseline: true,
-          source: 'REST',
-        ),
+        (count: restResult.followers, isComplete: false, source: 'REST'),
       ...wsResult.followerCounts,
     ];
     final followers = _corroborateFollowerCount(followerCounts);
@@ -1011,14 +1005,14 @@ class FollowRepository {
     return FollowerStats(followers: followers, following: following);
   }
 
-  /// Selects a follower count using REST as the stable baseline.
+  /// Selects a robust follower count across all usable observations.
   ///
-  /// One indexer cannot override REST because neither EOSE nor a timeout proves
-  /// that relay's holdings are complete. Two or more indexers can raise the
-  /// baseline using their second-highest count, which rejects a lone high
-  /// outlier without letting a low partial result drag REST down. Without REST,
-  /// the same second-highest fallback applies across indexers; a single indexer
-  /// is used only when it is the sole available evidence.
+  /// Three or more positive observations use their second-highest count so one
+  /// high outlier cannot win. With only one or two positives there is not enough
+  /// evidence to identify an outlier, so the highest observed lower bound wins.
+  /// Zero observations are ignored beside positive evidence. EOSE completion is
+  /// intentionally diagnostic only: it proves the response finished, not that
+  /// the relay holds every relevant kind 3 event.
   static int _corroborateFollowerCount(
     List<_FollowerCountObservation> observations,
   ) {
@@ -1033,25 +1027,8 @@ class FollowRepository {
     final usable = hasPositiveCount
         ? observations.where((result) => result.count > 0)
         : observations;
-    final restCounts = usable
-        .where((result) => result.isRestBaseline)
-        .map((result) => result.count)
-        .toList();
-    final indexerCounts = usable
-        .where((result) => !result.isRestBaseline)
-        .map((result) => result.count)
-        .toList();
-    final restBaseline = restCounts.isEmpty ? null : restCounts.reduce(max);
-
-    if (indexerCounts.length >= 2) {
-      final corroboratedIndexerCount = secondHighest(indexerCounts);
-      return restBaseline == null
-          ? corroboratedIndexerCount
-          : max(restBaseline, corroboratedIndexerCount);
-    }
-
-    if (restBaseline != null) return restBaseline;
-    return indexerCounts.single;
+    final counts = usable.map((result) => result.count).toList();
+    return counts.length >= 3 ? secondHighest(counts) : counts.reduce(max);
   }
 
   /// Try fetching follower stats via the Funnelcake REST API.
@@ -1223,7 +1200,6 @@ class FollowRepository {
       return (
         count: result,
         isComplete: isComplete,
-        isRestBaseline: false,
         source: indexerUrl,
       );
     } catch (e) {
@@ -1237,7 +1213,6 @@ class FollowRepository {
           : (
               count: followerPubkeys.length,
               isComplete: isComplete,
-              isRestBaseline: false,
               source: indexerUrl,
             );
     } finally {

--- a/mobile/packages/follow_repository/lib/src/follow_repository.dart
+++ b/mobile/packages/follow_repository/lib/src/follow_repository.dart
@@ -1012,7 +1012,8 @@ class FollowRepository {
   /// evidence to identify an outlier, so the highest observed lower bound wins.
   /// Zero observations are ignored beside positive evidence. EOSE completion is
   /// intentionally diagnostic only: it proves the response finished, not that
-  /// the relay holds every relevant kind 3 event.
+  /// the relay holds every relevant kind 3 event. Consequently, two low partial
+  /// observations can conservatively reject one high source in the 3+ fallback.
   static int _corroborateFollowerCount(
     List<_FollowerCountObservation> observations,
   ) {

--- a/mobile/packages/follow_repository/lib/src/follow_repository.dart
+++ b/mobile/packages/follow_repository/lib/src/follow_repository.dart
@@ -65,6 +65,7 @@ class FollowRepository {
     RelayFactory? relayFactory,
     BlockedPubkeysCallback? blockedPubkeys,
     DateTime Function()? now,
+    Duration indexerQueryTimeout = const Duration(seconds: 8),
   }) : _nostrClient = nostrClient,
        _blockedPubkeys = blockedPubkeys,
        _isCacheInitialized = isCacheInitialized,
@@ -77,7 +78,8 @@ class FollowRepository {
        _indexerRelayUrls = indexerRelayUrls,
        _queryContactList = queryContactList ?? _defaultQueryContactList,
        _relayFactory = relayFactory ?? _defaultRelayFactory,
-       _now = now ?? DateTime.now;
+       _now = now ?? DateTime.now,
+       _indexerQueryTimeout = indexerQueryTimeout;
 
   final NostrClient _nostrClient;
   final IsCacheInitializedCallback? _isCacheInitialized;
@@ -111,6 +113,9 @@ class FollowRepository {
 
   /// Clock used by expiring caches and persisted-stat stabilization.
   final DateTime Function() _now;
+
+  /// Maximum time to wait for an indexer relay to finish a count query.
+  final Duration _indexerQueryTimeout;
 
   /// Default relay factory — creates a real [RelayBase].
   static RelayBase _defaultRelayFactory(String url, RelayStatus status) =>
@@ -965,23 +970,20 @@ class FollowRepository {
 
   /// Fetch follower stats from the network.
   ///
-  /// Runs REST API and WebSocket queries in parallel, then corroborates the
-  /// follower count across the usable source observations.
+  /// Runs REST API and WebSocket queries in parallel, records each source's
+  /// completion state, then selects the highest observed follower count.
   Future<FollowerStats> _fetchFollowerStats(String pubkey) async {
     // Run REST and WebSocket queries in parallel for best coverage
-    final results = await Future.wait([
+    final (restResult, wsResult) = await (
       _fetchFollowerStatsViaRest(pubkey),
       _fetchFollowerStatsViaWebSocket(pubkey),
-    ]);
-
-    final restResult = results[0] as FollowerStats?;
-    final wsResult = results[1]! as _WebSocketFollowerStats;
+    ).wait;
     final followerCounts = [
       if (restResult != null)
-        (count: restResult.followers, isComplete: false, source: 'REST'),
+        (count: restResult.followers, isComplete: true, source: 'REST'),
       ...wsResult.followerCounts,
     ];
-    final followers = _corroborateFollowerCount(followerCounts);
+    final followers = _selectFollowerCount(followerCounts);
     final following = restResult == null
         ? wsResult.following
         : max(restResult.following, wsResult.following);
@@ -1005,31 +1007,18 @@ class FollowRepository {
     return FollowerStats(followers: followers, following: following);
   }
 
-  /// Selects a robust follower count across all usable observations.
+  /// Selects the best-covered follower count across all observations.
   ///
-  /// Three or more positive observations use their second-highest count so one
-  /// high outlier cannot win. With only one or two positives there is not enough
-  /// evidence to identify an outlier, so the highest observed lower bound wins.
-  /// Zero observations are ignored beside positive evidence. EOSE completion is
-  /// intentionally diagnostic only: it proves the response finished, not that
-  /// the relay holds every relevant kind 3 event. Consequently, two low partial
-  /// observations can conservatively reject one high source in the 3+ fallback.
-  static int _corroborateFollowerCount(
+  /// Aggregate counts cannot distinguish a stale over-count from a source with
+  /// broader relay coverage. Completion only means that source finished
+  /// answering; it does not make its holdings globally authoritative. Until
+  /// reconciliation can compare event identities, a lower observation must not
+  /// discard a potentially better-covered source.
+  static int _selectFollowerCount(
     List<_FollowerCountObservation> observations,
   ) {
     if (observations.isEmpty) return 0;
-
-    int secondHighest(List<int> counts) {
-      counts.sort();
-      return counts[counts.length - 2];
-    }
-
-    final hasPositiveCount = observations.any((result) => result.count > 0);
-    final usable = hasPositiveCount
-        ? observations.where((result) => result.count > 0)
-        : observations;
-    final counts = usable.map((result) => result.count).toList();
-    return counts.length >= 3 ? secondHighest(counts) : counts.reduce(max);
+    return observations.map((result) => result.count).reduce(max);
   }
 
   /// Try fetching follower stats via the Funnelcake REST API.
@@ -1073,14 +1062,14 @@ class FollowRepository {
     String pubkey,
   ) async {
     try {
-      final results = await Future.wait([
+      final (following, followerCounts) = await (
         _fetchFollowingCountViaWebSocket(pubkey),
         _fetchFollowersCountViaIndexers(pubkey),
-      ]);
+      ).wait;
 
       return (
-        following: results[0] as int,
-        followerCounts: results[1] as List<_FollowerCountObservation>,
+        following: following,
+        followerCounts: followerCounts,
       );
     } catch (e) {
       Log.error(
@@ -1121,7 +1110,7 @@ class FollowRepository {
     return 0;
   }
 
-  /// Get followers count by querying indexer relays directly.
+  /// Get follower-count observations by querying indexer relays directly.
   Future<List<_FollowerCountObservation>> _fetchFollowersCountViaIndexers(
     String pubkey,
   ) async {
@@ -1187,7 +1176,7 @@ class FollowRepository {
       }
 
       final result = await completer.future.timeout(
-        const Duration(seconds: 8),
+        _indexerQueryTimeout,
         onTimeout: () => followerPubkeys.length,
       );
 

--- a/mobile/packages/follow_repository/lib/src/follow_repository.dart
+++ b/mobile/packages/follow_repository/lib/src/follow_repository.dart
@@ -978,7 +978,7 @@ class FollowRepository {
     final wsResult = results[1]! as _WebSocketFollowerStats;
     final followerCounts = [
       if (restResult != null)
-        (count: restResult.followers, isComplete: true, source: 'REST'),
+        (count: restResult.followers, isComplete: false, source: 'REST'),
       ...wsResult.followerCounts,
     ];
     final followers = _corroborateFollowerCount(followerCounts);
@@ -1005,14 +1005,14 @@ class FollowRepository {
     return FollowerStats(followers: followers, following: following);
   }
 
-  /// Selects the highest follower count corroborated by another observation.
+  /// Selects a follower count from the highest-confidence usable observations.
   ///
-  /// Complete observations establish that a source finished answering, but
-  /// EOSE only covers that relay's own holdings. Two complete observations use
-  /// their second-highest count. A single complete observation is capped by the
-  /// best partial lower bound, while an all-partial result also uses its
-  /// second-highest count. A lone high value therefore cannot win any
-  /// multi-source result.
+  /// Complete observations establish that an indexer finished answering, but
+  /// EOSE only covers that relay's own holdings. Positive complete observations
+  /// form the preferred confidence tier and partial lower bounds never cap
+  /// them. Conflicts within a tier use the second-highest value so a lone high
+  /// source cannot win. Zero observations are ignored when any source found
+  /// followers because an empty index is not evidence against positive data.
   static int _corroborateFollowerCount(
     List<_FollowerCountObservation> observations,
   ) {
@@ -1023,20 +1023,21 @@ class FollowRepository {
       return counts[counts.length - 2];
     }
 
-    final completeCounts = observations
+    final hasPositiveCount = observations.any((result) => result.count > 0);
+    final usable = hasPositiveCount
+        ? observations.where((result) => result.count > 0)
+        : observations;
+    final completeCounts = usable
         .where((result) => result.isComplete)
         .map((result) => result.count)
         .toList();
     if (completeCounts.length >= 2) return secondHighest(completeCounts);
+    if (completeCounts.length == 1) return completeCounts.single;
 
-    final partialCounts = observations
+    final partialCounts = usable
         .where((result) => !result.isComplete)
         .map((result) => result.count)
         .toList();
-    if (completeCounts.length == 1) {
-      if (partialCounts.isEmpty) return completeCounts.single;
-      return min(completeCounts.single, partialCounts.reduce(max));
-    }
 
     return partialCounts.length == 1
         ? partialCounts.single

--- a/mobile/packages/follow_repository/test/src/follow_repository_test.dart
+++ b/mobile/packages/follow_repository/test/src/follow_repository_test.dart
@@ -5677,7 +5677,7 @@ void main() {
         );
 
         test(
-          'uses the highest count corroborated by another complete source',
+          'uses second-highest count across complete indexers',
           () async {
             var callCount = 0;
             repository = FollowRepository(
@@ -5808,6 +5808,44 @@ void main() {
             expect(stats.followers, equals(2));
           },
           timeout: const Timeout(Duration(seconds: 20)),
+        );
+
+        test(
+          'ignores empty EOSE indexers when REST has a positive count',
+          () async {
+            final mockFunnelcakeClient = _MockFunnelcakeApiClient();
+            when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+            when(
+              () => mockFunnelcakeClient.getSocialCounts(testTargetPubkey),
+            ).thenAnswer(
+              (_) async => const SocialCounts(
+                pubkey: testTargetPubkey,
+                followerCount: 1000,
+                followingCount: 10,
+              ),
+            );
+
+            repository = FollowRepository(
+              nostrClient: mockNostrClient,
+              isCacheInitialized: () => cacheIsInitialized,
+              getCachedEventsByKind: (kind) => getCachedEventsByKind(kind),
+              cacheUserEvent: cachedUserEvents.add,
+              funnelcakeApiClient: mockFunnelcakeClient,
+              indexerRelayUrls: const [
+                'wss://indexer1.test',
+                'wss://indexer2.test',
+              ],
+              relayFactory: fakeRelayFactory(
+                responses: const [
+                  ['EOSE', 's'],
+                ],
+              ),
+            );
+
+            final stats = await repository.getFollowerStats(testTargetPubkey);
+
+            expect(stats.followers, equals(1000));
+          },
         );
       });
 
@@ -6318,9 +6356,9 @@ void main() {
       });
     });
 
-    group('getFollowerStats - conflicting complete follower sources', () {
+    group('getFollowerStats - source confidence', () {
       test(
-        'does not let a lone higher indexer count beat REST',
+        'prefers a complete indexer count over partial REST',
         () async {
           final mockFunnelcakeClient = _MockFunnelcakeApiClient();
           when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
@@ -6365,16 +6403,14 @@ void main() {
 
           final stats = await repository.getFollowerStats(testTargetPubkey);
 
-          // The lower of two complete observations is the highest count both
-          // sources support.
-          expect(stats.followers, equals(5));
+          expect(stats.followers, equals(10));
           // following: max(REST 10, WS 0) = 10
           expect(stats.following, equals(10));
         },
       );
 
       test(
-        'caps one complete count at the best partial lower bound',
+        'does not let partial REST cap one complete indexer',
         () async {
           final mockFunnelcakeClient = _MockFunnelcakeApiClient();
           when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
@@ -6383,7 +6419,7 @@ void main() {
           ).thenAnswer(
             (_) async => const SocialCounts(
               pubkey: testTargetPubkey,
-              followerCount: 50,
+              followerCount: 40,
               followingCount: 10,
             ),
           );
@@ -6397,22 +6433,24 @@ void main() {
             indexerRelayUrls: const ['wss://idx.test'],
             relayFactory: (url, status) {
               return _FakeRelay(url, status)
-                ..fakeResponses = List.generate(
-                  40,
-                  (i) => <dynamic>[
-                    'EVENT',
-                    's',
-                    {'pubkey': i.toRadixString(16).padLeft(64, '0')},
-                  ],
-                );
+                ..fakeResponses = [
+                  ...List.generate(
+                    50,
+                    (i) => <dynamic>[
+                      'EVENT',
+                      's',
+                      {'pubkey': i.toRadixString(16).padLeft(64, '0')},
+                    ],
+                  ),
+                  <dynamic>['EOSE', 's'],
+                ];
             },
           );
 
           final stats = await repository.getFollowerStats(testTargetPubkey);
 
-          expect(stats.followers, equals(40));
+          expect(stats.followers, equals(50));
         },
-        timeout: const Timeout(Duration(seconds: 20)),
       );
     });
 

--- a/mobile/packages/follow_repository/test/src/follow_repository_test.dart
+++ b/mobile/packages/follow_repository/test/src/follow_repository_test.dart
@@ -5677,7 +5677,7 @@ void main() {
         );
 
         test(
-          'uses second-highest count across complete indexers',
+          'uses highest lower bound when only two indexers answer',
           () async {
             var callCount = 0;
             repository = FollowRepository(
@@ -5719,8 +5719,7 @@ void main() {
 
             final stats = await repository.getFollowerStats(testTargetPubkey);
 
-            // A lone high complete source cannot win outright.
-            expect(stats.followers, equals(1));
+            expect(stats.followers, equals(2));
           },
         );
 
@@ -5769,6 +5768,54 @@ void main() {
             final stats = await repository.getFollowerStats(testTargetPubkey);
 
             expect(stats.followers, equals(55));
+          },
+        );
+
+        test(
+          'corrects a high REST outlier with two lower indexers',
+          () async {
+            final mockFunnelcakeClient = _MockFunnelcakeApiClient();
+            when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+            when(
+              () => mockFunnelcakeClient.getSocialCounts(testTargetPubkey),
+            ).thenAnswer(
+              (_) async => const SocialCounts(
+                pubkey: testTargetPubkey,
+                followerCount: 500,
+                followingCount: 0,
+              ),
+            );
+
+            repository = FollowRepository(
+              nostrClient: mockNostrClient,
+              isCacheInitialized: () => cacheIsInitialized,
+              getCachedEventsByKind: (kind) => getCachedEventsByKind(kind),
+              cacheUserEvent: cachedUserEvents.add,
+              funnelcakeApiClient: mockFunnelcakeClient,
+              indexerRelayUrls: const [
+                'wss://indexer1.test',
+                'wss://indexer2.test',
+              ],
+              relayFactory: (url, status) {
+                final count = url.contains('indexer1') ? 88 : 90;
+                return _FakeRelay(url, status)
+                  ..fakeResponses = [
+                    ...List.generate(
+                      count,
+                      (i) => <dynamic>[
+                        'EVENT',
+                        's',
+                        {'pubkey': i.toRadixString(16).padLeft(64, '0')},
+                      ],
+                    ),
+                    <dynamic>['EOSE', 's'],
+                  ];
+              },
+            );
+
+            final stats = await repository.getFollowerStats(testTargetPubkey);
+
+            expect(stats.followers, equals(90));
           },
         );
 
@@ -5846,6 +5893,54 @@ void main() {
 
             expect(stats.followers, equals(1000));
           },
+        );
+
+        test(
+          'keeps the higher lower bound with no REST and two indexers',
+          () async {
+            var callCount = 0;
+            repository = FollowRepository(
+              nostrClient: mockNostrClient,
+              isCacheInitialized: () => cacheIsInitialized,
+              getCachedEventsByKind: (kind) => getCachedEventsByKind(kind),
+              cacheUserEvent: cachedUserEvents.add,
+              indexerRelayUrls: const [
+                'wss://indexer1.test',
+                'wss://indexer2.test',
+              ],
+              relayFactory: (url, status) {
+                callCount++;
+                return _FakeRelay(url, status)
+                  ..fakeResponses = callCount == 1
+                      ? [
+                          ...List.generate(
+                            10,
+                            (i) => <dynamic>[
+                              'EVENT',
+                              's',
+                              {
+                                'pubkey': i.toRadixString(16).padLeft(64, '0'),
+                              },
+                            ],
+                          ),
+                          <dynamic>['EOSE', 's'],
+                        ]
+                      : List.generate(
+                          3,
+                          (i) => <dynamic>[
+                            'EVENT',
+                            's',
+                            {'pubkey': i.toRadixString(16).padLeft(64, '0')},
+                          ],
+                        );
+              },
+            );
+
+            final stats = await repository.getFollowerStats(testTargetPubkey);
+
+            expect(stats.followers, equals(10));
+          },
+          timeout: const Timeout(Duration(seconds: 20)),
         );
       });
 
@@ -6357,6 +6452,47 @@ void main() {
     });
 
     group('getFollowerStats - source confidence', () {
+      test('uses a higher single-indexer lower bound over REST', () async {
+        final mockFunnelcakeClient = _MockFunnelcakeApiClient();
+        when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+        when(
+          () => mockFunnelcakeClient.getSocialCounts(testTargetPubkey),
+        ).thenAnswer(
+          (_) async => const SocialCounts(
+            pubkey: testTargetPubkey,
+            followerCount: 5,
+            followingCount: 10,
+          ),
+        );
+
+        repository = FollowRepository(
+          nostrClient: mockNostrClient,
+          isCacheInitialized: () => cacheIsInitialized,
+          getCachedEventsByKind: (kind) => getCachedEventsByKind(kind),
+          cacheUserEvent: cachedUserEvents.add,
+          funnelcakeApiClient: mockFunnelcakeClient,
+          indexerRelayUrls: const ['wss://idx.test'],
+          relayFactory: (url, status) {
+            return _FakeRelay(url, status)
+              ..fakeResponses = [
+                ...List.generate(
+                  10,
+                  (i) => <dynamic>[
+                    'EVENT',
+                    's',
+                    {'pubkey': i.toRadixString(16).padLeft(64, '0')},
+                  ],
+                ),
+                <dynamic>['EOSE', 's'],
+              ];
+          },
+        );
+
+        final stats = await repository.getFollowerStats(testTargetPubkey);
+
+        expect(stats.followers, equals(10));
+      });
+
       test(
         'does not let one low EOSE indexer drag REST down',
         () async {

--- a/mobile/packages/follow_repository/test/src/follow_repository_test.dart
+++ b/mobile/packages/follow_repository/test/src/follow_repository_test.dart
@@ -5858,6 +5858,52 @@ void main() {
         );
 
         test(
+          'uses conservative fallback for REST and two partial indexers',
+          () async {
+            final mockFunnelcakeClient = _MockFunnelcakeApiClient();
+            when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+            when(
+              () => mockFunnelcakeClient.getSocialCounts(testTargetPubkey),
+            ).thenAnswer(
+              (_) async => const SocialCounts(
+                pubkey: testTargetPubkey,
+                followerCount: 1000,
+                followingCount: 10,
+              ),
+            );
+
+            repository = FollowRepository(
+              nostrClient: mockNostrClient,
+              isCacheInitialized: () => cacheIsInitialized,
+              getCachedEventsByKind: (kind) => getCachedEventsByKind(kind),
+              cacheUserEvent: cachedUserEvents.add,
+              funnelcakeApiClient: mockFunnelcakeClient,
+              indexerRelayUrls: const [
+                'wss://indexer1.test',
+                'wss://indexer2.test',
+              ],
+              relayFactory: (url, status) {
+                final count = url.contains('indexer1') ? 5 : 3;
+                return _FakeRelay(url, status)
+                  ..fakeResponses = List.generate(
+                    count,
+                    (i) => <dynamic>[
+                      'EVENT',
+                      's',
+                      {'pubkey': i.toRadixString(16).padLeft(64, '0')},
+                    ],
+                  );
+              },
+            );
+
+            final stats = await repository.getFollowerStats(testTargetPubkey);
+
+            expect(stats.followers, equals(5));
+          },
+          timeout: const Timeout(Duration(seconds: 20)),
+        );
+
+        test(
           'ignores empty EOSE indexers when REST has a positive count',
           () async {
             final mockFunnelcakeClient = _MockFunnelcakeApiClient();

--- a/mobile/packages/follow_repository/test/src/follow_repository_test.dart
+++ b/mobile/packages/follow_repository/test/src/follow_repository_test.dart
@@ -6358,17 +6358,16 @@ void main() {
 
     group('getFollowerStats - source confidence', () {
       test(
-        'prefers a complete indexer count over partial REST',
+        'does not let one low EOSE indexer drag REST down',
         () async {
           final mockFunnelcakeClient = _MockFunnelcakeApiClient();
           when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
-          // REST: followers=5
           when(
             () => mockFunnelcakeClient.getSocialCounts(testTargetPubkey),
           ).thenAnswer(
             (_) async => const SocialCounts(
               pubkey: testTargetPubkey,
-              followerCount: 5,
+              followerCount: 1000,
               followingCount: 10,
             ),
           );
@@ -6383,7 +6382,6 @@ void main() {
             funnelcakeApiClient: mockFunnelcakeClient,
             indexerRelayUrls: const [indexerUrl],
             relayFactory: (url, status) {
-              // Return 10 follower pubkeys → WS followers=10 > REST=5
               return _FakeRelay(url, status)
                 ..fakeResponses = [
                   ...List.generate(
@@ -6403,14 +6401,14 @@ void main() {
 
           final stats = await repository.getFollowerStats(testTargetPubkey);
 
-          expect(stats.followers, equals(10));
+          expect(stats.followers, equals(1000));
           // following: max(REST 10, WS 0) = 10
           expect(stats.following, equals(10));
         },
       );
 
       test(
-        'does not let partial REST cap one complete indexer',
+        'does not let one low partial indexer drag REST down',
         () async {
           final mockFunnelcakeClient = _MockFunnelcakeApiClient();
           when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
@@ -6419,7 +6417,7 @@ void main() {
           ).thenAnswer(
             (_) async => const SocialCounts(
               pubkey: testTargetPubkey,
-              followerCount: 40,
+              followerCount: 1000,
               followingCount: 10,
             ),
           );
@@ -6433,24 +6431,22 @@ void main() {
             indexerRelayUrls: const ['wss://idx.test'],
             relayFactory: (url, status) {
               return _FakeRelay(url, status)
-                ..fakeResponses = [
-                  ...List.generate(
-                    50,
-                    (i) => <dynamic>[
-                      'EVENT',
-                      's',
-                      {'pubkey': i.toRadixString(16).padLeft(64, '0')},
-                    ],
-                  ),
-                  <dynamic>['EOSE', 's'],
-                ];
+                ..fakeResponses = List.generate(
+                  3,
+                  (i) => <dynamic>[
+                    'EVENT',
+                    's',
+                    {'pubkey': i.toRadixString(16).padLeft(64, '0')},
+                  ],
+                );
             },
           );
 
           final stats = await repository.getFollowerStats(testTargetPubkey);
 
-          expect(stats.followers, equals(50));
+          expect(stats.followers, equals(1000));
         },
+        timeout: const Timeout(Duration(seconds: 20)),
       );
     });
 

--- a/mobile/packages/follow_repository/test/src/follow_repository_test.dart
+++ b/mobile/packages/follow_repository/test/src/follow_repository_test.dart
@@ -5724,7 +5724,7 @@ void main() {
         );
 
         test(
-          'rejects one high outlier across REST and complete indexers',
+          'keeps the highest count across REST and complete indexers',
           () async {
             final mockFunnelcakeClient = _MockFunnelcakeApiClient();
             when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
@@ -5767,12 +5767,12 @@ void main() {
 
             final stats = await repository.getFollowerStats(testTargetPubkey);
 
-            expect(stats.followers, equals(55));
+            expect(stats.followers, equals(500));
           },
         );
 
         test(
-          'corrects a high REST outlier with two lower indexers',
+          'keeps a higher REST count over two lower indexers',
           () async {
             final mockFunnelcakeClient = _MockFunnelcakeApiClient();
             when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
@@ -5815,18 +5815,19 @@ void main() {
 
             final stats = await repository.getFollowerStats(testTargetPubkey);
 
-            expect(stats.followers, equals(90));
+            expect(stats.followers, equals(500));
           },
         );
 
         test(
-          'rejects one high outlier when all sources are partial',
+          'keeps the highest lower bound when all sources are partial',
           () async {
             repository = FollowRepository(
               nostrClient: mockNostrClient,
               isCacheInitialized: () => cacheIsInitialized,
               getCachedEventsByKind: (kind) => getCachedEventsByKind(kind),
               cacheUserEvent: cachedUserEvents.add,
+              indexerQueryTimeout: Duration.zero,
               indexerRelayUrls: const [
                 'wss://indexer1.test',
                 'wss://indexer2.test',
@@ -5852,13 +5853,12 @@ void main() {
 
             final stats = await repository.getFollowerStats(testTargetPubkey);
 
-            expect(stats.followers, equals(2));
+            expect(stats.followers, equals(200));
           },
-          timeout: const Timeout(Duration(seconds: 20)),
         );
 
         test(
-          'uses conservative fallback for REST and two partial indexers',
+          'does not let partial indexers lower the REST count',
           () async {
             final mockFunnelcakeClient = _MockFunnelcakeApiClient();
             when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
@@ -5878,6 +5878,7 @@ void main() {
               getCachedEventsByKind: (kind) => getCachedEventsByKind(kind),
               cacheUserEvent: cachedUserEvents.add,
               funnelcakeApiClient: mockFunnelcakeClient,
+              indexerQueryTimeout: Duration.zero,
               indexerRelayUrls: const [
                 'wss://indexer1.test',
                 'wss://indexer2.test',
@@ -5898,9 +5899,8 @@ void main() {
 
             final stats = await repository.getFollowerStats(testTargetPubkey);
 
-            expect(stats.followers, equals(5));
+            expect(stats.followers, equals(1000));
           },
-          timeout: const Timeout(Duration(seconds: 20)),
         );
 
         test(
@@ -5950,6 +5950,7 @@ void main() {
               isCacheInitialized: () => cacheIsInitialized,
               getCachedEventsByKind: (kind) => getCachedEventsByKind(kind),
               cacheUserEvent: cachedUserEvents.add,
+              indexerQueryTimeout: Duration.zero,
               indexerRelayUrls: const [
                 'wss://indexer1.test',
                 'wss://indexer2.test',
@@ -5986,7 +5987,6 @@ void main() {
 
             expect(stats.followers, equals(10));
           },
-          timeout: const Timeout(Duration(seconds: 20)),
         );
       });
 
@@ -6389,6 +6389,7 @@ void main() {
               isCacheInitialized: () => cacheIsInitialized,
               getCachedEventsByKind: (kind) => getCachedEventsByKind(kind),
               cacheUserEvent: cachedUserEvents.add,
+              indexerQueryTimeout: Duration.zero,
               indexerRelayUrls: const [indexerUrl],
               relayFactory: (url, status) {
                 final relay = _FakeRelay(url, status)
@@ -6416,7 +6417,6 @@ void main() {
             // Should get partial result from timeout
             expect(stats.followers, greaterThanOrEqualTo(0));
           },
-          timeout: const Timeout(Duration(seconds: 20)),
         );
 
         test(
@@ -6610,6 +6610,7 @@ void main() {
             getCachedEventsByKind: (kind) => getCachedEventsByKind(kind),
             cacheUserEvent: cachedUserEvents.add,
             funnelcakeApiClient: mockFunnelcakeClient,
+            indexerQueryTimeout: Duration.zero,
             indexerRelayUrls: const ['wss://idx.test'],
             relayFactory: (url, status) {
               return _FakeRelay(url, status)
@@ -6628,7 +6629,6 @@ void main() {
 
           expect(stats.followers, equals(1000));
         },
-        timeout: const Timeout(Duration(seconds: 20)),
       );
     });
 

--- a/mobile/packages/follow_repository/test/src/follow_repository_test.dart
+++ b/mobile/packages/follow_repository/test/src/follow_repository_test.dart
@@ -4974,7 +4974,7 @@ void main() {
 
     group('getFollowerStats - REST + WS merge', () {
       test(
-        'uses higher count when REST and WS both return data',
+        'keeps following max behavior while followers use available source',
         () async {
           final mockFunnelcakeClient = _MockFunnelcakeApiClient();
           when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
@@ -5038,8 +5038,7 @@ void main() {
 
           final stats = await repository.getFollowerStats(testTargetPubkey);
 
-          // Should pick the higher value from each source
-          // Followers: max(REST 50, WS 0) = 50
+          // Followers have only the REST observation because no indexers run.
           // Following: max(REST 100, WS 80) = 100
           expect(stats.followers, equals(50));
           expect(stats.following, equals(100));
@@ -5249,7 +5248,7 @@ void main() {
       );
     });
 
-    group('getFollowerStats - merge picks higher from each source', () {
+    group('getFollowerStats - following merge', () {
       test(
         'picks WS following when higher than REST',
         () async {
@@ -5678,7 +5677,7 @@ void main() {
         );
 
         test(
-          'uses highest count across multiple indexers',
+          'uses the highest count corroborated by another complete source',
           () async {
             var callCount = 0;
             repository = FollowRepository(
@@ -5720,9 +5719,95 @@ void main() {
 
             final stats = await repository.getFollowerStats(testTargetPubkey);
 
-            // indexer1: 1 follower, indexer2: 2 followers → best=2
+            // A lone high complete source cannot win outright.
+            expect(stats.followers, equals(1));
+          },
+        );
+
+        test(
+          'rejects one high outlier across REST and complete indexers',
+          () async {
+            final mockFunnelcakeClient = _MockFunnelcakeApiClient();
+            when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+            when(
+              () => mockFunnelcakeClient.getSocialCounts(testTargetPubkey),
+            ).thenAnswer(
+              (_) async => const SocialCounts(
+                pubkey: testTargetPubkey,
+                followerCount: 50,
+                followingCount: 0,
+              ),
+            );
+
+            repository = FollowRepository(
+              nostrClient: mockNostrClient,
+              isCacheInitialized: () => cacheIsInitialized,
+              getCachedEventsByKind: (kind) => getCachedEventsByKind(kind),
+              cacheUserEvent: cachedUserEvents.add,
+              funnelcakeApiClient: mockFunnelcakeClient,
+              indexerRelayUrls: const [
+                'wss://indexer1.test',
+                'wss://indexer2.test',
+              ],
+              relayFactory: (url, status) {
+                final count = url.contains('indexer1') ? 55 : 500;
+                return _FakeRelay(url, status)
+                  ..fakeResponses = [
+                    ...List.generate(
+                      count,
+                      (i) => <dynamic>[
+                        'EVENT',
+                        's',
+                        {'pubkey': i.toRadixString(16).padLeft(64, '0')},
+                      ],
+                    ),
+                    <dynamic>['EOSE', 's'],
+                  ];
+              },
+            );
+
+            final stats = await repository.getFollowerStats(testTargetPubkey);
+
+            expect(stats.followers, equals(55));
+          },
+        );
+
+        test(
+          'rejects one high outlier when all sources are partial',
+          () async {
+            repository = FollowRepository(
+              nostrClient: mockNostrClient,
+              isCacheInitialized: () => cacheIsInitialized,
+              getCachedEventsByKind: (kind) => getCachedEventsByKind(kind),
+              cacheUserEvent: cachedUserEvents.add,
+              indexerRelayUrls: const [
+                'wss://indexer1.test',
+                'wss://indexer2.test',
+                'wss://indexer3.test',
+              ],
+              relayFactory: (url, status) {
+                final count = url.contains('indexer1')
+                    ? 1
+                    : url.contains('indexer2')
+                    ? 2
+                    : 200;
+                return _FakeRelay(url, status)
+                  ..fakeResponses = List.generate(
+                    count,
+                    (i) => <dynamic>[
+                      'EVENT',
+                      's',
+                      {'pubkey': i.toRadixString(16).padLeft(64, '0')},
+                    ],
+                  );
+              },
+            );
+
+            final stats = await repository.getFollowerStats(testTargetPubkey);
+
             expect(stats.followers, equals(2));
           },
+          timeout: const Timeout(Duration(seconds: 20)),
         );
       });
 
@@ -6233,9 +6318,9 @@ void main() {
       });
     });
 
-    group('getFollowerStats - WS followers higher than REST', () {
+    group('getFollowerStats - conflicting complete follower sources', () {
       test(
-        'picks WS followers when higher than REST',
+        'does not let a lone higher indexer count beat REST',
         () async {
           final mockFunnelcakeClient = _MockFunnelcakeApiClient();
           when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
@@ -6280,11 +6365,54 @@ void main() {
 
           final stats = await repository.getFollowerStats(testTargetPubkey);
 
-          // followers: max(REST 5, WS 10) = 10
-          expect(stats.followers, equals(10));
+          // The lower of two complete observations is the highest count both
+          // sources support.
+          expect(stats.followers, equals(5));
           // following: max(REST 10, WS 0) = 10
           expect(stats.following, equals(10));
         },
+      );
+
+      test(
+        'caps one complete count at the best partial lower bound',
+        () async {
+          final mockFunnelcakeClient = _MockFunnelcakeApiClient();
+          when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+          when(
+            () => mockFunnelcakeClient.getSocialCounts(testTargetPubkey),
+          ).thenAnswer(
+            (_) async => const SocialCounts(
+              pubkey: testTargetPubkey,
+              followerCount: 50,
+              followingCount: 10,
+            ),
+          );
+
+          repository = FollowRepository(
+            nostrClient: mockNostrClient,
+            isCacheInitialized: () => cacheIsInitialized,
+            getCachedEventsByKind: (kind) => getCachedEventsByKind(kind),
+            cacheUserEvent: cachedUserEvents.add,
+            funnelcakeApiClient: mockFunnelcakeClient,
+            indexerRelayUrls: const ['wss://idx.test'],
+            relayFactory: (url, status) {
+              return _FakeRelay(url, status)
+                ..fakeResponses = List.generate(
+                  40,
+                  (i) => <dynamic>[
+                    'EVENT',
+                    's',
+                    {'pubkey': i.toRadixString(16).padLeft(64, '0')},
+                  ],
+                );
+            },
+          );
+
+          final stats = await repository.getFollowerStats(testTargetPubkey);
+
+          expect(stats.followers, equals(40));
+        },
+        timeout: const Timeout(Duration(seconds: 20)),
       );
     });
 
@@ -6432,7 +6560,7 @@ void main() {
       );
 
       test(
-        'indexer relay send error returns partial results',
+        'indexer close error keeps the EOSE-complete count',
         () async {
           const indexerUrl = 'wss://idx.test';
 
@@ -6461,7 +6589,7 @@ void main() {
           // send() throws after completer completes
           final stats = await repository.getFollowerStats(testTargetPubkey);
 
-          expect(stats, isNotNull);
+          expect(stats.followers, equals(1));
         },
       );
 


### PR DESCRIPTION
## Problem

Follower totals can disagree when REST and relay indexers have different event coverage. A count-only outlier rule cannot tell a stale over-count from a source with broader coverage, and timed-out partial responses could lower a valid persisted total by orders of magnitude.

## Why this approach

Each REST and indexer response remains a separate observation with source and completion diagnostics. Selection keeps the highest observed count because aggregate counts alone do not contain enough evidence to discard a better-covered source. REST is marked complete when its aggregate request finishes, while relay responses are complete only after EOSE.

The indexer count timeout is injectable so partial-response behavior can be tested without real eight-second sleeps. The parallel fetches use typed record waits instead of runtime casts.

## Out of scope

This does not correct stale replaceable kind-3 over-counts. That requires event-level reconciliation of the latest valid contact-list event per follower, not a heuristic over aggregate integers. Issue #6954 remains open for that work.

Following-count selection and the existing persisted-count hysteresis behavior are unchanged.

**Related Issue:** Refs #6954

## Verification

- flutter test packages/follow_repository/test/src/follow_repository_test.dart (226 passed)
- flutter test test/repositories/follow_repository_follower_stats_test.dart (14 passed)
- flutter analyze packages/follow_repository
- Repository pre-push analyzer and changed-file tests

## Type of Change

- [x] Bug fix
- [x] Refactor
