### PR TITLE
refactor(profile): consolidate own-video action sheets

### DIFF
--- a/mobile/lib/widgets/composable_video_grid.dart
+++ b/mobile/lib/widgets/composable_video_grid.dart
@@ -17,7 +17,6 @@ import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/creator_delete_enforcement_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/screens/video_metadata/video_metadata_edit_screen.dart';
-import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/feed_refresh_control.dart';
 import 'package:openvine/widgets/owner_video_actions_sheet.dart';
@@ -133,10 +132,19 @@ class _ComposableVideoGridState extends ConsumerState<ComposableVideoGrid>
   String? _resolveViewerPubkey() {
     // Identity gating for UI, so the auth state is the right rebuild trigger:
     // signing readiness (`nostrSessionProvider`) is a different question.
-    final authState = ref.watch(currentAuthStateProvider);
-    if (authState != AuthState.authenticated) return null;
+    ref.watch(currentAuthStateProvider);
+    final authService = ref.read(authServiceProvider);
+    // Sign-out queues the client replacement, so the outgoing client can still
+    // hand back its cached key on a rebuild. Neither identity source is
+    // trustworthy until the session itself says it is authenticated.
+    //
+    // Read as a bool rather than comparing against `AuthState.authenticated`:
+    // naming the enum would mean importing `services/auth_service.dart` into
+    // the UI layer, which `check_ui_service_boundary.sh` forbids.
+    // `AuthService.isAuthenticated` is defined as exactly that comparison.
+    if (!authService.isAuthenticated) return null;
 
-    final fromAuthService = ref.read(authServiceProvider).currentPublicKeyHex;
+    final fromAuthService = authService.currentPublicKeyHex;
     if (fromAuthService != null && fromAuthService.isNotEmpty) {
       return fromAuthService;
     }

--- a/mobile/lib/widgets/composable_video_grid.dart
+++ b/mobile/lib/widgets/composable_video_grid.dart
@@ -6,23 +6,20 @@ import 'dart:async';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart' show ScrollCacheExtent;
-import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
+import 'package:go_router/go_router.dart';
 import 'package:models/models.dart' hide AspectRatio;
 import 'package:openvine/blocs/owner_video_actions/owner_video_actions_cubit.dart';
-import 'package:openvine/extensions/modal_pop_extension.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/mixins/scroll_pagination_mixin.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/creator_delete_enforcement_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
-import 'package:openvine/utils/delete_result_localization.dart';
-import 'package:openvine/utils/owner_video_cleanup_feedback.dart';
+import 'package:openvine/screens/video_metadata/video_metadata_edit_screen.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/feed_refresh_control.dart';
-import 'package:openvine/widgets/owner_video_delete_confirmation_dialog.dart';
-import 'package:openvine/widgets/show_edit_dialog_for_video.dart';
+import 'package:openvine/widgets/owner_video_actions_sheet.dart';
 import 'package:openvine/widgets/user_name.dart';
 import 'package:openvine/widgets/video_thumbnail_widget.dart';
 
@@ -290,247 +287,16 @@ class _ComposableVideoGridState extends ConsumerState<ComposableVideoGrid>
   ///
   /// Ownership is decided in [_buildGrid] so a non-owned tile never wires the
   /// gesture — and therefore never advertises the action to assistive tech.
-  void _showVideoContextMenu(BuildContext context, VideoEvent video) {
-    showModalBottomSheet<void>(
-      context: context,
-      backgroundColor: context.vineColors.background,
-      builder: (sheetContext) => BlocProvider.value(
-        value: _ownerVideoActionsCubit,
-        child: BlocBuilder<OwnerVideoActionsCubit, OwnerVideoActionsState>(
-          builder: (_, state) {
-            final operation = state.forVideo(video.id);
-            final isDeletePublishing =
-                operation.deleteStatus == OwnerVideoDeleteStatus.deleting;
-            final isDeleteInProgress =
-                isDeletePublishing ||
-                operation.cleanupStatus == OwnerVideoCleanupStatus.inProgress;
-            return SafeArea(
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  // Header
-                  Padding(
-                    padding: const EdgeInsets.all(16),
-                    child: Row(
-                      children: [
-                        DivineIcon(
-                          icon: DivineIconName.dotsThreeVertical,
-                          color: sheetContext.vineColors.primaryText,
-                        ),
-                        const SizedBox(width: 12),
-                        Expanded(
-                          child: Text(
-                            sheetContext.l10n.videoGridOptionsTitle,
-                            style: TextStyle(
-                              color: sheetContext.vineColors.primaryText,
-                              fontSize: 18,
-                              fontWeight: FontWeight.bold,
-                            ),
-                          ),
-                        ),
-                        IconButton(
-                          onPressed: () => sheetContext.popModalIfMounted(),
-                          icon: DivineIcon(
-                            icon: DivineIconName.x,
-                            color: sheetContext.vineColors.secondaryText,
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-
-                  // Edit option
-                  ListTile(
-                    leading: Container(
-                      width: 40,
-                      height: 40,
-                      decoration: BoxDecoration(
-                        color: sheetContext.vineColors.card,
-                        borderRadius: BorderRadius.circular(8),
-                      ),
-                      child: DivineIcon(
-                        icon: DivineIconName.pencilSimple,
-                        color: sheetContext.vineColors.accentPositive,
-                        size: 20,
-                      ),
-                    ),
-                    title: Text(
-                      sheetContext.l10n.videoGridEditVideo,
-                      style: TextStyle(
-                        color: sheetContext.vineColors.primaryText,
-                        fontWeight: FontWeight.w500,
-                      ),
-                    ),
-                    subtitle: Text(
-                      sheetContext.l10n.videoGridEditVideoSubtitle,
-                      style: TextStyle(
-                        color: sheetContext.vineColors.secondaryText,
-                        fontSize: 12,
-                      ),
-                    ),
-                    enabled: !isDeleteInProgress,
-                    onTap: isDeleteInProgress
-                        ? null
-                        : () {
-                            if (_ownerVideoActionsCubit.isDeleteInProgress(
-                              video.id,
-                            )) {
-                              return;
-                            }
-                            if (!sheetContext.popModalIfMounted()) return;
-                            showEditDialogForVideo(context, video);
-                          },
-                  ),
-
-                  // Delete option
-                  ListTile(
-                    leading: Container(
-                      width: 40,
-                      height: 40,
-                      decoration: BoxDecoration(
-                        color: sheetContext.vineColors.card,
-                        borderRadius: BorderRadius.circular(8),
-                      ),
-                      child: isDeleteInProgress
-                          ? const CircularProgressIndicator(strokeWidth: 2)
-                          : const DivineIcon(
-                              icon: DivineIconName.trash,
-                              color: VineTheme.error,
-                              size: 20,
-                            ),
-                    ),
-                    title: Text(
-                      sheetContext.l10n.videoGridDeleteVideo,
-                      style: TextStyle(
-                        color: sheetContext.vineColors.primaryText,
-                        fontWeight: FontWeight.w500,
-                      ),
-                    ),
-                    subtitle: Text(
-                      sheetContext.l10n.videoGridDeleteVideoSubtitle,
-                      style: TextStyle(
-                        color: sheetContext.vineColors.secondaryText,
-                        fontSize: 12,
-                      ),
-                    ),
-                    enabled: !isDeleteInProgress,
-                    onTap: isDeleteInProgress
-                        ? null
-                        : () {
-                            if (!sheetContext.popModalIfMounted()) return;
-                            _showDeleteConfirmation(context, video);
-                          },
-                  ),
-
-                  const SizedBox(height: 16),
-                ],
-              ),
-            );
-          },
+  Future<void> _showVideoContextMenu(BuildContext context, VideoEvent video) =>
+      showOwnerVideoActionsSheet(
+        context: context,
+        video: video,
+        cubit: _ownerVideoActionsCubit,
+        onEditRequested: () => context.push(
+          VideoMetadataEditScreen.pathFor(video.id),
+          extra: video,
         ),
-      ),
-    );
-  }
-
-  /// Show delete confirmation dialog
-  Future<void> _showDeleteConfirmation(
-    BuildContext context,
-    VideoEvent video,
-  ) async {
-    final confirmed = await showOwnerVideoDeleteConfirmationDialog(context);
-
-    if (confirmed && context.mounted) {
-      await _deleteVideo(context, video);
-    }
-  }
-
-  /// Delete the video and confirm Divine-controlled media cleanup.
-  Future<void> _deleteVideo(BuildContext context, VideoEvent video) async {
-    try {
-      if (_ownerVideoActionsCubit.isDeleteInProgress(video.id)) return;
-      // Show loading snackbar
-      if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Row(
-              children: [
-                SizedBox(
-                  width: 16,
-                  height: 16,
-                  child: CircularProgressIndicator(
-                    strokeWidth: 2,
-                    color: context.vineColors.primaryText,
-                  ),
-                ),
-                const SizedBox(width: 12),
-                Text(context.l10n.videoGridDeletingContent),
-              ],
-            ),
-            backgroundColor: VineTheme.warning,
-            duration: const Duration(seconds: 2),
-          ),
-        );
-      }
-
-      final start = await _ownerVideoActionsCubit.deleteVideo(video);
-      if (start == OwnerVideoDeleteStart.busy) return;
-      if (!context.mounted) return;
-      final operation = _ownerVideoActionsCubit.state.forVideo(video.id);
-      if (operation.deleteStatus == OwnerVideoDeleteStatus.success) {
-        showOwnerVideoCleanupCompletion(
-          context,
-          _ownerVideoActionsCubit,
-          video.id,
-        );
-      }
-
-      if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Row(
-              children: [
-                Icon(
-                  operation.deleteStatus == OwnerVideoDeleteStatus.success
-                      ? Icons.check_circle
-                      : Icons.error,
-                  color: context.vineColors.primaryText,
-                ),
-                const SizedBox(width: 12),
-                Expanded(
-                  child: Text(
-                    operation.deleteStatus == OwnerVideoDeleteStatus.success
-                        ? localizedOwnerVideoDeleteSuccessMessage(
-                            context,
-                            operation,
-                          )
-                        : operation.deleteResult == null
-                        ? context.l10n.shareMenuDeleteFailedGeneric
-                        : localizedDeleteFailureMessage(
-                            context,
-                            operation.deleteResult!,
-                          ),
-                  ),
-                ),
-              ],
-            ),
-            backgroundColor:
-                operation.deleteStatus == OwnerVideoDeleteStatus.success
-                ? VineTheme.vineGreen
-                : VineTheme.error,
-          ),
-        );
-      }
-    } catch (e) {
-      if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text(context.l10n.shareMenuDeleteFailedGeneric),
-            backgroundColor: VineTheme.error,
-          ),
-        );
-      }
-    }
-  }
+      );
 }
 
 class _VideoItem extends StatelessWidget {

--- a/mobile/lib/widgets/composable_video_grid.dart
+++ b/mobile/lib/widgets/composable_video_grid.dart
@@ -123,10 +123,32 @@ class _ComposableVideoGridState extends ConsumerState<ComposableVideoGrid>
     super.dispose();
   }
 
