### PR TITLE
test(auth): stop email verification layout tests depending on run order

### DIFF
--- a/mobile/test/screens/auth/email_verification_screen_test.dart
+++ b/mobile/test/screens/auth/email_verification_screen_test.dart
@@ -12,6 +12,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
+import 'package:google_fonts/google_fonts.dart';
 import 'package:invite_api_client/invite_api_client.dart';
 import 'package:keycast_flutter/keycast_flutter.dart';
 import 'package:mocktail/mocktail.dart';
@@ -40,6 +41,14 @@ class _MockInviteApiClient extends Mock implements InviteApiClient {}
 
 Finder _divineIcon(DivineIconName name) =>
     find.byWidgetPredicate((w) => w is DivineIcon && w.icon == name);
+
+Future<void> _loadEmailVerificationLayoutFonts(WidgetTester tester) async {
+  // Construct the exact styles before draining them: google_fonts only queues
+  // bundled font I/O when a style is first requested.
+  VineTheme.bodyMediumFont();
+  VineTheme.labelLargeFont();
+  await tester.runAsync(GoogleFonts.pendingFonts);
+}
 
 void main() {
   late _MockEmailVerificationCubit mockCubit;
@@ -1643,6 +1652,7 @@ void main() {
       tester.view.viewInsets = const FakeViewPadding(bottom: keyboardExtent);
       addTearDown(tester.view.reset);
 
+      await _loadEmailVerificationLayoutFonts(tester);
       await tester.pumpWidget(
         createTestWidget(
           deviceCode: 'test-device-code',
@@ -1686,6 +1696,7 @@ void main() {
       tester.view.physicalSize = const Size(360, 560);
       addTearDown(tester.view.reset);
 
+      await _loadEmailVerificationLayoutFonts(tester);
       await tester.pumpWidget(
         MediaQuery(
           data: const MediaQueryData(textScaler: TextScaler.linear(1.6)),
@@ -1719,6 +1730,7 @@ void main() {
       tester.view.physicalSize = const Size(320, 480);
       addTearDown(tester.view.reset);
 
+      await _loadEmailVerificationLayoutFonts(tester);
       await tester.pumpWidget(
         MediaQuery(
           data: const MediaQueryData(textScaler: TextScaler.linear(1.6)),


### PR DESCRIPTION
A large-text email verification test could pass or fail depending on where it ran in a test bundle. When it ran first, Google Fonts had not loaded Inter yet, so fallback glyph metrics made the resend row overflow; later tests inherited the loaded font and passed.

This change explicitly queues the two Inter styles used by that row and drains their bundled font I/O before any of the three keyboard-reachability tests pumps the constrained screen. That makes each test measure the intended production font metrics independently of bundle order.

This is test-only. It does not change the shipped resend-row layout or accessibility behavior.

Verification:
- isolated large-text test
- all three keyboard-reachability tests
- complete email verification screen test file (53 tests)
- `flutter analyze lib test integration_test`
- pinned Dart formatter and repository commit/push hooks

Closes #8106