### PR TITLE
fix(profile): show the blue checkmark only for team members

### DIFF
--- a/mobile/lib/config/official_accounts.dart
+++ b/mobile/lib/config/official_accounts.dart
@@ -123,27 +123,6 @@ const Set<String> kDivineTeamPubkeys = {
   kHqPubkeyHex,
 };
 
-/// Checkmarks that are not team membership.
-///
-/// Two are grandfathered: [kDivineTeamPubkeys] replaced a NIP-05-host rule, and
-/// dropping them would have stripped a badge someone already had. The third was
-/// granted here, so this is not purely a legacy set — it is every checkmark the
-/// team rule does not explain.
-///
-/// All of them render the same badge and the same explanation as the team, so
-/// each should either move into [kDivineTeamPubkeys] or go away once its status
-/// is settled.
-const Set<String> kLegacyProfileCheckmarkPubkeys = {
-  // Kirsten Swasey, granted in #3445 by NIP-05 host; resolved to her pubkey
-  // via kirstenswasey.divine.video/.well-known/nostr.json.
-  'cd4ce30f980c960757b46179608a4946fc06cad47f6dc8960f638e41312c1643',
-  // Added in #4537 as a bare npub with no owner named in the PR or its issue.
-  'aa50001ef150418f30f62f827399d5c26a5ade52ab45ca4849f99b1726bb47b4',
-  // Improvising. Granted here, not grandfathered — it predates neither the
-  // team rule nor this set.
-  '5ab67f7d7fed4f781008c0ec0d26c8113f9fb46094a8346246c70c75e75db9fb',
-};
-
 /// Moderation pubkeys the account has rotated away from.
 ///
 /// A DM thread opened before a rotation stays keyed on the old pubkey. Those

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -4600,7 +4600,7 @@
     "ogBetaTesterBadgeLabel": "OG Beta Tester",
     "profileBadgeOgVinerBody": "ይህ ሰው Divine በማህደር ውስጥ ያገኘውን ዋና Vine ለጥፏል። ይህ የመለያ ማረጋገጫ ባጅ አይደለም።",
     "profileBadgeCheckmarkTitle": "የመገለጫ ምልክት",
-    "profileBadgeCheckmarkBody": "Divine ይህን ምልክት ለቡድን መለያዎች እና በእጅ ለጸደቁ ጥቂት መገለጫዎች ይሰጣል። ከNIP-05፣ ከተረጋገጡ የመለያ አገናኞች እና ከOG Viner ሁኔታ የተለየ ነው።",
+    "profileBadgeCheckmarkBody": "Divine ይህን ምልክት ለቡድን መለያዎች ይሰጣል። ከNIP-05፣ ከተረጋገጡ የመለያ አገናኞች እና ከOG Viner ሁኔታ የተለየ ነው።",
     "unfollowConfirmButton": "አትከተል",
     "videoClipSaveFailed": "ክሊፕ ማስቀመጥ አልተሳካም",
     "videoClipSaveTo": "ወደ {destination} አስቀምጥ",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -4475,7 +4475,7 @@
     "ogBetaTesterBadgeLabel": "OG Beta Tester",
     "profileBadgeOgVinerBody": "نشر هذا الشخص مقطع Vine أصليًا عثرت عليه Divine في الأرشيف. هذه ليست شارة توثيق حساب.",
     "profileBadgeCheckmarkTitle": "علامة الملف الشخصي",
-    "profileBadgeCheckmarkBody": "تمنح Divine هذه العلامة لحسابات الفريق ولمجموعة صغيرة من الملفات الشخصية المعتمدة يدويًا. وهي منفصلة عن NIP-05 وروابط الحسابات الموثّقة وحالة OG Viner.",
+    "profileBadgeCheckmarkBody": "تمنح Divine هذه العلامة لحسابات الفريق. وهي منفصلة عن NIP-05 وروابط الحسابات الموثّقة وحالة OG Viner.",
     "unfollowConfirmButton": "إلغاء المتابعة",
     "videoClipSaveFailed": "فشل حفظ المقطع",
     "videoClipSaveTo": "حفظ في {destination}",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -4606,7 +4606,7 @@
     "ogBetaTesterBadgeLabel": "OG Beta Tester",
     "profileBadgeOgVinerBody": "Този човек е публикувал оригинален Vine, който Divine намери в архива. Това не е значка за потвърден профил.",
     "profileBadgeCheckmarkTitle": "Отметка на профила",
-    "profileBadgeCheckmarkBody": "Divine дава тази отметка на профилите на екипа и на малка група ръчно одобрени профили. Това е различно от NIP-05, потвърдените връзки към профила и статуса OG Viner.",
+    "profileBadgeCheckmarkBody": "Divine дава тази отметка на профилите на екипа. Това е различно от NIP-05, потвърдените връзки към профила и статуса OG Viner.",
     "unfollowConfirmButton": "Спри да следваш",
     "videoClipSaveFailed": "Неуспешно запазване на клипа",
     "videoClipSaveTo": "Запази в {destination}",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -4475,7 +4475,7 @@
     "ogBetaTesterBadgeLabel": "OG Beta Tester",
     "profileBadgeOgVinerBody": "Diese Person hat ein Original-Vine gepostet, das Divine im Archiv gefunden hat. Das ist kein Verifizierungs-Badge fürs Konto.",
     "profileBadgeCheckmarkTitle": "Profil-Häkchen",
-    "profileBadgeCheckmarkBody": "Divine vergibt dieses Häkchen an Team-Konten und an eine kleine Zahl manuell freigegebener Profile. Das ist unabhängig von NIP-05, verifizierten Konto-Links und dem OG-Viner-Status.",
+    "profileBadgeCheckmarkBody": "Divine vergibt dieses Häkchen an Team-Konten. Das ist unabhängig von NIP-05, verifizierten Konto-Links und dem OG-Viner-Status.",
     "unfollowConfirmButton": "Nicht mehr folgen",
     "videoClipSaveFailed": "Clip konnte nicht gespeichert werden",
     "videoClipSaveTo": "In {destination} speichern",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -4715,9 +4715,9 @@
   "@profileBadgeCheckmarkTitle": {
     "description": "Title for the dialog explaining the special profile checkmark badge."
   },
-  "profileBadgeCheckmarkBody": "Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.",
+  "profileBadgeCheckmarkBody": "Divine gives this checkmark to team accounts. It is separate from NIP-05, verified account links, and OG Viner status.",
   "@profileBadgeCheckmarkBody": {
-    "description": "Body copy explaining that the special profile checkmark marks Divine team accounts and manually approved profiles, not NIP-05, verified-account links, or OG Viner status."
+    "description": "Body copy explaining that the special profile checkmark marks Divine team accounts, not NIP-05, verified-account links, or OG Viner status."
   },
   "unfollowConfirmButton": "Unfollow",
   "videoClipSaveFailed": "Failed to save clip",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -4475,7 +4475,7 @@
     "ogBetaTesterBadgeLabel": "OG Beta Tester",
     "profileBadgeOgVinerBody": "Esta persona publicó un Vine original que Divine encontró en el archivo. No es una insignia de verificación de cuenta.",
     "profileBadgeCheckmarkTitle": "Tilde de perfil",
