### PR TITLE
fix(dm): frame a retired moderation request as closed, not as an overture

### DIFF
--- a/mobile/lib/screens/inbox/message_requests/request_preview_view.dart
+++ b/mobile/lib/screens/inbox/message_requests/request_preview_view.dart
@@ -327,10 +327,13 @@ class _ProfileContent extends StatelessWidget {
                 ),
               ),
               const SizedBox(height: 32),
-              _MessageCountDescription(
-                displayName: displayName,
-                messageCount: messageCount,
-              ),
+              if (isRetiredModerationAccount(otherPubkey))
+                const _ClosedNoticeDescription()
+              else
+                _MessageCountDescription(
+                  displayName: displayName,
+                  messageCount: messageCount,
+                ),
               _InvitePreview(
                 messages: messages,
                 senderDisplayName: displayName,
@@ -411,6 +414,50 @@ class _StatsLine extends StatelessWidget {
         color: context.vineColors.onSurfaceVariant,
       ),
       textAlign: TextAlign.center,
+    );
+  }
+}
+
+/// Replaces the overture on a retired moderation notice, whose key nobody is
+/// behind. "Wants to message you" is wrong twice over there: the account was
+/// retired, and an enforcement notice is not a social approach.
+///
+/// Reuses the two ARB keys `_ClosedThreadNotice` renders in
+/// `conversation_view.dart`, which the request row also already shows, so the
+/// three surfaces a user crosses in one tap sequence cannot drift onto
+/// different wording (#6971).
+///
+/// Deliberately copy only. The thread behind "View messages" carries the
+/// redirect to the live support account, and this screen has been kept light
+/// on controls since #8090 pulled one back out of it.
+class _ClosedNoticeDescription extends StatelessWidget {
+  const _ClosedNoticeDescription();
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16),
+      child: Column(
+        spacing: 8,
+        children: [
+          Text(
+            l10n.dmRetiredThreadClosedTitle,
+            style: VineTheme.titleSmallFont(
+              color: context.vineColors.primaryText,
+            ),
+            textAlign: TextAlign.center,
+          ),
+          Text(
+            l10n.dmRetiredThreadClosedBody,
+            style: VineTheme.bodyMediumFont(
+              color: context.vineColors.onSurfaceVariant,
+            ),
+            textAlign: TextAlign.center,
+          ),
+        ],
+      ),
     );
   }
 }

--- a/mobile/test/screens/inbox/message_requests/request_preview_view_test.dart
+++ b/mobile/test/screens/inbox/message_requests/request_preview_view_test.dart
@@ -318,6 +318,49 @@ void main() {
           findsOneWidget,
         );
       });
+
+      // #6971. The row that opens this preview already reads "This
+      // conversation is closed"; the preview dropped every closed signal and
+      // replaced it with an overture. "Wants to message you" is false twice
+      // over on a retired key: nobody is behind it, and an enforcement notice
+      // is not a social approach.
+      testWidgets('a retired moderation notice reads as closed, not as an '
+          'overture', (tester) async {
+        await tester.pumpWidget(
+          buildModerationSubject(kLegacyModerationPubkeys.first),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text(l10n.dmRetiredThreadClosedTitle), findsOneWidget);
+        expect(find.text(l10n.dmRetiredThreadClosedBody), findsOneWidget);
+        expect(
+          find.text(
+            l10n.messageRequestWantsToMessageYou(
+              l10n.inboxSupportRowTitle,
+              l10n.messageRequestMessageCount(1),
+            ),
+          ),
+          findsNothing,
+        );
+      });
+
+      testWidgets('an ordinary request keeps the overture framing', (
+        tester,
+      ) async {
+        await tester.pumpWidget(buildModerationSubject(otherPubkey));
+        await tester.pumpAndSettle();
+
+        expect(
+          find.text(
+            l10n.messageRequestWantsToMessageYou(
+              UserProfile.defaultDisplayNameFor(otherPubkey),
+              l10n.messageRequestMessageCount(1),
+            ),
+          ),
+          findsOneWidget,
+        );
+        expect(find.text(l10n.dmRetiredThreadClosedTitle), findsNothing);
+      });
     });
 
     // #8185. The same screen links straight through to the profile, which


### PR DESCRIPTION
## Description

The Message Requests preview named a retired Divine Moderation notice with
**"Divine Moderation wants to message you, they've sent 1 message."**

That is wrong twice over. The key is retired, so nobody is behind it — our own
copy elsewhere says so verbatim: *"We moved Divine Moderation to a new account.
Nobody reads this one anymore."* And an enforcement notice is not a social
approach.

It was also the one step in the sequence that said nothing about being closed:

| Surface | Before |
|---|---|
| Request row (`request_tile.dart:71`) | "This conversation is closed." |
| **Request preview** | **"Divine Moderation wants to message you…"** |
| Thread (`_ClosedThreadNotice`) | "This conversation is closed." + body |

Tap the row and every closed signal disappeared, then reappeared one tap later.

#8302 removed the destructive action from this screen — the behavior half of
#6971. This is the copy half: the preview now renders `dmRetiredThreadClosedTitle`
and `dmRetiredThreadClosedBody`, the exact keys the other two surfaces already
use, so the wording cannot drift between the three screens a user crosses in one
tap sequence.

Gated on `isRetiredModerationAccount`, matching the row exactly. The current key
keeps the overture: the copy says the account *moved*, which is only true of a
retired one — and `extractPinnedSupport` lifts a current-key thread out of
Requests anyway.

**No new ARB keys** (nothing to translate — both strings already ship in 22
locales), and **copy only, no control added**. "View messages" still leads to the
thread, which is where the redirect to the live support account lives; this
screen has been kept deliberately light on controls since #8090 pulled one back
out of it.

**Related Issue:** Relates to #6971, part of epic #8228 (goal: *"A retired thread
is visually distinguishable from a live conversation"*)

## Out of Scope

- **"Remove all requests" is silent about the notice it keeps.** Since #8302 the
  sweep withholds a moderation notice, so a list holding nothing but a notice
  removes nothing and reports nothing — it reads as a broken button. I built and
  reverted this: the cubit seam is clean (`removeAllRequests` returning whether it
  withheld), but the user-visible half is the snackbar and I could not prove it
  with a test. `RequestBulkActionsSheet` closes through go_router's
  `context.pop(result)`, which `MockGoRouter` no-ops, so the sheet future never
  completes and the sweep is unreachable from a widget test. The repo's existing
  sheet test only asserts `pop` was *requested*, never that the sheet closed.
  Filed separately rather than shipped unverified.
- The remaining #6971 questions are already tracked elsewhere: a durable home for
  the enforcement reason is #8304, retention is #7850, key custody is #7851.

## Verification

- `flutter analyze lib test integration_test` — no issues
- `dart format --set-exit-if-changed` on both changed files — clean
- `flutter test test/screens/inbox/` — 493 passed (2 new, 491 pre-existing)
- `flutter test test/l10n/arb_consistency_test.dart` — passed
- Ratchets: raw TextStyle / raw colors / material button / raw dialog /
  orphaned ARB / ungrouped tests / skip / placeholder / l10n delegates /
  Nostr id truncation / pubkey log encoding — all pass
- Both new tests were watched failing first: the retired case failed with
  `Found 0 widgets with text "This conversation is closed."`, and the
  ordinary-request test passes before and after as a guard against
  over-applying the branch.

The device reproduction backing the diagnosis is on #6971 — a real kind-1059
gift wrap built with `divine-moderation-service`'s own template, ingested over
the wire on a physical device against the local stack.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)