### PR TITLE
fix(dm): distinguish retired moderation threads in the conversation list

### DIFF
--- a/mobile/lib/screens/inbox/message_requests/widgets/request_tile.dart
+++ b/mobile/lib/screens/inbox/message_requests/widgets/request_tile.dart
@@ -1,5 +1,5 @@
 // ABOUTME: Conversation tile variant for message requests.
-// ABOUTME: Always shows "Sent a message request" as the subtitle.
+// ABOUTME: Subtitle states the request, or that the thread is closed.
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
@@ -16,8 +16,9 @@ import 'package:unified_logger/unified_logger.dart';
 
 /// A conversation row in the message requests list.
 ///
-/// Layout matches [ConversationTile] but the subtitle always reads
-/// "Sent a message request" regardless of last message content.
+/// Layout matches [ConversationTile], but the subtitle never previews the
+/// last message: it reads "Sent a message request", or — for a thread keyed
+/// on a retired moderation account — the [ClosedThreadSubtitle] status line.
 class RequestTile extends ConsumerWidget {
   const RequestTile({
     required this.conversation,
@@ -67,9 +68,7 @@ class RequestTile extends ConsumerWidget {
             locale: Localizations.localeOf(context).toLanguageTag(),
           )
         : '';
-    final subtitle = isRetiredModerationAccount(otherPubkey)
-        ? context.l10n.dmRetiredThreadClosedTitle
-        : context.l10n.inboxRequestTileSubtitle;
+    final isClosedThread = isRetiredModerationAccount(otherPubkey);
 
     return Semantics(
       button: true,
@@ -139,14 +138,17 @@ class RequestTile extends ConsumerWidget {
                         ],
                       ),
                       const SizedBox(height: 4),
-                      Text(
-                        subtitle,
-                        style: VineTheme.bodyMediumFont(
-                          color: context.vineColors.onSurfaceVariant,
+                      if (isClosedThread)
+                        const ClosedThreadSubtitle()
+                      else
+                        Text(
+                          context.l10n.inboxRequestTileSubtitle,
+                          style: VineTheme.bodyMediumFont(
+                            color: context.vineColors.onSurfaceVariant,
+                          ),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
                         ),
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                      ),
                     ],
                   ),
                 ),

--- a/mobile/lib/screens/inbox/widgets/conversation_tile.dart
+++ b/mobile/lib/screens/inbox/widgets/conversation_tile.dart
@@ -97,12 +97,6 @@ class ConversationTile extends ConsumerWidget {
             locale: Localizations.localeOf(context).toLanguageTag(),
           )
         : '';
-    final effectiveSubtitleOverride =
-        subtitleOverride ??
-        (isRetiredModerationAccount(otherPubkey)
-            ? context.l10n.dmRetiredThreadClosedTitle
-            : null);
-
     final openThread = onTap;
 
     return Semantics(
@@ -194,7 +188,11 @@ class ConversationTile extends ConsumerWidget {
                           ],
                         ],
                       ),
