### PR TITLE
ci: auto-close issues from non-Divine members

### DIFF
--- a/.github/workflows/members-only-issues.yml
+++ b/.github/workflows/members-only-issues.yml
@@ -1,0 +1,48 @@
+name: Restrict issues to Divine members
+
+# Closes and locks any issue opened by someone who is not part of Divine.
+#
+# How it decides: GitHub stamps every issue event with the author's
+# `author_association`, computed server-side from the org context. MEMBER means
+# they are a member of the divinevideo org, and this is correct even when that
+# person's org membership is private, so we do NOT need an org-read token or a
+# stored PAT. COLLABORATOR means they were explicitly granted access to this repo.
+# Everyone else (CONTRIBUTOR, FIRST_TIME_CONTRIBUTOR, NONE) is treated as external.
+#
+# Automations are exempt by account type: legitimate issue-filing bots (the
+# Zendesk -> GitHub bridge, Dependabot, github-actions, and any future one) post
+# as GitHub Apps, which are stamped author_association NONE and would otherwise be
+# closed. We skip anything whose author is a Bot. This is safe because an external
+# human cannot make their issue appear as a Bot: only Apps/Actions installed on
+# the repo author as bots, and installing those requires access outsiders lack.
+#
+# Limitation (by design, GitHub has no way around it): the issue is created first
+# and closed seconds later. There is no native setting to block creation short of
+# disabling issues entirely.
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write  # overrides the repo's read-only default token for this job
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event.issue.user.type != 'Bot' &&
+      github.event.issue.author_association != 'MEMBER' &&
+      github.event.issue.author_association != 'OWNER' &&
+      github.event.issue.author_association != 'COLLABORATOR'
+    steps:
+      - name: Close and lock issue from non-member
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+          AUTHOR: ${{ github.event.issue.user.login }}
+        run: |
+          gh issue comment "$ISSUE" --repo "$REPO" --body "Hi @$AUTHOR, thanks for reaching out. This repository only accepts issues from the Divine team, so this one is being closed automatically. This is not a judgment on what you filed, it is just how we route requests from outside the team. If you need support, please reach us through our official support channels."
+          gh issue close "$ISSUE" --repo "$REPO" --reason "not planned"
+          gh issue lock "$ISSUE" --repo "$REPO"


### PR DESCRIPTION
## Summary
Adds a GitHub Actions workflow that closes and locks any issue opened by someone who is not part of the Divine org. Divine members, collaborators, and automation bots (Zendesk bridge, Dependabot, github-actions) are exempt.

## How it works
Uses GitHub's server-computed `author_association` to detect non-members (correct even for private org members, so no PAT needed), and skips any author of type `Bot` so our own issue-filing automations are never touched.

## Why
Restrict inbound issues to the Divine team. This is the first live rollout of a mechanism intended to go org-wide.

## Known limitation
GitHub cannot block issue *creation* short of disabling issues entirely, so the issue is created and then auto-closed within moments.

## Validation
- Verified against live divine-mobile data that the three issue-filing bots are all type `Bot` (so exempt) and that real members show `author_association: MEMBER`.
- Post-merge: member-filed test issue should stay open; next Zendesk-sourced issue should stay open.