### PR TITLE
ci(account): block releases when deletion coordination is unavailable

### DIFF
--- a/.github/scripts/tests/test_codemagic_shorebird_config.py
+++ b/.github/scripts/tests/test_codemagic_shorebird_config.py
@@ -111,6 +111,12 @@ class CodemagicShorebirdConfigTest(unittest.TestCase):
     def test_scheduled_probe_maintains_one_incident_issue(self) -> None:
         workflow = self.coordinator_probe_workflow_contents
         self.assertIn("issues: write", workflow)
+        self.assertIn("group: coordinator-route-probe", workflow)
+        self.assertIn("cancel-in-progress: false", workflow)
+        self.assertIn(
+            "github.ref_name == github.event.repository.default_branch",
+            workflow,
+        )
         self.assertIn("coordinator-route-probe-incident", workflow)
         self.assertIn("state: 'all'", workflow)
         self.assertIn("state: 'open'", workflow)

--- a/.github/scripts/tests/test_codemagic_shorebird_config.py
+++ b/.github/scripts/tests/test_codemagic_shorebird_config.py
@@ -11,6 +11,7 @@ MOBILE_CI_PATH = (
     Path(__file__).resolve().parents[3] / ".github" / "workflows" / "mobile_ci.yaml"
 )
 WORKFLOWS_PATH = Path(__file__).resolve().parents[2] / "workflows"
+COORDINATOR_PROBE_WORKFLOW_PATH = WORKFLOWS_PATH / "coordinator_route_probe.yml"
 SHOREBIRD_DOC_PATH = (
     Path(__file__).resolve().parents[3] / "mobile" / "docs" / "SHOREBIRD_CODE_PUSH.md"
 )
@@ -43,6 +44,9 @@ class CodemagicShorebirdConfigTest(unittest.TestCase):
     def setUp(self) -> None:
         self.contents = CODEMAGIC_PATH.read_text()
         self.mobile_ci_contents = MOBILE_CI_PATH.read_text()
+        self.coordinator_probe_workflow_contents = (
+            COORDINATOR_PROBE_WORKFLOW_PATH.read_text()
+        )
         self.mise_contents = MISE_PATH.read_text()
         self.shorebird_doc_contents = SHOREBIRD_DOC_PATH.read_text()
         self.shorebird_config_contents = SHOREBIRD_CONFIG_PATH.read_text()
@@ -91,6 +95,27 @@ class CodemagicShorebirdConfigTest(unittest.TestCase):
         self.assertIn("SUPPORTERS_API_BASE_URL", self.contents)
         self.assertIn("FF_DIVINE_SUPPORTERS", self.contents)
         self.assertIn("defines[name] = ENV.fetch(name, '')", self.contents)
+
+    def test_store_gate_probes_only_the_selected_environment(self) -> None:
+        self.assertRegex(
+            self.contents,
+            r'(?s)&check_coordinator_route.*?DEFAULT_ENV="\$\{\{ inputs\.DEFAULT_ENV \}\}"'
+            r"\s+\\\n\s+\./scripts/check_coordinator_route_serving\.sh",
+        )
+        for workflow in ("ios-build", "android-build"):
+            self.assertIn(
+                "- *check_coordinator_route",
+                self._workflow_block(workflow),
+            )
+
+    def test_scheduled_probe_maintains_one_incident_issue(self) -> None:
+        workflow = self.coordinator_probe_workflow_contents
+        self.assertIn("issues: write", workflow)
+        self.assertIn("coordinator-route-probe-incident", workflow)
+        self.assertIn("state: 'all'", workflow)
+        self.assertIn("state: 'open'", workflow)
+        self.assertIn("state: 'closed'", workflow)
+        self.assertEqual(1, workflow.count("github.rest.issues.create({"))
 
     def test_runtime_track_selection_disables_native_auto_update(self) -> None:
         self.assertRegex(

--- a/.github/workflows/coordinator_route_probe.yml
+++ b/.github/workflows/coordinator_route_probe.yml
@@ -9,8 +9,15 @@ permissions:
   contents: read
   issues: write
 
+concurrency:
+  group: coordinator-route-probe
+  cancel-in-progress: false
+
 jobs:
   probe:
+    if: >-
+      github.event_name == 'schedule' ||
+      github.ref_name == github.event.repository.default_branch
     name: Probe configured environments
     runs-on: ubuntu-24.04
     timeout-minutes: 10

--- a/.github/workflows/coordinator_route_probe.yml
+++ b/.github/workflows/coordinator_route_probe.yml
@@ -1,0 +1,30 @@
+name: Coordinator Route Probe
+
+on:
+  schedule:
+    - cron: "17 */4 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  probe:
+    name: Probe configured environments
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: mobile
+    steps:
+      - uses: actions/checkout@v7
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: "3.44.9"
+          channel: stable
+          cache: true
+      - name: Install dependencies
+        run: flutter pub get
+      - name: Probe account-deletion coordinator routes
+        run: ./scripts/check_coordinator_route_serving.sh

--- a/.github/workflows/coordinator_route_probe.yml
+++ b/.github/workflows/coordinator_route_probe.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
 
 jobs:
   probe:
@@ -27,4 +28,84 @@ jobs:
       - name: Install dependencies
         run: flutter pub get
       - name: Probe account-deletion coordinator routes
-        run: ./scripts/check_coordinator_route_serving.sh
+        id: coordinator_probe
+        run: |
+          set -o pipefail
+          ./scripts/check_coordinator_route_serving.sh 2>&1 \
+            | tee "$RUNNER_TEMP/coordinator-route-probe.txt"
+      - name: Open or update the coordinator-route incident
+        if: ${{ failure() && steps.coordinator_probe.outcome == 'failure' }}
+        uses: actions/github-script@v9
+        env:
+          PROBE_OUTPUT: ${{ runner.temp }}/coordinator-route-probe.txt
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- coordinator-route-probe-incident -->';
+            const title = 'ci(account): coordinator route probe is failing';
+            const output = fs.readFileSync(process.env.PROBE_OUTPUT, 'utf8').trim();
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = [
+              marker,
+              'The automated account-deletion coordinator probe is failing.',
+              '',
+              `Latest failed run: ${runUrl}`,
+              '',
+              '```text',
+              output.slice(-6000),
+              '```',
+              '',
+              'This issue is updated on repeated failures and closes automatically after every configured environment passes.',
+            ].join('\n');
+
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'all',
+              per_page: 100,
+            });
+            const existing = issues.find(issue =>
+              !issue.pull_request && issue.body && issue.body.includes(marker)
+            );
+
+            if (existing) {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                body,
+                state: 'open',
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: ['bug'],
+              });
+            }
+      - name: Close the resolved coordinator-route incident
+        if: ${{ success() }}
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const marker = '<!-- coordinator-route-probe-incident -->';
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              per_page: 100,
+            });
+            const existing = issues.find(issue =>
+              !issue.pull_request && issue.body && issue.body.includes(marker)
+            );
+            if (existing) {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                state: 'closed',
+                state_reason: 'completed',
+              });
+            }

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ A Docker-based local stack (relay, Keycast, Blossom, and supporting services) li
 
 ## Configuration
 
-Runtime environment is selected at build time with `--dart-define=DEFAULT_ENV=<env>`, defaulting to `PRODUCTION`. Supported values (see `mobile/lib/models/environment_config.dart`) are `POC`, `STAGING`, `TEST`, `PRODUCTION`, and `LOCAL`; each maps to one relay URL and API base URL (production API is `https://api.divine.video`). For example, `mise run local_build` builds a debug APK with `DEFAULT_ENV=LOCAL`.
+Runtime environment is selected at build time with `--dart-define=DEFAULT_ENV=<env>`, defaulting to `PRODUCTION`. Supported values (see `mobile/lib/models/environment_config.dart`) are `POC`, `STAGING`, `PRODUCTION`, and `LOCAL`; each maps to one relay URL and API base URL (production API is `https://api.divine.video`). For example, `mise run local_build` builds a debug APK with `DEFAULT_ENV=LOCAL`.
 
 Additional `--dart-define` values wire up optional services, supplied by the run/build scripts and CI:
 

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -17,7 +17,7 @@
 #   - ZENDESK_CLIENT_ID
 #   - ZENDESK_URL
 # 6 - DEFAULT_ENV is configured via build inputs (dropdown) when starting a build
-#   - Options: PRODUCTION, STAGING, TEST, POC
+#   - Options: PRODUCTION, STAGING, POC
 #   - Defaults to PRODUCTION for automatic builds
 # 7 - Create environment variable group "proofmode_credentials" with:
 #   - PROOFMODE_SIGNING_SERVER_ENDPOINT
@@ -923,7 +923,6 @@ workflows:
         options:
           - PRODUCTION
           - STAGING
-          - TEST
           - POC
       PUBLISH_TO_GITHUB:
         description: Upload IPA to GitHub Release (for direct distribution)
@@ -1005,7 +1004,6 @@ workflows:
         options:
           - PRODUCTION
           - STAGING
-          - TEST
           - POC
     environment:
       flutter: 3.44.9