-                      if (effectiveSubtitleOverride case final subtitle?) ...[
+                      // The closed marker ranks under an explicit override,
+                      // unchanged from #6416: the one caller that can pass
+                      // both is the Blocked slice's synthesised row, where
+                      // "you blocked this account" is the more urgent claim.
+                      if (subtitleOverride case final subtitle?) ...[
                         const SizedBox(height: 4),
                         Text(
                           subtitle,
@@ -204,6 +202,9 @@ class ConversationTile extends ConsumerWidget {
                           maxLines: 2,
                           overflow: TextOverflow.ellipsis,
                         ),
+                      ] else if (isRetiredModerationAccount(otherPubkey)) ...[
+                        const SizedBox(height: 4),
+                        const ClosedThreadSubtitle(maxLines: 2),
                       ] else if (conversation.lastMessageContent != null) ...[
                         const SizedBox(height: 4),
                         _ConversationPreviewText(

--- a/mobile/lib/screens/inbox/widgets/moderation_identity.dart
+++ b/mobile/lib/screens/inbox/widgets/moderation_identity.dart
@@ -1,6 +1,7 @@
-// ABOUTME: Divine Moderation's name and avatar for DM surfaces. One place, so
-// ABOUTME: the inbox list, the message-requests flow and the conversation
-// ABOUTME: header all recognise the account instead of only the inbox list.
+// ABOUTME: Divine Moderation's name, avatar and closed-thread status for DM
+// ABOUTME: surfaces. One place, so the inbox list, the message-requests flow
+// ABOUTME: and the conversation header all recognise the account and agree on
+// ABOUTME: which of its threads is dead.
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
@@ -47,6 +48,68 @@ class ModerationAvatar extends StatelessWidget {
     return ColoredBox(
       color: context.vineColors.containerLow,
       child: const DivineIcon(icon: DivineIconName.logo, fit: BoxFit.cover),
+    );
+  }
+}
+
+/// The status line a retired moderation thread shows in place of its message
+/// preview, in every list a closed thread can land in.
+///
+/// The row it sits in is otherwise indistinguishable from the live pinned
+/// support row: [isModerationAccount] answers for retired keys too, so both
+/// carry the name "Divine Moderation" and the same [ModerationAvatar]
+/// wordmark, and both stamp the same relative timestamp. #6416 already put
+/// `dmRetiredThreadClosedTitle` in the preview slot, but in the preview's own
+/// font and colour — a sentence sitting where the eye reads "the last thing
+/// they said", which is why a closed thread still had to be opened to be
+/// recognised (#7847). The lock is what makes it scan as a status instead.
+///
+/// The ink stays `onSurfaceVariant`, the colour the preview it replaces
+/// already used. Dimming it to `onSurfaceMuted` would have marked the row
+/// twice over, but that token is 3.3:1 on the light surface — under the 4.5:1
+/// this text needs — so the glyph carries the distinction alone.
+///
+/// Deliberately reuses the string the opened thread's closed-composer notice
+/// puts at its top, rather than a shorter list-only variant, so the row and the
+/// screen it opens make the same claim in the same words.
+///
+/// The glyph carries no semantics of its own — `DivineIcon` renders through
+/// `SvgPicture.asset` with no `semanticsLabel` — which is correct here: the
+/// sentence beside it already says "closed", and labelling the lock would make
+/// assistive tech announce the status twice.
+class ClosedThreadSubtitle extends StatelessWidget {
+  const ClosedThreadSubtitle({this.maxLines = 1, super.key});
+
+  /// Matches the preview this replaces, so swapping one for the other cannot
+  /// change the row's height: the inbox list wraps to two lines, the request
+  /// list to one.
+  final int maxLines;
+
+  @override
+  Widget build(BuildContext context) {
+    final style = VineTheme.bodyMediumFont(
+      color: context.vineColors.onSurfaceVariant,
+    );
+    return Row(
+      // Top-anchored with the glyph boxed to the line height, so the lock sits
+      // on the first line rather than drifting to the middle of a wrapped one.
+      crossAxisAlignment: CrossAxisAlignment.start,
+      spacing: 4,
+      children: [
+        DivineIcon(
+          icon: DivineIconName.lockSimple,
+          color: context.vineColors.onSurfaceVariant,
+          size: style.fontSize! * (style.height ?? 1),
+        ),
+        Expanded(
+          child: Text(
+            context.l10n.dmRetiredThreadClosedTitle,
+            style: style,
+            maxLines: maxLines,
+            overflow: TextOverflow.ellipsis,
+          ),
+        ),
+      ],
     );
   }
 }

--- a/mobile/test/screens/inbox/message_requests/widgets/request_tile_test.dart
+++ b/mobile/test/screens/inbox/message_requests/widgets/request_tile_test.dart
@@ -227,6 +227,12 @@ void main() {
         await tester.pumpAndSettle();
       }
 
+      Finder lockFinder() => find.byWidgetPredicate(
+        (widget) =>
+            widget is DivineIcon && widget.icon == DivineIconName.lockSimple,
+        description: 'closed-thread lock',
+      );
+
       Finder wordmarkFinder() => find.byWidgetPredicate(
         (widget) => widget is DivineIcon && widget.icon == DivineIconName.logo,
         description: 'bundled Divine wordmark',
@@ -247,6 +253,30 @@ void main() {
           findsNothing,
         );
         expect(wordmarkFinder(), findsOneWidget);
+      });
+
+      testWidgets('a retired moderation request is marked closed', (
+        tester,
+      ) async {
+        // Same shape as the inbox row: the request list also names a retired
+        // key "Divine Moderation" beside the same wordmark, so the closed
+        // sentence needs the same status affordance on both surfaces or a
+        // thread reads as dead in one list and live in the other (#7847).
+        await pumpTileFor(tester, kLegacyModerationPubkeys.first);
+
+        expect(lockFinder(), findsOneWidget);
+      });
+
+      testWidgets('a live moderation request carries no lock', (tester) async {
+        await pumpTileFor(tester, kModerationPubkeyHex);
+
+        expect(lockFinder(), findsNothing);
+      });
+
+      testWidgets('an ordinary request carries no lock', (tester) async {
+        await pumpTileFor(tester, otherPubkey);
+
+        expect(lockFinder(), findsNothing);
       });
 
       testWidgets('the current moderation key is named and badged too', (

--- a/mobile/test/screens/inbox/widgets/conversation_tile_test.dart
+++ b/mobile/test/screens/inbox/widgets/conversation_tile_test.dart
@@ -895,6 +895,12 @@ void main() {
           .firstWhere((account) => account.role == 'moderation')
           .pubkeyHex;
 
+      Finder lockFinder() => find.byWidgetPredicate(
+        (widget) =>
+            widget is DivineIcon && widget.icon == DivineIconName.lockSimple,
+        description: 'closed-thread lock',
+      );
+
       Finder wordmarkFinder() => find.byWidgetPredicate(
         (widget) => widget is DivineIcon && widget.icon == DivineIconName.logo,
         description: 'bundled Divine wordmark',
@@ -1032,6 +1038,33 @@ void main() {
             find.text(UserProfile.defaultDisplayNameFor(retired)),
             findsNothing,
           );
+        });
+
+        testWidgets('a retired thread is marked closed, not previewed', (
+          tester,
+        ) async {
+          // Name and wordmark are deliberately identical to the live pinned
+          // support row, so the closed sentence used to be the only thing
+          // separating them — rendered in the preview's own slot, font and
+          // colour, which reads as "the last thing they said" rather than as
+          // a status (#7847). The lock is what makes it scan as one.
+          await pumpUnprofiledTileFor(tester, kLegacyModerationPubkeys.first);
+
+          expect(lockFinder(), findsOneWidget);
+        });
+
+        testWidgets('a live moderation thread carries no lock', (
+          tester,
+        ) async {
+          await pumpUnprofiledTileFor(tester, moderationPubkey);
+
+          expect(lockFinder(), findsNothing);
+        });
+
+        testWidgets('an ordinary thread carries no lock', (tester) async {
+          await pumpUnprofiledTileFor(tester, otherPubkey);
+
+          expect(lockFinder(), findsNothing);
         });
 
         testWidgets('the current key is named without a kind-0 too', (


### PR DESCRIPTION
## Description

A thread on a retired moderation key renders with the **same name and the same wordmark avatar** as the live pinned support row. That is deliberate — `isModerationAccount` answers for retired keys because it is the same team on the other end of a pre-rotation thread — but it leaves the two rows visually identical.

#6416 already swapped the retired row's message preview for `dmRetiredThreadClosedTitle` ("This conversation is closed."). That half shipped in `ef4257f23`, nine days before this issue was filed, so the row is not unlabelled. What it is missing is a signal that the line is a *status*: it renders in the preview's own font and colour, in the preview's own slot, so the eye reads it as the last thing they said. Rendering both rows side by side, the only difference between them is that sentence:

```
[wordmark]  Divine Moderation            now
            Thanks — we are looking into it.

[wordmark]  Divine Moderation            now
            This conversation is closed.
```

This adds a `lockSimple` glyph ahead of that sentence, so the line scans as a marker rather than as content:

```
[wordmark]  Divine Moderation            now
            🔒 This conversation is closed.
```

Three notes on the shape:

- **Both lists, one widget.** `extractPinnedSupport` leaves a retired thread in whichever list it arrived in, and an inbound-only moderation DM lands in **Message requests**, not the inbox. So the marker lives in a shared `ClosedThreadSubtitle` used by `ConversationTile` and `RequestTile`; marking only one would leave a thread reading as dead in one list and live in the other.
- **The ink stays `onSurfaceVariant`.** Dimming to `onSurfaceMuted` would have marked the row twice over, but that token measures **3.29:1 on the light surface** — under the 4.5:1 `accessibility.md` requires for 14px text (it clears 5.32:1 in dark, which is how it passes unnoticed). The glyph carries the distinction alone.
- **The string is reused verbatim**, not shortened for the list, so the row and the closed-composer notice it opens make the same claim in the same words. No new ARB keys, so no 22-locale translation debt.

The lock is decorative to assistive tech by design: `DivineIcon` renders through `SvgPicture.asset` with no `semanticsLabel`, and the sentence beside it already says "closed". Verified against the rendered semantics tree — the retired row announces `"Divine Moderation conversation / Divine Moderation avatar / Divine Moderation / now / This conversation is closed."`, unchanged by this PR.

**Related Issue:** Closes #7847 (sub-issue of epic #8228, goal 1: "A retired thread is visually distinguishable from a live conversation")

## Out of Scope

- **The name and avatar stay shared.** Both rows keep "Divine Moderation" and the wordmark. That is the documented intent of `moderationDisplayName`, and the name is also what `ConversationListBloc` indexes for inbox search — changing it would move the search string and the action-sheet title too.
- **The unread dot still shows on a closed row.** An unread enforcement notice you have not opened is exactly what should be flagged.
- **The Blocked slice keeps its own subtitle.** When the viewer blocked the retired account and the Blocked filter synthesises a row, `inboxBlockedNoMessages` still wins — precedence unchanged from #6416.
- Whether any user actually holds a retired-key notice is still open on #7850 / #7851; this PR does not depend on the answer.

## Verification

- `flutter analyze lib test integration_test` — clean.
- `flutter test test/screens/inbox/ test/blocs/dm/` — 885 passing.
- Five new widget tests: the lock renders on a retired row in both tiles, and is absent on a live moderation row and on an ordinary row (all five watched fail first — the two `findsOneWidget` assertions were red before the widget existed).
- Ratchets run locally, all green: `check_raw_textstyle_ceiling`, `check_raw_colors_ceiling`, `check_material_button_ceiling`, `check_raw_dialog_ceiling`, `check_orphaned_arb_key_floor`, `check_ungrouped_tests`, `check_placeholder_tests`, `check_skip_ceiling`, `check_l10n_delegates_ceiling`, `check_layer_direction`.
- Contrast computed from the palette rather than eyeballed: `onSurfaceVariant` is 10.71:1 on the dark surface and 5.78:1 on the light one; `onSurfaceMuted` is 5.32:1 / 3.29:1, which is what ruled it out.
- Layout checked by rendering both tiles to a PNG off a `RepaintBoundary`: the lock sits on the first line of the subtitle, and a wrapped second line hangs under the text rather than under the glyph.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
