### PR TITLE
refactor(support): move log export to Developer Options and stop feeding Android's Copy chip

### DIFF
--- a/mobile/e2e/maestro/asserts/assertSettings.yaml
+++ b/mobile/e2e/maestro/asserts/assertSettings.yaml
@@ -57,10 +57,6 @@ appId: co.openvine.app.staging
     ProofMode Info
     Learn about ProofMode verification and authenticity
 
-- assertVisible: |-
-    Save Logs
-    Export logs to file for manual sending
-
 - assertVisible: ADVANCED ACCOUNT OPTIONS
 
 - assertVisible: |-

--- a/mobile/lib/blocs/export_logs/export_logs_cubit.dart
+++ b/mobile/lib/blocs/export_logs/export_logs_cubit.dart
@@ -1,0 +1,64 @@
+// ABOUTME: Drives the developer-options log export and reveal actions
+// ABOUTME: Keeps BugReportService out of the widget layer (UI -> Cubit -> Service)
+
+import 'dart:ui' show Rect;
+
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:openvine/blocs/close_guard.dart';
+import 'package:openvine/blocs/export_logs/export_logs_state.dart';
+import 'package:openvine/services/bug_report_service.dart';
+
+export 'package:openvine/blocs/export_logs/export_logs_state.dart';
+
+class ExportLogsCubit extends Cubit<ExportLogsState>
+    with CloseGuardedEmit<ExportLogsState> {
+  ExportLogsCubit({
+    required BugReportService bugReportService,
+    required String currentScreen,
+    String? userPubkey,
+  }) : _bugReportService = bugReportService,
+       _currentScreen = currentScreen,
+       _userPubkey = userPubkey,
+       super(const ExportLogsState());
+
+  final BugReportService _bugReportService;
+  final String _currentScreen;
+  final String? _userPubkey;
+
+  /// Writes the captured logs to a file and hands it to the platform.
+  ///
+  /// [sharePositionOrigin] anchors the iPad popover and must be resolved by
+  /// the caller before the first suspension point — the iPad idiom rejects
+  /// the share sheet without it.
+  Future<void> export({Rect? sharePositionOrigin}) async {
+    if (state.status == ExportLogsStatus.exporting) return;
+    emitIfOpen(const ExportLogsState(status: ExportLogsStatus.exporting));
+
+    final result = await _bugReportService.exportLogsToFile(
+      currentScreen: _currentScreen,
+      userPubkey: _userPubkey,
+      sharePositionOrigin: sharePositionOrigin,
+    );
+
+    emitIfOpen(
+      ExportLogsState(
+        status: _statusFor(result.status),
+        filePath: result.filePath,
+      ),
+    );
+  }
+
+  /// Opens the folder containing an exported file.
+  Future<void> revealFile(String filePath) =>
+      _bugReportService.revealExportedFile(filePath);
+
+  static ExportLogsStatus _statusFor(LogExportStatus status) =>
+      switch (status) {
+        LogExportStatus.shared => ExportLogsStatus.shared,
+        LogExportStatus.saved => ExportLogsStatus.saved,
+        LogExportStatus.cancelled => ExportLogsStatus.cancelled,
+        LogExportStatus.noLogs => ExportLogsStatus.noLogs,
+        LogExportStatus.unconfirmed => ExportLogsStatus.unconfirmed,
+        LogExportStatus.failed => ExportLogsStatus.failed,
+      };
+}

--- a/mobile/lib/blocs/export_logs/export_logs_state.dart
+++ b/mobile/lib/blocs/export_logs/export_logs_state.dart
@@ -1,0 +1,47 @@
+// ABOUTME: State for the developer-options log export flow
+// ABOUTME: Status enum only — the UI maps each outcome to its own l10n string
+
+import 'package:equatable/equatable.dart';
+
+/// Outcome of a log export, as the UI needs to distinguish it.
+///
+/// Four of these are not failures. Collapsing them into one is what made a
+/// working share report "Failed to export logs" (#8113) and an empty capture
+/// buffer look like a broken feature rather than a prompt to reproduce first
+/// (#8114).
+enum ExportLogsStatus {
+  idle,
+  exporting,
+
+  /// Handed to another app, which confirmed it.
+  shared,
+
+  /// Written to a path the user picked, carried in [ExportLogsState.filePath].
+  saved,
+
+  /// User backed out of the share sheet or the Save As dialog.
+  cancelled,
+
+  /// The capture buffer was empty. It is memory-only, so a crash or a
+  /// force-quit empties it.
+  noLogs,
+
+  /// The sheet opened but reported no outcome. The share may well have
+  /// completed — share_plus cannot tell.
+  unconfirmed,
+
+  failed,
+}
+
+class ExportLogsState extends Equatable {
+  const ExportLogsState({this.status = ExportLogsStatus.idle, this.filePath});
+
+  final ExportLogsStatus status;
+
+  /// Where the file landed, when the platform told us. Only ever set
+  /// alongside [ExportLogsStatus.saved].
+  final String? filePath;
+
+  @override
+  List<Object?> get props => [status, filePath];
+}

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -2021,8 +2021,6 @@
     "supportReportBugSubtitle": "ከመተግበሪያው ጋር ቴክኒካዊ ጉዳዮች",
     "supportRequestFeature": "ባህሪ ይጠይቁ",
     "supportRequestFeatureSubtitle": "ማሻሻያ ወይም አዲስ ባህሪን ይጠቁሙ",
-    "supportSaveLogs": "ምዝግብ ማስታወሻዎችን ያስቀምጡ",
-    "supportSaveLogsSubtitle": "በእጅ ለመላክ የምዝግብ ማስታወሻዎችን ወደ ፋይል ይላኩ።",
     "supportFaq": "የሚጠየቁ ጥያቄዎች",
     "supportFaqSubtitle": "የተለመዱ ጥያቄዎች እና መልሶች",
     "supportFamily": "Divine Family",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -1624,8 +1624,6 @@
     "supportReportBugSubtitle": "مشاكل تقنية في التطبيق",
     "supportRequestFeature": "طلب ميزة",
     "supportRequestFeatureSubtitle": "اقتراح تحسين أو ميزة جديدة",
-    "supportSaveLogs": "حفظ السجلات",
-    "supportSaveLogsSubtitle": "تصدير السجلات إلى ملف للإرسال يدويًا",
     "supportFaq": "الأسئلة الشائعة",
     "supportFaqSubtitle": "الأسئلة والأجوبة الشائعة",
     "supportFamily": "Divine Family",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -1833,8 +1833,6 @@
     "supportReportBugSubtitle": "Технически проблеми с приложението",
     "supportRequestFeature": "Заявка за функция",
     "supportRequestFeatureSubtitle": "Предложи подобрение или нова функция",
-    "supportSaveLogs": "Запази логове",
-    "supportSaveLogsSubtitle": "Експортирай логовете във файл за ръчно изпращане",
     "supportFaq": "ЧЗВ",
     "supportFaqSubtitle": "Често задавани въпроси и отговори",
     "supportFamily": "Divine Family",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -1634,8 +1634,6 @@
     "supportReportBugSubtitle": "Technische Probleme mit der App",
     "supportRequestFeature": "Feature wünschen",
     "supportRequestFeatureSubtitle": "Eine Verbesserung oder ein neues Feature vorschlagen",
-    "supportSaveLogs": "Logs speichern",
-    "supportSaveLogsSubtitle": "Logs als Datei exportieren, um sie manuell zu senden",
     "supportFaq": "FAQ",
     "supportFaqSubtitle": "Häufige Fragen & Antworten",
     "supportFamily": "Divine Family",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -1366,6 +1366,14 @@
   },
   "devOptionsDisableDeveloperModeSubtitle": "Hide developer options from settings",
   "devOptionsDisableDeveloperModeToast": "Developer mode disabled",
