### PR TITLE
fix(dm): keep the deletion rumor when a send policy blocks it

### DIFF
--- a/mobile/packages/db_client/lib/src/database/app_database.g.dart
+++ b/mobile/packages/db_client/lib/src/database/app_database.g.dart
@@ -9775,8 +9775,8 @@ class DirectMessageRow extends DataClass
   /// collision-prone `(sender, content, created_at ±5s)` tuple.
   final String? sendBatchId;
 
-  /// Serialized kind-5 rumor for an own delete-for-everyone still awaiting
-  /// confirmed delivery. Null for every other row.
+  /// Serialized kind-5 rumor for an own delete-for-everyone that is awaiting
+  /// confirmed delivery or was blocked. Null for every other row.
   ///
   /// Stored rather than rebuilt so each retry replays a byte-identical rumor
   /// id and the recipient's dedup treats repeats as idempotent. Mirrors

--- a/mobile/packages/db_client/lib/src/database/app_database.g.dart
+++ b/mobile/packages/db_client/lib/src/database/app_database.g.dart
@@ -9778,8 +9778,11 @@ class DirectMessageRow extends DataClass
   /// Serialized kind-5 rumor for an own delete-for-everyone that is awaiting
   /// confirmed delivery or was blocked. Null for every other row.
   ///
-  /// Stored rather than rebuilt so each retry replays a byte-identical rumor
-  /// id and the recipient's dedup treats repeats as idempotent. Mirrors
+  /// Stored rather than rebuilt so every retry replays a byte-identical rumor
+  /// id, keeping one retraction one kind-5 however many attempts it takes.
+  /// Receive-side dedup does not collapse the repeats — it is keyed on
+  /// gift-wrap id and NIP-59 gives every wrap a fresh ephemeral key — so what
+  /// makes them harmless is that re-applying a deletion is a no-op. Mirrors
   /// `DmReactions.rumorEventJson`, which serves the same purpose for a
   /// reaction removal.
   final String? deletionRumorJson;

--- a/mobile/packages/db_client/lib/src/database/app_database.g.dart
+++ b/mobile/packages/db_client/lib/src/database/app_database.g.dart
@@ -9787,8 +9787,8 @@ class DirectMessageRow extends DataClass
   /// Delivery state of the kind-5 in [deletionRumorJson]; null when the row
   /// carries no own deletion. Values: `deletion_pending` (soft-deleted
   /// locally, wrap awaiting a confirmed relay `OK`), `deletion_sent`
-  /// (confirmed, terminal), `deletion_blocked` (send policy refused the
-  /// recipient, terminal).
+  /// (confirmed, terminal), `deletion_blocked` (send policy blocked every
+  /// failed recipient, terminal; other recipients may have succeeded).
   ///
   /// `deletion_blocked` is deliberately distinct from `deletion_sent`, unlike
   /// the reaction path which collapses the two. A blocked *reaction* removal

--- a/mobile/packages/db_client/lib/src/database/daos/direct_messages_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/direct_messages_dao.dart
@@ -39,10 +39,12 @@ class DirectMessagesDao extends DatabaseAccessor<AppDatabase>
   /// Soft-deleted locally; the kind-5 wrap still needs a confirmed delivery.
   static const String _deletionPending = 'deletion_pending';
 
-  /// A relay confirmed the wrap. Terminal.
+  /// A relay confirmed the wrap for every recipient. Terminal.
   static const String _deletionSent = 'deletion_sent';
 
-  /// Send policy refused every recipient. Terminal, but NOT delivered.
+  /// Send policy blocked every recipient that failed. Terminal, and NOT a
+  /// claim of full delivery — recipients outside the block may already have
+  /// received the retraction.
   static const String _deletionBlocked = 'deletion_blocked';
 
   /// Build a filter expression that returns rows owned by [ownerPubkey]

--- a/mobile/packages/db_client/lib/src/database/daos/direct_messages_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/direct_messages_dao.dart
@@ -241,9 +241,9 @@ class DirectMessagesDao extends DatabaseAccessor<AppDatabase>
         ownerPubkey: ownerPubkey,
       );
 
-  /// Send policy refused every recipient: stop re-driving a send that will
-  /// always be refused, but record it as `'deletion_blocked'` rather than
-  /// `'deletion_sent'`.
+  /// Send policy blocked every failed recipient: stop re-driving a send that
+  /// will always be refused, but record it as `'deletion_blocked'` rather than
+  /// `'deletion_sent'`. Other recipients may already have succeeded.
   ///
   /// The reaction path collapses these two, reasoning that a blocked peer
   /// never received the reaction either so the removal is moot. That does not

