### PR TITLE
fix(follow): never publish a contact list we could not read

### DIFF
--- a/mobile/lib/providers/repository_providers.dart
+++ b/mobile/lib/providers/repository_providers.dart
@@ -24,6 +24,7 @@ import 'package:openvine/constants/app_constants.dart';
 import 'package:openvine/constants/hive_box_names.dart';
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
 import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
+import 'package:openvine/providers/app_foreground_provider.dart';
 import 'package:openvine/providers/auth_providers.dart';
 import 'package:openvine/providers/curation_providers.dart';
 import 'package:openvine/providers/database_provider.dart';
@@ -204,6 +205,44 @@ FollowRepository followRepository(Ref ref) {
 
   return repository;
 }
+
+/// Retries a contact-list broadcast withheld by an inconclusive read.
+///
+/// [FollowRepository] refuses to replace a kind 3 it could not read, because
+/// doing so publishes an empty `content` over the user's relay list (#8265).
+/// The follow is kept locally, so something has to flush it: the next follow
+/// or unfollow rebroadcasts the whole list anyway, and this covers the user
+/// who followed once while relays were unhealthy and has not followed since.
+///
+/// Both signals it listens to mean "we might be healthy again" — the session
+/// becoming ready, and the app returning to the foreground. Mirrors
+/// `relayListDirtyPublishBridgeProvider`, which retries the withheld
+/// kind:10002 publish the same way.
+final contactListDirtyBroadcastBridgeProvider = Provider<void>((ref) {
+  Future<void> retryIfPending() async {
+    final readiness = ref.read(nostrSessionProvider);
+    if (!readiness.isReadyForActiveClient) return;
+    final pubkey = readiness.pubkey;
+    if (pubkey == null || pubkey.isEmpty) return;
+
+    final repository = ref.read(followRepositoryProvider);
+    if (await repository.retryPendingContactListBroadcast()) {
+      Log.info(
+        'Flushed a withheld kind 3 contact-list broadcast',
+        name: 'ContactListDirtyBroadcastBridge',
+        category: LogCategory.system,
+      );
+    }
+  }
+
+  ref.listen<NostrSessionReadiness>(
+    nostrSessionProvider,
+    (_, _) => unawaited(retryIfPending()),
+  );
+  ref.listen<bool>(appForegroundProvider, (previous, next) {
+    if (next && previous != true) unawaited(retryIfPending());
+  });
+});
 
 /// Provider for [CuratedListRepository] instance.
 ///

--- a/mobile/lib/startup/app_side_effects.dart
+++ b/mobile/lib/startup/app_side_effects.dart
@@ -8,6 +8,7 @@ import 'package:openvine/providers/moderation_providers.dart';
 import 'package:openvine/providers/notifications_providers.dart';
 import 'package:openvine/providers/relay_list_repository_provider.dart';
 import 'package:openvine/providers/relay_providers.dart';
+import 'package:openvine/providers/repository_providers.dart';
 import 'package:openvine/providers/social_providers.dart';
 import 'package:openvine/providers/supporter_providers.dart';
 import 'package:openvine/router/providers/route_normalization_provider.dart';
