### PR TITLE
fix(dm): keep a repeated DM instead of collapsing it onto its own protocol

### DIFF
--- a/mobile/packages/db_client/lib/src/database/daos/direct_messages_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/direct_messages_dao.dart
@@ -8,6 +8,29 @@ import 'package:drift/drift.dart';
 
 part 'direct_messages_dao.g.dart';
 
+/// Which arrival protocol a stored `direct_messages` row must have for
+/// [DirectMessagesDao.hasMatchingMessage] to treat it as a duplicate.
+///
+/// This is not `Conversations.dmProtocol`, which classifies a whole
+/// *conversation* for send routing. This names one stored *row*, and it is
+/// derived rather than stored: the NIP-04 receive path writes the wire event
+/// id into both `id` and `gift_wrap_id`, while every NIP-17 path writes a
+/// rumor id distinct from its gift-wrap id.
+enum DmDedupCounterpart {
+  /// Only a row that arrived over NIP-04 counts. Asked by the NIP-17 receive
+  /// path: a near-identical row from its *own* protocol is a genuine earlier
+  /// message, not this one.
+  nip04Copy,
+
+  /// Only a row that arrived over NIP-17 counts. Mirror of [nip04Copy], asked
+  /// by the NIP-04 receive path.
+  nip17Copy,
+
+  /// No arrival constraint. For the self-send paths that match the user's own
+  /// persisted message rather than a cross-protocol twin.
+  unconstrained,
+}
+
 @DriftAccessor(tables: [DirectMessages])
 class DirectMessagesDao extends DatabaseAccessor<AppDatabase>
     with _$DirectMessagesDaoMixin {
@@ -208,21 +231,52 @@ class DirectMessagesDao extends DatabaseAccessor<AppDatabase>
     return present;
   }
 
-  /// Check if a message with the same sender and content already exists in a
-  /// conversation within a ±5 second window. Used for cross-protocol dedup
-  /// when both a NIP-17 and NIP-04 copy of the same message arrive.
+  /// Restricts a dedup match to rows that arrived over [counterpart]'s
+  /// protocol, read off the two id columns.
   ///
-  /// The window is deliberately narrow: a genuine repeat of the same text
-  /// (e.g. "ok") is only collapsed when it lands within ±[windowSeconds],
-  /// which is still wide enough for dual-send duplicates, whose timestamps
-  /// differ by at most a few seconds. Widening it drops more legitimate
-  /// repeats — it does not gain a retry signal, because a re-minted rumor
-  /// is indistinguishable from a genuine second send.
+  /// The NIP-04 receive path stores the wire event id in BOTH `id` and
+  /// `gift_wrap_id`; every NIP-17 path stores a rumor id distinct from its
+  /// gift-wrap id. Both columns are `NOT NULL`, so `id = gift_wrap_id` is a
+  /// plain two-valued predicate and its negation is exact.
+  Expression<bool> _arrivedOverCounterpart(DmDedupCounterpart counterpart) {
+    final arrivedOverNip04 = directMessages.id.equalsExp(
+      directMessages.giftWrapId,
+    );
+    return switch (counterpart) {
+      DmDedupCounterpart.nip04Copy => arrivedOverNip04,
+      DmDedupCounterpart.nip17Copy => arrivedOverNip04.not(),
+      DmDedupCounterpart.unconstrained => const Constant(true),
+    };
+  }
+
+  /// Whether a message with the same sender and content is already stored in
+  /// [conversationId] within ±[windowSeconds] **and** arrived over the
+  /// protocol named by [counterpart].
+  ///
+  /// This is cross-protocol dedup. A dual-send puts one message on the wire
+  /// twice — a NIP-17 rumor and a NIP-04 event with unrelated ids — so
+  /// [hasGiftWrap] cannot collapse them and only `(sender, content, ~time)`
+  /// can.
+  ///
+  /// [counterpart] is what stops that heuristic eating real messages. A
+  /// NIP-17 rumor is a duplicate only of a stored NIP-04 copy, and a NIP-04
+  /// event only of a stored NIP-17 copy; a genuine second send of the same
+  /// text seconds later is same-protocol, so it no longer matches and is kept
+  /// (#7324). Same-protocol replays need no help here — the primary key on
+  /// `id` and the UNIQUE index on `gift_wrap_id` already make [insertMessage]
+  /// a no-op for them.
+  ///
+  /// A group send is the one self-authored case that needs
+  /// [DmDedupCounterpart.unconstrained]: its siblings carry distinct rumor
+  /// ids, so the primary key does not collapse their self-wrap echoes.
+  /// Prefer [hasMessageWithSendBatchId] there when the batch token is
+  /// available — it matches exactly instead of heuristically.
   Future<bool> hasMatchingMessage({
     required String conversationId,
     required String senderPubkey,
     required String content,
     required int createdAt,
+    required DmDedupCounterpart counterpart,
     int windowSeconds = 5,
     String? ownerPubkey,
   }) async {
@@ -237,6 +291,7 @@ class DirectMessagesDao extends DatabaseAccessor<AppDatabase>
             directMessages.createdAt.isSmallerOrEqualValue(
               createdAt + windowSeconds,
             ) &
+            _arrivedOverCounterpart(counterpart) &
             _ownedOrLegacy(directMessages.ownerPubkey, ownerPubkey),
       )
       ..addColumns([directMessages.id])

