### PR TITLE
fix(feed): keep videos paused behind branch bottom sheets

### DIFF
--- a/mobile/lib/providers/shell_obscured_provider.dart
+++ b/mobile/lib/providers/shell_obscured_provider.dart
@@ -19,13 +19,15 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 /// the feed paused.
 ///
 /// AppShell also reconciles `overlayVisibilityProvider` when this flag becomes
-/// `false`. A fresh shell mount clears overlay owners only when the shell is
-/// the current route because it can still sit below a live page owner.
-/// `didPopNext` clears every page and bottom-sheet owner because popping the
-/// route directly above the shell proves no overlay should continue blocking
-/// autoplay, even if go_router removed the route with `go()` and never
-/// completed the original `pushWithVideoPause` future or the sheet's own
-/// dismiss callback.
+/// `false`. A fresh shell mount clears every stale overlay owner only when the
+/// shell is the current route. No branch-navigator sheet can predate that new
+/// shell, while a non-current shell may still sit below a live page owner.
+/// `didPopNext` is narrower: it clears only page owners because go_router can
+/// remove a pushed route with `go()` without completing the original
+/// `pushWithVideoPause` future. It preserves bottom-sheet owners because a
+/// branch-navigator sheet can remain visible while an unrelated root route is
+/// pushed and popped above the shell; that sheet releases its own owner when
+/// its route is dismissed.
 ///
 /// The home feed reads this to know it is offstage behind a pushed screen.
 /// GoRouter's `routeInformationProvider` collapses to the shell location

