### PR TITLE
fix(dm): search vanished and moderation rows by the name they show

### DIFF
--- a/mobile/docs/brainstorm/2026-08-27-issue8204-vanished-inbox-search-brainstorm.md
+++ b/mobile/docs/brainstorm/2026-08-27-issue8204-vanished-inbox-search-brainstorm.md
@@ -1,0 +1,193 @@
+# Brainstorm: naming a vanished DM peer consistently in inbox search
+
+Date: 2026-08-27
+
+Seeded by `tasks/findings_8204.md` (local-only; `tasks/` is in
+`.git/info/exclude`). Issue: #8204. Related: #8185 / PR #8196 (merged
+`ab98417e2`), #8205 / PR #8207, #8208 (reopened).
+
+## Problem Statement
+
+The DM inbox resolves a conversation peer's name **twice, independently**. The
+row renders through `dmPeerDisplayName` — a five-step chain that puts a NIP-62
+vanish first. The search index matches through `ConversationListBloc`, which
+implements only the last two steps of that chain. So a row can display
+"Deleted account" while the index holds a generated "Adjective Animal N" the
+viewer has never seen: searching what is on screen finds nothing, and searching
+an invisible string finds the row.
+
+The bug is not a missing vanish check. It is a **second naming chain that was
+never required to stay in sync with the first** — which is why the same
+expression also mis-names a retired-Divine-Moderation thread.
+
+## Constraints
+
+- **Layering.** `.claude/rules/architecture.md`: filtering is BLoC/repository
+  work, never UI work. So the match must stay in the BLoC — the UI cannot be
+  handed the filtering back.
+- **Localization.** `.claude/rules/localization.md`: "Strings stay in the UI
+  layer — BLoCs emit status enums, the UI maps them." A BLoC may not import
+  `context.l10n`. Any label it matches on must be **injected**.
+- **The labels are not constant.** There is a live in-app language picker
+  (`LocaleCubit`, `mobile/lib/blocs/locale/locale_cubit.dart`; Settings →
+  General, `general_settings_screen.dart:326`) which rebuilds `MaterialApp`
+  with a new `locale` **without restarting the app**. `BlocProvider.create:`
+  runs once, so a label injected only at construction goes stale on a language
+  change.
+- **The vanish signal must be live, not sampled.** `ProfileRepository.isVanished`
+  is an in-memory mirror seeded by an `unawaited` `loadVanishedPubkeys()`
+  (`repository_providers.dart:402`); the row instead watches the durable
+  `vanished_profiles` Drift table. Sampling the mirror reopens the bug at cold
+  start and whenever a vanish is discovered after indexing (findings F12).
+- **The batch response cannot carry the signal.** Measured against a funnelcake
+  built from `origin/main`: of five reachable vanish states, `POST /api/users/bulk`
+  yields a usable vanish signal in exactly one (findings F13). A pending vanish
+  is stripped from both `users` and `missing`.
+- **No protocol constraint.** NIP-62 is silent on rendering, naming and search;
+  no NIP defines a deleted-account label or a kind-0-absent fallback (findings
+  F10). This is entirely a client product decision.
+- BLoC-first, constructor injection, no new Riverpod.
+
+## Prior Art
+
+- `mobile/lib/screens/inbox/widgets/dm_peer_identity.dart` — the canonical
+  five-step chain, shipped by #8196. Its own doc comment explains why vanished
+  must come first.
+- `mobile/lib/screens/inbox/widgets/moderation_identity.dart` — step 3,
+  answering for retired keys too.
+- `ConversationListProfileRepositoryChanged` + `_InboxRepositorySync`
+  (`inbox_page.dart`) — the established pattern for **delivering a changing
+  dependency into this BLoC in place**, chosen deliberately over a `ValueKey`
+  because re-keying would lose tab selection, scroll offset and search text.
+  This is the precedent a label channel should copy.
+- `supportRowPubkey` (`inbox_page.dart:108`) — precedent for injecting a
+  configuration value into this BLoC at construction.
+- PR #8207 (#8205) — the sibling fix for reaction rows, which moved two more
+  surfaces onto `dmPeerDisplayName` rather than re-deriving the branch.
+
+## Approaches Explored
+
+### Approach A: add the branches to `_applyFilters`
+
+**Description:** Teach the BLoC's filter about vanished and moderation inline —
+two extra conditions in `_applyFilters`, plus the injected labels and the
+vanished set.
+
+**Layers affected:** BLoC, UI (label + vanished-set delivery).
+
+**Pros:** smallest diff; no new file; entirely inside the failing function.
+
+**Cons:** leaves **two hand-maintained copies** of the precedence. The render
+chain has already grown twice (moderation in #6283, vanished in #8196) and each
+growth is what created this bug; a third would diverge again by default. It
+fixes the instance, not the class.
+
+**Complexity:** Low.
+
+### Approach B: store the rendered name in `profileNames`
+
+**Description:** Make the index hold exactly the string the row displays, so
+index and row are one value by construction.
+
+**Layers affected:** BLoC, UI, and every consumer of `profileNames`.
+
+**Pros:** the strongest possible guarantee — there is nothing left to keep in
+sync.
+
+**Cons:** the UI can only compute names for **rendered** rows, and
+`_resolveMissingProfileNames` exists precisely to index rows that are not on
+screen, so a UI-sourced value is structurally incomplete. The BLoC must compute
+it anyway — at which point this collapses into Approach C plus a semantic change
+to `profileNames` affecting unrelated call sites. Largest blast radius for no
+extra correctness over C.
+
+**Complexity:** High.
+
+### Approach C: extract one shared, Flutter-free resolver — **chosen**
+
+**Description:** Lift the precedence out of the widget layer into a pure
+function parameterized by its labels. `dm_peer_identity.dart` keeps its
+`BuildContext` signature and delegates, passing `context.l10n.*`;
+`ConversationListBloc` calls the same function with labels injected through the
+existing in-place delivery channel. One precedence, two callers.
+
+**Layers affected:** a new pure helper, the widget chain, the BLoC, and the UI
+sync widget.
+
+**Pros:** a future branch is added **once** and both surfaces get it — this
+fixes the class, not the instance. The pure function is directly unit-testable
+without a widget pump. The BLoC stays Flutter-free and l10n stays owned by the
+UI, so both governing rules hold. It reuses the delivery pattern the file
+already documents rather than inventing one.
+
+**Cons:** more moving parts than A: a new file, a labels value type, and a
+second in-place delivery channel. The widget chain must delegate rather than be
+replaced, so `ConversationTile`'s behaviour stays byte-identical.
+
+**Risks / Unknowns:** the labels channel must fire on locale change, or the fix
+introduces a stale-language bug it did not have before. Mitigated by dispatching
+from a widget that reads `context.l10n` in `build` and compares before
+dispatching.
+
+**Complexity:** Medium.
+
+### Approach D: suppress instead of replace
+
+**Description:** Stop indexing the generated fallback for a vanished or
+moderation row — index the empty string — so the invisible handle stops
+matching.
+
+**Pros:** trivially small; satisfies acceptance criterion 2.
+
+**Cons:** does **not** satisfy criterion 1 — "Deleted account" still finds
+nothing, and the row becomes findable only by message text. Half a fix that
+reads as a whole one.
+
+**Complexity:** Low.
+
+## Recommendation
+
+**Approach C**, scoped to **both** the vanished and the retired-moderation
+branch, matching on the **localized label only** (no npub/hex) — all three
+confirmed with the issue owner.
+
+C is the only option that addresses the actual root cause. A and D treat the
+symptom in the function where it surfaced; B pays a large refactor for a
+guarantee C already provides. C also matches how #8196 and #8207 were built:
+both moved surfaces **onto** the shared chain rather than re-deriving a branch,
+and this extends that same consolidation one layer down so a non-widget caller
+can join it.
+
+Label-only matching is consistent with the shipped #8196 product decision —
+a vanished peer gets an identity-neutral reference, not a competing name — and
+adding pubkey matching would introduce a capability no other inbox row has,
+inside a bug fix.
+
+## Open Questions for /plan
+
+- [x] Where does the vanished set come from? → a new
+      `Stream<Set<String>> watchVanishedPubkeys()` on `ProfileRepository`,
+      a thin passthrough to `vanishedProfilesDao.watchAllPubkeys()`. The
+      repository already imports `db_client`, already holds the DAO, and already
+      exposes `watchProfile` / `watchProfileStats` / `watchPendingSave`, so this
+      is idiomatic and adds no dependency. Subscribing (rather than sampling
+      `isVanished`) is what satisfies the live-signal constraint.
+- [x] How do labels reach the BLoC without staleness? → a
+      `ConversationListPeerLabelsChanged` event, dispatched from the inbox's
+      existing sync widget, mirroring `ConversationListProfileRepositoryChanged`.
+- [ ] Does the subscription need re-establishing when `_profileRepository` is
+      swapped in place? (Almost certainly yes — resolve in the plan.)
+- [ ] Does the message-requests screen (`message_requests_page.dart`, the second
+      `ConversationListBloc` construction site) need the same wiring, or does it
+      never search?
+- [ ] Exact placement of the pure resolver: alongside the BLoC, or in
+      `packages/models`? It must not import Flutter.
+
+## Prerequisites
+
+None. No design input, no new package, no protocol decision, no team sign-off —
+the naming decision was settled by #8196 and re-confirmed above.
+
+## Next Step
+
+`/plan 8204`.

--- a/mobile/lib/blocs/dm/conversation_list/conversation_list_bloc.dart
+++ b/mobile/lib/blocs/dm/conversation_list/conversation_list_bloc.dart
@@ -14,6 +14,7 @@ import 'package:follow_repository/follow_repository.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/close_guard.dart';
 import 'package:openvine/blocs/dm/conversation_list/protected_minor_inbox_gate.dart';
+import 'package:openvine/blocs/dm/dm_peer_name.dart';
 import 'package:openvine/constants/search_constants.dart';
 import 'package:profile_repository/profile_repository.dart';
 import 'package:rxdart/rxdart.dart';
@@ -62,6 +63,9 @@ class ConversationListBloc
       transformer: droppable(),
     );
     on<ConversationListProfileRepositoryChanged>(_onProfileRepositoryChanged);