+  /// Pubkey of the signed-in viewer, or `null` when signed out.
+  ///
+  /// `NostrClient.publicKey` is a plain cache read that starts empty and is not
+  /// re-refreshed on a miss (#6813), so it cannot be the only source: an owner
+  /// would silently lose the edit/delete affordance whenever the cache is cold.
+  /// [AuthService.currentPublicKeyHex] resolves from the identity, key
+  /// container or profile and is populated far earlier, so it leads and the
+  /// client cache is the fallback — matching `video_providers.dart` and
+  /// `ProfileVideosGrid`.
+  String? _resolveViewerPubkey() {
+    // Identity gating for UI, so the auth state is the right rebuild trigger:
+    // signing readiness (`nostrSessionProvider`) is a different question.
+    ref.watch(currentAuthStateProvider);
+    final fromAuthService = ref.read(authServiceProvider).currentPublicKeyHex;
+    if (fromAuthService != null && fromAuthService.isNotEmpty) {
+      return fromAuthService;
+    }
+    final cached = ref.read(nostrServiceProvider).publicKey;
+    return cached.isEmpty ? null : cached;
+  }
+
   @override
   Widget build(BuildContext context) {
     // Watch broken video tracker asynchronously
     final brokenTrackerAsync = ref.watch(brokenVideoTrackerProvider);
+    final viewerPubkey = _resolveViewerPubkey();
 
     return brokenTrackerAsync.when(
       loading: () => Center(
@@ -136,7 +158,7 @@ class _ComposableVideoGridState extends ConsumerState<ComposableVideoGrid>
       ),
       error: (error, stack) {
         // Fallback: show all videos if tracker fails
-        return _buildGrid(context, widget.videos);
+        return _buildGrid(context, widget.videos, viewerPubkey);
       },
       data: (tracker) {
         // Filter out broken videos
@@ -144,12 +166,16 @@ class _ComposableVideoGridState extends ConsumerState<ComposableVideoGrid>
             .where((video) => !tracker.isVideoBroken(video.id))
             .toList();
 
-        return _buildGrid(context, filteredVideos);
+        return _buildGrid(context, filteredVideos, viewerPubkey);
       },
     );
   }
 
-  Widget _buildGrid(BuildContext context, List<VideoEvent> videosToShow) {
+  Widget _buildGrid(
+    BuildContext context,
+    List<VideoEvent> videosToShow,
+    String? viewerPubkey,
+  ) {
     if (videosToShow.isEmpty && widget.emptyBuilder != null) {
       return _buildEmptyState(context);
     }
@@ -175,13 +201,17 @@ class _ComposableVideoGridState extends ConsumerState<ComposableVideoGrid>
       final listIds = subscribedListCache?.getListsForVideo(video.id);
       final isInSubscribedList = listIds != null && listIds.isNotEmpty;
 
+      final isOwnVideo = viewerPubkey != null && viewerPubkey == video.pubkey;
+
       return _VideoItem(
         video: video,
         aspectRatio: widget.thumbnailAspectRatio,
         onVideoTap: widget.onVideoTap,
         index: index,
         displayedVideos: videosToShow,
-        onLongPress: () => _showVideoContextMenu(context, video),
+        onLongPress: isOwnVideo
+            ? () => _showVideoContextMenu(context, video)
+            : null,
         isInSubscribedList: isInSubscribedList,
       );
     }
@@ -256,18 +286,11 @@ class _ComposableVideoGridState extends ConsumerState<ComposableVideoGrid>
     );
   }
 