--- a/mobile/lib/router/app_shell.dart
+++ b/mobile/lib/router/app_shell.dart
@@ -105,10 +105,20 @@ class _AppShellState extends ConsumerState<AppShell> with RouteAware {
       if (!obscured) {
         final overlayVisibility = ref.read(overlayVisibilityProvider.notifier);
         if (clearOverlayOwners) {
-          // Popping the route directly above the shell proves no overlay owner
-          // remains. Force-clear because a `go()`-style back can skip an
-          // overlay route's own completion callback (#6239).
-          overlayVisibility.clearOverlays();
+          // Force-clear the page owners because a `go()`-style back can skip a
+          // pushed route's own completion callback (#6239): go_router completes
+          // an `ImperativeRouteMatch` only on the pop path, so the
+          // `pushWithVideoPause` completer never fires and its token strands.
+          //
+          // Page owners only. A popped route above the shell does *not* prove
+          // no overlay owner remains: a pause-aware sheet with
+          // `useRootNavigator: false` lives on a branch navigator, so the shell
+          // stays the top root route while that sheet is on screen. Clearing
+          // sheet owners here destroyed that live hold and resumed playback
+          // behind the visible sheet. A sheet token is released by its own
+          // route's dismiss callback and cannot strand the way a `go()`-removed
+          // page token does, so it never needed clearing here.
+          overlayVisibility.clearPageOpen();
         } else if (ModalRoute.of(context)?.isCurrent ?? false) {
           // A freshly mounted shell can still sit below a live page owner.
           // Clear only when navigation proves the shell is the top route.

--- a/mobile/lib/router/app_shell.dart
+++ b/mobile/lib/router/app_shell.dart
@@ -120,8 +120,10 @@ class _AppShellState extends ConsumerState<AppShell> with RouteAware {
           // page token does, so it never needed clearing here.
           overlayVisibility.clearPageOpen();
         } else if (ModalRoute.of(context)?.isCurrent ?? false) {
-          // A freshly mounted shell can still sit below a live page owner.
-          // Clear only when navigation proves the shell is the top route.
+          // `didPush` runs when this shell route is newly installed, before a
+          // branch-navigator sheet belonging to this shell can exist. Clear
+          // stale owners only when the fresh shell is also the top root route;
+          // otherwise it may still sit below a live page owner.
           overlayVisibility.clearOverlays();
         }
       }

--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -27,7 +27,6 @@ import 'package:openvine/models/view_traffic_source.dart';
 import 'package:openvine/providers/analytics_providers.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/foreground_idle_warmup_provider.dart';
-import 'package:openvine/router/app_router.dart';
 import 'package:openvine/router/route_paths.dart';
 import 'package:openvine/screens/comments/comments_screen.dart';
 import 'package:openvine/screens/feed/dm_reply_context.dart';
@@ -432,7 +431,7 @@ class FullscreenFeedContent extends ConsumerStatefulWidget {
 }
 
 class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
-    with RouteAware, WidgetsBindingObserver {
+    with WidgetsBindingObserver {
   late final ValueNotifier<double> _pagePosition;
   final _feedVideosKey = GlobalKey<FeedVideosState>();
 
@@ -468,16 +467,6 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
   final FeedImmersiveCubit _immersiveCubit = FeedImmersiveCubit();
 
   @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    // Subscribe to route changes to pause/resume when navigating away
-    final route = ModalRoute.of(context);
-    if (route is PageRoute) {
-      routeObserver.subscribe(this, route);
-    }
-  }
-
-  @override
   void initState() {
     super.initState();
     WidgetsBinding.instance.addObserver(this);
@@ -488,7 +477,6 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
   @override
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
-    routeObserver.unsubscribe(this);
     _pagePosition.dispose();
     unawaited(_autoAdvanceCubit.close());
     unawaited(_immersiveCubit.close());

--- a/mobile/test/providers/overlay_visibility_provider_test.dart
+++ b/mobile/test/providers/overlay_visibility_provider_test.dart
@@ -137,15 +137,38 @@ void main() {
       expect(container.read(overlayVisibilityProvider).isPageOpen, isFalse);
     });
 
-    test('clearPageOpen resets owner-held page overlays', () {
+    test('clearPageOpen drops every page owner, not just one', () {
       final container = ProviderContainer();
       addTearDown(container.dispose);
       final notifier = container.read(overlayVisibilityProvider.notifier);
 
+      // Two owners, so the test can tell a clear from a single remove.
+      notifier.setPageOpenForOwner(Object(), isOpen: true);
       notifier.setPageOpenForOwner(Object(), isOpen: true);
       notifier.clearPageOpen();
 
       expect(container.read(overlayVisibilityProvider).isPageOpen, isFalse);
+    });
+
+    test('clearPageOpen leaves bottom sheet owners holding', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final notifier = container.read(overlayVisibilityProvider.notifier);
+      final sheetOwner = Object();
+
+      notifier.setPageOpenForOwner(Object(), isOpen: true);
+      notifier.setBottomSheetOpenForOwner(sheetOwner, isOpen: true);
+      notifier.clearPageOpen();
+
+      final state = container.read(overlayVisibilityProvider);
+      expect(state.isPageOpen, isFalse);
+      expect(
+        state.isBottomSheetOpen,
+        isTrue,
+        reason:
+            'AppShell.didPopNext uses this to recover stranded page tokens '
+            'while a branch-navigator sheet is still on screen',
+      );
     });
 
     test('isMounted returns false after container disposal', () {
@@ -202,6 +225,52 @@ void main() {
       );
     });
 
+    test('releasing an unknown owner preserves active bottom sheets', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final notifier = container.read(overlayVisibilityProvider.notifier);
+      final owner = Object();
+
+      notifier.setBottomSheetOpenForOwner(owner, isOpen: true);
+      notifier.setBottomSheetOpenForOwner(Object(), isOpen: false);
+
+      expect(
+        container.read(overlayVisibilityProvider).isBottomSheetOpen,
+        isTrue,
+        reason: "an unmatched release must not close another owner's sheet",
+      );
+
+      notifier.setBottomSheetOpenForOwner(owner, isOpen: false);
+
+      expect(
+        container.read(overlayVisibilityProvider).isBottomSheetOpen,
+        isFalse,
+      );
+    });
+
+    test('duplicate open for the same bottom sheet owner is idempotent', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final notifier = container.read(overlayVisibilityProvider.notifier);
+      final owner = Object();
+
+      notifier.setBottomSheetOpenForOwner(owner, isOpen: true);
+      notifier.setBottomSheetOpenForOwner(owner, isOpen: true);
+
+      expect(
+        container.read(overlayVisibilityProvider).isBottomSheetOpen,
+        isTrue,
+      );
+
+      notifier.setBottomSheetOpenForOwner(owner, isOpen: false);
+
+      expect(
+        container.read(overlayVisibilityProvider).isBottomSheetOpen,
+        isFalse,
+        reason: 'one release must undo a repeated open for the same owner',
+      );
+    });
+
     test('provider rebuild preserves owner-held bottom sheet overlays', () {
       final container = ProviderContainer();
       addTearDown(container.dispose);
@@ -229,7 +298,10 @@ void main() {
       addTearDown(container.dispose);
       final notifier = container.read(overlayVisibilityProvider.notifier);
 
+      // Two owners per set, so the test can tell a clear from a remove.
       notifier.setPageOpenForOwner(Object(), isOpen: true);
+      notifier.setPageOpenForOwner(Object(), isOpen: true);
+      notifier.setBottomSheetOpenForOwner(Object(), isOpen: true);
       notifier.setBottomSheetOpenForOwner(Object(), isOpen: true);
       notifier.clearOverlays();
 

--- a/mobile/test/router/app_shell_obscured_test.dart
+++ b/mobile/test/router/app_shell_obscured_test.dart
@@ -249,6 +249,71 @@ void main() {
     });
   });
 
+  group('didPopNext recovery is page-scoped', () {
+    testWidgets('a live bottom-sheet owner survives an unrelated root pop', (
+      tester,
+    ) async {
+      final container = ProviderContainer(
+        overrides: _overrides(
+          mockAuthService: mockAuthService,
+          sharedPreferences: sharedPreferences,
+        ),
+      );
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        _wrapWithBlocs(
+          UncontrolledProviderScope(
+            container: container,
+            child: _appShellMaterialApp(),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // A pause-aware sheet opened with `useRootNavigator: false` lives on a
+      // branch navigator, so the shell stays the top *root* route while that
+      // sheet is on screen — community_suggest_sheet.dart is the shipped
+      // example. Model that still-visible hold.
+      final sheetOwner = Object();
+      container
+          .read(overlayVisibilityProvider.notifier)
+          .setBottomSheetOpenForOwner(sheetOwner, isOpen: true);
+      expect(
+        container.read(overlayVisibilityProvider).isBottomSheetOpen,
+        isTrue,
+      );
+
+      // An unrelated root route opens over the shell and closes again — e.g.
+      // the background upload-failure sheet, which needs no user tap. It takes
+      // no overlay token of its own, so it must not disturb the sheet's.
+      final shellContext = tester.element(find.byType(AppShell));
+      unawaited(
+        Navigator.of(shellContext, rootNavigator: true).push(
+          MaterialPageRoute<void>(
+            builder: (_) => const Scaffold(body: Text('Unrelated modal')),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(find.text('Unrelated modal'), findsOneWidget);
+      expect(container.read(shellObscuredProvider), isTrue);
+
+      Navigator.of(shellContext, rootNavigator: true).pop();
+      await tester.pumpAndSettle();
+
+      expect(container.read(shellObscuredProvider), isFalse);
+      expect(
+        container.read(overlayVisibilityProvider).isBottomSheetOpen,
+        isTrue,
+        reason:
+            'didPopNext force-clears page owners for #6239; clearing sheet '
+            'owners too destroyed this live hold and resumed playback behind '
+            'the still-visible sheet',
+      );
+    });
+  });
+
   testWidgets(
     'router.go() uncovering the shell clears a page overlay stranded by '
     'pushWithVideoPause (#6239)',
@@ -335,10 +400,11 @@ void main() {
       expect(container.read(overlayVisibilityProvider).isPageOpen, isTrue);
 
       // Model a recorder hold whose ordinary release was skipped. Uncovering
-      // the shell is the final recovery path and must clear every owner.
+      // the shell is the final recovery path and must clear every page owner.
       container
           .read(overlayVisibilityProvider.notifier)
           .setPageOpenForOwner(Object(), isOpen: true);
+      // A sheet owner alongside it, to prove the recovery is scoped to pages.
       container
           .read(overlayVisibilityProvider.notifier)
           .setBottomSheetOpenForOwner(Object(), isOpen: true);
@@ -358,8 +424,12 @@ void main() {
       );
       expect(
         container.read(overlayVisibilityProvider).isBottomSheetOpen,
-        isFalse,
-        reason: 'a stranded bottom-sheet flag keeps the home feed paused',
+        isTrue,
+        reason:
+            'the shell recovery is page-scoped: a sheet token is released by '
+            'its own route dismiss callback and cannot strand the way a '
+            'go()-removed page token does, so clearing it here would only ever '
+            'destroy a live hold',
       );
     },
   );


### PR DESCRIPTION
Refs #7540

## Description

Started as an investigation of #7540 (add reference counting to
`overlayVisibilityProvider.isPageOpen`). That refactor is already on `main` — see
"On #7540" below — but proving it turned up a real, device-reproducible playback bug
next to it, which is what this PR fixes.

### 1. `AppShell.didPopNext` destroyed live bottom-sheet owner tokens

`_setShellObscured(clearOverlayOwners: true)` called `clearOverlays()`, wiping every page
**and** bottom-sheet owner. Its comment claimed *"popping the route directly above the shell
proves no overlay owner remains."* That is false for a pause-aware sheet opened with
`useRootNavigator: false`: the sheet lives on a **branch** navigator, so the shell stays the
top *root* route while the sheet is on screen. Any unrelated root route opening and closing
then destroyed the sheet's hold and resumed feed playback behind it — audibly.

Reproduced on a physical iPhone (iOS 26.6.1) against `main`, driving the running app through
the VM service and reading `_VideoFeedViewState._isNewFeedActive` — the real playback gate —
rather than a proxy:

| step | action | live state read off the device |
|---|---|---|
| 0 | baseline, home feed playing | `feedActive=true page=false sheet=false obscured=false` |
| 1 | take one bottom-sheet owner token | `feedActive=false page=false sheet=true` |
| 2 | push an **unrelated** root route over the shell | `feedActive=false page=false sheet=true obscured=true` |
| 3 | **pop that unrelated route** | `feedActive=true page=false sheet=false obscured=false` |

The token holder never released. Device log shows exactly one `BottomSheet opened` and one
`BottomSheet closed`, with no dismiss callback between them — the close came from
`clearOverlays()`. The route in step 2 was a plain `Navigator.push`, not `pushWithVideoPause`,
so it held no token of its own; that isolates the cause.

**Fix:** narrow the recovery to `clearPageOpen()`. The #6239 stranding this path exists for is
specific to a *page* token whose route `go()` removed — go_router completes an
`ImperativeRouteMatch` only on the pop path, so `pushWithVideoPause`'s completer never fires.
A sheet token is released by its own route's dismiss callback and cannot strand that way, so
clearing it here could only ever destroy a live hold. The #6239 guarantee is unchanged: page
owners are still force-cleared.

Sheet owners keep their ultimate recovery either way — the fresh-shell-mount path
(`app_shell.dart:125`, guarded by `ModalRoute.isCurrent`) still calls `clearOverlays()`, so a
token that somehow stranded is cleared the next time a shell mounts as the top route. What this
removes is only the over-eager clear on every pop.

**Reachability — this is live in production.** There are two branch-navigator token holders,
and only one of them is flagged:

- `community_suggest_sheet.dart:36` passes `useRootNavigator: false` explicitly, behind the
  internal, default-off `communityContentWarnings` flag (feed action column,
  `video_feed_item.dart:780` → `help_classify_action_button.dart:56`).
- **`feed_mode_switch.dart:93` — the For You / Following / New / Classics picker on the home
  feed — is not flagged, and reaches the branch navigator by default rather than by choice.**
  `showVideoPausingSelectionMenu` is the one pause-aware wrapper that does not forward
  `useRootNavigator`; it calls `VineBottomSheetSelectionMenu.show`, which does not forward it
  either, so it lands on `VineBottomSheet.show`'s own default of `false`. Both siblings
  (`showVideoPausingVineBottomSheet`, `showVideoPausingDialog`) default to `true` and forward.

That second holder is what makes the bug ordinary rather than theoretical. Because the sheet
stops above the tab bar, the camera button and every tab stay tappable underneath it, and
`pushToCameraWithPermission` is a root `pushWithVideoPause` — so *open the feed-mode picker,
tap camera, come back* is a plain tap sequence that lands on this, with no flag and no
edge case.

The defect is in `AppShell`, not in either sheet, so it is fixed there. The
`showVideoPausingSelectionMenu` inconsistency is left alone deliberately: making it forward
`useRootNavigator: true` like its siblings would move the picker over the tab bar, which is a
visible presentation change and a separate call.

`app_shell_obscured_test.dart`'s #6239 test asserted the sheet owner *was* cleared. That
assertion encoded the over-broad behaviour; it now asserts the sheet owner survives while the
page owner is still cleared.

**Re-verified on the same physical iPhone after the fix**, identical steps. Step 3 now holds
(`feedActive=false page=false sheet=true`) instead of flipping. Negative control in the same
session: a *page* token taken and put through the same push/pop **is** still cleared, so the
#6239 recovery is intact. One device log timeline covers both:

```
[00:27:16.295] [UI] BottomSheet opened      <- sheet token taken
[00:27:16.494] [UI] Page push tracked       <- unrelated root route pushed
[00:27:27.527] [UI] Page pop tracked        <- popped
                                            <- no "BottomSheet closed": the hold survives
[00:27:58.944] [UI] BottomSheet closed      <- released by hand, 31s later
[00:27:58.945] [UI] Page opened             <- page token taken (models a go()-stranded hold)
[00:27:59.134] [UI] Page push tracked       <- unrelated root route pushed
[00:28:00.345] [UI] Page pop tracked        <- popped
[00:28:00.363] [UI] Page closed             <- #6239 recovery still fires, 18ms later
```

### 2. Inert `RouteAware` subscription on the reel

`_FullscreenFeedContentState` mixed in `RouteAware`, subscribed to `routeObserver`
(*"Subscribe to route changes to pause/resume when navigating away"*) and unsubscribed in
`dispose` — while overriding none of `didPush` / `didPushNext` / `didPop` / `didPopNext`. Every
callback fell through to the mixin's empty default, so it reads as a playback safety net that
does not exist. Removing it leaves the `app_router.dart` import unused, which confirms
`routeObserver` was its only use in the file. `WidgetsBindingObserver` is kept — that one is live.

### 3. Bottom-sheet owner coverage

The page half had the two tests that pin owner-token semantics against a naive reference count
— unknown-owner release, and duplicate-open idempotency. The bottom-sheet half had neither,
despite `pause_aware_modals.dart` releasing sheet tokens through async
`whenComplete`/`onDismiss` callbacks that can fire unmatched or twice. Both are mirrored here.
The two `clear` tests each held a single owner per set and so could not distinguish `clear()`
from `remove()`; they now hold two. And because `clearPageOpen()` is now load-bearing, a test
pins that a page clear leaves sheet owners holding.

## On #7540

**#7540's ask is already implemented on `main`, and implementing it as literally written would
be a regression.** #7540 and its older duplicate #6898 are now closed as completed by
#7500/#7503; this PR only references #7540 because it fixes a separate adjacent bug.

- `overlay_visibility_provider.dart:49-62` holds `Set<Object> _pageOpenOwners` /
  `_bottomSheetOwners` with `isPageOpen` derived from set occupancy. Every `lib/` call site
  mints a per-invocation token; the legacy unowned setter was deleted, not deprecated. Landed
  in #7500 (merged 2026-08-15T07:19Z, closing #7489) and #7503 (07:53Z) — **11h16m before
  #7540 was filed at 18:35Z the same day.**
- #7540 states the limitation was *"never filed as a tracked issue."* It was: **#6898**, same
  author, seven days earlier. PR #6889's body names it explicitly; both issues are now closed
  as completed by #7500/#7503.
- AC1 asks for *"a reference count instead of a boolean."* Swapping `_bottomSheetOwners` for an
  `int` counter fails exactly two tests in this PR and nothing else:
  `releasing an unknown owner preserves active bottom sheets` (an unmatched release decrements
  a count it never incremented) and `duplicate open for the same bottom sheet owner is
  idempotent` (two opens count 2, one release leaves 1). The owner Set is strictly stronger
  than the counter requested.

## Out of Scope

- `feed_videos.dart`'s `RouteAware` net never fires for the home feed (its `ModalRoute` is the
  branch page route, and branch navigators register no observers). It **is** live under
  `PooledFullscreenVideoFeedScreen`, and the home feed still has `AppShell` →
  `shellObscuredProvider`, so this is an inconsistency rather than a bug. Left alone.
- The design-system dialog ratchet does not count `VineBottomSheet.show`,
  `OverlayEntry`/`OverlayPortal`, or inspect `useRootNavigator:` — the property the video-pause
  contract actually depends on. A guard for that is worth its own issue.

## Verification

- Bug reproduced on a physical iPhone (iOS 26.6.1) against `main`; fix re-verified on device.
- Re-reproduced end-to-end on the iOS 26.5 Simulator against the full local Docker stack
  (relay, funnelcake, keycast, blossom, MinIO), driving the **real** production path — the
  `feed_mode_switch` picker via `showVideoPausingSelectionMenu`, not a synthetic token — and
  reading `_VideoFeedViewState._isNewFeedActive` live off the running app:

  | step | un-fixed (`clearOverlays`) | fixed (`clearPageOpen`) |
  |---|---|---|
  | baseline | `feedActive=true sheet=false` | `feedActive=true sheet=false` |
  | feed-mode picker opened | `feedActive=false sheet=true` | `feedActive=false sheet=true` |
  | unrelated root route pushed | `feedActive=false sheet=true obscured=true` | `feedActive=false sheet=true obscured=true` |
  | that route popped | `feedActive=true sheet=false` ← hold destroyed | `feedActive=false sheet=true` ← hold survives |

  On the un-fixed build the device log shows the phantom close and playback restarting behind
  the still-visible picker, with no dismiss callback between the open and the close:

  ```
  [06:40:48.747] [UI] BottomSheet opened          <- picker opened, token taken
  [06:40:51.631] [UI] Page push tracked           <- unrelated root route pushed
  [06:40:54.159] [UI] Page pop tracked            <- popped
  [06:40:54.174] [UI] BottomSheet closed          <- 15ms later, no dismiss: clearOverlays()
  [06:40:54.180] [VIDEO] Init player index 0 — from network
  [06:40:54.203] [VIDEO] Player 90249 (feed[0]) created
  ```

  The fixed build logs no `BottomSheet closed` and no player init for the same steps, and a
  screenshot at that point shows the picker still on screen with the feed still scrimmed.
- Negative control on the fixed build, same session: a stranded *page* token put through the
  same push/pop **is** still cleared, so the #6239 recovery is intact.
- Checked for sheet-token stranding on device with the fix in place: a branch sheet held its
  token correctly across a tab round-trip and 75s of polling, with the sheet subtree still
  mounted throughout.
- Regression test proven to fail without the fix and pass with it.
- Mutation-checked the new provider tests against an integer refcount: exactly the two intended
  tests fail, nothing else.
- `flutter analyze lib test integration_test` — no issues.
- `flutter test test/router/ test/providers/overlay_visibility_provider_test.dart test/utils/pause_aware_modals_test.dart test/screens/video_recorder_screen_test.dart` — 635 passed.
- `flutter test test/screens/feed/ test/widgets/video_feed_item/` — 601 passed.
- Ratchets run locally, all OK: `raw_dialog_ceiling`, `ungrouped_tests`, `skip_ceiling`,
  `placeholder_tests`, `l10n_delegates_ceiling`, `test_unit_structure`, `layer_direction`,
  `post_close_emit_ceiling`, `untested_services_floor`, `orphaned_arb_key_floor`,
  `nostr_id_log_truncation`, `pubkey_log_encoding`, `service_god_file_ceiling`.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] 🧹 Code refactor

