### PR TITLE
fix(support): make missing local content diagnosable

### DIFF
--- a/mobile/lib/providers/bug_report_providers.dart
+++ b/mobile/lib/providers/bug_report_providers.dart
@@ -3,8 +3,14 @@
 // ABOUTME: without creating an import cycle with storage_providers.
 
 import 'package:openvine/providers/analytics_providers.dart';
+import 'package:openvine/providers/database_provider.dart';
+import 'package:openvine/providers/documents_path_provider.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
+import 'package:openvine/providers/social_providers.dart';
 import 'package:openvine/providers/storage_providers.dart';
 import 'package:openvine/services/bug_report_service.dart';
+import 'package:openvine/services/database_recovery_store.dart';
+import 'package:openvine/services/local_content_diagnostics_service.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'bug_report_providers.g.dart';
@@ -12,8 +18,24 @@ part 'bug_report_providers.g.dart';
 /// Bug report service for collecting diagnostics and exporting logs.
 @riverpod
 BugReportService bugReportService(Ref ref) {
+  final database = ref.watch(databaseProvider);
+  final preferences = ref.watch(sharedPreferencesProvider);
+  final clipLibrary = ref.watch(clipLibraryServiceProvider);
   return BugReportService(
     errorTracker: ref.watch(errorAnalyticsTrackerProvider),
     storageManagementService: ref.watch(storageManagementServiceProvider),
+    supportDiagnosticsLoader: () async {
+      final recovery = DatabaseRecoveryStore(preferences: preferences).read();
+      final localContent = await LocalContentDiagnosticsService(
+        clipsDao: database.clipsDao,
+        draftsDao: database.draftsDao,
+        ownerPubkey: clipLibrary.ownerPubkey,
+        documentsPath: ref.read(documentsPathProvider),
+      ).collect();
+      return {
+        if (recovery != null) 'databaseRecovery': recovery.toDiagnostics(),
+        'contentInventory': localContent,
+      };
+    },
   );
 }

--- a/mobile/lib/providers/bug_report_providers.dart
+++ b/mobile/lib/providers/bug_report_providers.dart
@@ -21,6 +21,7 @@ BugReportService bugReportService(Ref ref) {
   final database = ref.watch(databaseProvider);
   final preferences = ref.watch(sharedPreferencesProvider);
   final clipLibrary = ref.watch(clipLibraryServiceProvider);
+  final documentsPath = ref.watch(documentsPathProvider);
   return BugReportService(
     errorTracker: ref.watch(errorAnalyticsTrackerProvider),
     storageManagementService: ref.watch(storageManagementServiceProvider),
@@ -30,7 +31,7 @@ BugReportService bugReportService(Ref ref) {
         clipsDao: database.clipsDao,
         draftsDao: database.draftsDao,
         ownerPubkey: clipLibrary.ownerPubkey,
-        documentsPath: ref.read(documentsPathProvider),
+        documentsPath: documentsPath,
       ).collect();
       return {
         if (recovery != null) 'databaseRecovery': recovery.toDiagnostics(),

--- a/mobile/lib/providers/bug_report_providers.g.dart
+++ b/mobile/lib/providers/bug_report_providers.g.dart
@@ -57,4 +57,4 @@ final class BugReportServiceProvider
   }
 }
 
-String _$bugReportServiceHash() => r'5470af6a84c2b76d1229610de95fcb272c045ab9';
+String _$bugReportServiceHash() => r'c8aee9fa1fdfbe303269b35c76dfadfaacb12d6b';

--- a/mobile/lib/providers/bug_report_providers.g.dart
+++ b/mobile/lib/providers/bug_report_providers.g.dart
@@ -57,4 +57,4 @@ final class BugReportServiceProvider
   }
 }
 
-String _$bugReportServiceHash() => r'c8aee9fa1fdfbe303269b35c76dfadfaacb12d6b';
+String _$bugReportServiceHash() => r'a9c35af1e20f19977fc9facd11c9338d48af4ac6';

--- a/mobile/lib/services/bug_report_service.dart
+++ b/mobile/lib/services/bug_report_service.dart
@@ -32,8 +32,10 @@ class BugReportService {
     ErrorAnalyticsTracker? errorTracker,
     StorageManagementService? storageManagementService,
     Future<PackageInfo> Function()? packageInfoLoader,
+    Future<Map<String, dynamic>> Function()? supportDiagnosticsLoader,
   }) : _errorTracker = errorTracker ?? ErrorAnalyticsTracker(),
        _storageManagementService = storageManagementService,
+       _supportDiagnosticsLoader = supportDiagnosticsLoader,
        _packageInfoLoader = packageInfoLoader ?? PackageInfo.fromPlatform;
 
   static const _uuid = Uuid();
