### PR TITLE
fix(privacy): harden account deletion sweep

### DIFF
--- a/mobile/lib/services/account_deletion_service.dart
+++ b/mobile/lib/services/account_deletion_service.dart
@@ -496,7 +496,11 @@ class AccountDeletionService {
     final total = events.length;
     final connectedRelays = _nostrService.connectedRelays;
     final kind5TargetRelays = connectedRelays
-        .where((relay) => !isDivineHostedRelayUrl(relay))
+        .where(
+          (relay) =>
+              !isDivineHostedRelayUrl(relay) &&
+              _nostrService.isRelayAllowed(relay),
+        )
         .toList(growable: false);
 
     if (connectedRelays.isEmpty) {

--- a/mobile/lib/services/account_deletion_service.dart
+++ b/mobile/lib/services/account_deletion_service.dart
@@ -47,15 +47,16 @@ class DeleteAccountResult {
   final int deletedEventsCount;
 
   /// True when the relay query that enumerates the user's existing content
-  /// failed, so the kind-5 sweep covered nothing.
+  /// failed or timed out, so the kind-5 sweep may have covered only cached or
+  /// partial results.
   ///
   /// The vanish request may still have been published, so the caller must tell
-  /// the user their existing content was *not* individually requested for
-  /// deletion rather than reporting an unqualified success.
+  /// the user their existing content may not all have been individually
+  /// requested for deletion rather than reporting an unqualified success.
   final bool contentQueryFailed;
 
-  /// True when at least one queried event did not get an OK-confirmed kind-5
-  /// deletion request.
+  /// True when enumeration reached its cap or at least one event that required
+  /// a kind-5 compatibility request did not get an OK confirmation.
   final bool contentDeletionIncomplete;
 
   factory DeleteAccountResult.createSuccess(
@@ -133,6 +134,9 @@ class AccountDeletionService {
   );
   static const _interBatchDelay = Duration(milliseconds: 500);
   static const _rateLimitRetryDelay = Duration(minutes: 1);
+  static const _sweepQueryLimit = 10000;
+  static const _sweepQueryTimeout = Duration(seconds: 30);
+  static const _divineRelayHost = 'relay.divine.video';
 
   /// Kinds this flow's own deletion machinery produces, excluded from the sweep.
   ///
@@ -182,6 +186,7 @@ class AccountDeletionService {
     String? expectedPubkey,
   }) async {
     var deletedCount = 0;
+    var kind5DeletionIncomplete = false;
     try {
       if (!_authService.isAuthenticated) {
         return DeleteAccountResult.failure(
@@ -218,18 +223,20 @@ class AccountDeletionService {
 
       Log.info(
         'Found ${allUserEvents.length} events to delete'
-        '${sweep.queryFailed ? ' (relay query FAILED — sweep will cover nothing)' : ''}',
+        '${sweep.queryFailed ? ' (relay query incomplete)' : ''}',
         name: 'AccountDeletionService',
         category: LogCategory.system,
       );
 
       if (allUserEvents.isNotEmpty) {
-        deletedCount = await _publishDeletionEventsForAll(
+        final deletion = await _publishDeletionEventsForAll(
           allUserEvents,
           reason,
           expectedPubkey: expectedPubkey,
           onProgress: onProgress,
         );
+        deletedCount = deletion.confirmedCount;
+        kind5DeletionIncomplete = deletion.incomplete;
 
         Log.info(
           'Published $deletedCount NIP-09 deletion requests',
@@ -293,7 +300,7 @@ class AccountDeletionService {
         deletedEventsCount: deletedCount,
         contentQueryFailed: sweep.queryFailed,
         contentDeletionIncomplete:
-            allUserEvents.isNotEmpty && deletedCount < allUserEvents.length,
+            sweep.reachedLimit || kind5DeletionIncomplete,
       );
     } on AccountChangedAfterDeletion {
       Log.warning(
@@ -409,27 +416,29 @@ class AccountDeletionService {
   /// NIP-01 filters cannot express "every kind except these", so the query stays
   /// broad and [_kindsExcludedFromSweep] is applied here.
   ///
-  /// Returns `queryFailed: true` when the relay query itself failed. The caller
-  /// must not treat that as "this account has no content" — the previous
-  /// behaviour of swallowing the error into an empty list silently skipped the
-  /// entire sweep while still publishing the vanish.
-  Future<({List<Event> events, bool queryFailed})> _fetchSweepTargets(
-    String pubkey,
-  ) async {
+  /// Returns `queryFailed: true` when the relay query failed or timed out. The
+  /// caller must not treat cached or partial results as complete enumeration.
+  Future<({List<Event> events, bool queryFailed, bool reachedLimit})>
+  _fetchSweepTargets(String pubkey) async {
     if (_nostrService.isDisposed) {
       Log.error(
         'Failed to fetch user events: Nostr client is disposed',
         name: 'AccountDeletionService',
         category: LogCategory.system,
       );
-      return (events: const <Event>[], queryFailed: true);
+      return (events: const <Event>[], queryFailed: true, reachedLimit: false);
     }
 
     try {
-      final filter = Filter(authors: [pubkey], limit: 10000);
-      final query = await _nostrService.queryEventsDetailed([filter]);
+      final filter = Filter(authors: [pubkey], limit: _sweepQueryLimit);
+      final query = await _nostrService.queryEventsDetailed(
+        [filter],
+        timeout: _sweepQueryTimeout,
+        requireAllRelaysSettled: true,
+      );
       final events = query.events;
       final queryFailed = query.timedOut || query.noRelays;
+      final reachedLimit = events.length >= _sweepQueryLimit;
 
       final targets = events
           .where((event) => !_kindsExcludedFromSweep.contains(event.kind))
@@ -452,19 +461,32 @@ class AccountDeletionService {
         );
       }
 
-      return (events: targets, queryFailed: queryFailed);
+      if (reachedLimit) {
+        Log.warning(
+          'Relay query reached the $_sweepQueryLimit-event account deletion '
+          'sweep limit for user ${pubkeyForLogs(pubkey)}',
+          name: 'AccountDeletionService',
+          category: LogCategory.system,
+        );
+      }
+
+      return (
+        events: targets,
+        queryFailed: queryFailed,
+        reachedLimit: reachedLimit,
+      );
     } catch (e) {
       Log.error(
         'Failed to fetch user events: $e',
         name: 'AccountDeletionService',
         category: LogCategory.system,
       );
-      return (events: const <Event>[], queryFailed: true);
+      return (events: const <Event>[], queryFailed: true, reachedLimit: false);
     }
   }
 
   /// Publish NIP-09 kind 5 deletion events for all user events
-  Future<int> _publishDeletionEventsForAll(
+  Future<({int confirmedCount, bool incomplete})> _publishDeletionEventsForAll(
     List<Event> events,
     String reason, {
     String? expectedPubkey,
@@ -472,6 +494,23 @@ class AccountDeletionService {
   }) async {
     int successCount = 0;
     final total = events.length;
+    final connectedRelays = _nostrService.connectedRelays;
+    final kind5TargetRelays = connectedRelays
+        .where((relay) => Uri.tryParse(relay)?.host != _divineRelayHost)
+        .toList(growable: false);
+    final excludesDivineRelay =
+        kind5TargetRelays.length < connectedRelays.length;
+
+    if (excludesDivineRelay && kind5TargetRelays.isEmpty) {
+      Log.info(
+        'Skipping NIP-09 sweep because no connected relay requires the '
+        'NIP-62 compatibility fallback',
+        name: 'AccountDeletionService',
+        category: LogCategory.system,
+      );
+      onProgress?.call(total, total);
+      return (confirmedCount: 0, incomplete: false);
+    }
 
     final eventsByKind = <int, List<Event>>{};
     for (final event in events) {
@@ -500,14 +539,24 @@ class AccountDeletionService {
       }
 
       if (deleteEvent != null) {
-        var outcome = await _nostrService.publishEventAwaitOk(deleteEvent);
+        var outcome = excludesDivineRelay
+            ? await _nostrService.publishEventAwaitOk(
+                deleteEvent,
+                targetRelays: kind5TargetRelays,
+              )
+            : await _nostrService.publishEventAwaitOk(deleteEvent);
         if (isRateLimitedOutcome(outcome)) {
           await _retryDelay(_rateLimitRetryDelay);
           _assertSignerStillMatches(
             expectedPubkey,
             anyConfirmed: successCount > 0,
           );
-          outcome = await _nostrService.publishEventAwaitOk(deleteEvent);
+          outcome = excludesDivineRelay
+              ? await _nostrService.publishEventAwaitOk(
+                  deleteEvent,
+                  targetRelays: kind5TargetRelays,
+                )
+              : await _nostrService.publishEventAwaitOk(deleteEvent);
         }
         _assertSignerStillMatches(
           expectedPubkey,
@@ -524,7 +573,7 @@ class AccountDeletionService {
             category: LogCategory.system,
           );
           onProgress?.call(successCount, total);
-          return successCount;
+          return (confirmedCount: successCount, incomplete: true);
         }
         if (outcome.confirmed) {
           successCount += kindEvents.length;
@@ -553,7 +602,7 @@ class AccountDeletionService {
       }
     }
 
-    return successCount;
+    return (confirmedCount: successCount, incomplete: successCount < total);
   }
 
   /// Create NIP-09 kind 5 deletion event for multiple events of the same kind

--- a/mobile/lib/services/account_deletion_service.dart
+++ b/mobile/lib/services/account_deletion_service.dart
@@ -8,6 +8,7 @@ import 'package:nostr_sdk/filter.dart';
 import 'package:nostr_sdk/nip19/pubkey_for_logs.dart';
 import 'package:nostr_sdk/relay/publish_outcome.dart';
 import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/utils/relay_url_utils.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 /// User-facing class of an account deletion failure.
@@ -136,7 +137,6 @@ class AccountDeletionService {
   static const _rateLimitRetryDelay = Duration(minutes: 1);
   static const _sweepQueryLimit = 10000;
   static const _sweepQueryTimeout = Duration(seconds: 30);
-  static const _divineRelayHost = 'relay.divine.video';
 
   /// Kinds this flow's own deletion machinery produces, excluded from the sweep.
   ///
@@ -496,7 +496,7 @@ class AccountDeletionService {
     final total = events.length;
     final connectedRelays = _nostrService.connectedRelays;
     final kind5TargetRelays = connectedRelays
-        .where((relay) => Uri.tryParse(relay)?.host != _divineRelayHost)
+        .where((relay) => !isDivineHostedRelayUrl(relay))
         .toList(growable: false);
 
     if (connectedRelays.isEmpty) {

--- a/mobile/lib/services/account_deletion_service.dart
+++ b/mobile/lib/services/account_deletion_service.dart
@@ -498,10 +498,18 @@ class AccountDeletionService {
     final kind5TargetRelays = connectedRelays
         .where((relay) => Uri.tryParse(relay)?.host != _divineRelayHost)
         .toList(growable: false);
-    final excludesDivineRelay =
-        kind5TargetRelays.length < connectedRelays.length;
 
-    if (excludesDivineRelay && kind5TargetRelays.isEmpty) {
+    if (connectedRelays.isEmpty) {
+      Log.warning(
+        'Skipping NIP-09 sweep because no relay is connected',
+        name: 'AccountDeletionService',
+        category: LogCategory.system,
+      );
+      onProgress?.call(total, total);
+      return (confirmedCount: 0, incomplete: true);
+    }
+
+    if (kind5TargetRelays.isEmpty) {
       Log.info(
         'Skipping NIP-09 sweep because no connected relay requires the '
         'NIP-62 compatibility fallback',
@@ -539,24 +547,20 @@ class AccountDeletionService {
       }
 
       if (deleteEvent != null) {
-        var outcome = excludesDivineRelay
-            ? await _nostrService.publishEventAwaitOk(
-                deleteEvent,
-                targetRelays: kind5TargetRelays,
-              )
-            : await _nostrService.publishEventAwaitOk(deleteEvent);
+        var outcome = await _nostrService.publishEventAwaitOk(
+          deleteEvent,
+          targetRelays: kind5TargetRelays,
+        );
         if (isRateLimitedOutcome(outcome)) {
           await _retryDelay(_rateLimitRetryDelay);
           _assertSignerStillMatches(
             expectedPubkey,
             anyConfirmed: successCount > 0,
           );
-          outcome = excludesDivineRelay
-              ? await _nostrService.publishEventAwaitOk(
-                  deleteEvent,
-                  targetRelays: kind5TargetRelays,
-                )
-              : await _nostrService.publishEventAwaitOk(deleteEvent);
+          outcome = await _nostrService.publishEventAwaitOk(
+            deleteEvent,
+            targetRelays: kind5TargetRelays,
+          );
         }
         _assertSignerStillMatches(
           expectedPubkey,

--- a/mobile/lib/utils/nostr_timestamp.dart
+++ b/mobile/lib/utils/nostr_timestamp.dart
@@ -33,6 +33,8 @@ class NostrTimestamp {
       case 3: // Contact list
       case 7: // Reaction
         return defaultClockDriftTolerance;
+      case 62: // Request to vanish; its timestamp is the deletion boundary.
+        return 0;
       default:
         return defaultClockDriftTolerance;
     }

--- a/mobile/lib/widgets/delete_account_dialog.dart
+++ b/mobile/lib/widgets/delete_account_dialog.dart
@@ -879,11 +879,9 @@ Future<void> executeAccountDeletion({
       // outcome is reported through the messenger captured up front — gating
       // this on `context.mounted` left a completed deletion silent (#6450).
       dismissProgressSheet();
-      // When the relay query that enumerates existing content failed, no
-      // per-item deletion request was sent for anything the user had already
-      // posted. When a kind-5 batch was not confirmed, some per-item requests
-      // also did not land. Saying "deletion requests sent" would overstate
-      // either outcome.
+      // A failed or timed-out relay query may only enumerate cached or partial
+      // content. A capped query or unconfirmed kind-5 batch is incomplete too.
+      // Saying "deletion requests sent" would overstate any of these outcomes.
       final snackbarText =
           keyDeletionWarning ??
           localDataDeletionFailure ??

--- a/mobile/test/services/account_deletion_service_test.dart
+++ b/mobile/test/services/account_deletion_service_test.dart
@@ -17,6 +17,8 @@ class _MockNostrClient extends Mock implements NostrClient {
   /// Drives the `timedOut` field of the record synthesized below, so tests
   /// keep stubbing the simpler [queryEvents] for the event list.
   bool queryTimedOut = false;
+  Duration? queryTimeout;
+  bool? queryRequiresAllRelaysSettled;
 
   @override
   Future<({List<Event> events, bool timedOut, bool noRelays})>
@@ -31,6 +33,8 @@ class _MockNostrClient extends Mock implements NostrClient {
     Duration timeout = const Duration(seconds: 5),
     bool requireAllRelaysSettled = false,
   }) async {
+    queryTimeout = timeout;
+    queryRequiresAllRelaysSettled = requireAllRelaysSettled;
     final events = await queryEvents(filters);
     return (
       events: events,
@@ -643,6 +647,99 @@ void main() {
         },
       );
 
+      test('does not publish kind 5 to the Divine relay', () async {
+        const divineRelay = 'wss://relay.divine.video';
+        const fallbackRelay = 'wss://relay.example.com';
+        when(
+          () => mockNostrService.connectedRelays,
+        ).thenReturn([divineRelay, fallbackRelay]);
+        final userEvent = createTestEvent(
+          pubkey: testPublicKey,
+          kind: 1,
+          tags: const [],
+          content: 'note',
+          id: 'note_for_external_sweep',
+        );
+        when(
+          () => mockNostrService.queryEvents(any()),
+        ).thenAnswer((_) async => [userEvent]);
+        when(
+          () => mockAuthService.createAndSignEvent(
+            kind: any(named: 'kind'),
+            content: any(named: 'content'),
+            tags: any(named: 'tags'),
+          ),
+        ).thenAnswer((invocation) async {
+          final kind = invocation.namedArguments[const Symbol('kind')] as int;
+          return createTestEvent(
+            pubkey: testPublicKey,
+            kind: kind,
+            tags: const [],
+            content: 'deletion',
+          );
+        });
+        when(
+          () => mockNostrService.publishEventAwaitOk(
+            any(),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((_) async => _confirmed);
+
+        final result = await service.deleteAccount();
+
+        expect(result.success, isTrue);
+        verify(
+          () => mockNostrService.publishEventAwaitOk(
+            any(),
+            targetRelays: [fallbackRelay],
+          ),
+        ).called(1);
+      });
+
+      test('skips kind 5 when only the Divine relay is connected', () async {
+        when(
+          () => mockNostrService.connectedRelays,
+        ).thenReturn(['wss://relay.divine.video']);
+        when(() => mockNostrService.queryEvents(any())).thenAnswer(
+          (_) async => [
+            createTestEvent(
+              pubkey: testPublicKey,
+              kind: 1,
+              tags: const [],
+              content: 'note',
+            ),
+          ],
+        );
+        when(
+          () => mockAuthService.createAndSignEvent(
+            kind: any(named: 'kind'),
+            content: any(named: 'content'),
+            tags: any(named: 'tags'),
+          ),
+        ).thenAnswer(
+          (_) async => createTestEvent(
+            pubkey: testPublicKey,
+            kind: 62,
+            tags: const [
+              ['relay', 'ALL_RELAYS'],
+            ],
+            content: 'deletion',
+          ),
+        );
+
+        final result = await service.deleteAccount();
+
+        expect(result.success, isTrue);
+        expect(result.deletedEventsCount, 0);
+        expect(result.contentDeletionIncomplete, isFalse);
+        verifyNever(
+          () => mockNostrService.publishEventAwaitOk(
+            any(),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        );
+      });
+
       test('should group events by kind for batch deletion', () async {
         // Arrange
         final videoEvent1 = createTestEvent(
@@ -1021,78 +1118,75 @@ void main() {
         },
       );
 
-      test(
-        'reports partial deletion when the account changes during the '
-        'inter-batch delay after a batch was confirmed',
-        () async {
-          var current = testPublicKey;
-          when(
-            () => mockAuthService.currentPublicKeyHex,
-          ).thenAnswer((_) => current);
+      test('reports partial deletion when the account changes during the '
+          'inter-batch delay after a batch was confirmed', () async {
+        var current = testPublicKey;
+        when(
+          () => mockAuthService.currentPublicKeyHex,
+        ).thenAnswer((_) => current);
 
-          final delays = <Duration>[];
-          final pacingService = AccountDeletionService(
-            nostrService: mockNostrService,
-            authService: mockAuthService,
-            retryDelay: (delay) async {
-              delays.add(delay);
-              // Swap the signed-in account while the sweep waits between
-              // batches, after batch 0 has already been confirmed on relays.
-              current = 'a_different_pubkey_than_confirmed';
-            },
-          );
+        final delays = <Duration>[];
+        final pacingService = AccountDeletionService(
+          nostrService: mockNostrService,
+          authService: mockAuthService,
+          retryDelay: (delay) async {
+            delays.add(delay);
+            // Swap the signed-in account while the sweep waits between
+            // batches, after batch 0 has already been confirmed on relays.
+            current = 'a_different_pubkey_than_confirmed';
+          },
+        );
 
-          when(() => mockNostrService.queryEvents(any())).thenAnswer(
-            (_) async => [
-              createTestEvent(
-                pubkey: testPublicKey,
-                kind: 1,
-                tags: const [],
-                content: 'note',
-                id: 'kind1_note',
-              ),
-              createTestEvent(
-                pubkey: testPublicKey,
-                kind: 7,
-                tags: const [],
-                content: 'reaction',
-                id: 'kind7_reaction',
-              ),
-            ],
-          );
-          when(
-            () => mockAuthService.createAndSignEvent(
-              kind: any(named: 'kind'),
-              content: any(named: 'content'),
-              tags: any(named: 'tags'),
-            ),
-          ).thenAnswer(
-            (_) async => createTestEvent(
+        when(() => mockNostrService.queryEvents(any())).thenAnswer(
+          (_) async => [
+            createTestEvent(
               pubkey: testPublicKey,
-              kind: 5,
+              kind: 1,
               tags: const [],
-              content: 'deletion',
+              content: 'note',
+              id: 'kind1_note',
             ),
-          );
-          when(
-            () => mockNostrService.publishEventAwaitOk(any()),
-          ).thenAnswer((_) async => _confirmed);
+            createTestEvent(
+              pubkey: testPublicKey,
+              kind: 7,
+              tags: const [],
+              content: 'reaction',
+              id: 'kind7_reaction',
+            ),
+          ],
+        );
+        when(
+          () => mockAuthService.createAndSignEvent(
+            kind: any(named: 'kind'),
+            content: any(named: 'content'),
+            tags: any(named: 'tags'),
+          ),
+        ).thenAnswer(
+          (_) async => createTestEvent(
+            pubkey: testPublicKey,
+            kind: 5,
+            tags: const [],
+            content: 'deletion',
+          ),
+        );
+        when(
+          () => mockNostrService.publishEventAwaitOk(any()),
+        ).thenAnswer((_) async => _confirmed);
 
-          final result = await pacingService.deleteAccount(
-            expectedPubkey: testPublicKey,
-          );
+        final result = await pacingService.deleteAccount(
+          expectedPubkey: testPublicKey,
+        );
 
-          // Two kind-5 deletion requests were already confirmed on relays
-          // before the swap, so the user must be told deletion began, not
-          // that nothing happened.
-          expect(result.success, isFalse);
-          expect(
-            result.failureReason,
-            DeleteAccountFailureReason.accountChangedAfterDeletion,
-          );
-          expect(delays, contains(const Duration(milliseconds: 500)));
-        },
-      );
+        // Two kind-5 deletion requests were already confirmed on relays
+        // before the swap, so the user must be told deletion began, not
+        // that nothing happened.
+        expect(result.success, isFalse);
+        expect(
+          result.failureReason,
+          DeleteAccountFailureReason.accountChangedAfterDeletion,
+        );
+        expect(delays, contains(const Duration(milliseconds: 500)));
+      });
 
       test(
         'batch deletion does not count events when every relay rejects',
@@ -1426,7 +1520,46 @@ void main() {
 
         expect(result.success, isTrue);
         expect(result.contentQueryFailed, isFalse);
+        expect(mockNostrService.queryTimeout, const Duration(seconds: 30));
+        expect(mockNostrService.queryRequiresAllRelaysSettled, isTrue);
       });
+
+      test(
+        'reports incomplete deletion when the query reaches its cap',
+        () async {
+          final priorDeletion = createTestEvent(
+            pubkey: testPublicKey,
+            kind: 5,
+            tags: const [],
+            content: 'prior deletion',
+          );
+          when(
+            () => mockNostrService.queryEvents(any()),
+          ).thenAnswer((_) async => List<Event>.filled(10000, priorDeletion));
+          when(
+            () => mockAuthService.createAndSignEvent(
+              kind: any(named: 'kind'),
+              content: any(named: 'content'),
+              tags: any(named: 'tags'),
+            ),
+          ).thenAnswer(
+            (_) async => createTestEvent(
+              pubkey: testPublicKey,
+              kind: 62,
+              tags: const [
+                ['relay', 'ALL_RELAYS'],
+              ],
+              content: 'deletion',
+            ),
+          );
+
+          final result = await service.deleteAccount();
+
+          expect(result.success, isTrue);
+          expect(result.contentQueryFailed, isFalse);
+          expect(result.contentDeletionIncomplete, isTrue);
+        },
+      );
 
       test('reports contentQueryFailed when no relay is connected', () async {
         when(

--- a/mobile/test/services/account_deletion_service_test.dart
+++ b/mobile/test/services/account_deletion_service_test.dart
@@ -161,6 +161,12 @@ void main() {
       when(
         () => mockNostrService.publishEventAwaitOk(
           any(),
+          targetRelays: any(named: 'targetRelays'),
+        ),
+      ).thenAnswer((_) async => _confirmed);
+      when(
+        () => mockNostrService.publishEventAwaitOk(
+          any(),
           timeout: any(named: 'timeout'),
         ),
       ).thenAnswer((_) async => _confirmed);
@@ -637,7 +643,12 @@ void main() {
 
           // Assert
           expect(result.success, isTrue);
-          verify(() => mockNostrService.publishEventAwaitOk(any())).called(1);
+          verify(
+            () => mockNostrService.publishEventAwaitOk(
+              any(),
+              targetRelays: ['wss://relay.example.com'],
+            ),
+          ).called(1);
           verify(
             () => mockNostrService.publishEventAwaitOk(
               any(),
@@ -694,6 +705,102 @@ void main() {
             targetRelays: [fallbackRelay],
           ),
         ).called(1);
+      });
+
+      test(
+        'targets non-Divine relays when the Divine relay is disconnected',
+        () async {
+          const fallbackRelay = 'wss://relay.example.com';
+          when(
+            () => mockNostrService.connectedRelays,
+          ).thenReturn([fallbackRelay]);
+          when(() => mockNostrService.queryEvents(any())).thenAnswer(
+            (_) async => [
+              createTestEvent(
+                pubkey: testPublicKey,
+                kind: 1,
+                tags: const [],
+                content: 'note',
+              ),
+            ],
+          );
+          when(
+            () => mockAuthService.createAndSignEvent(
+              kind: any(named: 'kind'),
+              content: any(named: 'content'),
+              tags: any(named: 'tags'),
+            ),
+          ).thenAnswer((invocation) async {
+            final kind = invocation.namedArguments[const Symbol('kind')] as int;
+            return createTestEvent(
+              pubkey: testPublicKey,
+              kind: kind,
+              tags: const [],
+              content: 'deletion',
+            );
+          });
+          when(
+            () => mockNostrService.publishEventAwaitOk(
+              any(),
+              targetRelays: any(named: 'targetRelays'),
+            ),
+          ).thenAnswer((_) async => _confirmed);
+
+          final result = await service.deleteAccount();
+
+          expect(result.success, isTrue);
+          verify(
+            () => mockNostrService.publishEventAwaitOk(
+              any(),
+              targetRelays: [fallbackRelay],
+            ),
+          ).called(1);
+        },
+      );
+
+      test('does not publish kind 5 when no relay is connected', () async {
+        when(
+          () => mockNostrService.connectedRelays,
+        ).thenReturn(const <String>[]);
+        when(() => mockNostrService.queryEvents(any())).thenAnswer(
+          (_) async => [
+            createTestEvent(
+              pubkey: testPublicKey,
+              kind: 1,
+              tags: const [],
+              content: 'cached note',
+            ),
+          ],
+        );
+        when(
+          () => mockAuthService.createAndSignEvent(
+            kind: any(named: 'kind'),
+            content: any(named: 'content'),
+            tags: any(named: 'tags'),
+          ),
+        ).thenAnswer(
+          (_) async => createTestEvent(
+            pubkey: testPublicKey,
+            kind: 62,
+            tags: const [
+              ['relay', 'ALL_RELAYS'],
+            ],
+            content: 'deletion',
+          ),
+        );
+
+        final result = await service.deleteAccount();
+
+        expect(result.success, isTrue);
+        expect(result.contentQueryFailed, isTrue);
+        expect(result.contentDeletionIncomplete, isTrue);
+        verifyNever(() => mockNostrService.publishEventAwaitOk(any()));
+        verifyNever(
+          () => mockNostrService.publishEventAwaitOk(
+            any(),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        );
       });
 
       test('skips kind 5 when only the Divine relay is connected', () async {
@@ -820,7 +927,12 @@ void main() {
         // Assert
         expect(result.success, isTrue);
         expect(result.deletedEventsCount, equals(3));
-        verify(() => mockNostrService.publishEventAwaitOk(any())).called(2);
+        verify(
+          () => mockNostrService.publishEventAwaitOk(
+            any(),
+            targetRelays: ['wss://relay.example.com'],
+          ),
+        ).called(2);
         verify(
           () => mockNostrService.publishEventAwaitOk(
             any(),
@@ -971,15 +1083,12 @@ void main() {
             return nip62Event;
           });
 
-          var publishCallCount = 0;
-          when(() => mockNostrService.publishEventAwaitOk(any())).thenAnswer((
-            _,
-          ) async {
-            publishCallCount++;
-            // First publish is the batch kind-5; second is NIP-62.
-            if (publishCallCount == 1) return _noRelayResponse;
-            return _confirmed;
-          });
+          when(
+            () => mockNostrService.publishEventAwaitOk(
+              any(),
+              targetRelays: any(named: 'targetRelays'),
+            ),
+          ).thenAnswer((_) async => _noRelayResponse);
 
           // Act
           final result = await service.deleteAccount();
@@ -1039,9 +1148,12 @@ void main() {
             (_) async => createCalls++ == 0 ? kind5Event : nip62Event,
           );
           var batchPublishes = 0;
-          when(() => mockNostrService.publishEventAwaitOk(any())).thenAnswer((
-            _,
-          ) async {
+          when(
+            () => mockNostrService.publishEventAwaitOk(
+              any(),
+              targetRelays: any(named: 'targetRelays'),
+            ),
+          ).thenAnswer((_) async {
             batchPublishes++;
             return batchPublishes == 1 ? _rateLimited : _confirmed;
           });
@@ -1097,7 +1209,10 @@ void main() {
             ),
           );
           when(
-            () => mockNostrService.publishEventAwaitOk(any()),
+            () => mockNostrService.publishEventAwaitOk(
+              any(),
+              targetRelays: any(named: 'targetRelays'),
+            ),
           ).thenAnswer((_) async => _accountRestricted);
           when(
             () => mockNostrService.publishEventAwaitOk(
@@ -1113,7 +1228,12 @@ void main() {
             result.failureReason,
             DeleteAccountFailureReason.accountRestricted,
           );
-          verify(() => mockNostrService.publishEventAwaitOk(any())).called(1);
+          verify(
+            () => mockNostrService.publishEventAwaitOk(
+              any(),
+              targetRelays: any(named: 'targetRelays'),
+            ),
+          ).called(1);
           expect(delays, isEmpty);
         },
       );
@@ -1170,7 +1290,10 @@ void main() {
           ),
         );
         when(
-          () => mockNostrService.publishEventAwaitOk(any()),
+          () => mockNostrService.publishEventAwaitOk(
+            any(),
+            targetRelays: any(named: 'targetRelays'),
+          ),
         ).thenAnswer((_) async => _confirmed);
 
         final result = await pacingService.deleteAccount(
@@ -1234,15 +1357,12 @@ void main() {
             return nip62Event;
           });
 
-          var publishCallCount = 0;
-          when(() => mockNostrService.publishEventAwaitOk(any())).thenAnswer((
-            _,
-          ) async {
-            publishCallCount++;
-            // First publish is the batch kind-5; second is NIP-62.
-            if (publishCallCount == 1) return _rejected;
-            return _confirmed;
-          });
+          when(
+            () => mockNostrService.publishEventAwaitOk(
+              any(),
+              targetRelays: any(named: 'targetRelays'),
+            ),
+          ).thenAnswer((_) async => _rejected);
 
           // Act
           final result = await service.deleteAccount();
@@ -1657,9 +1777,12 @@ void main() {
               content: 'deletion',
             ),
           );
-          when(() => mockNostrService.publishEventAwaitOk(any())).thenAnswer((
-            _,
-          ) async {
+          when(
+            () => mockNostrService.publishEventAwaitOk(
+              any(),
+              targetRelays: any(named: 'targetRelays'),
+            ),
+          ).thenAnswer((_) async {
             current = 'a_different_pubkey_than_confirmed';
             return _confirmed;
           });
@@ -1673,7 +1796,12 @@ void main() {
             result.failureReason,
             DeleteAccountFailureReason.accountChangedAfterDeletion,
           );
-          verify(() => mockNostrService.publishEventAwaitOk(any())).called(1);
+          verify(
+            () => mockNostrService.publishEventAwaitOk(
+              any(),
+              targetRelays: any(named: 'targetRelays'),
+            ),
+          ).called(1);
           verifyNever(
             () => mockNostrService.publishEventAwaitOk(
               any(),

--- a/mobile/test/services/account_deletion_service_test.dart
+++ b/mobile/test/services/account_deletion_service_test.dart
@@ -155,6 +155,7 @@ void main() {
       when(
         () => mockNostrService.defaultRelayUrl,
       ).thenReturn('wss://relay.example.com');
+      when(() => mockNostrService.isRelayAllowed(any())).thenReturn(true);
       when(
         () => mockNostrService.publishEventAwaitOk(any()),
       ).thenAnswer((_) async => _confirmed);
@@ -712,12 +713,9 @@ void main() {
         const pocRelay = 'wss://relay.poc.dvines.org';
         const localRelay = 'ws://localhost:47777';
         const fallbackRelay = 'wss://relay.example.com';
-        when(() => mockNostrService.connectedRelays).thenReturn([
-          stagingRelay,
-          pocRelay,
-          localRelay,
-          fallbackRelay,
-        ]);
+        when(
+          () => mockNostrService.connectedRelays,
+        ).thenReturn([stagingRelay, pocRelay, localRelay, fallbackRelay]);
         final userEvent = createTestEvent(
           pubkey: testPublicKey,
           kind: 1,
@@ -760,6 +758,61 @@ void main() {
           ),
         ).called(1);
       });
+
+      test(
+        'does not publish kind 5 when environment lock rejects every target',
+        () async {
+          const stagingRelay = 'wss://relay.staging.divine.video';
+          const externalRelay = 'wss://relay.example.com';
+          when(
+            () => mockNostrService.connectedRelays,
+          ).thenReturn([stagingRelay, externalRelay]);
+          when(
+            () => mockNostrService.isRelayAllowed(stagingRelay),
+          ).thenReturn(true);
+          when(
+            () => mockNostrService.isRelayAllowed(externalRelay),
+          ).thenReturn(false);
+          when(() => mockNostrService.queryEvents(any())).thenAnswer(
+            (_) async => [
+              createTestEvent(
+                pubkey: testPublicKey,
+                kind: 1,
+                tags: const [],
+                content: 'note',
+              ),
+            ],
+          );
+          when(
+            () => mockAuthService.createAndSignEvent(
+              kind: any(named: 'kind'),
+              content: any(named: 'content'),
+              tags: any(named: 'tags'),
+            ),
+          ).thenAnswer(
+            (_) async => createTestEvent(
+              pubkey: testPublicKey,
+              kind: 62,
+              tags: const [
+                ['relay', 'ALL_RELAYS'],
+              ],
+              content: 'deletion',
+            ),
+          );
+
+          final result = await service.deleteAccount();
+
+          expect(result.success, isTrue);
+          expect(result.deletedEventsCount, isZero);
+          expect(result.contentDeletionIncomplete, isFalse);
+          verifyNever(
+            () => mockNostrService.publishEventAwaitOk(
+              any(),
+              targetRelays: any(named: 'targetRelays'),
+            ),
+          );
+        },
+      );
 
       test(
         'targets non-Divine relays when the Divine relay is disconnected',

--- a/mobile/test/services/account_deletion_service_test.dart
+++ b/mobile/test/services/account_deletion_service_test.dart
@@ -707,6 +707,60 @@ void main() {
         ).called(1);
       });
 
+      test('does not publish kind 5 to any Divine-hosted relay', () async {
+        const stagingRelay = 'wss://relay.staging.divine.video';
+        const pocRelay = 'wss://relay.poc.dvines.org';
+        const localRelay = 'ws://localhost:47777';
+        const fallbackRelay = 'wss://relay.example.com';
+        when(() => mockNostrService.connectedRelays).thenReturn([
+          stagingRelay,
+          pocRelay,
+          localRelay,
+          fallbackRelay,
+        ]);
+        final userEvent = createTestEvent(
+          pubkey: testPublicKey,
+          kind: 1,
+          tags: const [],
+          content: 'note',
+          id: 'note_for_multi_env_sweep',
+        );
+        when(
+          () => mockNostrService.queryEvents(any()),
+        ).thenAnswer((_) async => [userEvent]);
+        when(
+          () => mockAuthService.createAndSignEvent(
+            kind: any(named: 'kind'),
+            content: any(named: 'content'),
+            tags: any(named: 'tags'),
+          ),
+        ).thenAnswer((invocation) async {
+          final kind = invocation.namedArguments[const Symbol('kind')] as int;
+          return createTestEvent(
+            pubkey: testPublicKey,
+            kind: kind,
+            tags: const [],
+            content: 'deletion',
+          );
+        });
+        when(
+          () => mockNostrService.publishEventAwaitOk(
+            any(),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((_) async => _confirmed);
+
+        final result = await service.deleteAccount();
+
+        expect(result.success, isTrue);
+        verify(
+          () => mockNostrService.publishEventAwaitOk(
+            any(),
+            targetRelays: [fallbackRelay],
+          ),
+        ).called(1);
+      });
+
       test(
         'targets non-Divine relays when the Divine relay is disconnected',
         () async {

--- a/mobile/test/services/timestamp_test.dart
+++ b/mobile/test/services/timestamp_test.dart
@@ -34,6 +34,11 @@ void main() {
       expect(tolerance, equals(30)); // 30 seconds
     });
 
+    test('should not backdate Kind 62 deletion boundaries', () {
+      final tolerance = NostrTimestamp.getDriftToleranceForKind(62);
+      expect(tolerance, isZero);
+    });
+
     test('Kind 0 timestamp should be 5 minutes behind current time', () {
       final tolerance = NostrTimestamp.getDriftToleranceForKind(0);
       final timestamp = NostrTimestamp.now(driftTolerance: tolerance);


### PR DESCRIPTION
## Summary

Account deletion could create compatibility deletion events outside the final deletion boundary and present a partial content sweep as complete.
This change keeps compatibility events away from the Divine relay, makes the final vanish event cover the whole flow, and tells users when content deletion could not be fully verified.

Closes #8224.

## What Changed

- Publish kind-5 compatibility deletions only to connected non-Divine relays, including retry attempts.
- Skip the compatibility sweep when no eligible relay is connected and mark a zero-relay sweep as incomplete.
- Publish kind 62 at the current timestamp after the compatibility sweep.
- Wait up to 30 seconds for relay queries to settle and report the configured event cap or unsettled relays as incomplete.
- Show qualified success copy when account credentials are deleted but remote content deletion cannot be fully verified.

This change does not alter the separate sign-out behavior after the vanish event is published.

## Testing

- `flutter analyze lib test integration_test tools`
- `dart format --output=none --set-exit-if-changed lib test integration_test tools`
- `flutter test test/services/account_deletion_service_test.dart test/services/timestamp_test.dart test/widgets/delete_account_dialog_test.dart`
- `bash scripts/check_service_god_file_ceiling.sh`
- `bash scripts/check_ungrouped_tests.sh`
- `bash scripts/check_nostr_id_log_truncation.sh`
- `bash scripts/check_pubkey_log_encoding.sh`
- `bash scripts/check_untested_services_floor.sh`
- `bash scripts/check_future_delayed_production_ceiling.sh`
- `bash scripts/check_skip_ceiling.sh`
- `bash scripts/check_placeholder_tests.sh`

The focused suite passed 94 tests.
The full `very_good test` command was not run because `very_good` is unavailable in the local environment; CI remains authoritative for that suite and workflow-only checks.

## Risks

Remote deletion remains best effort because relays can be unavailable or enforce private response limits.
The flow now reports known incomplete states instead of claiming that all remote content was deleted.