@@ -1047,7 +1045,6 @@ workflows:
         options:
           - PRODUCTION
           - STAGING
-          - TEST
           - POC
       PUBLISH_TO_GITHUB:
         description: Create a GitHub Release with APK artifacts (for Zapstore)
@@ -1164,7 +1161,6 @@ workflows:
         options:
           - PRODUCTION
           - STAGING
-          - TEST
           - POC
     environment:
       flutter: 3.44.9
@@ -1256,7 +1252,6 @@ workflows:
         options:
           - PRODUCTION
           - STAGING
-          - TEST
           - POC
     environment:
       flutter: 3.44.9
@@ -1308,7 +1303,6 @@ workflows:
         options:
           - PRODUCTION
           - STAGING
-          - TEST
           - POC
       PUBLISH_TO_GITHUB:
         description: Upload DMG to GitHub Release (for direct distribution)

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -82,7 +82,8 @@ definitions:
       name: Check account-deletion coordinator route
       script: |
         flutter pub get
-        ./scripts/check_coordinator_route_serving.sh
+        DEFAULT_ENV="${{ inputs.DEFAULT_ENV }}" \
+          ./scripts/check_coordinator_route_serving.sh
     - &clean_ios_workspace_state
       name: Clean stale Xcode/SPM workspace state
       script: |

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -78,6 +78,11 @@ definitions:
         # an unset variable ships an empty --dart-define that overrides the
         # in-app default and breaks signing on every capture. Require it here.
         REQUIRE_SIGNING_ENDPOINT=1 ./scripts/check_signing_endpoint.sh
+    - &check_coordinator_route
+      name: Check account-deletion coordinator route
+      script: |
+        flutter pub get
+        ./scripts/check_coordinator_route_serving.sh
     - &clean_ios_workspace_state
       name: Clean stale Xcode/SPM workspace state
       script: |
@@ -958,6 +963,7 @@ workflows:
     scripts:
       - *verify_shorebird_release_source
       - *shorebird_install
+      - *check_coordinator_route
       - *check_signing_endpoint
       - *check_supporters_config
       - *check_ios_extension_signing_contract
@@ -1074,6 +1080,7 @@ workflows:
     scripts:
       - *verify_shorebird_release_source
       - *shorebird_install
+      - *check_coordinator_route
       - *check_signing_endpoint
       - *check_supporters_config
       - *enable_spm

--- a/mobile/lib/models/environment_config.dart
+++ b/mobile/lib/models/environment_config.dart
@@ -1,4 +1,4 @@
-// ABOUTME: Environment configuration model for poc/staging/test/production/local
+// ABOUTME: Environment configuration model for poc/staging/production/local
 // ABOUTME: Each environment maps to exactly one relay URL and API base URL
 
 import 'package:flutter/foundation.dart';
