### PR TITLE
test(support): guard Copy Logs against breaking on emoji and non-English text

### DIFF
--- a/mobile/lib/services/bug_report_service.dart
+++ b/mobile/lib/services/bug_report_service.dart
@@ -698,10 +698,10 @@ class BugReportService {
         final fixedText = '$header$marker';
         final remaining =
             logClipboardByteBudget - utf8.encode(fixedText).length;
-        final newest = _truncateUtf8(sanitizedLines.last, remaining - 1);
+        final newest = truncateUtf8(sanitizedLines.last, remaining - 1);
         final text = '$fixedText$newest\n';
         return LogClipboardResult.success(
-          _truncateUtf8(text, logClipboardByteBudget),
+          truncateUtf8(text, logClipboardByteBudget),
         );
       }
 
@@ -738,7 +738,8 @@ class BugReportService {
   static String _omittedMarker(int omitted) =>
       omitted > 0 ? '... [$omitted earlier entries omitted]\n' : '';
 
-  static String _truncateUtf8(String value, int maxBytes) {
+  @visibleForTesting
+  static String truncateUtf8(String value, int maxBytes) {
     if (maxBytes <= 0) return '';
     final bytes = utf8.encode(value);
     if (bytes.length <= maxBytes) return value;

--- a/mobile/test/services/bug_report_log_export_test.dart
+++ b/mobile/test/services/bug_report_log_export_test.dart
@@ -184,9 +184,11 @@ void main() {
 
         expect(result.status, equals(LogClipboardStatus.success));
         expect(result.text, contains('newest failure'));
+        // An ASCII cut never backs off, so the copy fills the ceiling exactly.
+        // A bound alone would leave a shrunken newest-line budget green.
         expect(
           utf8.encode(result.text!).length,
-          lessThanOrEqualTo(BugReportService.logClipboardByteBudget),
+          equals(BugReportService.logClipboardByteBudget),
         );
       },
     );
@@ -196,12 +198,15 @@ void main() {
     test(
       'keeps multi-byte content within the clipboard byte ceiling',
       () async {
-        const reps = BugReportService.logClipboardByteBudget ~/ 4 + 500;
+        const emoji = '\u{1F3AC}';
+        final emojiBytes = utf8.encode(emoji).length;
+        final reps =
+            BugReportService.logClipboardByteBudget ~/ emojiBytes + 500;
         LogCaptureService().captureLog(
           LogEntry(
             timestamp: DateTime(2026, 8, 24),
             level: LogLevel.error,
-            message: 'newest failure ${'\u{1F3AC}' * reps}',
+            message: 'newest failure ${emoji * reps}',
           ),
         );
 
@@ -211,9 +216,15 @@ void main() {
 
         expect(result.status, equals(LogClipboardStatus.success));
         expect(result.text, contains('newest failure'));
+        // The back-off costs at most a partial character, so the copy stays at
+        // the ceiling instead of collapsing toward it. Deriving the slack from
+        // the character keeps the bound tight if this test ever swaps it.
         expect(
           utf8.encode(result.text!).length,
-          lessThanOrEqualTo(BugReportService.logClipboardByteBudget),
+          inInclusiveRange(
+            BugReportService.logClipboardByteBudget - (emojiBytes - 1),
+            BugReportService.logClipboardByteBudget,
+          ),
         );
       },
     );

--- a/mobile/test/services/bug_report_log_export_test.dart
+++ b/mobile/test/services/bug_report_log_export_test.dart
@@ -191,27 +191,17 @@ void main() {
       },
     );
 
-    // The oversized-line case above is all ASCII, so the cut lands on a
-    // character boundary and the back-off loop in _truncateUtf8 never runs:
-    // removing that loop leaves the case above green. Multi-byte units force
-    // the cut mid-sequence, and
-    // a truncation that ignored it would hand the clipboard malformed UTF-8:
-    // `utf8.decode` throws, and `copyVerified` compares the read-back value
-    // exactly, so the user would get "Couldn't copy the logs".
-    for (final (label, unit) in const [
-      ('4-byte emoji', '\u{1F3AC}'),
-      ('3-byte CJK', '\u65E5'),
-      ('2-byte accent', '\u00E9'),
-    ]) {
-      test('truncates on a character boundary with a $label line', () async {
-        final unitBytes = utf8.encode(unit).length;
-        final reps =
-            (BugReportService.logClipboardByteBudget ~/ unitBytes) + 500;
+    // Exercise the clipboard assembly with non-ASCII content. Exact byte
+    // boundary behavior is covered deterministically below.
+    test(
+      'keeps multi-byte content within the clipboard byte ceiling',
+      () async {
+        const reps = BugReportService.logClipboardByteBudget ~/ 4 + 500;
         LogCaptureService().captureLog(
           LogEntry(
             timestamp: DateTime(2026, 8, 24),
             level: LogLevel.error,
-            message: 'newest failure ${unit * reps}',
+            message: 'newest failure ${'\u{1F3AC}' * reps}',
           ),
         );
 
@@ -221,19 +211,40 @@ void main() {
 
         expect(result.status, equals(LogClipboardStatus.success));
         expect(result.text, contains('newest failure'));
-
-        final bytes = utf8.encode(result.text!);
         expect(
-          bytes.length,
+          utf8.encode(result.text!).length,
           lessThanOrEqualTo(BugReportService.logClipboardByteBudget),
         );
-        // Throws FormatException on a split multi-byte sequence.
-        expect(() => utf8.decode(bytes), returnsNormally);
-        // The back-off cost at most one unit, so the copy stays near the cap
-        // rather than collapsing to the header.
+      },
+    );
+
+    for (final (label, unit) in const [
+      ('4-byte emoji', '\u{1F3AC}'),
+      ('3-byte CJK', '\u65E5'),
+      ('2-byte accent', '\u00E9'),
+    ]) {
+      test('backs off every incomplete $label sequence', () {
+        const prefix = 'ASCII prefix ';
+        const suffix = ' trailing text';
+        final value = '$prefix$unit$suffix';
+        final prefixBytes = utf8.encode(prefix).length;
+        final unitBytes = utf8.encode(unit).length;
+
+        for (
+          var includedBytes = 1;
+          includedBytes < unitBytes;
+          includedBytes++
+        ) {
+          expect(
+            BugReportService.truncateUtf8(value, prefixBytes + includedBytes),
+            equals(prefix),
+            reason: 'included $includedBytes of $unitBytes bytes',
+          );
+        }
+
         expect(
-          bytes.length,
-          greaterThan(BugReportService.logClipboardByteBudget - unitBytes),
+          BugReportService.truncateUtf8(value, prefixBytes + unitBytes),
+          equals('$prefix$unit'),
         );
       });
     }

--- a/mobile/test/services/bug_report_log_export_test.dart
+++ b/mobile/test/services/bug_report_log_export_test.dart
@@ -191,6 +191,53 @@ void main() {
       },
     );
 
+    // The oversized-line case above is all ASCII, so the cut lands on a
+    // character boundary and the back-off loop in _truncateUtf8 never runs:
+    // removing that loop leaves the case above green. Multi-byte units force
+    // the cut mid-sequence, and
+    // a truncation that ignored it would hand the clipboard malformed UTF-8:
+    // `utf8.decode` throws, and `copyVerified` compares the read-back value
+    // exactly, so the user would get "Couldn't copy the logs".
+    for (final (label, unit) in const [
+      ('4-byte emoji', '\u{1F3AC}'),
+      ('3-byte CJK', '\u65E5'),
+      ('2-byte accent', '\u00E9'),
+    ]) {
+      test('truncates on a character boundary with a $label line', () async {
+        final unitBytes = utf8.encode(unit).length;
+        final reps =
+            (BugReportService.logClipboardByteBudget ~/ unitBytes) + 500;
+        LogCaptureService().captureLog(
+          LogEntry(
+            timestamp: DateTime(2026, 8, 24),
+            level: LogLevel.error,
+            message: 'newest failure ${unit * reps}',
+          ),
+        );
+
+        final result = await BugReportService(
+          packageInfoLoader: _loadPackageInfo,
+        ).buildLogClipboardText();
+
+        expect(result.status, equals(LogClipboardStatus.success));
+        expect(result.text, contains('newest failure'));
+
+        final bytes = utf8.encode(result.text!);
+        expect(
+          bytes.length,
+          lessThanOrEqualTo(BugReportService.logClipboardByteBudget),
+        );
+        // Throws FormatException on a split multi-byte sequence.
+        expect(() => utf8.decode(bytes), returnsNormally);
+        // The back-off cost at most one unit, so the copy stays near the cap
+        // rather than collapsing to the header.
+        expect(
+          bytes.length,
+          greaterThan(BugReportService.logClipboardByteBudget - unitBytes),
+        );
+      });
+    }
+
     test(
       'reports a header diagnostic failure separately from no logs',
       () async {


### PR DESCRIPTION
Copying logs from Support Center caps the clipboard payload at 64 KB so it stays pasteable into a support ticket. That ceiling is measured in bytes, so it can fall inside an emoji, accented character, or non-Latin character.

#8115 already backs the cut up to a complete UTF-8 character. The existing oversized test used only ASCII, though, so deleting that boundary handling still left the test green.

## What this adds

- Direct, fixed-offset tests for every incomplete position in representative 2-byte, 3-byte, and 4-byte characters.
- One end-to-end oversized emoji case that keeps coverage on the full clipboard assembly path and its 64 KB ceiling.
- Lower bounds on how full both oversized copies stay, so shrinking the byte budget for the newest line cannot pass silently. The multi-byte slack is derived from the character under test rather than written as a literal, so swapping that character cannot loosen the bound by accident.
- A testing-only public annotation on the existing truncation helper so the boundary behavior can be exercised without depending on the runtime-generated header's variable byte length.

## Not changed

There is no runtime behavior change. The existing UTF-8 truncation algorithm is unchanged; only its visibility for testing and its regression coverage changed.

## Verification

- `dart format lib test integration_test` — clean
- `flutter analyze lib test integration_test` — no issues
- `flutter test test/services/bug_report_log_export_test.dart` — 27 passed
- Pre-push affected tests — 42 passed, 2 platform-specific skips
- Mutation: replacing the back-off with `allowMalformed: true` fails all three direct boundary tests and the end-to-end emoji case
- Mutation: halving the byte budget for the newest line fails both oversized end-to-end cases

Relates to #8112 and to the truncation added in #8115.
