### PR TITLE
fix(db): tell iOS users how to restart after database failures

### DIFF
--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -4291,7 +4291,6 @@
     "databaseCorruptionTitle": "የአካባቢዎ ውሂብ ተበላሽቷል",
     "databaseCorruptionBody": "Divine ን ዘግተው እንደገና ይክፈቱት — በራስ-ሰር እናስተካክለዋለን። የቻልነውን ያህል ረቂቆችዎን እና ክሊፖችዎን እናስቀራለን፣ የቀረው እንደገና ይጫናል።",
     "databaseCorruptionCloseButton": "Divine ን ዝጋ",
-    "databaseCloseManual": "Divineን ከመሣሪያዎ ይዝጉት፣ ከዚያ እንደገና ይክፈቱት።",
     "videoDetailContextTitle": "የተጋራ ቪዲዮ",
     "videoDetailCloseSemanticLabel": "የቪዲዮ ማጫወቻን ዝጋ",
     "metadataHashtagChipTapHint": "#{hashtag}። ይህን ሃሽታግ ያላቸውን ቪዲዮዎች ለማየት መታ ያድርጉ።",

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -4291,6 +4291,7 @@
     "databaseCorruptionTitle": "የአካባቢዎ ውሂብ ተበላሽቷል",
     "databaseCorruptionBody": "Divine ን ዘግተው እንደገና ይክፈቱት — በራስ-ሰር እናስተካክለዋለን። የቻልነውን ያህል ረቂቆችዎን እና ክሊፖችዎን እናስቀራለን፣ የቀረው እንደገና ይጫናል።",
     "databaseCorruptionCloseButton": "Divine ን ዝጋ",
+    "databaseCloseManual": "Divineን ከመሣሪያዎ ይዝጉት፣ ከዚያ እንደገና ይክፈቱት።",
     "videoDetailContextTitle": "የተጋራ ቪዲዮ",
     "videoDetailCloseSemanticLabel": "የቪዲዮ ማጫወቻን ዝጋ",
     "metadataHashtagChipTapHint": "#{hashtag}። ይህን ሃሽታግ ያላቸውን ቪዲዮዎች ለማየት መታ ያድርጉ።",

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -4948,7 +4948,7 @@
     "dbFailureResetAction": "የአካባቢ ዳታቤዝ ዳግም አስጀምር",
     "dbFailureConfirmTitle": "የአካባቢ ዳታቤዝዎን ዳግም ያስጀምሩ?",
     "dbFailureConfirmBody": "መለያዎ ይቀራል። በዚህ መሣሪያ ላይ የተቀመጡ ረቂቆች እና ክሊፖች ይሰረዛሉ — መልእክቶች እና ምግቦች ከአውታረ መረቡ ይመለሳሉ።",
-    "dbFailureResetConfirm": "ዳግም አስጀምር እና ዝጋ",
+    "dbFailureResetConfirm": "የአካባቢ ዳታቤዝ አሁን ዳግም አስጀምር",
     "dbFailureCancel": "ሰርዝ",
     "dbFailureResetFailed": "ያ አልሰራም። Divineን ዘግተው እንደገና ይሞክሩ።",
     "dbFailureResetDoneTitle": "የአካባቢ ዳታቤዝ ዳግም ተጀምሯል",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -4166,6 +4166,7 @@
     "databaseCorruptionTitle": "بياناتك المحلية تعرضت للتلف",
     "databaseCorruptionBody": "أغلق Divine وافتحه من جديد — سنصلح ذلك تلقائيًا. سنحفظ ما نستطيع من مسوداتك ومقاطعك، وسيُعاد تحميل الباقي.",
     "databaseCorruptionCloseButton": "إغلاق Divine",
+    "databaseCloseManual": "أغلق Divine من جهازك، ثم افتحه مجددًا.",
     "videoDetailContextTitle": "فيديو تمت مشاركته",
     "videoDetailCloseSemanticLabel": "إغلاق مشغل الفيديو",
     "metadataHashtagChipTapHint": "#{hashtag}. اضغط لعرض الفيديوهات بهذا الوسم.",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -4823,7 +4823,7 @@
     "dbFailureResetAction": "إعادة تعيين قاعدة البيانات المحلية",
     "dbFailureConfirmTitle": "إعادة تعيين قاعدة البيانات المحلية؟",
     "dbFailureConfirmBody": "يبقى حسابك. تُحذف المسودات والمقاطع المحفوظة على هذا الجهاز — أما الرسائل والخلاصات فتعود من الشبكة.",
-    "dbFailureResetConfirm": "إعادة التعيين والإغلاق",
+    "dbFailureResetConfirm": "إعادة تعيين قاعدة البيانات المحلية الآن",
     "dbFailureCancel": "إلغاء",
     "dbFailureResetFailed": "لم ينجح ذلك. أغلق Divine وحاول مرة أخرى.",
     "dbFailureResetDoneTitle": "تمت إعادة تعيين قاعدة البيانات المحلية",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -4166,7 +4166,6 @@
     "databaseCorruptionTitle": "بياناتك المحلية تعرضت للتلف",
     "databaseCorruptionBody": "أغلق Divine وافتحه من جديد — سنصلح ذلك تلقائيًا. سنحفظ ما نستطيع من مسوداتك ومقاطعك، وسيُعاد تحميل الباقي.",
     "databaseCorruptionCloseButton": "إغلاق Divine",
-    "databaseCloseManual": "أغلق Divine من جهازك، ثم افتحه مجددًا.",
     "videoDetailContextTitle": "فيديو تمت مشاركته",
     "videoDetailCloseSemanticLabel": "إغلاق مشغل الفيديو",
     "metadataHashtagChipTapHint": "#{hashtag}. اضغط لعرض الفيديوهات بهذا الوسم.",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -4297,7 +4297,6 @@
     "databaseCorruptionTitle": "Локалните ти данни се повредиха",
     "databaseCorruptionBody": "Затвори Divine и го отвори пак — ще го поправим автоматично. Ще запазим каквото можем от черновите и клиповете ти, останалото се презарежда.",
     "databaseCorruptionCloseButton": "Затвори Divine",
-    "databaseCloseManual": "Затвори Divine от устройството си, след което го отвори отново.",
     "videoDetailContextTitle": "Споделено видео",
     "videoDetailCloseSemanticLabel": "Затворете видеоплейъра",
     "metadataHashtagChipTapHint": "#{hashtag}. Докосни, за да видиш видеа с този хаштаг.",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -4297,6 +4297,7 @@
     "databaseCorruptionTitle": "Локалните ти данни се повредиха",
     "databaseCorruptionBody": "Затвори Divine и го отвори пак — ще го поправим автоматично. Ще запазим каквото можем от черновите и клиповете ти, останалото се презарежда.",
     "databaseCorruptionCloseButton": "Затвори Divine",
+    "databaseCloseManual": "Затвори Divine от устройството си, след което го отвори отново.",
     "videoDetailContextTitle": "Споделено видео",
     "videoDetailCloseSemanticLabel": "Затворете видеоплейъра",
     "metadataHashtagChipTapHint": "#{hashtag}. Докосни, за да видиш видеа с този хаштаг.",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -4954,7 +4954,7 @@
     "dbFailureResetAction": "нулирай локалната база данни",
     "dbFailureConfirmTitle": "да нулираме ли локалната база данни?",
     "dbFailureConfirmBody": "Акаунтът ти остава. Черновите и клиповете, запазени на това устройство, се изтриват — съобщенията и емисиите се връщат от мрежата.",
-    "dbFailureResetConfirm": "нулирай и затвори",
+    "dbFailureResetConfirm": "нулирай локалната база данни сега",
     "dbFailureCancel": "отказ",
     "dbFailureResetFailed": "Това не сработи. Затвори Divine и опитай отново.",
     "dbFailureResetDoneTitle": "локалната база данни е нулирана",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -4823,7 +4823,7 @@
     "dbFailureResetAction": "Lokale Datenbank zurücksetzen",
     "dbFailureConfirmTitle": "Lokale Datenbank zurücksetzen?",
     "dbFailureConfirmBody": "Dein Konto bleibt. Auf diesem Gerät gespeicherte Entwürfe und Clips werden gelöscht — Nachrichten und Feeds kommen aus dem Netzwerk zurück.",
-    "dbFailureResetConfirm": "Zurücksetzen und schließen",
+    "dbFailureResetConfirm": "Lokale Datenbank jetzt zurücksetzen",
     "dbFailureCancel": "Abbrechen",
     "dbFailureResetFailed": "Das hat nicht geklappt. Schließe Divine und versuche es erneut.",
     "dbFailureResetDoneTitle": "Lokale Datenbank zurückgesetzt",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -4166,6 +4166,7 @@
     "databaseCorruptionTitle": "Deine lokalen Daten sind beschädigt",
     "databaseCorruptionBody": "Schließ Divine und öffne es neu — wir reparieren das automatisch. Wir retten so viel wie möglich von deinen Entwürfen und Clips, alles andere lädt neu.",
     "databaseCorruptionCloseButton": "Divine schließen",
+    "databaseCloseManual": "Schließe Divine auf deinem Gerät und öffne es dann erneut.",
     "videoDetailContextTitle": "Geteiltes Video",
     "videoDetailCloseSemanticLabel": "Videoplayer schließen",
     "metadataHashtagChipTapHint": "#{hashtag}. Tippen, um Videos mit diesem Hashtag anzusehen.",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -4166,7 +4166,6 @@
     "databaseCorruptionTitle": "Deine lokalen Daten sind beschädigt",
     "databaseCorruptionBody": "Schließ Divine und öffne es neu — wir reparieren das automatisch. Wir retten so viel wie möglich von deinen Entwürfen und Clips, alles andere lädt neu.",
     "databaseCorruptionCloseButton": "Divine schließen",
-    "databaseCloseManual": "Schließe Divine auf deinem Gerät und öffne es dann erneut.",
     "videoDetailContextTitle": "Geteiltes Video",
     "videoDetailCloseSemanticLabel": "Videoplayer schließen",
     "metadataHashtagChipTapHint": "#{hashtag}. Tippen, um Videos mit diesem Hashtag anzusehen.",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -8101,9 +8101,9 @@
   "@dbFailureConfirmBody": {
     "description": "Body of the confirmation step explaining what a local-database reset deletes and what survives."
   },
