### PR TITLE
fix(dm): stop a third party from hiding your own DM thread

### DIFF
--- a/mobile/lib/blocs/dm/conversation_list/conversation_list_bloc.dart
+++ b/mobile/lib/blocs/dm/conversation_list/conversation_list_bloc.dart
@@ -226,11 +226,11 @@ class ConversationListBloc
         // re-exposing yourself.
         //
         // This recovers the viewer's OWN blocks only, not everything the
-        // filter above removed: `shouldFilterFromFeeds` unions five buckets,
-        // and the other four (`_mutedPubkeys`, `_mutualMuteBlocklist`,
-        // `_blockedByOthers`, `_internalBlocklist`) stay hidden. A thread
-        // hidden because the counterparty blocked or muted *us* is still
-        // unreachable — deliberately out of scope, see #7025.
+        // filter above removed: `shouldFilterFromDms` unions three buckets,
+        // and the other two (`_mutedPubkeys`, `_internalBlocklist`) stay
+        // hidden. A thread hidden because the counterparty blocked or muted
+        // *us* no longer reaches this filter at all — that union is feeds-only
+        // now, see #7345.
         final blockedConversations = _computeBlockedConversations(
           userPubkey: userPubkey,
           candidates: [...inboxConversations, ...split.requests],

--- a/mobile/lib/screens/inbox/conversation/conversation_view.dart
+++ b/mobile/lib/screens/inbox/conversation/conversation_view.dart
@@ -135,14 +135,17 @@ class _ConversationViewState extends ConsumerState<ConversationView> {
     final currentPubkey = authService.currentPublicKeyHex ?? '';
 
     // Reactors to hide from the reaction pill + who-reacted sheet: the
-    // repository's canonical feed-hide set (blocked ∪ muted ∪ muted-by ∪
-    // blocked-by), the same union `shouldFilterFromFeeds` enforces app-wide.
+    // repository's DM-hide set (blocked ∪ muted), the same union
+    // `shouldFilterFromDms` enforces across DM surfaces. Deliberately not
+    // `feedHiddenPubkeys`, which also carries muted-by and blocked-by — a
+    // third party must not be able to strip reactions out of the viewer's own
+    // thread by publishing a list (#7345).
     // Watching blocklistVersionProvider rebuilds this view — re-reading the
     // set and re-passing it to every ReactionsRow — on any block/unblock/mute
     // change while the thread is open.
     ref.watch(blocklistVersionProvider);
     final blocklistRepository = ref.read(contentBlocklistRepositoryProvider);
-    final blockedReactors = blocklistRepository.feedHiddenPubkeys;
+    final blockedReactors = blocklistRepository.dmHiddenPubkeys;
 
     // A thread reached from the Blocked chip is readable but not writable:
     // the block stays in force, so the composer and the reaction affordance

--- a/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
+++ b/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
@@ -883,16 +883,32 @@ class ContentBlocklistRepository {
         _runtimeBlocklist.contains(pubkey);
   }
 
+  /// The buckets recording a hide **this account chose**: the operator list,
+  /// our own blocks, and the mutes we authored on our own kind 10000 list
+  /// (possibly from another client).
+  ///
+  /// DM surfaces filter on these alone. A direct message already received is
+  /// the viewer's own copy, and a third party must not be able to remove it
+  /// by publishing a list — see [_hideBuckets] and #7345.
+  late final List<Set<String>> _viewerHideBuckets = [
+    _internalBlocklist,
+    _runtimeBlocklist,
+    _mutedPubkeys,
+  ];
+
   /// The buckets whose union is hidden from feeds, held as live references
   /// to the underlying sets. Every instance is stable for the repository's
   /// lifetime — the `const` internal list plus four `final` sets that are
   /// only ever mutated in place — so both [feedHiddenPubkeys] and
-  /// [shouldFilterFromFeeds] derive from this one list and cannot drift. A
-  /// new hide-bucket is added here exactly once.
+  /// [shouldFilterFromFeeds] derive from this one list and cannot drift.
+  ///
+  /// This is a strict superset of [_viewerHideBuckets]: it adds the two
+  /// buckets fed by *other people's* lists, which suppress our content in
+  /// feeds but must never reach a DM surface. A new bucket is added in
+  /// exactly one place — [_viewerHideBuckets] when the viewer chose the hide
+  /// and it should apply everywhere, here when it is feeds-only.
   late final List<Set<String>> _hideBuckets = [
-    _internalBlocklist,
-    _runtimeBlocklist,
-    _mutedPubkeys,
+    ..._viewerHideBuckets,
     _mutualMuteBlocklist,
     _blockedByOthers,
   ];
@@ -904,10 +920,10 @@ class ContentBlocklistRepository {
   /// - Users who blocked us (kind 30000, d=block) — hides our content
   ///   from their feeds and their content from ours
   ///
-  /// This is the canonical feed-hide set. UI surfaces that need the
-  /// materialized set — e.g. DM reaction filtering in `conversation_view`
-  /// — read this rather than re-deriving the union by hand, so they stay
-  /// in lockstep with [shouldFilterFromFeeds].
+  /// This is the canonical feed-hide set. Feed surfaces that need the
+  /// materialized set read this rather than re-deriving the union by hand,
+  /// so they stay in lockstep with [shouldFilterFromFeeds]. DM surfaces read
+  /// [dmHiddenPubkeys] instead.
   Set<String> get feedHiddenPubkeys => {
     for (final bucket in _hideBuckets) ...bucket,
   };
@@ -922,6 +938,34 @@ class ContentBlocklistRepository {
   bool shouldFilterFromFeeds(String pubkey) {
     for (var i = 0; i < _hideBuckets.length; i++) {
       if (_hideBuckets[i].contains(pubkey)) return true;
+    }
+    return false;
+  }
+
+  /// The union of every pubkey hidden from **DM surfaces**:
+  /// - Users we blocked (internal + runtime blocklist)
+  /// - Users we muted on our own kind 10000 mute list
+  ///
+  /// Deliberately excludes the two buckets fed by other people's lists
+  /// (`_mutualMuteBlocklist`, `_blockedByOthers`). Publishing a kind 10000
+  /// mute or a kind 30000 `d=block` naming the viewer used to remove the
+  /// viewer's own copy of a thread from every DM surface at once, including
+  /// messages already received and stored on the device (#7345).
+  ///
+  /// Counterpart to [feedHiddenPubkeys]; both derive from [_hideBuckets] /
+  /// [_viewerHideBuckets] so the DM set stays a strict subset of the feed set.
+  Set<String> get dmHiddenPubkeys => {
+    for (final bucket in _viewerHideBuckets) ...bucket,
+  };
+
+  /// Whether [pubkey] is in [dmHiddenPubkeys] and so should be filtered from
+  /// DM surfaces.
+  ///
+  /// Same short-circuiting scan as [shouldFilterFromFeeds], over the narrower
+  /// bucket list.
+  bool shouldFilterFromDms(String pubkey) {
+    for (var i = 0; i < _viewerHideBuckets.length; i++) {
+      if (_viewerHideBuckets[i].contains(pubkey)) return true;
     }
     return false;
   }
@@ -1083,6 +1127,10 @@ class ContentBlocklistRepository {
   ///
   /// [userPubkey] is the current user's pubkey, used to identify which
   /// participant is "the other one" in each conversation.
+  ///
+  /// Filters on [shouldFilterFromDms], not [shouldFilterFromFeeds]: a thread
+  /// the viewer already received stays reachable even when the counterparty
+  /// mutes or blocks them (#7345).
   List<DmConversation> filterBlockedConversations(
     List<DmConversation> conversations, {
     required String userPubkey,
@@ -1094,7 +1142,7 @@ class ContentBlocklistRepository {
       );
       // Exclude self-conversations (no "other" participant found).
       if (otherPubkey.isEmpty) return false;
-      return !shouldFilterFromFeeds(otherPubkey);
+      return !shouldFilterFromDms(otherPubkey);
     }).toList();
   }
 

--- a/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
+++ b/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
@@ -4023,7 +4023,7 @@ void main() {
 
     test(
       "the blocker's DM conversation stays visible throughout, because a "
-      'third party cannot hide the viewer\'s own thread (#7345)',
+      "third party cannot hide the viewer's own thread (#7345)",
       () async {
         final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
         final conversations = [
@@ -4069,7 +4069,7 @@ void main() {
           ),
           hasLength(1),
           reason:
-              'being blocked must not remove the viewer\'s own copy of a '
+              "being blocked must not remove the viewer's own copy of a "
               'thread they already received',
         );
 

--- a/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
+++ b/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
@@ -2132,6 +2132,175 @@ void main() {
     );
   });
 
+  group('shouldFilterFromDms', () {
+    const ourPubkey =
+        '0000000000000000000000000000000000000000000000000000000000000001';
+    const runtimeBlocked =
+        '0000000000000000000000000000000000000000000000000000000000000002';
+    const mutedByUs =
+        '0000000000000000000000000000000000000000000000000000000000000003';
+    const mutualMuter =
+        '0000000000000000000000000000000000000000000000000000000000000004';
+    const blockedByOther =
+        '0000000000000000000000000000000000000000000000000000000000000005';
+    const stranger =
+        '0000000000000000000000000000000000000000000000000000000000000006';
+
+    DmConversation conversationWith(String otherPubkey) => DmConversation(
+      id: 'conv-$otherPubkey',
+      participantPubkeys: [ourPubkey, otherPubkey],
+      isGroup: false,
+      createdAt: 1,
+    );
+
+    test('is empty when no hide bucket is populated', () {
+      expect(ContentBlocklistRepository().dmHiddenPubkeys, isEmpty);
+    });
+
+    test('keeps a DM thread when the counterparty mutes or blocks us, and '
+        'still hides the ones we hid ourselves', () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+      final prefs = await SharedPreferences.getInstance();
+      final service = ContentBlocklistRepository(prefs: prefs);
+
+      final muteController = StreamController<Event>();
+      final blockController = StreamController<Event>();
+      final mockMuteClient = _MockNostrClient();
+      final mockBlockClient = _MockNostrClient();
+      final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+
+      await service.blockUser(runtimeBlocked, ourPubkey: ourPubkey);
+
+      when(
+        () => mockMuteClient.subscribe(any()),
+      ).thenAnswer((_) => muteController.stream);
+      await service.syncMuteListsInBackground(mockMuteClient, ourPubkey);
+      muteController
+        ..add(
+          Event(
+              ourPubkey,
+              10000,
+              [
+                ['p', mutedByUs],
+              ],
+              '',
+              createdAt: now,
+            )
+            ..id = 'own-mute'
+            ..sig = 'sig',
+        )
+        ..add(
+          Event(
+              mutualMuter,
+              10000,
+              [
+                ['p', ourPubkey],
+              ],
+              '',
+              createdAt: now,
+            )
+            ..id = 'mutual-mute'
+            ..sig = 'sig',
+        );
+
+      final mockSigner = _MockBlockListSigner();
+      when(() => mockSigner.isAuthenticated).thenReturn(false);
+      when(
+        () => mockBlockClient.subscribe(any()),
+      ).thenAnswer((_) => blockController.stream);
+      await service.syncBlockListsInBackground(
+        mockBlockClient,
+        mockSigner,
+        ourPubkey,
+      );
+      blockController.add(
+        Event(
+            blockedByOther,
+            30000,
+            [
+              ['d', 'block'],
+              ['p', ourPubkey],
+            ],
+            'Block list',
+            createdAt: now,
+          )
+          ..id = 'blocked-by'
+          ..sig = 'sig',
+      );
+
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+
+      // Precondition: all four buckets really are populated, so the
+      // assertions below cannot pass vacuously.
+      expect(
+        service.feedHiddenPubkeys,
+        containsAll(<String>{
+          runtimeBlocked,
+          mutedByUs,
+          mutualMuter,
+          blockedByOther,
+        }),
+      );
+
+      // The regression (#7345): a third party's list must not reach a DM
+      // surface, whether asked as a predicate, a set, or a conversation
+      // filter.
+      for (final pubkey in <String>{mutualMuter, blockedByOther}) {
+        expect(service.shouldFilterFromDms(pubkey), isFalse);
+        expect(service.dmHiddenPubkeys, isNot(contains(pubkey)));
+      }
+      expect(
+        service.filterBlockedConversations([
+          conversationWith(mutualMuter),
+          conversationWith(blockedByOther),
+        ], userPubkey: ourPubkey),
+        hasLength(2),
+      );
+
+      // The viewer's own decisions still hide, so this is not a blanket
+      // removal of DM filtering.
+      for (final pubkey in <String>{runtimeBlocked, mutedByUs}) {
+        expect(service.shouldFilterFromDms(pubkey), isTrue);
+        expect(service.dmHiddenPubkeys, contains(pubkey));
+      }
+      expect(
+        service.filterBlockedConversations([
+          conversationWith(runtimeBlocked),
+          conversationWith(mutedByUs),
+        ], userPubkey: ourPubkey),
+        isEmpty,
+      );
+
+      expect(service.shouldFilterFromDms(stranger), isFalse);
+
+      // The set and the predicate must agree for every pubkey, so a future
+      // bucket added to one cannot silently diverge from the other.
+      for (final pubkey in <String>{
+        runtimeBlocked,
+        mutedByUs,
+        mutualMuter,
+        blockedByOther,
+        stranger,
+      }) {
+        expect(
+          service.dmHiddenPubkeys.contains(pubkey),
+          equals(service.shouldFilterFromDms(pubkey)),
+          reason:
+              'dmHiddenPubkeys and shouldFilterFromDms '
+              'disagree for $pubkey',
+        );
+      }
+
+      // DM hiding is a strict subset of feed hiding: a bucket added to the
+      // viewer list reaches both, and one added to the feed list reaches
+      // only feeds.
+      expect(service.feedHiddenPubkeys, containsAll(service.dmHiddenPubkeys));
+
+      await muteController.close();
+      await blockController.close();
+    });
+  });
+
   group('blockedPubkeysForAccount', () {
     const ourPubkey =
         '0000000000000000000000000000000000000000000000000000000000000001';
@@ -3853,7 +4022,8 @@ void main() {
     );
 
     test(
-      "the blocker's DM conversation reappears once the block is lifted",
+      "the blocker's DM conversation stays visible throughout, because a "
+      'third party cannot hide the viewer\'s own thread (#7345)',
       () async {
         final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
         final conversations = [
@@ -3883,13 +4053,24 @@ void main() {
         );
         await pumpEventQueue();
 
+        // Precondition: the block really did land, so the assertion below
+        // cannot pass just because the bucket stayed empty.
+        expect(service.hasBlockedUs(blockerPubkey), isTrue);
+        expect(
+          service.shouldFilterFromFeeds(blockerPubkey),
+          isTrue,
+          reason: 'feeds still honour a third-party block',
+        );
+
         expect(
           service.filterBlockedConversations(
             conversations,
             userPubkey: ourPubkey,
           ),
-          isEmpty,
-          reason: 'while blocked, the conversation is hidden',
+          hasLength(1),
+          reason:
+              'being blocked must not remove the viewer\'s own copy of a '
+              'thread they already received',
         );
 
         relay.publish(
@@ -3904,13 +4085,14 @@ void main() {
         );
         await pumpEventQueue();
 
+        expect(service.hasBlockedUs(blockerPubkey), isFalse);
         expect(
           service.filterBlockedConversations(
             conversations,
             userPubkey: ourPubkey,
           ),
           hasLength(1),
-          reason: 'the lifted block must un-hide the DM conversation',
+          reason: 'and the lift does not change the DM surface either',
         );
       },
     );

--- a/mobile/test/screens/inbox/conversation/conversation_view_test.dart
+++ b/mobile/test/screens/inbox/conversation/conversation_view_test.dart
@@ -149,7 +149,7 @@ void main() {
       mockBlocklist = _MockContentBlocklistRepository();
       // Default: nobody blocked. Reaction-filtering tests re-stub this.
       when(
-        () => mockBlocklist.feedHiddenPubkeys,
+        () => mockBlocklist.dmHiddenPubkeys,
       ).thenReturn(const <String>{});
       when(() => mockBlocklist.isBlocked(any())).thenReturn(false);
 
@@ -2515,8 +2515,9 @@ void main() {
         );
       }
 
-      // The flat feed-hide set the view now reads from the repository
-      // (`feedHiddenPubkeys`), which is itself the union of these buckets.
+      // The flat DM-hide set the view reads from the repository
+      // (`dmHiddenPubkeys`) — the viewer's own blocks and mutes only. A
+      // third party's list must not reach a DM surface (#7345).
       Set<String> hiddenReactors({
         Set<String> blocked = const {},
         Set<String> muted = const {},
@@ -2552,7 +2553,7 @@ void main() {
             createdAt: 1_700_000_003,
           ),
         ]);
-        when(() => mockBlocklist.feedHiddenPubkeys).thenReturn(
+        when(() => mockBlocklist.dmHiddenPubkeys).thenReturn(
           hiddenReactors(blocked: {blockedReactor}, muted: {mutedReactor}),
         );
 
@@ -2573,7 +2574,7 @@ void main() {
           reaction(id: 'r-blk', reactor: blockedReactor, emoji: '😂'),
         ]);
         when(
-          () => mockBlocklist.feedHiddenPubkeys,
+          () => mockBlocklist.dmHiddenPubkeys,
         ).thenReturn(hiddenReactors(blocked: {blockedReactor}));
 
         await tester.pumpWidget(loadedWithReactedMessage());
@@ -2597,7 +2598,7 @@ void main() {
           ),
         ]);
         when(
-          () => mockBlocklist.feedHiddenPubkeys,
+          () => mockBlocklist.dmHiddenPubkeys,
         ).thenReturn(hiddenReactors(blocked: {blockedReactor}));
 
         await tester.pumpWidget(loadedWithReactedMessage());
@@ -2622,7 +2623,7 @@ void main() {
         tester,
       ) async {
         var hidden = <String>{};
-        when(() => mockBlocklist.feedHiddenPubkeys).thenAnswer((_) => hidden);
+        when(() => mockBlocklist.dmHiddenPubkeys).thenAnswer((_) => hidden);
         primeReactions([
           reaction(id: 'r-own', reactor: currentPubkey, emoji: '🔥'),
           reaction(


### PR DESCRIPTION
Closes #7345

## What

The Messages list, both DM unread badges, and the in-thread reaction pills filtered on `shouldFilterFromFeeds`, whose union carries two buckets that record **other people's** decisions: `_mutualMuteBlocklist` (someone published a kind 10000 mute naming us) and `_blockedByOthers` (a kind 30000 `d=block` naming us). Publishing either removed the viewer's existing DM thread — including messages already received and stored on the device — from every surface that lists conversations, with no entry under the Blocked chip, which is seeded only from the viewer's own runtime blocks.

DM surfaces now filter on a new `shouldFilterFromDms` / `dmHiddenPubkeys`, which union only the hides this account chose.

Closes the behaviour half of #7345.

## Why this shape

`_viewerHideBuckets` holds the viewer's own hides; `_hideBuckets` stays a strict superset by spreading it and appending the two third-party buckets. Feeds are byte-for-byte unchanged, and a new bucket still has exactly one place to go — `_viewerHideBuckets` if the viewer chose the hide, `_hideBuckets` if it is feeds-only.

Both consumers had to move, not just the predicate: `filterBlockedConversations` covers the list and both badges, and `conversation_view.dart:145` reads the materialized set for reaction pills. A predicate-only change would have left reactions filtered by the contaminated union.

## The decision behind it

The trigger is not exotic. `blockUsers` publishes every blocked pubkey as a **public `p` tag** on our own kind 10000 mute list, and divine-web does the same, so ordinary Divine-to-Divine blocking fires this continuously — not just a third party in another client.

That made it a Trust & Safety call rather than a mechanical fix, and it was taken on the issue: the thread stays. Two consequences were decided explicitly there:

- **Blocking someone still hides their thread.** `_runtimeBlocklist` stays in the DM predicate, so the blocker's own safety property is unchanged.
- **The composer is deliberately untouched.** Disabling it for a blocked party would tell them they had been blocked.

## Verification

**End to end through the local Docker stack.** Brought up the `local_stack` relay chain
(`docker compose up -d funnelcake-relay funnelcake-proxy` — `up.sh` still dies on arm64),
ran the app on an iOS Simulator with `--dart-define=DEFAULT_ENV=LOCAL` so it connects to
`ws://localhost:47777`, then published third-party lists with `nak`. Both were delivered to
the app's live `#p` subscription by the relay — no test injection anywhere in the path:

```
Added mutual mute:      npub1q9rysxz… (kind 10000, #p = us)
Detected block from user: npub1wmugkf6… (kind 30000, d=block, #p = us)
```

Measured against that live state:

| party | delivered by | shouldFilterFromFeeds | shouldFilterFromDms | conversation |
|---|---|---|---|---|
| muted us (kind 10000) | Docker relay | `true` | `false` | **KEPT** |
| blocked us (kind 30000 `d=block`) | Docker relay | `true` | `false` | **KEPT** |
| our own block (`blockUser`) | local action | `true` | `true` | **HIDDEN** |

So third-party lists no longer reach a DM surface, the viewer's own block still hides, and
feeds are unchanged in all three cases. `feedHiddenPubkeys` = 1 / `dmHiddenPubkeys` = 0 while
only the mute was present.

The own-block row also excludes a hazard this diff could have introduced: `_hideBuckets`
spreads `_viewerHideBuckets`, which copies the *list*, and the class doc depends on the
buckets being live references. `blockUser()` mutated `_runtimeBlocklist` long after both
`late final` lists were built, and both predicates saw it immediately — the sets are shared,
only the list is copied.

**On a physical iPhone**, same branch against production: 8 real conversations, and with a
third-party mute active for one counterparty the composed `filterBlockedConversations` call
returns **KEPT** (`feeds=true dms=false`). Pre-fix, the same measurement took the visible
inbox from 6 to 5 with the Blocked chip still at 0. The device cannot use `local_stack` —
`localHost` resolves to loopback, which on a device is the phone itself, and ATS permits
cleartext only to loopback — so the relay-delivered half was done on the Simulator.

**Coverage sweep.** All ten remaining callers of `shouldFilterFromFeeds` /
`feedHiddenPubkeys` / `filterContent` are video or badge surfaces (`BadgeRepository`,
`video_event_service`, the profile feeds, `UserPickerSheet` for badge award / collaborators /
people lists). No DM surface is left on the feeds predicate.

**Suites.** `content_blocklist_repository` 130 green; `test/blocs/dm/` + `test/screens/inbox/`
816 green; `flutter analyze lib test integration_test` clean; package-scoped
`flutter analyze lib test` clean. Mutation-checked: re-adding the two buckets to
`_viewerHideBuckets` turns the new group red.

Nothing was published to any production relay during validation — the Simulator wrote only to
the local Docker relay, and the device run injected client-side handlers that publish nothing.

## Test changes worth reviewing

One existing test — *"the blocker's DM conversation reappears once the block is lifted"* — asserted `isEmpty` while blocked-by, which is precisely the behaviour this PR removes. It is rewritten to pin the new contract (visible throughout, `hasBlockedUs` still tracking correctly), with a precondition assertion so it cannot pass vacuously. Its sibling above it still proves the by-author watch delivers the lift.

`conversation_view_test.dart` stubs moved from `feedHiddenPubkeys` to `dmHiddenPubkeys`; the helper there already composed only blocked ∪ muted, so intent is unchanged.

## Not in this PR

Two findings from the same device session, both filed separately rather than folded in:

1. **Blocks and unblocks publish fire-and-forget.** `_publishMuteListToNostr` uses `publishEvent` (`PublishSuccess` = "broadcast to at least one relay") rather than the sibling `publishEventAwaitOk`, and `unblockUser` discards the result. Observed live: an unblock reported success, cleared local state, and reached no relay; a retry landed. That is #7027 territory and needs its own fix.
2. **`_mutedPubkeys` has no undo inside Divine.** The app has no mute action at all, so a mute authored in another client hides the thread with no chip entry and no in-app way to reverse it. Left as-is here because the T&S decision named only the two third-party buckets.