@@ -60,8 +60,6 @@ AppEnvironment get buildTimeDefaultEnvironment {
       return AppEnvironment.poc;
     case 'STAGING':
       return AppEnvironment.staging;
-    case 'TEST':
-      return AppEnvironment.test;
     case 'LOCAL':
       return AppEnvironment.local;
     case 'PRODUCTION':
@@ -71,7 +69,7 @@ AppEnvironment get buildTimeDefaultEnvironment {
 }
 
 /// Available app environments
-enum AppEnvironment { poc, staging, test, production, local }
+enum AppEnvironment { poc, staging, production, local }
 
 /// Configuration for the current app environment
 @immutable
@@ -92,8 +90,6 @@ class EnvironmentConfig {
         return 'wss://relay.poc.dvines.org';
       case AppEnvironment.staging:
         return 'wss://relay.staging.divine.video';
-      case AppEnvironment.test:
-        return 'wss://relay.test.dvines.org';
       case AppEnvironment.local:
         return 'ws://$localHost:$localRelayPort';
       case AppEnvironment.production:
@@ -190,7 +186,6 @@ class EnvironmentConfig {
       case AppEnvironment.local:
         return 'http://$localHost:$localRelayManagerPort';
       case AppEnvironment.poc:
-      case AppEnvironment.test:
       case AppEnvironment.staging:
         return 'https://api-relay-staging.divine.video';
       case AppEnvironment.production:
@@ -208,8 +203,6 @@ class EnvironmentConfig {
         return 'POC';
       case AppEnvironment.staging:
         return 'Staging';
-      case AppEnvironment.test:
-        return 'Test';
       case AppEnvironment.local:
         return 'Local';
       case AppEnvironment.production:
@@ -226,8 +219,6 @@ class EnvironmentConfig {
         return '2fc7d43fc02ae951a226108d3a31330bd26f37c1ef88eaa91948251de98b049d';
       case AppEnvironment.staging:
         return '5414dcebf15d0d8b36fb80c6295ae4222113b61807e777870cbd1fd422a35809';
-      case AppEnvironment.test:
-        return '5414dcebf15d0d8b36fb80c6295ae4222113b61807e777870cbd1fd422a35809';
       case AppEnvironment.local:
         return '5414dcebf15d0d8b36fb80c6295ae4222113b61807e777870cbd1fd422a35809';
       case AppEnvironment.production:
@@ -242,8 +233,6 @@ class EnvironmentConfig {
         return 0xFFFF7640; // accentOrange
       case AppEnvironment.staging:
         return 0xFFFFF140; // accentYellow
-      case AppEnvironment.test:
-        return 0xFF34BBF1; // accentBlue
       case AppEnvironment.local:
         return 0xFFE040FB; // accentPurple
       case AppEnvironment.production:

--- a/mobile/lib/screens/developer_options_screen.dart
+++ b/mobile/lib/screens/developer_options_screen.dart
@@ -148,7 +148,6 @@ class _DeveloperOptionsScreenState
     const environments = [
       EnvironmentConfig.production,
       EnvironmentConfig(environment: AppEnvironment.staging),
-      EnvironmentConfig(environment: AppEnvironment.test),
       EnvironmentConfig(environment: AppEnvironment.poc),
     ];
 

--- a/mobile/lib/services/environment_service.dart
+++ b/mobile/lib/services/environment_service.dart
@@ -1,4 +1,4 @@
-// ABOUTME: Manages app environment (poc/staging/test/production) with persistence
+// ABOUTME: Manages app environment (poc/staging/production/local) with persistence
 // ABOUTME: Handles developer mode unlock and environment switching
 
 import 'package:flutter/foundation.dart';

--- a/mobile/lib/utils/relay_url_utils.dart
+++ b/mobile/lib/utils/relay_url_utils.dart
@@ -32,7 +32,6 @@ const _divineHostedRelayHosts = <String>{
   'relay.divine.video',
   'relay.staging.divine.video',
   'relay.poc.dvines.org',
-  'relay.test.dvines.org',
 };
 
 /// True when [url]'s host is a Divine-operated relay host or a loopback host

--- a/mobile/lib/widgets/environment_indicator.dart
+++ b/mobile/lib/widgets/environment_indicator.dart
@@ -40,8 +40,6 @@ class EnvironmentBadge extends ConsumerWidget {
         return 'POC';
       case AppEnvironment.staging:
         return 'STG';
-      case AppEnvironment.test:
-        return 'TEST';
       case AppEnvironment.local:
         return 'LOCAL';
       case AppEnvironment.production:

--- a/mobile/scripts/check_coordinator_route_serving.sh
+++ b/mobile/scripts/check_coordinator_route_serving.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-# Fails when the account-deletion coordinator route is absent or unreachable.
-# HTTP 401 passes: it proves the unauthenticated request reached a mounted route.
-# HTTP 404 fails: it means the client would ship ahead of its required backend.
+# Fails unless the account-deletion coordinator route rejects a credential-free
+# GET with HTTP 401. Missing, unreachable, unavailable, and unexpected responses
+# mean the client would ship without its required backend contract.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/mobile/scripts/check_coordinator_route_serving.sh
+++ b/mobile/scripts/check_coordinator_route_serving.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Fails when the account-deletion coordinator route is absent or unreachable.
+# HTTP 401 passes: it proves the unauthenticated request reached a mounted route.
+# HTTP 404 fails: it means the client would ship ahead of its required backend.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MOBILE_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+cd "$MOBILE_ROOT"
+
+if [ -n "${DEFAULT_ENV:-}" ]; then
+  dart run scripts/lib/coordinator_route_probe.dart "--environment=$DEFAULT_ENV"
+else
+  dart run scripts/lib/coordinator_route_probe.dart
+fi

--- a/mobile/scripts/lib/coordinator_route_probe.dart
+++ b/mobile/scripts/lib/coordinator_route_probe.dart
@@ -1,5 +1,5 @@
 // ABOUTME: Probes the account-deletion coordinator route for configured environments.
-// ABOUTME: Missing and unreachable routes fail before a mobile build can ship (#8125).
+// ABOUTME: Blocks releases unless selected routes return HTTP 401 (#8125).
 
 import 'dart:async';
 import 'dart:io';
@@ -7,6 +7,7 @@ import 'dart:io';
 import 'package:analyzer/dart/analysis/features.dart';
 import 'package:analyzer/dart/analysis/utilities.dart';
 import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/error/error.dart';
 import 'package:http/http.dart' as http;
 
 const coordinatorCurrentPath = '/api/account-deletion/attempts/current';
@@ -15,6 +16,8 @@ const defaultRetryDelay = Duration(seconds: 2);
 
 typedef StatusFetcher = Future<int> Function(Uri uri, Duration timeout);
 typedef RetryWaiter = Future<void> Function(Duration duration);
+typedef ConfigReader = String Function();
+typedef LineWriter = void Function(String line);
 
 final class CoordinatorTarget {
   const CoordinatorTarget({
@@ -28,7 +31,7 @@ final class CoordinatorTarget {
   Uri get probeUri => Uri.parse('$apiBaseUrl$coordinatorCurrentPath');
 }
 
-enum ProbeState { serving, missing, unreachable }
+enum ProbeState { serving, missing, unavailable, unexpected, unreachable }
 
 final class ProbeResult {
   const ProbeResult({
@@ -36,26 +39,39 @@ final class ProbeResult {
     required this.state,
     this.statusCode,
     this.error,
+    this.attempts = 1,
   });
 
   final CoordinatorTarget target;
   final ProbeState state;
   final int? statusCode;
   final Object? error;
+  final int attempts;
 
   bool get passed => state == ProbeState.serving;
 
   String get message => switch (state) {
     ProbeState.serving =>
-      'PASS ${target.environment}: ${target.probeUri} returned $statusCode.',
+      'PASS ${target.environment}: ${target.probeUri} returned $statusCode'
+          '${_attemptSuffix(attempts)}.',
     ProbeState.missing =>
       'FAIL ${target.environment}: coordinator route is not serving at '
           '${target.probeUri} (HTTP 404).',
+    ProbeState.unavailable =>
+      'FAIL ${target.environment}: coordinator route is unavailable at '
+          '${target.probeUri} (HTTP $statusCode${_attemptSuffix(attempts)}).',
+    ProbeState.unexpected =>
+      'FAIL ${target.environment}: coordinator route returned an unexpected '
+          'response at ${target.probeUri} (HTTP $statusCode).',
     ProbeState.unreachable =>
       'FAIL ${target.environment}: coordinator route is unreachable at '
-          '${target.probeUri} (${_safeError(error)}).',
+          '${target.probeUri} (${_safeError(error)}'
+          '${_attemptSuffix(attempts)}).',
   };
 }
+
+String _attemptSuffix(int attempts) =>
+    attempts > 1 ? ' after $attempts attempts' : '';
 
 String _safeError(Object? error) {
   if (error is TimeoutException) return 'request timed out';
@@ -77,7 +93,7 @@ List<CoordinatorTarget> extractCoordinatorTargets(String source) {
     throwIfDiagnostics: false,
   );
   if (parsed.errors.any(
-    (error) => error.diagnosticCode.severity.name == 'ERROR',
+    (error) => error.diagnosticCode.severity == DiagnosticSeverity.ERROR,
   )) {
     throw const FormatException('environment_config.dart does not parse');
   }
@@ -201,14 +217,40 @@ Future<ProbeResult> probeCoordinatorRoute(
     if (attempt > 0) await waitBeforeRetry(retryDelay);
     try {
       final statusCode = await fetchStatus(target.probeUri, timeout);
+      final attempts = attempt + 1;
+      if (statusCode == HttpStatus.unauthorized) {
+        return ProbeResult(
+          target: target,
+          state: ProbeState.serving,
+          statusCode: statusCode,
+          attempts: attempts,
+        );
+      }
+      if (statusCode == HttpStatus.notFound) {
+        return ProbeResult(
+          target: target,
+          state: ProbeState.missing,
+          statusCode: statusCode,
+          attempts: attempts,
+        );
+      }
+      if (statusCode >= HttpStatus.internalServerError && statusCode < 600) {
+        if (attempt == 0) continue;
+        return ProbeResult(
+          target: target,
+          state: ProbeState.unavailable,
+          statusCode: statusCode,
+          attempts: attempts,
+        );
+      }
       return ProbeResult(
         target: target,
-        state: statusCode == HttpStatus.notFound
-            ? ProbeState.missing
-            : ProbeState.serving,
+        state: ProbeState.unexpected,
         statusCode: statusCode,
+        attempts: attempts,
       );
     } on Object catch (error) {
+      if (!_isRetryableNetworkError(error)) rethrow;
       lastError = error;
     }
   }
@@ -216,8 +258,15 @@ Future<ProbeResult> probeCoordinatorRoute(
     target: target,
     state: ProbeState.unreachable,
     error: lastError,
+    attempts: 2,
   );
 }
+
+bool _isRetryableNetworkError(Object error) =>
+    error is TimeoutException ||
+    error is SocketException ||
+    error is HandshakeException ||
+    error is http.ClientException;
 
 Future<void> _waitWithTimer(Duration duration) {
   final completer = Completer<void>();
@@ -234,35 +283,51 @@ Future<int> _fetchStatus(Uri uri, Duration timeout) async {
   }
 }
 
-Future<void> main(List<String> arguments) async {
+Future<int> runCoordinatorRouteProbe(
+  List<String> arguments, {
+  required ConfigReader readEnvironmentConfig,
+  required StatusFetcher fetchStatus,
+  RetryWaiter waitBeforeRetry = _waitWithTimer,
+  LineWriter writeStdout = print,
+  LineWriter writeStderr = _writeStderr,
+}) async {
   String? selectedEnvironment;
   for (final argument in arguments) {
     if (argument.startsWith('--environment=')) {
+      if (selectedEnvironment != null) {
+        writeStderr('The --environment argument may only be provided once.');
+        writeStderr(_usage);
+        return 64;
+      }
       selectedEnvironment = argument
           .substring('--environment='.length)
           .toUpperCase();
+      if (selectedEnvironment.isEmpty) {
+        writeStderr('The --environment value must not be empty.');
+        writeStderr(_usage);
+        return 64;
+      }
     } else {
-      stderr.writeln(
-        'Usage: dart run scripts/lib/coordinator_route_probe.dart [--environment=NAME]',
-      );
-      exitCode = 64;
-      return;
+      writeStderr('Unknown argument: $argument');
+      writeStderr(_usage);
+      return 64;
     }
   }
 
   try {
-    final source = File(
-      'lib/models/environment_config.dart',
-    ).readAsStringSync();
+    final source = readEnvironmentConfig();
     var targets = extractCoordinatorTargets(source);
     if (selectedEnvironment != null) {
       targets = targets
           .where((target) => target.environment == selectedEnvironment)
           .toList(growable: false);
       if (targets.isEmpty) {
-        throw FormatException(
-          'Environment $selectedEnvironment is not a configured non-local environment',
+        writeStderr(
+          'Environment $selectedEnvironment is not a configured non-local '
+          'environment.',
         );
+        writeStderr(_usage);
+        return 64;
       }
     }
 
@@ -270,19 +335,33 @@ Future<void> main(List<String> arguments) async {
     for (final target in targets) {
       final result = await probeCoordinatorRoute(
         target,
-        fetchStatus: _fetchStatus,
+        fetchStatus: fetchStatus,
+        waitBeforeRetry: waitBeforeRetry,
       );
-      (result.passed ? stdout : stderr).writeln(result.message);
+      (result.passed ? writeStdout : writeStderr)(result.message);
       failed |= !result.passed;
     }
-    if (failed) exitCode = 1;
+    return failed ? 1 : 0;
   } on Object catch (error) {
-    stderr.writeln(
-      'FAIL coordinator route configuration: ${_safeError(error)}',
-    );
-    if (error is FormatException) stderr.writeln(error.message);
-    exitCode = 1;
+    writeStderr('FAIL coordinator route configuration: $error');
+    return 1;
   }
+}
+
+const _usage =
+    'Usage: dart run scripts/lib/coordinator_route_probe.dart '
+    '[--environment=NAME]';
+
+void _writeStderr(String line) => stderr.writeln(line);
+
+Future<void> main(List<String> arguments) async {
+  exitCode = await runCoordinatorRouteProbe(
+    arguments,
+    readEnvironmentConfig: () => File(
+      'lib/models/environment_config.dart',
+    ).readAsStringSync(),
+    fetchStatus: _fetchStatus,
+  );
 }
 
 extension<T> on Iterable<T> {

--- a/mobile/scripts/lib/coordinator_route_probe.dart
+++ b/mobile/scripts/lib/coordinator_route_probe.dart
@@ -1,0 +1,296 @@
+// ABOUTME: Probes the account-deletion coordinator route for configured environments.
+// ABOUTME: Missing and unreachable routes fail before a mobile build can ship (#8125).
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:analyzer/dart/analysis/features.dart';
+import 'package:analyzer/dart/analysis/utilities.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:http/http.dart' as http;
+
+const coordinatorCurrentPath = '/api/account-deletion/attempts/current';
+const defaultProbeTimeout = Duration(seconds: 10);
+const defaultRetryDelay = Duration(seconds: 2);
+
+typedef StatusFetcher = Future<int> Function(Uri uri, Duration timeout);
+typedef RetryWaiter = Future<void> Function(Duration duration);
+
+final class CoordinatorTarget {
+  const CoordinatorTarget({
+    required this.environment,
+    required this.apiBaseUrl,
+  });
+
+  final String environment;
+  final String apiBaseUrl;
+
+  Uri get probeUri => Uri.parse('$apiBaseUrl$coordinatorCurrentPath');
+}
+
+enum ProbeState { serving, missing, unreachable }
+
+final class ProbeResult {
+  const ProbeResult({
+    required this.target,
+    required this.state,
+    this.statusCode,
+    this.error,
+  });
+
+  final CoordinatorTarget target;
+  final ProbeState state;
+  final int? statusCode;
+  final Object? error;
+
+  bool get passed => state == ProbeState.serving;
+
+  String get message => switch (state) {
+    ProbeState.serving =>
+      'PASS ${target.environment}: ${target.probeUri} returned $statusCode.',
+    ProbeState.missing =>
+      'FAIL ${target.environment}: coordinator route is not serving at '
+          '${target.probeUri} (HTTP 404).',
+    ProbeState.unreachable =>
+      'FAIL ${target.environment}: coordinator route is unreachable at '
+          '${target.probeUri} (${_safeError(error)}).',
+  };
+}
+
+String _safeError(Object? error) {
+  if (error is TimeoutException) return 'request timed out';
+  if (error is SocketException) return 'network connection failed';
+  if (error is HandshakeException) return 'TLS handshake failed';
+  if (error is http.ClientException) return 'HTTP client failed';
+  return 'request failed';
+}
+
+/// Extracts all non-local API targets from `environment_config.dart`.
+///
+/// The extractor deliberately validates the current `apiBaseUrl` derivation
+/// rather than carrying a second host list. A new enum value or a changed URL
+/// rule fails extraction until this check understands the new configuration.
+List<CoordinatorTarget> extractCoordinatorTargets(String source) {
+  final parsed = parseString(
+    content: source,
+    featureSet: FeatureSet.latestLanguageVersion(),
+    throwIfDiagnostics: false,
+  );
+  if (parsed.errors.any(
+    (error) => error.diagnosticCode.severity.name == 'ERROR',
+  )) {
+    throw const FormatException('environment_config.dart does not parse');
+  }
+
+  final enumDeclaration = parsed.unit.declarations
+      .whereType<EnumDeclaration>()
+      .where(
+        (declaration) =>
+            declaration.namePart.typeName.lexeme == 'AppEnvironment',
+      )
+      .singleOrNull;
+  if (enumDeclaration == null) {
+    throw const FormatException('AppEnvironment enum was not found');
+  }
+
+  final environments = enumDeclaration.body.constants
+      .map((constant) => constant.name.lexeme)
+      .where((name) => name != 'local')
+      .toList(growable: false);
+  if (!enumDeclaration.body.constants.any(
+    (constant) => constant.name.lexeme == 'local',
+  )) {
+    throw const FormatException('AppEnvironment.local was not found');
+  }
+
+  final environmentClass = parsed.unit.declarations
+      .whereType<ClassDeclaration>()
+      .where(
+        (declaration) =>
+            declaration.namePart.typeName.lexeme == 'EnvironmentConfig',
+      )
+      .singleOrNull;
+  if (environmentClass == null) {
+    throw const FormatException('EnvironmentConfig class was not found');
+  }
+
+  String getterSource(String name) {
+    final getter = environmentClass.body.members
+        .whereType<MethodDeclaration>()
+        .where((member) => member.isGetter && member.name.lexeme == name)
+        .singleOrNull;
+    if (getter == null) {
+      throw FormatException('EnvironmentConfig.$name was not found');
+    }
+    return getter.toSource();
+  }
+
+  final apiSource = getterSource('apiBaseUrl');
+  const requiredApiFragments = [
+    'environment == AppEnvironment.production',
+    'return productionApiBaseUrl',
+    'final url = relayUrl',
+    "url.replaceFirst('wss://', 'https://')",
+    "url.replaceFirst('ws://', 'http://')",
+  ];
+  for (final fragment in requiredApiFragments) {
+    if (!apiSource.contains(fragment)) {
+      throw FormatException(
+        'Unsupported apiBaseUrl configuration: missing $fragment',
+      );
+    }
+  }
+
+  final productionUrl = _topLevelStringConstant(
+    parsed.unit,
+    'productionApiBaseUrl',
+  );
+  final relaySource = getterSource('relayUrl');
+  final relayPattern = RegExp(
+    r"case AppEnvironment\.(\w+):\s*return '([^'$]+)';",
+  );
+  final relayUrls = <String, String>{
+    for (final match in relayPattern.allMatches(relaySource))
+      match.group(1)!: match.group(2)!,
+  };
+
+  return environments
+      .map((environment) {
+        if (environment == 'production') {
+          return CoordinatorTarget(
+            environment: environment.toUpperCase(),
+            apiBaseUrl: productionUrl,
+          );
+        }
+        final relayUrl = relayUrls[environment];
+        if (relayUrl == null || !relayUrl.startsWith('wss://')) {
+          throw FormatException(
+            'Cannot resolve apiBaseUrl for AppEnvironment.$environment',
+          );
+        }
+        return CoordinatorTarget(
+          environment: environment.toUpperCase(),
+          apiBaseUrl: relayUrl.replaceFirst('wss://', 'https://'),
+        );
+      })
+      .toList(growable: false);
+}
+
+String _topLevelStringConstant(CompilationUnit unit, String name) {
+  for (final declaration
+      in unit.declarations.whereType<TopLevelVariableDeclaration>()) {
+    for (final variable in declaration.variables.variables) {
+      if (variable.name.lexeme != name) continue;
+      final initializer = variable.initializer;
+      if (initializer is SimpleStringLiteral) return initializer.value;
+      throw FormatException('$name is not a string literal');
+    }
+  }
+  throw FormatException('$name was not found');
+}
+
+Future<ProbeResult> probeCoordinatorRoute(
+  CoordinatorTarget target, {
+  required StatusFetcher fetchStatus,
+  RetryWaiter waitBeforeRetry = _waitWithTimer,
+  Duration timeout = defaultProbeTimeout,
+  Duration retryDelay = defaultRetryDelay,
+}) async {
+  Object? lastError;
+  for (var attempt = 0; attempt < 2; attempt++) {
+    if (attempt > 0) await waitBeforeRetry(retryDelay);
+    try {
+      final statusCode = await fetchStatus(target.probeUri, timeout);
+      return ProbeResult(
+        target: target,
+        state: statusCode == HttpStatus.notFound
+            ? ProbeState.missing
+            : ProbeState.serving,
+        statusCode: statusCode,
+      );
+    } on Object catch (error) {
+      lastError = error;
+    }
+  }
+  return ProbeResult(
+    target: target,
+    state: ProbeState.unreachable,
+    error: lastError,
+  );
+}
+
+Future<void> _waitWithTimer(Duration duration) {
+  final completer = Completer<void>();
+  Timer(duration, completer.complete);
+  return completer.future;
+}
+
+Future<int> _fetchStatus(Uri uri, Duration timeout) async {
+  final client = http.Client();
+  try {
+    return (await client.get(uri).timeout(timeout)).statusCode;
+  } finally {
+    client.close();
+  }
+}
+
+Future<void> main(List<String> arguments) async {
+  String? selectedEnvironment;
+  for (final argument in arguments) {
+    if (argument.startsWith('--environment=')) {
+      selectedEnvironment = argument
+          .substring('--environment='.length)
+          .toUpperCase();
+    } else {
+      stderr.writeln(
+        'Usage: dart run scripts/lib/coordinator_route_probe.dart [--environment=NAME]',
+      );
+      exitCode = 64;
+      return;
+    }
+  }
+
+  try {
+    final source = File(
+      'lib/models/environment_config.dart',
+    ).readAsStringSync();
+    var targets = extractCoordinatorTargets(source);
+    if (selectedEnvironment != null) {
+      targets = targets
+          .where((target) => target.environment == selectedEnvironment)
+          .toList(growable: false);
+      if (targets.isEmpty) {
+        throw FormatException(
+          'Environment $selectedEnvironment is not a configured non-local environment',
+        );
+      }
+    }
+
+    var failed = false;
+    for (final target in targets) {
+      final result = await probeCoordinatorRoute(
+        target,
+        fetchStatus: _fetchStatus,
+      );
+      (result.passed ? stdout : stderr).writeln(result.message);
+      failed |= !result.passed;
+    }
+    if (failed) exitCode = 1;
+  } on Object catch (error) {
+    stderr.writeln(
+      'FAIL coordinator route configuration: ${_safeError(error)}',
+    );
+    if (error is FormatException) stderr.writeln(error.message);
+    exitCode = 1;
+  }
+}
+
+extension<T> on Iterable<T> {
+  T? get singleOrNull {
+    final iterator = this.iterator;
+    if (!iterator.moveNext()) return null;
+    final value = iterator.current;
+    if (iterator.moveNext()) return null;
+    return value;
+  }
+}

--- a/mobile/scripts/lib/coordinator_route_probe.dart
+++ b/mobile/scripts/lib/coordinator_route_probe.dart
@@ -274,12 +274,17 @@ Future<void> _waitWithTimer(Duration duration) {
   return completer.future;
 }
 
-Future<int> _fetchStatus(Uri uri, Duration timeout) async {
-  final client = http.Client();
+Future<int> fetchCoordinatorStatus(
+  Uri uri,
+  Duration timeout, {
+  http.Client? client,
+}) async {
+  final requestClient = client ?? http.Client();
   try {
-    return (await client.get(uri).timeout(timeout)).statusCode;
+    final request = http.Request('GET', uri)..followRedirects = false;
+    return (await requestClient.send(request).timeout(timeout)).statusCode;
   } finally {
-    client.close();
+    if (client == null) requestClient.close();
   }
 }
 
@@ -357,10 +362,9 @@ void _writeStderr(String line) => stderr.writeln(line);
 Future<void> main(List<String> arguments) async {
   exitCode = await runCoordinatorRouteProbe(
     arguments,
-    readEnvironmentConfig: () => File(
-      'lib/models/environment_config.dart',
-    ).readAsStringSync(),
-    fetchStatus: _fetchStatus,
+    readEnvironmentConfig: () =>
+        File('lib/models/environment_config.dart').readAsStringSync(),
+    fetchStatus: fetchCoordinatorStatus,
   );
 }
 

--- a/mobile/test/models/environment_config_test.dart
+++ b/mobile/test/models/environment_config_test.dart
@@ -41,11 +41,10 @@ void main() {
   });
 
   group('AppEnvironment', () {
-    test('has five values', () {
-      expect(AppEnvironment.values.length, 5);
+    test('has four supported values', () {
+      expect(AppEnvironment.values.length, 4);
       expect(AppEnvironment.values, contains(AppEnvironment.poc));
       expect(AppEnvironment.values, contains(AppEnvironment.staging));
-      expect(AppEnvironment.values, contains(AppEnvironment.test));
       expect(AppEnvironment.values, contains(AppEnvironment.production));
       expect(AppEnvironment.values, contains(AppEnvironment.local));
     });
@@ -67,11 +66,6 @@ void main() {
       test('staging returns staging relay', () {
         const config = EnvironmentConfig(environment: AppEnvironment.staging);
         expect(config.relayUrl, 'wss://relay.staging.divine.video');
-      });
-
-      test('test returns test relay', () {
-        const config = EnvironmentConfig(environment: AppEnvironment.test);
-        expect(config.relayUrl, 'wss://relay.test.dvines.org');
       });
 
       test('local returns emulator relay', () {
@@ -97,11 +91,6 @@ void main() {
         expect(config.apiBaseUrl, 'https://relay.staging.divine.video');
       });
 
-      test('test derives from relay URL', () {
-        const config = EnvironmentConfig(environment: AppEnvironment.test);
-        expect(config.apiBaseUrl, 'https://relay.test.dvines.org');
-      });
-
       test('local returns local API URL (unified funnelcake-proxy port)', () {
         debugDefaultTargetPlatformOverride = TargetPlatform.android;
         const config = EnvironmentConfig(environment: AppEnvironment.local);
@@ -124,12 +113,10 @@ void main() {
     test('blossomUrl is same for all environments', () {
       const poc = EnvironmentConfig(environment: AppEnvironment.poc);
       const staging = EnvironmentConfig(environment: AppEnvironment.staging);
-      const testEnv = EnvironmentConfig(environment: AppEnvironment.test);
       const prod = EnvironmentConfig.production;
 
       expect(poc.blossomUrl, 'https://media.divine.video');
       expect(staging.blossomUrl, 'https://media.divine.video');
-      expect(testEnv.blossomUrl, 'https://media.divine.video');
       expect(prod.blossomUrl, 'https://media.divine.video');
     });
 
@@ -142,10 +129,6 @@ void main() {
         const EnvironmentConfig(
           environment: AppEnvironment.staging,
         ).isProduction,
-        false,
-      );
-      expect(
-        const EnvironmentConfig(environment: AppEnvironment.test).isProduction,
         false,
       );
       expect(
@@ -170,10 +153,6 @@ void main() {
         'Staging',
       );
       expect(
-        const EnvironmentConfig(environment: AppEnvironment.test).displayName,
-        'Test',
-      );
-      expect(
         const EnvironmentConfig(environment: AppEnvironment.local).displayName,
         'Local',
       );
@@ -193,12 +172,6 @@ void main() {
       expect(
         const EnvironmentConfig(
           environment: AppEnvironment.staging,
-        ).pushServicePubkey,
-        '5414dcebf15d0d8b36fb80c6295ae4222113b61807e777870cbd1fd422a35809',
-      );
-      expect(
-        const EnvironmentConfig(
-          environment: AppEnvironment.test,
         ).pushServicePubkey,
         '5414dcebf15d0d8b36fb80c6295ae4222113b61807e777870cbd1fd422a35809',
       );
@@ -226,12 +199,6 @@ void main() {
           environment: AppEnvironment.staging,
         ).indicatorColorValue,
         0xFFFFF140, // accentYellow
-      );
-      expect(
-        const EnvironmentConfig(
-          environment: AppEnvironment.test,
-        ).indicatorColorValue,
-        0xFF34BBF1, // accentBlue
       );
       expect(
         const EnvironmentConfig(

--- a/mobile/test/providers/push_notification_sync_test.dart
+++ b/mobile/test/providers/push_notification_sync_test.dart
@@ -181,7 +181,7 @@ void main() {
   const pushServicePubkey =
       '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef';
   const pushEnvironment = _ConfiguredEnvironmentConfig(
-    environment: AppEnvironment.test,
+    environment: AppEnvironment.staging,
     configuredPushServicePubkey: pushServicePubkey,
   );
   const stagingEnvironment = _ConfiguredEnvironmentConfig(
@@ -410,7 +410,8 @@ void main() {
               _MockNotificationService(),
             ),
             currentEnvironmentProvider.overrideWith(
-              (_) => const EnvironmentConfig(environment: AppEnvironment.test),
+              (_) =>
+                  const EnvironmentConfig(environment: AppEnvironment.staging),
             ),
             nostrSessionProvider.overrideWith(() => nostrSession),
           ],
@@ -2283,7 +2284,7 @@ void main() {
               _MockNotificationService(),
             ),
             currentEnvironmentProvider.overrideWithValue(
-              const EnvironmentConfig(environment: AppEnvironment.test),
+              const EnvironmentConfig(environment: AppEnvironment.staging),
             ),
             nostrSessionProvider.overrideWith(
               () => _TestNostrSession(const NostrSessionReadiness.signedOut()),
@@ -2325,7 +2326,7 @@ void main() {
               _MockNotificationService(),
             ),
             currentEnvironmentProvider.overrideWithValue(
-              const EnvironmentConfig(environment: AppEnvironment.test),
+              const EnvironmentConfig(environment: AppEnvironment.staging),
             ),
             nostrSessionProvider.overrideWith(
               () => _TestNostrSession(

--- a/mobile/test/services/environment_service_test.dart
+++ b/mobile/test/services/environment_service_test.dart
@@ -47,7 +47,7 @@ void main() {
       expect(service.currentConfig.environment, AppEnvironment.poc);
     });
 
-    test('loads test environment from SharedPreferences', () async {
+    test('falls back to production for retired test environment', () async {
       SharedPreferences.setMockInitialValues({
         'developer_mode_enabled': true,
         'app_environment': 'test',
@@ -56,7 +56,7 @@ void main() {
       service = EnvironmentService();
       await service.initialize();
 
-      expect(service.currentConfig.environment, AppEnvironment.test);
+      expect(service.currentConfig.environment, AppEnvironment.production);
     });
 
     test('enableDeveloperMode persists state', () async {
@@ -118,18 +118,6 @@ void main() {
 
       final prefs = await SharedPreferences.getInstance();
       expect(prefs.getString('app_environment'), 'poc');
-    });
-
-    test('setEnvironment to test persists correctly', () async {
-      service = EnvironmentService();
-      await service.initialize();
-
-      await service.setEnvironment(AppEnvironment.test);
-
-      expect(service.currentConfig.environment, AppEnvironment.test);
-
-      final prefs = await SharedPreferences.getInstance();
-      expect(prefs.getString('app_environment'), 'test');
     });
 
     test('setEnvironment clears configured_relays', () async {

--- a/mobile/test/services/push_notification_service_test.dart
+++ b/mobile/test/services/push_notification_service_test.dart
@@ -63,12 +63,12 @@ void main() {
       '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef';
 
   const testEnvironment = _ConfiguredEnvironmentConfig(
-    environment: AppEnvironment.test,
+    environment: AppEnvironment.staging,
     configuredPushServicePubkey: configuredPushServicePubkey,
   );
 
   const placeholderEnvironment = _ConfiguredEnvironmentConfig(
-    environment: AppEnvironment.test,
+    environment: AppEnvironment.staging,
     configuredPushServicePubkey: 'TODO_TEST_PUBKEY',
   );
 

--- a/mobile/test/tools/coordinator_route_probe_test.dart
+++ b/mobile/test/tools/coordinator_route_probe_test.dart
@@ -77,6 +77,109 @@ void main() {
         ),
       );
     });
+
+    test('fails when apiBaseUrl no longer derives from relayUrl', () {
+      final changed = currentConfigFixture.replaceFirst(
+        'final url = relayUrl;',
+        'final url = eventPublishBaseUrl;',
+      );
+
+      expect(
+        () => extractCoordinatorTargets(changed),
+        throwsA(
+          isA<FormatException>().having(
+            (error) => error.message,
+            'message',
+            contains('missing final url = relayUrl'),
+          ),
+        ),
+      );
+    });
+
+    test('fails when apiBaseUrl no longer converts secure relay URLs', () {
+      final changed = currentConfigFixture.replaceFirst(
+        "url.replaceFirst('wss://', 'https://')",
+        "url.replaceFirst('wss://', 'http://')",
+      );
+
+      expect(
+        () => extractCoordinatorTargets(changed),
+        throwsA(
+          isA<FormatException>().having(
+            (error) => error.message,
+            'message',
+            contains("missing url.replaceFirst('wss://', 'https://')"),
+          ),
+        ),
+      );
+    });
+
+    test('fails when production no longer uses productionApiBaseUrl', () {
+      final changed = currentConfigFixture.replaceFirst(
+        'return productionApiBaseUrl;',
+        'return relayUrl;',
+      );
+
+      expect(
+        () => extractCoordinatorTargets(changed),
+        throwsA(
+          isA<FormatException>().having(
+            (error) => error.message,
+            'message',
+            contains('missing return productionApiBaseUrl'),
+          ),
+        ),
+      );
+    });
+
+    test('fails when the local environment disappears', () {
+      final changed = currentConfigFixture.replaceFirst(
+        'production, local',
+        'production',
+      );
+
+      expect(
+        () => extractCoordinatorTargets(changed),
+        throwsA(
+          isA<FormatException>().having(
+            (error) => error.message,
+            'message',
+            contains('AppEnvironment.local was not found'),
+          ),
+        ),
+      );
+    });
+
+    test('fails when productionApiBaseUrl is not a string literal', () {
+      final changed = currentConfigFixture.replaceFirst(
+        "const productionApiBaseUrl = 'https://api.divine.video';",
+        'final productionApiBaseUrl = Uri.base.origin;',
+      );
+
+      expect(
+        () => extractCoordinatorTargets(changed),
+        throwsA(
+          isA<FormatException>().having(
+            (error) => error.message,
+            'message',
+            contains('productionApiBaseUrl is not a string literal'),
+          ),
+        ),
+      );
+    });
+
+    test('fails when the environment source does not parse', () {
+      expect(
+        () => extractCoordinatorTargets('enum AppEnvironment {'),
+        throwsA(
+          isA<FormatException>().having(
+            (error) => error.message,
+            'message',
+            contains('does not parse'),
+          ),
+        ),
+      );
+    });
   });
 
   group('probeCoordinatorRoute', () {
@@ -101,12 +204,17 @@ void main() {
     );
 
     test('fails a 404 with the environment and exact URL', () async {
+      var attempts = 0;
       final result = await probeCoordinatorRoute(
         target,
-        fetchStatus: (_, _) async => HttpStatus.notFound,
+        fetchStatus: (_, _) async {
+          attempts++;
+          return HttpStatus.notFound;
+        },
         waitBeforeRetry: noWait,
       );
 
+      expect(attempts, 1);
       expect(result.state, ProbeState.missing);
       expect(result.message, contains('STAGING'));
       expect(
@@ -114,6 +222,62 @@ void main() {
         contains('https://relay.staging.divine.video$coordinatorCurrentPath'),
       );
     });
+
+    test('retries a server error then passes a 401', () async {
+      var attempts = 0;
+      final result = await probeCoordinatorRoute(
+        target,
+        fetchStatus: (_, _) async {
+          attempts++;
+          return attempts == 1
+              ? HttpStatus.serviceUnavailable
+              : HttpStatus.unauthorized;
+        },
+        waitBeforeRetry: noWait,
+      );
+
+      expect(attempts, 2);
+      expect(result.state, ProbeState.serving);
+      expect(result.message, contains('after 2 attempts'));
+    });
+
+    test('retries server errors then reports unavailable', () async {
+      var attempts = 0;
+      final result = await probeCoordinatorRoute(
+        target,
+        fetchStatus: (_, _) async {
+          attempts++;
+          return HttpStatus.badGateway;
+        },
+        waitBeforeRetry: noWait,
+      );
+
+      expect(attempts, 2);
+      expect(result.state, ProbeState.unavailable);
+      expect(result.message, contains('HTTP 502 after 2 attempts'));
+    });
+
+    for (final statusCode in const [
+      HttpStatus.ok,
+      HttpStatus.forbidden,
+      HttpStatus.methodNotAllowed,
+    ]) {
+      test('fails unexpected HTTP $statusCode without retrying', () async {
+        var attempts = 0;
+        final result = await probeCoordinatorRoute(
+          target,
+          fetchStatus: (_, _) async {
+            attempts++;
+            return statusCode;
+          },
+          waitBeforeRetry: noWait,
+        );
+
+        expect(attempts, 1);
+        expect(result.state, ProbeState.unexpected);
+        expect(result.message, contains('HTTP $statusCode'));
+      });
+    }
 
     test('retries once then reports unreachable distinctly', () async {
       var attempts = 0;
@@ -130,6 +294,7 @@ void main() {
       expect(result.state, ProbeState.unreachable);
       expect(result.message, contains('STAGING'));
       expect(result.message, contains('unreachable'));
+      expect(result.message, contains('after 2 attempts'));
       expect(result.message, isNot(contains('synthetic private detail')));
       expect(result.message, isNot(contains('authorization')));
       expect(result.message, isNot(contains('token')));
@@ -144,6 +309,141 @@ void main() {
 
       expect(result.message, contains('request timed out'));
       expect(result.message, isNot(contains('secret=value')));
+    });
+
+    test('does not disguise a programming error as a network failure', () {
+      expect(
+        () => probeCoordinatorRoute(
+          target,
+          fetchStatus: (_, _) async => throw StateError('synthetic defect'),
+          waitBeforeRetry: noWait,
+        ),
+        throwsA(isA<StateError>()),
+      );
+    });
+  });
+
+  group('runCoordinatorRouteProbe', () {
+    Future<int> fetch401(Uri _, Duration timeout) async {
+      expect(timeout, defaultProbeTimeout);
+      return HttpStatus.unauthorized;
+    }
+
+    Future<void> noWait(Duration _) async {}
+
+    test('selects one configured environment', () async {
+      final requested = <Uri>[];
+      final stdout = <String>[];
+
+      final result = await runCoordinatorRouteProbe(
+        ['--environment=staging'],
+        readEnvironmentConfig: () => currentConfigFixture,
+        fetchStatus: (uri, _) async {
+          requested.add(uri);
+          return HttpStatus.unauthorized;
+        },
+        waitBeforeRetry: noWait,
+        writeStdout: stdout.add,
+        writeStderr: (_) {},
+      );
+
+      expect(result, 0);
+      expect(requested, hasLength(1));
+      expect(requested.single.host, 'relay.staging.divine.video');
+      expect(stdout.single, contains('STAGING'));
+    });
+
+    test(
+      'rejects duplicate environment arguments with usage exit code',
+      () async {
+        final stderr = <String>[];
+
+        final result = await runCoordinatorRouteProbe(
+          ['--environment=POC', '--environment=STAGING'],
+          readEnvironmentConfig: () => currentConfigFixture,
+          fetchStatus: fetch401,
+          waitBeforeRetry: noWait,
+          writeStdout: (_) {},
+          writeStderr: stderr.add,
+        );
+
+        expect(result, 64);
+        expect(stderr.join('\n'), contains('only be provided once'));
+      },
+    );
+
+    test('rejects an empty environment with usage exit code', () async {
+      final stderr = <String>[];
+
+      final result = await runCoordinatorRouteProbe(
+        ['--environment='],
+        readEnvironmentConfig: () => currentConfigFixture,
+        fetchStatus: fetch401,
+        waitBeforeRetry: noWait,
+        writeStdout: (_) {},
+        writeStderr: stderr.add,
+      );
+
+      expect(result, 64);
+      expect(stderr.join('\n'), contains('must not be empty'));
+    });
+
+    test('rejects an unknown argument with usage exit code', () async {
+      final stderr = <String>[];
+
+      final result = await runCoordinatorRouteProbe(
+        ['--unknown'],
+        readEnvironmentConfig: () => currentConfigFixture,
+        fetchStatus: fetch401,
+        waitBeforeRetry: noWait,
+        writeStdout: (_) {},
+        writeStderr: stderr.add,
+      );
+
+      expect(result, 64);
+      expect(stderr.join('\n'), contains('Unknown argument'));
+    });
+
+    for (final environment in const ['LOCAL', 'UNKNOWN']) {
+      test('rejects $environment as a non-probed environment', () async {
+        final stderr = <String>[];
+
+        final result = await runCoordinatorRouteProbe(
+          ['--environment=$environment'],
+          readEnvironmentConfig: () => currentConfigFixture,
+          fetchStatus: fetch401,
+          waitBeforeRetry: noWait,
+          writeStdout: (_) {},
+          writeStderr: stderr.add,
+        );
+
+        expect(result, 64);
+        expect(stderr.join('\n'), contains('not a configured non-local'));
+      });
+    }
+
+    test('preserves safe filesystem configuration diagnostics', () async {
+      final stderr = <String>[];
+
+      final result = await runCoordinatorRouteProbe(
+        const [],
+        readEnvironmentConfig: () => throw const FileSystemException(
+          'No such file',
+          'lib/models/environment_config.dart',
+        ),
+        fetchStatus: fetch401,
+        waitBeforeRetry: noWait,
+        writeStdout: (_) {},
+        writeStderr: stderr.add,
+      );
+
+      expect(result, 1);
+      expect(
+        stderr.join('\n'),
+        contains('lib/models/environment_config.dart'),
+      );
+      expect(stderr.join('\n'), contains('No such file'));
+      expect(stderr.join('\n'), isNot(contains('request failed')));
     });
   });
 }

--- a/mobile/test/tools/coordinator_route_probe_test.dart
+++ b/mobile/test/tools/coordinator_route_probe_test.dart
@@ -5,6 +5,8 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
 
 // ignore: avoid_relative_lib_imports, scripts are outside lib/ and not importable through package:openvine.
 import '../../scripts/lib/coordinator_route_probe.dart';
@@ -40,10 +42,12 @@ void main() {
         File('lib/models/environment_config.dart').readAsStringSync(),
       );
 
-      expect(
-        targets.map((target) => target.environment),
-        ['POC', 'STAGING', 'TEST', 'PRODUCTION'],
-      );
+      expect(targets.map((target) => target.environment), [
+        'POC',
+        'STAGING',
+        'TEST',
+        'PRODUCTION',
+      ]);
     });
 
     test('derives every non-local target from environment config', () {
@@ -189,6 +193,22 @@ void main() {
     );
     Future<void> noWait(Duration _) async {}
 
+    test('does not follow redirects away from the probed route', () async {
+      final client = MockClient((request) async {
+        expect(request.followRedirects, isFalse);
+        return http.Response('', HttpStatus.found);
+      });
+      addTearDown(client.close);
+
+      final statusCode = await fetchCoordinatorStatus(
+        target.probeUri,
+        defaultProbeTimeout,
+        client: client,
+      );
+
+      expect(statusCode, HttpStatus.found);
+    });
+
     test(
       'passes a mounted route that rejects unauthenticated access',
       () async {
@@ -259,6 +279,7 @@ void main() {
 
     for (final statusCode in const [
       HttpStatus.ok,
+      HttpStatus.found,
       HttpStatus.forbidden,
       HttpStatus.methodNotAllowed,
     ]) {
@@ -438,10 +459,7 @@ void main() {
       );
 
       expect(result, 1);
-      expect(
-        stderr.join('\n'),
-        contains('lib/models/environment_config.dart'),
-      );
+      expect(stderr.join('\n'), contains('lib/models/environment_config.dart'));
       expect(stderr.join('\n'), contains('No such file'));
       expect(stderr.join('\n'), isNot(contains('request failed')));
     });

--- a/mobile/test/tools/coordinator_route_probe_test.dart
+++ b/mobile/test/tools/coordinator_route_probe_test.dart
@@ -1,0 +1,149 @@
+// ABOUTME: Tests config extraction and coordinator route response classification.
+// ABOUTME: Keeps release checks exhaustive, credential-free, and diagnostic (#8125).
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+// ignore: avoid_relative_lib_imports, scripts are outside lib/ and not importable through package:openvine.
+import '../../scripts/lib/coordinator_route_probe.dart';
+
+const currentConfigFixture = r'''
+const productionApiBaseUrl = 'https://api.divine.video';
+enum AppEnvironment { poc, staging, test, production, local }
+class EnvironmentConfig {
+  String get relayUrl {
+    switch (environment) {
+      case AppEnvironment.poc: return 'wss://relay.poc.dvines.org';
+      case AppEnvironment.staging: return 'wss://relay.staging.divine.video';
+      case AppEnvironment.test: return 'wss://relay.test.dvines.org';
+      case AppEnvironment.local: return 'ws://$localHost:47777';
+      case AppEnvironment.production: return 'wss://relay.divine.video';
+    }
+  }
+  String get apiBaseUrl {
+    if (environment == AppEnvironment.local) return 'http://$localHost:47777';
+    if (environment == AppEnvironment.production) return productionApiBaseUrl;
+    final url = relayUrl;
+    if (url.startsWith('wss://')) return url.replaceFirst('wss://', 'https://');
+    if (url.startsWith('ws://')) return url.replaceFirst('ws://', 'http://');
+    return url;
+  }
+}
+''';
+
+void main() {
+  group('extractCoordinatorTargets', () {
+    test('extracts the repository environment config', () {
+      final targets = extractCoordinatorTargets(
+        File('lib/models/environment_config.dart').readAsStringSync(),
+      );
+
+      expect(
+        targets.map((target) => target.environment),
+        ['POC', 'STAGING', 'TEST', 'PRODUCTION'],
+      );
+    });
+
+    test('derives every non-local target from environment config', () {
+      final targets = extractCoordinatorTargets(currentConfigFixture);
+
+      expect(
+        targets.map((target) => '${target.environment}:${target.apiBaseUrl}'),
+        [
+          'POC:https://relay.poc.dvines.org',
+          'STAGING:https://relay.staging.divine.video',
+          'TEST:https://relay.test.dvines.org',
+          'PRODUCTION:https://api.divine.video',
+        ],
+      );
+    });
+
+    test('fails when a new environment cannot be resolved', () {
+      final changed = currentConfigFixture.replaceFirst(
+        'poc, staging',
+        'poc, preview, staging',
+      );
+
+      expect(
+        () => extractCoordinatorTargets(changed),
+        throwsA(
+          isA<FormatException>().having(
+            (error) => error.message,
+            'message',
+            contains('AppEnvironment.preview'),
+          ),
+        ),
+      );
+    });
+  });
+
+  group('probeCoordinatorRoute', () {
+    const target = CoordinatorTarget(
+      environment: 'STAGING',
+      apiBaseUrl: 'https://relay.staging.divine.video',
+    );
+    Future<void> noWait(Duration _) async {}
+
+    test(
+      'passes a mounted route that rejects unauthenticated access',
+      () async {
+        final result = await probeCoordinatorRoute(
+          target,
+          fetchStatus: (_, _) async => HttpStatus.unauthorized,
+          waitBeforeRetry: noWait,
+        );
+
+        expect(result.state, ProbeState.serving);
+        expect(result.message, contains('returned 401'));
+      },
+    );
+
+    test('fails a 404 with the environment and exact URL', () async {
+      final result = await probeCoordinatorRoute(
+        target,
+        fetchStatus: (_, _) async => HttpStatus.notFound,
+        waitBeforeRetry: noWait,
+      );
+
+      expect(result.state, ProbeState.missing);
+      expect(result.message, contains('STAGING'));
+      expect(
+        result.message,
+        contains('https://relay.staging.divine.video$coordinatorCurrentPath'),
+      );
+    });
+
+    test('retries once then reports unreachable distinctly', () async {
+      var attempts = 0;
+      final result = await probeCoordinatorRoute(
+        target,
+        fetchStatus: (_, _) async {
+          attempts++;
+          throw const SocketException('synthetic private detail');
+        },
+        waitBeforeRetry: noWait,
+      );
+
+      expect(attempts, 2);
+      expect(result.state, ProbeState.unreachable);
+      expect(result.message, contains('STAGING'));
+      expect(result.message, contains('unreachable'));
+      expect(result.message, isNot(contains('synthetic private detail')));
+      expect(result.message, isNot(contains('authorization')));
+      expect(result.message, isNot(contains('token')));
+    });
+
+    test('classifies a timeout without exposing its details', () async {
+      final result = await probeCoordinatorRoute(
+        target,
+        fetchStatus: (_, _) async => throw TimeoutException('secret=value'),
+        waitBeforeRetry: noWait,
+      );
+
+      expect(result.message, contains('request timed out'));
+      expect(result.message, isNot(contains('secret=value')));
+    });
+  });
+}

--- a/mobile/test/tools/coordinator_route_probe_test.dart
+++ b/mobile/test/tools/coordinator_route_probe_test.dart
@@ -13,13 +13,12 @@ import '../../scripts/lib/coordinator_route_probe.dart';
 
 const currentConfigFixture = r'''
 const productionApiBaseUrl = 'https://api.divine.video';
-enum AppEnvironment { poc, staging, test, production, local }
+enum AppEnvironment { poc, staging, production, local }
 class EnvironmentConfig {
   String get relayUrl {
     switch (environment) {
       case AppEnvironment.poc: return 'wss://relay.poc.dvines.org';
       case AppEnvironment.staging: return 'wss://relay.staging.divine.video';
-      case AppEnvironment.test: return 'wss://relay.test.dvines.org';
       case AppEnvironment.local: return 'ws://$localHost:47777';
       case AppEnvironment.production: return 'wss://relay.divine.video';
     }
@@ -45,7 +44,6 @@ void main() {
       expect(targets.map((target) => target.environment), [
         'POC',
         'STAGING',
-        'TEST',
         'PRODUCTION',
       ]);
     });
@@ -58,7 +56,6 @@ void main() {
         [
           'POC:https://relay.poc.dvines.org',
           'STAGING:https://relay.staging.divine.video',
-          'TEST:https://relay.test.dvines.org',
           'PRODUCTION:https://api.divine.video',
         ],
       );

--- a/mobile/test/utils/relay_url_utils_test.dart
+++ b/mobile/test/utils/relay_url_utils_test.dart
@@ -229,7 +229,6 @@ void main() {
         isTrue,
       );
       expect(isDivineHostedRelayUrl('wss://relay.poc.dvines.org'), isTrue);
-      expect(isDivineHostedRelayUrl('wss://relay.test.dvines.org'), isTrue);
     });
 
     test('accepts loopback relays (local environment)', () {

--- a/mobile/test/widgets/environment_indicator_test.dart
+++ b/mobile/test/widgets/environment_indicator_test.dart
@@ -13,8 +13,6 @@ void main() {
 
   const pocConfig = EnvironmentConfig(environment: AppEnvironment.poc);
 
-  const testConfig = EnvironmentConfig(environment: AppEnvironment.test);
-
   group('EnvironmentBadge', () {
     testWidgets('shows STG badge for staging environment', (
       WidgetTester tester,
@@ -58,27 +56,6 @@ void main() {
       expect(find.byType(Container), findsOneWidget);
     });
 
-    testWidgets('shows TEST badge for test environment', (
-      WidgetTester tester,
-    ) async {
-      await tester.pumpWidget(
-        ProviderScope(
-          overrides: [
-            currentEnvironmentProvider.overrideWith((ref) => testConfig),
-            showEnvironmentIndicatorProvider.overrideWith((ref) => true),
-          ],
-          child: const MaterialApp(
-            localizationsDelegates: AppLocalizations.localizationsDelegates,
-            supportedLocales: AppLocalizations.supportedLocales,
-            home: Scaffold(body: Stack(children: [EnvironmentBadge()])),
-          ),
-        ),
-      );
-
-      expect(find.text('TEST'), findsOneWidget);
-      expect(find.byType(Container), findsOneWidget);
-    });
-
     testWidgets('hides badge for production environment', (
       WidgetTester tester,
     ) async {
@@ -100,7 +77,6 @@ void main() {
 
       expect(find.text('STG'), findsNothing);
       expect(find.text('POC'), findsNothing);
-      expect(find.text('TEST'), findsNothing);
       expect(find.byType(SizedBox), findsOneWidget);
     });
 
@@ -181,34 +157,6 @@ void main() {
       final decoration = container.decoration! as BoxDecoration;
       expect(decoration.color, Color(pocConfig.indicatorColorValue));
     });
-
-    testWidgets('badge has correct styling for test', (
-      WidgetTester tester,
-    ) async {
-      await tester.pumpWidget(
-        ProviderScope(
-          overrides: [
-            currentEnvironmentProvider.overrideWith((ref) => testConfig),
-            showEnvironmentIndicatorProvider.overrideWith((ref) => true),
-          ],
-          child: const MaterialApp(
-            localizationsDelegates: AppLocalizations.localizationsDelegates,
-            supportedLocales: AppLocalizations.supportedLocales,
-            home: Scaffold(body: Stack(children: [EnvironmentBadge()])),
-          ),
-        ),
-      );
-
-      final container = tester.widget<Container>(
-        find.descendant(
-          of: find.byType(EnvironmentBadge),
-          matching: find.byType(Container),
-        ),
-      );
-
-      final decoration = container.decoration! as BoxDecoration;
-      expect(decoration.color, Color(testConfig.indicatorColorValue));
-    });
   });
 
   group('EnvironmentBanner', () {
@@ -258,28 +206,6 @@ void main() {
       );
 
       expect(find.text('Environment: POC - Tap for options'), findsOneWidget);
-    });
-
-    testWidgets('shows test banner with correct text', (
-      WidgetTester tester,
-    ) async {
-      await tester.pumpWidget(
-        ProviderScope(
-          overrides: [
-            currentEnvironmentProvider.overrideWith((ref) => testConfig),
-            showEnvironmentIndicatorProvider.overrideWith((ref) => true),
-          ],
-          child: MaterialApp(
-            localizationsDelegates: AppLocalizations.localizationsDelegates,
-            supportedLocales: AppLocalizations.supportedLocales,
-            home: Scaffold(
-              body: Stack(children: [EnvironmentBanner(onTap: () {})]),
-            ),
-          ),
-        ),
-      );
-
-      expect(find.text('Environment: Test - Tap for options'), findsOneWidget);
     });
 
     testWidgets('hides banner for production environment', (
@@ -423,35 +349,6 @@ void main() {
       );
 
       expect(container.color, Color(pocConfig.indicatorColorValue));
-    });
-
-    testWidgets('banner has correct styling for test', (
-      WidgetTester tester,
-    ) async {
-      await tester.pumpWidget(
-        ProviderScope(
-          overrides: [
-            currentEnvironmentProvider.overrideWith((ref) => testConfig),
-            showEnvironmentIndicatorProvider.overrideWith((ref) => true),
-          ],
-          child: MaterialApp(
-            localizationsDelegates: AppLocalizations.localizationsDelegates,
-            supportedLocales: AppLocalizations.supportedLocales,
-            home: Scaffold(
-              body: Stack(children: [EnvironmentBanner(onTap: () {})]),
-            ),
-          ),
-        ),
-      );
-
-      final container = tester.widget<Container>(
-        find.descendant(
-          of: find.byType(GestureDetector),
-          matching: find.byType(Container),
-        ),
-      );
-
-      expect(container.color, Color(testConfig.indicatorColorValue));
     });
   });
 }


### PR DESCRIPTION
## Problem

Account deletion fails closed when its coordinator dependency is unavailable, but mobile releases had no automated way to verify the exact unauthenticated route contract before shipping. Production returned HTTP 404 when this work began, while healthy mounted routes returned HTTP 401. The production rollout has since completed and now returns HTTP 401; this check prevents a future release from shipping after that contract regresses.

Mobile also still advertised TEST after its GKE environment was decommissioned. Its stale relay hostname timed out before TLS or HTTP, so TEST builds could never succeed and an exhaustive route monitor would fail permanently.

## Why this fix

This adds a credential-free probe that AST-parses `EnvironmentConfig` to derive every non-local API target without maintaining a second host list. The probe requires the exact response that proves the client request reached the authenticated route:

- HTTP 401 passes.
- HTTP 404 fails as missing.
- HTTP 5xx and network failures retry once, then fail as unavailable or unreachable.
- Every other response fails as unexpected, preventing an edge fallback or wrong method contract from passing.

The iOS and Android Codemagic store workflows explicitly pass their selected `DEFAULT_ENV`, so one unavailable supported environment cannot block a release for another. A four-hourly GitHub Actions workflow still checks every configured non-local environment.

TEST is removed from runtime configuration, Developer Options, hosted-relay recognition, documentation, and every Codemagic build selector. An existing persisted `test` selection safely falls back to that build's configured default environment.

Scheduled failures create or update one deduplicated incident issue containing the named environments and sanitized probe output. Recovery closes that issue automatically.

**Release-automation impact:** store builds are deliberately blocked whenever their selected coordinator target returns 404 or remains unreachable. The scheduled check covers every supported deployed environment: POC, staging, and production.

## Deliberately unchanged

This does not alter account-deletion behavior, probe the shared name-server route, generalize into backend uptime monitoring, restore the retired TEST infrastructure, add a warning-only bypass, or replace authenticated end-to-end deletion verification. Removing the stale TEST DNS record remains infrastructure cleanup outside this repository.

## Verification

- `flutter test test/tools/coordinator_route_probe_test.dart` — 28 tests
- `flutter analyze`
- `python3 .github/scripts/tests/test_codemagic_shorebird_config.py` — 32 tests
- `actionlint .github/workflows/coordinator_route_probe.yml`
- `.codex/scripts/test-config.sh`
- Affected Flutter suites — 202 tests
- Live all-environment probe on 2026-08-27 using the exact PR-head release probe:
  - POC: HTTP 401 passed
  - Staging: HTTP 401 passed
  - Production: HTTP 401 passed
- Pre-push analyzer, focused tests, package floors, backend-host guard, and Codemagic group check

Closes #8125
Closes #8137