+    on<ConversationListPeerLabelsChanged>(_onPeerLabelsChanged);
+    on<_ConversationListVanishedPubkeysChanged>(_onVanishedPubkeysChanged);
+    _subscribeToVanishedPubkeys();
   }
 
   final DmRepository _dmRepository;
@@ -79,6 +83,11 @@ class ConversationListBloc
   /// setRepository` precedent. The field is only modified via
   /// [ConversationListProfileRepositoryChanged] event handlers.
   ProfileRepository? _profileRepository;
+
+  /// Live vanished-set subscription, re-pointed whenever
+  /// [_profileRepository] is. Same exception as the field above.
+  StreamSubscription<Set<String>>? _vanishedSubscription;
+
   final ProtectedMinorInboxGate? _protectedMinorInboxGate;
 
   /// Moderation pubkey the pinned support row targets, injected rather than
@@ -345,6 +354,8 @@ class ConversationListBloc
             filter: filter,
             query: state.searchQuery,
             profileNames: state.profileNames,
+            vanishedPubkeys: state.vanishedPubkeys,
+            peerLabels: state.peerLabels,
             userPubkey: userPubkey,
             limit: state.currentLimit,
           ),
@@ -384,6 +395,8 @@ class ConversationListBloc
           filter: state.filter,
           query: state.searchQuery,
           profileNames: state.profileNames,
+          vanishedPubkeys: state.vanishedPubkeys,
+          peerLabels: state.peerLabels,
           userPubkey: _dmRepository.userPubkey,
           limit: limit,
         ),
@@ -406,6 +419,8 @@ class ConversationListBloc
           filter: event.filter,
           query: state.searchQuery,
           profileNames: state.profileNames,
+          vanishedPubkeys: state.vanishedPubkeys,
+          peerLabels: state.peerLabels,
           userPubkey: _dmRepository.userPubkey,
           limit: state.currentLimit,
         ),
@@ -433,6 +448,8 @@ class ConversationListBloc
           filter: state.filter,
           query: query,
           profileNames: state.profileNames,
+          vanishedPubkeys: state.vanishedPubkeys,
+          peerLabels: state.peerLabels,
           userPubkey: userPubkey,
           limit: state.currentLimit,
         ),
@@ -514,6 +531,8 @@ class ConversationListBloc
             filter: state.filter,
             query: query,
             profileNames: profileNames,
+            vanishedPubkeys: state.vanishedPubkeys,
+            peerLabels: state.peerLabels,
             userPubkey: userPubkey,
             limit: state.currentLimit,
           ),
@@ -678,6 +697,8 @@ class ConversationListBloc
     required InboxFilter filter,
     required String query,
     required Map<String, String> profileNames,
+    required Set<String> vanishedPubkeys,
+    required DmPeerLabels? peerLabels,
     required String userPubkey,
     required int limit,
   }) {
@@ -691,6 +712,8 @@ class ConversationListBloc
         unreadOnly: false,
         query: query,
         profileNames: profileNames,
+        vanishedPubkeys: vanishedPubkeys,
+        peerLabels: peerLabels,
         userPubkey: userPubkey,
       );
     }
@@ -705,6 +728,8 @@ class ConversationListBloc
       unreadOnly: unreadOnly,
       query: query,
       profileNames: profileNames,
+      vanishedPubkeys: vanishedPubkeys,
+      peerLabels: peerLabels,
       userPubkey: userPubkey,
     );
   }
@@ -714,6 +739,8 @@ class ConversationListBloc
     required bool unreadOnly,
     required String query,
     required Map<String, String> profileNames,
+    required Set<String> vanishedPubkeys,
+    required DmPeerLabels? peerLabels,
     required String userPubkey,
   }) {
     var result = conversations;
@@ -722,12 +749,39 @@ class ConversationListBloc
     final normalized = query.toLowerCase();
     return result.where((c) {
       final other = _otherParticipant(c, userPubkey);
-      final name =
-          (profileNames[other] ?? UserProfile.defaultDisplayNameFor(other))
-              .toLowerCase();
+      final name = _peerName(
+        other,
+        profileNames: profileNames,
+        vanishedPubkeys: vanishedPubkeys,
+        peerLabels: peerLabels,
+      ).toLowerCase();
       final preview = c.lastMessageContent?.toLowerCase() ?? '';
       return name.contains(normalized) || preview.contains(normalized);
     }).toList();
+  }
+
+  /// The name the row for [pubkey] renders, resolved the same way
+  /// `ConversationTile` resolves it.
+  ///
+  /// Falls back to the profile-or-generated value while [peerLabels] is null,
+  /// which is the pre-delivery window only — matching the substitutes needs the
+  /// strings, and there is nothing better to match on until they arrive.
+  static String _peerName(
+    String pubkey, {
+    required Map<String, String> profileNames,
+    required Set<String> vanishedPubkeys,
+    required DmPeerLabels? peerLabels,
+  }) {
+    final profileName = profileNames[pubkey];
+    if (peerLabels == null) {
+      return profileName ?? UserProfile.defaultDisplayNameFor(pubkey);
+    }
+    return dmPeerName(
+      pubkeyHex: pubkey,
+      isVanished: vanishedPubkeys.contains(pubkey),
+      labels: peerLabels,
+      profileName: profileName,
+    );
   }
 
   Future<void> _onMarkRead(
@@ -778,6 +832,7 @@ class ConversationListBloc
   ) {
     if (identical(_profileRepository, event.profileRepository)) return;
     _profileRepository = event.profileRepository;
+    _subscribeToVanishedPubkeys();
     if (state.searchQuery.isEmpty) return;
     // Any names cached while no repository was available are deterministic
     // fallbacks, not real profiles. Drop them so the active query re-resolves.
@@ -816,8 +871,70 @@ class ConversationListBloc
     add(const ConversationListStarted());
   }
 
