### PR TITLE
fix(enforcement): reconcile rejected likes

### DIFF
--- a/mobile/lib/blocs/video_interactions/video_interactions_bloc.dart
+++ b/mobile/lib/blocs/video_interactions/video_interactions_bloc.dart
@@ -398,7 +398,6 @@ class VideoInteractionsBloc
       case _LikeSettleRestricted(:final wasLiked):
         emit(
           state.copyWith(
-            status: VideoInteractionsStatus.accountRestricted,
             isLiked: wasLiked,
             likeCount: event.wasCount,
             accountRestrictionRevision: state.accountRestrictionRevision + 1,

--- a/mobile/lib/blocs/video_interactions/video_interactions_bloc.dart
+++ b/mobile/lib/blocs/video_interactions/video_interactions_bloc.dart
@@ -78,6 +78,7 @@ class VideoInteractionsBloc
   }
 
   final String _eventId;
+  int _likeToggleRevision = 0;
   final String _authorPubkey;
   final LikesRepository _likesRepository;
   final CommentsRepository _commentsRepository;
@@ -292,6 +293,7 @@ class VideoInteractionsBloc
     VideoInteractionsLikeToggled event,
     Emitter<VideoInteractionsState> emit,
   ) async {
+    final revision = ++_likeToggleRevision;
     final wasLiked = state.isLiked;
     final wasCount = state.likeCount;
     final optimisticLiked = !wasLiked;
@@ -310,6 +312,7 @@ class VideoInteractionsBloc
         optimisticLiked: optimisticLiked,
         wasLiked: wasLiked,
         wasCount: wasCount,
+        revision: revision,
       ),
     );
   }
@@ -318,6 +321,7 @@ class VideoInteractionsBloc
     required bool optimisticLiked,
     required bool wasLiked,
     required int? wasCount,
