### PR TITLE
fix(db): collapse every superseded replaceable event, not one arbitrary row

### DIFF
--- a/mobile/packages/db_client/lib/src/database/daos/nostr_events_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/nostr_events_dao.dart
@@ -46,29 +46,50 @@ class NostrEventsDao extends DatabaseAccessor<AppDatabase>
   /// For video events (kind 34236 or 16), also upserts video metrics to the
   /// video_metrics table for fast sorted queries.
   Future<void> upsertEvent(Event event, {int? expireAt}) async {
-    final effectiveExpireAt = expireAt ?? _defaultExpireAt();
+    await _upsertEvent(
+      event,
+      expireAt: expireAt ?? _defaultExpireAt(),
+      transactionActive: false,
+    );
+  }
 
+  Future<void> _upsertEvent(
+    Event event, {
+    required int expireAt,
+    required bool transactionActive,
+  }) async {
     // Handle replaceable events (kind 0, 3, 10000-19999)
     if (EventKind.isReplaceable(event.kind)) {
-      await transaction(
-        () => _upsertReplaceableEvent(event, expireAt: effectiveExpireAt),
-      );
+      if (transactionActive) {
+        await _upsertReplaceableEvent(event, expireAt: expireAt);
+      } else {
+        await transaction(
+          () => _upsertReplaceableEvent(event, expireAt: expireAt),
+        );
+      }
       return;
     }
 
     // Handle parameterized replaceable events (kind 30000-39999)
     if (EventKind.isParameterizedReplaceable(event.kind)) {
-      await transaction(
-        () => _upsertParameterizedReplaceableEvent(
+      if (transactionActive) {
+        await _upsertParameterizedReplaceableEvent(
           event,
-          expireAt: effectiveExpireAt,
-        ),
-      );
+          expireAt: expireAt,
+        );
+      } else {
+        await transaction(
+          () => _upsertParameterizedReplaceableEvent(
+            event,
+            expireAt: expireAt,
+          ),
+        );
+      }
       return;
     }
 
     // Regular event: simple insert or replace by ID
-    await _insertEvent(event, expireAt: effectiveExpireAt);
+    await _insertEvent(event, expireAt: expireAt);
 
     // Also upsert video metrics for video events (kind 34236 only)
     // Note: Kind 16 reposts reference videos but don't contain video metadata
@@ -234,7 +255,11 @@ class NostrEventsDao extends DatabaseAccessor<AppDatabase>
     await transaction(() async {
       // Batch upsert all events with replaceable logic
       for (final event in eventsSnapshot) {
-        await upsertEvent(event, expireAt: effectiveExpireAt);
+        await _upsertEvent(
+          event,
+          expireAt: effectiveExpireAt,
+          transactionActive: true,
+        );
       }
     });
   }