@@ -41,6 +43,7 @@ class BugReportService {
   final ErrorAnalyticsTracker _errorTracker;
   final StorageManagementService? _storageManagementService;
   final Future<PackageInfo> Function() _packageInfoLoader;
+  final Future<Map<String, dynamic>> Function()? _supportDiagnosticsLoader;
 
   /// Collect comprehensive diagnostics for bug report
   Future<BugReportData> collectDiagnostics({
@@ -136,6 +139,20 @@ class BugReportService {
 
       // Get error counts from the injected ErrorAnalyticsTracker
       final errorCounts = _errorTracker.getAllErrorCounts();
+
+      Map<String, dynamic>? supportDiagnostics;
+      try {
+        supportDiagnostics = await _supportDiagnosticsLoader?.call();
+      } on Object catch (error) {
+        Log.warning(
+          'Failed to collect local support diagnostics: $error',
+          category: LogCategory.system,
+        );
+      }
+
+      if (supportDiagnostics != null && supportDiagnostics.isNotEmpty) {
+        deviceInfo = {...deviceInfo, 'localStorage': supportDiagnostics};
+      }
 
       // Create bug report data
       final reportData = BugReportData(

--- a/mobile/lib/services/database_encryption_bootstrap.dart
+++ b/mobile/lib/services/database_encryption_bootstrap.dart
@@ -7,6 +7,7 @@ import 'package:db_client/db_client.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:openvine/database/sqlcipher_runtime.dart';
+import 'package:openvine/services/database_recovery_store.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 /// Secure-storage key for the at-rest DB cipher key. Versioned so a future
@@ -34,10 +35,13 @@ class DatabaseEncryptionBootstrap {
     Future<bool> Function(String rawKeyHex)? salvageDatabase,
     Future<bool> Function(String rawKeyHex)? encryptedKeyMatches,
     Future<void> Function(Object error, StackTrace stack)? recordRecovery,
+    Future<void> Function(DatabaseRecoveryOutcome outcome)?
+    persistRecoveryOutcome,
     Future<bool> Function()? hasPendingCorruptionRecovery,
     Future<void> Function()? clearPendingCorruptionRecovery,
   }) : _secureStorage = secureStorage,
        _recordRecovery = recordRecovery,
+       _persistRecoveryOutcome = persistRecoveryOutcome,
        _hasPendingCorruptionRecovery =
            hasPendingCorruptionRecovery ?? (() async => false),
        _clearPendingCorruptionRecovery =
@@ -98,6 +102,11 @@ class DatabaseEncryptionBootstrap {
   /// so it never reaches the startup error reporter. Best-effort; `null` in
   /// tests that don't assert on it.
   final Future<void> Function(Object error, StackTrace stack)? _recordRecovery;
+
+  /// Persists the completed outcome so a later support report can identify it
+  /// after startup logs have rolled out of the in-memory window.
+  final Future<void> Function(DatabaseRecoveryOutcome outcome)?
+  _persistRecoveryOutcome;
 
   /// Invoked after the key-loss recreate wipes the Drift DB, so callers can
   /// clear local state that lives OUTSIDE the database (e.g. the DM sync
@@ -196,6 +205,7 @@ class DatabaseEncryptionBootstrap {
             name: _logName,
           );
           await _reportRecovery('salvaged local-only data into a fresh DB');
+          await _persistOutcome(DatabaseRecoveryOutcome.salvaged);
           await _runPostDatabaseReset(_onDatabaseReset);
           return (key, true);
         }
@@ -304,6 +314,11 @@ class DatabaseEncryptionBootstrap {
     );
     await _deleteDatabase();
     await _reportRecovery('backed up + recreated ($reason)');
+    await _persistOutcome(switch (reason) {
+      'missing' => DatabaseRecoveryOutcome.recreatedMissingKey,
+      'key loss' => DatabaseRecoveryOutcome.recreatedKeyLoss,
+      _ => DatabaseRecoveryOutcome.recreatedCorrupt,
+    });
     await _runPostDatabaseReset(_onDatabaseReset);
     return key;
   }
@@ -318,6 +333,17 @@ class DatabaseEncryptionBootstrap {
       );
     } on Object catch (e) {
       Log.warning('Recovery reporting failed (non-fatal): $e', name: _logName);
+    }
+  }
+
+  Future<void> _persistOutcome(DatabaseRecoveryOutcome outcome) async {
+    try {
+      await _persistRecoveryOutcome?.call(outcome);
+    } on Object catch (error) {
+      Log.warning(
+        'Recovery outcome persistence failed (non-fatal): $error',
+        name: _logName,
+      );
     }
   }
 }
@@ -482,10 +508,23 @@ Future<void> resetEncryptedDatabaseCache({
   bool deleteCipherKey = true,
   Future<void> Function()? deleteDatabase,
   Future<void> Function()? onDatabaseReset,
+  DatabaseRecoveryOutcome? recoveryOutcome,
+  Future<void> Function(DatabaseRecoveryOutcome outcome)?
+  persistRecoveryOutcome,
 }) async {
   await (deleteDatabase ?? backUpAndRemoveSharedDatabase)();
   if (deleteCipherKey) {
     await secureStorage.delete(key: dbCipherKeyStorageKey);
+  }
+  if (recoveryOutcome != null) {
+    try {
+      await persistRecoveryOutcome?.call(recoveryOutcome);
+    } on Object catch (error) {
+      Log.warning(
+        'Manual recovery outcome persistence failed (non-fatal): $error',
+        name: DatabaseEncryptionBootstrap._logName,
+      );
+    }
   }
   await _runPostDatabaseReset(onDatabaseReset);
 }
