### PR TITLE
fix(auth): let users dismiss verification keyboard

### DIFF
--- a/mobile/lib/screens/auth/email_verification_screen.dart
+++ b/mobile/lib/screens/auth/email_verification_screen.dart
@@ -547,70 +547,81 @@ class _EmailVerificationScreenState
                   // (`resizeToAvoidBottomInset: false`), so shrink the scroll
                   // viewport by the inset instead: PIN entry and its submit
                   // button stay reachable while the keyboard is up.
-                  Padding(
-                    padding: EdgeInsets.only(
-                      bottom: MediaQuery.viewInsetsOf(context).bottom,
-                    ),
-                    child: CustomScrollView(
-                      slivers: [
-                        // Fills the viewport so the content's `Spacer`s can
-                        // center it, and scrolls once it no longer fits.
-                        SliverFillRemaining(
-                          hasScrollBody: false,
-                          child: Padding(
-                            padding: EdgeInsets.fromLTRB(
-                              24,
-                              _contentTopPadding(context),
-                              24,
-                              32,
-                            ),
-                            child: switch (state.status) {
-                              EmailVerificationStatus.initial =>
-                                _PollingContent(
-                                  email: null,
-                                  isPollingMode:
-                                      widget.isPollingMode || !_isTokenMode,
-                                ),
-                              EmailVerificationStatus.polling =>
-                                _PollingContent(
-                                  email: state.pendingEmail,
-                                  isPollingMode:
-                                      widget.isPollingMode || !_isTokenMode,
-                                ),
-                              EmailVerificationStatus.pollingTimedOut =>
-                                _PollingContent(
-                                  email: state.pendingEmail,
-                                  isPollingMode:
-                                      widget.isPollingMode || !_isTokenMode,
-                                  isActivelyPolling: false,
-                                ),
-                              EmailVerificationStatus.success =>
-                                const _SuccessContent(),
-                              EmailVerificationStatus.failure => _ErrorContent(
-                                errorCode: state.errorCode,
-                                onStartOver: _handleStartOver,
-                                onSignInInstead:
-                                    state.errorCode ==
-                                        EmailVerificationError
-                                            .emailAlreadyRegistered
-                                    ? () => _handleSignInRecovery(
-                                        state.pendingEmail,
-                                        state.errorCode!,
-                                      )
-                                    : null,
-                                onReturnToInviteGate:
-                                    state.showInviteGateRecovery &&
-                                        state.inviteRecoveryCode != null
-                                    ? () => _handleInviteRecovery(
-                                        state.inviteRecoveryCode!,
-                                        state.errorCode,
-                                      )
-                                    : null,
+                  GestureDetector(
+                    behavior: HitTestBehavior.opaque,
+                    // Focus dismissal is not an accessibility action; exclude
+                    // this detector so it does not make the whole screen tap.
+                    excludeFromSemantics: true,
+                    onTap: () => FocusManager.instance.primaryFocus?.unfocus(),
+                    child: Padding(
+                      padding: EdgeInsets.only(
+                        bottom: MediaQuery.viewInsetsOf(context).bottom,
+                      ),
+                      child: CustomScrollView(
+                        keyboardDismissBehavior:
+                            ScrollViewKeyboardDismissBehavior.onDrag,
+                        physics: const AlwaysScrollableScrollPhysics(),
+                        slivers: [
+                          // Fills the viewport so the content's `Spacer`s can
+                          // center it, and scrolls once it no longer fits.
+                          SliverFillRemaining(
+                            hasScrollBody: false,
+                            child: Padding(
+                              padding: EdgeInsets.fromLTRB(
+                                24,
+                                _contentTopPadding(context),
+                                24,
+                                32,
                               ),
-                            },
+                              child: switch (state.status) {
+                                EmailVerificationStatus.initial =>
+                                  _PollingContent(
+                                    email: null,
+                                    isPollingMode:
+                                        widget.isPollingMode || !_isTokenMode,
+                                  ),
+                                EmailVerificationStatus.polling =>
+                                  _PollingContent(
+                                    email: state.pendingEmail,
+                                    isPollingMode:
+                                        widget.isPollingMode || !_isTokenMode,
+                                  ),
+                                EmailVerificationStatus.pollingTimedOut =>
+                                  _PollingContent(
+                                    email: state.pendingEmail,
+                                    isPollingMode:
+                                        widget.isPollingMode || !_isTokenMode,
+                                    isActivelyPolling: false,
+                                  ),
+                                EmailVerificationStatus.success =>
+                                  const _SuccessContent(),
+                                EmailVerificationStatus.failure =>
+                                  _ErrorContent(
+                                    errorCode: state.errorCode,
+                                    onStartOver: _handleStartOver,
+                                    onSignInInstead:
+                                        state.errorCode ==
+                                            EmailVerificationError
+                                                .emailAlreadyRegistered
+                                        ? () => _handleSignInRecovery(
+                                            state.pendingEmail,
+                                            state.errorCode!,
+                                          )
+                                        : null,
+                                    onReturnToInviteGate:
+                                        state.showInviteGateRecovery &&
+                                            state.inviteRecoveryCode != null
+                                        ? () => _handleInviteRecovery(
+                                            state.inviteRecoveryCode!,
+                                            state.errorCode,
+                                          )
+                                        : null,
+                                  ),
+                              },
+                            ),
                           ),
-                        ),
-                      ],
+                        ],
+                      ),
                     ),
                   ),
 

--- a/mobile/lib/screens/auth/email_verification_screen.dart
+++ b/mobile/lib/screens/auth/email_verification_screen.dart
@@ -560,7 +560,6 @@ class _EmailVerificationScreenState
                       child: CustomScrollView(
                         keyboardDismissBehavior:
                             ScrollViewKeyboardDismissBehavior.onDrag,
-                        physics: const AlwaysScrollableScrollPhysics(),
                         slivers: [
                           // Fills the viewport so the content's `Spacer`s can
                           // center it, and scrolls once it no longer fits.

--- a/mobile/test/screens/auth/email_verification_screen_test.dart
+++ b/mobile/test/screens/auth/email_verification_screen_test.dart
@@ -97,6 +97,7 @@ void main() {
     String? email,
     String? token,
     bool restored = false,
+    TargetPlatform? platform,
     EmailVerificationState initialState = const EmailVerificationState(),
     Stream<EmailVerificationState>? stateStream,
   }) {
@@ -123,7 +124,7 @@ void main() {
           child: MaterialApp.router(
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,
-            theme: VineTheme.theme,
+            theme: VineTheme.theme.copyWith(platform: platform),
             routerConfig: GoRouter(
               initialLocation: '/verify-email',
               routes: [
@@ -877,6 +878,16 @@ void main() {
 
         await tester.enterText(find.byType(TextFormField), '123456');
         await tester.pump();
+
+        expect(
+          tester
+              .widget<EditableText>(find.byType(EditableText))
+              .focusNode
+              .hasFocus,
+          isTrue,
+          reason:
+              'the button tap must be exercised while the PIN field is focused',
+        );
         await tester.tap(
           find.widgetWithText(DivineButton, l10n.authVerificationPinSubmit),
         );
@@ -1748,6 +1759,63 @@ void main() {
 
       expect(tester.takeException(), isNull);
       expect(find.byType(CustomScrollView), findsOneWidget);
+    });
+  });
+
+  group('keyboard dismissal', () {
+    const pollingState = EmailVerificationState(
+      status: EmailVerificationStatus.polling,
+      pendingEmail: 'user@example.com',
+    );
+
+    testWidgets('unfocuses the PIN field when tapping the content outside it', (
+      tester,
+    ) async {
+      final l10n = lookupAppLocalizations(const Locale('en'));
+
+      await pumpVerificationScreen(
+        tester,
+        deviceCode: 'test-device-code',
+        verifier: 'test-verifier',
+        email: 'user@example.com',
+        initialState: pollingState,
+      );
+      await tester.pump();
+
+      final editable = find.byType(EditableText);
+      await tester.tap(editable);
+      await tester.pump();
+      expect(tester.widget<EditableText>(editable).focusNode.hasFocus, isTrue);
+
+      await tester.tap(find.text(l10n.authVerificationPinPrompt));
+      await tester.pump();
+
+      expect(tester.widget<EditableText>(editable).focusNode.hasFocus, isFalse);
+    });
+
+    testWidgets('unfocuses the PIN field when dragging the screen', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        createTestWidget(
+          deviceCode: 'test-device-code',
+          verifier: 'test-verifier',
+          email: 'user@example.com',
+          platform: TargetPlatform.iOS,
+          initialState: pollingState,
+        ),
+      );
+      await tester.pump();
+
+      final editable = find.byType(EditableText);
+      await tester.tap(editable);
+      await tester.pump();
+      expect(tester.widget<EditableText>(editable).focusNode.hasFocus, isTrue);
+
+      await tester.drag(find.byType(CustomScrollView), const Offset(0, -80));
+      await tester.pump();
+
+      expect(tester.widget<EditableText>(editable).focusNode.hasFocus, isFalse);
     });
   });
 

--- a/mobile/test/screens/auth/email_verification_screen_test.dart
+++ b/mobile/test/screens/auth/email_verification_screen_test.dart
@@ -181,10 +181,11 @@ void main() {
     String? token,
     bool restored = false,
     TargetPlatform? platform,
+    Size surfaceSize = const Size(800, 1200),
     EmailVerificationState initialState = const EmailVerificationState(),
     Stream<EmailVerificationState>? stateStream,
   }) async {
-    await tester.binding.setSurfaceSize(const Size(800, 1200));
+    await tester.binding.setSurfaceSize(surfaceSize);
     addTearDown(() => tester.binding.setSurfaceSize(null));
     await tester.pumpWidget(
       createTestWidget(
@@ -1804,6 +1805,7 @@ void main() {
         verifier: 'test-verifier',
         email: 'user@example.com',
         platform: TargetPlatform.iOS,
+        surfaceSize: const Size(1200, 2600),
         initialState: pollingState,
       );
       await tester.pump();

--- a/mobile/test/screens/auth/email_verification_screen_test.dart
+++ b/mobile/test/screens/auth/email_verification_screen_test.dart
@@ -180,6 +180,7 @@ void main() {
     String? email,
     String? token,
     bool restored = false,
+    TargetPlatform? platform,
     EmailVerificationState initialState = const EmailVerificationState(),
     Stream<EmailVerificationState>? stateStream,
   }) async {
@@ -192,6 +193,7 @@ void main() {
         email: email,
         token: token,
         restored: restored,
+        platform: platform,
         initialState: initialState,
         stateStream: stateStream,
       ),
@@ -1796,14 +1798,13 @@ void main() {
     testWidgets('unfocuses the PIN field when dragging the screen', (
       tester,
     ) async {
-      await tester.pumpWidget(
-        createTestWidget(
-          deviceCode: 'test-device-code',
-          verifier: 'test-verifier',
-          email: 'user@example.com',
-          platform: TargetPlatform.iOS,
-          initialState: pollingState,
-        ),
+      await pumpVerificationScreen(
+        tester,
+        deviceCode: 'test-device-code',
+        verifier: 'test-verifier',
+        email: 'user@example.com',
+        platform: TargetPlatform.iOS,
+        initialState: pollingState,
       );
       await tester.pump();
 


### PR DESCRIPTION
## Problem

On iOS, the six-digit registration verification field opens a numeric keypad with no return key. Users could still reach Verify, but the keyboard stayed onscreen until they left the registration flow because neither tapping the surrounding content nor dragging the screen released focus.

## Why this fix

The verification screen now owns both standard dismissal gestures: tapping non-interactive content unfocuses the PIN field, and dragging the scroll view dismisses the keyboard. The iOS bouncing scroll physics accepts drag gestures on larger screens even when the content fits without a scroll extent.

The content-wide tap detector is excluded from semantics so it does not expose the entire screen as an accessibility action. Child actions such as Verify and Resend continue to win the gesture arena and remain usable while the field is focused.

## Deliberately unchanged

- The shared authentication text field API is unchanged; this behavior is scoped to the app's only numeric verification field.
- The existing keyboard-inset layout and Verify-button reachability behavior remain intact.
- No state-management, localization, or generated-code changes are included.

## Verification

- `flutter test test/screens/auth/email_verification_screen_test.dart`: 55 tests passed
- `flutter analyze lib test integration_test`: no issues
- `scripts/check_ungrouped_tests.sh`: passed
- `scripts/check_placeholder_tests.sh`: passed
- Red/green regression cycle confirmed both new dismissal tests fail before the screen change and pass afterward
- No iOS simulator was booted for a manual run; the drag test explicitly uses iOS platform behavior

Closes #8280
