### PR TITLE
fix(dm): stop a pre-April own-send row growing a duplicate bubble

### DIFF
--- a/mobile/packages/db_client/lib/src/database/daos/direct_messages_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/direct_messages_dao.dart
@@ -376,11 +376,14 @@ class DirectMessagesDao extends DatabaseAccessor<AppDatabase>
   /// `id` and the UNIQUE index on `gift_wrap_id` already make [insertMessage]
   /// a no-op for them.
   ///
-  /// A group send is the one self-authored case that needs
-  /// [DmDedupCounterpart.unconstrained]: its siblings carry distinct rumor
-  /// ids, so the primary key does not collapse their self-wrap echoes.
-  /// Prefer [hasMessageWithSendBatchId] there when the batch token is
-  /// available — it matches exactly instead of heuristically.
+  /// Two self-authored cases need [DmDedupCounterpart.unconstrained], because
+  /// both match the user's OWN persisted send rather than a cross-protocol
+  /// twin. A group send's siblings carry distinct rumor ids, so the primary
+  /// key does not collapse their self-wrap echoes — prefer
+  /// [hasMessageWithSendBatchId] there when the batch token is available,
+  /// since it matches exactly instead of heuristically. And the user's own
+  /// replayed NIP-04 fallback may match a send written before #2654, which
+  /// stored the gift-wrap id in both columns and so reads as NIP-04 (#8211).
   Future<bool> hasMatchingMessage({
     required String conversationId,
     required String senderPubkey,

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -2886,16 +2886,26 @@ class DmRepository {
       // window because the NIP-17 rumor and NIP-04 event may have slightly
       // different timestamps.
       //
-      // Only the NIP-17 copy may suppress this event. Another NIP-04 row with
-      // the same text is a genuine earlier message — the mirror of #7324 on
-      // this side of the dual-send.
+      // Only the NIP-17 copy may suppress a PEER's event. Another NIP-04 row
+      // with the same text is a genuine earlier message — the mirror of #7324
+      // on this side of the dual-send.
+      //
+      // Our own replayed kind-4 is the exception, and takes no arrival-shape
+      // filter. It matches the user's own persisted send rather than a
+      // cross-protocol twin, and that send may carry either shape: every
+      // NIP-17 send path before #2654 wrote the gift-wrap id into BOTH
+      // columns, so a row from that window reads as NIP-04 and would be
+      // missed by nip17Copy — inserting a second bubble for a message the
+      // user already sent (#8211).
       final isDuplicate = await _directMessagesDao.hasMatchingMessage(
         conversationId: conversationId,
         senderPubkey: senderPubkey,
         content: plaintext,
         createdAt: persistedCreatedAt,
         ownerPubkey: _userPubkey,
-        counterpart: DmDedupCounterpart.nip17Copy,
+        counterpart: isSentByMe
+            ? DmDedupCounterpart.unconstrained
+            : DmDedupCounterpart.nip17Copy,
       );
       if (isDuplicate) {
         Log.debug(

--- a/mobile/packages/dm_repository/test/src/dm_legacy_own_send_shape_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_legacy_own_send_shape_test.dart
@@ -1,0 +1,219 @@
+// ABOUTME: Regression coverage for #8211 — an own-send row written before
+// ABOUTME: #2654 carries the NIP-04 id shape and must not grow a duplicate.
+
+import 'dart:async';
+
+import 'package:db_client/db_client.dart';
+import 'package:dm_repository/dm_repository.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:nostr_sdk/event_kind.dart';
+import 'package:nostr_sdk/signer/local_nostr_signer.dart';
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+const _owner =
+    'a4f5c1b2d3e4f5061728394a5b6c7d8e9f0a1b2c3d4e5f60718293a4b5c6d7e8';
+const _peer =
+    'b1c2d3e4f5061728394a5b6c7d8e9f0a1b2c3d4e5f60718293a4b5c6d7e8f9a0';
+const _privateKey =
+    '5426e5b8b4b0e2a1f5e8d3c7a9b2f4e6d8c0a2b4f6e8d0c2a4b6f8e0d2c4a6b8';
+
+const _baseCreatedAt = 1700000000;
+
+void main() {
+  // Drives the real DirectMessagesDao against a real database. The
+  // mock suite stubs hasMatchingMessage to a constant in its top-level
+  // setUp, so a test written there cannot observe this at all (#8170).
+  group('an own-send row carrying the pre-#2654 id shape', () {
+    late AppDatabase db;
+    late ConversationsDao conversationsDao;
+    late DirectMessagesDao messagesDao;
+    late _MockNostrClient nostrClient;
+    late StreamController<Event> relay;
+    late DmRepository repository;
+
+    final participants = [_owner, _peer]..sort();
+    late String conversationId;
+
+    setUp(() async {
+      db = AppDatabase.test(NativeDatabase.memory());
+      conversationsDao = ConversationsDao(db);
+      messagesDao = DirectMessagesDao(db);
+      nostrClient = _MockNostrClient();
+      relay = StreamController<Event>();
+      conversationId = DmRepository.computeConversationId(participants);
+
+      when(() => nostrClient.connectedRelayCount).thenReturn(1);
+      when(() => nostrClient.configuredRelayCount).thenReturn(1);
+      when(
+        () => nostrClient.queryEvents(
+          any(),
+          subscriptionId: any(named: 'subscriptionId'),
+          useCache: any(named: 'useCache'),
+        ),
+      ).thenAnswer((_) async => const <Event>[]);
+      when(() => nostrClient.unsubscribe(any())).thenAnswer((_) async {});
+      when(
+        () => nostrClient.subscribe(
+          any(),
+          subscriptionId: any(named: 'subscriptionId'),
+          tempRelays: any(named: 'tempRelays'),
+          targetRelays: any(named: 'targetRelays'),
+        ),
+      ).thenAnswer((_) => relay.stream);
+
+      repository = DmRepository(
+        nostrClient: nostrClient,
+        directMessagesDao: messagesDao,
+        conversationsDao: conversationsDao,
+        userPubkey: _owner,
+        signer: LocalNostrSigner(_privateKey),
+        rumorDecryptor: (_, _) async => null,
+        nip04Decryptor: (_, ciphertext) async => ciphertext,
+      );
+      await repository.startListening();
+    });
+
+    tearDown(() async {
+      await repository.stopListening();
+      await relay.close();
+      await db.close();
+    });
+
+    Future<void> settle() async {
+      for (var i = 0; i < 8; i++) {
+        await Future<void>.delayed(Duration.zero);
+      }
+    }
+
+    /// Persists one own-send row. [legacyShape] reproduces every NIP-17 send
+    /// path before `d9846bb5d` (#2654, 2026-04-01), which wrote the gift-wrap
+    /// id into BOTH columns; the modern shape writes a distinct rumor id.
+    Future<void> persistOwnSend({
+      required String content,
+      required bool legacyShape,
+    }) async {
+      const wrapId =
+          'ffffffffffffffffffffffffffffffffffffffffffffffffffffffff'
+          'ffffffff';
+      await conversationsDao.upsertConversation(
+        id: conversationId,
+        participantPubkeys: participants.join(','),
+        isGroup: false,
+        createdAt: _baseCreatedAt,
+        lastMessageTimestamp: _baseCreatedAt,
+        ownerPubkey: _owner,
+      );
+      await messagesDao.insertMessage(
+        id: legacyShape ? wrapId : 'a' * 64,
+        conversationId: conversationId,
+        senderPubkey: _owner,
+        content: content,
+        createdAt: _baseCreatedAt,
+        giftWrapId: wrapId,
+        ownerPubkey: _owner,
+      );
+    }
+
+    /// Replays the user's own outgoing kind-4 fallback, the way the history
+    /// drain's `_recoverOutgoingNip04` does.
+    Future<void> replayOwnNip04({required String content}) async {
+      relay.add(
+        Event.fromJson({
+          'id': 'c' * 64,
+          'pubkey': _owner,
+          'created_at': _baseCreatedAt + 1,
+          'kind': EventKind.directMessage,
+          'tags': [
+            ['p', _peer],
+          ],
+          'content': content,
+          'sig': '',
+        }),
+      );
+      await settle();
+    }
+
+    Future<int> storedCount() async {
+      final rows = await messagesDao.getMessagesForConversation(
+        conversationId,
+        ownerPubkey: _owner,
+      );
+      return rows.length;
+    }
+
+    test('does not grow a duplicate when its own kind-4 is replayed', () async {
+      await persistOwnSend(content: 'ok', legacyShape: true);
+      expect(await storedCount(), 1);
+
+      await replayOwnNip04(content: 'ok');
+
+      expect(
+        await storedCount(),
+        1,
+        reason:
+            'the legacy row is the same message, so the replayed kind-4 must '
+            'collapse onto it rather than insert a second bubble (#8211)',
+      );
+    });
+
+    test('collapses the modern-shaped own-send row too', () async {
+      // Control: the same replay against a row written after #2654. This
+      // already worked, and must keep working — it proves the test above
+      // fails for the id shape, not for own-send collapse generally.
+      await persistOwnSend(content: 'ok', legacyShape: false);
+      expect(await storedCount(), 1);
+
+      await replayOwnNip04(content: 'ok');
+
+      expect(await storedCount(), 1);
+    });
+
+    test("still keeps a peer's genuine repeat over NIP-04 (#7324)", () async {
+      // The peer path must stay untouched by the own-send exemption: two
+      // genuine kind-4 messages carrying the same text both survive.
+      await conversationsDao.upsertConversation(
+        id: conversationId,
+        participantPubkeys: participants.join(','),
+        isGroup: false,
+        createdAt: _baseCreatedAt,
+        lastMessageTimestamp: _baseCreatedAt,
+        ownerPubkey: _owner,
+      );
+      await messagesDao.insertMessage(
+        id: 'd' * 64,
+        conversationId: conversationId,
+        senderPubkey: _peer,
+        content: 'ok',
+        createdAt: _baseCreatedAt,
+        giftWrapId: 'd' * 64,
+        ownerPubkey: _owner,
+      );
+
+      relay.add(
+        Event.fromJson({
+          'id': 'e' * 64,
+          'pubkey': _peer,
+          'created_at': _baseCreatedAt + 2,
+          'kind': EventKind.directMessage,
+          'tags': [
+            ['p', _owner],
+          ],
+          'content': 'ok',
+          'sig': '',
+        }),
+      );
+      await settle();
+
+      expect(
+        await storedCount(),
+        2,
+        reason: 'a genuine second message from the peer must survive (#7324)',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## What

Resolves **defect 1 of #8211** — the regression #8169 introduced. A message the user sent before 2026-04-01 can grow a second bubble on their own device when the history drain replays its kind-4 fallback.

## Why it happens

#8169 derives a stored row's arrival protocol from `id == gift_wrap_id`, justified as "the NIP-04 receive path writes the wire event id into both columns, and every NIP-17 path writes a rumor id distinct from its gift-wrap id."

That holds for every write path **in the current tree**. It does not hold for rows already on disk. Before `d9846bb5d` (#2654, 2026-04-01) all three NIP-17 send paths wrote the gift-wrap id into *both* columns:

```dart
// mobile/lib/repositories/dm_repository.dart @ d9846bb5d^
 666:  id: result.messageEventId!,        671:  giftWrapId: result.messageEventId!,        // 1:1
 785:  id: firstSuccess.messageEventId!,  790:  giftWrapId: firstSuccess.messageEventId!,  // group
1013:  id: result.messageEventId!,       1018:  giftWrapId: result.messageEventId!,        // file
```

DMs shipped in `35d7648b4` (2026-03-11), so that is a ~3-week window of own-send rows carrying the NIP-04 marker shape, and nothing wipes or rewrites `direct_messages` on upgrade.

Measured against the real DAO before the fix:

```
legacy own-send row (id == giftWrapId):  seenAsNip17Twin=false   seenAsNip04Twin=true
modern row          (id != giftWrapId):  seenAsNip17Twin=true    seenAsNip04Twin=false
```

So when `_recoverOutgoingNip04` replays the user's own kind-4, `nip17Copy` excludes the legacy row and the event inserts again. Pre-#8169 the unconstrained window matched it and collapsed correctly.

## The fix

Our own replayed kind-4 takes no arrival-shape filter. That mirrors the two self-send branches that already exist — the NIP-17 receive path's `isSentByMe && isGroup` case and the group-send recovery path, both of which pass `unconstrained` with the same reasoning: they match the user's own persisted send rather than a cross-protocol twin, and that send may carry either shape.

A peer's kind-4 still asks for `nip17Copy` only, so #7324 stays fixed in both directions. The exemption is scoped to `senderPubkey == _userPubkey`, which is already computed one line above the call site.

## Testing

Red-first. Before the fix the legacy case failed with `Expected: <1>, Actual: <2>` — the duplicate bubble, reproduced end to end through the real repository, real DAO and real database — while both controls passed, proving it failed for the id shape rather than for own-send collapse generally.

The file carries three cases:

- the legacy-shaped row (the bug)
- a modern-shaped row, which already worked and must keep working
- a peer's genuine same-text repeat over NIP-04, which must still survive (#7324)

`dm_repository_test.dart` stubs `hasMatchingMessage` to a constant in its top-level `setUp`, so none of this is observable there — see #8170 and PR #8215.

- `dm_repository`: 679 pass
- `db_client`: 1,008 pass
- `flutter analyze lib test` from inside the package: no issues

## Not in this PR

**Defect 2** — one stored NIP-04 row suppressing unbounded NIP-17 arrivals. The predicate asks whether a matching row *exists*, not whether an *unconsumed* one does, so #7324's symptom survives in the NIP-04-first ordering. That needs consumption rather than existence semantics, which is a design call rather than a patch.

**Defect 3** — `hasMatchingMessage` ignores `is_deleted`, so a soft-deleted row still suppresses its twin. Predates #8169 and is unchanged by it.

Both stay open and #8211 remains their tracker, so this PR deliberately does **not** carry a closing keyword.

## Also in this PR

The `hasMatchingMessage` dartdoc called a group send "the one self-authored case" needing `DmDedupCounterpart.unconstrained`. This branch adds a second, so that line now contradicts the code — updated to name both.

Refs #8211
