### PR TITLE
fix(dm): name moderation in the sheet a non-pinned row opens

### DIFF
--- a/mobile/lib/screens/inbox/inbox_view.dart
+++ b/mobile/lib/screens/inbox/inbox_view.dart
@@ -966,8 +966,8 @@ class _MessagesScrollViewState extends ConsumerState<_MessagesScrollView>
       orElse: () => conversation.participantPubkeys.first,
     );
 
-    // Same chain [ConversationTile] resolves its title through, so the sheet
-    // cannot name a different account than the row that opened it (#7380).
+    // Match [ConversationTile]'s non-vanished identity chain, so moderation
+    // and profile fallbacks stay consistent between the row and sheet (#7380).
     // A known identity skips the lookup entirely: moderation's kind-0 resolves
     // late and a retired moderation key has none at all, so the sheet would
     // otherwise open labelled with the fallback the row's own name exists to

--- a/mobile/lib/screens/inbox/inbox_view.dart
+++ b/mobile/lib/screens/inbox/inbox_view.dart
@@ -36,6 +36,7 @@ import 'package:openvine/screens/inbox/widgets/inbox_error_state.dart';
 import 'package:openvine/screens/inbox/widgets/inbox_fab.dart';
 import 'package:openvine/screens/inbox/widgets/inbox_filter_chips.dart';
 import 'package:openvine/screens/inbox/widgets/inbox_segmented_toggle.dart';
+import 'package:openvine/screens/inbox/widgets/moderation_identity.dart';
 import 'package:openvine/screens/inbox/widgets/restore_paused_banner.dart';
 import 'package:unified_logger/unified_logger.dart';
 
@@ -965,18 +966,25 @@ class _MessagesScrollViewState extends ConsumerState<_MessagesScrollView>
       orElse: () => conversation.participantPubkeys.first,
     );
 
-    // A known identity skips the lookup entirely: kind-0 for the moderation
-    // account resolves late, and the sheet would open labelled with the
-    // generated fallback name the row's own override exists to avoid.
+    // Same chain [ConversationTile] resolves its title through, so the sheet
+    // cannot name a different account than the row that opened it (#7380).
+    // A known identity skips the lookup entirely: moderation's kind-0 resolves
+    // late and a retired moderation key has none at all, so the sheet would
+    // otherwise open labelled with the fallback the row's own name exists to
+    // avoid.
     String displayName;
-    if (displayNameOverride != null) {
-      displayName = displayNameOverride;
+    final knownName =
+        displayNameOverride ?? moderationDisplayName(context, otherPubkey);
+    if (knownName != null) {
+      displayName = knownName;
     } else {
       final profile = await ref.read(
         fetchUserProfileProvider(otherPubkey).future,
       );
       if (!context.mounted) return;
-      displayName = profile?.bestDisplayName ?? 'user';
+      displayName =
+          profile?.bestDisplayName ??
+          UserProfile.defaultDisplayNameFor(otherPubkey);
     }
 
     if (!context.mounted) return;

--- a/mobile/test/screens/inbox/inbox_view_test.dart
+++ b/mobile/test/screens/inbox/inbox_view_test.dart
@@ -1991,6 +1991,51 @@ void main() {
         expect(find.text(l10n.inboxActionBlock('user')), findsNothing);
       });
 
