### PR TITLE
fix(dm): name a vanished reactor for the state, not a handle

### DIFF
--- a/mobile/lib/screens/inbox/conversation/widgets/reactions_detail_sheet.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/reactions_detail_sheet.dart
@@ -11,6 +11,7 @@ import 'package:models/models.dart';
 import 'package:openvine/blocs/dm/reactions/conversation_reactions_cubit.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
+import 'package:openvine/screens/inbox/widgets/dm_peer_identity.dart';
 import 'package:openvine/widgets/user_avatar.dart';
 
 /// Modal sheet listing every reactor on a DM message.
@@ -142,9 +143,22 @@ class _ReactorRow extends ConsumerWidget {
       userProfileReactiveProvider(reaction.reactorPubkey),
     );
     final profile = profileAsync.asData?.value;
-    final name =
-        profile?.bestDisplayName ??
-        UserProfile.defaultDisplayNameFor(reaction.reactorPubkey);
+
+    // A reactor is a DM peer, so it resolves through the same chain as the
+    // conversation header and the inbox row — otherwise the one sheet a
+    // "Deleted account" thread can open names its reactors a different way.
+    // In a group thread the reactor need not be the counterparty at all, so
+    // this is the only DM surface that can name a third participant.
+    final isVanished = ref
+        .watch(profileVanishedProvider(reaction.reactorPubkey))
+        .maybeWhen(data: (vanished) => vanished, orElse: () => false);
+
+    final name = dmPeerDisplayName(
+      context,
+      pubkeyHex: reaction.reactorPubkey,
+      isVanished: isVanished,
+      profile: profile,
+    );
 
     final isFailed = reaction.publishStatus == DmReactionPublishStatus.failed;
     final isPending = reaction.publishStatus == DmReactionPublishStatus.pending;