-  "dbFailureResetConfirm": "reset and close",
+  "dbFailureResetConfirm": "reset local database now",
   "@dbFailureResetConfirm": {
-    "description": "Button that performs the local-database reset and then closes the app."
+    "description": "Destructive confirmation button that performs the local-database reset. Supported platforms close afterward; unsupported platforms remain on the completion step."
   },
   "dbFailureCancel": "cancel",
   "@dbFailureCancel": {

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -990,10 +990,6 @@
   "@databaseCorruptionCloseButton": {
     "description": "Button on the database-corruption takeover that closes the app so the user can reopen it. Flutter cannot relaunch its own process, so closing is the most we can offer."
   },
-  "databaseCloseManual": "Close Divine from your device, then open it again.",
-  "@databaseCloseManual": {
-    "description": "Instruction shown instead of a close button when the platform cannot close Divine itself. Keep this platform-neutral because the fallback also covers unverified desktop and web targets."
-  },
   "videoDetailContextTitle": "Shared Video",
   "@videoDetailContextTitle": {
     "description": "App bar title over the fullscreen player when a video is opened from a share/deep link; also forwarded verbatim as the feedMode analytics dimension."

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -990,6 +990,10 @@
   "@databaseCorruptionCloseButton": {
     "description": "Button on the database-corruption takeover that closes the app so the user can reopen it. Flutter cannot relaunch its own process, so closing is the most we can offer."
   },
+  "databaseCloseManual": "Close Divine from your device, then open it again.",
+  "@databaseCloseManual": {
+    "description": "Instruction shown instead of a close button when the platform cannot close Divine itself. Keep this platform-neutral because the fallback also covers unverified desktop and web targets."
+  },
   "videoDetailContextTitle": "Shared Video",
   "@videoDetailContextTitle": {
     "description": "App bar title over the fullscreen player when a video is opened from a share/deep link; also forwarded verbatim as the feedMode analytics dimension."

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -4823,7 +4823,7 @@
     "dbFailureResetAction": "restablecer base de datos local",
     "dbFailureConfirmTitle": "¿restablecer tu base de datos local?",
     "dbFailureConfirmBody": "Tu cuenta se mantiene. Los borradores y clips guardados en este dispositivo se eliminan — los mensajes y feeds vuelven desde la red.",
-    "dbFailureResetConfirm": "restablecer y cerrar",
+    "dbFailureResetConfirm": "restablecer base de datos local ahora",
     "dbFailureCancel": "cancelar",
     "dbFailureResetFailed": "Eso no funcionó. Cerrá Divine y probá de nuevo.",
     "dbFailureResetDoneTitle": "base de datos local restablecida",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -4166,7 +4166,6 @@
     "databaseCorruptionTitle": "Tus datos locales se estropearon",
     "databaseCorruptionBody": "Cierra Divine y ábrelo de nuevo: lo arreglamos automáticamente. Guardamos los borradores y clips que podamos, lo demás se recarga.",
     "databaseCorruptionCloseButton": "Cerrar Divine",
-    "databaseCloseManual": "Cerrá Divine desde tu dispositivo y volvé a abrirlo.",
     "videoDetailContextTitle": "Video compartido",
     "videoDetailCloseSemanticLabel": "Cerrar reproductor de video",
     "metadataHashtagChipTapHint": "#{hashtag}. Tocá para ver videos con este hashtag.",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -4166,6 +4166,7 @@
     "databaseCorruptionTitle": "Tus datos locales se estropearon",
     "databaseCorruptionBody": "Cierra Divine y ábrelo de nuevo: lo arreglamos automáticamente. Guardamos los borradores y clips que podamos, lo demás se recarga.",
     "databaseCorruptionCloseButton": "Cerrar Divine",
+    "databaseCloseManual": "Cerrá Divine desde tu dispositivo y volvé a abrirlo.",
     "videoDetailContextTitle": "Video compartido",
     "videoDetailCloseSemanticLabel": "Cerrar reproductor de video",
     "metadataHashtagChipTapHint": "#{hashtag}. Tocá para ver videos con este hashtag.",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -2962,6 +2962,7 @@
     "databaseCorruptionTitle": "Nasira ang local data mo",
     "databaseCorruptionBody": "Isara ang Divine at buksan ulit — awtomatiko naming aayusin. Ise-save namin ang makakaya sa mga draft at clip mo, mag-reload na lang ang iba.",
     "databaseCorruptionCloseButton": "Isara ang Divine",
+    "databaseCloseManual": "Isara ang Divine sa iyong device, pagkatapos ay buksan itong muli.",
     "videoDetailContextTitle": "Na-share na video",
     "videoDetailCloseSemanticLabel": "Isara ang video player",
     "metadataHashtagChipTapHint": "#{hashtag}. I-tap para makita ang mga video na may ganitong hashtag.",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -2962,7 +2962,6 @@
     "databaseCorruptionTitle": "Nasira ang local data mo",
     "databaseCorruptionBody": "Isara ang Divine at buksan ulit — awtomatiko naming aayusin. Ise-save namin ang makakaya sa mga draft at clip mo, mag-reload na lang ang iba.",
     "databaseCorruptionCloseButton": "Isara ang Divine",
-    "databaseCloseManual": "Isara ang Divine sa iyong device, pagkatapos ay buksan itong muli.",
     "videoDetailContextTitle": "Na-share na video",
     "videoDetailCloseSemanticLabel": "Isara ang video player",
     "metadataHashtagChipTapHint": "#{hashtag}. I-tap para makita ang mga video na may ganitong hashtag.",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -3619,7 +3619,7 @@
     "dbFailureResetAction": "i-reset ang lokal na database",
     "dbFailureConfirmTitle": "i-reset ang iyong lokal na database?",
     "dbFailureConfirmBody": "Mananatili ang iyong account. Buburahin ang mga draft at clip na naka-save sa device na ito — babalik ang mga mensahe at feed mula sa network.",
-    "dbFailureResetConfirm": "i-reset at isara",
+    "dbFailureResetConfirm": "i-reset na ang lokal na database",
     "dbFailureCancel": "kanselahin",
     "dbFailureResetFailed": "Hindi ito gumana. Isara ang Divine at subukan ulit.",
     "dbFailureResetDoneTitle": "na-reset ang lokal na database",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -4166,6 +4166,7 @@
     "databaseCorruptionTitle": "Tes données locales sont abîmées",
     "databaseCorruptionBody": "Ferme Divine et rouvre-la : on répare ça automatiquement. On sauve ce qu'on peut de tes brouillons et clips, le reste se recharge.",
     "databaseCorruptionCloseButton": "Fermer Divine",
+    "databaseCloseManual": "Fermez Divine depuis votre appareil, puis rouvrez-le.",
     "videoDetailContextTitle": "Vidéo partagée",
     "videoDetailCloseSemanticLabel": "Fermer le lecteur vidéo",
     "metadataHashtagChipTapHint": "#{hashtag}. Touche pour voir les vidéos avec ce hashtag.",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -4166,7 +4166,6 @@
     "databaseCorruptionTitle": "Tes données locales sont abîmées",
     "databaseCorruptionBody": "Ferme Divine et rouvre-la : on répare ça automatiquement. On sauve ce qu'on peut de tes brouillons et clips, le reste se recharge.",
     "databaseCorruptionCloseButton": "Fermer Divine",
-    "databaseCloseManual": "Fermez Divine depuis votre appareil, puis rouvrez-le.",
     "videoDetailContextTitle": "Vidéo partagée",
     "videoDetailCloseSemanticLabel": "Fermer le lecteur vidéo",
     "metadataHashtagChipTapHint": "#{hashtag}. Touche pour voir les vidéos avec ce hashtag.",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -4823,7 +4823,7 @@
     "dbFailureResetAction": "réinitialiser la base de données locale",
     "dbFailureConfirmTitle": "réinitialiser votre base de données locale ?",
     "dbFailureConfirmBody": "Votre compte est conservé. Les brouillons et clips enregistrés sur cet appareil sont supprimés — les messages et fils reviennent du réseau.",
-    "dbFailureResetConfirm": "réinitialiser et fermer",
+    "dbFailureResetConfirm": "réinitialiser la base de données locale maintenant",
     "dbFailureCancel": "annuler",
     "dbFailureResetFailed": "Ça n'a pas fonctionné. Fermez Divine et réessayez.",
     "dbFailureResetDoneTitle": "base de données locale réinitialisée",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -4823,7 +4823,7 @@
     "dbFailureResetAction": "atur ulang basis data lokal",
     "dbFailureConfirmTitle": "atur ulang basis data lokalmu?",
     "dbFailureConfirmBody": "Akunmu tetap ada. Draf dan klip yang tersimpan di perangkat ini akan dihapus — pesan dan feed kembali dari jaringan.",
-    "dbFailureResetConfirm": "atur ulang dan tutup",
+    "dbFailureResetConfirm": "atur ulang basis data lokal sekarang",
     "dbFailureCancel": "batal",
     "dbFailureResetFailed": "Itu tidak berhasil. Tutup Divine dan coba lagi.",
     "dbFailureResetDoneTitle": "basis data lokal telah diatur ulang",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -4166,7 +4166,6 @@
     "databaseCorruptionTitle": "Data lokalmu rusak",
     "databaseCorruptionBody": "Tutup Divine lalu buka lagi — kami perbaiki otomatis. Kami simpan draf dan klipmu semampu kami, sisanya dimuat ulang.",
     "databaseCorruptionCloseButton": "Tutup Divine",
-    "databaseCloseManual": "Tutup Divine dari perangkatmu, lalu buka lagi.",
     "videoDetailContextTitle": "Video yang dibagikan",
     "videoDetailCloseSemanticLabel": "Tutup pemutar video",
     "metadataHashtagChipTapHint": "#{hashtag}. Ketuk untuk melihat video dengan hashtag ini.",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -4166,6 +4166,7 @@
     "databaseCorruptionTitle": "Data lokalmu rusak",
     "databaseCorruptionBody": "Tutup Divine lalu buka lagi — kami perbaiki otomatis. Kami simpan draf dan klipmu semampu kami, sisanya dimuat ulang.",
     "databaseCorruptionCloseButton": "Tutup Divine",
+    "databaseCloseManual": "Tutup Divine dari perangkatmu, lalu buka lagi.",
     "videoDetailContextTitle": "Video yang dibagikan",
     "videoDetailCloseSemanticLabel": "Tutup pemutar video",
     "metadataHashtagChipTapHint": "#{hashtag}. Ketuk untuk melihat video dengan hashtag ini.",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -4823,7 +4823,7 @@
     "dbFailureResetAction": "reimposta database locale",
     "dbFailureConfirmTitle": "reimpostare il database locale?",
     "dbFailureConfirmBody": "Il tuo account resta. Le bozze e le clip salvate su questo dispositivo vengono eliminate — messaggi e feed tornano dalla rete.",
-    "dbFailureResetConfirm": "reimposta e chiudi",
+    "dbFailureResetConfirm": "reimposta ora il database locale",
     "dbFailureCancel": "annulla",
     "dbFailureResetFailed": "Non ha funzionato. Chiudi Divine e riprova.",
     "dbFailureResetDoneTitle": "database locale reimpostato",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -4166,6 +4166,7 @@
     "databaseCorruptionTitle": "I tuoi dati locali si sono rovinati",
     "databaseCorruptionBody": "Chiudi Divine e riaprila: sistemiamo tutto in automatico. Salviamo quello che possiamo delle tue bozze e clip, il resto si ricarica.",
     "databaseCorruptionCloseButton": "Chiudi Divine",
+    "databaseCloseManual": "Chiudi Divine dal tuo dispositivo, poi riaprilo.",
     "videoDetailContextTitle": "Video condiviso",
     "videoDetailCloseSemanticLabel": "Chiudi lettore video",
     "metadataHashtagChipTapHint": "#{hashtag}. Tocca per vedere i video con questo hashtag.",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -4166,7 +4166,6 @@
     "databaseCorruptionTitle": "I tuoi dati locali si sono rovinati",
     "databaseCorruptionBody": "Chiudi Divine e riaprila: sistemiamo tutto in automatico. Salviamo quello che possiamo delle tue bozze e clip, il resto si ricarica.",
     "databaseCorruptionCloseButton": "Chiudi Divine",
-    "databaseCloseManual": "Chiudi Divine dal tuo dispositivo, poi riaprilo.",
     "videoDetailContextTitle": "Video condiviso",
     "videoDetailCloseSemanticLabel": "Chiudi lettore video",
     "metadataHashtagChipTapHint": "#{hashtag}. Tocca per vedere i video con questo hashtag.",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -4166,7 +4166,6 @@
     "databaseCorruptionTitle": "ローカルデータが壊れちゃった",
     "databaseCorruptionBody": "Divine を閉じてもう一度開いてね。自動で直すよ。下書きとクリップはできるだけ残すよ。ほかは読み込み直すよ。",
     "databaseCorruptionCloseButton": "Divine を閉じる",
-    "databaseCloseManual": "デバイスで Divine を閉じてから、もう一度開いてください。",
     "videoDetailContextTitle": "共有された動画",
     "videoDetailCloseSemanticLabel": "動画プレーヤーを閉じる",
     "metadataHashtagChipTapHint": "#{hashtag}。タップするとこのハッシュタグの動画を見れるよ。",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -4823,7 +4823,7 @@
     "dbFailureResetAction": "ローカルデータベースをリセット",
     "dbFailureConfirmTitle": "ローカルデータベースをリセットしますか？",
     "dbFailureConfirmBody": "アカウントはそのまま残ります。この端末に保存された下書きとクリップは削除されます。メッセージとフィードはネットワークから復元されます。",
-    "dbFailureResetConfirm": "リセットして閉じる",
+    "dbFailureResetConfirm": "今すぐローカルデータベースをリセット",
     "dbFailureCancel": "キャンセル",
     "dbFailureResetFailed": "うまくいきませんでした。Divine を閉じてもう一度お試しください。",
     "dbFailureResetDoneTitle": "ローカルデータベースをリセットしました",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -4166,6 +4166,7 @@
     "databaseCorruptionTitle": "ローカルデータが壊れちゃった",
     "databaseCorruptionBody": "Divine を閉じてもう一度開いてね。自動で直すよ。下書きとクリップはできるだけ残すよ。ほかは読み込み直すよ。",
     "databaseCorruptionCloseButton": "Divine を閉じる",
+    "databaseCloseManual": "デバイスで Divine を閉じてから、もう一度開いてください。",
     "videoDetailContextTitle": "共有された動画",
     "videoDetailCloseSemanticLabel": "動画プレーヤーを閉じる",
     "metadataHashtagChipTapHint": "#{hashtag}。タップするとこのハッシュタグの動画を見れるよ。",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -3627,6 +3627,7 @@
     "databaseCorruptionTitle": "로컬 데이터가 손상됐어요",
     "databaseCorruptionBody": "Divine을 껐다가 다시 열어주세요. 자동으로 고쳐드릴게요. 초안과 클립은 최대한 살려볼게요. 나머지는 다시 불러와요.",
     "databaseCorruptionCloseButton": "Divine 닫기",
+    "databaseCloseManual": "기기에서 Divine을 닫은 다음 다시 여세요.",
     "videoDetailContextTitle": "공유된 영상",
     "videoDetailCloseSemanticLabel": "동영상 플레이어 닫기",
     "metadataHashtagChipTapHint": "#{hashtag}. 탭하면 이 해시태그가 달린 영상을 볼 수 있어요.",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -3627,7 +3627,6 @@
     "databaseCorruptionTitle": "로컬 데이터가 손상됐어요",
     "databaseCorruptionBody": "Divine을 껐다가 다시 열어주세요. 자동으로 고쳐드릴게요. 초안과 클립은 최대한 살려볼게요. 나머지는 다시 불러와요.",
     "databaseCorruptionCloseButton": "Divine 닫기",
-    "databaseCloseManual": "기기에서 Divine을 닫은 다음 다시 여세요.",
     "videoDetailContextTitle": "공유된 영상",
     "videoDetailCloseSemanticLabel": "동영상 플레이어 닫기",
     "metadataHashtagChipTapHint": "#{hashtag}. 탭하면 이 해시태그가 달린 영상을 볼 수 있어요.",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -4284,7 +4284,7 @@
     "dbFailureResetAction": "로컬 데이터베이스 초기화",
     "dbFailureConfirmTitle": "로컬 데이터베이스를 초기화할까요?",
     "dbFailureConfirmBody": "계정은 그대로 유지됩니다. 이 기기에 저장된 초안과 클립은 삭제됩니다. 메시지와 피드는 네트워크에서 다시 불러옵니다.",
-    "dbFailureResetConfirm": "초기화하고 닫기",
+    "dbFailureResetConfirm": "지금 로컬 데이터베이스 초기화",
     "dbFailureCancel": "취소",
     "dbFailureResetFailed": "실패했습니다. Divine을 닫고 다시 시도하세요.",
     "dbFailureResetDoneTitle": "로컬 데이터베이스가 초기화되었습니다",

--- a/mobile/lib/l10n/app_ms.arb
+++ b/mobile/lib/l10n/app_ms.arb
@@ -734,6 +734,7 @@
     "description": "Body of the database-corruption takeover, explaining that a restart triggers the repair. The hedge on drafts and clips is deliberate and must be preserved when translating: the next launch salvages on a best-effort basis and can drop rows sitting on damaged pages, so promising they all survive would be a lie."
   },
   "databaseCorruptionCloseButton": "Tutup Divine",
+  "databaseCloseManual": "Tutup Divine pada peranti anda, kemudian buka semula.",
   "@databaseCorruptionCloseButton": {
     "description": "Button on the database-corruption takeover that closes the app so the user can reopen it. Flutter cannot relaunch its own process, so closing is the most we can offer."
   },

--- a/mobile/lib/l10n/app_ms.arb
+++ b/mobile/lib/l10n/app_ms.arb
@@ -6616,7 +6616,7 @@
   "dbFailureResetAction": "tetapkan semula pangkalan data setempat",
   "dbFailureConfirmTitle": "tetapkan semula pangkalan data setempat anda?",
   "dbFailureConfirmBody": "Akaun anda kekal. Draf dan klip yang disimpan pada peranti ini akan dipadamkan — mesej dan suapan kembali daripada rangkaian.",
-  "dbFailureResetConfirm": "tetapkan semula dan tutup",
+  "dbFailureResetConfirm": "tetapkan semula pangkalan data setempat sekarang",
   "dbFailureCancel": "batal",
   "dbFailureResetFailed": "Itu tidak berjaya. Tutup Divine dan cuba lagi.",
   "dbFailureResetDoneTitle": "pangkalan data setempat ditetapkan semula",

--- a/mobile/lib/l10n/app_ms.arb
+++ b/mobile/lib/l10n/app_ms.arb
@@ -734,7 +734,6 @@
     "description": "Body of the database-corruption takeover, explaining that a restart triggers the repair. The hedge on drafts and clips is deliberate and must be preserved when translating: the next launch salvages on a best-effort basis and can drop rows sitting on damaged pages, so promising they all survive would be a lie."
   },
   "databaseCorruptionCloseButton": "Tutup Divine",
-  "databaseCloseManual": "Tutup Divine pada peranti anda, kemudian buka semula.",
   "@databaseCorruptionCloseButton": {
     "description": "Button on the database-corruption takeover that closes the app so the user can reopen it. Flutter cannot relaunch its own process, so closing is the most we can offer."
   },

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -4823,7 +4823,7 @@
     "dbFailureResetAction": "lokale database resetten",
     "dbFailureConfirmTitle": "je lokale database resetten?",
     "dbFailureConfirmBody": "Je account blijft behouden. Concepten en clips die op dit apparaat zijn opgeslagen worden verwijderd — berichten en feeds komen terug van het netwerk.",
-    "dbFailureResetConfirm": "resetten en sluiten",
+    "dbFailureResetConfirm": "lokale database nu resetten",
     "dbFailureCancel": "annuleren",
     "dbFailureResetFailed": "Dat werkte niet. Sluit Divine en probeer het opnieuw.",
     "dbFailureResetDoneTitle": "lokale database gereset",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -4166,7 +4166,6 @@
     "databaseCorruptionTitle": "Je lokale gegevens zijn beschadigd",
     "databaseCorruptionBody": "Sluit Divine en open het opnieuw — we repareren het automatisch. We redden wat we kunnen van je concepten en clips, de rest laadt opnieuw.",
     "databaseCorruptionCloseButton": "Divine sluiten",
-    "databaseCloseManual": "Sluit Divine op je apparaat en open het daarna opnieuw.",
     "videoDetailContextTitle": "Gedeelde video",
     "videoDetailCloseSemanticLabel": "Videospeler sluiten",
     "metadataHashtagChipTapHint": "#{hashtag}. Tik om video's met deze hashtag te bekijken.",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -4166,6 +4166,7 @@
     "databaseCorruptionTitle": "Je lokale gegevens zijn beschadigd",
     "databaseCorruptionBody": "Sluit Divine en open het opnieuw — we repareren het automatisch. We redden wat we kunnen van je concepten en clips, de rest laadt opnieuw.",
     "databaseCorruptionCloseButton": "Divine sluiten",
+    "databaseCloseManual": "Sluit Divine op je apparaat en open het daarna opnieuw.",
     "videoDetailContextTitle": "Gedeelde video",
     "videoDetailCloseSemanticLabel": "Videospeler sluiten",
     "metadataHashtagChipTapHint": "#{hashtag}. Tik om video's met deze hashtag te bekijken.",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -4166,6 +4166,7 @@
     "databaseCorruptionTitle": "Twoje lokalne dane się uszkodziły",
     "databaseCorruptionBody": "Zamknij Divine i otwórz ponownie — naprawimy to automatycznie. Zachowamy tyle Twoich szkiców i klipów, ile się da, reszta wczyta się na nowo.",
     "databaseCorruptionCloseButton": "Zamknij Divine",
+    "databaseCloseManual": "Zamknij Divine na urządzeniu, a następnie otwórz go ponownie.",
     "videoDetailContextTitle": "Udostępniony film",
     "videoDetailCloseSemanticLabel": "Zamknij odtwarzacz wideo",
     "metadataHashtagChipTapHint": "#{hashtag}. Dotknij, aby zobaczyć filmy z tym hashtagiem.",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -4823,7 +4823,7 @@
     "dbFailureResetAction": "zresetuj lokalną bazę danych",
     "dbFailureConfirmTitle": "zresetować lokalną bazę danych?",
     "dbFailureConfirmBody": "Twoje konto zostaje. Wersje robocze i klipy zapisane na tym urządzeniu zostaną usunięte — wiadomości i kanały wrócą z sieci.",
-    "dbFailureResetConfirm": "zresetuj i zamknij",
+    "dbFailureResetConfirm": "zresetuj teraz lokalną bazę danych",
     "dbFailureCancel": "anuluj",
     "dbFailureResetFailed": "To nie zadziałało. Zamknij Divine i spróbuj ponownie.",
     "dbFailureResetDoneTitle": "lokalna baza danych zresetowana",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -4166,7 +4166,6 @@
     "databaseCorruptionTitle": "Twoje lokalne dane się uszkodziły",
     "databaseCorruptionBody": "Zamknij Divine i otwórz ponownie — naprawimy to automatycznie. Zachowamy tyle Twoich szkiców i klipów, ile się da, reszta wczyta się na nowo.",
     "databaseCorruptionCloseButton": "Zamknij Divine",
-    "databaseCloseManual": "Zamknij Divine na urządzeniu, a następnie otwórz go ponownie.",
     "videoDetailContextTitle": "Udostępniony film",
     "videoDetailCloseSemanticLabel": "Zamknij odtwarzacz wideo",
     "metadataHashtagChipTapHint": "#{hashtag}. Dotknij, aby zobaczyć filmy z tym hashtagiem.",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -4823,7 +4823,7 @@
     "dbFailureResetAction": "redefinir banco de dados local",
     "dbFailureConfirmTitle": "redefinir seu banco de dados local?",
     "dbFailureConfirmBody": "Sua conta permanece. Rascunhos e clipes salvos neste dispositivo são excluídos — mensagens e feeds voltam da rede.",
-    "dbFailureResetConfirm": "redefinir e fechar",
+    "dbFailureResetConfirm": "redefinir banco de dados local agora",
     "dbFailureCancel": "cancelar",
     "dbFailureResetFailed": "Isso não funcionou. Feche o Divine e tente de novo.",
     "dbFailureResetDoneTitle": "banco de dados local redefinido",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -4166,7 +4166,6 @@
     "databaseCorruptionTitle": "Seus dados locais foram corrompidos",
     "databaseCorruptionBody": "Feche o Divine e abra de novo — a gente conserta automaticamente. A gente salva o que der dos seus rascunhos e clipes, o resto recarrega.",
     "databaseCorruptionCloseButton": "Fechar o Divine",
-    "databaseCloseManual": "Feche o Divine no seu dispositivo e abra-o novamente.",
     "videoDetailContextTitle": "Vídeo compartilhado",
     "videoDetailCloseSemanticLabel": "Fechar reprodutor de vídeo",
     "metadataHashtagChipTapHint": "#{hashtag}. Toque para ver vídeos com esta hashtag.",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -4166,6 +4166,7 @@
     "databaseCorruptionTitle": "Seus dados locais foram corrompidos",
     "databaseCorruptionBody": "Feche o Divine e abra de novo — a gente conserta automaticamente. A gente salva o que der dos seus rascunhos e clipes, o resto recarrega.",
     "databaseCorruptionCloseButton": "Fechar o Divine",
+    "databaseCloseManual": "Feche o Divine no seu dispositivo e abra-o novamente.",
     "videoDetailContextTitle": "Vídeo compartilhado",
     "videoDetailCloseSemanticLabel": "Fechar reprodutor de vídeo",
     "metadataHashtagChipTapHint": "#{hashtag}. Toque para ver vídeos com esta hashtag.",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -4166,6 +4166,7 @@
     "databaseCorruptionTitle": "Datele tale locale s-au deteriorat",
     "databaseCorruptionBody": "Închide Divine și deschide-l din nou — reparăm automat. Salvăm ce putem din ciornele și clipurile tale, restul se reîncarcă.",
     "databaseCorruptionCloseButton": "Închide Divine",
+    "databaseCloseManual": "Închide Divine de pe dispozitiv, apoi deschide-l din nou.",
     "videoDetailContextTitle": "Videoclip partajat",
     "videoDetailCloseSemanticLabel": "Închide playerul video",
     "metadataHashtagChipTapHint": "#{hashtag}. Atinge ca să vezi videoclipuri cu acest hashtag.",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -4166,7 +4166,6 @@
     "databaseCorruptionTitle": "Datele tale locale s-au deteriorat",
     "databaseCorruptionBody": "Închide Divine și deschide-l din nou — reparăm automat. Salvăm ce putem din ciornele și clipurile tale, restul se reîncarcă.",
     "databaseCorruptionCloseButton": "Închide Divine",
-    "databaseCloseManual": "Închide Divine de pe dispozitiv, apoi deschide-l din nou.",
     "videoDetailContextTitle": "Videoclip partajat",
     "videoDetailCloseSemanticLabel": "Închide playerul video",
     "metadataHashtagChipTapHint": "#{hashtag}. Atinge ca să vezi videoclipuri cu acest hashtag.",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -4823,7 +4823,7 @@
     "dbFailureResetAction": "resetează baza de date locală",
     "dbFailureConfirmTitle": "resetezi baza de date locală?",
     "dbFailureConfirmBody": "Contul tău rămâne. Ciornele și clipurile salvate pe acest dispozitiv sunt șterse — mesajele și fluxurile revin din rețea.",
-    "dbFailureResetConfirm": "resetează și închide",
+    "dbFailureResetConfirm": "resetează acum baza de date locală",
     "dbFailureCancel": "anulează",
     "dbFailureResetFailed": "Nu a funcționat. Închide Divine și încearcă din nou.",
     "dbFailureResetDoneTitle": "baza de date locală a fost resetată",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -4166,6 +4166,7 @@
     "databaseCorruptionTitle": "Dina lokala data har skadats",
     "databaseCorruptionBody": "Stäng Divine och öppna appen igen – vi fixar det automatiskt. Vi räddar så mycket vi kan av dina utkast och klipp, resten laddas om.",
     "databaseCorruptionCloseButton": "Stäng Divine",
+    "databaseCloseManual": "Stäng Divine på din enhet och öppna det sedan igen.",
     "videoDetailContextTitle": "Delad video",
     "videoDetailCloseSemanticLabel": "Stäng videospelaren",
     "metadataHashtagChipTapHint": "#{hashtag}. Tryck för att se videor med den här hashtaggen.",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -4166,7 +4166,6 @@
     "databaseCorruptionTitle": "Dina lokala data har skadats",
     "databaseCorruptionBody": "Stäng Divine och öppna appen igen – vi fixar det automatiskt. Vi räddar så mycket vi kan av dina utkast och klipp, resten laddas om.",
     "databaseCorruptionCloseButton": "Stäng Divine",
-    "databaseCloseManual": "Stäng Divine på din enhet och öppna det sedan igen.",
     "videoDetailContextTitle": "Delad video",
     "videoDetailCloseSemanticLabel": "Stäng videospelaren",
     "metadataHashtagChipTapHint": "#{hashtag}. Tryck för att se videor med den här hashtaggen.",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -4823,7 +4823,7 @@
     "dbFailureResetAction": "återställ lokal databas",
     "dbFailureConfirmTitle": "återställa din lokala databas?",
     "dbFailureConfirmBody": "Ditt konto finns kvar. Utkast och klipp som sparats på den här enheten raderas — meddelanden och flöden hämtas tillbaka från nätverket.",
-    "dbFailureResetConfirm": "återställ och stäng",
+    "dbFailureResetConfirm": "återställ lokal databas nu",
     "dbFailureCancel": "avbryt",
     "dbFailureResetFailed": "Det fungerade inte. Stäng Divine och försök igen.",
     "dbFailureResetDoneTitle": "lokal databas återställd",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -4166,6 +4166,7 @@
     "databaseCorruptionTitle": "Yerel verilerin bozuldu",
     "databaseCorruptionBody": "Divine'ı kapatıp yeniden aç — bunu otomatik olarak onarıyoruz. Taslaklarından ve kliplerinden kurtarabildiğimizi saklıyoruz, gerisi yeniden yükleniyor.",
     "databaseCorruptionCloseButton": "Divine'ı kapat",
+    "databaseCloseManual": "Divine’ı cihazınızdan kapatın, ardından yeniden açın.",
     "videoDetailContextTitle": "Paylaşılan video",
     "videoDetailCloseSemanticLabel": "Video oynatıcıyı kapat",
     "metadataHashtagChipTapHint": "#{hashtag}. Bu hashtag'e sahip videoları görmek için dokun.",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -4823,7 +4823,7 @@
     "dbFailureResetAction": "yerel veritabanını sıfırla",
     "dbFailureConfirmTitle": "yerel veritabanınız sıfırlansın mı?",
     "dbFailureConfirmBody": "Hesabınız kalır. Bu cihazda kayıtlı taslaklar ve klipler silinir — mesajlar ve akışlar ağdan geri gelir.",
-    "dbFailureResetConfirm": "sıfırla ve kapat",
+    "dbFailureResetConfirm": "yerel veritabanını şimdi sıfırla",
     "dbFailureCancel": "iptal",
     "dbFailureResetFailed": "Bu işe yaramadı. Divine’ı kapatıp tekrar deneyin.",
     "dbFailureResetDoneTitle": "yerel veritabanı sıfırlandı",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -4166,7 +4166,6 @@
     "databaseCorruptionTitle": "Yerel verilerin bozuldu",
     "databaseCorruptionBody": "Divine'ı kapatıp yeniden aç — bunu otomatik olarak onarıyoruz. Taslaklarından ve kliplerinden kurtarabildiğimizi saklıyoruz, gerisi yeniden yükleniyor.",
     "databaseCorruptionCloseButton": "Divine'ı kapat",
-    "databaseCloseManual": "Divine’ı cihazınızdan kapatın, ardından yeniden açın.",
     "videoDetailContextTitle": "Paylaşılan video",
     "videoDetailCloseSemanticLabel": "Video oynatıcıyı kapat",
     "metadataHashtagChipTapHint": "#{hashtag}. Bu hashtag'e sahip videoları görmek için dokun.",

--- a/mobile/lib/l10n/app_ur.arb
+++ b/mobile/lib/l10n/app_ur.arb
@@ -6616,7 +6616,7 @@
   "dbFailureResetAction": "مقامی ڈیٹابیس ری سیٹ کریں",
   "dbFailureConfirmTitle": "اپنا مقامی ڈیٹابیس ری سیٹ کریں؟",
   "dbFailureConfirmBody": "آپ کا اکاؤنٹ برقرار رہتا ہے۔ اس ڈیوائس پر محفوظ ڈرافٹس اور کلپس حذف ہو جائیں گے — پیغامات اور فیڈز نیٹ ورک سے واپس آ جاتے ہیں۔",
-  "dbFailureResetConfirm": "ری سیٹ کریں اور بند کریں",
+  "dbFailureResetConfirm": "مقامی ڈیٹابیس ابھی ری سیٹ کریں",
   "dbFailureCancel": "منسوخ کریں",
   "dbFailureResetFailed": "یہ کام نہیں کیا۔ Divine بند کریں اور دوبارہ کوشش کریں۔",
   "dbFailureResetDoneTitle": "مقامی ڈیٹابیس ری سیٹ ہو گیا",

--- a/mobile/lib/l10n/app_ur.arb
+++ b/mobile/lib/l10n/app_ur.arb
@@ -734,6 +734,7 @@
     "description": "Body of the database-corruption takeover, explaining that a restart triggers the repair. The hedge on drafts and clips is deliberate and must be preserved when translating: the next launch salvages on a best-effort basis and can drop rows sitting on damaged pages, so promising they all survive would be a lie."
   },
   "databaseCorruptionCloseButton": "Divine بند کریں",
