### PR TITLE
fix(seed): keep seeded events past the second cold start

### DIFF
--- a/mobile/lib/services/seed_data_preload_service.dart
+++ b/mobile/lib/services/seed_data_preload_service.dart
@@ -96,10 +96,19 @@ class SeedDataPreloadService {
 
   static void _insertEvent(Batch batch, Map<String, dynamic> event) {
     final kind = event['kind'] as int;
+    // `expire_at` is set, not omitted. `deleteExpiredEvents` runs from
+    // `beforeOpen` on every open and deletes `expire_at IS NULL` rows as well
+    // as past-dated ones, so an omitted column meant every seeded event was
+    // destroyed on the second cold start — and never restored, because the
+    // reload above is gated on the database being empty and relay-cached rows
+    // keep the count above zero. The profiles and metrics seeded alongside
+    // them are not swept, so what survived was an orphaned half of the bundle
+    // (#8316).
     batch.customStatement(
       'INSERT OR IGNORE INTO event '
-      '(id, pubkey, created_at, kind, tags, content, sig, sources, d_tag) '
-      'VALUES (?, ?, ?, ?, ?, ?, ?, NULL, ?)',
+      '(id, pubkey, created_at, kind, tags, content, sig, sources, d_tag, '
+      'expire_at) '
+      'VALUES (?, ?, ?, ?, ?, ?, ?, NULL, ?, ?)',
       [
         event['id'] as String,
         event['pubkey'] as String,
@@ -109,6 +118,7 @@ class SeedDataPreloadService {
         event['content'] as String,
         event['sig'] as String,
         _dTagForEvent(kind, event['tags'] as List?),
+        neverExpiresAtUnix,
       ],
     );
   }

--- a/mobile/lib/services/seed_data_preload_service.dart
+++ b/mobile/lib/services/seed_data_preload_service.dart
@@ -96,14 +96,8 @@ class SeedDataPreloadService {
 
   static void _insertEvent(Batch batch, Map<String, dynamic> event) {
     final kind = event['kind'] as int;
-    // `expire_at` is set, not omitted. `deleteExpiredEvents` runs from
-    // `beforeOpen` on every open and deletes `expire_at IS NULL` rows as well
-    // as past-dated ones, so an omitted column meant every seeded event was
-    // destroyed on the second cold start — and never restored, because the
-    // reload above is gated on the database being empty and relay-cached rows
-    // keep the count above zero. The profiles and metrics seeded alongside
-    // them are not swept, so what survived was an orphaned half of the bundle
-    // (#8316).
+    // NULL is treated as expired during startup cleanup; seed rows persist.
+    // See #8316.
     batch.customStatement(
       'INSERT OR IGNORE INTO event '
       '(id, pubkey, created_at, kind, tags, content, sig, sources, d_tag, '

--- a/mobile/packages/db_client/lib/src/database/daos/nostr_events_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/nostr_events_dao.dart
@@ -17,6 +17,14 @@ part 'nostr_events_dao.g.dart';
 /// re-fetching from relays.
 const Duration defaultEventCacheExpiry = Duration(days: 1);
 
+/// `expire_at` for rows that must survive [NostrEventsDao.deleteExpiredEvents].
+///
+/// NULL cannot express this: the sweep deletes `expire_at IS NULL` rows as well
+/// as past-dated ones, so NULL means *already expired*, not *never expires*.
+/// Anything that must outlive a cold start needs a real timestamp far enough
+/// out that it never arrives in practice (#8316).
+const int neverExpiresAtUnix = 4102444800; // 2100-01-01T00:00:00Z
+
 @DriftAccessor(tables: [NostrEvents, VideoMetrics])
 class NostrEventsDao extends DatabaseAccessor<AppDatabase>
     with _$NostrEventsDaoMixin {

--- a/mobile/packages/db_client/test/src/database/daos/nostr_events_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/nostr_events_dao_test.dart
@@ -1933,6 +1933,21 @@ void main() {
       });
 
       group('deleteExpiredEvents', () {
+        test('deletes legacy events with a null expiry', () async {
+          await database.customStatement('''
+            INSERT INTO event
+              (id, pubkey, created_at, kind, tags, content, sig, expire_at)
+            VALUES
+              ('legacy-null-expiry', '$testPubkey', 1000, 1, '[]',
+               'legacy', 'sig', NULL)
+          ''');
+
+          final deletedCount = await dao.deleteExpiredEvents(null);
+
+          expect(deletedCount, 1);
+          expect(await dao.getEventById('legacy-null-expiry'), isNull);
+        });
+
         test(
           'deletes events with expired timestamps using current time',
           () async {

--- a/mobile/test/services/seed_data_preload_service_test.dart
+++ b/mobile/test/services/seed_data_preload_service_test.dart
@@ -343,11 +343,10 @@ void main() {
     });
 
     test(
-      'a seeded event is not restored once relay rows keep the count non-zero',
+      'seeded events survive while relay rows keep the count non-zero',
       () async {
-        // The reload is gated on an empty database, so a destroyed seed can
-        // never come back on a device that has fetched anything at all. This
-        // is what made the original loss permanent rather than self-healing.
+        // Reloading is gated on an empty database, so an unexpired relay row
+        // prevents a destroyed seed from being restored on an active install.
         _mockSeedAsset(
           _encodeBundle(events: [seedEvent('2'.padLeft(64, '0'))]),
         );

--- a/mobile/test/services/seed_data_preload_service_test.dart
+++ b/mobile/test/services/seed_data_preload_service_test.dart
@@ -285,4 +285,98 @@ void main() {
       expect(trackingService.importProfilesCalled, isTrue);
     });
   });
+
+  group('SeedDataPreloadService cold-start survival', () {
+    late Directory tempDir;
+    late String dbPath;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('seed_expiry_');
+      dbPath = '${tempDir.path}/seed.db';
+    });
+
+    tearDown(() async {
+      if (tempDir.existsSync()) {
+        tempDir.deleteSync(recursive: true);
+      }
+      // rootBundle caches by asset key, so without this a later test in this
+      // file is served an earlier test's seed payload. Restore the framework's
+      // asset handler too — nulling it would strand asset loading for every
+      // later suite in the shared VGV isolate.
+      rootBundle.clear();
+      restoreFlutterAssetsDefaultHandler();
+    });
+
+    /// A file-backed database, so the seed can be written on one open and read
+    /// back on the next. The failure this pins only appears on the *second*
+    /// open, when `beforeOpen` runs `deleteExpiredEvents`.
+    AppDatabase openDb() => AppDatabase.test(NativeDatabase(File(dbPath)));
+
+    Map<String, dynamic> seedEvent(String id) => <String, dynamic>{
+      'id': id,
+      'pubkey':
+          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      'created_at': 1700000000,
+      'kind': 1,
+      'tags': <List<String>>[],
+      'content': 'seeded',
+      'sig': 's' * 128,
+    };
+
+    test('seeded events survive a second cold start', () async {
+      _mockSeedAsset(
+        _encodeBundle(events: [seedEvent('1'.padLeft(64, '0'))]),
+      );
+
+      // Launch 1: empty database, seed loads.
+      var db = openDb();
+      await SeedDataPreloadService.loadSeedDataIfNeeded(db);
+      expect(await db.nostrEventsDao.getEventCount(), 1);
+      await db.close();
+
+      // Launch 2: beforeOpen runs deleteExpiredEvents, which removes rows whose
+      // expire_at IS NULL as well as past-dated ones. Before #8316 the seed
+      // omitted the column, so every seeded event was destroyed here.
+      db = openDb();
+      expect(await db.nostrEventsDao.getEventCount(), 1);
+      await db.close();
+    });
+
+    test(
+      'a seeded event is not restored once relay rows keep the count non-zero',
+      () async {
+        // The reload is gated on an empty database, so a destroyed seed can
+        // never come back on a device that has fetched anything at all. This
+        // is what made the original loss permanent rather than self-healing.
+        _mockSeedAsset(
+          _encodeBundle(events: [seedEvent('2'.padLeft(64, '0'))]),
+        );
+
+        var db = openDb();
+        await SeedDataPreloadService.loadSeedDataIfNeeded(db);
+
+        // An ordinary relay-cached event, written through the DAO so it carries
+        // the default 1-day expiry.
+        final relayEvent = Event(
+          'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+          1,
+          const [],
+          'from a relay',
+          createdAt: 1700000001,
+        )..sig = 'r' * 128;
+        await db.nostrEventsDao.upsertEvent(relayEvent);
+        await db.close();
+
+        db = openDb();
+        await SeedDataPreloadService.loadSeedDataIfNeeded(db);
+
+        expect(
+          await db.nostrEventsDao.getEventById('2'.padLeft(64, '0')),
+          isNotNull,
+          reason: 'the seeded event must still be there on the second launch',
+        );
+        await db.close();
+      },
+    );
+  });
 }


### PR DESCRIPTION
Closes #8316.

## What was wrong

`SeedDataPreloadService._insertEvent` omitted `expire_at` from its column list, and the column has no default, so all 446 bundled events landed with NULL:

```dart
    batch.customStatement(
      'INSERT OR IGNORE INTO event '
      '(id, pubkey, created_at, kind, tags, content, sig, sources, d_tag) '
      'VALUES (?, ?, ?, ?, ?, ?, ?, NULL, ?)',
```

`NostrEventsDao.deleteExpiredEvents` treats NULL as expired:

```sql
DELETE FROM event WHERE expire_at IS NULL OR expire_at < ?
```

`AppDatabase.beforeOpen` calls `runStartupCleanup()` on **every** open, outside the schema-repair guard. So every seeded event was destroyed on the second launch.

While unexpired relay-cached rows remain, nothing restores those seed events. Reloading is gated on an empty database, and relay rows carry the 1-day default expiry that keeps the count above zero. An idle install can eventually become empty after those rows expire and re-seed on a later launch, but an active install stays non-empty and does not restore its missing seed events. The ordering is airtight rather than racy: the seed's own `getEventCount()` is a query, which forces Drift's lazy open, which runs `beforeOpen` → `runStartupCleanup` → `deleteExpiredEvents(null)` before the count comes back.

## It was worse than the issue described

The sweep only touches `event`. The same bundle also seeds `user_profiles` and `video_metrics`, and `runStartupCleanup` touches neither. It covers `event`, `profile_statistics`, `hashtag_stats` and `notifications`.

So the surviving state was not "seed gone" but **196 orphaned profiles and 250 orphaned metrics describing 446 events that no longer existed**. I found this while fixing it; the issue as filed missed it.

## The fix, and why this lifetime

Seeded events now carry an explicit far-future `expire_at`.

That matches what the service documents itself as: *"One-time operation on first app launch"*. It also prevents active installs from losing seed events while relay rows keep the database non-empty. A finite seed TTL would reintroduce that failure for active installs; it would only permit eventual recovery after an install remained idle long enough for every expirable event to be swept.

`neverExpiresAtUnix` sits beside `defaultEventCacheExpiry` in the DAO, because the reason it needs to exist belongs with the sweep it exists to survive: NULL cannot express "never expires" here. It means the opposite.

## Tests

Two regression tests, in their own group, against a **file-backed** database so it can be closed and reopened. The failure only appears on the second open, which is why the existing in-memory suite could never have caught it.

Both fail on the previous implementation:

```
seeded events survive a second cold start [E]
  Expected: <1>
    Actual: <0>

seeded events survive while relay rows keep the count non-zero [E]
  Expected: not null
    Actual: <null>
```

Their teardown clears `rootBundle` and calls `restoreFlutterAssetsDefaultHandler()`. Worth calling out: without the `rootBundle.clear()` the second test is served the **first test's cached asset payload**, so it passed in isolation and failed in the full file. That is the same shared-state trap `test/helpers/flutter_assets_channel.dart` was written for.

## Verification

- `flutter test test/services/seed_data_preload_service_test.dart` - 10 passed
- `flutter test` in `mobile/packages/db_client` - 1032 passed
- `flutter analyze lib test` (app and package) - no issues
- `dart format` - clean
- Test-structure, god-file, and empty-catch ratchets - pass

## Not in scope

The orphaned `user_profiles` / `video_metrics` rows already written to existing installs are not cleaned up here. With the events restored they are no longer orphaned going forward, but a device that already ran the broken version keeps whatever it has until the seed rows are re-fetched or the cache is reset. Happy to follow up if you want a one-shot reconciliation.

Found while investigating #6986.
