### PR TITLE
fix(blocklist): keep an unblock that never reached the relay

### DIFF
--- a/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
+++ b/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
@@ -93,7 +93,10 @@ class ContentBlocklistRepository {
     _scopedBasesPresentAtConstruction = seededAccount == null
         ? const <String>{}
         : <String>{
-            for (final base in _legacySetsByBase.keys)
+            for (final base in {
+              ..._legacySetsByBase.keys,
+              _pendingUnblocksPrefsKey,
+            })
               if (_prefs?.getString('$base.$seededAccount') != null) base,
           };
     _loadBlockedUsers();
@@ -425,6 +428,8 @@ class ContentBlocklistRepository {
       _notifyChanged();
     }
 
+    final pendingUnblocksMigration = _migrateLegacyPendingUnblocks(pubkey);
+
     for (final base in staleBases) {
       try {
         await prefs.remove(base);
@@ -458,6 +463,71 @@ class ContentBlocklistRepository {
           category: LogCategory.system,
         );
       }
+    }
+
+    await pendingUnblocksMigration;
+  }
+
+  Future<void> _migrateLegacyPendingUnblocks(String pubkey) async {
+    final prefs = _prefs;
+    if (prefs == null) return;
+    final legacy = prefs.getString(_pendingUnblocksPrefsKey);
+    if (legacy == null || legacy.isEmpty) return;
+
+    final scopedKey = '$_pendingUnblocksPrefsKey.$pubkey';
+    final scoped = prefs.getString(scopedKey);
+    if (scoped != null &&
+        (_scopedBasesPresentAtConstruction.contains(
+              _pendingUnblocksPrefsKey,
+            ) ||
+            _activeAccountPubkey == null)) {
+      try {
+        final decoded = jsonDecode(scoped) as Map<String, dynamic>;
+        _pendingUnblocks
+          ..clear()
+          ..addEntries(
+            decoded.entries
+                .where((entry) => entry.value is int)
+                .map((entry) => MapEntry(entry.key, entry.value as int)),
+          );
+        if (_pendingUnblocks.isNotEmpty) _muteListPublishPending = true;
+        await prefs.remove(_pendingUnblocksPrefsKey);
+        return;
+      } on Object catch (e) {
+        Log.error(
+          'Failed to adopt scoped blocklist key $scopedKey: $e',
+          name: 'ContentBlocklistRepository',
+          category: LogCategory.system,
+        );
+      }
+    }
+
+    try {
+      final decoded = jsonDecode(legacy) as Map<String, dynamic>;
+      for (final entry in decoded.entries) {
+        final unblockedAt = entry.value;
+        if (unblockedAt is! int) continue;
+        final current = _pendingUnblocks[entry.key];
+        if (current == null || unblockedAt > current) {
+          _pendingUnblocks[entry.key] = unblockedAt;
+        }
+      }
+      if (_pendingUnblocks.isNotEmpty) _muteListPublishPending = true;
+      if (_activeAccountPubkey != null && _activeAccountPubkey != pubkey) {
+        return;
+      }
+      final written = await prefs.setString(
+        scopedKey,
+        jsonEncode(_pendingUnblocks),
+      );
+      if (written) await prefs.remove(_pendingUnblocksPrefsKey);
+    } on Object catch (e) {
+      Log.error(
+        'Failed to migrate legacy blocklist key '
+        '$_pendingUnblocksPrefsKey: $e',
+        name: 'ContentBlocklistRepository',
+        category: LogCategory.system,
+      );
     }
   }
 

--- a/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
+++ b/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
@@ -513,9 +513,6 @@ class ContentBlocklistRepository {
         }
       }
       if (_pendingUnblocks.isNotEmpty) _muteListPublishPending = true;
