### PR TITLE
fix(reporting): make text-only content reports clear

### DIFF
--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -2064,6 +2064,7 @@
     "reportSelectReason": "እባክዎ ይህን ይዘት ሪፖርት ለማድረግ ምክንያት ይምረጡ",
     "reportOtherRequiresDetails": "«ሌላ» ስትመርጥ እባክህ ችግሩን ግለጽ",
     "reportDetailsRequired": "እባክህ ችግሩን ግለጽ",
+    "reportDetailsTextOnly": "ጽሑፍ ብቻ — ፎቶዎችን እና GIF-ዎችን እዚህ ማያያዝ አይቻልም።",
     "reportReasonSpam": "አይፈለጌ መልእክት ወይም የማይፈለግ ይዘት",
     "reportReasonHarassment": "ማስፈራራት፣ ማስፈራራት ወይም ማስፈራራት",
     "reportReasonViolence": "የጥቃት ወይም ጽንፈኛ ይዘት",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -1666,6 +1666,7 @@
     "reportSelectReason": "يُرجى اختيار سبب للإبلاغ عن هذا المحتوى",
     "reportOtherRequiresDetails": "يرجى وصف المشكلة عند اختيار «أخرى»",
     "reportDetailsRequired": "يرجى وصف المشكلة",
+    "reportDetailsTextOnly": "نص فقط — لا يمكن إرفاق الصور أو ملفات GIF هنا.",
     "reportReasonSpam": "محتوى غير مرغوب فيه أو مزعج",
     "reportReasonHarassment": "تحرُّش أو تنمُّر أو تهديدات",
     "reportReasonViolence": "محتوى عنيف أو متطرف",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -1876,6 +1876,7 @@
     "reportSelectReason": "Избери причина за докладване на това съдържание",
     "reportOtherRequiresDetails": "Моля, опиши проблема, когато избираш „Друго“",
     "reportDetailsRequired": "Моля, опиши проблема",
+    "reportDetailsTextOnly": "Само текст — тук не могат да се прикачват снимки или GIF файлове.",
     "reportReasonSpam": "Спам или нежелано съдържание",
     "reportReasonHarassment": "Тормоз, малтретиране или заплахи",
     "reportReasonViolence": "Насилствено или екстремистко съдържание",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -1676,6 +1676,7 @@
     "reportSelectReason": "Bitte wähl einen Grund für die Meldung dieses Inhalts",
     "reportOtherRequiresDetails": "Bitte beschreib das Problem, wenn du „Sonstiges“ wählst",
     "reportDetailsRequired": "Bitte beschreib das Problem",
+    "reportDetailsTextOnly": "Nur Text – Fotos und GIFs können hier nicht angehängt werden.",
     "reportReasonSpam": "Spam oder unerwünschte Inhalte",
     "reportReasonHarassment": "Belästigung, Mobbing oder Drohungen",
     "reportReasonViolence": "Gewalttätige oder extremistische Inhalte",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -2910,6 +2910,10 @@
   "reportSelectReason": "Please select a reason for reporting this content",
   "reportOtherRequiresDetails": "Please describe the issue when selecting Other",
   "reportDetailsRequired": "Please describe the issue",
+  "reportDetailsTextOnly": "Text only — photos and GIFs can’t be attached here.",
+  "@reportDetailsTextOnly": {
+    "description": "Shown below the content report details field to warn that photos, screenshots, and GIFs cannot be attached."
+  },
   "reportReasonSpam": "Spam or Unwanted Content",
   "reportReasonSpamSubtitle": "Unwanted or repetitive content",
   "reportReasonHarassment": "Harassment, Bullying, or Threats",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -2912,7 +2912,7 @@
   "reportDetailsRequired": "Please describe the issue",
   "reportDetailsTextOnly": "Text only — photos and GIFs can’t be attached here.",
   "@reportDetailsTextOnly": {
-    "description": "Shown below the content report details field to warn that photos, screenshots, and GIFs cannot be attached."
+    "description": "Shown above the content report details field to warn that photos, screenshots, and GIFs cannot be attached."
   },
   "reportReasonSpam": "Spam or Unwanted Content",
   "reportReasonSpamSubtitle": "Unwanted or repetitive content",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -1680,6 +1680,7 @@
     "reportSelectReason": "Elegí un motivo para reportar este contenido",
     "reportOtherRequiresDetails": "Describe el problema cuando elijas Otro",
     "reportDetailsRequired": "Describe el problema",
