### PR TITLE
fix(dm): stop dropping concurrent delete-for-everyone requests

### DIFF
--- a/mobile/lib/blocs/dm/conversation/conversation_bloc.dart
+++ b/mobile/lib/blocs/dm/conversation/conversation_bloc.dart
@@ -47,7 +47,22 @@ class ConversationBloc extends Bloc<ConversationEvent, ConversationState> {
     // handlers stay per-rumor isolated; `sendStatus` is last-writer-wins,
     // which only drives the bubble-less toasts (blocked / partial).
     on<ConversationMessageSent>(_onMessageSent, transformer: concurrent());
-    on<ConversationMessageDeleted>(_onMessageDeleted, transformer: droppable());
+    // `droppable()` here dropped a delete for message B whenever a delete
+    // for message A was still in flight: bloc_concurrency's droppable
+    // discards on subscription state alone and never inspects the payload,
+    // so the rumor id was irrelevant. The handler awaits a signer round trip
+    // (measured 215-493ms against Keycast) plus a relay publish that can
+    // first await `retryDisconnectedRelays()`, so deleting a short burst of
+    // messages retracted only the first — silently, since no path here
+    // emits. `sequential()` queues them instead; a same-rumor repeat is
+    // idempotent because `deleteMessageForEveryone` returns early on an
+    // already soft-deleted row. Head-of-line blocking is the accepted cost
+    // and is why this is not `concurrent()`: concurrent handlers would race
+    // that same-rumor guard and publish two kind-5s for one message.
+    on<ConversationMessageDeleted>(
+      _onMessageDeleted,
+      transformer: sequential(),
+    );
     on<ConversationSelfWrapRecoveryRequested>(
       _onSelfWrapRecoveryRequested,
       transformer: sequential(),

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -5144,6 +5144,20 @@ class DmRepository {
       );
     }
 
+    // Already retracted — stop before the signer round trip. `getMessageById`
+    // has no `isDeleted` predicate (the row is kept as dedup evidence), so
+    // without this a repeat delete of the same rumor sails through both
+    // checks above and signs + publishes a SECOND kind 5. That is reachable
+    // from the UI: the bubble only disappears once this method finishes, so
+    // a user who taps Delete and still sees the bubble taps it again.
+    if (row.isDeleted) {
+      Log.info(
+        'Message $rumorId already deleted — skipping duplicate kind 5',
+        category: LogCategory.system,
+      );
+      return;
+    }
+
     // Resolve conversation participants so the kind 5 event carries `p` tags.
     // This ensures the relay subscription (filtered by `#p`) delivers the
     // deletion to the other party.

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -10640,6 +10640,47 @@ void main() {
           ).called(1);
         },
       );