-  /// Show context menu for long press on video tiles
+  /// Show the owner action sheet for a long-pressed video tile.
+  ///
+  /// Ownership is decided in [_buildGrid] so a non-owned tile never wires the
+  /// gesture — and therefore never advertises the action to assistive tech.
   void _showVideoContextMenu(BuildContext context, VideoEvent video) {
-    // Check if user owns this video
-    final nostrService = ref.read(nostrServiceProvider);
-    final userPubkey = nostrService.publicKey;
-    final isOwnVideo = userPubkey == video.pubkey;
-
-    // Only show context menu for own videos
-    if (!isOwnVideo) {
-      return;
-    }
-
     showModalBottomSheet<void>(
       context: context,
       backgroundColor: context.vineColors.background,
@@ -515,16 +538,19 @@ class _VideoItem extends StatelessWidget {
     required this.video,
     required this.aspectRatio,
     required this.onVideoTap,
-    required this.onLongPress,
     required this.index,
     required this.displayedVideos,
+    this.onLongPress,
     this.isInSubscribedList = false,
   });
 
   final VideoEvent video;
   final double aspectRatio;
   final Function(List<VideoEvent> videos, int index) onVideoTap;
-  final VoidCallback onLongPress;
+
+  /// Opens the own-video actions sheet; `null` for videos the viewer does not
+  /// own, so neither the gesture nor the semantics action is offered.
+  final VoidCallback? onLongPress;
   final int index;
   final List<VideoEvent> displayedVideos;
   final bool isInSubscribedList;
@@ -535,6 +561,10 @@ class _VideoItem extends StatelessWidget {
       identifier: 'video_thumbnail_$index',
       label: context.l10n.profileVideoThumbnailLabel(index + 1),
       button: true,
+      onLongPress: onLongPress,
+      onLongPressHint: onLongPress == null
+          ? null
+          : context.l10n.videoGridOptionsTitle,
       child: GestureDetector(
         onTap: () => onVideoTap(displayedVideos, index),
         onLongPress: onLongPress,

--- a/mobile/lib/widgets/composable_video_grid.dart
+++ b/mobile/lib/widgets/composable_video_grid.dart
@@ -17,6 +17,7 @@ import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/creator_delete_enforcement_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/screens/video_metadata/video_metadata_edit_screen.dart';
+import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/feed_refresh_control.dart';
 import 'package:openvine/widgets/owner_video_actions_sheet.dart';
@@ -132,7 +133,9 @@ class _ComposableVideoGridState extends ConsumerState<ComposableVideoGrid>
   String? _resolveViewerPubkey() {
     // Identity gating for UI, so the auth state is the right rebuild trigger:
     // signing readiness (`nostrSessionProvider`) is a different question.
-    ref.watch(currentAuthStateProvider);
+    final authState = ref.watch(currentAuthStateProvider);
+    if (authState != AuthState.authenticated) return null;
+
     final fromAuthService = ref.read(authServiceProvider).currentPublicKeyHex;
     if (fromAuthService != null && fromAuthService.isNotEmpty) {
       return fromAuthService;

--- a/mobile/lib/widgets/owner_video_actions_sheet.dart
+++ b/mobile/lib/widgets/owner_video_actions_sheet.dart
@@ -1,0 +1,220 @@
+// ABOUTME: Shared edit/delete action sheet for a video the viewer owns.
+// ABOUTME: Used by the profile grid and the composable (mixed-owner) grid.
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:models/models.dart';
+import 'package:openvine/blocs/owner_video_actions/owner_video_actions_cubit.dart';
+import 'package:openvine/extensions/modal_pop_extension.dart';
+import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/utils/delete_result_localization.dart';
+import 'package:openvine/utils/owner_video_cleanup_feedback.dart';
+import 'package:openvine/widgets/owner_video_delete_confirmation_dialog.dart';
+
+/// Shows the edit/delete actions for a video the signed-in viewer owns.
+///
+/// Callers are responsible for deciding ownership: this sheet is the
+/// presentation of an action set, not a permission check. Both grids gate the
+/// long-press affordance per tile so a non-owner never reaches here.
+///
+/// [onEditRequested] runs after the sheet is dismissed. [onDeleted] runs after
+/// a successful delete and before the confirmation snackbar, and exists because
+/// the two surfaces differ: the profile grid refreshes its feed so the tile
+/// disappears without waiting for relay propagation, while the mixed-owner
+/// grids have no feed cubit to refresh.
+Future<void> showOwnerVideoActionsSheet({
+  required BuildContext context,
+  required VideoEvent video,
+  required OwnerVideoActionsCubit cubit,
+  required VoidCallback onEditRequested,
+  Future<void> Function()? onDeleted,
+}) {
+  return VineBottomSheet.show<void>(
+    context: context,
+    scrollable: false,
+    expanded: false,
+    title: Text(
+      context.l10n.videoGridOptionsTitle,
+      style: VineTheme.titleMediumFont(color: context.vineColors.primaryText),
+    ),
+    body: Builder(
+      builder: (sheetContext) => BlocProvider.value(
+        value: cubit,
+        child: BlocBuilder<OwnerVideoActionsCubit, OwnerVideoActionsState>(
+          builder: (_, state) {
+            final operation = state.forVideo(video.id);
+            return _OwnVideoActionsSheetBody(
+              onEditVideo: () {
+                if (cubit.isDeleteInProgress(video.id)) return;
+                if (!sheetContext.popModalIfMounted()) return;
+                onEditRequested();
+              },
+              onDeleteVideo: () => _confirmAndDelete(
+                hostContext: context,
+                sheetContext: sheetContext,
+                video: video,
+                cubit: cubit,
+                onDeleted: onDeleted,
+              ),
+              isDeleting:
+                  operation.deleteStatus == OwnerVideoDeleteStatus.deleting ||
+                  operation.cleanupStatus == OwnerVideoCleanupStatus.inProgress,
+            );
+          },
+        ),
+      ),
+    ),
+  );
+}
+
+/// Confirms, publishes the deletion, and reports the outcome.
+///
+/// Every surface reports through [DivineSnackbarContainer] with the same
+/// localized copy, so a delete reads identically wherever it was started.
+Future<void> _confirmAndDelete({
+  required BuildContext hostContext,
+  required BuildContext sheetContext,
+  required VideoEvent video,
+  required OwnerVideoActionsCubit cubit,
+  required Future<void> Function()? onDeleted,
+}) async {
+  final confirmed = await showOwnerVideoDeleteConfirmationDialog(hostContext);
+  if (!confirmed || !hostContext.mounted) return;
+
+  final start = await cubit.deleteVideo(video);
+  if (start == OwnerVideoDeleteStart.busy) return;
+  if (!hostContext.mounted) return;
+
+  final operation = cubit.state.forVideo(video.id);
+  final messenger = ScaffoldMessenger.of(hostContext);
+
+  if (operation.deleteStatus != OwnerVideoDeleteStatus.success) {
+    messenger.showSnackBar(
+      DivineSnackbarContainer.snackBar(
+        operation.deleteResult == null
+            ? hostContext.l10n.shareMenuDeleteFailedGeneric
+            : localizedDeleteFailureMessage(
+                hostContext,
+                operation.deleteResult!,
+              ),
+        error: true,
+      ),
+    );
+    return;
+  }
+
+  showOwnerVideoCleanupCompletion(hostContext, cubit, video.id);
+  await onDeleted?.call();
+  if (sheetContext.mounted) {
+    sheetContext.popModalIfMounted();
+  }
+  if (!hostContext.mounted) return;
+  messenger.showSnackBar(
+    DivineSnackbarContainer.snackBar(
+      localizedOwnerVideoDeleteSuccessMessage(hostContext, operation),
+      error: operation.cleanupStatus == OwnerVideoCleanupStatus.failed,
+    ),
+  );
+}
+
+/// Edit/Delete actions shown when long-pressing an own video tile.
+class _OwnVideoActionsSheetBody extends StatelessWidget {
+  const _OwnVideoActionsSheetBody({
+    required this.onEditVideo,
+    required this.onDeleteVideo,
+    required this.isDeleting,
+  });
+
+  final VoidCallback onEditVideo;
+  final VoidCallback onDeleteVideo;
+  final bool isDeleting;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        _OwnVideoActionTile(
+          icon: DivineIconName.pencilSimple,
+          iconColor: context.vineColors.accentPositive,
+          title: context.l10n.videoGridEditVideo,
+          subtitle: context.l10n.videoGridEditVideoSubtitle,
+          onTap: onEditVideo,
+          isDisabled: isDeleting,
+        ),
+        _OwnVideoActionTile(
+          icon: DivineIconName.trash,
+          iconColor: VineTheme.error,
+          title: context.l10n.videoGridDeleteVideo,
+          subtitle: context.l10n.videoGridDeleteVideoSubtitle,
+          onTap: onDeleteVideo,
+          isBusy: isDeleting,
+        ),
+        SizedBox(height: MediaQuery.viewPaddingOf(context).bottom + 16),
+      ],
+    );
+  }
+}
+
+class _OwnVideoActionTile extends StatelessWidget {
+  const _OwnVideoActionTile({
+    required this.icon,
+    required this.iconColor,
+    required this.title,
+    required this.subtitle,
+    required this.onTap,
+    this.isBusy = false,
+    this.isDisabled = false,
+  });
+
+  final DivineIconName icon;
+  final Color iconColor;
+  final String title;
+  final String subtitle;
+  final VoidCallback onTap;
+  final bool isBusy;
+  final bool isDisabled;
+
+  @override
+  Widget build(BuildContext context) {
+    final actionColor = isDisabled
+        ? context.vineColors.secondaryText
+        : iconColor;
+    // The sheet paints its own background; a transparent Material keeps
+    // ListTile's ink effects visible without double-painting a surface.
+    return Material(
+      type: MaterialType.transparency,
+      child: ListTile(
+        enabled: !isBusy && !isDisabled,
+        leading: Container(
+          width: 40,
+          height: 40,
+          alignment: Alignment.center,
+          decoration: BoxDecoration(
+            color: context.vineColors.card,
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: isBusy
+              ? const CircularProgressIndicator(strokeWidth: 2)
+              : DivineIcon(icon: icon, color: actionColor, size: 20),
+        ),
+        title: Text(
+          title,
+          style: VineTheme.titleMediumFont(
+            color: isDisabled
+                ? context.vineColors.secondaryText
+                : context.vineColors.primaryText,
+          ),
+        ),
+        subtitle: Text(
+          subtitle,
+          style: VineTheme.bodySmallFont(
+            color: context.vineColors.secondaryText,
+          ),
+        ),
+        onTap: isBusy || isDisabled ? null : onTap,
+      ),
+    );
+  }
+}

--- a/mobile/lib/widgets/profile/profile_videos_grid.dart
+++ b/mobile/lib/widgets/profile/profile_videos_grid.dart
@@ -14,7 +14,6 @@ import 'package:models/models.dart';
 import 'package:openvine/blocs/background_publish/background_publish_bloc.dart';
 import 'package:openvine/blocs/owner_video_actions/owner_video_actions_cubit.dart';
 import 'package:openvine/blocs/profile_feed/profile_feed_cubit.dart';
-import 'package:openvine/extensions/modal_pop_extension.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/mixins/grid_prefetch_mixin.dart';
 import 'package:openvine/mixins/scroll_pagination_mixin.dart';
@@ -22,10 +21,8 @@ import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/creator_delete_enforcement_providers.dart';
 import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
 import 'package:openvine/screens/video_metadata/video_metadata_edit_screen.dart';
-import 'package:openvine/utils/delete_result_localization.dart';
-import 'package:openvine/utils/owner_video_cleanup_feedback.dart';
 import 'package:openvine/utils/video_identity.dart';
-import 'package:openvine/widgets/owner_video_delete_confirmation_dialog.dart';
+import 'package:openvine/widgets/owner_video_actions_sheet.dart';
 import 'package:openvine/widgets/profile/pending_collaborator_invite_banner_cubit.dart';
 import 'package:openvine/widgets/profile/profile_tab_empty_state.dart';
 import 'package:openvine/widgets/profile/profile_tab_loading_more_sliver.dart';
@@ -192,83 +189,23 @@ class _ProfileVideosGridState extends ConsumerState<ProfileVideosGrid>
     context.read<ProfileFeedCubit>().add(const ProfileFeedLoadMoreRequested());
   }
 
-  Future<void> _showOwnVideoActions(VideoEvent video) async {
-    await VineBottomSheet.show<void>(
-      context: context,
-      scrollable: false,
-      expanded: false,
-      title: Text(
-        context.l10n.videoGridOptionsTitle,
-        style: VineTheme.titleMediumFont(color: context.vineColors.primaryText),
-      ),
-      body: Builder(
-        builder: (sheetContext) => BlocProvider.value(
-          value: _ownerVideoActionsCubit,
-          child: BlocBuilder<OwnerVideoActionsCubit, OwnerVideoActionsState>(
-            builder: (context, state) {
-              final operation = state.forVideo(video.id);
-              return _OwnVideoActionsSheetBody(
-                onEditVideo: () => _editVideo(video, sheetContext),
-                onDeleteVideo: () => _confirmDeleteVideo(video, sheetContext),
-                isDeleting:
-                    operation.deleteStatus == OwnerVideoDeleteStatus.deleting ||
-                    operation.cleanupStatus ==
-                        OwnerVideoCleanupStatus.inProgress,
-              );
-            },
-          ),
+  Future<void> _showOwnVideoActions(VideoEvent video) =>
+      showOwnerVideoActionsSheet(
+        context: context,
+        video: video,
+        cubit: _ownerVideoActionsCubit,
+        onEditRequested: () => context.push(
+          VideoMetadataEditScreen.pathFor(video.id),
+          extra: video,
         ),
-      ),
-    );
-  }
-
-  void _editVideo(VideoEvent video, BuildContext sheetContext) {
-    if (_ownerVideoActionsCubit.isDeleteInProgress(video.id)) return;
-    if (!sheetContext.popModalIfMounted()) return;
-    context.push(VideoMetadataEditScreen.pathFor(video.id), extra: video);
-  }
-
-  Future<void> _confirmDeleteVideo(
-    VideoEvent video,
-    BuildContext sheetContext,
-  ) async {
-    final confirmed = await showOwnerVideoDeleteConfirmationDialog(context);
-    if (!confirmed || !mounted) return;
-
-    final cubit = _ownerVideoActionsCubit;
-    final start = await cubit.deleteVideo(video);
-    if (start == OwnerVideoDeleteStart.busy) return;
-
-    if (!mounted) return;
-
-    final operation = cubit.state.forVideo(video.id);
-    final messenger = ScaffoldMessenger.of(context);
-    if (operation.deleteStatus == OwnerVideoDeleteStatus.success) {
-      showOwnerVideoCleanupCompletion(context, cubit, video.id);
-      // The service marks the video locally deleted; a refresh drops the
-      // tile from the grid without waiting for relay propagation.
-      context.read<ProfileFeedCubit>().add(const ProfileFeedRefreshRequested());
-      if (sheetContext.mounted) {
-        sheetContext.popModalIfMounted();
-      }
-      if (!mounted) return;
-      messenger.showSnackBar(
-        DivineSnackbarContainer.snackBar(
-          localizedOwnerVideoDeleteSuccessMessage(context, operation),
-          error: operation.cleanupStatus == OwnerVideoCleanupStatus.failed,
-        ),
+        onDeleted: () async {
+          // The service marks the video locally deleted; a refresh drops the
+          // tile from the grid without waiting for relay propagation.
+          context.read<ProfileFeedCubit>().add(
+            const ProfileFeedRefreshRequested(),
+          );
+        },
       );
-    } else {
-      messenger.showSnackBar(
-        DivineSnackbarContainer.snackBar(
-          operation.deleteResult == null
-              ? context.l10n.shareMenuDeleteFailedGeneric
-              : localizedDeleteFailureMessage(context, operation.deleteResult!),
-          error: true,
-        ),
-      );
-    }
-  }
 
   void _onVideoTapped(
     VideoEvent tappedVideo, {
@@ -560,107 +497,6 @@ class _VideoGridTile extends StatelessWidget {
       ),
     ),
   );
-}
-
-/// Edit/Delete actions shown when long-pressing an own video tile.
-class _OwnVideoActionsSheetBody extends StatelessWidget {
-  const _OwnVideoActionsSheetBody({
-    required this.onEditVideo,
-    required this.onDeleteVideo,
-    required this.isDeleting,
-  });
-
-  final VoidCallback onEditVideo;
-  final VoidCallback onDeleteVideo;
-  final bool isDeleting;
-
-  @override
-  Widget build(BuildContext context) {
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        _OwnVideoActionTile(
-          icon: DivineIconName.pencilSimple,
-          iconColor: context.vineColors.accentPositive,
-          title: context.l10n.videoGridEditVideo,
-          subtitle: context.l10n.videoGridEditVideoSubtitle,
-          onTap: onEditVideo,
-          isDisabled: isDeleting,
-        ),
-        _OwnVideoActionTile(
-          icon: DivineIconName.trash,
-          iconColor: VineTheme.error,
-          title: context.l10n.videoGridDeleteVideo,
-          subtitle: context.l10n.videoGridDeleteVideoSubtitle,
-          onTap: onDeleteVideo,
-          isBusy: isDeleting,
-        ),
-        SizedBox(height: MediaQuery.viewPaddingOf(context).bottom + 16),
-      ],
-    );
-  }
-}
-
-class _OwnVideoActionTile extends StatelessWidget {
-  const _OwnVideoActionTile({
-    required this.icon,
-    required this.iconColor,
-    required this.title,
-    required this.subtitle,
-    required this.onTap,
-    this.isBusy = false,
-    this.isDisabled = false,
-  });
-
-  final DivineIconName icon;
-  final Color iconColor;
-  final String title;
-  final String subtitle;
-  final VoidCallback onTap;
-  final bool isBusy;
-  final bool isDisabled;
-
-  @override
-  Widget build(BuildContext context) {
-    final actionColor = isDisabled
-        ? context.vineColors.secondaryText
-        : iconColor;
-    // The sheet paints its own background; a transparent Material keeps
-    // ListTile's ink effects visible without double-painting a surface.
-    return Material(
-      type: MaterialType.transparency,
-      child: ListTile(
-        enabled: !isBusy && !isDisabled,
-        leading: Container(
-          width: 40,
-          height: 40,
-          alignment: Alignment.center,
-          decoration: BoxDecoration(
-            color: context.vineColors.card,
-            borderRadius: BorderRadius.circular(8),
-          ),
-          child: isBusy
-              ? const CircularProgressIndicator(strokeWidth: 2)
-              : DivineIcon(icon: icon, color: actionColor, size: 20),
-        ),
-        title: Text(
-          title,
-          style: VineTheme.titleMediumFont(
-            color: isDisabled
-                ? context.vineColors.secondaryText
-                : context.vineColors.primaryText,
-          ),
-        ),
-        subtitle: Text(
-          subtitle,
-          style: VineTheme.bodySmallFont(
-            color: context.vineColors.secondaryText,
-          ),
-        ),
-        onTap: isBusy || isDisabled ? null : onTap,
-      ),
-    );
-  }
 }
 
 class _PendingCollaboratorInviteBanner extends ConsumerWidget {

--- a/mobile/scripts/baseline/material_buttons.txt
+++ b/mobile/scripts/baseline/material_buttons.txt
@@ -39,7 +39,6 @@ lib/widgets/auth/forgot_password_dialog.dart	2
 lib/widgets/camera_fab.dart	1
 lib/widgets/categories_tab.dart	1
 lib/widgets/circular_icon_button.dart	1
-lib/widgets/composable_video_grid.dart	1
 lib/widgets/content_warning.dart	5
 lib/widgets/library/drafts_tab.dart	3
 lib/widgets/owner_video_delete_confirmation_dialog.dart	2

--- a/mobile/scripts/baseline/raw_dialogs.txt
+++ b/mobile/scripts/baseline/raw_dialogs.txt
@@ -24,7 +24,6 @@ lib/utils/external_link_launcher.dart	1
 lib/utils/pause_aware_modals.dart	2
 lib/widgets/add_to_list_dialog.dart	1
 lib/widgets/age_verification_dialog.dart	1
-lib/widgets/composable_video_grid.dart	1
 lib/widgets/library/drafts_tab.dart	1
 lib/widgets/owner_video_delete_confirmation_dialog.dart	1
 lib/widgets/profile_editor/username_status_indicator.dart	1

--- a/mobile/scripts/baseline/raw_icons.txt
+++ b/mobile/scripts/baseline/raw_icons.txt
@@ -21,7 +21,6 @@ lib/screens/settings/settings_screen.dart	5
 lib/screens/user_list_people_screen.dart	3
 lib/widgets/classic_viners_slider.dart	1
 lib/widgets/classic_vines_tab.dart	2
-lib/widgets/composable_video_grid.dart	2
 lib/widgets/for_you_tab.dart	2
 lib/widgets/library/sounds_tab.dart	3
 lib/widgets/list_card.dart	1

--- a/mobile/scripts/baseline/raw_textstyle.txt
+++ b/mobile/scripts/baseline/raw_textstyle.txt
@@ -52,7 +52,6 @@ lib/widgets/auth/auth_form_scaffold.dart	1
 lib/widgets/auth/auth_hero_section.dart	2
 lib/widgets/categories/category_glyph.dart	1
 lib/widgets/classic_vines_tab.dart	7
-lib/widgets/composable_video_grid.dart	8
 lib/widgets/content_warning.dart	11
 lib/widgets/environment_indicator.dart	1
 lib/widgets/error_message.dart	1

--- a/mobile/scripts/baseline/skip_test_ceilings.txt
+++ b/mobile/scripts/baseline/skip_test_ceilings.txt
@@ -74,7 +74,6 @@ test/unit/services/video_event_service_infinite_scroll_test.dart	4 # recover: 3 
 test/unit/services/video_event_service_subscription_test.dart	1 # rewrite: kind 22 fixture never ingested; needs a 34236 event (#4836)
 test/widget/screens/hashtag_feed_screen_test.dart	1 # rewrite: container lacks sharedpreferencesprovider override (#4836)
 test/widgets/all_settings_screens_scaffold_test.dart	2 # rewrite: relaysettingsscreen throws: no sharedprefs override (#4836)
-test/widgets/composable_video_grid_test.dart	5 # rewrite: fails on missing sharedprefs override, not the stated ws (#4836)
 test/widgets/comprehensive_clickable_hashtag_text_test.dart	4 # rewrite: taps need a gorouter harness; style expects materialcolor (#4836)
 test/widgets/profile_menu_drafts_test.dart	1 # delete: inline fake sheet; libraryscreen has no 'drafts' text (#4836)
 test/widgets/settings_bottom_nav_test.dart	1 # delete: settings screens have no bottomnavigationbar or fab (#4836)

--- a/mobile/test/screens/hashtag_feed_blocklist_filter_test.dart
+++ b/mobile/test/screens/hashtag_feed_blocklist_filter_test.dart
@@ -9,11 +9,15 @@ import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/nostr_client_provider.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/screens/hashtag_feed_screen.dart';
 import 'package:openvine/services/hashtag_service.dart';
 import 'package:openvine/services/video_event_service.dart';
 import 'package:openvine/widgets/composable_video_grid.dart';
 import 'package:videos_repository/videos_repository.dart';
+
+import '../helpers/test_provider_overrides.dart';
 
 class _MockVideosRepository extends Mock implements VideosRepository {}
 
@@ -81,6 +85,13 @@ void main() {
         contentBlocklistRepositoryProvider.overrideWithValue(mockBlocklist),
         videoEventServiceProvider.overrideWithValue(mockVideoEventService),
         subscribedListVideoCacheProvider.overrideWithValue(null),
+        // The screen hosts a ComposableVideoGrid, which resolves the viewer's
+        // pubkey through the auth service to decide per-video ownership.
+        sharedPreferencesProvider.overrideWithValue(
+          createMockSharedPreferences(),
+        ),
+        authServiceProvider.overrideWithValue(createMockAuthService()),
+        nostrServiceProvider.overrideWithValue(createMockNostrService()),
       ],
       child: MaterialApp(
         localizationsDelegates: AppLocalizations.localizationsDelegates,

--- a/mobile/test/widgets/composable_video_grid_test.dart
+++ b/mobile/test/widgets/composable_video_grid_test.dart
@@ -24,6 +24,7 @@ import 'dart:async';
 import 'dart:ui' show PointerDeviceKind;
 
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -67,9 +68,13 @@ class _MockVideoEventService extends Mock implements VideoEventService {}
 List<Override> _gridOverrides(
   broken_tracker.BrokenVideoTracker tracker, {
   MockNostrClient? nostrService,
+  MockAuthService? authService,
   List<Override> extra = const [],
 }) => [
   sharedPreferencesProvider.overrideWithValue(createMockSharedPreferences()),
+  authServiceProvider.overrideWithValue(
+    authService ?? createMockAuthService(),
+  ),
   nostrServiceProvider.overrideWithValue(
     nostrService ?? createMockNostrService(),
   ),
@@ -725,6 +730,171 @@ void main() {
         await tester.pump();
 
         expect(find.byType(BrandedLoadingIndicator), findsNothing);
+      });
+    });
+
+    group('owner action affordance', () {
+      const otherPubkey =
+          'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+      VideoEvent videoBy(String pubkey) => VideoEvent(
+        id: 'video-by-$pubkey',
+        pubkey: pubkey,
+        content: 'A video',
+        title: 'A video',
+        authorName: 'Creator',
+        videoUrl: 'https://example.com/v.mp4',
+        thumbnailUrl: 'https://example.com/v.jpg',
+        duration: 5,
+        createdAt: DateTime(2026).millisecondsSinceEpoch ~/ 1000,
+        timestamp: DateTime(2026),
+      );
+
+      Future<void> pumpGridFor(
+        WidgetTester tester, {
+        required VideoEvent video,
+        required String nostrClientPubkey,
+        String? authServicePubkey,
+      }) async {
+        final mockNostr = createMockNostrService();
+        when(() => mockNostr.publicKey).thenReturn(nostrClientPubkey);
+        final mockAuth = createMockAuthService();
+        when(() => mockAuth.currentPublicKeyHex).thenReturn(authServicePubkey);
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: _gridOverrides(
+              mockTracker,
+              nostrService: mockNostr,
+              authService: mockAuth,
+            ),
+            child: MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: Scaffold(
+                body: ComposableVideoGrid(
+                  videos: [video],
+                  onVideoTap: (videos, index) {},
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.pump();
+      }
+
+      SemanticsNode tileNode(WidgetTester tester) {
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        return tester.getSemantics(
+          find.bySemanticsLabel(l10n.profileVideoThumbnailLabel(1)),
+        );
+      }
+
+      testWidgets(
+        'does not advertise a long-press action on a video the viewer '
+        'does not own',
+        (tester) async {
+          final handle = tester.ensureSemantics();
+
+          await pumpGridFor(
+            tester,
+            video: videoBy(otherPubkey),
+            nostrClientPubkey: _ownPubkey,
+            authServicePubkey: _ownPubkey,
+          );
+
+          expect(
+            tileNode(tester).getSemanticsData().hasAction(
+              SemanticsAction.longPress,
+            ),
+            isFalse,
+            reason:
+                'Advertising a long-press on a video the viewer does not own '
+                'invites assistive-tech users to perform an action that '
+                'silently does nothing.',
+          );
+          handle.dispose();
+        },
+      );
+
+      testWidgets('labels the owner long-press action with the options hint', (
+        tester,
+      ) async {
+        final handle = tester.ensureSemantics();
+        final l10n = lookupAppLocalizations(const Locale('en'));
+
+        await pumpGridFor(
+          tester,
+          video: videoBy(_ownPubkey),
+          nostrClientPubkey: _ownPubkey,
+          authServicePubkey: _ownPubkey,
+        );
+
+        expect(
+          tileNode(tester).getSemanticsData().hasAction(
+            SemanticsAction.longPress,
+          ),
+          isTrue,
+        );
+        expect(
+          tileNode(tester),
+          isSemantics(onLongPressHint: l10n.videoGridOptionsTitle),
+          reason:
+              'Without a hint, assistive tech announces that a long-press '
+              'exists but cannot say what it does.',
+        );
+        handle.dispose();
+      });
+
+      testWidgets(
+        'opens the owner sheet when the Nostr client public-key cache is '
+        'still empty but the auth service knows the owner',
+        (tester) async {
+          final l10n = lookupAppLocalizations(const Locale('en'));
+
+          // NostrClient.publicKey is a plain cache read that starts empty and
+          // is not re-refreshed on a miss (#6813), so ownership must not
+          // depend on it alone.
+          await pumpGridFor(
+            tester,
+            video: videoBy(_ownPubkey),
+            nostrClientPubkey: '',
+            authServicePubkey: _ownPubkey,
+          );
+
+          await tester.longPress(
+            find.bySemanticsLabel(l10n.profileVideoThumbnailLabel(1)),
+          );
+          await tester.pumpAndSettle();
+
+          expect(
+            find.text(l10n.videoGridDeleteVideo),
+            findsOneWidget,
+            reason:
+                'The signed-in owner must keep the edit/delete affordance even '
+                'while the Nostr client key cache is empty.',
+          );
+        },
+      );
+
+      testWidgets('advertises no long-press action when signed out', (
+        tester,
+      ) async {
+        final handle = tester.ensureSemantics();
+
+        await pumpGridFor(
+          tester,
+          video: videoBy(_ownPubkey),
+          nostrClientPubkey: '',
+        );
+
+        expect(
+          tileNode(tester).getSemanticsData().hasAction(
+            SemanticsAction.longPress,
+          ),
+          isFalse,
+        );
+        handle.dispose();
       });
     });
   });

