### PR TITLE
fix(dm): say which request the bulk sweep kept

### DIFF
--- a/mobile/lib/blocs/dm/message_requests/message_request_actions_cubit.dart
+++ b/mobile/lib/blocs/dm/message_requests/message_request_actions_cubit.dart
@@ -146,12 +146,18 @@ class MessageRequestActionsCubit extends Cubit<MessageRequestActionsState> {
   /// the view, and a new caller cannot forget it.
   ///
   /// Protected conversations are skipped and remain in the request list.
-  Future<void> removeAllRequests(List<DmConversation> conversations) async {
+  ///
+  /// Returns true when at least one row was withheld, so the caller can say
+  /// why one stayed behind. Without that the guard is invisible in the bulk
+  /// path: a list holding nothing but a notice removes nothing, emits nothing,
+  /// and reads as a broken button (#8347).
+  Future<bool> removeAllRequests(List<DmConversation> conversations) async {
     final removable = [
       for (final conversation in conversations)
         if (!_isProtected(conversation)) conversation.id,
     ];
-    if (removable.isEmpty) return;
+    final withheld = removable.length != conversations.length;
+    if (removable.isEmpty) return withheld;
     emit(state.copyWith(status: MessageRequestActionsStatus.processing));
     try {
       await _dmRepository.removeConversations(removable);
@@ -166,5 +172,6 @@ class MessageRequestActionsCubit extends Cubit<MessageRequestActionsState> {
         emit(state.copyWith(status: MessageRequestActionsStatus.error));
       }
     }
+    return withheld;
   }
 }

--- a/mobile/lib/blocs/dm/message_requests/message_request_actions_cubit.dart
+++ b/mobile/lib/blocs/dm/message_requests/message_request_actions_cubit.dart
@@ -147,17 +147,28 @@ class MessageRequestActionsCubit extends Cubit<MessageRequestActionsState> {
   ///
   /// Protected conversations are skipped and remain in the request list.
   ///
-  /// Returns true when at least one row was withheld, so the caller can say
-  /// why one stayed behind. Without that the guard is invisible in the bulk
+  /// [withheld] is true when at least one row was kept back, so the caller can
+  /// say why one stayed behind — without it the guard is invisible in the bulk
   /// path: a list holding nothing but a notice removes nothing, emits nothing,
   /// and reads as a broken button (#8347).
-  Future<bool> removeAllRequests(List<DmConversation> conversations) async {
+  ///
+  /// [failed] is reported separately for the same reason [declineRequest] is
+  /// three-valued: a refusal is not a failure, and the two must not share one
+  /// flag. `removeConversations` runs in a transaction, so a throw rolls back
+  /// every row — reporting only [withheld] there would blame the notice for a
+  /// sweep that removed nothing.
+  ///
+  /// The caller must consume this result rather than reading [state] after the
+  /// await, for the reason given on [declineRequest].
+  Future<({bool withheld, bool failed})> removeAllRequests(
+    List<DmConversation> conversations,
+  ) async {
     final removable = [
       for (final conversation in conversations)
         if (!_isProtected(conversation)) conversation.id,
     ];
     final withheld = removable.length != conversations.length;
-    if (removable.isEmpty) return withheld;
+    if (removable.isEmpty) return (withheld: withheld, failed: false);
     emit(state.copyWith(status: MessageRequestActionsStatus.processing));
     try {
       await _dmRepository.removeConversations(removable);
@@ -171,7 +182,8 @@ class MessageRequestActionsCubit extends Cubit<MessageRequestActionsState> {
       if (!isClosed) {
         emit(state.copyWith(status: MessageRequestActionsStatus.error));
       }
+      return (withheld: withheld, failed: true);
     }
-    return withheld;
+    return (withheld: withheld, failed: false);
   }
 }

--- a/mobile/lib/screens/inbox/message_requests/message_requests_view.dart
+++ b/mobile/lib/screens/inbox/message_requests/message_requests_view.dart
@@ -74,17 +74,26 @@ class MessageRequestsView extends ConsumerWidget {
         final messenger = ScaffoldMessenger.of(context);
         final withheldText =
             context.l10n.messageRequestModerationNoticeCannotBeRemoved;
+        final errorText = context.l10n.commonSomethingWentWrong;
         // Whole list, not ids: the cubit decides what "all requests" excludes,
         // so a Divine moderation notice cannot be swept away by a gesture
         // aimed at spam (#6971). Keeping the filter there rather than here
         // means a future caller inherits it.
-        final withheld = await actionsCubit.removeAllRequests(requests);
+        final outcome = await actionsCubit.removeAllRequests(requests);
         if (context.mounted) context.pop();
         // Silence reads as a broken button: a list holding nothing but a
         // notice removes nothing and emits nothing, so without this the tap
-        // looks like it missed (#8347). The messenger is captured before the
-        // await because the pop can retire this context.
-        if (withheld) {
+        // looks like it missed (#8347). The strings and messenger are captured
+        // before the await because the pop can retire this context.
+        //
+        // A failure outranks the withheld notice: the removal is transactional,
+        // so a throw left every row in place and naming the notice would blame
+        // the guard for a sweep that did nothing.
+        if (outcome.failed) {
+          messenger.showSnackBar(
+            DivineSnackbarContainer.snackBar(errorText, error: true),
+          );
+        } else if (outcome.withheld) {
           messenger.showSnackBar(
             DivineSnackbarContainer.snackBar(withheldText),
           );

--- a/mobile/lib/screens/inbox/message_requests/message_requests_view.dart
+++ b/mobile/lib/screens/inbox/message_requests/message_requests_view.dart
@@ -71,12 +71,24 @@ class MessageRequestsView extends ConsumerWidget {
       case RequestBulkAction.markAllRead:
         await actionsCubit.markAllRequestsAsRead(ids);
       case RequestBulkAction.removeAll:
+        final messenger = ScaffoldMessenger.of(context);
+        final withheldText =
+            context.l10n.messageRequestModerationNoticeCannotBeRemoved;
         // Whole list, not ids: the cubit decides what "all requests" excludes,
         // so a Divine moderation notice cannot be swept away by a gesture
         // aimed at spam (#6971). Keeping the filter there rather than here
         // means a future caller inherits it.
-        await actionsCubit.removeAllRequests(requests);
+        final withheld = await actionsCubit.removeAllRequests(requests);
         if (context.mounted) context.pop();
+        // Silence reads as a broken button: a list holding nothing but a
+        // notice removes nothing and emits nothing, so without this the tap
+        // looks like it missed (#8347). The messenger is captured before the
+        // await because the pop can retire this context.
+        if (withheld) {
+          messenger.showSnackBar(
+            DivineSnackbarContainer.snackBar(withheldText),
+          );
+        }
     }
   }
 }

--- a/mobile/test/blocs/dm/message_requests/message_request_actions_cubit_test.dart
+++ b/mobile/test/blocs/dm/message_requests/message_request_actions_cubit_test.dart
@@ -398,6 +398,63 @@ void main() {
           verifyNever(() => mockDmRepository.removeConversations(any()));
         },
       );
+
+      // The sweep is silent about what it kept, so the guard is invisible in
+      // the bulk path: with only a notice in the list it removes nothing,
+      // emits nothing, and the button looks broken. The caller needs to know a
+      // row was withheld so it can say so (#8347).
+      test('removeAllRequests reports the notice it withheld', () async {
+        when(
+          () => mockDmRepository.removeConversations(any()),
+        ).thenAnswer((_) async {});
+
+        final cubit = createCubit();
+
+        expect(
+          await cubit.removeAllRequests([
+            _conversation(_testConversationId1, peer: _stranger),
+            _conversation(_testConversationId2, peer: _moderation),
+          ]),
+          isTrue,
+        );
+
+        await cubit.close();
+      });
+
+      test('removeAllRequests reports a withheld row it could not sweep at '
+          'all', () async {
+        final cubit = createCubit();
+
+        expect(
+          await cubit.removeAllRequests([
+            _conversation(_testConversationId1, peer: _moderation),
+          ]),
+          isTrue,
+        );
+        verifyNever(() => mockDmRepository.removeConversations(any()));
+
+        await cubit.close();
+      });
+
+      test(
+        'removeAllRequests reports nothing withheld from a clean sweep',
+        () async {
+          when(
+            () => mockDmRepository.removeConversations(any()),
+          ).thenAnswer((_) async {});
+
+          final cubit = createCubit();
+
+          expect(
+            await cubit.removeAllRequests([
+              _conversation(_testConversationId1, peer: _stranger),
+            ]),
+            isFalse,
+          );
+
+          await cubit.close();
+        },
+      );
     });
 
     group('$MessageRequestActionsState', () {

--- a/mobile/test/blocs/dm/message_requests/message_request_actions_cubit_test.dart
+++ b/mobile/test/blocs/dm/message_requests/message_request_actions_cubit_test.dart
@@ -415,8 +415,11 @@ void main() {
             _conversation(_testConversationId1, peer: _stranger),
             _conversation(_testConversationId2, peer: _moderation),
           ]),
-          isTrue,
+          (withheld: true, failed: false),
         );
+        verify(
+          () => mockDmRepository.removeConversations([_testConversationId1]),
+        ).called(1);
 
         await cubit.close();
       });
