### PR TITLE
test(dm): cover the two DM decisions the blanket stubs hid

### DIFF
--- a/mobile/packages/dm_repository/test/src/dm_read_cursor_retry_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_read_cursor_retry_test.dart
@@ -1,0 +1,251 @@
+// ABOUTME: Regression coverage for the #4977 cross-device read-cursor retry —
+// ABOUTME: a marker arriving before its conversation row must be re-applied.
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:db_client/db_client.dart';
+import 'package:dm_repository/dm_repository.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:nostr_sdk/event_kind.dart';
+import 'package:nostr_sdk/signer/local_nostr_signer.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+const _owner =
+    'a4f5c1b2d3e4f5061728394a5b6c7d8e9f0a1b2c3d4e5f60718293a4b5c6d7e8';
+const _peer =
+    'b1c2d3e4f5061728394a5b6c7d8e9f0a1b2c3d4e5f60718293a4b5c6d7e8f9a0';
+const _privateKey =
+    '5426e5b8b4b0e2a1f5e8d3c7a9b2f4e6d8c0a2b4f6e8d0c2a4b6f8e0d2c4a6b8';
+
+const _readMarkerDTag = 'divine/dm-read/v1';
+const _baseCreatedAt = 1700000000;
+
+void main() {
+  // Drives the real ConversationsDao against a real database. The mock suite
+  // in dm_repository_test.dart stubs applyReadCursor to a constant `true` in
+  // its top-level setUp, so the `!applied` retry branch never executes there
+  // and _pendingReadCursors is always empty — a test written there would pass
+  // whether or not the retry works (#8170).
+  group(
+    'read-cursor retry for a marker that arrives before its conversation',
+    () {
+      late AppDatabase db;
+      late ConversationsDao conversationsDao;
+      late DirectMessagesDao messagesDao;
+      late _MockNostrClient nostrClient;
+      late StreamController<Event> relay;
+      late DmRepository repository;
+      late Map<String, Event> rumorByWrapId;
+      late DmSyncState syncState;
+
+      /// The conversation the marker names — deliberately not created yet.
+      final participants = [_owner, _peer]..sort();
+      late String conversationId;
+
+      setUp(() async {
+        SharedPreferences.setMockInitialValues(<String, Object>{});
+        syncState = DmSyncState(await SharedPreferences.getInstance());
+        db = AppDatabase.test(NativeDatabase.memory());
+        conversationsDao = ConversationsDao(db);
+        messagesDao = DirectMessagesDao(db);
+        nostrClient = _MockNostrClient();
+        relay = StreamController<Event>();
+        rumorByWrapId = <String, Event>{};
+        conversationId = DmRepository.computeConversationId(participants);
+
+        when(() => nostrClient.connectedRelayCount).thenReturn(1);
+        when(() => nostrClient.configuredRelayCount).thenReturn(1);
+        when(
+          () => nostrClient.queryEvents(
+            any(),
+            subscriptionId: any(named: 'subscriptionId'),
+            useCache: any(named: 'useCache'),
+          ),
+        ).thenAnswer((_) async => const <Event>[]);
+        when(() => nostrClient.unsubscribe(any())).thenAnswer((_) async {});
+        when(
+          () => nostrClient.subscribe(
+            any(),
+            subscriptionId: any(named: 'subscriptionId'),
+            tempRelays: any(named: 'tempRelays'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((_) => relay.stream);
+
+        repository = DmRepository(
+          nostrClient: nostrClient,
+          directMessagesDao: messagesDao,
+          conversationsDao: conversationsDao,
+          userPubkey: _owner,
+          syncState: syncState,
+          signer: LocalNostrSigner(_privateKey),
+          rumorDecryptor: (_, giftWrap) async => rumorByWrapId[giftWrap.id],
+          nip04Decryptor: (_, ciphertext) async => ciphertext,
+        );
+        await repository.startListening();
+      });
+
+      tearDown(() async {
+        await repository.stopListening();
+        await relay.close();
+        await db.close();
+      });
+
+      Future<void> settle() async {
+        for (var i = 0; i < 8; i++) {
+          await Future<void>.delayed(Duration.zero);
+        }
+      }
+
+      /// Feeds the owner's own kind-30078 read marker, naming [conversationId]
+      /// via its participant tuple and carrying [readAt] as the cursor.
+      Future<void> deliverReadMarker({
+        required String wrapId,
+        required String rumorId,
+        required int readAt,
+      }) async {
+        rumorByWrapId[wrapId] = Event.fromJson({
+          'id': rumorId,
+          'pubkey': _owner,
+          'created_at': _baseCreatedAt,
+          'kind': EventKind.appSpecificData,
+          'tags': [
+            ['d', _readMarkerDTag],
+            ['p', _owner],
+          ],
+          'content': jsonEncode({
+            'v': 1,
+            'read': {participants.join(','): readAt},
+          }),
+          'sig': '',
+        });
+        relay.add(
+          Event.fromJson({
+            'id': wrapId,
+            'pubkey': _owner,
+            'created_at': _baseCreatedAt,
+            'kind': EventKind.giftWrap,
+            'tags': [
+              ['p', _owner],
+            ],
+            'content': 'wrapped-$wrapId',
+            'sig': '',
+          }),
+        );
+        await settle();
+      }
+
+      /// Creates the conversation the marker named, with one unread inbound
+      /// message at [messageAt] — the row the marker was racing.
+      Future<void> ingestConversation({required int messageAt}) async {
+        final wrapId = 'e' * 64;
+        final rumorId = 'f' * 64;
+        rumorByWrapId[wrapId] = Event.fromJson({
+          'id': rumorId,
+          'pubkey': _peer,
+          'created_at': messageAt,
+          'kind': EventKind.privateDirectMessage,
+          'tags': [
+            ['p', _owner],
+          ],
+          'content': 'hello',
+          'sig': '',
+        });
+        relay.add(
+          Event.fromJson({
+            'id': wrapId,
+            'pubkey': _peer,
+            'created_at': messageAt,
+            'kind': EventKind.giftWrap,
+            'tags': [
+              ['p', _owner],
+            ],
+            'content': 'wrapped-$wrapId',
+            'sig': '',
+          }),
+        );
+        await settle();
+      }
+
+      Future<ConversationRow?> conversation() async {
+        final rows = await conversationsDao.getAllConversations(
+          ownerPubkey: _owner,
+        );
+        return rows.where((r) => r.id == conversationId).firstOrNull;
+      }
+
+      test(
+        'a marker landing before its conversation is retried after the drain',
+        () async {
+          // The marker names a conversation that does not exist yet, so
+          // applyReadCursor matches no row and returns false.
+          await deliverReadMarker(
+            wrapId: 'a' * 64,
+            rumorId: 'b' * 64,
+            readAt: _baseCreatedAt + 100,
+          );
+          expect(
+            await conversation(),
+            isNull,
+            reason:
+                'precondition: the marker must arrive before its row exists',
+          );
+
+          // The drain then ingests the conversation it was racing.
+          await ingestConversation(messageAt: _baseCreatedAt + 50);
+          final beforeRetry = await conversation();
+          expect(beforeRetry, isNotNull);
+          expect(
+            beforeRetry!.isRead,
+            isFalse,
+            reason: 'the dropped cursor has not been re-applied yet',
+          );
+
+          // backfillHistoryIfNeeded flushes the queued cursors (#4977).
+          await repository.backfillHistoryIfNeeded();
+          await settle();
+
+          final afterRetry = await conversation();
+          expect(
+            afterRetry!.lastReadTimestamp,
+            _baseCreatedAt + 100,
+            reason: 'the queued cursor must be re-applied, not discarded',
+          );
+          expect(
+            afterRetry.isRead,
+            isTrue,
+            reason: 'the cursor covers the latest message, so it reads as read',
+          );
+        },
+      );
+
+      test(
+        'a marker for an already-ingested conversation applies directly',
+        () async {
+          // Control: when the row exists, applyReadCursor returns true and
+          // the retry queue is never involved. Keeps the test above honest —
+          // it must fail for the retry, not because markers never work.
+          await ingestConversation(messageAt: _baseCreatedAt + 50);
+          expect(await conversation(), isNotNull);
+
+          await deliverReadMarker(
+            wrapId: 'c' * 64,
+            rumorId: 'd' * 64,
+            readAt: _baseCreatedAt + 100,
+          );
+
+          final row = await conversation();
+          expect(row!.lastReadTimestamp, _baseCreatedAt + 100);
+          expect(row.isRead, isTrue);
+        },
+      );
+    },
+  );
+}

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -173,6 +173,13 @@ class _InMemoryProcessedGiftWrapsDao extends Mock
   Future<bool> hasGiftWrap(String giftWrapId) async =>
       recorded.contains(giftWrapId);
 
+  /// The batch fast path probes this, not [hasGiftWrap]. Without a faithful
+  /// override it fell through to the `Mock` base and answered empty, so the
+  /// ledger half of `_alreadyProcessedBatch` was unobservable (#8170).
+  @override
+  Future<Set<String>> giftWrapIdsPresent(Set<String> giftWrapIds) async =>
+      giftWrapIds.intersection(recorded);
+
   @override
   Future<void> record({
     required String giftWrapId,
@@ -6637,6 +6644,101 @@ void main() {
           ).captured;
           expect(probed, isNotEmpty);
           expect(probed.first, equals({wrap1.id, wrap2.id}));
+        },
+      );
+
+      test(
+        'a wrap already in the processed-wrap ledger is not re-decrypted, '
+        'while its page-mate still persists (#5452)',
+        () async {
+          final alreadyProcessed = await _buildGiftWrap(
+            rumor: rumorFor('ledgered', createdAt: 1700000500),
+            senderPrivateKey: senderPriv,
+            recipientPubkey: recipientPub,
+            outerCreatedAt: 1700000000,
+          );
+          final fresh = await _buildGiftWrap(
+            rumor: rumorFor('fresh', createdAt: 1700000600),
+            senderPrivateKey: senderPriv,
+            recipientPubkey: recipientPub,
+            outerCreatedAt: 1700000001,
+          );
+          stubDrainPage([alreadyProcessed, fresh]);
+
+          // Only the ledger knows about the first wrap — the messages table
+          // does not. That is the split `_alreadyProcessedBatch` unions, and
+          // dropping its ledger half is invisible to every other test (#8170).
+          final ledger = _InMemoryProcessedGiftWrapsDao();
+          await ledger.record(
+            giftWrapId: alreadyProcessed.id,
+            ownerPubkey: recipientPub,
+          );
+
+          final repository = createRepository(
+            userPubkey: recipientPub,
+            signer: _IsolateLocalSigner(recipientPriv),
+            syncState: drainPending(),
+            processedGiftWrapsDao: ledger,
+          );
+
+          await repository.backfillHistoryIfNeeded();
+
+          // The page-mate proves the drain ran and decrypted normally.
+          verify(
+            () => mockDirectMessagesDao.insertMessage(
+              id: any(named: 'id'),
+              conversationId: any(named: 'conversationId'),
+              senderPubkey: senderPub,
+              content: 'fresh',
+              createdAt: 1700000600,
+              giftWrapId: fresh.id,
+              messageKind: any(named: 'messageKind'),
+              replyToId: any(named: 'replyToId'),
+              subject: any(named: 'subject'),
+              fileType: any(named: 'fileType'),
+              encryptionAlgorithm: any(named: 'encryptionAlgorithm'),
+              decryptionKey: any(named: 'decryptionKey'),
+              decryptionNonce: any(named: 'decryptionNonce'),
+              fileHash: any(named: 'fileHash'),
+              originalFileHash: any(named: 'originalFileHash'),
+              fileSize: any(named: 'fileSize'),
+              dimensions: any(named: 'dimensions'),
+              blurhash: any(named: 'blurhash'),
+              thumbnailUrl: any(named: 'thumbnailUrl'),
+              ownerPubkey: recipientPub,
+              tagsJson: any(named: 'tagsJson'),
+              sendBatchId: any(named: 'sendBatchId'),
+            ),
+          ).called(1);
+
+          // The ledgered one is skipped before any decrypt, so it never
+          // reaches an insert.
+          verifyNever(
+            () => mockDirectMessagesDao.insertMessage(
+              id: any(named: 'id'),
+              conversationId: any(named: 'conversationId'),
+              senderPubkey: any(named: 'senderPubkey'),
+              content: 'ledgered',
+              createdAt: any(named: 'createdAt'),
+              giftWrapId: any(named: 'giftWrapId'),
+              messageKind: any(named: 'messageKind'),
+              replyToId: any(named: 'replyToId'),
+              subject: any(named: 'subject'),
+              fileType: any(named: 'fileType'),
+              encryptionAlgorithm: any(named: 'encryptionAlgorithm'),
+              decryptionKey: any(named: 'decryptionKey'),
+              decryptionNonce: any(named: 'decryptionNonce'),
+              fileHash: any(named: 'fileHash'),
+              originalFileHash: any(named: 'originalFileHash'),
+              fileSize: any(named: 'fileSize'),
+              dimensions: any(named: 'dimensions'),
+              blurhash: any(named: 'blurhash'),
+              thumbnailUrl: any(named: 'thumbnailUrl'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+              tagsJson: any(named: 'tagsJson'),
+              sendBatchId: any(named: 'sendBatchId'),
+            ),
+          );
         },
       );
 


### PR DESCRIPTION
## What

Closes the two decisions #8170's audit found that no test anywhere could observe. Both were verified by mutation rather than by reading: each break below passed **676 `dm_repository` + 1,008 `db_client` tests** before this change, and turns the suite red now.

## Why these two

`dm_repository_test.dart` is 22k lines and its top-level `setUp` (499-673) stubs 14 DAO methods to constants for every test in the file. Most of that is fine — of 14 mutations run across the audit, 10 were caught. These two were not:

| Decision | Break that survived 1,684 tests |
|---|---|
| `applyReadCursor` -> constant `true` | invert `if (!applied)`; drop failed cursors instead of queueing; never drain the queue |
| ledger half of `_alreadyProcessedBatch` | remove `present.addAll(await ledger.giftWrapIdsPresent(...))` |

### 1. The read-cursor retry (#4977)

The real DAO returns `false` when **the conversation row does not exist yet** — precisely the ordering race `_pendingReadCursors` exists for, when a restored remote read-marker arrives before the history drain has created the row. Pinned to `true`, the `!applied` branch at `dm_repository.dart:6244` never executes, the queue is always empty, and the drain loop is dead code.

Left unguarded, the failing scenario is: on reinstall or a second device, a conversation whose read-marker lands before its row stays unread forever — the cursor is dropped, never retried, and the badge never self-heals.

The new file drives the real `ConversationsDao` against a real database, in a separate file so it cannot inherit the blanket stub.

### 2. The processed-wrap ledger (#5452)

`_InMemoryProcessedGiftWrapsDao` overrode `hasGiftWrap` and `record` but **not `giftWrapIdsPresent`** — the method the batch fast path actually calls. It fell through to the `Mock` base and answered empty, so deleting the messages-table half of `_alreadyProcessedBatch` failed a test while deleting the ledger half passed everything.

This makes the fake faithful and adds a behavioural test: a wrap known only to the ledger is skipped before any decrypt, while its page-mate still persists. The union of the two indexes is what is asserted, rather than either half alone.

## One correction to the issue's suggested remedy

#8170 proposes "a faithful fake or a real-DAO test at the layer that actually decides". Necessary, but not sufficient — at `c5525ee82^` the DAO's own test file (real DAO, real database, right layer) contained `matches cross-protocol duplicates within the default 5s window`, whose fixture was two **same-protocol NIP-17** rows and which asserted `expect(duplicate, isTrue)`. It pinned bug #7324 as correct behaviour under a name describing something else, which is why #8169 had to split it rather than add to it.

So the rule that generalises is that a test must be able to fail *for the reason its name claims* — running against real infrastructure is not on its own enough. Both tests here carry a control alongside the assertion for exactly that reason.

## Testing

- `dm_repository`: 679 pass (was 676)
- `db_client`: 1,008 pass, unchanged
- `flutter analyze lib test` from inside the package: no issues
- Every mutation above re-run against both packages, before and after

Full audit, including the ten mutations that were already caught: https://github.com/divinevideo/divine-mobile/issues/8170#issuecomment-5439131479

Refs #8170
