### PR TITLE
fix(dm): scope account-switch DM cleanup to the leaving account

### DIFF
--- a/mobile/lib/providers/social_providers.dart
+++ b/mobile/lib/providers/social_providers.dart
@@ -719,10 +719,13 @@ UserDataCleanupService userDataCleanupService(Ref ref) {
   // Escaping cleanup reads must go through port providers; direct reads of
   // auth-dependent providers from this callback can recreate #7389.
   //
-  // When [deleteUserData] is true (destructive sign-out or identity change),
-  // also deletes per-user DAO rows scoped by [userPubkey].
-  // Non-destructive sign-out (account switch) skips per-user deletion since
-  // those rows are already scoped by ownerPubkey.
+  // Every delete here is scoped to [userPubkey], the account being left. The
+  // DM family used to be wiped unqualified on this path, which destroyed every
+  // account's decrypted history on an ordinary switch (#7325).
+  //
+  // [deleteUserData] additionally widens the destructive paths: it drops rows
+  // this account may still need (removal tombstones, retryable reactions) that
+  // a plain switch deliberately preserves.
   service.onDatabaseCleanup =
       ({String? userPubkey, bool deleteUserData = false}) async {
         Future<void> safeCleanup(
@@ -756,19 +759,41 @@ UserDataCleanupService userDataCleanupService(Ref ref) {
             category: LogCategory.auth,
           );
         }
-        await safeCleanup('directMessages', db.directMessagesDao.clearAll);
-        await safeCleanup('conversations', db.conversationsDao.clearAll);
-        // Raw failed-decrypt gift wraps are encrypted DM data of the same
-        // class as direct_messages — wipe them on the same path so they never
-        // outlive the account's decrypted DMs. See #5202.
-        await safeCleanup('pendingGiftWraps', db.pendingGiftWrapsDao.clearAll);
-        // Wipe the processed-wrap dedup ledger on the same path: a stale ledger
-        // must never suppress re-population of an account's reactions/deletions
-        // after its DM data is cleared. See #5452.
-        await safeCleanup(
-          'processedGiftWraps',
-          db.processedGiftWrapsDao.clearAll,
-        );
+        // Scoped to the leaving account. These were unqualified deletes, which
+        // destroyed every account's decrypted DM history on an ordinary switch
+        // or sign-out — reads are already owner-filtered, so the wipe bought
+        // nothing it did not already have. Legacy NULL-owner rows, the reason
+        // the unscoped form was chosen, are drained by claimLegacyRows at
+        // session setup. See #7325.
+        //
+        // When userPubkey is null there is no account to scope to; skip rather
+        // than fall back to clearAll. The rows stay invisible to the incoming
+        // account through ownerPubkey filtering, and the claim below adopts
+        // any that are still unowned.
+        if (userPubkey != null) {
+          await safeCleanup(
+            'directMessages',
+            () => db.directMessagesDao.clearAllForUser(userPubkey),
+          );
+          await safeCleanup(
+            'conversations',
+            () => db.conversationsDao.clearAllForUser(userPubkey),
+          );
+          // Raw failed-decrypt gift wraps are encrypted DM data of the same
+          // class as direct_messages — wipe them on the same path so they
+          // never outlive the account's decrypted DMs. See #5202.
+          await safeCleanup(
+            'pendingGiftWraps',
+            () => db.pendingGiftWrapsDao.clearAllForUser(userPubkey),
+          );
+          // Wipe the processed-wrap dedup ledger on the same path: a stale
+          // ledger must never suppress re-population of an account's
+          // reactions/deletions after its DM data is cleared. See #5452.
+          await safeCleanup(
+            'processedGiftWraps',
+            () => db.processedGiftWrapsDao.clearAllForUser(userPubkey),
+          );
+        }
         if (deleteUserData && userPubkey != null) {
           await safeCleanup(
             'removedConversations',

--- a/mobile/lib/providers/social_providers.dart
+++ b/mobile/lib/providers/social_providers.dart
@@ -829,9 +829,26 @@ UserDataCleanupService userDataCleanupService(Ref ref) {
           'identityVerifications',
           db.identityVerificationsDao.clearAll,
         );
-        // Clear DM sync cursors so the next login triggers a full re-fetch
-        // from relays instead of using stale `since:` boundaries.
-        await safeCleanup('dmSyncState', () => DmSyncState(prefs).clearAll());
+        // Clear the leaving account's DM sync cursors so its next login
+        // re-fetches from relays instead of resuming from a `since:` boundary
+        // whose local rows have just been deleted.
+        //
+        // Per-pubkey, not clearAll: the sweep is prefix-based over every
+        // account's keys, so a switch used to drop the *other* accounts'
+        // cursors and drain-complete flags too, re-opening a full history
+        // re-download for each of them. `clear` has existed for this since it
+        // was written — its doc comment already says "Called on account
+        // switch" — it just was never wired up. See #7325.
+        //
+        // main.dart's onDatabaseReset callers keep clearAll: there the whole
+        // database was recreated, so every account's cursors are genuinely
+        // stale.
+        if (userPubkey != null) {
+          await safeCleanup(
+            'dmSyncState',
+            () => DmSyncState(prefs).clear(userPubkey),
+          );
+        }
 
         // Per-user data cleanup (#2999): only on destructive paths
         if (deleteUserData && userPubkey != null) {

--- a/mobile/lib/providers/social_providers.dart
+++ b/mobile/lib/providers/social_providers.dart
@@ -152,10 +152,7 @@ Stream<void> dmMessageRetryTriggerWithRelayRepair({
 
 /// Whether two connectivity reports describe the same set of transports.
 /// Order-insensitive: `connectivity_plus` gives no ordering guarantee.
-bool _sameConnectivity(
-  List<ConnectivityResult> a,
-  List<ConnectivityResult> b,
-) {
+bool _sameConnectivity(List<ConnectivityResult> a, List<ConnectivityResult> b) {
   final aSet = a.toSet();
   final bSet = b.toSet();
   return aSet.length == bSet.length && aSet.containsAll(bSet);
@@ -606,9 +603,7 @@ AnalyticsService analyticsService(Ref ref) {
   final appVersion = resolveProductAnalyticsRelease(
     runtimeVersion: ref.watch(appVersionProvider),
     environment: const String.fromEnvironment('DEFAULT_ENV'),
-    stagingOverride: const String.fromEnvironment(
-      'PRODUCT_ANALYTICS_RELEASE',
-    ),
+    stagingOverride: const String.fromEnvironment('PRODUCT_ANALYTICS_RELEASE'),
   );
   final service = AnalyticsService(
     viewEventPublisher: viewPublisher,
@@ -888,6 +883,14 @@ UserDataCleanupService userDataCleanupService(Ref ref) {
     // unattributed. Claim them for the first account to sign in after the
     // upgrade rather than leaving them visible to every account.
     await db.notificationsDao.claimLegacyRows(userPubkey);
+    // The DM tables gained `owner_pubkey` nullable with no backfill, so every
+    // row written before multi-account support is NULL-owned. Reads treat NULL
+    // as "visible to everyone" (`_ownedOrLegacy`), and no owner-scoped delete
+    // can reach them, which is why the cleanup callback used to wipe the whole
+    // table. Claim them here so the scoped delete below is complete. See #7325.
+    await db.directMessagesDao.claimLegacyRows(userPubkey);
+    await db.conversationsDao.claimLegacyRows(userPubkey);
+    await db.processedGiftWrapsDao.claimLegacyRows(userPubkey);
   };
 
   return service;

--- a/mobile/lib/providers/social_providers.dart
+++ b/mobile/lib/providers/social_providers.dart
@@ -743,7 +743,24 @@ UserDataCleanupService userDataCleanupService(Ref ref) {
           }
         }
 
-        await safeCleanup(
+        Future<void> requiredCleanup(
+          String name,
+          Future<void> Function() fn,
+        ) async {
+          try {
+            await fn();
+          } catch (e) {
+            Log.error(
+              'Required account-boundary cleanup failed for $name and '
+              '${pubkeyForLogs(userPubkey, whenNull: "unknown user")}: $e',
+              name: 'UserDataCleanup',
+              category: LogCategory.auth,
+            );
+            rethrow;
+          }
+        }
+
+        await requiredCleanup(
           'dmRepository',
           () => ref.read(dmListeningStopProvider)(),
         );
@@ -759,41 +776,28 @@ UserDataCleanupService userDataCleanupService(Ref ref) {
             category: LogCategory.auth,
           );
         }
-        // Scoped to the leaving account. These were unqualified deletes, which
-        // destroyed every account's decrypted DM history on an ordinary switch
-        // or sign-out — reads are already owner-filtered, so the wipe bought
-        // nothing it did not already have. Legacy NULL-owner rows, the reason
-        // the unscoped form was chosen, are drained by claimLegacyRows at
-        // session setup. See #7325.
-        //
-        // When userPubkey is null there is no account to scope to; skip rather
-        // than fall back to clearAll. The rows stay invisible to the incoming
-        // account through ownerPubkey filtering, and the claim below adopts
-        // any that are still unowned.
-        if (userPubkey != null) {
-          await safeCleanup(
-            'directMessages',
-            () => db.directMessagesDao.clearAllForUser(userPubkey),
-          );
-          await safeCleanup(
-            'conversations',
-            () => db.conversationsDao.clearAllForUser(userPubkey),
-          );
-          // Raw failed-decrypt gift wraps are encrypted DM data of the same
-          // class as direct_messages — wipe them on the same path so they
-          // never outlive the account's decrypted DMs. See #5202.
-          await safeCleanup(
-            'pendingGiftWraps',
-            () => db.pendingGiftWrapsDao.clearAllForUser(userPubkey),
-          );
-          // Wipe the processed-wrap dedup ledger on the same path: a stale
-          // ledger must never suppress re-population of an account's
-          // reactions/deletions after its DM data is cleared. See #5452.
-          await safeCleanup(
-            'processedGiftWraps',
-            () => db.processedGiftWrapsDao.clearAllForUser(userPubkey),
-          );
-        }
+        // A switch must leave no DM data attributable to the departing account
+        // and must never expose ambiguous legacy data to the incoming account.
+        // Known-owner rows for every other saved account remain intact. When
+        // the departing account is unknown, delete only NULL/empty-owner rows.
+        // See #7325.
+        await requiredCleanup('DM tables', () async {
+          await db.transaction(() async {
+            if (userPubkey != null) {
+              await db.directMessagesDao.clearForAccountSwitch(userPubkey);
+              await db.conversationsDao.clearForAccountSwitch(userPubkey);
+              // Raw failed-decrypt wraps and their terminal dedup ledger must
+              // never outlive the decrypted DM data they accompany.
+              await db.pendingGiftWrapsDao.clearForAccountSwitch(userPubkey);
+              await db.processedGiftWrapsDao.clearForAccountSwitch(userPubkey);
+            } else {
+              await db.directMessagesDao.clearUnowned();
+              await db.conversationsDao.clearUnowned();
+              await db.pendingGiftWrapsDao.clearUnowned();
+              await db.processedGiftWrapsDao.clearUnowned();
+            }
+          });
+        });
         if (deleteUserData && userPubkey != null) {
           await safeCleanup(
             'removedConversations',
@@ -925,14 +929,6 @@ UserDataCleanupService userDataCleanupService(Ref ref) {
     // unattributed. Claim them for the first account to sign in after the
     // upgrade rather than leaving them visible to every account.
     await db.notificationsDao.claimLegacyRows(userPubkey);
-    // The DM tables gained `owner_pubkey` nullable with no backfill, so every
-    // row written before multi-account support is NULL-owned. Reads treat NULL
-    // as "visible to everyone" (`_ownedOrLegacy`), and no owner-scoped delete
-    // can reach them, which is why the cleanup callback used to wipe the whole
-    // table. Claim them here so the scoped delete below is complete. See #7325.
-    await db.directMessagesDao.claimLegacyRows(userPubkey);
-    await db.conversationsDao.claimLegacyRows(userPubkey);
-    await db.processedGiftWrapsDao.claimLegacyRows(userPubkey);
   };
 
   return service;

--- a/mobile/lib/providers/social_providers.g.dart
+++ b/mobile/lib/providers/social_providers.g.dart
@@ -615,7 +615,7 @@ final class UserDataCleanupServiceProvider
 }
 
 String _$userDataCleanupServiceHash() =>
-    r'c27431231e1be0572388db93b99a2ba33ae919b8';
+    r'a8dcd5fec4d813c0007aa82865f93664bac9d4e3';
 
 /// Hashtag service depends on Video event service and cache service
 

--- a/mobile/lib/providers/social_providers.g.dart
+++ b/mobile/lib/providers/social_providers.g.dart
@@ -615,7 +615,7 @@ final class UserDataCleanupServiceProvider
 }
 
 String _$userDataCleanupServiceHash() =>
-    r'a88da45b797af3535355be5487402f2dabc93ccc';
+    r'd1995f09ff5e196346a62e5a56478091c8b794fb';
 
 /// Hashtag service depends on Video event service and cache service
 

--- a/mobile/lib/providers/social_providers.g.dart
+++ b/mobile/lib/providers/social_providers.g.dart
@@ -615,7 +615,7 @@ final class UserDataCleanupServiceProvider
 }
 
 String _$userDataCleanupServiceHash() =>
-    r'd1995f09ff5e196346a62e5a56478091c8b794fb';
+    r'c27431231e1be0572388db93b99a2ba33ae919b8';
 
 /// Hashtag service depends on Video event service and cache service
 

--- a/mobile/lib/providers/social_providers.g.dart
+++ b/mobile/lib/providers/social_providers.g.dart
@@ -615,7 +615,7 @@ final class UserDataCleanupServiceProvider
 }
 
 String _$userDataCleanupServiceHash() =>
-    r'a8dcd5fec4d813c0007aa82865f93664bac9d4e3';
+    r'c9a969827288ca3b1517947b61f85849b61f9b21';
 
 /// Hashtag service depends on Video event service and cache service
 

--- a/mobile/lib/services/user_data_cleanup_service.dart
+++ b/mobile/lib/services/user_data_cleanup_service.dart
@@ -74,9 +74,7 @@ class UserDataCleanupService {
 
   /// Legacy owner-scoped preference keys that contain user data but may still
   /// need to survive a same-user non-destructive logout.
-  static const List<String> ownerScopedLegacyKeys = [
-    'vine_drafts',
-  ];
+  static const List<String> ownerScopedLegacyKeys = ['vine_drafts'];
 
   static const String legacyDraftOwnerKey = 'vine_drafts_owner_pubkey_hex';
 
@@ -87,8 +85,6 @@ class UserDataCleanupService {
   static const List<String> identityChangePrefixes = [
     'following_list_', // follow cache per pubkey
     'relay_discovery_', // relay discovery cache per npub
-    'dm.newestSyncedAt.', // DM sync cursor per pubkey
-    'dm.oldestSyncedAt.', // DM sync cursor per pubkey
   ];
 
   /// Checks if user-specific data should be cleared for the given pubkey.
@@ -254,7 +250,11 @@ class UserDataCleanupService {
           name: 'UserDataCleanupService',
           category: LogCategory.auth,
         );
-        if (deleteUserData) {
+        // An account switch must fail closed: proceeding after its shared
+        // database cleanup fails can expose the departing account's local DM
+        // state to the incoming session. Ordinary same-account logout remains
+        // best-effort unless it is explicitly destructive.
+        if (deleteUserData || isIdentityChange) {
           rethrow;
         }
       }

--- a/mobile/packages/db_client/lib/src/database/app_database.g.dart
+++ b/mobile/packages/db_client/lib/src/database/app_database.g.dart
@@ -15542,9 +15542,9 @@ class ProcessedGiftWrap extends DataClass
   /// available for any future time-based retention.
   final int processedAt;
 
-  /// Recipient pubkey this wrap was processed for. Informational only — NOT
-  /// part of the dedup key, and not used to scope deletes: account cleanup
-  /// wipes the whole table via `clearAll()`. Retained for diagnostics.
+  /// Recipient pubkey this wrap was processed for. Not part of the global
+  /// gift-wrap dedup key, but used to scope account cleanup without deleting
+  /// another saved account's ledger entries.
   final String? ownerPubkey;
   const ProcessedGiftWrap({
     required this.giftWrapId,

--- a/mobile/packages/db_client/lib/src/database/daos/conversations_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/conversations_dao.dart
@@ -401,10 +401,7 @@ END
       'COALESCE(last_read_timestamp, 0), '
       'COALESCE(last_message_timestamp, 0)) '
       'WHERE id IN ($placeholders)${_ownerSqlClause(ownerPubkey)}',
-      variables: [
-        ...ids.map(Variable.new),
-        ..._ownerSqlVariables(ownerPubkey),
-      ],
+      variables: [...ids.map(Variable.new), ..._ownerSqlVariables(ownerPubkey)],
       updates: {attachedDatabase.conversations},
       updateKind: UpdateKind.update,
     );
@@ -437,6 +434,17 @@ END
     return (delete(
       conversations,
     )..where((t) => t.ownerPubkey.equals(ownerPubkey))).go();
+  }
+
+  /// Claim legacy conversations (NULL `ownerPubkey`) for [newOwnerPubkey].
+  ///
+  /// Called during session setup so pre-multi-account rows are attributed to
+  /// the signed-in account instead of staying visible to every account through
+  /// [_ownedOrLegacy]. Mirrors `NotificationsDao.claimLegacyRows`.
+  Future<int> claimLegacyRows(String newOwnerPubkey) {
+    return (update(conversations)..where((t) => t.ownerPubkey.isNull())).write(
+      ConversationsCompanion(ownerPubkey: Value(newOwnerPubkey)),
+    );
   }
 
   /// Delete all conversations.

--- a/mobile/packages/db_client/lib/src/database/daos/conversations_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/conversations_dao.dart
@@ -429,27 +429,24 @@ END
     return attachedDatabase.transaction(action);
   }
 
-  /// Delete all conversations for a specific user.
-  Future<int> clearAllForUser(String ownerPubkey) {
+  /// Deletes conversations for the departing account plus unattributed legacy
+  /// rows, while preserving every other known account's conversations.
+  Future<int> clearForAccountSwitch(String ownerPubkey) {
+    return (delete(conversations)..where(
+          (t) =>
+              t.ownerPubkey.equals(ownerPubkey) |
+              t.ownerPubkey.isNull() |
+              t.ownerPubkey.equals(''),
+        ))
+        .go();
+  }
+
+  /// Deletes only unattributed legacy rows when the departing account is
+  /// unknown, preserving every row with a valid owner.
+  Future<int> clearUnowned() {
     return (delete(
       conversations,
-    )..where((t) => t.ownerPubkey.equals(ownerPubkey))).go();
-  }
-
-  /// Claim legacy conversations (NULL `ownerPubkey`) for [newOwnerPubkey].
-  ///
-  /// Called during session setup so pre-multi-account rows are attributed to
-  /// the signed-in account instead of staying visible to every account through
-  /// [_ownedOrLegacy]. Mirrors `NotificationsDao.claimLegacyRows`.
-  Future<int> claimLegacyRows(String newOwnerPubkey) {
-    return (update(conversations)..where((t) => t.ownerPubkey.isNull())).write(
-      ConversationsCompanion(ownerPubkey: Value(newOwnerPubkey)),
-    );
-  }
-
-  /// Delete all conversations.
-  Future<int> clearAll() {
-    return delete(conversations).go();
+    )..where((t) => t.ownerPubkey.isNull() | t.ownerPubkey.equals(''))).go();
   }
 
   /// Backfill `current_user_has_sent` for conversations where the user

--- a/mobile/packages/db_client/lib/src/database/daos/direct_messages_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/direct_messages_dao.dart
@@ -347,28 +347,25 @@ class DirectMessagesDao extends DatabaseAccessor<AppDatabase>
     return attachedDatabase.transaction(action);
   }
 
-  /// Delete all DMs for a specific user.
-  Future<int> clearAllForUser(String ownerPubkey) {
+  /// Deletes DMs for the departing account plus unattributed legacy rows.
+  ///
+  /// Ambiguous rows must never cross an account boundary and become visible to
+  /// the incoming account. Rows owned by every other known account survive.
+  Future<int> clearForAccountSwitch(String ownerPubkey) {
+    return (delete(directMessages)..where(
+          (t) =>
+              t.ownerPubkey.equals(ownerPubkey) |
+              t.ownerPubkey.isNull() |
+              t.ownerPubkey.equals(''),
+        ))
+        .go();
+  }
+
+  /// Deletes only unattributed legacy rows when the departing account is
+  /// unknown, preserving every row with a valid owner.
+  Future<int> clearUnowned() {
     return (delete(
       directMessages,
-    )..where((t) => t.ownerPubkey.equals(ownerPubkey))).go();
-  }
-
-  /// Claim legacy DMs (NULL `ownerPubkey`) for [newOwnerPubkey].
-  ///
-  /// Called during session setup so pre-multi-account rows are attributed to
-  /// the signed-in account instead of staying visible to every account through
-  /// [_ownedOrLegacy]. Mirrors `NotificationsDao.claimLegacyRows`; without it
-  /// an owner-scoped delete can never reach these rows, because the column was
-  /// added nullable with no backfill.
-  Future<int> claimLegacyRows(String newOwnerPubkey) {
-    return (update(directMessages)..where((t) => t.ownerPubkey.isNull())).write(
-      DirectMessagesCompanion(ownerPubkey: Value(newOwnerPubkey)),
-    );
-  }
-
-  /// Delete all DMs.
-  Future<int> clearAll() {
-    return delete(directMessages).go();
+    )..where((t) => t.ownerPubkey.isNull() | t.ownerPubkey.equals(''))).go();
   }
 }

--- a/mobile/packages/db_client/lib/src/database/daos/direct_messages_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/direct_messages_dao.dart
@@ -354,6 +354,19 @@ class DirectMessagesDao extends DatabaseAccessor<AppDatabase>
     )..where((t) => t.ownerPubkey.equals(ownerPubkey))).go();
   }
 
+  /// Claim legacy DMs (NULL `ownerPubkey`) for [newOwnerPubkey].
+  ///
+  /// Called during session setup so pre-multi-account rows are attributed to
+  /// the signed-in account instead of staying visible to every account through
+  /// [_ownedOrLegacy]. Mirrors `NotificationsDao.claimLegacyRows`; without it
+  /// an owner-scoped delete can never reach these rows, because the column was
+  /// added nullable with no backfill.
+  Future<int> claimLegacyRows(String newOwnerPubkey) {
+    return (update(directMessages)..where((t) => t.ownerPubkey.isNull())).write(
+      DirectMessagesCompanion(ownerPubkey: Value(newOwnerPubkey)),
+    );
+  }
+
   /// Delete all DMs.
   Future<int> clearAll() {
     return delete(directMessages).go();

--- a/mobile/packages/db_client/lib/src/database/daos/outgoing_dms_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/outgoing_dms_dao.dart
@@ -460,7 +460,7 @@ class OutgoingDmsDao extends DatabaseAccessor<AppDatabase>
 
   /// Delete every queued outgoing DM owned by [ownerPubkey].
   ///
-  /// Mirrors [DirectMessagesDao.clearAllForUser]: the repository calls
+  /// Mirrors [DirectMessagesDao.clearForAccountSwitch]: cleanup calls
   /// this from the signout / account-switch path so a different
   /// account's retry service never picks up the previous user's
   /// in-flight rows. Returns the number of rows removed.

--- a/mobile/packages/db_client/lib/src/database/daos/pending_gift_wraps_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/pending_gift_wraps_dao.dart
@@ -41,6 +41,13 @@ class PendingGiftWrapsDao extends DatabaseAccessor<AppDatabase>
     required String rawJson,
     required int createdAt,
   }) async {
+    if (ownerPubkey.isEmpty) {
+      throw ArgumentError.value(
+        ownerPubkey,
+        'ownerPubkey',
+        'must not be empty',
+      );
+    }
     final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
     await transaction(() async {
       final existing =
@@ -106,21 +113,22 @@ class PendingGiftWrapsDao extends DatabaseAccessor<AppDatabase>
         .go();
   }
 
-  /// Removes every pending row owned by [ownerPubkey].
-  ///
-  /// `ownerPubkey` is non-nullable here and part of the primary key, so this
-  /// is exhaustive for that account — there are no legacy NULL-owner rows to
-  /// strand, unlike `direct_messages`. See #7325.
-  Future<int> clearAllForUser(String ownerPubkey) {
-    return (delete(
-      pendingGiftWraps,
-    )..where((t) => t.ownerPubkey.equals(ownerPubkey))).go();
+  /// Deletes pending wraps for the departing account plus any rows written
+  /// with the legacy empty owner, preserving every other known account.
+  Future<int> clearForAccountSwitch(String ownerPubkey) {
+    return (delete(pendingGiftWraps)..where(
+          (t) => t.ownerPubkey.equals(ownerPubkey) | t.ownerPubkey.equals(''),
+        ))
+        .go();
   }
 
-  /// Removes every pending row. Called during account cleanup (switch /
-  /// destructive sign-out) alongside the other DM-table wipes so an account's
-  /// raw (still-encrypted) gift wraps never outlive its decrypted DM data.
-  Future<int> clearAll() => delete(pendingGiftWraps).go();
+  /// Deletes only legacy empty-owner rows when the departing account is
+  /// unknown, preserving every row with a valid owner.
+  Future<int> clearUnowned() {
+    return (delete(
+      pendingGiftWraps,
+    )..where((t) => t.ownerPubkey.equals(''))).go();
+  }
 
   /// Returns rows for [ownerPubkey] still below [maxAttempts], newest first
   /// (so recent conversations are recovered before older ones).

--- a/mobile/packages/db_client/lib/src/database/daos/pending_gift_wraps_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/pending_gift_wraps_dao.dart
@@ -106,6 +106,17 @@ class PendingGiftWrapsDao extends DatabaseAccessor<AppDatabase>
         .go();
   }
 
+  /// Removes every pending row owned by [ownerPubkey].
+  ///
+  /// `ownerPubkey` is non-nullable here and part of the primary key, so this
+  /// is exhaustive for that account — there are no legacy NULL-owner rows to
+  /// strand, unlike `direct_messages`. See #7325.
+  Future<int> clearAllForUser(String ownerPubkey) {
+    return (delete(
+      pendingGiftWraps,
+    )..where((t) => t.ownerPubkey.equals(ownerPubkey))).go();
+  }
+
   /// Removes every pending row. Called during account cleanup (switch /
   /// destructive sign-out) alongside the other DM-table wipes so an account's
   /// raw (still-encrypted) gift wraps never outlive its decrypted DM data.

--- a/mobile/packages/db_client/lib/src/database/daos/processed_gift_wraps_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/processed_gift_wraps_dao.dart
@@ -66,6 +66,17 @@ class ProcessedGiftWrapsDao extends DatabaseAccessor<AppDatabase>
         .write(ProcessedGiftWrapsCompanion(ownerPubkey: Value(newOwnerPubkey)));
   }
 
+  /// Removes every processed-wrap row owned by [ownerPubkey].
+  ///
+  /// Legacy NULL-owner rows are claimed at session setup
+  /// ([claimLegacyRows]), so a scoped delete reaches them on the next switch.
+  /// See #7325.
+  Future<int> clearAllForUser(String ownerPubkey) {
+    return (delete(
+      processedGiftWraps,
+    )..where((t) => t.ownerPubkey.equals(ownerPubkey))).go();
+  }
+
   /// Removes every processed-wrap row. Called during account cleanup (switch /
   /// destructive sign-out) alongside the other DM-table wipes so a stale ledger
   /// can never suppress re-population of an account's reactions/deletions.

--- a/mobile/packages/db_client/lib/src/database/daos/processed_gift_wraps_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/processed_gift_wraps_dao.dart
@@ -47,10 +47,7 @@ class ProcessedGiftWrapsDao extends DatabaseAccessor<AppDatabase>
   /// wrap or a concurrent writer never throws). [ownerPubkey] is informational
   /// only — not part of the dedup key, and not used to scope deletes (cleanup
   /// is global via [clearAll]).
-  Future<void> record({
-    required String giftWrapId,
-    String? ownerPubkey,
-  }) async {
+  Future<void> record({required String giftWrapId, String? ownerPubkey}) async {
     final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
     await into(processedGiftWraps).insert(
       ProcessedGiftWrapsCompanion.insert(
@@ -60,6 +57,13 @@ class ProcessedGiftWrapsDao extends DatabaseAccessor<AppDatabase>
       ),
       mode: InsertMode.insertOrIgnore,
     );
+  }
+
+  /// Claim legacy processed-wrap rows (NULL `ownerPubkey`) for
+  /// [newOwnerPubkey], so an owner-scoped delete can reach them.
+  Future<int> claimLegacyRows(String newOwnerPubkey) {
+    return (update(processedGiftWraps)..where((t) => t.ownerPubkey.isNull()))
+        .write(ProcessedGiftWrapsCompanion(ownerPubkey: Value(newOwnerPubkey)));
   }
 
   /// Removes every processed-wrap row. Called during account cleanup (switch /

--- a/mobile/packages/db_client/lib/src/database/daos/processed_gift_wraps_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/processed_gift_wraps_dao.dart
@@ -44,10 +44,20 @@ class ProcessedGiftWrapsDao extends DatabaseAccessor<AppDatabase>
   }
 
   /// Records [giftWrapId] as terminally processed (idempotent — a re-delivered
-  /// wrap or a concurrent writer never throws). [ownerPubkey] is informational
-  /// only — not part of the dedup key, and not used to scope deletes (cleanup
-  /// is global via [clearAll]).
-  Future<void> record({required String giftWrapId, String? ownerPubkey}) async {
+  /// wrap or a concurrent writer never throws). [ownerPubkey] is not part of
+  /// the dedup key, but is required so account cleanup can remove the correct
+  /// ledger entry without affecting another local account.
+  Future<void> record({
+    required String giftWrapId,
+    required String ownerPubkey,
+  }) async {
+    if (ownerPubkey.isEmpty) {
+      throw ArgumentError.value(
+        ownerPubkey,
+        'ownerPubkey',
+        'must not be empty',
+      );
+    }
     final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
     await into(processedGiftWraps).insert(
       ProcessedGiftWrapsCompanion.insert(
@@ -59,28 +69,25 @@ class ProcessedGiftWrapsDao extends DatabaseAccessor<AppDatabase>
     );
   }
 
-  /// Claim legacy processed-wrap rows (NULL `ownerPubkey`) for
-  /// [newOwnerPubkey], so an owner-scoped delete can reach them.
-  Future<int> claimLegacyRows(String newOwnerPubkey) {
-    return (update(processedGiftWraps)..where((t) => t.ownerPubkey.isNull()))
-        .write(ProcessedGiftWrapsCompanion(ownerPubkey: Value(newOwnerPubkey)));
+  /// Deletes ledger rows for the departing account plus unattributed legacy
+  /// rows, while preserving every other known account's ledger entries.
+  Future<int> clearForAccountSwitch(String ownerPubkey) {
+    return (delete(processedGiftWraps)..where(
+          (t) =>
+              t.ownerPubkey.equals(ownerPubkey) |
+              t.ownerPubkey.isNull() |
+              t.ownerPubkey.equals(''),
+        ))
+        .go();
   }
 
-  /// Removes every processed-wrap row owned by [ownerPubkey].
-  ///
-  /// Legacy NULL-owner rows are claimed at session setup
-  /// ([claimLegacyRows]), so a scoped delete reaches them on the next switch.
-  /// See #7325.
-  Future<int> clearAllForUser(String ownerPubkey) {
+  /// Deletes only unattributed legacy rows when the departing account is
+  /// unknown, preserving every row with a valid owner.
+  Future<int> clearUnowned() {
     return (delete(
       processedGiftWraps,
-    )..where((t) => t.ownerPubkey.equals(ownerPubkey))).go();
+    )..where((t) => t.ownerPubkey.isNull() | t.ownerPubkey.equals(''))).go();
   }
-
-  /// Removes every processed-wrap row. Called during account cleanup (switch /
-  /// destructive sign-out) alongside the other DM-table wipes so a stale ledger
-  /// can never suppress re-population of an account's reactions/deletions.
-  Future<int> clearAll() => delete(processedGiftWraps).go();
 
   /// Total processed-wrap rows (diagnostics / tests).
   Future<int> count() async {

--- a/mobile/packages/db_client/lib/src/database/tables.dart
+++ b/mobile/packages/db_client/lib/src/database/tables.dart
@@ -1529,9 +1529,9 @@ class ProcessedGiftWraps extends Table {
   /// available for any future time-based retention.
   IntColumn get processedAt => integer().named('processed_at')();
 
-  /// Recipient pubkey this wrap was processed for. Informational only — NOT
-  /// part of the dedup key, and not used to scope deletes: account cleanup
-  /// wipes the whole table via `clearAll()`. Retained for diagnostics.
+  /// Recipient pubkey this wrap was processed for. Not part of the global
+  /// gift-wrap dedup key, but used to scope account cleanup without deleting
+  /// another saved account's ledger entries.
   TextColumn get ownerPubkey => text().nullable().named('owner_pubkey')();
 
   @override

--- a/mobile/packages/db_client/test/src/database/daos/conversations_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/conversations_dao_test.dart
@@ -985,34 +985,6 @@ void main() {
       });
     });
 
-    group('clearAll', () {
-      test('deletes all conversations', () async {
-        await dao.upsertConversation(
-          id: 'conv_1',
-          participantPubkeys: '["a","b"]',
-          isGroup: false,
-          createdAt: 1700000000,
-        );
-        await dao.upsertConversation(
-          id: 'conv_2',
-          participantPubkeys: '["a","c"]',
-          isGroup: false,
-          createdAt: 1700000000,
-        );
-
-        final deleted = await dao.clearAll();
-
-        expect(deleted, equals(2));
-        final results = await dao.getAllConversations();
-        expect(results, isEmpty);
-      });
-
-      test('returns 0 when table is empty', () async {
-        final deleted = await dao.clearAll();
-        expect(deleted, equals(0));
-      });
-    });
-
     group('ownerPubkey scoping', () {
       const userA = 'pubkey_user_a';
       const userB = 'pubkey_user_b';
@@ -1071,31 +1043,34 @@ void main() {
         },
       );
 
-      test('clearAllForUser only deletes that user conversations', () async {
-        await dao.upsertConversation(
-          id: 'conv_a1',
-          participantPubkeys: '["pubkey_a","pubkey_b"]',
-          isGroup: false,
-          createdAt: 1700000000,
-          lastMessageTimestamp: 1700000100,
-          ownerPubkey: userA,
-        );
-        await dao.upsertConversation(
-          id: 'conv_b1',
-          participantPubkeys: '["pubkey_c","pubkey_d"]',
-          isGroup: false,
-          createdAt: 1700000000,
-          lastMessageTimestamp: 1700000200,
-          ownerPubkey: userB,
-        );
+      test(
+        'account-switch cleanup preserves another user conversations',
+        () async {
+          await dao.upsertConversation(
+            id: 'conv_a1',
+            participantPubkeys: '["pubkey_a","pubkey_b"]',
+            isGroup: false,
+            createdAt: 1700000000,
+            lastMessageTimestamp: 1700000100,
+            ownerPubkey: userA,
+          );
+          await dao.upsertConversation(
+            id: 'conv_b1',
+            participantPubkeys: '["pubkey_c","pubkey_d"]',
+            isGroup: false,
+            createdAt: 1700000000,
+            lastMessageTimestamp: 1700000200,
+            ownerPubkey: userB,
+          );
 
-        final deleted = await dao.clearAllForUser(userA);
+          final deleted = await dao.clearForAccountSwitch(userA);
 
-        expect(deleted, equals(1));
-        final remaining = await dao.getAllConversations(ownerPubkey: userB);
-        expect(remaining, hasLength(1));
-        expect(remaining.first.id, equals('conv_b1'));
-      });
+          expect(deleted, equals(1));
+          final remaining = await dao.getAllConversations(ownerPubkey: userB);
+          expect(remaining, hasLength(1));
+          expect(remaining.first.id, equals('conv_b1'));
+        },
+      );
 
       test('unread count respects ownerPubkey', () async {
         await dao.upsertConversation(

--- a/mobile/packages/db_client/test/src/database/daos/direct_messages_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/direct_messages_dao_test.dart
@@ -892,84 +892,44 @@ void main() {
       });
     });
 
-    group('claimLegacyRows', () {
-      const userA = 'pubkey_claim_a';
-      const userB = 'pubkey_claim_b';
+    group('account-switch cleanup', () {
+      const userA = 'pubkey_cleanup_a';
+      const userB = 'pubkey_cleanup_b';
 
-      test('adopts NULL-owner rows and leaves owned rows alone', () async {
-        await dao.insertMessage(
-          id: 'msg_legacy',
+      Future<void> insert(String id, String? ownerPubkey) {
+        return dao.insertMessage(
+          id: id,
           conversationId: conversationId1,
           senderPubkey: 'pubkey_alice',
-          content: 'Legacy message',
+          content: id,
           createdAt: 1700000001,
-          giftWrapId: 'gw_legacy',
+          giftWrapId: 'gw_$id',
+          ownerPubkey: ownerPubkey,
         );
-        await dao.insertMessage(
-          id: 'msg_b1',
-          conversationId: conversationId1,
-          senderPubkey: 'pubkey_bob',
-          content: 'User B message',
-          createdAt: 1700000002,
-          giftWrapId: 'gw_b1',
-          ownerPubkey: userB,
-        );
+      }
 
-        final claimed = await dao.claimLegacyRows(userA);
+      test('deletes the leaving account and ambiguous owners', () async {
+        await insert('msg_a', userA);
+        await insert('msg_b', userB);
+        await insert('msg_null', null);
+        await insert('msg_empty', '');
 
-        expect(claimed, equals(1));
-        // The adopted row is now reachable by an owner-scoped delete, which is
-        // the whole point — before #7325 nothing could ever delete it.
-        expect(await dao.clearAllForUser(userA), equals(1));
+        expect(await dao.clearForAccountSwitch(userA), equals(3));
         expect(await dao.countMessages(conversationId1), equals(1));
+        expect(
+          await dao.countMessages(conversationId1, ownerPubkey: userB),
+          equals(1),
+        );
       });
 
-      test('returns 0 when there is nothing unowned', () async {
-        await dao.insertMessage(
-          id: 'msg_a1',
-          conversationId: conversationId1,
-          senderPubkey: 'pubkey_alice',
-          content: 'User A message',
-          createdAt: 1700000001,
-          giftWrapId: 'gw_a1',
-          ownerPubkey: userA,
-        );
+      test('unknown owner cleanup deletes only ambiguous rows', () async {
+        await insert('msg_a', userA);
+        await insert('msg_b', userB);
+        await insert('msg_null', null);
+        await insert('msg_empty', '');
 
-        expect(await dao.claimLegacyRows(userB), equals(0));
-      });
-    });
-
-    group('clearAll', () {
-      test('deletes all direct messages', () async {
-        await dao.insertMessage(
-          id: 'msg_1',
-          conversationId: conversationId1,
-          senderPubkey: 'pubkey_alice',
-          content: 'Msg 1',
-          createdAt: 1700000000,
-          giftWrapId: 'gw_1',
-        );
-        await dao.insertMessage(
-          id: 'msg_2',
-          conversationId: conversationId2,
-          senderPubkey: 'pubkey_bob',
-          content: 'Msg 2',
-          createdAt: 1700000100,
-          giftWrapId: 'gw_2',
-        );
-
-        final deleted = await dao.clearAll();
-
-        expect(deleted, equals(2));
-        final conv1 = await dao.getMessagesForConversation(conversationId1);
-        final conv2 = await dao.getMessagesForConversation(conversationId2);
-        expect(conv1, isEmpty);
-        expect(conv2, isEmpty);
-      });
-
-      test('returns 0 when table is empty', () async {
-        final deleted = await dao.clearAll();
-        expect(deleted, equals(0));
+        expect(await dao.clearUnowned(), equals(2));
+        expect(await dao.countMessages(conversationId1), equals(2));
       });
     });
 
@@ -1045,7 +1005,7 @@ void main() {
         },
       );
 
-      test('clearAllForUser only deletes that user messages', () async {
+      test('account-switch cleanup preserves another user messages', () async {
         await dao.insertMessage(
           id: 'msg_a1',
           conversationId: conversationId1,
@@ -1065,7 +1025,7 @@ void main() {
           ownerPubkey: userB,
         );
 
-        final deleted = await dao.clearAllForUser(userA);
+        final deleted = await dao.clearForAccountSwitch(userA);
 
         expect(deleted, equals(1));
         final remaining = await dao.getMessagesForConversation(

--- a/mobile/packages/db_client/test/src/database/daos/direct_messages_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/direct_messages_dao_test.dart
@@ -892,6 +892,53 @@ void main() {
       });
     });
 
+    group('claimLegacyRows', () {
+      const userA = 'pubkey_claim_a';
+      const userB = 'pubkey_claim_b';
+
+      test('adopts NULL-owner rows and leaves owned rows alone', () async {
+        await dao.insertMessage(
+          id: 'msg_legacy',
+          conversationId: conversationId1,
+          senderPubkey: 'pubkey_alice',
+          content: 'Legacy message',
+          createdAt: 1700000001,
+          giftWrapId: 'gw_legacy',
+        );
+        await dao.insertMessage(
+          id: 'msg_b1',
+          conversationId: conversationId1,
+          senderPubkey: 'pubkey_bob',
+          content: 'User B message',
+          createdAt: 1700000002,
+          giftWrapId: 'gw_b1',
+          ownerPubkey: userB,
+        );
+
+        final claimed = await dao.claimLegacyRows(userA);
+
+        expect(claimed, equals(1));
+        // The adopted row is now reachable by an owner-scoped delete, which is
+        // the whole point — before #7325 nothing could ever delete it.
+        expect(await dao.clearAllForUser(userA), equals(1));
+        expect(await dao.countMessages(conversationId1), equals(1));
+      });
+
+      test('returns 0 when there is nothing unowned', () async {
+        await dao.insertMessage(
+          id: 'msg_a1',
+          conversationId: conversationId1,
+          senderPubkey: 'pubkey_alice',
+          content: 'User A message',
+          createdAt: 1700000001,
+          giftWrapId: 'gw_a1',
+          ownerPubkey: userA,
+        );
+
+        expect(await dao.claimLegacyRows(userB), equals(0));
+      });
+    });
+
     group('clearAll', () {
       test('deletes all direct messages', () async {
         await dao.insertMessage(

--- a/mobile/packages/db_client/test/src/database/daos/pending_gift_wraps_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/pending_gift_wraps_dao_test.dart
@@ -51,6 +51,19 @@ void main() {
       expect(rows.single.createdAt, 100);
     });
 
+    test('recordFailedDecrypt rejects an empty owner', () async {
+      await expectLater(
+        dao.recordFailedDecrypt(
+          giftWrapId: wrap1,
+          ownerPubkey: '',
+          rawJson: 'raw',
+          createdAt: 100,
+        ),
+        throwsArgumentError,
+      );
+      expect(await dao.countForOwner(''), 0);
+    });
+
     test(
       'recordFailedDecrypt increments attempts on repeat and keeps the '
       'original raw payload',
@@ -216,7 +229,7 @@ void main() {
       expect(await dao.countForOwner(ownerB), 1);
     });
 
-    test('clearAll removes every row across all owners', () async {
+    test('account-switch cleanup preserves another owner', () async {
       await dao.recordFailedDecrypt(
         giftWrapId: wrap1,
         ownerPubkey: ownerA,
@@ -230,11 +243,30 @@ void main() {
         createdAt: 100,
       );
 
-      final deleted = await dao.clearAll();
+      final deleted = await dao.clearForAccountSwitch(ownerA);
 
-      expect(deleted, 2);
+      expect(deleted, 1);
       expect(await dao.countForOwner(ownerA), 0);
-      expect(await dao.countForOwner(ownerB), 0);
+      expect(await dao.countForOwner(ownerB), 1);
+    });
+
+    test('unknown-owner cleanup removes a legacy empty-owner row', () async {
+      await database.customStatement(
+        'INSERT INTO pending_gift_wraps '
+        '(gift_wrap_id, owner_pubkey, raw_json, created_at) '
+        "VALUES (?, '', '{}', 100)",
+        [wrap1],
+      );
+      await dao.recordFailedDecrypt(
+        giftWrapId: wrap2,
+        ownerPubkey: ownerB,
+        rawJson: 'r',
+        createdAt: 100,
+      );
+
+      expect(await dao.clearUnowned(), 1);
+      expect(await dao.countForOwner(''), 0);
+      expect(await dao.countForOwner(ownerB), 1);
     });
   });
 }

--- a/mobile/packages/db_client/test/src/database/daos/processed_gift_wraps_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/processed_gift_wraps_dao_test.dart
@@ -69,10 +69,13 @@ void main() {
       expect(await dao.count(), 1);
     });
 
-    test('record accepts a null owner', () async {
-      await dao.record(giftWrapId: wrap1);
+    test('record rejects an empty owner', () async {
+      await expectLater(
+        dao.record(giftWrapId: wrap1, ownerPubkey: ''),
+        throwsArgumentError,
+      );
 
-      expect(await dao.hasGiftWrap(wrap1), isTrue);
+      expect(await dao.hasGiftWrap(wrap1), isFalse);
     });
 
     test('giftWrapIdsPresent returns only the recorded subset', () async {
@@ -87,16 +90,36 @@ void main() {
       expect(await dao.giftWrapIdsPresent(const <String>{}), isEmpty);
     });
 
-    test('clearAll removes every row', () async {
+    test('account-switch cleanup preserves another owner', () async {
       await dao.record(giftWrapId: wrap1, ownerPubkey: ownerA);
       await dao.record(giftWrapId: wrap2, ownerPubkey: ownerB);
 
-      final deleted = await dao.clearAll();
+      final deleted = await dao.clearForAccountSwitch(ownerA);
 
-      expect(deleted, 2);
+      expect(deleted, 1);
       expect(await dao.hasGiftWrap(wrap1), isFalse);
-      expect(await dao.hasGiftWrap(wrap2), isFalse);
-      expect(await dao.count(), 0);
+      expect(await dao.hasGiftWrap(wrap2), isTrue);
+      expect(await dao.count(), 1);
+    });
+
+    test('unknown-owner cleanup removes NULL and empty legacy rows', () async {
+      await database.customStatement(
+        'INSERT INTO processed_gift_wraps '
+        '(gift_wrap_id, processed_at, owner_pubkey) VALUES (?, 100, NULL)',
+        [wrap1],
+      );
+      await database.customStatement(
+        'INSERT INTO processed_gift_wraps '
+        "(gift_wrap_id, processed_at, owner_pubkey) VALUES (?, 100, '')",
+        [wrap2],
+      );
+      const ownedWrap =
+          'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
+      await dao.record(giftWrapId: ownedWrap, ownerPubkey: ownerB);
+
+      expect(await dao.clearUnowned(), 2);
+      expect(await dao.count(), 1);
+      expect(await dao.hasGiftWrap(ownedWrap), isTrue);
     });
   });
 }

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -522,6 +522,11 @@ class DmRepository {
   /// never race into the dedup/insert path.
   Future<void>? _eventLock;
 
+  /// Preserves subscription ordering while gift-wrap decryption runs outside
+  /// [_eventLock]. A suspended remote signer must not block account cleanup;
+  /// generation checks prevent its late result from entering persistence.
+  Future<void>? _giftWrapProcessingLock;
+
   /// Tracks the first post-auth cleanup pass so conversation queries can avoid
   /// emitting stale denormalized previews before repairs land.
   Future<void>? _postAuthMaintenance;
@@ -996,7 +1001,9 @@ class DmRepository {
       final event = events[i];
       final rumor = preDecrypted[event.id];
       if (rumor != null) {
-        await _withEventLock(() => _persistDecryptedGiftWrap(event, rumor));
+        await _withEventLock(
+          () => _persistDecryptedGiftWrap(event, rumor, ownerPubkey: pubkey),
+        );
       } else {
         await _handleIncomingEvent(event);
       }
@@ -1647,15 +1654,42 @@ class DmRepository {
   /// Serialized via [_eventLock] so that subscription events never race
   /// into the dedup/insert path concurrently.
   Future<void> _handleIncomingEvent(Event event) async {
+    if (event.kind == EventKind.giftWrap) {
+      final gen = _resetGeneration;
+      final ownerPubkey = _userPubkey;
+      await _withGiftWrapProcessingLock(() async {
+        if (_disposed ||
+            _resetGeneration != gen ||
+            _userPubkey != ownerPubkey) {
+          return;
+        }
+        await _handleGiftWrapEvent(event);
+      });
+      return;
+    }
     await _withEventLock(() async {
       if (event.kind == EventKind.eventDeletion) {
         await _handleDeletionEvent(event);
       } else if (event.kind == EventKind.directMessage) {
         await _handleNip04Event(event);
-      } else {
-        await _handleGiftWrapEvent(event);
       }
     });
+  }
+
+  Future<void> _withGiftWrapProcessingLock(
+    Future<void> Function() body,
+  ) async {
+    while (_giftWrapProcessingLock != null) {
+      await _giftWrapProcessingLock;
+    }
+    final completer = Completer<void>();
+    _giftWrapProcessingLock = completer.future;
+    try {
+      await body();
+    } finally {
+      _giftWrapProcessingLock = null;
+      completer.complete();
+    }
   }
 
   /// Runs [body] under the [_eventLock] so dedup/insert work is serialized,
@@ -1764,10 +1798,15 @@ class DmRepository {
   /// the ledger DAO is absent (older test fixtures). Recorded AFTER the
   /// outcome write so a crash in between only ever costs a benign re-decrypt,
   /// never a lost reaction/deletion. #5452.
-  Future<void> _recordProcessedWrap(String giftWrapId) async {
+  Future<void> _recordProcessedWrap(
+    String giftWrapId, {
+    String? ownerPubkey,
+  }) async {
+    final owner = ownerPubkey ?? _ownerPubkey;
+    if (owner == null) return;
     await _processedGiftWrapsDao?.record(
       giftWrapId: giftWrapId,
-      ownerPubkey: _userPubkey,
+      ownerPubkey: owner,
     );
   }
 
@@ -1777,6 +1816,8 @@ class DmRepository {
   /// hold the [_eventLock] (via [_handleIncomingEvent]).
   Future<void> _handleGiftWrapEvent(Event giftWrapEvent) async {
     final gen = _resetGeneration;
+    final ownerPubkey = _userPubkey;
+    if (ownerPubkey.isEmpty) return;
     final Event? rumorEvent;
     try {
       // Dedup: skip if already processed (message row or ledger). #5452.
@@ -1806,7 +1847,9 @@ class DmRepository {
       // torn-down repository that nothing ever closes (PR #5957 review).
       // The wrap re-arrives via the next session's subscription window /
       // history drain, so nothing is lost.
-      if (_disposed || _resetGeneration != gen) return;
+      if (_disposed || _resetGeneration != gen || _userPubkey != ownerPubkey) {
+        return;
+      }
 
       rumorEvent = await _decryptRumor(nostr, giftWrapEvent);
     } on Object catch (e, stackTrace) {
@@ -1820,14 +1863,41 @@ class DmRepository {
       // Only the null path reached the queue, so a remote-signer (Keycast RPC)
       // failure that raised — the very case #5202's queue exists for — dropped
       // the wrap permanently with no retry. Skip when the session moved on:
-      // `recordFailedDecrypt` keys on `_userPubkey`, so queueing under a
-      // switched account would file the wrap against the wrong owner.
-      if (_disposed || _resetGeneration != gen) return;
-      await _persistDecryptedGiftWrap(giftWrapEvent, null);
+      // Queue only under the immutable owner that began this operation.
+      if (_disposed || _resetGeneration != gen || _userPubkey != ownerPubkey) {
+        return;
+      }
+      await _withEventLock(() async {
+        if (_disposed ||
+            _resetGeneration != gen ||
+            _userPubkey != ownerPubkey) {
+          return;
+        }
+        await _persistDecryptedGiftWrap(
+          giftWrapEvent,
+          null,
+          ownerPubkey: ownerPubkey,
+        );
+      });
       return;
     }
 
-    await _persistDecryptedGiftWrap(giftWrapEvent, rumorEvent);
+    // A successful remote decrypt can outlive the account that started it.
+    // Never enter persistence after teardown or under a replacement identity;
+    // relay replay will deliver the wrap to the correct session later.
+    if (_disposed || _resetGeneration != gen || _userPubkey != ownerPubkey) {
+      return;
+    }
+    await _withEventLock(() async {
+      if (_disposed || _resetGeneration != gen || _userPubkey != ownerPubkey) {
+        return;
+      }
+      await _persistDecryptedGiftWrap(
+        giftWrapEvent,
+        rumorEvent,
+        ownerPubkey: ownerPubkey,
+      );
+    });
   }
 
   /// Persists a single (already-decrypted) gift wrap. [rumorEvent] is the
@@ -1837,8 +1907,9 @@ class DmRepository {
   /// hold the [_eventLock]. See #5391.
   Future<void> _persistDecryptedGiftWrap(
     Event giftWrapEvent,
-    Event? rumorEvent,
-  ) async {
+    Event? rumorEvent, {
+    required String ownerPubkey,
+  }) async {
     try {
       if (rumorEvent == null) {
         // Persist the still-encrypted wrap so a later retry can recover the
@@ -1846,7 +1917,7 @@ class DmRepository {
         // RPC) decryption must not be permanent data loss. See #5202.
         await _pendingGiftWrapsDao?.recordFailedDecrypt(
           giftWrapId: giftWrapEvent.id,
-          ownerPubkey: _userPubkey,
+          ownerPubkey: ownerPubkey,
           rawJson: jsonEncode(giftWrapEvent.toJson()),
           createdAt: giftWrapEvent.createdAt,
         );
@@ -1861,7 +1932,7 @@ class DmRepository {
       // retry queue stops reprocessing this wrap. See #5202.
       await _pendingGiftWrapsDao?.deletePending(
         giftWrapId: giftWrapEvent.id,
-        ownerPubkey: _userPubkey,
+        ownerPubkey: ownerPubkey,
       );
 
       // Bind to a final local so the non-null type promotes inside the
@@ -1897,7 +1968,10 @@ class DmRepository {
         // Record only terminal outcomes: a reaction whose target message has
         // not synced is left out so it re-decrypts and lands later. #5452.
         if (outcome == DmReactionWrapOutcome.processed) {
-          await _recordProcessedWrap(giftWrapEvent.id);
+          await _recordProcessedWrap(
+            giftWrapEvent.id,
+            ownerPubkey: ownerPubkey,
+          );
         }
         return;
       }
@@ -1907,7 +1981,10 @@ class DmRepository {
           giftWrapId: giftWrapEvent.id,
         );
         if (outcome == DmReactionWrapOutcome.processed) {
-          await _recordProcessedWrap(giftWrapEvent.id);
+          await _recordProcessedWrap(
+            giftWrapEvent.id,
+            ownerPubkey: ownerPubkey,
+          );
         }
         return;
       }
@@ -1921,7 +1998,10 @@ class DmRepository {
       if (rumor.kind == EventKind.appSpecificData) {
         if (_hasReadMarkerDTag(rumor)) {
           await _reconcileReadMarker(rumor);
-          await _recordProcessedWrap(giftWrapEvent.id);
+          await _recordProcessedWrap(
+            giftWrapEvent.id,
+            ownerPubkey: ownerPubkey,
+          );
         }
         return;
       }
@@ -1933,7 +2013,7 @@ class DmRepository {
       // such a kind would need a one-off backfill. Acceptable vs. re-decrypting
       // every unknown wrap on every launch today. #5452.
       if (!_supportedDmKinds.contains(rumor.kind)) {
-        await _recordProcessedWrap(giftWrapEvent.id);
+        await _recordProcessedWrap(giftWrapEvent.id, ownerPubkey: ownerPubkey);
         return;
       }
 
@@ -1942,7 +2022,7 @@ class DmRepository {
       // from non-compliant clients that add extra p-tags.
       final rawParticipants = _extractParticipants(rumor);
       if (rawParticipants.length < 2) {
-        await _recordProcessedWrap(giftWrapEvent.id);
+        await _recordProcessedWrap(giftWrapEvent.id, ownerPubkey: ownerPubkey);
         return;
       }
 
@@ -1955,7 +2035,7 @@ class DmRepository {
       // Defense-in-depth: should not happen after the self-wrap fix above,
       // but guards against any future code path producing degenerate lists.
       if (participants.toSet().length < 2) {
-        await _recordProcessedWrap(giftWrapEvent.id);
+        await _recordProcessedWrap(giftWrapEvent.id, ownerPubkey: ownerPubkey);
         return;
       }
 
@@ -1979,7 +2059,7 @@ class DmRepository {
           // well-formed-hex check keeps this keyspace disjoint from the
           // legacy (content, createdAt) dedup tuple.
           if (tag[0] == _sendBatchTagKey &&
-              rumor.pubkey == _userPubkey &&
+              rumor.pubkey == ownerPubkey &&
               _isValidSendBatchId(tag[1])) {
             sendBatchId = tag[1];
           }
@@ -2000,10 +2080,10 @@ class DmRepository {
         senderPubkey: rumor.pubkey,
         content: rumor.content,
         createdAt: persistedCreatedAt,
-        ownerPubkey: _userPubkey,
+        ownerPubkey: ownerPubkey,
       );
       if (isDuplicate) {
-        await _recordProcessedWrap(giftWrapEvent.id);
+        await _recordProcessedWrap(giftWrapEvent.id, ownerPubkey: ownerPubkey);
         Log.debug(
           'Skipping duplicate NIP-17 DM ${rumor.id} in conversation '
           '$conversationId from ${pubkeyForLogs(rumor.pubkey)}: matching '
@@ -2018,7 +2098,7 @@ class DmRepository {
       // The inner hasGiftWrap re-check guards against TOCTOU races where
       // a poll and subscription event both pass the outer fast-path check.
       final isGroup = participants.length > 2;
-      final isSentByMe = rumor.pubkey == _userPubkey;
+      final isSentByMe = rumor.pubkey == ownerPubkey;
       final previewContent = rumor.kind == EventKind.fileMessage
           ? _filePreviewText(fileMetadata?.fileType)
           : rumor.content;
@@ -2028,9 +2108,6 @@ class DmRepository {
       var suppressedByRemovedConversation = false;
       int? removedAt;
       await _conversationsDao.runInTransaction(() async {
-        // Snapshot the owner for the whole transaction: an account switch
-        // mid-flight must not mix one account's reads with another's writes.
-        final ownerPubkey = _userPubkey;
         // Re-check dedup inside transaction (TOCTOU protection). The skip is
         // logged after the transaction below; logging here too would emit one
         // line per skip twice.
@@ -2112,7 +2189,7 @@ class DmRepository {
         // Terminal: record the wrap so replays skip it before decryption.
         // The tombstone is authoritative for the account's lifetime, so the
         // ledger is not racing a reopening that clears it.
-        await _recordProcessedWrap(giftWrapEvent.id);
+        await _recordProcessedWrap(giftWrapEvent.id, ownerPubkey: ownerPubkey);
         Log.debug(
           'Suppressed NIP-17 DM ${rumor.id} in removed conversation '
           '$conversationId: createdAt $persistedCreatedAt is at or before '
@@ -2122,7 +2199,7 @@ class DmRepository {
         return;
       }
       if (!inserted) {
-        await _recordProcessedWrap(giftWrapEvent.id);
+        await _recordProcessedWrap(giftWrapEvent.id, ownerPubkey: ownerPubkey);
         Log.debug(
           'Skipped duplicate NIP-17 DM ${rumor.id} in conversation '
           '$conversationId: insert was ignored by local dedup constraints',
@@ -2134,7 +2211,7 @@ class DmRepository {
       // Advance sync boundaries from the bounded local timestamp. The outer
       // gift wrap randomizes its own created_at within a ~2 day window
       // (NIP-17) so it must not be used for boundary tracking.
-      await _syncState?.recordSeen(_userPubkey, createdAt: persistedCreatedAt);
+      await _syncState?.recordSeen(ownerPubkey, createdAt: persistedCreatedAt);
 
       Log.debug(
         'Persisted NIP-17 DM ${rumor.id} (kind ${rumor.kind}) in conversation '
@@ -2770,10 +2847,7 @@ class DmRepository {
       // NIP-04 created_at values are not randomized (unlike NIP-17 gift
       // wraps), so this bounded timestamp is a real send time and safe to
       // record as a cursor.
-      await _syncState?.recordSeen(
-        _userPubkey,
-        createdAt: persistedCreatedAt,
-      );
+      await _syncState?.recordSeen(_userPubkey, createdAt: persistedCreatedAt);
 
       Log.debug(
         'Persisted NIP-04 DM ${nip04Event.id} '
@@ -2994,14 +3068,9 @@ class DmRepository {
       }
       // _OwnDmInboxState.absent — safe to self-advertise.
 
-      final unsigned = Event(
-        pubkey,
-        EventKind.dmRelaysList,
-        <List<String>>[
-          <String>['relay', relayUrl],
-        ],
-        '',
-      );
+      final unsigned = Event(pubkey, EventKind.dmRelaysList, <List<String>>[
+        <String>['relay', relayUrl],
+      ], '');
 
       final Event? signed;
       try {
@@ -5846,10 +5915,9 @@ class DmRepository {
         conversationId: conversationId,
         ownerPubkey: owner,
       );
-      await _reactionsRepository?.deleteForConversations(
-        [conversationId],
-        ownerPubkey: owner,
-      );
+      await _reactionsRepository?.deleteForConversations([
+        conversationId,
+      ], ownerPubkey: owner);
     });
   }
 

--- a/mobile/packages/dm_repository/lib/src/dm_sync_state.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_sync_state.dart
@@ -249,8 +249,8 @@ class DmSyncState {
 
   /// Removes all DM sync state entries for every pubkey.
   ///
-  /// Called during database cleanup to ensure the next login triggers a
-  /// full re-sync from relays instead of using stale `since:` cursors.
+  /// Called only after the entire database is recreated, when every account's
+  /// local rows and therefore every persisted sync boundary are stale.
   Future<void> clearAll() async {
     final keysToRemove = _prefs
         .getKeys()

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -156,6 +156,9 @@ Future<Event> _buildForgedSealGiftWrap({
 
 class _MockPendingGiftWrapsDao extends Mock implements PendingGiftWrapsDao {}
 
+class _MockProcessedGiftWrapsDao extends Mock
+    implements ProcessedGiftWrapsDao {}
+
 class _MockRemovedConversationsDao extends Mock
     implements RemovedConversationsDao {}
 
@@ -173,7 +176,7 @@ class _InMemoryProcessedGiftWrapsDao extends Mock
   @override
   Future<void> record({
     required String giftWrapId,
-    String? ownerPubkey,
+    required String ownerPubkey,
   }) async {
     recorded.add(giftWrapId);
   }
@@ -6182,6 +6185,130 @@ void main() {
           // The torn-down session persists nothing; the wrap re-arrives via
           // the next session's subscription window / history drain.
           expect(persistedGiftWrapIds, isNot(contains(wrap.id)));
+        },
+      );
+
+      test(
+        'a failed decrypt completing after stopListening is not queued under '
+        'an owner',
+        () async {
+          final giftWrap = await _buildGiftWrap(
+            rumor: rumorFor('late failed decrypt', createdAt: 1700000500),
+            senderPrivateKey: senderPriv,
+            recipientPubkey: recipientPub,
+            outerCreatedAt: 1700000000,
+          );
+          final controller = StreamController<Event>();
+          when(
+            () => mockNostrClient.subscribe(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+            ),
+          ).thenAnswer((_) => controller.stream);
+          when(
+            () => mockDirectMessagesDao.hasGiftWrap(giftWrap.id),
+          ).thenAnswer((_) async => false);
+
+          final decryptStarted = Completer<void>();
+          final decryptGate = Completer<void>();
+          final pendingDao = _MockPendingGiftWrapsDao();
+          final repository = createRepository(
+            pendingGiftWrapsDao: pendingDao,
+            rumorDecryptor: (_, _) async {
+              decryptStarted.complete();
+              await decryptGate.future;
+              return null;
+            },
+          );
+
+          await repository.startListening();
+          controller.add(giftWrap);
+          await decryptStarted.future;
+
+          await repository.stopListening();
+          decryptGate.complete();
+          await Future<void>.delayed(Duration.zero);
+
+          verifyNever(
+            () => pendingDao.recordFailedDecrypt(
+              giftWrapId: any(named: 'giftWrapId'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+              rawJson: any(named: 'rawJson'),
+              createdAt: any(named: 'createdAt'),
+            ),
+          );
+          await controller.close();
+        },
+      );
+
+      test(
+        'stopListening drains a processed-ledger write already in persistence',
+        () async {
+          final giftWrap = await _buildGiftWrap(
+            rumor: rumorFor('terminal outcome', createdAt: 1700000500),
+            senderPrivateKey: senderPriv,
+            recipientPubkey: recipientPub,
+            outerCreatedAt: 1700000000,
+          );
+          final terminalRumor = Event(
+            senderPub,
+            12345,
+            <List<String>>[
+              ['p', recipientPub],
+            ],
+            'unsupported',
+            createdAt: 1700000500,
+          );
+          final controller = StreamController<Event>();
+          when(
+            () => mockNostrClient.subscribe(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+            ),
+          ).thenAnswer((_) => controller.stream);
+          when(
+            () => mockDirectMessagesDao.hasGiftWrap(giftWrap.id),
+          ).thenAnswer((_) async => false);
+
+          final ledger = _MockProcessedGiftWrapsDao();
+          when(
+            () => ledger.hasGiftWrap(giftWrap.id),
+          ).thenAnswer((_) async => false);
+          final recordStarted = Completer<void>();
+          final recordGate = Completer<void>();
+          when(
+            () => ledger.record(
+              giftWrapId: giftWrap.id,
+              ownerPubkey: _validPubkeyA,
+            ),
+          ).thenAnswer((_) async {
+            recordStarted.complete();
+            await recordGate.future;
+          });
+          final repository = createRepository(
+            processedGiftWrapsDao: ledger,
+            rumorDecryptor: (_, _) async => terminalRumor,
+          );
+
+          await repository.startListening();
+          controller.add(giftWrap);
+          await recordStarted.future;
+
+          var stopped = false;
+          final stop = repository.stopListening().then((_) => stopped = true);
+          await Future<void>.delayed(Duration.zero);
+          expect(stopped, isFalse);
+
+          recordGate.complete();
+          await stop;
+          expect(stopped, isTrue);
+          verify(
+            () => ledger.record(
+              giftWrapId: giftWrap.id,
+              ownerPubkey: _validPubkeyA,
+            ),
+          ).called(1);
+          await controller.close();
         },
       );
 

--- a/mobile/test/providers/social_providers_cleanup_test.dart
+++ b/mobile/test/providers/social_providers_cleanup_test.dart
@@ -614,38 +614,50 @@ void main() {
       });
 
       test(
-        'legacy NULL-owner rows survive a switch and are claimable',
+        'a known-owner switch deletes NULL and empty-owner DM rows',
         () async {
           await seedDm(
             messageId: _dmTargetMessageId,
             conversationId: _dmConversationId,
           );
-
-          await readService().onDatabaseCleanup!(userPubkey: _pubkeyA);
-          expect(
-            await dmCountFor(null),
-            1,
-            reason: "an unowned row is nobody's to delete on a scoped switch",
+          await seedDm(
+            messageId: _dmSecondTargetMessageId,
+            conversationId: _reactionIdB,
+            ownerPubkey: '',
           );
 
-          await readService().onClaimLegacyRows!(_pubkeyB);
+          await readService().onDatabaseCleanup!(userPubkey: _pubkeyA);
           expect(await dmCountFor(null), 0);
-          expect(await dmCountFor(_pubkeyB), 1);
-          expect(await conversationCountFor(_pubkeyB), 1);
+          expect(await dmCountFor(''), 0);
+          expect(await conversationCountFor(null), 0);
+          expect(await conversationCountFor(''), 0);
         },
       );
 
-      test('a null userPubkey deletes nothing', () async {
+      test('an unknown leaving user deletes only ambiguous DM rows', () async {
         await seedDm(
           messageId: _dmTargetMessageId,
           conversationId: _dmConversationId,
           ownerPubkey: _pubkeyA,
+        );
+        await seedDm(
+          messageId: _dmSecondTargetMessageId,
+          conversationId: _reactionIdB,
+        );
+        await seedDm(
+          messageId: _pendingDeletionId,
+          conversationId: _reactionIdA,
+          ownerPubkey: '',
         );
 
         await readService().onDatabaseCleanup!();
 
         expect(await dmCountFor(_pubkeyA), 1);
         expect(await conversationCountFor(_pubkeyA), 1);
+        expect(await dmCountFor(null), 0);
+        expect(await dmCountFor(''), 0);
+        expect(await conversationCountFor(null), 0);
+        expect(await conversationCountFor(''), 0);
       });
 
       test("only the leaving account's DM sync cursors are cleared", () async {
@@ -655,7 +667,11 @@ void main() {
         await syncState.markHistoryDrainComplete(_pubkeyA);
         await syncState.markHistoryDrainComplete(_pubkeyB);
 
-        await readService().onDatabaseCleanup!(userPubkey: _pubkeyA);
+        await readService().clearUserSpecificData(
+          reason: 'test_identity_change',
+          isIdentityChange: true,
+          userPubkey: _pubkeyA,
+        );
 
         expect(syncState.newestSyncedAt(_pubkeyA), isNull);
         expect(syncState.historyDrainComplete(_pubkeyA), isFalse);

--- a/mobile/test/providers/social_providers_cleanup_test.dart
+++ b/mobile/test/providers/social_providers_cleanup_test.dart
@@ -6,6 +6,7 @@ import 'dart:io';
 import 'package:blossom_upload_service/blossom_upload_service.dart';
 import 'package:db_client/db_client.dart';
 import 'package:dm_repository/dm_repository.dart';
+import 'package:drift/drift.dart' show Variable;
 import 'package:drift/native.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -19,6 +20,7 @@ import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/social_providers.dart';
 import 'package:openvine/providers/upload_media_providers.dart';
 import 'package:openvine/services/upload_manager.dart';
+import 'package:openvine/services/user_data_cleanup_service.dart';
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -497,6 +499,173 @@ void main() {
         ),
         1700000000,
       );
+    });
+
+    group('#7325 owner-scoped DM cleanup', () {
+      Future<void> seedDm({
+        required String messageId,
+        required String conversationId,
+        String? ownerPubkey,
+      }) async {
+        await db.conversationsDao.upsertConversation(
+          id: conversationId,
+          participantPubkeys: _pubkeyA,
+          isGroup: false,
+          createdAt: 1700000000,
+          ownerPubkey: ownerPubkey,
+        );
+        await db.directMessagesDao.insertMessage(
+          id: messageId,
+          conversationId: conversationId,
+          senderPubkey: _pubkeyA,
+          content: 'hello',
+          createdAt: 1700000000,
+          giftWrapId: 'gw-$messageId',
+          ownerPubkey: ownerPubkey,
+        );
+      }
+
+      Future<int> dmCountFor(String? owner) async {
+        final row = await db
+            .customSelect(
+              owner == null
+                  ? 'SELECT COUNT(*) c FROM direct_messages '
+                        'WHERE owner_pubkey IS NULL'
+                  : 'SELECT COUNT(*) c FROM direct_messages '
+                        'WHERE owner_pubkey = ?',
+              variables: owner == null ? const [] : [Variable<String>(owner)],
+            )
+            .getSingle();
+        return row.data['c']! as int;
+      }
+
+      Future<int> conversationCountFor(String? owner) async {
+        final row = await db
+            .customSelect(
+              owner == null
+                  ? 'SELECT COUNT(*) c FROM conversations '
+                        'WHERE owner_pubkey IS NULL'
+                  : 'SELECT COUNT(*) c FROM conversations '
+                        'WHERE owner_pubkey = ?',
+              variables: owner == null ? const [] : [Variable<String>(owner)],
+            )
+            .getSingle();
+        return row.data['c']! as int;
+      }
+
+      UserDataCleanupService readService() {
+        final subscription = container.listen(
+          userDataCleanupServiceProvider,
+          (_, _) {},
+        );
+        addTearDown(subscription.close);
+        return subscription.read();
+      }
+
+      test("a plain switch keeps the other account's DM history", () async {
+        await seedDm(
+          messageId: _dmTargetMessageId,
+          conversationId: _dmConversationId,
+          ownerPubkey: _pubkeyA,
+        );
+        await seedDm(
+          messageId: _dmSecondTargetMessageId,
+          conversationId: _reactionIdB,
+          ownerPubkey: _pubkeyB,
+        );
+
+        // The two gift-wrap tables ride the same cleanup path. Their
+        // ownerPubkey is non-nullable (pending) / claimed (processed), so a
+        // scoped delete must be exhaustive for A and inert for B.
+        await db.pendingGiftWrapsDao.recordFailedDecrypt(
+          giftWrapId: 'gw-a',
+          ownerPubkey: _pubkeyA,
+          rawJson: '{}',
+          createdAt: 1700000000,
+        );
+        await db.pendingGiftWrapsDao.recordFailedDecrypt(
+          giftWrapId: 'gw-b',
+          ownerPubkey: _pubkeyB,
+          rawJson: '{}',
+          createdAt: 1700000000,
+        );
+        await db.processedGiftWrapsDao.record(
+          giftWrapId: 'pw-a',
+          ownerPubkey: _pubkeyA,
+        );
+        await db.processedGiftWrapsDao.record(
+          giftWrapId: 'pw-b',
+          ownerPubkey: _pubkeyB,
+        );
+
+        await readService().onDatabaseCleanup!(userPubkey: _pubkeyA);
+
+        expect(await dmCountFor(_pubkeyA), 0);
+        expect(await conversationCountFor(_pubkeyA), 0);
+        expect(await dmCountFor(_pubkeyB), 1);
+        expect(await conversationCountFor(_pubkeyB), 1);
+        expect(await db.pendingGiftWrapsDao.countForOwner(_pubkeyA), 0);
+        expect(await db.pendingGiftWrapsDao.countForOwner(_pubkeyB), 1);
+        expect(
+          await db.processedGiftWrapsDao.count(),
+          1,
+          reason: "only B's processed-wrap row should survive",
+        );
+      });
+
+      test(
+        'legacy NULL-owner rows survive a switch and are claimable',
+        () async {
+          await seedDm(
+            messageId: _dmTargetMessageId,
+            conversationId: _dmConversationId,
+          );
+
+          await readService().onDatabaseCleanup!(userPubkey: _pubkeyA);
+          expect(
+            await dmCountFor(null),
+            1,
+            reason: "an unowned row is nobody's to delete on a scoped switch",
+          );
+
+          await readService().onClaimLegacyRows!(_pubkeyB);
+          expect(await dmCountFor(null), 0);
+          expect(await dmCountFor(_pubkeyB), 1);
+          expect(await conversationCountFor(_pubkeyB), 1);
+        },
+      );
+
+      test('a null userPubkey deletes nothing', () async {
+        await seedDm(
+          messageId: _dmTargetMessageId,
+          conversationId: _dmConversationId,
+          ownerPubkey: _pubkeyA,
+        );
+
+        await readService().onDatabaseCleanup!();
+
+        expect(await dmCountFor(_pubkeyA), 1);
+        expect(await conversationCountFor(_pubkeyA), 1);
+      });
+
+      test("only the leaving account's DM sync cursors are cleared", () async {
+        final syncState = DmSyncState(prefs);
+        await syncState.recordSeen(_pubkeyA, createdAt: 1700000000);
+        await syncState.recordSeen(_pubkeyB, createdAt: 1700000000);
+        await syncState.markHistoryDrainComplete(_pubkeyA);
+        await syncState.markHistoryDrainComplete(_pubkeyB);
+
+        await readService().onDatabaseCleanup!(userPubkey: _pubkeyA);
+
+        expect(syncState.newestSyncedAt(_pubkeyA), isNull);
+        expect(syncState.historyDrainComplete(_pubkeyA), isFalse);
+        expect(
+          syncState.newestSyncedAt(_pubkeyB),
+          isNotNull,
+          reason: 'the other account must keep its cursor',
+        );
+        expect(syncState.historyDrainComplete(_pubkeyB), isTrue);
+      });
     });
   });
 }

--- a/mobile/test/providers/swap_account_test.dart
+++ b/mobile/test/providers/swap_account_test.dart
@@ -706,6 +706,81 @@ void main() {
     expect(currentAuthService.calls, equals(['archive', 'signIn']));
   });
 
+  group('DM lifecycle', () {
+    testWidgets('quiesces outgoing DM persistence before target sign-in', (
+      tester,
+    ) async {
+      final dmRepository = _MockDmRepository();
+      final events = <String>[];
+      when(dmRepository.stopListening).thenAnswer((_) async {
+        events.add('stop outgoing DMs');
+      });
+      when(dmRepository.startListening).thenAnswer((_) async {});
+      final initial = await pumpHost(
+        tester,
+        accountOverrides: [
+          dmRepositoryProvider.overrideWithValue(dmRepository),
+        ],
+      );
+      initial.read(dmRepositoryProvider);
+
+      await swapAccount(
+        deviceScope: deviceScope,
+        controller: controller,
+        currentAuthService: currentAuthService,
+        account: account,
+        signIn: (_, _) async => events.add('sign in target'),
+      );
+      await tester.pump();
+
+      expect(events, ['stop outgoing DMs', 'sign in target']);
+      verify(dmRepository.stopListening).called(1);
+      verifyNever(dmRepository.startListening);
+    });
+
+    testWidgets('resumes outgoing DMs when target sign-in fails', (
+      tester,
+    ) async {
+      final dmRepository = _MockDmRepository();
+      final events = <String>[];
+      when(dmRepository.stopListening).thenAnswer((_) async {
+        events.add('stop outgoing DMs');
+      });
+      when(dmRepository.startListening).thenAnswer((_) async {
+        events.add('resume outgoing DMs');
+      });
+      final initial = await pumpHost(
+        tester,
+        accountOverrides: [
+          dmRepositoryProvider.overrideWithValue(dmRepository),
+        ],
+      );
+      initial.read(dmRepositoryProvider);
+
+      await expectLater(
+        swapAccount(
+          deviceScope: deviceScope,
+          controller: controller,
+          currentAuthService: currentAuthService,
+          account: account,
+          signIn: (_, _) async {
+            events.add('sign in target');
+            throw Exception('signer unavailable');
+          },
+        ),
+        throwsException,
+      );
+      await tester.pump();
+
+      expect(events, [
+        'stop outgoing DMs',
+        'sign in target',
+        'resume outgoing DMs',
+      ]);
+      expect(_isDisposed(initial), isFalse);
+    });
+  });
+
   testWidgets('aborts before building anything when the archive fails', (
     tester,
   ) async {

--- a/mobile/test/services/user_data_cleanup_service_test.dart
+++ b/mobile/test/services/user_data_cleanup_service_test.dart
@@ -406,7 +406,7 @@ void main() {
       );
 
       test(
-        'clears dynamic prefix keys when isIdentityChange is true',
+        'clears shared dynamic caches but preserves scoped DM cursors',
         () async {
           // Set up dynamic pubkey-keyed caches
           await prefs.setString(
@@ -414,7 +414,8 @@ void main() {
             '["pubkey1","pubkey2"]',
           );
           await prefs.setString('relay_discovery_npub1abc', 'relay_data');
-          // DM sync cursors are also per-pubkey and should be cleared
+          // DM sync cursors are cleared by DmSyncState for the leaving pubkey,
+          // not by this global prefix sweep.
           await prefs.setInt('dm.newestSyncedAt.abc123', 1700000000);
           await prefs.setInt('dm.oldestSyncedAt.abc123', 1699000000);
 
@@ -426,8 +427,8 @@ void main() {
           // Dynamic prefix keys should be cleared on identity change
           expect(prefs.containsKey('following_list_abc123'), isFalse);
           expect(prefs.containsKey('relay_discovery_npub1abc'), isFalse);
-          expect(prefs.containsKey('dm.newestSyncedAt.abc123'), isFalse);
-          expect(prefs.containsKey('dm.oldestSyncedAt.abc123'), isFalse);
+          expect(prefs.containsKey('dm.newestSyncedAt.abc123'), isTrue);
+          expect(prefs.containsKey('dm.oldestSyncedAt.abc123'), isTrue);
         },
       );
 
@@ -526,6 +527,18 @@ void main() {
         );
       });
 
+      test('throws database cleanup failure on identity change', () async {
+        service.onDatabaseCleanup =
+            ({String? userPubkey, bool deleteUserData = false}) async {
+              throw StateError('cleanup failed');
+            };
+
+        await expectLater(
+          service.clearUserSpecificData(isIdentityChange: true),
+          throwsA(isA<StateError>()),
+        );
+      });
+
       test('claimLegacyRows calls onClaimLegacyRows callback', () async {
         String? receivedPubkey;
         service.onClaimLegacyRows = (String pubkey) async {
@@ -588,13 +601,13 @@ void main() {
     });
 
     group('identityChangePrefixes', () {
-      test('contains expected prefix categories', () {
+      test('contains only globally safe prefix categories', () {
         const prefixes = UserDataCleanupService.identityChangePrefixes;
 
         expect(prefixes, contains('following_list_'));
         expect(prefixes, contains('relay_discovery_'));
-        expect(prefixes, contains('dm.newestSyncedAt.'));
-        expect(prefixes, contains('dm.oldestSyncedAt.'));
+        expect(prefixes, isNot(contains('dm.newestSyncedAt.')));
+        expect(prefixes, isNot(contains('dm.oldestSyncedAt.')));
       });
 
       test('does NOT contain non-dynamic prefixes', () {


### PR DESCRIPTION
## Description

Account switching is a strict local-DM privacy boundary. Before this PR, `onDatabaseCleanup` issued four unqualified deletes over `direct_messages`, `conversations`, `pending_gift_wraps`, and `processed_gift_wraps`, destroying every saved account's DM history. The initial scoped fix still left ambiguous legacy rows, global sync-cursor deletion, and an in-flight writer race.

This PR now applies the maintainer-approved policy end to end:

- A known departing account loses all of its DM rows plus every ambiguous legacy row (`NULL` or empty owner), while rows with another valid owner are preserved.
- When the departing pubkey is unavailable, only ambiguous rows are purged; valid-owned rows remain intact.
- Ambiguous DM rows are never claimed by the incoming account.
- Pending and processed gift-wrap writes require a stable, non-empty owner.
- The outgoing DM pipeline is quiesced before the incoming sign-in starts cleanup. Late decrypt work is invalidated, while persistence already in progress is awaited so it cannot recreate rows after deletion.
- The four DM-table deletes run in one transaction and account-boundary cleanup fails closed.
- DM sync cursors are cleared only through `DmSyncState.clear(leavingPubkey)`; the global identity-change prefix sweep no longer deletes other accounts' cursors.
- Dead global `clearAll` methods and stale documentation introduced or exposed by this change are removed.

Physical-device reproduction from the original report showed a plain account switch taking `direct_messages` 5 → 0, `conversations` 1 → 0, and `processed_gift_wraps` 8 → 0 across all owners. The related race in #8117 separately showed `pending_gift_wraps` 0 → 2 after cleanup completed. The implementation and regression tests cover both failure modes.

Closes #7325
Closes #8117

## Out of Scope

- #8116 — a transient remote-signer failure disables gift-wrap batch unwrap for the session.
- Relay authentication support is tracked in the owning repository.
- Signed-out reads with a null owner still follow the existing `_ownedOrLegacy` behavior. Account-boundary cleanup now removes ambiguous DM rows before an incoming session can inherit them.

## Verification

- `flutter analyze lib test integration_test packages/db_client/lib packages/db_client/test packages/dm_repository/lib packages/dm_repository/test` — clean.
- Changed-file pre-push suite — 563 passed.
- `packages/db_client` full suite — 995 passed.
- `packages/dm_repository` full suite — 642 passed.
- Focused cleanup/provider/swap suite — 87 passed.
- Drift and Riverpod generated output regenerated and verified.
- Repository ratchets passed: test structure, service coverage, Nostr log safety, pubkey log encoding, post-close emits, localization delegates/orphans, dependency provenance, service size, design-system ceilings, and layer direction.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