+
+      // Regression for #7322: `getMessageById` has no `isDeleted`
+      // predicate, so without the early return a repeat delete of the same
+      // rumor passed both guards above and signed + published a SECOND
+      // kind 5. Reachable from the UI — the bubble only disappears once the
+      // first delete finishes, so an impatient user taps Delete again.
+      test(
+        'returns early on an already soft-deleted row without signing or '
+        'publishing a duplicate kind 5',
+        () async {
+          final repo = createRepository();
+
+          when(
+            () => mockDirectMessagesDao.getMessageById(
+              _rumorEventId,
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          ).thenAnswer(
+            (_) async => DirectMessageRow(
+              id: _rumorEventId,
+              conversationId: conversationId,
+              senderPubkey: _validPubkeyA,
+              content: 'Hello',
+              createdAt: 1700000000,
+              giftWrapId: _giftWrapEventId,
+              messageKind: 14,
+              isDeleted: true,
+            ),
+          );
+
+          await repo.deleteMessageForEveryone(_rumorEventId);
+
+          verifyNever(() => mockNostrClient.publishEvent(any()));
+          verifyNever(
+            () => mockDirectMessagesDao.markMessageDeleted(
+              _rumorEventId,
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          );
+        },
+      );
     });
 
     // -----------------------------------------------------------------

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -10650,7 +10650,8 @@ void main() {
         'returns early on an already soft-deleted row without signing or '
         'publishing a duplicate kind 5',
         () async {
-          final repo = createRepository();
+          final signer = _MockNostrSigner();
+          final repo = createRepository(signer: signer);
 
           when(
             () => mockDirectMessagesDao.getMessageById(
@@ -10672,6 +10673,7 @@ void main() {
 
           await repo.deleteMessageForEveryone(_rumorEventId);
 
+          verifyNever(() => signer.signEvent(any()));
           verifyNever(() => mockNostrClient.publishEvent(any()));
           verifyNever(
             () => mockDirectMessagesDao.markMessageDeleted(

--- a/mobile/test/blocs/dm/conversation/conversation_bloc_test.dart
+++ b/mobile/test/blocs/dm/conversation/conversation_bloc_test.dart
@@ -1681,6 +1681,9 @@ void main() {
     });
 
     group('ConversationMessageDeleted', () {
+      late Completer<void> firstDeleteStarted;
+      late Completer<void> releaseFirstDelete;
+
       blocTest<ConversationBloc, ConversationState>(
         'calls deleteMessageForEveryone on the repository',
         setUp: () {
@@ -1770,23 +1773,27 @@ void main() {
         'deleting a second message while the first is still in flight still '
         'reaches the repository for both',
         setUp: () {
-          final firstInFlight = Completer<void>();
+          firstDeleteStarted = Completer<void>();
+          releaseFirstDelete = Completer<void>();
           when(
             () => mockDmRepository.deleteMessageForEveryone(messageId),
-          ).thenAnswer((_) => firstInFlight.future);
+          ).thenAnswer((_) async {
+            firstDeleteStarted.complete();
+            await releaseFirstDelete.future;
+          });
           when(
             () => mockDmRepository.deleteMessageForEveryone(otherMessageId),
           ).thenAnswer((_) async {});
-          // Release the first delete only after the second was dispatched,
-          // so the second is guaranteed to land inside the await window.
-          Timer(const Duration(milliseconds: 50), firstInFlight.complete);
         },
         build: buildBloc,
         act: (bloc) async {
           bloc.add(const ConversationMessageDeleted(rumorId: messageId));
-          await Future<void>.delayed(const Duration(milliseconds: 5));
+          await firstDeleteStarted.future;
           bloc.add(const ConversationMessageDeleted(rumorId: otherMessageId));
-          await Future<void>.delayed(const Duration(milliseconds: 250));
+          // Let the second event enter the transformer while the first handler
+          // is still suspended, then allow the sequential queue to advance.
+          await Future<void>.delayed(Duration.zero);
+          releaseFirstDelete.complete();
         },
         verify: (_) {
           verify(

--- a/mobile/test/blocs/dm/conversation/conversation_bloc_test.dart
+++ b/mobile/test/blocs/dm/conversation/conversation_bloc_test.dart
@@ -73,6 +73,9 @@ void main() {
       '3333333333333333333333333333333333333333333333333333333333333333';
   const messageId =
       '4444444444444444444444444444444444444444444444444444444444444444';
+  // A second, distinct rumor id — #7322's concurrent-delete regression.
+  const otherMessageId =
+      '7777777777777777777777777777777777777777777777777777777777777777';
   const giftWrapId =
       '5555555555555555555555555555555555555555555555555555555555555555';
   const sentEventId =
@@ -1751,6 +1754,46 @@ void main() {
         verify: (_) {
           verify(
             () => mockDmRepository.cancelOutgoingBatch(rumorId: messageId),
+          ).called(1);
+        },
+      );
+
+      // Regression for #7322. The handler was registered with `droppable()`,
+      // which discards on subscription state alone and never inspects the
+      // payload — so a delete for a DIFFERENT message dispatched while the
+      // first was still awaiting its signer round trip never reached the
+      // repository at all: no kind 5, no local soft-delete, and (since no
+      // path here emits) no feedback. Reproduced on a physical iPhone:
+      // three deletes for three distinct rumor ids produced exactly one
+      // handler entry.
+      blocTest<ConversationBloc, ConversationState>(
+        'deleting a second message while the first is still in flight still '
+        'reaches the repository for both',
+        setUp: () {
+          final firstInFlight = Completer<void>();
+          when(
+            () => mockDmRepository.deleteMessageForEveryone(messageId),
+          ).thenAnswer((_) => firstInFlight.future);
+          when(
+            () => mockDmRepository.deleteMessageForEveryone(otherMessageId),
+          ).thenAnswer((_) async {});
+          // Release the first delete only after the second was dispatched,
+          // so the second is guaranteed to land inside the await window.
+          Timer(const Duration(milliseconds: 50), firstInFlight.complete);
+        },
+        build: buildBloc,
+        act: (bloc) async {
+          bloc.add(const ConversationMessageDeleted(rumorId: messageId));
+          await Future<void>.delayed(const Duration(milliseconds: 5));
+          bloc.add(const ConversationMessageDeleted(rumorId: otherMessageId));
+          await Future<void>.delayed(const Duration(milliseconds: 250));
+        },
+        verify: (_) {
+          verify(
+            () => mockDmRepository.deleteMessageForEveryone(messageId),
+          ).called(1);
+          verify(
+            () => mockDmRepository.deleteMessageForEveryone(otherMessageId),
           ).called(1);
         },
       );


### PR DESCRIPTION
Fixes #7322.

## What was wrong

`ConversationMessageDeleted` was registered with `droppable()`. bloc_concurrency 0.3.0's droppable discards on subscription state alone — `_ExhaustMapStreamTransformer.bind`'s listener returns at `if (mappedSubscription != null) return;` before it ever touches `data` — so the rumor id was irrelevant. A delete for message B was discarded because a delete for message A was still in flight.

Nothing surfaced the loss. `_onMessageDeleted` emits on no path, so a dropped delete published no kind 5, applied no local soft-delete, and showed no spinner, snackbar or error. The only feedback was the bubble failing to disappear, because `watchMessagesForConversation` filters `isDeleted.equals(false)` and the row was never marked.

## Why the obvious one-line fix was not enough

Swapping to `sequential()` on its own introduces a worse bug, and the issue's claim that it is safe rests on a false premise. #7322 says a same-message repeat is already idempotent because `deleteMessageForEveryone` "throws `ArgumentError` when the rumor is gone". The rumor is never gone: `markMessageDeleted` keeps the row as dedup evidence and `getMessageById` has **no `isDeleted` predicate**, so a repeat delete passes both the null-check and the sender-check and signs + publishes a **second kind 5**.

Proven by execution on a real Drift DB: after `markMessageDeleted`, `watchMessagesForConversation` hides the row while `getMessageById` still returns it with `senderPubkey` intact.

That duplicate is not free. Verified against the funnelcake relay in `local_stack`: two kind-5 events for the same `e` tag at different `created_at` are stored as two distinct events with no dedup, and NIP-09 line 33 tells relays to retain deletion requests indefinitely. Each carries the counterparty pubkey in a plaintext `p` tag, so one user action doubles that permanent record and costs a second remote signer round trip.

So this PR is two commits: the repository guard first, then the transformer that depends on it.

## The window is real, and now measured

#7322 inferred the in-flight window rather than measuring it. Measured here on a physical iPhone (iOS 26.6.1) against production Keycast: `sign_event` returned in **493ms cold, then 215/219/229/255ms warm**. `publishEvent` can additionally await `retryDisconnectedRelays()` when the pool has no connected relay, which extends it further — the same device session logged a `Connection reset by peer` against the signer host and a 30s unwrap timeout.

Scope note for reviewers: the only dispatcher is the user's tap (`conversation_view.dart:810`), so the drop is tap-rate-limited rather than systematic. It bites hardest exactly when deletion matters most — a degraded network, and an impatient user re-tapping a bubble that has not vanished yet.

## Why `sequential()` and not `concurrent()`

`concurrent()` matches the sibling `ConversationMessageSent` registration, but it would let two same-rumor handlers both read `isDeleted == false` before either writes, racing straight past the new guard and publishing two kind 5s for one message. Head-of-line blocking is the accepted cost. Transformers apply per event-type bucket, so sends are unaffected.

## Verification

- **Physical iPhone, before:** three deletes dispatched for three distinct rumor ids produced **one** handler entry. **After: three.** Driven through the live `ConversationBloc` over the VM service, using synthetic rumor ids so nothing was signed, published or deleted.
- Two regression tests, each confirmed to fail without its fix and pass with it.
- `flutter analyze lib test` clean; `conversation_bloc_test.dart` 74/74; `dm_repository` 648/648.
- Ratchets pass: nostr-id-log-truncation, pubkey-log-encoding, ungrouped-tests, post-close-emit.

## Not fixed here

Three things this PR deliberately leaves alone. **None of these is closed by merging this PR** — the references below are pointers, not closing keywords.

1. **#8165** — `deleteMessageForEveryone` **discards** `publishEvent`'s `PublishResult` and soft-deletes regardless, so a delete that reached no relay still makes the bubble vanish and logs "Deleted message … via kind 5". Proven by execution. Needs a UX decision (error surface or durable retry). Note this PR raises its priority: making a burst actually attempt N publishes means the relay's erasure limiter can now reject one, and that rejection is what #8165 swallows.
2. **#8166** — `publishEvent` blanks a pre-signed signature when it appends the NIP-89 `client` tag, so every delete pays two remote-signer round trips and the first is discarded. That is what doubles the in-flight window this PR's transformer change exists to survive. Not DM-specific, so it is not fixed here.
3. The same payload-blind `droppable()` shape exists on `CommentVoteToggled` and `CommentDeleteRequested` (`comment_reactions_bloc.dart:51,64`), both of which carry a `commentId`. Different feature area, not yet filed.
