### PR TITLE
fix(nostr): stop discarding a pre-signed signature to append the client tag

### DIFF
--- a/mobile/packages/nostr_client/lib/src/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/src/nostr_client.dart
@@ -461,14 +461,24 @@ class NostrClient {
   /// Tracks whether dispose() has been called
   bool _isDisposed = false;
 
+  /// Adds Divine's NIP-89 `client` tag before publishing, unless [event]
+  /// already carries a signature.
+  ///
+  /// Appending the tag rebuilds the event, which changes its id and so
+  /// invalidates any signature already on it. `nostr_sdk` signs whenever `sig`
+  /// is blank, so clobbering it here silently buys a second signature — with a
+  /// remote signer, a whole extra network round trip per publish (#8166).
+  ///
+  /// Events signed through `SignerFactory.createAndSignEvent` already carry the
+  /// tag, so the only events skipped here are the ones a call site signed
+  /// itself with a raw signer. Those forfeit attribution rather than a round
+  /// trip; NIP-89 makes the tag optional.
   Future<void> _prepareEventForPublish(Event event) async {
-    final changed = await Nip89ClientTag.applyToEvent(event);
-    if (!changed) {
+    if (event.sig.isNotEmpty) {
       return;
     }
 
-    // publishEvent()/publishEventAwaitOk() both delegate signing to nostr_sdk
-    // when sig is blank, so clearing the signature is enough here.
+    await Nip89ClientTag.applyToEvent(event);
   }
 
   /// Completes the first time [initialize] finishes, so consumers can await

--- a/mobile/packages/nostr_client/test/src/nip89_client_tag_test.dart
+++ b/mobile/packages/nostr_client/test/src/nip89_client_tag_test.dart
@@ -29,6 +29,7 @@ Event _event({
 void main() {
   setUpAll(() {
     registerFallbackValue(_FakeEvent());
+    registerFallbackValue(Duration.zero);
   });
 
   setUp(() {
@@ -112,16 +113,18 @@ void main() {
       });
     });
 
-    test('mutates a signed event in place before publish', () async {
+    test('leaves a pre-signed event untouched (#8166)', () async {
       final event = _event()..sig = 'already-signed';
       final originalId = event.id;
 
       final result = await client.publishEvent(event);
 
       expect(result, isA<PublishSuccess>());
-      expect(event.tags, contains(Nip89ClientTag.tag));
-      expect(event.id, isNot(originalId));
-      expect(event.sig, isEmpty);
+      // Tagging would rebuild the event and invalidate this signature, so
+      // nostr_sdk would buy a second one. Attribution is forfeited instead.
+      expect(event.sig, equals('already-signed'));
+      expect(event.id, equals(originalId));
+      expect(Nip89ClientTag.hasClientTag(event.tags), isFalse);
       verify(
         () => mockNostr.sendEvent(
           event,
@@ -129,6 +132,70 @@ void main() {
           tempRelays: any(named: 'tempRelays'),
         ),
       ).called(1);
+    });
+
+    test("the signature handed to the SDK is the caller's, so it does not "
+        're-sign', () async {
+      final event = _event()..sig = 'already-signed';
+
+      await client.publishEvent(event);
+
+      final sent =
+          verify(
+                () => mockNostr.sendEvent(
+                  captureAny(),
+                  targetRelays: any(named: 'targetRelays'),
+                  tempRelays: any(named: 'tempRelays'),
+                ),
+              ).captured.single
+              as Event;
+      // nostr_sdk signs iff sig is blank, so a non-blank sig here is exactly
+      // what spares the second signer round trip.
+      expect(sent.sig, equals('already-signed'));
+    });
+
+    test('still tags and re-ids an unsigned event', () async {
+      final event = _event();
+      final originalId = event.id;
+
+      final result = await client.publishEvent(event);
+
+      expect(result, isA<PublishSuccess>());
+      expect(event.tags, contains(Nip89ClientTag.tag));
+      expect(event.id, isNot(originalId));
+      // Left blank on purpose: nostr_sdk signs on the way out.
+      expect(event.sig, isEmpty);
+    });
+
+    test('publishEventAwaitOk applies the same rule', () async {
+      when(
+        () => mockNostr.sendEventAwaitOk(
+          any(),
+          targetRelays: any(named: 'targetRelays'),
+          tempRelays: any(named: 'tempRelays'),
+          timeout: any(named: 'timeout'),
+        ),
+      ).thenAnswer(
+        (invocation) async => PublishOutcome(
+          eventId: (invocation.positionalArguments.first as Event).id,
+          acceptedBy: const ['wss://relay'],
+          rejectedBy: const {},
+          noResponseFrom: const [],
+        ),
+      );
+
+      final signed = _event()..sig = 'already-signed';
+      await client.publishEventAwaitOk(signed);
+      expect(signed.sig, equals('already-signed'));
+      expect(Nip89ClientTag.hasClientTag(signed.tags), isFalse);
+
+      final unsigned = _event(
+        tags: const [
+          ['d', 'other'],
+        ],
+      );
+      await client.publishEventAwaitOk(unsigned);
+      expect(unsigned.tags, contains(Nip89ClientTag.tag));
     });
   });
 }


### PR DESCRIPTION
## Description

`_prepareEventForPublish` appended Divine's NIP-89 `client` tag to every outgoing event. Appending rebuilds the event and changes its id, which invalidates any signature already on it — and `nostr_sdk` signs whenever `sig` is blank (`nostr.dart:194`, `:233`). So a caller that had already signed its own event silently paid for a **second** signature. With a remote signer that is a whole extra network round trip per publish (~215-490ms against Keycast, which has no caching, dedup or single-flight), and it doubled the in-flight window behind #7322.

This skips the tag when the event arrives signed, rather than invalidating a signature it did not create.

**Why here rather than at the call sites.** `SignerFactory.createAndSignEvent` (`signer_factory.dart:217-221`) already adds the tag *before* signing, so everything through the canonical helper is already immune — including video (34236) and view (22236) events. Only 8 sites bypass it and hand-roll `Event(...)` + a raw `NostrSigner.signEvent(...)`. Editing all 8 would have forced `creator_sync` — a deliberately pure-Dart package on `package:test` — to take on `flutter_test` and SharedPreferences mocking, churned tag-shape assertions across three packages, and still let a 9th site regress silently later. One guard fixes all present and future sites.

### ⚠️ This changes what ships on the wire — please check this part

Nine infrastructure kinds stop carrying the `client` tag: **4** (DM), **5** (deletion), **3079/3080/3083** (push control), **10002** (relay list), **10050** (DM relay list), **30005** (curation set), **30078** (app data). None is user-visible content.

Evidence that nothing reads it for those kinds:

- The generic `nostr.events` table has **no** `client` column.
- Every table that does have one — `videos_latest_data`, `view_interactions`, `video_stats_snapshot` and the video read models — is fed only by kinds 34235/34236 and 22236, all of which sign through `createAndSignEvent` and are therefore **already tagged before signing**. Those columns are unaffected.
- Nothing filters, ranks or moderates on the tag: no index, no `WHERE`/`GROUP BY` on `client` anywhere in funnelcake.
- NIP-89 makes it optional: "When publishing events, clients **MAY** include a `client` tag." Divine also already ships the opt-out NIP-89 recommends (Settings → Nostr).

Behaviour for unsigned events is unchanged, which is what every `NostrClient` convenience method (`sendLike`, `sendRepost`, `deleteEvent`, `sendContactList`, …) relies on.

**Related Issue:** Fixes #8166. Relates to #7322 (already fixed by #8164; this is the round-trip cost that made it reachable).

## Out of Scope

The 8 raw-signing call sites are deliberately left alone — the guard covers them. Also out of scope, found while verifying this and filed separately:

- divinevideo/divine-funnelcake#1147 — the relay's NIP-01 id serializer escapes 3 of the 7 required characters, so valid events with a tab or CR in `content` are rejected.
- The optimistic cache in `publishEvent` runs before signing, so it persists rows with an empty `sig`. Pre-existing ordering issue, unrelated to this change.

## Verification

- `flutter test` in `packages/nostr_client` — **347 passed**, including the four pre-signed-publish tests at `nostr_client_test.dart:979/:1048/:1119/:1173`
- `flutter test` in `packages/dm_repository` (647), `packages/creator_sync` (141), `packages/curation_repository` (71) — the packages holding the affected call sites
- `flutter test test/services/auth/signer_factory_test.dart` (24)
- `flutter analyze lib test integration_test` in `mobile/`, and `flutter analyze lib test` in `packages/nostr_client` — no issues
- `dart format` on both touched files

**End-to-end against a live funnelcake relay in Docker**, driving the real `NostrClient.publishEventAwaitOk` with a counting signer:

| case | signatures | result |
|---|---|---|
| pre-signed kind 5 | **1** (was 2) | relay accepted; the caller's signature and id shipped unchanged; no `client` tag |
| control: unsigned kind 5 | 1 | relay accepted; `client` tag present, id rebuilt |
| control: pre-signed gift wrap | 1 | untouched |

Before this change the first row cost two signatures. Also confirmed on the relay that the old behaviour was unavoidable rather than incidental: an event carrying the tag with its pre-signed signature is rejected with `invalid: invalid signature: signature verification failed`, while the same event without the tag is accepted.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