+    "reportDetailsTextOnly": "Solo texto: aquí no se pueden adjuntar fotos ni GIF.",
     "reportReasonSpam": "Spam o contenido no deseado",
     "reportReasonHarassment": "Acoso, bullying o amenazas",
     "reportReasonViolence": "Contenido violento o extremista",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -1159,6 +1159,7 @@
     "reportSelectReason": "Pumili ng dahilan para i-report ang content na ito",
     "reportOtherRequiresDetails": "Pakilarawan ang problema kapag pinili mo ang Iba pa",
     "reportDetailsRequired": "Pakilarawan ang problema",
+    "reportDetailsTextOnly": "Text lang — hindi puwedeng mag-attach ng mga litrato o GIF dito.",
     "reportReasonSpam": "Spam o Hindi Gustong Content",
     "reportReasonHarassment": "Harassment, Bullying, o Pagbabanta",
     "reportReasonViolence": "Marahas o Extremist na Content",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -1676,6 +1676,7 @@
     "reportSelectReason": "Sélectionne une raison pour signaler ce contenu",
     "reportOtherRequiresDetails": "Décris le problème quand tu choisis Autre",
     "reportDetailsRequired": "Décris le problème",
+    "reportDetailsTextOnly": "Texte uniquement — impossible de joindre des photos ou des GIF ici.",
     "reportReasonSpam": "Spam ou contenu indésirable",
     "reportReasonHarassment": "Harcèlement, intimidation ou menaces",
     "reportReasonViolence": "Contenu violent ou extrémiste",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -1673,6 +1673,7 @@
     "reportSelectReason": "Silakan pilih alasan untuk melaporkan konten ini",
     "reportOtherRequiresDetails": "Jelaskan masalahnya kalau memilih Lainnya",
     "reportDetailsRequired": "Jelaskan masalahnya",
+    "reportDetailsTextOnly": "Hanya teks — foto dan GIF tidak dapat dilampirkan di sini.",
     "reportReasonSpam": "Spam atau Konten Tidak Diinginkan",
     "reportReasonHarassment": "Pelecehan, Perundungan, atau Ancaman",
     "reportReasonViolence": "Konten Kekerasan atau Ekstremis",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -1676,6 +1676,7 @@
     "reportSelectReason": "Seleziona un motivo per segnalare questo contenuto",
     "reportOtherRequiresDetails": "Descrivi il problema quando selezioni Altro",
     "reportDetailsRequired": "Descrivi il problema",
+    "reportDetailsTextOnly": "Solo testo: qui non puoi allegare foto o GIF.",
     "reportReasonSpam": "Spam o contenuto indesiderato",
     "reportReasonHarassment": "Molestie, bullismo o minacce",
     "reportReasonViolence": "Contenuto violento o estremista",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -1666,6 +1666,7 @@
     "reportSelectReason": "報告する理由を選んでね",
     "reportOtherRequiresDetails": "「その他」を選んだ場合は問題の内容を記入してください",
     "reportDetailsRequired": "問題の内容を記入してください",
+    "reportDetailsTextOnly": "テキストのみです。ここには写真やGIFを添付できません。",
     "reportReasonSpam": "スパムや迷惑なコンテンツ",
     "reportReasonHarassment": "嫌がらせ、いじめ、脅迫",
     "reportReasonViolence": "暴力的・過激なコンテンツ",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -1134,6 +1134,7 @@
     "reportSelectReason": "이 콘텐츠를 신고하는 이유를 선택해 주세요",
     "reportOtherRequiresDetails": "‘기타’를 선택했다면 문제를 설명해 주세요",
     "reportDetailsRequired": "문제를 설명해 주세요",
+    "reportDetailsTextOnly": "텍스트만 입력할 수 있습니다. 여기에는 사진이나 GIF를 첨부할 수 없습니다.",
     "reportReasonSpam": "스팸 또는 원치 않는 콘텐츠",
     "reportReasonHarassment": "괴롭힘, 따돌림, 협박",
     "reportReasonViolence": "폭력적이거나 극단적인 콘텐츠",

--- a/mobile/lib/l10n/app_ms.arb
+++ b/mobile/lib/l10n/app_ms.arb
@@ -2432,6 +2432,7 @@
   "reportSelectReason": "Sila pilih sebab untuk melaporkan kandungan ini",
   "reportOtherRequiresDetails": "Sila terangkan isu itu apabila memilih Lain-lain",
   "reportDetailsRequired": "Sila terangkan isu itu",