+  "databaseCloseManual": "اپنے آلے پر Divine بند کریں، پھر اسے دوبارہ کھولیں۔",
   "@databaseCorruptionCloseButton": {
     "description": "Button on the database-corruption takeover that closes the app so the user can reopen it. Flutter cannot relaunch its own process, so closing is the most we can offer."
   },

--- a/mobile/lib/l10n/app_ur.arb
+++ b/mobile/lib/l10n/app_ur.arb
@@ -734,7 +734,6 @@
     "description": "Body of the database-corruption takeover, explaining that a restart triggers the repair. The hedge on drafts and clips is deliberate and must be preserved when translating: the next launch salvages on a best-effort basis and can drop rows sitting on damaged pages, so promising they all survive would be a lie."
   },
   "databaseCorruptionCloseButton": "Divine بند کریں",
-  "databaseCloseManual": "اپنے آلے پر Divine بند کریں، پھر اسے دوبارہ کھولیں۔",
   "@databaseCorruptionCloseButton": {
     "description": "Button on the database-corruption takeover that closes the app so the user can reopen it. Flutter cannot relaunch its own process, so closing is the most we can offer."
   },

--- a/mobile/lib/l10n/app_vi.arb
+++ b/mobile/lib/l10n/app_vi.arb
@@ -734,6 +734,7 @@
     "description": "Body of the database-corruption takeover, explaining that a restart triggers the repair. The hedge on drafts and clips is deliberate and must be preserved when translating: the next launch salvages on a best-effort basis and can drop rows sitting on damaged pages, so promising they all survive would be a lie."
   },
   "databaseCorruptionCloseButton": "Đóng Divine",
