### PR TITLE
fix(dm): give a group message one shared rumor id

### DIFF
--- a/.github/workflows/mobile_service_integration_tests.yaml
+++ b/.github/workflows/mobile_service_integration_tests.yaml
@@ -63,7 +63,7 @@ jobs:
       #
       # The list is explicit rather than a glob over integration_test/e2e/,
       # because `service` and "runnable on a Linux CI runner" are different
-      # axes. Every suite in that directory is tagged `service`; these four
+      # axes. Every suite in that directory is tagged `service`; these five
       # are the ones this runner can actually execute. The remaining four are
       # excluded
       # for reasons no workflow change can fix:
@@ -85,7 +85,8 @@ jobs:
             integration_test/e2e/relay_list_admission_test.dart \
             integration_test/e2e/dm_inbox_relay_admission_test.dart \
             integration_test/e2e/reel_reply_retry_double_send_test.dart \
-            integration_test/e2e/block_leaves_kind3_follow_test.dart; do
+            integration_test/e2e/block_leaves_kind3_follow_test.dart \
+            integration_test/e2e/dm_group_delete_for_everyone_test.dart; do
             echo "── $suite"
             xvfb-run -a flutter test "$suite" --tags service -d linux
           done

--- a/mobile/docs/brainstorm/2026-08-28-group-delete-for-everyone-brainstorm.md
+++ b/mobile/docs/brainstorm/2026-08-28-group-delete-for-everyone-brainstorm.md
@@ -38,7 +38,7 @@ confirmed on the wire, so nothing surfaces the failure.
 
 ## Findings that shaped the exploration
 
-Full evidence in `tasks/findings_8188.md`. The four that changed the answer:
+The four findings that changed the answer:
 
 1. **The issue's stated mechanism is wrong.** Siblings do not differ by their
    p-tag *set* — the set is identical; only the *order* differs, because
@@ -152,8 +152,8 @@ sweep and the UI's sibling aggregation keep working unchanged.
 - **No schema migration.** Verified: `recoverFullSend` already treats its
   `rumorId` argument as an opaque queue handle (the rumor comes from
   `row.rumorEventJson`, the recipient from `row.recipientPubkey`); nothing
-  validates the format of `outgoing_dms.id`; `queuedRumorId` is only ever handed
-  back to `recoverFullSend`.
+  validates the format of `outgoing_dms.id`; recovery resolves the row through
+  the opaque handle for either a full-send retry or a self-wrap-only retry.
 - **`deleteMessageForEveryone` needs zero changes** — its existing single `e`
   tag becomes correct automatically.
 - **The receive path needs zero changes** — a recipient already stores under