+  "reportDetailsTextOnly": "Teks sahaja — foto dan GIF tidak boleh dilampirkan di sini.",
   "reportReasonSpam": "Spam atau Kandungan Tidak Diingini",
   "reportReasonSpamSubtitle": "Kandungan tidak diingini atau berulang",
   "reportReasonHarassment": "Gangguan, Buli atau Ancaman",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -1676,6 +1676,7 @@
     "reportSelectReason": "Selecteer een reden om deze inhoud te melden",
     "reportOtherRequiresDetails": "Beschrijf het probleem als je Overig kiest",
     "reportDetailsRequired": "Beschrijf het probleem",
+    "reportDetailsTextOnly": "Alleen tekst — je kunt hier geen foto's of GIF's toevoegen.",
     "reportReasonSpam": "Spam of ongewenste inhoud",
     "reportReasonHarassment": "Intimidatie, pesten of bedreigingen",
     "reportReasonViolence": "Gewelddadige of extremistische inhoud",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -1676,6 +1676,7 @@
     "reportSelectReason": "Wybierz powód zgłoszenia tej treści",
     "reportOtherRequiresDetails": "Przy wyborze „Inne” opisz problem",
     "reportDetailsRequired": "Opisz problem",
+    "reportDetailsTextOnly": "Tylko tekst — nie można tu dołączać zdjęć ani plików GIF.",
     "reportReasonSpam": "Spam lub niechciana treść",
     "reportReasonHarassment": "Nagabywanie, zniesławianie lub groźby",
     "reportReasonViolence": "Treści brutalne lub ekstremistyczne",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -1676,6 +1676,7 @@
     "reportSelectReason": "Selecione um motivo para denunciar este conteúdo",
     "reportOtherRequiresDetails": "Descreva o problema ao escolher Outro",
     "reportDetailsRequired": "Descreva o problema",
+    "reportDetailsTextOnly": "Apenas texto — não é possível anexar fotos ou GIFs aqui.",
     "reportReasonSpam": "Spam ou conteúdo indesejado",
     "reportReasonHarassment": "Assédio, bullying ou ameaças",
     "reportReasonViolence": "Conteúdo violento ou extremista",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -1676,6 +1676,7 @@
     "reportSelectReason": "Alege un motiv pentru raportarea acestui conținut",
     "reportOtherRequiresDetails": "Descrie problema când alegi „Altele”",
     "reportDetailsRequired": "Descrie problema",
+    "reportDetailsTextOnly": "Doar text — fotografiile și GIF-urile nu pot fi atașate aici.",
     "reportReasonSpam": "Spam sau conținut nedorit",
     "reportReasonHarassment": "Hărțuire, bullying sau amenințări",
     "reportReasonViolence": "Conținut violent sau extremist",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -1676,6 +1676,7 @@
     "reportSelectReason": "Välj en anledning för att rapportera det här innehållet",
     "reportOtherRequiresDetails": "Beskriv problemet när du väljer Övrigt",
     "reportDetailsRequired": "Beskriv problemet",
+    "reportDetailsTextOnly": "Endast text – foton och GIF-bilder kan inte bifogas här.",
     "reportReasonSpam": "Skräppost eller ovälkommet innehåll",
     "reportReasonHarassment": "Trakasserier, mobbning eller hot",
     "reportReasonViolence": "Våldsamt eller extremistiskt innehåll",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -1673,6 +1673,7 @@
     "reportSelectReason": "Lütfen bu içeriği bildirmek için bir sebep seç",
     "reportOtherRequiresDetails": "«Diğer»i seçtiğinde lütfen sorunu açıkla",
     "reportDetailsRequired": "Lütfen sorunu açıkla",
+    "reportDetailsTextOnly": "Yalnızca metin — buraya fotoğraf veya GIF eklenemez.",
     "reportReasonSpam": "Spam veya İstenmeyen İçerik",
     "reportReasonHarassment": "Taciz, Zorbalık veya Tehdit",
     "reportReasonViolence": "Şiddet veya Aşırı İçerik",

--- a/mobile/lib/l10n/app_ur.arb
+++ b/mobile/lib/l10n/app_ur.arb
@@ -2432,6 +2432,7 @@
   "reportSelectReason": "براہ کرم اس مواد کی رپورٹ کرنے کی وجہ منتخب کریں",
   "reportOtherRequiresDetails": "دیگر منتخب کرنے پر براہ کرم مسئلہ بیان کریں",
   "reportDetailsRequired": "براہ کرم مسئلہ بیان کریں",
