### PR TITLE
fix(dm): apply wrapped kind-5 deletions that target messages

### DIFF
--- a/mobile/packages/dm_repository/lib/src/dm_reactions_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_reactions_repository.dart
@@ -54,19 +54,24 @@ class DmReactionPublishResult {
   final bool optimisticInsertSucceeded;
 }
 
-/// Outcome of ingesting an incoming wrapped reaction/deletion rumor, used by
-/// `DmRepository` to decide whether to record the gift wrap in the
-/// processed-wrap dedup ledger (#5452).
-enum DmReactionWrapOutcome {
+/// Outcome of ingesting an incoming wrapped rumor — a reaction, or a kind-5
+/// deletion targeting either a reaction or a message — used by `DmRepository`
+/// to decide whether to record the gift wrap in the processed-wrap dedup
+/// ledger (#5452).
+enum DmWrapOutcome {
   /// The wrap reached a terminal state — persisted, or permanently dropped for
-  /// a reason that will not change (malformed content/tags, no matching row).
+  /// a reason that will not change (malformed content/tags, author mismatch).
   /// Safe to record so the wrap is never re-decrypted.
   processed,
 
-  /// The wrap could not be applied yet (signer not ready, the reaction's
-  /// target message has not synced, or a deletion's target reaction has not
-  /// synced). Must NOT be recorded so it re-decrypts on a later launch once the
-  /// target exists — preserving eventual consistency.
+  /// The wrap could not be applied yet: the signer is not ready, or the target
+  /// the rumor names has not synced. Must NOT be recorded so it re-decrypts on
+  /// a later launch once the target exists — preserving eventual consistency.
+  ///
+  /// Prefer this whenever the outcome is in doubt. `ProcessedGiftWrapsDao`
+  /// reads the ledger globally rather than per-owner, so a wrap recorded
+  /// terminally by mistake is suppressed for *every* account on the device,
+  /// and switching accounts away and back does not recover it.
   deferred,
 }
 
@@ -794,18 +799,18 @@ class DmReactionsRepository {
   /// Persist an incoming kind-7 reaction rumor. Called from
   /// `DmRepository._handleGiftWrapEvent` after rumor extraction.
   ///
-  /// Returns [DmReactionWrapOutcome.processed] when the wrap reached a terminal
+  /// Returns [DmWrapOutcome.processed] when the wrap reached a terminal
   /// state (persisted, or permanently dropped for malformed content/tags), and
-  /// [DmReactionWrapOutcome.deferred] when it could not be applied yet (signer
+  /// [DmWrapOutcome.deferred] when it could not be applied yet (signer
   /// not ready, or the target message has not synced) so the caller leaves it
   /// out of the dedup ledger and lets it re-decrypt later. See #5452.
-  Future<DmReactionWrapOutcome> persistIncoming({
+  Future<DmWrapOutcome> persistIncoming({
     required Event rumorEvent,
     required String giftWrapId,
   }) async {
-    if (_userPubkey.isEmpty) return DmReactionWrapOutcome.deferred;
+    if (_userPubkey.isEmpty) return DmWrapOutcome.deferred;
     if (rumorEvent.kind != EventKind.reaction) {
-      return DmReactionWrapOutcome.processed;
+      return DmWrapOutcome.processed;
     }
     final content = rumorEvent.content;
     if (content.isEmpty || content.length > _maxReactionContentLength) {
@@ -814,7 +819,7 @@ class DmReactionsRepository {
         '(content length: ${content.length})',
         category: LogCategory.system,
       );
-      return DmReactionWrapOutcome.processed;
+      return DmWrapOutcome.processed;
     }
     String? targetMessageId;
     String? targetAuthor;
@@ -833,7 +838,7 @@ class DmReactionsRepository {
         'Dropping reaction rumor ${rumorEvent.id} — missing/invalid e tag',
         category: LogCategory.system,
       );
-      return DmReactionWrapOutcome.processed;
+      return DmWrapOutcome.processed;
     }
     targetAuthor ??= rumorEvent.pubkey;
     final conversationId = await _resolveConversationIdForReaction(
@@ -843,7 +848,7 @@ class DmReactionsRepository {
     );
     // Target message not synced yet: leave undecided so a later launch retries
     // and the reaction lands once the message arrives. See #5452 (D4-terminal).
-    if (conversationId == null) return DmReactionWrapOutcome.deferred;
+    if (conversationId == null) return DmWrapOutcome.deferred;
     try {
       await _reactionsDao.upsertIncoming(
         id: rumorEvent.id,
@@ -856,7 +861,7 @@ class DmReactionsRepository {
         giftWrapId: giftWrapId,
         ownerPubkey: _userPubkey,
       );
-      return DmReactionWrapOutcome.processed;
+      return DmWrapOutcome.processed;
     } on Object catch (e, st) {
       _errorReporter?.call(
         e,
@@ -864,7 +869,7 @@ class DmReactionsRepository {
         site: DmReactionsRepositoryReportableSites.persistIncomingDaoUpsert,
       );
       // Transient DAO failure — let it retry rather than cement a skip.
-      return DmReactionWrapOutcome.deferred;
+      return DmWrapOutcome.deferred;
     }
   }
 
@@ -874,29 +879,29 @@ class DmReactionsRepository {
   /// This handler is specifically for wrapped deletions emitted by the
   /// reactions feature, which tag the deleted event with `k=7`.
   ///
-  /// Returns [DmReactionWrapOutcome.deferred] — leaving the wrap out of the
+  /// Returns [DmWrapOutcome.deferred] — leaving the wrap out of the
   /// dedup ledger so it re-decrypts on a later launch — when the signer is not
   /// ready, when a targeted reaction row has not synced yet, or on a transient
   /// soft-delete failure. Gift wraps carry NIP-59 randomized `created_at`, so a
   /// deletion can drain before the reaction it removes; recording it as
   /// terminal then would let the reaction insert live afterwards and never be
-  /// soft-deleted. Otherwise returns [DmReactionWrapOutcome.processed]
+  /// soft-deleted. Otherwise returns [DmWrapOutcome.processed]
   /// (terminal): the deletion applied, the target was already deleted, or the
   /// deletion is invalid (author mismatch). The soft-delete is idempotent, so
   /// re-applying on a benign re-decrypt is safe. #5452.
-  Future<DmReactionWrapOutcome> handleIncomingDeletion({
+  Future<DmWrapOutcome> handleIncomingDeletion({
     required Event rumorEvent,
     required String giftWrapId,
   }) async {
-    if (_userPubkey.isEmpty) return DmReactionWrapOutcome.deferred;
+    if (_userPubkey.isEmpty) return DmWrapOutcome.deferred;
     if (rumorEvent.kind != EventKind.eventDeletion) {
-      return DmReactionWrapOutcome.processed;
+      return DmWrapOutcome.processed;
     }
     if (!_targetsReactionKind(rumorEvent.tags)) {
-      return DmReactionWrapOutcome.processed;
+      return DmWrapOutcome.processed;
     }
 
-    var outcome = DmReactionWrapOutcome.processed;
+    var outcome = DmWrapOutcome.processed;
     for (final tag in rumorEvent.tags) {
       if (tag.length < 2 || tag[0] != 'e') continue;
       final rumorId = tag[1];
@@ -911,7 +916,7 @@ class DmReactionsRepository {
       // created_at). Symmetric with persistIncoming's unsynced-target handling.
       // #5452.
       if (row == null) {
-        outcome = DmReactionWrapOutcome.deferred;
+        outcome = DmWrapOutcome.deferred;
         continue;
       }
       if (row.isDeleted) continue;
@@ -938,7 +943,7 @@ class DmReactionsRepository {
               .handleIncomingDeletionSoftDelete,
         );
         // Transient DAO failure — let it retry rather than cement a skip.
-        outcome = DmReactionWrapOutcome.deferred;
+        outcome = DmWrapOutcome.deferred;
       }
     }
     return outcome;

--- a/mobile/packages/dm_repository/lib/src/dm_reactions_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_reactions_repository.dart
@@ -109,6 +109,8 @@ class DmReactionRetryTarget {
 /// - `watchForConversation` — Drift stream for the chip render path.
 /// - `persistIncoming` — entry point for the receive pipeline (called
 ///   from `DmRepository._handleGiftWrapEvent` when `rumor.kind == 7`).
+/// - `applyDeletion` — applies one already-classified kind-5 target;
+///   `DmRepository` owns the routing and calls this for reaction targets.
 class DmReactionsRepository {
   /// Construct the repository. Most fields are nullable for the legacy
   /// dependency-injection pattern where credentials are bound after
@@ -873,80 +875,76 @@ class DmReactionsRepository {
     }
   }
 
-  /// Apply an incoming wrapped NIP-09 kind-5 deletion for a reaction row.
+  /// Apply an incoming NIP-09 kind-5 deletion to the reaction row [rumorId],
+  /// on behalf of [deleterPubkey].
   ///
-  /// DM message deletions use the top-level kind-5 path in [DmRepository].
-  /// This handler is specifically for wrapped deletions emitted by the
-  /// reactions feature, which tag the deleted event with `k=7`.
+  /// This takes one already-classified target rather than a whole rumor:
+  /// [DmRepository] owns the `e`-tag loop and decides, per target, whether it
+  /// names a reaction or a message. It used to decide that here by demanding a
+  /// literal `['k','7']` tag, which is wrong twice over — NIP-09 makes `k` a
+  /// SHOULD, and a deletion aimed at a *message* was answered
+  /// [DmWrapOutcome.processed] and lost for good (#7809, #7329).
   ///
-  /// Returns [DmWrapOutcome.deferred] — leaving the wrap out of the
-  /// dedup ledger so it re-decrypts on a later launch — when the signer is not
-  /// ready, when a targeted reaction row has not synced yet, or on a transient
-  /// soft-delete failure. Gift wraps carry NIP-59 randomized `created_at`, so a
-  /// deletion can drain before the reaction it removes; recording it as
-  /// terminal then would let the reaction insert live afterwards and never be
-  /// soft-deleted. Otherwise returns [DmWrapOutcome.processed]
-  /// (terminal): the deletion applied, the target was already deleted, or the
-  /// deletion is invalid (author mismatch). The soft-delete is idempotent, so
-  /// re-applying on a benign re-decrypt is safe. #5452.
-  Future<DmWrapOutcome> handleIncomingDeletion({
-    required Event rumorEvent,
+  /// [deleterPubkey] must be the rumor's authenticated author — `rumor.pubkey`
+  /// as rebuilt from the signed seal, never the gift wrap's own ephemeral key.
+  ///
+  /// Returns `null` when this account holds no reaction with that id, so the
+  /// caller can try the message store instead — the apply doubles as the
+  /// probe, which keeps routing to one DAO read in the common case.
+  ///
+  /// Returns [DmWrapOutcome.deferred] — leaving the wrap out of the dedup
+  /// ledger so it re-decrypts on a later launch — when the signer is not
+  /// ready or on a transient soft-delete failure. Otherwise returns
+  /// [DmWrapOutcome.processed] (terminal): the deletion applied, the target
+  /// was already deleted, or the deletion is invalid (author mismatch). The
+  /// soft-delete is idempotent, so re-applying on a benign re-decrypt is
+  /// safe. #5452.
+  Future<DmWrapOutcome?> applyDeletion({
+    required String rumorId,
+    required String deleterPubkey,
     required String giftWrapId,
   }) async {
     if (_userPubkey.isEmpty) return DmWrapOutcome.deferred;
-    if (rumorEvent.kind != EventKind.eventDeletion) {
-      return DmWrapOutcome.processed;
-    }
-    if (!_targetsReactionKind(rumorEvent.tags)) {
-      return DmWrapOutcome.processed;
-    }
 
-    var outcome = DmWrapOutcome.processed;
-    for (final tag in rumorEvent.tags) {
-      if (tag.length < 2 || tag[0] != 'e') continue;
-      final rumorId = tag[1];
-      final row = await _reactionsDao.getById(
-        id: rumorId,
-        ownerPubkey: _userPubkey,
+    final row = await _reactionsDao.getById(
+      id: rumorId,
+      ownerPubkey: _userPubkey,
+    );
+    // `null` means no such reaction row, which is NOT the same as "give up":
+    // the caller tries the message store next, and only defers if neither
+    // holds the target. Deferring here matters because gift wraps carry
+    // NIP-59 randomized `created_at`, so a deletion can drain before the
+    // reaction it removes; recording it as terminal would let the reaction
+    // insert live afterwards and never be soft-deleted. Symmetric with
+    // persistIncoming's unsynced-target handling. #5452.
+    if (row == null) return null;
+    if (row.isDeleted) return DmWrapOutcome.processed;
+
+    // NIP-09: only the original reaction author may delete their reaction.
+    if (row.reactorPubkey != deleterPubkey) {
+      Log.debug(
+        'Ignoring wrapped reaction deletion for $rumorId: author mismatch '
+        '(event=${pubkeyForLogs(deleterPubkey)}, '
+        'reactor=${pubkeyForLogs(row.reactorPubkey)}, '
+        'giftWrap=$giftWrapId)',
+        category: LogCategory.system,
       );
-      // Target reaction not synced yet. Defer so the wrap stays unrecorded and
-      // re-decrypts once the reaction lands — otherwise upsertIncoming would
-      // insert it live afterwards and it would never be soft-deleted (the
-      // deletion-before-reaction drain race; NIP-59 randomizes gift-wrap
-      // created_at). Symmetric with persistIncoming's unsynced-target handling.
-      // #5452.
-      if (row == null) {
-        outcome = DmWrapOutcome.deferred;
-        continue;
-      }
-      if (row.isDeleted) continue;
-
-      // NIP-09: only the original reaction author may delete their reaction.
-      if (row.reactorPubkey != rumorEvent.pubkey) {
-        Log.debug(
-          'Ignoring wrapped reaction deletion for $rumorId: author mismatch '
-          '(event=${pubkeyForLogs(rumorEvent.pubkey)}, '
-          'reactor=${pubkeyForLogs(row.reactorPubkey)}, '
-          'giftWrap=$giftWrapId)',
-          category: LogCategory.system,
-        );
-        continue;
-      }
-
-      try {
-        await _reactionsDao.softDelete(id: rumorId, ownerPubkey: _userPubkey);
-      } on Object catch (e, st) {
-        _errorReporter?.call(
-          e,
-          st,
-          site: DmReactionsRepositoryReportableSites
-              .handleIncomingDeletionSoftDelete,
-        );
-        // Transient DAO failure — let it retry rather than cement a skip.
-        outcome = DmWrapOutcome.deferred;
-      }
+      return DmWrapOutcome.processed;
     }
-    return outcome;
+
+    try {
+      await _reactionsDao.softDelete(id: rumorId, ownerPubkey: _userPubkey);
+    } on Object catch (e, st) {
+      _errorReporter?.call(
+        e,
+        st,
+        site: DmReactionsRepositoryReportableSites
+            .handleIncomingDeletionSoftDelete,
+      );
+      // Transient DAO failure — let it retry rather than cement a skip.
+      return DmWrapOutcome.deferred;
+    }
+    return DmWrapOutcome.processed;
   }
 
   // -------------------------------------------------------------------------
@@ -1158,16 +1156,5 @@ class DmReactionsRepository {
       publishStatus: publishStatus,
       giftWrapId: row.giftWrapId,
     );
-  }
-
-  bool _targetsReactionKind(List<List<String>> tags) {
-    for (final tag in tags) {
-      if (tag.length >= 2 &&
-          tag[0] == 'k' &&
-          tag[1] == EventKind.reaction.toString()) {
-        return true;
-      }
-    }
-    return false;
   }
 }

--- a/mobile/packages/dm_repository/lib/src/dm_reactions_repository_reportable_sites.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_reactions_repository_reportable_sites.dart
@@ -12,8 +12,13 @@ abstract class DmReactionsRepositoryReportableSites {
   /// Programming-invariant violation — the validator above passed.
   static const String persistIncomingDaoUpsert = 'persistIncoming.daoUpsert';
 
-  /// `handleIncomingDeletion`: DAO soft-delete threw despite a validated
-  /// matching reaction row.
+  /// `applyDeletion`: DAO soft-delete threw despite a validated matching
+  /// reaction row.
+  ///
+  /// The wire value still says `handleIncomingDeletion` — the method's name
+  /// before #7809 split message routing out of it. Crashlytics aggregates on
+  /// this string, so renaming it would fork the dashboard history for a
+  /// failure whose cause has not changed.
   static const String handleIncomingDeletionSoftDelete =
       'handleIncomingDeletion.softDelete';
 

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -1719,36 +1719,9 @@ class DmRepository {
     try {
       for (final tag in deletionEvent.tags) {
         if (tag.length < 2 || tag[0] != 'e') continue;
-        final rumorId = tag[1];
-
-        final row = await _directMessagesDao.getMessageById(
-          rumorId,
-          ownerPubkey: _ownerPubkey,
-        );
-        if (row == null) continue;
-
-        // NIP-09: only the original author may delete.
-        if (row.senderPubkey != deletionEvent.pubkey) {
-          Log.debug(
-            'Ignoring kind 5 for $rumorId: author mismatch '
-            '(event=${pubkeyForLogs(deletionEvent.pubkey)}, '
-            'sender=${pubkeyForLogs(row.senderPubkey)})',
-            category: LogCategory.system,
-          );
-          continue;
-        }
-
-        if (row.isDeleted) continue; // Already processed.
-
-        await _directMessagesDao.markMessageDeleted(
-          rumorId,
-          ownerPubkey: _ownerPubkey,
-        );
-        await _refreshConversationPreview(row.conversationId);
-
-        Log.debug(
-          'Applied kind 5 deletion for message $rumorId',
-          category: LogCategory.system,
+        await _applyMessageDeletion(
+          rumorId: tag[1],
+          deleterPubkey: deletionEvent.pubkey,
         );
       }
     } on Object catch (e, stackTrace) {
@@ -1759,6 +1732,60 @@ class DmRepository {
         stackTrace: stackTrace,
       );
     }
+  }
+
+  /// Soft-deletes the message [rumorId] on behalf of [deleterPubkey], the
+  /// single place the NIP-09 author rule is enforced for messages.
+  ///
+  /// Returns [DmWrapOutcome.deferred] only when the target message has not
+  /// synced yet, so a wrapped caller leaves the gift wrap out of the
+  /// processed-wrap ledger and re-applies once the message lands. NIP-59
+  /// randomizes gift-wrap `created_at`, so a deletion really can drain ahead
+  /// of the message it names; recording it terminally would lose the deletion
+  /// for good. Mirrors the reaction side's unsynced-target handling (#5452).
+  ///
+  /// Every other outcome is [DmWrapOutcome.processed] — applied, already
+  /// deleted, or refused for author mismatch. A mismatch will never become
+  /// valid, so re-decrypting it forever buys nothing.
+  ///
+  /// [deleterPubkey] must be the rumor's authenticated author. For a wrapped
+  /// deletion that is `rumor.pubkey`, which `getRumorEvent` rebuilds from the
+  /// signed seal — never the gift wrap's own pubkey, which is an ephemeral
+  /// NIP-59 key carrying no identity.
+  Future<DmWrapOutcome> _applyMessageDeletion({
+    required String rumorId,
+    required String deleterPubkey,
+  }) async {
+    final row = await _directMessagesDao.getMessageById(
+      rumorId,
+      ownerPubkey: _ownerPubkey,
+    );
+    if (row == null) return DmWrapOutcome.deferred;
+
+    // NIP-09: only the original author may delete.
+    if (row.senderPubkey != deleterPubkey) {
+      Log.debug(
+        'Ignoring kind 5 for $rumorId: author mismatch '
+        '(event=${pubkeyForLogs(deleterPubkey)}, '
+        'sender=${pubkeyForLogs(row.senderPubkey)})',
+        category: LogCategory.system,
+      );
+      return DmWrapOutcome.processed;
+    }
+
+    if (row.isDeleted) return DmWrapOutcome.processed; // Already processed.
+
+    await _directMessagesDao.markMessageDeleted(
+      rumorId,
+      ownerPubkey: _ownerPubkey,
+    );
+    await _refreshConversationPreview(row.conversationId);
+
+    Log.debug(
+      'Applied kind 5 deletion for message $rumorId',
+      category: LogCategory.system,
+    );
+    return DmWrapOutcome.processed;
   }
 
   /// Pre-decrypt dedup: has this gift wrap (or NIP-04 event) already been

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -1734,15 +1734,81 @@ class DmRepository {
     }
   }
 
+  /// Applies a wrapped NIP-09 kind-5 rumor to whichever store holds each
+  /// target it names — the reaction rows, the message rows, or both.
+  ///
+  /// Routing resolves each `e` target against local state rather than
+  /// believing the rumor's `k` tag. `k` is only a hint for which store to try
+  /// first. Three reasons, and each one has bitten:
+  ///
+  ///  * NIP-09 makes `k` a SHOULD (`09.md:9`), so a conforming foreign client
+  ///    may omit it entirely (#7329).
+  ///  * Our own sender hardcodes `['k','14']` even when deleting a kind-15
+  ///    file message, so the tag is already wrong on our own wire.
+  ///  * Before this, *every* wrapped kind-5 went to the reactions handler,
+  ///    which answered `processed` for anything not tagged `['k','7']`. That
+  ///    recorded the wrap terminally and lost message deletions for good
+  ///    (#7809).
+  ///
+  /// The outcome across targets is a conjunction that only ever downgrades:
+  /// [DmWrapOutcome.processed] requires *every* target to have reached a
+  /// terminal state. NIP-09 permits several `e` tags, and a rumor naming one
+  /// known and one unsynced target must not be recorded — doing so would lose
+  /// the unsynced one permanently, which is the very bug this fixes.
+  Future<DmWrapOutcome> _routeWrappedDeletion({
+    required Event rumor,
+    required String giftWrapId,
+  }) async {
+    final reactions = _reactionsRepository;
+    final tryReactionsFirst = _hasKindHint(rumor.tags, EventKind.reaction);
+
+    var outcome = DmWrapOutcome.processed;
+    for (final tag in rumor.tags) {
+      if (tag.length < 2 || tag[0] != 'e') continue;
+      final rumorId = tag[1];
+
+      Future<DmWrapOutcome?> asReaction() async => reactions?.applyDeletion(
+        rumorId: rumorId,
+        deleterPubkey: rumor.pubkey,
+        giftWrapId: giftWrapId,
+      );
+      Future<DmWrapOutcome?> asMessage() async => _applyMessageDeletion(
+        rumorId: rumorId,
+        deleterPubkey: rumor.pubkey,
+      );
+
+      final resolved = tryReactionsFirst
+          ? await asReaction() ?? await asMessage()
+          : await asMessage() ?? await asReaction();
+
+      // Neither store holds the target — it may still arrive, since NIP-59
+      // randomizes gift-wrap `created_at` and a deletion can drain ahead of
+      // the event it names. A null `_reactionsRepository` (legacy fixtures)
+      // lands here too: that is "cannot resolve", not "nothing to do", and
+      // cementing it would burn the wrap for every account on the device.
+      if ((resolved ?? DmWrapOutcome.deferred) == DmWrapOutcome.deferred) {
+        outcome = DmWrapOutcome.deferred;
+      }
+    }
+    return outcome;
+  }
+
+  /// Whether [tags] carries a `['k', <kind>]` hint naming [kind].
+  static bool _hasKindHint(List<List<String>> tags, int kind) {
+    final wanted = kind.toString();
+    for (final tag in tags) {
+      if (tag.length >= 2 && tag[0] == 'k' && tag[1] == wanted) return true;
+    }
+    return false;
+  }
+
   /// Soft-deletes the message [rumorId] on behalf of [deleterPubkey], the
   /// single place the NIP-09 author rule is enforced for messages.
   ///
-  /// Returns [DmWrapOutcome.deferred] only when the target message has not
-  /// synced yet, so a wrapped caller leaves the gift wrap out of the
-  /// processed-wrap ledger and re-applies once the message lands. NIP-59
-  /// randomizes gift-wrap `created_at`, so a deletion really can drain ahead
-  /// of the message it names; recording it terminally would lose the deletion
-  /// for good. Mirrors the reaction side's unsynced-target handling (#5452).
+  /// Returns `null` when this account holds no message with that id, so the
+  /// wrapped classifier can try the reaction store instead — the apply
+  /// doubles as the probe, keeping routing to one DAO read when the `k` hint
+  /// is right.
   ///
   /// Every other outcome is [DmWrapOutcome.processed] — applied, already
   /// deleted, or refused for author mismatch. A mismatch will never become
@@ -1752,7 +1818,7 @@ class DmRepository {
   /// deletion that is `rumor.pubkey`, which `getRumorEvent` rebuilds from the
   /// signed seal — never the gift wrap's own pubkey, which is an ephemeral
   /// NIP-59 key carrying no identity.
-  Future<DmWrapOutcome> _applyMessageDeletion({
+  Future<DmWrapOutcome?> _applyMessageDeletion({
     required String rumorId,
     required String deleterPubkey,
   }) async {
@@ -1760,7 +1826,7 @@ class DmRepository {
       rumorId,
       ownerPubkey: _ownerPubkey,
     );
-    if (row == null) return DmWrapOutcome.deferred;
+    if (row == null) return null;
 
     // NIP-09: only the original author may delete.
     if (row.senderPubkey != deleterPubkey) {
@@ -2003,8 +2069,8 @@ class DmRepository {
         return;
       }
       if (rumor.kind == EventKind.eventDeletion) {
-        final outcome = await _reactionsRepository?.handleIncomingDeletion(
-          rumorEvent: rumor,
+        final outcome = await _routeWrappedDeletion(
+          rumor: rumor,
           giftWrapId: giftWrapEvent.id,
         );
         if (outcome == DmWrapOutcome.processed) {

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -1967,7 +1967,7 @@ class DmRepository {
         );
         // Record only terminal outcomes: a reaction whose target message has
         // not synced is left out so it re-decrypts and lands later. #5452.
-        if (outcome == DmReactionWrapOutcome.processed) {
+        if (outcome == DmWrapOutcome.processed) {
           await _recordProcessedWrap(
             giftWrapEvent.id,
             ownerPubkey: ownerPubkey,
@@ -1980,7 +1980,7 @@ class DmRepository {
           rumorEvent: rumor,
           giftWrapId: giftWrapEvent.id,
         );
-        if (outcome == DmReactionWrapOutcome.processed) {
+        if (outcome == DmWrapOutcome.processed) {
           await _recordProcessedWrap(
             giftWrapEvent.id,
             ownerPubkey: ownerPubkey,

--- a/mobile/packages/dm_repository/test/src/dm_reactions_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_reactions_repository_test.dart
@@ -1327,7 +1327,7 @@ void main() {
     );
 
     test(
-      'handleIncomingDeletion soft-deletes matching reaction rows',
+      'applyDeletion soft-deletes the matching reaction row',
       () async {
         when(
           () =>
@@ -1341,15 +1341,9 @@ void main() {
         ).thenAnswer((_) async => 1);
 
         final repository = createRepository();
-        final outcome = await repository.handleIncomingDeletion(
-          rumorEvent: reactionRumor(
-            kind: EventKind.eventDeletion,
-            content: '',
-            tags: [
-              ['e', _reactionRumorId],
-              ['k', EventKind.reaction.toString()],
-            ],
-          ),
+        final outcome = await repository.applyDeletion(
+          rumorId: _reactionRumorId,
+          deleterPubkey: _ownerPubkey,
           giftWrapId: _giftWrapId,
         );
 
@@ -1365,21 +1359,15 @@ void main() {
       },
     );
 
-    test('handleIncomingDeletion ignores author mismatches', () async {
+    test('applyDeletion ignores author mismatches', () async {
       when(
         () => mockDao.getById(id: _reactionRumorId, ownerPubkey: _ownerPubkey),
       ).thenAnswer((_) async => makeRow(reactorPubkey: _otherPubkey));
 
       final repository = createRepository();
-      final outcome = await repository.handleIncomingDeletion(
-        rumorEvent: reactionRumor(
-          kind: EventKind.eventDeletion,
-          content: '',
-          tags: [
-            ['e', _reactionRumorId],
-            ['k', EventKind.reaction.toString()],
-          ],
-        ),
+      final outcome = await repository.applyDeletion(
+        rumorId: _reactionRumorId,
+        deleterPubkey: _ownerPubkey,
         giftWrapId: _giftWrapId,
       );
 
@@ -1395,32 +1383,28 @@ void main() {
     });
 
     test(
-      'handleIncomingDeletion defers when the target reaction has not synced',
+      'applyDeletion returns null when the target reaction has not synced',
       () async {
-        // NIP-59 randomizes gift-wrap created_at, so a deletion can drain
-        // before the reaction it removes. With the target row absent, recording
-        // the deletion as terminal would let the reaction insert live later and
-        // never be soft-deleted. Defer instead so the wrap re-decrypts and
-        // applies once the reaction lands. #5452.
+        // `null` means "no reaction with that id here", which lets
+        // DmRepository's classifier try the message store before giving up.
+        // Only when neither store holds the target does the wrap defer — and
+        // it must, because NIP-59 randomizes gift-wrap created_at, so a
+        // deletion can drain before the reaction it removes. Recording it as
+        // terminal would let the reaction insert live later and never be
+        // soft-deleted. #5452, #7809.
         when(
           () =>
               mockDao.getById(id: _reactionRumorId, ownerPubkey: _ownerPubkey),
         ).thenAnswer((_) async => null);
 
         final repository = createRepository();
-        final outcome = await repository.handleIncomingDeletion(
-          rumorEvent: reactionRumor(
-            kind: EventKind.eventDeletion,
-            content: '',
-            tags: [
-              ['e', _reactionRumorId],
-              ['k', EventKind.reaction.toString()],
-            ],
-          ),
+        final outcome = await repository.applyDeletion(
+          rumorId: _reactionRumorId,
+          deleterPubkey: _ownerPubkey,
           giftWrapId: _giftWrapId,
         );
 
-        expect(outcome, DmWrapOutcome.deferred);
+        expect(outcome, isNull);
         verifyNever(
           () => mockDao.softDelete(
             id: any(named: 'id'),
@@ -1431,7 +1415,7 @@ void main() {
     );
 
     test(
-      'handleIncomingDeletion defers and reports on a soft-delete failure',
+      'applyDeletion defers and reports on a soft-delete failure',
       () async {
         when(
           () =>
@@ -1445,15 +1429,9 @@ void main() {
         ).thenThrow(StateError('boom'));
 
         final repository = createRepository();
-        final outcome = await repository.handleIncomingDeletion(
-          rumorEvent: reactionRumor(
-            kind: EventKind.eventDeletion,
-            content: '',
-            tags: [
-              ['e', _reactionRumorId],
-              ['k', EventKind.reaction.toString()],
-            ],
-          ),
+        final outcome = await repository.applyDeletion(
+          rumorId: _reactionRumorId,
+          deleterPubkey: _ownerPubkey,
           giftWrapId: _giftWrapId,
         );
 

--- a/mobile/packages/dm_repository/test/src/dm_reactions_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_reactions_repository_test.dart
@@ -1200,8 +1200,8 @@ void main() {
         giftWrapId: _giftWrapId,
       );
 
-      expect(emptyContentOutcome, DmReactionWrapOutcome.processed);
-      expect(missingTagOutcome, DmReactionWrapOutcome.processed);
+      expect(emptyContentOutcome, DmWrapOutcome.processed);
+      expect(missingTagOutcome, DmWrapOutcome.processed);
 
       verifyNever(
         () => mockDao.upsertIncoming(
@@ -1239,7 +1239,7 @@ void main() {
         giftWrapId: _giftWrapId,
       );
 
-      expect(outcome, DmReactionWrapOutcome.processed);
+      expect(outcome, DmWrapOutcome.processed);
       verify(
         () => mockDao.upsertIncoming(
           id: _reactionRumorId,
@@ -1278,7 +1278,7 @@ void main() {
 
       // A transient DAO failure must NOT cement a skip — leave it deferred so
       // the wrap retries on a later launch. #5452.
-      expect(outcome, DmReactionWrapOutcome.deferred);
+      expect(outcome, DmWrapOutcome.deferred);
       expect(
         reporterSites,
         contains(
@@ -1309,7 +1309,7 @@ void main() {
           giftWrapId: _giftWrapId,
         );
 
-        expect(outcome, DmReactionWrapOutcome.deferred);
+        expect(outcome, DmWrapOutcome.deferred);
         verifyNever(
           () => mockDao.upsertIncoming(
             id: any(named: 'id'),
@@ -1355,7 +1355,7 @@ void main() {
 
         // Terminal: the deletion wrap is recorded so it is not re-decrypted on
         // every launch. #5452.
-        expect(outcome, DmReactionWrapOutcome.processed);
+        expect(outcome, DmWrapOutcome.processed);
         verify(
           () => mockDao.softDelete(
             id: _reactionRumorId,
@@ -1385,7 +1385,7 @@ void main() {
 
       // An invalid deletion (author mismatch) will never apply — it is
       // terminal, so the wrap is recorded and not re-decrypted. #5452.
-      expect(outcome, DmReactionWrapOutcome.processed);
+      expect(outcome, DmWrapOutcome.processed);
       verifyNever(
         () => mockDao.softDelete(
           id: any(named: 'id'),
@@ -1420,7 +1420,7 @@ void main() {
           giftWrapId: _giftWrapId,
         );
 
-        expect(outcome, DmReactionWrapOutcome.deferred);
+        expect(outcome, DmWrapOutcome.deferred);
         verifyNever(
           () => mockDao.softDelete(
             id: any(named: 'id'),
@@ -1459,7 +1459,7 @@ void main() {
 
         // A transient DAO failure must NOT cement a skip — leave it deferred so
         // the wrap retries on a later launch. #5452.
-        expect(outcome, DmReactionWrapOutcome.deferred);
+        expect(outcome, DmWrapOutcome.deferred);
         expect(
           reporterSites,
           contains(

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -12675,6 +12675,7 @@ void main() {
         String id, {
         String senderPubkey = _validPubkeyB,
         bool isDeleted = false,
+        int messageKind = EventKind.privateDirectMessage,
       }) {
         when(
           () => mockDirectMessagesDao.getMessageById(
@@ -12689,7 +12690,7 @@ void main() {
             content: 'Hello',
             createdAt: 1700000000,
             giftWrapId: _giftWrapEventId,
-            messageKind: 14,
+            messageKind: messageKind,
             isDeleted: isDeleted,
           ),
         );
@@ -12724,6 +12725,26 @@ void main() {
 
         final repository = await deliver(
           deletionRumor(targets: [_giftWrapEventId2]),
+        );
+
+        verify(
+          () => mockDirectMessagesDao.markMessageDeleted(
+            _giftWrapEventId2,
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        ).called(1);
+        expect(ledger.recorded, contains(_giftWrapEventId));
+        await repository.stopListening();
+      });
+
+      test('applies a k=15 deletion to the file message it names', () async {
+        stubMessage(
+          _giftWrapEventId2,
+          messageKind: EventKind.fileMessage,
+        );
+
+        final repository = await deliver(
+          deletionRumor(targets: [_giftWrapEventId2], kTag: '15'),
         );
 
         verify(
@@ -12796,6 +12817,28 @@ void main() {
           await repository.stopListening();
         },
       );
+
+      test('applies a deferred deletion after the target syncs', () async {
+        stubNoMessage(_giftWrapEventId2);
+        final rumor = deletionRumor(targets: [_giftWrapEventId2]);
+        final repository = await deliver(rumor);
+
+        expect(ledger.recorded, isNot(contains(_giftWrapEventId)));
+
+        stubMessage(_giftWrapEventId2);
+        controller.add(giftWrap());
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+
+        verify(
+          () => mockDirectMessagesDao.markMessageDeleted(
+            _giftWrapEventId2,
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        ).called(1);
+        expect(ledger.recorded, contains(_giftWrapEventId));
+        await repository.stopListening();
+      });
 
       test('refuses a wrapped message deletion from a non-author', () async {
         // NIP-09's one client MUST (09.md:41). Terminal, not deferred — a

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -12523,7 +12523,7 @@ void main() {
               rumorEvent: any(named: 'rumorEvent'),
               giftWrapId: _giftWrapEventId,
             ),
-          ).thenAnswer((_) async => DmReactionWrapOutcome.processed);
+          ).thenAnswer((_) async => DmWrapOutcome.processed);
 
           final repository = createRepository(
             reactionsRepository: mockReactionsRepository,
@@ -12676,7 +12676,7 @@ void main() {
               rumorEvent: any(named: 'rumorEvent'),
               giftWrapId: _giftWrapEventId,
             ),
-          ).thenAnswer((_) async => DmReactionWrapOutcome.processed);
+          ).thenAnswer((_) async => DmWrapOutcome.processed);
 
           var decryptCount = 0;
           final repository = createRepository(
@@ -12713,7 +12713,7 @@ void main() {
               rumorEvent: any(named: 'rumorEvent'),
               giftWrapId: _giftWrapEventId,
             ),
-          ).thenAnswer((_) async => DmReactionWrapOutcome.processed);
+          ).thenAnswer((_) async => DmWrapOutcome.processed);
 
           var decryptCount = 0;
           final repository = createRepository(
@@ -12747,7 +12747,7 @@ void main() {
               rumorEvent: any(named: 'rumorEvent'),
               giftWrapId: _giftWrapEventId,
             ),
-          ).thenAnswer((_) async => DmReactionWrapOutcome.deferred);
+          ).thenAnswer((_) async => DmWrapOutcome.deferred);
 
           var decryptCount = 0;
           final repository = createRepository(
@@ -13457,7 +13457,7 @@ void main() {
               rumorEvent: any(named: 'rumorEvent'),
               giftWrapId: _giftWrapEventId,
             ),
-          ).thenAnswer((_) async => DmReactionWrapOutcome.processed);
+          ).thenAnswer((_) async => DmWrapOutcome.processed);
 
           final repository = createRepository(
             processedGiftWrapsDao: ledger,

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -12588,6 +12588,65 @@ void main() {
           await repository.stopListening();
         },
       );
+
+      test(
+        'routes a tag-less wrapped deletion to a matching reaction',
+        () async {
+          final controller = StreamController<Event>();
+          final ledger = _InMemoryProcessedGiftWrapsDao();
+          stubWrappedDeleteSubscription(controller);
+
+          when(
+            () => mockDirectMessagesDao.hasGiftWrap(_giftWrapEventId),
+          ).thenAnswer((_) async => false);
+          when(
+            () => mockDirectMessagesDao.getMessageById(
+              _giftWrapEventId2,
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          ).thenAnswer((_) async => null);
+          when(
+            () => mockReactionsRepository.applyDeletion(
+              rumorId: _giftWrapEventId2,
+              deleterPubkey: _validPubkeyB,
+              giftWrapId: _giftWrapEventId,
+            ),
+          ).thenAnswer((_) async => DmWrapOutcome.processed);
+
+          final repository = createRepository(
+            processedGiftWrapsDao: ledger,
+            reactionsRepository: mockReactionsRepository,
+            rumorDecryptor: (_, _) async => Event.fromJson({
+              'id': _rumorEventId,
+              'pubkey': _validPubkeyB,
+              'created_at': 1700000000,
+              'kind': EventKind.eventDeletion,
+              'tags': [
+                ['e', _giftWrapEventId2],
+              ],
+              'content': '',
+              'sig': '',
+            }),
+          );
+          await repository.startListening();
+
+          controller.add(createGiftWrapDeletionRumor());
+          await Future<void>.delayed(Duration.zero);
+          await Future<void>.delayed(Duration.zero);
+
+          verify(
+            () => mockReactionsRepository.applyDeletion(
+              rumorId: _giftWrapEventId2,
+              deleterPubkey: _validPubkeyB,
+              giftWrapId: _giftWrapEventId,
+            ),
+          ).called(1);
+          expect(ledger.recorded, contains(_giftWrapEventId));
+
+          await controller.close();
+          await repository.stopListening();
+        },
+      );
     });
 
     group('receive pipeline - wrapped message deletion (#7809, #7329)', () {

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -476,6 +476,10 @@ const _giftWrapEventId =
 const _giftWrapEventId2 =
     '06789012345678901234567890abcdef1234567890123456789012ab12c3d4e5';
 
+/// A second message rumor id, for a wrapped deletion naming two targets.
+const _secondTargetRumorId =
+    '16789012345678901234567890abcdef1234567890123456789012ab12c3d4e5';
+
 void main() {
   group(DmRepository, () {
     late _MockNostrClient mockNostrClient;
@@ -12519,8 +12523,9 @@ void main() {
             () => mockDirectMessagesDao.hasGiftWrap(_giftWrapEventId),
           ).thenAnswer((_) async => false);
           when(
-            () => mockReactionsRepository.handleIncomingDeletion(
-              rumorEvent: any(named: 'rumorEvent'),
+            () => mockReactionsRepository.applyDeletion(
+              rumorId: any(named: 'rumorId'),
+              deleterPubkey: any(named: 'deleterPubkey'),
               giftWrapId: _giftWrapEventId,
             ),
           ).thenAnswer((_) async => DmWrapOutcome.processed);
@@ -12546,8 +12551,9 @@ void main() {
           await Future<void>.delayed(Duration.zero);
 
           verify(
-            () => mockReactionsRepository.handleIncomingDeletion(
-              rumorEvent: any(named: 'rumorEvent'),
+            () => mockReactionsRepository.applyDeletion(
+              rumorId: any(named: 'rumorId'),
+              deleterPubkey: any(named: 'deleterPubkey'),
               giftWrapId: _giftWrapEventId,
             ),
           ).called(1);
@@ -12582,6 +12588,275 @@ void main() {
           await repository.stopListening();
         },
       );
+    });
+
+    group('receive pipeline - wrapped message deletion (#7809, #7329)', () {
+      final participants = [_validPubkeyA, _validPubkeyB]..sort();
+      final convId = DmRepository.computeConversationId(participants);
+
+      late StreamController<Event> controller;
+      late _InMemoryProcessedGiftWrapsDao ledger;
+
+      setUp(() {
+        controller = StreamController<Event>();
+        ledger = _InMemoryProcessedGiftWrapsDao();
+        when(
+          () => mockNostrClient.subscribe(
+            any(),
+            subscriptionId: any(named: 'subscriptionId'),
+          ),
+        ).thenAnswer((_) => controller.stream);
+        when(() => mockNostrClient.unsubscribe(any())).thenAnswer((_) async {});
+        when(
+          () => mockDirectMessagesDao.hasGiftWrap(_giftWrapEventId),
+        ).thenAnswer((_) async => false);
+        when(
+          () => mockDirectMessagesDao.markMessageDeleted(
+            any(),
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        ).thenAnswer((_) async => true);
+        when(
+          () => mockDirectMessagesDao.getMessagesForConversation(
+            convId,
+            limit: 1,
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        ).thenAnswer((_) async => []);
+        when(
+          () => mockConversationsDao.getConversation(
+            convId,
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        ).thenAnswer((_) async => null);
+        // No reaction row anywhere unless a test says otherwise, so the
+        // reaction arm reports "not mine" and routing falls through.
+        when(
+          () => mockReactionsRepository.applyDeletion(
+            rumorId: any(named: 'rumorId'),
+            deleterPubkey: any(named: 'deleterPubkey'),
+            giftWrapId: any(named: 'giftWrapId'),
+          ),
+        ).thenAnswer((_) async => null);
+      });
+
+      Event giftWrap() => Event.fromJson({
+        'id': _giftWrapEventId,
+        'pubkey': _validPubkeyC,
+        'created_at': 1700000100,
+        'kind': EventKind.giftWrap,
+        'tags': [
+          ['p', _validPubkeyA],
+        ],
+        'content': 'wrapped',
+        'sig': '',
+      });
+
+      /// A wrapped kind-5 authored by [authorPubkey] naming [targets].
+      /// [kTag] is the NIP-09 `k` hint; `null` omits it entirely.
+      Event deletionRumor({
+        required List<String> targets,
+        String? kTag = '14',
+        String authorPubkey = _validPubkeyB,
+      }) => Event.fromJson({
+        'id': _rumorEventId,
+        'pubkey': authorPubkey,
+        'created_at': 1700000000,
+        'kind': EventKind.eventDeletion,
+        'tags': [
+          for (final t in targets) ['e', t],
+          if (kTag != null) ['k', kTag],
+        ],
+        'content': '',
+        'sig': '',
+      });
+
+      void stubMessage(
+        String id, {
+        String senderPubkey = _validPubkeyB,
+        bool isDeleted = false,
+      }) {
+        when(
+          () => mockDirectMessagesDao.getMessageById(
+            id,
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        ).thenAnswer(
+          (_) async => DirectMessageRow(
+            id: id,
+            conversationId: convId,
+            senderPubkey: senderPubkey,
+            content: 'Hello',
+            createdAt: 1700000000,
+            giftWrapId: _giftWrapEventId,
+            messageKind: 14,
+            isDeleted: isDeleted,
+          ),
+        );
+      }
+
+      void stubNoMessage(String id) {
+        when(
+          () => mockDirectMessagesDao.getMessageById(
+            id,
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        ).thenAnswer((_) async => null);
+      }
+
+      Future<DmRepository> deliver(Event rumor) async {
+        final repository = createRepository(
+          processedGiftWrapsDao: ledger,
+          reactionsRepository: mockReactionsRepository,
+          rumorDecryptor: (_, _) async => rumor,
+        );
+        await repository.startListening();
+        controller.add(giftWrap());
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+        return repository;
+      }
+
+      tearDown(() async => controller.close());
+
+      test('applies a k=14 deletion to the message it names', () async {
+        stubMessage(_giftWrapEventId2);
+
+        final repository = await deliver(
+          deletionRumor(targets: [_giftWrapEventId2]),
+        );
+
+        verify(
+          () => mockDirectMessagesDao.markMessageDeleted(
+            _giftWrapEventId2,
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        ).called(1);
+        expect(ledger.recorded, contains(_giftWrapEventId));
+        await repository.stopListening();
+      });
+
+      test('resolves a deletion carrying no k tag at all', () async {
+        // NIP-09 makes `k` a SHOULD (09.md:9), so a conforming foreign client
+        // may omit it. Routing must fall back to local resolution. #7329.
+        stubMessage(_giftWrapEventId2);
+
+        final repository = await deliver(
+          deletionRumor(targets: [_giftWrapEventId2], kTag: null),
+        );
+
+        verify(
+          () => mockDirectMessagesDao.markMessageDeleted(
+            _giftWrapEventId2,
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        ).called(1);
+        await repository.stopListening();
+      });
+
+      test('resolves locally when the k tag contradicts the target', () async {
+        // k=7 naming a MESSAGE id. The reaction store answers "not mine" and
+        // routing falls through, so the hint orders the lookups and never
+        // gates them. This is the test that stops the k-gate coming back.
+        stubMessage(_giftWrapEventId2);
+
+        final repository = await deliver(
+          deletionRumor(targets: [_giftWrapEventId2], kTag: '7'),
+        );
+
+        verify(
+          () => mockDirectMessagesDao.markMessageDeleted(
+            _giftWrapEventId2,
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        ).called(1);
+        await repository.stopListening();
+      });
+
+      test(
+        'leaves the wrap unrecorded when no store holds the target',
+        () async {
+          // The permanent-loss guard. Recording here would suppress this wrap
+          // for EVERY account on the device, with no TTL and no recovery by
+          // switching accounts, so a deletion that merely arrived early would
+          // be lost for good.
+          stubNoMessage(_giftWrapEventId2);
+
+          final repository = await deliver(
+            deletionRumor(targets: [_giftWrapEventId2]),
+          );
+
+          expect(ledger.recorded, isNot(contains(_giftWrapEventId)));
+          verifyNever(
+            () => mockDirectMessagesDao.markMessageDeleted(
+              any(),
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          );
+          await repository.stopListening();
+        },
+      );
+
+      test('refuses a wrapped message deletion from a non-author', () async {
+        // NIP-09's one client MUST (09.md:41). Terminal, not deferred — a
+        // mismatch never becomes valid, so re-decrypting forever buys nothing.
+        stubMessage(_giftWrapEventId2, senderPubkey: _validPubkeyA);
+
+        final repository = await deliver(
+          deletionRumor(targets: [_giftWrapEventId2]),
+        );
+
+        verifyNever(
+          () => mockDirectMessagesDao.markMessageDeleted(
+            any(),
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        );
+        expect(ledger.recorded, contains(_giftWrapEventId));
+        await repository.stopListening();
+      });
+
+      test(
+        'defers the whole wrap when one of two targets is unsynced',
+        () async {
+          // NIP-09 permits several `e` tags. Recording the wrap because the
+          // first target resolved would lose the second one permanently.
+          stubMessage(_giftWrapEventId2);
+          stubNoMessage(_secondTargetRumorId);
+
+          final repository = await deliver(
+            deletionRumor(targets: [_giftWrapEventId2, _secondTargetRumorId]),
+          );
+
+          verify(
+            () => mockDirectMessagesDao.markMessageDeleted(
+              _giftWrapEventId2,
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          ).called(1);
+          expect(ledger.recorded, isNot(contains(_giftWrapEventId)));
+          await repository.stopListening();
+        },
+      );
+
+      test('defers when no reactions repository is wired', () async {
+        // Legacy fixtures pass null. That is "cannot resolve", not "nothing
+        // to do" — cementing it would burn the wrap for every account.
+        stubNoMessage(_giftWrapEventId2);
+
+        final repository = createRepository(
+          processedGiftWrapsDao: ledger,
+          rumorDecryptor: (_, _) async =>
+              deletionRumor(targets: [_giftWrapEventId2], kTag: '7'),
+        );
+        await repository.startListening();
+        controller.add(giftWrap());
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(ledger.recorded, isNot(contains(_giftWrapEventId)));
+        await repository.stopListening();
+      });
     });
 
     group('receive pipeline - processed-wrap dedup ledger (#5452)', () {
@@ -12709,8 +12984,9 @@ void main() {
         'a re-delivered deletion wrap is decrypted only once',
         () async {
           when(
-            () => mockReactionsRepository.handleIncomingDeletion(
-              rumorEvent: any(named: 'rumorEvent'),
+            () => mockReactionsRepository.applyDeletion(
+              rumorId: any(named: 'rumorId'),
+              deleterPubkey: any(named: 'deleterPubkey'),
               giftWrapId: _giftWrapEventId,
             ),
           ).thenAnswer((_) async => DmWrapOutcome.processed);


### PR DESCRIPTION
## Description

A wrapped NIP-09 kind-5 that targets a **message** was silently swallowed and lost permanently.

`_persistDecryptedGiftWrap` handed *every* wrapped kind-5 to the reactions handler, and that handler returned `processed` for anything not carrying a literal `['k','7']`. `processed` records the gift wrap in `processed_gift_wraps`, which is checked **before** decrypt and has **no TTL** — so the deletion never applied and never got a second chance. The ledger is also read globally rather than per-owner, so the loss covered every account on the device, and switching accounts away and back did not recover it.

This PR gives `DmRepository` the `e`-tag loop and resolves each target against local state, using `k` only to decide which store to try first.

**Not trusting `k` is deliberate**, and each reason has already bitten:

- NIP-09 makes `k` a SHOULD (`09.md:9`), so a conforming client may omit it entirely — that is #7329.
- Our own sender hardcodes `['k','14']` even when deleting a kind-15 file message, so the tag is already wrong on our own wire.
- The old code treated a missing-or-different `k` as terminal, which is #7809.

`DmReactionsRepository.applyDeletion` now takes one already-classified target and returns `null` for "no reaction with that id here", so the apply doubles as the probe and routing costs one DAO read when the hint is right. `_targetsReactionKind` is deleted.

The outcome across targets only ever downgrades: `processed` requires *every* target to be terminal. NIP-09 permits several `e` tags, and recording a wrap because its first target resolved would lose the rest — a fresh instance of the bug being fixed.

**Related Issue:** Closes #7809. Closes #7329.

## Out of Scope

This is the **receive half only**, and that ordering is the point.

Divine still *sends* delete-for-everyone as a bare plaintext kind-5, which leaks the counterparty publicly and permanently (#7341) and discards its publish result (#8165). Flipping the sender to the wrapped NIP-17:87 form **before** this ships would break deletes for everyone still on an older build — their client swallows the wrap and records it in the TTL-less ledger, so the deletion is lost for them even after they upgrade. Shipping the receive side first creates no such regression, because nothing sends the wrapped form yet. For the same reason no ledger backfill is needed here.

Also out of scope, and belonging to the sender PR:

- the hardcoded `['k','14']` at the send site, which should read `row.messageKind`
- group delete-for-everyone, which is already broken today: a group send builds a distinct rumor per recipient but persists one row keyed on recipient 1's id, so recipients 2..N never match. The real fix is retaining the sibling ids at send time; `sendBatchId` is the join key.

The bare kind-5 receive path is deliberately **kept** — other clients and older builds still send it, and #7341 is about not emitting cleartext, not refusing to receive it. `eventDeletion` stays in the subscription filters for the same reason.

## Verification

- `flutter analyze packages/dm_repository lib` — clean
- `flutter test` from `packages/dm_repository` — 657 pass
- `flutter test test/blocs/dm` — 359 pass
- Ratchets: `check_ungrouped_tests`, `check_pubkey_log_encoding`, `check_nostr_id_log_truncation`, `check_post_close_emit_ceiling` — all pass

**Mutation-tested.** Reverting the classifier to the old "not `k=7` ⇒ terminal" behaviour turns 4 of the original 7 tests red, including the two that encode #7809 and #7329 and the one guarding against permanent loss. The suite discriminates rather than merely covering.

New coverage: a `k=14` deletion applies to the message it names; a `k=15` deletion applies to a file message; a deletion with no `k` tag resolves a message; a tag-less reaction deletion falls through a message miss to the reaction store; a `k=7` tag naming a message id still resolves to the message; an unknown target leaves the wrap unrecorded and applies after the target syncs; a non-author deletion is refused; a rumor naming one known and one unsynced target defers as a whole; and a null reactions repository defers rather than cementing.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] 🧹 Code refactor