--- a/mobile/test/widgets/composable_video_grid_test.dart
+++ b/mobile/test/widgets/composable_video_grid_test.dart
@@ -36,6 +36,7 @@ import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/repositories/creator_delete_enforcement_repository.dart';
+import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/broken_video_tracker.dart' as broken_tracker;
 import 'package:openvine/services/content_deletion_service.dart';
 import 'package:openvine/services/video_event_service.dart';
@@ -72,19 +73,22 @@ List<Override> _gridOverrides(
   List<Override> extra = const [],
 }) => [
   sharedPreferencesProvider.overrideWithValue(createMockSharedPreferences()),
-  authServiceProvider.overrideWithValue(
-    authService ?? createMockAuthService(),
-  ),
+  authServiceProvider.overrideWithValue(authService ?? createMockAuthService()),
   nostrServiceProvider.overrideWithValue(
     nostrService ?? createMockNostrService(),
   ),
   brokenVideoTrackerProvider.overrideWith((ref) async => tracker),
   subscribedListVideoCacheProvider.overrideWithValue(null),
-  userProfileReactiveProvider.overrideWith(
-    (ref, pubkey) => Stream.value(null),
-  ),
+  userProfileReactiveProvider.overrideWith((ref, pubkey) => Stream.value(null)),
   ...extra,
 ];