+  "reportDetailsTextOnly": "صرف متن — یہاں تصاویر یا GIF منسلک نہیں کیے جا سکتے۔",
   "reportReasonSpam": "اسپیم یا ناپسندیدہ مواد",
   "reportReasonSpamSubtitle": "ناپسندیدہ یا بار بار کا مواد",
   "reportReasonHarassment": "ہراسانی، دھتکار، یا دھمکیاں",

--- a/mobile/lib/l10n/app_vi.arb
+++ b/mobile/lib/l10n/app_vi.arb
@@ -2432,6 +2432,7 @@
   "reportSelectReason": "Vui lòng chọn lý do báo cáo nội dung này",
   "reportOtherRequiresDetails": "Vui lòng mô tả vấn đề khi chọn Khác",
   "reportDetailsRequired": "Vui lòng mô tả vấn đề",
+  "reportDetailsTextOnly": "Chỉ văn bản — không thể đính kèm ảnh hoặc GIF ở đây.",
   "reportReasonSpam": "Spam hoặc nội dung không mong muốn",
   "reportReasonSpamSubtitle": "Nội dung không mong muốn hoặc lặp lại",
   "reportReasonHarassment": "Quấy rối, bắt nạt hoặc đe dọa",

--- a/mobile/lib/l10n/app_zh.arb
+++ b/mobile/lib/l10n/app_zh.arb
@@ -2432,6 +2432,7 @@
   "reportSelectReason": "请选择举报该内容的原因",
   "reportOtherRequiresDetails": "选择“其他”时请描述问题",
   "reportDetailsRequired": "请描述问题",