+      // The other half of #7380. Blocking moderation suppresses the pin, so
+      // the thread falls back into the Blocked slice as an ordinary row — and
+      // that row is the one a user unblocks through. Its long-press is only
+      // live once the thread carries a message; a blocked account with no
+      // thread renders a placeholder whose long-press is null.
+      testWidgets('names moderation in the sheet the Blocked slice opens', (
+        tester,
+      ) async {
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        final blockedModeration = DmConversation(
+          id: 'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc',
+          participantPubkeys: const [currentPubkey, moderationPubkey],
+          isGroup: false,
+          createdAt: nowUnix,
+          lastMessageContent: 'Your video was removed.',
+          lastMessageTimestamp: nowUnix,
+        );
+        final actionsCubit = _MockConversationActionsCubit();
+
+        final subject = buildSubject(
+          actionsCubit: actionsCubit,
+          state: ConversationListState(
+            status: ConversationListStatus.loaded,
+            filter: InboxFilter.blocked,
+            visibleConversations: [blockedModeration],
+            blockedConversations: [blockedModeration],
+            hasMore: false,
+          ),
+        );
+        // After buildSubject, which stubs isBlocked to false by default.
+        when(() => actionsCubit.isBlocked(any())).thenReturn(true);
+
+        await tester.pumpWidget(subject);
+        await openMessages(tester);
+
+        await tester.longPress(find.byType(ConversationTile));
+        await tester.pumpAndSettle();
+
+        expect(
+          find.text(l10n.inboxActionUnblock(l10n.inboxSupportRowTitle)),
+          findsOneWidget,
+        );
+        expect(find.text(l10n.inboxActionUnblock('user')), findsNothing);
+      });
+
       testWidgets('drops out of a search it does not match', (tester) async {
         final l10n = lookupAppLocalizations(const Locale('en'));
         final conversation = DmConversation(

--- a/mobile/test/screens/inbox/inbox_view_test.dart
+++ b/mobile/test/screens/inbox/inbox_view_test.dart
@@ -1944,6 +1944,53 @@ void main() {
         );
       });
 
+      // #7380: the long-press sheet resolves the peer name on its own, and
+      // that chain omits `moderationDisplayName`. The tile above it reads
+      // "Divine Moderation"; the sheet it opens must not disagree.
+      testWidgets('names moderation in the sheet a retired-key row opens', (
+        tester,
+      ) async {
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        final retiredConversation = DmConversation(
+          id: 'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+          participantPubkeys: [currentPubkey, kLegacyModerationPubkeys.first],
+          isGroup: false,
+          createdAt: nowUnix,
+          lastMessageContent: 'You can reply to this message to appeal.',
+          lastMessageTimestamp: nowUnix,
+        );
+
+        await tester.pumpWidget(
+          buildSubject(
+            state: ConversationListState(
+              status: ConversationListStatus.loaded,
+              conversations: [retiredConversation],
+              visibleConversations: [retiredConversation],
+              hasMore: false,
+            ),
+          ),
+        );
+        await openMessages(tester);
+
+        await tester.longPress(find.byType(ConversationTile));
+        await tester.pumpAndSettle();
+
+        // The tile and the sheet it opened must name the same account.
+        expect(find.text(l10n.inboxSupportRowTitle), findsOneWidget);
+        expect(
+          find.text(l10n.inboxActionBlock(l10n.inboxSupportRowTitle)),
+          findsOneWidget,
+        );
+        expect(
+          find.text(l10n.inboxActionReport(l10n.inboxSupportRowTitle)),
+          findsOneWidget,
+        );
+        // #7380: the peer used to resolve to the bare literal 'user', so the
+        // sheet offered to block "user" under a tile titled "Divine
+        // Moderation". No profile lookup can produce that string now.
+        expect(find.text(l10n.inboxActionBlock('user')), findsNothing);
+      });
+
       testWidgets('drops out of a search it does not match', (tester) async {
         final l10n = lookupAppLocalizations(const Locale('en'));
         final conversation = DmConversation(
@@ -2399,7 +2446,13 @@ void main() {
         await tester.pumpAndSettle();
 
         final l10n = lookupAppLocalizations(const Locale('en'));
-        await tester.tap(find.text(l10n.inboxActionReport('user')));
+        await tester.tap(
+          find.text(
+            l10n.inboxActionReport(
+              UserProfile.defaultDisplayNameFor(otherPubkey),
+            ),
+          ),
+        );
         await tester.pumpAndSettle();
       }
 
@@ -2410,7 +2463,14 @@ void main() {
         await longPressAndReport(tester);
 
         final l10n = lookupAppLocalizations(const Locale('en'));
-        expect(find.text(l10n.inboxReportedUser('user')), findsOneWidget);
+        expect(
+          find.text(
+            l10n.inboxReportedUser(
+              UserProfile.defaultDisplayNameFor(otherPubkey),
+            ),
+          ),
+          findsOneWidget,
+        );
       });
 
       testWidgets('surfaces an error when the report reached no channel', (
@@ -2429,7 +2489,14 @@ void main() {
           findsOneWidget,
         );
         // Silence is the regression, so the confirmation must not render.
-        expect(find.text(l10n.inboxReportedUser('user')), findsNothing);
+        expect(
+          find.text(
+            l10n.inboxReportedUser(
+              UserProfile.defaultDisplayNameFor(otherPubkey),
+            ),
+          ),
+          findsNothing,
+        );
       });
     });
 
@@ -2477,7 +2544,11 @@ void main() {
 
         expect(find.text(l10n.inboxRemoveConfirmTitle), findsOneWidget);
         expect(
-          find.text(l10n.inboxRemoveConfirmBody('user')),
+          find.text(
+            l10n.inboxRemoveConfirmBody(
+              UserProfile.defaultDisplayNameFor(otherPubkey),
+            ),
+          ),
           findsOneWidget,
         );
       });


### PR DESCRIPTION
## What

`_onConversationLongPressed` resolved the conversation peer through its own chain, which omitted `moderationDisplayName` and ended at a bare, unlocalized `'user'` literal. Only the pinned support row passes `displayNameOverride`, so every *other* moderation row opened an action sheet reading **"Block user"** beneath a tile titled **"Divine Moderation"**.

Both halves now route through what `ConversationTile` already uses — `moderationDisplayName` first, then `UserProfile.defaultDisplayNameFor` — so for non-vanished peers, a tile and the sheet it opens use the same naming chain.

## Verification

Reproduced in a widget test before fixing. One rendered frame contained, simultaneously:

```
Divine Moderation | This conversation is closed. | Mute conversation | Report user | Block user | Remove conversation
```

Backend checks behind the two reachable cases:

- **Retired key** `121b915baba659cbe59626a8afaf83b01dc42354dfecaad9d465d51bb5715d72` — no kind-0 on `relay.divine.video`, `relay.nos.social` or `purplepag.es`; funnelcake returns `profile: null`. That response maps to `UserProfileNotPublished`, which returns null **and skips the relay fallback entirely** (`profile_repository.dart:904-913`), so the lookup cannot resolve. Confirmed against production and against the local Docker stack.
- **Blocked moderation** — `_extractPinnedSupport` is handed `visibleInbox` / `visibleRequests` only, never `blockedConversations`, so a blocked moderation thread is never lifted into the pin and renders as an ordinary row. `_doFetchFreshProfile` then returns null for a blocked pubkey (`profile_repository.dart:847`) whenever no profile is already cached.

Worth noting the issue understated the blast radius: the literal was reachable for **ordinary** peers too, not only moderation. Three existing tests pinned `'user'` for a non-moderation peer with `fetchUserProfileProvider` overridden to null — they are updated here to the shared fallback.

The current moderation key `8fd5eb6d8f362163bc00a5ab6b4a3167dbf32d00ec4efdbcf43b3c9514433b7e` **does** resolve today (kind-0 on `relay.divine.video` and `relay.nos.social`, plus funnelcake), so its unblocked case was not broken — the fix removes the dependency on that staying true.

## Testing

Both rows the issue names are covered, and both tests fail against the parent commit — `Found 0 widgets with text "Block Divine Moderation"` and `"Unblock Divine Moderation"` respectively.

- `names moderation in the sheet a retired-key row opens`
- `names moderation in the sheet the Blocked slice opens`

One precondition worth recording on the blocked row: its long-press is live only once the thread carries a message. `_computeBlockedConversations` synthesizes a row with no `lastMessage*` for a blocked account the viewer never messaged, which makes `isBlockedPlaceholder` true and `onLongPress` null. The test uses a thread with a message for that reason. The existing blocked-moderation bloc test could not have caught any of this — it stubs `runtimeBlockedUsers` as an empty set, and `_computeBlockedConversations` early-returns `const []` on that, so it structurally never produces the blocked-slice row.

Note the fix checks `moderationDisplayName` **before** the profile lookup, so it covers both wrong outcomes, not just the null one: `bestDisplayName` is non-nullable and falls back to a generated "Adjective Animal N", so a moderation account with a nameless profile would have contradicted the tile too.
- `flutter test test/screens/inbox/` — 459 passed
- `flutter analyze lib test integration_test` — no issues
- Ratchets: `check_ungrouped_tests`, `check_orphaned_arb_key_floor`, `check_l10n_delegates_ceiling`, `check_nostr_id_log_truncation` all pass

## Still open

`ConversationTile` renders `profileDeletedAccountName` for a NIP-62 vanished peer; the sheet has no equivalent check, so it still shows the generated name there. Narrower than the reported bug and it changes user-visible copy, so it is left out of this fix rather than bundled in.

Refs #7380