-      if (_activeAccountPubkey != null && _activeAccountPubkey != pubkey) {
-        return;
-      }
       final written = await prefs.setString(
         scopedKey,
         jsonEncode(_pendingUnblocks),

--- a/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
+++ b/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
@@ -24,6 +24,17 @@ const _mutedUsersPrefsKey = 'muted_users_list';
 /// SharedPreferences key for severed followers (follow broken by block)
 const _severedFollowersPrefsKey = 'severed_followers_list';
 
+/// SharedPreferences key for unblocks whose kind 10000 publish has not been
+/// confirmed, as `pubkey -> unblocked-at` in Unix seconds.
+///
+/// A block that never reached the relay is derivable after a restart -- it is
+/// in `_blockedUsersPrefsKey` and absent from the list the relay serves back.
+/// An unblock is not: once the pubkey leaves the block set, "the user
+/// unblocked them" and "another client muted them" are the same state. The
+/// timestamp is what separates the two, against the list's `created_at`
+/// (#8263).
+const _pendingUnblocksPrefsKey = 'pending_unblocks';
+
 /// SharedPreferences key recording which account's per-account state the
 /// persisted sets belong to. Written on identity adoption so the next
 /// construction hydrates the right account before auth resolves.
@@ -88,6 +99,7 @@ class ContentBlocklistRepository {
     _loadBlockedUsers();
     _loadMutedUsers();
     _loadSeveredFollowers();
+    _loadPendingUnblocks();
     Log.info(
       'ContentBlocklistRepository initialized with '
       '$totalBlockedCount blocked accounts',
@@ -127,6 +139,12 @@ class ContentBlocklistRepository {
   // came back inconclusive. Flushed by [retryPendingMuteListPublish] and by
   // the next block or unblock, which republishes the whole list anyway.
   bool _muteListPublishPending = false;
+
+  // Unblocks whose removal from the published kind 10000 is not yet
+  // confirmed, as pubkey -> unblocked-at in Unix seconds. Persisted, because
+  // the whole point is to survive the restart that loses
+  // [_muteListPublishPending].
+  final Map<String, int> _pendingUnblocks = <String, int>{};
 
   // Latest replaceable kind-10000 mute-list event timestamp per author.
   // Prevent stale relay delivery order from resurrecting old mute state.
@@ -289,6 +307,7 @@ class ContentBlocklistRepository {
       _blockedByOthers.clear();
       _latestOwnMuteListEvent = null;
       _muteListPublishPending = false;
+      _pendingUnblocks.clear();
       _latestMuteListEventCreatedAtByAuthor.clear();
       _latestBlockListEventCreatedAtByAuthor.clear();
       _severedFollowers.clear();
@@ -489,6 +508,45 @@ class ContentBlocklistRepository {
   ///
   /// This is the hydration cache that covers the window between app start
   /// and relay delivery of our own kind 10000 event.
+  void _loadPendingUnblocks() {
+    final prefs = _prefs;
+    if (prefs == null) return;
+
+    final stored = prefs.getString(_scopedKey(_pendingUnblocksPrefsKey));
+    if (stored == null || stored.isEmpty) return;
+
+    try {
+      final decoded = jsonDecode(stored) as Map<String, dynamic>;
+      decoded.forEach((pubkey, unblockedAt) {
+        if (unblockedAt is int) _pendingUnblocks[pubkey] = unblockedAt;
+      });
+    } on Object catch (e) {
+      Log.error(
+        'Failed to load pending unblocks: $e',
+        name: 'ContentBlocklistRepository',
+        category: LogCategory.system,
+      );
+    }
+  }
+
+  Future<void> _savePendingUnblocks() async {
+    final prefs = _prefs;
+    if (prefs == null) return;
+
+    try {
+      await prefs.setString(
+        _scopedKey(_pendingUnblocksPrefsKey),
+        jsonEncode(_pendingUnblocks),
+      );
+    } on Object catch (e) {
+      Log.error(
+        'Failed to persist pending unblocks: $e',
+        name: 'ContentBlocklistRepository',
+        category: LogCategory.system,
+      );
+    }
+  }
+
   void _loadMutedUsers() {
     final prefs = _prefs;
     if (prefs == null) return;
@@ -1126,8 +1184,15 @@ class ContentBlocklistRepository {
     if (_runtimeBlocklist.contains(pubkey)) {
       _runtimeBlocklist.remove(pubkey);
       await _saveBlockedUsers();
+      // Recorded BEFORE the publish, so a withheld or failed publish still
+      // leaves the intent behind for the next launch to act on (#8263).
+      _pendingUnblocks[pubkey] = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+      await _savePendingUnblocks();
       _emitChange(BlocklistChange(pubkey: pubkey, op: BlocklistOp.unblocked));
       _notifyChanged();
+      // Retirement is not repeated here: a successful publish routes its own
+      // event through [_applyOwnMuteListEvent], which drops the intent
+      // because the list it just wrote no longer carries the tag.
       await _publishMuteListToNostr();
 
       Log.info(
@@ -1673,6 +1738,40 @@ class ContentBlocklistRepository {
         relayMuted.add(tag[1]);
       }
     }
+    // An unblock this list predates never reached the relay, so its `p` tag
+    // is stale and must not be re-adopted as a mute from another client
+    // (#8263). A tag on a list NEWER than the unblock is the opposite case --
+    // someone muted them again after we unblocked -- so it is honoured and
+    // the intent retired. `created_at` is what separates the two; without it
+    // a legitimate later re-mute would be suppressed forever.
+    if (_pendingUnblocks.isNotEmpty) {
+      final retired = <String>[];
+      for (final entry in _pendingUnblocks.entries) {
+        if (!relayMuted.contains(entry.key) || entry.value <= createdAt) {
+          // Either the tag is gone, so the unblock landed, or this list is
+          // newer than the unblock and the tag is a fresh mute from another
+          // client. Both retire the intent; the second also lets the mute
+          // through, which is the point of comparing against `created_at`.
+          retired.add(entry.key);
+        } else {
+          relayMuted.remove(entry.key);
+        }
+      }
+      if (retired.isNotEmpty) {
+        retired.forEach(_pendingUnblocks.remove);
+        if (persist) unawaited(_savePendingUnblocks());
+      }
+      if (reconcile && _pendingUnblocks.isNotEmpty) {
+        Log.info(
+          'Own mute list still carries an account we unblocked; republishing',
+          name: 'ContentBlocklistRepository',
+          category: LogCategory.system,
+        );
+        _muteListPublishPending = true;
+        unawaited(retryPendingMuteListPublish());
+      }
+    }
+
     // The relay's newest list is authoritative for what it holds, so blocks
     // we still hold locally that are absent from it are a publish that never
     // landed -- withheld by an inconclusive read (#6750), or lost with

--- a/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
+++ b/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
@@ -1773,7 +1773,7 @@ class ContentBlocklistRepository {
       }
       if (retired.isNotEmpty) {
         retired.forEach(_pendingUnblocks.remove);
-        if (persist) unawaited(_savePendingUnblocks());
+        unawaited(_savePendingUnblocks());
       }
       if (reconcile && _pendingUnblocks.isNotEmpty) {
         Log.info(

--- a/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
+++ b/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
@@ -504,10 +504,11 @@ class ContentBlocklistRepository {
     }
   }
 
-  /// Load persisted muted authors from SharedPreferences.
+  /// Load unblocks whose kind 10000 publish was never confirmed.
   ///
-  /// This is the hydration cache that covers the window between app start
-  /// and relay delivery of our own kind 10000 event.
+  /// The counterpart to [_loadBlockedUsers]: a block that did not reach the
+  /// relay is derivable from the two sets, an unblock is not, so the intent
+  /// has to survive the restart on its own (#8263).
   void _loadPendingUnblocks() {
     final prefs = _prefs;
     if (prefs == null) return;
@@ -517,9 +518,10 @@ class ContentBlocklistRepository {
 
     try {
       final decoded = jsonDecode(stored) as Map<String, dynamic>;
-      decoded.forEach((pubkey, unblockedAt) {
-        if (unblockedAt is int) _pendingUnblocks[pubkey] = unblockedAt;
-      });
+      for (final entry in decoded.entries) {
+        final unblockedAt = entry.value;
+        if (unblockedAt is int) _pendingUnblocks[entry.key] = unblockedAt;
+      }
     } on Object catch (e) {
       Log.error(
         'Failed to load pending unblocks: $e',
@@ -547,6 +549,10 @@ class ContentBlocklistRepository {
     }
   }
 
+  /// Load persisted muted authors from SharedPreferences.
+  ///
+  /// This is the hydration cache that covers the window between app start
+  /// and relay delivery of our own kind 10000 event.
   void _loadMutedUsers() {
     final prefs = _prefs;
     if (prefs == null) return;

--- a/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
+++ b/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
@@ -335,6 +335,7 @@ class ContentBlocklistRepository {
       _loadBlockedUsers();
       _loadMutedUsers();
       _loadSeveredFollowers();
+      _loadPendingUnblocks();
       _notifyChanged();
       Log.info(
         'Adopted new identity; blocklist state reset and reloaded '
@@ -522,6 +523,7 @@ class ContentBlocklistRepository {
         final unblockedAt = entry.value;
         if (unblockedAt is int) _pendingUnblocks[entry.key] = unblockedAt;
       }
+      if (_pendingUnblocks.isNotEmpty) _muteListPublishPending = true;
     } on Object catch (e) {
       Log.error(
         'Failed to load pending unblocks: $e',
@@ -676,6 +678,9 @@ class ContentBlocklistRepository {
   ///
   /// Returns `true` when the event was accepted by at least one relay.
   Future<bool> _publishMuteListToNostr() async {
+    // Keep every unsuccessful attempt retryable. This is set before the
+    // dependency guards too, because block/unblock actions can race startup.
+    _muteListPublishPending = true;
     final signer = _signer;
     final nostrClient = _nostrClient;
 
@@ -704,7 +709,6 @@ class ContentBlocklistRepository {
         // with it -- the encrypted private section, every t/word/e mute, and
         // any p mute authored on another client (#6750). The block is already
         // persisted locally, so withholding costs propagation, not safety.
-        _muteListPublishPending = true;
         Log.warning(
           'Withholding mute list publish - could not confirm the current '
           'kind 10000. Blocks stay local until a read succeeds.',
@@ -1133,6 +1137,7 @@ class ContentBlocklistRepository {
     var skippedSelf = false;
     final newlyBlocked = <String>[];
     final newlySeveredFollowers = <String>[];
+    var retiredPendingUnblock = false;
 
     for (final pubkey in pubkeys) {
       if (pubkey.isEmpty) continue;
@@ -1142,6 +1147,8 @@ class ContentBlocklistRepository {
       }
       if (_runtimeBlocklist.add(pubkey)) {
         newlyBlocked.add(pubkey);
+        retiredPendingUnblock =
+            _pendingUnblocks.remove(pubkey) != null || retiredPendingUnblock;
       }
       if (!_severedFollowers.contains(pubkey) &&
           !newlySeveredFollowers.contains(pubkey)) {
@@ -1159,6 +1166,7 @@ class ContentBlocklistRepository {
 
     if (newlyBlocked.isNotEmpty) {
       await _saveBlockedUsers();
+      if (retiredPendingUnblock) await _savePendingUnblocks();
       for (final pubkey in newlyBlocked) {
         _emitChange(BlocklistChange(pubkey: pubkey, op: BlocklistOp.blocked));
       }
@@ -1753,7 +1761,7 @@ class ContentBlocklistRepository {
     if (_pendingUnblocks.isNotEmpty) {
       final retired = <String>[];
       for (final entry in _pendingUnblocks.entries) {
-        if (!relayMuted.contains(entry.key) || entry.value <= createdAt) {
+        if (!relayMuted.contains(entry.key) || entry.value < createdAt) {
           // Either the tag is gone, so the unblock landed, or this list is
           // newer than the unblock and the tag is a fresh mute from another
           // client. Both retire the intent; the second also lets the mute

--- a/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
+++ b/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
@@ -1819,6 +1819,7 @@ class ContentBlocklistRepository {
         relayMuted.add(tag[1]);
       }
     }
+    var needsRepublish = false;
     // An unblock this list predates never reached the relay, so its `p` tag
     // is stale and must not be re-adopted as a mute from another client
     // (#8263). A tag on a list NEWER than the unblock is the opposite case --
@@ -1848,8 +1849,7 @@ class ContentBlocklistRepository {
           name: 'ContentBlocklistRepository',
           category: LogCategory.system,
         );
-        _muteListPublishPending = true;
-        unawaited(retryPendingMuteListPublish());
+        needsRepublish = true;
       }
     }
 
@@ -1867,6 +1867,9 @@ class ContentBlocklistRepository {
         name: 'ContentBlocklistRepository',
         category: LogCategory.system,
       );
+      needsRepublish = true;
+    }
+    if (needsRepublish) {
       _muteListPublishPending = true;
       unawaited(retryPendingMuteListPublish());
     }

--- a/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
+++ b/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
@@ -1160,6 +1160,42 @@ void main() {
       service.dispose();
     });
 
+    test('survives corrupt pending-unblock storage', () async {
+      final mockPrefs = _MockSharedPreferences();
+      when(() => mockPrefs.getString(any())).thenReturn(null);
+      when(
+        () => mockPrefs.getString('pending_unblocks'),
+      ).thenReturn('{not json');
+
+      // Construction hydrates; a corrupt blob must not take the repository
+      // down with it.
+      final service = ContentBlocklistRepository(prefs: mockPrefs);
+      expect(service.totalBlockedCount, equals(0));
+
+      service.dispose();
+    });
+
+    test('continues when persisting a pending unblock throws', () async {
+      final mockPrefs = _MockSharedPreferences();
+      when(() => mockPrefs.getString(any())).thenReturn(null);
+      when(
+        () => mockPrefs.getString('blocked_users_list'),
+      ).thenReturn(jsonEncode([blockerX]));
+      when(
+        () => mockPrefs.setString(any(), any()),
+      ).thenThrow(Exception('disk full'));
+
+      final service = ContentBlocklistRepository(prefs: mockPrefs);
+      expect(service.isBlocked(blockerX), isTrue);
+
+      // The unblock records an intent, whose persist fails. The in-memory
+      // unblock must still take effect.
+      await service.unblockUser(blockerX);
+      expect(service.isBlocked(blockerX), isFalse);
+
+      service.dispose();
+    });
+
     test('keeps the legacy key when the scoped copy reports failure', () async {
       final mockPrefs = _MockSharedPreferences();
       when(() => mockPrefs.getString(any())).thenReturn(null);
@@ -3363,6 +3399,269 @@ void main() {
           );
         },
       );
+    });
+
+    group('an unblock whose publish never landed (#8263)', () {
+      const target =
+          '00000000000000000000000000000000000000000000000000000000000000dd';
+
+      void stubHealthy() {
+        when(() => mockSigner.isAuthenticated).thenReturn(true);
+        when(
+          () => mockSigner.createAndSignEvent(
+            kind: any(named: 'kind'),
+            content: any(named: 'content'),
+            tags: any(named: 'tags'),
+          ),
+        ).thenAnswer(
+          (invocation) async => signedEventFromInvocation(invocation),
+        );
+        when(() => mockClient.publishEvent(any())).thenAnswer(
+          (invocation) async => PublishSuccess(
+            event: invocation.positionalArguments.first as Event,
+          ),
+        );
+      }
+
+      void stubReadSettled() {
+        when(
+          () => mockClient.queryEventsDetailed(
+            any(),
+            requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+          ),
+        ).thenAnswer(
+          (_) async => (
+            events: <Event>[],
+            timedOut: false,
+            noRelays: false,
+          ),
+        );
+      }
+
+      void stubReadInconclusive() {
+        when(
+          () => mockClient.queryEventsDetailed(
+            any(),
+            requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+          ),
+        ).thenAnswer(
+          (_) async => (events: <Event>[], timedOut: true, noRelays: false),
+        );
+      }
+
+      /// Blocks [target], then unblocks it with the read inconclusive, so the
+      /// unblock is recorded but never published. Returns fresh prefs holding
+      /// that state, as a relaunch would find them.
+      Future<SharedPreferences> prefsAfterAWithheldUnblock() async {
+        SharedPreferences.setMockInitialValues(<String, Object>{});
+        final prefs = await SharedPreferences.getInstance();
+        stubHealthy();
+        final before = ContentBlocklistRepository(prefs: prefs);
+        await before.syncBlockListsInBackground(
+          mockClient,
+          mockSigner,
+          ourPubkey,
+        );
+        await before.blockUser(target);
+        stubReadInconclusive();
+        await before.unblockUser(target);
+        before.dispose();
+        return prefs;
+      }
+
+      test(
+        'is not re-adopted as a mute from a list that predates it',
+        () async {
+          final prefs = await prefsAfterAWithheldUnblock();
+          final ownList = StreamController<Event>.broadcast();
+          addTearDown(ownList.close);
+          when(
+            () => mockClient.subscribe(any()),
+          ).thenAnswer((_) => ownList.stream);
+
+          final restarted = ContentBlocklistRepository(prefs: prefs);
+          await restarted.syncMuteListsInBackground(mockClient, ourPubkey);
+          ownList.add(
+            buildEvent(
+              kind: 10000,
+              tags: const [
+                ['p', target],
+              ],
+              createdAt: 1000,
+            ),
+          );
+          await Future<void>.delayed(Duration.zero);
+
+          expect(restarted.isMutedByUs(target), isFalse);
+          expect(restarted.shouldFilterFromFeeds(target), isFalse);
+        },
+      );
+
+      test('IS honoured when the list is newer than the unblock, because that '
+          'is another client muting them again', () async {
+        final prefs = await prefsAfterAWithheldUnblock();
+        final ownList = StreamController<Event>.broadcast();
+        addTearDown(ownList.close);
+        when(
+          () => mockClient.subscribe(any()),
+        ).thenAnswer((_) => ownList.stream);
+
+        final restarted = ContentBlocklistRepository(prefs: prefs);
+        await restarted.syncMuteListsInBackground(mockClient, ourPubkey);
+        ownList.add(
+          buildEvent(
+            kind: 10000,
+            tags: const [
+              ['p', target],
+            ],
+            // Comfortably after the unblock we just recorded.
+            createdAt: 99999999999,
+          ),
+        );
+        await Future<void>.delayed(Duration.zero);
+
+        expect(restarted.isMutedByUs(target), isTrue);
+      });
+
+      test('republishes so the relay drops the stale tag', () async {
+        final prefs = await prefsAfterAWithheldUnblock();
+        final ownList = StreamController<Event>.broadcast();
+        addTearDown(ownList.close);
+        when(
+          () => mockClient.subscribe(any()),
+        ).thenAnswer((_) => ownList.stream);
+        stubHealthy();
+        stubReadSettled();
+
+        final restarted = ContentBlocklistRepository(prefs: prefs);
+        await restarted.syncBlockListsInBackground(
+          mockClient,
+          mockSigner,
+          ourPubkey,
+        );
+        await restarted.syncMuteListsInBackground(mockClient, ourPubkey);
+        clearInteractions(mockSigner);
+        ownList.add(
+          buildEvent(
+            kind: 10000,
+            tags: const [
+              ['p', target],
+            ],
+            createdAt: 1000,
+          ),
+        );
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+
+        final tags =
+            verify(
+                  () => mockSigner.createAndSignEvent(
+                    kind: 10000,
+                    content: any(named: 'content'),
+                    tags: captureAny(named: 'tags'),
+                  ),
+                ).captured.last
+                as List<List<String>>;
+        expect(tags, isNot(contains(equals(['p', target]))));
+      });
+
+      test('blocking again retires the intent, so a later restart has no '
+          'outstanding work', () async {
+        final prefs = await prefsAfterAWithheldUnblock();
+        stubHealthy();
+        stubReadSettled();
+
+        // Re-block and publish: our own event carries the tag and postdates
+        // the unblock, which is what retires the intent.
+        final second = ContentBlocklistRepository(prefs: prefs);
+        await second.syncBlockListsInBackground(
+          mockClient,
+          mockSigner,
+          ourPubkey,
+        );
+        await second.blockUser(target);
+        // The retire persists fire-and-forget, matching `_saveMutedUsers` in
+        // the same method, so let it land before the restart reads prefs.
+        await Future<void>.delayed(Duration.zero);
+        second.dispose();
+
+        // Restart, so nothing is carried in memory.
+        final ownList = StreamController<Event>.broadcast();
+        addTearDown(ownList.close);
+        when(
+          () => mockClient.subscribe(any()),
+        ).thenAnswer((_) => ownList.stream);
+        final restarted = ContentBlocklistRepository(prefs: prefs);
+        await restarted.syncBlockListsInBackground(
+          mockClient,
+          mockSigner,
+          ourPubkey,
+        );
+        await restarted.syncMuteListsInBackground(mockClient, ourPubkey);
+        // The startup legacy migration publishes on its own; let it finish so
+        // it is not mistaken for the reconcile republish below.
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+        clearInteractions(mockSigner);
+
+        ownList.add(
+          buildEvent(
+            kind: 10000,
+            tags: const [
+              ['p', target],
+            ],
+            createdAt: 1000,
+          ),
+        );
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(restarted.isBlocked(target), isTrue);
+        // Nothing outstanding: the block is already on the relay's list.
+        verifyNever(
+          () => mockSigner.createAndSignEvent(
+            kind: any(named: 'kind'),
+            content: any(named: 'content'),
+            tags: any(named: 'tags'),
+          ),
+        );
+      });
+
+      test('a successful unblock publish leaves nothing pending', () async {
+        SharedPreferences.setMockInitialValues(<String, Object>{});
+        final prefs = await SharedPreferences.getInstance();
+        stubHealthy();
+        final service = ContentBlocklistRepository(prefs: prefs);
+        await service.syncBlockListsInBackground(
+          mockClient,
+          mockSigner,
+          ourPubkey,
+        );
+        await service.blockUser(target);
+        await service.unblockUser(target);
+        service.dispose();
+
+        // A later list that still carries the tag is now an ordinary foreign
+        // mute, because our unblock was confirmed.
+        final ownList = StreamController<Event>.broadcast();
+        addTearDown(ownList.close);
+        when(
+          () => mockClient.subscribe(any()),
+        ).thenAnswer((_) => ownList.stream);
+        final restarted = ContentBlocklistRepository(prefs: prefs);
+        await restarted.syncMuteListsInBackground(mockClient, ourPubkey);
+        ownList.add(
+          buildEvent(
+            kind: 10000,
+            tags: const [
+              ['p', target],
+            ],
+            createdAt: 1000,
+          ),
+        );
+        await Future<void>.delayed(Duration.zero);
+
+        expect(restarted.isMutedByUs(target), isTrue);
+      });
     });
   });
 

--- a/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
+++ b/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
@@ -3609,6 +3609,30 @@ void main() {
         expect(await service.retryPendingMuteListPublish(), isFalse);
       });
 
+      test(
+        'a restart makes a persisted unblock immediately retryable',
+        () async {
+          final prefs = await prefsAfterAWithheldUnblock();
+          await prefs.setBool(
+            'block_list_migrated_to_mute_list.$ourPubkey',
+            true,
+          );
+          await prefs.setBool('block_list_retired.$ourPubkey', true);
+          stubHealthy();
+          stubReadSettled();
+
+          final restarted = ContentBlocklistRepository(prefs: prefs);
+          await restarted.syncBlockListsInBackground(
+            mockClient,
+            mockSigner,
+            ourPubkey,
+          );
+
+          expect(await restarted.retryPendingMuteListPublish(), isTrue);
+          expect(await restarted.retryPendingMuteListPublish(), isFalse);
+        },
+      );
+
       test('republishes so the relay drops the stale tag', () async {
         final prefs = await prefsAfterAWithheldUnblock();
         final ownList = StreamController<Event>.broadcast();
@@ -3654,11 +3678,31 @@ void main() {
       test('blocking again retires the intent, so a later restart has no '
           'outstanding work', () async {
         final prefs = await prefsAfterAWithheldUnblock();
+        final pending =
+            jsonDecode(
+                  prefs.getString('pending_unblocks.$ourPubkey')!,
+                )
+                as Map<String, dynamic>;
+        final unblockedAt = pending[target]! as int;
         stubHealthy();
         stubReadSettled();
+        when(
+          () => mockSigner.createAndSignEvent(
+            kind: any(named: 'kind'),
+            content: any(named: 'content'),
+            tags: any(named: 'tags'),
+          ),
+        ).thenAnswer(
+          (invocation) async => buildEvent(
+            kind: invocation.namedArguments[#kind] as int,
+            content: invocation.namedArguments[#content] as String,
+            tags: invocation.namedArguments[#tags] as List<List<String>>,
+            createdAt: unblockedAt,
+          ),
+        );
 
-        // Re-block and publish: our own event carries the tag and postdates
-        // the unblock, which is what retires the intent.
+        // Re-block and publish in the same second as the unblock. The explicit
+        // re-block must retire the intent because the timestamp cannot.
         final second = ContentBlocklistRepository(prefs: prefs);
         await second.syncBlockListsInBackground(
           mockClient,
@@ -4108,6 +4152,53 @@ void main() {
         );
         expect(prefs.getBool(flagKey), isNull);
         expect(prefs.getBool(retiredKey), isNull);
+
+        service.dispose();
+      },
+    );
+
+    test(
+      'persists pending-unblock retirement during an in-memory merge',
+      () async {
+        SharedPreferences.setMockInitialValues(<String, Object>{
+          'blocklist_active_pubkey': ourPubkey,
+          'blocked_users_list.$ourPubkey': jsonEncode([blockB]),
+          'pending_unblocks.$ourPubkey': jsonEncode({blockA: 1500}),
+        });
+        prefs = await SharedPreferences.getInstance();
+        when(() => mockClient.queryEvents(any())).thenAnswer((
+          invocation,
+        ) async {
+          final filters = invocation.positionalArguments[0] as List<Filter>;
+          final kinds = filters.first.kinds ?? const <int>[];
+          if (kinds.contains(30000)) {
+            return [
+              ownBlockEvent([blockB]),
+            ];
+          }
+          if (kinds.contains(10000)) {
+            return [ownMuteEvent(const [])];
+          }
+          return <Event>[];
+        });
+        when(
+          () => mockClient.publishEvent(any()),
+        ).thenAnswer((_) async => const PublishFailed());
+
+        final service = ContentBlocklistRepository(prefs: prefs);
+        await service.syncBlockListsInBackground(
+          mockClient,
+          mockSigner,
+          ourPubkey,
+        );
+        await pumpEventQueue();
+
+        final pending =
+            jsonDecode(
+                  prefs.getString('pending_unblocks.$ourPubkey')!,
+                )
+                as Map<String, dynamic>;
+        expect(pending, isNot(contains(blockA)));
 
         service.dispose();
       },

--- a/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
+++ b/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
@@ -1149,6 +1149,138 @@ void main() {
       },
     );
 
+    test(
+      'first identity prefers an existing scoped pending-unblock map',
+      () async {
+        SharedPreferences.setMockInitialValues({
+          'pending_unblocks': jsonEncode({blockerX: 2000}),
+          'pending_unblocks.$accountA': jsonEncode({someoneElse: 2000}),
+        });
+        final prefs = await SharedPreferences.getInstance();
+        final service = ContentBlocklistRepository(prefs: prefs);
+
+        await service.syncMuteListsInBackground(mockNostrService, accountA);
+        await pumpEventQueue();
+
+        expect(prefs.getString('pending_unblocks'), isNull);
+        controller.add(
+          Event(
+              accountA,
+              10000,
+              const [
+                ['p', blockerX],
+              ],
+              '',
+              createdAt: 1000,
+            )
+            ..id = 'mute-list-after-partial-migration'
+            ..sig = 'signature',
+        );
+        await Future<void>.delayed(Duration.zero);
+        expect(service.isMutedByUs(blockerX), isTrue);
+
+        service.dispose();
+      },
+    );
+
+    test('recorded identity recovers a legacy pending-unblock map', () async {
+      SharedPreferences.setMockInitialValues({
+        'blocklist_active_pubkey': accountA,
+        'pending_unblocks': jsonEncode({blockerX: 2000}),
+      });
+      final prefs = await SharedPreferences.getInstance();
+      final service = ContentBlocklistRepository(prefs: prefs);
+      final signer = _MockBlockListSigner();
+      when(() => signer.isAuthenticated).thenReturn(true);
+      when(
+        () => mockNostrService.queryEvents(any()),
+      ).thenAnswer((_) async => []);
+      when(
+        () => signer.createAndSignEvent(
+          kind: any(named: 'kind'),
+          content: any(named: 'content'),
+          tags: any(named: 'tags'),
+        ),
+      ).thenAnswer(
+        (invocation) async =>
+            Event(
+                accountA,
+                invocation.namedArguments[#kind] as int,
+                invocation.namedArguments[#tags] as List<List<String>>,
+                invocation.namedArguments[#content] as String,
+                createdAt: 3000,
+              )
+              ..id = 'recovered-pending-unblock'
+              ..sig = 'signature',
+      );
+      when(() => mockNostrService.publishEvent(any())).thenAnswer(
+        (invocation) async => PublishSuccess(
+          event: invocation.positionalArguments.first as Event,
+        ),
+      );
+
+      await service.syncBlockListsInBackground(
+        mockNostrService,
+        signer,
+        accountA,
+      );
+      await pumpEventQueue();
+
+      expect(prefs.getString('pending_unblocks'), isNull);
+      expect(
+        jsonDecode(prefs.getString('pending_unblocks.$accountA')!),
+        containsPair(blockerX, 2000),
+      );
+      expect(await service.retryPendingMuteListPublish(), isTrue);
+
+      service.dispose();
+    });
+
+    test('recorded identity drops stale pending-unblock legacy data', () async {
+      SharedPreferences.setMockInitialValues({
+        'blocklist_active_pubkey': accountA,
+        'pending_unblocks': jsonEncode({blockerX: 1000}),
+        'pending_unblocks.$accountA': jsonEncode({someoneElse: 2000}),
+      });
+      final prefs = await SharedPreferences.getInstance();
+      final service = ContentBlocklistRepository(prefs: prefs);
+
+      await service.syncMuteListsInBackground(mockNostrService, accountA);
+      await pumpEventQueue();
+
+      expect(prefs.getString('pending_unblocks'), isNull);
+      expect(
+        jsonDecode(prefs.getString('pending_unblocks.$accountA')!),
+        equals({someoneElse: 2000}),
+      );
+
+      service.dispose();
+    });
+
+    test(
+      'recorded identity recovers when scoped pending unblocks are corrupt',
+      () async {
+        SharedPreferences.setMockInitialValues({
+          'blocklist_active_pubkey': accountA,
+          'pending_unblocks': jsonEncode({blockerX: 2000}),
+          'pending_unblocks.$accountA': 'not-json',
+        });
+        final prefs = await SharedPreferences.getInstance();
+        final service = ContentBlocklistRepository(prefs: prefs);
+
+        await service.syncMuteListsInBackground(mockNostrService, accountA);
+        await pumpEventQueue();
+
+        expect(prefs.getString('pending_unblocks'), isNull);
+        expect(
+          jsonDecode(prefs.getString('pending_unblocks.$accountA')!),
+          equals({blockerX: 2000}),
+        );
+
+        service.dispose();
+      },
+    );
+
     test('first identity adopts legacy un-namespaced persisted data', () async {
       SharedPreferences.setMockInitialValues({
         'blocked_users_list': jsonEncode([blockerX]),
@@ -1204,6 +1336,9 @@ void main() {
       // down with it.
       final service = ContentBlocklistRepository(prefs: mockPrefs);
       expect(service.totalBlockedCount, equals(0));
+
+      await service.syncMuteListsInBackground(mockNostrService, accountA);
+      await pumpEventQueue();
 
       service.dispose();
     });
@@ -3633,6 +3768,31 @@ void main() {
         },
       );
 
+      test('first identity scopes an unblock written before sync', () async {
+        SharedPreferences.setMockInitialValues(<String, Object>{});
+        final prefs = await SharedPreferences.getInstance();
+        final service = ContentBlocklistRepository(prefs: prefs);
+        await service.blockUser(target);
+        await service.unblockUser(target);
+        expect(prefs.getString('pending_unblocks'), isNotNull);
+        when(() => mockSigner.isAuthenticated).thenReturn(true);
+
+        await service.syncBlockListsInBackground(
+          mockClient,
+          mockSigner,
+          ourPubkey,
+        );
+        await pumpEventQueue();
+
+        expect(prefs.getString('pending_unblocks'), isNull);
+        final pending =
+            jsonDecode(
+                  prefs.getString('pending_unblocks.$ourPubkey')!,
+                )
+                as Map<String, dynamic>;
+        expect(pending, contains(target));
+      });
+
       test('republishes so the relay drops the stale tag', () async {
         final prefs = await prefsAfterAWithheldUnblock();
         final ownList = StreamController<Event>.broadcast();
@@ -3710,6 +3870,12 @@ void main() {
           ourPubkey,
         );
         await second.blockUser(target);
+        final persistedAfterReblock =
+            jsonDecode(
+                  prefs.getString('pending_unblocks.$ourPubkey')!,
+                )
+                as Map<String, dynamic>;
+        expect(persistedAfterReblock, isNot(contains(target)));
         // The retire persists fire-and-forget, matching `_saveMutedUsers` in
         // the same method, so let it land before the restart reads prefs.
         await Future<void>.delayed(Duration.zero);

--- a/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
+++ b/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
@@ -3953,6 +3953,61 @@ void main() {
         expect(tags, isNot(contains(equals(['p', target]))));
       });
 
+      test(
+        'reconciles a stale unblock and a missing block with one publish',
+        () async {
+          const stillBlocked =
+              '00000000000000000000000000000000'
+              '000000000000000000000000000000ee';
+          final prefs = await prefsAfterAWithheldUnblock();
+          await prefs.setString(
+            'blocked_users_list.$ourPubkey',
+            jsonEncode([stillBlocked]),
+          );
+          await prefs.setBool(
+            'block_list_migrated_to_mute_list.$ourPubkey',
+            true,
+          );
+          await prefs.setBool('block_list_retired.$ourPubkey', true);
+          final ownList = StreamController<Event>.broadcast();
+          addTearDown(ownList.close);
+          when(
+            () => mockClient.subscribe(any()),
+          ).thenAnswer((_) => ownList.stream);
+          stubHealthy();
+          stubReadSettled();
+
+          final restarted = ContentBlocklistRepository(prefs: prefs);
+          await restarted.syncBlockListsInBackground(
+            mockClient,
+            mockSigner,
+            ourPubkey,
+          );
+          await restarted.syncMuteListsInBackground(mockClient, ourPubkey);
+          await pumpEventQueue();
+          clearInteractions(mockSigner);
+
+          ownList.add(
+            buildEvent(
+              kind: 10000,
+              tags: const [
+                ['p', target],
+              ],
+              createdAt: 1000,
+            ),
+          );
+          await pumpEventQueue();
+
+          verify(
+            () => mockSigner.createAndSignEvent(
+              kind: 10000,
+              content: any(named: 'content'),
+              tags: any(named: 'tags'),
+            ),
+          ).called(1);
+        },
+      );
+
       test('blocking again retires the intent, so a later restart has no '
           'outstanding work', () async {
         final prefs = await prefsAfterAWithheldUnblock();

--- a/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
+++ b/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
@@ -1183,6 +1183,68 @@ void main() {
       },
     );
 
+    test(
+      'first identity makes an existing scoped pending unblock retryable',
+      () async {
+        SharedPreferences.setMockInitialValues({
+          'pending_unblocks': jsonEncode(<String, int>{}),
+          'pending_unblocks.$accountA': jsonEncode({someoneElse: 2000}),
+          'block_list_migrated_to_mute_list.$accountA': true,
+          'block_list_retired.$accountA': true,
+        });
+        final prefs = await SharedPreferences.getInstance();
+        final signer = _MockBlockListSigner();
+        when(() => signer.isAuthenticated).thenReturn(true);
+        when(
+          () => mockNostrService.queryEventsDetailed(
+            any(),
+            requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+          ),
+        ).thenAnswer(
+          (_) async => (
+            events: <Event>[],
+            timedOut: false,
+            noRelays: false,
+          ),
+        );
+        when(
+          () => signer.createAndSignEvent(
+            kind: any(named: 'kind'),
+            content: any(named: 'content'),
+            tags: any(named: 'tags'),
+          ),
+        ).thenAnswer(
+          (invocation) async =>
+              Event(
+                  accountA,
+                  invocation.namedArguments[#kind] as int,
+                  invocation.namedArguments[#tags] as List<List<String>>,
+                  invocation.namedArguments[#content] as String,
+                  createdAt: 3000,
+                )
+                ..id = 'retried-scoped-pending-unblock'
+                ..sig = 'signature',
+        );
+        when(() => mockNostrService.publishEvent(any())).thenAnswer(
+          (invocation) async => PublishSuccess(
+            event: invocation.positionalArguments.first as Event,
+          ),
+        );
+        final service = ContentBlocklistRepository(prefs: prefs);
+
+        await service.syncBlockListsInBackground(
+          mockNostrService,
+          signer,
+          accountA,
+        );
+        await pumpEventQueue();
+
+        expect(await service.retryPendingMuteListPublish(), isTrue);
+
+        service.dispose();
+      },
+    );
+
     test('recorded identity recovers a legacy pending-unblock map', () async {
       SharedPreferences.setMockInitialValues({
         'blocklist_active_pubkey': accountA,
@@ -1387,6 +1449,35 @@ void main() {
       service.dispose();
     });
 
+    test(
+      'keeps legacy pending unblocks when the scoped copy reports failure',
+      () async {
+        final mockPrefs = _MockSharedPreferences();
+        when(() => mockPrefs.getString(any())).thenReturn(null);
+        when(
+          () => mockPrefs.getString('blocklist_active_pubkey'),
+        ).thenReturn(accountA);
+        when(
+          () => mockPrefs.getString('pending_unblocks'),
+        ).thenReturn(jsonEncode({blockerX: 2000}));
+        when(
+          () => mockPrefs.setString(any(), any()),
+        ).thenAnswer((_) async => true);
+        when(
+          () => mockPrefs.setString('pending_unblocks.$accountA', any()),
+        ).thenAnswer((_) async => false);
+        when(() => mockPrefs.remove(any())).thenAnswer((_) async => true);
+
+        final service = ContentBlocklistRepository(prefs: mockPrefs);
+        await service.syncMuteListsInBackground(mockNostrService, accountA);
+        await pumpEventQueue();
+
+        verifyNever(() => mockPrefs.remove('pending_unblocks'));
+
+        service.dispose();
+      },
+    );
+
     test('survives an asynchronous setString failure during '
         'migration', () async {
       final mockPrefs = _MockSharedPreferences();
@@ -1485,6 +1576,33 @@ void main() {
       expect(scoped, containsAll([blockerX, someoneElse]));
       expect(service.isBlocked(blockerX), isTrue);
       expect(service.isBlocked(someoneElse), isTrue);
+
+      service.dispose();
+    });
+
+    test('keeps the newest pending-unblock timestamp when a save races '
+        'migration', () async {
+      SharedPreferences.setMockInitialValues({
+        'blocklist_active_pubkey': accountA,
+        'blocked_users_list.$accountA': jsonEncode([blockerX]),
+        'pending_unblocks': jsonEncode({blockerX: 1}),
+      });
+      final prefs = await SharedPreferences.getInstance();
+      final service = ContentBlocklistRepository(prefs: prefs);
+
+      await service.unblockUser(blockerX);
+      final savedBeforeMigration =
+          (jsonDecode(prefs.getString('pending_unblocks.$accountA')!)
+                  as Map<String, dynamic>)[blockerX]
+              as int;
+      await service.syncMuteListsInBackground(mockNostrService, accountA);
+      await pumpEventQueue();
+
+      final migrated =
+          (jsonDecode(prefs.getString('pending_unblocks.$accountA')!)
+                  as Map<String, dynamic>)[blockerX]
+              as int;
+      expect(migrated, savedBeforeMigration);
 
       service.dispose();
     });

--- a/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
+++ b/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
@@ -1116,6 +1116,39 @@ void main() {
       service.dispose();
     });
 
+    test(
+      'switching accounts reloads the incoming account pending unblocks',
+      () async {
+        SharedPreferences.setMockInitialValues({
+          'blocklist_active_pubkey': accountA,
+          'pending_unblocks.$accountB': jsonEncode({someoneElse: 2000}),
+        });
+        final prefs = await SharedPreferences.getInstance();
+        final service = ContentBlocklistRepository(prefs: prefs);
+
+        await service.syncMuteListsInBackground(mockNostrService, accountA);
+        await service.syncMuteListsInBackground(mockNostrService, accountB);
+        controller.add(
+          Event(
+              accountB,
+              10000,
+              const [
+                ['p', someoneElse],
+              ],
+              '',
+              createdAt: 1000,
+            )
+            ..id = 'stale-account-b-mute-list'
+            ..sig = 'signature',
+        );
+        await Future<void>.delayed(Duration.zero);
+
+        expect(service.isMutedByUs(someoneElse), isFalse);
+
+        service.dispose();
+      },
+    );
+
     test('first identity adopts legacy un-namespaced persisted data', () async {
       SharedPreferences.setMockInitialValues({
         'blocked_users_list': jsonEncode([blockerX]),
@@ -3523,6 +3556,59 @@ void main() {
         expect(restarted.isMutedByUs(target), isTrue);
       });
 
+      test('is not re-adopted from a stale list in the same second', () async {
+        final prefs = await prefsAfterAWithheldUnblock();
+        final pending =
+            jsonDecode(
+                  prefs.getString('pending_unblocks.$ourPubkey')!,
+                )
+                as Map<String, dynamic>;
+        final unblockedAt = pending[target]! as int;
+        final ownList = StreamController<Event>.broadcast();
+        addTearDown(ownList.close);
+        when(
+          () => mockClient.subscribe(any()),
+        ).thenAnswer((_) => ownList.stream);
+
+        final restarted = ContentBlocklistRepository(prefs: prefs);
+        await restarted.syncMuteListsInBackground(mockClient, ourPubkey);
+        ownList.add(
+          buildEvent(
+            kind: 10000,
+            tags: const [
+              ['p', target],
+            ],
+            createdAt: unblockedAt,
+          ),
+        );
+        await Future<void>.delayed(Duration.zero);
+
+        expect(restarted.isMutedByUs(target), isFalse);
+      });
+
+      test('retries an unblock after the relay rejects its publish', () async {
+        SharedPreferences.setMockInitialValues(<String, Object>{});
+        final prefs = await SharedPreferences.getInstance();
+        stubHealthy();
+        stubReadSettled();
+        final service = ContentBlocklistRepository(prefs: prefs);
+        await service.syncBlockListsInBackground(
+          mockClient,
+          mockSigner,
+          ourPubkey,
+        );
+        await service.blockUser(target);
+        when(
+          () => mockClient.publishEvent(any()),
+        ).thenThrow(Exception('relay rejected publish'));
+
+        await service.unblockUser(target);
+
+        stubHealthy();
+        expect(await service.retryPendingMuteListPublish(), isTrue);
+        expect(await service.retryPendingMuteListPublish(), isFalse);
+      });
+
       test('republishes so the relay drops the stale tag', () async {
         final prefs = await prefsAfterAWithheldUnblock();
         final ownList = StreamController<Event>.broadcast();
@@ -3600,7 +3686,7 @@ void main() {
         await restarted.syncMuteListsInBackground(mockClient, ourPubkey);
         // The startup legacy migration publishes on its own; let it finish so
         // it is not mistaken for the reconcile republish below.
-        await Future<void>.delayed(const Duration(milliseconds: 20));
+        await pumpEventQueue();
         clearInteractions(mockSigner);
 
         ownList.add(


### PR DESCRIPTION
Fixes #8263. Follow-up to #8260, which closed the block half of the same hazard.

## The bug

#8260 made a withheld mute-list publish recoverable, but only for a **block**.
A block is derivable after a restart: it sits in the persisted block set and is
absent from the list the relay serves back. An **unblock** leaves no such trace.
Once the pubkey leaves `_runtimeBlocklist`, *"the user unblocked them"* and
*"another client muted them"* are the same state.

So `_applyOwnMuteListEvent` adopted the relay's stale `p` tag into
`_mutedPubkeys` on the next subscription delivery, `isMutedByUs` started
returning true again, and the account the user unblocked stayed filtered with
nothing in the UI to explain it.

Reproduced as the real sequence: block, unblock with the read inconclusive so
the publish is withheld, then a fresh repository from the same prefs. It fails
on `main`:

```
Expected: false
  Actual: <true>   // the stale relay p tag was re-adopted as a mute
```

## The fix

Record the unblock with a timestamp, persisted alongside the block set, and
consult it when adopting `p` tags. The list's `created_at` is what separates the
two readings:

| relay list vs. the unblock | meaning | action |
|---|---|---|
| older or same second | our publish never landed, tag is stale | don't adopt, republish |
| newer | someone muted them again after we unblocked | honour it, retire the intent |
| tag gone | the unblock landed | retire the intent |

Without the timestamp a legitimate later re-mute from another client would be
suppressed forever. Same-second timestamps cannot establish ordering, so an
explicit re-block retires the pending unblock before publishing the replacement
list.

Pending unblocks are account-scoped, reload on identity changes, and migrate
from pre-adoption storage without deleting the legacy copy until the scoped
write succeeds. A restart restores the retry signal from the persisted map.
When one relay event reveals both a stale unblock and a missing block, the two
reconciliation signals are coalesced into one replacement-list publish.

## Verification

- 163 tests green; package at **100% line coverage** (673/673 lines).
- The reproduction fails on the prior PR head and passes here.
- Focused mutation checks cover account reload, retry restoration, same-second
  handling, re-block retirement, migration durability, timestamp merging, and
  coalescing simultaneous recovery signals into one publish.
- `flutter analyze` clean.
- Format, ungrouped-test, skipped-test, placeholder-test, test-unit, and
  untested-services checks pass.

## Out of scope

Unchanged from the issue: this covers the mute list Divine authors. It does not
attempt to reconcile a list held only on relays Divine never queries. That is
#8257.
