### PR TITLE
fix(a11y): name the feed description's tappable node

### DIFF
--- a/mobile/lib/widgets/video_feed_item/video_feed_item.dart
+++ b/mobile/lib/widgets/video_feed_item/video_feed_item.dart
@@ -158,6 +158,16 @@ class VideoOverlayActions extends ConsumerWidget {
     final hasTextContent =
         descriptionText.isNotEmpty || (titleText?.isNotEmpty ?? false);
 
+    // Shared by the title and the description, and on the description it is
+    // attached twice: once to the semantics node that carries the label, once
+    // to the detector that takes the real pointer.
+    final openMetadata = video == null
+        ? null
+        : () {
+            onInteracted?.call();
+            MetadataExpandedSheet.show(context, video);
+          };
+
     // In fullscreen mode, ensure badges clear the status bar icons
     // (battery, wifi, clock). viewPaddingOf may return 0 if a parent
     // widget (Scaffold, SafeArea) has already consumed the safe area.
@@ -470,12 +480,7 @@ class VideoOverlayActions extends ConsumerWidget {
                       label: context.l10n.videoOverlayOpenMetadataFromTitle,
                       child: GestureDetector(
                         behavior: HitTestBehavior.opaque,
-                        onTap: video == null
-                            ? null
-                            : () {
-                                onInteracted?.call();
-                                MetadataExpandedSheet.show(context, video);
-                              },
+                        onTap: openMetadata,
                         child: DivineHeartText(
                           titleText,
                           style: VineTheme.labelMediumFont(
@@ -500,14 +505,19 @@ class VideoOverlayActions extends ConsumerWidget {
                       button: true,
                       label:
                           context.l10n.videoOverlayOpenMetadataFromDescription,
+                      // The action belongs on the node that carries the label.
+                      // On the detector below it landed on an anonymous child:
+                      // `LinkifiedText` splits into several spans once the text
+                      // holds a hashtag, mention or URL, and then nothing merges
+                      // up to name the tappable node. Plain text merges and
+                      // passes, so this was data-dependent, not layout-dependent.
+                      onTap: openMetadata,
                       child: GestureDetector(
                         behavior: HitTestBehavior.opaque,
-                        onTap: video == null
-                            ? null
-                            : () {
-                                onInteracted?.call();
-                                MetadataExpandedSheet.show(context, video);
-                              },
+                        // Excluded so it cannot re-create the anonymous node
+                        // the annotation above exists to name.
+                        excludeFromSemantics: true,
+                        onTap: openMetadata,
                         child: LinkifiedText(
                           text: descriptionText,
                           style: VineTheme.bodySmallFont(

--- a/mobile/test/widgets/video_feed_item/video_description_label_test.dart
+++ b/mobile/test/widgets/video_feed_item/video_description_label_test.dart
@@ -1,0 +1,131 @@
+// ABOUTME: The feed description's tappable node must carry its own label.
+// ABOUTME: It lost it whenever the text held a hashtag, mention or URL, because
+// ABOUTME: LinkifiedText then splits and nothing merges up to name the node.
+
+import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:follow_repository/follow_repository.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/blocs/video_interactions/video_interactions_bloc.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/widgets/video_feed_item/video_feed_item.dart';
+import 'package:reposts_repository/reposts_repository.dart';
+
+import '../../builders/test_video_event_builder.dart';
+import '../../helpers/test_provider_overrides.dart';
+
+class _MockVideoInteractionsBloc extends Mock
+    implements VideoInteractionsBloc {}
+
+class _MockRepostsRepository extends Mock implements RepostsRepository {}
+
+void main() {
+  group('video description semantics', () {
+    late _MockVideoInteractionsBloc interactions;
+    late _MockRepostsRepository reposts;
+
+    setUp(() {
+      interactions = _MockVideoInteractionsBloc();
+      reposts = _MockRepostsRepository();
+      when(() => interactions.stream).thenAnswer((_) => const Stream.empty());
+      when(
+        () => interactions.state,
+      ).thenReturn(const VideoInteractionsState());
+      when(
+        () => reposts.fetchEventReposters(
+          eventId: any(named: 'eventId'),
+          addressableId: any(named: 'addressableId'),
+        ),
+      ).thenAnswer((_) async => const <String>[]);
+    });
+
+    Future<void> pump(WidgetTester tester, String description) async {
+      final follow = createMockFollowRepository();
+      when(() => follow.isFollowing(any())).thenReturn(true);
+      when(follow.watchMyFollowingCached).thenAnswer(
+        (_) => Stream.value(
+          const CacheResult<FollowingSnapshot>.live(
+            FollowingSnapshot(pubkeys: <String>[], count: 0),
+          ),
+        ),
+      );
+
+      await tester.pumpWidget(
+        testProviderScope(
+          additionalOverrides: <dynamic>[
+            repostsRepositoryProvider.overrideWithValue(reposts),
+          ],
+          mockFollowRepository: follow,
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: BlocProvider<VideoInteractionsBloc>.value(
+                value: interactions,
+                child: VideoOverlayActions(
+                  video: TestVideoEventBuilder.create(content: description),
+                  isVisible: true,
+                  isActive: true,
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump();
+    }
+
+    Finder descriptionNode() => find.byWidgetPredicate(
+      (widget) =>
+          widget is Semantics &&
+          widget.properties.identifier == 'video_description',
+    );
+
+    testWidgets('a linkified description still names its tappable node', (
+      tester,
+    ) async {
+      final handle = tester.ensureSemantics();
+      // A hashtag is the common case on this app, and it is exactly what broke
+      // it: LinkifiedText emits several spans, so the description text no
+      // longer merges into the gesture node the way a plain title does.
+      await pump(tester, 'And a #PuffPuffPost from the feed');
+
+      // The guideline is what caught this on device. It fails if the detector
+      // is allowed to publish its own anonymous tappable node again.
+      await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
+
+      // ...and the label has to sit on the node that owns the action, not on a
+      // silent parent. Asserted directly, because the guideline alone still
+      // passes if the description stops being tappable at all.
+      final node = tester.getSemantics(descriptionNode());
+      expect(node.label, isNotEmpty);
+      expect(
+        node.getSemanticsData().hasAction(SemanticsAction.tap),
+        isTrue,
+        reason: 'the labelled node must be the one that opens the sheet',
+      );
+      handle.dispose();
+    });
+
+    testWidgets('a link-free description is labelled too', (tester) async {
+      final handle = tester.ensureSemantics();
+      // The control. This case passed even before the fix — which is why the
+      // bug survived: it is data-dependent, so a fixture without a link
+      // reports the feature working.
+      await pump(tester, 'No links in this description at all');
+
+      await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
+      final node = tester.getSemantics(descriptionNode());
+      expect(node.label, isNotEmpty);
+      expect(
+        node.getSemanticsData().hasAction(SemanticsAction.tap),
+        isTrue,
+      );
+      handle.dispose();
+    });
+  });
+}


### PR DESCRIPTION
Closes #8103

Found while patrolling #8103 on an iPhone 17 Pro Max / iOS 26.6.1. Independent
of #8102 — different widget, pre-existing on `main`, and it carries no visual
change, so it does not need to wait on that PR's open design question.

## The defect

The description's tap action sat on a `GestureDetector` *below* the `Semantics`
that carries its label, so the label and the action lived on two different
nodes. Live feed, description reading `And a #PuffPuffPost 😄😎`:

```
SemanticsNode#15  identifier: "video_description"
                  label: "Open video details"  flags: isButton   <- no tap action
 └─ SemanticsNode#16  Rect(0,0,319.2,19)  actions: [tap]         <- no label at all
     ├─ #18 "And a "   ├─ #19 isLink "#PuffPuffPost"   ├─ #20 " 😄😎"
```

`SemanticsNode#16` fails `labeledTapTargetGuideline`. A screen-reader user
reaches the node that opens the sheet and it announces nothing.

## Why it hid

It is **data-dependent, not layout-dependent**. `LinkifiedText` emits a single
span for plain text, which merges up and hands the gesture node a label; it
emits several spans as soon as the text holds a hashtag, mention or URL, and
then nothing merges. So the defect only appears on descriptions that contain a
link — which on this app is most of them.

| description | `labeledTapTargetGuideline` |
|---|---|
| `Test video content #test` | **FAIL** |
| `Test video content plain` | PASS |

That is also why the neighbouring title is fine: it renders `DivineHeartText`,
one span, always merges.

## The fix

Move the action onto the labelled node and exclude the detector, so the label
and the action are the same node. The hashtag keeps its own tap action and
label, so link navigation is unchanged — that was the risk, and it is the
reason this is not a `MergeSemantics`.

Verified on device after the fix, on a `#DivineTravels` description:

```
SemanticsNode#71  Rect(16,800,199.6,818)  actions: tap  flags: isButton
                  identifier: "video_description"  label: "Open video details"
 └─ SemanticsNode#73  actions: tap  flags: isLink  label: "#DivineTravels"
```

Both on one node, and a whole-item sweep reports **zero** unlabeled tappable
nodes.

## Tests

`video_description_label_test.dart` pumps the linkified case and asserts the
guideline **and** that the labelled node is the one carrying the tap — the
guideline alone still passes if the description stops being tappable at all.
Both mutations were checked and turn it red:

- dropping `excludeFromSemantics` → 3 failures
- dropping `onTap` from the labelled node → fails on the tap assertion

The link-free case is kept as a control, since it passed before the fix and is
what made the bug invisible.

## Not fixed here

The description is still a 319.2x19 tap target, under both platform minimums.
That is caption sizing, which is the open design question on #8102, and it is
deliberately left alone.

**Gates:** `flutter analyze lib test integration_test` clean; `flutter test
test/widgets/video_feed_item/` 400 pass; format clean.