--- a/mobile/packages/db_client/test/src/database/daos/direct_messages_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/direct_messages_dao_test.dart
@@ -549,13 +549,16 @@ void main() {
       test(
         'matches cross-protocol duplicates within the default 5s window',
         () async {
+          // A NIP-04 arrival: the receive path writes the wire event id into
+          // BOTH columns, which is what marks the row as the twin a NIP-17
+          // rumor may collapse onto.
           await dao.insertMessage(
-            id: 'msg_original',
+            id: 'ev_nip04_original',
             conversationId: conversationId1,
             senderPubkey: 'pubkey_peer',
             content: 'Retryable message',
             createdAt: 1700000000,
-            giftWrapId: 'gw_original',
+            giftWrapId: 'ev_nip04_original',
             ownerPubkey: 'pubkey_owner',
           );
 
@@ -565,6 +568,7 @@ void main() {
             content: 'Retryable message',
             createdAt: 1700000004,
             ownerPubkey: 'pubkey_owner',
+            counterpart: DmDedupCounterpart.nip04Copy,
           );
 
           expect(duplicate, isTrue);
@@ -584,12 +588,15 @@ void main() {
             ownerPubkey: 'pubkey_owner',
           );
 
+          // Counterpart matches the stored row's shape, so the window is the
+          // only thing that can reject it — keeping this a window test.
           final duplicate = await dao.hasMatchingMessage(
             conversationId: conversationId1,
             senderPubkey: 'pubkey_peer',
             content: 'ok',
             createdAt: 1700000030,
             ownerPubkey: 'pubkey_owner',
+            counterpart: DmDedupCounterpart.nip17Copy,
           );
 
           expect(duplicate, isFalse);
@@ -657,6 +664,7 @@ void main() {
             content: text,
             createdAt: retryCreatedAt,
             ownerPubkey: recipientPubkey,
+            counterpart: DmDedupCounterpart.nip17Copy,
           ),
           isFalse,
           reason: '13s apart is outside the ±5s window',
@@ -668,9 +676,26 @@ void main() {
             content: text,
             createdAt: firstCreatedAt + 4,
             ownerPubkey: recipientPubkey,
+            counterpart: DmDedupCounterpart.nip17Copy,
           ),
           isTrue,
-          reason: 'positive control: the ±5s window still fires inside 5s',
+          reason:
+              'positive control: an arriving NIP-04 copy still collapses onto '
+              'its stored NIP-17 twin inside 5s',
+        );
+        expect(
+          await dao.hasMatchingMessage(
+            conversationId: conversationId,
+            senderPubkey: senderPubkey,
+            content: text,
+            createdAt: firstCreatedAt + 4,
+            ownerPubkey: recipientPubkey,
+            counterpart: DmDedupCounterpart.nip04Copy,
+          ),
+          isFalse,
+          reason:
+              '#7324: an arriving NIP-17 rumor must NOT collapse onto a row '
+              'that also arrived over NIP-17 — that is a genuine repeat',
         );
 
         // The bug: a fresh retry mints a second rumor id. Nothing collapses it.
@@ -690,6 +715,71 @@ void main() {
           reason: 'two rumor ids for one message render as two bubbles',
         );
         expect(rendered.map((m) => m.content).toSet(), {text});
+      });
+
+      test(
+        'a NIP-04 event does not collapse onto another NIP-04 row (#7324, '
+        'mirrored onto the legacy protocol)',
+        () async {
+          await dao.insertMessage(
+            id: 'ev_nip04_first',
+            conversationId: conversationId1,
+            senderPubkey: 'pubkey_peer',
+            content: 'ok',
+            createdAt: 1700000000,
+            giftWrapId: 'ev_nip04_first',
+            ownerPubkey: 'pubkey_owner',
+          );
+
+          expect(
+            await dao.hasMatchingMessage(
+              conversationId: conversationId1,
+              senderPubkey: 'pubkey_peer',
+              content: 'ok',
+              createdAt: 1700000002,
+              ownerPubkey: 'pubkey_owner',
+              counterpart: DmDedupCounterpart.nip17Copy,
+            ),
+            isFalse,
+            reason: 'a second kind-4 two seconds later is a genuine repeat',
+          );
+        },
+      );
+
+      test('unconstrained matches either arrival shape', () async {
+        await dao.insertMessage(
+          id: 'rumor_nip17',
+          conversationId: conversationId1,
+          senderPubkey: 'pubkey_owner',
+          content: 'ok',
+          createdAt: 1700000000,
+          giftWrapId: 'wrap_nip17',
+          ownerPubkey: 'pubkey_owner',
+        );
+        await dao.insertMessage(
+          id: 'ev_nip04',
+          conversationId: conversationId2,
+          senderPubkey: 'pubkey_owner',
+          content: 'ok',
+          createdAt: 1700000000,
+          giftWrapId: 'ev_nip04',
+          ownerPubkey: 'pubkey_owner',
+        );
+
+        for (final conversationId in [conversationId1, conversationId2]) {
+          expect(
+            await dao.hasMatchingMessage(
+              conversationId: conversationId,
+              senderPubkey: 'pubkey_owner',
+              content: 'ok',
+              createdAt: 1700000002,
+              ownerPubkey: 'pubkey_owner',
+              counterpart: DmDedupCounterpart.unconstrained,
+            ),
+            isTrue,
+            reason: 'the self-send paths opt out of the arrival filter',
+          );
+        }
       });
     });
 

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -2075,13 +2075,35 @@ class DmRepository {
       // processed first (network reordering), skip the duplicate. Record the
       // wrap so the skipped NIP-17 copy is not re-decrypted every launch.
       // #5452.
-      final isDuplicate = await _directMessagesDao.hasMatchingMessage(
-        conversationId: conversationId,
-        senderPubkey: rumor.pubkey,
-        content: rumor.content,
-        createdAt: persistedCreatedAt,
-        ownerPubkey: ownerPubkey,
-      );
+      //
+      // Only a NIP-04 copy may suppress a peer's rumor: a row that also
+      // arrived over NIP-17 is a genuine earlier message (#7324).
+      //
+      // Our own self-wrap echo is the exception. A group send persists one
+      // row but publishes one rumor per recipient, so the rumor-id primary
+      // key collapses only the first sibling's echo — the rest dedup on the
+      // batch token, or the unfiltered window when the send predates it
+      // (#6046).
+      final isSentByMe = rumor.pubkey == ownerPubkey;
+      final isGroup = participants.length > 2;
+      final bool isDuplicate;
+      if (isSentByMe && sendBatchId != null) {
+        isDuplicate = await _directMessagesDao.hasMessageWithSendBatchId(
+          batchId: sendBatchId,
+          ownerPubkey: ownerPubkey,
+        );
+      } else {
+        isDuplicate = await _directMessagesDao.hasMatchingMessage(
+          conversationId: conversationId,
+          senderPubkey: rumor.pubkey,
+          content: rumor.content,
+          createdAt: persistedCreatedAt,
+          ownerPubkey: ownerPubkey,
+          counterpart: isSentByMe && isGroup
+              ? DmDedupCounterpart.unconstrained
+              : DmDedupCounterpart.nip04Copy,
+        );
+      }
       if (isDuplicate) {
         await _recordProcessedWrap(giftWrapEvent.id, ownerPubkey: ownerPubkey);
         Log.debug(
@@ -2097,8 +2119,6 @@ class DmRepository {
       // Persist message + conversation atomically inside a transaction.
       // The inner hasGiftWrap re-check guards against TOCTOU races where
       // a poll and subscription event both pass the outer fast-path check.
-      final isGroup = participants.length > 2;
-      final isSentByMe = rumor.pubkey == ownerPubkey;
       final previewContent = rumor.kind == EventKind.fileMessage
           ? _filePreviewText(fileMetadata?.fileType)
           : rumor.content;
@@ -2729,12 +2749,17 @@ class DmRepository {
       // Match on sender+content within hasMatchingMessage's narrow createdAt
       // window because the NIP-17 rumor and NIP-04 event may have slightly
       // different timestamps.
+      //
+      // Only the NIP-17 copy may suppress this event. Another NIP-04 row with
+      // the same text is a genuine earlier message — the mirror of #7324 on
+      // this side of the dual-send.
       final isDuplicate = await _directMessagesDao.hasMatchingMessage(
         conversationId: conversationId,
         senderPubkey: senderPubkey,
         content: plaintext,
         createdAt: persistedCreatedAt,
         ownerPubkey: _userPubkey,
+        counterpart: DmDedupCounterpart.nip17Copy,
       );
       if (isDuplicate) {
         Log.debug(
@@ -4036,6 +4061,9 @@ class DmRepository {
                       content: row.content,
                       createdAt: row.createdAt,
                       ownerPubkey: _userPubkey,
+                      // Matches our OWN persisted send, not a cross-protocol
+                      // twin, so the arrival-shape filter does not apply.
+                      counterpart: DmDedupCounterpart.unconstrained,
                     ));
 
           if (!alreadyPersisted) {

--- a/mobile/packages/dm_repository/test/src/dm_identical_text_repeat_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_identical_text_repeat_test.dart
@@ -1,0 +1,292 @@
+// ABOUTME: Regression coverage for #7324 — two genuine messages carrying the
+// ABOUTME: same short text seconds apart must both survive on the receiver,
+// ABOUTME: while a cross-protocol dual-send twin is still collapsed.
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:db_client/db_client.dart';
+import 'package:dm_repository/dm_repository.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:nostr_sdk/event_kind.dart';
+import 'package:nostr_sdk/signer/local_nostr_signer.dart';
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+const _owner =
+    'a4f5c1b2d3e4f5061728394a5b6c7d8e9f0a1b2c3d4e5f60718293a4b5c6d7e8';
+const _peer =
+    'b1c2d3e4f5061728394a5b6c7d8e9f0a1b2c3d4e5f60718293a4b5c6d7e8f9a0';
+const _peer2 =
+    'c2d3e4f5061728394a5b6c7d8e9f0a1b2c3d4e5f60718293a4b5c6d7e8f9a0b1';
+const _privateKey =
+    '5426e5b8b4b0e2a1f5e8d3c7a9b2f4e6d8c0a2b4f6e8d0c2a4b6f8e0d2c4a6b8';
+
+const _baseCreatedAt = 1700000000;
+
+void main() {
+  // Deliberately exercises the real DirectMessagesDao against a real
+  // database. The mock-based suite in dm_repository_test.dart stubs
+  // hasMatchingMessage to a constant in its top-level setUp, so a test
+  // written there would pass whether or not the dedup is correct.
+  group('two genuine messages sharing their text', () {
+    late AppDatabase db;
+    late ConversationsDao conversationsDao;
+    late DirectMessagesDao messagesDao;
+    late _MockNostrClient nostrClient;
+    late StreamController<Event> relay;
+    late DmRepository repository;
+    late Map<String, Event> rumorByWrapId;
+
+    setUp(() async {
+      db = AppDatabase.test(NativeDatabase.memory());
+      conversationsDao = ConversationsDao(db);
+      messagesDao = DirectMessagesDao(db);
+      nostrClient = _MockNostrClient();
+      relay = StreamController<Event>();
+      rumorByWrapId = <String, Event>{};
+
+      when(() => nostrClient.connectedRelayCount).thenReturn(1);
+      when(() => nostrClient.configuredRelayCount).thenReturn(1);
+      when(
+        () => nostrClient.queryEvents(
+          any(),
+          subscriptionId: any(named: 'subscriptionId'),
+          useCache: any(named: 'useCache'),
+        ),
+      ).thenAnswer((_) async => const <Event>[]);
+      when(() => nostrClient.unsubscribe(any())).thenAnswer((_) async {});
+      when(
+        () => nostrClient.subscribe(
+          any(),
+          subscriptionId: any(named: 'subscriptionId'),
+          tempRelays: any(named: 'tempRelays'),
+          targetRelays: any(named: 'targetRelays'),
+        ),
+      ).thenAnswer((_) => relay.stream);
+
+      repository = DmRepository(
+        nostrClient: nostrClient,
+        directMessagesDao: messagesDao,
+        conversationsDao: conversationsDao,
+        userPubkey: _owner,
+        signer: LocalNostrSigner(_privateKey),
+        rumorDecryptor: (_, giftWrap) async => rumorByWrapId[giftWrap.id],
+        nip04Decryptor: (_, ciphertext) async => ciphertext,
+      );
+      await repository.startListening();
+    });
+
+    tearDown(() async {
+      // stopListening() before closing the stream: onDone would otherwise arm
+      // a reconnect timer that outlives this test.
+      await repository.stopListening();
+      await relay.close();
+      await db.close();
+    });
+
+    /// Waits for the serialized gift-wrap ingest to drain.
+    Future<void> settle() async {
+      for (var i = 0; i < 8; i++) {
+        await Future<void>.delayed(Duration.zero);
+      }
+    }
+
+    /// Feeds one NIP-17 gift wrap addressed to the owner, carrying a rumor
+    /// authored by [author] (the peer unless overridden).
+    Future<void> deliverNip17({
+      required String wrapId,
+      required String rumorId,
+      required String text,
+      required int createdAt,
+      String author = _peer,
+      List<List<String>> tags = const [
+        ['p', _owner],
+      ],
+    }) async {
+      rumorByWrapId[wrapId] = Event.fromJson({
+        'id': rumorId,
+        'pubkey': author,
+        'created_at': createdAt,
+        'kind': EventKind.privateDirectMessage,
+        'tags': tags,
+        'content': text,
+        'sig': '',
+      });
+      relay.add(
+        Event.fromJson({
+          'id': wrapId,
+          'pubkey': _peer,
+          'created_at': createdAt,
+          'kind': EventKind.giftWrap,
+          'tags': [
+            ['p', _owner],
+          ],
+          'content': 'wrapped-$wrapId',
+          'sig': '',
+        }),
+      );
+      await settle();
+    }
+
+    /// Feeds one legacy kind-4 addressed to the owner. The injected decryptor
+    /// is the identity, so [text] is both ciphertext and plaintext.
+    Future<void> deliverNip04({
+      required String id,
+      required String text,
+      required int createdAt,
+    }) async {
+      relay.add(
+        Event.fromJson({
+          'id': id,
+          'pubkey': _peer,
+          'created_at': createdAt,
+          'kind': EventKind.directMessage,
+          'tags': [
+            ['p', _owner],
+          ],
+          'content': text,
+          'sig': '',
+        }),
+      );
+      await settle();
+    }
+
+    Future<List<DirectMessageRow>> storedMessages() async {
+      final conversations = await conversationsDao.getAllConversations(
+        ownerPubkey: _owner,
+      );
+      expect(conversations, hasLength(1));
+      return messagesDao.getMessagesForConversation(
+        conversations.single.id,
+        ownerPubkey: _owner,
+      );
+    }
+
+    test('both are kept when they arrive two seconds apart', () async {
+      await deliverNip17(
+        wrapId: 'w' * 64,
+        rumorId: 'a' * 64,
+        text: 'ok',
+        createdAt: _baseCreatedAt,
+      );
+      await deliverNip17(
+        wrapId: 'x' * 64,
+        rumorId: 'b' * 64,
+        text: 'ok',
+        createdAt: _baseCreatedAt + 2,
+      );
+
+      final stored = await storedMessages();
+      expect(
+        stored,
+        hasLength(2),
+        reason:
+            'distinct rumor ids two seconds apart are two genuine messages; '
+            'collapsing them dropped the second one permanently (#7324)',
+      );
+      expect(stored.map((m) => m.id), containsAll(['a' * 64, 'b' * 64]));
+    });
+
+    test('the cross-protocol twin of the first is still collapsed', () async {
+      await deliverNip17(
+        wrapId: 'w' * 64,
+        rumorId: 'a' * 64,
+        text: 'ok',
+        createdAt: _baseCreatedAt,
+      );
+      // The dual-send's legacy copy: same text, a second later, unrelated id.
+      await deliverNip04(
+        id: 'c' * 64,
+        text: 'ok',
+        createdAt: _baseCreatedAt + 1,
+      );
+
+      expect(
+        await storedMessages(),
+        hasLength(1),
+        reason: 'the protection #7324 must not cost: one message, one bubble',
+      );
+    });
+
+    // A group send publishes one rumor per recipient — distinct ids, but a
+    // single persisted row keyed to the first live success. The rumor-id
+    // primary key therefore collapses only the first sibling's self-wrap
+    // echo; the rest must be caught by the batch token.
+    //
+    // Recreates the conversation the send path leaves behind. Without it the
+    // echoes resolve to a degenerate [self, self] pair and are discarded
+    // before any dedup runs.
+    Future<void> seedGroupSend() async {
+      final participants = [_owner, _peer, _peer2]..sort();
+      await conversationsDao.upsertConversation(
+        id: DmRepository.computeConversationId(participants),
+        participantPubkeys: jsonEncode(participants),
+        isGroup: true,
+        createdAt: _baseCreatedAt,
+        ownerPubkey: _owner,
+      );
+    }
+
+    Future<void> deliverSiblingEchoes({String? batchToken}) async {
+      List<List<String>> tagsFor(String first, String second) => [
+        ['p', first],
+        ['p', second],
+        if (batchToken != null) ['batch', batchToken],
+      ];
+
+      // Sibling rumors differ only in p-tag order, which is enough to give
+      // them distinct ids while sharing content and the batch timestamp.
+      await deliverNip17(
+        wrapId: 'e' * 64,
+        rumorId: '1' * 64,
+        text: 'ok',
+        createdAt: _baseCreatedAt,
+        author: _owner,
+        tags: tagsFor(_peer, _peer2),
+      );
+      await deliverNip17(
+        wrapId: 'f' * 64,
+        rumorId: '2' * 64,
+        text: 'ok',
+        createdAt: _baseCreatedAt,
+        author: _owner,
+        tags: tagsFor(_peer2, _peer),
+      );
+    }
+
+    test(
+      'sibling self-wrap echoes of one group send collapse to one row',
+      () async {
+        final batchToken = 'd' * 64;
+        await seedGroupSend();
+        await deliverSiblingEchoes(batchToken: batchToken);
+
+        expect(
+          await storedMessages(),
+          hasLength(1),
+          reason:
+              'one group send is one bubble on the sender device, however many '
+              'siblings its fan-out published',
+        );
+      },
+    );
+
+    test('legacy group echoes with no batch token still collapse', () async {
+      await seedGroupSend();
+      await deliverSiblingEchoes();
+
+      expect(
+        await storedMessages(),
+        hasLength(1),
+        reason:
+            'a send enqueued before the durable batch token existed (#6046) '
+            'falls back to the legacy content window',
+      );
+    });
+  });
+}

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -489,6 +489,7 @@ void main() {
       registerFallbackValue(_FakeEvent());
       registerFallbackValue(_FakeOutgoingDm());
       registerFallbackValue(OutgoingWrapStatus.pending);
+      registerFallbackValue(DmDedupCounterpart.nip04Copy);
     });
 
     setUp(() {
@@ -568,6 +569,7 @@ void main() {
       // and by the legacy null-batch fallback in group recovery.
       when(
         () => mockDirectMessagesDao.hasMatchingMessage(
+          counterpart: any(named: 'counterpart'),
           conversationId: any(named: 'conversationId'),
           senderPubkey: any(named: 'senderPubkey'),
           content: any(named: 'content'),
@@ -1551,6 +1553,7 @@ void main() {
       void stubDaoInserts() {
         when(
           () => mockDirectMessagesDao.hasMatchingMessage(
+            counterpart: any(named: 'counterpart'),
             conversationId: any(named: 'conversationId'),
             senderPubkey: any(named: 'senderPubkey'),
             content: any(named: 'content'),
@@ -4911,6 +4914,7 @@ void main() {
           ).thenAnswer((_) async => false);
           when(
             () => mockDirectMessagesDao.hasMatchingMessage(
+              counterpart: any(named: 'counterpart'),
               conversationId: any(named: 'conversationId'),
               senderPubkey: any(named: 'senderPubkey'),
               content: any(named: 'content'),
@@ -5737,6 +5741,7 @@ void main() {
         );
         when(
           () => mockDirectMessagesDao.hasMatchingMessage(
+            counterpart: any(named: 'counterpart'),
             conversationId: any(named: 'conversationId'),
             senderPubkey: any(named: 'senderPubkey'),
             content: any(named: 'content'),
@@ -8010,6 +8015,7 @@ void main() {
       void stubDaoInserts() {
         when(
           () => mockDirectMessagesDao.hasMatchingMessage(
+            counterpart: any(named: 'counterpart'),
             conversationId: any(named: 'conversationId'),
             senderPubkey: any(named: 'senderPubkey'),
             content: any(named: 'content'),
@@ -8177,6 +8183,7 @@ void main() {
       void stubDaoInserts() {
         when(
           () => mockDirectMessagesDao.hasMatchingMessage(
+            counterpart: any(named: 'counterpart'),
             conversationId: any(named: 'conversationId'),
             senderPubkey: any(named: 'senderPubkey'),
             content: any(named: 'content'),
@@ -8724,6 +8731,7 @@ void main() {
       void stubDaoInserts() {
         when(
           () => mockDirectMessagesDao.hasMatchingMessage(
+            counterpart: any(named: 'counterpart'),
             conversationId: any(named: 'conversationId'),
             senderPubkey: any(named: 'senderPubkey'),
             content: any(named: 'content'),
@@ -9094,6 +9102,7 @@ void main() {
       void stubDaoInserts() {
         when(
           () => mockDirectMessagesDao.hasMatchingMessage(
+            counterpart: any(named: 'counterpart'),
             conversationId: any(named: 'conversationId'),
             senderPubkey: any(named: 'senderPubkey'),
             content: any(named: 'content'),
@@ -9159,6 +9168,7 @@ void main() {
         ).thenAnswer((_) async => false);
         when(
           () => mockDirectMessagesDao.hasMatchingMessage(
+            counterpart: DmDedupCounterpart.nip17Copy,
             conversationId: any(named: 'conversationId'),
             senderPubkey: any(named: 'senderPubkey'),
             content: any(named: 'content'),
@@ -9224,6 +9234,7 @@ void main() {
         ).thenAnswer((_) async => false);
         when(
           () => mockDirectMessagesDao.hasMatchingMessage(
+            counterpart: any(named: 'counterpart'),
             conversationId: any(named: 'conversationId'),
             senderPubkey: any(named: 'senderPubkey'),
             content: any(named: 'content'),
@@ -9320,6 +9331,7 @@ void main() {
           ).thenAnswer((_) async => false);
           when(
             () => mockDirectMessagesDao.hasMatchingMessage(
+              counterpart: any(named: 'counterpart'),
               conversationId: any(named: 'conversationId'),
               senderPubkey: any(named: 'senderPubkey'),
               content: any(named: 'content'),
@@ -9384,6 +9396,7 @@ void main() {
           ).thenAnswer((_) async => false);
           when(
             () => mockDirectMessagesDao.hasMatchingMessage(
+              counterpart: any(named: 'counterpart'),
               conversationId: any(named: 'conversationId'),
               senderPubkey: any(named: 'senderPubkey'),
               content: any(named: 'content'),
@@ -9522,6 +9535,7 @@ void main() {
           ).thenAnswer((_) async => false);
           when(
             () => mockDirectMessagesDao.hasMatchingMessage(
+              counterpart: any(named: 'counterpart'),
               conversationId: any(named: 'conversationId'),
               senderPubkey: any(named: 'senderPubkey'),
               content: any(named: 'content'),
@@ -9619,6 +9633,7 @@ void main() {
           ).thenAnswer((_) async => hasGiftWrapCalls++ > 0);
           when(
             () => mockDirectMessagesDao.hasMatchingMessage(
+              counterpart: any(named: 'counterpart'),
               conversationId: any(named: 'conversationId'),
               senderPubkey: any(named: 'senderPubkey'),
               content: any(named: 'content'),
@@ -10073,6 +10088,7 @@ void main() {
         ).thenAnswer((_) async => false);
         when(
           () => mockDirectMessagesDao.hasMatchingMessage(
+            counterpart: any(named: 'counterpart'),
             conversationId: any(named: 'conversationId'),
             senderPubkey: any(named: 'senderPubkey'),
             content: any(named: 'content'),
@@ -10190,6 +10206,7 @@ void main() {
       void stubDaoInserts() {
         when(
           () => mockDirectMessagesDao.hasMatchingMessage(
+            counterpart: any(named: 'counterpart'),
             conversationId: any(named: 'conversationId'),
             senderPubkey: any(named: 'senderPubkey'),
             content: any(named: 'content'),
@@ -10702,6 +10719,7 @@ void main() {
           ).thenAnswer((_) async => false);
           when(
             () => mockDirectMessagesDao.hasMatchingMessage(
+              counterpart: any(named: 'counterpart'),
               conversationId: any(named: 'conversationId'),
               senderPubkey: any(named: 'senderPubkey'),
               content: any(named: 'content'),
@@ -10863,6 +10881,7 @@ void main() {
           ).thenAnswer((_) async => false);
           when(
             () => mockDirectMessagesDao.hasMatchingMessage(
+              counterpart: any(named: 'counterpart'),
               conversationId: any(named: 'conversationId'),
               senderPubkey: any(named: 'senderPubkey'),
               content: any(named: 'content'),
@@ -11002,6 +11021,7 @@ void main() {
           ).thenAnswer((_) async => false);
           when(
             () => mockDirectMessagesDao.hasMatchingMessage(
+              counterpart: any(named: 'counterpart'),
               conversationId: any(named: 'conversationId'),
               senderPubkey: any(named: 'senderPubkey'),
               content: any(named: 'content'),
@@ -11168,6 +11188,7 @@ void main() {
           ).thenAnswer((_) async => false);
           when(
             () => mockDirectMessagesDao.hasMatchingMessage(
+              counterpart: any(named: 'counterpart'),
               conversationId: any(named: 'conversationId'),
               senderPubkey: any(named: 'senderPubkey'),
               content: any(named: 'content'),
@@ -11330,6 +11351,7 @@ void main() {
         ).thenAnswer((_) async => false);
         when(
           () => mockDirectMessagesDao.hasMatchingMessage(
+            counterpart: any(named: 'counterpart'),
             conversationId: any(named: 'conversationId'),
             senderPubkey: any(named: 'senderPubkey'),
             content: any(named: 'content'),
@@ -12776,6 +12798,7 @@ void main() {
         () async {
           when(
             () => mockDirectMessagesDao.hasMatchingMessage(
+              counterpart: DmDedupCounterpart.nip04Copy,
               conversationId: any(named: 'conversationId'),
               senderPubkey: _validPubkeyB,
               content: 'Retried peer message',
@@ -12839,6 +12862,7 @@ void main() {
         () async {
           when(
             () => mockDirectMessagesDao.hasMatchingMessage(
+              counterpart: any(named: 'counterpart'),
               conversationId: any(named: 'conversationId'),
               senderPubkey: _validPubkeyB,
               content: 'Retried peer message',
@@ -12986,6 +13010,7 @@ void main() {
         final removedConversationsDao = _MockRemovedConversationsDao();
         when(
           () => mockDirectMessagesDao.hasMatchingMessage(
+            counterpart: any(named: 'counterpart'),
             conversationId: any(named: 'conversationId'),
             senderPubkey: _validPubkeyB,
             content: 'Retried peer message',
@@ -13064,6 +13089,7 @@ void main() {
         final removedConversationsDao = _MockRemovedConversationsDao();
         when(
           () => mockDirectMessagesDao.hasMatchingMessage(
+            counterpart: any(named: 'counterpart'),
             conversationId: any(named: 'conversationId'),
             senderPubkey: _validPubkeyB,
             content: 'Retried peer message',
@@ -13182,6 +13208,7 @@ void main() {
           ).thenAnswer((_) async => false);
           when(
             () => mockDirectMessagesDao.hasMatchingMessage(
+              counterpart: any(named: 'counterpart'),
               conversationId: any(named: 'conversationId'),
               senderPubkey: any(named: 'senderPubkey'),
               content: any(named: 'content'),
@@ -19045,6 +19072,7 @@ void main() {
           ).thenAnswer((_) async => queuedRow());
           when(
             () => mockDirectMessagesDao.hasMatchingMessage(
+              counterpart: DmDedupCounterpart.unconstrained,
               conversationId: any(named: 'conversationId'),
               senderPubkey: any(named: 'senderPubkey'),
               content: any(named: 'content'),


### PR DESCRIPTION
## Description

Sending the same short text twice a few seconds apart delivered **one** message to the receiver. Both gift wraps arrive and both decrypt; the second rumor is then discarded and its wrap written to `processed_gift_wraps`, so it is skipped before decryption on every later delivery. Nothing surfaces the loss — the sender's timeline shows two, the receiver's shows one.

**Reproduced on a physical iPhone against production** (real Keycast OAuth signer), then narrowed to the window itself with a control:

| pair | text | Δt | rumor ids | outcome |
|---|---|---|---|---|
| control | `probeA1` / `probeA2` | 2s | differ | **both persisted** |
| test | `probeB` / `probeB` | 2s | differ | **one persisted, one dropped** |

```
Persisted NIP-17 DM 26db03bd… createdAt=1787715332
Skipping duplicate NIP-17 DM 81c062c1… : matching message already stored
```

Both wraps were confirmed stored on `relay.divine.video` (queried by ephemeral author), so nothing server-side is involved. After an app restart the relay redelivered the dropped wrap twice and the ledger rejected it both times — the loss is permanent.

### Root cause

`hasMatchingMessage` matched `(conversation, sender, content)` within ±5s with **no term for how the stored row arrived**. It exists for the NIP-04/NIP-17 dual-send, where one message legitimately reaches the receiver as two events with unrelated ids — but it could not tell that twin apart from a genuine second message with the same text.

### The fix

A row arrived over NIP-04 **iff** its `id` equals its `gift_wrap_id`: the NIP-04 receive path writes the wire event id into both columns, and every NIP-17 path writes a rumor id distinct from its gift-wrap id. Verified across all six production `insertMessage` sites. Both columns are `NOT NULL`, so the split is total and its negation exact — no schema change, no migration, no wire change.

Each receive path now names the protocol it is looking for, so a genuine same-protocol repeat is kept in **both** directions (the NIP-04 side had the identical bug).

### The self-wrap exception — please read this part

A group send publishes **one rumor per recipient** (distinct ids, since the p-tag sets differ) but persists a **single** row keyed to the first live success. So the rumor-id primary key collapses only the first sibling's self-wrap echo; siblings 2..N were being suppressed *solely* by the content window. Constraining that path naively would have grown **N−1 duplicate bubbles on the sender's own device** for every group send.

Those echoes now dedup on the durable `batch` token from #6046 — an exact match rather than a heuristic — falling back to the unfiltered window for sends enqueued before the token existed. Both branches have tests that fail without them.

### One assertion flips

`direct_messages_dao_test.dart` had an assertion commented *"positive control: the ±5s window still fires inside 5s"* that asserted the old behaviour. It is now split: a NIP-04 arrival still collapses onto its stored NIP-17 twin (`isTrue`), while a NIP-17 arrival no longer collapses onto a same-protocol row (`isFalse`, the fix).

**Related Issue:** Closes #7324

## Out of Scope

- **Group-send recovery** (`dm_repository.dart` legacy `batchId == null` fallback) keeps today's behaviour — it matches the user's own persisted send, not a cross-protocol twin.
- **`hasMatchingMessage` does not filter `is_deleted`** — subsumed. A genuine repeat is no longer blocked at all, and a deleted row *should* still suppress its own twin, so filtering it would be wrong.
- **The `processed_gift_wraps` write on a dedup skip** — now correct by construction, since every remaining drop is a genuine twin.
- **Same-second identical text** still collides at the rumor id itself (no nonce in the NIP-01 preimage) and is dropped by the primary key before any window runs. That is #7326 / #8163, unchanged here.
- Legacy rows are re-classified retroactively, since the shape is derived rather than stored. All six current insert sites obey the invariant and `git log -S` shows both shapes introduced once and never reshaped; if an old build ever violated it, the failure mode is *under*-suppression (one extra bubble), never data loss.

## Verification

- `flutter analyze lib test integration_test packages/db_client packages/dm_repository` — clean
- `flutter test packages/db_client/test/ packages/dm_repository/test/` — **1648 passed**
- **The regression test fails on `origin/main`.** It drives the real DAO against a real database and never names the new API, so it compiles against unpatched code and reports `Expected: length of <2>` — verified by reverting the two production files and re-running.
- **Mutation-checked:** disabling the self-authored branch turns both group-echo tests red, so they genuinely guard the duplicate-bubble regression rather than passing vacuously.
- The new test deliberately lives outside `dm_repository_test.dart`, whose top-level `setUp` stubs `hasMatchingMessage` to a constant — a test written there would pass whether or not the dedup is correct.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