+  "reportDetailsTextOnly": "仅限文字——无法在此附加照片或 GIF。",
   "reportReasonSpam": "垃圾或不受欢迎的内容",
   "reportReasonSpamSubtitle": "不受欢迎或重复的内容",
   "reportReasonHarassment": "骚扰、霸凌或威胁",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -7817,7 +7817,7 @@ abstract class AppLocalizations {
   /// **'Please describe the issue'**
   String get reportDetailsRequired;
 
-  /// Shown below the content report details field to warn that photos, screenshots, and GIFs cannot be attached.
+  /// Shown above the content report details field to warn that photos, screenshots, and GIFs cannot be attached.
   ///
   /// In en, this message translates to:
   /// **'Text only — photos and GIFs can’t be attached here.'**

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -7817,6 +7817,12 @@ abstract class AppLocalizations {
   /// **'Please describe the issue'**
   String get reportDetailsRequired;
 
+  /// Shown below the content report details field to warn that photos, screenshots, and GIFs cannot be attached.
+  ///
+  /// In en, this message translates to:
+  /// **'Text only — photos and GIFs can’t be attached here.'**
+  String get reportDetailsTextOnly;
+
   /// No description provided for @reportReasonSpam.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -4473,6 +4473,10 @@ class AppLocalizationsAm extends AppLocalizations {
   String get reportDetailsRequired => 'እባክህ ችግሩን ግለጽ';
 
   @override
+  String get reportDetailsTextOnly =>
+      'ጽሑፍ ብቻ — ፎቶዎችን እና GIF-ዎችን እዚህ ማያያዝ አይቻልም።';
+
+  @override
   String get reportReasonSpam => 'አይፈለጌ መልእክት ወይም የማይፈለግ ይዘት';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -4534,6 +4534,10 @@ class AppLocalizationsAr extends AppLocalizations {
   String get reportDetailsRequired => 'يرجى وصف المشكلة';
 
   @override
+  String get reportDetailsTextOnly =>
+      'نص فقط — لا يمكن إرفاق الصور أو ملفات GIF هنا.';
+
+  @override
   String get reportReasonSpam => 'محتوى غير مرغوب فيه أو مزعج';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -4623,6 +4623,10 @@ class AppLocalizationsBg extends AppLocalizations {
   String get reportDetailsRequired => 'Моля, опиши проблема';
 
   @override
+  String get reportDetailsTextOnly =>
+      'Само текст — тук не могат да се прикачват снимки или GIF файлове.';
+
+  @override
   String get reportReasonSpam => 'Спам или нежелано съдържание';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -4631,6 +4631,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get reportDetailsRequired => 'Bitte beschreib das Problem';
 
   @override
+  String get reportDetailsTextOnly =>
+      'Nur Text – Fotos und GIFs können hier nicht angehängt werden.';
+
+  @override
   String get reportReasonSpam => 'Spam oder unerwünschte Inhalte';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -4662,6 +4662,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get reportDetailsRequired => 'Please describe the issue';
 
   @override
+  String get reportDetailsTextOnly =>
+      'Text only — photos and GIFs can’t be attached here.';
+
+  @override
   String get reportReasonSpam => 'Spam or Unwanted Content';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -4621,6 +4621,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get reportDetailsRequired => 'Describe el problema';
 
   @override
+  String get reportDetailsTextOnly =>
+      'Solo texto: aquí no se pueden adjuntar fotos ni GIF.';
+
+  @override
   String get reportReasonSpam => 'Spam o contenido no deseado';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -4605,6 +4605,10 @@ class AppLocalizationsFil extends AppLocalizations {
   String get reportDetailsRequired => 'Pakilarawan ang problema';
 
   @override
+  String get reportDetailsTextOnly =>
+      'Text lang — hindi puwedeng mag-attach ng mga litrato o GIF dito.';
+
+  @override
   String get reportReasonSpam => 'Spam o Hindi Gustong Content';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -4640,6 +4640,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get reportDetailsRequired => 'Décris le problème';
 
   @override
+  String get reportDetailsTextOnly =>
+      'Texte uniquement — impossible de joindre des photos ou des GIF ici.';
+
+  @override
   String get reportReasonSpam => 'Spam ou contenu indésirable';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -4505,6 +4505,10 @@ class AppLocalizationsId extends AppLocalizations {
   String get reportDetailsRequired => 'Jelaskan masalahnya';
 
   @override
+  String get reportDetailsTextOnly =>
+      'Hanya teks — foto dan GIF tidak dapat dilampirkan di sini.';
+
+  @override
   String get reportReasonSpam => 'Spam atau Konten Tidak Diinginkan';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -4625,6 +4625,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get reportDetailsRequired => 'Descrivi il problema';
 
   @override
+  String get reportDetailsTextOnly =>
+      'Solo testo: qui non puoi allegare foto o GIF.';
+
+  @override
   String get reportReasonSpam => 'Spam o contenuto indesiderato';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -4310,6 +4310,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get reportDetailsRequired => '問題の内容を記入してください';
 
   @override
+  String get reportDetailsTextOnly => 'テキストのみです。ここには写真やGIFを添付できません。';
+
+  @override
   String get reportReasonSpam => 'スパムや迷惑なコンテンツ';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -4326,6 +4326,10 @@ class AppLocalizationsKo extends AppLocalizations {
   String get reportDetailsRequired => '문제를 설명해 주세요';
 
   @override
+  String get reportDetailsTextOnly =>
+      '텍스트만 입력할 수 있습니다. 여기에는 사진이나 GIF를 첨부할 수 없습니다.';
+
+  @override
   String get reportReasonSpam => '스팸 또는 원치 않는 콘텐츠';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -4575,6 +4575,10 @@ class AppLocalizationsMs extends AppLocalizations {
   String get reportDetailsRequired => 'Sila terangkan isu itu';
 
   @override
+  String get reportDetailsTextOnly =>
+      'Teks sahaja — foto dan GIF tidak boleh dilampirkan di sini.';
+
+  @override
   String get reportReasonSpam => 'Spam atau Kandungan Tidak Diingini';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -4590,6 +4590,10 @@ class AppLocalizationsNl extends AppLocalizations {
   String get reportDetailsRequired => 'Beschrijf het probleem';
 
   @override
+  String get reportDetailsTextOnly =>
+      'Alleen tekst — je kunt hier geen foto\'s of GIF\'s toevoegen.';
+
+  @override
   String get reportReasonSpam => 'Spam of ongewenste inhoud';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -4692,6 +4692,10 @@ class AppLocalizationsPl extends AppLocalizations {
   String get reportDetailsRequired => 'Opisz problem';
 
   @override
+  String get reportDetailsTextOnly =>
+      'Tylko tekst — nie można tu dołączać zdjęć ani plików GIF.';
+
+  @override
   String get reportReasonSpam => 'Spam lub niechciana treść';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -4603,6 +4603,10 @@ class AppLocalizationsPt extends AppLocalizations {
   String get reportDetailsRequired => 'Descreva o problema';
 
   @override
+  String get reportDetailsTextOnly =>
+      'Apenas texto — não é possível anexar fotos ou GIFs aqui.';
+
+  @override
   String get reportReasonSpam => 'Spam ou conteúdo indesejado';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -4711,6 +4711,10 @@ class AppLocalizationsRo extends AppLocalizations {
   String get reportDetailsRequired => 'Descrie problema';
 
   @override
+  String get reportDetailsTextOnly =>
+      'Doar text — fotografiile și GIF-urile nu pot fi atașate aici.';
+
+  @override
   String get reportReasonSpam => 'Spam sau conținut nedorit';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -4571,6 +4571,10 @@ class AppLocalizationsSv extends AppLocalizations {
   String get reportDetailsRequired => 'Beskriv problemet';
 
   @override
+  String get reportDetailsTextOnly =>
+      'Endast text – foton och GIF-bilder kan inte bifogas här.';
+
+  @override
   String get reportReasonSpam => 'Skräppost eller ovälkommet innehåll';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -4516,6 +4516,10 @@ class AppLocalizationsTr extends AppLocalizations {
   String get reportDetailsRequired => 'Lütfen sorunu açıkla';
 
   @override
+  String get reportDetailsTextOnly =>
+      'Yalnızca metin — buraya fotoğraf veya GIF eklenemez.';
+
+  @override
   String get reportReasonSpam => 'Spam veya İstenmeyen İçerik';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -4582,6 +4582,10 @@ class AppLocalizationsUr extends AppLocalizations {
   String get reportDetailsRequired => 'براہ کرم مسئلہ بیان کریں';
 
   @override
+  String get reportDetailsTextOnly =>
+      'صرف متن — یہاں تصاویر یا GIF منسلک نہیں کیے جا سکتے۔';
+
+  @override
   String get reportReasonSpam => 'اسپیم یا ناپسندیدہ مواد';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -4543,6 +4543,10 @@ class AppLocalizationsVi extends AppLocalizations {
   String get reportDetailsRequired => 'Vui lòng mô tả vấn đề';
 
   @override
+  String get reportDetailsTextOnly =>
+      'Chỉ văn bản — không thể đính kèm ảnh hoặc GIF ở đây.';
+
+  @override
   String get reportReasonSpam => 'Spam hoặc nội dung không mong muốn';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -4298,6 +4298,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get reportDetailsRequired => '请描述问题';
 
   @override
+  String get reportDetailsTextOnly => '仅限文字——无法在此附加照片或 GIF。';
+
+  @override
   String get reportReasonSpam => '垃圾或不受欢迎的内容';
 
   @override

--- a/mobile/lib/widgets/report_content_dialog.dart
+++ b/mobile/lib/widgets/report_content_dialog.dart
@@ -764,6 +764,12 @@ class _CappedDetailsFieldState extends State<_CappedDetailsField> {
           keyboardType: TextInputType.multiline,
           textInputAction: TextInputAction.newline,
           textCapitalization: TextCapitalization.sentences,
+          // Android keyboards offer image/GIF insertion this field can't accept
+          // (the OS drops the media). NO_SUGGESTIONS removes that affordance
+          // while keeping the field multiline. iOS keeps its defaults.
+          autocorrect: Theme.of(context).platform != TargetPlatform.android,
+          enableSuggestions:
+              Theme.of(context).platform != TargetPlatform.android,
           onChanged: _onChanged,
           style: VineTheme.bodyLargeFont(color: context.vineColors.primaryText),
           minLines: 3,

--- a/mobile/lib/widgets/report_content_dialog.dart
+++ b/mobile/lib/widgets/report_content_dialog.dart
@@ -761,6 +761,9 @@ class _CappedDetailsFieldState extends State<_CappedDetailsField> {
           controller: widget.controller,
           focusNode: widget.focusNode,
           enableInteractiveSelection: true,
+          keyboardType: TextInputType.multiline,
+          textInputAction: TextInputAction.newline,
+          textCapitalization: TextCapitalization.sentences,
           onChanged: _onChanged,
           style: VineTheme.bodyLargeFont(color: context.vineColors.primaryText),
           minLines: 3,
@@ -774,6 +777,12 @@ class _CappedDetailsFieldState extends State<_CappedDetailsField> {
           decoration: const InputDecoration(
             border: InputBorder.none,
             isCollapsed: true,
+          ),
+        ),
+        Text(
+          context.l10n.reportDetailsTextOnly,
+          style: VineTheme.labelSmallFont(
+            color: context.vineColors.onSurfaceVariant,
           ),
         ),
         if (_truncated)

--- a/mobile/lib/widgets/report_content_dialog.dart
+++ b/mobile/lib/widgets/report_content_dialog.dart
@@ -764,12 +764,6 @@ class _CappedDetailsFieldState extends State<_CappedDetailsField> {
           keyboardType: TextInputType.multiline,
           textInputAction: TextInputAction.newline,
           textCapitalization: TextCapitalization.sentences,
-          // Android keyboards offer image/GIF insertion this field can't accept
-          // (the OS drops the media). NO_SUGGESTIONS removes that affordance
-          // while keeping the field multiline. iOS keeps its defaults.
-          autocorrect: Theme.of(context).platform != TargetPlatform.android,
-          enableSuggestions:
-              Theme.of(context).platform != TargetPlatform.android,
           onChanged: _onChanged,
           style: VineTheme.bodyLargeFont(color: context.vineColors.primaryText),
           minLines: 3,

--- a/mobile/lib/widgets/report_content_dialog.dart
+++ b/mobile/lib/widgets/report_content_dialog.dart
@@ -540,6 +540,12 @@ class _ReportFormBody extends StatelessWidget {
                       color: context.vineColors.accentPositive,
                     ),
                   ),
+                  Text(
+                    l10n.reportDetailsTextOnly,
+                    style: VineTheme.labelSmallFont(
+                      color: context.vineColors.onSurfaceVariant,
+                    ),
+                  ),
                   _CappedDetailsField(
                     fieldKey: detailsFieldKey,
                     controller: detailsController,
@@ -777,12 +783,6 @@ class _CappedDetailsFieldState extends State<_CappedDetailsField> {
           decoration: const InputDecoration(
             border: InputBorder.none,
             isCollapsed: true,
-          ),
-        ),
-        Text(
-          context.l10n.reportDetailsTextOnly,
-          style: VineTheme.labelSmallFont(
-            color: context.vineColors.onSurfaceVariant,
           ),
         ),
         if (_truncated)

--- a/mobile/test/widgets/report_content_dialog_test.dart
+++ b/mobile/test/widgets/report_content_dialog_test.dart
@@ -7,7 +7,6 @@ import 'dart:ui' show Tristate;
 import 'package:content_blocklist_repository/content_blocklist_repository.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:dm_repository/dm_repository.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -196,50 +195,6 @@ void main() {
       expect(detailsField.textInputAction, TextInputAction.newline);
       expect(detailsField.textCapitalization, TextCapitalization.sentences);
     });
-
-    testWidgets(
-      'on Android the details field disables suggestions and autocorrect so '
-      'the keyboard cannot offer image/GIF insertion the report would drop',
-      (tester) async {
-        debugDefaultTargetPlatformOverride = TargetPlatform.android;
-        try {
-          await setLargeSurface(tester);
-          await tester.pumpWidget(buildSubject());
-          await tester.pumpAndSettle();
-
-          await tester.tap(find.text(l10n.reportReasonOther));
-          await tester.pumpAndSettle();
-
-          final field = tester.widget<TextField>(find.byType(TextField));
-          expect(field.enableSuggestions, isFalse);
-          expect(field.autocorrect, isFalse);
-        } finally {
-          debugDefaultTargetPlatformOverride = null;
-        }
-      },
-    );
-
-    testWidgets(
-      'on iOS the details field keeps suggestions and autocorrect '
-      '(the Android-only suppression must not disrupt iOS)',
-      (tester) async {
-        debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
-        try {
-          await setLargeSurface(tester);
-          await tester.pumpWidget(buildSubject());
-          await tester.pumpAndSettle();
-
-          await tester.tap(find.text(l10n.reportReasonOther));
-          await tester.pumpAndSettle();
-
-          final field = tester.widget<TextField>(find.byType(TextField));
-          expect(field.enableSuggestions, isTrue);
-          expect(field.autocorrect, isTrue);
-        } finally {
-          debugDefaultTargetPlatformOverride = null;
-        }
-      },
-    );
 
     testWidgets(
       'Submit button is visible before selecting a reason (Apple requirement) '

--- a/mobile/test/widgets/report_content_dialog_test.dart
+++ b/mobile/test/widgets/report_content_dialog_test.dart
@@ -182,11 +182,18 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.byType(TextField), findsNothing);
+      expect(find.text(l10n.reportDetailsTextOnly), findsNothing);
 
       await tester.tap(find.text(l10n.reportReasonOther));
       await tester.pumpAndSettle();
 
       expect(find.byType(TextField), findsOneWidget);
+      expect(find.text(l10n.reportDetailsTextOnly), findsOneWidget);
+
+      final detailsField = tester.widget<TextField>(find.byType(TextField));
+      expect(detailsField.keyboardType, TextInputType.multiline);
+      expect(detailsField.textInputAction, TextInputAction.newline);
+      expect(detailsField.textCapitalization, TextCapitalization.sentences);
     });
 
     testWidgets(

--- a/mobile/test/widgets/report_content_dialog_test.dart
+++ b/mobile/test/widgets/report_content_dialog_test.dart
@@ -7,6 +7,7 @@ import 'dart:ui' show Tristate;
 import 'package:content_blocklist_repository/content_blocklist_repository.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:dm_repository/dm_repository.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -195,6 +196,50 @@ void main() {
       expect(detailsField.textInputAction, TextInputAction.newline);
       expect(detailsField.textCapitalization, TextCapitalization.sentences);
     });
+
+    testWidgets(
+      'on Android the details field disables suggestions and autocorrect so '
+      'the keyboard cannot offer image/GIF insertion the report would drop',
+      (tester) async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.android;
+        try {
+          await setLargeSurface(tester);
+          await tester.pumpWidget(buildSubject());
+          await tester.pumpAndSettle();
+
+          await tester.tap(find.text(l10n.reportReasonOther));
+          await tester.pumpAndSettle();
+
+          final field = tester.widget<TextField>(find.byType(TextField));
+          expect(field.enableSuggestions, isFalse);
+          expect(field.autocorrect, isFalse);
+        } finally {
+          debugDefaultTargetPlatformOverride = null;
+        }
+      },
+    );
+
+    testWidgets(
+      'on iOS the details field keeps suggestions and autocorrect '
+      '(the Android-only suppression must not disrupt iOS)',
+      (tester) async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+        try {
+          await setLargeSurface(tester);
+          await tester.pumpWidget(buildSubject());
+          await tester.pumpAndSettle();
+
+          await tester.tap(find.text(l10n.reportReasonOther));
+          await tester.pumpAndSettle();
+
+          final field = tester.widget<TextField>(find.byType(TextField));
+          expect(field.enableSuggestions, isTrue);
+          expect(field.autocorrect, isTrue);
+        } finally {
+          debugDefaultTargetPlatformOverride = null;
+        }
+      },
+    );
 
     testWidgets(
       'Submit button is visible before selecting a reason (Apple requirement) '

--- a/mobile/test/widgets/report_content_dialog_test.dart
+++ b/mobile/test/widgets/report_content_dialog_test.dart
@@ -189,6 +189,11 @@ void main() {
 
       expect(find.byType(TextField), findsOneWidget);
       expect(find.text(l10n.reportDetailsTextOnly), findsOneWidget);
+      expect(
+        tester.getTopLeft(find.text(l10n.reportDetailsTextOnly)).dy,
+        lessThan(tester.getTopLeft(find.byType(TextField)).dy),
+        reason: 'The text-only disclosure must be read before the field',
+      );
 
       final detailsField = tester.widget<TextField>(find.byType(TextField));
       expect(detailsField.keyboardType, TextInputType.multiline);


### PR DESCRIPTION
People reporting content can try to insert a photo or GIF from their Android keyboard and assume it accompanied the report, even though content reports accept text only. Moderators can then receive text such as “see attached” with no evidence behind it.

Flutter already tells Android that this field accepts no media, but keyboards can still show their own media affordances. Flutter and Android do not expose a supported API for hiding a keyboard-owned GIF button. This change therefore tells reporters up front—before the required details field—that photos and GIFs cannot be attached.

The notice is localized across every supported locale. The prose field now explicitly requests sentence capitalization while preserving Flutter's existing multiline and newline behavior.

This deliberately does not add image attachments to content reports or manipulate keyboard suggestions/autocorrection to hide a Gboard-specific entry point. Real moderation-evidence attachments remain tracked separately in #8222.

Verification:

- `flutter test test/widgets/report_content_dialog_test.dart`
- `flutter test test/l10n/arb_consistency_test.dart`
- `flutter analyze`
- orphaned ARB key, raw TextStyle, and raw color ratchets
- Maestro copy-drift guard
- pre-push checks

Refs #8210