-    "profileBadgeCheckmarkBody": "Divine da esta tilde a las cuentas del equipo y a un pequeño grupo de perfiles aprobados manualmente. Es independiente de NIP-05, de los enlaces de cuenta verificados y del estado OG Viner.",
+    "profileBadgeCheckmarkBody": "Divine da esta tilde a las cuentas del equipo. Es independiente de NIP-05, de los enlaces de cuenta verificados y del estado OG Viner.",
     "unfollowConfirmButton": "Dejar de seguir",
     "videoClipSaveFailed": "No se pudo guardar el clip",
     "videoClipSaveTo": "Guardar en {destination}",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -3271,7 +3271,7 @@
     "ogBetaTesterBadgeLabel": "OG Beta Tester",
     "profileBadgeOgVinerBody": "Nag-post ang taong ito ng orihinal na Vine na nakita ng Divine sa archive. Hindi ito badge ng verification ng account.",
     "profileBadgeCheckmarkTitle": "Tsek sa profile",
-    "profileBadgeCheckmarkBody": "Ibinibigay ng Divine ang tsek na ito sa mga account ng team at sa iilang profile na manu-manong inaprubahan. Hiwalay ito sa NIP-05, sa mga verified na link ng account, at sa OG Viner status.",
+    "profileBadgeCheckmarkBody": "Ibinibigay ng Divine ang tsek na ito sa mga account ng team. Hiwalay ito sa NIP-05, sa mga verified na link ng account, at sa OG Viner status.",
     "unfollowConfirmButton": "I-unfollow",
     "videoClipSaveFailed": "Hindi na-save ang clip",
     "videoClipSaveTo": "I-save sa {destination}",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -4475,7 +4475,7 @@
     "ogBetaTesterBadgeLabel": "OG Beta Tester",
     "profileBadgeOgVinerBody": "Cette personne a publié un Vine original que Divine a retrouvé dans les archives. Ce n'est pas un badge de vérification de compte.",
     "profileBadgeCheckmarkTitle": "Coche de profil",
-    "profileBadgeCheckmarkBody": "Divine attribue cette coche aux comptes de l'équipe et à un petit nombre de profils approuvés manuellement. C'est indépendant de NIP-05, des liens de compte vérifiés et du statut OG Viner.",
+    "profileBadgeCheckmarkBody": "Divine attribue cette coche aux comptes de l'équipe. C'est indépendant de NIP-05, des liens de compte vérifiés et du statut OG Viner.",
     "unfollowConfirmButton": "Ne plus suivre",
     "videoClipSaveFailed": "Échec de l'enregistrement du clip",
     "videoClipSaveTo": "Enregistrer dans {destination}",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -4475,7 +4475,7 @@
     "ogBetaTesterBadgeLabel": "OG Beta Tester",
     "profileBadgeOgVinerBody": "Orang ini pernah memposting Vine asli yang ditemukan Divine di arsip. Ini bukan lencana verifikasi akun.",
     "profileBadgeCheckmarkTitle": "Centang profil",
-    "profileBadgeCheckmarkBody": "Divine memberikan centang ini kepada akun tim dan sejumlah kecil profil yang disetujui secara manual. Ini terpisah dari NIP-05, tautan akun terverifikasi, dan status OG Viner.",
+    "profileBadgeCheckmarkBody": "Divine memberikan centang ini kepada akun tim. Ini terpisah dari NIP-05, tautan akun terverifikasi, dan status OG Viner.",
     "unfollowConfirmButton": "Berhenti mengikuti",
     "videoClipSaveFailed": "Gagal menyimpan klip",
     "videoClipSaveTo": "Simpan ke {destination}",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -4475,7 +4475,7 @@
     "ogBetaTesterBadgeLabel": "OG Beta Tester",
     "profileBadgeOgVinerBody": "Questa persona ha pubblicato un Vine originale che Divine ha trovato nell'archivio. Non è un badge di verifica dell'account.",
     "profileBadgeCheckmarkTitle": "Spunta del profilo",
-    "profileBadgeCheckmarkBody": "Divine assegna questa spunta agli account del team e a un piccolo gruppo di profili approvati manualmente. È separato da NIP-05, dai link di account verificati e dallo status OG Viner.",
+    "profileBadgeCheckmarkBody": "Divine assegna questa spunta agli account del team. È separato da NIP-05, dai link di account verificati e dallo status OG Viner.",
     "unfollowConfirmButton": "Smetti di seguire",
     "videoClipSaveFailed": "Impossibile salvare il clip",
     "videoClipSaveTo": "Salva in {destination}",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -4475,7 +4475,7 @@
     "ogBetaTesterBadgeLabel": "OG Beta Tester",
     "profileBadgeOgVinerBody": "この人はオリジナルの Vine を投稿していて、Divine がアーカイブで見つけたよ。アカウントの認証バッジではないので注意。",
     "profileBadgeCheckmarkTitle": "プロフィールのチェックマーク",
-    "profileBadgeCheckmarkBody": "Divine はこのチェックマークをチームのアカウントと、手動で承認したごく少数のプロフィールに付けてるよ。 NIP-05、認証済みアカウントのリンク、OG Viner ステータスとは別物だよ。",
+    "profileBadgeCheckmarkBody": "Divine はこのチェックマークをチームのアカウントに付けてるよ。 NIP-05、認証済みアカウントのリンク、OG Viner ステータスとは別物だよ。",
     "unfollowConfirmButton": "フォロー解除",
     "videoClipSaveFailed": "クリップの保存に失敗したよ",
     "videoClipSaveTo": "{destination}に保存",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -3936,7 +3936,7 @@
     "ogBetaTesterBadgeLabel": "OG Beta Tester",
     "profileBadgeOgVinerBody": "이 사람은 Divine이 아카이브에서 찾은 오리지널 Vine을 올렸어요. 계정 인증 배지는 아니에요.",
     "profileBadgeCheckmarkTitle": "프로필 체크마크",
-    "profileBadgeCheckmarkBody": "Divine는 이 체크마크를 팀 계정과 직접 승인한 소수의 프로필에 부여해요. NIP-05, 인증된 계정 링크, OG Viner 상태와는 별개예요.",
+    "profileBadgeCheckmarkBody": "Divine는 이 체크마크를 팀 계정에 부여해요. NIP-05, 인증된 계정 링크, OG Viner 상태와는 별개예요.",
     "unfollowConfirmButton": "언팔로우",
     "videoClipSaveFailed": "클립을 저장하지 못했어요",
     "videoClipSaveTo": "{destination}에 저장",

--- a/mobile/lib/l10n/app_ms.arb
+++ b/mobile/lib/l10n/app_ms.arb
@@ -4026,7 +4026,7 @@
     "ogBetaTesterBadgeLabel": "OG Beta Tester",
   "profileBadgeOgVinerBody": "Orang ini pernah menyiarkan Vine asli yang ditemui Divine dalam arkib. Ini bukan lencana pengesahan akaun.",
   "profileBadgeCheckmarkTitle": "Tanda semak profil",
-  "profileBadgeCheckmarkBody": "Divine memberikan tanda semak ini kepada akaun pasukan dan sebilangan kecil profil yang diluluskan secara manual. Ia berasingan daripada NIP-05, pautan akaun disahkan dan status OG Viner.",
+  "profileBadgeCheckmarkBody": "Divine memberikan tanda semak ini kepada akaun pasukan. Ia berasingan daripada NIP-05, pautan akaun disahkan dan status OG Viner.",
   "unfollowConfirmButton": "Nyahikut",
   "videoClipSaveFailed": "Gagal menyimpan klip",
   "videoClipSaveTo": "Simpan ke {destination}",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -4475,7 +4475,7 @@
     "ogBetaTesterBadgeLabel": "OG Beta Tester",
     "profileBadgeOgVinerBody": "Deze persoon plaatste een originele Vine die Divine in het archief vond. Dit is geen verificatiebadge voor het account.",
     "profileBadgeCheckmarkTitle": "Profielvinkje",