+    required int revision,
   }) async {
     _LikeSettleOutcome outcome;
     try {
@@ -337,6 +341,8 @@ class VideoInteractionsBloc
       outcome = const _LikeSettleAlready();
     } on NotLikedException {
       outcome = const _LikeSettleNotLiked();
+    } on LikeAccountRestrictedException {
+      outcome = _LikeSettleRestricted(wasLiked: wasLiked);
     } catch (e, stackTrace) {
       Log.error(
         'VideoInteractionsBloc: Like toggle failed for $_eventId - $e',
@@ -356,13 +362,20 @@ class VideoInteractionsBloc
     }
 
     if (isClosed) return;
-    add(_VideoInteractionsLikeSettled(outcome: outcome, wasCount: wasCount));
+    add(
+      _VideoInteractionsLikeSettled(
+        outcome: outcome,
+        wasCount: wasCount,
+        revision: revision,
+      ),
+    );
   }
 
   void _onLikeSettled(
     _VideoInteractionsLikeSettled event,
     Emitter<VideoInteractionsState> emit,
   ) {
+    if (event.revision != _likeToggleRevision) return;
     switch (event.outcome) {
       case _LikeSettleConfirmed():
         // Optimistic emit already matches the publish result; no-op.
@@ -381,8 +394,15 @@ class VideoInteractionsBloc
       case _LikeSettleNotLiked():
         emit(state.copyWith(isLiked: false, likeCount: event.wasCount));
       case _LikeSettleFailed(:final wasLiked):
+        emit(state.copyWith(isLiked: wasLiked, likeCount: event.wasCount));
+      case _LikeSettleRestricted(:final wasLiked):
         emit(
-          state.copyWith(isLiked: wasLiked, likeCount: event.wasCount),
+          state.copyWith(
+            status: VideoInteractionsStatus.accountRestricted,
+            isLiked: wasLiked,
+            likeCount: event.wasCount,
+            accountRestrictionRevision: state.accountRestrictionRevision + 1,
+          ),
         );
     }
   }

--- a/mobile/lib/blocs/video_interactions/video_interactions_event.dart
+++ b/mobile/lib/blocs/video_interactions/video_interactions_event.dart
@@ -65,13 +65,15 @@ class _VideoInteractionsLikeSettled extends VideoInteractionsEvent {
   const _VideoInteractionsLikeSettled({
     required this.outcome,
     required this.wasCount,
+    required this.revision,
   });
 
   final _LikeSettleOutcome outcome;
   final int? wasCount;
+  final int revision;
 
   @override
-  List<Object?> get props => [outcome, wasCount];
+  List<Object?> get props => [outcome, wasCount, revision];
 }
 
 /// Internal event dispatched when a fire-and-forget repost publish settles.
@@ -127,6 +129,16 @@ class _LikeSettleNotLiked extends _LikeSettleOutcome {
 /// Publish threw an unexpected error — revert to the pre-tap baseline.
 class _LikeSettleFailed extends _LikeSettleOutcome {
   const _LikeSettleFailed({required this.wasLiked});
+
+  final bool wasLiked;
+
+  @override
+  List<Object?> get props => [wasLiked];
+}
+
+/// The authoritative relay rejected the action for account policy.
+class _LikeSettleRestricted extends _LikeSettleOutcome {
+  const _LikeSettleRestricted({required this.wasLiked});
 
   final bool wasLiked;
 

--- a/mobile/lib/blocs/video_interactions/video_interactions_state.dart
+++ b/mobile/lib/blocs/video_interactions/video_interactions_state.dart
@@ -16,9 +16,6 @@ enum VideoInteractionsStatus {
 
   /// Failed to load data.
   failure,
-
-  /// An authoritative publish response confirmed account enforcement.
-  accountRestricted,
 }
 
 /// State for a single video's interactions.

--- a/mobile/lib/blocs/video_interactions/video_interactions_state.dart
+++ b/mobile/lib/blocs/video_interactions/video_interactions_state.dart
@@ -16,6 +16,9 @@ enum VideoInteractionsStatus {
 
   /// Failed to load data.
   failure,
+
+  /// An authoritative publish response confirmed account enforcement.
+  accountRestricted,
 }
 
 /// State for a single video's interactions.
@@ -42,6 +45,7 @@ class VideoInteractionsState extends Equatable {
     this.repostCount,
     this.commentCount,
     this.isCommentsInProgress = false,
+    this.accountRestrictionRevision = 0,
   });
 
   /// Current status of the bloc.
@@ -68,6 +72,10 @@ class VideoInteractionsState extends Equatable {
   /// Whether a comments operation is currently in progress.
   final bool isCommentsInProgress;
 
+  /// Increments for each restriction response so UI listeners fire once per
+  /// rejected action without carrying navigation or display strings in state.
+  final int accountRestrictionRevision;
+
   /// Whether interaction counts are still loading.
   bool get isLoading =>
       status == VideoInteractionsStatus.initial ||
@@ -85,6 +93,7 @@ class VideoInteractionsState extends Equatable {
     int? repostCount,
     int? commentCount,
     bool? isCommentsInProgress,
+    int? accountRestrictionRevision,
   }) {
     return VideoInteractionsState(
       status: status ?? this.status,
@@ -94,6 +103,8 @@ class VideoInteractionsState extends Equatable {
       repostCount: repostCount ?? this.repostCount,
       commentCount: commentCount ?? this.commentCount,
       isCommentsInProgress: isCommentsInProgress ?? this.isCommentsInProgress,
+      accountRestrictionRevision:
+          accountRestrictionRevision ?? this.accountRestrictionRevision,
     );
   }
 
@@ -106,5 +117,6 @@ class VideoInteractionsState extends Equatable {
     repostCount,
     commentCount,
     isCommentsInProgress,
+    accountRestrictionRevision,
   ];
 }

--- a/mobile/lib/services/account_deletion_service.dart
+++ b/mobile/lib/services/account_deletion_service.dart
@@ -8,7 +8,6 @@ import 'package:nostr_sdk/filter.dart';
 import 'package:nostr_sdk/nip19/pubkey_for_logs.dart';
 import 'package:nostr_sdk/relay/publish_outcome.dart';
 import 'package:openvine/services/auth_service.dart';
-import 'package:openvine/utils/relay_rejection_classifier.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 /// User-facing class of an account deletion failure.

--- a/mobile/lib/services/content_deletion_service.dart
+++ b/mobile/lib/services/content_deletion_service.dart
@@ -9,7 +9,6 @@ import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/event.dart';
 import 'package:openvine/constants/nip71_migration.dart';
 import 'package:openvine/services/auth_service.dart';
-import 'package:openvine/utils/relay_rejection_classifier.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:unified_logger/unified_logger.dart';
 

--- a/mobile/lib/services/pending_action_service.dart
+++ b/mobile/lib/services/pending_action_service.dart
@@ -5,6 +5,7 @@ import 'dart:async';
 
 import 'package:db_client/db_client.dart';
 import 'package:flutter/foundation.dart';
+import 'package:nostr_client/nostr_client.dart';
 import 'package:openvine/services/connection_status_service.dart';
 import 'package:openvine/utils/async_utils.dart';
 import 'package:rxdart/rxdart.dart';
@@ -413,6 +414,19 @@ class PendingActionService extends ChangeNotifier {
         name: 'PendingActionService',
         category: LogCategory.system,
       );
+    } on TerminalSocialActionException catch (e) {
+      await _dao.updateStatus(
+        action.id,
+        PendingActionStatus.failed,
+        lastError: e.toString(),
+        retryCount: action.retryCount,
+      );
+      Log.warning(
+        'Pending action rejected by terminal account policy: '
+        '${action.type} on ${action.targetId}',
+        name: 'PendingActionService',
+        category: LogCategory.system,
+      );
     } catch (e) {
       // Mark as failed or pending for retry
       final newRetryCount = action.retryCount + 1;
@@ -436,6 +450,7 @@ class PendingActionService extends ChangeNotifier {
   }
 
   bool _isRetriableError(dynamic error) {
+    if (error is TerminalSocialActionException) return false;
     final errorStr = error.toString().toLowerCase();
 
     // Network errors are retriable

--- a/mobile/lib/services/video_event_publisher.dart
+++ b/mobile/lib/services/video_event_publisher.dart
@@ -45,7 +45,6 @@ import 'package:openvine/utils/inspired_by_tags.dart';
 import 'package:openvine/utils/log_tag_sanitizer.dart';
 import 'package:openvine/utils/nostr_replacement_timestamp.dart';
 import 'package:openvine/utils/proofmode_publishing_helpers.dart';
-import 'package:openvine/utils/relay_rejection_classifier.dart';
 import 'package:profile_repository/profile_repository.dart';
 import 'package:unified_logger/unified_logger.dart';
 

--- a/mobile/lib/utils/relay_rejection_classifier.dart
+++ b/mobile/lib/utils/relay_rejection_classifier.dart
@@ -1,57 +1,9 @@
-// ABOUTME: Classifies deterministic relay rejections from publish outcomes.
-// ABOUTME: Trusts account restrictions only when the configured relay says so.
+// ABOUTME: Compatibility export for relay publish-rejection classification.
+// ABOUTME: The implementation lives with publish outcomes in nostr_client.
 
-import 'package:nostr_sdk/relay/publish_outcome.dart';
-import 'package:openvine/utils/relay_url_utils.dart';
-
-// These reason strings are the divine relay's verbatim OK-frame messages,
-// produced by divine-funnelcake `crates/relay/src/rejection.rs` (Display for
-// the SuspendedPubkey / BannedPubkey / rate-limit variants). This match is
-// exact, so a reword on the relay side silently reverts suspended users to the
-// retry path — change both repos together, or add a cross-repo contract test.
-
-/// True only for explicit account-level publishing restrictions.
-bool isAccountRestrictedReason(String reason) {
-  final normalized = reason.trim().toLowerCase();
-  return normalized == 'blocked: pubkey is suspended' ||
-      normalized == 'blocked: pubkey is banned';
-}
-
-/// Whether the configured authoritative relay rejected a publish because the
-/// account is restricted and no other relay accepted it.
-///
-/// Deletion publishes fan out to user-discovered relays. Their reason text is
-/// untrusted and must not decide Divine account standing or stop a vanish
-/// request. Relay URLs are compared by normalized endpoint identity so a
-/// harmless trailing slash does not discard the authoritative response.
-bool isAccountRestrictedOutcome(
-  PublishOutcome outcome, {
-  required String trustedRelayUrl,
-}) =>
-    accountRestrictedReasonFromOutcome(
-      outcome,
-      trustedRelayUrl: trustedRelayUrl,
-    ) !=
-    null;
-
-/// Returns the trusted relay's exact account-restriction reason, or `null`.
-String? accountRestrictedReasonFromOutcome(
-  PublishOutcome outcome, {
-  required String trustedRelayUrl,
-}) {
-  if (outcome.acceptedBy.isNotEmpty) return null;
-  for (final entry in outcome.rejectedBy.entries) {
-    if (relayUrlsEquivalent(entry.key, trustedRelayUrl) &&
-        isAccountRestrictedReason(entry.value)) {
-      return entry.value;
-    }
-  }
-  return null;
-}
-
-/// Whether at least one relay rate-limited a publish that none accepted.
-bool isRateLimitedOutcome(PublishOutcome outcome) =>
-    outcome.acceptedBy.isEmpty &&
-    outcome.rejectedBy.values.any(
-      (reason) => reason.trim().toLowerCase().startsWith('rate-limited:'),
-    );
+export 'package:nostr_client/nostr_client.dart'
+    show
+        accountRestrictedReasonFromOutcome,
+        isAccountRestrictedOutcome,
+        isAccountRestrictedReason,
+        isRateLimitedOutcome;

--- a/mobile/lib/widgets/video_feed_item/feed_videos.dart
+++ b/mobile/lib/widgets/video_feed_item/feed_videos.dart
@@ -50,6 +50,7 @@ import 'package:openvine/widgets/video_feed_item/subtitle_overlay.dart';
 import 'package:openvine/widgets/video_feed_item/verifying_aware_video_error_overlay.dart';
 import 'package:openvine/widgets/video_feed_item/video_feed_item.dart';
 import 'package:openvine/widgets/video_feed_item/video_interactions_bloc_key.dart';
+import 'package:openvine/widgets/video_feed_item/video_interactions_restriction_listener.dart';
 import 'package:openvine/widgets/video_feed_item/video_loading_placeholder.dart';
 
 class FeedVideos extends ConsumerStatefulWidget {
@@ -1011,137 +1012,139 @@ class __OverlayState extends ConsumerState<_Overlay> {
                   )
                   ..add(const VideoInteractionsSubscriptionRequested())
                   ..add(const VideoInteractionsFetchRequested()),
-            child: Builder(
-              builder: (context) {
-                return Semantics(
-                  button: true,
-                  label: context.l10n.videoPlayerPlayVideo,
-                  hint: isOwnVideo ? null : context.l10n.videoPlayerTapHint,
-                  // The chrome layers are SIBLINGS above the gesture surface,
-                  // never descendants of it. As descendants, any press held
-                  // past `kLongPressTimeout` anywhere on the action rail was
-                  // claimed by the video's long-press: the rail's own tap
-                  // recognizer only accepts on pointer-up, so it lost the
-                  // arena, and Report/More/Share swallowed the tap and faded
-                  // out under the viewer's finger. Keeping them siblings lets
-                  // an opaque button win the hit test outright, so the peek
-                  // never sees that pointer.
-                  child: Stack(
-                    children: [
-                      // The raw [Listener] owns immersive mode's release: it
-                      // counts the pointers over the item and exits once the
-                      // last lifts. `onLongPressEnd` alone would not do —
-                      // it does not fire for a pointer cancelled after the
-                      // press was accepted (`onLongPressCancel` does), and
-                      // neither callback can tell an incidental second finger
-                      // lifting from the hold finger lifting. A Listener also
-                      // sits outside the gesture arena, so it can't steal the
-                      // press.
-                      Positioned.fill(
-                        child: Listener(
-                          // Must match the translucent child below: with
-                          // `deferToChild` a press on empty video area never
-                          // adds this Listener to the hit-test path (the
-                          // translucent GestureDetector adds itself but still
-                          // reports a miss), so the pointer events would never
-                          // arrive.
-                          behavior: HitTestBehavior.translucent,
-                          onPointerDown: (event) {
-                            // An empty set means nothing is down, so any hold
-                            // this item still believes it owns is stale — its
-                            // terminal event was lost (a touch dropped on
-                            // backgrounding, a platform view taking over).
-                            // Without this the item could never peek again.
-                            if (_immersivePointers.isEmpty) _exitImmersive();
-                            _immersivePointers.add(event.pointer);
-                          },
-                          onPointerUp: (event) =>
-                              _handleImmersivePointerEnd(event.pointer),
-                          onPointerCancel: (event) =>
-                              _handleImmersivePointerEnd(event.pointer),
-                          child: GestureDetector(
-                            behavior: .translucent,
-                            onTap: interactiveReady ? _handlePlayerTap : null,
-                            onDoubleTapDown: interactiveReady
-                                ? (details) => _handleDoubleTapLike(
-                                    context,
-                                    details,
-                                    isOwnVideo: isOwnVideo,
-                                  )
-                                : null,
+            child: VideoInteractionsRestrictionListener(
+              child: Builder(
+                builder: (context) {
+                  return Semantics(
+                    button: true,
+                    label: context.l10n.videoPlayerPlayVideo,
+                    hint: isOwnVideo ? null : context.l10n.videoPlayerTapHint,
+                    // The chrome layers are SIBLINGS above the gesture surface,
+                    // never descendants of it. As descendants, any press held
+                    // past `kLongPressTimeout` anywhere on the action rail was
+                    // claimed by the video's long-press: the rail's own tap
+                    // recognizer only accepts on pointer-up, so it lost the
+                    // arena, and Report/More/Share swallowed the tap and faded
+                    // out under the viewer's finger. Keeping them siblings lets
+                    // an opaque button win the hit test outright, so the peek
+                    // never sees that pointer.
+                    child: Stack(
+                      children: [
+                        // The raw [Listener] owns immersive mode's release: it
+                        // counts the pointers over the item and exits once the
+                        // last lifts. `onLongPressEnd` alone would not do —
+                        // it does not fire for a pointer cancelled after the
+                        // press was accepted (`onLongPressCancel` does), and
+                        // neither callback can tell an incidental second finger
+                        // lifting from the hold finger lifting. A Listener also
+                        // sits outside the gesture arena, so it can't steal the
+                        // press.
+                        Positioned.fill(
+                          child: Listener(
+                            // Must match the translucent child below: with
+                            // `deferToChild` a press on empty video area never
+                            // adds this Listener to the hit-test path (the
+                            // translucent GestureDetector adds itself but still
+                            // reports a miss), so the pointer events would never
+                            // arrive.
+                            behavior: HitTestBehavior.translucent,
+                            onPointerDown: (event) {
+                              // An empty set means nothing is down, so any hold
+                              // this item still believes it owns is stale — its
+                              // terminal event was lost (a touch dropped on
+                              // backgrounding, a platform view taking over).
+                              // Without this the item could never peek again.
+                              if (_immersivePointers.isEmpty) _exitImmersive();
+                              _immersivePointers.add(event.pointer);
+                            },
+                            onPointerUp: (event) =>
+                                _handleImmersivePointerEnd(event.pointer),
+                            onPointerCancel: (event) =>
+                                _handleImmersivePointerEnd(event.pointer),
                             child: GestureDetector(
                               behavior: .translucent,
-                              // Press and hold to peek at the unobstructed
-                              // frame. Deliberately not gated on
-                              // [interactiveReady] the way tap and double-tap
-                              // are: those mutate the player or publish a
-                              // like, while this only hides chrome, which is
-                              // just as valid over a still-loading frame.
-                              //
-                              // Excluded from semantics, and kept on its own
-                              // detector so the tap action above still is
-                              // published. A `GestureDetector` publishes
-                              // `SemanticsAction.longPress` for ANY long-press
-                              // callback, `onLongPressStart` included — and
-                              // firing that action delivers no pointer events,
-                              // so the release path below would never run and
-                              // a screen-reader user would be left with every
-                              // control hidden and pointer-blocked until the
-                              // item was disposed.
-                              excludeFromSemantics: true,
-                              onLongPressStart: (_) => _enterImmersive(),
-                              child: const SizedBox.expand(),
+                              onTap: interactiveReady ? _handlePlayerTap : null,
+                              onDoubleTapDown: interactiveReady
+                                  ? (details) => _handleDoubleTapLike(
+                                      context,
+                                      details,
+                                      isOwnVideo: isOwnVideo,
+                                    )
+                                  : null,
+                              child: GestureDetector(
+                                behavior: .translucent,
+                                // Press and hold to peek at the unobstructed
+                                // frame. Deliberately not gated on
+                                // [interactiveReady] the way tap and double-tap
+                                // are: those mutate the player or publish a
+                                // like, while this only hides chrome, which is
+                                // just as valid over a still-loading frame.
+                                //
+                                // Excluded from semantics, and kept on its own
+                                // detector so the tap action above still is
+                                // published. A `GestureDetector` publishes
+                                // `SemanticsAction.longPress` for ANY long-press
+                                // callback, `onLongPressStart` included — and
+                                // firing that action delivers no pointer events,
+                                // so the release path below would never run and
+                                // a screen-reader user would be left with every
+                                // control hidden and pointer-blocked until the
+                                // item was disposed.
+                                excludeFromSemantics: true,
+                                onLongPressStart: (_) => _enterImmersive(),
+                                child: const SizedBox.expand(),
+                              ),
                             ),
                           ),
                         ),
-                      ),
-                      if (widget.controller != null)
-                        // The paused play indicator is chrome too — it
-                        // covers the frame the peek is meant to reveal,
-                        // and holding never resumes playback, so leaving
-                        // it up would contradict the gesture.
+                        if (widget.controller != null)
+                          // The paused play indicator is chrome too — it
+                          // covers the frame the peek is meant to reveal,
+                          // and holding never resumes playback, so leaving
+                          // it up would contradict the gesture.
+                          FeedImmersiveChrome(
+                            child: PausedVideoOverlay(
+                              controller: widget.controller!,
+                              videoId: video.id,
+                              // Only a pause the user can undo gets the
+                              // affordance. A comments/share sheet, a pushed
+                              // route or a backgrounded app pauses the player
+                              // too, but resumes it on its own — showing a play
+                              // button behind the sheet just reads as broken.
+                              isVisible: widget.isActive && widget.isFeedActive,
+                            ),
+                          ),
                         FeedImmersiveChrome(
-                          child: PausedVideoOverlay(
-                            controller: widget.controller!,
-                            videoId: video.id,
-                            // Only a pause the user can undo gets the
-                            // affordance. A comments/share sheet, a pushed
-                            // route or a backgrounded app pauses the player
-                            // too, but resumes it on its own — showing a play
-                            // button behind the sheet just reads as broken.
-                            isVisible: widget.isActive && widget.isFeedActive,
+                          child: _FeedItemActions(
+                            video: video,
+                            index: widget.index,
+                            contextTitle: widget.contextTitle,
+                            isOwnVideo: isOwnVideo,
+                            onSuppressAutoAdvance: widget.onSuppressAutoAdvance,
+                            // Captions fade with the rest of the chrome, by
+                            // design: the hold reveals the frame the UI covers,
+                            // and the caption is an overlay over that same frame,
+                            // so keeping it up would re-cover exactly what the
+                            // peek exposes. It is gone only while the viewer
+                            // holds, and returns the instant they release.
+                            subtitleLayer:
+                                video.hasSubtitles && widget.controller != null
+                                ? _SubtitleLayer(
+                                    video: video,
+                                    controller: widget.controller!,
+                                  )
+                                : null,
+                            pagePositionListenable: pagePositionListenable,
                           ),
                         ),
-                      FeedImmersiveChrome(
-                        child: _FeedItemActions(
-                          video: video,
-                          index: widget.index,
-                          contextTitle: widget.contextTitle,
-                          isOwnVideo: isOwnVideo,
-                          onSuppressAutoAdvance: widget.onSuppressAutoAdvance,
-                          // Captions fade with the rest of the chrome, by
-                          // design: the hold reveals the frame the UI covers,
-                          // and the caption is an overlay over that same frame,
-                          // so keeping it up would re-cover exactly what the
-                          // peek exposes. It is gone only while the viewer
-                          // holds, and returns the instant they release.
-                          subtitleLayer:
-                              video.hasSubtitles && widget.controller != null
-                              ? _SubtitleLayer(
-                                  video: video,
-                                  controller: widget.controller!,
-                                )
-                              : null,
-                          pagePositionListenable: pagePositionListenable,
+                        Positioned.fill(
+                          child: DoubleTapHeartOverlay(trigger: _heartTrigger),
                         ),
-                      ),
-                      Positioned.fill(
-                        child: DoubleTapHeartOverlay(trigger: _heartTrigger),
-                      ),
-                    ],
-                  ),
-                );
-              },
+                      ],
+                    ),
+                  );
+                },
+              ),
             ),
           ),
         );

--- a/mobile/lib/widgets/video_feed_item/video_interactions_restriction_listener.dart
+++ b/mobile/lib/widgets/video_feed_item/video_interactions_restriction_listener.dart
@@ -25,7 +25,11 @@ class VideoInteractionsRestrictionListener extends StatelessWidget {
           previous.accountRestrictionRevision !=
           current.accountRestrictionRevision,
       listener: (context, state) {
-        context.pushNamed(AccountStatusScreen.routeName, extra: true);
+        final router = GoRouter.of(context);
+        if (router.routerDelegate.currentConfiguration.uri.path !=
+            AccountStatusScreen.path) {
+          context.pushNamed(AccountStatusScreen.routeName, extra: true);
+        }
       },
       child: child,
     );

--- a/mobile/lib/widgets/video_feed_item/video_interactions_restriction_listener.dart
+++ b/mobile/lib/widgets/video_feed_item/video_interactions_restriction_listener.dart
@@ -1,0 +1,33 @@
+// ABOUTME: Opens Account Status after a social publish confirms enforcement.
+// ABOUTME: Keeps navigation out of repository and BLoC state.
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
+import 'package:openvine/blocs/video_interactions/video_interactions_bloc.dart';
+import 'package:openvine/screens/settings/account_status_screen.dart';
+
+/// Navigates to Account Status when the interactions BLoC confirms a ban.
+class VideoInteractionsRestrictionListener extends StatelessWidget {
+  /// Creates a listener around [child].
+  const VideoInteractionsRestrictionListener({
+    required this.child,
+    super.key,
+  });
+
+  /// Content kept unchanged while restriction state is observed.
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocListener<VideoInteractionsBloc, VideoInteractionsState>(
+      listenWhen: (previous, current) =>
+          previous.accountRestrictionRevision !=
+          current.accountRestrictionRevision,
+      listener: (context, state) {
+        context.pushNamed(AccountStatusScreen.routeName, extra: true);
+      },
+      child: child,
+    );
+  }
+}

--- a/mobile/packages/likes_repository/lib/src/exceptions.dart
+++ b/mobile/packages/likes_repository/lib/src/exceptions.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Exception classes for the likes repository.
 // ABOUTME: Provides typed exceptions for like/unlike operations.
 
+import 'package:nostr_client/nostr_client.dart';
+
 /// Base exception for all likes repository errors.
 class LikesRepositoryException implements Exception {
   /// Creates a new likes repository exception.
@@ -25,6 +27,21 @@ class LikeFailedException extends LikesRepositoryException {
 
   @override
   String toString() => 'LikeFailedException: $message';
+}
+
+/// The authoritative Divine relay rejected the action because the account is
+/// suspended or banned.
+///
+/// This is terminal: callers must not place the action in an offline retry
+/// queue. UI code may use the type to open the Account Status explanation.
+class LikeAccountRestrictedException extends LikesRepositoryException
+    implements TerminalSocialActionException {
+  /// Creates the terminal restriction signal.
+  const LikeAccountRestrictedException()
+    : super('Account is restricted from publishing social actions');
+
+  @override
+  String toString() => 'LikeAccountRestrictedException';
 }
 
 /// Exception thrown when an unlike operation fails.

--- a/mobile/packages/likes_repository/lib/src/likes_repository.dart
+++ b/mobile/packages/likes_repository/lib/src/likes_repository.dart
@@ -675,6 +675,16 @@ class LikesRepository {
           description: 'rolling back a restricted like placeholder',
           site: LikesRepositoryReportableSites.likeEventRollbackPlaceholder,
         );
+        if (_interactionRevisions[eventId] != interactionRevision) {
+          final currentRecord = _likeRecords[eventId];
+          if (currentRecord != null) {
+            await _bestEffortLocalStorage(
+              () async => _localStorage?.saveLikeRecord(currentRecord),
+              description: 'preserving the newer like record',
+              site: LikesRepositoryReportableSites.likeEventSaveConfirmed,
+            );
+          }
+        }
         if (_interactionRevisions[eventId] == interactionRevision) {
           if (previousCount != null) {
             _writeCachedLikeCount(
@@ -829,13 +839,24 @@ class LikesRepository {
     }
 
     // Publish Kind 7 reaction event via NostrClient
-    final reactionEvent = await _nostrClient.sendLike(
-      eventId,
-      content: _likeContent,
-      addressableId: addressableId,
-      targetAuthorPubkey: authorPubkey,
-      targetKind: targetKind,
-    );
+    final Event? reactionEvent;
+    try {
+      reactionEvent = await _nostrClient.sendLike(
+        eventId,
+        content: _likeContent,
+        addressableId: addressableId,
+        targetAuthorPubkey: authorPubkey,
+        targetKind: targetKind,
+      );
+    } on SocialPublishException catch (e, stackTrace) {
+      if (e.result.accountRestricted) {
+        Error.throwWithStackTrace(
+          const LikeAccountRestrictedException(),
+          stackTrace,
+        );
+      }
+      rethrow;
+    }
 
     if (reactionEvent == null) {
       throw const LikeFailedException('Failed to publish like reaction');
@@ -1015,6 +1036,22 @@ class LikesRepository {
           description: 'restoring a restricted unlike record',
           site: LikesRepositoryReportableSites.unlikeEventRestoreRecord,
         );
+        if (_interactionRevisions[eventId] != interactionRevision) {
+          final currentRecord = _likeRecords[resolvedEventId];
+          if (currentRecord == null) {
+            await _bestEffortLocalStorage(
+              () async => _localStorage?.deleteLikeRecord(resolvedEventId),
+              description: 'preserving the newer unlike state',
+              site: LikesRepositoryReportableSites.unlikeEventDeleteRecord,
+            );
+          } else {
+            await _bestEffortLocalStorage(
+              () async => _localStorage?.saveLikeRecord(currentRecord),
+              description: 'preserving the newer like record',
+              site: LikesRepositoryReportableSites.unlikeEventRestoreRecord,
+            );
+          }
+        }
         if (_interactionRevisions[eventId] == interactionRevision) {
           if (previousCount != null) {
             _writeCachedLikeCount(
@@ -1107,9 +1144,18 @@ class LikesRepository {
     }
 
     // Publish Kind 5 deletion event via NostrClient
-    final deletionEvent = await _nostrClient.deleteEvent(
-      record.reactionEventId,
-    );
+    final Event? deletionEvent;
+    try {
+      deletionEvent = await _nostrClient.deleteEvent(record.reactionEventId);
+    } on SocialPublishException catch (e, stackTrace) {
+      if (e.result.accountRestricted) {
+        Error.throwWithStackTrace(
+          const LikeAccountRestrictedException(),
+          stackTrace,
+        );
+      }
+      rethrow;
+    }
 
     if (deletionEvent == null) {
       throw const UnlikeFailedException('Failed to publish unlike deletion');

--- a/mobile/packages/likes_repository/lib/src/likes_repository.dart
+++ b/mobile/packages/likes_repository/lib/src/likes_repository.dart
@@ -184,6 +184,13 @@ class LikesRepository {
   /// second one (#7001).
   final Set<String> _unlikeRequestedWhilePending = {};
 
+  /// Latest local intent revision per target event.
+  ///
+  /// A relay response can arrive after a later tap. Reconciliation may only
+  /// mutate the optimistic record/count when its revision is still current.
+  final Map<String, int> _interactionRevisions = {};
+  int _nextInteractionRevision = 0;
+
   /// In-memory cache of downvote records keyed by target event ID.
   ///
   /// Mirror of [_likeRecords] for kind-7 reactions whose content is `-`.
@@ -511,6 +518,8 @@ class LikesRepository {
     int? targetKind,
   }) async {
     await _ensureInitialized();
+    final interactionRevision = ++_nextInteractionRevision;
+    _interactionRevisions[eventId] = interactionRevision;
 
     // Check if already liked — by event id, or (when addressableId is
     // known) by coordinate. The coordinate check catches the case where a
@@ -539,7 +548,7 @@ class LikesRepository {
     // Storage write is awaited so the placeholder survives an app crash
     // before sync; PendingActionService (offline) and executeLikeAction
     // (sync) reconcile the placeholder ID with the real reaction event ID.
-    final placeholderId = 'pending_like_$eventId';
+    final placeholderId = 'pending_like_${interactionRevision}_$eventId';
     final placeholder = LikeRecord(
       targetEventId: eventId,
       reactionEventId: placeholderId,
@@ -621,6 +630,66 @@ class LikesRepository {
       );
 
       return reactionEvent.id;
+    } on SocialPublishException catch (e, stackTrace) {
+      _inFlightLikePublishPlaceholders.remove(placeholderId);
+      _unlikeRequestedWhilePending.remove(placeholderId);
+      if (!e.result.accountRestricted) {
+        if (_queueOfflineAction != null) {
+          Log.error(
+            'Like publish failed; queuing optimistic action for retry',
+            name: 'LikesRepository',
+            category: LogCategory.relay,
+            error: e,
+            stackTrace: stackTrace,
+          );
+          await _queueOfflineAction(
+            isLike: true,
+            eventId: eventId,
+            authorPubkey: authorPubkey,
+            addressableId: addressableId,
+            targetKind: targetKind,
+          );
+          return placeholderId;
+        }
+        _deindexLikeRecord(eventId);
+        await _bestEffortLocalStorage(
+          () async => _localStorage?.deleteLikeRecord(eventId),
+          description: 'rolling back the like placeholder',
+          site: LikesRepositoryReportableSites.likeEventRollbackPlaceholder,
+        );
+        if (previousCount != null) {
+          _writeCachedLikeCount(
+            eventId,
+            previousCount,
+            addressableId: addressableId,
+          );
+        }
+        _emitLikedIds();
+        Error.throwWithStackTrace(e, stackTrace);
+      }
+      if (_interactionRevisions[eventId] == interactionRevision &&
+          _likeRecords[eventId]?.reactionEventId == placeholderId) {
+        _deindexLikeRecord(eventId);
+        await _bestEffortLocalStorage(
+          () async => _localStorage?.deleteLikeRecord(eventId),
+          description: 'rolling back a restricted like placeholder',
+          site: LikesRepositoryReportableSites.likeEventRollbackPlaceholder,
+        );
+        if (_interactionRevisions[eventId] == interactionRevision) {
+          if (previousCount != null) {
+            _writeCachedLikeCount(
+              eventId,
+              previousCount,
+              addressableId: addressableId,
+            );
+          }
+          _emitLikedIds();
+        }
+      }
+      Error.throwWithStackTrace(
+        const LikeAccountRestrictedException(),
+        stackTrace,
+      );
     } catch (e, stackTrace) {
       _inFlightLikePublishPlaceholders.remove(placeholderId);
       // The publish did not produce a reaction id this method can retract.
@@ -808,6 +877,8 @@ class LikesRepository {
   /// Throws `NotLikedException` if the event is not currently liked.
   Future<void> unlikeEvent(String eventId, {String? addressableId}) async {
     await _ensureInitialized();
+    final interactionRevision = ++_nextInteractionRevision;
+    _interactionRevisions[eventId] = interactionRevision;
 
     // Try in-memory cache first (by event id, then by coordinate), then
     // fall back to database. This handles both the cache-not-populated-yet
@@ -900,6 +971,65 @@ class LikesRepository {
       if (deletionEvent == null) {
         throw const UnlikeFailedException('Failed to publish unlike deletion');
       }
+    } on SocialPublishException catch (e, stackTrace) {
+      if (!e.result.accountRestricted) {
+        if (_queueOfflineAction != null) {
+          Log.error(
+            'Unlike publish failed; queuing optimistic action for retry',
+            name: 'LikesRepository',
+            category: LogCategory.relay,
+            error: e,
+            stackTrace: stackTrace,
+          );
+          await _queueOfflineAction(
+            isLike: false,
+            eventId: resolvedEventId,
+            authorPubkey: '',
+          );
+          return;
+        }
+        _indexLikeRecord(snapshotRecord);
+        await _bestEffortLocalStorage(
+          () async => _localStorage?.saveLikeRecord(snapshotRecord),
+          description: 'restoring the like record',
+          site: LikesRepositoryReportableSites.unlikeEventRestoreRecord,
+        );
+        if (previousCount != null) {
+          _writeCachedLikeCount(
+            eventId,
+            previousCount,
+            addressableId: addressableId,
+          );
+        }
+        _emitLikedIds();
+        Error.throwWithStackTrace(e, stackTrace);
+      }
+      // Funnelcake deliberately exempts Kind 5 erasure requests from account
+      // enforcement. Keep this terminal branch for other trusted deployments
+      // and for policy changes, but do not publish a compensating deletion.
+      if (_interactionRevisions[eventId] == interactionRevision &&
+          !_likeRecords.containsKey(resolvedEventId)) {
+        _indexLikeRecord(snapshotRecord);
+        await _bestEffortLocalStorage(
+          () async => _localStorage?.saveLikeRecord(snapshotRecord),
+          description: 'restoring a restricted unlike record',
+          site: LikesRepositoryReportableSites.unlikeEventRestoreRecord,
+        );
+        if (_interactionRevisions[eventId] == interactionRevision) {
+          if (previousCount != null) {
+            _writeCachedLikeCount(
+              eventId,
+              previousCount,
+              addressableId: addressableId,
+            );
+          }
+          _emitLikedIds();
+        }
+      }
+      Error.throwWithStackTrace(
+        const LikeAccountRestrictedException(),
+        stackTrace,
+      );
     } catch (e, stackTrace) {
       if (_queueOfflineAction != null) {
         Log.error(
@@ -2027,10 +2157,7 @@ class LikesRepository {
     List<String> eventIds, {
     required int kind,
   }) {
-    return _queryChunked(
-      eventIds,
-      (chunk) => Filter(kinds: [kind], e: chunk),
-    );
+    return _queryChunked(eventIds, (chunk) => Filter(kinds: [kind], e: chunk));
   }
 
   /// Runs [buildFilter] over [values] in chunks capped at [_reqEidChunkSize]

--- a/mobile/packages/likes_repository/lib/src/likes_repository.dart
+++ b/mobile/packages/likes_repository/lib/src/likes_repository.dart
@@ -504,6 +504,20 @@ class LikesRepository {
     }
   }
 
+  void _logSocialPublishFailure(
+    String message,
+    SocialPublishException error,
+    StackTrace stackTrace,
+  ) {
+    Log.error(
+      message,
+      name: 'LikesRepository',
+      category: LogCategory.relay,
+      error: error,
+      stackTrace: stackTrace,
+    );
+  }
+
   Future<void> _rollbackLikeIfCurrent({
     required String eventId,
     required String placeholderId,
@@ -733,6 +747,13 @@ class LikesRepository {
       } on SocialPublishException catch (e, stackTrace) {
         _inFlightLikePublishPlaceholders.remove(placeholderId);
         _unlikeRequestedWhilePending.remove(placeholderId);
+        if (_queueOfflineAction == null || e.result.accountRestricted) {
+          _logSocialPublishFailure(
+            'Like publish was not accepted',
+            e,
+            stackTrace,
+          );
+        }
         if (!e.result.accountRestricted) {
           if (_queueOfflineAction != null) {
             Log.error(
@@ -919,6 +940,11 @@ class LikesRepository {
         targetKind: targetKind,
       );
     } on SocialPublishException catch (e, stackTrace) {
+      _logSocialPublishFailure(
+        'Queued like publish was not accepted',
+        e,
+        stackTrace,
+      );
       if (e.result.accountRestricted) {
         Error.throwWithStackTrace(
           const LikeAccountRestrictedException(),
@@ -1067,6 +1093,13 @@ class LikesRepository {
           );
         }
       } on SocialPublishException catch (e, stackTrace) {
+        if (_queueOfflineAction == null || e.result.accountRestricted) {
+          _logSocialPublishFailure(
+            'Unlike publish was not accepted',
+            e,
+            stackTrace,
+          );
+        }
         if (!e.result.accountRestricted) {
           if (_queueOfflineAction != null) {
             Log.error(
@@ -1189,6 +1222,11 @@ class LikesRepository {
     try {
       deletionEvent = await _nostrClient.deleteEvent(record.reactionEventId);
     } on SocialPublishException catch (e, stackTrace) {
+      _logSocialPublishFailure(
+        'Queued unlike publish was not accepted',
+        e,
+        stackTrace,
+      );
       if (e.result.accountRestricted) {
         Error.throwWithStackTrace(
           const LikeAccountRestrictedException(),
@@ -1707,6 +1745,11 @@ class LikesRepository {
     } on SocialPublishException catch (e, stackTrace) {
       _deindexDownvoteRecord(eventId);
       _emitDownvotedIds();
+      _logSocialPublishFailure(
+        'Downvote publish was not accepted',
+        e,
+        stackTrace,
+      );
       if (e.result.accountRestricted) {
         Error.throwWithStackTrace(
           const LikeAccountRestrictedException(),
@@ -1783,6 +1826,11 @@ class LikesRepository {
     } on SocialPublishException catch (e, stackTrace) {
       _indexDownvoteRecord(snapshotRecord);
       _emitDownvotedIds();
+      _logSocialPublishFailure(
+        'Downvote deletion was not accepted',
+        e,
+        stackTrace,
+      );
       if (e.result.accountRestricted) {
         Error.throwWithStackTrace(
           const LikeAccountRestrictedException(),
@@ -1835,6 +1883,11 @@ class LikesRepository {
     try {
       deletionEvent = await _nostrClient.deleteEvent(reactionEventId);
     } on SocialPublishException catch (e, stackTrace) {
+      _logSocialPublishFailure(
+        'Reaction deletion was not accepted',
+        e,
+        stackTrace,
+      );
       if (e.result.accountRestricted) {
         Error.throwWithStackTrace(
           const LikeAccountRestrictedException(),

--- a/mobile/packages/likes_repository/lib/src/likes_repository.dart
+++ b/mobile/packages/likes_repository/lib/src/likes_repository.dart
@@ -184,11 +184,11 @@ class LikesRepository {
   /// second one (#7001).
   final Set<String> _unlikeRequestedWhilePending = {};
 
-  /// Latest local intent revision per target event.
+  /// Latest in-flight local intent token per target event.
   ///
   /// A relay response can arrive after a later tap. Reconciliation may only
-  /// mutate the optimistic record/count when its revision is still current.
-  final Map<String, int> _interactionRevisions = {};
+  /// mutate the optimistic record/count when its token is still current.
+  final Map<String, Object> _inFlightInteractions = {};
   int _nextInteractionRevision = 0;
 
   /// In-memory cache of downvote records keyed by target event ID.
@@ -489,6 +489,106 @@ class LikesRepository {
     return _downvoteRecords[eventId];
   }
 
+  Object _beginInteraction(String eventId) {
+    final token = Object();
+    _inFlightInteractions[eventId] = token;
+    return token;
+  }
+
+  bool _isCurrentInteraction(String eventId, Object token) =>
+      identical(_inFlightInteractions[eventId], token);
+
+  void _completeInteraction(String eventId, Object token) {
+    if (_isCurrentInteraction(eventId, token)) {
+      _inFlightInteractions.remove(eventId);
+    }
+  }
+
+  Future<void> _rollbackLikeIfCurrent({
+    required String eventId,
+    required String placeholderId,
+    required Object interactionToken,
+    required int? previousCount,
+    required String? addressableId,
+  }) async {
+    if (!_isCurrentInteraction(eventId, interactionToken) ||
+        _likeRecords[eventId]?.reactionEventId != placeholderId) {
+      return;
+    }
+
+    _deindexLikeRecord(eventId);
+    await _bestEffortLocalStorage(
+      () async => _localStorage?.deleteLikeRecord(eventId),
+      description: 'rolling back the like placeholder',
+      site: LikesRepositoryReportableSites.likeEventRollbackPlaceholder,
+    );
+    if (!_isCurrentInteraction(eventId, interactionToken)) {
+      final currentRecord = _likeRecords[eventId];
+      if (currentRecord != null) {
+        await _bestEffortLocalStorage(
+          () async => _localStorage?.saveLikeRecord(currentRecord),
+          description: 'preserving the newer like record',
+          site: LikesRepositoryReportableSites.likeEventSaveConfirmed,
+        );
+      }
+      return;
+    }
+    if (previousCount != null) {
+      _writeCachedLikeCount(
+        eventId,
+        previousCount,
+        addressableId: addressableId,
+      );
+    }
+    _emitLikedIds();
+  }
+
+  Future<void> _restoreUnlikeIfCurrent({
+    required String eventId,
+    required String resolvedEventId,
+    required LikeRecord snapshotRecord,
+    required Object interactionToken,
+    required int? previousCount,
+    required String? addressableId,
+  }) async {
+    if (!_isCurrentInteraction(eventId, interactionToken) ||
+        _likeRecords.containsKey(resolvedEventId)) {
+      return;
+    }
+
+    _indexLikeRecord(snapshotRecord);
+    await _bestEffortLocalStorage(
+      () async => _localStorage?.saveLikeRecord(snapshotRecord),
+      description: 'restoring the like record',
+      site: LikesRepositoryReportableSites.unlikeEventRestoreRecord,
+    );
+    if (!_isCurrentInteraction(eventId, interactionToken)) {
+      final currentRecord = _likeRecords[resolvedEventId];
+      if (currentRecord == null) {
+        await _bestEffortLocalStorage(
+          () async => _localStorage?.deleteLikeRecord(resolvedEventId),
+          description: 'preserving the newer unlike state',
+          site: LikesRepositoryReportableSites.unlikeEventDeleteRecord,
+        );
+      } else {
+        await _bestEffortLocalStorage(
+          () async => _localStorage?.saveLikeRecord(currentRecord),
+          description: 'preserving the newer like record',
+          site: LikesRepositoryReportableSites.unlikeEventRestoreRecord,
+        );
+      }
+      return;
+    }
+    if (previousCount != null) {
+      _writeCachedLikeCount(
+        eventId,
+        previousCount,
+        addressableId: addressableId,
+      );
+    }
+    _emitLikedIds();
+  }
+
   /// Like an event.
   ///
   /// Creates and publishes a Kind 7 reaction event with content '+'.
@@ -518,9 +618,6 @@ class LikesRepository {
     int? targetKind,
   }) async {
     await _ensureInitialized();
-    final interactionRevision = ++_nextInteractionRevision;
-    _interactionRevisions[eventId] = interactionRevision;
-
     // Check if already liked — by event id, or (when addressableId is
     // known) by coordinate. The coordinate check catches the case where a
     // pre-edit version of this target was already liked under a different
@@ -535,105 +632,153 @@ class LikesRepository {
       throw AlreadyLikedException(eventId);
     }
 
-    // Snapshot for rollback if the network publish fails
-    final previousCount = _readCachedLikeCount(
-      eventId,
-      addressableId: addressableId,
-    );
-
-    // 1. Optimistic-first: write to memory + local storage and tick the
-    // watchLikedEventIds stream BEFORE any network I/O. The UI flips here.
-    // Mirrors FollowRepository.follow's order-of-operations so likes match
-    // the design rabble described — local DB first, network confirms.
-    // Storage write is awaited so the placeholder survives an app crash
-    // before sync; PendingActionService (offline) and executeLikeAction
-    // (sync) reconcile the placeholder ID with the real reaction event ID.
-    final placeholderId = 'pending_like_${interactionRevision}_$eventId';
-    final placeholder = LikeRecord(
-      targetEventId: eventId,
-      reactionEventId: placeholderId,
-      createdAt: DateTime.now(),
-      addressableId: addressableId,
-    );
-    _indexLikeRecord(placeholder);
-    await _bestEffortLocalStorage(
-      () async => _localStorage?.saveLikeRecord(placeholder),
-      description: 'saving the like placeholder',
-      site: LikesRepositoryReportableSites.likeEventSavePlaceholder,
-    );
-    if (previousCount != null) {
-      _writeCachedLikeCount(
-        eventId,
-        previousCount + 1,
-        addressableId: addressableId,
-      );
-    }
-    _emitLikedIds();
-
-    // 2. Offline → leave the optimistic state in place; queue replays later
-    if (_isOnline != null && !_isOnline() && _queueOfflineAction != null) {
-      await _queueOfflineAction(
-        isLike: true,
-        eventId: eventId,
-        authorPubkey: authorPubkey,
-        addressableId: addressableId,
-        targetKind: targetKind,
-      );
-      return placeholderId;
-    }
-
-    // 3. Online → publish kind 7; on success swap placeholder for real id.
-    // On failure, prefer queuing via [_queueOfflineAction] when wired so the
-    // optimistic state survives transient relay-pool problems (e.g. all
-    // configured relays in `disconnected` state at publish time but
-    // [ConnectionStatusService] still reports online because at least one
-    // relay is technically connected). Without a wired callback, fall back
-    // to rollback + rethrow to preserve the original contract for tests
-    // and non-app embedders.
-    _inFlightLikePublishPlaceholders.add(placeholderId);
+    final interactionToken = _beginInteraction(eventId);
+    final interactionRevision = ++_nextInteractionRevision;
     try {
-      final reactionEvent = await _nostrClient.sendLike(
+      // Snapshot for rollback if the network publish fails
+      final previousCount = _readCachedLikeCount(
         eventId,
-        content: _likeContent,
         addressableId: addressableId,
-        targetAuthorPubkey: authorPubkey,
-        targetKind: targetKind,
       );
 
-      if (reactionEvent == null) {
-        throw const LikeFailedException('Failed to publish like reaction');
-      }
-
-      final confirmed = LikeRecord(
+      // 1. Optimistic-first: write to memory + local storage and tick the
+      // watchLikedEventIds stream BEFORE any network I/O. The UI flips here.
+      // Mirrors FollowRepository.follow's order-of-operations so likes match
+      // the design rabble described — local DB first, network confirms.
+      // Storage write is awaited so the placeholder survives an app crash
+      // before sync; PendingActionService (offline) and executeLikeAction
+      // (sync) reconcile the placeholder ID with the real reaction event ID.
+      final placeholderId = 'pending_like_${interactionRevision}_$eventId';
+      final placeholder = LikeRecord(
         targetEventId: eventId,
-        reactionEventId: reactionEvent.id,
-        createdAt: placeholder.createdAt,
+        reactionEventId: placeholderId,
+        createdAt: DateTime.now(),
         addressableId: addressableId,
       );
-
-      _inFlightLikePublishPlaceholders.remove(placeholderId);
-      if (_unlikeRequestedWhilePending.remove(placeholderId)) {
-        await _retractLikeUnlikedMidPublish(
-          confirmed: confirmed,
-          restoredCount: previousCount == null ? null : previousCount + 1,
-          countEventId: eventId,
-          countAddressableId: addressableId,
+      _indexLikeRecord(placeholder);
+      await _bestEffortLocalStorage(
+        () async => _localStorage?.saveLikeRecord(placeholder),
+        description: 'saving the like placeholder',
+        site: LikesRepositoryReportableSites.likeEventSavePlaceholder,
+      );
+      if (previousCount != null) {
+        _writeCachedLikeCount(
+          eventId,
+          previousCount + 1,
+          addressableId: addressableId,
         );
-        return reactionEvent.id;
+      }
+      _emitLikedIds();
+
+      // 2. Offline → leave the optimistic state in place; queue replays later
+      if (_isOnline != null && !_isOnline() && _queueOfflineAction != null) {
+        await _queueOfflineAction(
+          isLike: true,
+          eventId: eventId,
+          authorPubkey: authorPubkey,
+          addressableId: addressableId,
+          targetKind: targetKind,
+        );
+        return placeholderId;
       }
 
-      _indexLikeRecord(confirmed);
-      await _bestEffortLocalStorage(
-        () async => _localStorage?.saveLikeRecord(confirmed),
-        description: 'saving the confirmed like',
-        site: LikesRepositoryReportableSites.likeEventSaveConfirmed,
-      );
+      // 3. Online → publish kind 7; on success swap placeholder for real id.
+      // On failure, prefer queuing via [_queueOfflineAction] when wired so the
+      // optimistic state survives transient relay-pool problems (e.g. all
+      // configured relays in `disconnected` state at publish time but
+      // [ConnectionStatusService] still reports online because at least one
+      // relay is technically connected). Without a wired callback, fall back
+      // to rollback + rethrow to preserve the original contract for tests
+      // and non-app embedders.
+      _inFlightLikePublishPlaceholders.add(placeholderId);
+      try {
+        final reactionEvent = await _nostrClient.sendLike(
+          eventId,
+          content: _likeContent,
+          addressableId: addressableId,
+          targetAuthorPubkey: authorPubkey,
+          targetKind: targetKind,
+        );
 
-      return reactionEvent.id;
-    } on SocialPublishException catch (e, stackTrace) {
-      _inFlightLikePublishPlaceholders.remove(placeholderId);
-      _unlikeRequestedWhilePending.remove(placeholderId);
-      if (!e.result.accountRestricted) {
+        if (reactionEvent == null) {
+          throw const LikeFailedException('Failed to publish like reaction');
+        }
+
+        final confirmed = LikeRecord(
+          targetEventId: eventId,
+          reactionEventId: reactionEvent.id,
+          createdAt: placeholder.createdAt,
+          addressableId: addressableId,
+        );
+
+        _inFlightLikePublishPlaceholders.remove(placeholderId);
+        if (_unlikeRequestedWhilePending.remove(placeholderId)) {
+          await _retractLikeUnlikedMidPublish(
+            confirmed: confirmed,
+            restoredCount: previousCount == null ? null : previousCount + 1,
+            countEventId: eventId,
+            countAddressableId: addressableId,
+          );
+          return reactionEvent.id;
+        }
+
+        _indexLikeRecord(confirmed);
+        await _bestEffortLocalStorage(
+          () async => _localStorage?.saveLikeRecord(confirmed),
+          description: 'saving the confirmed like',
+          site: LikesRepositoryReportableSites.likeEventSaveConfirmed,
+        );
+
+        return reactionEvent.id;
+      } on SocialPublishException catch (e, stackTrace) {
+        _inFlightLikePublishPlaceholders.remove(placeholderId);
+        _unlikeRequestedWhilePending.remove(placeholderId);
+        if (!e.result.accountRestricted) {
+          if (_queueOfflineAction != null) {
+            Log.error(
+              'Like publish failed; queuing optimistic action for retry',
+              name: 'LikesRepository',
+              category: LogCategory.relay,
+              error: e,
+              stackTrace: stackTrace,
+            );
+            await _queueOfflineAction(
+              isLike: true,
+              eventId: eventId,
+              authorPubkey: authorPubkey,
+              addressableId: addressableId,
+              targetKind: targetKind,
+            );
+            return placeholderId;
+          }
+          await _rollbackLikeIfCurrent(
+            eventId: eventId,
+            placeholderId: placeholderId,
+            interactionToken: interactionToken,
+            previousCount: previousCount,
+            addressableId: addressableId,
+          );
+          Error.throwWithStackTrace(
+            const LikeFailedException('Failed to publish like reaction'),
+            stackTrace,
+          );
+        }
+        await _rollbackLikeIfCurrent(
+          eventId: eventId,
+          placeholderId: placeholderId,
+          interactionToken: interactionToken,
+          previousCount: previousCount,
+          addressableId: addressableId,
+        );
+        Error.throwWithStackTrace(
+          const LikeAccountRestrictedException(),
+          stackTrace,
+        );
+      } catch (e, stackTrace) {
+        _inFlightLikePublishPlaceholders.remove(placeholderId);
+        // The publish did not produce a reaction id this method can retract.
+        // Drop this attempt's intent so it cannot fire against a later like.
+        _unlikeRequestedWhilePending.remove(placeholderId);
         if (_queueOfflineAction != null) {
           Log.error(
             'Like publish failed; queuing optimistic action for retry',
@@ -651,92 +796,17 @@ class LikesRepository {
           );
           return placeholderId;
         }
-        _deindexLikeRecord(eventId);
-        await _bestEffortLocalStorage(
-          () async => _localStorage?.deleteLikeRecord(eventId),
-          description: 'rolling back the like placeholder',
-          site: LikesRepositoryReportableSites.likeEventRollbackPlaceholder,
-        );
-        if (previousCount != null) {
-          _writeCachedLikeCount(
-            eventId,
-            previousCount,
-            addressableId: addressableId,
-          );
-        }
-        _emitLikedIds();
-        Error.throwWithStackTrace(e, stackTrace);
-      }
-      if (_interactionRevisions[eventId] == interactionRevision &&
-          _likeRecords[eventId]?.reactionEventId == placeholderId) {
-        _deindexLikeRecord(eventId);
-        await _bestEffortLocalStorage(
-          () async => _localStorage?.deleteLikeRecord(eventId),
-          description: 'rolling back a restricted like placeholder',
-          site: LikesRepositoryReportableSites.likeEventRollbackPlaceholder,
-        );
-        if (_interactionRevisions[eventId] != interactionRevision) {
-          final currentRecord = _likeRecords[eventId];
-          if (currentRecord != null) {
-            await _bestEffortLocalStorage(
-              () async => _localStorage?.saveLikeRecord(currentRecord),
-              description: 'preserving the newer like record',
-              site: LikesRepositoryReportableSites.likeEventSaveConfirmed,
-            );
-          }
-        }
-        if (_interactionRevisions[eventId] == interactionRevision) {
-          if (previousCount != null) {
-            _writeCachedLikeCount(
-              eventId,
-              previousCount,
-              addressableId: addressableId,
-            );
-          }
-          _emitLikedIds();
-        }
-      }
-      Error.throwWithStackTrace(
-        const LikeAccountRestrictedException(),
-        stackTrace,
-      );
-    } catch (e, stackTrace) {
-      _inFlightLikePublishPlaceholders.remove(placeholderId);
-      // The publish did not produce a reaction id this method can retract.
-      // Drop this attempt's intent so it cannot fire against a later like.
-      _unlikeRequestedWhilePending.remove(placeholderId);
-      if (_queueOfflineAction != null) {
-        Log.error(
-          'Like publish failed; queuing optimistic action for retry',
-          name: 'LikesRepository',
-          category: LogCategory.relay,
-          error: e,
-          stackTrace: stackTrace,
-        );
-        await _queueOfflineAction(
-          isLike: true,
+        await _rollbackLikeIfCurrent(
           eventId: eventId,
-          authorPubkey: authorPubkey,
-          addressableId: addressableId,
-          targetKind: targetKind,
-        );
-        return placeholderId;
-      }
-      _deindexLikeRecord(eventId);
-      await _bestEffortLocalStorage(
-        () async => _localStorage?.deleteLikeRecord(eventId),
-        description: 'rolling back the like placeholder',
-        site: LikesRepositoryReportableSites.likeEventRollbackPlaceholder,
-      );
-      if (previousCount != null) {
-        _writeCachedLikeCount(
-          eventId,
-          previousCount,
+          placeholderId: placeholderId,
+          interactionToken: interactionToken,
+          previousCount: previousCount,
           addressableId: addressableId,
         );
+        rethrow;
       }
-      _emitLikedIds();
-      rethrow;
+    } finally {
+      _completeInteraction(eventId, interactionToken);
     }
   }
 
@@ -855,7 +925,10 @@ class LikesRepository {
           stackTrace,
         );
       }
-      rethrow;
+      Error.throwWithStackTrace(
+        const LikeFailedException('Failed to publish like reaction'),
+        stackTrace,
+      );
     }
 
     if (reactionEvent == null) {
@@ -898,9 +971,6 @@ class LikesRepository {
   /// Throws `NotLikedException` if the event is not currently liked.
   Future<void> unlikeEvent(String eventId, {String? addressableId}) async {
     await _ensureInitialized();
-    final interactionRevision = ++_nextInteractionRevision;
-    _interactionRevisions[eventId] = interactionRevision;
-
     // Try in-memory cache first (by event id, then by coordinate), then
     // fall back to database. This handles both the cache-not-populated-yet
     // case and the post-edit case where the record's real key is a
@@ -945,55 +1015,103 @@ class LikesRepository {
       addressableId: addressableId,
     );
 
-    // 1. Optimistic-first: remove from memory + local storage and tick the
-    // watchLikedEventIds stream BEFORE any network I/O (mirror of likeEvent).
-    _deindexLikeRecord(resolvedEventId);
-    await _bestEffortLocalStorage(
-      () async => _localStorage?.deleteLikeRecord(resolvedEventId),
-      description: 'deleting the like record',
-      site: LikesRepositoryReportableSites.unlikeEventDeleteRecord,
-    );
-    _decrementLikeCountCache(eventId, addressableId: addressableId);
-    _emitLikedIds();
-
-    // 2. Offline → leave the optimistic state in place; queue replays later
-    if (_isOnline != null && !_isOnline() && _queueOfflineAction != null) {
-      await _queueOfflineAction(
-        isLike: false,
-        eventId: resolvedEventId,
-        authorPubkey: '', // Not needed for unlike
-      );
-      return;
-    }
-
-    // 3. Online → publish kind 5 (deferred while the like is still in
-    // flight; see [_unlikeRequestedWhilePending]).
-    // On failure, prefer queuing via [_queueOfflineAction] when wired so the
-    // optimistic unlike survives transient relay-pool problems (mirror of
-    // [likeEvent]). Without a wired callback, fall back to rollback +
-    // rethrow to preserve the original contract.
-    if (snapshotRecord.reactionEventId.startsWith('pending_')) {
-      // The real reaction id does not exist yet, so nothing can be referenced
-      // in a Kind 5 here. If this placeholder belongs to a currently awaited
-      // publish, record the intent for that exact attempt — [likeEvent]
-      // retracts it the moment the publish resolves (#7001).
-      if (_inFlightLikePublishPlaceholders.contains(
-        snapshotRecord.reactionEventId,
-      )) {
-        _unlikeRequestedWhilePending.add(snapshotRecord.reactionEventId);
-      }
-      return;
-    }
-
+    final interactionToken = _beginInteraction(eventId);
     try {
-      final deletionEvent = await _nostrClient.deleteEvent(
-        snapshotRecord.reactionEventId,
+      // 1. Optimistic-first: remove from memory + local storage and tick the
+      // watchLikedEventIds stream BEFORE any network I/O (mirror of likeEvent).
+      _deindexLikeRecord(resolvedEventId);
+      await _bestEffortLocalStorage(
+        () async => _localStorage?.deleteLikeRecord(resolvedEventId),
+        description: 'deleting the like record',
+        site: LikesRepositoryReportableSites.unlikeEventDeleteRecord,
       );
-      if (deletionEvent == null) {
-        throw const UnlikeFailedException('Failed to publish unlike deletion');
+      _decrementLikeCountCache(eventId, addressableId: addressableId);
+      _emitLikedIds();
+
+      // 2. Offline → leave the optimistic state in place; queue replays later
+      if (_isOnline != null && !_isOnline() && _queueOfflineAction != null) {
+        await _queueOfflineAction(
+          isLike: false,
+          eventId: resolvedEventId,
+          authorPubkey: '', // Not needed for unlike
+        );
+        return;
       }
-    } on SocialPublishException catch (e, stackTrace) {
-      if (!e.result.accountRestricted) {
+
+      // 3. Online → publish kind 5 (deferred while the like is still in
+      // flight; see [_unlikeRequestedWhilePending]).
+      // On failure, prefer queuing via [_queueOfflineAction] when wired so the
+      // optimistic unlike survives transient relay-pool problems (mirror of
+      // [likeEvent]). Without a wired callback, fall back to rollback +
+      // rethrow to preserve the original contract.
+      if (snapshotRecord.reactionEventId.startsWith('pending_')) {
+        // The real reaction id does not exist yet, so nothing can be referenced
+        // in a Kind 5 here. If this placeholder belongs to a currently awaited
+        // publish, record the intent for that exact attempt — [likeEvent]
+        // retracts it the moment the publish resolves (#7001).
+        if (_inFlightLikePublishPlaceholders.contains(
+          snapshotRecord.reactionEventId,
+        )) {
+          _unlikeRequestedWhilePending.add(snapshotRecord.reactionEventId);
+        }
+        return;
+      }
+
+      try {
+        final deletionEvent = await _nostrClient.deleteEvent(
+          snapshotRecord.reactionEventId,
+        );
+        if (deletionEvent == null) {
+          throw const UnlikeFailedException(
+            'Failed to publish unlike deletion',
+          );
+        }
+      } on SocialPublishException catch (e, stackTrace) {
+        if (!e.result.accountRestricted) {
+          if (_queueOfflineAction != null) {
+            Log.error(
+              'Unlike publish failed; queuing optimistic action for retry',
+              name: 'LikesRepository',
+              category: LogCategory.relay,
+              error: e,
+              stackTrace: stackTrace,
+            );
+            await _queueOfflineAction(
+              isLike: false,
+              eventId: resolvedEventId,
+              authorPubkey: '',
+            );
+            return;
+          }
+          await _restoreUnlikeIfCurrent(
+            eventId: eventId,
+            resolvedEventId: resolvedEventId,
+            snapshotRecord: snapshotRecord,
+            interactionToken: interactionToken,
+            previousCount: previousCount,
+            addressableId: addressableId,
+          );
+          Error.throwWithStackTrace(
+            const UnlikeFailedException('Failed to publish unlike deletion'),
+            stackTrace,
+          );
+        }
+        // Funnelcake deliberately exempts Kind 5 erasure requests from account
+        // enforcement. Keep this terminal branch for other trusted deployments
+        // and for policy changes, but do not publish a compensating deletion.
+        await _restoreUnlikeIfCurrent(
+          eventId: eventId,
+          resolvedEventId: resolvedEventId,
+          snapshotRecord: snapshotRecord,
+          interactionToken: interactionToken,
+          previousCount: previousCount,
+          addressableId: addressableId,
+        );
+        Error.throwWithStackTrace(
+          const LikeAccountRestrictedException(),
+          stackTrace,
+        );
+      } catch (e, stackTrace) {
         if (_queueOfflineAction != null) {
           Log.error(
             'Unlike publish failed; queuing optimistic action for retry',
@@ -1005,99 +1123,22 @@ class LikesRepository {
           await _queueOfflineAction(
             isLike: false,
             eventId: resolvedEventId,
-            authorPubkey: '',
+            authorPubkey: '', // Not needed for unlike
           );
           return;
         }
-        _indexLikeRecord(snapshotRecord);
-        await _bestEffortLocalStorage(
-          () async => _localStorage?.saveLikeRecord(snapshotRecord),
-          description: 'restoring the like record',
-          site: LikesRepositoryReportableSites.unlikeEventRestoreRecord,
-        );
-        if (previousCount != null) {
-          _writeCachedLikeCount(
-            eventId,
-            previousCount,
-            addressableId: addressableId,
-          );
-        }
-        _emitLikedIds();
-        Error.throwWithStackTrace(e, stackTrace);
-      }
-      // Funnelcake deliberately exempts Kind 5 erasure requests from account
-      // enforcement. Keep this terminal branch for other trusted deployments
-      // and for policy changes, but do not publish a compensating deletion.
-      if (_interactionRevisions[eventId] == interactionRevision &&
-          !_likeRecords.containsKey(resolvedEventId)) {
-        _indexLikeRecord(snapshotRecord);
-        await _bestEffortLocalStorage(
-          () async => _localStorage?.saveLikeRecord(snapshotRecord),
-          description: 'restoring a restricted unlike record',
-          site: LikesRepositoryReportableSites.unlikeEventRestoreRecord,
-        );
-        if (_interactionRevisions[eventId] != interactionRevision) {
-          final currentRecord = _likeRecords[resolvedEventId];
-          if (currentRecord == null) {
-            await _bestEffortLocalStorage(
-              () async => _localStorage?.deleteLikeRecord(resolvedEventId),
-              description: 'preserving the newer unlike state',
-              site: LikesRepositoryReportableSites.unlikeEventDeleteRecord,
-            );
-          } else {
-            await _bestEffortLocalStorage(
-              () async => _localStorage?.saveLikeRecord(currentRecord),
-              description: 'preserving the newer like record',
-              site: LikesRepositoryReportableSites.unlikeEventRestoreRecord,
-            );
-          }
-        }
-        if (_interactionRevisions[eventId] == interactionRevision) {
-          if (previousCount != null) {
-            _writeCachedLikeCount(
-              eventId,
-              previousCount,
-              addressableId: addressableId,
-            );
-          }
-          _emitLikedIds();
-        }
-      }
-      Error.throwWithStackTrace(
-        const LikeAccountRestrictedException(),
-        stackTrace,
-      );
-    } catch (e, stackTrace) {
-      if (_queueOfflineAction != null) {
-        Log.error(
-          'Unlike publish failed; queuing optimistic action for retry',
-          name: 'LikesRepository',
-          category: LogCategory.relay,
-          error: e,
-          stackTrace: stackTrace,
-        );
-        await _queueOfflineAction(
-          isLike: false,
-          eventId: resolvedEventId,
-          authorPubkey: '', // Not needed for unlike
-        );
-        return;
-      }
-      _indexLikeRecord(snapshotRecord);
-      await _bestEffortLocalStorage(
-        () async => _localStorage?.saveLikeRecord(snapshotRecord),
-        description: 'restoring the like record',
-        site: LikesRepositoryReportableSites.unlikeEventRestoreRecord,
-      );
-      if (previousCount != null) {
-        _writeCachedLikeCount(
-          eventId,
-          previousCount,
+        await _restoreUnlikeIfCurrent(
+          eventId: eventId,
+          resolvedEventId: resolvedEventId,
+          snapshotRecord: snapshotRecord,
+          interactionToken: interactionToken,
+          previousCount: previousCount,
           addressableId: addressableId,
         );
+        rethrow;
       }
-      _emitLikedIds();
-      rethrow;
+    } finally {
+      _completeInteraction(eventId, interactionToken);
     }
   }
 
@@ -1154,7 +1195,10 @@ class LikesRepository {
           stackTrace,
         );
       }
-      rethrow;
+      Error.throwWithStackTrace(
+        const UnlikeFailedException('Failed to publish unlike deletion'),
+        stackTrace,
+      );
     }
 
     if (deletionEvent == null) {
@@ -1660,6 +1704,19 @@ class LikesRepository {
       );
 
       return reactionEvent.id;
+    } on SocialPublishException catch (e, stackTrace) {
+      _deindexDownvoteRecord(eventId);
+      _emitDownvotedIds();
+      if (e.result.accountRestricted) {
+        Error.throwWithStackTrace(
+          const LikeAccountRestrictedException(),
+          stackTrace,
+        );
+      }
+      Error.throwWithStackTrace(
+        const LikeFailedException('Failed to publish downvote reaction'),
+        stackTrace,
+      );
     } catch (_) {
       _deindexDownvoteRecord(eventId);
       _emitDownvotedIds();
@@ -1723,6 +1780,19 @@ class LikesRepository {
           'Failed to publish downvote deletion',
         );
       }
+    } on SocialPublishException catch (e, stackTrace) {
+      _indexDownvoteRecord(snapshotRecord);
+      _emitDownvotedIds();
+      if (e.result.accountRestricted) {
+        Error.throwWithStackTrace(
+          const LikeAccountRestrictedException(),
+          stackTrace,
+        );
+      }
+      Error.throwWithStackTrace(
+        const UnlikeFailedException('Failed to publish downvote deletion'),
+        stackTrace,
+      );
     } catch (_) {
       _indexDownvoteRecord(snapshotRecord);
       _emitDownvotedIds();
@@ -1761,7 +1831,21 @@ class LikesRepository {
   ///
   /// Used for vote switching (removing old vote before publishing new one).
   Future<void> deleteReaction(String reactionEventId) async {
-    final deletionEvent = await _nostrClient.deleteEvent(reactionEventId);
+    final Event? deletionEvent;
+    try {
+      deletionEvent = await _nostrClient.deleteEvent(reactionEventId);
+    } on SocialPublishException catch (e, stackTrace) {
+      if (e.result.accountRestricted) {
+        Error.throwWithStackTrace(
+          const LikeAccountRestrictedException(),
+          stackTrace,
+        );
+      }
+      Error.throwWithStackTrace(
+        const UnlikeFailedException('Failed to delete reaction'),
+        stackTrace,
+      );
+    }
     if (deletionEvent == null) {
       throw const UnlikeFailedException('Failed to delete reaction');
     }

--- a/mobile/packages/likes_repository/test/src/likes_repository_test.dart
+++ b/mobile/packages/likes_repository/test/src/likes_repository_test.dart
@@ -850,6 +850,66 @@ void main() {
         expect(await repository.isLiked(testEventId), isFalse);
       });
 
+      test('restricted like rolls back and is never queued', () async {
+        final event = MockEvent();
+        when(
+          () => mockNostrClient.sendLike(
+            any(),
+            content: any(named: 'content'),
+            addressableId: any(named: 'addressableId'),
+            targetAuthorPubkey: any(named: 'targetAuthorPubkey'),
+            targetKind: any(named: 'targetKind'),
+          ),
+        ).thenThrow(
+          SocialPublishException(
+            SocialPublishResult(
+              status: SocialPublishStatus.accountRestricted,
+              event: event,
+              outcome: const PublishOutcome(
+                eventId: testReactionEventId,
+                acceptedBy: [],
+                rejectedBy: {
+                  'wss://relay.divine.video': 'blocked: pubkey is suspended',
+                },
+                noResponseFrom: [],
+              ),
+            ),
+          ),
+        );
+        when(
+          () => mockLocalStorage.saveLikeRecord(any()),
+        ).thenAnswer((_) async {});
+        when(
+          () => mockLocalStorage.deleteLikeRecord(any()),
+        ).thenAnswer((_) async => true);
+
+        var queueCalls = 0;
+        repository = createRepository(
+          queueOfflineAction:
+              ({
+                required isLike,
+                required eventId,
+                required authorPubkey,
+                addressableId,
+                targetKind,
+              }) async {
+                queueCalls++;
+              },
+        );
+
+        await expectLater(
+          repository.likeEvent(
+            eventId: testEventId,
+            authorPubkey: testAuthorPubkey,
+          ),
+          throwsA(isA<LikeAccountRestrictedException>()),
+        );
+
+        expect(queueCalls, isZero);
+        expect(await repository.isLiked(testEventId), isFalse);
+        verify(() => mockLocalStorage.deleteLikeRecord(testEventId)).called(1);
+      });
+
       // Defense-in-depth: when the publish fails but the offline-action
       // callback is wired, the optimistic state must be preserved and the
       // action queued for retry. This covers the "device says online but
@@ -896,7 +956,7 @@ void main() {
 
         expect(
           result,
-          equals('pending_like_$testEventId'),
+          startsWith('pending_like_'),
           reason: 'must return placeholder ID, not throw',
         );
         expect(queueCalls, equals(1));
@@ -945,7 +1005,7 @@ void main() {
           authorPubkey: testAuthorPubkey,
         );
 
-        expect(result, equals('pending_like_$testEventId'));
+        expect(result, startsWith('pending_like_'));
         expect(queueCalls, equals(1));
         expect(await repository.isLiked(testEventId), isTrue);
       });

--- a/mobile/packages/likes_repository/test/src/likes_repository_test.dart
+++ b/mobile/packages/likes_repository/test/src/likes_repository_test.dart
@@ -985,6 +985,81 @@ void main() {
         },
       );
 
+      test(
+        'stale relay-failure rollback preserves a newer confirmed record',
+        () async {
+          LikeRecord? storedRecord;
+          final firstPublish = Completer<Event>();
+          final deleteStarted = Completer<void>();
+          final finishDelete = Completer<void>();
+          var publishCalls = 0;
+          final failedEvent = MockEvent();
+          final newerReaction = createMockReaction(
+            id: 'newer_reaction_id',
+            targetEventId: testEventId,
+          );
+          when(
+            () => mockNostrClient.sendLike(
+              any(),
+              content: any(named: 'content'),
+              addressableId: any(named: 'addressableId'),
+              targetAuthorPubkey: any(named: 'targetAuthorPubkey'),
+              targetKind: any(named: 'targetKind'),
+            ),
+          ).thenAnswer((_) {
+            publishCalls++;
+            return publishCalls == 1
+                ? firstPublish.future
+                : Future.value(newerReaction);
+          });
+          when(() => mockLocalStorage.saveLikeRecord(any())).thenAnswer((
+            call,
+          ) async {
+            storedRecord = call.positionalArguments.single as LikeRecord;
+          });
+          when(() => mockLocalStorage.deleteLikeRecord(testEventId)).thenAnswer(
+            (
+              _,
+            ) async {
+              if (!deleteStarted.isCompleted) deleteStarted.complete();
+              await finishDelete.future;
+              storedRecord = null;
+              return true;
+            },
+          );
+          repository = createRepository();
+
+          final staleLike = repository.likeEvent(
+            eventId: testEventId,
+            authorPubkey: testAuthorPubkey,
+          );
+          final staleExpectation = expectLater(
+            staleLike,
+            throwsA(isA<LikeFailedException>()),
+          );
+          await Future<void>.delayed(Duration.zero);
+          firstPublish.completeError(
+            SocialPublishException(
+              SocialPublishResult(
+                status: SocialPublishStatus.noResponse,
+                event: failedEvent,
+              ),
+            ),
+          );
+          await deleteStarted.future;
+
+          await repository.likeEvent(
+            eventId: testEventId,
+            authorPubkey: testAuthorPubkey,
+          );
+          finishDelete.complete();
+          await staleExpectation;
+
+          expect(storedRecord?.reactionEventId, 'newer_reaction_id');
+          expect(await repository.isLiked(testEventId), isTrue);
+        },
+      );
+
       // Defense-in-depth: when the publish fails but the offline-action
       // callback is wired, the optimistic state must be preserved and the
       // action queued for retry. This covers the "device says online but
@@ -1564,6 +1639,66 @@ void main() {
         expect(storedRecord, isNull);
         expect(await repository.isLiked(testEventId), isFalse);
       });
+
+      test('stale relay-failure restore preserves a newer unlike', () async {
+        LikeRecord? storedRecord = createLikeRecord();
+        final firstDeletion = Completer<Event>();
+        final saveStarted = Completer<void>();
+        final finishSave = Completer<void>();
+        var deletionCalls = 0;
+        final failedEvent = MockEvent();
+        when(
+          () => mockLocalStorage.getAllLikeRecords(),
+        ).thenAnswer((_) async => [storedRecord!]);
+        when(() => mockLocalStorage.deleteLikeRecord(testEventId)).thenAnswer((
+          _,
+        ) async {
+          storedRecord = null;
+          return true;
+        });
+        when(() => mockLocalStorage.saveLikeRecord(any())).thenAnswer((
+          call,
+        ) async {
+          if (!saveStarted.isCompleted) saveStarted.complete();
+          await finishSave.future;
+          storedRecord = call.positionalArguments.single as LikeRecord;
+        });
+        when(() => mockNostrClient.deleteEvent(testReactionEventId)).thenAnswer(
+          (
+            _,
+          ) {
+            deletionCalls++;
+            return deletionCalls == 1
+                ? firstDeletion.future
+                : Future.value(MockEvent());
+          },
+        );
+        repository = createRepository();
+        await repository.isLiked(testEventId);
+
+        final staleUnlike = repository.unlikeEvent(testEventId);
+        final staleExpectation = expectLater(
+          staleUnlike,
+          throwsA(isA<UnlikeFailedException>()),
+        );
+        await Future<void>.delayed(Duration.zero);
+        firstDeletion.completeError(
+          SocialPublishException(
+            SocialPublishResult(
+              status: SocialPublishStatus.noResponse,
+              event: failedEvent,
+            ),
+          ),
+        );
+        await saveStarted.future;
+
+        await repository.unlikeEvent(testEventId);
+        finishSave.complete();
+        await staleExpectation;
+
+        expect(storedRecord, isNull);
+        expect(await repository.isLiked(testEventId), isFalse);
+      });
     });
 
     group('toggleLike', () {
@@ -1889,6 +2024,67 @@ void main() {
 
         expect(await repository.isDownvoted(testEventId), isFalse);
       });
+
+      test(
+        'translates relay publish results to repository exceptions',
+        () async {
+          final event = MockEvent();
+          when(
+            () => mockNostrClient.sendLike(
+              any(),
+              content: any(named: 'content'),
+              addressableId: any(named: 'addressableId'),
+              targetAuthorPubkey: any(named: 'targetAuthorPubkey'),
+              targetKind: any(named: 'targetKind'),
+            ),
+          ).thenThrow(
+            SocialPublishException(
+              SocialPublishResult(
+                status: SocialPublishStatus.noResponse,
+                event: event,
+              ),
+            ),
+          );
+          repository = createRepository(withLocalStorage: false);
+
+          await expectLater(
+            repository.downvoteEvent(
+              eventId: testEventId,
+              authorPubkey: testAuthorPubkey,
+            ),
+            throwsA(isA<LikeFailedException>()),
+          );
+        },
+      );
+
+      test('terminalizes a trusted account restriction', () async {
+        final event = MockEvent();
+        when(
+          () => mockNostrClient.sendLike(
+            any(),
+            content: any(named: 'content'),
+            addressableId: any(named: 'addressableId'),
+            targetAuthorPubkey: any(named: 'targetAuthorPubkey'),
+            targetKind: any(named: 'targetKind'),
+          ),
+        ).thenThrow(
+          SocialPublishException(
+            SocialPublishResult(
+              status: SocialPublishStatus.accountRestricted,
+              event: event,
+            ),
+          ),
+        );
+        repository = createRepository(withLocalStorage: false);
+
+        await expectLater(
+          repository.downvoteEvent(
+            eventId: testEventId,
+            authorPubkey: testAuthorPubkey,
+          ),
+          throwsA(isA<LikeAccountRestrictedException>()),
+        );
+      });
     });
 
     group('removeDownvote', () {
@@ -2195,6 +2391,47 @@ void main() {
 
         expect(await repository.isDownvoted(testEventId), isTrue);
       });
+
+      test(
+        'translates typed relay failures to UnlikeFailedException',
+        () async {
+          when(
+            () => mockNostrClient.sendLike(
+              any(),
+              content: any(named: 'content'),
+              addressableId: any(named: 'addressableId'),
+              targetAuthorPubkey: any(named: 'targetAuthorPubkey'),
+              targetKind: any(named: 'targetKind'),
+            ),
+          ).thenAnswer(
+            (_) async => createMockReaction(
+              id: testReactionEventId,
+              targetEventId: testEventId,
+              content: '-',
+            ),
+          );
+          final failedEvent = MockEvent();
+          when(() => mockNostrClient.deleteEvent(any())).thenThrow(
+            SocialPublishException(
+              SocialPublishResult(
+                status: SocialPublishStatus.noResponse,
+                event: failedEvent,
+              ),
+            ),
+          );
+          repository = createRepository(withLocalStorage: false);
+          await repository.downvoteEvent(
+            eventId: testEventId,
+            authorPubkey: testAuthorPubkey,
+          );
+
+          await expectLater(
+            repository.removeDownvote(testEventId),
+            throwsA(isA<UnlikeFailedException>()),
+          );
+          expect(await repository.isDownvoted(testEventId), isTrue);
+        },
+      );
     });
 
     group('toggleDownvote', () {
@@ -2261,6 +2498,31 @@ void main() {
 
           expect(result, isFalse);
           expect(await repository.isDownvoted(testEventId), isFalse);
+        },
+      );
+    });
+
+    group('deleteReaction', () {
+      test(
+        'translates typed relay failures to UnlikeFailedException',
+        () async {
+          final failedEvent = MockEvent();
+          when(
+            () => mockNostrClient.deleteEvent(testReactionEventId),
+          ).thenThrow(
+            SocialPublishException(
+              SocialPublishResult(
+                status: SocialPublishStatus.noResponse,
+                event: failedEvent,
+              ),
+            ),
+          );
+          repository = createRepository(withLocalStorage: false);
+
+          await expectLater(
+            repository.deleteReaction(testReactionEventId),
+            throwsA(isA<UnlikeFailedException>()),
+          );
         },
       );
     });

--- a/mobile/packages/likes_repository/test/src/likes_repository_test.dart
+++ b/mobile/packages/likes_repository/test/src/likes_repository_test.dart
@@ -910,6 +910,81 @@ void main() {
         verify(() => mockLocalStorage.deleteLikeRecord(testEventId)).called(1);
       });
 
+      test(
+        'stale restricted rollback preserves a newer confirmed record',
+        () async {
+          LikeRecord? storedRecord;
+          final firstPublish = Completer<Event>();
+          final deleteStarted = Completer<void>();
+          final finishDelete = Completer<void>();
+          var publishCalls = 0;
+          final restrictedEvent = MockEvent();
+          final newerReaction = createMockReaction(
+            id: 'newer_reaction_id',
+            targetEventId: testEventId,
+          );
+          when(
+            () => mockNostrClient.sendLike(
+              any(),
+              content: any(named: 'content'),
+              addressableId: any(named: 'addressableId'),
+              targetAuthorPubkey: any(named: 'targetAuthorPubkey'),
+              targetKind: any(named: 'targetKind'),
+            ),
+          ).thenAnswer((_) {
+            publishCalls++;
+            return publishCalls == 1
+                ? firstPublish.future
+                : Future.value(newerReaction);
+          });
+          when(() => mockLocalStorage.saveLikeRecord(any())).thenAnswer((
+            call,
+          ) async {
+            storedRecord = call.positionalArguments.single as LikeRecord;
+          });
+          when(() => mockLocalStorage.deleteLikeRecord(testEventId)).thenAnswer(
+            (
+              _,
+            ) async {
+              if (!deleteStarted.isCompleted) deleteStarted.complete();
+              await finishDelete.future;
+              storedRecord = null;
+              return true;
+            },
+          );
+          repository = createRepository();
+
+          final staleLike = repository.likeEvent(
+            eventId: testEventId,
+            authorPubkey: testAuthorPubkey,
+          );
+          final staleExpectation = expectLater(
+            staleLike,
+            throwsA(isA<LikeAccountRestrictedException>()),
+          );
+          await Future<void>.delayed(Duration.zero);
+          firstPublish.completeError(
+            SocialPublishException(
+              SocialPublishResult(
+                status: SocialPublishStatus.accountRestricted,
+                event: restrictedEvent,
+              ),
+            ),
+          );
+          await deleteStarted.future;
+
+          await repository.likeEvent(
+            eventId: testEventId,
+            authorPubkey: testAuthorPubkey,
+          );
+          finishDelete.complete();
+          await staleExpectation;
+
+          expect(storedRecord?.reactionEventId, 'newer_reaction_id');
+          expect(await repository.isLiked(testEventId), isTrue);
+        },
+      );
+
       // Defense-in-depth: when the publish fails but the offline-action
       // callback is wired, the optimistic state must be preserved and the
       // action queued for retry. This covers the "device says online but
@@ -1427,6 +1502,66 @@ void main() {
         await repository.unlikeEvent(testEventId);
 
         expect(queueCalls, equals(1));
+        expect(await repository.isLiked(testEventId), isFalse);
+      });
+
+      test('stale restricted restore preserves a newer unlike', () async {
+        LikeRecord? storedRecord = createLikeRecord();
+        final firstDeletion = Completer<Event>();
+        final saveStarted = Completer<void>();
+        final finishSave = Completer<void>();
+        var deletionCalls = 0;
+        final restrictedEvent = MockEvent();
+        when(
+          () => mockLocalStorage.getAllLikeRecords(),
+        ).thenAnswer((_) async => [storedRecord!]);
+        when(() => mockLocalStorage.deleteLikeRecord(testEventId)).thenAnswer((
+          _,
+        ) async {
+          storedRecord = null;
+          return true;
+        });
+        when(() => mockLocalStorage.saveLikeRecord(any())).thenAnswer((
+          call,
+        ) async {
+          if (!saveStarted.isCompleted) saveStarted.complete();
+          await finishSave.future;
+          storedRecord = call.positionalArguments.single as LikeRecord;
+        });
+        when(() => mockNostrClient.deleteEvent(testReactionEventId)).thenAnswer(
+          (
+            _,
+          ) {
+            deletionCalls++;
+            return deletionCalls == 1
+                ? firstDeletion.future
+                : Future.value(MockEvent());
+          },
+        );
+        repository = createRepository();
+        await repository.isLiked(testEventId);
+
+        final staleUnlike = repository.unlikeEvent(testEventId);
+        final staleExpectation = expectLater(
+          staleUnlike,
+          throwsA(isA<LikeAccountRestrictedException>()),
+        );
+        await Future<void>.delayed(Duration.zero);
+        firstDeletion.completeError(
+          SocialPublishException(
+            SocialPublishResult(
+              status: SocialPublishStatus.accountRestricted,
+              event: restrictedEvent,
+            ),
+          ),
+        );
+        await saveStarted.future;
+
+        await repository.unlikeEvent(testEventId);
+        finishSave.complete();
+        await staleExpectation;
+
+        expect(storedRecord, isNull);
         expect(await repository.isLiked(testEventId), isFalse);
       });
     });
@@ -4830,6 +4965,45 @@ void main() {
           throwsA(isA<LikeFailedException>()),
         );
       });
+
+      test(
+        'terminalizes a trusted account restriction during replay',
+        () async {
+          final event = MockEvent();
+          when(
+            () => mockNostrClient.sendLike(
+              any(),
+              content: any(named: 'content'),
+              addressableId: any(named: 'addressableId'),
+              targetAuthorPubkey: any(named: 'targetAuthorPubkey'),
+              targetKind: any(named: 'targetKind'),
+            ),
+          ).thenThrow(
+            SocialPublishException(
+              SocialPublishResult(
+                status: SocialPublishStatus.accountRestricted,
+                event: event,
+              ),
+            ),
+          );
+
+          repository = createRepository();
+
+          await expectLater(
+            repository.executeLikeAction(
+              eventId: testEventId,
+              authorPubkey: testAuthorPubkey,
+            ),
+            throwsA(
+              isA<LikeAccountRestrictedException>().having(
+                (error) => error,
+                'terminal marker',
+                isA<TerminalSocialActionException>(),
+              ),
+            ),
+          );
+        },
+      );
     });
 
     group('executeUnlikeAction', () {
@@ -4957,6 +5131,36 @@ void main() {
           throwsA(isA<UnlikeFailedException>()),
         );
       });
+
+      test(
+        'terminalizes a trusted account restriction during replay',
+        () async {
+          final event = MockEvent();
+          when(
+            () => mockLocalStorage.getLikeRecord(testEventId),
+          ).thenAnswer((_) async => createLikeRecord());
+          when(() => mockNostrClient.deleteEvent(any())).thenThrow(
+            SocialPublishException(
+              SocialPublishResult(
+                status: SocialPublishStatus.accountRestricted,
+                event: event,
+              ),
+            ),
+          );
+          repository = createRepository();
+
+          await expectLater(
+            repository.executeUnlikeAction(testEventId),
+            throwsA(
+              isA<LikeAccountRestrictedException>().having(
+                (error) => error,
+                'terminal marker',
+                isA<TerminalSocialActionException>(),
+              ),
+            ),
+          );
+        },
+      );
 
       test('falls back to local storage when not in cache', () async {
         final record = createLikeRecord();

--- a/mobile/packages/nostr_client/lib/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/nostr_client.dart
@@ -11,3 +11,5 @@ export 'src/nip89_client_tag.dart';
 export 'src/nostr_client.dart';
 export 'src/publish_result.dart';
 export 'src/relay_manager.dart';
+export 'src/relay_rejection_classifier.dart' hide relayUrlsEquivalent;
+export 'src/social_publish_result.dart';

--- a/mobile/packages/nostr_client/lib/src/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/src/nostr_client.dart
@@ -802,19 +802,27 @@ class NostrClient {
       }
     }
 
-    final outcome =
-        await _nostr.sendEventAwaitOk(
-          event,
-          targetRelays: effectiveTargets,
-          tempRelays: effectiveTargets,
-          timeout: timeout,
-        ) ??
-        PublishOutcome(
-          eventId: event.id,
-          acceptedBy: const [],
-          rejectedBy: const {},
-          noResponseFrom: const [],
-        );
+    PublishOutcome outcome;
+    try {
+      outcome =
+          await _nostr.sendEventAwaitOk(
+            event,
+            targetRelays: effectiveTargets,
+            tempRelays: effectiveTargets,
+            timeout: timeout,
+          ) ??
+          PublishOutcome(
+            eventId: event.id,
+            acceptedBy: const [],
+            rejectedBy: const {},
+            noResponseFrom: const [],
+          );
+    } on Object {
+      if (useOptimisticCache) {
+        _rollbackCachedEvent(event.id);
+      }
+      rethrow;
+    }
 
     if (outcome.failed) {
       return rollbackOnFailure(outcome);
@@ -1687,10 +1695,18 @@ class NostrClient {
       }
     }
 
-    final outcome = await publishEventAwaitOk(
-      event,
-      targetRelays: targetRelays,
-    );
+    final PublishOutcome outcome;
+    try {
+      outcome = await publishEventAwaitOk(
+        event,
+        targetRelays: targetRelays,
+      );
+    } on Object {
+      return SocialPublishResult(
+        status: SocialPublishStatus.sendFailed,
+        event: event,
+      );
+    }
     final status = switch (outcome) {
       PublishOutcome(:final acceptedBy) when acceptedBy.isNotEmpty =>
         SocialPublishStatus.accepted,

--- a/mobile/packages/nostr_client/lib/src/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/src/nostr_client.dart
@@ -9,6 +9,8 @@ import 'package:nostr_client/src/models/models.dart';
 import 'package:nostr_client/src/nip89_client_tag.dart';
 import 'package:nostr_client/src/publish_result.dart';
 import 'package:nostr_client/src/relay_manager.dart';
+import 'package:nostr_client/src/relay_rejection_classifier.dart';
+import 'package:nostr_client/src/social_publish_result.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
 import 'package:nostr_sdk/utils/hash_util.dart';
 import 'package:pool/pool.dart';
@@ -1505,14 +1507,12 @@ class NostrClient {
       content ?? '+',
     );
 
-    final result = await publishEvent(
+    final result = await publishSocialEventAwaitOk(
       likeEvent,
       targetRelays: targetRelays ?? tempRelays,
     );
-    if (result case PublishSuccess(:final event)) {
-      return event;
-    }
-    return null;
+    if (!result.accepted) throw SocialPublishException(result);
+    return likeEvent;
   }
 
   /// Sends a user profile (Kind 0 metadata event), waiting for relay
@@ -1660,14 +1660,57 @@ class NostrClient {
       ['e', eventId],
     ], 'delete');
 
-    final result = await publishEvent(
+    final result = await publishSocialEventAwaitOk(
       deletionEvent,
       targetRelays: targetRelays ?? tempRelays,
     );
-    if (result case PublishSuccess(:final event)) {
-      return event;
+    if (!result.accepted) throw SocialPublishException(result);
+    return deletionEvent;
+  }
+
+  /// Publishes a social event and classifies its relay acknowledgement.
+  ///
+  /// Any relay acceptance wins. Account restrictions are only classified
+  /// from the trusted default relay when no relay accepted the event.
+  Future<SocialPublishResult> publishSocialEventAwaitOk(
+    Event event, {
+    List<String>? targetRelays,
+  }) async {
+    final hasExplicitTargets = targetRelays != null && targetRelays.isNotEmpty;
+    if (_relayManager.connectedRelays.isEmpty && !hasExplicitTargets) {
+      await retryDisconnectedRelays();
+      if (_relayManager.connectedRelays.isEmpty) {
+        return SocialPublishResult(
+          status: SocialPublishStatus.noRelays,
+          event: event,
+        );
+      }
     }
-    return null;
+
+    final outcome = await publishEventAwaitOk(
+      event,
+      targetRelays: targetRelays,
+    );
+    final status = switch (outcome) {
+      PublishOutcome(:final acceptedBy) when acceptedBy.isNotEmpty =>
+        SocialPublishStatus.accepted,
+      _
+          when isAccountRestrictedOutcome(
+            outcome,
+            trustedRelayUrl: defaultRelayUrl,
+          ) =>
+        SocialPublishStatus.accountRestricted,
+      _ when isRateLimitedOutcome(outcome) => SocialPublishStatus.rateLimited,
+      PublishOutcome(:final rejectedBy) when rejectedBy.isNotEmpty =>
+        SocialPublishStatus.rejected,
+      PublishOutcome(:final noResponseFrom) when noResponseFrom.isNotEmpty =>
+        SocialPublishStatus.noResponse,
+      PublishOutcome(:final unreachableTargets)
+          when unreachableTargets.isNotEmpty =>
+        SocialPublishStatus.noRelays,
+      _ => SocialPublishStatus.sendFailed,
+    };
+    return SocialPublishResult(status: status, event: event, outcome: outcome);
   }
 
   /// Deletes multiple events

--- a/mobile/packages/nostr_client/lib/src/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/src/nostr_client.dart
@@ -1701,7 +1701,13 @@ class NostrClient {
         event,
         targetRelays: targetRelays,
       );
-    } on Object {
+    } on Object catch (error, stackTrace) {
+      log(
+        'Social event dispatch failed before relay acknowledgement',
+        name: 'NostrClient',
+        error: error,
+        stackTrace: stackTrace,
+      );
       return SocialPublishResult(
         status: SocialPublishStatus.sendFailed,
         event: event,

--- a/mobile/packages/nostr_client/lib/src/relay_rejection_classifier.dart
+++ b/mobile/packages/nostr_client/lib/src/relay_rejection_classifier.dart
@@ -1,0 +1,56 @@
+// ABOUTME: Classifies deterministic relay rejections from publish outcomes.
+// ABOUTME: Trusts account restrictions only when the configured relay says so.
+
+import 'package:nostr_client/src/relay_manager.dart';
+import 'package:nostr_sdk/nostr_sdk.dart';
+
+// These reason strings are Funnelcake's verbatim NIP-01 OK-false messages.
+// Exact matching deliberately fails closed if the producer wording changes.
+/// Whether [reason] exactly matches a known account restriction.
+bool isAccountRestrictedReason(String reason) {
+  final normalized = reason.trim().toLowerCase();
+  return normalized == 'blocked: pubkey is suspended' ||
+      normalized == 'blocked: pubkey is banned';
+}
+
+/// Whether two relay URLs normalize to the same endpoint identity.
+bool relayUrlsEquivalent(String a, String b) {
+  final normalizedA = normalizeRelayUrl(a);
+  final normalizedB = normalizeRelayUrl(b);
+  return normalizedA != null &&
+      normalizedB != null &&
+      normalizedA == normalizedB;
+}
+
+/// Whether only the trusted relay confirms an account restriction.
+bool isAccountRestrictedOutcome(
+  PublishOutcome outcome, {
+  required String trustedRelayUrl,
+}) =>
+    accountRestrictedReasonFromOutcome(
+      outcome,
+      trustedRelayUrl: trustedRelayUrl,
+    ) !=
+    null;
+
+/// Returns the trusted relay's exact restriction reason, if authoritative.
+String? accountRestrictedReasonFromOutcome(
+  PublishOutcome outcome, {
+  required String trustedRelayUrl,
+}) {
+  if (outcome.acceptedBy.isNotEmpty) return null;
+  for (final entry in outcome.rejectedBy.entries) {
+    if (relayUrlsEquivalent(entry.key, trustedRelayUrl) &&
+        isAccountRestrictedReason(entry.value)) {
+      return entry.value;
+    }
+  }
+  return null;
+}
+
+/// Whether no relay accepted and at least one relay returned a rate limit.
+bool isRateLimitedOutcome(PublishOutcome outcome) =>
+    outcome.acceptedBy.isEmpty &&
+    outcome.rejectedBy.values.any(
+      (reason) => reason.trim().toLowerCase().startsWith('rate-limited:'),
+    );

--- a/mobile/packages/nostr_client/lib/src/social_publish_result.dart
+++ b/mobile/packages/nostr_client/lib/src/social_publish_result.dart
@@ -1,0 +1,68 @@
+// ABOUTME: Typed outcome for social-event publishes that await relay OK frames.
+// ABOUTME: Preserves relay evidence while separating terminal policy failures.
+
+import 'package:nostr_sdk/nostr_sdk.dart';
+
+/// Product-relevant classification of a social-event publish attempt.
+enum SocialPublishStatus {
+  /// At least one relay returned OK true.
+  accepted,
+
+  /// The trusted relay confirmed suspension or ban enforcement.
+  accountRestricted,
+
+  /// No relay accepted and at least one returned a rate limit.
+  rateLimited,
+
+  /// No relay accepted and a relay returned another rejection.
+  rejected,
+
+  /// The event reached a relay but no OK arrived in time.
+  noResponse,
+
+  /// No relay could be reached after reconnection.
+  noRelays,
+
+  /// Signing, serialization, or SDK dispatch failed before an OK result.
+  sendFailed,
+}
+
+/// Marker for a social action that retry infrastructure must terminalize.
+abstract interface class TerminalSocialActionException implements Exception {}
+
+/// Result of publishing a social event through the await-OK path.
+class SocialPublishResult {
+  /// Creates a classified result while retaining the raw relay [outcome].
+  const SocialPublishResult({
+    required this.status,
+    required this.event,
+    this.outcome,
+  });
+
+  /// Product-relevant classification.
+  final SocialPublishStatus status;
+
+  /// Event whose publication was attempted.
+  final Event event;
+
+  /// Per-relay evidence, absent when no relay attempt was possible.
+  final PublishOutcome? outcome;
+
+  /// Whether at least one relay accepted the event.
+  bool get accepted => status == SocialPublishStatus.accepted;
+
+  /// Whether the trusted relay confirmed account enforcement.
+  bool get accountRestricted => status == SocialPublishStatus.accountRestricted;
+}
+
+/// A social publish that no relay accepted.
+class SocialPublishException implements Exception {
+  /// Creates a typed failure from [result].
+  const SocialPublishException(this.result);
+
+  /// The classified publish result.
+  final SocialPublishResult result;
+
+  @override
+  String toString() => 'SocialPublishException(${result.status.name})';
+}

--- a/mobile/packages/nostr_client/test/src/nostr_client_test.dart
+++ b/mobile/packages/nostr_client/test/src/nostr_client_test.dart
@@ -3008,27 +3008,38 @@ void main() {
     });
 
     group('sendLike', () {
-      test('sends like successfully', () async {
-        const eventId = 'event-to-like';
-        final likeEvent = _createTestEvent(kind: EventKind.reaction);
-
+      void stubOutcome(PublishOutcome outcome) {
         when(
-          () => mockNostr.sendEvent(
+          () => mockNostr.sendEventAwaitOk(
             any(),
             tempRelays: any(named: 'tempRelays'),
             targetRelays: any(named: 'targetRelays'),
+            timeout: any(named: 'timeout'),
           ),
-        ).thenAnswer((_) async => likeEvent);
+        ).thenAnswer((_) async => outcome);
+      }
+
+      test('sends like successfully', () async {
+        const eventId = 'event-to-like';
+        stubOutcome(
+          const PublishOutcome(
+            eventId: eventId,
+            acceptedBy: ['wss://relay.example.com'],
+            rejectedBy: {},
+            noResponseFrom: [],
+          ),
+        );
 
         final result = await client.sendLike(eventId);
 
-        expect(result, equals(likeEvent));
+        expect(result, isNotNull);
         final captured =
             verify(
-                  () => mockNostr.sendEvent(
+                  () => mockNostr.sendEventAwaitOk(
                     captureAny(),
                     tempRelays: any(named: 'tempRelays'),
                     targetRelays: any(named: 'targetRelays'),
+                    timeout: any(named: 'timeout'),
                   ),
                 ).captured.single
                 as Event;
@@ -3047,24 +3058,24 @@ void main() {
       test('sends like with custom content', () async {
         const eventId = 'event-to-like';
         const content = '❤️';
-        final likeEvent = _createTestEvent(kind: EventKind.reaction);
-
-        when(
-          () => mockNostr.sendEvent(
-            any(),
-            tempRelays: any(named: 'tempRelays'),
-            targetRelays: any(named: 'targetRelays'),
+        stubOutcome(
+          const PublishOutcome(
+            eventId: eventId,
+            acceptedBy: ['wss://relay.example.com'],
+            rejectedBy: {},
+            noResponseFrom: [],
           ),
-        ).thenAnswer((_) async => likeEvent);
+        );
 
         await client.sendLike(eventId, content: content);
 
         final captured =
             verify(
-                  () => mockNostr.sendEvent(
+                  () => mockNostr.sendEventAwaitOk(
                     captureAny(),
                     tempRelays: any(named: 'tempRelays'),
                     targetRelays: any(named: 'targetRelays'),
+                    timeout: any(named: 'timeout'),
                   ),
                 ).captured.single
                 as Event;
@@ -3075,15 +3086,14 @@ void main() {
         const eventId = 'event-to-like';
         final tempRelays = ['wss://temp.example.com'];
         final targetRelays = ['wss://target.example.com'];
-        final likeEvent = _createTestEvent(kind: EventKind.reaction);
-
-        when(
-          () => mockNostr.sendEvent(
-            any(),
-            tempRelays: any(named: 'tempRelays'),
-            targetRelays: any(named: 'targetRelays'),
+        stubOutcome(
+          const PublishOutcome(
+            eventId: eventId,
+            acceptedBy: ['wss://target.example.com'],
+            rejectedBy: {},
+            noResponseFrom: [],
           ),
-        ).thenAnswer((_) async => likeEvent);
+        );
 
         await client.sendLike(
           eventId,
@@ -3092,28 +3102,141 @@ void main() {
         );
 
         verify(
-          () => mockNostr.sendEvent(
+          () => mockNostr.sendEventAwaitOk(
             any(),
             tempRelays: targetRelays,
             targetRelays: targetRelays,
+            timeout: any(named: 'timeout'),
           ),
         ).called(1);
       });
 
-      test('returns null when sendLike fails', () async {
+      test('throws a typed restricted result for trusted rejection', () async {
         const eventId = 'event-to-like';
+        stubOutcome(
+          const PublishOutcome(
+            eventId: eventId,
+            acceptedBy: [],
+            rejectedBy: {
+              'wss://relay.example.com/': 'blocked: pubkey is suspended',
+            },
+            noResponseFrom: [],
+          ),
+        );
+
+        await expectLater(
+          client.sendLike(eventId),
+          throwsA(
+            isA<SocialPublishException>().having(
+              (error) => error.result.status,
+              'status',
+              SocialPublishStatus.accountRestricted,
+            ),
+          ),
+        );
+      });
+
+      test('any relay acceptance wins over a trusted rejection', () async {
+        const eventId = 'event-to-like';
+        stubOutcome(
+          const PublishOutcome(
+            eventId: eventId,
+            acceptedBy: ['wss://personal.example.com'],
+            rejectedBy: {
+              'wss://relay.example.com': 'blocked: pubkey is banned',
+            },
+            noResponseFrom: [],
+          ),
+        );
+
+        expect(await client.sendLike(eventId), isNotNull);
+      });
+
+      test('distinguishes rate limiting from unrelated rejection', () async {
+        const eventId = 'event-to-like';
+        stubOutcome(
+          const PublishOutcome(
+            eventId: eventId,
+            acceptedBy: [],
+            rejectedBy: {
+              'wss://relay.example.com': 'rate-limited: slow down',
+            },
+            noResponseFrom: [],
+          ),
+        );
+
+        await expectLater(
+          client.sendLike(eventId),
+          throwsA(
+            isA<SocialPublishException>().having(
+              (error) => error.result.status,
+              'status',
+              SocialPublishStatus.rateLimited,
+            ),
+          ),
+        );
+
+        reset(mockNostr);
+        when(() => mockNostr.publicKey).thenReturn(testPublicKey);
+        stubOutcome(
+          const PublishOutcome(
+            eventId: eventId,
+            acceptedBy: [],
+            rejectedBy: {
+              'wss://relay.example.com': 'blocked: event rejected by policy',
+            },
+            noResponseFrom: [],
+          ),
+        );
+        await expectLater(
+          client.sendLike(eventId),
+          throwsA(
+            isA<SocialPublishException>().having(
+              (error) => error.result.status,
+              'status',
+              SocialPublishStatus.rejected,
+            ),
+          ),
+        );
+      });
+
+      test('distinguishes no relays from SDK send failure', () async {
+        const eventId = 'event-to-like';
+        when(() => mockRelayManager.connectedRelays).thenReturn(const []);
+        when(mockRelayManager.retryDisconnectedRelays).thenAnswer((_) async {});
+
+        await expectLater(
+          client.sendLike(eventId),
+          throwsA(
+            isA<SocialPublishException>().having(
+              (error) => error.result.status,
+              'status',
+              SocialPublishStatus.noRelays,
+            ),
+          ),
+        );
 
         when(
-          () => mockNostr.sendEvent(
+          () => mockRelayManager.connectedRelays,
+        ).thenReturn(['wss://relay.example.com']);
+        when(
+          () => mockNostr.sendEventAwaitOk(
             any(),
             tempRelays: any(named: 'tempRelays'),
             targetRelays: any(named: 'targetRelays'),
+            timeout: any(named: 'timeout'),
           ),
         ).thenAnswer((_) async => null);
-
-        final result = await client.sendLike(eventId);
-
-        expect(result, isNull);
+        await expectLater(
+          client.sendLike(eventId),
+          throwsA(
+            isA<SocialPublishException>().having(
+              (error) => error.result.status,
+              'status',
+              SocialPublishStatus.sendFailed,
+            ),
+          ),
+        );
       });
     });
 
@@ -3562,27 +3685,38 @@ void main() {
     });
 
     group('deleteEvent', () {
-      test('deletes event successfully', () async {
-        const eventId = 'event-to-delete';
-        final deleteEvent = _createTestEvent(kind: EventKind.eventDeletion);
-
+      void stubOutcome(PublishOutcome outcome) {
         when(
-          () => mockNostr.sendEvent(
+          () => mockNostr.sendEventAwaitOk(
             any(),
             tempRelays: any(named: 'tempRelays'),
             targetRelays: any(named: 'targetRelays'),
+            timeout: any(named: 'timeout'),
           ),
-        ).thenAnswer((_) async => deleteEvent);
+        ).thenAnswer((_) async => outcome);
+      }
+
+      test('deletes event successfully', () async {
+        const eventId = 'event-to-delete';
+        stubOutcome(
+          const PublishOutcome(
+            eventId: eventId,
+            acceptedBy: ['wss://relay.example.com'],
+            rejectedBy: {},
+            noResponseFrom: [],
+          ),
+        );
 
         final result = await client.deleteEvent(eventId);
 
-        expect(result, equals(deleteEvent));
+        expect(result, isNotNull);
         final captured =
             verify(
-                  () => mockNostr.sendEvent(
+                  () => mockNostr.sendEventAwaitOk(
                     captureAny(),
                     tempRelays: any(named: 'tempRelays'),
                     targetRelays: any(named: 'targetRelays'),
+                    timeout: any(named: 'timeout'),
                   ),
                 ).captured.single
                 as Event;
@@ -3602,15 +3736,14 @@ void main() {
         const eventId = 'event-to-delete';
         final tempRelays = ['wss://temp.example.com'];
         final targetRelays = ['wss://target.example.com'];
-        final deleteEvent = _createTestEvent(kind: EventKind.eventDeletion);
-
-        when(
-          () => mockNostr.sendEvent(
-            any(),
-            tempRelays: any(named: 'tempRelays'),
-            targetRelays: any(named: 'targetRelays'),
+        stubOutcome(
+          const PublishOutcome(
+            eventId: eventId,
+            acceptedBy: ['wss://target.example.com'],
+            rejectedBy: {},
+            noResponseFrom: [],
           ),
-        ).thenAnswer((_) async => deleteEvent);
+        );
 
         await client.deleteEvent(
           eventId,
@@ -3619,28 +3752,36 @@ void main() {
         );
 
         verify(
-          () => mockNostr.sendEvent(
+          () => mockNostr.sendEventAwaitOk(
             any(),
             tempRelays: targetRelays,
             targetRelays: targetRelays,
+            timeout: any(named: 'timeout'),
           ),
         ).called(1);
       });
 
-      test('returns null when deleteEvent fails', () async {
+      test('throws a typed no-response result when no relay answers', () async {
         const eventId = 'event-to-delete';
-
-        when(
-          () => mockNostr.sendEvent(
-            any(),
-            tempRelays: any(named: 'tempRelays'),
-            targetRelays: any(named: 'targetRelays'),
+        stubOutcome(
+          const PublishOutcome(
+            eventId: eventId,
+            acceptedBy: [],
+            rejectedBy: {},
+            noResponseFrom: ['wss://relay.example.com'],
           ),
-        ).thenAnswer((_) async => null);
+        );
 
-        final result = await client.deleteEvent(eventId);
-
-        expect(result, isNull);
+        await expectLater(
+          client.deleteEvent(eventId),
+          throwsA(
+            isA<SocialPublishException>().having(
+              (error) => error.result.status,
+              'status',
+              SocialPublishStatus.noResponse,
+            ),
+          ),
+        );
       });
     });
 

--- a/mobile/packages/nostr_client/test/src/nostr_client_test.dart
+++ b/mobile/packages/nostr_client/test/src/nostr_client_test.dart
@@ -892,6 +892,46 @@ void main() {
         ).called(1);
       });
 
+      test('rolls back optimistic cache when SDK dispatch throws', () async {
+        final mockDbClient = _MockAppDbClient();
+        final mockDatabase = _MockAppDatabase();
+        final mockNostrEventsDao = _MockNostrEventsDao();
+        when(() => mockDbClient.database).thenReturn(mockDatabase);
+        when(() => mockDatabase.nostrEventsDao).thenReturn(mockNostrEventsDao);
+        when(
+          () => mockNostrEventsDao.upsertEvent(any()),
+        ).thenAnswer((_) async {});
+        when(
+          () => mockNostrEventsDao.deleteEventsByIds(any()),
+        ).thenAnswer((_) async => 1);
+
+        final clientWithCache = NostrClient.forTesting(
+          nostr: mockNostr,
+          relayManager: mockRelayManager,
+          dbClient: mockDbClient,
+        );
+        final event = _createTestEvent(kind: EventKind.reaction);
+        final error = StateError('SDK dispatch failed');
+        when(
+          () => mockNostr.sendEventAwaitOk(
+            any(),
+            tempRelays: any(named: 'tempRelays'),
+            targetRelays: any(named: 'targetRelays'),
+            timeout: any(named: 'timeout'),
+          ),
+        ).thenThrow(error);
+
+        await expectLater(
+          clientWithCache.publishEventAwaitOk(event),
+          throwsA(same(error)),
+        );
+
+        verify(() => mockNostrEventsDao.upsertEvent(event)).called(1);
+        verify(
+          () => mockNostrEventsDao.deleteEventsByIds([event.id]),
+        ).called(1);
+      });
+
       test('returns failed outcome without attempting send when no relays are '
           'reachable', () async {
         final event = _createTestEvent();
@@ -3238,6 +3278,32 @@ void main() {
           ),
         );
       });
+
+      test(
+        'maps a thrown SDK failure to the typed send-failed result',
+        () async {
+          const eventId = 'event-to-like';
+          when(
+            () => mockNostr.sendEventAwaitOk(
+              any(),
+              tempRelays: any(named: 'tempRelays'),
+              targetRelays: any(named: 'targetRelays'),
+              timeout: any(named: 'timeout'),
+            ),
+          ).thenThrow(StateError('SDK dispatch failed'));
+
+          await expectLater(
+            client.sendLike(eventId),
+            throwsA(
+              isA<SocialPublishException>().having(
+                (error) => error.result.status,
+                'status',
+                SocialPublishStatus.sendFailed,
+              ),
+            ),
+          );
+        },
+      );
     });
 
     group('sendProfileAwaitOk', () {

--- a/mobile/packages/reposts_repository/lib/src/reposts_repository.dart
+++ b/mobile/packages/reposts_repository/lib/src/reposts_repository.dart
@@ -567,6 +567,14 @@ class RepostsRepository {
         _cacheRepostCount(addressableId, previousCount);
       }
       _emitRepostedIds();
+      if (e is SocialPublishException) {
+        Error.throwWithStackTrace(
+          const UnrepostFailedException(
+            'Failed to publish unrepost deletion',
+          ),
+          stackTrace,
+        );
+      }
       rethrow;
     }
   }
@@ -597,7 +605,15 @@ class RepostsRepository {
     }
 
     // Publish Kind 5 deletion event via NostrClient
-    final deletionEvent = await _nostrClient.deleteEvent(record.repostEventId);
+    final Event? deletionEvent;
+    try {
+      deletionEvent = await _nostrClient.deleteEvent(record.repostEventId);
+    } on SocialPublishException catch (_, stackTrace) {
+      Error.throwWithStackTrace(
+        const UnrepostFailedException('Failed to publish unrepost deletion'),
+        stackTrace,
+      );
+    }
 
     if (deletionEvent == null) {
       throw const UnrepostFailedException(

--- a/mobile/packages/reposts_repository/lib/src/reposts_repository.dart
+++ b/mobile/packages/reposts_repository/lib/src/reposts_repository.dart
@@ -568,6 +568,13 @@ class RepostsRepository {
       }
       _emitRepostedIds();
       if (e is SocialPublishException) {
+        Log.error(
+          'Unrepost deletion was not accepted',
+          name: 'RepostsRepository',
+          category: LogCategory.relay,
+          error: e,
+          stackTrace: stackTrace,
+        );
         Error.throwWithStackTrace(
           const UnrepostFailedException(
             'Failed to publish unrepost deletion',
@@ -608,7 +615,14 @@ class RepostsRepository {
     final Event? deletionEvent;
     try {
       deletionEvent = await _nostrClient.deleteEvent(record.repostEventId);
-    } on SocialPublishException catch (_, stackTrace) {
+    } on SocialPublishException catch (error, stackTrace) {
+      Log.error(
+        'Queued unrepost deletion was not accepted',
+        name: 'RepostsRepository',
+        category: LogCategory.relay,
+        error: error,
+        stackTrace: stackTrace,
+      );
       Error.throwWithStackTrace(
         const UnrepostFailedException('Failed to publish unrepost deletion'),
         stackTrace,

--- a/mobile/packages/reposts_repository/test/src/reposts_repository_test.dart
+++ b/mobile/packages/reposts_repository/test/src/reposts_repository_test.dart
@@ -2995,6 +2995,38 @@ void main() {
         );
       });
 
+      test(
+        'translates typed relay failures to UnrepostFailedException',
+        () async {
+          final failedEvent = createMockEvent(
+            id: 'deletion_event_id',
+            kind: 5,
+            createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+          );
+          when(() => mockNostrClient.deleteEvent(any())).thenThrow(
+            SocialPublishException(
+              SocialPublishResult(
+                status: SocialPublishStatus.noResponse,
+                event: failedEvent,
+              ),
+            ),
+          );
+          final repository = RepostsRepository(
+            nostrClient: mockNostrClient,
+            localStorage: mockLocalStorage,
+          );
+          await repository.repostVideo(
+            addressableId: testAddressableId,
+            originalAuthorPubkey: testAuthorPubkey,
+          );
+
+          await expectLater(
+            repository.executeUnrepostAction(testAddressableId),
+            throwsA(isA<UnrepostFailedException>()),
+          );
+        },
+      );
+
       test('falls back to local storage when not in cache', () async {
         final record = RepostRecord(
           addressableId: testAddressableId,

--- a/mobile/packages/reposts_repository/test/src/reposts_repository_test.dart
+++ b/mobile/packages/reposts_repository/test/src/reposts_repository_test.dart
@@ -1084,6 +1084,35 @@ void main() {
       });
 
       test(
+        'translates typed relay failures to UnrepostFailedException',
+        () async {
+          final failedEvent = createMockEvent(
+            id: 'deletion_event_id',
+            kind: 5,
+            createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+          );
+          when(() => mockNostrClient.deleteEvent(any())).thenThrow(
+            SocialPublishException(
+              SocialPublishResult(
+                status: SocialPublishStatus.noResponse,
+                event: failedEvent,
+              ),
+            ),
+          );
+          final repository = RepostsRepository(nostrClient: mockNostrClient);
+          await repository.repostVideo(
+            addressableId: testAddressableId,
+            originalAuthorPubkey: testAuthorPubkey,
+          );
+
+          await expectLater(
+            repository.unrepostVideo(testAddressableId),
+            throwsA(isA<UnrepostFailedException>()),
+          );
+        },
+      );
+
+      test(
         'ticks watchRepostedAddressableIds before deleteEvent completes',
         () async {
           // Seed a record by reposting first.

--- a/mobile/test/blocs/video_interactions/video_interactions_bloc_test.dart
+++ b/mobile/test/blocs/video_interactions/video_interactions_bloc_test.dart
@@ -1112,6 +1112,36 @@ void main() {
         errors: () => [isA<Exception>()],
       );
 
+      blocTest<VideoInteractionsBloc, VideoInteractionsState>(
+        'rolls back and emits typed restriction status',
+        setUp: () {
+          when(
+            () => mockLikesRepository.toggleLike(
+              eventId: testEventId,
+              authorPubkey: testAuthorPubkey,
+            ),
+          ).thenThrow(const LikeAccountRestrictedException());
+        },
+        build: createBloc,
+        seed: () => const VideoInteractionsState(
+          status: VideoInteractionsStatus.success,
+          likeCount: 10,
+        ),
+        act: (bloc) => bloc.add(const VideoInteractionsLikeToggled()),
+        expect: () => [
+          const VideoInteractionsState(
+            status: VideoInteractionsStatus.success,
+            isLiked: true,
+            likeCount: 11,
+          ),
+          const VideoInteractionsState(
+            status: VideoInteractionsStatus.accountRestricted,
+            likeCount: 10,
+            accountRestrictionRevision: 1,
+          ),
+        ],
+      );
+
       // Regression for #3503: when the home feed mounts a feed item whose
       // BlocProvider snapshotted a stale LikesRepository (one wrapping a
       // Nostr instance with an empty cached public key), every sendLike
@@ -1238,6 +1268,51 @@ void main() {
           expect(bloc.state.isLiked, isTrue);
           expect(bloc.state.likeCount, 11);
         },
+      );
+
+      blocTest<VideoInteractionsBloc, VideoInteractionsState>(
+        'older restriction cannot roll back a newer tap',
+        setUp: () {
+          final first = Completer<bool>();
+          final second = Completer<bool>();
+          var call = 0;
+          when(
+            () => mockLikesRepository.toggleLike(
+              eventId: testEventId,
+              authorPubkey: testAuthorPubkey,
+            ),
+          ).thenAnswer((_) => call++ == 0 ? first.future : second.future);
+          addTearDown(() {
+            if (!first.isCompleted) first.completeError(Exception('unused'));
+            if (!second.isCompleted) second.complete(false);
+          });
+          Future<void>.delayed(const Duration(milliseconds: 20), () {
+            second.complete(false);
+            first.completeError(const LikeAccountRestrictedException());
+          });
+        },
+        build: createBloc,
+        seed: () => const VideoInteractionsState(
+          status: VideoInteractionsStatus.success,
+          likeCount: 10,
+        ),
+        act: (bloc) async {
+          bloc.add(const VideoInteractionsLikeToggled());
+          await Future<void>.delayed(Duration.zero);
+          bloc.add(const VideoInteractionsLikeToggled());
+        },
+        wait: const Duration(milliseconds: 80),
+        expect: () => [
+          const VideoInteractionsState(
+            status: VideoInteractionsStatus.success,
+            isLiked: true,
+            likeCount: 11,
+          ),
+          const VideoInteractionsState(
+            status: VideoInteractionsStatus.success,
+            likeCount: 10,
+          ),
+        ],
       );
 
       blocTest<VideoInteractionsBloc, VideoInteractionsState>(

--- a/mobile/test/blocs/video_interactions/video_interactions_bloc_test.dart
+++ b/mobile/test/blocs/video_interactions/video_interactions_bloc_test.dart
@@ -1113,7 +1113,7 @@ void main() {
       );
 
       blocTest<VideoInteractionsBloc, VideoInteractionsState>(
-        'rolls back and emits typed restriction status',
+        'rolls back and advances the account restriction revision',
         setUp: () {
           when(
             () => mockLikesRepository.toggleLike(
@@ -1135,7 +1135,7 @@ void main() {
             likeCount: 11,
           ),
           const VideoInteractionsState(
-            status: VideoInteractionsStatus.accountRestricted,
+            status: VideoInteractionsStatus.success,
             likeCount: 10,
             accountRestrictionRevision: 1,
           ),

--- a/mobile/test/services/pending_action_service_test.dart
+++ b/mobile/test/services/pending_action_service_test.dart
@@ -6,11 +6,16 @@ import 'package:db_client/db_client.dart';
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:nostr_client/nostr_client.dart';
 import 'package:openvine/services/connection_status_service.dart';
 import 'package:openvine/services/pending_action_service.dart';
 
 class MockConnectionStatusService extends Mock
     implements ConnectionStatusService {}
+
+class _TerminalActionException implements TerminalSocialActionException {
+  const _TerminalActionException();
+}
 
 void main() {
   late PendingActionService service;
@@ -292,6 +297,28 @@ void main() {
         final allActions = service.allActions;
         expect(allActions.length, equals(1));
         expect(allActions.first.retryCount, greaterThan(0));
+      });
+
+      test('terminalizes account-policy failures without retrying', () async {
+        when(() => mockConnectionService.isOnline).thenReturn(true);
+        await service.queueAction(
+          type: PendingActionType.like,
+          targetId: 'event123',
+          authorPubkey: 'author123',
+        );
+
+        var attempts = 0;
+        service.registerExecutor(PendingActionType.like, (_) async {
+          attempts++;
+          throw const _TerminalActionException();
+        });
+
+        await service.syncPendingActions();
+
+        expect(attempts, 1);
+        expect(service.pendingActions, isEmpty);
+        expect(service.allActions.single.status, PendingActionStatus.failed);
+        expect(service.allActions.single.retryCount, 0);
       });
     });
 

--- a/mobile/test/widgets/video_feed_item/video_interactions_restriction_listener_test.dart
+++ b/mobile/test/widgets/video_feed_item/video_interactions_restriction_listener_test.dart
@@ -1,0 +1,63 @@
+// ABOUTME: Verifies restricted interaction publishes open Account Status.
+// ABOUTME: Pins the typed BLoC-state to UI-navigation boundary.
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:openvine/blocs/video_interactions/video_interactions_bloc.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/screens/settings/account_status_screen.dart';
+import 'package:openvine/widgets/video_feed_item/video_interactions_restriction_listener.dart';
+
+class _MockVideoInteractionsBloc
+    extends MockBloc<VideoInteractionsEvent, VideoInteractionsState>
+    implements VideoInteractionsBloc {}
+
+void main() {
+  testWidgets('opens Account Status with confirmed-publish evidence', (
+    tester,
+  ) async {
+    final bloc = _MockVideoInteractionsBloc();
+    const initial = VideoInteractionsState(
+      status: VideoInteractionsStatus.success,
+    );
+    const restricted = VideoInteractionsState(
+      status: VideoInteractionsStatus.accountRestricted,
+      accountRestrictionRevision: 1,
+    );
+    whenListen(bloc, Stream.value(restricted), initialState: initial);
+
+    final router = GoRouter(
+      routes: [
+        GoRoute(
+          path: '/',
+          builder: (context, state) =>
+              BlocProvider<VideoInteractionsBloc>.value(
+                value: bloc,
+                child: const VideoInteractionsRestrictionListener(
+                  child: SizedBox(),
+                ),
+              ),
+        ),
+        GoRoute(
+          path: '/account-status',
+          name: AccountStatusScreen.routeName,
+          builder: (context, state) => Text('confirmed=${state.extra}'),
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      MaterialApp.router(
+        routerConfig: router,
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('confirmed=true'), findsOneWidget);
+  });
+}

--- a/mobile/test/widgets/video_feed_item/video_interactions_restriction_listener_test.dart
+++ b/mobile/test/widgets/video_feed_item/video_interactions_restriction_listener_test.dart
@@ -16,48 +16,50 @@ class _MockVideoInteractionsBloc
     implements VideoInteractionsBloc {}
 
 void main() {
-  testWidgets('opens Account Status with confirmed-publish evidence', (
-    tester,
-  ) async {
-    final bloc = _MockVideoInteractionsBloc();
-    const initial = VideoInteractionsState(
-      status: VideoInteractionsStatus.success,
-    );
-    const restricted = VideoInteractionsState(
-      status: VideoInteractionsStatus.accountRestricted,
-      accountRestrictionRevision: 1,
-    );
-    whenListen(bloc, Stream.value(restricted), initialState: initial);
+  group('navigation', () {
+    testWidgets('opens Account Status with confirmed-publish evidence', (
+      tester,
+    ) async {
+      final bloc = _MockVideoInteractionsBloc();
+      const initial = VideoInteractionsState(
+        status: VideoInteractionsStatus.success,
+      );
+      const restricted = VideoInteractionsState(
+        status: VideoInteractionsStatus.accountRestricted,
+        accountRestrictionRevision: 1,
+      );
+      whenListen(bloc, Stream.value(restricted), initialState: initial);
 
-    final router = GoRouter(
-      routes: [
-        GoRoute(
-          path: '/',
-          builder: (context, state) =>
-              BlocProvider<VideoInteractionsBloc>.value(
-                value: bloc,
-                child: const VideoInteractionsRestrictionListener(
-                  child: SizedBox(),
+      final router = GoRouter(
+        routes: [
+          GoRoute(
+            path: '/',
+            builder: (context, state) =>
+                BlocProvider<VideoInteractionsBloc>.value(
+                  value: bloc,
+                  child: const VideoInteractionsRestrictionListener(
+                    child: SizedBox(),
+                  ),
                 ),
-              ),
-        ),
-        GoRoute(
-          path: '/account-status',
-          name: AccountStatusScreen.routeName,
-          builder: (context, state) => Text('confirmed=${state.extra}'),
-        ),
-      ],
-    );
+          ),
+          GoRoute(
+            path: '/account-status',
+            name: AccountStatusScreen.routeName,
+            builder: (context, state) => Text('confirmed=${state.extra}'),
+          ),
+        ],
+      );
 
-    await tester.pumpWidget(
-      MaterialApp.router(
-        routerConfig: router,
-        localizationsDelegates: AppLocalizations.localizationsDelegates,
-        supportedLocales: AppLocalizations.supportedLocales,
-      ),
-    );
-    await tester.pumpAndSettle();
+      await tester.pumpWidget(
+        MaterialApp.router(
+          routerConfig: router,
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+        ),
+      );
+      await tester.pumpAndSettle();
 
-    expect(find.text('confirmed=true'), findsOneWidget);
+      expect(find.text('confirmed=true'), findsOneWidget);
+    });
   });
 }

--- a/mobile/test/widgets/video_feed_item/video_interactions_restriction_listener_test.dart
+++ b/mobile/test/widgets/video_feed_item/video_interactions_restriction_listener_test.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Verifies restricted interaction publishes open Account Status.
 // ABOUTME: Pins the typed BLoC-state to UI-navigation boundary.
 
+import 'dart:async';
+
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -25,7 +27,6 @@ void main() {
         status: VideoInteractionsStatus.success,
       );
       const restricted = VideoInteractionsState(
-        status: VideoInteractionsStatus.accountRestricted,
         accountRestrictionRevision: 1,
       );
       whenListen(bloc, Stream.value(restricted), initialState: initial);
@@ -43,7 +44,7 @@ void main() {
                 ),
           ),
           GoRoute(
-            path: '/account-status',
+            path: AccountStatusScreen.path,
             name: AccountStatusScreen.routeName,
             builder: (context, state) => Text('confirmed=${state.extra}'),
           ),
@@ -60,6 +61,55 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('confirmed=true'), findsOneWidget);
+    });
+
+    testWidgets('does not stack Account Status for another restriction', (
+      tester,
+    ) async {
+      final bloc = _MockVideoInteractionsBloc();
+      final states = StreamController<VideoInteractionsState>();
+      whenListen(
+        bloc,
+        states.stream,
+        initialState: const VideoInteractionsState(),
+      );
+
+      final router = GoRouter(
+        routes: [
+          GoRoute(
+            path: '/',
+            builder: (context, state) =>
+                BlocProvider<VideoInteractionsBloc>.value(
+                  value: bloc,
+                  child: const VideoInteractionsRestrictionListener(
+                    child: SizedBox(),
+                  ),
+                ),
+          ),
+          GoRoute(
+            path: AccountStatusScreen.path,
+            name: AccountStatusScreen.routeName,
+            builder: (context, state) => Text('confirmed=${state.extra}'),
+          ),
+        ],
+      );
+
+      await tester.pumpWidget(
+        MaterialApp.router(
+          routerConfig: router,
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+        ),
+      );
+      states.add(const VideoInteractionsState(accountRestrictionRevision: 1));
+      await tester.pumpAndSettle();
+      states.add(const VideoInteractionsState(accountRestrictionRevision: 2));
+      await tester.pumpAndSettle();
+
+      router.pop();
+      await tester.pumpAndSettle();
+      expect(router.routerDelegate.currentConfiguration.uri.path, '/');
+      await states.close();
     });
   });
 }


### PR DESCRIPTION
## Description

Waits for relay OK confirmation before treating likes as published, rolls back authoritative account-policy rejections without adding permanent retries, and routes confirmed restrictions to Account Status. It also moves the relay classifier into nostr_client as the shared seam for the remaining social-action cuts; Kind 5 deletion remains supported and the producer contract follow-up is tracked in divinevideo/divine-funnelcake#1146.

**Related Issue:** Closes #8160

Part of #8159

## Scope

This does not change Funnelcake enforcement policy or extend relay-confirmed reconciliation to comments, follows, reposts, or direct messages. Those remain follow-up work under #8159.

## Verification

- Mobile CI passed, including format, analysis, generated-file checks, goldens, and all four test shards.
- Likes Repository CI passed.
- Nostr Client CI passed.
- Reposts Repository CI passed with 145 tests and full package line coverage.
- Mobile integration tests and the Flutter web preview build passed.
- Focused interaction, pending-action, and Account Status routing coverage passed during review.

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [ ] Build configuration change
- [ ] Documentation
- [ ] Chore