### PR TITLE
fix(dm): name a vanished peer for the state in the sheet and requests

### DIFF
--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -389,6 +389,7 @@
     "profileMyLibraryLabel": "የእኔ ቤተ-መጽሐፍት",
     "profileMessageLabel": "መልእክት",
     "profileDeletedAccountName": "የተሰረዘ መለያ",
+    "inboxVanishedAccountReference": "ይህን መለያ",
     "inboxConversationDeletedAccountSubtitle": "ይህ መለያ ተሰርዟል",
     "profileUserFallback": "ተጠቃሚ",
     "@profileUserFallback": {

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -3090,6 +3090,7 @@
     "profileMyLibraryLabel": "مكتبتي",
     "profileMessageLabel": "رسالة",
     "profileDeletedAccountName": "حساب محذوف",
+    "inboxVanishedAccountReference": "هذا الحساب",
     "inboxConversationDeletedAccountSubtitle": "تم حذف هذا الحساب",
     "profileUserFallback": "مستخدم",
     "@profileUserFallback": {

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -364,6 +364,7 @@
     "profileMyLibraryLabel": "Моята библиотека",
     "profileMessageLabel": "Съобщение",
     "profileDeletedAccountName": "Изтрит акаунт",
+    "inboxVanishedAccountReference": "този акаунт",
     "inboxConversationDeletedAccountSubtitle": "Този акаунт е изтрит",
     "profileUserFallback": "Потребител",
     "@profileUserFallback": {

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -3097,6 +3097,7 @@
     "profileMyLibraryLabel": "Meine Bibliothek",
     "profileMessageLabel": "Nachricht",
     "profileDeletedAccountName": "Gelöschtes Konto",
+    "inboxVanishedAccountReference": "dieses Konto",
     "inboxConversationDeletedAccountSubtitle": "Dieses Konto wurde gelöscht",
     "profileUserFallback": "Nutzer",
     "@profileUserFallback": {

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -544,6 +544,10 @@
   "profileMyLibraryLabel": "My Library",
   "profileMessageLabel": "Message",
   "profileDeletedAccountName": "Deleted account",
+  "inboxVanishedAccountReference": "this account",
+  "@inboxVanishedAccountReference": {
+    "description": "Identity-neutral account reference inserted into Report, Block, Unblock, and confirmation copy when a DM peer has vanished. Safety actions remain available even though the peer's name is no longer shown."
+  },
   "@profileDeletedAccountName": {
     "description": "Stands in for the display name of an account that requested deletion. A noun phrase used where a person's name would normally appear — the inbox row, the conversation header, and the following bar."
   },

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -3105,6 +3105,7 @@
     "profileMyLibraryLabel": "Mi biblioteca",
     "profileMessageLabel": "Mensaje",
     "profileDeletedAccountName": "Cuenta eliminada",
+    "inboxVanishedAccountReference": "esta cuenta",
     "inboxConversationDeletedAccountSubtitle": "Esta cuenta fue eliminada",
     "profileUserFallback": "usuario",
     "@profileUserFallback": {

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -2478,6 +2478,7 @@
     "profileMyLibraryLabel": "Aking Library",
     "profileMessageLabel": "Mensahe",
     "profileDeletedAccountName": "Tinanggal na account",
+    "inboxVanishedAccountReference": "ang account na ito",
     "inboxConversationDeletedAccountSubtitle": "Tinanggal na ang account na ito",
     "profileUserFallback": "user",
     "videoSettingsMenuOpen": "Buksan ang playback settings",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -3097,6 +3097,7 @@
     "profileMyLibraryLabel": "Ma bibliothèque",
     "profileMessageLabel": "Message",
     "profileDeletedAccountName": "Compte supprimé",
+    "inboxVanishedAccountReference": "ce compte",
     "inboxConversationDeletedAccountSubtitle": "Ce compte a été supprimé",
     "profileUserFallback": "utilisateur",
     "@profileUserFallback": {

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -3097,6 +3097,7 @@
     "profileMyLibraryLabel": "Pustakaku",
     "profileMessageLabel": "Pesan",
     "profileDeletedAccountName": "Akun dihapus",
+    "inboxVanishedAccountReference": "akun ini",
     "inboxConversationDeletedAccountSubtitle": "Akun ini telah dihapus",
     "profileUserFallback": "pengguna",
     "@profileUserFallback": {

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -3097,6 +3097,7 @@
     "profileMyLibraryLabel": "La mia libreria",
     "profileMessageLabel": "Messaggio",
     "profileDeletedAccountName": "Account eliminato",
+    "inboxVanishedAccountReference": "questo account",
     "inboxConversationDeletedAccountSubtitle": "Questo account è stato eliminato",
     "profileUserFallback": "utente",
     "@profileUserFallback": {

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -3090,6 +3090,7 @@
     "profileMyLibraryLabel": "マイライブラリ",
     "profileMessageLabel": "メッセージ",
     "profileDeletedAccountName": "削除されたアカウント",
+    "inboxVanishedAccountReference": "このアカウント",
     "inboxConversationDeletedAccountSubtitle": "このアカウントは削除されました",
     "profileUserFallback": "ユーザー",
     "@profileUserFallback": {

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -2558,6 +2558,7 @@
     "profileMyLibraryLabel": "내 라이브러리",
     "profileMessageLabel": "메시지",
     "profileDeletedAccountName": "삭제된 계정",
+    "inboxVanishedAccountReference": "이 계정",
     "inboxConversationDeletedAccountSubtitle": "이 계정은 삭제되었습니다",
     "profileUserFallback": "사용자",
     "@profileUserFallback": {

--- a/mobile/lib/l10n/app_ms.arb
+++ b/mobile/lib/l10n/app_ms.arb
@@ -413,6 +413,7 @@
   "profileMyLibraryLabel": "Pustaka Saya",
   "profileMessageLabel": "Mesej",
   "profileDeletedAccountName": "Akaun dipadam",
+  "inboxVanishedAccountReference": "akaun ini",
   "@profileDeletedAccountName": {
     "description": "Stands in for the display name of an account that requested deletion. A noun phrase used where a person's name would normally appear — the inbox row, the conversation header, and the following bar."
   },

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -3097,6 +3097,7 @@
     "profileMyLibraryLabel": "Mijn bibliotheek",
     "profileMessageLabel": "Bericht",
     "profileDeletedAccountName": "Verwijderd account",
+    "inboxVanishedAccountReference": "dit account",
     "inboxConversationDeletedAccountSubtitle": "Dit account is verwijderd",
     "profileUserFallback": "gebruiker",
     "@profileUserFallback": {

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -3097,6 +3097,7 @@
     "profileMyLibraryLabel": "Moja biblioteka",
     "profileMessageLabel": "Wiadomość",
     "profileDeletedAccountName": "Usunięte konto",
+    "inboxVanishedAccountReference": "to konto",
     "inboxConversationDeletedAccountSubtitle": "To konto zostało usunięte",
     "profileUserFallback": "użytkownik",
     "@profileUserFallback": {

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -3097,6 +3097,7 @@
     "profileMyLibraryLabel": "Minha biblioteca",
     "profileMessageLabel": "Mensagem",
     "profileDeletedAccountName": "Conta excluída",
+    "inboxVanishedAccountReference": "esta conta",
     "inboxConversationDeletedAccountSubtitle": "Esta conta foi excluída",
     "profileUserFallback": "usuário",
     "@profileUserFallback": {

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -3097,6 +3097,7 @@
     "profileMyLibraryLabel": "Biblioteca mea",
     "profileMessageLabel": "Mesaj",
     "profileDeletedAccountName": "Cont șters",
+    "inboxVanishedAccountReference": "acest cont",
     "inboxConversationDeletedAccountSubtitle": "Acest cont a fost șters",
     "profileUserFallback": "utilizator",
     "@profileUserFallback": {

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -3097,6 +3097,7 @@
     "profileMyLibraryLabel": "Mitt bibliotek",
     "profileMessageLabel": "Meddelande",
     "profileDeletedAccountName": "Raderat konto",
+    "inboxVanishedAccountReference": "det här kontot",
     "inboxConversationDeletedAccountSubtitle": "Det här kontot har raderats",
     "profileUserFallback": "användare",
     "@profileUserFallback": {

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -3097,6 +3097,7 @@
     "profileMyLibraryLabel": "Kütüphanem",
     "profileMessageLabel": "Mesaj",
     "profileDeletedAccountName": "Silinmiş hesap",
+    "inboxVanishedAccountReference": "bu hesap",
     "inboxConversationDeletedAccountSubtitle": "Bu hesap silindi",
     "profileUserFallback": "kullanıcı",
     "@profileUserFallback": {

--- a/mobile/lib/l10n/app_ur.arb
+++ b/mobile/lib/l10n/app_ur.arb
@@ -413,6 +413,7 @@
   "profileMyLibraryLabel": "میری لائبریری",
   "profileMessageLabel": "پیغام",
   "profileDeletedAccountName": "حذف شدہ اکاؤنٹ",
+  "inboxVanishedAccountReference": "یہ اکاؤنٹ",
   "@profileDeletedAccountName": {
     "description": "Stands in for the display name of an account that requested deletion. A noun phrase used where a person's name would normally appear — the inbox row, the conversation header, and the following bar."
   },

--- a/mobile/lib/l10n/app_vi.arb
+++ b/mobile/lib/l10n/app_vi.arb
@@ -413,6 +413,7 @@
   "profileMyLibraryLabel": "Thư viện của tôi",
   "profileMessageLabel": "Tin nhắn",
   "profileDeletedAccountName": "Tài khoản đã xóa",
+  "inboxVanishedAccountReference": "tài khoản này",
   "@profileDeletedAccountName": {
     "description": "Stands in for the display name of an account that requested deletion. A noun phrase used where a person's name would normally appear — the inbox row, the conversation header, and the following bar."
   },

--- a/mobile/lib/l10n/app_zh.arb
+++ b/mobile/lib/l10n/app_zh.arb
@@ -413,6 +413,7 @@
   "profileMyLibraryLabel": "我的作品库",
   "profileMessageLabel": "私信",
   "profileDeletedAccountName": "已注销账号",
+  "inboxVanishedAccountReference": "此账号",
   "@profileDeletedAccountName": {
     "description": "Stands in for the display name of an account that requested deletion. A noun phrase used where a person's name would normally appear — the inbox row, the conversation header, and the following bar."
   },

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -1410,6 +1410,12 @@ abstract class AppLocalizations {
   /// **'Deleted account'**
   String get profileDeletedAccountName;
 
+  /// Identity-neutral account reference inserted into Report, Block, Unblock, and confirmation copy when a DM peer has vanished. Safety actions remain available even though the peer's name is no longer shown.
+  ///
+  /// In en, this message translates to:
+  /// **'this account'**
+  String get inboxVanishedAccountReference;
+
   /// Shown under the name in a direct-message conversation header when the other participant deleted their account. Replaces their handle.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -814,6 +814,9 @@ class AppLocalizationsAm extends AppLocalizations {
   String get profileDeletedAccountName => 'የተሰረዘ መለያ';
 
   @override
+  String get inboxVanishedAccountReference => 'ይህን መለያ';
+
+  @override
   String get inboxConversationDeletedAccountSubtitle => 'ይህ መለያ ተሰርዟል';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -814,6 +814,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get profileDeletedAccountName => 'حساب محذوف';
 
   @override
+  String get inboxVanishedAccountReference => 'هذا الحساب';
+
+  @override
   String get inboxConversationDeletedAccountSubtitle => 'تم حذف هذا الحساب';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -841,6 +841,9 @@ class AppLocalizationsBg extends AppLocalizations {
   String get profileDeletedAccountName => 'Изтрит акаунт';
 
   @override
+  String get inboxVanishedAccountReference => 'този акаунт';
+
+  @override
   String get inboxConversationDeletedAccountSubtitle => 'Този акаунт е изтрит';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -839,6 +839,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get profileDeletedAccountName => 'Gelöschtes Konto';
 
   @override
+  String get inboxVanishedAccountReference => 'dieses Konto';
+
+  @override
   String get inboxConversationDeletedAccountSubtitle =>
       'Dieses Konto wurde gelöscht';
 

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -842,6 +842,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get profileDeletedAccountName => 'Deleted account';
 
   @override
+  String get inboxVanishedAccountReference => 'this account';
+
+  @override
   String get inboxConversationDeletedAccountSubtitle =>
       'This account was deleted';
 

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -839,6 +839,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get profileDeletedAccountName => 'Cuenta eliminada';
 
   @override
+  String get inboxVanishedAccountReference => 'esta cuenta';
+
+  @override
   String get inboxConversationDeletedAccountSubtitle =>
       'Esta cuenta fue eliminada';
 

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -810,6 +810,9 @@ class AppLocalizationsFil extends AppLocalizations {
   String get profileDeletedAccountName => 'Tinanggal na account';
 
   @override
+  String get inboxVanishedAccountReference => 'ang account na ito';
+
+  @override
   String get inboxConversationDeletedAccountSubtitle =>
       'Tinanggal na ang account na ito';
 

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -849,6 +849,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get profileDeletedAccountName => 'Compte supprimé';
 
   @override
+  String get inboxVanishedAccountReference => 'ce compte';
+
+  @override
   String get inboxConversationDeletedAccountSubtitle =>
       'Ce compte a été supprimé';
 

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -773,6 +773,9 @@ class AppLocalizationsId extends AppLocalizations {
   String get profileDeletedAccountName => 'Akun dihapus';
 
   @override
+  String get inboxVanishedAccountReference => 'akun ini';
+
+  @override
   String get inboxConversationDeletedAccountSubtitle =>
       'Akun ini telah dihapus';
 

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -843,6 +843,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get profileDeletedAccountName => 'Account eliminato';
 
   @override
+  String get inboxVanishedAccountReference => 'questo account';
+
+  @override
   String get inboxConversationDeletedAccountSubtitle =>
       'Questo account è stato eliminato';
 

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -734,6 +734,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get profileDeletedAccountName => '削除されたアカウント';
 
   @override
+  String get inboxVanishedAccountReference => 'このアカウント';
+
+  @override
   String get inboxConversationDeletedAccountSubtitle => 'このアカウントは削除されました';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -736,6 +736,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get profileDeletedAccountName => '삭제된 계정';
 
   @override
+  String get inboxVanishedAccountReference => '이 계정';
+
+  @override
   String get inboxConversationDeletedAccountSubtitle => '이 계정은 삭제되었습니다';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -803,6 +803,9 @@ class AppLocalizationsMs extends AppLocalizations {
   String get profileDeletedAccountName => 'Akaun dipadam';
 
   @override
+  String get inboxVanishedAccountReference => 'akaun ini';
+
+  @override
   String get inboxConversationDeletedAccountSubtitle =>
       'Akaun ini telah dipadam';
 

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -834,6 +834,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get profileDeletedAccountName => 'Verwijderd account';
 
   @override
+  String get inboxVanishedAccountReference => 'dit account';
+
+  @override
   String get inboxConversationDeletedAccountSubtitle =>
       'Dit account is verwijderd';
 

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -855,6 +855,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get profileDeletedAccountName => 'Usunięte konto';
 
   @override
+  String get inboxVanishedAccountReference => 'to konto';
+
+  @override
   String get inboxConversationDeletedAccountSubtitle =>
       'To konto zostało usunięte';
 

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -840,6 +840,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get profileDeletedAccountName => 'Conta excluída';
 
   @override
+  String get inboxVanishedAccountReference => 'esta conta';
+
+  @override
   String get inboxConversationDeletedAccountSubtitle =>
       'Esta conta foi excluída';
 

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -869,6 +869,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get profileDeletedAccountName => 'Cont șters';
 
   @override
+  String get inboxVanishedAccountReference => 'acest cont';
+
+  @override
   String get inboxConversationDeletedAccountSubtitle =>
       'Acest cont a fost șters';
 

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -816,6 +816,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get profileDeletedAccountName => 'Raderat konto';
 
   @override
+  String get inboxVanishedAccountReference => 'det här kontot';
+
+  @override
   String get inboxConversationDeletedAccountSubtitle =>
       'Det här kontot har raderats';
 

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -771,6 +771,9 @@ class AppLocalizationsTr extends AppLocalizations {
   String get profileDeletedAccountName => 'Silinmiş hesap';
 
   @override
+  String get inboxVanishedAccountReference => 'bu hesap';
+
+  @override
   String get inboxConversationDeletedAccountSubtitle => 'Bu hesap silindi';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -834,6 +834,9 @@ class AppLocalizationsUr extends AppLocalizations {
   String get profileDeletedAccountName => 'حذف شدہ اکاؤنٹ';
 
   @override
+  String get inboxVanishedAccountReference => 'یہ اکاؤنٹ';
+
+  @override
   String get inboxConversationDeletedAccountSubtitle => 'یہ اکاؤنٹ حذف ہو گیا';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -803,6 +803,9 @@ class AppLocalizationsVi extends AppLocalizations {
   String get profileDeletedAccountName => 'Tài khoản đã xóa';
 
   @override
+  String get inboxVanishedAccountReference => 'tài khoản này';
+
+  @override
   String get inboxConversationDeletedAccountSubtitle =>
       'Tài khoản này đã bị xóa';
 

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -757,6 +757,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get profileDeletedAccountName => '已注销账号';
 
   @override
+  String get inboxVanishedAccountReference => '此账号';
+
+  @override
   String get inboxConversationDeletedAccountSubtitle => '该账号已注销';
 
   @override

--- a/mobile/lib/providers/user_profile_providers.dart
+++ b/mobile/lib/providers/user_profile_providers.dart
@@ -22,8 +22,9 @@ final _vanishedProfilePubkeysProvider = StreamProvider<Set<String>>((ref) {
       .map((pubkeys) => pubkeys.toSet());
 });
 
-/// One-shot durable vanish lookup for imperative paths such as gesture
-/// handlers, where no mounted widget keeps [profileVanishedProvider] warm.
+/// One-shot durable vanish lookup for imperative paths that must resolve the
+/// state before acting instead of treating [profileVanishedProvider]'s loading
+/// placeholder as a live account.
 // ignore: specify_nonobvious_property_types
 final profileVanishedSnapshotProvider = FutureProvider.autoDispose
     .family<bool, String>((ref, pubkey) {

--- a/mobile/lib/providers/user_profile_providers.dart
+++ b/mobile/lib/providers/user_profile_providers.dart
@@ -22,6 +22,14 @@ final _vanishedProfilePubkeysProvider = StreamProvider<Set<String>>((ref) {
       .map((pubkeys) => pubkeys.toSet());
 });
 
+/// One-shot durable vanish lookup for imperative paths such as gesture
+/// handlers, where no mounted widget keeps [profileVanishedProvider] warm.
+// ignore: specify_nonobvious_property_types
+final profileVanishedSnapshotProvider = FutureProvider.autoDispose
+    .family<bool, String>((ref, pubkey) {
+      return ref.watch(databaseProvider).vanishedProfilesDao.isVanished(pubkey);
+    });
+
 // ignore: specify_nonobvious_property_types
 final userProfileStatsReactiveProvider =
     StreamProvider.family<ProfileStats?, String>((ref, pubkey) {

--- a/mobile/lib/screens/inbox/conversation/conversation_view.dart
+++ b/mobile/lib/screens/inbox/conversation/conversation_view.dart
@@ -27,7 +27,7 @@ import 'package:openvine/screens/feed/dm_reply_context.dart';
 import 'package:openvine/screens/inbox/conversation/conversation_page.dart';
 import 'package:openvine/screens/inbox/conversation/dm_video_target.dart';
 import 'package:openvine/screens/inbox/conversation/widgets/widgets.dart';
-import 'package:openvine/screens/inbox/widgets/moderation_identity.dart';
+import 'package:openvine/screens/inbox/widgets/dm_peer_identity.dart';
 import 'package:openvine/screens/other_profile_screen.dart';
 import 'package:openvine/services/collaborator_invite_parser.dart';
 import 'package:openvine/services/collaborator_invite_service.dart';
@@ -166,11 +166,12 @@ class _ConversationViewState extends ConsumerState<ConversationView> {
     final isDeleted = ref
         .watch(profileVanishedProvider(otherPubkey))
         .maybeWhen(data: (vanished) => vanished, orElse: () => false);
-    final displayName = isDeleted
-        ? context.l10n.profileDeletedAccountName
-        : moderationDisplayName(context, otherPubkey) ??
-              profile?.bestDisplayName ??
-              UserProfile.defaultDisplayNameFor(otherPubkey);
+    final displayName = dmPeerDisplayName(
+      context,
+      pubkeyHex: otherPubkey,
+      isVanished: isDeleted,
+      profile: profile,
+    );
     final claimedNip05 = profile?.shortDisplayNip05;
     final verificationStatus = claimedNip05 != null && claimedNip05.isNotEmpty
         ? ref

--- a/mobile/lib/screens/inbox/inbox_view.dart
+++ b/mobile/lib/screens/inbox/inbox_view.dart
@@ -973,28 +973,12 @@ class _MessagesScrollViewState extends ConsumerState<_MessagesScrollView>
     // has none at all — so the sheet would otherwise open labelled with the
     // generated fallback the row's own name exists to avoid.
     //
-    // `profileVanishedProvider` is autoDispose and stream-backed, which makes
-    // both obvious reads wrong here, and both were measured on device:
-    //
-    // - `ref.read(provider)` returns `AsyncLoading` whenever nothing is
-    //   currently watching that pubkey, so `orElse: false` reports a vanished
-    //   peer as live — the row said "Deleted account" while the sheet it
-    //   opened said the generated handle.
-    // - `ref.read(provider.future)` never completes, because the read does not
-    //   keep the provider alive and it is disposed before `Stream.value`
-    //   delivers its event. The sheet simply never opened.
-    //
-    // Holding a subscription across the await fixes both.
-    final vanishSubscription = ref.listenManual(
-      profileVanishedProvider(otherPubkey),
-      (_, _) {},
+    // The reactive provider intentionally renders false while its shared
+    // Drift stream is loading. An imperative read cannot use that placeholder:
+    // the sheet needs the durable answer before choosing a name.
+    final isVanished = await ref.read(
+      profileVanishedSnapshotProvider(otherPubkey).future,
     );
-    final bool isVanished;
-    try {
-      isVanished = await ref.read(profileVanishedProvider(otherPubkey).future);
-    } finally {
-      vanishSubscription.close();
-    }
     if (!context.mounted) return;
 
     final String displayName;

--- a/mobile/lib/screens/inbox/inbox_view.dart
+++ b/mobile/lib/screens/inbox/inbox_view.dart
@@ -973,12 +973,29 @@ class _MessagesScrollViewState extends ConsumerState<_MessagesScrollView>
     // has none at all — so the sheet would otherwise open labelled with the
     // generated fallback the row's own name exists to avoid.
     //
-    // `read`, not `watch`: this runs on a gesture, not in build. The tile that
-    // owns the gesture is still mounted and already watching the provider, so
-    // the value is settled — and while it is not, both resolve the same way.
-    final isVanished = ref
-        .read(profileVanishedProvider(otherPubkey))
-        .maybeWhen(data: (vanished) => vanished, orElse: () => false);
+    // `profileVanishedProvider` is autoDispose and stream-backed, which makes
+    // both obvious reads wrong here, and both were measured on device:
+    //
+    // - `ref.read(provider)` returns `AsyncLoading` whenever nothing is
+    //   currently watching that pubkey, so `orElse: false` reports a vanished
+    //   peer as live — the row said "Deleted account" while the sheet it
+    //   opened said the generated handle.
+    // - `ref.read(provider.future)` never completes, because the read does not
+    //   keep the provider alive and it is disposed before `Stream.value`
+    //   delivers its event. The sheet simply never opened.
+    //
+    // Holding a subscription across the await fixes both.
+    final vanishSubscription = ref.listenManual(
+      profileVanishedProvider(otherPubkey),
+      (_, _) {},
+    );
+    final bool isVanished;
+    try {
+      isVanished = await ref.read(profileVanishedProvider(otherPubkey).future);
+    } finally {
+      vanishSubscription.close();
+    }
+    if (!context.mounted) return;
 
     final String displayName;
     final knownName = dmPeerNameWithoutProfile(

--- a/mobile/lib/screens/inbox/inbox_view.dart
+++ b/mobile/lib/screens/inbox/inbox_view.dart
@@ -30,13 +30,13 @@ import 'package:openvine/screens/inbox/message_requests/widgets/message_requests
 import 'package:openvine/screens/inbox/new_message_sheet.dart';
 import 'package:openvine/screens/inbox/widgets/conversation_actions_sheet.dart';
 import 'package:openvine/screens/inbox/widgets/conversation_tile.dart';
+import 'package:openvine/screens/inbox/widgets/dm_peer_identity.dart';
 import 'package:openvine/screens/inbox/widgets/following_bar.dart';
 import 'package:openvine/screens/inbox/widgets/inbox_empty_state.dart';
 import 'package:openvine/screens/inbox/widgets/inbox_error_state.dart';
 import 'package:openvine/screens/inbox/widgets/inbox_fab.dart';
 import 'package:openvine/screens/inbox/widgets/inbox_filter_chips.dart';
 import 'package:openvine/screens/inbox/widgets/inbox_segmented_toggle.dart';
-import 'package:openvine/screens/inbox/widgets/moderation_identity.dart';
 import 'package:openvine/screens/inbox/widgets/restore_paused_banner.dart';
 import 'package:unified_logger/unified_logger.dart';
 
@@ -966,15 +966,27 @@ class _MessagesScrollViewState extends ConsumerState<_MessagesScrollView>
       orElse: () => conversation.participantPubkeys.first,
     );
 
-    // Match [ConversationTile]'s non-vanished identity chain, so moderation
-    // and profile fallbacks stay consistent between the row and sheet (#7380).
-    // A known identity skips the lookup entirely: moderation's kind-0 resolves
-    // late and a retired moderation key has none at all, so the sheet would
-    // otherwise open labelled with the fallback the row's own name exists to
-    // avoid.
-    String displayName;
-    final knownName =
-        displayNameOverride ?? moderationDisplayName(context, otherPubkey);
+    // Match [ConversationTile]'s identity chain, so the row and the sheet it
+    // opens cannot name two different accounts (#7380, #8185). A known
+    // identity skips the lookup entirely: applying a vanish evicts the cached
+    // profile, moderation's kind-0 resolves late, and a retired moderation key
+    // has none at all — so the sheet would otherwise open labelled with the
+    // generated fallback the row's own name exists to avoid.
+    //
+    // `read`, not `watch`: this runs on a gesture, not in build. The tile that
+    // owns the gesture is still mounted and already watching the provider, so
+    // the value is settled — and while it is not, both resolve the same way.
+    final isVanished = ref
+        .read(profileVanishedProvider(otherPubkey))
+        .maybeWhen(data: (vanished) => vanished, orElse: () => false);
+
+    final String displayName;
+    final knownName = dmPeerNameWithoutProfile(
+      context,
+      pubkeyHex: otherPubkey,
+      isVanished: isVanished,
+      displayNameOverride: displayNameOverride,
+    );
     if (knownName != null) {
       displayName = knownName;
     } else {
@@ -982,9 +994,13 @@ class _MessagesScrollViewState extends ConsumerState<_MessagesScrollView>
         fetchUserProfileProvider(otherPubkey).future,
       );
       if (!context.mounted) return;
-      displayName =
-          profile?.bestDisplayName ??
-          UserProfile.defaultDisplayNameFor(otherPubkey);
+      displayName = dmPeerDisplayName(
+        context,
+        pubkeyHex: otherPubkey,
+        isVanished: isVanished,
+        displayNameOverride: displayNameOverride,
+        profile: profile,
+      );
     }
 
     if (!context.mounted) return;

--- a/mobile/lib/screens/inbox/inbox_view.dart
+++ b/mobile/lib/screens/inbox/inbox_view.dart
@@ -976,9 +976,24 @@ class _MessagesScrollViewState extends ConsumerState<_MessagesScrollView>
     // The reactive provider intentionally renders false while its shared
     // Drift stream is loading. An imperative read cannot use that placeholder:
     // the sheet needs the durable answer before choosing a name.
-    final isVanished = await ref.read(
-      profileVanishedSnapshotProvider(otherPubkey).future,
-    );
+    bool isVanished;
+    try {
+      isVanished = await ref.read(
+        profileVanishedSnapshotProvider(otherPubkey).future,
+      );
+    } catch (error, stackTrace) {
+      // The sheet contains safety actions. A transient local-database failure
+      // must not make Report and Block disappear with the whole gesture.
+      Log.warning(
+        'Could not read durable vanish state; opening conversation actions '
+        'with the live-account identity fallback',
+        name: 'InboxView',
+        category: LogCategory.ui,
+        error: error,
+        stackTrace: stackTrace,
+      );
+      isVanished = false;
+    }
     if (!context.mounted) return;
 
     final String displayName;
@@ -1011,12 +1026,16 @@ class _MessagesScrollViewState extends ConsumerState<_MessagesScrollView>
 
     final actionsCubit = context.read<ConversationActionsCubit>();
     final isBlocked = actionsCubit.isBlocked(otherPubkey);
+    final actionDisplayName = isVanished
+        ? context.l10n.inboxVanishedAccountReference
+        : displayName;
 
     setState(() => _highlightedConversationId = conversation.id);
     try {
       final action = await ConversationActionsSheet.show(
         context,
         displayName: displayName,
+        isVanished: isVanished,
         isMuted: isMuted,
         isBlocked: isBlocked,
       );
@@ -1049,7 +1068,7 @@ class _MessagesScrollViewState extends ConsumerState<_MessagesScrollView>
               SnackBar(
                 content: Text(
                   reported
-                      ? context.l10n.inboxReportedUser(displayName)
+                      ? context.l10n.inboxReportedUser(actionDisplayName)
                       : context.l10n.reportNotSent,
                 ),
               ),
@@ -1067,8 +1086,8 @@ class _MessagesScrollViewState extends ConsumerState<_MessagesScrollView>
               SnackBar(
                 content: Text(
                   isBlocked
-                      ? context.l10n.inboxUnblockedUser(displayName)
-                      : context.l10n.inboxBlockedUser(displayName),
+                      ? context.l10n.inboxUnblockedUser(actionDisplayName)
+                      : context.l10n.inboxBlockedUser(actionDisplayName),
                 ),
               ),
             );

--- a/mobile/lib/screens/inbox/message_requests/request_preview_view.dart
+++ b/mobile/lib/screens/inbox/message_requests/request_preview_view.dart
@@ -18,6 +18,7 @@ import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/screens/inbox/conversation/conversation_page.dart';
 import 'package:openvine/screens/inbox/conversation/widgets/widgets.dart';
 import 'package:openvine/screens/inbox/inbox_page.dart';
+import 'package:openvine/screens/inbox/widgets/dm_peer_identity.dart';
 import 'package:openvine/screens/inbox/widgets/moderation_identity.dart';
 import 'package:openvine/screens/other_profile_screen.dart';
 import 'package:openvine/services/collaborator_invite_parser.dart';
@@ -100,10 +101,26 @@ class RequestPreviewView extends ConsumerWidget {
 
     final profile = profileAsync.asData?.value;
 
-    final displayName =
-        moderationDisplayName(context, otherPubkey) ??
-        profile?.bestDisplayName ??
-        UserProfile.defaultDisplayNameFor(otherPubkey);
+    // Same treatment as [ConversationTile]. This screen also links straight
+    // through to [OtherProfileScreen], which already names a vanished account
+    // for the state — so without this the same tap sequence showed a generated
+    // handle and then "Deleted account" (#8185).
+    final isDeleted = ref
+        .watch(profileVanishedProvider(otherPubkey))
+        .maybeWhen(data: (vanished) => vanished, orElse: () => false);
+
+    // Suppressing the profile object as well as the name matches
+    // [OtherProfileScreen], which nulls its own header profile on a vanish
+    // rather than pass a deleted account's avatar, handle and counts
+    // downstream.
+    final visibleProfile = isDeleted ? null : profile;
+
+    final displayName = dmPeerDisplayName(
+      context,
+      pubkeyHex: otherPubkey,
+      isVanished: isDeleted,
+      profile: visibleProfile,
+    );
 
     return Scaffold(
       backgroundColor: context.vineColors.surface,
@@ -121,7 +138,7 @@ class RequestPreviewView extends ConsumerWidget {
             Expanded(
               child: _ProfileContent(
                 displayName: displayName,
-                profile: profile,
+                profile: visibleProfile,
                 otherPubkey: otherPubkey,
                 currentPubkey: currentPubkey,
                 messageCount: messageCount,

--- a/mobile/lib/screens/inbox/message_requests/widgets/request_tile.dart
+++ b/mobile/lib/screens/inbox/message_requests/widgets/request_tile.dart
@@ -9,6 +9,7 @@ import 'package:openvine/config/official_accounts.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/l10n/localized_time_formatter.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
+import 'package:openvine/screens/inbox/widgets/dm_peer_identity.dart';
 import 'package:openvine/screens/inbox/widgets/moderation_identity.dart';
 import 'package:openvine/widgets/user_avatar.dart';
 import 'package:unified_logger/unified_logger.dart';
@@ -38,19 +39,29 @@ class RequestTile extends ConsumerWidget {
 
     final profileAsync = ref.watch(userProfileReactiveProvider(otherPubkey));
 
-    final displayName =
-        moderationDisplayName(context, otherPubkey) ??
-        profileAsync.maybeWhen<String>(
-          data: (profile) =>
-              profile?.bestDisplayName ??
-              UserProfile.defaultDisplayNameFor(otherPubkey),
-          orElse: () => UserProfile.defaultDisplayNameFor(otherPubkey),
-        );
+    // Same treatment as [ConversationTile]: a request from an account that
+    // later vanished is named for the state, not for the generated handle the
+    // eviction leaves behind (#8185).
+    final isDeleted = ref
+        .watch(profileVanishedProvider(otherPubkey))
+        .maybeWhen(data: (vanished) => vanished, orElse: () => false);
 
-    final imageUrl = profileAsync.maybeWhen(
-      data: (profile) => profile?.picture,
-      orElse: () => null,
+    final displayName = dmPeerDisplayName(
+      context,
+      pubkeyHex: otherPubkey,
+      isVanished: isDeleted,
+      profile: profileAsync.maybeWhen(
+        data: (profile) => profile,
+        orElse: () => null,
+      ),
     );
+
+    final imageUrl = isDeleted
+        ? null
+        : profileAsync.maybeWhen(
+            data: (profile) => profile?.picture,
+            orElse: () => null,
+          );
 
     final relativeTime = conversation.lastMessageTimestamp != null
         ? LocalizedTimeFormatter.formatConversationTimestamp(

--- a/mobile/lib/screens/inbox/message_requests/widgets/request_tile.dart
+++ b/mobile/lib/screens/inbox/message_requests/widgets/request_tile.dart
@@ -50,10 +50,7 @@ class RequestTile extends ConsumerWidget {
       context,
       pubkeyHex: otherPubkey,
       isVanished: isDeleted,
-      profile: profileAsync.maybeWhen(
-        data: (profile) => profile,
-        orElse: () => null,
-      ),
+      profile: profileAsync.asData?.value,
     );
 
     final imageUrl = isDeleted

--- a/mobile/lib/screens/inbox/widgets/conversation_actions_sheet.dart
+++ b/mobile/lib/screens/inbox/widgets/conversation_actions_sheet.dart
@@ -28,9 +28,17 @@ class ConversationActionsSheet {
   static Future<ConversationAction?> show(
     BuildContext context, {
     required String displayName,
+    required bool isVanished,
     required bool isMuted,
     required bool isBlocked,
   }) {
+    // A vanished peer can publish again under the same key, and their DMs
+    // remain in the recipient's history. Keep Report and Block available for
+    // safety, but do not turn the deleted-state label into an identity.
+    final actionDisplayName = isVanished
+        ? context.l10n.inboxVanishedAccountReference
+        : displayName;
+
     return VineBottomSheet.show<ConversationAction>(
       context: context,
       scrollable: false,
@@ -47,14 +55,14 @@ class ConversationActionsSheet {
             _MuteActionTile(isMuted: isMuted),
             _ActionTile(
               icon: DivineIconName.flag,
-              label: context.l10n.inboxActionReport(displayName),
+              label: context.l10n.inboxActionReport(actionDisplayName),
               result: ConversationAction.report,
             ),
             _ActionTile(
               icon: DivineIconName.eyeSlash,
               label: isBlocked
-                  ? context.l10n.inboxActionUnblock(displayName)
-                  : context.l10n.inboxActionBlock(displayName),
+                  ? context.l10n.inboxActionUnblock(actionDisplayName)
+                  : context.l10n.inboxActionBlock(actionDisplayName),
               isDestructive: !isBlocked,
               result: ConversationAction.block,
             ),

--- a/mobile/lib/screens/inbox/widgets/conversation_tile.dart
+++ b/mobile/lib/screens/inbox/widgets/conversation_tile.dart
@@ -80,10 +80,7 @@ class ConversationTile extends ConsumerWidget {
       pubkeyHex: otherPubkey,
       isVanished: isDeleted,
       displayNameOverride: displayNameOverride,
-      profile: profileAsync.maybeWhen(
-        data: (profile) => profile,
-        orElse: () => null,
-      ),
+      profile: profileAsync.asData?.value,
     );
 
     final imageUrl = isDeleted

--- a/mobile/lib/screens/inbox/widgets/conversation_tile.dart
+++ b/mobile/lib/screens/inbox/widgets/conversation_tile.dart
@@ -10,6 +10,7 @@ import 'package:openvine/config/official_accounts.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/l10n/localized_time_formatter.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
+import 'package:openvine/screens/inbox/widgets/dm_peer_identity.dart';
 import 'package:openvine/screens/inbox/widgets/moderation_identity.dart';
 import 'package:openvine/services/collaborator_invite_service.dart';
 import 'package:openvine/utils/string_utils.dart';
@@ -74,16 +75,16 @@ class ConversationTile extends ConsumerWidget {
         .watch(profileVanishedProvider(otherPubkey))
         .maybeWhen(data: (vanished) => vanished, orElse: () => false);
 
-    final displayName = isDeleted
-        ? context.l10n.profileDeletedAccountName
-        : displayNameOverride ??
-              moderationDisplayName(context, otherPubkey) ??
-              profileAsync.maybeWhen<String>(
-                data: (profile) =>
-                    profile?.bestDisplayName ??
-                    UserProfile.defaultDisplayNameFor(otherPubkey),
-                orElse: () => UserProfile.defaultDisplayNameFor(otherPubkey),
-              );
+    final displayName = dmPeerDisplayName(
+      context,
+      pubkeyHex: otherPubkey,
+      isVanished: isDeleted,
+      displayNameOverride: displayNameOverride,
+      profile: profileAsync.maybeWhen(
+        data: (profile) => profile,
+        orElse: () => null,
+      ),
+    );
 
     final imageUrl = isDeleted
         ? null

--- a/mobile/lib/screens/inbox/widgets/dm_peer_identity.dart
+++ b/mobile/lib/screens/inbox/widgets/dm_peer_identity.dart
@@ -1,0 +1,50 @@
+// ABOUTME: The one naming chain every DM surface uses for a conversation peer.
+// ABOUTME: Vanished first, so a row and the sheet it opens cannot name two
+// ABOUTME: different accounts.
+
+import 'package:flutter/widgets.dart';
+import 'package:models/models.dart';
+import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/screens/inbox/widgets/moderation_identity.dart';
+
+/// The peer's name when it resolves without a profile lookup.
+///
+/// A NIP-62 vanish comes first because it is the only branch that contradicts
+/// the ones below it: applying one evicts the cached profile and short-circuits
+/// every later fetch, so a surface that skips this check does not fall back to
+/// the peer's last known name — it falls all the way through to
+/// [UserProfile.defaultDisplayNameFor], a generated "Adjective Animal N" the
+/// viewer has never seen before.
+///
+/// Returns null when only the profile can name the peer, which is the caller's
+/// signal that a lookup is worth paying for.
+String? dmPeerNameWithoutProfile(
+  BuildContext context, {
+  required String pubkeyHex,
+  required bool isVanished,
+  String? displayNameOverride,
+}) => isVanished
+    ? context.l10n.profileDeletedAccountName
+    : displayNameOverride ?? moderationDisplayName(context, pubkeyHex);
+
+/// The full chain: vanished, then [displayNameOverride], then moderation, then
+/// [profile], then the generated fallback.
+///
+/// [isVanished] is required rather than defaulted so a new DM surface has to
+/// decide what to pass. Read it from `profileVanishedProvider`; every widget
+/// surface watches it, and `ConversationTile` is the reference call site.
+String dmPeerDisplayName(
+  BuildContext context, {
+  required String pubkeyHex,
+  required bool isVanished,
+  UserProfile? profile,
+  String? displayNameOverride,
+}) =>
+    dmPeerNameWithoutProfile(
+      context,
+      pubkeyHex: pubkeyHex,
+      isVanished: isVanished,
+      displayNameOverride: displayNameOverride,
+    ) ??
+    profile?.bestDisplayName ??
+    UserProfile.defaultDisplayNameFor(pubkeyHex);

--- a/mobile/lib/screens/inbox/widgets/dm_peer_identity.dart
+++ b/mobile/lib/screens/inbox/widgets/dm_peer_identity.dart
@@ -1,4 +1,4 @@
-// ABOUTME: The one naming chain every DM surface uses for a conversation peer.
+// ABOUTME: Shared naming chain for inbox and request DM conversation peers.
 // ABOUTME: Vanished first, so a row and the sheet it opens cannot name two
 // ABOUTME: different accounts.
 
@@ -30,9 +30,9 @@ String? dmPeerNameWithoutProfile(
 /// The full chain: vanished, then [displayNameOverride], then moderation, then
 /// [profile], then the generated fallback.
 ///
-/// [isVanished] is required rather than defaulted so a new DM surface has to
-/// decide what to pass. Read it from `profileVanishedProvider`; every widget
-/// surface watches it, and `ConversationTile` is the reference call site.
+/// [isVanished] is required rather than defaulted so every caller has to decide
+/// what to pass. Reactive widgets read it from `profileVanishedProvider`, with
+/// `ConversationTile` as the reference call site.
 String dmPeerDisplayName(
   BuildContext context, {
   required String pubkeyHex,

--- a/mobile/lib/screens/inbox/widgets/following_bar.dart
+++ b/mobile/lib/screens/inbox/widgets/following_bar.dart
@@ -6,10 +6,9 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:models/models.dart';
 import 'package:openvine/blocs/my_following/my_following_bloc.dart';
-import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
+import 'package:openvine/screens/inbox/widgets/dm_peer_identity.dart';
 import 'package:openvine/widgets/user_avatar.dart';
 
 /// Horizontal scrollable bar showing following users.
@@ -69,14 +68,12 @@ class _FollowingUserButton extends ConsumerWidget {
         .watch(profileVanishedProvider(pubkey))
         .maybeWhen(data: (vanished) => vanished, orElse: () => false);
 
-    final displayName = isDeleted
-        ? context.l10n.profileDeletedAccountName
-        : profileAsync.maybeWhen(
-            data: (profile) =>
-                profile?.bestDisplayName ??
-                UserProfile.defaultDisplayNameFor(pubkey),
-            orElse: () => UserProfile.defaultDisplayNameFor(pubkey),
-          );
+    final displayName = dmPeerDisplayName(
+      context,
+      pubkeyHex: pubkey,
+      isVanished: isDeleted,
+      profile: profileAsync.asData?.value,
+    );
 
     final imageUrl = isDeleted
         ? null

--- a/mobile/test/helpers/test_provider_overrides.dart
+++ b/mobile/test/helpers/test_provider_overrides.dart
@@ -88,9 +88,7 @@ MockSharedPreferences createMockSharedPreferences() {
     when(
       () => mockPrefs.remove('ff_${flag.name}'),
     ).thenAnswer((_) async => true);
-    when(
-      () => mockPrefs.containsKey('ff_${flag.name}'),
-    ).thenReturn(false);
+    when(() => mockPrefs.containsKey('ff_${flag.name}')).thenReturn(false);
   }
 
   // Add common SharedPreferences stubs that tests might need
@@ -308,9 +306,7 @@ MockFollowRepository createMockFollowRepository({
   when(() => mock.isFollowing(any())).thenReturn(false);
   when(
     mock.watchMyFollowingCached,
-  ).thenAnswer(
-    (_) => const Stream<CacheResult<FollowingSnapshot>>.empty(),
-  );
+  ).thenAnswer((_) => const Stream<CacheResult<FollowingSnapshot>>.empty());
   when(
     () => mock.watchOthersFollowingCached(
       any(),
@@ -551,6 +547,7 @@ Widget testMaterialApp({
   FollowRepository? mockFollowRepository,
   VideoEventService? mockVideoEventService,
   ThemeData? theme,
+  Locale? locale,
 }) {
   return testProviderScope(
     additionalOverrides: additionalOverrides,
@@ -568,6 +565,7 @@ Widget testMaterialApp({
     mockFollowRepository: mockFollowRepository,
     mockVideoEventService: mockVideoEventService,
     child: MaterialApp(
+      locale: locale,
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
       home: home,

--- a/mobile/test/helpers/test_provider_overrides.dart
+++ b/mobile/test/helpers/test_provider_overrides.dart
@@ -436,6 +436,7 @@ List<dynamic> getStandardTestOverrides({
     // build. Tests that exercise the deleted-account treatment override it
     // again with `additionalOverrides`.
     profileVanishedProvider.overrideWith((ref, pubkey) => Stream.value(false)),
+    profileVanishedSnapshotProvider.overrideWith((ref, pubkey) async => false),
 
     // ONLY override other service providers if explicitly requested
     if (mockAuthService != null)

--- a/mobile/test/providers/user_profile_providers_test.dart
+++ b/mobile/test/providers/user_profile_providers_test.dart
@@ -50,6 +50,29 @@ void main() {
   const pubkey =
       'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
 
+  group('profileVanishedSnapshotProvider', () {
+    test('reads the durable vanish row from a cold provider', () async {
+      final database = _MockAppDatabase();
+      final vanishedProfilesDao = _MockVanishedProfilesDao();
+      when(
+        () => database.vanishedProfilesDao,
+      ).thenReturn(vanishedProfilesDao);
+      when(
+        () => vanishedProfilesDao.isVanished(pubkey),
+      ).thenAnswer((_) async => true);
+      final container = ProviderContainer(
+        overrides: [databaseProvider.overrideWithValue(database)],
+      );
+      addTearDown(container.dispose);
+
+      expect(
+        await container.read(profileVanishedSnapshotProvider(pubkey).future),
+        isTrue,
+      );
+      verify(() => vanishedProfilesDao.isVanished(pubkey)).called(1);
+    });
+  });
+
   group('userProfileReactiveProvider', () {
     late _MockProfileRepository profileRepository;
     late ProviderContainer container;

--- a/mobile/test/providers/user_profile_providers_test.dart
+++ b/mobile/test/providers/user_profile_providers_test.dart
@@ -54,21 +54,25 @@ void main() {
     test('reads the durable vanish row from a cold provider', () async {
       final database = _MockAppDatabase();
       final vanishedProfilesDao = _MockVanishedProfilesDao();
-      when(
-        () => database.vanishedProfilesDao,
-      ).thenReturn(vanishedProfilesDao);
+      final lookup = Completer<bool>();
+      when(() => database.vanishedProfilesDao).thenReturn(vanishedProfilesDao);
       when(
         () => vanishedProfilesDao.isVanished(pubkey),
-      ).thenAnswer((_) async => true);
+      ).thenAnswer((_) => lookup.future);
       final container = ProviderContainer(
         overrides: [databaseProvider.overrideWithValue(database)],
       );
       addTearDown(container.dispose);
 
-      expect(
-        await container.read(profileVanishedSnapshotProvider(pubkey).future),
-        isTrue,
+      final result = container.read(
+        profileVanishedSnapshotProvider(pubkey).future,
       );
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      lookup.complete(true);
+
+      expect(await result, isTrue);
       verify(() => vanishedProfilesDao.isVanished(pubkey)).called(1);
     });
   });
@@ -137,9 +141,7 @@ void main() {
       );
       addTearDown(sub.close);
 
-      await untilCalled(
-        () => profileRepository.watchProfile(pubkey: pubkey),
-      );
+      await untilCalled(() => profileRepository.watchProfile(pubkey: pubkey));
       await Future<void>.delayed(Duration.zero);
       liveController.add(cachedProfile);
       await Future<void>.delayed(Duration.zero);
@@ -215,9 +217,7 @@ void main() {
       'resolves to AsyncData(null) when no repository is available',
       () async {
         final emptyContainer = ProviderContainer(
-          overrides: [
-            profileReadRepositoryProvider.overrideWithValue(null),
-          ],
+          overrides: [profileReadRepositoryProvider.overrideWithValue(null)],
         );
         addTearDown(emptyContainer.dispose);
 
@@ -331,9 +331,7 @@ void main() {
       await Future<void>.delayed(Duration.zero);
 
       expect(emitted, [cachedProfile]);
-      verify(
-        () => profileRepository.watchProfile(pubkey: pubkey),
-      ).called(1);
+      verify(() => profileRepository.watchProfile(pubkey: pubkey)).called(1);
       verifyNever(
         () => profileRepository.fetchFreshProfile(pubkey: any(named: 'pubkey')),
       );
@@ -549,49 +547,46 @@ void main() {
   });
 
   group('read/write split (#6423)', () {
-    test(
-      'the reactive profile resolves from cache while the signing gate is '
-      'still shut',
-      () async {
-        final repository = _MockProfileRepository();
-        final cached = UserProfile(
-          pubkey: pubkey,
-          name: 'real-name',
-          rawData: const {},
-          createdAt: DateTime.utc(2026),
-          eventId: 'event-id',
-        );
-        when(
-          () => repository.getCachedProfile(pubkey: pubkey),
-        ).thenAnswer((_) async => cached);
-        when(
-          () => repository.watchProfile(pubkey: pubkey),
-        ).thenAnswer((_) => Stream<UserProfile?>.value(cached));
+    test('the reactive profile resolves from cache while the signing gate is '
+        'still shut', () async {
+      final repository = _MockProfileRepository();
+      final cached = UserProfile(
+        pubkey: pubkey,
+        name: 'real-name',
+        rawData: const {},
+        createdAt: DateTime.utc(2026),
+        eventId: 'event-id',
+      );
+      when(
+        () => repository.getCachedProfile(pubkey: pubkey),
+      ).thenAnswer((_) async => cached);
+      when(
+        () => repository.watchProfile(pubkey: pubkey),
+      ).thenAnswer((_) => Stream<UserProfile?>.value(cached));
 
-        final container = ProviderContainer(
-          overrides: [
-            // The state the reporter was stuck in: identity known, relays not
-            // yet connected, so the signing-gated repository is null.
-            profileRepositoryProvider.overrideWithValue(null),
-            profileReadRepositoryProvider.overrideWithValue(repository),
-          ],
-        );
-        addTearDown(container.dispose);
+      final container = ProviderContainer(
+        overrides: [
+          // The state the reporter was stuck in: identity known, relays not
+          // yet connected, so the signing-gated repository is null.
+          profileRepositoryProvider.overrideWithValue(null),
+          profileReadRepositoryProvider.overrideWithValue(repository),
+        ],
+      );
+      addTearDown(container.dispose);
 
-        final emitted = <AsyncValue<UserProfile?>>[];
-        final sub = container.listen(
-          userProfileReactiveProvider(pubkey),
-          (_, next) => emitted.add(next),
-          fireImmediately: true,
-        );
-        addTearDown(sub.close);
+      final emitted = <AsyncValue<UserProfile?>>[];
+      final sub = container.listen(
+        userProfileReactiveProvider(pubkey),
+        (_, next) => emitted.add(next),
+        fireImmediately: true,
+      );
+      addTearDown(sub.close);
 
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
 
-        expect(emitted.last.value?.name, 'real-name');
-      },
-    );
+      expect(emitted.last.value?.name, 'real-name');
+    });
   });
 
   group('profileStatsRepository gating (#5863)', () {
@@ -606,9 +601,7 @@ void main() {
     }
 
     test('is null when signed out', () {
-      final container = containerWith(
-        const NostrSessionReadiness.signedOut(),
-      );
+      final container = containerWith(const NostrSessionReadiness.signedOut());
       expect(container.read(profileReadRepositoryProvider), isNull);
     });
 
@@ -626,72 +619,65 @@ void main() {
       },
     );
 
-    test(
-      'preserves the stats repository instance from identity-known to '
-      'nostrReady for the same pubkey',
-      () async {
-        SharedPreferences.setMockInitialValues({});
-        final prefs = await SharedPreferences.getInstance();
-        final nostrClient = _MockNostrClient();
-        final database = _MockAppDatabase();
-        final userProfilesDao = _MockUserProfilesDao();
-        final profileStatsDao = _MockProfileStatsDao();
-        final pendingProfileSavesDao = _MockPendingProfileSavesDao();
-        final funnelcakeClient = FunnelcakeApiClient(
-          baseUrl: 'https://api.divine.video',
-        );
+    test('preserves the stats repository instance from identity-known to '
+        'nostrReady for the same pubkey', () async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      final nostrClient = _MockNostrClient();
+      final database = _MockAppDatabase();
+      final userProfilesDao = _MockUserProfilesDao();
+      final profileStatsDao = _MockProfileStatsDao();
+      final pendingProfileSavesDao = _MockPendingProfileSavesDao();
+      final funnelcakeClient = FunnelcakeApiClient(
+        baseUrl: 'https://api.divine.video',
+      );
 
-        when(() => database.userProfilesDao).thenReturn(userProfilesDao);
-        when(() => database.profileStatsDao).thenReturn(profileStatsDao);
-        when(
-          () => database.pendingProfileSavesDao,
-        ).thenReturn(pendingProfileSavesDao);
-        when(
-          () => database.identityEventsDao,
-        ).thenReturn(_MockIdentityEventsDao());
-        final vanishedProfilesDao = _MockVanishedProfilesDao();
-        // The repository hydrates its vanish set on construction, so this has
-        // to resolve or the provider throws before it returns an instance.
-        when(vanishedProfilesDao.getAllPubkeys).thenAnswer(
-          (_) async => <String>[],
-        );
-        when(
-          () => database.vanishedProfilesDao,
-        ).thenReturn(vanishedProfilesDao);
+      when(() => database.userProfilesDao).thenReturn(userProfilesDao);
+      when(() => database.profileStatsDao).thenReturn(profileStatsDao);
+      when(
+        () => database.pendingProfileSavesDao,
+      ).thenReturn(pendingProfileSavesDao);
+      when(
+        () => database.identityEventsDao,
+      ).thenReturn(_MockIdentityEventsDao());
+      final vanishedProfilesDao = _MockVanishedProfilesDao();
+      // The repository hydrates its vanish set on construction, so this has
+      // to resolve or the provider throws before it returns an instance.
+      when(
+        vanishedProfilesDao.getAllPubkeys,
+      ).thenAnswer((_) async => <String>[]);
+      when(() => database.vanishedProfilesDao).thenReturn(vanishedProfilesDao);
 
-        final container = ProviderContainer(
-          overrides: [
-            nostrSessionProvider.overrideWith(
-              () => _TestNostrSession(
-                const NostrSessionReadiness.identityKnown(pubkey: pubkey),
-              ),
+      final container = ProviderContainer(
+        overrides: [
+          nostrSessionProvider.overrideWith(
+            () => _TestNostrSession(
+              const NostrSessionReadiness.identityKnown(pubkey: pubkey),
             ),
-            nostrServiceProvider.overrideWithValue(nostrClient),
-            databaseProvider.overrideWithValue(database),
-            sharedPreferencesProvider.overrideWithValue(prefs),
-            funnelcakeApiClientProvider.overrideWithValue(funnelcakeClient),
-          ],
-        );
-        addTearDown(container.dispose);
+          ),
+          nostrServiceProvider.overrideWithValue(nostrClient),
+          databaseProvider.overrideWithValue(database),
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          funnelcakeApiClientProvider.overrideWithValue(funnelcakeClient),
+        ],
+      );
+      addTearDown(container.dispose);
 
-        final identityKnownRepo = container.read(
-          profileReadRepositoryProvider,
-        );
-        expect(identityKnownRepo, isNotNull);
+      final identityKnownRepo = container.read(profileReadRepositoryProvider);
+      expect(identityKnownRepo, isNotNull);
 
-        container
-            .read(nostrSessionProvider.notifier)
-            .update(
-              NostrSessionReadiness.nostrReady(
-                pubkey: pubkey,
-                client: nostrClient,
-              ),
-            );
+      container
+          .read(nostrSessionProvider.notifier)
+          .update(
+            NostrSessionReadiness.nostrReady(
+              pubkey: pubkey,
+              client: nostrClient,
+            ),
+          );
 
-        final nostrReadyRepo = container.read(profileReadRepositoryProvider);
-        expect(identical(identityKnownRepo, nostrReadyRepo), isTrue);
-      },
-    );
+      final nostrReadyRepo = container.read(profileReadRepositoryProvider);
+      expect(identical(identityKnownRepo, nostrReadyRepo), isTrue);
+    });
   });
 }
 

--- a/mobile/test/screens/inbox/inbox_view_test.dart
+++ b/mobile/test/screens/inbox/inbox_view_test.dart
@@ -2036,6 +2036,65 @@ void main() {
         expect(find.text(l10n.inboxActionUnblock('user')), findsNothing);
       });
 
+      // #8185, the same shape one layer out: `ConversationTile` short-circuits
+      // on the NIP-62 vanish before every other branch, and the sheet's own
+      // chain had no such branch. Applying a vanish evicts the cached profile,
+      // so the sheet did not fall back to the peer's last known name — it fell
+      // all the way to a generated "Adjective Animal N" and offered to block
+      // that, under a row reading "Deleted account".
+      testWidgets('names a vanished peer in the sheet its row opens', (
+        tester,
+      ) async {
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        final conversation = DmConversation(
+          id: 'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
+          participantPubkeys: const [currentPubkey, otherPubkey],
+          isGroup: false,
+          createdAt: nowUnix,
+          lastMessageContent: 'Hello',
+          lastMessageTimestamp: nowUnix,
+        );
+
+        await tester.pumpWidget(
+          buildSubject(
+            state: ConversationListState(
+              status: ConversationListStatus.loaded,
+              conversations: [conversation],
+              visibleConversations: [conversation],
+              hasMore: false,
+            ),
+            additionalOverrides: [
+              profileVanishedProvider(
+                otherPubkey,
+              ).overrideWith((ref) => Stream.value(true)),
+            ],
+          ),
+        );
+        await openMessages(tester);
+
+        expect(find.text(l10n.profileDeletedAccountName), findsOneWidget);
+
+        await tester.longPress(find.byType(ConversationTile));
+        await tester.pumpAndSettle();
+
+        expect(
+          find.text(
+            l10n.inboxActionBlock(l10n.profileDeletedAccountName),
+          ),
+          findsOneWidget,
+        );
+        expect(
+          find.text(
+            l10n.inboxActionReport(l10n.profileDeletedAccountName),
+          ),
+          findsOneWidget,
+        );
+        expect(
+          find.textContaining(UserProfile.defaultDisplayNameFor(otherPubkey)),
+          findsNothing,
+        );
+      });
+
       testWidgets('drops out of a search it does not match', (tester) async {
         final l10n = lookupAppLocalizations(const Locale('en'));
         final conversation = DmConversation(

--- a/mobile/test/screens/inbox/inbox_view_test.dart
+++ b/mobile/test/screens/inbox/inbox_view_test.dart
@@ -2067,6 +2067,9 @@ void main() {
               profileVanishedProvider(
                 otherPubkey,
               ).overrideWith((ref) => Stream.value(true)),
+              profileVanishedSnapshotProvider(
+                otherPubkey,
+              ).overrideWith((ref) async => true),
             ],
           ),
         );

--- a/mobile/test/screens/inbox/inbox_view_test.dart
+++ b/mobile/test/screens/inbox/inbox_view_test.dart
@@ -200,9 +200,7 @@ void main() {
               BlocProvider<NotificationBadgeCubit>.value(
                 value: mockNotifBadgeCubit,
               ),
-              BlocProvider<ConversationMuteCubit>.value(
-                value: mockMuteCubit,
-              ),
+              BlocProvider<ConversationMuteCubit>.value(value: mockMuteCubit),
               BlocProvider<ConversationActionsCubit>.value(
                 value: mockActionsCubit,
               ),
@@ -221,33 +219,27 @@ void main() {
         expect(find.byType(InboxSegmentedToggle), findsOneWidget);
       });
 
-      testWidgets(
-        'forwards DmUnreadCountCubit state to '
-        '$InboxSegmentedToggle.messageCount',
-        (tester) async {
-          await tester.pumpWidget(buildSubject(dmUnreadCount: 5));
-          await tester.pump();
+      testWidgets('forwards DmUnreadCountCubit state to '
+          '$InboxSegmentedToggle.messageCount', (tester) async {
+        await tester.pumpWidget(buildSubject(dmUnreadCount: 5));
+        await tester.pump();
 
-          final toggle = tester.widget<InboxSegmentedToggle>(
-            find.byType(InboxSegmentedToggle),
-          );
-          expect(toggle.messageCount, equals(5));
-        },
-      );
+        final toggle = tester.widget<InboxSegmentedToggle>(
+          find.byType(InboxSegmentedToggle),
+        );
+        expect(toggle.messageCount, equals(5));
+      });
 
-      testWidgets(
-        'forwards NotificationBadgeCubit state to '
-        '$InboxSegmentedToggle.notificationCount',
-        (tester) async {
-          await tester.pumpWidget(buildSubject(notificationUnreadCount: 7));
-          await tester.pump();
+      testWidgets('forwards NotificationBadgeCubit state to '
+          '$InboxSegmentedToggle.notificationCount', (tester) async {
+        await tester.pumpWidget(buildSubject(notificationUnreadCount: 7));
+        await tester.pump();
 
-          final toggle = tester.widget<InboxSegmentedToggle>(
-            find.byType(InboxSegmentedToggle),
-          );
-          expect(toggle.notificationCount, equals(7));
-        },
-      );
+        final toggle = tester.widget<InboxSegmentedToggle>(
+          find.byType(InboxSegmentedToggle),
+        );
+        expect(toggle.notificationCount, equals(7));
+      });
 
       testWidgets('renders $FollowingBar in messages tab', (tester) async {
         await tester.pumpWidget(buildSubject());
@@ -261,10 +253,7 @@ void main() {
         // skipOffstage: false because the bar now lives in a sliver and this
         // subject follows nobody, so it collapses to SizedBox.shrink() — a
         // zero-extent sliver, which the default finder treats as offstage.
-        expect(
-          find.byType(FollowingBar, skipOffstage: false),
-          findsOneWidget,
-        );
+        expect(find.byType(FollowingBar, skipOffstage: false), findsOneWidget);
       });
 
       testWidgets('renders $CircularProgressIndicator when status is initial', (
@@ -486,121 +475,114 @@ void main() {
         expect(find.byType(InboxFilterChips), findsOneWidget);
       });
 
-      testWidgets(
-        'tapping the Unread chip dispatches '
-        '$ConversationListFilterChanged',
-        (tester) async {
-          final conversation = DmConversation(
-            id: 'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd',
-            participantPubkeys: const [currentPubkey, otherPubkey],
-            isGroup: false,
-            createdAt: nowUnix,
-            lastMessageContent: 'Hello',
-            lastMessageTimestamp: nowUnix,
-          );
+      testWidgets('tapping the Unread chip dispatches '
+          '$ConversationListFilterChanged', (tester) async {
+        final conversation = DmConversation(
+          id: 'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd',
+          participantPubkeys: const [currentPubkey, otherPubkey],
+          isGroup: false,
+          createdAt: nowUnix,
+          lastMessageContent: 'Hello',
+          lastMessageTimestamp: nowUnix,
+        );
 
-          await tester.pumpWidget(
-            buildSubject(
-              state: ConversationListState(
-                status: ConversationListStatus.loaded,
-                conversations: [conversation],
-                visibleConversations: [conversation],
-                hasMore: false,
-              ),
+        await tester.pumpWidget(
+          buildSubject(
+            state: ConversationListState(
+              status: ConversationListStatus.loaded,
+              conversations: [conversation],
+              visibleConversations: [conversation],
+              hasMore: false,
             ),
-          );
-          await tester.pump();
+          ),
+        );
+        await tester.pump();
 
-          await tester.tap(find.text('Messages'));
-          await tester.pump();
-          await tester.pump(const Duration(milliseconds: 350));
+        await tester.tap(find.text('Messages'));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 350));
 
-          final l10n = lookupAppLocalizations(const Locale('en'));
-          await tester.tap(find.text(l10n.inboxFilterUnread));
-          await tester.pump();
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        await tester.tap(find.text(l10n.inboxFilterUnread));
+        await tester.pump();
 
-          verify(
-            () => mockBloc.add(
-              const ConversationListFilterChanged(InboxFilter.unread),
+        verify(
+          () => mockBloc.add(
+            const ConversationListFilterChanged(InboxFilter.unread),
+          ),
+        ).called(1);
+      });
+
+      testWidgets('tapping the already-active All chip dispatches nothing', (
+        tester,
+      ) async {
+        final conversation = DmConversation(
+          id: 'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd',
+          participantPubkeys: const [currentPubkey, otherPubkey],
+          isGroup: false,
+          createdAt: nowUnix,
+          lastMessageContent: 'Hello',
+          lastMessageTimestamp: nowUnix,
+        );
+
+        await tester.pumpWidget(
+          buildSubject(
+            state: ConversationListState(
+              status: ConversationListStatus.loaded,
+              conversations: [conversation],
+              visibleConversations: [conversation],
+              hasMore: false,
             ),
-          ).called(1);
-        },
-      );
+          ),
+        );
+        await tester.pump();
 
-      testWidgets(
-        'tapping the already-active All chip dispatches nothing',
-        (tester) async {
-          final conversation = DmConversation(
-            id: 'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd',
-            participantPubkeys: const [currentPubkey, otherPubkey],
-            isGroup: false,
-            createdAt: nowUnix,
-            lastMessageContent: 'Hello',
-            lastMessageTimestamp: nowUnix,
-          );
+        await tester.tap(find.text('Messages'));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 350));
 
-          await tester.pumpWidget(
-            buildSubject(
-              state: ConversationListState(
-                status: ConversationListStatus.loaded,
-                conversations: [conversation],
-                visibleConversations: [conversation],
-                hasMore: false,
-              ),
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        await tester.tap(find.text(l10n.inboxFilterAll));
+        await tester.pump();
+
+        verifyNever(
+          () => mockBloc.add(
+            const ConversationListFilterChanged(InboxFilter.unread),
+          ),
+        );
+      });
+
+      testWidgets('shows caught-up state when unread filter is on and everything '
+          'is read', (tester) async {
+        final conversation = DmConversation(
+          id: 'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd',
+          participantPubkeys: const [currentPubkey, otherPubkey],
+          isGroup: false,
+          createdAt: nowUnix,
+          lastMessageContent: 'Hello',
+          lastMessageTimestamp: nowUnix,
+        );
+
+        await tester.pumpWidget(
+          buildSubject(
+            state: ConversationListState(
+              status: ConversationListStatus.loaded,
+              conversations: [conversation],
+              filter: InboxFilter.unread,
+              hasMore: false,
             ),
-          );
-          await tester.pump();
+          ),
+        );
+        await tester.pump();
 
-          await tester.tap(find.text('Messages'));
-          await tester.pump();
-          await tester.pump(const Duration(milliseconds: 350));
+        await tester.tap(find.text('Messages'));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 350));
 
-          final l10n = lookupAppLocalizations(const Locale('en'));
-          await tester.tap(find.text(l10n.inboxFilterAll));
-          await tester.pump();
-
-          verifyNever(
-            () => mockBloc.add(
-              const ConversationListFilterChanged(InboxFilter.unread),
-            ),
-          );
-        },
-      );
-
-      testWidgets(
-        'shows caught-up state when unread filter is on and everything '
-        'is read',
-        (tester) async {
-          final conversation = DmConversation(
-            id: 'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd',
-            participantPubkeys: const [currentPubkey, otherPubkey],
-            isGroup: false,
-            createdAt: nowUnix,
-            lastMessageContent: 'Hello',
-            lastMessageTimestamp: nowUnix,
-          );
-
-          await tester.pumpWidget(
-            buildSubject(
-              state: ConversationListState(
-                status: ConversationListStatus.loaded,
-                conversations: [conversation],
-                filter: InboxFilter.unread,
-                hasMore: false,
-              ),
-            ),
-          );
-          await tester.pump();
-
-          await tester.tap(find.text('Messages'));
-          await tester.pump();
-          await tester.pump(const Duration(milliseconds: 350));
-
-          final l10n = lookupAppLocalizations(const Locale('en'));
-          expect(find.text(l10n.inboxUnreadEmptyTitle), findsOneWidget);
-          expect(find.byType(ConversationTile), findsNothing);
-        },
-      );
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        expect(find.text(l10n.inboxUnreadEmptyTitle), findsOneWidget);
+        expect(find.byType(ConversationTile), findsNothing);
+      });
 
       testWidgets('typing in the search bar dispatches '
           '$ConversationListSearchQueryChanged', (tester) async {
@@ -678,49 +660,48 @@ void main() {
         expect(find.byType(ConversationTile), findsNothing);
       });
 
-      testWidgets(
-        'renders only visibleConversations, not the full list',
-        (tester) async {
-          DmConversation conversationWith({
-            required String id,
-            required bool isRead,
-          }) => DmConversation(
-            id: id,
-            participantPubkeys: const [currentPubkey, otherPubkey],
-            isGroup: false,
-            createdAt: nowUnix,
-            lastMessageContent: 'Hello',
-            lastMessageTimestamp: nowUnix,
-            isRead: isRead,
-          );
+      testWidgets('renders only visibleConversations, not the full list', (
+        tester,
+      ) async {
+        DmConversation conversationWith({
+          required String id,
+          required bool isRead,
+        }) => DmConversation(
+          id: id,
+          participantPubkeys: const [currentPubkey, otherPubkey],
+          isGroup: false,
+          createdAt: nowUnix,
+          lastMessageContent: 'Hello',
+          lastMessageTimestamp: nowUnix,
+          isRead: isRead,
+        );
 
-          final unread = conversationWith(id: 'unread-conv', isRead: false);
-          final read = conversationWith(id: 'read-conv', isRead: true);
+        final unread = conversationWith(id: 'unread-conv', isRead: false);
+        final read = conversationWith(id: 'read-conv', isRead: true);
 
-          await tester.pumpWidget(
-            buildSubject(
-              state: ConversationListState(
-                status: ConversationListStatus.loaded,
-                conversations: [unread, read],
-                visibleConversations: [unread],
-                filter: InboxFilter.unread,
-                hasMore: false,
-              ),
+        await tester.pumpWidget(
+          buildSubject(
+            state: ConversationListState(
+              status: ConversationListStatus.loaded,
+              conversations: [unread, read],
+              visibleConversations: [unread],
+              filter: InboxFilter.unread,
+              hasMore: false,
             ),
-          );
-          await tester.pump();
+          ),
+        );
+        await tester.pump();
 
-          await tester.tap(find.text('Messages'));
-          await tester.pump();
-          await tester.pump(const Duration(milliseconds: 350));
+        await tester.tap(find.text('Messages'));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 350));
 
-          expect(find.byType(ConversationTile), findsOneWidget);
-          final tile = tester.widget<ConversationTile>(
-            find.byType(ConversationTile),
-          );
-          expect(tile.conversation.id, equals('unread-conv'));
-        },
-      );
+        expect(find.byType(ConversationTile), findsOneWidget);
+        final tile = tester.widget<ConversationTile>(
+          find.byType(ConversationTile),
+        );
+        expect(tile.conversation.id, equals('unread-conv'));
+      });
 
       testWidgets(
         'suppresses the load-more spinner while a filter narrows the list',
@@ -1011,20 +992,14 @@ void main() {
               return found;
             }
 
-            expect(
-              hasConversationSemantics(),
-              isTrue,
-            );
+            expect(hasConversationSemantics(), isTrue);
 
             await tester.tap(find.text('Notifications'));
             await tester.pump();
             await tester.pump(const Duration(milliseconds: 350));
 
             expect(find.byType(ConversationTile), findsOneWidget);
-            expect(
-              hasConversationSemantics(),
-              isFalse,
-            );
+            expect(hasConversationSemantics(), isFalse);
           } finally {
             semantics.dispose();
           }
@@ -1499,10 +1474,7 @@ void main() {
         expect(find.byType(DivineSearchBar), findsOneWidget);
         final chipsBefore = tester.getTopLeft(find.byType(InboxFilterChips));
 
-        await tester.drag(
-          find.byType(CustomScrollView),
-          const Offset(0, -400),
-        );
+        await tester.drag(find.byType(CustomScrollView), const Offset(0, -400));
         await tester.pump();
 
         // The search field is chrome now, not a fixed header: it leaves the
@@ -1655,10 +1627,7 @@ void main() {
       testWidgets('the pinned header fits the chips at the default text scale', (
         tester,
       ) async {
-        final size = await pumpChips(
-          tester,
-          textScaler: TextScaler.noScaling,
-        );
+        final size = await pumpChips(tester, textScaler: TextScaler.noScaling);
 
         // 48 = 8px padding either side of a DivineButtonSize.tiny chip, which
         // is itself 6 + a 20px line box + 6. Asserting the chips ASK for 48 is
@@ -1742,10 +1711,7 @@ void main() {
 
         // Focus alone reclaims the bar — no text needed. minSearchQueryLength
         // is 2, so a query-driven collapse would still be showing faces here.
-        expect(
-          find.byType(FollowingBar, skipOffstage: false),
-          findsNothing,
-        );
+        expect(find.byType(FollowingBar, skipOffstage: false), findsNothing);
         expect(
           tester.getTopLeft(find.text('Message 0')).dy,
           lessThan(firstTileBefore - 100),
@@ -2046,6 +2012,10 @@ void main() {
         tester,
       ) async {
         final l10n = lookupAppLocalizations(const Locale('en'));
+        final actionsCubit = _MockConversationActionsCubit();
+        when(
+          () => actionsCubit.blockUser(otherPubkey),
+        ).thenAnswer((_) async {});
         final conversation = DmConversation(
           id: 'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
           participantPubkeys: const [currentPubkey, otherPubkey],
@@ -2057,6 +2027,8 @@ void main() {
 
         await tester.pumpWidget(
           buildSubject(
+            wrapInScaffold: true,
+            actionsCubit: actionsCubit,
             state: ConversationListState(
               status: ConversationListStatus.loaded,
               conversations: [conversation],
@@ -2080,22 +2052,17 @@ void main() {
         await tester.longPress(find.byType(ConversationTile));
         await tester.pumpAndSettle();
 
-        expect(
-          find.text(
-            l10n.inboxActionBlock(l10n.profileDeletedAccountName),
-          ),
-          findsOneWidget,
-        );
-        expect(
-          find.text(
-            l10n.inboxActionReport(l10n.profileDeletedAccountName),
-          ),
-          findsOneWidget,
-        );
+        expect(find.text('Block this account'), findsOneWidget);
+        expect(find.text('Report this account'), findsOneWidget);
         expect(
           find.textContaining(UserProfile.defaultDisplayNameFor(otherPubkey)),
           findsNothing,
         );
+
+        await tester.tap(find.text('Block this account'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Blocked this account'), findsOneWidget);
       });
 
       testWidgets('drops out of a search it does not match', (tester) async {
@@ -2484,6 +2451,44 @@ void main() {
       );
 
       testWidgets(
+        'keeps safety actions available when the vanish lookup fails',
+        (
+          tester,
+        ) async {
+          final l10n = lookupAppLocalizations(const Locale('en'));
+          await tester.pumpWidget(
+            buildSubject(
+              state: ConversationListState(
+                status: ConversationListStatus.loaded,
+                pinnedSupport: supportPin(
+                  isPersisted: true,
+                  lastMessageContent: 'We looked into your report',
+                ),
+              ),
+              additionalOverrides: [
+                profileVanishedSnapshotProvider(moderationPubkey).overrideWith(
+                  (ref) => Future<bool>.error(StateError('database closed')),
+                ),
+              ],
+            ),
+          );
+          await openMessages(tester);
+
+          await tester.longPress(find.text(l10n.inboxSupportRowTitle));
+          await tester.pumpAndSettle();
+
+          expect(
+            find.text(l10n.inboxActionReport(l10n.inboxSupportRowTitle)),
+            findsOneWidget,
+          );
+          expect(
+            find.text(l10n.inboxActionBlock(l10n.inboxSupportRowTitle)),
+            findsOneWidget,
+          );
+        },
+      );
+
+      testWidgets(
         "survives a search that matches the adopted pin's last message",
         (tester) async {
           final l10n = lookupAppLocalizations(const Locale('en'));
@@ -2591,10 +2596,7 @@ void main() {
         await longPressAndReport(tester);
 
         final l10n = lookupAppLocalizations(const Locale('en'));
-        expect(
-          find.text(l10n.reportNotSent),
-          findsOneWidget,
-        );
+        expect(find.text(l10n.reportNotSent), findsOneWidget);
         // Silence is the regression, so the confirmation must not render.
         expect(
           find.text(

--- a/mobile/test/screens/inbox/message_requests/request_preview_view_test.dart
+++ b/mobile/test/screens/inbox/message_requests/request_preview_view_test.dart
@@ -255,6 +255,77 @@ void main() {
       });
     });
 
+    // #8185. The same screen links straight through to the profile, which
+    // already names a vanished account for the state — so this row rendering
+    // a generated handle put both names one tap apart.
+    group('deleted accounts', () {
+      Widget buildVanishedSubject({required bool vanished}) {
+        when(() => mockPreviewCubit.state).thenReturn(
+          const RequestPreviewState(
+            status: RequestPreviewStatus.loaded,
+            messageCount: 1,
+            participantPubkeys: [otherPubkey],
+          ),
+        );
+
+        return testMaterialApp(
+          mockAuthService: mockAuthService,
+          mockNostrService: mockNostrClient,
+          additionalOverrides: [
+            goRouterProvider.overrideWithValue(mockGoRouter),
+            videosRepositoryProvider.overrideWithValue(mockVideosRepository),
+            userProfileReactiveProvider(
+              otherPubkey,
+            ).overrideWith((ref) => Stream.value(testProfile)),
+            profileVanishedProvider(
+              otherPubkey,
+            ).overrideWith((ref) => Stream.value(vanished)),
+          ],
+          home: MockGoRouterProvider(
+            goRouter: mockGoRouter,
+            child: MultiBlocProvider(
+              providers: [
+                BlocProvider<RequestPreviewCubit>.value(
+                  value: mockPreviewCubit,
+                ),
+                BlocProvider<MessageRequestActionsCubit>.value(
+                  value: mockActionsCubit,
+                ),
+                BlocProvider<CollaboratorInviteActionsCubit>.value(
+                  value: mockInviteActionsCubit,
+                ),
+              ],
+              child: const RequestPreviewView(),
+            ),
+          ),
+        );
+      }
+
+      testWidgets('names a vanished sender for the state everywhere', (
+        tester,
+      ) async {
+        await tester.pumpWidget(buildVanishedSubject(vanished: true));
+        await tester.pumpAndSettle();
+
+        // Header, the name under the avatar, the "wants to message you"
+        // sentence and the decline confirmation all read the same name.
+        expect(find.text(l10n.profileDeletedAccountName), findsWidgets);
+        expect(
+          find.textContaining(UserProfile.defaultDisplayNameFor(otherPubkey)),
+          findsNothing,
+        );
+        expect(find.textContaining('TestUser'), findsNothing);
+      });
+
+      testWidgets('leaves a live sender untouched', (tester) async {
+        await tester.pumpWidget(buildVanishedSubject(vanished: false));
+        await tester.pumpAndSettle();
+
+        expect(find.text('TestUser'), findsWidgets);
+        expect(find.text(l10n.profileDeletedAccountName), findsNothing);
+      });
+    });
+
     group('renders', () {
       testWidgets('renders app bar with display name as title', (tester) async {
         await tester.pumpWidget(buildSubject());

--- a/mobile/test/screens/inbox/message_requests/widgets/request_tile_test.dart
+++ b/mobile/test/screens/inbox/message_requests/widgets/request_tile_test.dart
@@ -23,10 +23,11 @@ void main() {
   final now = DateTime.now();
   final nowUnix = now.millisecondsSinceEpoch ~/ 1000;
 
-  UserProfile createTestProfile({String? displayName}) {
+  UserProfile createTestProfile({String? displayName, String? picture}) {
     return UserProfile(
       pubkey: otherPubkey,
       displayName: displayName,
+      picture: picture,
       rawData: const {},
       createdAt: now,
       eventId:
@@ -275,12 +276,15 @@ void main() {
       Future<void> pumpTile(
         WidgetTester tester, {
         required bool vanished,
+        String? picture,
       }) async {
         await tester.pumpWidget(
           testMaterialApp(
             additionalOverrides: [
               userProfileReactiveProvider(otherPubkey).overrideWith(
-                (ref) => Stream.value(createTestProfile(displayName: 'Alice')),
+                (ref) => Stream.value(
+                  createTestProfile(displayName: 'Alice', picture: picture),
+                ),
               ),
               profileVanishedProvider(
                 otherPubkey,
@@ -301,7 +305,11 @@ void main() {
       testWidgets('names a vanished requester for the state, not a handle', (
         tester,
       ) async {
-        await pumpTile(tester, vanished: true);
+        await pumpTile(
+          tester,
+          vanished: true,
+          picture: 'https://example.com/alice.jpg',
+        );
 
         final l10n = lookupAppLocalizations(const Locale('en'));
         expect(find.text(l10n.profileDeletedAccountName), findsOneWidget);
@@ -312,6 +320,10 @@ void main() {
           findsNothing,
         );
         expect(find.text('Alice'), findsNothing);
+        expect(
+          tester.widget<UserAvatar>(find.byType(UserAvatar)).imageUrl,
+          isNull,
+        );
       });
 
       testWidgets('reads the deleted-account copy from l10n', (tester) async {

--- a/mobile/test/screens/inbox/message_requests/widgets/request_tile_test.dart
+++ b/mobile/test/screens/inbox/message_requests/widgets/request_tile_test.dart
@@ -200,10 +200,7 @@ void main() {
     group('moderation identity', () {
       final l10n = lookupAppLocalizations(const Locale('en'));
 
-      Future<void> pumpTileFor(
-        WidgetTester tester,
-        String counterparty,
-      ) async {
+      Future<void> pumpTileFor(WidgetTester tester, String counterparty) async {
         await tester.pumpWidget(
           testMaterialApp(
             additionalOverrides: [
@@ -277,9 +274,11 @@ void main() {
         WidgetTester tester, {
         required bool vanished,
         String? picture,
+        Locale? locale,
       }) async {
         await tester.pumpWidget(
           testMaterialApp(
+            locale: locale,
             additionalOverrides: [
               userProfileReactiveProvider(otherPubkey).overrideWith(
                 (ref) => Stream.value(
@@ -327,10 +326,10 @@ void main() {
       });
 
       testWidgets('reads the deleted-account copy from l10n', (tester) async {
-        await pumpTile(tester, vanished: true);
+        await pumpTile(tester, vanished: true, locale: const Locale('de'));
 
         final de = lookupAppLocalizations(const Locale('de'));
-        expect(find.text(de.profileDeletedAccountName), findsNothing);
+        expect(find.text(de.profileDeletedAccountName), findsOneWidget);
       });
 
       testWidgets('leaves a live requester untouched', (tester) async {

--- a/mobile/test/screens/inbox/message_requests/widgets/request_tile_test.dart
+++ b/mobile/test/screens/inbox/message_requests/widgets/request_tile_test.dart
@@ -270,5 +270,64 @@ void main() {
         expect(wordmarkFinder(), findsNothing);
       });
     });
+
+    group('deleted accounts', () {
+      Future<void> pumpTile(
+        WidgetTester tester, {
+        required bool vanished,
+      }) async {
+        await tester.pumpWidget(
+          testMaterialApp(
+            additionalOverrides: [
+              userProfileReactiveProvider(otherPubkey).overrideWith(
+                (ref) => Stream.value(createTestProfile(displayName: 'Alice')),
+              ),
+              profileVanishedProvider(
+                otherPubkey,
+              ).overrideWith((ref) => Stream.value(vanished)),
+            ],
+            home: Scaffold(
+              body: RequestTile(
+                conversation: createTestConversation(),
+                currentUserPubkey: currentPubkey,
+                onTap: () {},
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+      }
+
+      testWidgets('names a vanished requester for the state, not a handle', (
+        tester,
+      ) async {
+        await pumpTile(tester, vanished: true);
+
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        expect(find.text(l10n.profileDeletedAccountName), findsOneWidget);
+        // The vanish evicts the cached profile, so without the check this row
+        // renders a generated "Adjective Animal N" the viewer has never seen.
+        expect(
+          find.text(UserProfile.defaultDisplayNameFor(otherPubkey)),
+          findsNothing,
+        );
+        expect(find.text('Alice'), findsNothing);
+      });
+
+      testWidgets('reads the deleted-account copy from l10n', (tester) async {
+        await pumpTile(tester, vanished: true);
+
+        final de = lookupAppLocalizations(const Locale('de'));
+        expect(find.text(de.profileDeletedAccountName), findsNothing);
+      });
+
+      testWidgets('leaves a live requester untouched', (tester) async {
+        await pumpTile(tester, vanished: false);
+
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        expect(find.text('Alice'), findsOneWidget);
+        expect(find.text(l10n.profileDeletedAccountName), findsNothing);
+      });
+    });
   });
 }

--- a/mobile/test/screens/inbox/widgets/conversation_actions_sheet_test.dart
+++ b/mobile/test/screens/inbox/widgets/conversation_actions_sheet_test.dart
@@ -14,6 +14,8 @@ void main() {
       required ValueChanged<ConversationAction?> onResult,
       bool isMuted = false,
       bool isBlocked = false,
+      String displayName = 'Alice',
+      bool isVanished = false,
     }) {
       return testMaterialApp(
         home: Builder(
@@ -23,7 +25,8 @@ void main() {
                 onPressed: () async {
                   final result = await ConversationActionsSheet.show(
                     context,
-                    displayName: 'Alice',
+                    displayName: displayName,
+                    isVanished: isVanished,
                     isMuted: isMuted,
                     isBlocked: isBlocked,
                   );
@@ -60,6 +63,26 @@ void main() {
 
         expect(find.text('Unblock Alice'), findsOneWidget);
         expect(find.text('Block Alice'), findsNothing);
+      });
+
+      testWidgets('keeps safety actions with identity-neutral vanished copy', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          buildSubject(
+            onResult: (_) {},
+            displayName: 'Deleted account',
+            isVanished: true,
+          ),
+        );
+
+        await tester.tap(find.text('Show sheet'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Report this account'), findsOneWidget);
+        expect(find.text('Block this account'), findsOneWidget);
+        expect(find.text('Report Deleted account'), findsNothing);
+        expect(find.text('Block Deleted account'), findsNothing);
       });
 
       testWidgets('renders $SwitchListTile for mute toggle', (tester) async {

--- a/mobile/test/screens/inbox/widgets/conversation_tile_test.dart
+++ b/mobile/test/screens/inbox/widgets/conversation_tile_test.dart
@@ -1063,9 +1063,11 @@ void main() {
       Future<void> pumpTile(
         WidgetTester tester, {
         required bool vanished,
+        Locale? locale,
       }) async {
         await tester.pumpWidget(
           testMaterialApp(
+            locale: locale,
             additionalOverrides: [
               fetchUserProfileProvider(otherPubkey).overrideWith(
                 (ref) async => createTestProfile(displayName: 'meylis.divine'),
@@ -1100,11 +1102,13 @@ void main() {
       });
 
       testWidgets('reads the deleted-account copy from l10n', (tester) async {
-        await pumpTile(tester, vanished: true);
+        // Pump in German and require the German string. Asserting the German
+        // copy is *absent* from an English pump passes whether or not the
+        // widget reads l10n, so it proved nothing.
+        await pumpTile(tester, vanished: true, locale: const Locale('de'));
 
-        // Proves the widget resolves the string rather than hardcoding it.
         final de = lookupAppLocalizations(const Locale('de'));
-        expect(find.text(de.profileDeletedAccountName), findsNothing);
+        expect(find.text(de.profileDeletedAccountName), findsOneWidget);
       });
 
       testWidgets('drops the avatar for a deleted account', (tester) async {

--- a/mobile/test/screens/inbox/widgets/dm_peer_identity_test.dart
+++ b/mobile/test/screens/inbox/widgets/dm_peer_identity_test.dart
@@ -1,0 +1,136 @@
+// ABOUTME: Tests the shared DM peer identity resolution order.
+// ABOUTME: Pins vanished, override, moderation, profile, and fallback branches.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart';
+import 'package:openvine/config/official_accounts.dart';
+import 'package:openvine/screens/inbox/widgets/dm_peer_identity.dart';
+
+import '../../../helpers/test_provider_overrides.dart';
+
+void main() {
+  const pubkey =
+      'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+  Widget buildSubject(String Function(BuildContext context) resolve) {
+    return testMaterialApp(
+      home: Builder(
+        builder: (context) => Text(resolve(context)),
+      ),
+    );
+  }
+
+  group('dmPeerDisplayName', () {
+    testWidgets('vanished state wins over every identity branch', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        buildSubject(
+          (context) => dmPeerDisplayName(
+            context,
+            pubkeyHex: kModerationPubkeyHex,
+            isVanished: true,
+            displayNameOverride: 'Override',
+            profile: _profile(kModerationPubkeyHex, 'Profile'),
+          ),
+        ),
+      );
+
+      expect(find.text('Deleted account'), findsOneWidget);
+    });
+
+    testWidgets('override wins over moderation and profile', (tester) async {
+      await tester.pumpWidget(
+        buildSubject(
+          (context) => dmPeerDisplayName(
+            context,
+            pubkeyHex: kModerationPubkeyHex,
+            isVanished: false,
+            displayNameOverride: 'Override',
+            profile: _profile(kModerationPubkeyHex, 'Profile'),
+          ),
+        ),
+      );
+
+      expect(find.text('Override'), findsOneWidget);
+    });
+
+    testWidgets('moderation wins over profile', (tester) async {
+      await tester.pumpWidget(
+        buildSubject(
+          (context) => dmPeerDisplayName(
+            context,
+            pubkeyHex: kModerationPubkeyHex,
+            isVanished: false,
+            profile: _profile(kModerationPubkeyHex, 'Profile'),
+          ),
+        ),
+      );
+
+      expect(find.text('Divine Moderation'), findsOneWidget);
+    });
+
+    testWidgets('profile wins over generated fallback', (tester) async {
+      await tester.pumpWidget(
+        buildSubject(
+          (context) => dmPeerDisplayName(
+            context,
+            pubkeyHex: pubkey,
+            isVanished: false,
+            profile: _profile(pubkey, 'Profile'),
+          ),
+        ),
+      );
+
+      expect(find.text('Profile'), findsOneWidget);
+    });
+
+    testWidgets('generates a name when no identity is available', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        buildSubject(
+          (context) => dmPeerDisplayName(
+            context,
+            pubkeyHex: pubkey,
+            isVanished: false,
+          ),
+        ),
+      );
+
+      expect(
+        find.text(UserProfile.defaultDisplayNameFor(pubkey)),
+        findsOneWidget,
+      );
+    });
+  });
+
+  group('dmPeerNameWithoutProfile', () {
+    testWidgets('returns null when a profile lookup is still needed', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        buildSubject(
+          (context) =>
+              dmPeerNameWithoutProfile(
+                context,
+                pubkeyHex: pubkey,
+                isVanished: false,
+              ) ??
+              'lookup required',
+        ),
+      );
+
+      expect(find.text('lookup required'), findsOneWidget);
+    });
+  });
+}
+
+UserProfile _profile(String pubkey, String displayName) => UserProfile(
+  pubkey: pubkey,
+  displayName: displayName,
+  rawData: const {},
+  createdAt: DateTime(2026),
+  eventId: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+);

--- a/mobile/test/screens/inbox/widgets/following_bar_test.dart
+++ b/mobile/test/screens/inbox/widgets/following_bar_test.dart
@@ -52,6 +52,7 @@ void main() {
       required MyFollowingState state,
       List<dynamic> additionalOverrides = const [],
       ValueChanged<String>? onUserTapped,
+      Locale? locale,
     }) {
       whenListen(
         mockFollowingBloc,
@@ -60,6 +61,7 @@ void main() {
       );
 
       return testMaterialApp(
+        locale: locale,
         additionalOverrides: additionalOverrides,
         home: BlocProvider<MyFollowingBloc>.value(
           value: mockFollowingBloc,
@@ -159,9 +161,11 @@ void main() {
       Future<void> pumpBar(
         WidgetTester tester, {
         required bool vanished,
+        Locale? locale,
       }) async {
         await tester.pumpWidget(
           buildSubject(
+            locale: locale,
             state: const MyFollowingState(
               status: MyFollowingStatus.success,
               followingPubkeys: [pubkey1],
@@ -193,10 +197,13 @@ void main() {
       });
 
       testWidgets('resolves the copy from l10n', (tester) async {
-        await pumpBar(tester, vanished: true);
+        // Pump in German and require the German string. Asserting the German
+        // copy is *absent* from an English pump passes whether or not the
+        // widget reads l10n, so it proved nothing.
+        await pumpBar(tester, vanished: true, locale: const Locale('de'));
 
         final de = lookupAppLocalizations(const Locale('de'));
-        expect(find.text(de.profileDeletedAccountName), findsNothing);
+        expect(find.text(de.profileDeletedAccountName), findsOneWidget);
       });
 
       testWidgets('leaves a live account untouched', (tester) async {


### PR DESCRIPTION
## What

Fixes inconsistent identity rendering for peers who have published a NIP-62 vanish request. DM surfaces now share one vanished-first resolver:

1. vanished account
2. display-name override
3. moderation account
4. profile name
5. generated fallback

This removes fabricated generated names from conversation actions, request tiles, request previews, conversation headers, and following bars. Request surfaces also suppress vanished profile imagery and metadata.

The imperative long-press path reads the durable vanished row through a one-shot provider. If that lookup fails, the actions sheet still opens with the live-account fallback instead of silently dropping the safety gesture.

## Safety copy decision

Report and Block/Unblock remain available for vanished peers. These actions protect the current user even when the peer has removed their public profile state.

To avoid presenting “Deleted account” as a person-like name, vanished-peer actions and confirmations use the localized, identity-neutral reference **“this account”**:

- Report this account
- Block this account
- Unblock this account

This is the explicit owner decision for #8185.

## Verification on a physical device

Worth keeping in the merged history, because CI could not find this bug and twice went green on a broken fix.

Reproduced on an iPhone (iOS 26.6.1) against staging with a real NIP-62 event: a throwaway peer published kind 0 `"Vanish Patrol Peer"`, sent a NIP-17 gift-wrapped DM, then published kind 62 with `["relay","ALL_RELAYS"]`. Staging flipped to `has_vanish_request: true` with `profile: null`. At that moment, on the same pubkey:

| Surface | Before | After |
|---|---|---|
| `OtherProfileScreen` | Deleted account | Deleted account |
| `RequestTile` | Subjective Ostrich 38 | Deleted account |
| `RequestPreviewView` | "Subjective Ostrich 38 wants to message you" | "Deleted account wants to message you" |
| `ConversationActionsSheet` | Block **Subjective Ostrich 38** | Block **this account** |

Before the vanish that request tile read "Vanish Patrol Peer" — so the vanish replaced a real name with a fabricated one rather than leaving a stale one. `_applyVanish` evicts the cached profile and both `fetchFreshProfile` and `fetchBatchProfiles` then short-circuit the pubkey to null, so the event that turns the label on is the event that guarantees an unchecked surface renders a generated pseudonym.

Two provider traps were measured on that device and are the reason the imperative path reads durable storage rather than the reactive provider:

| Read | Behaviour |
|---|---|
| `ref.read(profileVanishedProvider(pk))` | cold read is `AsyncLoading` → `orElse: false` reports a vanished peer as live |
| `await ref.read(profileVanishedProvider(pk).future)` | never completes — the read does not keep the autoDispose provider alive, so it is disposed before `Stream.value` delivers. The sheet stopped opening at all |

Both variants passed the full widget suite and all 19 checks. That is what `profileVanishedSnapshotProvider` and its cold-provider regression exist to prevent.

## Testing

- Direct unit coverage for all `dmPeerDisplayName` branches
- Cold durable-provider regression that holds the DAO future in flight across auto-dispose
- Widget coverage for vanished names, avatar/profile suppression, German localization, neutral safety-action copy, confirmations, and database-failure fallback
- `flutter test test/providers/user_profile_providers_test.dart test/screens/inbox/ test/l10n/arb_consistency_test.dart` — 503 passed
- Pre-push changed-file suite — 260 passed
- `flutter analyze lib test integration_test` — no issues
- Generated-file and affected architecture/design/localization/logging ratchets — pass

## Follow-ups

The adjacent deferred surfaces are now tracked rather than left only in PR history:

- #8204 — make vanished DM conversations searchable by their visible identity
- #8205 — name vanished accounts consistently in reaction details

Fixes #8185

