### PR TITLE
chore: remove unused video-feed code

### DIFF
--- a/mobile/lib/widgets/video_feed_item/video_feed_item.dart
+++ b/mobile/lib/widgets/video_feed_item/video_feed_item.dart
@@ -31,7 +31,6 @@ import 'package:openvine/widgets/og_viner_badge.dart';
 import 'package:openvine/widgets/profile_badge_explanation_sheet.dart';
 import 'package:openvine/widgets/special_profile_checkmark.dart';
 import 'package:openvine/widgets/user_avatar.dart';
-import 'package:openvine/widgets/user_name.dart';
 import 'package:openvine/widgets/video_feed_item/actions/actions.dart';
 import 'package:openvine/widgets/video_feed_item/audio_attribution_row.dart';
 import 'package:openvine/widgets/video_feed_item/collaborator_avatar_row.dart';
@@ -739,78 +738,6 @@ class VideoOverlayActionColumn extends ConsumerWidget {
           MoreActionButton(video: video, onInteracted: onInteracted),
         ],
       ),
-    );
-  }
-}
-
-/// Username and follow button row for video overlay.
-///
-/// Displays the video author's name (tappable to go to profile) and a follow button.
-class VideoAuthorRow extends ConsumerWidget {
-  const VideoAuthorRow({
-    required this.video,
-    super.key,
-    this.isFullscreen = false,
-  });
-
-  final VideoEvent video;
-  final bool isFullscreen;
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    // Profile is unused here (UserName.fromPubKey handles display),
-    // but watching ensures the widget rebuilds when profile data arrives.
-    ref.watch(userProfileReactiveProvider(video.pubkey));
-
-    return Row(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        // Username chip (tappable to go to profile)
-        GestureDetector(
-          onTap: () {
-            Log.info(
-              '👤 User tapped profile: videoId=${video.id}, authorPubkey=${pubkeyForLogs(video.pubkey)}',
-              name: 'VideoFeedItem',
-              category: LogCategory.ui,
-            );
-            // Push other user's profile (fullscreen, no bottom nav)
-            final npub = normalizeToNpub(video.pubkey);
-            if (npub != null) {
-              context.push(OtherProfileScreen.pathForNpub(npub));
-            }
-          },
-          child: Container(
-            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
-            decoration: BoxDecoration(
-              color: VineTheme.backgroundColor.withValues(alpha: 0.5),
-              borderRadius: BorderRadius.circular(16),
-            ),
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                const DivineIcon(
-                  icon: DivineIconName.user,
-                  size: 14,
-                  color: VineTheme.whiteText,
-                ),
-                const SizedBox(width: 6),
-                UserName.fromPubKey(
-                  video.pubkey,
-                  embeddedName: video.displayAuthorName,
-                  style: const TextStyle(
-                    color: VineTheme.whiteText,
-                    fontSize: 12,
-                  ),
-                  overflow: TextOverflow.ellipsis,
-                ),
-              ],
-            ),
-          ),
-        ),
-        // Follow button (handles own video check internally)
-        const SizedBox(width: 8),
-        VideoFollowButton(pubkey: video.pubkey),
-      ],
     );
   }
 }


### PR DESCRIPTION
Closes #8150

`VideoAuthorRow` has had **no caller anywhere in the repo** since #811 (2026-01-19), which replaced it — its own commit message says "Replace VideoAuthorRow with inline avatar design (48px with white border)" — and deleted the only call site while leaving the class behind. 117 commits have carried it through `video_feed_item.dart` since.

Call-site count over time: **2** before #811 (declaration + one use) → **1** after → **1** today.

## Why bother

A public widget nothing builds still absorbs every change made to what it composes. It renders `VideoFollowButton` as a bare `Row` child, so the 48dp tap-target work on #8102 would silently hand it a **79dp** footprint that no test and no screen would ever surface. Dead code that quietly tracks live changes is the kind that gets revived years later carrying a bug nobody wrote on purpose.

## On the merge plan that says "keep" it

`mobile/docs/plans/2026-01-09-merge-theming-d0.1-into-main.md` line 115 says *"Keep main's structure (VideoAuthorRow, ...)"*. That file is marked **`Status: Historical`**, and it is the merge plan **for #811 itself** — the shipped commit went the other way. Its step 6 (pass `hideIfFollowing` through `VideoAuthorRow`) never landed either: neither `hideIfFollowing` nor `hideFollowButtonIfFollowing` exists anywhere in `mobile/lib` today, and the same product behaviour is achieved by `VideoFollowButtonView` returning `SizedBox.shrink()` when already following.

## Scope

73 deletions, zero additions. The class, plus the `user_name.dart` import it stranded — `UserName` had no other use in the file.

**Gates:** `flutter analyze lib test integration_test` clean; `flutter test test/widgets/video_feed_item/` 398 pass; format clean.