### PR TITLE
fix(profile): restore REST-authoritative follower counts

### DIFF
--- a/mobile/lib/blocs/followers/follower_visibility.dart
+++ b/mobile/lib/blocs/followers/follower_visibility.dart
@@ -1,20 +1,7 @@
 // ABOUTME: Shared follower list visibility helpers.
 // ABOUTME: Keeps follower count and blocklist filtering semantics consistent.
 
-import 'dart:math';
-
 import 'package:content_blocklist_repository/content_blocklist_repository.dart';
-
-/// Computes the locally visible follower count from an authoritative count and
-/// the known hidden followers.
-int visibleFollowerCount({
-  required int visiblePubkeyCount,
-  required int rawPubkeyCount,
-  required int authoritativeFollowerCount,
-}) => max(
-  visiblePubkeyCount,
-  authoritativeFollowerCount - (rawPubkeyCount - visiblePubkeyCount),
-);
 
 /// Filters followers hidden from the current user's own follower list.
 List<String> filterMyFollowerPubkeys({

--- a/mobile/lib/blocs/followers/follower_visibility.dart
+++ b/mobile/lib/blocs/followers/follower_visibility.dart
@@ -8,17 +8,30 @@ import 'package:content_blocklist_repository/content_blocklist_repository.dart';
 /// Computes the locally visible follower count from an authoritative count and
 /// the known hidden followers.
 ///
-/// The server aggregate is not yet block-aware. Keep known blocked or
-/// follow-severed accounts out of the number shown beside an already-filtered
-/// list until that calculation becomes canonical upstream.
+/// The server aggregate is not yet block-aware, so accounts the profile owner
+/// blocked or follow-severed are subtracted here until that calculation
+/// becomes canonical upstream (divinevideo/divine-funnelcake#1166).
+///
+/// The subtraction is deliberately *not* floored at [visiblePubkeyCount].
+/// That count traces back to the relay-merged union in `_fetchOrderedFollowers`
+/// (API + connected relays + indexers), so flooring on it makes the displayed
+/// number the list length whenever the union is longer than the REST count —
+/// which is the normal case — and it then moves with whichever relays
+/// answered. That is the instability #8197 reports.
+///
+/// Dropping the floor also makes blocking legible rather than masking it: with
+/// a floor, blocking five accounts moves the number by five while relay
+/// variance moves it by ten, so the user cannot see that blocking did
+/// anything. Without one, five blocks reliably read as five fewer followers.
+///
+/// The cost is that this count can sit below the number of rows on screen,
+/// which is trade-off 1 in the pull request description and is intended.
 int visibleFollowerCount({
   required int visiblePubkeyCount,
   required int rawPubkeyCount,
   required int authoritativeFollowerCount,
-}) => max(
-  visiblePubkeyCount,
-  authoritativeFollowerCount - (rawPubkeyCount - visiblePubkeyCount),
-);
+}) =>
+    max(0, authoritativeFollowerCount - (rawPubkeyCount - visiblePubkeyCount));
 
 /// Filters followers hidden from the current user's own follower list.
 List<String> filterMyFollowerPubkeys({

--- a/mobile/lib/blocs/followers/follower_visibility.dart
+++ b/mobile/lib/blocs/followers/follower_visibility.dart
@@ -1,7 +1,24 @@
 // ABOUTME: Shared follower list visibility helpers.
 // ABOUTME: Keeps follower count and blocklist filtering semantics consistent.
 
+import 'dart:math';
+
 import 'package:content_blocklist_repository/content_blocklist_repository.dart';
+
+/// Computes the locally visible follower count from an authoritative count and
+/// the known hidden followers.
+///
+/// The server aggregate is not yet block-aware. Keep known blocked or
+/// follow-severed accounts out of the number shown beside an already-filtered
+/// list until that calculation becomes canonical upstream.
+int visibleFollowerCount({
+  required int visiblePubkeyCount,
+  required int rawPubkeyCount,
+  required int authoritativeFollowerCount,
+}) => max(
+  visiblePubkeyCount,
+  authoritativeFollowerCount - (rawPubkeyCount - visiblePubkeyCount),
+);
 
 /// Filters followers hidden from the current user's own follower list.
 List<String> filterMyFollowerPubkeys({

--- a/mobile/lib/blocs/my_followers/my_followers_state.dart
+++ b/mobile/lib/blocs/my_followers/my_followers_state.dart
@@ -61,17 +61,15 @@ final class MyFollowersState extends Equatable {
   /// list length.
   final int authoritativeFollowerCount;
 
-  /// Visible follower count after applying local blocklist filters.
+  /// Follower count shown in the UI.
   ///
-  /// Downloading all kind 3 events is limited by relay result caps, so
-  /// [authoritativeFollowerCount] may exceed the number of pubkeys actually
-  /// fetched. Followers we know are hidden locally are subtracted from it, and
-  /// the result never drops below the number of followers on screen.
-  int get followerCount => visibleFollowerCount(
-    visiblePubkeyCount: followersPubkeys.length,
-    rawPubkeyCount: rawFollowersPubkeys.length,
-    authoritativeFollowerCount: authoritativeFollowerCount,
-  );
+  /// This is the Funnelcake REST count verbatim (#8197): deterministic, and
+  /// available before any relay work finishes. It is deliberately NOT
+  /// adjusted by the fetched list — neither floored to its length nor
+  /// reduced by locally hidden rows — because both made the number depend on
+  /// which relays answered, which is the instability #8197 reports. The list
+  /// may therefore show more or fewer rows than this count states.
+  int get followerCount => authoritativeFollowerCount;
 
   /// True while cached data is shown but a fresh network fetch is in progress.
   final bool isRefreshing;

--- a/mobile/lib/blocs/my_followers/my_followers_state.dart
+++ b/mobile/lib/blocs/my_followers/my_followers_state.dart
@@ -63,7 +63,8 @@ final class MyFollowersState extends Equatable {
   /// Funnelcake remains the deterministic baseline (#8197), but accounts the
   /// owner has blocked or follow-severed must not still appear in their count.
   /// Only hidden rows actually observed in the fetched list are subtracted;
-  /// the result never falls below the visible rows.
+  /// the result is not floored at the relay-derived visible row count, so relay
+  /// coverage cannot inflate or destabilize the displayed number.
   int get followerCount => visibleFollowerCount(
     visiblePubkeyCount: followersPubkeys.length,
     rawPubkeyCount: rawFollowersPubkeys.length,

--- a/mobile/lib/blocs/my_followers/my_followers_state.dart
+++ b/mobile/lib/blocs/my_followers/my_followers_state.dart
@@ -52,21 +52,23 @@ final class MyFollowersState extends Equatable {
   /// The order [followersPubkeys] is presented in.
   final FollowSortOrder sortOrder;
 
-  /// Follower count as reported by the repository.
+  /// Follower count as reported by the repository, before local safety filters.
   ///
-  /// [followerCount] returns this value unchanged; the field is kept separate
-  /// because optimistic follow/unfollow mutates it directly.
+  /// Kept separately so blocklist changes can recompute [followerCount] from
+  /// the raw list without losing the server-provided baseline.
   final int authoritativeFollowerCount;
 
-  /// Follower count shown in the UI.
+  /// Follower count shown in the UI after applying known local safety filters.
   ///
-  /// This is the Funnelcake REST count verbatim (#8197): deterministic, and
-  /// available before any relay work finishes. It is deliberately NOT
-  /// adjusted by the fetched list — neither floored to its length nor
-  /// reduced by locally hidden rows — because both made the number depend on
-  /// which relays answered, which is the instability #8197 reports. The list
-  /// may therefore show more or fewer rows than this count states.
-  int get followerCount => authoritativeFollowerCount;
+  /// Funnelcake remains the deterministic baseline (#8197), but accounts the
+  /// owner has blocked or follow-severed must not still appear in their count.
+  /// Only hidden rows actually observed in the fetched list are subtracted;
+  /// the result never falls below the visible rows.
+  int get followerCount => visibleFollowerCount(
+    visiblePubkeyCount: followersPubkeys.length,
+    rawPubkeyCount: rawFollowersPubkeys.length,
+    authoritativeFollowerCount: authoritativeFollowerCount,
+  );
 
   /// True while cached data is shown but a fresh network fetch is in progress.
   final bool isRefreshing;

--- a/mobile/lib/blocs/my_followers/my_followers_state.dart
+++ b/mobile/lib/blocs/my_followers/my_followers_state.dart
@@ -52,13 +52,10 @@ final class MyFollowersState extends Equatable {
   /// The order [followersPubkeys] is presented in.
   final FollowSortOrder sortOrder;
 
-  /// Follower count as reported by the repository, before any local
-  /// blocklist filtering.
+  /// Follower count as reported by the repository.
   ///
-  /// Kept verbatim rather than derived from [followerCount] so re-filtering
-  /// stays exact: reconstructing it by inverting a previous [followerCount]
-  /// emission is only correct when that emission did not clamp to the visible
-  /// list length.
+  /// [followerCount] returns this value unchanged; the field is kept separate
+  /// because optimistic follow/unfollow mutates it directly.
   final int authoritativeFollowerCount;
 
   /// Follower count shown in the UI.

--- a/mobile/lib/blocs/others_followers/others_followers_state.dart
+++ b/mobile/lib/blocs/others_followers/others_followers_state.dart
@@ -53,7 +53,9 @@ final class OthersFollowersState extends Equatable {
   /// Funnelcake remains the deterministic baseline (#8197), but accounts
   /// hidden by the viewer's safety state must not still appear in the count
   /// beside the filtered list. Only hidden rows actually observed in the
-  /// fetched list are subtracted; the result never falls below visible rows.
+  /// fetched list are subtracted; the result is not floored at the
+  /// relay-derived visible row count, so relay coverage cannot inflate or
+  /// destabilize the displayed number.
   int get followerCount => visibleFollowerCount(
     visiblePubkeyCount: followersPubkeys.length,
     rawPubkeyCount: rawFollowersPubkeys.length,

--- a/mobile/lib/blocs/others_followers/others_followers_state.dart
+++ b/mobile/lib/blocs/others_followers/others_followers_state.dart
@@ -51,18 +51,15 @@ final class OthersFollowersState extends Equatable {
   /// clamp to the visible list length.
   final int authoritativeFollowerCount;
 
-  /// Visible follower count after applying local blocklist filters.
+  /// Follower count shown in the UI.
   ///
-  /// Downloading all kind 3 events is limited by relay result caps, so
-  /// [authoritativeFollowerCount] may exceed the number of pubkeys actually
-  /// fetched. Followers we know are hidden locally (blocked, or a
-  /// follow-severed viewer) are subtracted from it, and the result never
-  /// drops below the number of followers on screen.
-  int get followerCount => visibleFollowerCount(
-    visiblePubkeyCount: followersPubkeys.length,
-    rawPubkeyCount: rawFollowersPubkeys.length,
-    authoritativeFollowerCount: authoritativeFollowerCount,
-  );
+  /// This is the Funnelcake REST count verbatim (#8197): deterministic, and
+  /// available before any relay work finishes. It is deliberately NOT
+  /// adjusted by the fetched list — neither floored to its length nor
+  /// reduced by locally hidden rows — because both made the number depend on
+  /// which relays answered, which is the instability #8197 reports. The list
+  /// may therefore show more or fewer rows than this count states.
+  int get followerCount => authoritativeFollowerCount;
 
   /// The pubkey whose followers list is being viewed (for retry)
   final String? targetPubkey;

--- a/mobile/lib/blocs/others_followers/others_followers_state.dart
+++ b/mobile/lib/blocs/others_followers/others_followers_state.dart
@@ -42,13 +42,10 @@ final class OthersFollowersState extends Equatable {
   /// replay the full list without waiting for a new network event.
   final List<String> rawFollowersPubkeys;
 
-  /// Follower count as reported by the repository, before any local
-  /// blocklist filtering.
+  /// Follower count as reported by the repository.
   ///
-  /// Kept verbatim rather than derived from [followerCount] so optimistic
-  /// mutations stay exact: reconstructing it by inverting a previous
-  /// [followerCount] emission is only correct when that emission did not
-  /// clamp to the visible list length.
+  /// [followerCount] returns this value unchanged; the field is kept separate
+  /// because optimistic follow/unfollow mutates it directly.
   final int authoritativeFollowerCount;
 
   /// Follower count shown in the UI.

--- a/mobile/lib/blocs/others_followers/others_followers_state.dart
+++ b/mobile/lib/blocs/others_followers/others_followers_state.dart
@@ -42,21 +42,23 @@ final class OthersFollowersState extends Equatable {
   /// replay the full list without waiting for a new network event.
   final List<String> rawFollowersPubkeys;
 
-  /// Follower count as reported by the repository.
+  /// Follower count as reported by the repository, before local safety filters.
   ///
-  /// [followerCount] returns this value unchanged; the field is kept separate
-  /// because optimistic follow/unfollow mutates it directly.
+  /// Kept separately so blocklist changes can recompute [followerCount] from
+  /// the raw list without losing the server-provided baseline.
   final int authoritativeFollowerCount;
 
-  /// Follower count shown in the UI.
+  /// Follower count shown in the UI after applying known local safety filters.
   ///
-  /// This is the Funnelcake REST count verbatim (#8197): deterministic, and
-  /// available before any relay work finishes. It is deliberately NOT
-  /// adjusted by the fetched list — neither floored to its length nor
-  /// reduced by locally hidden rows — because both made the number depend on
-  /// which relays answered, which is the instability #8197 reports. The list
-  /// may therefore show more or fewer rows than this count states.
-  int get followerCount => authoritativeFollowerCount;
+  /// Funnelcake remains the deterministic baseline (#8197), but accounts
+  /// hidden by the viewer's safety state must not still appear in the count
+  /// beside the filtered list. Only hidden rows actually observed in the
+  /// fetched list are subtracted; the result never falls below visible rows.
+  int get followerCount => visibleFollowerCount(
+    visiblePubkeyCount: followersPubkeys.length,
+    rawPubkeyCount: rawFollowersPubkeys.length,
+    authoritativeFollowerCount: authoritativeFollowerCount,
+  );
 
   /// The pubkey whose followers list is being viewed (for retry)
   final String? targetPubkey;

--- a/mobile/packages/db_client/lib/src/database/daos/profile_stats_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/profile_stats_dao.dart
@@ -38,6 +38,16 @@ class ProfileStatsDao extends DatabaseAccessor<AppDatabase>
   /// same reason as `UserProfilesDao.upsertProfile`: the writers span layers
   /// that cannot all reach `ProfileRepository` — the classic-viner seed import
   /// re-runs on every manifest bump.
+  /// Writes profile stats, creating the row when absent.
+  ///
+  /// [stampCountFreshness] controls `followerCountsUpdatedAt`, which exists
+  /// solely so FollowRepository's relay-fallback hysteresis can decide when a
+  /// baseline has gone stale. Only a write that establishes such a baseline —
+  /// the relay path — should stamp it. REST-sourced counts pass `false`: they
+  /// update the values, but must not restart the staleness clock, because the
+  /// relay path deliberately skips re-persisting an unchanged count so that
+  /// clock can eventually expire. Refreshing it on every profile view would
+  /// mean it never does (#8259 review).
   Future<void> upsertStats({
     required String pubkey,
     int? videoCount,
@@ -45,6 +55,7 @@ class ProfileStatsDao extends DatabaseAccessor<AppDatabase>
     int? followingCount,
     int? totalViews,
     int? totalLikes,
+    bool stampCountFreshness = true,
   }) async {
     final tombstone = await (select(
       vanishedProfiles,
@@ -54,7 +65,8 @@ class ProfileStatsDao extends DatabaseAccessor<AppDatabase>
     final existing = await (select(
       profileStats,
     )..where((t) => t.pubkey.equals(pubkey))).getSingleOrNull();
-    final countsUpdatedAt = followerCount != null || followingCount != null
+    final wroteCounts = followerCount != null || followingCount != null;
+    final countsUpdatedAt = wroteCounts && stampCountFreshness
         ? DateTime.now()
         : existing?.followerCountsUpdatedAt;
 

--- a/mobile/packages/db_client/lib/src/database/daos/profile_stats_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/profile_stats_dao.dart
@@ -11,9 +11,10 @@ const profileStatsCacheDuration = Duration(minutes: 5);
 
 /// How long follower/following counts stay useful after they were written.
 ///
-/// Follower counts live in this row but are owned by `FollowRepository`, which
-/// stabilizes them with hysteresis against the persisted value. That
-/// stabilization only works if the baseline survives a restart, so the counts
+/// Follower counts live in this row and have coordinated REST and relay
+/// writers.
+/// The relay fallback stabilizes partial observations against the persisted
+/// value, which only works if the baseline survives a restart, so the counts
 /// outlive the 5-minute stats cache.
 ///
 /// This must stay comfortably longer than `FollowRepository`'s own staleness
@@ -49,11 +50,10 @@ class ProfileStatsDao extends DatabaseAccessor<AppDatabase>
   /// - `FollowRepository`'s relay-fallback hysteresis uses it to decide when a
   ///   baseline is old enough that a lower relay count should be accepted.
   ///
-  /// Those two readers agree because every writer withholds an ambiguous
-  /// `{0, 0}` response rather than storing it, so a stamp always means real
-  /// data arrived. A REST write and the hysteresis path cannot interleave:
-  /// when REST answers with a signal `getFollowerStats` returns before
-  /// hysteresis runs, and when it does not, no counts are written at all.
+  /// Those two readers agree because every writer withholds each ambiguous
+  /// zero field rather than storing it, so a stamp always means real data
+  /// arrived for at least one count. REST-authoritative fields and relay
+  /// fallback fields are combined before the row is written.
   Future<void> upsertStats({
     required String pubkey,
     int? videoCount,
@@ -91,9 +91,9 @@ class ProfileStatsDao extends DatabaseAccessor<AppDatabase>
   /// Get stats for a pubkey (returns null if not found or expired).
   ///
   /// An expired row is only deleted when it carries nothing worth keeping.
-  /// Follower counts outlive this cache ([followerCountsExpiry]) and are the
-  /// baseline `FollowRepository` stabilizes against, so evicting them here
-  /// would reintroduce the loss that [deleteExpired] is careful to avoid.
+  /// Follower counts outlive this cache ([followerCountsExpiry]) and form the
+  /// shared baseline for REST/profile rendering and relay fallback, so evicting
+  /// them here would reintroduce the loss [deleteExpired] avoids.
   Future<ProfileStatRow?> getStats(
     String pubkey, {
     Duration expiry = profileStatsCacheDuration,

--- a/mobile/packages/db_client/lib/src/database/daos/profile_stats_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/profile_stats_dao.dart
@@ -27,7 +27,7 @@ class ProfileStatsDao extends DatabaseAccessor<AppDatabase>
     with _$ProfileStatsDaoMixin {
   ProfileStatsDao(super.attachedDatabase);
 
-  /// Upsert profile stats (insert or update).
+  /// Upserts profile stats, creating the row when absent.
   ///
   /// Only overwrites fields that are explicitly provided (non-null).
   /// Null parameters are left unchanged in the existing row, preventing
@@ -38,16 +38,22 @@ class ProfileStatsDao extends DatabaseAccessor<AppDatabase>
   /// same reason as `UserProfilesDao.upsertProfile`: the writers span layers
   /// that cannot all reach `ProfileRepository` — the classic-viner seed import
   /// re-runs on every manifest bump.
-  /// Writes profile stats, creating the row when absent.
   ///
-  /// [stampCountFreshness] controls `followerCountsUpdatedAt`, which exists
-  /// solely so FollowRepository's relay-fallback hysteresis can decide when a
-  /// baseline has gone stale. Only a write that establishes such a baseline —
-  /// the relay path — should stamp it. REST-sourced counts pass `false`: they
-  /// update the values, but must not restart the staleness clock, because the
-  /// relay path deliberately skips re-persisting an unchanged count so that
-  /// clock can eventually expire. Refreshing it on every profile view would
-  /// mean it never does (#8259 review).
+  /// Writing either count refreshes `followerCountsUpdatedAt`, which answers
+  /// one question for two readers: *when were these counts last written from
+  /// a source we trust?*
+  ///
+  /// - [getStats] and [deleteExpired] use it as the retention clock, keeping a
+  ///   row whose counts are newer than [profileFollowerCountsCacheDuration]
+  ///   even after the rest of the row has expired.
+  /// - `FollowRepository`'s relay-fallback hysteresis uses it to decide when a
+  ///   baseline is old enough that a lower relay count should be accepted.
+  ///
+  /// Those two readers agree because every writer withholds an ambiguous
+  /// `{0, 0}` response rather than storing it, so a stamp always means real
+  /// data arrived. A REST write and the hysteresis path cannot interleave:
+  /// when REST answers with a signal `getFollowerStats` returns before
+  /// hysteresis runs, and when it does not, no counts are written at all.
   Future<void> upsertStats({
     required String pubkey,
     int? videoCount,
@@ -55,7 +61,6 @@ class ProfileStatsDao extends DatabaseAccessor<AppDatabase>
     int? followingCount,
     int? totalViews,
     int? totalLikes,
-    bool stampCountFreshness = true,
   }) async {
     final tombstone = await (select(
       vanishedProfiles,
@@ -65,8 +70,7 @@ class ProfileStatsDao extends DatabaseAccessor<AppDatabase>
     final existing = await (select(
       profileStats,
     )..where((t) => t.pubkey.equals(pubkey))).getSingleOrNull();
-    final wroteCounts = followerCount != null || followingCount != null;
-    final countsUpdatedAt = wroteCounts && stampCountFreshness
+    final countsUpdatedAt = followerCount != null || followingCount != null
         ? DateTime.now()
         : existing?.followerCountsUpdatedAt;
 

--- a/mobile/packages/db_client/test/src/database/daos/profile_stats_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/profile_stats_dao_test.dart
@@ -146,65 +146,66 @@ void main() {
       });
 
       test(
-        'does not restart the staleness clock when stamping is off',
+        'a later count write refreshes the stamp both readers rely on',
         () async {
-          // REST-sourced counts update the values but must not restart the
-          // clock the relay-fallback hysteresis measures, or the deliberate
-          // "skip the re-write so it can expire" behaviour never expires
-          // (#8259 review).
+          // Transition 1 (#8259 review). Retention (getStats/deleteExpired)
+          // and the relay hysteresis both read followerCountsUpdatedAt, so a
+          // write that left an older stamp in place would make a row holding
+          // *current* counts look stale to retention — evicting the very
+          // fallback baseline the 48h window exists to protect.
           await dao.upsertStats(
             pubkey: testPubkey,
             followerCount: 100,
             followingCount: 50,
           );
-          final original = await appDbClient.getProfileStatRow(testPubkey);
-          expect(original!.followerCountsUpdatedAt, isNotNull);
+          final first = await appDbClient.getProfileStatRow(testPubkey);
 
-          await Future<void>.delayed(const Duration(milliseconds: 5));
+          // The column stores unix seconds, so the writes need a real gap.
+          await Future<void>.delayed(const Duration(milliseconds: 1200));
+
           await dao.upsertStats(
             pubkey: testPubkey,
             followerCount: 512,
             followingCount: 430,
-            stampCountFreshness: false,
           );
+          final second = await appDbClient.getProfileStatRow(testPubkey);
 
-          final result = await appDbClient.getProfileStatRow(testPubkey);
-          // The values move...
-          expect(result!.followerCount, equals(512));
-          expect(result.followingCount, equals(430));
-          // ...but the clock does not.
+          expect(second!.followerCount, equals(512));
           expect(
-            result.followerCountsUpdatedAt,
-            equals(original.followerCountsUpdatedAt),
+            second.followerCountsUpdatedAt!.isAfter(
+              first!.followerCountsUpdatedAt!,
+            ),
+            isTrue,
+            reason:
+                'the counts are current, so the clock both readers share '
+                'must say so',
           );
         },
       );
 
-      test('stamps the staleness clock when stamping is on', () async {
-        await dao.upsertStats(
-          pubkey: testPubkey,
-          followerCount: 100,
-          followingCount: 50,
-        );
-        final original = await appDbClient.getProfileStatRow(testPubkey);
+      test(
+        'a REST-only row does not stay perpetually fresh for hysteresis',
+        () async {
+          // Transition 2 (#8259 review): a row that has never had a relay
+          // write. If the count stamp were left NULL, _loadPersistedStats
+          // would substitute cachedAt — refreshed by every upsert — and the
+          // relay hysteresis would never see the baseline age.
+          await dao.upsertStats(
+            pubkey: testPubkey,
+            followerCount: 512,
+            followingCount: 430,
+          );
 
-        // The column is stored as unix seconds, so the two writes have to
-        // land in different seconds for the comparison to mean anything.
-        await Future<void>.delayed(const Duration(milliseconds: 1100));
-        await dao.upsertStats(
-          pubkey: testPubkey,
-          followerCount: 101,
-          followingCount: 50,
-        );
-
-        final result = await appDbClient.getProfileStatRow(testPubkey);
-        expect(
-          result!.followerCountsUpdatedAt!.isAfter(
-            original!.followerCountsUpdatedAt!,
-          ),
-          isTrue,
-        );
-      });
+          final row = await appDbClient.getProfileStatRow(testPubkey);
+          expect(
+            row!.followerCountsUpdatedAt,
+            isNotNull,
+            reason:
+                'a REST-only row must carry its own count stamp so the '
+                'hysteresis clock can age',
+          );
+        },
+      );
 
       test('no-ops for a pubkey that requested deletion', () async {
         // The classic-viner seed import re-runs on every manifest bump and

--- a/mobile/packages/db_client/test/src/database/daos/profile_stats_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/profile_stats_dao_test.dart
@@ -145,6 +145,67 @@ void main() {
         );
       });
 
+      test(
+        'does not restart the staleness clock when stamping is off',
+        () async {
+          // REST-sourced counts update the values but must not restart the
+          // clock the relay-fallback hysteresis measures, or the deliberate
+          // "skip the re-write so it can expire" behaviour never expires
+          // (#8259 review).
+          await dao.upsertStats(
+            pubkey: testPubkey,
+            followerCount: 100,
+            followingCount: 50,
+          );
+          final original = await appDbClient.getProfileStatRow(testPubkey);
+          expect(original!.followerCountsUpdatedAt, isNotNull);
+
+          await Future<void>.delayed(const Duration(milliseconds: 5));
+          await dao.upsertStats(
+            pubkey: testPubkey,
+            followerCount: 512,
+            followingCount: 430,
+            stampCountFreshness: false,
+          );
+
+          final result = await appDbClient.getProfileStatRow(testPubkey);
+          // The values move...
+          expect(result!.followerCount, equals(512));
+          expect(result.followingCount, equals(430));
+          // ...but the clock does not.
+          expect(
+            result.followerCountsUpdatedAt,
+            equals(original.followerCountsUpdatedAt),
+          );
+        },
+      );
+
+      test('stamps the staleness clock when stamping is on', () async {
+        await dao.upsertStats(
+          pubkey: testPubkey,
+          followerCount: 100,
+          followingCount: 50,
+        );
+        final original = await appDbClient.getProfileStatRow(testPubkey);
+
+        // The column is stored as unix seconds, so the two writes have to
+        // land in different seconds for the comparison to mean anything.
+        await Future<void>.delayed(const Duration(milliseconds: 1100));
+        await dao.upsertStats(
+          pubkey: testPubkey,
+          followerCount: 101,
+          followingCount: 50,
+        );
+
+        final result = await appDbClient.getProfileStatRow(testPubkey);
+        expect(
+          result!.followerCountsUpdatedAt!.isAfter(
+            original!.followerCountsUpdatedAt!,
+          ),
+          isTrue,
+        );
+      });
+
       test('no-ops for a pubkey that requested deletion', () async {
         // The classic-viner seed import re-runs on every manifest bump and
         // writes counters straight to this DAO.

--- a/mobile/packages/follow_repository/lib/src/follow_repository.dart
+++ b/mobile/packages/follow_repository/lib/src/follow_repository.dart
@@ -418,16 +418,18 @@ class FollowRepository {
     final followers = await followersFuture;
     final countFromService = await countFuture;
 
+    // The service count (REST-authoritative, #8197) is what we display;
+    // the relay-fed list only backstops a failed or empty count fetch.
     return FollowersSnapshot(
       pubkeys: followers.pubkeys,
-      count: max(followers.pubkeys.length, countFromService),
+      count: countFromService > 0 ? countFromService : followers.pubkeys.length,
       datedCount: followers.datedCount,
     );
   }
 
   /// Get an accurate follower count for the current user.
   ///
-  /// Uses multi-source fetching with hysteresis stabilization.
+  /// REST-authoritative, with relay fallback (see [getFollowerStats]).
   Future<int> getMyFollowerCount() async {
     final count = await getFollowerCount(_nostrClient.publicKey);
     _cachedMyFollowerCount = count;
@@ -469,10 +471,14 @@ class FollowRepository {
     final countFuture = getMyFollowerCount();
     final followers = await followersFuture;
     final countFromService = await countFuture;
-    final count = max(followers.pubkeys.length, countFromService);
+    // The service count (REST-authoritative, #8197) is what we display;
+    // the relay-fed list only backstops a failed or empty count fetch.
+    final count = countFromService > 0
+        ? countFromService
+        : followers.pubkeys.length;
 
     // The list caches are updated by _fetchMyFollowers/getMyFollowerCount;
-    // store the merged count so the next watchMyFollowers call yields it.
+    // store the selected count so the next watchMyFollowers call yields it.
     _cachedMyFollowerCount = count;
 
     return FollowersSnapshot(
@@ -797,7 +803,11 @@ class FollowRepository {
     }
   }
 
-  // === FOLLOWER STATS (count stabilization with hysteresis) ===
+  // === FOLLOWER STATS ===
+  //
+  // REST counts are authoritative and displayed verbatim (#8197). The
+  // hysteresis machinery below applies only to the relay-fallback path,
+  // whose per-query indexer coverage varies.
 
   /// Counts older than this are considered stale and will be replaced
   /// even if the new value is lower.
@@ -927,9 +937,10 @@ class FollowRepository {
 
   /// Get follower and following counts for a specific pubkey.
   ///
-  /// Returns in-memory cached data when available, otherwise fetches from
-  /// the network and stabilizes the result against a persistent cache using
-  /// hysteresis to avoid visible count fluctuations across app restarts.
+  /// Returns in-memory cached data when available. Otherwise the REST API
+  /// is fetched and its answer returned verbatim (#8197). Only when REST is
+  /// unavailable do relay queries supply the counts, stabilized against the
+  /// persisted baseline with hysteresis to mask per-query relay variance.
   Future<FollowerStats> getFollowerStats(String pubkey) async {
     Log.debug(
       'Fetching follower stats for: ${pubkeyForLogs(pubkey)}',
@@ -952,8 +963,25 @@ class FollowRepository {
       _followerStatsCache.remove(pubkey);
 
       // Fetch from network
-      final freshStats = await _fetchFollowerStats(pubkey);
+      final fetch = await _fetchFollowerStats(pubkey);
+      final freshStats = fetch.stats;
 
+      if (fetch.isAuthoritative) {
+        // The REST API answered: its counts are definitive (#8197), so a
+        // zero is a real zero and a drop is a real drop — no hysteresis.
+        _cacheFollowerStats(pubkey, freshStats);
+        final persisted = await _loadPersistedStats(pubkey);
+        if (pubkey != _nostrClient.publicKey &&
+            (persisted == null ||
+                freshStats.followers != persisted.followers ||
+                freshStats.following != persisted.following)) {
+          await _persistFollowerStats(pubkey, freshStats);
+        }
+        return freshStats;
+      }
+
+      // Relay fallback below: counts are partial observations, so guard
+      // zeros and stabilize drops before display.
       // When all sources returned zero, treat it as a network failure
       // and fall back to persisted data rather than showing 0.
       if (freshStats.followers == 0 && freshStats.following == 0) {
@@ -1023,26 +1051,33 @@ class FollowRepository {
 
   /// Fetch follower stats from the network.
   ///
-  /// Runs REST API and WebSocket queries in parallel, records each source's
-  /// completion state, then selects the highest observed follower count.
-  Future<FollowerStats> _fetchFollowerStats(String pubkey) async {
-    // Run REST and WebSocket queries in parallel for best coverage
-    final (restResult, wsResult) = await (
-      _fetchFollowerStatsViaRest(pubkey),
-      _fetchFollowerStatsViaWebSocket(pubkey),
-    ).wait;
-    final followerCounts = [
-      if (restResult != null)
-        (count: restResult.followers, isComplete: true, source: 'REST'),
-      ...wsResult.followerCounts,
-    ];
-    final followers = _selectFollowerCount(followerCounts);
-    final following = restResult == null
-        ? wsResult.following
-        : max(restResult.following, wsResult.following);
-    final observationSummary = followerCounts.isEmpty
+  /// The Funnelcake REST API is queried first and, when it answers, its
+  /// counts are returned verbatim as the authoritative source (#8197) —
+  /// the same source divine-web displays, so surfaces cannot disagree.
+  /// WebSocket/indexer queries run only when REST is unavailable (offline,
+  /// self-hosted stacks); those observations are partial and vary per
+  /// query, which is why only that path feeds the hysteresis stabilizer.
+  Future<({FollowerStats stats, bool isAuthoritative})> _fetchFollowerStats(
+    String pubkey,
+  ) async {
+    final restResult = await _fetchFollowerStatsViaRest(pubkey);
+    if (restResult != null) {
+      Log.info(
+        'Follower counts from REST (authoritative): '
+        '${restResult.followers} followers, '
+        '${restResult.following} following '
+        'for ${pubkeyForLogs(pubkey)}',
+        name: 'FollowRepository',
+        category: LogCategory.system,
+      );
+      return (stats: restResult, isAuthoritative: true);
+    }
+
+    final wsResult = await _fetchFollowerStatsViaWebSocket(pubkey);
+    final followers = _selectFollowerCount(wsResult.followerCounts);
+    final observationSummary = wsResult.followerCounts.isEmpty
         ? 'none'
-        : followerCounts
+        : wsResult.followerCounts
               .map(
                 (result) =>
                     '${result.source}=${result.count}'
@@ -1051,22 +1086,25 @@ class FollowRepository {
               .join(', ');
 
     Log.info(
-      'Follower count observations: $observationSummary, '
+      'Follower count observations (REST unavailable): $observationSummary, '
       'using $followers for ${pubkeyForLogs(pubkey)}',
       name: 'FollowRepository',
       category: LogCategory.system,
     );
 
-    return FollowerStats(followers: followers, following: following);
+    return (
+      stats: FollowerStats(followers: followers, following: wsResult.following),
+      isAuthoritative: false,
+    );
   }
 
-  /// Selects the best-covered follower count across all observations.
+  /// Selects the best-covered follower count across relay observations.
   ///
-  /// Aggregate counts cannot distinguish a stale over-count from a source with
-  /// broader relay coverage. Completion only means that source finished
-  /// answering; it does not make its holdings globally authoritative. Until
-  /// reconciliation can compare event identities, a lower observation must not
-  /// discard a potentially better-covered source.
+  /// Only used on the relay-fallback path, where aggregate counts cannot
+  /// distinguish a stale over-count from a source with broader relay
+  /// coverage. Completion only means that source finished answering; it
+  /// does not make its holdings globally authoritative, so a lower
+  /// observation must not discard a potentially better-covered source.
   static int _selectFollowerCount(
     List<_FollowerCountObservation> observations,
   ) {
@@ -1120,10 +1158,7 @@ class FollowRepository {
         _fetchFollowersCountViaIndexers(pubkey),
       ).wait;
 
-      return (
-        following: following,
-        followerCounts: followerCounts,
-      );
+      return (following: following, followerCounts: followerCounts);
     } catch (e) {
       Log.error(
         'Error fetching follower stats via WebSocket: $e',
@@ -1251,11 +1286,7 @@ class FollowRepository {
         name: 'FollowRepository',
         category: LogCategory.system,
       );
-      return (
-        count: result,
-        isComplete: isComplete,
-        source: indexerUrl,
-      );
+      return (count: result, isComplete: isComplete, source: indexerUrl);
     } catch (e) {
       Log.warning(
         'Error querying $indexerUrl for followers: $e',

--- a/mobile/packages/follow_repository/lib/src/follow_repository.dart
+++ b/mobile/packages/follow_repository/lib/src/follow_repository.dart
@@ -807,9 +807,10 @@ class FollowRepository {
 
   // === FOLLOWER STATS ===
   //
-  // REST counts are authoritative and displayed verbatim (#8197). The
-  // hysteresis machinery below applies only to the relay-fallback path,
-  // whose per-query indexer coverage varies.
+  // Positive REST counts are authoritative per field (#8197). Funnelcake's
+  // follower and following counts come from independent inputs, so a positive
+  // value in one cannot make an ambiguous zero in the other authoritative.
+  // Hysteresis applies only to fields resolved through relay fallback.
 
   /// Counts older than this are considered stale and will be replaced
   /// even if the new value is lower.
@@ -861,9 +862,9 @@ class FollowRepository {
   ///
   /// This refreshes the row's count-freshness stamp, which is correct for both
   /// of its readers: retention keeps the row, and the relay hysteresis treats
-  /// the baseline as recently confirmed. Ambiguous `{0, 0}` responses never
-  /// reach here — they are withheld upstream — so a stamp always means real
-  /// data arrived.
+  /// the baseline as recently confirmed. Each ambiguous REST zero is withheld
+  /// upstream, so a stamp means at least one count came from a trusted source
+  /// or an established fallback baseline.
   Future<void> _persistFollowerStats(String pubkey, FollowerStats stats) async {
     await _profileStatsDao?.upsertStats(
       pubkey: pubkey,
@@ -910,19 +911,25 @@ class FollowRepository {
     String pubkey,
     FollowerStats freshStats, {
     required ({int followers, int following, DateTime timestamp})? persisted,
+    required bool followersAuthoritative,
+    required bool followingAuthoritative,
   }) {
     if (persisted == null) return freshStats;
 
-    final stableFollowers = _applyHysteresis(
-      freshCount: freshStats.followers,
-      persistedCount: persisted.followers,
-      persistedTimestamp: persisted.timestamp,
-    );
-    final stableFollowing = _applyHysteresis(
-      freshCount: freshStats.following,
-      persistedCount: persisted.following,
-      persistedTimestamp: persisted.timestamp,
-    );
+    final stableFollowers = followersAuthoritative
+        ? freshStats.followers
+        : _applyHysteresis(
+            freshCount: freshStats.followers,
+            persistedCount: persisted.followers,
+            persistedTimestamp: persisted.timestamp,
+          );
+    final stableFollowing = followingAuthoritative
+        ? freshStats.following
+        : _applyHysteresis(
+            freshCount: freshStats.following,
+            persistedCount: persisted.following,
+            persistedTimestamp: persisted.timestamp,
+          );
 
     if (stableFollowers != freshStats.followers ||
         stableFollowing != freshStats.following) {
@@ -945,10 +952,9 @@ class FollowRepository {
 
   /// Get follower and following counts for a specific pubkey.
   ///
-  /// Returns in-memory cached data when available. Otherwise the REST API
-  /// is fetched and its answer returned verbatim (#8197). Only when REST is
-  /// unavailable do relay queries supply the counts, stabilized against the
-  /// persisted baseline with hysteresis to mask per-query relay variance.
+  /// Returns in-memory cached data when available. Otherwise each positive
+  /// REST field is authoritative (#8197), while an ambiguous zero field falls
+  /// back to relays and the persisted baseline with hysteresis.
   Future<FollowerStats> getFollowerStats(String pubkey) async {
     Log.debug(
       'Fetching follower stats for: ${pubkeyForLogs(pubkey)}',
@@ -974,26 +980,26 @@ class FollowRepository {
       final fetch = await _fetchFollowerStats(pubkey);
       final freshStats = fetch.stats;
 
-      if (fetch.isAuthoritative) {
-        // The REST API answered: its counts are definitive (#8197), so a
-        // zero is a real zero and a drop is a real drop — no hysteresis.
+      if (fetch.followersAuthoritative && fetch.followingAuthoritative) {
+        // Both REST fields carry signal, so they are definitive (#8197): a
+        // drop is a real drop and no relay hysteresis applies.
         _cacheFollowerStats(pubkey, freshStats);
         final persisted = await _loadPersistedStats(pubkey);
-        if (pubkey != _nostrClient.publicKey &&
-            (persisted == null ||
-                freshStats.followers != persisted.followers ||
-                freshStats.following != persisted.following)) {
+        if (persisted == null ||
+            freshStats.followers != persisted.followers ||
+            freshStats.following != persisted.following) {
           await _persistFollowerStats(pubkey, freshStats);
         }
         return freshStats;
       }
+
+      final persisted = await _loadPersistedStats(pubkey);
 
       // Relay fallback below: counts are partial observations, so guard
       // zeros and stabilize drops before display.
       // When all sources returned zero, treat it as a network failure
       // and fall back to persisted data rather than showing 0.
       if (freshStats.followers == 0 && freshStats.following == 0) {
-        final persisted = await _loadPersistedStats(pubkey);
         if (persisted != null &&
             (persisted.followers > 0 || persisted.following > 0)) {
           final fallback = FollowerStats(
@@ -1006,10 +1012,33 @@ class FollowRepository {
         return freshStats;
       }
 
-      // Apply hysteresis against the persistent cache so counts don't
-      // visibly fluctuate across app restarts due to relay variance.
-      final persisted = await _loadPersistedStats(pubkey);
-      final stats = _stabilizeStats(pubkey, freshStats, persisted: persisted);
+      // A zero with no authoritative REST signal and no relay observation is
+      // absence, not a measured drop. Preserve that field's known baseline;
+      // otherwise the large-drop branch in hysteresis would accept it as real.
+      final fallbackStats = FollowerStats(
+        followers:
+            !fetch.followersAuthoritative &&
+                freshStats.followers == 0 &&
+                (persisted?.followers ?? 0) > 0
+            ? persisted!.followers
+            : freshStats.followers,
+        following:
+            !fetch.followingAuthoritative &&
+                freshStats.following == 0 &&
+                (persisted?.following ?? 0) > 0
+            ? persisted!.following
+            : freshStats.following,
+      );
+
+      // Apply hysteresis against the persistent cache so relay observations
+      // don't visibly fluctuate across app restarts.
+      final stats = _stabilizeStats(
+        pubkey,
+        fallbackStats,
+        persisted: persisted,
+        followersAuthoritative: fetch.followersAuthoritative,
+        followingAuthoritative: fetch.followingAuthoritative,
+      );
 
       // Cache in memory.
       _cacheFollowerStats(pubkey, stats);
@@ -1017,10 +1046,9 @@ class FollowRepository {
       // Only re-persist when the value actually changed. When hysteresis
       // keeps the old persisted count, skipping the write preserves the
       // original timestamp so the stale check can eventually trigger.
-      if (pubkey != _nostrClient.publicKey &&
-          (persisted == null ||
-              stats.followers != persisted.followers ||
-              stats.following != persisted.following)) {
+      if (persisted == null ||
+          stats.followers != persisted.followers ||
+          stats.following != persisted.following) {
         await _persistFollowerStats(pubkey, stats);
       }
 
@@ -1059,17 +1087,24 @@ class FollowRepository {
 
   /// Fetch follower stats from the network.
   ///
-  /// The Funnelcake REST API is queried first and, when it answers, its
-  /// counts are returned verbatim as the authoritative source (#8197) —
-  /// the same source divine-web displays, so surfaces cannot disagree.
-  /// WebSocket/indexer queries run only when REST is unavailable (offline,
-  /// self-hosted stacks); those observations are partial and vary per
-  /// query, which is why only that path feeds the hysteresis stabilizer.
-  Future<({FollowerStats stats, bool isAuthoritative})> _fetchFollowerStats(
+  /// The Funnelcake REST API is queried first. Each positive field is used
+  /// verbatim as authoritative (#8197); an ambiguous zero field is resolved
+  /// through relays and the persisted baseline instead. Relay observations
+  /// are partial and vary per query, so only fallback fields feed hysteresis.
+  Future<
+    ({
+      FollowerStats stats,
+      bool followersAuthoritative,
+      bool followingAuthoritative,
+    })
+  >
+  _fetchFollowerStats(
     String pubkey,
   ) async {
     final restResult = await _fetchFollowerStatsViaRest(pubkey);
-    // A 0/0 body is not an answer, so it must not be authoritative.
+    // Authority is per field. The two counts come from independent inputs, so
+    // a positive value in one is no evidence that zero in the other means
+    // "genuinely zero" rather than "not indexed" (#8259 review).
     // `/api/users/{pubkey}/social` answers 200 for every pubkey — there is no
     // 404 for an account funnelcake has never ingested — and `get_social_stats`
     // collapses any ClickHouse failure into `{0, 0}` rather than an error. Four
@@ -1078,31 +1113,42 @@ class FollowRepository {
     // as authoritative would display zeros and, worse, persist them over a good
     // baseline; the last of those states was observed returning zeros for every
     // pubkey in production during review of this change.
-    final restHasSignal =
-        restResult != null &&
-        (restResult.followers > 0 || restResult.following > 0);
-    if (restResult != null && restHasSignal) {
+    final followersAuthoritative = (restResult?.followers ?? 0) > 0;
+    final followingAuthoritative = (restResult?.following ?? 0) > 0;
+    if (followersAuthoritative && followingAuthoritative) {
+      final authoritativeRestResult = restResult!;
       Log.info(
         'Follower counts from REST (authoritative): '
-        '${restResult.followers} followers, '
-        '${restResult.following} following '
+        '${authoritativeRestResult.followers} followers, '
+        '${authoritativeRestResult.following} following '
         'for ${pubkeyForLogs(pubkey)}',
         name: 'FollowRepository',
         category: LogCategory.system,
       );
-      return (stats: restResult, isAuthoritative: true);
+      return (
+        stats: authoritativeRestResult,
+        followersAuthoritative: true,
+        followingAuthoritative: true,
+      );
     }
     if (restResult != null) {
       Log.info(
-        'REST returned 0/0 for ${pubkeyForLogs(pubkey)} — treating as no '
-        'answer and falling back to relays',
+        'REST follower stats need per-field fallback for '
+        '${pubkeyForLogs(pubkey)}: '
+        '${restResult.followers} followers, ${restResult.following} following',
         name: 'FollowRepository',
         category: LogCategory.system,
       );
     }
 
     final wsResult = await _fetchFollowerStatsViaWebSocket(pubkey);
-    final followers = _selectFollowerCount(wsResult.followerCounts);
+    final relayFollowers = _selectFollowerCount(wsResult.followerCounts);
+    final followers = followersAuthoritative
+        ? restResult!.followers
+        : relayFollowers;
+    final following = followingAuthoritative
+        ? restResult!.following
+        : wsResult.following;
     final observationSummary = wsResult.followerCounts.isEmpty
         ? 'none'
         : wsResult.followerCounts
@@ -1114,15 +1160,16 @@ class FollowRepository {
               .join(', ');
 
     Log.info(
-      'Follower count observations (REST unavailable): $observationSummary, '
+      'Follower count fallback observations: $observationSummary, '
       'using $followers for ${pubkeyForLogs(pubkey)}',
       name: 'FollowRepository',
       category: LogCategory.system,
     );
 
     return (
-      stats: FollowerStats(followers: followers, following: wsResult.following),
-      isAuthoritative: false,
+      stats: FollowerStats(followers: followers, following: following),
+      followersAuthoritative: followersAuthoritative,
+      followingAuthoritative: followingAuthoritative,
     );
   }
 

--- a/mobile/packages/follow_repository/lib/src/follow_repository.dart
+++ b/mobile/packages/follow_repository/lib/src/follow_repository.dart
@@ -418,11 +418,15 @@ class FollowRepository {
     final followers = await followersFuture;
     final countFromService = await countFuture;
 
-    // The service count (REST-authoritative, #8197) is what we display;
-    // the relay-fed list only backstops a failed or empty count fetch.
+    // The service count is the displayed number, full stop. Substituting the
+    // relay list length when it is 0 would put a relay-derived number back on
+    // screen — the exact inflation #8197 removes — and it would swap the
+    // rendered value a second time once the list resolved (#8259 review).
+    // getFollowerCount already falls back to the persisted baseline when
+    // neither REST nor the relays can answer.
     return FollowersSnapshot(
       pubkeys: followers.pubkeys,
-      count: countFromService > 0 ? countFromService : followers.pubkeys.length,
+      count: countFromService,
       datedCount: followers.datedCount,
     );
   }
@@ -471,11 +475,9 @@ class FollowRepository {
     final countFuture = getMyFollowerCount();
     final followers = await followersFuture;
     final countFromService = await countFuture;
-    // The service count (REST-authoritative, #8197) is what we display;
-    // the relay-fed list only backstops a failed or empty count fetch.
-    final count = countFromService > 0
-        ? countFromService
-        : followers.pubkeys.length;
+    // Same rule as fetchFollowersSnapshot: the service count is displayed
+    // verbatim, never substituted with the relay list length (#8259 review).
+    final count = countFromService;
 
     // The list caches are updated by _fetchMyFollowers/getMyFollowerCount;
     // store the selected count so the next watchMyFollowers call yields it.
@@ -856,11 +858,21 @@ class FollowRepository {
   }
 
   /// Persist follower stats to the Drift database.
-  Future<void> _persistFollowerStats(String pubkey, FollowerStats stats) async {
+  ///
+  /// [isRelayBaseline] must be true only for the relay-fallback path. That is
+  /// the path whose staleness `followerCountsUpdatedAt` measures, and it
+  /// deliberately skips re-persisting an unchanged count so the clock can
+  /// expire; a REST write that restarted it would keep it from ever doing so.
+  Future<void> _persistFollowerStats(
+    String pubkey,
+    FollowerStats stats, {
+    required bool isRelayBaseline,
+  }) async {
     await _profileStatsDao?.upsertStats(
       pubkey: pubkey,
       followerCount: stats.followers,
       followingCount: stats.following,
+      stampCountFreshness: isRelayBaseline,
     );
   }
 
@@ -975,7 +987,11 @@ class FollowRepository {
             (persisted == null ||
                 freshStats.followers != persisted.followers ||
                 freshStats.following != persisted.following)) {
-          await _persistFollowerStats(pubkey, freshStats);
+          await _persistFollowerStats(
+            pubkey,
+            freshStats,
+            isRelayBaseline: false,
+          );
         }
         return freshStats;
       }
@@ -1013,7 +1029,7 @@ class FollowRepository {
           (persisted == null ||
               stats.followers != persisted.followers ||
               stats.following != persisted.following)) {
-        await _persistFollowerStats(pubkey, stats);
+        await _persistFollowerStats(pubkey, stats, isRelayBaseline: true);
       }
 
       Log.debug(

--- a/mobile/packages/follow_repository/lib/src/follow_repository.dart
+++ b/mobile/packages/follow_repository/lib/src/follow_repository.dart
@@ -859,20 +859,16 @@ class FollowRepository {
 
   /// Persist follower stats to the Drift database.
   ///
-  /// [isRelayBaseline] must be true only for the relay-fallback path. That is
-  /// the path whose staleness `followerCountsUpdatedAt` measures, and it
-  /// deliberately skips re-persisting an unchanged count so the clock can
-  /// expire; a REST write that restarted it would keep it from ever doing so.
-  Future<void> _persistFollowerStats(
-    String pubkey,
-    FollowerStats stats, {
-    required bool isRelayBaseline,
-  }) async {
+  /// This refreshes the row's count-freshness stamp, which is correct for both
+  /// of its readers: retention keeps the row, and the relay hysteresis treats
+  /// the baseline as recently confirmed. Ambiguous `{0, 0}` responses never
+  /// reach here — they are withheld upstream — so a stamp always means real
+  /// data arrived.
+  Future<void> _persistFollowerStats(String pubkey, FollowerStats stats) async {
     await _profileStatsDao?.upsertStats(
       pubkey: pubkey,
       followerCount: stats.followers,
       followingCount: stats.following,
-      stampCountFreshness: isRelayBaseline,
     );
   }
 
@@ -987,11 +983,7 @@ class FollowRepository {
             (persisted == null ||
                 freshStats.followers != persisted.followers ||
                 freshStats.following != persisted.following)) {
-          await _persistFollowerStats(
-            pubkey,
-            freshStats,
-            isRelayBaseline: false,
-          );
+          await _persistFollowerStats(pubkey, freshStats);
         }
         return freshStats;
       }
@@ -1029,7 +1021,7 @@ class FollowRepository {
           (persisted == null ||
               stats.followers != persisted.followers ||
               stats.following != persisted.following)) {
-        await _persistFollowerStats(pubkey, stats, isRelayBaseline: true);
+        await _persistFollowerStats(pubkey, stats);
       }
 
       Log.debug(

--- a/mobile/packages/follow_repository/lib/src/follow_repository.dart
+++ b/mobile/packages/follow_repository/lib/src/follow_repository.dart
@@ -1061,7 +1061,19 @@ class FollowRepository {
     String pubkey,
   ) async {
     final restResult = await _fetchFollowerStatsViaRest(pubkey);
-    if (restResult != null) {
+    // A 0/0 body is not an answer, so it must not be authoritative.
+    // `/api/users/{pubkey}/social` answers 200 for every pubkey — there is no
+    // 404 for an account funnelcake has never ingested — and `get_social_stats`
+    // collapses any ClickHouse failure into `{0, 0}` rather than an error. Four
+    // different server states therefore arrive byte-identical: never indexed,
+    // genuinely zero, vanished, and the summary table being down. Treating them
+    // as authoritative would display zeros and, worse, persist them over a good
+    // baseline; the last of those states was observed returning zeros for every
+    // pubkey in production during review of this change.
+    final restHasSignal =
+        restResult != null &&
+        (restResult.followers > 0 || restResult.following > 0);
+    if (restResult != null && restHasSignal) {
       Log.info(
         'Follower counts from REST (authoritative): '
         '${restResult.followers} followers, '
@@ -1071,6 +1083,14 @@ class FollowRepository {
         category: LogCategory.system,
       );
       return (stats: restResult, isAuthoritative: true);
+    }
+    if (restResult != null) {
+      Log.info(
+        'REST returned 0/0 for ${pubkeyForLogs(pubkey)} — treating as no '
+        'answer and falling back to relays',
+        name: 'FollowRepository',
+        category: LogCategory.system,
+      );
     }
 
     final wsResult = await _fetchFollowerStatsViaWebSocket(pubkey);

--- a/mobile/packages/follow_repository/test/src/follow_repository_test.dart
+++ b/mobile/packages/follow_repository/test/src/follow_repository_test.dart
@@ -4840,6 +4840,13 @@ void main() {
               cachedAt: DateTime.now(),
             ),
           );
+          when(
+            () => mockStatsDao.upsertStats(
+              pubkey: any(named: 'pubkey'),
+              followerCount: any(named: 'followerCount'),
+              followingCount: any(named: 'followingCount'),
+            ),
+          ).thenAnswer((_) async {});
 
           repository = FollowRepository(
             nostrClient: mockNostrClient,
@@ -4892,6 +4899,13 @@ void main() {
               cachedAt: DateTime.now(),
             ),
           );
+          when(
+            () => mockStatsDao.upsertStats(
+              pubkey: any(named: 'pubkey'),
+              followerCount: any(named: 'followerCount'),
+              followingCount: any(named: 'followingCount'),
+            ),
+          ).thenAnswer((_) async {});
 
           repository = FollowRepository(
             nostrClient: mockNostrClient,
@@ -5785,6 +5799,104 @@ void main() {
               followingCount: 0,
             ),
           );
+        },
+      );
+
+      test(
+        'uses authoritative followers with following fallback',
+        () async {
+          final mockStatsDao = _MockProfileStatsDao();
+          final mockFunnelcakeClient = _MockFunnelcakeApiClient();
+
+          when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+          when(
+            () => mockFunnelcakeClient.getSocialCounts(testTargetPubkey),
+          ).thenAnswer(
+            (_) async => const SocialCounts(
+              pubkey: testTargetPubkey,
+              followerCount: 1976,
+              followingCount: 0,
+            ),
+          );
+          when(() => mockStatsDao.getStatsRaw(testTargetPubkey)).thenAnswer(
+            (_) async => ProfileStatRow(
+              pubkey: testTargetPubkey,
+              followerCount: 1900,
+              followingCount: 43,
+              cachedAt: DateTime.now(),
+            ),
+          );
+          when(
+            () => mockStatsDao.upsertStats(
+              pubkey: any(named: 'pubkey'),
+              followerCount: any(named: 'followerCount'),
+              followingCount: any(named: 'followingCount'),
+            ),
+          ).thenAnswer((_) async {});
+
+          repository = FollowRepository(
+            nostrClient: mockNostrClient,
+            isCacheInitialized: () => cacheIsInitialized,
+            getCachedEventsByKind: (kind) => getCachedEventsByKind(kind),
+            cacheUserEvent: cachedUserEvents.add,
+            funnelcakeApiClient: mockFunnelcakeClient,
+            profileStatsDao: mockStatsDao,
+            indexerRelayUrls: const [],
+          );
+
+          final stats = await repository.getFollowerStats(testTargetPubkey);
+
+          expect(stats.followers, equals(1976));
+          expect(stats.following, equals(43));
+        },
+      );
+
+      test(
+        'uses authoritative following with follower fallback',
+        () async {
+          final mockStatsDao = _MockProfileStatsDao();
+          final mockFunnelcakeClient = _MockFunnelcakeApiClient();
+
+          when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+          when(
+            () => mockFunnelcakeClient.getSocialCounts(testTargetPubkey),
+          ).thenAnswer(
+            (_) async => const SocialCounts(
+              pubkey: testTargetPubkey,
+              followerCount: 0,
+              followingCount: 42,
+            ),
+          );
+          when(() => mockStatsDao.getStatsRaw(testTargetPubkey)).thenAnswer(
+            (_) async => ProfileStatRow(
+              pubkey: testTargetPubkey,
+              followerCount: 512,
+              followingCount: 430,
+              cachedAt: DateTime.now(),
+            ),
+          );
+          when(
+            () => mockStatsDao.upsertStats(
+              pubkey: any(named: 'pubkey'),
+              followerCount: any(named: 'followerCount'),
+              followingCount: any(named: 'followingCount'),
+            ),
+          ).thenAnswer((_) async {});
+
+          repository = FollowRepository(
+            nostrClient: mockNostrClient,
+            isCacheInitialized: () => cacheIsInitialized,
+            getCachedEventsByKind: (kind) => getCachedEventsByKind(kind),
+            cacheUserEvent: cachedUserEvents.add,
+            funnelcakeApiClient: mockFunnelcakeClient,
+            profileStatsDao: mockStatsDao,
+            indexerRelayUrls: const [],
+          );
+
+          final stats = await repository.getFollowerStats(testTargetPubkey);
+
+          expect(stats.followers, equals(512));
+          expect(stats.following, equals(42));
         },
       );
 

--- a/mobile/packages/follow_repository/test/src/follow_repository_test.dart
+++ b/mobile/packages/follow_repository/test/src/follow_repository_test.dart
@@ -5730,6 +5730,58 @@ void main() {
       );
 
       test(
+        'a 0/0 REST body is not authoritative and is not persisted',
+        () async {
+          // funnelcake answers 200 for every pubkey and turns ClickHouse
+          // failures into {0, 0}, so a zero body cannot be trusted as data
+          // (#8259 review). It must fall through to the relay path.
+          final mockStatsDao = _MockProfileStatsDao();
+          final mockFunnelcakeClient = _MockFunnelcakeApiClient();
+
+          when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+          when(
+            () => mockFunnelcakeClient.getSocialCounts(testTargetPubkey),
+          ).thenAnswer(
+            (_) async => const SocialCounts(
+              pubkey: testTargetPubkey,
+              followerCount: 0,
+              followingCount: 0,
+            ),
+          );
+          when(() => mockStatsDao.getStatsRaw(testTargetPubkey)).thenAnswer(
+            (_) async => ProfileStatRow(
+              pubkey: testTargetPubkey,
+              followerCount: 512,
+              followingCount: 430,
+              cachedAt: DateTime.now(),
+            ),
+          );
+
+          repository = FollowRepository(
+            nostrClient: mockNostrClient,
+            isCacheInitialized: () => cacheIsInitialized,
+            getCachedEventsByKind: (kind) => getCachedEventsByKind(kind),
+            cacheUserEvent: cachedUserEvents.add,
+            funnelcakeApiClient: mockFunnelcakeClient,
+            profileStatsDao: mockStatsDao,
+            indexerRelayUrls: const [],
+          );
+
+          final stats = await repository.getFollowerStats(testTargetPubkey);
+
+          expect(stats.followers, equals(512));
+          expect(stats.following, equals(430));
+          verifyNever(
+            () => mockStatsDao.upsertStats(
+              pubkey: any(named: 'pubkey'),
+              followerCount: 0,
+              followingCount: 0,
+            ),
+          );
+        },
+      );
+
+      test(
         'persists when only the following count changed',
         () async {
           final mockStatsDao = _MockProfileStatsDao();

--- a/mobile/packages/follow_repository/test/src/follow_repository_test.dart
+++ b/mobile/packages/follow_repository/test/src/follow_repository_test.dart
@@ -4752,7 +4752,8 @@ void main() {
       );
 
       test(
-        'persists stats and applies hysteresis',
+        'returns REST counts verbatim over a higher persisted baseline '
+        '(#8197)',
         () async {
           final mockStatsDao = _MockProfileStatsDao();
           final mockFunnelcakeClient = _MockFunnelcakeApiClient();
@@ -4798,10 +4799,18 @@ void main() {
 
           final stats = await repository.getFollowerStats(testTargetPubkey);
 
-          // Hysteresis should keep the higher persisted values
-          // since 90 >= ceil(100 * 0.8) = 80
-          expect(stats.followers, equals(100));
-          expect(stats.following, equals(50));
+          // REST is authoritative (#8197): the drop from the persisted
+          // 100/50 baseline is real data, not relay variance, so no
+          // hysteresis applies and the fresh counts are persisted.
+          expect(stats.followers, equals(90));
+          expect(stats.following, equals(45));
+          verify(
+            () => mockStatsDao.upsertStats(
+              pubkey: testTargetPubkey,
+              followerCount: 90,
+              followingCount: 45,
+            ),
+          ).called(1);
         },
       );
 
@@ -5301,9 +5310,9 @@ void main() {
       );
     });
 
-    group('getFollowerStats - following merge', () {
+    group('getFollowerStats - REST following authority', () {
       test(
-        'picks WS following when higher than REST',
+        'uses REST following verbatim without querying relays (#8197)',
         () async {
           final mockFunnelcakeClient = _MockFunnelcakeApiClient();
           when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
@@ -5367,12 +5376,195 @@ void main() {
 
           final stats = await repository.getFollowerStats(testTargetPubkey);
 
-          // followers: max(REST 50, WS 0) = 50
-          // following: max(REST 30, WS 80) = 80 (WS wins)
+          // REST answered, so its counts stand verbatim (#8197) — the
+          // kind-3 event with 80 p-tags must never be consulted.
           expect(stats.followers, equals(50));
-          expect(stats.following, equals(80));
+          expect(stats.following, equals(30));
+          verifyNever(
+            () => mockNostrClient.subscribe(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+              tempRelays: any(named: 'tempRelays'),
+              targetRelays: any(named: 'targetRelays'),
+              relayTypes: any(named: 'relayTypes'),
+              sendAfterAuth: any(named: 'sendAfterAuth'),
+              onEose: any(named: 'onEose'),
+            ),
+          );
         },
       );
+    });
+
+    group('getFollowerStats - relay-fallback hysteresis', () {
+      // With REST unavailable, the relay fallback supplies the counts and
+      // hysteresis stabilizes them against the persisted baseline (#8197
+      // keeps this machinery for the fallback path only).
+      Event contactList(int pTagCount) => Event(
+        testTargetPubkey,
+        EventKind.contactList,
+        List.generate(
+          pTagCount,
+          (i) => ['p', i.toRadixString(16).padLeft(64, '0')],
+        ),
+        '',
+        createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+      );
+
+      ProfileStatRow persistedFollowing(
+        int following, {
+        DateTime? updatedAt,
+        DateTime? cachedAt,
+      }) => ProfileStatRow(
+        pubkey: testTargetPubkey,
+        followerCount: 0,
+        followingCount: following,
+        cachedAt: cachedAt ?? DateTime.now(),
+        followerCountsUpdatedAt: updatedAt,
+      );
+
+      _MockProfileStatsDao statsDaoWith(ProfileStatRow row) {
+        final dao = _MockProfileStatsDao();
+        when(
+          () => dao.getStatsRaw(testTargetPubkey),
+        ).thenAnswer((_) async => row);
+        when(
+          () => dao.upsertStats(
+            pubkey: any(named: 'pubkey'),
+            followerCount: any(named: 'followerCount'),
+            followingCount: any(named: 'followingCount'),
+          ),
+        ).thenAnswer((_) async {});
+        return dao;
+      }
+
+      FollowRepository buildFallbackRepository({
+        required _MockProfileStatsDao statsDao,
+        required int relayFollowing,
+      }) {
+        final mockFunnelcakeClient = _MockFunnelcakeApiClient();
+        when(() => mockFunnelcakeClient.isAvailable).thenReturn(false);
+        final event = contactList(relayFollowing);
+        when(
+          () => mockNostrClient.subscribe(
+            any(),
+            subscriptionId: any(named: 'subscriptionId'),
+            tempRelays: any(named: 'tempRelays'),
+            targetRelays: any(named: 'targetRelays'),
+            relayTypes: any(named: 'relayTypes'),
+            sendAfterAuth: any(named: 'sendAfterAuth'),
+            onEose: any(named: 'onEose'),
+          ),
+        ).thenAnswer((_) => Stream.value(event));
+        return FollowRepository(
+          nostrClient: mockNostrClient,
+          isCacheInitialized: () => cacheIsInitialized,
+          getCachedEventsByKind: (kind) => getCachedEventsByKind(kind),
+          cacheUserEvent: cachedUserEvents.add,
+          funnelcakeApiClient: mockFunnelcakeClient,
+          profileStatsDao: statsDao,
+          indexerRelayUrls: const [],
+          queryContactList:
+              ({
+                required eventStream,
+                required pubkey,
+                fallbackTimeoutSeconds = 10,
+              }) async {
+                await for (final event in eventStream) {
+                  if (event.kind == EventKind.contactList &&
+                      event.pubkey == pubkey) {
+                    return event;
+                  }
+                }
+                return null;
+              },
+        );
+      }
+
+      test(
+        'holds the following count across an overnight gap (#6902)',
+        () async {
+          // Last seen at 98 the night before; the relay answers 86 in the
+          // morning — within the threshold, so the baseline holds. The
+          // baseline's freshness must come from followerCountsUpdatedAt,
+          // not the unrelated (stale) cachedAt.
+          final dao = statsDaoWith(
+            persistedFollowing(
+              98,
+              updatedAt: DateTime.now().subtract(const Duration(hours: 10)),
+              cachedAt: DateTime.now().subtract(const Duration(hours: 30)),
+            ),
+          );
+          repository = buildFallbackRepository(
+            statsDao: dao,
+            relayFollowing: 86,
+          );
+
+          final stats = await repository.getFollowerStats(testTargetPubkey);
+
+          expect(stats.following, equals(98));
+          // Hysteresis kept the persisted values — nothing to re-persist.
+          verifyNever(
+            () => dao.upsertStats(
+              pubkey: any(named: 'pubkey'),
+              followerCount: any(named: 'followerCount'),
+              followingCount: any(named: 'followingCount'),
+            ),
+          );
+        },
+      );
+
+      test(
+        'accepts a relay drop below the threshold and persists it',
+        () async {
+          // Persisted 100, threshold ceil(100 * 0.8) = 80; the relay answers
+          // 79 — a genuine drop, accepted and written through.
+          final dao = statsDaoWith(persistedFollowing(100));
+          repository = buildFallbackRepository(
+            statsDao: dao,
+            relayFollowing: 79,
+          );
+
+          final stats = await repository.getFollowerStats(testTargetPubkey);
+
+          expect(stats.following, equals(79));
+          verify(
+            () => dao.upsertStats(
+              pubkey: testTargetPubkey,
+              followerCount: 0,
+              followingCount: 79,
+            ),
+          ).called(1);
+        },
+      );
+
+      test('accepts a lower relay count over a stale baseline', () async {
+        final dao = statsDaoWith(
+          persistedFollowing(
+            100,
+            updatedAt: DateTime.now().subtract(const Duration(hours: 30)),
+          ),
+        );
+        repository = buildFallbackRepository(
+          statsDao: dao,
+          relayFollowing: 86,
+        );
+
+        final stats = await repository.getFollowerStats(testTargetPubkey);
+
+        expect(stats.following, equals(86));
+      });
+
+      test('reflects one-person drops for small accounts', () async {
+        final dao = statsDaoWith(persistedFollowing(10));
+        repository = buildFallbackRepository(
+          statsDao: dao,
+          relayFollowing: 9,
+        );
+
+        final stats = await repository.getFollowerStats(testTargetPubkey);
+
+        expect(stats.following, equals(9));
+      });
     });
 
     group('getFollowerStats - persistence', () {
@@ -5480,13 +5672,13 @@ void main() {
       );
 
       test(
-        'does not persist when hysteresis keeps persisted values',
+        'persists lower REST counts that differ from the baseline (#8197)',
         () async {
           final mockStatsDao = _MockProfileStatsDao();
           final mockFunnelcakeClient = _MockFunnelcakeApiClient();
 
           when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
-          // Fresh stats slightly lower (within threshold)
+          // Fresh REST counts slightly lower than the persisted baseline.
           when(
             () => mockFunnelcakeClient.getSocialCounts(testTargetPubkey),
           ).thenAnswer(
@@ -5506,6 +5698,14 @@ void main() {
             ),
           );
 
+          when(
+            () => mockStatsDao.upsertStats(
+              pubkey: any(named: 'pubkey'),
+              followerCount: any(named: 'followerCount'),
+              followingCount: any(named: 'followingCount'),
+            ),
+          ).thenAnswer((_) async {});
+
           repository = FollowRepository(
             nostrClient: mockNostrClient,
             isCacheInitialized: () => cacheIsInitialized,
@@ -5518,14 +5718,71 @@ void main() {
 
           await repository.getFollowerStats(testTargetPubkey);
 
-          // Hysteresis keeps persisted values — no upsert needed
-          verifyNever(
+          // REST is authoritative — the changed counts are written through.
+          verify(
+            () => mockStatsDao.upsertStats(
+              pubkey: testTargetPubkey,
+              followerCount: 90,
+              followingCount: 45,
+            ),
+          ).called(1);
+        },
+      );
+
+      test(
+        'persists when only the following count changed',
+        () async {
+          final mockStatsDao = _MockProfileStatsDao();
+          final mockFunnelcakeClient = _MockFunnelcakeApiClient();
+
+          when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+          when(
+            () => mockFunnelcakeClient.getSocialCounts(testTargetPubkey),
+          ).thenAnswer(
+            (_) async => const SocialCounts(
+              pubkey: testTargetPubkey,
+              followerCount: 90,
+              followingCount: 45,
+            ),
+          );
+
+          // Same follower count; only following moved.
+          when(() => mockStatsDao.getStatsRaw(testTargetPubkey)).thenAnswer(
+            (_) async => ProfileStatRow(
+              pubkey: testTargetPubkey,
+              followerCount: 90,
+              followingCount: 50,
+              cachedAt: DateTime.now(),
+            ),
+          );
+
+          when(
             () => mockStatsDao.upsertStats(
               pubkey: any(named: 'pubkey'),
               followerCount: any(named: 'followerCount'),
               followingCount: any(named: 'followingCount'),
             ),
+          ).thenAnswer((_) async {});
+
+          repository = FollowRepository(
+            nostrClient: mockNostrClient,
+            isCacheInitialized: () => cacheIsInitialized,
+            getCachedEventsByKind: (kind) => getCachedEventsByKind(kind),
+            cacheUserEvent: cachedUserEvents.add,
+            funnelcakeApiClient: mockFunnelcakeClient,
+            profileStatsDao: mockStatsDao,
+            indexerRelayUrls: const [],
           );
+
+          await repository.getFollowerStats(testTargetPubkey);
+
+          verify(
+            () => mockStatsDao.upsertStats(
+              pubkey: testTargetPubkey,
+              followerCount: 90,
+              followingCount: 45,
+            ),
+          ).called(1);
         },
       );
     });
@@ -5713,6 +5970,35 @@ void main() {
       }
 
       group('_fetchFollowersCountViaIndexers', () {
+        test(
+          'relay fallback still settles when an indexer never connects',
+          () async {
+            // With REST unavailable the fallback path queries indexers, so
+            // this is the only route that exercises the connect deadline in
+            // _queryIndexerForFollowerCount: when REST answers, the #8197
+            // short-circuit skips indexers entirely.
+            final api = _MockFunnelcakeApiClient();
+            when(() => api.isAvailable).thenReturn(false);
+            repository = FollowRepository(
+              nostrClient: mockNostrClient,
+              isCacheInitialized: () => cacheIsInitialized,
+              getCachedEventsByKind: (kind) => getCachedEventsByKind(kind),
+              cacheUserEvent: cachedUserEvents.add,
+              funnelcakeApiClient: api,
+              indexerRelayUrls: const [indexerUrl],
+              indexerOperationTimeout: const Duration(milliseconds: 20),
+              relayFactory: (url, status) =>
+                  _FakeRelay(url, status, neverConnects: true),
+            );
+
+            final stats = await repository
+                .getFollowerStats(testTargetPubkey)
+                .timeout(const Duration(milliseconds: 500));
+
+            expect(stats, FollowerStats.zero);
+          },
+        );
+
         test('keeps REST count when an indexer never connects', () async {
           final api = _MockFunnelcakeApiClient();
           when(() => api.isAvailable).thenReturn(true);
@@ -5885,7 +6171,7 @@ void main() {
         );
 
         test(
-          'keeps the highest count across REST and complete indexers',
+          'uses the REST count verbatim, ignoring higher indexers (#8197)',
           () async {
             final mockFunnelcakeClient = _MockFunnelcakeApiClient();
             when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
@@ -5928,12 +6214,14 @@ void main() {
 
             final stats = await repository.getFollowerStats(testTargetPubkey);
 
-            expect(stats.followers, equals(500));
+            // REST answered with 50, so 50 is displayed — the indexers
+            // reporting 55 and 500 are never allowed to override it.
+            expect(stats.followers, equals(50));
           },
         );
 
         test(
-          'keeps a higher REST count over two lower indexers',
+          'uses a higher REST count without consulting indexers',
           () async {
             final mockFunnelcakeClient = _MockFunnelcakeApiClient();
             when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
@@ -6724,46 +7012,50 @@ void main() {
     });
 
     group('getFollowerStats - source confidence', () {
-      test('uses a higher single-indexer lower bound over REST', () async {
-        final mockFunnelcakeClient = _MockFunnelcakeApiClient();
-        when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
-        when(
-          () => mockFunnelcakeClient.getSocialCounts(testTargetPubkey),
-        ).thenAnswer(
-          (_) async => const SocialCounts(
-            pubkey: testTargetPubkey,
-            followerCount: 5,
-            followingCount: 10,
-          ),
-        );
+      test(
+        'REST verbatim even when an indexer reports higher (#8197)',
+        () async {
+          final mockFunnelcakeClient = _MockFunnelcakeApiClient();
+          when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+          when(
+            () => mockFunnelcakeClient.getSocialCounts(testTargetPubkey),
+          ).thenAnswer(
+            (_) async => const SocialCounts(
+              pubkey: testTargetPubkey,
+              followerCount: 5,
+              followingCount: 10,
+            ),
+          );
 
-        repository = FollowRepository(
-          nostrClient: mockNostrClient,
-          isCacheInitialized: () => cacheIsInitialized,
-          getCachedEventsByKind: (kind) => getCachedEventsByKind(kind),
-          cacheUserEvent: cachedUserEvents.add,
-          funnelcakeApiClient: mockFunnelcakeClient,
-          indexerRelayUrls: const ['wss://idx.test'],
-          relayFactory: (url, status) {
-            return _FakeRelay(url, status)
-              ..fakeResponses = [
-                ...List.generate(
-                  10,
-                  (i) => <dynamic>[
-                    'EVENT',
-                    's',
-                    {'pubkey': i.toRadixString(16).padLeft(64, '0')},
-                  ],
-                ),
-                <dynamic>['EOSE', 's'],
-              ];
-          },
-        );
+          repository = FollowRepository(
+            nostrClient: mockNostrClient,
+            isCacheInitialized: () => cacheIsInitialized,
+            getCachedEventsByKind: (kind) => getCachedEventsByKind(kind),
+            cacheUserEvent: cachedUserEvents.add,
+            funnelcakeApiClient: mockFunnelcakeClient,
+            indexerRelayUrls: const ['wss://idx.test'],
+            relayFactory: (url, status) {
+              return _FakeRelay(url, status)
+                ..fakeResponses = [
+                  ...List.generate(
+                    10,
+                    (i) => <dynamic>[
+                      'EVENT',
+                      's',
+                      {'pubkey': i.toRadixString(16).padLeft(64, '0')},
+                    ],
+                  ),
+                  <dynamic>['EOSE', 's'],
+                ];
+            },
+          );
 
-        final stats = await repository.getFollowerStats(testTargetPubkey);
+          final stats = await repository.getFollowerStats(testTargetPubkey);
 
-        expect(stats.followers, equals(10));
-      });
+          // REST said 5; the indexer's 10 is not consulted (#8197).
+          expect(stats.followers, equals(5));
+        },
+      );
 
       test(
         'does not let one low EOSE indexer drag REST down',

--- a/mobile/packages/follow_repository/test/src/follow_repository_test.dart
+++ b/mobile/packages/follow_repository/test/src/follow_repository_test.dart
@@ -4784,7 +4784,6 @@ void main() {
               pubkey: any(named: 'pubkey'),
               followerCount: any(named: 'followerCount'),
               followingCount: any(named: 'followingCount'),
-              stampCountFreshness: any(named: 'stampCountFreshness'),
             ),
           ).thenAnswer((_) async {});
 
@@ -4810,7 +4809,6 @@ void main() {
               pubkey: testTargetPubkey,
               followerCount: 90,
               followingCount: 45,
-              stampCountFreshness: false,
             ),
           ).called(1);
         },
@@ -5434,7 +5432,6 @@ void main() {
             pubkey: any(named: 'pubkey'),
             followerCount: any(named: 'followerCount'),
             followingCount: any(named: 'followingCount'),
-            stampCountFreshness: any(named: 'stampCountFreshness'),
           ),
         ).thenAnswer((_) async {});
         return dao;
@@ -5511,7 +5508,6 @@ void main() {
               pubkey: any(named: 'pubkey'),
               followerCount: any(named: 'followerCount'),
               followingCount: any(named: 'followingCount'),
-              stampCountFreshness: any(named: 'stampCountFreshness'),
             ),
           );
         },
@@ -5531,10 +5527,6 @@ void main() {
           final stats = await repository.getFollowerStats(testTargetPubkey);
 
           expect(stats.following, equals(79));
-          // Relay fallback: this write *is* the baseline whose age the
-          // staleness clock measures, so unlike the REST path it stamps
-          // (stampCountFreshness defaults to true; the DAO's own tests pin
-          // what stamping actually does).
           verify(
             () => dao.upsertStats(
               pubkey: testTargetPubkey,
@@ -5612,7 +5604,6 @@ void main() {
               pubkey: any(named: 'pubkey'),
               followerCount: any(named: 'followerCount'),
               followingCount: any(named: 'followingCount'),
-              stampCountFreshness: any(named: 'stampCountFreshness'),
             ),
           );
         },
@@ -5651,7 +5642,6 @@ void main() {
               pubkey: any(named: 'pubkey'),
               followerCount: any(named: 'followerCount'),
               followingCount: any(named: 'followingCount'),
-              stampCountFreshness: any(named: 'stampCountFreshness'),
             ),
           ).thenAnswer((_) async {});
 
@@ -5676,7 +5666,6 @@ void main() {
               pubkey: testTargetPubkey,
               followerCount: 200,
               followingCount: 100,
-              stampCountFreshness: false,
             ),
           ).called(1);
         },
@@ -5714,7 +5703,6 @@ void main() {
               pubkey: any(named: 'pubkey'),
               followerCount: any(named: 'followerCount'),
               followingCount: any(named: 'followingCount'),
-              stampCountFreshness: any(named: 'stampCountFreshness'),
             ),
           ).thenAnswer((_) async {});
 
@@ -5736,7 +5724,6 @@ void main() {
               pubkey: testTargetPubkey,
               followerCount: 90,
               followingCount: 45,
-              stampCountFreshness: false,
             ),
           ).called(1);
         },
@@ -5789,7 +5776,6 @@ void main() {
               pubkey: any(named: 'pubkey'),
               followerCount: 0,
               followingCount: 0,
-              stampCountFreshness: false,
             ),
           );
         },
@@ -5827,7 +5813,6 @@ void main() {
               pubkey: any(named: 'pubkey'),
               followerCount: any(named: 'followerCount'),
               followingCount: any(named: 'followingCount'),
-              stampCountFreshness: any(named: 'stampCountFreshness'),
             ),
           ).thenAnswer((_) async {});
 
@@ -5848,7 +5833,6 @@ void main() {
               pubkey: testTargetPubkey,
               followerCount: 90,
               followingCount: 45,
-              stampCountFreshness: false,
             ),
           ).called(1);
         },

--- a/mobile/packages/follow_repository/test/src/follow_repository_test.dart
+++ b/mobile/packages/follow_repository/test/src/follow_repository_test.dart
@@ -5569,7 +5569,7 @@ void main() {
 
     group('getFollowerStats - persistence', () {
       test(
-        'does not persist raw stats for the signed-in user',
+        'persists authoritative stats for the signed-in user',
         () async {
           final mockStatsDao = _MockProfileStatsDao();
           final mockFunnelcakeClient = _MockFunnelcakeApiClient();
@@ -5586,6 +5586,13 @@ void main() {
           when(
             () => mockStatsDao.getStatsRaw(testCurrentUserPubkey),
           ).thenAnswer((_) async => null);
+          when(
+            () => mockStatsDao.upsertStats(
+              pubkey: any(named: 'pubkey'),
+              followerCount: any(named: 'followerCount'),
+              followingCount: any(named: 'followingCount'),
+            ),
+          ).thenAnswer((_) async {});
 
           repository = FollowRepository(
             nostrClient: mockNostrClient,
@@ -5599,13 +5606,13 @@ void main() {
 
           await repository.getFollowerStats(testCurrentUserPubkey);
 
-          verifyNever(
+          verify(
             () => mockStatsDao.upsertStats(
-              pubkey: any(named: 'pubkey'),
-              followerCount: any(named: 'followerCount'),
-              followingCount: any(named: 'followingCount'),
+              pubkey: testCurrentUserPubkey,
+              followerCount: 200,
+              followingCount: 100,
             ),
-          );
+          ).called(1);
         },
       );
 
@@ -6050,35 +6057,6 @@ void main() {
             expect(stats, FollowerStats.zero);
           },
         );
-
-        test('keeps REST count when an indexer never connects', () async {
-          final api = _MockFunnelcakeApiClient();
-          when(() => api.isAvailable).thenReturn(true);
-          when(() => api.getSocialCounts(testTargetPubkey)).thenAnswer(
-            (_) async => const SocialCounts(
-              pubkey: testTargetPubkey,
-              followerCount: 50,
-              followingCount: 7,
-            ),
-          );
-          repository = FollowRepository(
-            nostrClient: mockNostrClient,
-            isCacheInitialized: () => cacheIsInitialized,
-            getCachedEventsByKind: (kind) => getCachedEventsByKind(kind),
-            cacheUserEvent: cachedUserEvents.add,
-            funnelcakeApiClient: api,
-            indexerRelayUrls: const [indexerUrl],
-            indexerOperationTimeout: const Duration(milliseconds: 20),
-            relayFactory: (url, status) =>
-                _FakeRelay(url, status, neverConnects: true),
-          );
-
-          final stats = await repository
-              .getFollowerStats(testTargetPubkey)
-              .timeout(const Duration(milliseconds: 200));
-
-          expect(stats, const FollowerStats(followers: 50, following: 7));
-        });
 
         test('bounds CLOSE and disconnect after a count response', () async {
           repository = FollowRepository(

--- a/mobile/packages/follow_repository/test/src/follow_repository_test.dart
+++ b/mobile/packages/follow_repository/test/src/follow_repository_test.dart
@@ -4784,6 +4784,7 @@ void main() {
               pubkey: any(named: 'pubkey'),
               followerCount: any(named: 'followerCount'),
               followingCount: any(named: 'followingCount'),
+              stampCountFreshness: any(named: 'stampCountFreshness'),
             ),
           ).thenAnswer((_) async {});
 
@@ -4809,6 +4810,7 @@ void main() {
               pubkey: testTargetPubkey,
               followerCount: 90,
               followingCount: 45,
+              stampCountFreshness: false,
             ),
           ).called(1);
         },
@@ -5432,6 +5434,7 @@ void main() {
             pubkey: any(named: 'pubkey'),
             followerCount: any(named: 'followerCount'),
             followingCount: any(named: 'followingCount'),
+            stampCountFreshness: any(named: 'stampCountFreshness'),
           ),
         ).thenAnswer((_) async {});
         return dao;
@@ -5508,6 +5511,7 @@ void main() {
               pubkey: any(named: 'pubkey'),
               followerCount: any(named: 'followerCount'),
               followingCount: any(named: 'followingCount'),
+              stampCountFreshness: any(named: 'stampCountFreshness'),
             ),
           );
         },
@@ -5527,6 +5531,10 @@ void main() {
           final stats = await repository.getFollowerStats(testTargetPubkey);
 
           expect(stats.following, equals(79));
+          // Relay fallback: this write *is* the baseline whose age the
+          // staleness clock measures, so unlike the REST path it stamps
+          // (stampCountFreshness defaults to true; the DAO's own tests pin
+          // what stamping actually does).
           verify(
             () => dao.upsertStats(
               pubkey: testTargetPubkey,
@@ -5604,6 +5612,7 @@ void main() {
               pubkey: any(named: 'pubkey'),
               followerCount: any(named: 'followerCount'),
               followingCount: any(named: 'followingCount'),
+              stampCountFreshness: any(named: 'stampCountFreshness'),
             ),
           );
         },
@@ -5642,6 +5651,7 @@ void main() {
               pubkey: any(named: 'pubkey'),
               followerCount: any(named: 'followerCount'),
               followingCount: any(named: 'followingCount'),
+              stampCountFreshness: any(named: 'stampCountFreshness'),
             ),
           ).thenAnswer((_) async {});
 
@@ -5666,6 +5676,7 @@ void main() {
               pubkey: testTargetPubkey,
               followerCount: 200,
               followingCount: 100,
+              stampCountFreshness: false,
             ),
           ).called(1);
         },
@@ -5703,6 +5714,7 @@ void main() {
               pubkey: any(named: 'pubkey'),
               followerCount: any(named: 'followerCount'),
               followingCount: any(named: 'followingCount'),
+              stampCountFreshness: any(named: 'stampCountFreshness'),
             ),
           ).thenAnswer((_) async {});
 
@@ -5724,6 +5736,7 @@ void main() {
               pubkey: testTargetPubkey,
               followerCount: 90,
               followingCount: 45,
+              stampCountFreshness: false,
             ),
           ).called(1);
         },
@@ -5776,6 +5789,7 @@ void main() {
               pubkey: any(named: 'pubkey'),
               followerCount: 0,
               followingCount: 0,
+              stampCountFreshness: false,
             ),
           );
         },
@@ -5813,6 +5827,7 @@ void main() {
               pubkey: any(named: 'pubkey'),
               followerCount: any(named: 'followerCount'),
               followingCount: any(named: 'followingCount'),
+              stampCountFreshness: any(named: 'stampCountFreshness'),
             ),
           ).thenAnswer((_) async {});
 
@@ -5833,6 +5848,7 @@ void main() {
               pubkey: testTargetPubkey,
               followerCount: 90,
               followingCount: 45,
+              stampCountFreshness: false,
             ),
           ).called(1);
         },
@@ -6269,54 +6285,6 @@ void main() {
             // REST answered with 50, so 50 is displayed — the indexers
             // reporting 55 and 500 are never allowed to override it.
             expect(stats.followers, equals(50));
-          },
-        );
-
-        test(
-          'uses a higher REST count without consulting indexers',
-          () async {
-            final mockFunnelcakeClient = _MockFunnelcakeApiClient();
-            when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
-            when(
-              () => mockFunnelcakeClient.getSocialCounts(testTargetPubkey),
-            ).thenAnswer(
-              (_) async => const SocialCounts(
-                pubkey: testTargetPubkey,
-                followerCount: 500,
-                followingCount: 0,
-              ),
-            );
-
-            repository = FollowRepository(
-              nostrClient: mockNostrClient,
-              isCacheInitialized: () => cacheIsInitialized,
-              getCachedEventsByKind: (kind) => getCachedEventsByKind(kind),
-              cacheUserEvent: cachedUserEvents.add,
-              funnelcakeApiClient: mockFunnelcakeClient,
-              indexerRelayUrls: const [
-                'wss://indexer1.test',
-                'wss://indexer2.test',
-              ],
-              relayFactory: (url, status) {
-                final count = url.contains('indexer1') ? 88 : 90;
-                return _FakeRelay(url, status)
-                  ..fakeResponses = [
-                    ...List.generate(
-                      count,
-                      (i) => <dynamic>[
-                        'EVENT',
-                        's',
-                        {'pubkey': i.toRadixString(16).padLeft(64, '0')},
-                      ],
-                    ),
-                    <dynamic>['EOSE', 's'],
-                  ];
-              },
-            );
-
-            final stats = await repository.getFollowerStats(testTargetPubkey);
-
-            expect(stats.followers, equals(500));
           },
         );
 
@@ -7106,98 +7074,6 @@ void main() {
 
           // REST said 5; the indexer's 10 is not consulted (#8197).
           expect(stats.followers, equals(5));
-        },
-      );
-
-      test(
-        'does not let one low EOSE indexer drag REST down',
-        () async {
-          final mockFunnelcakeClient = _MockFunnelcakeApiClient();
-          when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
-          when(
-            () => mockFunnelcakeClient.getSocialCounts(testTargetPubkey),
-          ).thenAnswer(
-            (_) async => const SocialCounts(
-              pubkey: testTargetPubkey,
-              followerCount: 1000,
-              followingCount: 10,
-            ),
-          );
-
-          const indexerUrl = 'wss://idx.test';
-
-          repository = FollowRepository(
-            nostrClient: mockNostrClient,
-            isCacheInitialized: () => cacheIsInitialized,
-            getCachedEventsByKind: (kind) => getCachedEventsByKind(kind),
-            cacheUserEvent: cachedUserEvents.add,
-            funnelcakeApiClient: mockFunnelcakeClient,
-            indexerRelayUrls: const [indexerUrl],
-            relayFactory: (url, status) {
-              return _FakeRelay(url, status)
-                ..fakeResponses = [
-                  ...List.generate(
-                    10,
-                    (i) => <dynamic>[
-                      'EVENT',
-                      's',
-                      {
-                        'pubkey': i.toRadixString(16).padLeft(64, '0'),
-                      },
-                    ],
-                  ),
-                  <dynamic>['EOSE', 's'],
-                ];
-            },
-          );
-
-          final stats = await repository.getFollowerStats(testTargetPubkey);
-
-          expect(stats.followers, equals(1000));
-          // following: max(REST 10, WS 0) = 10
-          expect(stats.following, equals(10));
-        },
-      );
-
-      test(
-        'does not let one low partial indexer drag REST down',
-        () async {
-          final mockFunnelcakeClient = _MockFunnelcakeApiClient();
-          when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
-          when(
-            () => mockFunnelcakeClient.getSocialCounts(testTargetPubkey),
-          ).thenAnswer(
-            (_) async => const SocialCounts(
-              pubkey: testTargetPubkey,
-              followerCount: 1000,
-              followingCount: 10,
-            ),
-          );
-
-          repository = FollowRepository(
-            nostrClient: mockNostrClient,
-            isCacheInitialized: () => cacheIsInitialized,
-            getCachedEventsByKind: (kind) => getCachedEventsByKind(kind),
-            cacheUserEvent: cachedUserEvents.add,
-            funnelcakeApiClient: mockFunnelcakeClient,
-            indexerQueryTimeout: Duration.zero,
-            indexerRelayUrls: const ['wss://idx.test'],
-            relayFactory: (url, status) {
-              return _FakeRelay(url, status)
-                ..fakeResponses = List.generate(
-                  3,
-                  (i) => <dynamic>[
-                    'EVENT',
-                    's',
-                    {'pubkey': i.toRadixString(16).padLeft(64, '0')},
-                  ],
-                );
-            },
-          );
-
-          final stats = await repository.getFollowerStats(testTargetPubkey);
-
-          expect(stats.followers, equals(1000));
         },
       );
     });

--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -750,16 +750,29 @@ class ProfileRepository implements ProfileReader {
           : engagement.totalLoops.round();
     }
 
+    // A 0/0 body is not data. `/api/users/{pubkey}/social` answers 200 for
+    // every pubkey, and funnelcake collapses ClickHouse failures into
+    // `{0, 0}`, so "never indexed", "genuinely zero", "vanished" and "the
+    // summary table is down" are indistinguishable here. Writing it would
+    // overwrite a good baseline with zeros (#8259 review), so this writer
+    // skips the counts entirely unless at least one of them carries a signal.
+    final hasSocialSignal =
+        social != null &&
+        (social.followerCount > 0 || social.followingCount > 0);
+
     await dao.upsertStats(
       pubkey: pubkey,
       // The REST social counts are the authoritative follower/following
       // numbers (#8197) and the only ones available before any relay work
       // finishes, so the profile header can render them immediately.
-      followerCount: social?.followerCount,
-      followingCount: social?.followingCount,
+      followerCount: hasSocialSignal ? social.followerCount : null,
+      followingCount: hasSocialSignal ? social.followingCount : null,
       videoCount: stats?.videoCount,
       totalLikes: engagement?.totalReactions,
       totalViews: publicViewCount,
+      // REST is not the relay-fallback baseline, so it must not restart the
+      // hysteresis staleness clock. See ProfileStatsDao.upsertStats.
+      stampCountFreshness: false,
     );
   }
 

--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -720,11 +720,14 @@ class ProfileRepository implements ProfileReader {
     });
   }
 
-  /// Caches profile stats (video stats and engagement data) from a
-  /// [UserProfileResult] into the local [ProfileStatsDao].
+  /// Caches profile stats — social counts, video stats and engagement data —
+  /// from a [UserProfileResult] into the local [ProfileStatsDao].
   ///
-  /// Follower/following counts are owned by FollowRepository because it merges
-  /// REST, relay, and persisted inputs with hysteresis stabilization.
+  /// The REST `social` counts are cached here because they are the
+  /// authoritative follower/following numbers (#8197) and the only ones
+  /// available before any relay work finishes, so the profile header can
+  /// render immediately. FollowRepository still owns the relay-fallback path
+  /// and its hysteresis stabilization for the case where REST cannot answer.
   Future<void> _cacheProfileStatsFromResult(
     String pubkey,
     UserProfileResult result,

--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -770,9 +770,6 @@ class ProfileRepository implements ProfileReader {
       videoCount: stats?.videoCount,
       totalLikes: engagement?.totalReactions,
       totalViews: publicViewCount,
-      // REST is not the relay-fallback baseline, so it must not restart the
-      // hysteresis staleness clock. See ProfileStatsDao.upsertStats.
-      stampCountFreshness: false,
     );
   }
 

--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -750,23 +750,26 @@ class ProfileRepository implements ProfileReader {
           : engagement.totalLoops.round();
     }
 
-    // A 0/0 body is not data. `/api/users/{pubkey}/social` answers 200 for
+    // A zero field is not data. `/api/users/{pubkey}/social` answers 200 for
     // every pubkey, and funnelcake collapses ClickHouse failures into
     // `{0, 0}`, so "never indexed", "genuinely zero", "vanished" and "the
     // summary table is down" are indistinguishable here. Writing it would
     // overwrite a good baseline with zeros (#8259 review), so this writer
-    // skips the counts entirely unless at least one of them carries a signal.
-    final hasSocialSignal =
-        social != null &&
-        (social.followerCount > 0 || social.followingCount > 0);
+    // withholds each ambiguous field independently. The two counts come from
+    // different inputs, so a positive value in one cannot legitimize a zero in
+    // the other (#8259 review).
 
     await dao.upsertStats(
       pubkey: pubkey,
       // The REST social counts are the authoritative follower/following
       // numbers (#8197) and the only ones available before any relay work
       // finishes, so the profile header can render them immediately.
-      followerCount: hasSocialSignal ? social.followerCount : null,
-      followingCount: hasSocialSignal ? social.followingCount : null,
+      followerCount: (social?.followerCount ?? 0) > 0
+          ? social!.followerCount
+          : null,
+      followingCount: (social?.followingCount ?? 0) > 0
+          ? social!.followingCount
+          : null,
       videoCount: stats?.videoCount,
       totalLikes: engagement?.totalReactions,
       totalViews: publicViewCount,

--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -736,8 +736,9 @@ class ProfileRepository implements ProfileReader {
     // so no switch is needed here.
     final stats = result.stats;
     final engagement = result.engagement;
+    final social = result.social;
 
-    if (stats == null && engagement == null) return;
+    if (stats == null && engagement == null && social == null) return;
 
     int? publicViewCount;
     if (engagement != null) {
@@ -748,6 +749,11 @@ class ProfileRepository implements ProfileReader {
 
     await dao.upsertStats(
       pubkey: pubkey,
+      // The REST social counts are the authoritative follower/following
+      // numbers (#8197) and the only ones available before any relay work
+      // finishes, so the profile header can render them immediately.
+      followerCount: social?.followerCount,
+      followingCount: social?.followingCount,
       videoCount: stats?.videoCount,
       totalLikes: engagement?.totalReactions,
       totalViews: publicViewCount,

--- a/mobile/packages/profile_repository/test/src/profile_repository_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_test.dart
@@ -666,7 +666,6 @@ void main() {
               followingCount: any(named: 'followingCount'),
               totalViews: any(named: 'totalViews'),
               totalLikes: any(named: 'totalLikes'),
-              stampCountFreshness: any(named: 'stampCountFreshness'),
             ),
           ).thenAnswer((_) async {});
           repoWithFunnelcake = ProfileRepository(
@@ -974,7 +973,6 @@ void main() {
                 videoCount: any(named: 'videoCount'),
                 totalLikes: any(named: 'totalLikes'),
                 totalViews: any(named: 'totalViews'),
-                stampCountFreshness: any(named: 'stampCountFreshness'),
               ),
             );
           });
@@ -1332,9 +1330,6 @@ void main() {
               videoCount: 3,
               totalLikes: 42,
               totalViews: 99,
-              // REST is not the relay baseline, so it must not restart the
-              // hysteresis staleness clock (#8259 review).
-              stampCountFreshness: false,
             ),
           ).called(1);
         });
@@ -1367,7 +1362,6 @@ void main() {
               videoCount: any(named: 'videoCount'),
               totalLikes: any(named: 'totalLikes'),
               totalViews: 13,
-              stampCountFreshness: any(named: 'stampCountFreshness'),
             ),
           ).called(1);
         });
@@ -1405,7 +1399,6 @@ void main() {
                 videoCount: 3,
                 totalLikes: any(named: 'totalLikes'),
                 totalViews: any(named: 'totalViews'),
-                stampCountFreshness: false,
               ),
             ).called(1);
           },

--- a/mobile/packages/profile_repository/test/src/profile_repository_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_test.dart
@@ -1322,6 +1322,11 @@ void main() {
           verify(
             () => mockProfileStatsDao.upsertStats(
               pubkey: testPubkey,
+              // REST social counts are cached alongside the other stats so
+              // the profile header can render them without waiting on any
+              // relay work (#8197).
+              followerCount: 12,
+              followingCount: 7,
               videoCount: 3,
               totalLikes: 42,
               totalViews: 99,

--- a/mobile/packages/profile_repository/test/src/profile_repository_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_test.dart
@@ -1366,43 +1366,67 @@ void main() {
           ).called(1);
         });
 
-        test(
-          'does not cache an ambiguous 0/0 social response',
-          () async {
-            // `/api/users/{pubkey}/social` answers 200 for every pubkey and
-            // funnelcake turns ClickHouse failures into `{0, 0}`, so a zero
-            // body cannot be told apart from "never indexed" or "the summary
-            // table is down". Writing it would overwrite a good baseline
-            // with zeros (#8259 review).
-            when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
-            when(
-              () => mockFunnelcakeClient.getUserProfile(testPubkey),
-            ).thenAnswer(
-              (_) async => UserProfileNotPublished(
-                pubkey: testPubkey,
-                social: ProfileSocialData.fromJson(const {
-                  'follower_count': 0,
-                  'following_count': 0,
-                }),
-                stats: ProfileStatsData.fromJson(const {'video_count': 3}),
-              ),
-            );
+        test('does not cache an ambiguous 0/0 social response', () async {
+          // `/api/users/{pubkey}/social` answers 200 for every pubkey and
+          // funnelcake turns ClickHouse failures into `{0, 0}`, so a zero
+          // body cannot be told apart from "never indexed" or "the summary
+          // table is down". Writing it would overwrite a good baseline
+          // with zeros (#8259 review).
+          when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+          when(
+            () => mockFunnelcakeClient.getUserProfile(testPubkey),
+          ).thenAnswer(
+            (_) async => UserProfileNotPublished(
+              pubkey: testPubkey,
+              social: ProfileSocialData.fromJson(const {
+                'follower_count': 0,
+                'following_count': 0,
+              }),
+              stats: ProfileStatsData.fromJson(const {'video_count': 3}),
+            ),
+          );
 
-            await repoWithFunnelcake.fetchFreshProfile(pubkey: testPubkey);
+          await repoWithFunnelcake.fetchFreshProfile(pubkey: testPubkey);
 
-            // The other stats are still cached; the counts are withheld,
-            // i.e. passed as null (the default), so the DAO leaves whatever
-            // baseline is already on the row untouched.
-            verify(
-              () => mockProfileStatsDao.upsertStats(
-                pubkey: testPubkey,
-                videoCount: 3,
-                totalLikes: any(named: 'totalLikes'),
-                totalViews: any(named: 'totalViews'),
-              ),
-            ).called(1);
-          },
-        );
+          // The other stats are still cached; the counts are withheld,
+          // i.e. passed as null (the default), so the DAO leaves whatever
+          // baseline is already on the row untouched.
+          verify(
+            () => mockProfileStatsDao.upsertStats(
+              pubkey: testPubkey,
+              videoCount: 3,
+              totalLikes: any(named: 'totalLikes'),
+              totalViews: any(named: 'totalViews'),
+            ),
+          ).called(1);
+        });
+
+        test('caches mixed social responses per field', () async {
+          when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+          when(
+            () => mockFunnelcakeClient.getUserProfile(testPubkey),
+          ).thenAnswer(
+            (_) async => UserProfileNotPublished(
+              pubkey: testPubkey,
+              social: ProfileSocialData.fromJson(const {
+                'follower_count': 1976,
+                'following_count': 0,
+              }),
+            ),
+          );
+
+          await repoWithFunnelcake.fetchFreshProfile(pubkey: testPubkey);
+
+          verify(
+            () => mockProfileStatsDao.upsertStats(
+              pubkey: testPubkey,
+              followerCount: 1976,
+              totalLikes: any(named: 'totalLikes'),
+              totalViews: any(named: 'totalViews'),
+              videoCount: any(named: 'videoCount'),
+            ),
+          ).called(1);
+        });
 
         test('skips Funnelcake when not available', () async {
           when(() => mockFunnelcakeClient.isAvailable).thenReturn(false);

--- a/mobile/packages/profile_repository/test/src/profile_repository_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_test.dart
@@ -666,6 +666,7 @@ void main() {
               followingCount: any(named: 'followingCount'),
               totalViews: any(named: 'totalViews'),
               totalLikes: any(named: 'totalLikes'),
+              stampCountFreshness: any(named: 'stampCountFreshness'),
             ),
           ).thenAnswer((_) async {});
           repoWithFunnelcake = ProfileRepository(
@@ -973,6 +974,7 @@ void main() {
                 videoCount: any(named: 'videoCount'),
                 totalLikes: any(named: 'totalLikes'),
                 totalViews: any(named: 'totalViews'),
+                stampCountFreshness: any(named: 'stampCountFreshness'),
               ),
             );
           });
@@ -1330,6 +1332,9 @@ void main() {
               videoCount: 3,
               totalLikes: 42,
               totalViews: 99,
+              // REST is not the relay baseline, so it must not restart the
+              // hysteresis staleness clock (#8259 review).
+              stampCountFreshness: false,
             ),
           ).called(1);
         });
@@ -1362,9 +1367,49 @@ void main() {
               videoCount: any(named: 'videoCount'),
               totalLikes: any(named: 'totalLikes'),
               totalViews: 13,
+              stampCountFreshness: any(named: 'stampCountFreshness'),
             ),
           ).called(1);
         });
+
+        test(
+          'does not cache an ambiguous 0/0 social response',
+          () async {
+            // `/api/users/{pubkey}/social` answers 200 for every pubkey and
+            // funnelcake turns ClickHouse failures into `{0, 0}`, so a zero
+            // body cannot be told apart from "never indexed" or "the summary
+            // table is down". Writing it would overwrite a good baseline
+            // with zeros (#8259 review).
+            when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+            when(
+              () => mockFunnelcakeClient.getUserProfile(testPubkey),
+            ).thenAnswer(
+              (_) async => UserProfileNotPublished(
+                pubkey: testPubkey,
+                social: ProfileSocialData.fromJson(const {
+                  'follower_count': 0,
+                  'following_count': 0,
+                }),
+                stats: ProfileStatsData.fromJson(const {'video_count': 3}),
+              ),
+            );
+
+            await repoWithFunnelcake.fetchFreshProfile(pubkey: testPubkey);
+
+            // The other stats are still cached; the counts are withheld,
+            // i.e. passed as null (the default), so the DAO leaves whatever
+            // baseline is already on the row untouched.
+            verify(
+              () => mockProfileStatsDao.upsertStats(
+                pubkey: testPubkey,
+                videoCount: 3,
+                totalLikes: any(named: 'totalLikes'),
+                totalViews: any(named: 'totalViews'),
+                stampCountFreshness: false,
+              ),
+            ).called(1);
+          },
+        );
 
         test('skips Funnelcake when not available', () async {
           when(() => mockFunnelcakeClient.isAvailable).thenReturn(false);

--- a/mobile/test/blocs/followers/follower_visibility_test.dart
+++ b/mobile/test/blocs/followers/follower_visibility_test.dart
@@ -1,0 +1,78 @@
+// ABOUTME: Pins the displayed follower count to the authoritative REST value
+// ABOUTME: minus locally hidden rows, with no relay-list-length floor (#8197).
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/blocs/followers/follower_visibility.dart';
+
+void main() {
+  group('visibleFollowerCount', () {
+    test('shows the authoritative count when nothing is hidden', () {
+      expect(
+        visibleFollowerCount(
+          visiblePubkeyCount: 146,
+          rawPubkeyCount: 146,
+          authoritativeFollowerCount: 146,
+        ),
+        equals(146),
+      );
+    });
+
+    test('subtracts followers the profile owner has blocked', () {
+      // 5 of the fetched rows are blocked: 146 - 5 = 141.
+      expect(
+        visibleFollowerCount(
+          visiblePubkeyCount: 175,
+          rawPubkeyCount: 180,
+          authoritativeFollowerCount: 146,
+        ),
+        equals(141),
+      );
+    });
+
+    test(
+      'is not floored by a relay list longer than the count (#8197)',
+      () {
+        // The real measured shape for @cptnbackfire: REST 146, relay-merged
+        // union 180. A floor at the visible row count would display 180 and
+        // move with relay coverage — the instability this issue reports.
+        expect(
+          visibleFollowerCount(
+            visiblePubkeyCount: 180,
+            rawPubkeyCount: 180,
+            authoritativeFollowerCount: 146,
+          ),
+          equals(146),
+        );
+      },
+    );
+
+    test('blocking stays legible as relay coverage changes', () {
+      // Same account, same 5 blocks, two runs where the union differed
+      // (170 one day, 180 the next). The number must not move.
+      final smallerUnion = visibleFollowerCount(
+        visiblePubkeyCount: 165,
+        rawPubkeyCount: 170,
+        authoritativeFollowerCount: 146,
+      );
+      final largerUnion = visibleFollowerCount(
+        visiblePubkeyCount: 175,
+        rawPubkeyCount: 180,
+        authoritativeFollowerCount: 146,
+      );
+
+      expect(smallerUnion, equals(largerUnion));
+      expect(smallerUnion, equals(141));
+    });
+
+    test('never goes negative when hidden rows exceed the count', () {
+      expect(
+        visibleFollowerCount(
+          visiblePubkeyCount: 0,
+          rawPubkeyCount: 5,
+          authoritativeFollowerCount: 2,
+        ),
+        equals(0),
+      );
+    });
+  });
+}

--- a/mobile/test/blocs/others_followers/others_followers_bloc_test.dart
+++ b/mobile/test/blocs/others_followers/others_followers_bloc_test.dart
@@ -186,10 +186,7 @@ void main() {
             bloc.add(OthersFollowersListLoadRequested(validPubkey('target'))),
         verify: (bloc) {
           expect(bloc.state.followersPubkeys, [validPubkey('follower1')]);
-          // The row is hidden locally, but the count stays the authoritative
-          // REST number (#8197) rather than being adjusted to match the
-          // rendered rows.
-          expect(bloc.state.followerCount, 2);
+          expect(bloc.state.followerCount, 1);
         },
       );
 
@@ -465,7 +462,7 @@ void main() {
       );
 
       blocTest<OthersFollowersBloc, OthersFollowersState>(
-        'still counts a new follower the viewer has blocked',
+        'keeps the visible count steady when the new follower is blocked',
         setUp: () {
           when(
             () => mockBlocklistRepository.isBlocked(validPubkey('new')),
@@ -482,13 +479,12 @@ void main() {
         act: (bloc) =>
             bloc.add(OthersFollowersIncrementRequested(validPubkey('new'))),
         verify: (bloc) {
-          // The target really did gain a follower, so the count moves. The
-          // viewer cannot see that follower's row, but blocking someone does
-          // not make them stop following (#8197): the count stays the
-          // authoritative REST number.
+          // The target really did gain a follower, so the authoritative count
+          // moves; the viewer cannot see that follower, so the displayed count
+          // must not.
           expect(bloc.state.authoritativeFollowerCount, equals(501));
           expect(bloc.state.followersPubkeys, [validPubkey('existing')]);
-          expect(bloc.state.followerCount, equals(501));
+          expect(bloc.state.followerCount, equals(500));
         },
       );
 
@@ -594,9 +590,8 @@ void main() {
           authoritativeFollowerCount: 500,
           targetPubkey: validPubkey('target'),
         ),
-        act: (bloc) => bloc.add(
-          OthersFollowersDecrementRequested(validPubkey('blocked')),
-        ),
+        act: (bloc) =>
+            bloc.add(OthersFollowersDecrementRequested(validPubkey('blocked'))),
         verify: (bloc) {
           expect(bloc.state.authoritativeFollowerCount, equals(499));
           expect(bloc.state.rawFollowersPubkeys, [validPubkey('existing')]);
@@ -628,7 +623,7 @@ void main() {
 
     group('OthersFollowersBlocklistChanged', () {
       blocTest<OthersFollowersBloc, OthersFollowersState>(
-        'hides newly blocked followers from the list without moving the count',
+        'subtracts newly hidden known followers from the visible count',
         setUp: () {
           when(
             () => mockBlocklistRepository.isBlocked(validPubkey('hidden')),
@@ -650,8 +645,7 @@ void main() {
             validPubkey('hidden'),
           ]);
           expect(bloc.state.followersPubkeys, [validPubkey('visible')]);
-          // Row hidden, count unchanged (#8197).
-          expect(bloc.state.followerCount, equals(500));
+          expect(bloc.state.followerCount, equals(499));
         },
       );
 

--- a/mobile/test/blocs/others_followers/others_followers_bloc_test.dart
+++ b/mobile/test/blocs/others_followers/others_followers_bloc_test.dart
@@ -186,7 +186,10 @@ void main() {
             bloc.add(OthersFollowersListLoadRequested(validPubkey('target'))),
         verify: (bloc) {
           expect(bloc.state.followersPubkeys, [validPubkey('follower1')]);
-          expect(bloc.state.followerCount, 1);
+          // The row is hidden locally, but the count stays the authoritative
+          // REST number (#8197) rather than being adjusted to match the
+          // rendered rows.
+          expect(bloc.state.followerCount, 2);
         },
       );
 
@@ -462,7 +465,7 @@ void main() {
       );
 
       blocTest<OthersFollowersBloc, OthersFollowersState>(
-        'keeps the visible count steady when the new follower is blocked',
+        'still counts a new follower the viewer has blocked',
         setUp: () {
           when(
             () => mockBlocklistRepository.isBlocked(validPubkey('new')),
@@ -479,12 +482,13 @@ void main() {
         act: (bloc) =>
             bloc.add(OthersFollowersIncrementRequested(validPubkey('new'))),
         verify: (bloc) {
-          // The target really did gain a follower, so the authoritative count
-          // moves; the viewer just cannot see that follower, so the displayed
-          // count must not.
+          // The target really did gain a follower, so the count moves. The
+          // viewer cannot see that follower's row, but blocking someone does
+          // not make them stop following (#8197): the count stays the
+          // authoritative REST number.
           expect(bloc.state.authoritativeFollowerCount, equals(501));
           expect(bloc.state.followersPubkeys, [validPubkey('existing')]);
-          expect(bloc.state.followerCount, equals(500));
+          expect(bloc.state.followerCount, equals(501));
         },
       );
 
@@ -624,7 +628,7 @@ void main() {
 
     group('OthersFollowersBlocklistChanged', () {
       blocTest<OthersFollowersBloc, OthersFollowersState>(
-        'subtracts newly hidden known followers from the visible count',
+        'hides newly blocked followers from the list without moving the count',
         setUp: () {
           when(
             () => mockBlocklistRepository.isBlocked(validPubkey('hidden')),
@@ -646,7 +650,8 @@ void main() {
             validPubkey('hidden'),
           ]);
           expect(bloc.state.followersPubkeys, [validPubkey('visible')]);
-          expect(bloc.state.followerCount, equals(499));
+          // Row hidden, count unchanged (#8197).
+          expect(bloc.state.followerCount, equals(500));
         },
       );
 

--- a/mobile/test/repositories/follow_repository_follower_stats_test.dart
+++ b/mobile/test/repositories/follow_repository_follower_stats_test.dart
@@ -301,6 +301,70 @@ void main() {
       });
     });
 
+    group('getFollowerStats - REST 0/0 is not an answer', () {
+      // `/api/users/{pubkey}/social` returns 200 for every pubkey and
+      // funnelcake collapses ClickHouse failures into {0, 0}, so a zero body
+      // cannot be distinguished from "never indexed", "vanished", or "the
+      // summary table is down". It must not be displayed or persisted over a
+      // known-good baseline (#8259 review).
+      test('keeps the persisted baseline instead of showing zeros', () async {
+        final apiClient = _MockFunnelcakeApiClient();
+        final dao = _MockProfileStatsDao();
+        final repository = _createRepository(
+          apiClient: apiClient,
+          dao: dao,
+          // restFollowers / restFollowing default to 0 — the "funnelcake
+          // knows nothing" shape.
+          persistedRow: _persistedRow(followers: 512, following: 430),
+        );
+
+        final stats = await repository.getFollowerStats(_testPubkey);
+
+        expect(stats.followers, equals(512));
+        expect(stats.following, equals(430));
+      });
+
+      test('does not persist zeros over a known-good baseline', () async {
+        final apiClient = _MockFunnelcakeApiClient();
+        final dao = _MockProfileStatsDao();
+        final repository = _createRepository(
+          apiClient: apiClient,
+          dao: dao,
+          // restFollowers / restFollowing default to 0 — the "funnelcake
+          // knows nothing" shape.
+          persistedRow: _persistedRow(followers: 512, following: 430),
+        );
+
+        await repository.getFollowerStats(_testPubkey);
+
+        verifyNever(
+          () => dao.upsertStats(
+            pubkey: any(named: 'pubkey'),
+            followerCount: 0,
+            followingCount: 0,
+          ),
+        );
+      });
+
+      test('a partial zero still counts as an answer', () async {
+        // 0 followers with a non-zero following is real data, not the
+        // "funnelcake knows nothing" shape.
+        final apiClient = _MockFunnelcakeApiClient();
+        final dao = _MockProfileStatsDao();
+        final repository = _createRepository(
+          apiClient: apiClient,
+          dao: dao,
+          restFollowing: 42,
+          persistedRow: _persistedRow(followers: 512, following: 430),
+        );
+
+        final stats = await repository.getFollowerStats(_testPubkey);
+
+        expect(stats.followers, equals(0));
+        expect(stats.following, equals(42));
+      });
+    });
+
     group('getFollowerStats - relay-fallback hysteresis', () {
       test(
         'holds the following count across an overnight gap (#6902)',

--- a/mobile/test/repositories/follow_repository_follower_stats_test.dart
+++ b/mobile/test/repositories/follow_repository_follower_stats_test.dart
@@ -88,6 +88,7 @@ FollowRepository _createRepository({
       pubkey: any(named: 'pubkey'),
       followerCount: any(named: 'followerCount'),
       followingCount: any(named: 'followingCount'),
+      stampCountFreshness: any(named: 'stampCountFreshness'),
     ),
   ).thenAnswer((_) async {});
 
@@ -154,6 +155,7 @@ void main() {
             pubkey: _testPubkey,
             followerCount: 50,
             followingCount: 20,
+            stampCountFreshness: false,
           ),
         ).called(1);
       });
@@ -274,6 +276,7 @@ void main() {
             pubkey: _testPubkey,
             followerCount: 90,
             followingCount: 20,
+            stampCountFreshness: false,
           ),
         ).called(1);
       });
@@ -296,6 +299,7 @@ void main() {
             pubkey: any(named: 'pubkey'),
             followerCount: any(named: 'followerCount'),
             followingCount: any(named: 'followingCount'),
+            stampCountFreshness: any(named: 'stampCountFreshness'),
           ),
         );
       });
@@ -342,6 +346,7 @@ void main() {
             pubkey: any(named: 'pubkey'),
             followerCount: 0,
             followingCount: 0,
+            stampCountFreshness: false,
           ),
         );
       });

--- a/mobile/test/repositories/follow_repository_follower_stats_test.dart
+++ b/mobile/test/repositories/follow_repository_follower_stats_test.dart
@@ -346,9 +346,9 @@ void main() {
         );
       });
 
-      test('a partial zero still counts as an answer', () async {
-        // 0 followers with a non-zero following is real data, not the
-        // "funnelcake knows nothing" shape.
+      test('treats authority per field when followers are zero', () async {
+        // The two fields come from independent Funnelcake inputs. A known
+        // following count cannot turn an ambiguous follower zero into data.
         final apiClient = _MockFunnelcakeApiClient();
         final dao = _MockProfileStatsDao();
         final repository = _createRepository(
@@ -360,8 +360,27 @@ void main() {
 
         final stats = await repository.getFollowerStats(_testPubkey);
 
-        expect(stats.followers, equals(0));
+        expect(stats.followers, equals(512));
         expect(stats.following, equals(42));
+      });
+
+      test('treats authority per field when following is zero', () async {
+        // A known follower count likewise cannot legitimize an ambiguous
+        // following zero. The relay/persisted fallback still owns that field.
+        final apiClient = _MockFunnelcakeApiClient();
+        final dao = _MockProfileStatsDao();
+        final repository = _createRepository(
+          apiClient: apiClient,
+          dao: dao,
+          restFollowers: 1976,
+          contactListEvent: _contactListEvent(41),
+          persistedRow: _persistedRow(followers: 1900, following: 43),
+        );
+
+        final stats = await repository.getFollowerStats(_testPubkey);
+
+        expect(stats.followers, equals(1976));
+        expect(stats.following, equals(43));
       });
     });
 

--- a/mobile/test/repositories/follow_repository_follower_stats_test.dart
+++ b/mobile/test/repositories/follow_repository_follower_stats_test.dart
@@ -1,5 +1,6 @@
-// ABOUTME: Tests for FollowRepository persistent follower count cache and
-// ABOUTME: hysteresis logic that stabilizes counts across app restarts.
+// ABOUTME: Tests for FollowRepository follower-count sourcing: REST counts
+// ABOUTME: are authoritative (#8197); hysteresis applies only to relay
+// ABOUTME: fallback, stabilizing partial counts across app restarts.
 
 import 'package:db_client/db_client.dart' hide Filter;
 import 'package:flutter_test/flutter_test.dart';
@@ -16,22 +17,41 @@ class _MockFunnelcakeApiClient extends Mock implements FunnelcakeApiClient {}
 
 class _MockProfileStatsDao extends Mock implements ProfileStatsDao {}
 
-const _testPubkey = 'abc123def456';
+const _testPubkey =
+    'abc123def4560000000000000000000000000000000000000000000000000001';
 
 void _registerFallbackValues() {
   registerFallbackValue(<Filter>[]);
 }
 
+/// Builds a kind-3 contact list event for [_testPubkey] with [pTagCount]
+/// `p` tags, used to drive the relay-fallback following count.
+Event _contactListEvent(int pTagCount) {
+  return Event(
+    _testPubkey,
+    EventKind.contactList,
+    List.generate(
+      pTagCount,
+      (i) => ['p', i.toRadixString(16).padLeft(64, '0')],
+    ),
+    '',
+    createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+  );
+}
+
 /// Creates a [FollowRepository] wired to mock dependencies.
 ///
-/// [restFollowers] / [restFollowing] control what the REST API returns.
-/// Pass [indexerRelayUrls] as empty to avoid real WebSocket connections.
+/// [restFollowers] / [restFollowing] control what the REST API returns when
+/// [restAvailable] is true. When [contactListEvent] is provided, the relay
+/// fallback path can resolve a following count from it.
 /// Pass [persistedRow] to seed the mock DAO with persisted stats.
 FollowRepository _createRepository({
   required _MockFunnelcakeApiClient apiClient,
   required _MockProfileStatsDao dao,
   int restFollowers = 0,
   int restFollowing = 0,
+  bool restAvailable = true,
+  Event? contactListEvent,
   ProfileStatRow? persistedRow,
 }) {
   final nostrClient = _MockNostrClient();
@@ -40,13 +60,15 @@ FollowRepository _createRepository({
   // repository-owned persistence remains part of the scenario under test.
   when(() => nostrClient.publicKey).thenReturn('current-user');
 
-  // Mock NostrClient.subscribe to return an empty stream (no WS data).
-  when(
-    () => nostrClient.subscribe(any()),
-  ).thenAnswer((_) => const Stream<Event>.empty());
+  // Relay fallback: emit the contact list event when provided.
+  when(() => nostrClient.subscribe(any())).thenAnswer(
+    (_) => contactListEvent == null
+        ? const Stream<Event>.empty()
+        : Stream.value(contactListEvent),
+  );
 
   // Mock REST API response.
-  when(() => apiClient.isAvailable).thenReturn(true);
+  when(() => apiClient.isAvailable).thenReturn(restAvailable);
   when(() => apiClient.getSocialCounts(_testPubkey)).thenAnswer(
     (_) async => SocialCounts(
       pubkey: _testPubkey,
@@ -74,6 +96,19 @@ FollowRepository _createRepository({
     funnelcakeApiClient: apiClient,
     profileStatsDao: dao,
     indexerRelayUrls: const [], // no real WebSocket connections
+    queryContactList:
+        ({
+          required eventStream,
+          required pubkey,
+          fallbackTimeoutSeconds = 10,
+        }) async {
+          await for (final event in eventStream) {
+            if (event.kind == EventKind.contactList && event.pubkey == pubkey) {
+              return event;
+            }
+          }
+          return null;
+        },
   );
 }
 
@@ -146,7 +181,7 @@ void main() {
       });
     });
 
-    group('getFollowerStats - hysteresis', () {
+    group('getFollowerStats - REST authoritative (#8197)', () {
       test('accepts higher count immediately', () async {
         final apiClient = _MockFunnelcakeApiClient();
         final dao = _MockProfileStatsDao();
@@ -165,11 +200,13 @@ void main() {
       });
 
       test(
-        'keeps persisted count when fresh is lower but within threshold',
+        'returns lower REST counts verbatim — no hysteresis on REST',
         () async {
           final apiClient = _MockFunnelcakeApiClient();
           final dao = _MockProfileStatsDao();
-          // Persisted: 100 followers. Fresh: 85 (15% drop, within 20% threshold).
+          // Persisted: 100 followers. Fresh REST: 85 — a drop that the old
+          // hysteresis would have suppressed as "relay variance". REST is
+          // deterministic, so the drop is real and must display.
           final repository = _createRepository(
             apiClient: apiClient,
             dao: dao,
@@ -180,125 +217,30 @@ void main() {
 
           final stats = await repository.getFollowerStats(_testPubkey);
 
-          // Hysteresis keeps the persisted count.
-          expect(stats.followers, equals(100));
-          expect(stats.following, equals(20));
+          expect(stats.followers, equals(85));
+          expect(stats.following, equals(18));
         },
       );
 
-      test('accepts lower count when drop exceeds threshold', () async {
+      test('does not query relays when REST answers', () async {
         final apiClient = _MockFunnelcakeApiClient();
         final dao = _MockProfileStatsDao();
-        // Persisted: 100 followers. Fresh: 70 (30% drop, exceeds 20% threshold).
         final repository = _createRepository(
           apiClient: apiClient,
           dao: dao,
-          restFollowers: 70,
-          restFollowing: 10,
-          persistedRow: _persistedRow(followers: 100, following: 20),
-        );
-
-        final stats = await repository.getFollowerStats(_testPubkey);
-
-        // Drop below threshold (80) → accept fresh count.
-        expect(stats.followers, equals(70));
-        expect(stats.following, equals(10));
-      });
-
-      test('accepts lower count when persisted data is stale', () async {
-        final apiClient = _MockFunnelcakeApiClient();
-        final dao = _MockProfileStatsDao();
-        // Persisted well beyond the staleness window.
-        final staleTimestamp = DateTime.now().subtract(
-          const Duration(hours: 30),
-        );
-        final repository = _createRepository(
-          apiClient: apiClient,
-          dao: dao,
-          restFollowers: 85,
-          restFollowing: 18,
-          persistedRow: _persistedRow(
-            followers: 100,
-            following: 20,
-            cachedAt: staleTimestamp,
-          ),
-        );
-
-        final stats = await repository.getFollowerStats(_testPubkey);
-
-        // Stale → accept fresh count even though it's within threshold.
-        expect(stats.followers, equals(85));
-        expect(stats.following, equals(18));
-      });
-
-      test('uses follower timestamp instead of unrelated cachedAt', () async {
-        final apiClient = _MockFunnelcakeApiClient();
-        final dao = _MockProfileStatsDao();
-        final staleCountsTimestamp = DateTime.now().subtract(
-          const Duration(hours: 30),
-        );
-        final repository = _createRepository(
-          apiClient: apiClient,
-          dao: dao,
-          restFollowers: 85,
-          restFollowing: 18,
-          persistedRow: _persistedRow(
-            followers: 100,
-            following: 20,
-            cachedAt: DateTime.now(),
-            followerCountsUpdatedAt: staleCountsTimestamp,
-          ),
-        );
-
-        final stats = await repository.getFollowerStats(_testPubkey);
-
-        expect(stats.followers, equals(85));
-        expect(stats.following, equals(18));
-      });
-
-      test('holds the count across an overnight gap (#6902)', () async {
-        final apiClient = _MockFunnelcakeApiClient();
-        final dao = _MockProfileStatsDao();
-        // The reported failure: last seen at 98 the night before, relays
-        // answer 86 in the morning. A window shorter than the gap would treat
-        // the baseline as stale and accept 86 outright.
-        final lastNight = DateTime.now().subtract(const Duration(hours: 10));
-        final repository = _createRepository(
-          apiClient: apiClient,
-          dao: dao,
-          restFollowers: 86,
+          restFollowers: 50,
           restFollowing: 20,
-          persistedRow: _persistedRow(
-            followers: 98,
-            following: 20,
-            cachedAt: lastNight,
-            followerCountsUpdatedAt: lastNight,
-          ),
+          contactListEvent: _contactListEvent(80),
         );
 
         final stats = await repository.getFollowerStats(_testPubkey);
 
-        expect(stats.followers, equals(98));
+        // REST wins verbatim; the kind-3 event (80 p-tags) is never fetched.
+        expect(stats.followers, equals(50));
+        expect(stats.following, equals(20));
       });
 
-      test('accepts one-person drops for small accounts', () async {
-        final apiClient = _MockFunnelcakeApiClient();
-        final dao = _MockProfileStatsDao();
-        final repository = _createRepository(
-          apiClient: apiClient,
-          dao: dao,
-          restFollowers: 8,
-          restFollowing: 4,
-          persistedRow: _persistedRow(followers: 9, following: 5),
-        );
-
-        final stats = await repository.getFollowerStats(_testPubkey);
-
-        expect(stats.followers, equals(8));
-        expect(stats.following, equals(4));
-      });
-
-      test('does not apply hysteresis when no persisted data exists', () async {
+      test('accepts counts when no persisted data exists', () async {
         final apiClient = _MockFunnelcakeApiClient();
         final dao = _MockProfileStatsDao();
         final repository = _createRepository(
@@ -314,47 +256,9 @@ void main() {
         expect(stats.following, equals(10));
       });
 
-      test('boundary: fresh count exactly at threshold is kept', () async {
+      test('persists fresh REST counts that differ from baseline', () async {
         final apiClient = _MockFunnelcakeApiClient();
         final dao = _MockProfileStatsDao();
-        // Persisted: 100. Threshold = ceil(100 * 0.8) = 80.
-        // Fresh: 80 → exactly at threshold → keep persisted.
-        final repository = _createRepository(
-          apiClient: apiClient,
-          dao: dao,
-          restFollowers: 80,
-          restFollowing: 20,
-          persistedRow: _persistedRow(followers: 100, following: 25),
-        );
-
-        final stats = await repository.getFollowerStats(_testPubkey);
-
-        expect(stats.followers, equals(100));
-        expect(stats.following, equals(25));
-      });
-
-      test('boundary: fresh count one below threshold is accepted', () async {
-        final apiClient = _MockFunnelcakeApiClient();
-        final dao = _MockProfileStatsDao();
-        // Persisted: 100. Threshold = ceil(100 * 0.8) = 80.
-        // Fresh: 79 → below threshold → accept fresh.
-        final repository = _createRepository(
-          apiClient: apiClient,
-          dao: dao,
-          restFollowers: 79,
-          restFollowing: 20,
-          persistedRow: _persistedRow(followers: 100, following: 25),
-        );
-
-        final stats = await repository.getFollowerStats(_testPubkey);
-
-        expect(stats.followers, equals(79));
-      });
-
-      test('does not re-persist when hysteresis keeps old value', () async {
-        final apiClient = _MockFunnelcakeApiClient();
-        final dao = _MockProfileStatsDao();
-        // Persisted: 100 followers, recent timestamp.
         final repository = _createRepository(
           apiClient: apiClient,
           dao: dao,
@@ -365,8 +269,28 @@ void main() {
 
         await repository.getFollowerStats(_testPubkey);
 
-        // Hysteresis kept 100/20 which matches persisted.
-        // upsertStats should NOT have been called since value didn't change.
+        verify(
+          () => dao.upsertStats(
+            pubkey: _testPubkey,
+            followerCount: 90,
+            followingCount: 20,
+          ),
+        ).called(1);
+      });
+
+      test('skips persisting when REST matches the baseline', () async {
+        final apiClient = _MockFunnelcakeApiClient();
+        final dao = _MockProfileStatsDao();
+        final repository = _createRepository(
+          apiClient: apiClient,
+          dao: dao,
+          restFollowers: 100,
+          restFollowing: 20,
+          persistedRow: _persistedRow(followers: 100, following: 20),
+        );
+
+        await repository.getFollowerStats(_testPubkey);
+
         verifyNever(
           () => dao.upsertStats(
             pubkey: any(named: 'pubkey'),
@@ -374,6 +298,75 @@ void main() {
             followingCount: any(named: 'followingCount'),
           ),
         );
+      });
+    });
+
+    group('getFollowerStats - relay-fallback hysteresis', () {
+      test(
+        'holds the following count across an overnight gap (#6902)',
+        () async {
+          final apiClient = _MockFunnelcakeApiClient();
+          final dao = _MockProfileStatsDao();
+          // REST is unavailable, so the relay fallback answers. Last seen at
+          // 98 the night before; the relay answers 86 in the morning — a
+          // partial view, within the hysteresis threshold, so the persisted
+          // baseline holds. The baseline's freshness must be judged by
+          // followerCountsUpdatedAt, not the unrelated (stale) cachedAt.
+          final lastNight = DateTime.now().subtract(const Duration(hours: 10));
+          final unrelated = DateTime.now().subtract(const Duration(hours: 30));
+          final repository = _createRepository(
+            apiClient: apiClient,
+            dao: dao,
+            restAvailable: false,
+            contactListEvent: _contactListEvent(86),
+            persistedRow: _persistedRow(
+              followers: 0,
+              following: 98,
+              cachedAt: unrelated,
+              followerCountsUpdatedAt: lastNight,
+            ),
+          );
+
+          final stats = await repository.getFollowerStats(_testPubkey);
+
+          expect(stats.following, equals(98));
+        },
+      );
+
+      test('boundary: relay count exactly at threshold is held', () async {
+        final apiClient = _MockFunnelcakeApiClient();
+        final dao = _MockProfileStatsDao();
+        // Persisted following: 100. Threshold = ceil(100 * 0.8) = 80.
+        // Relay answers exactly 80 → still treated as relay variance.
+        final repository = _createRepository(
+          apiClient: apiClient,
+          dao: dao,
+          restAvailable: false,
+          contactListEvent: _contactListEvent(80),
+          persistedRow: _persistedRow(followers: 0, following: 100),
+        );
+
+        final stats = await repository.getFollowerStats(_testPubkey);
+
+        expect(stats.following, equals(100));
+      });
+
+      test('boundary: relay count one below threshold is accepted', () async {
+        final apiClient = _MockFunnelcakeApiClient();
+        final dao = _MockProfileStatsDao();
+        // Persisted following: 100. Threshold = ceil(100 * 0.8) = 80.
+        // Relay answers 79 → genuine drop, accept it.
+        final repository = _createRepository(
+          apiClient: apiClient,
+          dao: dao,
+          restAvailable: false,
+          contactListEvent: _contactListEvent(79),
+          persistedRow: _persistedRow(followers: 0, following: 100),
+        );
+
+        final stats = await repository.getFollowerStats(_testPubkey);
+
+        expect(stats.following, equals(79));
       });
     });
 

--- a/mobile/test/repositories/follow_repository_follower_stats_test.dart
+++ b/mobile/test/repositories/follow_repository_follower_stats_test.dart
@@ -88,7 +88,6 @@ FollowRepository _createRepository({
       pubkey: any(named: 'pubkey'),
       followerCount: any(named: 'followerCount'),
       followingCount: any(named: 'followingCount'),
-      stampCountFreshness: any(named: 'stampCountFreshness'),
     ),
   ).thenAnswer((_) async {});
 
@@ -155,7 +154,6 @@ void main() {
             pubkey: _testPubkey,
             followerCount: 50,
             followingCount: 20,
-            stampCountFreshness: false,
           ),
         ).called(1);
       });
@@ -276,7 +274,6 @@ void main() {
             pubkey: _testPubkey,
             followerCount: 90,
             followingCount: 20,
-            stampCountFreshness: false,
           ),
         ).called(1);
       });
@@ -299,7 +296,6 @@ void main() {
             pubkey: any(named: 'pubkey'),
             followerCount: any(named: 'followerCount'),
             followingCount: any(named: 'followingCount'),
-            stampCountFreshness: any(named: 'stampCountFreshness'),
           ),
         );
       });
@@ -346,7 +342,6 @@ void main() {
             pubkey: any(named: 'pubkey'),
             followerCount: 0,
             followingCount: 0,
-            stampCountFreshness: false,
           ),
         );
       });


### PR DESCRIPTION

## Description

Follower and following counts on the profile were unstable — one account showed **710**, then **592** after a logout/login with nothing changed — and they arrived late, after a visible swap from a different number.

Three defects, all on `main`:

**1. The count was merged from REST *and* relays with `max()`.** `_fetchFollowerStats` ran the Funnelcake REST query and N indexer-relay queries in parallel and took the highest observation. Whichever relay answered biggest within its timeout won, so the number moved between loads. Two further floors re-introduced the same inflation after the merge: `max(followers.pubkeys.length, countFromService)` in the snapshot builders, and `max(visibleRows, authoritative)` in the UI.

**2. The profile header never read the REST count at all.** `ProfileRepository` cached `videoCount`, `totalLikes` and `totalViews` from the REST payload but discarded `social.follower_count` / `social.following_count`, so the header's initial value came from whatever had been persisted in an *earlier session*. It was then replaced by a value from the follower-**list** BLoC, which waits on the full relay merge (12 s in captured logs) and subtracted `rawPubkeyCount - visiblePubkeyCount` — making the final number depend on how many rows the relays happened to return.

**3. Counts were stabilised instead of corrected.** Hysteresis, a 24-hour staleness window and persisted floors existed to suppress the symptoms of a non-deterministic source. They are now scoped to the relay-fallback path only, where per-query coverage genuinely varies.

### The fix

Query Funnelcake first and use each positive social-count field as authoritative; relay/indexer queries run only for a field REST cannot answer. Restore `ProfileRepository` caching the REST social counts so the header renders an authoritative value immediately. The displayed follower count has no list-length floor, but it continues to subtract known followers blocked by the profile owner so the header and visible list share the same safety-aware meaning.

**Ambiguous zero fields.** `/api/users/{pubkey}/social` answers 200 for every pubkey — there is no 404 for an account Funnelcake has never ingested — and `get_social_stats` can collapse a ClickHouse failure into zeros. Never indexed, genuinely zero, vanished, and unavailable data can therefore look identical. Each field is evaluated independently: a positive REST value is authoritative, while a zero field falls through to relays and the persisted baseline. Mixed responses such as `{followers: 0, following: 612}` preserve the valid REST field while resolving only the ambiguous field.

**Genuine-zero accounts.** The API cannot distinguish them client-side, so an account that really has no followers takes the same path: REST 0 → relays → nothing found → 0 displayed. Correct result, one relay round-trip slower than a non-zero account.

**Ownership of the shared columns.** `follower_count` / `following_count` in `profile_stats` have two trusted writers. Any count write stamps `followerCountsUpdatedAt`, so the column consistently answers when the persisted count was last updated. REST writes can populate one known field without treating an ambiguous zero in the other field as authoritative; relay fallback and the persisted baseline resolve that field independently.

**Signed-in-user persistence (reverses part of #8077).** The `pubkey != _nostrClient.publicKey` guard is removed from the persist path, so the signed-in user's counts persist like any other profile's. (`main` had one persist site; the authoritative and relay-fallback paths are now separate, and neither carries the guard.) #8077 added it because *"raw repository counts could overwrite the blocklist-aware value owned by the followers BLoC"*, leaving persistence for the signed-in account *"exclusively with the BLoC"*. That premise no longer holds, in three ways:

- **There is no blocklist-aware persisted value left to overwrite.** The persisted column is by definition the raw authoritative count; the blocklist subtraction is a render-time function (`visibleFollowerCount`) applied over `authoritativeFollowerCount` in the state getter, and its result is never written back. The raw count is that subtraction's *input* — persisting the already-subtracted value is what would actually corrupt the column, by subtracting a second time on the next cold start.
- **No BLoC ever held that ownership.** `upsertStats` is the only writer of these columns, and at #8077's merge its call sites were `FollowRepository`, `ProfileRepository` and the classic-Viner seed preload — no BLoC among them. The guard therefore did not transfer ownership; it left the signed-in user's counts with no refreshing writer at all. `ProfileRepository` was not writing counts at that point (#6911 had removed it), and publishing a video calls `deleteStats(currentPubkey)`, which drops the whole row — so posting a video cleared your own persisted baseline with nothing able to restore it.
- **Keeping it would reproduce #8197 on your own profile.** Yours would be the only profile whose persisted counts the REST fast path never refreshes — precisely the "count from an earlier session" staleness this issue reports, on the profile you open most. And because `ProfileRepository` now writes REST social counts for every pubkey with no such guard, keeping it in `FollowRepository` alone would leave the two writers disagreeing about whether your own row may be updated.

Pinned by `persists authoritative stats for the signed-in user`, which replaces #8077's `does not persist raw stats for the signed-in user`. Flagged by @realmeylisdev in review.

This restores the model from #2571 / #2657, which #2776 replaced three days after it merged (its own commit message notes the divergence: *"web uses only the Funnelcake REST API count while mobile supplements with indexer relays"*), and which #6911 further reversed by removing the fast path and routing the header through the list BLoC.

**Related Issue:** Closes #8197

## Investigation tasks from #8197

**Review the prior profile-screen PRs for the earlier count fix.** #2571 (New Profile screen) and #2657 (`populate ProfileStats from REST API response`, merged 2026-04-03) established one deterministic source: the Funnelcake `/api/users/{pubkey}` response, cached in Drift and streamed to the header. That model is what this PR restores.

**Current relay sources, hydration and caching.** The count came from `_fetchFollowerStats`, which ran in parallel: the Funnelcake REST `social` counts, the connected relays (kind-3 with `#p`), and three configured indexers — `purplepag.es`, `user.kindpag.es`, `relay.nos.social` — then took `max()` across every observation. The list additionally uses `/api/users/{pubkey}/followers`, which the server clamps to **100 rows regardless of the `limit: 5000` we send**. Four caches sit on top: an in-memory stats cache (30 s), the `CacheSync` profile-list entries (30 s TTL, added by #8077), the Drift `profile_stats` row, and a persisted baseline guarded by hysteresis (24-hour staleness window, 0.8 drop threshold). Regressions since #2657: **#2776** replaced the single source with the `max()` merge three days after it merged; **#2985** carried that into the extracted package; **#6911** removed `ProfileRepository`'s REST social-count caching and routed the header through the follower-list BLoC; **#6911/#8077/#8107** then layered hysteresis, TTLs and floors to suppress the resulting movement.

**Why counts change materially.** Three distinct mechanisms, all removed here: (a) *relay response differences* — `max()` means whichever indexer answered biggest within its timeout set the number, so a slow or absent relay changed it; (b) *logout/login* — the account-scoped `CacheSync` entries are cleared at sign-out and the in-memory stats cache does not survive the account switch, so the next load refetches and a different relay subset answers; (c) *refresh* — the same, once the 30 s TTL expires. Hysteresis masked small drops for 24 h, which made the movement intermittent rather than fixing it.

**Mobile vs web.** ✅ Verified, not inferred. divine-web renders **146 followers / 612 following** for the audited account — identical to what this branch displays, and to the REST values in our logs (`Follower counts from REST (authoritative): 146 followers, 612 following`). Current `main` displays **170** for the same account at the same moment, so the surfaces disagree by 24 today and agree exactly with this change. (Web screenshot not attached: the capture includes signed-in account chrome that does not belong on a public PR. The numbers are reproducible at `divine.video/u/cptnbackfire`.)

**Should Funnelcake be the single source of truth for displayed counts?** Yes, for the *count*. It is the only source that is deterministic, complete in one request, and shared with web; relay observations cannot distinguish a stale over-count from broader coverage, which is what made the number move. The *list* keeps its multi-source union, because there a superfluous row is visible and self-correcting, whereas an aggregate is not.

**Implications for Nostr-native users.** They are undercounted, and now measurably so: for the audited account, 15 of 160 verified current followers (~9%) exist only on relays Divine has not ingested, so we display 145. Previously the union sometimes surfaced them — but inconsistently, and mixed with 9 accounts that had already unfollowed. The honest framing is that Divine shows *Divine's view* of the social graph, consistently, rather than an unstable approximation of the global one. Closing the gap is server-side work, filed under Out of Scope.

**Loading and performance.** The count no longer waits on any relay: it renders from the REST payload as soon as the profile loads, and the indexer queries are off the critical path entirely, removing up to 8 s of timeout per profile open on healthy networks — and an unbounded wait on networks where those indexers are unreachable. The follower/following **lists** are unchanged: they still merge all sources and still take a few seconds (~12 s observed when indexers time out), which is acceptable because the header no longer blocks on them.

### Measured accuracy

A relay census for one reported account (query every kind-3 naming the target, then re-check each author's *newest* contact list to drop stale unfollows):

| Source | Followers | What it measures |
|---|---|---|
| Verified current | **160** | authors whose newest kind-3 still follows |
| Naive relay union | 169 | anyone who ever followed, including proven unfollows |
| `main` (relay-merged) | 168 | the naive union, one relay-timing wobble away |
| **Funnelcake / this PR** | **145** | Divine's indexed subset |

The arithmetic closes: `169 = 160 + 9 stale unfollows`, and `160 = 145 indexed + 15 relay-only`. So `main`'s number is wrong in two directions at once — it counts 9 accounts that have since unfollowed, and it moves with relay availability. Funnelcake's 145 is stable and matches divine-web, at the cost of ~9% undercount for accounts with followers on relays Divine has not ingested.

### Relationship to #8234

Complementary, not overlapping. #8234 fixed stats rendering **blank**; this fixes them rendering **wrong**. Our own narrower workaround for that hang was dropped on rebase in favour of #8234's SDK-level fix, which is better.

### Before / after

The same profile (`@cptnbackfire`) across all three surfaces at the same moment. The two mobile captures are one minute apart with **identical relay conditions** — both builds logged `API=100, relays=146, indexers=147, merged=170`:

| `main` (mobile) | This PR (mobile) | divine-web |
|---|---|---|
| <img width="250" alt="main displays 170 followers" src="https://github.com/user-attachments/assets/91d66c0e-23e1-489e-93ee-e1ae06e203d7" /> | <img width="250" alt="this PR displays 146 followers" src="https://github.com/user-attachments/assets/47bd7e3b-19a1-4b8b-ae3c-76e4e3587014" /> | <img width="250" alt="image-1787924812364" src="https://github.com/user-attachments/assets/8ed855a2-40d5-4802-a265-c34a9e0c459a" /> |
| Followers: **170** ❌ | Followers: **146** ✅ | Followers: **146** ✅ |

Funnelcake reported **146**, and divine-web renders **146 / 612** — but `main` displayed **170**: `_selectFollowerCount` took `max(REST=146, kindpag=1, nos.social=147) = 147`, then the snapshot floor raised it again to the merged list length of 170. This branch displays REST's 146 verbatim, so mobile and web agree by construction.

Both mobile captures are from current `main` (i.e. with #8234 merged), so this is a like-for-like comparison of the *number*, not of the blank-stats hang #8234 already fixed.

## Out of Scope

- **`following_count: 0` for accounts Funnelcake has not ingested.** Verified as *not* a regression — `origin/main` and this branch render the same 0 on device, because production only queries `relay.divine.video` for contact lists and that relay has no kind 3 for those accounts, so `max(REST, relay)` lands on 0 too. Worth stating plainly all the same: for followers the cost of the REST-only count is a ~9% undercount, but for **following** it is the entire number for that class of account, with no relay fallback left to recover it. Sampled on prod: `fiatjaf` and `jack` report a follower count with `following: 0`, while `gigi` reports both. #8197 asks specifically for the implications for Nostr-native users, and this is the sharpest one.

- **Canonical block-aware and field-authoritative calculation.** Tracked in divinevideo/divine-funnelcake#1166 and assigned to @dcadenas. This will make the server exclude followers blocked by the profile owner, represent field-level availability, and let mobile eventually remove its local subtraction without changing visible behavior.
- **Funnelcake kind-3 ingest coverage.** 15 of that account's 160 verified followers are invisible to Divine. Widening ingest — and currency-checking superseded contact lists server-side — is the durable path to a count that is both stable *and* complete. Belongs in `divine-funnelcake`.
- **The indexer relay list.** Three configured indexers (`purplepag.es`, `user.kindpag.es`, `relay.nos.social`) were unreachable throughout this work. Whether they are globally dead or network-specific is worth checking separately; a dead default costs every user a timeout.

## Trade-offs

These are deliberate consequences of using deterministic aggregate data while preserving Divine block semantics:

1. **The count can differ from the number of visible rows**, in either direction. The list is a union across sources (generous, and inspectable); the count is Divine's index (deterministic). Flooring the count to the list length is exactly the inflation this PR removes.
2. **Accounts blocked by the profile owner are excluded from that profile displayed follower count.** The client subtracts blocked followers it knows about so blocking has the user-visible meaning people expect and the header agrees with the visible list. The durable fix is to apply the same policy in the canonical server calculation; until then, clients can disagree when their local block-aware knowledge differs.

## Product explanation follow-ups

- Creator Analytics explainer: #8276, assigned to @mbradley
- Public website FAQ: divinevideo/divine-web#690, assigned to @mbradley
- Canonical server calculation: divinevideo/divine-funnelcake#1166, assigned to @dcadenas

The shared copy defines that Divine excludes accounts blocked by the profile owner, explains indexing differences across Nostr apps, and states the limits of blocking public Nostr content.

## Verification

- `flutter test` in `mobile/packages/follow_repository` — **314 passed, 100% line coverage** (the package gates at 100%)
- `flutter test` in `mobile/packages/profile_repository` — 451 passed
- `flutter test test/blocs test/repositories test/widgets/profile` — 4,018 passed
- `flutter analyze lib test packages/follow_repository packages/profile_repository` — no issues
- Takeover regression pass: 568 changed-file tests passed; full `flutter analyze` passed; generated outputs unchanged
- Manual: two simulators side by side, own profile and another user's, on `main` vs this branch

Tests that pinned the old behaviour were re-pinned to the new contract rather than deleted — including a fallback-path hang test, because #8234's own hang tests stop reaching the indexer path once REST short-circuits it.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore





