### PR TITLE
fix(dm): give a 1:1 DM send a per-invocation nonce so same-second duplicates cannot collide

### DIFF
--- a/mobile/lib/blocs/dm/conversation/conversation_state.dart
+++ b/mobile/lib/blocs/dm/conversation/conversation_state.dart
@@ -150,10 +150,11 @@ class ConversationState extends Equatable {
   static String _batchKeyOf(OutgoingDm q) =>
       q.sendBatchId ?? '${q.ownerPubkey}|${q.createdAt}|${q.content}';
 
-  /// Batch key for a persisted message, mirroring [_batchKeyOf]. A received
-  /// message or 1:1 send has a null `sendBatchId` and falls back to a tuple
-  /// keyed on its OWN sender — which no owner-scoped group queue row shares —
-  /// so it can never aggregate someone else's in-flight batch.
+  /// Batch key for a persisted message, mirroring [_batchKeyOf]. Received and
+  /// legacy messages have a null `sendBatchId` and fall back to a tuple keyed
+  /// on their OWN sender, which no owner-scoped group queue row shares. A 1:1
+  /// send has a unique id, but topology checks still keep it out of group
+  /// aggregation.
   static String _batchKeyOfMessage(DmMessage m) =>
       m.sendBatchId ?? '${m.senderPubkey}|${m.createdAt}|${m.content}';
 

--- a/mobile/packages/db_client/lib/src/database/app_database.g.dart
+++ b/mobile/packages/db_client/lib/src/database/app_database.g.dart
@@ -9715,14 +9715,12 @@ class DirectMessageRow extends DataClass
   /// NULL for legacy messages created before multi-account support.
   final String? ownerPubkey;
 
-  /// Durable, collision-proof identity of the group-send fan-out this message
-  /// belongs to (the first sibling rumor's event id). Set ONLY when persisting
-  /// a group send's single local message; NULL for 1:1 sends and every received
-  /// message. Lets the send / recovery dedup and the UI's optimistic grouping
-  /// match a batch by an exact stored value instead of the collision-prone
-  /// `(sender, content, created_at ±5s)` heuristic that `hasMatchingMessage`
-  /// uses — two distinct group sends of identical text seconds apart no longer
-  /// collapse into one.
+  /// Durable, collision-proof identity of one send invocation. Set on the
+  /// sender's local message for 1:1 sends and shared by the single local
+  /// message representing a group fan-out; NULL for received and legacy
+  /// messages. It gives same-second 1:1 sends distinct rumor ids and lets group
+  /// recovery and optimistic UI grouping match a fan-out by an exact value
+  /// instead of the collision-prone `(sender, content, created_at ±5s)` tuple.
   final String? sendBatchId;
   const DirectMessageRow({
     required this.id,
@@ -12680,12 +12678,12 @@ class OutgoingDmRow extends DataClass implements Insertable<OutgoingDmRow> {
   /// `direct_messages.owner_pubkey` for multi-account isolation.
   final String ownerPubkey;
 
-  /// Durable, collision-proof identity of the group-send fan-out this row
-  /// belongs to (the first sibling rumor's event id, stamped identically on
-  /// every per-recipient sibling by `sendGroupMessage`). NULL for 1:1 sends,
-  /// which have no siblings. Persistence dedup, optimistic grouping, sibling
-  /// lookup, and cancellation all key off this instead of the collision-prone
-  /// `(content, created_at)` tuple. See `DirectMessages.sendBatchId`.
+  /// Durable, collision-proof identity of one send invocation. A 1:1 send has
+  /// one unique value; `sendGroupMessage` stamps one shared value on every
+  /// per-recipient sibling. It separates same-second identical sends and lets
+  /// group persistence dedup, optimistic grouping, sibling lookup, and
+  /// cancellation use an exact value. NULL only for legacy rows. See
+  /// `DirectMessages.sendBatchId`.
   final String? sendBatchId;
   const OutgoingDmRow({
     required this.id,

--- a/mobile/packages/db_client/lib/src/database/app_database.g.dart
+++ b/mobile/packages/db_client/lib/src/database/app_database.g.dart
@@ -9717,10 +9717,11 @@ class DirectMessageRow extends DataClass
 
   /// Durable, collision-proof identity of one send invocation. Set on the
   /// sender's local message for 1:1 sends and shared by the single local
-  /// message representing a group fan-out; NULL for received and legacy
-  /// messages. It gives same-second 1:1 sends distinct rumor ids and lets group
-  /// recovery and optimistic UI grouping match a fan-out by an exact value
-  /// instead of the collision-prone `(sender, content, created_at ±5s)` tuple.
+  /// message representing a group fan-out. A self-wrap received on another
+  /// device preserves it; peer-authored and legacy messages leave it NULL. It
+  /// gives same-second 1:1 sends distinct rumor ids and lets group recovery and
+  /// optimistic UI grouping match a fan-out by an exact value instead of the
+  /// collision-prone `(sender, content, created_at ±5s)` tuple.
   final String? sendBatchId;
   const DirectMessageRow({
     required this.id,

--- a/mobile/packages/db_client/lib/src/database/daos/direct_messages_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/direct_messages_dao.dart
@@ -254,9 +254,9 @@ class DirectMessagesDao extends DatabaseAccessor<AppDatabase>
   /// this to avoid inserting a second copy.
   ///
   /// Scoped by strict `owner_pubkey` equality (not `_ownedOrLegacy`): generated
-  /// send ids are only stamped on self-sent messages with a non-null owner, so
-  /// the NULL-owner legacy branch would only widen the match with nothing to
-  /// gain.
+  /// send ids are only stamped on the owner's sends, including self-wrap echoes
+  /// received on another device, so the NULL-owner legacy branch would only
+  /// widen the match with nothing to gain.
   Future<bool> hasMessageWithSendBatchId({
     required String batchId,
     required String ownerPubkey,

--- a/mobile/packages/db_client/lib/src/database/daos/direct_messages_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/direct_messages_dao.dart
@@ -253,10 +253,10 @@ class DirectMessagesDao extends DatabaseAccessor<AppDatabase>
   /// sibling — or the happy-path persist racing a concurrent recovery — asks
   /// this to avoid inserting a second copy.
   ///
-  /// Scoped by strict `owner_pubkey` equality (not `_ownedOrLegacy`):
-  /// `send_batch_id` is only ever stamped on self-sent group messages with a
-  /// non-null owner, so the NULL-owner legacy branch would only widen the
-  /// match with nothing to gain.
+  /// Scoped by strict `owner_pubkey` equality (not `_ownedOrLegacy`): generated
+  /// send ids are only stamped on self-sent messages with a non-null owner, so
+  /// the NULL-owner legacy branch would only widen the match with nothing to
+  /// gain.
   Future<bool> hasMessageWithSendBatchId({
     required String batchId,
     required String ownerPubkey,

--- a/mobile/packages/db_client/lib/src/database/daos/outgoing_dms_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/outgoing_dms_dao.dart
@@ -111,11 +111,11 @@ class OutgoingDm {
   final DateTime queuedAt;
   final String ownerPubkey;
 
-  /// Durable, collision-proof id of the group-send fan-out this row belongs
-  /// to (the first sibling rumor's event id, stamped identically on every
-  /// per-recipient sibling). NULL for 1:1 sends, which have no siblings.
-  /// The repository and the conversation state key batch membership off this
-  /// instead of the collision-prone `(content, createdAt)` tuple.
+  /// Durable, collision-proof id of one send invocation. Unique for a 1:1
+  /// send and shared by every per-recipient sibling of a group fan-out. The
+  /// repository uses it to separate same-second identical sends, while the
+  /// conversation state also uses it for group batch membership. NULL only
+  /// for legacy rows.
   final String? sendBatchId;
 
   /// Whether **both** wraps have landed. The repository deletes the

--- a/mobile/packages/db_client/lib/src/database/tables.dart
+++ b/mobile/packages/db_client/lib/src/database/tables.dart
@@ -817,10 +817,11 @@ class DirectMessages extends Table {
 
   /// Durable, collision-proof identity of one send invocation. Set on the
   /// sender's local message for 1:1 sends and shared by the single local
-  /// message representing a group fan-out; NULL for received and legacy
-  /// messages. It gives same-second 1:1 sends distinct rumor ids and lets group
-  /// recovery and optimistic UI grouping match a fan-out by an exact value
-  /// instead of the collision-prone `(sender, content, created_at ±5s)` tuple.
+  /// message representing a group fan-out. A self-wrap received on another
+  /// device preserves it; peer-authored and legacy messages leave it NULL. It
+  /// gives same-second 1:1 sends distinct rumor ids and lets group recovery and
+  /// optimistic UI grouping match a fan-out by an exact value instead of the
+  /// collision-prone `(sender, content, created_at ±5s)` tuple.
   TextColumn get sendBatchId => text().nullable().named('send_batch_id')();
 
   @override

--- a/mobile/packages/db_client/lib/src/database/tables.dart
+++ b/mobile/packages/db_client/lib/src/database/tables.dart
@@ -815,14 +815,12 @@ class DirectMessages extends Table {
   /// NULL for legacy messages created before multi-account support.
   TextColumn get ownerPubkey => text().nullable().named('owner_pubkey')();
 
-  /// Durable, collision-proof identity of the group-send fan-out this message
-  /// belongs to (the first sibling rumor's event id). Set ONLY when persisting
-  /// a group send's single local message; NULL for 1:1 sends and every received
-  /// message. Lets the send / recovery dedup and the UI's optimistic grouping
-  /// match a batch by an exact stored value instead of the collision-prone
-  /// `(sender, content, created_at ±5s)` heuristic that `hasMatchingMessage`
-  /// uses — two distinct group sends of identical text seconds apart no longer
-  /// collapse into one.
+  /// Durable, collision-proof identity of one send invocation. Set on the
+  /// sender's local message for 1:1 sends and shared by the single local
+  /// message representing a group fan-out; NULL for received and legacy
+  /// messages. It gives same-second 1:1 sends distinct rumor ids and lets group
+  /// recovery and optimistic UI grouping match a fan-out by an exact value
+  /// instead of the collision-prone `(sender, content, created_at ±5s)` tuple.
   TextColumn get sendBatchId => text().nullable().named('send_batch_id')();
 
   @override
@@ -1228,12 +1226,12 @@ class OutgoingDms extends Table {
   /// `direct_messages.owner_pubkey` for multi-account isolation.
   TextColumn get ownerPubkey => text().named('owner_pubkey')();
 
-  /// Durable, collision-proof identity of the group-send fan-out this row
-  /// belongs to (the first sibling rumor's event id, stamped identically on
-  /// every per-recipient sibling by `sendGroupMessage`). NULL for 1:1 sends,
-  /// which have no siblings. Persistence dedup, optimistic grouping, sibling
-  /// lookup, and cancellation all key off this instead of the collision-prone
-  /// `(content, created_at)` tuple. See `DirectMessages.sendBatchId`.
+  /// Durable, collision-proof identity of one send invocation. A 1:1 send has
+  /// one unique value; `sendGroupMessage` stamps one shared value on every
+  /// per-recipient sibling. It separates same-second identical sends and lets
+  /// group persistence dedup, optimistic grouping, sibling lookup, and
+  /// cancellation use an exact value. NULL only for legacy rows. See
+  /// `DirectMessages.sendBatchId`.
   TextColumn get sendBatchId => text().nullable().named('send_batch_id')();
 
   @override

--- a/mobile/packages/db_client/test/src/database/daos/outgoing_dms_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/outgoing_dms_dao_test.dart
@@ -236,7 +236,7 @@ void main() {
         expect(fetched!.sendBatchId, equals('batch-e'));
       });
 
-      test('leaves sendBatchId null for a 1:1 send', () async {
+      test('leaves sendBatchId null when the caller omits it', () async {
         await dao.enqueue(makeDm(id: 'solo'));
 
         final fetched = await dao.getById('solo');

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -362,9 +362,10 @@ class DmRepository {
   /// [ensureDmRelayListPublished] is a no-op (nothing to advertise).
   final String? _dmInboxRelayUrl;
 
-  /// Mints the durable, collision-proof identity for one group fan-out
-  /// ([sendGroupMessage]). Injected so tests can pin a deterministic value;
-  /// production defaults to [_defaultSendBatchId] (256 bits of secure random).
+  /// Mints the durable, collision-proof identity for one send invocation.
+  /// Group sends share it across the fan-out. Injected so tests can pin a
+  /// deterministic value; production defaults to [_defaultSendBatchId]
+  /// (256 bits of secure random).
   final String Function() _newSendBatchId;
 
   StreamSubscription<Event>? _giftWrapSubscription;
@@ -4089,9 +4090,9 @@ class DmRepository {
               giftWrapId: result.messageEventId!,
               messageKind: row.messageKind,
               replyToId: row.replyToId,
-              // Carry the row's batch label onto the persisted message so a
-              // later sibling's recovery dedups against it (null for 1:1 and
-              // legacy rows).
+              // Carry the row's send label onto the persisted message so a
+              // later group sibling's recovery dedups against it (null only
+              // for legacy rows).
               sendBatchId: batchId,
               // Reconstruct tagsJson from the rebuilt rumor so a recovered
               // row hydrates the same read-time-derived fields (e.g.

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -404,15 +404,16 @@ class DmRepository {
   final Duration _readMarkerDebounceDelay;
   static const _defaultReadMarkerDebounceDelay = Duration(seconds: 3);
 
-  /// Rumor tag key carrying the per-send batch token (see [sendGroupMessage]).
-  /// Client-internal: injected only so two identical group sends in the same
-  /// Unix second produce distinct rumor ids. Divine's own receive path and
-  /// other clients ignore unrecognised rumor tags, so it is inert on the wire.
+  /// Rumor tag key carrying the per-send token that [sendMessage] and
+  /// [sendGroupMessage] both mint. Client-internal: injected only so two
+  /// identical sends in the same Unix second produce distinct rumor ids.
+  /// Divine's own receive path and other clients ignore unrecognised rumor
+  /// tags, so it is inert on the wire.
   static const _sendBatchTagKey = 'batch';
 
   /// Default [_newSendBatchId]: a 256-bit secure-random, event-id-shaped hex
   /// token. Independent of rumor content, so two byte-identical same-second
-  /// group sends never share a batch id.
+  /// sends never share a token.
   static String _defaultSendBatchId() {
     const hexDigits = '0123456789abcdef';
     final random = Random.secure();
@@ -3251,13 +3252,40 @@ class DmRepository {
     final participants = [_userPubkey, recipientPubkey]..sort();
     final conversationId = computeConversationId(participants);
 
+    // Durable, collision-proof identity for this send, minted BEFORE the
+    // rumor is built — the 1:1 counterpart of the token [sendGroupMessage]
+    // mints, for the same reason. A rumor's event id is
+    // sha256([0, pubkey, created_at(seconds), kind, tags, content]) with no
+    // nonce, so two sends of byte-identical text to the same recipient in the
+    // SAME Unix second would otherwise build byte-identical rumors, and every
+    // layer below keys on that id: the queue row PK (`OutgoingDm.id`, enqueued
+    // with insertOrIgnore), the local message PK (likewise insertOrIgnore),
+    // and — beyond this device — the RECIPIENT's own rumor-id dedup. The
+    // second send would report success while vanishing from the queue, from
+    // local history, and from the recipient, leaving no failure status and
+    // nothing for the retry sweep to re-drive.
+    //
+    // The token is injected into the rumor as the same client-internal `batch`
+    // tag the group path uses, so both paths stay symmetric and the ingest
+    // side needs no new case. It rides inside the encrypted gift-wrapped rumor
+    // (only the recipient and the sender's own self-wrap ever decrypt it) and
+    // is independent secure random, so it discloses nothing. See #7326.
+    final sendBatchId = _newSendBatchId();
+
     // Build the rumor up front so the queue row PK matches the rumor id
     // the relay will see — receiver-side gift-wrap dedup keys on this id
     // and a re-mint between enqueue and publish would defeat it.
+    //
+    // The batch tag is deliberately NOT part of [rumorTags]: that list is what
+    // gets persisted as the local row's `tagsJson`, and the group path
+    // likewise keeps its wire-only token out of the persisted tags.
     final rumor = _messageService!.buildRumor(
       recipientPubkey: recipientPubkey,
       content: content,
-      additionalTags: rumorTags,
+      additionalTags: [
+        ...rumorTags,
+        [_sendBatchTagKey, sendBatchId],
+      ],
     );
 
     // Enqueue before publish so an app crash mid-send leaves a
@@ -3279,6 +3307,11 @@ class DmRepository {
           selfWrapStatus: OutgoingWrapStatus.pending,
           queuedAt: DateTime.now(),
           ownerPubkey: _userPubkey,
+          // Stamped verbatim, as the group path stamps its siblings: a 1:1
+          // row has no siblings, but carrying the token makes a deleted
+          // bubble's cancellation match by exact value instead of falling
+          // back to the collision-prone `(createdAt, content)` tuple.
+          sendBatchId: sendBatchId,
         ),
       );
     }
@@ -3346,6 +3379,7 @@ class DmRepository {
             replyToId: replyToId,
             tagsJson: rumorTags.isEmpty ? null : jsonEncode(rumorTags),
             ownerPubkey: _userPubkey,
+            sendBatchId: sendBatchId,
           );
 
           final existingSend = await _conversationsDao.getConversation(

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -3278,8 +3278,9 @@ class DmRepository {
     // and a re-mint between enqueue and publish would defeat it.
     //
     // The batch tag is deliberately NOT part of [rumorTags]: that list is what
-    // gets persisted as the local row's `tagsJson`, and the group path
-    // likewise keeps its wire-only token out of the persisted tags.
+    // the happy path persists as the local row's `tagsJson`, and the group path
+    // likewise keeps its wire-only token out of the happy-path persisted tags.
+    // Recovery reconstructs `tagsJson` from the full stored rumor instead.
     final rumor = _messageService!.buildRumor(
       recipientPubkey: recipientPubkey,
       content: content,
@@ -5012,8 +5013,9 @@ class DmRepository {
         if (liveSuccessIndexes.isEmpty) {
           Log.info(
             'Group publish landed after every successful sibling row was '
-            'already removed (cancelled mid-flight); skipping local persist '
-            'for conversation $conversationId.',
+            'already removed (cancelled mid-flight, or finalized by a '
+            'concurrent recovery); skipping local persist for conversation '
+            '$conversationId.',
             category: LogCategory.system,
           );
           return;

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -3349,18 +3349,23 @@ class DmRepository {
         String? protocol;
         var persistedLocally = false;
         await _conversationsDao.runInTransaction(() async {
-          // Cancel interlock (mirrors _recoverFullSendLocked): the user may
-          // have deleted the send (cancelOutgoingSend) during the publish
-          // window — OK-confirmation can legitimately take tens of seconds.
-          // The wire copy is out and receiver dedup keeps it single, but do
-          // NOT resurrect the message locally from a row that no longer
-          // exists.
+          // Cancel interlock (mirrors _recoverFullSendLocked): the row may be
+          // gone by the time this publish lands — the user deleted the send
+          // (cancelOutgoingSend) during the publish window (OK-confirmation
+          // can legitimately take tens of seconds), or the retry sweep's
+          // interrupted arm recovered and finalized the same rumor. The wire
+          // copy is out and receiver dedup keeps it single, but do NOT
+          // resurrect the message locally from a row that no longer exists.
+          //
+          // Naming only the cancel here actively misled: before #7326 a
+          // colliding same-second sibling deleted the row, and this line
+          // reported a cancellation that never happened.
           if (outgoingDao != null &&
               await outgoingDao.getById(rumor.id) == null) {
             Log.info(
               'Publish for ${rumor.id} landed after the queue row was '
-              'already removed (cancelled mid-flight); skipping local '
-              'persist.',
+              'already removed (cancelled mid-flight, or finalized by a '
+              'concurrent recovery); skipping local persist.',
               category: LogCategory.system,
             );
             return;

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -16403,10 +16403,12 @@ void main() {
           // surfaces as a dropped row rather than being hidden by a permissive
           // stub.
           final store = <OutgoingDm>[];
+          final enqueuedBatchIds = <String?>[];
           when(() => mockOutgoingDmsDao.enqueue(any())).thenAnswer((inv) async {
             final dm = inv.positionalArguments.first as OutgoingDm;
             if (store.any((r) => r.id == dm.id)) return; // insertOrIgnore
             store.add(dm);
+            enqueuedBatchIds.add(dm.sendBatchId);
           });
           when(() => mockOutgoingDmsDao.getById(any())).thenAnswer((inv) async {
             final id = inv.positionalArguments.first as String;
@@ -16497,12 +16499,14 @@ void main() {
           // Distinct wire rumors: two sends, two ids.
           expect(sentRumorIds, hasLength(2));
           expect(sentRumorIds.toSet(), hasLength(2));
+          expect(enqueuedBatchIds, equals(tokens));
 
           // Two local bubbles. Under the collision this is 1: the second
           // send's insertMessage carries the colliding rumor id, and the dao's
           // insertOrIgnore drops it. The user typed two messages and sees one.
           expect(persisted, hasLength(2));
           expect(persisted.map((m) => m.id).toSet(), hasLength(2));
+          expect(persisted.map((m) => m.batchId), orderedEquals(tokens));
         },
       );
 

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -16338,6 +16338,331 @@ void main() {
           );
         },
       );
+
+      test(
+        'two IDENTICAL 1:1 sends in the SAME Unix second BOTH enqueue and '
+        'BOTH persist under distinct rumor ids (regression: #7326 '
+        'same-second 1:1 rumor-id collision)',
+        () async {
+          // A rumor id is sha256([0, pubkey, created_at(seconds), kind, tags,
+          // content]) with no nonce, so without a per-invocation token two 1:1
+          // sends of byte-identical text in one Unix second build
+          // byte-identical rumors. Same event id ⇒ same queue-row PK, which
+          // `enqueue`'s insertOrIgnore drops ⇒ the second bubble never exists;
+          // and the loser's success transaction is skipped by the cancel
+          // interlock, because the winner's finalize already deleted the row
+          // it re-reads. Both calls still return success, so nothing surfaces
+          // to the user and nothing is left for the retry sweep to re-drive.
+          //
+          // sendGroupMessage was given a per-invocation batch token for this
+          // exact mechanism (#6046); this pins the 1:1 sibling.
+          //
+          // Drive REAL rumor-id hashing (the faithful buildRumor stub builds a
+          // real Event from the passed tags) under a frozen second, so this is
+          // a production-path proof rather than a stub that pre-distinguishes
+          // ids.
+          const frozenSecond = 1700000000;
+          when(
+            () => mockMessageService.buildRumor(
+              recipientPubkey: any(named: 'recipientPubkey'),
+              content: any(named: 'content'),
+              eventKind: any(named: 'eventKind'),
+              additionalTags: any(named: 'additionalTags'),
+              createdAt: any(named: 'createdAt'),
+            ),
+          ).thenAnswer((inv) {
+            final recipient = inv.namedArguments[#recipientPubkey] as String;
+            final content = inv.namedArguments[#content] as String;
+            final eventKind =
+                (inv.namedArguments[#eventKind] as int?) ??
+                EventKind.privateDirectMessage;
+            final additionalTags =
+                (inv.namedArguments[#additionalTags] as List<List<String>>?) ??
+                const <List<String>>[];
+            // Ignore the wall-clock created_at so both invocations genuinely
+            // share one second — the collision case.
+            return Event(
+              _validPubkeyA,
+              eventKind,
+              [
+                ['p', recipient],
+                ...additionalTags,
+              ],
+              content,
+              createdAt: frozenSecond,
+            );
+          });
+
+          // Deterministic per-invocation tokens in the shape production mints
+          // (64 lowercase hex); a counter makes the assertions crisp.
+          final tokens = <String>['a' * 64, 'b' * 64];
+          var tokenIndex = 0;
+
+          // Model the durable queue faithfully: insertOrIgnore enqueue plus
+          // reads/deletes over the captured rows, so a rumor-id collision
+          // surfaces as a dropped row rather than being hidden by a permissive
+          // stub.
+          final store = <OutgoingDm>[];
+          when(() => mockOutgoingDmsDao.enqueue(any())).thenAnswer((inv) async {
+            final dm = inv.positionalArguments.first as OutgoingDm;
+            if (store.any((r) => r.id == dm.id)) return; // insertOrIgnore
+            store.add(dm);
+          });
+          when(() => mockOutgoingDmsDao.getById(any())).thenAnswer((inv) async {
+            final id = inv.positionalArguments.first as String;
+            for (final r in store) {
+              if (r.id == id) return r;
+            }
+            return null;
+          });
+          when(
+            () => mockOutgoingDmsDao.deleteById(any()),
+          ).thenAnswer((inv) async {
+            final id = inv.positionalArguments.first as String;
+            final before = store.length;
+            store.removeWhere((r) => r.id == id);
+            return before - store.length;
+          });
+
+          // Model persisted messages with the same insertOrIgnore-on-id
+          // semantics the real dao has, so a rumor-id collision shows up as a
+          // missing local bubble.
+          final persisted = <({String id, String? batchId})>[];
+          when(
+            () => mockDirectMessagesDao.insertMessage(
+              id: any(named: 'id'),
+              conversationId: any(named: 'conversationId'),
+              senderPubkey: any(named: 'senderPubkey'),
+              content: any(named: 'content'),
+              createdAt: any(named: 'createdAt'),
+              giftWrapId: any(named: 'giftWrapId'),
+              messageKind: any(named: 'messageKind'),
+              replyToId: any(named: 'replyToId'),
+              subject: any(named: 'subject'),
+              fileType: any(named: 'fileType'),
+              encryptionAlgorithm: any(named: 'encryptionAlgorithm'),
+              decryptionKey: any(named: 'decryptionKey'),
+              decryptionNonce: any(named: 'decryptionNonce'),
+              fileHash: any(named: 'fileHash'),
+              originalFileHash: any(named: 'originalFileHash'),
+              fileSize: any(named: 'fileSize'),
+              dimensions: any(named: 'dimensions'),
+              blurhash: any(named: 'blurhash'),
+              thumbnailUrl: any(named: 'thumbnailUrl'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+              tagsJson: any(named: 'tagsJson'),
+              sendBatchId: any(named: 'sendBatchId'),
+            ),
+          ).thenAnswer((inv) async {
+            final id = inv.namedArguments[#id] as String;
+            // insertOrIgnore
+            if (persisted.any((m) => m.id == id)) return false;
+            persisted.add((
+              id: id,
+              batchId: inv.namedArguments[#sendBatchId] as String?,
+            ));
+            return true;
+          });
+
+          // Full delivery: the queue row is deleted on finalize, which is what
+          // leaves the second send's cancel interlock looking at an absent row.
+          final sentRumorIds = <String>[];
+          stubSendRumor((rumor, recipient) async {
+            sentRumorIds.add(rumor.id);
+            return NIP17SendResult.success(
+              rumorEventId: rumor.id,
+              messageEventId: 'wrap-${rumor.id}',
+              recipientPubkey: recipient,
+            );
+          });
+
+          final repository = createRepository(
+            outgoingDmsDao: mockOutgoingDmsDao,
+            sendBatchIdGenerator: () => tokens[tokenIndex++],
+          );
+
+          final first = await repository.sendMessage(
+            recipientPubkey: _validPubkeyB,
+            content: 'ok',
+          );
+          final second = await repository.sendMessage(
+            recipientPubkey: _validPubkeyB,
+            content: 'ok',
+          );
+
+          // Both calls report success — that is what makes the loss silent.
+          expect(first.success, isTrue);
+          expect(second.success, isTrue);
+
+          // Distinct wire rumors: two sends, two ids.
+          expect(sentRumorIds, hasLength(2));
+          expect(sentRumorIds.toSet(), hasLength(2));
+
+          // Two local bubbles. Under the collision this is 1: the second
+          // send's insertMessage carries the colliding rumor id, and the dao's
+          // insertOrIgnore drops it. The user typed two messages and sees one.
+          expect(persisted, hasLength(2));
+          expect(persisted.map((m) => m.id).toSet(), hasLength(2));
+        },
+      );
+
+      test(
+        'two OVERLAPPING identical 1:1 sends in the SAME Unix second keep '
+        'two queue rows and persist two bubbles (regression: #7326 '
+        'same-second 1:1 rumor-id collision, concurrent arm)',
+        () async {
+          // ConversationBloc registers ConversationMessageSent with
+          // `concurrent()`, so two sends genuinely overlap rather than
+          // serialising. This arm parks the first send mid-publish so the
+          // second enqueues while the first row is still live — the path where
+          // the collision is swallowed by the QUEUE (insertOrIgnore on the
+          // rumor-id PK) and then by the cancel interlock, rather than by
+          // insertMessage as in the back-to-back arm above.
+          const frozenSecond = 1700000000;
+          when(
+            () => mockMessageService.buildRumor(
+              recipientPubkey: any(named: 'recipientPubkey'),
+              content: any(named: 'content'),
+              eventKind: any(named: 'eventKind'),
+              additionalTags: any(named: 'additionalTags'),
+              createdAt: any(named: 'createdAt'),
+            ),
+          ).thenAnswer((inv) {
+            final recipient = inv.namedArguments[#recipientPubkey] as String;
+            final content = inv.namedArguments[#content] as String;
+            final eventKind =
+                (inv.namedArguments[#eventKind] as int?) ??
+                EventKind.privateDirectMessage;
+            final additionalTags =
+                (inv.namedArguments[#additionalTags] as List<List<String>>?) ??
+                const <List<String>>[];
+            return Event(
+              _validPubkeyA,
+              eventKind,
+              [
+                ['p', recipient],
+                ...additionalTags,
+              ],
+              content,
+              createdAt: frozenSecond,
+            );
+          });
+
+          final tokens = <String>['a' * 64, 'b' * 64];
+          var tokenIndex = 0;
+
+          final store = <OutgoingDm>[];
+          final enqueuedIds = <String>[];
+          when(() => mockOutgoingDmsDao.enqueue(any())).thenAnswer((inv) async {
+            final dm = inv.positionalArguments.first as OutgoingDm;
+            if (store.any((r) => r.id == dm.id)) return; // insertOrIgnore
+            store.add(dm);
+            enqueuedIds.add(dm.id);
+          });
+          when(() => mockOutgoingDmsDao.getById(any())).thenAnswer((inv) async {
+            final id = inv.positionalArguments.first as String;
+            for (final r in store) {
+              if (r.id == id) return r;
+            }
+            return null;
+          });
+          when(
+            () => mockOutgoingDmsDao.deleteById(any()),
+          ).thenAnswer((inv) async {
+            final id = inv.positionalArguments.first as String;
+            final before = store.length;
+            store.removeWhere((r) => r.id == id);
+            return before - store.length;
+          });
+
+          final persisted = <String>[];
+          when(
+            () => mockDirectMessagesDao.insertMessage(
+              id: any(named: 'id'),
+              conversationId: any(named: 'conversationId'),
+              senderPubkey: any(named: 'senderPubkey'),
+              content: any(named: 'content'),
+              createdAt: any(named: 'createdAt'),
+              giftWrapId: any(named: 'giftWrapId'),
+              messageKind: any(named: 'messageKind'),
+              replyToId: any(named: 'replyToId'),
+              subject: any(named: 'subject'),
+              fileType: any(named: 'fileType'),
+              encryptionAlgorithm: any(named: 'encryptionAlgorithm'),
+              decryptionKey: any(named: 'decryptionKey'),
+              decryptionNonce: any(named: 'decryptionNonce'),
+              fileHash: any(named: 'fileHash'),
+              originalFileHash: any(named: 'originalFileHash'),
+              fileSize: any(named: 'fileSize'),
+              dimensions: any(named: 'dimensions'),
+              blurhash: any(named: 'blurhash'),
+              thumbnailUrl: any(named: 'thumbnailUrl'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+              tagsJson: any(named: 'tagsJson'),
+              sendBatchId: any(named: 'sendBatchId'),
+            ),
+          ).thenAnswer((inv) async {
+            final id = inv.namedArguments[#id] as String;
+            if (persisted.contains(id)) return false; // insertOrIgnore
+            persisted.add(id);
+            return true;
+          });
+
+          // Park the first publish so the second send's enqueue lands while
+          // the first row is still live, then release it after the second has
+          // finalized (and deleted the row it shares).
+          final firstPublishReached = Completer<void>();
+          final releaseFirstPublish = Completer<void>();
+          var publishCall = 0;
+          final sentRumorIds = <String>[];
+          stubSendRumor((rumor, recipient) async {
+            final call = ++publishCall;
+            sentRumorIds.add(rumor.id);
+            if (call == 1) {
+              firstPublishReached.complete();
+              await releaseFirstPublish.future;
+            }
+            return NIP17SendResult.success(
+              rumorEventId: rumor.id,
+              messageEventId: 'wrap-${rumor.id}-$call',
+              recipientPubkey: recipient,
+            );
+          });
+
+          final repository = createRepository(
+            outgoingDmsDao: mockOutgoingDmsDao,
+            sendBatchIdGenerator: () => tokens[tokenIndex++],
+          );
+
+          final firstSend = repository.sendMessage(
+            recipientPubkey: _validPubkeyB,
+            content: 'ok',
+          );
+          await firstPublishReached.future;
+          final secondSend = repository.sendMessage(
+            recipientPubkey: _validPubkeyB,
+            content: 'ok',
+          );
+          final second = await secondSend;
+          releaseFirstPublish.complete();
+          final first = await firstSend;
+
+          expect(first.success, isTrue);
+          expect(second.success, isTrue);
+
+          // Two durable queue rows with distinct rumor-id PKs. Under the
+          // collision this is 1: the second enqueue is insertOrIgnore'd away,
+          // leaving that send with no durable trace for the retry sweep.
+          expect(enqueuedIds, hasLength(2));
+          expect(enqueuedIds.toSet(), hasLength(2));
+
+          // Two local bubbles. Under the collision this is 1: the loser's
+          // success transaction re-reads a row the winner's finalize already
+          // deleted, so the cancel interlock skips the persist outright.
+          expect(persisted, hasLength(2));
+          expect(persisted.toSet(), hasLength(2));
+        },
+      );
     });
 
     group('sendGroupMessage with outgoing_dms queue wired in', () {

--- a/mobile/packages/models/lib/src/dm_message.dart
+++ b/mobile/packages/models/lib/src/dm_message.dart
@@ -73,9 +73,10 @@ class DmMessage extends Equatable {
 
   /// Durable, collision-proof id of the send invocation. Non-null for the
   /// sender's own persisted 1:1 message and for the single message representing
-  /// a group fan-out; null for received and legacy messages. The conversation
-  /// state additionally uses a group message's value to collapse its
-  /// per-recipient bubbles and aggregate their delivery status.
+  /// a group fan-out. A self-wrap received on another device preserves it;
+  /// peer-authored and legacy messages leave it null. The conversation state
+  /// additionally uses a group message's value to collapse its per-recipient
+  /// bubbles and aggregate their delivery status.
   final String? sendBatchId;
 
   /// Whether this is a file message (kind 15).

--- a/mobile/packages/models/lib/src/dm_message.dart
+++ b/mobile/packages/models/lib/src/dm_message.dart
@@ -71,12 +71,11 @@ class DmMessage extends Equatable {
   /// messages and for shares that carry only a URL and no event identity.
   final DmSharedVideoRef? sharedVideoRef;
 
-  /// Durable, collision-proof id of the group-send fan-out this message
-  /// belongs to. Non-null only for the sender's own persisted group-send
-  /// message (mirrors `DirectMessages.sendBatchId`); null for 1:1 sends and
-  /// every received message. The conversation state uses it to collapse a
-  /// group send's per-recipient bubbles into one and to aggregate their
-  /// delivery status, without colliding two distinct same-text sends.
+  /// Durable, collision-proof id of the send invocation. Non-null for the
+  /// sender's own persisted 1:1 message and for the single message representing
+  /// a group fan-out; null for received and legacy messages. The conversation
+  /// state additionally uses a group message's value to collapse its
+  /// per-recipient bubbles and aggregate their delivery status.
   final String? sendBatchId;
 
   /// Whether this is a file message (kind 15).


### PR DESCRIPTION
## Description

A Nostr rumor id is `sha256([0, pubkey, created_at, kind, tags, content])` with second-granular `created_at` and no nonce, so two 1:1 DM sends of byte-identical text to the same recipient inside one Unix second built **byte-identical rumors** — one id. Every layer below keys on that id, so the second message was lost with no error and nothing to retry.

`sendGroupMessage` was given a per-invocation token for exactly this mechanism (#6046), and the reactions DAO handles the same collision explicitly (`insertOwnReactionSuperseding`, #5419). The plain 1:1 path never got the equivalent.

**Reproduced end-to-end on a physical iPhone (iOS 26.6.1) against the production relay**, driving the real `DmRepository.sendMessage` twice in one second:

```
PROBE-START sec=1787710849
PROBE-B ok=true rumor=188e6e82…672e wrap=cfe389ca…89e7
PROBE-A ok=true rumor=188e6e82…672e wrap=7f9e85cb…b91a   <- same rumor id
Persisted sent message locally in conversation b763559f…   <- once
Publish for 188e6e82…672e landed after the queue row was already
  removed (cancelled mid-flight); skipping local persist.  <- nothing was cancelled
```

Then, from the relay:

* `relay.divine.video` stored and served **both** gift wraps (distinct ids, distinct ephemeral pubkeys, NIP-59-randomized past `created_at`).
* Unwrapping both with the recipient key yielded **one** rumor id, `created_at`, tag set and content — so a recipient deduplicating on the rumor id keeps one message.
* The sender's own local database held **1** message for 2 successful sends (`sendMessage` returned `success` both times).
* The local Docker relay (`local_stack/`) behaves identically: both wraps stored and served, and re-publishing a duplicate id is accepted rather than rejected.

After the fix, on the same phone, two identical sends in one second produce two distinct rumor ids, two distinct tokens, and **two** rows in the conversation (measured twice, at seconds `1787711841` and `1787711880`); the pre-fix message is still there alone with `batch=null`:

```
DB2 count=5
c608101f… createdAt=1787711880 batch=5ad7e0c1…   <- pair 2
9be7b2e7… createdAt=1787711880 batch=bc9fb7a7…
9a72074b… createdAt=1787711841 batch=90b4ae3e…   <- pair 1
9902d541… createdAt=1787711841 batch=0f3fbe01…
188e6e82… createdAt=1787710849 batch=null        <- pre-fix: 2 sends, 1 row
```

The fix mints one secure-random token per invocation and injects it into the rumor as the same client-internal `batch` tag the group path already uses, so both paths stay symmetric and the ingest side needs no new case. The token rides inside the encrypted gift-wrapped rumor and is content-independent, so it discloses nothing on the wire; it is kept out of `rumorTags`, so the happy-path persisted `tagsJson` stays unchanged; queue recovery reconstructs `tagsJson` from the full stored rumor, mirroring `sendGroupMessage`'s `localTags`.

Two protocol-level consequences reinforce why the ids must differ, beyond the storage collisions above: NIP-17 threads replies with `["e", "<kind-14-id>"]` (`17.md:127,136`) and deletes a message with a gift-wrapped `kind:5` targeting the same id (`17.md:87`, NIP-09), so a shared rumor id makes a reply's parent ambiguous and makes one deletion request name both messages. NIP-17 also makes both collision inputs mandatory and honest — *"Fields `id` and `created_at` are required"* (`17.md:134`).

Why a tag and not a timestamp: NIP-59 states *"The canonical `created_at` time belongs to the `rumor`. All other timestamps SHOULD be tweaked"* — only the seal and wrap may be randomized, so varying the rumor's `created_at` is not available. NIP-17's kind-14 tag list is explicitly open-ended (`// rest of tags...`), and NIP-13's `nonce` tag carries a PoW target-difficulty commitment, so reusing it here would be a false PoW claim.

Second commit: the cancel interlock logged exactly one cause — "cancelled mid-flight" — and the device run above produced that line for a send nobody cancelled. It now names both real causes, matching the sibling log in `_recoverFullSendLocked`.

**Related Issue:** Closes #7326

## Out of Scope

Every other path that builds a DM rumor was checked for the same collision; none needs a change here:

* **DM reactions** (`dm_reactions_repository.dart:277`) — the kind-7 reaction rumor has the identical no-nonce shape, but the react → remove → re-react sequence is **not reachable through the shipped UI**: all three steps must go through the long-press picker (`conversation_view.dart:755`), and one cycle costs a 500 ms `kLongPressTimeout` hold plus a modal sheet in/out, so three cycles cannot fit in one Unix second. `_onSet` additionally short-circuits on an optimistic-inclusive pending-or-live check, and the toggle handler is `sequential()`, which only widens the gap.

  Worth stating precisely, because my first pass understated it: the DAO half is handled — `insertOwnReactionSuperseding` documents the collision and resurrects the soft-deleted row (`dm_reactions_dao.dart:59-63, 106-123`) rather than letting `insertOrIgnore` drop the wanted re-reaction. The **recipient** half is not: `upsertIncoming` deliberately never touches `is_deleted` on a same-id re-arrival (`dm_reactions_dao.dart:270`), so were the sequence to occur the sender would show the emoji and the recipient never would. Latent, not live. Extending the nonce there would make the resurrect branch dead code and invalidate `dm_reactions_dao_test.dart:193` and `:256`, so it is a separate decision, not a line to add here.
* **`sendFileMessage`** (kind 15) — same nonce-free shape, but it has **no production caller**; only its own definition exists under `mobile/lib` / `mobile/packages`.
* **`sendSharedVideo`, reel replies, collaborator invites, moderation report DMs** — all route through `sendMessage` (or `sendGroupMessage`) and are therefore covered by this fix. Their callers each carry an in-flight guard as well (`droppable()` on `ShareSheetSendRequested`, the `InlineReelReplyStatus.sending` early-return, the report cubit's parked-row idempotency).
* `sendMessage` does not register its publish under the per-rumor recovery key the way `sendGroupMessage` does; it relies on the retry sweep's `_interruptedMinAge` guard instead. That is deliberate and documented, and is left as is.

### The issue's user-visible symptom is not fully closed by this PR — that half is #7324

#7326's Impact says *"Sending the same text twice in rapid succession delivers it once."* That stays true after this fix, for a **second and wider** reason on the **receive** side, which I confirmed with a throwaway probe against the real receive pipeline:

`_processGiftWrap` runs `hasMatchingMessage(conversationId, senderPubkey, content, createdAt)` unconditionally on every incoming NIP-17 rumor (`dm_repository.dart:2079`), and that DAO matches on `createdAt ± 5s` (`direct_messages_dao.dart:226`). So two **genuinely distinct** rumors with identical content from the same sender inside a five-second window collapse to one on the recipient, or on the sender's other devices when they ingest the self-wrap, whatever their ids are. Driving two distinct-id rumors (`cccc…`, `dddd…`), same content, `created_at` 2s apart, into the pipeline persisted exactly one:

```
Skipping duplicate NIP-17 DM dddd… : matching message already stored
PROBE-RECV persisted=1 ids=[cccc]
```

That check exists for a real reason — the NIP-04/NIP-17 dual-send publishes two events with different ids for one message — so narrowing it is a deliberate behaviour change with its own regression risk, not a line to slip into this PR. Delivery is not made worse by this PR (one copy arrived before it too); what changes is that the originating sender device's history is now correct, so its divergence from the recipient and the sender's other devices becomes observable.

**That half is already tracked as #7324**, filed alongside #7326 from the same audit and still open. I have added the runtime reproduction above to it rather than opening a duplicate. The two issues are halves of one symptom: this PR fixes the sender, #7324 is the recipient.

## Verification

* `flutter test` in `mobile/packages/dm_repository` — 649 tests, all pass (includes the two new regression tests, which fail on `main`).
* `flutter test test/services/outgoing_dm_retry_service_test.dart test/blocs/dm` — 417 pass.
* `flutter test test/services/collaborator_invite_service_test.dart …` — pass.
* `flutter analyze` in `mobile/packages/dm_repository` — no issues.
* `flutter analyze lib test integration_test` in `mobile/` — no issues.
* Physical-device run on `00008150-00195C563AB9401C` against the production relay, before and after the fix.
* Relay behaviour cross-checked on `relay.divine.video` and on the local Docker `funnelcake-relay`.

The two new tests cover both interleavings, because they fail for different reasons:

* **back-to-back** — the winner's finalize deletes the queue row before the loser enqueues, so both rows exist and the loss lands on `insertMessage`'s `insertOrIgnore`.
* **overlapping** (`ConversationMessageSent` uses `concurrent()`) — the loser's enqueue is dropped by the queue's `insertOrIgnore` while the winner's row is still live, and its persist is then skipped by the cancel interlock.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)


