### PR TITLE
fix(db): stop startup when the local database format is unknown

### DIFF
--- a/mobile/lib/services/database_encryption_bootstrap.dart
+++ b/mobile/lib/services/database_encryption_bootstrap.dart
@@ -128,6 +128,9 @@ class DatabaseEncryptionBootstrap {
   ///   corrupt. Distinct from the deferral above: that one hands back a `null`
   ///   key for a database that genuinely is readable plaintext, this one has no
   ///   readable database to hand a key for.
+  /// * [DatabaseClassificationException] when a transient SQLite failure left
+  ///   the existing file format unknown. Startup fails closed and preserves
+  ///   both the database and cipher key for a later retry.
   ///
   /// Must run before the first `AppDatabase` open.
   Future<String?> resolveCipherKey() async {
@@ -441,6 +444,7 @@ const _sqliteNotADb = 26;
 /// unusable.
 bool shouldRepairLocalDatabaseCacheAfterBootstrapError(Object error) {
   if (error is DatabaseCipherUnavailableError) return false;
+  if (error is DatabaseClassificationException) return false;
   // The database is fine; only the keystore holding its key was unreachable.
   // Repairing would delete that key and strand a recoverable database.
   if (error is DatabaseCipherStorageUnavailableException) return false;

--- a/mobile/lib/startup/database_bootstrap_failure_app.dart
+++ b/mobile/lib/startup/database_bootstrap_failure_app.dart
@@ -1,3 +1,4 @@
+import 'package:db_client/db_client.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -464,6 +465,10 @@ enum DatabaseBootstrapDiagnosis {
   /// recognizably encrypted.
   databaseUnreadable('db-unreadable'),
 
+  /// A transient SQLite failure prevented the file format from being safely
+  /// classified. Restarting may recover; deleting data is not justified.
+  classificationUnavailable('db-classification-unavailable'),
+
   /// Anything else. Read the exception from Crashlytics for this one.
   bootstrapFailed('db-bootstrap-failed');
 
@@ -492,7 +497,7 @@ enum DatabaseBootstrapDiagnosis {
   /// choice deliberately instead of defaulting into a destructive offer.
   bool get allowsLocalDatabaseReset => switch (this) {
     cipherMismatch || databaseUnreadable || bootstrapFailed => true,
-    cipherUnavailable || secureStorage => false,
+    cipherUnavailable || secureStorage || classificationUnavailable => false,
   };
 }
 
@@ -514,6 +519,9 @@ DatabaseBootstrapDiagnosis databaseBootstrapDiagnosis(Object error) {
   }
   if (error is DatabaseUnreadableError) {
     return DatabaseBootstrapDiagnosis.databaseUnreadable;
+  }
+  if (error is DatabaseClassificationException) {
+    return DatabaseBootstrapDiagnosis.classificationUnavailable;
   }
 
   final message = error.toString();

--- a/mobile/packages/db_client/lib/src/database/connection/connection_native.dart
+++ b/mobile/packages/db_client/lib/src/database/connection/connection_native.dart
@@ -499,6 +499,36 @@ enum CipherMigrationOutcome {
   unreadable,
 }
 
+/// The keyless classifier operation that could not determine the database
+/// format.
+enum DatabaseClassificationStage {
+  openDatabase,
+  readSchema,
+}
+
+/// A transient SQLite failure left the existing database format unknown.
+///
+/// Callers must fail closed: the file may be plaintext or encrypted, so
+/// opening it with either assumption can corrupt data or strand the session.
+/// The diagnostic fields intentionally omit the database path and SQL text.
+class DatabaseClassificationException implements Exception {
+  const DatabaseClassificationException({
+    required this.stage,
+    required this.resultCode,
+    required this.extendedResultCode,
+  });
+
+  final DatabaseClassificationStage stage;
+  final int resultCode;
+  final int extendedResultCode;
+
+  @override
+  String toString() =>
+      'DatabaseClassificationException: stage=${stage.name}, '
+      'resultCode=$resultCode, extendedResultCode=$extendedResultCode; '
+      'refusing to open an unclassified database.';
+}
+
 /// One-time in-place rekey of the existing **plaintext** `divine_db.db` into a
 /// SQLite3MultipleCiphers-encrypted database.
 ///
@@ -517,8 +547,10 @@ enum CipherMigrationOutcome {
 /// while copying the rest of it — which no retry can fix, so the caller must
 /// fail closed rather than open it unkeyed.
 ///
-/// Requires SQLite3MultipleCiphers; returns [CipherMigrationOutcome.failed]
-/// when it is not linked, leaving the source intact.
+/// Throws [DatabaseClassificationException] when a transient SQLite failure
+/// leaves the existing file format unknown. Requires SQLite3MultipleCiphers;
+/// returns [CipherMigrationOutcome.failed] when it is not linked, leaving the
+/// proven-readable plaintext source intact.
 Future<CipherMigrationOutcome> migratePlaintextToEncrypted({
   required String rawKeyHex,
   String? databasePath,
@@ -558,12 +590,6 @@ Future<CipherMigrationOutcome> migratePlaintextToEncrypted({
       return CipherMigrationOutcome.alreadyEncrypted;
     case _DbClassification.corrupt:
       return CipherMigrationOutcome.unreadable;
-    case _DbClassification.indeterminate:
-      // A transient error (busy, locked, I/O) — do NOT assume "encrypted",
-      // which would trigger the key-loss recovery path on a readable plaintext
-      // DB. Leave everything intact and retry next launch, when the contention
-      // or the I/O fault is likely gone.
-      return CipherMigrationOutcome.failed;
     case _DbClassification.emptyPlaintext:
       deleteDatabaseAndSidecars(dbPath);
       return CipherMigrationOutcome.removedEmptyPlaintext;
@@ -618,9 +644,6 @@ enum _DbClassification {
   /// not `SQLite format 3`, so it always reports `SQLITE_NOTADB` — which makes
   /// this a plaintext-shaped file that no key can rescue.
   corrupt,
-
-  /// Something transient stopped the classification (busy, locked, I/O).
-  indeterminate,
 }
 
 /// Classifies [dbPath] by opening it **without** a key. A plaintext database
@@ -637,7 +660,10 @@ _DbClassification _classifyDatabase(String dbPath) {
   try {
     db = sqlite3.open(dbPath, mode: OpenMode.readOnly);
   } on SqliteException catch (e) {
-    return _classifyKeylessFailure(e);
+    return _classifyKeylessFailure(
+      e,
+      stage: DatabaseClassificationStage.openDatabase,
+    );
   }
 
   try {
@@ -650,18 +676,27 @@ _DbClassification _classifyDatabase(String dbPath) {
         ? _DbClassification.emptyPlaintext
         : _DbClassification.populatedPlaintext;
   } on SqliteException catch (e) {
-    return _classifyKeylessFailure(e);
+    return _classifyKeylessFailure(
+      e,
+      stage: DatabaseClassificationStage.readSchema,
+    );
   } finally {
     db.close();
   }
 }
 
-_DbClassification _classifyKeylessFailure(SqliteException e) =>
-    switch (e.resultCode) {
-      _sqliteNotADb => _DbClassification.encrypted,
-      _sqliteCorrupt => _DbClassification.corrupt,
-      _ => _DbClassification.indeterminate,
-    };
+_DbClassification _classifyKeylessFailure(
+  SqliteException error, {
+  required DatabaseClassificationStage stage,
+}) => switch (error.resultCode) {
+  _sqliteNotADb => _DbClassification.encrypted,
+  _sqliteCorrupt => _DbClassification.corrupt,
+  _ => throw DatabaseClassificationException(
+    stage: stage,
+    resultCode: error.resultCode,
+    extendedResultCode: error.extendedResultCode,
+  ),
+};
 
 /// Maps a rekey failure to an outcome, on the same result-code split
 /// [_classifyKeylessFailure] applies one step earlier.

--- a/mobile/packages/db_client/lib/src/database/connection/connection_stub.dart
+++ b/mobile/packages/db_client/lib/src/database/connection/connection_stub.dart
@@ -56,6 +56,20 @@ enum CipherMigrationOutcome {
   unreadable,
 }
 
+enum DatabaseClassificationStage { openDatabase, readSchema }
+
+class DatabaseClassificationException implements Exception {
+  const DatabaseClassificationException({
+    required this.stage,
+    required this.resultCode,
+    required this.extendedResultCode,
+  });
+
+  final DatabaseClassificationStage stage;
+  final int resultCode;
+  final int extendedResultCode;
+}
+
 /// Stub implementation - will be replaced by conditional imports
 Future<CipherMigrationOutcome> migratePlaintextToEncrypted({
   required String rawKeyHex,

--- a/mobile/packages/db_client/lib/src/database/connection/connection_web.dart
+++ b/mobile/packages/db_client/lib/src/database/connection/connection_web.dart
@@ -85,6 +85,20 @@ enum CipherMigrationOutcome {
   unreadable,
 }
 
+enum DatabaseClassificationStage { openDatabase, readSchema }
+
+class DatabaseClassificationException implements Exception {
+  const DatabaseClassificationException({
+    required this.stage,
+    required this.resultCode,
+    required this.extendedResultCode,
+  });
+
+  final DatabaseClassificationStage stage;
+  final int resultCode;
+  final int extendedResultCode;
+}
+
 /// Native plaintext→encrypted migration does not apply on web. Never reached
 /// at runtime (guarded by `kIsWeb` in the app).
 Future<CipherMigrationOutcome> migratePlaintextToEncrypted({

--- a/mobile/packages/db_client/test/src/database/connection/connection_native_test.dart
+++ b/mobile/packages/db_client/test/src/database/connection/connection_native_test.dart
@@ -1325,6 +1325,30 @@ void main() {
       );
     });
 
+    test('fails closed when the keyless classification is locked', () async {
+      _createSqliteDatabase(dbPath, draftCount: 1);
+      final lockHolder = sqlite3.open(dbPath)..execute('BEGIN EXCLUSIVE;');
+      addTearDown(() {
+        lockHolder
+          ..execute('ROLLBACK;')
+          ..close();
+      });
+
+      await expectLater(
+        migratePlaintextToEncrypted(rawKeyHex: validKey, databasePath: dbPath),
+        throwsA(
+          isA<DatabaseClassificationException>()
+              .having(
+                (error) => error.stage,
+                'stage',
+                DatabaseClassificationStage.readSchema,
+              )
+              .having((error) => error.resultCode, 'resultCode', 5),
+        ),
+      );
+      expect(File(dbPath).existsSync(), isTrue);
+    });
+
     test(
       'migrates a populated plaintext DB to encrypted raw-key storage',
       () async {

--- a/mobile/test/services/database_encryption_bootstrap_test.dart
+++ b/mobile/test/services/database_encryption_bootstrap_test.dart
@@ -605,6 +605,30 @@ void main() {
       expect(await bootstrap.resolveCipherKey(), isNull);
     });
 
+    test(
+      'fails closed and preserves the key when classification is unknown',
+      () async {
+        const existing =
+            '2dd29ca851e7b56e4697b0e1f08507293d761a05ce4d1b628663f411a8086d99';
+        const error = DatabaseClassificationException(
+          stage: DatabaseClassificationStage.readSchema,
+          resultCode: 5,
+          extendedResultCode: 5,
+        );
+        store[dbCipherKeyStorageKey] = existing;
+        final bootstrap = DatabaseEncryptionBootstrap(
+          secureStorage: storage,
+          ensureRuntime: () async {},
+          isCipherAvailable: () => true,
+          migrate: (_) async => throw error,
+          deleteDatabase: () async {},
+        );
+
+        await expectLater(bootstrap.resolveCipherKey(), throwsA(same(error)));
+        expect(store[dbCipherKeyStorageKey], existing);
+      },
+    );
+
     test('fails closed instead of handing back a null key for an unreadable '
         'database', () async {
       // The gap #6897 closes: this used to share the plaintext deferral's

--- a/mobile/test/startup/database_bootstrap_failure_app_test.dart
+++ b/mobile/test/startup/database_bootstrap_failure_app_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:db_client/db_client.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -333,6 +334,20 @@ void main() {
         databaseBootstrapDiagnosticCode(const DatabaseUnreadableError()),
         equals('db-unreadable'),
       );
+    });
+
+    test('classifies an indeterminate database without offering reset', () {
+      const error = DatabaseClassificationException(
+        stage: DatabaseClassificationStage.readSchema,
+        resultCode: 5,
+        extendedResultCode: 5,
+      );
+
+      expect(
+        databaseBootstrapDiagnosticCode(error),
+        equals('db-classification-unavailable'),
+      );
+      expect(databaseBootstrapDiagnosis(error).allowsLocalDatabaseReset, false);
     });
 
     test('falls back to the catch-all for unrecognized failures', () {


### PR DESCRIPTION
## Problem
A transient SQLite failure during startup could leave the local database format unknown, but the app treated that state as readable plaintext and opened the file without a cipher key. On an encrypted database, every database-backed feature then failed for the rest of the session.

## Why this fix
The classifier now raises a typed failure containing only the safe classification stage and SQLite result codes. Startup therefore follows the existing fail-closed path while preserving both the database and its stored key. The failure screen identifies this as a restartable classification problem and does not offer a destructive reset.

## Deliberately unchanged
Readable plaintext databases may still open without a key for one launch when an encryption migration fails after classification. Existing encrypted, corrupt, and key-loss recovery behavior is unchanged.

## Verification
- `flutter test packages/db_client/test/src/database/connection/connection_native_test.dart test/services/database_encryption_bootstrap_test.dart test/startup/database_bootstrap_failure_app_test.dart` (137 tests)
- `flutter analyze`
- Pre-push analyzer and changed-file tests

Closes #8240