@@ -429,7 +432,7 @@ void main() {
           await cubit.removeAllRequests([
             _conversation(_testConversationId1, peer: _moderation),
           ]),
-          isTrue,
+          (withheld: true, failed: false),
         );
         verifyNever(() => mockDmRepository.removeConversations(any()));
 
@@ -449,7 +452,51 @@ void main() {
             await cubit.removeAllRequests([
               _conversation(_testConversationId1, peer: _stranger),
             ]),
-            isFalse,
+            (withheld: false, failed: false),
+          );
+
+          await cubit.close();
+        },
+      );
+
+      // `removeConversations` is transactional, so a throw leaves every row in
+      // place. Folding that into the withheld flag would tell the user the
+      // notice was the reason a sweep that removed nothing removed nothing.
+      test(
+        'removeAllRequests separates a failed sweep from the row it withheld',
+        () async {
+          when(
+            () => mockDmRepository.removeConversations(any()),
+          ).thenThrow(Exception('drift is down'));
+
+          final cubit = createCubit();
+
+          expect(
+            await cubit.removeAllRequests([
+              _conversation(_testConversationId1, peer: _stranger),
+              _conversation(_testConversationId2, peer: _moderation),
+            ]),
+            (withheld: true, failed: true),
+          );
+
+          await cubit.close();
+        },
+      );
+
+      test(
+        'removeAllRequests reports a failure with nothing withheld',
+        () async {
+          when(
+            () => mockDmRepository.removeConversations(any()),
+          ).thenThrow(Exception('drift is down'));
+
+          final cubit = createCubit();
+
+          expect(
+            await cubit.removeAllRequests([
+              _conversation(_testConversationId1, peer: _stranger),
+            ]),
+            (withheld: false, failed: true),
           );
 
           await cubit.close();

--- a/mobile/test/screens/inbox/message_requests/message_requests_view_test.dart
+++ b/mobile/test/screens/inbox/message_requests/message_requests_view_test.dart
@@ -340,7 +340,7 @@ void main() {
       testWidgets('explains the notice the sweep kept', (tester) async {
         when(
           () => mockActionsCubit.removeAllRequests(any()),
-        ).thenAnswer((_) async => true);
+        ).thenAnswer((_) async => (withheld: true, failed: false));
 
         await sweep(tester);
 
@@ -353,7 +353,7 @@ void main() {
       testWidgets('stays quiet when the sweep kept nothing', (tester) async {
         when(
           () => mockActionsCubit.removeAllRequests(any()),
-        ).thenAnswer((_) async => false);
+        ).thenAnswer((_) async => (withheld: false, failed: false));
 
         await sweep(tester);
 
@@ -361,6 +361,25 @@ void main() {
         // never reached at all — which is exactly how this test behaves under
         // a MockGoRouter, whose no-op pop leaves the sheet future hanging.
         verify(() => mockActionsCubit.removeAllRequests(any())).called(1);
+        expect(
+          find.text(l10n.messageRequestModerationNoticeCannotBeRemoved),
+          findsNothing,
+        );
+      });
+
+      // The removal is transactional, so a failed sweep left the spam in place
+      // too. Naming the notice there would blame the guard for the whole
+      // no-op, which is why the cubit reports the two separately.
+      testWidgets('reports a failed sweep instead of blaming the notice', (
+        tester,
+      ) async {
+        when(
+          () => mockActionsCubit.removeAllRequests(any()),
+        ).thenAnswer((_) async => (withheld: true, failed: true));
+
+        await sweep(tester);
+
+        expect(find.text(l10n.commonSomethingWentWrong), findsOneWidget);
         expect(
           find.text(l10n.messageRequestModerationNoticeCannotBeRemoved),
           findsNothing,

--- a/mobile/test/screens/inbox/message_requests/message_requests_view_test.dart
+++ b/mobile/test/screens/inbox/message_requests/message_requests_view_test.dart
@@ -6,10 +6,12 @@ import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/dm/conversation_list/conversation_list_bloc.dart';
 import 'package:openvine/blocs/dm/message_requests/message_request_actions_cubit.dart';
+import 'package:openvine/config/official_accounts.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/router/app_router.dart';
@@ -57,6 +59,10 @@ void main() {
     late _MockMessageRequestActionsCubit mockActionsCubit;
     late _MockAuthService mockAuthService;
     late MockGoRouter mockGoRouter;
+
+    setUpAll(() {
+      registerFallbackValue(<DmConversation>[]);
+    });
 
     setUp(() {
       mockBloc = _MockConversationListBloc();
@@ -246,6 +252,119 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(find.byType(RequestTile), findsOneWidget);
+      });
+    });
+
+    // #8347. "Remove all requests" is the routine spam-clearing gesture, and
+    // since #8302 the cubit withholds a Divine moderation notice from it.
+    // Saying nothing makes that guard read as a broken button: with only a
+    // notice in the list the sweep removes nothing and reports nothing.
+    group('bulk removal', () {
+      final l10n = lookupAppLocalizations(const Locale('en'));
+
+      final moderationRequest = DmConversation(
+        id: 'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd',
+        participantPubkeys: [currentPubkey, kLegacyModerationPubkeys.first],
+        isGroup: false,
+        createdAt: nowUnix,
+        lastMessageTimestamp: nowUnix,
+      );
+
+      // A real GoRouter, not the MockGoRouter the rest of this file uses. The
+      // bulk sheet dismisses through go_router's `context.pop(result)`, and a
+      // mock no-ops it — so `VineBottomSheet.show` never completes its future
+      // and the sweep below is simply unreachable, with no error and no missed
+      // tap to explain why. A real router pops the modal route with its result,
+      // which is what the app does. `/requests` is nested under `/` so the pop
+      // after the sweep has somewhere to land.
+      Widget buildRoutedSubject() {
+        final loaded = ConversationListState(
+          status: ConversationListStatus.loaded,
+          requestConversations: [moderationRequest],
+        );
+        whenListen(
+          mockBloc,
+          Stream<ConversationListState>.value(loaded),
+          initialState: loaded,
+        );
+
+        final router = GoRouter(
+          initialLocation: '/requests',
+          routes: [
+            GoRoute(
+              path: '/',
+              builder: (_, _) => const Scaffold(),
+              routes: [
+                GoRoute(
+                  path: 'requests',
+                  builder: (_, _) => MultiBlocProvider(
+                    providers: [
+                      BlocProvider<ConversationListBloc>.value(value: mockBloc),
+                      BlocProvider<MessageRequestActionsCubit>.value(
+                        value: mockActionsCubit,
+                      ),
+                    ],
+                    child: const MessageRequestsView(),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        );
+        addTearDown(router.dispose);
+
+        return testProviderScope(
+          mockAuthService: mockAuthService,
+          additionalOverrides: [goRouterProvider.overrideWithValue(router)],
+          child: MaterialApp.router(
+            routerConfig: router,
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            theme: ThemeData.dark(),
+          ),
+        );
+      }
+
+      Future<void> sweep(WidgetTester tester) async {
+        await tester.pumpWidget(buildRoutedSubject());
+        await tester.pumpAndSettle();
+
+        await tester.tap(
+          find.bySemanticsLabel(l10n.profileMoreSemanticLabel),
+        );
+        await tester.pumpAndSettle();
+        await tester.tap(find.text(l10n.inboxRequestsRemoveAll));
+        await tester.pumpAndSettle();
+      }
+
+      testWidgets('explains the notice the sweep kept', (tester) async {
+        when(
+          () => mockActionsCubit.removeAllRequests(any()),
+        ).thenAnswer((_) async => true);
+
+        await sweep(tester);
+
+        expect(
+          find.text(l10n.messageRequestModerationNoticeCannotBeRemoved),
+          findsOneWidget,
+        );
+      });
+
+      testWidgets('stays quiet when the sweep kept nothing', (tester) async {
+        when(
+          () => mockActionsCubit.removeAllRequests(any()),
+        ).thenAnswer((_) async => false);
+
+        await sweep(tester);
+
+        // Without this the assertion above would also pass if the sweep were
+        // never reached at all — which is exactly how this test behaves under
+        // a MockGoRouter, whose no-op pop leaves the sheet future hanging.
+        verify(() => mockActionsCubit.removeAllRequests(any())).called(1);
+        expect(
+          find.text(l10n.messageRequestModerationNoticeCannotBeRemoved),
+          findsNothing,
+        );
       });
     });
 


### PR DESCRIPTION
## Description

Since #8302, **"Remove all requests"** withholds a Divine Moderation notice from
the sweep. That is right — removal is permanent (it writes a tombstone that
suppresses relay replay for the account's lifetime) and the notice is the user's
only copy of why they were actioned.

Nothing told the user:

- **Mixed list** (spam + a notice): the spam goes, one row stays, unexplained.
- **Only a notice**: `removeAllRequests` returns *before its first `emit`* when
  `removable` is empty — nothing removed, nothing emitted, nothing said. The
  button reads as broken.

Bulk removal is the routine spam-clearing gesture, which is exactly the path the
guard was added for, and it was the one path where the guard was invisible.

**No new copy.** `messageRequestModerationNoticeCannotBeRemoved` is already the
refusal snackbar on the single-request path, and the failure case reuses
`commonSomethingWentWrong` from that same path. Both already ship in 22 locales.

**Related Issue:** Closes #8347 (split out of #6971, sub-issue of #8228)

## The two commits

**1 — `say which request the bulk sweep kept`.** `removeAllRequests` reports
whether it withheld a row, and the view says so. The decision about what "all
requests" excludes stays in the cubit, per #8302's reasoning; the view does not
own it.

**2 — `do not blame the withheld notice for a failed sweep`.** A single bool made
a sweep that *threw* indistinguishable from one that *kept a notice*.
`DmRepository.removeConversations` runs every DAO call inside
`runInTransaction`, so a throw rolls back every row — the user would have got
their list unchanged plus "This Divine Moderation notice can't be removed",
naming the guard as the reason for a sweep that removed nothing. The two are now
reported separately, for the same reason `declineRequest` is already
three-valued: a refusal is not a failure. A failure outranks the withheld notice
at the call site.

```dart
Future<({bool withheld, bool failed})> removeAllRequests(List<DmConversation>)
```

## The harness note, which is most of why this is a separate PR

This was built and reverted during #8346 because the user-visible half could not
be proven. The bulk sheet dismisses through go_router's `context.pop(result)`,
and `MockGoRouter` no-ops that — so `VineBottomSheet.show` never completes its
future and the sweep is simply unreachable from a widget test. There is no error
and no missed-tap warning to explain it: instrumenting showed the sheet open,
both tiles found, correct geometry, no tap warning, and `removeAllRequests`
never called.

Worth knowing for the next person: `request_bulk_actions_sheet_test.dart` passes
today only because it asserts `pop` was *requested*. It never asserts the sheet
closed, so it does not cover what a caller awaiting `show()` needs.

So the `bulk removal` group drives a **real `GoRouter`** via `MaterialApp.router`
(`testMaterialApp` exposes only `home:`), with `/requests` nested under `/` so
the pop after the sweep has somewhere to land. `GoRouter.pop` documents that it
pops a top-most popup or dialog ahead of any `GoRoute` beneath it, which is what
closes the sheet — the same thing that happens in the app.

The quiet-path test additionally verifies the sweep was called, so it cannot go
green vacuously if that harness ever regresses — which is precisely how it
behaved under the mock.

## Out of Scope

- `markAllRead` is untouched. It withholds nothing, and its lack of feedback on
  failure is pre-existing rather than introduced here.
- The preview-copy half of #6971 shipped separately as #8346, now merged. The
  two touch disjoint files.

## Verification

- `flutter analyze lib test integration_test` — no issues
- `dart format --set-exit-if-changed` — clean
- `flutter test test/screens/inbox/ test/blocs/dm/` — 887 passed
- Ratchets: raw TextStyle / raw colors / material button / raw dialog /
  orphaned ARB / post-close emit / ungrouped tests / skip / placeholder /
  l10n delegates — all pass
- Re-verified against current `main` after #8346, #8348, #8350 and #8357 landed:
  merges clean, and the message-requests suites pass on the merged tree.
  `removeConversations`, `runInTransaction` and `markConversationsAsRead` are
  unchanged on main, so the transactional reasoning above still holds.
- Every test was watched failing first. The cubit tests failed to compile against
  the previous return type; the view test failed with
  `Found 0 widgets with text "This Divine Moderation notice can't be removed."`
  and then went green, which is itself the evidence the real-router harness
  reaches the sweep where the mock never did.

Behaviour is covered at both levels for every combination that reaches a distinct
branch: withheld-only, failure-with-withheld, and neither.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)