--- a/mobile/packages/db_client/lib/src/database/daos/direct_messages_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/direct_messages_dao.dart
@@ -236,8 +236,7 @@ class DirectMessagesDao extends DatabaseAccessor<AppDatabase>
       _settleMessageDeletion(
         rumorId,
         status: _deletionSent,
-        // Delivered, so there is nothing left to replay. Dropping the payload
-        // also stops a retraction sitting in the clear on disk forever.
+        // Delivered, so there is nothing left to replay.
         retainRumor: false,
         ownerPubkey: ownerPubkey,
       );
@@ -251,11 +250,18 @@ class DirectMessagesDao extends DatabaseAccessor<AppDatabase>
   /// transfer to a message, which may well have been delivered before the
   /// block took effect — calling it sent would misreport a message the peer
   /// still holds.
-  /// The rumor is **kept**. A block is the one terminal state that can be
-  /// lifted from outside the app — a moderation account un-retires, a minor's
-  /// restriction is approved, the server-side signer stops refusing — and the
-  /// stored rumor is the only payload a later replay could use. Dropping it
-  /// makes the row permanently unrepairable, including in the mixed case
+  ///
+  /// The rumor is **kept**. A block is the one terminal state that can lift
+  /// while the build is running — the minor restriction reads live remote
+  /// state, and a server-side signer refusal clears on re-authorization. (The
+  /// retired-moderation-account case cannot: that list is a compile-time
+  /// `const`, so lifting it needs a new build.)
+  ///
+  /// The stored rumor is also the idempotency token, not merely a payload. A
+  /// replay of the stored JSON carries a byte-identical rumor id that the
+  /// recipient dedups; a rebuilt one carries a fresh id, and so lands as a
+  /// second, distinct retraction. Dropping it therefore leaves the row
+  /// unrepairable rather than merely un-retried — including in the mixed case
   /// where some recipients already received the retraction (#8226).
   ///
   /// Retention is inert for the sweep: [getRetryableOwnMessageDeletions]

--- a/mobile/packages/db_client/lib/src/database/daos/direct_messages_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/direct_messages_dao.dart
@@ -236,6 +236,9 @@ class DirectMessagesDao extends DatabaseAccessor<AppDatabase>
       _settleMessageDeletion(
         rumorId,
         status: _deletionSent,
+        // Delivered, so there is nothing left to replay. Dropping the payload
+        // also stops a retraction sitting in the clear on disk forever.
+        retainRumor: false,
         ownerPubkey: ownerPubkey,
       );
 
@@ -248,18 +251,35 @@ class DirectMessagesDao extends DatabaseAccessor<AppDatabase>
   /// transfer to a message, which may well have been delivered before the
   /// block took effect — calling it sent would misreport a message the peer
   /// still holds.
+  /// The rumor is **kept**. A block is the one terminal state that can be
+  /// lifted from outside the app — a moderation account un-retires, a minor's
+  /// restriction is approved, the server-side signer stops refusing — and the
+  /// stored rumor is the only payload a later replay could use. Dropping it
+  /// makes the row permanently unrepairable, including in the mixed case
+  /// where some recipients already received the retraction (#8226).
+  ///
+  /// Retention is inert for the sweep: [getRetryableOwnMessageDeletions]
+  /// additionally requires `deletion_pending`, so a blocked row stays off the
+  /// worklist whether or not the rumor is present.
   Future<bool> markMessageDeletionBlocked(
     String rumorId, {
     String? ownerPubkey,
   }) => _settleMessageDeletion(
     rumorId,
     status: _deletionBlocked,
+    retainRumor: true,
     ownerPubkey: ownerPubkey,
   );
 
+  /// Move a deletion row to a terminal [status].
+  ///
+  /// [retainRumor] is required rather than defaulted: whether the payload
+  /// survives is the whole difference between the two terminal states, so a
+  /// future third caller has to decide it deliberately.
   Future<bool> _settleMessageDeletion(
     String rumorId, {
     required String status,
+    required bool retainRumor,
     String? ownerPubkey,
   }) async {
     final rows =
@@ -270,7 +290,9 @@ class DirectMessagesDao extends DatabaseAccessor<AppDatabase>
             ))
             .write(
               DirectMessagesCompanion(
-                deletionRumorJson: const Value(null),
+                deletionRumorJson: retainRumor
+                    ? const Value.absent()
+                    : const Value(null),
                 deletionPublishStatus: Value(status),
               ),
             );