--- a/mobile/packages/db_client/lib/src/database/daos/nostr_events_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/nostr_events_dao.dart
@@ -117,27 +117,37 @@ class NostrEventsDao extends DatabaseAccessor<AppDatabase>
     Event event, {
     required int expireAt,
   }) async {
-    // Check if a newer event already exists for this pubkey+kind
-    final existingRows = await customSelect(
-      'SELECT id, created_at FROM event WHERE pubkey = ? AND kind = ? LIMIT 1',
+    // Compare against the newest stored version. MAX over all versions (rather
+    // than an arbitrary first row) keeps the newest even when raw ingestion via
+    // cacheEventsBatch left multiple versions behind — event_router sends
+    // every non-parameterized kind there, so several rows per (pubkey, kind)
+    // is the normal case rather than the exception. An aggregate without
+    // GROUP BY always yields exactly one row (NULL when no version exists).
+    final existingRow = await customSelect(
+      'SELECT MAX(created_at) AS max_created_at FROM event '
+      'WHERE pubkey = ? AND kind = ?',
       variables: [
         Variable.withString(event.pubkey),
         Variable.withInt(event.kind),
       ],
       readsFrom: {nostrEvents},
-    ).get();
+    ).getSingle();
 
-    if (existingRows.isNotEmpty) {
-      final existingCreatedAt = existingRows.first.read<int>('created_at');
-      if (event.createdAt <= existingCreatedAt) {
+    final maxCreatedAt = existingRow.read<int?>('max_created_at');
+    if (maxCreatedAt != null) {
+      if (event.createdAt <= maxCreatedAt) {
         // Existing event is newer or same age, don't replace
         return;
       }
-      // Delete the old event before inserting the new one
-      final existingId = existingRows.first.read<String>('id');
+      // Delete every superseded version before inserting the new one. Deleting
+      // a single arbitrary row left the rest behind, so the count never fell
+      // and the table grew without bound.
       await customUpdate(
-        'DELETE FROM event WHERE id = ?',
-        variables: [Variable.withString(existingId)],
+        'DELETE FROM event WHERE pubkey = ? AND kind = ?',
+        variables: [
+          Variable.withString(event.pubkey),
+          Variable.withInt(event.kind),
+        ],
         updates: {nostrEvents},
         updateKind: UpdateKind.delete,
       );

--- a/mobile/packages/db_client/lib/src/database/daos/nostr_events_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/nostr_events_dao.dart
@@ -50,15 +50,19 @@ class NostrEventsDao extends DatabaseAccessor<AppDatabase>
 
     // Handle replaceable events (kind 0, 3, 10000-19999)
     if (EventKind.isReplaceable(event.kind)) {
-      await _upsertReplaceableEvent(event, expireAt: effectiveExpireAt);
+      await transaction(
+        () => _upsertReplaceableEvent(event, expireAt: effectiveExpireAt),
+      );
       return;
     }
 
     // Handle parameterized replaceable events (kind 30000-39999)
     if (EventKind.isParameterizedReplaceable(event.kind)) {
-      await _upsertParameterizedReplaceableEvent(
-        event,
-        expireAt: effectiveExpireAt,
+      await transaction(
+        () => _upsertParameterizedReplaceableEvent(
+          event,
+          expireAt: effectiveExpireAt,
+        ),
       );
       return;
     }

--- a/mobile/packages/db_client/test/src/database/daos/nostr_events_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/nostr_events_dao_test.dart
@@ -1446,6 +1446,61 @@ void main() {
       });
 
       test(
+        'upsert collapses duplicate standard-replaceable versions left by '
+        'cacheEventsBatch when a newer version arrives',
+        () async {
+          // event_router routes every non-parameterized kind to
+          // cacheEventsBatch, so several rows per (pubkey, kind) is the normal
+          // case for kind 0 and kind 3 — the same precondition the kind 30023
+          // tests below rely on.
+          final v1 = createEvent(kind: 0, content: 'v1', createdAt: 1000);
+          final v2 = createEvent(kind: 0, content: 'v2', createdAt: 2000);
+          await dao.cacheEventsBatch([v1, v2]);
+
+          final v3 = createEvent(kind: 0, content: 'v3', createdAt: 3000);
+          await dao.upsertEvent(v3);
+
+          final results = await dao.getEventsByFilter(Filter(kinds: [0]));
+          expect(results, hasLength(1));
+          expect(results.first.content, equals('v3'));
+        },
+      );
+
+      test(
+        'upsert collapses duplicate contact lists left by cacheEventsBatch',
+        () async {
+          final v1 = createEvent(kind: 3, content: 'v1', createdAt: 1000);
+          final v2 = createEvent(kind: 3, content: 'v2', createdAt: 2000);
+          final v3 = createEvent(kind: 3, content: 'v3', createdAt: 3000);
+          await dao.cacheEventsBatch([v1, v2, v3]);
+
+          final v4 = createEvent(kind: 3, content: 'v4', createdAt: 4000);
+          await dao.upsertEvent(v4);
+
+          final results = await dao.getEventsByFilter(Filter(kinds: [3]));
+          expect(results, hasLength(1));
+          expect(results.first.content, equals('v4'));
+        },
+      );
+
+      test(
+        'upsert of a standard-replaceable compares against the newest cached '
+        'duplicate, not an arbitrary one',
+        () async {
+          final v1 = createEvent(kind: 0, content: 'v1', createdAt: 1000);
+          final v3 = createEvent(kind: 0, content: 'v3', createdAt: 3000);
+          await dao.cacheEventsBatch([v1, v3]);
+
+          // Older than v3 — must be rejected even though v1 is older still.
+          final v2 = createEvent(kind: 0, content: 'v2', createdAt: 2000);
+          await dao.upsertEvent(v2);
+
+          expect(await dao.getEventById(v2.id), isNull);
+          expect(await dao.getEventById(v3.id), isNotNull);
+        },
+      );
+
+      test(
         'kind 30023 without d-tag: newer replaces older via empty-string '
         'identifier (NIP-01 default)',
         () async {

--- a/mobile/packages/db_client/test/src/database/daos/nostr_events_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/nostr_events_dao_test.dart
@@ -229,6 +229,23 @@ void main() {
         }
       });
 
+      test('serializes concurrent replaceable-event batches', () async {
+        await dao.upsertEventsBatch([
+          createEvent(kind: 0, content: 'v1', createdAt: 1000),
+        ]);
+        final newest = createEvent(kind: 0, content: 'v3', createdAt: 3000);
+        final middle = createEvent(kind: 0, content: 'v2', createdAt: 2000);
+
+        await Future.wait([
+          dao.upsertEventsBatch([newest]),
+          dao.upsertEventsBatch([middle]),
+        ]);
+
+        final results = await dao.getEventsByFilter(Filter(kinds: [0]));
+        expect(results, hasLength(1));
+        expect(results.single.id, newest.id);
+      });
+
       test('handles an empty batch without error', () async {
         await expectLater(dao.upsertEventsBatch([]), completes);
       });

--- a/mobile/packages/db_client/test/src/database/daos/nostr_events_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/nostr_events_dao_test.dart
@@ -1501,6 +1501,22 @@ void main() {
       );
 
       test(
+        'concurrent standard-replaceable upserts keep only the newest event',
+        () async {
+          final v1 = createEvent(kind: 0, content: 'v1', createdAt: 1000);
+          await dao.upsertEvent(v1);
+
+          final v3 = createEvent(kind: 0, content: 'v3', createdAt: 3000);
+          final v2 = createEvent(kind: 0, content: 'v2', createdAt: 2000);
+          await Future.wait([dao.upsertEvent(v3), dao.upsertEvent(v2)]);
+
+          final results = await dao.getEventsByFilter(Filter(kinds: [0]));
+          expect(results, hasLength(1));
+          expect(results.single.id, v3.id);
+        },
+      );
+
+      test(
         'kind 30023 without d-tag: newer replaces older via empty-string '
         'identifier (NIP-01 default)',
         () async {
@@ -1598,6 +1614,41 @@ void main() {
 
           expect(await dao.getEventById(v2.id), isNull);
           expect(await dao.getEventById(v3.id), isNotNull);
+        },
+      );
+
+      test(
+        'concurrent parameterized-replaceable upserts keep only the newest '
+        'event',
+        () async {
+          final tags = [
+            ['d', 'my-article'],
+          ];
+          final v1 = createEvent(
+            kind: 30023,
+            tags: tags,
+            content: 'v1',
+            createdAt: 1000,
+          );
+          await dao.upsertEvent(v1);
+
+          final v3 = createEvent(
+            kind: 30023,
+            tags: tags,
+            content: 'v3',
+            createdAt: 3000,
+          );
+          final v2 = createEvent(
+            kind: 30023,
+            tags: tags,
+            content: 'v2',
+            createdAt: 2000,
+          );
+          await Future.wait([dao.upsertEvent(v3), dao.upsertEvent(v2)]);
+
+          final results = await dao.getEventsByFilter(Filter(kinds: [30023]));
+          expect(results, hasLength(1));
+          expect(results.single.id, v3.id);
         },
       );
 


### PR DESCRIPTION
## What

`_upsertReplaceableEvent` now compares against `MAX(created_at)` and deletes every superseded row for the `(pubkey, kind)` coordinate, instead of comparing against one arbitrary row and deleting only that row.

Standalone upserts now serialize comparison, deletion, and insertion in one transaction for both standard and parameterized replaceable events. `upsertEventsBatch` reuses its existing outer transaction instead of opening a savepoint for every event.

## Why

The method's own doc comment says it *"replaces existing event with same pubkey+kind only if the new event has a higher created_at"*. It did not do that.

```sql
SELECT id, created_at FROM event WHERE pubkey = ? AND kind = ? LIMIT 1
```

No `ORDER BY`. It then deleted a single row by id.

That would be harmless if there were only ever one row per coordinate, but there isn't. `event_router._persistRawEvents` deliberately sends every non-parameterized kind to `cacheEventsBatch`, whose own doc says *"Cache raw events by ID without applying replaceable-event deletion"* — so several rows per `(pubkey, kind)` is the **normal** case for kind 0 and kind 3. Against N stale rows the upsert deleted one and inserted one, so N never fell.

The sibling `_upsertParameterizedReplaceableEvent` already handles exactly this, and its comment names the precondition:

> Compare against the newest stored version. MAX over all versions (rather than an arbitrary first row) keeps the newest even when raw ingestion via `cacheEventsBatch` left multiple versions behind.

That fix landed in #5957 as part of a `d_tag` indexed-lookup performance rewrite that only touched the parameterized path, so the standard-replaceable path looks overlooked rather than deliberately excluded. The existing tests tell the same story: `upsert collapses duplicate versions left by cacheEventsBatch` and `upsert compares against the newest cached duplicate, not an arbitrary one` both exist, both for kind 30023 only — while the test immediately above them, `cacheEventsBatch preserves raw replaceable events by id`, uses **kind 0** and proves the precondition applies there too.

## Scope of the defect — reads were never wrong

Worth stating plainly, because it bounds the risk:

- `getEventsByFilter` orders `created_at DESC`, so the newest version always won a read. No caller was served a stale replaceable event.
- Nothing reads multiple raw standard-replaceable rows locally. The one place that fetches several kind-0 versions (`profile_repository.dart:1115`, `limit: 5`) is a relay query with `useCache: false`, and the DAO read that expects multiple rows (`nostr_client.dart:439`) is addressable-only.

What was wrong is that the table never converged, and the comparison ran against whichever row the index yielded first. Verified with `EXPLAIN QUERY PLAN`:

```
SEARCH event USING INDEX idx_event_pubkey_kind_d_tag_created_at (pubkey=? AND kind=?)
```

With `pubkey` and `kind` bound and `d_tag` NULL-and-equal across all kind-3 rows, that index scan proceeds in `created_at` ASC order, so `LIMIT 1` returned the **oldest** row. That is why no write was ever dropped — the comparison was always against the oldest, so the `<=` early return effectively never fired. It was benign by accident of one index, not by design; a different plan would have compared against a newer row and silently discarded the write.

## Tests

Six regression tests cover duplicate collapse, newest-version comparison, and concurrent serialization:

- `upsert collapses duplicate standard-replaceable versions left by cacheEventsBatch when a newer version arrives` (kind 0)
- `upsert collapses duplicate contact lists left by cacheEventsBatch` (kind 3)
- `upsert of a standard-replaceable compares against the newest cached duplicate, not an arbitrary one` (kind 0)
- `concurrent standard-replaceable upserts keep only the newest event` (kind 0)
- `concurrent parameterized-replaceable upserts keep only the newest event` (kind 30023)
- `serializes concurrent replaceable-event batches` (kind 0)

The duplicate-collapse tests fail on the previous implementation:

```
upsert collapses duplicate standard-replaceable versions ... [E]
  Expected: an object with length of <1>
    Actual: [Instance of 'Event', Instance of 'Event']

upsert collapses duplicate contact lists left by cacheEventsBatch [E]
  Expected: an object with length of <1>
    Actual: [Instance of 'Event', Instance of 'Event', Instance of 'Event']

upsert of a standard-replaceable compares against the newest ... [E]
  Expected: null
    Actual: <Instance of 'Event'>
```

The concurrency tests fail when the corresponding transaction wrapper is removed.

## Verification

- `flutter test` in `mobile/packages/db_client` — passed
- `flutter test test/src/database/daos/nostr_events_dao_test.dart` — **96 passed**
- `flutter analyze lib test` from inside the package — no issues
- `dart format lib test` — no changes
- App-side `test/database/daos/nostr_events_dao_test.dart` + `test/services/event_router_test.dart` — 28 passed

## Context

Found while investigating #6986 (bounding the `PersonalEventCacheService` Hive boxes). It is split out because it is independent of that refactor and lives in a different package — but it is also a prerequisite for any design there that routes the user's own kind 3 into the shared `event` table.

Refs #6986
