### PR TITLE
fix(dm): require an answered page before the history drain marks itself complete

### DIFF
--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -1023,7 +1023,12 @@ class DmRepository {
   /// the caller can advance its own pagination cursor by their outer
   /// `created_at`, or `null` if the user switched / the repository was torn
   /// down mid-fetch (so the caller stops paging for the stale user).
-  Future<List<Event>?> _fetchHistoryPage({
+  ///
+  /// `authoritative` is false when nothing answered this page — no relay took
+  /// the REQ, a relay refused it with `CLOSED`, the client was disposed, or
+  /// only some relays answered. An empty page is proof of exhaustion only when
+  /// it is authoritative; see the guard in [_runHistoryDrain]. See #8209.
+  Future<({List<Event> events, bool authoritative})?> _fetchHistoryPage({
     required int until,
     required int limit,
     required String subscriptionId,
@@ -1046,12 +1051,21 @@ class DmRepository {
     // default pool) so the #4953/#4973 history drain reads gift wraps a
     // sender delivered outside the default pool. `null` keeps the prior
     // default-pool-only behavior. See #4974.
-    final events = await _nostrClient.queryEvents(
+    //
+    // queryEventsDetailed, not queryEvents: the latter discards `timedOut` and
+    // `noRelays`, so a page nothing answered arrives as an ordinary empty one
+    // and the drain reads it as exhaustion. `requireAllRelaysSettled` is what
+    // makes a relay's `CLOSED` refusal and a partial fan-out surface as
+    // `timedOut` rather than completing on whichever relays did answer. #8209.
+    final result = await _nostrClient.queryEventsDetailed(
       [filter],
       subscriptionId: subscriptionId,
       useCache: false,
       tempRelays: tempRelays,
+      requireAllRelaysSettled: true,
     );
+    final events = result.events;
+    final authoritative = !result.noRelays && !result.timedOut;
     if (_ingestSessionEnded(pubkey, generation)) return null;
 
     // Pass 1 (off the _eventLock): batch-decrypt this page's gift wraps in one
@@ -1079,7 +1093,7 @@ class DmRepository {
       }
       await _maybeYieldDuringDrain(i);
     }
-    return events;
+    return (events: events, authoritative: authoritative);
   }
 
   /// Recovers the user's OWN outgoing NIP-04 (kind-4) messages after a wipe.
@@ -1094,19 +1108,19 @@ class DmRepository {
   /// already sets `currentUserHasSent` for self-authored messages. Bounded by
   /// [DmHistoryDrainConfig.maxPages].
   ///
-  /// Returns `true` when the pass completed against a live relay — genuine
-  /// exhaustion or the page budget — and `false` when it could not run: no
-  /// relay connected, the repository was torn down / the user switched, or a
-  /// relay error. A `false` result MUST NOT mark the drain complete, mirroring
-  /// the gift-wrap drain's `connectedRelayCount == 0` guard so a momentary
-  /// disconnect in this window doesn't silently skip recovery *and*
-  /// permanently strand the user's outgoing NIP-04 history. See #5304.
+  /// Returns `true` when the pass completed against a relay that actually
+  /// answered — genuine exhaustion or the page budget — and `false` when it
+  /// could not run: nothing answered the page, the repository was torn down /
+  /// the user switched, or a relay error. A `false` result MUST NOT mark the
+  /// drain complete, mirroring the gift-wrap drain's authoritative-page guard
+  /// so a momentary outage in this window doesn't silently skip recovery *and*
+  /// permanently strand the user's outgoing NIP-04 history. See #5304, #8209.
   Future<bool> _recoverOutgoingNip04(String pubkey, int generation) async {
     try {
       var cursor = DateTime.now().millisecondsSinceEpoch ~/ 1000;
       for (var page = 0; page < DmHistoryDrainConfig.maxPages; page++) {
         if (_ingestSessionEnded(pubkey, generation)) return false;
-        final events = await _nostrClient.queryEvents(
+        final result = await _nostrClient.queryEventsDetailed(
           [
             nostr_filter.Filter(
               authors: [pubkey],
@@ -1117,15 +1131,18 @@ class DmRepository {
           ],
           subscriptionId: 'dm_drain_nip04_${pubkey}_$page',
           useCache: false,
+          requireAllRelaysSettled: true,
         );
+        final events = result.events;
         if (_ingestSessionEnded(pubkey, generation)) return false;
         if (events.isEmpty) {
-          // An empty page is genuine exhaustion only if a relay was actually
-          // connected to answer it. With 0 connected relays queryEvents
-          // short-circuits to [] — concluding "nothing to recover" and letting
-          // the caller mark the drain complete would permanently strand the
+          // An empty page is genuine exhaustion only if a relay actually
+          // ANSWERED it. Nothing answering — no relay took the REQ, a relay
+          // refused it with `CLOSED`, or only some answered — arrives as an
+          // ordinary empty list, and concluding "nothing to recover" would let
+          // the caller mark the drain complete and permanently strand the
           // user's outgoing NIP-04 (the #5202 failure mode, mirrored here).
-          return _nostrClient.connectedRelayCount > 0;
+          return !result.noRelays && !result.timedOut;
         }
         for (var i = 0; i < events.length; i++) {
           if (_ingestSessionEnded(pubkey, generation)) return false;
@@ -1514,7 +1531,7 @@ class DmRepository {
       for (var page = 0; page < DmHistoryDrainConfig.maxPages; page++) {
         // Bail if the user switched or the repository was torn down.
         if (_ingestSessionEnded(pubkey, gen)) return;
-        final events = await _fetchHistoryPage(
+        final historyPage = await _fetchHistoryPage(
           until: cursor,
           limit: DmHistoryDrainConfig.pageSize,
           subscriptionId: 'dm_drain_${pubkey}_$page',
@@ -1522,7 +1539,8 @@ class DmRepository {
           generation: gen,
           tempRelays: ownInbox,
         );
-        if (events == null) return;
+        if (historyPage == null) return;
+        final events = historyPage.events;
         // _fetchHistoryPage's own guard sits at the top of its persist loop,
         // so the last event's persist and the yield after it are both
         // suspension points it cannot see past — it returns the page either
@@ -1532,17 +1550,20 @@ class DmRepository {
         pagesRun++;
         totalEvents += events.length;
         if (events.isEmpty) {
-          // An empty page is genuine history exhaustion ONLY if a relay was
-          // actually connected to answer it. With 0 connected relays the
-          // query short-circuits to [] — marking the drain complete then
-          // would permanently strand unrecovered history (the #5202 root
-          // cause). Defer instead: leave historyDrainComplete unset and the
-          // cursor persisted so the next inbox open resumes once relays
-          // are up.
-          if (_nostrClient.connectedRelayCount == 0) {
+          // An empty page is genuine history exhaustion ONLY if a relay
+          // actually ANSWERED it. Connected is not answered: a write-only
+          // relay and one whose socket died since its last status update both
+          // still count as connected, so the old `connectedRelayCount` test
+          // could not see a fan-out nobody took, a relay that refused the REQ
+          // with `CLOSED`, or a page the settle window completed on the
+          // relays that did answer. Marking the drain complete on any of those
+          // permanently strands unrecovered history (#5202 root cause, #8209).
+          // Defer instead: leave historyDrainComplete unset and the cursor
+          // persisted so the next inbox open resumes where this run stopped.
+          if (!historyPage.authoritative) {
             Log.warning(
-              'DM history drain saw an empty page with 0 connected relays '
-              'for ${pubkeyForLogs(pubkey)}; deferring completion to the next '
+              'DM history drain saw an empty page that no relay answered for '
+              '${pubkeyForLogs(pubkey)}; deferring completion to the next '
               'inbox open.',
               category: LogCategory.system,
             );

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -1564,12 +1564,18 @@ class DmRepository {
           // relays that did answer. Marking the drain complete on any of those
           // permanently strands unrecovered history (#5202 root cause, #8209).
           // Defer instead: leave historyDrainComplete unset and resume on the
-          // next inbox open from the last boundary this run persisted.
+          // next inbox open from the window this run pins below.
           if (!historyPage.authoritative) {
+            // Pin the resume point at this window before giving up on the
+            // run. Falling back to the seed is not safe: with no cursor
+            // persisted the next run seeds from oldestSyncedAt, which this
+            // run's own persisted messages drag downward (recordSeen), so the
+            // window would be skipped by the very events it did return.
+            await syncState.setHistoryDrainCursor(pubkey, cursor);
             Log.warning(
               'DM history drain saw an empty page that no relay answered for '
-              '${pubkeyForLogs(pubkey)}; deferring completion to the next '
-              'inbox open.',
+              '${pubkeyForLogs(pubkey)}; holding the resume cursor at $cursor '
+              'and deferring completion to the next inbox open.',
               category: LogCategory.system,
             );
             return;
@@ -1595,6 +1601,11 @@ class DmRepository {
           // this one (dedup absorbs the overlap); and do not complete off this
           // run. See #8209.
           if (!sawUnansweredPage) {
+            // Pin the resume point at the top of this window, for the same
+            // reason as the empty case above: an unpinned run falls back to
+            // oldestSyncedAt, which this page's own persisted messages have
+            // already dragged below the window we still need to re-read.
+            await syncState.setHistoryDrainCursor(pubkey, cursor);
             Log.warning(
               'DM history drain saw a page not every relay settled for '
               '${pubkeyForLogs(pubkey)}; holding the resume cursor at '

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -1118,6 +1118,7 @@ class DmRepository {
   Future<bool> _recoverOutgoingNip04(String pubkey, int generation) async {
     try {
       var cursor = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+      var sawUnansweredPage = false;
       for (var page = 0; page < DmHistoryDrainConfig.maxPages; page++) {
         if (_ingestSessionEnded(pubkey, generation)) return false;
         final result = await _nostrClient.queryEventsDetailed(
@@ -1135,6 +1136,7 @@ class DmRepository {
         );
         final events = result.events;
         if (_ingestSessionEnded(pubkey, generation)) return false;
+        final authoritative = !result.noRelays && !result.timedOut;
         if (events.isEmpty) {
           // An empty page is genuine exhaustion only if a relay actually
           // ANSWERED it. Nothing answering — no relay took the REQ, a relay
@@ -1142,8 +1144,9 @@ class DmRepository {
           // ordinary empty list, and concluding "nothing to recover" would let
           // the caller mark the drain complete and permanently strand the
           // user's outgoing NIP-04 (the #5202 failure mode, mirrored here).
-          return !result.noRelays && !result.timedOut;
+          return authoritative && !sawUnansweredPage;
         }
+        if (!authoritative) sawUnansweredPage = true;
         for (var i = 0; i < events.length; i++) {
           if (_ingestSessionEnded(pubkey, generation)) return false;
           await _handleIncomingEvent(events[i]);
@@ -1156,13 +1159,13 @@ class DmRepository {
             .map((event) => event.createdAt)
             .reduce((a, b) => a < b ? a : b);
         final next = minCreatedAt < cursor ? minCreatedAt : cursor - 1;
-        if (next <= 0) return true;
+        if (next <= 0) return !sawUnansweredPage;
         cursor = next;
       }
       // Page budget exhausted. NIP-04 is legacy/low-volume and the gift-wrap
       // drain already reached the end, so treat this as done rather than
       // looping a re-drain for a pathologically long kind-4 history.
-      return true;
+      return !sawUnansweredPage;
     } on Object catch (e) {
       // Relay/IO failures are expected on flaky networks. Returning false
       // defers drain completion so recovery retries on the next inbox open
@@ -1566,18 +1569,20 @@ class DmRepository {
           // Defer instead: leave historyDrainComplete unset and resume on the
           // next inbox open from the window this run pins below.
           if (!historyPage.authoritative) {
-            // Pin the resume point at this window before giving up on the
-            // run. Falling back to the seed is not safe: with no cursor
-            // persisted the next run seeds from oldestSyncedAt, which this
-            // run's own persisted messages drag downward (recordSeen), so the
-            // window would be skipped by the very events it did return.
-            await syncState.setHistoryDrainCursor(pubkey, cursor);
-            Log.warning(
-              'DM history drain saw an empty page that no relay answered for '
-              '${pubkeyForLogs(pubkey)}; holding the resume cursor at $cursor '
-              'and deferring completion to the next inbox open.',
-              category: LogCategory.system,
-            );
+            if (!sawUnansweredPage) {
+              // Pin the resume point at this window before giving up on the
+              // run. Falling back to the seed is not safe: with no cursor
+              // persisted the next run seeds from oldestSyncedAt, which this
+              // run's own persisted messages drag downward (recordSeen), so
+              // the window would be skipped by the events it did return.
+              await syncState.setHistoryDrainCursor(pubkey, cursor);
+              Log.warning(
+                'DM history drain saw an empty page that no relay answered for '
+                '${pubkeyForLogs(pubkey)}; holding the resume cursor at '
+                '$cursor and deferring completion to the next inbox open.',
+                category: LogCategory.system,
+              );
+            }
             return;
           }
           reachedEnd = true;

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -1690,12 +1690,17 @@ class DmRepository {
         // Page cap hit: leave historyDrainComplete unset and the cursor
         // persisted so the next inbox open resumes the remaining history
         // instead of permanently truncating it for heavy users. See #4953.
+        // Report the DURABLE cursor, not the loop's: once a page goes
+        // unsettled the persist above is frozen while `cursor` keeps
+        // descending, so the two diverge in exactly the case a reader of
+        // this line is trying to diagnose. See #8209.
         Log.warning(
           'DM history drain paused at the page cap '
           '(${DmHistoryDrainConfig.maxPages}) for ${pubkeyForLogs(pubkey)} '
           'after '
           '$totalEvents events; will resume from the persisted cursor '
-          '($cursor) on the next inbox open.',
+          '(${syncState.historyDrainCursor(pubkey) ?? cursor}) on the next '
+          'inbox open.',
           category: LogCategory.system,
         );
       }

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -1526,6 +1526,11 @@ class DmRepository {
       if (_ingestSessionEnded(pubkey, gen)) return;
 
       var reachedEnd = false;
+      // Set by any page not every relay settled — empty or not. Freezes the
+      // durable cursor and blocks completion for the rest of this run, so a
+      // window one relay never answered is re-requested rather than skipped
+      // past. See the partial-page guard below. #8209.
+      var sawUnansweredPage = false;
       var pagesRun = 0;
       var totalEvents = 0;
       for (var page = 0; page < DmHistoryDrainConfig.maxPages; page++) {
@@ -1558,8 +1563,8 @@ class DmRepository {
           // with `CLOSED`, or a page the settle window completed on the
           // relays that did answer. Marking the drain complete on any of those
           // permanently strands unrecovered history (#5202 root cause, #8209).
-          // Defer instead: leave historyDrainComplete unset and the cursor
-          // persisted so the next inbox open resumes where this run stopped.
+          // Defer instead: leave historyDrainComplete unset and resume on the
+          // next inbox open from the last boundary this run persisted.
           if (!historyPage.authoritative) {
             Log.warning(
               'DM history drain saw an empty page that no relay answered for '
@@ -1571,6 +1576,33 @@ class DmRepository {
           }
           reachedEnd = true;
           break;
+        }
+
+        if (!historyPage.authoritative) {
+          // A page that carried events but which not every relay settled: one
+          // relay answered while another never did, so this window can still
+          // hold events this page did not see. The events it did return are
+          // real and already persisted. What must not happen is the durable
+          // cursor moving below a window we have only partly seen — the
+          // unanswered relay's events in it would never be requested again,
+          // and a later authoritative empty page would then latch completion
+          // over the gap. That is the same permanent strand as latching on an
+          // empty page, one window wide instead of the whole tail.
+          //
+          // So: keep paging, because this run should still recover everything
+          // the relays that DID answer hold; stop persisting, so the next run
+          // resumes from the last window every relay settled and re-requests
+          // this one (dedup absorbs the overlap); and do not complete off this
+          // run. See #8209.
+          if (!sawUnansweredPage) {
+            Log.warning(
+              'DM history drain saw a page not every relay settled for '
+              '${pubkeyForLogs(pubkey)}; holding the resume cursor at '
+              '$cursor and deferring completion to the next inbox open.',
+              category: LogCategory.system,
+            );
+          }
+          sawUnansweredPage = true;
         }
 
         // Step strictly below the oldest event seen so the loop always
@@ -1587,11 +1619,14 @@ class DmRepository {
         }
         // Persist the boundary so an interrupted or page-capped run
         // resumes from here on the next inbox open rather than restarting
-        // from the top.
-        await syncState.setHistoryDrainCursor(pubkey, cursor);
+        // from the top. Frozen once a page went unanswered, so the resume
+        // point never moves below a window that page may not have seen whole.
+        if (!sawUnansweredPage) {
+          await syncState.setHistoryDrainCursor(pubkey, cursor);
+        }
       }
 
-      if (reachedEnd) {
+      if (reachedEnd && !sawUnansweredPage) {
         // Before declaring history complete, recover the user's OWN outgoing
         // NIP-04 messages. The paged drain above filters `p:[self]`, which
         // matches incoming NIP-04 and the user's NIP-17 self-wraps but never
@@ -1624,6 +1659,17 @@ class DmRepository {
             category: LogCategory.system,
           );
         }
+      } else if (reachedEnd) {
+        // Reached the end of what the answering relays hold, but an earlier
+        // page in this run was not fully settled, so the run has no standing
+        // to call history exhausted. The resume cursor is still parked above
+        // that window; the next inbox open re-requests it. #8209.
+        Log.warning(
+          'DM history drain reached the end for ${pubkeyForLogs(pubkey)} but '
+          'an earlier page was not fully settled; deferring completion to the '
+          'next inbox open.',
+          category: LogCategory.system,
+        );
       } else {
         // Page cap hit: leave historyDrainComplete unset and the cursor
         // persisted so the next inbox open resumes the remaining history

--- a/mobile/packages/dm_repository/lib/src/dm_sync_state.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_sync_state.dart
@@ -43,7 +43,17 @@ class DmSyncState {
   /// unsticks installs whose earlier drain completed before the user's own
   /// historical messages were recovered — which had stranded established chats
   /// under "Message requests".
-  static const int currentDrainVersion = 3;
+  ///
+  /// Bumped to 4 for #8209: the drain read an empty page as exhaustion
+  /// whenever a relay was merely *connected*, so a fan-out nobody took, a
+  /// `CLOSED` refusal, or a page only some relays answered latched completion
+  /// with history still on the relay. Fixing the guard alone helps nobody who
+  /// already latched — those installs return before issuing a query, and there
+  /// is no user-facing re-sync. The forced pass costs every install one extra
+  /// drain; the gift wraps are still there to recover (funnelcake retains kind
+  /// 1059 indefinitely), and the drain is unawaited background work that
+  /// resumes from its persisted cursor, so the cost is bounded and one-time.
+  static const int currentDrainVersion = 4;
 
   /// Maximum clock skew, in seconds, tolerated on a self-asserted DM
   /// `created_at` before callers should stop treating it as an honest send

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -5286,6 +5286,46 @@ void main() {
       );
 
       test(
+        'an unanswered empty page after a partial page keeps the first '
+        'unsettled resume cursor (#8209)',
+        () async {
+          var giftWrapPages = 0;
+          when(
+            () => mockNostrClient.queryEventsDetailed(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+              useCache: any(named: 'useCache'),
+              tempRelays: any(named: 'tempRelays'),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+            ),
+          ).thenAnswer((inv) async {
+            final filter =
+                (inv.positionalArguments.first as List<nostr_filter.Filter>)
+                    .single;
+            if (filter.authors != null && (filter.p?.isEmpty ?? true)) {
+              return answeredPage(const <Event>[]);
+            }
+            giftWrapPages++;
+            return giftWrapPages == 1
+                ? partialPage([deletion(50)])
+                : unansweredPage(timedOut: true);
+          });
+
+          final syncState = _FakeDmSyncState()
+            ..oldestOverride = 100
+            ..drainVersionOverride = DmSyncState.currentDrainVersion;
+          final repository = createRepository(syncState: syncState);
+
+          await repository.backfillHistoryIfNeeded();
+
+          expect(giftWrapPages, 2);
+          expect(syncState.persistedDrainCursors, [100]);
+          expect(syncState.drainCursorOverride, 100);
+          expect(syncState.drainCompleteOverride, isFalse);
+        },
+      );
+
+      test(
         'a later run re-requests the window a partial page left unsettled '
         '(#8209)',
         () async {
@@ -5744,6 +5784,64 @@ void main() {
           await repository.backfillHistoryIfNeeded();
 
           expect(capturedUntil, isNotEmpty);
+          expect(syncState.drainCompleteOverride, isFalse);
+          expect(syncState.markedCompletePubkeys, isEmpty);
+        },
+      );
+
+      test(
+        'defers completion after a non-empty NIP-04 page that not every relay '
+        'settled (#8209)',
+        () async {
+          final partialNip04 = Event.fromJson({
+            'id':
+                'abcdabcdabcdabcdabcdabcdabcdabcd'
+                'abcdabcdabcdabcdabcdabcdabcdabcd',
+            'pubkey': _validPubkeyA,
+            'created_at': 50,
+            'kind': EventKind.directMessage,
+            'tags': [
+              ['p', _validPubkeyB],
+            ],
+            'content': 'already-processed',
+            'sig': '',
+          });
+          var nip04Pages = 0;
+          when(
+            () => mockNostrClient.queryEventsDetailed(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+              useCache: any(named: 'useCache'),
+              tempRelays: any(named: 'tempRelays'),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+            ),
+          ).thenAnswer((inv) async {
+            final filter =
+                (inv.positionalArguments.first as List<nostr_filter.Filter>)
+                    .single;
+            if (filter.kinds?.contains(EventKind.dmRelaysList) ?? false) {
+              return answeredPage(const <Event>[]);
+            }
+            final isNip04Recovery =
+                filter.authors != null && (filter.p?.isEmpty ?? true);
+            if (!isNip04Recovery) return answeredPage(const <Event>[]);
+            nip04Pages++;
+            return nip04Pages == 1
+                ? partialPage([partialNip04])
+                : answeredPage(const <Event>[]);
+          });
+          when(
+            () => mockDirectMessagesDao.hasGiftWrap(partialNip04.id),
+          ).thenAnswer((_) async => true);
+
+          final syncState = _FakeDmSyncState()
+            ..oldestOverride = 100
+            ..drainVersionOverride = DmSyncState.currentDrainVersion;
+          final repository = createRepository(syncState: syncState);
+
+          await repository.backfillHistoryIfNeeded();
+
+          expect(nip04Pages, 2);
           expect(syncState.drainCompleteOverride, isFalse);
           expect(syncState.markedCompletePubkeys, isEmpty);
         },

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -24,6 +24,7 @@ import 'package:nostr_sdk/signer/isolate_decrypt_signer.dart';
 import 'package:nostr_sdk/signer/local_nostr_signer.dart';
 import 'package:nostr_sdk/signer/nostr_signer.dart';
 import 'package:nostr_sdk/utils/relay_url_policy.dart';
+import 'package:unified_logger/unified_logger.dart';
 
 class _MockOutgoingDmsDao extends Mock implements OutgoingDmsDao {}
 
@@ -6057,6 +6058,66 @@ void main() {
           expect(
             syncState.persistedDrainCursors,
             hasLength(DmHistoryDrainConfig.maxPages),
+          );
+        },
+      );
+
+      test(
+        "the page-cap log names the frozen resume cursor, not the loop's "
+        '(#8209)',
+        () async {
+          await LogCaptureService().clearAllLogs();
+
+          var calls = 0;
+          when(
+            () => mockNostrClient.queryEventsDetailed(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+              useCache: any(named: 'useCache'),
+              tempRelays: any(named: 'tempRelays'),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+            ),
+          ).thenAnswer((inv) async {
+            final filters =
+                inv.positionalArguments.first as List<nostr_filter.Filter>;
+            if (filters.single.kinds?.contains(EventKind.dmRelaysList) ??
+                false) {
+              return answeredPage(const <Event>[]);
+            }
+            calls++;
+            final until = filters.single.until!;
+            // Every page unsettled, over an infinite descending supply: the
+            // durable cursor freezes at the seed on page 1 while the loop's
+            // own `cursor` keeps descending all the way to the cap. The log
+            // has to name the former — it is what the next run resumes from.
+            return partialPage([deletion(until - 1)]);
+          });
+
+          final syncState = _FakeDmSyncState()..oldestOverride = 1000000;
+          final repository = createRepository(syncState: syncState);
+
+          await repository.backfillHistoryIfNeeded();
+
+          expect(calls, DmHistoryDrainConfig.maxPages);
+          expect(syncState.persistedDrainCursors, [1000000]);
+
+          const loopCursor = 1000000 - DmHistoryDrainConfig.maxPages;
+          final capLogs = LogCaptureService()
+              .getRecentLogs()
+              .where(
+                (e) =>
+                    e.level == LogLevel.warning &&
+                    e.message.contains('paused at the page cap'),
+              )
+              .toList();
+          expect(capLogs, hasLength(1));
+          expect(
+            capLogs.single.message,
+            contains('will resume from the persisted cursor (1000000)'),
+          );
+          expect(
+            capLogs.single.message,
+            isNot(contains('persisted cursor ($loopCursor)')),
           );
         },
       );

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -235,6 +235,31 @@ class _MockNostrClient extends Mock implements NostrClient {}
   bool timedOut = false,
 }) => (events: const <Event>[], timedOut: timedOut, noRelays: noRelays);
 
+/// Shapes a `queryEventsDetailed` answer a relay actually gave: [events] is
+/// the whole truth, so an empty list is genuine exhaustion. This is what the
+/// history drain requires before it may mark itself complete (#8209).
+({List<Event> events, bool timedOut, bool noRelays}) answeredPage(
+  List<Event> events,
+) => (events: events, timedOut: false, noRelays: false);
+
+/// Shapes a page that carries real [events] but which NOT every relay settled:
+/// one relay answered while another never did, so the window may still hold
+/// events this page could not see. The drain may persist these events, but must
+/// not advance its durable cursor past them or mark itself complete (#8209).
+({List<Event> events, bool timedOut, bool noRelays}) partialPage(
+  List<Event> events,
+) => (events: events, timedOut: true, noRelays: false);
+
+/// Shapes a `queryEventsDetailed` answer that nothing gave: a fan-out no relay
+/// took ([noRelays]), or a relay that refused the REQ with `CLOSED` / a page
+/// the settle window completed without every relay answering ([timedOut]).
+/// The events list is empty and means nothing — the drain must defer, not
+/// conclude exhaustion.
+({List<Event> events, bool timedOut, bool noRelays}) unansweredPage({
+  bool noRelays = false,
+  bool timedOut = false,
+}) => (events: const <Event>[], timedOut: timedOut, noRelays: noRelays);
+
 class _MockNIP17MessageService extends Mock implements NIP17MessageService {}
 
 class _MockDirectMessagesDao extends Mock implements DirectMessagesDao {}
@@ -565,12 +590,14 @@ void main() {
         ),
       ).thenAnswer((_) async => <Event>[]);
 
-      // Default for every kind-10050 lookup — resolveDmInboxRelays() on the
-      // send path, the memoized own-inbox resolve, and the RC3 publish check.
-      // ANSWERED and empty: the relays replied and this pubkey genuinely has
-      // no list, which is what every test that does not care about the read
-      // assumed when it went through queryEvents. An UNANSWERED empty is a
-      // different outcome and must be stubbed explicitly (#8212).
+      // Default for every queryEventsDetailed read — the kind-10050 lookups
+      // (resolveDmInboxRelays() on the send path, the memoized own-inbox
+      // resolve, the RC3 publish check) and the history drain's paged reads.
+      // ANSWERED and empty: the relays replied and there is genuinely nothing,
+      // which is what every test that cares about neither read assumed when
+      // both went through queryEvents. An UNANSWERED empty is a different
+      // outcome — absence the RC3 publisher must not act on (#8212), a page the
+      // drain must not read as exhaustion (#8209) — and is stubbed explicitly.
       when(
         () => mockNostrClient.queryEventsDetailed(
           any(),
@@ -1917,10 +1944,12 @@ void main() {
 
           var servedGiftWrapPage = false;
           when(
-            () => mockNostrClient.queryEvents(
+            () => mockNostrClient.queryEventsDetailed(
               any(),
               subscriptionId: any(named: 'subscriptionId'),
               useCache: any(named: 'useCache'),
+              tempRelays: any(named: 'tempRelays'),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
             ),
           ).thenAnswer((inv) async {
             final filters =
@@ -1928,12 +1957,12 @@ void main() {
             final filter = filters.single;
             // Outgoing-NIP-04 recovery pass (authors:[self], no p): nothing.
             if (filter.authors != null && (filter.p?.isEmpty ?? true)) {
-              return const <Event>[];
+              return answeredPage(const <Event>[]);
             }
             // One page of wraps, then exhaustion.
-            if (servedGiftWrapPage) return const <Event>[];
+            if (servedGiftWrapPage) return answeredPage(const <Event>[]);
             servedGiftWrapPage = true;
-            return wraps;
+            return answeredPage(wraps);
           });
 
           final syncState = _FakeDmSyncState()
@@ -2035,21 +2064,23 @@ void main() {
         void serveOnePage(List<Event> wraps) {
           var served = false;
           when(
-            () => mockNostrClient.queryEvents(
+            () => mockNostrClient.queryEventsDetailed(
               any(),
               subscriptionId: any(named: 'subscriptionId'),
               useCache: any(named: 'useCache'),
+              tempRelays: any(named: 'tempRelays'),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
             ),
           ).thenAnswer((inv) async {
             final filters =
                 inv.positionalArguments.first as List<nostr_filter.Filter>;
             final filter = filters.single;
             if (filter.authors != null && (filter.p?.isEmpty ?? true)) {
-              return const <Event>[];
+              return answeredPage(const <Event>[]);
             }
-            if (served) return const <Event>[];
+            if (served) return answeredPage(const <Event>[]);
             served = true;
-            return wraps;
+            return answeredPage(wraps);
           });
         }
 
@@ -4235,6 +4266,9 @@ void main() {
         'history drain targets the own kind-10050 inbox relays as tempRelays',
         () async {
           final capturedDrainTempRelays = <List<String>?>[];
+          // The own kind-10050 resolve (#8212) and the drain pages (#8209)
+          // both read through queryEventsDetailed, so one stub serves both and
+          // branches on the filter.
           when(
             () => mockNostrClient.queryEventsDetailed(
               any(),
@@ -4244,24 +4278,15 @@ void main() {
               requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
               timeout: any(named: 'timeout'),
             ),
-          ).thenAnswer(
-            (_) async => answeredList([
-              ownInbox(['wss://own.example']),
-            ]),
-          );
-          // The drain pages still read through queryEvents; only the own
-          // kind-10050 resolve moved to queryEventsDetailed (#8212).
-          when(
-            () => mockNostrClient.queryEvents(
-              any(),
-              subscriptionId: any(named: 'subscriptionId'),
-              useCache: any(named: 'useCache'),
-              tempRelays: any(named: 'tempRelays'),
-            ),
           ).thenAnswer((inv) async {
             final filter =
                 (inv.positionalArguments.first as List<nostr_filter.Filter>)
                     .single;
+            if (filter.kinds?.contains(EventKind.dmRelaysList) ?? false) {
+              return answeredList([
+                ownInbox(['wss://own.example']),
+              ]);
+            }
             // Only the gift-wrap drain pages carry p:[self]; capture their
             // tempRelays (the NIP-04 recovery uses authors:[self] with no p
             // and is intentionally not 10050-targeted).
@@ -4270,7 +4295,7 @@ void main() {
                 inv.namedArguments[#tempRelays] as List<String>?,
               );
             }
-            return const <Event>[];
+            return answeredPage(const <Event>[]);
           });
 
           final syncState = _FakeDmSyncState()
@@ -5009,10 +5034,12 @@ void main() {
 
       void stubFiniteHistory(List<Event> history, List<int?> capturedUntil) {
         when(
-          () => mockNostrClient.queryEvents(
+          () => mockNostrClient.queryEventsDetailed(
             any(),
             subscriptionId: any(named: 'subscriptionId'),
             useCache: any(named: 'useCache'),
+            tempRelays: any(named: 'tempRelays'),
+            requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
           ),
         ).thenAnswer((inv) async {
           final filters =
@@ -5023,27 +5050,48 @@ void main() {
           // tag. Return empty (and don't capture its cursor) so these gift-wrap
           // pagination assertions stay focused on the drain itself.
           if (filter.authors != null && (filter.p?.isEmpty ?? true)) {
-            return const <Event>[];
+            return answeredPage(const <Event>[]);
           }
           final until = filter.until;
           capturedUntil.add(until);
           // Mirror NIP-01 `until` (inclusive) semantics.
-          return history
-              .where((e) => e.createdAt <= (until ?? 1 << 31))
-              .toList();
+          return answeredPage(
+            history.where((e) => e.createdAt <= (until ?? 1 << 31)).toList(),
+          );
         });
       }
 
+      /// Stubs every drain page as one nothing answered.
+      ///
+      /// [noRelays] is a fan-out no relay took; [timedOut] is a relay that
+      /// refused the REQ with `CLOSED`, or a page the settle window completed
+      /// while the relay holding the history stayed silent.
+      void stubUnansweredHistory({
+        bool noRelays = false,
+        bool timedOut = false,
+      }) {
+        when(
+          () => mockNostrClient.queryEventsDetailed(
+            any(),
+            subscriptionId: any(named: 'subscriptionId'),
+            useCache: any(named: 'useCache'),
+            tempRelays: any(named: 'tempRelays'),
+            requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+          ),
+        ).thenAnswer(
+          (_) async => unansweredPage(noRelays: noRelays, timedOut: timedOut),
+        );
+      }
+
       test(
-        'does NOT mark complete on an empty page when no relays are '
-        'connected — defers to the next inbox open (#5202)',
+        'does NOT mark complete when a fan-out reached no relay — defers to '
+        'the next inbox open (#5202)',
         () async {
-          // queryEvents short-circuits to [] when the relay pool has not
-          // connected yet; treating that as exhaustion would permanently
-          // strand unrecovered history (the reported regression).
-          when(() => mockNostrClient.connectedRelayCount).thenReturn(0);
-          final capturedUntil = <int?>[];
-          stubFiniteHistory(const <Event>[], capturedUntil);
+          // Relays report connected, so the old `connectedRelayCount` guard
+          // would have passed here and latched. Only the fan-out's own account
+          // of who took the REQ can see this.
+          when(() => mockNostrClient.connectedRelayCount).thenReturn(2);
+          stubUnansweredHistory(noRelays: true);
 
           final syncState = _FakeDmSyncState()
             ..oldestOverride = 100
@@ -5052,16 +5100,37 @@ void main() {
 
           await repository.backfillHistoryIfNeeded();
 
-          // Queried once, got empty, but deferred instead of completing.
-          expect(capturedUntil, [100]);
           expect(syncState.drainCompleteOverride, isFalse);
           expect(syncState.markedCompletePubkeys, isEmpty);
         },
       );
 
       test(
-        'marks complete on an empty page when at least one relay is '
-        'connected (genuine exhaustion)',
+        'does NOT mark complete when a relay refused the page — defers to the '
+        'next inbox open (#8209)',
+        () async {
+          // divine-funnelcake answers a failed query with
+          // `CLOSED "error: could not complete query"`. With
+          // requireAllRelaysSettled that refusal arrives as timedOut; without
+          // it the pool reports timedOut:false and the drain latches.
+          when(() => mockNostrClient.connectedRelayCount).thenReturn(2);
+          stubUnansweredHistory(timedOut: true);
+
+          final syncState = _FakeDmSyncState()
+            ..oldestOverride = 100
+            ..drainVersionOverride = DmSyncState.currentDrainVersion;
+          final repository = createRepository(syncState: syncState);
+
+          await repository.backfillHistoryIfNeeded();
+
+          expect(syncState.drainCompleteOverride, isFalse);
+          expect(syncState.markedCompletePubkeys, isEmpty);
+        },
+      );
+
+      test(
+        'demands full relay settlement on every drain page, so a refusal '
+        'cannot arrive as an ordinary empty answer (#8209)',
         () async {
           when(() => mockNostrClient.connectedRelayCount).thenReturn(2);
           final capturedUntil = <int?>[];
@@ -5074,6 +5143,83 @@ void main() {
 
           await repository.backfillHistoryIfNeeded();
 
+          final captured = verify(
+            () => mockNostrClient.queryEventsDetailed(
+              captureAny(),
+              subscriptionId: any(named: 'subscriptionId'),
+              useCache: any(named: 'useCache'),
+              tempRelays: any(named: 'tempRelays'),
+              requireAllRelaysSettled: captureAny(
+                named: 'requireAllRelaysSettled',
+              ),
+            ),
+          ).captured;
+
+          // Pair each call's filters with the flag it passed, then keep the
+          // drain's own reads. The memoized kind-10050 inbox resolve goes
+          // through this same method and deliberately does NOT demand
+          // settlement — a relay list is re-resolvable, a skipped page is not
+          // (#8212).
+          final demands = <Object?>[];
+          for (var i = 0; i + 1 < captured.length; i += 2) {
+            final filters = captured[i]! as List<nostr_filter.Filter>;
+            final kinds = filters.single.kinds ?? const <int>[];
+            if (kinds.contains(EventKind.dmRelaysList)) continue;
+            demands.add(captured[i + 1]);
+          }
+          expect(demands, isNotEmpty);
+          expect(demands, everyElement(isTrue));
+        },
+      );
+
+      test(
+        'marks complete on an empty page a relay actually answered '
+        '(genuine exhaustion)',
+        () async {
+          when(() => mockNostrClient.connectedRelayCount).thenReturn(2);
+          final capturedUntil = <int?>[];
+          stubFiniteHistory(const <Event>[], capturedUntil);
+
+          final syncState = _FakeDmSyncState()
+            ..oldestOverride = 100
+            ..drainVersionOverride = DmSyncState.currentDrainVersion;
+          final repository = createRepository(syncState: syncState);
+
+          await repository.backfillHistoryIfNeeded();
+
+          // Queried once, got an authoritative empty page, completed.
+          expect(capturedUntil, [100]);
+          expect(syncState.drainCompleteOverride, isTrue);
+        },
+      );
+
+      test(
+        'an unanswered page leaves the drain re-runnable, so history is '
+        'recovered once the relays come back (#8209)',
+        () async {
+          when(() => mockNostrClient.connectedRelayCount).thenReturn(2);
+          stubUnansweredHistory(timedOut: true);
+
+          final syncState = _FakeDmSyncState()
+            ..oldestOverride = 100
+            ..drainVersionOverride = DmSyncState.currentDrainVersion;
+          final repository = createRepository(syncState: syncState);
+
+          await repository.backfillHistoryIfNeeded();
+          expect(syncState.drainCompleteOverride, isFalse);
+
+          // The relays recover and serve real history. Under the latching
+          // behavior this second pass never issued a query at all.
+          final capturedUntil = <int?>[];
+          stubFiniteHistory(const <Event>[], capturedUntil);
+
+          await repository.backfillHistoryIfNeeded();
+
+          expect(
+            capturedUntil,
+            isNotEmpty,
+            reason: 'the drain must still be armed after an unanswered page',
+          );
           expect(syncState.drainCompleteOverride, isTrue);
         },
       );
@@ -5085,10 +5231,12 @@ void main() {
           when(() => mockNostrClient.connectedRelayCount).thenReturn(2);
           final capturedFilters = <nostr_filter.Filter>[];
           when(
-            () => mockNostrClient.queryEvents(
+            () => mockNostrClient.queryEventsDetailed(
               any(),
               subscriptionId: any(named: 'subscriptionId'),
               useCache: any(named: 'useCache'),
+              tempRelays: any(named: 'tempRelays'),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
             ),
           ).thenAnswer((inv) async {
             capturedFilters.addAll(
@@ -5096,7 +5244,7 @@ void main() {
             );
             // Gift-wrap drain exhausts immediately; the NIP-04 recovery query
             // also returns empty — we only assert that it was issued.
-            return const <Event>[];
+            return answeredPage(const <Event>[]);
           });
 
           final syncState = _FakeDmSyncState()
@@ -5127,12 +5275,14 @@ void main() {
         () async {
           when(() => mockNostrClient.connectedRelayCount).thenReturn(2);
           when(
-            () => mockNostrClient.queryEvents(
+            () => mockNostrClient.queryEventsDetailed(
               any(),
               subscriptionId: any(named: 'subscriptionId'),
               useCache: any(named: 'useCache'),
+              tempRelays: any(named: 'tempRelays'),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
             ),
-          ).thenAnswer((_) async => const <Event>[]);
+          ).thenAnswer((_) async => answeredPage(const <Event>[]));
           // The drain recovered the user's own last-sent message in this convo.
           when(
             () => mockConversationsDao.lastSentTimestampsByConversation(
@@ -5247,10 +5397,12 @@ void main() {
           final authorsUntils = <int?>[];
           var nip04Pages = 0;
           when(
-            () => mockNostrClient.queryEvents(
+            () => mockNostrClient.queryEventsDetailed(
               any(),
               subscriptionId: any(named: 'subscriptionId'),
               useCache: any(named: 'useCache'),
+              tempRelays: any(named: 'tempRelays'),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
             ),
           ).thenAnswer((inv) async {
             final filter =
@@ -5260,14 +5412,14 @@ void main() {
             // kinds:[10050]) also matches authors-with-no-p; skip it so it is
             // not mistaken for a NIP-04 recovery page.
             if (filter.kinds?.contains(EventKind.dmRelaysList) ?? false) {
-              return const <Event>[];
+              return answeredPage(const <Event>[]);
             }
             final isNip04Recovery =
                 filter.authors != null && (filter.p?.isEmpty ?? true);
-            if (!isNip04Recovery) return const <Event>[];
+            if (!isNip04Recovery) return answeredPage(const <Event>[]);
             authorsUntils.add(filter.until);
             nip04Pages++;
-            return nip04Pages == 1 ? [outgoing] : const <Event>[];
+            return answeredPage(nip04Pages == 1 ? [outgoing] : const <Event>[]);
           });
 
           when(
@@ -5381,10 +5533,12 @@ void main() {
           // back empty with 0 connected relays. Recovery must NOT be treated
           // as "nothing to recover" and the drain must NOT be marked complete.
           when(
-            () => mockNostrClient.queryEvents(
+            () => mockNostrClient.queryEventsDetailed(
               any(),
               subscriptionId: any(named: 'subscriptionId'),
               useCache: any(named: 'useCache'),
+              tempRelays: any(named: 'tempRelays'),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
             ),
           ).thenAnswer((inv) async {
             final filter =
@@ -5393,14 +5547,15 @@ void main() {
             final isNip04Recovery =
                 filter.authors != null && (filter.p?.isEmpty ?? true);
             if (isNip04Recovery) {
-              // Simulate a disconnect for the recovery window.
-              when(
-                () => mockNostrClient.connectedRelayCount,
-              ).thenReturn(0);
-              return const <Event>[];
+              // Nothing answers the recovery window. The relays still report
+              // connected, so only the fan-out's own account of who took the
+              // REQ distinguishes this from "the user has no outgoing NIP-04".
+              return unansweredPage(noRelays: true);
             }
             capturedUntil.add(filter.until);
-            return const <Event>[]; // gift-wrap drain reaches the end
+            return answeredPage(
+              const <Event>[],
+            ); // gift-wrap drain reaches the end
           });
 
           final syncState = _FakeDmSyncState()
@@ -5527,10 +5682,12 @@ void main() {
         await repository.backfillHistoryIfNeeded();
 
         verifyNever(
-          () => mockNostrClient.queryEvents(
+          () => mockNostrClient.queryEventsDetailed(
             any(),
             subscriptionId: any(named: 'subscriptionId'),
             useCache: any(named: 'useCache'),
+            tempRelays: any(named: 'tempRelays'),
+            requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
           ),
         );
       });
@@ -5541,10 +5698,12 @@ void main() {
         await repository.backfillHistoryIfNeeded();
 
         verifyNever(
-          () => mockNostrClient.queryEvents(
+          () => mockNostrClient.queryEventsDetailed(
             any(),
             subscriptionId: any(named: 'subscriptionId'),
             useCache: any(named: 'useCache'),
+            tempRelays: any(named: 'tempRelays'),
+            requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
           ),
         );
       });
@@ -5555,10 +5714,12 @@ void main() {
         () async {
           var calls = 0;
           when(
-            () => mockNostrClient.queryEvents(
+            () => mockNostrClient.queryEventsDetailed(
               any(),
               subscriptionId: any(named: 'subscriptionId'),
               useCache: any(named: 'useCache'),
+              tempRelays: any(named: 'tempRelays'),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
             ),
           ).thenAnswer((inv) async {
             final filters =
@@ -5567,12 +5728,12 @@ void main() {
             // counted as a drain page.
             if (filters.single.kinds?.contains(EventKind.dmRelaysList) ??
                 false) {
-              return const <Event>[];
+              return answeredPage(const <Event>[]);
             }
             calls++;
             final until = filters.single.until!;
             // Infinite descending supply: only the maxPages cap can stop it.
-            return [deletion(until - 1)];
+            return answeredPage([deletion(until - 1)]);
           });
 
           final syncState = _FakeDmSyncState()..oldestOverride = 1000000;
@@ -5627,10 +5788,12 @@ void main() {
         () async {
           var calls = 0;
           when(
-            () => mockNostrClient.queryEvents(
+            () => mockNostrClient.queryEventsDetailed(
               any(),
               subscriptionId: any(named: 'subscriptionId'),
               useCache: any(named: 'useCache'),
+              tempRelays: any(named: 'tempRelays'),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
             ),
           ).thenAnswer((inv) async {
             final filters =
@@ -5639,12 +5802,12 @@ void main() {
             // counted as a drain page.
             if (filters.single.kinds?.contains(EventKind.dmRelaysList) ??
                 false) {
-              return const <Event>[];
+              return answeredPage(const <Event>[]);
             }
             calls++;
             final until = filters.single.until!;
             // Page 0 advances + persists the cursor; page 1 fails.
-            if (calls == 1) return [deletion(until - 1)];
+            if (calls == 1) return answeredPage([deletion(until - 1)]);
             throw Exception('relay boom');
           });
 
@@ -5678,10 +5841,12 @@ void main() {
         () async {
           final error = StateError('bad drain state');
           when(
-            () => mockNostrClient.queryEvents(
+            () => mockNostrClient.queryEventsDetailed(
               any(),
               subscriptionId: any(named: 'subscriptionId'),
               useCache: any(named: 'useCache'),
+              tempRelays: any(named: 'tempRelays'),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
             ),
           ).thenThrow(error);
 
@@ -5732,10 +5897,12 @@ void main() {
           final queriedPubkeys = <String>[];
 
           when(
-            () => mockNostrClient.queryEvents(
+            () => mockNostrClient.queryEventsDetailed(
               any(),
               subscriptionId: any(named: 'subscriptionId'),
               useCache: any(named: 'useCache'),
+              tempRelays: any(named: 'tempRelays'),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
             ),
           ).thenAnswer((inv) async {
             final filter =
@@ -5745,7 +5912,7 @@ void main() {
             // with no p tag after the gift-wrap drain completes. Return empty
             // so this test stays focused on gift-wrap drain pubkey routing.
             if (filter.authors != null && (filter.p?.isEmpty ?? true)) {
-              return const <Event>[];
+              return answeredPage(const <Event>[]);
             }
             final pubkey = filter.p!.single;
             queriedPubkeys.add(pubkey);
@@ -5753,7 +5920,7 @@ void main() {
             if (pubkey == _validPubkeyA) {
               oldQueryStarted.complete();
               await oldQueryRelease.future;
-              return [
+              return answeredPage([
                 Event(
                   _validPubkeyA,
                   EventKind.eventDeletion,
@@ -5763,12 +5930,12 @@ void main() {
                   '',
                   createdAt: 90,
                 ),
-              ];
+              ]);
             }
 
             newQueryStarted.complete();
             await newQueryRelease.future;
-            return <Event>[];
+            return answeredPage(<Event>[]);
           });
           when(
             () => mockConversationsDao.getConversation(
@@ -5819,10 +5986,12 @@ void main() {
         final secondPageRelease = Completer<void>();
 
         when(
-          () => mockNostrClient.queryEvents(
+          () => mockNostrClient.queryEventsDetailed(
             any(),
             subscriptionId: any(named: 'subscriptionId'),
             useCache: any(named: 'useCache'),
+            tempRelays: any(named: 'tempRelays'),
+            requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
           ),
         ).thenAnswer((inv) async {
           final filter =
@@ -5832,10 +6001,10 @@ void main() {
           // outgoing-NIP-04 recovery pass (#5304) is a history page; keep
           // both out of the page counter.
           if (filter.kinds?.contains(EventKind.dmRelaysList) ?? false) {
-            return const <Event>[];
+            return answeredPage(const <Event>[]);
           }
           if (filter.authors != null && (filter.p?.isEmpty ?? true)) {
-            return const <Event>[];
+            return answeredPage(const <Event>[]);
           }
           pageCalls++;
           if (pageCalls == 2) {
@@ -5844,9 +6013,9 @@ void main() {
           }
           // Three populated pages then exhaustion, so an unstopped drain runs
           // all the way through to markHistoryDrainComplete.
-          return pageCalls <= 3
-              ? [deletion(filter.until! - 1)]
-              : const <Event>[];
+          return answeredPage(
+            pageCalls <= 3 ? [deletion(filter.until! - 1)] : const <Event>[],
+          );
         });
 
         final syncState = _FakeDmSyncState()
@@ -5956,32 +6125,36 @@ void main() {
 
           var pageCalls = 0;
           when(
-            () => mockNostrClient.queryEvents(
+            () => mockNostrClient.queryEventsDetailed(
               any(),
               subscriptionId: any(named: 'subscriptionId'),
               useCache: any(named: 'useCache'),
+              tempRelays: any(named: 'tempRelays'),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
             ),
           ).thenAnswer((inv) async {
             final filter =
                 (inv.positionalArguments.first as List<nostr_filter.Filter>)
                     .single;
             if (filter.authors != null && (filter.p?.isEmpty ?? true)) {
-              return const <Event>[];
+              return answeredPage(const <Event>[]);
             }
             pageCalls++;
-            return pageCalls == 1
-                ? [
-                    Event(
-                      _validPubkeyA,
-                      EventKind.eventDeletion,
-                      const [
-                        ['e', _rumorEventId],
-                      ],
-                      '',
-                      createdAt: 99,
-                    ),
-                  ]
-                : const <Event>[];
+            return answeredPage(
+              pageCalls == 1
+                  ? [
+                      Event(
+                        _validPubkeyA,
+                        EventKind.eventDeletion,
+                        const [
+                          ['e', _rumorEventId],
+                        ],
+                        '',
+                        createdAt: 99,
+                      ),
+                    ]
+                  : const <Event>[],
+            );
           });
 
           final repository = createRepository(syncState: syncState);
@@ -6178,20 +6351,22 @@ void main() {
       // pass (authors:[self]).
       void stubDrainPage(List<Event> page) {
         when(
-          () => mockNostrClient.queryEvents(
+          () => mockNostrClient.queryEventsDetailed(
             any(),
             subscriptionId: any(named: 'subscriptionId'),
             useCache: any(named: 'useCache'),
+            tempRelays: any(named: 'tempRelays'),
+            requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
           ),
         ).thenAnswer((inv) async {
           final filters =
               inv.positionalArguments.first as List<nostr_filter.Filter>;
           final filter = filters.single;
           if (filter.authors != null && (filter.p?.isEmpty ?? true)) {
-            return const <Event>[];
+            return answeredPage(const <Event>[]);
           }
           final until = filter.until ?? (1 << 31);
-          return page.where((e) => e.createdAt <= until).toList();
+          return answeredPage(page.where((e) => e.createdAt <= until).toList());
         });
       }
 
@@ -6822,10 +6997,12 @@ void main() {
           final secondQueryStarted = Completer<void>();
           final secondQueryResult = Completer<List<Event>>();
           when(
-            () => mockNostrClient.queryEvents(
+            () => mockNostrClient.queryEventsDetailed(
               any(),
               subscriptionId: any(named: 'subscriptionId'),
               useCache: any(named: 'useCache'),
+              tempRelays: any(named: 'tempRelays'),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
             ),
           ).thenAnswer((inv) async {
             final filters =
@@ -6833,9 +7010,9 @@ void main() {
             final filter = filters.single;
             if (filter.p?.contains(senderPub) ?? false) {
               secondQueryStarted.complete();
-              return secondQueryResult.future;
+              return answeredPage(await secondQueryResult.future);
             }
-            return const <Event>[];
+            return answeredPage(const <Event>[]);
           });
 
           final repository = createRepository(

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -5272,10 +5272,11 @@ void main() {
           expect(capturedUntil.first, 100);
           expect(capturedUntil.last! < 50, isTrue);
 
-          // But nothing is persisted past that window, so the next run
-          // re-requests it instead of resuming below it.
-          expect(syncState.persistedDrainCursors, isEmpty);
-          expect(syncState.drainCursorOverride, isNull);
+          // The resume point is pinned at the top of the unsettled window and
+          // never moves below it, so the next run re-requests that window
+          // whole instead of resuming underneath it.
+          expect(syncState.persistedDrainCursors, [100]);
+          expect(syncState.drainCursorOverride, 100);
 
           // And the authoritative empty page that followed cannot latch
           // completion over the gap.
@@ -5298,6 +5299,14 @@ void main() {
           final repository = createRepository(syncState: syncState);
 
           await repository.backfillHistoryIfNeeded();
+
+          // Persisting the partial page's own gift wraps / NIP-04 messages
+          // drags oldestSyncedAt down to their timestamps (recordSeen, from
+          // _persistDecryptedGiftWrap and _handleNip04Event). The drain must
+          // not depend on that boundary to find its way back: it seeds from
+          // `historyDrainCursor ?? oldestSyncedAt ?? now`.
+          syncState.oldestOverride = 50;
+
           capturedUntil.clear();
           await repository.backfillHistoryIfNeeded();
 
@@ -5356,6 +5365,40 @@ void main() {
             reason: 'the drain must still be armed after an unanswered page',
           );
           expect(syncState.drainCompleteOverride, isTrue);
+        },
+      );
+
+      test(
+        'pins the resume cursor when a page goes unanswered, so a sync '
+        'boundary that moves meanwhile cannot pull the next run below the '
+        'window still owed (#8209)',
+        () async {
+          when(() => mockNostrClient.connectedRelayCount).thenReturn(2);
+          stubUnansweredHistory(timedOut: true);
+
+          final syncState = _FakeDmSyncState()
+            ..oldestOverride = 100
+            ..drainVersionOverride = DmSyncState.currentDrainVersion;
+          final repository = createRepository(syncState: syncState);
+
+          await repository.backfillHistoryIfNeeded();
+
+          // Deferring is not enough on its own: the drain seeds from
+          // `historyDrainCursor ?? oldestSyncedAt ?? now`, so a run that
+          // defers without persisting anything comes back to whatever
+          // oldestSyncedAt has become.
+          expect(syncState.drainCursorOverride, 100);
+
+          // The live subscription keeps ingesting while the drain is deferred,
+          // and recordSeen drags oldestSyncedAt below the window the drain
+          // still owes.
+          syncState.oldestOverride = 50;
+
+          final capturedUntil = <int?>[];
+          stubFiniteHistory(const <Event>[], capturedUntil);
+          await repository.backfillHistoryIfNeeded();
+
+          expect(capturedUntil.first, 100);
         },
       );
 

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -5129,6 +5129,51 @@ void main() {
       );
 
       test(
+        'defers on a refused gift-wrap page even when NIP-04 recovery would '
+        'answer, so the gift-wrap guard is pinned on its own (#8209)',
+        () async {
+          // The refused/fan-out tests above stub ONE answer for both the
+          // gift-wrap drain and the NIP-04 recovery pass, so the NIP-04 guard
+          // masks a regressed gift-wrap guard: break the gift-wrap guard alone
+          // and they still pass because recovery defers on the same refusal.
+          // Split the two queries so this test dies to the gift-wrap guard
+          // specifically — the gift-wrap page is refused while NIP-04 recovery
+          // answers authoritatively, so only a working gift-wrap guard can keep
+          // the drain from latching (a broken one reaches the answering
+          // recovery pass and marks complete).
+          when(() => mockNostrClient.connectedRelayCount).thenReturn(2);
+          when(
+            () => mockNostrClient.queryEventsDetailed(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+              useCache: any(named: 'useCache'),
+              tempRelays: any(named: 'tempRelays'),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+            ),
+          ).thenAnswer((inv) async {
+            final filter =
+                (inv.positionalArguments.first as List<nostr_filter.Filter>)
+                    .single;
+            final isNip04Recovery =
+                filter.authors != null && (filter.p?.isEmpty ?? true);
+            return isNip04Recovery
+                ? answeredPage(const <Event>[])
+                : unansweredPage(timedOut: true);
+          });
+
+          final syncState = _FakeDmSyncState()
+            ..oldestOverride = 100
+            ..drainVersionOverride = DmSyncState.currentDrainVersion;
+          final repository = createRepository(syncState: syncState);
+
+          await repository.backfillHistoryIfNeeded();
+
+          expect(syncState.drainCompleteOverride, isFalse);
+          expect(syncState.markedCompletePubkeys, isEmpty);
+        },
+      );
+
+      test(
         'demands full relay settlement on every drain page, so a refusal '
         'cannot arrive as an ordinary empty answer (#8209)',
         () async {

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -5172,6 +5172,96 @@ void main() {
         },
       );
 
+      /// Stubs a first page that carries [events] but which not every relay
+      /// settled (`timedOut`), and an authoritative empty page for every read
+      /// below it — the shape that used to advance the durable cursor past a
+      /// window one relay never answered, then latch completion over the gap.
+      void stubPartialThenExhausted(
+        List<Event> events,
+        List<int?> capturedUntil,
+      ) {
+        when(
+          () => mockNostrClient.queryEventsDetailed(
+            any(),
+            subscriptionId: any(named: 'subscriptionId'),
+            useCache: any(named: 'useCache'),
+            tempRelays: any(named: 'tempRelays'),
+            requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+          ),
+        ).thenAnswer((inv) async {
+          final filter =
+              (inv.positionalArguments.first as List<nostr_filter.Filter>)
+                  .single;
+          // Let the outgoing-NIP-04 recovery pass answer cleanly, so anything
+          // this test observes comes from the gift-wrap drain's own guard.
+          if (filter.authors != null && (filter.p?.isEmpty ?? true)) {
+            return answeredPage(const <Event>[]);
+          }
+          final until = filter.until;
+          capturedUntil.add(until);
+          final page = events.where((e) => e.createdAt <= (until ?? 0));
+          return page.isEmpty
+              ? answeredPage(const <Event>[])
+              : partialPage(page.toList());
+        });
+      }
+
+      test(
+        'does NOT advance the resume cursor past a page carrying events that '
+        'not every relay settled (#8209)',
+        () async {
+          when(() => mockNostrClient.connectedRelayCount).thenReturn(2);
+          final capturedUntil = <int?>[];
+          stubPartialThenExhausted([deletion(50)], capturedUntil);
+
+          final syncState = _FakeDmSyncState()
+            ..oldestOverride = 100
+            ..drainVersionOverride = DmSyncState.currentDrainVersion;
+          final repository = createRepository(syncState: syncState);
+
+          await repository.backfillHistoryIfNeeded();
+
+          // The run still pages below the partial page: the events the
+          // answering relay DID hold are worth recovering now, and the page
+          // after it is authoritative and empty.
+          expect(capturedUntil.first, 100);
+          expect(capturedUntil.last! < 50, isTrue);
+
+          // But nothing is persisted past that window, so the next run
+          // re-requests it instead of resuming below it.
+          expect(syncState.persistedDrainCursors, isEmpty);
+          expect(syncState.drainCursorOverride, isNull);
+
+          // And the authoritative empty page that followed cannot latch
+          // completion over the gap.
+          expect(syncState.drainCompleteOverride, isFalse);
+          expect(syncState.markedCompletePubkeys, isEmpty);
+        },
+      );
+
+      test(
+        'a later run re-requests the window a partial page left unsettled '
+        '(#8209)',
+        () async {
+          when(() => mockNostrClient.connectedRelayCount).thenReturn(2);
+          final capturedUntil = <int?>[];
+          stubPartialThenExhausted([deletion(50)], capturedUntil);
+
+          final syncState = _FakeDmSyncState()
+            ..oldestOverride = 100
+            ..drainVersionOverride = DmSyncState.currentDrainVersion;
+          final repository = createRepository(syncState: syncState);
+
+          await repository.backfillHistoryIfNeeded();
+          capturedUntil.clear();
+          await repository.backfillHistoryIfNeeded();
+
+          // Seeded from the same boundary as the first run, not from below
+          // the partial page — that window is requested again, whole.
+          expect(capturedUntil.first, 100);
+        },
+      );
+
       test(
         'marks complete on an empty page a relay actually answered '
         '(genuine exhaustion)',

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -5690,6 +5690,32 @@ void main() {
       );
 
       test(
+        're-arms an install the pre-#8209 drain latched complete while '
+        'history was still on the relay',
+        () async {
+          final capturedUntil = <int?>[];
+          stubFiniteHistory(const <Event>[], capturedUntil);
+
+          // 3 is the version that shipped the `connectedRelayCount` guard: an
+          // install that latched under it has historyDrainComplete set and
+          // returns before issuing a single query, so the corrected guard
+          // never reaches it. Only a currentDrainVersion bump does — this is
+          // hardcoded rather than `currentDrainVersion - 1` precisely so it
+          // fails if #8209 ships without one.
+          final syncState = _FakeDmSyncState()
+            ..drainCompleteOverride = true
+            ..drainVersionOverride = 3;
+          final repository = createRepository(syncState: syncState);
+
+          await repository.backfillHistoryIfNeeded();
+
+          expect(syncState.upgradedPubkeys, isNotEmpty);
+          expect(capturedUntil, isNotEmpty);
+          expect(syncState.drainCompleteOverride, isTrue);
+        },
+      );
+
+      test(
         'emits recovery true→false on historyRecoveryStream around an '
         'actual drain (#5202)',
         () async {


### PR DESCRIPTION
## What

The DM history drain treated an empty page as history exhaustion whenever `connectedRelayCount > 0`, then latched `historyDrainComplete` permanently. This makes it require evidence a relay actually **answered** the page.

Refs #8209 — this resolves the drain-latching half only, so it must not close the issue. That issue describes two independently composing mechanisms, and the other one — the wrong-clock `since:` window that makes the live subscription miss the message in the first place — is untouched here, so this deliberately does not close it. One call site of #6238.

## Why the old guard could not work

Connected is not answered. `NostrClient.queryEvents` is `queryEventsDetailed(...).events` — it discards `timedOut` and `noRelays`, so an empty list means all of:

- the relays answered and there is nothing
- no relay took the REQ
- the client was disposed, or its query pool was closed
- **a relay refused the REQ with `CLOSED`**
- only some relays answered inside the 1s `RelayPool.querySettleWindow`

`connectedRelayCount` cannot see any of those — it reads `RelayManager`'s cached status map (`relay_manager.dart:151-155`), and `nostr_client.dart:889-892` already documents why that is not enough: *"a write-only relay and one whose socket died since its last status update both still count as connected."*

The `CLOSED` case is the one that makes this ordinary rather than rare. divine-funnelcake answers a failed ClickHouse query with `CLOSED "error: could not complete query"` (`crates/relay/src/handler.rs:29`, `:537-548`). The relay tells us the query failed, and the drain concluded the user has no more message history — forever. Kind 1059 is retained indefinitely on funnelcake, so those messages are still sitting on the relay behind a flag that never clears.

There is no user-facing re-sync. The only escapes are a shipped `currentDrainVersion` bump, a full database reset, or an account switch.

## What changed

**The page must be answered.** `_fetchHistoryPage` now reads through `queryEventsDetailed(..., requireAllRelaysSettled: true)` and returns `({List<Event> events, bool authoritative})?`. The empty-page guard defers unless the page was authoritative.

`requireAllRelaysSettled: true` is load-bearing, not decoration — without it a `CLOSED` refusal still reports `timedOut: false` and the bug survives the change. There is a test that pins the flag itself for exactly that reason.

The same weak guard sat in `_recoverOutgoingNip04` (`:1101`), whose return value gates `markHistoryDrainComplete`. Fixing only the gift-wrap half would still latch through the NIP-04 pass, so both move together.

This matches five existing call sites that already fail closed this way — `creator_sync/sync_index_client.dart:129`, `creator_sync/vault_key_service.dart:190`, `bookmark_service.dart:598`, `account_deletion_service.dart:430`, `notify_subscriptions_repository_impl.dart:345`.

**The cursor stops at the last window every relay settled.** `authoritative` was checked only on an empty page, so a page that carried events but which one relay never settled still advanced the durable cursor below those events. The unanswered relay's events in that window were then never requested again, and a later authoritative empty page latched completion over the gap — the same permanent strand, one window wide instead of the whole tail.

The run now keeps paging (the events the answering relays hold are worth recovering now) but freezes the resume cursor at the last fully settled window and cannot complete off that run, so the next inbox open re-requests the window whole and dedup absorbs the overlap.

Freezing alone was not enough, which only showed up on a second pass over this. The drain seeds from `historyDrainCursor ?? oldestSyncedAt ?? now`, so a run that defers **before persisting anything** — an unanswered first page — comes back to whatever `oldestSyncedAt` has become, and persisting that page's own gift wraps and NIP-04 messages drags it down through `recordSeen`. The window would have been skipped by the very events the page returned. Both deferral paths now pin the resume point at the top of the unsettled window before giving up on the run; at that moment the cursor still equals the page's `until`, so the write is a no-op when a boundary was already persisted and pins the seed when none was.

**`currentDrainVersion` 3 → 4.** Correcting the guard helps nobody who has already latched: those installs read `historyDrainComplete` and return before issuing a query. The constant is the documented lever for exactly this ("bump this whenever a drain-correctness fix must force one more recovery pass"), with precedent in #5202 and #5304. The pass costs every install one extra drain; the wraps are still on the relay to recover, and the drain is unawaited background work resuming from its persisted cursor, so the cost is bounded and one-time.

## Cost, stated plainly

A page now waits for every relay or the 5s timeout rather than releasing on the first answer plus 1s. Worst case for a 50-page drain against a permanently silent relay goes ~50s → ~250s.

That is acceptable and it is the right trade: both call sites are `unawaited(...)` background work (`conversation_list_bloc.dart:115`, `conversation_bloc.dart:97`), and `setHistoryDrainCursor` persists after every fully settled page. Runs whose first page settles resume from the last fully settled boundary; a run whose first page is unsettled intentionally pins that seed and retries the same window. Deferring is recoverable; latching is not.

The one case that does not converge is a user whose own kind-10050 lists a relay that connects and never answers: every page is then unsettled, so the drain recovers what the answering relays hold on each run but never latches complete. That is deliberate — it is the same "deferring is recoverable" trade, and the alternative is concluding exhaustion we cannot prove.

## Testing

700 tests pass; package coverage 94.34% against the 93 gate.

Every guard here was **mutation-checked** rather than assumed:

| Mutation | Result |
|---|---|
| Revert the guard to `connectedRelayCount` | 4 tests go red, including the NIP-04 half |
| Drop `requireAllRelaysSettled: true`, keep everything else | the settlement-demand test goes red |
| Revert **only** the gift-wrap empty-page guard | before this round: whole suite still green; now: the split-query test goes red |
| Remove the cursor freeze on an unsettled page | both partial-page tests go red |
| Leave `currentDrainVersion` at 3 | the re-arm test goes red |
| Drop either resume-cursor pin | the matching boundary test goes red |
| Point the page-cap log back at the loop's `cursor` | the page-cap log test goes red |

New tests: a fan-out that reached no relay does not latch; a relay that refused the page does not latch; full settlement is demanded on every drain page; an authoritative empty page still latches (the behaviour that must keep working); an unanswered page leaves the drain re-runnable; a partial page does not move the durable cursor and cannot latch; a later run re-requests the window that partial page left unsettled even after `oldestSyncedAt` moves beneath it; a deferred run pins its resume cursor rather than trusting a boundary other code paths move; a refused gift-wrap page defers even when NIP-04 recovery answers; a partial page followed by an unanswered empty page keeps the first unsettled resume cursor; a non-empty unsettled NIP-04 page defers completion; and an install stamped at version 3 is re-armed.

`dm_repository_test.dart`'s *"marks complete on an empty page when at least one relay is connected (genuine exhaustion)"* pinned the broken behaviour as intended. It is rewritten, not deleted — it now asserts an **authoritative** empty page latches.

Most of the diff is test churn: `queryEventsDetailed` was stubbed nowhere in this package, so ~20 stub sites moved. A file-level default keeps every test that does not exercise the drain unchanged in behaviour.

## Out of scope

The send path still uses `queryEvents`. The former `_queryOwnDmInbox` settlement defect was fixed separately by #8220, which moved that read to `queryEventsDetailed`; this branch does not alter that merged behavior.


