### PR TITLE
fix(followers): stop unreachable indexers from leaving profile stats blank

### DIFF
--- a/mobile/packages/follow_repository/lib/src/follow_repository.dart
+++ b/mobile/packages/follow_repository/lib/src/follow_repository.dart
@@ -25,6 +25,12 @@ import 'package:unified_logger/unified_logger.dart';
 /// API does not expose event timestamps.
 typedef _FollowerRef = ({String pubkey, int? followedAt});
 
+typedef _FollowerSourceResult = ({
+  List<_FollowerRef> refs,
+  Object? error,
+  StackTrace? stackTrace,
+});
+
 typedef _CachedFollowerStats = ({
   FollowerStats stats,
   DateTime cachedAt,
@@ -1282,7 +1288,9 @@ class FollowRepository {
   ///
   /// Ordering comes from [_newestFirst].
   ///
-  /// Returns empty list on timeout or failure.
+  /// Returns an empty list when every successful source reports no followers.
+  /// Propagates a source error when no source returns a usable follower, since
+  /// callers cannot distinguish that result from a genuinely empty list.
   Future<List<String>> _fetchFollowers(String pubkey) async =>
       (await _fetchOrderedFollowers(pubkey)).pubkeys;
 
@@ -1299,18 +1307,12 @@ class FollowRepository {
 
     // One unavailable source must not discard usable observations from the
     // others, but total failure is not evidence that the user has no followers.
-    final results = await Future.wait(
-      _followerSources(pubkey).map(
-        (source) => source.then<(List<_FollowerRef>, Object?, StackTrace?)>(
-          (refs) => (refs, null, null),
-          onError: (Object error, StackTrace stackTrace) =>
-              (const <_FollowerRef>[], error, stackTrace),
-        ),
-      ),
+    final results = await Future.wait<_FollowerSourceResult>(
+      _followerSources(pubkey).map(_guardFollowerSource),
     );
-    final apiFollowers = results[0].$1;
-    final relayFollowers = results[1].$1;
-    final indexerFollowers = results[2].$1;
+    final apiFollowers = results[0].refs;
+    final relayFollowers = results[1].refs;
+    final indexerFollowers = results[2].refs;
 
     // Merge all sources (union of pubkeys)
     final merged = _newestFirst([
@@ -1319,12 +1321,15 @@ class FollowRepository {
       ...indexerFollowers,
     ]);
 
-    if (merged.pubkeys.isEmpty) {
-      for (final (_, error, stackTrace) in results.reversed) {
-        if (error != null) {
-          Error.throwWithStackTrace(error, stackTrace ?? StackTrace.empty);
-        }
-      }
+    _FollowerSourceResult? failed;
+    for (final result in results) {
+      if (result.error != null) failed = result;
+    }
+    if (merged.pubkeys.isEmpty && failed != null) {
+      Error.throwWithStackTrace(
+        failed.error!,
+        failed.stackTrace ?? StackTrace.empty,
+      );
     }
 
     // Unique per source, not raw events: the relay and indexer paths hand
@@ -1453,6 +1458,17 @@ class FollowRepository {
     ];
   }
 
+  Future<_FollowerSourceResult> _guardFollowerSource(
+    Future<List<_FollowerRef>> source,
+  ) => source.then<_FollowerSourceResult>(
+    (refs) => (refs: refs, error: null, stackTrace: null),
+    onError: (Object error, StackTrace stackTrace) => (
+      refs: const <_FollowerRef>[],
+      error: error,
+      stackTrace: stackTrace,
+    ),
+  );
+
   /// Streams the current user's followers as each source resolves.
   ///
   /// Every emission is the union of all sources that have answered so far, so
@@ -1486,18 +1502,12 @@ class FollowRepository {
     Object? lastError;
     StackTrace? lastStackTrace;
 
-    final guarded = _followerSources(pubkey).map(
-      (source) => source.then<(List<_FollowerRef>, Object?, StackTrace?)>(
-        (refs) => (refs, null, null),
-        onError: (Object error, StackTrace stackTrace) =>
-            (const <_FollowerRef>[], error, stackTrace),
-      ),
-    );
+    final guarded = _followerSources(pubkey).map(_guardFollowerSource);
 
-    await for (final (refs, error, stackTrace)
-        in Stream<(List<_FollowerRef>, Object?, StackTrace?)>.fromFutures(
-          guarded,
-        )) {
+    await for (final result in Stream<_FollowerSourceResult>.fromFutures(
+      guarded,
+    )) {
+      final (:refs, :error, :stackTrace) = result;
       if (error != null) {
         lastError = error;
         lastStackTrace = stackTrace;

--- a/mobile/packages/follow_repository/lib/src/follow_repository.dart
+++ b/mobile/packages/follow_repository/lib/src/follow_repository.dart
@@ -66,6 +66,7 @@ class FollowRepository {
     BlockedPubkeysCallback? blockedPubkeys,
     DateTime Function()? now,
     Duration indexerQueryTimeout = const Duration(seconds: 8),
+    Duration indexerOperationTimeout = const Duration(seconds: 12),
   }) : _nostrClient = nostrClient,
        _blockedPubkeys = blockedPubkeys,
        _isCacheInitialized = isCacheInitialized,
@@ -79,7 +80,8 @@ class FollowRepository {
        _queryContactList = queryContactList ?? _defaultQueryContactList,
        _relayFactory = relayFactory ?? _defaultRelayFactory,
        _now = now ?? DateTime.now,
-       _indexerQueryTimeout = indexerQueryTimeout;
+       _indexerQueryTimeout = indexerQueryTimeout,
+       _indexerOperationTimeout = indexerOperationTimeout;
 
   final NostrClient _nostrClient;
   final IsCacheInitializedCallback? _isCacheInitialized;
@@ -116,6 +118,49 @@ class FollowRepository {
 
   /// Maximum time to wait for an indexer relay to finish a count query.
   final Duration _indexerQueryTimeout;
+
+  /// Maximum time for connect, response collection, and cleanup combined.
+  final Duration _indexerOperationTimeout;
+
+  Duration _remainingIndexerTime(
+    DateTime deadline, {
+    Duration? cap,
+  }) {
+    final remaining = deadline.difference(DateTime.now());
+    if (remaining <= Duration.zero) return Duration.zero;
+    if (cap != null && cap < remaining) return cap;
+    return remaining;
+  }
+
+  Future<T> _awaitIndexerOperation<T>(
+    Future<T> future,
+    DateTime deadline, {
+    required FutureOr<T> Function() onTimeout,
+    Duration? cap,
+  }) => future.timeout(
+    _remainingIndexerTime(deadline, cap: cap),
+    onTimeout: onTimeout,
+  );
+
+  Future<void> _disconnectIndexer(
+    RelayBase relay,
+    String indexerUrl,
+    DateTime deadline,
+  ) async {
+    try {
+      await _awaitIndexerOperation<void>(
+        relay.disconnect(),
+        deadline,
+        onTimeout: () {},
+      );
+    } catch (e) {
+      Log.warning(
+        'Error disconnecting from $indexerUrl: $e',
+        name: 'FollowRepository',
+        category: LogCategory.system,
+      );
+    }
+  }
 
   /// Default relay factory — creates a real [RelayBase].
   static RelayBase _defaultRelayFactory(String url, RelayStatus status) =>
@@ -1137,6 +1182,7 @@ class FollowRepository {
     String indexerUrl,
     String pubkey,
   ) async {
+    final deadline = DateTime.now().add(_indexerOperationTimeout);
     final relayStatus = RelayStatus(indexerUrl);
     final relay = _relayFactory(indexerUrl, relayStatus);
     final completer = Completer<int>();
@@ -1170,17 +1216,27 @@ class FollowRepository {
       };
       relay.pendingMessages.add(<dynamic>['REQ', subscriptionId, filter]);
 
-      final connected = await relay.connect();
+      final connected = await _awaitIndexerOperation<bool>(
+        relay.connect(),
+        deadline,
+        onTimeout: () => false,
+      );
       if (!connected) {
         return null;
       }
 
-      final result = await completer.future.timeout(
-        _indexerQueryTimeout,
+      final result = await _awaitIndexerOperation<int>(
+        completer.future,
+        deadline,
+        cap: _indexerQueryTimeout,
         onTimeout: () => followerPubkeys.length,
       );
 
-      await relay.send(<dynamic>['CLOSE', subscriptionId]);
+      await _awaitIndexerOperation<bool>(
+        relay.send(<dynamic>['CLOSE', subscriptionId]),
+        deadline,
+        onTimeout: () => false,
+      );
       Log.debug(
         'Indexer $indexerUrl returned $result '
         'followers for ${pubkeyForLogs(pubkey)}',
@@ -1206,15 +1262,7 @@ class FollowRepository {
               source: indexerUrl,
             );
     } finally {
-      try {
-        await relay.disconnect();
-      } catch (e) {
-        Log.warning(
-          'Error disconnecting from $indexerUrl: $e',
-          name: 'FollowRepository',
-          category: LogCategory.system,
-        );
-      }
+      await _disconnectIndexer(relay, indexerUrl, deadline);
     }
   }
 
@@ -1247,12 +1295,12 @@ class FollowRepository {
       return (pubkeys: <String>[], datedCount: 0);
     }
 
-    // The API and indexer sources are best-effort here; a connected-relay
-    // failure still fails the whole call, as it always has.
+    // Every source is best-effort. One unavailable relay must not discard
+    // usable follower observations from the others.
     final sources = _followerSources(pubkey);
     final results = await Future.wait<List<_FollowerRef>>([
       sources[0].catchError((_) => <_FollowerRef>[]),
-      sources[1],
+      sources[1].catchError((_) => <_FollowerRef>[]),
       sources[2].catchError((_) => <_FollowerRef>[]),
     ]);
     final apiFollowers = results[0];
@@ -1558,6 +1606,7 @@ class FollowRepository {
     String indexerUrl,
     String pubkey,
   ) async {
+    final deadline = DateTime.now().add(_indexerOperationTimeout);
     final relayStatus = RelayStatus(indexerUrl);
     final relay = _relayFactory(indexerUrl, relayStatus);
     final completer = Completer<List<_FollowerRef>>();
@@ -1594,17 +1643,27 @@ class FollowRepository {
       };
       relay.pendingMessages.add(<dynamic>['REQ', subscriptionId, filter]);
 
-      final connected = await relay.connect();
+      final connected = await _awaitIndexerOperation<bool>(
+        relay.connect(),
+        deadline,
+        onTimeout: () => false,
+      );
       if (!connected) {
         return [];
       }
 
-      final result = await completer.future.timeout(
-        _fetchFollowersTimeout,
+      final result = await _awaitIndexerOperation<List<_FollowerRef>>(
+        completer.future,
+        deadline,
+        cap: _fetchFollowersTimeout,
         onTimeout: () => List<_FollowerRef>.of(followers),
       );
 
-      await relay.send(<dynamic>['CLOSE', subscriptionId]);
+      await _awaitIndexerOperation<bool>(
+        relay.send(<dynamic>['CLOSE', subscriptionId]),
+        deadline,
+        onTimeout: () => false,
+      );
       return result;
     } catch (e) {
       Log.warning(
@@ -1614,9 +1673,7 @@ class FollowRepository {
       );
       return List<_FollowerRef>.of(followers);
     } finally {
-      try {
-        await relay.disconnect();
-      } catch (_) {}
+      await _disconnectIndexer(relay, indexerUrl, deadline);
     }
   }
 
@@ -1632,21 +1689,12 @@ class FollowRepository {
     if (!isFollowing(pubkey)) return false;
 
     // Step 2: Check if they follow us (requires relay query)
-    try {
-      final theirFollowers = await _fetchFollowers(_nostrClient.publicKey);
-      return theirFollowers.contains(pubkey) ||
-          // They follow us means their contact list mentions our pubkey.
-          // _fetchFollowers returns authors of events mentioning us in p-tags,
-          // so we check if the target pubkey is among those authors.
-          await _checkIfTheyFollowUs(pubkey);
-    } catch (e) {
-      Log.warning(
-        'Failed to check mutual follow for ${pubkeyForLogs(pubkey)}: $e',
-        name: 'FollowRepository',
-        category: LogCategory.system,
-      );
-      return false;
-    }
+    final theirFollowers = await _fetchFollowers(_nostrClient.publicKey);
+    return theirFollowers.contains(pubkey) ||
+        // They follow us means their contact list mentions our pubkey.
+        // _fetchFollowers returns authors of events mentioning us in p-tags,
+        // so we check if the target pubkey is among those authors.
+        await _checkIfTheyFollowUs(pubkey);
   }
 
   /// Check if [pubkey] follows the current user by querying their Kind 3 event.
@@ -2374,6 +2422,7 @@ class FollowRepository {
     String indexerUrl,
     String pubkey,
   ) async {
+    final deadline = DateTime.now().add(_indexerOperationTimeout);
     final relayStatus = RelayStatus(indexerUrl);
     final relay = _relayFactory(indexerUrl, relayStatus);
     final completer = Completer<Event?>();
@@ -2415,15 +2464,25 @@ class FollowRepository {
       };
       relay.pendingMessages.add(<dynamic>['REQ', subscriptionId, filter]);
 
-      final connected = await relay.connect();
+      final connected = await _awaitIndexerOperation<bool>(
+        relay.connect(),
+        deadline,
+        onTimeout: () => false,
+      );
       if (!connected) return null;
 
-      final result = await completer.future.timeout(
-        const Duration(seconds: 5),
+      final result = await _awaitIndexerOperation<Event?>(
+        completer.future,
+        deadline,
+        cap: const Duration(seconds: 5),
         onTimeout: () => bestEvent,
       );
 
-      await relay.send(<dynamic>['CLOSE', subscriptionId]);
+      await _awaitIndexerOperation<bool>(
+        relay.send(<dynamic>['CLOSE', subscriptionId]),
+        deadline,
+        onTimeout: () => false,
+      );
       return result;
     } catch (e) {
       Log.warning(
@@ -2434,9 +2493,7 @@ class FollowRepository {
       );
       return bestEvent;
     } finally {
-      try {
-        await relay.disconnect();
-      } catch (_) {}
+      await _disconnectIndexer(relay, indexerUrl, deadline);
     }
   }
 

--- a/mobile/packages/follow_repository/lib/src/follow_repository.dart
+++ b/mobile/packages/follow_repository/lib/src/follow_repository.dart
@@ -492,9 +492,11 @@ class FollowRepository {
   /// Returns a [FollowingSnapshot] with the deduplicated list of followed
   /// pubkeys. Returns an empty snapshot if no event is found.
   Future<FollowingSnapshot> getOthersFollowing(String pubkey) async {
-    final events = await _nostrClient.queryEvents([
-      Filter(authors: [pubkey], kinds: const [3], limit: 1),
-    ]);
+    final events = await _nostrClient
+        .queryEvents([
+          Filter(authors: [pubkey], kinds: const [3], limit: 1),
+        ])
+        .timeout(_fetchFollowersTimeout);
 
     final following = <String>[];
     if (events.isNotEmpty) {
@@ -1295,17 +1297,20 @@ class FollowRepository {
       return (pubkeys: <String>[], datedCount: 0);
     }
 
-    // Every source is best-effort. One unavailable relay must not discard
-    // usable follower observations from the others.
-    final sources = _followerSources(pubkey);
-    final results = await Future.wait<List<_FollowerRef>>([
-      sources[0].catchError((_) => <_FollowerRef>[]),
-      sources[1].catchError((_) => <_FollowerRef>[]),
-      sources[2].catchError((_) => <_FollowerRef>[]),
-    ]);
-    final apiFollowers = results[0];
-    final relayFollowers = results[1];
-    final indexerFollowers = results[2];
+    // One unavailable source must not discard usable observations from the
+    // others, but total failure is not evidence that the user has no followers.
+    final results = await Future.wait(
+      _followerSources(pubkey).map(
+        (source) => source.then<(List<_FollowerRef>, Object?, StackTrace?)>(
+          (refs) => (refs, null, null),
+          onError: (Object error, StackTrace stackTrace) =>
+              (const <_FollowerRef>[], error, stackTrace),
+        ),
+      ),
+    );
+    final apiFollowers = results[0].$1;
+    final relayFollowers = results[1].$1;
+    final indexerFollowers = results[2].$1;
 
     // Merge all sources (union of pubkeys)
     final merged = _newestFirst([
@@ -1313,6 +1318,14 @@ class FollowRepository {
       ...relayFollowers,
       ...indexerFollowers,
     ]);
+
+    if (merged.pubkeys.isEmpty) {
+      for (final (_, error, stackTrace) in results.reversed) {
+        if (error != null) {
+          Error.throwWithStackTrace(error, stackTrace ?? StackTrace.empty);
+        }
+      }
+    }
 
     // Unique per source, not raw events: the relay and indexer paths hand
     // back one ref per kind 3 they saw, so a follower whose superseded event
@@ -1425,7 +1438,7 @@ class FollowRepository {
     final apiFuture = (_funnelcakeApiClient?.isAvailable ?? false)
         ? _funnelcakeApiClient!
               .getFollowers(pubkey: pubkey, limit: 5000)
-              .then(
+              .then<List<_FollowerRef>>(
                 (r) => [
                   for (final follower in r.pubkeys)
                     (pubkey: follower, followedAt: null),
@@ -1689,12 +1702,21 @@ class FollowRepository {
     if (!isFollowing(pubkey)) return false;
 
     // Step 2: Check if they follow us (requires relay query)
-    final theirFollowers = await _fetchFollowers(_nostrClient.publicKey);
-    return theirFollowers.contains(pubkey) ||
-        // They follow us means their contact list mentions our pubkey.
-        // _fetchFollowers returns authors of events mentioning us in p-tags,
-        // so we check if the target pubkey is among those authors.
-        await _checkIfTheyFollowUs(pubkey);
+    try {
+      final theirFollowers = await _fetchFollowers(_nostrClient.publicKey);
+      return theirFollowers.contains(pubkey) ||
+          // They follow us means their contact list mentions our pubkey.
+          // _fetchFollowers returns authors of events mentioning us in p-tags,
+          // so we check if the target pubkey is among those authors.
+          await _checkIfTheyFollowUs(pubkey);
+    } catch (e) {
+      Log.warning(
+        'Failed to check mutual follow for ${pubkeyForLogs(pubkey)}: $e',
+        name: 'FollowRepository',
+        category: LogCategory.system,
+      );
+      return false;
+    }
   }
 
   /// Check if [pubkey] follows the current user by querying their Kind 3 event.

--- a/mobile/packages/follow_repository/test/src/follow_repository_test.dart
+++ b/mobile/packages/follow_repository/test/src/follow_repository_test.dart
@@ -33,6 +33,9 @@ class _FakeRelay extends RelayBase {
     super.url,
     super.relayStatus, {
     this.shouldConnect = true,
+    this.neverConnects = false,
+    this.neverCloses = false,
+    this.neverDisconnects = false,
     this.throwOnSend = false,
     this.throwOnDisconnect = false,
   });
@@ -43,6 +46,15 @@ class _FakeRelay extends RelayBase {
   /// Whether [connect] should succeed.
   final bool shouldConnect;
 
+  /// Whether [connect] should remain pending forever.
+  final bool neverConnects;
+
+  /// Whether a CLOSE request should remain pending forever.
+  final bool neverCloses;
+
+  /// Whether [disconnect] should remain pending forever.
+  final bool neverDisconnects;
+
   /// Whether [send] should throw.
   final bool throwOnSend;
 
@@ -51,6 +63,7 @@ class _FakeRelay extends RelayBase {
 
   @override
   Future<bool> doConnect() async {
+    if (neverConnects) return Completer<bool>().future;
     if (!shouldConnect) return false;
     // Fire fake responses to trigger onMessage handlers
     for (final msg in fakeResponses) {
@@ -70,11 +83,15 @@ class _FakeRelay extends RelayBase {
     if (throwOnSend && message.isNotEmpty && message[0] == 'CLOSE') {
       throw Exception('Send failed');
     }
+    if (neverCloses && message.isNotEmpty && message[0] == 'CLOSE') {
+      return Completer<bool>().future;
+    }
     return true;
   }
 
   @override
   Future<void> disconnect() async {
+    if (neverDisconnects) return Completer<void>().future;
     if (throwOnDisconnect) throw Exception('Disconnect failed');
   }
 }
@@ -5593,18 +5610,75 @@ void main() {
       RelayFactory fakeRelayFactory({
         List<List<dynamic>> responses = const [],
         bool shouldConnect = true,
+        bool neverCloses = false,
+        bool neverDisconnects = false,
       }) {
         return (String url, RelayStatus status) {
           final relay = _FakeRelay(
             url,
             status,
             shouldConnect: shouldConnect,
+            neverCloses: neverCloses,
+            neverDisconnects: neverDisconnects,
           )..fakeResponses = responses;
           return relay;
         };
       }
 
       group('_fetchFollowersCountViaIndexers', () {
+        test('keeps REST count when an indexer never connects', () async {
+          final api = _MockFunnelcakeApiClient();
+          when(() => api.isAvailable).thenReturn(true);
+          when(() => api.getSocialCounts(testTargetPubkey)).thenAnswer(
+            (_) async => const SocialCounts(
+              pubkey: testTargetPubkey,
+              followerCount: 50,
+              followingCount: 7,
+            ),
+          );
+          repository = FollowRepository(
+            nostrClient: mockNostrClient,
+            isCacheInitialized: () => cacheIsInitialized,
+            getCachedEventsByKind: (kind) => getCachedEventsByKind(kind),
+            cacheUserEvent: cachedUserEvents.add,
+            funnelcakeApiClient: api,
+            indexerRelayUrls: const [indexerUrl],
+            indexerOperationTimeout: const Duration(milliseconds: 20),
+            relayFactory: (url, status) =>
+                _FakeRelay(url, status, neverConnects: true),
+          );
+
+          final stats = await repository
+              .getFollowerStats(testTargetPubkey)
+              .timeout(const Duration(milliseconds: 200));
+
+          expect(stats, const FollowerStats(followers: 50, following: 7));
+        });
+
+        test('bounds CLOSE and disconnect after a count response', () async {
+          repository = FollowRepository(
+            nostrClient: mockNostrClient,
+            isCacheInitialized: () => cacheIsInitialized,
+            getCachedEventsByKind: (kind) => getCachedEventsByKind(kind),
+            cacheUserEvent: cachedUserEvents.add,
+            indexerRelayUrls: const [indexerUrl],
+            indexerOperationTimeout: const Duration(milliseconds: 20),
+            relayFactory: fakeRelayFactory(
+              responses: const [
+                ['EOSE', 'sub1'],
+              ],
+              neverCloses: true,
+              neverDisconnects: true,
+            ),
+          );
+
+          final stats = await repository
+              .getFollowerStats(testTargetPubkey)
+              .timeout(const Duration(milliseconds: 200));
+
+          expect(stats.followers, 0);
+        });
+
         test(
           'returns follower count from indexer relay',
           () async {
@@ -5991,6 +6065,71 @@ void main() {
       });
 
       group('_fetchFollowerRefsFromIndexers', () {
+        test('keeps REST followers when an indexer never connects', () async {
+          final api = _MockFunnelcakeApiClient();
+          when(() => api.isAvailable).thenReturn(true);
+          when(
+            () => api.getFollowers(
+              pubkey: testTargetPubkey,
+              limit: any(named: 'limit'),
+            ),
+          ).thenAnswer(
+            (_) async => const PaginatedPubkeys(pubkeys: [followerPubkey1]),
+          );
+          final connectedRelay = Completer<List<Event>>();
+          when(
+            () => mockNostrClient.queryEvents(any()),
+          ).thenAnswer((_) => connectedRelay.future);
+          repository = FollowRepository(
+            nostrClient: mockNostrClient,
+            isCacheInitialized: () => cacheIsInitialized,
+            getCachedEventsByKind: (kind) => getCachedEventsByKind(kind),
+            cacheUserEvent: cachedUserEvents.add,
+            funnelcakeApiClient: api,
+            indexerRelayUrls: const [indexerUrl],
+            indexerOperationTimeout: const Duration(milliseconds: 20),
+            relayFactory: (url, status) =>
+                _FakeRelay(url, status, neverConnects: true),
+          );
+
+          final followersFuture = repository.getFollowers(testTargetPubkey);
+          await Future<void>.delayed(Duration.zero);
+          connectedRelay.completeError(
+            Exception('connected relay unavailable'),
+          );
+          final followers = await followersFuture.timeout(
+            const Duration(milliseconds: 200),
+          );
+
+          expect(followers, [followerPubkey1]);
+        });
+
+        test('bounds CLOSE after follower refs complete', () async {
+          when(() => mockNostrClient.queryEvents(any())).thenAnswer(
+            (_) async => [],
+          );
+          repository = FollowRepository(
+            nostrClient: mockNostrClient,
+            isCacheInitialized: () => cacheIsInitialized,
+            getCachedEventsByKind: (kind) => getCachedEventsByKind(kind),
+            cacheUserEvent: cachedUserEvents.add,
+            indexerRelayUrls: const [indexerUrl],
+            indexerOperationTimeout: const Duration(milliseconds: 20),
+            relayFactory: fakeRelayFactory(
+              responses: const [
+                ['EOSE', 'sub1'],
+              ],
+              neverCloses: true,
+            ),
+          );
+
+          final followers = await repository
+              .getFollowers(testTargetPubkey)
+              .timeout(const Duration(milliseconds: 200));
+
+          expect(followers, isEmpty);
+        });
+
         test(
           'orders indexer followers by their contact-list timestamp',
           () async {
@@ -7033,6 +7172,46 @@ void main() {
       );
 
       test(
+        '_loadContactListFromIndexer is bounded when connect never completes',
+        () async {
+          when(
+            () => mockNostrClient.subscribe(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+              tempRelays: any(named: 'tempRelays'),
+              targetRelays: any(named: 'targetRelays'),
+              relayTypes: any(named: 'relayTypes'),
+              sendAfterAuth: any(named: 'sendAfterAuth'),
+              onEose: any(named: 'onEose'),
+            ),
+          ).thenAnswer((_) => const Stream<Event>.empty());
+
+          repository = FollowRepository(
+            nostrClient: mockNostrClient,
+            isCacheInitialized: () => cacheIsInitialized,
+            getCachedEventsByKind: (kind) => getCachedEventsByKind(kind),
+            cacheUserEvent: cachedUserEvents.add,
+            indexerRelayUrls: const ['wss://idx.test'],
+            indexerOperationTimeout: const Duration(milliseconds: 20),
+            relayFactory: (url, status) =>
+                _FakeRelay(url, status, neverConnects: true),
+            queryContactList:
+                ({
+                  required eventStream,
+                  required pubkey,
+                  fallbackTimeoutSeconds = 10,
+                }) async => null,
+          );
+
+          await repository.initialize().timeout(
+            const Duration(milliseconds: 200),
+          );
+
+          expect(repository.followingCount, 0);
+        },
+      );
+
+      test(
         '_queryIndexerForContactList timeout returns bestEvent',
         () async {
           // Create a relay that sends an EVENT but no EOSE
@@ -7069,9 +7248,10 @@ void main() {
             getCachedEventsByKind: (kind) => getCachedEventsByKind(kind),
             cacheUserEvent: cachedUserEvents.add,
             indexerRelayUrls: const ['wss://idx.test'],
+            indexerOperationTimeout: const Duration(milliseconds: 20),
             relayFactory: (url, status) {
               // EVENT but no EOSE → timeout fires
-              return _FakeRelay(url, status)
+              return _FakeRelay(url, status, neverCloses: true)
                 ..fakeResponses = [
                   ['EVENT', 'sub1', contactListJson],
                   // No EOSE — completer times out

--- a/mobile/packages/follow_repository/test/src/follow_repository_test.dart
+++ b/mobile/packages/follow_repository/test/src/follow_repository_test.dart
@@ -2325,6 +2325,29 @@ void main() {
     });
 
     group('getOthersFollowing', () {
+      test('times out when the relay query never completes', () {
+        fakeAsync((async) {
+          when(
+            () => mockNostrClient.queryEvents(any()),
+          ).thenAnswer((_) => Completer<List<Event>>().future);
+          Object? error;
+
+          unawaited(
+            repository
+                .getOthersFollowing(testTargetPubkey)
+                .then<void>(
+                  (_) {},
+                  onError: (Object caught) => error = caught,
+                ),
+          );
+          async
+            ..elapse(const Duration(seconds: 8))
+            ..flushMicrotasks();
+
+          expect(error, isA<TimeoutException>());
+        });
+      });
+
       test('returns empty snapshot when no events found', () async {
         when(
           () => mockNostrClient.queryEvents(any()),
@@ -5495,6 +5518,57 @@ void main() {
     });
 
     group('getFollowers with API branch', () {
+      test('keeps relay results when the API fails', () async {
+        const relayFollower =
+            'bb00000000000000000000000000000000000000000000000000000000000002';
+        final api = _MockFunnelcakeApiClient();
+        when(() => api.isAvailable).thenReturn(true);
+        when(
+          () => api.getFollowers(
+            pubkey: any(named: 'pubkey'),
+            limit: any(named: 'limit'),
+          ),
+        ).thenAnswer((_) async => throw Exception('API unavailable'));
+        when(() => mockNostrClient.queryEvents(any())).thenAnswer(
+          (_) async => [
+            Event(
+              relayFollower,
+              3,
+              [
+                ['p', testTargetPubkey],
+              ],
+              '',
+              createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+            ),
+          ],
+        );
+        repository = FollowRepository(
+          nostrClient: mockNostrClient,
+          isCacheInitialized: () => cacheIsInitialized,
+          getCachedEventsByKind: (kind) => getCachedEventsByKind(kind),
+          cacheUserEvent: cachedUserEvents.add,
+          funnelcakeApiClient: api,
+          indexerRelayUrls: const [],
+        );
+
+        final followers = await repository.getFollowers(testTargetPubkey);
+
+        expect(followers, [relayFollower]);
+      });
+
+      test('throws instead of returning empty when all sources fail', () {
+        when(
+          () => mockNostrClient.queryEvents(any()),
+        ).thenAnswer(
+          (_) => Future<List<Event>>.error(Exception('Relay unavailable')),
+        );
+
+        expect(
+          repository.getFollowers(testTargetPubkey),
+          throwsException,
+        );
+      });
+
       test(
         'merges API results with relay results',
         () async {

--- a/mobile/packages/follow_repository/test/src/follow_repository_test.dart
+++ b/mobile/packages/follow_repository/test/src/follow_repository_test.dart
@@ -1682,6 +1682,18 @@ void main() {
           expect(followers, isEmpty);
         });
       });
+
+      test('does not cache an empty snapshot when a source fails', () async {
+        when(
+          () => mockNostrClient.queryEvents(any()),
+        ).thenThrow(Exception('Relays unavailable'));
+
+        await expectLater(
+          repository.watchOthersFollowersCached(testTargetPubkey),
+          emitsError(isA<Exception>()),
+        );
+        expect(cacheDao.length, isZero);
+      });
     });
 
     group('follower ordering', () {
@@ -3077,7 +3089,7 @@ void main() {
         expect(result, isFalse);
       });
 
-      test('returns false on error', () async {
+      test('returns false when every follower source fails', () async {
         // Set up: we follow testTargetPubkey
         SharedPreferences.setMockInitialValues({
           'following_list_$testCurrentUserPubkey': '["$testTargetPubkey"]',
@@ -3093,7 +3105,8 @@ void main() {
 
         await repository.initialize();
 
-        // Mock: relay query throws
+        // No REST or indexer sources are configured, so this makes the only
+        // network source fail and exercises isMutualFollow's public guard.
         when(
           () => mockNostrClient.queryEvents(any()),
         ).thenThrow(Exception('Network error'));

--- a/mobile/packages/nostr_sdk/lib/relay/web_socket_connection_manager.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/web_socket_connection_manager.dart
@@ -24,6 +24,9 @@ class WebSocketConfig {
   /// Timeout for initial connection attempt
   final Duration connectionTimeout;
 
+  /// Maximum time to wait for a WebSocket close handshake.
+  final Duration closeTimeout;
+
   /// Interval for heartbeat checks (0 to disable)
   ///
   /// When enabled, the connection manager periodically checks if the
@@ -44,6 +47,7 @@ class WebSocketConfig {
     this.baseReconnectDelay = const Duration(seconds: 2),
     this.maxReconnectDelay = const Duration(minutes: 5),
     this.connectionTimeout = const Duration(seconds: 10),
+    this.closeTimeout = const Duration(seconds: 2),
     this.heartbeatInterval = const Duration(seconds: 30),
     this.idleTimeout = const Duration(seconds: 90),
   });
@@ -279,11 +283,7 @@ class WebSocketConnectionManager {
   /// Closes a socket that no longer has an owner.
   Future<void> _closeOrphanedChannel(WebSocketChannel? channel) async {
     if (channel == null) return;
-    try {
-      await channel.sink.close();
-    } catch (e) {
-      log('Error closing orphaned channel: $e');
-    }
+    await _closeSink(channel, description: 'orphaned channel');
   }
 
   /// Publishes to [errorStream] unless teardown already closed it.
@@ -349,10 +349,19 @@ class WebSocketConnectionManager {
     _channel = null;
     if (channel == null) return;
 
+    await _closeSink(channel, description: 'channel');
+  }
+
+  Future<void> _closeSink(
+    WebSocketChannel channel, {
+    required String description,
+  }) async {
     try {
-      await channel.sink.close();
+      await channel.sink.close().timeout(config.closeTimeout);
+    } on TimeoutException {
+      log('Timed out closing $description after ${config.closeTimeout}');
     } catch (e) {
-      log('Error closing channel: $e');
+      log('Error closing $description: $e');
     }
   }
 

--- a/mobile/packages/nostr_sdk/test/unit/web_socket_connection_manager_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/web_socket_connection_manager_test.dart
@@ -340,6 +340,32 @@ void main() {
 
         await slowManager.dispose();
       });
+
+      test('connection timeout is not held open by channel cleanup', () async {
+        final factory = MockWebSocketChannelFactory();
+        factory.readyGate = Completer<void>();
+        final boundedManager = WebSocketConnectionManager(
+          url: 'wss://test.relay.com',
+          channelFactory: factory,
+          logger: logMessages.add,
+          config: const WebSocketConfig(
+            connectionTimeout: Duration(milliseconds: 20),
+            closeTimeout: Duration(milliseconds: 20),
+          ),
+        );
+
+        final connecting = boundedManager.connect();
+        await Future<void>.delayed(Duration.zero);
+        factory.lastChannel!.blockClose();
+
+        expect(
+          await connecting.timeout(const Duration(milliseconds: 100)),
+          isFalse,
+        );
+        expect(boundedManager.state, ConnectionState.disconnected);
+
+        await boundedManager.dispose();
+      });
     });
 
     group('disconnection', () {
@@ -352,6 +378,29 @@ void main() {
         expect(manager.isConnected, isFalse);
         expect(mockFactory.lastChannel!.isClosed, isTrue);
       });
+
+      test(
+        'disconnect is bounded when channel close never completes',
+        () async {
+          final boundedManager = WebSocketConnectionManager(
+            url: 'wss://test.relay.com',
+            channelFactory: mockFactory,
+            logger: logMessages.add,
+            config: const WebSocketConfig(
+              closeTimeout: Duration(milliseconds: 20),
+            ),
+          );
+          await boundedManager.connect();
+          mockFactory.lastChannel!.blockClose();
+
+          await boundedManager.disconnect().timeout(
+            const Duration(milliseconds: 100),
+          );
+          expect(boundedManager.state, ConnectionState.disconnected);
+
+          await boundedManager.dispose();
+        },
+      );
 
       test('emits disconnected state', () async {
         await manager.connect();


### PR DESCRIPTION
Profile follower and following numbers could remain blank forever when one configured indexer blackholed its WebSocket connection, even after Funnelcake and other relays had returned usable data.

The handshake timeout was followed by an unbounded close handshake, so the relay connection future never settled. This change bounds WebSocket cleanup in the shared Nostr SDK, then gives follower indexer operations a single deadline across connection, collection, CLOSE, and disconnect. Each follower-list source is now best-effort, so one failed relay cannot discard successful results from the others.

This deliberately leaves the shared NIP-65 indexer configuration and the one-shot CacheSync snapshot contract unchanged. The durable fix applies to every configured endpoint without weakening relay discovery or publishing.

Verification:

- `flutter test` in `mobile/packages/nostr_sdk` - 619 passed
- `flutter test test/src/follow_repository_test.dart` - 235 passed
- `dart pub global run very_good_cli:very_good test --coverage --min-coverage 100 --show-uncovered` - 308 passed, 100% coverage
- pre-push affected tests - 272 passed
- `flutter analyze` in both affected packages - no issues

Closes #8231