+  "devOptionsExportLogs": "Export Logs",
+  "@devOptionsExportLogs": {
+    "description": "Developer-options row that opens the system share sheet with the captured log file attached."
+  },
+  "devOptionsExportLogsSubtitle": "Share the log file so we can dig in",
+  "@devOptionsExportLogsSubtitle": {
+    "description": "Subtitle for the developer-options Export Logs row. Says what the row does: hands the file to another app."
+  },
   "devOptionsShorebirdTitle": "Shorebird Patches",
   "devOptionsShorebirdPatchLabel": "Running patch",
   "@devOptionsShorebirdPatchLabel": {
@@ -2831,8 +2839,6 @@
   "supportReportBugSubtitle": "Technical issues with the app",
   "supportRequestFeature": "Request a Feature",
   "supportRequestFeatureSubtitle": "Suggest an improvement or new feature",
-  "supportSaveLogs": "Save Logs",
-  "supportSaveLogsSubtitle": "Export logs to file for manual sending",
   "supportFaq": "FAQ",
   "supportFaqSubtitle": "Common questions & answers",
   "supportFamily": "Divine Family",
@@ -2856,22 +2862,6 @@
   "supportLoginRequired": "Log in to contact support",
   "supportExportingLogs": "Exporting logs...",
   "supportExportLogsFailed": "Failed to export logs",
-  "supportCopyLogs": "Copy Logs",
-  "@supportCopyLogs": {
-    "description": "Support Center tile that copies recent logs to the clipboard. Separate from Save Logs because Android's share sheet Copy action can only copy text, never the attached log file."
-  },
-  "supportCopyLogsSubtitle": "Put the recent ones on your clipboard",
-  "@supportCopyLogsSubtitle": {
-    "description": "Subtitle for the Copy Logs tile. 'The recent ones' refers to log entries; the copy is capped so it stays pasteable."
-  },
-  "supportLogsCopied": "Logs copied",
-  "@supportLogsCopied": {
-    "description": "Snackbar confirming the logs reached the clipboard."
-  },
-  "supportCopyLogsFailed": "Couldn't copy the logs",
-  "@supportCopyLogsFailed": {
-    "description": "Snackbar shown when the clipboard write failed or could not be verified."
-  },
   "supportNoLogsToExport": "No logs yet — they start fresh each launch. Reproduce the problem, then come back without restarting.",
   "@supportNoLogsToExport": {
     "description": "Shown when the user exports or copies logs but the in-memory capture buffer is empty, which is what happens after a crash or force-quit. Tells them the logs do not survive a restart so they know to reproduce first."

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -1638,8 +1638,6 @@
     "supportReportBugSubtitle": "Problemas técnicos con la app",
     "supportRequestFeature": "Pedir una función",
     "supportRequestFeatureSubtitle": "Sugerí una mejora o una función nueva",
-    "supportSaveLogs": "Guardar logs",
-    "supportSaveLogsSubtitle": "Exportá los logs a un archivo para enviarlos manualmente",
     "supportFaq": "Preguntas frecuentes",
     "supportFaqSubtitle": "Preguntas y respuestas comunes",
     "supportFamily": "Divine Family",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -1134,8 +1134,6 @@
     "supportReportBugSubtitle": "Mga technical issue sa app",
     "supportRequestFeature": "Humiling ng Feature",
     "supportRequestFeatureSubtitle": "Magmungkahi ng improvement o bagong feature",
-    "supportSaveLogs": "I-save ang Logs",
-    "supportSaveLogsSubtitle": "I-export ang logs sa file para manual na maipadala",
     "supportFaq": "FAQ",
     "supportFaqSubtitle": "Mga karaniwang tanong at sagot",
     "supportFamily": "Divine Family",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -1634,8 +1634,6 @@
     "supportReportBugSubtitle": "Problèmes techniques avec l'app",
     "supportRequestFeature": "Demander une fonctionnalité",
     "supportRequestFeatureSubtitle": "Suggérer une amélioration ou une nouvelle fonctionnalité",
-    "supportSaveLogs": "Sauvegarder les logs",
-    "supportSaveLogsSubtitle": "Exporter les logs vers un fichier pour envoi manuel",
     "supportFaq": "FAQ",
     "supportFaqSubtitle": "Questions et réponses courantes",
     "supportFamily": "Divine Family",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -1631,8 +1631,6 @@
     "supportReportBugSubtitle": "Masalah teknis dengan aplikasi",
     "supportRequestFeature": "Minta Fitur",
     "supportRequestFeatureSubtitle": "Sarankan perbaikan atau fitur baru",
-    "supportSaveLogs": "Simpan Log",
-    "supportSaveLogsSubtitle": "Ekspor log ke file untuk pengiriman manual",
     "supportFaq": "FAQ",
     "supportFaqSubtitle": "Pertanyaan & jawaban umum",
     "supportFamily": "Divine Family",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -1634,8 +1634,6 @@
     "supportReportBugSubtitle": "Problemi tecnici con l'app",
     "supportRequestFeature": "Richiedi una funzionalità",
     "supportRequestFeatureSubtitle": "Suggerisci un miglioramento o una nuova funzionalità",
-    "supportSaveLogs": "Salva log",
-    "supportSaveLogsSubtitle": "Esporta i log in un file per l'invio manuale",
     "supportFaq": "FAQ",
     "supportFaqSubtitle": "Domande frequenti e risposte",
     "supportFamily": "Divine Family",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -1624,8 +1624,6 @@
     "supportReportBugSubtitle": "アプリの技術的な問題",
     "supportRequestFeature": "機能リクエスト",
     "supportRequestFeatureSubtitle": "改善や新機能の提案",
-    "supportSaveLogs": "ログを保存",
-    "supportSaveLogsSubtitle": "手動送信用にログをファイルにエクスポート",
     "supportFaq": "よくある質問",
     "supportFaqSubtitle": "よくある質問と回答",
     "supportFamily": "Divine Family",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -1092,8 +1092,6 @@
     "supportReportBugSubtitle": "앱의 기술적 문제",
     "supportRequestFeature": "기능 요청",
     "supportRequestFeatureSubtitle": "개선이나 새로운 기능을 제안해요",
-    "supportSaveLogs": "로그 저장",
-    "supportSaveLogsSubtitle": "수동 전송을 위해 로그를 파일로 내보내요",
     "supportFaq": "자주 묻는 질문",
     "supportFaqSubtitle": "일반적인 질문과 답변",
     "supportFamily": "Divine Family",

--- a/mobile/lib/l10n/app_ms.arb
+++ b/mobile/lib/l10n/app_ms.arb
@@ -2376,8 +2376,6 @@
   "supportReportBugSubtitle": "Isu teknikal dengan apl",
   "supportRequestFeature": "Minta Ciri Baharu",
   "supportRequestFeatureSubtitle": "Cadangkan penambahbaikan atau ciri baharu",
-  "supportSaveLogs": "Simpan Log",
-  "supportSaveLogsSubtitle": "Eksport log ke fail untuk penghantaran manual",
   "supportFaq": "Soalan Lazim",
   "supportFaqSubtitle": "Soalan & jawapan lazim",
   "supportFamily": "Divine Family",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -1634,8 +1634,6 @@
     "supportReportBugSubtitle": "Technische problemen met de app",
     "supportRequestFeature": "Functie aanvragen",
     "supportRequestFeatureSubtitle": "Stel een verbetering of nieuwe functie voor",
-    "supportSaveLogs": "Logs opslaan",
-    "supportSaveLogsSubtitle": "Exporteer logs naar bestand om handmatig te versturen",
     "supportFaq": "Veelgestelde vragen",
     "supportFaqSubtitle": "Veelgestelde vragen & antwoorden",
     "supportFamily": "Divine Family",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -1634,8 +1634,6 @@
     "supportReportBugSubtitle": "Problemy techniczne z aplikacją",
     "supportRequestFeature": "Poproś o funkcję",
     "supportRequestFeatureSubtitle": "Zasugeruj usprawnienie lub nową funkcję",
-    "supportSaveLogs": "Zapisz logi",
-    "supportSaveLogsSubtitle": "Eksportuj logi do pliku do ręcznego wysłania",
     "supportFaq": "FAQ",
     "supportFaqSubtitle": "Częste pytania i odpowiedzi",
     "supportFamily": "Divine Family",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -1634,8 +1634,6 @@
     "supportReportBugSubtitle": "Problemas técnicos com o app",
     "supportRequestFeature": "Pedir uma funcionalidade",
     "supportRequestFeatureSubtitle": "Sugira uma melhoria ou nova funcionalidade",
-    "supportSaveLogs": "Salvar logs",
-    "supportSaveLogsSubtitle": "Exportar logs para um arquivo para envio manual",
     "supportFaq": "FAQ",
     "supportFaqSubtitle": "Perguntas e respostas comuns",
     "supportFamily": "Divine Family",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -1634,8 +1634,6 @@
     "supportReportBugSubtitle": "Probleme tehnice cu aplicația",
     "supportRequestFeature": "Cere o funcție",
     "supportRequestFeatureSubtitle": "Sugerează o îmbunătățire sau o funcție nouă",
-    "supportSaveLogs": "Salvează jurnalele",
-    "supportSaveLogsSubtitle": "Exportă jurnalele într-un fișier pentru trimitere manuală",
     "supportFaq": "Întrebări frecvente",
     "supportFaqSubtitle": "Întrebări și răspunsuri comune",
     "supportFamily": "Divine Family",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -1634,8 +1634,6 @@
     "supportReportBugSubtitle": "Tekniska problem med appen",
     "supportRequestFeature": "Begär en funktion",
     "supportRequestFeatureSubtitle": "Föreslå en förbättring eller ny funktion",
-    "supportSaveLogs": "Spara loggar",
-    "supportSaveLogsSubtitle": "Exportera loggar till fil för manuell sändning",
     "supportFaq": "FAQ",
     "supportFaqSubtitle": "Vanliga frågor och svar",
     "supportFamily": "Divine Family",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -1631,8 +1631,6 @@
     "supportReportBugSubtitle": "Uygulamayla ilgili teknik sorunlar",
     "supportRequestFeature": "Özellik İste",
     "supportRequestFeatureSubtitle": "Bir iyileştirme veya yeni özellik öner",
-    "supportSaveLogs": "Günlükleri Kaydet",
-    "supportSaveLogsSubtitle": "Manuel göndermek için günlükleri dosyaya aktar",
     "supportFaq": "SSS",
     "supportFaqSubtitle": "Sık sorulan sorular ve cevapları",
     "supportFamily": "Divine Family",

--- a/mobile/lib/l10n/app_ur.arb
+++ b/mobile/lib/l10n/app_ur.arb
@@ -2376,8 +2376,6 @@
   "supportReportBugSubtitle": "ایپ کے تکنیکی مسائل",
   "supportRequestFeature": "فیچر کی درخواست کریں",
   "supportRequestFeatureSubtitle": "کوئی بہتری یا نیا فیچر تجویز کریں",
-  "supportSaveLogs": "لاگز محفوظ کریں",
-  "supportSaveLogsSubtitle": "دستی بھیجنے کے لیے لاگز فائل میں ایکسپورٹ کریں",
   "supportFaq": "عمومی سوالات",
   "supportFaqSubtitle": "عام سوالات اور جوابات",
   "supportFamily": "Divine Family",

--- a/mobile/lib/l10n/app_vi.arb
+++ b/mobile/lib/l10n/app_vi.arb
@@ -2376,8 +2376,6 @@
   "supportReportBugSubtitle": "Sự cố kỹ thuật của ứng dụng",
   "supportRequestFeature": "Yêu cầu tính năng",
   "supportRequestFeatureSubtitle": "Đề xuất cải tiến hoặc tính năng mới",
-  "supportSaveLogs": "Lưu nhật ký",
-  "supportSaveLogsSubtitle": "Xuất nhật ký ra tệp để gửi thủ công",
   "supportFaq": "Câu hỏi thường gặp",
   "supportFaqSubtitle": "Câu hỏi & câu trả lời phổ biến",
   "supportFamily": "Divine Family",

--- a/mobile/lib/l10n/app_zh.arb
+++ b/mobile/lib/l10n/app_zh.arb
@@ -2376,8 +2376,6 @@
   "supportReportBugSubtitle": "应用的技术问题",
   "supportRequestFeature": "功能建议",
   "supportRequestFeatureSubtitle": "提出改进建议或新功能想法",
-  "supportSaveLogs": "保存日志",
-  "supportSaveLogsSubtitle": "导出日志到文件，手动发送",
   "supportFaq": "常见问题",
   "supportFaqSubtitle": "常见问题与解答",
   "supportFamily": "Divine Family",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -3403,6 +3403,18 @@ abstract class AppLocalizations {
   /// **'Developer mode disabled'**
   String get devOptionsDisableDeveloperModeToast;
 
+  /// Developer-options row that opens the system share sheet with the captured log file attached.
+  ///
+  /// In en, this message translates to:
+  /// **'Export Logs'**
+  String get devOptionsExportLogs;
+
+  /// Subtitle for the developer-options Export Logs row. Says what the row does: hands the file to another app.
+  ///
+  /// In en, this message translates to:
+  /// **'Share the log file so we can dig in'**
+  String get devOptionsExportLogsSubtitle;
+
   /// No description provided for @devOptionsShorebirdTitle.
   ///
   /// In en, this message translates to:
@@ -7637,18 +7649,6 @@ abstract class AppLocalizations {
   /// **'Suggest an improvement or new feature'**
   String get supportRequestFeatureSubtitle;
 
-  /// No description provided for @supportSaveLogs.
-  ///
-  /// In en, this message translates to:
-  /// **'Save Logs'**
-  String get supportSaveLogs;
-
-  /// No description provided for @supportSaveLogsSubtitle.
-  ///
-  /// In en, this message translates to:
-  /// **'Export logs to file for manual sending'**
-  String get supportSaveLogsSubtitle;
-
   /// No description provided for @supportFaq.
   ///
   /// In en, this message translates to:
@@ -7714,30 +7714,6 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Failed to export logs'**
   String get supportExportLogsFailed;
-
-  /// Support Center tile that copies recent logs to the clipboard. Separate from Save Logs because Android's share sheet Copy action can only copy text, never the attached log file.
-  ///
-  /// In en, this message translates to:
-  /// **'Copy Logs'**
-  String get supportCopyLogs;
-
-  /// Subtitle for the Copy Logs tile. 'The recent ones' refers to log entries; the copy is capped so it stays pasteable.
-  ///
-  /// In en, this message translates to:
-  /// **'Put the recent ones on your clipboard'**
-  String get supportCopyLogsSubtitle;
-
-  /// Snackbar confirming the logs reached the clipboard.
-  ///
-  /// In en, this message translates to:
-  /// **'Logs copied'**
-  String get supportLogsCopied;
-
-  /// Snackbar shown when the clipboard write failed or could not be verified.
-  ///
-  /// In en, this message translates to:
-  /// **'Couldn\'t copy the logs'**
-  String get supportCopyLogsFailed;
 
   /// Shown when the user exports or copies logs but the in-memory capture buffer is empty, which is what happens after a crash or force-quit. Tells them the logs do not survive a restart so they know to reproduce first.
   ///

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -1955,6 +1955,13 @@ class AppLocalizationsAm extends AppLocalizations {
   String get devOptionsDisableDeveloperModeToast => 'የገንቢ ሁነታ ተሰናክሏል';
 
   @override
+  String get devOptionsExportLogs => 'Export Logs';
+
+  @override
+  String get devOptionsExportLogsSubtitle =>
+      'Share the log file so we can dig in';
+
+  @override
   String get devOptionsShorebirdTitle => 'የShorebird ማስተካከያዎች';
 
   @override
@@ -4373,12 +4380,6 @@ class AppLocalizationsAm extends AppLocalizations {
   String get supportRequestFeatureSubtitle => 'ማሻሻያ ወይም አዲስ ባህሪን ይጠቁሙ';
 
   @override
-  String get supportSaveLogs => 'ምዝግብ ማስታወሻዎችን ያስቀምጡ';
-
-  @override
-  String get supportSaveLogsSubtitle => 'በእጅ ለመላክ የምዝግብ ማስታወሻዎችን ወደ ፋይል ይላኩ።';
-
-  @override
   String get supportFaq => 'የሚጠየቁ ጥያቄዎች';
 
   @override
@@ -4411,18 +4412,6 @@ class AppLocalizationsAm extends AppLocalizations {
 
   @override
   String get supportExportLogsFailed => 'ምዝግብ ማስታወሻዎችን ወደ ውጭ መላክ አልተሳካም።';
-
-  @override
-  String get supportCopyLogs => 'Copy Logs';
-
-  @override
-  String get supportCopyLogsSubtitle => 'Put the recent ones on your clipboard';
-
-  @override
-  String get supportLogsCopied => 'Logs copied';
-
-  @override
-  String get supportCopyLogsFailed => 'Couldn\'t copy the logs';
 
   @override
   String get supportNoLogsToExport =>

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -1975,6 +1975,13 @@ class AppLocalizationsAr extends AppLocalizations {
   String get devOptionsDisableDeveloperModeToast => 'تم تعطيل وضع المطوّر';
 
   @override
+  String get devOptionsExportLogs => 'Export Logs';
+
+  @override
+  String get devOptionsExportLogsSubtitle =>
+      'Share the log file so we can dig in';
+
+  @override
   String get devOptionsShorebirdTitle => 'تصحيحات Shorebird';
 
   @override
@@ -4434,12 +4441,6 @@ class AppLocalizationsAr extends AppLocalizations {
   String get supportRequestFeatureSubtitle => 'اقتراح تحسين أو ميزة جديدة';
 
   @override
-  String get supportSaveLogs => 'حفظ السجلات';
-
-  @override
-  String get supportSaveLogsSubtitle => 'تصدير السجلات إلى ملف للإرسال يدويًا';
-
-  @override
   String get supportFaq => 'الأسئلة الشائعة';
 
   @override
@@ -4472,18 +4473,6 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get supportExportLogsFailed => 'تعذر تصدير السجلات';
-
-  @override
-  String get supportCopyLogs => 'Copy Logs';
-
-  @override
-  String get supportCopyLogsSubtitle => 'Put the recent ones on your clipboard';
-
-  @override
-  String get supportLogsCopied => 'Logs copied';
-
-  @override
-  String get supportCopyLogsFailed => 'Couldn\'t copy the logs';
 
   @override
   String get supportNoLogsToExport =>

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -2025,6 +2025,13 @@ class AppLocalizationsBg extends AppLocalizations {
       'Режимът за разработчици е изключен';
 
   @override
+  String get devOptionsExportLogs => 'Export Logs';
+
+  @override
+  String get devOptionsExportLogsSubtitle =>
+      'Share the log file so we can dig in';
+
+  @override
   String get devOptionsShorebirdTitle => 'Корекции на Shorebird';
 
   @override
@@ -4518,13 +4525,6 @@ class AppLocalizationsBg extends AppLocalizations {
       'Предложи подобрение или нова функция';
 
   @override
-  String get supportSaveLogs => 'Запази логове';
-
-  @override
-  String get supportSaveLogsSubtitle =>
-      'Експортирай логовете във файл за ръчно изпращане';
-
-  @override
   String get supportFaq => 'ЧЗВ';
 
   @override
@@ -4558,18 +4558,6 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get supportExportLogsFailed => 'Не успяхме да експортираме логовете';
-
-  @override
-  String get supportCopyLogs => 'Copy Logs';
-
-  @override
-  String get supportCopyLogsSubtitle => 'Put the recent ones on your clipboard';
-
-  @override
-  String get supportLogsCopied => 'Logs copied';
-
-  @override
-  String get supportCopyLogsFailed => 'Couldn\'t copy the logs';
 
   @override
   String get supportNoLogsToExport =>

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -2017,6 +2017,13 @@ class AppLocalizationsDe extends AppLocalizations {
       'Entwicklermodus deaktiviert';
 
   @override
+  String get devOptionsExportLogs => 'Export Logs';
+
+  @override
+  String get devOptionsExportLogsSubtitle =>
+      'Share the log file so we can dig in';
+
+  @override
   String get devOptionsShorebirdTitle => 'Shorebird-Patches';
 
   @override
@@ -4525,13 +4532,6 @@ class AppLocalizationsDe extends AppLocalizations {
       'Eine Verbesserung oder ein neues Feature vorschlagen';
 
   @override
-  String get supportSaveLogs => 'Logs speichern';
-
-  @override
-  String get supportSaveLogsSubtitle =>
-      'Logs als Datei exportieren, um sie manuell zu senden';
-
-  @override
   String get supportFaq => 'FAQ';
 
   @override
@@ -4566,18 +4566,6 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get supportExportLogsFailed => 'Logs konnten nicht exportiert werden';
-
-  @override
-  String get supportCopyLogs => 'Copy Logs';
-
-  @override
-  String get supportCopyLogsSubtitle => 'Put the recent ones on your clipboard';
-
-  @override
-  String get supportLogsCopied => 'Logs copied';
-
-  @override
-  String get supportCopyLogsFailed => 'Couldn\'t copy the logs';
 
   @override
   String get supportNoLogsToExport =>

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -2002,6 +2002,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get devOptionsDisableDeveloperModeToast => 'Developer mode disabled';
 
   @override
+  String get devOptionsExportLogs => 'Export Logs';
+
+  @override
+  String get devOptionsExportLogsSubtitle =>
+      'Share the log file so we can dig in';
+
+  @override
   String get devOptionsShorebirdTitle => 'Shorebird Patches';
 
   @override
@@ -4558,13 +4565,6 @@ class AppLocalizationsEn extends AppLocalizations {
       'Suggest an improvement or new feature';
 
   @override
-  String get supportSaveLogs => 'Save Logs';
-
-  @override
-  String get supportSaveLogsSubtitle =>
-      'Export logs to file for manual sending';
-
-  @override
   String get supportFaq => 'FAQ';
 
   @override
@@ -4598,18 +4598,6 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get supportExportLogsFailed => 'Failed to export logs';
-
-  @override
-  String get supportCopyLogs => 'Copy Logs';
-
-  @override
-  String get supportCopyLogsSubtitle => 'Put the recent ones on your clipboard';
-
-  @override
-  String get supportLogsCopied => 'Logs copied';
-
-  @override
-  String get supportCopyLogsFailed => 'Couldn\'t copy the logs';
 
   @override
   String get supportNoLogsToExport =>

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -2014,6 +2014,13 @@ class AppLocalizationsEs extends AppLocalizations {
       'Modo de desarrollador desactivado';
 
   @override
+  String get devOptionsExportLogs => 'Export Logs';
+
+  @override
+  String get devOptionsExportLogsSubtitle =>
+      'Share the log file so we can dig in';
+
+  @override
   String get devOptionsShorebirdTitle => 'Parches de Shorebird';
 
   @override
@@ -4515,13 +4522,6 @@ class AppLocalizationsEs extends AppLocalizations {
       'Sugerí una mejora o una función nueva';
 
   @override
-  String get supportSaveLogs => 'Guardar logs';
-
-  @override
-  String get supportSaveLogsSubtitle =>
-      'Exportá los logs a un archivo para enviarlos manualmente';
-
-  @override
   String get supportFaq => 'Preguntas frecuentes';
 
   @override
@@ -4556,18 +4556,6 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get supportExportLogsFailed => 'No se pudieron exportar los logs';
-
-  @override
-  String get supportCopyLogs => 'Copy Logs';
-
-  @override
-  String get supportCopyLogsSubtitle => 'Put the recent ones on your clipboard';
-
-  @override
-  String get supportLogsCopied => 'Logs copied';
-
-  @override
-  String get supportCopyLogsFailed => 'Couldn\'t copy the logs';
 
   @override
   String get supportNoLogsToExport =>

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -1995,6 +1995,13 @@ class AppLocalizationsFil extends AppLocalizations {
       'Na-disable ang developer mode';
 
   @override
+  String get devOptionsExportLogs => 'Export Logs';
+
+  @override
+  String get devOptionsExportLogsSubtitle =>
+      'Share the log file so we can dig in';
+
+  @override
   String get devOptionsShorebirdTitle => 'Mga patch ng Shorebird';
 
   @override
@@ -4498,13 +4505,6 @@ class AppLocalizationsFil extends AppLocalizations {
       'Magmungkahi ng improvement o bagong feature';
 
   @override
-  String get supportSaveLogs => 'I-save ang Logs';
-
-  @override
-  String get supportSaveLogsSubtitle =>
-      'I-export ang logs sa file para manual na maipadala';
-
-  @override
   String get supportFaq => 'FAQ';
 
   @override
@@ -4540,18 +4540,6 @@ class AppLocalizationsFil extends AppLocalizations {
 
   @override
   String get supportExportLogsFailed => 'Hindi na-export ang logs';
-
-  @override
-  String get supportCopyLogs => 'Copy Logs';
-
-  @override
-  String get supportCopyLogsSubtitle => 'Put the recent ones on your clipboard';
-
-  @override
-  String get supportLogsCopied => 'Logs copied';
-
-  @override
-  String get supportCopyLogsFailed => 'Couldn\'t copy the logs';
 
   @override
   String get supportNoLogsToExport =>

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -2028,6 +2028,13 @@ class AppLocalizationsFr extends AppLocalizations {
       'Mode développeur désactivé';
 
   @override
+  String get devOptionsExportLogs => 'Export Logs';
+
+  @override
+  String get devOptionsExportLogsSubtitle =>
+      'Share the log file so we can dig in';
+
+  @override
   String get devOptionsShorebirdTitle => 'Correctifs Shorebird';
 
   @override
@@ -4534,13 +4541,6 @@ class AppLocalizationsFr extends AppLocalizations {
       'Suggérer une amélioration ou une nouvelle fonctionnalité';
 
   @override
-  String get supportSaveLogs => 'Sauvegarder les logs';
-
-  @override
-  String get supportSaveLogsSubtitle =>
-      'Exporter les logs vers un fichier pour envoi manuel';
-
-  @override
   String get supportFaq => 'FAQ';
 
   @override
@@ -4575,18 +4575,6 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get supportExportLogsFailed => 'Échec de l\'exportation des logs';
-
-  @override
-  String get supportCopyLogs => 'Copy Logs';
-
-  @override
-  String get supportCopyLogsSubtitle => 'Put the recent ones on your clipboard';
-
-  @override
-  String get supportLogsCopied => 'Logs copied';
-
-  @override
-  String get supportCopyLogsFailed => 'Couldn\'t copy the logs';
 
   @override
   String get supportNoLogsToExport =>

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -1924,6 +1924,13 @@ class AppLocalizationsId extends AppLocalizations {
       'Mode pengembang dinonaktifkan';
 
   @override
+  String get devOptionsExportLogs => 'Export Logs';
+
+  @override
+  String get devOptionsExportLogsSubtitle =>
+      'Share the log file so we can dig in';
+
+  @override
   String get devOptionsShorebirdTitle => 'Patch Shorebird';
 
   @override
@@ -4401,13 +4408,6 @@ class AppLocalizationsId extends AppLocalizations {
       'Sarankan perbaikan atau fitur baru';
 
   @override
-  String get supportSaveLogs => 'Simpan Log';
-
-  @override
-  String get supportSaveLogsSubtitle =>
-      'Ekspor log ke file untuk pengiriman manual';
-
-  @override
   String get supportFaq => 'FAQ';
 
   @override
@@ -4441,18 +4441,6 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get supportExportLogsFailed => 'Gagal mengekspor log';
-
-  @override
-  String get supportCopyLogs => 'Copy Logs';
-
-  @override
-  String get supportCopyLogsSubtitle => 'Put the recent ones on your clipboard';
-
-  @override
-  String get supportLogsCopied => 'Logs copied';
-
-  @override
-  String get supportCopyLogsFailed => 'Couldn\'t copy the logs';
 
   @override
   String get supportNoLogsToExport =>

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -2022,6 +2022,13 @@ class AppLocalizationsIt extends AppLocalizations {
       'Modalità sviluppatore disattivata';
 
   @override
+  String get devOptionsExportLogs => 'Export Logs';
+
+  @override
+  String get devOptionsExportLogsSubtitle =>
+      'Share the log file so we can dig in';
+
+  @override
   String get devOptionsShorebirdTitle => 'Patch Shorebird';
 
   @override
@@ -4519,13 +4526,6 @@ class AppLocalizationsIt extends AppLocalizations {
       'Suggerisci un miglioramento o una nuova funzionalità';
 
   @override
-  String get supportSaveLogs => 'Salva log';
-
-  @override
-  String get supportSaveLogsSubtitle =>
-      'Esporta i log in un file per l\'invio manuale';
-
-  @override
   String get supportFaq => 'FAQ';
 
   @override
@@ -4560,18 +4560,6 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get supportExportLogsFailed => 'Esportazione log fallita';
-
-  @override
-  String get supportCopyLogs => 'Copy Logs';
-
-  @override
-  String get supportCopyLogsSubtitle => 'Put the recent ones on your clipboard';
-
-  @override
-  String get supportLogsCopied => 'Logs copied';
-
-  @override
-  String get supportCopyLogsFailed => 'Couldn\'t copy the logs';
 
   @override
   String get supportNoLogsToExport =>

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -1843,6 +1843,13 @@ class AppLocalizationsJa extends AppLocalizations {
   String get devOptionsDisableDeveloperModeToast => '開発者モードを無効にしました';
 
   @override
+  String get devOptionsExportLogs => 'Export Logs';
+
+  @override
+  String get devOptionsExportLogsSubtitle =>
+      'Share the log file so we can dig in';
+
+  @override
   String get devOptionsShorebirdTitle => 'Shorebirdパッチ';
 
   @override
@@ -4211,12 +4218,6 @@ class AppLocalizationsJa extends AppLocalizations {
   String get supportRequestFeatureSubtitle => '改善や新機能の提案';
 
   @override
-  String get supportSaveLogs => 'ログを保存';
-
-  @override
-  String get supportSaveLogsSubtitle => '手動送信用にログをファイルにエクスポート';
-
-  @override
   String get supportFaq => 'よくある質問';
 
   @override
@@ -4248,18 +4249,6 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get supportExportLogsFailed => 'ログのエクスポートがうまくいかなかった';
-
-  @override
-  String get supportCopyLogs => 'Copy Logs';
-
-  @override
-  String get supportCopyLogsSubtitle => 'Put the recent ones on your clipboard';
-
-  @override
-  String get supportLogsCopied => 'Logs copied';
-
-  @override
-  String get supportCopyLogsFailed => 'Couldn\'t copy the logs';
 
   @override
   String get supportNoLogsToExport =>

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -1853,6 +1853,13 @@ class AppLocalizationsKo extends AppLocalizations {
   String get devOptionsDisableDeveloperModeToast => '개발자 모드가 비활성화됨';
 
   @override
+  String get devOptionsExportLogs => 'Export Logs';
+
+  @override
+  String get devOptionsExportLogsSubtitle =>
+      'Share the log file so we can dig in';
+
+  @override
   String get devOptionsShorebirdTitle => 'Shorebird 패치';
 
   @override
@@ -4227,12 +4234,6 @@ class AppLocalizationsKo extends AppLocalizations {
   String get supportRequestFeatureSubtitle => '개선이나 새로운 기능을 제안해요';
 
   @override
-  String get supportSaveLogs => '로그 저장';
-
-  @override
-  String get supportSaveLogsSubtitle => '수동 전송을 위해 로그를 파일로 내보내요';
-
-  @override
   String get supportFaq => '자주 묻는 질문';
 
   @override
@@ -4264,18 +4265,6 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get supportExportLogsFailed => '로그 내보내기에 실패했어요';
-
-  @override
-  String get supportCopyLogs => 'Copy Logs';
-
-  @override
-  String get supportCopyLogsSubtitle => 'Put the recent ones on your clipboard';
-
-  @override
-  String get supportLogsCopied => 'Logs copied';
-
-  @override
-  String get supportCopyLogsFailed => 'Couldn\'t copy the logs';
 
   @override
   String get supportNoLogsToExport =>

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -1977,6 +1977,13 @@ class AppLocalizationsMs extends AppLocalizations {
   String get devOptionsDisableDeveloperModeToast => 'Mod pembangun dilumpuhkan';
 
   @override
+  String get devOptionsExportLogs => 'Export Logs';
+
+  @override
+  String get devOptionsExportLogsSubtitle =>
+      'Share the log file so we can dig in';
+
+  @override
   String get devOptionsShorebirdTitle => 'Tampalan Shorebird';
 
   @override
@@ -4469,13 +4476,6 @@ class AppLocalizationsMs extends AppLocalizations {
       'Cadangkan penambahbaikan atau ciri baharu';
 
   @override
-  String get supportSaveLogs => 'Simpan Log';
-
-  @override
-  String get supportSaveLogsSubtitle =>
-      'Eksport log ke fail untuk penghantaran manual';
-
-  @override
   String get supportFaq => 'Soalan Lazim';
 
   @override
@@ -4510,18 +4510,6 @@ class AppLocalizationsMs extends AppLocalizations {
 
   @override
   String get supportExportLogsFailed => 'Gagal mengeksport log';
-
-  @override
-  String get supportCopyLogs => 'Copy Logs';
-
-  @override
-  String get supportCopyLogsSubtitle => 'Put the recent ones on your clipboard';
-
-  @override
-  String get supportLogsCopied => 'Logs copied';
-
-  @override
-  String get supportCopyLogsFailed => 'Couldn\'t copy the logs';
 
   @override
   String get supportNoLogsToExport =>

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -2002,6 +2002,13 @@ class AppLocalizationsNl extends AppLocalizations {
       'Ontwikkelaarsmodus uitgeschakeld';
 
   @override
+  String get devOptionsExportLogs => 'Export Logs';
+
+  @override
+  String get devOptionsExportLogsSubtitle =>
+      'Share the log file so we can dig in';
+
+  @override
   String get devOptionsShorebirdTitle => 'Shorebird-patches';
 
   @override
@@ -4485,13 +4492,6 @@ class AppLocalizationsNl extends AppLocalizations {
       'Stel een verbetering of nieuwe functie voor';
 
   @override
-  String get supportSaveLogs => 'Logs opslaan';
-
-  @override
-  String get supportSaveLogsSubtitle =>
-      'Exporteer logs naar bestand om handmatig te versturen';
-
-  @override
   String get supportFaq => 'Veelgestelde vragen';
 
   @override
@@ -4526,18 +4526,6 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get supportExportLogsFailed => 'Logs exporteren mislukt';
-
-  @override
-  String get supportCopyLogs => 'Copy Logs';
-
-  @override
-  String get supportCopyLogsSubtitle => 'Put the recent ones on your clipboard';
-
-  @override
-  String get supportLogsCopied => 'Logs copied';
-
-  @override
-  String get supportCopyLogsFailed => 'Couldn\'t copy the logs';
 
   @override
   String get supportNoLogsToExport =>

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -2032,6 +2032,13 @@ class AppLocalizationsPl extends AppLocalizations {
   String get devOptionsDisableDeveloperModeToast => 'Tryb dewelopera wyłączony';
 
   @override
+  String get devOptionsExportLogs => 'Export Logs';
+
+  @override
+  String get devOptionsExportLogsSubtitle =>
+      'Share the log file so we can dig in';
+
+  @override
   String get devOptionsShorebirdTitle => 'Poprawki Shorebird';
 
   @override
@@ -4587,13 +4594,6 @@ class AppLocalizationsPl extends AppLocalizations {
       'Zasugeruj usprawnienie lub nową funkcję';
 
   @override
-  String get supportSaveLogs => 'Zapisz logi';
-
-  @override
-  String get supportSaveLogsSubtitle =>
-      'Eksportuj logi do pliku do ręcznego wysłania';
-
-  @override
   String get supportFaq => 'FAQ';
 
   @override
@@ -4629,18 +4629,6 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get supportExportLogsFailed => 'Nie udało się wyeksportować logów';
-
-  @override
-  String get supportCopyLogs => 'Copy Logs';
-
-  @override
-  String get supportCopyLogsSubtitle => 'Put the recent ones on your clipboard';
-
-  @override
-  String get supportLogsCopied => 'Logs copied';
-
-  @override
-  String get supportCopyLogsFailed => 'Couldn\'t copy the logs';
 
   @override
   String get supportNoLogsToExport =>

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -2009,6 +2009,13 @@ class AppLocalizationsPt extends AppLocalizations {
       'Modo de desenvolvedor desativado';
 
   @override
+  String get devOptionsExportLogs => 'Export Logs';
+
+  @override
+  String get devOptionsExportLogsSubtitle =>
+      'Share the log file so we can dig in';
+
+  @override
   String get devOptionsShorebirdTitle => 'Patches do Shorebird';
 
   @override
@@ -4497,13 +4504,6 @@ class AppLocalizationsPt extends AppLocalizations {
       'Sugira uma melhoria ou nova funcionalidade';
 
   @override
-  String get supportSaveLogs => 'Salvar logs';
-
-  @override
-  String get supportSaveLogsSubtitle =>
-      'Exportar logs para um arquivo para envio manual';
-
-  @override
   String get supportFaq => 'FAQ';
 
   @override
@@ -4537,18 +4537,6 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get supportExportLogsFailed => 'Falha ao exportar logs';
-
-  @override
-  String get supportCopyLogs => 'Copy Logs';
-
-  @override
-  String get supportCopyLogsSubtitle => 'Put the recent ones on your clipboard';
-
-  @override
-  String get supportLogsCopied => 'Logs copied';
-
-  @override
-  String get supportCopyLogsFailed => 'Couldn\'t copy the logs';
 
   @override
   String get supportNoLogsToExport =>

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -2041,6 +2041,13 @@ class AppLocalizationsRo extends AppLocalizations {
       'Modul dezvoltator a fost dezactivat';
 
   @override
+  String get devOptionsExportLogs => 'Export Logs';
+
+  @override
+  String get devOptionsExportLogsSubtitle =>
+      'Share the log file so we can dig in';
+
+  @override
   String get devOptionsShorebirdTitle => 'Patch-uri Shorebird';
 
   @override
@@ -4604,13 +4611,6 @@ class AppLocalizationsRo extends AppLocalizations {
       'Sugerează o îmbunătățire sau o funcție nouă';
 
   @override
-  String get supportSaveLogs => 'Salvează jurnalele';
-
-  @override
-  String get supportSaveLogsSubtitle =>
-      'Exportă jurnalele într-un fișier pentru trimitere manuală';
-
-  @override
   String get supportFaq => 'Întrebări frecvente';
 
   @override
@@ -4646,18 +4646,6 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get supportExportLogsFailed => 'N-am putut exporta jurnalele';
-
-  @override
-  String get supportCopyLogs => 'Copy Logs';
-
-  @override
-  String get supportCopyLogsSubtitle => 'Put the recent ones on your clipboard';
-
-  @override
-  String get supportLogsCopied => 'Logs copied';
-
-  @override
-  String get supportCopyLogsFailed => 'Couldn\'t copy the logs';
 
   @override
   String get supportNoLogsToExport =>

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -1987,6 +1987,13 @@ class AppLocalizationsSv extends AppLocalizations {
   String get devOptionsDisableDeveloperModeToast => 'Utvecklarläge inaktiverat';
 
   @override
+  String get devOptionsExportLogs => 'Export Logs';
+
+  @override
+  String get devOptionsExportLogsSubtitle =>
+      'Share the log file so we can dig in';
+
+  @override
   String get devOptionsShorebirdTitle => 'Shorebird-korrigeringar';
 
   @override
@@ -4467,13 +4474,6 @@ class AppLocalizationsSv extends AppLocalizations {
       'Föreslå en förbättring eller ny funktion';
 
   @override
-  String get supportSaveLogs => 'Spara loggar';
-
-  @override
-  String get supportSaveLogsSubtitle =>
-      'Exportera loggar till fil för manuell sändning';
-
-  @override
   String get supportFaq => 'FAQ';
 
   @override
@@ -4506,18 +4506,6 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get supportExportLogsFailed => 'Kunde inte exportera loggar';
-
-  @override
-  String get supportCopyLogs => 'Copy Logs';
-
-  @override
-  String get supportCopyLogsSubtitle => 'Put the recent ones on your clipboard';
-
-  @override
-  String get supportLogsCopied => 'Logs copied';
-
-  @override
-  String get supportCopyLogsFailed => 'Couldn\'t copy the logs';
 
   @override
   String get supportNoLogsToExport =>

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -1929,6 +1929,13 @@ class AppLocalizationsTr extends AppLocalizations {
       'Geliştirici modu devre dışı bırakıldı';
 
   @override
+  String get devOptionsExportLogs => 'Export Logs';
+
+  @override
+  String get devOptionsExportLogsSubtitle =>
+      'Share the log file so we can dig in';
+
+  @override
   String get devOptionsShorebirdTitle => 'Shorebird yamaları';
 
   @override
@@ -4412,13 +4419,6 @@ class AppLocalizationsTr extends AppLocalizations {
       'Bir iyileştirme veya yeni özellik öner';
 
   @override
-  String get supportSaveLogs => 'Günlükleri Kaydet';
-
-  @override
-  String get supportSaveLogsSubtitle =>
-      'Manuel göndermek için günlükleri dosyaya aktar';
-
-  @override
   String get supportFaq => 'SSS';
 
   @override
@@ -4452,18 +4452,6 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get supportExportLogsFailed => 'Günlükler dışa aktarılamadı';
-
-  @override
-  String get supportCopyLogs => 'Copy Logs';
-
-  @override
-  String get supportCopyLogsSubtitle => 'Put the recent ones on your clipboard';
-
-  @override
-  String get supportLogsCopied => 'Logs copied';
-
-  @override
-  String get supportCopyLogsFailed => 'Couldn\'t copy the logs';
 
   @override
   String get supportNoLogsToExport =>

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -1995,6 +1995,13 @@ class AppLocalizationsUr extends AppLocalizations {
       'ڈویلپر موڈ غیر فعال ہو گیا';
 
   @override
+  String get devOptionsExportLogs => 'Export Logs';
+
+  @override
+  String get devOptionsExportLogsSubtitle =>
+      'Share the log file so we can dig in';
+
+  @override
   String get devOptionsShorebirdTitle => 'Shorebird پیچز';
 
   @override
@@ -4478,13 +4485,6 @@ class AppLocalizationsUr extends AppLocalizations {
       'کوئی بہتری یا نیا فیچر تجویز کریں';
 
   @override
-  String get supportSaveLogs => 'لاگز محفوظ کریں';
-
-  @override
-  String get supportSaveLogsSubtitle =>
-      'دستی بھیجنے کے لیے لاگز فائل میں ایکسپورٹ کریں';
-
-  @override
   String get supportFaq => 'عمومی سوالات';
 
   @override
@@ -4518,18 +4518,6 @@ class AppLocalizationsUr extends AppLocalizations {
 
   @override
   String get supportExportLogsFailed => 'لاگز ایکسپورٹ نہیں ہو سکے';
-
-  @override
-  String get supportCopyLogs => 'Copy Logs';
-
-  @override
-  String get supportCopyLogsSubtitle => 'Put the recent ones on your clipboard';
-
-  @override
-  String get supportLogsCopied => 'Logs copied';
-
-  @override
-  String get supportCopyLogsFailed => 'Couldn\'t copy the logs';
 
   @override
   String get supportNoLogsToExport =>

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -1968,6 +1968,13 @@ class AppLocalizationsVi extends AppLocalizations {
       'Đã tắt chế độ nhà phát triển';
 
   @override
+  String get devOptionsExportLogs => 'Export Logs';
+
+  @override
+  String get devOptionsExportLogsSubtitle =>
+      'Share the log file so we can dig in';
+
+  @override
   String get devOptionsShorebirdTitle => 'Bản vá Shorebird';
 
   @override
@@ -4440,12 +4447,6 @@ class AppLocalizationsVi extends AppLocalizations {
       'Đề xuất cải tiến hoặc tính năng mới';
 
   @override
-  String get supportSaveLogs => 'Lưu nhật ký';
-
-  @override
-  String get supportSaveLogsSubtitle => 'Xuất nhật ký ra tệp để gửi thủ công';
-
-  @override
   String get supportFaq => 'Câu hỏi thường gặp';
 
   @override
@@ -4480,18 +4481,6 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get supportExportLogsFailed => 'Không xuất được nhật ký';
-
-  @override
-  String get supportCopyLogs => 'Copy Logs';
-
-  @override
-  String get supportCopyLogsSubtitle => 'Put the recent ones on your clipboard';
-
-  @override
-  String get supportLogsCopied => 'Logs copied';
-
-  @override
-  String get supportCopyLogsFailed => 'Couldn\'t copy the logs';
 
   @override
   String get supportNoLogsToExport =>

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -1868,6 +1868,13 @@ class AppLocalizationsZh extends AppLocalizations {
   String get devOptionsDisableDeveloperModeToast => '开发者模式已关闭';
 
   @override
+  String get devOptionsExportLogs => 'Export Logs';
+
+  @override
+  String get devOptionsExportLogsSubtitle =>
+      'Share the log file so we can dig in';
+
+  @override
   String get devOptionsShorebirdTitle => 'Shorebird 补丁';
 
   @override
@@ -4199,12 +4206,6 @@ class AppLocalizationsZh extends AppLocalizations {
   String get supportRequestFeatureSubtitle => '提出改进建议或新功能想法';
 
   @override
-  String get supportSaveLogs => '保存日志';
-
-  @override
-  String get supportSaveLogsSubtitle => '导出日志到文件，手动发送';
-
-  @override
   String get supportFaq => '常见问题';
 
   @override
@@ -4236,18 +4237,6 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get supportExportLogsFailed => '日志导出失败';
-
-  @override
-  String get supportCopyLogs => 'Copy Logs';
-
-  @override
-  String get supportCopyLogsSubtitle => 'Put the recent ones on your clipboard';
-
-  @override
-  String get supportLogsCopied => 'Logs copied';
-
-  @override
-  String get supportCopyLogsFailed => 'Couldn\'t copy the logs';
 
   @override
   String get supportNoLogsToExport =>

--- a/mobile/lib/screens/developer_options_screen.dart
+++ b/mobile/lib/screens/developer_options_screen.dart
@@ -28,6 +28,7 @@ import 'package:openvine/screens/clip_recovery_screen.dart';
 import 'package:openvine/services/openvine_media_cache.dart';
 import 'package:openvine/services/video_format_preference.dart';
 import 'package:openvine/widgets/developer/storage_footprint_section.dart';
+import 'package:openvine/widgets/developer_options/export_logs_section.dart';
 import 'package:openvine/widgets/developer_options/shorebird_patch_section.dart';
 import 'package:shorebird_code_push/shorebird_code_push.dart';
 import 'package:unified_logger/unified_logger.dart';
@@ -203,7 +204,12 @@ class _DeveloperOptionsScreenState
                 );
               }),
 
-              // Divider between environments and Shorebird patches
+              // Divider between environments and log export
+              Divider(color: context.vineColors.outline, height: 32),
+
+              const ExportLogsSection(),
+
+              // Divider between log export and Shorebird patches
               Divider(color: context.vineColors.outline, height: 32),
 
               ShorebirdPatchSection(

--- a/mobile/lib/screens/settings/support_center_screen.dart
+++ b/mobile/lib/screens/settings/support_center_screen.dart
@@ -12,17 +12,15 @@ import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/router/route_paths.dart';
 import 'package:openvine/screens/auth/welcome_screen.dart';
 import 'package:openvine/services/auth_service.dart';
-import 'package:openvine/services/bug_report_service.dart';
 import 'package:openvine/services/support_email_composer.dart';
 import 'package:openvine/services/zendesk_support_service.dart';
-import 'package:openvine/utils/clipboard_utils.dart';
 import 'package:openvine/utils/share_position_origin.dart';
 import 'package:openvine/widgets/bug_report_dialog.dart';
 import 'package:openvine/widgets/delete_account_action.dart';
 import 'package:openvine/widgets/feature_request_dialog.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-class SupportCenterScreen extends ConsumerStatefulWidget {
+class SupportCenterScreen extends ConsumerWidget {
   static const routeName = 'support-center';
   static const String path = RoutePaths.supportCenter;
 
@@ -36,20 +34,11 @@ class SupportCenterScreen extends ConsumerStatefulWidget {
   final Future<bool> Function()? openZendeskSupport;
 
   @override
-  ConsumerState<SupportCenterScreen> createState() =>
-      _SupportCenterScreenState();
-}
-
-class _SupportCenterScreenState extends ConsumerState<SupportCenterScreen> {
-  var _copyingLogs = false;
-
-  @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final authService = ref.watch(authServiceProvider);
     final userPubkey = authService.currentPublicKeyHex;
     final isAuthenticated =
         ref.watch(currentAuthStateProvider) == AuthState.authenticated;
-    final bugReportService = ref.read(bugReportServiceProvider);
 
     final l10n = context.l10n;
     return Scaffold(
@@ -76,8 +65,7 @@ class _SupportCenterScreenState extends ConsumerState<SupportCenterScreen> {
                   icon: DivineIconName.warningCircle,
                   title: l10n.supportReportBug,
                   subtitle: l10n.supportReportBugSubtitle,
-                  onTap: () =>
-                      _showBugReport(context, bugReportService, userPubkey),
+                  onTap: () => _showBugReport(context, userPubkey),
                 ),
               if (isAuthenticated)
                 _SupportTile(
@@ -86,21 +74,6 @@ class _SupportCenterScreenState extends ConsumerState<SupportCenterScreen> {
                   subtitle: l10n.supportRequestFeatureSubtitle,
                   onTap: () => _showFeatureRequest(context),
                 ),
-              _SupportTile(
-                icon: DivineIconName.save,
-                title: l10n.supportSaveLogs,
-                subtitle: l10n.supportSaveLogsSubtitle,
-                onTap: () => _exportLogs(context, bugReportService, userPubkey),
-              ),
-              // Separate from Save Logs because the share sheet cannot serve
-              // a copy on Android — its Copy chip copies EXTRA_TEXT and never
-              // the attached file (#8112).
-              _SupportTile(
-                icon: DivineIconName.copy,
-                title: l10n.supportCopyLogs,
-                subtitle: l10n.supportCopyLogsSubtitle,
-                onTap: () => _copyLogs(context, bugReportService, userPubkey),
-              ),
               // #6335 was filed from here by someone who could not find
               // deletion, so it has to be reachable from here too. It sits
               // above the outbound links rather than last so it stays on
@@ -166,11 +139,7 @@ class _SupportCenterScreenState extends ConsumerState<SupportCenterScreen> {
     );
   }
 
-  void _showBugReport(
-    BuildContext context,
-    BugReportService bugReportService,
-    String? userPubkey,
-  ) {
+  void _showBugReport(BuildContext context, String? userPubkey) {
     if (userPubkey == null) {
       ScaffoldMessenger.of(context).showSnackBar(
         DivineSnackbarContainer.snackBar(
@@ -188,144 +157,6 @@ class _SupportCenterScreenState extends ConsumerState<SupportCenterScreen> {
     context.push(FeatureRequestScreen.path);
   }
 
-  Future<void> _exportLogs(
-    BuildContext context,
-    BugReportService bugReportService,
-    String? userPubkey,
-  ) async {
-    // Resolve the popover anchor before any await — iPad idiom (including
-    // iOS builds on Apple Silicon Macs) rejects the share sheet without it.
-    final sharePositionOrigin = shareAnchorForContext(context);
-    ScaffoldMessenger.of(context).showSnackBar(
-      DivineSnackbarContainer.snackBar(
-        context.l10n.supportExportingLogs,
-        duration: const Duration(seconds: 2),
-      ),
-    );
-
-    final result = await bugReportService.exportLogsToFile(
-      currentScreen: 'SupportCenterScreen',
-      userPubkey: userPubkey,
-      sharePositionOrigin: sharePositionOrigin,
-    );
-    if (!context.mounted) return;
-
-    final messenger = ScaffoldMessenger.of(context)..hideCurrentSnackBar();
-
-    switch (result.status) {
-      case LogExportStatus.cancelled:
-        // User backed out of the share sheet or Save As dialog.
-        return;
-      case LogExportStatus.noLogs:
-        messenger.showSnackBar(
-          DivineSnackbarContainer.snackBar(
-            context.l10n.supportNoLogsToExport,
-            duration: const Duration(seconds: 8),
-          ),
-        );
-        return;
-      case LogExportStatus.unconfirmed:
-        messenger.showSnackBar(
-          DivineSnackbarContainer.snackBar(
-            context.l10n.supportExportLogsUnconfirmed,
-            duration: const Duration(seconds: 6),
-          ),
-        );
-        return;
-      case LogExportStatus.failed:
-        messenger.showSnackBar(
-          DivineSnackbarContainer.snackBar(
-            context.l10n.supportExportLogsFailed,
-            error: true,
-          ),
-        );
-        return;
-      case LogExportStatus.shared:
-      case LogExportStatus.saved:
-        break;
-    }
-
-    final filePath = result.filePath;
-    if (filePath != null) {
-      messenger.showSnackBar(
-        DivineSnackbarContainer.snackBar(
-          context.l10n.supportLogsSavedTo(filePath),
-          duration: const Duration(seconds: 8),
-          actionLabel: context.l10n.supportRevealLogsAction,
-          onActionPressed: () {
-            // DivineSnackbarContainer's action is a plain button, so unlike
-            // SnackBarAction it does not dismiss the banner for us.
-            messenger.hideCurrentSnackBar();
-            bugReportService.revealExportedFile(filePath);
-          },
-        ),
-      );
-    }
-  }
-
-  Future<void> _copyLogs(
-    BuildContext context,
-    BugReportService bugReportService,
-    String? userPubkey,
-  ) async {
-    if (_copyingLogs) return;
-    _copyingLogs = true;
-    ScaffoldMessenger.of(context).showSnackBar(
-      DivineSnackbarContainer.snackBar(
-        context.l10n.supportExportingLogs,
-        duration: const Duration(seconds: 2),
-      ),
-    );
-
-    try {
-      final result = await bugReportService.buildLogClipboardText(
-        currentScreen: 'SupportCenterScreen',
-        userPubkey: userPubkey,
-      );
-      if (!context.mounted) return;
-
-      final messenger = ScaffoldMessenger.of(context)..hideCurrentSnackBar();
-      switch (result.status) {
-        case LogClipboardStatus.noLogs:
-          messenger.showSnackBar(
-            DivineSnackbarContainer.snackBar(
-              context.l10n.supportNoLogsToExport,
-              duration: const Duration(seconds: 8),
-            ),
-          );
-          return;
-        case LogClipboardStatus.failed:
-          messenger.showSnackBar(
-            DivineSnackbarContainer.snackBar(
-              context.l10n.supportCopyLogsFailed,
-              error: true,
-            ),
-          );
-          return;
-        case LogClipboardStatus.success:
-          break;
-      }
-
-      // copyVerified reads the value back, so a clipboard blocked by a work
-      // profile or a device policy reports failure instead of looking fine.
-      final copied = await ClipboardUtils.copyVerified(
-        context,
-        result.text!,
-        message: context.l10n.supportLogsCopied,
-      );
-      if (!context.mounted || copied) return;
-
-      ScaffoldMessenger.of(context).showSnackBar(
-        DivineSnackbarContainer.snackBar(
-          context.l10n.supportCopyLogsFailed,
-          error: true,
-        ),
-      );
-    } finally {
-      _copyingLogs = false;
-    }
-  }
-
   Future<bool> _viewSupportMessages() async {
     // JWT refresh is handled internally by showTicketListScreen via _ensureFreshJwt
     return ZendeskSupportService.showTicketListScreen();
@@ -335,7 +166,7 @@ class _SupportCenterScreenState extends ConsumerState<SupportCenterScreen> {
     final l10n = context.l10n;
     var emailBody = l10n.supportContactSupportSubtitle;
     final openZendesk =
-        widget.openZendeskSupport ??
+        openZendeskSupport ??
         (ZendeskSupportService.isAvailable ? _viewSupportMessages : null);
     if (openZendesk != null) {
       if (await openZendesk()) return;
@@ -347,7 +178,7 @@ class _SupportCenterScreenState extends ConsumerState<SupportCenterScreen> {
 
     final sharePositionOrigin = shareAnchorForContext(context);
     try {
-      await (widget.composeEmail ?? SupportEmailComposer().compose)(
+      await (composeEmail ?? SupportEmailComposer().compose)(
         toEmail: AppConstants.supportEmail,
         subject: l10n.supportContactSupport,
         body: emailBody,

--- a/mobile/lib/services/bug_report_service.dart
+++ b/mobile/lib/services/bug_report_service.dart
@@ -26,6 +26,8 @@ import 'package:uuid/uuid.dart';
 
 /// Service for creating and managing bug reports
 class BugReportService {
+  static const _logExportShareSubject = 'Divine Full Logs';
+
   BugReportService({
     ErrorAnalyticsTracker? errorTracker,
     StorageManagementService? storageManagementService,
@@ -672,10 +674,7 @@ class BugReportService {
       // copy the attachment, so a label there pastes as a placeholder
       // that looks like a successful copy (#8112).
       final result = await showShareSheetAtOrigin(
-        ShareParams(
-          files: [XFile(filePath)],
-          subject: 'Divine Full Logs',
-        ),
+        buildLogExportShareParams(filePath),
         sharePositionOrigin: sharePositionOrigin,
       );
 
@@ -707,6 +706,12 @@ class BugReportService {
       return const LogExportResult.failed();
     }
   }
+
+  @visibleForTesting
+  static ShareParams buildLogExportShareParams(String filePath) => ShareParams(
+    files: [XFile(filePath)],
+    subject: _logExportShareSubject,
+  );
 
   // Private helper methods
 

--- a/mobile/lib/services/bug_report_service.dart
+++ b/mobile/lib/services/bug_report_service.dart
@@ -36,14 +36,6 @@ class BugReportService {
 
   static const _uuid = Uuid();
 
-  /// Byte ceiling for a clipboard copy of the logs.
-  ///
-  /// Android moves clipboard data across a Binder transaction whose ~1 MB
-  /// ceiling covers everything in flight, and Zendesk caps a ticket
-  /// description at 64K — so a copy someone can actually paste into a
-  /// support ticket is the smaller of the two constraints.
-  @visibleForTesting
-  static const int logClipboardByteBudget = 64 * 1024;
   final ErrorAnalyticsTracker _errorTracker;
   final StorageManagementService? _storageManagementService;
   final Future<PackageInfo> Function() _packageInfoLoader;
@@ -612,8 +604,8 @@ class BugReportService {
     }
   }
 
-  /// The diagnostic preamble both the exported file and the clipboard
-  /// copy start with, terminated by a blank line.
+  /// The diagnostic preamble the exported log file starts with,
+  /// terminated by a blank line.
   Future<String> _buildLogHeader({
     required Map<String, dynamic> stats,
     required int lineCount,
@@ -650,110 +642,6 @@ class BugReportService {
         .toString();
   }
 
-  /// Build the diagnostic header plus the most recent log lines that fit
-  /// under [logClipboardByteBudget], for copying to the clipboard.
-  ///
-  /// This exists because the share sheet cannot serve a copy on Android: its
-  /// "Copy" chip copies `Intent.EXTRA_TEXT`, never the attached file. A
-  /// separate path is the only way that gesture yields logs, and it has to
-  /// be capped — the full buffer runs to 5-10 MB and the clipboard crosses a
-  /// Binder transaction with roughly a 1 MB ceiling for everything in it.
-  Future<LogClipboardResult> buildLogClipboardText({
-    String? currentScreen,
-    String? userPubkey,
-  }) async {
-    try {
-      final allLogLines = await LogCaptureService().getAllLogsAsText();
-      if (allLogLines.isEmpty) return const LogClipboardResult.noLogs();
-
-      final stats = await LogCaptureService().getLogStatistics();
-      final header = await _buildLogHeader(
-        stats: stats,
-        lineCount: allLogLines.length,
-        currentScreen: currentScreen,
-        userPubkey: userPubkey,
-      );
-
-      // Walk backwards so the tail — the part nearest whatever just went
-      // wrong — is what survives the budget.
-      final sanitizedLines = allLogLines.map(_sanitizeString).toList();
-      final tail = <String>[];
-      final headerBytes = utf8.encode(header).length;
-      var tailBytes = 0;
-      for (final line in sanitizedLines.reversed) {
-        final lineBytes = utf8.encode(line).length + 1;
-        final omitted = sanitizedLines.length - tail.length - 1;
-        final markerBytes = utf8.encode(_omittedMarker(omitted)).length;
-        if (headerBytes + markerBytes + tailBytes + lineBytes >
-            logClipboardByteBudget) {
-          break;
-        }
-        tail.add(line);
-        tailBytes += lineBytes;
-      }
-
-      if (tail.isEmpty) {
-        final omitted = sanitizedLines.length - 1;
-        final marker = _omittedMarker(omitted);
-        final fixedText = '$header$marker';
-        final remaining =
-            logClipboardByteBudget - utf8.encode(fixedText).length;
-        final newest = truncateUtf8(sanitizedLines.last, remaining - 1);
-        final text = '$fixedText$newest\n';
-        return LogClipboardResult.success(
-          truncateUtf8(text, logClipboardByteBudget),
-        );
-      }
-
-      return LogClipboardResult.success(
-        _buildClipboardPayload(
-          header: header,
-          reversedTail: tail,
-          totalLineCount: sanitizedLines.length,
-        ),
-      );
-    } catch (e, stackTrace) {
-      Log.error(
-        'Failed to build clipboard log text: $e',
-        category: LogCategory.system,
-        error: e,
-        stackTrace: stackTrace,
-      );
-      return const LogClipboardResult.failed();
-    }
-  }
-
-  static String _buildClipboardPayload({
-    required String header,
-    required List<String> reversedTail,
-    required int totalLineCount,
-  }) {
-    final buffer = StringBuffer(header);
-    final omitted = totalLineCount - reversedTail.length;
-    if (omitted > 0) buffer.write(_omittedMarker(omitted));
-    reversedTail.reversed.forEach(buffer.writeln);
-    return buffer.toString();
-  }
-
-  static String _omittedMarker(int omitted) =>
-      omitted > 0 ? '... [$omitted earlier entries omitted]\n' : '';
-
-  @visibleForTesting
-  static String truncateUtf8(String value, int maxBytes) {
-    if (maxBytes <= 0) return '';
-    final bytes = utf8.encode(value);
-    if (bytes.length <= maxBytes) return value;
-    var end = maxBytes;
-    while (end > 0) {
-      try {
-        return utf8.decode(bytes.sublist(0, end));
-      } on FormatException {
-        end--;
-      }
-    }
-    return '';
-  }
-
   /// Export logs on mobile platforms using the system share sheet.
   Future<LogExportResult> _exportLogsNative(
     String content,
@@ -778,17 +666,15 @@ class BugReportService {
         category: LogCategory.system,
       );
 
-      // `text` stays short because it is the body every share target
-      // prefills — a log dump here would land in the email or message
-      // alongside the attachment. On Android it is also what the share
-      // sheet's own "Copy" chip copies, which copies EXTRA_TEXT and never
-      // the attachment, so that chip cannot deliver logs however it is
-      // worded. Copying is served by [buildLogClipboardText] instead.
+      // No `text`: share_plus only sets Intent.EXTRA_TEXT when it is
+      // non-blank, and EXTRA_TEXT is what Android's share-sheet "Copy"
+      // action copies. Any value here is a decoy — the chip can never
+      // copy the attachment, so a label there pastes as a placeholder
+      // that looks like a successful copy (#8112).
       final result = await showShareSheetAtOrigin(
         ShareParams(
           files: [XFile(filePath)],
-          subject: 'OpenVine Full Logs',
-          text: 'OpenVine Full Logs',
+          subject: 'Divine Full Logs',
         ),
         sharePositionOrigin: sharePositionOrigin,
       );
@@ -901,23 +787,6 @@ class BugReportService {
     }).toList();
   }
 }
-
-/// Result of preparing captured logs for the clipboard.
-class LogClipboardResult {
-  const LogClipboardResult._(this.status, {this.text});
-
-  const LogClipboardResult.success(String text)
-    : this._(LogClipboardStatus.success, text: text);
-
-  const LogClipboardResult.noLogs() : this._(LogClipboardStatus.noLogs);
-
-  const LogClipboardResult.failed() : this._(LogClipboardStatus.failed);
-
-  final LogClipboardStatus status;
-  final String? text;
-}
-
-enum LogClipboardStatus { success, noLogs, failed }
 
 /// Outcome of [BugReportService.exportLogsToFile].
 ///

--- a/mobile/lib/widgets/developer_options/export_logs_section.dart
+++ b/mobile/lib/widgets/developer_options/export_logs_section.dart
@@ -1,0 +1,110 @@
+// ABOUTME: Developer-options section for sharing the captured log file
+// ABOUTME: Developer tooling — users ship logs automatically via Report a Bug
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/services/bug_report_service.dart';
+import 'package:openvine/utils/share_position_origin.dart';
+
+/// Hands the captured log file to the system share sheet.
+class ExportLogsSection extends ConsumerWidget {
+  const ExportLogsSection({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return ListTile(
+      leading: DivineIcon(
+        icon: DivineIconName.save,
+        color: context.vineColors.accentPositive,
+      ),
+      title: Text(
+        context.l10n.devOptionsExportLogs,
+        style: VineTheme.titleMediumFont(
+          color: context.vineColors.primaryText,
+        ),
+      ),
+      subtitle: Text(
+        context.l10n.devOptionsExportLogsSubtitle,
+        style: VineTheme.bodyMediumFont(color: context.vineColors.mutedText),
+      ),
+      onTap: () => _exportLogs(context, ref),
+    );
+  }
+
+  Future<void> _exportLogs(BuildContext context, WidgetRef ref) async {
+    final bugReportService = ref.read(bugReportServiceProvider);
+    final userPubkey = ref.read(authServiceProvider).currentPublicKeyHex;
+
+    // Resolve the popover anchor before any await — iPad idiom (including
+    // iOS builds on Apple Silicon Macs) rejects the share sheet without it.
+    final sharePositionOrigin = shareAnchorForContext(context);
+    ScaffoldMessenger.of(context).showSnackBar(
+      DivineSnackbarContainer.snackBar(
+        context.l10n.supportExportingLogs,
+        duration: const Duration(seconds: 2),
+      ),
+    );
+
+    final result = await bugReportService.exportLogsToFile(
+      currentScreen: 'DeveloperOptionsScreen',
+      userPubkey: userPubkey,
+      sharePositionOrigin: sharePositionOrigin,
+    );
+    if (!context.mounted) return;
+
+    final messenger = ScaffoldMessenger.of(context)..hideCurrentSnackBar();
+
+    switch (result.status) {
+      case LogExportStatus.cancelled:
+        // User backed out of the share sheet or Save As dialog.
+        return;
+      case LogExportStatus.noLogs:
+        messenger.showSnackBar(
+          DivineSnackbarContainer.snackBar(
+            context.l10n.supportNoLogsToExport,
+            duration: const Duration(seconds: 8),
+          ),
+        );
+        return;
+      case LogExportStatus.unconfirmed:
+        messenger.showSnackBar(
+          DivineSnackbarContainer.snackBar(
+            context.l10n.supportExportLogsUnconfirmed,
+            duration: const Duration(seconds: 6),
+          ),
+        );
+        return;
+      case LogExportStatus.failed:
+        messenger.showSnackBar(
+          DivineSnackbarContainer.snackBar(
+            context.l10n.supportExportLogsFailed,
+            error: true,
+          ),
+        );
+        return;
+      case LogExportStatus.shared:
+      case LogExportStatus.saved:
+        break;
+    }
+
+    final filePath = result.filePath;
+    if (filePath != null) {
+      messenger.showSnackBar(
+        DivineSnackbarContainer.snackBar(
+          context.l10n.supportLogsSavedTo(filePath),
+          duration: const Duration(seconds: 8),
+          actionLabel: context.l10n.supportRevealLogsAction,
+          onActionPressed: () {
+            // DivineSnackbarContainer's action is a plain button, so unlike
+            // SnackBarAction it does not dismiss the banner for us.
+            messenger.hideCurrentSnackBar();
+            bugReportService.revealExportedFile(filePath);
+          },
+        ),
+      );
+    }
+  }
+}

--- a/mobile/lib/widgets/developer_options/export_logs_section.dart
+++ b/mobile/lib/widgets/developer_options/export_logs_section.dart
@@ -3,10 +3,11 @@
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:openvine/blocs/export_logs/export_logs_cubit.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
-import 'package:openvine/services/bug_report_service.dart';
 import 'package:openvine/utils/share_position_origin.dart';
 
 /// Hands the captured log file to the system share sheet.
@@ -15,6 +16,110 @@ class ExportLogsSection extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final bugReportService = ref.watch(bugReportServiceProvider);
+    final authService = ref.watch(authServiceProvider);
+    return BlocProvider<ExportLogsCubit>(
+      key: ValueKey((bugReportService, authService)),
+      create: (_) => ExportLogsCubit(
+        bugReportService: bugReportService,
+        currentScreen: 'DeveloperOptionsScreen',
+        userPubkey: authService.currentPublicKeyHex,
+      ),
+      child: const ExportLogsView(),
+    );
+  }
+}
+
+@visibleForTesting
+class ExportLogsView extends StatelessWidget {
+  @visibleForTesting
+  const ExportLogsView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocListener<ExportLogsCubit, ExportLogsState>(
+      listenWhen: (previous, current) => previous.status != current.status,
+      listener: _showOutcome,
+      child: const _ExportLogsTile(),
+    );
+  }
+
+  static void _showOutcome(BuildContext context, ExportLogsState state) {
+    final l10n = context.l10n;
+    final messenger = ScaffoldMessenger.of(context);
+
+    if (state.status == ExportLogsStatus.exporting) {
+      messenger.showSnackBar(
+        DivineSnackbarContainer.snackBar(
+          l10n.supportExportingLogs,
+          duration: const Duration(seconds: 2),
+        ),
+      );
+      return;
+    }
+
+    messenger.hideCurrentSnackBar();
+
+    switch (state.status) {
+      case ExportLogsStatus.idle:
+      case ExportLogsStatus.exporting:
+      case ExportLogsStatus.cancelled:
+        // Cancelled means the user backed out — they know what they did.
+        return;
+      case ExportLogsStatus.noLogs:
+        messenger.showSnackBar(
+          DivineSnackbarContainer.snackBar(
+            l10n.supportNoLogsToExport,
+            duration: const Duration(seconds: 8),
+          ),
+        );
+        return;
+      case ExportLogsStatus.unconfirmed:
+        messenger.showSnackBar(
+          DivineSnackbarContainer.snackBar(
+            l10n.supportExportLogsUnconfirmed,
+            duration: const Duration(seconds: 6),
+          ),
+        );
+        return;
+      case ExportLogsStatus.failed:
+        messenger.showSnackBar(
+          DivineSnackbarContainer.snackBar(
+            l10n.supportExportLogsFailed,
+            error: true,
+          ),
+        );
+        return;
+      case ExportLogsStatus.shared:
+      case ExportLogsStatus.saved:
+        break;
+    }
+
+    final filePath = state.filePath;
+    if (filePath == null) return;
+
+    final cubit = context.read<ExportLogsCubit>();
+    messenger.showSnackBar(
+      DivineSnackbarContainer.snackBar(
+        l10n.supportLogsSavedTo(filePath),
+        duration: const Duration(seconds: 8),
+        actionLabel: l10n.supportRevealLogsAction,
+        onActionPressed: () {
+          // DivineSnackbarContainer's action is a plain button, so unlike
+          // SnackBarAction it does not dismiss the banner for us.
+          messenger.hideCurrentSnackBar();
+          cubit.revealFile(filePath);
+        },
+      ),
+    );
+  }
+}
+
+class _ExportLogsTile extends StatelessWidget {
+  const _ExportLogsTile();
+
+  @override
+  Widget build(BuildContext context) {
     return ListTile(
       leading: DivineIcon(
         icon: DivineIconName.save,
@@ -22,89 +127,18 @@ class ExportLogsSection extends ConsumerWidget {
       ),
       title: Text(
         context.l10n.devOptionsExportLogs,
-        style: VineTheme.titleMediumFont(
-          color: context.vineColors.primaryText,
-        ),
+        style: VineTheme.titleMediumFont(color: context.vineColors.primaryText),
       ),
       subtitle: Text(
         context.l10n.devOptionsExportLogsSubtitle,
         style: VineTheme.bodyMediumFont(color: context.vineColors.mutedText),
       ),
-      onTap: () => _exportLogs(context, ref),
-    );
-  }
-
-  Future<void> _exportLogs(BuildContext context, WidgetRef ref) async {
-    final bugReportService = ref.read(bugReportServiceProvider);
-    final userPubkey = ref.read(authServiceProvider).currentPublicKeyHex;
-
-    // Resolve the popover anchor before any await — iPad idiom (including
-    // iOS builds on Apple Silicon Macs) rejects the share sheet without it.
-    final sharePositionOrigin = shareAnchorForContext(context);
-    ScaffoldMessenger.of(context).showSnackBar(
-      DivineSnackbarContainer.snackBar(
-        context.l10n.supportExportingLogs,
-        duration: const Duration(seconds: 2),
+      // Resolve the popover anchor before the cubit's first await — the iPad
+      // idiom (including iOS builds on Apple Silicon Macs) rejects the share
+      // sheet without it.
+      onTap: () => context.read<ExportLogsCubit>().export(
+        sharePositionOrigin: shareAnchorForContext(context),
       ),
     );
-
-    final result = await bugReportService.exportLogsToFile(
-      currentScreen: 'DeveloperOptionsScreen',
-      userPubkey: userPubkey,
-      sharePositionOrigin: sharePositionOrigin,
-    );
-    if (!context.mounted) return;
-
-    final messenger = ScaffoldMessenger.of(context)..hideCurrentSnackBar();
-
-    switch (result.status) {
-      case LogExportStatus.cancelled:
-        // User backed out of the share sheet or Save As dialog.
-        return;
-      case LogExportStatus.noLogs:
-        messenger.showSnackBar(
-          DivineSnackbarContainer.snackBar(
-            context.l10n.supportNoLogsToExport,
-            duration: const Duration(seconds: 8),
-          ),
-        );
-        return;
-      case LogExportStatus.unconfirmed:
-        messenger.showSnackBar(
-          DivineSnackbarContainer.snackBar(
-            context.l10n.supportExportLogsUnconfirmed,
-            duration: const Duration(seconds: 6),
-          ),
-        );
-        return;
-      case LogExportStatus.failed:
-        messenger.showSnackBar(
-          DivineSnackbarContainer.snackBar(
-            context.l10n.supportExportLogsFailed,
-            error: true,
-          ),
-        );
-        return;
-      case LogExportStatus.shared:
-      case LogExportStatus.saved:
-        break;
-    }
-
-    final filePath = result.filePath;
-    if (filePath != null) {
-      messenger.showSnackBar(
-        DivineSnackbarContainer.snackBar(
-          context.l10n.supportLogsSavedTo(filePath),
-          duration: const Duration(seconds: 8),
-          actionLabel: context.l10n.supportRevealLogsAction,
-          onActionPressed: () {
-            // DivineSnackbarContainer's action is a plain button, so unlike
-            // SnackBarAction it does not dismiss the banner for us.
-            messenger.hideCurrentSnackBar();
-            bugReportService.revealExportedFile(filePath);
-          },
-        ),
-      );
-    }
   }
 }

--- a/mobile/lib/widgets/developer_options/export_logs_section.dart
+++ b/mobile/lib/widgets/developer_options/export_logs_section.dart
@@ -18,8 +18,9 @@ class ExportLogsSection extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final bugReportService = ref.watch(bugReportServiceProvider);
     final authService = ref.watch(authServiceProvider);
+    final authState = ref.watch(currentAuthStateProvider);
     return BlocProvider<ExportLogsCubit>(
-      key: ValueKey((bugReportService, authService)),
+      key: ValueKey((bugReportService, authService, authState)),
       create: (_) => ExportLogsCubit(
         bugReportService: bugReportService,
         currentScreen: 'DeveloperOptionsScreen',

--- a/mobile/test/blocs/export_logs/export_logs_cubit_test.dart
+++ b/mobile/test/blocs/export_logs/export_logs_cubit_test.dart
@@ -1,0 +1,185 @@
+// ABOUTME: Tests the log-export cubit's status mapping and in-flight guard
+// ABOUTME: Four of the six export outcomes are not failures (#8113, #8114)
+
+import 'dart:async';
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/blocs/export_logs/export_logs_cubit.dart';
+import 'package:openvine/services/bug_report_service.dart';
+
+class _MockBugReportService extends Mock implements BugReportService {}
+
+const _pubkeyHex =
+    '3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d';
+
+void main() {
+  group(ExportLogsCubit, () {
+    late _MockBugReportService bugReportService;
+
+    setUp(() {
+      bugReportService = _MockBugReportService();
+    });
+
+    ExportLogsCubit build() => ExportLogsCubit(
+      bugReportService: bugReportService,
+      currentScreen: 'DeveloperOptionsScreen',
+      userPubkey: _pubkeyHex,
+    );
+
+    void stubExport(LogExportResult result) {
+      when(
+        () => bugReportService.exportLogsToFile(
+          currentScreen: any(named: 'currentScreen'),
+          userPubkey: any(named: 'userPubkey'),
+          sharePositionOrigin: any(named: 'sharePositionOrigin'),
+        ),
+      ).thenAnswer((_) async => result);
+    }
+
+    group('export', () {
+      blocTest<ExportLogsCubit, ExportLogsState>(
+        'passes the screen and pubkey through to the service',
+        setUp: () => stubExport(const LogExportResult.shared()),
+        build: build,
+        act: (cubit) => cubit.export(),
+        verify: (_) {
+          verify(
+            () => bugReportService.exportLogsToFile(
+              currentScreen: 'DeveloperOptionsScreen',
+              userPubkey: _pubkeyHex,
+              sharePositionOrigin: any(named: 'sharePositionOrigin'),
+            ),
+          ).called(1);
+        },
+      );
+
+      // #8113: share_plus reports `unavailable` whenever it cannot attach to
+      // an Activity, even though the sheet opened. Mapping that to failure is
+      // what told the user log export was broken.
+      blocTest<ExportLogsCubit, ExportLogsState>(
+        'maps an unknown outcome to unconfirmed, not failed',
+        setUp: () => stubExport(const LogExportResult.unconfirmed()),
+        build: build,
+        act: (cubit) => cubit.export(),
+        expect: () => const [
+          ExportLogsState(status: ExportLogsStatus.exporting),
+          ExportLogsState(status: ExportLogsStatus.unconfirmed),
+        ],
+      );
+
+      // #8114: the capture buffer is memory-only, so a crash empties it.
+      blocTest<ExportLogsCubit, ExportLogsState>(
+        'maps an empty buffer to noLogs, not failed',
+        setUp: () => stubExport(const LogExportResult.noLogs()),
+        build: build,
+        act: (cubit) => cubit.export(),
+        expect: () => const [
+          ExportLogsState(status: ExportLogsStatus.exporting),
+          ExportLogsState(status: ExportLogsStatus.noLogs),
+        ],
+      );
+
+      blocTest<ExportLogsCubit, ExportLogsState>(
+        'maps a dismissed sheet to cancelled',
+        setUp: () => stubExport(const LogExportResult.cancelled()),
+        build: build,
+        act: (cubit) => cubit.export(),
+        expect: () => const [
+          ExportLogsState(status: ExportLogsStatus.exporting),
+          ExportLogsState(status: ExportLogsStatus.cancelled),
+        ],
+      );
+
+      blocTest<ExportLogsCubit, ExportLogsState>(
+        'maps a real failure to failed',
+        setUp: () => stubExport(const LogExportResult.failed()),
+        build: build,
+        act: (cubit) => cubit.export(),
+        expect: () => const [
+          ExportLogsState(status: ExportLogsStatus.exporting),
+          ExportLogsState(status: ExportLogsStatus.failed),
+        ],
+      );
+
+      blocTest<ExportLogsCubit, ExportLogsState>(
+        'carries the saved path so the UI can offer to reveal it',
+        setUp: () => stubExport(const LogExportResult.saved('/tmp/logs.txt')),
+        build: build,
+        act: (cubit) => cubit.export(),
+        expect: () => const [
+          ExportLogsState(status: ExportLogsStatus.exporting),
+          ExportLogsState(
+            status: ExportLogsStatus.saved,
+            filePath: '/tmp/logs.txt',
+          ),
+        ],
+      );
+
+      blocTest<ExportLogsCubit, ExportLogsState>(
+        'ignores a second export while one is in flight',
+        setUp: () {
+          when(
+            () => bugReportService.exportLogsToFile(
+              currentScreen: any(named: 'currentScreen'),
+              userPubkey: any(named: 'userPubkey'),
+              sharePositionOrigin: any(named: 'sharePositionOrigin'),
+            ),
+          ).thenAnswer((_) => Completer<LogExportResult>().future);
+        },
+        build: build,
+        act: (cubit) {
+          unawaited(cubit.export());
+          unawaited(cubit.export());
+        },
+        expect: () => const [
+          ExportLogsState(status: ExportLogsStatus.exporting),
+        ],
+        verify: (_) {
+          verify(
+            () => bugReportService.exportLogsToFile(
+              currentScreen: any(named: 'currentScreen'),
+              userPubkey: any(named: 'userPubkey'),
+              sharePositionOrigin: any(named: 'sharePositionOrigin'),
+            ),
+          ).called(1);
+        },
+      );
+
+      // close() does not cancel an in-flight export; the resumed emit would
+      // throw without the guard (#7370).
+      test('drops the outcome when closed mid-export', () async {
+        final gate = Completer<LogExportResult>();
+        when(
+          () => bugReportService.exportLogsToFile(
+            currentScreen: any(named: 'currentScreen'),
+            userPubkey: any(named: 'userPubkey'),
+            sharePositionOrigin: any(named: 'sharePositionOrigin'),
+          ),
+        ).thenAnswer((_) => gate.future);
+
+        final cubit = build();
+        final pending = cubit.export();
+        await cubit.close();
+        gate.complete(const LogExportResult.shared());
+
+        await expectLater(pending, completes);
+      });
+    });
+
+    group('revealFile', () {
+      test('asks the service to open the containing folder', () async {
+        when(
+          () => bugReportService.revealExportedFile(any()),
+        ).thenAnswer((_) async {});
+
+        await build().revealFile('/tmp/logs.txt');
+
+        verify(
+          () => bugReportService.revealExportedFile('/tmp/logs.txt'),
+        ).called(1);
+      });
+    });
+  });
+}

--- a/mobile/test/blocs/export_logs/export_logs_cubit_test.dart
+++ b/mobile/test/blocs/export_logs/export_logs_cubit_test.dart
@@ -55,6 +55,20 @@ void main() {
         },
       );
 
+      // The mobile happy path: another app confirmed it took the file. It
+      // carries no path (unlike a desktop save) and the UI stays silent, so
+      // nothing else guards this mapping against a mis-wire to failure.
+      blocTest<ExportLogsCubit, ExportLogsState>(
+        'maps a confirmed share to shared',
+        setUp: () => stubExport(const LogExportResult.shared()),
+        build: build,
+        act: (cubit) => cubit.export(),
+        expect: () => const [
+          ExportLogsState(status: ExportLogsStatus.exporting),
+          ExportLogsState(status: ExportLogsStatus.shared),
+        ],
+      );
+
       // #8113: share_plus reports `unavailable` whenever it cannot attach to
       // an Activity, even though the sheet opened. Mapping that to failure is
       // what told the user log export was broken.

--- a/mobile/test/l10n/arb_consistency_test.dart
+++ b/mobile/test/l10n/arb_consistency_test.dart
@@ -484,13 +484,12 @@ void main() {
 // Keys intentionally allowed to fall back to English until a translation pass.
 // Keep this list small and reviewable so new translation gaps stay visible.
 const _knownUntranslatedDebt = <String>{
-  // Support Center log copy (#8112 / #8113 / #8114). Left in English until a
+  // Log-export copy (#8112 / #8113 / #8114 / #8127). Left in English until a
   // human translation pass; machine-translating a diagnostic instruction the
-  // user has to follow exactly is how it stops meaning what it says.
-  'supportCopyLogs',
-  'supportCopyLogsSubtitle',
-  'supportLogsCopied',
-  'supportCopyLogsFailed',
+  // user has to follow exactly is how it stops meaning what it says. The
+  // devOptions pair is developer-only surface behind the seven-tap unlock.
+  'devOptionsExportLogs',
+  'devOptionsExportLogsSubtitle',
   'supportNoLogsToExport',
   'supportExportLogsUnconfirmed',
   // Account-enforcement translation remains tracked in #7765. The policy copy

--- a/mobile/test/screens/developer_options_screen_test.dart
+++ b/mobile/test/screens/developer_options_screen_test.dart
@@ -120,6 +120,32 @@ void main() {
       },
     );
 
+    // #8127 moved log export here from Support Center, which regular users
+    // see. It belongs between the environment picker and Shorebird patches.
+    testWidgets('places Export Logs between environments and Shorebird', (
+      tester,
+    ) async {
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      await pumpScreen(tester, await mockPrefs());
+
+      expect(find.text(l10n.devOptionsExportLogs), findsOneWidget);
+
+      final production = tester.getTopLeft(find.text('Production')).dy;
+      final exportLogs = tester
+          .getTopLeft(
+            find.text(l10n.devOptionsExportLogs),
+          )
+          .dy;
+      final shorebird = tester
+          .getTopLeft(
+            find.text(l10n.devOptionsShorebirdTitle),
+          )
+          .dy;
+
+      expect(exportLogs, greaterThan(production));
+      expect(exportLogs, lessThan(shorebird));
+    });
+
     testWidgets(
       'DeveloperOptionsScreen constrains menu content width on wide screens',
       (tester) async {

--- a/mobile/test/screens/settings/support_center_screen_test.dart
+++ b/mobile/test/screens/settings/support_center_screen_test.dart
@@ -1,10 +1,7 @@
 // ABOUTME: Tests the Support Center resource links and account-deletion auth gate
 // ABOUTME: Regression cover for #6335, which was reported from this screen
 
-import 'dart:async';
-
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -14,7 +11,6 @@ import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/screens/settings/support_center_screen.dart';
 import 'package:openvine/services/account_deletion_service.dart';
 import 'package:openvine/services/auth_service.dart';
-import 'package:openvine/services/bug_report_service.dart';
 import 'package:openvine/services/support_email_composer.dart';
 import 'package:openvine/services/zendesk_support_service.dart';
 import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
@@ -22,8 +18,6 @@ import 'package:url_launcher_platform_interface/url_launcher_platform_interface.
 import '../../helpers/url_launcher_test_double.dart';
 
 class _MockAuthService extends Mock implements AuthService {}
-
-class _MockBugReportService extends Mock implements BugReportService {}
 
 class _MockAccountDeletionService extends Mock
     implements AccountDeletionService {}
@@ -34,14 +28,12 @@ const _pubkeyHex =
 void main() {
   group(SupportCenterScreen, () {
     late _MockAuthService authService;
-    late _MockBugReportService bugReportService;
     late _MockAccountDeletionService accountDeletionService;
     final en = lookupAppLocalizations(const Locale('en'));
 
     setUp(() {
       ZendeskSupportService.resetForTesting();
       authService = _MockAuthService();
-      bugReportService = _MockBugReportService();
       accountDeletionService = _MockAccountDeletionService();
       when(() => authService.currentPublicKeyHex).thenReturn(_pubkeyHex);
     });
@@ -60,7 +52,6 @@ void main() {
           overrides: [
             authServiceProvider.overrideWithValue(authService),
             currentAuthStateProvider.overrideWith((ref) => authState),
-            bugReportServiceProvider.overrideWithValue(bugReportService),
             accountDeletionServiceProvider.overrideWithValue(
               accountDeletionService,
             ),
@@ -94,202 +85,6 @@ void main() {
 
     // #6335 was filed from this screen by a user who could not find how to
     // delete their account. Deletion has to be reachable from here.
-    // #8112: the share sheet's Copy action copies EXTRA_TEXT on Android and
-    // never the attached file, so copying needs its own path. These pin the
-    // outcomes a user actually sees.
-    group('copy logs', () {
-      testWidgets('puts the built log text on the clipboard', (tester) async {
-        const logText = 'OpenVine Comprehensive Log Export\nupload stalled';
-        when(
-          () => bugReportService.buildLogClipboardText(
-            currentScreen: any(named: 'currentScreen'),
-            userPubkey: any(named: 'userPubkey'),
-          ),
-        ).thenAnswer((_) async => const LogClipboardResult.success(logText));
-
-        final clipboardWrites = <String>[];
-        tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
-          SystemChannels.platform,
-          (call) async {
-            if (call.method == 'Clipboard.setData') {
-              clipboardWrites.add((call.arguments as Map)['text'] as String);
-            }
-            if (call.method == 'Clipboard.getData') {
-              return <String, dynamic>{'text': clipboardWrites.last};
-            }
-            return null;
-          },
-        );
-        addTearDown(
-          () => tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
-            SystemChannels.platform,
-            null,
-          ),
-        );
-
-        await pump(tester);
-        await tester.tap(find.text(en.supportCopyLogs));
-        await tester.pumpAndSettle();
-
-        expect(clipboardWrites, equals([logText]));
-        expect(find.text(en.supportLogsCopied), findsOneWidget);
-      });
-
-      // #8114: an empty buffer is the user's to fix by reproducing without
-      // restarting, so it must not read as a generic failure.
-      testWidgets('explains an empty buffer instead of reporting failure', (
-        tester,
-      ) async {
-        when(
-          () => bugReportService.buildLogClipboardText(
-            currentScreen: any(named: 'currentScreen'),
-            userPubkey: any(named: 'userPubkey'),
-          ),
-        ).thenAnswer((_) async => const LogClipboardResult.noLogs());
-
-        await pump(tester);
-        await tester.tap(find.text(en.supportCopyLogs));
-        await tester.pumpAndSettle();
-
-        expect(find.text(en.supportNoLogsToExport), findsOneWidget);
-        expect(find.text(en.supportCopyLogsFailed), findsNothing);
-      });
-
-      testWidgets('reports a diagnostic build failure', (tester) async {
-        when(
-          () => bugReportService.buildLogClipboardText(
-            currentScreen: any(named: 'currentScreen'),
-            userPubkey: any(named: 'userPubkey'),
-          ),
-        ).thenAnswer((_) async => const LogClipboardResult.failed());
-
-        await pump(tester);
-        await tester.tap(find.text(en.supportCopyLogs));
-        await tester.pumpAndSettle();
-
-        expect(find.text(en.supportCopyLogsFailed), findsOneWidget);
-        expect(find.text(en.supportNoLogsToExport), findsNothing);
-      });
-
-      testWidgets('reports when the clipboard refuses the logs', (
-        tester,
-      ) async {
-        const logText = 'OpenVine Comprehensive Log Export\nupload stalled';
-        when(
-          () => bugReportService.buildLogClipboardText(
-            currentScreen: any(named: 'currentScreen'),
-            userPubkey: any(named: 'userPubkey'),
-          ),
-        ).thenAnswer((_) async => const LogClipboardResult.success(logText));
-        tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
-          SystemChannels.platform,
-          (call) async {
-            if (call.method == 'Clipboard.getData') {
-              return <String, dynamic>{'text': 'device policy blocked this'};
-            }
-            return null;
-          },
-        );
-        addTearDown(
-          () => tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
-            SystemChannels.platform,
-            null,
-          ),
-        );
-
-        await pump(tester);
-        await tester.tap(find.text(en.supportCopyLogs));
-        await tester.pumpAndSettle();
-
-        expect(find.text(en.supportCopyLogsFailed), findsOneWidget);
-        expect(find.text(en.supportLogsCopied), findsNothing);
-      });
-
-      testWidgets('shows progress and ignores a second tap while building', (
-        tester,
-      ) async {
-        final result = Completer<LogClipboardResult>();
-        when(
-          () => bugReportService.buildLogClipboardText(
-            currentScreen: any(named: 'currentScreen'),
-            userPubkey: any(named: 'userPubkey'),
-          ),
-        ).thenAnswer((_) => result.future);
-
-        await pump(tester);
-        await tester.tap(find.text(en.supportCopyLogs));
-        await tester.pump();
-        await tester.tap(find.text(en.supportCopyLogs));
-        await tester.pump();
-
-        expect(find.text(en.supportExportingLogs), findsOneWidget);
-        verify(
-          () => bugReportService.buildLogClipboardText(
-            currentScreen: 'SupportCenterScreen',
-            userPubkey: _pubkeyHex,
-          ),
-        ).called(1);
-
-        result.complete(const LogClipboardResult.noLogs());
-        await tester.pumpAndSettle();
-      });
-    });
-
-    group('save logs', () {
-      Future<void> tapSaveLogs(
-        WidgetTester tester,
-        LogExportResult result,
-      ) async {
-        when(
-          () => bugReportService.exportLogsToFile(
-            currentScreen: any(named: 'currentScreen'),
-            userPubkey: any(named: 'userPubkey'),
-            sharePositionOrigin: any(named: 'sharePositionOrigin'),
-          ),
-        ).thenAnswer((_) async => result);
-
-        await pump(tester);
-        await tester.tap(find.text(en.supportSaveLogs));
-        await tester.pumpAndSettle();
-      }
-
-      // #8113: share_plus returns `unavailable` on Android whenever it cannot
-      // attach to an Activity, even though the sheet opened and the share may
-      // well have completed. Reporting that as a failure is what told the
-      // user log export was broken.
-      testWidgets('does not report failure when the outcome is unknown', (
-        tester,
-      ) async {
-        await tapSaveLogs(tester, const LogExportResult.unconfirmed());
-
-        expect(find.text(en.supportExportLogsFailed), findsNothing);
-        expect(find.text(en.supportExportLogsUnconfirmed), findsOneWidget);
-      });
-
-      testWidgets('stays silent when the user backs out', (tester) async {
-        await tapSaveLogs(tester, const LogExportResult.cancelled());
-
-        expect(find.text(en.supportExportLogsFailed), findsNothing);
-        expect(find.text(en.supportExportLogsUnconfirmed), findsNothing);
-        expect(find.text(en.supportNoLogsToExport), findsNothing);
-      });
-
-      testWidgets('explains an empty buffer rather than failing', (
-        tester,
-      ) async {
-        await tapSaveLogs(tester, const LogExportResult.noLogs());
-
-        expect(find.text(en.supportNoLogsToExport), findsOneWidget);
-        expect(find.text(en.supportExportLogsFailed), findsNothing);
-      });
-
-      testWidgets('still reports a real failure', (tester) async {
-        await tapSaveLogs(tester, const LogExportResult.failed());
-
-        expect(find.text(en.supportExportLogsFailed), findsOneWidget);
-      });
-    });
-
     testWidgets('shows the delete-account entry when authenticated', (
       tester,
     ) async {

--- a/mobile/test/services/bug_report_log_export_test.dart
+++ b/mobile/test/services/bug_report_log_export_test.dart
@@ -3,29 +3,17 @@
 // ABOUTME: depends on the device's Downloads directory and LogCaptureService
 // ABOUTME: file IO that is awkward to mock in pure unit tests.
 
-import 'dart:convert';
-
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:models/models.dart' show LogEntry, LogLevel;
 import 'package:openvine/services/bug_report_service.dart';
 import 'package:openvine/services/storage_management_service.dart';
 import 'package:openvine/utils/app_uptime.dart';
 import 'package:openvine/utils/device_memory_util.dart';
-import 'package:package_info_plus/package_info_plus.dart';
-import 'package:unified_logger/unified_logger.dart' show LogCaptureService;
 
 class _MockStorageManagementService extends Mock
     implements StorageManagementService {}
-
-Future<PackageInfo> _loadPackageInfo() async => PackageInfo(
-  appName: 'Divine',
-  packageName: 'video.divine',
-  version: '1.0.21',
-  buildNumber: '849',
-);
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -71,215 +59,6 @@ void main() {
       expect(failed.status, equals(LogExportStatus.failed));
       expect(noLogs.status, isNot(equals(failed.status)));
     });
-  });
-
-  group('buildLogClipboardText', () {
-    setUp(() async {
-      await LogCaptureService().clearAllLogs();
-    });
-
-    tearDown(() async {
-      await LogCaptureService().clearAllLogs();
-      AppUptime.reset();
-      DeviceMemoryUtil.resetCache();
-    });
-
-    // #8114: an empty buffer has to be reportable as "nothing captured"
-    // rather than handed over as a bare header the user would paste into a
-    // ticket believing it held their logs.
-    test('reports no logs when nothing has been captured', () async {
-      final result = await BugReportService(
-        packageInfoLoader: _loadPackageInfo,
-      ).buildLogClipboardText();
-
-      expect(result.status, equals(LogClipboardStatus.noLogs));
-      expect(result.text, isNull);
-    });
-
-    test('includes the header and the captured line', () async {
-      LogCaptureService().captureLog(
-        LogEntry(
-          timestamp: DateTime(2026, 8, 24),
-          level: LogLevel.error,
-          message: 'upload stalled at 40 percent',
-        ),
-      );
-
-      final result = await BugReportService(
-        packageInfoLoader: _loadPackageInfo,
-      ).buildLogClipboardText();
-
-      expect(result.status, equals(LogClipboardStatus.success));
-      expect(result.text, contains('OpenVine Comprehensive Log Export'));
-      expect(result.text, contains('App Version: 1.0.21+849'));
-      expect(result.text, contains('upload stalled at 40 percent'));
-    });
-
-    // #8112: the clipboard crosses a Binder transaction, so an uncapped
-    // copy of a full 5-10 MB buffer is the one outcome that cannot work.
-    test('caps the copy and keeps the newest entries', () async {
-      final filler = 'x' * 512;
-      for (var i = 0; i < 400; i++) {
-        LogCaptureService().captureLog(
-          LogEntry(
-            timestamp: DateTime(2026, 8, 24).add(Duration(seconds: i)),
-            level: LogLevel.info,
-            message: 'entry $i $filler',
-          ),
-        );
-      }
-
-      final result = await BugReportService(
-        packageInfoLoader: _loadPackageInfo,
-      ).buildLogClipboardText();
-      final text = result.text!;
-
-      expect(
-        utf8.encode(text).length,
-        lessThanOrEqualTo(BugReportService.logClipboardByteBudget),
-      );
-      expect(text, contains('entry 399'));
-      expect(text, contains('earlier entries omitted'));
-      expect(text, isNot(contains('entry 0 ')));
-    });
-
-    test('includes the omission marker within the byte ceiling', () async {
-      for (var i = 0; i < 200; i++) {
-        LogCaptureService().captureLog(
-          LogEntry(
-            timestamp: DateTime(2026, 8, 24).add(Duration(seconds: i)),
-            level: LogLevel.info,
-            message: 'entry $i ${'x' * 1024}',
-          ),
-        );
-      }
-
-      final result = await BugReportService(
-        packageInfoLoader: _loadPackageInfo,
-      ).buildLogClipboardText();
-
-      expect(result.status, equals(LogClipboardStatus.success));
-      expect(
-        utf8.encode(result.text!).length,
-        lessThanOrEqualTo(BugReportService.logClipboardByteBudget),
-      );
-      expect(result.text, contains('earlier entries omitted'));
-    });
-
-    test(
-      'keeps useful content when the newest line exceeds the budget',
-      () async {
-        LogCaptureService().captureLog(
-          LogEntry(
-            timestamp: DateTime(2026, 8, 24),
-            level: LogLevel.error,
-            message:
-                'newest failure ${'z' * BugReportService.logClipboardByteBudget}',
-          ),
-        );
-
-        final result = await BugReportService(
-          packageInfoLoader: _loadPackageInfo,
-        ).buildLogClipboardText();
-
-        expect(result.status, equals(LogClipboardStatus.success));
-        expect(result.text, contains('newest failure'));
-        // An ASCII cut never backs off, so the copy fills the ceiling exactly.
-        // A bound alone would leave a shrunken newest-line budget green.
-        expect(
-          utf8.encode(result.text!).length,
-          equals(BugReportService.logClipboardByteBudget),
-        );
-      },
-    );
-
-    // Exercise the clipboard assembly with non-ASCII content. Exact byte
-    // boundary behavior is covered deterministically below.
-    test(
-      'keeps multi-byte content within the clipboard byte ceiling',
-      () async {
-        const emoji = '\u{1F3AC}';
-        final emojiBytes = utf8.encode(emoji).length;
-        final reps =
-            BugReportService.logClipboardByteBudget ~/ emojiBytes + 500;
-        LogCaptureService().captureLog(
-          LogEntry(
-            timestamp: DateTime(2026, 8, 24),
-            level: LogLevel.error,
-            message: 'newest failure ${emoji * reps}',
-          ),
-        );
-
-        final result = await BugReportService(
-          packageInfoLoader: _loadPackageInfo,
-        ).buildLogClipboardText();
-
-        expect(result.status, equals(LogClipboardStatus.success));
-        expect(result.text, contains('newest failure'));
-        // The back-off costs at most a partial character, so the copy stays at
-        // the ceiling instead of collapsing toward it. Deriving the slack from
-        // the character keeps the bound tight if this test ever swaps it.
-        expect(
-          utf8.encode(result.text!).length,
-          inInclusiveRange(
-            BugReportService.logClipboardByteBudget - (emojiBytes - 1),
-            BugReportService.logClipboardByteBudget,
-          ),
-        );
-      },
-    );
-
-    for (final (label, unit) in const [
-      ('4-byte emoji', '\u{1F3AC}'),
-      ('3-byte CJK', '\u65E5'),
-      ('2-byte accent', '\u00E9'),
-    ]) {
-      test('backs off every incomplete $label sequence', () {
-        const prefix = 'ASCII prefix ';
-        const suffix = ' trailing text';
-        final value = '$prefix$unit$suffix';
-        final prefixBytes = utf8.encode(prefix).length;
-        final unitBytes = utf8.encode(unit).length;
-
-        for (
-          var includedBytes = 1;
-          includedBytes < unitBytes;
-          includedBytes++
-        ) {
-          expect(
-            BugReportService.truncateUtf8(value, prefixBytes + includedBytes),
-            equals(prefix),
-            reason: 'included $includedBytes of $unitBytes bytes',
-          );
-        }
-
-        expect(
-          BugReportService.truncateUtf8(value, prefixBytes + unitBytes),
-          equals('$prefix$unit'),
-        );
-      });
-    }
-
-    test(
-      'reports a header diagnostic failure separately from no logs',
-      () async {
-        LogCaptureService().captureLog(
-          LogEntry(
-            timestamp: DateTime(2026, 8, 24),
-            level: LogLevel.error,
-            message: 'captured before diagnostics failed',
-          ),
-        );
-
-        final result = await BugReportService(
-          packageInfoLoader: () async =>
-              throw StateError('diagnostics unavailable'),
-        ).buildLogClipboardText();
-
-        expect(result.status, equals(LogClipboardStatus.failed));
-        expect(result.text, isNull);
-      },
-    );
   });
 
   group('buildDeviceDescription', () {

--- a/mobile/test/services/bug_report_log_export_test.dart
+++ b/mobile/test/services/bug_report_log_export_test.dart
@@ -61,6 +61,14 @@ void main() {
     });
   });
 
+  test('native log share params carry the file without a text extra', () {
+    final params = BugReportService.buildLogExportShareParams('/tmp/logs.txt');
+
+    expect(params.files!.single.path, '/tmp/logs.txt');
+    expect(params.subject, 'Divine Full Logs');
+    expect(params.text, isNull);
+  });
+
   group('buildDeviceDescription', () {
     const channel = MethodChannel('dev.fluttercommunity.plus/device_info');
     final messenger =

--- a/mobile/test/services/bug_report_log_export_test.dart
+++ b/mobile/test/services/bug_report_log_export_test.dart
@@ -61,12 +61,16 @@ void main() {
     });
   });
 
-  test('native log share params carry the file without a text extra', () {
-    final params = BugReportService.buildLogExportShareParams('/tmp/logs.txt');
+  group('buildLogExportShareParams', () {
+    test('carries the file without a text extra', () {
+      final params = BugReportService.buildLogExportShareParams(
+        '/tmp/logs.txt',
+      );
 
-    expect(params.files!.single.path, '/tmp/logs.txt');
-    expect(params.subject, 'Divine Full Logs');
-    expect(params.text, isNull);
+      expect(params.files!.single.path, '/tmp/logs.txt');
+      expect(params.subject, 'Divine Full Logs');
+      expect(params.text, isNull);
+    });
   });
 
   group('buildDeviceDescription', () {

--- a/mobile/test/widgets/developer_options/export_logs_section_test.dart
+++ b/mobile/test/widgets/developer_options/export_logs_section_test.dart
@@ -4,7 +4,6 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
@@ -12,6 +11,8 @@ import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/bug_report_service.dart';
 import 'package:openvine/widgets/developer_options/export_logs_section.dart';
+
+import '../../helpers/test_provider_overrides.dart';
 
 class _MockAuthService extends Mock implements AuthService {}
 
@@ -34,17 +35,14 @@ void main() {
 
     Future<void> pump(WidgetTester tester) async {
       await tester.pumpWidget(
-        ProviderScope(
-          overrides: [
+        testMaterialApp(
+          additionalOverrides: [
             authServiceProvider.overrideWithValue(authService),
             bugReportServiceProvider.overrideWithValue(bugReportService),
+            currentAuthStateProvider.overrideWithValue(AuthState.authenticated),
           ],
-          child: MaterialApp(
-            localizationsDelegates: AppLocalizations.localizationsDelegates,
-            supportedLocales: AppLocalizations.supportedLocales,
-            home: Scaffold(
-              body: ListView(children: const [ExportLogsSection()]),
-            ),
+          home: Scaffold(
+            body: ListView(children: const [ExportLogsSection()]),
           ),
         ),
       );

--- a/mobile/test/widgets/developer_options/export_logs_section_test.dart
+++ b/mobile/test/widgets/developer_options/export_logs_section_test.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Tests the developer-options Export Logs row and its outcome copy
 // ABOUTME: Regression cover for #8113 and #8114, moved here from #8127
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -85,6 +87,38 @@ void main() {
           () => bugReportService.exportLogsToFile(
             currentScreen: 'DeveloperOptionsScreen',
             userPubkey: _pubkeyHex,
+            sharePositionOrigin: any(named: 'sharePositionOrigin'),
+          ),
+        ).called(1);
+      });
+
+      testWidgets('ignores a second tap while an export is in flight', (
+        tester,
+      ) async {
+        final gate = Completer<LogExportResult>();
+        when(
+          () => bugReportService.exportLogsToFile(
+            currentScreen: any(named: 'currentScreen'),
+            userPubkey: any(named: 'userPubkey'),
+            sharePositionOrigin: any(named: 'sharePositionOrigin'),
+          ),
+        ).thenAnswer((_) => gate.future);
+
+        await pump(tester);
+        await tester.tap(find.text(en.devOptionsExportLogs));
+        await tester.pump();
+        await tester.tap(find.text(en.devOptionsExportLogs));
+        await tester.pump();
+
+        expect(find.text(en.supportExportingLogs), findsOneWidget);
+
+        gate.complete(const LogExportResult.shared());
+        await tester.pumpAndSettle();
+
+        verify(
+          () => bugReportService.exportLogsToFile(
+            currentScreen: any(named: 'currentScreen'),
+            userPubkey: any(named: 'userPubkey'),
             sharePositionOrigin: any(named: 'sharePositionOrigin'),
           ),
         ).called(1);

--- a/mobile/test/widgets/developer_options/export_logs_section_test.dart
+++ b/mobile/test/widgets/developer_options/export_logs_section_test.dart
@@ -1,0 +1,156 @@
+// ABOUTME: Tests the developer-options Export Logs row and its outcome copy
+// ABOUTME: Regression cover for #8113 and #8114, moved here from #8127
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/bug_report_service.dart';
+import 'package:openvine/widgets/developer_options/export_logs_section.dart';
+
+class _MockAuthService extends Mock implements AuthService {}
+
+class _MockBugReportService extends Mock implements BugReportService {}
+
+const _pubkeyHex =
+    '3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d';
+
+void main() {
+  group(ExportLogsSection, () {
+    late _MockAuthService authService;
+    late _MockBugReportService bugReportService;
+    final en = lookupAppLocalizations(const Locale('en'));
+
+    setUp(() {
+      authService = _MockAuthService();
+      bugReportService = _MockBugReportService();
+      when(() => authService.currentPublicKeyHex).thenReturn(_pubkeyHex);
+    });
+
+    Future<void> pump(WidgetTester tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            authServiceProvider.overrideWithValue(authService),
+            bugReportServiceProvider.overrideWithValue(bugReportService),
+          ],
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: ListView(children: const [ExportLogsSection()]),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+    }
+
+    Future<void> tapExportLogs(
+      WidgetTester tester,
+      LogExportResult result,
+    ) async {
+      when(
+        () => bugReportService.exportLogsToFile(
+          currentScreen: any(named: 'currentScreen'),
+          userPubkey: any(named: 'userPubkey'),
+          sharePositionOrigin: any(named: 'sharePositionOrigin'),
+        ),
+      ).thenAnswer((_) async => result);
+
+      await pump(tester);
+      await tester.tap(find.text(en.devOptionsExportLogs));
+      await tester.pumpAndSettle();
+    }
+
+    group('renders', () {
+      testWidgets('reads its title and subtitle from l10n', (tester) async {
+        await pump(tester);
+
+        expect(find.text(en.devOptionsExportLogs), findsOneWidget);
+        expect(find.text(en.devOptionsExportLogsSubtitle), findsOneWidget);
+      });
+    });
+
+    group('interactions', () {
+      testWidgets('exports with the signed-in pubkey and this screen', (
+        tester,
+      ) async {
+        await tapExportLogs(tester, const LogExportResult.shared());
+
+        verify(
+          () => bugReportService.exportLogsToFile(
+            currentScreen: 'DeveloperOptionsScreen',
+            userPubkey: _pubkeyHex,
+            sharePositionOrigin: any(named: 'sharePositionOrigin'),
+          ),
+        ).called(1);
+      });
+
+      // #8113: share_plus returns `unavailable` on Android whenever it cannot
+      // attach to an Activity, even though the sheet opened and the share may
+      // well have completed. Reporting that as a failure is what told the
+      // user log export was broken.
+      testWidgets('does not report failure when the outcome is unknown', (
+        tester,
+      ) async {
+        await tapExportLogs(tester, const LogExportResult.unconfirmed());
+
+        expect(find.text(en.supportExportLogsFailed), findsNothing);
+        expect(find.text(en.supportExportLogsUnconfirmed), findsOneWidget);
+      });
+
+      testWidgets('stays silent when the user backs out', (tester) async {
+        await tapExportLogs(tester, const LogExportResult.cancelled());
+
+        expect(find.text(en.supportExportLogsFailed), findsNothing);
+        expect(find.text(en.supportExportLogsUnconfirmed), findsNothing);
+        expect(find.text(en.supportNoLogsToExport), findsNothing);
+      });
+
+      // #8114: the buffer is memory-only, so a crash or force-quit empties
+      // it — exactly when the user needs to be told to reproduce first
+      // rather than conclude export is broken.
+      testWidgets('explains an empty buffer rather than failing', (
+        tester,
+      ) async {
+        await tapExportLogs(tester, const LogExportResult.noLogs());
+
+        expect(find.text(en.supportNoLogsToExport), findsOneWidget);
+        expect(find.text(en.supportExportLogsFailed), findsNothing);
+      });
+
+      testWidgets('still reports a real failure', (tester) async {
+        await tapExportLogs(tester, const LogExportResult.failed());
+
+        expect(find.text(en.supportExportLogsFailed), findsOneWidget);
+      });
+
+      testWidgets('offers to reveal a saved file', (tester) async {
+        when(
+          () => bugReportService.revealExportedFile(any()),
+        ).thenAnswer((_) async {});
+
+        await tapExportLogs(
+          tester,
+          const LogExportResult.saved('/tmp/divine_logs.txt'),
+        );
+
+        expect(
+          find.text(en.supportLogsSavedTo('/tmp/divine_logs.txt')),
+          findsOneWidget,
+        );
+
+        await tester.tap(find.text(en.supportRevealLogsAction));
+        await tester.pumpAndSettle();
+
+        verify(
+          () => bugReportService.revealExportedFile('/tmp/divine_logs.txt'),
+        ).called(1);
+      });
+    });
+  });
+}


### PR DESCRIPTION
Closes #8127. Closes #8112.

## What

Three changes, one goal: make sharing the log file the obvious and only path for the internal folks who need it, and get log tooling out of the settings surface regular users see.

**1. Stop feeding Android’s share-sheet Copy chip** (`efcbb2e55f`)

An internal Android tester tapped Copy in the share sheet and pasted the literal string `OpenVine Full Logs` into Slack instead of the logs. That string was ours: `bug_report_service.dart` passed `text: 'OpenVine Full Logs'` to `ShareParams`, share_plus maps it to `Intent.EXTRA_TEXT` (`share_plus-13.2.0/.../Share.kt:109`), and `EXTRA_TEXT` is exactly what Android’s Copy action copies.

There is no API to suppress the chip — `excludedCupertinoActivities` is iOS-only, and Android’s `EXTRA_EXCLUDE_COMPONENTS` excludes apps, not system actions. But share_plus only sets the extra when `text` is non-blank, so dropping the argument removes the decoy. On stock Android the Copy action is tied to a *text* content preview, which a file share is not, so it should not render at all; an OEM share sheet may still show it, but with nothing to copy. Either outcome beats a placeholder that looks like a successful copy.

`subject:` stays (Gmail uses it for the subject line) and now says Divine rather than OpenVine, since it lands in user-visible copy.

**2. Move the tile to Developer Options** (`da30458635`)

New `ExportLogsSection`, between the environment picker and the Shorebird patch section, mirroring the existing `shorebird_patch_section.dart` in that directory. Renamed **Save Logs** → **Export Logs**.

**3. Delete Copy Logs**

Change 1 removes the decoy the Copy Logs tile existed to work around, so the tile goes rather than moving. That leaves `buildLogClipboardText`, `LogClipboardResult`, `LogClipboardStatus`, `logClipboardByteBudget` and the three payload helpers dead — all removed. `ClipboardUtils.copyVerified` stays; five other screens use it.

Support Center now has no log affordance and, with the copy re-entrancy guard gone, no state — so it drops to a plain `ConsumerWidget`.

## Why this is safe for users

**Report a Bug already attaches the recent log buffer to the Zendesk ticket** via `collectDiagnostics` (`bug_report_service.dart:138`), independently of either tile. Nothing a regular user relies on changes. Support Center was also a public route reachable while signed out, which is the wrong place for developer tooling.

## The #8113 / #8114 fixes travel with the tile

Those fixes are split across two layers. The service half (`_exportLogsNative`'s `ShareResultStatus` mapping, and `noLogs` on an empty buffer) is untouched. The UI half is the `switch (result.status)` — all six `LogExportStatus` arms — which moved **verbatim**. Copying only the happy path would have silently regressed both, so the four tests that pin those outcomes moved with it.

## Testing

- Moved the four `save logs` tests into `test/widgets/developer_options/export_logs_section_test.dart`, plus two new cases: the export is called with `DeveloperOptionsScreen` and the signed-in pubkey, and the saved-file snackbar's "Show in folder" action reveals the file.
- Deleted the `copy logs` group and the `buildLogClipboardText` group.
- New `developer_options_screen_test.dart` case pinning the tile's vertical position between the environment picker and Shorebird.
- Dropped the `Save Logs` assertion from `e2e/maestro/asserts/assertSettings.yaml`.

```
flutter test test/widgets/developer_options/ test/screens/developer_options_screen_test.dart \
             test/screens/settings/support_center_screen_test.dart \
             test/services/bug_report_log_export_test.dart test/l10n/arb_consistency_test.dart
# 82 passed
flutter analyze lib test integration_test   # clean
```

Ratchets run locally, all green: orphaned ARB keys, Maestro copy drift, ungrouped tests, l10n delegates, test/unit structure, untested services.

## l10n

Added `devOptionsExportLogs` / `devOptionsExportLogsSubtitle`; both are developer-only surface behind the seven-tap unlock, so they go in `_knownUntranslatedDebt` rather than a 21-locale pass. Deleted `supportSaveLogs`, `supportSaveLogsSubtitle`, `supportCopyLogs`, `supportCopyLogsSubtitle`, `supportLogsCopied`, `supportCopyLogsFailed` across all 22 ARB files. Six keys stay live and are read from the new location.

## Physical Android verification

Passed on a Pixel 8a running Android 17 (API 37). **Export Logs** opened Android’s chooser as **Sharing 1 file**, showed the generated `.txt`, and did not render a Copy chip. Opening the share in Gmail produced an empty message body, the subject **Divine Full Logs**, and the `.txt` attached as a text file. The unsent verification draft was discarded.

Android has no Shorebird patch path here, so this reaches testers in the next Play release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Rebase note

This branch was rebased over #8118. That PR hardened the UTF-8 truncation used only by Copy Logs; this PR removes Copy Logs and the clipboard payload implementation entirely, so #8118’s tests were removed with the code they covered rather than silently retained against a dead API.