--- a/mobile/docs/brainstorm/2026-08-28-group-delete-for-everyone-brainstorm.md
+++ b/mobile/docs/brainstorm/2026-08-28-group-delete-for-everyone-brainstorm.md
@@ -1,0 +1,220 @@
+# Brainstorm: group delete-for-everyone reaches only one recipient (#8188)
+
+Date: 2026-08-28
+
+## Problem Statement
+
+Deleting a group DM "for everyone" silently no-ops for every recipient except
+one. `sendGroupMessage` builds a **distinct rumor per recipient**, so recipient
+*i* stores the message under rumor id *i*; the sender persists exactly one row
+(keyed to the first live success) and `deleteMessageForEveryone` emits a single
+`['e', <that one id>]`. Recipients 2..N look up an id they have never seen and
+apply nothing. The sender's UI shows the bubble gone and the retraction is
+confirmed on the wire, so nothing surfaces the failure.
+
+## Constraints
+
+- Layered flow `UI -> BLoC/Cubit -> Repository -> Client`; this change lives
+  entirely in the repository layer (`mobile/packages/dm_repository`).
+- `dm_repository` and `db_client` are pure-Dart packages under the workspace;
+  `db_client` carries a Drift schema with a migration test, so any schema change
+  is a real migration plus a regenerated snapshot.
+- NIP-17 / NIP-59 / NIP-09 govern the wire format; the kind-5 travels
+  gift-wrapped, so the relay never sees it.
+- No technical debt, no skipped tests; every new behaviour needs a test that can
+  fail (`.claude/rules/testing.md`).
+
+## Prior Art
+
+- **#8174** (`cbba859b7`) — receive half: `_routeWrappedDeletion` applies wrapped
+  kind-5 deletions and is **conjunct** across `e` tags.
+- **#8184** (`4fcd18016`) — sender half for 1:1: delete-for-everyone became a
+  wrapped, durable NIP-17 rumor. The group case was split out to #8188.
+- **#8164**, **#8232** — concurrency and blocked-policy handling on the same path.
+- **#6046** — the same-second sibling-id collision that introduced the durable
+  `sendBatchId` token.
+- `divine-web/src/lib/dm.ts` — the first-party web client, which **already**
+  builds one rumor per group send and wraps it N times.
+
+## Findings that shaped the exploration
+
+Full evidence in `tasks/findings_8188.md`. The four that changed the answer:
+
+1. **The issue's stated mechanism is wrong.** Siblings do not differ by their
+   p-tag *set* — the set is identical; only the *order* differs, because
+   `buildRumor` prepends `['p', <addressee>]`. A NIP-01 id hashes the tags
+   *array*, so the rotation alone forks the ids. Measured: rotated -> 3 ids,
+   canonical -> 1 id.
+2. **"No receive-side change" is false.** `_routeWrappedDeletion` downgrades the
+   whole wrap to `deferred` if *any* `e` tag fails to resolve, and `deferred`
+   wraps are deliberately never ledgered. A group recipient can never hold the
+   other N-1 sibling ids, so a multi-`e` deletion would be deferred **forever**,
+   on every recipient, and re-decrypted on every later drain.
+3. **Every working group-DM client emits ONE shared rumor** — Amethyst (the NIP
+   author's reference client, whose source says *"every seal encodes the same
+   rumor id. This anchors cross-recipient dedupe + reaction/receipt targeting on
+   group sends"*), 0xchat, Coracle/Flotilla (`// Stabilize the event id across
+   the different wraps`), Nostrudel. Nobody sorts tags; they all reuse one rumor
+   object. NIP-59 says it outright: *"a **single** rumor may be wrapped and
+   addressed for each recipient individually"* (`59.md:108`).
+4. **The breakage is one-directional and it is ours.** Inbound group messages
+   already carry one id, so our receive path is fine. Only our *sends* are
+   unaddressable by peers — and by our own web client.
+
+## Approaches Explored
+
+### Approach A: multi-`e` deletion (the issue's suggestion)
+
+**Description:** Retain the sibling rumor ids at send time and emit one `e` tag
+per sibling on the deletion.
+
+**Layers affected:** Repository.
+
+**Pros:**
+- Small sender-side diff; spec-legal (NIP-09 permits "one or more" `e` tags).
+- The receive half genuinely does iterate all `e` tags.
+
+**Cons:**
+- **Permanently defers every group deletion on every recipient** (finding 2).
+  Not a correctness bug, but an unbounded background-work leak feeding a set
+  that is already an open follow-up from #8174.
+- Compensates for the divergence instead of removing it; leaves group reactions
+  and reply threading broken.
+
+**Complexity:** Low — and wrong.
+
+### Approach A': multi-`e` plus a receive-side rule change
+
+**Description:** As A, but relax the conjunct rule so a deletion is `processed`
+once at least one named target resolves.
+
+**Pros:** Keeps the issue's payload shape.
+
+**Cons:**
+- Breaks the case #8174 was written for: a deletion naming a target that has
+  genuinely not synced yet would be cemented and lost.
+- NIP-09 requires per-`e` authorship validation (`09.md:31`), which a client
+  cannot perform for an event it does not hold — so "treat unknown ids as done"
+  is not obviously safe.
+
+**Complexity:** Medium, with a real regression risk.
+
+### Approach B: one deletion rumor per recipient
+
+**Description:** Build N deletion rumors, each naming only that recipient's
+sibling id. Sibling ids are recoverable without new storage (the persisted row
+already carries content, `createdAt`, all recipients in original order,
+`messageKind` and `sendBatchId` — the full preimage).
+
+**Pros:**
+- No deferred pollution; each recipient's deletion resolves and is ledgered.
+- No schema change if the ids are recomputed.
+
+**Cons:**
+- `markMessageDeletionPending` stores exactly one `deletionRumorJson` for the
+  retry sweep, so N deletions need storage or deterministic rebuild.
+- Fixes only deletion. Group reactions and reply threading stay broken, and the
+  sender's second device stays broken.
+- Entrenches the divergence from every other client.
+
+**Complexity:** Medium.
+
+### Approach C: canonical rumor with an `outgoing_dms` PK migration
+
+**Description:** Emit one byte-identical rumor per group send; change the queue
+PK from `{id}` to `{id, recipientPubkey}` so N sibling rows can coexist.
+
+**Pros:** Removes the root cause; fixes deletion, reactions, replies and the
+sender's second device at once.
+
+**Cons:**
+- Drift PK migration v11 -> v12, plus schema dump and migration test.
+- ~31 production call sites and 14 test files on the outgoing-DM id surface.
+- **Silent-failure trap:** `_joinOrStartRecovery` is keyed `'full:${rumor.id}'`.
+  With a shared id, siblings 2..N join sibling 1's in-flight future instead of
+  publishing — a group send would reach one recipient.
+
+**Complexity:** High.
+
+### Approach C': canonical rumor with a per-recipient surrogate queue handle — **CHOSEN**
+
+**Description:** Build the rumor **once** per group send (all recipients as `p`
+tags, stable order) and hand that same rumor to every wrap — exactly what
+`divine-web`'s `createRecipientGiftWraps` does today, and what
+`_fanOutDeletion` already does for deletions. Give each queue row a
+per-recipient handle in the existing single-column `id` so the queue, the retry
+sweep and the UI's sibling aggregation keep working unchanged.
+
+**Layers affected:** Repository only (`dm_repository`), plus doc comments in
+`db_client`.
+
+**Pros:**
+- **No schema migration.** Verified: `recoverFullSend` already treats its
+  `rumorId` argument as an opaque queue handle (the rumor comes from
+  `row.rumorEventJson`, the recipient from `row.recipientPubkey`); nothing
+  validates the format of `outgoing_dms.id`; `queuedRumorId` is only ever handed
+  back to `recoverFullSend`.
+- **`deleteMessageForEveryone` needs zero changes** — its existing single `e`
+  tag becomes correct automatically.
+- **The receive path needs zero changes** — a recipient already stores under
+  `rumor.id`.
+- Dissolves C's two traps: the lock key and the UI map are keyed on the
+  surrogate, so both stay unique.
+- Fixes group reactions cross-visibility and group reply threading, which share
+  the same root.
+- Brings mobile in line with divine-web, Amethyst, 0xchat, Coracle and NIP-59.
+- Removes the per-recipient rumor loop rather than adding machinery.
+
+**Cons / risks:**
+- `outgoing_dms.id`'s documented invariant changes for group rows; existing rows
+  keep plain ids, so the keyspace is mixed (disjoint by separator, the same
+  precedent `_batchKeyOf` already relies on). Every doc comment must be corrected.
+- 1:1 sends keep the plain rumor id, so the surrogate is group-only — an
+  asymmetry that must be explicit and tested.
+- `_finalizeAfterRecipient*` and the cancel interlock currently pass
+  `rumors[i].id`; each must pass the surrogate. Missing one silently finalizes
+  the wrong row.
+- Forward-only: group messages already sent keep per-recipient ids and stay
+  undeletable-for-everyone. Accepted and to be documented.
+- A future per-recipient element in a `p` tag (e.g. a relay hint) would re-fork
+  the ids. Amethyst avoids this by putting hints on the gift wrap's `p` tag.
+  Guarded by an explicit test rather than convention.
+
+**Complexity:** Medium.
+
+## Recommendation
+
+**Approach C'.** It removes the cause rather than compensating for it, needs no
+migration, leaves the deletion and receive paths untouched, and converges four
+first- and third-party clients on one rumor identity. Inspired directly by
+divine-web's current behaviour, and independently corroborated by the NIP-59
+text and by every shipping group-DM client surveyed.
+
+Deliberately **not** in scope:
+- Changing whether the sender appears in the rumor's `p` tags. mobile excludes
+  the sender, matching Amethyst; divine-web and 0xchat include it. Both are
+  tolerated everywhere (room keys are Sets in every client). Recorded, not acted on.
+- The sender's own second device persisting a different sibling id. C' fixes it
+  inherently for new sends; no extra work is planned for it.
+
+## Open Questions for /plan
+
+- [ ] Exact surrogate handle format for group queue rows, and how 1:1 stays on
+      the plain rumor id.
+- [ ] Every call site that currently passes `rumors[i].id` and must pass the
+      surrogate (cancel interlock, `_finalizeAfterRecipient*`, `_stampQueuedRow`).
+- [ ] Whether `buildRumor` gains a group-shaped entry point or `sendGroupMessage`
+      assembles the tags and calls it once.
+- [ ] Shape of the 3-party real-socket test against the `fake_relay` harness.
+- [ ] Which existing group-send tests assert per-sibling ids and must be updated.
+
+## Prerequisites
+
+- [x] Worktree from `origin/main` — `.worktrees/8188-group-delete`,
+      branch `fix/8188-group-delete-canonical-rumor`, base `7732e48ce`.
+- [x] Correction comment posted on #8188.
+- [ ] None outstanding; no design or protocol decision is blocked.
+
+## Next Step
+
+`/plan 8188` — implementation plan against this direction.

--- a/mobile/integration_test/e2e/dm_group_delete_for_everyone_test.dart
+++ b/mobile/integration_test/e2e/dm_group_delete_for_everyone_test.dart
@@ -8,7 +8,6 @@ library;
 
 import 'package:db_client/db_client.dart';
 import 'package:dm_repository/dm_repository.dart';
-import 'package:drift/drift.dart' show Variable;
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
@@ -310,16 +309,20 @@ void main() {
         );
         expect(published.success, isTrue);
 
-        Future<int> reactionCount(_Party party) async {
-          final rows = await party.db
-              .customSelect(
-                'SELECT COUNT(*) c FROM dm_message_reactions '
-                'WHERE target_message_id = ?',
-                variables: [Variable<String>(sharedId)],
-              )
-              .getSingle();
-          return rows.data['c']! as int;
-        }
+        // Until #7338 lands, each recipient files an inbound group DM under
+        // its local 1:1 fallback conversation with the sender.
+        Future<int> reactionCount(_Party party) async =>
+            (await party.reactionsDao
+                    .watchForConversation(
+                      conversationId: DmRepository.computeConversationId([
+                        sender.pubkey,
+                        party.pubkey,
+                      ]),
+                      ownerPubkey: party.pubkey,
+                    )
+                    .first)
+                .where((row) => row.targetMessageId == sharedId)
+                .length;
 
         final landed = await waitFor(
           () async =>

--- a/mobile/integration_test/e2e/dm_group_delete_for_everyone_test.dart
+++ b/mobile/integration_test/e2e/dm_group_delete_for_everyone_test.dart
@@ -1,0 +1,339 @@
+// ABOUTME: E2E for #8188 — a group DM must carry ONE shared rumor id, so
+// ABOUTME: delete-for-everyone reaches every participant and a reaction from
+// ABOUTME: one member lands for the rest. Three real DmRepository stacks over
+// ABOUTME: real sockets. Requires: NO Docker stack — everything is local.
+
+@Tags(['service'])
+library;
+
+import 'package:db_client/db_client.dart';
+import 'package:dm_repository/dm_repository.dart';
+import 'package:drift/drift.dart' show Variable;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/client_utils/keys.dart';
+import 'package:nostr_sdk/nostr.dart';
+import 'package:nostr_sdk/relay/relay_base.dart';
+import 'package:nostr_sdk/relay/relay_status.dart';
+import 'package:nostr_sdk/relay/web_socket_connection_manager.dart';
+import 'package:nostr_sdk/signer/local_nostr_signer.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+import '../helpers/fake_relay.dart';
+
+/// Sends every socket to the in-process relay, whatever host was asked for.
+///
+/// `isRemoteSuppliedRelayUrlAllowed` refuses loopback by design, so the fake
+/// relay can never *be* an admitted target — it has to be reached through one.
+class _RedirectFactory implements WebSocketChannelFactory {
+  _RedirectFactory(this.port);
+
+  final int port;
+
+  @override
+  WebSocketChannel create(Uri uri) =>
+      WebSocketChannel.connect(Uri.parse('ws://127.0.0.1:$port${uri.path}'));
+}
+
+/// One participant's complete stack.
+typedef _Party = ({
+  String pubkey,
+  DmRepository repository,
+  DmReactionsRepository reactions,
+  DirectMessagesDao messages,
+  DmReactionsDao reactionsDao,
+  AppDatabase db,
+  Nostr nostr,
+});
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  const keyA =
+      '1111111111111111111111111111111111111111111111111111111111111111';
+  const keyB =
+      '2222222222222222222222222222222222222222222222222222222222222222';
+  const keyC =
+      '3333333333333333333333333333333333333333333333333333333333333333';
+  final pubA = getPublicKey(keyA);
+  final pubB = getPublicKey(keyB);
+  final pubC = getPublicKey(keyC);
+
+  Future<_Party> buildParty(FakeRelay relay, String privateKey) async {
+    final factory = _RedirectFactory(relay.port);
+    final signer = LocalNostrSigner(privateKey);
+    final pubkey = getPublicKey(privateKey);
+
+    RelayBase gen(String url) =>
+        RelayBase(url, RelayStatus(url), channelFactory: factory);
+    final nostr = Nostr(signer, [], gen, channelFactory: factory);
+
+    final relayManager = RelayManager(
+      config: RelayManagerConfig(
+        defaultRelayUrl: relay.url,
+        storage: InMemoryRelayStorage(),
+        autoReconnect: false,
+      ),
+      relayPool: nostr.relayPool,
+    );
+    final client = NostrClient.forTesting(
+      nostr: nostr,
+      relayManager: relayManager,
+    );
+
+    final db = AppDatabase.test(NativeDatabase.memory());
+    addTearDown(db.close);
+
+    final messageService = NIP17MessageService(
+      signer: signer,
+      senderPublicKey: pubkey,
+      nostrService: client,
+    );
+    final reactions = DmReactionsRepository(
+      reactionsDao: db.dmReactionsDao,
+      messageService: messageService,
+      userPubkey: pubkey,
+      conversationsDao: db.conversationsDao,
+      directMessagesDao: db.directMessagesDao,
+    );
+    final repository = DmRepository(
+      nostrClient: client,
+      directMessagesDao: db.directMessagesDao,
+      conversationsDao: db.conversationsDao,
+      outgoingDmsDao: db.outgoingDmsDao,
+      processedGiftWrapsDao: db.processedGiftWrapsDao,
+      userPubkey: pubkey,
+      signer: signer,
+      messageService: messageService,
+      reactionsRepository: reactions,
+    );
+    addTearDown(repository.stopListening);
+    addTearDown(nostr.relayPool.removeAll);
+
+    await client.initialize();
+    return (
+      pubkey: pubkey,
+      repository: repository,
+      reactions: reactions,
+      messages: db.directMessagesDao,
+      reactionsDao: db.dmReactionsDao,
+      db: db,
+      nostr: nostr,
+    );
+  }
+
+  /// Polls until [predicate] holds or the budget runs out, so the test waits
+  /// on the observable outcome rather than a fixed sleep.
+  Future<bool> waitFor(
+    Future<bool> Function() predicate, {
+    Duration budget = const Duration(seconds: 10),
+  }) async {
+    final deadline = DateTime.now().add(budget);
+    while (DateTime.now().isBefore(deadline)) {
+      if (await predicate()) return true;
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+    }
+    return predicate();
+  }
+
+  group('#8188 group delete-for-everyone', () {
+    testWidgets(
+      'every participant stores the message under ONE shared rumor id, and '
+      'delete-for-everyone retracts it for all of them',
+      (tester) async {
+        final relay = await FakeRelay.start(broadcast: true);
+        addTearDown(relay.stop);
+
+        final sender = await buildParty(relay, keyA);
+        final peerB = await buildParty(relay, keyB);
+        final peerC = await buildParty(relay, keyC);
+
+        await peerB.repository.startListening();
+        await peerC.repository.startListening();
+        // Both DM subscriptions must be registered before the send, or the
+        // broadcast has nowhere to land.
+        await waitFor(
+          () async =>
+              relay.receivedFrames
+                  .where(
+                    (f) =>
+                        f.isNotEmpty &&
+                        f[0] == 'REQ' &&
+                        f.length >= 2 &&
+                        (f[1] as String).startsWith('dm_inbox_'),
+                  )
+                  .length >=
+              2,
+        );
+
+        final results = await sender.repository.sendGroupMessage(
+          recipientPubkeys: [peerB.pubkey, peerC.pubkey],
+          content: 'group message for #8188',
+        );
+        expect(results.where((r) => r.success), hasLength(2));
+
+        final senderRow = await sender.messages.getMessagesForConversation(
+          DmRepository.computeConversationId([pubA, pubB, pubC]),
+          ownerPubkey: sender.pubkey,
+        );
+        expect(senderRow, hasLength(1));
+        final sharedId = senderRow.single.id;
+
+        // THE INVARIANT (#8188). Each recipient is looked up by the id the
+        // SENDER holds. Before the fix each party held a different rumor id —
+        // `buildRumor` prepends the addressee, so the siblings carried the
+        // same p-tag SET in a rotated ORDER and a NIP-01 id hashes the tags
+        // array — and this lookup could only ever resolve for one of them.
+        //
+        // Deliberately NOT keyed on the conversation id: an inbound group DM
+        // is still filed as a 1:1 with the sender
+        // (`_resolveConversationParticipants` falls back to `canonical1to1`
+        // when no group conversation exists locally yet), which is the
+        // separate, already-open #7338. Message identity is what #8188 is
+        // about, and it is what a retraction names.
+        final bothHoldIt = await waitFor(() async {
+          final b = await peerB.messages.getMessageById(
+            sharedId,
+            ownerPubkey: peerB.pubkey,
+          );
+          final c = await peerC.messages.getMessageById(
+            sharedId,
+            ownerPubkey: peerC.pubkey,
+          );
+          return b != null && c != null;
+        });
+        expect(
+          bothHoldIt,
+          isTrue,
+          reason:
+              'every participant must store the message under the SAME rumor '
+              'id — a per-recipient id makes it unaddressable by everyone but '
+              'its own holder',
+        );
+
+        await sender.repository.deleteMessageForEveryone(sharedId);
+
+        final retracted = await waitFor(() async {
+          final b = await peerB.messages.getMessageById(
+            sharedId,
+            ownerPubkey: peerB.pubkey,
+          );
+          final c = await peerC.messages.getMessageById(
+            sharedId,
+            ownerPubkey: peerC.pubkey,
+          );
+          return (b?.isDeleted ?? false) && (c?.isDeleted ?? false);
+        });
+
+        expect(
+          retracted,
+          isTrue,
+          reason:
+              'delete-for-everyone must retract the message on EVERY '
+              'participant, not just the one whose sibling id the sender '
+              'happened to persist',
+        );
+
+        // The sender's own copy is retracted too.
+        final own = await sender.messages.getMessageById(
+          sharedId,
+          ownerPubkey: sender.pubkey,
+        );
+        expect(own?.isDeleted, isTrue);
+      },
+    );
+
+    testWidgets(
+      'a reaction on the group message lands for EVERY participant, because '
+      'they all hold the id it names',
+      (tester) async {
+        final relay = await FakeRelay.start(broadcast: true);
+        addTearDown(relay.stop);
+
+        final sender = await buildParty(relay, keyA);
+        final peerB = await buildParty(relay, keyB);
+        final peerC = await buildParty(relay, keyC);
+
+        await peerB.repository.startListening();
+        await peerC.repository.startListening();
+        await waitFor(
+          () async =>
+              relay.receivedFrames
+                  .where(
+                    (f) =>
+                        f.isNotEmpty &&
+                        f[0] == 'REQ' &&
+                        f.length >= 2 &&
+                        (f[1] as String).startsWith('dm_inbox_'),
+                  )
+                  .length >=
+              2,
+        );
+
+        final groupId = DmRepository.computeConversationId([pubA, pubB, pubC]);
+        final sent = await sender.repository.sendGroupMessage(
+          recipientPubkeys: [peerB.pubkey, peerC.pubkey],
+          content: 'react to me',
+        );
+        expect(sent.where((r) => r.success), hasLength(2));
+
+        final senderRow = await sender.messages.getMessagesForConversation(
+          groupId,
+          ownerPubkey: sender.pubkey,
+        );
+        final sharedId = senderRow.single.id;
+
+        await waitFor(() async {
+          final b = await peerB.messages.getMessageById(
+            sharedId,
+            ownerPubkey: peerB.pubkey,
+          );
+          final c = await peerC.messages.getMessageById(
+            sharedId,
+            ownerPubkey: peerC.pubkey,
+          );
+          return b != null && c != null;
+        });
+
+        // The reaction's `e` tag names the reactor's LOCAL id for the target.
+        // On a mismatch the receiver cannot resolve the conversation and
+        // `persistIncoming` returns `deferred` — the reaction is never stored
+        // at all, and its wrap re-decrypts forever. So this lands for both
+        // recipients only because the id is now shared.
+        final published = await sender.reactions.publish(
+          conversationId: groupId,
+          targetMessageId: sharedId,
+          targetMessageAuthor: sender.pubkey,
+          emoji: '🔥',
+        );
+        expect(published.success, isTrue);
+
+        Future<int> reactionCount(_Party party) async {
+          final rows = await party.db
+              .customSelect(
+                'SELECT COUNT(*) c FROM dm_message_reactions '
+                'WHERE target_message_id = ?',
+                variables: [Variable<String>(sharedId)],
+              )
+              .getSingle();
+          return rows.data['c']! as int;
+        }
+
+        final landed = await waitFor(
+          () async =>
+              await reactionCount(peerB) > 0 && await reactionCount(peerC) > 0,
+        );
+
+        expect(
+          landed,
+          isTrue,
+          reason:
+              'a group reaction must reach every participant — with a '
+              'per-recipient rumor id it resolved for at most one of them',
+        );
+      },
+    );
+  });
+}

--- a/mobile/integration_test/helpers/fake_relay.dart
+++ b/mobile/integration_test/helpers/fake_relay.dart
@@ -17,20 +17,25 @@ import 'dart:io';
 /// - `REQ` → the configured [reply] event (if any), then `EOSE`
 /// - `EVENT` → `["OK", <id>, true, ""]`, so an OK-confirmed publish settles
 ///   instead of timing out into `retryablePending`
+/// - with [broadcast], `EVENT` is also forwarded to every OTHER open
+///   subscription, which is what a multi-party test needs
 class FakeRelay {
-  FakeRelay._(this._server, this.reply, this.okConfirms);
+  FakeRelay._(this._server, this.reply, this.okConfirms, this.broadcast);
 
   /// Starts a relay on an ephemeral loopback port.
   ///
   /// [reply] is the event served for any `REQ`; null answers `EOSE` only.
   /// Set [okConfirms] false to model a relay that accepts the frame but never
-  /// confirms it.
+  /// confirms it. Set [broadcast] true to fan a published `EVENT` out to every
+  /// other open subscription — off by default so existing tests, which assert
+  /// on what the relay was *sent*, see no extra traffic.
   static Future<FakeRelay> start({
     Map<String, dynamic>? reply,
     bool okConfirms = true,
+    bool broadcast = false,
   }) async {
     final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
-    final relay = FakeRelay._(server, reply, okConfirms);
+    final relay = FakeRelay._(server, reply, okConfirms, broadcast);
     server.listen(relay._handle, onError: (_) {});
     return relay;
   }
@@ -47,6 +52,23 @@ class FakeRelay {
 
   /// Whether an inbound `EVENT` is answered with `OK … true`.
   final bool okConfirms;
+
+  /// Whether a published `EVENT` is forwarded to other open subscriptions.
+  ///
+  /// Gift wraps are addressed by their outer `p` tag, and every party in a
+  /// multi-recipient test subscribes for its own pubkey, so this fans out to
+  /// every live subscription and lets each client's own filter decide. That
+  /// is coarser than a real relay but sufficient: the client discards wraps
+  /// it cannot decrypt.
+  final bool broadcast;
+
+  /// Live subscriptions per socket, so a broadcast can address them.
+  final Map<WebSocket, Set<String>> _subscriptions = {};
+
+  /// How many `EVENT` frames this relay has fanned out to subscribers.
+  /// Lets a multi-party test tell "the relay never forwarded it" apart from
+  /// "the client received it and dropped it".
+  int fannedOutFrames = 0;
 
   /// Every frame this relay received, in arrival order.
   final List<List<dynamic>> receivedFrames = [];
@@ -86,6 +108,7 @@ class FakeRelay {
 
     final socket = await WebSocketTransformer.upgrade(req);
     _sockets.add(socket);
+    _subscriptions[socket] = <String>{};
 
     // A client can close mid-exchange, and `readyState` still reads as open
     // for a moment after the sink is gone. An unguarded write then throws
@@ -113,20 +136,46 @@ class FakeRelay {
 
         if (frame[0] == 'REQ' && frame.length >= 2) {
           final subId = frame[1] as String;
+          _subscriptions[socket]?.add(subId);
           if (reply != null) {
             send(<dynamic>['EVENT', subId, reply]);
           }
           send(<dynamic>['EOSE', subId]);
-        } else if (frame[0] == 'EVENT' && frame.length >= 2 && okConfirms) {
+        } else if (frame[0] == 'CLOSE' && frame.length >= 2) {
+          _subscriptions[socket]?.remove(frame[1] as String);
+        } else if (frame[0] == 'EVENT' && frame.length >= 2) {
           final event = frame[1] as Map<String, dynamic>;
-          send(<dynamic>['OK', event['id'], true, '']);
+          if (okConfirms) {
+            send(<dynamic>['OK', event['id'], true, '']);
+          }
+          if (broadcast) _fanOut(from: socket, event: event);
         }
       },
       onError: (_) {},
     );
   }
 
+  /// Forwards [event] to every open subscription except the publisher's own.
+  void _fanOut({required WebSocket from, required Map<String, dynamic> event}) {
+    for (final entry in _subscriptions.entries) {
+      final target = entry.key;
+      if (identical(target, from)) continue;
+      if (target.readyState != WebSocket.open) continue;
+      for (final subId in entry.value) {
+        try {
+          target.add(jsonEncode(<dynamic>['EVENT', subId, event]));
+          fannedOutFrames++;
+          // Only an Error distinguishes "the client hung up" here.
+          // ignore: avoid_catching_errors
+        } on StateError {
+          // Subscriber went away mid-broadcast; nothing to deliver.
+        }
+      }
+    }
+  }
+
   Future<void> stop() async {
+    _subscriptions.clear();
     for (final socket in _sockets) {
       await socket.close().catchError((_) => null);
     }

--- a/mobile/lib/blocs/dm/conversation/conversation_bloc.dart
+++ b/mobile/lib/blocs/dm/conversation/conversation_bloc.dart
@@ -248,8 +248,8 @@ class ConversationBloc extends Bloc<ConversationEvent, ConversationState> {
       // reach relays. The sender's other devices will not see this
       // message on relay-only restore. Surface as a distinct status so
       // the UI can offer a self-wrap-only retry without re-delivering
-      // to the recipient. [lastPartialSend.rumorIds] carries the
-      // per-recipient rumor ids whose self-wrap publish failed, so
+      // to the recipient. [lastPartialSend.rumorIds] carries the durable queue
+      // handles whose self-wrap publish failed, so
       // retrying republishes only those self-wraps via
       // [recoverSelfWrap].
       final partialRumorIds = <String>[];
@@ -314,7 +314,7 @@ class ConversationBloc extends Bloc<ConversationEvent, ConversationState> {
       }
       if (partialRumorIds.isNotEmpty) {
         // Union with any outstanding partial: two concurrent sends that
-        // both end sentPartial must accumulate their rumor ids — the
+        // both end sentPartial must accumulate their queue handles — the
         // second overwrite silently orphaned the first send's self-wrap
         // recovery set. Stale ids (already recovered by the sweep) are
         // dropped by the recovery handler's ArgumentError-skip.

--- a/mobile/lib/blocs/dm/conversation/conversation_bloc.dart
+++ b/mobile/lib/blocs/dm/conversation/conversation_bloc.dart
@@ -276,7 +276,7 @@ class ConversationBloc extends Bloc<ConversationEvent, ConversationState> {
           throw Exception(result.error ?? 'Failed to send message');
         }
         if (result.selfWrapPublished == false) {
-          partialRumorIds.add(result.rumorEventId!);
+          partialRumorIds.add(result.queuedRumorId ?? result.rumorEventId!);
         }
       } else {
         final results = await _dmRepository.sendGroupMessage(
@@ -304,12 +304,11 @@ class ConversationBloc extends Bloc<ConversationEvent, ConversationState> {
             results.first.error ?? 'Failed to send group message',
           );
         }
-        // For groups, "self-wrap" is per-recipient. We collect the rumor
-        // ids of the successful per-recipient sends whose self-wrap
-        // failed — only those rumors need a recovery republish.
+        // For groups, "self-wrap" is per-recipient. Recovery needs each
+        // surviving durable queue handle, not the shared wire rumor id.
         for (final result in results) {
           if (result.success && result.selfWrapPublished == false) {
-            partialRumorIds.add(result.rumorEventId!);
+            partialRumorIds.add(result.queuedRumorId ?? result.rumorEventId!);
           }
         }
       }

--- a/mobile/lib/blocs/dm/conversation/conversation_state.dart
+++ b/mobile/lib/blocs/dm/conversation/conversation_state.dart
@@ -289,6 +289,8 @@ class ConversationState extends Equatable {
       if (persistedBatchKeys.contains(_batchKeyOf(batch.first))) {
         continue;
       }
+      // Legacy rows have no wire rumor JSON and therefore expose their queue
+      // handle as the bubble id; keep their representative deterministic.
       batch.sort((a, b) => a.id.compareTo(b.id));
       pendingBubbles.add(_outgoingToBubble(batch.first));
     }

--- a/mobile/lib/blocs/dm/conversation/conversation_state.dart
+++ b/mobile/lib/blocs/dm/conversation/conversation_state.dart
@@ -124,9 +124,12 @@ class ConversationState extends Equatable {
   ///   until the user explicitly cancels.
   final List<OutgoingDm> pendingOutgoing;
 
-  /// Lookup of queue rows by rumor id once the map is built.
+  /// Lookup by either the durable queue handle or the wire rumor id.
+  ///
+  /// Group siblings share one wire rumor id, so the latter key resolves an
+  /// arbitrary sibling; [_siblingRowsFor] then expands it by batch id.
   Map<String, OutgoingDm> get _outgoingByRumorId => {
-    for (final row in pendingOutgoing) row.id: row,
+    for (final row in pendingOutgoing) ...{row.id: row, row.rumorId: row},
   };
 
   /// Whether [q] belongs to a GROUP send — the repository's own
@@ -158,8 +161,8 @@ class ConversationState extends Equatable {
   static String _batchKeyOfMessage(DmMessage m) =>
       m.sendBatchId ?? '${m.senderPubkey}|${m.createdAt}|${m.content}';
 
-  /// The fan-out batch containing [id] — a queue-row rumor id or a
-  /// persisted message id.
+  /// The fan-out batch containing [id] — a durable queue handle, wire rumor
+  /// id, or persisted message id.
   ///
   /// A group send enqueues one queue row PER RECIPIENT for one logical
   /// message; every sibling carries the same durable `sendBatchId`
@@ -192,7 +195,7 @@ class ConversationState extends Equatable {
     ];
   }
 
-  /// Rumor ids of the hard-failed queue rows in [id]'s fan-out batch —
+  /// Durable handles of the hard-failed queue rows in [id]'s fan-out batch —
   /// the exact set a manual Resend must replay. For a 1:1 failed bubble
   /// this is just `[id]`.
   List<String> failedSiblingRumorIdsFor(String id) => [
@@ -200,7 +203,7 @@ class ConversationState extends Equatable {
       if (q.recipientWrapStatus == OutgoingWrapStatus.failed) q.id,
   ];
 
-  /// Rumor ids of every sibling in [id]'s fan-out batch whose recipient
+  /// Durable handles of every sibling in [id]'s fan-out batch whose recipient
   /// has NOT received the message (pending + failed) — the set a snackbar
   /// "cancel send" must drop. Deliberately EXCLUDES delivered-awaiting-
   /// self-wrap rows: those recipients already have the message, and
@@ -275,7 +278,7 @@ class ConversationState extends Equatable {
     final grouped = <String, List<OutgoingDm>>{};
     final pendingBubbles = <DmMessage>[];
     for (final q in pendingOutgoing) {
-      if (persistedIds.contains(q.id)) continue;
+      if (persistedIds.contains(q.rumorId)) continue;
       if (_isGroupRow(q)) {
         grouped.putIfAbsent(_batchKeyOf(q), () => []).add(q);
       } else {
@@ -334,12 +337,14 @@ class ConversationState extends Equatable {
 
 DmMessage _outgoingToBubble(OutgoingDm row) {
   return DmMessage(
-    id: row.id,
+    // Message actions (reaction, reply, delete) must address the wire rumor,
+    // never the per-recipient durable queue handle used by group sends.
+    id: row.rumorId,
     conversationId: row.conversationId,
     senderPubkey: row.ownerPubkey,
     content: row.content,
     createdAt: row.createdAt,
-    giftWrapId: row.id,
+    giftWrapId: row.rumorId,
     // Carry the reply linkage so an optimistic reply bubble can resolve its
     // parent's shared video and render the quoted preview immediately, before
     // the persisted `watchMessages` tick replaces this row.

--- a/mobile/packages/db_client/lib/src/database/daos/outgoing_dms_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/outgoing_dms_dao.dart
@@ -2,11 +2,26 @@
 // ABOUTME: Tracks per-wrap publish status (recipient + self gift wrap)
 // ABOUTME: so partial deliveries can be retried without double-delivering.
 
+import 'dart:convert';
+
 import 'package:db_client/db_client.dart';
 import 'package:drift/drift.dart';
 import 'package:meta/meta.dart';
 
 part 'outgoing_dms_dao.g.dart';
+
+String? _rumorIdFromJson(String rumorEventJson) {
+  try {
+    final decoded = jsonDecode(rumorEventJson);
+    if (decoded is Map<String, dynamic>) {
+      final value = decoded['id'];
+      if (value is String && value.isNotEmpty) return value;
+    }
+  } on FormatException {
+    return null;
+  }
+  return null;
+}
 
 /// Status of one of the two NIP-17 gift-wrap publishes for an outgoing DM.
 ///
@@ -83,7 +98,11 @@ class OutgoingDm {
     this.sendBatchId,
   });
 
-  /// Rumor event id (kind 14/15). Stable across retries.
+  /// Opaque durable queue-row handle.
+  ///
+  /// This equals [rumorId] for 1:1 and legacy sends. Group sends use a
+  /// per-recipient handle because every recipient shares one wire rumor while
+  /// delivery state is tracked separately per recipient.
   final String id;
   final String conversationId;
   final String recipientPubkey;
@@ -117,6 +136,12 @@ class OutgoingDm {
   /// conversation state also uses it for group batch membership. NULL only
   /// for legacy rows.
   final String? sendBatchId;
+
+  /// The kind-14/15 wire rumor id, stable across retries and recipients.
+  ///
+  /// Legacy and malformed fixtures fall back to [id]. Production rows always
+  /// store the complete rumor JSON before publishing.
+  String get rumorId => _rumorIdFromJson(rumorEventJson) ?? id;
 
   /// Whether **both** wraps have landed. The repository deletes the
   /// queue row only when this is true (in the same transaction that
@@ -528,6 +553,24 @@ class OutgoingDmsDao extends DatabaseAccessor<AppDatabase>
       ]);
     final rows = await query.get();
     return rows.map(_rowToModel).toList();
+  }
+
+  /// Finds one owner-scoped queue row carrying [rumorId] on the wire.
+  ///
+  /// Group rows use per-recipient queue handles, so their primary-key `id`
+  /// differs from the shared rumor id exposed by an optimistic message bubble.
+  Future<OutgoingDm?> getByRumorId({
+    required String rumorId,
+    required String ownerPubkey,
+  }) async {
+    final query = select(outgoingDms)
+      ..where((t) => t.ownerPubkey.equals(ownerPubkey));
+    for (final row in await query.get()) {
+      if (_rumorIdFromJson(row.rumorEventJson) == rumorId) {
+        return _rowToModel(row);
+      }
+    }
+    return null;
   }
 
   /// Watch every row for the given account, oldest first.

--- a/mobile/packages/db_client/lib/src/database/daos/outgoing_dms_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/outgoing_dms_dao.dart
@@ -76,7 +76,7 @@ class UnknownOutgoingWrapStatusException implements Exception {
 /// at the repository / service / bloc layers don't import Drift types.
 @immutable
 class OutgoingDm {
-  const OutgoingDm({
+  OutgoingDm({
     required this.id,
     required this.conversationId,
     required this.recipientPubkey,
@@ -96,7 +96,7 @@ class OutgoingDm {
     this.selfWrapLastError,
     this.lastAttemptAt,
     this.sendBatchId,
-  });
+  }) : rumorId = _rumorIdFromJson(rumorEventJson) ?? id;
 
   /// Opaque durable queue-row handle.
   ///
@@ -140,8 +140,9 @@ class OutgoingDm {
   /// The kind-14/15 wire rumor id, stable across retries and recipients.
   ///
   /// Legacy and malformed fixtures fall back to [id]. Production rows always
-  /// store the complete rumor JSON before publishing.
-  String get rumorId => _rumorIdFromJson(rumorEventJson) ?? id;
+  /// store the complete rumor JSON before publishing. Parsed once when the
+  /// model is created because conversation state reads this value per bubble.
+  final String rumorId;
 
   /// Whether **both** wraps have landed. The repository deletes the
   /// queue row only when this is true (in the same transaction that
@@ -343,10 +344,9 @@ class OutgoingDmsDao extends DatabaseAccessor<AppDatabase>
   /// event ids) is preserved. Use [markRecipientWrapStatus],
   /// [markSelfWrapStatus], or [incrementRetry] to update a row in place.
   Future<void> enqueue(OutgoingDm dm) async {
-    await into(outgoingDms).insert(
-      _modelToCompanion(dm),
-      mode: InsertMode.insertOrIgnore,
-    );
+    await into(
+      outgoingDms,
+    ).insert(_modelToCompanion(dm), mode: InsertMode.insertOrIgnore);
   }
 
   /// Update the recipient gift-wrap status for [id]. Pass [eventId] when
@@ -439,12 +439,8 @@ class OutgoingDmsDao extends DatabaseAccessor<AppDatabase>
   /// [getRetryableForOwner] forever — an explicit user resend is the signal
   /// to re-arm it. Returns `false` when no row exists for [id].
   Future<bool> resetRetryCount(String id) async {
-    final affected =
-        await (update(
-          outgoingDms,
-        )..where((t) => t.id.equals(id))).write(
-          const OutgoingDmsCompanion(retryCount: Value(0)),
-        );
+    final affected = await (update(outgoingDms)..where((t) => t.id.equals(id)))
+        .write(const OutgoingDmsCompanion(retryCount: Value(0)));
     return affected > 0;
   }
 
@@ -522,10 +518,7 @@ class OutgoingDmsDao extends DatabaseAccessor<AppDatabase>
             t.ownerPubkey.equals(ownerPubkey),
       )
       ..orderBy([
-        (t) => OrderingTerm(
-          expression: t.createdAt,
-          mode: OrderingMode.desc,
-        ),
+        (t) => OrderingTerm(expression: t.createdAt, mode: OrderingMode.desc),
       ]);
     return query.watch().map((rows) => rows.map(_rowToModel).toList());
   }
@@ -546,10 +539,7 @@ class OutgoingDmsDao extends DatabaseAccessor<AppDatabase>
             t.ownerPubkey.equals(ownerPubkey),
       )
       ..orderBy([
-        (t) => OrderingTerm(
-          expression: t.createdAt,
-          mode: OrderingMode.desc,
-        ),
+        (t) => OrderingTerm(expression: t.createdAt, mode: OrderingMode.desc),
       ]);
     final rows = await query.get();
     return rows.map(_rowToModel).toList();

--- a/mobile/packages/db_client/lib/src/database/tables.dart
+++ b/mobile/packages/db_client/lib/src/database/tables.dart
@@ -1171,9 +1171,9 @@ class OutgoingDms extends Table {
   @override
   String get tableName => 'outgoing_dms';
 
-  /// Primary key. Equal to the rumor's event id (`rumor_event_json` →
-  /// `id`), so a single logical message has exactly one queue row even
-  /// across retries.
+  /// Opaque durable queue-row handle. It equals the rumor event id for 1:1
+  /// and legacy sends. Group sends append the recipient pubkey because one
+  /// shared wire rumor needs separate delivery state for each recipient.
   TextColumn get id => text()();
 
   /// Deterministic conversation identifier (SHA-256 of sorted

--- a/mobile/packages/db_client/test/src/database/daos/outgoing_dms_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/outgoing_dms_dao_test.dart
@@ -30,6 +30,7 @@ void main() {
   // Helper: build a fresh queued OutgoingDm with both wraps pending.
   OutgoingDm makeDm({
     required String id,
+    String? rumorId,
     String owner = ownerA,
     String recipientPubkey = recipient,
     String conversationIdValue = conversationId,
@@ -46,7 +47,7 @@ void main() {
       recipientPubkey: recipientPubkey,
       content: 'hello',
       createdAt: createdAt,
-      rumorEventJson: '{"id":"$id","kind":14,"content":"hello"}',
+      rumorEventJson: '{"id":"${rumorId ?? id}","kind":14,"content":"hello"}',
       recipientWrapStatus: recipientStatus,
       selfWrapStatus: selfStatus,
       retryCount: retryCount,
@@ -77,6 +78,13 @@ void main() {
   });
 
   group('OutgoingDm value equality', () {
+    test('rumorId reads the wire id independently of the queue handle', () {
+      final row = makeDm(id: 'queue-handle', rumorId: 'wire-rumor');
+
+      expect(row.id, equals('queue-handle'));
+      expect(row.rumorId, equals('wire-rumor'));
+    });
+
     test(
       'rows differing only in wrap status are NOT equal — id-only equality '
       'made a pending row compare equal to its failed re-read, so Bloc.emit '
@@ -185,6 +193,46 @@ void main() {
         expect(fetched.retryCount, equals(0));
         expect(fetched.recipientWrapLastError, isNull);
         expect(fetched.selfWrapLastError, isNull);
+      });
+
+      test('finds a per-recipient queue row by its shared rumor id', () async {
+        await dao.enqueue(
+          makeDm(id: 'wire-rumor:$recipient', rumorId: 'wire-rumor'),
+        );
+        await dao.enqueue(
+          makeDm(
+            id: 'wire-rumor:$recipient2',
+            rumorId: 'wire-rumor',
+            recipientPubkey: recipient2,
+          ),
+        );
+
+        final row = await dao.getByRumorId(
+          rumorId: 'wire-rumor',
+          ownerPubkey: ownerA,
+        );
+
+        expect(row, isNotNull);
+        expect(row!.rumorId, equals('wire-rumor'));
+        expect(row.id, isNot(equals(row.rumorId)));
+      });
+
+      test('ignores an unrelated row with a corrupt wrap status', () async {
+        await dao.enqueue(makeDm(id: 'corrupt-row'));
+        await database.customStatement(
+          "UPDATE outgoing_dms SET recipient_wrap_status = 'cancelled' "
+          "WHERE id = 'corrupt-row'",
+        );
+        await dao.enqueue(
+          makeDm(id: 'wire-rumor:$recipient', rumorId: 'wire-rumor'),
+        );
+
+        final row = await dao.getByRumorId(
+          rumorId: 'wire-rumor',
+          ownerPubkey: ownerA,
+        );
+
+        expect(row?.id, equals('wire-rumor:$recipient'));
       });
 
       test(

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -2345,11 +2345,10 @@ class DmRepository {
       // Only a NIP-04 copy may suppress a peer's rumor: a row that also
       // arrived over NIP-17 is a genuine earlier message (#7324).
       //
-      // Our own self-wrap echo is the exception. A group send persists one
-      // row but publishes one rumor per recipient, so the rumor-id primary
-      // key collapses only the first sibling's echo — the rest dedup on the
-      // batch token, or the unfiltered window when the send predates it
-      // (#6046).
+      // Our own self-wrap echo is the exception. A group send persists one row
+      // but publishes one self-wrap per recipient for the shared rumor. Every
+      // echo dedups on the batch token, or the unfiltered window when the send
+      // predates it (#6046).
       final isSentByMe = rumor.pubkey == ownerPubkey;
       final isGroup = participants.length > 2;
       final bool isDuplicate;
@@ -5234,8 +5233,7 @@ class DmRepository {
     // invocation's wire events — and therefore their ids, queue-row handles,
     // and recovery locks — are unique even at same-second identical text. The
     // same value is stamped verbatim on every sibling queue row AND the batch's
-    // one
-    // persisted local message, so persistence dedup, optimistic grouping,
+    // one persisted local message, so persistence dedup, optimistic grouping,
     // sibling lookup, and cancellation all match a batch by one exact stored
     // value. The token rides inside the encrypted gift-wrapped rumor (only the
     // recipient and the sender's own self-wrap ever decrypt it) and is random,

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -3928,15 +3928,18 @@ class DmRepository {
   /// durable row, and the sweep then delivers one copy while the retry
   /// delivers another.
   ///
-  /// Only ever called for a row that survives the call — the soft-unconfirmed
-  /// and hard-failure arms of both [sendMessage] and [sendGroupMessage], plus
-  /// a [sendGroupMessage] sibling whose enqueue-failure unwind could not
-  /// delete it. The blocked branch deletes its row, a cancelled group sibling
-  /// never had one, an unwound sibling no longer has one, and the success
-  /// branch consumes it (except on partial delivery — see
-  /// [NIP17SendResult.queuedRumorId]).
+  /// Called only for a row that survives the call: retryable failures and
+  /// partial successes whose recipient wrap landed but self-wrap did not.
   NIP17SendResult _stampQueuedRow(NIP17SendResult result, String rumorId) =>
       switch (result) {
+        NIP17SendSuccess() when !result.selfWrapPublished => NIP17SendSuccess(
+          rumorEventId: result.rumorEventId,
+          messageEventId: result.messageEventId,
+          recipientPubkey: result.recipientPubkey,
+          selfWrapPublished: false,
+          queuedRumorId: rumorId,
+          timestamp: result.timestamp,
+        ),
         NIP17SendSuccess() => result,
         NIP17SendFailure() => NIP17SendFailure(
           result.error,
@@ -4846,7 +4849,7 @@ class DmRepository {
     // The durable batch id when available; null for a legacy (pre-column)
     // in-flight batch, which falls back to the `(createdAt, content)` tuple.
     final String? batchId;
-    final row = await dao.getById(rumorId);
+    var row = await dao.getById(rumorId);
     if (row != null) {
       if (row.ownerPubkey != _userPubkey) {
         throw ArgumentError.value(
@@ -4873,11 +4876,26 @@ class DmRepository {
         rumorId,
         ownerPubkey: _ownerPubkey,
       );
-      if (message == null || message.senderPubkey != _userPubkey) return 0;
-      conversationId = message.conversationId;
-      createdAt = message.createdAt;
-      content = message.content;
-      batchId = message.sendBatchId;
+      if (message != null) {
+        if (message.senderPubkey != _userPubkey) return 0;
+        conversationId = message.conversationId;
+        createdAt = message.createdAt;
+        content = message.content;
+        batchId = message.sendBatchId;
+      } else {
+        // A queue-only group bubble exposes the shared wire rumor id, while
+        // each durable row is keyed by its per-recipient queue handle. Resolve
+        // one sibling from the stored rumor before expanding the whole batch.
+        row = await dao.getByRumorId(
+          rumorId: rumorId,
+          ownerPubkey: _userPubkey,
+        );
+        if (row == null) return 0;
+        conversationId = row.conversationId;
+        createdAt = row.createdAt;
+        content = row.content;
+        batchId = row.sendBatchId;
+      }
     }
 
     final rows = await dao.getForConversation(
@@ -5119,8 +5137,8 @@ class DmRepository {
   ///
   /// When an [OutgoingDmsDao] is injected, each per-recipient send
   /// goes through the durable queue with the same atomicity contract
-  /// as [sendMessage]: enqueue a `pending`/`pending` row keyed by the
-  /// per-recipient rumor id, publish, then transition the row by wrap
+  /// as [sendMessage]: enqueue a `pending`/`pending` row keyed by a
+  /// per-recipient queue handle, publish, then transition the row by wrap
   /// outcome (full delivery → row deleted in the same transaction
   /// that inserts `direct_messages`; partial delivery → recipient
   /// `sent` + self `failed` so the recovery path can replay only the
@@ -5498,6 +5516,7 @@ class DmRepository {
               rumorId: queueIds[i],
               result: results[i],
             );
+            results[i] = _stampQueuedRow(results[i], queueIds[i]);
           }
         }
       });

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -492,13 +492,12 @@ class DmRepository {
   /// would silently drop the siblings rather than throw.
   ///
   /// This needs no migration: nothing reads the column's format. Every
-  /// consumer treats it as an opaque handle — `recoverFullSend` takes the
-  /// rumor from `row.rumorEventJson` and the recipient from
-  /// `row.recipientPubkey`, and `NIP17SendResult.queuedRumorId` is only ever
-  /// handed back to `recoverFullSend`. A 64-hex rumor id can never contain
-  /// `:`, so group handles and the plain 1:1 ids (and any row written before
-  /// this change) stay in disjoint keyspaces — the same property
-  /// `ConversationState._batchKeyOf` already relies on.
+  /// consumer treats it as an opaque handle: `recoverFullSend` takes the rumor
+  /// from `row.rumorEventJson` and the recipient from `row.recipientPubkey`,
+  /// while `recoverSelfWrap` resolves the same row after partial delivery. A
+  /// 64-hex rumor id can never contain `:`, so group handles and the plain 1:1
+  /// ids (and any row written before this change) stay in disjoint keyspaces —
+  /// the same property `ConversationState._batchKeyOf` already relies on.
   static String _groupQueueId(String rumorId, String recipientPubkey) =>
       '$rumorId:$recipientPubkey';
 
@@ -5467,8 +5466,9 @@ class DmRepository {
               ownerPubkey: _userPubkey,
             );
 
-        // Key the insert off the first LIVE success — a cancelled sibling's
-        // rumor id must not name the persisted message.
+        // Key the insert off the first LIVE success so a cancelled sibling's
+        // giftWrapId does not land in storage. If cancellation removed every
+        // success, there is no local message to persist.
         final firstLiveSuccess = results[liveSuccessIndexes.first];
         if (!alreadyPersisted) {
           await _directMessagesDao.insertMessage(

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -484,6 +484,24 @@ class DmRepository {
 
   static final _sendBatchIdPattern = RegExp(r'^[0-9a-f]{64}$');
 
+  /// Durable queue handle for one recipient of a group send.
+  ///
+  /// A group send wraps ONE shared rumor for every recipient (#8188), so the
+  /// rumor id no longer identifies a single queue row — but `outgoing_dms`
+  /// tracks delivery PER RECIPIENT, and `enqueue` is `insertOrIgnore`, which
+  /// would silently drop the siblings rather than throw.
+  ///
+  /// This needs no migration: nothing reads the column's format. Every
+  /// consumer treats it as an opaque handle — `recoverFullSend` takes the
+  /// rumor from `row.rumorEventJson` and the recipient from
+  /// `row.recipientPubkey`, and `NIP17SendResult.queuedRumorId` is only ever
+  /// handed back to `recoverFullSend`. A 64-hex rumor id can never contain
+  /// `:`, so group handles and the plain 1:1 ids (and any row written before
+  /// this change) stay in disjoint keyspaces — the same property
+  /// `ConversationState._batchKeyOf` already relies on.
+  static String _groupQueueId(String rumorId, String recipientPubkey) =>
+      '$rumorId:$recipientPubkey';
+
   /// Whether [value] is a well-formed batch token — the 64-char lowercase-hex
   /// shape [_defaultSendBatchId] mints. Ingest only stamps a self-wrap's
   /// `batch` tag onto the persisted row when it matches, keeping the batch-id
@@ -5171,6 +5189,13 @@ class DmRepository {
     ]);
 
     final rumors = <Event>[];
+    // Per-recipient durable handle for the queue row. The wire rumor is shared
+    // across the batch, so the rumor id alone can no longer key a row: the
+    // queue tracks per-recipient delivery, and `enqueue` is `insertOrIgnore`,
+    // which would silently discard the siblings WITHOUT throwing. Composed
+    // rather than migrated because nothing reads this column's format — see
+    // [_groupQueueId].
+    final queueIds = <String>[];
     final results = <NIP17SendResult>[];
 
     // Durable, collision-proof identity for this whole fan-out, minted BEFORE
@@ -5197,30 +5222,37 @@ class DmRepository {
     // so it discloses nothing.
     final sendBatchId = _newSendBatchId();
 
-    // Build EVERY per-recipient rumor up front, stamped with one shared batch
-    // timestamp and the shared batch token, before any publish. Each recipient
-    // already gets a distinct rumor id within a batch (their p-tag set
-    // differs); the batch token additionally separates two whole invocations
-    // that would otherwise be byte-identical.
+    // ONE rumor for the whole fan-out, wrapped once per recipient (#8188).
+    // NIP-59 59.md:108 permits exactly this — "a single `rumor` may be wrapped
+    // and addressed for each recipient individually" — and it is what every
+    // shipping group-DM client does. It is also already the shape of this
+    // repository's OWN kind-5 deletions (`_fanOutDeletion`) and kind-7
+    // reactions (`DmReactionsRepository._fanOutRumor`); kind-14/15 messages
+    // were the outlier.
+    //
+    // Building one rumor per recipient forked the id: `buildRumor` prepends
+    // `['p', recipientPubkey]`, so each sibling carried the same p-tag SET in a
+    // rotated ORDER, and a NIP-01 id hashes the tags array. A retraction can
+    // name only one id, so delete-for-everyone reached exactly one participant;
+    // a reaction naming one sibling was never persisted by the others at all.
+    //
+    // The batch token still separates two whole invocations of identical text
+    // in the same second (#6046) — it is one shared tag, so it does not
+    // re-fork the id within a batch.
     final batchCreatedAt = DateTime.now().millisecondsSinceEpoch ~/ 1000;
-    for (final pubkey in recipientPubkeys) {
-      final rumorTags = <List<String>>[
+    final groupRumor = _messageService!.buildGroupRumor(
+      recipientPubkeys: recipientPubkeys,
+      content: content,
+      additionalTags: <List<String>>[
         ...additionalTags,
-        // Include all recipients as p tags per NIP-17
-        for (final pk in recipientPubkeys)
-          if (pk != pubkey) ['p', pk],
         if (replyToId != null) ['e', replyToId],
         [_sendBatchTagKey, sendBatchId],
-      ];
-
-      rumors.add(
-        _messageService!.buildRumor(
-          recipientPubkey: pubkey,
-          content: content,
-          additionalTags: rumorTags,
-          createdAt: batchCreatedAt,
-        ),
-      );
+      ],
+      createdAt: batchCreatedAt,
+    );
+    for (var i = 0; i < recipientPubkeys.length; i++) {
+      rumors.add(groupRumor);
+      queueIds.add(_groupQueueId(groupRumor.id, recipientPubkeys[i]));
     }
 
     // Enqueue every sibling before publish so an app crash mid-send leaves a
@@ -5239,10 +5271,11 @@ class DmRepository {
     if (outgoingDao != null) {
       for (var i = 0; i < recipientPubkeys.length; i++) {
         final rumor = rumors[i];
+        final queueId = queueIds[i];
         try {
           await outgoingDao.enqueue(
             OutgoingDm(
-              id: rumor.id,
+              id: queueId,
               conversationId: conversationId,
               recipientPubkey: recipientPubkeys[i],
               content: content,
@@ -5272,7 +5305,7 @@ class DmRepository {
             failure,
           );
           for (var j = 0; j < i; j++) {
-            final parkedRumorId = rumors[j].id;
+            final parkedRumorId = queueIds[j];
             try {
               await outgoingDao.deleteById(parkedRumorId);
             } on Object catch (deleteError, deleteStackTrace) {
@@ -5326,7 +5359,7 @@ class DmRepository {
       // kind-5 from. The currently-publishing sibling's inherent TOCTOU is
       // accepted, the same trade-off as recoverFullSend.
       if (outgoingDao != null &&
-          await outgoingDao.getById(rumors[i].id) == null) {
+          await outgoingDao.getById(queueIds[i]) == null) {
         cancelledBeforePublish.add(i);
         results.add(
           const NIP17SendResult.failure('send cancelled before publish'),
@@ -5348,7 +5381,7 @@ class DmRepository {
       NIP17SendResult result;
       try {
         result = await _joinOrStartRecovery(
-          'full:${rumors[i].id}',
+          'full:${queueIds[i]}',
           () => _sendRumorWithTimeout(
             rumor: rumors[i],
             recipientPubkey: pubkey,
@@ -5389,7 +5422,7 @@ class DmRepository {
         for (var i = 0; i < results.length; i++) {
           if (!results[i].success) continue;
           if (outgoingDao != null &&
-              await outgoingDao.getById(rumors[i].id) == null) {
+              await outgoingDao.getById(queueIds[i]) == null) {
             continue;
           }
           liveSuccessIndexes.add(i);
@@ -5462,7 +5495,7 @@ class DmRepository {
           for (final i in liveSuccessIndexes) {
             await _finalizeAfterRecipientSuccess(
               outgoingDao: outgoingDao,
-              rumorId: rumors[i].id,
+              rumorId: queueIds[i],
               result: results[i],
             );
           }
@@ -5497,21 +5530,21 @@ class DmRepository {
         if (result.blocked) {
           await _finalizeAfterRecipientBlocked(
             outgoingDao: outgoingDao,
-            rumorId: rumors[i].id,
+            rumorId: queueIds[i],
           );
         } else if (result.retryablePending) {
           await _finalizeAfterRecipientUnconfirmed(
             outgoingDao: outgoingDao,
-            rumorId: rumors[i].id,
+            rumorId: queueIds[i],
           );
-          results[i] = _stampQueuedRow(result, rumors[i].id);
+          results[i] = _stampQueuedRow(result, queueIds[i]);
         } else {
           await _finalizeAfterRecipientFailure(
             outgoingDao: outgoingDao,
-            rumorId: rumors[i].id,
+            rumorId: queueIds[i],
             errorMessage: result.error ?? 'Unknown publish failure',
           );
-          results[i] = _stampQueuedRow(result, rumors[i].id);
+          results[i] = _stampQueuedRow(result, queueIds[i]);
         }
       }
     }

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -5188,7 +5188,6 @@ class DmRepository {
         resolveDmInboxRelays(pubkey).then((r) => inboxByRecipient[pubkey] = r),
     ]);
 
-    final rumors = <Event>[];
     // Per-recipient durable handle for the queue row. The wire rumor is shared
     // across the batch, so the rumor id alone can no longer key a row: the
     // queue tracks per-recipient delivery, and `enqueue` is `insertOrIgnore`,
@@ -5204,17 +5203,20 @@ class DmRepository {
     // nonce, so two group sends of identical text in the SAME Unix second
     // would otherwise build byte-identical rumors: identical event ids ⇒
     // identical queue-row PKs (`OutgoingDm.id`, enqueued with insertOrIgnore
-    // so the second is silently dropped) ⇒ identical `full:<rumorId>` recovery
+    // so the second is silently dropped) ⇒ identical `full:<queueId>` recovery
     // locks (the second publish joins the first) ⇒ identical batch id (the
     // persist dedup drops the second local message). The user's second send
     // would vanish from the queue, local history, AND recipients. Deriving the
-    // batch id from `rumors.first.id` inherits that same-second collision.
+    // batch id from the rumor's own id would inherit that same-second
+    // collision — and since #8188 the whole batch shares ONE rumor id, so the
+    // rumor can no longer distinguish two invocations at all.
     //
     // Instead this token is independent secure random, and it is injected into
-    // every sibling rumor (a client-internal `batch` tag, below) so each
-    // invocation's wire events — and therefore their ids, queue-row PKs, and
-    // recovery locks — are unique even at same-second identical text. The same
-    // value is stamped verbatim on every sibling queue row AND the batch's one
+    // the batch's one rumor (a client-internal `batch` tag, below) so each
+    // invocation's wire events — and therefore their ids, queue-row handles,
+    // and recovery locks — are unique even at same-second identical text. The
+    // same value is stamped verbatim on every sibling queue row AND the batch's
+    // one
     // persisted local message, so persistence dedup, optimistic grouping,
     // sibling lookup, and cancellation all match a batch by one exact stored
     // value. The token rides inside the encrypted gift-wrapped rumor (only the
@@ -5250,9 +5252,8 @@ class DmRepository {
       ],
       createdAt: batchCreatedAt,
     );
-    for (var i = 0; i < recipientPubkeys.length; i++) {
-      rumors.add(groupRumor);
-      queueIds.add(_groupQueueId(groupRumor.id, recipientPubkeys[i]));
+    for (final recipient in recipientPubkeys) {
+      queueIds.add(_groupQueueId(groupRumor.id, recipient));
     }
 
     // Enqueue every sibling before publish so an app crash mid-send leaves a
@@ -5270,7 +5271,6 @@ class DmRepository {
     // minting a duplicating fresh fan-out (#7316).
     if (outgoingDao != null) {
       for (var i = 0; i < recipientPubkeys.length; i++) {
-        final rumor = rumors[i];
         final queueId = queueIds[i];
         try {
           await outgoingDao.enqueue(
@@ -5279,9 +5279,9 @@ class DmRepository {
               conversationId: conversationId,
               recipientPubkey: recipientPubkeys[i],
               content: content,
-              createdAt: rumor.createdAt,
-              rumorEventJson: jsonEncode(rumor.toJson()),
-              messageKind: rumor.kind,
+              createdAt: groupRumor.createdAt,
+              rumorEventJson: jsonEncode(groupRumor.toJson()),
+              messageKind: groupRumor.kind,
               replyToId: replyToId,
               recipientWrapStatus: OutgoingWrapStatus.pending,
               selfWrapStatus: OutgoingWrapStatus.pending,
@@ -5383,7 +5383,7 @@ class DmRepository {
         result = await _joinOrStartRecovery(
           'full:${queueIds[i]}',
           () => _sendRumorWithTimeout(
-            rumor: rumors[i],
+            rumor: groupRumor,
             recipientPubkey: pubkey,
             targetRelays: inboxByRecipient[pubkey],
             awaitRecipientOk: true,
@@ -5517,7 +5517,7 @@ class DmRepository {
     // rumors the receiver cannot collapse (#7316). Cancelled and blocked
     // siblings are deliberately unstamped: none leaves a row behind.
     if (outgoingDao != null) {
-      for (var i = 0; i < rumors.length; i++) {
+      for (var i = 0; i < queueIds.length; i++) {
         // A sibling skipped for cancellation has no live row to transition; an
         // update-by-id would match zero rows anyway, but skipping is explicit
         // and keeps such an index from resurrecting a queue transition or a

--- a/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
+++ b/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
@@ -429,6 +429,7 @@ class NIP17MessageService {
   /// - [content]: Message content (text for kind 14, file URL for kind 15)
   /// - [eventKind]: The rumor event kind (14 = text, 15 = file)
   /// - [additionalTags]: Optional tags to include in the rumor event
+  /// - [createdAt]: Optional canonical event timestamp
   Event buildRumor({
     required String recipientPubkey,
     required String content,
@@ -441,10 +442,6 @@ class NIP17MessageService {
       ...additionalTags,
     ];
 
-    // [createdAt] lets a group fan-out stamp every per-recipient rumor with
-    // one shared batch timestamp, so all sibling rows sort together on the
-    // sender-side timeline. (The batch identity used for dedup/grouping is a
-    // separate durable id — see `OutgoingDms.sendBatchId`.)
     return Event(
       _senderPublicKey,
       eventKind,

--- a/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
+++ b/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
@@ -454,6 +454,50 @@ class NIP17MessageService {
     );
   }
 
+  /// Build the ONE unsigned NIP-17 rumor a group send wraps for every
+  /// recipient.
+  ///
+  /// **Invariant: one byte-identical rumor per group send.** NIP-59 states it
+  /// outright — "If a `rumor` is intended for more than one party […] a single
+  /// `rumor` may be wrapped and addressed for each recipient individually"
+  /// (`59.md:108`) — and NIP-17 assumes it: "The set of `pubkey` + `p` tags
+  /// defines a chat room" (`17.md:17`), a set, unordered.
+  ///
+  /// [buildRumor] prepends `['p', recipientPubkey]`, so calling it once per
+  /// recipient produced N rumors carrying the same p-tag SET rotated into a
+  /// different ORDER. A NIP-01 id hashes the tags *array*, so the rotation
+  /// alone forked the id — and a retraction, which can name only one, then
+  /// reached only one participant (#8188).
+  ///
+  /// Recipients are sorted so the id does not depend on the caller's argument
+  /// order. The receiving recipient is included, as `17.md:118-132` shows;
+  /// the sender is not (matching Amethyst — the convention is split across
+  /// clients and both are tolerated, since every client keys a room on the
+  /// participant set).
+  ///
+  /// Callers must not vary any tag element per recipient. A per-recipient
+  /// relay hint inside a `p` tag would re-fork the id even with canonical
+  /// ordering; NIP-17 puts hints on the gift wrap's own `p` tag instead.
+  Event buildGroupRumor({
+    required List<String> recipientPubkeys,
+    required String content,
+    int eventKind = EventKind.privateDirectMessage,
+    List<List<String>> additionalTags = const [],
+    int? createdAt,
+  }) {
+    final ordered = [...recipientPubkeys]..sort();
+    return Event(
+      _senderPublicKey,
+      eventKind,
+      <List<String>>[
+        for (final pubkey in ordered) ['p', pubkey],
+        ...additionalTags,
+      ],
+      content,
+      createdAt: createdAt,
+    );
+  }
+
   /// OK-confirmation window for the recipient wrap when [sendRumor] runs
   /// with `awaitRecipientOk: true` (reaction sends and message sends). Kept
   /// well under the caller's outer publish cap so the confirmation resolves

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -750,6 +750,41 @@ void main() {
         );
       });
 
+      // Faithful mirror of Nip17MessageService.buildGroupRumor: ONE rumor for
+      // the whole fan-out, recipients sorted so the id does not depend on
+      // caller argument order (#8188).
+      when(
+        () => mockMessageService.buildGroupRumor(
+          recipientPubkeys: any(named: 'recipientPubkeys'),
+          content: any(named: 'content'),
+          eventKind: any(named: 'eventKind'),
+          additionalTags: any(named: 'additionalTags'),
+          createdAt: any(named: 'createdAt'),
+        ),
+      ).thenAnswer((inv) {
+        final recipients =
+            (inv.namedArguments[#recipientPubkeys] as List<String>).toList()
+              ..sort();
+        final content = inv.namedArguments[#content] as String;
+        final eventKind =
+            (inv.namedArguments[#eventKind] as int?) ??
+            EventKind.privateDirectMessage;
+        final additionalTags =
+            (inv.namedArguments[#additionalTags] as List<List<String>>?) ??
+            const <List<String>>[];
+        final createdAt = inv.namedArguments[#createdAt] as int?;
+        return Event(
+          _validPubkeyA,
+          eventKind,
+          [
+            for (final pubkey in recipients) ['p', pubkey],
+            ...additionalTags,
+          ],
+          content,
+          createdAt: createdAt,
+        );
+      });
+
       // Default: the send policy permits everyone (behavior preserved). The
       // protected-minor gate tests override this per-recipient. (#176)
       when(
@@ -18786,7 +18821,9 @@ void main() {
       test(
         'enqueues a row per recipient and deletes them all on full delivery',
         () async {
-          // Per-recipient rumor.id differs because additionalTags differ.
+          // The rumor is now SHARED across recipients (#8188); what differs
+          // per sibling is the durable QUEUE HANDLE. Pin success on both so
+          // both queue rows take the full-delivery path.
           // Pin success on both recipients so both queued rumor ids
           // take the full-delivery path.
           stubSendRumor((_, recipient) async {
@@ -18826,8 +18863,10 @@ void main() {
             enqueuedB.id,
             isNot(equals(enqueuedC.id)),
             reason:
-                'each recipient gets its own rumor id; group queue rows '
-                'must not collide',
+                'the rumor id is shared across the batch (#8188), so each '
+                'recipient needs its own queue handle — enqueue is '
+                'insertOrIgnore and would silently discard a colliding '
+                'sibling rather than throw',
           );
           // The linchpin of the durable batch identity: every sibling row is
           // stamped with the SAME non-null sendBatchId — an independent
@@ -18861,6 +18900,152 @@ void main() {
               lastError: any(named: 'lastError'),
             ),
           );
+        },
+      );
+
+      test(
+        'fans out ONE shared rumor id to every recipient (#8188)',
+        () async {
+          // The bug: a per-recipient rumor forks the id, so the single `e`
+          // tag a delete-for-everyone carries names an id only one recipient
+          // holds. NIP-59 59.md:108 permits — and every shipping group-DM
+          // client uses — a single rumor wrapped for each recipient. Kind-5
+          // deletions and kind-7 reactions in this very repository already
+          // fan out one shared rumor; kind-14/15 messages are the outlier.
+          final rumorIdsSeen = <String>[];
+          stubSendRumor((rumor, recipient) async {
+            rumorIdsSeen.add(rumor.id);
+            return NIP17SendResult.success(
+              rumorEventId: rumor.id,
+              messageEventId: 'wrap-$recipient',
+              recipientPubkey: recipient,
+            );
+          });
+
+          final repository = createRepository(
+            outgoingDmsDao: mockOutgoingDmsDao,
+          );
+
+          final _ = await repository.sendGroupMessage(
+            recipientPubkeys: [_validPubkeyB, _validPubkeyC],
+            content: 'group hello',
+          );
+
+          expect(rumorIdsSeen, hasLength(2));
+          expect(
+            rumorIdsSeen.toSet(),
+            hasLength(1),
+            reason:
+                'every participant must store the message under the SAME '
+                'rumor id, or a retraction naming one id no-ops for the rest',
+          );
+        },
+      );
+
+      test(
+        'keeps one queue row per recipient even though the rumor id is '
+        'shared (#8188)',
+        () async {
+          // The shared rumor id must not collapse the durable queue:
+          // `enqueue` is insertOrIgnore and does NOT throw, so colliding PKs
+          // would silently discard siblings with no trace for the sweep.
+          stubSendRumor((rumor, recipient) async {
+            return NIP17SendResult.success(
+              rumorEventId: rumor.id,
+              messageEventId: 'wrap-$recipient',
+              recipientPubkey: recipient,
+            );
+          });
+
+          final repository = createRepository(
+            outgoingDmsDao: mockOutgoingDmsDao,
+          );
+
+          final _ = await repository.sendGroupMessage(
+            recipientPubkeys: [_validPubkeyB, _validPubkeyC],
+            content: 'group hello',
+          );
+
+          final captured = verify(
+            () => mockOutgoingDmsDao.enqueue(captureAny()),
+          ).captured.cast<OutgoingDm>();
+
+          expect(captured, hasLength(2));
+          expect(
+            captured.map((r) => r.id).toSet(),
+            hasLength(2),
+            reason: 'each recipient needs its own durable queue row',
+          );
+          expect(
+            captured.map((r) => r.recipientPubkey).toSet(),
+            {_validPubkeyB, _validPubkeyC},
+          );
+          // Both rows replay the SAME rumor, so a retry re-publishes the
+          // shared id rather than minting a fresh one.
+          expect(
+            captured
+                .map(
+                  (r) =>
+                      (jsonDecode(r.rumorEventJson)
+                          as Map<String, dynamic>)['id'],
+                )
+                .toSet(),
+            hasLength(1),
+          );
+        },
+      );
+
+      test(
+        'persists the local message under the shared rumor id, which is what '
+        'delete-for-everyone will name (#8188)',
+        () async {
+          stubSendRumor((rumor, recipient) async {
+            return NIP17SendResult.success(
+              rumorEventId: rumor.id,
+              messageEventId: 'wrap-$recipient',
+              recipientPubkey: recipient,
+            );
+          });
+
+          final repository = createRepository(
+            outgoingDmsDao: mockOutgoingDmsDao,
+          );
+
+          final results = await repository.sendGroupMessage(
+            recipientPubkeys: [_validPubkeyB, _validPubkeyC],
+            content: 'group hello',
+          );
+
+          final sharedRumorId = results.first.rumorEventId;
+          expect(sharedRumorId, isNotNull);
+          final id = sharedRumorId!;
+
+          verify(
+            () => mockDirectMessagesDao.insertMessage(
+              id: id,
+              conversationId: any(named: 'conversationId'),
+              senderPubkey: any(named: 'senderPubkey'),
+              content: any(named: 'content'),
+              createdAt: any(named: 'createdAt'),
+              giftWrapId: any(named: 'giftWrapId'),
+              messageKind: any(named: 'messageKind'),
+              replyToId: any(named: 'replyToId'),
+              subject: any(named: 'subject'),
+              fileType: any(named: 'fileType'),
+              encryptionAlgorithm: any(named: 'encryptionAlgorithm'),
+              decryptionKey: any(named: 'decryptionKey'),
+              decryptionNonce: any(named: 'decryptionNonce'),
+              fileHash: any(named: 'fileHash'),
+              originalFileHash: any(named: 'originalFileHash'),
+              fileSize: any(named: 'fileSize'),
+              dimensions: any(named: 'dimensions'),
+              blurhash: any(named: 'blurhash'),
+              thumbnailUrl: any(named: 'thumbnailUrl'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+              tagsJson: any(named: 'tagsJson'),
+              sendBatchId: any(named: 'sendBatchId'),
+            ),
+          ).called(1);
         },
       );
 

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -19150,9 +19150,11 @@ void main() {
           final enqueuedC = captured.last as OutgoingDm;
 
           // Recipient B: full delivery → row deleted.
+          expect(results.first.queuedRumorId, isNull);
           verify(() => mockOutgoingDmsDao.deleteById(enqueuedB.id)).called(1);
           // Recipient C: partial → recipient sent + self failed, row
           // preserved for recovery.
+          expect(results.last.queuedRumorId, equals(enqueuedC.id));
           verify(
             () => mockOutgoingDmsDao.markRecipientWrapStatus(
               id: enqueuedC.id,
@@ -22552,6 +22554,7 @@ void main() {
       OutgoingDm sibling({
         required String id,
         required OutgoingWrapStatus recipientWrapStatus,
+        String? rumorId,
         String conversationId = groupConversationId,
         String content = batchContent,
         int createdAt = batchCreatedAt,
@@ -22563,7 +22566,7 @@ void main() {
         recipientPubkey: _validPubkeyC,
         content: content,
         createdAt: createdAt,
-        rumorEventJson: '{}',
+        rumorEventJson: rumorId == null ? '{}' : '{"id":"$rumorId"}',
         recipientWrapStatus: recipientWrapStatus,
         selfWrapStatus: OutgoingWrapStatus.pending,
         queuedAt: DateTime.fromMillisecondsSinceEpoch(0),
@@ -22688,6 +22691,59 @@ void main() {
           verify(
             () => mockOutgoingDmsDao.deleteById(failedSiblingId),
           ).called(1);
+        },
+      );
+
+      test(
+        'resolves a queue-only shared rumor id to its per-recipient handles',
+        () async {
+          const sharedRumorId = 'shared-wire-rumor';
+          const batchId = 'shared-batch';
+          final pending = sibling(
+            id: '$sharedRumorId:$_validPubkeyB',
+            rumorId: sharedRumorId,
+            recipientWrapStatus: OutgoingWrapStatus.pending,
+            sendBatchId: batchId,
+          );
+          final failed = sibling(
+            id: '$sharedRumorId:$_validPubkeyC',
+            rumorId: sharedRumorId,
+            recipientWrapStatus: OutgoingWrapStatus.failed,
+            sendBatchId: batchId,
+          );
+          when(
+            () => mockOutgoingDmsDao.getById(sharedRumorId),
+          ).thenAnswer((_) async => null);
+          when(
+            () => mockDirectMessagesDao.getMessageById(
+              sharedRumorId,
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          ).thenAnswer((_) async => null);
+          when(
+            () => mockOutgoingDmsDao.getByRumorId(
+              rumorId: sharedRumorId,
+              ownerPubkey: _validPubkeyA,
+            ),
+          ).thenAnswer((_) async => pending);
+          when(
+            () => mockOutgoingDmsDao.getForConversation(
+              conversationId: groupConversationId,
+              ownerPubkey: _validPubkeyA,
+            ),
+          ).thenAnswer((_) async => [pending, failed]);
+
+          final repository = createRepository(
+            outgoingDmsDao: mockOutgoingDmsDao,
+          );
+
+          final cancelled = await repository.cancelOutgoingBatch(
+            rumorId: sharedRumorId,
+          );
+
+          expect(cancelled, equals(2));
+          verify(() => mockOutgoingDmsDao.deleteById(pending.id)).called(1);
+          verify(() => mockOutgoingDmsDao.deleteById(failed.id)).called(1);
         },
       );
 
@@ -22859,6 +22915,12 @@ void main() {
             () => mockDirectMessagesDao.getMessageById(
               winnerRumorId,
               ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          ).thenAnswer((_) async => null);
+          when(
+            () => mockOutgoingDmsDao.getByRumorId(
+              rumorId: winnerRumorId,
+              ownerPubkey: _validPubkeyA,
             ),
           ).thenAnswer((_) async => null);
 

--- a/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
+++ b/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
@@ -1692,6 +1692,111 @@ void main() {
       );
     });
 
+    group('buildGroupRumor (#8188)', () {
+      const peerB =
+          'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+      const peerC =
+          'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
+      const peerA =
+          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+      test('carries every recipient as a p tag', () {
+        final rumor = service.buildGroupRumor(
+          recipientPubkeys: const [peerC, peerA, peerB],
+          content: 'hi all',
+        );
+
+        expect(
+          rumor.tags.where((t) => t.first == 'p').map((t) => t[1]).toSet(),
+          {peerA, peerB, peerC},
+        );
+      });
+
+      test('orders p tags canonically, so the id ignores argument order', () {
+        // Two callers listing the same room in different orders must produce
+        // the SAME message identity — otherwise the id depends on an
+        // incidental argument order.
+        final one = service.buildGroupRumor(
+          recipientPubkeys: const [peerC, peerA, peerB],
+          content: 'hi all',
+          createdAt: 1700000000,
+        );
+        final two = service.buildGroupRumor(
+          recipientPubkeys: const [peerA, peerB, peerC],
+          content: 'hi all',
+          createdAt: 1700000000,
+        );
+
+        expect(
+          one.tags.where((t) => t.first == 'p').map((t) => t[1]).toList(),
+          [peerA, peerB, peerC],
+        );
+        expect(one.id, equals(two.id));
+      });
+
+      test(
+        'is ONE byte-identical rumor for the whole fan-out, unlike a '
+        'per-recipient buildRumor',
+        () {
+          const room = [peerA, peerB, peerC];
+
+          // What sendGroupMessage used to do: buildRumor once per recipient,
+          // which prepends the addressee and so rotates the p-tag order.
+          final perRecipient = [
+            for (final me in room)
+              service.buildRumor(
+                recipientPubkey: me,
+                content: 'hi all',
+                additionalTags: [
+                  for (final other in room)
+                    if (other != me) ['p', other],
+                ],
+                createdAt: 1700000000,
+              ),
+          ];
+          expect(
+            perRecipient.map((r) => r.id).toSet(),
+            hasLength(3),
+            reason:
+                'the old shape forked the id — this is the bug, pinned so '
+                'the contrast stays visible',
+          );
+
+          // What it does now: one rumor, wrapped N times (NIP-59 59.md:108).
+          final shared = service.buildGroupRumor(
+            recipientPubkeys: room,
+            content: 'hi all',
+            createdAt: 1700000000,
+          );
+          expect(
+            List.generate(room.length, (_) => shared.id).toSet(),
+            hasLength(1),
+          );
+        },
+      );
+
+      test('appends additionalTags after the p tags and keeps the kind', () {
+        final rumor = service.buildGroupRumor(
+          recipientPubkeys: const [peerB, peerA],
+          content: '',
+          eventKind: EventKind.fileMessage,
+          additionalTags: const [
+            ['e', 'parent'],
+            ['batch', 'token'],
+          ],
+        );
+
+        expect(rumor.kind, EventKind.fileMessage);
+        expect(rumor.tags.last, ['batch', 'token']);
+        expect(rumor.tags.map((t) => t.first).toList(), [
+          'p',
+          'p',
+          'e',
+          'batch',
+        ]);
+      });
+    });
+
     group('publishSelfWrap', () {
       // The recovery primitive: re-publish only the sender
       // self-addressed gift wrap for a rumor whose recipient publish

--- a/mobile/packages/models/lib/src/nip17_send_result.dart
+++ b/mobile/packages/models/lib/src/nip17_send_result.dart
@@ -34,10 +34,9 @@ import 'package:meta/meta.dart';
 /// Pre-existing callers that only check [success] continue to work
 /// unchanged via the base-class getter. [selfWrapPublished] surfaces
 /// partial delivery so a half-delivered send can be visibly
-/// distinguished from a fully-delivered one. Acting on it (e.g.
-/// retrying only the missing self-wrap publish without re-publishing
-/// to the recipient) is left to future callers — the durable
-/// outgoing-message queue tracked in #3909 is not yet on `main`.
+/// distinguished from a fully-delivered one. [queuedRumorId] identifies the
+/// durable row when recovery must retry only the missing self-wrap without
+/// re-publishing to the recipient.
 sealed class NIP17SendResult {
   const NIP17SendResult();
 
@@ -51,11 +50,13 @@ sealed class NIP17SendResult {
     required String messageEventId,
     required String recipientPubkey,
     bool selfWrapPublished = true,
+    String? queuedRumorId,
   }) => NIP17SendSuccess(
     rumorEventId: rumorEventId,
     messageEventId: messageEventId,
     recipientPubkey: recipientPubkey,
     selfWrapPublished: selfWrapPublished,
+    queuedRumorId: queuedRumorId,
     timestamp: DateTime.now(),
   );
 
@@ -97,8 +98,7 @@ sealed class NIP17SendResult {
   /// pre-publish crypto build timeouts where retry is still the honest outcome.
   bool get retryablePending => false;
 
-  /// The `outgoing_dms` row this send left parked for the retry sweep, when
-  /// it enqueued one before failing.
+  /// The `outgoing_dms` row this send left parked for recovery.
   ///
   /// A caller that wants to try the same message again must re-drive **this**
   /// row (`DmRepository.recoverFullSend`) rather than calling `sendMessage`
@@ -106,15 +106,10 @@ sealed class NIP17SendResult {
   /// the sweep and the retry each deliver a copy. Receiver-side gift-wrap
   /// dedup keys on the rumor id and cannot collapse two of them.
   ///
-  /// `null` on every success, on a [blocked] result (the send gate returns
-  /// before the enqueue), and whenever the queue DAO is not wired in.
-  ///
-  /// On success that usually means there is no row left to point at — a fully
-  /// delivered send consumes it. Partial delivery is the exception: when
-  /// [selfWrapPublished] is `false` the row survives with a retryable
-  /// self-wrap and this still reads `null`. Finishing that row is the retry
-  /// sweep's job (or `recoverSelfWrap`'s); it must never be re-published to
-  /// the recipient, who already has the message — so no handle is offered.
+  /// `null` on a fully delivered success, on a [blocked] result (the send gate
+  /// returns before the enqueue), and whenever the queue DAO is not wired in.
+  /// A partial success may carry the surviving row so `recoverSelfWrap` can
+  /// publish only the missing self-wrap without re-delivering to the recipient.
   String? get queuedRumorId => null;
 
   /// The rumor event ID (kind 14/15) — the canonical message
@@ -161,6 +156,7 @@ final class NIP17SendSuccess extends NIP17SendResult {
     required this.messageEventId,
     required this.recipientPubkey,
     required this.selfWrapPublished,
+    this.queuedRumorId,
     this.timestamp,
   });
 
@@ -177,6 +173,9 @@ final class NIP17SendSuccess extends NIP17SendResult {
   final bool selfWrapPublished;
 
   @override
+  final String? queuedRumorId;
+
+  @override
   final DateTime? timestamp;
 
   @override
@@ -190,6 +189,7 @@ final class NIP17SendSuccess extends NIP17SendResult {
         other.messageEventId == messageEventId &&
         other.recipientPubkey == recipientPubkey &&
         other.selfWrapPublished == selfWrapPublished &&
+        other.queuedRumorId == queuedRumorId &&
         other.timestamp == timestamp;
   }
 
@@ -199,6 +199,7 @@ final class NIP17SendSuccess extends NIP17SendResult {
     messageEventId,
     recipientPubkey,
     selfWrapPublished,
+    queuedRumorId,
     timestamp,
   );
 
@@ -207,7 +208,8 @@ final class NIP17SendSuccess extends NIP17SendResult {
       'NIP17SendSuccess(rumorEventId: $rumorEventId, '
       'messageEventId: $messageEventId, '
       'recipient: $recipientPubkey, '
-      'selfWrapPublished: $selfWrapPublished)';
+      'selfWrapPublished: $selfWrapPublished, '
+      'queuedRumorId: $queuedRumorId)';
 }
 
 /// Recipient gift wrap was not published — the message did not reach

--- a/mobile/packages/models/lib/src/nip17_send_result.dart
+++ b/mobile/packages/models/lib/src/nip17_send_result.dart
@@ -100,16 +100,19 @@ sealed class NIP17SendResult {
 
   /// The `outgoing_dms` row this send left parked for recovery.
   ///
-  /// A caller that wants to try the same message again must re-drive **this**
-  /// row (`DmRepository.recoverFullSend`) rather than calling `sendMessage`
-  /// again: a second call mints a fresh rumor and a second durable row, so
-  /// the sweep and the retry each deliver a copy. Receiver-side gift-wrap
-  /// dedup keys on the rumor id and cannot collapse two of them.
+  /// On [NIP17SendFailure], a caller that wants to try the same message again
+  /// must re-drive **this** row (`DmRepository.recoverFullSend`) rather than
+  /// calling `sendMessage` again: a second call mints a fresh rumor and a
+  /// second durable row, so the sweep and the retry each deliver a copy.
+  /// Receiver-side gift-wrap dedup keys on the rumor id and cannot collapse
+  /// two of them.
   ///
   /// `null` on a fully delivered success, on a [blocked] result (the send gate
   /// returns before the enqueue), and whenever the queue DAO is not wired in.
-  /// A partial success may carry the surviving row so `recoverSelfWrap` can
-  /// publish only the missing self-wrap without re-delivering to the recipient.
+  /// On [NIP17SendSuccess] with [selfWrapPublished] false, a group send carries
+  /// the surviving row so `recoverSelfWrap` can publish only the missing
+  /// self-wrap without re-delivering to the recipient. A 1:1 partial success
+  /// may omit it because its rumor event id is also its queue-row handle.
   String? get queuedRumorId => null;
 
   /// The rumor event ID (kind 14/15) — the canonical message

--- a/mobile/packages/models/test/src/nip17_send_result_test.dart
+++ b/mobile/packages/models/test/src/nip17_send_result_test.dart
@@ -1,6 +1,6 @@
 // ABOUTME: Tests for NIP17SendResult including the per-wrap status
 // ABOUTME: that surfaces partial delivery (recipient delivered but
-// ABOUTME: self-wrap dropped); future retry handling tracked in #3909.
+// ABOUTME: self-wrap dropped) and its durable recovery queue handle.
 
 import 'package:models/models.dart';
 import 'package:test/test.dart';
@@ -50,6 +50,18 @@ void main() {
 
         expect(result.success, isTrue);
         expect(result.selfWrapPublished, isFalse);
+      });
+
+      test('carries a surviving queue handle for partial recovery', () {
+        final result = NIP17SendResult.success(
+          rumorEventId: rumorEventId,
+          messageEventId: messageEventId,
+          recipientPubkey: recipientPubkey,
+          selfWrapPublished: false,
+          queuedRumorId: 'queue-handle',
+        );
+
+        expect(result.queuedRumorId, equals('queue-handle'));
       });
     });
 
@@ -117,8 +129,7 @@ void main() {
         expect(result.queuedRumorId, isNull);
       });
 
-      test('success and blocked never carry a queuedRumorId: success '
-          'consumes the row and the send gate returns before the enqueue', () {
+      test('full success and blocked never carry a queuedRumorId', () {
         final success = NIP17SendResult.success(
           rumorEventId: rumorEventId,
           messageEventId: messageEventId,

--- a/mobile/test/blocs/dm/conversation/conversation_bloc_test.dart
+++ b/mobile/test/blocs/dm/conversation/conversation_bloc_test.dart
@@ -870,17 +870,14 @@ void main() {
         );
 
         blocTest<ConversationBloc, ConversationState>(
-          'emits [sending, sentPartial with only the failing rumor id] '
+          'emits [sending, sentPartial with the partial queue handle] '
           'when one per-recipient sendGroupMessage has self-wrap unpublished',
           setUp: () {
-            // Each per-recipient send produces its own rumor id.
-            // recipient1 fully delivers, recipient2 partial — only the
-            // partial one should land in lastPartialSend.rumorIds, so
-            // the recovery path republishes only that self-wrap.
-            const rumorIdRecipient1 =
+            // Both recipients share one wire rumor, but partial self-wrap
+            // recovery must retain the affected recipient's queue handle.
+            const sharedRumorId =
                 '7777777777777777777777777777777777777777777777777777777777777777';
-            const rumorIdRecipient2 =
-                '8888888888888888888888888888888888888888888888888888888888888888';
+            const partialQueueId = '$sharedRumorId:$recipientPubkey2';
             when(
               () => mockDmRepository.sendGroupMessage(
                 recipientPubkeys: [recipientPubkey, recipientPubkey2],
@@ -889,15 +886,16 @@ void main() {
             ).thenAnswer(
               (_) async => [
                 NIP17SendResult.success(
-                  rumorEventId: rumorIdRecipient1,
-                  messageEventId: rumorIdRecipient1,
+                  rumorEventId: sharedRumorId,
+                  messageEventId: 'wrap-1',
                   recipientPubkey: recipientPubkey,
                 ),
                 NIP17SendResult.success(
-                  rumorEventId: rumorIdRecipient2,
-                  messageEventId: rumorIdRecipient2,
+                  rumorEventId: sharedRumorId,
+                  messageEventId: 'wrap-2',
                   recipientPubkey: recipientPubkey2,
                   selfWrapPublished: false,
+                  queuedRumorId: partialQueueId,
                 ),
               ],
             );
@@ -927,7 +925,7 @@ void main() {
                   equals(
                     const PartialSend(
                       rumorIds: [
-                        '8888888888888888888888888888888888888888888888888888888888888888',
+                        '7777777777777777777777777777777777777777777777777777777777777777:$recipientPubkey2',
                       ],
                     ),
                   ),

--- a/mobile/test/blocs/dm/conversation/conversation_state_test.dart
+++ b/mobile/test/blocs/dm/conversation/conversation_state_test.dart
@@ -30,6 +30,7 @@ String _pairConversationId(String recipient) =>
 /// additionally exposes [replyToId], which the reply-linkage case needs.
 OutgoingDm _outgoingDm({
   required String id,
+  String? rumorId,
   String content = 'test',
   int createdAtSec = 1700000000,
   String? replyToId,
@@ -46,7 +47,7 @@ OutgoingDm _outgoingDm({
     recipientPubkey: recipientPubkey,
     content: content,
     createdAt: createdAtSec,
-    rumorEventJson: '{}',
+    rumorEventJson: rumorId == null ? '{}' : '{"id":"$rumorId"}',
     replyToId: replyToId,
     recipientWrapStatus: recipientWrap,
     selfWrapStatus: selfWrap,
@@ -114,6 +115,32 @@ void main() {
           expect(bubble.replyToId, isNull);
         },
       );
+
+      test('a shared-rumor group batch exposes the wire id while retaining '
+          'queue handles for recovery', () {
+        const wireId = 'shared-wire-rumor';
+        final pending = _outgoingDm(
+          id: '$wireId:$_recipientB',
+          rumorId: wireId,
+          sendBatchId: 'batch-shared',
+        );
+        final failed = _outgoingDm(
+          id: '$wireId:$_recipientC',
+          rumorId: wireId,
+          recipientPubkey: _recipientC,
+          recipientWrap: OutgoingWrapStatus.failed,
+          sendBatchId: 'batch-shared',
+        );
+        final state = ConversationState(pendingOutgoing: [pending, failed]);
+
+        expect(state.displayedMessages.single.id, equals(wireId));
+        expect(state.statusFor(wireId), equals(DmDeliveryStatus.failed));
+        expect(
+          state.failedSiblingRumorIdsFor(wireId),
+          equals(['$wireId:$_recipientC']),
+          reason: 'recovery still receives the durable queue handle',
+        );
+      });
 
       test(
         'partial group delivery renders exactly ONE bubble with the '
@@ -186,8 +213,8 @@ void main() {
       );
 
       test(
-        'a fully in-flight batch renders one bubble keyed to the lowest '
-        'rumor id',
+        'a legacy in-flight batch renders one bubble keyed to the lowest '
+        'queue handle',
         () {
           final rowB = _outgoingDm(id: 'rumor-b', content: 'live batch');
           final rowC = _outgoingDm(
@@ -458,7 +485,7 @@ void main() {
                 'both sends into a single bubble; the durable sendBatchId '
                 'keeps them independent',
           );
-          // Each batch projects one bubble keyed to its own lowest rumor id.
+          // Legacy fixtures without rumor JSON fall back to queue handles.
           expect(
             displayed.map((m) => m.id),
             unorderedEquals(['rumor-a1', 'rumor-b1']),


### PR DESCRIPTION
## Description

Deleting a group message "for everyone" silently reached only one recipient. Everyone else looked up an id they had never seen and applied nothing, while the sender's UI showed the bubble gone and the retraction confirmed on the wire.

**The divergence was incidental, not intended.** `sendGroupMessage` built a distinct rumor per recipient, and `buildRumor` prepends `['p', recipientPubkey]` — so the siblings carried the same p-tag **set** in a rotated **order**, and a NIP-01 id hashes the tags *array*. The rotation alone forked the id. Measured against the production `Event`:

```
rotated p tags: [aa,bb,cc] [bb,aa,cc] [cc,aa,bb]  ->  3 distinct ids
canonical      : [aa,bb,cc] x3                     ->  1 id
```

So this builds the rumor **once** and wraps it for each recipient, which is what NIP-59 describes — *"a single `rumor` may be wrapped and addressed for each recipient individually"* (`59.md:108`) — and what NIP-17 assumes, since *"The set of `pubkey` + `p` tags defines a chat room"* (`17.md:17`) is a set. It is also already the shape of this repository's own kind-5 deletions (`_fanOutDeletion`) and kind-7 reactions (`_fanOutRumor`); kind-14/15 messages were the outlier. `divine-web` has done it this way all along (`src/lib/dm.ts:483-489`), and so do Amethyst, 0xchat, Coracle and Nostrudel — the breakage was one-directional and ours.

`deleteMessageForEveryone` and the entire receive path are **unchanged**: the existing single `e` tag becomes correct on its own once every participant holds the same id.

The same divergence also broke **group reactions**, and worse — a reaction naming a sibling id the reader doesn't hold cannot resolve its conversation, so `persistIncoming` returns `deferred` and it is never stored at all (`dm_reactions_repository.dart:853`). That is repaired here too.

**Why not multi-`e` on the deletion** (the shape the issue originally proposed): `_routeWrappedDeletion` is conjunct — if any `e` tag fails to resolve the whole wrap returns `deferred`, and deferred wraps are deliberately never ledgered. A group recipient can *never* hold the other N−1 sibling ids, so every group deletion would defer permanently on every recipient and re-decrypt on every later drain. Details in the issue comment.

### The one thing worth reviewing closely

The wire rumor is now shared, so it can no longer key `outgoing_dms` — which tracks delivery per recipient, and whose `enqueue` is `insertOrIgnore` and would have **silently discarded** the siblings rather than thrown. Each group queue row therefore gets a per-recipient handle.

That needs **no migration**: nothing reads the column's format. Both `recoverFullSend` and the partial-delivery `recoverSelfWrap` path resolve the row through the opaque queue handle, then take the rumor from `row.rumorEventJson` and the recipient from `row.recipientPubkey`. A 64-hex rumor id can never contain `:`, so group handles stay disjoint from plain 1:1 ids and from rows written before this change. 1:1 sends are untouched.

## Reproducing this — worth knowing before you review

**A group DM is not reachable through the app's UI today**, so this is a real bug in the data layer that is currently latent in the product. I checked before claiming it:

- `isGroup: true` is written in exactly three places, all inside `sendGroupMessage` (`dm_repository.dart:5330, :5485, :5566`). `recoverFullSend` (`:4550`) only sets it for a queue row a prior `sendGroupMessage` created.
- The inbound path computes `isGroup` from `participants.length > 2` (`:2354`), but `_resolveConversationParticipants` returns `canonical1to1` when no group row already exists (`:7057`) — a deliberate anti-phantom-group guard. So an inbound group message cannot bootstrap one.
- There is **no** `isGroup: true` anywhere in `mobile/lib`.
- The share sheet *is* multi-select, but it fans out N separate 1:1 sends (`video_sharing_service.dart:318-345` loops the singular `sendSharedVideo`), and `NewMessageSheet` is single-select by type signature.

So the loop is closed: a group send needs a group row, and only a group send makes one. Everything downstream of a picker — `ConversationParticipantsCubit` → `ConversationView` → `_SendBar` → `conversation_bloc.dart:282` → `sendGroupMessage` — already handles N>1 and would work as-is.

That is the argument for landing this now rather than alongside a picker: whoever opens that loop should not also inherit a delete-for-everyone that reaches one person and reactions that are never stored.

The E2E test drives the repository directly for exactly this reason.

## Out of Scope

- **#7338** — an inbound group DM is still filed as a 1:1 with the sender (`_resolveConversationParticipants` falls back to `canonical1to1` when no group conversation exists locally). Confirmed empirically by the new E2E, which is why it keys on the rumor id rather than the conversation id. Unchanged here: the p-tag set is identical before and after, so the participant derivation input never moved.
- Messages already sent keep their per-recipient ids. The sender never knew the other recipients' ids, so no migration or alias table can reach them. Forward-only by necessity.
- Bounding the unbounded deferred re-decrypt set (the open follow-up from #8174). This change does not feed it.
- Whether the sender belongs in the rumor's `p` tags. We exclude it, matching Amethyst; divine-web and 0xchat include it. Both are tolerated everywhere — every client keys a room on the participant set — so it is left alone.

## Verification

- `flutter test` in `mobile/packages/dm_repository` — **710 pass**, coverage **94.37%** (gate 93).
- `flutter analyze lib test integration_test` — clean.
- `flutter test test/blocs/dm test/services/outgoing_dm_retry_service_test.dart test/screens/inbox` — **926 pass**.
- New 3-party E2E on real sockets with real NIP-59 gift wrapping, run on macOS. **Both new E2E tests fail on the pre-fix code for the right reason** — verified by reverting the two lib files and re-running — and pass after:

  ```
  Persisted NIP-17 DM 274c2430… in conversation 4e3d1e57…   <- recipient B
  Persisted NIP-17 DM 274c2430… in conversation 425ac1f2…   <- recipient C
  Deleted message 274c2430… via wrapped kind 5
  Applied kind 5 deletion for message 274c2430…             <- B
  Applied kind 5 deletion for message 274c2430…             <- C
  ```

### Verified on the real app, and on the wire

Ran the real app (`env=local`, 1.0.22+820) on the iOS Simulator against the local Docker stack, driving `sendGroupMessage` and `deleteMessageForEveryone` through the Dart VM Service — a group send is not reachable by tapping, per the section above.

App-side, the sender's two self-wrap echoes now collapse on **one** rumor-id primary key (before, they carried different ids and needed the batch-token dedup):

```
Sending NIP-17 encrypted message to recipient   x2
Created recipient gift wrap with ephemeral key: 65a9c6e2…   <- distinct wraps
Created recipient gift wrap with ephemeral key: 6c82a616…
Successfully published NIP-17 message (selfWrapPublished=true)   x2
Skipping duplicate NIP-17 DM 7571504b… : matching message already stored
Wrapping kind 5 rumor event   x2
Deleted message 7571504b… via wrapped kind 5
```

Then, independently of the app — each recipient's wraps pulled off the relay and decrypted with that recipient's own key (`nak req` + `nak gift unwrap`):

```
RECIPIENT B: kind=14 id=7571504bf425765b07bad7eb tags=[p 3c72addb…, p 466d7fca…]
             kind=5  id=da21d72041b11404434affc4 tags=[p 3c72addb…, e 7571504b…]
RECIPIENT C: kind=14 id=7571504bf425765b07bad7eb  <- IDENTICAL
             kind=5  id=da21d72041b11404434affc4 tags=[p 3c72addb…, e 7571504b…]
```

Both participants hold the same kind-14 id, their `p` tags are identical and canonically ordered, and the kind-5 names that shared id and reached both. Before this change those two kind-14s carried different ids and the single `e` tag matched only one of them.

(Only the local relay was ever connected — verified `configuredRelayCount=1` / `defaultRelayUrl=ws://localhost:47777` before publishing, because an account with no kind-10002 makes the auth layer log a public fallback set.)

- Ratchets pass: ungrouped tests, placeholder tests, skip ceiling, test/unit structure, nostr-id truncation, pubkey log encoding, post-close emit, l10n delegates, untested services, layer direction.

`FakeRelay` gained opt-in broadcasting so it can carry a multi-party exchange; it is off by default, so existing tests that assert on what the relay was *sent* see no extra traffic.

**Related Issue:** Closes #8188

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