--- a/mobile/packages/db_client/lib/src/database/daos/direct_messages_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/direct_messages_dao.dart
@@ -251,18 +251,22 @@ class DirectMessagesDao extends DatabaseAccessor<AppDatabase>
   /// block took effect — calling it sent would misreport a message the peer
   /// still holds.
   ///
-  /// The rumor is **kept**. A block is the one terminal state that can lift
-  /// while the build is running — the minor restriction reads live remote
-  /// state, and a server-side signer refusal clears on re-authorization. (The
-  /// retired-moderation-account case cannot: that list is a compile-time
-  /// `const`, so lifting it needs a new build.)
+  /// The rumor is **kept**. A block can lift while the build is running: the
+  /// minor restriction reads live remote state, and Keycast's server-side
+  /// `verified_minor` gate — the other blocked source — clears from that same
+  /// state. (The retired-moderation-account case cannot: that list is a
+  /// compile-time `const`, so lifting it needs a new build.)
   ///
-  /// The stored rumor is also the idempotency token, not merely a payload. A
-  /// replay of the stored JSON carries a byte-identical rumor id that the
-  /// recipient dedups; a rebuilt one carries a fresh id, and so lands as a
-  /// second, distinct retraction. Dropping it therefore leaves the row
-  /// unrepairable rather than merely un-retried — including in the mixed case
-  /// where some recipients already received the retraction (#8226).
+  /// The stored rumor is also the retraction's event identity, not merely a
+  /// payload. Replaying the stored JSON keeps every attempt one kind-5;
+  /// rebuilding would mint a fresh id per attempt and put N distinct
+  /// retractions on the wire for one user action. Nothing on the receive side
+  /// collapses them — dedup is keyed on gift-wrap id, and NIP-59 gives every
+  /// wrap a fresh ephemeral key and `created_at`, so a replay is always a new
+  /// wrap; what makes it safe is that re-applying a deletion is a no-op.
+  /// Dropping the rumor therefore leaves the row unrepairable rather than
+  /// merely un-retried — including in the mixed case where some recipients
+  /// already received the retraction (#8226).
   ///
   /// Retention is inert for the sweep: [getRetryableOwnMessageDeletions]
   /// additionally requires `deletion_pending`, so a blocked row stays off the

