### PR TITLE
fix(video): require an answered scan before latching the #2144 repair complete

### DIFF
--- a/mobile/lib/services/corrupted_video_repair_service.dart
+++ b/mobile/lib/services/corrupted_video_repair_service.dart
@@ -74,9 +74,11 @@ class CorruptedVideoRepairService {
 
   /// Scans and repairs the user's corrupted video events.
   ///
-  /// Returns the number repaired, or `null` when the repair could not run
-  /// because there is no authenticated identity / public key yet — the caller
-  /// must not treat that as a completed run.
+  /// Returns the number repaired, or `null` when the repair could not run:
+  /// there is no authenticated identity / public key yet, or no relay answered
+  /// the scan. The caller must not treat either as a completed run — a scan
+  /// nobody answered is indistinguishable from one that found nothing, and
+  /// latching on it disables the migration permanently (#8213).
   Future<int?> _repairCorruptedEvents() async {
     if (!_authService.isAuthenticated) {
       Log.debug(
@@ -100,7 +102,29 @@ class CorruptedVideoRepairService {
     // Query all of the user's own kind 34236 events from relay
     final filter = Filter(kinds: [EventKind.videoVertical], authors: [pubkey]);
 
-    final events = await _nostrClient.queryEvents([filter], useCache: false);
+    // queryEventsDetailed, not queryEvents: the latter discards `timedOut` and
+    // `noRelays`, so a scan nothing answered returns [] and reads as "no
+    // corrupted events" — the loop no-ops, 0 comes back instead of null, and
+    // the caller latches _completedKey permanently. `requireAllRelaysSettled`
+    // is what makes a relay's `CLOSED` refusal and a partial fan-out surface
+    // as `timedOut` rather than completing on whichever relays answered. With
+    // useCache: false there is no cached row to fall back on either. #8213.
+    final result = await _nostrClient.queryEventsDetailed(
+      [filter],
+      useCache: false,
+      requireAllRelaysSettled: true,
+    );
+    if (result.noRelays || result.timedOut) {
+      Log.warning(
+        'Skipping corrupted-video repair: no relay answered the scan '
+        '(noRelays: ${result.noRelays}, timedOut: ${result.timedOut}). '
+        'Retrying on the next launch.',
+        name: _logName,
+        category: LogCategory.video,
+      );
+      return null;
+    }
+    final events = result.events;
 
     Log.info(
       'Scanning ${events.length} video events for corrupted URLs',

--- a/mobile/lib/services/corrupted_video_repair_service.dart
+++ b/mobile/lib/services/corrupted_video_repair_service.dart
@@ -43,7 +43,8 @@ class CorruptedVideoRepairService {
   ///
   /// Returns the number of events repaired, `-1` if skipped (already done), or
   /// `0` without marking complete when there is no authenticated identity /
-  /// public key yet (the caller retries once the Nostr session is ready).
+  /// public key yet or the relay scan is incomplete (the caller retries once
+  /// the Nostr session is ready or on the next launch).
   ///
   /// The completion flag is only set once the scan actually ran, so calling
   /// this during the pre-restore startup window (no identity yet) cannot
@@ -75,9 +76,9 @@ class CorruptedVideoRepairService {
   /// Scans and repairs the user's corrupted video events.
   ///
   /// Returns the number repaired, or `null` when the repair could not run:
-  /// there is no authenticated identity / public key yet, or no relay answered
-  /// the scan. The caller must not treat either as a completed run — a scan
-  /// nobody answered is indistinguishable from one that found nothing, and
+  /// there is no authenticated identity / public key yet, or the relay scan is
+  /// incomplete. The caller must not treat either as a completed run — an
+  /// incomplete scan cannot prove that there is nothing to repair, and
   /// latching on it disables the migration permanently (#8213).
   Future<int?> _repairCorruptedEvents() async {
     if (!_authService.isAuthenticated) {
@@ -116,7 +117,7 @@ class CorruptedVideoRepairService {
     );
     if (result.noRelays || result.timedOut) {
       Log.warning(
-        'Skipping corrupted-video repair: no relay answered the scan '
+        'Skipping corrupted-video repair: relay scan was incomplete '
         '(noRelays: ${result.noRelays}, timedOut: ${result.timedOut}). '
         'Retrying on the next launch.',
         name: _logName,

--- a/mobile/scripts/baseline/test_unit_files.txt
+++ b/mobile/scripts/baseline/test_unit_files.txt
@@ -18,7 +18,6 @@ test/unit/profile_screen_empty_container_test.dart
 test/unit/providers/relay_set_change_bridge_test.dart
 test/unit/screens/explore_screen_pagination_test.dart
 test/unit/services/classic_vines_priority_test.dart
-test/unit/services/corrupted_video_repair_service_test.dart
 test/unit/services/nip17_message_service_test.dart
 test/unit/services/simple_video_cache_tdd_test.dart
 test/unit/services/subscription_manager_filter_test.dart

--- a/mobile/test/services/corrupted_video_repair_service_test.dart
+++ b/mobile/test/services/corrupted_video_repair_service_test.dart
@@ -9,23 +9,23 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 class _MockNostrClient extends Mock implements NostrClient {}
 
+class _MockAuthService extends Mock implements AuthService {}
+
+class _MockVideoEventService extends Mock implements VideoEventService {}
+
 /// Shapes a `queryEventsDetailed` answer a relay actually gave, so an empty
 /// [events] list is genuine "this account has no corrupted videos" — the only
 /// result the repair may latch on (#8213).
-({List<Event> events, bool timedOut, bool noRelays}) answeredScan(
+({List<Event> events, bool timedOut, bool noRelays}) _answeredScan(
   List<Event> events,
 ) => (events: events, timedOut: false, noRelays: false);
 
 /// Shapes a scan nothing answered: a fan-out no relay took ([noRelays]), or a
 /// relay that refused the REQ with `CLOSED` / a partial fan-out ([timedOut]).
-({List<Event> events, bool timedOut, bool noRelays}) unansweredScan({
+({List<Event> events, bool timedOut, bool noRelays}) _unansweredScan({
   bool noRelays = false,
   bool timedOut = false,
 }) => (events: const <Event>[], timedOut: timedOut, noRelays: noRelays);
-
-class _MockAuthService extends Mock implements AuthService {}
-
-class _MockVideoEventService extends Mock implements VideoEventService {}
 
 class _FakeEvent extends Fake implements Event {}
 
@@ -152,7 +152,7 @@ void main() {
             useCache: any(named: 'useCache'),
             requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
           ),
-        ).thenAnswer((_) async => answeredScan([corruptedEvent]));
+        ).thenAnswer((_) async => _answeredScan([corruptedEvent]));
 
         stubSignAndPublishSuccess();
 
@@ -209,7 +209,7 @@ void main() {
             useCache: any(named: 'useCache'),
             requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
           ),
-        ).thenAnswer((_) async => answeredScan([validEvent]));
+        ).thenAnswer((_) async => _answeredScan([validEvent]));
 
         final result = await repairService.repairIfNeeded();
 
@@ -237,7 +237,7 @@ void main() {
             useCache: any(named: 'useCache'),
             requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
           ),
-        ).thenAnswer((_) async => answeredScan([corruptedNoHash]));
+        ).thenAnswer((_) async => _answeredScan([corruptedNoHash]));
 
         final result = await repairService.repairIfNeeded();
 
@@ -266,7 +266,7 @@ void main() {
             useCache: any(named: 'useCache'),
             requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
           ),
-        ).thenAnswer((_) async => answeredScan([corruptedEvent]));
+        ).thenAnswer((_) async => _answeredScan([corruptedEvent]));
 
         stubSignAndPublishSuccess();
 
@@ -296,27 +296,24 @@ void main() {
         expect(prefs.getBool('corrupted_video_repair_v1_completed'), isNull);
       });
 
-      test(
-        'does not set completion flag when the fan-out reached no relay '
-        '(#8213)',
-        () async {
-          // A scan nobody answered is not a scan that found nothing. Latching
-          // here disables the #2144 repair on this device permanently, because
-          // the flag lives in SharedPreferences and nothing re-arms it.
-          when(
-            () => mockNostrClient.queryEventsDetailed(
-              any(),
-              useCache: any(named: 'useCache'),
-              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
-            ),
-          ).thenAnswer((_) async => unansweredScan(noRelays: true));
+      test('does not set completion flag when the fan-out reached no relay '
+          '(#8213)', () async {
+        // A scan nobody answered is not a scan that found nothing. Latching
+        // here disables the #2144 repair on this device permanently, because
+        // the flag lives in SharedPreferences and nothing re-arms it.
+        when(
+          () => mockNostrClient.queryEventsDetailed(
+            any(),
+            useCache: any(named: 'useCache'),
+            requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+          ),
+        ).thenAnswer((_) async => _unansweredScan(noRelays: true));
 
-          final result = await repairService.repairIfNeeded();
+        final result = await repairService.repairIfNeeded();
 
-          expect(result, equals(0));
-          expect(prefs.getBool('corrupted_video_repair_v1_completed'), isNull);
-        },
-      );
+        expect(result, equals(0));
+        expect(prefs.getBool('corrupted_video_repair_v1_completed'), isNull);
+      });
 
       test(
         'does not set completion flag when a relay refused the scan (#8213)',
@@ -330,7 +327,7 @@ void main() {
               useCache: any(named: 'useCache'),
               requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
             ),
-          ).thenAnswer((_) async => unansweredScan(timedOut: true));
+          ).thenAnswer((_) async => _unansweredScan(timedOut: true));
 
           final result = await repairService.repairIfNeeded();
 
@@ -339,79 +336,70 @@ void main() {
         },
       );
 
-      test(
-        'demands full relay settlement, so a refusal cannot arrive as an '
-        'ordinary empty scan (#8213)',
-        () async {
-          when(
-            () => mockNostrClient.queryEventsDetailed(
-              any(),
-              useCache: any(named: 'useCache'),
-              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+      test('demands full relay settlement, so a refusal cannot arrive as an '
+          'ordinary empty scan (#8213)', () async {
+        when(
+          () => mockNostrClient.queryEventsDetailed(
+            any(),
+            useCache: any(named: 'useCache'),
+            requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+          ),
+        ).thenAnswer((_) async => _answeredScan(const []));
+
+        await repairService.repairIfNeeded();
+
+        final demands = verify(
+          () => mockNostrClient.queryEventsDetailed(
+            any(),
+            useCache: any(named: 'useCache'),
+            requireAllRelaysSettled: captureAny(
+              named: 'requireAllRelaysSettled',
             ),
-          ).thenAnswer((_) async => answeredScan(const []));
+          ),
+        ).captured;
+        expect(demands, isNotEmpty);
+        expect(demands, everyElement(isTrue));
+      });
 
-          await repairService.repairIfNeeded();
-
-          final demands = verify(
-            () => mockNostrClient.queryEventsDetailed(
-              any(),
-              useCache: any(named: 'useCache'),
-              requireAllRelaysSettled: captureAny(
-                named: 'requireAllRelaysSettled',
-              ),
-            ),
-          ).captured;
-          expect(demands, isNotEmpty);
-          expect(demands, everyElement(isTrue));
-        },
-      );
-
-      test(
-        'an unanswered scan leaves the repair armed for the next launch '
-        '(#8213)',
-        () async {
-          final corruptedEvent = _createVideoEvent(
-            id: 'event1',
-            tags: [
-              ['d', 'video_123'],
-              [
-                'imeta',
-                'url /var/mobile/Containers/Data/Application/xxx/video.mp4',
-                'm video/mp4',
-                'x $_testSha256',
-              ],
+      test('an unanswered scan leaves the repair armed for the next launch '
+          '(#8213)', () async {
+        final corruptedEvent = _createVideoEvent(
+          id: 'event1',
+          tags: [
+            ['d', 'video_123'],
+            [
+              'imeta',
+              'url /var/mobile/Containers/Data/Application/xxx/video.mp4',
+              'm video/mp4',
+              'x $_testSha256',
             ],
-          );
-          var scans = 0;
-          when(
-            () => mockNostrClient.queryEventsDetailed(
-              any(),
-              useCache: any(named: 'useCache'),
-              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
-            ),
-          ).thenAnswer((_) async {
-            scans++;
-            // First launch: nothing answers. Second: the relay is back and
-            // serves the corrupted event the repair exists to fix.
-            return scans == 1
-                ? unansweredScan(timedOut: true)
-                : answeredScan([corruptedEvent]);
-          });
-          stubSignAndPublishSuccess();
+          ],
+        );
+        var scans = 0;
+        when(
+          () => mockNostrClient.queryEventsDetailed(
+            any(),
+            useCache: any(named: 'useCache'),
+            requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+          ),
+        ).thenAnswer((_) async {
+          scans++;
+          // First launch: nothing answers. Second: the relay is back and
+          // serves the corrupted event the repair exists to fix.
+          return scans == 1
+              ? _unansweredScan(timedOut: true)
+              : _answeredScan([corruptedEvent]);
+        });
+        stubSignAndPublishSuccess();
 
-          expect(await repairService.repairIfNeeded(), equals(0));
-          expect(prefs.getBool('corrupted_video_repair_v1_completed'), isNull);
+        expect(await repairService.repairIfNeeded(), equals(0));
+        expect(prefs.getBool('corrupted_video_repair_v1_completed'), isNull);
 
-          // Under the latching behavior this second run returned -1 without
-          // ever querying, and the corrupted event stayed broken forever.
-          expect(await repairService.repairIfNeeded(), equals(1));
-          expect(
-            prefs.getBool('corrupted_video_repair_v1_completed'),
-            isTrue,
-          );
-        },
-      );
+        // Under the latching behavior this second run returned -1 without
+        // ever querying, and the corrupted event stayed broken forever.
+        expect(await repairService.repairIfNeeded(), equals(1));
+        expect(prefs.getBool('corrupted_video_repair_v1_completed'), isTrue);
+      });
 
       test('skips when not authenticated', () async {
         when(() => mockAuthService.isAuthenticated).thenReturn(false);
@@ -465,7 +453,7 @@ void main() {
             useCache: any(named: 'useCache'),
             requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
           ),
-        ).thenAnswer((_) async => answeredScan([corruptedEvent]));
+        ).thenAnswer((_) async => _answeredScan([corruptedEvent]));
 
         when(
           () => mockAuthService.createAndSignEvent(
@@ -503,7 +491,7 @@ void main() {
             useCache: any(named: 'useCache'),
             requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
           ),
-        ).thenAnswer((_) async => answeredScan([corruptedEvent]));
+        ).thenAnswer((_) async => _answeredScan([corruptedEvent]));
 
         when(
           () => mockAuthService.createAndSignEvent(
@@ -549,7 +537,7 @@ void main() {
             useCache: any(named: 'useCache'),
             requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
           ),
-        ).thenAnswer((_) async => answeredScan([mixedEvent]));
+        ).thenAnswer((_) async => _answeredScan([mixedEvent]));
 
         stubSignAndPublishSuccess();
 

--- a/mobile/test/unit/services/corrupted_video_repair_service_test.dart
+++ b/mobile/test/unit/services/corrupted_video_repair_service_test.dart
@@ -9,6 +9,20 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 class _MockNostrClient extends Mock implements NostrClient {}
 
+/// Shapes a `queryEventsDetailed` answer a relay actually gave, so an empty
+/// [events] list is genuine "this account has no corrupted videos" — the only
+/// result the repair may latch on (#8213).
+({List<Event> events, bool timedOut, bool noRelays}) answeredScan(
+  List<Event> events,
+) => (events: events, timedOut: false, noRelays: false);
+
+/// Shapes a scan nothing answered: a fan-out no relay took ([noRelays]), or a
+/// relay that refused the REQ with `CLOSED` / a partial fan-out ([timedOut]).
+({List<Event> events, bool timedOut, bool noRelays}) unansweredScan({
+  bool noRelays = false,
+  bool timedOut = false,
+}) => (events: const <Event>[], timedOut: timedOut, noRelays: noRelays);
+
 class _MockAuthService extends Mock implements AuthService {}
 
 class _MockVideoEventService extends Mock implements VideoEventService {}
@@ -133,8 +147,12 @@ void main() {
         );
 
         when(
-          () => mockNostrClient.queryEvents(any(), useCache: false),
-        ).thenAnswer((_) async => [corruptedEvent]);
+          () => mockNostrClient.queryEventsDetailed(
+            any(),
+            useCache: any(named: 'useCache'),
+            requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+          ),
+        ).thenAnswer((_) async => answeredScan([corruptedEvent]));
 
         stubSignAndPublishSuccess();
 
@@ -186,8 +204,12 @@ void main() {
         );
 
         when(
-          () => mockNostrClient.queryEvents(any(), useCache: false),
-        ).thenAnswer((_) async => [validEvent]);
+          () => mockNostrClient.queryEventsDetailed(
+            any(),
+            useCache: any(named: 'useCache'),
+            requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+          ),
+        ).thenAnswer((_) async => answeredScan([validEvent]));
 
         final result = await repairService.repairIfNeeded();
 
@@ -210,8 +232,12 @@ void main() {
         );
 
         when(
-          () => mockNostrClient.queryEvents(any(), useCache: false),
-        ).thenAnswer((_) async => [corruptedNoHash]);
+          () => mockNostrClient.queryEventsDetailed(
+            any(),
+            useCache: any(named: 'useCache'),
+            requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+          ),
+        ).thenAnswer((_) async => answeredScan([corruptedNoHash]));
 
         final result = await repairService.repairIfNeeded();
 
@@ -235,8 +261,12 @@ void main() {
         );
 
         when(
-          () => mockNostrClient.queryEvents(any(), useCache: false),
-        ).thenAnswer((_) async => [corruptedEvent]);
+          () => mockNostrClient.queryEventsDetailed(
+            any(),
+            useCache: any(named: 'useCache'),
+            requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+          ),
+        ).thenAnswer((_) async => answeredScan([corruptedEvent]));
 
         stubSignAndPublishSuccess();
 
@@ -253,7 +283,11 @@ void main() {
 
       test('does not set completion flag on query failure', () async {
         when(
-          () => mockNostrClient.queryEvents(any(), useCache: false),
+          () => mockNostrClient.queryEventsDetailed(
+            any(),
+            useCache: any(named: 'useCache'),
+            requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+          ),
         ).thenThrow(Exception('Relay connection failed'));
 
         final result = await repairService.repairIfNeeded();
@@ -261,6 +295,123 @@ void main() {
         expect(result, equals(0));
         expect(prefs.getBool('corrupted_video_repair_v1_completed'), isNull);
       });
+
+      test(
+        'does not set completion flag when the fan-out reached no relay '
+        '(#8213)',
+        () async {
+          // A scan nobody answered is not a scan that found nothing. Latching
+          // here disables the #2144 repair on this device permanently, because
+          // the flag lives in SharedPreferences and nothing re-arms it.
+          when(
+            () => mockNostrClient.queryEventsDetailed(
+              any(),
+              useCache: any(named: 'useCache'),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+            ),
+          ).thenAnswer((_) async => unansweredScan(noRelays: true));
+
+          final result = await repairService.repairIfNeeded();
+
+          expect(result, equals(0));
+          expect(prefs.getBool('corrupted_video_repair_v1_completed'), isNull);
+        },
+      );
+
+      test(
+        'does not set completion flag when a relay refused the scan (#8213)',
+        () async {
+          // divine-funnelcake answers a failed query with
+          // `CLOSED "error: could not complete query"`, which surfaces as
+          // timedOut only because the scan demands full settlement.
+          when(
+            () => mockNostrClient.queryEventsDetailed(
+              any(),
+              useCache: any(named: 'useCache'),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+            ),
+          ).thenAnswer((_) async => unansweredScan(timedOut: true));
+
+          final result = await repairService.repairIfNeeded();
+
+          expect(result, equals(0));
+          expect(prefs.getBool('corrupted_video_repair_v1_completed'), isNull);
+        },
+      );
+
+      test(
+        'demands full relay settlement, so a refusal cannot arrive as an '
+        'ordinary empty scan (#8213)',
+        () async {
+          when(
+            () => mockNostrClient.queryEventsDetailed(
+              any(),
+              useCache: any(named: 'useCache'),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+            ),
+          ).thenAnswer((_) async => answeredScan(const []));
+
+          await repairService.repairIfNeeded();
+
+          final demands = verify(
+            () => mockNostrClient.queryEventsDetailed(
+              any(),
+              useCache: any(named: 'useCache'),
+              requireAllRelaysSettled: captureAny(
+                named: 'requireAllRelaysSettled',
+              ),
+            ),
+          ).captured;
+          expect(demands, isNotEmpty);
+          expect(demands, everyElement(isTrue));
+        },
+      );
+
+      test(
+        'an unanswered scan leaves the repair armed for the next launch '
+        '(#8213)',
+        () async {
+          final corruptedEvent = _createVideoEvent(
+            id: 'event1',
+            tags: [
+              ['d', 'video_123'],
+              [
+                'imeta',
+                'url /var/mobile/Containers/Data/Application/xxx/video.mp4',
+                'm video/mp4',
+                'x $_testSha256',
+              ],
+            ],
+          );
+          var scans = 0;
+          when(
+            () => mockNostrClient.queryEventsDetailed(
+              any(),
+              useCache: any(named: 'useCache'),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+            ),
+          ).thenAnswer((_) async {
+            scans++;
+            // First launch: nothing answers. Second: the relay is back and
+            // serves the corrupted event the repair exists to fix.
+            return scans == 1
+                ? unansweredScan(timedOut: true)
+                : answeredScan([corruptedEvent]);
+          });
+          stubSignAndPublishSuccess();
+
+          expect(await repairService.repairIfNeeded(), equals(0));
+          expect(prefs.getBool('corrupted_video_repair_v1_completed'), isNull);
+
+          // Under the latching behavior this second run returned -1 without
+          // ever querying, and the corrupted event stayed broken forever.
+          expect(await repairService.repairIfNeeded(), equals(1));
+          expect(
+            prefs.getBool('corrupted_video_repair_v1_completed'),
+            isTrue,
+          );
+        },
+      );
 
       test('skips when not authenticated', () async {
         when(() => mockAuthService.isAuthenticated).thenReturn(false);
@@ -309,8 +460,12 @@ void main() {
         );
 
         when(
-          () => mockNostrClient.queryEvents(any(), useCache: false),
-        ).thenAnswer((_) async => [corruptedEvent]);
+          () => mockNostrClient.queryEventsDetailed(
+            any(),
+            useCache: any(named: 'useCache'),
+            requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+          ),
+        ).thenAnswer((_) async => answeredScan([corruptedEvent]));
 
         when(
           () => mockAuthService.createAndSignEvent(
@@ -343,8 +498,12 @@ void main() {
         );
 
         when(
-          () => mockNostrClient.queryEvents(any(), useCache: false),
-        ).thenAnswer((_) async => [corruptedEvent]);
+          () => mockNostrClient.queryEventsDetailed(
+            any(),
+            useCache: any(named: 'useCache'),
+            requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+          ),
+        ).thenAnswer((_) async => answeredScan([corruptedEvent]));
 
         when(
           () => mockAuthService.createAndSignEvent(
@@ -385,8 +544,12 @@ void main() {
         );
 
         when(
-          () => mockNostrClient.queryEvents(any(), useCache: false),
-        ).thenAnswer((_) async => [mixedEvent]);
+          () => mockNostrClient.queryEventsDetailed(
+            any(),
+            useCache: any(named: 'useCache'),
+            requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+          ),
+        ).thenAnswer((_) async => answeredScan([mixedEvent]));
 
         stubSignAndPublishSuccess();
 


### PR DESCRIPTION
## What

The #2144 corrupted-video repair permanently marked itself complete when its relay scan came back empty because **nothing answered**, not because there was nothing to find.

Fixes #8213. One call site of #6238.

## The guard already existed and could not be reached

This service is written correctly at the top. `_repairCorruptedEvents` returns `null` for "not ready" (`:87`, `:97`) and `repairIfNeeded` honours it:

```dart
// :51-61
final repaired = await _repairCorruptedEvents();
if (repaired == null) {
  // Not ready to run: don't mark complete, let the caller retry.
  return 0;
}
await _prefs.setBool(_completedKey, true);
```

The escape hatch is right. It was simply never reached on the path that matters, because a failed read arrived as a successful zero:

`queryEvents` is `queryEventsDetailed(...).events` — it discards `timedOut` and `noRelays`. So `[]` means all of: the relays answered and there is nothing; no relay took the REQ; the client was disposed; the query pool was closed; **a relay refused the REQ with `CLOSED`**; or only some relays answered inside the 1s `RelayPool.querySettleWindow`.

From there: the loop at `:113` never executes → `repairedCount` stays `0` (`:111`) → `:163` returns `0` → `0` is not `null` → `:60` writes `_completedKey`.

`useCache: false` makes it strictly a network read with no cached rows to fall back on, so an empty result is more readily produced here than at call sites that merge cache.

## Impact

The flag lives in SharedPreferences, so it survives restarts. A device that latches never repairs its corrupted local-file-path imeta tags — the exact condition #2144 was filed for — and nothing re-arms it short of a reinstall or a shipped key change.

The existing startup gate does not cover this. `main.dart` defers the call until `nostrSessionPhase.nostrReady` and reasons that the flag "is only set once the scan actually ran" — but `nostrReady` means a keyed `NostrClient` exists, not that a relay answered.

## What changed

Read the scan through `queryEventsDetailed(..., requireAllRelaysSettled: true)` and return `null` when `noRelays || timedOut`. Nothing downstream changes — `:56` already does the right thing with `null`.

`requireAllRelaysSettled: true` is load-bearing, not decoration: without it a relay's `CLOSED` refusal still reports `timedOut: false` and the bug survives the change. There is a test pinning the flag itself for that reason.

Matches the existing fail-closed call sites — `bookmark_service.dart:598`, `account_deletion_service.dart:430`, `mobile/packages/creator_sync/lib/src/vault_key_service.dart:190`.

## Testing

15 tests pass. Both halves were **mutation-checked** rather than assumed:

| Mutation | Result |
|---|---|
| Remove the not-answered guard | the 3 new tests go red |
| Drop `requireAllRelaysSettled: true`, keep everything else | the settlement-demand test goes red |

New tests: a fan-out that reached no relay does not latch; a relay that refused the scan does not latch; full settlement is demanded; and an unanswered scan leaves the repair armed, so the corrupted event is actually fixed on the next launch.

**The existing "genuinely empty scan sets the flag" assertion still passes** — that is the behaviour this must not break, and it is what separates the fix from simply never latching.

The eight existing stubs moved from `queryEvents` to `queryEventsDetailed`; that is most of the diff.

## Note for reviewers

The regression test now lives at `test/services/corrupted_video_repair_service_test.dart`, matching the service path. This PR removes its former `test/unit/` baseline entry, shrinking that frozen legacy bucket by one.

`main.dart:2254-2270` runs this once per launch behind a `nostrReady` listener that closes after the first fire, so a `null` return retries on the next cold start rather than immediately. That is the intended shape, not a gap.