@@ -500,11 +539,15 @@ Future<void> resetUnreadablePlaintextDatabaseCache({
   required FlutterSecureStorage secureStorage,
   @visibleForTesting Future<void> Function()? deleteDatabase,
   Future<void> Function()? onDatabaseReset,
+  Future<void> Function(DatabaseRecoveryOutcome outcome)?
+  persistRecoveryOutcome,
 }) => resetEncryptedDatabaseCache(
   secureStorage: secureStorage,
   deleteCipherKey: false,
   deleteDatabase: deleteDatabase ?? deleteSharedDatabase,
   onDatabaseReset: onDatabaseReset,
+  recoveryOutcome: DatabaseRecoveryOutcome.recreatedUnreadable,
+  persistRecoveryOutcome: persistRecoveryOutcome,
 );
 
 Future<void> _runPostDatabaseReset(

--- a/mobile/lib/services/database_recovery_store.dart
+++ b/mobile/lib/services/database_recovery_store.dart
@@ -1,0 +1,79 @@
+// ABOUTME: Persists the last local-database recovery outcome for support diagnostics.
+// ABOUTME: Stores only an outcome and timestamp, never database contents or key material.
+
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:unified_logger/unified_logger.dart';
+
+/// A completed operation that replaced or rebuilt the local database.
+enum DatabaseRecoveryOutcome {
+  salvaged,
+  recreatedMissingKey,
+  recreatedKeyLoss,
+  recreatedCorrupt,
+  recreatedAfterBootstrapFailure,
+  recreatedUnreadable,
+}
+
+/// Durable, aggregate-only evidence that database recovery ran on this install.
+class DatabaseRecoveryRecord {
+  const DatabaseRecoveryRecord({
+    required this.outcome,
+    required this.occurredAt,
+  });
+
+  final DatabaseRecoveryOutcome outcome;
+  final DateTime occurredAt;
+
+  Map<String, dynamic> toDiagnostics() => {
+    'outcome': outcome.name,
+    'occurredAt': occurredAt.toUtc().toIso8601String(),
+  };
+}
+
+/// SharedPreferences-backed storage for the latest database recovery record.
+class DatabaseRecoveryStore {
+  DatabaseRecoveryStore({
+    required SharedPreferences preferences,
+    DateTime Function()? now,
+  }) : _preferences = preferences,
+       _now = now ?? DateTime.now;
+
+  static const _key = 'db.recovery.latest.v1';
+  static const _logName = 'DatabaseRecoveryStore';
+
+  final SharedPreferences _preferences;
+  final DateTime Function() _now;
+
+  Future<void> record(DatabaseRecoveryOutcome outcome) async {
+    final value = jsonEncode({
+      'outcome': outcome.name,
+      'occurredAt': _now().toUtc().toIso8601String(),
+    });
+    final stored = await _preferences.setString(_key, value);
+    if (!stored) {
+      throw StateError('SharedPreferences rejected the recovery record');
+    }
+  }
+
+  DatabaseRecoveryRecord? read() {
+    final raw = _preferences.getString(_key);
+    if (raw == null || raw.isEmpty) return null;
+
+    try {
+      final json = jsonDecode(raw) as Map<String, dynamic>;
+      final outcomeName = json['outcome'] as String;
+      final occurredAt = DateTime.parse(json['occurredAt'] as String);
+      final outcome = DatabaseRecoveryOutcome.values.byName(outcomeName);
+      return DatabaseRecoveryRecord(outcome: outcome, occurredAt: occurredAt);
+    } on Object catch (error) {
+      Log.warning(
+        'Ignoring an unreadable database recovery record: $error',
+        name: _logName,
+        category: LogCategory.system,
+      );
+      return null;
+    }
+  }
+}

--- a/mobile/lib/services/local_content_diagnostics_service.dart
+++ b/mobile/lib/services/local_content_diagnostics_service.dart
@@ -4,6 +4,7 @@
 import 'dart:io';
 
 import 'package:db_client/db_client.dart';
+import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/services/draft_storage_service.dart';
 import 'package:openvine/utils/path_resolver.dart';
 
@@ -34,7 +35,13 @@ class LocalContentDiagnosticsService {
     final clips = await _clipsDao.getAllClips(includeTrashed: true);
     final drafts = await _draftsDao.getAllDrafts();
 
-    final visibleClips = clips.where((row) => _isVisible(row.ownerPubkey));
+    final visibleClips = clips.where(
+      (row) =>
+          row.deletedAt == null &&
+          _isVisible(row.ownerPubkey) &&
+          (row.draftId == null ||
+              row.draftId == VideoEditorConstants.autoSaveId),
+    );
     final visibleDrafts = drafts.where((row) => _isVisible(row.ownerPubkey));
     final anonymousClips = clips.where(
       (row) => row.ownerPubkey == DraftStorageService.anonymousOwnerPubkey,
@@ -47,10 +54,14 @@ class LocalContentDiagnosticsService {
 
     final draftIdsWithClips = {
       for (final clip in clips)
-        if (clip.draftId != null && clip.deletedAt == null) clip.draftId!,
+        if (clip.draftId != null &&
+            clip.deletedAt == null &&
+            _isVisible(clip.ownerPubkey))
+          clip.draftId!,
     };
     final sourceFiles = <String>{};
     for (final clip in clips) {
+      if (clip.deletedAt != null || !_isVisible(clip.ownerPubkey)) continue;
       final rawPath = clip.filePath;
       if (rawPath == null || rawPath.isEmpty) continue;
       final path = resolvePath(rawPath, _documentsPath);
@@ -66,7 +77,7 @@ class LocalContentDiagnosticsService {
       'anonymousClipRows': anonymousClips.length,
       'foreignDraftRows': foreignDrafts.length,
       'foreignClipRows': foreignClips.length,
-      'zeroClipDraftRows': drafts
+      'zeroClipDraftRows': visibleDrafts
           .where((draft) => !draftIdsWithClips.contains(draft.id))
           .length,
       'missingSourceMediaFiles': missingSourceFileCount,

--- a/mobile/lib/services/local_content_diagnostics_service.dart
+++ b/mobile/lib/services/local_content_diagnostics_service.dart
@@ -1,0 +1,84 @@
+// ABOUTME: Builds aggregate-only diagnostics for locally stored drafts and clips.
+// ABOUTME: Reads database rows and media existence without changing either one.
+
+import 'dart:io';
+
+import 'package:db_client/db_client.dart';
+import 'package:openvine/services/draft_storage_service.dart';
+import 'package:openvine/utils/path_resolver.dart';
+
+/// Collects a safe inventory that explains why a local library appears empty.
+class LocalContentDiagnosticsService {
+  const LocalContentDiagnosticsService({
+    required ClipsDao clipsDao,
+    required DraftsDao draftsDao,
+    required String? ownerPubkey,
+    required String documentsPath,
+    Future<bool> Function(String path)? fileExists,
+  }) : _clipsDao = clipsDao,
+       _draftsDao = draftsDao,
+       _ownerPubkey = ownerPubkey,
+       _documentsPath = documentsPath,
+       _fileExists = fileExists ?? _defaultFileExists;
+
+  final ClipsDao _clipsDao;
+  final DraftsDao _draftsDao;
+  final String? _ownerPubkey;
+  final String _documentsPath;
+  final Future<bool> Function(String path) _fileExists;
+
+  static Future<bool> _defaultFileExists(String path) =>
+      Future.value(File(path).existsSync());
+
+  Future<Map<String, dynamic>> collect() async {
+    final clips = await _clipsDao.getAllClips(includeTrashed: true);
+    final drafts = await _draftsDao.getAllDrafts();
+
+    final visibleClips = clips.where((row) => _isVisible(row.ownerPubkey));
+    final visibleDrafts = drafts.where((row) => _isVisible(row.ownerPubkey));
+    final anonymousClips = clips.where(
+      (row) => row.ownerPubkey == DraftStorageService.anonymousOwnerPubkey,
+    );
+    final anonymousDrafts = drafts.where(
+      (row) => row.ownerPubkey == DraftStorageService.anonymousOwnerPubkey,
+    );
+    final foreignClips = clips.where((row) => _isForeign(row.ownerPubkey));
+    final foreignDrafts = drafts.where((row) => _isForeign(row.ownerPubkey));
+
+    final draftIdsWithClips = {
+      for (final clip in clips)
+        if (clip.draftId != null && clip.deletedAt == null) clip.draftId!,
+    };
+    final sourceFiles = <String>{};
+    for (final clip in clips) {
+      final rawPath = clip.filePath;
+      if (rawPath == null || rawPath.isEmpty) continue;
+      final path = resolvePath(rawPath, _documentsPath);
+      if (path != null) sourceFiles.add(path);
+    }
+    final existence = await Future.wait(sourceFiles.map(_fileExists));
+    final missingSourceFileCount = existence.where((exists) => !exists).length;
+
+    return {
+      'visibleDraftRows': visibleDrafts.length,
+      'visibleClipRows': visibleClips.length,
+      'anonymousDraftRows': anonymousDrafts.length,
+      'anonymousClipRows': anonymousClips.length,
+      'foreignDraftRows': foreignDrafts.length,
+      'foreignClipRows': foreignClips.length,
+      'zeroClipDraftRows': drafts
+          .where((draft) => !draftIdsWithClips.contains(draft.id))
+          .length,
+      'missingSourceMediaFiles': missingSourceFileCount,
+    };
+  }
+
+  bool _isVisible(String? rowOwner) =>
+      _ownerPubkey == null || rowOwner == null || rowOwner == _ownerPubkey;
+
+  bool _isForeign(String? rowOwner) =>
+      _ownerPubkey != null &&
+      rowOwner != null &&
+      rowOwner != _ownerPubkey &&
+      rowOwner != DraftStorageService.anonymousOwnerPubkey;
+}

--- a/mobile/lib/startup/app_bootstrap.dart
+++ b/mobile/lib/startup/app_bootstrap.dart
@@ -37,6 +37,7 @@ import 'package:openvine/services/c2pa_signing_service.dart';
 import 'package:openvine/services/crash_reporting_service.dart';
 import 'package:openvine/services/database_corruption_service.dart';
 import 'package:openvine/services/database_encryption_bootstrap.dart';
+import 'package:openvine/services/database_recovery_store.dart';
 import 'package:openvine/services/install_source_service.dart';
 import 'package:openvine/services/locale_preference_service.dart';
 import 'package:openvine/services/pro_video_editor_log_forwarder.dart';
@@ -470,6 +471,9 @@ Future<void> startOpenVineApp({
       reason: 'Runtime database corruption',
     ),
   );
+  final databaseRecoveryStore = DatabaseRecoveryStore(
+    preferences: sharedPreferences,
+  );
 
   // Resets preserve a backup by default because encrypted backups stay readable
   // under the retained cipher key. The db-unreadable diagnosis is different:
@@ -484,6 +488,8 @@ Future<void> startOpenVineApp({
         // instead of skipping it as "already complete" (which had left
         // recovered chats stranded under "Message requests"). See #5304.
         onDatabaseReset: () => DmSyncState(sharedPreferences).clearAll(),
+        recoveryOutcome: DatabaseRecoveryOutcome.recreatedAfterBootstrapFailure,
+        persistRecoveryOutcome: databaseRecoveryStore.record,
       );
 
   // The fail-closed screen below renders before the app's own MaterialApp
@@ -512,6 +518,7 @@ Future<void> startOpenVineApp({
         // recover-every-launch loop in Crashlytics.
         recordRecovery: (error, stack) => CrashReportingService.instance
             .recordError(error, stack, reason: 'DB startup recovery'),
+        persistRecoveryOutcome: databaseRecoveryStore.record,
         // A previous session's runtime corruption report forces the salvage.
         // The probe below is reactive and already missed this corruption once,
         // so re-running it would just clear the DB for another broken session.
@@ -545,6 +552,7 @@ Future<void> startOpenVineApp({
           await resetUnreadablePlaintextDatabaseCache(
             secureStorage: dbCipherSecureStorage,
             onDatabaseReset: () => DmSyncState(sharedPreferences).clearAll(),
+            persistRecoveryOutcome: databaseRecoveryStore.record,
           );
         } else {
           await resetLocalDatabaseCache(deleteCipherKey: false);

--- a/mobile/test/providers/bug_report_providers_test.dart
+++ b/mobile/test/providers/bug_report_providers_test.dart
@@ -1,0 +1,102 @@
+// ABOUTME: Tests deferred diagnostics created by the bug report provider.
+// ABOUTME: Covers collection after the auto-disposed provider is released.
+
+import 'package:analytics/analytics.dart';
+import 'package:db_client/db_client.dart';
+import 'package:drift/native.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/providers/analytics_providers.dart';
+import 'package:openvine/providers/bug_report_providers.dart';
+import 'package:openvine/providers/database_provider.dart';
+import 'package:openvine/providers/documents_path_provider.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
+import 'package:openvine/providers/social_providers.dart';
+import 'package:openvine/providers/storage_providers.dart';
+import 'package:openvine/services/clip_library_service.dart';
+import 'package:openvine/services/storage_management_service.dart';
+import 'package:riverpod/riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockStorageManagementService extends Mock
+    implements StorageManagementService {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('bugReportServiceProvider', () {
+    late AppDatabase database;
+    late ProviderContainer container;
+
+    setUp(() async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+            const MethodChannel('dev.fluttercommunity.plus/package_info'),
+            (call) async => call.method == 'getAll'
+                ? <String, dynamic>{
+                    'appName': 'Divine',
+                    'packageName': 'video.divine',
+                    'version': '1.0.0',
+                    'buildNumber': '1',
+                  }
+                : null,
+          );
+      SharedPreferences.setMockInitialValues({});
+      final preferences = await SharedPreferences.getInstance();
+      database = AppDatabase.test(NativeDatabase.memory());
+      final clipLibrary = ClipLibraryService(
+        clipsDao: database.clipsDao,
+        draftsDao: database.draftsDao,
+        clipCategoriesDao: database.clipCategoriesDao,
+        ownerPubkey: 'owner',
+      );
+      container = ProviderContainer(
+        overrides: [
+          databaseProvider.overrideWithValue(database),
+          sharedPreferencesProvider.overrideWithValue(preferences),
+          clipLibraryServiceProvider.overrideWithValue(clipLibrary),
+          documentsPathProvider.overrideWithValue('/documents'),
+          errorAnalyticsTrackerProvider.overrideWithValue(
+            ErrorAnalyticsTracker(sink: const NoOpAnalyticsEventSink()),
+          ),
+          storageManagementServiceProvider.overrideWithValue(
+            _MockStorageManagementService(),
+          ),
+        ],
+      );
+    });
+
+    tearDown(() async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+            const MethodChannel('dev.fluttercommunity.plus/package_info'),
+            null,
+          );
+      container.dispose();
+      await database.close();
+    });
+
+    test('collects diagnostics after a read-only provider access', () async {
+      final service = container.read(bugReportServiceProvider);
+      await Future<void>.delayed(Duration.zero);
+
+      final report = await service.collectDiagnostics(
+        userDescription: 'Drafts disappeared',
+      );
+
+      expect(report.deviceInfo['localStorage'], {
+        'contentInventory': {
+          'visibleDraftRows': 0,
+          'visibleClipRows': 0,
+          'anonymousDraftRows': 0,
+          'anonymousClipRows': 0,
+          'foreignDraftRows': 0,
+          'foreignClipRows': 0,
+          'zeroClipDraftRows': 0,
+          'missingSourceMediaFiles': 0,
+        },
+      });
+    });
+  });
+}

--- a/mobile/test/services/bug_report_service_test.dart
+++ b/mobile/test/services/bug_report_service_test.dart
@@ -102,6 +102,43 @@ void main() {
       expect(data.errorCounts, {'NewVideosTab:feed_load_failed': 1});
     });
 
+    test('includes durable local support diagnostics in the report', () async {
+      final service = BugReportService(
+        supportDiagnosticsLoader: () async => {
+          'databaseRecovery': {
+            'outcome': 'recreatedKeyLoss',
+            'occurredAt': '2026-08-29T17:34:56.000Z',
+          },
+          'contentInventory': {'visibleDraftRows': 0, 'foreignDraftRows': 4},
+        },
+      );
+
+      final data = await service.collectDiagnostics(
+        userDescription: 'My drafts are missing',
+      );
+
+      expect(data.deviceInfo['localStorage'], {
+        'databaseRecovery': {
+          'outcome': 'recreatedKeyLoss',
+          'occurredAt': '2026-08-29T17:34:56.000Z',
+        },
+        'contentInventory': {'visibleDraftRows': 0, 'foreignDraftRows': 4},
+      });
+    });
+
+    test('diagnostic collection failure does not block a report', () async {
+      final service = BugReportService(
+        supportDiagnosticsLoader: () async => throw StateError('db busy'),
+      );
+
+      final data = await service.collectDiagnostics(
+        userDescription: 'My drafts are missing',
+      );
+
+      expect(data.userDescription, 'My drafts are missing');
+      expect(data.additionalContext, isNull);
+    });
+
     test('collectDiagnostics returns sanitized description', () async {
       final data = await service.collectDiagnostics(
         userDescription: 'My key is $_rawNsec and email liz@example.com',

--- a/mobile/test/services/database_encryption_bootstrap_test.dart
+++ b/mobile/test/services/database_encryption_bootstrap_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/services/database_encryption_bootstrap.dart';
+import 'package:openvine/services/database_recovery_store.dart';
 
 class _MockSecureStorage extends Mock implements FlutterSecureStorage {}
 
@@ -54,6 +55,7 @@ void main() {
       bool Function(String rawKeyHex)? salvageDatabase,
       bool Function(String rawKeyHex)? encryptedKeyMatches,
       void Function(Object error)? onRecordRecovery,
+      void Function(DatabaseRecoveryOutcome outcome)? onPersistRecovery,
       bool hasPendingCorruptionRecovery = false,
       void Function()? onClearPendingCorruptionRecovery,
     }) {
@@ -82,6 +84,9 @@ void main() {
         recordRecovery: onRecordRecovery == null
             ? null
             : (error, _) async => onRecordRecovery(error),
+        persistRecoveryOutcome: onPersistRecovery == null
+            ? null
+            : (outcome) async => onPersistRecovery(outcome),
       );
     }
 
@@ -417,6 +422,83 @@ void main() {
         expect(store[dbCipherKeyStorageKey], equals(key));
         expect(deleted, isTrue);
         expect(reset, isTrue);
+      },
+    );
+
+    test('persists each completed automatic recovery outcome', () async {
+      const existing =
+          '2dd29ca851e7b56e4697b0e1f08507293d761a05ce4d1b628663f411a8086d99';
+
+      Future<DatabaseRecoveryOutcome> run({
+        required bool keyExists,
+        required bool salvageSucceeds,
+        required bool keyMatches,
+      }) async {
+        store.clear();
+        if (keyExists) store[dbCipherKeyStorageKey] = existing;
+        final outcomes = <DatabaseRecoveryOutcome>[];
+        await buildBootstrap(
+          outcome: CipherMigrationOutcome.alreadyEncrypted,
+          onDelete: () {},
+          canOpenEncryptedDatabase: (_) => false,
+          salvageDatabase: (_) => salvageSucceeds,
+          encryptedKeyMatches: (_) => keyMatches,
+          onPersistRecovery: outcomes.add,
+        ).resolveCipherKey();
+        return outcomes.single;
+      }
+
+      expect(
+        await run(
+          keyExists: false,
+          salvageSucceeds: false,
+          keyMatches: false,
+        ),
+        DatabaseRecoveryOutcome.recreatedMissingKey,
+      );
+      expect(
+        await run(
+          keyExists: true,
+          salvageSucceeds: true,
+          keyMatches: true,
+        ),
+        DatabaseRecoveryOutcome.salvaged,
+      );
+      expect(
+        await run(
+          keyExists: true,
+          salvageSucceeds: false,
+          keyMatches: true,
+        ),
+        DatabaseRecoveryOutcome.recreatedCorrupt,
+      );
+      expect(
+        await run(
+          keyExists: true,
+          salvageSucceeds: false,
+          keyMatches: false,
+        ),
+        DatabaseRecoveryOutcome.recreatedKeyLoss,
+      );
+    });
+
+    test(
+      'a failed recovery breadcrumb never fails successful salvage',
+      () async {
+        const existing =
+            '2dd29ca851e7b56e4697b0e1f08507293d761a05ce4d1b628663f411a8086d99';
+        store[dbCipherKeyStorageKey] = existing;
+        final bootstrap = DatabaseEncryptionBootstrap(
+          secureStorage: storage,
+          ensureRuntime: () async {},
+          isCipherAvailable: () => true,
+          migrate: (_) async => CipherMigrationOutcome.alreadyEncrypted,
+          canOpenEncryptedDatabase: (_) async => false,
+          salvageDatabase: (_) async => true,
+          persistRecoveryOutcome: (_) async => throw StateError('disk full'),
+        );
+
+        expect(await bootstrap.resolveCipherKey(), existing);
       },
     );
 
@@ -767,6 +849,28 @@ void main() {
         verifyNever(() => storage.delete(key: any(named: 'key')));
       },
     );
+
+    test('records completed explicit reset outcomes', () async {
+      final outcomes = <DatabaseRecoveryOutcome>[];
+
+      await resetEncryptedDatabaseCache(
+        secureStorage: storage,
+        deleteCipherKey: false,
+        deleteDatabase: () async {},
+        recoveryOutcome: DatabaseRecoveryOutcome.recreatedAfterBootstrapFailure,
+        persistRecoveryOutcome: (outcome) async => outcomes.add(outcome),
+      );
+      await resetUnreadablePlaintextDatabaseCache(
+        secureStorage: storage,
+        deleteDatabase: () async {},
+        persistRecoveryOutcome: (outcome) async => outcomes.add(outcome),
+      );
+
+      expect(outcomes, [
+        DatabaseRecoveryOutcome.recreatedAfterBootstrapFailure,
+        DatabaseRecoveryOutcome.recreatedUnreadable,
+      ]);
+    });
   });
 
   group('resolveStartupDatabaseCipherKey', () {

--- a/mobile/test/services/database_recovery_store_test.dart
+++ b/mobile/test/services/database_recovery_store_test.dart
@@ -1,0 +1,54 @@
+// ABOUTME: Tests durable database recovery breadcrumbs used by support reports.
+// ABOUTME: Covers valid, absent, and malformed SharedPreferences records.
+
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/services/database_recovery_store.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  group(DatabaseRecoveryStore, () {
+    late SharedPreferences preferences;
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      preferences = await SharedPreferences.getInstance();
+    });
+
+    test('persists the outcome and UTC timestamp', () async {
+      final store = DatabaseRecoveryStore(
+        preferences: preferences,
+        now: () => DateTime.parse('2026-08-29T12:34:56-05:00'),
+      );
+
+      await store.record(DatabaseRecoveryOutcome.recreatedKeyLoss);
+
+      expect(store.read()?.toDiagnostics(), {
+        'outcome': 'recreatedKeyLoss',
+        'occurredAt': '2026-08-29T17:34:56.000Z',
+      });
+    });
+
+    test('returns null when recovery has never run', () {
+      final store = DatabaseRecoveryStore(preferences: preferences);
+
+      expect(store.read(), isNull);
+    });
+
+    test('ignores malformed or future records', () async {
+      await preferences.setString(
+        'db.recovery.latest.v1',
+        jsonEncode({
+          'outcome': 'futureOutcome',
+          'occurredAt': '2026-08-29T17:34:56Z',
+        }),
+      );
+
+      expect(
+        DatabaseRecoveryStore(preferences: preferences).read(),
+        isNull,
+      );
+    });
+  });
+}

--- a/mobile/test/services/local_content_diagnostics_service_test.dart
+++ b/mobile/test/services/local_content_diagnostics_service_test.dart
@@ -6,6 +6,7 @@ import 'dart:convert';
 import 'package:db_client/db_client.dart';
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/services/draft_storage_service.dart';
 import 'package:openvine/services/local_content_diagnostics_service.dart';
 
@@ -91,7 +92,7 @@ void main() {
 
       expect(diagnostics, {
         'visibleDraftRows': 3,
-        'visibleClipRows': 2,
+        'visibleClipRows': 0,
         'anonymousDraftRows': 1,
         'anonymousClipRows': 1,
         'foreignDraftRows': 1,
@@ -175,5 +176,65 @@ void main() {
         expect(diagnostics['zeroClipDraftRows'], 1);
       },
     );
+
+    test('matches active library clip visibility', () async {
+      Future<void> saveClip({
+        required String id,
+        required String? owner,
+        required String? draftId,
+      }) {
+        return database.clipsDao.upsertClip(
+          id: id,
+          orderIndex: 0,
+          durationMs: 1000,
+          recordedAt: DateTime(2026, 8, 29),
+          data: '{}',
+          filePath: '$id.mp4',
+          thumbnailPath: null,
+          draftId: draftId,
+          ownerPubkey: owner,
+        );
+      }
+
+      await saveClip(id: 'library', owner: _ownerA, draftId: null);
+      await saveClip(
+        id: 'autosave',
+        owner: _ownerA,
+        draftId: VideoEditorConstants.autoSaveId,
+      );
+      await saveClip(id: 'named-draft', owner: _ownerA, draftId: 'draft');
+      await saveClip(id: 'foreign', owner: _ownerB, draftId: null);
+      await saveClip(id: 'trashed', owner: _ownerA, draftId: null);
+      await database.clipsDao.softDeleteClip(
+        id: 'trashed',
+        deletedAt: DateTime(2026, 8, 29),
+      );
+
+      final diagnostics = await LocalContentDiagnosticsService(
+        clipsDao: database.clipsDao,
+        draftsDao: database.draftsDao,
+        ownerPubkey: _ownerA,
+        documentsPath: '/documents',
+        fileExists: (_) async => false,
+      ).collect();
+
+      expect(diagnostics['visibleClipRows'], 2);
+      expect(diagnostics['missingSourceMediaFiles'], 3);
+    });
+
+    test('counts zero-clip drafts for the visible owner only', () async {
+      await saveDraft(id: 'owned-empty', owner: _ownerA);
+      await saveDraft(id: 'foreign-empty', owner: _ownerB);
+
+      final diagnostics = await LocalContentDiagnosticsService(
+        clipsDao: database.clipsDao,
+        draftsDao: database.draftsDao,
+        ownerPubkey: _ownerA,
+        documentsPath: '/documents',
+        fileExists: (_) async => true,
+      ).collect();
+
+      expect(diagnostics['zeroClipDraftRows'], 1);
+    });
   });
 }

--- a/mobile/test/services/local_content_diagnostics_service_test.dart
+++ b/mobile/test/services/local_content_diagnostics_service_test.dart
@@ -1,0 +1,179 @@
+// ABOUTME: Tests aggregate diagnostics for missing local drafts and clips.
+// ABOUTME: Proves owner grouping, malformed-row counts, and identifier privacy.
+
+import 'dart:convert';
+
+import 'package:db_client/db_client.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/services/draft_storage_service.dart';
+import 'package:openvine/services/local_content_diagnostics_service.dart';
+
+const _ownerA =
+    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const _ownerB =
+    'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+void main() {
+  group(LocalContentDiagnosticsService, () {
+    late AppDatabase database;
+
+    setUp(() {
+      database = AppDatabase.test(NativeDatabase.memory());
+    });
+
+    tearDown(() => database.close());
+
+    Future<void> saveDraft({
+      required String id,
+      required String? owner,
+      String? clipId,
+      String? filePath,
+    }) {
+      return database.draftsDao.saveDraftWithClips(
+        id: id,
+        title: '',
+        description: '',
+        publishStatus: 'draft',
+        createdAt: DateTime(2026, 8, 29),
+        lastModified: DateTime(2026, 8, 29),
+        data: '{}',
+        renderedFilePath: null,
+        renderedThumbnailPath: null,
+        customThumbnailPath: null,
+        ownerPubkey: owner,
+        clipDataList: [
+          if (clipId != null)
+            DraftClipData(
+              id: clipId,
+              orderIndex: 0,
+              durationMs: 1000,
+              recordedAt: DateTime(2026, 8, 29),
+              data: jsonEncode({'id': clipId}),
+              filePath: filePath,
+            ),
+        ],
+      );
+    }
+
+    test('separates visible, anonymous, foreign, and malformed rows', () async {
+      await saveDraft(
+        id: 'owned-draft',
+        owner: _ownerA,
+        clipId: 'owned-clip',
+        filePath: 'missing.mp4',
+      );
+      await saveDraft(
+        id: 'legacy-draft',
+        owner: null,
+        clipId: 'legacy-clip',
+        filePath: 'present.mp4',
+      );
+      await saveDraft(
+        id: 'anonymous-draft',
+        owner: DraftStorageService.anonymousOwnerPubkey,
+        clipId: 'anonymous-clip',
+      );
+      await saveDraft(
+        id: 'foreign-draft',
+        owner: _ownerB,
+        clipId: 'foreign-clip',
+      );
+      await saveDraft(id: 'zero-clip-draft', owner: _ownerA);
+
+      final diagnostics = await LocalContentDiagnosticsService(
+        clipsDao: database.clipsDao,
+        draftsDao: database.draftsDao,
+        ownerPubkey: _ownerA,
+        documentsPath: '/documents',
+        fileExists: (path) async => path.endsWith('present.mp4'),
+      ).collect();
+
+      expect(diagnostics, {
+        'visibleDraftRows': 3,
+        'visibleClipRows': 2,
+        'anonymousDraftRows': 1,
+        'anonymousClipRows': 1,
+        'foreignDraftRows': 1,
+        'foreignClipRows': 1,
+        'zeroClipDraftRows': 1,
+        'missingSourceMediaFiles': 1,
+      });
+    });
+
+    test('returns aggregate counts without identifiers or paths', () async {
+      await saveDraft(
+        id: 'sensitive-row-id',
+        owner: _ownerB,
+        clipId: 'sensitive-clip-id',
+        filePath: 'sensitive-filename.mp4',
+      );
+
+      final diagnostics = await LocalContentDiagnosticsService(
+        clipsDao: database.clipsDao,
+        draftsDao: database.draftsDao,
+        ownerPubkey: _ownerA,
+        documentsPath: '/private/documents',
+        fileExists: (_) async => false,
+      ).collect();
+      final encoded = jsonEncode(diagnostics);
+
+      expect(encoded, isNot(contains(_ownerB)));
+      expect(encoded, isNot(contains('sensitive-row-id')));
+      expect(encoded, isNot(contains('sensitive-clip-id')));
+      expect(encoded, isNot(contains('sensitive-filename.mp4')));
+      expect(encoded, isNot(contains('/private/documents')));
+    });
+
+    test('collecting diagnostics does not change stored rows', () async {
+      await saveDraft(id: 'zero-clip-draft', owner: _ownerA);
+      final beforeDrafts = await database.draftsDao.getAllDrafts();
+      final beforeClips = await database.clipsDao.getAllClips(
+        includeTrashed: true,
+      );
+
+      await LocalContentDiagnosticsService(
+        clipsDao: database.clipsDao,
+        draftsDao: database.draftsDao,
+        ownerPubkey: _ownerA,
+        documentsPath: '/documents',
+        fileExists: (_) async => false,
+      ).collect();
+
+      expect(await database.draftsDao.getAllDrafts(), beforeDrafts);
+      expect(
+        await database.clipsDao.getAllClips(includeTrashed: true),
+        beforeClips,
+      );
+    });
+
+    test(
+      'counts drafts with only trashed clips as having zero clips',
+      () async {
+        await saveDraft(
+          id: 'draft-with-trashed-clip',
+          owner: _ownerA,
+          clipId: 'trashed-clip',
+        );
+        final storedClip = (await database.clipsDao.getClipsByDraftId(
+          'draft-with-trashed-clip',
+        )).single;
+        final deleted = await database.clipsDao.softDeleteClip(
+          id: storedClip.id,
+          deletedAt: DateTime(2026, 8, 29),
+        );
+        expect(deleted, isTrue);
+
+        final diagnostics = await LocalContentDiagnosticsService(
+          clipsDao: database.clipsDao,
+          draftsDao: database.draftsDao,
+          ownerPubkey: _ownerA,
+          documentsPath: '/documents',
+          fileExists: (_) async => true,
+        ).collect();
+
+        expect(diagnostics['zeroClipDraftRows'], 1);
+      },
+    );
+  });
+}

--- a/mobile/test/services/zendesk_support_service_test.dart
+++ b/mobile/test/services/zendesk_support_service_test.dart
@@ -928,6 +928,51 @@ void main() {
       expect(capturedSubject, isNot(startsWith('fix:')));
     });
 