--- a/mobile/packages/db_client/lib/src/database/tables.dart
+++ b/mobile/packages/db_client/lib/src/database/tables.dart
@@ -824,8 +824,8 @@ class DirectMessages extends Table {
   /// collision-prone `(sender, content, created_at ±5s)` tuple.
   TextColumn get sendBatchId => text().nullable().named('send_batch_id')();
 
-  /// Serialized kind-5 rumor for an own delete-for-everyone still awaiting
-  /// confirmed delivery. Null for every other row.
+  /// Serialized kind-5 rumor for an own delete-for-everyone that is awaiting
+  /// confirmed delivery or was blocked. Null for every other row.
   ///
   /// Stored rather than rebuilt so each retry replays a byte-identical rumor
   /// id and the recipient's dedup treats repeats as idempotent. Mirrors

--- a/mobile/packages/db_client/lib/src/database/tables.dart
+++ b/mobile/packages/db_client/lib/src/database/tables.dart
@@ -827,8 +827,11 @@ class DirectMessages extends Table {
   /// Serialized kind-5 rumor for an own delete-for-everyone that is awaiting
   /// confirmed delivery or was blocked. Null for every other row.
   ///
-  /// Stored rather than rebuilt so each retry replays a byte-identical rumor
-  /// id and the recipient's dedup treats repeats as idempotent. Mirrors
+  /// Stored rather than rebuilt so every retry replays a byte-identical rumor
+  /// id, keeping one retraction one kind-5 however many attempts it takes.
+  /// Receive-side dedup does not collapse the repeats — it is keyed on
+  /// gift-wrap id and NIP-59 gives every wrap a fresh ephemeral key — so what
+  /// makes them harmless is that re-applying a deletion is a no-op. Mirrors
   /// `DmReactions.rumorEventJson`, which serves the same purpose for a
   /// reaction removal.
   TextColumn get deletionRumorJson =>

--- a/mobile/packages/db_client/lib/src/database/tables.dart
+++ b/mobile/packages/db_client/lib/src/database/tables.dart
@@ -837,8 +837,8 @@ class DirectMessages extends Table {
   /// Delivery state of the kind-5 in [deletionRumorJson]; null when the row
   /// carries no own deletion. Values: `deletion_pending` (soft-deleted
   /// locally, wrap awaiting a confirmed relay `OK`), `deletion_sent`
-  /// (confirmed, terminal), `deletion_blocked` (send policy refused the
-  /// recipient, terminal).
+  /// (confirmed, terminal), `deletion_blocked` (send policy blocked every
+  /// failed recipient, terminal; other recipients may have succeeded).
   ///
   /// `deletion_blocked` is deliberately distinct from `deletion_sent`, unlike
   /// the reaction path which collapses the two. A blocked *reaction* removal

--- a/mobile/packages/db_client/test/src/database/daos/direct_messages_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/direct_messages_dao_test.dart
@@ -676,8 +676,7 @@ void main() {
             ownerPubkey: 'pubkey_alice',
           );
           expect(row!.deletionPublishStatus, equals('deletion_sent'));
-          // Delivered: nothing left to replay, and the retraction should not
-          // sit in the clear on disk. Unlike the blocked path (#8226).
+          // Delivered: nothing left to replay. Unlike the blocked path (#8226).
           expect(row.deletionRumorJson, isNull);
           expect(row.isDeleted, isTrue);
         });

--- a/mobile/packages/db_client/test/src/database/daos/direct_messages_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/direct_messages_dao_test.dart
@@ -676,6 +676,8 @@ void main() {
             ownerPubkey: 'pubkey_alice',
           );
           expect(row!.deletionPublishStatus, equals('deletion_sent'));
+          // Delivered: nothing left to replay, and the retraction should not
+          // sit in the clear on disk. Unlike the blocked path (#8226).
           expect(row.deletionRumorJson, isNull);
           expect(row.isDeleted, isTrue);
         });
@@ -701,7 +703,59 @@ void main() {
             ownerPubkey: 'pubkey_alice',
           );
           expect(row!.deletionPublishStatus, equals('deletion_blocked'));