+
+MockAuthService _authenticatedAuthService(String pubkey) {
+  final authService = createMockAuthService();
+  when(() => authService.authState).thenReturn(AuthState.authenticated);
+  when(() => authService.currentPublicKeyHex).thenReturn(pubkey);
+  return authService;
+}
 
 void main() {
   group('ComposableVideoGrid', () {
@@ -404,7 +408,11 @@ void main() {
 
           await tester.pumpWidget(
             ProviderScope(
-              overrides: _gridOverrides(mockTracker, nostrService: mockNostr),
+              overrides: _gridOverrides(
+                mockTracker,
+                nostrService: mockNostr,
+                authService: _authenticatedAuthService(_ownPubkey),
+              ),
               child: MaterialApp(
                 localizationsDelegates: AppLocalizations.localizationsDelegates,
                 supportedLocales: AppLocalizations.supportedLocales,
@@ -472,6 +480,7 @@ void main() {
             overrides: _gridOverrides(
               mockTracker,
               nostrService: mockNostr,
+              authService: _authenticatedAuthService(_ownPubkey),
               extra: [
                 contentDeletionServiceProvider.overrideWith(
                   (ref) async => deletionService,
@@ -572,6 +581,7 @@ void main() {
             overrides: _gridOverrides(
               mockTracker,
               nostrService: mockNostr,
+              authService: _authenticatedAuthService(_ownPubkey),
               extra: [
                 contentDeletionServiceProvider.overrideWith(
                   (ref) async => deletionService,
@@ -760,6 +770,11 @@ void main() {
         when(() => mockNostr.publicKey).thenReturn(nostrClientPubkey);
         final mockAuth = createMockAuthService();
         when(() => mockAuth.currentPublicKeyHex).thenReturn(authServicePubkey);
+        when(() => mockAuth.authState).thenReturn(
+          authServicePubkey == null
+              ? AuthState.unauthenticated
+              : AuthState.authenticated,
+        );
 
         await tester.pumpWidget(
           ProviderScope(
@@ -804,9 +819,9 @@ void main() {
           );
 
           expect(
-            tileNode(tester).getSemanticsData().hasAction(
-              SemanticsAction.longPress,
-            ),
+            tileNode(
+              tester,
+            ).getSemanticsData().hasAction(SemanticsAction.longPress),
             isFalse,
             reason:
                 'Advertising a long-press on a video the viewer does not own '
@@ -831,9 +846,9 @@ void main() {
         );
 
         expect(
-          tileNode(tester).getSemanticsData().hasAction(
-            SemanticsAction.longPress,
-          ),
+          tileNode(
+            tester,
+          ).getSemanticsData().hasAction(SemanticsAction.longPress),
           isTrue,
         );
         expect(
@@ -885,13 +900,15 @@ void main() {
         await pumpGridFor(
           tester,
           video: videoBy(_ownPubkey),
-          nostrClientPubkey: '',
+          // Client replacement is queued during sign-out, so the old client
+          // can still expose its cached key for a rebuild. Auth state must win.
+          nostrClientPubkey: _ownPubkey,
         );
 
         expect(
-          tileNode(tester).getSemanticsData().hasAction(
-            SemanticsAction.longPress,
-          ),
+          tileNode(
+            tester,
+          ).getSemanticsData().hasAction(SemanticsAction.longPress),
           isFalse,
         );
         handle.dispose();

--- a/mobile/test/widgets/composable_video_grid_test.dart
+++ b/mobile/test/widgets/composable_video_grid_test.dart
@@ -32,6 +32,7 @@ import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/creator_delete_enforcement_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/repositories/creator_delete_enforcement_repository.dart';
 import 'package:openvine/services/broken_video_tracker.dart' as broken_tracker;
@@ -39,6 +40,9 @@ import 'package:openvine/services/content_deletion_service.dart';
 import 'package:openvine/services/video_event_service.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/composable_video_grid.dart';
+// Override lives in riverpod's misc barrel; flutter_riverpod does not
+// re-export the type name even though it accepts List<Override>.
+import 'package:riverpod/misc.dart' show Override;
 
 import '../helpers/test_provider_overrides.dart';
 
@@ -52,6 +56,30 @@ class _MockEnforcementRepository extends Mock
     implements CreatorDeleteEnforcementRepository {}
 
 class _MockVideoEventService extends Mock implements VideoEventService {}
+
+/// Provider overrides every scope in this file needs.
+///
+/// [ComposableVideoGrid] renders `UserName`, which reaches the user-profile
+/// provider chain and transitively requires SharedPreferences. Without the
+/// override the scope throws `UnimplementedError: sharedPreferencesProvider
+/// must be overridden`, which is why this file's tile-rendering tests were
+/// previously disabled with `skip: true`.
+List<Override> _gridOverrides(
+  broken_tracker.BrokenVideoTracker tracker, {
+  MockNostrClient? nostrService,
+  List<Override> extra = const [],
+}) => [
+  sharedPreferencesProvider.overrideWithValue(createMockSharedPreferences()),
+  nostrServiceProvider.overrideWithValue(
+    nostrService ?? createMockNostrService(),
+  ),
+  brokenVideoTrackerProvider.overrideWith((ref) async => tracker),
+  subscribedListVideoCacheProvider.overrideWithValue(null),
+  userProfileReactiveProvider.overrideWith(
+    (ref, pubkey) => Stream.value(null),
+  ),
+  ...extra,
+];
 
 void main() {
   group('ComposableVideoGrid', () {
@@ -110,9 +138,7 @@ void main() {
     testWidgets('renders grid with provided videos', (tester) async {
       await tester.pumpWidget(
         ProviderScope(
-          overrides: [
-            brokenVideoTrackerProvider.overrideWith((ref) async => mockTracker),
-          ],
+          overrides: _gridOverrides(mockTracker),
           child: MaterialApp(
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,
@@ -131,8 +157,7 @@ void main() {
 
       // Should render 2 video tiles
       expect(find.byType(GestureDetector), findsNWidgets(2));
-      // TODO(any): Fix and re-enable these tests
-    }, skip: true);
+    });
 
     testWidgets('filters out broken videos using BrokenVideoTracker', (
       tester,
@@ -142,9 +167,7 @@ void main() {
 
       await tester.pumpWidget(
         ProviderScope(
-          overrides: [
-            brokenVideoTrackerProvider.overrideWith((ref) async => mockTracker),
-          ],
+          overrides: _gridOverrides(mockTracker),
           child: MaterialApp(
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,
@@ -162,17 +185,14 @@ void main() {
 
       // Should only render 2 tiles (broken_video filtered out)
       expect(find.byType(GestureDetector), findsNWidgets(2));
-      // TODO(any): Fix and re-enable these tests
-    }, skip: true);
+    });
 
     testWidgets('shows empty state when no videos after filtering', (
       tester,
     ) async {
       await tester.pumpWidget(
         ProviderScope(
-          overrides: [
-            brokenVideoTrackerProvider.overrideWith((ref) async => mockTracker),
-          ],
+          overrides: _gridOverrides(mockTracker),
           child: MaterialApp(
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,
@@ -199,9 +219,7 @@ void main() {
 
       await tester.pumpWidget(
         ProviderScope(
-          overrides: [
-            brokenVideoTrackerProvider.overrideWith((ref) async => mockTracker),
-          ],
+          overrides: _gridOverrides(mockTracker),
           child: MaterialApp(
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,
@@ -240,9 +258,7 @@ void main() {
 
       await tester.pumpWidget(
         ProviderScope(
-          overrides: [
-            brokenVideoTrackerProvider.overrideWith((ref) async => mockTracker),
-          ],
+          overrides: _gridOverrides(mockTracker),
           child: MaterialApp(
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,
@@ -279,9 +295,7 @@ void main() {
 
       await tester.pumpWidget(
         ProviderScope(
-          overrides: [
-            brokenVideoTrackerProvider.overrideWith((ref) async => mockTracker),
-          ],
+          overrides: _gridOverrides(mockTracker),
           child: MaterialApp(
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,
@@ -307,15 +321,12 @@ void main() {
       expect(tappedIndex, equals(1));
       expect(tappedVideos, isNotNull);
       expect(tappedVideos!.length, equals(2));
-      // TODO(any): Fix and re-enable these tests
-    }, skip: true);
+    });
 
     testWidgets('uses correct grid parameters', (tester) async {
       await tester.pumpWidget(
         ProviderScope(
-          overrides: [
-            brokenVideoTrackerProvider.overrideWith((ref) async => mockTracker),
-          ],
+          overrides: _gridOverrides(mockTracker),
           child: MaterialApp(
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,
@@ -332,22 +343,20 @@ void main() {
 
       await tester.pump();
 
-      // Find GridView and verify delegate
-      final gridView = tester.widget<GridView>(find.byType(GridView));
+      // The grid is built from slivers inside a CustomScrollView, so the
+      // delegate hangs off SliverGrid rather than a GridView.
+      final sliverGrid = tester.widget<SliverGrid>(find.byType(SliverGrid));
       final delegate =
-          gridView.gridDelegate as SliverGridDelegateWithFixedCrossAxisCount;
+          sliverGrid.gridDelegate as SliverGridDelegateWithFixedCrossAxisCount;
 
       expect(delegate.crossAxisCount, equals(3));
       expect(delegate.childAspectRatio, equals(1.0));
-      // TODO(any): Fix and re-enable these tests
-    }, skip: true);
+    });
 
-    testWidgets('displays video metadata correctly', (tester) async {
+    testWidgets('renders the video title over the thumbnail', (tester) async {
       await tester.pumpWidget(
         ProviderScope(
-          overrides: [
-            brokenVideoTrackerProvider.overrideWith((ref) async => mockTracker),
-          ],
+          overrides: _gridOverrides(mockTracker),
           child: MaterialApp(
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,
@@ -363,12 +372,10 @@ void main() {
 
       await tester.pump();
 
-      // Check for video metadata display
+      // The info overlay carries the author and the title. Engagement counts
+      // and the duration badge are no longer rendered here.
       expect(find.text('Video 1'), findsOneWidget);
-      expect(find.text('10'), findsOneWidget); // likes count
-      expect(find.text('5s'), findsOneWidget); // duration badge
-      // TODO(any): Fix and re-enable these tests
-    }, skip: true);
+    });
 
     group('delete confirmation copy', () {
       testWidgets(
@@ -392,16 +399,7 @@ void main() {
 
           await tester.pumpWidget(
             ProviderScope(
-              overrides: [
-                brokenVideoTrackerProvider.overrideWith(
-                  (ref) async => mockTracker,
-                ),
-                subscribedListVideoCacheProvider.overrideWithValue(null),
-                nostrServiceProvider.overrideWithValue(mockNostr),
-                userProfileReactiveProvider.overrideWith(
-                  (ref, pubkey) => Stream.value(null),
-                ),
-              ],
+              overrides: _gridOverrides(mockTracker, nostrService: mockNostr),
               child: MaterialApp(
                 localizationsDelegates: AppLocalizations.localizationsDelegates,
                 supportedLocales: AppLocalizations.supportedLocales,
@@ -466,23 +464,19 @@ void main() {
 
         await tester.pumpWidget(
           ProviderScope(
-            overrides: [
-              brokenVideoTrackerProvider.overrideWith(
-                (ref) async => mockTracker,
-              ),
-              subscribedListVideoCacheProvider.overrideWithValue(null),
-              nostrServiceProvider.overrideWithValue(mockNostr),
-              userProfileReactiveProvider.overrideWith(
-                (ref, pubkey) => Stream.value(null),
-              ),
-              contentDeletionServiceProvider.overrideWith(
-                (ref) async => deletionService,
-              ),
-              creatorDeleteEnforcementRepositoryProvider.overrideWithValue(
-                enforcementRepository,
-              ),
-              videoEventServiceProvider.overrideWithValue(videoEventService),
-            ],
+            overrides: _gridOverrides(
+              mockTracker,
+              nostrService: mockNostr,
+              extra: [
+                contentDeletionServiceProvider.overrideWith(
+                  (ref) async => deletionService,
+                ),
+                creatorDeleteEnforcementRepositoryProvider.overrideWithValue(
+                  enforcementRepository,
+                ),
+                videoEventServiceProvider.overrideWithValue(videoEventService),
+              ],
+            ),
             child: MaterialApp(
               localizationsDelegates: AppLocalizations.localizationsDelegates,
               supportedLocales: AppLocalizations.supportedLocales,
@@ -570,23 +564,19 @@ void main() {
 
         await tester.pumpWidget(
           ProviderScope(
-            overrides: [
-              brokenVideoTrackerProvider.overrideWith(
-                (ref) async => mockTracker,
-              ),
-              subscribedListVideoCacheProvider.overrideWithValue(null),
-              nostrServiceProvider.overrideWithValue(mockNostr),
-              userProfileReactiveProvider.overrideWith(
-                (ref, pubkey) => Stream.value(null),
-              ),
-              contentDeletionServiceProvider.overrideWith(
-                (ref) async => deletionService,
-              ),
-              creatorDeleteEnforcementRepositoryProvider.overrideWithValue(
-                enforcementRepository,
-              ),
-              videoEventServiceProvider.overrideWithValue(videoEventService),
-            ],
+            overrides: _gridOverrides(
+              mockTracker,
+              nostrService: mockNostr,
+              extra: [
+                contentDeletionServiceProvider.overrideWith(
+                  (ref) async => deletionService,
+                ),
+                creatorDeleteEnforcementRepositoryProvider.overrideWithValue(
+                  enforcementRepository,
+                ),
+                videoEventServiceProvider.overrideWithValue(videoEventService),
+              ],
+            ),
             child: MaterialApp(
               localizationsDelegates: AppLocalizations.localizationsDelegates,
               supportedLocales: AppLocalizations.supportedLocales,
@@ -659,10 +649,7 @@ void main() {
         Future<void> Function()? onLoadMore,
       }) {
         return ProviderScope(
-          overrides: [
-            brokenVideoTrackerProvider.overrideWith((ref) async => mockTracker),
-            subscribedListVideoCacheProvider.overrideWithValue(null),
-          ],
+          overrides: _gridOverrides(mockTracker),
           child: MaterialApp(
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,

--- a/mobile/test/widgets/composable_video_grid_test.dart
+++ b/mobile/test/widgets/composable_video_grid_test.dart
@@ -83,9 +83,15 @@ List<Override> _gridOverrides(
   ...extra,
 ];
 
+/// A mock auth service reporting a signed-in session for [pubkey].
+///
+/// `createMockAuthService` stubs `authState` and `isAuthenticated`
+/// independently, so both are set here: the grid reads the bool, and leaving
+/// them inconsistent would make a "signed in" fixture behave as signed out.
 MockAuthService _authenticatedAuthService(String pubkey) {
   final authService = createMockAuthService();
   when(() => authService.authState).thenReturn(AuthState.authenticated);
+  when(() => authService.isAuthenticated).thenReturn(true);
   when(() => authService.currentPublicKeyHex).thenReturn(pubkey);
   return authService;
 }
@@ -770,11 +776,11 @@ void main() {
         when(() => mockNostr.publicKey).thenReturn(nostrClientPubkey);
         final mockAuth = createMockAuthService();
         when(() => mockAuth.currentPublicKeyHex).thenReturn(authServicePubkey);
+        final signedIn = authServicePubkey != null;
         when(() => mockAuth.authState).thenReturn(
-          authServicePubkey == null
-              ? AuthState.unauthenticated
-              : AuthState.authenticated,
+          signedIn ? AuthState.authenticated : AuthState.unauthenticated,
         );
+        when(() => mockAuth.isAuthenticated).thenReturn(signedIn);
 
         await tester.pumpWidget(
           ProviderScope(

--- a/mobile/test/widgets/for_you_tab_test.dart
+++ b/mobile/test/widgets/for_you_tab_test.dart
@@ -7,10 +7,15 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/providers/auth_providers.dart';
 import 'package:openvine/providers/curation_providers.dart';
 import 'package:openvine/providers/for_you_provider.dart';
+import 'package:openvine/providers/nostr_client_provider.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/state/video_feed_state.dart';
 import 'package:openvine/widgets/for_you_tab.dart';
+
+import '../helpers/test_provider_overrides.dart';
 
 class _AvailableFunnelcake extends FunnelcakeAvailable {
   @override
@@ -27,6 +32,11 @@ Widget _host({double textScale = 1}) => ProviderScope(
   overrides: [
     funnelcakeAvailableProvider.overrideWith(_AvailableFunnelcake.new),
     forYouFeedProvider.overrideWith(_EmptyForYouFeed.new),
+    // ForYouTab hosts a ComposableVideoGrid, which resolves the viewer's
+    // pubkey through the auth service to decide per-video ownership.
+    sharedPreferencesProvider.overrideWithValue(createMockSharedPreferences()),
+    authServiceProvider.overrideWithValue(createMockAuthService()),
+    nostrServiceProvider.overrideWithValue(createMockNostrService()),
   ],
   child: MaterialApp(
     localizationsDelegates: AppLocalizations.localizationsDelegates,

--- a/mobile/test/widgets/owner_video_actions_sheet_test.dart
+++ b/mobile/test/widgets/owner_video_actions_sheet_test.dart
@@ -1,0 +1,145 @@
+// ABOUTME: Tests the shared owner-video action sheet helper.
+// ABOUTME: Pins the onDeleted contract that lets the two grids differ.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
+import 'package:openvine/blocs/owner_video_actions/owner_video_actions_cubit.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/repositories/creator_delete_enforcement_repository.dart';
+import 'package:openvine/services/content_deletion_service.dart';
+import 'package:openvine/services/video_event_service.dart';
+import 'package:openvine/widgets/owner_video_actions_sheet.dart';
+
+class _MockContentDeletionService extends Mock
+    implements ContentDeletionService {}
+
+class _MockVideoEventService extends Mock implements VideoEventService {}
+
+class _MockEnforcementRepository extends Mock
+    implements CreatorDeleteEnforcementRepository {}
+
+class _FakeVideoEvent extends Fake implements VideoEvent {}
+
+void main() {
+  group('showOwnerVideoActionsSheet', () {
+    final l10n = lookupAppLocalizations(const Locale('en'));
+    final video = VideoEvent(
+      id: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+      pubkey:
+          'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789',
+      createdAt: 1757385263,
+      content: 'Test video content',
+      timestamp: DateTime.fromMillisecondsSinceEpoch(1757385263 * 1000),
+      videoUrl: 'https://example.com/video.mp4',
+    );
+
+    late _MockContentDeletionService deletionService;
+    late _MockVideoEventService videoEventService;
+    late _MockEnforcementRepository enforcementRepository;
+    late OwnerVideoActionsCubit cubit;
+
+    setUpAll(() => registerFallbackValue(_FakeVideoEvent()));
+
+    setUp(() {
+      deletionService = _MockContentDeletionService();
+      videoEventService = _MockVideoEventService();
+      enforcementRepository = _MockEnforcementRepository();
+      when(() => enforcementRepository.enforce(any())).thenAnswer(
+        (_) async => const CreatorDeleteEnforcementResult.confirmed(),
+      );
+      when(
+        () => videoEventService.removeVideoEventCompletely(any()),
+      ).thenAnswer((_) async {});
+      cubit = OwnerVideoActionsCubit(
+        contentDeletionService: () async => deletionService,
+        videoEventService: () => videoEventService,
+        enforcementRepository: () => enforcementRepository,
+      );
+    });
+
+    tearDown(() => cubit.close());
+
+    void stubDelete({required bool success}) {
+      when(
+        () => deletionService.quickDelete(
+          video: video,
+          reason: DeleteReason.personalChoice,
+        ),
+      ).thenAnswer(
+        (_) async => success
+            ? DeleteResult.createSuccess(
+                'delete-event-id',
+                acceptance: DeleteAcceptance.everyRelay,
+              )
+            : DeleteResult.failure(
+                'rejected',
+                DeleteFailureKind.relayRejected,
+              ),
+      );
+    }
+
+    Future<List<String>> openSheetAndDelete(WidgetTester tester) async {
+      final calls = <String>[];
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: Builder(
+              builder: (context) => TextButton(
+                onPressed: () => showOwnerVideoActionsSheet(
+                  context: context,
+                  video: video,
+                  cubit: cubit,
+                  onEditRequested: () => calls.add('edit'),
+                  onDeleted: () async => calls.add('deleted'),
+                ),
+                child: const Text('open'),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(l10n.videoGridDeleteVideo));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(l10n.shareMenuDelete));
+      await tester.pumpAndSettle();
+      return calls;
+    }
+
+    testWidgets('runs onDeleted after a successful delete', (tester) async {
+      stubDelete(success: true);
+
+      final calls = await openSheetAndDelete(tester);
+
+      expect(calls, contains('deleted'));
+    });
+
+    testWidgets('does not run onDeleted when the delete fails', (tester) async {
+      stubDelete(success: false);
+
+      final calls = await openSheetAndDelete(tester);
+
+      expect(
+        calls,
+        isNot(contains('deleted')),
+        reason:
+            "onDeleted drops the tile from the caller's feed, so running it "
+            'on a failed delete would hide a video that still exists.',
+      );
+    });
+
+    testWidgets('reports a failed delete to the user', (tester) async {
+      stubDelete(success: false);
+
+      await openSheetAndDelete(tester);
+
+      expect(find.byType(SnackBar), findsOneWidget);
+    });
+  });
+}

--- a/mobile/test/widgets/video_editor/timeline_editor/controls/animation_picker_components_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/controls/animation_picker_components_test.dart
@@ -31,8 +31,20 @@ void main() {
       );
     }
 
+    // Scoped to the chip rather than `find.byType(DecoratedBox).first`, which
+    // asserts on a tree shape this test does not control: anything the ambient
+    // route wraps around the app — a Cupertino page transition's
+    // `_CupertinoEdgeShadowDecoration`, for one — sorts ahead of the chip and
+    // fails the cast. The chip owns exactly one DecoratedBox, so name it.
     BoxDecoration decorationOf(WidgetTester tester) =>
-        tester.widget<DecoratedBox>(find.byType(DecoratedBox).first).decoration
+        tester
+                .widget<DecoratedBox>(
+                  find.descendant(
+                    of: find.byType(AnimationPickerChip),
+                    matching: find.byType(DecoratedBox),
+                  ),
+                )
+                .decoration
             as BoxDecoration;
 
     testWidgets('marks the selected chip with a readable border in light '


### PR DESCRIPTION
Closes #6327.

## What changed

`ProfileVideosGrid` and `ComposableVideoGrid` both let an owner long-press their own video tile to edit or delete it, through two implementations that had drifted about ten months apart. Two of the issue's five acceptance criteria already passed — #6914 and #8193 retrofitted `OwnerVideoActionsCubit` and the shared delete dialog into both grids — so the issue body's description of the composable grid as "older raw modal/dialog/delete code" is now half stale. The three that did not pass are here, plus two accessibility defects found while verifying them.

`feed_settings_menu.dart` is deliberately untouched. It is an overlay popover rather than a bottom sheet, and #6327 names it as the reference implementation, not a target.

## The accessibility defects (the substance of this PR)

These are measured against the real semantics tree — by invoking `SemanticsAction.longPress` through the semantics owner, which is what VoiceOver and TalkBack do — not inferred from reading the source.

**A tile you do not own still advertised a long-press action, and performing it did nothing.** `ComposableVideoGrid` backs eight mixed-owner surfaces (explore, hashtag, category, curated list, user list, For You, Popular, New), and wired the gesture unconditionally, deciding ownership inside the handler and returning silently. On a mixed feed that is most tiles: a screen-reader user was invited to act on every one and got silence on nearly all of them.

**The action carried no `onLongPressHint`**, so even on a video you do own, assistive tech announced that a long-press existed without saying what it does.

`ProfileVideosGrid` already did both correctly (#6325): `onLongPress` is nullable and `null` for non-owners, which removes the gesture and the semantics action together, and it supplies the hint. This adopts the same shape.

## The identity fix (hardening, not a live outage)

Ownership resolved from `NostrClient.publicKey` — a plain cache read that starts empty and, as `resolvePublicKey`'s own doc records, is not re-refreshed on a miss, so it can stay `''` for a whole session. #6813 fixed this class for author-scoped relay filters, but its sweep covered `authors: [...]` filters; identity *comparisons* were outside it.

I want to be precise about severity rather than oversell it. Instrumenting a cold boot on a Keycast session showed the placeholder-client path is real (`Public key changed from <null> to npub1…`), but the key is populated at `13.352` and the router does not reach `/home/0` — the first route hosting a grid — until `13.599`. The window closes 247 ms before a user can reach a tile. **So this is a latent robustness defect, not something users are hitting routinely.** It is still worth fixing: an owner whose signer came up empty would lose edit and delete entirely, with no error, and `AuthService.currentPublicKeyHex` is populated far earlier and is the source the profile grid already trusts.

Resolution now first requires an authenticated auth state, then uses `currentPublicKeyHex ?? client.publicKey`, matching `video_providers.dart:215`. It is evaluated once per build and rebuilt via `currentAuthStateProvider`, so signed-out transitions cannot expose a stale client-cache identity.

## The consolidation

`showOwnerVideoActionsSheet` in `lib/widgets/owner_video_actions_sheet.dart` owns presentation and the whole delete orchestration — confirm, publish, cleanup completion, snackbar. The composable grid previously hand-rolled a raw `showModalBottomSheet` with eight inline `TextStyle`s and reported through raw `SnackBar`s in `VineTheme.warning` / `VineTheme.error` with a hardcoded two-second toast, so the same delete told users different things depending on which grid they started from. Both now report identically through `DivineSnackbarContainer`.

The surfaces differ in one real way, so the helper takes it as a parameter rather than assuming it away: after a successful delete the profile grid refreshes its feed to drop the tile without waiting for relay propagation, while the mixed-owner grids have no feed cubit to refresh. That is `onDeleted`.

This is the fourth consolidation of this feature, after the confirmation dialog, the cleanup feedback and the cubit — all functions or classes every surface calls, so no new architectural shape is introduced. The sheet body and action tile moved out of the profile grid **byte-identically** (verified by diff), and `check_dark_value_parity.dart` reports **0 dark mismatches**.

## Behaviour change

**Long-pressing a video you do not own no longer does anything on those eight surfaces.** Previously it accepted the gesture and silently discarded it. This is intended and matches the profile grid, but it is a user-visible change and reviewers should see it called out.

## Tests

Four regression tests were written first and each failed for the right reason on unmodified `main`:

```
does not advertise a long-press ... viewer does not own   Expected: false  Actual: <true>
labels the owner long-press action with the options hint  Expected: 'Video Options'  Actual: ''
opens the owner sheet when the ... cache is still empty   Found 0 widgets with text "Delete Video"
advertises no long-press action when signed out           Expected: false  Actual: <true>
```

The existing owner tests passed on the broken code and could never have caught any of this: they stub `publicKey` to the owner value, so they prove the path works when the key is populated but say nothing about the population; and they drive the sheet with `tester.longPress`, a hit-test gesture that cannot see the semantics defects at all. The new assertions go through the semantics tree instead.

Both the hint fix and the `onDeleted` contract were re-verified by breaking the production code and confirming exactly the expected single test goes red.

The five `skip: true` tests in `composable_video_grid_test.dart` are recovered. The baseline reason was correct — they failed on a missing SharedPreferences override — and that turned out to be a prerequisite rather than an add-on, since reading the viewer's pubkey pulls `authServiceProvider` into the graph, which needs the same override. Two of the five were stale rather than merely blocked (they asserted a `GridView` where the widget builds slivers, and a likes count and duration badge the tile no longer renders) and are rewritten to current behaviour — the `# rewrite:` outcome the baseline recorded. Two consumer suites that render the grid needed the same overrides.

Worth noting for review: `nostrServiceProvider` already watched `authServiceProvider` in production, so this adds **no new runtime dependency** — those tests were short-circuiting the real provider graph by overriding the client directly.

## Ratchets

Deleting the hand-rolled sheet took `composable_video_grid.dart` to zero on four design-system ratchets, each of which fails CI until regenerated: raw dialogs 1→0, raw `TextStyle(` 8→0, Material buttons 1→0, raw `Icons.*` 2→0. The skip ceiling drops its entry (5→0).

Only entries for files this branch touched are changed. Regenerating wholesale would also have swept up shrinks other branches made without locking them (`creator_analytics_screen` 5→3, `sounds_tab` 3→2, `invite_gate_screen` 12→11, and three more) which belong to those PRs. Those guards only fail on growth, so leaving them is safe.

## Verification

- `flutter analyze lib test integration_test` — no issues
- Full suite — ~9,400 green. Two failure groups, both proven environmental: `post_close_emit_detector_test` failed on a stale `.dart_tool/hooks_runner` cache (`Invalid SDK hash`) and passes 27/27 after clearing it; the `divine_ui` gallery goldens fail at **2.67%** against the documented ~4% macOS antialiasing ceiling, on components this diff does not touch.
- Every `scripts/check_*.sh` passes, except `check_ios_extension_signing_contract.sh`, which fails identically with `origin/main`'s own copy of the script and touches no file here.
- No new ARB keys — `videoGridOptionsTitle` and the rest already exist in all 22 locales, so no translation pass and no orphan-ratchet exposure.
- Production code is **~298 lines lighter** (−322 composable, −196 profile, +220 shared).

## Follow-ups (filed separately, not in this PR)

- A repo-wide sweep for identity *comparisons* built on the plain `publicKey` cache read. `comment_item.dart` guards with `.isNotEmpty`; the composable grid did not.
- An `OwnerVideoActionsTile` wrapper so a call site cannot get the affordance wrong again — which is exactly how this happened. Too large here; wants semantics/golden coverage on both grids first.
- The unlocked ratchet shrinks listed above.