### PR TITLE
fix(a11y): give the feed's author row and player surface real tap targets

### DIFF
--- a/mobile/lib/widgets/video_feed_item/feed_videos.dart
+++ b/mobile/lib/widgets/video_feed_item/feed_videos.dart
@@ -19,7 +19,6 @@ import 'package:openvine/constants/app_constants.dart';
 import 'package:openvine/extensions/video_event_extensions.dart';
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
 import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
-import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/models/view_traffic_source.dart'
     show ViewTrafficSource;
 import 'package:openvine/providers/app_foreground_provider.dart';
@@ -45,6 +44,7 @@ import 'package:openvine/widgets/video_feed_item/double_tap_like_helpers.dart';
 import 'package:openvine/widgets/video_feed_item/feed_immersive_chrome.dart';
 import 'package:openvine/widgets/video_feed_item/moderated_content_overlay.dart';
 import 'package:openvine/widgets/video_feed_item/paused_video_overlay.dart';
+import 'package:openvine/widgets/video_feed_item/player_gesture_surface.dart';
 import 'package:openvine/widgets/video_feed_item/player_tap_helpers.dart';
 import 'package:openvine/widgets/video_feed_item/subtitle_overlay.dart';
 import 'package:openvine/widgets/video_feed_item/verifying_aware_video_error_overlay.dart';