-          expect(row.deletionRumorJson, isNull);
+        });
+
+        test(
+          'retains the rumor so a lifted block can still replay it',
+          () async {
+            // #8226: a block is the one terminal state an outside change can
+            // lift, and this payload is the only thing a replay could send.
+            const rumor = '{"kind":5,"tags":[["e","msg_del"],["k","14"]]}';
+            await insertOwnMessage();
+            await dao.markMessageDeletionPending(
+              'msg_del',
+              deletionRumorJson: rumor,
+              ownerPubkey: 'pubkey_alice',
+            );
+
+            await dao.markMessageDeletionBlocked(
+              'msg_del',
+              ownerPubkey: 'pubkey_alice',
+            );
+
+            final row = await dao.getMessageById(
+              'msg_del',
+              ownerPubkey: 'pubkey_alice',
+            );
+            expect(row!.deletionRumorJson, equals(rumor));
+          },
+        );
+
+        test('the retained rumor stays off the retry worklist', () async {
+          // Retention must not resurrect the send: the sweep additionally
+          // requires deletion_pending, so a blocked row is excluded on
+          // status alone.
+          await insertOwnMessage();
+          await dao.markMessageDeletionPending(
+            'msg_del',
+            deletionRumorJson: '{"kind":5}',
+            ownerPubkey: 'pubkey_alice',
+          );
+          await dao.markMessageDeletionBlocked(
+            'msg_del',
+            ownerPubkey: 'pubkey_alice',
+          );
+
+          final pending = await dao.getRetryableOwnMessageDeletions(
+            ownerPubkey: 'pubkey_alice',
+          );
+
+          expect(pending, isEmpty);
+          final row = await dao.getMessageById(
+            'msg_del',
+            ownerPubkey: 'pubkey_alice',
+          );
+          expect(row!.deletionRumorJson, isNotNull);
         });
       });
     });

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -247,8 +247,9 @@ enum DmMessageDeletionOutcome {
   /// A relay confirmed the wrap. The row is settled; stop re-driving.
   sent,
 
-  /// Send policy refused every recipient. Terminal, but NOT delivered —
-  /// the row records `deletion_blocked` rather than claiming a delivery.
+  /// Send policy blocked every failed recipient. Terminal, but not fully
+  /// delivered — some recipients may already have received the retraction.
+  /// The row records `deletion_blocked` rather than claiming full delivery.
   blocked,
 
   /// Nothing confirmed. The row stays pending for the next sweep.

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -5635,10 +5635,14 @@ class DmRepository {
 
   /// Re-drive a delete-for-everyone that no relay confirmed.
   ///
-  /// Replays the **stored** rumor rather than rebuilding one, so every
-  /// attempt carries a byte-identical rumor id and a recipient that already
-  /// received an earlier attempt dedups it. Rebuilding would mint a fresh id
-  /// on each pass and deliver the same retraction over and over.
+  /// Replays the **stored** rumor rather than rebuilding one, so every attempt
+  /// carries a byte-identical rumor id and the retraction stays a single
+  /// kind-5 no matter how many attempts it takes. Rebuilding would mint a
+  /// fresh id per pass, putting N distinct retractions on the wire for one
+  /// user action. No receive-side dedup collapses them either way — that is
+  /// keyed on gift-wrap id, and NIP-59 gives every wrap a fresh ephemeral key
+  /// and `created_at` — so what makes a replay safe is that re-applying a
+  /// deletion is a no-op.
   Future<DmMessageDeletionOutcome> retryMessageDeletion({
     required String rumorId,
   }) async {


### PR DESCRIPTION
`markMessageDeletionSent` and `markMessageDeletionBlocked` shared one settle helper that nulled `deletionRumorJson` for both. Nulling is right once a relay confirms delivery because nothing is left to replay. On the blocked path it destroyed the only payload a later replay could use.

Closes #8226. Introduced by #8184 (`4fcd18016`), which has not shipped — so no released build has produced one of these rows.

## Verified before fixing

Reproduced on a real Drift database with a real `DmRepository` and a `NIP17MessageService` whose policy refuses every recipient:

```
after blocked drive: status=deletion_blocked rumorJson=null isDeleted=true
after re-tap:        status=deletion_blocked rumorJson=null
```

The row is unrepairable three ways: `retryableMessageDeletions()` is empty, `retryMessageDeletion()` returns `unavailable`, and re-tapping Delete hits the already-deleted guard and returns silently. Nothing writes `isDeleted` back to `false` on the message table, so the no-op is permanent.

## Two things the issue understates

**The destruction is not limited to a wholly-refused send.** `_fanOutDeletion` classifies on `failures.every((f) => f.blocked)`, so a group where one recipient is refused and the others succeed is also recorded blocked. Confirmed against the local relay — Carol genuinely received the retraction over the wire, and the payload was discarded anyway:

```
mixed fan-out: status=deletion_blocked rumorJson=null
```

**There is a third cause of `deletion_blocked`.** Besides the two `dmSendPolicyProvider` cases, `sendRumor` also returns `blocked` when the server-side signer refuses (`nip17_message_service.dart:812-821`, matching `'Operation denied by policy'`). That path is server-driven and sits inside `sendRumor`, so it reaches the deletion fan-out too. It is **latent rather than live** today: all three app authorization sites pass `policy:full`, only the `keycast_flutter` library default is `policy:social`, and the refresh grant sends no `scope`, so a session cannot drift down into it.

Both are covered by the same behavioural change — one ternary in the settle helper.

## Scope

Retention is inert for the sweep, which requires `deletion_pending` as well as a non-null rumor — so a blocked row stays off the worklist either way, and the only production caller of `retryMessageDeletion` reads that filtered worklist. No status value, sweep filter, or guard changes here. This makes the row repairable; it does not repair it. Surfacing the outcome and offering recovery belong to #8201 / #8206.

`retainRumor` is required rather than defaulted because whether the payload survives is the whole difference between the two terminal states.

## Verification

- `db_client` 1010 tests, `dm_repository` 689, app-layer DM + retry service 446 — all green.
- Package-scoped `flutter analyze` clean in `db_client` (the app-scoped form does not apply the package lint set).
- Ratchets pass: ungrouped-tests, pubkey-log-encoding, nostr-id-truncation, untested-services.
- No schema change; codegen only propagated corrected table documentation.
- **Mutation-tested**: restoring the destructive write turns exactly the two new tests red, and nothing else.

