### PR TITLE
fix(people-lists): reconcile before replacing an addressable list

### DIFF
--- a/mobile/lib/features/people_lists/bloc/people_lists_bloc.dart
+++ b/mobile/lib/features/people_lists/bloc/people_lists_bloc.dart
@@ -547,7 +547,7 @@ class PeopleListsBloc extends Bloc<PeopleListsEvent, PeopleListsState> {
         pubkey: pubkey,
       );
       if (!_resultStillApplies(mutation, owner)) return;
-      if (!result.submitted) {
+      if (result.status == PeopleListPublishStatus.failed) {
         _emitRollback(emit, mutation.id, undo);
         return;
       }
@@ -618,7 +618,7 @@ class PeopleListsBloc extends Bloc<PeopleListsEvent, PeopleListsState> {
         pubkey: pubkey,
       );
       if (!_resultStillApplies(mutation, owner)) return;
-      if (!result.submitted) {
+      if (result.status == PeopleListPublishStatus.failed) {
         _emitRollback(emit, mutation.id, undo);
         return;
       }

--- a/mobile/packages/people_lists_repository/lib/src/people_lists_repository_impl.dart
+++ b/mobile/packages/people_lists_repository/lib/src/people_lists_repository_impl.dart
@@ -57,15 +57,51 @@ class PeopleListsRepositoryImpl implements PeopleListsRepository {
     return _cache.readLists(ownerPubkey: ownerPubkey);
   }
 
+  /// How long an authoritative read waits for every relay to settle.
+  ///
+  /// Deliberately shorter than the 5s default: an expiry reports `timedOut`,
+  /// which refuses the mutation, so erring short errs toward not publishing
+  /// over a list we could not read.
+  static const _reconcileTimeout = Duration(seconds: 3);
+
   @override
   Future<void> syncOwner({required String ownerPubkey}) async {
+    await _reconcileOwner(ownerPubkey);
+  }
+
+  /// Refresh the cached lists for [ownerPubkey] and report whether the answer
+  /// was conclusive.
+  ///
+  /// Returns `false` when no relay settled the query — a timeout, or a fan-out
+  /// no relay took. That is not the same as "this owner has no lists", and the
+  /// difference decides whether it is safe to publish a replacement: these are
+  /// addressable events, so a full replacement built on a stale cache drops
+  /// every member only the relay's copy holds (#8273).
+  ///
+  /// [NostrClient.queryEvents] cannot express this — it drops `timedOut` and
+  /// `noRelays` — which is why the detailed form is used, with
+  /// `requireAllRelaysSettled` so a relay abandoned by the settle window
+  /// arrives as a timeout rather than as an empty answer.
+  ///
+  /// [addPubkey] and [removePubkey] report an inconclusive answer as
+  /// [PeopleListPublishResult.failed] rather than publishing over it — the
+  /// bloc rolls its optimistic update back on that, and unlike a block or a
+  /// follow there is no local-only meaning to preserve here: the list *is*
+  /// the published artifact.
+  Future<bool> _reconcileOwner(String ownerPubkey) async {
     final filter = Filter(
       kinds: const [Nip51PeopleListCodec.kind],
       authors: [ownerPubkey],
     );
 
-    final events = await _nostrClient.queryEvents([filter]);
-    if (events.isEmpty) return;
+    final result = await _nostrClient.queryEventsDetailed(
+      [filter],
+      requireAllRelaysSettled: true,
+      timeout: _reconcileTimeout,
+    );
+    final conclusive = !result.timedOut && !result.noRelays;
+    final events = result.events;
+    if (events.isEmpty) return conclusive;
 
     // Index existing lists by id so we can skip stale relay echoes whose
     // createdAt is older than the locally-stored updatedAt. The cache alone
@@ -94,6 +130,7 @@ class PeopleListsRepositoryImpl implements PeopleListsRepository {
         receivedAt: receivedAt,
       );
     }
+    return conclusive;
   }
 
   @override
@@ -123,6 +160,10 @@ class PeopleListsRepositoryImpl implements PeopleListsRepository {
     required String listId,
     required String pubkey,
   }) async {
+    // A replacement built on a stale cache drops members only the relay has.
+    if (!await _reconcileOwner(ownerPubkey)) {
+      return const PeopleListPublishResult.failed();
+    }
     final existing = await _findList(ownerPubkey: ownerPubkey, listId: listId);
     if (existing == null) {
       return const PeopleListPublishResult.failed();
@@ -143,6 +184,10 @@ class PeopleListsRepositoryImpl implements PeopleListsRepository {
     required String listId,
     required String pubkey,
   }) async {
+    // A replacement built on a stale cache drops members only the relay has.
+    if (!await _reconcileOwner(ownerPubkey)) {
+      return const PeopleListPublishResult.failed();
+    }
     final existing = await _findList(ownerPubkey: ownerPubkey, listId: listId);
     if (existing == null) {
       return const PeopleListPublishResult.failed();

--- a/mobile/packages/people_lists_repository/test/people_lists_repository_impl_test.dart
+++ b/mobile/packages/people_lists_repository/test/people_lists_repository_impl_test.dart
@@ -25,7 +25,7 @@ class _MockNostrClient extends Mock implements NostrClient {
     when(
       () => queryEventsDetailed(
         any(),
-        requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+        requireAllRelaysSettled: true,
         timeout: any(named: 'timeout'),
       ),
     ).thenAnswer((invocation) async {
@@ -440,7 +440,7 @@ void main() {
         when(
           () => client.queryEventsDetailed(
             any(),
-            requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+            requireAllRelaysSettled: true,
             timeout: any(named: 'timeout'),
           ),
         ).thenAnswer(
@@ -531,10 +531,17 @@ void main() {
 
         expect(result.status, equals(PeopleListPublishStatus.submitted));
         verify(() => client.publishEvent(any())).called(1);
+        verify(
+          () => client.queryEventsDetailed(
+            any(),
+            requireAllRelaysSettled: true,
+            timeout: any(named: 'timeout'),
+          ),
+        ).called(1);
       });
 
       test(
-        'a concurrent member added elsewhere survives the next local edit',
+        'a member added elsewhere before a local edit survives replacement',
         () async {
           final client = publishingClient();
           final repository = buildRepository(nostrClient: client);
@@ -542,7 +549,6 @@ void main() {
 
           // Another client added a member since; the reconcile must learn
           // about it before this device rebuilds the replacement.
-          // before this device rebuilds the replacement.
           stubReconcile(
             client,
             events: [

--- a/mobile/packages/people_lists_repository/test/people_lists_repository_impl_test.dart
+++ b/mobile/packages/people_lists_repository/test/people_lists_repository_impl_test.dart
@@ -11,7 +11,33 @@ import 'package:nostr_sdk/nostr_sdk.dart';
 import 'package:people_lists_repository/people_lists_repository.dart';
 import 'package:test/test.dart';
 
-class _MockNostrClient extends Mock implements NostrClient {}
+class _MockNostrClient extends Mock implements NostrClient {
+  _MockNostrClient() {
+    // Self-registered so the stub below works without each file needing its
+    // own `setUpAll`. Idempotent.
+    registerFallbackValue(Duration.zero);
+    // The reconcile that precedes a publish goes through `queryEventsDetailed`
+    // so it can tell a relay's "I hold nothing" apart from an answer nobody
+    // gave (#8273). Mirror whatever `queryEvents` is stubbed to return, as a
+    // *settled* answer — the state every existing test describes. Tests about
+    // the inconclusive read override this with `timedOut` or `noRelays`.
+    when(() => queryEvents(any())).thenAnswer((_) async => <Event>[]);
+    when(
+      () => queryEventsDetailed(
+        any(),
+        requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+        timeout: any(named: 'timeout'),
+      ),
+    ).thenAnswer((invocation) async {
+      final filters = invocation.positionalArguments[0] as List<Filter>;
+      return (
+        events: await queryEvents(filters),
+        timedOut: false,
+        noRelays: false,
+      );
+    });
+  }
+}
 
 class _FakeEvent extends Fake implements Event {}
 
@@ -385,6 +411,175 @@ void main() {
         final stored = await repository.readLists(ownerPubkey: _ownerPubkey);
         expect(stored.single.pubkeys, equals(const [_memberB]));
       });
+    });
+
+    group('inconclusive reconcile before a replacement (#8273)', () {
+      _MockNostrClient publishingClient() {
+        final client = _MockNostrClient();
+        when(() => client.publicKey).thenReturn(_ownerPubkey);
+        when(() => client.publishEvent(any())).thenAnswer((invocation) async {
+          final event = invocation.positionalArguments.first as Event;
+          return PublishSuccess(
+            event: signedEvent(
+              kind: event.kind,
+              tags: event.tags,
+              content: event.content,
+              createdAt: event.createdAt,
+            ),
+          );
+        });
+        return client;
+      }
+
+      void stubReconcile(
+        _MockNostrClient client, {
+        List<Event> events = const <Event>[],
+        bool timedOut = false,
+        bool noRelays = false,
+      }) {
+        when(
+          () => client.queryEventsDetailed(
+            any(),
+            requireAllRelaysSettled: any(named: 'requireAllRelaysSettled'),
+            timeout: any(named: 'timeout'),
+          ),
+        ).thenAnswer(
+          (_) async => (events: events, timedOut: timedOut, noRelays: noRelays),
+        );
+      }
+
+      const memberAddedElsewhere =
+          '4444444444444444444444444444444444444444444444444444444444444444';
+
+      Future<String> seedList(PeopleListsRepositoryImpl repository) async {
+        await repository.createList(
+          ownerPubkey: _ownerPubkey,
+          name: 'Besties',
+          initialPubkeys: const [_memberA],
+        );
+        return (await repository.readLists(
+          ownerPubkey: _ownerPubkey,
+        )).single.id;
+      }
+
+      test('addPubkey does not publish when the reconcile timed out', () async {
+        final client = publishingClient();
+        final repository = buildRepository(nostrClient: client);
+        final listId = await seedList(repository);
+        clearInteractions(client);
+        stubReconcile(client, timedOut: true);
+
+        final result = await repository.addPubkey(
+          ownerPubkey: _ownerPubkey,
+          listId: listId,
+          pubkey: _memberB,
+        );
+
+        expect(result.status, equals(PeopleListPublishStatus.failed));
+        verifyNever(() => client.publishEvent(any()));
+      });
+
+      test('addPubkey does not publish when no relay took the query', () async {
+        final client = publishingClient();
+        final repository = buildRepository(nostrClient: client);
+        final listId = await seedList(repository);
+        clearInteractions(client);
+        stubReconcile(client, noRelays: true);
+
+        final result = await repository.addPubkey(
+          ownerPubkey: _ownerPubkey,
+          listId: listId,
+          pubkey: _memberB,
+        );
+
+        expect(result.status, equals(PeopleListPublishStatus.failed));
+        verifyNever(() => client.publishEvent(any()));
+      });
+
+      test(
+        'removePubkey does not publish when the reconcile is inconclusive',
+        () async {
+          final client = publishingClient();
+          final repository = buildRepository(nostrClient: client);
+          final listId = await seedList(repository);
+          clearInteractions(client);
+          stubReconcile(client, timedOut: true);
+
+          final result = await repository.removePubkey(
+            ownerPubkey: _ownerPubkey,
+            listId: listId,
+            pubkey: _memberA,
+          );
+
+          expect(result.status, equals(PeopleListPublishStatus.failed));
+          verifyNever(() => client.publishEvent(any()));
+        },
+      );
+
+      test('a settled empty reconcile still publishes', () async {
+        final client = publishingClient();
+        final repository = buildRepository(nostrClient: client);
+        final listId = await seedList(repository);
+        clearInteractions(client);
+        stubReconcile(client);
+
+        final result = await repository.addPubkey(
+          ownerPubkey: _ownerPubkey,
+          listId: listId,
+          pubkey: _memberB,
+        );
+
+        expect(result.status, equals(PeopleListPublishStatus.submitted));
+        verify(() => client.publishEvent(any())).called(1);
+      });
+
+      test(
+        'a concurrent member added elsewhere survives the next local edit',
+        () async {
+          final client = publishingClient();
+          final repository = buildRepository(nostrClient: client);
+          final listId = await seedList(repository);
+
+          // Another client added a member since; the reconcile must learn
+          // about it before this device rebuilds the replacement.
+          // before this device rebuilds the replacement.
+          stubReconcile(
+            client,
+            events: [
+              signedEvent(
+                kind: Nip51PeopleListCodec.kind,
+                tags: [
+                  ['d', listId],
+                  ['title', 'Besties'],
+                  ['p', _memberA],
+                  ['p', memberAddedElsewhere],
+                ],
+                createdAt:
+                    DateTime.now().toUtc().millisecondsSinceEpoch ~/ 1000 + 60,
+              ),
+            ],
+          );
+
+          final result = await repository.addPubkey(
+            ownerPubkey: _ownerPubkey,
+            listId: listId,
+            pubkey: _memberB,
+          );
+
+          expect(result.status, equals(PeopleListPublishStatus.submitted));
+          final published =
+              verify(() => client.publishEvent(captureAny())).captured.last
+                  as Event;
+          final members = published.tags
+              .where((tag) => tag.isNotEmpty && tag.first == 'p')
+              .map((tag) => tag[1])
+              .toSet();
+          expect(
+            members,
+            containsAll(<String>[_memberA, _memberB, memberAddedElsewhere]),
+          );
+        },
+      );
     });
 
     group('deleteList', () {

--- a/mobile/test/features/people_lists/bloc/people_lists_bloc_test.dart
+++ b/mobile/test/features/people_lists/bloc/people_lists_bloc_test.dart
@@ -1371,6 +1371,90 @@ void main() {
           equals([_memberAlice, _memberBob]),
         );
       });
+
+      test('a reconciled add noop keeps the relay member', () async {
+        final publish = Completer<PeopleListPublishResult>();
+        when(
+          () => repository.addPubkey(
+            ownerPubkey: _ownerA,
+            listId: 'l1',
+            pubkey: _memberBob,
+          ),
+        ).thenAnswer((_) => publish.future);
+
+        final bloc = await startedWithOwnerALists([
+          _buildList(id: 'l1', name: 'Friends', pubkeys: const [_memberAlice]),
+        ]);
+        addTearDown(bloc.close);
+
+        bloc.add(
+          const PeopleListsPubkeyAddRequested(listId: 'l1', pubkey: _memberBob),
+        );
+        await _flush();
+
+        // Reconciliation discovers that another client already added Bob.
+        ownerAListsController.add([
+          _buildList(
+            id: 'l1',
+            name: 'Friends',
+            pubkeys: const [_memberAlice, _memberBob],
+          ),
+        ]);
+        await _flush();
+
+        publish.complete(const PeopleListPublishResult.noop());
+        await _flush();
+        await _flush();
+
+        expect(bloc.state.status, equals(PeopleListsStatus.ready));
+        expect(
+          bloc.state.lists.single.pubkeys,
+          equals([_memberAlice, _memberBob]),
+        );
+        expect(bloc.state.pendingMutations, isEmpty);
+      });
+
+      test('a reconciled remove noop keeps the relay removal', () async {
+        final publish = Completer<PeopleListPublishResult>();
+        when(
+          () => repository.removePubkey(
+            ownerPubkey: _ownerA,
+            listId: 'l1',
+            pubkey: _memberAlice,
+          ),
+        ).thenAnswer((_) => publish.future);
+
+        final bloc = await startedWithOwnerALists([
+          _buildList(
+            id: 'l1',
+            name: 'Friends',
+            pubkeys: const [_memberAlice, _memberBob],
+          ),
+        ]);
+        addTearDown(bloc.close);
+
+        bloc.add(
+          const PeopleListsPubkeyRemoveRequested(
+            listId: 'l1',
+            pubkey: _memberAlice,
+          ),
+        );
+        await _flush();
+
+        // Reconciliation discovers that another client already removed Alice.
+        ownerAListsController.add([
+          _buildList(id: 'l1', name: 'Friends', pubkeys: const [_memberBob]),
+        ]);
+        await _flush();
+
+        publish.complete(const PeopleListPublishResult.noop());
+        await _flush();
+        await _flush();
+
+        expect(bloc.state.status, equals(PeopleListsStatus.ready));
+        expect(bloc.state.lists.single.pubkeys, equals([_memberBob]));
+        expect(bloc.state.pendingMutations, isEmpty);
+      });
     });
 
     // #6504: rollbacks are computed from a snapshot captured before the


### PR DESCRIPTION
Fixes #8273. Found by the #8258 audit — third and last of the three sites it
confirmed.

## The bug

`addPubkey` and `removePubkey` built their replacement from
`_cache.readLists()` and published it without asking the relay. These are
NIP-51 addressable events, so the publish is a **full replacement**: a stale
cache drops every member only the relay's copy holds.

**Scope, stated honestly — this is not #6750.** An *empty* cache was already
safe: `_findList` returns `null` and the method returns `failed()` without
publishing, so a fresh install cannot wipe a populated remote list. What bites
is a **stale** cache — {A,B} on the relay, another client adds C, this device
still says {A,B}, the user adds D here, and C is gone. It needs a concurrent
edit elsewhere, not just a cold start. (I corrected an earlier overstatement of
this on #8258.)

Nothing kept the cache fresh:

1. `syncOwner` is fired **`unawaited`** from the bloc (`people_lists_bloc.dart:340`).
2. It read through `NostrClient.queryEvents`, which discards `timedOut` and
   `noRelays` — a fan-out no relay took, a `CLOSED`, a disposed client and a
   closed query pool all arrive as an ordinary empty list.
3. On that empty list it returned early, so a failed read left the cache stale
   and said nothing.

## The fix

Extract `_reconcileOwner`, reading through
`queryEventsDetailed(requireAllRelaysSettled: true)` and reporting whether the
answer was conclusive. `syncOwner` delegates to it — so a failed sync stops
being indistinguishable from an empty one — and both mutations refuse to
publish when it says no. A settled answer of zero events stays conclusive.

The read uses a **3s budget** rather than the 5s default: an expiry reports
`timedOut`, which refuses, so erring short errs toward not overwriting.

## Why this one fails instead of deferring

#6750 and #8265 keep the action locally and retry, because a block still
filters your feed and a follow still shows in your UI. A people list has no
local-only meaning — the list *is* the published artifact — so an inconclusive
read returns the existing `PeopleListPublishResult.failed()`, which the bloc
already handles by rolling its optimistic update back. No new failure contract.

`createList` and `deleteList` are deliberately untouched: the first mints a new
`d` tag with nothing to lose, the second publishes a kind-5 deletion rather than
a replacement.

## Verification

- 94 tests pass; coverage **96.61%** against the package's `min_coverage: 95`,
  and *up* from the 96.56% baseline. The remaining uncovered lines are
  pre-existing error-log paths in `deleteList` and `searchPublicLists`.
- Mutation run: disabling the guard turns 4 of the 5 new tests red.
- `flutter analyze` clean.

New tests pin: no publish on `timedOut`; none on `noRelays`; `removePubkey`
behaves the same; a settled-empty reconcile still publishes; and — the one that
states the actual bug — a member added on another client survives the next local
edit rather than being dropped.

Existing tests kept their assertions: `_MockNostrClient` now mirrors whatever
`queryEvents` is stubbed to return as a *settled* answer, which is the state
they were all written in.

## Not in scope

#8274 — curated lists have the same publish shape but **no relay reconcile of
the user's own lists at all**; `_lists` comes from SharedPreferences and is
never refreshed. That is a local-first design decision, not an oversight, so it
is filed as a product question rather than patched here.