-    "profileBadgeCheckmarkBody": "Divine geeft dit vinkje aan teamaccounts en aan een klein aantal handmatig goedgekeurde profielen. Dat staat los van NIP-05, geverifieerde accountlinks en de OG Viner-status.",
+    "profileBadgeCheckmarkBody": "Divine geeft dit vinkje aan teamaccounts. Dat staat los van NIP-05, geverifieerde accountlinks en de OG Viner-status.",
     "unfollowConfirmButton": "Ontvolgen",
     "videoClipSaveFailed": "Clip opslaan mislukt",
     "videoClipSaveTo": "Opslaan bij {destination}",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -4475,7 +4475,7 @@
     "ogBetaTesterBadgeLabel": "OG Beta Tester",
     "profileBadgeOgVinerBody": "Ta osoba opublikowała oryginalnego Vine'a, którego Divine znalazło w archiwum. To nie jest odznaka weryfikacji konta.",
     "profileBadgeCheckmarkTitle": "Znacznik profilu",
-    "profileBadgeCheckmarkBody": "Divine przyznaje ten znacznik kontom zespołu i niewielkiej grupie ręcznie zatwierdzonych profili. To coś innego niż NIP-05, zweryfikowane linki konta i status OG Viner.",
+    "profileBadgeCheckmarkBody": "Divine przyznaje ten znacznik kontom zespołu. To coś innego niż NIP-05, zweryfikowane linki konta i status OG Viner.",
     "unfollowConfirmButton": "Przestań obserwować",
     "videoClipSaveFailed": "Nie udało się zapisać klipu",
     "videoClipSaveTo": "Zapisz do {destination}",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -4475,7 +4475,7 @@
     "ogBetaTesterBadgeLabel": "OG Beta Tester",
     "profileBadgeOgVinerBody": "Essa pessoa postou um Vine original que a Divine encontrou no arquivo. Não é um selo de verificação de conta.",
     "profileBadgeCheckmarkTitle": "Marca de verificação do perfil",
-    "profileBadgeCheckmarkBody": "A Divine dá essa marca às contas da equipe e a um pequeno grupo de perfis aprovados manualmente. É separado do NIP-05, dos links de conta verificados e do status de Viner OG.",
+    "profileBadgeCheckmarkBody": "A Divine dá essa marca às contas da equipe. É separado do NIP-05, dos links de conta verificados e do status de Viner OG.",
     "unfollowConfirmButton": "Deixar de seguir",
     "videoClipSaveFailed": "Falha ao salvar o clipe",
     "videoClipSaveTo": "Salvar em {destination}",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -4475,7 +4475,7 @@
     "ogBetaTesterBadgeLabel": "OG Beta Tester",
     "profileBadgeOgVinerBody": "Persoana asta a postat un Vine original pe care Divine l-a găsit în arhivă. Nu e o insignă de verificare a contului.",
     "profileBadgeCheckmarkTitle": "Bifa de profil",
-    "profileBadgeCheckmarkBody": "Divine dă bifa asta conturilor echipei și unui număr mic de profiluri aprobate manual. E separat de NIP-05, de linkurile de cont verificate și de statutul OG Viner.",
+    "profileBadgeCheckmarkBody": "Divine dă bifa asta conturilor echipei. E separat de NIP-05, de linkurile de cont verificate și de statutul OG Viner.",
     "unfollowConfirmButton": "Nu mai urmări",
     "videoClipSaveFailed": "Nu am putut salva clipul",
     "videoClipSaveTo": "Salvează în {destination}",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -4475,7 +4475,7 @@
     "ogBetaTesterBadgeLabel": "OG Beta Tester",
     "profileBadgeOgVinerBody": "Den här personen postade en originalvine som Divine hittade i arkivet. Det är inte en verifieringsbadge för kontot.",
     "profileBadgeCheckmarkTitle": "Profilbock",
-    "profileBadgeCheckmarkBody": "Divine ger den här bocken till teamets konton och till ett litet antal manuellt godkända profiler. Det är skilt från NIP-05, verifierade kontolänkar och OG Viner-status.",
+    "profileBadgeCheckmarkBody": "Divine ger den här bocken till teamets konton. Det är skilt från NIP-05, verifierade kontolänkar och OG Viner-status.",
     "unfollowConfirmButton": "Sluta följa",
     "videoClipSaveFailed": "Kunde inte spara klipp",
     "videoClipSaveTo": "Spara till {destination}",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -4475,7 +4475,7 @@
     "ogBetaTesterBadgeLabel": "OG Beta Tester",
     "profileBadgeOgVinerBody": "Bu kişi, Divine'ın arşivde bulduğu orijinal bir Vine paylaşmış. Bu bir hesap doğrulama rozeti değil.",
     "profileBadgeCheckmarkTitle": "Profil onay işareti",
-    "profileBadgeCheckmarkBody": "Divine bu onay işaretini ekip hesaplarına ve elle onaylanmış az sayıda profile veriyor. NIP-05'ten, doğrulanmış hesap bağlantılarından ve OG Viner durumundan ayrıdır.",
+    "profileBadgeCheckmarkBody": "Divine bu onay işaretini ekip hesaplarına veriyor. NIP-05'ten, doğrulanmış hesap bağlantılarından ve OG Viner durumundan ayrıdır.",
     "unfollowConfirmButton": "Takipten çık",
     "videoClipSaveFailed": "Klip kaydedilemedi",
     "videoClipSaveTo": "{destination} konumuna kaydet",

--- a/mobile/lib/l10n/app_ur.arb
+++ b/mobile/lib/l10n/app_ur.arb
@@ -4026,7 +4026,7 @@
     "ogBetaTesterBadgeLabel": "OG Beta Tester",
   "profileBadgeOgVinerBody": "اس شخص نے ایک اصل Vine پوسٹ کیا تھا جو Divine کو آرکائیو میں ملا۔ یہ اکاؤنٹ کی تصدیق کا بیج نہیں ہے۔",
   "profileBadgeCheckmarkTitle": "پروفائل چیک مارک",
-  "profileBadgeCheckmarkBody": "Divine یہ چیک مارک ٹیم کے اکاؤنٹس اور دستی طور پر منظور شدہ چند پروفائلز کو دیتا ہے۔ یہ NIP-05، تصدیق شدہ اکاؤنٹ لنکس اور OG Viner اسٹیٹس سے الگ ہے۔",
+  "profileBadgeCheckmarkBody": "Divine یہ چیک مارک ٹیم کے اکاؤنٹس کو دیتا ہے۔ یہ NIP-05، تصدیق شدہ اکاؤنٹ لنکس اور OG Viner اسٹیٹس سے الگ ہے۔",
   "unfollowConfirmButton": "ان فالو کریں",
   "videoClipSaveFailed": "کلپ محفوظ نہیں ہو سکی",
   "videoClipSaveTo": "{destination} میں محفوظ کریں",

--- a/mobile/lib/l10n/app_vi.arb
+++ b/mobile/lib/l10n/app_vi.arb
@@ -4026,7 +4026,7 @@
     "ogBetaTesterBadgeLabel": "OG Beta Tester",
   "profileBadgeOgVinerBody": "Người này đã đăng một Vine gốc mà Divine tìm thấy trong kho lưu trữ. Đây không phải huy hiệu xác minh tài khoản.",
   "profileBadgeCheckmarkTitle": "Dấu tích hồ sơ",