@@ -117,6 +118,10 @@ class AppShellSideEffects extends ConsumerWidget {
 
     // Retries a dirty kind:10002 relay-list publish once the session is ready.
     ref.watch(relayListDirtyPublishBridgeProvider);
+
+    // Retries a kind 3 contact-list broadcast withheld by an unreadable
+    // relay, once the session is ready or the app returns to the foreground.
+    ref.watch(contactListDirtyBroadcastBridgeProvider);
 
     // Drains notification preferences marked dirty while offline, then
     // registers the FCM token for the ready signer.

--- a/mobile/packages/follow_repository/lib/src/follow_repository.dart
+++ b/mobile/packages/follow_repository/lib/src/follow_repository.dart
@@ -229,6 +229,11 @@ class FollowRepository {
   // In-memory cache — following
   List<String> _followingPubkeys = [];
   Event? _currentUserContactListEvent;
+
+  // A contact-list broadcast withheld because the read that precedes it came
+  // back inconclusive. Flushed by [retryPendingContactListBroadcast] and by
+  // the next follow or unfollow, which rebroadcasts the whole list anyway.
+  bool _contactListBroadcastPending = false;
   bool _isInitialized = false;
   final Completer<void> _initializedCompleter = Completer<void>();
 
@@ -2641,6 +2646,79 @@ class FollowRepository {
     return publishable;
   }
 
+  /// How long the pre-broadcast read waits for every relay to settle.
+  ///
+  /// Deliberately shorter than the 5s default: an expiry reports `timedOut`,
+  /// which withholds the broadcast, so erring short errs toward not
+  /// overwriting. It also bounds what a follow tap costs.
+  static const _contactListReadTimeout = Duration(seconds: 3);
+
+  /// Re-read our own kind 3 and report whether the answer was conclusive.
+  ///
+  /// Returns `false` when no relay settled the query — a timeout, or a
+  /// fan-out no relay took. That is not the same as "this account follows
+  /// nobody", and the difference decides whether it is safe to replace the
+  /// event: kind 3 is replaceable, so a broadcast built on an unread answer
+  /// deletes whatever only the unread event held. A *settled* answer of zero
+  /// events is conclusive and returns `true`, so a first-ever follow still
+  /// publishes.
+  ///
+  /// [NostrClient.queryEvents] cannot express this — it drops `timedOut` and
+  /// `noRelays` — which is why the detailed form is used, with
+  /// `requireAllRelaysSettled` so a relay abandoned by the settle window
+  /// arrives as a timeout rather than as an empty answer.
+  Future<bool> _refreshCurrentUserContactList() async {
+    final pubkey = _nostrClient.publicKey;
+    if (pubkey.isEmpty) return false;
+
+    final result = await _nostrClient.queryEventsDetailed(
+      [
+        Filter(authors: [pubkey], kinds: const [EventKind.contactList]),
+      ],
+      requireAllRelaysSettled: true,
+      timeout: _contactListReadTimeout,
+    );
+
+    var newest = _currentUserContactListEvent;
+    for (final event in result.events) {
+      if (event.pubkey != pubkey) continue;
+      if (event.kind != EventKind.contactList) continue;
+      final current = newest;
+      if (current != null && event.createdAt <= current.createdAt) continue;
+      newest = event;
+    }
+    _currentUserContactListEvent = newest;
+
+    return !result.timedOut && !result.noRelays;
+  }
+
+  /// Rebroadcast a contact list whose publish was withheld by an inconclusive
+  /// read.
+  ///
+  /// A no-op unless something is pending, so callers can fire it on any "we
+  /// might be healthy again" signal. Follows and unfollows rebroadcast the
+  /// whole list themselves, so this only matters for a user who followed once
+  /// while relays were unhealthy and has not followed since.
+  ///
+  /// Returns whether the broadcast reached a relay. [_broadcastContactList]
+  /// throws when the publish itself fails; this is a background retry with no
+  /// caller to surface that to, so it is logged and reported as `false` rather
+  /// than propagated. The pending flag stays set, so the next signal retries.
+  Future<bool> retryPendingContactListBroadcast() async {
+    if (!_contactListBroadcastPending) return false;
+    try {
+      await _broadcastContactList();
+      return !_contactListBroadcastPending;
+    } on Object catch (e) {
+      Log.warning(
+        'Retry of a withheld contact list broadcast failed: $e',
+        name: 'FollowRepository',
+        category: LogCategory.system,
+      );
+      return false;
+    }
+  }
+
   /// Broadcast updated contact list to network (Kind 3 event)
   Future<void> _broadcastContactList() async {
     // Last line of defence: [executeFollowAction] appends without validating,
@@ -2652,6 +2730,22 @@ class FollowRepository {
       source: 'in-memory following list',
     );
     _emitFollowingList();
+
+    // Establish what the relay currently holds before replacing it. Without
+    // this, a cold start publishes `content: ''` over whatever was there —
+    // `_currentUserContactListEvent` is memory-only, and NIP-02 puts the
+    // user's relay list in that field (#8265). The follow is already applied
+    // locally and persisted, so withholding costs propagation, not the follow.
+    if (!await _refreshCurrentUserContactList()) {
+      _contactListBroadcastPending = true;
+      Log.warning(
+        'Withholding contact list broadcast - could not confirm the current '
+        'kind 3. Follows stay local until a read succeeds.',
+        name: 'FollowRepository',
+        category: LogCategory.system,
+      );
+      return;
+    }
 
     final contactList = ContactList();
     for (final pubkey in _publishableFollows()) {
@@ -2672,6 +2766,7 @@ class FollowRepository {
     _cacheUserEvent?.call(event);
 
     _currentUserContactListEvent = event;
+    _contactListBroadcastPending = false;
 
     Log.debug(
       'Broadcasted contact list: ${event.id}',

--- a/mobile/packages/follow_repository/test/src/follow_repository_cached_test.dart
+++ b/mobile/packages/follow_repository/test/src/follow_repository_cached_test.dart
@@ -9,10 +9,32 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:follow_repository/follow_repository.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/nostr_sdk.dart';
 
 import '../../../cache_sync/test/fake_cache_dao.dart';
 
-class _MockNostrClient extends Mock implements NostrClient {}
+class _MockNostrClient extends Mock implements NostrClient {
+  _MockNostrClient() {
+    // Self-registered so the stub below works in every file that builds this
+    // mock, whether or not that file has its own `setUpAll`. Idempotent.
+    registerFallbackValue(Duration.zero);
+    // The pre-broadcast read of our own kind 3 goes through
+    // `queryEventsDetailed` so it can tell a relay's "I hold nothing" apart
+    // from an answer nobody gave (#8265). Default to a *settled* empty answer
+    // — the relay replied and holds nothing — which is the state every test
+    // here was written in, and which still broadcasts. Tests about the
+    // inconclusive read override this with `timedOut` or `noRelays`.
+    when(
+      () => queryEventsDetailed(
+        any(),
+        requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+        timeout: any(named: 'timeout'),
+      ),
+    ).thenAnswer(
+      (_) async => (events: <Event>[], timedOut: false, noRelays: false),
+    );
+  }
+}
 
 class _RecordingCacheDao extends FakeCacheDao {
   Duration? lastTtl;

--- a/mobile/packages/follow_repository/test/src/follow_repository_test.dart
+++ b/mobile/packages/follow_repository/test/src/follow_repository_test.dart
@@ -17,7 +17,28 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../../cache_sync/test/fake_cache_dao.dart';
 
-class _MockNostrClient extends Mock implements NostrClient {}
+class _MockNostrClient extends Mock implements NostrClient {
+  _MockNostrClient() {
+    // Self-registered so the stub below works in every file that builds this
+    // mock, whether or not that file has its own `setUpAll`. Idempotent.
+    registerFallbackValue(Duration.zero);
+    // The pre-broadcast read of our own kind 3 goes through
+    // `queryEventsDetailed` so it can tell a relay's "I hold nothing" apart
+    // from an answer nobody gave (#8265). Default to a *settled* empty answer
+    // — the relay replied and holds nothing — which is the state every test
+    // here was written in, and which still broadcasts. Tests about the
+    // inconclusive read override this with `timedOut` or `noRelays`.
+    when(
+      () => queryEventsDetailed(
+        any(),
+        requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+        timeout: any(named: 'timeout'),
+      ),
+    ).thenAnswer(
+      (_) async => (events: <Event>[], timedOut: false, noRelays: false),
+    );
+  }
+}
 
 class _MockFunnelcakeApiClient extends Mock implements FunnelcakeApiClient {}
 
@@ -671,6 +692,256 @@ void main() {
         expect(repository.isFollowing(testTargetPubkey), isFalse);
         expect(repository.followingCount, 0);
       });
+    });
+
+    group('inconclusive own contact-list read (#8265)', () {
+      void stubContactListRead({
+        List<Event> events = const <Event>[],
+        bool timedOut = false,
+        bool noRelays = false,
+      }) {
+        when(
+          () => mockNostrClient.queryEventsDetailed(
+            any(),
+            requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+            timeout: any(named: 'timeout'),
+          ),
+        ).thenAnswer(
+          (_) async => (
+            events: events,
+            timedOut: timedOut,
+            noRelays: noRelays,
+          ),
+        );
+      }
+
+      void stubBroadcastSucceeds() {
+        final mockEvent = _MockEvent();
+        when(() => mockEvent.id).thenReturn(testCurrentUserPubkey);
+        when(() => mockEvent.content).thenReturn('');
+        when(
+          () => mockNostrClient.sendContactList(
+            any(),
+            any(),
+            tempRelays: any(named: 'tempRelays'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((_) async => mockEvent);
+      }
+
+      test('following does not broadcast when the read timed out', () async {
+        stubBroadcastSucceeds();
+        stubContactListRead(timedOut: true);
+
+        await repository.initialize();
+        await repository.follow(testTargetPubkey);
+
+        verifyNever(
+          () => mockNostrClient.sendContactList(
+            any(),
+            any(),
+            tempRelays: any(named: 'tempRelays'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        );
+      });
+
+      test(
+        'following does not broadcast when no relay took the query',
+        () async {
+          stubBroadcastSucceeds();
+          stubContactListRead(noRelays: true);
+
+          await repository.initialize();
+          await repository.follow(testTargetPubkey);
+
+          verifyNever(
+            () => mockNostrClient.sendContactList(
+              any(),
+              any(),
+              tempRelays: any(named: 'tempRelays'),
+              targetRelays: any(named: 'targetRelays'),
+            ),
+          );
+        },
+      );
+
+      test(
+        'the follow still applies locally when the broadcast is withheld',
+        () async {
+          stubBroadcastSucceeds();
+          stubContactListRead(timedOut: true);
+
+          await repository.initialize();
+          await repository.follow(testTargetPubkey);
+
+          expect(repository.isFollowing(testTargetPubkey), isTrue);
+          expect(repository.followingCount, 1);
+        },
+      );
+
+      test(
+        'unfollowing does not broadcast when the read is inconclusive',
+        () async {
+          SharedPreferences.setMockInitialValues({
+            'following_list_$testCurrentUserPubkey': '["$testTargetPubkey"]',
+          });
+          stubBroadcastSucceeds();
+          stubContactListRead(timedOut: true);
+
+          await repository.initialize();
+          await repository.unfollow(testTargetPubkey);
+
+          expect(repository.isFollowing(testTargetPubkey), isFalse);
+          verifyNever(
+            () => mockNostrClient.sendContactList(
+              any(),
+              any(),
+              tempRelays: any(named: 'tempRelays'),
+              targetRelays: any(named: 'targetRelays'),
+            ),
+          );
+        },
+      );
+
+      test('a settled empty read still broadcasts, so a first follow reaches '
+          'the relay', () async {
+        stubBroadcastSucceeds();
+        stubContactListRead();
+
+        await repository.initialize();
+        await repository.follow(testTargetPubkey);
+
+        verify(
+          () => mockNostrClient.sendContactList(
+            any(),
+            any(),
+            tempRelays: any(named: 'tempRelays'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).called(1);
+      });
+
+      test('a withheld broadcast is flushed by the retry, preserving the '
+          "relay's content", () async {
+        stubBroadcastSucceeds();
+        stubContactListRead(timedOut: true);
+
+        await repository.initialize();
+        await repository.follow(testTargetPubkey);
+        expect(await repository.retryPendingContactListBroadcast(), isFalse);
+
+        final existing = _MockEvent();
+        when(() => existing.id).thenReturn('existing-contact-list');
+        when(() => existing.pubkey).thenReturn(testCurrentUserPubkey);
+        when(() => existing.kind).thenReturn(EventKind.contactList);
+        when(() => existing.createdAt).thenReturn(1000);
+        when(() => existing.content).thenReturn('{"wss://relay.example":{}}');
+        when(() => existing.tags).thenReturn(const []);
+        stubContactListRead(events: [existing]);
+
+        expect(await repository.retryPendingContactListBroadcast(), isTrue);
+
+        final content =
+            verify(
+                  () => mockNostrClient.sendContactList(
+                    any(),
+                    captureAny(),
+                    tempRelays: any(named: 'tempRelays'),
+                    targetRelays: any(named: 'targetRelays'),
+                  ),
+                ).captured.last
+                as String;
+        expect(content, '{"wss://relay.example":{}}');
+      });
+
+      test('the retry is a no-op when nothing is pending', () async {
+        stubBroadcastSucceeds();
+        stubContactListRead();
+
+        await repository.initialize();
+        await repository.follow(testTargetPubkey);
+        clearInteractions(mockNostrClient);
+
+        expect(await repository.retryPendingContactListBroadcast(), isFalse);
+        verifyNever(
+          () => mockNostrClient.sendContactList(
+            any(),
+            any(),
+            tempRelays: any(named: 'tempRelays'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        );
+      });
+
+      test(
+        'a retry whose publish fails reports false and stays pending',
+        () async {
+          stubBroadcastSucceeds();
+          stubContactListRead(timedOut: true);
+
+          await repository.initialize();
+          await repository.follow(testTargetPubkey);
+
+          // Read now succeeds, but the publish does not: _broadcastContactList
+          // throws, and a background retry has no caller to surface that to.
+          stubContactListRead();
+          when(
+            () => mockNostrClient.sendContactList(
+              any(),
+              any(),
+              tempRelays: any(named: 'tempRelays'),
+              targetRelays: any(named: 'targetRelays'),
+            ),
+          ).thenAnswer((_) async => null);
+
+          expect(await repository.retryPendingContactListBroadcast(), isFalse);
+
+          // Still pending, so a later signal retries rather than dropping it.
+          stubBroadcastSucceeds();
+          expect(await repository.retryPendingContactListBroadcast(), isTrue);
+        },
+      );
+
+      test(
+        'keeps the newest kind 3 when the relay serves several versions',
+        () async {
+          stubBroadcastSucceeds();
+
+          _MockEvent contactList(int createdAt, String content) {
+            final event = _MockEvent();
+            when(() => event.id).thenReturn('contact-list-$createdAt');
+            when(() => event.pubkey).thenReturn(testCurrentUserPubkey);
+            when(() => event.kind).thenReturn(EventKind.contactList);
+            when(() => event.createdAt).thenReturn(createdAt);
+            when(() => event.content).thenReturn(content);
+            when(() => event.tags).thenReturn(const []);
+            return event;
+          }
+
+          // Newest first, so the older one exercises the skip rather than the
+          // adopt. A relay that has not merged its replaceable rows yet can
+          // serve both.
+          stubContactListRead(
+            events: [contactList(2000, 'newer'), contactList(1000, 'older')],
+          );
+
+          await repository.initialize();
+          await repository.follow(testTargetPubkey);
+
+          final content =
+              verify(
+                    () => mockNostrClient.sendContactList(
+                      any(),
+                      captureAny(),
+                      tempRelays: any(named: 'tempRelays'),
+                      targetRelays: any(named: 'targetRelays'),
+                    ),
+                  ).captured.last
+                  as String;
+          expect(content, 'newer');
+        },
+      );
     });
 
     // Regression: a real user's Kind 3 event carried a `["p","nos"]` entry,

--- a/mobile/test/startup/app_side_effects_test.dart
+++ b/mobile/test/startup/app_side_effects_test.dart
@@ -15,6 +15,7 @@ import 'package:openvine/providers/moderation_providers.dart';
 import 'package:openvine/providers/notifications_providers.dart';
 import 'package:openvine/providers/relay_list_repository_provider.dart';
 import 'package:openvine/providers/relay_providers.dart';
+import 'package:openvine/providers/repository_providers.dart';
 import 'package:openvine/providers/social_providers.dart';
 import 'package:openvine/providers/supporter_providers.dart';
 import 'package:openvine/router/providers/route_normalization_provider.dart';
@@ -118,6 +119,7 @@ void main() {
       (ref) => onBlockedFollowReconcilerBuilt?.call(),
     ),
     relayListDirtyPublishBridgeProvider.overrideWithValue(null),
+    contactListDirtyBroadcastBridgeProvider.overrideWithValue(null),
     notificationPreferencesDirtySyncBridgeProvider.overrideWithValue((_) {}),
     pushNotificationSyncProvider.overrideWithValue(null),
     blocklistSyncBridgeProvider.overrideWithValue(null),
@@ -282,6 +284,7 @@ void main() {
       'relayStatisticsBridgeProvider',
       'relaySetChangeBridgeProvider',
       'relayListDirtyPublishBridgeProvider',
+      'contactListDirtyBroadcastBridgeProvider',
       'notificationPreferencesDirtySyncBridgeProvider',
       'pushNotificationSyncProvider',
       'blocklistSyncBridgeProvider',


### PR DESCRIPTION
Fixes #8265. Found by the #8258 audit.

## The bug

`_broadcastContactList` rebuilt the kind 3 from local state and took its
`content` from:

```dart
final content = _currentUserContactListEvent?.content ?? '';
```

That is the same shape as #6750 — same `?? ''` tell — on a more visible list.
`_currentUserContactListEvent` is a plain `Event?` (`:231`), written only in
memory and never persisted; only `_followingPubkeys` goes through
`_saveToLocalStorage`. So the asymmetry is identical to the mute list's: the
`p` tags survive a restart, the `content` does not, and on a cold start the
`??` publishes an empty `content` over whatever was there. NIP-02 puts the
user's relay list in that field.

Unlike #6750 there was **no read at all** on the publish path. `followUser`
guarded on `hasKeys` and nothing else. The startup hydration that would fill
the field (`_loadFromRelay`) runs only "when local cache and REST API are both
empty", through a subscribe-with-timeout that returns `null` for both absence
and failure — and logs the two identically:

```
No kind 3 contact list found on relay (user may genuinely follow nobody)
```

## The fix

Establish the current kind 3 through
`queryEventsDetailed(requireAllRelaysSettled: true)` before rebuilding, and
withhold the broadcast when the answer was not conclusive. A settled answer of
zero events stays conclusive, so a first-ever follow still publishes.

The read uses a **3s budget** rather than the 5s default — an expiry reports
`timedOut`, which withholds, so erring short errs toward not overwriting, and it
bounds what a follow tap costs. That reasoning is borrowed from #8220's
`_ownDmInboxAuthoritativeTimeout`.

The follow keeps applying and persisting locally — a relay hiccup should not
lose a follow — and the withheld broadcast is flushed by the next follow or
unfollow, or by `contactListDirtyBroadcastBridgeProvider` when the session
becomes ready or the app returns to the foreground. That bridge mirrors the
existing `relayListDirtyPublishBridgeProvider`, which retries the withheld
kind:10002 publish the same way.

## Behaviour change worth flagging

`_broadcastContactList` previously threw on every failure, and `follow` rolled
the follow back. A **withheld** broadcast now returns normally, so the follow
stays. A **failed publish** still throws and still rolls back — that path is
unchanged. This matches the decision taken for #6750: the safety/intent action
applies locally, and only propagation is deferred.

## Verification

- 317 tests pass; package coverage **100%** (VGV gate, no `min_coverage`
  override).
- Mutation run: disabling the guard turns 4 of the 8 new tests red. The other 4
  are invariant pins that hold either way by design.
- `flutter analyze lib test integration_test` clean; no generated-file churn
  (the bridge is a plain `Provider`, like its relay-list sibling).

New tests pin: no broadcast on `timedOut`; none on `noRelays`; the follow still
applies locally when withheld; unfollow behaves the same; a settled-empty read
still broadcasts; the retry flushes and preserves the relay's `content`; the
retry is a no-op with nothing pending; the newest kind 3 wins when a relay
serves several versions; and a retry whose publish fails reports false and
stays pending.

Every pre-existing test kept its assertions. `_MockNostrClient` now defaults
`queryEventsDetailed` to a *settled* empty answer — the state those tests were
written in, and one that still broadcasts.

## Not in scope

#8266 — the two `more p-tags wins` heuristics (`_pickBestContactList` and the
PersonalEventCache guard) pick a stale base and undo a legitimate unfollow.
They select a wrong base; they do not publish it. Filed separately because
fixing them changes startup hydration for every user.