@@ -1015,133 +1015,109 @@ class __OverlayState extends ConsumerState<_Overlay> {
             child: VideoInteractionsRestrictionListener(
               child: Builder(
                 builder: (context) {
-                  return Semantics(
-                    button: true,
-                    label: context.l10n.videoPlayerPlayVideo,
-                    hint: isOwnVideo ? null : context.l10n.videoPlayerTapHint,
-                    // The chrome layers are SIBLINGS above the gesture surface,
-                    // never descendants of it. As descendants, any press held
-                    // past `kLongPressTimeout` anywhere on the action rail was
-                    // claimed by the video's long-press: the rail's own tap
-                    // recognizer only accepts on pointer-up, so it lost the
-                    // arena, and Report/More/Share swallowed the tap and faded
-                    // out under the viewer's finger. Keeping them siblings lets
-                    // an opaque button win the hit test outright, so the peek
-                    // never sees that pointer.
-                    child: Stack(
-                      children: [
-                        // The raw [Listener] owns immersive mode's release: it
-                        // counts the pointers over the item and exits once the
-                        // last lifts. `onLongPressEnd` alone would not do —
-                        // it does not fire for a pointer cancelled after the
-                        // press was accepted (`onLongPressCancel` does), and
-                        // neither callback can tell an incidental second finger
-                        // lifting from the hold finger lifting. A Listener also
-                        // sits outside the gesture arena, so it can't steal the
-                        // press.
-                        Positioned.fill(
-                          child: Listener(
-                            // Must match the translucent child below: with
-                            // `deferToChild` a press on empty video area never
-                            // adds this Listener to the hit-test path (the
-                            // translucent GestureDetector adds itself but still
-                            // reports a miss), so the pointer events would never
-                            // arrive.
-                            behavior: HitTestBehavior.translucent,
-                            onPointerDown: (event) {
-                              // An empty set means nothing is down, so any hold
-                              // this item still believes it owns is stale — its
-                              // terminal event was lost (a touch dropped on
-                              // backgrounding, a platform view taking over).
-                              // Without this the item could never peek again.
-                              if (_immersivePointers.isEmpty) _exitImmersive();
-                              _immersivePointers.add(event.pointer);
-                            },
-                            onPointerUp: (event) =>
-                                _handleImmersivePointerEnd(event.pointer),
-                            onPointerCancel: (event) =>
-                                _handleImmersivePointerEnd(event.pointer),
-                            child: GestureDetector(
-                              behavior: .translucent,
-                              onTap: interactiveReady ? _handlePlayerTap : null,
-                              onDoubleTapDown: interactiveReady
-                                  ? (details) => _handleDoubleTapLike(
-                                      context,
-                                      details,
-                                      isOwnVideo: isOwnVideo,
-                                    )
-                                  : null,
-                              child: GestureDetector(
-                                behavior: .translucent,
-                                // Press and hold to peek at the unobstructed
-                                // frame. Deliberately not gated on
-                                // [interactiveReady] the way tap and double-tap
-                                // are: those mutate the player or publish a
-                                // like, while this only hides chrome, which is
-                                // just as valid over a still-loading frame.
-                                //
-                                // Excluded from semantics, and kept on its own
-                                // detector so the tap action above still is
-                                // published. A `GestureDetector` publishes
-                                // `SemanticsAction.longPress` for ANY long-press
-                                // callback, `onLongPressStart` included — and
-                                // firing that action delivers no pointer events,
-                                // so the release path below would never run and
-                                // a screen-reader user would be left with every
-                                // control hidden and pointer-blocked until the
-                                // item was disposed.
-                                excludeFromSemantics: true,
-                                onLongPressStart: (_) => _enterImmersive(),
-                                child: const SizedBox.expand(),
-                              ),
-                            ),
-                          ),
-                        ),
-                        if (widget.controller != null)
-                          // The paused play indicator is chrome too — it
-                          // covers the frame the peek is meant to reveal,
-                          // and holding never resumes playback, so leaving
-                          // it up would contradict the gesture.
-                          FeedImmersiveChrome(
-                            child: PausedVideoOverlay(
-                              controller: widget.controller!,
-                              videoId: video.id,
-                              // Only a pause the user can undo gets the
-                              // affordance. A comments/share sheet, a pushed
-                              // route or a backgrounded app pauses the player
-                              // too, but resumes it on its own — showing a play
-                              // button behind the sheet just reads as broken.
-                              isVisible: widget.isActive && widget.isFeedActive,
-                            ),
-                          ),
-                        FeedImmersiveChrome(
-                          child: _FeedItemActions(
-                            video: video,
-                            index: widget.index,
-                            contextTitle: widget.contextTitle,
+                  // The chrome layers are SIBLINGS above the gesture surface,
+                  // never descendants of it. As descendants, any press held
+                  // past `kLongPressTimeout` anywhere on the action rail was
+                  // claimed by the video's long-press: the rail's own tap
+                  // recognizer only accepts on pointer-up, so it lost the
+                  // arena, and Report/More/Share swallowed the tap and faded
+                  // out under the viewer's finger. Keeping them siblings lets
+                  // an opaque button win the hit test outright, so the peek
+                  // never sees that pointer.
+                  //
+                  // The player's label and hint live on the gesture surface
+                  // below, not on a wrapper here: a node with no tap action
+                  // cannot name the one a screen reader activates.
+                  return Stack(
+                    children: [
+                      // The raw [Listener] owns immersive mode's release: it
+                      // counts the pointers over the item and exits once the
+                      // last lifts. `onLongPressEnd` alone would not do —
+                      // it does not fire for a pointer cancelled after the
+                      // press was accepted (`onLongPressCancel` does), and
+                      // neither callback can tell an incidental second finger
+                      // lifting from the hold finger lifting. A Listener also
+                      // sits outside the gesture arena, so it can't steal the
+                      // press.
+                      Positioned.fill(
+                        child: Listener(
+                          // Must match the translucent child below: with
+                          // `deferToChild` a press on empty video area never
+                          // adds this Listener to the hit-test path (the
+                          // translucent GestureDetector adds itself but still
+                          // reports a miss), so the pointer events would never
+                          // arrive.
+                          behavior: HitTestBehavior.translucent,
+                          onPointerDown: (event) {
+                            // An empty set means nothing is down, so any hold
+                            // this item still believes it owns is stale — its
+                            // terminal event was lost (a touch dropped on
+                            // backgrounding, a platform view taking over).
+                            // Without this the item could never peek again.
+                            if (_immersivePointers.isEmpty) _exitImmersive();
+                            _immersivePointers.add(event.pointer);
+                          },
+                          onPointerUp: (event) =>
+                              _handleImmersivePointerEnd(event.pointer),
+                          onPointerCancel: (event) =>
+                              _handleImmersivePointerEnd(event.pointer),
+                          child: PlayerGestureSurface(
+                            interactiveReady: interactiveReady,
                             isOwnVideo: isOwnVideo,
-                            onSuppressAutoAdvance: widget.onSuppressAutoAdvance,
-                            // Captions fade with the rest of the chrome, by
-                            // design: the hold reveals the frame the UI covers,
-                            // and the caption is an overlay over that same frame,
-                            // so keeping it up would re-cover exactly what the
-                            // peek exposes. It is gone only while the viewer
-                            // holds, and returns the instant they release.
-                            subtitleLayer:
-                                video.hasSubtitles && widget.controller != null
-                                ? _SubtitleLayer(
-                                    video: video,
-                                    controller: widget.controller!,
-                                  )
-                                : null,
-                            pagePositionListenable: pagePositionListenable,
+                            onTap: _handlePlayerTap,
+                            onDoubleTapDown: (details) => _handleDoubleTapLike(
+                              context,
+                              details,
+                              isOwnVideo: isOwnVideo,
+                            ),
+                            onLongPressStart: _enterImmersive,
                           ),
                         ),
-                        Positioned.fill(
-                          child: DoubleTapHeartOverlay(trigger: _heartTrigger),
+                      ),
+                      if (widget.controller != null)
+                        // The paused play indicator is chrome too — it
+                        // covers the frame the peek is meant to reveal,
+                        // and holding never resumes playback, so leaving
+                        // it up would contradict the gesture.
+                        FeedImmersiveChrome(
+                          child: PausedVideoOverlay(
+                            controller: widget.controller!,
+                            videoId: video.id,
+                            // Only a pause the user can undo gets the
+                            // affordance. A comments/share sheet, a pushed
+                            // route or a backgrounded app pauses the player
+                            // too, but resumes it on its own — showing a play
+                            // button behind the sheet just reads as broken.
+                            isVisible: widget.isActive && widget.isFeedActive,
+                          ),
                         ),
-                      ],
-                    ),
+                      FeedImmersiveChrome(
+                        child: _FeedItemActions(
+                          video: video,
+                          index: widget.index,
+                          contextTitle: widget.contextTitle,
+                          isOwnVideo: isOwnVideo,
+                          onSuppressAutoAdvance: widget.onSuppressAutoAdvance,
+                          // Captions fade with the rest of the chrome, by
+                          // design: the hold reveals the frame the UI covers,
+                          // and the caption is an overlay over that same frame,
+                          // so keeping it up would re-cover exactly what the
+                          // peek exposes. It is gone only while the viewer
+                          // holds, and returns the instant they release.
+                          subtitleLayer:
+                              video.hasSubtitles && widget.controller != null
+                              ? _SubtitleLayer(
+                                  video: video,
+                                  controller: widget.controller!,
+                                )
+                              : null,
+                          pagePositionListenable: pagePositionListenable,
+                        ),
+                      ),
+                      Positioned.fill(
+                        child: DoubleTapHeartOverlay(trigger: _heartTrigger),
+                      ),
+                    ],
                   );
                 },
               ),

--- a/mobile/lib/widgets/video_feed_item/player_gesture_surface.dart
+++ b/mobile/lib/widgets/video_feed_item/player_gesture_surface.dart
@@ -1,0 +1,82 @@
+// ABOUTME: The full-bleed gesture surface over a feed video: tap to play/pause,
+// ABOUTME: double-tap to like, press-and-hold to peek at the unobstructed frame.
+// ABOUTME: Extracted so its semantics can be tested without a video player pool.
+
+import 'package:flutter/material.dart';
+import 'package:openvine/l10n/l10n.dart';
+
+/// The tap/double-tap/long-press surface painted under a feed item's chrome.
+///
+/// Pulled out of `feed_videos.dart` for one reason: in place, its tap action is
+/// gated on a controller that has rendered a first frame, `FeedVideos` takes no
+/// controller (it comes from an internal pool), and so no widget test could
+/// make the surface interactive. The labelling below shipped broken precisely
+/// because nothing could assert it. Here [interactiveReady] is a parameter, so
+/// a test can pump the real thing in its real state.
+class PlayerGestureSurface extends StatelessWidget {
+  /// Creates a [PlayerGestureSurface].
+  const PlayerGestureSurface({
+    required this.interactiveReady,
+    required this.isOwnVideo,
+    required this.onTap,
+    required this.onDoubleTapDown,
+    required this.onLongPressStart,
+    super.key,
+  });
+
+  /// Whether the player can accept play/pause and like gestures yet.
+  final bool interactiveReady;
+
+  /// Suppresses the double-tap-to-like hint on the viewer's own video.
+  final bool isOwnVideo;
+
+  /// Play or pause the video.
+  final VoidCallback onTap;
+
+  /// Publish a like, anchored at the tap position.
+  final void Function(TapDownDetails details) onDoubleTapDown;
+
+  /// Enter immersive mode — hide chrome while the press is held.
+  final VoidCallback onLongPressStart;
+
+  @override
+  Widget build(BuildContext context) {
+    // The annotation must sit DIRECTLY above the GestureDetector. In the
+    // original tree it wrapped the whole Stack instead, several layers up and
+    // around the chrome siblings, so it annotated a node that owned no tap
+    // action while the real tappable node stayed anonymous — on device,
+    // SemanticsNode#7(Rect 0,0,440,850, actions: [tap]) with no label. Here
+    // there is nothing between the two, so the annotation merges onto the
+    // gesture node. (MergeSemantics was tried first and is NOT what fixes
+    // this: with the widget extracted, a mutation removing it changes
+    // nothing.)
+    return Semantics(
+      button: true,
+      label: context.l10n.videoPlayerPlayVideo,
+      hint: isOwnVideo ? null : context.l10n.videoPlayerTapHint,
+      child: GestureDetector(
+        behavior: HitTestBehavior.translucent,
+        onTap: interactiveReady ? onTap : null,
+        onDoubleTapDown: interactiveReady ? onDoubleTapDown : null,
+        child: GestureDetector(
+          behavior: HitTestBehavior.translucent,
+          // Press and hold to peek at the unobstructed frame. Deliberately
+          // not gated on [interactiveReady] the way tap and double-tap are:
+          // those mutate the player or publish a like, while this only hides
+          // chrome, which is just as valid over a still-loading frame.
+          //
+          // Excluded from semantics, and kept on its own detector so the tap
+          // action above is still published. A `GestureDetector` publishes
+          // `SemanticsAction.longPress` for ANY long-press callback,
+          // `onLongPressStart` included — and firing that action delivers no
+          // pointer events, so the release path in the parent would never run
+          // and a screen-reader user would be left with every control hidden
+          // and pointer-blocked until the item was disposed.
+          excludeFromSemantics: true,
+          onLongPressStart: (_) => onLongPressStart(),
+          child: const SizedBox.expand(),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/widgets/video_feed_item/video_feed_item.dart
+++ b/mobile/lib/widgets/video_feed_item/video_feed_item.dart
@@ -43,6 +43,11 @@ import 'package:openvine/widgets/video_feed_item/video_follow_button.dart';
 import 'package:openvine/widgets/video_reply_parent_link.dart';
 import 'package:unified_logger/unified_logger.dart';
 
+/// Size of the avatar block: the avatar plus the sliver of overflow the follow
+/// badge has always drawn into. Also the height the author text is centred
+/// against, so raising it to a 48dp target cannot shift it off the avatar.
+const double _avatarClusterSize = 58;
+
 class VideoOverlayPreviewData {
   const VideoOverlayPreviewData({
     required this.pubkey,
@@ -343,8 +348,8 @@ class VideoOverlayActions extends ConsumerWidget {
                       children: [
                         // Avatar with follow button overlay
                         SizedBox(
-                          width: 58, // 48 avatar + follow button overflow
-                          height: 58,
+                          width: _avatarClusterSize,
+                          height: _avatarClusterSize,
                           child: Stack(
                             clipBehavior: Clip.none,
                             children: [
@@ -373,53 +378,73 @@ class VideoOverlayActions extends ConsumerWidget {
                         // User name and loop count (tappable to go to profile)
                         Expanded(
                           child: GestureDetector(
+                            // Opaque, so the whole author strip navigates to
+                            // the profile rather than only the painted glyphs.
+                            // This widens an existing target; it adds no new
+                            // destination.
+                            behavior: HitTestBehavior.opaque,
                             onTap: navigateToProfile,
-                            child: Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              mainAxisSize: MainAxisSize.min,
-                              children: [
-                                Row(
+                            // The name + meta column is intrinsically 44dp,
+                            // which failed androidTapTargetGuideline (48) on
+                            // device. Constrained to the avatar block and
+                            // centred, so the text sits where it always has
+                            // while the target clears 48dp. minHeight, not a
+                            // fixed height, so it still grows with the system
+                            // font scale (.claude/rules/accessibility.md).
+                            child: ConstrainedBox(
+                              constraints: const BoxConstraints(
+                                minHeight: _avatarClusterSize,
+                              ),
+                              child: Align(
+                                alignment: Alignment.centerLeft,
+                                child: Column(
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  mainAxisSize: MainAxisSize.min,
                                   children: [
-                                    Flexible(
-                                      child: Semantics(
-                                        identifier: 'video_author_name',
-                                        container: true,
-                                        explicitChildNodes: true,
-                                        label: context.l10n
-                                            .videoAuthorSemanticLabel(
+                                    Row(
+                                      children: [
+                                        Flexible(
+                                          child: Semantics(
+                                            identifier: 'video_author_name',
+                                            container: true,
+                                            explicitChildNodes: true,
+                                            label: context.l10n
+                                                .videoAuthorSemanticLabel(
+                                                  displayName,
+                                                ),
+                                            child: DivineHeartText(
                                               displayName,
+                                              style: VineTheme.titleSmallFont(
+                                                color: VineTheme.whiteText,
+                                              ),
+                                              maxLines: 1,
+                                              overflow: TextOverflow.ellipsis,
                                             ),
-                                        child: DivineHeartText(
-                                          displayName,
-                                          style: VineTheme.titleSmallFont(
-                                            color: VineTheme.whiteText,
                                           ),
-                                          maxLines: 1,
-                                          overflow: TextOverflow.ellipsis,
                                         ),
+                                        if (showCheckmark)
+                                          const SpecialProfileCheckmark(),
+                                        if (isOgViner) const OgVinerBadge(),
+                                        if (isOgBetaTester)
+                                          OgBetaBadge(
+                                            onTap: () =>
+                                                showProfileBadgeExplanationSheet(
+                                                  context,
+                                                  ProfileBadgeExplanationType
+                                                      .ogBetaTester,
+                                                ),
+                                          ),
+                                      ],
+                                    ),
+                                    _VideoCardMetaLine(
+                                      meta: resolveVideoCardMeta(
+                                        video: video,
+                                        isOwnVideo: isOwnVideo,
                                       ),
                                     ),
-                                    if (showCheckmark)
-                                      const SpecialProfileCheckmark(),
-                                    if (isOgViner) const OgVinerBadge(),
-                                    if (isOgBetaTester)
-                                      OgBetaBadge(
-                                        onTap: () =>
-                                            showProfileBadgeExplanationSheet(
-                                              context,
-                                              ProfileBadgeExplanationType
-                                                  .ogBetaTester,
-                                            ),
-                                      ),
                                   ],
                                 ),
-                                _VideoCardMetaLine(
-                                  meta: resolveVideoCardMeta(
-                                    video: video,
-                                    isOwnVideo: isOwnVideo,
-                                  ),
-                                ),
-                              ],
+                              ),
                             ),
                           ),
                         ),

--- a/mobile/lib/widgets/video_feed_item/video_feed_item.dart
+++ b/mobile/lib/widgets/video_feed_item/video_feed_item.dart
@@ -377,31 +377,44 @@ class VideoOverlayActions extends ConsumerWidget {
                         const SizedBox(width: 6),
                         // User name and loop count (tappable to go to profile)
                         Expanded(
-                          child: GestureDetector(
-                            // Opaque, so the whole author strip navigates to
-                            // the profile rather than only the painted glyphs.
-                            // This widens an existing target; it adds no new
-                            // destination.
-                            behavior: HitTestBehavior.opaque,
-                            onTap: navigateToProfile,
-                            // The name + meta column is intrinsically 44dp,
-                            // which failed androidTapTargetGuideline (48) on
-                            // device. Constrained to the avatar block and
-                            // centred, so the text sits where it always has
-                            // while the target clears 48dp. minHeight, not a
-                            // fixed height, so it still grows with the system
-                            // font scale (.claude/rules/accessibility.md).
-                            child: ConstrainedBox(
-                              constraints: const BoxConstraints(
-                                minHeight: _avatarClusterSize,
-                              ),
-                              child: Align(
-                                alignment: Alignment.centerLeft,
+                          child: Align(
+                            // Aligned OUTSIDE the detector so the target hugs
+                            // the author content. Inside it, the detector
+                            // filled the whole Expanded, and an opaque hit box
+                            // that wide swallowed the empty video to the right
+                            // of a short name — taking double-tap-to-like and
+                            // press-and-hold-to-peek with it.
+                            alignment: AlignmentDirectional.centerStart,
+                            child: GestureDetector(
+                              // Opaque, so the target is tappable across its
+                              // full height rather than only on the painted
+                              // glyphs: deferring to the child leaves the 58dp
+                              // node it advertises just 20dp of real target.
+                              behavior: HitTestBehavior.opaque,
+                              onTap: navigateToProfile,
+                              // The name + meta column is intrinsically 44dp,
+                              // which failed androidTapTargetGuideline (48) on
+                              // device. Constrained to the avatar block and
+                              // centred, so the text sits where it always has
+                              // while the target clears 48dp. minHeight, not a
+                              // fixed height, so it still grows with the system
+                              // font scale (.claude/rules/accessibility.md);
+                              // minWidth covers a display name too short to
+                              // reach the minimum on its own.
+                              child: ConstrainedBox(
+                                constraints: const BoxConstraints(
+                                  minWidth: kMinInteractiveDimension,
+                                  minHeight: _avatarClusterSize,
+                                ),
                                 child: Column(
                                   crossAxisAlignment: CrossAxisAlignment.start,
                                   mainAxisSize: MainAxisSize.min,
+                                  mainAxisAlignment: MainAxisAlignment.center,
                                   children: [
                                     Row(
+                                      // Hugs the name and its badges, so the
+                                      // detector above can hug in turn.
+                                      mainAxisSize: MainAxisSize.min,
                                       children: [
                                         Flexible(
                                           child: Semantics(

--- a/mobile/test/widgets/video_feed_item/feed_videos_test.dart
+++ b/mobile/test/widgets/video_feed_item/feed_videos_test.dart
@@ -55,6 +55,7 @@ import 'package:openvine/widgets/video_feed_item/feed_immersive_chrome.dart';
 import 'package:openvine/widgets/video_feed_item/feed_videos.dart';
 import 'package:openvine/widgets/video_feed_item/moderated_content_overlay.dart';
 import 'package:openvine/widgets/video_feed_item/paused_video_overlay.dart';
+import 'package:openvine/widgets/video_feed_item/player_gesture_surface.dart';
 import 'package:openvine/widgets/video_feed_item/pooled_video_error_overlay.dart';
 import 'package:openvine/widgets/video_feed_item/video_feed_item.dart';
 import 'package:openvine/widgets/video_feed_item/video_loading_placeholder.dart';
@@ -854,6 +855,75 @@ void main() {
         );
       } finally {
         semantics.dispose();
+      }
+    });
+
+    testWidgets('the profile target stops at the author content', (
+      tester,
+    ) async {
+      InfiniteVideoFeed.debugIsSupportedOverride = true;
+
+      final video = _makeVideo();
+      final cubit = _MockVideoPlaybackStatusCubit()
+        ..stub(PlaybackStatus.ready, video.id);
+
+      await _pumpFeedVideos(
+        tester,
+        videos: [video],
+        videoPlaybackStatusCubit: cubit,
+      );
+      await tester.pump(const Duration(seconds: 4));
+
+      final target = find
+          .ancestor(
+            of: find.bySemanticsIdentifier('video_author_name'),
+            matching: find.byType(GestureDetector),
+          )
+          .first;
+      final targetRect = tester.getRect(target);
+      expect(
+        targetRect.height,
+        greaterThanOrEqualTo(48),
+        reason: 'sanity: this is the 48dp profile target, not an inner one',
+      );
+
+      // The surface returns false from its own hit test — both of its
+      // GestureDetectors are translucent, and a translucent box adds itself to
+      // the path but reports a miss. So ownership has to be read off the path,
+      // and against the whole subtree rather than its root proxy, which never
+      // gets added at all.
+      final surface = <RenderObject>{};
+      void collect(Element element) {
+        final renderObject = element.renderObject;
+        if (renderObject != null) surface.add(renderObject);
+        element.visitChildren(collect);
+      }
+
+      collect(find.byType(PlayerGestureSurface).evaluate().single);
+
+      bool videoOwns(Offset point) => tester
+          .hitTestOnBinding(point)
+          .path
+          .any((entry) => surface.contains(entry.target));
+
+      // Inside the target the profile wins, across the FULL 58dp — 2dp above
+      // the bottom edge is below the meta text, so deferring to the child
+      // would drop it and leave only the ~20dp name line really tappable.
+      expect(
+        videoOwns(Offset(targetRect.left + 4, targetRect.bottom - 2)),
+        isFalse,
+        reason: 'the whole 48dp target must navigate to the profile',
+      );
+
+      // Past its trailing edge the video takes over again. An opaque detector
+      // filling the Expanded reported false here for another 400dp, taking
+      // double-tap-to-like and press-and-hold-to-peek off empty video.
+      for (final beyond in [2.0, 40.0, 200.0]) {
+        expect(
+          videoOwns(Offset(targetRect.right + beyond, targetRect.center.dy)),
+          isTrue,
+          reason: 'video keeps its gestures ${beyond}dp past the author text',
+        );
       }
     });
 

--- a/mobile/test/widgets/video_feed_item/feed_videos_test.dart
+++ b/mobile/test/widgets/video_feed_item/feed_videos_test.dart
@@ -813,6 +813,52 @@ void main() {
       expect(feed.canAutoPlay!(video), isTrue);
     });
 
+    testWidgets('the author row is a 48dp tap target', (tester) async {
+      final semantics = tester.ensureSemantics();
+      try {
+        InfiniteVideoFeed.debugIsSupportedOverride = true;
+
+        final video = _makeVideo();
+        final cubit = _MockVideoPlaybackStatusCubit()
+          ..stub(PlaybackStatus.ready, video.id);
+
+        await _pumpFeedVideos(
+          tester,
+          videos: [video],
+          videoPlaybackStatusCubit: cubit,
+        );
+        await tester.pump(const Duration(seconds: 4));
+
+        // The name + meta column is intrinsically 44dp and shipped that way:
+        // on an iPhone it reported Size(280.0, 44.0) and failed
+        // androidTapTargetGuideline (48). Walk the tree rather than matching a
+        // label, because the meta line's text is date-dependent.
+        final heights = <double>[];
+        void visit(SemanticsNode node) {
+          if (node.getSemanticsData().hasAction(SemanticsAction.tap)) {
+            heights.add(node.rect.height);
+          }
+          node.visitChildren((child) {
+            visit(child);
+            return true;
+          });
+        }
+
+        visit(tester.getSemantics(find.byType(FeedVideos)));
+
+        // The author row is the only wide tappable in the header.
+        final authorRow = heights.where((h) => h > 20).toList();
+        expect(authorRow, isNotEmpty, reason: 'no header tap target found');
+        expect(
+          authorRow.every((h) => h >= 48),
+          isTrue,
+          reason: 'header tap targets must be >= 48dp, got $authorRow',
+        );
+      } finally {
+        semantics.dispose();
+      }
+    });
+
     testWidgets('exposes localized semantics label and hint', (tester) async {
       final semantics = tester.ensureSemantics();
       try {

--- a/mobile/test/widgets/video_feed_item/feed_videos_test.dart
+++ b/mobile/test/widgets/video_feed_item/feed_videos_test.dart
@@ -829,30 +829,28 @@ void main() {
         );
         await tester.pump(const Duration(seconds: 4));
 
-        // The name + meta column is intrinsically 44dp and shipped that way:
-        // on an iPhone it reported Size(280.0, 44.0) and failed
-        // androidTapTargetGuideline (48). Walk the tree rather than matching a
-        // label, because the meta line's text is date-dependent.
-        final heights = <double>[];
-        void visit(SemanticsNode node) {
-          if (node.getSemanticsData().hasAction(SemanticsAction.tap)) {
-            heights.add(node.rect.height);
-          }
-          node.visitChildren((child) {
-            visit(child);
-            return true;
-          });
+        final authorName = find.bySemanticsIdentifier('video_author_name');
+        expect(authorName, findsOneWidget);
+
+        // The name node sits inside the row's tappable semantics node. Walk
+        // upward from that stable identifier so removing the profile action
+        // fails this test instead of silently dropping the row from a global
+        // list of tap targets.
+        SemanticsNode? authorRow = tester.getSemantics(authorName);
+        while (authorRow != null &&
+            !authorRow.getSemanticsData().hasAction(SemanticsAction.tap)) {
+          authorRow = authorRow.parent;
         }
 
-        visit(tester.getSemantics(find.byType(FeedVideos)));
-
-        // The author row is the only wide tappable in the header.
-        final authorRow = heights.where((h) => h > 20).toList();
-        expect(authorRow, isNotEmpty, reason: 'no header tap target found');
         expect(
-          authorRow.every((h) => h >= 48),
-          isTrue,
-          reason: 'header tap targets must be >= 48dp, got $authorRow',
+          authorRow,
+          isNotNull,
+          reason: 'the author row must expose a profile tap action',
+        );
+        expect(
+          authorRow!.rect.height,
+          greaterThanOrEqualTo(48),
+          reason: 'the author row must be at least 48dp tall',
         );
       } finally {
         semantics.dispose();

--- a/mobile/test/widgets/video_feed_item/player_gesture_surface_test.dart
+++ b/mobile/test/widgets/video_feed_item/player_gesture_surface_test.dart
@@ -1,0 +1,110 @@
+// ABOUTME: Tests for PlayerGestureSurface — the feed video's tap surface.
+// ABOUTME: Pins that the LABEL and the TAP ACTION land on the same semantics
+// ABOUTME: node, which is what shipped broken and what a device caught.
+
+import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/widgets/video_feed_item/player_gesture_surface.dart';
+
+import '../../helpers/accessibility_guidelines.dart';
+
+void main() {
+  group(PlayerGestureSurface, () {
+    Widget host({required bool interactiveReady, bool isOwnVideo = false}) =>
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: PlayerGestureSurface(
+              interactiveReady: interactiveReady,
+              isOwnVideo: isOwnVideo,
+              onTap: () {},
+              onDoubleTapDown: (_) {},
+              onLongPressStart: () {},
+            ),
+          ),
+        );
+
+    testWidgets('the labelled node is the one that owns the tap action', (
+      tester,
+    ) async {
+      final handle = tester.ensureSemantics();
+      try {
+        await tester.pumpWidget(host(interactiveReady: true));
+        await tester.pump();
+
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        final node = tester.getSemantics(
+          find.bySemanticsLabel(l10n.videoPlayerPlayVideo),
+        );
+
+        // The label used to sit on an ANCESTOR Semantics that owned no tap
+        // action, so the node a screen reader activates was anonymous. On device
+        // that surfaced as SemanticsNode#7(Rect 0,0,440,850, actions: [tap]) with
+        // no label, failing labeledTapTargetGuideline.
+        expect(
+          node.getSemanticsData().hasAction(SemanticsAction.tap),
+          isTrue,
+          reason: 'the labelled node must be the tappable one',
+        );
+        expect(node.hint, equals(l10n.videoPlayerTapHint));
+      } finally {
+        handle.dispose();
+      }
+    });
+
+    testWidgets('omits the double-tap hint on the viewer own video', (
+      tester,
+    ) async {
+      final handle = tester.ensureSemantics();
+      try {
+        await tester.pumpWidget(
+          host(interactiveReady: true, isOwnVideo: true),
+        );
+        await tester.pump();
+
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        final node = tester.getSemantics(
+          find.bySemanticsLabel(l10n.videoPlayerPlayVideo),
+        );
+
+        expect(node.hint, isEmpty);
+      } finally {
+        handle.dispose();
+      }
+    });
+
+    testWidgets('meets the tap-target and labelling guidelines', (
+      tester,
+    ) async {
+      await tester.pumpWidget(host(interactiveReady: true));
+      await tester.pump();
+
+      await expectMeetsAccessibilityGuidelines(
+        tester,
+        guidelines: divineSemanticsGuidelines,
+      );
+    });
+
+    testWidgets('publishes no tap action before the player is ready', (
+      tester,
+    ) async {
+      final handle = tester.ensureSemantics();
+      try {
+        await tester.pumpWidget(host(interactiveReady: false));
+        await tester.pump();
+
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        final node = tester.getSemantics(
+          find.bySemanticsLabel(l10n.videoPlayerPlayVideo),
+        );
+
+        expect(node.getSemanticsData().hasAction(SemanticsAction.tap), isFalse);
+      } finally {
+        handle.dispose();
+      }
+    });
+  });
+}

--- a/mobile/test/widgets/video_feed_item/player_gesture_surface_test.dart
+++ b/mobile/test/widgets/video_feed_item/player_gesture_surface_test.dart
@@ -9,20 +9,24 @@ import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/widgets/video_feed_item/player_gesture_surface.dart';
 
 import '../../helpers/accessibility_guidelines.dart';
+import '../../helpers/test_provider_overrides.dart';
 
 void main() {
   group(PlayerGestureSurface, () {
     Widget host({required bool interactiveReady, bool isOwnVideo = false}) =>
-        MaterialApp(
-          localizationsDelegates: AppLocalizations.localizationsDelegates,
-          supportedLocales: AppLocalizations.supportedLocales,
+        testMaterialApp(
           home: Scaffold(
-            body: PlayerGestureSurface(
-              interactiveReady: interactiveReady,
-              isOwnVideo: isOwnVideo,
-              onTap: () {},
-              onDoubleTapDown: (_) {},
-              onLongPressStart: () {},
+            body: Center(
+              child: SizedBox.square(
+                dimension: 200,
+                child: PlayerGestureSurface(
+                  interactiveReady: interactiveReady,
+                  isOwnVideo: isOwnVideo,
+                  onTap: () {},
+                  onDoubleTapDown: (_) {},
+                  onLongPressStart: () {},
+                ),
+              ),
             ),
           ),
         );


### PR DESCRIPTION
The two accessibility fixes from #8102 that carry **no visual change and no open
design question**, split out so they can land while the follow-badge geometry
waits on design. Found by running Flutter's accessibility guidelines against
the real app on an iPhone 17 Pro Max / iOS 26.6.1.

## 1. Author row — 280x44

```
SemanticsNode#10(..., label: "11h ago"):
  expected tap target size of at least Size(48.0, 48.0), but found Size(280.0, 44.0)
```

Constrained to the avatar block (58dp) and centred, so the text sits exactly
where it always has while the target clears 48. `minHeight`, not a fixed
height, so it still grows with system font scale.

**Nothing moves.** The cluster stays the `SizedBox(58, 58)` main already
shipped, and the column now matches it, so centring is a no-op.

Verified on device after the fix: `Rect(80,716,360,774)` = **280x58**.

### Gesture ownership: the target hugs the author content

The first version of this fix made the detector `opaque` while it still filled
its `Expanded`, so it owned the whole strip — 640dp in the widget test, ~280dp
on device — including the empty video to the right of a short display name.
Hit-testing that band showed the video losing double-tap-to-like and
press-and-hold-to-peek across all of it.

**None of that width was the accessibility fix.** The failure was vertical, and
the `ConstrainedBox` alone answers it: swapping `opaque` for `deferToChild`
leaves the semantics node identical at `640x58` with its tap action, and the
48dp assertion still passes.

`opaque` is still needed, but only so the height the node advertises is really
tappable — deferring to the child leaves just the ~20dp name line live, which
would make the 58dp node an automated-check pass and a real-finger miss.

So the alignment moved outside the detector and the `Row` hugs its content. The
target keeps its full 58dp and now ends at the author text instead of 240dp
short of the viewport edge:

| | target rect | video keeps its gestures |
|---|---|---|
| before | `Rect(80, 492, 720, 550)` | no, for 400dp past the text |
| after | `Rect(80, 492, 319.7, 550)` | yes, from the text edge on |

The author name renders at exactly the same rect either way
(`Rect(80, 501, 319.7, 521)`), so this is still a no-visual-change PR.
`minWidth` guards a display name too short to clear the minimum on its own.

## 2. Full-screen tappable with no label

```
SemanticsNode#7(Rect.fromLTRB(0.0, 0.0, 440.0, 850.0), actions: [tap]):
  expected tappable node to have semantic label, but none was found
```

Not a missing label — a **misplaced** one. The annotation wrapped the whole
`Stack` while the tap sat on a `GestureDetector` several layers below, so the
tree carried two nodes: one with the name and no action, one with the action
and no name. **Distance is the bug.** Extracting `PlayerGestureSurface` puts
the annotation directly above the detector, where it merges onto the node that
owns the tap.

Verified on device: the same `Rect(0,0,440,850)` now reports
`label: "Play video"`.

The extraction is also what makes it testable — in place, the tap is gated on a
controller with a rendered first frame and `FeedVideos` takes no controller (it
comes from an internal pool), so no widget test could make the surface
interactive. That is precisely why it shipped broken.

## What is deliberately NOT here

The **follow badge** (20x20, under both platform minimums) stays on #8102. Its
48dp target cannot be reached without either growing the author cluster or
taking hits from the avatar, and both are design calls — measurements are in
that PR. Keeping it out is what lets these two land now.

Also not here: caption sizing, and the four pre-existing undersized targets in
#8145.

## Tests

- `feed_videos_test` anchors on the `video_author_name` identifier, walks up to
  the tappable ancestor, and requires both the profile action and >= 48dp.
  Removing the callback turns it red; so does dropping the constraint (`40.0`).
- `feed_videos_test` also pins gesture ownership by hit-testing the boundary.
  Restoring the full-width geometry fails it 200dp past the author text;
  swapping `opaque` for `deferToChild` fails it 2dp above the target's bottom
  edge.
- `player_gesture_surface_test` pumps the extracted widget inset and
  constrained, so the tap-target guidelines are actually evaluated rather than
  skipped as a viewport-edge node.

**Gates:** `flutter analyze lib test integration_test` clean; `flutter test
test/widgets/video_feed_item/` plus the four adjacent `VideoOverlayActions`
suites **429 pass**; format clean.

Refs #8103
