### PR TITLE
fix(dm): stop relay failures from replacing inbox settings

### DIFF
--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -151,6 +151,24 @@ const bool _classifyDiagnostics =
 /// See #4974.
 const Duration _dmRelayListSignTimeout = Duration(seconds: 10);
 
+/// Budget for an ordinary kind-10050 lookup — the recipient resolve on the
+/// send path and the memoized own-inbox read. Restates `NostrClient`'s own
+/// default so the two call shapes read alike; changing it changes nothing
+/// about which relays answer.
+const Duration _dmInboxQueryTimeout = Duration(seconds: 5);
+
+/// Budget for the authoritative own-inbox read that gates the RC3 publish.
+///
+/// Deliberately shorter than [_dmInboxQueryTimeout]. `requireAllRelaysSettled`
+/// waits for every relay that took the REQ, so one connected-but-silent relay
+/// spends the whole budget even after a healthy relay has answered (measured
+/// at 6004ms on a 6s budget). Every relay in the default pool that answers at
+/// all answers in 0.5-1.1s, so a shorter budget stays conclusive in the normal
+/// case and halves the cost of the pathological one. An expiry reports
+/// `timedOut`, which is `failed`, which does not publish — so erring short errs
+/// toward not overwriting. See #8212.
+const Duration _ownDmInboxAuthoritativeTimeout = Duration(seconds: 3);
+
 /// Hard backstop on a single NIP-17 message publish (wrap build + recipient
 /// wrap OK-confirm + self-wrap). On timeout the send is reported as a soft,
 /// retryable-pending failure (the frame may already be written), so the
