### PR TITLE
fix(video): stop duplicate source attempts while offline

### DIFF
--- a/mobile/lib/widgets/subtitle_editor/subtitle_editor_stage.dart
+++ b/mobile/lib/widgets/subtitle_editor/subtitle_editor_stage.dart
@@ -52,6 +52,9 @@ Future<void> loadSubtitlePreviewSources({
     sources: sources,
     log: log,
     isLoadCurrent: isLoadCurrent,
+    // Preserve the editor's pre-feed-policy behavior: an alternate rendition
+    // may still decode even when the first candidate does not.
+    stopOnTypedNonFailoverError: false,
     // The feed trims the loop seam; the editor cannot. Its timeline is drawn
     // from the container duration, so a clamp to the shorter of the two tracks
     // would put the last half-second of the axis out of the preview's reach —

--- a/mobile/lib/widgets/subtitle_editor/subtitle_editor_stage.dart
+++ b/mobile/lib/widgets/subtitle_editor/subtitle_editor_stage.dart
@@ -54,7 +54,7 @@ Future<void> loadSubtitlePreviewSources({
     isLoadCurrent: isLoadCurrent,
     // Preserve the editor's pre-feed-policy behavior: an alternate rendition
     // may still decode even when the first candidate does not.
-    stopOnTypedNonFailoverError: false,
+    applyTypedFailoverPolicy: false,
     // The feed trims the loop seam; the editor cannot. Its timeline is drawn
     // from the container duration, so a clamp to the shorter of the two tracks
     // would put the last half-second of the axis out of the preview's reach —

--- a/mobile/packages/infinite_video_feed/lib/src/utils/source_loader.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/utils/source_loader.dart
@@ -33,9 +33,10 @@ class SourceLoadAborted implements Exception {
 /// source fails.
 ///
 /// Authentication errors always stop the source ladder immediately. When
-/// [stopOnTypedNonFailoverError] is true, other typed player errors whose
-/// policy disallows failover also stop immediately and preserve their original
-/// error and stack trace.
+/// [applyTypedFailoverPolicy] is true, other typed player errors that cannot be
+/// fixed by changing sources also stop immediately and preserve their original
+/// error and stack trace. Media-processing errors remain eligible for fallback
+/// because another rendition may already be ready.
 ///
 /// [maxPlaybackDuration] becomes the clip's end position, so the native
 /// player stops (and loops) there. Sources shorter than the cap are
@@ -55,7 +56,7 @@ Future<(String, int)> setSourceWithFallbacks({
   bool Function()? isLoadCurrent,
   Duration? maxPlaybackDuration,
   bool trimToCommonTrackEnd = true,
-  bool stopOnTypedNonFailoverError = true,
+  bool applyTypedFailoverPolicy = true,
   Future<void> Function(Duration duration) delay = Future<void>.delayed,
   void Function(String source)? onFailoverSourceFailure,
   void Function(String source)? onSourceLoadFailure,
@@ -93,7 +94,7 @@ Future<(String, int)> setSourceWithFallbacks({
       final nativeErrorCode = nativePlayerErrorCodeFromError(error);
       final isTypedNonFailoverError =
           nativeErrorCode == NativePlayerErrorCode.authRequired ||
-          (stopOnTypedNonFailoverError &&
+          (applyTypedFailoverPolicy &&
               nativeErrorCode != null &&
               nativeErrorCode != NativePlayerErrorCode.unknown &&
               nativeErrorCode != NativePlayerErrorCode.mediaProcessing &&

--- a/mobile/packages/infinite_video_feed/lib/src/utils/source_loader.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/utils/source_loader.dart
@@ -32,6 +32,11 @@ class SourceLoadAborted implements Exception {
 /// Logs each failure via [log] and re-throws the last error when every
 /// source fails.
 ///
+/// Authentication errors always stop the source ladder immediately. When
+/// [stopOnTypedNonFailoverError] is true, other typed player errors whose
+/// policy disallows failover also stop immediately and preserve their original
+/// error and stack trace.
+///
 /// [maxPlaybackDuration] becomes the clip's end position, so the native
 /// player stops (and loops) there. Sources shorter than the cap are
 /// unaffected — both backends clamp the clip end to the real duration.
@@ -50,6 +55,7 @@ Future<(String, int)> setSourceWithFallbacks({
   bool Function()? isLoadCurrent,
   Duration? maxPlaybackDuration,
   bool trimToCommonTrackEnd = true,
+  bool stopOnTypedNonFailoverError = true,
   Future<void> Function(Duration duration) delay = Future<void>.delayed,
   void Function(String source)? onFailoverSourceFailure,
   void Function(String source)? onSourceLoadFailure,
@@ -86,10 +92,12 @@ Future<(String, int)> setSourceWithFallbacks({
       onSourceLoadFailure?.call(source);
       final nativeErrorCode = nativePlayerErrorCodeFromError(error);
       final isTypedNonFailoverError =
-          nativeErrorCode != null &&
-          nativeErrorCode != NativePlayerErrorCode.unknown &&
-          nativeErrorCode != NativePlayerErrorCode.mediaProcessing &&
-          !nativeErrorCode.shouldFailover;
+          nativeErrorCode == NativePlayerErrorCode.authRequired ||
+          (stopOnTypedNonFailoverError &&
+              nativeErrorCode != null &&
+              nativeErrorCode != NativePlayerErrorCode.unknown &&
+              nativeErrorCode != NativePlayerErrorCode.mediaProcessing &&
+              !nativeErrorCode.shouldFailover);
       if (isTypedNonFailoverError) {
         log(
           'Source failed without failover index $index: '

--- a/mobile/packages/infinite_video_feed/lib/src/utils/source_loader.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/utils/source_loader.dart
@@ -85,7 +85,12 @@ Future<(String, int)> setSourceWithFallbacks({
       lastStackTrace = stackTrace;
       onSourceLoadFailure?.call(source);
       final nativeErrorCode = nativePlayerErrorCodeFromError(error);
-      if (nativeErrorCode == NativePlayerErrorCode.authRequired) {
+      final isTypedNonFailoverError =
+          nativeErrorCode != null &&
+          nativeErrorCode != NativePlayerErrorCode.unknown &&
+          nativeErrorCode != NativePlayerErrorCode.mediaProcessing &&
+          !nativeErrorCode.shouldFailover;
+      if (isTypedNonFailoverError) {
         log(
           'Source failed without failover index $index: '
           'failedSource=$source '

--- a/mobile/packages/infinite_video_feed/test/src/utils/source_loader_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/utils/source_loader_test.dart
@@ -278,30 +278,45 @@ void main() {
       },
     );
 
-    test('does not record transient timeout failure before failover', () async {
-      final controller = _RecordingControllerWithFailures(
-        (_) {},
-        failures: [
-          PlatformException(
-            code: 'PLAYER_ERROR',
-            message: 'timeout',
-            details: const <String, Object?>{'errorCode': 'timeout'},
+    for (final errorCode in [
+      NativePlayerErrorCode.networkError,
+      NativePlayerErrorCode.timeout,
+      NativePlayerErrorCode.decoderError,
+    ]) {
+      test('does not fail over typed ${errorCode.name} failures', () async {
+        final clips = <VideoClip>[];
+        final error = PlatformException(
+          code: 'PLAYER_ERROR',
+          message: errorCode.name,
+          details: <String, Object?>{
+            'errorCode': switch (errorCode) {
+              NativePlayerErrorCode.networkError => 'network_error',
+              NativePlayerErrorCode.timeout => 'timeout',
+              NativePlayerErrorCode.decoderError => 'decoder_error',
+              _ => throw StateError('unsupported test case'),
+            },
+          },
+        );
+        final controller = _RecordingControllerWithFailures(
+          clips.add,
+          failures: [error],
+        );
+        addTearDown(controller.dispose);
+
+        await expectLater(
+          () => setSourceWithFallbacks(
+            index: 2,
+            controller: controller,
+            sources: ['derivedMp4', 'hlsUrl'],
+            log: logs.add,
           ),
-        ],
-      );
-      addTearDown(controller.dispose);
-      final recordedFailures = <String>[];
+          throwsA(same(error)),
+        );
 
-      await setSourceWithFallbacks(
-        index: 2,
-        controller: controller,
-        sources: ['derivedMp4', 'hlsUrl'],
-        log: logs.add,
-        onFailoverSourceFailure: recordedFailures.add,
-      );
-
-      expect(recordedFailures, isEmpty);
-    });
+        expect(clips.map((clip) => clip.uri), equals(['derivedMp4']));
+        expect(logs.single, contains('Source failed without failover'));
+      });
+    }
 
     test('uses source headers when retrying after HTTP 202', () async {
       final clips = <VideoClip>[];

--- a/mobile/packages/infinite_video_feed/test/src/utils/source_loader_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/utils/source_loader_test.dart
@@ -250,16 +250,29 @@ void main() {
       expect(recordedFailures, equals(['processingUrl']));
     });
 
-    test(
-      'records typed failover-class source failure before failover',
-      () async {
+    for (final errorCode in [
+      NativePlayerErrorCode.httpClientError,
+      NativePlayerErrorCode.httpServerError,
+      NativePlayerErrorCode.ioError,
+      NativePlayerErrorCode.parseError,
+    ]) {
+      test('fails over typed ${errorCode.name} failures', () async {
+        final clips = <VideoClip>[];
         final controller = _RecordingControllerWithFailures(
-          (_) {},
+          clips.add,
           failures: [
             PlatformException(
               code: 'PLAYER_ERROR',
-              message: 'ERROR_CODE_IO_UNSPECIFIED',
-              details: const <String, Object?>{'errorCode': 'io_error'},
+              message: errorCode.name,
+              details: <String, Object?>{
+                'errorCode': switch (errorCode) {
+                  NativePlayerErrorCode.httpClientError => 'http_client_error',
+                  NativePlayerErrorCode.httpServerError => 'http_server_error',
+                  NativePlayerErrorCode.ioError => 'io_error',
+                  NativePlayerErrorCode.parseError => 'parse_error',
+                  _ => throw StateError('unsupported test case'),
+                },
+              },
             ),
           ],
         );
@@ -274,9 +287,10 @@ void main() {
           onFailoverSourceFailure: recordedFailures.add,
         );
 
+        expect(clips.map((clip) => clip.uri), equals(['derivedMp4', 'hlsUrl']));
         expect(recordedFailures, equals(['derivedMp4']));
-      },
-    );
+      });
+    }
 
     for (final errorCode in [
       NativePlayerErrorCode.networkError,
@@ -435,6 +449,42 @@ void main() {
       expect(logs.single, contains('Source failed without failover'));
       expect(logs.single, contains('code=NativePlayerErrorCode.authRequired'));
     });
+
+    test(
+      'preserves the original stack trace for non-failover errors',
+      () async {
+        final error = PlatformException(
+          code: 'PLAYER_ERROR',
+          details: const <String, Object?>{'errorCode': 'network_error'},
+        );
+        final originalStackTrace = StackTrace.current;
+        final controller = _StackTraceController(
+          error: error,
+          stackTrace: originalStackTrace,
+        );
+        addTearDown(controller.dispose);
+
+        Object? caughtError;
+        StackTrace? caughtStackTrace;
+        try {
+          await setSourceWithFallbacks(
+            index: 0,
+            controller: controller,
+            sources: ['optimizedUrl', 'hlsUrl'],
+            log: logs.add,
+          );
+        } on Object catch (error, stackTrace) {
+          caughtError = error;
+          caughtStackTrace = stackTrace;
+        }
+
+        expect(caughtError, same(error));
+        expect(
+          caughtStackTrace.toString(),
+          equals(originalStackTrace.toString()),
+        );
+      },
+    );
 
     test('uses headers returned for the successful failover source', () async {
       final clips = <VideoClip>[];
@@ -618,6 +668,18 @@ class _RecordingControllerWithFailures extends FakeController {
       throw failures[attempts++];
     }
     attempts++;
+  }
+}
+
+class _StackTraceController extends FakeController {
+  _StackTraceController({required this.error, required this.stackTrace});
+
+  final Object error;
+  final StackTrace stackTrace;
+
+  @override
+  Future<void> setSource(VideoClip clip) async {
+    Error.throwWithStackTrace(error, stackTrace);
   }
 }
 

--- a/mobile/packages/infinite_video_feed/test/src/utils/source_loader_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/utils/source_loader_test.dart
@@ -332,6 +332,31 @@ void main() {
       });
     }
 
+    test('allows non-feed callers to retain typed source fallback', () async {
+      final clips = <VideoClip>[];
+      final controller = _RecordingControllerWithFailures(
+        clips.add,
+        failures: [
+          PlatformException(
+            code: 'PLAYER_ERROR',
+            details: const <String, Object?>{'errorCode': 'decoder_error'},
+          ),
+        ],
+      );
+      addTearDown(controller.dispose);
+
+      final result = await setSourceWithFallbacks(
+        index: 2,
+        controller: controller,
+        sources: ['derivedMp4', 'hlsUrl'],
+        log: logs.add,
+        stopOnTypedNonFailoverError: false,
+      );
+
+      expect(result, equals(('hlsUrl', 1)));
+      expect(clips.map((clip) => clip.uri), equals(['derivedMp4', 'hlsUrl']));
+    });
+
     test('uses source headers when retrying after HTTP 202', () async {
       final clips = <VideoClip>[];
       final controller = _RecordingControllerWithFailures(

--- a/mobile/packages/infinite_video_feed/test/src/utils/source_loader_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/utils/source_loader_test.dart
@@ -202,11 +202,18 @@ void main() {
       expect(logs.single, contains('retrySource=rawUrl'));
     });
 
-    test('advances immediately on HTTP 202 when a fallback remains', () async {
+    test('fails over typed media-processing errors immediately', () async {
       final clips = <VideoClip>[];
       final controller = _RecordingControllerWithFailures(
         clips.add,
-        failures: [Exception('CoreMediaErrorDomain error -12667 - HTTP 202')],
+        failures: [
+          PlatformException(
+            code: 'PLAYER_ERROR',
+            details: const <String, Object?>{
+              'errorCode': 'media_processing',
+            },
+          ),
+        ],
       );
       addTearDown(controller.dispose);
 

--- a/mobile/packages/infinite_video_feed/test/src/utils/source_loader_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/utils/source_loader_test.dart
@@ -350,7 +350,7 @@ void main() {
         controller: controller,
         sources: ['derivedMp4', 'hlsUrl'],
         log: logs.add,
-        stopOnTypedNonFailoverError: false,
+        applyTypedFailoverPolicy: false,
       );
 
       expect(result, equals(('hlsUrl', 1)));
@@ -446,34 +446,41 @@ void main() {
       },
     );
 
-    test('does not fail over typed auth-required errors', () async {
-      final clips = <VideoClip>[];
-      final authError = PlatformException(
-        code: 'COMPOSITION_ERROR',
-        message: 'NSURLErrorDomain error -1013',
-        details: const <String, Object?>{'errorCode': 'auth_required'},
-      );
-      final controller = _RecordingControllerWithFailures(
-        clips.add,
-        failures: [authError],
-      );
-      addTearDown(controller.dispose);
+    test(
+      'keeps auth terminal when typed failover policy is disabled',
+      () async {
+        final clips = <VideoClip>[];
+        final authError = PlatformException(
+          code: 'COMPOSITION_ERROR',
+          message: 'NSURLErrorDomain error -1013',
+          details: const <String, Object?>{'errorCode': 'auth_required'},
+        );
+        final controller = _RecordingControllerWithFailures(
+          clips.add,
+          failures: [authError],
+        );
+        addTearDown(controller.dispose);
 
-      await expectLater(
-        () => setSourceWithFallbacks(
-          index: 0,
-          controller: controller,
-          sources: ['optimizedUrl', 'hlsUrl'],
-          log: logs.add,
-        ),
-        throwsA(same(authError)),
-      );
+        await expectLater(
+          () => setSourceWithFallbacks(
+            index: 0,
+            controller: controller,
+            sources: ['optimizedUrl', 'hlsUrl'],
+            log: logs.add,
+            applyTypedFailoverPolicy: false,
+          ),
+          throwsA(same(authError)),
+        );
 
-      expect(clips.map((clip) => clip.uri), equals(['optimizedUrl']));
-      expect(logs, hasLength(1));
-      expect(logs.single, contains('Source failed without failover'));
-      expect(logs.single, contains('code=NativePlayerErrorCode.authRequired'));
-    });
+        expect(clips.map((clip) => clip.uri), equals(['optimizedUrl']));
+        expect(logs, hasLength(1));
+        expect(logs.single, contains('Source failed without failover'));
+        expect(
+          logs.single,
+          contains('code=NativePlayerErrorCode.authRequired'),
+        );
+      },
+    );
 
     test(
       'preserves the original stack trace for non-failover errors',

--- a/mobile/test/widgets/subtitle_editor/subtitle_editor_stage_test.dart
+++ b/mobile/test/widgets/subtitle_editor/subtitle_editor_stage_test.dart
@@ -6,6 +6,7 @@ import 'dart:io';
 
 import 'package:divine_video_player/divine_video_player.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:infinite_video_feed/infinite_video_feed.dart';
 import 'package:openvine/blocs/subtitle_editor/subtitle_editor_cubit.dart';
@@ -326,6 +327,23 @@ void main() {
       expect(controller.lastSource?.trimToCommonTrackEnd, isFalse);
       expect(controller.lastSource?.end, isNull);
     });
+
+    test('tries another rendition after a typed decoder failure', () async {
+      final controller = _DecoderFailureController();
+      addTearDown(controller.dispose);
+
+      await loadSubtitlePreviewSources(
+        controller: controller,
+        sources: const ['https://example.com/720p.mp4', 'hlsUrl'],
+        log: (_) {},
+        isLoadCurrent: () => true,
+      );
+
+      expect(
+        controller.sources.map((source) => source.uri),
+        equals(['https://example.com/720p.mp4', 'hlsUrl']),
+      );
+    });
   });
 }
 
@@ -342,6 +360,30 @@ class _RecordingController extends DivineVideoPlayerController {
 
   @override
   Future<void> setSource(VideoClip clip) async => lastSource = clip;
+
+  @override
+  Future<void> dispose() async {}
+}
+
+class _DecoderFailureController extends DivineVideoPlayerController {
+  final List<VideoClip> sources = [];
+
+  @override
+  int get playerId => 0;
+
+  @override
+  Future<void> initialize() async {}
+
+  @override
+  Future<void> setSource(VideoClip clip) async {
+    sources.add(clip);
+    if (sources.length == 1) {
+      throw PlatformException(
+        code: 'PLAYER_ERROR',
+        details: const <String, Object?>{'errorCode': 'decoder_error'},
+      );
+    }
+  }
 
   @override
   Future<void> dispose() async {}


### PR DESCRIPTION
## Problem
When a video was not cached and the device went offline, initial playback tried both MP4 and HLS sources even though the native player had already reported a network failure. Automatic retries repeated that guaranteed-to-fail source ladder and created unnecessary players and requests.

## Why this fix
Initial source loading now honors the same typed failover policy used by runtime playback. Network, timeout, authentication, and decoder errors stop immediately and preserve the original exception; source-specific failures can still advance to another rendition.

## Deliberately unchanged
Media-processing responses can still advance to an available fallback, and unknown legacy errors retain the existing best-effort fallback behavior.

## Verification
- `flutter test packages/infinite_video_feed/test/src/utils/source_loader_test.dart` (30 tests)
- `flutter test` in `packages/infinite_video_feed` (263 tests)
- `flutter test test/widgets/subtitle_editor/` (16 tests)
- Package and targeted app analysis
- Pre-push analyzer and changed-file tests

Closes #8241
