### PR TITLE
fix(blocklist): never publish a mute list we could not read

### DIFF
--- a/mobile/lib/providers/moderation_providers.dart
+++ b/mobile/lib/providers/moderation_providers.dart
@@ -5,6 +5,7 @@ import 'dart:async';
 import 'package:content_blocklist_repository/content_blocklist_repository.dart';
 import 'package:content_policy/content_policy.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:openvine/providers/app_foreground_provider.dart';
 import 'package:openvine/providers/auth_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/providers/preferences_providers.dart';
@@ -286,6 +287,14 @@ class BlocklistVersion extends _$BlocklistVersion {
 ///
 /// Both sync methods have internal guards (`_mutualMuteSyncStarted`,
 /// `_blockListSyncStarted`) so duplicate calls are no-ops.
+///
+/// It also flushes a mute-list publish that was withheld because the read
+/// preceding it was inconclusive (#6750). A block is kept local rather than
+/// published over a list we could not read, so something has to retry it: a
+/// later block republishes the whole list anyway, and this covers the user who
+/// blocked once while relays were unhealthy and has not blocked since. Both
+/// signals it listens to are "we might be healthy again" — a session becoming
+/// ready, and the app returning to the foreground.
 @Riverpod(keepAlive: true)
 void blocklistSyncBridge(Ref ref) {
   final authService = ref.watch(authServiceProvider);
@@ -329,6 +338,12 @@ void blocklistSyncBridge(Ref ref) {
 
   ref.listen<NostrSessionReadiness>(nostrSessionProvider, (_, next) {
     unawaited(startSync(next));
+  });
+
+  ref.listen<bool>(appForegroundProvider, (previous, next) {
+    if (next && previous != true) {
+      unawaited(blocklistRepository.retryPendingMuteListPublish());
+    }
   });
 }
 

--- a/mobile/lib/providers/moderation_providers.dart
+++ b/mobile/lib/providers/moderation_providers.dart
@@ -292,9 +292,10 @@ class BlocklistVersion extends _$BlocklistVersion {
 /// preceding it was inconclusive (#6750). A block is kept local rather than
 /// published over a list we could not read, so something has to retry it: a
 /// later block republishes the whole list anyway, and this covers the user who
-/// blocked once while relays were unhealthy and has not blocked since. Both
-/// signals it listens to are "we might be healthy again" — a session becoming
-/// ready, and the app returning to the foreground.
+/// blocked once while relays were unhealthy and has not blocked since. The
+/// signal is the app returning to the foreground — "we might be healthy
+/// again". A restart is covered inside the repository instead, which
+/// reconciles its persisted blocks against the list the relay serves back.
 @Riverpod(keepAlive: true)
 void blocklistSyncBridge(Ref ref) {
   final authService = ref.watch(authServiceProvider);

--- a/mobile/lib/providers/moderation_providers.g.dart
+++ b/mobile/lib/providers/moderation_providers.g.dart
@@ -569,9 +569,10 @@ abstract class _$BlocklistVersion extends $Notifier<int> {
 /// preceding it was inconclusive (#6750). A block is kept local rather than
 /// published over a list we could not read, so something has to retry it: a
 /// later block republishes the whole list anyway, and this covers the user who
-/// blocked once while relays were unhealthy and has not blocked since. Both
-/// signals it listens to are "we might be healthy again" — a session becoming
-/// ready, and the app returning to the foreground.
+/// blocked once while relays were unhealthy and has not blocked since. The
+/// signal is the app returning to the foreground — "we might be healthy
+/// again". A restart is covered inside the repository instead, which
+/// reconciles its persisted blocks against the list the relay serves back.
 
 @ProviderFor(blocklistSyncBridge)
 final blocklistSyncBridgeProvider = BlocklistSyncBridgeProvider._();
@@ -591,9 +592,10 @@ final blocklistSyncBridgeProvider = BlocklistSyncBridgeProvider._();
 /// preceding it was inconclusive (#6750). A block is kept local rather than
 /// published over a list we could not read, so something has to retry it: a
 /// later block republishes the whole list anyway, and this covers the user who
-/// blocked once while relays were unhealthy and has not blocked since. Both
-/// signals it listens to are "we might be healthy again" — a session becoming
-/// ready, and the app returning to the foreground.
+/// blocked once while relays were unhealthy and has not blocked since. The
+/// signal is the app returning to the foreground — "we might be healthy
+/// again". A restart is covered inside the repository instead, which
+/// reconciles its persisted blocks against the list the relay serves back.
 
 final class BlocklistSyncBridgeProvider
     extends $FunctionalProvider<void, void, void>
@@ -613,9 +615,10 @@ final class BlocklistSyncBridgeProvider
   /// preceding it was inconclusive (#6750). A block is kept local rather than
   /// published over a list we could not read, so something has to retry it: a
   /// later block republishes the whole list anyway, and this covers the user who
-  /// blocked once while relays were unhealthy and has not blocked since. Both
-  /// signals it listens to are "we might be healthy again" — a session becoming
-  /// ready, and the app returning to the foreground.
+  /// blocked once while relays were unhealthy and has not blocked since. The
+  /// signal is the app returning to the foreground — "we might be healthy
+  /// again". A restart is covered inside the repository instead, which
+  /// reconciles its persisted blocks against the list the relay serves back.
   BlocklistSyncBridgeProvider._()
     : super(
         from: null,

--- a/mobile/lib/providers/moderation_providers.g.dart
+++ b/mobile/lib/providers/moderation_providers.g.dart
@@ -564,6 +564,14 @@ abstract class _$BlocklistVersion extends $Notifier<int> {
 ///
 /// Both sync methods have internal guards (`_mutualMuteSyncStarted`,
 /// `_blockListSyncStarted`) so duplicate calls are no-ops.
+///
+/// It also flushes a mute-list publish that was withheld because the read
+/// preceding it was inconclusive (#6750). A block is kept local rather than
+/// published over a list we could not read, so something has to retry it: a
+/// later block republishes the whole list anyway, and this covers the user who
+/// blocked once while relays were unhealthy and has not blocked since. Both
+/// signals it listens to are "we might be healthy again" — a session becoming
+/// ready, and the app returning to the foreground.
 
 @ProviderFor(blocklistSyncBridge)
 final blocklistSyncBridgeProvider = BlocklistSyncBridgeProvider._();
@@ -578,6 +586,14 @@ final blocklistSyncBridgeProvider = BlocklistSyncBridgeProvider._();
 ///
 /// Both sync methods have internal guards (`_mutualMuteSyncStarted`,
 /// `_blockListSyncStarted`) so duplicate calls are no-ops.
+///
+/// It also flushes a mute-list publish that was withheld because the read
+/// preceding it was inconclusive (#6750). A block is kept local rather than
+/// published over a list we could not read, so something has to retry it: a
+/// later block republishes the whole list anyway, and this covers the user who
+/// blocked once while relays were unhealthy and has not blocked since. Both
+/// signals it listens to are "we might be healthy again" — a session becoming
+/// ready, and the app returning to the foreground.
 
 final class BlocklistSyncBridgeProvider
     extends $FunctionalProvider<void, void, void>
@@ -592,6 +608,14 @@ final class BlocklistSyncBridgeProvider
   ///
   /// Both sync methods have internal guards (`_mutualMuteSyncStarted`,
   /// `_blockListSyncStarted`) so duplicate calls are no-ops.
+  ///
+  /// It also flushes a mute-list publish that was withheld because the read
+  /// preceding it was inconclusive (#6750). A block is kept local rather than
+  /// published over a list we could not read, so something has to retry it: a
+  /// later block republishes the whole list anyway, and this covers the user who
+  /// blocked once while relays were unhealthy and has not blocked since. Both
+  /// signals it listens to are "we might be healthy again" — a session becoming
+  /// ready, and the app returning to the foreground.
   BlocklistSyncBridgeProvider._()
     : super(
         from: null,
@@ -626,7 +650,7 @@ final class BlocklistSyncBridgeProvider
 }
 
 String _$blocklistSyncBridgeHash() =>
-    r'0ffe1bb65877c094a330ec773089bb738247fe98';
+    r'8dab15bbb574ddc0ed97e28a4898b37d7149719f';
 
 /// Republishes the contact list when a block contradicts the published
 /// follow list.

--- a/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
+++ b/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
@@ -748,6 +748,14 @@ class ContentBlocklistRepository {
     final source = _latestOwnMuteListEvent;
     final tags = <List<String>>[];
     final includedPubkeys = <String>{};
+    // A NIP-51 `p` tag can carry a third element -- a relay hint -- that is
+    // ours to preserve, not to invent. Keyed by pubkey so an entry we re-emit
+    // below keeps whatever the source published. Without this, a pubkey that
+    // is both muted on the relay and blocked in-app loses its hint on every
+    // republish: `_applyOwnMuteListEvent` keeps our own blocks out of
+    // `_mutedPubkeys`, so the preservation loop skips it and the
+    // `_runtimeBlocklist` loop rewrites it as a bare ['p', pubkey].
+    final sourcePubkeyTags = <String, List<String>>{};
 
     if (source != null) {
       for (final tag in source.tags) {
@@ -758,23 +766,21 @@ class ContentBlocklistRepository {
 
         if (tag.length < 2) continue;
         final pubkey = tag[1];
+        sourcePubkeyTags.putIfAbsent(pubkey, () => List<String>.of(tag));
         if (_mutedPubkeys.contains(pubkey) && includedPubkeys.add(pubkey)) {
           tags.add(List<String>.of(tag));
         }
       }
     }
 
-    for (final pubkey in _mutedPubkeys) {
-      if (includedPubkeys.add(pubkey)) {
-        tags.add(['p', pubkey]);
-      }
+    void addPubkey(String pubkey) {
+      if (!includedPubkeys.add(pubkey)) return;
+      final sourceTag = sourcePubkeyTags[pubkey];
+      tags.add(sourceTag == null ? ['p', pubkey] : List<String>.of(sourceTag));
     }
 
-    for (final pubkey in _runtimeBlocklist) {
-      if (includedPubkeys.add(pubkey)) {
-        tags.add(['p', pubkey]);
-      }
-    }
+    _mutedPubkeys.forEach(addPubkey);
+    _runtimeBlocklist.forEach(addPubkey);
 
     return _MuteListPublishShape(tags: tags, content: source?.content ?? '');
   }

--- a/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
+++ b/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
@@ -1638,13 +1638,14 @@ class ContentBlocklistRepository {
   /// Our own pubkey is excluded so a malformed self-referential mute list
   /// can never filter the user's own content (#2192).
   void _handleOwnMuteListEvent(Event event) {
-    _applyOwnMuteListEvent(event);
+    _applyOwnMuteListEvent(event, reconcile: true);
   }
 
   void _applyOwnMuteListEvent(
     Event event, {
     bool notify = true,
     bool persist = true,
+    bool reconcile = false,
   }) {
     final ourPubkey = event.pubkey;
     final createdAt = event.createdAt;
@@ -1672,6 +1673,24 @@ class ContentBlocklistRepository {
         relayMuted.add(tag[1]);
       }
     }
+    // The relay's newest list is authoritative for what it holds, so blocks
+    // we still hold locally that are absent from it are a publish that never
+    // landed -- withheld by an inconclusive read (#6750), or lost with
+    // `_muteListPublishPending` when the app was killed. Derive that from the
+    // two sets that DO survive a restart rather than persisting a flag; it is
+    // a no-op in steady state, because our own publishes put every block on
+    // the list we read back. Only the subscription reconciles: a read taken
+    // inside `_publishMuteListToNostr` is about to republish anyway.
+    if (reconcile && _runtimeBlocklist.difference(relayMuted).isNotEmpty) {
+      Log.info(
+        'Own mute list is missing blocks we hold locally; republishing',
+        name: 'ContentBlocklistRepository',
+        category: LogCategory.system,
+      );
+      _muteListPublishPending = true;
+      unawaited(retryPendingMuteListPublish());
+    }
+
     // Entries we blocked in-app are republished onto this same list; keep
     // them out of the mute set so they stay tracked as blocks only.
     relayMuted.removeAll(_runtimeBlocklist);

--- a/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
+++ b/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
@@ -123,6 +123,11 @@ class ContentBlocklistRepository {
   // preserves other clients' public t/word/e mutes and encrypted content.
   Event? _latestOwnMuteListEvent;
 
+  // A mute-list publish that was withheld because the read that precedes it
+  // came back inconclusive. Flushed by [retryPendingMuteListPublish] and by
+  // the next block or unblock, which republishes the whole list anyway.
+  bool _muteListPublishPending = false;
+
   // Latest replaceable kind-10000 mute-list event timestamp per author.
   // Prevent stale relay delivery order from resurrecting old mute state.
   final Map<String, int> _latestMuteListEventCreatedAtByAuthor =
@@ -283,6 +288,7 @@ class ContentBlocklistRepository {
       _mutualMuteBlocklist.clear();
       _blockedByOthers.clear();
       _latestOwnMuteListEvent = null;
+      _muteListPublishPending = false;
       _latestMuteListEventCreatedAtByAuthor.clear();
       _latestBlockListEventCreatedAtByAuthor.clear();
       _severedFollowers.clear();
@@ -628,7 +634,21 @@ class ContentBlocklistRepository {
     }
 
     try {
-      await _refreshLatestOwnMuteList(nostrClient);
+      if (!await _refreshLatestOwnMuteList(nostrClient)) {
+        // Kind 10000 is replaceable: publishing now would replace a list we
+        // could not read. Everything only the unread event holds would go
+        // with it -- the encrypted private section, every t/word/e mute, and
+        // any p mute authored on another client (#6750). The block is already
+        // persisted locally, so withholding costs propagation, not safety.
+        _muteListPublishPending = true;
+        Log.warning(
+          'Withholding mute list publish - could not confirm the current '
+          'kind 10000. Blocks stay local until a read succeeds.',
+          name: 'ContentBlocklistRepository',
+          category: LogCategory.system,
+        );
+        return false;
+      }
       final publishShape = _buildMuteListPublishShape();
 
       final event = await signer.createAndSignEvent(
@@ -646,6 +666,7 @@ class ContentBlocklistRepository {
         // echo of an older own mute list cannot race back and drop the
         // mutes we just merged in.
         _applyOwnMuteListEvent(sentEvent.event);
+        _muteListPublishPending = false;
         Log.info(
           'Published mute list to Nostr with '
           '${_runtimeBlocklist.length + _mutedPubkeys.length} pubkey entries',
@@ -671,16 +692,33 @@ class ContentBlocklistRepository {
     }
   }
 
-  Future<void> _refreshLatestOwnMuteList(NostrClient nostrClient) async {
+  /// Re-read our own latest kind 10000, and report whether the answer was
+  /// conclusive.
+  ///
+  /// Returns `false` when no relay settled the query -- a timeout, or a
+  /// fan-out no relay took. That is not the same as "this account has no mute
+  /// list", and the difference is load-bearing: kind 10000 is replaceable, so
+  /// a caller that publishes on an unread answer deletes whatever only the
+  /// unread event held. A *settled* answer of zero events is conclusive and
+  /// returns `true`, so a first-ever block still publishes.
+  ///
+  /// [NostrClient.queryEvents] cannot express this -- it drops `timedOut` and
+  /// `noRelays` -- which is why the detailed form is used here, with
+  /// `requireAllRelaysSettled` so a relay abandoned by the settle window
+  /// arrives as a timeout rather than as an empty answer.
+  Future<bool> _refreshLatestOwnMuteList(NostrClient nostrClient) async {
     final ourPubkey = _ourPubkey;
-    if (ourPubkey == null) return;
+    if (ourPubkey == null) return false;
 
-    final muteEvents = await nostrClient.queryEvents([
-      Filter(authors: [ourPubkey], kinds: const [10000]),
-    ]);
+    final result = await nostrClient.queryEventsDetailed(
+      [
+        Filter(authors: [ourPubkey], kinds: const [10000]),
+      ],
+      requireAllRelaysSettled: true,
+    );
 
     var newest = _latestOwnMuteListEvent;
-    for (final event in muteEvents) {
+    for (final event in result.events) {
       if (event.pubkey != ourPubkey) continue;
       if (newest == null || event.createdAt > newest.createdAt) {
         newest = event;
@@ -690,6 +728,20 @@ class ContentBlocklistRepository {
     if (newest != null && newest != _latestOwnMuteListEvent) {
       _applyOwnMuteListEvent(newest);
     }
+
+    return !result.timedOut && !result.noRelays;
+  }
+
+  /// Republish a mute list whose publish was withheld by an inconclusive read.
+  ///
+  /// A no-op unless something is pending, so callers can fire it on any
+  /// "we might be healthy again" signal. Returns whether a publish reached a
+  /// relay. Blocks and unblocks republish the whole list themselves, so this
+  /// only matters for a user who blocked once while relays were unhealthy and
+  /// has not blocked since.
+  Future<bool> retryPendingMuteListPublish() async {
+    if (!_muteListPublishPending) return false;
+    return _publishMuteListToNostr();
   }
 
   _MuteListPublishShape _buildMuteListPublishShape() {
@@ -1399,12 +1451,28 @@ class ContentBlocklistRepository {
       if (!_isStillActiveAccount(ourPubkey)) return;
 
       // 2. Read the existing kind 10000 mute list (newest replaceable wins)
-      //    so the merge never drops mutes authored on other clients.
-      final muteEvents = await nostrClient.queryEvents([
-        Filter(authors: [ourPubkey], kinds: const [10000]),
-      ]);
+      //    so the merge never drops mutes authored on other clients. An
+      //    inconclusive read aborts the migration rather than merging into a
+      //    list we could not see -- step 4 republishes the whole event, and
+      //    the completion flag below stays unset so the next launch retries
+      //    (#6750).
+      final muteRead = await nostrClient.queryEventsDetailed(
+        [
+          Filter(authors: [ourPubkey], kinds: const [10000]),
+        ],
+        requireAllRelaysSettled: true,
+      );
+      if (muteRead.timedOut || muteRead.noRelays) {
+        Log.warning(
+          'Deferring legacy block-list migration - could not confirm the '
+          'current kind 10000 mute list; retrying next launch',
+          name: 'ContentBlocklistRepository',
+          category: LogCategory.system,
+        );
+        return;
+      }
       Event? newestMuteList;
-      for (final event in muteEvents) {
+      for (final event in muteRead.events) {
         if (event.pubkey != ourPubkey) continue;
         if (newestMuteList == null ||
             event.createdAt > newestMuteList.createdAt) {

--- a/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
+++ b/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
@@ -11,7 +11,28 @@ import 'package:nostr_sdk/event.dart';
 import 'package:nostr_sdk/filter.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-class _MockNostrClient extends Mock implements NostrClient {}
+class _MockNostrClient extends Mock implements NostrClient {
+  _MockNostrClient() {
+    // The own-mute-list read goes through `queryEventsDetailed` so it can tell
+    // a relay's "I hold nothing" apart from an answer nobody gave (#6750).
+    // Every test that stubs `queryEvents` is describing the former, so mirror
+    // it here as a settled answer. Tests about the inconclusive read override
+    // this stub with `timedOut` or `noRelays`.
+    when(
+      () => queryEventsDetailed(
+        any(),
+        requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+      ),
+    ).thenAnswer((invocation) async {
+      final filters = invocation.positionalArguments[0] as List<Filter>;
+      return (
+        events: await queryEvents(filters),
+        timedOut: false,
+        noRelays: false,
+      );
+    });
+  }
+}
 
 class _MockBlockListSigner extends Mock implements BlockListSigner {}
 
@@ -2944,6 +2965,237 @@ void main() {
 
       expect(service.isBlocked('pubkey1'), isTrue);
     });
+
+    group('inconclusive own-mute-list read (#6750)', () {
+      const blockedPubkey =
+          '00000000000000000000000000000000000000000000000000000000000000dd';
+
+      void stubMuteRead({
+        List<Event> events = const <Event>[],
+        bool timedOut = false,
+        bool noRelays = false,
+      }) {
+        when(
+          () => mockClient.queryEventsDetailed(
+            any(),
+            requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+          ),
+        ).thenAnswer(
+          (_) async => (
+            events: events,
+            timedOut: timedOut,
+            noRelays: noRelays,
+          ),
+        );
+      }
+
+      void stubSigningAndPublishing() {
+        when(() => mockSigner.isAuthenticated).thenReturn(true);
+        when(
+          () => mockSigner.createAndSignEvent(
+            kind: any(named: 'kind'),
+            content: any(named: 'content'),
+            tags: any(named: 'tags'),
+          ),
+        ).thenAnswer(
+          (invocation) async => signedEventFromInvocation(invocation),
+        );
+        when(() => mockClient.publishEvent(any())).thenAnswer(
+          (invocation) async => PublishSuccess(
+            event: invocation.positionalArguments.first as Event,
+          ),
+        );
+      }
+
+      Future<ContentBlocklistRepository> startedService([
+        SharedPreferences? prefs,
+      ]) async {
+        final service = ContentBlocklistRepository(prefs: prefs);
+        await service.syncBlockListsInBackground(
+          mockClient,
+          mockSigner,
+          ourPubkey,
+        );
+        return service;
+      }
+
+      test('blocking does not publish when the read timed out', () async {
+        stubSigningAndPublishing();
+        stubMuteRead(timedOut: true);
+
+        final service = await startedService();
+        await service.blockUser(blockedPubkey);
+
+        verifyNever(
+          () => mockSigner.createAndSignEvent(
+            kind: 10000,
+            content: any(named: 'content'),
+            tags: any(named: 'tags'),
+          ),
+        );
+      });
+
+      test(
+        'blocking does not publish when no relay took the query',
+        () async {
+          stubSigningAndPublishing();
+          stubMuteRead(noRelays: true);
+
+          final service = await startedService();
+          await service.blockUser(blockedPubkey);
+
+          verifyNever(
+            () => mockSigner.createAndSignEvent(
+              kind: 10000,
+              content: any(named: 'content'),
+              tags: any(named: 'tags'),
+            ),
+          );
+        },
+      );
+
+      test('the block still applies and persists when the publish is '
+          'withheld', () async {
+        SharedPreferences.setMockInitialValues(<String, Object>{});
+        final prefs = await SharedPreferences.getInstance();
+        stubSigningAndPublishing();
+        stubMuteRead(timedOut: true);
+
+        final service = await startedService(prefs);
+        await service.blockUser(blockedPubkey);
+
+        expect(service.isBlocked(blockedPubkey), isTrue);
+        // Survives a restart: the local block is the part that must not be
+        // gated on relay health.
+        expect(
+          ContentBlocklistRepository(prefs: prefs).isBlocked(blockedPubkey),
+          isTrue,
+        );
+      });
+
+      test(
+        'unblocking does not publish when the read is inconclusive',
+        () async {
+          stubSigningAndPublishing();
+          stubMuteRead();
+
+          final service = await startedService();
+          await service.blockUser(blockedPubkey);
+          clearInteractions(mockSigner);
+
+          stubMuteRead(timedOut: true);
+          await service.unblockUser(blockedPubkey);
+
+          expect(service.isBlocked(blockedPubkey), isFalse);
+          verifyNever(
+            () => mockSigner.createAndSignEvent(
+              kind: 10000,
+              content: any(named: 'content'),
+              tags: any(named: 'tags'),
+            ),
+          );
+        },
+      );
+
+      test('a settled empty read still publishes, so a first block reaches '
+          'the relay', () async {
+        stubSigningAndPublishing();
+        stubMuteRead();
+
+        final service = await startedService();
+        await service.blockUser(blockedPubkey);
+
+        final tags =
+            verify(
+                  () => mockSigner.createAndSignEvent(
+                    kind: 10000,
+                    content: any(named: 'content'),
+                    tags: captureAny(named: 'tags'),
+                  ),
+                ).captured.last
+                as List<List<String>>;
+        expect(tags, contains(equals(['p', blockedPubkey])));
+      });
+
+      test('a withheld publish leaves the source event untouched, so the '
+          'retry preserves it', () async {
+        const existingMute =
+            '00000000000000000000000000000000000000000000000000000000000000cc';
+        final existingEvent = buildEvent(
+          kind: 10000,
+          content: 'encrypted-private-tags',
+          tags: const [
+            ['p', existingMute],
+            ['t', 'spoilers'],
+            ['word', 'spoiler'],
+          ],
+          createdAt: 1000,
+        );
+        stubSigningAndPublishing();
+        stubMuteRead(timedOut: true);
+
+        final service = await startedService();
+        await service.blockUser(blockedPubkey);
+        verifyNever(
+          () => mockSigner.createAndSignEvent(
+            kind: 10000,
+            content: any(named: 'content'),
+            tags: any(named: 'tags'),
+          ),
+        );
+
+        stubMuteRead(events: [existingEvent]);
+        expect(await service.retryPendingMuteListPublish(), isTrue);
+
+        final captured = verify(
+          () => mockSigner.createAndSignEvent(
+            kind: 10000,
+            content: captureAny(named: 'content'),
+            tags: captureAny(named: 'tags'),
+          ),
+        ).captured;
+        expect(captured[0] as String, 'encrypted-private-tags');
+        final tags = captured[1] as List<List<String>>;
+        expect(tags, contains(equals(['t', 'spoilers'])));
+        expect(tags, contains(equals(['word', 'spoiler'])));
+        expect(tags, contains(equals(['p', existingMute])));
+        expect(tags, contains(equals(['p', blockedPubkey])));
+      });
+
+      test(
+        'retryPendingMuteListPublish is a no-op when nothing is pending',
+        () async {
+          stubSigningAndPublishing();
+          stubMuteRead();
+
+          final service = await startedService();
+          await service.blockUser(blockedPubkey);
+          clearInteractions(mockSigner);
+
+          expect(await service.retryPendingMuteListPublish(), isFalse);
+          verifyNever(
+            () => mockSigner.createAndSignEvent(
+              kind: any(named: 'kind'),
+              content: any(named: 'content'),
+              tags: any(named: 'tags'),
+            ),
+          );
+        },
+      );
+
+      test('a retry that is still inconclusive stays pending', () async {
+        stubSigningAndPublishing();
+        stubMuteRead(timedOut: true);
+
+        final service = await startedService();
+        await service.blockUser(blockedPubkey);
+
+        expect(await service.retryPendingMuteListPublish(), isFalse);
+
+        stubMuteRead();
+        expect(await service.retryPendingMuteListPublish(), isTrue);
+      });
+    });
   });
 
   group('ContentBlocklistRepository - legacy block list migration', () {
@@ -3486,6 +3738,51 @@ void main() {
       // applied locally.
       expect(prefs.getBool(flagKey), isNull);
       expect(service.isBlocked(blockA), isTrue);
+
+      service.dispose();
+    });
+
+    test('defers the migration when the mute-list read is inconclusive '
+        '(#6750)', () async {
+      when(() => mockClient.queryEvents(any())).thenAnswer((invocation) async {
+        final filters = invocation.positionalArguments[0] as List<Filter>;
+        final kinds = filters.first.kinds ?? const <int>[];
+        if (kinds.contains(30000)) {
+          return [
+            ownBlockEvent([blockA]),
+          ];
+        }
+        return <Event>[];
+      });
+      // The legacy kind-30000 read succeeds; only the kind-10000 read is
+      // unanswered. Merging into a mute list we could not see would republish
+      // over it.
+      when(
+        () => mockClient.queryEventsDetailed(
+          any(),
+          requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+        ),
+      ).thenAnswer(
+        (_) async => (events: <Event>[], timedOut: true, noRelays: false),
+      );
+
+      final service = ContentBlocklistRepository(prefs: prefs);
+      await service.syncBlockListsInBackground(
+        mockClient,
+        mockSigner,
+        ourPubkey,
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      verifyNever(
+        () => mockSigner.createAndSignEvent(
+          kind: 10000,
+          content: any(named: 'content'),
+          tags: any(named: 'tags'),
+        ),
+      );
+      // Unset, so the next launch retries.
+      expect(prefs.getBool(flagKey), isNull);
 
       service.dispose();
     });

--- a/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
+++ b/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
@@ -2800,6 +2800,67 @@ void main() {
       expect(tags, contains(equals(['e', 'event-thread-id'])));
     });
 
+    test(
+      'blocking someone already muted elsewhere keeps their relay hint',
+      () async {
+        // `_applyOwnMuteListEvent` keeps our own blocks out of `_mutedPubkeys`,
+        // so the source-preservation loop skips this pubkey and the re-emit
+        // path is what decides whether the hint survives.
+        const alreadyMuted =
+            '00000000000000000000000000000000000000000000000000000000000000ee';
+        final existingEvent = buildEvent(
+          kind: 10000,
+          content: 'encrypted-private-tags',
+          tags: const [
+            ['p', alreadyMuted, 'wss://relay.example'],
+          ],
+          createdAt: 1000,
+        );
+        when(() => mockSigner.isAuthenticated).thenReturn(true);
+        when(
+          () => mockClient.queryEvents(any()),
+        ).thenAnswer((_) async => [existingEvent]);
+        when(
+          () => mockSigner.createAndSignEvent(
+            kind: any(named: 'kind'),
+            content: any(named: 'content'),
+            tags: any(named: 'tags'),
+          ),
+        ).thenAnswer(
+          (invocation) async => signedEventFromInvocation(invocation),
+        );
+        when(() => mockClient.publishEvent(any())).thenAnswer(
+          (invocation) async => PublishSuccess(
+            event: invocation.positionalArguments.first as Event,
+          ),
+        );
+
+        final service = ContentBlocklistRepository();
+        await service.syncBlockListsInBackground(
+          mockClient,
+          mockSigner,
+          ourPubkey,
+        );
+
+        await service.blockUser(alreadyMuted);
+
+        final tags =
+            verify(
+                  () => mockSigner.createAndSignEvent(
+                    kind: 10000,
+                    content: any(named: 'content'),
+                    tags: captureAny(named: 'tags'),
+                  ),
+                ).captured.last
+                as List<List<String>>;
+        expect(
+          tags,
+          contains(equals(['p', alreadyMuted, 'wss://relay.example'])),
+        );
+        expect(tags, isNot(contains(equals(['p', alreadyMuted]))));
+      },
+    );
+
     test('blocking appends hydrated external p mutes before the latest source '
         'event is available', () async {
       const existingMute =

--- a/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
+++ b/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
@@ -3176,6 +3176,16 @@ void main() {
                 ).captured.last
                 as List<List<String>>;
         expect(tags, contains(equals(['p', blockedPubkey])));
+
+        // The read that precedes a replace must demand every relay settle;
+        // without it a partial answer reads as empty and clobbers the list
+        // (#6750). Pin the argument so flipping it back to false fails here.
+        verify(
+          () => mockClient.queryEventsDetailed(
+            any(),
+            requireAllRelaysSettled: true,
+          ),
+        ).called(greaterThanOrEqualTo(1));
       });
 
       test('a withheld publish leaves the source event untouched, so the '
@@ -3844,6 +3854,15 @@ void main() {
       );
       // Unset, so the next launch retries.
       expect(prefs.getBool(flagKey), isNull);
+
+      // The migration's kind 10000 read must also demand all relays settle,
+      // for the same reason the publish path does (#6750).
+      verify(
+        () => mockClient.queryEventsDetailed(
+          any(),
+          requireAllRelaysSettled: true,
+        ),
+      ).called(greaterThanOrEqualTo(1));
 
       service.dispose();
     });

--- a/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
+++ b/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
@@ -3266,6 +3266,103 @@ void main() {
         stubMuteRead();
         expect(await service.retryPendingMuteListPublish(), isTrue);
       });
+
+      test('a restart republishes a block the relay never received', () async {
+        // The app-kill case: the block survived in SharedPreferences, the
+        // pending flag did not, and the relay's list predates it.
+        SharedPreferences.setMockInitialValues(<String, Object>{
+          'blocked_users_list': jsonEncode([blockedPubkey]),
+        });
+        final prefs = await SharedPreferences.getInstance();
+        stubSigningAndPublishing();
+        stubMuteRead();
+        final ownList = StreamController<Event>();
+        addTearDown(ownList.close);
+        when(
+          () => mockClient.subscribe(any()),
+        ).thenAnswer((_) => ownList.stream);
+
+        final service = ContentBlocklistRepository(prefs: prefs);
+        await service.syncMuteListsInBackground(mockClient, ourPubkey);
+        await service.syncBlockListsInBackground(
+          mockClient,
+          mockSigner,
+          ourPubkey,
+        );
+        clearInteractions(mockSigner);
+
+        // The relay serves a list that predates the block.
+        ownList.add(
+          buildEvent(
+            kind: 10000,
+            content: 'encrypted-private-tags',
+            tags: const [
+              ['t', 'spoilers'],
+            ],
+            createdAt: 5000,
+          ),
+        );
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+
+        final captured = verify(
+          () => mockSigner.createAndSignEvent(
+            kind: 10000,
+            content: captureAny(named: 'content'),
+            tags: captureAny(named: 'tags'),
+          ),
+        ).captured;
+        expect(captured[0] as String, 'encrypted-private-tags');
+        final tags = captured[1] as List<List<String>>;
+        expect(tags, contains(equals(['p', blockedPubkey])));
+        expect(tags, contains(equals(['t', 'spoilers'])));
+      });
+
+      test(
+        'a list that already carries our blocks republishes nothing',
+        () async {
+          SharedPreferences.setMockInitialValues(<String, Object>{
+            'blocked_users_list': jsonEncode([blockedPubkey]),
+          });
+          final prefs = await SharedPreferences.getInstance();
+          stubSigningAndPublishing();
+          stubMuteRead();
+          final ownList = StreamController<Event>();
+          addTearDown(ownList.close);
+          when(
+            () => mockClient.subscribe(any()),
+          ).thenAnswer((_) => ownList.stream);
+
+          final service = ContentBlocklistRepository(prefs: prefs);
+          await service.syncMuteListsInBackground(mockClient, ourPubkey);
+          await service.syncBlockListsInBackground(
+            mockClient,
+            mockSigner,
+            ourPubkey,
+          );
+          clearInteractions(mockSigner);
+
+          ownList.add(
+            buildEvent(
+              kind: 10000,
+              tags: const [
+                ['p', blockedPubkey],
+              ],
+              createdAt: 5000,
+            ),
+          );
+          await Future<void>.delayed(Duration.zero);
+          await Future<void>.delayed(Duration.zero);
+
+          verifyNever(
+            () => mockSigner.createAndSignEvent(
+              kind: any(named: 'kind'),
+              content: any(named: 'content'),
+              tags: any(named: 'tags'),
+            ),
+          );
+        },
+      );
     });
   });
 


### PR DESCRIPTION
Fixes #6750.

## The bug

Kind 10000 is replaceable, so every publish replaces the whole event.
`_buildMuteListPublishShape` rebuilds it from local state and only carries the
encrypted `content` and the non-`p` tags forward when `_latestOwnMuteListEvent`
is populated. That field is memory-only, so it is null on every cold start until
a relay read fills it.

The read could not tell *"this account has no mute list"* from *"nobody
answered"*. `NostrClient.queryEvents` is a wrapper that drops the `timedOut` and
`noRelays` flags its detailed form returns, and without `requireAllRelaysSettled`
a relay abandoned by the 1s settle window arrives as an empty answer rather than
a timeout. So an unanswered read looked exactly like an empty list, and one
ordinary Block published a `p`-only event with empty `content` over whatever was
there.

`RelayPool` already names this caller class, in the dartdoc for the flag that
fixes it:

> it is unusable for a caller that is about to *replace* what it read — a
> replaceable event republished from a partial answer deletes whatever only the
> silent relay held.

## Blast radius is wider than the title

Reproduced on the running app against a funnelcake relay, with a WebSocket
relay-in-the-middle that swallows the own-mute-list REQ while the relay still
holds the event. Before one block:

```
tags:    p 1111…, t spoilers, t politics, word crypto, e 2222…
content: 'PRIVATE_MUTES_FROM_ANOTHER_CLIENT?iv=Zm9vYmFy'
```

After one block:

```
tags:    p 3333…
content: ''
```

So it is not only the encrypted private section. It also destroys `t` hashtag
mutes, `word` mutes, `e` thread mutes, **and public `p` mutes authored on
another client** — the last of those whenever `_mutedPubkeys` has not been
hydrated, which is the same cold-start window. The app logged the whole thing
as `Published mute list to Nostr with 1 pubkey entries`.

It is also not confined to other Nostr clients — though only through the `p`
tags. funnelcake's `nostr.mute_list_pubkeys` is rebuilt from the user's
*newest* kind 10000 every five minutes (migration `000183`), and
`filter_muted_pubkeys` (`crates/clickhouse/src/event_filters.rs:816`) uses it
for server-side mute filtering on served queries including notifications
(`client.rs:17126`, `:17494`). A wipe of the `p` tags propagates to the backend
within one refresh window, so muted accounts start reappearing in the user's
own feeds and inbox.

The encrypted `content` and the `t` tags have **no** server-side reader —
funnelcake states the policy explicitly (*"The encrypted `content` field
(private mutes per NIP-51) is NOT handled server-side"*), and
`nostr.mute_lists`, the only view exposing them, has no non-test consumer. That
half of the damage is invisible to us in both directions: nothing renders it,
and no backend signal will ever alert us that it happened.

## The fix

Read through `queryEventsDetailed(requireAllRelaysSettled: true)` and withhold
the publish when the answer was not conclusive. A *settled* answer of zero
events stays conclusive, so a first-ever block still publishes.

The block itself still applies and persists locally — a safety action is not
gated on relay health — and the withheld publish is retried by the next block or
unblock, and on foreground through the existing `blocklistSyncBridge`.

The one-time legacy migration carried its own copy of the same lossy read. It
now defers *without* setting its completion flag, so it retries next launch.

## Second commit: a relay hint dropped on the happy path

Found in the same function while proving the above, verified, and fixed here
rather than left behind — **not requested by #6750**, so calling it out
separately.

A NIP-51 `p` tag can carry a third element, a relay hint. The publish shape
preserved it only for entries in `_mutedPubkeys`, and `_applyOwnMuteListEvent`
deliberately keeps our own blocks *out* of that set — so the preservation loop
skipped exactly the entries the `_runtimeBlocklist` loop then rewrote as a bare
`['p', pubkey]`. Mute someone in another client with a relay hint, block them in
Divine, and the hint is gone on the next republish. Unlike the main bug this
fires with a fully successful read.

## Third commit: recovering a withheld publish across a restart

From review. The doc claimed the retry fired on session-ready *and* foreground;
only foreground called it, and `_muteListPublishPending` is memory-only — so a
block made during a relay outage, with the app killed before a
background/foreground cycle, stayed local until the user happened to block
someone else.

Closed by deriving the work rather than persisting a flag: when the
subscription delivers our own kind 10000, any block we hold in
`_runtimeBlocklist` (which *does* survive a restart) that the relay's newest
list lacks is a publish that never landed, so we republish. No-op in steady
state. Only the subscription reconciles, and our own just-published event is
applied with reconciliation off, so it cannot recurse.

**Known boundary, stated rather than hidden:** this recovers a withheld
*block*, not a withheld *unblock*. An unblock leaves no durable trace — absent
from `_runtimeBlocklist` is indistinguishable from muted on another client — so
it still waits for the next block/unblock or a foreground cycle in the same
session.

## Prior art: divine-web already does this

`divine-web`'s `fetchMuteListForPublish` (`src/hooks/useModeration.ts:175-195`)
sets `relayQuerySucceeded` only on `EOSE`, breaks without it on `CLOSED`, and
throws `MuteListUnavailableError` rather than publishing on an unconfirmed read
— then `publishMuteListUpdate` carries `base.content` and `base.tags` forward
verbatim. This PR brings mobile to the same contract by a different route
(`requireAllRelaysSettled` turns an unanswered or `CLOSED`-without-answer REQ
into `timedOut`), which is worth knowing for anyone comparing the two clients.

## Verification

Same rig, same cold state, same block action, on the built app:

| Run | Own-mute-list REQ | Result |
|---|---|---|
| before the fix | never answered | rich list destroyed, `content` emptied |
| after the fix | never answered | **list untouched**, block applied locally, publish pending |
| after the fix | relay healthy, retry fires | block **appended**, every tag and the `content` preserved |
| after the fix | app killed, then relaunched | subscription reconcile republishes the block, `content` and other tags preserved |

Plus: `flutter analyze lib test integration_test` clean; the package suite green
at **100% line coverage** (it inherits VeryGood's gate); and a mutation run —
disabling the two new guards — turns eight of the nine new tests red, so they
can fail for the right reason.

The nine new tests pin: no publish on `timedOut`; no publish on `noRelays`; the
block still applies and survives a restart when withheld; unblock behaves the
same; a settled-empty read still publishes; the retry preserves the source
event's tags and `content`; the retry is a no-op with nothing pending; a retry
that is still inconclusive stays pending; and the migration defers without
setting its flag.

Every pre-existing test kept its assertions unchanged. `_MockNostrClient` now
mirrors whatever `queryEvents` is stubbed to return as a *settled* answer, which
is exactly what those tests were written to mean.

## Deliberately out of scope

Two adjacent problems surfaced and were filed rather than folded in:

- #8257 — Divine never reads NIP-65, so a mute list living only on relays we do
  not query returns a *legitimately* empty answer that no settlement flag can
  detect, and our newer, emptier event then wins the merge in multi-relay
  clients. Not fixable by this change; needs outbox-relay reads.
- #8258 — `queryEvents` discards the same failure state at every other
  read-modify-write-before-publish call site (kind 3, 10001, 10002, curated
  lists). This PR fixes the two in this repository.

Also filed: divinevideo/divine-funnelcake#1158, a latent schema issue found
while proving this out (`FINAL` on `events_local`, which is `ORDER BY id`,
cannot deduplicate replaceable events, so five views return every historical
version).

## Risk

With `requireAllRelaysSettled: true`, a relay that stays connected and never
terminates a REQ holds the query for its full 5s and the read reports
`timedOut`. Such a user's blocks apply locally and do not reach the relay until
that relay behaves. `_canStillSettleQuery` already writes off disconnected
relays and zombie repairs, so only a pathological connected-but-mute relay
produces this, and it now logs a warning naming the cause. Trading propagation
delay for not destroying data is the intent.

**A known residual hole this does not close.** funnelcake accepts up to +60s of
clock drift at ingest (`max_created_at_drift_seconds: 60`) but refuses to serve
a future-dated event (`push_future_date_condition`, `created_at <= now()`). So a
device with a fast clock publishes its mute list, gets `OK`, and then its own
read comes back `EOSE`-empty until wall-clock catches up — a *settled* empty
answer, which this fix treats as conclusive and will publish over.
`requireAllRelaysSettled` cannot detect it. Filed as
divinevideo/divine-funnelcake#1159 rather than papered over here.