@@ -964,6 +982,15 @@ class DmRepository {
     if (cached != null) return cached;
     final future = _queryOwnDmInbox(
       _userPubkey,
+      // Deliberately NOT authoritative. Every consumer of this memo — the live
+      // gift-wrap subscription, the history drain, the read-marker publish —
+      // falls back to the default pool on `absent` and `failed` alike, and
+      // `startListening` awaits it before opening the subscription. Making it
+      // strict would put a full timeout in front of DM delivery on every login
+      // and every reconnect to protect a write that happens at most once per
+      // device. The publish path reads authoritatively on its own instead.
+      // See #8212.
+      requireAuthoritative: false,
       source: _DmRelayListSource.selfAuthored,
     );
     _ownInboxFuture = future;
@@ -3057,8 +3084,14 @@ class DmRepository {
   /// this device carrying the gift wrap, so a counterparty decides neither
   /// how many hosts we dial nor whether any of them sit on the sender's own
   /// network (#6585).
+  ///
+  /// The read is deliberately non-authoritative: it runs on every send,
+  /// degrades to the default pool whether the list is absent or unreadable,
+  /// and overwrites nothing — so it keeps the cache and the first answer it
+  /// gets rather than waiting for full relay settlement (#8212). Reporting an
+  /// unreadable recipient inbox as delivery is a separate defect, #7317.
   Future<List<String>?> resolveDmInboxRelays(String pubkey) async {
-    return (await _queryOwnDmInbox(pubkey)).relays;
+    return (await _queryOwnDmInbox(pubkey, requireAuthoritative: false)).relays;
   }
 
   /// Filters and bounds the relay URLs advertised in a kind-10050.
@@ -3124,23 +3157,69 @@ class DmRepository {
   /// [resolveDmInboxRelays] does) is safe for the send path and the live
   /// read (both fall back to the default pool either way), but RC3 must tell
   /// them apart — see [ensureDmRelayListPublished].
+  ///
+  /// [requireAuthoritative] is what makes `absent` trustworthy enough to
+  /// publish over. RC3 REPLACES whatever the user advertises, so it may only
+  /// act on an answer the relays actually gave: `useCache: false` stops a
+  /// stale local row standing in for a relay answer, and
+  /// `requireAllRelaysSettled: true` turns a fan-out nobody took and a REQ a
+  /// relay refused with `CLOSED` into `timedOut` rather than a prompt empty
+  /// list. Without it `queryEvents` reports every one of those as an ordinary
+  /// empty result, `absent` swallows them, and the publish guard below can
+  /// never fire — which is how a transient read replaced a real list (#8212).
+  ///
+  /// Resolving a COUNTERPARTY's inbox passes `false`: it runs on every send,
+  /// degrades to the default pool on either outcome, and overwrites nothing,
+  /// so it keeps the cache and the first answer it gets.
   Future<({_OwnDmInboxState state, List<String>? relays})> _queryOwnDmInbox(
     String pubkey, {
+    required bool requireAuthoritative,
     // Defaults to the strict reading so a call site added later fails closed.
     // Every path here except the signed-in user's own inbox is resolving
     // somebody else's list.
     _DmRelayListSource source = _DmRelayListSource.remote,
   }) async {
     try {
-      final events = await _nostrClient.queryEvents([
-        nostr_filter.Filter(
-          authors: [pubkey],
-          kinds: [EventKind.dmRelaysList],
-          limit: 1,
-        ),
-      ]);
+      final result = await _nostrClient.queryEventsDetailed(
+        [
+          nostr_filter.Filter(
+            authors: [pubkey],
+            kinds: [EventKind.dmRelaysList],
+            limit: 1,
+          ),
+        ],
+        useCache: !requireAuthoritative,
+        requireAllRelaysSettled: requireAuthoritative,
+        timeout: requireAuthoritative
+            ? _ownDmInboxAuthoritativeTimeout
+            : _dmInboxQueryTimeout,
+      );
+      final events = result.events;
+      // Computed here but applied ONLY at the two exits below where nothing
+      // matching came back. A read that DID return the list stays `found` even
+      // when some relay never settled: the list is in hand, and RC3's job is
+      // not to publish over it. Checking the flags before `events` — as the
+      // obvious form of this fix does — would discard a real answer, because
+      // the local cache leg is merged in regardless of how the relay leg went.
+      final _OwnDmInboxState absentOrFailed;
+      if (requireAuthoritative && (result.noRelays || result.timedOut)) {
+        absentOrFailed = _OwnDmInboxState.failed;
+        // `noRelays` first: an offline device sets both flags, and reporting
+        // that as a timeout misreads it.
+        final reason = result.noRelays
+            ? 'no relay took the REQ'
+            : 'not every relay settled';
+        Log.warning(
+          'Own kind-10050 lookup for ${pubkeyForLogs(pubkey)} was '
+          'inconclusive ($reason) — not publishing over a list we could not '
+          'read; will retry',
+          category: LogCategory.system,
+        );
+      } else {
+        absentOrFailed = _OwnDmInboxState.absent;
+      }
       if (events.isEmpty) {
-        return (state: _OwnDmInboxState.absent, relays: null);
+        return (state: absentOrFailed, relays: null);
       }
       final matchingEvents = [
         for (final event in events)
@@ -3153,7 +3232,7 @@ class DmRepository {
           '${pubkeyForLogs(pubkey)}',
           category: LogCategory.system,
         );
-        return (state: _OwnDmInboxState.absent, relays: null);
+        return (state: absentOrFailed, relays: null);
       }
       // Newest wins for a replaceable event served from multiple relays.
       matchingEvents.sort((a, b) => b.createdAt.compareTo(a.createdAt));
@@ -3199,9 +3278,16 @@ class DmRepository {
   /// left untouched. The own-inbox lookup distinguishes `found` / `absent` /
   /// `failed`, so a transient relay failure (`failed`) NEVER triggers a
   /// publish that could overwrite a real list divine simply couldn't fetch —
-  /// it retries next login. The lookup is the shared session memo, so it
-  /// reuses the live subscription's resolve rather than issuing a second
-  /// query. Idempotent per (device, pubkey) via
+  /// it retries next login.
+  ///
+  /// The lookup is its OWN authoritative read, not the shared session memo.
+  /// The memo is tuned for the live read — cached, and satisfied by the first
+  /// relay that answers — which is right for a caller that falls back to the
+  /// default pool but not for one about to replace what it read. Sharing it
+  /// was what made the guard above unreachable (#8212). The extra query is
+  /// bounded: this method returns early once `dmRelayListPublished` is set, so
+  /// it runs at most once per (device, pubkey), and it is never awaited by
+  /// login. Idempotent per (device, pubkey) via
   /// `DmSyncState.dmRelayListPublished`, with the flag set ONLY on a confirmed
   /// relay `OK`. A relay that rejects kind-10050 or a slow/failed signer
   /// leaves the flag unset and the next login retries — the publish never
@@ -3223,8 +3309,13 @@ class DmRepository {
     try {
       if (syncState.dmRelayListPublished(pubkey)) return;
 
-      // Shared session memo — dedupes with the live subscription's resolve.
-      final resolution = await _resolveOwnDmInbox();
+      // Its own authoritative read, NOT the shared session memo: this is the
+      // one caller that replaces what it read. See #8212.
+      final resolution = await _queryOwnDmInbox(
+        pubkey,
+        requireAuthoritative: true,
+        source: _DmRelayListSource.selfAuthored,
+      );
       if (_disposed || _resetGeneration != gen) return;
       if (resolution.state == _OwnDmInboxState.found) {
         // Already advertising an inbox — never overwrite a richer list.
@@ -3273,9 +3364,12 @@ class DmRepository {
       }
 
       await syncState.markDmRelayListPublished(pubkey);
+      // The event id is the anchor: a relay serves only the newest revision of
+      // a replaceable kind for a coordinate query, so an id is the one handle
+      // that still reaches an earlier one. Logged whole.
       Log.info(
         'Published kind-10050 DM inbox relay list for ${pubkeyForLogs(pubkey)} '
-        '-> $relayUrl',
+        '-> $relayUrl (event ${signed.id})',
         category: LogCategory.system,
       );
     } on Object catch (e, stackTrace) {

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -970,12 +970,12 @@ class DmRepository {
   /// Resolves and memoizes the CURRENT user's own kind-10050 DM inbox
   /// resolution for the session (#4974 RC2).
   ///
-  /// Shared by the live subscription, the history drain, and the RC3
-  /// existence check, so the relay is queried at most once per login. A
-  /// `found`/`absent` outcome is cached; a `failed` (transient) outcome is
-  /// NOT — the memo clears itself once it resolves `failed` so the next
-  /// caller re-queries instead of degrading the whole session to the default
-  /// pool. [_resetState] clears the memo on account switch.
+  /// Shared by the live subscription, history drain, and read-marker publish.
+  /// The RC3 existence check deliberately performs its own authoritative read.
+  /// A `found`/`absent` outcome is cached; a `failed` (transient) outcome is NOT
+  /// — the memo clears itself once it resolves `failed` so the next caller
+  /// re-queries instead of degrading the whole session to the default pool.
+  /// [_resetState] clears the memo on account switch.
   Future<({_OwnDmInboxState state, List<String>? relays})>
   _resolveOwnDmInbox() {
     final cached = _ownInboxFuture;
@@ -1746,9 +1746,7 @@ class DmRepository {
     });
   }
 
-  Future<void> _withGiftWrapProcessingLock(
-    Future<void> Function() body,
-  ) async {
+  Future<void> _withGiftWrapProcessingLock(Future<void> Function() body) async {
     while (_giftWrapProcessingLock != null) {
       await _giftWrapProcessingLock;
     }
@@ -1842,10 +1840,8 @@ class DmRepository {
         deleterPubkey: rumor.pubkey,
         giftWrapId: giftWrapId,
       );
-      Future<DmWrapOutcome?> asMessage() async => _applyMessageDeletion(
-        rumorId: rumorId,
-        deleterPubkey: rumor.pubkey,
-      );
+      Future<DmWrapOutcome?> asMessage() async =>
+          _applyMessageDeletion(rumorId: rumorId, deleterPubkey: rumor.pubkey);
 
       final resolved = tryReactionsFirst
           ? await asReaction() ?? await asMessage()
@@ -3199,26 +3195,34 @@ class DmRepository {
       // matching came back. A read that DID return the list stays `found` even
       // when some relay never settled: the list is in hand, and RC3's job is
       // not to publish over it. Checking the flags before `events` — as the
-      // obvious form of this fix does — would discard a real answer, because
-      // the local cache leg is merged in regardless of how the relay leg went.
+      // obvious form of this fix does — would discard a real answer from a
+      // relay that settled before another relay timed out.
       final _OwnDmInboxState absentOrFailed;
+      String? inconclusiveReason;
       if (requireAuthoritative && (result.noRelays || result.timedOut)) {
         absentOrFailed = _OwnDmInboxState.failed;
         // `noRelays` first: an offline device sets both flags, and reporting
         // that as a timeout misreads it.
-        final reason = result.noRelays
+        inconclusiveReason = result.noRelays
             ? 'no relay took the REQ'
             : 'not every relay settled';
+      } else {
+        absentOrFailed = _OwnDmInboxState.absent;
+      }
+
+      void logInconclusiveRead() {
+        final reason = inconclusiveReason;
+        if (reason == null) return;
         Log.warning(
           'Own kind-10050 lookup for ${pubkeyForLogs(pubkey)} was '
           'inconclusive ($reason) — not publishing over a list we could not '
           'read; will retry',
           category: LogCategory.system,
         );
-      } else {
-        absentOrFailed = _OwnDmInboxState.absent;
       }
+
       if (events.isEmpty) {
+        logInconclusiveRead();
         return (state: absentOrFailed, relays: null);
       }
       final matchingEvents = [
@@ -3232,6 +3236,7 @@ class DmRepository {
           '${pubkeyForLogs(pubkey)}',
           category: LogCategory.system,
         );
+        logInconclusiveRead();
         return (state: absentOrFailed, relays: null);
       }
       // Newest wins for a replaceable event served from multiple relays.

--- a/mobile/packages/dm_repository/test/src/dm_future_dated_created_at_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_future_dated_created_at_test.dart
@@ -27,6 +27,12 @@ const _privateKey =
 const _year2100 = 4102444800;
 
 void main() {
+  setUpAll(() {
+    // queryEventsDetailed takes a `Duration timeout`, so a stub matching on
+    // it needs a fallback (#8212).
+    registerFallbackValue(Duration.zero);
+  });
+
   group('a future-dated NIP-04 DM cannot freeze the unread badge', () {
     late AppDatabase db;
     late ConversationsDao conversationsDao;
@@ -51,6 +57,25 @@ void main() {
           useCache: any(named: 'useCache'),
         ),
       ).thenAnswer((_) async => const <Event>[]);
+      // The own kind-10050 resolve reads through queryEventsDetailed (#8212).
+      // Answered and empty: the relays replied and there is no list, so the
+      // live subscription falls back to the default pool as before.
+      when(
+        () => nostrClient.queryEventsDetailed(
+          any(),
+          subscriptionId: any(named: 'subscriptionId'),
+          useCache: any(named: 'useCache'),
+          tempRelays: any(named: 'tempRelays'),
+          requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+          timeout: any(named: 'timeout'),
+        ),
+      ).thenAnswer(
+        (_) async => (
+          events: const <Event>[],
+          timedOut: false,
+          noRelays: false,
+        ),
+      );
       when(() => nostrClient.unsubscribe(any())).thenAnswer((_) async {});
       when(
         () => nostrClient.subscribe(

--- a/mobile/packages/dm_repository/test/src/dm_identical_text_repeat_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_identical_text_repeat_test.dart
@@ -33,6 +33,12 @@ void main() {
   // database. The mock-based suite in dm_repository_test.dart stubs
   // hasMatchingMessage to a constant in its top-level setUp, so a test
   // written there would pass whether or not the dedup is correct.
+  setUpAll(() {
+    // queryEventsDetailed takes a `Duration timeout`, so a stub matching on
+    // it needs a fallback (#8212).
+    registerFallbackValue(Duration.zero);
+  });
+
   group('two genuine messages sharing their text', () {
     late AppDatabase db;
     late ConversationsDao conversationsDao;
@@ -59,6 +65,25 @@ void main() {
           useCache: any(named: 'useCache'),
         ),
       ).thenAnswer((_) async => const <Event>[]);
+      // The own kind-10050 resolve reads through queryEventsDetailed (#8212).
+      // Answered and empty: the relays replied and there is no list, so the
+      // live subscription falls back to the default pool as before.
+      when(
+        () => nostrClient.queryEventsDetailed(
+          any(),
+          subscriptionId: any(named: 'subscriptionId'),
+          useCache: any(named: 'useCache'),
+          tempRelays: any(named: 'tempRelays'),
+          requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+          timeout: any(named: 'timeout'),
+        ),
+      ).thenAnswer(
+        (_) async => (
+          events: const <Event>[],
+          timedOut: false,
+          noRelays: false,
+        ),
+      );
       when(() => nostrClient.unsubscribe(any())).thenAnswer((_) async {});
       when(
         () => nostrClient.subscribe(

--- a/mobile/packages/dm_repository/test/src/dm_legacy_own_send_shape_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_legacy_own_send_shape_test.dart
@@ -25,6 +25,10 @@ const _privateKey =
 const _baseCreatedAt = 1700000000;
 
 void main() {
+  setUpAll(() {
+    registerFallbackValue(Duration.zero);
+  });
+
   // Drives the real DirectMessagesDao against a real database. The
   // mock suite stubs hasMatchingMessage to a constant in its top-level
   // setUp, so a test written there cannot observe this at all (#8170).
@@ -56,6 +60,19 @@ void main() {
           useCache: any(named: 'useCache'),
         ),
       ).thenAnswer((_) async => const <Event>[]);
+      when(
+        () => nostrClient.queryEventsDetailed(
+          any(),
+          subscriptionId: any(named: 'subscriptionId'),
+          useCache: any(named: 'useCache'),
+          tempRelays: any(named: 'tempRelays'),
+          requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+          timeout: any(named: 'timeout'),
+        ),
+      ).thenAnswer(
+        (_) async =>
+            (events: const <Event>[], timedOut: false, noRelays: false),
+      );
       when(() => nostrClient.unsubscribe(any())).thenAnswer((_) async {});
       when(
         () => nostrClient.subscribe(

--- a/mobile/packages/dm_repository/test/src/dm_read_cursor_retry_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_read_cursor_retry_test.dart
@@ -28,6 +28,10 @@ const _readMarkerDTag = 'divine/dm-read/v1';
 const _baseCreatedAt = 1700000000;
 
 void main() {
+  setUpAll(() {
+    registerFallbackValue(Duration.zero);
+  });
+
   // Drives the real ConversationsDao against a real database. The mock suite
   // in dm_repository_test.dart stubs applyReadCursor to a constant `true` in
   // its top-level setUp, so the `!applied` retry branch never executes there
@@ -69,6 +73,19 @@ void main() {
             useCache: any(named: 'useCache'),
           ),
         ).thenAnswer((_) async => const <Event>[]);
+        when(
+          () => nostrClient.queryEventsDetailed(
+            any(),
+            subscriptionId: any(named: 'subscriptionId'),
+            useCache: any(named: 'useCache'),
+            tempRelays: any(named: 'tempRelays'),
+            requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+            timeout: any(named: 'timeout'),
+          ),
+        ).thenAnswer(
+          (_) async =>
+              (events: const <Event>[], timedOut: false, noRelays: false),
+        );
         when(() => nostrClient.unsubscribe(any())).thenAnswer((_) async {});
         when(
           () => nostrClient.subscribe(

--- a/mobile/packages/dm_repository/test/src/dm_repository_cold_start_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_cold_start_test.dart
@@ -36,6 +36,8 @@ void main() {
 
     setUpAll(() {
       registerFallbackValue(_FakeEvent());
+      // queryEventsDetailed takes a `Duration timeout` (#8212).
+      registerFallbackValue(Duration.zero);
     });
 
     setUp(() {
@@ -80,7 +82,9 @@ void main() {
           ),
         );
 
-        // No one-shot relay query either.
+        // No one-shot relay query either, through either read API — the own
+        // kind-10050 resolve moved to queryEventsDetailed (#8212), so
+        // asserting only on queryEvents would pass vacuously.
         verifyNever(
           () => mockNostrClient.queryEvents(
             any(),
@@ -89,6 +93,18 @@ void main() {
             relayTypes: any(named: 'relayTypes'),
             sendAfterAuth: any(named: 'sendAfterAuth'),
             useCache: any(named: 'useCache'),
+          ),
+        );
+        verifyNever(
+          () => mockNostrClient.queryEventsDetailed(
+            any(),
+            subscriptionId: any(named: 'subscriptionId'),
+            tempRelays: any(named: 'tempRelays'),
+            relayTypes: any(named: 'relayTypes'),
+            sendAfterAuth: any(named: 'sendAfterAuth'),
+            useCache: any(named: 'useCache'),
+            requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+            timeout: any(named: 'timeout'),
           ),
         );
 

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -219,6 +219,22 @@ class _InMemoryRemovedConversationsDao extends Mock
 
 class _MockNostrClient extends Mock implements NostrClient {}
 
+/// Shapes a `queryEventsDetailed` answer to a kind-10050 lookup that the relays
+/// actually gave: an empty [events] is genuine absence, which is the only thing
+/// the RC3 publisher may act on (#8212).
+({List<Event> events, bool timedOut, bool noRelays}) answeredList(
+  List<Event> events,
+) => (events: events, timedOut: false, noRelays: false);
+
+/// Shapes a kind-10050 lookup nothing answered: a fan-out no relay took
+/// ([noRelays]), or a relay that refused the REQ with `CLOSED` / a settle window
+/// that completed while the relay holding the list stayed silent ([timedOut]).
+/// The empty list means nothing — RC3 must NOT read it as absence (#8212).
+({List<Event> events, bool timedOut, bool noRelays}) unansweredList({
+  bool noRelays = false,
+  bool timedOut = false,
+}) => (events: const <Event>[], timedOut: timedOut, noRelays: noRelays);
+
 class _MockNIP17MessageService extends Mock implements NIP17MessageService {}
 
 class _MockDirectMessagesDao extends Mock implements DirectMessagesDao {}
@@ -501,6 +517,9 @@ void main() {
       registerFallbackValue(_FakeOutgoingDm());
       registerFallbackValue(OutgoingWrapStatus.pending);
       registerFallbackValue(DmDedupCounterpart.nip04Copy);
+      // `queryEventsDetailed` takes a `Duration timeout`, so any stub that
+      // matches on it needs a fallback (#8212).
+      registerFallbackValue(Duration.zero);
     });
 
     setUp(() {
@@ -536,9 +555,8 @@ void main() {
         () => mockDirectMessagesDao.giftWrapIdsPresent(any()),
       ).thenAnswer((_) async => const <String>{});
 
-      // Default for resolveDmInboxRelays(), which sendMessage now calls on
-      // every send: recipient has no kind-10050 list, so the gift wrap
-      // falls back to the default relay pool (existing behavior).
+      // Default for the history drain's paged reads, which still go through
+      // queryEvents.
       when(
         () => mockNostrClient.queryEvents(
           any(),
@@ -546,6 +564,23 @@ void main() {
           useCache: any(named: 'useCache'),
         ),
       ).thenAnswer((_) async => <Event>[]);
+
+      // Default for every kind-10050 lookup — resolveDmInboxRelays() on the
+      // send path, the memoized own-inbox resolve, and the RC3 publish check.
+      // ANSWERED and empty: the relays replied and this pubkey genuinely has
+      // no list, which is what every test that does not care about the read
+      // assumed when it went through queryEvents. An UNANSWERED empty is a
+      // different outcome and must be stubbed explicitly (#8212).
+      when(
+        () => mockNostrClient.queryEventsDetailed(
+          any(),
+          subscriptionId: any(named: 'subscriptionId'),
+          useCache: any(named: 'useCache'),
+          tempRelays: any(named: 'tempRelays'),
+          requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+          timeout: any(named: 'timeout'),
+        ),
+      ).thenAnswer((_) async => answeredList(const <Event>[]));
 
       // Stub backfillCurrentUserHasSent for _backfillCurrentUserHasSent().
       when(
@@ -3766,16 +3801,26 @@ void main() {
         // Wait well beyond any former poll interval.
         await Future<void>.delayed(const Duration(milliseconds: 100));
 
-        // queryEvents is called EXACTLY once — the one-shot #4974 own
-        // kind-10050 inbox-relay resolve at subscription open — and never
-        // again: no background poller re-fetches events on a timer.
+        // The relay is read EXACTLY once — the one-shot #4974 own kind-10050
+        // inbox-relay resolve at subscription open — and never again: no
+        // background poller re-fetches events on a timer.
         verify(
+          () => mockNostrClient.queryEventsDetailed(
+            any(),
+            subscriptionId: any(named: 'subscriptionId'),
+            useCache: any(named: 'useCache'),
+            tempRelays: any(named: 'tempRelays'),
+            requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+            timeout: any(named: 'timeout'),
+          ),
+        ).called(1);
+        verifyNever(
           () => mockNostrClient.queryEvents(
             any(),
             subscriptionId: any(named: 'subscriptionId'),
             useCache: any(named: 'useCache'),
           ),
-        ).called(1);
+        );
 
         await repository.stopListening();
         await controller.close();
@@ -3867,12 +3912,15 @@ void main() {
 
       void stubQuery(List<Event> events) {
         when(
-          () => mockNostrClient.queryEvents(
+          () => mockNostrClient.queryEventsDetailed(
             any(),
             subscriptionId: any(named: 'subscriptionId'),
             useCache: any(named: 'useCache'),
+            tempRelays: any(named: 'tempRelays'),
+            requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+            timeout: any(named: 'timeout'),
           ),
-        ).thenAnswer((_) async => events);
+        ).thenAnswer((_) async => answeredList(events));
       }
 
       test('returns relay urls from the kind-10050 relay tags', () async {
@@ -4025,10 +4073,15 @@ void main() {
         await repository.resolveDmInboxRelays(_validPubkeyB);
         final captured =
             verify(
-                  () => mockNostrClient.queryEvents(
+                  () => mockNostrClient.queryEventsDetailed(
                     captureAny(),
                     subscriptionId: any(named: 'subscriptionId'),
                     useCache: any(named: 'useCache'),
+                    tempRelays: any(named: 'tempRelays'),
+                    requireAllRelaysSettled: any(
+                      named: 'requireAllRelaysSettled',
+                    ),
+                    timeout: any(named: 'timeout'),
                   ),
                 ).captured.single
                 as List<nostr_filter.Filter>;
@@ -4038,10 +4091,13 @@ void main() {
 
       test('returns null and does not throw when the query errors', () async {
         when(
-          () => mockNostrClient.queryEvents(
+          () => mockNostrClient.queryEventsDetailed(
             any(),
             subscriptionId: any(named: 'subscriptionId'),
             useCache: any(named: 'useCache'),
+            tempRelays: any(named: 'tempRelays'),
+            requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+            timeout: any(named: 'timeout'),
           ),
         ).thenThrow(Exception('relay down'));
         final repository = createRepository();
@@ -4052,13 +4108,16 @@ void main() {
         // Some clients write `r` tags into a kind-10050; within a 10050 event
         // both denote DM inbox relays, so both must be read. See divine-web.
         when(
-          () => mockNostrClient.queryEvents(
+          () => mockNostrClient.queryEventsDetailed(
             any(),
             subscriptionId: any(named: 'subscriptionId'),
             useCache: any(named: 'useCache'),
+            tempRelays: any(named: 'tempRelays'),
+            requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+            timeout: any(named: 'timeout'),
           ),
         ).thenAnswer(
-          (_) async => [
+          (_) async => answeredList([
             Event(
               _validPubkeyB,
               EventKind.dmRelaysList,
@@ -4069,7 +4128,7 @@ void main() {
               '',
               createdAt: 1700000000,
             ),
-          ],
+          ]),
         );
         final repository = createRepository();
         expect(
@@ -4095,15 +4154,18 @@ void main() {
         'tempRelays and targetRelays',
         () async {
           when(
-            () => mockNostrClient.queryEvents(
+            () => mockNostrClient.queryEventsDetailed(
               any(),
               subscriptionId: any(named: 'subscriptionId'),
               useCache: any(named: 'useCache'),
+              tempRelays: any(named: 'tempRelays'),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+              timeout: any(named: 'timeout'),
             ),
           ).thenAnswer(
-            (_) async => [
+            (_) async => answeredList([
               ownInbox(['wss://own.example']),
-            ],
+            ]),
           );
           final controller = StreamController<Event>();
           when(
@@ -4174,6 +4236,22 @@ void main() {
         () async {
           final capturedDrainTempRelays = <List<String>?>[];
           when(
+            () => mockNostrClient.queryEventsDetailed(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+              useCache: any(named: 'useCache'),
+              tempRelays: any(named: 'tempRelays'),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+              timeout: any(named: 'timeout'),
+            ),
+          ).thenAnswer(
+            (_) async => answeredList([
+              ownInbox(['wss://own.example']),
+            ]),
+          );
+          // The drain pages still read through queryEvents; only the own
+          // kind-10050 resolve moved to queryEventsDetailed (#8212).
+          when(
             () => mockNostrClient.queryEvents(
               any(),
               subscriptionId: any(named: 'subscriptionId'),
@@ -4184,11 +4262,6 @@ void main() {
             final filter =
                 (inv.positionalArguments.first as List<nostr_filter.Filter>)
                     .single;
-            if (filter.kinds?.contains(EventKind.dmRelaysList) ?? false) {
-              return [
-                ownInbox(['wss://own.example']),
-              ];
-            }
             // Only the gift-wrap drain pages carry p:[self]; capture their
             // tempRelays (the NIP-04 recovery uses authors:[self] with no p
             // and is intentionally not 10050-targeted).
@@ -4227,12 +4300,17 @@ void main() {
               targetRelays: any(named: 'targetRelays'),
             ),
           ).thenAnswer((_) => controller.stream);
+          // Answered on purpose: an unanswered read resolves to `failed`,
+          // which is deliberately NOT memoized, so the second consumer would
+          // re-query and this count would be 2 (#8212).
           when(
-            () => mockNostrClient.queryEvents(
+            () => mockNostrClient.queryEventsDetailed(
               any(),
               subscriptionId: any(named: 'subscriptionId'),
               useCache: any(named: 'useCache'),
               tempRelays: any(named: 'tempRelays'),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+              timeout: any(named: 'timeout'),
             ),
           ).thenAnswer((inv) async {
             final filter =
@@ -4240,11 +4318,11 @@ void main() {
                     .single;
             if (filter.kinds?.contains(EventKind.dmRelaysList) ?? false) {
               resolveQueries++;
-              return [
+              return answeredList([
                 ownInbox(['wss://own.example']),
-              ];
+              ]);
             }
-            return const <Event>[];
+            return answeredList(const <Event>[]);
           });
 
           final syncState = _FakeDmSyncState()
@@ -4421,15 +4499,18 @@ void main() {
         'advertises a kind-10050',
         () async {
           when(
-            () => mockNostrClient.queryEvents(
+            () => mockNostrClient.queryEventsDetailed(
               any(),
               subscriptionId: any(named: 'subscriptionId'),
               useCache: any(named: 'useCache'),
+              tempRelays: any(named: 'tempRelays'),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+              timeout: any(named: 'timeout'),
             ),
           ).thenAnswer(
-            (_) async => [
+            (_) async => answeredList([
               existingInbox(['wss://own.example']),
-            ],
+            ]),
           );
 
           final syncState = _FakeDmSyncState();
@@ -4508,10 +4589,13 @@ void main() {
 
         // Gated before any work — no relay query, no signer round-trip.
         verifyNever(
-          () => mockNostrClient.queryEvents(
+          () => mockNostrClient.queryEventsDetailed(
             any(),
             subscriptionId: any(named: 'subscriptionId'),
             useCache: any(named: 'useCache'),
+            tempRelays: any(named: 'tempRelays'),
+            requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+            timeout: any(named: 'timeout'),
           ),
         );
         verifyNever(
@@ -4528,10 +4612,13 @@ void main() {
         '(transient) — never overwrites a real list',
         () async {
           when(
-            () => mockNostrClient.queryEvents(
+            () => mockNostrClient.queryEventsDetailed(
               any(),
               subscriptionId: any(named: 'subscriptionId'),
               useCache: any(named: 'useCache'),
+              tempRelays: any(named: 'tempRelays'),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+              timeout: any(named: 'timeout'),
             ),
           ).thenThrow(Exception('relay down'));
 
@@ -4555,15 +4642,18 @@ void main() {
         () async {
           var queries = 0;
           when(
-            () => mockNostrClient.queryEvents(
+            () => mockNostrClient.queryEventsDetailed(
               any(),
               subscriptionId: any(named: 'subscriptionId'),
               useCache: any(named: 'useCache'),
+              tempRelays: any(named: 'tempRelays'),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+              timeout: any(named: 'timeout'),
             ),
           ).thenAnswer((_) async {
             queries++;
             if (queries == 1) throw Exception('relay down');
-            return const <Event>[]; // absent on the retry
+            return answeredList(const <Event>[]); // absent on the retry
           });
           when(
             () => mockNostrClient.publishEventAwaitOk(
@@ -4597,10 +4687,15 @@ void main() {
       );
 
       test(
-        'reuses the live subscription own-inbox resolve — one kind-10050 '
-        'query shared at login',
+        'does NOT reuse the live subscription resolve — the publish reads the '
+        'own kind-10050 authoritatively on its own (#8212)',
         () async {
-          var resolveQueries = 0;
+          // The live read is cached and satisfied by the first relay that
+          // answers, which is right for a caller that falls back to the
+          // default pool and wrong for one about to REPLACE what it read.
+          // Sharing one read between them is what made the publish guard
+          // unreachable, so the publish now pays its own query.
+          final settlementByRead = <bool?>[];
           final controller = StreamController<Event>();
           when(
             () => mockNostrClient.subscribe(
@@ -4611,19 +4706,24 @@ void main() {
             ),
           ).thenAnswer((_) => controller.stream);
           when(
-            () => mockNostrClient.queryEvents(
+            () => mockNostrClient.queryEventsDetailed(
               any(),
               subscriptionId: any(named: 'subscriptionId'),
               useCache: any(named: 'useCache'),
+              tempRelays: any(named: 'tempRelays'),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+              timeout: any(named: 'timeout'),
             ),
           ).thenAnswer((inv) async {
             final filter =
                 (inv.positionalArguments.first as List<nostr_filter.Filter>)
                     .single;
             if (filter.kinds?.contains(EventKind.dmRelaysList) ?? false) {
-              resolveQueries++;
+              settlementByRead.add(
+                inv.namedArguments[#requireAllRelaysSettled] as bool?,
+              );
             }
-            return const <Event>[];
+            return answeredList(const <Event>[]);
           });
           when(
             () => mockNostrClient.publishEventAwaitOk(
@@ -4637,12 +4737,262 @@ void main() {
           await repository.startListening();
           await repository.ensureDmRelayListPublished();
 
-          expect(resolveQueries, 1);
+          // The live read stays cheap; exactly one read is authoritative.
+          expect(settlementByRead, [false, true]);
 
           await repository.stopListening();
           await controller.close();
         },
       );
+
+      group('own kind-10050 authoritative read (#8212)', () {
+        void stubOwnInbox(
+          ({List<Event> events, bool timedOut, bool noRelays}) answer,
+        ) {
+          when(
+            () => mockNostrClient.queryEventsDetailed(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+              useCache: any(named: 'useCache'),
+              tempRelays: any(named: 'tempRelays'),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+              timeout: any(named: 'timeout'),
+            ),
+          ).thenAnswer((_) async => answer);
+        }
+
+        void stubAcceptedPublish() {
+          when(
+            () => mockNostrClient.publishEventAwaitOk(
+              any(),
+              targetRelays: any(named: 'targetRelays'),
+            ),
+          ).thenAnswer((_) async => outcome(accepted: true));
+        }
+
+        test(
+          'does NOT publish when the own-inbox read reached no relay — a '
+          'fan-out nobody took is not evidence of absence',
+          () async {
+            stubOwnInbox(unansweredList(noRelays: true));
+            stubAcceptedPublish();
+
+            final syncState = _FakeDmSyncState();
+            final repository = createRepository(syncState: syncState);
+            await repository.ensureDmRelayListPublished();
+
+            verifyNever(
+              () => mockNostrClient.publishEventAwaitOk(
+                any(),
+                targetRelays: any(named: 'targetRelays'),
+              ),
+            );
+            expect(syncState.dmRelayListPublishedPubkeys, isEmpty);
+          },
+        );
+
+        test(
+          'does NOT publish when the own-inbox read did not settle — a relay '
+          'that refused the REQ is not evidence of absence',
+          () async {
+            stubOwnInbox(unansweredList(timedOut: true));
+            stubAcceptedPublish();
+
+            final syncState = _FakeDmSyncState();
+            final repository = createRepository(syncState: syncState);
+            await repository.ensureDmRelayListPublished();
+
+            verifyNever(
+              () => mockNostrClient.publishEventAwaitOk(
+                any(),
+                targetRelays: any(named: 'targetRelays'),
+              ),
+            );
+            expect(syncState.dmRelayListPublishedPubkeys, isEmpty);
+          },
+        );
+
+        test(
+          'still publishes when the relays answered and the user genuinely '
+          'has no kind-10050',
+          () async {
+            stubOwnInbox(answeredList(const <Event>[]));
+            stubAcceptedPublish();
+
+            final syncState = _FakeDmSyncState();
+            final repository = createRepository(syncState: syncState);
+            await repository.ensureDmRelayListPublished();
+
+            verify(
+              () => mockNostrClient.publishEventAwaitOk(
+                any(),
+                targetRelays: any(named: 'targetRelays'),
+              ),
+            ).called(1);
+            expect(
+              syncState.dmRelayListPublishedPubkeys,
+              contains(_validPubkeyA),
+            );
+          },
+        );
+
+        test(
+          'a partially settled read that DID return the list is found, never '
+          'republished',
+          () async {
+            stubOwnInbox((
+              events: [
+                existingInbox(const ['wss://own.example']),
+              ],
+              timedOut: true,
+              noRelays: false,
+            ));
+            stubAcceptedPublish();
+
+            final syncState = _FakeDmSyncState();
+            final repository = createRepository(syncState: syncState);
+            await repository.ensureDmRelayListPublished();
+
+            verifyNever(
+              () => mockNostrClient.publishEventAwaitOk(
+                any(),
+                targetRelays: any(named: 'targetRelays'),
+              ),
+            );
+            // `found`, not `failed` — the flag is recorded so the device stops
+            // re-checking.
+            expect(
+              syncState.dmRelayListPublishedPubkeys,
+              contains(_validPubkeyA),
+            );
+          },
+        );
+
+        test(
+          'reads the own kind-10050 authoritatively: no cache, full relay '
+          'settlement',
+          () async {
+            stubOwnInbox(answeredList(const <Event>[]));
+            stubAcceptedPublish();
+
+            final repository = createRepository(syncState: _FakeDmSyncState());
+            await repository.ensureDmRelayListPublished();
+
+            final captured = verify(
+              () => mockNostrClient.queryEventsDetailed(
+                captureAny(),
+                subscriptionId: any(named: 'subscriptionId'),
+                useCache: captureAny(named: 'useCache'),
+                tempRelays: any(named: 'tempRelays'),
+                requireAllRelaysSettled: captureAny(
+                  named: 'requireAllRelaysSettled',
+                ),
+                timeout: any(named: 'timeout'),
+              ),
+            ).captured;
+
+            var sawOwnInboxRead = false;
+            for (var i = 0; i < captured.length; i += 3) {
+              final filters = captured[i] as List<nostr_filter.Filter>;
+              if (!(filters.single.kinds?.contains(EventKind.dmRelaysList) ??
+                  false)) {
+                continue;
+              }
+              sawOwnInboxRead = true;
+              expect(captured[i + 1], isFalse, reason: 'useCache');
+              expect(
+                captured[i + 2],
+                isTrue,
+                reason: 'requireAllRelaysSettled',
+              );
+            }
+            expect(sawOwnInboxRead, isTrue);
+          },
+        );
+
+        test(
+          'reads a recipient kind-10050 cheaply: cache on, first answer wins',
+          () async {
+            stubOwnInbox(answeredList(const <Event>[]));
+
+            final repository = createRepository(syncState: _FakeDmSyncState());
+            await repository.resolveDmInboxRelays(_validPubkeyB);
+
+            final captured = verify(
+              () => mockNostrClient.queryEventsDetailed(
+                captureAny(),
+                subscriptionId: any(named: 'subscriptionId'),
+                useCache: captureAny(named: 'useCache'),
+                tempRelays: any(named: 'tempRelays'),
+                requireAllRelaysSettled: captureAny(
+                  named: 'requireAllRelaysSettled',
+                ),
+                timeout: any(named: 'timeout'),
+              ),
+            ).captured;
+
+            var sawRecipientRead = false;
+            for (var i = 0; i < captured.length; i += 3) {
+              final filters = captured[i] as List<nostr_filter.Filter>;
+              if (!(filters.single.kinds?.contains(EventKind.dmRelaysList) ??
+                  false)) {
+                continue;
+              }
+              sawRecipientRead = true;
+              expect(captured[i + 1], isTrue, reason: 'useCache');
+              expect(
+                captured[i + 2],
+                isFalse,
+                reason: 'requireAllRelaysSettled',
+              );
+            }
+            expect(sawRecipientRead, isTrue);
+          },
+        );
+
+        test(
+          'an unanswered own-inbox read is not memoized — a later call '
+          're-queries and can publish',
+          () async {
+            var queries = 0;
+            when(
+              () => mockNostrClient.queryEventsDetailed(
+                any(),
+                subscriptionId: any(named: 'subscriptionId'),
+                useCache: any(named: 'useCache'),
+                tempRelays: any(named: 'tempRelays'),
+                requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+                timeout: any(named: 'timeout'),
+              ),
+            ).thenAnswer((_) async {
+              queries++;
+              // A read nothing answered — not an exception. This is the shape
+              // #8212 actually fails in; the throwing variant is a separate
+              // test. It must leave the path re-runnable just the same.
+              if (queries == 1) return unansweredList(timedOut: true);
+              return answeredList(const <Event>[]);
+            });
+            stubAcceptedPublish();
+
+            final syncState = _FakeDmSyncState();
+            final repository = createRepository(syncState: syncState);
+            await repository.ensureDmRelayListPublished();
+            await repository.ensureDmRelayListPublished();
+
+            expect(queries, 2);
+            verify(
+              () => mockNostrClient.publishEventAwaitOk(
+                any(),
+                targetRelays: any(named: 'targetRelays'),
+              ),
+            ).called(1);
+            expect(
+              syncState.dmRelayListPublishedPubkeys,
+              contains(_validPubkeyA),
+            );
+          },
+        );
+      });
     });
 
     group('backfillHistoryIfNeeded', () {
@@ -17950,17 +18300,20 @@ void main() {
           // author query); each wrap must route there with OK-confirm, not the
           // default pool.
           when(
-            () => mockNostrClient.queryEvents(
+            () => mockNostrClient.queryEventsDetailed(
               any(),
               subscriptionId: any(named: 'subscriptionId'),
               useCache: any(named: 'useCache'),
+              tempRelays: any(named: 'tempRelays'),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+              timeout: any(named: 'timeout'),
             ),
           ).thenAnswer((invocation) async {
             final filters =
                 invocation.positionalArguments.first
                     as List<nostr_filter.Filter>;
             final recipient = filters.single.authors!.single;
-            return [
+            return answeredList([
               Event(
                 recipient,
                 EventKind.dmRelaysList,
@@ -17970,7 +18323,7 @@ void main() {
                 '',
                 createdAt: 1700000000,
               ),
-            ];
+            ]);
           });
           stubSendRumor((_, recipient) async {
             return NIP17SendResult.success(
@@ -20828,13 +21181,16 @@ void main() {
           // OK-confirm is meaningful for an inbox-only reader, not satisfied
           // by an unrelated default-pool relay.
           when(
-            () => mockNostrClient.queryEvents(
+            () => mockNostrClient.queryEventsDetailed(
               any(),
               subscriptionId: any(named: 'subscriptionId'),
               useCache: any(named: 'useCache'),
+              tempRelays: any(named: 'tempRelays'),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+              timeout: any(named: 'timeout'),
             ),
           ).thenAnswer(
-            (_) async => [
+            (_) async => answeredList([
               Event(
                 _validPubkeyB,
                 EventKind.dmRelaysList,
@@ -20844,7 +21200,7 @@ void main() {
                 '',
                 createdAt: 1700000000,
               ),
-            ],
+            ]),
           );
           stubSendRumor(
             (_, recipientPubkey) async => NIP17SendResult.success(


### PR DESCRIPTION
Closes #8212

## Summary

`ensureDmRelayListPublished` carries a guard that refuses to publish when the own-inbox lookup was inconclusive, so a transient relay failure cannot replace a kind-10050 the user set from another client. That guard is unreachable.

`_queryOwnDmInbox` read through `NostrClient.queryEvents`, which is `queryEventsDetailed(...)` followed by `return result.events;` — the two flags that separate *"the relays answered and there is nothing"* from *"nobody answered"* are dropped. A fan-out no relay took, a relay that refused the REQ with `CLOSED`, a disposed client and a closed query pool all arrive as an ordinary empty list and are classified `absent`, the one state that publishes. `_OwnDmInboxState.failed` was producible in production only by a Drift exception.

The API's own docstring states the rule this call site broke (`nostr_client.dart:867-878`):

> Set `requireAllRelaysSettled` when that distinction is load-bearing — **a caller about to replace what it read cannot act on a partial answer**.

Fixes the defect reported in #8212. **Blocks #7336**, whose stated safety property — *"a transient relay error never clobbers an existing list"* — only becomes true once this lands.

## What changed

`_queryOwnDmInbox` gains a `required bool requireAuthoritative` mode that reads through `queryEventsDetailed` with `useCache: false` and `requireAllRelaysSettled: true`.

The inconclusive → `failed` mapping applies **only at the two exits where nothing matching came back**. A read that *did* return the list stays `found` even when some relay never settled — the list is in hand, and the publisher's job is not to overwrite it. Checking the flags before `events`, which is the obvious form of this fix and the one the issue suggests, would discard a real answer: one relay can return the list while another relay remains unsettled, so `events` can be non-empty while `timedOut` is true.

The publish path reads authoritatively **on its own** rather than sharing the session memo:

| caller | mode | why |
|---|---|---|
| `ensureDmRelayListPublished` | authoritative | about to replace what it read |
| `_resolveOwnDmInbox` (live subscription, history drain, read-marker publish) | cheap, cached, memoized | falls back to the default pool either way |
| `resolveDmInboxRelays` (send path) | cheap, cached | overwrites nothing; unchanged |

`startListening` awaits the memo *before* opening the gift-wrap subscription, and one connected-but-silent relay spends the whole budget even after a healthy relay has answered — measured at 6004ms on a 6s budget while probing #8217. Making the shared memo strict would put that in front of DM delivery on every login and every reconnect, to protect a write that happens at most once per (device, pubkey). The publish read is `unawaited` and bounded by the `dmRelayListPublished` flag, so nothing waits on it.

The authoritative read takes a **3s** budget rather than the 5s default. Probing the default pool (`IndexerRelayConfig.safeFallbackRelays` + Divine's relay, 3 tries each): `relay.divine.video` 0.98–1.07s, `nos.lol` 0.50–0.57s, `relay.primal.net` 0.63–0.67s all answered 3/3, while `relay.nos.social` and `relay.damus.io` failed to connect 3/3 — and a non-connected relay is excluded by `_canStillSettleQuery`, so it does not hold the query open. 3s stays conclusive against that pool and halves the pathological case. An expiry reports `timedOut` → `failed` → no publish, so erring short errs toward not overwriting.

Two log lines: why an inconclusive read was inconclusive (so #7336 can measure the rate before flipping the default), and the published event id — a relay serves only the newest revision of a replaceable kind for a coordinate query, so an id is the one handle that still reaches an earlier one.

## Why this matters now

Kind 10050 is replaceable (NIP-01 `01.md:97`), and NIP-17's publishing rule was strengthened from `SHOULD` to **`MUST only publish`** on 2026-06-01 (`17.md:77`, commit `9c2d38c`) — an exclusivity constraint, so a clobbered list is binding on every conforming sender, not merely a hint.

Measured against `relay.divine.video`: **621 accounts** advertise a DM inbox there, and **515 of them (83%) list 2–16 relays**, dominated by nos.lol / relay.damus.io / relay.0xchat.com — i.e. written by third-party clients. The publisher has already run 46 times in production (identified by divine-mobile's own NIP-89 client tag), all single-relay; the flag was not internal-audience-gated for its first month, so 32 of those predate the gating in `21d9a916d`.

No *destroyed* multi-relay list is proven among those 46 — they appear to have genuinely been `absent`. The accurate framing is a live, exercised code path whose only safety guard is unreachable, about to be pointed at the population it was written to protect.

## Verification

**The repository's own tests demonstrated both halves of the bug on `main`**, all green: the RC3 test at `:4353` inherited the `setUp` default `queryEvents → []` — the exact shape an unanswered read produces — and asserted a kind-10050 *is* published; the two `failed` tests forced the state with `.thenThrow(Exception('relay down'))`, which `queryEvents` never produces.

**Docker end-to-end** against real funnelcake (`funnelcake-relay:local`, `ws://localhost:47777`): a 3-relay list, then a single-relay publish 3s later, and every NIP-17 sender resolving that relay gets one relay. The original survives only as an id-addressed artifact. (A first attempt published both inside the same second and the relay kept serving the *old* list — funnelcake resolves a coordinate with `argMax`, documented at `client.rs:14681` as diverging from NIP-01's lowest-id tie-break.)

**Mutation-checked** — every row kills the intended test:

| mutation | killed by |
|---|---|
| drop the inconclusive → `failed` mapping | T1, T2, T7 |
| test `noRelays` only | T2, T7 |
| test `timedOut` only | T1 |
| move the mapping above `events.isEmpty` | T4 |
| revert `requireAllRelaysSettled:` to a literal `false` | T5, "does NOT reuse" |
| revert `useCache:` to a literal `true` | T5 |

T5/T6 are captured-arg tests and are not optional: the mock returns the same record whichever flags are passed, so T1–T4 are blind to a reverted flag.

```
flutter analyze .            → No issues found
flutter test                 → 689 passed
flutter test --coverage      → 94.33% (gate: 93)
check_nostr_id_log_truncation / check_pubkey_log_encoding / check_ungrouped_tests → all OK
flutter analyze lib test integration_test  → No issues found
```

## Notes for the reviewer

- **Sequencing with #8217.** That PR is open on the same file for #8209. The production hunks are disjoint (it touches 996–1120 and 1487–1543; this touches 963–968, 3038–3051, 3110–3177). The **test file will conflict** in three places — the `setUp` block, the record-builder anchor, and the drain/own-inbox test. Whichever lands second resolves them; I am happy to rebase onto #8217.
- **Two existing tests changed meaning, deliberately.** The non-throwing `failed` test now uses the real shape (empty + `timedOut`) and the throwing one is kept so the `on Object catch` stays covered. The test asserting *"one kind-10050 query shared at login"* is rewritten rather than renamed — that sharing is exactly what this fix gives up, and it now asserts the live read stays cheap while exactly one read is authoritative.
- **`resolveDmInboxRelays` is untouched by design.** Reporting an unreadable *recipient* inbox as delivery is the send-side twin, #7317, and needs its own decision about send semantics.
- The flag description string (*"Keep off until the backend relay accepts kind-10050"*) is now stale — funnelcake auto-allows the whole 10000–19999 range (`relay.rs:2169-2171`) and serves 621 live kind-10050 events. Left alone here; it belongs with the flag flip in #7336.
- **Not included, deliberately:** an in-session retry when the read is inconclusive. Production does not restrict relay hosts, so a user with a persistently silent relay in their own NIP-65 list will fail closed on every login and never self-publish while that relay stays silent. That is a rollout question #7336 can measure behind the flag with the new log line, and adding a hook to `startListening` (which runs on every 2s reconnect) needs its own bound.
