### PR TITLE
fix(dm): reset the unread badge when the DM repository swaps identities

### DIFF
--- a/mobile/lib/blocs/dm/unread_count/dm_unread_count_cubit.dart
+++ b/mobile/lib/blocs/dm/unread_count/dm_unread_count_cubit.dart
@@ -105,6 +105,24 @@ class DmUnreadCountCubit extends Cubit<int> with CloseGuardedEmit<int> {
   /// provider-listener fires are cheap. The generation guard discards any
   /// late emission from the cancelled subscription so a swap can never
   /// regress the badge to a stale count.
+  ///
+  /// A swap to a repository that has no identity yet resets the count to zero
+  /// (#7330). This cubit lives above `MaterialApp` and survives an in-app
+  /// sign-out/sign-in-as-a-different-account, so without the reset the badge
+  /// keeps rendering the *previous* account's number: `dmRepositoryProvider`
+  /// hands over an uncredentialed [DmRepository] while `nostrSession` is only
+  /// `identityKnown`, its `userPubkey` is empty, and [_countUnread]'s
+  /// deliberate empty-pubkey hold re-emits the value already on screen — which
+  /// `Cubit.emit` then suppresses as unchanged.
+  ///
+  /// This is the only place the reset belongs, because a swap is the only way
+  /// an empty pubkey reaches [_countUnread]: `_userPubkeyController` is fed
+  /// exclusively by `DmRepository.setCredentials` with a non-empty value, so
+  /// the stream never emits `''`. The empty value can only arrive as the
+  /// `startWith(dmRepository.userPubkey)` seed at subscribe time. Leaving the
+  /// hold in [_countUnread] keeps #5374 working: at cold start the seed is
+  /// also empty, and holding a `0` there is what stops the classifier
+  /// misreading every followed 1:1 as a group before the identity lands.
   void setRepositories({
     required DmRepository dmRepository,
     required FollowRepository followRepository,
@@ -126,6 +144,14 @@ class DmUnreadCountCubit extends Cubit<int> with CloseGuardedEmit<int> {
     if (oldSubscription != null) {
       unawaited(oldSubscription.cancel());
     }
+
+    // No count is defensible until the incoming repository can say whose
+    // messages these are; the old number belongs to whoever was signed in
+    // before. Only ever changes anything after a real account flip — at cold
+    // start and on the auth-ready wave the state is already 0. Reset AFTER the
+    // generation bump, so the outgoing subscription can no longer put its
+    // count back however this method is edited later.
+    if (dmRepository.userPubkey.isEmpty) emitIfOpen(0);
 
     // Recompute whenever the accepted conversations, the potential requests,
     // the following list, or the blocklist change. The blocklist tick value is

--- a/mobile/lib/blocs/dm/unread_count/dm_unread_count_cubit.dart
+++ b/mobile/lib/blocs/dm/unread_count/dm_unread_count_cubit.dart
@@ -146,11 +146,12 @@ class DmUnreadCountCubit extends Cubit<int> with CloseGuardedEmit<int> {
     }
 
     // No count is defensible until the incoming repository can say whose
-    // messages these are; the old number belongs to whoever was signed in
-    // before. Only ever changes anything after a real account flip — at cold
-    // start and on the auth-ready wave the state is already 0. Reset AFTER the
-    // generation bump, so the outgoing subscription can no longer put its
-    // count back however this method is edited later.
+    // messages these are. This clears the old account's count during an
+    // account change; it can also show a conservative 0 while the same
+    // identity's Nostr client retries initialization, until the ready wave
+    // recomputes the count. Reset AFTER the generation bump, so the outgoing
+    // subscription can no longer put its count back however this method is
+    // edited later.
     if (dmRepository.userPubkey.isEmpty) emitIfOpen(0);
 
     // Recompute whenever the accepted conversations, the potential requests,

--- a/mobile/test/widgets/app_shell_badge_scope_account_switch_test.dart
+++ b/mobile/test/widgets/app_shell_badge_scope_account_switch_test.dart
@@ -132,6 +132,7 @@ void main() {
             subscriptionId: any(named: 'subscriptionId'),
           ),
         ).thenAnswer((_) => giftWraps.stream);
+        when(() => nostrClient.queryEvents(any())).thenAnswer((_) async => []);
         when(() => nostrClient.unsubscribe(any())).thenAnswer((_) async {});
 
         when(() => authService.isAuthenticated).thenReturn(true);
@@ -267,10 +268,6 @@ void main() {
         );
       }
 
-      /// Tears the container down inside the test body. `DmRepository` arms a
-      /// reconnect timer while it is listening, and the widget-tree invariant
-      /// that fails on a pending timer runs before `tearDown` does — so the
-      /// dispose that cancels it has to happen here.
       /// Tears the session down inside the test body. `DmRepository` arms a
       /// reconnect timer while it is listening and cancelling a Drift query
       /// stream posts a zero-duration `markAsClosed` timer — and the widget

--- a/mobile/test/widgets/app_shell_badge_scope_account_switch_test.dart
+++ b/mobile/test/widgets/app_shell_badge_scope_account_switch_test.dart
@@ -1,0 +1,383 @@
+// ABOUTME: Reproduction + regression guard for #7330 — the DM unread badge
+// ABOUTME: must not keep rendering the previous account's count after an
+// ABOUTME: in-app sign-out/sign-in-as-a-different-account. Drives the REAL
+// ABOUTME: AppShellBadgeScope over the REAL dmRepositoryProvider, a real
+// ABOUTME: DmRepository and a real in-memory Drift database, stepping
+// ABOUTME: nostrSessionProvider through the production phase sequence
+// ABOUTME: (nostrReady -> tearingDown -> identityKnown -> nostrReady).
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:content_blocklist_repository/content_blocklist_repository.dart';
+import 'package:content_policy/content_policy.dart';
+import 'package:db_client/db_client.dart';
+import 'package:drift/native.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:follow_repository/follow_repository.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:nostr_sdk/filter.dart' as nostr_filter;
+import 'package:nostr_sdk/signer/local_nostr_signer.dart';
+import 'package:notification_repository/notification_repository.dart';
+import 'package:openvine/blocs/dm/conversation_list/protected_minor_inbox_gate.dart';
+import 'package:openvine/blocs/dm/unread_count/dm_unread_count_cubit.dart';
+import 'package:openvine/notifications/providers/notification_repository_provider.dart';
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/database_provider.dart';
+import 'package:openvine/providers/nostr_client_provider.dart';
+import 'package:openvine/providers/official_accounts_providers.dart';
+import 'package:openvine/providers/protected_minor_providers.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
+import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/widgets/app_shell_badge_scope.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _MockAuthService extends Mock implements AuthService {}
+
+class _MockFollowRepository extends Mock implements FollowRepository {}
+
+class _MockContentBlocklistRepository extends Mock
+    implements ContentBlocklistRepository {}
+
+class _MockNotificationRepository extends Mock
+    implements NotificationRepository {}
+
+class _FakeFilter extends Fake implements nostr_filter.Filter {}
+
+/// Pass-through inbox gate — these tests are about identity scoping, not the
+/// protected-minor predicate, so nothing is ever hidden.
+class _PassThroughInboxGate implements ProtectedMinorInboxGate {
+  @override
+  Stream<void> get changes => const Stream<void>.empty();
+
+  @override
+  void notifyRestrictionChanged() {}
+
+  @override
+  List<DmConversation> filter(
+    List<DmConversation> conversations, {
+    required String userPubkey,
+  }) => conversations;
+}
+
+/// Seeded [NostrSession] whose phase the test drives directly, standing in for
+/// `NostrService._handleAuthStateChange`.
+class _TestNostrSession extends NostrSession {
+  _TestNostrSession(this._initial);
+
+  final NostrSessionReadiness _initial;
+
+  @override
+  NostrSessionReadiness build() => stateOrNull ?? _initial;
+}
+
+// Full 64-character hex Nostr IDs — never truncate.
+const _accountA =
+    'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2';
+const _accountB =
+    'b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3';
+const _peerOne =
+    'c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4';
+const _peerTwo =
+    'd4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5';
+const _privateKey =
+    '0000000000000000000000000000000000000000000000000000000000000001';
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(<nostr_filter.Filter>[_FakeFilter()]);
+  });
+
+  group(AppShellBadgeScope, () {
+    group('in-app account switch (#7330)', () {
+      late AppDatabase database;
+      late SharedPreferences prefs;
+      late _MockNostrClient nostrClient;
+      late _MockAuthService authService;
+      late StreamController<Event> giftWraps;
+      late ProviderContainer container;
+      late bool containerDisposed;
+
+      setUp(() async {
+        containerDisposed = false;
+        database = AppDatabase.test(NativeDatabase.memory());
+        SharedPreferences.setMockInitialValues({});
+        prefs = await SharedPreferences.getInstance();
+
+        nostrClient = _MockNostrClient();
+        authService = _MockAuthService();
+        // A stream that stays open. `Stream.empty()` completes immediately,
+        // which DmRepository reads as a dropped relay subscription and answers
+        // with its 2s reconnect timer, on a loop.
+        giftWraps = StreamController<Event>.broadcast();
+
+        when(() => nostrClient.connectedRelayCount).thenReturn(1);
+        when(() => nostrClient.configuredRelayCount).thenReturn(1);
+        when(() => nostrClient.hasKeys).thenReturn(true);
+        when(() => nostrClient.publicKey).thenReturn(_accountA);
+        when(
+          () => nostrClient.signer,
+        ).thenReturn(LocalNostrSigner(_privateKey));
+        when(
+          () => nostrClient.subscribe(
+            any(),
+            subscriptionId: any(named: 'subscriptionId'),
+          ),
+        ).thenAnswer((_) => giftWraps.stream);
+        when(() => nostrClient.unsubscribe(any())).thenAnswer((_) async {});
+
+        when(() => authService.isAuthenticated).thenReturn(true);
+        when(() => authService.currentPublicKeyHex).thenReturn(_accountA);
+        when(() => authService.currentIdentity).thenReturn(null);
+        when(() => authService.userRelays).thenReturn(const []);
+        when(
+          () => authService.authStateStream,
+        ).thenAnswer((_) => const Stream<AuthState>.empty());
+      });
+
+      tearDown(() async {
+        await giftWraps.close();
+        await database.close();
+      });
+
+      _MockFollowRepository buildFollow() {
+        final follow = _MockFollowRepository();
+        when(
+          () => follow.followingStream,
+        ).thenAnswer((_) => const Stream<List<String>>.empty());
+        when(() => follow.isFollowing(any())).thenReturn(false);
+        return follow;
+      }
+
+      _MockContentBlocklistRepository buildBlocklist() {
+        final blocklist = _MockContentBlocklistRepository();
+        when(
+          () => blocklist.stateStream,
+        ).thenAnswer((_) => const Stream<ContentPolicyState>.empty());
+        when(
+          () => blocklist.filterBlockedConversations(
+            any(),
+            userPubkey: any(named: 'userPubkey'),
+          ),
+        ).thenAnswer(
+          (invocation) =>
+              invocation.positionalArguments.first as List<DmConversation>,
+        );
+        return blocklist;
+      }
+
+      _MockNotificationRepository buildNotification() {
+        final repo = _MockNotificationRepository();
+        when(
+          repo.watchUnreadCount,
+        ).thenAnswer((_) => const Stream<int>.empty());
+        return repo;
+      }
+
+      /// Persists an unread, already-accepted conversation owned by [owner] —
+      /// the row shape the DM ingest path writes.
+      ///
+      /// Seeding two owners at once is a test convenience, not a picture of
+      /// production: every identity change wipes the departing account's DM
+      /// rows (`auth_service.dart` `clearUserSpecificData(reason:
+      /// 'identity_change')` -> `ConversationsDao.clearForAccountSwitch`), so
+      /// at most one account's rows exist on a device. Keeping both here
+      /// proves the badge counts by owner rather than by row count.
+      ///
+      /// Each conversation needs a distinct [peer]: post-auth maintenance runs
+      /// `_mergeDuplicateConversations`, which collapses two rows that share a
+      /// peer into one canonical 1:1.
+      Future<void> seedUnreadConversation({
+        required String id,
+        required String owner,
+        required String peer,
+      }) {
+        return database.conversationsDao.upsertConversation(
+          id: id,
+          participantPubkeys: jsonEncode([owner, peer]),
+          isGroup: false,
+          createdAt: 1700000000,
+          lastMessageTimestamp: 1700000000,
+          lastMessageContent: 'hello',
+          lastMessageSenderPubkey: peer,
+          isRead: false,
+          currentUserHasSent: true,
+          ownerPubkey: owner,
+        );
+      }
+
+      void disposeContainerOnce() {
+        if (containerDisposed) return;
+        containerDisposed = true;
+        container.dispose();
+      }
+
+      Future<void> pumpScope(WidgetTester tester) async {
+        container = ProviderContainer(
+          overrides: [
+            nostrServiceProvider.overrideWithValue(nostrClient),
+            authServiceProvider.overrideWithValue(authService),
+            currentAuthStateProvider.overrideWithValue(AuthState.authenticated),
+            nostrSessionProvider.overrideWith(
+              () => _TestNostrSession(
+                NostrSessionReadiness.nostrReady(
+                  pubkey: _accountA,
+                  client: nostrClient,
+                ),
+              ),
+            ),
+            databaseProvider.overrideWithValue(database),
+            sharedPreferencesProvider.overrideWithValue(prefs),
+            followRepositoryProvider.overrideWithValue(buildFollow()),
+            contentBlocklistRepositoryProvider.overrideWithValue(
+              buildBlocklist(),
+            ),
+            protectedMinorInboxGateProvider.overrideWithValue(
+              _PassThroughInboxGate(),
+            ),
+            notificationRepositoryProvider.overrideWithValue(
+              buildNotification(),
+            ),
+            isDmRestrictedProvider.overrideWithValue(false),
+          ],
+        );
+        // Safety net: a failing expectation skips [disposeSession], and a
+        // leaked DmRepository reconnect timer then stalls the whole run for
+        // minutes instead of failing fast.
+        addTearDown(disposeContainerOnce);
+
+        await tester.pumpWidget(
+          UncontrolledProviderScope(
+            container: container,
+            child: AppShellBadgeScope(
+              child: BlocBuilder<DmUnreadCountCubit, int>(
+                builder: (context, count) =>
+                    Text('badge=$count', textDirection: TextDirection.ltr),
+              ),
+            ),
+          ),
+        );
+      }
+
+      /// Tears the container down inside the test body. `DmRepository` arms a
+      /// reconnect timer while it is listening, and the widget-tree invariant
+      /// that fails on a pending timer runs before `tearDown` does — so the
+      /// dispose that cancels it has to happen here.
+      /// Tears the session down inside the test body. `DmRepository` arms a
+      /// reconnect timer while it is listening and cancelling a Drift query
+      /// stream posts a zero-duration `markAsClosed` timer — and the widget
+      /// invariant that fails on a pending timer runs before `tearDown` does,
+      /// so both have to be flushed here. Disposing the container is what
+      /// stops the repository: `dmRepositoryProvider` registers
+      /// `ref.onDispose(repository.stopListening)`.
+      Future<void> disposeSession(WidgetTester tester) async {
+        if (containerDisposed) return;
+        await tester.pumpWidget(const SizedBox.shrink());
+        disposeContainerOnce();
+        await tester.pump(const Duration(milliseconds: 1));
+      }
+
+      /// Steps the session exactly as `NostrService._handleAuthStateChange`
+      /// does when the signed-in pubkey changes: tear the old client down,
+      /// publish the new identity, and only reach `nostrReady` once the new
+      /// client has finished initializing.
+      void driveSessionTo(NostrSessionReadiness readiness) {
+        container.read(nostrSessionProvider.notifier).update(readiness);
+      }
+
+      Future<void> switchToAccountB(WidgetTester tester) async {
+        when(() => nostrClient.publicKey).thenReturn(_accountB);
+        when(() => authService.currentPublicKeyHex).thenReturn(_accountB);
+        driveSessionTo(
+          const NostrSessionReadiness.tearingDown(pubkey: _accountA),
+        );
+        await tester.pump();
+        driveSessionTo(
+          const NostrSessionReadiness.identityKnown(pubkey: _accountB),
+        );
+        await tester.pump(const Duration(milliseconds: 250));
+      }
+
+      testWidgets(
+        'drops the previous account unread count while the incoming account '
+        'is identity-known but not yet nostr-ready',
+        (tester) async {
+          await seedUnreadConversation(
+            id: 'a-convo',
+            owner: _accountA,
+            peer: _peerOne,
+          );
+          await pumpScope(tester);
+          await tester.pump(const Duration(milliseconds: 250));
+
+          // Account A is signed in with one unread accepted conversation.
+          expect(find.text('badge=1'), findsOneWidget);
+
+          // The user signs out and signs straight back in as account B. This
+          // path does not rebuild the Riverpod container, so the badge cubit
+          // above MaterialApp survives holding account A's count.
+          await switchToAccountB(tester);
+
+          // Account B owns no conversations. The badge must not advertise
+          // account A's unread messages to them.
+          expect(find.text('badge=0'), findsOneWidget);
+          expect(find.text('badge=1'), findsNothing);
+
+          await disposeSession(tester);
+        },
+      );
+
+      testWidgets(
+        'counts the incoming account own unread conversations once the '
+        'session reaches nostrReady',
+        (tester) async {
+          await seedUnreadConversation(
+            id: 'a-convo',
+            owner: _accountA,
+            peer: _peerOne,
+          );
+          await seedUnreadConversation(
+            id: 'b-convo-1',
+            owner: _accountB,
+            peer: _peerOne,
+          );
+          await seedUnreadConversation(
+            id: 'b-convo-2',
+            owner: _accountB,
+            peer: _peerTwo,
+          );
+          await pumpScope(tester);
+          await tester.pump(const Duration(milliseconds: 250));
+
+          expect(find.text('badge=1'), findsOneWidget);
+
+          await switchToAccountB(tester);
+
+          // Not-yet-credentialed window: account A's single unread is gone and
+          // account B's two are not counted yet either.
+          expect(find.text('badge=0'), findsOneWidget);
+
+          driveSessionTo(
+            NostrSessionReadiness.nostrReady(
+              pubkey: _accountB,
+              client: nostrClient,
+            ),
+          );
+          await tester.pump(const Duration(milliseconds: 250));
+
+          expect(find.text('badge=2'), findsOneWidget);
+
+          await disposeSession(tester);
+        },
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

The DM unread badge kept rendering the **previous account's** count after an in-app sign-out/sign-in-as-a-different-account. Fixes #7330.

`DmUnreadCountCubit` is provided above `MaterialApp` in `AppShellBadgeScope`, so it survives the flip — only the cold launch and `swapAccount` rebuild the Riverpod container. On every other sign-out path `setRepositories` swaps just the stream subscription and the emitted count carries over.

That breaks the moment the incoming repository has no identity yet. `dmRepositoryProvider` hands over an uncredentialed `DmRepository` for the whole `identityKnown` phase, its `userPubkey` is `''`, and `_countUnread` answers an empty pubkey by returning `state` — the value already on screen. `Cubit.emit` then suppresses it as unchanged, so the badge freezes on the departing account's number.

## The fix

One line in `setRepositories`: reset to `0` when the incoming repository has no identity yet.

Reset at the swap rather than removing the hold in `_countUnread`, because a swap is the **only** way an empty pubkey ever reaches it — `_userPubkeyController` is fed exclusively by `setCredentials` with a non-empty value and never emits `''`, so the empty value can only arrive as the `startWith(dmRepository.userPubkey)` seed at subscribe time. Keeping the hold keeps #5374 working, where the same empty seed at cold start stops the classifier misreading every followed 1:1 as a group.

**Reset behavior.** At cold start and on the auth-ready wave the state is already `0`, so `Cubit.emit` suppresses an unchanged value. During a real account flip, `0` replaces a number that belongs to the departing account. The same conservative `0` can also appear while the same identity's Nostr client retries initialization; the next successful ready wave recomputes the count.

## Reachability (narrower and wider than the issue said)

The issue named `settings_screen.dart` `_offerReauthentication` as *the* reachable path. That one is the **narrowest** — a failure fallback behind a feature flag plus a `SessionExpiredException`. The widest is `SettingsAccountCubit.addNewAccount()`: Settings → account header → picker sheet → **"Add account"**, which signs out to `/welcome`, where the user may pick **any** known account. Three more sign-out sites (`minor_account_review_screen`, `nostr_settings_screen`, `delete_account_dialog`) are behind no flag at all.

## Testing

New `mobile/test/widgets/app_shell_badge_scope_account_switch_test.dart` drives the **real** `AppShellBadgeScope` over the **real** `dmRepositoryProvider`, a real `DmRepository`, and a real in-memory Drift database, stepping `nostrSessionProvider` through the production sequence `nostrReady → tearingDown → identityKnown → nostrReady`.

Verified in both directions:

- **Without the fix**, both tests fail: after the switch the badge renders `badge=1` — account A's count, shown to account B.
- **With the fix**, both pass: `0` during the not-ready window, then account B's own `2` once the session reaches `nostrReady`.

`flutter test test/blocs/dm/ test/widgets/app_shell_badge_scope_test.dart test/widgets/app_shell_badge_scope_account_switch_test.dart test/providers/dm_repository_provider_test.dart` → **368 passing**, including the #5374 test that pins the empty-pubkey hold. `flutter analyze lib test integration_test` → clean.

## Scope notes

- **No spec involvement.** Checked NIP-17, NIP-59, NIP-44 and the full NIP index against a fresh `nostr-protocol/nips` clone: there is no normative text on read state, unread counts, or per-identity scoping of client UI state, and no Nostr standard for DM read receipts at all. The count never leaves the device.
- **Display-only, confirmed.** An uncredentialed `DmRepository` maps to a `null` owner, which `_ownedOrLegacy` degrades to `WHERE true` — an unscoped read. That is not exploitable here: every identity change hard-deletes the departing account's DM rows (`clearUserSpecificData(reason: 'identity_change')` → `ConversationsDao.clearForAccountSwitch`) before the incoming container goes live, so at most one account's rows exist on a device. The staleness is own-account, in cubit state only. The `WHERE true` degradation is left as-is — it is a latent sharp edge held safe by invariants in other files, and narrowing it is a separate change.