-  "profileBadgeCheckmarkBody": "Divine trao dấu tích này cho các tài khoản của đội ngũ và một số ít hồ sơ được duyệt thủ công. Nó tách biệt với NIP-05, liên kết tài khoản đã xác minh và trạng thái OG Viner.",
+  "profileBadgeCheckmarkBody": "Divine trao dấu tích này cho các tài khoản của đội ngũ. Nó tách biệt với NIP-05, liên kết tài khoản đã xác minh và trạng thái OG Viner.",
   "unfollowConfirmButton": "Bỏ theo dõi",
   "videoClipSaveFailed": "Không lưu được clip",
   "videoClipSaveTo": "Lưu vào {destination}",

--- a/mobile/lib/l10n/app_zh.arb
+++ b/mobile/lib/l10n/app_zh.arb
@@ -4026,7 +4026,7 @@
     "ogBetaTesterBadgeLabel": "OG Beta Tester",
   "profileBadgeOgVinerBody": "这个人发过一条原版 Vine，被 Divine 在存档里找到了。这不是账号认证徽章。",
   "profileBadgeCheckmarkTitle": "个人资料对勾",
-  "profileBadgeCheckmarkBody": "Divine 把这个对勾给团队账号，以及少数经过人工审核的个人资料。它与 NIP-05、已验证的账号链接和 OG Viner 状态无关。",
+  "profileBadgeCheckmarkBody": "Divine 把这个对勾给团队账号。它与 NIP-05、已验证的账号链接和 OG Viner 状态无关。",
   "unfollowConfirmButton": "取消关注",
   "videoClipSaveFailed": "片段保存失败",
   "videoClipSaveTo": "保存到{destination}",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -12293,10 +12293,10 @@ abstract class AppLocalizations {
   /// **'Profile checkmark'**
   String get profileBadgeCheckmarkTitle;
 
-  /// Body copy explaining that the special profile checkmark marks Divine team accounts and manually approved profiles, not NIP-05, verified-account links, or OG Viner status.
+  /// Body copy explaining that the special profile checkmark marks Divine team accounts, not NIP-05, verified-account links, or OG Viner status.
   ///
   /// In en, this message translates to:
-  /// **'Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.'**
+  /// **'Divine gives this checkmark to team accounts. It is separate from NIP-05, verified account links, and OG Viner status.'**
   String get profileBadgeCheckmarkBody;
 
   /// No description provided for @unfollowConfirmButton.

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -7045,7 +7045,7 @@ class AppLocalizationsAm extends AppLocalizations {
 
   @override
   String get profileBadgeCheckmarkBody =>
-      'Divine ይህን ምልክት ለቡድን መለያዎች እና በእጅ ለጸደቁ ጥቂት መገለጫዎች ይሰጣል። ከNIP-05፣ ከተረጋገጡ የመለያ አገናኞች እና ከOG Viner ሁኔታ የተለየ ነው።';
+      'Divine ይህን ምልክት ለቡድን መለያዎች ይሰጣል። ከNIP-05፣ ከተረጋገጡ የመለያ አገናኞች እና ከOG Viner ሁኔታ የተለየ ነው።';
 
   @override
   String get unfollowConfirmButton => 'አትከተል';

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -7152,7 +7152,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get profileBadgeCheckmarkBody =>
-      'تمنح Divine هذه العلامة لحسابات الفريق ولمجموعة صغيرة من الملفات الشخصية المعتمدة يدويًا. وهي منفصلة عن NIP-05 وروابط الحسابات الموثّقة وحالة OG Viner.';
+      'تمنح Divine هذه العلامة لحسابات الفريق. وهي منفصلة عن NIP-05 وروابط الحسابات الموثّقة وحالة OG Viner.';
 
   @override
   String get unfollowConfirmButton => 'إلغاء المتابعة';

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -7275,7 +7275,7 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get profileBadgeCheckmarkBody =>
-      'Divine дава тази отметка на профилите на екипа и на малка група ръчно одобрени профили. Това е различно от NIP-05, потвърдените връзки към профила и статуса OG Viner.';
+      'Divine дава тази отметка на профилите на екипа. Това е различно от NIP-05, потвърдените връзки към профила и статуса OG Viner.';
 
   @override
   String get unfollowConfirmButton => 'Спри да следваш';

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -7293,7 +7293,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get profileBadgeCheckmarkBody =>
-      'Divine vergibt dieses Häkchen an Team-Konten und an eine kleine Zahl manuell freigegebener Profile. Das ist unabhängig von NIP-05, verifizierten Konto-Links und dem OG-Viner-Status.';
+      'Divine vergibt dieses Häkchen an Team-Konten. Das ist unabhängig von NIP-05, verifizierten Konto-Links und dem OG-Viner-Status.';
 
   @override
   String get unfollowConfirmButton => 'Nicht mehr folgen';

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -7315,7 +7315,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get profileBadgeCheckmarkBody =>
-      'Divine gives this checkmark to team accounts and a small set of manually approved profiles. It is separate from NIP-05, verified account links, and OG Viner status.';
+      'Divine gives this checkmark to team accounts. It is separate from NIP-05, verified account links, and OG Viner status.';
 
   @override
   String get unfollowConfirmButton => 'Unfollow';

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -7272,7 +7272,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get profileBadgeCheckmarkBody =>
-      'Divine da esta tilde a las cuentas del equipo y a un pequeño grupo de perfiles aprobados manualmente. Es independiente de NIP-05, de los enlaces de cuenta verificados y del estado OG Viner.';
+      'Divine da esta tilde a las cuentas del equipo. Es independiente de NIP-05, de los enlaces de cuenta verificados y del estado OG Viner.';
 
   @override
   String get unfollowConfirmButton => 'Dejar de seguir';

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -7257,7 +7257,7 @@ class AppLocalizationsFil extends AppLocalizations {
 
   @override
   String get profileBadgeCheckmarkBody =>
-      'Ibinibigay ng Divine ang tsek na ito sa mga account ng team at sa iilang profile na manu-manong inaprubahan. Hiwalay ito sa NIP-05, sa mga verified na link ng account, at sa OG Viner status.';
+      'Ibinibigay ng Divine ang tsek na ito sa mga account ng team. Hiwalay ito sa NIP-05, sa mga verified na link ng account, at sa OG Viner status.';
 
   @override
   String get unfollowConfirmButton => 'I-unfollow';

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -7299,7 +7299,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get profileBadgeCheckmarkBody =>
-      'Divine attribue cette coche aux comptes de l\'équipe et à un petit nombre de profils approuvés manuellement. C\'est indépendant de NIP-05, des liens de compte vérifiés et du statut OG Viner.';
+      'Divine attribue cette coche aux comptes de l\'équipe. C\'est indépendant de NIP-05, des liens de compte vérifiés et du statut OG Viner.';
 
   @override
   String get unfollowConfirmButton => 'Ne plus suivre';

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -7131,7 +7131,7 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get profileBadgeCheckmarkBody =>
-      'Divine memberikan centang ini kepada akun tim dan sejumlah kecil profil yang disetujui secara manual. Ini terpisah dari NIP-05, tautan akun terverifikasi, dan status OG Viner.';
+      'Divine memberikan centang ini kepada akun tim. Ini terpisah dari NIP-05, tautan akun terverifikasi, dan status OG Viner.';
 
   @override
   String get unfollowConfirmButton => 'Berhenti mengikuti';

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -7277,7 +7277,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get profileBadgeCheckmarkBody =>
-      'Divine assegna questa spunta agli account del team e a un piccolo gruppo di profili approvati manualmente. È separato da NIP-05, dai link di account verificati e dallo status OG Viner.';
+      'Divine assegna questa spunta agli account del team. È separato da NIP-05, dai link di account verificati e dallo status OG Viner.';
 
   @override
   String get unfollowConfirmButton => 'Smetti di seguire';

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -6847,7 +6847,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get profileBadgeCheckmarkBody =>
-      'Divine はこのチェックマークをチームのアカウントと、手動で承認したごく少数のプロフィールに付けてるよ。 NIP-05、認証済みアカウントのリンク、OG Viner ステータスとは別物だよ。';
+      'Divine はこのチェックマークをチームのアカウントに付けてるよ。 NIP-05、認証済みアカウントのリンク、OG Viner ステータスとは別物だよ。';
 
   @override
   String get unfollowConfirmButton => 'フォロー解除';

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -6864,7 +6864,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get profileBadgeCheckmarkBody =>
-      'Divine는 이 체크마크를 팀 계정과 직접 승인한 소수의 프로필에 부여해요. NIP-05, 인증된 계정 링크, OG Viner 상태와는 별개예요.';
+      'Divine는 이 체크마크를 팀 계정에 부여해요. NIP-05, 인증된 계정 링크, OG Viner 상태와는 별개예요.';
 
   @override
   String get unfollowConfirmButton => '언팔로우';

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -7216,7 +7216,7 @@ class AppLocalizationsMs extends AppLocalizations {
 
   @override
   String get profileBadgeCheckmarkBody =>
-      'Divine memberikan tanda semak ini kepada akaun pasukan dan sebilangan kecil profil yang diluluskan secara manual. Ia berasingan daripada NIP-05, pautan akaun disahkan dan status OG Viner.';
+      'Divine memberikan tanda semak ini kepada akaun pasukan. Ia berasingan daripada NIP-05, pautan akaun disahkan dan status OG Viner.';
 
   @override
   String get unfollowConfirmButton => 'Nyahikut';

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -7235,7 +7235,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get profileBadgeCheckmarkBody =>
-      'Divine geeft dit vinkje aan teamaccounts en aan een klein aantal handmatig goedgekeurde profielen. Dat staat los van NIP-05, geverifieerde accountlinks en de OG Viner-status.';
+      'Divine geeft dit vinkje aan teamaccounts. Dat staat los van NIP-05, geverifieerde accountlinks en de OG Viner-status.';
 
   @override
   String get unfollowConfirmButton => 'Ontvolgen';

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -7367,7 +7367,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get profileBadgeCheckmarkBody =>
-      'Divine przyznaje ten znacznik kontom zespołu i niewielkiej grupie ręcznie zatwierdzonych profili. To coś innego niż NIP-05, zweryfikowane linki konta i status OG Viner.';
+      'Divine przyznaje ten znacznik kontom zespołu. To coś innego niż NIP-05, zweryfikowane linki konta i status OG Viner.';
 
   @override
   String get unfollowConfirmButton => 'Przestań obserwować';

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -7255,7 +7255,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get profileBadgeCheckmarkBody =>
-      'A Divine dá essa marca às contas da equipe e a um pequeno grupo de perfis aprovados manualmente. É separado do NIP-05, dos links de conta verificados e do status de Viner OG.';
+      'A Divine dá essa marca às contas da equipe. É separado do NIP-05, dos links de conta verificados e do status de Viner OG.';
 
   @override
   String get unfollowConfirmButton => 'Deixar de seguir';

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -7377,7 +7377,7 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get profileBadgeCheckmarkBody =>
-      'Divine dă bifa asta conturilor echipei și unui număr mic de profiluri aprobate manual. E separat de NIP-05, de linkurile de cont verificate și de statutul OG Viner.';
+      'Divine dă bifa asta conturilor echipei. E separat de NIP-05, de linkurile de cont verificate și de statutul OG Viner.';
 
   @override
   String get unfollowConfirmButton => 'Nu mai urmări';

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -7198,7 +7198,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get profileBadgeCheckmarkBody =>
-      'Divine ger den här bocken till teamets konton och till ett litet antal manuellt godkända profiler. Det är skilt från NIP-05, verifierade kontolänkar och OG Viner-status.';
+      'Divine ger den här bocken till teamets konton. Det är skilt från NIP-05, verifierade kontolänkar och OG Viner-status.';
 
   @override
   String get unfollowConfirmButton => 'Sluta följa';

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -7133,7 +7133,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get profileBadgeCheckmarkBody =>
-      'Divine bu onay işaretini ekip hesaplarına ve elle onaylanmış az sayıda profile veriyor. NIP-05\'ten, doğrulanmış hesap bağlantılarından ve OG Viner durumundan ayrıdır.';
+      'Divine bu onay işaretini ekip hesaplarına veriyor. NIP-05\'ten, doğrulanmış hesap bağlantılarından ve OG Viner durumundan ayrıdır.';
 
   @override
   String get unfollowConfirmButton => 'Takipten çık';

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -7206,7 +7206,7 @@ class AppLocalizationsUr extends AppLocalizations {
 
   @override
   String get profileBadgeCheckmarkBody =>
-      'Divine یہ چیک مارک ٹیم کے اکاؤنٹس اور دستی طور پر منظور شدہ چند پروفائلز کو دیتا ہے۔ یہ NIP-05، تصدیق شدہ اکاؤنٹ لنکس اور OG Viner اسٹیٹس سے الگ ہے۔';
+      'Divine یہ چیک مارک ٹیم کے اکاؤنٹس کو دیتا ہے۔ یہ NIP-05، تصدیق شدہ اکاؤنٹ لنکس اور OG Viner اسٹیٹس سے الگ ہے۔';
 
   @override
   String get unfollowConfirmButton => 'ان فالو کریں';

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -7176,7 +7176,7 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get profileBadgeCheckmarkBody =>
-      'Divine trao dấu tích này cho các tài khoản của đội ngũ và một số ít hồ sơ được duyệt thủ công. Nó tách biệt với NIP-05, liên kết tài khoản đã xác minh và trạng thái OG Viner.';
+      'Divine trao dấu tích này cho các tài khoản của đội ngũ. Nó tách biệt với NIP-05, liên kết tài khoản đã xác minh và trạng thái OG Viner.';
 
   @override
   String get unfollowConfirmButton => 'Bỏ theo dõi';

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -6793,7 +6793,7 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get profileBadgeCheckmarkBody =>
-      'Divine 把这个对勾给团队账号，以及少数经过人工审核的个人资料。它与 NIP-05、已验证的账号链接和 OG Viner 状态无关。';
+      'Divine 把这个对勾给团队账号。它与 NIP-05、已验证的账号链接和 OG Viner 状态无关。';
 
   @override
   String get unfollowConfirmButton => '取消关注';

--- a/mobile/lib/widgets/profile/profile_header_identity.dart
+++ b/mobile/lib/widgets/profile/profile_header_identity.dart
@@ -144,8 +144,8 @@ class _ProfileHeaderNameRow extends ConsumerWidget {
     final showCheckmark = shouldShowSpecialProfileCheckmark(userIdHex);
     // The beta chit yields to both the checkmark and the OG Viner chit, so a
     // name never carries two of them. The Viner rosters are disjoint by
-    // construction; the checkmark is an independent list that 15 of its 18
-    // pubkeys share with the beta roster, so that one has to be checked here.
+    // construction; many team accounts also appear on the beta roster, so the
+    // checkmark still has to be checked here.
     // A vanished account renders profileDeletedAccountName, so a chit beside
     // it is incoherent. The roster is compiled in and cannot drop anyone who
     // vanishes after release, so the gate has to live here.

--- a/mobile/lib/widgets/special_profile_checkmark.dart
+++ b/mobile/lib/widgets/special_profile_checkmark.dart
@@ -18,8 +18,7 @@ import 'package:openvine/l10n/l10n.dart';
 bool shouldShowSpecialProfileCheckmark(String? pubkeyHex) {
   if (pubkeyHex == null) return false;
   final pubkey = pubkeyHex.toLowerCase();
-  return kDivineTeamPubkeys.contains(pubkey) ||
-      kLegacyProfileCheckmarkPubkeys.contains(pubkey);
+  return kDivineTeamPubkeys.contains(pubkey);
 }
 
 class SpecialProfileCheckmark extends StatelessWidget {

--- a/mobile/lib/widgets/user_name.dart
+++ b/mobile/lib/widgets/user_name.dart
@@ -167,8 +167,8 @@ class UserName extends ConsumerWidget {
         showProfileBadges && shouldShowSpecialProfileCheckmark(effectivePubkey);
     // The beta chit yields to both the checkmark and the OG Viner chit, so a
     // name never carries two of them. The Viner rosters are disjoint by
-    // construction; the checkmark is an independent list that 15 of its 18
-    // pubkeys share with the beta roster, so that one has to be checked here.
+    // construction; many team accounts also appear on the beta roster, so the
+    // checkmark still has to be checked here.
     final isOgBetaTester =
         showProfileBadges &&
         !isOgViner &&

--- a/mobile/lib/widgets/video_feed_item/video_feed_item.dart
+++ b/mobile/lib/widgets/video_feed_item/video_feed_item.dart
@@ -324,8 +324,7 @@ class VideoOverlayActions extends ConsumerWidget {
                     // The beta chit yields to both the checkmark and the OG
                     // Viner chit, so a name never carries two of them. The
                     // Viner rosters are disjoint by construction; the
-                    // checkmark is an independent list that 15 of its 18
-                    // pubkeys share with the beta roster.
+                    // many team accounts also appear on the beta roster.
                     final isOgBetaTester =
                         !isOgViner &&
                         !showCheckmark &&

--- a/mobile/lib/widgets/video_feed_item/video_feed_item.dart
+++ b/mobile/lib/widgets/video_feed_item/video_feed_item.dart
@@ -323,8 +323,8 @@ class VideoOverlayActions extends ConsumerWidget {
                     );
                     // The beta chit yields to both the checkmark and the OG
                     // Viner chit, so a name never carries two of them. The
-                    // Viner rosters are disjoint by construction; the
-                    // many team accounts also appear on the beta roster.
+                    // Viner rosters are disjoint by construction; many team
+                    // accounts also appear on the beta roster.
                     final isOgBetaTester =
                         !isOgViner &&
                         !showCheckmark &&

--- a/mobile/test/config/official_accounts_test.dart
+++ b/mobile/test/config/official_accounts_test.dart
@@ -94,26 +94,14 @@ void main() {
       // Lookups lowercase the profile's pubkey before testing membership, so
       // an entry pasted in mixed case matches nobody — no crash, no analyzer
       // complaint, just a team member who never gets the checkmark.
-      final checkmarkPubkeys = {
-        ...kDivineTeamPubkeys,
-        ...kLegacyProfileCheckmarkPubkeys,
-      };
-
       test('every entry is a 64-character lowercase hex pubkey', () {
-        for (final pubkey in checkmarkPubkeys) {
+        for (final pubkey in kDivineTeamPubkeys) {
           expect(
             pubkey,
             matches(RegExp(r'^[0-9a-f]{64}$')),
             reason: '$pubkey is not a lowercase hex pubkey',
           );
         }
-      });
-
-      test('the two sets do not overlap', () {
-        expect(
-          kDivineTeamPubkeys.intersection(kLegacyProfileCheckmarkPubkeys),
-          isEmpty,
-        );
       });
 
       // Sebastian and Rabble are spelled out in both this file and the

--- a/mobile/test/helpers/former_profile_checkmark_pubkeys.dart
+++ b/mobile/test/helpers/former_profile_checkmark_pubkeys.dart
@@ -1,0 +1,9 @@
+// ABOUTME: Identifies profiles whose non-team checkmarks were retired.
+// ABOUTME: Keeps regression coverage for the decisions in #7419 and #8235.
+
+/// Non-team profiles that must not regain the Divine team checkmark.
+const formerProfileCheckmarkPubkeys = <String>{
+  'cd4ce30f980c960757b46179608a4946fc06cad47f6dc8960f638e41312c1643',
+  'aa50001ef150418f30f62f827399d5c26a5ade52ab45ca4849f99b1726bb47b4',
+  '5ab67f7d7fed4f781008c0ec0d26c8113f9fb46094a8346246c70c75e75db9fb',
+};

--- a/mobile/test/helpers/former_profile_checkmark_pubkeys.dart
+++ b/mobile/test/helpers/former_profile_checkmark_pubkeys.dart
@@ -1,9 +1,0 @@
-// ABOUTME: Identifies profiles whose non-team checkmarks were retired.
-// ABOUTME: Keeps regression coverage for the decisions in #7419 and #8235.
-
-/// Non-team profiles that must not regain the Divine team checkmark.
-const formerProfileCheckmarkPubkeys = <String>{
-  'cd4ce30f980c960757b46179608a4946fc06cad47f6dc8960f638e41312c1643',
-  'aa50001ef150418f30f62f827399d5c26a5ade52ab45ca4849f99b1726bb47b4',
-  '5ab67f7d7fed4f781008c0ec0d26c8113f9fb46094a8346246c70c75e75db9fb',
-};

--- a/mobile/test/widgets/profile/profile_header_widget_test.dart
+++ b/mobile/test/widgets/profile/profile_header_widget_test.dart
@@ -57,6 +57,7 @@ import 'package:openvine/widgets/vine_cached_image.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:skeletonizer/skeletonizer.dart';
 
+import '../../helpers/former_profile_checkmark_pubkeys.dart';
 import '../../helpers/go_router.dart';
 import '../../helpers/test_provider_overrides.dart';
 import '../../helpers/test_pubkeys.dart';
@@ -650,13 +651,33 @@ void main() {
       expect(find.text(l10n.commonClose), findsOneWidget);
     });
 
+    for (final (index, pubkey) in formerProfileCheckmarkPubkeys.indexed) {
+      testWidgets('shows OG Beta Tester for former profile ${index + 1}', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          buildTestWidget(
+            userIdHex: pubkey,
+            isOwnProfile: false,
+            suppliedProfile: createTestProfile(
+              displayName: 'Beta User',
+              pubkey: pubkey,
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.byType(SpecialProfileCheckmark), findsNothing);
+        expect(find.byType(OgBetaBadge), findsOneWidget);
+      });
+    }
+
     testWidgets('hides the OG Beta Tester chit behind the team checkmark', (
       tester,
     ) async {
-      // 15 of the 18 checkmark-bearing pubkeys are also on the beta roster,
-      // so this is the default state for Divine team accounts rather than an
-      // edge case. Without the guard the header renders two explainer
-      // buttons side by side.
+      // Many team accounts also appear on the beta roster, so this is the
+      // default state rather than an edge case. Without the guard the header
+      // renders two explainer buttons side by side.
       final dualPubkey = kDivineTeamPubkeys.firstWhere(isOgBetaTesterPubkey);
 
       await tester.pumpWidget(

--- a/mobile/test/widgets/profile/profile_header_widget_test.dart
+++ b/mobile/test/widgets/profile/profile_header_widget_test.dart
@@ -57,7 +57,6 @@ import 'package:openvine/widgets/vine_cached_image.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:skeletonizer/skeletonizer.dart';
 
-import '../../helpers/former_profile_checkmark_pubkeys.dart';
 import '../../helpers/go_router.dart';
 import '../../helpers/test_provider_overrides.dart';
 import '../../helpers/test_pubkeys.dart';
@@ -651,26 +650,27 @@ void main() {
       expect(find.text(l10n.commonClose), findsOneWidget);
     });
 
-    for (final (index, pubkey) in formerProfileCheckmarkPubkeys.indexed) {
-      testWidgets('shows OG Beta Tester for former profile ${index + 1}', (
-        tester,
-      ) async {
-        await tester.pumpWidget(
-          buildTestWidget(
-            userIdHex: pubkey,
-            isOwnProfile: false,
-            suppliedProfile: createTestProfile(
-              displayName: 'Beta User',
-              pubkey: pubkey,
-            ),
+    testWidgets('shows OG Beta Tester for a non-team roster member', (
+      tester,
+    ) async {
+      final pubkey = ogBetaTesterPubkeys.firstWhere(
+        (candidate) => !kDivineTeamPubkeys.contains(candidate),
+      );
+      await tester.pumpWidget(
+        buildTestWidget(
+          userIdHex: pubkey,
+          isOwnProfile: false,
+          suppliedProfile: createTestProfile(
+            displayName: 'Beta User',
+            pubkey: pubkey,
           ),
-        );
-        await tester.pumpAndSettle();
+        ),
+      );
+      await tester.pumpAndSettle();
 
-        expect(find.byType(SpecialProfileCheckmark), findsNothing);
-        expect(find.byType(OgBetaBadge), findsOneWidget);
-      });
-    }
+      expect(find.byType(SpecialProfileCheckmark), findsNothing);
+      expect(find.byType(OgBetaBadge), findsOneWidget);
+    });
 
     testWidgets('hides the OG Beta Tester chit behind the team checkmark', (
       tester,

--- a/mobile/test/widgets/special_profile_checkmark_test.dart
+++ b/mobile/test/widgets/special_profile_checkmark_test.dart
@@ -7,6 +7,8 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/config/official_accounts.dart';
+import 'package:openvine/constants/og_beta_testers.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/widgets/special_profile_checkmark.dart';
 
@@ -23,6 +25,18 @@ Widget _buildSubject() {
 }
 
 void main() {
+  group('visibility', () {
+    test('only team members on the OG Beta Tester roster get a checkmark', () {
+      for (final pubkey in ogBetaTesterPubkeys) {
+        expect(
+          shouldShowSpecialProfileCheckmark(pubkey),
+          kDivineTeamPubkeys.contains(pubkey),
+          reason: 'checkmark visibility must be derived from team membership',
+        );
+      }
+    });
+  });
+
   group('renders', () {
     testWidgets('renders an accessible non-tappable checkmark', (tester) async {
       final handle = tester.ensureSemantics();

--- a/mobile/test/widgets/user_name_nip05_test.dart
+++ b/mobile/test/widgets/user_name_nip05_test.dart
@@ -7,13 +7,12 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:models/models.dart';
 import 'package:openvine/config/official_accounts.dart';
+import 'package:openvine/constants/og_beta_testers.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/nip05_verification_provider.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/services/nip05_verification_service.dart';
 import 'package:openvine/widgets/user_name.dart';
-
-import '../helpers/former_profile_checkmark_pubkeys.dart';
 
 Finder _specialCheckmark() => find.byWidgetPredicate(
   (w) => w is DivineIcon && w.icon == DivineIconName.check,
@@ -73,17 +72,18 @@ void main() {
       expect(_specialCheckmark(), findsOneWidget);
     });
 
-    for (final (index, pubkey) in formerProfileCheckmarkPubkeys.indexed) {
-      testWidgets('does not show a checkmark for former profile ${index + 1}', (
-        tester,
-      ) async {
-        await tester.pumpWidget(buildSubject(pubkey: pubkey));
-        await tester.pump();
+    testWidgets('does not show a checkmark for a non-team beta tester', (
+      tester,
+    ) async {
+      final pubkey = ogBetaTesterPubkeys.firstWhere(
+        (candidate) => !kDivineTeamPubkeys.contains(candidate),
+      );
+      await tester.pumpWidget(buildSubject(pubkey: pubkey));
+      await tester.pump();
 
-        expect(find.text('Alice'), findsOneWidget);
-        expect(_specialCheckmark(), findsNothing);
-      });
-    }
+      expect(find.text('Alice'), findsOneWidget);
+      expect(_specialCheckmark(), findsNothing);
+    });
 
     testWidgets('matches a Divine team pubkey case-insensitively', (
       tester,

--- a/mobile/test/widgets/user_name_nip05_test.dart
+++ b/mobile/test/widgets/user_name_nip05_test.dart
@@ -13,6 +13,8 @@ import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/services/nip05_verification_service.dart';
 import 'package:openvine/widgets/user_name.dart';
 
+import '../helpers/former_profile_checkmark_pubkeys.dart';
+
 Finder _specialCheckmark() => find.byWidgetPredicate(
   (w) => w is DivineIcon && w.icon == DivineIconName.check,
 );
@@ -71,15 +73,17 @@ void main() {
       expect(_specialCheckmark(), findsOneWidget);
     });
 
-    testWidgets('shows a checkmark for a grandfathered pubkey', (tester) async {
-      await tester.pumpWidget(
-        buildSubject(pubkey: kLegacyProfileCheckmarkPubkeys.first),
-      );
-      await tester.pump();
+    for (final (index, pubkey) in formerProfileCheckmarkPubkeys.indexed) {
+      testWidgets('does not show a checkmark for former profile ${index + 1}', (
+        tester,
+      ) async {
+        await tester.pumpWidget(buildSubject(pubkey: pubkey));
+        await tester.pump();
 
-      expect(find.text('Alice'), findsOneWidget);
-      expect(_specialCheckmark(), findsOneWidget);
-    });
+        expect(find.text('Alice'), findsOneWidget);
+        expect(_specialCheckmark(), findsNothing);
+      });
+    }
 
     testWidgets('matches a Divine team pubkey case-insensitively', (
       tester,

--- a/mobile/test/widgets/user_name_og_beta_badge_test.dart
+++ b/mobile/test/widgets/user_name_og_beta_badge_test.dart
@@ -20,8 +20,6 @@ import 'package:openvine/widgets/special_profile_checkmark.dart';
 import 'package:openvine/widgets/user_name.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-import '../helpers/former_profile_checkmark_pubkeys.dart';
-
 void main() {
   final rosterPubkey = ogBetaTesterPubkeys.first;
   const strangerPubkey =
@@ -83,17 +81,18 @@ void main() {
       handle.dispose();
     });
 
-    for (final (index, pubkey) in formerProfileCheckmarkPubkeys.indexed) {
-      testWidgets('shows OG Beta Tester for former profile ${index + 1}', (
-        tester,
-      ) async {
-        await tester.pumpWidget(await buildSubject(pubkey: pubkey));
-        await tester.pump();
+    testWidgets('shows OG Beta Tester for a non-team roster member', (
+      tester,
+    ) async {
+      final pubkey = ogBetaTesterPubkeys.firstWhere(
+        (candidate) => !kDivineTeamPubkeys.contains(candidate),
+      );
+      await tester.pumpWidget(await buildSubject(pubkey: pubkey));
+      await tester.pump();
 
-        expect(find.byType(SpecialProfileCheckmark), findsNothing);
-        expect(find.byType(OgBetaBadge), findsOneWidget);
-      });
-    }
+      expect(find.byType(SpecialProfileCheckmark), findsNothing);
+      expect(find.byType(OgBetaBadge), findsOneWidget);
+    });
 
     testWidgets('a screen reader can open the explainer, not just a finger', (
       tester,

--- a/mobile/test/widgets/user_name_og_beta_badge_test.dart
+++ b/mobile/test/widgets/user_name_og_beta_badge_test.dart
@@ -20,6 +20,8 @@ import 'package:openvine/widgets/special_profile_checkmark.dart';
 import 'package:openvine/widgets/user_name.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import '../helpers/former_profile_checkmark_pubkeys.dart';
+
 void main() {
   final rosterPubkey = ogBetaTesterPubkeys.first;
   const strangerPubkey =
@@ -80,6 +82,18 @@ void main() {
       expect(data.hasAction(ui.SemanticsAction.tap), isTrue);
       handle.dispose();
     });
+
+    for (final (index, pubkey) in formerProfileCheckmarkPubkeys.indexed) {
+      testWidgets('shows OG Beta Tester for former profile ${index + 1}', (
+        tester,
+      ) async {
+        await tester.pumpWidget(await buildSubject(pubkey: pubkey));
+        await tester.pump();
+
+        expect(find.byType(SpecialProfileCheckmark), findsNothing);
+        expect(find.byType(OgBetaBadge), findsOneWidget);
+      });
+    }
 
     testWidgets('a screen reader can open the explainer, not just a finger', (
       tester,
@@ -161,12 +175,11 @@ void main() {
     testWidgets('yields to the profile checkmark so only one chit renders', (
       tester,
     ) async {
-      // 15 of the 19 checkmark-bearing pubkeys are also on the beta roster,
-      // so this overlap is the default for Divine team accounts, not an edge.
-      final overlapping = {
-        ...kDivineTeamPubkeys,
-        ...kLegacyProfileCheckmarkPubkeys,
-      }.where(isOgBetaTesterPubkey).toList();
+      // Many team accounts also appear on the beta roster, so this overlap is
+      // the default for Divine team accounts, not an edge.
+      final overlapping = kDivineTeamPubkeys
+          .where(isOgBetaTesterPubkey)
+          .toList();
       expect(
         overlapping,
         isNotEmpty,

--- a/mobile/test/widgets/video_feed_item/video_feed_item_meta_line_test.dart
+++ b/mobile/test/widgets/video_feed_item/video_feed_item_meta_line_test.dart
@@ -9,6 +9,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/video_interactions/video_interactions_bloc.dart';
+import 'package:openvine/config/official_accounts.dart';
+import 'package:openvine/constants/og_beta_testers.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/services/auth_service.dart';
@@ -18,7 +20,6 @@ import 'package:openvine/widgets/special_profile_checkmark.dart';
 import 'package:openvine/widgets/video_feed_item/video_feed_item.dart';
 import 'package:reposts_repository/reposts_repository.dart';
 
-import '../../helpers/former_profile_checkmark_pubkeys.dart';
 import '../../helpers/test_provider_overrides.dart';
 
 const _authorPubkey =
@@ -129,16 +130,17 @@ void main() {
   ).videoFeedLoopCountLine(StringUtils.formatCompactNumber(count), count);
 
   group('video card meta line', () {
-    for (final (index, pubkey) in formerProfileCheckmarkPubkeys.indexed) {
-      testWidgets('shows OG Beta Tester for former profile ${index + 1}', (
-        tester,
-      ) async {
-        await pump(tester, video: _video(pubkey: pubkey));
+    testWidgets('shows OG Beta Tester for a non-team roster member', (
+      tester,
+    ) async {
+      final pubkey = ogBetaTesterPubkeys.firstWhere(
+        (candidate) => !kDivineTeamPubkeys.contains(candidate),
+      );
+      await pump(tester, video: _video(pubkey: pubkey));
 
-        expect(find.byType(SpecialProfileCheckmark), findsNothing);
-        expect(find.byType(OgBetaBadge), findsOneWidget);
-      });
-    }
+      expect(find.byType(SpecialProfileCheckmark), findsNothing);
+      expect(find.byType(OgBetaBadge), findsOneWidget);
+    });
 
     testWidgets('hides a small count from a stranger', (
       tester,

--- a/mobile/test/widgets/video_feed_item/video_feed_item_meta_line_test.dart
+++ b/mobile/test/widgets/video_feed_item/video_feed_item_meta_line_test.dart
@@ -13,9 +13,12 @@ import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/utils/string_utils.dart';
+import 'package:openvine/widgets/og_beta_badge.dart';
+import 'package:openvine/widgets/special_profile_checkmark.dart';
 import 'package:openvine/widgets/video_feed_item/video_feed_item.dart';
 import 'package:reposts_repository/reposts_repository.dart';
 
+import '../../helpers/former_profile_checkmark_pubkeys.dart';
 import '../../helpers/test_provider_overrides.dart';
 
 const _authorPubkey =
@@ -37,6 +40,7 @@ AppLocalizations _l10n(WidgetTester tester) =>
     AppLocalizations.of(tester.element(find.byType(Scaffold).first));
 
 VideoEvent _video({
+  String pubkey = _authorPubkey,
   int? originalLoops,
   Map<String, String> rawTags = const {},
   int? createdAt,
@@ -44,7 +48,7 @@ VideoEvent _video({
   final at = createdAt ?? DateTime.now().millisecondsSinceEpoch ~/ 1000;
   return VideoEvent(
     id: 'video-card-meta-line-test-0123456789abcdef0123456789abcdef0123',
-    pubkey: _authorPubkey,
+    pubkey: pubkey,
     createdAt: at,
     content: 'caption',
     timestamp: DateTime.fromMillisecondsSinceEpoch(at * 1000, isUtc: true),
@@ -125,6 +129,17 @@ void main() {
   ).videoFeedLoopCountLine(StringUtils.formatCompactNumber(count), count);
 
   group('video card meta line', () {
+    for (final (index, pubkey) in formerProfileCheckmarkPubkeys.indexed) {
+      testWidgets('shows OG Beta Tester for former profile ${index + 1}', (
+        tester,
+      ) async {
+        await pump(tester, video: _video(pubkey: pubkey));
+
+        expect(find.byType(SpecialProfileCheckmark), findsNothing);
+        expect(find.byType(OgBetaBadge), findsOneWidget);
+      });
+    }
+
     testWidgets('hides a small count from a stranger', (
       tester,
     ) async {


### PR DESCRIPTION
Three non-team profiles currently display the same blue checkmark as Divine team members, which makes the badge's meaning ambiguous. After this change, those profiles show their existing green OG Beta Tester chit everywhere their name appears.

The cause was a second compiled-in allowlist alongside the team roster. This removes that legacy list and makes team membership the only input to the checkmark decision. Regression coverage pins both sides of the behavior across inline names, profile headers, and feed author rows: the three former exceptions do not show a checkmark, while team members still do.

This deliberately does not change OG Viner behavior, the frozen OG Beta Tester roster, NIP-58 badges, or badge precedence. The checkmark explainer was updated in all 22 locales to describe team accounts only.

Verification:
- flutter analyze lib test
- Focused config, widget, feed-row, profile-header, and localization tests (154 passing)
- Pre-push locale consistency, analyzer, and changed-file test suite

Closes #8235