+  /// (Re)points the vanished-set subscription at [_profileRepository].
+  ///
+  /// Called at construction and again on every repository swap: the stream
+  /// belongs to the instance, so keeping the old subscription would leave the
+  /// index reading a repository nothing else is using any more.
+  void _subscribeToVanishedPubkeys() {
+    unawaited(_vanishedSubscription?.cancel());
+    _vanishedSubscription = _profileRepository?.watchVanishedPubkeys().listen(
+      // A stream callback resumes outside the handler that started it, so the
+      // add has to be guarded — `close()` does not cancel it.
+      (pubkeys) => addIfOpen(_ConversationListVanishedPubkeysChanged(pubkeys)),
+    );
+  }
+
+  void _onVanishedPubkeysChanged(
+    _ConversationListVanishedPubkeysChanged event,
+    Emitter<ConversationListState> emit,
+  ) {
+    // Exact set equality without reaching for a Flutter import: this bloc
+    // must stay free of the Flutter SDK.
+    if (event.pubkeys.length == state.vanishedPubkeys.length &&
+        event.pubkeys.containsAll(state.vanishedPubkeys)) {
+      return;
+    }
+    _emitWithVisible(emit, state.copyWith(vanishedPubkeys: event.pubkeys));
+  }
+
+  void _onPeerLabelsChanged(
+    ConversationListPeerLabelsChanged event,
+    Emitter<ConversationListState> emit,
+  ) {
+    if (event.labels == state.peerLabels) return;
+    _emitWithVisible(emit, state.copyWith(peerLabels: event.labels));
+  }
+
+  /// Emits [next] with `visibleConversations` recomputed against it.
+  ///
+  /// Both naming inputs feed the search match, so changing either has to
+  /// re-filter — otherwise a vanish discovered after the query was typed, or a
+  /// language change, leaves the results reflecting the previous naming.
+  void _emitWithVisible(
+    Emitter<ConversationListState> emit,
+    ConversationListState next,
+  ) {
+    emit(
+      next.copyWith(
+        visibleConversations: _computeVisible(
+          next.conversations,
+          blockedConversations: next.blockedConversations,
+          filter: next.filter,
+          query: next.searchQuery,
+          profileNames: next.profileNames,
+          vanishedPubkeys: next.vanishedPubkeys,
+          peerLabels: next.peerLabels,
+          userPubkey: _dmRepository.userPubkey,
+          limit: next.currentLimit,
+        ),
+      ),
+    );
+  }
+
   @override
   Future<void> close() {
+    unawaited(_vanishedSubscription?.cancel());
     // The gift-wrap subscription is owned by `dmRepositoryProvider` for the
     // whole authenticated session — do NOT stop it here. See #2931.
     return super.close();

--- a/mobile/lib/blocs/dm/conversation_list/conversation_list_bloc.dart
+++ b/mobile/lib/blocs/dm/conversation_list/conversation_list_bloc.dart
@@ -22,6 +22,10 @@ import 'package:rxdart/rxdart.dart';
 part 'conversation_list_event.dart';
 part 'conversation_list_state.dart';
 
+typedef DmPeerAccountPredicate = bool Function(String pubkeyHex);
+
+bool _neverDmPeerAccount(String _) => false;
+
 class ConversationListBloc
     extends Bloc<ConversationListEvent, ConversationListState> {
   ConversationListBloc({
@@ -32,6 +36,8 @@ class ConversationListBloc
     ProtectedMinorInboxGate? protectedMinorInboxGate,
     Duration recomputeDebounce = _defaultRecomputeDebounce,
     String? supportRowPubkey,
+    DmPeerAccountPredicate moderationAccount = _neverDmPeerAccount,
+    DmPeerAccountPredicate retiredModerationAccount = _neverDmPeerAccount,
   }) : _dmRepository = dmRepository,
        _followRepository = followRepository,
        _blocklistRepository = contentBlocklistRepository,
@@ -39,6 +45,8 @@ class ConversationListBloc
        _protectedMinorInboxGate = protectedMinorInboxGate,
        _recomputeDebounce = recomputeDebounce,
        _supportRowPubkey = supportRowPubkey,
+       _moderationAccount = moderationAccount,
+       _retiredModerationAccount = retiredModerationAccount,
        super(const ConversationListState()) {
     on<ConversationListStarted>(_onStarted, transformer: restartable());
     on<ConversationListLoadMore>(_onLoadMore, transformer: droppable());
@@ -93,6 +101,11 @@ class ConversationListBloc
   /// Moderation pubkey the pinned support row targets, injected rather than
   /// imported so this bloc stays free of app-layer config (#6283).
   final String? _supportRowPubkey;
+
+  /// App-configured identity predicates, injected so this bloc does not import
+  /// release-pinned account configuration directly (#6283).
+  final DmPeerAccountPredicate _moderationAccount;
+  final DmPeerAccountPredicate _retiredModerationAccount;
 
   /// Window over which bursty conversation writes are coalesced before the
   /// list is re-composed. The combined stream re-runs `classifyPotentialRequests`
@@ -691,7 +704,7 @@ class ConversationListBloc
   /// [conversations] is the COMPLETE accepted-union-followed set, so a filter
   /// result is always complete — "You're all caught up" and "No matches" can no
   /// longer be statements about just the loaded page.
-  static List<DmConversation> _computeVisible(
+  List<DmConversation> _computeVisible(
     List<DmConversation> conversations, {
     required List<DmConversation> blockedConversations,
     required InboxFilter filter,
@@ -734,7 +747,7 @@ class ConversationListBloc
     );
   }
 
-  static List<DmConversation> _applyFilters(
+  List<DmConversation> _applyFilters(
     List<DmConversation> conversations, {
     required bool unreadOnly,
     required String query,
@@ -755,7 +768,9 @@ class ConversationListBloc
         vanishedPubkeys: vanishedPubkeys,
         peerLabels: peerLabels,
       ).toLowerCase();
-      final preview = c.lastMessageContent?.toLowerCase() ?? '';
+      final preview = peerLabels != null && _retiredModerationAccount(other)
+          ? peerLabels.retiredConversationClosed.toLowerCase()
+          : c.lastMessageContent?.toLowerCase() ?? '';
       return name.contains(normalized) || preview.contains(normalized);
     }).toList();
   }
@@ -766,7 +781,7 @@ class ConversationListBloc
   /// Falls back to the profile-or-generated value while [peerLabels] is null,
   /// which is the pre-delivery window only — matching the substitutes needs the
   /// strings, and there is nothing better to match on until they arrive.
-  static String _peerName(
+  String _peerName(
     String pubkey, {
     required Map<String, String> profileNames,
     required Set<String> vanishedPubkeys,
@@ -779,6 +794,7 @@ class ConversationListBloc
     return dmPeerName(
       pubkeyHex: pubkey,
       isVanished: vanishedPubkeys.contains(pubkey),
+      isModeration: _moderationAccount(pubkey),
       labels: peerLabels,
       profileName: profileName,
     );
@@ -882,6 +898,10 @@ class ConversationListBloc
       // A stream callback resumes outside the handler that started it, so the
       // add has to be guarded — `close()` does not cancel it.
       (pubkeys) => addIfOpen(_ConversationListVanishedPubkeysChanged(pubkeys)),
+      onError: (Object error, StackTrace stackTrace) {
+        // Drift / IO failures are expected and are not Reportable.
+        addError(error, stackTrace);
+      },
     );
   }
 
@@ -889,8 +909,7 @@ class ConversationListBloc
     _ConversationListVanishedPubkeysChanged event,
     Emitter<ConversationListState> emit,
   ) {
-    // Exact set equality without reaching for a Flutter import: this bloc
-    // must stay free of the Flutter SDK.
+    // Exact set equality without adding another dependency to this BLoC.
     if (event.pubkeys.length == state.vanishedPubkeys.length &&
         event.pubkeys.containsAll(state.vanishedPubkeys)) {
       return;

--- a/mobile/lib/blocs/dm/conversation_list/conversation_list_event.dart
+++ b/mobile/lib/blocs/dm/conversation_list/conversation_list_event.dart
@@ -101,3 +101,30 @@ class _ConversationListProfileResolutionRequested
     extends ConversationListEvent {
   const _ConversationListProfileResolutionRequested();
 }
+
+/// The localized names for peers who must not be shown their own name.
+///
+/// Delivered by the inbox rather than read here, because a BLoC has no
+/// `context.l10n` — and re-delivered on a locale change, because
+/// `BlocProvider.create:` runs once while the app's language picker does not
+/// restart the app.
+class ConversationListPeerLabelsChanged extends ConversationListEvent {
+  const ConversationListPeerLabelsChanged(this.labels);
+
+  final DmPeerLabels labels;
+
+  @override
+  List<Object?> get props => [labels];
+}
+
+/// The durable vanished set changed.
+///
+/// Private: it mirrors a repository stream this bloc owns, not a user action.
+class _ConversationListVanishedPubkeysChanged extends ConversationListEvent {
+  const _ConversationListVanishedPubkeysChanged(this.pubkeys);
+
+  final Set<String> pubkeys;
+
+  @override
+  List<Object?> get props => [pubkeys];
+}

--- a/mobile/lib/blocs/dm/conversation_list/conversation_list_state.dart
+++ b/mobile/lib/blocs/dm/conversation_list/conversation_list_state.dart
@@ -71,6 +71,8 @@ class ConversationListState extends Equatable {
     this.filter = InboxFilter.all,
     this.searchQuery = '',
     this.profileNames = const {},
+    this.vanishedPubkeys = const {},
+    this.peerLabels,
     this.requestConversations = const [],
     this.potentialRequests = const [],
     this.hasMore = true,
@@ -121,7 +123,25 @@ class ConversationListState extends Equatable {
 
   /// Resolved display names by counterparty pubkey, used for search
   /// matching. Grows lazily the first time a query needs a name.
+  ///
+  /// A step-4 value only — the kind-0 name, or the generated fallback when
+  /// there is none. The vanished and moderation branches that outrank it are
+  /// applied by [dmPeerName] at match time, never baked in here.
   final Map<String, String> profileNames;
+
+  /// Counterparties that published a NIP-62 request to vanish.
+  ///
+  /// A live view of the durable `vanished_profiles` table, which is the same
+  /// source `ConversationTile` renders from. Search has to read it rather than
+  /// sample `ProfileRepository.isVanished`, or the index names an account the
+  /// row on screen contradicts (#8204).
+  final Set<String> vanishedPubkeys;
+
+  /// Localized substitutes for a peer whose own name must not be shown.
+  ///
+  /// Null until the inbox delivers them, and re-delivered when the app locale
+  /// changes; matching falls back to the generated name in the meantime.
+  final DmPeerLabels? peerLabels;
 
   /// Conversations shown in the Requests tab (non-followed, never replied).
   final List<DmConversation> requestConversations;
@@ -192,6 +212,8 @@ class ConversationListState extends Equatable {
     InboxFilter? filter,
     String? searchQuery,
     Map<String, String>? profileNames,
+    Set<String>? vanishedPubkeys,
+    DmPeerLabels? peerLabels,
     List<DmConversation>? requestConversations,
     List<DmConversation>? potentialRequests,
     bool? hasMore,
@@ -211,6 +233,8 @@ class ConversationListState extends Equatable {
       filter: filter ?? this.filter,
       searchQuery: searchQuery ?? this.searchQuery,
       profileNames: profileNames ?? this.profileNames,
+      vanishedPubkeys: vanishedPubkeys ?? this.vanishedPubkeys,
+      peerLabels: peerLabels ?? this.peerLabels,
       requestConversations: requestConversations ?? this.requestConversations,
       potentialRequests: potentialRequests ?? this.potentialRequests,
       hasMore: hasMore ?? this.hasMore,
@@ -235,6 +259,8 @@ class ConversationListState extends Equatable {
     filter,
     searchQuery,
     profileNames,
+    vanishedPubkeys,
+    peerLabels,
     requestConversations,
     potentialRequests,
     hasMore,

--- a/mobile/lib/blocs/dm/dm_peer_name.dart
+++ b/mobile/lib/blocs/dm/dm_peer_name.dart
@@ -1,0 +1,61 @@
+// ABOUTME: The one naming precedence every DM surface resolves a peer through.
+// ABOUTME: Pure and Flutter-free, so the inbox search index in
+// ABOUTME: ConversationListBloc matches the string the row actually renders.
+
+import 'package:equatable/equatable.dart';
+import 'package:models/models.dart';
+import 'package:openvine/config/official_accounts.dart';
+
+/// The localized strings [dmPeerName] substitutes for a peer whose own name
+/// must not be shown.
+///
+/// Injected rather than read from `context.l10n`, because the search index
+/// that matches on them lives in a BLoC. Both values are already-translated
+/// ARB keys: [deletedAccount] is `profileDeletedAccountName`, [moderation] is
+/// `inboxSupportRowTitle`.
+class DmPeerLabels extends Equatable {
+  const DmPeerLabels({required this.deletedAccount, required this.moderation});
+
+  /// Shown instead of the name of an account that published a NIP-62 vanish.
+  final String deletedAccount;
+
+  /// Shown instead of the kind-0 name of a Divine Moderation key.
+  final String moderation;
+
+  @override
+  List<Object?> get props => [deletedAccount, moderation];
+}
+
+/// The peer's name, in the precedence every DM surface has to agree on:
+/// vanished, override, moderation, profile, generated.
+///
+/// This function exists because that precedence used to be written twice — the
+/// widget chain rendered all five steps while `ConversationListBloc` matched on
+/// the last two, so a vanished peer's row read "Deleted account" while inbox
+/// search indexed a generated "Adjective Animal N" the viewer had never seen
+/// (#8204). Keeping it in one pure place is what stops the next branch
+/// diverging the same way.
+///
+/// A vanish comes first because it is the only branch that contradicts the ones
+/// below it: applying one evicts the cached profile and short-circuits every
+/// later fetch, so a caller that skips this check does not fall back to the
+/// peer's last known name — it falls all the way through to
+/// [UserProfile.defaultDisplayNameFor].
+///
+/// [profileName] is the caller's already-resolved step-4 value: the widget
+/// chain passes `profile?.bestDisplayName`, and the BLoC passes its cached
+/// entry. Both may be null, and the generated fallback answers for them.
+String dmPeerName({
+  required String pubkeyHex,
+  required bool isVanished,
+  required DmPeerLabels labels,
+  String? profileName,
+  String? displayNameOverride,
+}) {
+  if (isVanished) return labels.deletedAccount;
+  if (displayNameOverride != null) return displayNameOverride;
+  // Answers for retired keys too, via `isModerationAccount`: a rotated-away
+  // thread stays an ordinary inbox row and has no kind 0 of its own.
+  if (isModerationAccount(pubkeyHex)) return labels.moderation;
+  return profileName ?? UserProfile.defaultDisplayNameFor(pubkeyHex);
+}

--- a/mobile/lib/blocs/dm/dm_peer_name.dart
+++ b/mobile/lib/blocs/dm/dm_peer_name.dart
@@ -4,7 +4,6 @@
 
 import 'package:equatable/equatable.dart';
 import 'package:models/models.dart';
-import 'package:openvine/config/official_accounts.dart';
 
 /// The localized strings [dmPeerName] substitutes for a peer whose own name
 /// must not be shown.
@@ -12,9 +11,14 @@ import 'package:openvine/config/official_accounts.dart';
 /// Injected rather than read from `context.l10n`, because the search index
 /// that matches on them lives in a BLoC. Both values are already-translated
 /// ARB keys: [deletedAccount] is `profileDeletedAccountName`, [moderation] is
-/// `inboxSupportRowTitle`.
+/// `inboxSupportRowTitle`, and [retiredConversationClosed] is
+/// `dmRetiredThreadClosedTitle`.
 class DmPeerLabels extends Equatable {
-  const DmPeerLabels({required this.deletedAccount, required this.moderation});
+  const DmPeerLabels({
+    required this.deletedAccount,
+    required this.moderation,
+    required this.retiredConversationClosed,
+  });
 
   /// Shown instead of the name of an account that published a NIP-62 vanish.
   final String deletedAccount;
@@ -22,8 +26,28 @@ class DmPeerLabels extends Equatable {
   /// Shown instead of the kind-0 name of a Divine Moderation key.
   final String moderation;
 
+  /// Shown instead of message content for a retired moderation thread.
+  final String retiredConversationClosed;
+
   @override
-  List<Object?> get props => [deletedAccount, moderation];
+  List<Object?> get props => [
+    deletedAccount,
+    moderation,
+    retiredConversationClosed,
+  ];
+}
+
+/// Resolves the profile-independent prefix shared by the row and action sheet.
+String? dmPeerSubstituteName({
+  required bool isVanished,
+  required bool isModeration,
+  required DmPeerLabels labels,
+  String? displayNameOverride,
+}) {
+  if (isVanished) return labels.deletedAccount;
+  if (displayNameOverride != null) return displayNameOverride;
+  if (isModeration) return labels.moderation;
+  return null;
 }
 
 /// The peer's name, in the precedence every DM surface has to agree on:
@@ -48,14 +72,17 @@ class DmPeerLabels extends Equatable {
 String dmPeerName({
   required String pubkeyHex,
   required bool isVanished,
+  required bool isModeration,
   required DmPeerLabels labels,
   String? profileName,
   String? displayNameOverride,
 }) {
-  if (isVanished) return labels.deletedAccount;
-  if (displayNameOverride != null) return displayNameOverride;
-  // Answers for retired keys too, via `isModerationAccount`: a rotated-away
-  // thread stays an ordinary inbox row and has no kind 0 of its own.
-  if (isModerationAccount(pubkeyHex)) return labels.moderation;
+  final substitute = dmPeerSubstituteName(
+    isVanished: isVanished,
+    isModeration: isModeration,
+    labels: labels,
+    displayNameOverride: displayNameOverride,
+  );
+  if (substitute != null) return substitute;
   return profileName ?? UserProfile.defaultDisplayNameFor(pubkeyHex);
 }

--- a/mobile/lib/screens/inbox/inbox_page.dart
+++ b/mobile/lib/screens/inbox/inbox_page.dart
@@ -106,6 +106,8 @@ class InboxPage extends ConsumerWidget {
             // gate resolves against — so the row can never point somewhere
             // the gate would not approve.
             supportRowPubkey: kModerationPubkeyHex,
+            moderationAccount: isModerationAccount,
+            retiredModerationAccount: isRetiredModerationAccount,
           )..add(const ConversationListStarted()),
         ),
         // Inbox-scope NotificationBadgeCubit feeds the segmented

--- a/mobile/lib/screens/inbox/inbox_view.dart
+++ b/mobile/lib/screens/inbox/inbox_view.dart
@@ -323,6 +323,44 @@ void _pushConversation(
   );
 }
 
+/// Hands `ConversationListBloc` the localized names it substitutes for peers
+/// whose own name must not be shown, so inbox search matches the string the
+/// row actually renders (#8204).
+///
+/// A widget of its own, mounted inside the Messages subtree, for two reasons.
+/// The bloc has no `context.l10n`, so the strings have to come from the UI —
+/// and `BlocProvider` is lazy, so reading the bloc anywhere higher would drag
+/// its creation earlier than the Messages tab being opened. Everything below
+/// the enclosing `BlocListener` is already a consumer, so nothing here changes
+/// when the bloc starts.
+///
+/// `didChangeDependencies` rather than `initState`: reading l10n registers a
+/// dependency on `Localizations`, so this fires again when the language
+/// changes. It can, without an app restart, via Settings -> General — and
+/// `BlocProvider.create:` runs once, so labels injected only at construction
+/// would leave search matching the previous language.
+class _PeerLabelSync extends StatefulWidget {
+  const _PeerLabelSync({required this.child});
+
+  final Widget child;
+
+  @override
+  State<_PeerLabelSync> createState() => _PeerLabelSyncState();
+}
+
+class _PeerLabelSyncState extends State<_PeerLabelSync> {
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    context.read<ConversationListBloc>().add(
+      ConversationListPeerLabelsChanged(dmPeerLabels(context)),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) => widget.child;
+}
+
 /// Content for the Messages tab: following bar + conversation list or
 /// empty state, with a FAB for composing new messages.
 class _MessagesContent extends ConsumerWidget {
@@ -360,7 +398,9 @@ class _MessagesContent extends ConsumerWidget {
       },
       child: Stack(
         children: [
-          _MessagesScrollView(currentUserPubkey: currentPubkey),
+          _PeerLabelSync(
+            child: _MessagesScrollView(currentUserPubkey: currentPubkey),
+          ),
           // FAB positioned bottom-right
           PositionedDirectional(
             end: _kFabInset,

--- a/mobile/lib/screens/inbox/message_requests/message_requests_page.dart
+++ b/mobile/lib/screens/inbox/message_requests/message_requests_page.dart
@@ -59,6 +59,8 @@ class MessageRequestsPage extends ConsumerWidget {
             // read" / "remove all" sweep a conversation the user is not
             // looking at.
             supportRowPubkey: kModerationPubkeyHex,
+            moderationAccount: isModerationAccount,
+            retiredModerationAccount: isRetiredModerationAccount,
           )..add(const ConversationListStarted()),
         ),
         BlocProvider(

--- a/mobile/lib/screens/inbox/widgets/dm_peer_identity.dart
+++ b/mobile/lib/screens/inbox/widgets/dm_peer_identity.dart
@@ -4,6 +4,7 @@
 
 import 'package:flutter/widgets.dart';
 import 'package:models/models.dart';
+import 'package:openvine/blocs/dm/dm_peer_name.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/screens/inbox/widgets/moderation_identity.dart';
 
@@ -27,8 +28,21 @@ String? dmPeerNameWithoutProfile(
     ? context.l10n.profileDeletedAccountName
     : displayNameOverride ?? moderationDisplayName(context, pubkeyHex);
 
+/// The localized labels [dmPeerName] needs, read from this [context].
+///
+/// The one place the ARB keys behind the chain are named, so the inbox search
+/// index — which matches on the same strings from a BLoC — cannot drift onto
+/// different ones.
+DmPeerLabels dmPeerLabels(BuildContext context) => DmPeerLabels(
+  deletedAccount: context.l10n.profileDeletedAccountName,
+  moderation: context.l10n.inboxSupportRowTitle,
+);
+
 /// The full chain: vanished, then [displayNameOverride], then moderation, then
 /// [profile], then the generated fallback.
+///
+/// Thin `BuildContext` wrapper over [dmPeerName]; the precedence itself lives
+/// there so a non-widget caller can share it (#8204).
 ///
 /// [isVanished] is required rather than defaulted so every caller has to decide
 /// what to pass. Reactive widgets read it from `profileVanishedProvider`, with
@@ -39,12 +53,10 @@ String dmPeerDisplayName(
   required bool isVanished,
   UserProfile? profile,
   String? displayNameOverride,
-}) =>
-    dmPeerNameWithoutProfile(
-      context,
-      pubkeyHex: pubkeyHex,
-      isVanished: isVanished,
-      displayNameOverride: displayNameOverride,
-    ) ??
-    profile?.bestDisplayName ??
-    UserProfile.defaultDisplayNameFor(pubkeyHex);
+}) => dmPeerName(
+  pubkeyHex: pubkeyHex,
+  isVanished: isVanished,
+  labels: dmPeerLabels(context),
+  profileName: profile?.bestDisplayName,
+  displayNameOverride: displayNameOverride,
+);

--- a/mobile/lib/screens/inbox/widgets/dm_peer_identity.dart
+++ b/mobile/lib/screens/inbox/widgets/dm_peer_identity.dart
@@ -5,8 +5,8 @@
 import 'package:flutter/widgets.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/dm/dm_peer_name.dart';
+import 'package:openvine/config/official_accounts.dart';
 import 'package:openvine/l10n/l10n.dart';
-import 'package:openvine/screens/inbox/widgets/moderation_identity.dart';
 
 /// The peer's name when it resolves without a profile lookup.
 ///
@@ -24,9 +24,12 @@ String? dmPeerNameWithoutProfile(
   required String pubkeyHex,
   required bool isVanished,
   String? displayNameOverride,
-}) => isVanished
-    ? context.l10n.profileDeletedAccountName
-    : displayNameOverride ?? moderationDisplayName(context, pubkeyHex);
+}) => dmPeerSubstituteName(
+  isVanished: isVanished,
+  isModeration: isModerationAccount(pubkeyHex),
+  labels: dmPeerLabels(context),
+  displayNameOverride: displayNameOverride,
+);
 
 /// The localized labels [dmPeerName] needs, read from this [context].
 ///
@@ -36,6 +39,7 @@ String? dmPeerNameWithoutProfile(
 DmPeerLabels dmPeerLabels(BuildContext context) => DmPeerLabels(
   deletedAccount: context.l10n.profileDeletedAccountName,
   moderation: context.l10n.inboxSupportRowTitle,
+  retiredConversationClosed: context.l10n.dmRetiredThreadClosedTitle,
 );
 
 /// The full chain: vanished, then [displayNameOverride], then moderation, then
@@ -56,6 +60,7 @@ String dmPeerDisplayName(
 }) => dmPeerName(
   pubkeyHex: pubkeyHex,
   isVanished: isVanished,
+  isModeration: isModerationAccount(pubkeyHex),
   labels: dmPeerLabels(context),
   profileName: profile?.bestDisplayName,
   displayNameOverride: displayNameOverride,

--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -315,6 +315,21 @@ class ProfileRepository implements ProfileReader {
     _vanished.addAll(await dao.getAllPubkeys());
   }
 
+  /// Live view of the durable `vanished_profiles` table.
+  ///
+  /// The same source the inbox row reads through `profileVanishedProvider`,
+  /// and deliberately not [isVanished]: that mirror is seeded by an unawaited
+  /// [loadVanishedPubkeys], so until it resolves it is a strict subset of the
+  /// table and a consumer sampling it names an account the row contradicts.
+  ///
+  /// Emits an empty set when no [VanishedProfilesDao] is wired, matching
+  /// [isVanished]'s behaviour in the same configuration.
+  Stream<Set<String>> watchVanishedPubkeys() {
+    final dao = _vanishedProfilesDao;
+    if (dao == null) return Stream.value(const <String>{});
+    return dao.watchAllPubkeys().map(Set<String>.from);
+  }
+
   /// Evicts the local profile, stats, identity-claims and Divine-identity
   /// entries for an account that requested deletion, and records the pubkey
   /// durably so the eviction survives a restart.

--- a/mobile/packages/profile_repository/test/src/profile_repository_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_test.dart
@@ -1116,6 +1116,55 @@ void main() {
             verify(() => mockVanishedDao.clearVanished(testPubkey)).called(1);
           });
 
+          group('watchVanishedPubkeys', () {
+            test('mirrors the durable table', () async {
+              when(
+                () => mockVanishedDao.watchAllPubkeys(),
+              ).thenAnswer((_) => Stream.value([testPubkey]));
+
+              expect(
+                await repoWithVanishDao.watchVanishedPubkeys().first,
+                equals({testPubkey}),
+              );
+            });
+
+            test(
+              'follows later writes, so a consumer cannot go stale',
+              () async {
+                final controller = StreamController<List<String>>();
+                addTearDown(controller.close);
+                when(
+                  () => mockVanishedDao.watchAllPubkeys(),
+                ).thenAnswer((_) => controller.stream);
+
+                // Subscribe before writing, then await: awaiting first would
+                // deadlock, since nothing has been added yet.
+                final settled = expectLater(
+                  repoWithVanishDao.watchVanishedPubkeys(),
+                  emitsInOrder([
+                    <String>{},
+                    {testPubkey},
+                  ]),
+                );
+
+                controller
+                  ..add([])
+                  ..add([testPubkey]);
+
+                await settled;
+              },
+            );
+
+            test('emits an empty set when no dao is wired', () async {
+              // Matches isVanished in the same configuration: a caller gets a
+              // usable answer rather than an error.
+              expect(
+                await profileRepository.watchVanishedPubkeys().first,
+                isEmpty,
+              );
+            });
+          });
+
           test('loadVanishedPubkeys hydrates the in-memory set', () async {
             when(
               () => mockVanishedDao.getAllPubkeys(),

--- a/mobile/test/blocs/dm/conversation_list/conversation_list_bloc_test.dart
+++ b/mobile/test/blocs/dm/conversation_list/conversation_list_bloc_test.dart
@@ -8,13 +8,16 @@ import 'dart:async';
 import 'package:bloc_test/bloc_test.dart';
 import 'package:content_blocklist_repository/content_blocklist_repository.dart';
 import 'package:dm_repository/dm_repository.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:follow_repository/follow_repository.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/dm/conversation_list/conversation_list_bloc.dart';
 import 'package:openvine/blocs/dm/conversation_list/protected_minor_inbox_gate.dart';
+import 'package:openvine/blocs/dm/dm_peer_name.dart';
 import 'package:openvine/config/official_accounts.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:profile_repository/profile_repository.dart';
 
 class _MockDmRepository extends Mock implements DmRepository {}
@@ -341,6 +344,9 @@ void main() {
           when(
             () => profiles.fetchBatchProfiles(pubkeys: any(named: 'pubkeys')),
           ).thenAnswer((_) async => const <String, UserProfile>{});
+          when(
+            profiles.watchVanishedPubkeys,
+          ).thenAnswer((_) => Stream.value(const <String>{}));
 
           final bloc = ConversationListBloc(
             dmRepository: mockDmRepository,
@@ -1967,6 +1973,8 @@ void main() {
         InboxFilter.all, // filter
         '', // searchQuery
         const <String, String>{}, // profileNames
+        const <String>{}, // vanishedPubkeys
+        null, // peerLabels
         const <DmConversation>[],
         const <DmConversation>[],
         true,
@@ -2319,6 +2327,316 @@ void main() {
     );
   });
 
+  group('search names a peer the way the row does (#8204)', () {
+    late _MockDmRepository mockDmRepository;
+    late _MockFollowRepository mockFollowRepository;
+    late _MockProfileRepository mockProfileRepository;
+
+    /// The two ARB values the inbox substitutes for a peer whose own name must
+    /// not be shown, resolved rather than hardcoded so a copy change moves the
+    /// test with the product.
+    late DmPeerLabels labels;
+
+    setUp(() {
+      mockDmRepository = _MockDmRepository();
+      mockFollowRepository = _MockFollowRepository();
+      mockProfileRepository = _MockProfileRepository();
+
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      labels = DmPeerLabels(
+        deletedAccount: l10n.profileDeletedAccountName,
+        moderation: l10n.inboxSupportRowTitle,
+      );
+
+      when(() => mockFollowRepository.isFollowing(any())).thenReturn(true);
+      when(
+        () => mockFollowRepository.followingStream,
+      ).thenAnswer((_) => const Stream<List<String>>.empty());
+      when(
+        () => mockDmRepository.backfillHistoryIfNeeded(),
+      ).thenAnswer((_) async {});
+      when(
+        () => mockDmRepository.retryPendingDecryptions(),
+      ).thenAnswer((_) async {});
+      // The batch path never yields a profile for either peer, which is the
+      // measured reality: a PENDING vanish is stripped from the funnelcake
+      // bulk response entirely, and a retired moderation key has no kind 0.
+      when(
+        () => mockProfileRepository.fetchBatchProfiles(
+          pubkeys: any(named: 'pubkeys'),
+        ),
+      ).thenAnswer((_) async => const {});
+    });
+
+    void stubVanished(Set<String> pubkeys) {
+      when(
+        () => mockProfileRepository.watchVanishedPubkeys(),
+      ).thenAnswer((_) => Stream.value(pubkeys));
+    }
+
+    ConversationListBloc createBloc({DmPeerLabels? withLabels}) {
+      final bloc = ConversationListBloc(
+        dmRepository: mockDmRepository,
+        followRepository: mockFollowRepository,
+        profileRepository: mockProfileRepository,
+        recomputeDebounce: Duration.zero,
+      );
+      if (withLabels != null) {
+        bloc.add(ConversationListPeerLabelsChanged(withLabels));
+      }
+      return bloc;
+    }
+
+    /// Awaits the next state matching [test], failing fast instead of hanging.
+    ///
+    /// A bare `firstWhere` on a bloc stream never completes when the behaviour
+    /// under test regresses, which turns a red test into a stuck CI job.
+    Future<ConversationListState> firstMatch(
+      ConversationListBloc bloc,
+      bool Function(ConversationListState) test,
+    ) => bloc.stream
+        .firstWhere(test)
+        .timeout(
+          const Duration(seconds: 5),
+          onTimeout: () => fail('no state matched within 5s'),
+        );
+
+    Future<ConversationListState> search(
+      ConversationListBloc bloc,
+      String query,
+    ) async {
+      bloc.add(const ConversationListStarted());
+      await bloc.stream.firstWhere(
+        (s) => s.status == ConversationListStatus.loaded,
+      );
+      bloc.add(ConversationListSearchQueryChanged(query));
+      return bloc.stream.firstWhere((s) => s.searchQuery == query);
+    }
+
+    group('a vanished counterparty', () {
+      setUp(() => stubVanished({_testPubkey2}));
+
+      test('is found by the deleted-account label the row shows', () async {
+        _stubStreams(
+          mockDmRepository,
+          accepted: [_createConversation(id: 'vanished')],
+        );
+        final bloc = createBloc(withLabels: labels);
+        addTearDown(bloc.close);
+
+        final state = await search(bloc, labels.deletedAccount);
+
+        expect(
+          state.visibleConversations.map((c) => c.id).toList(),
+          equals(['vanished']),
+        );
+      });
+
+      test('is not found by the generated handle nobody has seen', () async {
+        _stubStreams(
+          mockDmRepository,
+          accepted: [_createConversation(id: 'vanished')],
+        );
+        final bloc = createBloc(withLabels: labels);
+        addTearDown(bloc.close);
+
+        final state = await search(
+          bloc,
+          UserProfile.defaultDisplayNameFor(_testPubkey2),
+        );
+
+        expect(state.visibleConversations, isEmpty);
+      });
+
+      test('is still found by its message preview', () async {
+        _stubStreams(
+          mockDmRepository,
+          accepted: [
+            _createConversation(
+              id: 'vanished',
+              lastMessageContent: 'pizza friday?',
+            ),
+          ],
+        );
+        final bloc = createBloc(withLabels: labels);
+        addTearDown(bloc.close);
+
+        final state = await search(bloc, 'pizza');
+
+        expect(
+          state.visibleConversations.map((c) => c.id).toList(),
+          equals(['vanished']),
+        );
+      });
+    });
+
+    group('a retired Divine Moderation key', () {
+      // Rotated away from, so `_extractPinnedSupport` leaves it in the list as
+      // an ordinary searchable row — while `isModerationAccount` still answers
+      // for it, so the row renders the brand name.
+      final retired = kLegacyModerationPubkeys.first;
+
+      setUp(() => stubVanished(const {}));
+
+      test('is found by the moderation name the row shows', () async {
+        _stubStreams(
+          mockDmRepository,
+          accepted: [
+            _createConversation(
+              id: 'retired',
+              participantPubkeys: [_testPubkey1, retired],
+            ),
+          ],
+        );
+        final bloc = createBloc(withLabels: labels);
+        addTearDown(bloc.close);
+
+        final state = await search(bloc, labels.moderation);
+
+        expect(
+          state.visibleConversations.map((c) => c.id).toList(),
+          equals(['retired']),
+        );
+      });
+
+      test('is not found by the generated handle', () async {
+        _stubStreams(
+          mockDmRepository,
+          accepted: [
+            _createConversation(
+              id: 'retired',
+              participantPubkeys: [_testPubkey1, retired],
+            ),
+          ],
+        );
+        final bloc = createBloc(withLabels: labels);
+        addTearDown(bloc.close);
+
+        final state = await search(
+          bloc,
+          UserProfile.defaultDisplayNameFor(retired),
+        );
+
+        expect(state.visibleConversations, isEmpty);
+      });
+    });
+
+    test('a live counterparty still matches its generated name', () async {
+      stubVanished(const {});
+      _stubStreams(
+        mockDmRepository,
+        accepted: [_createConversation(id: 'live')],
+      );
+      final bloc = createBloc(withLabels: labels);
+      addTearDown(bloc.close);
+
+      final state = await search(
+        bloc,
+        UserProfile.defaultDisplayNameFor(_testPubkey2),
+      );
+
+      expect(
+        state.visibleConversations.map((c) => c.id).toList(),
+        equals(['live']),
+        reason: 'the vanished branch must not swallow ordinary rows',
+      );
+    });
+
+    test('a vanish arriving after the query re-filters on its own', () async {
+      // The row learns of a vanish from its own singular profile fetch, which
+      // can land after the index was built. Without a live subscription the
+      // results would stay wrong until the next keystroke.
+      final vanished = StreamController<Set<String>>();
+      addTearDown(vanished.close);
+      when(
+        () => mockProfileRepository.watchVanishedPubkeys(),
+      ).thenAnswer((_) => vanished.stream);
+      _stubStreams(
+        mockDmRepository,
+        accepted: [_createConversation(id: 'vanished')],
+      );
+      final bloc = createBloc(withLabels: labels);
+      addTearDown(bloc.close);
+
+      final before = await search(bloc, labels.deletedAccount);
+      expect(before.visibleConversations, isEmpty);
+
+      vanished.add({_testPubkey2});
+
+      final after = await firstMatch(
+        bloc,
+        (s) => s.visibleConversations.isNotEmpty,
+      );
+      expect(after.visibleConversations.map((c) => c.id).toList(), [
+        'vanished',
+      ]);
+    });
+
+    test('changing the app language re-filters into the new one', () async {
+      stubVanished({_testPubkey2});
+      final german = lookupAppLocalizations(const Locale('de'));
+      _stubStreams(
+        mockDmRepository,
+        accepted: [_createConversation(id: 'vanished')],
+      );
+      final bloc = createBloc(withLabels: labels);
+      addTearDown(bloc.close);
+
+      final inGerman = await search(bloc, german.profileDeletedAccountName);
+      expect(
+        inGerman.visibleConversations,
+        isEmpty,
+        reason: 'the German label must not match while the app is in English',
+      );
+
+      bloc.add(
+        ConversationListPeerLabelsChanged(
+          DmPeerLabels(
+            deletedAccount: german.profileDeletedAccountName,
+            moderation: german.inboxSupportRowTitle,
+          ),
+        ),
+      );
+
+      final after = await firstMatch(
+        bloc,
+        (s) => s.visibleConversations.isNotEmpty,
+      );
+      expect(after.visibleConversations.map((c) => c.id).toList(), [
+        'vanished',
+      ]);
+    });
+
+    test('a repository swap re-points the vanished subscription', () async {
+      stubVanished(const {});
+      _stubStreams(
+        mockDmRepository,
+        accepted: [_createConversation(id: 'vanished')],
+      );
+      final bloc = createBloc(withLabels: labels);
+      addTearDown(bloc.close);
+      await search(bloc, labels.deletedAccount);
+
+      final swapped = _MockProfileRepository();
+      when(
+        () => swapped.fetchBatchProfiles(pubkeys: any(named: 'pubkeys')),
+      ).thenAnswer((_) async => const {});
+      when(
+        swapped.watchVanishedPubkeys,
+      ).thenAnswer((_) => Stream.value({_testPubkey2}));
+
+      bloc.add(ConversationListProfileRepositoryChanged(swapped));
+
+      final after = await firstMatch(
+        bloc,
+        (s) => s.visibleConversations.isNotEmpty,
+      );
+      expect(after.visibleConversations.map((c) => c.id).toList(), [
+        'vanished',
+      ]);
+    });
+  });
+
   group('ConversationListSearchQueryChanged', () {
     late _MockDmRepository mockDmRepository;
     late _MockFollowRepository mockFollowRepository;
@@ -2344,6 +2662,9 @@ void main() {
           pubkeys: any(named: 'pubkeys'),
         ),
       ).thenAnswer((_) async => const {});
+      when(
+        () => mockProfileRepository.watchVanishedPubkeys(),
+      ).thenAnswer((_) => Stream.value(const <String>{}));
     });
 
     ConversationListBloc createBloc({bool withProfiles = true}) =>
@@ -2439,6 +2760,9 @@ void main() {
             ),
           },
         );
+        when(
+          () => mockProfileRepository.watchVanishedPubkeys(),
+        ).thenAnswer((_) => Stream.value(const <String>{}));
 
         // Cold start: the repository is not ready yet.
         final bloc = createBloc(withProfiles: false);
@@ -2518,6 +2842,9 @@ void main() {
           ),
         },
       );
+      when(
+        () => mockProfileRepository.watchVanishedPubkeys(),
+      ).thenAnswer((_) => Stream.value(const <String>{}));
       final bloc = createBloc();
       addTearDown(bloc.close);
       await load(bloc);
@@ -2685,6 +3012,9 @@ void main() {
             ),
           },
         );
+        when(
+          () => mockProfileRepository.watchVanishedPubkeys(),
+        ).thenAnswer((_) => Stream.value(const <String>{}));
 
         final bloc = createBloc()..add(const ConversationListStarted());
         addTearDown(() async {
@@ -2750,6 +3080,9 @@ void main() {
             ),
           },
         );
+        when(
+          () => mockProfileRepository.watchVanishedPubkeys(),
+        ).thenAnswer((_) => Stream.value(const <String>{}));
 
         final bloc = createBloc()..add(const ConversationListStarted());
         addTearDown(() async {
@@ -2812,6 +3145,9 @@ void main() {
             pubkeys: any(named: 'pubkeys'),
           ),
         ).thenAnswer((_) async => const <String, UserProfile>{});
+        when(
+          () => mockProfileRepository.watchVanishedPubkeys(),
+        ).thenAnswer((_) => Stream.value(const <String>{}));
 
         // Cold start: the nullable-gated provider has not handed over yet.
         final bloc = ConversationListBloc(

--- a/mobile/test/blocs/dm/conversation_list/conversation_list_bloc_test.dart
+++ b/mobile/test/blocs/dm/conversation_list/conversation_list_bloc_test.dart
@@ -2346,6 +2346,7 @@ void main() {
       labels = DmPeerLabels(
         deletedAccount: l10n.profileDeletedAccountName,
         moderation: l10n.inboxSupportRowTitle,
+        retiredConversationClosed: l10n.dmRetiredThreadClosedTitle,
       );
 
       when(() => mockFollowRepository.isFollowing(any())).thenReturn(true);
@@ -2380,6 +2381,8 @@ void main() {
         followRepository: mockFollowRepository,
         profileRepository: mockProfileRepository,
         recomputeDebounce: Duration.zero,
+        moderationAccount: isModerationAccount,
+        retiredModerationAccount: isRetiredModerationAccount,
       );
       if (withLabels != null) {
         bloc.add(ConversationListPeerLabelsChanged(withLabels));
@@ -2519,7 +2522,58 @@ void main() {
 
         expect(state.visibleConversations, isEmpty);
       });
+
+      test('is found by the closed subtitle the row shows', () async {
+        _stubStreams(
+          mockDmRepository,
+          accepted: [
+            _createConversation(
+              id: 'retired',
+              participantPubkeys: [_testPubkey1, retired],
+              lastMessageContent: 'Your video was removed',
+            ),
+          ],
+        );
+        final bloc = createBloc(withLabels: labels);
+        addTearDown(bloc.close);
+
+        final state = await search(bloc, labels.retiredConversationClosed);
+
+        expect(state.visibleConversations.map((c) => c.id).toList(), [
+          'retired',
+        ]);
+      });
+
+      test('is not found by hidden last-message content', () async {
+        _stubStreams(
+          mockDmRepository,
+          accepted: [
+            _createConversation(
+              id: 'retired',
+              participantPubkeys: [_testPubkey1, retired],
+              lastMessageContent: 'Your video was removed',
+            ),
+          ],
+        );
+        final bloc = createBloc(withLabels: labels);
+        addTearDown(bloc.close);
+
+        final state = await search(bloc, 'removed');
+
+        expect(state.visibleConversations, isEmpty);
+      });
     });
+
+    blocTest<ConversationListBloc, ConversationListState>(
+      'routes vanished-stream IO errors through the bloc error channel',
+      setUp: () {
+        when(
+          () => mockProfileRepository.watchVanishedPubkeys(),
+        ).thenAnswer((_) => Stream.error(Exception('db failure')));
+      },
+      build: createBloc,
+      errors: () => [isA<Exception>()],
+    );
 
     test('a live counterparty still matches its generated name', () async {
       stubVanished(const {});
@@ -2594,6 +2648,7 @@ void main() {
           DmPeerLabels(
             deletedAccount: german.profileDeletedAccountName,
             moderation: german.inboxSupportRowTitle,
+            retiredConversationClosed: german.dmRetiredThreadClosedTitle,
           ),
         ),
       );

--- a/mobile/test/blocs/dm/dm_peer_name_test.dart
+++ b/mobile/test/blocs/dm/dm_peer_name_test.dart
@@ -9,6 +9,7 @@ import 'package:openvine/config/official_accounts.dart';
 const _labels = DmPeerLabels(
   deletedAccount: 'Deleted account',
   moderation: 'Divine Moderation',
+  retiredConversationClosed: 'This conversation is closed.',
 );
 
 const _ordinaryPubkey =
@@ -22,6 +23,7 @@ void main() {
           dmPeerName(
             pubkeyHex: kModerationPubkeyHex,
             isVanished: true,
+            isModeration: true,
             labels: _labels,
             profileName: 'Kind Zero Name',
             displayNameOverride: 'Override',
@@ -35,6 +37,7 @@ void main() {
           dmPeerName(
             pubkeyHex: kModerationPubkeyHex,
             isVanished: false,
+            isModeration: true,
             labels: _labels,
             profileName: 'Kind Zero Name',
             displayNameOverride: 'Override',
@@ -48,6 +51,7 @@ void main() {
           dmPeerName(
             pubkeyHex: kModerationPubkeyHex,
             isVanished: false,
+            isModeration: true,
             labels: _labels,
             profileName: 'Kind Zero Name',
           ),
@@ -60,6 +64,7 @@ void main() {
           dmPeerName(
             pubkeyHex: _ordinaryPubkey,
             isVanished: false,
+            isModeration: false,
             labels: _labels,
             profileName: 'Kind Zero Name',
           ),
@@ -72,6 +77,7 @@ void main() {
           dmPeerName(
             pubkeyHex: _ordinaryPubkey,
             isVanished: false,
+            isModeration: false,
             labels: _labels,
           ),
           equals(UserProfile.defaultDisplayNameFor(_ordinaryPubkey)),
@@ -90,6 +96,7 @@ void main() {
           dmPeerName(
             pubkeyHex: retired,
             isVanished: false,
+            isModeration: true,
             labels: _labels,
           ),
           equals(_labels.moderation),
@@ -101,6 +108,7 @@ void main() {
           dmPeerName(
             pubkeyHex: _ordinaryPubkey,
             isVanished: false,
+            isModeration: false,
             labels: _labels,
           ),
           isNot(equals(_labels.moderation)),
@@ -112,15 +120,37 @@ void main() {
   group(DmPeerLabels, () {
     test('compares by value, so a redelivery of the same copy is a no-op', () {
       expect(
-        const DmPeerLabels(deletedAccount: 'a', moderation: 'b'),
-        equals(const DmPeerLabels(deletedAccount: 'a', moderation: 'b')),
+        const DmPeerLabels(
+          deletedAccount: 'a',
+          moderation: 'b',
+          retiredConversationClosed: 'c',
+        ),
+        equals(
+          const DmPeerLabels(
+            deletedAccount: 'a',
+            moderation: 'b',
+            retiredConversationClosed: 'c',
+          ),
+        ),
       );
     });
 
     test('differs when the locale changes the copy', () {
       expect(
-        const DmPeerLabels(deletedAccount: 'a', moderation: 'b'),
-        isNot(equals(const DmPeerLabels(deletedAccount: 'z', moderation: 'b'))),
+        const DmPeerLabels(
+          deletedAccount: 'a',
+          moderation: 'b',
+          retiredConversationClosed: 'c',
+        ),
+        isNot(
+          equals(
+            const DmPeerLabels(
+              deletedAccount: 'z',
+              moderation: 'b',
+              retiredConversationClosed: 'c',
+            ),
+          ),
+        ),
       );
     });
   });

--- a/mobile/test/blocs/dm/dm_peer_name_test.dart
+++ b/mobile/test/blocs/dm/dm_peer_name_test.dart
@@ -1,0 +1,127 @@
+// ABOUTME: Tests for dmPeerName - the single naming precedence every DM
+// ABOUTME: surface resolves a conversation peer through.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart';
+import 'package:openvine/blocs/dm/dm_peer_name.dart';
+import 'package:openvine/config/official_accounts.dart';
+
+const _labels = DmPeerLabels(
+  deletedAccount: 'Deleted account',
+  moderation: 'Divine Moderation',
+);
+
+const _ordinaryPubkey =
+    'd4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5';
+
+void main() {
+  group(dmPeerName, () {
+    group('precedence', () {
+      test('vanished outranks every other branch', () {
+        expect(
+          dmPeerName(
+            pubkeyHex: kModerationPubkeyHex,
+            isVanished: true,
+            labels: _labels,
+            profileName: 'Kind Zero Name',
+            displayNameOverride: 'Override',
+          ),
+          equals(_labels.deletedAccount),
+        );
+      });
+
+      test('the override outranks moderation and the profile', () {
+        expect(
+          dmPeerName(
+            pubkeyHex: kModerationPubkeyHex,
+            isVanished: false,
+            labels: _labels,
+            profileName: 'Kind Zero Name',
+            displayNameOverride: 'Override',
+          ),
+          equals('Override'),
+        );
+      });
+
+      test('moderation outranks the profile', () {
+        expect(
+          dmPeerName(
+            pubkeyHex: kModerationPubkeyHex,
+            isVanished: false,
+            labels: _labels,
+            profileName: 'Kind Zero Name',
+          ),
+          equals(_labels.moderation),
+        );
+      });
+
+      test('the profile outranks the generated fallback', () {
+        expect(
+          dmPeerName(
+            pubkeyHex: _ordinaryPubkey,
+            isVanished: false,
+            labels: _labels,
+            profileName: 'Kind Zero Name',
+          ),
+          equals('Kind Zero Name'),
+        );
+      });
+
+      test('the generated fallback answers when nothing else does', () {
+        expect(
+          dmPeerName(
+            pubkeyHex: _ordinaryPubkey,
+            isVanished: false,
+            labels: _labels,
+          ),
+          equals(UserProfile.defaultDisplayNameFor(_ordinaryPubkey)),
+        );
+      });
+    });
+
+    group('moderation keys', () {
+      // A rotated-away key has no kind 0 at all, so without this branch the
+      // row falls through to a generated handle and an enforcement thread
+      // reads as a stranger.
+      test('answers for a retired key, not only the current one', () {
+        final retired = kLegacyModerationPubkeys.first;
+
+        expect(
+          dmPeerName(
+            pubkeyHex: retired,
+            isVanished: false,
+            labels: _labels,
+          ),
+          equals(_labels.moderation),
+        );
+      });
+
+      test('leaves an ordinary pubkey alone', () {
+        expect(
+          dmPeerName(
+            pubkeyHex: _ordinaryPubkey,
+            isVanished: false,
+            labels: _labels,
+          ),
+          isNot(equals(_labels.moderation)),
+        );
+      });
+    });
+  });
+
+  group(DmPeerLabels, () {
+    test('compares by value, so a redelivery of the same copy is a no-op', () {
+      expect(
+        const DmPeerLabels(deletedAccount: 'a', moderation: 'b'),
+        equals(const DmPeerLabels(deletedAccount: 'a', moderation: 'b')),
+      );
+    });
+
+    test('differs when the locale changes the copy', () {
+      expect(
+        const DmPeerLabels(deletedAccount: 'a', moderation: 'b'),
+        isNot(equals(const DmPeerLabels(deletedAccount: 'z', moderation: 'b'))),
+      );
+    });
+  });
+}

--- a/mobile/test/screens/inbox/inbox_page_test.dart
+++ b/mobile/test/screens/inbox/inbox_page_test.dart
@@ -346,6 +346,11 @@ void main() {
         (tester) async {
           stubInbox(mockDmRepository, userPubkey: testPubkey);
           final readyProfileRepo = _MockProfileRepository();
+          // The bloc subscribes to the vanished set on every repository swap,
+          // so the incoming instance has to answer for it.
+          when(
+            readyProfileRepo.watchVanishedPubkeys,
+          ).thenAnswer((_) => Stream.value(const <String>{}));
 
           await tester.pumpWidget(
             buildApp(mockDmRepository, readyProfileRepo: readyProfileRepo),


### PR DESCRIPTION
## What

The DM inbox resolved a conversation peer's name **twice, through two independent chains**. The row rendered through `dmPeerDisplayName` — five steps, vanished first. Inbox search matched through `ConversationListBloc._applyFilters`, which implemented the last two and nothing else:

```dart
final name =
    (profileNames[other] ?? UserProfile.defaultDisplayNameFor(other))
        .toLowerCase();
```

So a peer who published a NIP-62 vanish showed **"Deleted account"** on the row and was indexed under a generated **"Adjective Animal N"** the viewer has never seen. Searching what is on screen found nothing; searching the invisible string found the row.

## The part that isn't in the issue

The same expression mis-names a **second** row nobody had reported. A thread on a *retired* Divine Moderation key stays an ordinary searchable row — `_extractPinnedSupport` lifts out only the current key — while `isModerationAccount` still answers for retired keys, so it renders "Divine Moderation" and indexes a generated handle too. `moderation_identity.dart` already documents why that profile is always null: a retired key has no kind 0 at all.

Both are fixed here. Fixing only the reported half would knowingly ship the twin.

## How

The root cause is structural — a duplicated chain, not a missing branch — so the fix unifies rather than patches. `dmPeerName` is a pure, Flutter-free resolver both callers share; `dmPeerDisplayName` keeps its exact signature as a thin `BuildContext` wrapper, so `ConversationTile` and the surfaces #8196/#8207 moved onto the chain are untouched. A future branch is now added once and both surfaces inherit it.

Two things the vanish signal could **not** come from, both established before writing code:

- **Not the batch response.** Measured against a funnelcake built from `origin/main` (`3ea33693`) in Docker: of five reachable vanish states, `POST /api/users/bulk` yields a usable signal in exactly one. A *pending* request is stripped upstream by `get_hidden_pubkeys` and appears in neither `users` nor `missing` — the client cannot tell it asked.
- **Not `ProfileRepository.isVanished`.** It reads an in-memory mirror seeded by an *unawaited* `loadVanishedPubkeys`, while the row watches the durable `vanished_profiles` table. Sampling it reopens the bug at cold start.

So the bloc subscribes to a new `watchVanishedPubkeys()` — the same source the row reads — and re-points it on every repository swap.

Labels are injected because a bloc has no `context.l10n`, and **re-delivered on a locale change**: `BlocProvider.create:` runs once while the in-app language picker does not restart the app, so labels injected only at construction would leave search matching the previous language. They are delivered from inside the Messages subtree, below the `BlocListener` that already consumes the bloc, so `BlocProvider`'s laziness is unchanged.

**No ARB changes** — all three labels already ship in all 22 locales.

## Testing

`mobile/test/blocs/dm/conversation_list/` — a vanished row is found by the deleted-account label and *not* by the generated handle; the same pair for a retired moderation key; a live row still matches its generated name; message-preview search still works; a vanish arriving *after* the query re-filters without a keystroke; a language change re-filters into the new language; a repository swap re-points the subscription.

`mobile/test/blocs/dm/dm_peer_name_test.dart` — each branch in precedence order.
`mobile/packages/profile_repository/` — the stream mirrors the DAO, follows later writes, and answers when no DAO is wired.

Every assertion was **verified by mutation**: reverting the vanished branch reddens 5, reverting the moderation branch reddens exactly the 2 moderation tests, and dropping the swap re-subscribe reddens exactly the swap test.

Local: `flutter analyze lib test integration_test` clean; `test/blocs/dm/` + `test/screens/inbox/` 851 pass; `profile_repository` 451 pass.

## Not fixed here

- A pending vanish nobody has fetched is unknown to *both* chains — the row shows the generated name too, so they still agree. This issue is about disagreement.
- divine-web shows `genUserName(pubkey)` for the same peer. It has no DM conversation list and no vanish handling at all, so there is nothing to keep in sync; noted rather than changed.

Fixes #8204
