### PR TITLE
fix(moderation): retry a labeler load that no relay answered

### DIFF
--- a/mobile/lib/services/moderation_label_service.dart
+++ b/mobile/lib/services/moderation_label_service.dart
@@ -163,6 +163,9 @@ class ModerationLabelService {
   StreamSubscription<Map<String, RelayConnectionStatus>>?
   _relayReadyRetrySubscription;
 
+  /// Set by [dispose]; stops an in-flight load from arming a new retry.
+  bool _disposed = false;
+
   /// Active subscriptions.
   final Map<String, StreamSubscription<dynamic>> _subscriptions = {};
 
@@ -348,6 +351,9 @@ class ModerationLabelService {
   /// abandon and re-drive itself in a tight loop. Waiting for the next status
   /// change cannot spin and is still strictly better than latching.
   void _scheduleRetryWhenRelayReady(String pubkey) {
+    // A load already in flight when dispose() ran still completes, and would
+    // otherwise arm a subscription nothing is left to cancel.
+    if (_disposed) return;
     _labelersAwaitingRelay.add(pubkey);
 
     if (_relayReadyRetrySubscription != null) return;
@@ -854,6 +860,7 @@ class ModerationLabelService {
 
   /// Clean up subscriptions.
   void dispose() {
+    _disposed = true;
     unawaited(_relayReadyRetrySubscription?.cancel());
     _relayReadyRetrySubscription = null;
     _labelersAwaitingRelay.clear();

--- a/mobile/lib/services/moderation_label_service.dart
+++ b/mobile/lib/services/moderation_label_service.dart
@@ -163,6 +163,13 @@ class ModerationLabelService {
   StreamSubscription<Map<String, RelayConnectionStatus>>?
   _relayReadyRetrySubscription;
 
+  /// Whether a relay was connected when the latest status was observed.
+  ///
+  /// A retry is driven only by a disconnected-to-connected transition. Without
+  /// this edge detector, any unrelated status update while another relay stayed
+  /// connected could re-run every pending labeler's full-history query.
+  bool _hadConnectedRelayWhileWaiting = false;
+
   /// Set by [dispose]; stops an in-flight load from arming a new retry.
   bool _disposed = false;
 
@@ -294,6 +301,7 @@ class ModerationLabelService {
         requireAllRelaysSettled: true,
       );
       final events = result.events;
+      final isIncomplete = result.noRelays || result.timedOut;
 
       // Apply whatever came back before deciding whether to latch.
       // `queryEventsDetailed` merges cached rows into `events` regardless of
@@ -304,10 +312,17 @@ class ModerationLabelService {
       // and then retried, and `_processLabelEvent` appends, so reprocessing the
       // same events would accumulate duplicate rows for every retry. Each load
       // replaces what that labeler previously contributed.
-      _removeLabelsForLabeler(pubkey);
-      events.forEach(_processLabelEvent);
+      // An incomplete empty result has no evidence with which to replace known
+      // rows. This is reachable when the client is already disposed (which
+      // returns `noRelays` before consulting the cache), or after cached rows
+      // expire. Preserve existing warnings until a retry produces events or an
+      // affirmative empty answer.
+      if (events.isNotEmpty || !isIncomplete) {
+        _removeLabelsForLabeler(pubkey);
+        events.forEach(_processLabelEvent);
+      }
 
-      if (result.noRelays || result.timedOut) {
+      if (isIncomplete) {
         Log.warning(
           'Labeler load incomplete for ${pubkeyForLogs(pubkey)} '
           '(noRelays: ${result.noRelays}, timedOut: ${result.timedOut}, '
@@ -358,11 +373,18 @@ class ModerationLabelService {
 
     if (_relayReadyRetrySubscription != null) return;
 
+    _hadConnectedRelayWhileWaiting = _nostrClient.connectedRelayCount > 0;
+
     _relayReadyRetrySubscription = _nostrClient.relayStatusStream.listen((
       statuses,
     ) {
-      if (statuses.values.any((status) => status.isConnected)) {
+      final hasConnectedRelay = statuses.values.any(
+        (status) => status.isConnected,
+      );
+      if (hasConnectedRelay && !_hadConnectedRelayWhileWaiting) {
         _retryLabelersAwaitingRelay();
+      } else {
+        _hadConnectedRelayWhileWaiting = hasConnectedRelay;
       }
     });
   }
@@ -372,6 +394,7 @@ class ModerationLabelService {
     _labelersAwaitingRelay.clear();
     unawaited(_relayReadyRetrySubscription?.cancel());
     _relayReadyRetrySubscription = null;
+    _hadConnectedRelayWhileWaiting = false;
 
     if (pending.isEmpty) return;
 
@@ -691,8 +714,18 @@ class ModerationLabelService {
   Future<void> _unloadLabeler(String pubkey) async {
     await _subscriptions[pubkey]?.cancel();
     _subscriptions.remove(pubkey);
+    _removePendingLabelerRetry(pubkey);
     _loadedLabelers.remove(pubkey);
     _removeLabelsForLabeler(pubkey);
+  }
+
+  void _removePendingLabelerRetry(String pubkey) {
+    _labelersAwaitingRelay.remove(pubkey);
+    if (_labelersAwaitingRelay.isNotEmpty) return;
+
+    unawaited(_relayReadyRetrySubscription?.cancel());
+    _relayReadyRetrySubscription = null;
+    _hadConnectedRelayWhileWaiting = false;
   }
 
   void _removeLabelsForLabeler(String pubkey) {
@@ -846,6 +879,7 @@ class ModerationLabelService {
 
     for (final pubkey in retired) {
       // Clean up any labels fetched from the old key
+      _removePendingLabelerRetry(pubkey);
       _removeLabelsForLabeler(pubkey);
       _loadedLabelers.remove(pubkey);
     }
@@ -864,6 +898,7 @@ class ModerationLabelService {
     unawaited(_relayReadyRetrySubscription?.cancel());
     _relayReadyRetrySubscription = null;
     _labelersAwaitingRelay.clear();
+    _hadConnectedRelayWhileWaiting = false;
     for (final sub in _subscriptions.values) {
       sub.cancel();
     }

--- a/mobile/lib/services/moderation_label_service.dart
+++ b/mobile/lib/services/moderation_label_service.dart
@@ -290,10 +290,25 @@ class ModerationLabelService {
         [filter],
         requireAllRelaysSettled: true,
       );
+      final events = result.events;
+
+      // Apply whatever came back before deciding whether to latch.
+      // `queryEventsDetailed` merges cached rows into `events` regardless of
+      // `timedOut` / `noRelays`, so an unanswered query can still carry real
+      // labels — dropping them would lose warnings the previous build applied.
+      //
+      // Drop this labeler's existing rows first: an incomplete load is applied
+      // and then retried, and `_processLabelEvent` appends, so reprocessing the
+      // same events would accumulate duplicate rows for every retry. Each load
+      // replaces what that labeler previously contributed.
+      _removeLabelsForLabeler(pubkey);
+      events.forEach(_processLabelEvent);
+
       if (result.noRelays || result.timedOut) {
         Log.warning(
           'Labeler load incomplete for ${pubkeyForLogs(pubkey)} '
-          '(noRelays: ${result.noRelays}, timedOut: ${result.timedOut}); '
+          '(noRelays: ${result.noRelays}, timedOut: ${result.timedOut}, '
+          'applied ${events.length} cached label event(s)); '
           'leaving it unloaded so a later attempt retries',
           name: 'ModerationLabelService',
           category: LogCategory.system,
@@ -301,9 +316,6 @@ class ModerationLabelService {
         _scheduleRetryWhenRelayReady(pubkey);
         return;
       }
-      final events = result.events;
-
-      events.forEach(_processLabelEvent);
 
       _loadedLabelers.add(pubkey);
 

--- a/mobile/lib/services/moderation_label_service.dart
+++ b/mobile/lib/services/moderation_label_service.dart
@@ -154,6 +154,15 @@ class ModerationLabelService {
   /// Labelers currently being loaded from relays.
   final Map<String, Future<void>> _loadingLabelers = {};
 
+  /// Labelers whose load was abandoned because no relay answered.
+  ///
+  /// Retried when a relay reconnects; see [_scheduleRetryWhenRelayReady].
+  final Set<String> _labelersAwaitingRelay = {};
+
+  /// Live while at least one labeler is waiting for a relay to come back.
+  StreamSubscription<Map<String, RelayConnectionStatus>>?
+  _relayReadyRetrySubscription;
+
   /// Active subscriptions.
   final Map<String, StreamSubscription<dynamic>> _subscriptions = {};
 
@@ -268,7 +277,31 @@ class ModerationLabelService {
         kinds: [NostrEventKinds.label], // NIP-32 label events
       );
 
-      final events = await _nostrClient.queryEvents([filter]);
+      // queryEventsDetailed, not queryEvents: the latter discards `timedOut`
+      // and `noRelays`, so a load nobody answered returns [] and is
+      // indistinguishable from "this labeler has no labels" — the forEach
+      // no-ops and the labeler is latched as loaded having contributed none.
+      // `requireAllRelaysSettled` is what makes a relay's `CLOSED` refusal and
+      // a partial fan-out surface as `timedOut` rather than completing on
+      // whichever relays answered first. Cache stays on, unlike #8213's scan:
+      // cached labels are still worth applying, and the fix is about not
+      // latching. #8214.
+      final result = await _nostrClient.queryEventsDetailed(
+        [filter],
+        requireAllRelaysSettled: true,
+      );
+      if (result.noRelays || result.timedOut) {
+        Log.warning(
+          'Labeler load incomplete for ${pubkeyForLogs(pubkey)} '
+          '(noRelays: ${result.noRelays}, timedOut: ${result.timedOut}); '
+          'leaving it unloaded so a later attempt retries',
+          name: 'ModerationLabelService',
+          category: LogCategory.system,
+        );
+        _scheduleRetryWhenRelayReady(pubkey);
+        return;
+      }
+      final events = result.events;
 
       events.forEach(_processLabelEvent);
 
@@ -286,6 +319,55 @@ class ModerationLabelService {
         name: 'ModerationLabelService',
         category: LogCategory.system,
       );
+    }
+  }
+
+  /// Retry [pubkey] the next time a relay connects.
+  ///
+  /// Deliberately event-bounded rather than attempt-bounded, mirroring
+  /// `VideoEventService`'s relay-ready retry: the pending set is bounded by the
+  /// number of subscribed labelers and every retry is driven by a relay status
+  /// update, so a hard attempt cap would risk leaving moderation labels
+  /// unloaded for the rest of the session after relay flapping.
+  ///
+  /// Note there is deliberately no "retry now if a relay is already
+  /// connected" branch. A load that timed out *with* a relay connected is the
+  /// common case — a connected-but-silent relay — and retrying it inline would
+  /// abandon and re-drive itself in a tight loop. Waiting for the next status
+  /// change cannot spin and is still strictly better than latching.
+  void _scheduleRetryWhenRelayReady(String pubkey) {
+    _labelersAwaitingRelay.add(pubkey);
+
+    if (_relayReadyRetrySubscription != null) return;
+
+    _relayReadyRetrySubscription = _nostrClient.relayStatusStream.listen((
+      statuses,
+    ) {
+      if (statuses.values.any((status) => status.isConnected)) {
+        _retryLabelersAwaitingRelay();
+      }
+    });
+  }
+
+  void _retryLabelersAwaitingRelay() {
+    final pending = Set<String>.of(_labelersAwaitingRelay);
+    _labelersAwaitingRelay.clear();
+    unawaited(_relayReadyRetrySubscription?.cancel());
+    _relayReadyRetrySubscription = null;
+
+    if (pending.isEmpty) return;
+
+    Log.info(
+      'Retrying ${pending.length} labeler load(s) after a relay connected',
+      name: 'ModerationLabelService',
+      category: LogCategory.system,
+    );
+
+    for (final pubkey in pending) {
+      // Back through the public entry point so the loaded gate and the
+      // in-flight coalescer both apply, and a retry racing a normal call
+      // cannot double-query.
+      unawaited(subscribeToLabeler(pubkey));
     }
   }
 
@@ -760,6 +842,9 @@ class ModerationLabelService {
 
   /// Clean up subscriptions.
   void dispose() {
+    unawaited(_relayReadyRetrySubscription?.cancel());
+    _relayReadyRetrySubscription = null;
+    _labelersAwaitingRelay.clear();
     for (final sub in _subscriptions.values) {
       sub.cancel();
     }

--- a/mobile/test/providers/moderation_label_provider_session_test.dart
+++ b/mobile/test/providers/moderation_label_provider_session_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:follow_repository/follow_repository.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/event.dart';
 import 'package:nostr_sdk/filter.dart';
 import 'package:openvine/providers/auth_providers.dart';
 import 'package:openvine/providers/moderation_providers.dart';
@@ -88,7 +89,12 @@ void main() {
       container.read(moderationLabelServiceProvider);
       await Future<void>.delayed(Duration.zero);
 
-      verifyNever(() => nostrClient.queryEvents(any()));
+      verifyNever(
+        () => nostrClient.queryEventsDetailed(
+          any(),
+          requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+        ),
+      );
     });
 
     test('subscribes labelers once active Nostr client is ready', () async {
@@ -99,7 +105,14 @@ void main() {
 
       when(() => nostrClient.hasKeys).thenReturn(true);
       when(() => nostrClient.publicKey).thenReturn(testPubkey);
-      when(() => nostrClient.queryEvents(any())).thenAnswer((_) async => []);
+      when(
+        () => nostrClient.queryEventsDetailed(
+          any(),
+          requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+        ),
+      ).thenAnswer(
+        (_) async => (events: <Event>[], timedOut: false, noRelays: false),
+      );
       when(() => followRepository.followingPubkeys).thenReturn(const []);
       when(
         () => followRepository.followingStream,
@@ -118,7 +131,12 @@ void main() {
       container.read(moderationLabelServiceProvider);
       await Future<void>.delayed(Duration.zero);
 
-      verify(() => nostrClient.queryEvents(any())).called(1);
+      verify(
+        () => nostrClient.queryEventsDetailed(
+          any(),
+          requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+        ),
+      ).called(1);
     });
 
     test(
@@ -142,8 +160,18 @@ void main() {
         container.read(moderationLabelServiceProvider);
         await Future<void>.delayed(Duration.zero);
 
-        verifyNever(() => activeClient.queryEvents(any()));
-        verifyNever(() => staleReadyClient.queryEvents(any()));
+        verifyNever(
+          () => activeClient.queryEventsDetailed(
+            any(),
+            requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+          ),
+        );
+        verifyNever(
+          () => staleReadyClient.queryEventsDetailed(
+            any(),
+            requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+          ),
+        );
       },
     );
   });

--- a/mobile/test/services/moderation_label_service_test.dart
+++ b/mobile/test/services/moderation_label_service_test.dart
@@ -1143,7 +1143,10 @@ void main() {
       );
 
       test('retries an abandoned labeler when a relay connects', () async {
-        final statuses = StreamController<Map<String, RelayConnectionStatus>>();
+        // Broadcast, like the real relayStatusStream: a single-subscription
+        // controller's close() never completes when nothing listened.
+        final statuses =
+            StreamController<Map<String, RelayConnectionStatus>>.broadcast();
         addTearDown(statuses.close);
         when(
           () => mockNostrClient.relayStatusStream,
@@ -1189,7 +1192,10 @@ void main() {
       });
 
       test('dispose cancels the pending relay-ready retry', () async {
-        final statuses = StreamController<Map<String, RelayConnectionStatus>>();
+        // Broadcast, like the real relayStatusStream: a single-subscription
+        // controller's close() never completes when nothing listened.
+        final statuses =
+            StreamController<Map<String, RelayConnectionStatus>>.broadcast();
         addTearDown(statuses.close);
         when(
           () => mockNostrClient.relayStatusStream,
@@ -1286,6 +1292,41 @@ void main() {
           );
         },
       );
+
+      test('a load completing after dispose does not re-arm a retry', () async {
+        // Broadcast, like the real relayStatusStream: a single-subscription
+        // controller's close() never completes when nothing listened.
+        final statuses =
+            StreamController<Map<String, RelayConnectionStatus>>.broadcast();
+        addTearDown(statuses.close);
+        when(
+          () => mockNostrClient.relayStatusStream,
+        ).thenAnswer((_) => statuses.stream);
+        when(() => mockNostrClient.connectedRelayCount).thenReturn(0);
+        final inFlight =
+            Completer<({List<Event> events, bool timedOut, bool noRelays})>();
+        when(
+          () => mockNostrClient.queryEventsDetailed(
+            any(),
+            requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+          ),
+        ).thenAnswer((_) => inFlight.future);
+
+        final pending = service.subscribeToLabeler(labeler);
+        await Future<void>.delayed(Duration.zero);
+
+        service.dispose();
+
+        inFlight.complete((events: <Event>[], timedOut: true, noRelays: false));
+        await pending;
+        await pumpEventQueue();
+
+        expect(
+          statuses.hasListener,
+          isFalse,
+          reason: 'a disposed service must not subscribe to relay status',
+        );
+      });
 
       test(
         'a retry replaces the labeler rows instead of appending them',

--- a/mobile/test/services/moderation_label_service_test.dart
+++ b/mobile/test/services/moderation_label_service_test.dart
@@ -73,6 +73,12 @@ void main() {
     mockPrefs = await SharedPreferences.getInstance();
     mockNostrClient = _MockNostrClient();
     mockAuthService = _MockAuthService();
+    when(() => mockNostrClient.connectedRelayCount).thenReturn(0);
+    when(
+      () => mockNostrClient.relayStatusStream,
+    ).thenAnswer(
+      (_) => const Stream<Map<String, RelayConnectionStatus>>.empty(),
+    );
     service = ModerationLabelService(
       nostrClient: mockNostrClient,
       authService: mockAuthService,
@@ -1038,6 +1044,67 @@ void main() {
           expect(service.getContentWarnings('explicit_event'), hasLength(1));
         },
       );
+
+      test(
+        'disabling followed moderation cancels a queued labeler retry',
+        () async {
+          const followedLabeler =
+              'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
+          final statuses =
+              StreamController<Map<String, RelayConnectionStatus>>.broadcast();
+          addTearDown(statuses.close);
+          when(
+            () => mockNostrClient.relayStatusStream,
+          ).thenAnswer((_) => statuses.stream);
+          when(() => mockNostrClient.connectedRelayCount).thenReturn(0);
+          when(
+            () => mockNostrClient.queryEventsDetailed(
+              any(),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+            ),
+          ).thenAnswer(
+            (_) async => (
+              events: <Event>[
+                _FakeLabelEvent(
+                  pubkey: followedLabeler,
+                  tags: [
+                    ['L', 'content-warning'],
+                    ['l', 'violence', 'content-warning'],
+                    ['e', 'removed_followed_event'],
+                  ],
+                ),
+              ],
+              timedOut: true,
+              noRelays: false,
+            ),
+          );
+
+          await service.setFollowingModerationEnabled(
+            true,
+            followedPubkeys: [followedLabeler],
+          );
+          expect(
+            service.getContentWarnings('removed_followed_event'),
+            hasLength(1),
+          );
+
+          await service.setFollowingModerationEnabled(false);
+          statuses.add({
+            'wss://relay.example': RelayConnectionStatus.connected(
+              'wss://relay.example',
+            ),
+          });
+          await pumpEventQueue();
+
+          expect(service.getContentWarnings('removed_followed_event'), isEmpty);
+          verify(
+            () => mockNostrClient.queryEventsDetailed(
+              any(),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+            ),
+          ).called(1);
+        },
+      );
     });
 
     group('incomplete labeler loads (#8214)', () {
@@ -1257,6 +1324,45 @@ void main() {
       );
 
       test(
+        'does not retry for unrelated status churn while a relay stays connected',
+        () async {
+          final statuses =
+              StreamController<Map<String, RelayConnectionStatus>>.broadcast();
+          addTearDown(statuses.close);
+          when(
+            () => mockNostrClient.relayStatusStream,
+          ).thenAnswer((_) => statuses.stream);
+          when(() => mockNostrClient.connectedRelayCount).thenReturn(1);
+          when(
+            () => mockNostrClient.queryEventsDetailed(
+              any(),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+            ),
+          ).thenAnswer(
+            (_) async => (events: <Event>[], timedOut: true, noRelays: false),
+          );
+
+          await service.subscribeToLabeler(labeler);
+          statuses.add({
+            'wss://stable.example': RelayConnectionStatus.connected(
+              'wss://stable.example',
+            ),
+            'wss://flapping.example': RelayConnectionStatus.connecting(
+              'wss://flapping.example',
+            ),
+          });
+          await pumpEventQueue();
+
+          verify(
+            () => mockNostrClient.queryEventsDetailed(
+              any(),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+            ),
+          ).called(1);
+        },
+      );
+
+      test(
         'applies cached labels even when the relay did not answer',
         () async {
           final statuses =
@@ -1331,9 +1437,7 @@ void main() {
       test(
         'a retry replaces the labeler rows instead of appending them',
         () async {
-          when(
-            () => mockNostrClient.relayStatusStream,
-          ).thenAnswer(
+          when(() => mockNostrClient.relayStatusStream).thenAnswer(
             (_) => const Stream<Map<String, RelayConnectionStatus>>.empty(),
           );
           when(() => mockNostrClient.connectedRelayCount).thenReturn(0);
@@ -1375,6 +1479,43 @@ void main() {
           );
         },
       );
+
+      test('an empty incomplete retry preserves known label rows', () async {
+        when(() => mockNostrClient.relayStatusStream).thenAnswer(
+          (_) => const Stream<Map<String, RelayConnectionStatus>>.empty(),
+        );
+        when(() => mockNostrClient.connectedRelayCount).thenReturn(0);
+        when(
+          () => mockNostrClient.queryEventsDetailed(
+            any(),
+            requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+          ),
+        ).thenAnswer(
+          (_) async => (
+            events: <Event>[labelFor('preserved_event')],
+            timedOut: true,
+            noRelays: false,
+          ),
+        );
+        await service.subscribeToLabeler(labeler);
+        expect(service.getContentWarnings('preserved_event'), hasLength(1));
+
+        when(
+          () => mockNostrClient.queryEventsDetailed(
+            any(),
+            requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+          ),
+        ).thenAnswer(
+          (_) async => (events: <Event>[], timedOut: false, noRelays: true),
+        );
+        await service.subscribeToLabeler(labeler);
+
+        expect(
+          service.getContentWarnings('preserved_event'),
+          hasLength(1),
+          reason: 'an inconclusive empty read must not erase known warnings',
+        );
+      });
     });
   });
 }

--- a/mobile/test/services/moderation_label_service_test.dart
+++ b/mobile/test/services/moderation_label_service_test.dart
@@ -1249,6 +1249,91 @@ void main() {
           );
         },
       );
+
+      test(
+        'applies cached labels even when the relay did not answer',
+        () async {
+          final statuses =
+              StreamController<Map<String, RelayConnectionStatus>>();
+          addTearDown(statuses.close);
+          when(
+            () => mockNostrClient.relayStatusStream,
+          ).thenAnswer((_) => statuses.stream);
+          when(() => mockNostrClient.connectedRelayCount).thenReturn(0);
+          // queryEventsDetailed merges cached rows into `events` regardless of
+          // timedOut/noRelays, so an unanswered query can still carry labels.
+          when(
+            () => mockNostrClient.queryEventsDetailed(
+              any(),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+            ),
+          ).thenAnswer(
+            (_) async => (
+              events: <Event>[labelFor('cached_event')],
+              timedOut: true,
+              noRelays: false,
+            ),
+          );
+
+          await service.subscribeToLabeler(labeler);
+
+          expect(
+            service.getContentWarnings('cached_event'),
+            hasLength(1),
+            reason:
+                'a cached label must not be dropped just because the relay '
+                'never answered',
+          );
+        },
+      );
+
+      test(
+        'a retry replaces the labeler rows instead of appending them',
+        () async {
+          when(
+            () => mockNostrClient.relayStatusStream,
+          ).thenAnswer(
+            (_) => const Stream<Map<String, RelayConnectionStatus>>.empty(),
+          );
+          when(() => mockNostrClient.connectedRelayCount).thenReturn(0);
+          // First attempt: cache rows present, relay silent.
+          when(
+            () => mockNostrClient.queryEventsDetailed(
+              any(),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+            ),
+          ).thenAnswer(
+            (_) async => (
+              events: <Event>[labelFor('repeat_event')],
+              timedOut: true,
+              noRelays: false,
+            ),
+          );
+          await service.subscribeToLabeler(labeler);
+          expect(service.getContentWarnings('repeat_event'), hasLength(1));
+
+          // Retry: the relay answers with the same event.
+          when(
+            () => mockNostrClient.queryEventsDetailed(
+              any(),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+            ),
+          ).thenAnswer(
+            (_) async => (
+              events: <Event>[labelFor('repeat_event')],
+              timedOut: false,
+              noRelays: false,
+            ),
+          );
+          await service.subscribeToLabeler(labeler);
+
+          expect(
+            service.getContentWarnings('repeat_event'),
+            hasLength(1),
+            reason: 'reprocessing the same label must not accumulate rows',
+          );
+        },
+      );
     });
   });
 }

--- a/mobile/test/services/moderation_label_service_test.dart
+++ b/mobile/test/services/moderation_label_service_test.dart
@@ -184,8 +184,13 @@ void main() {
         '{"names":{"moderation":"$divergentKey"}}',
       );
       when(
-        () => mockNostrClient.queryEvents(any()),
-      ).thenAnswer((_) async => <Event>[]);
+        () => mockNostrClient.queryEventsDetailed(
+          any(),
+          requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+        ),
+      ).thenAnswer(
+        (_) async => (events: <Event>[], timedOut: false, noRelays: false),
+      );
       final service = buildService(canQueryRelays: true);
 
       await service.initialize();
@@ -230,7 +235,12 @@ void main() {
             ModerationLabelService.fallbackModerationPubkeyHex,
           ]),
         );
-        verifyNever(() => mockNostrClient.queryEvents(any()));
+        verifyNever(
+          () => mockNostrClient.queryEventsDetailed(
+            any(),
+            requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+          ),
+        );
       },
     );
 
@@ -254,22 +264,36 @@ void main() {
 
       expect(localOnlyService.isFollowingModerationEnabled, isTrue);
       expect(localOnlyService.customLabelers, contains(existingLabeler));
-      verifyNever(() => mockNostrClient.queryEvents(any()));
+      verifyNever(
+        () => mockNostrClient.queryEventsDetailed(
+          any(),
+          requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+        ),
+      );
     });
 
     group('_processLabelEvent', () {
       test('parses basic content-warning label', () async {
-        when(() => mockNostrClient.queryEvents(any())).thenAnswer(
-          (_) async => [
-            _FakeLabelEvent(
-              pubkey: service.divineModerationPubkeyHex,
-              tags: [
-                ['L', 'content-warning'],
-                ['l', 'nudity', 'content-warning'],
-                ['e', 'target_event_id_abc'],
-              ],
-            ),
-          ],
+        when(
+          () => mockNostrClient.queryEventsDetailed(
+            any(),
+            requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+          ),
+        ).thenAnswer(
+          (_) async => (
+            events: <Event>[
+              _FakeLabelEvent(
+                pubkey: service.divineModerationPubkeyHex,
+                tags: [
+                  ['L', 'content-warning'],
+                  ['l', 'nudity', 'content-warning'],
+                  ['e', 'target_event_id_abc'],
+                ],
+              ),
+            ],
+            timedOut: false,
+            noRelays: false,
+          ),
         );
 
         await service.subscribeToLabeler(service.divineModerationPubkeyHex);
@@ -286,17 +310,26 @@ void main() {
       test('parses ai-generated label with confidence metadata', () async {
         const metadata =
             '{"confidence": 0.95, "source": "hiveai", "verified": true}';
-        when(() => mockNostrClient.queryEvents(any())).thenAnswer(
-          (_) async => [
-            _FakeLabelEvent(
-              pubkey: service.divineModerationPubkeyHex,
-              tags: [
-                ['L', 'content-warning'],
-                ['l', 'ai-generated', 'content-warning', metadata],
-                ['e', 'event_123'],
-              ],
-            ),
-          ],
+        when(
+          () => mockNostrClient.queryEventsDetailed(
+            any(),
+            requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+          ),
+        ).thenAnswer(
+          (_) async => (
+            events: <Event>[
+              _FakeLabelEvent(
+                pubkey: service.divineModerationPubkeyHex,
+                tags: [
+                  ['L', 'content-warning'],
+                  ['l', 'ai-generated', 'content-warning', metadata],
+                  ['e', 'event_123'],
+                ],
+              ),
+            ],
+            timedOut: false,
+            noRelays: false,
+          ),
         );
 
         await service.subscribeToLabeler(service.divineModerationPubkeyHex);
@@ -310,17 +343,26 @@ void main() {
       });
 
       test('handles malformed metadata JSON gracefully', () async {
-        when(() => mockNostrClient.queryEvents(any())).thenAnswer(
-          (_) async => [
-            _FakeLabelEvent(
-              pubkey: service.divineModerationPubkeyHex,
-              tags: [
-                ['L', 'content-warning'],
-                ['l', 'ai-generated', 'content-warning', 'not-valid-json'],
-                ['e', 'event_456'],
-              ],
-            ),
-          ],
+        when(
+          () => mockNostrClient.queryEventsDetailed(
+            any(),
+            requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+          ),
+        ).thenAnswer(
+          (_) async => (
+            events: <Event>[
+              _FakeLabelEvent(
+                pubkey: service.divineModerationPubkeyHex,
+                tags: [
+                  ['L', 'content-warning'],
+                  ['l', 'ai-generated', 'content-warning', 'not-valid-json'],
+                  ['e', 'event_456'],
+                ],
+              ),
+            ],
+            timedOut: false,
+            noRelays: false,
+          ),
         );
 
         await service.subscribeToLabeler(service.divineModerationPubkeyHex);
@@ -335,18 +377,27 @@ void main() {
 
       test('indexes labels by content hash from x tag', () async {
         const metadata = '{"confidence": 0.12, "source": "hiveai"}';
-        when(() => mockNostrClient.queryEvents(any())).thenAnswer(
-          (_) async => [
-            _FakeLabelEvent(
-              pubkey: service.divineModerationPubkeyHex,
-              tags: [
-                ['L', 'content-warning'],
-                ['l', 'ai-generated', 'content-warning', metadata],
-                ['e', 'event_789'],
-                ['x', 'sha256_hash_of_content'],
-              ],
-            ),
-          ],
+        when(
+          () => mockNostrClient.queryEventsDetailed(
+            any(),
+            requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+          ),
+        ).thenAnswer(
+          (_) async => (
+            events: <Event>[
+              _FakeLabelEvent(
+                pubkey: service.divineModerationPubkeyHex,
+                tags: [
+                  ['L', 'content-warning'],
+                  ['l', 'ai-generated', 'content-warning', metadata],
+                  ['e', 'event_789'],
+                  ['x', 'sha256_hash_of_content'],
+                ],
+              ),
+            ],
+            timedOut: false,
+            noRelays: false,
+          ),
         );
 
         await service.subscribeToLabeler(service.divineModerationPubkeyHex);
@@ -364,17 +415,26 @@ void main() {
           const addressableId =
               '30311:creator_pubkey_hex:codex-staging-video-replaceable-id';
 
-          when(() => mockNostrClient.queryEvents(any())).thenAnswer(
-            (_) async => [
-              _FakeLabelEvent(
-                pubkey: service.divineModerationPubkeyHex,
-                tags: [
-                  ['L', 'content-warning'],
-                  ['l', 'nudity', 'content-warning'],
-                  ['a', addressableId],
-                ],
-              ),
-            ],
+          when(
+            () => mockNostrClient.queryEventsDetailed(
+              any(),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+            ),
+          ).thenAnswer(
+            (_) async => (
+              events: <Event>[
+                _FakeLabelEvent(
+                  pubkey: service.divineModerationPubkeyHex,
+                  tags: [
+                    ['L', 'content-warning'],
+                    ['l', 'nudity', 'content-warning'],
+                    ['a', addressableId],
+                  ],
+                ),
+              ],
+              timedOut: false,
+              noRelays: false,
+            ),
           );
 
           await service.subscribeToLabeler(service.divineModerationPubkeyHex);
@@ -390,17 +450,26 @@ void main() {
       test(
         'stores content-warning labels by content hash from x tag',
         () async {
-          when(() => mockNostrClient.queryEvents(any())).thenAnswer(
-            (_) async => [
-              _FakeLabelEvent(
-                pubkey: service.divineModerationPubkeyHex,
-                tags: [
-                  ['L', 'content-warning'],
-                  ['l', 'graphic-media', 'content-warning'],
-                  ['x', 'sha256_content_warning_hash'],
-                ],
-              ),
-            ],
+          when(
+            () => mockNostrClient.queryEventsDetailed(
+              any(),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+            ),
+          ).thenAnswer(
+            (_) async => (
+              events: <Event>[
+                _FakeLabelEvent(
+                  pubkey: service.divineModerationPubkeyHex,
+                  tags: [
+                    ['L', 'content-warning'],
+                    ['l', 'graphic-media', 'content-warning'],
+                    ['x', 'sha256_content_warning_hash'],
+                  ],
+                ),
+              ],
+              timedOut: false,
+              noRelays: false,
+            ),
           );
 
           await service.subscribeToLabeler(service.divineModerationPubkeyHex);
@@ -414,17 +483,26 @@ void main() {
       );
 
       test('stores labels by pubkey when p tag present', () async {
-        when(() => mockNostrClient.queryEvents(any())).thenAnswer(
-          (_) async => [
-            _FakeLabelEvent(
-              pubkey: service.divineModerationPubkeyHex,
-              tags: [
-                ['L', 'content-warning'],
-                ['l', 'spam', 'content-warning'],
-                ['p', 'target_pubkey_xyz'],
-              ],
-            ),
-          ],
+        when(
+          () => mockNostrClient.queryEventsDetailed(
+            any(),
+            requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+          ),
+        ).thenAnswer(
+          (_) async => (
+            events: <Event>[
+              _FakeLabelEvent(
+                pubkey: service.divineModerationPubkeyHex,
+                tags: [
+                  ['L', 'content-warning'],
+                  ['l', 'spam', 'content-warning'],
+                  ['p', 'target_pubkey_xyz'],
+                ],
+              ),
+            ],
+            timedOut: false,
+            noRelays: false,
+          ),
         );
 
         await service.subscribeToLabeler(service.divineModerationPubkeyHex);
@@ -439,18 +517,27 @@ void main() {
             '{"confidence": 0.91, "source": "hiveai", "verified": true}';
         const violenceMetadata =
             '{"confidence": 0.42, "source": "human-review"}';
-        when(() => mockNostrClient.queryEvents(any())).thenAnswer(
-          (_) async => [
-            _FakeLabelEvent(
-              pubkey: service.divineModerationPubkeyHex,
-              tags: [
-                ['L', 'content-warning'],
-                ['l', 'ai-generated', 'content-warning', aiMetadata],
-                ['l', 'violence', 'content-warning', violenceMetadata],
-                ['e', 'multi_label_event'],
-              ],
-            ),
-          ],
+        when(
+          () => mockNostrClient.queryEventsDetailed(
+            any(),
+            requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+          ),
+        ).thenAnswer(
+          (_) async => (
+            events: <Event>[
+              _FakeLabelEvent(
+                pubkey: service.divineModerationPubkeyHex,
+                tags: [
+                  ['L', 'content-warning'],
+                  ['l', 'ai-generated', 'content-warning', aiMetadata],
+                  ['l', 'violence', 'content-warning', violenceMetadata],
+                  ['e', 'multi_label_event'],
+                ],
+              ),
+            ],
+            timedOut: false,
+            noRelays: false,
+          ),
         );
 
         await service.subscribeToLabeler(service.divineModerationPubkeyHex);
@@ -477,20 +564,29 @@ void main() {
       test(
         'indexes each repeated event and pubkey target separately',
         () async {
-          when(() => mockNostrClient.queryEvents(any())).thenAnswer(
-            (_) async => [
-              _FakeLabelEvent(
-                pubkey: service.divineModerationPubkeyHex,
-                tags: [
-                  ['L', 'content-warning'],
-                  ['l', 'nudity', 'content-warning'],
-                  ['e', 'target_event_1'],
-                  ['e', 'target_event_2'],
-                  ['p', 'target_pubkey_1'],
-                  ['p', 'target_pubkey_2'],
-                ],
-              ),
-            ],
+          when(
+            () => mockNostrClient.queryEventsDetailed(
+              any(),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+            ),
+          ).thenAnswer(
+            (_) async => (
+              events: <Event>[
+                _FakeLabelEvent(
+                  pubkey: service.divineModerationPubkeyHex,
+                  tags: [
+                    ['L', 'content-warning'],
+                    ['l', 'nudity', 'content-warning'],
+                    ['e', 'target_event_1'],
+                    ['e', 'target_event_2'],
+                    ['p', 'target_pubkey_1'],
+                    ['p', 'target_pubkey_2'],
+                  ],
+                ),
+              ],
+              timedOut: false,
+              noRelays: false,
+            ),
           );
 
           await service.subscribeToLabeler(service.divineModerationPubkeyHex);
@@ -515,33 +611,42 @@ void main() {
       test(
         'accepts unmarked labels only for a single content-warning L',
         () async {
-          when(() => mockNostrClient.queryEvents(any())).thenAnswer(
-            (_) async => [
-              _FakeLabelEvent(
-                pubkey: service.divineModerationPubkeyHex,
-                tags: [
-                  ['L', 'content-warning'],
-                  ['l', 'nudity'],
-                  ['e', 'unmarked_single_namespace_event'],
-                ],
-              ),
-              _FakeLabelEvent(
-                pubkey: service.divineModerationPubkeyHex,
-                tags: [
-                  ['l', 'violence'],
-                  ['e', 'unmarked_no_namespace_event'],
-                ],
-              ),
-              _FakeLabelEvent(
-                pubkey: service.divineModerationPubkeyHex,
-                tags: [
-                  ['L', 'content-warning'],
-                  ['L', 'other-namespace'],
-                  ['l', 'graphic-media'],
-                  ['e', 'unmarked_ambiguous_namespace_event'],
-                ],
-              ),
-            ],
+          when(
+            () => mockNostrClient.queryEventsDetailed(
+              any(),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+            ),
+          ).thenAnswer(
+            (_) async => (
+              events: <Event>[
+                _FakeLabelEvent(
+                  pubkey: service.divineModerationPubkeyHex,
+                  tags: [
+                    ['L', 'content-warning'],
+                    ['l', 'nudity'],
+                    ['e', 'unmarked_single_namespace_event'],
+                  ],
+                ),
+                _FakeLabelEvent(
+                  pubkey: service.divineModerationPubkeyHex,
+                  tags: [
+                    ['l', 'violence'],
+                    ['e', 'unmarked_no_namespace_event'],
+                  ],
+                ),
+                _FakeLabelEvent(
+                  pubkey: service.divineModerationPubkeyHex,
+                  tags: [
+                    ['L', 'content-warning'],
+                    ['L', 'other-namespace'],
+                    ['l', 'graphic-media'],
+                    ['e', 'unmarked_ambiguous_namespace_event'],
+                  ],
+                ),
+              ],
+              timedOut: false,
+              noRelays: false,
+            ),
           );
 
           await service.subscribeToLabeler(service.divineModerationPubkeyHex);
@@ -564,25 +669,34 @@ void main() {
       );
 
       test('trims and case-folds content-warning namespace only', () async {
-        when(() => mockNostrClient.queryEvents(any())).thenAnswer(
-          (_) async => [
-            _FakeLabelEvent(
-              pubkey: service.divineModerationPubkeyHex,
-              tags: [
-                ['L', ' Content-Warning '],
-                ['l', 'nudity', ' CONTENT-WARNING '],
-                ['e', 'case_folded_namespace_event'],
-              ],
-            ),
-            _FakeLabelEvent(
-              pubkey: service.divineModerationPubkeyHex,
-              tags: [
-                ['L', 'content_warning'],
-                ['l', 'violence', 'content_warning'],
-                ['e', 'underscore_namespace_event'],
-              ],
-            ),
-          ],
+        when(
+          () => mockNostrClient.queryEventsDetailed(
+            any(),
+            requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+          ),
+        ).thenAnswer(
+          (_) async => (
+            events: <Event>[
+              _FakeLabelEvent(
+                pubkey: service.divineModerationPubkeyHex,
+                tags: [
+                  ['L', ' Content-Warning '],
+                  ['l', 'nudity', ' CONTENT-WARNING '],
+                  ['e', 'case_folded_namespace_event'],
+                ],
+              ),
+              _FakeLabelEvent(
+                pubkey: service.divineModerationPubkeyHex,
+                tags: [
+                  ['L', 'content_warning'],
+                  ['l', 'violence', 'content_warning'],
+                  ['e', 'underscore_namespace_event'],
+                ],
+              ),
+            ],
+            timedOut: false,
+            noRelays: false,
+          ),
         );
 
         await service.subscribeToLabeler(service.divineModerationPubkeyHex);
@@ -600,17 +714,26 @@ void main() {
       });
 
       test('ignores events without content-warning namespace', () async {
-        when(() => mockNostrClient.queryEvents(any())).thenAnswer(
-          (_) async => [
-            _FakeLabelEvent(
-              pubkey: service.divineModerationPubkeyHex,
-              tags: [
-                ['L', 'other-namespace'],
-                ['l', 'some-label', 'other-namespace'],
-                ['e', 'ignored_event'],
-              ],
-            ),
-          ],
+        when(
+          () => mockNostrClient.queryEventsDetailed(
+            any(),
+            requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+          ),
+        ).thenAnswer(
+          (_) async => (
+            events: <Event>[
+              _FakeLabelEvent(
+                pubkey: service.divineModerationPubkeyHex,
+                tags: [
+                  ['L', 'other-namespace'],
+                  ['l', 'some-label', 'other-namespace'],
+                  ['e', 'ignored_event'],
+                ],
+              ),
+            ],
+            timedOut: false,
+            noRelays: false,
+          ),
         );
 
         await service.subscribeToLabeler(service.divineModerationPubkeyHex);
@@ -622,17 +745,26 @@ void main() {
     group('getAIDetectionResult', () {
       test('returns result for event with ai-generated label', () async {
         const metadata = '{"confidence": 0.73, "source": "hiveai"}';
-        when(() => mockNostrClient.queryEvents(any())).thenAnswer(
-          (_) async => [
-            _FakeLabelEvent(
-              pubkey: service.divineModerationPubkeyHex,
-              tags: [
-                ['L', 'content-warning'],
-                ['l', 'ai-generated', 'content-warning', metadata],
-                ['e', 'ai_event_1'],
-              ],
-            ),
-          ],
+        when(
+          () => mockNostrClient.queryEventsDetailed(
+            any(),
+            requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+          ),
+        ).thenAnswer(
+          (_) async => (
+            events: <Event>[
+              _FakeLabelEvent(
+                pubkey: service.divineModerationPubkeyHex,
+                tags: [
+                  ['L', 'content-warning'],
+                  ['l', 'ai-generated', 'content-warning', metadata],
+                  ['e', 'ai_event_1'],
+                ],
+              ),
+            ],
+            timedOut: false,
+            noRelays: false,
+          ),
         );
 
         await service.subscribeToLabeler(service.divineModerationPubkeyHex);
@@ -644,17 +776,26 @@ void main() {
       });
 
       test('returns null for event without ai-generated label', () async {
-        when(() => mockNostrClient.queryEvents(any())).thenAnswer(
-          (_) async => [
-            _FakeLabelEvent(
-              pubkey: service.divineModerationPubkeyHex,
-              tags: [
-                ['L', 'content-warning'],
-                ['l', 'nudity', 'content-warning'],
-                ['e', 'non_ai_event'],
-              ],
-            ),
-          ],
+        when(
+          () => mockNostrClient.queryEventsDetailed(
+            any(),
+            requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+          ),
+        ).thenAnswer(
+          (_) async => (
+            events: <Event>[
+              _FakeLabelEvent(
+                pubkey: service.divineModerationPubkeyHex,
+                tags: [
+                  ['L', 'content-warning'],
+                  ['l', 'nudity', 'content-warning'],
+                  ['e', 'non_ai_event'],
+                ],
+              ),
+            ],
+            timedOut: false,
+            noRelays: false,
+          ),
         );
 
         await service.subscribeToLabeler(service.divineModerationPubkeyHex);
@@ -686,17 +827,26 @@ void main() {
       test('enables followed pubkeys as trusted labelers', () async {
         const followedLabeler =
             'abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd';
-        when(() => mockNostrClient.queryEvents(any())).thenAnswer(
-          (_) async => [
-            _FakeLabelEvent(
-              pubkey: followedLabeler,
-              tags: [
-                ['L', 'content-warning'],
-                ['l', 'nudity', 'content-warning'],
-                ['e', 'followed_event'],
-              ],
-            ),
-          ],
+        when(
+          () => mockNostrClient.queryEventsDetailed(
+            any(),
+            requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+          ),
+        ).thenAnswer(
+          (_) async => (
+            events: <Event>[
+              _FakeLabelEvent(
+                pubkey: followedLabeler,
+                tags: [
+                  ['L', 'content-warning'],
+                  ['l', 'nudity', 'content-warning'],
+                  ['e', 'followed_event'],
+                ],
+              ),
+            ],
+            timedOut: false,
+            noRelays: false,
+          ),
         );
 
         await service.setFollowingModerationEnabled(
@@ -718,17 +868,26 @@ void main() {
           sharedPreferences: mockPrefs,
           canQueryRelays: () => canQueryRelays,
         );
-        when(() => mockNostrClient.queryEvents(any())).thenAnswer(
-          (_) async => [
-            _FakeLabelEvent(
-              pubkey: followedLabeler,
-              tags: [
-                ['L', 'content-warning'],
-                ['l', 'nudity', 'content-warning'],
-                ['e', 'deferred_followed_event'],
-              ],
-            ),
-          ],
+        when(
+          () => mockNostrClient.queryEventsDetailed(
+            any(),
+            requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+          ),
+        ).thenAnswer(
+          (_) async => (
+            events: <Event>[
+              _FakeLabelEvent(
+                pubkey: followedLabeler,
+                tags: [
+                  ['L', 'content-warning'],
+                  ['l', 'nudity', 'content-warning'],
+                  ['e', 'deferred_followed_event'],
+                ],
+              ),
+            ],
+            timedOut: false,
+            noRelays: false,
+          ),
         );
 
         await gatedService.setFollowingModerationEnabled(
@@ -741,7 +900,12 @@ void main() {
           gatedService.getContentWarnings('deferred_followed_event'),
           isEmpty,
         );
-        verifyNever(() => mockNostrClient.queryEvents(any()));
+        verifyNever(
+          () => mockNostrClient.queryEventsDetailed(
+            any(),
+            requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+          ),
+        );
 
         canQueryRelays = true;
         await gatedService.syncFollowedLabelers([followedLabeler]);
@@ -750,33 +914,51 @@ void main() {
           gatedService.getContentWarnings('deferred_followed_event'),
           hasLength(1),
         );
-        verify(() => mockNostrClient.queryEvents(any())).called(1);
+        verify(
+          () => mockNostrClient.queryEventsDetailed(
+            any(),
+            requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+          ),
+        ).called(1);
       });
 
       test('coalesces concurrent labeler subscriptions', () async {
         const labeler =
             'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd';
-        final events = Completer<List<Event>>();
+        final events =
+            Completer<({List<Event> events, bool timedOut, bool noRelays})>();
         when(
-          () => mockNostrClient.queryEvents(any()),
+          () => mockNostrClient.queryEventsDetailed(
+            any(),
+            requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+          ),
         ).thenAnswer((_) => events.future);
 
         final firstSubscribe = service.subscribeToLabeler(labeler);
         final secondSubscribe = service.subscribeToLabeler(labeler);
         await Future<void>.delayed(Duration.zero);
 
-        verify(() => mockNostrClient.queryEvents(any())).called(1);
-
-        events.complete([
-          _FakeLabelEvent(
-            pubkey: labeler,
-            tags: [
-              ['L', 'content-warning'],
-              ['l', 'nudity', 'content-warning'],
-              ['e', 'coalesced_event'],
-            ],
+        verify(
+          () => mockNostrClient.queryEventsDetailed(
+            any(),
+            requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
           ),
-        ]);
+        ).called(1);
+
+        events.complete((
+          events: <Event>[
+            _FakeLabelEvent(
+              pubkey: labeler,
+              tags: [
+                ['L', 'content-warning'],
+                ['l', 'nudity', 'content-warning'],
+                ['e', 'coalesced_event'],
+              ],
+            ),
+          ],
+          timedOut: false,
+          noRelays: false,
+        ));
         await Future.wait([firstSubscribe, secondSubscribe]);
 
         expect(service.getContentWarnings('coalesced_event'), hasLength(1));
@@ -785,17 +967,26 @@ void main() {
       test('disabling followed labelers removes their cached labels', () async {
         const followedLabeler =
             'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
-        when(() => mockNostrClient.queryEvents(any())).thenAnswer(
-          (_) async => [
-            _FakeLabelEvent(
-              pubkey: followedLabeler,
-              tags: [
-                ['L', 'content-warning'],
-                ['l', 'violence', 'content-warning'],
-                ['e', 'followed_event_2'],
-              ],
-            ),
-          ],
+        when(
+          () => mockNostrClient.queryEventsDetailed(
+            any(),
+            requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+          ),
+        ).thenAnswer(
+          (_) async => (
+            events: <Event>[
+              _FakeLabelEvent(
+                pubkey: followedLabeler,
+                tags: [
+                  ['L', 'content-warning'],
+                  ['l', 'violence', 'content-warning'],
+                  ['e', 'followed_event_2'],
+                ],
+              ),
+            ],
+            timedOut: false,
+            noRelays: false,
+          ),
         );
 
         await service.setFollowingModerationEnabled(
@@ -815,17 +1006,26 @@ void main() {
         () async {
           const explicitLabeler =
               'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
-          when(() => mockNostrClient.queryEvents(any())).thenAnswer(
-            (_) async => [
-              _FakeLabelEvent(
-                pubkey: explicitLabeler,
-                tags: [
-                  ['L', 'content-warning'],
-                  ['l', 'graphic-media', 'content-warning'],
-                  ['e', 'explicit_event'],
-                ],
-              ),
-            ],
+          when(
+            () => mockNostrClient.queryEventsDetailed(
+              any(),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+            ),
+          ).thenAnswer(
+            (_) async => (
+              events: <Event>[
+                _FakeLabelEvent(
+                  pubkey: explicitLabeler,
+                  tags: [
+                    ['L', 'content-warning'],
+                    ['l', 'graphic-media', 'content-warning'],
+                    ['e', 'explicit_event'],
+                  ],
+                ),
+              ],
+              timedOut: false,
+              noRelays: false,
+            ),
           );
 
           await service.addLabeler(explicitLabeler);
@@ -836,6 +1036,217 @@ void main() {
           await service.setFollowingModerationEnabled(false);
 
           expect(service.getContentWarnings('explicit_event'), hasLength(1));
+        },
+      );
+    });
+
+    group('incomplete labeler loads (#8214)', () {
+      const labeler =
+          'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+      _FakeLabelEvent labelFor(String eventId) => _FakeLabelEvent(
+        pubkey: labeler,
+        tags: [
+          ['L', 'content-warning'],
+          ['l', 'nudity', 'content-warning'],
+          ['e', eventId],
+        ],
+      );
+
+      test(
+        'a timed-out load is not latched, so a later call retries',
+        () async {
+          when(
+            () => mockNostrClient.queryEventsDetailed(
+              any(),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+            ),
+          ).thenAnswer(
+            (_) async => (events: <Event>[], timedOut: true, noRelays: false),
+          );
+
+          await service.subscribeToLabeler(labeler);
+          expect(service.getContentWarnings('timed_out_event'), isEmpty);
+
+          when(
+            () => mockNostrClient.queryEventsDetailed(
+              any(),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+            ),
+          ).thenAnswer(
+            (_) async => (
+              events: <Event>[labelFor('timed_out_event')],
+              timedOut: false,
+              noRelays: false,
+            ),
+          );
+
+          await service.subscribeToLabeler(labeler);
+
+          expect(service.getContentWarnings('timed_out_event'), hasLength(1));
+        },
+      );
+
+      test('a no-relay load is not latched, so a later call retries', () async {
+        when(
+          () => mockNostrClient.queryEventsDetailed(
+            any(),
+            requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+          ),
+        ).thenAnswer(
+          (_) async => (events: <Event>[], timedOut: false, noRelays: true),
+        );
+
+        await service.subscribeToLabeler(labeler);
+        expect(service.getContentWarnings('no_relay_event'), isEmpty);
+
+        when(
+          () => mockNostrClient.queryEventsDetailed(
+            any(),
+            requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+          ),
+        ).thenAnswer(
+          (_) async => (
+            events: <Event>[labelFor('no_relay_event')],
+            timedOut: false,
+            noRelays: false,
+          ),
+        );
+
+        await service.subscribeToLabeler(labeler);
+
+        expect(service.getContentWarnings('no_relay_event'), hasLength(1));
+      });
+
+      test(
+        'an answered-but-empty load still latches, so there is no retry storm',
+        () async {
+          when(
+            () => mockNostrClient.queryEventsDetailed(
+              any(),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+            ),
+          ).thenAnswer(
+            (_) async => (events: <Event>[], timedOut: false, noRelays: false),
+          );
+
+          await service.subscribeToLabeler(labeler);
+          await service.subscribeToLabeler(labeler);
+
+          verify(
+            () => mockNostrClient.queryEventsDetailed(
+              any(),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+            ),
+          ).called(1);
+        },
+      );
+
+      test('retries an abandoned labeler when a relay connects', () async {
+        final statuses = StreamController<Map<String, RelayConnectionStatus>>();
+        addTearDown(statuses.close);
+        when(
+          () => mockNostrClient.relayStatusStream,
+        ).thenAnswer((_) => statuses.stream);
+        when(() => mockNostrClient.connectedRelayCount).thenReturn(0);
+        when(
+          () => mockNostrClient.queryEventsDetailed(
+            any(),
+            requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+          ),
+        ).thenAnswer(
+          (_) async => (events: <Event>[], timedOut: true, noRelays: false),
+        );
+
+        await service.subscribeToLabeler(labeler);
+        expect(service.getContentWarnings('relay_ready_event'), isEmpty);
+
+        when(
+          () => mockNostrClient.queryEventsDetailed(
+            any(),
+            requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+          ),
+        ).thenAnswer(
+          (_) async => (
+            events: <Event>[labelFor('relay_ready_event')],
+            timedOut: false,
+            noRelays: false,
+          ),
+        );
+
+        statuses.add({
+          'wss://relay.example': RelayConnectionStatus.connected(
+            'wss://relay.example',
+          ),
+        });
+        await pumpEventQueue();
+
+        expect(
+          service.getContentWarnings('relay_ready_event'),
+          hasLength(1),
+          reason: 'the labeler must reload once a relay is available',
+        );
+      });
+
+      test('dispose cancels the pending relay-ready retry', () async {
+        final statuses = StreamController<Map<String, RelayConnectionStatus>>();
+        addTearDown(statuses.close);
+        when(
+          () => mockNostrClient.relayStatusStream,
+        ).thenAnswer((_) => statuses.stream);
+        when(() => mockNostrClient.connectedRelayCount).thenReturn(0);
+        when(
+          () => mockNostrClient.queryEventsDetailed(
+            any(),
+            requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+          ),
+        ).thenAnswer(
+          (_) async => (events: <Event>[], timedOut: true, noRelays: false),
+        );
+
+        await service.subscribeToLabeler(labeler);
+        expect(
+          statuses.hasListener,
+          isTrue,
+          reason: 'an abandoned load must be waiting on relay status',
+        );
+
+        service.dispose();
+        await pumpEventQueue();
+
+        expect(statuses.hasListener, isFalse);
+      });
+
+      test(
+        'does not spin when a relay is connected but the load keeps timing out',
+        () async {
+          final statuses =
+              StreamController<Map<String, RelayConnectionStatus>>();
+          addTearDown(statuses.close);
+          when(
+            () => mockNostrClient.relayStatusStream,
+          ).thenAnswer((_) => statuses.stream);
+          // A relay IS connected — the query still does not settle.
+          when(() => mockNostrClient.connectedRelayCount).thenReturn(1);
+          var calls = 0;
+          when(
+            () => mockNostrClient.queryEventsDetailed(
+              any(),
+              requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+            ),
+          ).thenAnswer((_) async {
+            calls++;
+            return (events: <Event>[], timedOut: true, noRelays: false);
+          });
+
+          await service.subscribeToLabeler(labeler);
+          await pumpEventQueue();
+
+          expect(
+            calls,
+            1,
+            reason: 'an abandoned load must not immediately re-drive itself',
+          );
         },
       );
     });

--- a/mobile/test/services/nsfw_content_filter_test.dart
+++ b/mobile/test/services/nsfw_content_filter_test.dart
@@ -63,13 +63,22 @@ void main() {
     late ModerationLabelService moderationLabelService;
 
     Future<void> seedModerationLabels(List<List<String>> tags) async {
-      when(() => mockNostrClient.queryEvents(any())).thenAnswer(
-        (_) async => [
-          _FakeLabelEvent(
-            pubkey: moderationLabelService.divineModerationPubkeyHex,
-            tags: tags,
-          ),
-        ],
+      when(
+        () => mockNostrClient.queryEventsDetailed(
+          any(),
+          requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+        ),
+      ).thenAnswer(
+        (_) async => (
+          events: <Event>[
+            _FakeLabelEvent(
+              pubkey: moderationLabelService.divineModerationPubkeyHex,
+              tags: tags,
+            ),
+          ],
+          timedOut: false,
+          noRelays: false,
+        ),
       );
 
       await moderationLabelService.subscribeToLabeler(

--- a/mobile/test/services/video_event_service_content_filter_test.dart
+++ b/mobile/test/services/video_event_service_content_filter_test.dart
@@ -65,13 +65,22 @@ void main() {
   late AgeVerificationService ageVerificationService;
 
   Future<void> seedModerationLabels(List<List<String>> tags) async {
-    when(() => mockNostrClient.queryEvents(any())).thenAnswer(
-      (_) async => [
-        _FakeLabelEvent(
-          pubkey: moderationLabelService.divineModerationPubkeyHex,
-          tags: tags,
-        ),
-      ],
+    when(
+      () => mockNostrClient.queryEventsDetailed(
+        any(),
+        requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+      ),
+    ).thenAnswer(
+      (_) async => (
+        events: <Event>[
+          _FakeLabelEvent(
+            pubkey: moderationLabelService.divineModerationPubkeyHex,
+            tags: tags,
+          ),
+        ],
+        timedOut: false,
+        noRelays: false,
+      ),
     );
 
     await moderationLabelService.subscribeToLabeler(


### PR DESCRIPTION
Closes #8214

## Summary

A NIP-32 labeler whose first load no relay answered was recorded as loaded anyway, and the skip gate then suppressed every later attempt for the life of the process. That labeler's content warnings were never applied — silently, and in the permissive direction.

`queryEvents` discards `timedOut` and `noRelays`, so an unanswered load returns `[]`, which is indistinguishable from "this labeler has no labels". The `forEach` no-ops, execution reaches `_loadedLabelers.add(pubkey)`, and the log line reports `loaded 0 label events` as an ordinary success.

Fixes the mobile half of #8214. Four commits, each independently revertable.

## 1. Only record a labeler as loaded when a relay actually answered

Reads through `queryEventsDetailed` with `requireAllRelaysSettled: true` — the flag that makes a relay's `CLOSED` refusal and a partial fan-out surface as `timedOut` rather than completing on whichever relays answered first. An *affirmative* empty answer still latches, so a relay that genuinely holds no labels is not re-queried.

Two deliberate departures from #8219's shape at the corrupted-video scan:

- **The cache stays on.** #8219 passed `useCache: false`; here cached labels are still worth applying, and the bug is the latch, not the cache.
- **The log moves from `debug` to `warning`.** An abandoned moderation load that is invisible in a bug report is most of why this went unnoticed.

## 2. Retry an abandoned load when a relay connects

Removing the latch alone would not have changed behaviour: `initialize()` is reached only from the `nostrSessionProvider` readiness *transition*, and the followed-labeler path skips anything already in `_subscribedLabelers` — which always contains the Divine labeler. Once the session settles at a stable `nostrReady`, nothing calls `subscribeToLabeler` again, so "not latched" and "latched" produce the same outcome.

The retry mirrors `VideoEventService._scheduleRetryWhenRelayReady`: queue the labeler, subscribe once to `relayStatusStream`, drain and cancel when a relay connects. Event-bounded rather than attempt-bounded, per that precedent's rationale.

There is deliberately **no** "retry now if a relay is already connected" branch, even though the precedent has one. It is only safe there because `VideoEventService` re-schedules solely on `RelayNotReadyException`. Here a load that timed out *with* a relay connected is the common case — a connected-but-silent relay — and re-driving it inline spins. A regression test pins that.

`dispose()` is now real; it previously iterated a map nothing ever writes to.

## 3. Corrections found while validating this PR against the client contract

Three defects introduced by commit 1, each caught by a test watched failing first:

- **Cached labels were being dropped.** `queryEventsDetailed` merges cached rows into `events` *regardless* of `timedOut`/`noRelays` (`nostr_client.dart:1017-1020`), so returning early discarded them — making a warm-cache user worse off than before this PR. Events are now applied before the latch decision.
- **Retries accumulated duplicate rows.** `_processLabelEvent` appends, so re-applying after a retry added a duplicate per attempt. Not user-visible (`effective_content_labels.addLabel` dedupes by value) but unbounded across a flapping session. Each load now replaces that labeler's rows.
- **A load completing after `dispose()` re-armed an uncancellable subscription.** Reachable on account switch / sign-out. Guarded by a disposal flag.

## 4. Takeover corrections

- Removing or retiring a labeler now cancels its queued retry, so a disabled moderation source cannot return on a later relay event.
- Retry fan-out is bounded to a real disconnected-to-connected transition; unrelated status churn while another relay remains connected does not re-run full-history queries.
- An incomplete empty read preserves known warnings until an affirmative answer or replacement events arrive.

Each correction has a regression test that failed against the previous head.

## Verification

**Controlled local-stack reproduction** — `docker pause` the funnelcake relay and proxy (the port still accepts TCP while the container never answers, i.e. a connected-but-silent relay), run with `DEFAULT_ENV=LOCAL`:

```
Labeler load incomplete … (noRelays: true, timedOut: true)   → not latched
  ← docker unpause
Retrying 1 labeler load(s) after a relay connected
Subscribed to labeler 8fd5eb6d…, loaded 2 label events        → recovered
```

**Production relay, simulator** — three attempts, each preserving cached labels, third succeeding. Both incomplete attempts logged `applied 2 cached label event(s)`, which is the cache correction above working in the real app.

**Contrast with `main`** — one query, `loaded 0 label events`, latched, never re-queried across a 2 h 10 min session even though the relay connected 9 s later.

## Scope note

The auto-subscribed Divine labeler currently publishes nothing this filter keeps — its only kind-1985 events are in the `moderation/resolution` namespace, and `_isContentWarningLabel` keeps only `content-warning`. Today's live blast radius is therefore user-added custom labelers and followed-moderator labelers (opt-in, default off), plus a latent failure on the default path the moment that labeler starts publishing. Filed separately: divinevideo/divine-moderation-service#209 (why no such labels exist), #8253 (three rival moderation pubkeys), #8252 (the query refetches a labeler's whole history every cold start).

## Not in scope

A *successful* load is still one-shot — `_subscriptions` is never written to, so labels published later in the session still do not arrive. Real gap, larger change.

## Tests

Twelve new tests in `incomplete labeler loads (#8214)`, each verified able to fail — four by watching a genuine RED, five by mutating the production guard and confirming only the intended test went red:

- a timed-out load is not latched, and a later call retries
- a no-relay load is not latched, and a later call retries
- an answered-but-empty load still latches (no retry storm)
- an abandoned labeler reloads when a relay connects
- `dispose()` cancels the pending retry
- no spin when a relay is connected but the load keeps timing out
- cached labels survive an unanswered query
- a retry replaces labeler rows instead of appending
- a load completing after dispose does not re-arm a retry
- disabling followed moderation cancels a queued retry
- unrelated relay-status churn does not trigger a retry
- an empty incomplete retry preserves known label rows

The relay-status controllers in these tests are `.broadcast()`, matching the real stream: a single-subscription controller's `close()` never completes when nothing listened, which hung the suite rather than failing it.

The switch to `queryEventsDetailed` required restubbing existing mocks across four suites.

```
flutter analyze lib test integration_test   → No issues found
flutter test (4 affected suites)            → 89 passing
```