+  "databaseCloseManual": "Đóng Divine trên thiết bị, rồi mở lại.",
   "@databaseCorruptionCloseButton": {
     "description": "Button on the database-corruption takeover that closes the app so the user can reopen it. Flutter cannot relaunch its own process, so closing is the most we can offer."
   },

--- a/mobile/lib/l10n/app_vi.arb
+++ b/mobile/lib/l10n/app_vi.arb
@@ -734,7 +734,6 @@
     "description": "Body of the database-corruption takeover, explaining that a restart triggers the repair. The hedge on drafts and clips is deliberate and must be preserved when translating: the next launch salvages on a best-effort basis and can drop rows sitting on damaged pages, so promising they all survive would be a lie."
   },
   "databaseCorruptionCloseButton": "Đóng Divine",
-  "databaseCloseManual": "Đóng Divine trên thiết bị, rồi mở lại.",
   "@databaseCorruptionCloseButton": {
     "description": "Button on the database-corruption takeover that closes the app so the user can reopen it. Flutter cannot relaunch its own process, so closing is the most we can offer."
   },

--- a/mobile/lib/l10n/app_vi.arb
+++ b/mobile/lib/l10n/app_vi.arb
@@ -6616,7 +6616,7 @@
   "dbFailureResetAction": "đặt lại cơ sở dữ liệu cục bộ",
   "dbFailureConfirmTitle": "đặt lại cơ sở dữ liệu cục bộ của bạn?",
   "dbFailureConfirmBody": "Tài khoản của bạn vẫn còn. Bản nháp và clip đã lưu trên thiết bị này sẽ bị xóa — tin nhắn và bảng tin sẽ được tải lại từ mạng.",
-  "dbFailureResetConfirm": "đặt lại và đóng",
+  "dbFailureResetConfirm": "đặt lại cơ sở dữ liệu cục bộ ngay",
   "dbFailureCancel": "hủy",
   "dbFailureResetFailed": "Không thành công. Hãy đóng Divine và thử lại.",
   "dbFailureResetDoneTitle": "đã đặt lại cơ sở dữ liệu cục bộ",

--- a/mobile/lib/l10n/app_zh.arb
+++ b/mobile/lib/l10n/app_zh.arb
@@ -6616,7 +6616,7 @@
   "dbFailureResetAction": "重置本地数据库",
   "dbFailureConfirmTitle": "重置你的本地数据库？",
   "dbFailureConfirmBody": "你的账号会保留。保存在此设备上的草稿和片段将被删除 — 消息和信息流会从网络重新获取。",
-  "dbFailureResetConfirm": "重置并关闭",
+  "dbFailureResetConfirm": "立即重置本地数据库",
   "dbFailureCancel": "取消",
   "dbFailureResetFailed": "没有成功。请关闭 Divine 后重试。",
   "dbFailureResetDoneTitle": "本地数据库已重置",

--- a/mobile/lib/l10n/app_zh.arb
+++ b/mobile/lib/l10n/app_zh.arb
@@ -734,7 +734,6 @@
     "description": "Body of the database-corruption takeover, explaining that a restart triggers the repair. The hedge on drafts and clips is deliberate and must be preserved when translating: the next launch salvages on a best-effort basis and can drop rows sitting on damaged pages, so promising they all survive would be a lie."
   },
   "databaseCorruptionCloseButton": "关闭 Divine",
-  "databaseCloseManual": "在设备上关闭 Divine，然后重新打开。",
   "@databaseCorruptionCloseButton": {
     "description": "Button on the database-corruption takeover that closes the app so the user can reopen it. Flutter cannot relaunch its own process, so closing is the most we can offer."
   },

--- a/mobile/lib/l10n/app_zh.arb
+++ b/mobile/lib/l10n/app_zh.arb
@@ -734,6 +734,7 @@
     "description": "Body of the database-corruption takeover, explaining that a restart triggers the repair. The hedge on drafts and clips is deliberate and must be preserved when translating: the next launch salvages on a best-effort basis and can drop rows sitting on damaged pages, so promising they all survive would be a lie."
   },
   "databaseCorruptionCloseButton": "关闭 Divine",