+    test(
+      'includes aggregate local-storage diagnostics in the ticket',
+      () async {
+        String? capturedDescription;
+
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(channel, (MethodCall call) async {
+              if (call.method == 'initialize') return true;
+              if (call.method == 'createTicket') {
+                capturedDescription = call.arguments['description'] as String?;
+                return true;
+              }
+              return null;
+            });
+
+        await ZendeskSupportService.initialize(
+          appId: 'test',
+          clientId: 'test',
+          zendeskUrl: 'https://test.zendesk.com',
+        );
+
+        await ZendeskSupportService.createStructuredBugReport(
+          subject: 'Drafts disappeared',
+          description: 'The library is empty',
+          reportId: 'test-local-storage-001',
+          appVersion: '1.0.20+848',
+          deviceInfo: {
+            'platform': 'ios',
+            'localStorage': {
+              'databaseRecovery': {'outcome': 'recreatedKeyLoss'},
+              'contentInventory': {
+                'visibleDraftRows': 0,
+                'foreignDraftRows': 4,
+              },
+            },
+          },
+        );
+
+        expect(capturedDescription, contains('localStorage'));
+        expect(capturedDescription, contains('recreatedKeyLoss'));
+        expect(capturedDescription, contains('visibleDraftRows: 0'));
+        expect(capturedDescription, contains('foreignDraftRows: 4'));
+      },
+    );
+
     test('subject with user-typed prefix is not double-prefixed', () async {
       String? capturedSubject;
 


### PR DESCRIPTION
## Problem

When drafts and clips disappear, the support report currently cannot tell whether the encrypted database was recreated, rows are hidden by owner scope, draft rows have no active clips, or source media is missing. The relevant database-recovery log is emitted during startup and is usually gone before the report is filed.

## What changed

- Persist the latest database recovery outcome and UTC timestamp for every salvage or automatic recreate path.
- Add a read-only, aggregate local-content inventory to bug-report device diagnostics.
- Distinguish owner-visible, anonymous, and foreign draft/clip rows, plus zero-active-clip drafts and missing source media.
- Keep diagnostic collection best-effort so storage inspection cannot block report submission or app startup.
- Exclude row identifiers, owner identifiers, and file paths from the report.

This makes the next report in this symptom class identify the failing layer. It does not change encryption recovery behavior, mutate local content, or claim that the cause of the original report is known.

## Verification

- `flutter test test/services/database_recovery_store_test.dart test/services/local_content_diagnostics_service_test.dart test/services/database_encryption_bootstrap_test.dart test/services/bug_report_service_test.dart test/services/zendesk_support_service_test.dart`
- `flutter analyze`
- `bash scripts/check_untested_services_floor.sh`
- `bash scripts/check_nostr_id_log_truncation.sh`
- `bash scripts/check_pubkey_log_encoding.sh`
- pre-commit generated-file verification
- pre-push targeted analyzer and tests

Closes #8332

Related: #7507, #4623