@@ -173,7 +187,9 @@ class _ReactorRow extends ConsumerWidget {
           // also circular. Wrapping the rounded-square UserAvatar in ClipOval
           // would slice its border into arcs (the "cut border" artifact).
           leading: UserAvatar(
-            imageUrl: profile?.picture,
+            // `watchProfile` is an ungated `select(userProfiles)`, so a row
+            // that outlived its tombstone still streams a picture here.
+            imageUrl: isVanished ? null : profile?.picture,
             name: name,
             size: _avatarSize,
             cornerRadius: _avatarSize / 2,

--- a/mobile/lib/screens/inbox/conversation/widgets/reactions_row.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/reactions_row.dart
@@ -407,6 +407,13 @@ class _PillAvatar extends ConsumerWidget {
         .asData
         ?.value;
 
+    // The pill is what opens the reactor sheet, so it resolves the vanish the
+    // same way: a peer whose photo is still on the pill and whose sheet row
+    // reads "Deleted account" is the divergence this pill would introduce.
+    final isVanished = ref
+        .watch(profileVanishedProvider(pubkey))
+        .maybeWhen(data: (vanished) => vanished, orElse: () => false);
+
     // cornerRadius == diameter / 2 makes UserAvatar a true circle whose own
     // border is circular too. Clipping the default rounded-square avatar to a
     // circle would slice that border into arcs (the "cut border" artifact) —
@@ -417,8 +424,12 @@ class _PillAvatar extends ConsumerWidget {
         border: Border.all(color: context.vineColors.primaryText, width: 1.5),
       ),
       child: UserAvatar(
-        imageUrl: profile?.picture,
-        name: profile?.bestDisplayName,
+        imageUrl: isVanished ? null : profile?.picture,
+        // The initial is derived from the name, so a stale row would leak the
+        // account's first letter even with the picture suppressed.
+        name: isVanished
+            ? context.l10n.profileDeletedAccountName
+            : profile?.bestDisplayName,
         size: _diameter,
         cornerRadius: _diameter / 2,
       ),

--- a/mobile/test/screens/inbox/conversation/widgets/reactions_detail_sheet_test.dart
+++ b/mobile/test/screens/inbox/conversation/widgets/reactions_detail_sheet_test.dart
@@ -11,6 +11,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/dm/reactions/conversation_reactions_cubit.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/screens/inbox/conversation/widgets/reactions_detail_sheet.dart';
 import 'package:openvine/widgets/user_avatar.dart';
 
@@ -52,8 +53,14 @@ void main() {
     );
   }
 
-  Widget host(_MockConversationReactionsCubit cubit) {
+  Widget host(
+    _MockConversationReactionsCubit cubit, {
+    List<dynamic> additionalOverrides = const <dynamic>[],
+    Locale? locale,
+  }) {
     return testMaterialApp(
+      additionalOverrides: additionalOverrides,
+      locale: locale,
       home: Scaffold(
         body: Builder(
           builder: (context) => Center(
@@ -324,6 +331,131 @@ void main() {
       );
 
       semantics.dispose();
+    });
+
+    group('deleted accounts', () {
+      const picture = 'https://example.com/alice.jpg';
+
+      UserProfile aliceProfile() => UserProfile(
+        pubkey: otherPubkey,
+        displayName: 'Alice',
+        picture: picture,
+        rawData: const {},
+        createdAt: DateTime(2026),
+        eventId:
+            'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd',
+      );
+
+      Future<void> openWith(
+        WidgetTester tester, {
+        required bool vanished,
+        Locale? locale,
+      }) async {
+        primeState([
+          makeReaction(
+            id: 'other1',
+            reactorPubkey: otherPubkey,
+            emoji: '😂',
+            publishStatus: DmReactionPublishStatus.received,
+          ),
+        ]);
+
+        await tester.pumpWidget(
+          host(
+            cubit,
+            locale: locale,
+            additionalOverrides: [
+              // A profile row that outlived its vanish tombstone: `watchProfile`
+              // is an ungated `select(userProfiles)`, so the sheet sees it.
+              userProfileReactiveProvider(
+                otherPubkey,
+              ).overrideWith((ref) => Stream.value(aliceProfile())),
+              profileVanishedProvider(
+                otherPubkey,
+              ).overrideWith((ref) => Stream.value(vanished)),
+            ],
+          ),
+        );
+        await tester.pump();
+        await tester.tap(find.text('open'));
+        await tester.pumpAndSettle();
+      }
+
+      testWidgets('names a vanished reactor for the state, not a handle', (
+        tester,
+      ) async {
+        await openWith(tester, vanished: true);
+
+        expect(find.text(l10n.profileDeletedAccountName), findsOneWidget);
+        expect(find.text('Alice'), findsNothing);
+        // The vanish evicts the cached profile, so a sheet without the check
+        // does not fall back to the last known name — it falls all the way
+        // through to a generated "Adjective Animal N" the viewer never saw.
+        expect(
+          find.text(UserProfile.defaultDisplayNameFor(otherPubkey)),
+          findsNothing,
+        );
+      });
+
+      testWidgets("drops a vanished reactor's avatar", (tester) async {
+        await openWith(tester, vanished: true);
+
+        expect(
+          tester.widget<UserAvatar>(find.byType(UserAvatar)).imageUrl,
+          isNull,
+        );
+      });
+
+      testWidgets(
+        'names the vanished reactor for the state in the a11y label',
+        (
+          tester,
+        ) async {
+          await openWith(tester, vanished: true);
+
+          // The row's label is the only place the reactor's name reaches
+          // assistive tech, so it has to name the state too — a screen-reader
+          // user would otherwise hear the generated handle the sheet no longer
+          // shows.
+          // The row merges its label with the avatar's and the title's, so
+          // assert on the merged announcement rather than one node: every part
+          // of it has to name the state, and none of them may carry the
+          // identity the sheet stopped showing.
+          final announced = tester.semantics.find(find.byType(ListTile)).label;
+          expect(
+            announced,
+            contains(
+              l10n.dmReactionChipOtherA11yLabel(
+                l10n.profileDeletedAccountName,
+                '😂',
+              ),
+            ),
+          );
+          expect(announced, isNot(contains('Alice')));
+          expect(
+            announced,
+            isNot(contains(UserProfile.defaultDisplayNameFor(otherPubkey))),
+          );
+        },
+      );
+
+      testWidgets('reads the deleted-account copy from l10n', (tester) async {
+        await openWith(tester, vanished: true, locale: const Locale('de'));
+
+        final de = lookupAppLocalizations(const Locale('de'));
+        expect(find.text(de.profileDeletedAccountName), findsOneWidget);
+      });
+
+      testWidgets('leaves a live reactor untouched', (tester) async {
+        await openWith(tester, vanished: false);
+
+        expect(find.text('Alice'), findsOneWidget);
+        expect(find.text(l10n.profileDeletedAccountName), findsNothing);
+        expect(
+          tester.widget<UserAvatar>(find.byType(UserAvatar)).imageUrl,
+          picture,
+        );
+      });
     });
   });
 }

--- a/mobile/test/screens/inbox/conversation/widgets/reactions_row_test.dart
+++ b/mobile/test/screens/inbox/conversation/widgets/reactions_row_test.dart
@@ -12,6 +12,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/dm/reactions/conversation_reactions_cubit.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/screens/inbox/conversation/widgets/reactions_row.dart';
 import 'package:openvine/widgets/user_avatar.dart';
 
@@ -64,8 +65,10 @@ void main() {
   Widget buildSubject(
     _MockConversationReactionsCubit cubit, {
     Set<String> blockedPubkeys = const <String>{},
+    List<dynamic> additionalOverrides = const <dynamic>[],
   }) {
     return testMaterialApp(
+      additionalOverrides: additionalOverrides,
       home: Scaffold(
         body: BlocProvider<ConversationReactionsCubit>.value(
           value: cubit,
@@ -472,6 +475,74 @@ void main() {
         expect(_emojiScale(tester, '🔥'), closeTo(1, 0.01));
       },
     );
+
+    group('deleted accounts', () {
+      const picture = 'https://example.com/alice.jpg';
+
+      Future<void> pumpPill(
+        WidgetTester tester, {
+        required bool vanished,
+      }) async {
+        primeState(
+          stateWith([
+            makeReaction(
+              id: 'other1',
+              reactorPubkey: otherPubkey,
+              emoji: '😂',
+              publishStatus: DmReactionPublishStatus.received,
+            ),
+          ]),
+        );
+
+        await tester.pumpWidget(
+          buildSubject(
+            cubit,
+            additionalOverrides: [
+              userProfileReactiveProvider(otherPubkey).overrideWith(
+                (ref) => Stream.value(
+                  UserProfile(
+                    pubkey: otherPubkey,
+                    displayName: 'Alice',
+                    picture: picture,
+                    rawData: const {},
+                    createdAt: DateTime(2026),
+                    eventId:
+                        'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd',
+                  ),
+                ),
+              ),
+              profileVanishedProvider(
+                otherPubkey,
+              ).overrideWith((ref) => Stream.value(vanished)),
+            ],
+          ),
+        );
+        await tester.pump();
+      }
+
+      testWidgets("drops a vanished reactor's picture and initial", (
+        tester,
+      ) async {
+        await pumpPill(tester, vanished: true);
+
+        // The pill is what opens the reactor sheet. Leaving the photo here
+        // would put the account's face directly above a row that reads
+        // "Deleted account".
+        final avatar = tester.widget<UserAvatar>(find.byType(UserAvatar));
+        expect(avatar.imageUrl, isNull);
+        // The placeholder initial comes from `name`, so a stale row would
+        // still leak the account's first letter with the photo suppressed.
+        expect(avatar.name, l10n.profileDeletedAccountName);
+      });
+
+      testWidgets('leaves a live reactor untouched', (tester) async {
+        await pumpPill(tester, vanished: false);
+
+        final avatar = tester.widget<UserAvatar>(find.byType(UserAvatar));
+        expect(avatar.imageUrl, picture);
+        expect(avatar.name, 'Alice');
+      });
+    });
   });
 }
 


### PR DESCRIPTION
## Summary

`ReactionsDetailSheet` resolved each reactor straight through `userProfileReactiveProvider`, with no NIP-62 branch — so the one sheet a "Deleted account" thread can open named its reactors a different way than the thread around it. Fixes #8205, the surface deliberately deferred from #8185 / PR #8196.

The divergence is not a stale label. `ProfileRepository._applyVanish` calls `deleteCachedProfile`, so the event that turns the "Deleted account" treatment on is the same event that guarantees an unchecked surface falls all the way through to `UserProfile.defaultDisplayNameFor` — a generated "Adjective Animal N" the viewer has never seen. A vanish **replaces** a real name with a fabricated one.

Both surfaces now route through the `dmPeerDisplayName` resolver #8196 lifted out for exactly this, so a reactor resolves in the same order as the conversation header and the inbox row.

## Also fixed: the pill that opens the sheet

`_PillAvatar` in `reactions_row.dart` had the identical defect. Fixing only the sheet would have left the vanished account's photo on the pill directly above a row reading "Deleted account" — recreating the inconsistency this issue is about, one layer up. It is the same defect in the same feature, so it is in the same PR rather than a follow-up.

The complete inventory of reactor-identity render sites is three: the sheet row, the pill avatar, and `mobile/lib/widgets/video_feed_item/reel_dm_reply_bar.dart` (a different tree — it is not a sibling of the other two) — which only ever matches `ownerPubkey` (self) and renders no other reactor's identity, so it is unaffected.

## Why the avatar needs its own branch

`watchProfile` is an ungated `select(userProfiles)` (`mobile/packages/db_client/lib/src/database/daos/user_profiles_dao.dart:174-180`) — no tombstone join. The `upsertProfile` guard prevents a vanished row being **re-created**, but does nothing about one that was never deleted, and `_applyVanish` commits `markVanished` (`mobile/packages/profile_repository/lib/src/profile_repository.dart:343`) *before* `deleteCachedProfile` (`:344`). Those are two separate Drift streams, so a row can outlive its tombstone:

- **transiently**, between the two awaits — `_vanishedProfilePubkeysProvider` flips on the first while `watchProfile` still holds the row;
- **durably**, if the process dies between them — nothing re-runs the eviction, because `fetchFreshProfile` (`:770-773`) and `fetchBatchProfiles` (`:2470-2474`) both short-circuit a pubkey already in `_vanished`.

`ConversationTile` already suppresses the picture for this reason (`mobile/lib/screens/inbox/widgets/conversation_tile.dart:86-91`); the sheet now mirrors it. The pill suppresses the name as well, because its placeholder initial is derived from it.

## Group threads

In a group thread the reactor need not be the counterparty, so this is the only DM surface that can name a **third** participant. The reaction is the viewer's own gift-wrapped copy and survives the vanish that erases its author's kind 0 — which is why the row is still there to be misnamed.

## Verified end to end against the local stack

`local_stack` funnelcake subset (relay + API + ClickHouse + Redis), relay advertising NIP-62. Same throwaway pubkey throughout:

| Step | Result |
|---|---|
| kind 0 published | `GET /api/users/{pk}` → `has_vanish_request: false`, profile with `name` + `picture` |
| public kind 7 published | present on the relay |
| kind 62 `["relay","ALL_RELAYS"]` | published, accepted |
| `GET /api/users/{pk}` | **`has_vanish_request: true`, `profile: null`** |
| kind 0 on relay (REQ) | gone |
| public kind 7 on relay (REQ) | gone |
| `POST /api/users/bulk` | `{"users":[],"missing":[]}` — in neither array |

To be precise about that "gone": nothing was physically deleted in those five seconds. The janitor is a deferred CronJob (`relay.rs:3102-3105`); what I observed is the **REQ read filter**, whose set is populated synchronously on ingest (`relay.rs:3034`). That filter is kind-blind (`event_queries.rs:2171-2191` adds `pubkey NOT IN vanished_pubkeys_set` to every query with no kind clause), which is why the kind 7 vanished alongside the kind 0 — incidental, not reaction-specific handling.

That `true` + `null` pair is exactly what `FunnelcakeApiClient` maps to `UserProfileVanished` (`mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart:2081-2083`), which `_fetchFreshProfile` turns into `_applyVanish` (`mobile/packages/profile_repository/lib/src/profile_repository.dart:854-857`), which writes the durable tombstone the sheet now reads. The chain from protocol event to rendered label is closed.

Three things that measurement settled rather than assumed:

- A vanished author's **public** kind 7 stops being served alongside their kind 0, so a public reaction from a vanished account disappears outright. This defect is specific to **DM** reactions, which live in the viewer's local Drift copy via gift wrap and cannot be retracted by the counterparty — which is why the row is still there to be misnamed.
- The bulk endpoint omits a vanished pubkey from `users` **and** `missing`, so the batch path can never trigger `_applyVanish`. Only the singular fetch can. The tombstone is durable, so `profileVanishedProvider` still answers on a later launch.
- **The state this PR fixes is the steady state, not a window.** `has_vanish_request` reads the permanent `vanish_requests` table and never filters on `deletion_status` (`vanish.rs:166-177`), while the sweep deletes `user_profiles_latest_data` with **no** `created_at` boundary (`vanish.rs:521-522`). So once the janitor completes, the pubkey leaves the pending-only read filter and its events are served again — with no kind 0 left to name them, and `has_vanish_request` still `true`. `true` + `null` is permanent, so an unfixed surface renders the fabricated handle indefinitely rather than briefly.

## Protocol basis

There is none, in either direction — and that is worth stating rather than leaving implied. Read at `nostr-protocol/nips@dabfcb2`: NIP-62 is 61 lines, entirely relay obligations, and never mentions kind 0, identity, or client rendering. NIP-25 identifies a reactor only by the event's own `.pubkey` and says nothing about displaying it. NIP-01's kind-0 stanza (`01.md:92`) specifies no fallback display name. NIP-17 names kind 7 as sendable in an encrypted chat (`17.md:11`) but defines no kind-7 rumor. A repo-wide grep for deleted-account phrasing or anonymization guidance returns nothing.

So both "Deleted account" and the generated "Adjective Animal N" are Divine product decisions. This PR does not introduce a new one — it makes the reaction surfaces obey the one already shipped in #8196.

## Test plan

Five new regression tests, all confirmed to **fail without the production change** and pass with it (production files stashed, suite re-run):

- sheet: names a vanished reactor for the state, not a handle
- sheet: drops a vanished reactor's avatar
- sheet: names the vanished reactor in the merged a11y announcement, and leaks neither the profile name nor the generated handle
- sheet: reads the deleted-account copy from l10n (pumped in `de`, asserting the German string is present)
- pill: drops a vanished reactor's picture **and** initial

Two more pin no-regression for a live reactor (name and picture both still rendered); those correctly stay green under the mutation, which is what makes them meaningful.

```
flutter test test/screens/inbox/          → 480 passed
flutter analyze lib/… test/…              → no issues
dart format                               → clean
13 CI ratchets (ungrouped, l10n delegates, orphaned ARB, post-close emit,
4 design-system ceilings, nostr-id truncation, pubkey encoding,
test/unit, untested services, layer direction) → all PASS
```

No ARB changes: both `profileDeletedAccountName` and `dmReactionChipOtherA11yLabel` already ship in all 22 locales.

## Deliberately not changed

The sheet's avatar keeps its name-derived placeholder tone rather than gaining `placeholderSeed`. Passing the seed would change the accent colour for **live** reactors with no picture, which this issue does not ask for — and a pubkey-seeded colour is itself a per-account identity signal, which is the opposite of what the acceptance criteria want for a vanished one.

The inbox search index (#8204) is still open and unaffected by this change.

**A pre-existing one-frame flash, measured and left alone.** `profileVanished` is a `@riverpod Stream<bool>` whose `Stream.value` delivers on a microtask, so the first build is always `AsyncLoading` and `orElse: false` renders the generated handle for exactly one frame before correcting. I measured it frame-by-frame on both the new sheet row **and** the already-shipped `ConversationTile`, and both flash identically on their very first build — so it is a property of the shared provider, not of this diff. Fixing it means changing that provider's shape, which would alter every vanished-account surface, including ones #8205 does not name. Filed as #8208 rather than widened into this PR.

Fixes #8205