+  "databaseCloseManual": "在设备上关闭 Divine，然后重新打开。",
   "@databaseCorruptionCloseButton": {
     "description": "Button on the database-corruption takeover that closes the app so the user can reopen it. Flutter cannot relaunch its own process, so closing is the most we can offer."
   },

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -19672,10 +19672,10 @@ abstract class AppLocalizations {
   /// **'Your account stays. Drafts and clips saved on this device are deleted — messages and feeds come back from the network.'**
   String get dbFailureConfirmBody;
 
-  /// Button that performs the local-database reset and then closes the app.
+  /// Destructive confirmation button that performs the local-database reset. Supported platforms close afterward; unsupported platforms remain on the completion step.
   ///
   /// In en, this message translates to:
-  /// **'reset and close'**
+  /// **'reset local database now'**
   String get dbFailureResetConfirm;
 
   /// Button that returns from the reset confirmation to the failure screen.

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -2790,6 +2790,12 @@ abstract class AppLocalizations {
   /// **'Close Divine'**
   String get databaseCorruptionCloseButton;
 
+  /// Instruction shown instead of a close button when the platform cannot close Divine itself. Keep this platform-neutral because the fallback also covers unverified desktop and web targets.
+  ///
+  /// In en, this message translates to:
+  /// **'Close Divine from your device, then open it again.'**
+  String get databaseCloseManual;
+
   /// App bar title over the fullscreen player when a video is opened from a share/deep link; also forwarded verbatim as the feedMode analytics dimension.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -2790,12 +2790,6 @@ abstract class AppLocalizations {
   /// **'Close Divine'**
   String get databaseCorruptionCloseButton;
 
-  /// Instruction shown instead of a close button when the platform cannot close Divine itself. Keep this platform-neutral because the fallback also covers unverified desktop and web targets.
-  ///
-  /// In en, this message translates to:
-  /// **'Close Divine from your device, then open it again.'**
-  String get databaseCloseManual;
-
   /// App bar title over the fullscreen player when a video is opened from a share/deep link; also forwarded verbatim as the feedMode analytics dimension.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -11356,7 +11356,7 @@ class AppLocalizationsAm extends AppLocalizations {
       'መለያዎ ይቀራል። በዚህ መሣሪያ ላይ የተቀመጡ ረቂቆች እና ክሊፖች ይሰረዛሉ — መልእክቶች እና ምግቦች ከአውታረ መረቡ ይመለሳሉ።';
 
   @override
-  String get dbFailureResetConfirm => 'ዳግም አስጀምር እና ዝጋ';
+  String get dbFailureResetConfirm => 'የአካባቢ ዳታቤዝ አሁን ዳግም አስጀምር';
 
   @override
   String get dbFailureCancel => 'ሰርዝ';

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -1574,6 +1574,9 @@ class AppLocalizationsAm extends AppLocalizations {
   String get databaseCorruptionCloseButton => 'Divine ን ዝጋ';
 
   @override
+  String get databaseCloseManual => 'Divineን ከመሣሪያዎ ይዝጉት፣ ከዚያ እንደገና ይክፈቱት።';
+
+  @override
   String get videoDetailContextTitle => 'የተጋራ ቪዲዮ';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -1574,9 +1574,6 @@ class AppLocalizationsAm extends AppLocalizations {
   String get databaseCorruptionCloseButton => 'Divine ን ዝጋ';
 
   @override
-  String get databaseCloseManual => 'Divineን ከመሣሪያዎ ይዝጉት፣ ከዚያ እንደገና ይክፈቱት።';
-
-  @override
   String get videoDetailContextTitle => 'የተጋራ ቪዲዮ';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -1592,9 +1592,6 @@ class AppLocalizationsAr extends AppLocalizations {
   String get databaseCorruptionCloseButton => 'إغلاق Divine';
 
   @override
-  String get databaseCloseManual => 'أغلق Divine من جهازك، ثم افتحه مجددًا.';
-
-  @override
   String get videoDetailContextTitle => 'فيديو تمت مشاركته';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -1592,6 +1592,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get databaseCorruptionCloseButton => 'إغلاق Divine';
 
   @override
+  String get databaseCloseManual => 'أغلق Divine من جهازك، ثم افتحه مجددًا.';
+
+  @override
   String get videoDetailContextTitle => 'فيديو تمت مشاركته';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -11575,7 +11575,7 @@ class AppLocalizationsAr extends AppLocalizations {
       'يبقى حسابك. تُحذف المسودات والمقاطع المحفوظة على هذا الجهاز — أما الرسائل والخلاصات فتعود من الشبكة.';
 
   @override
-  String get dbFailureResetConfirm => 'إعادة التعيين والإغلاق';
+  String get dbFailureResetConfirm => 'إعادة تعيين قاعدة البيانات المحلية الآن';
 
   @override
   String get dbFailureCancel => 'إلغاء';

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -1634,10 +1634,6 @@ class AppLocalizationsBg extends AppLocalizations {
   String get databaseCorruptionCloseButton => 'Затвори Divine';
 
   @override
-  String get databaseCloseManual =>
-      'Затвори Divine от устройството си, след което го отвори отново.';
-
-  @override
   String get videoDetailContextTitle => 'Споделено видео';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -1634,6 +1634,10 @@ class AppLocalizationsBg extends AppLocalizations {
   String get databaseCorruptionCloseButton => 'Затвори Divine';
 
   @override
+  String get databaseCloseManual =>
+      'Затвори Divine от устройството си, след което го отвори отново.';
+
+  @override
   String get videoDetailContextTitle => 'Споделено видео';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -11780,7 +11780,7 @@ class AppLocalizationsBg extends AppLocalizations {
       'Акаунтът ти остава. Черновите и клиповете, запазени на това устройство, се изтриват — съобщенията и емисиите се връщат от мрежата.';
 
   @override
-  String get dbFailureResetConfirm => 'нулирай и затвори';
+  String get dbFailureResetConfirm => 'нулирай локалната база данни сега';
 
   @override
   String get dbFailureCancel => 'отказ';

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -11806,7 +11806,7 @@ class AppLocalizationsDe extends AppLocalizations {
       'Dein Konto bleibt. Auf diesem Gerät gespeicherte Entwürfe und Clips werden gelöscht — Nachrichten und Feeds kommen aus dem Netzwerk zurück.';
 
   @override
-  String get dbFailureResetConfirm => 'Zurücksetzen und schließen';
+  String get dbFailureResetConfirm => 'Lokale Datenbank jetzt zurücksetzen';
 
   @override
   String get dbFailureCancel => 'Abbrechen';

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -1633,6 +1633,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get databaseCorruptionCloseButton => 'Divine schließen';
 
   @override
+  String get databaseCloseManual =>
+      'Schließe Divine auf deinem Gerät und öffne es dann erneut.';
+
+  @override
   String get videoDetailContextTitle => 'Geteiltes Video';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -1633,10 +1633,6 @@ class AppLocalizationsDe extends AppLocalizations {
   String get databaseCorruptionCloseButton => 'Divine schließen';
 
   @override
-  String get databaseCloseManual =>
-      'Schließe Divine auf deinem Gerät und öffne es dann erneut.';
-
-  @override
   String get videoDetailContextTitle => 'Geteiltes Video';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -11764,7 +11764,7 @@ class AppLocalizationsEn extends AppLocalizations {
       'Your account stays. Drafts and clips saved on this device are deleted — messages and feeds come back from the network.';
 
   @override
-  String get dbFailureResetConfirm => 'reset and close';
+  String get dbFailureResetConfirm => 'reset local database now';
 
   @override
   String get dbFailureCancel => 'cancel';

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -1620,6 +1620,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get databaseCorruptionCloseButton => 'Close Divine';
 
   @override
+  String get databaseCloseManual =>
+      'Close Divine from your device, then open it again.';
+
+  @override
   String get videoDetailContextTitle => 'Shared Video';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -1620,10 +1620,6 @@ class AppLocalizationsEn extends AppLocalizations {
   String get databaseCorruptionCloseButton => 'Close Divine';
 
   @override
-  String get databaseCloseManual =>
-      'Close Divine from your device, then open it again.';
-
-  @override
   String get videoDetailContextTitle => 'Shared Video';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -1632,10 +1632,6 @@ class AppLocalizationsEs extends AppLocalizations {
   String get databaseCorruptionCloseButton => 'Cerrar Divine';
 
   @override
-  String get databaseCloseManual =>
-      'Cerrá Divine desde tu dispositivo y volvé a abrirlo.';
-
-  @override
   String get videoDetailContextTitle => 'Video compartido';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -1632,6 +1632,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get databaseCorruptionCloseButton => 'Cerrar Divine';
 
   @override
+  String get databaseCloseManual =>
+      'Cerrá Divine desde tu dispositivo y volvé a abrirlo.';
+
+  @override
   String get videoDetailContextTitle => 'Video compartido';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -11788,7 +11788,7 @@ class AppLocalizationsEs extends AppLocalizations {
       'Tu cuenta se mantiene. Los borradores y clips guardados en este dispositivo se eliminan — los mensajes y feeds vuelven desde la red.';
 
   @override
-  String get dbFailureResetConfirm => 'restablecer y cerrar';
+  String get dbFailureResetConfirm => 'restablecer base de datos local ahora';
 
   @override
   String get dbFailureCancel => 'cancelar';

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -1607,6 +1607,10 @@ class AppLocalizationsFil extends AppLocalizations {
   String get databaseCorruptionCloseButton => 'Isara ang Divine';
 
   @override
+  String get databaseCloseManual =>
+      'Isara ang Divine sa iyong device, pagkatapos ay buksan itong muli.';
+
+  @override
   String get videoDetailContextTitle => 'Na-share na video';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -1607,10 +1607,6 @@ class AppLocalizationsFil extends AppLocalizations {
   String get databaseCorruptionCloseButton => 'Isara ang Divine';
 
   @override
-  String get databaseCloseManual =>
-      'Isara ang Divine sa iyong device, pagkatapos ay buksan itong muli.';
-
-  @override
   String get videoDetailContextTitle => 'Na-share na video';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -11773,7 +11773,7 @@ class AppLocalizationsFil extends AppLocalizations {
       'Mananatili ang iyong account. Buburahin ang mga draft at clip na naka-save sa device na ito — babalik ang mga mensahe at feed mula sa network.';
 
   @override
-  String get dbFailureResetConfirm => 'i-reset at isara';
+  String get dbFailureResetConfirm => 'i-reset na ang lokal na database';
 
   @override
   String get dbFailureCancel => 'kanselahin';

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -1644,10 +1644,6 @@ class AppLocalizationsFr extends AppLocalizations {
   String get databaseCorruptionCloseButton => 'Fermer Divine';
 
   @override
-  String get databaseCloseManual =>
-      'Fermez Divine depuis votre appareil, puis rouvrez-le.';
-
-  @override
   String get videoDetailContextTitle => 'Vidéo partagée';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -1644,6 +1644,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get databaseCorruptionCloseButton => 'Fermer Divine';
 
   @override
+  String get databaseCloseManual =>
+      'Fermez Divine depuis votre appareil, puis rouvrez-le.';
+
+  @override
   String get videoDetailContextTitle => 'Vidéo partagée';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -11838,7 +11838,8 @@ class AppLocalizationsFr extends AppLocalizations {
       'Votre compte est conservé. Les brouillons et clips enregistrés sur cet appareil sont supprimés — les messages et fils reviennent du réseau.';
 
   @override
-  String get dbFailureResetConfirm => 'réinitialiser et fermer';
+  String get dbFailureResetConfirm =>
+      'réinitialiser la base de données locale maintenant';
 
   @override
   String get dbFailureCancel => 'annuler';

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -1547,10 +1547,6 @@ class AppLocalizationsId extends AppLocalizations {
   String get databaseCorruptionCloseButton => 'Tutup Divine';
 
   @override
-  String get databaseCloseManual =>
-      'Tutup Divine dari perangkatmu, lalu buka lagi.';
-
-  @override
   String get videoDetailContextTitle => 'Video yang dibagikan';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -1547,6 +1547,10 @@ class AppLocalizationsId extends AppLocalizations {
   String get databaseCorruptionCloseButton => 'Tutup Divine';
 
   @override
+  String get databaseCloseManual =>
+      'Tutup Divine dari perangkatmu, lalu buka lagi.';
+
+  @override
   String get videoDetailContextTitle => 'Video yang dibagikan';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -11575,7 +11575,7 @@ class AppLocalizationsId extends AppLocalizations {
       'Akunmu tetap ada. Draf dan klip yang tersimpan di perangkat ini akan dihapus — pesan dan feed kembali dari jaringan.';
 
   @override
-  String get dbFailureResetConfirm => 'atur ulang dan tutup';
+  String get dbFailureResetConfirm => 'atur ulang basis data lokal sekarang';
 
   @override
   String get dbFailureCancel => 'batal';

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -1639,6 +1639,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get databaseCorruptionCloseButton => 'Chiudi Divine';
 
   @override
+  String get databaseCloseManual =>
+      'Chiudi Divine dal tuo dispositivo, poi riaprilo.';
+
+  @override
   String get videoDetailContextTitle => 'Video condiviso';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -1639,10 +1639,6 @@ class AppLocalizationsIt extends AppLocalizations {
   String get databaseCorruptionCloseButton => 'Chiudi Divine';
 
   @override
-  String get databaseCloseManual =>
-      'Chiudi Divine dal tuo dispositivo, poi riaprilo.';
-
-  @override
   String get videoDetailContextTitle => 'Video condiviso';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -11801,7 +11801,7 @@ class AppLocalizationsIt extends AppLocalizations {
       'Il tuo account resta. Le bozze e le clip salvate su questo dispositivo vengono eliminate — messaggi e feed tornano dalla rete.';
 
   @override
-  String get dbFailureResetConfirm => 'reimposta e chiudi';
+  String get dbFailureResetConfirm => 'reimposta ora il database locale';
 
   @override
   String get dbFailureCancel => 'annulla';

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -11081,7 +11081,7 @@ class AppLocalizationsJa extends AppLocalizations {
       'アカウントはそのまま残ります。この端末に保存された下書きとクリップは削除されます。メッセージとフィードはネットワークから復元されます。';
 
   @override
-  String get dbFailureResetConfirm => 'リセットして閉じる';
+  String get dbFailureResetConfirm => '今すぐローカルデータベースをリセット';
 
   @override
   String get dbFailureCancel => 'キャンセル';

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -1471,6 +1471,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get databaseCorruptionCloseButton => 'Divine を閉じる';
 
   @override
+  String get databaseCloseManual => 'デバイスで Divine を閉じてから、もう一度開いてください。';
+
+  @override
   String get videoDetailContextTitle => '共有された動画';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -1471,9 +1471,6 @@ class AppLocalizationsJa extends AppLocalizations {
   String get databaseCorruptionCloseButton => 'Divine を閉じる';
 
   @override
-  String get databaseCloseManual => 'デバイスで Divine を閉じてから、もう一度開いてください。';
-
-  @override
   String get videoDetailContextTitle => '共有された動画';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -1481,9 +1481,6 @@ class AppLocalizationsKo extends AppLocalizations {
   String get databaseCorruptionCloseButton => 'Divine 닫기';
 
   @override
-  String get databaseCloseManual => '기기에서 Divine을 닫은 다음 다시 여세요.';
-
-  @override
   String get videoDetailContextTitle => '공유된 영상';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -1481,6 +1481,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get databaseCorruptionCloseButton => 'Divine 닫기';
 
   @override
+  String get databaseCloseManual => '기기에서 Divine을 닫은 다음 다시 여세요.';
+
+  @override
   String get videoDetailContextTitle => '공유된 영상';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -11094,7 +11094,7 @@ class AppLocalizationsKo extends AppLocalizations {
       '계정은 그대로 유지됩니다. 이 기기에 저장된 초안과 클립은 삭제됩니다. 메시지와 피드는 네트워크에서 다시 불러옵니다.';
 
   @override
-  String get dbFailureResetConfirm => '초기화하고 닫기';
+  String get dbFailureResetConfirm => '지금 로컬 데이터베이스 초기화';
 
   @override
   String get dbFailureCancel => '취소';

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -11668,7 +11668,8 @@ class AppLocalizationsMs extends AppLocalizations {
       'Akaun anda kekal. Draf dan klip yang disimpan pada peranti ini akan dipadamkan — mesej dan suapan kembali daripada rangkaian.';
 
   @override
-  String get dbFailureResetConfirm => 'tetapkan semula dan tutup';
+  String get dbFailureResetConfirm =>
+      'tetapkan semula pangkalan data setempat sekarang';
 
   @override
   String get dbFailureCancel => 'batal';

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -1592,6 +1592,10 @@ class AppLocalizationsMs extends AppLocalizations {
   String get databaseCorruptionCloseButton => 'Tutup Divine';
 
   @override
+  String get databaseCloseManual =>
+      'Tutup Divine pada peranti anda, kemudian buka semula.';
+
+  @override
   String get videoDetailContextTitle => 'Video Dikongsi';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ms.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ms.dart
@@ -1592,10 +1592,6 @@ class AppLocalizationsMs extends AppLocalizations {
   String get databaseCorruptionCloseButton => 'Tutup Divine';
 
   @override
-  String get databaseCloseManual =>
-      'Tutup Divine pada peranti anda, kemudian buka semula.';
-
-  @override
   String get videoDetailContextTitle => 'Video Dikongsi';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -1620,6 +1620,10 @@ class AppLocalizationsNl extends AppLocalizations {
   String get databaseCorruptionCloseButton => 'Divine sluiten';
 
   @override
+  String get databaseCloseManual =>
+      'Sluit Divine op je apparaat en open het daarna opnieuw.';
+
+  @override
   String get videoDetailContextTitle => 'Gedeelde video';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -11724,7 +11724,7 @@ class AppLocalizationsNl extends AppLocalizations {
       'Je account blijft behouden. Concepten en clips die op dit apparaat zijn opgeslagen worden verwijderd — berichten en feeds komen terug van het netwerk.';
 
   @override
-  String get dbFailureResetConfirm => 'resetten en sluiten';
+  String get dbFailureResetConfirm => 'lokale database nu resetten';
 
   @override
   String get dbFailureCancel => 'annuleren';

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -1620,10 +1620,6 @@ class AppLocalizationsNl extends AppLocalizations {
   String get databaseCorruptionCloseButton => 'Divine sluiten';
 
   @override
-  String get databaseCloseManual =>
-      'Sluit Divine op je apparaat en open het daarna opnieuw.';
-
-  @override
   String get videoDetailContextTitle => 'Gedeelde video';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -1646,6 +1646,10 @@ class AppLocalizationsPl extends AppLocalizations {
   String get databaseCorruptionCloseButton => 'Zamknij Divine';
 
   @override
+  String get databaseCloseManual =>
+      'Zamknij Divine na urządzeniu, a następnie otwórz go ponownie.';
+
+  @override
   String get videoDetailContextTitle => 'Udostępniony film';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -11891,7 +11891,7 @@ class AppLocalizationsPl extends AppLocalizations {
       'Twoje konto zostaje. Wersje robocze i klipy zapisane na tym urządzeniu zostaną usunięte — wiadomości i kanały wrócą z sieci.';
 
   @override
-  String get dbFailureResetConfirm => 'zresetuj i zamknij';
+  String get dbFailureResetConfirm => 'zresetuj teraz lokalną bazę danych';
 
   @override
   String get dbFailureCancel => 'anuluj';

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -1646,10 +1646,6 @@ class AppLocalizationsPl extends AppLocalizations {
   String get databaseCorruptionCloseButton => 'Zamknij Divine';
 
   @override
-  String get databaseCloseManual =>
-      'Zamknij Divine na urządzeniu, a następnie otwórz go ponownie.';
-
-  @override
   String get videoDetailContextTitle => 'Udostępniony film';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -11750,7 +11750,7 @@ class AppLocalizationsPt extends AppLocalizations {
       'Sua conta permanece. Rascunhos e clipes salvos neste dispositivo são excluídos — mensagens e feeds voltam da rede.';
 
   @override
-  String get dbFailureResetConfirm => 'redefinir e fechar';
+  String get dbFailureResetConfirm => 'redefinir banco de dados local agora';
 
   @override
   String get dbFailureCancel => 'cancelar';

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -1627,10 +1627,6 @@ class AppLocalizationsPt extends AppLocalizations {
   String get databaseCorruptionCloseButton => 'Fechar o Divine';
 
   @override
-  String get databaseCloseManual =>
-      'Feche o Divine no seu dispositivo e abra-o novamente.';
-
-  @override
   String get videoDetailContextTitle => 'Vídeo compartilhado';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -1627,6 +1627,10 @@ class AppLocalizationsPt extends AppLocalizations {
   String get databaseCorruptionCloseButton => 'Fechar o Divine';
 
   @override
+  String get databaseCloseManual =>
+      'Feche o Divine no seu dispositivo e abra-o novamente.';
+
+  @override
   String get videoDetailContextTitle => 'Vídeo compartilhado';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -1657,6 +1657,10 @@ class AppLocalizationsRo extends AppLocalizations {
   String get databaseCorruptionCloseButton => 'Închide Divine';
 
   @override
+  String get databaseCloseManual =>
+      'Închide Divine de pe dispozitiv, apoi deschide-l din nou.';
+
+  @override
   String get videoDetailContextTitle => 'Videoclip partajat';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -1657,10 +1657,6 @@ class AppLocalizationsRo extends AppLocalizations {
   String get databaseCorruptionCloseButton => 'Închide Divine';
 
   @override
-  String get databaseCloseManual =>
-      'Închide Divine de pe dispozitiv, apoi deschide-l din nou.';
-
-  @override
   String get videoDetailContextTitle => 'Videoclip partajat';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -11912,7 +11912,7 @@ class AppLocalizationsRo extends AppLocalizations {
       'Contul tău rămâne. Ciornele și clipurile salvate pe acest dispozitiv sunt șterse — mesajele și fluxurile revin din rețea.';
 
   @override
-  String get dbFailureResetConfirm => 'resetează și închide';
+  String get dbFailureResetConfirm => 'resetează acum baza de date locală';
 
   @override
   String get dbFailureCancel => 'anulează';

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -1608,6 +1608,10 @@ class AppLocalizationsSv extends AppLocalizations {
   String get databaseCorruptionCloseButton => 'Stäng Divine';
 
   @override
+  String get databaseCloseManual =>
+      'Stäng Divine på din enhet och öppna det sedan igen.';
+
+  @override
   String get videoDetailContextTitle => 'Delad video';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -1608,10 +1608,6 @@ class AppLocalizationsSv extends AppLocalizations {
   String get databaseCorruptionCloseButton => 'Stäng Divine';
 
   @override
-  String get databaseCloseManual =>
-      'Stäng Divine på din enhet och öppna det sedan igen.';
-
-  @override
   String get videoDetailContextTitle => 'Delad video';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -11663,7 +11663,7 @@ class AppLocalizationsSv extends AppLocalizations {
       'Ditt konto finns kvar. Utkast och klipp som sparats på den här enheten raderas — meddelanden och flöden hämtas tillbaka från nätverket.';
 
   @override
-  String get dbFailureResetConfirm => 'återställ och stäng';
+  String get dbFailureResetConfirm => 'återställ lokal databas nu';
 
   @override
   String get dbFailureCancel => 'avbryt';

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -1549,10 +1549,6 @@ class AppLocalizationsTr extends AppLocalizations {
   String get databaseCorruptionCloseButton => 'Divine\'ı kapat';
 
   @override
-  String get databaseCloseManual =>
-      'Divine’ı cihazınızdan kapatın, ardından yeniden açın.';
-
-  @override
   String get videoDetailContextTitle => 'Paylaşılan video';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -11592,7 +11592,7 @@ class AppLocalizationsTr extends AppLocalizations {
       'Hesabınız kalır. Bu cihazda kayıtlı taslaklar ve klipler silinir — mesajlar ve akışlar ağdan geri gelir.';
 
   @override
-  String get dbFailureResetConfirm => 'sıfırla ve kapat';
+  String get dbFailureResetConfirm => 'yerel veritabanını şimdi sıfırla';
 
   @override
   String get dbFailureCancel => 'iptal';

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -1549,6 +1549,10 @@ class AppLocalizationsTr extends AppLocalizations {
   String get databaseCorruptionCloseButton => 'Divine\'ı kapat';
 
   @override
+  String get databaseCloseManual =>
+      'Divine’ı cihazınızdan kapatın, ardından yeniden açın.';
+
+  @override
   String get videoDetailContextTitle => 'Paylaşılan video';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -11649,7 +11649,7 @@ class AppLocalizationsUr extends AppLocalizations {
       'آپ کا اکاؤنٹ برقرار رہتا ہے۔ اس ڈیوائس پر محفوظ ڈرافٹس اور کلپس حذف ہو جائیں گے — پیغامات اور فیڈز نیٹ ورک سے واپس آ جاتے ہیں۔';
 
   @override
-  String get dbFailureResetConfirm => 'ری سیٹ کریں اور بند کریں';
+  String get dbFailureResetConfirm => 'مقامی ڈیٹابیس ابھی ری سیٹ کریں';
 
   @override
   String get dbFailureCancel => 'منسوخ کریں';

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -1612,10 +1612,6 @@ class AppLocalizationsUr extends AppLocalizations {
   String get databaseCorruptionCloseButton => 'Divine بند کریں';
 
   @override
-  String get databaseCloseManual =>
-      'اپنے آلے پر Divine بند کریں، پھر اسے دوبارہ کھولیں۔';
-
-  @override
   String get videoDetailContextTitle => 'شیئر شدہ ویڈیو';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ur.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ur.dart
@@ -1612,6 +1612,10 @@ class AppLocalizationsUr extends AppLocalizations {
   String get databaseCorruptionCloseButton => 'Divine بند کریں';
 
   @override
+  String get databaseCloseManual =>
+      'اپنے آلے پر Divine بند کریں، پھر اسے دوبارہ کھولیں۔';
+
+  @override
   String get videoDetailContextTitle => 'شیئر شدہ ویڈیو';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -11612,7 +11612,7 @@ class AppLocalizationsVi extends AppLocalizations {
       'Tài khoản của bạn vẫn còn. Bản nháp và clip đã lưu trên thiết bị này sẽ bị xóa — tin nhắn và bảng tin sẽ được tải lại từ mạng.';
 
   @override
-  String get dbFailureResetConfirm => 'đặt lại và đóng';
+  String get dbFailureResetConfirm => 'đặt lại cơ sở dữ liệu cục bộ ngay';
 
   @override
   String get dbFailureCancel => 'hủy';

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -1583,6 +1583,9 @@ class AppLocalizationsVi extends AppLocalizations {
   String get databaseCorruptionCloseButton => 'Đóng Divine';
 
   @override
+  String get databaseCloseManual => 'Đóng Divine trên thiết bị, rồi mở lại.';
+
+  @override
   String get videoDetailContextTitle => 'Video được chia sẻ';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_vi.dart
+++ b/mobile/lib/l10n/generated/app_localizations_vi.dart
@@ -1583,9 +1583,6 @@ class AppLocalizationsVi extends AppLocalizations {
   String get databaseCorruptionCloseButton => 'Đóng Divine';
 
   @override
-  String get databaseCloseManual => 'Đóng Divine trên thiết bị, rồi mở lại.';
-
-  @override
   String get videoDetailContextTitle => 'Video được chia sẻ';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -1487,6 +1487,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get databaseCorruptionCloseButton => '关闭 Divine';
 
   @override
+  String get databaseCloseManual => '在设备上关闭 Divine，然后重新打开。';
+
+  @override
   String get videoDetailContextTitle => '分享的视频';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -10961,7 +10961,7 @@ class AppLocalizationsZh extends AppLocalizations {
       '你的账号会保留。保存在此设备上的草稿和片段将被删除 — 消息和信息流会从网络重新获取。';
 
   @override
-  String get dbFailureResetConfirm => '重置并关闭';
+  String get dbFailureResetConfirm => '立即重置本地数据库';
 
   @override
   String get dbFailureCancel => '取消';

--- a/mobile/lib/l10n/generated/app_localizations_zh.dart
+++ b/mobile/lib/l10n/generated/app_localizations_zh.dart
@@ -1487,9 +1487,6 @@ class AppLocalizationsZh extends AppLocalizations {
   String get databaseCorruptionCloseButton => '关闭 Divine';
 
   @override
-  String get databaseCloseManual => '在设备上关闭 Divine，然后重新打开。';
-
-  @override
   String get videoDetailContextTitle => '分享的视频';
 
   @override

--- a/mobile/lib/startup/close_app_support.dart
+++ b/mobile/lib/startup/close_app_support.dart
@@ -1,0 +1,11 @@
+// ABOUTME: Identifies platforms where Divine can close its own process.
+// ABOUTME: Keeps unsupported startup screens from offering dead close actions.
+
+import 'package:flutter/foundation.dart';
+
+/// Whether the current platform lets Divine end its own process.
+///
+/// Android is deliberately allowlisted. Other platforms either cannot honor
+/// `SystemNavigator.pop` from the app root or have not been verified here.
+bool get platformCanCloseApp =>
+    !kIsWeb && defaultTargetPlatform == TargetPlatform.android;

--- a/mobile/lib/startup/close_app_support.dart
+++ b/mobile/lib/startup/close_app_support.dart
@@ -5,7 +5,13 @@ import 'package:flutter/foundation.dart';
 
 /// Whether the current platform lets Divine end its own process.
 ///
-/// Android is deliberately allowlisted. Other platforms either cannot honor
-/// `SystemNavigator.pop` from the app root or have not been verified here.
+/// Android, Linux, and macOS terminate the application. iOS cannot close the
+/// root application view, Windows and Fuchsia do not implement the method, and
+/// web only pops browser history.
 bool get platformCanCloseApp =>
-    !kIsWeb && defaultTargetPlatform == TargetPlatform.android;
+    !kIsWeb &&
+    const {
+      TargetPlatform.android,
+      TargetPlatform.linux,
+      TargetPlatform.macOS,
+    }.contains(defaultTargetPlatform);

--- a/mobile/lib/startup/database_bootstrap_failure_app.dart
+++ b/mobile/lib/startup/database_bootstrap_failure_app.dart
@@ -7,6 +7,7 @@ import 'package:flutter/services.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/l10n/resolve_app_ui_locale.dart';
 import 'package:openvine/services/database_encryption_bootstrap.dart';
+import 'package:openvine/startup/close_app_support.dart';
 
 /// Result of resolving the DB cipher key during app startup.
 class DatabaseBootstrapStartupResult {
@@ -103,6 +104,7 @@ class DatabaseBootstrapFailureApp extends StatelessWidget {
     required this.error,
     required this.stack,
     this.locale,
+    this.canCloseApp,
     this.onCloseApp = SystemNavigator.pop,
     this.onResetLocalDatabase,
     super.key,
@@ -118,6 +120,9 @@ class DatabaseBootstrapFailureApp extends StatelessWidget {
   /// this screen keeps no dependency on SharedPreferences — it has to render
   /// even when startup did not get far enough to have one.
   final Locale? locale;
+
+  /// Overrides platform close support in tests.
+  final bool? canCloseApp;
 
   final VoidCallback onCloseApp;
 
@@ -149,6 +154,7 @@ class DatabaseBootstrapFailureApp extends StatelessWidget {
       home: _FailureScreen(
         error: error,
         stack: stack,
+        canCloseApp: canCloseApp ?? platformCanCloseApp,
         onCloseApp: onCloseApp,
         onResetLocalDatabase: onResetLocalDatabase,
       ),
@@ -160,12 +166,14 @@ class _FailureScreen extends StatefulWidget {
   const _FailureScreen({
     required this.error,
     required this.stack,
+    required this.canCloseApp,
     required this.onCloseApp,
     required this.onResetLocalDatabase,
   });
 
   final Object error;
   final StackTrace stack;
+  final bool canCloseApp;
   final VoidCallback onCloseApp;
   final Future<void> Function(DatabaseBootstrapDiagnosis diagnosis)?
   onResetLocalDatabase;
@@ -224,9 +232,9 @@ class _FailureScreenState extends State<_FailureScreen> {
       });
       _announce(context.l10n.dbFailureResetDoneTitle);
     }
-    // Finishes the activity on Android. On iOS the process stays alive, which
-    // is what the done step renders for.
-    widget.onCloseApp();
+    // Finishes the activity on Android. Unsupported platforms stay on the done
+    // step, which explains how to close Divine manually.
+    if (widget.canCloseApp) widget.onCloseApp();
   }
 
   void _announce(String message) => SemanticsService.sendAnnouncement(
@@ -249,6 +257,7 @@ class _FailureScreenState extends State<_FailureScreen> {
                 _Step.failure => _FailureView(
                   error: widget.error,
                   stack: widget.stack,
+                  canCloseApp: widget.canCloseApp,
                   onCloseApp: widget.onCloseApp,
                   onResetRequested: _canReset
                       ? () => _goTo(
@@ -264,7 +273,10 @@ class _FailureScreenState extends State<_FailureScreen> {
                   onCancel: () =>
                       _goTo(_Step.failure, context.l10n.dbFailureTitle),
                 ),
-                _Step.done => _ResetDoneView(onCloseApp: widget.onCloseApp),
+                _Step.done => _ResetDoneView(
+                  canCloseApp: widget.canCloseApp,
+                  onCloseApp: widget.onCloseApp,
+                ),
               },
             ),
           ),
@@ -278,12 +290,14 @@ class _FailureView extends StatelessWidget {
   const _FailureView({
     required this.error,
     required this.stack,
+    required this.canCloseApp,
     required this.onCloseApp,
     required this.onResetRequested,
   });
 
   final Object error;
   final StackTrace stack;
+  final bool canCloseApp;
   final VoidCallback onCloseApp;
   final VoidCallback? onResetRequested;
 
@@ -320,11 +334,18 @@ class _FailureView extends StatelessWidget {
           style: _diagnosticStyle,
         ),
         const SizedBox(height: 24),
-        DivineButton(
-          label: l10n.dbFailureCloseApp,
-          onPressed: onCloseApp,
-          type: DivineButtonType.secondary,
-        ),
+        if (canCloseApp)
+          DivineButton(
+            label: l10n.dbFailureCloseApp,
+            onPressed: onCloseApp,
+            type: DivineButtonType.secondary,
+          )
+        else
+          Text(
+            l10n.databaseCloseManual,
+            textAlign: TextAlign.center,
+            style: _bodyStyle,
+          ),
         if (onResetRequested != null) ...[
           const SizedBox(height: 12),
           DivineButton(
@@ -411,8 +432,12 @@ class _ResetConfirmView extends StatelessWidget {
 /// this step the confirmation would sit there spinning behind two disabled
 /// buttons with nothing left to happen.
 class _ResetDoneView extends StatelessWidget {
-  const _ResetDoneView({required this.onCloseApp});
+  const _ResetDoneView({
+    required this.canCloseApp,
+    required this.onCloseApp,
+  });
 
+  final bool canCloseApp;
   final VoidCallback onCloseApp;
 
   @override
@@ -439,11 +464,18 @@ class _ResetDoneView extends StatelessWidget {
           style: _bodyStyle,
         ),
         const SizedBox(height: 24),
-        DivineButton(
-          label: l10n.dbFailureCloseApp,
-          onPressed: onCloseApp,
-          type: DivineButtonType.secondary,
-        ),
+        if (canCloseApp)
+          DivineButton(
+            label: l10n.dbFailureCloseApp,
+            onPressed: onCloseApp,
+            type: DivineButtonType.secondary,
+          )
+        else
+          Text(
+            l10n.databaseCloseManual,
+            textAlign: TextAlign.center,
+            style: _bodyStyle,
+          ),
       ],
     );
   }

--- a/mobile/lib/startup/database_bootstrap_failure_app.dart
+++ b/mobile/lib/startup/database_bootstrap_failure_app.dart
@@ -232,8 +232,8 @@ class _FailureScreenState extends State<_FailureScreen> {
       });
       _announce(context.l10n.dbFailureResetDoneTitle);
     }
-    // Finishes the activity on Android. Unsupported platforms stay on the done
-    // step, which explains how to close Divine manually.
+    // Supported platforms close after the reset. Unsupported platforms stay
+    // on the done step, whose body already explains how to restart Divine.
     if (widget.canCloseApp) widget.onCloseApp();
   }
 
@@ -339,12 +339,6 @@ class _FailureView extends StatelessWidget {
             label: l10n.dbFailureCloseApp,
             onPressed: onCloseApp,
             type: DivineButtonType.secondary,
-          )
-        else
-          Text(
-            l10n.databaseCloseManual,
-            textAlign: TextAlign.center,
-            style: _bodyStyle,
           ),
         if (onResetRequested != null) ...[
           const SizedBox(height: 12),
@@ -427,10 +421,9 @@ class _ResetConfirmView extends StatelessWidget {
 
 /// Terminal step after a successful reset.
 ///
-/// Only ever seen where [DatabaseBootstrapFailureApp.onCloseApp] did not end
-/// the process — on iOS `SystemNavigator.pop` cannot close the app, so without
-/// this step the confirmation would sit there spinning behind two disabled
-/// buttons with nothing left to happen.
+/// Unsupported platforms stay here after reset because they cannot close the
+/// app. Supported platforms briefly build this step before closing, keeping
+/// the state transition deterministic and testable.
 class _ResetDoneView extends StatelessWidget {
   const _ResetDoneView({
     required this.canCloseApp,
@@ -469,12 +462,6 @@ class _ResetDoneView extends StatelessWidget {
             label: l10n.dbFailureCloseApp,
             onPressed: onCloseApp,
             type: DivineButtonType.secondary,
-          )
-        else
-          Text(
-            l10n.databaseCloseManual,
-            textAlign: TextAlign.center,
-            style: _bodyStyle,
           ),
       ],
     );

--- a/mobile/lib/startup/database_corruption_gate.dart
+++ b/mobile/lib/startup/database_corruption_gate.dart
@@ -48,8 +48,8 @@ class DatabaseCorruptionGate extends ConsumerWidget {
 /// Tells the user their local database is damaged and a restart repairs it.
 ///
 /// The sibling of `DatabaseBootstrapFailureApp`, for corruption that surfaces
-/// *after* startup. Android can close the app directly; other platforms explain
-/// how to close it manually because Flutter cannot relaunch its own process.
+/// *after* startup. Supported platforms can close the app directly; the body
+/// copy tells users on other platforms how to restart it themselves.
 class DatabaseCorruptionScreen extends StatelessWidget {
   /// Creates the screen. [onCloseApp] is injected for tests.
   const DatabaseCorruptionScreen({
@@ -157,20 +157,25 @@ class _CloseAppAffordanceState extends State<_CloseAppAffordance> {
         // the service has already logged it, and a user who restarts anyway is
         // better off than one held in a session that cannot recover.
         final settled = snapshot.connectionState == ConnectionState.done;
-        if (!settled || widget.canCloseApp) {
+        if (!settled) {
+          if (!widget.canCloseApp) {
+            return const SizedBox.square(
+              dimension: 24,
+              child: CircularProgressIndicator(),
+            );
+          }
           return DivineButton(
             label: context.l10n.databaseCorruptionCloseButton,
-            onPressed: settled ? widget.onCloseApp : null,
-            isLoading: !settled,
+            onPressed: null,
+            isLoading: true,
             type: DivineButtonType.secondary,
           );
         }
-        return Text(
-          context.l10n.databaseCloseManual,
-          textAlign: TextAlign.center,
-          style: VineTheme.bodyMediumFont(
-            color: context.vineColors.onSurfaceVariant,
-          ),
+        if (!widget.canCloseApp) return const SizedBox.shrink();
+        return DivineButton(
+          label: context.l10n.databaseCorruptionCloseButton,
+          onPressed: widget.onCloseApp,
+          type: DivineButtonType.secondary,
         );
       },
     );

--- a/mobile/lib/startup/database_corruption_gate.dart
+++ b/mobile/lib/startup/database_corruption_gate.dart
@@ -7,6 +7,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/database_corruption_provider.dart';
+import 'package:openvine/startup/close_app_support.dart';
 
 /// Swaps [child] for [DatabaseCorruptionScreen] once corruption surfaces.
 ///
@@ -47,13 +48,13 @@ class DatabaseCorruptionGate extends ConsumerWidget {
 /// Tells the user their local database is damaged and a restart repairs it.
 ///
 /// The sibling of `DatabaseBootstrapFailureApp`, for corruption that surfaces
-/// *after* startup. It closes the app rather than restarting it because Flutter
-/// cannot relaunch its own process; `SystemNavigator.pop` is the same affordance
-/// the startup failure screen offers.
+/// *after* startup. Android can close the app directly; other platforms explain
+/// how to close it manually because Flutter cannot relaunch its own process.
 class DatabaseCorruptionScreen extends StatelessWidget {
   /// Creates the screen. [onCloseApp] is injected for tests.
   const DatabaseCorruptionScreen({
     this.awaitRecoveryPersisted,
+    this.canCloseApp,
     this.onCloseApp = SystemNavigator.pop,
     super.key,
   });
@@ -63,6 +64,9 @@ class DatabaseCorruptionScreen extends StatelessWidget {
   /// `null` leaves the button enabled immediately, for callers with no flag to
   /// wait on (tests covering the layout).
   final Future<void> Function()? awaitRecoveryPersisted;
+
+  /// Overrides platform close support in tests.
+  final bool? canCloseApp;
 
   /// Invoked by the close button.
   final VoidCallback onCloseApp;
@@ -103,8 +107,9 @@ class DatabaseCorruptionScreen extends StatelessWidget {
                       color: context.vineColors.onSurfaceVariant,
                     ),
                   ),
-                  _CloseAppButton(
+                  _CloseAppAffordance(
                     awaitRecoveryPersisted: awaitRecoveryPersisted,
+                    canCloseApp: canCloseApp ?? platformCanCloseApp,
                     onCloseApp: onCloseApp,
                   ),
                 ],
@@ -123,20 +128,22 @@ class DatabaseCorruptionScreen extends StatelessWidget {
 /// database: the restart only repairs anything if the next launch can read the
 /// flag. The wait is invisible in practice — the write settles long before
 /// anyone finishes reading the screen.
-class _CloseAppButton extends StatefulWidget {
-  const _CloseAppButton({
+class _CloseAppAffordance extends StatefulWidget {
+  const _CloseAppAffordance({
     required this.awaitRecoveryPersisted,
+    required this.canCloseApp,
     required this.onCloseApp,
   });
 
   final Future<void> Function()? awaitRecoveryPersisted;
+  final bool canCloseApp;
   final VoidCallback onCloseApp;
 
   @override
-  State<_CloseAppButton> createState() => _CloseAppButtonState();
+  State<_CloseAppAffordance> createState() => _CloseAppAffordanceState();
 }
 
-class _CloseAppButtonState extends State<_CloseAppButton> {
+class _CloseAppAffordanceState extends State<_CloseAppAffordance> {
   // Resolved once, not per build, so a rebuild cannot restart the wait.
   late final Future<void> _persisted =
       widget.awaitRecoveryPersisted?.call() ?? Future<void>.value();
@@ -150,11 +157,20 @@ class _CloseAppButtonState extends State<_CloseAppButton> {
         // the service has already logged it, and a user who restarts anyway is
         // better off than one held in a session that cannot recover.
         final settled = snapshot.connectionState == ConnectionState.done;
-        return DivineButton(
-          label: context.l10n.databaseCorruptionCloseButton,
-          onPressed: settled ? widget.onCloseApp : null,
-          isLoading: !settled,
-          type: DivineButtonType.secondary,
+        if (!settled || widget.canCloseApp) {
+          return DivineButton(
+            label: context.l10n.databaseCorruptionCloseButton,
+            onPressed: settled ? widget.onCloseApp : null,
+            isLoading: !settled,
+            type: DivineButtonType.secondary,
+          );
+        }
+        return Text(
+          context.l10n.databaseCloseManual,
+          textAlign: TextAlign.center,
+          style: VineTheme.bodyMediumFont(
+            color: context.vineColors.onSurfaceVariant,
+          ),
         );
       },
     );

--- a/mobile/lib/startup/database_corruption_gate.dart
+++ b/mobile/lib/startup/database_corruption_gate.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Replaces the app UI with a restart prompt once the local database
 // ABOUTME: reports on-disk corruption, so the next launch can salvage it.
 
+import 'dart:async';
+
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -8,6 +10,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/database_corruption_provider.dart';
 import 'package:openvine/startup/close_app_support.dart';
+import 'package:unified_logger/unified_logger.dart';
 
 const _recoveryPersistenceTimeout = Duration(seconds: 15);
 
@@ -140,11 +143,43 @@ class _CloseAppAffordance extends StatefulWidget {
 }
 
 class _CloseAppAffordanceState extends State<_CloseAppAffordance> {
+  Timer? _persistenceTimer;
+
   // Resolved once, not per build, so a rebuild cannot restart the wait.
-  late final Future<void> _persisted =
-      (widget.awaitRecoveryPersisted?.call() ?? Future<void>.value()).timeout(
-        _recoveryPersistenceTimeout,
+  late final Future<void> _persisted = _waitForPersistence();
+
+  Future<void> _waitForPersistence() {
+    final source =
+        widget.awaitRecoveryPersisted?.call() ?? Future<void>.value();
+    final completion = Completer<void>();
+    late final Timer timer;
+    timer = Timer(_recoveryPersistenceTimeout, () {
+      Log.warning(
+        'Timed out waiting for the database recovery flag to persist',
+        name: 'DatabaseCorruptionScreen',
+        category: LogCategory.system,
       );
+      if (!completion.isCompleted) completion.complete();
+    });
+    _persistenceTimer = timer;
+    source.then(
+      (_) {
+        timer.cancel();
+        if (!completion.isCompleted) completion.complete();
+      },
+      onError: (Object error, StackTrace stack) {
+        timer.cancel();
+        if (!completion.isCompleted) completion.completeError(error, stack);
+      },
+    );
+    return completion.future;
+  }
+
+  @override
+  void dispose() {
+    _persistenceTimer?.cancel();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/mobile/lib/startup/database_corruption_gate.dart
+++ b/mobile/lib/startup/database_corruption_gate.dart
@@ -9,6 +9,8 @@ import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/database_corruption_provider.dart';
 import 'package:openvine/startup/close_app_support.dart';
 
+const _recoveryPersistenceTimeout = Duration(seconds: 15);
+
 /// Swaps [child] for [DatabaseCorruptionScreen] once corruption surfaces.
 ///
 /// Installed as `MaterialApp.builder`, so it covers every route with one gate
@@ -140,7 +142,9 @@ class _CloseAppAffordance extends StatefulWidget {
 class _CloseAppAffordanceState extends State<_CloseAppAffordance> {
   // Resolved once, not per build, so a rebuild cannot restart the wait.
   late final Future<void> _persisted =
-      widget.awaitRecoveryPersisted?.call() ?? Future<void>.value();
+      (widget.awaitRecoveryPersisted?.call() ?? Future<void>.value()).timeout(
+        _recoveryPersistenceTimeout,
+      );
 
   @override
   Widget build(BuildContext context) {
@@ -153,31 +157,22 @@ class _CloseAppAffordanceState extends State<_CloseAppAffordance> {
         // better off than one held in a session that cannot recover.
         final settled = snapshot.connectionState == ConnectionState.done;
         if (!settled) {
-          return Column(
-            mainAxisSize: MainAxisSize.min,
-            spacing: 12,
-            children: [
-              CircularProgressIndicator(
-                semanticsLabel: context.l10n.commonLoading,
-              ),
-              Text(
-                context.l10n.commonLoading,
-                style: VineTheme.bodyMediumFont(
-                  color: context.vineColors.onSurfaceVariant,
-                ),
-              ),
-            ],
+          return CircularProgressIndicator(
+            semanticsLabel: context.l10n.commonLoading,
           );
         }
         return Column(
           mainAxisSize: MainAxisSize.min,
           spacing: 16,
           children: [
-            Text(
-              context.l10n.databaseCorruptionBody,
-              textAlign: TextAlign.center,
-              style: VineTheme.bodyMediumFont(
-                color: context.vineColors.onSurfaceVariant,
+            Semantics(
+              liveRegion: true,
+              child: Text(
+                context.l10n.databaseCorruptionBody,
+                textAlign: TextAlign.center,
+                style: VineTheme.bodyMediumFont(
+                  color: context.vineColors.onSurfaceVariant,
+                ),
               ),
             ),
             if (widget.canCloseApp)

--- a/mobile/lib/startup/database_corruption_gate.dart
+++ b/mobile/lib/startup/database_corruption_gate.dart
@@ -100,13 +100,6 @@ class DatabaseCorruptionScreen extends StatelessWidget {
                       color: context.vineColors.primaryText,
                     ),
                   ),
-                  Text(
-                    l10n.databaseCorruptionBody,
-                    textAlign: TextAlign.center,
-                    style: VineTheme.bodyMediumFont(
-                      color: context.vineColors.onSurfaceVariant,
-                    ),
-                  ),
                   _CloseAppAffordance(
                     awaitRecoveryPersisted: awaitRecoveryPersisted,
                     canCloseApp: canCloseApp ?? platformCanCloseApp,
@@ -122,7 +115,8 @@ class DatabaseCorruptionScreen extends StatelessWidget {
   }
 }
 
-/// The close affordance, held until the recovery flag is durable.
+/// The recovery instructions and close affordance, held until the recovery
+/// flag is durable.
 ///
 /// Closing before the write lands would strand the user on the same corrupt
 /// database: the restart only repairs anything if the next launch can read the
@@ -153,29 +147,46 @@ class _CloseAppAffordanceState extends State<_CloseAppAffordance> {
     return FutureBuilder<void>(
       future: _persisted,
       builder: (context, snapshot) {
-        // Any terminal state releases the button, including a failed write:
+        // Any terminal state releases the instructions, including a failed
+        // write:
         // the service has already logged it, and a user who restarts anyway is
         // better off than one held in a session that cannot recover.
         final settled = snapshot.connectionState == ConnectionState.done;
         if (!settled) {
-          if (!widget.canCloseApp) {
-            return const SizedBox.square(
-              dimension: 24,
-              child: CircularProgressIndicator(),
-            );
-          }
-          return DivineButton(
-            label: context.l10n.databaseCorruptionCloseButton,
-            onPressed: null,
-            isLoading: true,
-            type: DivineButtonType.secondary,
+          return Column(
+            mainAxisSize: MainAxisSize.min,
+            spacing: 12,
+            children: [
+              CircularProgressIndicator(
+                semanticsLabel: context.l10n.commonLoading,
+              ),
+              Text(
+                context.l10n.commonLoading,
+                style: VineTheme.bodyMediumFont(
+                  color: context.vineColors.onSurfaceVariant,
+                ),
+              ),
+            ],
           );
         }
-        if (!widget.canCloseApp) return const SizedBox.shrink();
-        return DivineButton(
-          label: context.l10n.databaseCorruptionCloseButton,
-          onPressed: widget.onCloseApp,
-          type: DivineButtonType.secondary,
+        return Column(
+          mainAxisSize: MainAxisSize.min,
+          spacing: 16,
+          children: [
+            Text(
+              context.l10n.databaseCorruptionBody,
+              textAlign: TextAlign.center,
+              style: VineTheme.bodyMediumFont(
+                color: context.vineColors.onSurfaceVariant,
+              ),
+            ),
+            if (widget.canCloseApp)
+              DivineButton(
+                label: context.l10n.databaseCorruptionCloseButton,
+                onPressed: widget.onCloseApp,
+                type: DivineButtonType.secondary,
+              ),
+          ],
         );
       },
     );

--- a/mobile/test/startup/close_app_support_test.dart
+++ b/mobile/test/startup/close_app_support_test.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/startup/close_app_support.dart';
+
+void main() {
+  tearDown(() {
+    debugDefaultTargetPlatformOverride = null;
+  });
+
+  for (final platform in TargetPlatform.values) {
+    test('only Android can close the app ($platform)', () {
+      debugDefaultTargetPlatformOverride = platform;
+
+      expect(platformCanCloseApp, platform == TargetPlatform.android);
+    });
+  }
+}

--- a/mobile/test/startup/close_app_support_test.dart
+++ b/mobile/test/startup/close_app_support_test.dart
@@ -7,11 +7,13 @@ void main() {
     debugDefaultTargetPlatformOverride = null;
   });
 
-  for (final platform in TargetPlatform.values) {
-    test('only Android can close the app ($platform)', () {
-      debugDefaultTargetPlatformOverride = platform;
+  group('platformCanCloseApp', () {
+    for (final platform in TargetPlatform.values) {
+      test('only Android can close the app ($platform)', () {
+        debugDefaultTargetPlatformOverride = platform;
 
-      expect(platformCanCloseApp, platform == TargetPlatform.android);
-    });
-  }
+        expect(platformCanCloseApp, platform == TargetPlatform.android);
+      });
+    }
+  });
 }

--- a/mobile/test/startup/close_app_support_test.dart
+++ b/mobile/test/startup/close_app_support_test.dart
@@ -9,10 +9,17 @@ void main() {
 
   group('platformCanCloseApp', () {
     for (final platform in TargetPlatform.values) {
-      test('only Android can close the app ($platform)', () {
+      test('reports close support for $platform', () {
         debugDefaultTargetPlatformOverride = platform;
 
-        expect(platformCanCloseApp, platform == TargetPlatform.android);
+        expect(
+          platformCanCloseApp,
+          const {
+            TargetPlatform.android,
+            TargetPlatform.linux,
+            TargetPlatform.macOS,
+          }.contains(platform),
+        );
       });
     }
   });

--- a/mobile/test/startup/database_bootstrap_failure_app_test.dart
+++ b/mobile/test/startup/database_bootstrap_failure_app_test.dart
@@ -729,6 +729,13 @@ void main() {
     // back to constants cannot pass.
     final es = lookupAppLocalizations(const Locale('es'));
 
+    test('keeps the reset confirmation platform neutral', () {
+      expect(
+        l10n.dbFailureResetConfirm.toLowerCase(),
+        isNot(contains('close')),
+      );
+    });
+
     testWidgets('renders the failure step in the requested locale', (
       tester,
     ) async {
@@ -765,6 +772,7 @@ void main() {
 
       expect(find.text(es.dbFailureConfirmTitle), findsOneWidget);
       expect(find.text(es.dbFailureConfirmBody), findsOneWidget);
+      expect(find.text(es.dbFailureResetConfirm), findsOneWidget);
       expect(find.text(es.dbFailureCancel), findsOneWidget);
     });
 

--- a/mobile/test/startup/database_bootstrap_failure_app_test.dart
+++ b/mobile/test/startup/database_bootstrap_failure_app_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:db_client/db_client.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -299,24 +300,25 @@ void main() {
       expect(closed, isTrue);
     });
 
-    testWidgets('instructs iOS users to close after startup failure', (
+    testWidgets('hides the close action on iOS by platform default', (
       tester,
     ) async {
-      await tester.pumpWidget(
-        DatabaseBootstrapFailureApp(
-          error: DatabaseCipherStorageUnavailableException(
-            _lockedKeychainFailure(),
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      try {
+        await tester.pumpWidget(
+          DatabaseBootstrapFailureApp(
+            error: DatabaseCipherStorageUnavailableException(
+              _lockedKeychainFailure(),
+            ),
+            stack: StackTrace.current,
           ),
-          stack: StackTrace.current,
-          canCloseApp: false,
-        ),
-      );
+        );
 
-      expect(find.text(l10n.dbFailureCloseApp), findsNothing);
-      expect(
-        find.text(l10n.databaseCloseManual),
-        findsOneWidget,
-      );
+        expect(find.text(l10n.dbFailureCloseApp), findsNothing);
+        expect(find.text(l10n.dbFailureAdviceRestart), findsOneWidget);
+      } finally {
+        debugDefaultTargetPlatformOverride = null;
+      }
     });
 
     test('classifies cipher availability failures for release diagnostics', () {
@@ -556,10 +558,7 @@ void main() {
       expect(closes, isZero);
 
       expect(find.text(l10n.dbFailureCloseApp), findsNothing);
-      expect(
-        find.text(l10n.databaseCloseManual),
-        findsOneWidget,
-      );
+      expect(find.text(l10n.dbFailureResetDoneBody), findsOneWidget);
       expect(
         closes,
         isZero,

--- a/mobile/test/startup/database_bootstrap_failure_app_test.dart
+++ b/mobile/test/startup/database_bootstrap_failure_app_test.dart
@@ -299,6 +299,26 @@ void main() {
       expect(closed, isTrue);
     });
 
+    testWidgets('instructs iOS users to close after startup failure', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        DatabaseBootstrapFailureApp(
+          error: DatabaseCipherStorageUnavailableException(
+            _lockedKeychainFailure(),
+          ),
+          stack: StackTrace.current,
+          canCloseApp: false,
+        ),
+      );
+
+      expect(find.text(l10n.dbFailureCloseApp), findsNothing);
+      expect(
+        find.text(l10n.databaseCloseManual),
+        findsOneWidget,
+      );
+    });
+
     test('classifies cipher availability failures for release diagnostics', () {
       expect(
         databaseBootstrapDiagnosticCode(
@@ -520,6 +540,7 @@ void main() {
         DatabaseBootstrapFailureApp(
           error: StateError('something else entirely'),
           stack: StackTrace.current,
+          canCloseApp: false,
           onCloseApp: () => closes++,
           onResetLocalDatabase: (_) async {},
         ),
@@ -532,14 +553,43 @@ void main() {
 
       expect(find.text(l10n.dbFailureResetDoneTitle), findsOneWidget);
       expect(find.text(l10n.dbFailureResetConfirm), findsNothing);
-      expect(closes, equals(1));
+      expect(closes, isZero);
 
-      await tester.tap(find.text(l10n.dbFailureCloseApp));
+      expect(find.text(l10n.dbFailureCloseApp), findsNothing);
+      expect(
+        find.text(l10n.databaseCloseManual),
+        findsOneWidget,
+      );
       expect(
         closes,
-        equals(2),
-        reason: 'the terminal step still needs a live way out',
+        isZero,
+        reason: 'the terminal step must not offer another dead close action',
       );
+    });
+
+    testWidgets('keeps the terminal close action on Android', (tester) async {
+      var closes = 0;
+
+      await tester.pumpWidget(
+        DatabaseBootstrapFailureApp(
+          error: StateError('something else entirely'),
+          stack: StackTrace.current,
+          canCloseApp: true,
+          onCloseApp: () => closes++,
+          onResetLocalDatabase: (_) async {},
+        ),
+      );
+
+      await tester.tap(find.text(l10n.dbFailureResetAction));
+      await tester.pump();
+      await tester.tap(find.text(l10n.dbFailureResetConfirm));
+      await tester.pump();
+
+      expect(closes, equals(1));
+      expect(find.text(l10n.dbFailureCloseApp), findsOneWidget);
+
+      await tester.tap(find.text(l10n.dbFailureCloseApp));
+      expect(closes, equals(2));
     });
 
     testWidgets('reports a reset that hangs instead of spinning forever', (

--- a/mobile/test/startup/database_corruption_gate_test.dart
+++ b/mobile/test/startup/database_corruption_gate_test.dart
@@ -98,6 +98,7 @@ void main() {
 
     testWidgets('explains the restart repairs the database', (tester) async {
       await tester.pumpWidget(buildScreen(() {}));
+      await tester.pump();
 
       expect(find.text(l10n.databaseCorruptionTitle), findsOneWidget);
       expect(find.text(l10n.databaseCorruptionBody), findsOneWidget);
@@ -174,12 +175,12 @@ void main() {
       );
       await tester.pump();
 
-      await tester.tap(find.byType(DivineButton));
-      await tester.pump();
-
       // Closing before the flag lands strands the user on the same corrupt
       // database: the restart only repairs anything if the next launch can
       // read the flag this write is still committing.
+      expect(find.byType(DivineButton), findsNothing);
+      expect(find.text(l10n.databaseCorruptionBody), findsNothing);
+      expect(find.text(l10n.commonLoading), findsOneWidget);
       expect(closed, isFalse);
 
       persisted.complete();
@@ -190,28 +191,39 @@ void main() {
       expect(closed, isTrue);
     });
 
-    testWidgets('shows no dead close action while iOS recovery is persisting', (
+    testWidgets('holds iOS restart instructions until recovery is durable', (
       tester,
     ) async {
       final persisted = Completer<void>();
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
 
-      await tester.pumpWidget(
-        buildScreen(
-          () {},
-          awaitRecoveryPersisted: () => persisted.future,
-          canCloseApp: false,
-        ),
-      );
-      await tester.pump();
+      try {
+        await tester.pumpWidget(
+          buildScreen(
+            () {},
+            awaitRecoveryPersisted: () => persisted.future,
+          ),
+        );
+        await tester.pump();
 
-      expect(find.byType(DivineButton), findsNothing);
-      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+        expect(find.byType(DivineButton), findsNothing);
+        expect(find.text(l10n.databaseCorruptionBody), findsNothing);
+        expect(find.text(l10n.commonLoading), findsOneWidget);
+        expect(
+          tester.getSemantics(find.byType(CircularProgressIndicator)),
+          matchesSemantics(label: l10n.commonLoading),
+        );
 
-      persisted.complete();
-      await tester.pump();
+        persisted.complete();
+        await tester.pump();
 
-      expect(find.byType(DivineButton), findsNothing);
-      expect(find.byType(CircularProgressIndicator), findsNothing);
+        expect(find.byType(DivineButton), findsNothing);
+        expect(find.byType(CircularProgressIndicator), findsNothing);
+        expect(find.text(l10n.commonLoading), findsNothing);
+        expect(find.text(l10n.databaseCorruptionBody), findsOneWidget);
+      } finally {
+        debugDefaultTargetPlatformOverride = null;
+      }
     });
   });
 }

--- a/mobile/test/startup/database_corruption_gate_test.dart
+++ b/mobile/test/startup/database_corruption_gate_test.dart
@@ -180,7 +180,7 @@ void main() {
       // read the flag this write is still committing.
       expect(find.byType(DivineButton), findsNothing);
       expect(find.text(l10n.databaseCorruptionBody), findsNothing);
-      expect(find.text(l10n.commonLoading), findsOneWidget);
+      expect(find.text(l10n.commonLoading), findsNothing);
       expect(closed, isFalse);
 
       persisted.complete();
@@ -208,7 +208,7 @@ void main() {
 
         expect(find.byType(DivineButton), findsNothing);
         expect(find.text(l10n.databaseCorruptionBody), findsNothing);
-        expect(find.text(l10n.commonLoading), findsOneWidget);
+        expect(find.text(l10n.commonLoading), findsNothing);
         expect(
           tester.getSemantics(find.byType(CircularProgressIndicator)),
           matchesSemantics(label: l10n.commonLoading),
@@ -221,9 +221,37 @@ void main() {
         expect(find.byType(CircularProgressIndicator), findsNothing);
         expect(find.text(l10n.commonLoading), findsNothing);
         expect(find.text(l10n.databaseCorruptionBody), findsOneWidget);
+        expect(
+          tester
+              .getSemantics(find.text(l10n.databaseCorruptionBody))
+              .getSemanticsData()
+              .flagsCollection
+              .isLiveRegion,
+          isTrue,
+        );
       } finally {
         debugDefaultTargetPlatformOverride = null;
       }
+    });
+
+    testWidgets('releases restart instructions when persistence hangs', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        buildScreen(
+          () {},
+          awaitRecoveryPersisted: () => Completer<void>().future,
+          canCloseApp: false,
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text(l10n.databaseCorruptionBody), findsNothing);
+
+      await tester.pump(const Duration(seconds: 16));
+
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+      expect(find.text(l10n.databaseCorruptionBody), findsOneWidget);
     });
   });
 }

--- a/mobile/test/startup/database_corruption_gate_test.dart
+++ b/mobile/test/startup/database_corruption_gate_test.dart
@@ -253,5 +253,19 @@ void main() {
       expect(find.byType(CircularProgressIndicator), findsNothing);
       expect(find.text(l10n.databaseCorruptionBody), findsOneWidget);
     });
+
+    testWidgets('cancels the persistence timeout when disposed', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        buildScreen(
+          () {},
+          awaitRecoveryPersisted: () => Completer<void>().future,
+        ),
+      );
+      await tester.pump();
+
+      await tester.pumpWidget(const SizedBox.shrink());
+    });
   });
 }

--- a/mobile/test/startup/database_corruption_gate_test.dart
+++ b/mobile/test/startup/database_corruption_gate_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
@@ -83,11 +84,13 @@ void main() {
     Widget buildScreen(
       VoidCallback onCloseApp, {
       Future<void> Function()? awaitRecoveryPersisted,
+      bool? canCloseApp,
     }) => MaterialApp(
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
       home: DatabaseCorruptionScreen(
         awaitRecoveryPersisted: awaitRecoveryPersisted,
+        canCloseApp: canCloseApp,
         onCloseApp: onCloseApp,
       ),
     );
@@ -108,6 +111,51 @@ void main() {
       await tester.pump();
 
       expect(closed, isTrue);
+    });
+
+    testWidgets('instructs iOS users to close the app themselves', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildScreen(() {}, canCloseApp: false));
+      await tester.pump();
+
+      expect(find.byType(DivineButton), findsNothing);
+      expect(
+        find.text(l10n.databaseCloseManual),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('uses SystemNavigator.pop by default on Android', (
+      tester,
+    ) async {
+      final methodCalls = <MethodCall>[];
+      final messenger =
+          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+      messenger.setMockMethodCallHandler(SystemChannels.platform, (call) async {
+        methodCalls.add(call);
+        return null;
+      });
+      addTearDown(
+        () => messenger.setMockMethodCallHandler(SystemChannels.platform, null),
+      );
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: DatabaseCorruptionScreen(),
+        ),
+      );
+      await tester.pump();
+
+      await tester.tap(find.text(l10n.databaseCorruptionCloseButton));
+      await tester.pump();
+
+      expect(
+        methodCalls.where((call) => call.method == 'SystemNavigator.pop'),
+        hasLength(1),
+      );
     });
 
     testWidgets('will not close until the recovery flag is durable', (
@@ -137,6 +185,36 @@ void main() {
       await tester.pump();
 
       expect(closed, isTrue);
+    });
+
+    testWidgets('holds the iOS instruction until recovery is durable', (
+      tester,
+    ) async {
+      final persisted = Completer<void>();
+
+      await tester.pumpWidget(
+        buildScreen(
+          () {},
+          awaitRecoveryPersisted: () => persisted.future,
+          canCloseApp: false,
+        ),
+      );
+      await tester.pump();
+
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      expect(
+        find.text(l10n.databaseCloseManual),
+        findsNothing,
+      );
+
+      persisted.complete();
+      await tester.pump();
+
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+      expect(
+        find.text(l10n.databaseCloseManual),
+        findsOneWidget,
+      );
     });
   });
 }

--- a/mobile/test/startup/database_corruption_gate_test.dart
+++ b/mobile/test/startup/database_corruption_gate_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -113,17 +114,19 @@ void main() {
       expect(closed, isTrue);
     });
 
-    testWidgets('instructs iOS users to close the app themselves', (
+    testWidgets('hides the close action on iOS by platform default', (
       tester,
     ) async {
-      await tester.pumpWidget(buildScreen(() {}, canCloseApp: false));
-      await tester.pump();
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      try {
+        await tester.pumpWidget(buildScreen(() {}));
+        await tester.pump();
 
-      expect(find.byType(DivineButton), findsNothing);
-      expect(
-        find.text(l10n.databaseCloseManual),
-        findsOneWidget,
-      );
+        expect(find.byType(DivineButton), findsNothing);
+        expect(find.text(l10n.databaseCorruptionBody), findsOneWidget);
+      } finally {
+        debugDefaultTargetPlatformOverride = null;
+      }
     });
 
     testWidgets('uses SystemNavigator.pop by default on Android', (
@@ -187,7 +190,7 @@ void main() {
       expect(closed, isTrue);
     });
 
-    testWidgets('holds the iOS instruction until recovery is durable', (
+    testWidgets('shows no dead close action while iOS recovery is persisting', (
       tester,
     ) async {
       final persisted = Completer<void>();
@@ -201,20 +204,14 @@ void main() {
       );
       await tester.pump();
 
+      expect(find.byType(DivineButton), findsNothing);
       expect(find.byType(CircularProgressIndicator), findsOneWidget);
-      expect(
-        find.text(l10n.databaseCloseManual),
-        findsNothing,
-      );
 
       persisted.complete();
       await tester.pump();
 
+      expect(find.byType(DivineButton), findsNothing);
       expect(find.byType(CircularProgressIndicator), findsNothing);
-      expect(
-        find.text(l10n.databaseCloseManual),
-        findsOneWidget,
-      );
     });
   });
 }

--- a/mobile/test/startup/database_corruption_gate_test.dart
+++ b/mobile/test/startup/database_corruption_gate_test.dart
@@ -11,6 +11,7 @@ import 'package:openvine/providers/database_corruption_provider.dart';
 import 'package:openvine/services/database_corruption_service.dart';
 import 'package:openvine/startup/database_corruption_gate.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:unified_logger/unified_logger.dart';
 
 void main() {
   late AppLocalizations l10n;
@@ -237,6 +238,7 @@ void main() {
     testWidgets('releases restart instructions when persistence hangs', (
       tester,
     ) async {
+      await LogCaptureService().clearAllLogs();
       await tester.pumpWidget(
         buildScreen(
           () {},
@@ -252,6 +254,52 @@ void main() {
 
       expect(find.byType(CircularProgressIndicator), findsNothing);
       expect(find.text(l10n.databaseCorruptionBody), findsOneWidget);
+      expect(
+        LogCaptureService().getRecentLogs().map((entry) => entry.message),
+        contains(
+          contains(
+            'Timed out waiting for the database recovery flag to persist',
+          ),
+        ),
+      );
+    });
+
+    testWidgets('absorbs persistence completion after the timeout', (
+      tester,
+    ) async {
+      final persisted = Completer<void>();
+      await tester.pumpWidget(
+        buildScreen(
+          () {},
+          awaitRecoveryPersisted: () => persisted.future,
+          canCloseApp: false,
+        ),
+      );
+      await tester.pump(const Duration(seconds: 16));
+
+      persisted.complete();
+      await tester.pump();
+
+      expect(find.text(l10n.databaseCorruptionBody), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('absorbs persistence error after the timeout', (tester) async {
+      final persisted = Completer<void>();
+      await tester.pumpWidget(
+        buildScreen(
+          () {},
+          awaitRecoveryPersisted: () => persisted.future,
+          canCloseApp: false,
+        ),
+      );
+      await tester.pump(const Duration(seconds: 16));
+
+      persisted.completeError(StateError('late persistence failure'));
+      await tester.pump();
+
+      expect(find.text(l10n.databaseCorruptionBody), findsOneWidget);
+      expect(tester.takeException(), isNull);
     });
 
     testWidgets('cancels the persistence timeout when disposed', (


### PR DESCRIPTION
On iOS, database recovery screens offered a Close Divine button that silently did nothing, leaving users stuck on a full-screen takeover. Flutter cannot end an iOS app whose view controller is the root, so the promised action was impossible.

This change makes app-close support an explicit platform capability. Android, macOS, and Linux keep their working close action. iOS, Windows, Fuchsia, and web do not offer it; the existing localized recovery copy already tells users to close and reopen Divine. The corruption screen now waits for recovery state to persist before showing restart instructions, with a bounded fallback if the platform channel hangs. The same correction covers the two adjacent startup database-failure views that had the identical dead action.

This does not change corruption detection, database salvage, reset behavior, or the working close paths on Android and desktop.

Verification:
- all 111 startup and localization consistency tests
- platform-default mutation coverage for both affected widgets
- timeout, disposal, and late-completion mutation coverage
- flutter analyze
- ARB consistency across all 22 locales
- hardcoded localization scan
- orphaned ARB key and test-structure ratchets
- repository pre-push checks

Closes #8246
